### PR TITLE
🩺 podman: add engine, root mode, and cgroup preflight checks

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -115,6 +115,16 @@ jobs:
         working-directory: .
         run: bash bin/test_hive_standalone_runtime.sh
 
+      # #4207: Podman preflight must diagnose engine/version, the connection it
+      # is actually talking to, root mode, and cgroup version BEFORE Hive
+      # invokes a lifecycle implementation — and must run only when Podman is
+      # explicitly selected, so Docker's default path is untouched. The stub
+      # engine lets the whole matrix (old versions, rootful, cgroup v1, remote,
+      # missing binary) run on a host with no Podman installed.
+      - name: Podman preflight contract (#4207)
+        working-directory: .
+        run: bash bin/test_hive_podman_preflight.sh
+
       # #4210: rootless Podman/Buildah share one store with the operator's
       # unrelated containers, Distroboxes, and builds, so Hive cleanup must
       # select only Hive-labelled resources and the broad store-wide prune,

--- a/bin/README.md
+++ b/bin/README.md
@@ -57,6 +57,7 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `hive-deploy.sh` | Deploy | Pulls the latest Hive repository and syncs scripts to `/usr/local/bin`; also restarts Discord bot components when their files change. |
 | `hive-standalone-runtime.sh` | Deploy | Selects the standalone container engine from `HIVE_DEPLOY_RUNTIME` (`docker` by default) and runs commands against it without ever falling back to the other engine. |
 | `hive-podman-cleanup.sh` | Deploy | Defines the Hive ownership labels for Podman containers, pods, networks, volumes, and images, and guards cleanup so it can never widen into a store-wide Podman/Buildah operation. See [`src/docs/podman-ownership-cleanup.md`](../src/docs/podman-ownership-cleanup.md). |
+| `hive-podman-preflight.sh` | Bootstrap | Read-only Podman diagnostics before a lifecycle runs: engine/version, the connection it is actually talking to, rootless vs rootful, and cgroup version. Runs only when `HIVE_DEPLOY_RUNTIME` selects podman; `hive-prereq-check.sh` invokes it. |
 | `federation-heartbeat.sh` | Federation | Sends live contributor and actionable-work stats to the Hive federation registry. |
 | `notify.sh` | Notifications | Shared Bash notification library for ntfy, Slack incoming webhooks, and Discord webhooks. |
 
@@ -88,3 +89,4 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `gh-wrapper.test.sh` | `gh-wrapper.sh` author-gate and restriction regressions using a mock `gh` binary. |
 | `test_hive_standalone_runtime.sh` | `hive-standalone-runtime.sh` engine selection: Docker default, explicit Podman, and no silent fallback. |
 | `test_hive_podman_cleanup.sh` | `hive-podman-cleanup.sh` ownership labels and cleanup guard. Analyses arguments only: it contacts no container engine and deletes nothing. |
+| `test_hive_podman_preflight.sh` | `hive-podman-preflight.sh` engine, connection, root-mode, and cgroup checks. Drives a stub engine, so the whole matrix runs on a host with no Podman installed. |

--- a/bin/hive-podman-preflight.sh
+++ b/bin/hive-podman-preflight.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Podman preflight: engine, root mode, and cgroup checks (#4207).
+#
+# Operators need actionable diagnostics BEFORE Hive invokes a Podman lifecycle
+# implementation. Without them the first sign of an unusable host is a
+# half-created deployment failing somewhere inside `podman run`.
+#
+# This layer answers four questions and nothing else:
+#
+#   1. Is there a Podman engine, and is it new enough?
+#   2. Which connection is it actually talking to? (local, or a remote/Machine
+#      service, which changes what every later check even means)
+#   3. Rootless or rootful?
+#   4. Is the host on cgroup v2?
+#
+# Storage, SELinux, networking, secrets, and ports are separate issues (#4208,
+# #4209). Nothing here writes to the host, starts a container, or contacts a
+# registry.
+#
+# These checks run ONLY when Podman is explicitly selected through
+# HIVE_DEPLOY_RUNTIME. Docker is the default and is not touched: with Docker
+# selected this script reports that Podman is not in use and exits 0 without
+# running a single Podman command.
+#
+# Run: bin/hive-podman-preflight.sh
+# Exit codes: 0 no failing check, 78 at least one failing check (EX_CONFIG).
+
+# Quadlet arrived in Podman 4.4; below that none of the lifecycle options under
+# evaluation exist. Override for a host deliberately running something older.
+HIVE_PODMAN_MIN_VERSION="${HIVE_PODMAN_MIN_VERSION:-4.4}"
+
+# .pod units, the Pod= key, and Notify=healthy are Podman 5 features. Below 5
+# the engine works but the Quadlet shape recorded in
+# src/docs/podman-quadlet-container-pod-spike.md does not.
+HIVE_PODMAN_QUADLET_POD_VERSION="${HIVE_PODMAN_QUADLET_POD_VERSION:-5.0}"
+
+HIVE_PREFLIGHT_PASS=0
+HIVE_PREFLIGHT_WARN=0
+HIVE_PREFLIGHT_FAIL=0
+
+# Markers match bin/hive-prereq-check.sh so the two read as one report when
+# this is invoked from there.
+_pf_pass() { echo "  ✓ $1"; HIVE_PREFLIGHT_PASS=$((HIVE_PREFLIGHT_PASS + 1)); }
+_pf_warn() { echo "  △ $1"; HIVE_PREFLIGHT_WARN=$((HIVE_PREFLIGHT_WARN + 1)); }
+_pf_fail() { echo "  ✗ $1"; HIVE_PREFLIGHT_FAIL=$((HIVE_PREFLIGHT_FAIL + 1)); }
+_pf_hint() { echo "    → $1"; }
+
+# Compares dotted versions. Returns 0 when $1 >= $2.
+_pf_version_ge() {
+  local have="$1" want="$2"
+  local -a h w
+  IFS='.' read -r -a h <<<"${have%%-*}"
+  IFS='.' read -r -a w <<<"${want%%-*}"
+
+  local i hv wv
+  for i in 0 1 2; do
+    hv="${h[i]:-0}"; wv="${w[i]:-0}"
+    hv="${hv//[!0-9]/}"; wv="${wv//[!0-9]/}"
+    hv="${hv:-0}"; wv="${wv:-0}"
+    (( hv > wv )) && return 0
+    (( hv < wv )) && return 1
+  done
+  return 0
+}
+
+# One `podman info` field. A template an older Podman does not know must
+# degrade to "unknown" rather than abort the preflight.
+_pf_info() {
+  local template="$1" value
+  value="$(podman info --format "$template" 2>/dev/null)" || return 1
+  [[ -n "$value" && "$value" != "<no value>" ]] || return 1
+  printf '%s\n' "$value"
+}
+
+# --- 1. Engine executable and version ---------------------------------------
+
+hive_podman_check_engine() {
+  local version
+
+  if ! command -v podman >/dev/null 2>&1; then
+    _pf_fail "Podman: not installed or not on PATH"
+    _pf_hint "Install podman, or unset HIVE_DEPLOY_RUNTIME to use the Docker default."
+    return 1
+  fi
+
+  if ! version="$(podman version --format '{{.Client.Version}}' 2>/dev/null)" || [[ -z "$version" ]]; then
+    _pf_fail "Podman: $(command -v podman) did not report a client version"
+    _pf_hint "Run 'podman version' directly; the install is not usable until it does."
+    return 1
+  fi
+
+  if ! _pf_version_ge "$version" "$HIVE_PODMAN_MIN_VERSION"; then
+    _pf_fail "Podman ${version} at $(command -v podman) — Hive needs ${HIVE_PODMAN_MIN_VERSION} or newer"
+    _pf_hint "Quadlet arrived in 4.4; below that none of the supported lifecycle options exist."
+    return 1
+  fi
+
+  _pf_pass "Podman ${version} ($(command -v podman))"
+
+  if ! _pf_version_ge "$version" "$HIVE_PODMAN_QUADLET_POD_VERSION"; then
+    _pf_warn "Podman ${version} predates ${HIVE_PODMAN_QUADLET_POD_VERSION} — .pod units, Pod=, and Notify=healthy are unavailable"
+    _pf_hint "The Compose lifecycle still works; the Quadlet pod layout does not."
+  fi
+
+  return 0
+}
+
+# --- 2. Connection identity --------------------------------------------------
+#
+# Reported, not judged. A remote or Machine connection is legitimate, but every
+# later check means something different when the engine is not on this host --
+# storage, SELinux, and published ports all belong to the far side.
+
+hive_podman_check_connection() {
+  local remote connection
+
+  remote="$(_pf_info '{{.Host.ServiceIsRemote}}')" || remote="unknown"
+
+  connection="$(podman system connection list --format '{{.Name}} {{.URI}} {{.Default}}' 2>/dev/null \
+    | awk '$3 == "true" { print $1 " -> " $2 }' | head -1)"
+
+  if [[ "$remote" == "true" ]]; then
+    _pf_warn "Podman connection: REMOTE${connection:+ (${connection})}"
+    _pf_hint "The engine is not on this host. Storage, SELinux, and port checks apply to the far side, not here."
+  elif [[ -n "$connection" ]]; then
+    _pf_pass "Podman connection: local, default connection ${connection}"
+  elif [[ "$remote" == "false" ]]; then
+    _pf_pass "Podman connection: local (no named connection configured)"
+  else
+    _pf_warn "Podman connection: could not be determined"
+    _pf_hint "Run 'podman system connection list' and 'podman info' to see what this install is talking to."
+  fi
+
+  return 0
+}
+
+# --- 3. Root mode ------------------------------------------------------------
+#
+# Reported explicitly rather than inferred, because the supported
+# rootful/rootless matrix in #4188 turns on it and because the effective
+# security mode differs between them.
+
+hive_podman_check_root_mode() {
+  local rootless
+
+  if ! rootless="$(_pf_info '{{.Host.Security.Rootless}}')"; then
+    _pf_fail "Podman root mode: podman info did not report it"
+    _pf_hint "Run 'podman info' directly; the engine is not answering."
+    return 1
+  fi
+
+  case "$rootless" in
+    true)  _pf_pass "Podman root mode: rootless (uid $(id -u))" ;;
+    false) _pf_pass "Podman root mode: rootful" ;;
+    *)
+      _pf_warn "Podman root mode: unrecognized value ${rootless}"
+      return 0
+      ;;
+  esac
+
+  return 0
+}
+
+# --- 4. cgroup version -------------------------------------------------------
+
+hive_podman_check_cgroups() {
+  local version manager
+
+  if ! version="$(_pf_info '{{.Host.CgroupsVersion}}')"; then
+    _pf_fail "cgroups: podman info did not report a version"
+    return 1
+  fi
+
+  manager="$(_pf_info '{{.Host.CgroupManager}}')" || manager="unknown"
+
+  if [[ "$version" != "v2" ]]; then
+    _pf_fail "cgroups: ${version} — Hive's Podman path requires cgroup v2"
+    _pf_hint "Quadlet requires v2, and rootless resource control is unavailable on v1."
+    _pf_hint "Boot with systemd.unified_cgroup_hierarchy=1, then re-run."
+    return 1
+  fi
+
+  _pf_pass "cgroups: v2 (manager: ${manager})"
+  return 0
+}
+
+# --- Runner ------------------------------------------------------------------
+
+hive_podman_preflight_selected_runtime() {
+  local selector="${HIVE_PODMAN_PREFLIGHT_SELECTOR:-$(dirname "${BASH_SOURCE[0]}")/hive-standalone-runtime.sh}"
+
+  if [[ -r "$selector" ]]; then
+    # shellcheck source=bin/hive-standalone-runtime.sh disable=SC1090,SC1091
+    source "$selector"
+    hive_deploy_runtime_select
+    return
+  fi
+
+  printf '%s\n' "${HIVE_DEPLOY_RUNTIME:-docker}"
+}
+
+hive_podman_preflight_main() {
+  local runtime
+
+  if ! runtime="$(hive_podman_preflight_selected_runtime)"; then
+    return 64
+  fi
+
+  # The whole point of this gate: with Docker selected, not one Podman command
+  # runs and Docker's own prerequisite checks are left exactly as they were.
+  if [[ "$runtime" != "podman" ]]; then
+    echo "Podman preflight: skipped — HIVE_DEPLOY_RUNTIME selects ${runtime}"
+    return 0
+  fi
+
+  echo "Podman preflight (engine, root mode, cgroups)"
+
+  if hive_podman_check_engine; then
+    hive_podman_check_connection
+    hive_podman_check_root_mode
+    hive_podman_check_cgroups
+  else
+    # Every remaining check shells out to podman, so without a usable engine
+    # they would all report the same missing binary in four different ways.
+    _pf_hint "Connection, root mode, and cgroup checks skipped — no usable engine."
+  fi
+
+  printf 'SUMMARY: pass=%d warn=%d fail=%d\n' \
+    "$HIVE_PREFLIGHT_PASS" "$HIVE_PREFLIGHT_WARN" "$HIVE_PREFLIGHT_FAIL"
+
+  [[ "$HIVE_PREFLIGHT_FAIL" -eq 0 ]] || return 78
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -uo pipefail
+  case "${1:-check}" in
+    check) hive_podman_preflight_main ;;
+    -h|--help|help)
+      cat <<'EOF'
+Usage: hive-podman-preflight.sh [check]
+
+Reports the Podman engine and version, the connection it is talking to, the
+root mode, and the cgroup version. Read-only: it starts no container, writes
+nothing to the host, and contacts no registry.
+
+Runs only when HIVE_DEPLOY_RUNTIME selects podman; with the Docker default it
+reports that it was skipped and exits 0.
+
+Exit codes: 0 clean, 78 at least one failing check.
+EOF
+      ;;
+    *)
+      printf 'ERROR: unknown action %q\n' "$1" >&2
+      exit 64
+      ;;
+  esac
+fi

