### PR TITLE
🐛 fix(agents): give advisory-tier agents a repo read path (Contents:read + credential-helper fetch)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -104,6 +104,16 @@ jobs:
         working-directory: .
         run: bash bin/test_gh_wrapper_gates.sh
 
+      # #4289: git-credential-hive.sh is the fetch/clone AND push credential
+      # source for every agent. Its mode block used to exit 1 in ADVISORY/
+      # ISSUES_ONLY/NO_GITHUB modes, cutting off every git READ for advisory
+      # agents. This EXECUTES the helper and asserts `get` returns the scoped
+      # (contents:read-only) credential in those modes while the H3 refusals
+      # (no per-agent token, non-https) stay fail-closed.
+      - name: git-credential-hive helper tests (#4289)
+        working-directory: .
+        run: bash bin/test_git_credential_hive.sh
+
       # N14 (#3842): kick-agents.sh (the native/systemd-install path — no Go
       # AgentManager, no per-agent scoped token) used to instruct every kicked
       # agent to `cat` the shared, fleet-wide, full-privilege App token cache

--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -2,6 +2,20 @@
 # git-credential-hive.sh — Git credential helper that uses the GitHub App token.
 # Reads from the cached token file, refreshing if stale (>55 min old).
 #
+# MODE SEMANTICS (#4289): mode blocks NO LONGER suppress read credentials.
+# Git uses the same credential helper for fetch/clone AND push — the
+# credential protocol ("get") cannot distinguish them — so exiting 1 in
+# ADVISORY/ISSUES_ONLY/NO_GITHUB modes blocked all git reads, leaving
+# advisory agents with no repo read path at all. This helper now always
+# answers `get` with the per-agent SCOPED token. Write-prevention is
+# enforced by token scope server-side: sub-L3 tiers ("advisor",
+# "newcomer") are minted WITHOUT contents:write (src/pkg/github/app.go),
+# so a push authenticates but is rejected by GitHub with 403. The helper
+# still refuses loudly when the per-agent token is absent — it NEVER
+# falls back to the shared full-privilege App token (audit H3), which is
+# the one path that would hand an advisory agent a write-capable
+# credential.
+#
 # Install (github.com): git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh
 # Install (GHE):         git config --global credential.https://<ghe-host>.helper /usr/local/bin/git-credential-hive.sh
 #
@@ -66,7 +80,16 @@ else
   AGENT="${HIVE_AGENT:-}"
 fi
 
-# ── Mode-based enforcement: block git push for agents without push capability ──
+# ── Mode awareness: NOTE, do not block (#4289) ──
+# Git invokes this helper for fetch/clone as well as push, and the credential
+# `get` operation cannot tell them apart. Exiting 1 here (as this script did
+# before) therefore blocked ALL git network operations for sub-push-capable
+# agents — including the reads that are an advisory agent's entire job.
+# Push-prevention does not need this block: the per-agent token at these
+# tiers is minted without contents:write, so GitHub itself rejects any push
+# with 403 (server-side enforcement that the agent cannot bypass). We emit a
+# one-line notice so an agent whose push just failed sees WHY and does not
+# loop retrying.
 
 # Read mode from file first (hot-reloadable), fallback to env var.
 # -r as well as -f: this script runs under `set -e`, so a mode file that exists
@@ -83,24 +106,17 @@ fi
 if [ -n "$AGENT_MODE" ]; then
   case "$AGENT_MODE" in
     NO_GITHUB|ADVISORY|ISSUES_ONLY)
-      echo "⛔ git push blocked: ${AGENT} is in ${AGENT_MODE} mode" >&2
-      echo "⛔ TERMINAL: this block is mode-enforced and retrying can NEVER succeed. Do NOT retry, loop, or seek workarounds. Record your intended change as an advisory finding (bd create / [FINDING]) and end this task." >&2
-      exit 1
+      echo "ℹ️  hive credential: ${AGENT} is in ${AGENT_MODE} mode — this credential is READ-ONLY for repo contents. git fetch/clone work; git push will be rejected by GitHub (403). Do NOT retry a failed push: record your intended change as an advisory finding (bd create / [FINDING]) instead." >&2
       ;;
   esac
 else
-  # Fallback: level-based enforcement
+  # Fallback: level-based awareness (same non-blocking semantics as above)
   ACMM="${HIVE_ACMM_LEVEL:-0}"
   if [ -n "$AGENT" ] && [ "$ACMM" -gt 0 ]; then
     if [ "$ACMM" -lt 3 ]; then
