### PR TITLE
🐛 fix(dashboard,hub): live allowlist role binding so granted owners pass all owner gates (3rd report)

### DIFF
--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -3221,28 +3221,30 @@ func RoleAtLeast(role, tier string) bool {
 	return okRole && okTier && roleRank >= tierRank
 }
 
-// AuthorizedRole resolves a GitHub username against the spoke's authorized-users
+// AuthorizedRole resolves a username against the spoke's authorized-users
 // allowlist and returns the user's role and whether they are authorized.
 //
 // Each entry is either "username" or "username:role" (role = "owner" or "read").
 // An entry without an explicit role defaults to "owner" for the first entry
 // (the hive owner) and "read" for the rest (granted viewers). Matching is
-// case-insensitive because GitHub usernames are case-insensitive.
-//
-// A spoke with an empty AuthorizedUsers list is NOT a direct-route spoke that
-// enforces device-flow authz (it is either hub-proxied or misconfigured); the
-// caller decides how to treat that case — see IsDirectRouteAuthzEnabled.
+// case-insensitive because GitHub usernames are case-insensitive, and tolerant
+// of the hub's canonical identity form: a bare login and its "github:<login>"
+// wire form denote the SAME user (the hub's legacy shim), so an allowlist entry
+// in either form matches a session username in either form. Without this, a
+// hub-delivered "github:alice:owner" entry silently failed to authorize the
+// device-flow login "alice" — one more variant of the recurring
+// "granted owner still gets 'owner access required'" class.
 func (d DashboardConfig) AuthorizedRole(username string) (string, bool) {
 	if username == "" {
 		return "", false
 	}
-	want := strings.ToLower(username)
+	want := identityMatchKey(username)
 	for i, entry := range d.AuthorizedUsers {
 		name, role := splitAuthorizedEntry(entry)
 		if name == "" {
 			continue
 		}
-		if strings.ToLower(name) != want {
+		if identityMatchKey(name) != want {
 			continue
 		}
 		if role == "" {
@@ -3255,6 +3257,17 @@ func (d DashboardConfig) AuthorizedRole(username string) (string, bool) {
 		return role, true
 	}
 	return "", false
+}
+
+// identityMatchKey normalizes an identity string for allowlist comparison:
+// lower-cased (GitHub logins are case-insensitive, and the pre-existing
+// allowlist match always folded case), with the legacy-GitHub provider prefix
+// stripped so "github:alice" and "alice" compare equal. Other providers'
+// prefixes ("ibmid:", "google:", ...) are kept — those subjects are only ever
+// delivered and presented in their full canonical form.
+func identityMatchKey(id string) string {
+	key := strings.ToLower(strings.TrimSpace(id))
+	return strings.TrimPrefix(key, "github:")
 }
 
 // IsDirectRouteAuthzEnabled reports whether this hive must enforce per-user

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -2091,21 +2091,20 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 	// keeps the spoke the authority on who may enter, even via SSO — a valid
 	// hub token for a user not on the allowlist is refused. The role comes from
 	// the allowlist (authoritative), not the token, so the hub can never
-	// escalate a user's role on the spoke.
-	role := tokenRole
-	if s.deps != nil && s.deps.Config != nil {
-		if allowRole, ok := s.deps.Config.Dashboard.AuthorizedRole(username); ok {
-			role = allowRole
-		} else if s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled() {
-			// Allowlist is enforced and this user isn't on it → deny.
-			if s.deps.Logger != nil {
-				s.deps.Logger.Warn("sso handoff: user not authorized for this hive", "username", username)
-			}
-			writeSSOError(w, r, http.StatusForbidden, ssoErrNotAuthorized,
-				"You are signed in to the hub, but this hive's own authorized-users list does not include your account.",
-				"Ask the hive owner to grant you access to this hive, then open it again from the hub dashboard.")
-			return
+	// escalate a user's role on the spoke. liveAllowlistRole is the same shared
+	// rule authenticate re-applies on EVERY subsequent request
+	// (session_live_role.go), so the role minted here can never outlive a later
+	// Manage Access change.
+	role, authorized := s.liveAllowlistRole(username, tokenRole)
+	if !authorized {
+		// Allowlist is enforced and this user isn't on it → deny.
+		if s.deps != nil && s.deps.Logger != nil {
+			s.deps.Logger.Warn("sso handoff: user not authorized for this hive", "username", username)
 		}
+		writeSSOError(w, r, http.StatusForbidden, ssoErrNotAuthorized,
+			"You are signed in to the hub, but this hive's own authorized-users list does not include your account.",
+			"Ask the hive owner to grant you access to this hive, then open it again from the hub dashboard.")
+		return
 	}
 	if role == "" {
 		role = config.RoleRead

--- a/src/pkg/dashboard/budget_owner_gate_4134_test.go
+++ b/src/pkg/dashboard/budget_owner_gate_4134_test.go
@@ -92,7 +92,9 @@ func TestBudgetSave4134_OwnerViaSession(t *testing.T) {
 
 // Non-owner denial — a read-role session must still be blocked.
 func TestBudgetSave4134_ReadSessionDenied(t *testing.T) {
-	s := newDirectRouteServer(t, "readuser")
+	// Explicit ":read": the allowlist is the live role authority
+	// (liveSessionRole), and a bare first entry would default to owner.
+	s := newDirectRouteServer(t, "readuser:read")
 	seedBudget4134(s)
 	sid := s.createUserSession("readuser", "read")
 
@@ -109,7 +111,9 @@ func TestBudgetSave4134_ReadSessionDenied(t *testing.T) {
 
 // Non-owner denial — a non-owner (read-write) session lacks the owner gate.
 func TestBudgetSave4134_NonOwnerSessionDenied(t *testing.T) {
-	s := newDirectRouteServer(t, "rwuser")
+	// Explicit ":read-write": the allowlist is the live role authority
+	// (liveSessionRole), and a bare first entry would default to owner.
+	s := newDirectRouteServer(t, "rwuser:read-write")
 	seedBudget4134(s)
 	sid := s.createUserSession("rwuser", "read-write")
 

--- a/src/pkg/dashboard/budget_owner_live_role_4299_test.go
+++ b/src/pkg/dashboard/budget_owner_live_role_4299_test.go
@@ -1,0 +1,174 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for #4299 (3rd report of the "owner access required" class,
+// after #4081/#4082 and #4134): on a direct-route spoke, the role resolved at
+// login was frozen into the 30-day persisted session, so a Manage Access OWNER
+// grant delivered by the hub heartbeat (which live-updates
+// cfg.Dashboard.AuthorizedUsers) never took effect for an already-signed-in
+// user — every owner-gated mutation kept answering 403 "owner access required"
+// until they signed out and back in. Downgrades and revocations were equally
+// frozen.
+//
+// These tests run PUT /api/config/governor/budget through the FULL middleware
+// stack (authenticate → roleEnforcement → mux), exactly as a browser request
+// arrives, with a session whose stored role deliberately DISAGREES with the
+// live allowlist — the allowlist must win, in both directions.
+
+// seedBudget4299 stores a known-good budget so a partial update validates.
+func seedBudget4299(s *Server) {
+	s.deps.Config.Governor.Budget.TotalTokens = 1000
+	s.deps.Config.Governor.Budget.PeriodDays = 7
+	s.deps.Config.Governor.Budget.CriticalPct = 90
+}
+
+func putBudget4299(s *Server, sid string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget",
+		strings.NewReader(`{"totalTokens":50000}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+// The dwaddington scenario: logged in while read-write, THEN granted owner via
+// Manage Access (heartbeat updates the allowlist in place). The very next
+// request must already be an owner — no re-login, no session mutation.
+func TestBudgetSave4299_GithubGrantedOwnerWithStaleSession(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:read-write")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "read-write")
+
+	// The hub heartbeat delivers the new grant.
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:owner"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("granted owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000 {
+		t.Fatalf("totalTokens = %d, want 50000 (save did not persist)", got)
+	}
+}
+
+// Same scenario for a non-GitHub canonical identity: an ibmid-granted owner
+// must pass the budget-save owner gate.
+func TestBudgetSave4299_IbmidGrantedOwnerWithStaleSession(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "ibmid:310002BM0V:read")
+	seedBudget4299(s)
+	sid := s.createUserSession("ibmid:310002BM0V", "read")
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "ibmid:310002BM0V:owner"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ibmid granted owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// Legacy/canonical GitHub form mismatch: the hub may deliver the allowlist
+// entry in canonical wire form ("github:<login>") while the device-flow login
+// yields the bare login. They are the SAME user (the hub's legacy shim) and
+// must match.
+func TestBudgetSave4299_CanonicalAllowlistEntryMatchesBareLogin(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "github:dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "read-write")
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("canonical-entry owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// And the reverse form mix: bare allowlist entry, canonical session username
+// (an SSO handoff carries the hub's cookie subject).
+func TestBudgetSave4299_BareAllowlistEntryMatchesCanonicalLogin(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("github:dwaddington", "read")
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("bare-entry owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// The gate must be LIVE in both directions: a downgrade delivered after login
+// takes owner away from a session that was minted as owner.
+func TestBudgetSave4299_DowngradeBindsImmediately(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "owner")
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:read"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("downgraded user budget save = %d, want 403; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 1000 {
+		t.Fatalf("totalTokens = %d, want 1000 (denied save must not persist)", got)
+	}
+}
+
+// A revocation must invalidate the session outright — a revoked user must not
+// coast on a stale 30-day session at any role.
+func TestBudgetSave4299_RevocationBindsImmediately(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "owner")
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked user budget save = %d, want 401; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// Every owner-gated mutation goes through the SAME shared chain
+// (authenticate's liveSessionRole → requireOwnerRole reading X-Hive-Role +
+// the server-set verification marker), so proving the chain at the middleware
+// boundary covers the whole class, not just the budget endpoint. A stale
+// read-write session with a live owner grant must arrive at ANY handler as a
+// verified owner.
+func TestLiveRole4299_AuthenticateInjectsLiveOwnerForAllHandlers(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:read-write")
+	sid := s.createUserSession("dwaddington", "read-write")
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:owner"}
+
+	var sawUser, sawRole, sawMarker string
+	handler := s.authenticate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawUser = r.Header.Get("X-Hive-User")
+		sawRole = r.Header.Get("X-Hive-Role")
+		sawMarker = r.Header.Get(ownerRoleVerifiedHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// requireOwnerRole gates every owner-only endpoint on exactly these two
+	// headers; asserting them here therefore covers pause/resume, config
+	// download, self-upgrade, governor settings, packs, escalation, backup —
+	// every requireOwnerRole caller — in one place.
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget", strings.NewReader(`{}`))
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if sawUser != "dwaddington" {
+		t.Errorf("X-Hive-User = %q, want dwaddington", sawUser)
+	}
+	if sawRole != "owner" {
+		t.Errorf("X-Hive-Role = %q, want owner (live allowlist role, not the frozen session role)", sawRole)
+	}
+	if sawMarker != "true" {
+		t.Errorf("%s = %q, want true (requireOwnerRole demands the server-set marker)", ownerRoleVerifiedHeader, sawMarker)
+	}
+}

--- a/src/pkg/dashboard/dashboard_owner_authz_test.go
+++ b/src/pkg/dashboard/dashboard_owner_authz_test.go
@@ -124,7 +124,10 @@ func TestOwnerOnlyMutationsAllowInternalSharedToken(t *testing.T) {
 // A per-user session always scopes an internal-token request DOWN: a read-role
 // session riding alongside X-Hive-Internal must not inherit owner.
 func TestOwnerOnlyMutationsRejectReadSessionWithInternalAuth(t *testing.T) {
-	s := newDirectRouteServer(t, "readuser")
+	// Explicit ":read" — the allowlist is the live role authority now
+	// (liveSessionRole), so the entry itself must say this user is a reader; a
+	// bare first entry would default to owner and elevate the session.
+	s := newDirectRouteServer(t, "readuser:read")
 	sid := s.createUserSession("readuser", "read")
 	req := httptest.NewRequest(http.MethodPost, "/api/breaker/engage", nil)
 	req.Header.Set("X-Hive-Internal", s.authToken)

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -977,10 +977,14 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			// sends the user back to log in — a bounce. This grants no extra
 			// access: everyone is already admitted on this branch.
 			if sess := s.sessionFromRequest(r); sess != nil {
-				r.Header.Set("X-Hive-User", sess.Username)
-				r.Header.Set("X-Hive-Role", sess.Role)
-				if isOwnerRole(sess.Role) {
-					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				// Role comes from liveSessionRole, never sess.Role directly: a
+				// Manage Access change must not stay frozen in a 30-day session.
+				if role, ok := s.liveSessionRole(sess); ok {
+					r.Header.Set("X-Hive-User", sess.Username)
+					r.Header.Set("X-Hive-Role", role)
+					if isOwnerRole(role) {
+						r.Header.Set(ownerRoleVerifiedHeader, "true")
+					}
 				}
 			} else if r.Header.Get("X-Hive-Role") == "" {
 				r.Header.Set("X-Hive-Role", config.RoleOwner)
@@ -1013,10 +1017,19 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		trusted := internalTrusted
 		if internalTrusted {
 			if sess := s.sessionFromRequest(r); sess != nil {
-				r.Header.Set("X-Hive-User", sess.Username)
-				r.Header.Set("X-Hive-Role", sess.Role)
-				if isOwnerRole(sess.Role) {
-					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				// Scope the shared-token request down to the session's user, at
+				// their LIVE allowlist role (liveSessionRole): a hub-side grant,
+				// downgrade, or revocation must take effect now, not when the
+				// 30-day session happens to expire. A revoked user (ok=false)
+				// gets no identity injected at all — possession of the internal
+				// token still authenticates the request, but it must not carry
+				// the revoked user's name or any role.
+				if role, ok := s.liveSessionRole(sess); ok {
+					r.Header.Set("X-Hive-User", sess.Username)
+					r.Header.Set("X-Hive-Role", role)
+					if isOwnerRole(role) {
+						r.Header.Set(ownerRoleVerifiedHeader, "true")
+					}
 				}
 			} else {
 				// No per-user session to scope this request down: the shared
@@ -1088,12 +1101,23 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// and each sees themselves — no shared identity.
 		if !trusted {
 			if sess := s.sessionFromRequest(r); sess != nil {
-				r.Header.Set("X-Hive-User", sess.Username)
-				r.Header.Set("X-Hive-Role", sess.Role)
-				if isOwnerRole(sess.Role) {
-					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				// The role is re-resolved against the LIVE allowlist on every
+				// request (liveSessionRole), never read from the session record:
+				// the hub heartbeat keeps cfg.Dashboard.AuthorizedUsers in sync
+				// with Manage Access, and a grant/downgrade/revocation must bind
+				// now — not after the 30-day session expires. This is the fix for
+				// the recurring "owner access required for a granted owner" class
+				// (3rd report; see session_live_role.go). ok=false means the
+				// allowlist is enforced and the user was REVOKED: fall through
+				// unauthenticated instead of honoring the stale session.
+				if role, ok := s.liveSessionRole(sess); ok {
+					r.Header.Set("X-Hive-User", sess.Username)
+					r.Header.Set("X-Hive-Role", role)
+					if isOwnerRole(role) {
+						r.Header.Set(ownerRoleVerifiedHeader, "true")
+					}
+					trusted = true
 				}
-				trusted = true
 			}
 		}
 

--- a/src/pkg/dashboard/session_live_role.go
+++ b/src/pkg/dashboard/session_live_role.go
@@ -1,0 +1,69 @@
+package dashboard
+
+// Live session-role resolution (#4299 — 3rd report of the "owner access
+// required" class, after #4081/#4082 and #4134).
+//
+// # THE RECURRING BUG CLASS THIS KILLS
+//
+// A per-user session (device-flow login or hub SSO handoff) used to FREEZE the
+// role resolved at login into the persisted userSession for the whole
+// sessionTTL (30 days, surviving pod restarts). Meanwhile the hive's
+// authorized-users allowlist — the authority the login itself consulted — keeps
+// changing underneath it: the hub heartbeat re-delivers Manage Access grants
+// every beat (hub.AuthorizedUsersCallback updates
+// cfg.Dashboard.AuthorizedUsers in place, exactly so grants "take effect
+// ... without any kubectl push").
+//
+// The result was that a Manage Access grant NEVER took effect for an
+// already-signed-in user on a direct-route spoke: the hub said "owner", the
+// heartbeat delivered "owner", the Manage Access panel showed "owner" — and the
+// spoke kept answering every owner-gated mutation with 403 "owner access
+// required" from the role frozen days earlier. Refreshing the tab changes
+// nothing (the hive_session cookie and its stored role persist); only a full
+// sign-out/sign-in re-resolved the role. Downgrades and revocations were
+// equally frozen, which is the same defect pointing the other way.
+//
+// handleRenewTerminalAssertion already re-resolves the role live for exactly
+// this reason ("a self-renewing grant that froze its own role at login would be
+// strictly worse ..."). This file makes that the ONE shared rule for every
+// consumer of a session's role, so no future auth path can reintroduce the
+// frozen-role variant of the bug.
+
+// liveSessionRole resolves the CURRENT role for a session-authenticated user,
+// consulting this hive's authorized-users allowlist on EVERY request rather
+// than trusting the role frozen into the session at login.
+//
+//   - If the allowlist has an entry for the user (canonical or legacy identity
+//     form — see config.AuthorizedRole), that entry's role is authoritative:
+//     upgrades AND downgrades granted hub-side take effect immediately.
+//   - If the allowlist is enforced (direct-route spoke) and the user is absent,
+//     their access was revoked: returns ok=false and the caller must treat the
+//     session as unauthenticated. A revoked user must not coast on a stale
+//     session for up to 30 days.
+//   - If no allowlist governs this spoke (hub-proxied or open/dev), the
+//     session's own role stands — the hub nginx or the deployment's open trust
+//     model is the authority there, not a list this spoke doesn't have.
+func (s *Server) liveSessionRole(sess *userSession) (role string, ok bool) {
+	if sess == nil {
+		return "", false
+	}
+	return s.liveAllowlistRole(sess.Username, sess.Role)
+}
+
+// liveAllowlistRole is the single shared rule for resolving a user's CURRENT
+// role on this spoke: the allowlist entry when one exists, the caller's
+// fallback when no allowlist governs, and ok=false (revoked — treat as
+// unauthenticated/denied) when the allowlist is enforced and the user is
+// absent. Session injection (authenticate), the SSO handoff mint, and terminal
+// assertion renewal all resolve through here so they can never disagree.
+func (s *Server) liveAllowlistRole(username, fallback string) (role string, ok bool) {
+	role = fallback
+	if s.deps != nil && s.deps.Config != nil {
+		if allowRole, found := s.deps.Config.Dashboard.AuthorizedRole(username); found {
+			role = allowRole
+		} else if s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled() {
+			return "", false
+		}
+	}
+	return role, true
+}

--- a/src/pkg/dashboard/terminal_assertion_renew.go
+++ b/src/pkg/dashboard/terminal_assertion_renew.go
@@ -97,16 +97,14 @@ func (s *Server) handleRenewTerminalAssertion(w http.ResponseWriter, r *http.Req
 
 	// Re-resolve the role from this hive's allowlist so a hub-side revocation or
 	// downgrade takes effect at renewal rather than being frozen at login.
-	role := sess.Role
-	if s.deps != nil && s.deps.Config != nil {
-		if allowRole, ok := s.deps.Config.Dashboard.AuthorizedRole(sess.Username); ok {
-			role = allowRole
-		} else if s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled() {
-			// Allowlist is enforced and this user is no longer on it. Deny, and
-			// write no cookie — the existing assertion then simply expires.
-			http.Error(w, `{"error":"not authorized for this hive"}`, http.StatusForbidden)
-			return
-		}
+	// liveAllowlistRole is the same shared rule authenticate and the SSO mint
+	// use (see session_live_role.go).
+	role, ok := s.liveAllowlistRole(sess.Username, sess.Role)
+	if !ok {
+		// Allowlist is enforced and this user is no longer on it. Deny, and
+		// write no cookie — the existing assertion then simply expires.
+		http.Error(w, `{"error":"not authorized for this hive"}`, http.StatusForbidden)
+		return
 	}
 
 	// Mint with the same helper the login and SSO paths use, so the assertion's

--- a/src/pkg/hub/authorized_users_canonical_4299_test.go
+++ b/src/pkg/hub/authorized_users_canonical_4299_test.go
@@ -1,0 +1,58 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for the hub half of #4299: the allowlist the hub delivers
+// to a direct-route spoke (provisioning env + heartbeat) must carry canonical
+// provider identities INTACT. The old hive-id sanitize() lower-cased and
+// stripped every character outside [a-z0-9-], so "ibmid:310002BM0V" was
+// delivered as "ibmid310002bm0v" — an entry that could never match the user's
+// real identity at login, silently locking a granted non-GitHub user out.
+
+func TestAuthorizedUsersForHivePreservesCanonicalIdentities(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const hiveID = "hosted-canon"
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "ibmid:310002BM0V",
+		Hives:          map[string]string{hiveID: "owner"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "dwaddington",
+		Hives:          map[string]string{hiveID: "read-write"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := authorizedUsersForHive(&SaaSHive{ID: hiveID, Owner: "clubanderson"})
+	for _, want := range []string{"clubanderson:owner", "ibmid:310002BM0V:owner", "dwaddington:read-write"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("allowlist %q missing entry %q", got, want)
+		}
+	}
+	if strings.Contains(got, "ibmid310002bm0v") {
+		t.Errorf("allowlist %q carries the corrupted (stripped) ibmid entry", got)
+	}
+}
+
+func TestSanitizeAllowlistIdentity(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"dwaddington", "dwaddington"},
+		{"github:dwaddington", "github:dwaddington"},
+		{"ibmid:310002BM0V", "ibmid:310002BM0V"}, // case and colon preserved
+		{"google:107.8_x-1", "google:107.8_x-1"},
+		{"evil,entry:owner", "evilentry:owner"}, // list separator stripped
+		{"sp ace\"'$;`", "space"},               // env-hostile bytes stripped
+	}
+	for _, c := range cases {
+		if got := sanitizeAllowlistIdentity(c.in); got != c.want {
+			t.Errorf("sanitizeAllowlistIdentity(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -1719,10 +1719,19 @@ func countUserHives(username string) int {
 // user record, so direct-route spokes enforce the same read/read-write/merger
 // tiers as hub-proxied spokes. Usernames are sanitized to guard the env value,
 // and the owner is de-duplicated so they appear exactly once.
+//
+// Identities are sanitized with sanitizeAllowlistIdentity, NOT the hive-id
+// sanitize() below: that one lower-cases and strips every character outside
+// [a-z0-9-], which DESTROYED canonical provider identities — "ibmid:310002BM0V"
+// became "ibmid310002bm0v", an entry that can never match the user's real
+// identity at login, so a non-GitHub grantee was silently locked out of the
+// spoke they were granted (part of the recurring "granted owner still denied"
+// class). The spoke parses entries on the LAST colon (splitAuthorizedEntry),
+// so a provider-prefixed name is safe to deliver verbatim.
 func authorizedUsersForHive(h *SaaSHive) string {
 	entries := make([]string, 0, 4)
 	seen := map[string]bool{}
-	owner := sanitize(h.Owner)
+	owner := sanitizeAllowlistIdentity(h.Owner)
 	if owner != "" {
 		entries = append(entries, owner+":"+saasRoleOwner)
 		seen[strings.ToLower(owner)] = true
@@ -1735,7 +1744,7 @@ func authorizedUsersForHive(h *SaaSHive) string {
 		if !config.ValidRole(role) {
 			role = saasRoleRead
 		}
-		name := sanitize(u.GitHubUsername)
+		name := sanitizeAllowlistIdentity(u.GitHubUsername)
 		if name == "" || seen[strings.ToLower(name)] {
 			continue
 		}
@@ -1743,6 +1752,22 @@ func authorizedUsersForHive(h *SaaSHive) string {
 		seen[strings.ToLower(name)] = true
 	}
 	return strings.Join(entries, ",")
+}
+
+// sanitizeAllowlistIdentity guards an identity destined for the allowlist env
+// value while PRESERVING it: letters (both cases — OIDC subjects are
+// case-sensitive), digits, and the identity charset ':', '.', '_', '-' pass;
+// everything else (spaces, commas, quotes, shell metacharacters) is dropped so
+// the comma-separated env value cannot be corrupted or escaped.
+func sanitizeAllowlistIdentity(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+			c == ':' || c == '.' || c == '_' || c == '-' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
 }
 
 // provisionAppKey is one additional App key rendered into the provisioning


### PR DESCRIPTION
Fixes #4299 — the THIRD report of the "owner access required" class (after #4081/#4082 and #4134). Reported today on Slack by @dwaddington: a GitHub-granted **owner** on hosted hive `hosted-ai-native-systems-research-ai-native-st-iubg` gets **"Failed to save budget: owner access required"**, even after a tab refresh.

## Root cause

The affected hive is a **direct-route spoke**: hub identity headers are ignored and identity comes from spoke-local sessions. The role was resolved from the `AuthorizedUsers` allowlist **once at login** and frozen into the persisted session for the 30-day session TTL. The hub heartbeat live-syncs the allowlist after a Manage Access grant, but `authenticate` injected `sess.Role` verbatim — so a new owner grant (or a downgrade/revocation) never bound to an existing session. Refreshing does nothing because the session cookie persists.

Two adjacent identity bugs in the same delivery chain:
- `authorizedUsersForHive` (hub) sanitized allowlist entries with the hive-**id** sanitizer, corrupting canonical identities: `ibmid:310002BM0V` → `ibmid310002bm0v` — an entry that can never match at login.
- `config.AuthorizedRole` didn't treat `github:dwaddington` and `dwaddington` as the same user (canonical vs legacy wire forms).

## Why this kept recurring

Each prior report fixed one endpoint's/path's own ad-hoc owner logic (hub role serving in #4082, spoke budget gate F14 semantics in #4134) while the *session-role freeze* stayed. Ad-hoc allowlist walks existed in device-flow login, `handleSSO`, and `terminal_assertion_renew.go`, each with slightly different semantics.

## Fix — one shared resolver, class dead

- **`pkg/dashboard/session_live_role.go` (new)**: `liveSessionRole` / `liveAllowlistRole` resolve the CURRENT allowlist role on every request; when an enforced allowlist no longer lists the user, the session is treated as revoked.
- `server.go` `authenticate`: all three session-role injection sites use `liveSessionRole` — this covers **every** `requireOwnerRole` endpoint (budget save, pause/resume, governor settings, packs, self-upgrade, backup, config download, escalation, …) at the middleware boundary rather than per endpoint.
- `handleSSO` and `terminal_assertion_renew.go` now reuse the shared helper.
- `config.AuthorizedRole`: `identityMatchKey` matches `github:<login>` ≡ `<login>`.
- `hub/saas_provision.go`: `sanitizeAllowlistIdentity` preserves canonical provider ids (`[A-Za-z0-9:._-]`) while stripping list-separator/env-hostile bytes.

## Tests

New full-middleware regression tests (`budget_owner_live_role_4299_test.go`):
- stale read-write session + live github owner grant → budget save **200** (the dwaddington scenario)
- ibmid-granted owner (`ibmid:310002BM0V:owner`) → **200**
- canonical/legacy form mixes match both directions
- downgrade binds immediately (**403**, save not persisted); revocation binds immediately (**401**)
- middleware-level assertion that a live grant arrives at ANY handler as verified owner (covers all owner-gated endpoints via the shared `requireOwnerRole` contract)

Hub side (`authorized_users_canonical_4299_test.go`): allowlist delivery preserves `ibmid:310002BM0V:owner` intact; sanitizer table test.

`go build ./...`, `go vet`, `go test ./pkg/dashboard/ ./pkg/hub/ -count=1` all pass (2 pre-existing environment-specific `pkg/config` failures unrelated, present on clean tree).

Note: the live spoke runs a v4-lineage build (its error string matches v4's `requireOwnerRole`), so v4 is the live path for this bug.
