### PR TITLE
fix(dashboard): show immediate + error toast feedback on agent kick

### DIFF
--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -13432,11 +13432,19 @@ function burnAreaChart() {
 
       const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
       if (prompt) opts.body = JSON.stringify({ prompt });
-      const res = await fetch(`/api/kick/${agent}`, opts);
-      const data = await res.json();
-      if (!data.ok) { showToast('Kick failed: ' + (data.error || 'unknown'), 'error'); return; }
-      showToast(`Kicked ${agent}`, 'success');
-      if (input) input.value = '';
+      // Acknowledge the click immediately with a persistent toast, then rewrite
+      // it into the result — mirrors planIssue() so a slow, failed, or thrown
+      // request still surfaces feedback instead of silently doing nothing.
+      const toast = showToast(`Kicking ${agent}...`, 'info', true);
+      try {
+        const res = await fetch(`/api/kick/${agent}`, opts);
+        const data = await res.json();
+        if (!data.ok) { dismissToast(toast, 'Kick failed: ' + (data.error || 'unknown'), 'error'); return; }
+        dismissToast(toast, `Kicked ${agent}`, 'success');
+        if (input) input.value = '';
+      } catch (e) {
+        dismissToast(toast, 'Kick failed: ' + e.message, 'error');
+      }
     }
 
     // planIssue (Phase 4 "Plan this issue"): POST the issue to /api/plan/from-issue,


### PR DESCRIPTION
## Problem

Clicking the **kick** button on an agent card in the hive dashboard showed **no toast/feedback** to the user.

The previous \`kick()\` had two flaws:

1. **No immediate acknowledgement** — the success toast only fired *after* \`await fetch()\` resolved. On a slow request the user got no signal their click registered.
2. **No try/catch** — if \`fetch()\` threw (network error) or \`res.json()\` failed on a non-JSON error response, the function rejected with an unhandled promise rejection and **no toast was ever shown**. This is the most likely reason the user "sees no toast."

## Fix

Rewrite \`kick()\` to mirror the existing \`planIssue()\` pattern already in this file:

- Show an **immediate** persistent info toast on click (\`showToast('Kicking ' + agent + '...', 'info', true)\`) — instant acknowledgement.
- Wrap the fetch + JSON parse in **try/catch**.
- On success: \`dismissToast(toast, 'Kicked ' + agent, 'success')\`.
- On \`!data.ok\`: \`dismissToast(toast, 'Kick failed: ' + (data.error || 'unknown'), 'error')\`.
- On thrown exception: \`dismissToast(toast, 'Kick failed: ' + e.message, 'error')\`.

The prompt-input read and clear-on-success behavior is preserved.

Uses the file's existing \`showToast(msg, type, persistent)\` / \`dismissToast(el, newMsg, newType)\` signatures — no API changes. Only \`src/pkg/dashboard/static/index.html\` changed; the \`/api/kick\` endpoint and all other functions are untouched.