### PR TITLE
🐛 fix(pluk): write the publisher's log, and read the key pluk actually sets

### DIFF
--- a/src/docs/agent-logging.md
+++ b/src/docs/agent-logging.md
@@ -68,6 +68,28 @@ Session names follow Hive's `hive-<agent-name>` convention (e.g.
 `hive-brainstorm.jsonl` for the `brainstorm` agent). Each line is one JSON
 object, newline-delimited (JSONL), appended as the agent produces output.
 
+The file is written by a shell redirect, not by pluk. `pluk watch` classifies
+its stdin and prints events to stdout; it opens no file of its own. `tmux
+pipe-pane` feeds the pane into that command's stdin but does nothing with its
+stdout, so the publisher invocation in `pkg/agent/manager.go` has to end in
+`>> /var/run/pluk/logs/<session>.jsonl` for anything to be written at all. It
+did not between [#1759](https://github.com/kubestellar/hive/pull/1759) — which
+replaced the Go `pluk-publish` binary, a publisher that wrote the log itself,
+with the TypeScript `pluk watch` — and
+[#4285](https://github.com/kubestellar/hive/issues/4285). Throughout that
+window this directory was empty and every consumer below was reading files that
+did not exist.
+
+Hive pre-creates each session log `0660` and `dev:node` before attaching
+pipe-pane. `hive-panes` is run by one agent to read every *other* agent's log,
+and agent UIDs differ, so the shared `node` group is what makes cross-agent
+reads work — leaving creation to the shell's `>>` would take whatever umask the
+pane shell carries and a tight one yields a log no peer can read.
+
+Nothing rotates or caps these files. `hive-panes` only ever reads the last 2000
+lines and the inception subscriber seeks to the end, so no consumer needs the
+history, but the files themselves grow for the life of the container.
+
 The event envelope, as read by Hive's own code, is:
 
 ```json
@@ -79,13 +101,20 @@ keys depend on `type`. Hive's dashboard subscribes to this stream for the
 `brainstorm` session (`pkg/dashboard/inception_watcher.go`, `plukEvent`) and
 reacts to a subset of event types:
 
-- `raw_output` — captured pane output. `hive-panes.sh` reads the text from
-  `data.line`; the dashboard's own Go subscriber reads it from `data.message`
-  (see `handlePlukEvent` in `inception_watcher.go`). Both are read from real
-  pluk output in this codebase — if you are writing a new consumer, check
-  both keys rather than assuming one, since pluk's own event shape is outside
-  this repo's control and the two existing readers do not agree on the field
-  name.
+- `raw_output` — captured pane output. The text is on `data.line`, and only
+  there. Both readers now agree: `hive-panes.sh` has always read `data.line`,
+  and the dashboard's Go subscriber (`handlePlukEvent` in
+  `inception_watcher.go`) read `data.message` until
+  [#4285](https://github.com/kubestellar/hive/issues/4285) corrected it, which
+  had left its whole `raw_output` arm dead. Earlier revisions of this page
+  advised new consumers to check both keys; that was wrong, and generalised
+  from the `error`/`rate_limit` shape below. pluk builds the event as
+  `createEvent(..., 'raw_output', { line })` in `dist/classifier.js`.
+
+  `raw_output` is opt-in: `pluk watch` defaults `includeRaw` to false, so the
+  publisher has to pass `--include-raw` or no such event is ever emitted. It is
+  the only event type `hive-panes.sh` consumes, so peer awareness depends on
+  that flag.
 - `state_change` — `data.state` is `"working"` or `"idle"`. The inception
   watcher uses idle transitions to decide when to re-kick a stalled agent or
   fall back to auto-generating questions/facts.

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1392,9 +1392,19 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		if backend == "" || IsInferenceBackend(backend) {
 			backend = "claude"
 		}
-		pipePaneCmd := fmt.Sprintf("%s watch %s --cli=%s", plukPath, agent.tmuxSession, backend)
+		logFile, err := ensurePlukLogFile(plukRunDir, agent.tmuxSession)
+		if err != nil {
+			// Non-fatal, and deliberately not a reason to skip the attach: the
+			// shell's own `>>` will still create the file. It may land 0600 under
+			// a tight umask, which costs peer readability but not the agent's own
+			// logging, and that is strictly better than no publisher at all.
+			m.logger.Warn("pluk log file setup failed; peer agents may not be able to read this session's log",
+				"agent", agent.Name, "error", err)
+			logFile = plukSessionLogPath(plukRunDir, agent.tmuxSession)
+		}
+		pipePaneCmd := plukPipePaneCmd(plukPath, agent.tmuxSession, backend, logFile)
 		_ = m.tmuxCmd(agent, "pipe-pane", "-t", agent.tmuxSession, "-o", pipePaneCmd).Run()
-		m.logger.Info("pluk publisher attached", "agent", agent.Name, "cli", backend)
+		m.logger.Info("pluk publisher attached", "agent", agent.Name, "cli", backend, "log", logFile)
 	}
 
 	return nil

--- a/src/pkg/agent/pluk_dirs.go
+++ b/src/pkg/agent/pluk_dirs.go
@@ -15,6 +15,55 @@ const (
 // directory to unrelated container users.
 var plukSharedDirMode = os.FileMode(0o770) | os.ModeSetgid
 
+// plukLogFileMode matches plukSharedDirMode's intent one level down. hive-panes
+// is run BY one agent to read every OTHER agent's log, so a session log written
+// by uid A has to be readable by uid B; the shared node group is what makes that
+// work, exactly as it does for the directory.
+//
+// The file has to be created here rather than left to the shell. pipe-pane's
+// `>>` would create it under whatever umask the agent's pane shell carries, and
+// a 0077 umask yields a 0600 log that no peer can read — the same class of
+// silent breakage permissions_watcher.go exists to repair for agent config
+// (#3882). Creating it up front with an explicit mode means `>>` only ever
+// appends to a file that is already correct.
+var plukLogFileMode = os.FileMode(0o660)
+
+// plukSessionLogPath is where pluk's events for one tmux session are appended.
+// It mirrors what pluk's own `attach` builds — <run-dir>/logs/<session>.jsonl —
+// and is the path src/deploy/hive-panes.sh globs and
+// src/pkg/dashboard/inception_watcher.go tails.
+func plukSessionLogPath(runDir, session string) string {
+	return filepath.Join(runDir, "logs", session+".jsonl")
+}
+
+// ensurePlukLogFile creates (or leaves alone) the session's JSONL log with a
+// mode peer agents can read, and returns its path. Both the O_CREATE mode and a
+// following Chmod are needed: O_CREATE is umask-filtered, and an existing file
+// from an earlier run under a tighter umask has to be widened back to the shared
+// mode rather than inherited as-is.
+func ensurePlukLogFile(runDir, session string) (string, error) {
+	path := plukSessionLogPath(runDir, session)
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, plukLogFileMode)
+	if err != nil {
+		return "", fmt.Errorf("creating %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("closing %s: %w", path, err)
+	}
+
+	if os.Geteuid() == 0 {
+		if err := os.Chown(path, DevUID, NodeGID); err != nil {
+			return "", fmt.Errorf("chowning %s to %d:%d: %w", path, DevUID, NodeGID, err)
+		}
+	}
+	if err := os.Chmod(path, plukLogFileMode); err != nil {
+		return "", fmt.Errorf("chmoding %s to %s: %w", path, plukLogFileMode, err)
+	}
+
+	return path, nil
+}
+
 func ensurePlukRunDirs(runDir string) error {
 	for _, name := range []string{"logs", "commands"} {
 		dir := filepath.Join(runDir, name)
@@ -31,4 +80,45 @@ func ensurePlukRunDirs(runDir string) error {
 		}
 	}
 	return nil
+}
+
+// plukPipePaneCmd builds the shell command tmux pipe-pane runs for one agent
+// session (kubestellar/hive#4285).
+//
+// `pluk watch` classifies its stdin and writes the resulting events to STDOUT.
+// It opens no file of its own — the published package contains no
+// createWriteStream, appendFile, writeFile or openSync in any module — and
+// pipe-pane only feeds the pane into the command's stdin; it does nothing with
+// the command's stdout. So without the `>>` here the events are produced and
+// discarded, /var/run/pluk/logs stays empty, and both consumers
+// (src/deploy/hive-panes.sh, src/pkg/dashboard/inception_watcher.go) wait on
+// files that never appear.
+//
+// The redirect and --include-raw were lost together in #1759, which replaced
+// the Go `pluk-publish` binary — a publisher, which wrote the log itself — with
+// the TypeScript `pluk watch`. That migration translated the flags
+// (`--session X --cli Y` became `watch X --cli=Y`) but not the file-writing half
+// the rewrite had moved into the shell. hive-panes.sh predates #1759 and has
+// only ever read raw_output, so restoring both is restoring the contract it was
+// written against, not picking a new one.
+//
+// --include-raw is load-bearing, not cosmetic: watch defaults includeRaw to
+// false, and raw_output is the ONLY event type hive-panes.sh consumes. Pluk's
+// own `attach` passes it by default (opt out with --no-raw).
+//
+// PLUK_RUN_DIR is inert for `watch` on 0.8.0 — only subscribe, send and
+// sessions read it — but it is what pluk's own attach exports, so a later pluk
+// that does consult it resolves to the hive run dir instead of /tmp/pluk-run.
+//
+// Every operand is shell-quoted. The whole string is handed to a shell by tmux,
+// and the log path now embeds the session name, so a name carrying a space or a
+// shell metacharacter would otherwise split the redirect target.
+func plukPipePaneCmd(plukPath, session, backend, logFile string) string {
+	return fmt.Sprintf("PLUK_RUN_DIR=%s %s watch %s --cli=%s --include-raw >> %s",
+		shellQuote(plukRunDir),
+		shellQuote(plukPath),
+		shellQuote(session),
+		shellQuote(backend),
+		shellQuote(logFile),
+	)
 }

--- a/src/pkg/agent/pluk_publisher_test.go
+++ b/src/pkg/agent/pluk_publisher_test.go
@@ -1,0 +1,205 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pluk_publisher_test.go covers kubestellar/hive#4285: the pipe-pane invocation
+// that is supposed to produce /var/run/pluk/logs/<session>.jsonl.
+//
+// `pluk watch` classifies stdin and prints events to stdout; it opens no file.
+// tmux pipe-pane feeds the pane into that command's stdin and does nothing with
+// its stdout. So the redirect is the only thing that writes the log, and
+// --include-raw is the only thing that puts raw_output in it — which is the sole
+// event type src/deploy/hive-panes.sh reads. Both were dropped in #1759 when the
+// Go `pluk-publish` binary (a publisher, which wrote the file itself) was
+// replaced by `pluk watch`, and the log has been empty ever since.
+
+// TestPlukPipePaneCmdRedirectsToTheSessionLog is the core regression. Without a
+// redirect the classified events go to a stdout nothing is reading, and every
+// consumer of the log directory waits forever on a file that is never created.
+func TestPlukPipePaneCmdRedirectsToTheSessionLog(t *testing.T) {
+	logFile := plukSessionLogPath(plukRunDir, "hive-brainstorm")
+	cmd := plukPipePaneCmd("/usr/bin/pluk", "hive-brainstorm", "claude", logFile)
+
+	if !strings.Contains(cmd, ">>") {
+		t.Fatalf("#4285: the pipe-pane command has no redirect, so pluk's events go "+
+			"to a stdout nobody reads and the log file is never written: %s", cmd)
+	}
+
+	// Appending, never truncating: a re-attach (agent restart, pane respawn)
+	// must not blow away the history hive-panes is about to read.
+	if strings.Contains(cmd, "> "+shellQuote(logFile)) && !strings.Contains(cmd, ">> "+shellQuote(logFile)) {
+		t.Fatalf("the redirect truncates instead of appending: %s", cmd)
+	}
+	if !strings.HasSuffix(cmd, ">> "+shellQuote(logFile)) {
+		t.Fatalf("the command does not end by appending to %s: %s", logFile, cmd)
+	}
+}
+
+// TestPlukPipePaneCmdRequestsRawOutput pins the second half. `pluk watch`
+// defaults includeRaw to false, so without the flag the log exists but contains
+// no raw_output at all — and raw_output is the only event hive-panes.sh keeps.
+func TestPlukPipePaneCmdRequestsRawOutput(t *testing.T) {
+	cmd := plukPipePaneCmd("/usr/bin/pluk", "hive-architect", "codex", "/var/run/pluk/logs/hive-architect.jsonl")
+
+	if !strings.Contains(cmd, "--include-raw") {
+		t.Fatalf("#4285: --include-raw missing. pluk watch defaults includeRaw to false, "+
+			"so hive-panes.sh — which keeps only raw_output events — would still show "+
+			"nothing for every agent: %s", cmd)
+	}
+	// The subcommand and the CLI selector must survive alongside it.
+	if !strings.Contains(cmd, " watch ") {
+		t.Fatalf("the watch subcommand is missing: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--cli="+shellQuote("codex")) {
+		t.Fatalf("the --cli selector did not carry the backend: %s", cmd)
+	}
+}
+
+// TestPlukPipePaneCmdQuotesEveryOperand matters more now than it did before:
+// the command already went to a shell, but the redirect target is new and is
+// built from the session name. An unquoted name with a space would split the
+// redirect and send the log somewhere else entirely.
+func TestPlukPipePaneCmdQuotesEveryOperand(t *testing.T) {
+	session := "hive-odd name"
+	logFile := plukSessionLogPath(plukRunDir, session)
+	cmd := plukPipePaneCmd("/opt/my pluk/bin/pluk", session, "claude", logFile)
+
+	for _, operand := range []string{"/opt/my pluk/bin/pluk", session, logFile} {
+		if !strings.Contains(cmd, shellQuote(operand)) {
+			t.Errorf("operand %q is not shell-quoted in: %s", operand, cmd)
+		}
+	}
+
+	// A name carrying shell syntax must land inside quotes, not as a second command.
+	nasty := "hive-a; touch /tmp/pwned"
+	nastyCmd := plukPipePaneCmd("/usr/bin/pluk", nasty, "claude", plukSessionLogPath(plukRunDir, nasty))
+	if !strings.Contains(nastyCmd, shellQuote(nasty)) {
+		t.Errorf("a session name containing shell syntax was not quoted: %s", nastyCmd)
+	}
+}
+
+// TestPlukSessionLogPathMatchesItsConsumers pins the path against the two
+// readers, which hardcode it independently: inception_watcher.go builds
+// "<plukLogDir>/hive-brainstorm.jsonl" and hive-panes.sh globs
+// "$LOG_DIR"/hive-*.jsonl. If this drifts, both go quiet without erroring.
+func TestPlukSessionLogPathMatchesItsConsumers(t *testing.T) {
+	got := plukSessionLogPath(plukRunDir, "hive-brainstorm")
+	const want = "/var/run/pluk/logs/hive-brainstorm.jsonl"
+	if got != want {
+		t.Fatalf("log path = %q, want %q — the inception watcher tails the literal %q",
+			got, want, want)
+	}
+
+	matched, err := filepath.Match("/var/run/pluk/logs/hive-*.jsonl", got)
+	if err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if !matched {
+		t.Fatalf("%q does not match the hive-*.jsonl glob hive-panes.sh iterates", got)
+	}
+}
+
+// TestEnsurePlukLogFileIsPeerReadableUnderTightUmask is the reason the file is
+// created here at all rather than by the shell's `>>`.
+//
+// hive-panes is run BY one agent to read every OTHER agent's log, and agent UIDs
+// differ. If the pane shell's umask creates the log, a 0077 umask yields a 0600
+// file no peer can read — the peer listing silently stays empty and nothing
+// reports an error. Pre-creating with an explicit mode makes `>>` append to a
+// file that is already group-readable.
+func TestEnsurePlukLogFileIsPeerReadableUnderTightUmask(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "pluk")
+	if err := ensurePlukRunDirs(runDir); err != nil {
+		t.Fatalf("ensure pluk dirs: %v", err)
+	}
+
+	oldUmask := setUmask(0o077)
+	defer setUmask(oldUmask)
+
+	path, err := ensurePlukLogFile(runDir, "hive-architect")
+	if err != nil {
+		t.Fatalf("ensure pluk log file: %v", err)
+	}
+	if want := plukSessionLogPath(runDir, "hive-architect"); path != want {
+		t.Fatalf("returned path = %q, want %q", path, want)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Fatalf("#4285: log mode = %04o, want 0660. Under a tight umask the shell's "+
+			">> would leave this 0600 and hive-panes would read nothing for this agent", got)
+	}
+	if info.Mode().Perm()&0o040 == 0 {
+		t.Errorf("log is not group-readable (%s) — peer agents cannot read it", info.Mode())
+	}
+	if info.Mode().Perm()&0o007 != 0 {
+		t.Errorf("log is accessible to other (%s) — the node group is the intended boundary", info.Mode())
+	}
+}
+
+// TestEnsurePlukLogFileAppendsRatherThanTruncating: agents restart and panes get
+// respawned, so this runs again over a log that already has content. Losing it
+// would blank the peer listing every time an agent bounced.
+func TestEnsurePlukLogFileAppendsRatherThanTruncating(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "pluk")
+	if err := ensurePlukRunDirs(runDir); err != nil {
+		t.Fatalf("ensure pluk dirs: %v", err)
+	}
+
+	path, err := ensurePlukLogFile(runDir, "hive-brainstorm")
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	const existing = `{"type":"raw_output","data":{"line":"hello"}}` + "\n"
+	if err := os.WriteFile(path, []byte(existing), 0o660); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	if _, err := ensurePlukLogFile(runDir, "hive-brainstorm"); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != existing {
+		t.Fatalf("re-attaching truncated the log: got %q, want %q", got, existing)
+	}
+}
+
+// TestEnsurePlukLogFileWidensATightExistingLog: O_CREATE's mode is umask-filtered
+// and does not apply to a file that already exists, so a log left behind by an
+// earlier run — or by the pre-#4285 shell redirect — has to be widened back to
+// the shared mode rather than inherited as-is.
+func TestEnsurePlukLogFileWidensATightExistingLog(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "pluk")
+	if err := ensurePlukRunDirs(runDir); err != nil {
+		t.Fatalf("ensure pluk dirs: %v", err)
+	}
+
+	path := plukSessionLogPath(runDir, "hive-legacy")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("seed tight log: %v", err)
+	}
+
+	if _, err := ensurePlukLogFile(runDir, "hive-legacy"); err != nil {
+		t.Fatalf("ensure over existing: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Fatalf("a pre-existing 0600 log stayed %04o — peers still cannot read it", got)
+	}
+}

--- a/src/pkg/dashboard/inception_watcher.go
+++ b/src/pkg/dashboard/inception_watcher.go
@@ -577,7 +577,15 @@ func (w *InceptionWatcher) handlePlukEvent(event plukEvent) {
 		}
 
 	case "raw_output":
-		line := event.Data["message"]
+		// #4285: pluk puts the pane text on "line" for raw_output, and only
+		// "line" — classifier.js builds the event as
+		// createEvent(..., 'raw_output', { line }). "message" is a real pluk key,
+		// but it belongs to rate_limit and error (handled above), which is
+		// evidently where this generalised from. Reading "message" here made the
+		// whole raw_output arm dead: every bd-create interception and every
+		// keyword re-poll below returned on the empty string.
+		// src/deploy/hive-panes.sh has always read data.line and was correct.
+		line := event.Data["line"]
 		if line == "" {
 			return
 		}

--- a/src/pkg/dashboard/inception_watcher_coverage_test.go
+++ b/src/pkg/dashboard/inception_watcher_coverage_test.go
@@ -287,9 +287,12 @@ func TestCovF_HandlePlukEvent(t *testing.T) {
 	}
 
 	// raw_output during capture with a bd create question line -> buffered.
+	// #4285: the payload key is "line". This case used to pass "message", which
+	// the handler also read, so the arm ran on an empty string and this test
+	// covered the line without exercising anything.
 	w.handlePlukEvent(plukEvent{
 		Type: "raw_output",
-		Data: map[string]string{"message": `bd create --title "Who are the users?" --actor brainstorm`},
+		Data: map[string]string{"line": `bd create --title "Who are the users?" --actor brainstorm`},
 	})
 
 	// state_change to working then idle.

--- a/src/pkg/dashboard/pluk_raw_output_key_test.go
+++ b/src/pkg/dashboard/pluk_raw_output_key_test.go
@@ -1,0 +1,109 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/knowledge"
+)
+
+// pluk_raw_output_key_test.go covers the third defect in kubestellar/hive#4285:
+// handlePlukEvent read the raw_output text from data["message"], but pluk puts
+// it on data["line"] and only there — classifier.js builds the event as
+// createEvent(..., 'raw_output', { line }). "message" is a real pluk key, but it
+// belongs to rate_limit and error.
+//
+// The consequence was total rather than partial: line came back "" for every
+// raw_output event, the handler returned immediately, and every bd-create
+// interception and keyword re-poll underneath it was unreachable.
+
+// TestPlukRawOutputReadsLineKey is the regression. A bd create line arriving on
+// the key pluk actually uses must reach the buffer the capture phase parses.
+func TestPlukRawOutputReadsLineKey(t *testing.T) {
+	w, eng, _ := covFWatcher(t)
+	if _, err := eng.Start("raw output key idea in go"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	const bdCreate = `bd create --title "Who are the users?" --actor brainstorm`
+	w.handlePlukEvent(plukEvent{
+		Type: "raw_output",
+		Data: map[string]string{"line": bdCreate},
+	})
+
+	w.plukMu.Lock()
+	buffered := append([]string(nil), w.plukBdCreateLines...)
+	w.plukMu.Unlock()
+
+	if len(buffered) == 0 {
+		t.Fatalf("#4285: a raw_output event carrying %q on the \"line\" key was dropped — "+
+			"the handler is reading a key pluk does not set for this event type", bdCreate)
+	}
+	if buffered[0] != bdCreate {
+		t.Fatalf("buffered line = %q, want %q", buffered[0], bdCreate)
+	}
+}
+
+// TestPlukRawOutputIgnoresMessageKey is the other half, and the one that keeps
+// the fix from being quietly reverted into "read both keys". pluk never puts
+// raw_output text on "message"; treating it as an alias would mean acting on
+// rate_limit and error prose as though it were pane output — those events carry
+// human-readable provider text, and "bd create --title" appearing inside an
+// error message is not a bd create the agent ran.
+func TestPlukRawOutputIgnoresMessageKey(t *testing.T) {
+	w, eng, _ := covFWatcher(t)
+	if _, err := eng.Start("message key idea in go"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	w.handlePlukEvent(plukEvent{
+		Type: "raw_output",
+		Data: map[string]string{"message": `bd create --title "Should not be read" --actor brainstorm`},
+	})
+
+	w.plukMu.Lock()
+	buffered := len(w.plukBdCreateLines)
+	w.plukMu.Unlock()
+
+	if buffered != 0 {
+		t.Fatalf("#4285: raw_output text was read from \"message\"; pluk only ever sets " +
+			"\"line\" for this event, and \"message\" belongs to rate_limit/error")
+	}
+}
+
+// TestPlukRawOutputParsesQuestionsThroughTheLineKey walks the path end to end:
+// enough bd create lines on the real key must actually populate the question
+// list, which is the behaviour the capture phase depends on and which had been
+// unreachable since the key mismatch was introduced.
+func TestPlukRawOutputParsesQuestionsThroughTheLineKey(t *testing.T) {
+	w, eng, _ := covFWatcher(t)
+	if _, err := eng.Start("question parsing idea in go"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if st := eng.GetState(); st == nil || st.Phase != knowledge.PhaseCapture {
+		t.Skipf("inception did not start in capture phase; nothing to drive")
+	}
+
+	for _, title := range []string{
+		"Who are the users?",
+		"What is the deployment target?",
+		"Which data must persist?",
+	} {
+		w.handlePlukEvent(plukEvent{
+			Type: "raw_output",
+			Data: map[string]string{"line": `bd create --title "` + title + `" --actor brainstorm`},
+		})
+	}
+
+	w.plukMu.Lock()
+	questions := len(w.plukQuestions)
+	buffered := len(w.plukBdCreateLines)
+	w.plukMu.Unlock()
+
+	if buffered != 3 {
+		t.Fatalf("buffered %d bd create lines, want 3", buffered)
+	}
+	if questions == 0 {
+		t.Fatalf("#4285: no questions were parsed from bd create lines delivered on the " +
+			"\"line\" key — the capture-phase interception is still unreachable")
+	}
+}


### PR DESCRIPTION
## What

Fixes all three defects in #4285. Closes #4285.

Verified against `@kubestellar/pluk@0.8.0` — the version `PLUK_VERSION` pins in `src/Dockerfile` — installed from npm and run end to end, not just read.

## 1. The attach command had no redirect, so no file was ever written

`pluk watch` classifies its stdin and prints events to **stdout**. It opens no file of its own — no `createWriteStream`, `appendFile`, `writeFile` or `openSync` in any module of the published package. `tmux pipe-pane` feeds the pane into that command's *stdin* and does nothing with its stdout. So the events were produced and discarded.

Running the two invocations against real pluk, same input, same run dir:

```
===== OLD (pre-#4285): no redirect, no --include-raw =====
files in run dir: []

===== NEW: exactly what plukPipePaneCmd builds =====
files in run dir: [hive-brainstorm.jsonl]
{"...","type":"raw_output","data":{"line":"● Running bd create --title \"Who are the users?\" --actor brainstorm"}}
{"...","type":"tool_call_started","data":{"tool":"Read","input_preview":"● Read src/pkg/agent/manager.go"}}
{"...","type":"raw_output","data":{"line":"● Read src/pkg/agent/manager.go"}}
{"...","type":"raw_output","data":{"line":"✻ Thinking about the redirect"}}
```

And `hive-panes.sh`'s own extractor, run unmodified over that real log, finally prints something:

```
● Running bd create --title "Who are the users?" --actor brainstorm
● Read src/pkg/agent/manager.go
✻ Thinking about the redirect
```

## 2. `raw_output` was gated behind `--include-raw`

`watch.js` sets `includeRaw = opts.includeRaw ?? false`. And `raw_output` is the **only** event type `hive-panes.sh` keeps — it drops every other type before touching the payload. So the redirect on its own would have produced a file that still left peer awareness empty for every agent.

**The issue left this as an open maintainer question on log-volume grounds. I think the repo's own history answers it, which is why I didn't wait.**

Both halves were lost together in #1759, which replaced the Go `pluk-publish` binary — a *publisher*, which wrote the log itself — with the TypeScript `pluk watch`:

```diff
-pipePaneCmd := fmt.Sprintf("%s --session %s --cli %s", plukPath, agent.tmuxSession, backend)
+pipePaneCmd := fmt.Sprintf("%s watch %s --cli=%s", plukPath, agent.tmuxSession, backend)
```

That translated the flags but not the file-writing half the rewrite had moved into the shell. And the dates settle intent:

| | |
|---|---|
| `f6a1db81` **2026-06-23** | `hive-panes.sh` added — reads `raw_output` / `data.line`, nothing else |
| `5aeb24ec` **2026-07-02** | #1759 migration drops the redirect *and* the raw flag |

`hive-panes.sh` predates the migration by nine days and has only ever read `raw_output`, so raw output was flowing when it was written. This restores the contract it was built against rather than choosing a new policy. Pluk's own `attach` reaches the same conclusion from upstream — `attach.js:168` passes `--include-raw` by **default** (opt out via `--no-raw`).

One correction to the issue: **option 2 wouldn't work.** It suggests the flag only where "a consumer needs it (the `brainstorm` session is the one with a Go subscriber)", but `hive-panes.sh` globs `hive-*.jsonl` and needs `raw_output` from *every* agent, not just the one with a Go subscriber.

## 3. The watcher read a key pluk does not set for that event

`classifier.js:114` builds it as `createEvent(..., 'raw_output', { line })`. `handlePlukEvent` read `data["message"]` — a real pluk key, but one belonging to `rate_limit` and `error`, which is evidently where it generalised from.

The consequence was total rather than partial: `line` came back `""` for every `raw_output`, the handler returned immediately, and every bd-create interception and keyword re-poll beneath it was unreachable.

Worth flagging: the existing coverage test drove this arm with `"message"` and asserted nothing about the outcome, so it covered the line without exercising it. That's how the bug survived. Corrected, and backed by tests that assert the effect.

## Also fixed: the log wouldn't have been peer-readable

Not in the issue, but it would have blunted the fix silently.

`hive-panes` is run **by** one agent to read every **other** agent's log, and agent UIDs differ — the shared `node` group is what makes that work. Leaving creation to the shell's `>>` takes whatever umask the pane shell carries, and a `0077` umask yields a `0600` log no peer can read. Same class of silent breakage `permissions_watcher.go` exists to repair for agent config (#3882), and it fails without erroring.

`ensurePlukLogFile` pre-creates each log `0660 dev:node`, matching what `ensurePlukRunDirs` already does one level up, and widens a tight file left by an earlier run. Both the `O_CREATE` mode and the following `Chmod` are needed — `O_CREATE` is umask-filtered and doesn't apply to an existing file.

Every operand is now shell-quoted. The string always went to a shell, but the redirect target is new and embeds the session name, so a name with a space would otherwise split it.

## Deliberately not included

**Rotation.** Nothing caps these files and they grow for the life of the container. It's the remaining half of the issue's option 1 and belongs in its own issue: naively truncating a file that `pipe-pane` holds an append fd on is worse than not rotating, so it needs a deliberate design rather than a rider here. No consumer needs the history — `hive-panes` reads the last 2000 lines, the subscriber seeks to the end — so the gap is bounded in impact. Documented in `agent-logging.md`.

**For review:** restoring `raw_output` puts pane content back into a group-shared file. That is the documented purpose of the directory and the whole premise of `hive-panes`, but it has not actually been happening since 2026-07-02 — so it is a real change to what lands on disk today, and I'd rather flag it than have it noticed after merge.

## Verification

```
$ go test ./pkg/agent/ -short -race -count=1
ok  	github.com/kubestellar/hive/pkg/agent	428.223s
$ go test ./pkg/dashboard/ -short -race -count=1
ok  	github.com/kubestellar/hive/pkg/dashboard	55.359s
```

All eight new tests fail against the pre-fix behaviour with their own diagnostics — I checked rather than assuming:

```
--- FAIL: TestPlukPipePaneCmdRedirectsToTheSessionLog
    #4285: the pipe-pane command has no redirect, so pluk's events go to a stdout
    nobody reads and the log file is never written: /usr/bin/pluk watch hive-brainstorm --cli=claude
--- FAIL: TestPlukPipePaneCmdRequestsRawOutput
    #4285: --include-raw missing. pluk watch defaults includeRaw to false, so
    hive-panes.sh — which keeps only raw_output events — would still show nothing
--- FAIL: TestPlukPipePaneCmdQuotesEveryOperand
    a session name containing shell syntax was not quoted: /usr/bin/pluk watch hive-a; touch /tmp/pwned --cli=claude
--- FAIL: TestEnsurePlukLogFileIsPeerReadableUnderTightUmask
    #4285: log mode = 0600, want 0660 …
--- FAIL: TestEnsurePlukLogFileWidensATightExistingLog
    a pre-existing 0600 log stayed 0600 — peers still cannot read it
--- FAIL: TestPlukRawOutputReadsLineKey
    #4285: a raw_output event carrying … on the "line" key was dropped
--- FAIL: TestPlukRawOutputIgnoresMessageKey
    #4285: raw_output text was read from "message" …
--- FAIL: TestPlukRawOutputParsesQuestionsThroughTheLineKey
    buffered 0 bd create lines, want 3
```

`TestPlukRawOutputIgnoresMessageKey` is there to stop the fix being reverted into "read both keys": `rate_limit`/`error` carry human-readable provider prose, and `bd create --title` appearing inside an error message is not a bd create the agent ran.

## Files

- `src/pkg/agent/pluk_dirs.go` — `plukPipePaneCmd`, `plukSessionLogPath`, `ensurePlukLogFile`
- `src/pkg/agent/manager.go` — attach through the builder, pre-create the log
- `src/pkg/dashboard/inception_watcher.go` — `data["message"]` → `data["line"]`
- `src/pkg/agent/pluk_publisher_test.go`, `src/pkg/dashboard/pluk_raw_output_key_test.go` — new tests
- `src/pkg/dashboard/inception_watcher_coverage_test.go` — the case that encoded the bug
- `src/docs/agent-logging.md` — corrects the "check both keys" advice, records why the redirect exists and that nothing rotates

## What I did not verify

Same caveat as the issue: I have no running hive deployment, so I have not confirmed in situ that `/var/run/pluk/logs/` is empty on a live host. Everything above is from the published pluk package, the repo's history, and running the two invocations side by side locally. A single `ls -la /var/run/pluk/logs/` on any running deployment confirms the premise.

— hive: backend=claude model=claude-opus-5