--- a/bin/hive-prereq-check.sh
+++ b/bin/hive-prereq-check.sh
@@ -227,6 +227,31 @@ else
     && pass "SSH root login: enabled"
 fi
 
+# ── Podman (only when explicitly selected) ─────────────────────────
+# Docker is the default and every Docker check above is untouched. When
+# HIVE_DEPLOY_RUNTIME selects podman, add engine/connection/root-mode/cgroup
+# diagnostics (#4207). hive-podman-preflight.sh self-gates on the same runtime
+# selector, so with Docker selected it prints one skip line and runs no Podman
+# command at all.
+PODMAN_PREFLIGHT="$(dirname "$0")/hive-podman-preflight.sh"
+if [[ -x "$PODMAN_PREFLIGHT" ]]; then
+  echo ""
+  # It exits 78 when a check fails; that is a result to fold in, not a reason
+  # to abort this script under `set -e`.
+  PREFLIGHT_OUT="$("$PODMAN_PREFLIGHT" 2>&1)" || true
+  grep -v '^SUMMARY:' <<<"$PREFLIGHT_OUT" || true
+
+  PREFLIGHT_SUMMARY="$(grep '^SUMMARY:' <<<"$PREFLIGHT_OUT" || true)"
+  if [[ -n "$PREFLIGHT_SUMMARY" ]]; then
+    P_PASS="${PREFLIGHT_SUMMARY#*pass=}"; P_PASS="${P_PASS%% *}"
+    P_WARN="${PREFLIGHT_SUMMARY#*warn=}"; P_WARN="${P_WARN%% *}"
+    P_FAIL="${PREFLIGHT_SUMMARY#*fail=}"; P_FAIL="${P_FAIL%% *}"
+    PASS=$((PASS + P_PASS))
+    WARN=$((WARN + P_WARN))
+    FAIL=$((FAIL + P_FAIL))
+  fi
+fi
+
 # ── Summary ─────────────────────────────────────────────────────────
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/bin/test_hive_podman_preflight.sh
+++ b/bin/test_hive_podman_preflight.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Contract tests for bin/hive-podman-preflight.sh (#4207).
+# Run: bash bin/test_hive_podman_preflight.sh
+#
+# Every case drives a stub `podman` whose output is set from the environment,
+# so the whole matrix — old versions, rootful, cgroup v1, a remote connection,
+# a missing engine — runs on a host that has no Podman at all and never
+# executes a real container command.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFLIGHT="${ROOT}/bin/hive-podman-preflight.sh"
+BASH_BIN="$(command -v bash)"
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+FAKE_BIN="${TEST_TMP}/bin"
+CALL_LOG="${TEST_TMP}/podman-calls.log"
+mkdir -p "$FAKE_BIN"
+
+cat >"${FAKE_BIN}/podman" <<'EOF'
+#!/bin/sh
+# Stub Podman. Records every invocation, then answers from the environment.
+printf 'podman %s\n' "$*" >>"$PODMAN_CALL_LOG"
+
+case "$*" in
+  "version --format {{.Client.Version}}")
+    [ "${FAKE_VERSION:-}" = "__ERR__" ] && exit 125
+    printf '%s\n' "${FAKE_VERSION:-5.8.4}"
+    ;;
+  "info --format {{.Host.ServiceIsRemote}}")
+    [ "${FAKE_REMOTE:-}" = "__ERR__" ] && exit 125
+    printf '%s\n' "${FAKE_REMOTE:-false}"
+    ;;
+  "info --format {{.Host.Security.Rootless}}")
+    [ "${FAKE_ROOTLESS:-}" = "__ERR__" ] && exit 125
+    printf '%s\n' "${FAKE_ROOTLESS:-true}"
+    ;;
+  "info --format {{.Host.CgroupsVersion}}")
+    [ "${FAKE_CGROUPS:-}" = "__ERR__" ] && exit 125
+    printf '%s\n' "${FAKE_CGROUPS:-v2}"
+    ;;
+  "info --format {{.Host.CgroupManager}}")
+    printf '%s\n' "${FAKE_CGROUP_MANAGER:-systemd}"
+    ;;
+  "system connection list --format {{.Name}} {{.URI}} {{.Default}}")
+    [ -n "${FAKE_CONNECTIONS:-}" ] && printf '%s\n' "$FAKE_CONNECTIONS"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${FAKE_BIN}/podman"
+TEST_PATH="${FAKE_BIN}:/usr/bin:/bin"
+
+pass_count=0
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+assert_eq() {
+  [[ "$2" == "$1" ]] || fail "$3: got '$2', want '$1'"
+  pass_count=$((pass_count + 1))
+}
+
+assert_contains() {
+  [[ "$1" == *"$2"* ]] || fail "$3: missing '$2' in: $1"
+  pass_count=$((pass_count + 1))
+}
+
+assert_not_contains() {
+  [[ "$1" != *"$2"* ]] || fail "$3: unexpectedly found '$2' in: $1"
+  pass_count=$((pass_count + 1))
+}
+
+run_preflight() {
+  : >"$CALL_LOG"
+  set +e
+  RUN_OUT="$(env PATH="$TEST_PATH" PODMAN_CALL_LOG="$CALL_LOG" "$@" \
+    "$BASH_BIN" "$PREFLIGHT" 2>&1)"
+  RUN_STATUS=$?
+  set -e
+  RUN_CALLS="$(cat "$CALL_LOG")"
+}
+
+# --- Docker stays the default and stays untouched ---------------------------
+#
+# The strongest form of "Docker behavior is unchanged": with Docker selected,
+# the stub Podman is never executed at all.
+
+run_preflight env -u HIVE_DEPLOY_RUNTIME
+assert_eq "0" "$RUN_STATUS" "default runtime exit"
+assert_contains "$RUN_OUT" "skipped" "default runtime skips"
+assert_contains "$RUN_OUT" "selects docker" "default runtime names docker"
+assert_eq "" "$RUN_CALLS" "default runtime runs no podman command"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=docker
+assert_eq "0" "$RUN_STATUS" "explicit docker exit"
+assert_contains "$RUN_OUT" "skipped" "explicit docker skips"
+assert_eq "" "$RUN_CALLS" "explicit docker runs no podman command"
+
+# An unusable selection fails before any check runs.
+run_preflight env HIVE_DEPLOY_RUNTIME=containerd
+assert_eq "64" "$RUN_STATUS" "invalid runtime exit"
+assert_eq "" "$RUN_CALLS" "invalid runtime runs no podman command"
+
+# --- A healthy Podman host ---------------------------------------------------
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_eq "0" "$RUN_STATUS" "healthy host exit"
+assert_contains "$RUN_OUT" "Podman 5.8.4" "healthy host reports the version"
+assert_contains "$RUN_OUT" "root mode: rootless" "healthy host reports root mode"
+assert_contains "$RUN_OUT" "cgroups: v2" "healthy host reports cgroups"
+assert_contains "$RUN_OUT" "SUMMARY: pass=4 warn=0 fail=0" "healthy host summary"
+
+# --- Engine presence and version --------------------------------------------
+
+# A PATH that really has no podman on it. The test host may well have a real
+# Podman installed, so this cannot be done by prepending a directory — the slim
+# PATH carries only the handful of tools the preflight shells out to.
+SLIM_BIN="${TEST_TMP}/slim"
+mkdir -p "$SLIM_BIN"
+for tool in dirname id awk head; do
+  ln -sf "$(command -v "$tool")" "${SLIM_BIN}/${tool}"
+done
+[[ -x "${SLIM_BIN}/podman" ]] && fail "slim PATH must not contain podman"
+
+set +e
+RUN_OUT="$(env PATH="$SLIM_BIN" HIVE_DEPLOY_RUNTIME=podman \
+  PODMAN_CALL_LOG="$CALL_LOG" "$BASH_BIN" "$PREFLIGHT" 2>&1)"
+RUN_STATUS=$?
+set -e
+assert_eq "78" "$RUN_STATUS" "missing engine exit"
+assert_contains "$RUN_OUT" "not installed or not on PATH" "missing engine message"
+assert_contains "$RUN_OUT" "skipped — no usable engine" "missing engine skips later checks"
+assert_not_contains "$RUN_OUT" "root mode:" "missing engine reports no root mode"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_VERSION=4.0.3
+assert_eq "78" "$RUN_STATUS" "old version exit"
+assert_contains "$RUN_OUT" "Hive needs 4.4 or newer" "old version message"
+assert_contains "$RUN_OUT" "Quadlet arrived in 4.4" "old version remediation"
+
+# Exactly at the floor: usable, but warned about the Podman 5 Quadlet shape.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_VERSION=4.4.0
+assert_eq "0" "$RUN_STATUS" "floor version exit"
+assert_contains "$RUN_OUT" "✓ Podman 4.4.0" "floor version passes"
+assert_contains "$RUN_OUT" "predates 5.0" "floor version warns about pod units"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_VERSION=5.0.0
+assert_eq "0" "$RUN_STATUS" "pod-capable version exit"
+assert_not_contains "$RUN_OUT" "predates 5.0" "pod-capable version does not warn"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_VERSION=__ERR__
+assert_eq "78" "$RUN_STATUS" "unusable engine exit"
+assert_contains "$RUN_OUT" "did not report a client version" "unusable engine message"
+
+# --- Connection identity ------------------------------------------------------
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_REMOTE=true
+assert_eq "0" "$RUN_STATUS" "remote connection exit"
+assert_contains "$RUN_OUT" "connection: REMOTE" "remote connection reported"
+assert_contains "$RUN_OUT" "not on this host" "remote connection caveat"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman \
+  FAKE_CONNECTIONS="prod ssh://hive@example.invalid/run/podman.sock true"
+assert_eq "0" "$RUN_STATUS" "named connection exit"
+assert_contains "$RUN_OUT" "prod -> ssh://hive@example.invalid/run/podman.sock" \
+  "named connection reports name and URI"
+
+# A non-default connection must not be reported as the active one.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman \
+  FAKE_CONNECTIONS="staging ssh://elsewhere.invalid/run/podman.sock false"
+assert_not_contains "$RUN_OUT" "staging" "non-default connection is not reported as active"
+
+# --- Root mode ----------------------------------------------------------------
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=false
+assert_eq "0" "$RUN_STATUS" "rootful exit"
+assert_contains "$RUN_OUT" "root mode: rootful" "rootful reported"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=__ERR__
+assert_eq "78" "$RUN_STATUS" "unreported root mode exit"
+assert_contains "$RUN_OUT" "did not report it" "unreported root mode message"
+
+# --- cgroups ------------------------------------------------------------------
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_CGROUPS=v1
+assert_eq "78" "$RUN_STATUS" "cgroup v1 exit"
+assert_contains "$RUN_OUT" "requires cgroup v2" "cgroup v1 message"
+assert_contains "$RUN_OUT" "systemd.unified_cgroup_hierarchy=1" "cgroup v1 remediation is actionable"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_CGROUP_MANAGER=cgroupfs
+assert_contains "$RUN_OUT" "manager: cgroupfs" "cgroup manager reported"
+
+# --- Failures accumulate rather than short-circuiting -------------------------
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_CGROUPS=v1 FAKE_ROOTLESS=__ERR__
+assert_eq "78" "$RUN_STATUS" "multiple failures exit"
+assert_contains "$RUN_OUT" "fail=2" "both failures counted"
+
+printf 'PASS: %d Podman preflight assertions\n' "$pass_count"


