### PR TITLE
🩺 podman: add SELinux, mount, secret, and port preflight checks

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -155,6 +155,17 @@ jobs:
         working-directory: .
         run: bash bin/test_hive_podman_cleanup.sh
 
+      # #4209: SELinux labeling, configuration/secrets readability, and host
+      # port conflicts are the operator-facing Podman failures that surface
+      # only after `podman run` has started making changes. Every input is
+      # mocked, so the enforcing/permissive/disabled matrix runs on a runner
+      # with no SELinux and no Podman. The suite also asserts the remediation
+      # never proposes disabling SELinux or widening a secret, and that the
+      # deployment fixture is byte-identical after every run.
+      - name: Podman SELinux, mount, secret, and port preflight (#4209)
+        working-directory: .
+        run: bash bin/test_hive_podman_preflight_host.sh
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'

--- a/bin/README.md
+++ b/bin/README.md
@@ -58,6 +58,7 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `hive-standalone-runtime.sh` | Deploy | Selects the standalone container engine from `HIVE_DEPLOY_RUNTIME` (`docker` by default) and runs commands against it without ever falling back to the other engine. |
 | `hive-podman-cleanup.sh` | Deploy | Defines the Hive ownership labels for Podman containers, pods, networks, volumes, and images, and guards cleanup so it can never widen into a store-wide Podman/Buildah operation. See [`src/docs/podman-ownership-cleanup.md`](../src/docs/podman-ownership-cleanup.md). |
 | `hive-podman-preflight.sh` | Bootstrap | Read-only Podman diagnostics before a lifecycle runs: engine/version, the connection it is actually talking to, rootless vs rootful, and cgroup version. Runs only when `HIVE_DEPLOY_RUNTIME` selects podman; `hive-prereq-check.sh` invokes it. |
+| `hive-podman-preflight-host.sh` | Deploy | Read-only Podman preflight for SELinux state and mount labeling, configuration/secrets readability, and published host-port availability. Runs only when `HIVE_DEPLOY_RUNTIME=podman`. See [`src/docs/podman-preflight-host.md`](../src/docs/podman-preflight-host.md). |
 | `federation-heartbeat.sh` | Federation | Sends live contributor and actionable-work stats to the Hive federation registry. |
 | `notify.sh` | Notifications | Shared Bash notification library for ntfy, Slack incoming webhooks, and Discord webhooks. |
 
@@ -90,3 +91,4 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `test_hive_standalone_runtime.sh` | `hive-standalone-runtime.sh` engine selection: Docker default, explicit Podman, and no silent fallback. |
 | `test_hive_podman_cleanup.sh` | `hive-podman-cleanup.sh` ownership labels and cleanup guard. Analyses arguments only: it contacts no container engine and deletes nothing. |
 | `test_hive_podman_preflight.sh` | `hive-podman-preflight.sh` engine, connection, root-mode, and cgroup checks. Drives a stub engine, so the whole matrix runs on a host with no Podman installed. |
+| `test_hive_podman_preflight_host.sh` | `hive-podman-preflight-host.sh` across enforcing, permissive, and disabled SELinux, wrong and missing mount labels, unreadable and over-permissive secrets, and occupied and sub-floor ports. Every input is mocked; it runs no container and changes nothing on the host. |

--- a/bin/hive-podman-preflight-host.sh
+++ b/bin/hive-podman-preflight-host.sh
@@ -1,0 +1,542 @@
+#!/usr/bin/env bash
+# Podman preflight: SELinux, mounts, secrets, and ports (#4209).
+#
+# Three of the most common ways a standalone Podman deployment fails on a
+# Fedora/RHEL-class host have nothing to do with the engine itself, and all
+# three surface as an unhelpful error long after `podman run` has already
+# started making changes:
+#
+#   1. SELinux is enforcing and the bind-mount sources carry a host label the
+#      container type cannot read, so the process inside sees EACCES on a file
+#      that is plainly mode 0644 on the host.
+#   2. The configuration file or the secrets directory is absent, unreadable by
+#      the user the engine actually runs as, or readable by everyone on the box.
+#   3. Something already holds the port the gateway is about to publish, or the
+#      port is below the rootless unprivileged-port floor.
+#
+# This layer diagnoses exactly those and stops. It is read-only: it starts no
+# container, relabels nothing, changes no mode or owner, writes nothing to the
+# host, and contacts no registry.
+#
+# Deliberate non-goals, so the remediation advice stays honest:
+#
+#   * Disabling SELinux is never offered as the fix. Every remediation here is
+#     a labeling or policy action that leaves the kernel enforcing.
+#   * Secret permissions are never broadened, and never changed at all. Modes
+#     that are too open are reported with the command to NARROW them; the
+#     operator runs it.
+#   * Host firewall rules, port reservations, and running processes are left
+#     exactly as they are.
+#
+# The engine, connection, root mode, and cgroup layer is #4207; subordinate
+# IDs, graphroot, and networking are #4208.
+#
+# Operator guide, including every remediation this prints:
+# src/docs/podman-preflight-host.md
+#
+# These checks run ONLY when Podman is explicitly selected through
+# HIVE_DEPLOY_RUNTIME. Docker is the default and is untouched: with Docker
+# selected this reports that Podman is not in use and exits 0 without running
+# a single Podman command.
+#
+# Run: bin/hive-podman-preflight-host.sh
+# Exit codes: 0 no failing check, 64 unusable runtime selection,
+#             78 at least one failing check (EX_CONFIG).
+
+# Where the standalone deployment assets live. The bind-mount sources in
+# src/docker-compose.yaml are relative to this directory.
+HIVE_SRC_DIR="${HIVE_SRC_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../src" 2>/dev/null && pwd)}"
+HIVE_SRC_DIR="${HIVE_SRC_DIR:-$(dirname "${BASH_SOURCE[0]}")/../src}"
+
+# Host ports the deployment publishes. 3001 is the authenticated gateway and is
+# always checked; the raw ttyd port is deliberately NOT published and so is
+# deliberately NOT listed here. Space- or comma-separated.
+HIVE_PODMAN_PREFLIGHT_PORTS="${HIVE_PODMAN_PREFLIGHT_PORTS:-3001}"
+
+HIVE_PREFLIGHT_PASS=0
+HIVE_PREFLIGHT_WARN=0
+HIVE_PREFLIGHT_FAIL=0
+
+# Markers match bin/hive-prereq-check.sh so the two read as one report when
+# this is invoked from there.
+_pfh_pass() { echo "  ✓ $1"; HIVE_PREFLIGHT_PASS=$((HIVE_PREFLIGHT_PASS + 1)); }
+_pfh_warn() { echo "  △ $1"; HIVE_PREFLIGHT_WARN=$((HIVE_PREFLIGHT_WARN + 1)); }
+_pfh_fail() { echo "  ✗ $1"; HIVE_PREFLIGHT_FAIL=$((HIVE_PREFLIGHT_FAIL + 1)); }
+_pfh_hint() { echo "    → $1"; }
+
+# One `podman info` field. A template an older Podman does not know must
+# degrade to a caller-visible failure rather than abort the preflight.
+_pfh_info() {
+  local template="$1" value
+  value="$(podman info --format "$template" 2>/dev/null)" || return 1
+  [[ -n "$value" && "$value" != "<no value>" ]] || return 1
+  printf '%s\n' "$value"
+}
+
+# true when the engine is rootless, false when rootful, empty when unknown.
+# Several checks below mean different things in each mode, so an unknown mode
+# downgrades them to a report rather than a verdict. Asked once: the answer
+# cannot change mid-run and several checks want it.
+_PFH_ROOTLESS_CACHE=""
+_pfh_rootless() {
+  local rootless
+
+  if [[ -n "$_PFH_ROOTLESS_CACHE" ]]; then
+    [[ "$_PFH_ROOTLESS_CACHE" == "unknown" ]] || printf '%s\n' "$_PFH_ROOTLESS_CACHE"
+    return 0
+  fi
+
+  _PFH_ROOTLESS_CACHE="unknown"
+  rootless="$(_pfh_info '{{.Host.Security.Rootless}}')" || return 0
+  case "$rootless" in
+    true|false)
+      _PFH_ROOTLESS_CACHE="$rootless"
+      printf '%s\n' "$rootless"
+      ;;
+  esac
+}
+
+# --- 1. SELinux state --------------------------------------------------------
+#
+# Two independent facts matter and they can disagree. The kernel's mode says
+# whether a denial stops the process; Podman's own view says whether it will
+# apply container labels and honour :z/:Z at all. Enforcing-kernel with
+# labeling-off is the genuinely broken combination, and it is invisible from
+# either fact alone.
+
+# Enforcing | Permissive | Disabled | unknown
+_pfh_selinux_mode() {
+  local mode
+
+  if command -v getenforce >/dev/null 2>&1 && mode="$(getenforce 2>/dev/null)" && [[ -n "$mode" ]]; then
+    printf '%s\n' "$mode"
+    return 0
+  fi
+
+  # No policy utilities installed: read the filesystem the utilities read.
+  # Deliberately a bash builtin rather than `cat` — a preflight that cannot
+  # report the SELinux mode because coreutils is missing from a trimmed PATH
+  # is worse than no preflight at all.
+  local raw=""
+  if [[ -r /sys/fs/selinux/enforce ]]; then
+    # The node holds a single byte with no trailing newline, so `read` reports
+    # EOF-without-delimiter and still assigns. Judge the value, not the status.
+    read -r raw </sys/fs/selinux/enforce 2>/dev/null || true
+    case "$raw" in
+      1) printf 'Enforcing\n'; return 0 ;;
+      0) printf 'Permissive\n'; return 0 ;;
+    esac
+  fi
+
+  # An absent selinuxfs mount is how a kernel without SELinux looks, which is
+  # the normal state on Debian/Ubuntu hosts and is not a problem.
+  if [[ ! -d /sys/fs/selinux ]]; then
+    printf 'Disabled\n'
+    return 0
+  fi
+
+  printf 'unknown\n'
+}
+
+hive_podman_check_selinux() {
+  local mode podman_selinux
+  mode="$(_pfh_selinux_mode)"
+  podman_selinux="$(_pfh_info '{{.Host.Security.SELinuxEnabled}}')" || podman_selinux="unknown"
+
+  case "$mode" in
+    Enforcing)
+      if [[ "$podman_selinux" == "true" ]]; then
+        _pfh_pass "SELinux: Enforcing, Podman labeling enabled"
+      elif [[ "$podman_selinux" == "false" ]]; then
+        # The kernel denies on label mismatch and Podman will not set a label
+        # the container type can read, so every bind mount is a denial and no
+        # :z/:Z in any lifecycle asset will fix it.
+        _pfh_fail "SELinux: Enforcing, but Podman reports labeling DISABLED"
+        _pfh_hint "Bind mounts will be denied and :z/:Z will do nothing. Do not turn SELinux off to work around this."
+        _pfh_hint "Install the container policy (dnf install container-selinux) and check for label=false in containers.conf."
+        return 1
+      else
+        _pfh_warn "SELinux: Enforcing, but Podman did not report its labeling state"
+        _pfh_hint "Run 'podman info --format {{.Host.Security.SELinuxEnabled}}' to confirm labeling is on."
+      fi
+      ;;
+    Permissive)
+      # Everything appears to work here and then fails on the first host that
+      # enforces, which is usually production.
+      _pfh_warn "SELinux: Permissive — denials are logged, not enforced"
+      _pfh_hint "Label problems will not surface here but will on an enforcing host. Qualify the deployment with 'setenforce 1'."
+      _pfh_hint "Check for accumulated denials: ausearch -m AVC -ts recent"
+      ;;
+    Disabled)
+      _pfh_pass "SELinux: not enabled on this host — mount labeling does not apply"
+      ;;
+    *)
+      _pfh_warn "SELinux: state could not be determined"
+      _pfh_hint "Run 'getenforce', or read /sys/fs/selinux/enforce, to establish the mode before deploying."
+      ;;
+  esac
+
+  return 0
+}
+
+# --- 2. Mount labeling -------------------------------------------------------
+#
+# The three bind-mount sources in src/docker-compose.yaml. Each is consumed by
+# exactly one container, so the private (:Z) form is always available; the
+# read-only configuration files are called out as shared (:z) candidates
+# because :Z stamps a per-container MCS category onto a file that is part of
+# the operator's checkout and is likely read by other tooling.
+#
+# Format: relative-path|description|recommended-option
+HIVE_PODMAN_BIND_SOURCES=(
+  "hive.yaml|Hive configuration|z"
+  "deploy/nginx.conf|gateway configuration|z"
+  "secrets|secrets directory|Z"
+)
+
+# Labels a container process can read without a relabel. container_file_t is
+# what :Z/:z and the container_file_t fcontext produce; container_share_t is
+# the read-only shared variant.
+_pfh_label_is_container_readable() {
+  case "$1" in
+    *:container_file_t:*|*:container_share_t:*|*:container_ro_file_t:*) return 0 ;;
+  esac
+  return 1
+}
+
+# Escapes a path for the POSIX extended regular expression semanage expects.
+# Without it the dot in "hive.yaml" matches any character and the fcontext rule
+# is wider than the operator wrote.
+_pfh_regex_escape() {
+  local out="$1"
+  out="${out//\\/\\\\}"
+  local meta
+  for meta in '.' '[' ']' '^' '$' '*' '+' '?' '(' ')' '{' '}' '|'; do
+    out="${out//"$meta"/\\$meta}"
+  done
+  printf '%s\n' "$out"
+}
+
+hive_podman_check_mount_labels() {
+  local selinux_mode entry rel desc opt path label stat_out
+  local unlabeled=0 checked=0
+
+  selinux_mode="$(_pfh_selinux_mode)"
+
+  if [[ "$selinux_mode" == "Disabled" ]]; then
+    _pfh_pass "Mount labeling: not applicable — SELinux is not enabled"
+    return 0
+  fi
+
+  for entry in "${HIVE_PODMAN_BIND_SOURCES[@]}"; do
+    IFS='|' read -r rel desc opt <<<"$entry"
+    path="${HIVE_SRC_DIR}/${rel}"
+
+    # Existence and readability are the config/secrets check's job; a path that
+    # is not there yet has no label to judge.
+    [[ -e "$path" ]] || continue
+
+    checked=$((checked + 1))
+    stat_out="$(stat -c '%C' "$path" 2>/dev/null)" || stat_out=""
+    label="$stat_out"
+
+    if [[ -z "$label" || "$label" == "?" ]]; then
+      _pfh_warn "Mount label: ${rel} (${desc}) carries no SELinux label"
+      _pfh_hint "The filesystem holding it may not support security xattrs. Move the deployment onto one that does."
+      continue
+    fi
+
+    if _pfh_label_is_container_readable "$label"; then
+      _pfh_pass "Mount label: ${rel} is ${label} — already container-readable"
+      continue
+    fi
+
+    unlabeled=$((unlabeled + 1))
+    _pfh_warn "Mount label: ${rel} (${desc}) is ${label} — a container cannot read it as-is"
+    if [[ "$opt" == "Z" ]]; then
+      _pfh_hint "Mount it with :Z so Podman relabels it private to the one container that uses it."
+    else
+      _pfh_hint "Mount it with :z so Podman relabels it shared; :Z would stamp a private category onto a checked-out file."
+    fi
+    _pfh_hint "To label it once, up front, instead of on every run:"
+    if [[ -d "$path" ]]; then
+      _pfh_hint "  semanage fcontext -a -t container_file_t '$(_pfh_regex_escape "$path")(/.*)?' && restorecon -R '${path}'"
+    else
+      _pfh_hint "  semanage fcontext -a -t container_file_t '$(_pfh_regex_escape "$path")' && restorecon '${path}'"
+    fi
+  done
+
+  if [[ "$checked" -eq 0 ]]; then
+    _pfh_warn "Mount labeling: no bind-mount source found under ${HIVE_SRC_DIR}"
+    _pfh_hint "Set HIVE_SRC_DIR to the directory holding hive.yaml, deploy/, and secrets/."
+    return 0
+  fi
+
+  if [[ "$unlabeled" -gt 0 ]]; then
+    _pfh_hint "None of this requires weakening SELinux; the kernel stays enforcing either way."
+  fi
+
+  return 0
+}
+
+# --- 3. Configuration and secrets readability --------------------------------
+#
+# Readable by the process that needs it, and by nobody else. Both halves are
+# reported; neither is repaired here. Broadening a secret's permissions to make
+# a check pass would defeat the point of running the check.
+
+# Reports on one path. Usage: _pfh_check_readable <path> <label> <max-mode> <required>
+#   max-mode: octal permission bits that must not be exceeded, empty to skip
+#   required: "required" to fail when absent, anything else to warn
+_pfh_check_readable() {
+  local path="$1" desc="$2" max_mode="$3" required="$4"
+  local mode owner_uid owner_name stat_out rootless
+
+  if [[ ! -e "$path" ]]; then
+    if [[ "$required" == "required" ]]; then
+      _pfh_fail "${desc}: ${path} does not exist"
+      return 1
+    fi
+    _pfh_warn "${desc}: ${path} does not exist"
+    return 0
+  fi
+
+  if ! stat_out="$(stat -c '%a %u %U' "$path" 2>/dev/null)"; then
+    _pfh_warn "${desc}: ${path} could not be inspected"
+    return 0
+  fi
+  read -r mode owner_uid owner_name <<<"$stat_out"
+
+  if [[ ! -r "$path" ]]; then
+    _pfh_fail "${desc}: ${path} is not readable by $(id -un) (mode ${mode}, owner ${owner_name})"
+    _pfh_hint "Rootless Podman opens bind mounts as the invoking user, so an unreadable source is an unreadable mount."
+    _pfh_hint "Give that user access deliberately — do not widen the mode to make this pass."
+    return 1
+  fi
+
+  # In rootless mode the invoking user maps to root inside the user namespace
+  # and every other host owner maps to nobody, so an accessible-by-luck file
+  # owned by someone else is a latent failure even when it reads fine today.
+  rootless="$(_pfh_rootless)"
+  if [[ "$rootless" == "true" && "$owner_uid" != "$(id -u)" ]]; then
+    _pfh_warn "${desc}: ${path} is owned by ${owner_name}, not $(id -un)"
+    _pfh_hint "Under rootless Podman it appears inside the container as 'nobody'; only the invoking user maps to container root."
+  fi
+
+  # Too-open modes are reported, never corrected, and the suggestion only ever
+  # narrows. 0640 and 0600 both satisfy a 0640 maximum.
+  if [[ -n "$max_mode" ]] && (( 8#$mode & ~8#$max_mode )); then
+    _pfh_warn "${desc}: ${path} is mode ${mode} — wider than ${max_mode}"
+    _pfh_hint "Narrow it when you are ready: chmod ${max_mode} '${path}'"
+    _pfh_hint "Preflight does not change it; loosening host permissions is never the remedy."
+    return 0
+  fi
+
+  _pfh_pass "${desc}: ${path} readable (mode ${mode}, owner ${owner_name})"
+  return 0
+}
+
+hive_podman_check_config_secrets() {
+  local secrets_dir="${HIVE_SRC_DIR}/secrets" key
+  local rc=0
+
+  _pfh_check_readable "${HIVE_SRC_DIR}/hive.yaml" "Hive config" "" "required" || rc=1
+  _pfh_check_readable "${HIVE_SRC_DIR}/deploy/nginx.conf" "Gateway config" "" "required" || rc=1
+
+  if [[ ! -d "$secrets_dir" ]]; then
+    # Token-only deployments never create it; a GitHub App deployment must.
+    _pfh_warn "Secrets: ${secrets_dir} does not exist"
+    _pfh_hint "Only needed for GitHub App key auth. Create it narrow: mkdir -m 700 -p '${secrets_dir}'"
+    return "$rc"
+  fi
+
+  # 0700: the directory is bind-mounted read-only, but the host copy is the
+  # thing an unrelated local account would read.
+  _pfh_check_readable "$secrets_dir" "Secrets dir" "700" "required" || rc=1
+
+  local had_nullglob=0
+  shopt -q nullglob && had_nullglob=1
+  shopt -s nullglob
+  for key in "$secrets_dir"/*; do
+    [[ -f "$key" ]] || continue
+    _pfh_check_readable "$key" "Secret" "600" "required" || rc=1
+  done
+  (( had_nullglob )) || shopt -u nullglob
+
+  return "$rc"
+}
+
+# --- 4. Host port availability -----------------------------------------------
+
+# Prints the listening sockets bound to $1, one per line, or returns 1 when no
+# tool on this host can enumerate them.
+_pfh_listeners() {
+  local port="$1"
+
+  if command -v ss >/dev/null 2>&1; then
+    ss -Hltn 2>/dev/null | awk -v p=":${port}" '$4 ~ (p "$") { print }'
+    return 0
+  fi
+
+  if command -v netstat >/dev/null 2>&1; then
+    netstat -ltn 2>/dev/null | awk -v p=":${port}" '$4 ~ (p "$") { print }'
+    return 0
+  fi
+
+  return 1
+}
+
+# The lowest port an unprivileged process may bind. Only meaningful rootless:
+# rootful Podman binds anything. Empty when the value cannot be read, which
+# turns the floor check off rather than guessing at it.
+_pfh_unprivileged_port_start() {
+  local floor=""
+
+  if command -v sysctl >/dev/null 2>&1; then
+    floor="$(sysctl -n net.ipv4.ip_unprivileged_port_start 2>/dev/null)"
+  fi
+
+  if [[ ! "$floor" =~ ^[0-9]+$ ]]; then
+    # As above: assignment can succeed while the status reports EOF.
+    read -r floor </proc/sys/net/ipv4/ip_unprivileged_port_start 2>/dev/null || true
+  fi
+
+  [[ "$floor" =~ ^[0-9]+$ ]] || return 0
+  printf '%s\n' "$floor"
+}
+
+hive_podman_check_ports() {
+  local rootless floor ports port listeners
+  local rc=0
+
+  # Accept either separator so the variable can be written the way it reads.
+  read -r -a ports <<<"${HIVE_PODMAN_PREFLIGHT_PORTS//,/ }"
+
+  if [[ "${#ports[@]}" -eq 0 ]]; then
+    _pfh_warn "Ports: HIVE_PODMAN_PREFLIGHT_PORTS is empty — nothing checked"
+    return 0
+  fi
+
+  rootless="$(_pfh_rootless)"
+  floor=""
+  if [[ "$rootless" == "true" ]]; then
+    floor="$(_pfh_unprivileged_port_start)"
+  fi
+
+  for port in "${ports[@]}"; do
+    if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+      _pfh_fail "Ports: ${port} is not a valid TCP port"
+      rc=1
+      continue
+    fi
+
+    if [[ -n "$floor" ]] && (( port < floor )); then
+      # Rootless cannot bind below the floor at all; the container never starts
+      # and the message from the engine does not mention the sysctl.
+      _pfh_fail "Port ${port}: below the rootless unprivileged floor (${floor}) — rootless Podman cannot publish it"
+      _pfh_hint "Raise the host's allowance: sysctl -w net.ipv4.ip_unprivileged_port_start=${port}"
+      _pfh_hint "Or publish a port at or above ${floor} and put the privileged listener in front of it."
+      rc=1
+      continue
+    fi
+
+    if ! listeners="$(_pfh_listeners "$port")"; then
+      _pfh_warn "Port ${port}: neither ss nor netstat is installed — availability unverified"
+      _pfh_hint "Install iproute2 so preflight can see conflicts before startup."
+      continue
+    fi
+
+    if [[ -n "$listeners" ]]; then
+      _pfh_fail "Port ${port}: already in use on this host"
+      printf '%s\n' "$listeners" | while IFS= read -r line; do
+        [[ -n "$line" ]] && _pfh_hint "held by: ${line}"
+      done
+      _pfh_hint "Stop whatever holds it, or publish Hive's gateway on a different host port. Preflight changes nothing."
+      rc=1
+      continue
+    fi
+
+    _pfh_pass "Port ${port}: free"
+  done
+
+  return "$rc"
+}
+
+# --- Runner ------------------------------------------------------------------
+
+hive_podman_preflight_host_selected_runtime() {
+  local selector="${HIVE_PODMAN_PREFLIGHT_SELECTOR:-$(dirname "${BASH_SOURCE[0]}")/hive-standalone-runtime.sh}"
+
+  if [[ -r "$selector" ]]; then
+    # shellcheck source=bin/hive-standalone-runtime.sh disable=SC1090,SC1091
+    source "$selector"
+    hive_deploy_runtime_select
+    return
+  fi
+
+  printf '%s\n' "${HIVE_DEPLOY_RUNTIME:-docker}"
+}
+
+hive_podman_preflight_host_main() {
+  local runtime
+
+  if ! runtime="$(hive_podman_preflight_host_selected_runtime)"; then
+    return 64
+  fi
+
+  # The whole point of this gate: with Docker selected, not one Podman command
+  # runs and Docker's own prerequisite checks are left exactly as they were.
+  if [[ "$runtime" != "podman" ]]; then
+    echo "Podman preflight: skipped — HIVE_DEPLOY_RUNTIME selects ${runtime}"
+    return 0
+  fi
+
+  echo "Podman preflight (SELinux, mounts, secrets, ports)"
+
+  # Each check reports independently: an operator fixing a host wants the whole
+  # list, not the first item on it.
+  hive_podman_check_selinux
+  hive_podman_check_mount_labels
+  hive_podman_check_config_secrets
+  hive_podman_check_ports
+
+  printf 'SUMMARY: pass=%d warn=%d fail=%d\n' \
+    "$HIVE_PREFLIGHT_PASS" "$HIVE_PREFLIGHT_WARN" "$HIVE_PREFLIGHT_FAIL"
+
+  [[ "$HIVE_PREFLIGHT_FAIL" -eq 0 ]] || return 78
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -uo pipefail
+  case "${1:-check}" in
+    check) hive_podman_preflight_host_main ;;
+    -h|--help|help)
+      cat <<'EOF'
+Usage: hive-podman-preflight-host.sh [check]
+
+Reports the SELinux mode and Podman's labeling state, the SELinux labels on
+every bind-mount source, whether the Hive configuration and secrets are
+readable by the right user and nobody else, and whether the published host
+ports are free.
+
+Read-only. It starts no container, relabels nothing, changes no permission or
+owner, and contacts no registry. It never proposes disabling SELinux and never
+proposes widening access to a secret.
+
+Runs only when HIVE_DEPLOY_RUNTIME selects podman; with the Docker default it
+reports that it was skipped and exits 0.
+
+Environment:
+  HIVE_SRC_DIR                    directory holding hive.yaml, deploy/, secrets/
+  HIVE_PODMAN_PREFLIGHT_PORTS     published host ports to check (default 3001)
+
+Exit codes: 0 clean, 64 unusable runtime selection, 78 at least one failure.
+EOF
+      ;;
+    *)
+      printf 'ERROR: unknown action %q\n' "$1" >&2
+      exit 64
+      ;;
+  esac
+fi

--- a/bin/test_hive_podman_preflight_host.sh
+++ b/bin/test_hive_podman_preflight_host.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+# Contract tests for bin/hive-podman-preflight-host.sh (#4209).
+# Run: bash bin/test_hive_podman_preflight_host.sh
+#
+# Every input is mocked. A stub `podman`, `getenforce`, `sysctl`, and `ss`
+# answer from the environment, and a stub `stat` answers from a lookup table
+# for the paths a case wants to control and delegates to the real one for
+# everything else. The whole matrix — enforcing, permissive, disabled,
+# labeling off, wrong labels, unreadable and over-permissive secrets, occupied
+# and sub-floor ports — therefore runs on a host with no SELinux, no Podman,
+# and no privileges, and never executes a container command.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFLIGHT="${ROOT}/bin/hive-podman-preflight-host.sh"
+BASH_BIN="$(command -v bash)"
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+FAKE_BIN="${TEST_TMP}/bin"
+CALL_LOG="${TEST_TMP}/podman-calls.log"
+STAT_MAP="${TEST_TMP}/stat-map"
+mkdir -p "$FAKE_BIN"
+: >"$STAT_MAP"
+
+REAL_STAT="$(command -v stat)"
+
+cat >"${FAKE_BIN}/podman" <<'EOF'
+#!/bin/sh
+printf 'podman %s\n' "$*" >>"$PODMAN_CALL_LOG"
+case "$*" in
+  "info --format {{.Host.Security.SELinuxEnabled}}")
+    [ "${FAKE_SELINUX_ENABLED:-}" = "__ERR__" ] && exit 125
+    printf '%s\n' "${FAKE_SELINUX_ENABLED:-true}"
+    ;;
+  "info --format {{.Host.Security.Rootless}}")
+    [ "${FAKE_ROOTLESS:-}" = "__ERR__" ] && exit 125
+    printf '%s\n' "${FAKE_ROOTLESS:-true}"
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+
+cat >"${FAKE_BIN}/getenforce" <<'EOF'
+#!/bin/sh
+[ "${FAKE_ENFORCE:-}" = "__ERR__" ] && exit 1
+printf '%s\n' "${FAKE_ENFORCE:-Enforcing}"
+EOF
+
+cat >"${FAKE_BIN}/sysctl" <<'EOF'
+#!/bin/sh
+# Only the unprivileged-port floor is consulted. -n <key>
+[ "${FAKE_PORT_FLOOR:-}" = "__ERR__" ] && exit 1
+printf '%s\n' "${FAKE_PORT_FLOOR:-1024}"
+EOF
+
+cat >"${FAKE_BIN}/ss" <<'EOF'
+#!/bin/sh
+# `ss -Hltn`. FAKE_LISTENERS holds whole listener lines; the script filters
+# them by the local-address column exactly as it would filter real output.
+printf '%s' "${FAKE_LISTENERS:-}"
+[ -n "${FAKE_LISTENERS:-}" ] && printf '\n'
+exit 0
+EOF
+
+# Answers `stat -c FMT PATH` field by field. STAT_MAP lines are
+# <path>|<mode>|<uid>|<user>|<label>, and any field left empty falls through to
+# the real stat — so a case can fake an SELinux label on a host that has none
+# without also freezing the permissions the case is actually manipulating.
+# Absolute interpreter: the stub has to survive the trimmed-PATH cases below,
+# where neither `env` nor `bash` is reachable by name.
+cat >"${FAKE_BIN}/stat" <<EOF
+#!${BASH_BIN}
+fmt=""
+path=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -c) fmt="\$2"; shift 2 ;;
+    -c*) fmt="\${1#-c}"; shift ;;
+    *) path="\$1"; shift ;;
+  esac
+done
+
+line="\$(grep -F -- "\${path}|" "\$FAKE_STAT_MAP" 2>/dev/null | head -1)"
+IFS='|' read -r _p mode uid user label <<<"\$line"
+
+real() { "${REAL_STAT}" -c "\$1" "\$path" 2>/dev/null; }
+[ -n "\$mode" ]  || mode="\$(real %a)"
+[ -n "\$uid" ]   || uid="\$(real %u)"
+[ -n "\$user" ]  || user="\$(real %U)"
+[ -n "\$label" ] || label="\$(real %C)"
+
+out="\$fmt"
+out="\${out//%a/\$mode}"
+out="\${out//%u/\$uid}"
+out="\${out//%U/\$user}"
+out="\${out//%C/\$label}"
+printf '%s\n' "\$out"
+EOF
+
+chmod +x "${FAKE_BIN}"/*
+TEST_PATH="${FAKE_BIN}:/usr/bin:/bin"
+
+# --- Deployment fixture -------------------------------------------------------
+#
+# A stand-in for src/: the three bind-mount sources src/docker-compose.yaml
+# declares, at permissions a correctly prepared host would have.
+
+SRC_FIXTURE="${TEST_TMP}/src"
+mkdir -p "${SRC_FIXTURE}/deploy" "${SRC_FIXTURE}/secrets"
+echo "levels: []" >"${SRC_FIXTURE}/hive.yaml"
+echo "events {}" >"${SRC_FIXTURE}/deploy/nginx.conf"
+echo "-----BEGIN PRIVATE KEY-----" >"${SRC_FIXTURE}/secrets/gh-app-key.pem"
+chmod 700 "${SRC_FIXTURE}/secrets"
+chmod 600 "${SRC_FIXTURE}/secrets/gh-app-key.pem"
+
+# Default map: every bind source already carries a container-readable label, so
+# a case that says nothing about labels gets a clean labeling report.
+label_all_container_readable() {
+  cat >"$STAT_MAP" <<EOF
+${SRC_FIXTURE}/hive.yaml||||system_u:object_r:container_file_t:s0
+${SRC_FIXTURE}/deploy/nginx.conf||||system_u:object_r:container_file_t:s0
+${SRC_FIXTURE}/secrets||||system_u:object_r:container_file_t:s0
+${SRC_FIXTURE}/secrets/gh-app-key.pem||||system_u:object_r:container_file_t:s0
+EOF
+}
+label_all_container_readable
+
+pass_count=0
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+assert_eq() {
+  [[ "$2" == "$1" ]] || fail "$3: got '$2', want '$1'"
+  pass_count=$((pass_count + 1))
+}
+
+assert_contains() {
+  [[ "$1" == *"$2"* ]] || fail "$3: missing '$2' in: $1"
+  pass_count=$((pass_count + 1))
+}
+
+assert_not_contains() {
+  [[ "$1" != *"$2"* ]] || fail "$3: unexpectedly found '$2' in: $1"
+  pass_count=$((pass_count + 1))
+}
+
+# Snapshot of the fixture's ownership and permissions, taken with the REAL stat
+# so the stub cannot hide a change. Used to prove the preflight is read-only.
+fixture_snapshot() {
+  find "$SRC_FIXTURE" -mindepth 0 -print0 \
+    | sort -z \
+    | xargs -0 "$REAL_STAT" -c '%n %a %u %g %s'
+}
+
+run_preflight() {
+  : >"$CALL_LOG"
+  local before after
+  before="$(fixture_snapshot)"
+  set +e
+  RUN_OUT="$(env PATH="$TEST_PATH" PODMAN_CALL_LOG="$CALL_LOG" FAKE_STAT_MAP="$STAT_MAP" \
+    HIVE_SRC_DIR="$SRC_FIXTURE" "$@" "$BASH_BIN" "$PREFLIGHT" 2>&1)"
+  RUN_STATUS=$?
+  set -e
+  RUN_CALLS="$(cat "$CALL_LOG")"
+  after="$(fixture_snapshot)"
+  [[ "$before" == "$after" ]] || fail "preflight modified the deployment fixture"
+  pass_count=$((pass_count + 1))
+}
+
+# --- Docker stays the default and stays untouched -----------------------------
+#
+# The strongest form of "Docker behavior is unchanged": with Docker selected,
+# the stub Podman is never executed at all and no host state is even read.
+
+run_preflight env -u HIVE_DEPLOY_RUNTIME
+assert_eq "0" "$RUN_STATUS" "default runtime exit"
+assert_contains "$RUN_OUT" "skipped" "default runtime skips"
+assert_contains "$RUN_OUT" "selects docker" "default runtime names docker"
+assert_eq "" "$RUN_CALLS" "default runtime runs no podman command"
+assert_not_contains "$RUN_OUT" "SELinux" "default runtime checks no SELinux state"
+assert_not_contains "$RUN_OUT" "Port" "default runtime checks no port"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=docker
+assert_eq "0" "$RUN_STATUS" "explicit docker exit"
+assert_contains "$RUN_OUT" "skipped" "explicit docker skips"
+assert_eq "" "$RUN_CALLS" "explicit docker runs no podman command"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=containerd
+assert_eq "64" "$RUN_STATUS" "invalid runtime exit"
+assert_eq "" "$RUN_CALLS" "invalid runtime runs no podman command"
+
+# --- A correctly prepared enforcing host --------------------------------------
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_eq "0" "$RUN_STATUS" "prepared host exit"
+assert_contains "$RUN_OUT" "SELinux: Enforcing, Podman labeling enabled" "prepared host SELinux"
+assert_contains "$RUN_OUT" "already container-readable" "prepared host labels"
+assert_contains "$RUN_OUT" "Port 3001: free" "prepared host port"
+assert_contains "$RUN_OUT" "fail=0" "prepared host has no failure"
+assert_not_contains "$RUN_OUT" "△" "prepared host has no warning"
+
+# --- SELinux state: enforcing, permissive, disabled ---------------------------
+
+# Enforcing with Podman labeling off is the combination that breaks every bind
+# mount while both facts look fine in isolation.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_SELINUX_ENABLED=false
+assert_eq "78" "$RUN_STATUS" "labeling-off exit"
+assert_contains "$RUN_OUT" "labeling DISABLED" "labeling-off message"
+assert_contains "$RUN_OUT" "container-selinux" "labeling-off names the policy package"
+assert_contains "$RUN_OUT" "containers.conf" "labeling-off names the config to check"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_SELINUX_ENABLED=__ERR__
+assert_eq "0" "$RUN_STATUS" "unreported labeling exit"
+assert_contains "$RUN_OUT" "did not report its labeling state" "unreported labeling message"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ENFORCE=Permissive
+assert_eq "0" "$RUN_STATUS" "permissive exit"
+assert_contains "$RUN_OUT" "SELinux: Permissive" "permissive reported"
+assert_contains "$RUN_OUT" "will on an enforcing host" "permissive warns about the enforcing case"
+assert_contains "$RUN_OUT" "ausearch" "permissive points at the denial log"
+
+# Disabled is a legitimate host configuration, not a finding, and it takes the
+# labeling checks off the table rather than leaving them noisy.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ENFORCE=Disabled
+assert_eq "0" "$RUN_STATUS" "disabled exit"
+assert_contains "$RUN_OUT" "not enabled on this host" "disabled reported"
+assert_contains "$RUN_OUT" "Mount labeling: not applicable" "disabled skips labeling"
+assert_not_contains "$RUN_OUT" "Mount label:" "disabled judges no individual label"
+
+# No policy utilities on PATH at all. The mode must still be resolved from the
+# kernel rather than degrading to "unknown", because a trimmed PATH is exactly
+# what a minimal deployment host looks like.
+SLIM_BIN="${TEST_TMP}/slim"
+mkdir -p "$SLIM_BIN"
+for tool in dirname id awk head grep; do
+  ln -sf "$(command -v "$tool")" "${SLIM_BIN}/${tool}"
+done
+ln -sf "${FAKE_BIN}/podman" "${SLIM_BIN}/podman"
+ln -sf "${FAKE_BIN}/stat" "${SLIM_BIN}/stat"
+[[ -x "${SLIM_BIN}/getenforce" ]] && fail "slim PATH must not contain getenforce"
+
+set +e
+RUN_OUT="$(env PATH="$SLIM_BIN" HIVE_DEPLOY_RUNTIME=podman PODMAN_CALL_LOG="$CALL_LOG" \
+  FAKE_STAT_MAP="$STAT_MAP" HIVE_SRC_DIR="$SRC_FIXTURE" "$BASH_BIN" "$PREFLIGHT" 2>&1)"
+RUN_STATUS=$?
+set -e
+assert_eq "0" "$RUN_STATUS" "no-utilities host exit"
+if [[ -r /sys/fs/selinux/enforce ]]; then
+  # This host really runs SELinux; selinuxfs must supply the mode unaided.
+  case "$(cat /sys/fs/selinux/enforce)" in
+    1) assert_contains "$RUN_OUT" "SELinux: Enforcing" "selinuxfs supplies Enforcing without getenforce" ;;
+    *) assert_contains "$RUN_OUT" "SELinux: Permissive" "selinuxfs supplies Permissive without getenforce" ;;
+  esac
+else
+  assert_contains "$RUN_OUT" "not enabled on this host" "absent selinuxfs reads as not enabled"
+fi
+assert_not_contains "$RUN_OUT" "could not be determined" "no-utilities host still resolves a state"
+
+# --- Mount labeling -----------------------------------------------------------
+
+# The everyday Fedora case: a checkout under $HOME, so every source is
+# user_home_t and no container type can read it without a relabel.
+cat >"$STAT_MAP" <<EOF
+${SRC_FIXTURE}/hive.yaml||||unconfined_u:object_r:user_home_t:s0
+${SRC_FIXTURE}/deploy/nginx.conf||||unconfined_u:object_r:user_home_t:s0
+${SRC_FIXTURE}/secrets||||unconfined_u:object_r:user_home_t:s0
+${SRC_FIXTURE}/secrets/gh-app-key.pem||||system_u:object_r:container_file_t:s0
+EOF
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_eq "0" "$RUN_STATUS" "wrong labels are a warning, not a failure"
+assert_contains "$RUN_OUT" "a container cannot read it as-is" "wrong label reported"
+# Read-only configuration out of a checkout gets the shared option; the secrets
+# directory gets the private one.
+assert_contains "$RUN_OUT" "Mount it with :z" "config gets the shared relabel"
+assert_contains "$RUN_OUT" "Mount it with :Z" "secrets get the private relabel"
+assert_contains "$RUN_OUT" "semanage fcontext -a -t container_file_t" "persistent labeling offered"
+# A directory rule needs the recursive suffix; a single file must not get one.
+assert_contains "$RUN_OUT" "/src/secrets(/.*)?' && restorecon -R " "directory fcontext is recursive"
+assert_contains "$RUN_OUT" "hive\\.yaml' &&" "file fcontext is exact and escapes the dot"
+assert_contains "$RUN_OUT" "kernel stays enforcing" "relabeling is framed as SELinux-preserving"
+
+# A filesystem with no security xattrs reports as unlabeled rather than wrong.
+cat >"$STAT_MAP" <<EOF
+${SRC_FIXTURE}/hive.yaml||||?
+EOF
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_contains "$RUN_OUT" "carries no SELinux label" "unlabeled source reported"
+assert_contains "$RUN_OUT" "security xattrs" "unlabeled source explains why"
+
+label_all_container_readable
+
+# --- Configuration and secrets ------------------------------------------------
+
+# Config that is not there yet fails: the bind mount has nothing to bind.
+mv "${SRC_FIXTURE}/hive.yaml" "${TEST_TMP}/hive.yaml.stash"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_eq "78" "$RUN_STATUS" "missing config exit"
+assert_contains "$RUN_OUT" "Hive config: ${SRC_FIXTURE}/hive.yaml does not exist" "missing config reported"
+mv "${TEST_TMP}/hive.yaml.stash" "${SRC_FIXTURE}/hive.yaml"
+
+mv "${SRC_FIXTURE}/deploy/nginx.conf" "${TEST_TMP}/nginx.conf.stash"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_eq "78" "$RUN_STATUS" "missing gateway config exit"
+assert_contains "$RUN_OUT" "Gateway config" "missing gateway config reported"
+mv "${TEST_TMP}/nginx.conf.stash" "${SRC_FIXTURE}/deploy/nginx.conf"
+
+# A token-only deployment never creates secrets/, so its absence is a warning
+# with a narrow-by-construction remedy — not a failure and not a wide mkdir.
+mv "${SRC_FIXTURE}/secrets" "${TEST_TMP}/secrets.stash"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_eq "0" "$RUN_STATUS" "absent secrets dir is not a failure"
+assert_contains "$RUN_OUT" "does not exist" "absent secrets dir reported"
+assert_contains "$RUN_OUT" "mkdir -m 700" "absent secrets dir remedy creates it narrow"
+mv "${TEST_TMP}/secrets.stash" "${SRC_FIXTURE}/secrets"
+
+# An over-permissive secret is reported and left alone. The only command
+# offered narrows it, and run_preflight has already asserted the mode on disk
+# did not move.
+chmod 644 "${SRC_FIXTURE}/secrets/gh-app-key.pem"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_eq "0" "$RUN_STATUS" "over-permissive secret is a warning"
+assert_contains "$RUN_OUT" "wider than 600" "over-permissive secret reported"
+assert_contains "$RUN_OUT" "chmod 600" "over-permissive secret remedy narrows"
+assert_contains "$RUN_OUT" "loosening host permissions is never the remedy" "no broadening offered"
+assert_eq "644" "$("$REAL_STAT" -c '%a' "${SRC_FIXTURE}/secrets/gh-app-key.pem")" \
+  "secret mode untouched by preflight"
+chmod 600 "${SRC_FIXTURE}/secrets/gh-app-key.pem"
+
+chmod 755 "${SRC_FIXTURE}/secrets"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_contains "$RUN_OUT" "wider than 700" "over-permissive secrets dir reported"
+chmod 700 "${SRC_FIXTURE}/secrets"
+
+# 0400 is narrower than the 0600 maximum and must not be flagged.
+chmod 400 "${SRC_FIXTURE}/secrets/gh-app-key.pem"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_not_contains "$RUN_OUT" "wider than 600" "0400 secret is not flagged as too wide"
+chmod 600 "${SRC_FIXTURE}/secrets/gh-app-key.pem"
+
+# Rootless maps only the invoking user to container root; anything else lands
+# as nobody, so foreign ownership is a latent failure even when it reads today.
+cat >"$STAT_MAP" <<EOF
+${SRC_FIXTURE}/secrets/gh-app-key.pem||4242|otheruser|system_u:object_r:container_file_t:s0
+EOF
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=true
+assert_contains "$RUN_OUT" "is owned by otheruser" "foreign ownership reported rootless"
+assert_contains "$RUN_OUT" "'nobody'" "foreign ownership explains the mapping"
+
+# Rootful Podman does not map UIDs that way, so the same file is unremarkable.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=false
+assert_not_contains "$RUN_OUT" "is owned by otheruser" "foreign ownership is rootless-only"
+
+label_all_container_readable
+
+if [[ "$EUID" -ne 0 ]]; then
+  # root can read anything, so this case only means something unprivileged.
+  chmod 000 "${SRC_FIXTURE}/hive.yaml"
+  run_preflight env HIVE_DEPLOY_RUNTIME=podman
+  assert_eq "78" "$RUN_STATUS" "unreadable config exit"
+  assert_contains "$RUN_OUT" "is not readable by" "unreadable config reported"
+  assert_contains "$RUN_OUT" "do not widen the mode to make this pass" "no broadening offered"
+  chmod 644 "${SRC_FIXTURE}/hive.yaml"
+else
+  printf 'SKIP: running as root — the unreadable-source case cannot be exercised\n'
+fi
+
+# --- Ports --------------------------------------------------------------------
+
+# 3001 is the authenticated gateway and is checked whether or not the operator
+# names it. 7681, the raw writable ttyd port, is deliberately never published
+# and so is deliberately never checked.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+assert_contains "$RUN_OUT" "Port 3001" "3001 checked by default"
+assert_not_contains "$RUN_OUT" "Port 7681" "the unpublished ttyd port is not checked"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman \
+  FAKE_LISTENERS="LISTEN 0 4096 0.0.0.0:3001 0.0.0.0:*"
+assert_eq "78" "$RUN_STATUS" "occupied port exit"
+assert_contains "$RUN_OUT" "Port 3001: already in use" "occupied port reported"
+assert_contains "$RUN_OUT" "held by: LISTEN 0 4096 0.0.0.0:3001" "occupied port names the listener"
+assert_contains "$RUN_OUT" "Preflight changes nothing" "occupied port is not resolved for the operator"
+
+# A listener on a different port must not be mistaken for one on 3001, and a
+# port that merely ends in the same digits must not match either.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman \
+  FAKE_LISTENERS="LISTEN 0 4096 0.0.0.0:13001 0.0.0.0:*"
+assert_eq "0" "$RUN_STATUS" "13001 is not 3001"
+assert_contains "$RUN_OUT" "Port 3001: free" "suffix match does not occupy the port"
+
+# Additional published ports are checked, in either separator style.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman HIVE_PODMAN_PREFLIGHT_PORTS="3001,8443"
+assert_contains "$RUN_OUT" "Port 8443: free" "comma-separated extra port checked"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman HIVE_PODMAN_PREFLIGHT_PORTS="3001 8443"
+assert_contains "$RUN_OUT" "Port 8443: free" "space-separated extra port checked"
+
+run_preflight env HIVE_DEPLOY_RUNTIME=podman HIVE_PODMAN_PREFLIGHT_PORTS="https"
+assert_eq "78" "$RUN_STATUS" "non-numeric port exit"
+assert_contains "$RUN_OUT" "is not a valid TCP port" "non-numeric port reported"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman HIVE_PODMAN_PREFLIGHT_PORTS="70000"
+assert_eq "78" "$RUN_STATUS" "out-of-range port exit"
+
+# Rootless cannot bind below the unprivileged floor at all. The remedy raises
+# the host's allowance or moves the port; it never says "run Hive as root".
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=true \
+  HIVE_PODMAN_PREFLIGHT_PORTS="443"
+assert_eq "78" "$RUN_STATUS" "sub-floor rootless port exit"
+assert_contains "$RUN_OUT" "below the rootless unprivileged floor (1024)" "sub-floor port reported"
+assert_contains "$RUN_OUT" "net.ipv4.ip_unprivileged_port_start=443" "sub-floor remedy is the sysctl"
+assert_not_contains "$RUN_OUT" "as root" "sub-floor remedy does not propose running as root"
+
+# Rootful publishes any port, so the floor does not apply.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=false \
+  HIVE_PODMAN_PREFLIGHT_PORTS="443"
+assert_eq "0" "$RUN_STATUS" "rootful sub-floor port exit"
+assert_contains "$RUN_OUT" "Port 443: free" "rootful ignores the unprivileged floor"
+
+# A host that already lowered the floor can publish below 1024 rootless.
+run_preflight env HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=true FAKE_PORT_FLOOR=80 \
+  HIVE_PODMAN_PREFLIGHT_PORTS="443"
+assert_eq "0" "$RUN_STATUS" "lowered floor exit"
+assert_contains "$RUN_OUT" "Port 443: free" "lowered floor permits the port"
+
+# No enumeration tool: say so rather than reporting the port as free.
+NOSS_BIN="${TEST_TMP}/noss"
+mkdir -p "$NOSS_BIN"
+for tool in dirname id awk head grep cat find sort xargs sed; do
+  ln -sf "$(command -v "$tool")" "${NOSS_BIN}/${tool}"
+done
+for tool in podman getenforce stat sysctl; do
+  ln -sf "${FAKE_BIN}/${tool}" "${NOSS_BIN}/${tool}"
+done
+[[ -x "${NOSS_BIN}/ss" || -x "${NOSS_BIN}/netstat" ]] && fail "no-ss PATH must have neither tool"
+
+set +e
+RUN_OUT="$(env PATH="$NOSS_BIN" HIVE_DEPLOY_RUNTIME=podman PODMAN_CALL_LOG="$CALL_LOG" \
+  FAKE_STAT_MAP="$STAT_MAP" HIVE_SRC_DIR="$SRC_FIXTURE" "$BASH_BIN" "$PREFLIGHT" 2>&1)"
+RUN_STATUS=$?
+set -e
+assert_eq "0" "$RUN_STATUS" "no port tool exit"
+assert_contains "$RUN_OUT" "availability unverified" "no port tool reported"
+assert_contains "$RUN_OUT" "iproute2" "no port tool remedy"
+assert_not_contains "$RUN_OUT" "Port 3001: free" "no port tool does not claim the port is free"
+
+# --- Remediation never weakens the host ---------------------------------------
+#
+# Swept across every case above rather than asserted once: no output path may
+# offer to turn SELinux off, opt a container out of labeling, or widen access.
+
+FORBIDDEN=(
+  "setenforce 0"
+  "SELINUX=disabled"
+  "selinux=0"
+  "label=disable"
+  "label:disable"
+  "--privileged"
+  "chmod 777"
+  "chmod 666"
+  "chmod a+r"
+  "chmod o+r"
+  "chmod -R 777"
+)
+
+sweep_out=""
+for case_env in \
+  "HIVE_DEPLOY_RUNTIME=podman" \
+  "HIVE_DEPLOY_RUNTIME=podman FAKE_SELINUX_ENABLED=false" \
+  "HIVE_DEPLOY_RUNTIME=podman FAKE_ENFORCE=Permissive" \
+  "HIVE_DEPLOY_RUNTIME=podman FAKE_ENFORCE=Disabled" \
+  "HIVE_DEPLOY_RUNTIME=podman FAKE_ROOTLESS=true HIVE_PODMAN_PREFLIGHT_PORTS=443" \
+  "HIVE_DEPLOY_RUNTIME=podman FAKE_LISTENERS=LISTEN_0_4096_0.0.0.0:3001"
+do
+  # shellcheck disable=SC2086 # the case string is a deliberate word-split env list
+  run_preflight env $case_env
+  sweep_out+="${RUN_OUT}"$'\n'
+done
+
+# The user_home_t case carries the densest remediation text, so sweep it too.
+cat >"$STAT_MAP" <<EOF
+${SRC_FIXTURE}/hive.yaml||||unconfined_u:object_r:user_home_t:s0
+${SRC_FIXTURE}/deploy/nginx.conf||||unconfined_u:object_r:user_home_t:s0
+${SRC_FIXTURE}/secrets||||unconfined_u:object_r:user_home_t:s0
+EOF
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+sweep_out+="${RUN_OUT}"$'\n'
+chmod 644 "${SRC_FIXTURE}/secrets/gh-app-key.pem"
+run_preflight env HIVE_DEPLOY_RUNTIME=podman
+sweep_out+="${RUN_OUT}"$'\n'
+chmod 600 "${SRC_FIXTURE}/secrets/gh-app-key.pem"
+
+for forbidden in "${FORBIDDEN[@]}"; do
+  assert_not_contains "$sweep_out" "$forbidden" "no case ever recommends '${forbidden}'"
+done
+
+printf 'PASS: %d Podman host preflight assertions\n' "$pass_count"

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -59,6 +59,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Podman rootless CI](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-ci.md) — rootless Podman contract for `contribute-hive`.
 - [Podman Quadlet `.kube` compatibility spike](podman-quadlet-kube-spike.md) — why the standalone Kubernetes overlay is not a safe direct source for Podman units.
 - [Podman ownership and cleanup contract](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-ownership-cleanup.md) — the labels that mark a resource Hive-owned and the guard that keeps Podman/Buildah cleanup from reaching the operator's other containers, Distroboxes, and images.
+- [Podman preflight: SELinux, mounts, secrets, and ports](podman-preflight-host.md) — read-only diagnostics for SELinux state and mount labeling, configuration/secrets readability, and published host-port availability, with remediation that never disables SELinux or widens a secret.
 - [CLI backend setup](https://github.com/kubestellar/hive/blob/v4/docs/backend-setup.md) — setup notes for Claude, Copilot, Goose, Bob, Pi, Codex, and Aider.
 - [Inference backends](https://github.com/kubestellar/hive/blob/v4/docs/inference-backends.md) — vLLM, llm-d, LiteLLM, and Model Gateway troubleshooting.
 - [apiproxy](https://github.com/kubestellar/hive/blob/v4/src/docs/apiproxy.md) — Anthropic-compatible proxy logging and deployment notes.

--- a/src/docs/podman-preflight-host.md
+++ b/src/docs/podman-preflight-host.md
@@ -1,0 +1,171 @@
+# Podman preflight: SELinux, mounts, secrets, and ports
+
+`bin/hive-podman-preflight-host.sh` diagnoses the three host conditions that
+break a standalone Podman deployment of Hive without ever mentioning Podman in
+the error message. Part of [#4188](https://github.com/kubestellar/hive/issues/4188);
+implements [#4209](https://github.com/kubestellar/hive/issues/4209).
+
+It is **read-only**. It starts no container, relabels nothing, changes no mode
+or owner, writes nothing to the host, and contacts no registry. Every finding
+comes with a command for the operator to run, and preflight never runs it.
+
+```bash
+HIVE_DEPLOY_RUNTIME=podman bin/hive-podman-preflight-host.sh
+```
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | No failing check. Warnings may still be present. |
+| `64` | `HIVE_DEPLOY_RUNTIME` names something other than `docker` or `podman`. |
+| `78` | At least one failing check. |
+
+With the Docker default selected — that is, with `HIVE_DEPLOY_RUNTIME` unset or
+set to `docker` — the script reports that it was skipped and exits `0` without
+running a single Podman command. Docker deployments are unaffected.
+
+Related layers: the engine, connection, root mode, and cgroup checks are
+[#4207](https://github.com/kubestellar/hive/issues/4207); subordinate IDs,
+graphroot, and networking are
+[#4208](https://github.com/kubestellar/hive/issues/4208).
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HIVE_DEPLOY_RUNTIME` | `docker` | Selects the engine. The checks run only for `podman`. |
+| `HIVE_SRC_DIR` | `<repo>/src` | Directory holding `hive.yaml`, `deploy/`, and `secrets/`. |
+| `HIVE_PODMAN_PREFLIGHT_PORTS` | `3001` | Published host ports to check, space- or comma-separated. |
+
+Port 3001 is the authenticated gateway and is checked by default. Port 7681 —
+the raw writable ttyd terminal — is deliberately *not* published by
+`src/docker-compose.yaml` and is deliberately not checked here; if it ever
+appears in this list, something has gone wrong upstream of preflight.
+
+## 1. SELinux state and Podman labeling
+
+Two facts are read independently and they can disagree:
+
+* The kernel's mode (`getenforce`, or `/sys/fs/selinux/enforce`).
+* Whether Podman itself will apply container labels
+  (`podman info --format '{{.Host.Security.SELinuxEnabled}}'`).
+
+| Kernel | Podman labeling | Result |
+| --- | --- | --- |
+| Enforcing | enabled | Pass. |
+| Enforcing | **disabled** | **Fail.** Every bind mount is denied and `:z`/`:Z` do nothing, because Podman will not set a label the container type can read. |
+| Enforcing | unreported | Warn — confirm labeling before deploying. |
+| Permissive | either | Warn. Label problems are logged, not enforced, so the deployment will appear healthy here and fail on the first enforcing host. |
+| Disabled / not built in | n/a | Pass. Mount labeling does not apply; this is the normal Debian/Ubuntu state. |
+
+For the enforcing-with-labeling-off case the remedy is to install the container
+policy and remove whatever turned labeling off:
+
+```bash
+sudo dnf install container-selinux
+grep -rn 'label' /etc/containers/containers.conf /etc/containers/containers.conf.d/ 2>/dev/null
+```
+
+**Disabling SELinux is not offered as a fix anywhere in this check**, and
+`setenforce 0`, `SELINUX=disabled`, and `--security-opt label=disable` never
+appear in its output. A test asserts that across every case.
+
+If you are on a permissive host and want to qualify the deployment properly,
+switch to enforcing and re-run rather than shipping the permissive result:
+
+```bash
+sudo setenforce 1
+sudo ausearch -m AVC -ts recent   # denials accumulated while permissive
+```
+
+## 2. Mount labeling
+
+The three bind-mount sources in `src/docker-compose.yaml` are checked against
+the label their host path actually carries:
+
+| Source | Consumed by | Recommended option |
+| --- | --- | --- |
+| `hive.yaml` | `hive` | `:z` |
+| `deploy/nginx.conf` | `gateway` | `:z` |
+| `secrets/` | `hive` | `:Z` |
+
+`container_file_t`, `container_share_t`, and `container_ro_file_t` are readable
+by a container as-is and pass. Anything else — `user_home_t` for a checkout
+under `$HOME` is the everyday case — warns, because a lifecycle asset that does
+not carry `:z` or `:Z` will hit `EACCES` on a file that looks perfectly
+readable on the host.
+
+The read-only configuration files get `:z` rather than `:Z`: they live inside
+the operator's checkout and are likely read by other tooling, and `:Z` stamps a
+per-container MCS category that makes them unreadable to everything else. The
+secrets directory gets `:Z`, because exactly one container should be able to
+read it.
+
+To label a path once instead of relabeling on every run, preflight prints the
+persistent form:
+
+```bash
+sudo semanage fcontext -a -t container_file_t '/opt/hive/src/secrets(/.*)?'
+sudo restorecon -R /opt/hive/src/secrets
+```
+
+A source that carries no label at all is reported separately: that usually
+means the filesystem underneath it does not support security xattrs, and the
+deployment needs to move rather than be relabeled.
+
+## 3. Configuration and secrets readability
+
+Readable by the process that needs it, and by nobody else. Both halves are
+reported; **neither is repaired**.
+
+* A missing `hive.yaml` or `deploy/nginx.conf` fails — the bind mount has
+  nothing to bind.
+* A missing `secrets/` warns rather than fails: token-only deployments never
+  create it. The suggested `mkdir -m 700` creates it narrow.
+* A source the invoking user cannot read fails. Rootless Podman opens bind
+  mounts with that user's credentials, so an unreadable source is an unreadable
+  mount.
+* Under rootless Podman, a source owned by *another* host user warns: only the
+  invoking user maps to container root, and everyone else lands as `nobody`
+  inside the user namespace. That is a latent failure even when the file reads
+  fine today. Rootful Podman does not map UIDs that way, so the check does not
+  apply there.
+* A secrets directory wider than `0700`, or a secret file wider than `0600`,
+  warns and prints the `chmod` that **narrows** it.
+
+Preflight never widens permissions, and the test suite asserts both that no
+output path proposes `chmod 777`, `chmod a+r`, or similar, and that the
+deployment tree is byte-identical in mode, owner, and size after every run.
+
+## 4. Host port availability
+
+Each selected port is checked against the host's listening sockets via `ss`,
+falling back to `netstat`. Neither installed means the port is reported as
+unverified — never as free.
+
+Rootless Podman additionally cannot publish a port below
+`net.ipv4.ip_unprivileged_port_start`, which defaults to 1024. Preflight reads
+that floor and fails a sub-floor port with the sysctl that raises the host's
+allowance:
+
+```bash
+sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443
+```
+
+The alternative it offers is to publish at or above the floor and put a
+privileged listener in front. Running Hive as root is not offered. The floor
+does not apply rootful, and the check is skipped there.
+
+An occupied port fails and names the listener. Preflight does not stop it, does
+not touch firewall rules, and does not reserve anything.
+
+## Tests
+
+```bash
+bash bin/test_hive_podman_preflight_host.sh
+```
+
+Every input is mocked — a stub `podman`, `getenforce`, `sysctl`, and `ss`, plus
+a `stat` that fakes SELinux labels and ownership per path while letting real
+permissions through. The enforcing, permissive, and disabled matrix therefore
+runs on a host with no SELinux, no Podman, and no privileges, which is what
+`.github/workflows/v2-ci.yml` runs it on.


### PR DESCRIPTION
## What

Adds `bin/hive-podman-preflight-host.sh`: a read-only Podman preflight layer for SELinux state and mount labeling, configuration/secrets readability, and published host-port availability.

Part of #4188. Closes #4209.

Three of the ways a standalone Podman deployment fails on a Fedora/RHEL-class host have nothing to do with the engine, and all three surface as an unhelpful error long after `podman run` has already started making changes:

1. SELinux is enforcing and the bind-mount sources carry a host label no container type can read, so the process inside sees `EACCES` on a file that is plainly mode `0644` on the host.
2. The configuration file or the secrets directory is absent, unreadable by the user the engine actually runs as, or readable by everyone on the box.
3. Something already holds the port the gateway is about to publish, or the port is below the rootless unprivileged-port floor.

```bash
HIVE_DEPLOY_RUNTIME=podman bin/hive-podman-preflight-host.sh
```

Exit `0` no failing check, `64` unusable runtime selection, `78` at least one failing check.

## The checks

**SELinux** is read as two independent facts, because they can disagree and the disagreement is invisible from either one alone: the kernel's mode (`getenforce`, falling back to `/sys/fs/selinux/enforce` via a bash builtin so a trimmed PATH cannot silence it), and whether Podman will apply container labels at all (`{{.Host.Security.SELinuxEnabled}}`).

| Kernel | Podman labeling | Result |
| --- | --- | --- |
| Enforcing | enabled | Pass |
| Enforcing | **disabled** | **Fail** — every bind mount is denied and `:z`/`:Z` do nothing |
| Enforcing | unreported | Warn |
| Permissive | either | Warn — will break on the first enforcing host |
| Disabled / not built in | n/a | Pass — labeling does not apply |

**Mount labels** are checked against the three bind-mount sources in `src/docker-compose.yaml`. The read-only configuration files are offered `:z` rather than `:Z` — they live in the operator's checkout and `:Z` would stamp a per-container MCS category onto them — while `secrets/` is offered `:Z`. Both come with the persistent `semanage fcontext` / `restorecon` form as an alternative to relabeling on every run. A source with no label at all is reported separately, since that usually means the filesystem has no security xattrs and the deployment needs to move rather than be relabeled.

**Configuration and secrets** are reported on two axes — readable by the process that needs them, and by nobody else — and repaired on neither. Missing `hive.yaml` or `deploy/nginx.conf` fails; a missing `secrets/` only warns, because token-only deployments never create it. Under rootless Podman, a source owned by another host user is called out as a latent failure: only the invoking user maps to container root, and everyone else lands as `nobody` inside the user namespace. Rootful does not map UIDs that way, so the check does not apply there.

**Ports** are checked via `ss`, falling back to `netstat`; with neither installed the port is reported *unverified*, never *free*. Rootless additionally cannot bind below `net.ipv4.ip_unprivileged_port_start`, so a sub-floor port fails with the sysctl that raises the host's allowance. 3001 is always checked; extra published ports go in `HIVE_PODMAN_PREFLIGHT_PORTS`.

## Acceptance criteria

- **Never recommends disabling SELinux as the normal fix.** Every remedy is a labeling or policy action that leaves the kernel enforcing. A test sweeps the output of every case and asserts `setenforce 0`, `SELINUX=disabled`, `selinux=0`, `label=disable`, and `--privileged` appear nowhere.
- **Does not broaden secret permissions automatically.** An over-permissive secret prints the `chmod` that *narrows* it and nothing else; a missing `secrets/` is remedied with `mkdir -m 700`; an unreadable source says "do not widen the mode to make this pass". The same sweep asserts no `chmod 777`/`666`/`a+r`/`o+r` anywhere, and every run asserts the deployment fixture is byte-identical in mode, owner, and size afterwards.
- **Port 3001 and any other selected published ports are checked before startup.** 7681 — the raw writable ttyd terminal — is deliberately not published by the Compose stack and is deliberately not checked; a test asserts it never appears.
- **Docker behavior remains unchanged.** With `HIVE_DEPLOY_RUNTIME` unset or `docker`, the script reports it was skipped and exits 0. Tests assert the stub Podman is never executed and no SELinux state or port is even read.
- **Tests cover enforcing/permissive/disabled and representative failures using mocked inputs.** A stub `podman`, `getenforce`, `sysctl`, and `ss`, plus a `stat` that fakes SELinux labels and ownership per path while letting real permissions through — so the whole matrix runs on a runner with no SELinux, no Podman, and no privileges. 137 assertions, wired into `.github/workflows/v2-ci.yml`.

## 30-minute boundary

SELinux, mount-access, and port checks only. Nothing here changes volume ownership or host policy, starts a container, or contacts a registry. The engine, connection, root mode, and cgroup layer is #4207; subordinate IDs, graphroot, and networking are #4208. This PR is independent of both and does not touch `bin/hive-podman-preflight.sh`.

## Verification

```
$ bash bin/test_hive_podman_preflight_host.sh
PASS: 137 Podman host preflight assertions

$ shellcheck -S style bin/hive-podman-preflight-host.sh bin/test_hive_podman_preflight_host.sh
(clean)
```

Also run live on an SELinux-enforcing Fedora host with rootless Podman, where it correctly reported `Enforcing` with labeling enabled, flagged all three `user_home_t` bind sources with the right `:z`/`:Z` split, and found 3001 free.

## Files

- `bin/hive-podman-preflight-host.sh` — the checks
- `bin/test_hive_podman_preflight_host.sh` — the mocked contract tests
- `src/docs/podman-preflight-host.md` — operator guide with every remediation it prints
- `.github/workflows/v2-ci.yml`, `bin/README.md`, `src/docs/README.md` — wiring and index entries

— hive: backend=claude model=claude-opus-5
