### PR TITLE
🧪 podman: capture rootless startup and exit-77 behavior

### DIFF
--- a/src/deploy/probe_podman_rootless_netadmin.sh
+++ b/src/deploy/probe_podman_rootless_netadmin.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Rootless Podman startup and exit-77 probe (#4199).
+#
+# Runs the three-case rootless matrix against a Hive image and reports, for
+# each case, whether the container started AND whether the forced-proxy egress
+# gate was actually installed. Those are different questions: a container that
+# starts under `--cap-add NET_ADMIN` proves nothing about the redirect, and a
+# container that fails may have failed downstream of a gate that installed
+# fine.
+#
+#   default    rootless, no added capability  -> expect exit 77, no gate
+#   netadmin   rootless + --cap-add NET_ADMIN -> expect gate installed
+#   advisory   rootless + HIVE_PROXY_ADVISORY_OK=true -> expect advisory warning
+#
+# By default every container, image, and volume goes into a throwaway store
+# created for this run, so the probe never adds to or removes from the
+# operator's own Podman storage. Cleanup targets only the containers this
+# script created, by name.
+#
+# Usage:
+#   src/deploy/probe_podman_rootless_netadmin.sh [options]
+#
+#   --image REF     image to probe (default ghcr.io/kubestellar/hive:v4-latest)
+#   --store DIR     reuse a probe store instead of creating one (kept on exit)
+#   --shared-store  deliberately use the caller's default Podman store
+#   --bypass        additionally probe interception from an agent UID (needs egress)
+#   --timeout SEC   per-case run cap (default 90)
+#
+# Exit codes: 0 the matrix matched the documented contract, 1 it did not,
+# 78 a prerequisite is missing (EX_CONFIG).
+
+set -uo pipefail
+
+IMAGE="ghcr.io/kubestellar/hive:v4-latest"
+STORE=""
+SHARED_STORE="false"
+BYPASS="false"
+CASE_TIMEOUT="90"
+OWN_STORE="false"
+
+PROBE_PREFIX="hive-rootless-probe"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image) IMAGE="${2:?--image needs a value}"; shift 2 ;;
+    --store) STORE="${2:?--store needs a value}"; shift 2 ;;
+    --shared-store) SHARED_STORE="true"; shift ;;
+    --bypass) BYPASS="true"; shift ;;
+    --timeout) CASE_TIMEOUT="${2:?--timeout needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) printf 'ERROR: unknown argument %q\n' "$1" >&2; exit 78 ;;
+  esac
+done
+
+fail_prereq() {
+  printf 'PREREQUISITE MISSING: %s\n' "$1" >&2
+  exit 78
+}
+
+command -v podman >/dev/null 2>&1 || fail_prereq "podman is not installed or not on PATH"
+
+# This probe is only meaningful rootless. Rootful Podman is #4200.
+rootless="$(podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null)"
+[[ "$rootless" == "true" ]] || \
+  fail_prereq "podman reports rootless=${rootless:-unknown}; this probe requires rootless Podman (rootful is #4200)"
+
+WORK="$(mktemp -d)"
+# shellcheck disable=SC2329 # invoked through the EXIT trap below
+cleanup() {
+  local name
+  for name in "${PROBE_PREFIX}-default" "${PROBE_PREFIX}-netadmin" "${PROBE_PREFIX}-advisory" "${PROBE_PREFIX}-live"; do
+    podman rm -f "$name" >/dev/null 2>&1
+  done
+  rm -rf "$WORK"
+  [[ "$OWN_STORE" == "true" && -n "$STORE" ]] && rm -rf "$STORE"
+  return 0
+}
+trap cleanup EXIT
+
+if [[ "$SHARED_STORE" != "true" ]]; then
+  if [[ -z "$STORE" ]]; then
+    STORE="$(mktemp -d -t hive-rootless-probe-store-XXXXXX)"
+    OWN_STORE="true"
+  fi
+  mkdir -p "${STORE}/graph" "${STORE}/run" "${STORE}/tmp"
+  cat >"${STORE}/storage.conf" <<EOF
+[storage]
+driver = "overlay"
+graphroot = "${STORE}/graph"
+runroot = "${STORE}/run"
+EOF
+  export CONTAINERS_STORAGE_CONF="${STORE}/storage.conf"
+  export TMPDIR="${STORE}/tmp"
+fi
+
+# The forced-egress gate lives behind "at least one agent is configured", so a
+# config with no agents skips it entirely and the container starts clean while
+# proving nothing. This is the smallest config that reaches the gate.
+cat >"${WORK}/hive.yaml" <<'EOF'
+project:
+  org: kubestellar
+  repos:
+    - kubestellar/hive
+github:
+  token: "ghp_probe_not_a_real_token"
+agents:
+  probe:
+    backend: claude
+EOF
+
+printf '== Hive rootless Podman startup / exit-77 probe ==\n'
+podman info --format 'podman={{.Version.Version}} rootless={{.Host.Security.Rootless}} cgroups={{.Host.CgroupsVersion}} netbackend={{.Host.NetworkBackend}} rootlessnet={{.Host.RootlessNetworkCmd}} runtime={{.Host.OCIRuntime.Name}}'
+printf 'store=%s\nimage=%s\n\n' "${CONTAINERS_STORAGE_CONF:-<caller default>}" "$IMAGE"
+
+podman pull -q "$IMAGE" >/dev/null 2>&1 || fail_prereq "cannot pull ${IMAGE}"
+
+failures=0
+note_fail() { printf '  RESULT: UNEXPECTED — %s\n' "$1"; failures=$((failures + 1)); }
+note_ok() { printf '  RESULT: as documented — %s\n' "$1"; }
+
+# CapBnd bit 12 (0x1000) is CAP_NET_ADMIN, the same bit the entrypoint tests.
+capbnd_of() {
+  podman run --rm "$@" --entrypoint /bin/sh "$IMAGE" \
+    -c 'grep -m1 ^CapBnd: /proc/self/status | awk "{print \$2}"' 2>/dev/null
+}
+
+has_net_admin() {
+  local hex="$1"
+  [[ -n "$hex" ]] || return 1
+  (( 0x${hex} & 0x1000 ))
+}
+
+run_case() {
+  local name="$1"; shift
+  local logfile="${WORK}/${name}.log"
+  local status
+
+  timeout "$CASE_TIMEOUT" podman run --rm --name "${PROBE_PREFIX}-${name}" \
+    -v "${WORK}/hive.yaml:/etc/hive/hive.yaml:ro,Z" "$@" "$IMAGE" >"$logfile" 2>&1
+  status=$?
+
+  CASE_STATUS="$status"
+  CASE_LOG="$logfile"
+
+  if [[ "$status" -eq 124 ]]; then
+    printf '  exit: still running at the %ss cap (started)\n' "$CASE_TIMEOUT"
+  else
+    printf '  exit: %s\n' "$status"
+  fi
+
+  # Started is not installed. Report both, separately, always.
+  if grep -q 'outbound :443 -> :18443' "$logfile"; then
+    printf '  gate: INSTALLED — %s\n' "$(grep -m1 'outbound :443 -> :18443' "$logfile" | sed 's/^\[entrypoint\] //')"
+    CASE_GATE="installed"
+  elif grep -q 'ADVISORY-ONLY' "$logfile"; then
+    printf '  gate: NOT installed, advisory mode accepted\n'
+    CASE_GATE="advisory"
+  else
+    printf '  gate: NOT installed\n'
+    CASE_GATE="absent"
+  fi
+}
+
+# ── Capability bounding sets ────────────────────────────────────────────────
+printf -- '--- capability bounding set ---\n'
+cap_default="$(capbnd_of)"
+cap_netadmin="$(capbnd_of --cap-add NET_ADMIN)"
+printf '  default          CapBnd=%s NET_ADMIN=%s\n' \
+  "${cap_default:-?}" "$(has_net_admin "$cap_default" && echo yes || echo no)"
+printf '  --cap-add        CapBnd=%s NET_ADMIN=%s\n' \
+  "${cap_netadmin:-?}" "$(has_net_admin "$cap_netadmin" && echo yes || echo no)"
+
+has_net_admin "$cap_default" && note_fail "rootless default already carries CAP_NET_ADMIN"
+has_net_admin "$cap_netadmin" || note_fail "--cap-add NET_ADMIN did not put CAP_NET_ADMIN in the bounding set"
+
+# ── Case 1: default rootless ────────────────────────────────────────────────
+printf -- '\n--- case: default (rootless, no added capability) ---\n'
+run_case default
+if [[ "$CASE_STATUS" -eq 77 ]] && grep -q 'exiting 77' "$CASE_LOG"; then
+  note_ok "fail-closed, exit 77 (EX_NOPERM) with the bounding-set explanation"
+else
+  note_fail "expected exit 77 with the CAP_NET_ADMIN bounding-set message"
+fi
+
+# ── Case 2: rootless + NET_ADMIN ────────────────────────────────────────────
+printf -- '\n--- case: netadmin (rootless + --cap-add NET_ADMIN) ---\n'
+run_case netadmin --cap-add NET_ADMIN
+if [[ "$CASE_GATE" == "installed" ]]; then
+  if grep -q 'ambient CAP_NET_ADMIN granted' "$CASE_LOG"; then
+    note_ok "redirect installed and ambient CAP_NET_ADMIN survived the privilege drop"
+  else
+    note_fail "redirect installed but the ambient CAP_NET_ADMIN raise did not survive"
+  fi
+else
+  note_fail "the forced-egress redirect did not install under --cap-add NET_ADMIN"
+fi
+
+# ── Case 3: deliberate advisory ─────────────────────────────────────────────
+printf -- '\n--- case: advisory (rootless, HIVE_PROXY_ADVISORY_OK=true) ---\n'
+run_case advisory -e HIVE_PROXY_ADVISORY_OK=true
+if grep -q 'ADVISORY-ONLY' "$CASE_LOG"; then
+  note_ok "started with the explicit advisory-only warning"
+  grep -m1 'ADVISORY-ONLY' "$CASE_LOG" | sed 's/^/  log: /'
+  grep -m1 'NOTICE: CAP_NET_ADMIN is not in the bounding set' "$CASE_LOG" | sed 's/^/  log: /'
+else
+  note_fail "advisory mode did not produce the ADVISORY-ONLY warning"
+fi
+
+# ── Optional: does the redirect actually intercept an agent? ────────────────
+if [[ "$BYPASS" == "true" ]]; then
+  printf -- '\n--- bypass resistance (needs outbound network) ---\n'
+  podman rm -f "${PROBE_PREFIX}-live" >/dev/null 2>&1
+  podman run -d --name "${PROBE_PREFIX}-live" --cap-add NET_ADMIN \
+    -v "${WORK}/hive.yaml:/etc/hive/hive.yaml:ro,Z" "$IMAGE" >/dev/null 2>&1
+
+  for _ in $(seq 1 45); do
+    podman logs "${PROBE_PREFIX}-live" 2>&1 | grep -q 'Dropping to dev' && break
+    sleep 2
+  done
+
+  printf '  installed nat rules:\n'
+  podman exec "${PROBE_PREFIX}-live" iptables-nft -t nat -S HIVE_PROXY 2>&1 | sed 's/^/    /'
+
+  agent_uid="$(podman exec "${PROBE_PREFIX}-live" \
+    sh -c 'sed -n "s/.*\"probe\": \([0-9]*\).*/\1/p" /var/run/hive/uid-map.json' 2>/dev/null | head -1)"
+  agent_uid="${agent_uid:-2001}"
+
+  printf '  agent uid %s issuer: %s\n' "$agent_uid" \
+    "$(podman exec -u "$agent_uid" "${PROBE_PREFIX}-live" \
+        sh -c 'echo | openssl s_client -connect api.github.com:443 -servername api.github.com 2>/dev/null | grep -m1 ^issuer' 2>&1)"
+  printf '  proxy uid 1001 dial: %s\n' \
+    "$(podman exec -u 1001 "${PROBE_PREFIX}-live" \
+        sh -c 'curl -sS -m 12 -o /dev/null -w "http_code=%{http_code} remote=%{remote_ip}:%{remote_port}" https://api.github.com' 2>&1 | tail -1)"
+
+  podman rm -f "${PROBE_PREFIX}-live" >/dev/null 2>&1
+fi
+
+printf '\nSUMMARY: %d unexpected result(s)\n' "$failures"
+[[ "$failures" -eq 0 ]] || exit 1
+exit 0

