### PR TITLE
✨ feature: add standalone runtime selector

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -108,6 +108,13 @@ jobs:
         working-directory: .
         run: bash bin/test_agent_env_scrub.sh
 
+      # #4205: standalone deployment selection is explicit and fail-closed.
+      # Docker remains the default; selecting Podman must never fall back to
+      # Docker because the Podman binary is missing or a command fails.
+      - name: Standalone runtime selection contract (#4205)
+        working-directory: .
+        run: bash bin/test_hive_standalone_runtime.sh
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'

--- a/bin/hive-standalone-runtime.sh
+++ b/bin/hive-standalone-runtime.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Select the container engine for standalone Hive deployments.
+#
+# This layer intentionally selects only the engine. Runtime-specific lifecycle
+# assets (Compose, Quadlet, and so on) remain responsible for their own
+# provider and version checks.
+
+HIVE_DEPLOY_RUNTIME_DEFAULT="docker"
+
+hive_deploy_runtime_select() {
+  local runtime="${HIVE_DEPLOY_RUNTIME:-$HIVE_DEPLOY_RUNTIME_DEFAULT}"
+
+  case "$runtime" in
+    docker|podman)
+      printf '%s\n' "$runtime"
+      ;;
+    *)
+      printf 'ERROR: unsupported HIVE_DEPLOY_RUNTIME=%q; expected docker or podman\n' "$runtime" >&2
+      return 64
+      ;;
+  esac
+}
+
+hive_deploy_runtime_require() {
+  local runtime
+  runtime="$(hive_deploy_runtime_select)" || return
+
+  if ! command -v "$runtime" >/dev/null 2>&1; then
+    printf 'ERROR: selected Hive deployment runtime %q is not installed or not in PATH\n' "$runtime" >&2
+    return 127
+  fi
+
+  printf '%s\n' "$runtime"
+}
+
+hive_deploy_runtime_report() {
+  local runtime
+  runtime="$(hive_deploy_runtime_require)" || return
+  printf 'Hive deployment runtime: %s (%s)\n' "$runtime" "$(command -v "$runtime")"
+}
+
+hive_deploy_runtime_run() {
+  local runtime
+  runtime="$(hive_deploy_runtime_require)" || return
+
+  printf 'Hive deployment runtime: %s (%s)\n' "$runtime" "$(command -v "$runtime")" >&2
+  "$runtime" "$@"
+}
+
+hive_deploy_runtime_usage() {
+  cat <<'EOF'
+Usage: hive-standalone-runtime.sh [report]
+       hive-standalone-runtime.sh run [--] <runtime-arguments...>
+
+HIVE_DEPLOY_RUNTIME selects docker or podman. It defaults to docker.
+The run command never falls back to a different runtime.
+EOF
+}
+
+hive_deploy_runtime_main() {
+  local action="${1:-report}"
+
+  case "$action" in
+    report)
+      [[ $# -le 1 ]] || {
+        hive_deploy_runtime_usage >&2
+        return 64
+      }
+      hive_deploy_runtime_report
+      ;;
+    run)
+      shift
+      [[ "${1:-}" == "--" ]] && shift
+      [[ $# -gt 0 ]] || {
+        printf 'ERROR: run requires runtime arguments\n' >&2
+        hive_deploy_runtime_usage >&2
+        return 64
+      }
+      hive_deploy_runtime_run "$@"
+      ;;
+    -h|--help|help)
+      hive_deploy_runtime_usage
+      ;;
+    *)
+      printf 'ERROR: unknown action %q\n' "$action" >&2
+      hive_deploy_runtime_usage >&2
+      return 64
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  hive_deploy_runtime_main "$@"
+fi

