### PR TITLE
🐛 fix(contribute): let a reconnecting relay resume its in-flight task

### DIFF
--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -242,6 +242,31 @@ The shipped relay declares `environment` only where the cause is unambiguous (CL
 
 Whether the hub should ever *act* on client declarations — the ROUTE half of [#2547](https://github.com/kubestellar/hive/issues/2547) — remains an open maintainer decision, and needs task-side requirements metadata that does not exist yet.
 
+## Reconnecting without losing in-flight work
+
+The relay heartbeats every 30 s and reconnects with exponential backoff (1 s to 60 s). A drop inside that window is meant to be invisible to the agent: the relay keeps its task locally, re-asserts it on the new socket, and carries on typing into the same tmux pane.
+
+Three things have to line up for that to work.
+
+**The hub keeps the lease across a disconnect.** Every release path — `task_complete`, `task_failed`, a `ready` that abandons, an operator requeue or yank, the wedged-task backstop — revokes the server-issued lease, and a revoked lease is terminal. A plain socket drop deliberately does not, which is what leaves something for the returning relay to re-adopt.
+
+**The relay proves it owns the task.** On reconnect it sends `task_accepted` followed by a `task_progress` carrying the `task_gen` the hub issued in `task_assign`. The hub honours the resume only when that claim matches the lease it recorded, exactly, on identity, task id, repo, number and generation, and only while the lease is unexpired. Ownership is never rebuilt from the relay's own fields, so a client cannot assert a task it was never given. A relay too old to echo a generation sends `0` and is asked to `ready` for fresh work instead.
+
+**The lease has to still be alive.** The window is `leaseTTL` (30 minutes, the same as the wedged-task timeout) measured from the last accepted `task_progress` — not from assignment. This is the part [#4260](https://github.com/kubestellar/hive/issues/4260) fixed: the expiry used to be stamped once at assignment and never moved, so a task that had been reporting progress for more than 30 minutes was correctly never reclaimed as wedged, yet its lease had quietly expired. The next drop, however brief, produced this:
+
+```
+Reconnected while working on kubestellar/hive#4203 — resuming
+Task revoked: ct-kubestellar/hive-4203-… — no active lease for this task
+Task assigned: issue kubestellar/hive#4203 — …
+Task prompt sent to CLI
+```
+
+That last line types a fresh prompt into a pane whose CLI is still mid-turn, interrupting it. Renewing the lease on every progress report keeps the two clocks together: a task the hub still considers alive is a task the relay can still resume.
+
+A resume that is genuinely refused — an operator yanked the task, or the relay stopped reporting for longer than the lease window — still ends in `task_revoke`, and that is correct. The relay clears its task and asks for new work.
+
+**A dropped socket is not a failed issue.** The disconnect books a short cooldown on the issue so a second session cannot pick it up during the reconnect window and file a duplicate PR ([#2356](https://github.com/kubestellar/hive/issues/2356)). That cooldown no longer counts toward the consecutive-failure quarantine: three drops on a flaky connection used to park a perfectly workable issue for six hours with nothing having actually failed. Real failures — `task_failed`, the relay's own 30-minute watchdog giving up, the wedged-task backstop — still count, and still quarantine.
+
 ## Troubleshooting: the backend dies seconds after every task
 
 Symptom: the CLI starts fine and sits at its prompt, the relay reports `CLI ready` and `Task prompt sent to CLI`, and then the backend exits a few seconds later with a non-zero status — no crash, no log, no message. The pane falls back to a shell, and (on a relay without the liveness fix) subsequent task prompts get typed into that shell.

--- a/src/pkg/dashboard/contribute_reconnect_resume_test.go
+++ b/src/pkg/dashboard/contribute_reconnect_resume_test.go
@@ -1,0 +1,526 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_reconnect_resume_test.go covers kubestellar/hive#4260: a relay whose
+// socket drops and reconnects inside the backoff window must be able to resume the
+// task it never stopped working, and a dropped socket must not be counted as a
+// failure OF THE ISSUE.
+//
+// Two independent defects sat behind the one report:
+//
+//  1. taskLease.expiresAt was stamped once by recordLease at assignment and never
+//     moved, while reclaimExpiredLeases measured liveness from lastLeaseRenew, which
+//     every task_progress refreshed. The leaseTTL comment claimed the two clocks were
+//     aligned. They were not: a task reporting progress for longer than leaseTTL was
+//     correctly never reclaimed, yet its lease had silently expired, so the next
+//     socket drop could not be resumed.
+//
+//  2. The disconnect path booked its #2356 cooldown through recordTaskFailure, which
+//     also advances consecutiveFailures. Three drops on one issue crossed
+//     consecutiveFailureQuarantineThreshold and quarantined an issue nobody failed.
+
+// --- 1. The lease must not expire under a task that is still working -----------
+
+// TestReconnectResume_LeaseSurvivesBeyondTTLWhileProgressing is the core #4260
+// regression. A task that has been reporting progress for well over leaseTTL is
+// exactly the task reclaimExpiredLeases refuses to reclaim, because it is alive. Its
+// lease must still be re-adoptable, or the first socket drop after leaseTTL costs the
+// relay its in-flight work.
+func TestReconnectResume_LeaseSurvivesBeyondTTLWhileProgressing(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	const identity = "c-longrunner"
+	assigned := time.Now()
+	hub.recordLease(identity, "ct-long", "myorg/repo1", 42, "contributor", 9, assigned)
+
+	// Report progress every five minutes for two full lease windows, the way a relay
+	// working a long task does.
+	last := assigned
+	for elapsed := 5 * time.Minute; elapsed <= 2*leaseTTL; elapsed += 5 * time.Minute {
+		last = assigned.Add(elapsed)
+		hub.renewLease(identity, "ct-long", last)
+	}
+
+	// A socket drop one second after the last progress report.
+	drop := last.Add(time.Second)
+	if hub.lookupLease(identity, "ct-long", "myorg/repo1", 42, 9, drop) == nil {
+		t.Fatalf("#4260: a task that has been reporting progress for %v could not be "+
+			"re-adopted after a reconnect — the lease expired under work the hub "+
+			"itself considers alive", 2*leaseTTL)
+	}
+
+	// The window is measured from the last renewal, not from assignment.
+	stillGood := last.Add(leaseTTL - time.Minute)
+	if hub.lookupLease(identity, "ct-long", "myorg/repo1", 42, 9, stillGood) == nil {
+		t.Fatalf("#4260: the lease window is not measured from the last renewal")
+	}
+}
+
+// TestReconnectResume_LeaseStillExpiresWhenProgressStops proves the backstop survives
+// the fix. Renewal extends the window; it does not make a lease immortal. A relay that
+// stops reporting is past its re-adoption window exactly leaseTTL after its LAST
+// report, matching when reclaimExpiredLeases would reclaim the task.
+func TestReconnectResume_LeaseStillExpiresWhenProgressStops(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	const identity = "c-stalled"
+	assigned := time.Now()
+	hub.recordLease(identity, "ct-stall", "myorg/repo1", 7, "contributor", 3, assigned)
+
+	lastProgress := assigned.Add(10 * time.Minute)
+	hub.renewLease(identity, "ct-stall", lastProgress)
+
+	// Inside the window from the last report: still re-adoptable.
+	if hub.lookupLease(identity, "ct-stall", "myorg/repo1", 7, 3, lastProgress.Add(leaseTTL-time.Minute)) == nil {
+		t.Fatalf("a lease inside its renewed window was not re-adoptable")
+	}
+	// Past it: gone, and the stale entry is dropped from the registry.
+	if hub.lookupLease(identity, "ct-stall", "myorg/repo1", 7, 3, lastProgress.Add(leaseTTL+time.Minute)) != nil {
+		t.Fatalf("#4260 must not make leases immortal: a lease unrenewed for %v was "+
+			"still re-adoptable", leaseTTL)
+	}
+	hub.leaseMu.Lock()
+	_, still := hub.leases[identity]
+	hub.leaseMu.Unlock()
+	if still {
+		t.Fatalf("an expired lease was left in the registry instead of being dropped")
+	}
+}
+
+// TestReconnectResume_RenewalGrantsNoAuthority is the security half. renewLease moves
+// one timestamp and nothing else: it cannot create a lease, cross identities, name a
+// task the caller does not hold, or resurrect a revoked one — so C4 (no ownership
+// rebuilt from client-supplied fields) is untouched by the fix.
+func TestReconnectResume_RenewalGrantsNoAuthority(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	now := time.Now()
+
+	// It cannot CREATE a lease for an identity that holds none.
+	hub.renewLease("c-nobody", "ct-invented", now)
+	if hub.lookupLease("c-nobody", "ct-invented", "myorg/repo1", 1, 5, now) != nil {
+		t.Fatalf("C4: renewLease minted a lease for an identity the hub never assigned")
+	}
+
+	hub.recordLease("c-owner", "ct-owned", "myorg/repo1", 11, "contributor", 4, now)
+
+	// It cannot renew a lease for a DIFFERENT task than the one recorded — a relay
+	// naming someone else's task id must not extend the lease it does hold.
+	hub.renewLease("c-owner", "ct-someone-elses", now.Add(leaseTTL))
+	if hub.lookupLease("c-owner", "ct-owned", "myorg/repo1", 11, 4, now.Add(leaseTTL+time.Minute)) != nil {
+		t.Fatalf("C4: a renewal naming a different task extended the caller's lease")
+	}
+
+	// It cannot renew ACROSS identities.
+	hub.recordLease("c-a", "ct-a", "myorg/repo1", 21, "contributor", 6, now)
+	hub.renewLease("c-b", "ct-a", now.Add(leaseTTL))
+	if hub.lookupLease("c-a", "ct-a", "myorg/repo1", 21, 6, now.Add(leaseTTL+time.Minute)) != nil {
+		t.Fatalf("C4: one identity's renewal extended another identity's lease")
+	}
+
+	// It cannot resurrect a REVOKED lease — every release path stays terminal.
+	hub.recordLease("c-rev", "ct-rev", "myorg/repo1", 31, "contributor", 8, now)
+	hub.revokeLease("c-rev", "ct-rev")
+	hub.renewLease("c-rev", "ct-rev", now)
+	if hub.lookupLease("c-rev", "ct-rev", "myorg/repo1", 31, 8, now) != nil {
+		t.Fatalf("C4: a renewal resurrected a revoked lease — a released worker could " +
+			"re-adopt the task the hub took back")
+	}
+
+	// Empty operands are no-ops rather than wildcard matches.
+	hub.recordLease("c-guard", "ct-guard", "myorg/repo1", 41, "contributor", 12, now)
+	hub.renewLease("", "ct-guard", now.Add(leaseTTL))
+	hub.renewLease("c-guard", "", now.Add(leaseTTL))
+	if hub.lookupLease("c-guard", "ct-guard", "myorg/repo1", 41, 12, now.Add(leaseTTL+time.Minute)) != nil {
+		t.Fatalf("C4: an empty identity or task id was treated as a wildcard renewal")
+	}
+}
+
+// TestReconnectResume_RenewalPreservesTheMatchTuple proves a renewal rewrites only
+// expiresAt. The {task, repo, number, tier, generation} tuple lookupLease matches on —
+// and the #2568 generation fence built on it — must come through untouched, so a
+// renewed lease is no easier to claim than a fresh one.
+func TestReconnectResume_RenewalPreservesTheMatchTuple(t *testing.T) {
+	hub, _ := covK2Hub(t)
+	now := time.Now()
+	hub.recordLease("c-fence", "ct-fence", "myorg/repo1", 55, "contributor", 17, now)
+
+	hub.leaseMu.Lock()
+	before := *hub.leases["c-fence"]
+	hub.leaseMu.Unlock()
+
+	renewedAt := now.Add(20 * time.Minute)
+	hub.renewLease("c-fence", "ct-fence", renewedAt)
+
+	hub.leaseMu.Lock()
+	after := *hub.leases["c-fence"]
+	hub.leaseMu.Unlock()
+
+	if after.identity != before.identity || after.taskID != before.taskID ||
+		after.repo != before.repo || after.number != before.number ||
+		after.tier != before.tier || after.gen != before.gen {
+		t.Fatalf("renewal rewrote the match tuple: before=%+v after=%+v", before, after)
+	}
+	if !after.expiresAt.Equal(renewedAt.Add(leaseTTL)) {
+		t.Fatalf("renewal did not move expiresAt to lastRenewal+leaseTTL: got %v", after.expiresAt)
+	}
+
+	// #2568: the fence still holds on a renewed lease.
+	after10 := renewedAt.Add(time.Minute)
+	if hub.lookupLease("c-fence", "ct-fence", "myorg/repo1", 55, 16, after10) != nil {
+		t.Fatalf("#2568: a stale generation matched a RENEWED lease — the fence was lost")
+	}
+	if hub.lookupLease("c-fence", "ct-fence", "myorg/repo1", 55, 0, after10) != nil {
+		t.Fatalf("C4: an unversioned resume (gen 0) matched a renewed lease")
+	}
+	if hub.lookupLease("c-fence", "ct-fence", "myorg/other", 55, 17, after10) != nil {
+		t.Fatalf("C4: a wrong-repo resume matched a renewed lease")
+	}
+	if hub.lookupLease("c-fence", "ct-fence", "myorg/repo1", 56, 17, after10) != nil {
+		t.Fatalf("C4: a wrong-number resume matched a renewed lease")
+	}
+	if hub.lookupLease("c-fence", "ct-fence", "myorg/repo1", 55, 17, after10) == nil {
+		t.Fatalf("the exact resume claim did not match its own renewed lease")
+	}
+}
+
+// TestReconnectResume_ProgressHandlerRenewsLease drives the real task_progress handler
+// and asserts the lease registry moved — proving the renewal is actually wired into
+// the message path and not merely available as a method.
+func TestReconnectResume_ProgressHandlerRenewsLease(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	seedOneIssue(s, 91, "Long-running work")
+
+	conn, _ := registerAndAuth(t, s, ts, "resume-progress-user")
+	defer conn.Close()
+
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" || assign.Number != 91 {
+		t.Fatalf("expected task_assign for #91, got type=%s number=%d", assign.Type, assign.Number)
+	}
+
+	identity := onlyLeaseIdentity(t, s.contributeHub)
+	firstExpiry := leaseExpiry(t, s.contributeHub, identity)
+
+	// A progress report from the relay, exactly as contributor-relay.sh sends it.
+	time.Sleep(10 * time.Millisecond)
+	conn.WriteJSON(WSMessage{
+		Type: "task_progress", Seq: 2, TaskID: assign.TaskID, TaskGen: assign.TaskGen,
+		Repo: assign.Repo, Number: assign.Number, Status: "working",
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if leaseExpiry(t, s.contributeHub, identity).After(firstExpiry) {
+			return // wired
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("#4260: task_progress did not renew the lease registry — expiresAt is "+
+		"still %v, so the lease still ages out from assignment while the task works",
+		firstExpiry)
+}
+
+// TestReconnectResume_HandlerResumesPastOriginalTTL is the end-to-end proof of the
+// reported behaviour. A relay is assigned a task, works past the point where the
+// lease used to expire, drops its socket, reconnects, and re-asserts the task exactly
+// as contributor-relay.sh does. It must be resumed, not told "no active lease for
+// this task" and handed the same issue as a brand-new assignment.
+func TestReconnectResume_HandlerResumesPastOriginalTTL(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	s.deps = &Dependencies{GHAppAuth: newSucceedingAppAuth(t, "ghs_resume_4260")}
+	s.contributeHub.server = s
+	seedOneIssue(s, 4203, "Podman: evaluate Quadlet .kube reuse")
+
+	conn, reg := registerAndAuth(t, s, ts, "resume-reconnect-user")
+
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" || assign.Number != 4203 {
+		t.Fatalf("expected task_assign for #4203, got type=%s number=%d", assign.Type, assign.Number)
+	}
+	if assign.TaskGen == 0 {
+		t.Fatalf("task_assign carried no task_gen — the relay would have nothing to echo")
+	}
+	identity := onlyLeaseIdentity(t, s.contributeHub)
+
+	// The task has been working for longer than a lease window. Before #4260 the
+	// registry entry aged out here even though the relay never stopped reporting;
+	// now the last progress report carries it forward.
+	backdateLease(t, s.contributeHub, identity, time.Now().Add(-(leaseTTL + 10*time.Minute)))
+	conn.WriteJSON(WSMessage{
+		Type: "task_progress", Seq: 2, TaskID: assign.TaskID, TaskGen: assign.TaskGen,
+		Repo: assign.Repo, Number: assign.Number, Status: "working",
+	})
+
+	// The socket drops. The disconnect defer runs: currentTask cleared, generation
+	// bumped on the dead connection, cooldown booked. The hub's read loop consumes
+	// this connection's frames in order, so the progress above is already processed
+	// by the time the close is seen — no sleep needed, and deliberately no assertion
+	// on the lease here: the point of the test is what the RECONNECT gets back.
+	conn.Close()
+	waitForFailureCooldown(t, s.contributeHub, "myorg/repo1", 4203)
+
+	// The relay reconnects one backoff later with the SAME registration identity and
+	// re-asserts the task it is still working, carrying the generation it was
+	// originally assigned.
+	conn2, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("reconnect dial: %v", err)
+	}
+	defer conn2.Close()
+	readMsg(t, conn2) // auth_challenge
+	conn2.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn2) // auth_ok
+
+	conn2.WriteJSON(WSMessage{Type: "task_accepted", Seq: 3, TaskID: assign.TaskID})
+	conn2.WriteJSON(WSMessage{
+		Type: "task_progress", Seq: 4, TaskID: assign.TaskID, TaskGen: assign.TaskGen,
+		Repo: assign.Repo, Number: assign.Number, Kind: "issue", Title: assign.Title,
+		Status: "working",
+	})
+
+	// Nothing may come back revoking or re-assigning the task. A token_refresh is the
+	// expected consequence of a successful resume (resumeTaskToken re-arms the
+	// credential), so it is accepted, not treated as noise.
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		conn2.SetReadDeadline(time.Now().Add(remaining))
+		_, raw, rerr := conn2.ReadMessage()
+		if rerr != nil {
+			break
+		}
+		var m WSMessage
+		if json.Unmarshal(raw, &m) != nil {
+			continue
+		}
+		switch m.Type {
+		case "task_revoke":
+			t.Fatalf("#4260: the reconnecting relay was told %q and lost its in-flight "+
+				"work — the resume the disconnect path documents did not happen", m.Reason)
+		case "task_assign":
+			t.Fatalf("#4260: the reconnecting relay was handed a NEW assignment for "+
+				"%s#%d — this is the frame that types a fresh prompt into a pane whose "+
+				"CLI is still mid-turn", m.Repo, m.Number)
+		}
+	}
+
+	// And the hub must now actually hold the task on the new connection.
+	if !hubHoldsTask(s.contributeHub, assign.TaskID) {
+		t.Fatalf("#4260: the resume produced no revoke, but the hub does not hold the " +
+			"task on the reconnected session either")
+	}
+}
+
+// --- 2. A dropped socket is not a failure of the issue -------------------------
+
+// TestDisconnectCooldown_DoesNotQuarantineTheIssue is the second, separable half of
+// #4260. The disconnect cooldown exists to stop a SECOND session picking up the issue
+// during the reconnect window (#2356). Routing it through recordTaskFailure also
+// advanced the consecutive-failure counter, so three dropped sockets on one issue —
+// ordinary on a flaky connection across a long session — quarantined a perfectly
+// workable issue for quarantineCooldownHours.
+func TestDisconnectCooldown_DoesNotQuarantineTheIssue(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	for i := 0; i < consecutiveFailureQuarantineThreshold; i++ {
+		hub.bookReleaseCooldown("myorg/repo1", 4144)
+	}
+
+	if got := hub.recentFailureCount("myorg/repo1", 4144); got != 0 {
+		t.Fatalf("#4260: %d disconnects advanced the consecutive-failure counter to %d — "+
+			"nothing failed", consecutiveFailureQuarantineThreshold, got)
+	}
+
+	hub.completedMu.Lock()
+	window := hub.failureCooldownForLocked("myorg/repo1#4144")
+	hub.completedMu.Unlock()
+	if window != failedTaskCooldownMinutes*time.Minute {
+		t.Fatalf("#4260: %d disconnects earned the %v quarantine instead of the %v "+
+			"reconnect cooldown", consecutiveFailureQuarantineThreshold,
+			quarantineCooldownHours*time.Hour, failedTaskCooldownMinutes*time.Minute)
+	}
+}
+
+// TestDisconnectCooldown_KeepsTheDuplicatePRGuard proves the #2356 guarantee is
+// untouched: the cooldown the disconnect books still excludes the issue from
+// selection, which is the whole reason it is booked.
+func TestDisconnectCooldown_KeepsTheDuplicatePRGuard(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	if hub.isTaskInFailureCooldown("myorg/repo1", 4203) {
+		t.Fatalf("issue unexpectedly in cooldown before the release")
+	}
+	hub.bookReleaseCooldown("myorg/repo1", 4203)
+	if !hub.isTaskInFailureCooldown("myorg/repo1", 4203) {
+		t.Fatalf("#2356: a released issue was instantly re-admissible — a second " +
+			"session could take it while the original relay reconnects, and both file PRs")
+	}
+}
+
+// TestDisconnectCooldown_RealFailuresStillQuarantine is the control. Dropping the
+// counter for disconnects must not disarm quarantine for things that genuinely fail:
+// task_failed, the relay's own watchdog abandoning via "ready", and the wedged-task
+// lease backstop all still call recordTaskFailure and still count.
+func TestDisconnectCooldown_RealFailuresStillQuarantine(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	for i := 0; i < consecutiveFailureQuarantineThreshold; i++ {
+		hub.recordTaskFailure("myorg/repo1", 99, false)
+	}
+	if got := hub.recentFailureCount("myorg/repo1", 99); got != consecutiveFailureQuarantineThreshold {
+		t.Fatalf("real failures stopped counting: got %d, want %d",
+			got, consecutiveFailureQuarantineThreshold)
+	}
+	hub.completedMu.Lock()
+	window := hub.failureCooldownForLocked("myorg/repo1#99")
+	hub.completedMu.Unlock()
+	if window != quarantineCooldownHours*time.Hour {
+		t.Fatalf("#2435 regression: %d real failures no longer quarantine (window %v)",
+			consecutiveFailureQuarantineThreshold, window)
+	}
+
+	// A disconnect mixed in with real failures neither adds to nor erases the count.
+	hub.bookReleaseCooldown("myorg/repo1", 99)
+	if got := hub.recentFailureCount("myorg/repo1", 99); got != consecutiveFailureQuarantineThreshold {
+		t.Fatalf("a disconnect changed an existing failure count: got %d, want %d",
+			got, consecutiveFailureQuarantineThreshold)
+	}
+}
+
+// TestDisconnectCooldown_HandlerBooksWithoutCounting drives a real socket drop through
+// the disconnect defer and asserts both halves at once: the #2356 cooldown is on the
+// issue, and the quarantine counter never moved.
+func TestDisconnectCooldown_HandlerBooksWithoutCounting(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+	seedOneIssue(s, 4260, "Relay reconnect resume")
+
+	conn, _ := registerAndAuth(t, s, ts, "disconnect-count-user")
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+	assign := readMsg(t, conn)
+	if assign.Type != "task_assign" || assign.Number != 4260 {
+		t.Fatalf("expected task_assign for #4260, got type=%s number=%d", assign.Type, assign.Number)
+	}
+
+	conn.Close()
+	waitForFailureCooldown(t, s.contributeHub, "myorg/repo1", 4260)
+
+	if got := s.contributeHub.recentFailureCount("myorg/repo1", 4260); got != 0 {
+		t.Fatalf("#4260: the disconnect handler counted a dropped socket as a failure "+
+			"of the issue (count=%d)", got)
+	}
+}
+
+// --- helpers -------------------------------------------------------------------
+
+// seedOneIssue puts a single admissible issue in the status payload so `ready`
+// yields a task_assign for it.
+func seedOneIssue(s *Server, number int, title string) {
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{{
+			Name: "repo1",
+			Full: "myorg/repo1",
+			ActionableIssues: []any{map[string]any{
+				"number": float64(number),
+				"title":  title,
+				"url":    "https://github.com/myorg/repo1/issues/" + itoa(number),
+				"author": "someone",
+			}},
+		}},
+	}
+	s.statusMu.Unlock()
+}
+
+// onlyLeaseIdentity returns the identity of the single lease the hub holds, failing
+// if there is not exactly one — the tests below assume one assignment in flight.
+func onlyLeaseIdentity(t *testing.T, h *ContributeWSHub) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.leaseMu.Lock()
+		n := len(h.leases)
+		var id string
+		for k := range h.leases {
+			id = k
+		}
+		h.leaseMu.Unlock()
+		if n == 1 {
+			return id
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected exactly one server-issued lease, found %d", n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func leaseExpiry(t *testing.T, h *ContributeWSHub, identity string) time.Time {
+	t.Helper()
+	h.leaseMu.Lock()
+	defer h.leaseMu.Unlock()
+	l, ok := h.leases[identity]
+	if !ok {
+		t.Fatalf("no lease recorded for identity %q", identity)
+	}
+	return l.expiresAt
+}
+
+// backdateLease rewinds a lease's expiry to simulate a task that has been working
+// long enough for the pre-#4260 assignment-anchored window to have lapsed.
+func backdateLease(t *testing.T, h *ContributeWSHub, identity string, lastRenewal time.Time) {
+	t.Helper()
+	h.leaseMu.Lock()
+	defer h.leaseMu.Unlock()
+	l, ok := h.leases[identity]
+	if !ok {
+		t.Fatalf("no lease recorded for identity %q", identity)
+	}
+	l.expiresAt = lastRenewal.Add(leaseTTL)
+}
+
+func waitForFailureCooldown(t *testing.T, h *ContributeWSHub, repo string, number int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if h.isTaskInFailureCooldown(repo, number) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("disconnect did not book the #2356 cooldown for %s#%d", repo, number)
+}
+
+// hubHoldsTask reports whether any live connection currently holds the given task.
+func hubHoldsTask(h *ContributeWSHub, taskID string) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mu.RLock()
+		for _, c := range h.connections {
+			c.mu.Lock()
+			held := c.currentTask != nil && c.currentTask.TaskID == taskID
+			c.mu.Unlock()
+			if held {
+				h.mu.RUnlock()
+				return true
+			}
+		}
+		h.mu.RUnlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -490,12 +490,25 @@ type taskLease struct {
 	expiresAt time.Time
 }
 
-// leaseTTL is how long a hub-issued task lease remains re-adoptable after
-// assignment (kubestellar/hive C4). It is deliberately aligned with wsTaskTimeout
-// (the wedged-task backstop): a task that has been reclaimed by the lease-TTL
-// backstop is also past its re-adoption window, so a relay that reconnects after
-// its task was auto-released cannot resurrect ownership from the client side. A
-// resume presented after this window is treated as a stale/forged claim and
+// leaseTTL is how long a hub-issued task lease remains re-adoptable after the last
+// time the relay proved it was still working (kubestellar/hive C4). It is aligned
+// with wsTaskTimeout (the wedged-task backstop) and, since #4260, is measured from
+// the SAME event: recordLease stamps it at assignment and renewLease re-stamps it on
+// every accepted task_progress, exactly where reclaimExpiredLeases re-stamps
+// lastLeaseRenew. The two clocks therefore expire together, which is what makes the
+// intended invariant true — a task past its re-adoption window is also one the
+// wedged-task backstop has reclaimed, and a task the backstop considers alive is
+// still re-adoptable.
+//
+// #4260: before that renewal existed, expiresAt was stamped once at assignment and
+// never moved, so the alignment was only nominal. A perfectly healthy task that had
+// been reporting progress for longer than leaseTTL was NEVER reclaimed (correctly —
+// it was alive) yet its lease had silently expired, so the first socket drop after
+// that point could not be resumed: lookupLease rejected the reconnecting relay,
+// the hub sent task_revoke, and the same issue was re-assigned as a new task,
+// typing a fresh prompt into a pane whose CLI was still mid-turn.
+//
+// A resume presented after this window is treated as a stale/forged claim and
 // rejected; the relay simply asks for fresh work via "ready".
 const leaseTTL = wsTaskTimeout
 
@@ -521,6 +534,31 @@ func (h *ContributeWSHub) recordLease(identity, taskID, repo string, number int,
 		tier:      tier,
 		gen:       gen,
 		expiresAt: now.Add(leaseTTL),
+	}
+	h.leaseMu.Unlock()
+}
+
+// renewLease extends an identity's server-issued lease window when the relay proves
+// it is still working the task (kubestellar/hive#4260). It is the lease-registry half
+// of the lastLeaseRenew stamp that reclaimExpiredLeases reads: both are driven by the
+// same accepted task_progress, so "still alive" and "still re-adoptable" cannot drift
+// apart and a long-running task does not lose the ability to survive a reconnect
+// simply because it has been working for longer than leaseTTL.
+//
+// It grants NOTHING a caller did not already have. The lease is only touched when it
+// is already the one recorded for this identity AND is for this exact taskID, so a
+// connection can neither renew another identity's lease nor extend a lease for a task
+// it does not hold; a revoked lease is absent and stays absent. Only expiresAt moves —
+// the {task, repo, number, tier, generation} tuple lookupLease matches on is never
+// rewritten, so the C4 exact-match contract and the #2568 generation fence are
+// untouched.
+func (h *ContributeWSHub) renewLease(identity, taskID string, now time.Time) {
+	if identity == "" || taskID == "" {
+		return
+	}
+	h.leaseMu.Lock()
+	if l, ok := h.leases[identity]; ok && l.taskID == taskID {
+		l.expiresAt = now.Add(leaseTTL)
 	}
 	h.leaseMu.Unlock()
 }
@@ -1561,6 +1599,37 @@ func (h *ContributeWSHub) recordTaskFailure(repo string, number int, permanent b
 	h.saveFailedTasks()
 }
 
+// bookReleaseCooldown stamps the SAME short cooldown recordTaskFailure stamps, but
+// does NOT advance the issue's consecutive-failure counter (kubestellar/hive#4260).
+//
+// It exists for releases that are not failures OF THE ISSUE. The disconnect path
+// books a cooldown for one reason (#2356): while a relay is reconnecting, its issue
+// has dropped out of activeIssues — the only double-assign guard — and selectTask
+// could hand the same issue to a second session, so both reach "open a PR" and file
+// duplicates. That guarantee needs the timestamp and nothing else.
+//
+// Routing it through recordTaskFailure also incremented consecutiveFailures, so three
+// dropped sockets on one issue — unremarkable on a flaky connection across a long
+// session — pushed it past consecutiveFailureQuarantineThreshold and parked a
+// perfectly workable issue for quarantineCooldownHours with nothing having actually
+// failed. The counter also feeds recentFailureCount, which deprioritises the issue
+// behind never-failed peers in selectTask, so a disconnect quietly demoted work that
+// was progressing fine.
+//
+// The #2356 window is byte-for-byte unchanged: failedTasks carries the same timestamp,
+// isTaskInFailureCooldown reads it the same way, and with the count left at zero
+// failureCooldownForLocked returns the same failedTaskCooldownMinutes it always did.
+// Paths where the release IS evidence about the issue — task_failed, the relay's own
+// watchdog giving up via "ready", and the wedged-task lease backstop — deliberately
+// keep calling recordTaskFailure and keep counting.
+func (h *ContributeWSHub) bookReleaseCooldown(repo string, number int) {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	h.failedTasks[key] = time.Now()
+	h.completedMu.Unlock()
+	h.saveFailedTasks()
+}
+
 // failureCooldownForLocked returns how long, from the last failure time, an
 // issue should be excluded from selection. It is the SHORT
 // failedTaskCooldownMinutes normally, or the LONGER quarantineCooldownHours once
@@ -2521,16 +2590,24 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				// window (BASE_RECONNECT_DELAY_MS..MAX_RECONNECT_DELAY_MS, i.e. 1s–60s)
 				// while the original relay — which keeps currentTask locally and
 				// re-asserts it via task_progress on reconnect — is still working it.
-				// Both sessions then reach "open a PR" and file duplicates. Mirror the
-				// task_failed path (#2435) and book the SHORT non-permanent failure
-				// cooldown so the issue is not instantly re-admissible. The short
+				// Both sessions then reach "open a PR" and file duplicates. Book the
+				// SHORT cooldown so the issue is not instantly re-admissible. The short
 				// window comfortably outlasts the reconnect backoff, so the returning
 				// session re-asserts and resumes (repopulating activeIssues) before the
-				// cooldown lapses; a completion later resets the failure ledger. Only
-				// real issue tasks are booked — synthetic pr-review tasks carry
-				// Number == 0 and must not poison an issue key.
+				// cooldown lapses — which is the contract #4260 restored by renewing
+				// the lease on every progress report, so a task alive longer than
+				// leaseTTL is still re-adoptable. Only real issue tasks are booked —
+				// synthetic pr-review tasks carry Number == 0 and must not poison an
+				// issue key.
+				//
+				// #4260: bookReleaseCooldown rather than recordTaskFailure. The window
+				// is identical; what is dropped is the consecutive-failure increment,
+				// which turned three dropped sockets on one issue into a
+				// quarantineCooldownHours quarantine of an issue nobody had failed.
+				// The #2356 duplicate-PR guarantee lives entirely in the timestamp and
+				// is unaffected.
 				if abandonedTask.Number > 0 {
-					h.recordTaskFailure(abandonedTask.Repo, abandonedTask.Number, false)
+					h.bookReleaseCooldown(abandonedTask.Repo, abandonedTask.Number)
 				}
 			}
 			h.mu.Lock()
