### PR TITLE
📖 docs: target v4 in the CONTRIBUTING pull-requests section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Thank you for helping improve KubeStellar Hive. This guide is for contributing c
 - `bin/` — deterministic pipeline, supervision, enforcement, deployment, and maintainer helper scripts. See [`bin/README.md`](bin/README.md) for the script-by-script index.
 - `config/hive-project.yaml.example` — project metadata for the top-level
   deterministic shell pipeline; see [config/README.md](config/README.md). This
-  is separate from the v2 Go runtime config in `src/hive.yaml.example`.
+  is separate from the Go runtime config in `src/hive.yaml.example`.
 - `dashboard/`, `docs/`, `config/`, `systemd/`, `launchd/`, and top-level scripts — supporting assets for hub, dashboard, installation, and operational workflows.
 - `Justfile` — contributor relay recipes; see [Just recipes](docs/development.md#just-recipes).
 
@@ -102,7 +102,7 @@ The sign-off adds a `Signed-off-by:` trailer certifying that you have the right 
 
 ## Pull requests
 
-- Target `v2` for v2 code and documentation.
+- Target `v4` for all code and documentation contributions (the active development branch).
 - Start PR titles with the repository's emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
 - Include `Fixes #<issue>` lines for issues the PR closes.
 - Describe what changed, why, and how you tested it.


### PR DESCRIPTION
Fixes #4273.

## What changed

The **Pull requests** section of `CONTRIBUTING.md` still said:

> - Target `v2` for v2 code and documentation.

It now says:

> - Target `v4` for all code and documentation contributions (the active development branch).

That is the wording the issue recommended, verbatim.

## Why it mattered

This was the one instruction a first-time contributor follows literally, and it was the only line in the file that disagreed with the rest of it. Three lines earlier, the **Branches** section already says to use `v4`, and the setup snippet right below it branches from `origin/v4` — so the file contradicted itself within a single screen.

Every other guide in the tree already says `v4`. I verified each claim the issue makes rather than taking them on trust:

| Source | Says |
|---|---|
| `CONTRIBUTING.md:33` | "Use `v4` as the base branch for Hive work and PRs" |
| `CONTRIBUTING.md:39` | `git switch -c <topic-branch> origin/v4` |
| `docs/development.md:3,19,22` | "on the `v4` branch"; `origin/v4`; "Use `v4` as the PR base" |
| `docs/getting-started-contributing.md:70` | "Open your PR against the **`v4`** branch (the active development branch)." |
| `src/docs/README.md:3` | "The `v2` branch was retired in August 2026." |

So a contributor following `CONTRIBUTING.md` to the letter opened a PR against a **retired** branch, and got it rejected or told to rebase — friction at precisely the moment the guide is supposed to be reliable.

## The second change, and why I'm flagging it

The issue also asks to "verify the rest of the Pull Requests section for any other v2-era references." The Pull requests section had none. But the file's **only** other `v2` reference was one line elsewhere:

```diff
-  is separate from the v2 Go runtime config in `src/hive.yaml.example`.
+  is separate from the Go runtime config in `src/hive.yaml.example`.
```

`src/hive.yaml.example` is present and current on `v4` (verified with `git cat-file -e upstream/v4:src/hive.yaml.example`), so calling it "the v2 Go runtime config" is not merely stale phrasing — it is wrong about a live file, and it is the same class of defect this issue is about.

**This one line is outside the Pull requests section the issue names.** I included it because leaving the file's last v2 reference in place would invite an immediate follow-up issue, but it is easy to drop if you would rather keep this PR to the single reported line — say the word and I will remove it.

## Result

`CONTRIBUTING.md` now contains no `v2` references at all, and a tree-wide sweep confirms no other document instructs contributors to target `v2`:

```
$ grep -n "v2" CONTRIBUTING.md
(no output)

$ grep -rn "Target \`v2\`|target v2|against \`v2\`" --include="*.md" .
(no output outside src/docs/README.md, which correctly records the retirement)
```

## Testing

Not run (docs only). No code, build, or test files are touched — the diff is four lines in one Markdown file.

— hive: backend=claude model=claude-opus-5
