### PR TITLE
✨ dibs feed: carry each hive's public contribute URL

### DIFF
--- a/src/pkg/hub/dibs_public_feed_test.go
+++ b/src/pkg/hub/dibs_public_feed_test.go
@@ -246,3 +246,63 @@ func TestDibsReposTTLExpiryAndTransientFallback(t *testing.T) {
 	advance(dibsPublicCheckErrTTL + time.Minute)
 	waitForFeed(t, s, []string{})
 }
+
+// TestDibsReposContributeURL pins the contributeURL field (#4238): built from
+// the claimed vanity URL when present, else the heartbeat-reported dashboard
+// URL; suffixed /contribute; omitted when the base is missing or private
+// (fail-closed, same guard as findContributeHive).
+func TestDibsReposContributeURL(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	gh := newFakeGitHubAPI(t, nil)
+	s.dibsPublic = newTestDibsChecker(gh.srv.URL)
+	stubPrivateURLResolver(t, "vanity.example.com", "dash.example.com")
+
+	// Vanity URL wins over the reported dashboard URL.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-vanity", Owner: "octocat", Org: "acme",
+		PrimaryRepo: "vanity-repo", GitHubHost: "github.com", IsPublic: true,
+		VanityURL: "https://vanity.example.com/", Status: "active",
+	})
+	// No vanity: the registry's heartbeat-reported dashboard URL is used.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-dash", Owner: "octocat", Org: "acme",
+		PrimaryRepo: "dash-repo", GitHubHost: "github.com", IsPublic: true,
+	})
+	// Private dashboard URL: fail closed, no link.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-priv", Owner: "octocat", Org: "acme",
+		PrimaryRepo: "priv-repo", GitHubHost: "github.com", IsPublic: true,
+	})
+	// No base at all: no link.
+	mkDibsHive(t, SaaSHive{
+		ID: "hosted-none", Owner: "octocat", Org: "acme",
+		PrimaryRepo: "none-repo", GitHubHost: "github.com", IsPublic: true,
+	})
+	s.registry.Hives = append(s.registry.Hives,
+		RegistryEntry{ID: "hosted-dash", DashboardURL: "https://dash.example.com"},
+		RegistryEntry{ID: "hosted-priv", DashboardURL: "http://127.0.0.1:8080"},
+	)
+
+	got := dibsFeed(t, s)
+	want := map[string]string{
+		"acme/vanity-repo": "https://vanity.example.com/contribute",
+		"acme/dash-repo":   "https://dash.example.com/contribute",
+		"acme/priv-repo":   "",
+		"acme/none-repo":   "",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("feed returned %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for _, e := range got {
+		w, ok := want[e.RepoID]
+		if !ok {
+			t.Errorf("unexpected entry %q", e.RepoID)
+			continue
+		}
+		if e.ContributeURL != w {
+			t.Errorf("%s contributeURL = %q, want %q", e.RepoID, e.ContributeURL, w)
+		}
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -8614,6 +8614,13 @@ type dibsRepoEntry struct {
 	HiveID      string `json:"hiveID"`
 	Owner       string `json:"owner"`
 	Description string `json:"description,omitempty"`
+	// ContributeURL is the hive's public /contribute page (ClankeR, the
+	// contributor relay), built from the claimed vanity URL when present or
+	// the heartbeat-reported dashboard URL otherwise (#4238). Empty when the
+	// hive has reported no public base — dibs falls back to the hub's public
+	// hive directory. Public info: the hub's own public-hives table renders
+	// this same link to anonymous visitors.
+	ContributeURL string `json:"contributeURL,omitempty"`
 }
 
 // handleDibsRepos lists the PUBLIC hive-managed repos for dibs's idea-matching
@@ -8656,6 +8663,16 @@ type dibsRepoEntry struct {
 func (s *HubServer) handleDibsRepos(w http.ResponseWriter, r *http.Request) {
 	entries := []dibsRepoEntry{}
 	seen := map[string]bool{}
+	// Heartbeat-reported dashboard bases, snapshotted once so the hive loop
+	// never holds the registry lock while doing per-repo work.
+	dashByID := map[string]string{}
+	s.mu.RLock()
+	for i := range s.registry.Hives {
+		if u := s.registry.Hives[i].DashboardURL; u != "" {
+			dashByID[s.registry.Hives[i].ID] = u
+		}
+	}
+	s.mu.RUnlock()
 	for _, sh := range listSaaSHives() {
 		// GitHub family only — the pkg/forge adapters (gitlab/gitea) never
 		// point at github.com repos.
@@ -8690,6 +8707,18 @@ func (s *HubServer) handleDibsRepos(w http.ResponseWriter, r *http.Request) {
 		if provider, subject, ok := parseCanonical(canonicalizeLegacy(owner)); ok && provider == legacyProvider {
 			owner = subject
 		}
+		// The hive's public contribute page: claimed vanity URL first (the
+		// validated, user-facing host), else the heartbeat-reported dashboard
+		// URL. Private/unset bases yield no link — same guard the hub's own
+		// contribute proxy applies (findContributeHive).
+		contributeURL := ""
+		base := claimedVanityURL(&sh)
+		if base == "" {
+			base = dashByID[sh.ID]
+		}
+		if base != "" && !isPrivateURL(r.Context(), base) {
+			contributeURL = strings.TrimRight(base, "/") + "/contribute"
+		}
 		for _, repo := range append([]string{sh.PrimaryRepo}, sh.Repos...) {
 			if repo == "" {
 				continue
@@ -8713,10 +8742,11 @@ func (s *HubServer) handleDibsRepos(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			entries = append(entries, dibsRepoEntry{
-				RepoID:      repoID,
-				HiveID:      sh.ID,
-				Owner:       owner,
-				Description: sh.ProjectName,
+				RepoID:        repoID,
+				HiveID:        sh.ID,
+				Owner:         owner,
+				Description:   sh.ProjectName,
+				ContributeURL: contributeURL,
 			})
 		}
 	}


### PR DESCRIPTION
Fixes #4238

Adds `contributeURL` to each `GET /api/saas/dibs/repos` entry: claimed vanity URL preferred, else heartbeat-reported dashboard URL, suffixed `/contribute`; omitted when missing or private (same `isPrivateURL` fail-closed guard as `findContributeHive`). Lets dibs's Donate-tokens flow deep-link each public hive's contribute page instead of the generic directory.

Known unrelated CI risk: per-package coverage gate may fail on packages not touched here (rotation was below floor on the previous PR).