@@ -2946,6 +3023,12 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					contributor.tmuxOutput = msg.TmuxOutput
 					contributor.mu.Unlock()
 
+					// #4260: a resume is itself proof of life, so restart the lease
+					// window alongside lastLeaseRenew. Without this a relay that
+					// reconnected twice inside one lease window would be refused the
+					// second time even though it never stopped working.
+					h.renewLease(identity, lease.taskID, time.Now())
+
 					h.logger.Info("[contribute-ws] task resumed from server-issued lease",
 						"username", contributor.profile.GitHubUsername,
 						"task", lease.taskID, "repo", lease.repo, "number", lease.number)
@@ -3005,7 +3088,22 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				// never reclaimed) from "connected but wedged" (lease goes stale and
 				// cleanupLoop reclaims it after wsTaskTimeout).
 				contributor.lastLeaseRenew = time.Now()
+				// #4260: the task id is taken from the hub's OWN record of what this
+				// connection holds, never from msg.TaskID, so the renewal cannot be
+				// pointed at a task the client merely names. Captured here under the
+				// connection lock and applied below without it, matching how the other
+				// release paths call into the lease registry.
+				heldTaskID := ""
+				if contributor.currentTask != nil {
+					heldTaskID = contributor.currentTask.TaskID
+				}
 				contributor.mu.Unlock()