--- a/bin/test_hive_standalone_runtime.sh
+++ b/bin/test_hive_standalone_runtime.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Contract tests for bin/hive-standalone-runtime.sh.
+# Run: bash bin/test_hive_standalone_runtime.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELECTOR="${ROOT}/bin/hive-standalone-runtime.sh"
+BASH_BIN="$(command -v bash)"
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+FAKE_BIN="${TEST_TMP}/bin"
+mkdir -p "$FAKE_BIN"
+
+cat >"${FAKE_BIN}/docker" <<'EOF'
+#!/bin/sh
+printf 'docker:%s\n' "$*"
+exit "${FAKE_DOCKER_EXIT:-0}"
+EOF
+
+cat >"${FAKE_BIN}/podman" <<'EOF'
+#!/bin/sh
+printf 'podman:%s\n' "$*"
+exit "${FAKE_PODMAN_EXIT:-0}"
+EOF
+
+chmod +x "${FAKE_BIN}/docker" "${FAKE_BIN}/podman"
+TEST_PATH="${FAKE_BIN}:/usr/bin:/bin"
+
+pass_count=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local want="$1"
+  local got="$2"
+  local context="$3"
+  [[ "$got" == "$want" ]] || fail "${context}: got '${got}', want '${want}'"
+  pass_count=$((pass_count + 1))
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local context="$3"
+  [[ "$haystack" == *"$needle"* ]] || fail "${context}: missing '${needle}' in '${haystack}'"
+  pass_count=$((pass_count + 1))
+}
+
+run_capture() {
+  local stdout_file="${TEST_TMP}/stdout"
+  local stderr_file="${TEST_TMP}/stderr"
+  set +e
+  "$@" >"$stdout_file" 2>"$stderr_file"
+  RUN_STATUS=$?
+  set -e
+  RUN_STDOUT="$(cat "$stdout_file")"
+  RUN_STDERR="$(cat "$stderr_file")"
+}
+
+# Unset selection is exactly Docker, even when Podman is also installed.
+run_capture env -u HIVE_DEPLOY_RUNTIME PATH="$TEST_PATH" \
+  "$BASH_BIN" "$SELECTOR" run -- version
+assert_eq "0" "$RUN_STATUS" "default runtime status"
+assert_eq "docker:version" "$RUN_STDOUT" "default runtime command"
+assert_contains "$RUN_STDERR" "Hive deployment runtime: docker" "default runtime report"
+
+# Explicit Docker preserves the same behavior.
+run_capture env HIVE_DEPLOY_RUNTIME=docker PATH="$TEST_PATH" \
+  "$BASH_BIN" "$SELECTOR" run info
+assert_eq "0" "$RUN_STATUS" "explicit Docker status"
+assert_eq "docker:info" "$RUN_STDOUT" "explicit Docker command"
+assert_contains "$RUN_STDERR" "Hive deployment runtime: docker" "explicit Docker report"
+
+# Explicit Podman wins deterministically when both binaries are present.
+run_capture env HIVE_DEPLOY_RUNTIME=podman PATH="$TEST_PATH" \
+  "$BASH_BIN" "$SELECTOR" run info
+assert_eq "0" "$RUN_STATUS" "explicit Podman status"
+assert_eq "podman:info" "$RUN_STDOUT" "explicit Podman command"
+assert_contains "$RUN_STDERR" "Hive deployment runtime: podman" "explicit Podman report"
+
+# Unknown values fail before invoking either runtime.
+run_capture env HIVE_DEPLOY_RUNTIME=containerd PATH="$TEST_PATH" \
+  "$BASH_BIN" "$SELECTOR" run info
+assert_eq "64" "$RUN_STATUS" "invalid runtime status"
+assert_eq "" "$RUN_STDOUT" "invalid runtime command suppression"
+assert_contains "$RUN_STDERR" "expected docker or podman" "invalid runtime error"
+
+# A missing explicitly selected Podman binary must not fall back to Docker.
+DOCKER_ONLY_BIN="${TEST_TMP}/docker-only"
+mkdir -p "$DOCKER_ONLY_BIN"
+cp "${FAKE_BIN}/docker" "$DOCKER_ONLY_BIN/docker"
+run_capture env HIVE_DEPLOY_RUNTIME=podman PATH="$DOCKER_ONLY_BIN" \
+  "$BASH_BIN" "$SELECTOR" run info
+assert_eq "127" "$RUN_STATUS" "missing Podman status"
+assert_eq "" "$RUN_STDOUT" "missing Podman no-fallback command"
+assert_contains "$RUN_STDERR" "runtime podman is not installed" "missing Podman error"
+
+# Runtime command failures propagate unchanged and do not retry with Docker.
+run_capture env HIVE_DEPLOY_RUNTIME=podman FAKE_PODMAN_EXIT=42 PATH="$TEST_PATH" \
+  "$BASH_BIN" "$SELECTOR" run info
+assert_eq "42" "$RUN_STATUS" "Podman command failure status"
+assert_eq "podman:info" "$RUN_STDOUT" "Podman command failure no fallback"
+
+# The report action exposes the selected implementation without running it.
+run_capture env HIVE_DEPLOY_RUNTIME=podman PATH="$TEST_PATH" \
+  "$BASH_BIN" "$SELECTOR" report
+assert_eq "0" "$RUN_STATUS" "report status"
+assert_contains "$RUN_STDOUT" "Hive deployment runtime: podman" "report output"
+assert_eq "" "$RUN_STDERR" "report diagnostics"
+
+printf 'PASS: %d standalone runtime selector assertions\n' "$pass_count"


### PR DESCRIPTION
## Summary

- add `HIVE_DEPLOY_RUNTIME` selection with Docker as the default and Podman only by explicit request
- report the selected engine and fail clearly for invalid values or missing binaries
- preserve command failures without retrying through a different runtime
- add a shell contract test and run it in the existing v4 CI workflow

## Scope

This establishes only the deterministic engine-selection layer. It does not add Podman deployment assets or choose a Compose provider, which remain separate work items under the umbrella.

## Testing

- `bash bin/test_hive_standalone_runtime.sh` (20 assertions)
- `shellcheck bin/hive-standalone-runtime.sh bin/test_hive_standalone_runtime.sh`
- `actionlint -shellcheck='' .github/workflows/v2-ci.yml`
- `git diff --check upstream/v4...HEAD`

Live container startup was not run; the scoped selector contract uses stub Docker and Podman binaries and does not deploy containers.

Fixes #4205
Part of #4188

— hive: backend=codex