### PR TITLE
🐛 fix(hub): populate the dibs repo feed — include github.com github_host, verify actually-public repos

### DIFF
--- a/src/pkg/hub/dibs_public_check.go
+++ b/src/pkg/hub/dibs_public_check.go
@@ -1,0 +1,202 @@
+package hub
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// This file implements the public-repo verification behind the dibs repo feed
+// (GET /api/saas/dibs/repos, #4233).
+//
+// The feed used to require is_public — an owner opt-in "registry visibility"
+// toggle that is false on every production hive — so the feed could never
+// populate. The feed's actual safety requirement is narrower: it must only
+// expose facts that are ALREADY public. A repo that is public on github.com
+// satisfies that by definition, so the gate is now "verifiably public on
+// github.com right now", checked against the GitHub API:
+//
+//	GET https://api.github.com/repos/{owner}/{repo}
+//
+// 200 with "private": false → public; 404 (GitHub's answer for both private
+// and nonexistent, deliberately indistinguishable to an unauthenticated
+// caller) or "private": true → excluded.
+//
+// The check NEVER runs on the request path. handleDibsRepos consults only the
+// in-memory verdict cache and kicks off bounded, deduplicated background
+// refreshes for missing/expired entries — an unknown repo is simply excluded
+// until its first verdict lands. The first responses after a hub restart are
+// therefore smaller and converge as the cache fills, which is fine: dibs
+// re-syncs every ~5 minutes and merges.
+
+const (
+	// dibsPublicCheckTTL is how long a definitive verdict (public or not) is
+	// trusted before re-verification. Positive AND negative verdicts are
+	// cached: a repo flipping visibility is picked up within one TTL, and the
+	// unauthenticated GitHub rate limit (60/h) comfortably covers the fleet's
+	// ~30 real repos re-checked once per hour.
+	dibsPublicCheckTTL = time.Hour
+	// dibsPublicCheckErrTTL is the retry-after for a TRANSIENT failure
+	// (network error, 5xx, rate limit): the prior verdict — or the
+	// excluded-by-default when there is none — is kept, and the next check
+	// happens sooner than a full TTL so an outage does not pin a stale answer
+	// for an hour.
+	dibsPublicCheckErrTTL = 5 * time.Minute
+	// dibsPublicCheckTimeout bounds one GitHub API round-trip. Checks are
+	// background work; a hung connection must release its concurrency slot
+	// promptly rather than pile up goroutines.
+	dibsPublicCheckTimeout = 5 * time.Second
+	// dibsPublicCheckParallel bounds concurrent GitHub API checks so a cold
+	// cache over the whole fleet cannot open dozens of simultaneous
+	// connections. Repos over the bound are retried on the next poll.
+	dibsPublicCheckParallel = 4
+)
+
+// dibsHubGitHubTokenEnv optionally names a GitHub token the hub uses for the
+// public-repo checks, raising the API rate limit from 60/h (unauthenticated)
+// to 5000/h. No hub-level GitHub token env existed before this (the hub's App
+// credentials are per-installation), so this is a new, optional knob; unset
+// means unauthenticated checks, which the TTL math above fits.
+const dibsHubGitHubTokenEnv = "HIVE_HUB_GITHUB_TOKEN"
+
+// dibsPublicVerdict is one cached answer: whether the repo was public when
+// last checked, and when the answer stops being trusted.
+type dibsPublicVerdict struct {
+	public  bool
+	expires time.Time
+}
+
+// dibsPublicChecker is the mutex-guarded verdict cache plus the background
+// refresh machinery. One per HubServer, created lazily by dibsChecker.
+type dibsPublicChecker struct {
+	mu       sync.Mutex
+	verdicts map[string]dibsPublicVerdict
+	inflight map[string]bool
+	// sem bounds concurrent background checks (dibsPublicCheckParallel). A
+	// slot is acquired under mu in isPublic and released by refresh.
+	sem     chan struct{}
+	apiBase string // test seam; production is https://api.github.com
+	token   string // optional bearer for higher rate limits (env, read once)
+	client  *http.Client
+	logger  *slog.Logger
+	now     func() time.Time // test seam for TTL expiry
+}
+
+func newDibsPublicChecker(logger *slog.Logger) *dibsPublicChecker {
+	return &dibsPublicChecker{
+		verdicts: map[string]dibsPublicVerdict{},
+		inflight: map[string]bool{},
+		sem:      make(chan struct{}, dibsPublicCheckParallel),
+		apiBase:  "https://api.github.com",
+		token:    strings.TrimSpace(os.Getenv(dibsHubGitHubTokenEnv)),
+		client:   &http.Client{Timeout: dibsPublicCheckTimeout},
+		logger:   logger,
+		now:      time.Now,
+	}
+}
+
+// dibsChecker returns the server's lazily-created public-repo checker. Tests
+// pre-set s.dibsPublic (pointing apiBase at a fake GitHub API) before the
+// first call and the Once respects it.
+func (s *HubServer) dibsChecker() *dibsPublicChecker {
+	s.dibsPublicOnce.Do(func() {
+		if s.dibsPublic == nil {
+			s.dibsPublic = newDibsPublicChecker(s.logger)
+		}
+	})
+	return s.dibsPublic
+}
+
+// isPublic answers from the cache and NEVER blocks: a missing or expired
+// verdict schedules one deduplicated background refresh (subject to the
+// concurrency bound) and reports the current best answer — the stale verdict
+// if one exists, otherwise excluded.
+func (c *dibsPublicChecker) isPublic(repoID string) bool {
+	c.mu.Lock()
+	v, known := c.verdicts[repoID]
+	fresh := known && c.now().Before(v.expires)
+	launch := !fresh && !c.inflight[repoID]
+	if launch {
+		select {
+		case c.sem <- struct{}{}:
+			c.inflight[repoID] = true
+		default:
+			// Bound reached: skip this round; the next poll retries.
+			launch = false
+		}
+	}
+	c.mu.Unlock()
+	if launch {
+		go c.refresh(repoID)
+	}
+	return known && v.public
+}
+
+// refresh performs one GitHub API check and records the verdict. Runs in its
+// own goroutine holding a sem slot acquired by isPublic.
+func (c *dibsPublicChecker) refresh(repoID string) {
+	public, definitive := c.check(repoID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.inflight, repoID)
+	<-c.sem
+	now := c.now()
+	if definitive {
+		c.verdicts[repoID] = dibsPublicVerdict{public: public, expires: now.Add(dibsPublicCheckTTL)}
+		return
+	}
+	// Transient failure: fall back to the prior verdict (zero value = excluded
+	// when there is none) and retry sooner than a full TTL.
+	prior := c.verdicts[repoID]
+	c.verdicts[repoID] = dibsPublicVerdict{public: prior.public, expires: now.Add(dibsPublicCheckErrTTL)}
+}
+
+// check asks the GitHub API whether repoID ("owner/name") is a public repo.
+// definitive=false means a transient failure the caller must not cache for a
+// full TTL.
+func (c *dibsPublicChecker) check(repoID string) (public, definitive bool) {
+	owner, name, ok := strings.Cut(repoID, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		// Not an owner/repo pair at all — permanently excludable, no API call.
+		return false, true
+	}
+	req, err := http.NewRequest(http.MethodGet,
+		c.apiBase+"/repos/"+url.PathEscape(owner)+"/"+url.PathEscape(name), nil)
+	if err != nil {
+		return false, true
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Warn("dibs public check: github unreachable", "repo", repoID, "error", err)
+		return false, false
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var payload struct {
+			Private *bool `json:"private"`
+		}
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil || payload.Private == nil {
+			// A 200 without a parseable private field is not a verdict.
+			return false, false
+		}
+		return !*payload.Private, true
+	case http.StatusNotFound:
+		// GitHub 404s both "private" and "nonexistent" to callers without
+		// access — either way, not publicly listable.
+		return false, true
+	default:
+		// 403/429 (rate limit), 5xx — transient; keep the prior verdict.
+		return false, false
+	}
+}