### PR DESCRIPTION
## What

`bin/hive-podman-preflight.sh` — read-only diagnostics that run **before** Hive invokes a Podman lifecycle implementation. Without them, the first sign of an unusable host is a half-created deployment failing somewhere inside `podman run`.

It answers four questions and deliberately nothing else:

| Check | Behavior |
| --- | --- |
| **Engine and version** | Fails below **4.4**, where Quadlet first appeared and below which none of the lifecycle options under evaluation exist. Warns between 4.4 and 5.0, where the engine works but `.pod` units, `Pod=`, and `Notify=healthy` do not — the shape recorded in the #4202 spike. Both floors overridable. |
| **Connection identity** | Reports the active connection by name and URI; warns when the service is **REMOTE**, because storage, SELinux, and port checks then apply to the far side, not this host. A non-default connection is never reported as active. |
| **Root mode** | Rootless vs rootful, reported explicitly rather than inferred — the supported matrix in #4188 turns on it. |
| **cgroup version** | v2 required (Quadlet needs it; rootless resource control is unavailable on v1), with a bootable remediation rather than a vague complaint. |

Storage, SELinux, networking, secrets, and ports stay with #4208/#4209. Nothing here writes to the host, starts a container, or contacts a registry.

## Docker is untouched, and that is tested rather than asserted

