### PR TITLE
fix(config): tighten copilot-auth login-detector pattern to stop false-positive pauses

### DIFF
--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -2098,7 +2098,14 @@ var defaultLoginPatterns = []string{
 	// gh / copilot / gemini: the commands their CLIs tell the user to run.
 	"gh auth login",
 	"claude login",
-	"copilot auth",
+	// "copilot auth login" is the Copilot CLI's full logged-out instruction.
+	// The bare 2-word fragment "copilot auth" false-positived: it also matched
+	// `copilot auth status` (an auth CHECK) and incidental doc/comment mentions
+	// (e.g. bin/copilot-models.mjs), pausing logged-IN agents — a live quality
+	// agent flapped on `(?i)copilot auth` for days (restart_count 83). Tightening
+	// to the full command matches the specificity of its `gh auth login` /
+	// `gemini auth login` siblings and still catches genuine Copilot logouts.
+	"copilot auth login",
 	"gemini auth login",
 	// bob: its API-key entry prompts.
 	"Enter Bob-Shell API Key",


### PR DESCRIPTION
## Problem

The login-detector auto-pauses **logged-in** agents on a false positive. An operator directly witnessed the `quality` agent on `ks/hive` get paused by the login-detector *while it was authenticated*. The live pause event logged `"pattern":"(?i)copilot auth"`.

## Root cause

The detector scans each running agent's terminal pane against `cfg.Governor.Sensing.LoginPatterns` (case-insensitive) and pauses on any match. The default set is `defaultLoginPatterns` in `src/pkg/config/config.go`.

Every other CLI entry is a full logged-out command (`gh auth login`, `gemini auth login`), but `"copilot auth"` was a bare **2-word fragment** that matches incidentally:

- `copilot auth status` — an auth **check** a logged-in agent runs, which contains the fragment.
- Incidental doc/comment mentions, e.g. the hive's own `bin/copilot-models.mjs` line 3: `// Copilot auth, via the official @github/copilot-sdk.`

This is a **known, recurring** false-positive: a code comment in `config.go` (near `applyDefaults`) already documents a live hosted hive's quality agent flapping on `(?i)copilot auth` for days with **restart_count 83**.

## Fix (surgical — one pattern, protection preserved)

Tighten `"copilot auth"` → `"copilot auth login"` in `defaultLoginPatterns`.

`copilot auth login` is the Copilot CLI's actual logged-out instruction — confirmed by `src/docs/troubleshooting.md`, which lists it alongside `claude login` and `gemini auth login` as the command shown in the pause notification. This matches the specificity of its sibling patterns and still catches genuine Copilot logouts, but no longer matches the bare `copilot auth` fragment, `copilot auth status`, or incidental doc/comment mentions — eliminating the false-positive while preserving the login-detector safety net.

## Scope

- Changes **only** `defaultLoginPatterns` in `src/pkg/config/config.go` (one pattern string + explanatory comment).
- The frozen `legacyDefaultLoginPatterns` migration artifact, `CLIExcludePatterns`, and the detector loop in `main.go` are **untouched**.
- No test changes needed: the migration tests reference `defaultLoginPatterns` symbolically (not a hardcoded string), so they track the new value automatically. The `copilot auth` strings elsewhere in tests belong to the frozen legacy fixtures and must stay byte-identical.

The login-detector is **not weakened or removed** — only made more specific.
