### PR TITLE
🐛 fix(dashboard,hub): live allowlist role binding so granted owners pass all owner gates (v2 port)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2264,28 +2264,30 @@ func RoleAtLeast(role, tier string) bool {
 	return okRole && okTier && roleRank >= tierRank
 }
 
-// AuthorizedRole resolves a GitHub username against the spoke's authorized-users
+// AuthorizedRole resolves a username against the spoke's authorized-users
 // allowlist and returns the user's role and whether they are authorized.
 //
 // Each entry is either "username" or "username:role" (role = "owner" or "read").
 // An entry without an explicit role defaults to "owner" for the first entry
 // (the hive owner) and "read" for the rest (granted viewers). Matching is
-// case-insensitive because GitHub usernames are case-insensitive.
-//
-// A spoke with an empty AuthorizedUsers list is NOT a direct-route spoke that
-// enforces device-flow authz (it is either hub-proxied or misconfigured); the
-// caller decides how to treat that case — see IsDirectRouteAuthzEnabled.
+// case-insensitive because GitHub usernames are case-insensitive, and tolerant
+// of the hub's canonical identity form: a bare login and its "github:<login>"
+// wire form denote the SAME user (the hub's legacy shim), so an allowlist entry
+// in either form matches a session username in either form. Without this, a
+// hub-delivered "github:alice:owner" entry silently failed to authorize the
+// device-flow login "alice" — one more variant of the recurring
+// "granted owner still gets 'owner access required'" class.
 func (d DashboardConfig) AuthorizedRole(username string) (string, bool) {
 	if username == "" {
 		return "", false
 	}
-	want := strings.ToLower(username)
+	want := identityMatchKey(username)
 	for i, entry := range d.AuthorizedUsers {
 		name, role := splitAuthorizedEntry(entry)
 		if name == "" {
 			continue
 		}
-		if strings.ToLower(name) != want {
+		if identityMatchKey(name) != want {
 			continue
 		}
 		if role == "" {
@@ -2298,6 +2300,17 @@ func (d DashboardConfig) AuthorizedRole(username string) (string, bool) {
 		return role, true
 	}
 	return "", false
+}
+
+// identityMatchKey normalizes an identity string for allowlist comparison:
+// lower-cased (GitHub logins are case-insensitive, and the pre-existing
+// allowlist match always folded case), with the legacy-GitHub provider prefix
+// stripped so "github:alice" and "alice" compare equal. Other providers'
+// prefixes ("ibmid:", "google:", ...) are kept — those subjects are only ever
+// delivered and presented in their full canonical form.
+func identityMatchKey(id string) string {
+	key := strings.ToLower(strings.TrimSpace(id))
+	return strings.TrimPrefix(key, "github:")
 }
 
 // IsDirectRouteAuthzEnabled reports whether this hive must enforce per-user

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1876,21 +1876,20 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 	// keeps the spoke the authority on who may enter, even via SSO — a valid
 	// hub token for a user not on the allowlist is refused. The role comes from
 	// the allowlist (authoritative), not the token, so the hub can never
-	// escalate a user's role on the spoke.
-	role := tokenRole
-	if s.deps != nil && s.deps.Config != nil {
-		if allowRole, ok := s.deps.Config.Dashboard.AuthorizedRole(username); ok {
-			role = allowRole
-		} else if s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled() {
-			// Allowlist is enforced and this user isn't on it → deny.
-			if s.deps.Logger != nil {
-				s.deps.Logger.Warn("sso handoff: user not authorized for this hive", "username", username)
-			}
-			writeSSOError(w, r, http.StatusForbidden, ssoErrNotAuthorized,
-				"You are signed in to the hub, but this hive's own authorized-users list does not include your account.",
-				"Ask the hive owner to grant you access to this hive, then open it again from the hub dashboard.")
-			return
+	// escalate a user's role on the spoke. liveAllowlistRole is the same shared
+	// rule authenticate re-applies on EVERY subsequent request
+	// (session_live_role.go), so the role minted here can never outlive a later
+	// Manage Access change.
+	role, authorized := s.liveAllowlistRole(username, tokenRole)
+	if !authorized {
+		// Allowlist is enforced and this user isn't on it → deny.
+		if s.deps != nil && s.deps.Logger != nil {
+			s.deps.Logger.Warn("sso handoff: user not authorized for this hive", "username", username)
 		}
+		writeSSOError(w, r, http.StatusForbidden, ssoErrNotAuthorized,
+			"You are signed in to the hub, but this hive's own authorized-users list does not include your account.",
+			"Ask the hive owner to grant you access to this hive, then open it again from the hub dashboard.")
+		return
 	}
 	if role == "" {
 		role = config.RoleRead

--- a/v2/pkg/dashboard/budget_owner_live_role_4299_test.go
+++ b/v2/pkg/dashboard/budget_owner_live_role_4299_test.go
@@ -1,0 +1,174 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for #4299 (3rd report of the "owner access required" class,
+// after #4081/#4082 and #4134): on a direct-route spoke, the role resolved at
+// login was frozen into the 30-day persisted session, so a Manage Access OWNER
+// grant delivered by the hub heartbeat (which live-updates
+// cfg.Dashboard.AuthorizedUsers) never took effect for an already-signed-in
+// user — every owner-gated mutation kept answering 403 "owner access required"
+// until they signed out and back in. Downgrades and revocations were equally
+// frozen.
+//
+// These tests run PUT /api/config/governor/budget through the FULL middleware
+// stack (authenticate → roleEnforcement → mux), exactly as a browser request
+// arrives, with a session whose stored role deliberately DISAGREES with the
+// live allowlist — the allowlist must win, in both directions.
+
+// seedBudget4299 stores a known-good budget so a partial update validates.
+func seedBudget4299(s *Server) {
+	s.deps.Config.Governor.Budget.TotalTokens = 1000
+	s.deps.Config.Governor.Budget.PeriodDays = 7
+	s.deps.Config.Governor.Budget.CriticalPct = 90
+}
+
+func putBudget4299(s *Server, sid string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget",
+		strings.NewReader(`{"totalTokens":50000}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+// The dwaddington scenario: logged in while read-write, THEN granted owner via
+// Manage Access (heartbeat updates the allowlist in place). The very next
+// request must already be an owner — no re-login, no session mutation.
+func TestBudgetSave4299_GithubGrantedOwnerWithStaleSession(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:read-write")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "read-write")
+
+	// The hub heartbeat delivers the new grant.
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:owner"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("granted owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000 {
+		t.Fatalf("totalTokens = %d, want 50000 (save did not persist)", got)
+	}
+}
+
+// Same scenario for a non-GitHub canonical identity: an ibmid-granted owner
+// must pass the budget-save owner gate.
+func TestBudgetSave4299_IbmidGrantedOwnerWithStaleSession(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "ibmid:310002BM0V:read")
+	seedBudget4299(s)
+	sid := s.createUserSession("ibmid:310002BM0V", "read")
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "ibmid:310002BM0V:owner"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ibmid granted owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// Legacy/canonical GitHub form mismatch: the hub may deliver the allowlist
+// entry in canonical wire form ("github:<login>") while the device-flow login
+// yields the bare login. They are the SAME user (the hub's legacy shim) and
+// must match.
+func TestBudgetSave4299_CanonicalAllowlistEntryMatchesBareLogin(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "github:dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "read-write")
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("canonical-entry owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// And the reverse form mix: bare allowlist entry, canonical session username
+// (an SSO handoff carries the hub's cookie subject).
+func TestBudgetSave4299_BareAllowlistEntryMatchesCanonicalLogin(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("github:dwaddington", "read")
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("bare-entry owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// The gate must be LIVE in both directions: a downgrade delivered after login
+// takes owner away from a session that was minted as owner.
+func TestBudgetSave4299_DowngradeBindsImmediately(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "owner")
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:read"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("downgraded user budget save = %d, want 403; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 1000 {
+		t.Fatalf("totalTokens = %d, want 1000 (denied save must not persist)", got)
+	}
+}
+
+// A revocation must invalidate the session outright — a revoked user must not
+// coast on a stale 30-day session at any role.
+func TestBudgetSave4299_RevocationBindsImmediately(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:owner")
+	seedBudget4299(s)
+	sid := s.createUserSession("dwaddington", "owner")
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner"}
+
+	w := putBudget4299(s, sid)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked user budget save = %d, want 401; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// Every owner-gated mutation goes through the SAME shared chain
+// (authenticate's liveSessionRole → requireOwnerRole reading X-Hive-Role +
+// the server-set verification marker), so proving the chain at the middleware
+// boundary covers the whole class, not just the budget endpoint. A stale
+// read-write session with a live owner grant must arrive at ANY handler as a
+// verified owner.
+func TestLiveRole4299_AuthenticateInjectsLiveOwnerForAllHandlers(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:read-write")
+	sid := s.createUserSession("dwaddington", "read-write")
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:owner"}
+
+	var sawUser, sawRole, sawMarker string
+	handler := s.authenticate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawUser = r.Header.Get("X-Hive-User")
+		sawRole = r.Header.Get("X-Hive-Role")
+		sawMarker = r.Header.Get(ownerRoleVerifiedHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// requireOwnerRole gates every owner-only endpoint on exactly these two
+	// headers; asserting them here therefore covers pause/resume, config
+	// download, self-upgrade, governor settings, packs, escalation, backup —
+	// every requireOwnerRole caller — in one place.
+	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget", strings.NewReader(`{}`))
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if sawUser != "dwaddington" {
+		t.Errorf("X-Hive-User = %q, want dwaddington", sawUser)
+	}
+	if sawRole != "owner" {
+		t.Errorf("X-Hive-Role = %q, want owner (live allowlist role, not the frozen session role)", sawRole)
+	}
+	if sawMarker != "true" {
+		t.Errorf("%s = %q, want true (requireOwnerRole demands the server-set marker)", ownerRoleVerifiedHeader, sawMarker)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -785,10 +785,14 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			// sends the user back to log in — a bounce. This grants no extra
 			// access: everyone is already admitted on this branch.
 			if sess := s.sessionFromRequest(r); sess != nil {
-				r.Header.Set("X-Hive-User", sess.Username)
-				r.Header.Set("X-Hive-Role", sess.Role)
-				if isOwnerRole(sess.Role) {
-					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				// Role comes from liveSessionRole, never sess.Role directly: a
+				// Manage Access change must not stay frozen in a 30-day session.
+				if role, ok := s.liveSessionRole(sess); ok {
+					r.Header.Set("X-Hive-User", sess.Username)
+					r.Header.Set("X-Hive-Role", role)
+					if isOwnerRole(role) {
+						r.Header.Set(ownerRoleVerifiedHeader, "true")
+					}
 				}
 			} else if r.Header.Get("X-Hive-Role") == "" {
 				r.Header.Set("X-Hive-Role", config.RoleOwner)
@@ -821,10 +825,19 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		trusted := internalTrusted
 		if internalTrusted {
 			if sess := s.sessionFromRequest(r); sess != nil {
-				r.Header.Set("X-Hive-User", sess.Username)
-				r.Header.Set("X-Hive-Role", sess.Role)
-				if isOwnerRole(sess.Role) {
-					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				// Scope the shared-token request down to the session's user, at
+				// their LIVE allowlist role (liveSessionRole): a hub-side grant,
+				// downgrade, or revocation must take effect now, not when the
+				// 30-day session happens to expire. A revoked user (ok=false)
+				// gets no identity injected at all — possession of the internal
+				// token still authenticates the request, but it must not carry
+				// the revoked user's name or any role.
+				if role, ok := s.liveSessionRole(sess); ok {
+					r.Header.Set("X-Hive-User", sess.Username)
+					r.Header.Set("X-Hive-Role", role)
+					if isOwnerRole(role) {
+						r.Header.Set(ownerRoleVerifiedHeader, "true")
+					}
 				}
 			}
 		}
@@ -882,12 +895,23 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// and each sees themselves — no shared identity.
 		if !trusted {
 			if sess := s.sessionFromRequest(r); sess != nil {
-				r.Header.Set("X-Hive-User", sess.Username)
-				r.Header.Set("X-Hive-Role", sess.Role)
-				if isOwnerRole(sess.Role) {
-					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				// The role is re-resolved against the LIVE allowlist on every
+				// request (liveSessionRole), never read from the session record:
+				// the hub heartbeat keeps cfg.Dashboard.AuthorizedUsers in sync
+				// with Manage Access, and a grant/downgrade/revocation must bind
+				// now — not after the 30-day session expires. This is the fix for
+				// the recurring "owner access required for a granted owner" class
+				// (3rd report; see session_live_role.go). ok=false means the
+				// allowlist is enforced and the user was REVOKED: fall through
+				// unauthenticated instead of honoring the stale session.
+				if role, ok := s.liveSessionRole(sess); ok {
+					r.Header.Set("X-Hive-User", sess.Username)
+					r.Header.Set("X-Hive-Role", role)
+					if isOwnerRole(role) {
+						r.Header.Set(ownerRoleVerifiedHeader, "true")
+					}
+					trusted = true
 				}
-				trusted = true
 			}
 		}
 

--- a/v2/pkg/dashboard/session_live_role.go
+++ b/v2/pkg/dashboard/session_live_role.go
@@ -1,0 +1,68 @@
+package dashboard
+
+// Live session-role resolution (#4299 — 3rd report of the "owner access
+// required" class, after #4081/#4082 and #4134).
+//
+// # THE RECURRING BUG CLASS THIS KILLS
+//
+// A per-user session (device-flow login or hub SSO handoff) used to FREEZE the
+// role resolved at login into the persisted userSession for the whole
+// sessionTTL (30 days, surviving pod restarts). Meanwhile the hive's
+// authorized-users allowlist — the authority the login itself consulted — keeps
+// changing underneath it: the hub heartbeat re-delivers Manage Access grants
+// every beat (hub.AuthorizedUsersCallback updates
+// cfg.Dashboard.AuthorizedUsers in place, exactly so grants "take effect
+// ... without any kubectl push").
+//
+// The result was that a Manage Access grant NEVER took effect for an
+// already-signed-in user on a direct-route spoke: the hub said "owner", the
+// heartbeat delivered "owner", the Manage Access panel showed "owner" — and the
+// spoke kept answering every owner-gated mutation with 403 "owner access
+// required" from the role frozen days earlier. Refreshing the tab changes
+// nothing (the hive_session cookie and its stored role persist); only a full
+// sign-out/sign-in re-resolved the role. Downgrades and revocations were
+// equally frozen, which is the same defect pointing the other way.
+//
+// handleSSO's allowlist resolution already re-resolves the role live for
+// exactly this reason. This file makes that the ONE shared rule for every
+// consumer of a session's role, so no future auth path can reintroduce the
+// frozen-role variant of the bug.
+
+// liveSessionRole resolves the CURRENT role for a session-authenticated user,
+// consulting this hive's authorized-users allowlist on EVERY request rather
+// than trusting the role frozen into the session at login.
+//
+//   - If the allowlist has an entry for the user (canonical or legacy identity
+//     form — see config.AuthorizedRole), that entry's role is authoritative:
+//     upgrades AND downgrades granted hub-side take effect immediately.
+//   - If the allowlist is enforced (direct-route spoke) and the user is absent,
+//     their access was revoked: returns ok=false and the caller must treat the
+//     session as unauthenticated. A revoked user must not coast on a stale
+//     session for up to 30 days.
+//   - If no allowlist governs this spoke (hub-proxied or open/dev), the
+//     session's own role stands — the hub nginx or the deployment's open trust
+//     model is the authority there, not a list this spoke doesn't have.
+func (s *Server) liveSessionRole(sess *userSession) (role string, ok bool) {
+	if sess == nil {
+		return "", false
+	}
+	return s.liveAllowlistRole(sess.Username, sess.Role)
+}
+
+// liveAllowlistRole is the single shared rule for resolving a user's CURRENT
+// role on this spoke: the allowlist entry when one exists, the caller's
+// fallback when no allowlist governs, and ok=false (revoked — treat as
+// unauthenticated/denied) when the allowlist is enforced and the user is
+// absent. Session injection (authenticate) and the SSO handoff mint both
+// resolve through here so they can never disagree.
+func (s *Server) liveAllowlistRole(username, fallback string) (role string, ok bool) {
+	role = fallback
+	if s.deps != nil && s.deps.Config != nil {
+		if allowRole, found := s.deps.Config.Dashboard.AuthorizedRole(username); found {
+			role = allowRole
+		} else if s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled() {
+			return "", false
+		}
+	}
+	return role, true
+}

--- a/v2/pkg/hub/authorized_users_canonical_4299_test.go
+++ b/v2/pkg/hub/authorized_users_canonical_4299_test.go
@@ -1,0 +1,58 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression tests for the hub half of #4299: the allowlist the hub delivers
+// to a direct-route spoke (provisioning env + heartbeat) must carry canonical
+// provider identities INTACT. The old hive-id sanitize() lower-cased and
+// stripped every character outside [a-z0-9-], so "ibmid:310002BM0V" was
+// delivered as "ibmid310002bm0v" — an entry that could never match the user's
+// real identity at login, silently locking a granted non-GitHub user out.
+
+func TestAuthorizedUsersForHivePreservesCanonicalIdentities(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const hiveID = "hosted-canon"
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "ibmid:310002BM0V",
+		Hives:          map[string]string{hiveID: "owner"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "dwaddington",
+		Hives:          map[string]string{hiveID: "read-write"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := authorizedUsersForHive(&SaaSHive{ID: hiveID, Owner: "clubanderson"})
+	for _, want := range []string{"clubanderson:owner", "ibmid:310002BM0V:owner", "dwaddington:read-write"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("allowlist %q missing entry %q", got, want)
+		}
+	}
+	if strings.Contains(got, "ibmid310002bm0v") {
+		t.Errorf("allowlist %q carries the corrupted (stripped) ibmid entry", got)
+	}
+}
+
+func TestSanitizeAllowlistIdentity(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"dwaddington", "dwaddington"},
+		{"github:dwaddington", "github:dwaddington"},
+		{"ibmid:310002BM0V", "ibmid:310002BM0V"}, // case and colon preserved
+		{"google:107.8_x-1", "google:107.8_x-1"},
+		{"evil,entry:owner", "evilentry:owner"}, // list separator stripped
+		{"sp ace\"'$;`", "space"},               // env-hostile bytes stripped
+	}
+	for _, c := range cases {
+		if got := sanitizeAllowlistIdentity(c.in); got != c.want {
+			t.Errorf("sanitizeAllowlistIdentity(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1604,10 +1604,19 @@ func countUserHives(username string) int {
 // user record, so direct-route spokes enforce the same read/read-write/merger
 // tiers as hub-proxied spokes. Usernames are sanitized to guard the env value,
 // and the owner is de-duplicated so they appear exactly once.
+//
+// Identities are sanitized with sanitizeAllowlistIdentity, NOT the hive-id
+// sanitize() below: that one lower-cases and strips every character outside
+// [a-z0-9-], which DESTROYED canonical provider identities — "ibmid:310002BM0V"
+// became "ibmid310002bm0v", an entry that can never match the user's real
+// identity at login, so a non-GitHub grantee was silently locked out of the
+// spoke they were granted (part of the recurring "granted owner still denied"
+// class). The spoke parses entries on the LAST colon (splitAuthorizedEntry),
+// so a provider-prefixed name is safe to deliver verbatim.
 func authorizedUsersForHive(h *SaaSHive) string {
 	entries := make([]string, 0, 4)
 	seen := map[string]bool{}
-	owner := sanitize(h.Owner)
+	owner := sanitizeAllowlistIdentity(h.Owner)
 	if owner != "" {
 		entries = append(entries, owner+":"+saasRoleOwner)
 		seen[strings.ToLower(owner)] = true
@@ -1620,7 +1629,7 @@ func authorizedUsersForHive(h *SaaSHive) string {
 		if !config.ValidRole(role) {
 			role = saasRoleRead
 		}
-		name := sanitize(u.GitHubUsername)
+		name := sanitizeAllowlistIdentity(u.GitHubUsername)
 		if name == "" || seen[strings.ToLower(name)] {
 			continue
 		}
@@ -1628,6 +1637,22 @@ func authorizedUsersForHive(h *SaaSHive) string {
 		seen[strings.ToLower(name)] = true
 	}
 	return strings.Join(entries, ",")
+}
+
+// sanitizeAllowlistIdentity guards an identity destined for the allowlist env
+// value while PRESERVING it: letters (both cases — OIDC subjects are
+// case-sensitive), digits, and the identity charset ':', '.', '_', '-' pass;
+// everything else (spaces, commas, quotes, shell metacharacters) is dropped so
+// the comma-separated env value cannot be corrupted or escaped.
+func sanitizeAllowlistIdentity(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+			c == ':' || c == '.' || c == '_' || c == '-' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
 }
 
 // provisionAppKey is one additional App key rendered into the provisioning


### PR DESCRIPTION
v2 port of #4302 (fixes the v2 half of #4299 — 3rd report of the "owner access required" class, after #4081/#4082 and #4134).

The v2 branch is an active release channel (LONG_LIVED images) and carries the identical defect: on direct-route spokes the role resolved at login is frozen into the persisted 30-day session, so a Manage Access owner grant delivered live by the hub heartbeat never binds to an existing session — every owner-gated mutation (budget save, pause, governor, packs, upgrade, backup, …) keeps failing with "owner access required" until sign-out/sign-in. Downgrades and revocations are equally frozen. Two adjacent identity bugs are also ported: the hub allowlist delivery corrupted canonical ids (`ibmid:310002BM0V` → `ibmid310002bm0v`), and `AuthorizedRole` didn't match `github:<login>` ≡ `<login>`.

Same shared-resolver fix and same regression tests as #4302 (`session_live_role.go`, three `authenticate` injection sites, `handleSSO`, `AuthorizedRole` + `identityMatchKey`, `sanitizeAllowlistIdentity`). v2 has no `terminal_assertion_renew.go`, so that part of the v4 change has no counterpart here.

`go build ./... && go vet && go test ./pkg/dashboard/ ./pkg/config/ ./pkg/hub/ -count=1` — all pass.

Ref #4299