The checks run only when `HIVE_DEPLOY_RUNTIME` explicitly selects `podman`, reusing the merged runtime selector rather than re-deciding. With Docker selected the script prints one skip line and runs **no Podman command at all** — the tests assert this the strong way, by failing if the stub engine is executed even once:

```
run_preflight env -u HIVE_DEPLOY_RUNTIME
assert_eq "" "$RUN_CALLS" "default runtime runs no podman command"
```

`hive-prereq-check.sh` gains one delegating block before its summary. Every existing Docker check is untouched; the preflight's counts fold into the existing pass/warn/fail totals, and its exit 78 doesn't abort the script under `set -e`. I verified the folding in isolation (5/2/0 + 1/1/1 → 6/3/1, `SUMMARY:` line suppressed from operator output) rather than by running the full prereq check, which would have pulled an image onto the machine.

## Tests use controlled output, not a Podman host

`bin/test_hive_podman_preflight.sh` — 44 assertions against a stub engine whose answers come from the environment, so the whole matrix runs on a host with **no Podman installed**: old versions, the 4.4 floor and its warning, 5.0 clearing it, rootful, cgroup v1, cgroup manager reporting, a remote connection, a non-default connection, an engine that answers nothing, and no engine at all. Failures accumulate rather than short-circuiting (`fail=2` asserted).