-      echo "⛔ git push blocked: ACMM L${ACMM} agents are advisory-only" >&2
-      echo "⛔ TERMINAL: this block is mode-enforced and retrying can NEVER succeed. Do NOT retry, loop, or seek workarounds. Record your intended change as an advisory finding (bd create / [FINDING]) and end this task." >&2
-      exit 1
-    fi
-    if [ "$ACMM" -eq 3 ] && [ "$AGENT" != "quality" ]; then
-      echo "⛔ git push blocked: only quality agent can push at ACMM L3" >&2
-      echo "⛔ TERMINAL: this block is mode-enforced and retrying can NEVER succeed. Do NOT retry, loop, or seek workarounds. Record your intended change as an advisory finding (bd create / [FINDING]) and end this task." >&2
-      exit 1
+      echo "ℹ️  hive credential: ACMM L${ACMM} agents are advisory-only — this credential is READ-ONLY for repo contents. git fetch/clone work; git push will be rejected by GitHub (403). Do NOT retry a failed push: record your intended change as an advisory finding (bd create / [FINDING]) instead." >&2
+    elif [ "$ACMM" -eq 3 ] && [ "$AGENT" != "quality" ]; then
+      echo "ℹ️  hive credential: only the quality agent can push at ACMM L3 — this credential is READ-ONLY for repo contents. git fetch/clone work; git push will be rejected by GitHub (403). Do NOT retry a failed push: record your intended change as an advisory finding (bd create / [FINDING]) instead." >&2
     fi
   fi
 fi

