### PR TITLE
🐛 fix(advisory): heal repo-access findings once the read path is verified

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -5375,6 +5375,53 @@ func runEvalCycle(
 							logger.Info("closed healed GitHub App access findings after successful App digest post",
 								"count", len(healed), "titles", strings.Join(healed, "; "))
 						}
+						// Repo-ACCESS findings ("no clone mechanism", "no
+						// repository access mechanism in L2 advisory mode",
+						// …) are the second #2575 family: true before #4291
+						// gave advisory tiers Contents:read and a working
+						// credential-helper fetch, but a digest post only
+						// proves issues:WRITE, so they need their own proof.
+						// Verify with a real advisor-scoped Contents read of
+						// the repo each finding names (or the primary repo
+						// when it names none), memoized per repo — a finding
+						// about a repo the hive genuinely cannot read stays
+						// open.
+						readVerified := map[string]bool{}
+						canRead := func(ownerRepo string) bool {
+							target := ownerRepo
+							if target == "" {
+								target = primaryRepo
+							}
+							owner, name := cfg.Project.Org, target
+							if i := strings.LastIndex(target, "/"); i > 0 {
+								owner, name = target[:i], target[i+1:]
+							}
+							if owner == "" || name == "" {
+								return false
+							}
+							key := owner + "/" + name
+							if v, ok := readVerified[key]; ok {
+								return v
+							}
+							appAuth := ghClient.AppAuth()
+							if appAuth == nil {
+								// Static-token client: no advisor-tier token
+								// can be minted, so the read path cannot be
+								// verified — leave the finding open.
+								return false
+							}
+							err := appAuth.VerifyRepoRead(ctx, owner, name)
+							if err != nil {
+								logger.Info("repo-access finding left open: advisor read probe failed",
+									"repo", key, "error", err)
+							}
+							readVerified[key] = err == nil
+							return readVerified[key]
+						}
+						if healed := advisory.CloseHealedRepoAccessFindings(beadStores, canRead); len(healed) > 0 {
+							logger.Info("closed healed repo-access findings after verified advisory read path",
+								"count", len(healed), "titles", strings.Join(healed, "; "))
+						}
 					}
 				} else {
 					// No pinned advisory issue for this repo, yet there IS

--- a/src/pkg/advisory/heal.go
+++ b/src/pkg/advisory/heal.go
@@ -2,6 +2,7 @@ package advisory
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/kubestellar/hive/pkg/beads"
 )
@@ -84,6 +85,143 @@ func CloseHealedAppAuthFindings(stores map[string]*beads.Store) []string {
 				continue
 			}
 			_ = store.SetMetadata(b.ID, closeReasonMetadataKey, appAuthHealedCloseReason)