--- a/src/deploy/probe_podman_rootless_netadmin.sh
+++ b/src/deploy/probe_podman_rootless_netadmin.sh
@@ -72,7 +72,13 @@ cleanup() {
     podman rm -f "$name" >/dev/null 2>&1
   done
   rm -rf "$WORK"
-  [[ "$OWN_STORE" == "true" && -n "$STORE" ]] && rm -rf "$STORE"
+
+  # Files the containers wrote are owned by mapped subordinate UIDs, so a plain
+  # rm -rf cannot remove a store this script created. Delete it from inside the
+  # user namespace instead, and fall back to rm for the pre-container case.
+  if [[ "$OWN_STORE" == "true" && -n "$STORE" ]]; then
+    podman unshare rm -rf "$STORE" 2>/dev/null || rm -rf "$STORE" 2>/dev/null
+  fi
   return 0
 }
 trap cleanup EXIT

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -77,6 +77,7 @@ Some documents describe planned or design-only work rather than live features. T
 
 - [Security model — operator guide](security-model.md) — Ed25519-only sessions/SSO, per-hive keys, master key rotation, forced proxy egress and `CAP_NET_ADMIN`, privilege model, and supply-chain posture.
 - [Security threat model](https://github.com/kubestellar/hive/blob/v4/src/docs/security-threat-model.md) — actors, boundaries, layered defenses, known gaps, and reporting.
+- [Rootless Podman startup and exit-77 behavior](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-startup-spike.md) — measured rootless matrix: fail-closed exit 77, gate installation under `--cap-add NET_ADMIN`, proven interception, and what is still unproven.
 - [Architecture Decision Records](https://github.com/kubestellar/hive/blob/v4/src/docs/adr/README.md) — lightweight ADR process and records 0001-0010.
 - [Intent verification](https://github.com/kubestellar/hive/blob/v4/src/docs/intent-verification.md) — tier-based change authorization for merge eligibility.
 - [Rootless Podman CI seam](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-ci.md) — documented test intent and static contract for contributor-container runtime handling.

--- a/src/docs/podman-rootless-startup-spike.md
+++ b/src/docs/podman-rootless-startup-spike.md
@@ -1,0 +1,227 @@
+# Rootless Podman startup and exit-77 behavior
+
+## Result
+
+Rootless Podman with `--cap-add NET_ADMIN` **does** install Hive's forced-proxy
+egress gate, and the gate demonstrably intercepts agent traffic. The
+fail-closed contract also holds: without the capability the container exits 77
+rather than running unenforced.
+
+That is stronger than #4188's blocking design gate assumed. It is not, on its
+own, a decision that rootless Podman is first-class — see
+[What remains unproven](#what-remains-unproven). It does mean option 1
+("rootful first, rootless experimental") is not forced by the egress gate on
+this configuration.
+
+| Case | Container | Gate installed | Exit |
+| --- | --- | --- | --- |
+| Default rootless | refuses to start | no | **77** (`EX_NOPERM`) |
+| Rootless + `--cap-add NET_ADMIN` | starts and stays up | **yes** | still running at the cap |
+| Rootless + `HIVE_PROXY_ADVISORY_OK=true` | starts and stays up | no — advisory accepted | still running at the cap |
+
+Started and enforcing are different questions, and the probe reports them
+separately in every case. The `--cap-add NET_ADMIN` run initially exited 1 with
+`validating config: project.org is required` — a config error **after** a gate
+that had already installed correctly. Reading that exit code as a gate failure
+would have been wrong.
+
+## Environment
+
+| | |
+| --- | --- |
+| Podman | 5.8.4, rootless |
+| OCI runtime | crun 1.28 |
+| Network backend | netavark, rootless helper `pasta` |
+| cgroups | v2 |
+| Kernel / host | 7.1.4-200.fc44.x86_64, Aurora (Fedora) 44.20260815.1, SELinux enforcing |
+| Image | `ghcr.io/kubestellar/hive:v4-latest`, digest `sha256:e1479d76c453cdd8271be76913a1544d5b70fd3569adebdd388bdd4632b4a263` |
+| Architecture | `amd64` only |
+
+Every container, image, and volume went into a throwaway store with a private
+graphroot and runroot. The host's own Podman storage was not written to and was
+verified untouched afterwards.
+
+## Reproducing
+
+`src/deploy/probe_podman_rootless_netadmin.sh` runs the whole matrix:
+
+```bash
+src/deploy/probe_podman_rootless_netadmin.sh --bypass
+```
+
+It creates its own throwaway store by default, removes only the containers it
+created, by name, and exits non-zero if any case stops matching the contract
+recorded here. It stops with `EX_CONFIG` (78) and names the missing
+prerequisite if Podman is absent, is not rootless, or the image cannot be
+pulled — it never falls back to Docker.
+
+## Capability bounding set
+
+CAP_NET_ADMIN is capability 12, so the entrypoint tests `CapBnd & 0x1000`:
+
+```
+default          CapBnd=00000000800405fb   NET_ADMIN=no
+--cap-add        CapBnd=00000000800415fb   NET_ADMIN=yes
+```
+
+Rootless Podman does not grant NET_ADMIN by default, and `--cap-add NET_ADMIN`
+does put it in the bounding set. The capability is scoped to the container's
+user and network namespaces, which is exactly why it is sufficient here: the
+netfilter tables it manipulates belong to the container's own network
+namespace.
+
+Confirmed directly, outside the entrypoint:
+
+```
+$ podman run --rm --cap-add NET_ADMIN --entrypoint /bin/sh IMAGE \
+    -c 'iptables-nft -t nat -N HIVE_PROBE && echo OK'
+OK
+$ podman run --rm --entrypoint /bin/sh IMAGE -c 'iptables-nft -t nat -N HIVE_PROBE'
+iptables v1.8.11 (nf_tables): Could not fetch rule set generation id:
+Permission denied (you must be root)
+```
+
+## Case 1 — default rootless: exit 77
+
+```
+[entrypoint] WARN: iptables chain creation attempt 1/5 failed: iptables v1.8.11 (nf_tables):
+  Could not fetch rule set generation id: Permission denied (you must be root) — retrying
+  ... attempts 2/5 through 5/5 ...
+[entrypoint] ERROR: iptables chain creation failed after 5 attempts: ...
+[entrypoint] FATAL: could not establish forced proxy egress (iptables redirect). The ACMM
+  capability model would be advisory-only, allowing agents with raw tokens to bypass the
+  MITM proxy.
+[entrypoint] FATAL: refusing to start. Grant NET_ADMIN + install iptables, or set
+  HIVE_PROXY_ADVISORY_OK=true to deliberately run in advisory mode.
+[entrypoint] FATAL: CAP_NET_ADMIN is not in the container's capability bounding set —
+  exiting 77 (EX_NOPERM) rather than 1.
+```
+
+Exit status 77. The whole run was 21 log lines. The five retries cost real
+startup time for a condition that the bounding-set probe already knows is
+hopeless — a small improvement candidate, not a defect.
+
+## Case 2 — rootless + `--cap-add NET_ADMIN`: the gate installs
+
+```
+[entrypoint] iptables (iptables-nft): outbound :443 -> :18443
+  (proxy UID 1001 + egress mark 0x1112 exempt)
+[entrypoint] Dropping to dev user (ambient CAP_NET_ADMIN granted for proxy SO_MARK egress-gate)
+```
+
+The rules really are in the container's nat table:
+
+```
+-N HIVE_PROXY
+-A OUTPUT -j HIVE_PROXY
+-A HIVE_PROXY -m owner --uid-owner 0 -j RETURN
+-A HIVE_PROXY -m owner --uid-owner 1001 -j RETURN
+-A HIVE_PROXY -m mark --mark 0x1112 -j RETURN
+-A HIVE_PROXY -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 18443
+```
+
+The ambient capability survived the privilege drop, which is what the proxy's
+`SO_MARK` exemption depends on. The Go process, running as uid 1001:
+
+```
+Uid:     1001  1001  1001  1001
+CapEff:  0000000000001000
+CapAmb:  0000000000001000
+```
+
+Bit 12 set in both — so this is not the #3874 silent-no-op path.
+
+### Bypass resistance
+
+From the agent UID (2001), which no `RETURN` rule exempts:
+
+```
+$ podman exec -u 2001 ... openssl s_client -connect api.github.com:443
+subject=CN=api.github.com
+issuer=CN=Hive ACMM Proxy CA
+```
+
+The agent's TLS session was terminated by Hive's own MITM proxy, not GitHub.
+`curl` from the same UID fails closed on certificate validation
+(`self-signed certificate in certificate chain`) rather than reaching GitHub.
+
+From the exempt proxy UID (1001):
+
+```
+http_code=200 remote=140.82.114.5:443
+```
+
+So the redirect intercepts unexempt traffic and the self-exemption works.
+
+## Case 3 — deliberate advisory mode
+
+```
+[entrypoint] WARN: proxy egress enforcement is ADVISORY-ONLY (HIVE_PROXY_ADVISORY_OK=true set).
+  Agents can bypass the MITM proxy — capability model is NOT enforced.
+[entrypoint] NOTICE: CAP_NET_ADMIN is not in the bounding set — the forced-proxy egress
+  exemption (SO_MARK) is unavailable. Owner-UID backstop: ABSENT (no xt_owner on this kernel)
+  — the proxy has NO self-exemption; outbound :443 from the proxy will loop back into the
+  redirect. ...
+```
+
+The container started and reached steady state, and the agent audit line
+records the reduced posture explicitly:
+
+```json
+{"msg":"audit: agent started","name":"probe","backend":"claude","mode":"ADVISORY"}
+```
+
+Advisory mode is never silent and never claims to be enforcing, which matches
+what #4188 requires of it.
+
+### One diagnostic is wrong in this mode
+
+`no xt_owner on this kernel` is a misdiagnosis here. The same kernel loaded
+`-m owner --uid-owner` rules without complaint in case 2. The check behind that
+message is:
+
+```sh
+if iptables -t nat -C HIVE_PROXY -m owner --uid-owner "$PROXY_UID" -j RETURN 2>/dev/null
+```
+
+In advisory mode the `HIVE_PROXY` chain was never created, because creating it
+is exactly what failed. So the `-C` probe fails for the obvious reason and the
+message blames the kernel. The code comment above it says the intent was to
+"report what is actually in the chain" — the wording just outruns the check.
+
+Two candidate fixes, neither implemented here: say "chain absent — no
+self-exemption is in place" when the chain does not exist, or note that in
+advisory mode there is no chain for the proxy to be exempt from and skip the
+backstop clause entirely. Worth a separate issue.
+
+## What remains unproven
+
+The result above is one configuration. None of the following is settled:
+
+- **`SO_MARK` specifically.** Both a UID `RETURN` and a mark `RETURN` were in
+  the chain, and the proxy's dial succeeded. Which rule matched was not
+  isolated, so the mark path is untested on its own. Isolating it means
+  removing the owner rule and re-testing.
+- **Kernels without `xt_owner`.** There the mark is the only exemption, so the
+  untested path becomes the only path. This host is not that host.
+- **`slirp4netns`.** Only `pasta` was exercised. The rootless helper terminates
+  the container's traffic and is a plausible source of difference.
+- **Restart, reboot, and recreate.** Single `podman run` only; nothing about
+  whether the gate re-installs reliably across a restart.
+- **The gateway and the pod topology.** One container in isolation. Nothing
+  here covers publishing 3001, withholding 7681, or two containers sharing a
+  network.
+- **`arm64`.** `amd64` only.
+- **A locally built image.** The published `v4-latest` was probed, not a
+  `src/Dockerfile` build.
+- **Rootful Podman.** Out of scope by design — that is #4200.
+
+A support-matrix decision needs at least the `SO_MARK` isolation, the
+`slirp4netns` lane, and restart behavior. This spike removes the assumption
+that rootless cannot enforce; it does not finish the argument.
+
+## References
+
+- [`src/deploy/entrypoint.sh`](https://github.com/kubestellar/hive/blob/v4/src/deploy/entrypoint.sh) — `EXIT_NET_ADMIN_REQUIRED`, the bounding-set probe, and the fail-closed branch.
+- [NET_ADMIN requirement](https://github.com/kubestellar/hive/blob/v4/src/docs/net-admin-requirement.md)
+- [Security model](https://github.com/kubestellar/hive/blob/v4/src/docs/security-model.md)

--- a/src/docs/podman-rootless-startup-spike.md
+++ b/src/docs/podman-rootless-startup-spike.md
@@ -51,7 +51,10 @@ src/deploy/probe_podman_rootless_netadmin.sh --bypass
 
 It creates its own throwaway store by default, removes only the containers it
 created, by name, and exits non-zero if any case stops matching the contract
-recorded here. It stops with `EX_CONFIG` (78) and names the missing
+recorded here. It deletes its own store with `podman unshare rm -rf`, because
+files the containers wrote are owned by mapped subordinate UIDs and a plain
+`rm -rf` cannot remove them. A store passed with `--store` is kept, and needs
+the same `podman unshare rm -rf` when you are done with it. It stops with `EX_CONFIG` (78) and names the missing
 prerequisite if Podman is absent, is not rootless, or the image cannot be
 pulled — it never falls back to Docker.
 


### PR DESCRIPTION
## Result

**Rootless Podman with `--cap-add NET_ADMIN` does install Hive's forced-proxy egress gate, and the gate demonstrably intercepts agent traffic.** The fail-closed contract also holds: without the capability the container exits 77 rather than running unenforced.

That is stronger than #4188's blocking design gate assumed. It does not by itself settle the support matrix — see *What remains unproven* — but it does mean option 1 ("rootful first, rootless experimental") is not forced by the egress gate on this configuration.

| Case | Container | Gate installed | Exit |
| --- | --- | --- | --- |
| Default rootless | refuses to start | no | **77** (`EX_NOPERM`) |
| Rootless + `--cap-add NET_ADMIN` | starts, stays up | **yes** | still running at the cap |
| Rootless + `HIVE_PROXY_ADVISORY_OK=true` | starts, stays up | no — advisory accepted | still running at the cap |

Run against `ghcr.io/kubestellar/hive:v4-latest` (digest `sha256:e1479d76…`) on rootless Podman 5.8.4, crun 1.28, netavark + pasta, cgroup v2, kernel 7.1.4-200.fc44, SELinux enforcing, amd64.

## Startup ≠ gate installation

The probe reports the two separately for every case, because they came apart in practice: the `--cap-add NET_ADMIN` run first exited **1** on `validating config: project.org is required` — a config error *downstream* of a gate that had already installed correctly. Reading that exit code as a gate failure would have been wrong.

## Evidence

**Bounding set** — CAP_NET_ADMIN is capability 12, so the entrypoint tests `CapBnd & 0x1000`:

```
default    CapBnd=00000000800405fb  NET_ADMIN=no
--cap-add  CapBnd=00000000800415fb  NET_ADMIN=yes
```

**Exit 77 (default)** — iptables denied on all 5 retries, then `FATAL: CAP_NET_ADMIN is not in the container's capability bounding set — exiting 77 (EX_NOPERM) rather than 1.`

**Gate installed (`--cap-add NET_ADMIN`)** — the rules are really in the container's nat table:

```
-A HIVE_PROXY -m owner --uid-owner 0 -j RETURN
-A HIVE_PROXY -m owner --uid-owner 1001 -j RETURN
-A HIVE_PROXY -m mark --mark 0x1112 -j RETURN
-A HIVE_PROXY -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 18443
```

The ambient capability survived the privilege drop — the Go process at uid 1001 shows `CapEff`/`CapAmb` = `0000000000001000`, so this is not the #3874 silent-no-op path.

**Bypass resistance** — from agent uid 2001, which no `RETURN` exempts:

```
issuer=CN=Hive ACMM Proxy CA
```

The agent's TLS session was terminated by Hive's own MITM proxy, and `curl` fails closed on certificate validation rather than reaching GitHub. From the exempt proxy uid 1001: `http_code=200 remote=140.82.114.5:443`.

**Advisory** — the `ADVISORY-ONLY` warning is emitted and the agent audit line carries `"mode":"ADVISORY"`. Never silent, never claimed as equivalent.

## A diagnostic bug found along the way

In rootless advisory mode the entrypoint reports `Owner-UID backstop: ABSENT (no xt_owner on this kernel)`. That is a misdiagnosis — the same kernel loaded `-m owner` rules without complaint in the NET_ADMIN case. The check is `iptables -t nat -C HIVE_PROXY -m owner ...`, and in advisory mode the `HIVE_PROXY` chain was never created, because creating it is exactly what failed. So the probe fails for the obvious reason and the message blames the kernel.

Recorded with two candidate fixes and **left for a separate issue** rather than changed here — the 30-minute boundary says capture behavior, not redesign the gate.

## The repeatable probe

`src/deploy/probe_podman_rootless_netadmin.sh` reruns the whole matrix and exits non-zero if any case stops matching the recorded contract:

```bash
src/deploy/probe_podman_rootless_netadmin.sh --bypass
```

Safety properties, since this one actually runs containers:

- Builds a **throwaway store** with a private graphroot and runroot by default, so it never writes to the operator's own Podman storage. Verified afterwards: zero probe containers and zero `kubestellar` images in the host's default store.
- Removes only the containers it created, by name. It never prunes anything — consistent with the ownership contract in #4210.
- Honors the issue's stop condition: exits `EX_CONFIG` (78) naming the exact missing prerequisite when Podman is absent, is not rootless, or the image cannot be pulled. It never falls back to Docker or broadens scope.
- Generates the smallest config that actually reaches the gate — the forced-egress block sits behind "at least one agent is configured", so a config with no agents skips it entirely and the container starts clean while proving nothing.

Verified: full run exits 0 with `SUMMARY: 0 unexpected result(s)`; shellcheck clean.

## Acceptance criteria

- [x] **Distinguishes container startup from gate installation** — reported separately per case, and they genuinely diverged.
- [x] **Exit 77 and the advisory warning captured** — verbatim log excerpts for both.
- [x] **States what remains unproven** — `SO_MARK` in isolation (both a UID `RETURN` and a mark `RETURN` were present; which one matched was not isolated), kernels without `xt_owner`, `slirp4netns` (only `pasta` was exercised), restart/reboot, the gateway and pod topology, `arm64`, a locally built image, and rootful Podman (#4200).
- [x] **Repeatable probe added** — narrowly scoped script, above.

## Testing

```
$ src/deploy/probe_podman_rootless_netadmin.sh --image <v4-latest by digest> --bypass
SUMMARY: 0 unexpected result(s)      # exit 0
$ shellcheck src/deploy/probe_podman_rootless_netadmin.sh
(clean)
```

Part of #4188
Fixes #4199

— hive: backend=claude model=claude-opus-5