### PR TITLE
🐛 copilot: canonicalize model ids against CLI-accepted nomenclature (fable.5 → fable-5)

### DIFF
--- a/src/pkg/agent/copilot_models.go
+++ b/src/pkg/agent/copilot_models.go
@@ -1,0 +1,110 @@
+package agent
+
+import "strings"
+
+// Copilot model-id nomenclature drift (#4262).
+//
+// The Copilot models catalog (the raw /models endpoint and the SDK helper
+// probe) periodically returns ids in a different nomenclature than the
+// copilot CLI's --model flag accepts, with version separators drifting
+// between "." and "-" in BOTH directions. Verified live on a spoke: copilot
+// CLI v1.0.78 rejected `--model claude-fable.5` ("is not available") and
+// switched itself to `claude-fable-5` — the CLI wants the DASHED form for
+// the -5 family (claude-fable-5, claude-sonnet-5, claude-opus-5) while
+// older families remain DOTTED (claude-opus-4.6, gpt-5.5, gemini-2.5-pro).
+//
+// Canonicalization is alias-based, never a blind rewrite: an id is matched
+// against the known CLI-accepted list with the separator drift collapsed,
+// and only an id that differs from a known-good id purely by "." vs "-"
+// drift is normalized to that known-good form. Everything else — unknown
+// ids, future models, the "auto" sentinel — passes through untouched, so a
+// catalog id we have never seen can still be selected and launched verbatim.
+
+// copilotCLIAcceptedModels are the model ids the copilot CLI's --model flag
+// accepts, in the CLI's own nomenclature. This is the alias target set for
+// CanonicalizeCopilotModel — NOT an allowlist: ids absent from this list are
+// passed through unchanged, so it only needs to cover ids whose separator
+// spelling is known to drift in the catalog. Note the deliberate mix: the
+// -5 family is DASHED, older families are DOTTED — exactly the drift the
+// canonicalization exists to absorb.
+var copilotCLIAcceptedModels = []string{
+	// Anthropic — the -5 family is DASHED in CLI nomenclature.
+	"claude-opus-5",
+	"claude-sonnet-5",
+	"claude-fable-5",
+	// Anthropic — the 4.x family is DOTTED.
+	"claude-opus-4.8",
+	"claude-opus-4.7",
+	"claude-opus-4.6",
+	"claude-opus-4.5",
+	"claude-sonnet-4.6",
+	"claude-sonnet-4.5",
+	"claude-haiku-4.5",
+	// OpenAI.
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
+	"gpt-5.5",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.3-codex",
+	"gpt-5.2",
+	"gpt-5-mini",
+	"gpt-4.1",
+	"gpt-4o",
+	"o3",
+	"o4-mini",
+	// Google.
+	"gemini-3.6-flash",
+	"gemini-3.5-flash",
+	"gemini-3.1-pro-preview",
+	"gemini-2.5-pro",
+	"gemini-flash-3.5",
+	// Others seen in live Copilot catalogs.
+	"grok-4.5",
+	"kimi-k3",
+	"kimi-k2.7-code",
+	"mai-code-1-flash-picker",
+}
+
+// copilotModelKey collapses the separator drift ("." vs "-") and case so two
+// spellings of the same model compare equal. Used ONLY as a lookup key into
+// the known-good list — never as an output form.
+func copilotModelKey(id string) string {
+	return strings.ToLower(strings.ReplaceAll(id, ".", "-"))
+}
+
+// copilotModelByKey maps each drift-collapsed key to its canonical CLI id.
+var copilotModelByKey = func() map[string]string {
+	m := make(map[string]string, len(copilotCLIAcceptedModels))
+	for _, id := range copilotCLIAcceptedModels {
+		k := copilotModelKey(id)
+		if _, exists := m[k]; !exists {
+			m[k] = id
+		}
+	}
+	return m
+}()
+
+// CanonicalizeCopilotModel normalizes a Copilot model id to the form the
+// copilot CLI's --model flag accepts. Handles separator drift in BOTH
+// directions (catalog dotted / CLI dashed, and vice versa):
+//
+//	claude-fable.5   -> claude-fable-5   (CLI wants dashed for the -5 family)
+//	claude-opus-4-6  -> claude-opus-4.6  (CLI wants dotted for the 4.x family)
+//	claude-fable-5   -> claude-fable-5   (already canonical — unchanged)
+//	gpt-5.5          -> gpt-5.5          (legitimate dot — unchanged)
+//	some-future-id   -> some-future-id   (unknown — passed through verbatim)
+//
+// Idempotent and safe to apply at every layer: discovery (so dropdowns show
+// canonical ids), model set (so stored selections are canonical), and launch
+// (so an already-stored bad id self-corrects without operator action).
+func CanonicalizeCopilotModel(id string) string {
+	if id == "" {
+		return id
+	}
+	if canonical, ok := copilotModelByKey[copilotModelKey(id)]; ok {
+		return canonical
+	}
+	return id
+}