+			closed = append(closed, b.Title)
+		}
+	}
+	return closed
+}
+
+// repoAccessHealedCloseReason is stamped into a bead's metadata when the hive
+// auto-closes it because the advisory-tier repository READ path demonstrably
+// works. Distinct from appAuthHealedCloseReason because the proof is different:
+// a digest post proves the App can WRITE issues, while this close requires an
+// actual verified Contents read.
+const repoAccessHealedCloseReason = "auto-closed: the hive verified an advisory-tier scoped token can read the repository, so this repo-access finding no longer holds"
+
+// repoAccessFindingPatterns recognize the #2575 finding family: advisory-tier
+// (guide/newcomer) agents reporting they have NO WAY TO READ the repository
+// they exist to audit — "no clone mechanism", "no repository access mechanism
+// in L2 advisory mode", "repository access infrastructure missing", "lacks
+// read-only repository access", "no repository workspace provisioning". These
+// were true findings before #4291 (the advisor/newcomer scoped-token tiers
+// omitted Contents:read and the credential helper blocked fetches), and agents
+// word them freely, so the patterns tolerate drift.
+//
+// Like appAuthFindingPatterns they must stay directional: every pattern
+// requires the LACK language ("no/missing/lacks/cannot") adjacent to the
+// access/clone subject, so a CODE finding that merely mentions repository
+// access ("Repository access logs are not retained", "read access to
+// repository secrets not restricted") never matches. And unlike the app-auth
+// healer, a title match alone is NOT sufficient to close — see
+// CloseHealedRepoAccessFindings, which additionally requires a verified read
+// of the repository the finding concerns.
+var repoAccessFindingPatterns = []*regexp.Regexp{
+	// "no clone mechanism available", "agent lacks a checkout mechanism"
+	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without|unavailable)\b[^.\n]*\b(clone|checkout|fetch)\s+mechanism\b`),
+	// "clone mechanism missing/unavailable/not available"
+	regexp.MustCompile(`(?i)\b(clone|checkout|fetch)\s+mechanism\b[^.\n]*\b(missing|unavailable|absent|not\s+available)\b`),
+	// "no repository access mechanism", "lacks read-only repository access
+	// mechanism", "no repo read access path"
+	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without|unavailable)\b[^.\n]*\brepo(sitory)?\s+(read\s+)?access\b[^.\n]*\b(mechanism|infrastructure|capabilit|path|method|provision)`),
+	// "repository access infrastructure missing"
+	regexp.MustCompile(`(?i)\brepo(sitory)?\s+(read\s+)?access\b[^.\n]*\b(mechanism|infrastructure|capabilit|path|method|provision)[a-z]*\b[^.\n]*\b(missing|unavailable|absent|lacking|not\s+available)\b`),
+	// "no repository workspace provisioning for advisory agents"
+	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without)\b[^.\n]*\brepo(sitory)?\s+workspace\s+provisioning\b`),
+	// "guide agent cannot access target repository", "unable to clone the repository"
+	regexp.MustCompile(`(?i)\b(cannot|can't|unable\s+to)\s+(access|read|clone|fetch)\b[^.\n]*\brepo(sitory)?\b`),
+}
+
+// IsRepoAccessFinding reports whether a finding title describes the hive's own
+// agents lacking a repository read path (clone/fetch/contents access), as
+// opposed to a code finding that merely mentions repository access. Titles
+// only, for the same reason as IsAppAuthFinding.
+func IsRepoAccessFinding(title string) bool {
+	if title == "" {
+		return false
+	}
+	for _, p := range repoAccessFindingPatterns {
+		if p.MatchString(title) {
+			return true
+		}
+	}
+	return false
+}
+
+// RepoFromFindingRef extracts an "owner/repo" from a finding's file reference
+// (Bead.ExternalRef), when the agent attributed the finding to a repository
+// rather than a file. Agents write refs like:
+//
+//	"github.ibm.com/devx-prod/epx-vscode-ext-poc" → devx-prod/epx-vscode-ext-poc
+//	"hive.yaml:repos", "src/main.go:12", "hive-infrastructure" → not a repo
+//
+// The parse is deliberately conservative: anything with a ":" is a file:line
+// or file:section ref, and a two-segment path only parses as owner/repo when
+// neither segment contains a "." (so "docs/install.md" never does). A ref
+// that fails to parse means "the finding is about the hive's own configured
+// repo", which is the safe default for the verification gate.
+func RepoFromFindingRef(ref string) (string, bool) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.Contains(ref, ":") {
+		return "", false
+	}
+	parts := strings.Split(strings.Trim(ref, "/"), "/")
+	switch len(parts) {
+	case 3:
+		// host/owner/repo — the leading segment must look like a hostname.
+		if strings.Contains(parts[0], ".") && parts[1] != "" && parts[2] != "" {
+			return parts[1] + "/" + parts[2], true
+		}
+	case 2:
+		if parts[0] != "" && parts[1] != "" && !strings.Contains(parts[0], ".") && !strings.Contains(parts[1], ".") {
+			return parts[0] + "/" + parts[1], true
+		}
+	}
+	return "", false
+}
+
+// CloseHealedRepoAccessFindings closes open advisory beads that report the
+// hive's agents lacking a repository READ path, but ONLY for repositories the
+// caller can PROVE are readable right now. canRead receives the "owner/repo"
+// the finding names (parsed from its ref), or "" when the finding names no
+// repo — meaning the hive's own primary repo. It must return true only after
+// an actual verified read (e.g. a Contents fetch with an advisory-tier scoped
+// token — the exact path #4291 fixed), and is consulted per bead so a finding
+// about a repo that is GENUINELY unreadable is never closed alongside healed
+// ones. Callers should memoize canRead: many findings name the same repo.
+//
+// Invoked after a successful App-authenticated digest post, like
+// CloseHealedAppAuthFindings — but the digest post only proves issues:write,
+// so the read verification is what actually gates each close here. A wrongly
+// surviving finding costs nothing (it heals next cycle); a wrongly closed one
+// re-opens only when an agent re-files it, so the gate errs toward staying
+// open. Returns the closed titles for logging.
+func CloseHealedRepoAccessFindings(stores map[string]*beads.Store, canRead func(ownerRepo string) bool) []string {
+	if canRead == nil {
+		return nil
+	}
+	var closed []string
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		for _, b := range store.List(beads.ListFilter{}) {
+			if b.Status == beads.StatusClosed || b.Status == beads.StatusDone {
+				continue
+			}
+			if !isAdvisoryBeadType(b.Type) {
+				continue
+			}
+			if !IsRepoAccessFinding(b.Title) {
+				continue
+			}
+			repo, _ := RepoFromFindingRef(b.ExternalRef)
+			if !canRead(repo) {
+				continue
+			}
+			if err := store.Close(b.ID); err != nil {
+				continue
+			}
+			_ = store.SetMetadata(b.ID, closeReasonMetadataKey, repoAccessHealedCloseReason)
 			closed = append(closed, b.Title)
 		}
 	}

