### PR TITLE
🐛 fix: show task title in completed/failed activity feed events

### DIFF
--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -5541,8 +5541,8 @@ function ccNarrate(e){
     case 'joined': body=who+' entered the hive'; break;
     case 'left': body=who+' left the hive'; break;
     case 'picked up': body=who+' grabbed'+pickedRef; break;
-    case 'completed': body=who+' completed'+ref; break;
-    case 'failed': body=who+' hit a snag on'+ref; break;
+    case 'completed': body=who+' completed'+(e.task?' '+ccTaskRefLink(e.task):''); break;
+    case 'failed': body=who+' hit a snag on'+(e.task?' '+ccTaskRefLink(e.task):''); break;
     case 'promoted': body=who+' was promoted to <b>'+esc(e.task||e.role||'contributor')+'</b>'; break;
     default: body=who+' '+esc(e.action)+ref;
   }

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -3124,7 +3124,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						h.markTaskCompletedVerdict(completedTask.Repo, completedTask.Number, verifiedPR,
 							verdict, contributor.profile.GitHubUsername, strings.TrimSpace(msg.VerdictReason))
 					}
-					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, msg.TaskID)
+					completedDesc := msg.TaskID
+					if completedTask != nil && completedTask.Number > 0 {
+						completedDesc = fmt.Sprintf("%s %s#%d: %s", completedTask.Kind, completedTask.Repo, completedTask.Number, completedTask.Title)
+					}
+					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, completedDesc)
 					h.logger.Info("[contribute-ws] task complete",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
@@ -3254,7 +3258,11 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					}
 					contributor.mu.Unlock()
 
-					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, msg.TaskID)
+					failedDesc := msg.TaskID
+					if failedTask != nil && failedTask.Number > 0 {
+						failedDesc = fmt.Sprintf("%s %s#%d: %s", failedTask.Kind, failedTask.Repo, failedTask.Number, failedTask.Title)
+					}
+					h.addActivity(contributor.profile.GitHubUsername, "failed", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, failedDesc)
 					h.logger.Info("[contribute-ws] task failed",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,


### PR DESCRIPTION
Closes #4234

**Problem:** Completed and failed events in the Live Activity feed showed the opaque internal task ID (`ct-repo-123-ts`) instead of the human-readable title that `picked up` events show.

**Fix (server):** Build `taskDesc` from `completedTask`/`failedTask` fields for both `completed` and `failed` `addActivity` calls. Falls back to `msg.TaskID` only when the task struct is nil.

**Fix (client):** `ccNarrate` now routes `completed`/`failed` refs through `ccTaskRefLink` (clickable GitHub link), matching `picked up`.