### PR TITLE
🐛 fix(ci): grant AI Fix the permissions its reusable workflow declares

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -9,18 +9,30 @@ on:
         type: string
   issues:
     types: [labeled]
-  pull_request:
-    types: [opened]
 
+# A caller must grant AT LEAST what the called workflow requests. The pinned
+# reusable workflow declares `contents: write`, `issues: write`, and
+# `pull-requests: write`; this caller granted only `issues: write`, so GitHub
+# refused every run at validation time with `startup_failure` — before any job
+# started, on every trigger. These three now match the callee exactly; widening
+# them further would grant more than it asks for.
+#
+# `pull_request: [opened]` was removed at the same time. Neither job in the
+# reusable workflow can run on it: `trigger-copilot` gates on
+# `issues`/`workflow_dispatch`/`workflow_call`, and `update-issue-on-pr` gates
+# on `pull_request_target`. Every PR opened here burned one guaranteed-failed
+# run for nothing.
 permissions:
+  contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   ai-fix:
     # SECURITY: pin the cross-repo reusable workflow to an immutable commit SHA,
-    # not the mutable @main. This workflow runs on pull_request_target (which has
-    # write permissions + secret access), so a mutable ref means anyone who can
-    # push to kubestellar/infra's main could alter what runs here with our token.
+    # not the mutable @main. This runs with contents/issues/pull-requests write
+    # and is handed a token, so a mutable ref means anyone who can push to
+    # kubestellar/infra's main could alter what runs here with our credentials.
     # Bump this SHA deliberately when adopting a reviewed change to the reusable
     # workflow.
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11


### PR DESCRIPTION
Fixes #4278.

## The outage

`ai-fix.yml` has never run. **50 of the last 50 runs are `startup_failure`**, the most recent minutes before this PR, across both the `issues` and `pull_request` triggers. Nothing ever started; every run died at validation.

```
32401854590 pull_request startup_failure 2026-08-20T18:11:55Z
32401428404 issues       startup_failure 2026-08-20T18:07:15Z
32400759593 pull_request startup_failure 2026-08-20T18:00:17Z
...  {"startup_failure": 50}  over the last 50 runs
```

## Cause

A caller cannot grant a called workflow less than it requests. I checked the pin itself rather than taking the report's word for it — `kubestellar/infra` `reusable-ai-fix.yml@1a04a3f`, lines 15–18:

```yaml
permissions:
  contents: write
  issues: write
  pull-requests: write
```

The caller granted `issues: write` alone, so GitHub refused every run before any job started.

#3088 reduced these as a hardening change and landed below what the callee needs. **That intent is preserved here** — this grants exactly the declared set, not a blanket widening. Machine-checked:

```
caller: {'contents': 'write', 'issues': 'write', 'pull-requests': 'write'}
callee: {'contents': 'write', 'issues': 'write', 'pull-requests': 'write'}
EXACT MATCH
```

## Also removed: the `pull_request` trigger

Neither job in the reusable workflow can act on it — I read both gates:

- `trigger-copilot` → `issues` / `workflow_dispatch` / `workflow_call`
- `update-issue-on-pr` → `pull_request_target`

`pull_request` matches neither, so every PR opened against this repo burned one guaranteed-failed run that could not have done anything. Including, while I was working on this, the runs from my own PRs.

Resulting triggers: `issues` + `workflow_dispatch`.

## A comment correction in the same file

The pin rationale claimed "this workflow runs on `pull_request_target`". It does not, and did not before this change — the caller's triggers were `issues`, `workflow_dispatch`, and `pull_request`.

The reasoning behind the pin is untouched and still correct, so I restated the true reason it matters: this runs with contents/issues/pull-requests write and is handed a token, which is exactly why a mutable `@main` ref would be dangerous. If you'd rather I leave comments alone in a fix PR, say so and I'll drop that hunk.

## Deliberately not done

Switching the trigger to `pull_request_target` to activate the reusable workflow's `update-issue-on-pr` job (which links Copilot PRs back to their issues). That would *add* behavior on a security-sensitive trigger rather than fix the outage, and it's a maintainer's call — worth its own issue if you want that job live.

## On the earlier comment in #4278

The ci-maintainer agent prepared essentially this patch and reported it could not push, because its GitHub App token lacks the `workflows` permission. My token carries the `workflow` scope, so I was able to push it as a normal PR — no human hand-application needed. The change here matches what that agent proposed, independently re-verified against the pinned callee.

## Testing

Not run (workflow file). CI cannot exercise the fix until it's on the default path — this PR will itself still trip one final failed `ai-fix` run, because PRs are evaluated against the workflow on the base branch, which still has the `pull_request` trigger. That stops once this merges.

Verified locally: the file parses as YAML, the resulting trigger set is `['issues', 'workflow_dispatch']`, and the caller's permission block compares exactly equal to the pinned callee's.

— hive: backend=claude model=claude-opus-5