One wrinkle worth noting: the missing-engine case can't be done by prepending an empty directory, because the test host may have a real Podman on `PATH`. It builds a slim `PATH` carrying only the four tools the preflight shells out to, and asserts podman isn't on it.

Mutation-checked — dropping the Docker gate and accepting cgroup v1 each fail the suite.

## Acceptance criteria

- [x] **Docker checks and default behavior remain intact** — no Docker check touched; the added block only delegates, and the delegate self-gates.
- [x] **Checks run only for explicitly selected Podman** — enforced via the runtime selector and asserted by "no podman command was executed".
- [x] **Output reports the exact selected engine/connection and root mode** — resolved binary path and version, connection name → URI (or an explicit REMOTE/local statement), and rootless/rootful with the uid.
- [x] **Unsupported or missing prerequisites produce actionable failures** — install/downgrade guidance, `systemd.unified_cgroup_hierarchy=1` for cgroup v1, and "run `podman info` directly" when the engine answers nothing. When the engine is unusable the three dependent checks are skipped with a reason instead of repeating the same missing binary four times.
- [x] **Tests use controlled command output** — stub engine throughout.

## Note on file ownership

This creates `bin/hive-podman-preflight.sh` as the base of the preflight path. #4208 and #4209 add their checks as further functions in the same file — whichever lands first establishes it, and the others rebase. Nothing here forecloses their sections.

## Testing

```
$ bash bin/test_hive_podman_preflight.sh
PASS: 44 Podman preflight assertions

$ bash bin/test_hive_standalone_runtime.sh    # unchanged
PASS: 20 standalone runtime selector assertions
$ bash bin/test_hive_podman_cleanup.sh        # unchanged
PASS: 127 Podman ownership and cleanup contract assertions

$ shellcheck bin/hive-podman-preflight.sh bin/test_hive_podman_preflight.sh
(clean)
```

`shellcheck bin/hive-prereq-check.sh` reports the same 2 pre-existing findings before and after this change. Live sanity check on a real rootless Podman 5.8.4 host: `✓ Podman 5.8.4`, `✓ connection: local`, `✓ root mode: rootless (uid 1000)`, `✓ cgroups: v2 (manager: systemd)`.

Part of #4188
Fixes #4207

— hive: backend=claude model=claude-opus-5