### PR TITLE
🐛 fix(contribute): tell contributor agents not to open draft PRs

### DIFF
--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -3911,7 +3911,22 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 			"Commit with 'git commit -s' so every commit carries a Signed-off-by "+
 			"trailer — the DCO check blocks the merge without it, and the trailer's "+
 			"email must match the commit author's email. "+
+			// Open it READY, not draft. A draft trips the repo's
+			// do-not-merge/work-in-progress automation and tide will not merge
+			// one, so a draft left behind is a PR nobody is waiting on and
+			// nothing will land. The prompt used to say only "open a PR", which
+			// an agent can satisfy perfectly well with `gh pr create --draft`.
+			//
+			// Observed live: the task for #4188 scoped down to child #4205 and
+			// ran `gh pr create --draft`, then verified `isDraft: true` and
+			// reported "Draft PR #4242 is open" as a SUCCESSFUL handoff — it had
+			// no reason to think otherwise. The contributor had to intervene by
+			// hand ("don't make them draft. Make sure they are submitted and
+			// ready for review") to get it marked ready.
 			"Push your branch to your fork remote, then open a PR from your fork. "+
+			"Open it ready for review, not as a draft (do not pass --draft): a draft "+
+			"is auto-labelled do-not-merge/work-in-progress and cannot merge. If a PR "+
+			"is already open as a draft, mark it ready for review. "+
 			"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN'). "+
 			// #3987: the no_work_needed sentinel. The relay scrapes this exact
 			// marker from the agent's output and reports it as the completion

--- a/src/pkg/dashboard/contribute_ws_ops_ext_test.go
+++ b/src/pkg/dashboard/contribute_ws_ops_ext_test.go
@@ -277,3 +277,23 @@ func TestBuildTaskPrompt_InstructsDCOSignoff(t *testing.T) {
 		t.Errorf("prompt must state the trailer email matches the author; got: %q", prompt)
 	}
 }
+
+// TestBuildTaskPrompt_ForbidsDraftPR: a draft PR is auto-labelled
+// do-not-merge/work-in-progress and tide will not merge one, so a draft left
+// behind is a PR nobody is waiting on and nothing will land. The prompt used to
+// say only "open a PR", which `gh pr create --draft` satisfies perfectly well.
+//
+// Observed live: the task for #4188 scoped down to child #4205, ran
+// `gh pr create --draft`, verified isDraft: true, and reported "Draft PR #4242
+// is open" as a successful handoff. The contributor had to say "don't make them
+// draft" by hand.
+func TestBuildTaskPrompt_ForbidsDraftPR(t *testing.T) {
+	prompt := buildTaskPrompt("myorg/repo1", 101, "Actionable issue")
+
+	if !strings.Contains(prompt, "ready for review") {
+		t.Errorf("prompt must ask for a PR ready for review; got: %q", prompt)
+	}
+	if !strings.Contains(prompt, "--draft") {
+		t.Errorf("prompt must name the --draft flag it is forbidding; got: %q", prompt)
+	}
+}


### PR DESCRIPTION
## Problem

The prompt said *"open a PR from your fork"* and stopped. `gh pr create --draft` satisfies that perfectly well — and a draft is auto-labelled `do-not-merge/work-in-progress` and cannot be merged by tide. A draft left behind is a PR nobody is waiting on and nothing will land.

## Observed live

The task for #4188 scoped down to child #4205 and opened #4242:

```
• Ran ... gh pr create --draft --repo kubestellar/hive ...
  └ {"isDraft":true,"number":4242,"state":"OPEN", ...}
• Draft PR #4242 is open.
• Opened draft PR kubestellar/hive#4242 ... — Implements child #4205 under the #4188 umbrella.
```

It reported that as a **successful handoff**, and it was right to — nothing had told it otherwise. The timeline shows what that cost:

```
10:17:54  labeled    do-not-merge/work-in-progress
10:19:20  ready_for_review
10:19:21  unlabeled  do-not-merge/work-in-progress
```

The gap closed only because the contributor intervened by hand:

> `› don't make them draft. Make sure they are submitted and ready for review`

**An agent that does not self-correct leaves the PR blocked indefinitely, and nothing in the loop notices.** The relay sees a PR URL and reports the task complete; `verifyReportedPRDetail` does not consult draft state either, so the completion verifies and the contributor even earns trust credit — for a PR that cannot merge.

## Change

Adds to the prompt, next to the other PR-handling steps:

> Open it ready for review, not as a draft (do not pass `--draft`): a draft is auto-labelled do-not-merge/work-in-progress and cannot merge. If a PR is already open as a draft, mark it ready for review.

The flag is named so the instruction is actionable rather than aspirational, and the recovery case is covered — an agent reusing a branch from a prior task can find a draft already open.

## Precedent

Same shape as #4177 (DCO sign-off), which demonstrably worked. On this very run the agent planned and applied sign-off unprompted:

```
□ Commit with DCO sign-off, push fork branch, and open the PR
"...identity matches the sign-off identity. I'm committing this reviewed patch now with DCO sign-off."
• Ran git commit -s -m "✨ feature: add standalone runtime selector"
```

Backend-independent: this is prompt text every contributor agent receives.

## Tests

New `TestBuildTaskPrompt_ForbidsDraftPR` asserts the prompt asks for a PR ready for review and names `--draft`. Reverting only `contribute_ws.go` fails both assertions.

`go build ./...` clean; `pkg/dashboard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)