--- a/src/pkg/hub/dibs_public_feed_test.go
+++ b/src/pkg/hub/dibs_public_feed_test.go
@@ -1,0 +1,248 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// #4233 — the dibs repo feed lists repos that are ACTUALLY public on
+// github.com, verified against the GitHub API with a TTL verdict cache,
+// instead of requiring the is_public opt-in (false on every production hive,
+// so the feed could never populate). These tests drive the verification path
+// against a fake GitHub API server; dibs_sso_followups_test.go keeps the
+// static filtering (github_host, forge, placeholder) pins.
+// ============================================================
+
+// newTestDibsChecker builds a checker pointed at a fake GitHub API, mirroring
+// newDibsPublicChecker minus the env token read (tests must not inherit a
+// real token from the environment).
+func newTestDibsChecker(apiBase string) *dibsPublicChecker {
+	return &dibsPublicChecker{
+		verdicts: map[string]dibsPublicVerdict{},
+		inflight: map[string]bool{},
+		sem:      make(chan struct{}, dibsPublicCheckParallel),
+		apiBase:  apiBase,
+		client:   &http.Client{Timeout: 2 * time.Second},
+		logger:   slog.Default(),
+		now:      time.Now,
+	}
+}
+
+// fakeGitHubAPI serves GET /repos/{owner}/{repo} from a mutex-guarded
+// visibility map ("public"/"private"; absent = 404) and counts requests. A
+// set failAll makes every response a 500, simulating an outage/rate-limit.
+type fakeGitHubAPI struct {
+	mu       sync.Mutex
+	repos    map[string]string
+	requests atomic.Int64
+	failAll  atomic.Bool
+	srv      *httptest.Server
+}
+
+func (f *fakeGitHubAPI) setRepo(id, visibility string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.repos[id] = visibility
+}
+
+func newFakeGitHubAPI(t *testing.T, repos map[string]string) *fakeGitHubAPI {
+	t.Helper()
+	if repos == nil {
+		repos = map[string]string{}
+	}
+	f := &fakeGitHubAPI{repos: repos}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.requests.Add(1)
+		if f.failAll.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		f.mu.Lock()
+		visibility := f.repos[strings.TrimPrefix(r.URL.Path, "/repos/")]
+		f.mu.Unlock()
+		switch visibility {
+		case "public":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"private":false}`)
+		case "private":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"private":true}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// dibsFeed performs one handler call and returns the decoded entries.
+func dibsFeed(t *testing.T, s *HubServer) []dibsRepoEntry {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/dibs/repos", nil)
+	rec := httptest.NewRecorder()
+	s.handleDibsRepos(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/api/saas/dibs/repos = %d, want 200", rec.Code)
+	}
+	var got []dibsRepoEntry
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("feed body is not JSON: %v (body %s)", err, rec.Body.String())
+	}
+	return got
+}
+
+// waitForFeed polls the handler until it returns exactly the wanted repo IDs
+// (in sorted feed order) or times out. The verification is lazy/async by
+// design — the handler never blocks on the GitHub API — so tests converge the
+// way production does, across successive polls.
+func waitForFeed(t *testing.T, s *HubServer, want []string) []dibsRepoEntry {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	var got []dibsRepoEntry
+	for {
+		got = dibsFeed(t, s)
+		if len(got) == len(want) {
+			match := true
+			for i := range want {
+				if got[i].RepoID != want[i] {
+					match = false
+					break
+				}
+			}
+			if match {
+				return got
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("feed never converged: got %v, want repo IDs %v", got, want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestDibsReposVerifiesPublicOnGitHub pins the verification path: hives
+// WITHOUT the is_public opt-in are included exactly when the GitHub API says
+// their repo is public — "private": true and 404 (private or nonexistent)
+// both exclude — and every verdict, positive and negative, is served from the
+// cache afterwards without further API traffic.
+func TestDibsReposVerifiesPublicOnGitHub(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	gh := newFakeGitHubAPI(t, map[string]string{
+		"acme/widgets": "public",
+		"acme/secret":  "private",
+		// acme/ghost absent → 404
+	})
+	s.dibsPublic = newTestDibsChecker(gh.srv.URL)
+
+	for i, repo := range []string{"widgets", "secret", "ghost"} {
+		mkDibsHive(t, SaaSHive{
+			ID: fmt.Sprintf("hosted-verify-%d", i), Owner: "octocat", Org: "acme",
+			PrimaryRepo: repo, GitHubHost: "github.com", // is_public deliberately false
+		})
+	}
+
+	got := waitForFeed(t, s, []string{"acme/widgets"})
+	if got[0].HiveID != "hosted-verify-0" || got[0].Owner != "octocat" {
+		t.Errorf("verified entry = %+v, want hive hosted-verify-0 owned by octocat", got[0])
+	}
+
+	// Cache: all three verdicts (one positive, two negative) are now fresh,
+	// so further polls must not touch the GitHub API at all.
+	after := gh.requests.Load()
+	if after != 3 {
+		t.Errorf("verification made %d GitHub API calls, want exactly 3 (one per repo)", after)
+	}
+	for i := 0; i < 3; i++ {
+		waitForFeed(t, s, []string{"acme/widgets"})
+	}
+	if gh.requests.Load() != after {
+		t.Errorf("cached polls made %d further API calls, want 0 — both positive AND negative verdicts must cache", gh.requests.Load()-after)
+	}
+}
+
+// TestDibsReposIsPublicSkipsVerification pins the immediate-include lane: an
+// operator's explicit is_public opt-in needs no GitHub round-trip, so the
+// entry appears on the FIRST poll with zero API traffic.
+func TestDibsReposIsPublicSkipsVerification(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	gh := newFakeGitHubAPI(t, nil)
+	s.dibsPublic = newTestDibsChecker(gh.srv.URL)
+
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-optin", Owner: "octocat", Org: "acme",
+		PrimaryRepo: "widgets", GitHubHost: "github.com", IsPublic: true,
+	})
+
+	got := dibsFeed(t, s)
+	if len(got) != 1 || got[0].RepoID != "acme/widgets" {
+		t.Fatalf("first poll = %v, want the opted-in repo immediately (no async wait)", got)
+	}
+	if n := gh.requests.Load(); n != 0 {
+		t.Errorf("is_public include made %d GitHub API calls, want 0", n)
+	}
+}
+
+// TestDibsReposTTLExpiryAndTransientFallback pins the cache's time behavior:
+// an expired verdict is re-verified (so a repo flipping private disappears
+// within one TTL), and a TRANSIENT failure keeps serving the prior verdict
+// instead of dropping the repo or blocking the response.
+func TestDibsReposTTLExpiryAndTransientFallback(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	gh := newFakeGitHubAPI(t, map[string]string{"acme/widgets": "public"})
+	checker := newTestDibsChecker(gh.srv.URL)
+	var clockMu sync.Mutex
+	now := time.Now()
+	checker.now = func() time.Time { clockMu.Lock(); defer clockMu.Unlock(); return now }
+	advance := func(d time.Duration) { clockMu.Lock(); now = now.Add(d); clockMu.Unlock() }
+	s.dibsPublic = checker
+
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-ttl", Owner: "octocat", Org: "acme",
+		PrimaryRepo: "widgets", GitHubHost: "github.com",
+	})
+	waitForFeed(t, s, []string{"acme/widgets"})
+	base := gh.requests.Load()
+
+	// Fresh verdict: no re-check within the TTL.
+	waitForFeed(t, s, []string{"acme/widgets"})
+	if gh.requests.Load() != base {
+		t.Fatalf("re-checked a fresh verdict (%d extra calls)", gh.requests.Load()-base)
+	}
+
+	// TRANSIENT failure past the TTL: the stale POSITIVE verdict keeps the
+	// repo listed (never a flap on a GitHub hiccup), a re-check was attempted,
+	// and the failure is cached with the short error TTL (no hammering).
+	gh.failAll.Store(true)
+	advance(dibsPublicCheckTTL + time.Minute)
+	for i := 0; i < 3; i++ {
+		waitForFeed(t, s, []string{"acme/widgets"})
+	}
+	// Let the (single) background re-check land before counting.
+	time.Sleep(100 * time.Millisecond)
+	waitForFeed(t, s, []string{"acme/widgets"})
+	if gh.requests.Load() == base {
+		t.Error("expired verdict was never re-checked")
+	}
+
+	// Definitive flip past the error TTL: the repo went private, so the next
+	// re-verification drops it from the feed.
+	gh.failAll.Store(false)
+	gh.setRepo("acme/widgets", "private")
+	advance(dibsPublicCheckErrTTL + time.Minute)
+	waitForFeed(t, s, []string{})
+}

--- a/src/pkg/hub/dibs_sso_followups_test.go
+++ b/src/pkg/hub/dibs_sso_followups_test.go
@@ -141,6 +141,14 @@ func TestDibsReposShapeAndFiltering(t *testing.T) {
 		ID: "hosted-good-2", Owner: "hubber", Org: "some-org",
 		PrimaryRepo: "other-owner/tool", IsPublic: true,
 	})
+	// Included: the EXPLICIT "github.com" github_host production meta.json
+	// records actually store (spoke-heartbeat truth) means public GitHub,
+	// same as "" — the empty-only check excluded every production hive
+	// (#4233). Case-insensitive, and it outranks a cluster GHE default.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-good-3", Owner: "prodder", Org: "prod-org",
+		PrimaryRepo: "prod-repo", IsPublic: true, GitHubHost: "GitHub.com",
+	})
 	// Excluded: not public.
 	mkDibsHive(t, SaaSHive{
 		ID: "hosted-private", Owner: "octocat", Org: "secretcorp",
@@ -169,6 +177,14 @@ func TestDibsReposShapeAndFiltering(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/api/saas/dibs/repos", nil)
 	rec := httptest.NewRecorder()
+	// The non-is_public hive (hosted-private) reaches the public-repo verdict
+	// path; point it at a fake GitHub API that 404s everything so the test
+	// never touches the network and the repo stays excluded.
+	notFound := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer notFound.Close()
+	s.dibsPublic = newTestDibsChecker(notFound.URL)
 	s.handleDibsRepos(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -189,9 +205,10 @@ func TestDibsReposShapeAndFiltering(t *testing.T) {
 		t.Fatalf("body is not the expected JSON array: %v (body %s)", err, rec.Body.String())
 	}
 	want := map[string]struct{ hive, owner string }{
-		"kubestellar/hive": {"hosted-good-1", "octocat"},
-		"kubestellar/dibs": {"hosted-good-1", "octocat"},
-		"other-owner/tool": {"hosted-good-2", "hubber"},
+		"kubestellar/hive":   {"hosted-good-1", "octocat"},
+		"kubestellar/dibs":   {"hosted-good-1", "octocat"},
+		"other-owner/tool":   {"hosted-good-2", "hubber"},
+		"prod-org/prod-repo": {"hosted-good-3", "prodder"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("feed lists %d repos %v, want exactly the %d public github.com repos", len(got), got, len(want))

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -8617,19 +8617,32 @@ type dibsRepoEntry struct {
 }
 
 // handleDibsRepos lists the PUBLIC hive-managed repos for dibs's idea-matching
-// registry (#4193). Dibs polls this server-to-server with no browser session,
-// so the endpoint is deliberately unauthenticated — which is safe only because
-// every fact it returns is already public, and the inclusion rules below are
-// what make that true. A hive contributes its repos only when ALL hold:
+// registry (#4193, policy revised in #4233). Dibs polls this server-to-server
+// with no browser session, so the endpoint is deliberately unauthenticated —
+// which is safe only because every fact it returns is already public, and the
+// inclusion rules below are what make that true. A hive contributes a repo
+// only when ALL hold:
 //
-//   - is_public: the operator opted the hive into registry visibility (the
-//     same flag that gates the public hive registry), so its project identity
-//     is already published;
-//   - it lives on PUBLIC github.com — the GitHub-family forge with no GHE
-//     host pinned at hive or cluster level (effectiveGitHubBaseURL == "").
-//     An enterprise repo's very NAME can be confidential, so GHE hives are
-//     excluded outright;
-//   - it has a real assigned identity: a non-placeholder org (the synthetic
+//   - the repo is PUBLIC: either the operator set is_public (the registry-
+//     visibility opt-in, an immediate include with no API call), or the repo
+//     is verifiably public on github.com right now — an unauthenticated
+//     GET api.github.com/repos/{owner}/{repo} answering 200 with
+//     "private": false. Verdicts are cached in memory with a TTL and checked
+//     lazily in the background (dibs_public_check.go), so this handler never
+//     blocks on the GitHub API: an unverified repo is excluded until its
+//     verdict lands and the feed converges across dibs's 5-minute polls.
+//     The opt-in-only policy this replaces could never populate the feed —
+//     is_public is false on every production hive;
+//   - it lives on PUBLIC github.com. github_host "" and "github.com" both
+//     mean public GitHub (the sameGitHubHost normalization; production
+//     records store the EXPLICIT "github.com" the spoke heartbeats, which the
+//     original empty-only check wrongly excluded as GHE). A real GHE host is
+//     excluded outright — an enterprise repo's very NAME can be confidential.
+//     A cluster-level GHE default also excludes, unless the hive's own
+//     github_host explicitly says github.com (the spoke-reported truth
+//     outranks the cluster fallback);
+//   - it is GitHub-family (not the gitlab/gitea forge adapters) and has a
+//     real assigned identity: a non-placeholder org (the synthetic
 //     "available-<id>" inventory org never names a repo) and at least one
 //     repo recorded.
 //
@@ -8644,20 +8657,27 @@ func (s *HubServer) handleDibsRepos(w http.ResponseWriter, r *http.Request) {
 	entries := []dibsRepoEntry{}
 	seen := map[string]bool{}
 	for _, sh := range listSaaSHives() {
-		if !sh.IsPublic {
-			continue
-		}
 		// GitHub family only — the pkg/forge adapters (gitlab/gitea) never
 		// point at github.com repos.
 		if sh.Forge != "" && sh.Forge != "github" {
 			continue
 		}
-		// GHE anywhere in the resolution chain (heartbeat-recorded host,
-		// hive-level pin, or cluster default) excludes the hive.
-		if sh.GitHubHost != "" {
+		// "" and "github.com" both mean public GitHub; anything else is a
+		// real GHE host and excludes the hive. Production meta.json records
+		// carry the explicit "github.com" the spoke heartbeats (#4233).
+		explicitPublicHost := sh.GitHubHost != "" && sameGitHubHost(sh.GitHubHost, publicGitHubHost)
+		if sh.GitHubHost != "" && !explicitPublicHost {
 			continue
 		}
+		// A GHE pin elsewhere in the resolution chain (hive-level
+		// github_base_url, or the cluster default) also excludes — except
+		// that an explicit github.com github_host outranks the CLUSTER
+		// fallback: the host is spoke-reported truth, the cluster value only
+		// a default for hives that never said.
 		cluster := s.clusters[sh.ClusterID]
+		if explicitPublicHost {
+			cluster = ClusterConfig{}
+		}
 		if effectiveGitHubBaseURL(&sh, &cluster) != "" {
 			continue
 		}
@@ -8685,6 +8705,13 @@ func (s *HubServer) handleDibsRepos(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			seen[repoID] = true
+			// is_public stays an immediate include (the operator already
+			// published the identity); everything else must be verifiably
+			// public on github.com per the cached verdict (#4233). isPublic
+			// never blocks — it answers from the cache and refreshes lazily.
+			if !sh.IsPublic && !s.dibsChecker().isPublic(repoID) {
+				continue
+			}
 			entries = append(entries, dibsRepoEntry{
 				RepoID:      repoID,
 				HiveID:      sh.ID,

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -1115,6 +1115,13 @@ type HubServer struct {
 	// persisted to reachHistoryPath, read by /api/reach for before/after
 	// deltas. nil on bare test servers; every touch point is nil-safe.
 	reachHistory *reachHistoryStore
+
+	// dibsPublic caches "is this repo public on github.com?" verdicts for the
+	// dibs repo feed (#4233, dibs_public_check.go). Created lazily by
+	// dibsChecker on the first /api/saas/dibs/repos request; tests pre-set the
+	// field to point at a fake GitHub API before that first call.
+	dibsPublicOnce sync.Once
+	dibsPublic     *dibsPublicChecker
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.


### PR DESCRIPTION
Fixes #4233

`GET /api/saas/dibs/repos` returned `[]` in production, so dibs's "listed companies" board was empty. Two causes in `handleDibsRepos`, both fixed:

## 1. Bug: `github_host: "github.com"` excluded as GHE

The handler skipped any hive with a non-empty `github_host` — but production meta.json records (verified on the hive-oke PVC) store the **explicit** `"github.com"` the spoke heartbeats, so every public-GitHub hive was excluded. Now `""` and `"github.com"` both mean public GitHub, using the existing `sameGitHubHost` normalization (case-insensitive) so the check can't drift from the rest of the forge code. Only real GHE hosts exclude, and an explicit `github.com` host outranks a cluster-level GHE **default** (the host is spoke-reported truth; the cluster value is only a fallback for hives that never said).

## 2. Policy: the `is_public` opt-in gate could never populate the feed

`is_public` (owner opt-in registry visibility) is false on all 64 production hives. Founder decision: the feed lists hives whose repos are **actually public on github.com** regardless of the toggle — the feed only exposes already-public facts (repoID, owner login, project name).

### How the verification cache works (`dibs_public_check.go`)

- **Check:** unauthenticated `GET https://api.github.com/repos/{owner}/{repo}` — 200 with `"private": false` → public; 404 (GitHub's answer for both private and nonexistent) or `"private": true` → excluded.
- **Never on the request path:** the handler consults only the in-memory verdict cache; a missing/expired verdict schedules one deduplicated **background** refresh and the repo is excluded until its verdict lands. First responses after a restart are smaller and converge across dibs's 5-minute polls (dibs merges).
- **TTL:** definitive verdicts — positive **and** negative — cache for **1 h**, so a repo flipping visibility is picked up within one TTL and the unauthenticated 60/h rate limit comfortably covers ~30 repos.
- **Transient failure** (network error, 5xx, 403/429 rate limit): the **prior verdict is kept** (no flapping on a GitHub hiccup; excluded-by-default when there is none) with a **5-minute retry TTL** so an outage doesn't pin a stale answer for an hour.
- **Bounds:** max 4 concurrent checks (repos over the bound retry next poll), 5 s per-request timeout.
- **Token:** no hub-level GitHub token env existed in the codebase (only Slack + user/spoke tokens), so this adds optional **`HIVE_HUB_GITHUB_TOKEN`** — set it to raise the limit to 5000/h; unset means unauthenticated checks, which the TTL math fits.
- `is_public: true` remains an **immediate include** with zero API traffic. All other exclusions unchanged (non-GitHub forge, placeholder `available-*` orgs, empty org).

The endpoint doc comment is rewritten for the new policy.

## Tests

- github.com `github_host` inclusion (case-insensitive) and real-GHE exclusion (both `github_host` and `github_base_url` pins)
- verification path against a fake GitHub API server: public in, private and 404 out
- cache behavior: exactly one API call per repo, then zero on subsequent polls (positive and negative verdicts both cached)
- `is_public` immediate-include lane makes zero API calls
- TTL expiry triggers re-verification; transient 500s keep serving the prior verdict; a definitive private flip drops the repo

## Validation

- `go build ./... && go vet ./...` clean
- `go test ./pkg/hub/ -short -race -count=1` **passes** (141 s, run serially)
- Note: the v4 coverage gate may fail on the **unrelated** worksource package (~77 % vs 90 % floor, other session's code) — known issue, not touched by this PR; all tests for this change pass.