--- a/bin/test_git_credential_hive.sh
+++ b/bin/test_git_credential_hive.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Behavioural tests for bin/git-credential-hive.sh.
+# Run: bash bin/test_git_credential_hive.sh
+#
+# #4289 regression harness: git uses the SAME credential helper for
+# fetch/clone and push, and the credential protocol's `get` operation cannot
+# distinguish them. The helper used to exit 1 in ADVISORY/ISSUES_ONLY/
+# NO_GITHUB modes (and the sub-L3 ACMM fallback), which blocked every git
+# READ for advisory agents — agents whose entire job is reading the repo.
+# These tests EXECUTE the helper and assert that `get` now returns a
+# credential in those modes (write-prevention is server-side: the per-agent
+# token at those tiers has no contents:write, so GitHub 403s any push), while
+# the security-critical refusals that DO still apply — no per-agent token
+# file, empty token file, non-https protocols (audit H3) — stay fail-closed.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="${REPO_ROOT}/bin/git-credential-hive.sh"
+
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+TOKEN_CACHE="${WORK}/token"
+echo "ghs_stubtoken" >"$TOKEN_CACHE"
+
+# Unique agent name so /tmp/.hive-mode-<agent> from a real deployment can
+# never shadow the HIVE_AGENT_MODE env var the harness sets.
+TEST_AGENT="cred-harness-$$"
+
+# run_helper <mode> <acmm> <token_file> <stdin> -- <helper args...>
+# Echoes "exit=<code>\n<combined stdout+stderr>" for the assertions below.
+run_helper() {
+  local mode="$1" acmm="$2" token_file="$3" stdin="$4"; shift 4
+  [ "${1:-}" = "--" ] && shift
+  local out rc
+  out="$(
+    printf '%b' "$stdin" | \
+    HIVE_AGENT="$TEST_AGENT" \
+    HIVE_AGENT_MODE="$mode" \
+    HIVE_ACMM_LEVEL="$acmm" \
+    HIVE_AGENT_TOKEN_CACHE="$token_file" \
+    bash "$HELPER" "$@" 2>&1
+  )"
+  rc=$?
+  printf 'exit=%d\n%s\n' "$rc" "$out"
+}
+
+# assert <name> <result> <want>
+# want format: "exit=<code> ::: <glob over combined output>"
+assert() {
+  local name="$1" result="$2" want="$3"
+  local want_exit="${want%% ::: *}"
+  local want_glob="${want#* ::: }"
+  local got_exit got_out
+  got_exit="$(printf '%s\n' "$result" | head -n1)"
+  got_out="$(printf '%s\n' "$result" | tail -n +2)"
+  # Glob matching on the RHS is intentional (want_glob is a pattern).
+  # shellcheck disable=SC2053
+  if [ "$got_exit" = "$want_exit" ] && [[ "$got_out" == $want_glob ]]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $name"
+    echo "  want: $want"
+    echo "  got:  $got_exit output: $got_out"
+  fi
+}
+
+GET_STDIN='protocol=https\nhost=github.com\n\n'
+
+# ── #4289: `get` must return a credential in sub-push-capable modes ──
+assert "ADVISORY mode + get returns a credential (the read path, #4289)" \
+  "$(run_helper ADVISORY 2 "$TOKEN_CACHE" "$GET_STDIN" -- get)" \
+  "exit=0 ::: *username=x-access-token*password=ghs_stubtoken*"
+assert "ISSUES_ONLY mode + get returns a credential" \
+  "$(run_helper ISSUES_ONLY 1 "$TOKEN_CACHE" "$GET_STDIN" -- get)" \
+  "exit=0 ::: *username=x-access-token*password=ghs_stubtoken*"
+assert "NO_GITHUB mode + get returns a credential (token delivery is the gate)" \
+  "$(run_helper NO_GITHUB 0 "$TOKEN_CACHE" "$GET_STDIN" -- get)" \
+  "exit=0 ::: *username=x-access-token*password=ghs_stubtoken*"
+assert "ACMM L2 fallback (no mode) + get returns a credential" \
+  "$(run_helper "" 2 "$TOKEN_CACHE" "$GET_STDIN" -- get)" \
+  "exit=0 ::: *username=x-access-token*password=ghs_stubtoken*"
+
+# ── the notice replaces the hard block: agents must see WHY a push 403s ──
+assert "ADVISORY mode emits the read-only notice (no silent 403 loops)" \
+  "$(run_helper ADVISORY 2 "$TOKEN_CACHE" "$GET_STDIN" -- get)" \
+  "exit=0 ::: *READ-ONLY*rejected by GitHub*"
+assert "ACMM L2 fallback emits the read-only notice" \
+  "$(run_helper "" 2 "$TOKEN_CACHE" "$GET_STDIN" -- get)" \
+  "exit=0 ::: *READ-ONLY*rejected by GitHub*"
+assert "push-capable mode emits no notice" \
+  "$(run_helper CONTRIBUTOR 4 "$TOKEN_CACHE" "$GET_STDIN" -- get)" \
+  "exit=0 ::: *username=x-access-token*"
+PUSHCAP_OUT="$(run_helper CONTRIBUTOR 4 "$TOKEN_CACHE" "$GET_STDIN" -- get | tail -n +2)"
+if [[ "$PUSHCAP_OUT" == *"READ-ONLY"* ]]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: push-capable mode wrongly emitted the read-only notice"
+else
+  PASS=$((PASS + 1))
+  echo "PASS: push-capable mode has no read-only notice text"
+fi
+
+# ── refusals that MUST stay fail-closed (audit H3) ──
+assert "missing per-agent token file refuses loudly (H3: no shared-cache fallback)" \
+  "$(run_helper ADVISORY 2 "${WORK}/no-such-token" "$GET_STDIN" -- get)" \
+  "exit=1 ::: *git push blocked*scoped GitHub token not available*"
+assert "HIVE_AGENT_TOKEN_CACHE unset refuses loudly" \
+  "$(run_helper ADVISORY 2 "" "$GET_STDIN" -- get)" \
+  "exit=1 ::: *git push blocked*"
+
+EMPTY_TOKEN="${WORK}/empty-token"
+: >"$EMPTY_TOKEN"
+assert "empty token file yields no credential" \
+  "$(run_helper ADVISORY 2 "$EMPTY_TOKEN" "$GET_STDIN" -- get)" \
+  "exit=1 ::: *"
+
+# ── protocol / host handling unchanged ──
+NONHTTPS_RESULT="$(run_helper CONTRIBUTOR 4 "$TOKEN_CACHE" 'protocol=ssh\nhost=github.com\n\n' -- get)"
+NONHTTPS_EXIT="$(printf '%s\n' "$NONHTTPS_RESULT" | head -n1)"
+NONHTTPS_OUT="$(printf '%s\n' "$NONHTTPS_RESULT" | tail -n +2)"
+if [ "$NONHTTPS_EXIT" = "exit=0" ] && [[ "$NONHTTPS_OUT" != *"password="* ]]; then
+  PASS=$((PASS + 1))
+  echo "PASS: non-https protocol gets no credential"
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: non-https protocol gets no credential"
+  echo "  got:  $NONHTTPS_EXIT output: $NONHTTPS_OUT"
+fi
+assert "GHE host is echoed back, not hardcoded github.com" \
+  "$(run_helper ADVISORY 2 "$TOKEN_CACHE" 'protocol=https\nhost=ghe.example.com\n\n' -- get)" \
+  "exit=0 ::: *host=ghe.example.com*password=ghs_stubtoken*"
+assert "store op emits no credential" \
+  "$(run_helper ADVISORY 2 "$TOKEN_CACHE" "$GET_STDIN" -- store)" \
+  "exit=0 ::: *"
+
+# store/erase must never leak the token to stdout
+STORE_OUT="$(run_helper ADVISORY 2 "$TOKEN_CACHE" "$GET_STDIN" -- store | tail -n +2)"
+if [[ "$STORE_OUT" == *"ghs_stubtoken"* ]]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL: store op leaked the token: $STORE_OUT"
+else
+  PASS=$((PASS + 1))
+  echo "PASS: store op does not leak the token"
+fi
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2801,12 +2801,17 @@ func (m *Manager) logOutputSignals(agent, line string) {
 }
 
 // Blocked-action thrash breaker: an agent that keeps hammering a policy wall