--- a/src/pkg/advisory/heal_test.go
+++ b/src/pkg/advisory/heal_test.go
@@ -285,3 +285,165 @@ func TestClosePRLinkedAdvisoryBeadsIgnoresDissimilarAndClosed(t *testing.T) {
 		t.Fatalf("closed = %v on an empty PR title, want none", closed)
 	}
 }
+
+// gee4veeRepoAccessTitles are the five exact guide-agent finding titles from
+// #2575 (comment 5359943936) that survived the #4291 fix — the repo-access
+// heal exists to retire precisely these once the read path is verified.
+var gee4veeRepoAccessTitles = []struct{ title, ref string }{
+	{"ACMM L2 guide agent lacks read-only repository access mechanism", "hive-infrastructure"},
+	{"Critical infrastructure gap: No repository workspace provisioning for advisory agents", "hive.yaml:repos"},
+	{"Critical: Repository access infrastructure missing - guide agent cannot audit documentation", "hive.yaml.runtime:repos"},
+	{"Guide agent cannot access target repository - no clone mechanism available", "github.ibm.com/devx-prod/epx-vscode-ext-poc"},
+	{"Guide agent blocked: No repository access mechanism in L2 advisory mode", "github.ibm.com/devx-prod/epx-vscode-ext-poc"},
+}
+
+func TestIsRepoAccessFinding(t *testing.T) {
+	for _, f := range gee4veeRepoAccessTitles {
+		if !IsRepoAccessFinding(f.title) {
+			t.Errorf("IsRepoAccessFinding(%q) = false, want true (the #2575 family must match)", f.title)
+		}
+	}
+	// Drift the agents plausibly produce must still match.
+	drift := []string{
+		"Advisory agent has no repository access path in ISSUES_ONLY mode",
+		"clone mechanism unavailable for L2 guide agents",
+		"Guide agent unable to fetch the target repository",
+		"Agent workspace lacks a git clone mechanism",
+	}
+	for _, title := range drift {
+		if !IsRepoAccessFinding(title) {
+			t.Errorf("IsRepoAccessFinding(%q) = false, want true (wording drift)", title)
+		}
+	}
+	// Code findings that merely mention repository access must NEVER match —
+	// closing one would silently retire a real finding.
+	negatives := []string{
+		"Repository access logs are not retained",
+		"Public read access to repository secrets endpoint not restricted",
+		"Workflow permissions overly broad in ci.yml",
+		"Add repository access checks to the admin API",
+		"Overly permissive repository access granted to all org members",
+		"Insufficient repo permissions", // app-auth family, handled by the other healer
+		"",
+	}
+	for _, title := range negatives {
+		if IsRepoAccessFinding(title) {
+			t.Errorf("IsRepoAccessFinding(%q) = true, want false", title)
+		}
+	}
+}
+
+func TestRepoFromFindingRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want string
+		ok   bool
+	}{
+		{"github.ibm.com/devx-prod/epx-vscode-ext-poc", "devx-prod/epx-vscode-ext-poc", true},
+		{"acme/widgets", "acme/widgets", true},
+		{"hive.yaml:repos", "", false},
+		{"hive.yaml.runtime:repos", "", false},
+		{"hive-infrastructure", "", false},
+		{"src/main.go:12", "", false},
+		{"docs/install.md", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := RepoFromFindingRef(tt.ref)
+		if got != tt.want || ok != tt.ok {
+			t.Errorf("RepoFromFindingRef(%q) = (%q, %v), want (%q, %v)", tt.ref, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+// TestCloseHealedRepoAccessFindings is the #2575 follow-up regression test:
+// each of the five surviving guide-agent findings must close once the read
+// path is verified, while a finding about a repo that is GENUINELY unreadable
+// must stay open, as must code findings and non-advisory beads.
+func TestCloseHealedRepoAccessFindings(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stores := map[string]*beads.Store{"guide": store}
+
+	for _, f := range gee4veeRepoAccessTitles {
+		if _, err := store.Create(f.title, beads.TypeAdvisory, beads.PriorityHigh, "guide", f.ref); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A repo-access finding about a repo the verifier CANNOT read: real
+	// condition, must survive the heal.
+	locked, err := store.Create("Guide agent cannot access target repository - no clone mechanism available",
+		beads.TypeAdvisory, beads.PriorityHigh, "guide", "github.ibm.com/other-org/locked-repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A code finding mentioning access must never be considered.
+	code, err := store.Create("Repository access logs are not retained", beads.TypeAdvisory, beads.PriorityMedium, "guide", "audit.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var probed []string
+	canRead := func(ownerRepo string) bool {
+		probed = append(probed, ownerRepo)
+		// "" = the hive's own primary repo (readable); the configured GHE
+		// repo is readable; anything else is not.
+		return ownerRepo == "" || ownerRepo == "devx-prod/epx-vscode-ext-poc"
+	}
+
+	healed := CloseHealedRepoAccessFindings(stores, canRead)
+	if len(healed) != len(gee4veeRepoAccessTitles) {
+		t.Fatalf("healed %d findings (%v), want the %d from #2575", len(healed), healed, len(gee4veeRepoAccessTitles))
+	}
+	for _, f := range gee4veeRepoAccessTitles {
+		found := false
+		for _, h := range healed {
+			if h == f.title {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("finding %q was not healed", f.title)
+		}
+	}
+	// The unreadable repo's probe must have been consulted and refused.
+	probedLocked := false
+	for _, p := range probed {
+		if p == "other-org/locked-repo" {
+			probedLocked = true
+		}
+	}
+	if !probedLocked {
+		t.Error("verification was never consulted for the unreadable repo")
+	}
+	got, _ := store.Get(locked.ID)
+	if got.Status != beads.StatusOpen {
+		t.Errorf("finding about unreadable repo status = %s, want open — a real access problem must never auto-close", got.Status)
+	}
+	gotCode, _ := store.Get(code.ID)
+	if gotCode.Status != beads.StatusOpen {
+		t.Errorf("code finding status = %s, want open", gotCode.Status)
+	}
+
+	// Closed beads carry the distinct repo-access close reason.
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Status != beads.StatusClosed {
+			continue
+		}
+		if reason := b.Meta(closeReasonMetadataKey); reason != repoAccessHealedCloseReason {
+			t.Errorf("close reason for %q = %q, want %q", b.Title, reason, repoAccessHealedCloseReason)
+		}
+	}
+
+	// Idempotent: nothing left to close on a second pass.
+	if again := CloseHealedRepoAccessFindings(stores, canRead); len(again) != 0 {
+		t.Errorf("second heal closed %v, want none", again)
+	}
+	// A nil verifier must close nothing, ever.
+	if closed := CloseHealedRepoAccessFindings(stores, nil); closed != nil {
+		t.Errorf("nil verifier closed %v, want none", closed)
+	}
+}

--- a/src/pkg/github/app.go
+++ b/src/pkg/github/app.go
@@ -521,6 +521,34 @@ func (a *AppAuth) VerifyInstallation(ctx context.Context) (*InstallationInfo, er
 	}, nil
 }
 
+// VerifyRepoRead proves the ADVISORY-TIER repository read path works for
+// owner/repo: it mints an advisor scoped token restricted to that single repo
+// (exactly the credential an L2 guide agent receives) and performs a real
+// Contents read with it. This is the verification gate for closing #2575's
+// "no clone mechanism / no repository access mechanism" findings — a digest
+// post only proves issues:write, while those findings are about Contents
+// read, which the advisor tier lacked entirely before #4291. A nil return
+// means the read demonstrably succeeded; any error means the finding's
+// condition may still hold and the caller must not close it.
+func (a *AppAuth) VerifyRepoRead(ctx context.Context, owner, repo string) error {
+	if owner == "" || repo == "" {
+		return fmt.Errorf("verifying repo read: owner and repo are required")
+	}
+	token, err := a.ScopedTokenForRepos(ctx, "advisor", []string{repo})
+	if err != nil {
+		return fmt.Errorf("minting advisor token for %s/%s: %w", owner, repo, err)
+	}
+	readCtx, cancel := mintContext(ctx)
+	defer cancel()
+	client := newTokenClient(token, a.apiURL)
+	// Root directory listing: works on any non-empty repo with Contents:read,
+	// unlike a README fetch, which 404s on repos without one.
+	if _, _, _, err := client.Repositories.GetContents(readCtx, owner, repo, "", nil); err != nil {
+		return fmt.Errorf("reading contents of %s/%s with advisor token: %w", owner, repo, err)
+	}
+	return nil
+}
+
 type appTransport struct {
 	auth *AppAuth
 	base http.RoundTripper

--- a/src/pkg/github/verify_repo_read_test.go
+++ b/src/pkg/github/verify_repo_read_test.go
@@ -1,0 +1,75 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestVerifyRepoRead exercises the #2575 repo-access verification gate: a
+// verified advisor-scoped Contents read returns nil, an unreadable repo
+// returns the error that keeps its finding open, and the minted token must be
+// advisor-shaped (contents:read, no write, restricted to the single repo).
+func TestVerifyRepoRead(t *testing.T) {
+	var mintedPerms map[string]any
+	var mintedRepos []any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/access_tokens"):
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if p, ok := body["permissions"].(map[string]any); ok {
+				mintedPerms = p
+			}
+			if rs, ok := body["repositories"].([]any); ok {
+				mintedRepos = rs
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"scoped-tok","expires_at":"2099-01-01T00:00:00Z"}`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/repos/acme/widgets/contents"):
+			_, _ = w.Write([]byte(`[{"name":"README.md","type":"file"}]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/repos/acme/locked/contents"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	auth, err := NewAppAuthFromPEM(1234, 5678, []byte(testAppPrivateKeyPEM(t)), slog.Default(), srv.URL)
+	if err != nil {
+		t.Fatalf("NewAppAuthFromPEM: %v", err)
+	}
+
+	if err := auth.VerifyRepoRead(context.Background(), "acme", "widgets"); err != nil {
+		t.Fatalf("VerifyRepoRead(readable repo) = %v, want nil", err)
+	}
+	// The credential probed with must be the ADVISOR shape — contents:read
+	// only, single-repo — or the probe would prove more access than the
+	// agents actually receive.
+	if got := mintedPerms["contents"]; got != "read" {
+		t.Errorf("minted contents permission = %v, want read", got)
+	}
+	if _, hasIssues := mintedPerms["issues"]; hasIssues {
+		t.Errorf("advisor probe token requested issues permission: %v", mintedPerms)
+	}
+	if len(mintedRepos) != 1 || mintedRepos[0] != "widgets" {
+		t.Errorf("minted token repositories = %v, want [widgets]", mintedRepos)
+	}
+
+	if err := auth.VerifyRepoRead(context.Background(), "acme", "locked"); err == nil {
+		t.Fatal("VerifyRepoRead(unreadable repo) = nil, want error — a real access problem must keep its finding open")
+	}
+
+	if err := auth.VerifyRepoRead(context.Background(), "", "widgets"); err == nil {
+		t.Fatal("VerifyRepoRead with empty owner = nil, want error")
+	}
+	if err := auth.VerifyRepoRead(context.Background(), "acme", ""); err == nil {
+		t.Fatal("VerifyRepoRead with empty repo = nil, want error")
+	}
+}


### PR DESCRIPTION
Follow-up to #4291, closes the remaining half of #2575.

## Problem

After #4291 gave advisory-tier agents a working repo read path (Contents:read on the `advisor`/`newcomer` scoped-token tiers + credential-helper fetch), @gee4vee's digest dropped 24→10 findings — but **five guide-agent findings survive and will never auto-close**:

1. "ACMM L2 guide agent lacks read-only repository access mechanism"
2. "Critical infrastructure gap: No repository workspace provisioning for advisory agents"
3. "Critical: Repository access infrastructure missing - guide agent cannot audit documentation"
4. "Guide agent cannot access target repository - no clone mechanism available"
5. "Guide agent blocked: No repository access mechanism in L2 advisory mode"

None of them matches `appAuthFindingPatterns` (they describe missing clone/workspace mechanisms, not insufficient permissions / App-not-installed / "resource not accessible by integration"), so `CloseHealedAppAuthFindings` skips them and they stay in the digest forever until manually closed.

## Fix

A second heal family with **stronger verification than the app-auth healer**:

- `repoAccessFindingPatterns` — case-insensitive, drift-tolerant recognition of the "no clone mechanism / no repository access mechanism / repository access infrastructure missing / lacks read-only repository access / no repository workspace provisioning" family. Every pattern requires the LACK language adjacent to the access/clone subject, so code findings that merely mention repository access ("Repository access logs are not retained") never match.
- `CloseHealedRepoAccessFindings` — a title match alone is NOT sufficient: the successful App digest post that gates the app-auth healer only proves issues:**write**, and these findings are about Contents **read**. Each matching bead closes only when the caller proves the repository the finding names (parsed from its ref via `RepoFromFindingRef`, defaulting to the hive's primary repo) is readable right now. A finding about a genuinely unreadable repo stays open.
- `AppAuth.VerifyRepoRead` — the proof: mints an **advisor-tier scoped token restricted to that single repo** (exactly the credential an L2 guide agent receives) and performs a real root-contents read with it. Wired into the digest-post success path in `main.go` with per-repo memoization.

## Tests

- All 5 exact titles above close under the new patterns (`TestCloseHealedRepoAccessFindings`), with drift variants and never-match negatives (`TestIsRepoAccessFinding`).
- A finding about an unreadable repo does NOT close; nil verifier closes nothing; distinct close reason recorded; idempotent.
- `TestVerifyRepoRead` asserts the probe token is advisor-shaped (contents:read, no issues, single-repo) and that 403 keeps the finding open.

`go build ./...`, `go test ./pkg/advisory/ ./pkg/github/ ./cmd/hive/` green.
