### PR TITLE
🧩 podman: define one standalone image-reference source of truth

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -63,6 +63,15 @@ jobs:
       - name: Supply-chain pin guard
         run: bash deploy/test_supply_chain_pins.sh
 
+      # #4206: the standalone stack's image references live in exactly one
+      # place, src/deploy/standalone-images.sh, so the Docker Compose assets
+      # and the Podman assets that land later cannot drift onto different
+      # images. Also blocks the retired v2-latest tag, which resolves to a
+      # different digest than the v4 channels, from coming back into any
+      # deployment asset. Pure string analysis: no registry is contacted.
+      - name: Standalone image-reference source of truth (#4206)
+        run: bash deploy/test_standalone_image_refs.sh
+
       # #3865: watchtower bind-mounted /var/run/docker.sock — the full daemon
       # API, including /exec, which reads the GitHub App private key out of the
       # hive container with no escalation at all. The socket now sits behind a

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker compose -f src/docker-compose.yaml up -d
 
 Dashboard at `http://localhost:3001`.
 
-The pre-built image tag is documented in [src/docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest](src/docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest).
+The pre-built image tag is documented in [src/docs/operator-reference.md#image-provenance-and-tags](src/docs/operator-reference.md#image-provenance-and-tags). Standalone image references come from one source of truth, [`src/deploy/standalone-images.sh`](src/deploy/standalone-images.sh).
 
 To build from source instead of pulling the pre-built image:
 

--- a/src/README.md
+++ b/src/README.md
@@ -35,14 +35,16 @@ docker compose -f src/docker-compose.yaml up -d
 
 ### Pre-built image
 
-The default `src/docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:v2-latest`. To build from source instead, run `docker compose -f src/docker-compose.yaml build` before `docker compose -f src/docker-compose.yaml up -d`.
+The default `src/docker-compose.yaml` uses the pre-built image `ghcr.io/kubestellar/hive:stable`, the operator-blessed release channel. To build from source instead, run `docker compose -f src/docker-compose.yaml build` before `docker compose -f src/docker-compose.yaml up -d`.
 
-For tag provenance, digest pinning, and the release/tagging flow, see [docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest](docs/operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest).
+Every standalone image reference comes from one source of truth, [`deploy/standalone-images.sh`](deploy/standalone-images.sh), so the Docker assets and the Podman assets cannot drift apart. Change a reference there, not in an individual asset.
+
+For tag provenance, digest pinning, and the release/tagging flow, see [docs/operator-reference.md#image-provenance-and-tags](docs/operator-reference.md#image-provenance-and-tags).
 
 ### Troubleshooting
 
 - **Rancher Desktop / Lima**: Volume mounts from `/tmp` may fail silently (file appears as directory inside container). Clone the repo under your home directory instead.
-- **Gateway won't start**: The gateway depends on the hive health check (120s start period). If it times out, run the hive container directly: `docker run -d --name hive --cap-add NET_ADMIN -p 3001:3001 -v ./src/hive.yaml:/etc/hive/hive.yaml -e HIVE_GITHUB_TOKEN=$HIVE_GITHUB_TOKEN ghcr.io/kubestellar/hive:v2-latest` (the `--cap-add NET_ADMIN` enables the full forced-proxy-egress gate — see below).
+- **Gateway won't start**: The gateway depends on the hive health check (120s start period). If it times out, run the hive container directly: `docker run -d --name hive --cap-add NET_ADMIN -p 3001:3001 -v ./src/hive.yaml:/etc/hive/hive.yaml -e HIVE_GITHUB_TOKEN=$HIVE_GITHUB_TOKEN ghcr.io/kubestellar/hive:stable` (the `--cap-add NET_ADMIN` enables the full forced-proxy-egress gate — see below).
 - **Forced-proxy-egress gate is degraded / `SO_MARK unavailable` in logs**: the container runs fine without `NET_ADMIN`, but the proxy's SO_MARK self-exemption needs it. Grant `NET_ADMIN` (`--cap-add NET_ADMIN` for docker/podman, `securityContext.capabilities.add: ["NET_ADMIN"]` for Kubernetes) for the full egress gate; without it the spoke stays in best-effort/degraded egress mode. See [docs/net-admin-requirement.md](docs/net-admin-requirement.md).
 - **Policy clone errors in logs**: The example config has a placeholder policy repo. Comment out the `policies:` section in `src/hive.yaml` if you don't have a custom policy repo.
 

--- a/src/deploy/standalone-images.sh
+++ b/src/deploy/standalone-images.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# The one image-reference source of truth for standalone Hive deployments
+# (#4206).
+#
+# Every standalone deployment asset -- the Docker Compose stack today, the
+# Podman Quadlet units later -- takes its image references from here. Two
+# assets that each hard-code their own reference drift silently: one gets
+# bumped, the other keeps pulling last quarter's image, and nothing fails until
+# an operator notices the two runtimes are running different code.
+#
+# References here are FULLY QUALIFIED, because `podman auto-update` and the
+# Quadlet generator both require a registry-qualified name, and a short name
+# resolves through whatever `unqualified-search-registries` happens to say on
+# the host. Docker may spell the same image without the `docker.io/` prefix;
+# hive_standalone_image_normalize exists so the two spellings compare equal.
+#
+# Digest pinning stays available and is used where an asset pins one: the
+# `tag@sha256:...` form is carried through unchanged.
+#
+# src/deploy/test_standalone_image_refs.sh enforces that every asset agrees
+# with this file, and runs in CI.
+
+# The Hive image itself. `stable` is the operator-blessed release channel; see
+# src/docs/operator-reference.md#image-provenance-and-tags and
+# src/docs/release-channels.md. Do NOT use `v2-latest`: it was the rolling tag
+# of the retired v2 branch. src/deploy/k8s/backup-cronjob.yaml already moved
+# off it for the same reason (#3709).
+HIVE_STANDALONE_IMAGE_HIVE="ghcr.io/kubestellar/hive:stable"
+
+# The authenticating gateway. Digest-pinned against floating-tag supply-chain
+# risk; refresh the tag and the digest together, as src/docker-compose.yaml
+# documents.
+HIVE_STANDALONE_IMAGE_GATEWAY="docker.io/library/nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752"
+
+# The optional auto-update profile. Docker-only by design: it is built on the
+# Docker socket and a filtered Docker API proxy, and #4188 rules out repointing
+# it at the Podman socket. Listed here so the profile cannot drift either.
+HIVE_STANDALONE_IMAGE_DOCKER_SOCKET_PROXY="docker.io/tecnativa/docker-socket-proxy:0.3.0@sha256:9e4b9e7517a6b660f2cc903a19b257b1852d5b3344794e3ea334ff00ae677ac2"
+HIVE_STANDALONE_IMAGE_WATCHTOWER="docker.io/containrrr/watchtower:1.7.1@sha256:6dd50763bbd632a83cb154d5451700530d1e44200b268a4e9488fefdfcf2b038"
+
+# Component name -> variable name. The component names are what assets and the
+# contract test refer to.
+hive_standalone_image_components() {
+  cat <<'EOF'
+hive
+gateway
+docker-socket-proxy
+watchtower
+EOF
+}
+
+# Prints the canonical reference for one component.
+hive_standalone_image() {
+  local component="${1:-}"
+
+  case "$component" in
+    hive) printf '%s\n' "$HIVE_STANDALONE_IMAGE_HIVE" ;;
+    gateway) printf '%s\n' "$HIVE_STANDALONE_IMAGE_GATEWAY" ;;
+    docker-socket-proxy) printf '%s\n' "$HIVE_STANDALONE_IMAGE_DOCKER_SOCKET_PROXY" ;;
+    watchtower) printf '%s\n' "$HIVE_STANDALONE_IMAGE_WATCHTOWER" ;;
+    *)
+      printf 'ERROR: unknown standalone image component %q\n' "$component" >&2
+      return 64
+      ;;
+  esac
+}
+
+# Expands a reference to its fully qualified form, the way a registry client
+# resolves a short name. `nginx:alpine` and `docker.io/library/nginx:alpine`
+# are the same image; this makes them the same string so Docker's spelling and
+# Podman's required spelling can be compared.
+hive_standalone_image_normalize() {
+  local ref="${1:-}"
+  local first="${ref%%/*}"
+
+  [[ -n "$ref" ]] || return 64
+
+  # A first segment carrying a dot, a port, or the literal localhost is a
+  # registry host; anything else is part of the repository path.
+  if [[ "$ref" == */* ]] && { [[ "$first" == *.* ]] || [[ "$first" == *:* ]] || [[ "$first" == "localhost" ]]; }; then
+    printf '%s\n' "$ref"
+    return 0
+  fi
+
+  if [[ "$ref" == */* ]]; then
+    printf 'docker.io/%s\n' "$ref"
+  else
+    printf 'docker.io/library/%s\n' "$ref"
+  fi
+}
+
+# The digest of a reference, or the empty string when it is not pinned.
+hive_standalone_image_digest() {
+  local ref="${1:-}"
+
+  case "$ref" in
+    *@sha256:*) printf 'sha256:%s\n' "${ref##*@sha256:}" ;;
+    *) printf '\n' ;;
+  esac
+}
+
+hive_standalone_images_list() {
+  local component
+  while IFS= read -r component; do
+    [[ -n "$component" ]] || continue
+    printf '%s\t%s\n' "$component" "$(hive_standalone_image "$component")"
+  done < <(hive_standalone_image_components)
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  case "${1:-list}" in
+    list) hive_standalone_images_list ;;
+    get) hive_standalone_image "${2:-}" ;;
+    normalize) hive_standalone_image_normalize "${2:-}" ;;
+    -h|--help|help)
+      cat <<'EOF'
+Usage: standalone-images.sh [list]
+       standalone-images.sh get <component>
+       standalone-images.sh normalize <image-reference>
+
+Components: hive, gateway, docker-socket-proxy, watchtower.
+EOF
+      ;;
+    *)
+      printf 'ERROR: unknown action %q\n' "$1" >&2
+      exit 64
+      ;;
+  esac
+fi

