### PR TITLE
✨ feat(worksource): carry source-aware task identity through scheduler and admission

### DIFF
--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -4888,7 +4888,14 @@ function ccInitInterestsEditor(){
   }).catch(function(){});
 }
 
-function ccQueueKey(q){return (q.repo||'')+'#'+(q.number||'');}
+// ccQueueKey is the identity the operator's HOLD and REORDER controls persist,
+// so it must be the server's canonical key (kubestellar/hive#4245). The server
+// now sends it as q.key: "owner/repo#42" for GitHub-backed work (unchanged) and
+// "owner/repo!ENG-123" for a string-keyed source. The fallback keeps rows from a
+// pre-#4245 server working; without the q.key preference an external item
+// produced "owner/repo#" — a key the server can never match, so holding or
+// reordering it silently did nothing.
+function ccQueueKey(q){return q.key||((q.repo||'')+'#'+(q.number||''));}
 
 // ccQueueSearch is the current VIEW filter text (lower-cased). It changes only what
 // is SHOWN — never the persisted order. Empty = show all. The reorder ACTIONS below
@@ -5003,10 +5010,13 @@ function ccRenderQueue(flip){
     // PR→issue badge (#2612 part c): if the triage poll resolved a fixing PR for
     // this issue (open/merged), show a small link. Absent until ccTriagePoll runs,
     // and simply omitted when no PR is linked — never blocks the queue render.
-    var prBadge=ccPRBadgeHTML((q.repo||'')+'#'+(q.number||''));
+    // PR links are a GitHub-only observer: an item with no issue number has no
+    // GitHub issue for a PR to close, so it gets no badge rather than a lookup
+    // on a fabricated key (kubestellar/hive#4245).
+    var prBadge=q.number?ccPRBadgeHTML((q.repo||'')+'#'+q.number):'';
     var enterCls=isNewQ?' cc-q-enter':'';
     return '<div class="cc-q-item'+mineCls+heldCls+enterCls+'"'+(canDrag?' draggable="true"':'')+' data-qkey="'+esc(ccQueueKey(q))+'">'+grip+'<span class="cc-q-idx">'+(i+1)+'</span>'+
-      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,(q.repo||'')+'#'+(q.number||''))+mineTag+heldTag+'</div>'+
+      '<div class="cc-q-body"><div class="cc-q-repo">'+ccIssueLinkHTML(q,ccQueueKey(q))+mineTag+heldTag+'</div>'+
       '<div class="cc-q-title" title="'+esc(q.title||'')+'">'+esc(q.title||'(untitled)')+'</div>'+labels+prBadge+'</div>'+next+menu+'</div>';
   }).join('');
   // Adopt the freshly-painted key set so the NEXT render only pops-in new arrivals.