-// (e.g. git push in ADVISORY mode, blocked every ~3s by git-credential-hive)
-// burns model tokens indefinitely with zero possible output — observed live
-// 2026-08-04 on a hosted L2 hive whose guide agent retried a blocked push
-// every 3 seconds. The hub, not the model, breaks the loop: thrashThreshold
-// blocked-action lines within thrashWindow pauses the session (visible,
-// reversible, stops governor kicks) with the reason spelled out.
+// (e.g. a push with no per-agent token, blocked every ~3s by
+// git-credential-hive, or a proxy hard-deny) burns model tokens indefinitely
+// with zero possible output — observed live 2026-08-04 on a hosted L2 hive
+// whose guide agent retried a blocked push every 3 seconds. (Since #4289,
+// ADVISORY-mode pushes are no longer blocked by the credential helper — the
+// read-only token is served and GitHub rejects the push with 403 — but the
+// helper still emits "git push blocked:" for unknown-UID and missing-token
+// failures, which this breaker continues to catch.) The hub, not the model,
+// breaks the loop: thrashThreshold blocked-action lines within thrashWindow
+// pauses the session (visible, reversible, stops governor kicks) with the
+// reason spelled out.
 const (
 	thrashWindow    = 60 * time.Second
 	thrashThreshold = 5

--- a/src/pkg/github/app.go
+++ b/src/pkg/github/app.go
@@ -286,9 +286,15 @@ func (a *AppAuth) ScopedTokenForRepos(ctx context.Context, tier string, repos []
 	var perms *gh.InstallationPermissions
 	switch tier {
 	case "newcomer":
-		// Newcomers can comment on issues but not access code
+		// Newcomers (ISSUES_ONLY agents) can comment on and file issues, and
+		// READ code — filing a meaningful issue requires reading the repo it
+		// is about (#4289). Write remains impossible: contents:write is
+		// absent, so any push authenticates but is rejected server-side by
+		// GitHub with 403.
 		perms = &gh.InstallationPermissions{
-			Issues: gh.Ptr("write"),
+			Issues:   gh.Ptr("write"),
+			Contents: gh.Ptr("read"),
+			Metadata: gh.Ptr("read"),
 		}
 	case "contributor":
 		perms = &gh.InstallationPermissions{
@@ -306,9 +312,14 @@ func (a *AppAuth) ScopedTokenForRepos(ctx context.Context, tier string, repos []
 			Metadata:     gh.Ptr("read"),
 		}
 	case "advisor":
-		// Advisors review agent PRs — they only need to read, not write.
-		// Don't request issues permission at all to prevent creation.
+		// Advisors review agent PRs and audit repo contents — their core
+		// function is READING the repo, so Contents:read is required (#4289:
+		// without it every contents/tarball API call and git fetch 403s no
+		// matter what the installation grants). They must not write:
+		// contents:write is absent, so pushes are rejected server-side by
+		// GitHub. Don't request issues permission at all to prevent creation.
 		perms = &gh.InstallationPermissions{
+			Contents:     gh.Ptr("read"),
 			Metadata:     gh.Ptr("read"),
 			PullRequests: gh.Ptr("read"),
 		}

--- a/src/pkg/github/tier_permissions_test.go
+++ b/src/pkg/github/tier_permissions_test.go
@@ -1,0 +1,81 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestScopedToken_AdvisoryTiersRequestContentsRead is the regression test for
+// #4289: advisory-tier agents ("advisor", "newcomer") must be able to READ
+// repo contents — auditing the repo is their core function — while remaining
+// unable to write (contents:write must be absent so GitHub rejects any push
+// server-side with 403). The advisor tier must also not request issues at
+// all, to prevent issue creation.
+func TestScopedToken_AdvisoryTiersRequestContentsRead(t *testing.T) {
+	cases := []struct {
+		tier       string
+		wantIssues string // "" means the issues permission must be absent
+	}{
+		{tier: "advisor", wantIssues: ""},
+		{tier: "newcomer", wantIssues: "write"},
+	}
+
+	for _, tc := range cases {
+		t.Run("tier_"+tc.tier, func(t *testing.T) {
+			key, _ := generateTestKey(t)
+
+			var gotPerms map[string]string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				var body struct {
+					Permissions map[string]string `json:"permissions"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decoding token request body: %v", err)
+				}
+				gotPerms = body.Permissions
+				json.NewEncoder(w).Encode(map[string]any{
+					"token":      "scoped-token-" + tc.tier,
+					"expires_at": time.Now().Add(time.Hour).Format(time.RFC3339),
+				})
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			auth := &AppAuth{
+				appID:          1,
+				installationID: 2,
+				key:            key,
+				logger:         slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+				apiURL:         server.URL,
+			}
+
+			if _, err := auth.ScopedToken(context.Background(), tc.tier); err != nil {
+				t.Fatalf("ScopedToken(%q): %v", tc.tier, err)
+			}
+
+			if got := gotPerms["contents"]; got != "read" {
+				t.Errorf("tier %q contents permission = %q, want %q (advisory agents need a repo read path, #4289)", tc.tier, got, "read")
+			}
+			if got := gotPerms["metadata"]; got != "read" {
+				t.Errorf("tier %q metadata permission = %q, want %q", tc.tier, got, "read")
+			}
+			if got := gotPerms["issues"]; got != tc.wantIssues {
+				t.Errorf("tier %q issues permission = %q, want %q", tc.tier, got, tc.wantIssues)
+			}
+			// The write-prevention boundary: contents must never be "write"
+			// at these tiers — GitHub enforces the push block server-side.
+			for perm, level := range gotPerms {
+				if level == "write" && perm != "issues" {
+					t.Errorf("tier %q requested %s:write — advisory tiers must not hold any repo write capability", tc.tier, perm)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

#2575 — a GHE hive's advisory digest floods with `guide agent cannot access repository` / `403 Resource not accessible by integration`, even though the App installation grants read+write to code, issues, and PRs. Advisory-tier agents had **no repo read path at all** — API and git both dead — yet their core function is reading the repo to audit it.

## Two coupled defects fixed

**1. `src/pkg/github/app.go` — scoped-token tier permissions.** The `advisor` tier omitted `Contents` entirely, so every contents/tarball API call 403'd regardless of what the installation grants. `newcomer` (ISSUES_ONLY) had `Issues:write` only. Fix: add `Contents:read` to `advisor`, and `Contents:read` + `Metadata:read` to `newcomer` (agents must read code to file meaningful issues). **No write permission is added** — `contents:write` remains absent from both tiers.

**2. `bin/git-credential-hive.sh` — mode block killed reads, not just writes.** The ADVISORY/ISSUES_ONLY/NO_GITHUB mode block (and the sub-L3 ACMM fallback) exited 1 before the `get` handler — but git uses the same credential helper for **fetch/clone and push**, and the credential protocol cannot distinguish them. This produced the `no clone mechanism available in L2 advisory mode` / `terminal prompts disabled` findings. Fix: `get` now serves the per-agent scoped token in those modes, with a one-line read-only notice so an agent whose push 403s sees why and doesn't loop.

## Security analysis (why this does not weaken write-prevention)

- The helper only ever reads the **per-agent** token cache (`HIVE_AGENT_TOKEN_CACHE`), minted per tier by `ScopedToken`. At `advisor`/`newcomer` tiers that token has **no `contents:write`**, so a push authenticates but is **rejected server-side by GitHub with 403** — enforcement the agent cannot bypass, unlike the client-side helper block.
- The refusal that guards a real boundary is **unchanged**: no fallback to the shared full-privilege App token cache (audit H3). An advisory agent still cannot obtain a write-capable credential through this helper. UID verification, token-access logging, and the https-only guard are untouched.
- `manager.go`'s blocked-action thrash markers still catch the remaining `git push blocked:` failures (unknown UID, missing token delivery); comment updated.

## Tests

- Go: `TestScopedToken_AdvisoryTiersRequestContentsRead` asserts advisor/newcomer request `contents:read` + `metadata:read`, advisor requests no issues at all, and neither tier requests any repo write.
- Shell: new `bin/test_git_credential_hive.sh` (wired into v2-ci) executes the helper: `get` returns a credential in ADVISORY/ISSUES_ONLY/NO_GITHUB and ACMM-fallback modes; read-only notice present; H3 refusals (missing/unset token file), https-only guard, GHE host echo, and no-token-leak on store all stay green. 15/15 pass; shellcheck clean.
- `go build ./... && go vet ./... && go test ./pkg/github/ -count=1` ✅

Closes #4289. Refs #2575.