--- a/src/deploy/test_standalone_image_refs.sh
+++ b/src/deploy/test_standalone_image_refs.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Contract test for the standalone image-reference source of truth (#4206).
+# Run: bash src/deploy/test_standalone_image_refs.sh
+#
+# Enforces that every standalone deployment asset takes its image references
+# from src/deploy/standalone-images.sh, so the Docker Compose stack and the
+# Podman assets that land later cannot drift apart. Pure string analysis: it
+# contacts no registry, pulls nothing, and runs offline.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=src/deploy/standalone-images.sh disable=SC1091
+source "${ROOT}/src/deploy/standalone-images.sh"
+
+# Standalone deployment assets. The Podman globs match nothing today and start
+# being enforced automatically the moment those assets land, which is the point
+# — drift detection must not need a second edit to switch on.
+DOCKER_ASSETS=(
+  "src/docker-compose.yaml"
+)
+PODMAN_ASSET_GLOBS=(
+  "src/deploy/quadlet/*.container"
+  "src/deploy/quadlet/*.pod"
+  "src/deploy/quadlet/*.kube"
+  "src/deploy/podman-compose.yaml"
+  "src/podman-compose.yaml"
+)
+
+# The retired rolling tag of the v2 branch. It resolves to a different digest
+# than the v4 release channels, so an asset still naming it is running other
+# code, not merely an older spelling.
+RETIRED_TAG="v2-latest"
+
+pass_count=0
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+ok() {
+  pass_count=$((pass_count + 1))
+}
+
+# Collects `image: <ref>` values out of an asset, ignoring comments. Handles
+# both the Compose `image:` key and the Quadlet `Image=` key.
+asset_image_refs() {
+  local file="$1"
+  sed -e 's/[[:space:]]*#.*$//' "$file" \
+    | grep -oE '^[[:space:]]*(image:|Image=)[[:space:]]*[^[:space:]]+' \
+    | sed -e 's/^[[:space:]]*//' -e 's/^image:[[:space:]]*//' -e 's/^Image=[[:space:]]*//' \
+    | grep -v '^$' || true
+}
+
+collect_assets() {
+  local asset glob
+  for asset in "${DOCKER_ASSETS[@]}"; do
+    [[ -f "${ROOT}/${asset}" ]] && printf '%s\n' "$asset"
+  done
+  for glob in "${PODMAN_ASSET_GLOBS[@]}"; do
+    for asset in ${ROOT}/${glob}; do
+      [[ -f "$asset" ]] && printf '%s\n' "${asset#"${ROOT}/"}"
+    done
+  done
+  return 0
+}
+
+# --- 1. Every canonical reference is already fully qualified ----------------
+#
+# Podman's Quadlet generator warns on short names and `podman auto-update`
+# refuses them outright, so the source of truth must not hand out a reference
+# that resolves through unqualified-search-registries.
+
+while IFS=$'\t' read -r component canonical; do
+  [[ -n "$component" ]] || continue
+  normalized="$(hive_standalone_image_normalize "$canonical")"
+  if [[ "$normalized" == "$canonical" ]]; then
+    ok
+  else
+    fail "canonical reference for '${component}' is not fully qualified: ${canonical} (resolves to ${normalized})"
+  fi
+
+  if [[ "$canonical" == *"$RETIRED_TAG"* ]]; then
+    fail "canonical reference for '${component}' still names the retired ${RETIRED_TAG} tag"
+  else
+    ok
+  fi
+done < <(hive_standalone_images_list)
+
+# --- 2. Every asset reference matches a canonical reference -----------------
+#
+# This is the Docker/Podman drift check. Comparison is on the normalized form,
+# so Compose may keep Docker's short spelling while the Podman assets carry the
+# fully qualified one, and both still have to point at the same image.
+
+canonical_normalized=()
+while IFS=$'\t' read -r _component canonical; do
+  [[ -n "$canonical" ]] || continue
+  canonical_normalized+=("$(hive_standalone_image_normalize "$canonical")")
+done < <(hive_standalone_images_list)
+
+asset_count=0
+while IFS= read -r asset; do
+  [[ -n "$asset" ]] || continue
+  asset_count=$((asset_count + 1))
+
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] || continue
+
+    # A reference built locally rather than pulled is out of scope here.
+    [[ "$ref" == \$* ]] && continue
+
+    if [[ "$ref" == *"$RETIRED_TAG"* ]]; then
+      fail "${asset} references the retired ${RETIRED_TAG} tag: ${ref}"
+      continue
+    fi
+
+    normalized="$(hive_standalone_image_normalize "$ref")"
+    matched="false"
+    for canonical in "${canonical_normalized[@]}"; do
+      [[ "$normalized" == "$canonical" ]] && matched="true" && break
+    done
+
+    if [[ "$matched" == "true" ]]; then
+      ok
+    else
+      fail "${asset} uses an image reference that is not in src/deploy/standalone-images.sh: ${ref}"
+      printf '      (normalized: %s)\n' "$normalized" >&2
+      printf '      Add it to the source of truth, or change the asset to match one of:\n' >&2
+      printf '        %s\n' "${canonical_normalized[@]}" >&2
+    fi
+  done < <(asset_image_refs "${ROOT}/${asset}")
+done < <(collect_assets)
+
+[[ "$asset_count" -gt 0 ]] || fail "no standalone deployment assets were found to check"
+
+# --- 3. Digest pinning survives ---------------------------------------------
+#
+# Where the source of truth pins a digest, the asset must carry the same one.
+# A tag-only asset reference against a digest-pinned canonical is exactly the
+# supply-chain regression the pins exist to prevent.
+
+while IFS= read -r asset; do
+  [[ -n "$asset" ]] || continue
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] || continue
+    [[ "$ref" == \$* ]] && continue
+
+    normalized="$(hive_standalone_image_normalize "$ref")"
+    ref_repo="${normalized%%@*}"
+    ref_repo="${ref_repo%%:*}"
+
+    while IFS=$'\t' read -r _component canonical; do
+      [[ -n "$canonical" ]] || continue
+      canonical_norm="$(hive_standalone_image_normalize "$canonical")"
+      canonical_repo="${canonical_norm%%@*}"
+      canonical_repo="${canonical_repo%%:*}"
+      [[ "$ref_repo" == "$canonical_repo" ]] || continue
+
+      canonical_digest="$(hive_standalone_image_digest "$canonical_norm")"
+      [[ -n "$canonical_digest" ]] || continue
+
+      ref_digest="$(hive_standalone_image_digest "$normalized")"
+      if [[ "$ref_digest" == "$canonical_digest" ]]; then
+        ok
+      else
+        fail "${asset} drops or changes the digest pin for ${canonical_repo}: asset has '${ref_digest:-none}', source of truth has '${canonical_digest}'"
+      fi
+    done < <(hive_standalone_images_list)
+  done < <(asset_image_refs "${ROOT}/${asset}")
+done < <(collect_assets)
+
+# --- 4. The Hive image tracks a live channel --------------------------------
+
+hive_ref="$(hive_standalone_image hive)"
+case "$hive_ref" in
+  ghcr.io/kubestellar/hive:stable|ghcr.io/kubestellar/hive:v4-latest|ghcr.io/kubestellar/hive@sha256:*|ghcr.io/kubestellar/hive:*@sha256:*)
+    ok
+    ;;
+  *)
+    fail "the Hive image should track a live release channel or a pinned digest, got: ${hive_ref}"
+    ;;
+esac
+
+if [[ "$failures" -gt 0 ]]; then
+  printf '\n%d standalone image-reference contract failure(s)\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'PASS: %d standalone image-reference assertions across %d asset(s)\n' \
+  "$pass_count" "$asset_count"

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -29,7 +29,20 @@ services:
       retries: 3
 
   hive:
-    image: ghcr.io/kubestellar/hive:v2-latest
+    # Image references for the standalone stack come from ONE source of truth,
+    # src/deploy/standalone-images.sh, so the Docker and Podman assets cannot
+    # drift apart. src/deploy/test_standalone_image_refs.sh fails the build if
+    # this line stops agreeing with it.
+    #
+    # Bumped off the retired `v2-latest` (#4206). That tag belonged to the v2
+    # branch and resolves to a different, older digest than the v4 channels;
+    # src/docs/operator-reference.md already told operators not to use it for
+    # new deployments and flagged this default as pending a bump, and
+    # src/deploy/k8s/backup-cronjob.yaml made the same move for the same reason
+    # (#3709). `stable` is the operator-blessed release channel; pin a digest
+    # here instead (`ghcr.io/kubestellar/hive@sha256:...`) for full
+    # reproducibility.
+    image: ghcr.io/kubestellar/hive:stable
     build:
       context: ..
       dockerfile: src/Dockerfile

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -84,7 +84,28 @@ Pre-built images are published by [`.github/workflows/docker.yml`](../../.github
 
 PR and short-lived branch builds compile the image as a CI gate but only long-lived branches push tags, and only `v4` moves the release channels. Before tagging, the workflow verifies its SHA is still branch HEAD, so a stale queued build cannot move a rolling tag backward.
 
-> **Note:** `v2-latest` was the rolling tag of the retired `v2` branch. Do not use it for new deployments — prefer `stable` for production, or pin a digest. (`src/docker-compose.yaml` may still reference it until its default is bumped.)
+> **Note:** `v2-latest` was the rolling tag of the retired `v2` branch. Do not use it for new deployments — prefer `stable` for production, or pin a digest. (`src/docker-compose.yaml` was bumped off it in #4206; standalone image references now come from one source of truth, [`src/deploy/standalone-images.sh`](../deploy/standalone-images.sh).)
+
+### One source of truth for standalone assets
+
+Standalone deployment assets do not carry their own image references. They take
+them from [`src/deploy/standalone-images.sh`](../deploy/standalone-images.sh),
+which names the Hive, gateway, and auto-update-profile images in fully
+qualified form. Change a reference there rather than in an individual asset.
+
+Fully qualified is deliberate: `podman auto-update` refuses a short name, and
+Podman's Quadlet generator warns on one, so a reference that resolves through
+the host's `unqualified-search-registries` is not portable across the two
+runtimes. Docker may still spell the same image without the `docker.io/`
+prefix — the contract test compares the normalized forms, so the two spellings
+are equal as long as they name the same image. Digest pins are carried through
+unchanged and are checked for as well.
+
+[`src/deploy/test_standalone_image_refs.sh`](../deploy/test_standalone_image_refs.sh)
+runs in CI and fails the build when an asset stops agreeing with that file,
+when a digest pin is dropped, or when the retired `v2-latest` tag reappears. It
+already covers the Podman asset paths, so drift detection switches on by itself
+when those assets land.
 
 ### Choosing a tag
 


### PR DESCRIPTION
## What

Standalone deployment assets no longer carry their own image references. They read them from one file, `src/deploy/standalone-images.sh`, and a contract test in CI fails the build when any asset stops agreeing with it.

Two assets that each hard-code their own reference drift silently: one gets bumped, the other keeps pulling last quarter's image, and nothing fails until someone notices the two runtimes are running different code. That is the failure this prevents before the Podman assets exist to cause it.

## The source of truth

`src/deploy/standalone-images.sh` names the Hive image, the gateway, and the auto-update profile's two images, plus helpers to normalize a reference and extract a digest.

References are **fully qualified** because `podman auto-update` refuses a short name and the Quadlet generator warns on one — both findings from the #4201 and #4202 spikes. A name resolved through the host's `unqualified-search-registries` is not portable across runtimes.

## The drift check

`src/deploy/test_standalone_image_refs.sh` (wired into `v2-ci`) asserts:

1. every canonical reference is fully qualified,
2. every reference in every standalone asset matches one of them,
3. digest pins are not silently dropped,
4. `v2-latest` never reappears in a deployment asset.

Comparison is on the **normalized** form, so Compose may keep Docker's short `nginx:alpine@sha256:…` while the Podman assets carry `docker.io/library/nginx:alpine@sha256:…`, and both still have to name the same image. The Podman asset paths (`src/deploy/quadlet/*.container`, `*.pod`, `*.kube`, …) are already in the scan, so **drift detection switches on by itself when those assets land** rather than needing a second edit.

Verified by mutation — each of these was actually run:

| Mutation | Result |
| --- | --- |
| Compose reverted to `v2-latest` | **fails** — retired tag |
| Gateway digest pin dropped | **fails** — reference not in the source of truth |
| Quadlet unit bumped to `v4-latest`, Compose left on `stable` | **fails** — Docker/Podman drift |
| `v2-latest` copied into a Quadlet unit | **fails** — retired tag |
| Quadlet unit spelling the same images fully qualified vs Compose's short form | **passes** — 19 assertions across 3 assets |

Pure string analysis: it contacts no registry and runs offline.

## Docker behavior is changed, deliberately

`src/docker-compose.yaml` moves from `ghcr.io/kubestellar/hive:v2-latest` to `:stable`. This is the "separately justified, tested edit" the acceptance criteria allow, not an incidental bump:

- **It is not the same image.** `v2-latest` resolves to `sha256:e11c7a8c…` (built 2026-08-18, retired `v2` branch); `stable` and `v4-latest` both resolve to `sha256:e1479d76…`. Leaving it would keep the default Docker deployment on a different codebase from every other asset.
- **The project already decided this.** `src/docs/operator-reference.md` says "Do not use it for new deployments — prefer `stable`" and explicitly flagged this default as pending a bump. I removed that now-stale parenthetical.
- **There is precedent in-tree.** `src/deploy/k8s/backup-cronjob.yaml` made the identical move for the identical reason, documented against #3709.
- **#4188 permits it**: "Resolve the Docker default separately or in this work, but keep one source of truth for both runtimes."

Both existing Compose contract tests still pass against the edited file: supply-chain pin guard (17 passed) and docker-socket containment guard (21 passed).

## Stale docs the retired tag left behind

`README.md` and `src/README.md` both linked `operator-reference.md#image-provenance-for-ghcriokubestellarhivev2-latest` — an anchor that no longer exists, since the heading is now "Image provenance and tags". Both links were already broken. Fixed, along with the two other places `src/README.md` advertised `v2-latest` (its pre-built-image section and its troubleshooting `docker run` line).

## Acceptance criteria

- [x] **`v2-latest` is not propagated into new Podman work** — blocked by the contract test in any deployment asset, Docker or Podman, and removed from the one asset that still had it.
- [x] **Docker behavior intentionally changed in a separately justified, tested edit** — justified above; the two existing Compose contract tests pass, and the new test pins the reference so a future silent bump fails.
- [x] **Fully qualified names and optional digest pinning remain possible** — fully qualified is the required form for canonical references; three of the four are digest-pinned today, and the test fails if a pin is dropped.
- [x] **A test detects accidental Docker/Podman drift once both assets exist** — demonstrated in the table above, including that a legal spelling difference is *not* reported as drift.

## Testing

```
$ bash src/deploy/test_standalone_image_refs.sh
PASS: 16 standalone image-reference assertions across 1 asset(s)

$ bash src/deploy/test_supply_chain_pins.sh            # unchanged
=== 17 passed, 0 failed ===
$ bash src/deploy/test_watchtower_socket_contract.sh   # unchanged
=== Results: 21 passed, 0 failed ===

$ shellcheck src/deploy/standalone-images.sh src/deploy/test_standalone_image_refs.sh
(clean)
```

Compose file re-parsed with a YAML loader after the edit; workflow YAML validated.

Part of #4188
Fixes #4206

— hive: backend=claude model=claude-opus-5