### PR TITLE
🧪 podman: verify the rootful egress-gate baseline

### DIFF
--- a/src/deploy/probe_podman_rootful_netadmin.sh
+++ b/src/deploy/probe_podman_rootful_netadmin.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# probe_podman_rootful_netadmin.sh — rootful Podman baseline for Hive's
+# forced-proxy egress gate (kubestellar/hive#4200).
+#
+# The rootless counterpart is probe_podman_rootless_netadmin.sh (#4199). This
+# script asks the same questions of ROOTFUL Podman, so the rootless result has a
+# known-good baseline to be compared against, and adds the one test the rootless
+# spike could not do: isolating the SO_MARK exemption from the owner-UID one.
+#
+# Cases:
+#   default    rootful, no added capability   -> expect fail-closed, exit 77
+#   netadmin   rootful + --cap-add NET_ADMIN  -> expect gate installed
+#   advisory   rootful + HIVE_PROXY_ADVISORY_OK=true -> expect advisory warning
+#   somark     (--somark) delete the owner-UID RETURNs from a live HIVE_PROXY
+#              chain and re-dial, so the packet-mark exemption is exercised on
+#              its own rather than shadowed by the owner match.
+#
+# STORAGE SAFETY. Rootful Podman on a workstation is usually where the long-
+# lived services live. This probe therefore NEVER touches the host's rootful
+# store: every podman call goes through pod(), which pins --root/--runroot to a
+# throwaway directory. Cleanup removes only the containers this script created,
+# by exact name, and only deletes a store this script created itself.
+#
+# Exit codes:
+#   0  every case matched what src/docs/podman-rootful-egress-baseline.md records
+#   1  at least one case did not match
+#  78  a prerequisite is missing (EX_CONFIG)
+
+set -uo pipefail
+
+IMAGE="${IMAGE:-ghcr.io/kubestellar/hive:v4-latest}"
+CASE_TIMEOUT="${CASE_TIMEOUT:-90}"
+PROBE_PREFIX="hive-rootful-probe-$$"
+STORE="${STORE:-}"
+OWN_STORE="false"
+SOMARK="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --somark) SOMARK="true"; shift ;;
+    --store)  STORE="$2"; shift 2 ;;
+    --image)  IMAGE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+
+fail_prereq() {
+  printf 'PREREQUISITE MISSING: %s\n' "$1" >&2
+  exit 78
+}
+
+command -v podman >/dev/null 2>&1 || fail_prereq "podman is not installed or not on PATH"
+[[ "$(id -u)" -eq 0 ]] || fail_prereq "this probe must run as root (rootless Podman is #4199); re-run with sudo"
+
+# A throwaway store, on disk rather than tmpfs: the image is measured in GB and
+# a tmpfs store would spend RAM for it.
+if [[ -z "$STORE" ]]; then
+  STORE="$(mktemp -d -p /var/tmp hive-rootful-probe-store-XXXXXX)"
+  OWN_STORE="true"
+fi
+mkdir -p "${STORE}/graph" "${STORE}/run"
+
+# Refuse to address the host's own rootful store, whatever was passed in. On a
+# workstation that store holds long-lived services, and a probe has no business
+# writing to it.
+host_graph="$(podman info --format '{{.Store.GraphRoot}}' 2>/dev/null || true)"
+case "$STORE" in
+  /var/lib/containers*|/run/containers*)
+    fail_prereq "refusing to use ${STORE}: that is the host's rootful store" ;;
+esac
+if [[ -n "$host_graph" && "${STORE}/graph" == "$host_graph" ]]; then
+  fail_prereq "refusing to use ${STORE}/graph: that is the host's graphRoot"
+fi
+
+# Every podman call in this script goes through here. Nothing addresses the
+# host's rootful store.
+# An ARRAY, not a function: `timeout` execs its argument, and cannot run a shell
+# function — a function here makes every timed case exit 127 instead of running.
+POD=(podman --root "${STORE}/graph" --runroot "${STORE}/run")
+pod() { "${POD[@]}" "$@"; }
+
+WORK="$(mktemp -d)"
+# shellcheck disable=SC2329 # invoked through the EXIT trap below
+cleanup() {
+  local name
+  for name in "${PROBE_PREFIX}-default" "${PROBE_PREFIX}-netadmin" \
+              "${PROBE_PREFIX}-advisory" "${PROBE_PREFIX}-live"; do
+    pod rm -f "$name" >/dev/null 2>&1
+  done
+  rm -rf "$WORK"
+  # Only a store this script created is removed. A --store passed in is kept.
+  if [[ "$OWN_STORE" == "true" && -n "$STORE" ]]; then
+    rm -rf "$STORE" 2>/dev/null
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+# The gate lives behind "at least one agent is configured", so a config with no
+# agents skips it and the container starts clean while proving nothing.
+cat >"${WORK}/hive.yaml" <<'EOF'
+project:
+  org: kubestellar
+  repos:
+    - kubestellar/hive
+github:
+  token: "ghp_probe_not_a_real_token"
+agents:
+  probe:
+    backend: claude
+EOF
+
+printf '== Hive rootful Podman egress-gate baseline (#4200) ==\n'
+pod info --format 'podman={{.Version.Version}} rootless={{.Host.Security.Rootless}} cgroups={{.Host.CgroupsVersion}} netbackend={{.Host.NetworkBackend}} runtime={{.Host.OCIRuntime.Name}}'
+printf 'store=%s (throwaway=%s)\nimage=%s\n\n' "$STORE" "$OWN_STORE" "$IMAGE"
+
+rootless="$(pod info --format '{{.Host.Security.Rootless}}' 2>/dev/null)"
+[[ "$rootless" == "false" ]] || \
+  fail_prereq "podman reports rootless=${rootless:-unknown}; this probe requires ROOTFUL podman (rootless is #4199)"
+
+pod pull -q "$IMAGE" >/dev/null 2>&1 || fail_prereq "cannot pull ${IMAGE} into the throwaway store"
+
+failures=0
+note_fail() { printf '  RESULT: UNEXPECTED — %s\n' "$1"; failures=$((failures + 1)); }
+note_ok()   { printf '  RESULT: as documented — %s\n' "$1"; }
+
+# CapBnd bit 12 (0x1000) is CAP_NET_ADMIN, the bit the entrypoint tests.
+capbnd_of() {
+  # shellcheck disable=SC2016 # $2 is awk's field, expanded in the container, not here
+  pod run --rm "$@" --entrypoint /bin/sh "$IMAGE" \
+    -c 'grep -m1 ^CapBnd: /proc/self/status | awk "{print \$2}"' 2>/dev/null
+}
+
+has_net_admin() {
+  local hex="$1"
+  [[ -n "$hex" ]] || return 1
+  (( 0x${hex} & 0x1000 ))
+}
+
+run_case() {
+  local name="$1"; shift
+  local logfile="${WORK}/${name}.log"
+  local status
+
+  timeout "$CASE_TIMEOUT" "${POD[@]}" run --rm --name "${PROBE_PREFIX}-${name}" \
+    -v "${WORK}/hive.yaml:/etc/hive/hive.yaml:ro,Z" "$@" "$IMAGE" >"$logfile" 2>&1
+  status=$?
+
+  CASE_STATUS="$status"
+  CASE_LOG="$logfile"
+
+  if [[ "$status" -eq 124 ]]; then
+    printf '  exit: still running at the %ss cap (started)\n' "$CASE_TIMEOUT"
+  else
+    printf '  exit: %s\n' "$status"
+  fi
+
+  # Started and enforcing are different questions. Report both, separately.
+  if grep -q 'outbound :443 -> :18443' "$logfile"; then
+    printf '  gate: INSTALLED — %s\n' "$(grep -m1 'outbound :443 -> :18443' "$logfile" | sed 's/^\[entrypoint\] //')"
+    CASE_GATE="installed"
+  elif grep -q 'ADVISORY-ONLY' "$logfile"; then
+    printf '  gate: NOT installed, advisory mode accepted\n'
+    CASE_GATE="advisory"
+  else
+    printf '  gate: NOT installed\n'
+    CASE_GATE="absent"
+  fi
+}
+
+# ── Capability bounding sets ────────────────────────────────────────────────
+printf -- '--- capability bounding set ---\n'
+cap_default="$(capbnd_of)"
+cap_netadmin="$(capbnd_of --cap-add NET_ADMIN)"
+printf '  default          CapBnd=%s NET_ADMIN=%s\n' \
+  "${cap_default:-?}" "$(has_net_admin "$cap_default" && echo yes || echo no)"
+printf '  --cap-add        CapBnd=%s NET_ADMIN=%s\n' \
+  "${cap_netadmin:-?}" "$(has_net_admin "$cap_netadmin" && echo yes || echo no)"
+
+has_net_admin "$cap_default" && note_fail "rootful default already carries CAP_NET_ADMIN"
+has_net_admin "$cap_netadmin" || note_fail "--cap-add NET_ADMIN did not put CAP_NET_ADMIN in the bounding set"
+
+# ── Case 1: default rootful ─────────────────────────────────────────────────
+printf -- '\n--- case: default (rootful, no added capability) ---\n'
+run_case default
+if [[ "$CASE_STATUS" -eq 77 ]] && grep -q 'exiting 77' "$CASE_LOG"; then
+  note_ok "fail-closed, exit 77 (EX_NOPERM) with the bounding-set explanation"
+else
+  note_fail "expected exit 77 with the CAP_NET_ADMIN bounding-set message"
+fi
+
+# ── Case 2: rootful + NET_ADMIN ─────────────────────────────────────────────
+printf -- '\n--- case: netadmin (rootful + --cap-add NET_ADMIN) ---\n'
+run_case netadmin --cap-add NET_ADMIN
+if [[ "$CASE_GATE" == "installed" ]]; then
+  if grep -q 'ambient CAP_NET_ADMIN granted' "$CASE_LOG"; then
+    note_ok "redirect installed and ambient CAP_NET_ADMIN survived the privilege drop"
+  else
+    note_fail "redirect installed but the ambient CAP_NET_ADMIN raise did not survive"
+  fi
+else
+  note_fail "the forced-egress redirect did not install under --cap-add NET_ADMIN"
+fi
+
+# ── Case 3: deliberate advisory ─────────────────────────────────────────────
+printf -- '\n--- case: advisory (rootful, HIVE_PROXY_ADVISORY_OK=true) ---\n'
+run_case advisory -e HIVE_PROXY_ADVISORY_OK=true
+if grep -q 'ADVISORY-ONLY' "$CASE_LOG"; then
+  note_ok "started with the explicit advisory-only warning"
+  grep -m1 'ADVISORY-ONLY' "$CASE_LOG" | sed 's/^/  log: /'
+else
+  note_fail "advisory mode did not produce the ADVISORY-ONLY warning"
+fi
+
+# ── Optional: isolate the SO_MARK exemption ─────────────────────────────────
+# The rootless spike could not tell which RETURN matched, because the owner-UID
+# rule and the mark rule were both in the chain. Deleting the owner rules leaves
+# the mark as the only exemption, which is the OpenShift/OVN configuration.
+if [[ "$SOMARK" == "true" ]]; then
+  printf -- '\n--- SO_MARK isolation (needs outbound network) ---\n'
+  pod rm -f "${PROBE_PREFIX}-live" >/dev/null 2>&1
+  pod run -d --name "${PROBE_PREFIX}-live" --cap-add NET_ADMIN \
+    -v "${WORK}/hive.yaml:/etc/hive/hive.yaml:ro,Z" "$IMAGE" >/dev/null 2>&1
+
+  for _ in $(seq 1 45); do
+    pod logs "${PROBE_PREFIX}-live" 2>&1 | grep -q 'Dropping to dev' && break
+    sleep 2
+  done
+
+  printf '  chain as installed:\n'
+  pod exec "${PROBE_PREFIX}-live" iptables-nft -t nat -S HIVE_PROXY 2>&1 | sed 's/^/    /'
+
+  # CONTROL. curl exec'd as the proxy UID carries NO packet mark: SO_MARK is set
+  # by the proxy's own dialer (pkg/proxy/somark_linux.go), and an exec'd process
+  # gets neither that code path nor the ambient CAP_NET_ADMIN that setting a mark
+  # requires. So this line measures the OWNER rule only, never the mark.
+  printf '  control, unmarked uid-1001 dial, owner rules present: %s\n' \
+    "$(pod exec -u 1001 "${PROBE_PREFIX}-live" \
+        sh -c 'curl -sS -m 12 -o /dev/null -w "http_code=%{http_code}" https://api.github.com' 2>&1 | tail -1)"
+
+  # THE REAL TEST. An AGENT-uid request is redirected into the proxy, which then
+  # makes its own upstream dial — and that dial is the one carrying SO_MARK. If it
+  # still completes once the owner RETURNs are gone, the mark path carried it.
+  agent_uid="$(pod exec "${PROBE_PREFIX}-live" \
+    sh -c 'sed -n "s/.*\"probe\": \([0-9]*\).*/\1/p" /var/run/hive/uid-map.json' 2>/dev/null | head -1)"
+  agent_uid="${agent_uid:-2001}"
+  printf '  agent uid: %s\n' "$agent_uid"
+
+  agent_before="$(pod exec -u "$agent_uid" "${PROBE_PREFIX}-live" \
+      sh -c 'curl -sS -k -m 15 -o /dev/null -w "http_code=%{http_code}" https://api.github.com' 2>&1 | tail -1)"
+  printf '  agent through proxy, owner rules present:            %s\n' "$agent_before"
+
+  # Remove BOTH owner-UID RETURNs. The mark RETURN is then the only exemption --
+  # the OpenShift/OVN configuration, where xt_owner is absent.
+  pod exec "${PROBE_PREFIX}-live" \
+    sh -c 'iptables-nft -t nat -D HIVE_PROXY -m owner --uid-owner 0 -j RETURN 2>/dev/null;
+           iptables-nft -t nat -D HIVE_PROXY -m owner --uid-owner 1001 -j RETURN 2>/dev/null; true' >/dev/null 2>&1
+
+  printf '  chain with owner RETURNs removed:\n'
+  pod exec "${PROBE_PREFIX}-live" iptables-nft -t nat -S HIVE_PROXY 2>&1 | sed 's/^/    /'
+
+  printf '  control, unmarked uid-1001 dial, owner rules gone:   %s\n' \
+    "$(pod exec -u 1001 "${PROBE_PREFIX}-live" \
+        sh -c 'curl -sS -m 12 -o /dev/null -w "http_code=%{http_code}" https://api.github.com' 2>&1 | tail -1)"
+
+  agent_after="$(pod exec -u "$agent_uid" "${PROBE_PREFIX}-live" \
+      sh -c 'curl -sS -k -m 15 -o /dev/null -w "http_code=%{http_code}" https://api.github.com' 2>&1 | tail -1)"
+  printf '  agent through proxy, MARK path alone:                %s\n' "$agent_after"
+
+  if printf '%s' "$agent_before" | grep -q 'http_code=[23]'; then
+    if printf '%s' "$agent_after" | grep -q 'http_code=[23]'; then
+      note_ok "SO_MARK alone carries the proxy's upstream dial with no owner rule present"
+    else
+      note_fail "proxy upstream broke once only the mark exemption remained (the #2678 shape)"
+    fi
+  else
+    printf '  RESULT: INCONCLUSIVE — the agent path did not work even WITH the owner rules,\n'
+    printf '          so this run cannot say anything about the mark path.\n'
+  fi
+
+  pod rm -f "${PROBE_PREFIX}-live" >/dev/null 2>&1
+fi
+
+printf '\nSUMMARY: %d unexpected result(s)\n' "$failures"
+[[ "$failures" -eq 0 ]] || exit 1
+exit 0

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -85,6 +85,7 @@ Some documents describe planned or design-only work rather than live features. T
 - [Security model — operator guide](security-model.md) — Ed25519-only sessions/SSO, per-hive keys, master key rotation, forced proxy egress and `CAP_NET_ADMIN`, privilege model, and supply-chain posture.
 - [Security threat model](https://github.com/kubestellar/hive/blob/v4/src/docs/security-threat-model.md) — actors, boundaries, layered defenses, known gaps, and reporting.
 - [Rootless Podman startup and exit-77 behavior](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-startup-spike.md) — measured rootless matrix: fail-closed exit 77, gate installation under `--cap-add NET_ADMIN`, proven interception, and what is still unproven.
+- [Rootful Podman egress-gate baseline](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootful-egress-baseline.md) — the rootful baseline the rootless result is measured against: fail-closed exit 77, redirect and ambient-capability evidence, and `SO_MARK` isolated from the owner-UID exemption.
 - [Architecture Decision Records](https://github.com/kubestellar/hive/blob/v4/src/docs/adr/README.md) — lightweight ADR process and records 0001-0010.
 - [Intent verification](https://github.com/kubestellar/hive/blob/v4/src/docs/intent-verification.md) — tier-based change authorization for merge eligibility.
 - [Rootless Podman CI seam](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-ci.md) — documented test intent and static contract for contributor-container runtime handling.

--- a/src/docs/podman-rootful-egress-baseline.md
+++ b/src/docs/podman-rootful-egress-baseline.md
@@ -1,0 +1,151 @@
+# Rootful Podman egress-gate baseline
+
+## Result
+
+Rootful Podman is a clean baseline for Hive's forced-proxy egress gate. It
+behaves exactly as the enforcing standalone path expects, and in the same three
+states the rootless spike measured:
+
+| Case | Container | Gate installed | Exit |
+| --- | --- | --- | --- |
+| Default rootful | refuses to start | no | **77** (`EX_NOPERM`) |
+| Rootful + `--cap-add NET_ADMIN` | starts and stays up | **yes** | still running at the cap |
+| Rootful + `HIVE_PROXY_ADVISORY_OK=true` | starts and stays up | no — advisory accepted | still running at the cap |
+
+Rootful does **not** hand out `CAP_NET_ADMIN` by default, so the fail-closed
+branch is reached for a real reason rather than by accident:
+
+```
+default    CapBnd=00000000800405fb   NET_ADMIN=no
+--cap-add  CapBnd=00000000800415fb   NET_ADMIN=yes
+```
+
+Bit 12 (`0x1000`) is `CAP_NET_ADMIN` — the same bit the entrypoint tests.
+
+This makes the rootless result in
+[podman-rootless-startup-spike.md](podman-rootless-startup-spike.md)
+comparable: rootless matched rootful on all three cases, so rootless is not
+weaker than the baseline on this configuration.
+
+## Environment
+
+| | |
+| --- | --- |
+| Podman | 5.8.4, **rootful** |
+| OCI runtime | crun 1.28 |
+| Network backend | netavark (bridge; the container has its own netns) |
+| cgroups | v2 |
+| Kernel / host | 7.1.4-200.fc44.x86_64, Aurora 44.20260815.1 (Kinoite), SELinux enforcing |
+| Image | `ghcr.io/kubestellar/hive:v4-latest`, digest `sha256:654d835632ab1e813a3157c901319056f85c62417cc63e95e2764ee29c94adfa` |
+| Architecture | `amd64` only |
+
+The image digest differs from the one the rootless spike recorded
+(`sha256:e1479d76…`); `v4-latest` moved between the two runs. The comparison
+above is therefore across two builds of the same tag, not one artifact.
+
+### Storage safety
+
+Rootful Podman on a workstation is usually where the long-lived services live,
+so every Podman call in the probe is pinned to a throwaway `--root`/`--runroot`
+under `/var/tmp`. The host's rootful store was never addressed, and the probe
+refuses to run if the store path resolves to `/var/lib/containers`,
+`/run/containers`, or the host's reported `graphRoot`. Cleanup removes only the
+containers the probe created, by exact name; it never prunes.
+
+Verified before the first container started: the host store listed 11
+containers, the probe's store listed 0.
+
+## Reproducing
+
+`src/deploy/probe_podman_rootful_netadmin.sh` runs the whole matrix and must be
+run as root:
+
+```bash
+sudo src/deploy/probe_podman_rootful_netadmin.sh --somark
+```
+
+It creates its own throwaway store by default, removes only the containers it
+created, and exits non-zero if any case stops matching the contract recorded
+here. A store passed with `--store` is kept, so repeated runs do not re-pull the
+image. It stops with `EX_CONFIG` (78) and names the missing prerequisite if
+Podman is absent, is not rootful, or the image cannot be pulled — it never falls
+back to Docker.
+
+No Docker configuration was read or changed by any part of this spike.
+
+## Evidence: what the gate actually installs
+
+Under `--cap-add NET_ADMIN` the entrypoint reports:
+
+```
+[entrypoint] iptables (iptables-nft): outbound :443 -> :18443 (proxy UID 1001 + egress mark 0x1112 exempt)
+[entrypoint] Dropping to dev user (ambient CAP_NET_ADMIN granted for proxy SO_MARK egress-gate)
+```
+
+and the chain in the container's own network namespace is:
+
+```
+-N HIVE_PROXY
+-A HIVE_PROXY -m owner --uid-owner 0 -j RETURN
+-A HIVE_PROXY -m owner --uid-owner 1001 -j RETURN
+-A HIVE_PROXY -m mark --mark 0x1112 -j RETURN
+-A HIVE_PROXY -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 18443
+```
+
+Both the redirect and the capability propagation across the privilege drop are
+therefore observed, not inferred: the ambient-`CAP_NET_ADMIN` line is printed by
+the process that has already dropped to `dev`.
+
+## `SO_MARK` isolated
+
+The rootless spike could not say which exemption carried the proxy's own
+traffic, because the owner-UID rule and the mark rule were both in the chain.
+Deleting the two owner `RETURN`s leaves the mark as the only exemption — the
+OpenShift/OVN shape, where `xt_owner` is absent.
+
+| | owner rules present | owner `RETURN`s removed |
+| --- | --- | --- |
+| unmarked dial as UID 1001 (control) | `http_code=200` | `http_code=000` |
+| agent request through the proxy | `http_code=200` | **`http_code=200`** |
+
+The control is what makes this readable. An exec'd `curl` carries no packet
+mark — `SO_MARK` is set by the proxy's own dialer in
+`src/pkg/proxy/somark_linux.go`, and setting it needs `CAP_NET_ADMIN`, which an
+exec'd process does not inherit. So the control measures the *owner* rule only:
+its `000` after deletion proves the owner exemption is genuinely gone and the
+`REDIRECT` is live. The agent request, by contrast, is redirected *into* the
+proxy and forces the proxy's own upstream dial — the one that does carry the
+mark. That still returning 200 is the mark path working alone.
+
+**This does not retire the #2678 regression history.** That failure was
+`SO_MARK` not reliably sticking to the proxy's sockets on OKE, which is a
+property of that platform, not of the rule. The result here is that the mark
+exemption is correct and sufficient *on this kernel and network backend*. Both
+exemptions should stay.
+
+## What remains unproven
+
+- **IPv6.** The gate is IPv4-only — the entrypoint has no `ip6tables` path at
+  all. On this configuration the container gets no global IPv6 address, so there
+  is nothing to bypass; on a host or network that does hand out IPv6, an agent
+  could reach `:443` over v6 and miss the redirect entirely. **This is the
+  bypass-resistance test that needs its own follow-up issue.**
+- **Kernels without `xt_owner`.** Deleting the owner rules emulates the shape
+  but not the kernel. This host has `xt_owner`.
+- **Restart, reboot, and recreate.** Single `podman run` only; nothing about
+  whether the gate re-installs reliably across a restart.
+- **The gateway and the pod topology.** One container in isolation — nothing
+  about publishing 3001, withholding 7681, or two containers sharing a network.
+- **`arm64`.** `amd64` only.
+- **A locally built image.** The published `v4-latest` was probed, not a
+  `src/Dockerfile` build.
+- **An agent setting its own mark.** Agents drop to unprivileged UIDs without
+  ambient `CAP_NET_ADMIN`, so they should not be able to stamp `0x1112` and
+  exempt themselves. That is argued from the capability model here, not measured.
+
+## References
+
+- [Rootless Podman startup and exit-77 behavior](podman-rootless-startup-spike.md) — the rootless counterpart (#4199).
+- `src/deploy/probe_podman_rootful_netadmin.sh` — the probe that produces every number above.
+- `src/deploy/entrypoint.sh` — the gate itself, and the `#2678` regression history in its comments.
+- `src/pkg/proxy/somark_linux.go` — where `SO_MARK` is stamped.


### PR DESCRIPTION
Closes #4200. Part of #4188.

## Result

Rootful Podman is a clean baseline for the forced-proxy egress gate, in the same
three states #4199 measured for rootless — so the rootless result now has
something to be compared against, and is not weaker than the baseline on this
configuration.

| Case | Container | Gate installed | Exit |
| --- | --- | --- | --- |
| Default rootful | refuses to start | no | **77** (`EX_NOPERM`) |
| Rootful + `--cap-add NET_ADMIN` | starts and stays up | **yes** | still running at the cap |
| Rootful + `HIVE_PROXY_ADVISORY_OK=true` | starts and stays up | no — advisory accepted | still running at the cap |

Rootful does **not** carry `CAP_NET_ADMIN` by default, so the fail-closed branch
is reached for a real reason rather than by accident:

```
default    CapBnd=00000000800405fb   NET_ADMIN=no
--cap-add  CapBnd=00000000800415fb   NET_ADMIN=yes
```

## Evidence, not inference

```
[entrypoint] iptables (iptables-nft): outbound :443 -> :18443 (proxy UID 1001 + egress mark 0x1112 exempt)
[entrypoint] Dropping to dev user (ambient CAP_NET_ADMIN granted for proxy SO_MARK egress-gate)
```

The ambient-capability line is printed by the process that has *already* dropped
to `dev`, and the `HIVE_PROXY` chain is read back out of the running container,
so redirect creation and capability propagation are both observed directly.

## `SO_MARK` isolated — the thing #4199 could not do

#4199 could not say which exemption carried the proxy's traffic, because the
owner-UID and mark `RETURN`s were both in the chain. Deleting the owner rules
leaves the mark as the only exemption (the OpenShift/OVN shape):

| | owner rules present | owner `RETURN`s removed |
| --- | --- | --- |
| unmarked dial as UID 1001 (control) | `http_code=200` | `http_code=000` |
| agent request through the proxy | `http_code=200` | **`http_code=200`** |

The control is what makes it readable, and it is worth being explicit about
because the obvious version of this test is wrong: an exec'd `curl` carries **no
packet mark**, since `SO_MARK` is stamped by the proxy's own dialer
(`src/pkg/proxy/somark_linux.go`) and setting it requires `CAP_NET_ADMIN`, which
an exec'd process does not inherit. So the control measures the *owner* rule
only — its `000` proves the owner exemption is genuinely gone and the `REDIRECT`
is live. Only the agent request forces the proxy's own upstream dial, which is
the one carrying the mark.

**This does not retire the #2678 history.** That was `SO_MARK` failing to stick
on OKE — a property of that platform, not of the rule. Both exemptions should
stay.

## The bypass-resistance gap this found

**The gate is IPv4-only.** `src/deploy/entrypoint.sh` has no `ip6tables` path at
all. On this host the container gets no global IPv6 address, so there is nothing
to bypass here — but on a v6-capable network an agent could reach `:443` over
IPv6 and miss the redirect entirely. Recorded in the doc's *What remains
unproven* rather than fixed here, per this issue's 30-minute boundary; it wants
its own follow-up.

## Safety

Rootful Podman on a workstation is usually where the long-lived services live.
Every Podman call is pinned to a throwaway `--root`/`--runroot` under `/var/tmp`;
the probe refuses to run if the store resolves to `/var/lib/containers`,
`/run/containers`, or the host's reported `graphRoot`; cleanup removes only the
containers it created, by exact name, and never prunes. Isolation was verified
before the first container started — the host store listed 11 containers, the
probe's store listed 0 — and the host's containers were confirmed untouched
afterwards. Containers use their own netns, so the gate's rules never reach the
host's netfilter tables.

No Docker configuration was read or changed.

## Reproducing

```bash
sudo src/deploy/probe_podman_rootful_netadmin.sh --somark
```

Exits non-zero if any case stops matching what the doc records; `EX_CONFIG` (78)
if Podman is absent, is not rootful, or the image cannot be pulled. It never
falls back to Docker. `shellcheck` clean.

## Acceptance criteria

- **Exact commands, Podman version, image reference and logs recorded** — in
  `src/docs/podman-rootful-egress-baseline.md`, including the image digest and
  the note that `v4-latest` moved between this run and #4199's.
- **A missing capability or iptables dependency fails closed** — default rootful
  exits 77; advisory mode is the only way to start unenforced and says so loudly.
- **Remaining bypass-resistance test identified** — IPv6, above.
- **No Docker configuration changed** — nothing in this PR reads or writes any
  Docker configuration.
