### PR TITLE
🧹 podman: define Hive-owned resources and a safe cleanup contract

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -115,6 +115,16 @@ jobs:
         working-directory: .
         run: bash bin/test_hive_standalone_runtime.sh
 
+      # #4210: rootless Podman/Buildah share one store with the operator's
+      # unrelated containers, Distroboxes, and builds, so Hive cleanup must
+      # select only Hive-labelled resources and the broad store-wide prune,
+      # reset, and remove-all forms are rejected outright. See
+      # src/docs/podman-ownership-cleanup.md. The test analyses arguments only:
+      # it contacts no engine and deletes nothing.
+      - name: Podman ownership and cleanup contract (#4210)
+        working-directory: .
+        run: bash bin/test_hive_podman_cleanup.sh
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'

--- a/bin/README.md
+++ b/bin/README.md
@@ -55,6 +55,8 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `hive-setup.sh` | Bootstrap | All-in-one Ubuntu 24.04 LXC setup for a Docker-based Hive v2 instance, including generated `hive.yaml` and env files. |
 | `hive-prereq-check.sh` | Bootstrap | Validates host prerequisites for a Docker-based Hive v2 install and can attempt fixes with `--fix`. |
 | `hive-deploy.sh` | Deploy | Pulls the latest Hive repository and syncs scripts to `/usr/local/bin`; also restarts Discord bot components when their files change. |
+| `hive-standalone-runtime.sh` | Deploy | Selects the standalone container engine from `HIVE_DEPLOY_RUNTIME` (`docker` by default) and runs commands against it without ever falling back to the other engine. |
+| `hive-podman-cleanup.sh` | Deploy | Defines the Hive ownership labels for Podman containers, pods, networks, volumes, and images, and guards cleanup so it can never widen into a store-wide Podman/Buildah operation. See [`src/docs/podman-ownership-cleanup.md`](../src/docs/podman-ownership-cleanup.md). |
 | `federation-heartbeat.sh` | Federation | Sends live contributor and actionable-work stats to the Hive federation registry. |
 | `notify.sh` | Notifications | Shared Bash notification library for ntfy, Slack incoming webhooks, and Discord webhooks. |
 
@@ -84,3 +86,5 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `contributor-agent.test.sh` | Contributor-agent regression for knowledge export handling. |
 | `contributor-relay.test.js` | Contributor relay task/restart/headless behavior; loads `contributor-relay.sh` as JavaScript with stubs. |
 | `gh-wrapper.test.sh` | `gh-wrapper.sh` author-gate and restriction regressions using a mock `gh` binary. |
+| `test_hive_standalone_runtime.sh` | `hive-standalone-runtime.sh` engine selection: Docker default, explicit Podman, and no silent fallback. |
+| `test_hive_podman_cleanup.sh` | `hive-podman-cleanup.sh` ownership labels and cleanup guard. Analyses arguments only: it contacts no container engine and deletes nothing. |

--- a/bin/hive-podman-cleanup.sh
+++ b/bin/hive-podman-cleanup.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# Hive-owned Podman resources and the safe cleanup contract (#4210).
+#
+# Rootless Podman and Buildah share one image/container store with whatever
+# else the operator runs on the host: unrelated development containers,
+# Distroboxes, and local builds. Hive lifecycle tooling therefore must never
+# translate broad Docker cleanup into a global Podman operation. This file is
+# the single source of truth for two things:
+#
+#   1. The stable labels that mark a resource as Hive-owned.
+#   2. A guard that rejects any Podman/Buildah cleanup command that is not
+#      restricted to those labels or to explicit Hive-owned operands.
+#
+# Scope: ownership and the cleanup contract only. Actually tearing resources
+# down belongs to the later Podman lifecycle work, which must call
+# hive_podman_cleanup_check before running anything destructive. Docker
+# cleanup behavior is deliberately untouched by this contract.
+
+# --- Ownership labels -------------------------------------------------------
+#
+# Applied at create/build time to every Hive-owned container, pod, network,
+# volume, and image. Selected at cleanup time as filters. Reverse-DNS keys keep
+# them from colliding with labels other tools put in the same shared store.
+
+HIVE_PODMAN_OWNED_LABEL_KEY="io.kubestellar.hive.owned"
+HIVE_PODMAN_OWNED_LABEL_VALUE="true"
+HIVE_PODMAN_COMPONENT_LABEL_KEY="io.kubestellar.hive.component"
+HIVE_PODMAN_INSTANCE_LABEL_KEY="io.kubestellar.hive.instance"
+HIVE_PODMAN_RUNTIME_LABEL_KEY="io.kubestellar.hive.runtime"
+
+# The one selector every cleanup command must carry.
+HIVE_PODMAN_OWNED_LABEL="${HIVE_PODMAN_OWNED_LABEL_KEY}=${HIVE_PODMAN_OWNED_LABEL_VALUE}"
+
+HIVE_PODMAN_INSTANCE_DEFAULT="default"
+
+# Podman/Buildah global options that consume a separate value. They must be
+# skipped when locating the subcommand, or `podman --root /tmp/x rm c1` parses
+# as if `/tmp/x` were the verb.
+HIVE_PODMAN_VALUE_OPTIONS=(
+  --cgroup-manager --cni-config-dir --conmon --connection --events-backend
+  --hooks-dir --identity --log-level --module --namespace --network-cmd-path
+  --registries-conf --root --runroot --ssh --storage-driver --storage-opt
+  --tmpdir --url -c -r
+)
+
+hive_podman_instance() {
+  local instance="${HIVE_DEPLOY_INSTANCE:-$HIVE_PODMAN_INSTANCE_DEFAULT}"
+
+  # The instance name lands inside label filters, so keep it to characters that
+  # cannot smuggle a second filter term or a shell metacharacter.
+  if [[ ! "$instance" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    printf 'ERROR: invalid HIVE_DEPLOY_INSTANCE=%q; expected [A-Za-z0-9][A-Za-z0-9._-]*\n' \
+      "$instance" >&2
+    return 64
+  fi
+
+  printf '%s\n' "$instance"
+}
+
+# Create/build-time labels, one CLI argument per line.
+# Usage: hive_podman_labels <component>
+hive_podman_labels() {
+  local component="${1:-}"
+  local instance
+
+  if [[ -z "$component" ]]; then
+    printf 'ERROR: labels requires a component name\n' >&2
+    return 64
+  fi
+
+  if [[ ! "$component" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    printf 'ERROR: invalid component %q; expected [A-Za-z0-9][A-Za-z0-9._-]*\n' "$component" >&2
+    return 64
+  fi
+
+  instance="$(hive_podman_instance)" || return
+
+  printf -- '--label\n%s\n' "$HIVE_PODMAN_OWNED_LABEL"
+  printf -- '--label\n%s=%s\n' "$HIVE_PODMAN_COMPONENT_LABEL_KEY" "$component"
+  printf -- '--label\n%s=%s\n' "$HIVE_PODMAN_INSTANCE_LABEL_KEY" "$instance"
+  printf -- '--label\n%s=%s\n' "$HIVE_PODMAN_RUNTIME_LABEL_KEY" "podman"
+}
+
+# Cleanup-time selectors, one CLI argument per line.
+hive_podman_filters() {
+  local instance
+  instance="$(hive_podman_instance)" || return
+
+  printf -- '--filter\nlabel=%s\n' "$HIVE_PODMAN_OWNED_LABEL"
+  printf -- '--filter\nlabel=%s=%s\n' "$HIVE_PODMAN_INSTANCE_LABEL_KEY" "$instance"
+}
+
+# --- Cleanup guard ----------------------------------------------------------
+
+_hive_podman_is_value_option() {
+  local candidate="$1"
+  local option
+
+  for option in "${HIVE_PODMAN_VALUE_OPTIONS[@]}"; do
+    [[ "$candidate" == "$option" ]] && return 0
+  done
+
+  return 1
+}
+
+# Splits a Podman/Buildah command into tool, resource noun, verb, and the
+# remaining arguments. Sets HIVE_GUARD_TOOL, HIVE_GUARD_NOUN, HIVE_GUARD_VERB,
+# and the HIVE_GUARD_REST array.
+_hive_podman_parse_command() {
+  local -a args=("$@")
+  local nouns=" container containers image images volume volumes network networks pod pods system builder secret manifest machine farm "
+  local index=0
+  local token
+
+  HIVE_GUARD_TOOL="${args[0]:-}"
+  HIVE_GUARD_NOUN=""
+  HIVE_GUARD_VERB=""
+  HIVE_GUARD_REST=()
+
+  index=1
+  while (( index < ${#args[@]} )); do
+    token="${args[index]}"
+
+    if [[ "$token" == "--" ]]; then
+      index=$((index + 1))
+      continue
+    fi
+
+    if _hive_podman_is_value_option "$token"; then
+      index=$((index + 2))
+      continue
+    fi
+
+    if [[ "$token" == -* ]]; then
+      index=$((index + 1))
+      continue
+    fi
+
+    break
+  done
+
+  (( index < ${#args[@]} )) || return 0
+  token="${args[index]}"
+
+  if [[ "$nouns" == *" $token "* ]]; then
+    HIVE_GUARD_NOUN="$token"
+    index=$((index + 1))
+
+    while (( index < ${#args[@]} )); do
+      token="${args[index]}"
+
+      if _hive_podman_is_value_option "$token"; then
+        index=$((index + 2))
+        continue
+      fi
+
+      if [[ "$token" == -* ]]; then
+        index=$((index + 1))
+        continue
+      fi
+
+      break
+    done
+
+    (( index < ${#args[@]} )) || return 0
+    token="${args[index]}"
+  fi
+
+  HIVE_GUARD_VERB="$token"
+  index=$((index + 1))
+  HIVE_GUARD_REST=("${args[@]:index}")
+}
+
+# True when the argument list selects every resource of a kind.
+_hive_podman_selects_all() {
+  local token
+
+  for token in "$@"; do
+    case "$token" in
+      --all|--all=true)
+        return 0
+        ;;
+      -[A-Za-z]*)
+        # Short flags may be bundled: -af is --all --force.
+        [[ "$token" != --* && "$token" == *a* ]] && return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+# True when the argument list carries the Hive ownership label filter.
+_hive_podman_has_owner_filter() {
+  local -a args=("$@")
+  local index=0
+  local token
+
+  while (( index < ${#args[@]} )); do
+    token="${args[index]}"
+
+    case "$token" in
+      --filter=label="$HIVE_PODMAN_OWNED_LABEL"|-f=label="$HIVE_PODMAN_OWNED_LABEL")
+        return 0
+        ;;
+      --filter)
+        [[ "${args[index + 1]:-}" == "label=$HIVE_PODMAN_OWNED_LABEL" ]] && return 0
+        ;;
+    esac
+
+    index=$((index + 1))
+  done
+
+  return 1
+}
+
+# True when at least one explicit operand (a name or ID) is present.
+_hive_podman_has_operand() {
+  local -a args=("$@")
+  local index=0
+  local token
+
+  while (( index < ${#args[@]} )); do
+    token="${args[index]}"
+
+    if [[ "$token" == "--filter" || "$token" == "--format" ]]; then
+      index=$((index + 2))
+      continue
+    fi
+
+    if [[ "$token" == -* ]]; then
+      index=$((index + 1))
+      continue
+    fi
+
+    return 0
+  done
+
+  return 1
+}
+
+# The guard. Exits 0 when the command is scoped to Hive-owned resources, 65
+# when the ownership contract rejects it, and 64 on unusable input.
+hive_podman_cleanup_check() {
+  if (( $# == 0 )); then
+    printf 'ERROR: check requires a command to inspect\n' >&2
+    return 64
+  fi
+
+  _hive_podman_parse_command "$@"
+
+  case "$HIVE_GUARD_TOOL" in
+    podman|buildah) ;;
+    *)
+      printf 'ERROR: the Hive cleanup contract covers podman and buildah only; got %q\n' \
+        "$HIVE_GUARD_TOOL" >&2
+      return 64
+      ;;
+  esac
+
+  local subject="$HIVE_GUARD_TOOL${HIVE_GUARD_NOUN:+ $HIVE_GUARD_NOUN}${HIVE_GUARD_VERB:+ $HIVE_GUARD_VERB}"
+
+  # Whole-store operations cannot be narrowed to Hive-owned resources at all.
+  if [[ "$HIVE_GUARD_NOUN" == "system" || "$HIVE_GUARD_NOUN" == "machine" ]]; then
+    case "$HIVE_GUARD_VERB" in
+      prune|reset)
+        printf 'REJECTED: %s operates on the whole shared store; it cannot be scoped to Hive-owned resources.\n' \
+          "$subject" >&2
+        printf 'HINT: select Hive resources with --filter label=%s instead.\n' \
+          "$HIVE_PODMAN_OWNED_LABEL" >&2
+        return 65
+        ;;
+    esac
+  fi
+
+  # Build-cache pruning is shared with every other build on the host and
+  # carries no per-image ownership label.
+  if [[ "$HIVE_GUARD_NOUN" == "builder" && "$HIVE_GUARD_VERB" == "prune" ]]; then
+    printf 'REJECTED: %s prunes build cache shared with unrelated builds and cannot be label-scoped.\n' \
+      "$subject" >&2
+    return 65
+  fi
+
+  case "$HIVE_GUARD_VERB" in
+    prune)
+      if _hive_podman_selects_all "${HIVE_GUARD_REST[@]}"; then
+        printf 'REJECTED: %s with --all reaches resources Hive does not own.\n' "$subject" >&2
+        return 65
+      fi
+
+      if ! _hive_podman_has_owner_filter "${HIVE_GUARD_REST[@]}"; then
+        printf 'REJECTED: %s must carry --filter label=%s.\n' \
+          "$subject" "$HIVE_PODMAN_OWNED_LABEL" >&2
+        return 65
+      fi
+      ;;
+    rm|rmi|remove)
+      if _hive_podman_selects_all "${HIVE_GUARD_REST[@]}"; then
+        printf 'REJECTED: %s with --all removes resources Hive does not own.\n' "$subject" >&2
+        return 65
+      fi
+
+      if _hive_podman_has_owner_filter "${HIVE_GUARD_REST[@]}"; then
+        :
+      elif _hive_podman_has_operand "${HIVE_GUARD_REST[@]}"; then
+        :
+      else
+        printf 'REJECTED: %s must name Hive-owned resources or carry --filter label=%s.\n' \
+          "$subject" "$HIVE_PODMAN_OWNED_LABEL" >&2
+        return 65
+      fi
+      ;;
+    reset)
+      printf 'REJECTED: %s discards the whole shared store.\n' "$subject" >&2
+      return 65
+      ;;
+  esac
+
+  return 0
+}
+
+# --- Cleanup plan -----------------------------------------------------------
+#
+# The scoped commands a Podman lifecycle implementation is allowed to run.
+# Printing them is not running them: this command never contacts an engine.
+
+hive_podman_cleanup_plan() {
+  local -a filters=()
+  local line
+
+  while IFS= read -r line; do
+    filters+=("$line")
+  done < <(hive_podman_filters) || return
+
+  (( ${#filters[@]} > 0 )) || return 1
+
+  local -a commands=(
+    "podman ps --all ${filters[*]} --format {{.ID}}"
+    "podman rm --force ${filters[*]}"
+    "podman pod ps ${filters[*]} --format {{.ID}}"
+    "podman pod rm --force POD_ID"
+    "podman volume ls ${filters[*]} --format {{.Name}}"
+    "podman volume rm VOLUME_NAME"
+    "podman network ls ${filters[*]} --format {{.Name}}"
+    "podman network rm NETWORK_NAME"
+    "podman images ${filters[*]} --format {{.ID}}"
+    "podman rmi IMAGE_ID"
+  )
+
+  local command
+  for command in "${commands[@]}"; do
+    # Self-check: the plan must never emit anything the guard would reject.
+    # shellcheck disable=SC2086 # the plan lines are built here, word-splitting is intended
+    if ! hive_podman_cleanup_check $command 2>/dev/null; then
+      printf 'ERROR: planned command failed its own ownership guard: %s\n' "$command" >&2
+      return 70
+    fi
+
+    printf '%s\n' "$command"
+  done
+}
+
+hive_podman_cleanup_usage() {
+  cat <<'EOF'
+Usage: hive-podman-cleanup.sh labels <component>
+       hive-podman-cleanup.sh filters
+       hive-podman-cleanup.sh plan
+       hive-podman-cleanup.sh check [--] <podman|buildah> <arguments...>
+
+labels   Print the create/build-time ownership labels, one argument per line.
+filters  Print the cleanup-time ownership selectors, one argument per line.
+plan     Print the scoped cleanup commands. It never contacts a container engine.
+check    Exit 0 when a command is scoped to Hive-owned resources, 65 when the
+         ownership contract rejects it.
+
+HIVE_DEPLOY_INSTANCE names the deployment being labeled or selected. It
+defaults to "default".
+EOF
+}
+
+hive_podman_cleanup_main() {
+  local action="${1:-help}"
+
+  case "$action" in
+    labels)
+      shift
+      hive_podman_labels "$@"
+      ;;
+    filters)
+      shift
+      [[ $# -eq 0 ]] || {
+        hive_podman_cleanup_usage >&2
+        return 64
+      }
+      hive_podman_filters
+      ;;
+    plan)
+      shift
+      [[ $# -eq 0 ]] || {
+        hive_podman_cleanup_usage >&2
+        return 64
+      }
+      hive_podman_cleanup_plan
+      ;;
+    check)
+      shift
+      [[ "${1:-}" == "--" ]] && shift
+      hive_podman_cleanup_check "$@"
+      ;;
+    -h|--help|help)
+      hive_podman_cleanup_usage
+      ;;
+    *)
+      printf 'ERROR: unknown action %q\n' "$action" >&2
+      hive_podman_cleanup_usage >&2
+      return 64
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  hive_podman_cleanup_main "$@"
+fi

--- a/bin/test_hive_podman_cleanup.sh
+++ b/bin/test_hive_podman_cleanup.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Contract tests for bin/hive-podman-cleanup.sh (#4210).
+# Run: bash bin/test_hive_podman_cleanup.sh
+#
+# This test never deletes a container, pod, volume, network, or image. The
+# guard is pure argument analysis, and every engine binary on the test PATH is
+# a tripwire that records the call and fails the run instead of doing anything.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACT="${ROOT}/bin/hive-podman-cleanup.sh"
+BASH_BIN="$(command -v bash)"
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+OWNER_LABEL="io.kubestellar.hive.owned=true"
+
+# Tripwire engines: if the contract module ever shells out to a real engine,
+# these record it and the run fails.
+TRIPWIRE_BIN="${TEST_TMP}/bin"
+TRIPWIRE_LOG="${TEST_TMP}/engine-calls.log"
+mkdir -p "$TRIPWIRE_BIN"
+for engine in podman buildah docker; do
+  cat >"${TRIPWIRE_BIN}/${engine}" <<EOF
+#!/bin/sh
+printf '${engine} %s\n' "\$*" >>"${TRIPWIRE_LOG}"
+exit 1
+EOF
+  chmod +x "${TRIPWIRE_BIN}/${engine}"
+done
+TEST_PATH="${TRIPWIRE_BIN}:/usr/bin:/bin"
+
+pass_count=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local want="$1"
+  local got="$2"
+  local context="$3"
+  [[ "$got" == "$want" ]] || fail "${context}: got '${got}', want '${want}'"
+  pass_count=$((pass_count + 1))
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local context="$3"
+  [[ "$haystack" == *"$needle"* ]] || fail "${context}: missing '${needle}' in '${haystack}'"
+  pass_count=$((pass_count + 1))
+}
+
+run_capture() {
+  local stdout_file="${TEST_TMP}/stdout"
+  local stderr_file="${TEST_TMP}/stderr"
+  set +e
+  env PATH="$TEST_PATH" "$@" >"$stdout_file" 2>"$stderr_file"
+  RUN_STATUS=$?
+  set -e
+  RUN_STDOUT="$(cat "$stdout_file")"
+  RUN_STDERR="$(cat "$stderr_file")"
+}
+
+contract() {
+  run_capture "$BASH_BIN" "$CONTRACT" "$@"
+}
+
+# --- Ownership labels are stable and cover every resource kind --------------
+
+contract labels hive
+assert_eq "0" "$RUN_STATUS" "labels status"
+assert_contains "$RUN_STDOUT" "$OWNER_LABEL" "labels ownership marker"
+assert_contains "$RUN_STDOUT" "io.kubestellar.hive.component=hive" "labels component"
+assert_contains "$RUN_STDOUT" "io.kubestellar.hive.instance=default" "labels instance"
+assert_contains "$RUN_STDOUT" "io.kubestellar.hive.runtime=podman" "labels runtime"
+
+# The same label set applies to every kind Podman can own, so a component name
+# is all a caller ever supplies.
+for component in gateway network-hive volume-hive-data image-hive; do
+  contract labels "$component"
+  assert_eq "0" "$RUN_STATUS" "labels ${component} status"
+  assert_contains "$RUN_STDOUT" "io.kubestellar.hive.component=${component}" "labels ${component} value"
+done
+
+# A component name cannot smuggle a second label or a shell metacharacter.
+contract labels 'hive --label evil=true'
+assert_eq "64" "$RUN_STATUS" "labels reject injected component"
+
+contract labels
+assert_eq "64" "$RUN_STATUS" "labels require a component"
+
+# --- Selection filters carry the ownership marker ---------------------------
+
+contract filters
+assert_eq "0" "$RUN_STATUS" "filters status"
+assert_contains "$RUN_STDOUT" "label=${OWNER_LABEL}" "filters ownership marker"
+assert_contains "$RUN_STDOUT" "label=io.kubestellar.hive.instance=default" "filters instance"
+
+run_capture env HIVE_DEPLOY_INSTANCE=staging "$BASH_BIN" "$CONTRACT" filters
+assert_eq "0" "$RUN_STATUS" "named instance filters status"
+assert_contains "$RUN_STDOUT" "label=io.kubestellar.hive.instance=staging" "named instance filters"
+
+run_capture env HIVE_DEPLOY_INSTANCE='x --filter label=other' "$BASH_BIN" "$CONTRACT" filters
+assert_eq "64" "$RUN_STATUS" "reject injected instance"
+assert_eq "" "$RUN_STDOUT" "injected instance emits no filter"
+
+# --- Broad commands are rejected --------------------------------------------
+#
+# The four named in #4210 lead, followed by the variants a mechanical Docker
+# translation would otherwise produce.
+
+while IFS='|' read -r command expected_reason; do
+  [[ -n "$command" ]] || continue
+  # shellcheck disable=SC2086 # the table stores whole command lines on purpose
+  contract check $command
+  assert_eq "65" "$RUN_STATUS" "reject: ${command}"
+  assert_contains "$RUN_STDERR" "REJECTED" "reject reason present: ${command}"
+  assert_contains "$RUN_STDERR" "$expected_reason" "reject reason text: ${command}"
+done <<'EOF'
+podman system prune|whole shared store
+podman system prune -a --volumes --force|whole shared store
+podman image prune -a|--all
+podman image prune --all --force|--all
+podman rmi -a -f|--all
+podman rmi --all|--all
+buildah rm --all|--all
+buildah rmi --all|--all
+podman system reset --force|whole shared store
+podman machine reset|whole shared store
+podman builder prune --all|build cache
+podman container prune|must carry --filter
+podman volume prune --force|must carry --filter
+podman network prune|must carry --filter
+podman pod prune|must carry --filter
+podman image prune --filter label=other=1|must carry --filter
+podman rm --force|must name Hive-owned resources
+podman volume rm --all|--all
+podman pod rm -a|--all
+buildah rm -a|--all
+podman --root /var/tmp/store system prune|whole shared store
+podman --connection remote image prune -a|--all
+EOF
+
+# --- Scoped commands are allowed --------------------------------------------
+
+while IFS= read -r command; do
+  [[ -n "$command" ]] || continue
+  # shellcheck disable=SC2086 # the table stores whole command lines on purpose
+  contract check $command
+  assert_eq "0" "$RUN_STATUS" "allow: ${command} (stderr: ${RUN_STDERR})"
+done <<EOF
+podman rm --force hive hive-gateway
+podman rm --filter label=${OWNER_LABEL}
+podman container prune --filter label=${OWNER_LABEL}
+podman volume prune --force --filter label=${OWNER_LABEL}
+podman network prune --filter label=${OWNER_LABEL}
+podman volume rm hive-data
+podman network rm hive-net
+podman rmi ghcr.io/kubestellar/hive:v4
+buildah rm hive-build
+podman ps --all --filter label=${OWNER_LABEL}
+podman images --filter label=${OWNER_LABEL}
+EOF
+
+# --- Docker cleanup behavior is not changed by this contract ----------------
+#
+# The guard refuses to render a verdict on Docker rather than quietly blessing
+# or rewriting the existing Docker cleanup paths.
+
+contract check docker system prune -a
+assert_eq "64" "$RUN_STATUS" "docker is out of contract scope"
+assert_contains "$RUN_STDERR" "podman and buildah only" "docker scope message"
+
+contract check
+assert_eq "64" "$RUN_STATUS" "check requires a command"
+
+# --- The plan is scoped, and printing it runs nothing ------------------------
+
+contract plan
+assert_eq "0" "$RUN_STATUS" "plan status"
+assert_eq "" "$RUN_STDERR" "plan diagnostics"
+
+plan_output="$RUN_STDOUT"
+plan_lines=0
+while IFS= read -r planned; do
+  [[ -n "$planned" ]] || continue
+  plan_lines=$((plan_lines + 1))
+
+  # Every selection command must be label-scoped; every removal command must be
+  # label-scoped or name explicit Hive-owned operands.
+  case "$planned" in
+    *ps*|*ls*|*images*)
+      assert_contains "$planned" "label=${OWNER_LABEL}" "plan selection is label-scoped"
+      ;;
+  esac
+
+  # shellcheck disable=SC2086 # planned lines are whole commands
+  contract check $planned
+  assert_eq "0" "$RUN_STATUS" "plan line passes the guard: ${planned}"
+done <<<"$plan_output"
+
+[[ "$plan_lines" -ge 10 ]] || fail "plan covers too few resource kinds: ${plan_lines}"
+pass_count=$((pass_count + 1))
+
+for kind in "podman rm" "podman pod rm" "podman volume rm" "podman network rm" "podman rmi"; do
+  assert_contains "$plan_output" "$kind" "plan covers ${kind}"
+done
+
+# --- No Hive tooling ships a broad Podman or Buildah cleanup ----------------
+
+broad_patterns=(
+  'podman system prune'
+  'podman system reset'
+  'podman machine reset'
+  'podman image prune -a'
+  'podman image prune --all'
+  'podman rmi -a'
+  'podman rmi --all'
+  'podman builder prune'
+  'buildah rm --all'
+  'buildah rm -a'
+  'buildah rmi --all'
+  'buildah rmi -a'
+)
+
+# The contract module, this test, and the contract documentation quote those
+# commands in order to reject and explain them.
+exempt=(
+  'bin/hive-podman-cleanup.sh'
+  'bin/test_hive_podman_cleanup.sh'
+  'src/docs/podman-ownership-cleanup.md'
+)
+
+if command -v git >/dev/null 2>&1 && git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  offenders=""
+  while IFS= read -r tracked; do
+    skip=""
+    for exempt_path in "${exempt[@]}"; do
+      [[ "$tracked" == "$exempt_path" ]] && skip="yes"
+    done
+    [[ -n "$skip" ]] && continue
+    [[ -f "${ROOT}/${tracked}" ]] || continue
+
+    for pattern in "${broad_patterns[@]}"; do
+      if grep -qF -- "$pattern" "${ROOT}/${tracked}" 2>/dev/null; then
+        offenders+="${tracked}: ${pattern}"$'\n'
+      fi
+    done
+  done < <(git -C "$ROOT" ls-files)
+
+  [[ -z "$offenders" ]] || fail "broad Podman/Buildah cleanup found:"$'\n'"${offenders}"
+  pass_count=$((pass_count + 1))
+fi
+
+# --- The whole test ran without touching a container engine ------------------
+
+if [[ -s "$TRIPWIRE_LOG" ]]; then
+  fail "the contract invoked a container engine:"$'\n'"$(cat "$TRIPWIRE_LOG")"
+fi
+pass_count=$((pass_count + 1))
+
+printf 'PASS: %d Podman ownership and cleanup contract assertions\n' "$pass_count"

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -58,6 +58,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Per-agent gh restrictions](https://github.com/kubestellar/hive/blob/v4/config/restrictions/README.md) — file-based wrapper denials in `/etc/hive/restrictions/`.
 - [Podman rootless CI](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-ci.md) — rootless Podman contract for `contribute-hive`.
 - [Podman Quadlet `.kube` compatibility spike](podman-quadlet-kube-spike.md) — why the standalone Kubernetes overlay is not a safe direct source for Podman units.
+- [Podman ownership and cleanup contract](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-ownership-cleanup.md) — the labels that mark a resource Hive-owned and the guard that keeps Podman/Buildah cleanup from reaching the operator's other containers, Distroboxes, and images.
 - [CLI backend setup](https://github.com/kubestellar/hive/blob/v4/docs/backend-setup.md) — setup notes for Claude, Copilot, Goose, Bob, Pi, Codex, and Aider.
 - [Inference backends](https://github.com/kubestellar/hive/blob/v4/docs/inference-backends.md) — vLLM, llm-d, LiteLLM, and Model Gateway troubleshooting.
 - [apiproxy](https://github.com/kubestellar/hive/blob/v4/src/docs/apiproxy.md) — Anthropic-compatible proxy logging and deployment notes.

--- a/src/docs/podman-ownership-cleanup.md
+++ b/src/docs/podman-ownership-cleanup.md
@@ -1,0 +1,115 @@
+# Podman: Hive-owned resources and the safe cleanup contract
+
+Rootless Podman and Buildah keep containers, pods, networks, volumes, images,
+and build cache in **one store per user**. On a developer workstation that same
+store usually holds unrelated development containers, Distroboxes, and local
+builds. Docker's cleanup habits do not transfer: `docker system prune` on a
+dedicated Docker host is inconvenient, while `podman system prune` on a
+contributor's laptop deletes their other work.
+
+This page defines what Hive owns and what Hive lifecycle tooling is allowed to
+remove. It is the contract that the Podman lifecycle work in
+[#4188](https://github.com/kubestellar/hive/issues/4188) must build on.
+
+The contract lives in `bin/hive-podman-cleanup.sh` and is enforced by
+`bin/test_hive_podman_cleanup.sh` in CI.
+
+> Docker cleanup behavior is unchanged. `src/deploy/blue-green-deploy.sh` still
+> prunes Docker images and build cache on the dedicated deployment host. This
+> contract covers Podman and Buildah only, and the guard deliberately refuses to
+> render a verdict on a `docker` command rather than quietly blessing it.
+
+## Ownership labels
+
+Every Hive-owned Podman resource carries the same four labels, applied at
+create or build time:
+
+| Label | Value | Purpose |
+| --- | --- | --- |
+| `io.kubestellar.hive.owned` | `true` | The single selector every cleanup command filters on. |
+| `io.kubestellar.hive.component` | for example `hive`, `gateway` | Which Hive service the resource belongs to. |
+| `io.kubestellar.hive.instance` | `HIVE_DEPLOY_INSTANCE`, default `default` | Which deployment on this host, so two Hive installs clean up separately. |
+| `io.kubestellar.hive.runtime` | `podman` | The engine that created the resource. |
+
+The keys are reverse-DNS so they cannot collide with labels other tools write
+into the same shared store. They apply uniformly to **containers, pods,
+networks, volumes, and images** — a caller only ever supplies the component
+name:
+
+```bash
+mapfile -t labels < <(bin/hive-podman-cleanup.sh labels gateway)
+podman run "${labels[@]}" ...
+podman volume create "${labels[@]}" hive-data
+podman build "${labels[@]}" -f src/Dockerfile ..
+```
+
+`HIVE_DEPLOY_INSTANCE` and the component name are validated against
+`[A-Za-z0-9][A-Za-z0-9._-]*`, so neither can smuggle a second label or a shell
+metacharacter into a filter.
+
+## Selection
+
+Cleanup selects on the ownership labels and nothing else:
+
+```bash
+mapfile -t filters < <(bin/hive-podman-cleanup.sh filters)
+podman ps --all "${filters[@]}" --format '{{.ID}}'
+```
+
+`bin/hive-podman-cleanup.sh plan` prints the full set of scoped commands for
+every resource kind. It only prints them — it never contacts an engine.
+
+## What is rejected
+
+`bin/hive-podman-cleanup.sh check -- <command>` exits `0` when a command is
+scoped to Hive-owned resources and `65` when the ownership contract rejects it.
+Hive lifecycle code must run every destructive Podman or Buildah command
+through it first.
+
+Rejected outright, because no filter can narrow them to Hive-owned resources:
+
+- `podman system prune`, `podman system reset`, `podman machine reset` — the
+  whole shared store.
+- `podman builder prune` — build cache shared with unrelated builds, with no
+  per-entry ownership label.
+
+Rejected because they reach past what Hive owns:
+
+- Any `--all`/`-a` form, including bundled short flags: `podman image prune -a`,
+  `podman rmi -a -f`, `podman rmi -af`, `podman volume rm --all`,
+  `buildah rm --all`, `buildah rmi --all`.
+- Any `prune` without `--filter label=io.kubestellar.hive.owned=true`, including
+  a prune filtered on some *other* label.
+- Any `rm`/`rmi` that neither names explicit operands nor carries the ownership
+  filter.
+
+Global options are parsed before the subcommand, so
+`podman --root /var/tmp/store system prune` and
+`podman --connection remote image prune -a` are rejected too.
+
+Allowed, because they are scoped:
+
+```bash
+podman rm --force hive hive-gateway
+podman volume prune --force --filter label=io.kubestellar.hive.owned=true
+podman rmi ghcr.io/kubestellar/hive:v4
+buildah rm hive-build
+```
+
+## Testing
+
+`bin/test_hive_podman_cleanup.sh` runs in CI and **deletes nothing**. The guard
+is pure argument analysis, every engine binary on the test `PATH` is a tripwire
+that records the call and fails the run, and the test asserts the tripwire log
+stayed empty.
+
+It also scans every tracked file for the broad commands above, so a future
+change cannot reintroduce `podman system prune` or `buildah rm --all` into Hive
+tooling without the test failing.
+
+## Scope
+
+This is the ownership and cleanup contract only. Applying the labels to real
+deployment assets, and implementing the teardown itself, belong to the later
+Podman lifecycle slices of #4188 — which must use this module rather than
+inventing a second label scheme.


### PR DESCRIPTION
## What

Defines the ownership and cleanup contract that the Podman lifecycle work in #4188 has to build on, and adds a guard plus contract test that keeps Hive cleanup from ever widening into a store-wide Podman/Buildah operation.

Rootless Podman and Buildah keep containers, pods, networks, volumes, images, and build cache in **one store per user**. On a contributor's host that store also holds unrelated development containers, Distroboxes, and local builds, so a mechanical translation of Docker's cleanup habits into `podman system prune` or an equivalent destroys the operator's other work.

## How

**`bin/hive-podman-cleanup.sh`** — the single source of truth:

| Action | Behavior |
|---|---|
| `labels <component>` | Create/build-time ownership labels, one CLI argument per line. |
| `filters` | The matching cleanup-time selectors. |
| `plan` | The scoped cleanup commands for every resource kind. Prints only; contacts no engine. |
| `check -- <cmd>` | Exit `0` when scoped to Hive-owned resources, `65` when the contract rejects it. |

The labels are reverse-DNS so they cannot collide with what other tools write into the same shared store, and they apply uniformly to containers, pods, networks, volumes, and images:

- `io.kubestellar.hive.owned=true` — the one selector every cleanup filters on
- `io.kubestellar.hive.component=<hive|gateway|…>`
- `io.kubestellar.hive.instance=<HIVE_DEPLOY_INSTANCE, default `default`>` — so two Hive installs on one host clean up separately
- `io.kubestellar.hive.runtime=podman`

The guard rejects:

- **Store-wide operations, outright**, because no filter can narrow them: `system prune`, `system`/`machine reset`, and `builder prune` (build cache is shared with unrelated builds and carries no per-entry ownership label).
- **Every remove-all form**, including bundled short flags (`-af`) and `--all=true`.
- **Any prune without `--filter label=io.kubestellar.hive.owned=true`**, including a prune filtered on some *other* label.
- **Any `rm`/`rmi` that neither names explicit operands nor carries the ownership filter.**

Global options are parsed before the subcommand, so a leading `--root` or `--connection` cannot hide a broad command. The component name and `HIVE_DEPLOY_INSTANCE` are validated against `[A-Za-z0-9][A-Za-z0-9._-]*`, so neither can smuggle a second label into a filter. `plan` self-checks every line it prints through the guard.

**`bin/test_hive_podman_cleanup.sh`** — wired into `v2-ci.yml` next to the #4205 runtime-selector test. It also scans every tracked file for the broad commands, so they cannot be reintroduced into Hive tooling silently.

**`src/docs/podman-ownership-cleanup.md`** — the contract, what is rejected and why, and the scope boundary.

## Acceptance criteria

- [x] **`podman system prune`, `podman image prune -a`, `podman rmi -a -f`, and `buildah rm --all` are explicitly rejected in Hive tooling.** All four are in the rejection table, each asserted for both exit code `65` and the specific reason text, alongside the variants a mechanical Docker translation would produce.
- [x] **Ownership labels cover containers, networks, volumes, and images where applicable** — plus pods, which Podman also owns. One label set, one component argument.
- [x] **Docker cleanup behavior is not changed.** `src/deploy/blue-green-deploy.sh` is untouched and still prunes Docker images and build cache on the dedicated deployment host. The guard deliberately exits `64` ("covers podman and buildah only") on a `docker` command rather than quietly blessing or rewriting it.
- [x] **The test can run without deleting any real resources.** The guard is pure argument analysis; the module never shells out to an engine. Every engine binary on the test `PATH` is a tripwire that records the call and exits `1`, and the final assertion is that the tripwire log stayed empty.

## Scope

Per the issue's 30-minute boundary, this is the contract only. Applying the labels to real deployment assets and implementing teardown remain the later lifecycle slices of #4188, which must use this module rather than inventing a second label scheme.

## Testing

```
$ bash bin/test_hive_podman_cleanup.sh
PASS: 127 Podman ownership and cleanup contract assertions

$ bash bin/test_hive_standalone_runtime.sh     # unchanged, still passes
PASS: 20 standalone runtime selector assertions

$ shellcheck bin/hive-podman-cleanup.sh bin/test_hive_podman_cleanup.sh
(clean)
```

Mutation-checked: removing `prune` from the store-wide rejection branch makes the test fail on `podman system prune`, and adding a broad command to a tracked file fails the repo scan (caught a `podman image prune -a` I had quoted in a CI comment while writing this).

Part of #4188
Fixes #4210

— hive: backend=claude model=claude-opus-5