--- a/src/pkg/agent/copilot_models_test.go
+++ b/src/pkg/agent/copilot_models_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import "testing"
+
+// TestCanonicalizeCopilotModel covers the Copilot model-id nomenclature drift
+// (#4262): the catalog periodically returns ids whose version separator
+// ("." vs "-") differs from what the copilot CLI's --model flag accepts, in
+// BOTH directions. Canonicalization is alias-based against the known
+// CLI-accepted list; anything unknown passes through verbatim.
+func TestCanonicalizeCopilotModel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Dotted -> dashed: the live bug. Copilot CLI v1.0.78 rejected
+		// `--model claude-fable.5` and wants the dashed -5 family form.
+		{"dotted fable to dashed", "claude-fable.5", "claude-fable-5"},
+		{"dotted sonnet to dashed", "claude-sonnet.5", "claude-sonnet-5"},
+		{"dotted opus to dashed", "claude-opus.5", "claude-opus-5"},
+
+		// Dashed passthrough: already-canonical ids are unchanged.
+		{"dashed fable unchanged", "claude-fable-5", "claude-fable-5"},
+		{"dashed sonnet unchanged", "claude-sonnet-5", "claude-sonnet-5"},
+
+		// Dashed -> dotted: the other drift direction (YAML-friendly ids).
+		{"dashed opus 4-6 to dotted", "claude-opus-4-6", "claude-opus-4.6"},
+		{"dashed sonnet 4-6 to dotted", "claude-sonnet-4-6", "claude-sonnet-4.6"},
+		{"dashed gpt 5-5 to dotted", "gpt-5-5", "gpt-5.5"},
+		{"dashed gemini to dotted", "gemini-2-5-pro", "gemini-2.5-pro"},
+
+		// Legitimate dots unchanged: canonical dotted ids must never be
+		// rewritten to dashes.
+		{"opus 4.6 unchanged", "claude-opus-4.6", "claude-opus-4.6"},
+		{"gpt 5.5 unchanged", "gpt-5.5", "gpt-5.5"},
+		{"gemini 2.5 pro unchanged", "gemini-2.5-pro", "gemini-2.5-pro"},
+		{"kimi k2.7 unchanged", "kimi-k2.7-code", "kimi-k2.7-code"},
+		{"gpt 5.6 sol unchanged", "gpt-5.6-sol", "gpt-5.6-sol"},
+
+		// Unknown ids pass through verbatim — this is an alias map, not an
+		// allowlist, so future catalog ids stay selectable and launchable.
+		{"unknown id unchanged", "some-future-model.9", "some-future-model.9"},
+		{"unknown dashless unchanged", "gpt-next", "gpt-next"},
+		{"auto sentinel unchanged", "auto", "auto"},
+		{"empty unchanged", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalizeCopilotModel(tt.in); got != tt.want {
+				t.Errorf("CanonicalizeCopilotModel(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalizeCopilotModelIdempotent: applying canonicalization twice must
+// equal applying it once — it is applied at discovery, model-set, AND launch,
+// so a value that has already been normalized flows through all three.
+func TestCanonicalizeCopilotModelIdempotent(t *testing.T) {
+	for _, id := range append([]string{"claude-fable.5", "claude-opus-4-6", "unknown.7"}, copilotCLIAcceptedModels...) {
+		once := CanonicalizeCopilotModel(id)
+		if twice := CanonicalizeCopilotModel(once); twice != once {
+			t.Errorf("not idempotent for %q: once=%q twice=%q", id, once, twice)
+		}
+	}
+}
+
+// TestNormalizeModelNameCopilotDrift verifies the launch-time path: the old
+// blind trailing-digits dot-rewrite corrupted claude-fable-5 into the
+// CLI-rejected claude-fable.5 (#4262); normalizeModelName must now emit
+// CLI-accepted spellings for copilot, self-correcting stored bad ids.
+func TestNormalizeModelNameCopilotDrift(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"claude-fable-5", "claude-fable-5"}, // dashed family must NOT gain a dot
+		{"claude-fable.5", "claude-fable-5"}, // stored bad id self-corrects at launch
+		{"claude-sonnet-5", "claude-sonnet-5"},
+		{"claude-opus-5", "claude-opus-5"},
+		{"claude-sonnet-4-6", "claude-sonnet-4.6"}, // YAML-friendly dashed still maps to dotted
+		{"claude-opus-4.6", "claude-opus-4.6"},     // legitimate dot unchanged
+		{"gpt-5.5", "gpt-5.5"},
+		{"gemini-2.5-pro", "gemini-2.5-pro"},
+		{"auto", "auto"},           // auto-select sentinel flows through
+		{"gpt-next", "gpt-next"},   // unknown id passthrough
+		{"custom-7", "custom-7"},   // unknown id: no blind dot-rewrite anymore
+	}
+	for _, tt := range tests {
+		if got := normalizeModelName(tt.in, "copilot"); got != tt.want {
+			t.Errorf("normalizeModelName(%q, copilot) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1780,7 +1780,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			// gh-wrapper/proxy layer only, not what the MCP may write.
 			launchCmd = base + claudeGitHubWriteDenyFlags
 		case "copilot":
-			// model is passed verbatim to `copilot --model %s`. It may be a
+			// model arrives here already canonicalized by normalizeModelName
+			// (CanonicalizeCopilotModel: separator drift like claude-fable.5 is
+			// normalized to the CLI-accepted claude-fable-5, #4262) and is then
+			// passed as-is to `copilot --model %s`. It may be a
 			// concrete id OR the auto-selection sentinel "auto" (copilotAutoModel
 			// in cli_models.go), which lets the Copilot CLI pick/adjust the model
 			// per task. Nothing here assumes a concrete id, so the sentinel flows
@@ -5500,8 +5503,10 @@ const claudeGitHubWriteDenyFlags = " --disallowed-tools 'mcp__github__create_pul
 //
 // No --model is passed, and that is load-bearing. bob auto-selects its own
 // model, and hive's normalizeModelName rewrites a trailing -<digits> to
-// .<digits> for every backend except claude/inference, so a configured
-// `claude-sonnet-4-6` reached bob as `claude-sonnet-4.6` — an id bob's backend
+// .<digits> for every backend except claude/copilot/inference (copilot uses
+// alias-based canonicalization instead, see CanonicalizeCopilotModel), so a
+// configured `claude-sonnet-4-6` reached bob as `claude-sonnet-4.6` — an id
+// bob's backend
 // does not know. Its model config came back undefined and every prompt died
 // with "🛑 Cannot read properties of undefined (reading 'maxTokens')". Verified
 // live: the same bob with no --model runs inference successfully.
@@ -5830,7 +5835,19 @@ func (m *Manager) ensureWorldWritable(root string) {
 
 // normalizeModelName converts YAML-friendly model names to the format each
 // CLI backend expects. Claude CLI uses hyphens (claude-opus-4-7), while
-// Copilot and other backends use dots (claude-opus-4.7).
+// gemini/goose/agy-style backends use dots (claude-opus-4.7).
+//
+// copilot does NOT take the blind trailing-digits dot-rewrite below: the
+// Copilot CLI's --model nomenclature mixes separators per model family
+// (claude-fable-5 is DASHED, claude-opus-4.6 is DOTTED), so the rewrite
+// corrupted every dashed-family id — verified live, copilot CLI v1.0.78
+// rejected the rewritten `claude-fable.5` ("is not available") and fell back
+// to a different model (#4262). copilot instead uses the alias-based
+// CanonicalizeCopilotModel (copilot_models.go), which normalizes separator
+// drift against the known CLI-accepted list in both directions and passes
+// unknown ids through verbatim. Applied here — at launch time — so an
+// already-stored bad id self-corrects on existing spokes without operator
+// action.
 //
 // Self-hosted inference backends (vllm, llm-d, litellm) are the outbound
 // gateway model id verbatim — the string must match an entitled model on the
@@ -5851,6 +5868,9 @@ func (m *Manager) ensureWorldWritable(root string) {
 func normalizeModelName(model, backend string) string {
 	if backend == "claude" || backend == bobBackend || IsInferenceBackend(backend) {
 		return model
+	}
+	if backend == "copilot" {
+		return CanonicalizeCopilotModel(model)
 	}
 	idx := strings.LastIndex(model, "-")
 	if idx < 0 || idx == len(model)-1 {
@@ -7459,6 +7479,15 @@ func (m *Manager) SetModelOverride(name, model string) error {
 	agent, ok := m.agents[name]
 	if !ok {
 		return fmt.Errorf("agent %s not found", name)
+	}
+
+	// Store the CLI-accepted spelling for copilot so the persisted selection,
+	// the dropdown preselect, and auto-heal all agree on one canonical id
+	// (separator drift like claude-fable.5 vs claude-fable-5, #4262). Launch
+	// re-applies the same canonicalization, so even ids stored before this
+	// existed self-correct there.
+	if agent.effectiveBackend() == "copilot" {
+		model = CanonicalizeCopilotModel(model)
 	}
 
 	// A pin blocks the governor's auto-selection, never a user's explicit

--- a/src/pkg/agent/manager_coverage2_test.go
+++ b/src/pkg/agent/manager_coverage2_test.go
@@ -1065,14 +1065,28 @@ func TestNormalizeModelName_EdgeCases(t *testing.T) {
 		{"no-hyphen", "no-hyphen"},
 		{"trailing-", "trailing-"},
 		{"-leading", "-leading"},
-		{"a-b-c-1", "a-b-c.1"},
-		{"just-123", "just.123"},
+		// Unknown copilot ids pass through VERBATIM (#4262): the old blind
+		// digit-suffix dot-rewrite is what corrupted the known claude-fable-5
+		// into the CLI-rejected claude-fable.5. Copilot ids are canonicalized
+		// against the CLI-accepted list instead (see CanonicalizeCopilotModel).
+		{"a-b-c-1", "a-b-c-1"},
+		{"just-123", "just-123"},
 		{"model", "model"},
 	}
 	for _, tt := range tests {
 		got := normalizeModelName(tt.input, "copilot")
 		if got != tt.want {
 			t.Errorf("normalizeModelName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+
+	// The digit-suffix dot-rewrite still applies to non-copilot CLI backends.
+	for _, tt := range []struct{ input, want string }{
+		{"a-b-c-1", "a-b-c.1"},
+		{"just-123", "just.123"},
+	} {
+		if got := normalizeModelName(tt.input, "gemini"); got != tt.want {
+			t.Errorf("normalizeModelName(%q, gemini) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/src/pkg/agent/routing_coverage_test.go
+++ b/src/pkg/agent/routing_coverage_test.go
@@ -297,9 +297,17 @@ func TestConnectionMCPFlags_NonClaude(t *testing.T) {
 
 func TestNormalizeModelName(t *testing.T) {
 	cases := []struct{ model, backend, want string }{
-		{"opus", "claude", "opus"},                      // claude passes through
-		{"deepseek-14", "litellm", "deepseek-14"},       // inference passes through
-		{"gpt-4o-2024", "copilot", "gpt-4o.2024"},       // digit suffix -> dot
+		{"opus", "claude", "opus"},                // claude passes through
+		{"deepseek-14", "litellm", "deepseek-14"}, // inference passes through
+		// copilot no longer takes the blind digit-suffix dot-rewrite (#4262):
+		// ids are canonicalized against the CLI-accepted list and UNKNOWN ids
+		// pass through verbatim — the rewrite is what corrupted the known
+		// claude-fable-5 into the CLI-rejected claude-fable.5.
+		{"gpt-4o-2024", "copilot", "gpt-4o-2024"},        // unknown id passthrough
+		{"claude-fable-5", "copilot", "claude-fable-5"},  // dashed family kept dashed
+		{"claude-fable.5", "copilot", "claude-fable-5"},  // stored bad id self-corrects
+		{"claude-opus-4-6", "copilot", "claude-opus-4.6"}, // known dotted family still mapped
+		{"gpt-4o-2024", "gemini", "gpt-4o.2024"},        // digit suffix -> dot (non-copilot)
 		{"gpt-4o-preview", "copilot", "gpt-4o-preview"}, // non-digit suffix unchanged
 		{"nohyphen", "copilot", "nohyphen"},             // no hyphen
 		{"trailing-", "copilot", "trailing-"},           // trailing hyphen

--- a/src/pkg/agent/sandbox_executor.go
+++ b/src/pkg/agent/sandbox_executor.go
@@ -296,7 +296,9 @@ func sandboxCommand(cfg configSnapshot, promptRel string) ([]string, error) {
 	case "copilot":
 		cmd = binary + " --no-auto-update --allow-all"
 		if cfg.Model != "" {
-			cmd += " --model " + shellQuote(cfg.Model)
+			// Canonicalize separator drift (claude-fable.5 -> claude-fable-5)
+			// so a stored bad id never reaches --model (#4262).
+			cmd += " --model " + shellQuote(CanonicalizeCopilotModel(cfg.Model))
 		}
 	default:
 		cmd = binary

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/beads"
 	"github.com/kubestellar/hive/pkg/classify"
 	"github.com/kubestellar/hive/pkg/config"
@@ -1309,6 +1310,12 @@ func (s *Server) validateModelForAgent(name, model string) error {
 	known := s.modelIDsForBackend(backend)
 	if len(known) == 0 {
 		return nil // cannot enumerate — do not block
+	}
+	// Copilot catalog/CLI nomenclature drifts between "." and "-" (#4262):
+	// the served list is canonical, so compare the canonicalized candidate
+	// rather than rejecting a dotted/dashed variant of an available model.
+	if backend == "copilot" {
+		model = agent.CanonicalizeCopilotModel(model)
 	}
 	for _, id := range known {
 		if id == model {

--- a/src/pkg/dashboard/cli_models.go
+++ b/src/pkg/dashboard/cli_models.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/claude"
 )
 
@@ -300,6 +301,11 @@ var copilotStaticModels = []string{
 	"gpt-5.2",
 	"gpt-4.1",
 	"gpt-4o",
+	// The -5 family is DASHED in copilot CLI nomenclature; the 4.x family is
+	// DOTTED. Keep in sync with agent.copilotCLIAcceptedModels (#4262).
+	"claude-opus-5",
+	"claude-sonnet-5",
+	"claude-fable-5",
 	"claude-opus-4.6",
 	"claude-sonnet-4.6",
 	"claude-sonnet-4.5",
@@ -600,7 +606,7 @@ func (s *Server) discoverCopilotModels() cliModelResult {
 	} else if len(models) == 0 {
 		s.logger.Info("copilot SDK model discovery returned no models, falling back to HTTP probe")
 	} else {
-		return cliModelResult{models: dedupeModels(models), fallback: false}
+		return cliModelResult{models: dedupeModels(canonicalizeCopilotModelIDs(models)), fallback: false}
 	}
 
 	if token == "" {
@@ -620,7 +626,24 @@ func (s *Server) discoverCopilotModels() cliModelResult {
 		}
 		return cliModelResult{fallback: true}
 	}
-	return cliModelResult{models: dedupeModels(models), fallback: false}
+	return cliModelResult{models: dedupeModels(canonicalizeCopilotModelIDs(models)), fallback: false}
+}
+
+// canonicalizeCopilotModelIDs maps every discovered Copilot catalog id to the
+// nomenclature the copilot CLI's --model flag accepts (#4262): the catalog
+// periodically returns ids whose version separator drifts between "." and "-"
+// relative to the CLI (e.g. claude-fable.5 vs the CLI-accepted claude-fable-5).
+// Normalizing at discovery time keeps the dropdown, the stored selections it
+// produces, AND the stabilize/auto-heal retention keys in one canonical
+// spelling, so a sample that flips separators can never look like a new model
+// appearing plus the old one vanishing (false "model revoked" churn). Unknown
+// ids pass through verbatim (see agent.CanonicalizeCopilotModel).
+func canonicalizeCopilotModelIDs(in []string) []string {
+	out := make([]string, len(in))
+	for i, id := range in {
+		out[i] = agent.CanonicalizeCopilotModel(id)
+	}
+	return out
 }
 
 // runCopilotSDKHelper executes the SDK helper and returns its stdout. A

--- a/src/pkg/dashboard/cli_models_sdk_test.go
+++ b/src/pkg/dashboard/cli_models_sdk_test.go
@@ -154,3 +154,72 @@ func TestProbeCopilotModelsSDK_HelperNotInstalled(t *testing.T) {
 		t.Skip("copilot SDK helper present on this machine; skipping absence check")
 	}
 }
+
+// TestDiscoverCopilotModels_CanonicalizesNomenclatureDrift verifies discovery
+// normalizes catalog ids whose version separator drifts from the copilot
+// CLI's --model nomenclature (#4262): a catalog sample carrying the dotted
+// claude-fable.5 is served as the CLI-accepted claude-fable-5, canonical
+// dotted ids (claude-opus-4.6, gpt-5.5, gemini-2.5-pro) are untouched, and
+// unknown ids pass through verbatim. Because the served list is canonical,
+// the stabilize/auto-heal retention keys can never see the same model under
+// two spellings (false "model revoked" churn).
+func TestDiscoverCopilotModels_CanonicalizesNomenclatureDrift(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		return []byte(`{"models":[
+			{"id":"claude-fable.5","policyState":"enabled"},
+			{"id":"claude-opus-4.6","policyState":"enabled"},
+			{"id":"gpt-5.5","policyState":"enabled"},
+			{"id":"gemini-2.5-pro","policyState":"enabled"},
+			{"id":"some-future-model.9","policyState":"enabled"}
+		]}`), nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.discoverCopilotModels()
+	if r.fallback {
+		t.Fatalf("SDK success must be a live result, got %+v", r)
+	}
+	want := []string{"claude-fable-5", "claude-opus-4.6", "gpt-5.5", "gemini-2.5-pro", "some-future-model.9"}
+	if !equalStrings(r.models, want) {
+		t.Fatalf("got %v, want canonicalized %v", r.models, want)
+	}
+}
+
+// TestStabilize_NomenclatureDriftNoChurn verifies alternating catalog samples
+// that flip a model's separator spelling do not accumulate duplicate retained
+// entries once discovery canonicalizes ids: both spellings collapse to one
+// retention key, so the same model can never be counted absent while present.
+func TestStabilize_NomenclatureDriftNoChurn(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	samples := [][]byte{
+		[]byte(`{"models":[{"id":"claude-fable.5","policyState":"enabled"}]}`),
+		[]byte(`{"models":[{"id":"claude-fable-5","policyState":"enabled"}]}`),
+		[]byte(`{"models":[{"id":"claude-fable.5","policyState":"enabled"}]}`),
+	}
+	i := 0
+	swapSDKHelper(t, func(ctx context.Context, token string) ([]byte, error) {
+		out := samples[i%len(samples)]
+		i++
+		return out, nil
+	})
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	for n := 0; n < 3; n++ {
+		s.cliModels.entries = map[string]cliModelCacheEntry{}
+		r := s.queryCLIModels("copilot")
+		if r.fallback {
+			t.Fatalf("sample %d: live result expected, got %+v", n, r)
+		}
+		count := 0
+		for _, m := range r.models {
+			if m == "claude-fable-5" {
+				count++
+			}
+			if m == "claude-fable.5" {
+				t.Fatalf("sample %d: non-canonical spelling served: %v", n, r.models)
+			}
+		}
+		if count != 1 {
+			t.Fatalf("sample %d: want exactly one claude-fable-5, got %v", n, r.models)
+		}
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -7218,6 +7218,12 @@
       // always-valid selection that reconcileModelsAfterDiscovery never heals.
       { value: 'auto', label: 'Auto (Copilot picks)' },
       { value: 'mai-code-1-flash-picker', label: 'MAI Code 1 Flash' },
+      // The -5 family is DASHED in copilot CLI nomenclature (claude-fable-5,
+      // not claude-fable.5) while the 4.x family is DOTTED — keep in sync with
+      // copilotCLIAcceptedModels in pkg/agent/copilot_models.go (#4262).
+      { value: 'claude-opus-5', label: 'Opus 5' },
+      { value: 'claude-sonnet-5', label: 'Sonnet 5' },
+      { value: 'claude-fable-5', label: 'Fable 5' },
       { value: 'claude-opus-4.6', label: 'Opus 4.6' },
       { value: 'claude-sonnet-4.6', label: 'Sonnet 4.6' },
       { value: 'claude-sonnet-4.5', label: 'Sonnet 4.5' },
@@ -7613,7 +7619,12 @@
       }
     }
 
-    function _normalizeModel(m) { return (m || '').replace(/(\d+)\.(\d+)$/, '$1-$2'); }
+    // _normalizeModel collapses the "." vs "-" separator drift between the
+    // catalog and CLI spellings of the SAME model id (claude-fable.5 vs
+    // claude-fable-5, claude-opus-4.6 vs claude-opus-4-6, #4262). Applied to
+    // BOTH sides of every comparison, so mapping all dots to dashes is a pure
+    // equivalence key — never a display or launch value.
+    function _normalizeModel(m) { return (m || '').replace(/\./g, '-'); }
     function _modelsEqual(a, b) { return _normalizeModel(a) === _normalizeModel(b); }
 
     function _modelTier(model) {


### PR DESCRIPTION
Fixes the live spoke bug where Copilot CLI v1.0.78 rejected `--model claude-fable.5` ("is not available") and silently switched models — the CLI accepts `claude-fable-5` (dashed).

Confirmed by the operator: dotted `claude-opus-4.6` works, dotted `claude-fable.5` does not — dotted minor versions (4.6, 5.5, 2.5) are legitimate CLI ids, whole-number families like fable 5 are dashed.

## Root cause
`normalizeModelName` (pkg/agent/manager.go) blindly rewrote a trailing `-<digits>` group to `.<digits>` for the copilot backend, corrupting every dashed-family id. The models catalog also periodically returns ids whose separator drifts from the CLI nomenclature, in both directions.

## Fix — alias-based canonicalization (`CanonicalizeCopilotModel`)
An id is matched against the known CLI-accepted list with the `.`/`-` drift collapsed; only an id differing purely by separator drift from a known-good id is normalized. Unknown ids and legitimately dotted ids (`claude-opus-4.6`, `gpt-5.5`, `gemini-2.5-pro`) pass through verbatim.

Applied at every layer:
- **launch time** (`normalizeModelName` + sandbox executor) — already-stored `claude-fable.5` selections self-correct on existing spokes without operator action
- **discovery time** (SDK helper + raw-HTTP probes) — dropdowns and stabilize/auto-heal retention keys use one canonical spelling
- **model set / validation** — stored selections are canonical; dotted variants of available models are not rejected
- **frontend auto-heal** — `_normalizeModel` is now fully separator-insensitive (old regex only matched `<digit>.<digit>$`, missing `fable.5`), so `claude-fable.5` and `claude-fable-5` are the same model: no false "model revoked" churn

Static copilot lists (Go + frontend) gain the dashed -5 family (`claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`).

## Tests
- dotted→dashed (`claude-fable.5` → `claude-fable-5`), dashed passthrough
- dashed→dotted (`claude-opus-4-6` → `claude-opus-4.6`, `gpt-5-5` → `gpt-5.5`)
- legitimate dots unchanged (`claude-opus-4.6`, `gpt-5.5`, `gemini-2.5-pro`, `kimi-k2.7-code`)
- unknown ids passthrough, `auto` sentinel untouched, idempotence
- discovery canonicalization end-to-end; stabilize no-churn across separator-flipping catalog samples

Validated: `go build ./...`, `go vet`, `go test ./pkg/agent/ ./pkg/dashboard/` all pass.

Closes #4262
