### PR TITLE
fix(csp): complete script-src-attr event-delegation refactor

### DIFF
--- a/src/docs/adr/0016-csp-script-src-scope.md
+++ b/src/docs/adr/0016-csp-script-src-scope.md
@@ -38,9 +38,9 @@ event-delegation refactor of the 21k-line SPA, which remains the open scope of
 `script-src` becomes three directives, on both emitters:
 
 ```text
-script-src      'self' 'unsafe-inline'      ← CSP2 fallback, UNCHANGED
+script-src      'self'                      ← CSP2 fallback (unsafe-inline dropped with #3848)
 script-src-elem 'self' 'sha256-…' …         ← inline <script> elements: CLOSED
-script-src-attr 'unsafe-inline'             ← on*= attributes: STAGED (#3848)
+script-src-attr 'none'                      ← on*= attributes: CLOSED (#3848 event delegation)
 ```
 
 - **`script-src-elem` carries a sha256 hash for every inline `<script>` this
@@ -56,19 +56,21 @@ script-src-attr 'unsafe-inline'             ← on*= attributes: STAGED (#3848)
   `hubURL` derives from the Host header; `/snapshot`, built at runtime) the
   handler stamps the allowlist from the finished document before the first
   write (`applyDocumentScriptSrcElem`).
-- **The CSP2 fallback `script-src` keeps `'unsafe-inline'` and must never
-  carry the hashes.** Per CSP2, the presence of a hash source makes a browser
-  ignore `'unsafe-inline'` in the same directive — so a browser that
-  understands hashes but not `script-src-elem`/`-attr` (Firefox < 108) would
-  block all 426+ inline handlers and blank the dashboard. Keeping the fallback
-  hash-free means pre-CSP3 browsers enforce exactly what they enforced before
-  this change: no regression, no new protection.
-- **`script-src-attr 'unsafe-inline'` is STAGED, not accepted.** Unlike
-  `style-src-attr` (a permanent acceptance, ADR-0015), the handler attributes
-  *can* be eliminated by refactoring the SPA to delegated `addEventListener`
-  wiring, and #3848 remains open for exactly that. The tripwire test
-  `TestCSPScriptSrcAttrUnsafeInlineIsStaged` fails the moment that refactor
-  lands, and must then be inverted — never relaxed.
+- **The CSP2 fallback `script-src` must never carry the hashes.** Per CSP2,
+  the presence of a hash source makes a browser ignore `'unsafe-inline'` in
+  the same directive, so the hashes belong in `script-src-elem` and only
+  there. Since the #3848 event-delegation refactor removed every inline
+  handler attribute, the fallback also dropped `'unsafe-inline'`: nothing
+  inline-attribute-based remains for any browser to permit.
+- **`script-src-attr` is now `'none'` — the attribute half is CLOSED.** The
+  #3848 event-delegation refactor replaced every inline `on*=` handler
+  attribute (in `static/index.html` and in Go-generated HTML) with
+  `data-action` / `data-*` attributes dispatched by central document-level
+  listeners, so an injected handler attribute never executes. Unlike
+  `style-src-attr` (a permanent acceptance, ADR-0015), this half was
+  eliminable and has been eliminated. The former staged tripwire
+  `TestCSPScriptSrcAttrUnsafeInlineIsStaged` was inverted into
+  `TestCSPScriptSrcAttrUnsafeInlineIsAbsent`, which pins the closed state.
 - Documents whose bytes this code never renders keep the blanket CSP2 policy:
   `/terminal` (ttyd's own UI, streamed through a reverse proxy) on both
   emitters, and on the Node proxy additionally the Go-rendered `/contribute`,
@@ -79,12 +81,10 @@ script-src-attr 'unsafe-inline'             ← on*= attributes: STAGED (#3848)
 
 What this ADR accepts, stated plainly:
 
-- **Injected `on*=` handler attributes still execute in every browser** while
-  `script-src-attr 'unsafe-inline'` stands — markup injection such as
-  `<img src=x onerror=…>` remains an executable XSS primitive. Closing it is
-  the remaining scope of #3848.
-- **Pre-CSP3 browsers (e.g. Firefox < 108) gain nothing**: they enforce only
-  the unchanged fallback.
+- **Injected `on*=` handler attributes no longer execute in CSP3 browsers**:
+  `script-src-attr` is `'none'` after the #3848 event-delegation refactor.
+  Pre-CSP3 browsers enforce the `script-src 'self'` fallback, which also
+  blocks inline handlers.
 - The dashboard credential still lives in `localStorage` (operator-pasted);
   moving it out is tracked separately in #3315's recommendation trail.
 - The hub SaaS SPA ([pkg/hub/saas.go](../../pkg/hub/saas.go)) serves no CSP
@@ -98,6 +98,8 @@ What this ADR accepts, stated plainly:
   must either be byte-stable (then its document belongs in the startup set) or
   call `applyDocumentScriptSrcElem` with the finished document; the
   hash-coverage tests in `csp_script_src_test.go` fail otherwise.
-- When #3848's event-delegation refactor lands, `script-src-attr` drops
-  `'unsafe-inline'`, the fallback `script-src` can finally drop it too, and
-  the tripwire is inverted to pin the closed state.
+- With #3848's event-delegation refactor landed, `script-src-attr` is
+  `'none'`, the fallback `script-src` dropped `'unsafe-inline'`, and the
+  tripwire is inverted (`TestCSPScriptSrcAttrUnsafeInlineIsAbsent`) to pin
+  the closed state. New UI handlers must be wired through the `data-action`
+  dispatcher, never as inline attributes.

--- a/src/pkg/dashboard/agent_config_single_save_test.go
+++ b/src/pkg/dashboard/agent_config_single_save_test.go
@@ -58,7 +58,7 @@ func TestPromptTemplateDirtyTracking(t *testing.T) {
 	for _, snippet := range []string{
 		"function markPromptTemplateDirty(el)",
 		"function capturePromptTemplate()",
-		`oninput="markPromptTemplateDirty(this)"`,
+		`data-input-action="markPromptTemplateDirty"`,
 		"_configState.promptTemplateDirty = true;",
 		// Re-entering the tab must not clobber a pending edit with the server copy.
 		"if (el && !_configState.promptTemplateDirty) { el.value = data.prompt || ''; }",

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -773,7 +773,7 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 				customStyleNoticeHTML = fmt.Sprintf(`<div class="lb-custom-style-note" id="leaderboard-custom-style-note" role="status">Custom style active: <code>%s</code></div>`, escapedSrc)
 			}
 		} else {
-			customStyleNoticeHTML = `<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status">Custom style could not be loaded — using default <button type="button" onclick="this.parentElement.remove()">Dismiss</button></div>`
+			customStyleNoticeHTML = `<div class="lb-custom-style-note lb-custom-style-note--warn" id="leaderboard-custom-style-note" role="status">Custom style could not be loaded — using default <button type="button" data-action="dismiss-parent">Dismiss</button></div>`
 		}
 	}
 
@@ -1878,7 +1878,7 @@ code{background:var(--cc-bg);padding:2px 8px;border-radius:4px;font-size:.9rem}
 </div>
 <div id="model-row" style="margin-bottom:12px;display:none;align-items:center;gap:8px">
 <label style="font-size:.9rem;color:#8b949e">Model (optional):</label>
-<input id="model-input" type="text" placeholder="e.g. claude-sonnet-4-6, gpt-4o" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.85rem;flex:1;max-width:300px" oninput="updateCmds()">
+<input id="model-input" type="text" placeholder="e.g. claude-sonnet-4-6, gpt-4o" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.85rem;flex:1;max-width:300px" data-input-action="updateCmds">
 </div>
 <!-- #2549 Kubernetes-mode note. Hidden except in Kubernetes mode. States the two
      honest constraints up front: only headless-capable backends run in a cluster
@@ -1977,6 +1977,9 @@ function isHostOnly(c){return HOST_ONLY_BACKENDS.indexOf(c)>=0;}
 var modelRow=document.getElementById('model-row');
 var modelInput=document.getElementById('model-input');
 function updateCmds(){update();}
+// Event delegation (#3848): replaces the former inline oninput= attribute so
+// CSP script-src-attr can be 'none'.
+if(modelInput){modelInput.addEventListener('input',updateCmds);}
 function update(){
 var os=osSel.value;
 var prereq=prereqByOS[os]||prereqByOS.macos;
@@ -2558,6 +2561,33 @@ It clears automatically when the period elapses. An operator can shorten or disa
 </footer>
 <script>
 (function(){
+// ── Event delegation (#3848) ─────────────────────────────────────────────────
+// Replaces former inline on*= handler attributes so CSP script-src-attr can be
+// 'none'. Behaviors are keyed off data-* attributes:
+//   data-action="dismiss-parent"  → remove the button's parent element
+//   data-hide-on-error="1"        → hide <img> whose load failed
+//   data-select-on-click="1"      → select input contents on click
+//   data-stop-prop="1"            → stop click/mousedown propagating to parents
+document.addEventListener('click',function(e){
+  if(!e.target.closest)return;
+  var d=e.target.closest('[data-action="dismiss-parent"]');
+  if(d&&d.parentElement){d.parentElement.remove();return;}
+  var s=e.target.closest('[data-select-on-click]');
+  if(s&&s.select){s.select();}
+});
+document.addEventListener('error',function(e){
+  var t=e.target;
+  if(t&&t.getAttribute&&t.getAttribute('data-hide-on-error')){t.style.visibility='hidden';}
+},true);
+['click','mousedown'].forEach(function(type){
+  document.addEventListener(type,function(e){
+    if(e.target.closest&&e.target.closest('[data-stop-prop]')){e.stopPropagation();}
+  },true);
+});
+})();
+</script>
+<script>
+(function(){
 // ── Init-order hoist (fixes the #2603/#2604/#2606 merge-interleaving regression) ──
 // These were declared FAR below their first use. var hoists the name but not the
 // value, so ADMIN_TIER_ORDER.map / ccActivitySeen[k] / ccActivity.length ran against
@@ -3105,7 +3135,7 @@ function meCollaborators(p){
     var occ=(c.occasions>1)?(' · '+c.occasions+' occasions'):'';
     out+='<a class="dz-collab" href="/contribute/dossier/'+encodeURIComponent(c.username)+'">'
       +'<img class="dz-collab__av" src="https://github.com/'+encodeURIComponent(c.username)+'.png" alt="" '
-        +'onerror="this.style.visibility=\'hidden\'">'
+        +'data-hide-on-error="1">'
       +'<span class="dz-collab__body"><span class="dz-collab__name">'+esc(c.username)+'</span>'
       +'<span class="dz-collab__how">'+esc(how)+esc(occ)+'</span></span></a>';
   }
@@ -3299,7 +3329,7 @@ function renderMeCard(mount,p){
   +'<section class="dz-identity" aria-label="Identity">'
   +'<div class="me-emblem" style="--a1:'+em.a1+';--a2:'+em.a2+';--p1:'+em.p1+';--p2:'+em.p2+'"></div>'
   +'<div class="dz-identity-inner">'
-  +'<div class="dz-medallion"><img src="'+esc(avatar)+'" alt="" onerror="this.style.visibility=\'hidden\'"></div>'
+  +'<div class="dz-medallion"><img src="'+esc(avatar)+'" alt="" data-hide-on-error="1"></div>'
   +'<div class="dz-namebloc">'+callsign+'<h1 class="dz-heroname">'+esc(p.github_username)+'</h1>'+desig+founding+'</div>'
   +'<div class="dz-rankpill"><div class="rank-name">'+esc(rankMeta[0])+'</div><div class="rank-sub">trust · '+esc(tier)+'</div></div>'
   +'</div>'+livebar+'</section>'
@@ -3346,7 +3376,7 @@ function renderMeCard(mount,p){
       +'<span class="info-affordance custom-css-help"><button type="button" class="info-btn" id="custom-css-info-btn" aria-haspopup="true" aria-expanded="false" aria-controls="custom-css-info-pop" aria-label="Custom CSS stylesheet help" title="Custom CSS">Custom CSS</button>'
       +'<div class="info-pop custom-css-pop" id="custom-css-info-pop" role="tooltip" hidden><h4>Custom CSS</h4>'
       +'Use <code>?style=owner/repo/path/theme.css@ref</code> to load a theme. Example:'
-      +'<input class="custom-css-example" readonly aria-label="Custom CSS example" value="?style=castrojo/themes/lb/bluefin.css@main" onclick="this.select()">'
+      +'<input class="custom-css-example" readonly aria-label="Custom CSS example" value="?style=castrojo/themes/lb/bluefin.css@main" data-select-on-click="1">'
       +'Omit <code>@ref</code> to use the repo&rsquo;s <code>HEAD</code>. Public GitHub repos only; CSS is sanitized server-side and capped at <code>128 KiB</code>. Allowed: custom properties, attribute and pseudo selectors, <code>calc()</code>/<code>clamp()</code>/gradients, and <code>@media</code>, <code>@supports</code>, <code>@container</code>, <code>@keyframes</code>. <code>@font-face</code> is kept only with same-origin or <code>data:</code> sources. Removed: <code>@import</code>, external <code>url()</code> fetches, CSS escapes, and legacy executable CSS. Add <code>&amp;report=1</code> to the style API URL for sanitizer details. The same param works on <code>/</code> and <code>/snapshot</code>.</div></span>'
     +'</div>'
     +meInviteSection(p)
@@ -3709,7 +3739,7 @@ function ccIssueLinkHTML(item,label,extraClass){
   var url=ccIssueURL(item);
   if(!url)return '<span class="'+(extraClass||'')+'">'+esc(label)+'</span>';
   return '<a class="cc-issue-link '+(extraClass||'')+'" href="'+esc(url)+'" target="_blank" rel="noopener noreferrer" '+
-    'title="Open on GitHub" onclick="event.stopPropagation();" onmousedown="event.stopPropagation();">'+
+    'title="Open on GitHub" data-stop-prop="1">'+
     esc(label)+
     '<svg class="cc-issue-link-ic" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true" focusable="false">'+
     '<path fill="currentColor" d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"/>'+

--- a/src/pkg/dashboard/clickable_avatars_test.go
+++ b/src/pkg/dashboard/clickable_avatars_test.go
@@ -90,7 +90,7 @@ func TestAvatarLinkDegradesWithoutUsername(t *testing.T) {
 // move into an anchor: a broken-image glyph inside a link reads as a dead
 // control.
 func TestAvatarOnErrorFallbackKept(t *testing.T) {
-	if !strings.Contains(indexHTML(t), `onerror="this.style.display='none'">`) {
+	if !strings.Contains(indexHTML(t), `data-error-action="gh19"`) {
 		t.Error("avatarImg no longer hides a broken avatar image")
 	}
 }
@@ -143,7 +143,7 @@ func TestAnonymousAuditActorIsNotLinked(t *testing.T) {
 // destination — and that the profile is reachable from a menu entry instead.
 func TestNavAvatarKeepsItsMenu(t *testing.T) {
 	html := indexHTML(t)
-	if !strings.Contains(html, `id="oc-gh-avatar"`) || !strings.Contains(html, `onclick="toggleGHUserMenu()"`) {
+	if !strings.Contains(html, `id="oc-gh-avatar"`) || !strings.Contains(html, `data-action="toggleGHUserMenu"`) {
 		t.Error("the top-bar avatar no longer opens the user menu")
 	}
 	if !strings.Contains(html, `id="oc-gh-menu-profile"`) {

--- a/src/pkg/dashboard/contribute_cooldown_ui_test.go
+++ b/src/pkg/dashboard/contribute_cooldown_ui_test.go
@@ -18,7 +18,7 @@ func TestGovernorHubTabHasCooldownControl(t *testing.T) {
 		// Enable toggle wired to the same section/key the PUT round-trips.
 		`data-key="contribute_cooldown_enabled"`,
 		`Task Cooldown`,
-		`toggleCooldownEnabled(this)`,
+		`data-action="toggleCooldownEnabled"`,
 		`function toggleCooldownEnabled(`,
 		// Period input, marks the hub section dirty so Save PUTs it.
 		`id="hub-cooldown-hours"`,

--- a/src/pkg/dashboard/contribute_ops_issue_links_test.go
+++ b/src/pkg/dashboard/contribute_ops_issue_links_test.go
@@ -52,7 +52,7 @@ func TestIssueLinkHelpersExistAndPreferURLField(t *testing.T) {
 		`target="_blank"`,
 		`rel="noopener noreferrer"`,
 		`title="Open on GitHub"`,
-		"event.stopPropagation();",
+		"data-stop-prop", // delegated stopPropagation for click+mousedown (#3848)
 		"cc-issue-link-ic", // the external-link icon
 	} {
 		if !strings.Contains(linkBody, want) {
@@ -142,10 +142,13 @@ func TestIssueLinkClickStopsPropagation(t *testing.T) {
 		t.Fatal("ccIssueLinkHTML is missing")
 	}
 	linkBody := body[linkStart : linkStart+strings.Index(body[linkStart:], "\n}")]
-	if !strings.Contains(linkBody, `onclick="event.stopPropagation();"`) {
-		t.Error("issue link does not stop click propagation — clicking it could trigger a parent row handler")
+	// #3848: propagation stopping is delegated — the link carries
+	// data-stop-prop and capture-phase click/mousedown listeners call
+	// event.stopPropagation() (see the delegation script block).
+	if !strings.Contains(linkBody, `data-stop-prop="1"`) {
+		t.Error("issue link does not carry data-stop-prop — clicking it could trigger a parent row handler or start a drag")
 	}
-	if !strings.Contains(linkBody, `onmousedown="event.stopPropagation();"`) {
-		t.Error("issue link does not stop mousedown propagation — clicking it could start a drag (dragstart begins on mousedown+move)")
+	if !strings.Contains(body, `[data-stop-prop]`) || !strings.Contains(body, "e.stopPropagation()") {
+		t.Error("delegated data-stop-prop handler is missing from the served page")
 	}
 }

--- a/src/pkg/dashboard/csp_script_src.go
+++ b/src/pkg/dashboard/csp_script_src.go
@@ -19,16 +19,16 @@ package dashboard
 //     request and defeat the ETag entirely. Hashes are a pure function of the
 //     bytes already being served, so the #3863 caching design is untouched.
 //
-//   - Inline on*= EVENT-HANDLER attributes (426 in static/index.html alone,
-//     plus ~145 more built as strings and injected through innerHTML sites)
-//     have no nonce and no hash form under script-src-elem semantics; only
-//     script-src-attr 'unsafe-hashes' could pin them, at a hash per distinct
-//     attribute value — rejected for the same reason ADR-0015 rejected it for
-//     styles. That half is STAGED as script-src-attr 'unsafe-inline' behind an
-//     event-delegation refactor of the SPA. See ADR-0016 and the tripwire
-//     TestCSPScriptSrcAttrUnsafeInlineIsStaged.
+//   - Inline on*= EVENT-HANDLER attributes have no nonce and no hash form
+//     under script-src-elem semantics; only script-src-attr 'unsafe-hashes'
+//     could pin them, at a hash per distinct attribute value — rejected for
+//     the same reason ADR-0015 rejected it for styles. That half is now
+//     CLOSED: the #3848 event-delegation refactor replaced every inline
+//     handler attribute with data-action dispatch, so script-src-attr is
+//     'none'. See ADR-0016 and TestCSPScriptSrcAttrUnsafeInlineIsAbsent.
 //
-//   - script-src itself stays 'self' 'unsafe-inline' as the CSP2 fallback, and
+//   - script-src itself is 'self' as the CSP2 fallback ('unsafe-inline'
+//     dropped with #3848), and
 //     MUST NOT carry the hashes: per CSP2 §7.15, the presence of a hash makes
 //     a browser ignore 'unsafe-inline' in the same directive, so a browser
 //     that understands hashes but not script-src-elem/-attr (Firefox < 108)

--- a/src/pkg/dashboard/csp_script_src_test.go
+++ b/src/pkg/dashboard/csp_script_src_test.go
@@ -26,12 +26,13 @@ import (
 //     TestCSPScriptSrcElemUnsafeInlineIsClosed plus the per-document coverage
 //     tests, which recompute every served inline script's hash and demand it
 //     be allowlisted.
-//   - script-src-attr: STAGED — 'unsafe-inline' remains for the 426+ inline
-//     on*= handler attributes until the event-delegation refactor (#3848).
-//     TestCSPScriptSrcAttrUnsafeInlineIsStaged is the new tripwire.
-//   - script-src: the CSP2 fallback stays 'self' 'unsafe-inline' and must stay
-//     HASH-FREE — a hash in that directive would make hash-aware pre-CSP3
-//     browsers ignore 'unsafe-inline' and blank the dashboard.
+//   - script-src-attr: CLOSED — 'none' after the #3848 event-delegation
+//     refactor replaced every inline on*= handler attribute with data-action
+//     dispatch. TestCSPScriptSrcAttrUnsafeInlineIsAbsent pins it closed.
+//   - script-src: the CSP2 fallback is 'self' only — 'unsafe-inline' dropped
+//     at the same moment as script-src-attr's — and must stay HASH-FREE: a
+//     hash in that directive would change semantics for hash-aware pre-CSP3
+//     browsers.
 
 // sha256SourceRe matches a CSP sha256 hash source token.
 var sha256SourceRe = regexp.MustCompile(`'sha256-[A-Za-z0-9+/]+=*'`)
@@ -48,20 +49,19 @@ func TestCSPScriptSrcScopedIntoElemAndAttr(t *testing.T) {
 		}
 	}
 
-	// The fallback must keep permitting what it always permitted: a pre-CSP3
-	// browser sees ONLY this directive, and tightening it is not this change's
-	// job (that is the event-delegation refactor's).
+	// The fallback keeps 'self' for pre-CSP3 browsers but no longer needs
+	// 'unsafe-inline': the #3848 event-delegation refactor removed every
+	// inline handler attribute, so there is nothing inline left to permit.
 	fallback := cspDirective(csp, "script-src")
-	if !strings.Contains(fallback, "'self'") || !strings.Contains(fallback, "'unsafe-inline'") {
-		t.Errorf("script-src fallback must stay permissive for pre-CSP3 browsers, got %q", fallback)
+	if !strings.Contains(fallback, "'self'") {
+		t.Errorf("script-src fallback must keep 'self' for same-origin script files, got %q", fallback)
 	}
 
 	// THE LOAD-BEARING NEGATIVE: the fallback must never carry a hash. Per
 	// CSP2, a hash source makes the browser ignore 'unsafe-inline' in the same
-	// directive — so a browser that understands hashes but not
-	// script-src-elem/-attr (Firefox < 108) would block all 426+ inline on*=
-	// handlers and blank the dashboard. The hashes belong in script-src-elem
-	// and ONLY there.
+	// directive — and keeping this directive semantically stable across
+	// hash-aware and hash-unaware pre-CSP3 browsers requires the hashes to
+	// live in script-src-elem and ONLY there.
 	if sha256SourceRe.MatchString(fallback) {
 		t.Errorf("script-src fallback carries a sha256 source (%q) — this DISABLES "+
 			"'unsafe-inline' on hash-aware pre-CSP3 browsers and blanks every inline "+
@@ -104,31 +104,30 @@ func TestCSPScriptSrcElemUnsafeInlineIsClosed(t *testing.T) {
 	}
 }
 
-// TestCSPScriptSrcAttrUnsafeInlineIsStaged is the TRIPWIRE for the half that is
-// NOT closed, replacing the old whole-directive tripwire per #3848's own
-// instruction to invert-not-relax as halves land.
+// TestCSPScriptSrcAttrUnsafeInlineIsAbsent is the INVERSION of the old staged
+// tripwire (TestCSPScriptSrcAttrUnsafeInlineIsStaged), landed with the #3848
+// event-delegation refactor: every inline on*= handler attribute in
+// static/index.html and in Go-generated HTML was replaced with data-action /
+// data-* attributes dispatched by central document listeners, so
+// script-src-attr is 'none' and an injected on*= attribute never executes.
 //
-// script-src-attr still carries 'unsafe-inline' because the SPA wires 426
-// inline on*= attributes (plus ~145 more built as strings and injected through
-// innerHTML sites), and CSP offers no nonce and no elem-hash form for handler
-// attributes. Until the event-delegation refactor lands, an injected on*=
-// attribute still executes — stated in ADR-0016 "Residual risk", not hidden.
-//
-// When that refactor lands, this test FAILS by design. Do not relax it —
-// INVERT it (assert 'unsafe-inline' absent from script-src-attr AND from the
-// script-src fallback, which becomes droppable at the same moment), and update
-// ADR-0016's status in the same PR.
-func TestCSPScriptSrcAttrUnsafeInlineIsStaged(t *testing.T) {
+// Do not relax this. If a new handler is needed, wire it through the
+// data-action dispatcher — never by reintroducing an inline attribute.
+func TestCSPScriptSrcAttrUnsafeInlineIsAbsent(t *testing.T) {
 	attr := cspDirective(servedCSP(t), "script-src-attr")
 	if attr == "" {
 		t.Fatal("CSP must declare script-src-attr explicitly (#3848, ADR-0016)")
 	}
-	if !strings.Contains(attr, "'unsafe-inline'") {
-		t.Fatalf("script-src-attr no longer has 'unsafe-inline' (got %q).\n"+
-			"This is GOOD NEWS: the event-delegation half of #3848 appears to have landed.\n"+
-			"Invert this test into an assertion that 'unsafe-inline' is ABSENT here and in "+
-			"the script-src fallback, so it can never come back, and update ADR-0016 in the "+
-			"same PR.", attr)
+	if strings.Contains(attr, "'unsafe-inline'") {
+		t.Fatalf("script-src-attr must not contain 'unsafe-inline' after the #3848 "+
+			"event-delegation refactor (got %q) — inline handler attributes are gone "+
+			"and must never come back", attr)
+	}
+	// The CSP2 fallback must also not carry unsafe-inline: it became droppable
+	// at the same moment the attribute half closed.
+	src := cspDirective(servedCSP(t), "script-src")
+	if strings.Contains(src, "'unsafe-inline'") {
+		t.Fatalf("script-src fallback must not contain 'unsafe-inline' after #3848 (got %q)", src)
 	}
 	// 'unsafe-hashes' would mean a hash per distinct handler-attribute value,
 	// regenerated on every UI edit — rejected in ADR-0016 exactly as ADR-0015

--- a/src/pkg/dashboard/gh_app_banner_test.go
+++ b/src/pkg/dashboard/gh_app_banner_test.go
@@ -284,7 +284,7 @@ func TestInstallIdInputIsCrossBrowserHardened(t *testing.T) {
 	if !strings.Contains(inTag, `autocomplete="off"`) {
 		t.Errorf("install-ID input must set autocomplete=\"off\" so Firefox form history can't clear/refill the value:\n%s", inTag)
 	}
-	if !strings.Contains(inTag, "submitGitHubInstallationID()") || !strings.Contains(inTag, "Enter") {
+	if !strings.Contains(inTag, `data-keydown-action="submitGitHubInstallationID"`) || !strings.Contains(inTag, "Enter") {
 		t.Errorf("install-ID input must submit on Enter so entry works even if the Set-ID button is obscured or its click is flaky in Firefox:\n%s", inTag)
 	}
 

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -885,21 +885,20 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		//     nonces, so the #3863 startup-pre-gzip + strong-ETag design for the
 		//     SPA document is untouched.
 		//
-		//   script-src-attr 'unsafe-inline'  — inline on*= HANDLER attributes.
-		//     STAGED, not accepted: 426 on*= attributes in static/index.html
-		//     plus ~145 more built as strings and injected through 169
-		//     innerHTML/insertAdjacentHTML sites. Neither nonces nor elem-hashes
-		//     apply to attributes, so closing this half is an event-delegation
-		//     refactor of the SPA (#3848), and until then an injected on*=
-		//     attribute still executes. TestCSPScriptSrcAttrUnsafeInlineIsStaged
-		//     is the tripwire: invert it, never relax it.
+		//   script-src-attr 'none'  — inline on*= HANDLER attributes.
+		//     CLOSED by the #3848 event-delegation refactor: every former on*=
+		//     attribute in static/index.html and in Go-generated HTML now uses
+		//     data-action / data-* attributes dispatched by central document
+		//     listeners, so no markup-level handler attribute remains and an
+		//     injected on*= attribute never executes.
+		//     TestCSPScriptSrcAttrUnsafeInlineIsAbsent pins this closed.
 		//
-		//   script-src 'self' 'unsafe-inline'  — the CSP2 fallback, unchanged,
+		//   script-src 'self'  — the CSP2 fallback, now also without
+		//     'unsafe-inline' (nothing inline-attribute-based remains to allow),
 		//     and it must NEVER carry the hashes: a hash in this directive makes
 		//     hash-aware browsers ignore 'unsafe-inline' here, and a browser
 		//     that knows hashes but not script-src-elem/-attr (Firefox < 108)
 		//     would then block every inline handler and blank the dashboard.
-		//     Pre-CSP3 browsers keep exactly today's behaviour.
 		//
 		// The secret that 'unsafe-inline' used to expose is gone regardless: the
 		// dashboard token is never rendered into the page (see serveIndex in
@@ -915,10 +914,12 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		// style-src (#3848 part 2) is scoped as TWO directives rather than one
 		// blanket allowance, because the two halves have different futures:
 		//
-		//   style-src-attr 'unsafe-inline'  — the 2061 inline style="" attributes.
-		//     ACCEPTED, permanently, and not a staging compromise: CSP has no
-		//     nonce or hash form for attribute-level styles, so there is no
-		//     policy that both allows them and constrains them. Closing this
+		//   style-src-attr 'unsafe-inline'  — the ~2,055 inline style="" attributes.
+		//     ACCEPTED, permanently, and not a staging compromise (ADR-0015/0016):
+		//     CSP has no nonce or hash form for attribute-level styles, so there
+		//     is no policy that both allows them and constrains them, and CSS
+		//     injection is not an XSS vector — an injected style attribute can
+		//     deface the page but cannot execute script. Closing this
 		//     would mean deleting every style attribute in the UI. See
 		//     ADR-0015 for the rationale and the residual risk.
 		//
@@ -933,7 +934,7 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		// Both are listed AFTER the style-src fallback, which browsers without
 		// CSP3 support use instead; the effective policy is identical either way,
 		// so this split names the decision without changing behaviour.
-		scriptDirectives := "script-src 'self' 'unsafe-inline'; script-src-elem " + baseScriptSrcElem() + "; script-src-attr 'unsafe-inline'"
+		scriptDirectives := "script-src 'self'; script-src-elem " + baseScriptSrcElem() + "; script-src-attr 'none'"
 		if r.URL.Path == "/terminal" || strings.HasPrefix(r.URL.Path, "/terminal/") {
 			scriptDirectives = "script-src 'self' 'unsafe-inline'"
 		}
@@ -1306,13 +1307,13 @@ a:hover{text-decoration:underline}
   <h1>Hive</h1>
   <p class="subtitle">Sign in with GitHub to access this dashboard</p>
   <div id="step-start">
-    <button id="btn-start" onclick="startFlow()">Sign in with GitHub</button>
+    <button id="btn-start" data-action="startFlow">Sign in with GitHub</button>
   </div>
   <div id="step-code" style="display:none">
     <p class="instructions">Enter this code at GitHub:</p>
     <div class="code-wrap">
       <div class="code-box" id="user-code">--------</div>
-      <button class="copy-btn" id="copy-btn" onclick="copyAndOpen()">Copy &amp; Open</button>
+      <button class="copy-btn" id="copy-btn" data-action="copyAndOpen">Copy &amp; Open</button>
     </div>
     <p class="instructions"><a id="verify-link" href="#" target="_blank" rel="noopener">Open GitHub verification page ↗</a></p>
     <p class="status"><span class="spinner"></span> Waiting for authorization…</p>
@@ -1323,10 +1324,20 @@ a:hover{text-decoration:underline}
   </div>
   <div id="step-error" style="display:none">
     <p class="error" id="error-msg"></p>
-    <button onclick="location.reload()" style="margin-top:16px">Try again</button>
+    <button data-action="reload" style="margin-top:16px">Try again</button>
   </div>
 </div>
 <script>
+// Event delegation (no inline on*= attributes; CSP script-src-attr is 'none').
+document.addEventListener('click',function(e){
+  var el=e.target.closest('[data-action]');
+  if(!el)return;
+  switch(el.getAttribute('data-action')){
+    case 'startFlow':startFlow();break;
+    case 'copyAndOpen':copyAndOpen();break;
+    case 'reload':location.reload();break;
+  }
+});
 function showStep(id){['step-start','step-code','step-done','step-error'].forEach(
   s=>document.getElementById(s).style.display=s===id?'block':'none')}
 function showError(msg){document.getElementById('error-msg').textContent=msg;showStep('step-error')}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -2720,7 +2720,7 @@
 </script>
 <div id="gh-auth-banner" class="gh-auth-banner" style="display:none">
   <span id="gh-auth-msg">GitHub login required for advisory posting</span>
-  <button class="gh-auth-btn" id="gh-auth-btn" onclick="startGHLogin()">Sign in with GitHub</button>
+  <button class="gh-auth-btn" id="gh-auth-btn" data-action="startGHLogin">Sign in with GitHub</button>
 </div>
 <div id="gh-auth-modal-overlay" class="gh-auth-overlay" style="display:none">
   <div class="gh-auth-modal">
@@ -2728,22 +2728,22 @@
     <p>Enter this code on GitHub to authorize Hive:</p>
     <div style="position:relative;display:inline-block">
       <div class="device-code" id="gh-device-code">--------</div>
-      <button id="gh-copy-btn" onclick="copyDeviceCode()" style="position:absolute;top:4px;right:4px;background:var(--green);color:var(--bg);border:none;padding:3px 10px;border-radius:4px;cursor:pointer;font-size:0.7rem;font-weight:600">Copy</button>
+      <button id="gh-copy-btn" data-action="copyDeviceCode" style="position:absolute;top:4px;right:4px;background:var(--green);color:var(--bg);border:none;padding:3px 10px;border-radius:4px;cursor:pointer;font-size:0.7rem;font-weight:600">Copy</button>
     </div>
     <a id="gh-verify-link" class="gh-verify-link" href="https://github.com/login/device" target="_blank" rel="noopener">Open GitHub →</a>
     <div class="gh-poll-status" id="gh-poll-status">Waiting for authorization...</div>
-    <button class="gh-cancel" onclick="cancelGHLogin()">Cancel</button>
+    <button class="gh-cancel" data-action="cancelGHLogin">Cancel</button>
   </div>
 </div>
 <div id="gh-setup-overlay" class="gh-auth-overlay" style="display:none">
   <div class="gh-setup-modal">
     <h3>GitHub App Setup Required</h3>
     <p>Hive needs a GitHub App to authenticate. Choose an option:</p>
-    <div id="setup-option-public" class="setup-option" onclick="showSetupDetails('public')">
+    <div id="setup-option-public" class="setup-option" data-action="showSetupDetails" data-arg0="public">
       <h4>Use the public Hive App (quickest)</h4>
       <p>Dashboard login only. Agents can read repos but cannot create issues, PRs, or merge.</p>
     </div>
-    <div class="setup-option" onclick="showSetupDetails('custom')">
+    <div class="setup-option" data-action="showSetupDetails" data-arg0="custom">
       <h4>Create your own GitHub App (recommended for full ACMM)</h4>
       <p>Full agent capabilities: issues, PRs, auto-merge. Required for ACMM levels 3-6.</p>
     </div>
@@ -2796,7 +2796,7 @@
         </ul>
       </div>
     </div>
-    <button class="gh-cancel" onclick="document.getElementById('gh-setup-overlay').style.display='none'">Close</button>
+    <button class="gh-cancel" data-action="gh0">Close</button>
   </div>
 </div>
 <div id="hive-dashboard-root" class="hive-dashboard-root">
@@ -2820,13 +2820,13 @@
   <div class="config-modal">
     <div class="config-header">
       <h2 class="config-title"></h2>
-      <button class="config-close" onclick="closeConfigDialog()">&times;</button>
+      <button class="config-close" data-action="closeConfigDialog">&times;</button>
     </div>
     <nav class="config-tabs" id="config-tabs"></nav>
     <div class="config-body" id="config-body"></div>
     <div class="config-footer">
-      <button class="btn config-cancel" onclick="closeConfigDialog()">Cancel</button>
-      <button class="btn config-save" onclick="saveConfig()">Save</button>
+      <button class="btn config-cancel" data-action="closeConfigDialog">Cancel</button>
+      <button class="btn config-save" data-action="saveConfig">Save</button>
     </div>
   </div>
 </div>
@@ -2836,7 +2836,7 @@
   <div class="config-modal" style="max-width:800px;max-height:85vh">
     <div class="config-header">
       <h2 class="config-title">ACMM Maturity Level <span id="acmm-dialog-current" style="font-size:0.72em;font-weight:400;color:var(--muted)"></span></h2>
-      <button class="config-close" onclick="closeACMMDialog()">&times;</button>
+      <button class="config-close" data-action="closeACMMDialog">&times;</button>
     </div>
     <div class="config-body" style="padding:16px 24px;overflow-y:auto;max-height:calc(85vh - 120px)">
       <p style="font-size:0.82rem;color:var(--muted);margin:0 0 16px">
@@ -2852,15 +2852,15 @@
   <div class="config-modal welcome-modal">
     <div class="config-header">
       <h2 class="config-title">🐝 Getting Started<span id="welcome-progress" class="welcome-progress"></span></h2>
-      <button class="config-close" onclick="closeWelcomeDialog()">&times;</button>
+      <button class="config-close" data-action="closeWelcomeDialog">&times;</button>
     </div>
     <!-- Bee-to-hive banner. Markup is injected from beeStageHtml() on dialog
          open so this and the ACMM "Applying Level…" overlay stay in sync. -->
     <div class="wb-stage" id="welcome-bee-stage" aria-hidden="true"></div>
     <div class="config-body welcome-body" id="welcome-body"></div>
     <div class="config-footer welcome-footer">
-      <button class="hive-dialog-btn" onclick="closeWelcomeDialog()" title="Close for now — the checklist opens again on the next dashboard load">Remind me next time</button>
-      <button class="hive-dialog-btn primary" onclick="dismissWelcomeDialog()" title="Stop opening this checklist on load — reopen it any time from Getting Started in the sidebar or the Guide button in the top bar">Don't show on load</button>
+      <button class="hive-dialog-btn" data-action="closeWelcomeDialog" title="Close for now — the checklist opens again on the next dashboard load">Remind me next time</button>
+      <button class="hive-dialog-btn primary" data-action="dismissWelcomeDialog" title="Stop opening this checklist on load — reopen it any time from Getting Started in the sidebar or the Guide button in the top bar">Don't show on load</button>
     </div>
   </div>
 </div>
@@ -2878,18 +2878,18 @@
       </div>
     </div>
     <div style="padding:4px 16px 8px;text-align:center">
-      <span id="acmm-sidebar-badge" title="Click to change maturity level" style="cursor:pointer;display:inline-block;padding:3px 12px;border-radius:999px;font-size:0.7rem;font-weight:700;background:color-mix(in srgb, var(--amber) 14%, transparent);border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);color:var(--amber);letter-spacing:0.5px" onclick="openACMMDialog()"></span>
+      <span id="acmm-sidebar-badge" title="Click to change maturity level" style="cursor:pointer;display:inline-block;padding:3px 12px;border-radius:999px;font-size:0.7rem;font-weight:700;background:color-mix(in srgb, var(--amber) 14%, transparent);border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);color:var(--amber);letter-spacing:0.5px" data-action="openACMMDialog"></span>
     </div>
     <div class="oc-nav-group">
       <div class="oc-nav-label">Control</div>
-      <a class="oc-nav-item active" data-section="governor" onclick="ocNavigate('governor')"><span class="oc-nav-emoji">📊</span><span class="oc-nav-text">Governor</span></a>
-      <a class="oc-nav-item" data-section="advisory-section" onclick="ocNavigate('advisory-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Advisory</span></a>
-      <a class="oc-nav-item" data-section="acmm-eval-section" onclick="ocNavigate('acmm-eval-section')"><span class="oc-nav-emoji">🎯</span><span class="oc-nav-text">ACMM Eval</span></a>
-      <a class="oc-nav-item" data-section="token-panel" onclick="ocNavigate('token-panel')"><span class="oc-nav-emoji">🪙</span><span class="oc-nav-text">Tokens</span></a>
-      <a class="oc-nav-item" data-section="cost-panel" onclick="ocNavigate('cost-panel')"><span class="oc-nav-emoji">💵</span><span class="oc-nav-text">Cost</span></a>
+      <a class="oc-nav-item active" data-section="governor" data-action="ocNavigate" data-arg0="governor"><span class="oc-nav-emoji">📊</span><span class="oc-nav-text">Governor</span></a>
+      <a class="oc-nav-item" data-section="advisory-section" data-action="ocNavigate" data-arg0="advisory-section"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Advisory</span></a>
+      <a class="oc-nav-item" data-section="acmm-eval-section" data-action="ocNavigate" data-arg0="acmm-eval-section"><span class="oc-nav-emoji">🎯</span><span class="oc-nav-text">ACMM Eval</span></a>
+      <a class="oc-nav-item" data-section="token-panel" data-action="ocNavigate" data-arg0="token-panel"><span class="oc-nav-emoji">🪙</span><span class="oc-nav-text">Tokens</span></a>
+      <a class="oc-nav-item" data-section="cost-panel" data-action="ocNavigate" data-arg0="cost-panel"><span class="oc-nav-emoji">💵</span><span class="oc-nav-text">Cost</span></a>
     </div>
     <div class="oc-nav-group">
-      <div class="oc-tree-toggle" onclick="ocToggleAgentTree(this)">
+      <div class="oc-tree-toggle" data-action="ocToggleAgentTree" data-arg-types="t">
         <span class="oc-tree-arrow">▼</span> <span>Agent</span>
       </div>
       <div class="oc-tree-children" id="oc-agent-tree">
@@ -2900,21 +2900,21 @@
         <div id="nous-sb-phase" style="opacity:0.8"></div>
       </div>
       <div style="display:flex;gap:4px;margin:4px 10px">
-        <a class="oc-nav-item" style="color:var(--muted);font-style:italic;flex:1" onclick="openAddAgentDialog()">+ agent</a>
-        <a class="oc-nav-item" style="color:var(--muted);font-style:italic;flex:1" onclick="ocAddSidebarGroup()">+ group</a>
+        <a class="oc-nav-item" style="color:var(--muted);font-style:italic;flex:1" data-action="openAddAgentDialog">+ agent</a>
+        <a class="oc-nav-item" style="color:var(--muted);font-style:italic;flex:1" data-action="ocAddSidebarGroup">+ group</a>
       </div>
     </div>
     <div class="oc-nav-group">
       <div class="oc-nav-label">Resources</div>
-      <a class="oc-nav-item" data-section="repos-section" onclick="ocNavigate('repos-section')"><span class="oc-nav-emoji">📦</span><span class="oc-nav-text">Repos</span><span id="repos-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
-      <a class="oc-nav-item" data-section="beads-section" onclick="ocNavigate('beads-section')"><span class="oc-nav-emoji">🔮</span><span class="oc-nav-text">Beads</span><span id="beads-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
-      <a class="oc-nav-item" data-section="inception-section" onclick="ocNavigate('inception-section')"><span class="oc-nav-emoji">💡</span><span class="oc-nav-text">Inception</span></a>
-      <a class="oc-nav-item" data-section="knowledge-section" onclick="ocNavigate('knowledge-section')"><span class="oc-nav-emoji">📚</span><span class="oc-nav-text">Knowledge</span><span id="knowledge-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
-      <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
-      <a class="oc-nav-item" data-section="audit-section" onclick="ocNavigate('audit-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Audit Log</span></a>
-      <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
-      <a class="oc-nav-item" data-section="faq-section" onclick="ocNavigate('faq-section')" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
-      <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
+      <a class="oc-nav-item" data-section="repos-section" data-action="ocNavigate" data-arg0="repos-section"><span class="oc-nav-emoji">📦</span><span class="oc-nav-text">Repos</span><span id="repos-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
+      <a class="oc-nav-item" data-section="beads-section" data-action="ocNavigate" data-arg0="beads-section"><span class="oc-nav-emoji">🔮</span><span class="oc-nav-text">Beads</span><span id="beads-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
+      <a class="oc-nav-item" data-section="inception-section" data-action="ocNavigate" data-arg0="inception-section"><span class="oc-nav-emoji">💡</span><span class="oc-nav-text">Inception</span></a>
+      <a class="oc-nav-item" data-section="knowledge-section" data-action="ocNavigate" data-arg0="knowledge-section"><span class="oc-nav-emoji">📚</span><span class="oc-nav-text">Knowledge</span><span id="knowledge-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
+      <a class="oc-nav-item" data-section="contributors-section" data-action="ocNavigate" data-arg0="contributors-section"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
+      <a class="oc-nav-item" data-section="audit-section" data-action="ocNavigate" data-arg0="audit-section"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Audit Log</span></a>
+      <a class="oc-nav-item" data-section="nous-section" data-action="ocNavigate" data-arg0="nous-section"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
+      <a class="oc-nav-item" data-section="faq-section" data-action="ocNavigate" data-arg0="faq-section" title="Answers to common first-time questions: the Advisory Digest, ACMM levels, how to advance, and managing cost"><span class="oc-nav-emoji">❓</span><span class="oc-nav-text">FAQ</span></a>
+      <a class="oc-nav-item" id="welcome-nav-item" style="display:none" data-action="openWelcomeDialog" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
       <a class="oc-nav-item" href="https://docs.kubestellar.io/docs/hive/getting-started" target="_blank" rel="noopener noreferrer" title="Zero to Automation: the beginner guide to running your hive, level by level"><span class="oc-nav-emoji">📖</span><span class="oc-nav-text">Getting Started Guide</span></a>
       <a class="oc-nav-item" href="https://github.com/kubestellar/hive/issues" target="_blank" rel="noopener noreferrer"><span class="oc-nav-emoji">🐛</span><span class="oc-nav-text">Report an Issue</span></a>
@@ -2963,7 +2963,7 @@
            for read-write+ viewers (server also 403s the POST for read-only). -->
       <span id="fleet-breaker-wrap" style="display:none">
         <span id="fleet-breaker-pill" class="pill-passed">running</span>
-        <button type="button" id="fleet-breaker-btn2" onclick="toggleFleetBreaker()"
+        <button type="button" id="fleet-breaker-btn2" data-action="toggleFleetBreaker"
                 title="Fleet breaker: pause every running agent at once. Releasing restores only the agents this breaker paused — on-demand agents and any agent you paused yourself are never touched."
                 aria-label="Fleet breaker">
           <span id="fleet-breaker-icon"><svg viewBox="0 0 12 12" aria-hidden="true"><rect x="2.5" y="2" width="2.4" height="8" rx="0.6"/><rect x="7.1" y="2" width="2.4" height="8" rx="0.6"/></svg></span>
@@ -2971,20 +2971,20 @@
       </span>
     </div>
     <div class="oc-topbar-center">
-      <button type="button" class="btn" id="oc-settings-btn" onclick="openConfigDialog('governor')" title="Settings — governor, agents, thresholds, and all hive settings" aria-label="Settings">⚙️ Settings</button>
+      <button type="button" class="btn" id="oc-settings-btn" data-action="openConfigDialog" data-arg0="governor" title="Settings — governor, agents, thresholds, and all hive settings" aria-label="Settings">⚙️ Settings</button>
       <span id="dashboard-custom-style-note" class="dashboard-custom-style-note" style="display:none" role="status"></span>
-      <span class="oc-tb-link" onclick="ocNavigate('debug-section')" title="System Diagnostics — health checks and troubleshooting" aria-label="System Diagnostics"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg></span>
+      <span class="oc-tb-link" data-action="ocNavigate" data-arg0="debug-section" title="System Diagnostics — health checks and troubleshooting" aria-label="System Diagnostics"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg></span>
       <!-- Agent Logs hidden (redundant with per-agent output) -->
-      <button class="layout-toggle" onclick="toggleLayout()" title="Switch to Dark Mode" aria-label="Switch to Dark Mode">☾</button>
+      <button class="layout-toggle" data-action="toggleLayout" title="Switch to Dark Mode" aria-label="Switch to Dark Mode">☾</button>
     </div>
     <div class="oc-topbar-right">
       <span class="oc-health-badge" id="oc-health">● Health OK</span>
-      <span id="oc-hive-id" class="git-version" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
+      <span id="oc-hive-id" class="git-version" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" data-action="openConfigDialog" data-arg0="governor"></span>
       <span class="oc-topbar-ts" id="oc-ts"></span>
-      <button class="btn" id="welcome-topbar-btn" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started guide" aria-label="Guide">🧭 Guide</button>
+      <button class="btn" id="welcome-topbar-btn" style="display:none" data-action="openWelcomeDialog" title="Open the Getting Started guide" aria-label="Guide">🧭 Guide</button>
       <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
       <div id="oc-gh-avatar-wrap" style="display:none;position:relative">
-        <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid var(--green);vertical-align:middle" onclick="toggleGHUserMenu()">
+        <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid var(--green);vertical-align:middle" data-action="toggleGHUserMenu">
         <!-- max-width keeps the longest entry ("Back up this hive") from
              widening the menu past the right edge of a narrow viewport; the
              menu is right-anchored, so extra width grows leftward and stays
@@ -3001,15 +3001,15 @@
           <!-- Owner-only self-service backup. Shown only for role === 'owner',
                matching the hive.yaml entry above; the server enforces the same
                check, so hiding this is UX, not the security boundary. -->
-          <button type="button" id="oc-gh-menu-backup" onclick="downloadHiveBackup()" style="display:none;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem;line-height:1.35">
+          <button type="button" id="oc-gh-menu-backup" data-action="downloadHiveBackup" style="display:none;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem;line-height:1.35">
             Back up this hive
             <span style="display:block;font-size:0.68rem;color:var(--muted)">Encrypted · includes beads · needs a backup key (Settings → Security)</span>
           </button>
           <a href="/api/docs" target="_blank" style="display:block;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">API Docs ↗</a>
-          <button onclick="ghLogout()" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem">Sign out</button>
+          <button data-action="ghLogout" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem">Sign out</button>
         </div>
       </div>
-      <button class="gh-auth-btn" id="oc-gh-login-btn" onclick="startGHLogin()" style="display:none;font-size:0.75rem;padding:3px 10px">Sign in</button>
+      <button class="gh-auth-btn" id="oc-gh-login-btn" data-action="startGHLogin" style="display:none;font-size:0.75rem;padding:3px 10px">Sign in</button>
     </div>
   </header>
 
@@ -3019,9 +3019,9 @@
 
   <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard&nbsp;<span id="project-name">for KubeStellar/Console</span> <span class="timestamp" id="ts"></span>
     <span class="git-version" id="git-version"></span>
-    <span class="git-version" id="hive-id-badge" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
-    <span class="git-version" id="acmm-badge" title="Click to change maturity level" style="cursor:pointer;border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);padding:2px 8px;border-radius:999px;background:color-mix(in srgb, var(--amber) 14%, transparent);color:var(--amber);font-weight:600" onclick="openACMMDialog()"></span>
-    <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch to Dark Mode" aria-label="Switch to Dark Mode">☾</button>
+    <span class="git-version" id="hive-id-badge" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" data-action="openConfigDialog" data-arg0="governor"></span>
+    <span class="git-version" id="acmm-badge" title="Click to change maturity level" style="cursor:pointer;border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);padding:2px 8px;border-radius:999px;background:color-mix(in srgb, var(--amber) 14%, transparent);color:var(--amber);font-weight:600" data-action="openACMMDialog"></span>
+    <button class="layout-toggle" id="layout-toggle" data-action="toggleLayout" title="Switch to Dark Mode" aria-label="Switch to Dark Mode">☾</button>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
@@ -3038,7 +3038,7 @@
          Firefox — matching Safari, where the flow already worked instantly. -->
     <input id="gh-app-install-id-input" type="text" inputmode="numeric" placeholder="Installation ID"
       autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false"
-      onkeydown="if(event.key==='Enter'){event.preventDefault();submitGitHubInstallationID();}"
+      data-keydown-action="submitGitHubInstallationID" data-prevent="1" data-keys="Enter"
       title="After installing the app, paste the numeric installation_id from the install URL (github.com/settings/installations/&lt;ID&gt;)"
       style="width:120px;padding:6px 8px;margin-right:6px;background:var(--panel);border:1px solid var(--line);border-radius:4px;color:var(--text);font-size:0.8rem" />
     <!-- Where-do-I-find-this hint. Content is injected by
@@ -3049,7 +3049,7 @@
       <button type="button" class="gh-idhint-btn" id="gh-app-install-id-hint-btn"
         aria-expanded="false" aria-controls="gh-app-install-id-hint-pop"
         aria-label="Where do I find my Installation ID?"
-        onclick="toggleInstallIdHint(event)">?</button>
+        data-action="toggleInstallIdHint" data-arg-types="e">?</button>
       <span class="gh-idhint-pop" id="gh-app-install-id-hint-pop" role="tooltip"></span>
     </span>
     <!-- type=button is explicit: with no type a <button> defaults to
@@ -3061,8 +3061,8 @@
          the banner's solid primary recipe (.gh-app-btn). The old transparent
          style made it read as static text — operators typed the ID and never
          realized a click was required. -->
-    <button type="button" onclick="submitGitHubInstallationID()" class="gh-app-btn" style="margin-right:8px" id="gh-app-set-id-btn">Save Installation ID</button>
-    <button type="button" onclick="recheckGitHubApp()" class="gh-app-btn" style="background:transparent;border-color:var(--line-strong);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
+    <button type="button" data-action="submitGitHubInstallationID" class="gh-app-btn" style="margin-right:8px" id="gh-app-set-id-btn">Save Installation ID</button>
+    <button type="button" data-action="recheckGitHubApp" class="gh-app-btn" style="background:transparent;border-color:var(--line-strong);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
   <div id="repo-target-banner" class="gh-app-install-banner perm-issue" hidden>
@@ -3071,7 +3071,7 @@
       <div class="gh-app-title">Repo Target Misconfigured</div>
       <div class="gh-app-desc" id="repo-target-banner-desc">Expected org/repo.</div>
     </div>
-    <button type="button" class="gh-app-btn" onclick="openConfigDialog('governor',null,'Repos')">Fix in Repos</button>
+    <button type="button" class="gh-app-btn" data-action="gh1">Fix in Repos</button>
   </div>
   <div id="hub-banner" style="display:none"></div>
   <div id="planning-intro" style="display:none"></div>
@@ -3079,7 +3079,7 @@
   <div class="governor" id="governor"></div>
 
   <div id="advisory-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
-    <h2 class="section-label advisory-collapse-header section-header-toggle" style="margin-bottom: 8px; cursor: pointer; user-select: none;" onclick="toggleAdvisorySection('advisory-digest-main')">
+    <h2 class="section-label advisory-collapse-header section-header-toggle" style="margin-bottom: 8px; cursor: pointer; user-select: none;" data-action="toggleAdvisorySection" data-arg0="advisory-digest-main">
       <span id="advisory-digest-main-chevron" class="collapse-chevron">▼</span> 📋 Advisory Digest
     </h2>
     <div class="section-body">
@@ -3092,7 +3092,7 @@
   <div class="cost-usage" id="cost-panel" style="margin-bottom: 24px;"></div>
 
   <div class="repos" id="repos-section">
-    <h2 class="section-header-toggle" onclick="toggleSection('repos-section')"><span class="section-chevron">▼</span> Repositories <span id="repos-host-badge" title="Every repo in this hive is on this single GitHub host" style="font-size:0.62em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px"></span> <button class="config-gear" onclick="event.stopPropagation();openConfigDialog('governor',null,'Repos')" title="Manage monitored repositories" style="font-size:0.7em;vertical-align:middle">⚙️</button></h2>
+    <h2 class="section-header-toggle" data-action="toggleSection" data-arg0="repos-section"><span class="section-chevron">▼</span> Repositories <span id="repos-host-badge" title="Every repo in this hive is on this single GitHub host" style="font-size:0.62em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px"></span> <button class="config-gear" data-action="gh1" data-stop="1" title="Manage monitored repositories" style="font-size:0.7em;vertical-align:middle">⚙️</button></h2>
     <div class="section-body">
       <!-- Read-only view of project.issue_filter: which issues agents may
            initiate work on, by label. Hidden unless a filter is configured;
@@ -3104,25 +3104,25 @@
   </div>
 
   <div id="beads-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('beads-section')"><span class="section-chevron">▼</span> Beads</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="beads-section"><span class="section-chevron">▼</span> Beads</h2>
     <div class="section-body">
       <div class="beads" id="beads"></div>
     </div>
   </div>
 
   <div id="acmm-eval-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('acmm-eval-section')"><span class="section-chevron">▼</span> 🎯 ACMM Evaluation <button class="btn" onclick="event.stopPropagation();openACMMDialog()" title="Click to change maturity level" style="vertical-align:middle;margin-left:8px;font-weight:400">Change level ▾</button></h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="acmm-eval-section"><span class="section-chevron">▼</span> 🎯 ACMM Evaluation <button class="btn" data-action="openACMMDialog" data-stop="1" title="Click to change maturity level" style="vertical-align:middle;margin-left:8px;font-weight:400">Change level ▾</button></h2>
     <div class="section-body">
       <div id="acmm-eval-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
         <div class="kb-stat-grid" id="acmm-eval-stats">
-          <div class="kb-stat" onclick="acmmShowCodebaseDialog()" style="cursor:pointer"><div class="val" id="acmm-codebase-level">--</div><div class="lbl">Codebase Readiness</div></div>
-          <div class="kb-stat" onclick="acmmShowOpsDialog()" style="cursor:pointer"><div class="val" id="acmm-ops-level">--</div><div class="lbl">Operational Autonomy</div></div>
-          <div class="kb-stat" onclick="acmmShowOverallDialog()" style="cursor:pointer"><div class="val" id="acmm-overall-level">--</div><div class="lbl">Overall ACMM</div></div>
-          <div class="kb-stat" onclick="acmmShowAllCriteriaDialog()" style="cursor:pointer"><div class="val" id="acmm-criteria-ratio">--</div><div class="lbl">Criteria Passed</div></div>
+          <div class="kb-stat" data-action="acmmShowCodebaseDialog" style="cursor:pointer"><div class="val" id="acmm-codebase-level">--</div><div class="lbl">Codebase Readiness</div></div>
+          <div class="kb-stat" data-action="acmmShowOpsDialog" style="cursor:pointer"><div class="val" id="acmm-ops-level">--</div><div class="lbl">Operational Autonomy</div></div>
+          <div class="kb-stat" data-action="acmmShowOverallDialog" style="cursor:pointer"><div class="val" id="acmm-overall-level">--</div><div class="lbl">Overall ACMM</div></div>
+          <div class="kb-stat" data-action="acmmShowAllCriteriaDialog" style="cursor:pointer"><div class="val" id="acmm-criteria-ratio">--</div><div class="lbl">Criteria Passed</div></div>
         </div>
         <div id="acmm-repo-selector" style="display:none;margin-top:8px;font-size:0.75rem;display:flex;align-items:center;gap:6px;flex-wrap:wrap">
           <span class="muted">Repo:</span>
-          <button onclick="acmmSelectRepo(null)" id="acmm-repo-btn-all" class="repo-chip-btn" style="font-weight:600">All (aggregate)</button>
+          <button data-action="gh2" id="acmm-repo-btn-all" class="repo-chip-btn" style="font-weight:600">All (aggregate)</button>
         </div>
         <div id="acmm-level-bars" style="margin-top:12px"></div>
         <div id="acmm-eval-meta" style="margin-top:10px;font-size:0.7rem;color:var(--muted);display:flex;justify-content:space-between">
@@ -3135,7 +3135,7 @@
   </div>
 
   <div id="platform-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('platform-section')"><span class="section-chevron">▼</span> 🧩 Platform</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="platform-section"><span class="section-chevron">▼</span> 🧩 Platform</h2>
     <div class="section-body">
       <div id="platform-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
         <div class="kb-stat-grid" id="platform-stats"></div>
@@ -3144,29 +3144,29 @@
   </div>
 
   <div id="acmm-reco-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('acmm-reco-section')"><span class="section-chevron">▼</span> ⬆️ Ready to level up? <span style="font-size:0.6em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px;background:color-mix(in srgb, var(--muted) 18%, transparent);color:var(--muted)">advisory</span></h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="acmm-reco-section"><span class="section-chevron">▼</span> ⬆️ Ready to level up? <span style="font-size:0.6em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px;background:color-mix(in srgb, var(--muted) 18%, transparent);color:var(--muted)">advisory</span></h2>
     <div class="section-body">
       <div id="acmm-reco-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px"></div>
     </div>
   </div>
 
   <div id="lifecycle-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('lifecycle-section')"><span class="section-chevron">▼</span> 🔀 Lifecycle Timeline</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="lifecycle-section"><span class="section-chevron">▼</span> 🔀 Lifecycle Timeline</h2>
     <div class="section-body">
       <div id="lifecycle-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px"></div>
     </div>
   </div>
 
   <div id="audit-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('audit-section')"><span class="section-chevron">▼</span> 📋 Audit Log</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="audit-section"><span class="section-chevron">▼</span> 📋 Audit Log</h2>
     <div class="section-body">
       <div class="audit-controls-row" style="margin-bottom:5px;padding:3px;display:flex;align-items:center;gap:8px">
         <div style="flex:1;position:relative">
-          <input id="audit-search" list="audit-saved-searches" type="text" placeholder="Search audit log... (terms are OR'd, supports /regex/)" oninput="filterAuditLog()" onkeydown="if(event.key==='Enter')saveAuditSearch()" style="width:100%;padding:6px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.82rem;outline:none">
+          <input id="audit-search" list="audit-saved-searches" type="text" placeholder="Search audit log... (terms are OR'd, supports /regex/)" data-input-action="filterAuditLog" data-keydown-action="saveAuditSearch" data-keys="Enter" style="width:100%;padding:6px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.82rem;outline:none">
           <datalist id="audit-saved-searches"></datalist>
         </div>
-        <button onclick="saveAuditSearch()" title="Save this search" style="padding:4px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer;font-size:0.75rem;white-space:nowrap">💾 Save</button>
-        <button onclick="clearAuditSearches()" title="Clear saved searches" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer;font-size:0.75rem">✕</button>
+        <button data-action="saveAuditSearch" title="Save this search" style="padding:4px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer;font-size:0.75rem;white-space:nowrap">💾 Save</button>
+        <button data-action="clearAuditSearches" title="Clear saved searches" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer;font-size:0.75rem">✕</button>
         <span id="audit-match-count" style="font-size:0.7rem;color:var(--muted);white-space:nowrap"></span>
       </div>
       <div id="audit-panel" style="padding:12px;max-height:320px;overflow-y:auto">
@@ -3176,7 +3176,7 @@
   </div>
 
   <div id="nous-section" style="display:none; margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('nous-section')"><span class="section-chevron">▼</span> 🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button onclick="event.stopPropagation();openNousConfig()" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="nous-section"><span class="section-chevron">▼</span> 🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button data-action="openNousConfig" data-stop="1" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
     <div class="section-body">
       <div id="nous-panel"></div>
       <div id="nous-config-overlay" class="nous-config-overlay" style="display:none"></div>
@@ -3184,25 +3184,25 @@
   </div>
 
   <div id="inception-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('inception-section')"><span class="section-chevron">▼</span> 💡 Project Inception</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="inception-section"><span class="section-chevron">▼</span> 💡 Project Inception</h2>
     <div class="section-body">
       <div id="inception-panel" style="height:min(800px,70vh);overflow-y:auto;overflow-x:hidden;"></div>
     </div>
   </div>
 
   <div id="knowledge-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('knowledge-section')"><span class="section-chevron">▼</span> 📚 Knowledge Base <span id="kb-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="knowledge-section"><span class="section-chevron">▼</span> 📚 Knowledge Base <span id="kb-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
     <div class="section-body">
       <div id="knowledge-panel"></div>
     </div>
   </div>
 
   <div id="contributors-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap" class="section-header-toggle" onclick="toggleSection('contributors-section')">
+    <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap" class="section-header-toggle" data-action="toggleSection" data-arg0="contributors-section">
       <span class="section-chevron">▼</span>
       <h2 class="section-label" style="margin:0;">👥 Contributors <span id="contributors-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
-      <a href="/contribute" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:var(--green);color:var(--bg);border-radius:6px;text-decoration:none;font-weight:600">Share /contribute link &rarr;</a>
-      <a href="/leaderboard" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:transparent;color:var(--blue);border:1px solid var(--blue);border-radius:6px;text-decoration:none">🏆 Leaderboard</a>
+      <a href="/contribute" target="_blank" data-action="gh3" style="font-size:0.75rem;padding:4px 12px;background:var(--green);color:var(--bg);border-radius:6px;text-decoration:none;font-weight:600">Share /contribute link &rarr;</a>
+      <a href="/leaderboard" target="_blank" data-action="gh3" style="font-size:0.75rem;padding:4px 12px;background:transparent;color:var(--blue);border:1px solid var(--blue);border-radius:6px;text-decoration:none">🏆 Leaderboard</a>
     </div>
     <div class="section-body">
       <div id="contributors-filters" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px"></div>
@@ -3213,14 +3213,14 @@
   </div>
 
   <div id="debug-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('debug-section')"><span class="section-chevron">▼</span> 🔍 System Diagnostics</h2>
+    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="debug-section"><span class="section-chevron">▼</span> 🔍 System Diagnostics</h2>
     <div class="section-body">
       <div id="debug-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px;"></div>
     </div>
   </div>
 
   <div id="logs-section" style="display: none; margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('logs-section')"><span class="section-chevron">▼</span> 📋 Agent Logs</h2>
+    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="logs-section"><span class="section-chevron">▼</span> 📋 Agent Logs</h2>
     <div class="section-body">
       <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
         <select id="logs-agent-select" style="padding: 6px 12px; border: 1px solid var(--border); border-radius: 6px; font-size: 0.82rem; background: var(--surface); color: var(--text); cursor: pointer;" title="Filter logs to a specific agent or view all agents combined">
@@ -3238,8 +3238,8 @@
   <div id="oc-agent-detail" class="oc-agent-detail"></div>
   <div id="agents-section">
     <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-      <h2 style="margin:0; cursor:pointer" class="section-label section-header-toggle" onclick="toggleSection('agents-section')"><span class="section-chevron">▼</span> Agents</h2>
-      <button id="agents-compact-all-btn" onclick="event.stopPropagation();toggleAllAgentsCompact()" style="font-size:0.7rem;padding:2px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer" title="Toggle all agent cards between compact and expanded view"></button>
+      <h2 style="margin:0; cursor:pointer" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="agents-section"><span class="section-chevron">▼</span> Agents</h2>
+      <button id="agents-compact-all-btn" data-action="toggleAllAgentsCompact" data-stop="1" style="font-size:0.7rem;padding:2px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer" title="Toggle all agent cards between compact and expanded view"></button>
     </div>
     <div class="section-body">
       <div class="agents" id="agents"></div>
@@ -3250,7 +3250,7 @@
        sidebarItems list and no display:none default), because the audience for
        it is a confused L1/L2 user. Static content only: no JS, no fetch. -->
   <div id="faq-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('faq-section')"><span class="section-chevron">▼</span> ❓ FAQ</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" data-action="toggleSection" data-arg0="faq-section"><span class="section-chevron">▼</span> ❓ FAQ</h2>
     <div class="section-body">
       <div id="faq-panel" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-size:0.85rem;line-height:1.6;max-width:900px">
 
@@ -4129,12 +4129,12 @@
             const claudeIcon = '<span class="cli-icon claude-icon"></span>';
             const copilotIcon = '<span class="cli-icon copilot-icon"></span>';
             if (_needsLogin) {
-              if (isClaude) return '<button class="cli-login-btn claude" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Authenticate Claude Code CLI">' + claudeIcon + ' Login</button>';
-              if (isCopilot) return '<button class="cli-login-btn copilot" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Authenticate GitHub Copilot CLI">' + copilotIcon + ' Login</button>';
+              if (isClaude) return '<button class="cli-login-btn claude" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="claude" data-stop="1" title="Authenticate Claude Code CLI">' + claudeIcon + ' Login</button>';
+              if (isCopilot) return '<button class="cli-login-btn copilot" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="copilot" data-stop="1" title="Authenticate GitHub Copilot CLI">' + copilotIcon + ' Login</button>';
               return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">Login</button>';
             }
-            if (isClaude) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Re-authenticate Claude Code CLI">' + claudeIcon + ' ✓ logged in</button>';
-            if (isCopilot) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Re-authenticate GitHub Copilot CLI">' + copilotIcon + ' ✓ logged in</button>';
+            if (isClaude) return '<button class="cli-login-btn logged-in" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="claude" data-stop="1" title="Re-authenticate Claude Code CLI">' + claudeIcon + ' ✓ logged in</button>';
+            if (isCopilot) return '<button class="cli-login-btn logged-in" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="copilot" data-stop="1" title="Re-authenticate GitHub Copilot CLI">' + copilotIcon + ' ✓ logged in</button>';
             return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">✓ logged in</button>';
           })()}</div></div>
         </div>
@@ -4349,7 +4349,7 @@
         <div class="oc-detail-indicators">${agentIndicators(a.name)}</div>
         <div class="oc-detail-summary-wrap">
           <div class="oc-detail-summary" id="oc-summary-scroll">${(a.detailSummary || a.liveSummary) ? escBlock(a.detailSummary || a.liveSummary) : '<span style="color:var(--muted)">No activity summary</span>'}</div>
-          <button class="oc-summary-follow-btn" id="oc-summary-follow" title="Follow new output" onclick="ocSummaryResumeTail()">⬇</button>
+          <button class="oc-summary-follow-btn" id="oc-summary-follow" title="Follow new output" data-action="ocSummaryResumeTail">⬇</button>
         </div>
         <div class="oc-chat-prompt">
           <input type="text" class="oc-chat-input" id="${kickId}" placeholder="Send a message to ${esc(a.name)}..." value="${prevVal.replace(/"/g, '&quot;')}" data-enter-action="ocSendKick" data-agent="${esc(a.name)}" />
@@ -4758,7 +4758,7 @@
           html += `<div class="oc-sidebar-group" data-group-name="${esc}">`;
           html += `<div class="oc-sidebar-group-header" draggable="true" data-action="ocToggleSidebarGroup">`;
           html += `<span class="oc-group-arrow">▼</span> ${esc}`;
-          html += `<span class="oc-group-actions" onclick="event.stopPropagation()">`;
+          html += `<span class="oc-group-actions" data-action="gh3">`;
           html += `<button data-action="ocRenameSidebarGroup" data-group="${esc}" title="Rename">✏</button>`;
           html += `<button data-action="ocRemoveSidebarGroup" data-group="${esc}" title="Remove group">✕</button>`;
           html += `</span></div>`;
@@ -5398,9 +5398,9 @@
         // datetime-local wants local wall-clock time without zone suffix.
         const toLocal = (ms) => new Date(ms - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16);
         customControls = `<div class="cost-custom-range">
-          <input type="datetime-local" id="cost-custom-start" value="${toLocal(_costCustom.start)}" onchange="costCustomChanged()" title="Custom range start">
+          <input type="datetime-local" id="cost-custom-start" value="${toLocal(_costCustom.start)}" data-change-action="costCustomChanged" title="Custom range start">
           <span>→</span>
-          <input type="datetime-local" id="cost-custom-end" value="${toLocal(_costCustom.end)}" onchange="costCustomChanged()" title="Custom range end">
+          <input type="datetime-local" id="cost-custom-end" value="${toLocal(_costCustom.end)}" data-change-action="costCustomChanged" title="Custom range end">
         </div>`;
       }
       const buckets = costBuckets();
@@ -5749,7 +5749,7 @@
         if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">PR open (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
         if (allMergedCount > 0) {
           const mergedOpen = localStorage.getItem('hive-merged-expanded') !== 'false';
-          html += `<details class="agent-indicators merged-collapse" ${mergedOpen ? 'open' : ''} ontoggle="localStorage.setItem('hive-merged-expanded', this.open)"><summary class="ind-label" style="cursor:pointer;user-select:none">Merged today (${allMergedCount})</summary>${mergedPairs.map(renderPair).join('')}${standaloneMerged.map(renderStandalonePr).join('')}</details>`;
+          html += `<details class="agent-indicators merged-collapse" ${mergedOpen ? 'open' : ''} data-toggle-action="gh4"><summary class="ind-label" style="cursor:pointer;user-select:none">Merged today (${allMergedCount})</summary>${mergedPairs.map(renderPair).join('')}${standaloneMerged.map(renderStandalonePr).join('')}</details>`;
         }
         if (!html) html = '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
         return html;
@@ -5937,7 +5937,7 @@
         const configTarget = a.replicaBase || a.name;
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" onclick="event.stopPropagation();toggleAgentCompact('${esc(a.name)}')" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
@@ -5977,12 +5977,12 @@
             const claudeIcon = '<span class="cli-icon claude-icon"></span>';
             const copilotIcon = '<span class="cli-icon copilot-icon"></span>';
             if (needsLogin) {
-              if (isClaude) return '<button class="cli-login-btn claude" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Authenticate Claude Code CLI">' + claudeIcon + ' Login</button>';
-              if (isCopilot) return '<button class="cli-login-btn copilot" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Authenticate GitHub Copilot CLI">' + copilotIcon + ' Login</button>';
+              if (isClaude) return '<button class="cli-login-btn claude" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="claude" data-stop="1" title="Authenticate Claude Code CLI">' + claudeIcon + ' Login</button>';
+              if (isCopilot) return '<button class="cli-login-btn copilot" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="copilot" data-stop="1" title="Authenticate GitHub Copilot CLI">' + copilotIcon + ' Login</button>';
               return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">Login</button>';
             }
-            if (isClaude) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27claude\x27)" title="Re-authenticate Claude Code CLI">' + claudeIcon + ' ✓ logged in</button>';
-            if (isCopilot) return '<button class="cli-login-btn logged-in" onclick="event.stopPropagation();loginAgent(\x27' + esc(a.name) + '\x27,\x27copilot\x27)" title="Re-authenticate GitHub Copilot CLI">' + copilotIcon + ' ✓ logged in</button>';
+            if (isClaude) return '<button class="cli-login-btn logged-in" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="claude" data-stop="1" title="Re-authenticate Claude Code CLI">' + claudeIcon + ' ✓ logged in</button>';
+            if (isCopilot) return '<button class="cli-login-btn logged-in" data-action="loginAgent" data-arg0="' + esc(a.name) + '" data-arg1="copilot" data-stop="1" title="Re-authenticate GitHub Copilot CLI">' + copilotIcon + ' ✓ logged in</button>';
             return '<button class="cli-login-btn disabled" disabled title="This backend requires manual /login in the terminal">✓ logged in</button>';
           })()}</span></div>
           ${summaryEl}${indEl}
@@ -6494,7 +6494,7 @@
       el.innerHTML = '<div style="background:' + s.bg + ';border:1px solid ' + s.border + ';border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
         + '<span style="font-size:1.1rem">📢</span>'
         + '<span style="flex:1;color:' + s.color + '">' + bannerMarkdown(banner.message, s.color) + '</span>'
-        + '<button onclick="dismissHubBanner(\'' + (banner.id || '').replace(/'/g, "\\'") + '\')" style="background:none;border:none;color:' + s.color + ';opacity:0.6;cursor:pointer;font-size:1.1rem;padding:0 4px" title="Dismiss">✕</button>'
+        + '<button data-action="dismissHubBanner" data-arg0="' + esc(banner.id || '') + '" style="background:none;border:none;color:' + s.color + ';opacity:0.6;cursor:pointer;font-size:1.1rem;padding:0 4px" title="Dismiss">✕</button>'
         + '</div>';
     }
 
@@ -6546,7 +6546,7 @@
       el.innerHTML = '<div style="background:rgba(124,58,237,0.10);border:1px solid rgba(124,58,237,0.32);border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
         + '<span style="font-size:1.1rem">🧭</span>'
         + '<span style="flex:1;color:var(--text)"><strong>New: plan a GitHub issue.</strong> Add the <code>plan</code> label to any issue on GitHub — or click <strong>⧉ Plan</strong> on an issue below — and the architect breaks it into a reviewable task plan you approve before work starts.</span>'
-        + '<button onclick="dismissPlanningIntro()" style="background:none;border:none;color:var(--text);opacity:0.6;cursor:pointer;font-size:1.1rem;padding:0 4px" title="Dismiss">✕</button>'
+        + '<button data-action="dismissPlanningIntro" style="background:none;border:none;color:var(--text);opacity:0.6;cursor:pointer;font-size:1.1rem;padding:0 4px" title="Dismiss">✕</button>'
         + '</div>';
     }
     function dismissPlanningIntro() {
@@ -6724,7 +6724,7 @@
       const holdSpark = sparkline('govHold');
 
       el.innerHTML = `
-        <div class="gov-title">Governor <button class="config-gear" onclick="openConfigDialog('governor')" title="Open Governor configuration — manage agents, thresholds, budget, notifications, health checks, and sensing patterns">⚙️</button></div>
+        <div class="gov-title">Governor <button class="config-gear" data-action="openConfigDialog" data-arg0="governor" title="Open Governor configuration — manage agents, thresholds, budget, notifications, health checks, and sensing patterns">⚙️</button></div>
         <div class="gov-grid">
           <div class="gov-stat" title="TIMER — is the governor's evaluation loop alive?&#10;&#10;WHAT: The governor re-evaluates mode and kicks due agents on a fixed cadence. This shows whether that loop is running.&#10;&#10;HOW: 'active' if the governor reported a heartbeat within its expected interval; 'starting' during boot before the first tick; 'DEAD' if no heartbeat has arrived — agents will NOT be kicked automatically until it recovers."><div class="label">timer</div><div class="val ${cls}">${gov.active ? '● active' : (isStarting ? '⏳ starting' : '⚠ DEAD')}</div></div>
           <div class="gov-stat" title="MODE — the governor's current activity level.&#10;&#10;WHAT: Sets how aggressively agents are scheduled. idle → quiet → busy → surge, each with faster cadences.&#10;&#10;HOW: Derived from queue pressure — actionable issues + open PRs — against the thresholds shown on the gauge below: 0–${CLASSIC_THRESH_QUIET-1}=idle, ${CLASSIC_THRESH_QUIET}–${CLASSIC_THRESH_BUSY-1}=quiet, ${CLASSIC_THRESH_BUSY}–${CLASSIC_THRESH_SURGE-1}=busy, ≥${CLASSIC_THRESH_SURGE}=surge. Thresholds are configurable in Governor settings."><div class="label">mode</div><div class="val" style="color:${modeColor}">${escapeHtml(gov.mode)}</div></div>
@@ -6753,7 +6753,7 @@
           <div class="gov-stat" title="NEXT RUN — when the governor next wakes up.&#10;&#10;WHAT: The next scheduled moment the governor will re-evaluate mode and kick any agents that are due.&#10;&#10;HOW: Computed from the current mode's cadence schedule — the governor adds the mode's interval to the last run time. Faster modes (busy/surge) produce a nearer next run than idle/quiet."><div class="label">next run</div><div class="val">${escapeHtml(gov.nextKick || '—')}</div></div>
           <div class="gov-stat" title="PR AUTHOR — the GitHub identity this hive's agents open PRs and push commits as.&#10;&#10;WHAT: Either the configured project.ai_author, or the GitHub App bot ('<slug>[bot]') when the hive runs in App-authored mode.&#10;&#10;HOW: Reported by the spoke as ai_author_effective. A '[bot]' value means PRs are authored by the App installation, not a personal account."><div class="label">PR author</div><div class="val">${escapeHtml(window._aiAuthor || '—')}</div></div>
         </div>
-        <div class="temp-gauge" style="cursor:pointer" onclick="openConfigDialog('governor',null,'Thresholds')" title="Click to adjust governor thresholds">
+        <div class="temp-gauge" style="cursor:pointer" data-action="gh5" title="Click to adjust governor thresholds">
           <div class="temp-gauge-label"><span>Pressure: ${govPressure} (${issueCount} issues + ${prCount} PRs)</span><span>max ${maxQ}</span></div>
           <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${CLASSIC_THRESH_QUIET/maxQ*100}%, var(--blue) ${CLASSIC_THRESH_QUIET/maxQ*100}%, var(--blue) ${CLASSIC_THRESH_BUSY/maxQ*100}%, var(--yellow) ${CLASSIC_THRESH_BUSY/maxQ*100}%, var(--yellow) ${CLASSIC_THRESH_SURGE/maxQ*100}%, var(--red) ${CLASSIC_THRESH_SURGE/maxQ*100}%, var(--red) 100%)">
             <div class="temp-gauge-glow" style="width:100%"></div>
@@ -6910,7 +6910,7 @@
         const agentKey = 'advisory-agent-' + agent;
         const agentCollapsed = isAdvisoryCollapsed(agentKey);
         html += `<div style="margin-bottom:12px">
-          <div style="font-weight:600;font-size:0.85rem;margin-bottom:6px;color:var(--text);cursor:pointer;user-select:none" onclick="toggleAdvisorySection('${agentKey}')">
+          <div style="font-weight:600;font-size:0.85rem;margin-bottom:6px;color:var(--text);cursor:pointer;user-select:none" data-action="toggleAdvisorySection" data-arg0="${agentKey}">
             <span id="${agentKey}-chevron" class="collapse-chevron${agentCollapsed ? ' collapsed' : ''}">▼</span>
             ${escapeHtml(agent)} <span style="color:var(--muted);font-weight:400">(${findings.length})</span>
           </div>
@@ -7013,7 +7013,7 @@
           const queueBtn = canQueue
             ? (queued
                 ? '<span class="repo-pr-pill mergeable" title="Already queued for Hive auto-merge on green CI">Queued</span>'
-                : `<button class="repo-pr-pill" style="cursor:pointer" onclick="event.preventDefault();event.stopPropagation();queuePRAutoMerge(${JSON.stringify(owner)},${JSON.stringify(repoName)},${p.number},this)">Queue auto-merge</button>`)
+                : `<button class="repo-pr-pill" style="cursor:pointer" data-action="queuePRAutoMerge" data-arg0="${esc(owner)}" data-arg1="${esc(repoName)}" data-arg2="${p.number}" data-arg-types="s,s,j,t" data-stop="1" data-prevent="1">Queue auto-merge</button>`)
             : '';
           return `<a class="repo-pr-pill${mergeClass}" href="${esc(p.url)}" target="_blank" rel="noopener" title="${esc(prTip)}"><span class="pill-num">#${p.number}</span><span class="pill-title">${esc(title)}</span>${mergeIcon}</a>${queueBtn}`;
         }).join('');
@@ -7130,7 +7130,7 @@
         govAction = '<span style="color:var(--muted)">Budget enforcement disabled by operator</span>';
       } else if (exhausted) {
         const windowEnds = budget.WINDOW_ENDS_AT ? new Date(budget.WINDOW_ENDS_AT).toLocaleString() : 'the next window';
-        govAction = `<span style="color:var(--red)" title="Agents on the budget exempt list keep running">budget exhausted — agent kicks suspended until ${windowEnds}</span> <button onclick="resetBudgetWindow()" title="Open a fresh budget window now: spend restarts at 0 and suspended kicks resume. Budget enforcement stays on — raise Total Tokens in Settings first if the limit itself was too small." style="margin-left:8px;padding:1px 8px;font-size:0.66rem;background:var(--bg);border:1px solid var(--border);border-radius:5px;color:var(--fg);cursor:pointer">reset window now</button>`;
+        govAction = `<span style="color:var(--red)" title="Agents on the budget exempt list keep running">budget exhausted — agent kicks suspended until ${windowEnds}</span> <button data-action="resetBudgetWindow" title="Open a fresh budget window now: spend restarts at 0 and suspended kicks resume. Budget enforcement stays on — raise Total Tokens in Settings first if the limit itself was too small." style="margin-left:8px;padding:1px 8px;font-size:0.66rem;background:var(--bg);border:1px solid var(--border);border-radius:5px;color:var(--fg);cursor:pointer">reset window now</button>`;
       } else if (pctUsed >= PCT_BUDGET_WARN) {
         govAction = `<span style="color:var(--yellow)">Budget warning — ${pctUsed}% of weekly limit used; kicks suspend at 100%</span>`;
       } else if (projPct > PCT_WARN) {
@@ -7142,8 +7142,8 @@
       }
 
       const ignoreCheck = `<label style="font-size:0.68rem;color:var(--muted);cursor:pointer;margin-left:12px" title="When checked, the governor ignores budget limits entirely. No model downgrading, no kick skipping. Use with caution — spending will be uncapped until unchecked.">
-        <input type="checkbox" ${budgetIgnored ? 'checked' : ''} onchange="toggleBudgetIgnore()" style="cursor:pointer;vertical-align:middle"> ignore budget
-      </label><button onclick="resetBudgetWindow()" title="Open a fresh budget window now: spend re-anchors at 0 and the window timer restarts. Budget enforcement stays on." style="margin-left:8px;padding:0 6px;font-size:0.64rem;background:none;border:1px solid var(--border);border-radius:5px;color:var(--muted);cursor:pointer;vertical-align:middle">reset window</button>`;
+        <input type="checkbox" ${budgetIgnored ? 'checked' : ''} data-change-action="toggleBudgetIgnore" style="cursor:pointer;vertical-align:middle"> ignore budget
+      </label><button data-action="resetBudgetWindow" title="Open a fresh budget window now: spend re-anchors at 0 and the window timer restarts. Budget enforcement stays on." style="margin-left:8px;padding:0 6px;font-size:0.64rem;background:none;border:1px solid var(--border);border-radius:5px;color:var(--muted);cursor:pointer;vertical-align:middle">reset window</button>`;
 
       return `<div class="budget-bar">
         <div class="budget-bar-label">
@@ -8333,7 +8333,7 @@ function burnAreaChart() {
         </table>`;
 
       el.innerHTML = `<div class="cost-panel">
-        <div class="cost-title cost-toggle" role="button" tabindex="0" aria-expanded="true" aria-controls="cost-panel-body" onclick="toggleCostPanel()" onkeydown="costHeaderKey(event)" title="Collapse / expand the cost panel">
+        <div class="cost-title cost-toggle" role="button" tabindex="0" aria-expanded="true" aria-controls="cost-panel-body" data-action="toggleCostPanel" data-keydown-action="costHeaderKey" data-arg-types="e" data-keys="*" title="Collapse / expand the cost panel">
           <span class="cost-chevron" aria-hidden="true">▼</span>
           Cost <span class="cost-badge est" title="Estimated from token counts × list prices; subscription/self-hosted billing may differ">est.</span>
           <span class="cost-collapsed-total" title="Estimated all-time total">${fmtUSD(est.total_usd)}</span>
@@ -8943,7 +8943,7 @@ function burnAreaChart() {
         html += `<span>Queue limit: ${exp.fastFail.queueMax}</span>`;
         html += `<span>MTTR limit: ${exp.fastFail.mttrMax}min</span>`;
         html += '</div>';
-        html += `<button class="nous-btn nous-btn-abort" style="margin-top:10px" onclick="nousAbort()" title="Immediately stop the running experiment and revert the governor to its pre-experiment configuration. Results collected so far will be saved for analysis.">Abort Experiment</button>`;
+        html += `<button class="nous-btn nous-btn-abort" style="margin-top:10px" data-action="nousAbort" title="Immediately stop the running experiment and revert the governor to its pre-experiment configuration. Results collected so far will be saved for analysis.">Abort Experiment</button>`;
         html += '</div>';
       }
 
@@ -8964,8 +8964,8 @@ function burnAreaChart() {
           html += `<div style="font-size:0.72rem;color:var(--yellow)">Predicted: ${escapeHtml(JSON.stringify(p.predicted))}</div>`;
         }
         html += '<div style="margin-top:10px">';
-        html += '<button class="nous-btn nous-btn-approve" onclick="nousApprove()" title="Approve this experiment proposal and start running it. The governor will apply the proposed parameter changes for the configured experiment duration.">Apply</button>';
-        html += '<button class="nous-btn nous-btn-reject" onclick="nousReject()" title="Reject this experiment proposal. Nous will discard it and generate a new hypothesis based on collected data.">Reject</button>';
+        html += '<button class="nous-btn nous-btn-approve" data-action="nousApprove" title="Approve this experiment proposal and start running it. The governor will apply the proposed parameter changes for the configured experiment duration.">Apply</button>';
+        html += '<button class="nous-btn nous-btn-reject" data-action="nousReject" title="Reject this experiment proposal. Nous will discard it and generate a new hypothesis based on collected data.">Reject</button>';
         html += '</div></div>';
       }
 
@@ -9101,7 +9101,7 @@ function burnAreaChart() {
 
       const cfg = await fetchNousConfig();
       if (!cfg) {
-        overlay.innerHTML = '<div class="nous-config-dialog"><div style="color:var(--red);padding:20px">Failed to load config</div><div class="nous-config-btn-bar"><button class="nous-config-btn nous-config-btn-cancel" onclick="closeNousConfig()">Close</button></div></div>';
+        overlay.innerHTML = '<div class="nous-config-dialog"><div style="color:var(--red);padding:20px">Failed to load config</div><div class="nous-config-btn-bar"><button class="nous-config-btn nous-config-btn-cancel" data-action="closeNousConfig">Close</button></div></div>';
         return;
       }
       renderNousConfig(cfg);
@@ -9178,7 +9178,7 @@ function burnAreaChart() {
       ];
       for (const om of outModes) {
         const active = (output.mode || 'state-only') === om.id ? ' active' : '';
-        h += `<button class="nous-config-output-mode${active}" data-output-mode="${om.id}" onclick="selectNousOutputMode(this)" title="${escapeHtml(om.desc)}">${escapeHtml(om.label)}</button>`;
+        h += `<button class="nous-config-output-mode${active}" data-output-mode="${om.id}" data-action="selectNousOutputMode" data-arg-types="t" title="${escapeHtml(om.desc)}">${escapeHtml(om.label)}</button>`;
       }
       h += '</div>';
       h += '<div style="margin-top:8px">';
@@ -9194,7 +9194,7 @@ function burnAreaChart() {
       for (const repo of projectRepos) {
         const active = repoTargets.includes(repo) ? ' active' : '';
         const shortName = repo.includes('/') ? repo.split('/')[1] : repo;
-        h += `<div class="nous-config-pill${active}" data-repo="${escapeHtml(repo)}" onclick="toggleNousRepo(this)">`;
+        h += `<div class="nous-config-pill${active}" data-repo="${escapeHtml(repo)}" data-action="toggleNousRepo" data-arg-types="t">`;
         h += `<span>${escapeHtml(shortName)}</span>`;
         h += '</div>';
       }
@@ -9258,7 +9258,7 @@ function burnAreaChart() {
           h += '<div class="nous-config-principle-row">';
           h += `<span class="conf">${conf}%</span>`;
           h += `<span class="text">${escapeHtml(p.text || p.id)}</span>`;
-          h += `<button class="del-btn" onclick="deleteNousPrinciple('${escapeHtml(p.id)}')" title="Invalidate this principle">✕</button>`;
+          h += `<button class="del-btn" data-action="deleteNousPrinciple" data-arg0="${escapeHtml(p.id)}" title="Invalidate this principle">✕</button>`;
           h += '</div>';
         }
         h += '</div>';
@@ -9269,8 +9269,8 @@ function burnAreaChart() {
 
       // Save / Cancel
       h += '<div class="nous-config-btn-bar">';
-      h += '<button class="nous-config-btn nous-config-btn-cancel" onclick="closeNousConfig()" title="Discard all changes and close this dialog">Cancel</button>';
-      h += '<button class="nous-config-btn nous-config-btn-save" onclick="saveNousConfig()" title="Save all configuration changes to the server. Goals, output mode, repo targets, fast-fail bounds, timing, controllable knobs, and principle settings will be updated.">Save Configuration</button>';
+      h += '<button class="nous-config-btn nous-config-btn-cancel" data-action="closeNousConfig" title="Discard all changes and close this dialog">Cancel</button>';
+      h += '<button class="nous-config-btn nous-config-btn-save" data-action="saveNousConfig" title="Save all configuration changes to the server. Goals, output mode, repo targets, fast-fail bounds, timing, controllable knobs, and principle settings will be updated.">Save Configuration</button>';
       h += '</div>';
 
       h += '</div>';
@@ -9508,7 +9508,8 @@ function burnAreaChart() {
       if (list) {
         for (const btn of list.children) {
           const isAll = btn.textContent.includes('All Layers');
-          btn.classList.toggle('active', layer === 'all' ? isAll : btn.getAttribute('onclick')?.includes("'" + layer + "'"));
+          const btnLayer = btn.dataset.action === 'gh14' ? 'vault:' + btn.dataset.arg0 : btn.dataset.arg0;
+          btn.classList.toggle('active', layer === 'all' ? isAll : btnLayer === layer);
         }
       }
       kbSearch();
@@ -9933,10 +9934,10 @@ function burnAreaChart() {
       const zoomControls = document.createElement('div');
       zoomControls.style.cssText = 'position:absolute;top:10px;right:10px;display:flex;flex-direction:column;gap:4px;z-index:20';
       zoomControls.innerHTML = `
-        <button onclick="this.parentElement._zoomIn()" style="${controlBtnStyle};font-size:16px" title="Zoom in">+</button>
-        <button onclick="this.parentElement._zoomReset()" style="${controlBtnStyle};font-size:10px" title="Reset zoom">&#x27F2;</button>
-        <button onclick="this.parentElement._zoomOut()" style="${controlBtnStyle};font-size:16px" title="Zoom out">&minus;</button>
-        <button onclick="this.parentElement._toggleFullscreen()" style="${controlBtnStyle};font-size:13px" title="Toggle fullscreen">&#x26F6;</button>
+        <button data-action="gh6" style="${controlBtnStyle};font-size:16px" title="Zoom in">+</button>
+        <button data-action="gh7" style="${controlBtnStyle};font-size:10px" title="Reset zoom">&#x27F2;</button>
+        <button data-action="gh8" style="${controlBtnStyle};font-size:16px" title="Zoom out">&minus;</button>
+        <button data-action="gh9" style="${controlBtnStyle};font-size:13px" title="Toggle fullscreen">&#x26F6;</button>
       `;
       zoomControls._zoomIn = () => { zoomLevel = Math.min(ZOOM_MAX, zoomLevel * 1.25); draw(); };
       zoomControls._zoomOut = () => { zoomLevel = Math.max(ZOOM_MIN, zoomLevel / 1.25); draw(); };
@@ -10018,14 +10019,14 @@ function burnAreaChart() {
       html += '<div class="kb-setup-grid">';
 
       // Git Repo card
-      html += '<div class="kb-setup-card" onclick="_kbSetupView=\'git\';renderKnowledge()">';
+      html += '<div class="kb-setup-card" data-action="gh10">';
       html += '<div class="kb-setup-card-icon">🔗</div>';
       html += '<div class="kb-setup-card-title">Connect via Git Repo</div>';
       html += '<div class="kb-setup-card-desc">Use the Obsidian Git plugin to push your vault to a repo. Hive clones it and auto-syncs every 60 seconds.</div>';
       html += '</div>';
 
       // Webhook card
-      html += '<div class="kb-setup-card" onclick="_kbSetupView=\'webhook\';renderKnowledge()">';
+      html += '<div class="kb-setup-card" data-action="gh11">';
       html += '<div class="kb-setup-card-icon">⚡</div>';
       html += '<div class="kb-setup-card-title">Connect via Webhook</div>';
       html += '<div class="kb-setup-card-desc">Use the Obsidian Post Webhook plugin to send individual notes instantly. No git required.</div>';
@@ -10035,7 +10036,7 @@ function burnAreaChart() {
 
       // Skip link to go straight to the full KB view
       html += '<div style="text-align:center;margin-top:16px">';
-      html += '<button onclick="_kbSetupView=\'none\';renderKnowledge()" style="background:none;border:none;color:var(--muted);cursor:pointer;font-size:0.72rem;text-decoration:underline">Skip setup and use Knowledge Base without Obsidian</button>';
+      html += '<button data-action="gh12" style="background:none;border:none;color:var(--muted);cursor:pointer;font-size:0.72rem;text-decoration:underline">Skip setup and use Knowledge Base without Obsidian</button>';
       html += '</div>';
 
       panel.innerHTML = html;
@@ -10045,7 +10046,7 @@ function burnAreaChart() {
       const showBack = !(opts && opts.noBack);
       const showForm = !(opts && opts.noForm);
       let html = '<div class="kb-setup-instructions">';
-      if (showBack) html += '<button class="kb-setup-back" onclick="_kbSetupView=\'choose\';renderKnowledge()">&larr; Back to connection methods</button>';
+      if (showBack) html += '<button class="kb-setup-back" data-action="gh13">&larr; Back to connection methods</button>';
       html += '<div style="font-size:0.92rem;font-weight:700;color:var(--fg);margin-bottom:12px">🔗 Connect via Git Repo</div>';
       html += '<ol>';
       html += '<li><strong>Install the "Obsidian Git" community plugin</strong><br>';
@@ -10076,7 +10077,7 @@ function burnAreaChart() {
         html += '<div style="display:grid;grid-template-columns:2fr 1fr auto;gap:8px;align-items:center">';
         html += '<input id="kb-setup-vault-path" type="text" class="kb-search-box" placeholder="/data/vaults/hive-wiki">';
         html += '<input id="kb-setup-vault-name" type="text" class="kb-search-box" placeholder="Display name">';
-        html += '<button class="nous-btn" style="background:var(--accent);color:var(--bg);white-space:nowrap" onclick="kbSetupConnectVault()">Connect</button>';
+        html += '<button class="nous-btn" style="background:var(--accent);color:var(--bg);white-space:nowrap" data-action="kbSetupConnectVault">Connect</button>';
         html += '</div></div>';
       }
 
@@ -10087,7 +10088,7 @@ function burnAreaChart() {
       const showBack = !(opts && opts.noBack);
       const showDone = !(opts && opts.noDone);
       let html = '<div class="kb-setup-instructions">';
-      if (showBack) html += '<button class="kb-setup-back" onclick="_kbSetupView=\'choose\';renderKnowledge()">&larr; Back to connection methods</button>';
+      if (showBack) html += '<button class="kb-setup-back" data-action="gh13">&larr; Back to connection methods</button>';
       html += '<div style="font-size:0.92rem;font-weight:700;color:var(--fg);margin-bottom:12px">⚡ Connect via Webhook</div>';
       html += '<ol>';
       html += '<li><strong>Install the "Post Webhook" community plugin</strong><br>';
@@ -10101,8 +10102,8 @@ function burnAreaChart() {
       html += '<div style="position:relative;margin-top:4px">';
       html += '<pre id="kb-headers-block" style="margin:0;font-size:0.72rem;padding:8px 10px;background:var(--bg);border:1px solid var(--border);border-radius:4px;white-space:pre;overflow-x:auto">{\n  "Authorization": "Bearer <span id="kb-token-display">&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;</span>",\n  "Content-Type": "application/json"\n}</pre>';
       html += '<div style="position:absolute;top:4px;right:6px;display:flex;gap:3px">';
-      html += '<button onclick="kbToggleToken()" id="kb-token-toggle" style="font-size:0.6rem;padding:2px 6px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--muted);cursor:pointer">show</button>';
-      html += '<button onclick="kbCopyHeaders()" id="kb-headers-copy" style="font-size:0.6rem;padding:2px 6px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--muted);cursor:pointer">copy</button>';
+      html += '<button data-action="kbToggleToken" id="kb-token-toggle" style="font-size:0.6rem;padding:2px 6px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--muted);cursor:pointer">show</button>';
+      html += '<button data-action="kbCopyHeaders" id="kb-headers-copy" style="font-size:0.6rem;padding:2px 6px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--muted);cursor:pointer">copy</button>';
       html += '</div></div>';
       html += '</div></li>';
       html += '<li><strong>Use it:</strong><br>';
@@ -10124,7 +10125,7 @@ function burnAreaChart() {
       // Enable knowledge button for webhook (webhook works without vault connection)
       if (showDone) {
         html += '<div style="border-top:1px solid var(--border);padding-top:14px;margin-top:16px;text-align:center">';
-        html += '<button onclick="_kbSetupView=\'none\';renderKnowledge()" class="nous-btn" style="background:var(--accent);color:var(--bg);padding:8px 24px;font-size:0.82rem">Done -- go to Knowledge Base</button>';
+        html += '<button data-action="gh12" class="nous-btn" style="background:var(--accent);color:var(--bg);padding:8px 24px;font-size:0.82rem">Done -- go to Knowledge Base</button>';
         html += '</div>';
       }
 
@@ -10197,7 +10198,7 @@ function burnAreaChart() {
 
       if (!_kbCache || !_kbCache.enabled) {
         if (badge) { badge.textContent = 'disabled'; badge.style.background = 'var(--muted)'; badge.style.color = 'white'; }
-        panel.innerHTML = '<div class="kb-disabled"><div style="font-size:2rem;margin-bottom:8px">📚</div><div>Knowledge system not enabled</div><div style="font-size:0.72rem;margin-top:4px;color:var(--muted);margin-bottom:12px">Enable the knowledge base to store and retrieve facts across agents.</div><button onclick="toggleKnowledge(true)" style="padding:8px 20px;background:var(--blue);color:var(--bg);border:none;border-radius:6px;cursor:pointer;font-size:0.82rem;font-weight:600" title="Enable the knowledge base system. Agents will be able to store and retrieve facts (patterns, gotchas, regressions, decisions) across sessions and layers (personal, project, org, community).">Enable Knowledge</button></div>';
+        panel.innerHTML = '<div class="kb-disabled"><div style="font-size:2rem;margin-bottom:8px">📚</div><div>Knowledge system not enabled</div><div style="font-size:0.72rem;margin-top:4px;color:var(--muted);margin-bottom:12px">Enable the knowledge base to store and retrieve facts across agents.</div><button data-action="toggleKnowledge" data-arg0="true" data-arg-types="j" style="padding:8px 20px;background:var(--blue);color:var(--bg);border:none;border-radius:6px;cursor:pointer;font-size:0.82rem;font-weight:600" title="Enable the knowledge base system. Agents will be able to store and retrieve facts (patterns, gotchas, regressions, decisions) across sessions and layers (personal, project, org, community).">Enable Knowledge</button></div>';
         return;
       }
 
@@ -10221,11 +10222,11 @@ function burnAreaChart() {
       let html = '<div style="display:flex;justify-content:flex-end;gap:8px;margin-bottom:8px">';
       if (synthEnabled) {
         html += `<span style="font-size:0.72rem;color:var(--green);display:flex;align-items:center;gap:4px" title="Bead synthesizer is ${synthRunning ? 'running' : 'enabled but not running'}. Schedule: ${escapeHtml((_beadSynthStatus||{}).schedule||'hourly')}"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:${synthRunning ? 'var(--green)' : 'var(--yellow)'}"></span> Synth ${synthRunning ? 'active' : 'idle'}</span>`;
-        html += '<button onclick="toggleBeadSynth(false)" style="padding:4px 12px;background:none;border:1px solid var(--yellow);color:var(--yellow);border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the bead synthesizer. Completed beads will no longer be automatically converted to wiki facts.">Pause Synth</button>';
+        html += '<button data-action="toggleBeadSynth" data-arg0="false" data-arg-types="j" style="padding:4px 12px;background:none;border:1px solid var(--yellow);color:var(--yellow);border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the bead synthesizer. Completed beads will no longer be automatically converted to wiki facts.">Pause Synth</button>';
       } else {
-        html += '<button onclick="toggleBeadSynth(true)" style="padding:4px 12px;background:var(--blue);color:var(--bg);border:none;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Enable the bead synthesizer. Completed beads will be automatically scanned and converted to wiki facts on an hourly schedule.">Enable Synth</button>';
+        html += '<button data-action="toggleBeadSynth" data-arg0="true" data-arg-types="j" style="padding:4px 12px;background:var(--blue);color:var(--bg);border:none;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Enable the bead synthesizer. Completed beads will be automatically scanned and converted to wiki facts on an hourly schedule.">Enable Synth</button>';
       }
-      html += '<button onclick="toggleKnowledge(false)" style="padding:4px 12px;background:none;border:1px solid var(--red);color:var(--red);border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the knowledge base. Agents will no longer inject facts into prompts. Stored facts are preserved for when re-enabled.">Disable</button>';
+      html += '<button data-action="toggleKnowledge" data-arg0="false" data-arg-types="j" style="padding:4px 12px;background:none;border:1px solid var(--red);color:var(--red);border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the knowledge base. Agents will no longer inject facts into prompts. Stored facts are preserved for when re-enabled.">Disable</button>';
       html += '</div>';
 
       // Stats row
@@ -10242,12 +10243,12 @@ function burnAreaChart() {
 
       // Action buttons
       html += '<div style="display:flex;gap:8px;margin-bottom:14px">';
-      html += '<button class="nous-btn btn-blue" onclick="kbOpenCreate()" title="Create a new knowledge fact manually. Choose a layer (personal, project, org, community), type, and enter the fact content.">+ New Fact</button>';
-      html += '<button class="nous-btn btn-surface" onclick="kbOpenSubscriptions()" title="Manage knowledge sources: git repos, wiki subscriptions, document imports, and fact imports.">🔗 Knowledge Sources</button>';
-      html += '<button class="nous-btn btn-surface" onclick="kbOpenVaults()" title="Manage knowledge vaults — collections of facts organized by topic or project. Vaults can be shared across hive instances.">📂 Vaults</button>';
-      html += '<button class="nous-btn btn-surface" onclick="kbOpenHowItWorks()">📖 How it works</button>';
-      html += '<button class="nous-btn btn-surface" onclick="kbOpenObsidianSetup()" title="View step-by-step instructions for connecting Obsidian via Git sync or webhook.">🔮 Obsidian Setup</button>';
-      html += `<button class="nous-btn" style="background:${_kbGraphView ? 'var(--cyan)' : 'var(--surface)'};color:${_kbGraphView ? 'var(--bg)' : 'var(--fg)'};border:1px solid ${_kbGraphView ? 'var(--cyan)' : 'var(--border)'}" onclick="kbToggleGraph()" title="Toggle knowledge graph visualization showing relationships between facts.">🕸️ Graph</button>`;
+      html += '<button class="nous-btn btn-blue" data-action="kbOpenCreate" title="Create a new knowledge fact manually. Choose a layer (personal, project, org, community), type, and enter the fact content.">+ New Fact</button>';
+      html += '<button class="nous-btn btn-surface" data-action="kbOpenSubscriptions" title="Manage knowledge sources: git repos, wiki subscriptions, document imports, and fact imports.">🔗 Knowledge Sources</button>';
+      html += '<button class="nous-btn btn-surface" data-action="kbOpenVaults" title="Manage knowledge vaults — collections of facts organized by topic or project. Vaults can be shared across hive instances.">📂 Vaults</button>';
+      html += '<button class="nous-btn btn-surface" data-action="kbOpenHowItWorks">📖 How it works</button>';
+      html += '<button class="nous-btn btn-surface" data-action="kbOpenObsidianSetup" title="View step-by-step instructions for connecting Obsidian via Git sync or webhook.">🔮 Obsidian Setup</button>';
+      html += `<button class="nous-btn" style="background:${_kbGraphView ? 'var(--cyan)' : 'var(--surface)'};color:${_kbGraphView ? 'var(--bg)' : 'var(--fg)'};border:1px solid ${_kbGraphView ? 'var(--cyan)' : 'var(--border)'}" data-action="kbToggleGraph" title="Toggle knowledge graph visualization showing relationships between facts.">🕸️ Graph</button>`;
       html += '</div>';
 
       // Main layout: sidebar + content
@@ -10263,7 +10264,7 @@ function burnAreaChart() {
       html += '<div class="section-label" style="margin:0">Knowledge Sources</div>';
       html += '<div class="kb-layer-list" id="kb-layer-btns">';
       // Aggregate row stays on top as the filter reset (kbSelectLayer keys on the 'All Layers' text)
-      html += `<button class="kb-layer-btn${_kbSelectedLayer === 'all' ? ' active' : ''}" onclick="kbSelectLayer('all')"><span class="kb-layer-label">📋 All Layers</span><span class="kb-layer-count">${totalPages}</span></button>`;
+      html += `<button class="kb-layer-btn${_kbSelectedLayer === 'all' ? ' active' : ''}" data-action="kbSelectLayer" data-arg0="all"><span class="kb-layer-label">📋 All Layers</span><span class="kb-layer-count">${totalPages}</span></button>`;
       for (const l of layers) {
         const isGitSource = l.type && l.type.startsWith('git_source:');
         const icon = KB_LAYER_ICONS[l.type] || (isGitSource ? '📄' : '📂');
@@ -10273,10 +10274,10 @@ function burnAreaChart() {
         const dotColor = l.healthy ? 'var(--green)' : 'var(--red)';
         const healthTip = `${escapeHtml(label)}: ${l.healthy ? 'healthy' : 'unreachable'}`;
         const repoUrl = isGitSource && l.url ? (l.subpath ? l.url + '/tree/' + 'main/' + l.subpath : l.url) : '';
-        html += `<button class="kb-layer-btn${active}" onclick="kbSelectLayer('${escapeHtml(l.type)}')" title="${healthTip}">`;
+        html += `<button class="kb-layer-btn${active}" data-action="kbSelectLayer" data-arg0="${escapeHtml(l.type)}" title="${healthTip}">`;
         html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:${dotColor}" title="${healthTip}"></span>${icon} ${escapeHtml(label)}</span>`;
         if (isGitSource && repoUrl) {
-          html += `<a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="color:var(--accent);text-decoration:none;font-size:0.82rem;flex-shrink:0" title="Open source repo in new tab">↗</a>`;
+          html += `<a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener" data-action="gh3" style="color:var(--accent);text-decoration:none;font-size:0.82rem;flex-shrink:0" title="Open source repo in new tab">↗</a>`;
         }
         html += `<span class="kb-src-type vault">vault</span>`;
         html += `<span class="kb-layer-count">${count}</span>`;
@@ -10287,7 +10288,7 @@ function burnAreaChart() {
       const layerTypes = new Set(layers.map(l => l.type));
       for (const v of connectedVaults.filter(v => !layerTypes.has(v.name))) {
         const vTip = `${escapeHtml(v.name)}: connected — ${escapeHtml(v.root_dir)}`;
-        html += `<button class="kb-layer-btn${_kbSelectedLayer === 'vault:'+v.name ? ' active' : ''}" onclick="_kbSelectedLayer='vault:${escapeHtml(v.name)}';kbSearchVault('${escapeHtml(v.name)}')" title="${vTip}">`;
+        html += `<button class="kb-layer-btn${_kbSelectedLayer === 'vault:'+v.name ? ' active' : ''}" data-action="gh14" data-arg0="${escapeHtml(v.name)}" title="${vTip}">`;
         html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:var(--green)" title="${vTip}"></span>📂 ${escapeHtml(v.name)}</span>`;
         html += `<span class="kb-src-type vault">vault</span>`;
         html += `<span class="kb-layer-count">${v.pages}</span>`;
@@ -10298,7 +10299,7 @@ function burnAreaChart() {
         const dIcon = DOC_CONTENT_ICONS[d.content_type] || '📄';
         const dFacts = d.fact_count || 0;
         const dTip = `${escapeHtml(d.title || d.slug)}: imported — ${escapeHtml(d.source_url || d.source_file || d.slug)}`;
-        html += `<button class="kb-layer-btn${_kbSelectedLayer === 'doc:'+d.slug ? ' active' : ''}" onclick="kbSelectLayer('doc:${escapeHtml(d.slug)}')" title="${dTip}">`;
+        html += `<button class="kb-layer-btn${_kbSelectedLayer === 'doc:'+d.slug ? ' active' : ''}" data-action="kbSelectLayer" data-arg0="doc:${escapeHtml(d.slug)}" title="${dTip}">`;
         html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:var(--green)" title="${dTip}"></span>${dIcon} ${escapeHtml(d.title || d.slug)}</span>`;
         html += `<span class="kb-src-type doc">doc</span>`;
         html += `<span class="kb-layer-count">${dFacts}</span>`;
@@ -10307,14 +10308,14 @@ function burnAreaChart() {
       html += '</div>';
 
       // Search
-      html += `<input type="text" class="kb-search-box" placeholder="Search facts..." value="${escapeHtml(_kbSearchQuery)}" onkeyup="if(event.key==='Enter'){_kbSearchQuery=this.value;kbSearch()}" onchange="_kbSearchQuery=this.value" title="Search across all knowledge layers by keyword. Press Enter to search. Results are filtered by the selected layer and type.">`;
+      html += `<input type="text" class="kb-search-box" placeholder="Search facts..." value="${escapeHtml(_kbSearchQuery)}" data-keyup-action="gh15" data-keys="Enter" data-change-action="gh16" title="Search across all knowledge layers by keyword. Press Enter to search. Results are filtered by the selected layer and type.">`;
 
       // Type filter pills
       html += '<div class="kb-filter-row" id="kb-type-pills">';
-      html += `<span class="kb-filter-pill${_kbSelectedType === '' ? ' active' : ''}" onclick="kbSelectType('')">All</span>`;
+      html += `<span class="kb-filter-pill${_kbSelectedType === '' ? ' active' : ''}" data-action="kbSelectType" data-arg0="">All</span>`;
       for (const t of KB_FACT_TYPES) {
         const active = _kbSelectedType === t ? ' active' : '';
-        html += `<span class="kb-filter-pill${active}" onclick="kbSelectType('${escapeHtml(t)}')">${escapeHtml(t)}</span>`;
+        html += `<span class="kb-filter-pill${active}" data-action="kbSelectType" data-arg0="${escapeHtml(t)}">${escapeHtml(t)}</span>`;
       }
       html += '</div>';
 
@@ -10378,7 +10379,7 @@ function burnAreaChart() {
         const typeClass = 'kb-type-' + (f.type || 'pattern');
         const layerClass = 'kb-layer-' + (f.layer || 'project');
         const selected = _kbSelectedFact && _kbSelectedFact.slug === f.slug ? ' selected' : '';
-        html += `<div class="kb-fact-item${selected}" onclick="kbReadFact('${escapeHtml(f.slug || '')}')">`;
+        html += `<div class="kb-fact-item${selected}" data-action="gh17" data-arg0="${escapeHtml(f.slug || '')}">`;
         html += '<div class="kb-fact-meta">';
         html += `<span class="kb-fact-conf" style="color:${confColor(conf)}">${confPct}%</span>`;
         html += `<div class="kb-fact-conf-bar"><div class="kb-fact-conf-fill" style="width:${confPct}%;background:${confColor(conf)}"></div></div>`;
@@ -10420,13 +10421,13 @@ function burnAreaChart() {
 
       // Action buttons
       html += '<div style="display:flex;gap:6px;margin-top:12px;flex-wrap:wrap">';
-      html += `<button class="nous-btn" style="background:var(--blue);color:var(--bg);font-size:0.72rem;padding:5px 10px" onclick="kbOpenEdit()">✏️ Edit</button>`;
+      html += `<button class="nous-btn" style="background:var(--blue);color:var(--bg);font-size:0.72rem;padding:5px 10px" data-action="kbOpenEdit">✏️ Edit</button>`;
       const promoteTargets = { personal: 'project', project: 'org', org: 'community' };
       const promoteTo = promoteTargets[f.layer];
       if (promoteTo) {
-        html += `<button class="nous-btn" style="background:#7c3aed;color:white;font-size:0.72rem;padding:5px 10px" onclick="kbPromote('${escapeHtml(f.slug)}','${escapeHtml(f.layer)}','${promoteTo}')">⬆ Promote to ${promoteTo}</button>`;
+        html += `<button class="nous-btn" style="background:#7c3aed;color:white;font-size:0.72rem;padding:5px 10px" data-action="kbPromote" data-arg0="${escapeHtml(f.slug)}" data-arg1="${escapeHtml(f.layer)}" data-arg2="${promoteTo}">⬆ Promote to ${promoteTo}</button>`;
       }
-      html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.72rem;padding:5px 10px" onclick="kbDelete('${escapeHtml(f.slug)}','${escapeHtml(f.layer)}')">🗑 Delete</button>`;
+      html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.72rem;padding:5px 10px" data-action="kbDelete" data-arg0="${escapeHtml(f.slug)}" data-arg1="${escapeHtml(f.layer)}">🗑 Delete</button>`;
       html += '</div>';
 
       html += '</div>';
@@ -10459,7 +10460,7 @@ function burnAreaChart() {
       overlay.innerHTML = `<div class="nous-config-dialog" style="width:${dialogWidth}">
         <h2 style="font-size:1rem;margin:0 0 0 0;padding:24px 24px 16px;display:flex;align-items:center;justify-content:space-between;flex-shrink:0">
           ${title}
-          <button onclick="kbCloseModal()" style="background:none;border:none;font-size:1.2rem;cursor:pointer;color:var(--muted)">✕</button>
+          <button data-action="kbCloseModal" style="background:none;border:none;font-size:1.2rem;cursor:pointer;color:var(--muted)">✕</button>
         </h2>
         <div class="nous-config-body">${bodyHtml}</div>
       </div>`;
@@ -10507,8 +10508,8 @@ function burnAreaChart() {
             <input id="kb-create-tags" type="text" class="kb-search-box" style="margin-top:4px" placeholder="react, testing, hooks">
           </label>
           <div class="row-end" style="margin-top:8px">
-            <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn btn-blue" onclick="kbSubmitCreate()">Create Fact</button>
+            <button class="nous-btn nous-config-btn-cancel" data-action="kbCloseModal">Cancel</button>
+            <button class="nous-btn btn-blue" data-action="kbSubmitCreate">Create Fact</button>
           </div>
         </div>`;
       kbShowModal('New Fact', html);
@@ -10576,8 +10577,8 @@ function burnAreaChart() {
           </label>
           <div class="muted-xs">Layer: ${escapeHtml(f.layer || '')} · Slug: ${escapeHtml(f.slug || '')}</div>
           <div class="row-end" style="margin-top:8px">
-            <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn btn-blue" onclick="kbSubmitEdit()">Save Changes</button>
+            <button class="nous-btn nous-config-btn-cancel" data-action="kbCloseModal">Cancel</button>
+            <button class="nous-btn btn-blue" data-action="kbSubmitEdit">Save Changes</button>
           </div>
         </div>`;
       kbShowModal('Edit Fact', html);
@@ -10665,12 +10666,12 @@ function burnAreaChart() {
           <div style="display:flex;align-items:center;gap:10px;margin-top:4px">
             <label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px">
               <span>or load from file:</span>
-              <input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" onchange="kbLoadFile(this)">
+              <input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" data-change-action="kbLoadFile" data-arg-types="t">
             </label>
           </div>
           <div class="row-end" style="margin-top:8px">
-            <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn btn-blue" onclick="kbSubmitImport()">Import</button>
+            <button class="nous-btn nous-config-btn-cancel" data-action="kbCloseModal">Cancel</button>
+            <button class="nous-btn btn-blue" data-action="kbSubmitImport">Import</button>
           </div>
         </div>`;
       kbShowModal('📥 Import Facts', html, { width: 'min(700px, 80vw)', maxHeight: '85vh' });
@@ -10850,7 +10851,7 @@ function burnAreaChart() {
             html += ` ↗</a>`;
             html += ` &middot; ${escapeHtml(gs.layer)} &middot; ${gs.pages} pages &middot; ${statusText}</div>`;
             html += '</div>';
-            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" onclick="kbRemoveGitSource('${escapeHtml(gs.url)}','${escapeHtml(gs.subpath || '')}')">Remove</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" data-action="gh18" data-arg0="${escapeHtml(gs.url)}" data-arg1="${escapeHtml(gs.subpath || '')}">Remove</button>`;
             html += '</div>';
           }
         } else {
@@ -10870,7 +10871,7 @@ function burnAreaChart() {
           <option value="personal">Personal</option>
         </select>`;
         html += '<div class="row-end">';
-        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbAddGitSource()">Clone &amp; Index</button>';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" data-action="kbAddGitSource">Clone &amp; Index</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -10887,7 +10888,7 @@ function burnAreaChart() {
             html += '<div class="card-inset row-between" style="margin-bottom:6px">';
             html += `<div><div style="font-size:0.82rem;font-weight:600;color:var(--fg)">${escapeHtml(s.name || s.url)}</div>`;
             html += `<div class="muted-xs">${escapeHtml(s.url)} &middot; ${escapeHtml(s.layer || 'org')}</div></div>`;
-            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" onclick="kbRemoveSub('${escapeHtml(s.url)}')">Remove</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" data-action="kbRemoveSub" data-arg0="${escapeHtml(s.url)}">Remove</button>`;
             html += '</div>';
           }
         } else {
@@ -10905,7 +10906,7 @@ function burnAreaChart() {
           <option value="personal">Personal</option>
         </select>`;
         html += '<div class="row-end">';
-        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbAddSub()">Add</button>';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" data-action="kbAddSub">Add</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -10933,8 +10934,8 @@ function burnAreaChart() {
             html += `<div style="font-size:0.7rem;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(dSource)} &middot; ${dFacts} facts</div>`;
             html += '</div>';
             html += '<div style="display:flex;gap:4px;flex-shrink:0;margin-left:8px">';
-            html += `<button class="nous-btn" style="font-size:0.7rem;padding:4px 8px;background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbReimportDoc('${escapeHtml(d.slug)}')" title="Re-fetch and re-extract facts">🔄</button>`;
-            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px" onclick="kbDeleteDoc('${escapeHtml(d.slug)}')">Remove</button>`;
+            html += `<button class="nous-btn" style="font-size:0.7rem;padding:4px 8px;background:var(--surface);color:var(--fg);border:1px solid var(--border)" data-action="kbReimportDoc" data-arg0="${escapeHtml(d.slug)}" title="Re-fetch and re-extract facts">🔄</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px" data-action="kbDeleteDoc" data-arg0="${escapeHtml(d.slug)}">Remove</button>`;
             html += '</div></div>';
           }
         } else {
@@ -10952,7 +10953,7 @@ function burnAreaChart() {
           <option value="personal">Personal</option>
         </select>`;
         html += '<div class="row-end">';
-        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbImportDocFromModal()">Import</button>';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" data-action="kbImportDocFromModal">Import</button>';
         html += '</div></div></details>';
 
         html += '<details open style="margin-top:10px"><summary class="summary-label">📚 Import from Context7</summary>';
@@ -10960,7 +10961,7 @@ function burnAreaChart() {
         html += '<div style="font-size:0.72rem;color:var(--muted)">Search Context7 for library documentation (e.g. "vllm", "next.js", "kubernetes").</div>';
         html += '<div style="display:flex;gap:8px">';
         html += '<input id="kb-ctx7-query" type="text" class="kb-search-box" placeholder="Search libraries..." style="flex:1">';
-        html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);padding:6px 14px;font-size:0.78rem" onclick="kbCtx7Search()">Search</button>';
+        html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);padding:6px 14px;font-size:0.78rem" data-action="kbCtx7Search">Search</button>';
         html += '</div>';
         html += '<div id="kb-ctx7-results" style="max-height:200px;overflow-y:auto"></div>';
         html += '</div></details>';
@@ -10991,12 +10992,12 @@ function burnAreaChart() {
         html += '<div class="stack" style="margin-top:8px">';
         html += `<div style="display:flex;gap:8px;align-items:center">`;
         html += `<select id="kb-import-layer" class="field-input" style="flex:1">${layerOpts2}</select>`;
-        html += `<button class="nous-btn btn-blue" style="padding:8px 20px;white-space:nowrap" onclick="kbNewChannel()" title="Create a new knowledge channel to import into">+ New channel</button>`;
-        html += `<button class="nous-btn btn-blue" style="padding:8px 20px;white-space:nowrap" onclick="kbRemoveChannel()" title="Remove the selected channel (stops it feeding agents; files remain on disk)">Remove</button>`;
+        html += `<button class="nous-btn btn-blue" style="padding:8px 20px;white-space:nowrap" data-action="kbNewChannel" title="Create a new knowledge channel to import into">+ New channel</button>`;
+        html += `<button class="nous-btn btn-blue" style="padding:8px 20px;white-space:nowrap" data-action="kbRemoveChannel" title="Remove the selected channel (stops it feeding agents; files remain on disk)">Remove</button>`;
         html += `</div>`;
         html += `<div id="kb-newchannel-row" style="display:none;gap:8px;align-items:center">`;
-        html += `<input id="kb-newchannel-name" type="text" class="kb-search-box" placeholder="New channel name (e.g. Runbooks)" style="flex:1" onkeydown="if(event.key==='Enter'){event.preventDefault();kbCreateChannel();}">`;
-        html += `<button class="nous-btn btn-blue" style="padding:8px 20px;white-space:nowrap" onclick="kbCreateChannel()">Create</button>`;
+        html += `<input id="kb-newchannel-name" type="text" class="kb-search-box" placeholder="New channel name (e.g. Runbooks)" style="flex:1" data-keydown-action="kbCreateChannel" data-prevent="1" data-keys="Enter">`;
+        html += `<button class="nous-btn btn-blue" style="padding:8px 20px;white-space:nowrap" data-action="kbCreateChannel">Create</button>`;
         html += `</div>`;
         html += `<select id="kb-import-format" class="field-input">
           <option value="markdown" selected>Markdown</option>
@@ -11004,8 +11005,8 @@ function burnAreaChart() {
         </select>`;
         html += '<textarea id="kb-import-content" rows="8" style="width:100%;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:var(--font-mono);resize:vertical;min-height:120px;box-sizing:border-box" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(\',\')..."></textarea>';
         html += '<div style="display:flex;align-items:center;justify-content:space-between">';
-        html += '<label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px"><span>or load from file:</span><input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" onchange="kbLoadFile(this)"></label>';
-        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbSubmitImport()">Import</button>';
+        html += '<label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px"><span>or load from file:</span><input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" data-change-action="kbLoadFile" data-arg-types="t"></label>';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" data-action="kbSubmitImport">Import</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -11157,7 +11158,7 @@ function burnAreaChart() {
           html += '</div>';
           if (desc) html += '<div style="color:var(--muted);font-size:0.68rem;margin-top:2px;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical">' + escapeHtml(desc) + '</div>';
           html += '</div>';
-          html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);font-size:0.68rem;padding:4px 10px;margin-left:8px;white-space:nowrap" onclick="kbImportCtx7(\'' + escapeHtml(id) + '\',\'' + escapeHtml(name) + '\')">Import</button>';
+          html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);font-size:0.68rem;padding:4px 10px;margin-left:8px;white-space:nowrap" data-action="kbImportCtx7" data-arg0="' + escapeHtml(id) + '" data-arg1="' + escapeHtml(name) + '">Import</button>';
           html += '</div>';
         }
         el.innerHTML = html;
@@ -11297,8 +11298,8 @@ function burnAreaChart() {
             html += `<div><div style="font-size:0.82rem;font-weight:600;color:var(--fg)">📂 ${escapeHtml(v.name)}</div>`;
             html += `<div class="muted-xs">${escapeHtml(v.root_dir)} · ${v.pages} pages</div></div>`;
             html += `<div style="display:flex;gap:4px">`;
-            html += `<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);font-size:0.7rem;padding:4px 8px" onclick="kbReindexVault('${escapeHtml(v.root_dir)}')">↻ Reindex</button>`;
-            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px" onclick="kbDisconnectVault('${escapeHtml(v.root_dir)}')">Disconnect</button>`;
+            html += `<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);font-size:0.7rem;padding:4px 8px" data-action="kbReindexVault" data-arg0="${escapeHtml(v.root_dir)}">↻ Reindex</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px" data-action="kbDisconnectVault" data-arg0="${escapeHtml(v.root_dir)}">Disconnect</button>`;
             html += '</div></div>';
             if (tagList) html += `<div style="margin-top:4px">${tagList}</div>`;
             html += `<div style="font-size:0.65rem;color:var(--muted);margin-top:4px">Last indexed: ${v.last_indexed ? new Date(v.last_indexed).toLocaleTimeString() : 'never'}</div>`;
@@ -11317,7 +11318,7 @@ function burnAreaChart() {
         html += '<input id="kb-vault-name" type="text" class="kb-search-box" placeholder="Display name">';
         html += '</div>';
         html += '<div class="row-end">';
-        html += '<button class="nous-btn btn-blue" onclick="kbConnectVault()">Connect</button>';
+        html += '<button class="nous-btn btn-blue" data-action="kbConnectVault">Connect</button>';
         html += '</div></div>';
 
         el.innerHTML = html;
@@ -11548,7 +11549,7 @@ function burnAreaChart() {
     function avatarImg(src, px, extraStyle) {
       return `<img src="${esc(src)}" alt="" width="${px}" height="${px}" ` +
         `style="width:${px}px;height:${px}px;border-radius:50%;vertical-align:middle;` +
-        `${extraStyle || ''}" onerror="this.style.display='none'">`;
+        `${extraStyle || ''}" data-error-action="gh19">`;
     }
 
     /* The common case: a linked, round avatar for a github.com login. avatarURL
@@ -11592,7 +11593,7 @@ function burnAreaChart() {
         const bg = active ? 'var(--line)' : 'transparent';
         const fg = active ? 'var(--text)' : 'var(--muted)';
         const border = 'var(--line)';
-        return `<button onclick="toggleContributorFilter('${key}')" style="display:inline-flex;align-items:center;gap:4px;padding:4px 12px;border-radius:9999px;font-size:0.72rem;font-weight:600;cursor:pointer;border:1px solid ${border};background:${bg};color:${fg};transition:all 0.15s">${esc(label)} <span style="opacity:0.8">${count}</span></button>`;
+        return `<button data-action="toggleContributorFilter" data-arg0="${key}" style="display:inline-flex;align-items:center;gap:4px;padding:4px 12px;border-radius:9999px;font-size:0.72rem;font-weight:600;cursor:pointer;border:1px solid ${border};background:${bg};color:${fg};transition:all 0.15s">${esc(label)} <span style="opacity:0.8">${count}</span></button>`;
       }
 
       let html = pill(CONTRIBUTOR_FILTER_ALL, 'All', totalCount);
@@ -11661,7 +11662,7 @@ function burnAreaChart() {
             '</div>' +
             '<div style="display:flex;gap:10px;justify-content:flex-start;flex-wrap:wrap">' +
               '<a href="/contribute" target="_blank" style="font-size:var(--fs-sm);padding:7px 16px;background:var(--amber);color:var(--bg);border-radius:var(--radius);text-decoration:none;font-weight:600">Open /contribute page \u2192</a>' +
-              '<button onclick="navigator.clipboard.writeText(\'' + contributeUrl + '\');showToast(\'Contribute link copied \u2014 share it with your community!\', \'success\')" style="font-size:var(--fs-sm);padding:7px 16px;background:transparent;color:var(--muted);border:1px solid var(--line-strong);border-radius:var(--radius);cursor:pointer;font-weight:600">\ud83d\udccb Copy invite link</button>' +
+              '<button data-action="ghCopyInviteLink" data-arg0="' + esc(contributeUrl) + '" style="font-size:var(--fs-sm);padding:7px 16px;background:transparent;color:var(--muted);border:1px solid var(--line-strong);border-radius:var(--radius);cursor:pointer;font-weight:600">\ud83d\udccb Copy invite link</button>' +
             '</div>' +
             '<div style="color:var(--muted);font-size:var(--fs-sm);margin-top:10px">Tip: post the link in your project README, Discord, or a pinned GitHub issue to recruit contributors.</div>' +
           '</div>');
@@ -11709,8 +11710,8 @@ function burnAreaChart() {
             ${(c.active_tasks && c.active_tasks.length > 0) ? '<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Current tasks</div>' + c.active_tasks.map(t => `<div style="font-size:0.75rem;color:var(--muted);margin-bottom:4px;padding:6px 10px;background:rgba(56,139,253,0.08);border:1px solid rgba(56,139,253,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:var(--blue)">${esc(t.kind)}</span> <a href="https://github.com/${esc(t.repo)}/issues/${t.number}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:underline;font-weight:600">${esc(t.repo)}#${t.number} ↗</a> — ${esc(t.title)}</div>`).join('') : (c.current_task ? `<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Current task</div><div style="font-size:0.75rem;color:var(--muted);margin-bottom:10px;padding:8px 10px;background:rgba(56,139,253,0.08);border:1px solid rgba(56,139,253,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:var(--blue)">${esc(c.current_task.kind)}</span> <a href="https://github.com/${esc(c.current_task.repo)}/issues/${c.current_task.number}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:underline;font-weight:600">${esc(c.current_task.repo)}#${c.current_task.number} ↗</a> — ${esc(c.current_task.title)}</div>` : (c.last_completed_task ? `<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Last completed</div><div style="font-size:0.75rem;color:var(--muted);margin-bottom:10px;padding:6px 10px;background:rgba(34,197,94,0.08);border:1px solid rgba(34,197,94,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:var(--green)">${esc(c.last_completed_task.kind)}</span> <a href="https://github.com/${esc(c.last_completed_task.repo)}/issues/${c.last_completed_task.number}" target="_blank" rel="noopener" style="color:var(--green);text-decoration:underline">${esc(c.last_completed_task.repo)}#${c.last_completed_task.number} ↗</a> — ${esc(c.last_completed_task.title)}</div>` : (c.active ? '<div style="font-size:0.75rem;color:var(--green);margin-bottom:10px">Idle — waiting for task</div>' : '')))}
             ${c.sessions > 1 ? `<div style="font-size:0.7rem;color:var(--muted);margin-bottom:6px">${c.sessions} active sessions</div>` : ''}
             <div style="display:flex;gap:8px;align-items:center;font-size:0.75rem">
-              <select onchange="changeContributorTier('${esc(c.contributor_id)}', this.value)" style="background:var(--card-bg);color:var(--fg);border:1px solid var(--border);border-radius:4px;padding:2px 6px;font-size:0.75rem">${tierOptions}</select>
-              <button onclick="revokeContributor('${esc(c.contributor_id)}')" style="background:transparent;color:var(--muted);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.75rem">Revoke</button>
+              <select data-change-action="changeContributorTier" data-arg0="${esc(c.contributor_id)}" data-arg-types="s,v" style="background:var(--card-bg);color:var(--fg);border:1px solid var(--border);border-radius:4px;padding:2px 6px;font-size:0.75rem">${tierOptions}</select>
+              <button data-action="revokeContributor" data-arg0="${esc(c.contributor_id)}" style="background:transparent;color:var(--muted);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.75rem">Revoke</button>
             </div>
           </div>`;
         }).join('');
@@ -11732,8 +11733,8 @@ function burnAreaChart() {
             <td style="padding:6px 12px"><a href="${ghLink}" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none">@${esc(c.github_username)}</a></td>
             <td style="padding:6px 12px;color:var(--muted);font-size:0.75rem">${esc(revokedDate)}</td>
             <td style="padding:6px 12px;text-align:right">
-              <button onclick="changeContributorTier('${esc(c.contributor_id)}', 'newcomer')" style="background:transparent;color:var(--blue);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem;margin-right:4px">Unrevoke</button>
-              <button onclick="deleteContributor('${esc(c.contributor_id)}')" style="background:transparent;color:var(--red);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem">Remove</button>
+              <button data-action="changeContributorTier" data-arg0="${esc(c.contributor_id)}" data-arg1="newcomer" style="background:transparent;color:var(--blue);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem;margin-right:4px">Unrevoke</button>
+              <button data-action="deleteContributor" data-arg0="${esc(c.contributor_id)}" style="background:transparent;color:var(--red);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem">Remove</button>
             </td>
           </tr>`;
         }).join('');
@@ -12463,12 +12464,12 @@ function burnAreaChart() {
           'In greenfield mode a brainstorm agent captures your one-line idea, asks clarifying questions, structures the answers into vision, requirements, and constraints (stored as Knowledge Base facts), then scaffolds the project. ' +
           'In brownfield mode it scans an existing repo and captures its conventions and principles as KB facts instead. Pick a mode below to begin.')}</div>
         <div style="display:flex;gap:16px;max-width:700px;margin:0 auto">
-          <div onclick="startInceptionGreenfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue)'" onmouseout="this.style.borderColor='var(--border)'">
+          <div data-action="startInceptionGreenfield" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" data-mouseover-action="gh20" data-mouseout-action="gh21">
             <div style="font-size:2rem;margin-bottom:8px">🌱</div>
             <div style="font-weight:600;margin-bottom:4px">Start from an idea</div>
             <div style="font-size:0.78rem;color:var(--muted)">New project — describe what you want to build and we'll scaffold it</div>
           </div>
-          <div onclick="startInceptionBrownfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue)'" onmouseout="this.style.borderColor='var(--border)'">
+          <div data-action="startInceptionBrownfield" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" data-mouseover-action="gh20" data-mouseout-action="gh21">
             <div style="font-size:2rem;margin-bottom:8px">🏗️</div>
             <div style="font-weight:600;margin-bottom:4px">Add to existing repo</div>
             <div style="font-size:0.78rem;color:var(--muted)">Scan an existing project and capture its principles as KB facts</div>
@@ -12482,9 +12483,9 @@ function burnAreaChart() {
           <div style="font-size:0.85rem;color:var(--muted);margin-bottom:12px">Describe your project idea in a sentence or two.</div>
           <textarea id="inception-idea" placeholder="A CLI tool that syncs Obsidian vaults to a wiki server..." style="width:100%;min-height:80px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--card-bg);color:var(--fg);font-family:inherit;font-size:0.85rem;resize:vertical"></textarea>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
-            <button onclick="stopInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
-            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
-            <button onclick="submitInceptionIdea()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Start</button>
+            <button data-action="stopInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
+            <button data-action="clearInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
+            <button data-action="submitInceptionIdea" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Start</button>
           </div>
         </div>`;
     }
@@ -12520,12 +12521,12 @@ function burnAreaChart() {
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: ${phase}</div>
           </div>
           <div style="position:relative">
-          <div id="inception-activity" style="padding:16px;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Waiting for brainstorm agent...</div>
-          <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
+          <div id="inception-activity" style="padding:16px;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" data-scroll-action="onInceptionScroll">Waiting for brainstorm agent...</div>
+          <button id="inception-follow-btn" class="oc-summary-follow-btn" data-action="inceptionResumeTail" title="Follow new output">⬇</button>
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
-            <button onclick="stopInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
-            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
+            <button data-action="stopInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
+            <button data-action="clearInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
           </div>
         </div>`;
     }
@@ -12591,7 +12592,7 @@ function burnAreaChart() {
           <div style="font-size:1.2rem;margin-bottom:12px">🔍</div>
           <div style="font-size:0.85rem;color:var(--muted)">Scanning repository...</div>
           <div style="font-size:0.78rem;color:var(--muted);margin-top:4px">${escapeHtml(_inceptionState.repo_url || '')}</div>
-          <div style="margin-top:16px"><button onclick="resetInception()" style="padding:6px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.78rem">Cancel</button></div>
+          <div style="margin-top:16px"><button data-action="resetInception" style="padding:6px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.78rem">Cancel</button></div>
         </div>`;
     }
 
@@ -12608,8 +12609,8 @@ function burnAreaChart() {
         </div>`;
       });
       html += `<div style="display:flex;gap:8px;justify-content:flex-end">
-        <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Reset</button>
-        <button onclick="submitInceptionAnswers()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Submit</button>
+        <button data-action="resetInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Reset</button>
+        <button data-action="submitInceptionAnswers" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Submit</button>
       </div>`;
       html += '</div>';
       return html;
@@ -12624,12 +12625,12 @@ function burnAreaChart() {
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: structure</div>
           </div>
           <div style="position:relative">
-          <div id="inception-activity" style="padding:16px;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
-          <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
+          <div id="inception-activity" style="padding:16px;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" data-scroll-action="onInceptionScroll">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
+          <button id="inception-follow-btn" class="oc-summary-follow-btn" data-action="inceptionResumeTail" title="Follow new output">⬇</button>
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
-            <button onclick="stopInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
-            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
+            <button data-action="stopInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
+            <button data-action="clearInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
           </div>
         </div>`;
     }
@@ -12641,8 +12642,8 @@ function burnAreaChart() {
           <div style="font-size:0.85rem;color:var(--muted);margin-bottom:12px">Your scaffold is ready. Review the generated files below, then approve to complete.</div>
           <div id="inception-scaffold-summary" style="margin-bottom:16px"><div style="text-align:center;color:var(--muted);padding:20px">Loading scaffold summary...</div></div>
           <div style="display:flex;gap:8px;justify-content:flex-end">
-            <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Start Over</button>
-            <button onclick="approveInception()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Approve</button>
+            <button data-action="resetInception" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Start Over</button>
+            <button data-action="approveInception" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Approve</button>
           </div>
         </div>`;
     }
@@ -12696,9 +12697,9 @@ function burnAreaChart() {
           </div>
           <div id="inception-complete-files" style="margin-bottom:16px"></div>
           <div style="display:flex;gap:8px;justify-content:center">
-            <button onclick="resetInception()" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">New Inception</button>
-            <button onclick="downloadInceptionZip()" style="padding:8px 20px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Download Project</button>
-            <button onclick="loadInceptionCompleteFiles()" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--fg);cursor:pointer;font-size:0.82rem">Refresh Files</button>
+            <button data-action="resetInception" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">New Inception</button>
+            <button data-action="downloadInceptionZip" style="padding:8px 20px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Download Project</button>
+            <button data-action="loadInceptionCompleteFiles" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--fg);cursor:pointer;font-size:0.82rem">Refresh Files</button>
           </div>
         </div>`;
     }
@@ -13173,8 +13174,60 @@ function burnAreaChart() {
     });
 
     // ── Event delegation for actions with user-controlled data ──
-    // Eliminates XSS via inline onclick="func('${unsafeValue}')" injection.
+    // Eliminates XSS via inline data-action="func" data-arg0="${unsafeValue}" injection.
     // All agent/group names are read from data-* attributes (HTML-decoded by the browser).
+    //
+    // #3848: this dispatcher is now GENERIC and covers every event type the UI
+    // uses (click, change, input, keydown, keyup, mouseover, mouseout, scroll,
+    // toggle, error), so no inline on*= handler attribute remains and CSP
+    // script-src-attr is 'none'. An action resolves, in order, to:
+    //   1. an entry in HIVE_GEN_HANDLERS (multi-statement former inline bodies), or
+    //   2. a top-level function of the same name (window[action]).
+    // Arguments come from data-arg0..data-argN. data-arg-types (comma-separated)
+    // maps each position: s=string (default), j=JSON (number/bool/null),
+    // t=element, e=event, v=element.value, w=element.value.trim(),
+    // N=+element.value, V=value?Number(value):undefined, c=element.checked,
+    // o=element.open. data-stop/data-prevent call stopPropagation/
+    // preventDefault. For key events, data-keys lists accepted event.key values
+    // ('*' = any; default 'Enter').
+    function hiveResolveActionArgs(el, event) {
+      const types = (el.dataset.argTypes || '').split(',').map(t => t.trim()).filter(Boolean);
+      let n = types.length;
+      while (el.dataset['arg' + n] !== undefined) n++;
+      for (let i = 0; i < n; i++) if (!types[i]) types[i] = 's';
+      return types.map((t, i) => {
+        const raw = el.dataset['arg' + i];
+        switch (t) {
+          case 't': return el;
+          case 'e': return event;
+          case 'v': return el.value;
+          case 'w': return (el.value || '').trim();
+          case 'N': return +el.value;
+          case 'V': return el.value ? Number(el.value) : undefined;
+          case 'c': return el.checked;
+          case 'o': return el.open;
+          case 'j': try { return JSON.parse(raw); } catch { return raw; }
+          default: return raw;
+        }
+      });
+    }
+    function hiveDispatchAction(attr, event) {
+      const el = event.target.closest ? event.target.closest('[data-' + attr + ']') : null;
+      if (!el) return false;
+      const camel = attr.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      const action = el.dataset[camel];
+      if (!action) return false;
+      if ((attr === 'keydown-action' || attr === 'keyup-action')) {
+        const keys = el.dataset.keys || 'Enter';
+        if (keys !== '*' && !keys.split(',').some(k => (k === '' ? ',' : k) === event.key)) return false;
+      }
+      const fn = (typeof HIVE_GEN_HANDLERS !== 'undefined' && HIVE_GEN_HANDLERS[action]) || window[action];
+      if (typeof fn !== 'function') return false;
+      if (el.dataset.stop === '1') event.stopPropagation();
+      if (el.dataset.prevent === '1') event.preventDefault();
+      fn.apply(el, HIVE_GEN_HANDLERS[action] ? [event, hiveResolveActionArgs(el, event)] : hiveResolveActionArgs(el, event));
+      return true;
+    }
     document.addEventListener('click', (e) => {
       const el = e.target.closest('[data-action]');
       if (!el) return;
@@ -13183,7 +13236,7 @@ function burnAreaChart() {
       switch (action) {
         case 'toggleAgent': toggleAgent(agent, el.dataset.paused === 'true'); break;
         case 'restartAgent': restartAgent(agent); break;
-        case 'openConfigDialog': { const ct = el.dataset.configType || 'agent'; const tab = el.dataset.tab || null; if (el.classList.contains('agent-link')) { closeConfigDialog(); setTimeout(() => openConfigDialog(ct, agent, tab), 100); } else { openConfigDialog(ct, agent, tab); } } break;
+        case 'openConfigDialog': { const ct = el.dataset.configType || el.dataset.arg0 || 'agent'; const tab = el.dataset.tab || el.dataset.arg2 || null; if (el.classList.contains('agent-link')) { closeConfigDialog(); setTimeout(() => openConfigDialog(ct, agent, tab), 100); } else { openConfigDialog(ct, agent || null, tab); } } break;
         case 'ocSendKick': ocSendKick(agent); break;
         case 'ocSelectAgent': { if (!e.target.closest('.oc-nav-actions')) ocSelectAgent(agent); } break;
         case 'kick': kick(agent); break;
@@ -13194,30 +13247,40 @@ function burnAreaChart() {
         case 'ocRenameSidebarGroup': ocRenameSidebarGroup(el.dataset.group); break;
         case 'ocRemoveSidebarGroup': ocRemoveSidebarGroup(el.dataset.group); break;
         case 'ocToggleSidebarGroup': ocToggleSidebarGroup(el); break;
-        case 'switchConfigTab': switchConfigTab(el.dataset.tab); break;
-        case 'nousSetMode': nousSetMode(el.dataset.mode); break;
-        case 'nousSetScope': nousSetScope(el.dataset.scope); break;
+        case 'switchConfigTab': switchConfigTab(el.dataset.tab || el.dataset.arg0); break;
+        case 'nousSetMode': nousSetMode(el.dataset.mode || el.dataset.arg0); break;
+        case 'nousSetScope': nousSetScope(el.dataset.scope || el.dataset.arg0); break;
         case 'toggleConfigSwitch': toggleConfigSwitch(el, el.dataset.section, el.dataset.key); break;
         case 'toggleEscalationEnabled': toggleEscalationEnabled(el); break;
-        case 'removeListItem': removeListItem(el.dataset.section, el.dataset.key, parseInt(el.dataset.index, 10)); break;
-        case 'toggleRestriction': { const cb = el.querySelector('input[type=checkbox]') || el; toggleRestriction(parseInt(el.dataset.index, 10), cb.checked); } break;
-        case 'removeRestriction': removeRestriction(parseInt(el.dataset.index, 10)); break;
+        case 'removeListItem': removeListItem(el.dataset.section || el.dataset.arg0, el.dataset.key || el.dataset.arg1, parseInt(el.dataset.index !== undefined ? el.dataset.index : el.dataset.arg2, 10)); break;
+        case 'toggleRestriction': { if (el.dataset.index !== undefined) { const cb = el.querySelector('input[type=checkbox]') || el; toggleRestriction(parseInt(el.dataset.index, 10), cb.checked); } else { toggleRestriction(parseInt(el.dataset.arg0, 10), el.checked); } } break;
+        case 'removeRestriction': removeRestriction(parseInt(el.dataset.index !== undefined ? el.dataset.index : el.dataset.arg0, 10)); break;
         case 'removeAgent': removeAgent(agent); break;
         case 'planIssue': planIssue(el); break;
-        default: break;
+        case 'bobKeySet': case 'bobKeyClear': case 'bobKeyTest': break; // direct listeners attached at render time
+        default: hiveDispatchAction('action', e); break;
       }
     });
     document.addEventListener('keydown', (e) => {
-      if (e.key !== 'Enter') return;
-      const el = e.target.closest('[data-enter-action]');
-      if (!el) return;
-      const action = el.dataset.enterAction;
-      const agent = el.dataset.agent || '';
-      switch (action) {
-        case 'ocSendKick': ocSendKick(agent); break;
-        case 'kick': kick(agent); break;
-        default: break;
+      if (e.key === 'Enter') {
+        const el = e.target.closest('[data-enter-action]');
+        if (el) {
+          const agent = el.dataset.agent || '';
+          switch (el.dataset.enterAction) {
+            case 'ocSendKick': ocSendKick(agent); return;
+            case 'kick': kick(agent); return;
+            default: {
+              const fn = window[el.dataset.enterAction];
+              if (typeof fn === 'function') {
+                if (el.dataset.prevent === '1') e.preventDefault();
+                fn.apply(el, hiveResolveActionArgs(el, e));
+                return;
+              }
+            }
+          }
+        }
       }
+      hiveDispatchAction('keydown-action', e);
     });
     document.addEventListener('change', (e) => {
       const el = e.target.closest('[data-change-action]');
@@ -13227,9 +13290,17 @@ function burnAreaChart() {
       switch (action) {
         case 'switchCli': switchCli(agent, el.value); el.selectedIndex = 0; break;
         case 'switchModel': switchModel(agent, el.value); el.selectedIndex = 0; break;
-        default: break;
+        default: hiveDispatchAction('change-action', e); break;
       }
     });
+    document.addEventListener('input', (e) => hiveDispatchAction('input-action', e));
+    document.addEventListener('keyup', (e) => hiveDispatchAction('keyup-action', e));
+    document.addEventListener('mouseover', (e) => hiveDispatchAction('mouseover-action', e));
+    document.addEventListener('mouseout', (e) => hiveDispatchAction('mouseout-action', e));
+    // scroll/toggle/error do not bubble — delegate via the capture phase.
+    document.addEventListener('scroll', (e) => hiveDispatchAction('scroll-action', e), true);
+    document.addEventListener('toggle', (e) => hiveDispatchAction('toggle-action', e), true);
+    document.addEventListener('error', (e) => hiveDispatchAction('error-action', e), true);
 
     const TOAST_DURATION_MS = 3000;
     const TOAST_PROGRESS_MAX_MS = 60000;
@@ -13932,7 +14003,7 @@ function burnAreaChart() {
         } else {
           const escapedId = escapeHtml(c.id).replace(/'/g, "\\'");
           const escapedRepo = escapeHtml(repo).replace(/'/g, "\\'");
-          issueBtn = '<button onclick="event.stopPropagation();acmmCreateIssue(\'' + escapedRepo + '\',\'' + escapedId + '\',' + c.level + ',this)" ' +
+          issueBtn = '<button data-action="acmmCreateIssue" data-arg0="' + escapeHtml(repo) + '" data-arg1="' + escapeHtml(c.id) + '" data-arg2="' + c.level + '" data-arg-types="s,s,j,t" data-stop="1" ' +
             'style="margin-left:auto;padding:3px 10px;font-size:0.7rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;cursor:pointer;color:var(--muted);white-space:nowrap" ' +
             'title="Open GitHub issue for agents to fix this">📋 Open Issue</button>';
         }
@@ -13940,7 +14011,7 @@ function burnAreaChart() {
       const rowId = 'acmm-row-' + c.id.replace(/[^a-zA-Z0-9]/g, '-');
       return '<div style="padding:8px 10px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border)"' +
         (tip ? ' title="' + escapeHtml(tip) + '"' : '') + '>' +
-        '<div style="display:flex;align-items:center;gap:8px;cursor:pointer" onclick="var el=document.getElementById(\'' + rowId + '\');if(el)el.style.display=el.style.display===\'none\'?\'block\':\'none\'">' +
+        '<div style="display:flex;align-items:center;gap:8px;cursor:pointer" data-action="ghToggleDisplayById" data-arg0="' + rowId + '">' +
         '<span style="font-size:0.9rem">' + icon + '</span>' +
         '<span style="font-size:0.82rem;font-weight:500;flex:1">' + escapeHtml(c.name) + '</span>' +
         issueBtn +
@@ -14002,9 +14073,9 @@ function burnAreaChart() {
             '<span class="text-base">✅ ' + escapeHtml(repo) + '</span>' +
             '<span style="font-size:0.72rem;color:var(--muted);margin-left:8px">(already passing)</span></div>';
         } else {
-          html += '<div onclick="acmmCloseDialog();acmmCreateIssueDirectFromPicker(\'' + escapedRepo + '\',\'' + escapedId + '\',' + level + ')" ' +
+          html += '<div data-action="ghAcmmCreateIssueDirect" data-arg0="' + escapeHtml(repo) + '" data-arg1="' + escapeHtml(criterionId) + '" data-arg2="' + level + '" data-arg-types="s,s,j" ' +
             'class="row-card" ' +
-            'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+            'data-mouseover-action="gh22" data-mouseout-action="gh21">' +
             '<span class="text-base">❌ ' + escapeHtml(repo) + '</span></div>';
         }
       }
@@ -14045,7 +14116,7 @@ function burnAreaChart() {
       if (newCriteria.length === 0) {
         html += '<p class="dialog-note">All ' + criteria.length + ' failing criteria already have issues opened.</p>';
         html += '<div class="row-end">' +
-          '<button onclick="acmmCloseDialog()" class="dialog-btn">Close</button></div>';
+          '<button data-action="acmmCloseDialog" class="dialog-btn">Close</button></div>';
       } else {
         html += '<p class="dialog-note">This will create ' + newCriteria.length + ' issue(s) for failing criteria at L' + level + '.' +
           (alreadyOpened > 0 ? ' (' + alreadyOpened + ' already opened, will be skipped)' : '') + '</p>';
@@ -14063,8 +14134,8 @@ function burnAreaChart() {
         }
         html += '</div>';
         html += '<div class="row-end">' +
-          '<button onclick="acmmCloseDialog()" class="dialog-btn">Cancel</button>' +
-          '<button onclick="acmmBatchCreateIssues(' + level + ')" style="padding:6px 14px;background:var(--green);border:none;border-radius:6px;cursor:pointer;color:var(--bg);font-size:0.78rem;font-weight:600">Create ' + newCriteria.length + ' Issue(s)</button></div>';
+          '<button data-action="acmmCloseDialog" class="dialog-btn">Cancel</button>' +
+          '<button data-action="acmmBatchCreateIssues" data-arg0="' + level + '" data-arg-types="j" style="padding:6px 14px;background:var(--green);border:none;border-radius:6px;cursor:pointer;color:var(--bg);font-size:0.78rem;font-weight:600">Create ' + newCriteria.length + ' Issue(s)</button></div>';
       }
       acmmShowDialog('Open Issues for L' + level + ' ' + (ACMM_LEVEL_NAMES[level] || ''), html);
     }
@@ -14152,7 +14223,7 @@ function burnAreaChart() {
 
       let batchBtn = '';
       if (failCount > 0) {
-        batchBtn = '<button onclick="acmmOpenAllIssuesForLevel(' + level + ')" style="padding:4px 10px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;cursor:pointer;color:var(--muted);margin-left:8px" title="Open issues for all failing criteria at this level">📋 Open All (' + failCount + ')</button>';
+        batchBtn = '<button data-action="acmmOpenAllIssuesForLevel" data-arg0="' + level + '" data-arg-types="j" style="padding:4px 10px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;cursor:pointer;color:var(--muted);margin-left:8px" title="Open issues for all failing criteria at this level">📋 Open All (' + failCount + ')</button>';
       }
 
       acmmShowDialog(
@@ -14193,7 +14264,7 @@ function burnAreaChart() {
         const fpct = Math.round(firstFail.score * 100);
         html += '<div style="margin-bottom:12px;padding:8px 10px;background:var(--bg);border-radius:6px;font-size:0.78rem;color:var(--muted);border-left:3px solid var(--yellow)">' +
           '<strong>Blocked at L' + firstFail.level + ' ' + escapeHtml(firstFail.name) + '</strong> — ' + fpct + '%, need ' + needed + ' more criteria to reach 70%. ' +
-          '<span onclick="acmmShowLevelDialog(' + firstFail.level + ')" style="color:var(--blue);cursor:pointer;text-decoration:underline">View missing criteria →</span></div>';
+          '<span data-action="acmmShowLevelDialog" data-arg0="' + firstFail.level + '" data-arg-types="j" style="color:var(--blue);cursor:pointer;text-decoration:underline">View missing criteria →</span></div>';
       }
 
       if (hasMultiRepo) {
@@ -14205,9 +14276,9 @@ function burnAreaChart() {
           const rColor = rr.codebase_level >= 2 ? 'var(--green)' : (rr.criteria_passed > rr.criteria_total * 0.5 ? 'var(--yellow)' : 'var(--red)');
           const expandId = 'acmm-repo-expand-' + ri;
           html += '<div style="margin-bottom:3px">' +
-            '<div onclick="var el=document.getElementById(\'' + expandId + '\');el.style.display=el.style.display===\'none\'?\'block\':\'none\'" ' +
+            '<div data-action="ghToggleDisplayById" data-arg0="' + expandId + '" ' +
             'style="cursor:pointer;padding:6px 8px;background:var(--bg);border-radius:6px;border:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;transition:border-color .15s" ' +
-            'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+            'data-mouseover-action="gh22" data-mouseout-action="gh21">' +
             '<span style="font-size:0.8rem"><span class="acmm-chevron" style="display:inline-block;transition:transform .15s;font-size:0.65rem;margin-right:4px">▶</span>' + escapeHtml(rr.repo) + '</span>' +
             '<span style="font-size:0.72rem;color:' + rColor + ';font-weight:600">' + rr.criteria_passed + '/' + rr.criteria_total + ' (' + rPct + '%)</span></div>' +
             '<div id="' + expandId + '" style="display:none;padding:6px 8px 8px;border:1px solid var(--border);border-top:none;border-radius:0 0 6px 6px;background:var(--surface)">';
@@ -14215,9 +14286,9 @@ function burnAreaChart() {
             const pct = Math.round(lvl.score * 100);
             const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
             const safeRepo = escapeHtml(rr.repo).replace(/'/g, "\\'");
-            html += '<div onclick="event.stopPropagation();acmmShowLevelDialog(' + lvl.level + ',\'' + safeRepo + '\')" ' +
+            html += '<div data-action="acmmShowLevelDialog" data-arg0="' + lvl.level + '" data-arg1="' + escapeHtml(rr.repo) + '" data-arg-types="j,s" data-stop="1" ' +
               'style="cursor:pointer;padding:5px 6px;margin-bottom:3px;background:var(--bg);border-radius:4px;border:1px solid var(--border);transition:border-color .15s" ' +
-              'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+              'data-mouseover-action="gh22" data-mouseout-action="gh21">' +
               '<div class="row-between">' +
               '<span style="font-size:0.75rem;font-weight:500">' + (lvl.passed ? '✓' : '✗') + ' L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
               '<span style="font-size:0.7rem;color:' + color + ';font-weight:600">' + lvl.matched + '/' + lvl.total + '</span></div>' +
@@ -14231,7 +14302,7 @@ function burnAreaChart() {
         for (const lvl of levels) {
           const pct = Math.round(lvl.score * 100);
           const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
-          html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" class="row-card" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+          html += '<div data-action="acmmShowLevelDialog" data-arg0="' + lvl.level + '" data-arg-types="j" class="row-card" data-mouseover-action="gh22" data-mouseout-action="gh21">' +
             '<div class="row-between">' +
             '<span style="font-size:0.82rem;font-weight:600">' + (lvl.passed ? '✓' : '✗') + ' L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
             '<span style="font-size:0.75rem;color:' + color + ';font-weight:600">' + lvl.matched + '/' + lvl.total + ' (' + pct + '%)</span></div>' +
@@ -14274,9 +14345,9 @@ function burnAreaChart() {
       acmmShowDialog('Overall ACMM Level — L' + d.overall_level + ' ' + escapeHtml(overallName),
         '<p class="dialog-note">The overall ACMM level is the <strong>minimum</strong> of codebase readiness and operational autonomy. Both dimensions must align — a high operational level means nothing if the repo lacks foundational tooling, and vice versa.</p>' +
         '<div style="display:flex;gap:12px;margin-bottom:12px">' +
-        '<div class="card-tile" onclick="acmmCloseDialog();acmmShowCodebaseDialog()">' +
+        '<div class="card-tile" data-action="gh23">' +
         '<div class="stat-num">L' + d.codebase_level + '</div><div class="muted-xs">Codebase</div></div>' +
-        '<div class="card-tile" onclick="acmmCloseDialog();acmmShowOpsDialog()">' +
+        '<div class="card-tile" data-action="gh24">' +
         '<div class="stat-num">L' + d.operational_level + '</div><div class="muted-xs">Operational</div></div>' +
         '</div>' +
         '<div style="padding:10px;background:var(--bg);border-radius:6px;border:1px solid var(--border);font-size:0.8rem">' +
@@ -14301,11 +14372,11 @@ function burnAreaChart() {
         const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
         const failCount = criteria.filter(c => !c.passed).length;
         html += '<div style="margin-bottom:8px">' +
-          '<div onclick="acmmCloseDialog();acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:6px 8px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+          '<div data-action="ghAcmmCloseAndShowLevel" data-arg0="' + lvl.level + '" data-arg-types="j" style="cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:6px 8px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" data-mouseover-action="gh22" data-mouseout-action="gh21">' +
           '<span style="font-size:0.82rem;font-weight:600">L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
           '<div style="display:flex;align-items:center;gap:6px">';
         if (failCount > 0) {
-          html += '<button onclick="event.stopPropagation();acmmOpenAllIssuesForLevel(' + lvl.level + ')" style="padding:2px 6px;font-size:0.65rem;background:var(--card-bg);border:1px solid var(--border);border-radius:3px;cursor:pointer;color:var(--muted)">📋 ' + failCount + '</button>';
+          html += '<button data-action="acmmOpenAllIssuesForLevel" data-arg0="' + lvl.level + '" data-arg-types="j" data-stop="1" style="padding:2px 6px;font-size:0.65rem;background:var(--card-bg);border:1px solid var(--border);border-radius:3px;cursor:pointer;color:var(--muted)">📋 ' + failCount + '</button>';
         }
         html += '<span style="font-size:0.75rem;color:' + color + '">' + lvl.matched + '/' + lvl.total + '</span></div></div>';
         for (const c of criteria) {
@@ -14332,7 +14403,7 @@ function burnAreaChart() {
       overlay.innerHTML = '<div class="acmm-dialog">' +
         '<div class="row-between" style="margin-bottom:12px">' +
         '<h3 style="margin:0;font-size:1rem;font-weight:700;color:var(--text)">' + title + '</h3>' +
-        '<button onclick="acmmCloseDialog()" style="background:none;border:none;cursor:pointer;font-size:1.1rem;color:var(--muted);padding:4px">✕</button></div>' +
+        '<button data-action="acmmCloseDialog" style="background:none;border:none;cursor:pointer;font-size:1.1rem;color:var(--muted);padding:4px">✕</button></div>' +
         '<div>' + bodyHtml + '</div></div>';
     }
 
@@ -14395,7 +14466,7 @@ function burnAreaChart() {
         for (const lvl of levels) {
           const pct = Math.round(lvl.score * 100);
           const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
-          html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem;cursor:pointer;padding:2px 4px;border-radius:4px;transition:background .15s" onmouseover="this.style.background=\'var(--bg)\'" onmouseout="this.style.background=\'transparent\'">' +
+          html += '<div data-action="acmmShowLevelDialog" data-arg0="' + lvl.level + '" data-arg-types="j" style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem;cursor:pointer;padding:2px 4px;border-radius:4px;transition:background .15s" data-mouseover-action="gh25" data-mouseout-action="gh26">' +
             '<span style="width:100px;color:var(--muted)">' + escapeHtml(lvl.name) + '</span>' +
             '<div style="flex:1;height:8px;background:var(--bg);border-radius:4px;overflow:hidden">' +
             '<div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:4px;transition:width .3s"></div></div>' +
@@ -14473,7 +14544,7 @@ function burnAreaChart() {
             // Manual path: name the action AND the target — "Upgrade available →
             // <sha>" — with a hover state, so the button cannot be misread as a
             // status label (real feedback: owners could not find how to upgrade).
-            html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" onmouseover="this.style.filter='brightness(1.15)'" onmouseout="this.style.filter=''" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">↑ Upgrade available → ${escapeHtml(v.latestShort || 'latest')}</button>`;
+            html += ` <button id="spoke-upgrade-btn" data-action="gh27" data-arg0="${escapeHtml(v.latestHash || '')}" data-mouseover-action="gh28" data-mouseout-action="gh29" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">↑ Upgrade available → ${escapeHtml(v.latestShort || 'latest')}</button>`;
           }
         } else if (v.latestHash) {
           html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';
@@ -14934,8 +15005,8 @@ function burnAreaChart() {
             </div>
             <div style="text-align:right;min-width:80px">
               <div style="font-size:0.7rem;color:var(--muted)">${p.agentCount} agent${p.agentCount !== 1 ? 's' : ''}</div>
-              ${!isCurrent && p.level > 0 ? '<button onclick="applyACMMPack(' + p.level + ')" style="margin-top:4px;padding:6px 14px;background:' + color + ';color:#fff;border:none;border-radius:6px;font-size:0.75rem;font-weight:600;cursor:pointer">Apply</button>' : ''}
-              ${!isCurrent ? '<button onclick="setACMMLevel(' + p.level + ')" style="margin-top:4px;padding:5px 10px;background:transparent;color:' + color + ';border:1px solid ' + color + ';border-radius:6px;font-size:0.68rem;font-weight:600;cursor:pointer" title="Preview this level — changes the display without affecting running agents">Preview</button>' : ''}
+              ${!isCurrent && p.level > 0 ? '<button data-action="applyACMMPack" data-arg0="' + p.level + '" data-arg-types="j" style="margin-top:4px;padding:6px 14px;background:' + color + ';color:#fff;border:none;border-radius:6px;font-size:0.75rem;font-weight:600;cursor:pointer">Apply</button>' : ''}
+              ${!isCurrent ? '<button data-action="setACMMLevel" data-arg0="' + p.level + '" data-arg-types="j" style="margin-top:4px;padding:5px 10px;background:transparent;color:' + color + ';border:1px solid ' + color + ';border-radius:6px;font-size:0.68rem;font-weight:600;cursor:pointer" title="Preview this level — changes the display without affecting running agents">Preview</button>' : ''}
             </div>
           </div>
           ${p.governor ? '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:6px"><span style="font-weight:600">Governor:</span> ' + esc(p.governor.modes || 'none') + ' · <span style="font-weight:600">Merge:</span> ' + esc(p.governor.mergePolicy || 'manual') + '</div>' : ''}
@@ -15191,7 +15262,7 @@ function burnAreaChart() {
         '<p style="font-size:0.82rem;color:var(--muted);margin-bottom:16px">Import an agent from a YAML definition file. <a href="' + docsURL + '" target="_blank" rel="noopener" style="color:var(--accent)">Field reference ↗</a> · <a href="' + exampleURL + '" target="_blank" rel="noopener" style="color:var(--accent)">example definition ↗</a></p>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Import from URL</label>' +
-          '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button onclick="previewImportFromURL()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg);white-space:nowrap">Preview</button></div>' +
+          '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button data-action="previewImportFromURL" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg);white-space:nowrap">Preview</button></div>' +
           '<label style="display:flex;align-items:center;gap:8px;margin-top:8px;font-size:0.78rem;cursor:pointer;font-weight:400">' +
             '<input type="checkbox" id="import-keep-linked" style="width:auto;margin:0">' +
             '<span>Keep linked to repo (live) <span style="color:var(--muted)">— re-fetch this definition on reload so repo edits propagate. Keep-linked URL imports support GitHub blob URLs and raw.githubusercontent.com file URLs only; gist URLs are one-shot imports, so uncheck this box for gists. Only presentation/behavior fields are re-applied; security and privilege fields are never changed. The repo must be on the operator\'s allowlist. (URL import only.)</span></span>' +
@@ -15200,14 +15271,14 @@ function burnAreaChart() {
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Or paste agent definition</label>' +
           '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
-          '<div style="text-align:right;margin-top:6px"><button onclick="previewImportFromPaste()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Preview</button></div>' +
+          '<div style="text-align:right;margin-top:6px"><button data-action="previewImportFromPaste" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Preview</button></div>' +
         '</div>' +
         '<div id="import-preview" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px;margin-top:16px">' +
           '<div style="font-weight:600;margin-bottom:12px">Preview</div>' +
           '<div id="import-preview-content"></div>' +
           '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:16px">' +
-            '<button onclick="document.getElementById(\'import-preview\').style.display=\'none\'" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer">Cancel</button>' +
-            '<button onclick="confirmImport()" style="padding:8px 20px;border:none;border-radius:6px;background:var(--green);color:var(--bg);cursor:pointer;font-weight:600">Create Agent</button>' +
+            '<button data-action="gh30" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer">Cancel</button>' +
+            '<button data-action="confirmImport" style="padding:8px 20px;border:none;border-radius:6px;background:var(--green);color:var(--bg);cursor:pointer;font-weight:600">Create Agent</button>' +
           '</div>' +
         '</div>' +
       '</div>';
@@ -15410,7 +15481,7 @@ function burnAreaChart() {
       const models = modelsForBackend('litellm');
       const cur = current || '';
       if (!models.length) {
-        return `<input type="text" value="${esc(cur)}" placeholder="e.g. gpt-4o" onchange="markDirty('litellm','defaultModel',this.value)">`;
+        return `<input type="text" value="${esc(cur)}" placeholder="e.g. gpt-4o" data-change-action="markDirty" data-arg0="litellm" data-arg1="defaultModel" data-arg-types="s,s,v">`;
       }
       const inList = cur && models.some(m => m.value === cur);
       const options = models.map(m =>
@@ -15421,11 +15492,11 @@ function burnAreaChart() {
       const customSelected = cur && !inList;
       const emptyOpt = cur ? '' : '<option value="" selected disabled>Select a discovered model…</option>';
       return `
-        <select onchange="onLitellmDefaultModelSelect(this)">
+        <select data-change-action="onLitellmDefaultModelSelect" data-arg-types="t">
           ${emptyOpt}${options}
           <option value="${LITELLM_CUSTOM_MODEL_SENTINEL}"${customSelected ? ' selected' : ''}>${customOptLabel}</option>
         </select>
-        <input type="text" value="${customSelected ? esc(cur) : ''}" placeholder="e.g. Azure/gpt-4o" style="margin-top:6px;display:${customSelected ? 'block' : 'none'}" data-litellm-custom-model onchange="markDirty('litellm','defaultModel',this.value)">`;
+        <input type="text" value="${customSelected ? esc(cur) : ''}" placeholder="e.g. Azure/gpt-4o" style="margin-top:6px;display:${customSelected ? 'block' : 'none'}" data-litellm-custom-model data-change-action="markDirty" data-arg0="litellm" data-arg1="defaultModel" data-arg-types="s,s,v">`;
     }
 
     // onLitellmDefaultModelSelect handles the discovered-model <select>:
@@ -15630,7 +15701,7 @@ function burnAreaChart() {
           <div class="config-field-row">
             <div class="config-field"><label>Name</label><input id="var-add-name" placeholder="MY_VAR" style="text-transform:uppercase"></div>
             <div class="config-field"><label>Type</label>
-              <select id="var-add-type" onchange="onVarAddTypeChange()">
+              <select id="var-add-type" data-change-action="onVarAddTypeChange">
                 <option value="static">static (fixed value)</option>
                 <option value="env">env (environment variable)</option>
               </select>
@@ -15648,7 +15719,7 @@ function burnAreaChart() {
             <div class="config-field" id="var-add-env-field" style="display:none"><label>Env var name</label><input id="var-add-env" placeholder="HIVE_REGION"></div>
             <div class="config-field"><label>Default (optional)</label><input id="var-add-default" placeholder="fallback if unset"></div>
           </div>
-          <button class="config-btn" onclick="saveNewVariable()" style="margin-top:6px">Add variable</button>
+          <button class="config-btn" data-action="saveNewVariable" style="margin-top:6px">Add variable</button>
         </div>
         <details style="margin-top:16px;border-top:1px solid var(--border,#2a2a2a);padding-top:12px">
           <summary style="cursor:pointer;font-weight:600;font-size:0.78rem">Advanced — script &amp; http variables (seed config only)</summary>
@@ -15732,7 +15803,7 @@ function burnAreaChart() {
         const seedOnly = (v.type === 'script' || v.type === 'http');
         const del = seedOnly
           ? '<span style="color:var(--muted);font-size:0.68rem;white-space:nowrap" title="script/http variables are managed in the seed config">seed-managed</span>'
-          : `<button class="config-btn" style="padding:2px 8px;font-size:0.68rem" onclick="deleteVariable('${esc(v.name)}')">delete</button>`;
+          : `<button class="config-btn" style="padding:2px 8px;font-size:0.68rem" data-action="deleteVariable" data-arg0="${esc(v.name)}">delete</button>`;
         return `<div class="config-list-item" style="align-items:center;gap:8px">
           <code style="flex:0 0 auto">\${${esc(v.name)}}</code>
           <span style="color:var(--muted);font-size:0.7rem">${esc(v.type)}</span>
@@ -15927,7 +15998,7 @@ function burnAreaChart() {
     // the same behavior the banner's View App Settings action relies on).
     function forgeAppActions(a) {
       const hostLabel = esc(String(a.base_url || 'https://github.com').replace(/^https?:\/\//, ''));
-      const recheckBtn = '<button type="button" onclick="forgeAppRecheck(this)" style="padding:6px 14px;border:1px solid var(--border);border-radius:6px;background:transparent;color:var(--muted);cursor:pointer;font-size:0.76rem">Re-check</button>';
+      const recheckBtn = '<button type="button" data-action="forgeAppRecheck" data-arg-types="t" style="padding:6px 14px;border:1px solid var(--border);border-radius:6px;background:transparent;color:var(--muted);cursor:pointer;font-size:0.76rem">Re-check</button>';
       if (forgeAppNeedsInstall(a)) {
         if (a.install_url) {
           return `<div id="forge-app-actions" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;border-top:1px solid var(--border);margin-top:10px;padding-top:10px">
@@ -15970,7 +16041,7 @@ function burnAreaChart() {
           </div>
           <label style="font-size:0.72rem;color:var(--muted)">Key file path<input id="forge-app-keyfile" type="text" value="${esc(a.key_file || '')}" style="${inputStyle};margin-bottom:8px"></label>
           <label style="font-size:0.72rem;color:var(--muted)">Private key (PEM — write-only, replaces the key file; never displayed back)<textarea id="forge-app-pem" rows="3" placeholder="-----BEGIN RSA PRIVATE KEY----- (leave empty to keep the current key)" style="${inputStyle};font-family:monospace;margin-bottom:8px"></textarea></label>
-          <button id="forge-app-save-btn" onclick="saveForgeApp()" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">Save</button>
+          <button id="forge-app-save-btn" data-action="saveForgeApp" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">Save</button>
         </div>`;
     }
 
@@ -16030,8 +16101,8 @@ function burnAreaChart() {
           hive — never in hive.yaml, logs, or config downloads.
         </div>
         <div style="margin-bottom:12px;display:flex;gap:8px;flex-wrap:wrap">
-          <button onclick="openGatewayForm()" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">+ Add gateway</button>
-          <button onclick="openOpenRouterFund()" style="padding:7px 16px;border:1px solid var(--cyan);border-radius:6px;background:transparent;color:var(--cyan);cursor:pointer;font-weight:600;font-size:0.8rem">⚡ Fund this hive with OpenRouter</button>
+          <button data-action="openGatewayForm" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">+ Add gateway</button>
+          <button data-action="openOpenRouterFund" style="padding:7px 16px;border:1px solid var(--cyan);border-radius:6px;background:transparent;color:var(--cyan);cursor:pointer;font-weight:600;font-size:0.8rem">⚡ Fund this hive with OpenRouter</button>
         </div>
         <div id="openrouter-fund-host"></div>
         <div id="gateways-form-host"></div>
@@ -16063,11 +16134,11 @@ function burnAreaChart() {
           <div style="font-weight:600;font-size:0.9rem;margin-bottom:4px">⚡ Fund this hive with OpenRouter</div>
           <div style="font-size:0.76rem;color:var(--muted);margin-bottom:10px">Scan the QR (or open the link) to authorize on OpenRouter. A scoped key funded from your OpenRouter credits is stored as the <code>openrouter</code> gateway — the key never leaves this hive.</div>
           <label style="display:block;font-size:0.74rem;color:var(--muted);margin-bottom:4px">Default model for the new gateway</label>
-          <select id="or-model-select" onchange="orModelSelectChange()" style="width:100%;padding:7px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;margin-bottom:8px">${opts}</select>
+          <select id="or-model-select" data-change-action="orModelSelectChange" style="width:100%;padding:7px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;margin-bottom:8px">${opts}</select>
           <input id="or-model-manual" placeholder="e.g. anthropic/claude-opus-4.8" style="display:none;width:100%;padding:7px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;margin-bottom:8px;box-sizing:border-box">
           <div style="display:flex;gap:8px;margin-top:4px">
-            <button onclick="orStartFlow()" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">Generate QR</button>
-            <button onclick="closeOpenRouterFund()" style="padding:7px 16px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.8rem">Cancel</button>
+            <button data-action="orStartFlow" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">Generate QR</button>
+            <button data-action="closeOpenRouterFund" style="padding:7px 16px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.8rem">Cancel</button>
           </div>
           <div id="or-qr-area" style="margin-top:12px"></div>
           <div id="or-status" style="margin-top:8px;font-size:0.78rem"></div>
@@ -16194,9 +16265,9 @@ function burnAreaChart() {
             <span style="font-weight:600;font-size:0.9rem">${esc(gw.name)}</span>
             <span style="font-size:0.68rem;font-weight:600;padding:2px 8px;border-radius:10px;border:1px solid ${meta.color};color:${meta.color}">${esc(meta.label)}</span>
             <span style="flex:1"></span>
-            <button onclick="testGateway('${esc(gw.name)}')" style="padding:4px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.74rem">Test</button>
-            <button onclick="editGateway('${esc(gw.name)}')" style="padding:4px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.74rem">Edit</button>
-            <button onclick="deleteGateway('${esc(gw.name)}')" style="padding:4px 12px;border:1px solid var(--red);border-radius:6px;background:var(--bg);color:var(--red);cursor:pointer;font-size:0.74rem">Delete</button>
+            <button data-action="testGateway" data-arg0="${esc(gw.name)}" style="padding:4px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.74rem">Test</button>
+            <button data-action="editGateway" data-arg0="${esc(gw.name)}" style="padding:4px 12px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.74rem">Edit</button>
+            <button data-action="deleteGateway" data-arg0="${esc(gw.name)}" style="padding:4px 12px;border:1px solid var(--red);border-radius:6px;background:var(--bg);color:var(--red);cursor:pointer;font-size:0.74rem">Delete</button>
           </div>
           <div style="font-size:0.74rem;color:var(--muted);margin-top:8px;word-break:break-all">
             <div>Endpoint: ${esc(gw.endpoint || '—')}</div>
@@ -16330,7 +16401,7 @@ function burnAreaChart() {
       const gw = existing || { name: '', kind: 'custom', endpoint: '', default_model: '', hasKey: false, project_id: '', keyName: '' };
       const presetButtons = GATEWAY_PRESETS.map(function(p) {
         const active = gw.kind === p.kind;
-        return `<button type="button" onclick="applyGatewayPreset('${p.kind}')" data-gw-preset="${p.kind}" style="padding:5px 12px;border:1px solid ${active ? 'var(--cyan)' : 'var(--border)'};border-radius:6px;background:${active ? 'var(--cyan)' : 'var(--bg)'};color:${active ? 'var(--bg)' : 'var(--fg)'};cursor:pointer;font-size:0.74rem;font-weight:600">${esc(p.label)}</button>`;
+        return `<button type="button" data-action="applyGatewayPreset" data-arg0="${p.kind}" data-gw-preset="${p.kind}" style="padding:5px 12px;border:1px solid ${active ? 'var(--cyan)' : 'var(--border)'};border-radius:6px;background:${active ? 'var(--cyan)' : 'var(--bg)'};color:${active ? 'var(--bg)' : 'var(--fg)'};cursor:pointer;font-size:0.74rem;font-weight:600">${esc(p.label)}</button>`;
       }).join('');
       host.innerHTML = `
         <div style="border:1px solid var(--cyan);border-radius:8px;padding:16px;margin-bottom:14px;background:var(--surface)">
@@ -16346,16 +16417,16 @@ function burnAreaChart() {
           <input type="hidden" id="gw-kind" value="${esc(gw.kind || 'custom')}">
           <div class="config-field" style="margin-bottom:10px">
             <label>Endpoint URL</label>
-            <input type="text" id="gw-endpoint" value="${esc(gw.endpoint || '')}" placeholder="https://…/v1" onchange="onGatewayEndpointOrKeyChange()">
+            <input type="text" id="gw-endpoint" value="${esc(gw.endpoint || '')}" placeholder="https://…/v1" data-change-action="onGatewayEndpointOrKeyChange">
           </div>
           <div class="config-field" id="gw-project-id-field" style="margin-bottom:10px;display:${(gw.kind === 'watsonx') ? 'block' : 'none'}">
             <label>watsonx Project ID</label>
-            <input type="text" id="gw-project-id" value="${esc(gw.project_id || '')}" placeholder="e.g. 63dc4cf1-252f-424b-b52d-5cdd9814987f" onchange="onGatewayEndpointOrKeyChange()">
+            <input type="text" id="gw-project-id" value="${esc(gw.project_id || '')}" placeholder="e.g. 63dc4cf1-252f-424b-b52d-5cdd9814987f" data-change-action="onGatewayEndpointOrKeyChange">
             <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Required for watsonx — sent as the X-IBM-Project-ID header. Your API key is exchanged for a short-lived IAM token; the raw key is never sent.</div>
           </div>
           <div class="config-field" style="margin-bottom:10px">
             <label>API Key</label>
-            <input type="password" id="gw-apikey" value="" autocomplete="new-password" placeholder="${gw.hasKey ? '(key is set — enter a new key to replace it)' : 'sk-…'}" onchange="onGatewayEndpointOrKeyChange()">
+            <input type="password" id="gw-apikey" value="" autocomplete="new-password" placeholder="${gw.hasKey ? '(key is set — enter a new key to replace it)' : 'sk-…'}" data-change-action="onGatewayEndpointOrKeyChange">
             <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Stored as a secret on this hive (owner-only file), never in config.</div>
           </div>
           <div class="config-field" style="margin-bottom:10px">
@@ -16368,8 +16439,8 @@ function burnAreaChart() {
             <div id="gw-default-model-field">${gatewayDefaultModelFieldHtml(gw.default_model || '')}</div>
           </div>
           <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:14px">
-            <button type="button" onclick="closeGatewayForm()" style="padding:7px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.78rem">Cancel</button>
-            <button type="button" onclick="saveGateway(${isEdit ? 'true' : 'false'})" style="padding:7px 18px;border:none;border-radius:6px;background:var(--green);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.78rem">Save</button>
+            <button type="button" data-action="closeGatewayForm" style="padding:7px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.78rem">Cancel</button>
+            <button type="button" data-action="saveGateway" data-arg0="${isEdit ? 'true' : 'false'}" data-arg-types="j" style="padding:7px 18px;border:none;border-radius:6px;background:var(--green);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.78rem">Save</button>
           </div>
           <div id="gw-form-result" style="display:none;font-size:0.75rem;margin-top:10px;white-space:pre-wrap"></div>
         </div>`;
@@ -16434,7 +16505,7 @@ function burnAreaChart() {
       const customSelected = cur && !inList;
       const emptyOpt = cur ? '' : '<option value="" selected disabled>Select a discovered model…</option>';
       return `
-        <select id="gw-default-model-select" onchange="onGatewayDefaultModelSelect(this)">
+        <select id="gw-default-model-select" data-change-action="onGatewayDefaultModelSelect" data-arg-types="t">
           ${emptyOpt}${options}
           <option value="${GATEWAY_CUSTOM_MODEL_SENTINEL}"${customSelected ? ' selected' : ''}>${customOptLabel}</option>
         </select>
@@ -16608,11 +16679,11 @@ function burnAreaChart() {
       return `
         <div class="config-field">
           <label>Endpoint URL <span class="config-info">i<span class="config-tooltip">Base URL of the LiteLLM proxy (e.g. https://litellm.example.com). Agents reach it through the hive's inference translator — the MITM proxy stays in the path. The HIVE_LITELLM_ENDPOINT env var overrides this at runtime.</span></span></label>
-          <input type="text" value="${esc(litellm.endpoint || '')}" placeholder="https://litellm.example.com" onchange="markDirty('litellm','endpoint',this.value)">
+          <input type="text" value="${esc(litellm.endpoint || '')}" placeholder="https://litellm.example.com" data-change-action="markDirty" data-arg0="litellm" data-arg1="endpoint" data-arg-types="s,s,v">
         </div>
         <div class="config-field">
           <label>API Key <span class="config-info">i<span class="config-tooltip">Paste the key from your gateway/provider. It is stored privately on this hive (owner-only file on the persistent volume, plus the hive's Kubernetes Secret when available) — never in hive.yaml, logs, or config downloads. Saving runs a live connection test.</span></span></label>
-          <input type="password" value="" placeholder="${litellm.hasKey ? '(key is set — enter a new key to replace it)' : 'sk-...'}" autocomplete="new-password" onchange="markDirty('litellm','apiKey',this.value.trim())">
+          <input type="password" value="" placeholder="${litellm.hasKey ? '(key is set — enter a new key to replace it)' : 'sk-...'}" autocomplete="new-password" data-change-action="markDirty" data-arg0="litellm" data-arg1="apiKey" data-arg-types="s,s,w">
           <div style="font-size:0.72rem;margin-top:4px;color:${litellm.hasKey ? 'var(--green)' : 'var(--red)'}">${keyLine}</div>
         </div>
         <div class="config-field">
@@ -16623,19 +16694,19 @@ function burnAreaChart() {
           <summary style="cursor:pointer;font-size:0.75rem;color:var(--muted)">Advanced — self-hosted key sources &amp; proxy options</summary>
           <div class="config-field" style="margin-top:10px">
             <label>Read Key From Environment Variable <span class="config-info">i<span class="config-tooltip">For self-hosted operators who manage the key outside the dashboard. Takes the NAME of an environment variable — never the key itself.</span></span></label>
-            <input type="text" value="${esc(keyEnvValue)}" placeholder="HIVE_LITELLM_API_KEY" onchange="onLitellmKeyEnvChange(this)">
+            <input type="text" value="${esc(keyEnvValue)}" placeholder="HIVE_LITELLM_API_KEY" data-change-action="onLitellmKeyEnvChange" data-arg-types="t">
             <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Enter the NAME of an environment variable on the hive container that contains your key (self-hosted installs). Hosted users: paste your key in the API Key field above instead.</div>
             ${keyEnvWarning}
           </div>
           <div class="config-field">
             <label>Read Key From File Path <span class="config-info">i<span class="config-tooltip">For self-hosted operators. Path to a mounted file containing the key (e.g. a Kubernetes Secret mount).</span></span></label>
-            <input type="text" value="${esc(keyFileValue)}" placeholder="/secrets/litellm_api_key" onchange="onLitellmKeyFileChange(this)">
+            <input type="text" value="${esc(keyFileValue)}" placeholder="/secrets/litellm_api_key" data-change-action="onLitellmKeyFileChange" data-arg-types="t">
             <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Path to a file that contains your key, such as a Kubernetes Secret mount (self-hosted installs). Hosted users: paste your key in the API Key field above instead.</div>
             ${keyFileWarning}
           </div>
           <div class="config-field">
             <label>CA Bundle Path <span class="config-info">i<span class="config-tooltip">Optional PEM file for a private CA (e.g. an internal VPC endpoint). Certificate verification is never disabled — the CA is added to the trust pool.</span></span></label>
-            <input type="text" value="${esc(litellm.caBundle || '')}" placeholder="/secrets/litellm-ca.pem" onchange="markDirty('litellm','caBundle',this.value)">
+            <input type="text" value="${esc(litellm.caBundle || '')}" placeholder="/secrets/litellm-ca.pem" data-change-action="markDirty" data-arg0="litellm" data-arg1="caBundle" data-arg-types="s,s,v">
           </div>
           <div class="config-toggle">
             <div class="config-toggle-switch ${litellm.localProxy ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="litellm" data-key="localProxy"></div>
@@ -16643,7 +16714,7 @@ function burnAreaChart() {
           </div>
         </details>
         <div style="margin-top:12px">
-          <button onclick="testLiteLLMConnection()" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);cursor:pointer;font-size:0.78rem">Test Connection</button>
+          <button data-action="testLiteLLMConnection" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);cursor:pointer;font-size:0.78rem">Test Connection</button>
           <div id="litellm-test-result" style="display:none;font-size:0.75rem;margin-top:8px;white-space:pre-wrap"></div>
         </div>`;
     }
@@ -16715,11 +16786,11 @@ function burnAreaChart() {
         </div>
         <div class="config-field">
           <label>Hub URL <span class="config-info">i<span class="config-tooltip">URL of the Hive Hub. Heartbeats and task status are sent here.</span></span></label>
-          <input type="text" value="${esc(hub.url || '')}" onchange="markDirty('hub','url',this.value)">
+          <input type="text" value="${esc(hub.url || '')}" data-change-action="markDirty" data-arg0="hub" data-arg1="url" data-arg-types="s,s,v">
         </div>
         <div class="config-field">
           <label>Dashboard URL <span class="config-info">i<span class="config-tooltip">Public URL of this hive's dashboard.</span></span></label>
-          <input type="text" value="${esc(dashUrl)}" onchange="markDirty('hub','dashboard_url',this.value)">
+          <input type="text" value="${esc(dashUrl)}" data-change-action="markDirty" data-arg0="hub" data-arg1="dashboard_url" data-arg-types="s,s,v">
         </div>
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.is_public ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="is_public"></div>
@@ -16729,17 +16800,17 @@ function burnAreaChart() {
         <hr style="border-color:var(--border);margin:16px 0">
         <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Snapshot</h4>
         <div class="config-toggle">
-          <div class="config-toggle-switch ${hub.auto_snapshot ? 'on' : ''}" onclick="toggleAutoSnapshot(this)" data-section="hub" data-key="auto_snapshot"></div>
+          <div class="config-toggle-switch ${hub.auto_snapshot ? 'on' : ''}" data-action="toggleAutoSnapshot" data-arg-types="t" data-section="hub" data-key="auto_snapshot"></div>
           <span class="config-toggle-label">Auto-generate &amp; Publish Snapshot <span class="config-info">i<span class="config-tooltip">Generate a read-only snapshot at /snapshot every 15 min. When off, you can set a custom preview URL below.</span></span></span>
         </div>
         <div class="config-field">
           <label>Snapshot / Preview URL <span class="config-info">i<span class="config-tooltip">${hub.auto_snapshot ? 'Auto-generated from Dashboard URL. Read-only while auto-publish is on.' : 'Enter a custom preview URL (e.g. your own static dashboard). Sent to hub as the Preview link.'}</span></span></label>
-          <input type="text" id="hub-snapshot-url" value="${esc(snapUrl)}" onchange="markDirty('hub','snapshot_url',this.value)" ${hub.auto_snapshot ? 'disabled style="opacity:0.5"' : ''} placeholder="${hub.auto_snapshot ? '' : 'https://your-site.com/dashboard-preview'}">
+          <input type="text" id="hub-snapshot-url" value="${esc(snapUrl)}" data-change-action="markDirty" data-arg0="hub" data-arg1="snapshot_url" data-arg-types="s,s,v" ${hub.auto_snapshot ? 'disabled style="opacity:0.5"' : ''} placeholder="${hub.auto_snapshot ? '' : 'https://your-site.com/dashboard-preview'}">
         </div>
         <div class="config-field">
           <label>Snapshot frame allowlist <span class="config-info">i<span class="config-tooltip">Exact HTTPS origins allowed to embed the public read-only /snapshot page. Empty keeps frame-ancestors 'none' and X-Frame-Options: DENY. X-Frame-Options is omitted for /snapshot only when this allowlist is non-empty because XFO cannot express allowlists.</span></span></label>
-          <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px">${frameAncestors.map(function(o) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(96,165,250,0.15);color:var(--blue);border:1px solid rgba(96,165,250,0.3)">' + esc(o) + ' <span onclick="removeHubFilter(\'snapshot_frame_ancestors\',' + esc(JSON.stringify(o)) + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('') || '<span style="font-size:0.72rem;color:var(--muted)">No origins allowed — /snapshot cannot be framed.</span>'}</div>
-          <textarea rows="3" style="width:100%;font-family:var(--font-mono);font-size:0.72rem;resize:vertical" placeholder="https://docs.projectbluefin.io" onchange="setSnapshotFrameAncestorsFromText(this.value)">${esc(frameAncestors.join('\n'))}</textarea>
+          <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px">${frameAncestors.map(function(o) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(96,165,250,0.15);color:var(--blue);border:1px solid rgba(96,165,250,0.3)">' + esc(o) + ' <span data-action="removeHubFilter" data-arg0="snapshot_frame_ancestors" data-arg1="' + esc(o) + '" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('') || '<span style="font-size:0.72rem;color:var(--muted)">No origins allowed — /snapshot cannot be framed.</span>'}</div>
+          <textarea rows="3" style="width:100%;font-family:var(--font-mono);font-size:0.72rem;resize:vertical" placeholder="https://docs.projectbluefin.io" data-change-action="setSnapshotFrameAncestorsFromText" data-arg-types="v">${esc(frameAncestors.join('\n'))}</textarea>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">One exact origin per line: <code>https://host</code> or <code>https://host:port</code>. Paths, http://, credentials, and wildcards are rejected.</span>
         </div>
 
@@ -16757,12 +16828,12 @@ function burnAreaChart() {
         </div>
 
         <div class="config-toggle">
-          <div class="config-toggle-switch ${hub.contribute_cooldown_enabled ? 'on' : ''}" onclick="toggleCooldownEnabled(this)" data-section="hub" data-key="contribute_cooldown_enabled"></div>
+          <div class="config-toggle-switch ${hub.contribute_cooldown_enabled ? 'on' : ''}" data-action="toggleCooldownEnabled" data-arg-types="t" data-section="hub" data-key="contribute_cooldown_enabled"></div>
           <span class="config-toggle-label">Task Cooldown <span class="config-info">i<span class="config-tooltip">After a task completes WITH a merged/verified PR, keep that issue out of the queue for the period below (default 168h = one week) so it isn't immediately re-offered. Turn off to disable cooldown gating entirely. Failure quarantine is separate and always on. Mirrored on the /contribute Management tab.</span></span></span>
         </div>
         <div class="config-field" style="margin-left:44px" ${hub.contribute_cooldown_enabled ? '' : 'title="Enable Task Cooldown to edit the period"'}>
           <label>Cooldown Period (hours) <span class="config-info">i<span class="config-tooltip">The with-PR completion cooldown, in hours. 168 = one week (default). Range 1–8760.</span></span></label>
-          <input type="number" id="hub-cooldown-hours" min="1" max="8760" value="${hub.contribute_cooldown_hours || 168}" onchange="markDirty('hub','contribute_cooldown_hours',parseInt(this.value,10)||168)" ${hub.contribute_cooldown_enabled ? '' : 'disabled style="opacity:0.5"'}>
+          <input type="number" id="hub-cooldown-hours" min="1" max="8760" value="${hub.contribute_cooldown_hours || 168}" data-change-action="gh31" ${hub.contribute_cooldown_enabled ? '' : 'disabled style="opacity:0.5"'}>
         </div>
 
         <div class="config-field">
@@ -16773,7 +16844,7 @@ function burnAreaChart() {
             }).join('')}
             ${privilegedDelegatableRoles.map(function(r) {
               const checked = delegatableRoles.includes(r);
-              return '<label style="display:flex;align-items:center;gap:8px;font-size:0.78rem"><input type="checkbox" ' + (checked ? 'checked ' : '') + 'onchange="toggleDelegatableAgentRole(\'' + r + '\',this.checked)"> ' + r + ' <span style="font-size:0.65rem;color:var(--muted)">Delegatable to contributors</span></label>';
+              return '<label style="display:flex;align-items:center;gap:8px;font-size:0.78rem"><input type="checkbox" ' + (checked ? 'checked ' : '') + 'data-change-action="toggleDelegatableAgentRole" data-arg0="' + r + '" data-arg-types="s,c"> ' + r + ' <span style="font-size:0.65rem;color:var(--muted)">Delegatable to contributors</span></label>';
             }).join('')}
           </div>
         </div>
@@ -16802,16 +16873,16 @@ function burnAreaChart() {
 
         <div class="config-field">
           <label>Allowed Models <span class="config-info">i<span class="config-tooltip">Models matching these patterns are accepted. Supports wildcards (*) and regex (/pattern/). Empty = allow all.</span></span></label>
-          <div id="hub-allow-models" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowModels.map(function(m) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:var(--green);border:1px solid rgba(34,197,94,0.3)">' + esc(m) + ' <span onclick="removeHubFilter(\'contribute_allow_models\',\'' + esc(m).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div id="hub-allow-models" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowModels.map(function(m) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:var(--green);border:1px solid rgba(34,197,94,0.3)">' + esc(m) + ' <span data-action="removeHubFilter" data-arg0="contribute_allow_models" data-arg1="' + esc(m) + '" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
           <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px">
-            <button onclick="addModelPreset('claude-opus*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ opus</button>
-            <button onclick="addModelPreset('claude-sonnet*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ sonnet</button>
-            <button onclick="addModelPreset('claude-haiku*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ haiku</button>
-            <button onclick="addModelPreset('gpt-4o*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ gpt-4o</button>
-            <button onclick="addModelPreset('gemini*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ gemini</button>
-            <button onclick="addModelPreset('deepseek*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ deepseek</button>
+            <button data-action="addModelPreset" data-arg0="claude-opus*" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ opus</button>
+            <button data-action="addModelPreset" data-arg0="claude-sonnet*" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ sonnet</button>
+            <button data-action="addModelPreset" data-arg0="claude-haiku*" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ haiku</button>
+            <button data-action="addModelPreset" data-arg0="gpt-4o*" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ gpt-4o</button>
+            <button data-action="addModelPreset" data-arg0="gemini*" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ gemini</button>
+            <button data-action="addModelPreset" data-arg0="deepseek*" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ deepseek</button>
           </div>
-          <div style="display:flex;gap:4px"><input type="text" id="hub-allow-model-input" placeholder="e.g. claude-opus*, /gemini-\\d/" style="flex:1" onkeydown="if(event.key==='Enter'){addHubFilter('contribute_allow_models','hub-allow-model-input');event.preventDefault()}"><button onclick="addHubFilter('contribute_allow_models','hub-allow-model-input')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
+          <div style="display:flex;gap:4px"><input type="text" id="hub-allow-model-input" placeholder="e.g. claude-opus*, /gemini-\\d/" style="flex:1" data-keydown-action="addHubFilter" data-arg0="contribute_allow_models" data-arg1="hub-allow-model-input" data-prevent="1" data-keys="Enter"><button data-action="addHubFilter" data-arg0="contribute_allow_models" data-arg1="hub-allow-model-input" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
         </div>
 
         <hr style="border-color:var(--border);margin:16px 0">
@@ -16826,7 +16897,7 @@ function burnAreaChart() {
         <div class="config-field">
           <label>Repos for Contribute <span class="config-info">i<span class="config-tooltip">Toggle which repos serve work to contributors. New repos default to on.</span></span></label>
           <div style="display:flex;flex-direction:column;gap:4px">${repos.map(function(r) {
-            return '<div class="config-toggle" style="padding:2px 0"><div class="config-toggle-switch ' + (r.enabled ? 'on' : '') + '" onclick="toggleContribRepo(this,\'' + esc(r.name) + '\')"></div><span style="font-size:0.78rem">' + esc(r.full) + '</span></div>';
+            return '<div class="config-toggle" style="padding:2px 0"><div class="config-toggle-switch ' + (r.enabled ? 'on' : '') + '" data-action="toggleContribRepo" data-arg1="' + esc(r.name) + '" data-arg-types="t,s"></div><span style="font-size:0.78rem">' + esc(r.full) + '</span></div>';
           }).join('')}</div>
         </div>
 
@@ -16840,10 +16911,10 @@ function burnAreaChart() {
             const mph = limits.max_per_hour != null ? limits.max_per_hour : def.mph;
             const mpd = limits.max_per_day != null ? limits.max_per_day : def.mpd;
             const mc = limits.max_concurrent != null ? limits.max_concurrent : def.mc;
-            return '<div style="display:flex;align-items:center;gap:8px;padding:2px 0"><div class="config-toggle-switch ' + (enabled ? 'on' : '') + '" onclick="toggleContribTier(this,\'' + t + '\')" style="flex-shrink:0"></div><span style="font-size:0.78rem;width:80px">' + t + '</span>' +
-              '<input type="number" min="0" placeholder="/hr" value="' + mph + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" onchange="setTierLimit(\'' + t + '\',\'max_per_hour\',+this.value)">' +
-              '<input type="number" min="0" placeholder="/day" value="' + mpd + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" onchange="setTierLimit(\'' + t + '\',\'max_per_day\',+this.value)">' +
-              '<input type="number" min="0" placeholder="max" value="' + mc + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" onchange="setTierLimit(\'' + t + '\',\'max_concurrent\',+this.value)">' +
+            return '<div style="display:flex;align-items:center;gap:8px;padding:2px 0"><div class="config-toggle-switch ' + (enabled ? 'on' : '') + '" data-action="toggleContribTier" data-arg1="' + t + '" data-arg-types="t,s" style="flex-shrink:0"></div><span style="font-size:0.78rem;width:80px">' + t + '</span>' +
+              '<input type="number" min="0" placeholder="/hr" value="' + mph + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" data-change-action="setTierLimit" data-arg0="' + t + '" data-arg1="max_per_hour" data-arg-types="s,s,N">' +
+              '<input type="number" min="0" placeholder="/day" value="' + mpd + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" data-change-action="setTierLimit" data-arg0="' + t + '" data-arg1="max_per_day" data-arg-types="s,s,N">' +
+              '<input type="number" min="0" placeholder="max" value="' + mc + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" data-change-action="setTierLimit" data-arg0="' + t + '" data-arg1="max_concurrent" data-arg-types="s,s,N">' +
               '<span style="font-size:0.65rem;color:var(--muted)">/hr · /day · max</span></div>';
           }).join('')}</div>
         </div>`;
@@ -16938,7 +17009,7 @@ function burnAreaChart() {
       }
       function seg(m, text) {
         var on = cfg.mode === m;
-        return '<button onclick="setHubFilterMode(\'' + cfg.modeKey + '\',\'' + m + '\')" ' +
+        return '<button data-action="setHubFilterMode" data-arg0="' + cfg.modeKey + '" data-arg1="' + m + '" ' +
           'style="padding:3px 12px;border:1px solid var(--border);cursor:pointer;font-size:0.72rem;' +
           (m === 'allow' ? 'border-radius:6px 0 0 6px;' : 'border-radius:0 6px 6px 0;border-left:none;') +
           (on ? 'background:' + (m === 'allow' ? 'var(--green)' : 'var(--red)') + ';color:#fff;font-weight:600;' : 'background:var(--bg);color:var(--muted);') +
@@ -16946,7 +17017,7 @@ function burnAreaChart() {
       }
       var chips = (cfg.list || []).map(function(v) {
         return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:' + chipBg + ';color:' + chipColor + ';border:1px solid ' + chipBorder + '">' +
-          esc(v) + ' <span onclick="removeHubFilter(\'' + cfg.listKey + '\',\'' + esc(v).replace(/'/g, "\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>';
+          esc(v) + ' <span data-action="removeHubFilter" data-arg0="' + cfg.listKey + '" data-arg1="' + esc(v) + '" style="cursor:pointer;opacity:0.7">✕</span></span>';
       }).join('');
       return '<div class="config-field">' +
         '<label>' + cfg.label + ' <span class="config-info">i<span class="config-tooltip">Choose a mode, then add patterns. Supports wildcards (*) and regex (/pattern/).</span></span></label>' +
@@ -16954,8 +17025,8 @@ function burnAreaChart() {
         '<div style="font-size:0.68rem;color:var(--muted);margin-bottom:6px">' + help + '</div>' +
         '<div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">' + chips + '</div>' +
         '<div style="display:flex;gap:4px"><input type="text" id="' + cfg.inputId + '" placeholder="' + cfg.placeholder + '" style="flex:1" ' +
-          'onkeydown="if(event.key===\'Enter\'){addHubFilter(\'' + cfg.listKey + '\',\'' + cfg.inputId + '\');event.preventDefault()}">' +
-          '<button onclick="addHubFilter(\'' + cfg.listKey + '\',\'' + cfg.inputId + '\')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>' +
+          'data-enter-action="addHubFilter" data-arg0="' + cfg.listKey + '" data-arg1="' + cfg.inputId + '" data-prevent="1">' +
+          '<button data-action="addHubFilter" data-arg0="' + cfg.listKey + '" data-arg1="' + cfg.inputId + '" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>' +
         '</div>';
     }
 
@@ -17055,42 +17126,42 @@ function burnAreaChart() {
       if (isCreate) {
         html += `<div class="config-field">
           <label>Name <span style="color:var(--red)">*</span> <span class="config-info">i<span class="config-tooltip">The agent's internal name used as its ID, config file name, and tmux session. Lowercase, hyphens allowed.</span></span></label>
-          <input type="text" id="cfg-create-name" value="" placeholder="e.g. docs-writer, sec-scanner" onchange="markDirty('_create','name',this.value)">
+          <input type="text" id="cfg-create-name" value="" placeholder="e.g. docs-writer, sec-scanner" data-change-action="markDirty" data-arg0="_create" data-arg1="name" data-arg-types="s,s,v">
           <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lowercase, hyphens allowed. Used as the agent ID.</div>
         </div>`;
       }
       html += `
         <div class="config-field">
           <label>Display Name <span class="config-info">i<span class="config-tooltip">The friendly name shown on the agent card and sidebar. Does not affect the agent's internal ID or tmux session name.</span></span></label>
-          <input type="text" id="cfg-agent-name" value="${esc(g.displayName || (isCreate ? '' : agentName))}" placeholder="e.g. Scanner, Code Reviewer" onchange="updateConfigAgentName(this.value);markDirty('general','displayName',this.value)">
+          <input type="text" id="cfg-agent-name" value="${esc(g.displayName || (isCreate ? '' : agentName))}" placeholder="e.g. Scanner, Code Reviewer" data-change-action="gh32">
         </div>
         <div class="config-field">
           <label>Description <span class="config-info">i<span class="config-tooltip">A short description of what this agent is responsible for. Shown as hover text on the sidebar agent list. Helps operators and collaborators understand each agent's role at a glance.</span></span></label>
-          <textarea id="cfg-agent-desc" rows="2" style="width:100%;resize:vertical;font-size:0.75rem" placeholder="e.g. Triages GitHub issues and dispatches fix agents" onchange="markDirty('general','description',this.value)">${esc(g.description || (isCreate ? '' : AGENT_DESCRIPTIONS[agentName]) || '')}</textarea>
+          <textarea id="cfg-agent-desc" rows="2" style="width:100%;resize:vertical;font-size:0.75rem" placeholder="e.g. Triages GitHub issues and dispatches fix agents" data-change-action="markDirty" data-arg0="general" data-arg1="description" data-arg-types="s,s,v">${esc(g.description || (isCreate ? '' : AGENT_DESCRIPTIONS[agentName]) || '')}</textarea>
         </div>
         <div class="config-field-row">
           <div class="config-field">
             <label>Emoji <span class="config-info">i<span class="config-tooltip">Emoji shown next to the agent name in the sidebar and agent cards.</span></span></label>
-            <input type="text" id="cfg-agent-emoji" value="${esc(g.emoji || '')}" placeholder="🤖" onchange="markDirty('general','emoji',this.value)">
+            <input type="text" id="cfg-agent-emoji" value="${esc(g.emoji || '')}" placeholder="🤖" data-change-action="markDirty" data-arg0="general" data-arg1="emoji" data-arg-types="s,s,v">
           </div>
           <div class="config-field">
             <label>Color <span class="config-info">i<span class="config-tooltip">The agent's identity color, used to represent it in token charts and sparklines. Does not affect card or status styling.</span></span></label>
-            <input type="color" id="cfg-agent-color" class="config-color-input" value="${esc(g.color || '#3498db')}" onchange="markDirty('general','color',this.value)">
+            <input type="color" id="cfg-agent-color" class="config-color-input" value="${esc(g.color || '#3498db')}" data-change-action="markDirty" data-arg0="general" data-arg1="color" data-arg-types="s,s,v">
             <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Identity color for this agent's token charts and sparklines.</div>
           </div>
         </div>
         <div class="config-field-row">
           <div class="config-field">
             <label>Sort Order <span class="config-info">i<span class="config-tooltip">Controls position in sidebar and agent grid. Lower numbers appear first.</span></span></label>
-            <input type="number" id="cfg-agent-sort" value="${g.sortOrder || 50}" onchange="markDirty('general','sortOrder',parseInt(this.value,10))">
+            <input type="number" id="cfg-agent-sort" value="${g.sortOrder || 50}" data-change-action="gh33">
           </div>
           <div class="config-field">
             <label>Replicas <span class="config-info">i<span class="config-tooltip">Run multiple isolated copies of this agent. Replica 1 keeps this name; extra replicas appear as name-2, name-3, etc. Cap ${MAX_AGENT_REPLICAS}.</span></span></label>
-            <input type="number" id="cfg-agent-replicas" min="1" max="${MAX_AGENT_REPLICAS}" value="${g.replicas || 1}" onchange="markDirty('general','replicas',Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1)));this.value=Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1))">
+            <input type="number" id="cfg-agent-replicas" min="1" max="${MAX_AGENT_REPLICAS}" value="${g.replicas || 1}" data-change-action="gh34">
           </div>
           <div class="config-field">
             <label>Bead Role <span class="config-info">i<span class="config-tooltip">Worker agents do tasks. Supervisor monitors other agents.</span></span></label>
-            <select id="cfg-agent-bead-role" onchange="markDirty('general','beadRole',this.value)">
+            <select id="cfg-agent-bead-role" data-change-action="markDirty" data-arg0="general" data-arg1="beadRole" data-arg-types="s,s,v">
               <option value="worker" ${(g.beadRole || 'worker') === 'worker' ? 'selected' : ''}>worker</option>
               <option value="supervisor" ${g.beadRole === 'supervisor' ? 'selected' : ''}>supervisor</option>
             </select>
@@ -17099,11 +17170,11 @@ function burnAreaChart() {
         <div class="config-field-row">
           <div class="config-field">
             <label>Role <span class="config-info">i<span class="config-tooltip">Semantic role for behavioral dispatch (e.g. scanner, reviewer, architect). Used by lane routing and kick templates.</span></span></label>
-            <input type="text" id="cfg-agent-role" value="${esc(g.role || '')}" placeholder="e.g. scanner, reviewer" onchange="markDirty('general','role',this.value)">
+            <input type="text" id="cfg-agent-role" value="${esc(g.role || '')}" placeholder="e.g. scanner, reviewer" data-change-action="markDirty" data-arg0="general" data-arg1="role" data-arg-types="s,s,v">
           </div>
           <div class="config-field">
             <label>Kick Template <span class="config-info">i<span class="config-tooltip">Prompt template file used when the governor kicks this agent. Located in the prompts directory.</span></span></label>
-            <input type="text" id="cfg-agent-kick-tpl" value="${esc(g.kickTemplate || '')}" placeholder="e.g. scanner-CLAUDE.md" onchange="markDirty('general','kickTemplate',this.value)">
+            <input type="text" id="cfg-agent-kick-tpl" value="${esc(g.kickTemplate || '')}" placeholder="e.g. scanner-CLAUDE.md" data-change-action="markDirty" data-arg0="general" data-arg1="kickTemplate" data-arg-types="s,s,v">
           </div>
         </div>
         <div class="config-field">
@@ -17112,21 +17183,21 @@ function burnAreaChart() {
           <div class="config-field-row">
             <div class="config-field">
               <label style="font-size:0.7rem">Owner</label>
-              <input type="text" id="cfg-agent-ps-owner" value="${esc((g.promptSource && g.promptSource.owner) || '')}" placeholder="e.g. kubestellar" oninput="markPromptSourceDirty()">
+              <input type="text" id="cfg-agent-ps-owner" value="${esc((g.promptSource && g.promptSource.owner) || '')}" placeholder="e.g. kubestellar" data-input-action="markPromptSourceDirty">
             </div>
             <div class="config-field">
               <label style="font-size:0.7rem">Repo</label>
-              <input type="text" id="cfg-agent-ps-repo" value="${esc((g.promptSource && g.promptSource.repo) || '')}" placeholder="e.g. hive" oninput="markPromptSourceDirty()">
+              <input type="text" id="cfg-agent-ps-repo" value="${esc((g.promptSource && g.promptSource.repo) || '')}" placeholder="e.g. hive" data-input-action="markPromptSourceDirty">
             </div>
           </div>
           <div class="config-field-row">
             <div class="config-field">
               <label style="font-size:0.7rem">File path</label>
-              <input type="text" id="cfg-agent-ps-path" value="${esc((g.promptSource && g.promptSource.path) || '')}" placeholder="e.g. prompts/scanner.md" oninput="markPromptSourceDirty()">
+              <input type="text" id="cfg-agent-ps-path" value="${esc((g.promptSource && g.promptSource.path) || '')}" placeholder="e.g. prompts/scanner.md" data-input-action="markPromptSourceDirty">
             </div>
             <div class="config-field">
               <label style="font-size:0.7rem">Ref <span style="font-weight:400;color:var(--muted)">(optional)</span></label>
-              <input type="text" id="cfg-agent-ps-ref" value="${esc((g.promptSource && g.promptSource.ref) || '')}" placeholder="branch, tag, or SHA (default branch if blank)" oninput="markPromptSourceDirty()">
+              <input type="text" id="cfg-agent-ps-ref" value="${esc((g.promptSource && g.promptSource.ref) || '')}" placeholder="branch, tag, or SHA (default branch if blank)" data-input-action="markPromptSourceDirty">
             </div>
           </div>
         </div>
@@ -17137,7 +17208,7 @@ function burnAreaChart() {
             const statusAgent = ((window._lastStatus || {}).agents || []).find(sa => sa.name === agentName);
             const dflt = statusAgent ? statusAgent.defaultMode : '';
             const current = g.mode || '';
-            return '<select id="cfg-agent-mode" onchange="markDirty(\'general\',\'mode\',this.value)">'
+            return '<select id="cfg-agent-mode" data-change-action="markDirty" data-arg0="general" data-arg1="mode" data-arg-types="s,s,v">'
               + '<option value=""' + (!current ? ' selected' : '') + '>— use level default' + (dflt ? ' (' + modeEmoji(dflt) + ' ' + dflt + ')' : '') + '</option>'
               + allModes.map(m => '<option value="' + m + '"' + (current === m ? ' selected' : '') + '>' + modeEmoji(m) + ' ' + m + (m === dflt ? ' (default)' : '') + '</option>').join('')
               + '</select>';
@@ -17145,7 +17216,7 @@ function burnAreaChart() {
         </div>
         <div class="config-field">
           <label>Launch Command <span class="config-info">i<span class="config-tooltip">The shell command used to start this agent's CLI process. Typically uses agent-launch.sh with a --backend flag. Changing the CLI Pin Value will auto-update the binary path here.</span></span></label>
-          <input type="text" id="cfg-launch-cmd" value="${esc(g.launchCmd || '')}" onchange="markDirty('general','launchCmd',this.value)">
+          <input type="text" id="cfg-launch-cmd" value="${esc(g.launchCmd || '')}" data-change-action="markDirty" data-arg0="general" data-arg1="launchCmd" data-arg-types="s,s,v">
         </div>
         <div class="config-toggle">
           <div class="config-toggle-switch ${g.sandboxEnabled ? 'on' : ''}" id="cfg-agent-sandbox" data-action="toggleConfigSwitch" data-section="general" data-key="sandboxEnabled"></div>
@@ -17165,25 +17236,25 @@ function burnAreaChart() {
         </div>
         <div class="config-field">
           <label>CLI Pin Value <span class="config-info">i<span class="config-tooltip">Which CLI backend to pin this agent to when CLI Pinned is on. Options: claude, copilot, bob, gemini, codex, amazonq, goose, aider. copilot and goose are free backends (no token cost).</span></span></label>
-          <select id="cfg-pin-value" data-prev="${esc(g.cliPinValue || '')}" onchange="onCliPinChange(this)">
+          <select id="cfg-pin-value" data-prev="${esc(g.cliPinValue || '')}" data-change-action="onCliPinChange" data-arg-types="t">
             ${backendOptionList().map(b => `<option value="${b}" ${g.cliPinValue === b ? 'selected' : ''}>${backendLabel(b)}</option>`).join('')}
           </select>
         </div>
         <div class="config-field-row">
           <div class="config-field">
             <label>Stale Timeout <span class="config-info">i<span class="config-tooltip">How long an agent can be idle before the governor considers it stale and triggers a restart. Use m (minutes) or h (hours), e.g. 20m, 2.5h. Default is 20m.</span></span></label>
-            <input type="text" id="cfg-stale-timeout" value="${cadenceToHuman(g.staleTimeout || 1200)}" onchange="markDirty('general','staleTimeout',cadenceFromHuman(this.value));this.value=cadenceToHuman(cadenceFromHuman(this.value))">
+            <input type="text" id="cfg-stale-timeout" value="${cadenceToHuman(g.staleTimeout || 1200)}" data-change-action="gh35">
           </div>
           <div class="config-field">
             <label>Restart Strategy <span class="config-info">i<span class="config-tooltip">immediate: restart right away when stale or crashed. backoff: wait progressively longer between restart attempts (useful for rate-limited agents). none: do not auto-restart — operator must manually intervene.</span></span></label>
-            <select id="cfg-restart-strategy" onchange="markDirty('general','restartStrategy',this.value)">
+            <select id="cfg-restart-strategy" data-change-action="markDirty" data-arg0="general" data-arg1="restartStrategy" data-arg-types="s,s,v">
               ${RESTART_STRATEGIES.map(s => `<option value="${s}" ${g.restartStrategy === s ? 'selected' : ''}>${s}</option>`).join('')}
             </select>
           </div>
         </div>
         <div class="config-field">
           <label>Model <span class="config-info">i<span class="config-tooltip">Override the LLM model for this agent. Select "(from launch command)" to let the CLI choose its default. The governor may downgrade models automatically when budget is tight, unless Model Lock is enabled in Governor Health settings.</span></span></label>
-          <select id="cfg-model" onchange="markDirty('general','model',this.value)">
+          <select id="cfg-model" data-change-action="markDirty" data-arg0="general" data-arg1="model" data-arg-types="s,s,v">
             <option value="">(from launch command)</option>
             ${_modelOpts.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
             ${(g.model && !_modelOpts.some(m => _modelsEqual(g.model, m.value))) ? `<option value="${esc(g.model)}" selected>${esc(g.model)} (current)</option>` : ''}
@@ -17191,21 +17262,21 @@ function burnAreaChart() {
         </div>
         <div class="config-field">
           <label>Caveman Mode <span class="config-info">i<span class="config-tooltip">Enable Caveman output compression to reduce token usage by ~65%. Modes: lite (removes filler), full (caveman-speak), ultra (telegraphic), wenyan (classical Chinese). Leave empty to disable.</span></span></label>
-          <select id="cfg-caveman-mode" onchange="markDirty('general','cavemanMode',this.value)">
+          <select id="cfg-caveman-mode" data-change-action="markDirty" data-arg0="general" data-arg1="cavemanMode" data-arg-types="s,s,v">
             ${CAVEMAN_MODES.map(m => `<option value="${m}" ${(g.cavemanMode || '') === m ? 'selected' : ''}>${m || '(disabled)'}</option>`).join('')}
           </select>
         </div>
         <div class="config-field">
           <label>Lane Keywords <span class="config-info">i<span class="config-tooltip">Comma-separated keywords for issue classification routing. Issues matching these keywords are routed to this agent.</span></span></label>
-          <input type="text" id="cfg-agent-lane-kw" value="${esc((g.laneKeywords || []).join(', '))}" placeholder="e.g. bug, triage, security" onchange="markDirty('general','laneKeywords',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+          <input type="text" id="cfg-agent-lane-kw" value="${esc((g.laneKeywords || []).join(', '))}" placeholder="e.g. bug, triage, security" data-change-action="gh36">
         </div>
         <div class="config-field">
           <label>Detect Keywords <span class="config-info">i<span class="config-tooltip">Comma-separated keywords for token session detection. Used to identify which agent produced a given session.</span></span></label>
-          <input type="text" id="cfg-agent-detect-kw" value="${esc((g.detectKeywords || []).join(', '))}" placeholder="e.g. scanner, triage, issue" onchange="markDirty('general','detectKeywords',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+          <input type="text" id="cfg-agent-detect-kw" value="${esc((g.detectKeywords || []).join(', '))}" placeholder="e.g. scanner, triage, issue" data-change-action="gh37">
         </div>
         <div class="config-field">
           <label>Aliases <span class="config-info">i<span class="config-tooltip">Comma-separated short aliases for Discord commands.</span></span></label>
-          <input type="text" id="cfg-agent-aliases" value="${esc((g.aliases || []).join(', '))}" placeholder="e.g. sc, scan" onchange="markDirty('general','aliases',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+          <input type="text" id="cfg-agent-aliases" value="${esc((g.aliases || []).join(', '))}" placeholder="e.g. sc, scan" data-change-action="gh38">
         </div>
         ${isCreate ? '' : `<div style="margin-top:24px;padding-top:16px;border-top:1px solid var(--red-border)">
           <label style="color:#b91c1c;font-weight:600;font-size:0.75rem;margin-bottom:8px;display:block">Danger Zone</label>
@@ -17301,18 +17372,18 @@ function burnAreaChart() {
       const times = kind === 'times' ? (value.times || []).join(',') : '09:00';
       const cron = kind === 'cron' ? (value.cron || '') : '30 9 * * 1-5';
       const selectedDays = new Set(kind === 'times' ? (value.days || []) : []);
-      const days = ['mon','tue','wed','thu','fri','sat','sun'].map(d => `<label style="display:inline-flex;gap:3px;align-items:center;margin-right:6px"><input type="checkbox" data-cadence-day="${mode}" value="${d}" ${selectedDays.size===0 || selectedDays.has(d) ? 'checked' : ''} onchange="cadenceChanged('${mode}')">${d}</label>`).join('');
+      const days = ['mon','tue','wed','thu','fri','sat','sun'].map(d => `<label style="display:inline-flex;gap:3px;align-items:center;margin-right:6px"><input type="checkbox" data-cadence-day="${mode}" value="${d}" ${selectedDays.size===0 || selectedDays.has(d) ? 'checked' : ''} data-change-action="cadenceChanged" data-arg0="${mode}">${d}</label>`).join('');
       return `<div class="config-field" style="border:1px solid var(--border);border-radius:8px;padding:10px">
         <label>${mode[0].toUpperCase()+mode.slice(1)} cadence</label>
         <div style="display:flex;gap:6px;flex-wrap:wrap;margin:4px 0 8px">
-          <button type="button" onclick="cadenceSetPreset('${mode}','daily')">Daily at…</button>
-          <button type="button" onclick="cadenceSetPreset('${mode}','weekdays')">Weekdays at…</button>
-          <button type="button" onclick="cadenceSetPreset('${mode}','hours')">Every N hours</button>
+          <button type="button" data-action="cadenceSetPreset" data-arg0="${mode}" data-arg1="daily">Daily at…</button>
+          <button type="button" data-action="cadenceSetPreset" data-arg0="${mode}" data-arg1="weekdays">Weekdays at…</button>
+          <button type="button" data-action="cadenceSetPreset" data-arg0="${mode}" data-arg1="hours">Every N hours</button>
         </div>
-        <select id="cad-${mode}-kind" onchange="cadenceChanged('${mode}');renderConfigTab(_configState.tab)"><option value="interval" ${kind==='interval'?'selected':''}>Interval</option><option value="times" ${kind==='times'?'selected':''}>Times</option><option value="cron" ${kind==='cron'?'selected':''}>Custom cron</option></select>
-        ${kind === 'interval' ? `<input id="cad-${mode}-interval" type="text" value="${esc(interval)}" placeholder="30m, 4h, 0=off" onchange="cadenceChanged('${mode}')">` : ''}
-        ${kind === 'times' ? `<input id="cad-${mode}-times" type="text" value="${esc(times)}" placeholder="09:00,17:00" onchange="cadenceChanged('${mode}')"><div style="margin-top:6px">${days}</div>` : ''}
-        ${kind === 'cron' ? `<input id="cad-${mode}-cron" type="text" value="${esc(cron)}" placeholder="30 9 * * 1-5" onchange="cadenceChanged('${mode}')"><div style="font-size:.7rem;color:var(--muted)">5-field cron. Timezone saved from this browser: ${esc(browserTimeZone())}</div>` : ''}
+        <select id="cad-${mode}-kind" data-change-action="gh39" data-arg0="${mode}"><option value="interval" ${kind==='interval'?'selected':''}>Interval</option><option value="times" ${kind==='times'?'selected':''}>Times</option><option value="cron" ${kind==='cron'?'selected':''}>Custom cron</option></select>
+        ${kind === 'interval' ? `<input id="cad-${mode}-interval" type="text" value="${esc(interval)}" placeholder="30m, 4h, 0=off" data-change-action="cadenceChanged" data-arg0="${mode}">` : ''}
+        ${kind === 'times' ? `<input id="cad-${mode}-times" type="text" value="${esc(times)}" placeholder="09:00,17:00" data-change-action="cadenceChanged" data-arg0="${mode}"><div style="margin-top:6px">${days}</div>` : ''}
+        ${kind === 'cron' ? `<input id="cad-${mode}-cron" type="text" value="${esc(cron)}" placeholder="30 9 * * 1-5" data-change-action="cadenceChanged" data-arg0="${mode}"><div style="font-size:.7rem;color:var(--muted)">5-field cron. Timezone saved from this browser: ${esc(browserTimeZone())}</div>` : ''}
         <div id="cad-${mode}-summary" style="font-size:.72rem;color:var(--muted);margin-top:6px">${esc(cadenceSummary(value))}</div>
       </div>`;
     }
@@ -17368,7 +17439,7 @@ function burnAreaChart() {
           ${preList || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">None configured</div>'}
           <div class="config-list-add">
             <input type="text" id="cfg-pre-kick-input" placeholder="script path" title="Absolute path to a shell script to run before each kick">
-            <button onclick="addListItem('hooks','preKick','cfg-pre-kick-input')" title="Add this script to the pre-kick hook list">+ Add</button>
+            <button data-action="addListItem" data-arg0="hooks" data-arg1="preKick" data-arg2="cfg-pre-kick-input" title="Add this script to the pre-kick hook list">+ Add</button>
           </div>
         </div>
         <div class="config-list">
@@ -17376,7 +17447,7 @@ function burnAreaChart() {
           ${postList || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">None configured</div>'}
           <div class="config-list-add">
             <input type="text" id="cfg-post-idle-input" placeholder="script path" title="Absolute path to a shell script to run after the agent returns to idle">
-            <button onclick="addListItem('hooks','postIdle','cfg-post-idle-input')" title="Add this script to the post-idle hook list">+ Add</button>
+            <button data-action="addListItem" data-arg0="hooks" data-arg1="postIdle" data-arg2="cfg-post-idle-input" title="Add this script to the post-idle hook list">+ Add</button>
           </div>
         </div>`;
     }
@@ -17403,7 +17474,7 @@ function burnAreaChart() {
           h += '</div>';
           if (editable) {
             h += `<label style="font-size:0.7rem;display:flex;align-items:center;gap:4px;cursor:pointer;white-space:nowrap">`;
-            h += `<input type="checkbox" ${r.enabled !== false ? 'checked' : ''} onchange="toggleRestriction(${i}, this.checked)"> on</label>`;
+            h += `<input type="checkbox" ${r.enabled !== false ? 'checked' : ''} data-change-action="toggleRestriction" data-arg0="${i}" data-arg-types="j,c"> on</label>`;
             h += `<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" data-action="removeRestriction" data-index="${i}">✕</button>`;
           }
           h += '</div>';
@@ -17412,7 +17483,7 @@ function burnAreaChart() {
           h += `<div style="display:flex;gap:6px;margin-top:6px">`;
           h += `<input type="text" id="cfg-restriction-pattern" placeholder="glob pattern, e.g. gh issue list*" style="flex:2;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)" title="Glob pattern matching commands this agent is blocked from running. The gh wrapper enforces these restrictions.">`;
           h += `<input type="text" id="cfg-restriction-reason" placeholder="reason (optional)" style="flex:1;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)" title="Optional explanation shown when the agent hits this restriction">`;
-          h += `<button onclick="addRestriction()" style="padding:6px 12px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap" title="Add this restriction to the agent command blocklist">+ Add</button>`;
+          h += `<button data-action="addRestriction" style="padding:6px 12px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap" title="Add this restriction to the agent command blocklist">+ Add</button>`;
           h += '</div>';
         }
         h += '</div>';
@@ -17451,17 +17522,17 @@ function burnAreaChart() {
           if (ch.match) html += 'match: '+Object.entries(ch.match).map(([k,v]) => '<code>'+esc(k)+'='+esc(v)+'</code>').join(', ');
           if (ch.repos && ch.repos.length) html += ' (repos: '+ch.repos.join(', ')+')';
           html += '</div>';
-          html += '<label style="font-size:0.7rem;display:flex;align-items:center;gap:4px;cursor:pointer"><input type="checkbox" '+(enabled?'checked':'')+' onchange="toggleChannel('+i+',this.checked)"> on</label>';
-          html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeChannel('+i+')">✕</button>';
+          html += '<label style="font-size:0.7rem;display:flex;align-items:center;gap:4px;cursor:pointer"><input type="checkbox" '+(enabled?'checked':'')+' data-change-action="toggleChannel" data-arg0="+i+" data-arg-types="s,c"> on</label>';
+          html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" data-action="removeChannel" data-arg0="+i+">✕</button>';
           html += '</div>';
         }
       }
       html += '<div style="margin-top:12px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--surface)">';
       html += '<div style="font-size:0.72rem;font-weight:600;margin-bottom:8px;text-transform:uppercase;color:var(--muted)">+ Add Channel</div>';
       html += '<div style="display:flex;gap:6px;flex-wrap:wrap;align-items:end">';
-      html += '<div><label style="font-size:0.7rem;color:var(--muted)">Type</label><select id="ch-add-type" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)" onchange="channelTypeChanged()">'+CHANNEL_TYPES.map(t => '<option value="'+t+'">'+t+'</option>').join('')+'</select></div>';
+      html += '<div><label style="font-size:0.7rem;color:var(--muted)">Type</label><select id="ch-add-type" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)" data-change-action="channelTypeChanged">'+CHANNEL_TYPES.map(t => '<option value="'+t+'">'+t+'</option>').join('')+'</select></div>';
       html += '<div id="ch-add-fields" style="display:flex;gap:6px;flex:1;flex-wrap:wrap"></div>';
-      html += '<button onclick="addChannel()" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap;height:32px">Add</button>';
+      html += '<button data-action="addChannel" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap;height:32px">Add</button>';
       html += '</div></div>';
       setTimeout(channelTypeChanged, 0);
       return html;
@@ -17538,8 +17609,8 @@ function burnAreaChart() {
     function renderAgentTools(tools) {
       let html = '<div style="font-size:0.78rem;color:var(--muted);line-height:1.55;background:color-mix(in srgb, var(--accent) 7%, transparent);border:1px solid color-mix(in srgb, var(--accent) 22%, transparent);border-radius:6px;padding:10px 12px;margin-bottom:14px"><b>What this is.</b> The agent\'s tool-permission tier (advisory, issues-only, issues-prs, or full) plus per-tool allow/deny overrides. <b>Why use it.</b> It controls which MCP tools the agent can call, letting you grant or withhold write actions like creating PRs or merging. <b>Where it shows up.</b> When set, these declarative permissions override the Mode-based restrictions from the General tab. <b>How to configure.</b> Pick a preset, then add rules for exceptions; an explicit allow rule overrides a deny that the preset would otherwise apply.</div>';
       if (!tools) {
-        html += '<div style="font-size:0.8rem;color:var(--muted);padding:16px 0;text-align:center;border:1px dashed var(--border);border-radius:8px">No explicit tool config — using Mode-based restrictions from the General tab. <a href="#" onclick="switchConfigTab(\'General\');return false" style="color:var(--accent)">Go to General</a></div>';
-        html += '<div style="margin-top:12px;text-align:center"><button onclick="enableToolsConfig()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem">Enable Declarative Tools</button></div>';
+        html += '<div style="font-size:0.8rem;color:var(--muted);padding:16px 0;text-align:center;border:1px dashed var(--border);border-radius:8px">No explicit tool config — using Mode-based restrictions from the General tab. <a href="#" data-action="switchConfigTab" data-arg0="General" data-prevent="1" style="color:var(--accent)">Go to General</a></div>';
+        html += '<div style="margin-top:12px;text-align:center"><button data-action="enableToolsConfig" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem">Enable Declarative Tools</button></div>';
         return html;
       }
       const preset = tools.preset || '';
@@ -17548,7 +17619,7 @@ function burnAreaChart() {
       html += '<div style="display:flex;gap:6px;flex-wrap:wrap">';
       TOOL_PRESETS.forEach(p => {
         const active = preset === p;
-        html += '<button onclick="setToolPreset(\''+p+'\')" style="padding:6px 14px;border-radius:16px;font-size:0.75rem;cursor:pointer;border:1px solid '+(active?'var(--accent)':'var(--border)')+';background:'+(active?'var(--accent)':'var(--surface)')+';color:'+(active?'#fff':'var(--fg)')+';font-weight:'+(active?'600':'400')+'">'+p+'</button>';
+        html += '<button data-action="setToolPreset" data-arg0="'+p+'" style="padding:6px 14px;border-radius:16px;font-size:0.75rem;cursor:pointer;border:1px solid '+(active?'var(--accent)':'var(--border)')+';background:'+(active?'var(--accent)':'var(--surface)')+';color:'+(active?'#fff':'var(--fg)')+';font-weight:'+(active?'600':'400')+'">'+p+'</button>';
       });
       html += '</div>';
       if (preset && TOOL_PRESET_DENIES[preset]) {
@@ -17574,14 +17645,14 @@ function burnAreaChart() {
         html += '<div style="flex:1"><code style="font-size:0.75rem">'+esc(r.pattern)+'</code>';
         if (r.reason) html += '<div style="font-size:0.7rem;color:var(--muted);margin-top:2px">'+esc(r.reason)+'</div>';
         html += '</div>';
-        html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeToolRule('+i+')">✕</button>';
+        html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" data-action="removeToolRule" data-arg0="+i+">✕</button>';
         html += '</div>';
       });
       html += '<div style="display:flex;gap:6px;margin-top:6px;flex-wrap:wrap;align-items:end">';
       html += '<input type="text" id="tool-rule-pattern" placeholder="mcp__github__delete_*" style="flex:2;min-width:180px;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">';
       html += '<select id="tool-rule-action" style="padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)"><option value="deny">deny</option><option value="allow">allow</option></select>';
       html += '<input type="text" id="tool-rule-reason" placeholder="reason (optional)" style="flex:1;min-width:100px;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">';
-      html += '<button onclick="addToolRule()" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap">+ Add</button>';
+      html += '<button data-action="addToolRule" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap">+ Add</button>';
       html += '</div></div>';
       return html;
     }
@@ -17644,7 +17715,7 @@ function burnAreaChart() {
           if (c.uri) html += '<div style="font-size:0.72rem;color:var(--muted);font-family:var(--font-mono);overflow:hidden;text-overflow:ellipsis;max-width:400px" title="'+esc(c.uri)+'">'+esc(c.uri)+'</div>';
           if (c.auth) html += '<div style="font-size:0.68rem;color:var(--muted)">🔒 '+esc(c.auth.type)+': '+(c.auth.env_var||c.auth.file||'')+'</div>';
           html += '</div>';
-          html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeConnection('+i+')">✕</button>';
+          html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" data-action="removeConnection" data-arg0="+i+">✕</button>';
           html += '</div>';
         });
       }
@@ -17654,7 +17725,7 @@ function burnAreaChart() {
       html += '<div><label style="font-size:0.7rem;color:var(--muted)">Name</label><input id="conn-add-name" type="text" placeholder="jira-api" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:100px"></div>';
       html += '<div><label style="font-size:0.7rem;color:var(--muted)">Type</label><select id="conn-add-type" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">'+CONN_TYPES.map(t => '<option value="'+t+'">'+t+'</option>').join('')+'</select></div>';
       html += '<div><label style="font-size:0.7rem;color:var(--muted)">URI</label><input id="conn-add-uri" type="text" placeholder="stdio:///usr/local/bin/mcp-github" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:250px"></div>';
-      html += '<button onclick="addConnection()" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap;height:32px">Add</button>';
+      html += '<button data-action="addConnection" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap;height:32px">Add</button>';
       html += '</div></div>';
       return html;
     }
@@ -17762,7 +17833,7 @@ function burnAreaChart() {
       }
 
       const varPickerItems = TEMPLATE_VARS.map(v =>
-        '<button onclick="insertTemplateVar(\'' + v.name.replace(/'/g, "\\'") + '\')" style="display:flex;align-items:center;gap:6px;padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;cursor:pointer;font-size:0.7rem;color:var(--text);white-space:nowrap" title="' + esc(v.desc) + '">'
+        '<button data-action="insertTemplateVar" data-arg0="' + esc(v.name) + '" style="display:flex;align-items:center;gap:6px;padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;cursor:pointer;font-size:0.7rem;color:var(--text);white-space:nowrap" title="' + esc(v.desc) + '">'
         + '<code style="color:var(--cyan);font-size:0.68rem">' + esc(v.name) + '</code>'
         + '<span style="color:var(--muted)">' + esc(v.desc) + '</span>'
         + '</button>'
@@ -17790,16 +17861,16 @@ function burnAreaChart() {
             <input type="checkbox" id="pt-ps-keep-linked" style="width:auto;margin:0"${ps.owner ? ' checked' : ''}>
             <span>Keep linked to repo (live) <span style="color:var(--muted)">— resolve the prompt at kick time so repo edits propagate. Unchecked: fetch once and bake a static copy.</span></span>
           </label>
-          <button onclick="importPromptFromRepo()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Import Prompt</button>
+          <button data-action="importPromptFromRepo" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Import Prompt</button>
         </details>
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Kick template with <code>$​{VAR}</code> placeholders. Edit the raw template or preview with variables expanded.</p>
         <div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">
-          <button id="prompt-btn-edit" onclick="switchPromptMode('edit')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--green);color:var(--bg)">Edit</button>
-          <button id="prompt-btn-preview" onclick="switchPromptMode('preview')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Preview</button>
+          <button id="prompt-btn-edit" data-action="switchPromptMode" data-arg0="edit" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--green);color:var(--bg)">Edit</button>
+          <button id="prompt-btn-preview" data-action="switchPromptMode" data-arg0="preview" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Preview</button>
           <div style="flex:1"></div>
           <span style="font-size:0.68rem;color:var(--muted);align-self:center">Edits are saved by the <strong style="color:var(--text)">Save</strong> button below.</span>
         </div>
-        <textarea id="${editorId}" oninput="markPromptTemplateDirty(this)" style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain" placeholder="Enter your agent's kick template here. Use \${VARIABLE} placeholders from the picker below.">${agentName ? '' : ''}</textarea>
+        <textarea id="${editorId}" data-input-action="markPromptTemplateDirty" data-arg-types="t" style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain" placeholder="Enter your agent's kick template here. Use \${VARIABLE} placeholders from the picker below.">${agentName ? '' : ''}</textarea>
         <div id="${previewId}" class="config-pre config-pre-fill" style="display:none;flex:1;min-height:300px;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain"></div>
         <div style="margin-top:8px;flex-shrink:0">
           <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Variable Picker <span style="font-weight:400;color:var(--muted)">(click to insert at cursor)</span></div>
@@ -17962,8 +18033,8 @@ function burnAreaChart() {
       return '<div style="display:flex;flex-direction:column;height:100%">'
         + '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Portable agent definition in YAML format. Use this to share agents across hive instances.</p>'
         + '<div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">'
-        + '<button onclick="copyExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Copy to Clipboard</button>'
-        + '<button onclick="downloadExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
+        + '<button data-action="copyExportYaml" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Copy to Clipboard</button>'
+        + '<button data-action="downloadExportYaml" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
         + '</div>'
         + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--terminal-bg);color:var(--terminal-fg);border:1px solid var(--terminal-line);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
         + '</div>';
@@ -18243,8 +18314,8 @@ function burnAreaChart() {
         <div class="config-field">
           <label>Hive ID <span class="config-info">i<span class="config-tooltip">Unique identifier for this hive instance. Stamped into beads and available as \${HIVE_ID} in agent CLAUDE.md templates. Persists across container restarts.</span></span></label>
           <div style="display:flex;gap:8px;align-items:center">
-            <input type="text" id="cfg-hive-id" value="${esc(currentId)}" placeholder="hive-xxxxxxxx" style="flex:1" oninput="markDirty('general','hiveId',this.value)">
-            <button onclick="saveHiveId()" style="font-size:0.75rem;padding:6px 14px;background:var(--green);color:var(--bg);border:none;border-radius:6px;cursor:pointer;font-weight:600">Save</button>
+            <input type="text" id="cfg-hive-id" value="${esc(currentId)}" placeholder="hive-xxxxxxxx" style="flex:1" data-input-action="markDirty" data-arg0="general" data-arg1="hiveId" data-arg-types="s,s,v">
+            <button data-action="saveHiveId" style="font-size:0.75rem;padding:6px 14px;background:var(--green);color:var(--bg);border:none;border-radius:6px;cursor:pointer;font-weight:600">Save</button>
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Format: hive-adjective-noun (e.g. hive-bold-hawk). Changes take effect immediately.</span>
         </div>
@@ -18252,24 +18323,24 @@ function burnAreaChart() {
           <label>Maturity Level <span class="config-info">i<span class="config-tooltip">ACMM (AI-native Continuous Maturity Model) level — controls which agents run and how autonomous they are, from advisory-only (L1) to fully autonomous (L6).</span></span></label>
           <div style="display:flex;gap:10px;align-items:center">
             <span style="display:inline-block;padding:3px 12px;border-radius:999px;font-size:0.75rem;font-weight:700;background:color-mix(in srgb, var(--amber) 14%, transparent);border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);color:var(--amber)">${currentACMMLevel > 0 ? acmmLevelLabel(currentACMMLevel) : 'Not set'}</span>
-            <button class="btn" onclick="closeConfigDialog();openACMMDialog()" title="Open the ACMM maturity level selector">Change&hellip;</button>
+            <button class="btn" data-action="gh41" title="Open the ACMM maturity level selector">Change&hellip;</button>
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Each level applies a curated agent pack. Change&hellip; opens the level selector.</span>
           <div style="margin-top:8px">${securityPostureStripHtml()}</div>
         </div>
         <div class="config-field" style="margin-top:14px">
           <label>Eval interval (seconds) <span class="config-info">i<span class="config-tooltip">How often the governor evaluates the hive (sensing, mode ladder, agent kicks). Default 60. Lower = more responsive, more API calls.</span></span></label>
-          <input type="number" min="10" max="86400" value="${evalInterval || ''}" placeholder="60" onchange="saveGovGeneralAdvanced('eval_interval_s', this.value === '' ? null : parseInt(this.value,10))" style="width:140px">
+          <input type="number" min="10" max="86400" value="${evalInterval || ''}" placeholder="60" data-change-action="gh70" style="width:140px">
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Changes take effect on next restart.</span>
         </div>
         <div class="config-toggle" style="margin-top:14px">
-          <div class="config-toggle-switch ${attribOn ? 'on' : ''}" onclick="toggleAttributionTrailer(this)"></div>
+          <div class="config-toggle-switch ${attribOn ? 'on' : ''}" data-action="toggleAttributionTrailer" data-arg-types="t"></div>
           <span class="config-toggle-label">Show attribution trailer on PRs/issues <span class="config-info">i<span class="config-tooltip">Append attribution trailer (agent, backend, model) to agent-created PRs and issues &mdash; audit log always records regardless. Hive-wide: one setting for all agents.</span></span></span>
         </div>
         <div class="config-field" style="border-top:1px solid var(--border);margin-top:18px;padding-top:16px">
           <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap">
             <div class="config-toggle" style="margin:0">
-              <div class="config-toggle-switch ${trajOn ? 'on' : ''}" onclick="toggleTrajectoryReview(this)"></div>
+              <div class="config-toggle-switch ${trajOn ? 'on' : ''}" data-action="toggleTrajectoryReview" data-arg-types="t"></div>
               <span class="config-toggle-label" style="font-weight:600">Trajectory Review</span>
             </div>
             <span style="font-family:monospace;font-size:0.72rem;padding:2px 10px;border-radius:999px;background:color-mix(in srgb, ${trajStatusColor} 14%, transparent);border:1px solid color-mix(in srgb, ${trajStatusColor} 45%, transparent);color:${trajStatusColor}">${esc(trajStatus)}</span>
@@ -18285,22 +18356,22 @@ function burnAreaChart() {
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:14px">
             <div>
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Reviewer model <span class="config-info">i<span class="config-tooltip">Model id sent to the reviewer endpoint. Empty = the Governor's LiteLLM default model. A cheap-but-capable model is right; a tiny model gives weaker verdicts (fails open, so it catches less rather than false-pausing).</span></span></label>
-              <input type="text" value="${esc(traj.model || '')}" placeholder="${esc(trajModel || 'litellm default')}" onchange="saveTrajectoryField('model', this.value)" style="width:100%">
+              <input type="text" value="${esc(traj.model || '')}" placeholder="${esc(trajModel || 'litellm default')}" data-change-action="saveTrajectoryField" data-arg0="model" data-arg-types="s,v" style="width:100%">
             </div>
             <div>
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Review interval (sec) <span class="config-info">i<span class="config-tooltip">How often the lane reviews running agents. Floored by the Governor eval interval. Empty/0 = default (600s).</span></span></label>
-              <input type="number" min="0" value="${trajInterval || ''}" placeholder="600" onchange="saveTrajectoryField('intervalS', this.value === '' ? 0 : parseInt(this.value,10))" style="width:100%">
+              <input type="number" min="0" value="${trajInterval || ''}" placeholder="600" data-change-action="gh42" style="width:100%">
             </div>
             <div style="grid-column:1 / -1">
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Reviewer endpoint <span class="config-info">i<span class="config-tooltip">OpenAI-compatible base URL for the reviewer (LiteLLM / vLLM / llm-d). Empty = inherit the Governor's LiteLLM endpoint. The API key is inherited from LiteLLM or set in hive.yaml (governor.trajectory.api_key_env/api_key_file); a bare vLLM server needs none.</span></span></label>
-              <input type="text" value="${esc(traj.endpoint || '')}" placeholder="${trajEndpoint ? esc(trajEndpoint) + '  (inherited from LiteLLM)' : 'https://litellm-or-vllm-or-llmd:port'}" onchange="saveTrajectoryField('endpoint', this.value)" style="width:100%">
+              <input type="text" value="${esc(traj.endpoint || '')}" placeholder="${trajEndpoint ? esc(trajEndpoint) + '  (inherited from LiteLLM)' : 'https://litellm-or-vllm-or-llmd:port'}" data-change-action="saveTrajectoryField" data-arg0="endpoint" data-arg-types="s,v" style="width:100%">
               <span style="font-size:0.62rem;margin-top:3px;display:block;color:${trajOn && !trajEndpoint ? 'var(--amber)' : 'var(--muted)'}">Resolved: ${trajEndpoint ? esc(trajEndpoint) + ' (' + esc(traj.endpointSource || '') + (traj.hasKey ? ', key set' : ', no key') + ')' : (trajOn ? 'none — Trajectory Review is ON but no agents are being reviewed. Set an endpoint above (or a Governor LiteLLM endpoint) to activate it.' : 'none — reviewer will not run')}</span>
             </div>
             <div style="grid-column:1 / -1">
               <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">On divergence</label>
               <div style="display:flex;gap:14px;font-size:0.8rem">
-                <label style="display:flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="traj-div" ${trajDiv === 'pause' ? 'checked' : ''} onchange="saveTrajectoryField('onDivergence','pause')"> Pause the agent &amp; alert</label>
-                <label style="display:flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="traj-div" ${trajDiv === 'alert' ? 'checked' : ''} onchange="saveTrajectoryField('onDivergence','alert')"> Alert only (don't pause)</label>
+                <label style="display:flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="traj-div" ${trajDiv === 'pause' ? 'checked' : ''} data-change-action="saveTrajectoryField" data-arg0="onDivergence" data-arg1="pause"> Pause the agent &amp; alert</label>
+                <label style="display:flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="traj-div" ${trajDiv === 'alert' ? 'checked' : ''} data-change-action="saveTrajectoryField" data-arg0="onDivergence" data-arg1="alert"> Alert only (don't pause)</label>
               </div>
               <span style="font-size:0.62rem;color:var(--muted);margin-top:3px;display:block">Start in alert-only to calibrate on your agents, then switch to pause. Changes take effect on next restart.</span>
             </div>
@@ -18427,7 +18498,7 @@ function burnAreaChart() {
             <option value="">blank</option>
             ${agents.map(a => { const name = typeof a === 'string' ? a : (a && a.name) || ''; return '<option value="' + esc(name) + '">copy ' + esc(name) + '</option>'; }).join('')}
           </select>
-          <button onclick="addAgent()" title="Create the new agent with the specified name and optional copied config">+ Add Agent</button>
+          <button data-action="addAgent" title="Create the new agent with the specified name and optional copied config">+ Add Agent</button>
         </div>`;
     }
 
@@ -18461,7 +18532,7 @@ function burnAreaChart() {
       return `
         <div class="config-field" style="margin-bottom:20px">
           <label title="How issue/PR thresholds scale as repo count grows. Square-root is recommended for large hives.">Multi-repo threshold scaling <span class="config-info">i<span class="config-tooltip">How issue/PR thresholds scale as repo count grows. Square-root is recommended for large hives.</span></span></label>
-          <select id="cfg-threshold-scaling" onchange="markDirty('threshold-scaling','thresholdScaling',this.value)">
+          <select id="cfg-threshold-scaling" data-change-action="markDirty" data-arg0="threshold-scaling" data-arg1="thresholdScaling" data-arg-types="s,s,v">
             ${[['linear', 'Linear'], ['sqrt', 'Square-root (default)'], ['none', 'None']]
               .map(([v, label]) => `<option value="${v}" ${activeScaling === v ? 'selected' : ''}>${label}</option>`).join('')}
           </select>
@@ -18494,9 +18565,10 @@ function burnAreaChart() {
           </div>
         </div>
         <div class="config-field-row" style="margin-top:24px">
-          <div class="config-field"><label title="Number of actionable issues at which the governor transitions from idle to quiet mode. Below this count, agents run at their idle cadence.">Quiet</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-quiet" value="${q}" oninput="setThreshFromInput('quiet',this.value)"></div>
-          <div class="config-field"><label title="Number of actionable issues at which the governor transitions from quiet to busy mode. Agents increase their kick frequency to handle the growing workload.">Busy</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-busy" value="${b}" oninput="setThreshFromInput('busy',this.value)"></div>
-          <div class="config-field"><label title="Number of actionable issues at which the governor transitions from busy to surge mode. Maximum agent activity — monitor your token budget closely at this level.">Surge</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-surge" value="${s}" oninput="setThreshFromInput('surge',this.value)"></div>
+          <div class="config-field"><label title="Number of actionable issues at which the governor transitions from idle to quiet mode. Below this count, agents run at their idle cadence.">Quiet</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-quiet" value="${q}" data-input-action="setThreshFromInput" data-arg0="quiet" data-arg-types="s,v"></div>
+          <div class="config-field"><label title="Number of actionable issues at which the governor transitions from quiet to busy mode. Agents increase their kick frequency to handle the growing workload.">Busy</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-busy" value="${b}" data-input-action="setThreshFromInput" data-arg0="busy" data-arg-types="s,v"></div>
+          <div class="config-field"><label title="Number of actionable issues at which the governor transitions from busy to surge mode. Maximum agent activity — monitor your token budget closely at this level.">Surge</label><input type="number" min="1" max="${THRESH_BAR_MAX}" id="thresh-in-surge" value="${s}" data-input-action="setThreshFromInput" data-arg0="surge" data-arg-types="s,v"></div>
+
         </div>`;
     }
 
@@ -18572,14 +18644,14 @@ function burnAreaChart() {
         `<div class="config-list-item" style="opacity:0.7"><span>${esc(l)}</span><span style="font-size:0.65rem;color:var(--muted);margin-left:auto;margin-right:8px">permanent</span></div>`
       ).join('');
       const list = labels.map((l, i) =>
-        `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" onclick="removeListItem('labels','list',${i})">✕</button></div>`
+        `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" data-action="removeListItem" data-arg0="labels" data-arg1="list" data-arg2="${i}" data-arg-types="s,s,j">✕</button></div>`
       ).join('');
       // Required labels (allow-list) — the OPPOSITE polarity from the exempt
       // list above: exempt = "never touch these", required = "ONLY touch
       // these". Stored as project.issue_filter.require_labels and enforced at
       // the actionable scan, not just in prompts.
       const reqList = (requireLabels || []).map((l, i) =>
-        `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" onclick="removeListItem('labels','require',${i})">✕</button></div>`
+        `<div class="config-list-item"><span>${esc(l)}</span><button class="remove-item" data-action="removeListItem" data-arg0="labels" data-arg1="require" data-arg2="${i}" data-arg-types="s,s,j">✕</button></div>`
       ).join('');
       return `
         <h4 style="margin:0 0 6px">Exempt labels (deny-list)</h4>
@@ -18591,7 +18663,7 @@ function burnAreaChart() {
           ${list || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No additional exempt labels</div>'}
           <div class="config-list-add">
             <input type="text" id="cfg-label-input" placeholder="label name" title="GitHub label name to exempt from actionable issues and mergeable PRs.">
-            <button onclick="addListItem('labels','list','cfg-label-input')" title="Add this label to the exempt list">+ Add</button>
+            <button data-action="addListItem" data-arg0="labels" data-arg1="list" data-arg2="cfg-label-input" title="Add this label to the exempt list">+ Add</button>
           </div>
         </div>
         <h4 style="margin:18px 0 6px">Required labels (allow-list)</h4>
@@ -18600,7 +18672,7 @@ function burnAreaChart() {
           ${reqList || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No required labels — agents may work every actionable issue</div>'}
           <div class="config-list-add">
             <input type="text" id="cfg-require-label-input" placeholder="label name" title="GitHub label an issue must carry before agents may work it (e.g. an approval/queue label).">
-            <button onclick="addListItem('labels','require','cfg-require-label-input')" title="Add this label to the required (allow) list">+ Add</button>
+            <button data-action="addListItem" data-arg0="labels" data-arg1="require" data-arg2="cfg-require-label-input" title="Add this label to the required (allow) list">+ Add</button>
           </div>
         </div>`;
     }
@@ -18641,7 +18713,7 @@ function burnAreaChart() {
           : 'Set as default repo for advisory issue';
         // Fully forge-qualified so the row is unambiguous: github.ibm.com/org/repo.
         const displayName = ghHost + '/' + r;
-        return `<div class="config-list-item" style="align-items:center;gap:6px"><span onclick="setDefaultRepo('${esc(r)}')" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(displayName)}">${esc(displayName)}</span><span style="${pillBase}" title="${pillTitle}">${pillLabel}</span><button class="remove-item" onclick="removeListItem('repos','list',${i})">&#x2715;</button></div>`;
+        return `<div class="config-list-item" style="align-items:center;gap:6px"><span data-action="setDefaultRepo" data-arg0="${esc(r)}" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(displayName)}">${esc(displayName)}</span><span style="${pillBase}" title="${pillTitle}">${pillLabel}</span><button class="remove-item" data-action="removeListItem" data-arg0="repos" data-arg1="list" data-arg2="${i}" data-arg-types="s,s,j">&#x2715;</button></div>`;
       }).join('');
       const hostNote = isGHE
         ? ` on <strong style="color:var(--indigo)">${esc(ghHost)}</strong> (GitHub Enterprise)`
@@ -18666,9 +18738,9 @@ function burnAreaChart() {
           <div class="config-list-add" style="align-items:stretch">
             <div style="display:flex;flex:1;min-width:0;align-items:stretch;border:1px solid var(--border);border-radius:6px;overflow:hidden">
               <span style="display:inline-flex;align-items:center;padding:0 8px;background:color-mix(in srgb, ${prefixColor} 12%, var(--surface));color:${prefixColor};font-size:0.78rem;font-weight:600;white-space:nowrap;border-right:1px solid var(--border)" title="This hive's forge — every repo must live on ${esc(ghHost)}">${esc(ghHost)}/</span>
-              <input type="text" id="cfg-repo-input" style="flex:1;min-width:0;border:none;border-radius:0" placeholder="org/repo" onkeydown="if(event.key==='Enter'){event.preventDefault();addListItem('repos','list','cfg-repo-input');}" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
+              <input type="text" id="cfg-repo-input" style="flex:1;min-width:0;border:none;border-radius:0" placeholder="org/repo" data-keydown-action="addListItem" data-arg0="repos" data-arg1="list" data-arg2="cfg-repo-input" data-prevent="1" data-keys="Enter" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
             </div>
-            <button onclick="addListItem('repos','list','cfg-repo-input')" title="Add this repository to the monitored list">+ Add</button>
+            <button data-action="addListItem" data-arg0="repos" data-arg1="list" data-arg2="cfg-repo-input" title="Add this repository to the monitored list">+ Add</button>
           </div>
           <div id="cfg-repo-add-status" style="font-size:0.72rem;margin-top:6px"></div>
           ${defaultWarn}
@@ -18686,12 +18758,12 @@ function burnAreaChart() {
       loadBudgetExemptions();
       return `
         <div class="config-field-row">
-          <div class="config-field"><label>Total Tokens <span class="config-info">i<span class="config-tooltip">Maximum token budget for the period. When usage approaches this limit, the governor will downgrade models or skip low-priority kicks. Set to 0 to disable budget tracking.</span></span></label><input type="number" value="${b.totalTokens || 0}" onchange="markDirty('budget','totalTokens',Number(this.value))"></div>
-          <div class="config-field"><label>Period (days) <span class="config-info">i<span class="config-tooltip">Rolling window length in days for token budget accounting. Default is 7 (weekly). The budget resets at the end of each period.</span></span></label><input type="number" value="${b.periodDays || 7}" onchange="markDirty('budget','periodDays',Number(this.value))"></div>
+          <div class="config-field"><label>Total Tokens <span class="config-info">i<span class="config-tooltip">Maximum token budget for the period. When usage approaches this limit, the governor will downgrade models or skip low-priority kicks. Set to 0 to disable budget tracking.</span></span></label><input type="number" value="${b.totalTokens || 0}" data-change-action="gh43"></div>
+          <div class="config-field"><label>Period (days) <span class="config-info">i<span class="config-tooltip">Rolling window length in days for token budget accounting. Default is 7 (weekly). The budget resets at the end of each period.</span></span></label><input type="number" value="${b.periodDays || 7}" data-change-action="gh44"></div>
         </div>
         <div class="config-field">
           <label>Critical Percent <span class="config-info">i<span class="config-tooltip">When token usage exceeds this percentage of the total budget, the governor enters budget-critical mode: downgrading models to cheaper alternatives and potentially skipping non-essential kicks. Default is 90%.</span></span></label>
-          <input type="number" value="${b.criticalPct || 90}" onchange="markDirty('budget','criticalPct',Number(this.value))">
+          <input type="number" value="${b.criticalPct || 90}" data-change-action="gh45">
         </div>
         <div class="config-field" style="margin-top:14px">
           <label>Per-Agent Exemptions <span class="config-info">i<span class="config-tooltip">Exempt agents keep getting kicked even while an exhausted budget suppresses everyone else. Toggles apply immediately (no Save needed). The governor panel's global "ignore budget" checkbox bypasses enforcement for ALL agents; these exemptions are per-agent.</span></span></label>
@@ -18732,7 +18804,7 @@ function burnAreaChart() {
           <span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}</span>
           <span style="color:var(--muted);font-size:0.7rem;white-space:nowrap" title="Tokens recorded for this agent by the governor's budget tracker">${burn > 0 ? burn.toLocaleString() + ' tok' : '—'}</span>
           <label style="display:flex;align-items:center;gap:4px;font-size:0.72rem;color:var(--muted);cursor:pointer;white-space:nowrap">
-            <input type="checkbox" ${exempt ? 'checked' : ''} onchange="toggleBudgetExempt('${esc(a.name)}', this.checked)" style="cursor:pointer"> exempt
+            <input type="checkbox" ${exempt ? 'checked' : ''} data-change-action="toggleBudgetExempt" data-arg0="${esc(a.name)}" data-arg-types="s,c" style="cursor:pointer"> exempt
           </label>
         </div>`;
       }).join('');
@@ -18767,15 +18839,15 @@ function burnAreaChart() {
       return `
         <div class="config-field">
           <label>Ntfy Server ${ntfyHint} <span class="config-info">i<span class="config-tooltip">URL of the ntfy.sh server for push notifications. The governor sends alerts for mode changes, budget warnings, agent crashes, and rate limits. Leave empty to disable ntfy notifications. Default: https://ntfy.sh</span></span></label>
-          <input type="text" value="${esc(n.ntfyServer || '')}" onchange="markDirty('notifications','ntfyServer',this.value)" placeholder="https://ntfy.sh">
+          <input type="text" value="${esc(n.ntfyServer || '')}" data-change-action="markDirty" data-arg0="notifications" data-arg1="ntfyServer" data-arg-types="s,s,v" placeholder="https://ntfy.sh">
         </div>
         <div class="config-field">
           <label>Ntfy Topic <span class="config-info">i<span class="config-tooltip">Topic name on the ntfy server. Subscribe to this topic in the ntfy app or web UI to receive governor notifications on your phone or desktop.</span></span></label>
-          <input type="text" value="${esc(n.ntfyTopic || '')}" onchange="markDirty('notifications','ntfyTopic',this.value)" placeholder="my-topic">
+          <input type="text" value="${esc(n.ntfyTopic || '')}" data-change-action="markDirty" data-arg0="notifications" data-arg1="ntfyTopic" data-arg-types="s,s,v" placeholder="my-topic">
         </div>
         <div class="config-field">
           <label>Discord Webhook ${discordHint} <span class="config-info">i<span class="config-tooltip">Discord webhook URL for posting governor notifications to a channel. Create a webhook in your Discord server settings under Integrations. Leave empty to disable Discord notifications.</span></span></label>
-          <input type="text" value="${n.hasDiscord ? '••••••••' : ''}" onchange="markDirty('notifications','discordWebhook',this.value)" placeholder="https://discord.com/api/webhooks/...">
+          <input type="text" value="${n.hasDiscord ? '••••••••' : ''}" data-change-action="markDirty" data-arg0="notifications" data-arg1="discordWebhook" data-arg-types="s,s,v" placeholder="https://discord.com/api/webhooks/...">
         </div>`;
     }
 
@@ -18802,28 +18874,28 @@ function burnAreaChart() {
         const fieldOptions = (sources[s.source] || {}).fields || [];
         return `<div class="config-stat-row" data-idx="${i}">
           <div class="config-field-row" style="margin-bottom:4px;align-items:center">
-            <div class="config-field" style="flex:0.7"><label title="Display name shown on the agent card for this metric">Label</label><input type="text" value="${esc(s.label || '')}" onchange="updateStat(${i},'label',this.value)"></div>
+            <div class="config-field" style="flex:0.7"><label title="Display name shown on the agent card for this metric">Label</label><input type="text" value="${esc(s.label || '')}" data-change-action="updateStat" data-arg0="${i}" data-arg1="label" data-arg-types="j,s,v"></div>
             <div class="config-field" style="flex:0.8"><label title="Data source to pull this metric from (e.g. agentMetrics, github, budget)">Source</label>
-              <select onchange="updateStatSource(${i},this.value)" title="Changing the source resets the field to the first available option">
+              <select data-change-action="updateStatSource" data-arg0="${i}" data-arg-types="j,v" title="Changing the source resets the field to the first available option">
                 ${sourceKeys.map(k => `<option value="${k}" ${s.source === k ? 'selected' : ''}>${(sources[k] || {}).label || k}</option>`).join('')}
               </select>
             </div>
             <div class="config-field" style="flex:0.8"><label title="Specific data field from the selected source to display">Field</label>
-              <select id="stat-field-${i}" onchange="updateStat(${i},'field',this.value)">
+              <select id="stat-field-${i}" data-change-action="updateStat" data-arg0="${i}" data-arg1="field" data-arg-types="j,s,v">
                 ${fieldOptions.map(f => `<option value="${f}" ${s.field === f ? 'selected' : ''}>${f}</option>`).join('')}
               </select>
             </div>
             <div class="config-field" style="flex:0.6"><label title="Visual display style: number (raw value), dot (colored indicator), pct (percentage), pct-bar (progress bar), spark (sparkline chart)">Style</label>
-              <select onchange="updateStat(${i},'style',this.value)">
+              <select data-change-action="updateStat" data-arg0="${i}" data-arg1="style" data-arg-types="j,s,v">
                 ${styles.map(st => `<option value="${st}" ${s.style === st ? 'selected' : ''}>${st}</option>`).join('')}
               </select>
             </div>
-            <div class="config-field" style="flex:0.4"><label title="Emoji or symbol shown next to this stat on the agent card">Icon</label><input type="text" value="${esc(s.icon || '')}" onchange="updateStat(${i},'icon',this.value)" style="width:40px"></div>
-            <div class="config-field" style="flex:0.4"><label title="Target value for percentage and progress bar styles. The stat is shown as (value/target). Leave empty for raw values.">Target</label><input type="number" value="${s.target || ''}" onchange="updateStat(${i},'target',this.value ? Number(this.value) : undefined)" style="width:50px"></div>
+            <div class="config-field" style="flex:0.4"><label title="Emoji or symbol shown next to this stat on the agent card">Icon</label><input type="text" value="${esc(s.icon || '')}" data-change-action="updateStat" data-arg0="${i}" data-arg1="icon" data-arg-types="j,s,v" style="width:40px"></div>
+            <div class="config-field" style="flex:0.4"><label title="Target value for percentage and progress bar styles. The stat is shown as (value/target). Leave empty for raw values.">Target</label><input type="number" value="${s.target || ''}" data-change-action="updateStat" data-arg0="${i}" data-arg1="target" data-arg-types="j,s,V" style="width:50px"></div>
             <div style="display:flex;gap:2px;align-items:flex-end;padding-bottom:2px">
-              <button class="btn-sm" onclick="moveStatUp(${i})" title="Move up" ${i === 0 ? 'disabled' : ''}>▲</button>
-              <button class="btn-sm" onclick="moveStatDown(${i})" title="Move down" ${i === stats.length - 1 ? 'disabled' : ''}>▼</button>
-              <button class="btn-sm btn-danger" onclick="removeStat(${i})" title="Remove">✕</button>
+              <button class="btn-sm" data-action="moveStatUp" data-arg0="${i}" data-arg-types="j" title="Move up" ${i === 0 ? 'disabled' : ''}>▲</button>
+              <button class="btn-sm" data-action="moveStatDown" data-arg0="${i}" data-arg-types="j" title="Move down" ${i === stats.length - 1 ? 'disabled' : ''}>▼</button>
+              <button class="btn-sm btn-danger" data-action="removeStat" data-arg0="${i}" data-arg-types="j" title="Remove">✕</button>
             </div>
           </div>
         </div>`;
@@ -18836,7 +18908,7 @@ function burnAreaChart() {
           <b>How to configure.</b> Add a row and set its label, source, field, and style (plus an optional icon and target); reorder or remove rows as needed.
         </div>
         <div class="config-stats-list">${rows}</div>
-        <button class="btn-add" onclick="addStat()" style="margin-top:8px">+ Add Stat</button>
+        <button class="btn-add" data-action="addStat" style="margin-top:8px">+ Add Stat</button>
         <p style="color:var(--muted);font-size:0.75rem;margin-top:8px">Configure which metrics appear on this agent's card. Changes take effect after saving.</p>`;
     }
 
@@ -18896,8 +18968,8 @@ function burnAreaChart() {
     function renderGovHealth(h) {
       return `
         <div class="config-field-row">
-          <div class="config-field"><label>Healthcheck Interval (sec) <span class="config-info">i<span class="config-tooltip">How often the governor checks each agent's tmux session for liveness (responding to prompts, no crash indicators). Default is 300 seconds (5 minutes).</span></span></label><input type="number" value="${h.healthcheckInterval || 300}" onchange="markDirty('health','healthcheckInterval',Number(this.value))"></div>
-          <div class="config-field"><label>Restart Cooldown (sec) <span class="config-info">i<span class="config-tooltip">Minimum time between restart attempts for the same agent. Prevents restart loops when an agent keeps crashing. Default is 60 seconds.</span></span></label><input type="number" value="${h.restartCooldown || 60}" onchange="markDirty('health','restartCooldown',Number(this.value))"></div>
+          <div class="config-field"><label>Healthcheck Interval (sec) <span class="config-info">i<span class="config-tooltip">How often the governor checks each agent's tmux session for liveness (responding to prompts, no crash indicators). Default is 300 seconds (5 minutes).</span></span></label><input type="number" value="${h.healthcheckInterval || 300}" data-change-action="gh46"></div>
+          <div class="config-field"><label>Restart Cooldown (sec) <span class="config-info">i<span class="config-tooltip">Minimum time between restart attempts for the same agent. Prevents restart loops when an agent keeps crashing. Default is 60 seconds.</span></span></label><input type="number" value="${h.restartCooldown || 60}" data-change-action="gh47"></div>
         </div>
         <div class="config-toggle">
           <div class="config-toggle-switch ${h.modelLock ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="health" data-key="modelLock"></div>
@@ -18924,7 +18996,7 @@ function burnAreaChart() {
           <span class="config-toggle-label">Escalation breaker enabled <span class="config-info">i<span class="config-tooltip">${tip}</span></span></span>
         </div>
         <div class="config-field-row">
-          <div class="config-field"><label>Red-attempt threshold <span class="config-info">i<span class="config-tooltip">${tip}</span></span></label><input type="number" min="0" placeholder="3" value="${e.threshold || ''}" onchange="markDirty('escalation','threshold',Number(this.value))"></div>
+          <div class="config-field"><label>Red-attempt threshold <span class="config-info">i<span class="config-tooltip">${tip}</span></span></label><input type="number" min="0" placeholder="3" value="${e.threshold || ''}" data-change-action="markDirty" data-arg0="escalation" data-arg1="threshold" data-arg-types="s,s,N"></div>
         </div>`;
     }
 
@@ -18950,13 +19022,13 @@ function burnAreaChart() {
 
     function renderGovSensing(s) {
       const ghPatterns = (s.ghRatePatterns || []).map((p, i) =>
-        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" onclick="removeSensingItem('ghRatePatterns',${i})">✕</button></div>`
+        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" data-action="removeSensingItem" data-arg0="ghRatePatterns" data-arg1="${i}" data-arg-types="s,j">✕</button></div>`
       ).join('');
       const cliPatterns = (s.cliExcludePatterns || []).map((p, i) =>
-        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" onclick="removeSensingItem('cliExcludePatterns',${i})">✕</button></div>`
+        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" data-action="removeSensingItem" data-arg0="cliExcludePatterns" data-arg1="${i}" data-arg-types="s,j">✕</button></div>`
       ).join('');
       const loginPatterns = (s.loginPatterns || []).map((p, i) =>
-        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" onclick="removeSensingItem('loginPatterns',${i})">✕</button></div>`
+        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" data-action="removeSensingItem" data-arg0="loginPatterns" data-arg1="${i}" data-arg-types="s,j">✕</button></div>`
       ).join('');
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Patterns scanned in agent tmux panes to detect rate limits, CLI usage caps, and login requirements.</p>
@@ -18966,7 +19038,7 @@ function burnAreaChart() {
             ${ghPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No patterns configured</div>'}
             <div class="config-list-add">
               <input type="text" id="cfg-sensing-gh-input" placeholder="e.g. 403.*rate limit" style="font-family:var(--font-mono);font-size:0.75rem" title="Regular expression to match against agent tmux pane output. When matched, the governor triggers a rate-limit pullback for that agent.">
-              <button onclick="addSensingItem('ghRatePatterns','cfg-sensing-gh-input')" title="Add this regex pattern to the GitHub rate limit detection list">+ Add</button>
+              <button data-action="addSensingItem" data-arg0="ghRatePatterns" data-arg1="cfg-sensing-gh-input" title="Add this regex pattern to the GitHub rate limit detection list">+ Add</button>
             </div>
           </div>
         </div>
@@ -18976,7 +19048,7 @@ function burnAreaChart() {
             ${cliPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No exclude patterns</div>'}
             <div class="config-list-add">
               <input type="text" id="cfg-sensing-cli-input" placeholder="e.g. out of extra usage" style="font-family:var(--font-mono);font-size:0.75rem" title="Lines matching these patterns are filtered out before rate-limit detection. Use for known false positives in agent output.">
-              <button onclick="addSensingItem('cliExcludePatterns','cfg-sensing-cli-input')" title="Add this pattern to the CLI exclusion list">+ Add</button>
+              <button data-action="addSensingItem" data-arg0="cliExcludePatterns" data-arg1="cfg-sensing-cli-input" title="Add this pattern to the CLI exclusion list">+ Add</button>
             </div>
           </div>
         </div>
@@ -18986,13 +19058,13 @@ function burnAreaChart() {
             ${loginPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No login patterns configured</div>'}
             <div class="config-list-add">
               <input type="text" id="cfg-sensing-login-input" placeholder="e.g. session expired" style="font-family:var(--font-mono);font-size:0.75rem" title="Regular expression to match against agent tmux pane output. When matched, the agent is paused and a notification is sent prompting you to log in.">
-              <button onclick="addSensingItem('loginPatterns','cfg-sensing-login-input')" title="Add this regex pattern to the login detection list">+ Add</button>
+              <button data-action="addSensingItem" data-arg0="loginPatterns" data-arg1="cfg-sensing-login-input" title="Add this regex pattern to the login detection list">+ Add</button>
             </div>
           </div>
         </div>
         <div class="config-field-row">
-          <div class="config-field"><label>Alert TTL (sec) <span class="config-info">i<span class="config-tooltip">How long a rate-limit alert stays active before auto-clearing. Default is 900 seconds (15 minutes). After this time, the agent is considered safe to kick again.</span></span></label><input type="number" value="${s.ttlSeconds || 900}" onchange="markDirty('sensing','ttlSeconds',Number(this.value))"></div>
-          <div class="config-field"><label>Pullback Duration (sec) <span class="config-info">i<span class="config-tooltip">How long to pause an agent after detecting a rate limit. During pullback, the governor skips kicks for this agent. Default is 900 seconds (15 minutes).</span></span></label><input type="number" value="${s.pullbackSeconds || 900}" onchange="markDirty('sensing','pullbackSeconds',Number(this.value))"></div>
+          <div class="config-field"><label>Alert TTL (sec) <span class="config-info">i<span class="config-tooltip">How long a rate-limit alert stays active before auto-clearing. Default is 900 seconds (15 minutes). After this time, the agent is considered safe to kick again.</span></span></label><input type="number" value="${s.ttlSeconds || 900}" data-change-action="gh48"></div>
+          <div class="config-field"><label>Pullback Duration (sec) <span class="config-info">i<span class="config-tooltip">How long to pause an agent after detecting a rate limit. During pullback, the governor skips kicks for this agent. Default is 900 seconds (15 minutes).</span></span></label><input type="number" value="${s.pullbackSeconds || 900}" data-change-action="gh49"></div>
         </div>`;
     }
 
@@ -19004,13 +19076,13 @@ function burnAreaChart() {
           <input type="text" value="${esc(l.dir || '/data/logs')}" disabled style="opacity:0.6">
         </div>
         <div class="config-field-row">
-          <div class="config-field"><label>Max File Size (MB) <span class="config-info">i<span class="config-tooltip">Maximum size of a single log file before rotation. When reached, the current file is rotated and a new one starts. Default 50 MB.</span></span></label><input type="number" value="${l.maxSizeMB || 50}" onchange="markDirty('logging','maxSizeMB',Number(this.value))"></div>
-          <div class="config-field"><label>Retention (days) <span class="config-info">i<span class="config-tooltip">How many days to keep rotated log files. Files older than this are automatically deleted by lumberjack. Default 7 days.</span></span></label><input type="number" value="${l.maxAgeDays || 7}" onchange="markDirty('logging','maxAgeDays',Number(this.value))"></div>
+          <div class="config-field"><label>Max File Size (MB) <span class="config-info">i<span class="config-tooltip">Maximum size of a single log file before rotation. When reached, the current file is rotated and a new one starts. Default 50 MB.</span></span></label><input type="number" value="${l.maxSizeMB || 50}" data-change-action="gh50"></div>
+          <div class="config-field"><label>Retention (days) <span class="config-info">i<span class="config-tooltip">How many days to keep rotated log files. Files older than this are automatically deleted by lumberjack. Default 7 days.</span></span></label><input type="number" value="${l.maxAgeDays || 7}" data-change-action="gh51"></div>
         </div>
         <div class="config-field-row">
-          <div class="config-field"><label>Max Backups <span class="config-info">i<span class="config-tooltip">Maximum number of rotated log files to keep. Works alongside retention days — whichever limit is hit first triggers cleanup. Default 10 files.</span></span></label><input type="number" value="${l.maxBackups || 10}" onchange="markDirty('logging','maxBackups',Number(this.value))"></div>
+          <div class="config-field"><label>Max Backups <span class="config-info">i<span class="config-tooltip">Maximum number of rotated log files to keep. Works alongside retention days — whichever limit is hit first triggers cleanup. Default 10 files.</span></span></label><input type="number" value="${l.maxBackups || 10}" data-change-action="gh52"></div>
           <div class="config-field"><label>Log Level <span class="config-info">i<span class="config-tooltip">Minimum severity level for log output. DEBUG includes all messages. INFO is the default operational level. WARN and ERROR reduce noise. Takes effect on next container restart.</span></span></label>
-            <select onchange="markDirty('logging','level',this.value)">
+            <select data-change-action="markDirty" data-arg0="logging" data-arg1="level" data-arg-types="s,s,v">
               ${levels.map(lv => '<option value="' + lv + '" ' + ((l.level||'info')===lv?'selected':'') + '>' + lv.toUpperCase() + '</option>').join('')}
             </select>
           </div>
@@ -19059,11 +19131,11 @@ function burnAreaChart() {
     }
 
     function securityModelInput(key, value, placeholder) {
-      return '<input type="text" list="security-model-options" value="' + esc(value || '') + '" placeholder="' + esc(placeholder || 'model id') + '" onchange="markDirty(\'security\',\'' + key + '\',this.value.trim())">';
+      return '<input type="text" list="security-model-options" value="' + esc(value || '') + '" placeholder="' + esc(placeholder || 'model id') + '" data-change-action="markDirty" data-arg0="security" data-arg1="' + key + '" data-arg-types="s,s,w">';
     }
 
     function featureModelInput(key, value, placeholder) {
-      return '<input type="text" list="security-model-options" value="' + esc(value || '') + '" placeholder="' + esc(placeholder || 'model id') + '" onchange="markDirty(\'features\',\'' + key + '\',this.value.trim())">';
+      return '<input type="text" list="security-model-options" value="' + esc(value || '') + '" placeholder="' + esc(placeholder || 'model id') + '" data-change-action="markDirty" data-arg0="features" data-arg1="' + key + '" data-arg-types="s,s,w">';
     }
 
     function parseSecurityList(value) {
@@ -19096,8 +19168,8 @@ function burnAreaChart() {
       const classifierAdvanced = Object.prototype.hasOwnProperty.call(sec, 'ioscanClassifier')
         ? `<div class="config-field-row">
             <div class="config-field"><label>Classifier model</label>${securityModelInput('ioscanClassifierModel', (sec.ioscanClassifier || {}).model || '', 'e.g. gpt-4o-mini')}</div>
-            <div class="config-field"><label>Warn threshold</label><input type="number" min="0" max="1" step="0.01" value="${(sec.ioscanClassifier || {}).warnThreshold ?? ''}" onchange="markDirty('security','ioscanClassifierWarnThreshold',Number(this.value))"></div>
-            <div class="config-field"><label>Block threshold</label><input type="number" min="0" max="1" step="0.01" value="${(sec.ioscanClassifier || {}).blockThreshold ?? ''}" onchange="markDirty('security','ioscanClassifierBlockThreshold',Number(this.value))"></div>
+            <div class="config-field"><label>Warn threshold</label><input type="number" min="0" max="1" step="0.01" value="${(sec.ioscanClassifier || {}).warnThreshold ?? ''}" data-change-action="gh53"></div>
+            <div class="config-field"><label>Block threshold</label><input type="number" min="0" max="1" step="0.01" value="${(sec.ioscanClassifier || {}).blockThreshold ?? ''}" data-change-action="gh54"></div>
           </div>`
         : '<p style="font-size:0.72rem;color:var(--muted);margin:8px 0 0">ioscan classifier fields are not present in this v4 backend yet; this disclosure will render them automatically when the API reports support.</p>';
 
@@ -19108,7 +19180,7 @@ function burnAreaChart() {
         </div>
         <div class="config-field">
           <label>ioscan fail mode <span class="config-info">i<span class="config-tooltip">open redacts and continues; closed blocks kicks with critical injection findings.</span></span></label>
-          <select onchange="markDirty('security','ioscanFailMode',this.value)">
+          <select data-change-action="markDirty" data-arg0="security" data-arg1="ioscanFailMode" data-arg-types="s,s,v">
             <option value="open" ${failMode === 'open' ? 'selected' : ''}>open — redact and continue</option>
             <option value="closed" ${failMode === 'closed' ? 'selected' : ''}>closed — block critical findings</option>
           </select>
@@ -19138,10 +19210,10 @@ function burnAreaChart() {
         </div>
         <details style="margin:10px 0 0"><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced review gate</summary>
           <div class="config-field-row">
-            <div class="config-field"><label>Max parallel reviews</label><input type="number" min="0" max="64" value="${sec.reviewMaxParallelReviews || 0}" onchange="markDirty('security','reviewMaxParallelReviews',Number(this.value))"><span style="font-size:0.65rem;color:var(--muted)">0 uses the default (${sec.reviewMaxParallelReviews || 5}).</span></div>
-            <div class="config-field"><label>Fixer agent</label><input type="text" list="security-agent-options" value="${esc(sec.reviewFixerAgent || '')}" placeholder="scanner" onchange="markDirty('security','reviewFixerAgent',this.value.trim())"></div>
+            <div class="config-field"><label>Max parallel reviews</label><input type="number" min="0" max="64" value="${sec.reviewMaxParallelReviews || 0}" data-change-action="gh55"><span style="font-size:0.65rem;color:var(--muted)">0 uses the default (${sec.reviewMaxParallelReviews || 5}).</span></div>
+            <div class="config-field"><label>Fixer agent</label><input type="text" list="security-agent-options" value="${esc(sec.reviewFixerAgent || '')}" placeholder="scanner" data-change-action="markDirty" data-arg0="security" data-arg1="reviewFixerAgent" data-arg-types="s,s,w"></div>
           </div>
-          <div class="config-field"><label>Reviewer agents <span style="font-weight:400;color:var(--muted)">(comma-separated allowlist)</span></label><input type="text" value="${esc((sec.reviewReviewerAgents || []).join(', '))}" placeholder="leave blank to auto-detect review-capable agents" onchange="markDirty('security','reviewReviewerAgents',parseSecurityList(this.value))"></div>
+          <div class="config-field"><label>Reviewer agents <span style="font-weight:400;color:var(--muted)">(comma-separated allowlist)</span></label><input type="text" value="${esc((sec.reviewReviewerAgents || []).join(', '))}" placeholder="leave blank to auto-detect review-capable agents" data-change-action="gh56"></div>
           <p style="font-size:0.72rem;color:var(--muted);margin:6px 0 0">Review severity threshold is not present in this v4 backend config yet, so there is no safe field to persist.</p>
         </details>`;
 
@@ -19364,13 +19436,13 @@ function burnAreaChart() {
             <span class="config-toggle-label">OpenTelemetry export enabled <span class="config-info">i<span class="config-tooltip">Exports OTLP/HTTP spans for hub/agent activity. Zero overhead when off. When on, traces export to your OTLP collector — view them in Grafana/Jaeger.</span></span></span>
           </div>
           <details style="margin:10px 0 0" open><summary style="cursor:pointer;color:var(--muted);font-size:0.78rem;font-weight:600">Advanced OpenTelemetry</summary>
-            <div class="config-field"><label>Endpoint <span class="config-info">i<span class="config-tooltip">Collector endpoint (e.g. https://otel-collector:4318). Leave empty to fall back to the standard OTEL_EXPORTER_OTLP_ENDPOINT env var.</span></span></label><input type="text" value="${esc(f.tracingEndpoint || '')}" placeholder="https://otel-collector:4318" onchange="markDirty('features','tracingEndpoint',this.value.trim())"></div>
+            <div class="config-field"><label>Endpoint <span class="config-info">i<span class="config-tooltip">Collector endpoint (e.g. https://otel-collector:4318). Leave empty to fall back to the standard OTEL_EXPORTER_OTLP_ENDPOINT env var.</span></span></label><input type="text" value="${esc(f.tracingEndpoint || '')}" placeholder="https://otel-collector:4318" data-change-action="markDirty" data-arg0="features" data-arg1="tracingEndpoint" data-arg-types="s,s,w"></div>
             <div class="config-field-row">
-              <div class="config-field"><label>Service name</label><input type="text" value="${esc(f.otelServiceName || '')}" placeholder="hive" onchange="markDirty('features','otelServiceName',this.value.trim())"></div>
-              <div class="config-field"><label>Sample ratio</label><input type="number" min="0" max="1" step="0.01" value="${f.tracingSampleRatio || 0}" onchange="markDirty('features','tracingSampleRatio',Number(this.value))"><span style="font-size:0.65rem;color:var(--muted)">0 means sample all.</span></div>
+              <div class="config-field"><label>Service name</label><input type="text" value="${esc(f.otelServiceName || '')}" placeholder="hive" data-change-action="markDirty" data-arg0="features" data-arg1="otelServiceName" data-arg-types="s,s,w"></div>
+              <div class="config-field"><label>Sample ratio</label><input type="number" min="0" max="1" step="0.01" value="${f.tracingSampleRatio || 0}" data-change-action="gh57"><span style="font-size:0.65rem;color:var(--muted)">0 means sample all.</span></div>
             </div>
             <div class="config-toggle"><div class="config-toggle-switch ${f.otelInsecure ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="features" data-key="otelInsecure"></div><span class="config-toggle-label">Allow insecure OTLP transport</span></div>
-            <div class="config-field"><label>Headers <span style="font-weight:400;color:var(--muted)">(write-only, one key=value per line)</span></label><textarea rows="3" style="width:100%;resize:vertical;font-family:var(--font-mono);font-size:0.74rem" placeholder="authorization=\${OTEL_EXPORTER_TOKEN}" onchange="parseOtelHeaders(this.value)"></textarea><div style="font-size:0.68rem;color:var(--muted);margin-top:4px">${f.otelHasHeaders ? 'Headers are configured; values are never echoed back.' : 'No headers configured.'} <button type="button" onclick="markDirty('features','otelHeaders',{});showToast('OTel headers will be cleared on Save','info')" style="margin-left:8px;font-size:0.68rem;padding:2px 8px;border:1px solid var(--border);background:var(--bg);color:var(--muted);border-radius:4px;cursor:pointer">Clear saved headers</button></div></div>
+            <div class="config-field"><label>Headers <span style="font-weight:400;color:var(--muted)">(write-only, one key=value per line)</span></label><textarea rows="3" style="width:100%;resize:vertical;font-family:var(--font-mono);font-size:0.74rem" placeholder="authorization=\${OTEL_EXPORTER_TOKEN}" data-change-action="parseOtelHeaders" data-arg-types="v"></textarea><div style="font-size:0.68rem;color:var(--muted);margin-top:4px">${f.otelHasHeaders ? 'Headers are configured; values are never echoed back.' : 'No headers configured.'} <button type="button" data-action="gh58" style="margin-left:8px;font-size:0.68rem;padding:2px 8px;border:1px solid var(--border);background:var(--bg);color:var(--muted);border-radius:4px;cursor:pointer">Clear saved headers</button></div></div>
           </details>
         </div>
 
@@ -19392,7 +19464,7 @@ function burnAreaChart() {
           </div>
           <div class="config-field" style="margin-top:10px">
             <label>Issuer <span class="config-info">i<span class="config-tooltip">The 'iss' claim and the identity WIF providers are configured to trust — typically the mint's public URL.</span></span></label>
-            <input type="text" value="${esc(f.mintIssuer || '')}" placeholder="https://mint.example.com" onchange="markDirty('features','mintIssuer',this.value.trim())">
+            <input type="text" value="${esc(f.mintIssuer || '')}" placeholder="https://mint.example.com" data-change-action="markDirty" data-arg0="features" data-arg1="mintIssuer" data-arg-types="s,s,w">
             <p style="font-size:0.72rem;color:var(--muted);margin:4px 0 0">Signing key is provisioned on-disk, not here.</p>
           </div>
         </div>
@@ -19413,11 +19485,11 @@ function burnAreaChart() {
           </div>
           <div class="config-field" style="margin-top:10px">
             <label>Max merges per sweep <span class="config-info">i<span class="config-tooltip">Caps how many PRs one sweep pass may merge. 0 or empty uses the default.</span></span></label>
-            <input type="number" min="0" step="1" value="${am.max_merges || ''}" placeholder="5" onchange="markDirty('auto-merge','max_merges',Number(this.value)||0)">
+            <input type="number" min="0" step="1" value="${am.max_merges || ''}" placeholder="5" data-change-action="gh71">
           </div>
           <div class="config-field" style="margin-top:10px">
             <label>Required CI checks <span class="config-info">i<span class="config-tooltip">Comma-separated status-check/check-run names the sweep must see green before merging, e.g. build-gate. Empty falls back to the built-in allowlist.</span></span></label>
-            <input type="text" value="${esc(amChecks.join(', '))}" placeholder="build-gate, lint" onchange="markDirty('auto-merge','required_checks',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+            <input type="text" value="${esc(amChecks.join(', '))}" placeholder="build-gate, lint" data-change-action="gh72">
           </div>
         </div>
 
@@ -19433,15 +19505,15 @@ function burnAreaChart() {
           </div>
           <div class="config-field" style="margin-top:10px">
             <label>Max parallel reviews <span class="config-info">i<span class="config-tooltip">Caps how many reviewer agents run concurrently when fan-out is on. 0 or empty uses the default.</span></span></label>
-            <input type="number" min="0" step="1" value="${rv.max_parallel_reviews || ''}" placeholder="3" onchange="markDirty('review','max_parallel_reviews',Number(this.value)||0)">
+            <input type="number" min="0" step="1" value="${rv.max_parallel_reviews || ''}" placeholder="3" data-change-action="gh73">
           </div>
           <div class="config-field" style="margin-top:10px">
             <label>Reviewer agents <span class="config-info">i<span class="config-tooltip">Comma-separated agent names that review each PR, e.g. reviewer, security-reviewer.</span></span></label>
-            <input type="text" value="${esc(rvAgents.join(', '))}" placeholder="reviewer, security-reviewer" onchange="markDirty('review','reviewer_agents',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+            <input type="text" value="${esc(rvAgents.join(', '))}" placeholder="reviewer, security-reviewer" data-change-action="gh74">
           </div>
           <div class="config-field" style="margin-top:10px">
             <label>Fixer agent <span class="config-info">i<span class="config-tooltip">The agent kicked to address reviewer findings before re-review.</span></span></label>
-            <input type="text" value="${esc(rv.fixer_agent || '')}" placeholder="fixer" onchange="markDirty('review','fixer_agent',this.value.trim())">
+            <input type="text" value="${esc(rv.fixer_agent || '')}" placeholder="fixer" data-change-action="markDirty" data-arg0="review" data-arg1="fixer_agent" data-arg-types="s,s,w">
           </div>
         </div>
 
@@ -19464,10 +19536,10 @@ function burnAreaChart() {
             <span class="config-toggle-label">Stall replan enabled <span class="config-info">i<span class="config-tooltip">Periodically scans approved plans whose sub-tasks have stopped progressing and re-kicks the architect to revise them, bounded by a per-plan cap. On by default; a no-op when there are no approved plans.</span></span></span>
           </div>
           <div class="config-field-row" style="margin-top:10px">
-            <div class="config-field"><label>Scan interval (s) <span class="config-info">i<span class="config-tooltip">How often the lane scans for stalled plans, in seconds. Runs off the governor tick, so the effective floor is the governor eval interval. 0 means the default (1800 = 30m).</span></span></label><input type="number" min="0" step="1" value="${rp.interval_s || 0}" placeholder="1800" onchange="markDirty('replan','interval_s',Number(this.value))"></div>
-            <div class="config-field"><label>Stall threshold (s) <span class="config-info">i<span class="config-tooltip">How long a plan may go without any child progressing before it is considered stalled, in seconds. 0 means the default (21600 = 6h).</span></span></label><input type="number" min="0" step="1" value="${rp.stall_threshold_s || 0}" placeholder="21600" onchange="markDirty('replan','stall_threshold_s',Number(this.value))"></div>
+            <div class="config-field"><label>Scan interval (s) <span class="config-info">i<span class="config-tooltip">How often the lane scans for stalled plans, in seconds. Runs off the governor tick, so the effective floor is the governor eval interval. 0 means the default (1800 = 30m).</span></span></label><input type="number" min="0" step="1" value="${rp.interval_s || 0}" placeholder="1800" data-change-action="markDirty" data-arg0="replan" data-arg1="interval_s" data-arg-types="s,s,N"></div>
+            <div class="config-field"><label>Stall threshold (s) <span class="config-info">i<span class="config-tooltip">How long a plan may go without any child progressing before it is considered stalled, in seconds. 0 means the default (21600 = 6h).</span></span></label><input type="number" min="0" step="1" value="${rp.stall_threshold_s || 0}" placeholder="21600" data-change-action="markDirty" data-arg0="replan" data-arg1="stall_threshold_s" data-arg-types="s,s,N"></div>
           </div>
-          <div class="config-field"><label>Max replans per plan <span class="config-info">i<span class="config-tooltip">Caps replans per plan before the lane stops and escalates to a human. 0 means the default (5).</span></span></label><input type="number" min="0" step="1" value="${rp.max_replans || 0}" placeholder="5" onchange="markDirty('replan','max_replans',Number(this.value))"></div>
+          <div class="config-field"><label>Max replans per plan <span class="config-info">i<span class="config-tooltip">Caps replans per plan before the lane stops and escalates to a human. 0 means the default (5).</span></span></label><input type="number" min="0" step="1" value="${rp.max_replans || 0}" placeholder="5" data-change-action="markDirty" data-arg0="replan" data-arg1="max_replans" data-arg-types="s,s,N"></div>
         </div>`;
     }
 
@@ -19489,7 +19561,7 @@ function burnAreaChart() {
           <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">What is shown</div>
           <div class="config-field">
             <label>Max findings shown <span class="config-info">i<span class="config-tooltip">The digest renders this many findings, ranked by severity then recency across all agents. The remainder is counted in a note, never dropped silently. To render every finding, turn on "Show all findings" below.</span></span></label>
-            <input type="number" min="1" step="1" value="${maxFindings}" onchange="markDirty('advisory','max_findings',Number(this.value))">
+            <input type="number" min="1" step="1" value="${maxFindings}" data-change-action="gh59">
           </div>
           <div class="config-toggle" style="margin-top:10px">
             <div class="config-toggle-switch ${a.show_all ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="advisory" data-key="show_all"></div>
@@ -19501,7 +19573,7 @@ function burnAreaChart() {
           <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Keeping findings current</div>
           <div class="config-field">
             <label>Staleness window (days) <span class="config-info">i<span class="config-tooltip">Agents re-report a finding for as long as its condition holds. A finding no agent has re-reported within this many days is auto-closed and leaves the digest.</span></span></label>
-            <input type="number" min="1" step="1" value="${stalenessDays}" onchange="markDirty('advisory','staleness_days',Number(this.value))">
+            <input type="number" min="1" step="1" value="${stalenessDays}" data-change-action="gh60">
           </div>
           <div class="config-toggle" style="margin-top:10px">
             <div class="config-toggle-switch ${a.pr_autoclose === false ? '' : 'on'}" data-action="toggleConfigSwitch" data-section="advisory" data-key="pr_autoclose"></div>
@@ -19558,7 +19630,7 @@ function burnAreaChart() {
 
         <div class="config-field" style="margin-bottom:20px">
           <label>Work source <span class="config-info">i<span class="config-tooltip">GitHub Issues is the default and requires no config. GitHub Projects, Linear, and Jira are opt-in — add credentials below after selecting.</span></span></label>
-          <select onchange="markWorkSourceDirty('type',this.value);renderConfigTab('Work Source')">${typeOpts}</select>
+          <select data-change-action="gh61">${typeOpts}</select>
         </div>
 
         ${type === 'github_projects' ? `
@@ -19566,27 +19638,27 @@ function burnAreaChart() {
           <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">GitHub Projects v2</div>
           <div class="config-field">
             <label>Org</label>
-            <input type="text" placeholder="my-org" value="${esc(ghp.org||'')}" onchange="markWorkSourceDirty('github_projects.org',this.value.trim())">
+            <input type="text" placeholder="my-org" value="${esc(ghp.org||'')}" data-change-action="markWorkSourceDirty" data-arg0="github_projects.org" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Project number</label>
-            <input type="number" min="1" step="1" value="${ghp.project_number||''}" placeholder="42" onchange="markWorkSourceDirty('github_projects.project_number',Number(this.value)||0)">
+            <input type="number" min="1" step="1" value="${ghp.project_number||''}" placeholder="42" data-change-action="gh62">
           </div>
           <div class="config-field">
             <label>Status filter <span class="config-info">i<span class="config-tooltip">Comma-separated Status field values to include, e.g. "Todo, Backlog". Leave empty for all open items.</span></span></label>
-            <input type="text" placeholder="Todo, Backlog" value="${esc((ghp.states||[]).join(', '))}" onchange="markWorkSourceDirty('github_projects.states',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+            <input type="text" placeholder="Todo, Backlog" value="${esc((ghp.states||[]).join(', '))}" data-change-action="gh63">
           </div>
           <div class="config-field">
             <label>Priority field <span class="config-info">i<span class="config-tooltip">Name of the project's priority custom field, e.g. "Priority". Leave empty if not using priority.</span></span></label>
-            <input type="text" placeholder="Priority" value="${esc(ghp.priority_field||'')}" onchange="markWorkSourceDirty('github_projects.priority_field',this.value.trim())">
+            <input type="text" placeholder="Priority" value="${esc(ghp.priority_field||'')}" data-change-action="markWorkSourceDirty" data-arg0="github_projects.priority_field" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Iteration field <span class="config-info">i<span class="config-tooltip">Name of the project's sprint/iteration field. When set, only items in the current iteration are shown. Leave empty to include all.</span></span></label>
-            <input type="text" placeholder="Sprint" value="${esc(ghp.iteration_field||'')}" onchange="markWorkSourceDirty('github_projects.iteration_field',this.value.trim())">
+            <input type="text" placeholder="Sprint" value="${esc(ghp.iteration_field||'')}" data-change-action="markWorkSourceDirty" data-arg0="github_projects.iteration_field" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Default repo <span class="config-info">i<span class="config-tooltip">Fallback repo (owner/name) agents clone when an issue has no repository. Usually leave empty if your project only tracks one repo.</span></span></label>
-            <input type="text" placeholder="my-org/my-repo" value="${esc(ghp.default_repo||'')}" onchange="markWorkSourceDirty('github_projects.default_repo',this.value.trim())">
+            <input type="text" placeholder="my-org/my-repo" value="${esc(ghp.default_repo||'')}" data-change-action="markWorkSourceDirty" data-arg0="github_projects.default_repo" data-arg-types="s,w">
           </div>
         </div>` : ''}
 
@@ -19595,11 +19667,11 @@ function burnAreaChart() {
           <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">Linear</div>
           <div class="config-field">
             <label>API key <span class="config-info">i<span class="config-tooltip">Linear personal API key (Settings → API → Personal API keys). Stored as a secret reference; use \${ENV_VAR} syntax to avoid putting the raw key in config.</span></span></label>
-            <input type="text" placeholder="\${LINEAR_API_KEY}" value="${esc(lin.api_key||'')}" onchange="markWorkSourceDirty('linear.api_key',this.value.trim())">
+            <input type="text" placeholder="\${LINEAR_API_KEY}" value="${esc(lin.api_key||'')}" data-change-action="markWorkSourceDirty" data-arg0="linear.api_key" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Hold labels <span class="config-info">i<span class="config-tooltip">Comma-separated Linear label names that gate an issue (like GitHub's "hold" label). Issues carrying any of these labels are excluded.</span></span></label>
-            <input type="text" placeholder="hold, blocked" value="${esc((lin.hold_labels||[]).join(', '))}" onchange="markWorkSourceDirty('linear.hold_labels',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+            <input type="text" placeholder="hold, blocked" value="${esc((lin.hold_labels||[]).join(', '))}" data-change-action="gh64">
           </div>
           <p style="font-size:0.72rem;color:var(--muted);margin:8px 0 0">Teams are configured in <code>hive.yaml</code> — each team maps to a GitHub repo agents clone.</p>
         </div>` : ''}
@@ -19609,31 +19681,31 @@ function burnAreaChart() {
           <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">Jira Cloud</div>
           <div class="config-field">
             <label>Base URL</label>
-            <input type="text" placeholder="https://myorg.atlassian.net" value="${esc(jira.base_url||'')}" onchange="markWorkSourceDirty('jira.base_url',this.value.trim())">
+            <input type="text" placeholder="https://myorg.atlassian.net" value="${esc(jira.base_url||'')}" data-change-action="markWorkSourceDirty" data-arg0="jira.base_url" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Email</label>
-            <input type="email" placeholder="bot@myorg.com" value="${esc(jira.email||'')}" onchange="markWorkSourceDirty('jira.email',this.value.trim())">
+            <input type="email" placeholder="bot@myorg.com" value="${esc(jira.email||'')}" data-change-action="markWorkSourceDirty" data-arg0="jira.email" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>API token <span class="config-info">i<span class="config-tooltip">Atlassian API token from id.atlassian.com → Security → API tokens. Use \${JIRA_API_TOKEN} to reference an environment variable.</span></span></label>
-            <input type="text" placeholder="\${JIRA_API_TOKEN}" value="${esc(jira.api_token||'')}" onchange="markWorkSourceDirty('jira.api_token',this.value.trim())">
+            <input type="text" placeholder="\${JIRA_API_TOKEN}" value="${esc(jira.api_token||'')}" data-change-action="markWorkSourceDirty" data-arg0="jira.api_token" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Project keys <span class="config-info">i<span class="config-tooltip">Comma-separated Jira project keys, e.g. "ENG, OPS". Used to build the default JQL query.</span></span></label>
-            <input type="text" placeholder="ENG, OPS" value="${esc((jira.project_keys||[]).join(', '))}" onchange="markWorkSourceDirty('jira.project_keys',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+            <input type="text" placeholder="ENG, OPS" value="${esc((jira.project_keys||[]).join(', '))}" data-change-action="gh65">
           </div>
           <div class="config-field">
             <label>JQL override <span class="config-info">i<span class="config-tooltip">Optional. Leave empty to use the default: "project in (&lt;keys&gt;) AND statusCategory != Done AND issuetype != Epic".</span></span></label>
-            <input type="text" placeholder="project = ENG AND status = Todo" value="${esc(jira.jql||'')}" onchange="markWorkSourceDirty('jira.jql',this.value.trim())">
+            <input type="text" placeholder="project = ENG AND status = Todo" value="${esc(jira.jql||'')}" data-change-action="markWorkSourceDirty" data-arg0="jira.jql" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Repo <span class="config-info">i<span class="config-tooltip">GitHub repo (owner/name) agents clone for these issues.</span></span></label>
-            <input type="text" placeholder="my-org/my-repo" value="${esc(jira.repo||'')}" onchange="markWorkSourceDirty('jira.repo',this.value.trim())">
+            <input type="text" placeholder="my-org/my-repo" value="${esc(jira.repo||'')}" data-change-action="markWorkSourceDirty" data-arg0="jira.repo" data-arg-types="s,w">
           </div>
           <div class="config-field">
             <label>Hold labels</label>
-            <input type="text" placeholder="hold, blocked" value="${esc((jira.hold_labels||[]).join(', '))}" onchange="markWorkSourceDirty('jira.hold_labels',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+            <input type="text" placeholder="hold, blocked" value="${esc((jira.hold_labels||[]).join(', '))}" data-change-action="gh66">
           </div>
         </div>` : ''}
 
@@ -19836,9 +19908,9 @@ function burnAreaChart() {
           // exactly like the App-required banner; Re-check re-probes and, on
           // success, completes the add.
           const installBtn = (d.installUrl)
-            ? '<a href="' + esc(d.installUrl) + '" target="_blank" rel="noopener" onclick="markGitHubAppInstallClicked()" style="color:var(--accent);font-weight:600">Install/authorize the App for ' + esc(d.org || '') + ' ↗</a>'
+            ? '<a href="' + esc(d.installUrl) + '" target="_blank" rel="noopener" data-action="markGitHubAppInstallClicked" style="color:var(--accent);font-weight:600">Install/authorize the App for ' + esc(d.org || '') + ' ↗</a>'
             : '<span style="color:var(--amber)">This hive\'s GitHub Enterprise App slug is not configured, so an install link cannot be built — ask your operator to install the Hive App for ' + esc(d.org || '') + '.</span>';
-          setStatus('⚠ ' + esc(d.error || ('The App needs access to ' + val)) + '<br>' + installBtn + ' &nbsp;·&nbsp; <a href="#" onclick="recheckRepoAccessThenAdd(event)" style="color:var(--accent);font-weight:600">Re-check &amp; add</a>', 'var(--amber)');
+          setStatus('⚠ ' + esc(d.error || ('The App needs access to ' + val)) + '<br>' + installBtn + ' &nbsp;·&nbsp; <a href="#" data-action="recheckRepoAccessThenAdd" data-arg-types="e" style="color:var(--accent);font-weight:600">Re-check &amp; add</a>', 'var(--amber)');
           return;
         }
         if (!res.ok) {
@@ -20427,7 +20499,7 @@ function burnAreaChart() {
       // a delegated click listener further up the tree.
       sidebar.addEventListener('click', (e) => {
         if (!isMobile() || !isOpen()) return;
-        const item = e.target.closest('[data-action="ocSelectAgent"], .oc-nav-item[onclick], .oc-nav-item');
+        const item = e.target.closest('[data-action="ocSelectAgent"], .oc-nav-item');
         if (!item) return;
         // Row-level action buttons (⚙ / ✕) open their own dialogs — keep the
         // drawer up so the user keeps their place in the list.
@@ -20834,12 +20906,12 @@ function burnAreaChart() {
         '<p style="color:var(--muted);font-size:0.85rem;margin:12px 0">Enter this one-time code at github.com/login/device:</p>' +
         '<div id="copilot-user-code" style="font-size:1.8rem;font-weight:700;letter-spacing:4px;color:var(--green);' +
           'background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:14px;margin:12px 0;cursor:pointer" ' +
-          'title="Click to copy" onclick="copyCopilotCode()">' + userCode + '</div>' +
+          'title="Click to copy" data-action="copyCopilotCode">' + userCode + '</div>' +
         '<div id="copilot-auth-status" style="color:var(--muted);font-size:0.8rem;min-height:20px;margin:8px 0">Waiting for authorization…</div>' +
         '<div style="display:flex;gap:8px;justify-content:center;margin-top:8px">' +
-          '<button onclick="window.open(\x27' + verificationUri + '\x27, \x27_blank\x27)" ' +
+          '<button data-action="ghOpenUrl" data-arg0="' + esc(verificationUri) + '" ' +
             'style="background:var(--green);color:var(--bg);border:none;padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer">Open GitHub</button>' +
-          '<button onclick="cancelCopilotLogin()" class="gh-cancel" style="margin-top:0">Cancel</button>' +
+          '<button data-action="cancelCopilotLogin" class="gh-cancel" style="margin-top:0">Cancel</button>' +
         '</div>' +
       '</div>';
       document.body.appendChild(overlay);
@@ -21149,8 +21221,8 @@ function burnAreaChart() {
           'style="width:100%;padding:10px;border:1px solid #d1d5db;border-radius:6px;font-size:0.9rem;margin:12px 0;box-sizing:border-box">' +
         '<div id="claude-exchange-status" style="color:var(--muted);font-size:0.8rem;min-height:20px;margin-bottom:8px"></div>' +
         '<div style="display:flex;gap:8px;justify-content:center">' +
-          '<button onclick="submitClaudeCode()" style="background:#d97706;color:#fff;border:none;padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer">Submit</button>' +
-          '<button onclick="cancelClaudeLogin()" class="gh-cancel" style="margin-top:0">Cancel</button>' +
+          '<button data-action="submitClaudeCode" style="background:#d97706;color:#fff;border:none;padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer">Submit</button>' +
+          '<button data-action="cancelClaudeLogin" class="gh-cancel" style="margin-top:0">Cancel</button>' +
         '</div>' +
       '</div>';
       document.body.appendChild(overlay);
@@ -21442,8 +21514,8 @@ function burnAreaChart() {
         body: 'The <strong>Forge App</strong> is the app Hive installs on your forge (your source control system, e.g., GitHub, GitHub Enterprise, GitLab, or Gitea) — on GitHub.com and GitHub Enterprise it is a GitHub App. It unlocks issues, advisory reports, and PRs on your primary repo; without it the hive can only observe. ⏰ <strong>Do this in your first session:</strong> hosted hives that never finish this step are reclaimed (reaped) on a timer — the hive disappears from the hub and its URL stops working. If that happens, request a new hive from the hub and complete this step right away. On GitHub Enterprise the install page lives on your enterprise host, not github.com. Full instructions: <a href="https://github.com/kubestellar/hive/blob/v4/src/docs/github-app-setup.md" target="_blank" rel="noopener noreferrer">Forge App (GitHub App) setup</a>.',
         autoNote: 'Checks itself once the app is detected on your repository.',
         actions: [
-          { label: 'Install GitHub App', onclick: 'welcomeInstallGitHubApp()' },
-          { label: 'Re-check', onclick: 'welcomeRecheckGitHubApp(event)' }
+          { label: 'Install GitHub App', action: 'welcomeInstallGitHubApp' },
+          { label: 'Re-check', action: 'welcomeRecheckGitHubApp', actionArgTypes: 'e' }
         ]
       },
       {
@@ -21456,7 +21528,7 @@ function burnAreaChart() {
         },
         body: 'Each agent card has a <strong>method dropdown</strong>: <strong>claude / copilot / gemini</strong> run on subscription CLIs, while <strong>vllm / llm-d / litellm</strong> use a self-hosted inference endpoint (litellm takes an endpoint + API key under Settings → LiteLLM). Mix and match per agent.',
         autoNote: 'Checks itself once every configured agent has a resolved method/backend.',
-        actions: [{ label: 'Show me', onclick: 'welcomeShowAgentCard()' }]
+        actions: [{ label: 'Show me', action: 'welcomeShowAgentCard' }]
       },
       {
         id: 'logins',
@@ -21467,14 +21539,14 @@ function burnAreaChart() {
         },
         body: 'Credentials are shared <strong>per method, not per agent</strong> — one copilot device-code login covers every copilot agent, and claude uses a paste-the-code flow. Inference methods (vllm / llm-d / litellm) never log in; they use the endpoint + key instead.',
         autoNote: 'Checks itself once every agent’s method is authenticated.',
-        actions: [{ label: 'Show me', onclick: 'welcomeShowLogin()' }]
+        actions: [{ label: 'Show me', action: 'welcomeShowLogin' }]
       },
       {
         id: 'terminal',
         title: 'Watch an agent in its terminal',
         auto: null,
         body: 'The cyan <strong>▶ terminal</strong> button on each agent card opens the agent’s live tmux session: watch it work in real time, scroll its history, or type <strong>/login</strong> in the CLI when a login needs interaction. Etiquette: it is the agent’s working session — observe, don’t drive, except for logins.',
-        actions: [{ label: '▶ Open a terminal', onclick: 'welcomeOpenTerminal()' }]
+        actions: [{ label: '▶ Open a terminal', action: 'welcomeOpenTerminal' }]
       },
       {
         id: 'models',
@@ -21486,7 +21558,7 @@ function burnAreaChart() {
         },
         body: 'The <strong>model dropdown</strong> on each agent card lists models auto-discovered for its method. 📌 pinning a model stops the governor from auto-selecting a different one — it never blocks your own changes.',
         autoNote: 'Checks itself once every configured agent has a concrete non-default model, or uses a backend with no model choice.',
-        actions: [{ label: 'Show me', onclick: 'welcomeShowAgentCard()' }]
+        actions: [{ label: 'Show me', action: 'welcomeShowAgentCard' }]
       },
       {
         id: 'repos',
@@ -21494,21 +21566,21 @@ function burnAreaChart() {
         auto: () => window._primaryRepo ? true : false,
         body: 'Settings → <strong>Repos</strong>: add every repository the agents should watch, and set the <strong>primary</strong> repo — it hosts the advisory issue and default markings.',
         autoNote: 'Checks itself once a primary repo is set.',
-        actions: [{ label: 'Show me', onclick: "welcomeShowConfigTab('Repos')" }]
+        actions: [{ label: 'Show me', action: 'welcomeShowConfigTab', actionArg: 'Repos' }]
       },
       {
         id: 'cadences',
         title: 'Tune cadences',
         auto: null,
         body: 'Each agent’s ⚙️ config has a <strong>Cadences</strong> tab: per-mode kick intervals (idle / quiet / busy / surge), on-demand vs scheduled, and pausing. Set them per agent — the intensity bar on the Governor panel shows which mode is active right now.',
-        actions: [{ label: 'Show me', onclick: 'welcomeShowCadences()' }]
+        actions: [{ label: 'Show me', action: 'welcomeShowCadences' }]
       },
       {
         id: 'add-agent',
         title: 'Add a custom agent',
         auto: null,
         body: 'The built-in agents are a starting point, not a limit. The <strong>+ agent</strong> control (in the agents bar) opens a create dialog where you name your own agent, pick its method and model, and give it a prompt template and cadences — or <strong>Import</strong> one from the community registry. Build a specialist for whatever your repo needs: a docs writer, a dependency bumper, a release-notes drafter.',
-        actions: [{ label: '+ Add an agent', onclick: 'welcomeAddAgent()' }]
+        actions: [{ label: '+ Add an agent', action: 'welcomeAddAgent' }]
       },
       {
         id: 'acmm',
@@ -21516,7 +21588,7 @@ function burnAreaChart() {
         auto: (data) => !!(data && data.acmmLevelConfigured === true),
         body: 'The amber badge in the sidebar opens the <strong>maturity-level dialog</strong>: L1 (advisory-only) → L6 (fully autonomous), each level additive. A default is preset — confirm it matches how much autonomy you want.',
         autoNote: 'Checks itself once an ACMM level is explicitly saved on the hive.',
-        actions: [{ label: 'Show me', onclick: 'welcomeShowACMM()' }]
+        actions: [{ label: 'Show me', action: 'welcomeShowACMM' }]
       }
     ];
 
@@ -21531,14 +21603,14 @@ function burnAreaChart() {
     // updateWelcomeProgress() counts only WELCOME_STEPS, so nothing listed
     // here can inflate the "N of M done" counter or read as a required step.
     const WELCOME_MORE_ITEMS = [
-      { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Settings → Budget).', onclick: "welcomeShowConfigTab('Budget')" },
-      { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Settings → Notifications).', onclick: "welcomeShowConfigTab('Notifications')" },
-      { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.', onclick: "welcomeShowSection('knowledge-section')" },
-      { id: 'contributors', label: 'ClankeR (Contributor Relay)', desc: 'let outside contributors drive agents, with a leaderboard.', onclick: "welcomeShowSection('contributors-section')" },
-      { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Settings → Hub).', onclick: "welcomeShowConfigTab('Hub')" },
-      { id: 'backup', label: 'Backups', desc: 'set a backup encryption key, then download an encrypted archive of this hive from your account menu. No deployment or cluster access needed — the key is set right here (Settings → Security → Backup). Backups are refused while no key is set, so an archive is never written unencrypted.', onclick: "welcomeShowConfigTab('Security')" },
-      { id: 'trajectory', label: 'Trajectory Review <span class="welcome-more-tag">advanced</span>', desc: 'an LLM reviewer periodically reads each running agent’s transcript and pauses or alerts you if the agent drifts from the task it was given. Needs one OpenAI-compatible reviewer endpoint (LiteLLM, vLLM, or llm-d) — without it the lane stays inert (Settings → General).', onclick: `welcomeShowConfigTab('${TRAJECTORY_CONFIG_TAB}')` },
-      { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.', onclick: 'toggleLayout()' }
+      { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Settings → Budget).', action: 'welcomeShowConfigTab', actionArg: 'Budget' },
+      { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Settings → Notifications).', action: 'welcomeShowConfigTab', actionArg: 'Notifications' },
+      { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.', action: 'welcomeShowSection', actionArg: 'knowledge-section' },
+      { id: 'contributors', label: 'ClankeR (Contributor Relay)', desc: 'let outside contributors drive agents, with a leaderboard.', action: 'welcomeShowSection', actionArg: 'contributors-section' },
+      { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Settings → Hub).', action: 'welcomeShowConfigTab', actionArg: 'Hub' },
+      { id: 'backup', label: 'Backups', desc: 'set a backup encryption key, then download an encrypted archive of this hive from your account menu. No deployment or cluster access needed — the key is set right here (Settings → Security → Backup). Backups are refused while no key is set, so an archive is never written unencrypted.', action: 'welcomeShowConfigTab', actionArg: 'Security' },
+      { id: 'trajectory', label: 'Trajectory Review <span class="welcome-more-tag">advanced</span>', desc: 'an LLM reviewer periodically reads each running agent’s transcript and pauses or alerts you if the agent drifts from the task it was given. Needs one OpenAI-compatible reviewer endpoint (LiteLLM, vLLM, or llm-d) — without it the lane stays inert (Settings → General).', action: 'welcomeShowConfigTab', actionArg: '${TRAJECTORY_CONFIG_TAB}' },
+      { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.', action: 'toggleLayout' }
     ];
 
     /** Done-state for one step: auto steps compute from the payload, manual
@@ -21570,21 +21642,21 @@ function burnAreaChart() {
         const checkTitle = step.auto
           ? 'Checked automatically from the hive’s live status'
           : 'Click to mark this step done (saved in this browser)';
-        const checkAttrs = step.auto ? '' : ` onclick="toggleWelcomeCheck(event,'${step.id}')" role="checkbox" aria-checked="${done}" tabindex="0" onkeydown="if(event.key===' '||event.key==='Enter')toggleWelcomeCheck(event,'${step.id}')"`;
+        const checkAttrs = step.auto ? '' : ` data-action="toggleWelcomeCheck" data-arg1="${step.id}" data-arg-types="e,s" role="checkbox" aria-checked="${done}" tabindex="0" data-keydown-action="toggleWelcomeCheck" data-arg1="${step.id}" data-arg-types="e,s" data-keys="Enter, "`;
         html += `<div class="welcome-step${done ? ' done' : ''}${open ? ' open' : ''}" id="welcome-step-${step.id}">`
-          + `<div class="welcome-step-header" onclick="toggleWelcomeStep('${step.id}')">`
+          + `<div class="welcome-step-header" data-action="toggleWelcomeStep" data-arg0="${step.id}">`
           + `<span class="${checkCls}" title="${checkTitle}"${checkAttrs}>${done ? '✓' : ''}</span>`
           + `<span class="welcome-step-title">${n}. ${step.title}</span>`
           + `<span class="welcome-step-chevron">▶</span>`
           + `</div>`
           + `<div class="welcome-step-body">${step.body}`
           + (step.autoNote ? `<span class="welcome-auto-note">${step.autoNote}</span>` : '')
-          + (step.actions ? `<div class="welcome-step-actions">` + step.actions.map(a => `<button class="btn" onclick="${a.onclick}">${a.label}</button>`).join('') + `</div>` : '')
+          + (step.actions ? `<div class="welcome-step-actions">` + step.actions.map(a => `<button class="btn" data-action="${a.action}"${a.actionArg !== undefined ? ` data-arg0="${a.actionArg}"` : ''}${a.actionArgTypes ? ` data-arg-types="${a.actionArgTypes}"` : ''}>${a.label}</button>`).join('') + `</div>` : '')
           + `</div></div>`;
       }
       html += '<div class="welcome-more-title">More to explore</div>';
       for (const item of WELCOME_MORE_ITEMS) {
-        html += `<div class="welcome-more-item"><span class="welcome-more-link" id="welcome-more-${item.id}" onclick="${item.onclick}">${item.label}</span> — ${item.desc}</div>`;
+        html += `<div class="welcome-more-item"><span class="welcome-more-link" id="welcome-more-${item.id}" data-action="${item.action}"${item.actionArg !== undefined ? ` data-arg0="${item.actionArg}"` : ''}>${item.label}</span> — ${item.desc}</div>`;
       }
       body.innerHTML = html;
       updateWelcomeProgress();
@@ -21844,6 +21916,105 @@ function burnAreaChart() {
         Promise.all(allDone).then(resolveAll);
       }, DEFERRED_INIT_DELAY_MS);
     });
+    // ── Generated event-delegation handlers (#3848) ──
+    // Each entry replaces a former inline on*= attribute body verbatim;
+    // A[] carries the values that used to be interpolated into the
+    // attribute, now read from data-arg* (so CSP script-src-attr can be
+    // 'none' and injected handler attributes never execute).
+    // Named helpers for former multi-statement/string-concat inline handlers.
+    function ghCopyInviteLink(url) {
+      navigator.clipboard.writeText(url);
+      showToast('Contribute link copied \u2014 share it with your community!', 'success');
+    }
+    function ghToggleDisplayById(id) {
+      const el = document.getElementById(id);
+      if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
+    }
+    function ghAcmmCreateIssueDirect(repo, id, level) {
+      acmmCloseDialog();
+      acmmCreateIssueDirectFromPicker(repo, id, level);
+    }
+    function ghAcmmCloseAndShowLevel(level) {
+      acmmCloseDialog();
+      acmmShowLevelDialog(level);
+    }
+    function ghOpenUrl(url) {
+      window.open(url, '_blank');
+    }
+    const HIVE_GEN_HANDLERS = {
+      gh70: function (event, A) { saveGovGeneralAdvanced('eval_interval_s', this.value === '' ? null : parseInt(this.value,10)); },
+      gh71: function (event, A) { markDirty('auto-merge','max_merges',Number(this.value)||0); },
+      gh72: function (event, A) { markDirty('auto-merge','required_checks',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh73: function (event, A) { markDirty('review','max_parallel_reviews',Number(this.value)||0); },
+      gh74: function (event, A) { markDirty('review','reviewer_agents',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh0: function (event, A) { document.getElementById('gh-setup-overlay').style.display='none'; },
+      gh1: function (event, A) { openConfigDialog('governor',null,'Repos'); },
+      gh2: function (event, A) { acmmSelectRepo(null); },
+      gh3: function (event, A) { event.stopPropagation(); },
+      gh4: function (event, A) { localStorage.setItem('hive-merged-expanded', this.open); },
+      gh5: function (event, A) { openConfigDialog('governor',null,'Thresholds'); },
+      gh6: function (event, A) { this.parentElement._zoomIn(); },
+      gh7: function (event, A) { this.parentElement._zoomReset(); },
+      gh8: function (event, A) { this.parentElement._zoomOut(); },
+      gh9: function (event, A) { this.parentElement._toggleFullscreen(); },
+      gh10: function (event, A) { _kbSetupView='git';renderKnowledge(); },
+      gh11: function (event, A) { _kbSetupView='webhook';renderKnowledge(); },
+      gh12: function (event, A) { _kbSetupView='none';renderKnowledge(); },
+      gh13: function (event, A) { _kbSetupView='choose';renderKnowledge(); },
+      gh14: function (event, A) { _kbSelectedLayer='vault:'+A[0];kbSearchVault(A[0]); },
+      gh15: function (event, A) { _kbSearchQuery=this.value;kbSearch(); },
+      gh16: function (event, A) { _kbSearchQuery=this.value; },
+      gh17: function (event, A) { kbReadFact(A[0]); },
+      gh18: function (event, A) { kbRemoveGitSource(A[0],A[1]); },
+      gh19: function (event, A) { this.style.display='none'; },
+      gh20: function (event, A) { this.style.borderColor='var(--blue)'; },
+      gh21: function (event, A) { this.style.borderColor='var(--border)'; },
+      gh22: function (event, A) { this.style.borderColor='var(--muted)'; },
+      gh23: function (event, A) { acmmCloseDialog();acmmShowCodebaseDialog(); },
+      gh24: function (event, A) { acmmCloseDialog();acmmShowOpsDialog(); },
+      gh25: function (event, A) { this.style.background='var(--bg)'; },
+      gh26: function (event, A) { this.style.background='transparent'; },
+      gh27: function (event, A) { selfUpgrade(A[0]); },
+      gh28: function (event, A) { this.style.filter='brightness(1.15)'; },
+      gh29: function (event, A) { this.style.filter=''; },
+      gh30: function (event, A) { document.getElementById('import-preview').style.display='none'; },
+      gh31: function (event, A) { markDirty('hub','contribute_cooldown_hours',parseInt(this.value,10)||168); },
+      gh32: function (event, A) { updateConfigAgentName(this.value);markDirty('general','displayName',this.value); },
+      gh33: function (event, A) { markDirty('general','sortOrder',parseInt(this.value,10)); },
+      gh34: function (event, A) { markDirty('general','replicas',Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1)));this.value=Math.max(1,Math.min(MAX_AGENT_REPLICAS,parseInt(this.value,10)||1)); },
+      gh35: function (event, A) { markDirty('general','staleTimeout',cadenceFromHuman(this.value));this.value=cadenceToHuman(cadenceFromHuman(this.value)); },
+      gh36: function (event, A) { markDirty('general','laneKeywords',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh37: function (event, A) { markDirty('general','detectKeywords',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh38: function (event, A) { markDirty('general','aliases',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh39: function (event, A) { cadenceChanged(A[0]);renderConfigTab(_configState.tab); },
+      gh41: function (event, A) { closeConfigDialog();openACMMDialog(); },
+      gh42: function (event, A) { saveTrajectoryField('intervalS', this.value === '' ? 0 : parseInt(this.value,10)); },
+      gh43: function (event, A) { markDirty('budget','totalTokens',Number(this.value)); },
+      gh44: function (event, A) { markDirty('budget','periodDays',Number(this.value)); },
+      gh45: function (event, A) { markDirty('budget','criticalPct',Number(this.value)); },
+      gh46: function (event, A) { markDirty('health','healthcheckInterval',Number(this.value)); },
+      gh47: function (event, A) { markDirty('health','restartCooldown',Number(this.value)); },
+      gh48: function (event, A) { markDirty('sensing','ttlSeconds',Number(this.value)); },
+      gh49: function (event, A) { markDirty('sensing','pullbackSeconds',Number(this.value)); },
+      gh50: function (event, A) { markDirty('logging','maxSizeMB',Number(this.value)); },
+      gh51: function (event, A) { markDirty('logging','maxAgeDays',Number(this.value)); },
+      gh52: function (event, A) { markDirty('logging','maxBackups',Number(this.value)); },
+      gh53: function (event, A) { markDirty('security','ioscanClassifierWarnThreshold',Number(this.value)); },
+      gh54: function (event, A) { markDirty('security','ioscanClassifierBlockThreshold',Number(this.value)); },
+      gh55: function (event, A) { markDirty('security','reviewMaxParallelReviews',Number(this.value)); },
+      gh56: function (event, A) { markDirty('security','reviewReviewerAgents',parseSecurityList(this.value)); },
+      gh57: function (event, A) { markDirty('features','tracingSampleRatio',Number(this.value)); },
+      gh58: function (event, A) { markDirty('features','otelHeaders',{});showToast('OTel headers will be cleared on Save','info'); },
+      gh59: function (event, A) { markDirty('advisory','max_findings',Number(this.value)); },
+      gh60: function (event, A) { markDirty('advisory','staleness_days',Number(this.value)); },
+      gh61: function (event, A) { markWorkSourceDirty('type',this.value);renderConfigTab('Work Source'); },
+      gh62: function (event, A) { markWorkSourceDirty('github_projects.project_number',Number(this.value)||0); },
+      gh63: function (event, A) { markWorkSourceDirty('github_projects.states',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh64: function (event, A) { markWorkSourceDirty('linear.hold_labels',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh65: function (event, A) { markWorkSourceDirty('jira.project_keys',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh66: function (event, A) { markWorkSourceDirty('jira.hold_labels',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+    };
+
   </script>
 </body>
 </html>

--- a/src/proxy/csp_script_src_elem.test.js
+++ b/src/proxy/csp_script_src_elem.test.js
@@ -10,15 +10,18 @@ import path from 'path';
 // Covers the script-src half of kubestellar/hive#3848 (#3907) on the proxy —
 // the Node-side counterpart of csp_script_src_test.go, mirroring ADR-0016:
 //
-//   script-src      'self' 'unsafe-inline' …  <- CSP2 fallback, UNCHANGED and
-//                                               hash-free (a hash here disables
-//                                               'unsafe-inline' on hash-aware
-//                                               pre-CSP3 browsers and blanks
-//                                               every inline on*= handler)
+//   script-src      'self' …                  <- CSP2 fallback, now without
+//                                               'unsafe-inline' (#3848 closed
+//                                               the attribute half) and still
+//                                               hash-free (a hash here changes
+//                                               semantics on hash-aware
+//                                               pre-CSP3 browsers)
 //   script-src-elem 'self' cdn 'sha256-…'     <- inline <script> elements:
 //                                               CLOSED — only the SPA's own
 //                                               inline scripts can execute
-//   script-src-attr 'unsafe-inline'           <- on*= attributes: STAGED
+//   script-src-attr 'none'                    <- on*= attributes: CLOSED by
+//                                               the #3848 event-delegation
+//                                               refactor
 //
 // Go-rendered documents (/contribute, /leaderboard, /snapshot) and ttyd's UI
 // (/terminal) keep the blanket policy: the Go upstream stamps its own
@@ -160,16 +163,15 @@ async function main() {
       `script-src-elem must carry exactly the 2 inline-script hashes, got ${hashCount}: ${elem}`);
 
     const attr = directive(csp, 'script-src-attr');
-    assert.ok(attr.includes("'unsafe-inline'"),
-      `script-src-attr must keep 'unsafe-inline' until the #3848 event-delegation refactor — ` +
-      `dropping it silently kills every inline on*= handler: ${csp}`);
+    assert.ok(attr.includes("'none'") && !attr.includes("'unsafe-inline'"),
+      `script-src-attr must be 'none' after the #3848 event-delegation refactor — ` +
+      `inline on*= handlers are gone and must never come back: ${csp}`);
 
-    // The CSP2 fallback: unchanged, and LOAD-BEARINGLY hash-free — a hash in
-    // script-src makes hash-aware pre-CSP3 browsers (Firefox < 108) ignore
-    // 'unsafe-inline' and blank every inline handler.
+    // The CSP2 fallback: 'unsafe-inline' dropped with #3848, and
+    // LOAD-BEARINGLY hash-free — hashes belong only in script-src-elem.
     const fallback = directive(csp, 'script-src');
-    assert.ok(fallback.includes("'self'") && fallback.includes("'unsafe-inline'"),
-      `script-src fallback must stay permissive for pre-CSP3 browsers: ${fallback}`);
+    assert.ok(fallback.includes("'self'") && !fallback.includes("'unsafe-inline'"),
+      `script-src fallback must keep 'self' and drop 'unsafe-inline' after #3848: ${fallback}`);
     assert.ok(!/'sha256-/.test(fallback),
       `script-src fallback must NEVER carry hashes (disables 'unsafe-inline' on ` +
       `hash-aware pre-CSP3 browsers): ${fallback}`);
@@ -218,9 +220,9 @@ async function main() {
     //    it and trip the CSP2 'unsafe-inline'-suppression footgun.
     // -------------------------------------------------------------------
     const src = readFileSync(path.join(__dirname, 'server.js'), 'utf8');
-    assert.ok(src.includes(`"script-src 'self' 'unsafe-inline' https://cdn.redoc.ly"`),
+    assert.ok(src.includes(`"script-src 'self' https://cdn.redoc.ly"`),
       'server.js must keep the literal, hash-free script-src fallback');
-    assert.ok(/script-src-attr 'unsafe-inline'/.test(src),
+    assert.ok(/script-src-attr 'none'/.test(src),
       'server.js must declare script-src-attr explicitly');
     console.log('  ok: source guard — fallback literal and hash-free');
   } finally {

--- a/src/proxy/server.js
+++ b/src/proxy/server.js
@@ -782,13 +782,14 @@ async function snapshotFrameAncestors() {
 //   script-src-elem 'self' cdn + sha256 hashes — inline <script> ELEMENTS,
 //     CLOSED: only this proxy's own inline scripts (the SPA document's) can
 //     execute; an injected inline <script> matches no hash and is blocked.
-//   script-src-attr 'unsafe-inline' — the SPA's ~426 inline on*= handler
-//     attributes, STAGED behind an event-delegation refactor (#3848). Hashes
-//     and nonces do not exist for attributes.
-//   script-src (fallback) keeps 'self' 'unsafe-inline' UNCHANGED for pre-CSP3
-//     browsers, and must never carry the hashes: a hash there makes hash-aware
-//     browsers ignore 'unsafe-inline' in the same directive, blanking the UI
-//     on browsers that know hashes but not -elem/-attr (Firefox < 108).
+//   script-src-attr 'none' — inline on*= handler attributes, CLOSED by the
+//     #3848 event-delegation refactor: the SPA and Go-generated HTML use
+//     data-action / data-* dispatch, so no handler attribute remains and an
+//     injected one never executes.
+//   script-src (fallback) is 'self' (+ cdn) for pre-CSP3 browsers —
+//     'unsafe-inline' dropped with #3848 — and must never carry the hashes: a
+//     hash there makes hash-aware browsers ignore 'unsafe-inline' in the same
+//     directive on browsers that know hashes but not -elem/-attr (Firefox < 108).
 //
 // Hashes are computed from the exact index.html bytes this proxy serves —
 // lazily, because the dashboard file can be built after startup (see
@@ -833,9 +834,9 @@ app.use(async (req, res, next) => {
   const scriptDirectives = isUpstreamDocPath(req.path)
     ? ["script-src 'self' 'unsafe-inline' https://cdn.redoc.ly"]
     : [
-        "script-src 'self' 'unsafe-inline' https://cdn.redoc.ly",
+        "script-src 'self' https://cdn.redoc.ly",
         `script-src-elem ${["'self'", 'https://cdn.redoc.ly', ...spaScriptElemHashes()].join(' ')}`,
-        "script-src-attr 'unsafe-inline'",
+        "script-src-attr 'none'",
       ];
   res.setHeader('Content-Security-Policy', [
     "default-src 'self'",


### PR DESCRIPTION
Closes #3848

Completes the second half of the CSP script-src refactor:

- Replaces all inline on*= event handler attributes in index.html and Go-generated HTML with data-action + data-* attributes dispatched centrally
- Removes unsafe-inline from script-src-attr (now 'none') and from the script-src CSP2 fallback, on both emitters (Go spoke server and Node proxy)
- Inverts TestCSPScriptSrcAttrUnsafeInlineIsStaged → TestCSPScriptSrcAttrUnsafeInlineIsAbsent, and updates the proxy CSP test to pin the closed state
- Adds written rationale for style-src unsafe-inline (CSS injection is not an XSS vector; ~2,055 inline style attributes accepted per ADR-0015/0016)
- Updates ADR-0016 to record the closed state

The script-src-elem half was already closed in #3907. This closes the remaining open half.