### PR TITLE
🐛 fix(contribute): never offer a tracker/umbrella issue as a task

### DIFF
--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -4414,6 +4414,29 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			lane, _ := issue["lane"].(string)
 			labels := stringSliceFromAny(issue["labels"])
 			assignees := stringSliceFromAny(issue["assignees"])
+
+			// A tracker/umbrella issue is coordination-only: its children carry
+			// the work and are queued independently, so handing the parent to one
+			// contributor is never right. The enumerator has flagged these all
+			// along (github.Issue.IsTracker) and this queue simply never read it —
+			// scheduler.go consumed the flag for a "[TRACKER]" prompt annotation
+			// and nothing else.
+			//
+			// Live cost of the omission: kubestellar/hive#4188 ("coordination-only
+			// umbrella. Do not assign #4188 as one Hive task", per its own body,
+			// above a 13-item child task list) was offered to a contributor, which
+			// spent the full 30-minute MAX_TASK_DURATION budget and booked a
+			// failure on an issue that only final integration can close. The agent
+			// behaved correctly throughout — it triaged the children and shipped
+			// one — but no agent can "complete" a parent like this.
+			//
+			// Logged rather than skipped silently: an issue that is never offered
+			// should not be a mystery to the operator watching the queue.
+			if isTracker, _ := issue["is_tracker"].(bool); isTracker {
+				h.logger.Info("[contribute-ws] skipping tracker/umbrella issue",
+					"repo", repo.Full, "number", number, "title", title)
+				continue
+			}
 			if requestedRole != "" && !h.issueMatchesAgentRole(requestedRole, title, labels, lane) {
 				continue
 			}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -572,7 +572,7 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 			UpdatedAt:  issue.GetUpdatedAt().Time,
 			AgeMinutes: ageMinutes,
 			URL:        issue.GetHTMLURL(),
-			IsTracker:  isTracker(issue.GetTitle(), labels),
+			IsTracker:  isTracker(issue.GetTitle(), labels, issue.GetBody()),
 		})
 	}
 
@@ -1082,7 +1082,36 @@ func (c *Client) isExempt(labels []string) bool {
 	return false
 }
 