+				// #4260: keep the lease registry's expiry on the same clock as
+				// lastLeaseRenew above. Stamping it only at assignment meant a task
+				// still healthily reporting progress past leaseTTL was never reclaimed
+				// yet could no longer be re-adopted, so the next socket drop cost the
+				// relay its in-flight work.
+				h.renewLease(identityOf(contributor), heldTaskID, time.Now())
 			}
 
 		case "task_complete":


### PR DESCRIPTION
## What

A relay that reconnects inside the backoff window can now resume the task it never stopped working. Closes #4260.

Two independent defects sat behind the one report.

## 1. The lease expired under work the hub considered alive

`taskLease.expiresAt` was stamped once by `recordLease` at assignment and never moved again. `reclaimExpiredLeases` measures liveness from `lastLeaseRenew`, which every `task_progress` refreshes. The `leaseTTL` comment asserted the two were aligned:

> It is deliberately aligned with `wsTaskTimeout` (the wedged-task backstop): a task that has been reclaimed by the lease-TTL backstop is also past its re-adoption window

They were only *nominally* aligned. One clock is renewable; the other was absolute from assignment. So a task reporting progress for longer than `leaseTTL` was correctly **never reclaimed** — it was plainly alive — while its lease had silently expired half an hour earlier. `lookupLease` then rejected the reconnecting relay, and `selectTask` handed the same issue back as a fresh assignment with a fresh 30-minute budget, typing a new prompt into a pane whose CLI was mid-turn.