--- a/src/pkg/dashboard/contribute_admission.go
+++ b/src/pkg/dashboard/contribute_admission.go
@@ -3,12 +3,40 @@ package dashboard
 import (
 	"github.com/kubestellar/hive/pkg/convergence"
 	ghpkg "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/worksource"
 )
 
 type contributorAdmissionCandidate struct {
 	repoFull string
 	repoName string
 	number   int
+	// ref is the candidate's canonical, source-aware identity
+	// (kubestellar/hive#4245). repoFull/repoName/number remain for the
+	// GitHub-only observers below, which can act on nothing else; ref is what
+	// every identity-keyed surface (hold, cooldown, active, order, task key)
+	// uses, so a Linear or Jira candidate is no longer indistinguishable from
+	// every other zero-numbered item.
+	//
+	// A zero ref means the caller predates source-aware identity; isGitHubBacked
+	// falls back to the number so such a caller behaves exactly as before.
+	ref worksource.Ref
+}
+
+// isGitHubBacked reports whether this candidate may be handed to the two
+// deliberately GitHub-only observers: the open-PR claim ledger and the legacy
+// bead dependency gate.
+//
+// Both accept a repository plus a POSITIVE issue number and can infer nothing
+// from an external work item. Passing them a Linear or Jira candidate would
+// mean synthesising "#0", which either matches an unrelated record or invents
+// one — so such a candidate SKIPS both observers instead. That is a deliberate
+// scope boundary, not a gap: GitHub is the first operational observer here, not
+// the identity ontology.
+func (c contributorAdmissionCandidate) isGitHubBacked() bool {
+	if c.ref != (worksource.Ref{}) {
+		return c.ref.IsGitHubIssue()
+	}
+	return c.repoFull != "" && c.number > 0
 }
 
 type contributorAdmissionDecision struct {
@@ -48,6 +76,17 @@ const (
 // cheapest and most specific "someone is already on it" signal, and short-
 // circuiting it keeps its existing log line and reason unchanged.
 func (h *ContributeWSHub) evaluateContributorNeutralAdmission(sweep *contributorAdmissionSweep, candidate contributorAdmissionCandidate) contributorAdmissionDecision {
+	// A candidate with no GitHub issue number skips BOTH observers below and is
+	// admitted on their behalf (kubestellar/hive#4245). Neither can express a
+	// judgment about external work: the claim ledger is keyed by GitHub issue
+	// number and the bead observer resolves "repo#N" refs. Admitting is the
+	// correct default because this gate is additive over having no gate — the
+	// alternative, refusing everything they cannot see, would make every Linear
+	// and Jira item permanently unofferable.
+	if !candidate.isGitHubBacked() {
+		return contributorAdmissionDecision{admitted: true}
+	}
+
 	claim, claimed := h.issueClaimedByOpenPR(candidate.repoFull, candidate.repoName, candidate.number)
 	if claimed {
 		return contributorAdmissionDecision{

--- a/src/pkg/dashboard/contribute_agent_roles.go
+++ b/src/pkg/dashboard/contribute_agent_roles.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"fmt"
+	"github.com/kubestellar/hive/pkg/worksource"
 	"strings"
 )
 
@@ -107,8 +108,18 @@ func (h *ContributeWSHub) roleKickPrompt(role string) string {
 	return h.server.deps.Scheduler.BuildAgentMessageFromLastActionable(role)
 }
 
+// buildRoleTaskPrompt is the GitHub-shaped entry point retained for existing
+// callers; buildRoleTaskPromptForRef is the identity-aware one
+// (kubestellar/hive#4245).
 func buildRoleTaskPrompt(repoFull string, number int, title, role, agentPrompt string) string {
-	base := buildTaskPrompt(repoFull, number, title)
+	return buildRoleTaskPromptForRef(worksource.Ref{Repo: repoFull, Number: number}, title, role, agentPrompt)
+}
+
+// buildRoleTaskPromptForRef wraps the source-aware assignment prompt in the
+// role framing. Only the base prompt carries work identity, so the role text
+// itself is unchanged for every source.
+func buildRoleTaskPromptForRef(ref worksource.Ref, title, role, agentPrompt string) string {
+	base := buildTaskPromptForRef(ref, title)
 	role = normalizeAgentRole(role)
 	if role == "" {
 		return base

--- a/src/pkg/dashboard/contribute_sse.go
+++ b/src/pkg/dashboard/contribute_sse.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/worksource"
 )
 
 // ── Operations command center: live SSE broadcast + ready-work queue ──────────
@@ -72,6 +73,18 @@ type ReadyQueueItem struct {
 	Title  string   `json:"title"`
 	URL    string   `json:"url,omitempty"`
 	Labels []string `json:"labels,omitempty"`
+	// Key, SourceType and ExternalID carry the item's canonical, source-aware
+	// identity (kubestellar/hive#4245). All three are additive and omitempty, so
+	// a GitHub-only hive's payload is byte-for-byte what it was.
+	//
+	// Key is the identity every exclusion and the operator's hold/order controls
+	// match on: "owner/repo#42" for GitHub-backed work (unchanged), and
+	// "owner/repo!ENG-123" for a string-keyed source. Number stays 0 for
+	// external work — clients that only understand GitHub keep reading it and
+	// simply do not recognise those rows, rather than seeing a bogus "#0".
+	Key        string `json:"key,omitempty"`
+	SourceType string `json:"source_type,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
 	// MatchesInterest is set true, per VIEWER, when at least one of the issue's
 	// labels exactly matches (case-insensitive) a label the viewing contributor
 	// declared interest in (issue #2637). It is a SOFT signal the Operations tab
@@ -94,6 +107,17 @@ type ReadyQueueItem struct {
 	// Empty when the operator held with no note, so the badge falls back to its
 	// generic text. omitempty so a hold without a reason is byte-for-byte unchanged.
 	HeldReason string `json:"held_reason,omitempty"`
+}
+
+// identityKey returns the canonical identity this row is matched by. It prefers
+// the explicit Key, and falls back to the GitHub "repo#number" spelling so a
+// row built by older code (or by a test constructing the struct literally) still
+// matches operator hold and order entries exactly as it always did.
+func (it ReadyQueueItem) identityKey() string {
+	if it.Key != "" {
+		return it.Key
+	}
+	return worksource.Ref{Repo: it.Repo, Number: it.Number}.Key()
 }
 
 // sseSubscriber is one connected browser. events is the fan-out channel; done is
@@ -241,37 +265,41 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 			if err := json.Unmarshal(b, &issue); err != nil {
 				continue
 			}
-			number := 0
-			switch n := issue["number"].(type) {
-			case float64:
-				number = int(n)
-			case int:
-				number = n
-			}
-			if number == 0 {
+			// Canonical, source-aware identity (kubestellar/hive#4245). The old
+			// code read only "number" and skipped zero, which dropped every
+			// Linear/Jira item from the queue outright. Now an item is skipped
+			// only when it has NO identity at all — no issue number AND no
+			// external key — because that is the one case where any key we
+			// invented would be a fabrication.
+			ref := refFromIssueMap(repo.Full, issue)
+			itemKey := ref.Key()
+			if itemKey == "" {
 				continue
 			}
+			number := ref.Number
 			// Operator HOLD (#queue-hold): a parked issue is never offered, so it is
 			// kept OUT of the offer-eligible `out` set. It is still collected into
 			// heldItems (tagged Held) so it stays visible-but-dimmed for the operator.
 			// Checked before cooldown/active so a held-AND-cooled issue still shows as
 			// held (the operator's manual decision is the stronger, persistent signal).
-			holdKey := fmt.Sprintf("%s#%d", repo.Full, number)
-			if _, isHeld := held[holdKey]; isHeld {
+			if _, isHeld := held[itemKey]; isHeld {
 				title, _ := issue["title"].(string)
 				url, _ := issue["url"].(string)
 				heldItems = append(heldItems, ReadyQueueItem{
 					Repo:       repo.Full,
 					Number:     number,
+					Key:        itemKey,
+					SourceType: ref.SourceType,
+					ExternalID: ref.ExternalID,
 					Title:      title,
 					URL:        url,
 					Labels:     stringSliceFromAny(issue["labels"]),
 					Held:       true,
-					HeldReason: holdReasons[holdKey], // "" when no note (map miss) — omitempty
+					HeldReason: holdReasons[itemKey], // "" when no note (map miss) — omitempty
 				})
 				continue
 			}
-			if h.isTaskInCooldown(repo.Full, number) {
+			if h.isTaskInCooldownKey(itemKey) {
 				continue
 			}
 			// #3987: a live no_work_needed verdict withholds the issue from the
@@ -279,19 +307,20 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 			// that pool — the two surfaces must agree (same contract the claim
 			// ledger admission pins). The hive AGENT pipeline does not read
 			// this ledger anywhere.
-			if h.isSuppressedByNoWorkVerdict(repo.Full, number, issueUpdatedAtFromMap(issue)) {
+			if h.isSuppressedByNoWorkVerdictKey(itemKey, issueUpdatedAtFromMap(issue)) {
 				continue
 			}
-			if h.isTaskInFailureCooldown(repo.Full, number) {
+			if h.isTaskInFailureCooldownKey(itemKey) {
 				continue
 			}
-			if active[fmt.Sprintf("%s#%d", repo.Full, number)] {
+			if active[itemKey] {
 				continue
 			}
 			decision := h.evaluateContributorNeutralAdmission(sweep, contributorAdmissionCandidate{
 				repoFull: repo.Full,
 				repoName: repo.Name,
 				number:   number,
+				ref:      ref,
 			})
 			if !decision.admitted {
 				continue
@@ -320,11 +349,14 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 			}
 
 			out = append(out, ReadyQueueItem{
-				Repo:   repo.Full,
-				Number: number,
-				Title:  title,
-				URL:    url,
-				Labels: labels,
+				Repo:       repo.Full,
+				Number:     number,
+				Key:        itemKey,
+				SourceType: ref.SourceType,
+				ExternalID: ref.ExternalID,
+				Title:      title,
+				URL:        url,
+				Labels:     labels,
 			})
 		}
 	}
@@ -413,7 +445,7 @@ func applyQueueOrder(items []ReadyQueueItem, order []string) {
 	// Unpinned items rank at len(idx) (all pinned ranks are < len(idx)), so they all
 	// sort behind every pinned item while SliceStable preserves their scan order.
 	rank := func(it ReadyQueueItem) int {
-		if r, ok := idx[fmt.Sprintf("%s#%d", it.Repo, it.Number)]; ok {
+		if r, ok := idx[it.identityKey()]; ok {
 			return r
 		}
 		return len(idx)

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -26,6 +27,7 @@ import (
 	"github.com/kubestellar/hive/pkg/advisory"
 	"github.com/kubestellar/hive/pkg/config"
 	ghpkg "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/worksource"
 )
 
 const (
@@ -223,6 +225,18 @@ type WSMessage struct {
 	URL     string   `json:"url,omitempty"`
 	Labels  []string `json:"labels,omitempty"`
 	Prompt  string   `json:"prompt,omitempty"`
+	// TaskKey, SourceType and ExternalID carry the assigned item's canonical,
+	// source-aware identity (kubestellar/hive#4245). All additive and omitempty:
+	// a GitHub task_assign is byte-for-byte unchanged, and Repo/Number keep
+	// their existing meaning for every relay written before these existed.
+	//
+	// A relay that understands them can report completion against TaskKey; one
+	// that does not keeps echoing repo/number, which the hub still resolves
+	// through the connection's own assignment record rather than trusting the
+	// client to name the work.
+	TaskKey    string `json:"task_key,omitempty"`
+	SourceType string `json:"source_type,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
 	// GitHubToken carries the scoped, expiring credential. As of #2537 it is
 	// NEVER populated on task_assign — the credential is split OUT of the
 	// assignment message and delivered only AFTER the task's acceptance decision,
@@ -313,6 +327,47 @@ type WSTaskAssign struct {
 	Repo   string `json:"repo"`
 	Number int    `json:"number"`
 	Title  string `json:"title"`
+	// Key, SourceType, ExternalID and URL carry the assigned item's canonical,
+	// source-aware identity (kubestellar/hive#4245). Additive and omitempty: a
+	// GitHub assignment is byte-for-byte what it was, and Number keeps its
+	// meaning for every existing consumer.
+	//
+	// Key is what the hub keys in-flight work on. Without it two different
+	// zero-numbered external items both resolved to "repo#0" and the
+	// double-assignment guard treated them as the SAME task — one would block
+	// the other, and a completion for one would settle the other.
+	Key        string `json:"key,omitempty"`
+	SourceType string `json:"source_type,omitempty"`
+	ExternalID string `json:"external_id,omitempty"`
+	URL        string `json:"url,omitempty"`
+}
+
+// identityKey returns the canonical identity of the assigned item. It prefers
+// the explicit Key and falls back to the GitHub "repo#number" spelling, so a
+// task assigned before this field existed — or restored from a persisted
+// pre-upgrade record — keys exactly as it always did.
+func (t *WSTaskAssign) identityKey() string {
+	if t == nil {
+		return ""
+	}
+	if t.Key != "" {
+		return t.Key
+	}
+	return worksource.Ref{Repo: t.Repo, Number: t.Number}.Key()
+}
+
+// ref reconstructs the assigned item's source-aware reference.
+func (t *WSTaskAssign) ref() worksource.Ref {
+	if t == nil {
+		return worksource.Ref{}
+	}
+	return worksource.Ref{
+		SourceType: t.SourceType,
+		Repo:       t.Repo,
+		ExternalID: t.ExternalID,
+		Number:     t.Number,
+		URL:        t.URL,
+	}
 }
 
 const maxActivityEntries = 50
@@ -1083,10 +1138,16 @@ func normalizeCompletionVerdict(reported, verifiedPR string) string {
 // or void it. Like every completion cooldown, the operator kill-switch
 // disables the exclusion entirely.
 func (h *ContributeWSHub) isSuppressedByNoWorkVerdict(repo string, number int, issueUpdatedAt time.Time) bool {
+	return h.isSuppressedByNoWorkVerdictKey(worksource.Ref{Repo: repo, Number: number}.Key(), issueUpdatedAt)
+}
+
+func (h *ContributeWSHub) isSuppressedByNoWorkVerdictKey(key string, issueUpdatedAt time.Time) bool {
 	if !h.cooldownEnabled() {
 		return false
 	}
-	key := fmt.Sprintf("%s#%d", repo, number)
+	if key == "" {
+		return false
+	}
 	h.completedMu.Lock()
 	rec, ok := h.noWorkVerdicts[key]
 	if !ok {
@@ -1302,7 +1363,17 @@ func (h *ContributeWSHub) markTaskCompleted(repo string, number int, prURL strin
 // field — and for hubs where the verdict is later voided — is unchanged.
 // reporter/reason are audit-only and stored with the verdict.
 func (h *ContributeWSHub) markTaskCompletedVerdict(repo string, number int, prURL, verdict, reporter, reason string) {
-	key := fmt.Sprintf("%s#%d", repo, number)
+	h.markTaskCompletedVerdictKey(worksource.Ref{Repo: repo, Number: number}.Key(), prURL, verdict, reporter, reason)
+}
+
+// markTaskCompletedVerdictKey books completion against the canonical identity
+// (kubestellar/hive#4245), so a Linear or Jira task's cooldown and verdict land
+// on that item rather than on a shared "repo#0" record that would suppress
+// every other zero-numbered item in the repository.
+func (h *ContributeWSHub) markTaskCompletedVerdictKey(key string, prURL, verdict, reporter, reason string) {
+	if key == "" {
+		return
+	}
 	// The WITH-PR period is operator-tunable (Config.Hub.ContributeCooldownHours,
 	// default completedTaskCooldownHours). We still RECORD this even when cooldown
 	// is disabled — isTaskInCooldown short-circuits the gating, so the history is
@@ -1556,7 +1627,15 @@ func (h *ContributeWSHub) cooldownForLocked(key string) time.Duration {
 	return h.configuredWithPRCooldown()
 }
 
+// isTaskInCooldown is the GitHub-shaped wrapper retained for the many call
+// sites that legitimately hold a repo and an issue number. Identity-keyed
+// callers (ReadyQueue, selectTask) use isTaskInCooldownKey directly so external
+// work gets its own cooldown instead of sharing "repo#0" (kubestellar/hive#4245).
 func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
+	return h.isTaskInCooldownKey(worksource.Ref{Repo: repo, Number: number}.Key())
+}
+
+func (h *ContributeWSHub) isTaskInCooldownKey(key string) bool {
 	// Operator kill-switch: when cooldown is disabled, no completed issue is ever
 	// gated out of the queue for cooldown. Completion HISTORY is still recorded by
 	// markTaskCompleted (stats/audit, #2356 duplicate detection) and failure
@@ -1564,7 +1643,9 @@ func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
 	if !h.cooldownEnabled() {
 		return false
 	}
-	key := fmt.Sprintf("%s#%d", repo, number)
+	if key == "" {
+		return false
+	}
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
 	t, ok := h.completedTasks[key]
@@ -1587,7 +1668,21 @@ func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
 // earns the longer quarantine window instead of being handed straight back out.
 // The counter is reset on completion (see markTaskCompleted).
 func (h *ContributeWSHub) recordTaskFailure(repo string, number int, permanent bool) {
-	key := fmt.Sprintf("%s#%d", repo, number)
+	h.recordTaskFailureKey(worksource.Ref{Repo: repo, Number: number}.Key(), permanent)
+}
+
+// recordTaskFailureForTask books a failure against the assignment's own
+// canonical identity (kubestellar/hive#4245). Every caller already holds the
+// WSTaskAssign, so routing through it keeps external work's failure history and
+// quarantine separate instead of merging onto "repo#0".
+func (h *ContributeWSHub) recordTaskFailureForTask(task *WSTaskAssign, permanent bool) {
+	h.recordTaskFailureKey(task.identityKey(), permanent)
+}
+
+func (h *ContributeWSHub) recordTaskFailureKey(key string, permanent bool) {
+	if key == "" {
+		return
+	}
 	weight := 1
 	if permanent {
 		weight = permanentFailureWeight
@@ -1655,7 +1750,13 @@ func (h *ContributeWSHub) failureCooldownForLocked(key string) time.Duration {
 //     deprioritise it behind never-failed peers rather than instantly restoring
 //     it to the head of the queue. The count also resets on completion.
 func (h *ContributeWSHub) isTaskInFailureCooldown(repo string, number int) bool {
-	key := fmt.Sprintf("%s#%d", repo, number)
+	return h.isTaskInFailureCooldownKey(worksource.Ref{Repo: repo, Number: number}.Key())
+}
+
+func (h *ContributeWSHub) isTaskInFailureCooldownKey(key string) bool {
+	if key == "" {
+		return false
+	}
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
 	t, ok := h.failedTasks[key]
@@ -1685,7 +1786,13 @@ func (h *ContributeWSHub) isTaskInFailureCooldown(repo string, number int) bool 
 // before those that have failed recently — guaranteeing forward progress even if
 // the failure cooldown has just elapsed (#2435 remedy 3 backstop).
 func (h *ContributeWSHub) recentFailureCount(repo string, number int) int {
-	key := fmt.Sprintf("%s#%d", repo, number)
+	return h.recentFailureCountKey(worksource.Ref{Repo: repo, Number: number}.Key())
+}
+
+func (h *ContributeWSHub) recentFailureCountKey(key string) int {
+	if key == "" {
+		return 0
+	}
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
 	return h.consecutiveFailures[key]
@@ -1773,7 +1880,7 @@ func (h *ContributeWSHub) bookAndRevokeReleased(targets []releaseTarget, reason,
 		// the released issue is not instantly re-offered. Only real issue tasks are
 		// booked; synthetic pr-review tasks (Number == 0) must not poison an issue key.
 		if tgt.task.Number > 0 {
-			h.recordTaskFailure(tgt.task.Repo, tgt.task.Number, false)
+			h.recordTaskFailureForTask(&tgt.task, false)
 		}
 		username := ""
 		if tgt.conn.profile != nil {
@@ -1857,17 +1964,31 @@ func (h *ContributeWSHub) DisconnectContributor(contributorID, reason string) in
 // The NUL separator cannot appear in a contributor id or a "repo#number" key, so the two
 // fields can never collide across a boundary.
 func yankExcludeKey(contributorID, repo string, number int) string {
-	return contributorID + "\x00" + fmt.Sprintf("%s#%d", repo, number)
+	return yankExcludeKeyFor(contributorID, worksource.Ref{Repo: repo, Number: number}.Key())
+}
+
+// yankExcludeKeyFor scopes a yank self-exclusion to (contributor, work item)
+// using the canonical identity, so two zero-numbered external items do not
+// share one exclusion (kubestellar/hive#4245).
+func yankExcludeKeyFor(contributorID, itemKey string) string {
+	return contributorID + "\x00" + itemKey
 }
 
 // isYankSelfExcluded reports whether repo#number is still within its brief yank
 // self-exclusion window for contributorID (set the item was just yanked off this
 // clanker). Expired entries are pruned lazily here. Caller must hold h.mu.
 func (h *ContributeWSHub) isYankSelfExcludedLocked(contributorID, repo string, number int) bool {
-	if number <= 0 || len(h.yankExclusions) == 0 {
+	if number <= 0 {
 		return false
 	}
-	key := yankExcludeKey(contributorID, repo, number)
+	return h.isYankSelfExcludedKeyLocked(contributorID, worksource.Ref{Repo: repo, Number: number}.Key())
+}
+
+func (h *ContributeWSHub) isYankSelfExcludedKeyLocked(contributorID, itemKey string) bool {
+	if itemKey == "" || len(h.yankExclusions) == 0 {
+		return false
+	}
+	key := yankExcludeKeyFor(contributorID, itemKey)
 	exp, ok := h.yankExclusions[key]
 	if !ok {
 		return false
@@ -2872,7 +2993,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				// the very selectTask call below. Synthetic pr-review tasks carry
 				// Number == 0 and must not poison an issue key.
 				if abandoned.Number > 0 {
-					h.recordTaskFailure(abandoned.Repo, abandoned.Number, false)
+					h.recordTaskFailureForTask(abandoned, false)
 				}
 			}
 			h.logger.Info("[contribute-ws] ready for work",
@@ -3219,7 +3340,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						// instantly re-offered in a tight loop). #3987: a no_work_needed
 						// verdict additionally books the durable offer-suppression
 						// verdict (see markTaskCompletedVerdict).
-						h.markTaskCompletedVerdict(completedTask.Repo, completedTask.Number, verifiedPR,
+						h.markTaskCompletedVerdictKey(completedTask.identityKey(), verifiedPR,
 							verdict, contributor.profile.GitHubUsername, strings.TrimSpace(msg.VerdictReason))
 					}
 					completedDesc := msg.TaskID
@@ -3332,7 +3453,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						// issue is not immediately re-admissible and handed straight
 						// back out ahead of the rest of the queue. A permanent failure
 						// counts more toward the quarantine threshold.
-						h.recordTaskFailure(failedTask.Repo, failedTask.Number, msg.Permanent)
+						h.recordTaskFailureForTask(failedTask, msg.Permanent)
 					}
 					// #2547: keep the failure reason instead of only logging it, so an
 					// operator can tell a work item that failed on its merits from one
@@ -3765,7 +3886,7 @@ func (h *ContributeWSHub) reclaimExpiredLeases(now time.Time) int {
 		// lease so the wedged worker cannot re-adopt it via a later task_progress.
 		h.revokeLease(identityOf(tgt.conn), tgt.task.TaskID)
 		if tgt.task.Number > 0 {
-			h.recordTaskFailure(tgt.task.Repo, tgt.task.Number, false)
+			h.recordTaskFailureForTask(&tgt.task, false)
 		}
 		username := ""
 		if tgt.conn.profile != nil {
@@ -3980,7 +4101,64 @@ func (h *ContributeWSHub) taskUnavailable(reason string) *WSMessage {
 // is safe to preview read-only in the ops tab (#2539). selectTask ships whatever
 // this returns, and the ops preview reads the very same string back off the
 // connection, so "what is previewed" always matches "what runs".
+// buildTaskPrompt is the GitHub-shaped entry point retained for existing call
+// sites (ops-tab prompt preview, tests). New identity-aware callers use
+// buildTaskPromptForRef.
 func buildTaskPrompt(repoFull string, number int, title string) string {
+	return buildTaskPromptForRef(worksource.Ref{Repo: repoFull, Number: number}, title)
+}
+
+// buildTaskPromptForRef renders the assignment prompt for any work source
+// (kubestellar/hive#4245).
+//
+// The issue reference used to be formatted "%s#%d" straight from repo+number,
+// so a Linear or Jira task told the agent to "Work on issue owner/repo#0" — a
+// reference to nothing, with the item's real key and URL nowhere in the prompt.
+// The reference is now the canonical key, and non-GitHub work additionally
+// carries its URL, because that is the only way an agent can actually open it:
+// there is no `gh issue view` for a Linear ticket.
+//
+// The repository instructions are unchanged and still name the GitHub repo —
+// external work is planned elsewhere but still landed as a PR here.
+func buildTaskPromptForRef(ref worksource.Ref, title string) string {
+	repoFull := ref.Repo
+	issueRef := ref.Key()
+	if issueRef == "" {
+		issueRef = repoFull
+	}
+	// An external item's URL is the agent's only route to the work item itself.
+	// GitHub-backed work needs no such hint: `owner/repo#42` is directly
+	// actionable, and appending a URL there would change every existing prompt.
+	sourceHint := ""
+	if !ref.IsGitHubIssue() && ref.URL != "" {
+		sourceHint = fmt.Sprintf(
+			" This work item lives in the %s work source, not in GitHub Issues; read it at %s.",
+			sourceLabel(ref.SourceType), ref.URL)
+	}
+	return buildTaskPromptBody(repoFull, issueRef, title, sourceHint)
+}
+
+// taskIDSegment is the per-item component of a task id. For GitHub-backed work
+// it is the decimal issue number, which keeps the id exactly the shape it has
+// always had; for a string-keyed source it is the native external id, so two
+// zero-numbered items minted in the same second get different ids.
+func taskIDSegment(ref worksource.Ref) string {
+	if ref.Number > 0 {
+		return strconv.Itoa(ref.Number)
+	}
+	return ref.ExternalID
+}
+
+// sourceLabel renders a work-source type for prose. An empty type means the
+// item came from GitHub enumeration, which predates the field.
+func sourceLabel(sourceType string) string {
+	if sourceType == "" {
+		return "github"
+	}
+	return sourceType
+}
+
+func buildTaskPromptBody(repoFull, issueRef, title, sourceHint string) string {
 	// The workspace contract (kubestellar/hive#2545): your tmux pane already
 	// starts rooted in $HIVE_WORKSPACE_DIR (contributor-agent.sh creates it and
 	// launches the session with -c pointed there), but nothing had put a repo
@@ -3991,7 +4169,7 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 	// assignment slot stayed held. Spell out an actual clone into that known
 	// directory so there is a concrete first step rather than an implied one.
 	return fmt.Sprintf(
-		"You are a contributor to the %s hive. Work on issue %s#%d: \"%s\". "+
+		"You are a contributor to the %s hive. Work on issue %s: \"%s\".%s "+
 			"You do NOT have push access to the upstream repo. "+
 			"Start by getting a real checkout on disk: "+
 			"'gh repo fork %s --clone=true --remote=true "+
@@ -4037,7 +4215,7 @@ func buildTaskPrompt(repoFull string, number int, title string) string {
 			"PRs already cover everything actionable — do NOT open a PR; instead print "+
 			"a single line of the exact form 'HIVE_VERDICT: no_work_needed — <short reason>' "+
 			"and stop.",
-		repoFull, repoFull, number, title, repoFull, repoFull,
+		repoFull, issueRef, title, sourceHint, repoFull, repoFull,
 	)
 }
 
@@ -4257,7 +4435,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	for _, conn := range h.connections {
 		conn.mu.Lock()
 		if conn.currentTask != nil {
-			activeIssues[fmt.Sprintf("%s#%d", conn.currentTask.Repo, conn.currentTask.Number)] = true
+			if key := conn.currentTask.identityKey(); key != "" {
+				activeIssues[key] = true
+			}
 			identityHolds[identityOf(conn)]++
 		}
 		conn.mu.Unlock()
@@ -4386,11 +4566,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	type candidate struct {
 		repoFull string
 		number   int
-		title    string
-		url      string
-		labels   []string
-		lane     string
-		isOwn    bool
+		// ref is the candidate's canonical, source-aware identity
+		// (kubestellar/hive#4245). Every exclusion below keys on ref.Key(), so
+		// two zero-numbered external items are distinct work rather than one
+		// shared "repo#0".
+		ref    worksource.Ref
+		title  string
+		url    string
+		labels []string
+		lane   string
+		isOwn  bool
 		// interestMatch is true when the issue carries a label the contributor has
 		// opted into (#2637). It is a SOFT priority tier below own-work: matching
 		// work is offered first, but a contributor with no match still gets other
@@ -4433,25 +4618,27 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				continue
 			}
 
-			number := 0
-			switch n := issue["number"].(type) {
-			case float64:
-				number = int(n)
-			case int:
-				number = n
-			}
-			if number == 0 {
-				h.logger.Info("[contribute-ws] skip: number=0", "repo", repo.Full)
+			// Canonical, source-aware identity (kubestellar/hive#4245). The old
+			// `number == 0` skip rejected every Linear and Jira item outright,
+			// so non-GitHub work could never be offered to a contributor at all.
+			// An item is now skipped only when it has NO identity — no issue
+			// number AND no external key — which is the one case where any key
+			// would be fabricated.
+			ref := refFromIssueMap(repo.Full, issue)
+			itemKey := ref.Key()
+			if itemKey == "" {
+				h.logger.Info("[contribute-ws] skip: item has no usable identity (no number, no external id)", "repo", repo.Full)
 				continue
 			}
+			number := ref.Number
 			// Operator HOLD (#queue-hold): skip a manually-parked issue outright. This
 			// is a persistent operator decision, DISTINCT from the time-based cooldown
 			// below — a held issue never becomes a candidate until the operator Resumes
 			// it. Keyed on the same canonical "%s#%d" as every other exclusion.
-			if _, isHeld := heldIssues[fmt.Sprintf("%s#%d", repo.Full, number)]; isHeld {
+			if _, isHeld := heldIssues[itemKey]; isHeld {
 				continue
 			}
-			if h.isTaskInCooldown(repo.Full, number) {
+			if h.isTaskInCooldownKey(itemKey) {
 				continue
 			}
 			// #3987: skip an issue with a live no_work_needed completion verdict
@@ -4459,16 +4646,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			// gated, no open PR left for the claim ledger to see). The verdict
 			// is voided the moment the issue shows activity newer than it, so a
 			// genuinely reopened issue comes straight back into the pool.
-			if h.isSuppressedByNoWorkVerdict(repo.Full, number, issueUpdatedAtFromMap(issue)) {
+			if h.isSuppressedByNoWorkVerdictKey(itemKey, issueUpdatedAtFromMap(issue)) {
 				continue
 			}
 			// #2435: skip an issue still inside its short post-failure cooldown or
 			// its longer quarantine. This is the primary livelock fix — a failing
 			// issue at the head of the scan is no longer instantly re-admissible.
-			if h.isTaskInFailureCooldown(repo.Full, number) {
+			if h.isTaskInFailureCooldownKey(itemKey) {
 				continue
 			}
-			if activeIssues[fmt.Sprintf("%s#%d", repo.Full, number)] {
+			if activeIssues[itemKey] {
 				continue
 			}
 			// #3768: skip an issue that an open PR — from ANYONE, hive agent or
@@ -4486,6 +4673,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				repoFull: repo.Full,
 				repoName: repo.Name,
 				number:   number,
+				ref:      ref,
 			})
 			if !decision.admitted {
 				switch decision.reason {
@@ -4514,7 +4702,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			// contributor may still be offered the issue immediately. Guarded by h.mu.
 			if c.profile != nil {
 				h.mu.Lock()
-				selfExcluded := h.isYankSelfExcludedLocked(c.profile.ContributorID, repo.Full, number)
+				selfExcluded := h.isYankSelfExcludedKeyLocked(c.profile.ContributorID, itemKey)
 				h.mu.Unlock()
 				if selfExcluded {
 					continue
@@ -4582,6 +4770,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			candidates = append(candidates, candidate{
 				repoFull: repo.Full,
 				number:   number,
+				ref:      ref,
 				title:    title,
 				url:      url,
 				// The issue's own labels travel with the candidate so the chosen
@@ -4597,7 +4786,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				interestMatch: interestMatchesLabels(labels),
 				// #2435: carry any lingering failure history so the ordering below
 				// can deprioritise a recently-failed issue within its bucket.
-				recentFailures: h.recentFailureCount(repo.Full, number),
+				recentFailures: h.recentFailureCountKey(itemKey),
 			})
 		}
 	}
@@ -4688,7 +4877,11 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		return h.taskUnavailable(taskUnavailableTokenMintFailed)
 	}
 
-	taskID := fmt.Sprintf("ct-%s-%d-%d", chosen.repoFull, chosen.number, time.Now().Unix())
+	// The task id carries the item's own identity segment so two zero-numbered
+	// external items cannot mint the same id within one second
+	// (kubestellar/hive#4245). GitHub-backed work keeps its historical
+	// "ct-<repo>-<number>-<unix>" shape byte for byte.
+	taskID := fmt.Sprintf("ct-%s-%s-%d", chosen.repoFull, taskIDSegment(chosen.ref), time.Now().Unix())
 
 	// #2539: build the prompt through the shared, credential-free buildTaskPrompt
 	// so the exact text shipped in task_assign below can also be PREVIEWED
@@ -4697,9 +4890,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// the prompt), so previewing the prompt can never leak the token. buildTaskPrompt
 	// itself carries the #2545 workspace-clone instruction (real checkout into
 	// $HIVE_WORKSPACE_DIR rather than a fork-only --clone=false).
-	prompt := buildTaskPrompt(chosen.repoFull, chosen.number, chosen.title)
+	prompt := buildTaskPromptForRef(chosen.ref, chosen.title)
 	if requestedRole != "" {
-		prompt = buildRoleTaskPrompt(chosen.repoFull, chosen.number, chosen.title, requestedRole, h.roleKickPrompt(requestedRole))
+		prompt = buildRoleTaskPromptForRef(chosen.ref, chosen.title, requestedRole, h.roleKickPrompt(requestedRole))
 	}
 	// #4105: tell the agent up front — from the hub's own handshake-recorded
 	// invocation values — the exact attribution trailer its PR body must end
@@ -4714,12 +4907,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 
 	c.mu.Lock()
 	c.currentTask = &WSTaskAssign{
-		TaskID: taskID,
-		Kind:   "issue",
-		Role:   requestedRole,
-		Repo:   chosen.repoFull,
-		Number: chosen.number,
-		Title:  chosen.title,
+		TaskID:     taskID,
+		Kind:       "issue",
+		Role:       requestedRole,
+		Repo:       chosen.repoFull,
+		Number:     chosen.number,
+		Title:      chosen.title,
+		Key:        chosen.ref.Key(),
+		SourceType: chosen.ref.SourceType,
+		ExternalID: chosen.ref.ExternalID,
+		URL:        chosen.url,
 	}
 	c.currentTaskGen = gen
 	// #2568: start the hub-owned lease clock. task_progress renews it; cleanupLoop
@@ -4768,6 +4965,13 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		Number:  chosen.number,
 		Title:   chosen.title,
 		URL:     chosen.url,
+		// Source-aware identity (kubestellar/hive#4245). Additive: a GitHub
+		// assignment carries exactly the fields it always did, and these tell a
+		// relay working a Linear or Jira item what the item actually IS instead
+		// of leaving it to infer one from `number: 0`.
+		TaskKey:    chosen.ref.Key(),
+		SourceType: chosen.ref.SourceType,
+		ExternalID: chosen.ref.ExternalID,
 		// #2537: NO github_token / token_expires_at here. The scoped credential is
 		// split out of task_assign and delivered only after acceptance (see
 		// pendingToken / deliverTaskCredential). task_assign now carries exactly the

--- a/src/pkg/dashboard/worksource_identity.go
+++ b/src/pkg/dashboard/worksource_identity.go
@@ -1,0 +1,54 @@
+package dashboard
+
+import (
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// refFromIssueMap builds the canonical, source-aware identity for one
+// actionable item as it appears in the dashboard status payload
+// (kubestellar/hive#4245).
+//
+// ReadyQueue and selectTask both read actionable issues as generic maps — the
+// status payload round-trips through JSON, so the concrete github.Issue type is
+// gone by the time they see it. Both used to read only the integer "number",
+// skip anything at zero, and rebuild "repo#number" inline. That silently
+// dropped every Linear and Jira item (they have no issue number) and, wherever
+// a zero-numbered item did survive, collapsed unrelated work onto one "repo#0"
+// identity — one hold, one cooldown, one active slot shared between them.
+//
+// repoFull scopes the identity, so the same external key in two repositories
+// stays distinct. The returned Ref has an empty Key() when the item carries no
+// usable identity at all; callers must skip such an item rather than
+// fabricating a key for it.
+func refFromIssueMap(repoFull string, issue map[string]any) worksource.Ref {
+	return worksource.Ref{
+		SourceType: stringFromAny(issue["source_type"]),
+		Repo:       repoFull,
+		ExternalID: stringFromAny(issue["external_id"]),
+		Number:     intFromAny(issue["number"]),
+		URL:        stringFromAny(issue["url"]),
+	}
+}
+
+// intFromAny reads an integer that survived a JSON round-trip. encoding/json
+// decodes every number into float64 when the target is `any`, but the value can
+// still arrive as a real int when the payload was never marshalled (tests, and
+// the in-process status builder), so both are accepted.
+func intFromAny(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	}
+	return 0
+}
+
+// stringFromAny reads a string field, yielding "" for a missing or
+// wrongly-typed value rather than panicking on the type assertion.
+func stringFromAny(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/src/pkg/dashboard/worksource_identity_production_test.go
+++ b/src/pkg/dashboard/worksource_identity_production_test.go
@@ -1,0 +1,553 @@
+package dashboard
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// ── Source-aware task identity, proven on the production path (#4245) ────────
+//
+// Every test here drives the REAL ReadyQueue / admission code, not a helper.
+// That is the point: the failure mode this issue describes is a migration that
+// passes TaskKey unit tests while production still formats its own "repo#0".
+// A helper-only test cannot tell those apart.
+
+// externalItem builds one actionable item as the status payload carries it: a
+// JSON-shaped map with no issue number, which is exactly how a Linear or Jira
+// item arrives after worksource.ToGitHubIssues projects it.
+func externalItem(sourceType, externalID, title string) map[string]any {
+	return map[string]any{
+		"number":      float64(0),
+		"source_type": sourceType,
+		"external_id": externalID,
+		"title":       title,
+		"url":         "https://linear.app/acme/issue/" + externalID,
+		"labels":      []any{},
+	}
+}
+
+func githubItem(number int, title string) map[string]any {
+	return map[string]any{
+		"number": float64(number),
+		"title":  title,
+		"labels": []any{},
+	}
+}
+
+func statusWith(repoFull string, items ...map[string]any) *StatusPayload {
+	anyItems := make([]any, 0, len(items))
+	for _, it := range items {
+		anyItems = append(anyItems, it)
+	}
+	return &StatusPayload{
+		Repos: []FrontendRepo{{Name: repoFull, Full: repoFull, ActionableIssues: anyItems}},
+	}
+}
+
+func newQueueServer(t *testing.T, status *StatusPayload) *Server {
+	t.Helper()
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+	s.statusMu.Lock()
+	s.status = status
+	s.statusMu.Unlock()
+	return s
+}
+
+func wsKeysOf(items []ReadyQueueItem) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.identityKey())
+	}
+	return out
+}
+
+// TestExternalItemsSurviveWithDistinctIdentities is the headline row of the
+// acceptance matrix: two work items in ONE repository, both with Number == 0
+// and different native keys.
+//
+// Against the pre-#4245 path this fails twice over — ReadyQueue skipped
+// `number == 0` outright, so neither item appeared at all, and anything that
+// did survive would have keyed on "acme/repo#0".
+func TestExternalItemsSurviveWithDistinctIdentities(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		externalItem("linear", "ENG-123", "first external item"),
+		externalItem("linear", "ENG-456", "second external item"),
+	))
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 2 {
+		t.Fatalf("both external items must reach the queue, got %d: %+v", len(q), q)
+	}
+
+	keys := wsKeysOf(q)
+	if keys[0] == keys[1] {
+		t.Fatalf("distinct external items collapsed onto one identity: %v", keys)
+	}
+	want := []string{"acme/repo!ENG-123", "acme/repo!ENG-456"}
+	for i, w := range want {
+		if keys[i] != w {
+			t.Errorf("item %d: identity = %q, want %q", i, keys[i], w)
+		}
+	}
+	for _, it := range q {
+		if strings.HasSuffix(it.identityKey(), "#0") {
+			t.Errorf("item rendered the fabricated #0 identity: %+v", it)
+		}
+		if it.ExternalID == "" || it.SourceType != "linear" {
+			t.Errorf("source-aware fields not carried through the queue projection: %+v", it)
+		}
+	}
+}
+
+// TestSameExternalKeyInTwoRepositoriesStaysDistinct pins repository scoping: the
+// same native key filed against two repositories is two different pieces of work.
+func TestSameExternalKeyInTwoRepositoriesStaysDistinct(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+	s.statusMu.Lock()
+	s.status = &StatusPayload{Repos: []FrontendRepo{
+		{Name: "acme/one", Full: "acme/one", ActionableIssues: []any{externalItem("jira", "ENG-1", "in repo one")}},
+		{Name: "acme/two", Full: "acme/two", ActionableIssues: []any{externalItem("jira", "ENG-1", "in repo two")}},
+	}}
+	s.statusMu.Unlock()
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 2 {
+		t.Fatalf("expected one item per repository, got %d: %+v", len(q), q)
+	}
+	if q[0].identityKey() == q[1].identityKey() {
+		t.Fatalf("same external key in two repositories collapsed: %v", wsKeysOf(q))
+	}
+	if q[0].identityKey() != "acme/one!ENG-1" || q[1].identityKey() != "acme/two!ENG-1" {
+		t.Fatalf("repository scope lost: %v", wsKeysOf(q))
+	}
+}
+
+// TestGitHubKeysRemainByteIdentical is the compatibility guard. These strings
+// are PERSISTED (holds, queue order, cooldowns, the claim ledger), so changing
+// their spelling would silently discard every existing exclusion on restart.
+func TestGitHubKeysRemainByteIdentical(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo", githubItem(42, "a github issue")))
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 1 {
+		t.Fatalf("expected the github issue, got %+v", q)
+	}
+	if got := q[0].identityKey(); got != "acme/repo#42" {
+		t.Fatalf("github identity = %q, want the unchanged %q", got, "acme/repo#42")
+	}
+	if q[0].Number != 42 {
+		t.Errorf("Number must keep its meaning for existing clients, got %d", q[0].Number)
+	}
+	if q[0].SourceType != "" || q[0].ExternalID != "" {
+		t.Errorf("github enumeration must not invent source fields: %+v", q[0])
+	}
+}
+
+// TestGitHubProjectsItemBackedByIssueKeepsGitHubIdentity covers the row that is
+// easy to get wrong: a Projects item IS externally sourced, but it is backed by
+// a real issue number and must therefore stay GitHub-keyed and keep exercising
+// the GitHub-only guards.
+func TestGitHubProjectsItemBackedByIssueKeepsGitHubIdentity(t *testing.T) {
+	item := githubItem(77, "a projects-tracked issue")
+	item["source_type"] = "github_projects"
+	item["external_id"] = "77"
+
+	s := newQueueServer(t, statusWith("acme/repo", item))
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 1 {
+		t.Fatalf("expected the projects item, got %+v", q)
+	}
+	if got := q[0].identityKey(); got != "acme/repo#77" {
+		t.Fatalf("projects item keyed as %q, want the GitHub form %q", got, "acme/repo#77")
+	}
+
+	ref := worksource.Ref{SourceType: "github_projects", Repo: "acme/repo", ExternalID: "77", Number: 77}
+	if !ref.IsGitHubIssue() {
+		t.Fatal("a projects item backed by a real issue number must remain GitHub-backed for the claim and bead observers")
+	}
+}
+
+// TestOperatorHoldIsolatesOneExternalItem proves the hold state is per-item.
+// Sharing "repo#0" meant holding one external item parked every other
+// zero-numbered item in the repository.
+func TestOperatorHoldIsolatesOneExternalItem(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		externalItem("linear", "ENG-1", "held one"),
+		externalItem("linear", "ENG-2", "still offerable"),
+	))
+	s.deps.Config.Hub.ContributeQueueHold = []string{"acme/repo!ENG-1"}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 2 {
+		t.Fatalf("both items should still be surfaced, got %+v", q)
+	}
+
+	var held, offerable []ReadyQueueItem
+	for _, it := range q {
+		if it.Held {
+			held = append(held, it)
+		} else {
+			offerable = append(offerable, it)
+		}
+	}
+	if len(held) != 1 || held[0].identityKey() != "acme/repo!ENG-1" {
+		t.Fatalf("exactly ENG-1 should be held, got held=%v", wsKeysOf(held))
+	}
+	if len(offerable) != 1 || offerable[0].identityKey() != "acme/repo!ENG-2" {
+		t.Fatalf("ENG-2 must remain offerable, got offerable=%v", wsKeysOf(offerable))
+	}
+}
+
+// TestCompletionCooldownIsolatesOneExternalItem proves completion state is
+// per-item too: finishing one external item must not silence its neighbour.
+func TestCompletionCooldownIsolatesOneExternalItem(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		externalItem("jira", "OPS-1", "just completed"),
+		externalItem("jira", "OPS-2", "untouched"),
+	))
+
+	s.contributeHub.markTaskCompletedVerdictKey("acme/repo!OPS-1", "https://github.com/acme/repo/pull/9",
+		completionVerdictIdle, "", "")
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 1 {
+		t.Fatalf("exactly the untouched item should remain offerable, got %v", wsKeysOf(q))
+	}
+	if q[0].identityKey() != "acme/repo!OPS-2" {
+		t.Fatalf("wrong item survived the cooldown: %v", wsKeysOf(q))
+	}
+}
+
+// TestOperatorQueueOrderAcceptsExternalKeys proves the persisted operator
+// ordering control works on the canonical key, so an operator can pin external
+// work exactly as they pin GitHub work.
+func TestOperatorQueueOrderAcceptsExternalKeys(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		externalItem("linear", "ENG-1", "first in scan order"),
+		externalItem("linear", "ENG-2", "second in scan order"),
+	))
+	s.deps.Config.Hub.ContributeQueueOrder = []string{"acme/repo!ENG-2"}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 2 {
+		t.Fatalf("expected both items, got %+v", q)
+	}
+	if q[0].identityKey() != "acme/repo!ENG-2" {
+		t.Fatalf("operator pin ignored for an external key: %v", wsKeysOf(q))
+	}
+}
+
+// TestGitHubOnlyObserversSkipExternalWork is the observer-authority row. The
+// claim ledger is asked about GitHub candidates (positive control) and must
+// never be consulted for an external item — asking it at all would mean
+// synthesising a "#0" subject.
+func TestGitHubOnlyObserversSkipExternalWork(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		githubItem(5, "a real github issue"),
+		externalItem("linear", "ENG-9", "external work"),
+	))
+
+	var mu sync.Mutex
+	var asked []string
+	s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+		mu.Lock()
+		asked = append(asked, fmt.Sprintf("%s#%d", repo, number))
+		mu.Unlock()
+		return ghpkg.IssueClaim{}, false
+	}
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 2 {
+		t.Fatalf("both items should be admissible, got %v", wsKeysOf(q))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(asked) == 0 {
+		t.Fatal("the claim observer was never consulted — the positive control did not run")
+	}
+	sawGitHub := false
+	for _, a := range asked {
+		if strings.HasSuffix(a, "#0") {
+			t.Errorf("claim observer was asked about a fabricated identity %q", a)
+		}
+		if a == "acme/repo#5" {
+			sawGitHub = true
+		}
+	}
+	if !sawGitHub {
+		t.Errorf("the GitHub candidate must still exercise the claim observer; asked=%v", asked)
+	}
+}
+
+// TestExternalCandidateIsNotGitHubBacked pins the admission-side predicate that
+// keeps the GitHub-only observers out of external work, and keeps them ON for
+// GitHub work — including a candidate built by a caller that predates the ref.
+func TestExternalCandidateIsNotGitHubBacked(t *testing.T) {
+	external := contributorAdmissionCandidate{
+		repoFull: "acme/repo",
+		ref:      worksource.Ref{SourceType: "linear", Repo: "acme/repo", ExternalID: "ENG-1"},
+	}
+	if external.isGitHubBacked() {
+		t.Error("an external candidate must not be handed to the GitHub-only observers")
+	}
+
+	backed := contributorAdmissionCandidate{
+		repoFull: "acme/repo",
+		number:   12,
+		ref:      worksource.Ref{Repo: "acme/repo", Number: 12, ExternalID: "12"},
+	}
+	if !backed.isGitHubBacked() {
+		t.Error("a GitHub-backed candidate must keep exercising the claim and bead observers")
+	}
+
+	legacy := contributorAdmissionCandidate{repoFull: "acme/repo", number: 12}
+	if !legacy.isGitHubBacked() {
+		t.Error("a candidate built without a ref must behave exactly as it did before #4245")
+	}
+}
+
+// TestItemWithNoIdentityIsSkipped proves the one case that must still be
+// dropped: an item with neither an issue number nor an external key. Admitting
+// it would mean inventing a key, which is the whole defect.
+func TestItemWithNoIdentityIsSkipped(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		map[string]any{"number": float64(0), "title": "no identity at all", "labels": []any{}},
+		externalItem("linear", "ENG-7", "identifiable"),
+	))
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 1 || q[0].identityKey() != "acme/repo!ENG-7" {
+		t.Fatalf("only the identifiable item may be offered, got %v", wsKeysOf(q))
+	}
+}
+
+// TestDuplicateEnumerationOfOneItemIsNotDoubleOffered covers the re-projection
+// row: a source that emits the same item twice in one snapshot must not yield
+// two independently assignable copies.
+func TestDuplicateEnumerationOfOneItemIsNotDoubleOffered(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		externalItem("linear", "ENG-1", "emitted once"),
+		externalItem("linear", "ENG-1", "emitted again in the same snapshot"),
+	))
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	seen := map[string]int{}
+	for _, it := range q {
+		seen[it.identityKey()]++
+	}
+	if seen["acme/repo!ENG-1"] > 1 {
+		// Both copies carry the SAME canonical identity, so the in-flight guard
+		// and every cooldown treat them as one item. That is the property that
+		// matters; surfacing a duplicate row is a display concern, assigning it
+		// twice is not.
+		t.Logf("duplicate rows surfaced (%d) — acceptable only because they share one identity", seen["acme/repo!ENG-1"])
+	}
+	for key := range seen {
+		if strings.HasSuffix(key, "#0") {
+			t.Fatalf("duplicate enumeration produced a fabricated identity %q", key)
+		}
+	}
+}
+
+// TestActiveWorkGuardIsPerItem proves two different zero-numbered external
+// items do not block each other in the in-flight guard, while the SAME item is
+// held only once. Before #4245 both mapped to "repo#0": picking up one made the
+// other unofferable.
+func TestActiveWorkGuardIsPerItem(t *testing.T) {
+	one := &WSTaskAssign{Repo: "acme/repo", Number: 0, Key: "acme/repo!ENG-1", SourceType: "linear", ExternalID: "ENG-1"}
+	two := &WSTaskAssign{Repo: "acme/repo", Number: 0, Key: "acme/repo!ENG-2", SourceType: "linear", ExternalID: "ENG-2"}
+
+	if one.identityKey() == two.identityKey() {
+		t.Fatalf("two distinct external assignments share an identity: %q", one.identityKey())
+	}
+	if one.identityKey() != "acme/repo!ENG-1" {
+		t.Errorf("assignment identity = %q", one.identityKey())
+	}
+
+	legacy := &WSTaskAssign{Repo: "acme/repo", Number: 42}
+	if legacy.identityKey() != "acme/repo#42" {
+		t.Errorf("an assignment recorded before #4245 must key exactly as before, got %q", legacy.identityKey())
+	}
+}
+
+// TestPromptCarriesNativeKeyAndURL is the assignment/prompt row: a contributor
+// working a Linear item must be told what the item IS and where to read it,
+// never "issue acme/repo#0".
+func TestPromptCarriesNativeKeyAndURL(t *testing.T) {
+	ref := worksource.Ref{
+		SourceType: "linear",
+		Repo:       "acme/repo",
+		ExternalID: "ENG-123",
+		URL:        "https://linear.app/acme/issue/ENG-123",
+	}
+	prompt := buildTaskPromptForRef(ref, "make the thing work")
+
+	if strings.Contains(prompt, "#0") {
+		t.Errorf("prompt referenced the fabricated #0 identity:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "acme/repo!ENG-123") {
+		t.Errorf("prompt does not name the item's native key:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, ref.URL) {
+		t.Errorf("prompt does not tell the agent where to read the item:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "gh repo fork acme/repo") {
+		t.Errorf("prompt lost the GitHub repository instructions:\n%s", prompt)
+	}
+
+	// The GitHub prompt must be untouched — same reference, and no source hint.
+	gh := buildTaskPrompt("acme/repo", 42, "make the thing work")
+	if !strings.Contains(gh, "Work on issue acme/repo#42:") {
+		t.Errorf("github prompt reference changed:\n%s", gh)
+	}
+	if strings.Contains(gh, "work source") {
+		t.Errorf("github prompt gained an external-source hint it should not have:\n%s", gh)
+	}
+}
+
+// TestCanonicalKeyRoundTripsThroughParse proves the persisted-key reader and
+// writer agree, which is what lets operator hold/order entries survive a
+// restart without a migration.
+func TestCanonicalKeyRoundTripsThroughParse(t *testing.T) {
+	for _, ref := range []worksource.Ref{
+		{Repo: "acme/repo", Number: 42, ExternalID: "42"},
+		{Repo: "acme/repo", ExternalID: "ENG-123", SourceType: "linear"},
+	} {
+		key := ref.Key()
+		parsed, ok := worksource.ParseKey(key)
+		if !ok {
+			t.Fatalf("ParseKey(%q) failed", key)
+		}
+		if parsed.Key() != key {
+			t.Errorf("round trip changed the key: %q -> %q", key, parsed.Key())
+		}
+		if parsed.IsGitHubIssue() != ref.IsGitHubIssue() {
+			t.Errorf("round trip changed GitHub-backedness for %q", key)
+		}
+	}
+
+	// A fabricated "#0" must never parse into a usable identity.
+	if _, ok := worksource.ParseKey("acme/repo#0"); ok {
+		t.Error(`ParseKey accepted "acme/repo#0" — the fabricated identity must be refused`)
+	}
+}
+
+// TestNoSecondKeyImplementation is the bypass guard the acceptance matrix asks
+// for: it fails if the dashboard's queue projection stops producing exactly
+// what pkg/worksource produces. A parallel key implementation would satisfy
+// every helper test above and still break production.
+func TestNoSecondKeyImplementation(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		githubItem(42, "github"),
+		externalItem("linear", "ENG-1", "linear"),
+		externalItem("jira", "OPS-9", "jira"),
+	))
+
+	q := s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 3 {
+		t.Fatalf("expected all three items, got %v", wsKeysOf(q))
+	}
+	want := []string{
+		worksource.Ref{Repo: "acme/repo", Number: 42}.Key(),
+		worksource.Ref{Repo: "acme/repo", ExternalID: "ENG-1"}.Key(),
+		worksource.Ref{Repo: "acme/repo", ExternalID: "OPS-9"}.Key(),
+	}
+	for i, w := range want {
+		if q[i].identityKey() != w {
+			t.Errorf("queue item %d keyed %q, but pkg/worksource says %q — there is a second key implementation",
+				i, q[i].identityKey(), w)
+		}
+	}
+}
+
+// TestTaskIDShapeUnchangedForGitHub guards a compatibility detail that is easy
+// to break while threading identity through: the assignment task id. Nothing
+// parses it, but it is echoed by every relay and appears in operator-facing
+// logs, so GitHub work must keep the exact "ct-<repo>-<number>-<unix>" shape it
+// has always had — while two zero-numbered external items must still get
+// distinct ids.
+func TestTaskIDShapeUnchangedForGitHub(t *testing.T) {
+	if got := taskIDSegment(worksource.Ref{Repo: "acme/repo", Number: 42}); got != "42" {
+		t.Errorf("github task id segment = %q, want the bare issue number", got)
+	}
+	one := taskIDSegment(worksource.Ref{Repo: "acme/repo", ExternalID: "ENG-1"})
+	two := taskIDSegment(worksource.Ref{Repo: "acme/repo", ExternalID: "ENG-2"})
+	if one == two {
+		t.Fatalf("two external items produced the same task id segment %q", one)
+	}
+	if one != "ENG-1" {
+		t.Errorf("external task id segment = %q, want the native external id", one)
+	}
+}
+
+// TestOperatorQueueKeyPrefersCanonicalKey pins the browser-side half of the
+// operator controls. ccQueueKey builds the string the HOLD and REORDER actions
+// persist, so it must prefer the server's canonical q.key. Building it from
+// repo+number produced "owner/repo#" for an external item — a key the server can
+// never match, so the operator's action silently did nothing.
+func TestOperatorQueueKeyPrefersCanonicalKey(t *testing.T) {
+	page := opsPageBody(t)
+	if !strings.Contains(page, "function ccQueueKey(q){return q.key||") {
+		t.Error("ccQueueKey no longer prefers the server's canonical key; operator hold/reorder will miss external work")
+	}
+	if strings.Contains(page, "var prBadge=ccPRBadgeHTML((q.repo||'')+'#'+(q.number||''));") {
+		t.Error("the PR badge still looks up a fabricated key for numberless items")
+	}
+}
+
+// TestLedgerKeysReconstructAfterRestart is the restart row.
+//
+// It deliberately does NOT round-trip through the ledger file:
+// completedTasksFile is a hardcoded /data path, not redirected by the test
+// environment, so a save/load here would write nothing and the test would pass
+// for the wrong reason. What matters — and what this asserts — is that the
+// exclusion state is addressed purely by canonical key strings, so a hub that
+// comes up with those strings and no process memory reproduces exactly the same
+// exclusions: the GitHub key byte-identically (no migration, nothing silently
+// discarded) and the external key as its own distinct record.
+func TestLedgerKeysReconstructAfterRestart(t *testing.T) {
+	s := newQueueServer(t, statusWith("acme/repo",
+		githubItem(42, "github work"),
+		externalItem("linear", "ENG-1", "external work"),
+		externalItem("linear", "ENG-2", "other external work"),
+	))
+
+	// Exactly the strings a pre-upgrade ledger holds for GitHub work, plus the
+	// new external form, as a restart would hand them back.
+	persisted := []string{"acme/repo#42", "acme/repo!ENG-1"}
+	hub := s.contributeHub
+	hub.completedMu.Lock()
+	for _, key := range persisted {
+		hub.completedTasks[key] = time.Now()
+	}
+	hub.completedMu.Unlock()
+
+	for _, key := range persisted {
+		if !hub.isTaskInCooldownKey(key) {
+			t.Errorf("persisted exclusion %q did not reconstruct", key)
+		}
+	}
+	if hub.isTaskInCooldownKey("acme/repo!ENG-2") {
+		t.Error("an unrelated external item inherited another item's exclusion")
+	}
+
+	q := hub.ReadyQueue(readyQueueDefaultLimit)
+	if len(q) != 1 {
+		t.Fatalf("both reconstructed exclusions must hold; offerable = %v", wsKeysOf(q))
+	}
+	if got := q[0].identityKey(); got != "acme/repo!ENG-2" {
+		t.Fatalf("wrong item survived: %q (offerable = %v)", got, wsKeysOf(q))
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -170,13 +170,29 @@ type Issue struct {
 	// so fresh activity on a previously "nothing to ship" issue re-opens it for
 	// offers. Zero when produced by an older enumerator; consumers must fail
 	// OPEN (treat activity as unknown → do not suppress) in that case.
-	UpdatedAt      time.Time `json:"updated_at,omitempty"`
-	AgeMinutes     int       `json:"age_minutes"`
-	URL            string    `json:"url"`
-	IsTracker      bool      `json:"is_tracker"`
-	ComplexityTier string    `json:"complexity_tier,omitempty"`
-	ModelRec       string    `json:"model_recommendation,omitempty"`
-	Lane           string    `json:"lane,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at,omitempty"`
+	AgeMinutes int       `json:"age_minutes"`
+	URL        string    `json:"url"`
+	IsTracker  bool      `json:"is_tracker"`
+	// SourceType and ExternalID carry the work source's own identity through
+	// this GitHub-shaped compatibility envelope (kubestellar/hive#4245).
+	//
+	// Non-default work sources (Linear, Jira) are projected into this struct by
+	// worksource.ToGitHubIssues so the scheduler, governor and dashboard keep
+	// ONE actionable list. Those items have no GitHub issue number, so Number is
+	// 0 — and before these fields existed that was ALL that survived the
+	// projection. Every downstream identity site then formatted "repo#0", so two
+	// unrelated Linear items shared one hold, one cooldown, one active-task slot.
+	//
+	// Both are additive and omitempty: an envelope written by GitHub enumeration
+	// leaves them empty, and an empty SourceType reads as "github". Consumers
+	// must build identity through worksource.Ref rather than reading these
+	// directly, so there is a single key implementation.
+	SourceType     string `json:"source_type,omitempty"`
+	ExternalID     string `json:"external_id,omitempty"`
+	ComplexityTier string `json:"complexity_tier,omitempty"`
+	ModelRec       string `json:"model_recommendation,omitempty"`
+	Lane           string `json:"lane,omitempty"`
 }
 
 type PullRequest struct {

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kubestellar/hive/pkg/policies"
 	"github.com/kubestellar/hive/pkg/promptsrc"
 	"github.com/kubestellar/hive/pkg/resolve"
+	"github.com/kubestellar/hive/pkg/worksource"
 )
 
 type Scheduler struct {
@@ -338,8 +339,8 @@ func (s *Scheduler) formatIssueListWithPolicy(issues []github.Issue) (string, bo
 		}
 		labels, labelsFailClosed := s.enforceLabelsWithPolicy(issue.Labels)
 		failClosed = failClosed || labelsFailClosed
-		b.WriteString(fmt.Sprintf("  %dm %s#%d [%s] %s\n",
-			issue.AgeMinutes, issue.Repo, issue.Number,
+		b.WriteString(fmt.Sprintf("  %dm %s [%s] %s\n",
+			issue.AgeMinutes, issueDisplayRef(issue),
 			strings.Join(labels, ","), title))
 		shown++
 	}
@@ -450,17 +451,49 @@ func issueRefsForAgent(agentName string, issues []github.Issue) []string {
 	refs := make([]string, 0, len(agentIssues))
 	seen := make(map[string]bool, len(agentIssues))
 	for _, issue := range agentIssues {
-		if issue.Repo == "" || issue.Number <= 0 {
-			continue
-		}
-		ref := fmt.Sprintf("%s#%d", issue.Repo, issue.Number)
-		if seen[ref] {
+		// One canonical key implementation (kubestellar/hive#4245). The old
+		// `Number <= 0` skip dropped every Linear and Jira item on the floor:
+		// they reach here with Number == 0, so no non-GitHub work was ever
+		// referenced in an internal-agent kick at all. issueKey keeps
+		// GitHub-backed refs byte-identical "repo#number" and gives external
+		// work its own "repo!EXT-1" identity instead of a shared "repo#0".
+		ref := issueKey(issue)
+		if ref == "" || seen[ref] {
 			continue
 		}
 		seen[ref] = true
 		refs = append(refs, ref)
 	}
 	return refs
+}
+
+// issueKey is the scheduler's single entry point to the canonical work
+// identity. It delegates to pkg/worksource so the scheduler cannot drift into a
+// second key format — the parity test in scheduler_worksource_identity_test.go
+// pins that it produces exactly what worksource.Ref.Key() does.
+func issueKey(issue github.Issue) string {
+	return worksource.Ref{
+		SourceType: issue.SourceType,
+		Repo:       issue.Repo,
+		ExternalID: issue.ExternalID,
+		Number:     issue.Number,
+		URL:        issue.URL,
+	}.Key()
+}
+
+// issueDisplayRef is the human-facing form written into kick message bodies:
+// "owner/repo#42" for GitHub-backed work, "owner/repo!ENG-123" for a
+// string-keyed source. It exists so no rendering site formats "%s#%d" directly
+// and prints "owner/repo#0" for an item that simply has no issue number.
+//
+// It falls back to the bare repo when an item carries no usable identity at
+// all, which keeps a malformed enumeration readable in the message rather than
+// rendering a key nothing can match.
+func issueDisplayRef(issue github.Issue) string {
+	if key := issueKey(issue); key != "" {
+		return key
+	}
+	return issue.Repo
 }
 
 // BuildAgentMessageFromLastActionable builds a kick message for the named
@@ -618,8 +651,8 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 		if runes := []rune(title); len(runes) > maxTitleRunes {
 			title = string(runes[:maxTitleRunes])
 		}
-		b.WriteString(fmt.Sprintf("  %dm %s#%d [%s/%s] [%s] %s%s\n",
-			issue.AgeMinutes, issue.Repo, issue.Number,
+		b.WriteString(fmt.Sprintf("  %dm %s [%s/%s] [%s] %s%s\n",
+			issue.AgeMinutes, issueDisplayRef(issue),
 			tier, issue.ModelRec,
 			strings.Join(issue.Labels, ","),
 			title, tracker))
@@ -867,7 +900,7 @@ func (s *Scheduler) buildGenericMessage(agentName string, issues []github.Issue,
 	if len(agentIssues) > 0 {
 		b.WriteString(fmt.Sprintf("Work items (%d):\n", len(agentIssues)))
 		for _, issue := range agentIssues {
-			b.WriteString(fmt.Sprintf("  %s#%d %s\n", issue.Repo, issue.Number, issue.Title))
+			b.WriteString(fmt.Sprintf("  %s %s\n", issueDisplayRef(issue), issue.Title))
 		}
 	}
 
@@ -902,8 +935,8 @@ func (s *Scheduler) buildQualityMessage(issues []github.Issue, actionable *githu
 			if runes := []rune(title); len(runes) > maxTitleRunes {
 				title = string(runes[:maxTitleRunes])
 			}
-			b.WriteString(fmt.Sprintf("  %s#%d [%s] %s\n",
-				issue.Repo, issue.Number,
+			b.WriteString(fmt.Sprintf("  %s [%s] %s\n",
+				issueDisplayRef(issue),
 				strings.Join(issue.Labels, ","),
 				title))
 			shown++
@@ -960,8 +993,8 @@ func (s *Scheduler) buildArchitectMessage(issues []github.Issue, actionable *git
 			if runes := []rune(title); len(runes) > maxTitleRunes {
 				title = string(runes[:maxTitleRunes])
 			}
-			b.WriteString(fmt.Sprintf("  %s#%d [%s] %s\n",
-				issue.Repo, issue.Number,
+			b.WriteString(fmt.Sprintf("  %s [%s] %s\n",
+				issueDisplayRef(issue),
 				strings.Join(issue.Labels, ","),
 				title))
 			shown++

--- a/src/pkg/scheduler/worksource_identity_test.go
+++ b/src/pkg/scheduler/worksource_identity_test.go
@@ -1,0 +1,125 @@
+package scheduler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// ── Source-aware identity in internal-agent kicks (#4245) ────────────────────
+
+// TestIssueRefsCarryExternalWork proves non-GitHub work reaches an
+// internal-agent kick at all. issueRefsForAgent used to `continue` on
+// `Number <= 0`, so every Linear and Jira item was dropped before an agent ever
+// saw it — and the two items here would have produced zero refs, not two.
+func TestIssueRefsCarryExternalWork(t *testing.T) {
+	issues := []github.Issue{
+		{Repo: "acme/repo", SourceType: "linear", ExternalID: "ENG-1", Title: "first"},
+		{Repo: "acme/repo", SourceType: "linear", ExternalID: "ENG-2", Title: "second"},
+	}
+
+	refs := issueRefsForAgent("scanner", issues)
+	if len(refs) != 2 {
+		t.Fatalf("both external items must be referenced in the kick, got %d: %v", len(refs), refs)
+	}
+	if refs[0] == refs[1] {
+		t.Fatalf("distinct external items collapsed onto one ref: %v", refs)
+	}
+	for _, r := range refs {
+		if strings.HasSuffix(r, "#0") {
+			t.Errorf("kick referenced the fabricated #0 identity: %q", r)
+		}
+	}
+	if refs[0] != "acme/repo!ENG-1" || refs[1] != "acme/repo!ENG-2" {
+		t.Errorf("refs = %v, want the native keys", refs)
+	}
+}
+
+// TestIssueRefsKeepGitHubSpelling is the compatibility half: GitHub-backed refs
+// must stay byte-identical, because recordKick and everything downstream of it
+// has always received this exact string.
+func TestIssueRefsKeepGitHubSpelling(t *testing.T) {
+	refs := issueRefsForAgent("scanner", []github.Issue{
+		{Repo: "acme/repo", Number: 42, Title: "a github issue"},
+	})
+	if len(refs) != 1 || refs[0] != "acme/repo#42" {
+		t.Fatalf("github ref = %v, want [acme/repo#42]", refs)
+	}
+}
+
+// TestIssueRefsDropUnidentifiableItems pins the one case that must still be
+// dropped: no number AND no external key. Referencing it would mean inventing
+// an identity.
+func TestIssueRefsDropUnidentifiableItems(t *testing.T) {
+	refs := issueRefsForAgent("scanner", []github.Issue{
+		{Repo: "acme/repo", Title: "no identity"},
+		{Repo: "", Number: 7, Title: "no repository"},
+		{Repo: "acme/repo", Number: 3, Title: "fine"},
+	})
+	if len(refs) != 1 || refs[0] != "acme/repo#3" {
+		t.Fatalf("only the identifiable item may be referenced, got %v", refs)
+	}
+}
+
+// TestIssueRefsDedupeOnCanonicalIdentity proves the de-duplication key moved
+// with the identity: the same external item enumerated twice is one ref.
+func TestIssueRefsDedupeOnCanonicalIdentity(t *testing.T) {
+	refs := issueRefsForAgent("scanner", []github.Issue{
+		{Repo: "acme/repo", SourceType: "jira", ExternalID: "OPS-1"},
+		{Repo: "acme/repo", SourceType: "jira", ExternalID: "OPS-1"},
+	})
+	if len(refs) != 1 {
+		t.Fatalf("a repeated enumeration of one item must yield one ref, got %v", refs)
+	}
+}
+
+// TestSchedulerHasNoSecondKeyImplementation is the bypass guard: the scheduler
+// must produce exactly what pkg/worksource produces. A parallel implementation
+// here would pass every helper test in pkg/worksource and still send agents
+// "#0" refs.
+func TestSchedulerHasNoSecondKeyImplementation(t *testing.T) {
+	cases := []github.Issue{
+		{Repo: "acme/repo", Number: 42, ExternalID: "42"},
+		{Repo: "acme/repo", SourceType: "linear", ExternalID: "ENG-1"},
+		{Repo: "acme/repo", SourceType: "jira", ExternalID: "OPS-9"},
+		{Repo: "acme/repo", SourceType: "github_projects", Number: 7, ExternalID: "7"},
+	}
+	for _, issue := range cases {
+		want := worksource.Ref{
+			SourceType: issue.SourceType,
+			Repo:       issue.Repo,
+			ExternalID: issue.ExternalID,
+			Number:     issue.Number,
+			URL:        issue.URL,
+		}.Key()
+		if got := issueKey(issue); got != want {
+			t.Errorf("scheduler keyed %+v as %q, pkg/worksource says %q — second implementation", issue, got, want)
+		}
+	}
+}
+
+// TestIssueDisplayRefNeverRendersZero pins the message BODY, not just the ref
+// list. The kick text formatted "%s#%d" directly, so an external item was
+// described to the agent as "acme/repo#0".
+func TestIssueDisplayRefNeverRendersZero(t *testing.T) {
+	external := github.Issue{Repo: "acme/repo", SourceType: "linear", ExternalID: "ENG-1"}
+	if got := issueDisplayRef(external); got != "acme/repo!ENG-1" {
+		t.Errorf("display ref = %q, want the native key", got)
+	}
+	if strings.Contains(issueDisplayRef(external), "#0") {
+		t.Error("display ref rendered the fabricated #0 identity")
+	}
+
+	gh := github.Issue{Repo: "acme/repo", Number: 42}
+	if got := issueDisplayRef(gh); got != "acme/repo#42" {
+		t.Errorf("github display ref = %q, want acme/repo#42 unchanged", got)
+	}
+
+	// An item with no identity at all falls back to the bare repo rather than
+	// rendering a key nothing can match.
+	if got := issueDisplayRef(github.Issue{Repo: "acme/repo"}); got != "acme/repo" {
+		t.Errorf("unidentifiable item display = %q, want the bare repo", got)
+	}
+}

--- a/src/pkg/worksource/adapt.go
+++ b/src/pkg/worksource/adapt.go
@@ -6,19 +6,27 @@ import "github.com/kubestellar/hive/pkg/github"
 // that the scheduler and governor consume. GitHub-native fields not present in
 // the worksource type (AgeMinutes, IsTracker, ComplexityTier, ModelRec, Lane)
 // are left at their zero values and will be populated downstream by classify.
+//
+// SourceType and ExternalID are carried across (kubestellar/hive#4245). They are
+// the item's ONLY identity when Number is 0, which is every Linear and Jira
+// item: without them the projection is lossy and every downstream site collapses
+// distinct work onto "repo#0". GitHub-backed items keep Number, so their keys
+// stay byte-identical "repo#number".
 func ToGitHubIssues(issues []Issue) []github.Issue {
 	out := make([]github.Issue, len(issues))
 	for i, ws := range issues {
 		out[i] = github.Issue{
-			Repo:      ws.Repo,
-			Number:    ws.Number,
-			Title:     ws.Title,
-			Author:    ws.Author,
-			Labels:    ws.Labels,
-			Assignees: ws.Assignees,
-			CreatedAt: ws.CreatedAt,
-			UpdatedAt: ws.UpdatedAt,
-			URL:       ws.URL,
+			Repo:       ws.Repo,
+			Number:     ws.Number,
+			SourceType: ws.SourceType,
+			ExternalID: ws.ExternalID,
+			Title:      ws.Title,
+			Author:     ws.Author,
+			Labels:     ws.Labels,
+			Assignees:  ws.Assignees,
+			CreatedAt:  ws.CreatedAt,
+			UpdatedAt:  ws.UpdatedAt,
+			URL:        ws.URL,
 		}
 	}
 	return out

--- a/src/pkg/worksource/adapt_identity_test.go
+++ b/src/pkg/worksource/adapt_identity_test.go
@@ -1,0 +1,72 @@
+package worksource
+
+import "testing"
+
+// TestToGitHubIssuesPreservesSourceIdentity pins the compatibility-envelope half
+// of #4245. ToGitHubIssues is the ONLY path a non-default work source takes into
+// the actionable result, and it used to drop SourceType and ExternalID — which,
+// for an item with no issue number, is the item's entire identity. Everything
+// downstream then had nothing left to tell two Linear items apart.
+func TestToGitHubIssuesPreservesSourceIdentity(t *testing.T) {
+	in := []Issue{
+		{SourceType: "linear", Repo: "acme/repo", ExternalID: "ENG-1", Title: "first", URL: "https://linear.app/1"},
+		{SourceType: "linear", Repo: "acme/repo", ExternalID: "ENG-2", Title: "second", URL: "https://linear.app/2"},
+	}
+
+	out := ToGitHubIssues(in)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 projected issues, got %d", len(out))
+	}
+	for i, got := range out {
+		if got.SourceType != in[i].SourceType {
+			t.Errorf("item %d: SourceType dropped by the projection (%q)", i, got.SourceType)
+		}
+		if got.ExternalID != in[i].ExternalID {
+			t.Errorf("item %d: ExternalID dropped by the projection (%q)", i, got.ExternalID)
+		}
+		if got.Number != 0 {
+			t.Errorf("item %d: a string-keyed source must not gain an issue number (%d)", i, got.Number)
+		}
+	}
+
+	// The two projected items must remain distinguishable — the property the
+	// whole change exists to preserve.
+	a := Ref{SourceType: out[0].SourceType, Repo: out[0].Repo, ExternalID: out[0].ExternalID, Number: out[0].Number}
+	b := Ref{SourceType: out[1].SourceType, Repo: out[1].Repo, ExternalID: out[1].ExternalID, Number: out[1].Number}
+	if a.Key() == b.Key() {
+		t.Fatalf("projection collapsed two distinct items onto %q", a.Key())
+	}
+}
+
+// TestToGitHubIssuesKeepsGitHubItemsUnchanged proves GitHub-backed items keep
+// their number, and therefore their byte-identical "repo#number" key.
+func TestToGitHubIssuesKeepsGitHubItemsUnchanged(t *testing.T) {
+	out := ToGitHubIssues([]Issue{
+		{SourceType: "github", Repo: "acme/repo", ExternalID: "42", Number: 42, Title: "issue"},
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(out))
+	}
+	if out[0].Number != 42 {
+		t.Fatalf("github issue number lost: %d", out[0].Number)
+	}
+	ref := Ref{SourceType: out[0].SourceType, Repo: out[0].Repo, ExternalID: out[0].ExternalID, Number: out[0].Number}
+	if got := ref.Key(); got != "acme/repo#42" {
+		t.Fatalf("github key = %q, want the unchanged acme/repo#42", got)
+	}
+}
+
+// TestKeyRefusesFabricatedIdentity is the negative case that matters most: a
+// Ref with no number and no external ID has NO identity, and Key() must say so
+// rather than returning something that looks usable.
+func TestKeyRefusesFabricatedIdentity(t *testing.T) {
+	if got := (Ref{Repo: "acme/repo"}).Key(); got != "" {
+		t.Errorf("Ref with no identity produced key %q, want empty", got)
+	}
+	if got := (Ref{ExternalID: "ENG-1"}).Key(); got != "" {
+		t.Errorf("Ref with no repository produced key %q, want empty", got)
+	}
+	if (Ref{Repo: "acme/repo", ExternalID: "ENG-1"}).IsGitHubIssue() {
+		t.Error("a string-keyed item must not be reported as GitHub-backed")
+	}
+}

--- a/src/pkg/worksource/key.go
+++ b/src/pkg/worksource/key.go
@@ -1,0 +1,154 @@
+package worksource
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// externalKeySeparator joins a repository to a string-keyed source's native
+// identifier. It is "!" because that character cannot appear in a GitHub issue
+// number, a Linear key ("ENG-123"), or a Jira key ("ENG-42"), so a key from one
+// source can never be mistaken for a key from another — and, critically, can
+// never collide with the "#" form GitHub-backed work has always used.
+const externalKeySeparator = "!"
+
+// Ref is the canonical, source-aware identity of one work item: the single
+// thing scheduler kicks, contributor admission, holds, cooldowns, claims, and
+// active-work tracking key on.
+//
+// It exists because those sites each rebuilt `fmt.Sprintf("%s#%d", repo, num)`
+// independently. That is correct for GitHub and silently wrong for everything
+// else: a Linear or Jira item arrives with Number == 0, so every one of them
+// formatted to "repo#0" and they all collapsed onto ONE identity — one hold,
+// one cooldown, one active-task slot, shared between unrelated work.
+//
+// The zero value is not a usable identity; callers get "" from Key() and must
+// treat that as "not identifiable", never as a key.
+type Ref struct {
+	// SourceType is the work source that produced the item ("github",
+	// "github_projects", "linear", "jira"). Empty is treated as GitHub for
+	// backward compatibility with envelopes written before this field existed.
+	SourceType string
+	// Repo is the GitHub repository (owner/name) work happens against. It scopes
+	// every key, so the same external ID in two repositories stays distinct.
+	Repo string
+	// ExternalID is the source-native identifier ("ENG-123"). For GitHub-backed
+	// items it is the decimal issue number as a string.
+	ExternalID string
+	// Number is the GitHub issue number, or 0 for a string-keyed source. It is
+	// what makes an item GitHub-backed, and the only thing the GitHub-only
+	// observers (PR claims, bead dependencies) can act on.
+	Number int
+	// URL is the canonical web URL of the item, carried so a contributor sees
+	// where non-GitHub work actually lives.
+	URL string
+}
+
+// Key returns the canonical identity string.
+//
+// For GitHub-backed work it is byte-identical to the "repo#number" form every
+// call site used before this type existed. That is a hard compatibility
+// requirement, not a stylistic one: operator hold lists, queue order, completion
+// cooldowns, failure quarantine and the PR-claim ledger are all PERSISTED under
+// these strings, so changing the GitHub spelling would silently discard every
+// existing exclusion on the next restart and re-dispatch claimed or
+// cooling-down work.
+//
+// For a string-keyed source it is "repo!externalID".
+//
+// A Ref with no repository, or with neither a positive number nor an external
+// ID, has no identity and returns "". Callers must skip such an item rather
+// than indexing it — a fabricated key is exactly the "#0" collapse this type
+// exists to prevent.
+func (r Ref) Key() string {
+	if r.Repo == "" {
+		return ""
+	}
+	if r.Number > 0 {
+		return fmt.Sprintf("%s#%d", r.Repo, r.Number)
+	}
+	if r.ExternalID == "" {
+		return ""
+	}
+	return r.Repo + externalKeySeparator + r.ExternalID
+}
+
+// IsGitHubIssue reports whether this item is backed by a real GitHub issue
+// number, and is therefore a legitimate subject for the GitHub-only observers:
+// the PR-claim ledger and the legacy bead dependency gate.
+//
+// A GitHub Projects item backed by an actual issue number answers true here and
+// keeps its existing claim and dependency behavior. A Linear or Jira item
+// answers false and must be SKIPPED by those observers — never handed to them
+// under a fabricated "#0", which would match an unrelated record or invent one.
+func (r Ref) IsGitHubIssue() bool {
+	return r.Repo != "" && r.Number > 0
+}
+
+// Display returns the short human form used in kick messages and prompts:
+// "#42" for GitHub-backed work, the native key ("ENG-123") otherwise. It never
+// renders "#0".
+func (r Ref) Display() string {
+	if r.Number > 0 {
+		return "#" + strconv.Itoa(r.Number)
+	}
+	return r.ExternalID
+}
+
+// RefFromIssue builds the canonical reference for an enumerated work item.
+func RefFromIssue(issue Issue) Ref {
+	return Ref{
+		SourceType: issue.SourceType,
+		Repo:       issue.Repo,
+		ExternalID: issue.ExternalID,
+		Number:     issue.Number,
+		URL:        issue.URL,
+	}
+}
+
+// TaskKey returns the canonical identity key for an enumerated work item.
+//
+// Retained as the package's original entry point; it is now one line over Ref
+// so there is exactly ONE implementation of the key format in the tree. A
+// second one is the failure mode this whole change is about: it passes every
+// helper-level test while production keeps formatting keys its own way.
+func TaskKey(issue Issue) string {
+	return RefFromIssue(issue).Key()
+}
+
+// ParseKey recovers a Ref from a canonical key string. It is the reader half of
+// Key(), needed because operator controls — the hold list and the queue order
+// override — persist bare key strings in config and must be matched against
+// live items without every handler re-deriving the format.
+//
+// It reports ok=false for anything that is not a well-formed key, so a
+// malformed or hand-edited entry is skipped rather than silently matching
+// nothing (or, worse, matching the wrong item).
+//
+// The "#" form is tried FIRST and its number must parse as a positive integer,
+// which keeps "owner/repo#12" GitHub-backed and refuses "owner/repo#0" —
+// exactly the fabricated identity that must never be admitted.
+func ParseKey(raw string) (Ref, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Ref{}, false
+	}
+	if repo, num, found := strings.Cut(raw, "#"); found {
+		repo = strings.TrimSpace(repo)
+		n, err := strconv.Atoi(strings.TrimSpace(num))
+		if repo == "" || err != nil || n <= 0 {
+			return Ref{}, false
+		}
+		return Ref{Repo: repo, Number: n, ExternalID: strconv.Itoa(n)}, true
+	}
+	if repo, ext, found := strings.Cut(raw, externalKeySeparator); found {
+		repo = strings.TrimSpace(repo)
+		ext = strings.TrimSpace(ext)
+		if repo == "" || ext == "" {
+			return Ref{}, false
+		}
+		return Ref{Repo: repo, ExternalID: ext}, true
+	}
+	return Ref{}, false
+}

--- a/src/pkg/worksource/key_test.go
+++ b/src/pkg/worksource/key_test.go
@@ -1,0 +1,70 @@
+package worksource
+
+import "testing"
+
+// TestDisplayNeverRendersZero pins the human-facing short form: "#42" for
+// GitHub-backed work, the native key for a string-keyed source, and never the
+// fabricated "#0" this package exists to prevent.
+func TestDisplayNeverRendersZero(t *testing.T) {
+	if got := (Ref{Repo: "acme/repo", Number: 42}).Display(); got != "#42" {
+		t.Errorf("github display = %q, want #42", got)
+	}
+	if got := (Ref{Repo: "acme/repo", ExternalID: "ENG-123", SourceType: "linear"}).Display(); got != "ENG-123" {
+		t.Errorf("external display = %q, want the native key", got)
+	}
+	if got := (Ref{Repo: "acme/repo"}).Display(); got != "" {
+		t.Errorf("unidentifiable item display = %q, want empty", got)
+	}
+}
+
+// TestParseKeyRoundTripsBothShapes proves the reader half of Key() agrees with
+// the writer for both the GitHub "#" form and the external "!" form — what lets
+// persisted operator hold/order entries survive a restart without a migration.
+func TestParseKeyRoundTripsBothShapes(t *testing.T) {
+	for _, ref := range []Ref{
+		{Repo: "acme/repo", Number: 42, ExternalID: "42"},
+		{Repo: "acme/repo", ExternalID: "ENG-123"},
+	} {
+		key := ref.Key()
+		parsed, ok := ParseKey(key)
+		if !ok {
+			t.Fatalf("ParseKey(%q) failed", key)
+		}
+		if parsed.Key() != key {
+			t.Errorf("round trip changed the key: %q -> %q", key, parsed.Key())
+		}
+		if parsed.IsGitHubIssue() != ref.IsGitHubIssue() {
+			t.Errorf("round trip changed GitHub-backedness for %q", key)
+		}
+	}
+}
+
+// TestParseKeyRefusesMalformedInput pins every rejection branch: a malformed or
+// hand-edited operator entry must be skipped, never matched against the wrong
+// item — and "repo#0" is exactly the fabricated identity that must be refused.
+func TestParseKeyRefusesMalformedInput(t *testing.T) {
+	for _, raw := range []string{
+		"",
+		"   ",
+		"acme/repo",     // no separator at all
+		"acme/repo#0",   // the fabricated identity
+		"acme/repo#-3",  // negative number
+		"acme/repo#abc", // non-numeric number
+		"#42",           // no repository (github form)
+		"!ENG-1",        // no repository (external form)
+		"acme/repo!",    // no external id
+		"acme/repo!   ", // whitespace external id
+	} {
+		if ref, ok := ParseKey(raw); ok {
+			t.Errorf("ParseKey(%q) accepted a malformed key as %+v", raw, ref)
+		}
+	}
+
+	// Surrounding whitespace on a well-formed key is tolerated.
+	if ref, ok := ParseKey("  acme/repo#7 "); !ok || ref.Key() != "acme/repo#7" {
+		t.Errorf("ParseKey should trim surrounding whitespace, got %+v ok=%v", ref, ok)
+	}
+	if ref, ok := ParseKey(" acme/repo!ENG-9 "); !ok || ref.Key() != "acme/repo!ENG-9" {
+		t.Errorf("ParseKey should trim the external form too, got %+v ok=%v", ref, ok)
+	}
+}

--- a/src/pkg/worksource/worksource.go
+++ b/src/pkg/worksource/worksource.go
@@ -7,7 +7,6 @@ package worksource
 
 import (
 	"context"
-	"fmt"
 	"time"
 )
 
@@ -45,24 +44,6 @@ type Issue struct {
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	// URL is the canonical web URL of the issue.
 	URL string `json:"url"`
-}
-
-// TaskKey returns a collision-free identity key for task admission, claim
-// ledger, and contributor-relay active-task tracking.
-//
-// For GitHub issues it produces "repo#number" (e.g. "my-org/my-repo#42"),
-// preserving backward compatibility with the 30 sites that used
-// fmt.Sprintf("%s#%d", repo, num) directly.
-//
-// For string-keyed sources (Linear, Jira) it produces "repo!externalID"
-// (e.g. "my-org/my-repo!ENG-123"). The "!" separator is chosen because it
-// cannot appear in a GitHub issue number or a Linear/Jira key, so keys from
-// different sources never collide even if two teams share an integer.
-func TaskKey(issue Issue) string {
-	if issue.Number > 0 {
-		return fmt.Sprintf("%s#%d", issue.Repo, issue.Number)
-	}
-	return fmt.Sprintf("%s!%s", issue.Repo, issue.ExternalID)
 }
 
 // WorkSource is the Step 01 abstraction: it enumerates actionable work items


### PR DESCRIPTION
Closes #4245.

## The gap this closes

#4189 added `worksource.Issue` and `TaskKey`; #4195 wired non-default work sources through `ToGitHubIssues`. But that projection dropped `SourceType` and `ExternalID` — and for an item with no issue number, that IS the item's entire identity.

So Linear and Jira items arrived downstream with `Number == 0`, and every identity site formatted `repo#0`:

- two unrelated items shared one hold, one cooldown, one failure record, one active-task slot;
- the assignment prompt told the agent to work on `owner/repo#0`;
- and most items never got that far — `issueRefsForAgent`, `ReadyQueue` and `selectTask` all skipped `Number <= 0` outright, so non-GitHub work was invisible to internal-agent kicks and to contributors alike.

## One canonical key, one implementation

- **`worksource.Ref`** (`Key` / `ParseKey` / `IsGitHubIssue` / `Display`) is now the only place the key format lives; `TaskKey` is one line over it. GitHub-backed work produces exactly `repo#number`; string-keyed sources produce `repo!ENG-123`. A `Ref` with neither a positive number nor an external id has **no** key, and callers skip it — a fabricated key is the defect, not a fallback.
- **`github.Issue`** gains additive, `omitempty` `SourceType`/`ExternalID`, and `ToGitHubIssues` carries them. The compatibility envelope stops being lossy without a parallel actionable list.
- **Scheduler**: `issueRefsForAgent` and every issue-rendering site go through `issueKey`/`issueDisplayRef`, so external work reaches kicks at all and no message body prints `#0`.
- **Dashboard**: `ReadyQueue` and `selectTask` build one `Ref` per item and key hold, cooldown, failure, no-work, active, yank, order and admission on it. The cooldown/failure/verdict helpers gained key-form variants; the repo+number wrappers remain for callers that legitimately hold both.
- **Assignment and prompts** carry the native key and, for external work, its URL — an agent cannot `gh issue view` a Linear ticket.

## Two things I found while implementing

**The operator's queue controls were broken for external work.** `ccQueueKey` builds the string the HOLD and REORDER actions persist, client-side, as `repo#number`. For a numberless item that yields `owner/repo#` — a key the server can never match, so holding or reordering it would silently do nothing. It now prefers the server's canonical `key`, and the PR badge no longer looks up a fabricated key.

**I changed the GitHub task-id shape and reverted it.** My first pass built the id from `ref.Key()`, turning `ct-acme/repo-42-…` into `ct-acme/repo#42-…`. Nothing parses that id, but the issue requires existing GitHub behavior to be unchanged, so the historical shape is restored and pinned by a test.

## Scope boundaries held deliberately

- The **PR-claim ledger and the legacy bead observer stay GitHub-only**. A candidate without a positive issue number *skips* both rather than being matched under a synthesised `#0`; GitHub candidates still exercise both as positive controls. A GitHub Projects item backed by a real issue number stays GitHub-keyed and keeps that behavior.
- **GitHub keys are unchanged**, so persisted completion, failure/quarantine, hold/order and claim-ledger state loads with no migration.
- The **`runEvalCycle` fallback is untouched**: a work-source construction or enumeration failure still leaves the GitHub Issues result in place, and those items carry GitHub identities only.
- **Identity transport only** — no change to convergence decisions, contributor ranking/routing, governor cadence, source ownership, or observer authority.

## Tests

Driven through the real production path, because the failure this issue warns about is a migration that passes `TaskKey` unit tests while production keeps formatting its own keys.

**Confirmed RED**: restoring the old `number == 0` skip and inline `%s#%d` key in `ReadyQueue` fails eight of the new dashboard tests — external items surviving, repository scoping, hold isolation, cooldown isolation, operator order, observer skipping, unidentifiable-item skipping, and the parity guard. Both `pkg/dashboard` and `pkg/scheduler` carry an explicit **no-second-implementation** parity test, which is the bypass row the matrix asks for.

`pkg/dashboard` passes under `-race`; `go vet ./...` is clean.

### One test I want to flag

I first wrote the restart row as a real save/load round trip through the completion ledger. It failed: `completedTasksFile` is a hardcoded `/data/...` path that the test environment does not redirect, so the save wrote nothing and a passing version would have passed for the wrong reason. Rather than weaken the assertion, `TestLedgerKeysReconstructAfterRestart` now asserts the property that actually matters — exclusion state is addressed purely by canonical key strings, so a hub holding those strings with no process memory reproduces exactly the same exclusions — and its comment says plainly that it does not round-trip through disk. Making that path genuinely testable means making the ledger path injectable, which is out of scope here.

### Acceptance rows not directly covered

The concurrent-selection row is covered only insofar as the suite passes under `-race`; I did not write a dedicated two-contributor concurrent `selectTask` test. The `runEvalCycle` fallback row is argued structurally (the GitHub result is simply never replaced on error) rather than pinned by a test, since that function is not currently seam-testable.

— hive: backend=claude model=claude-opus-5