-func isTracker(title string, labels []string) bool {
+// trackerTaskListRe matches a Markdown task-list item whose subject is an issue
+// reference — "- [ ] #4199", "* [x] owner/repo#12". This is deliberately
+// STRUCTURAL rather than a prose match: GitHub renders these lists specially
+// (the "N of M" tracked-task-list widget), so the pattern is a first-class
+// convention an author opts into, not a phrase they happened to write. Prose
+// gets reworded; structure does not.
+var trackerTaskListRe = regexp.MustCompile(`(?m)^\s*[-*]\s*\[[ xX]\]\s*(?:[\w.-]+/[\w.-]+)?#\d+`)
+
+// trackerTaskListMin is how many task-list issue references a body needs before
+// the issue counts as a tracker. One or two can legitimately appear on ordinary
+// work (a blocked-on note, an acceptance criterion); three or more is a
+// tracking list by construction.
+const trackerTaskListMin = 3
+
+// isTracker reports whether an issue is coordination-only — an umbrella whose
+// children carry the actual work — and so must never be handed out as a single
+// task.
+//
+// body is consulted because the title/label markers below miss the common case.
+// kubestellar/hive#4188 carried no labels and an ordinary "✨ feature:" title
+// while its body said, in a callout, "This is a coordination-only umbrella. Do
+// not assign #4188 as one Hive task", above a 13-item task list of children. It
+// was offered to a contributor anyway, which burned the full 30-minute task
+// budget and booked a failure on work that cannot be completed by one agent
+// (only final integration closes such a parent).
+//
+// The callout text itself is NOT matched — free-text matching is brittle in the
+// direction that hurts. The task list is enough, and it is what GitHub itself
+// treats as the tracking signal.
+func isTracker(title string, labels []string, body string) bool {
 	if strings.HasPrefix(title, "[Tracker]") {
 		return true
 	}
@@ -1090,6 +1119,11 @@ func isTracker(title string, labels []string) bool {
 		if l == "meta-tracker" {
 			return true
 		}
+	}
+	// FindAllString with a cap: we only care whether the threshold is reached,
+	// not how many refs a long umbrella body carries.
+	if len(trackerTaskListRe.FindAllString(body, trackerTaskListMin)) >= trackerTaskListMin {
+		return true
 	}
 	return false
 }

--- a/src/pkg/github/client_test.go
+++ b/src/pkg/github/client_test.go
@@ -573,21 +573,64 @@ func TestIsTracker(t *testing.T) {
 	tests := []struct {
 		title  string
 		labels []string
+		body   string
 		want   bool
 	}{
-		{"[Tracker] big epic", []string{}, true},
-		{"[Tracker]", []string{}, true},
-		{"regular issue", []string{"meta-tracker"}, true},
-		{"regular issue", []string{"bug", "meta-tracker"}, true},
-		{"regular issue", []string{"bug"}, false},
-		{"regular issue", []string{}, false},
-		{"", []string{}, false},
-		{"Not a tracker", []string{"tracker"}, false}, // label must be exactly "meta-tracker"
+		{"[Tracker] big epic", []string{}, "", true},
+		{"[Tracker]", []string{}, "", true},
+		{"regular issue", []string{"meta-tracker"}, "", true},
+		{"regular issue", []string{"bug", "meta-tracker"}, "", true},
+		{"regular issue", []string{"bug"}, "", false},
+		{"regular issue", []string{}, "", false},
+		{"", []string{}, "", false},
+		{"Not a tracker", []string{"tracker"}, "", false}, // label must be exactly "meta-tracker"
 	}
 	for _, tt := range tests {
-		got := isTracker(tt.title, tt.labels)
+		got := isTracker(tt.title, tt.labels, tt.body)
 		if got != tt.want {
-			t.Errorf("isTracker(%q, %v) = %v, want %v", tt.title, tt.labels, got, tt.want)
+			t.Errorf("isTracker(%q, %v, body=%d bytes) = %v, want %v", tt.title, tt.labels, len(tt.body), got, tt.want)
+		}
+	}
+}
+
+// A coordination-only umbrella carries its children as a Markdown task list of
+// issue references. kubestellar/hive#4188 is the live case: no labels, an
+// ordinary "feature:" title, and a 13-item child list — offered to a
+// contributor, which burned the whole 30-minute budget on work no single agent
+// can complete.
+//
+// The threshold matters in both directions, so both are pinned here: three or
+// more refs is a tracking list by construction, while one or two are ordinary
+// on real work (a blocked-on note, an acceptance criterion) and must stay
+// claimable.
+func TestIsTrackerFromBodyTaskList(t *testing.T) {
+	umbrella := `## Linked 30-minute work items
+
+- [ ] #4199 — Capture rootless startup and exit-77 behavior.
+- [ ] #4200 — Verify the rootful egress-gate baseline.
+- [ ] #4205 — Add explicit runtime selection with Docker as the default.
+`
+	twoRefs := "Blocked until these land:\n\n- [ ] #101\n- [x] #102\n"
+	oneRef := "Acceptance:\n\n- [ ] #101 must merge first\n"
+	prose := "We should track #101, #102, #103 and #104 before shipping.\n"
+	checklistNoRefs := "- [ ] write the tests\n- [ ] update docs\n- [x] file the issue\n"
+
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"umbrella with a child task list", umbrella, true},
+		{"cross-repo refs count too", "- [ ] owner/repo#1\n- [x] owner/repo#2\n* [ ] other/repo#3\n", true},
+		{"two refs stay claimable", twoRefs, false},
+		{"one ref stays claimable", oneRef, false},
+		{"bare prose mentions are not a task list", prose, false},
+		{"a checklist without issue refs is not a tracker", checklistNoRefs, false},
+		{"empty body", "", false},
+	}
+	for _, tt := range tests {
+		if got := isTracker("feature: something", nil, tt.body); got != tt.want {
+			t.Errorf("%s: isTracker(body) = %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

An umbrella issue is coordination-only: its children carry the work and are queued independently. Handing the parent to one contributor cannot succeed — by construction, only final integration closes it.

#4188 was offered anyway. The contributor spent the full 30-minute `MAX_TASK_DURATION` budget and had a failure booked against an issue that says, in its own body:

> [!IMPORTANT]
> **This is a coordination-only umbrella. Do not assign #4188 as one Hive task or expect one contributor/agent to complete it within the 30-minute task window.**

The agent behaved correctly throughout — it triaged all 13 children, picked the narrowest implementable one (#4205), and scoped its PR `Fixes #4205` / `Part of #4188` rather than claiming to close the parent. The queue was the problem.

**Backend-independent.** This is queue behaviour, not agent behaviour: any contributor on any CLI offered such a parent loses the same 30 minutes.

## Two independent gaps

**1. The queue never read the flag.** `github.Issue.IsTracker` has been computed at enumeration and serialized as `is_tracker` all along. `selectTask` referenced it **zero** times — `scheduler.go:613` consumed it for a `[TRACKER]` prompt annotation and nothing else. A correctly-flagged umbrella was still fully assignable.

**2. Detection could not see the common case.** `isTracker()` looked only at a `[Tracker]` title prefix or a `meta-tracker` label. #4188 has neither — no labels at all, ordinary `✨ feature:` title — and declares itself an umbrella in the body, above a 13-item child task list.

`issue.GetBody()` is already in hand at the call site (it comes back in the list response), so consulting it costs no extra API calls.

## Why the body rule is the task list, not the callout

Deliberately **structural**, not prose. The "coordination-only umbrella" text is *not* matched — free-text matching is brittle in the direction that hurts. `- [ ] #123` is rendered by GitHub as a tracked task list, so it is a convention an author opts into, and it survives rewording.

**Threshold is 3.** One or two refs appear on ordinary work (a blocked-on note, an acceptance criterion) and must stay claimable; three or more is a tracking list by construction. #4188 has thirteen.

The asymmetry justifies erring slightly liberal: a false positive means one issue is not offered to contributors and an operator can still work it. A false negative is what happened here — 30 minutes burned, a failure booked, and children at risk of duplicate work.

## Why not just label the umbrella?

Reasonable question, and worth answering up front: the label path is not currently usable.

- **`meta-tracker`** — the label `isTracker()` has always checked for — **does not exist** in this repository (`GET /labels/meta-tracker` → 404).
- **`Epic`** (*"Epic tracking issue"*) exists but is applied to **zero** issues.

So the label branch has been effectively dead code here, and there is no established umbrella convention in practice.

It is also not something a contributor can fix from outside: applying a label needs `triage`, and an external contributor has `pull` only. The person best placed to notice an umbrella is being mis-assigned is the contributor losing 30 minutes to it — and they cannot label it.

That is the case for detecting the structure the author already wrote, rather than depending on a label somebody with elevated access has to remember to apply. A maintainer adopting `meta-tracker` (or wiring `Epic` in) would still work and would take precedence — this change does not replace that, it makes the common case work without it.

## Skips are logged

An issue that is never offered should not be a mystery to the operator watching the queue.

## Tests

- `TestIsTracker` — existing title/label cases, extended for the new signature.
- `TestIsTrackerFromBodyTaskList` — pins **both** directions: 3+ refs (incl. cross-repo `owner/repo#1`) detected; two refs, one ref, bare prose mentions of `#101, #102, #103`, and a checklist with no issue refs all stay claimable.
- Verified against the **real #4188 body** fetched from the API — detected.

`go build ./...` clean; `pkg/github` and `pkg/dashboard` both pass.

## Not in scope

`bin/issue-classifier.sh` has its own divergent tracker rule (`[Auto-QA]`, `[Nightly]`, config-driven). Left alone — reconciling the two enumeration paths is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