Both captures in the issue are long-running tasks, and repro 1 shows a token refresh immediately before the drop — which only happens well past the point where the lease had already gone.

`renewLease` puts the registry's expiry on the same clock as `lastLeaseRenew`, called from the two places that already stamp it: an accepted `task_progress`, and a successful resume.

**It grants nothing.** The lease is touched only when it is already the one recorded for that identity *and* is for that exact task id, so a connection can neither renew another identity's lease nor extend one for a task it does not hold; a revoked lease is absent and stays absent. Only `expiresAt` moves — the `{task, repo, number, tier, generation}` tuple `lookupLease` matches on is never rewritten, so the C4 exact-match contract and the #2568 generation fence are untouched. The progress path takes the task id from the hub's own record of what the connection holds, never from `msg.TaskID`, so a renewal cannot be pointed at a task the client merely names.

**The backstop is unchanged.** Renewal extends the window; it does not make a lease immortal. A relay that stops reporting is past re-adoption exactly `leaseTTL` after its *last report* — the same moment `reclaimExpiredLeases` reclaims it. That is the invariant the comment always claimed, now true in both directions.

## 2. A dropped socket was counted as a failure of the issue

This is the half the issue notes "stands on its own", and it does.

The disconnect books a short cooldown for one reason (#2356): the issue has dropped out of `activeIssues` — the only double-assign guard — so `selectTask` could hand it to a second session during the reconnect window and both would file PRs. That guarantee lives entirely in the timestamp.

Routing it through `recordTaskFailure` also advanced `consecutiveFailures`. Three drops on one issue crossed `consecutiveFailureQuarantineThreshold` and parked a workable issue for `quarantineCooldownHours` with nothing having failed. The counter also feeds `recentFailureCount`, so a disconnect quietly demoted the issue behind never-failed peers in selection.

`bookReleaseCooldown` stamps the identical cooldown without the increment. The #2356 window is byte-for-byte what it was: same timestamp, same reader, and with the count left at zero `failureCooldownForLocked` returns the same `failedTaskCooldownMinutes`. Paths where the release *is* evidence about the issue — `task_failed`, the relay's own watchdog abandoning via `ready`, and the wedged-task lease backstop — deliberately keep calling `recordTaskFailure` and keep counting, which a control test pins.

## On the contract question

The issue asks for a steer between **A** (resume is supposed to work) and **B** (resume was superseded by the #2568 fencing). The code answers it: there is an entire server-authoritative resume path — `lookupLease` → adopt-from-lease → `resumeTaskToken` — whose only purpose is to let a reconnecting relay resume, and reading B would make all of it dead code. This is A, and the defect is that the lease's expiry clock did not match the liveness clock it claimed to match.

**Deliberately not included:** a send gate for a pane whose CLI is still working. That is B's remedy for the genuinely-unresumable cases (operator yank, a relay silent past the lease window), it changes relay behaviour rather than hub behaviour, and it interacts with `paneIsRunningShell` (#2203) in ways worth deciding separately. Happy to open it as its own issue.

Also untouched, though they share the pattern: `bookAndRevokeReleased` (operator requeue/yank) still books through `recordTaskFailure`, so an operator action still advances the quarantine counter. That looked like the same class of thing, but it is operator-visible behaviour nobody asked to change, so I left it alone rather than widen the scope.

## Verification

10 tests in `contribute_reconnect_resume_test.go`.

I checked they are not vacuous — against the unfixed call sites three fail, and the end-to-end one fails with the reported string **verbatim**:

```
--- FAIL: TestReconnectResume_ProgressHandlerRenewsLease
    #4260: task_progress did not renew the lease registry — expiresAt is still …
--- FAIL: TestReconnectResume_HandlerResumesPastOriginalTTL
    #4260: the reconnecting relay was told "no active lease for this task" and lost
    its in-flight work — the resume the disconnect path documents did not happen
--- FAIL: TestDisconnectCooldown_HandlerBooksWithoutCounting
    #4260: the disconnect handler counted a dropped socket as a failure of the issue (count=1)
```

With the fix:

```
$ go test ./pkg/dashboard/ -short -race -count=1
ok  	github.com/kubestellar/hive/pkg/dashboard	57.391s
```

The full package is clean, including the #2356 (`TestDupePR_DisconnectReleaseRecordsCooldown`), #2435, #2568 and C4 suites this sits on top of. `TestC4_ResumeOnlyAgainstServerLease_ExactRepo`'s "an EXPIRED lease was still re-adoptable" leg still passes — that lease is never renewed, so it ages out exactly as before.

Coverage:

| Test | Pins |
| --- | --- |
| `LeaseSurvivesBeyondTTLWhileProgressing` | the regression: progress for 2× `leaseTTL`, still re-adoptable |
| `LeaseStillExpiresWhenProgressStops` | renewal is not immortality; the stale entry is still dropped |
| `RenewalGrantsNoAuthority` | cannot create, cross identities, name another task, or resurrect a revoked lease |
| `RenewalPreservesTheMatchTuple` | only `expiresAt` moves; wrong gen / gen 0 / wrong repo / wrong number still rejected on a renewed lease |
| `ProgressHandlerRenewsLease` | the renewal is wired into the message path |
| `HandlerResumesPastOriginalTTL` | end-to-end: assign → work past TTL → drop → reconnect → resumed, no revoke, no re-assign |
| `DisconnectCooldown_DoesNotQuarantineTheIssue` | 3 disconnects ≠ quarantine |
| `DisconnectCooldown_KeepsTheDuplicatePRGuard` | #2356 still holds |
| `DisconnectCooldown_RealFailuresStillQuarantine` | control: real failures still count |
| `DisconnectCooldown_HandlerBooksWithoutCounting` | a real socket drop books the cooldown and counts nothing |

Note: `go test ./...` also hangs in `src/test/` here, but that is the browser-driven inception suite dialling `ws://127.0.0.1:9222` for a CDP endpoint that does not exist in my sandbox. It is outside the `./pkg/...` + `./cmd/...` partitions CI runs and is unrelated to this change.

## Files

- `src/pkg/dashboard/contribute_ws.go` — `renewLease`, `bookReleaseCooldown`, the two call sites, and a `leaseTTL` doc comment that now describes what the code does
- `src/pkg/dashboard/contribute_reconnect_resume_test.go` — the tests
- `src/docs/contributor-relay.md` — a "Reconnecting without losing in-flight work" section: what has to line up for a resume to work, and why a dropped socket is not a failed issue

— hive: backend=claude model=claude-opus-5
