### PR TITLE
✨ feat(logs): durable per-kick agent run logs with history in the dashboard

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1075,9 +1075,17 @@ func main() {
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	// preShutdownHook, when set, runs in the signal handler before the context
+	// is canceled. It is stored after the agent manager exists and archives
+	// every agent's in-flight kick log to /data so a pod roll or hive upgrade
+	// does not destroy the latest run's scrollback (#4296).
+	var preShutdownHook atomic.Pointer[func()]
 	go func() {
 		sig := <-sigCh
 		logger.Info("received signal, shutting down", "signal", sig)
+		if fn := preShutdownHook.Load(); fn != nil {
+			(*fn)()
+		}
 		cancel()
 	}()
 
@@ -1343,6 +1351,10 @@ func main() {
 		AppAuthoredPRs:  cfg.GitHub.AppAuthoredPRsEnabled(),
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
+	// SIGTERM (pod roll, hive upgrade) destroys every tmux server and with it
+	// the in-flight kick's scrollback; archive it to /data first (#4296).
+	archiveOnShutdown := func() { agentMgr.ArchiveAllKickLogs("shutdown") }
+	preShutdownHook.Store(&archiveOnShutdown)
 	agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 	// Treat any configured gateway name as an inference-routable backend so an
 	// agent with backend: <gateway> routes through it. Resolution is live

--- a/src/docs/agent-logging.md
+++ b/src/docs/agent-logging.md
@@ -222,6 +222,49 @@ terminal scrollback:
   agent card. Normal dashboard auth applies (any authenticated role); output
   passes through token redaction, so it is not a redaction bypass.
 
+The live capture is scoped to the agent's **current** tmux session: a restart
+kills and recreates the session, and a hive upgrade replaces the whole
+container. Per-kick log archiving (below) is what preserves run logs across
+those boundaries.
+
+## Per-kick log history
+
+Hive archives each kick's terminal output to a durable file so operators can
+read the logs of the last several runs — not just the latest —
+([#4296](https://github.com/kubestellar/hive/issues/4296),
+[#4295](https://github.com/kubestellar/hive/issues/4295)):
+
+- **When snapshots happen.** The scrollback is captured to a file *before*
+  it can be destroyed: when the next kick is delivered (the previous kick's
+  output is archived and the tmux history is cleared, so each archive covers
+  exactly one kick), before `kill-session` on an agent restart, and on
+  graceful shutdown (SIGTERM — pod roll or hive upgrade) for every agent
+  with un-archived kick output.
+- **Where they live.** `/data/logs/kicks/<agent>/<timestamp>-<reason>.log`
+  (override the root with `HIVE_KICK_LOG_DIR`). `/data` is the persistent
+  volume on hosted hives, so archives survive agent restarts, pod rolls, and
+  hive image upgrades. Each file starts with a small header (agent, archive
+  time, snapshot reason, kick start time, prompt snippet) followed by the raw
+  scrollback. `<reason>` is `kick`, `restart`, or `shutdown`.
+- **Retention.** Per agent, the newest **10** archives are kept
+  (`HIVE_KICK_LOG_RETENTION`; `0` disables archiving) within a **64 MiB**
+  per-agent size cap (`HIVE_KICK_LOG_MAX_BYTES`); the oldest files are pruned
+  first and the newest archive is never deleted. An agent with less history
+  than normal (fresh install, retention just lowered) simply lists fewer
+  entries — never an error.
+- **Dashboard access.** The `🕘 past kicks` control on the agent card opens
+  `GET /agents/{name}/kicks`, an index of the live log plus every archived
+  kick with view/download links. Programmatic access:
+  `GET /api/agents/{name}/kicks` (JSON list, newest first) and
+  `GET /api/agents/{name}/kicks/{id}` (`text/plain`; `?download=1` for an
+  attachment). Same auth rule as the full-log endpoint (any authenticated
+  role), and archived content passes through the same token redaction.
+- **Limitations.** Sandbox-executor kicks have no tmux session and are not
+  archived here. The archive holds at most the retained scrollback
+  (`history-limit`, 50000 lines by default), so an extremely long run
+  self-truncates from the top. A hard kill (SIGKILL, node loss) skips the
+  shutdown snapshot; the previous kicks' archives on `/data` are unaffected.
+
 ## Related
 
 - [`src/deploy/README.md`](../deploy/README.md) — `hive-panes.sh` inventory

--- a/src/pkg/agent/kick_logs.go
+++ b/src/pkg/agent/kick_logs.go
@@ -1,0 +1,406 @@
+package agent
+
+// Durable per-kick agent run logs (#4296, #4295).
+//
+// The dashboard's "full log" is a live capture-pane of the agent's CURRENT
+// tmux session, so a restart — or a hive upgrade, which replaces the whole
+// container — destroys every previous run's scrollback. Operators debugging
+// why an agent misbehaved several kicks ago had nothing to look at.
+//
+// This file archives the scrollback of each kick to a durable file BEFORE the
+// content is lost:
+//
+//   - at kick delivery (deliverKickLocked), the outgoing scrollback — the
+//     previous kick's output — is snapshotted to a file and the tmux history
+//     is then cleared, so each archive covers exactly one kick;
+//   - at Restart, the scrollback is snapshotted BEFORE kill-session runs;
+//   - at graceful shutdown (SIGTERM: pod roll, hive upgrade), every agent
+//     with un-archived kick output is snapshotted via ArchiveAllKickLogs.
+//
+// Archives live under kickLogDir (default /data/logs/kicks — the /data PVC
+// survives agent restarts, pod rolls, and hive image upgrades) as
+// <agent>/<timestamp>-<reason>.log, pruned to the newest kickLogRetention
+// files and kickLogMaxBytes total bytes per agent.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// kickLogDirEnv overrides the root directory per-kick log archives are
+	// written under. Empty (unset) uses defaultKickLogDir.
+	kickLogDirEnv = "HIVE_KICK_LOG_DIR"
+
+	// defaultKickLogDir is on the /data persistent volume so archived kick
+	// logs survive agent restarts, pod rolls, and hive image upgrades. It
+	// sits beside the other durable log roots (Data.LogsDir = /data/logs).
+	defaultKickLogDir = "/data/logs/kicks"
+
+	// kickLogRetentionEnv overrides how many archived kick logs are kept per
+	// agent. 0 disables archiving entirely.
+	kickLogRetentionEnv = "HIVE_KICK_LOG_RETENTION"
+
+	// defaultKickLogRetention keeps the last 10 kicks per agent — enough to
+	// reach "the run several kicks ago" (#4296) without unbounded growth.
+	defaultKickLogRetention = 10
+
+	// kickLogMaxBytesEnv overrides the per-agent total size cap (in bytes)
+	// across an agent's archived kick logs.
+	kickLogMaxBytesEnv = "HIVE_KICK_LOG_MAX_BYTES"
+
+	// defaultKickLogMaxBytes caps one agent's archive directory. A full
+	// 50000-line scrollback of 200-column lines is ~10 MiB, so 64 MiB
+	// comfortably holds the default retention of even very chatty runs.
+	defaultKickLogMaxBytes = 64 << 20
+
+	// kickLogTimestampFormat is the filename prefix. Lexicographic order of
+	// this format IS chronological order, which is what pruning and listing
+	// sort by. Millisecond precision keeps two archives in the same second
+	// (kick storm, restart-then-kick) from colliding.
+	kickLogTimestampFormat = "20060102-150405.000"
+
+	// kickLogSuffix is the archive file extension.
+	kickLogSuffix = ".log"
+
+	// kickLogPromptSnippetLen bounds the prompt snippet recorded in an
+	// archive's header, mirroring KickRecord.Snippet's truncation.
+	kickLogPromptSnippetLen = 120
+
+	// Archive directories and files are owner-only: they are written and
+	// served by the hive process itself, and raw pane content may hold
+	// secrets that the dashboard redacts only at serve time — peer agent
+	// UIDs must not be able to read them off /data directly.
+	kickLogDirMode  = os.FileMode(0o700)
+	kickLogFileMode = os.FileMode(0o600)
+)
+
+// KickLogInfo describes one archived kick log, as listed by ListKickLogs and
+// the dashboard's kick-history endpoint.
+type KickLogInfo struct {
+	// ID is the archive's filename — the handle ReadKickLog accepts.
+	ID string `json:"id"`
+	// Timestamp is when the archive was written (parsed from the filename,
+	// falling back to the file mtime).
+	Timestamp time.Time `json:"timestamp"`
+	// SizeBytes is the archive size on disk.
+	SizeBytes int64 `json:"size_bytes"`
+	// Reason says what triggered the snapshot: "kick" (a newer kick rotated
+	// this one out), "restart", or "shutdown" (pod roll / hive upgrade).
+	Reason string `json:"reason"`
+}
+
+// kickLogSettingsFromEnv resolves the archive root, per-agent retention
+// count, and per-agent byte cap, applying env overrides over the defaults.
+// Invalid or negative overrides fall back to the defaults; retention 0 is a
+// valid explicit "archiving off".
+func kickLogSettingsFromEnv() (dir string, retention int, maxBytes int64) {
+	dir = os.Getenv(kickLogDirEnv)
+	if dir == "" {
+		dir = defaultKickLogDir
+	}
+	retention = defaultKickLogRetention
+	if v := os.Getenv(kickLogRetentionEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			retention = n
+		}
+	}
+	maxBytes = defaultKickLogMaxBytes
+	if v := os.Getenv(kickLogMaxBytesEnv); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			maxBytes = n
+		}
+	}
+	return dir, retention, maxBytes
+}
+
+// SetKickLogDir points archives at dir (tests; empty restores the env/default
+// resolution done in NewManager).
+func (m *Manager) SetKickLogDir(dir string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if dir == "" {
+		dir, _, _ = kickLogSettingsFromEnv()
+	}
+	m.kickLogDir = dir
+}
+
+// sanitizeKickLogComponent reduces a name to characters safe in a filename
+// component so an agent name or reason can never smuggle a path separator
+// into the archive path. Mirrors dashboard.sanitizeLogFilename.
+func sanitizeKickLogComponent(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "agent"
+	}
+	return out
+}
+
+// agentKickLogDir is the directory one agent's archives live in.
+func (m *Manager) agentKickLogDir(name string) string {
+	return filepath.Join(m.kickLogDir, sanitizeKickLogComponent(name))
+}
+
+// captureScrollbackForAgent pulls the agent's full retained scrollback, via
+// the test seam when one is wired. It is the single capture path shared by
+// CaptureFullLog (live "full log") and archiveKickLogLocked (durable
+// snapshot), so both always see the same bytes.
+func (m *Manager) captureScrollbackForAgent(agent *AgentProcess) (string, error) {
+	if m.captureFullLogFn != nil {
+		return m.captureFullLogFn(agent)
+	}
+	// -S -<n>: start n lines back into history; -E -: through the last visible
+	// line; -J: join wrapped lines so copied text is not hard-wrapped at the
+	// pane width; -p: print to stdout.
+	cmd := m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p", "-J",
+		"-S", fmt.Sprintf("-%d", fullLogCaptureLines), "-E", "-")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("capturing pane for %s: %w", agent.Name, err)
+	}
+	return string(out), nil
+}
+
+// clearScrollbackForAgent drops the session's scrollback history (the visible
+// pane is untouched) so the NEXT archive covers only the kick being delivered
+// now. Only called after its content has been archived.
+func (m *Manager) clearScrollbackForAgent(agent *AgentProcess) {
+	if m.clearHistoryFn != nil {
+		m.clearHistoryFn(agent)
+		return
+	}
+	_ = m.tmuxCmd(agent, "clear-history", "-t", agent.tmuxSession).Run()
+}
+
+// archiveKickLogLocked snapshots the agent's current scrollback to a durable
+// per-kick file and prunes the agent's archive directory to the retention
+// policy. Returns true when a file was written. Callers must hold m.mu.
+//
+// It must run BEFORE whatever destroys the scrollback (kill-session on
+// restart, container teardown on shutdown, clear-history on kick rotation) —
+// that ordering is the entire point of this feature.
+func (m *Manager) archiveKickLogLocked(agent *AgentProcess, reason string) bool {
+	if m.kickLogRetention <= 0 || m.kickLogDir == "" {
+		return false
+	}
+	if agent.tmuxSession == "" {
+		return false
+	}
+	content, err := m.captureScrollbackForAgent(agent)
+	if err != nil {
+		m.logger.Warn("kick log archive: capture failed", "name", agent.Name, "reason", reason, "error", err)
+		return false
+	}
+	if strings.TrimSpace(content) == "" {
+		return false
+	}
+
+	now := time.Now()
+	kickStarted := "unknown"
+	if agent.LastKick != nil {
+		kickStarted = agent.LastKick.UTC().Format(time.RFC3339)
+	}
+	header := fmt.Sprintf(
+		"==== hive kick log ====\nagent: %s\narchived: %s\nreason: %s\nkick_started: %s\nkick_prompt: %s\n=======================\n",
+		agent.Name,
+		now.UTC().Format(time.RFC3339),
+		reason,
+		kickStarted,
+		truncateStr(strings.ReplaceAll(agent.LastKickMessage, "\n", " "), kickLogPromptSnippetLen),
+	)
+
+	dir := m.agentKickLogDir(agent.Name)
+	if err := os.MkdirAll(dir, kickLogDirMode); err != nil {
+		m.logger.Warn("kick log archive: mkdir failed", "name", agent.Name, "dir", dir, "error", err)
+		return false
+	}
+	fname := now.UTC().Format(kickLogTimestampFormat) + "-" + sanitizeKickLogComponent(reason) + kickLogSuffix
+	path := filepath.Join(dir, fname)
+	if err := os.WriteFile(path, []byte(header+content), kickLogFileMode); err != nil {
+		m.logger.Warn("kick log archive: write failed", "name", agent.Name, "path", path, "error", err)
+		return false
+	}
+	m.logger.Info("archived kick log", "name", agent.Name, "reason", reason, "file", fname, "bytes", len(header)+len(content))
+
+	m.pruneKickLogs(dir)
+	return true
+}
+
+// rotateKickLogOnKickLocked runs at the top of deliverKickLocked, before any
+// input reaches the pane: if a previous kick's output is sitting in the
+// scrollback (kickLogPending), archive it and clear the history so the new
+// kick starts a fresh, cleanly-delimited log. Callers must hold m.mu.
+func (m *Manager) rotateKickLogOnKickLocked(agent *AgentProcess) {
+	if !agent.kickLogPending {
+		return
+	}
+	if m.archiveKickLogLocked(agent, "kick") {
+		m.clearScrollbackForAgent(agent)
+	}
+	agent.kickLogPending = false
+}
+
+// ArchiveAllKickLogs snapshots every agent whose session holds un-archived
+// kick output. Wired to graceful shutdown (SIGTERM) so a pod roll or hive
+// image upgrade — which destroys every tmux server in the container — does
+// not take the in-flight kick's log with it.
+func (m *Manager) ArchiveAllKickLogs(reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, agent := range m.agents {
+		if !agent.kickLogPending {
+			continue
+		}
+		m.archiveKickLogLocked(agent, reason)
+		agent.kickLogPending = false
+	}
+}
+
+// pruneKickLogs enforces the retention policy on one agent's archive
+// directory: keep the newest kickLogRetention files, then drop the oldest
+// files until the directory total fits kickLogMaxBytes (the newest archive is
+// always kept, even if it alone exceeds the cap).
+func (m *Manager) pruneKickLogs(dir string) {
+	infos, err := readKickLogDir(dir)
+	if err != nil {
+		return
+	}
+	// readKickLogDir returns newest-first.
+	var total int64
+	for i, info := range infos {
+		total += info.SizeBytes
+		if i == 0 {
+			continue // never delete the newest archive
+		}
+		if i >= m.kickLogRetention || total > m.kickLogMaxBytes {
+			if err := os.Remove(filepath.Join(dir, info.ID)); err != nil {
+				m.logger.Warn("kick log prune failed", "file", info.ID, "error", err)
+			}
+		}
+	}
+}
+
+// readKickLogDir lists a directory's archives newest-first. A missing
+// directory is "no history yet", not an error — new code must not crash when
+// less history is available than normal (#4296).
+func readKickLogDir(dir string) ([]KickLogInfo, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []KickLogInfo{}, nil
+		}
+		return nil, err
+	}
+	infos := make([]KickLogInfo, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), kickLogSuffix) {
+			continue
+		}
+		fi, err := e.Info()
+		if err != nil {
+			continue
+		}
+		infos = append(infos, KickLogInfo{
+			ID:        e.Name(),
+			Timestamp: kickLogTimestamp(e.Name(), fi.ModTime()),
+			SizeBytes: fi.Size(),
+			Reason:    kickLogReason(e.Name()),
+		})
+	}
+	// Filename timestamps sort lexicographically == chronologically; sort by
+	// name descending for newest-first.
+	sort.Slice(infos, func(i, j int) bool { return infos[i].ID > infos[j].ID })
+	return infos, nil
+}
+
+// kickLogTimestamp parses the archive time from a filename, falling back to
+// the file mtime for names that do not match the format.
+func kickLogTimestamp(name string, fallback time.Time) time.Time {
+	if len(name) >= len(kickLogTimestampFormat) {
+		if ts, err := time.ParseInLocation(kickLogTimestampFormat, name[:len(kickLogTimestampFormat)], time.UTC); err == nil {
+			return ts
+		}
+	}
+	return fallback
+}
+
+// kickLogReason extracts the snapshot reason ("kick", "restart", "shutdown")
+// from a filename of the form <timestamp>-<reason>.log.
+func kickLogReason(name string) string {
+	base := strings.TrimSuffix(name, kickLogSuffix)
+	if len(base) > len(kickLogTimestampFormat)+1 {
+		return base[len(kickLogTimestampFormat)+1:]
+	}
+	return ""
+}
+
+// ListKickLogs returns the agent's archived kick logs, newest first. An agent
+// with no archives yet gets an empty list, never an error.
+func (m *Manager) ListKickLogs(name string) ([]KickLogInfo, error) {
+	m.mu.RLock()
+	_, ok := m.agents[name]
+	dir := m.agentKickLogDir(name)
+	m.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("agent %s not found", name)
+	}
+	return readKickLogDir(dir)
+}
+
+// ReadKickLog returns the content of one archived kick log by the ID that
+// ListKickLogs reported. The ID is validated as a bare archive filename so a
+// crafted value can never traverse out of the agent's archive directory.
+func (m *Manager) ReadKickLog(name, id string) (string, error) {
+	m.mu.RLock()
+	_, ok := m.agents[name]
+	dir := m.agentKickLogDir(name)
+	m.mu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("agent %s not found", name)
+	}
+	if !validKickLogID(id) {
+		return "", fmt.Errorf("invalid kick log id %q", id)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("kick log %s not found for agent %s", id, name)
+		}
+		return "", fmt.Errorf("reading kick log %s for %s: %w", id, name, err)
+	}
+	return string(data), nil
+}
+
+// validKickLogID accepts only names archiveKickLogLocked can produce: a bare
+// filename (no separators, no dot-dot) ending in the archive suffix with a
+// conservative character set.
+func validKickLogID(id string) bool {
+	if id == "" || !strings.HasSuffix(id, kickLogSuffix) || strings.TrimSuffix(id, kickLogSuffix) == "" {
+		return false
+	}
+	if id != filepath.Base(id) || strings.Contains(id, "..") {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/src/pkg/agent/kick_logs_test.go
+++ b/src/pkg/agent/kick_logs_test.go
@@ -1,0 +1,421 @@
+package agent
+
+// Tests for durable per-kick agent run logs (#4296, #4295): the archive
+// write, the retention pruning, the rotation-on-kick ordering (snapshot then
+// clear then input — never input first), the restart hook (snapshot happens
+// even when the relaunch itself fails), and the list/read accessors the
+// dashboard endpoints sit on.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// kickLogTestManager builds a Manager with one agent whose tmux capture and
+// clear-history are seamed, archiving into a fresh temp dir.
+func kickLogTestManager(t *testing.T, captured string) (*Manager, *AgentProcess, string) {
+	t.Helper()
+	dir := t.TempDir()
+	agent := &AgentProcess{
+		Name:        "scanner",
+		Config:      config.AgentConfig{Backend: "claude"},
+		State:       StateRunning,
+		tmuxSession: "hive-scanner-kicklog-test",
+	}
+	m := &Manager{
+		agents:           map[string]*AgentProcess{"scanner": agent},
+		idToName:         map[string]string{"scanner": "scanner"},
+		logger:           slog.Default(),
+		kickLogDir:       dir,
+		kickLogRetention: defaultKickLogRetention,
+		kickLogMaxBytes:  defaultKickLogMaxBytes,
+		captureFullLogFn: func(*AgentProcess) (string, error) { return captured, nil },
+		clearHistoryFn:   func(*AgentProcess) {},
+	}
+	return m, agent, dir
+}
+
+func TestKickLogSettingsFromEnv_Defaults(t *testing.T) {
+	t.Setenv(kickLogDirEnv, "")
+	t.Setenv(kickLogRetentionEnv, "")
+	t.Setenv(kickLogMaxBytesEnv, "")
+	dir, retention, maxBytes := kickLogSettingsFromEnv()
+	if dir != defaultKickLogDir {
+		t.Errorf("dir = %q, want %q", dir, defaultKickLogDir)
+	}
+	if retention != defaultKickLogRetention {
+		t.Errorf("retention = %d, want %d", retention, defaultKickLogRetention)
+	}
+	if maxBytes != defaultKickLogMaxBytes {
+		t.Errorf("maxBytes = %d, want %d", maxBytes, defaultKickLogMaxBytes)
+	}
+}
+
+func TestKickLogSettingsFromEnv_Overrides(t *testing.T) {
+	t.Setenv(kickLogDirEnv, "/elsewhere/kicks")
+	t.Setenv(kickLogRetentionEnv, "3")
+	t.Setenv(kickLogMaxBytesEnv, "1024")
+	dir, retention, maxBytes := kickLogSettingsFromEnv()
+	if dir != "/elsewhere/kicks" || retention != 3 || maxBytes != 1024 {
+		t.Errorf("got (%q, %d, %d), want (/elsewhere/kicks, 3, 1024)", dir, retention, maxBytes)
+	}
+}
+
+// Garbage or negative overrides must fall back to the defaults rather than
+// disable archiving by accident; an explicit "0" retention IS honored as off.
+func TestKickLogSettingsFromEnv_InvalidOverrides(t *testing.T) {
+	t.Setenv(kickLogRetentionEnv, "not-a-number")
+	t.Setenv(kickLogMaxBytesEnv, "-5")
+	_, retention, maxBytes := kickLogSettingsFromEnv()
+	if retention != defaultKickLogRetention || maxBytes != defaultKickLogMaxBytes {
+		t.Errorf("got (%d, %d), want defaults", retention, maxBytes)
+	}
+
+	t.Setenv(kickLogRetentionEnv, "0")
+	_, retention, _ = kickLogSettingsFromEnv()
+	if retention != 0 {
+		t.Errorf("retention = %d, want explicit 0 honored", retention)
+	}
+}
+
+func TestArchiveKickLogLocked_WritesHeaderAndContent(t *testing.T) {
+	m, agent, dir := kickLogTestManager(t, "run output line 1\nrun output line 2\n")
+	kickAt := time.Date(2026, 8, 20, 7, 0, 0, 0, time.UTC)
+	agent.LastKick = &kickAt
+	agent.LastKickMessage = "scan the repo\nand report"
+
+	if !m.archiveKickLogLocked(agent, "kick") {
+		t.Fatal("archiveKickLogLocked returned false, want an archive written")
+	}
+
+	infos, err := m.ListKickLogs("scanner")
+	if err != nil {
+		t.Fatalf("ListKickLogs: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("archives = %d, want 1", len(infos))
+	}
+	if infos[0].Reason != "kick" {
+		t.Errorf("reason = %q, want kick", infos[0].Reason)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "scanner", infos[0].ID))
+	if err != nil {
+		t.Fatalf("reading archive: %v", err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"agent: scanner",
+		"reason: kick",
+		"kick_started: 2026-08-20T07:00:00Z",
+		"kick_prompt: scan the repo and report", // newline flattened
+		"run output line 2",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("archive missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// Nothing worth archiving — an empty or whitespace-only capture — must not
+// burn a retention slot with an empty file.
+func TestArchiveKickLogLocked_SkipsEmptyCapture(t *testing.T) {
+	m, agent, _ := kickLogTestManager(t, "   \n\n  ")
+	if m.archiveKickLogLocked(agent, "kick") {
+		t.Fatal("archived an empty capture")
+	}
+	infos, _ := m.ListKickLogs("scanner")
+	if len(infos) != 0 {
+		t.Fatalf("archives = %d, want 0", len(infos))
+	}
+}
+
+// Retention 0 is "archiving off"; no directory should even be created.
+func TestArchiveKickLogLocked_RetentionZeroDisables(t *testing.T) {
+	m, agent, dir := kickLogTestManager(t, "content")
+	m.kickLogRetention = 0
+	if m.archiveKickLogLocked(agent, "kick") {
+		t.Fatal("archived with retention 0")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "scanner")); !os.IsNotExist(err) {
+		t.Errorf("agent archive dir exists, want none")
+	}
+}
+
+// A capture failure is logged and swallowed — the kick/restart it decorates
+// must proceed.
+func TestArchiveKickLogLocked_CaptureErrorIsNonFatal(t *testing.T) {
+	m, agent, _ := kickLogTestManager(t, "")
+	m.captureFullLogFn = func(*AgentProcess) (string, error) { return "", fmt.Errorf("boom") }
+	if m.archiveKickLogLocked(agent, "restart") {
+		t.Fatal("archived despite capture error")
+	}
+}
+
+func TestPruneKickLogs_KeepsNewestN(t *testing.T) {
+	m, agent, dir := kickLogTestManager(t, "x")
+	m.kickLogRetention = 3
+	// Write 6 archives with strictly increasing timestamps.
+	agentDir := filepath.Join(dir, "scanner")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 6; i++ {
+		name := fmt.Sprintf("20260820-07000%d.000-kick%s", i, kickLogSuffix)
+		if err := os.WriteFile(filepath.Join(agentDir, name), []byte("old"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// One more real archive triggers the prune. Its capture content makes 7.
+	if !m.archiveKickLogLocked(agent, "kick") {
+		t.Fatal("archive failed")
+	}
+	infos, err := m.ListKickLogs("scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 3 {
+		t.Fatalf("archives after prune = %d, want 3", len(infos))
+	}
+	// Newest-first: the just-written archive leads, then the two newest olds.
+	if infos[0].Reason != "kick" || !strings.HasPrefix(infos[1].ID, "20260820-070005") || !strings.HasPrefix(infos[2].ID, "20260820-070004") {
+		t.Errorf("unexpected survivors: %+v", infos)
+	}
+}
+
+// The size cap prunes oldest-first but must never delete the newest archive,
+// even when that archive alone exceeds the cap.
+func TestPruneKickLogs_SizeCapKeepsNewest(t *testing.T) {
+	m, agent, dir := kickLogTestManager(t, strings.Repeat("y", 4096))
+	m.kickLogMaxBytes = 1024
+	agentDir := filepath.Join(dir, "scanner")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := filepath.Join(agentDir, "20260820-070000.000-kick"+kickLogSuffix)
+	if err := os.WriteFile(old, []byte(strings.Repeat("z", 2048)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !m.archiveKickLogLocked(agent, "kick") {
+		t.Fatal("archive failed")
+	}
+	infos, _ := m.ListKickLogs("scanner")
+	if len(infos) != 1 {
+		t.Fatalf("archives = %d, want only the newest to survive the size cap", len(infos))
+	}
+	if !strings.HasPrefix(infos[0].ID, time.Now().UTC().Format("2006")) {
+		t.Errorf("survivor is not the newest archive: %+v", infos)
+	}
+}
+
+// The rotation invariant: on a kick with pending output, the capture and
+// clear-history run BEFORE any input is sent to the pane. If the capture ran
+// after the C-c/C-u clearing or after the kick text, the archived log would
+// be polluted or the scrollback already mutated.
+func TestDeliverKickLocked_ArchivesAndClearsBeforeInput(t *testing.T) {
+	m, agent, _ := kickLogTestManager(t, "previous kick output")
+	var events []string
+	m.captureFullLogFn = func(*AgentProcess) (string, error) {
+		events = append(events, "capture")
+		return "previous kick output", nil
+	}
+	m.clearHistoryFn = func(*AgentProcess) { events = append(events, "clear") }
+	m.sendKeysForAgent = func(_ *AgentProcess, keys ...string) {
+		events = append(events, "sendkeys:"+strings.Join(keys, "+"))
+	}
+	m.visiblePaneCapture = func(*AgentProcess) string { return "" }
+	agent.kickLogPending = true
+
+	m.deliverKickLocked(agent, "next task", "send-kick")
+
+	if len(events) < 3 || events[0] != "capture" || events[1] != "clear" {
+		t.Fatalf("events = %v, want capture then clear before any pane input", events)
+	}
+	for _, e := range events[2:] {
+		if e == "capture" || e == "clear" {
+			t.Fatalf("capture/clear repeated after input started: %v", events)
+		}
+	}
+	if !agent.kickLogPending {
+		t.Error("kickLogPending = false after delivery, want true (new kick output is now pending)")
+	}
+	infos, _ := m.ListKickLogs("scanner")
+	if len(infos) != 1 {
+		t.Fatalf("archives = %d, want 1", len(infos))
+	}
+}
+
+// The very first kick into a fresh session has no previous kick output;
+// rotation must not archive the boot banner or clear anything.
+func TestDeliverKickLocked_NoRotationWithoutPendingOutput(t *testing.T) {
+	m, agent, _ := kickLogTestManager(t, "boot banner")
+	captured := false
+	m.captureFullLogFn = func(*AgentProcess) (string, error) { captured = true; return "boot banner", nil }
+	m.sendKeysForAgent = func(*AgentProcess, ...string) {}
+	m.visiblePaneCapture = func(*AgentProcess) string { return "" }
+
+	m.deliverKickLocked(agent, "first task", "startup")
+
+	if captured {
+		t.Error("capture ran with no pending kick output")
+	}
+	if infos, _ := m.ListKickLogs("scanner"); len(infos) != 0 {
+		t.Errorf("archives = %d, want 0", len(infos))
+	}
+	if !agent.kickLogPending {
+		t.Error("kickLogPending = false after first kick, want true")
+	}
+}
+
+// Restart must snapshot the outgoing session's kick output before the session
+// is destroyed — and the snapshot must survive even when the relaunch itself
+// fails (no tmux in the environment): the archive is the whole point.
+func TestRestart_ArchivesPendingKickOutput(t *testing.T) {
+	m, agent, dir := kickLogTestManager(t, "output of the run being restarted")
+	m.sendKeysForAgent = func(*AgentProcess, ...string) {}
+	agent.kickLogPending = true
+	// Paused short-circuits Restart right after ensureTmuxSession, keeping the
+	// test away from token minting and a real CLI launch.
+	agent.Paused = true
+	m.workDir = t.TempDir()
+	t.Cleanup(func() { _ = testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run() })
+
+	_ = m.Restart(context.Background(), "scanner") // relaunch outcome irrelevant here
+
+	if agent.kickLogPending {
+		t.Error("kickLogPending still true after restart")
+	}
+	infos, err := m.ListKickLogs("scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 1 || infos[0].Reason != "restart" {
+		t.Fatalf("archives = %+v, want one with reason restart", infos)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "scanner", infos[0].ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "output of the run being restarted") {
+		t.Error("archive missing the pre-restart scrollback")
+	}
+}
+
+// Graceful shutdown archives every agent with pending kick output, so a pod
+// roll or hive upgrade cannot destroy the latest run's log (#4296).
+func TestArchiveAllKickLogs(t *testing.T) {
+	m, agent, _ := kickLogTestManager(t, "in-flight output")
+	quiet := &AgentProcess{Name: "quiet", tmuxSession: "hive-quiet", Config: config.AgentConfig{}}
+	m.agents["quiet"] = quiet
+	agent.kickLogPending = true // scanner has un-archived output; quiet does not
+
+	m.ArchiveAllKickLogs("shutdown")
+
+	if agent.kickLogPending {
+		t.Error("scanner still pending after shutdown archive")
+	}
+	infos, _ := m.ListKickLogs("scanner")
+	if len(infos) != 1 || infos[0].Reason != "shutdown" {
+		t.Fatalf("scanner archives = %+v, want one with reason shutdown", infos)
+	}
+	if quietInfos, _ := m.ListKickLogs("quiet"); len(quietInfos) != 0 {
+		t.Errorf("quiet archives = %d, want 0 (nothing pending)", len(quietInfos))
+	}
+}
+
+func TestListKickLogs_UnknownAgent(t *testing.T) {
+	m, _, _ := kickLogTestManager(t, "x")
+	if _, err := m.ListKickLogs("nope"); err == nil {
+		t.Fatal("want error for unknown agent")
+	}
+}
+
+// No archive directory yet is "no history", not an error — new code must not
+// crash when less history is available than normal (#4296).
+func TestListKickLogs_NoHistoryYet(t *testing.T) {
+	m, _, _ := kickLogTestManager(t, "x")
+	infos, err := m.ListKickLogs("scanner")
+	if err != nil {
+		t.Fatalf("ListKickLogs: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("archives = %d, want 0", len(infos))
+	}
+}
+
+func TestReadKickLog_RejectsTraversalAndBadIDs(t *testing.T) {
+	m, agent, _ := kickLogTestManager(t, "content")
+	agent.kickLogPending = true
+	m.rotateKickLogOnKickLocked(agent)
+
+	for _, id := range []string{
+		"",
+		"../../etc/passwd",
+		"../other/20260820-070000.000-kick.log",
+		"sub/20260820-070000.000-kick.log",
+		"20260820-070000.000-kick.txt",
+		"a b.log",
+		"..\\evil.log",
+	} {
+		if _, err := m.ReadKickLog("scanner", id); err == nil {
+			t.Errorf("ReadKickLog accepted invalid id %q", id)
+		}
+	}
+	if _, err := m.ReadKickLog("scanner", "20990101-000000.000-kick.log"); err == nil {
+		t.Error("ReadKickLog found a nonexistent archive")
+	}
+}
+
+func TestReadKickLog_RoundTrip(t *testing.T) {
+	m, agent, _ := kickLogTestManager(t, "the run output")
+	agent.kickLogPending = true
+	m.rotateKickLogOnKickLocked(agent)
+
+	infos, err := m.ListKickLogs("scanner")
+	if err != nil || len(infos) != 1 {
+		t.Fatalf("infos = %v, err = %v", infos, err)
+	}
+	body, err := m.ReadKickLog("scanner", infos[0].ID)
+	if err != nil {
+		t.Fatalf("ReadKickLog: %v", err)
+	}
+	if !strings.Contains(body, "the run output") || !strings.Contains(body, "==== hive kick log ====") {
+		t.Errorf("unexpected archive body:\n%s", body)
+	}
+}
+
+func TestValidKickLogID(t *testing.T) {
+	valid := []string{"20260820-070000.000-kick.log", "a-b_c.log", "X1.log"}
+	invalid := []string{"", ".log", "..", "a/b.log", "a\\b.log", "a..b.log", "a b.log", "a.txt", "é.log"}
+	for _, id := range valid {
+		if !validKickLogID(id) {
+			t.Errorf("validKickLogID(%q) = false, want true", id)
+		}
+	}
+	for _, id := range invalid {
+		if validKickLogID(id) {
+			t.Errorf("validKickLogID(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestSanitizeKickLogComponent(t *testing.T) {
+	cases := map[string]string{
+		"scanner":    "scanner",
+		"weird/../x": "weird----x",
+		"":           "agent",
+		"a b":        "a-b",
+	}
+	for in, want := range cases {
+		if got := sanitizeKickLogComponent(in); got != want {
+			t.Errorf("sanitizeKickLogComponent(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -187,8 +187,13 @@ type AgentProcess struct {
 	StallNudges        int       // total post-kick stall nudges sent (surfaced to the dashboard)
 	launchGen          int       // increments per launch; stale deliverStartupKick goroutines check it and drop
 	lastInferKickMarks int       // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
-	actionNudgeSent    bool      // no-action watchdog: at most one action nudge per kick
-	ActionNudges       int       // total prose-only-response action nudges sent (surfaced to the dashboard)
+	// kickLogPending is true while the current tmux session holds kick output
+	// that has not yet been archived to a per-kick log file (see
+	// kick_logs.go). Set after every kick delivery; cleared when the
+	// scrollback is archived (next kick, restart, shutdown). Guarded by m.mu.
+	kickLogPending  bool
+	actionNudgeSent bool // no-action watchdog: at most one action nudge per kick
+	ActionNudges    int  // total prose-only-response action nudges sent (surfaced to the dashboard)
 	// sandboxResumeAfterCancel is set when an operator resumes a paused
 	// sandbox agent while the canceled sandbox goroutine is still draining.
 	// The completion handler then turns the expected cancellation into Idle
@@ -356,6 +361,16 @@ type Manager struct {
 	sendKeysForAgent     func(agent *AgentProcess, keys ...string)
 	promptDismissSleep   func(time.Duration)
 	promptDismissTimeout time.Duration
+
+	// Per-kick durable log archiving (#4296, #4295) — see kick_logs.go.
+	// kickLogDir/kickLogRetention/kickLogMaxBytes are resolved once in
+	// NewManager from env overrides; captureFullLogFn and clearHistoryFn are
+	// test seams over the tmux capture-pane / clear-history subprocesses.
+	kickLogDir       string
+	kickLogRetention int
+	kickLogMaxBytes  int64
+	captureFullLogFn func(agent *AgentProcess) (string, error)
+	clearHistoryFn   func(agent *AgentProcess)
 }
 
 // SetPersistPauseCallback wires a function that persists an agent's paused
@@ -884,6 +899,8 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 		logger.Info("no UID map found, agents will share dev UID", "path", UIDMapPath)
 	}
 
+	kickLogDir, kickLogRetention, kickLogMaxBytes := kickLogSettingsFromEnv()
+
 	m := &Manager{
 		agents:           make(map[string]*AgentProcess),
 		idToName:         make(map[string]string),
@@ -893,6 +910,9 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 		copilotAuthToken: copilotToken,
 		claudeAuthToken:  claudeToken,
 		uidMap:           uidMap,
+		kickLogDir:       kickLogDir,
+		kickLogRetention: kickLogRetention,
+		kickLogMaxBytes:  kickLogMaxBytes,
 	}
 
 	for name, cfg := range agents {
@@ -1874,6 +1894,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		now := time.Now()
 		agent.LastKick = &now
 		agent.LastKickMessage = bootstrapPrompt
+		agent.kickLogPending = true
 		snippet := bootstrapPrompt
 		const maxBootstrapSnippet = 200
 		snippet = truncateStr(snippet, maxBootstrapSnippet)
@@ -3167,16 +3188,7 @@ func (m *Manager) CaptureFullLog(name string) (string, error) {
 	if agent.tmuxSession == "" {
 		return "", fmt.Errorf("agent %s has no active session", name)
 	}
-	// -S -<n>: start n lines back into history; -E -: through the last visible
-	// line; -J: join wrapped lines so copied text is not hard-wrapped at the
-	// pane width; -p: print to stdout. -1: keep the tail behaviour bounded.
-	cmd := m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p", "-J",
-		"-S", fmt.Sprintf("-%d", fullLogCaptureLines), "-E", "-")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("capturing pane for %s: %w", name, err)
-	}
-	return string(out), nil
+	return m.captureScrollbackForAgent(agent)
 }
 
 // captureVisiblePaneForAgent captures only the visible pane (no scrollback).
@@ -3736,6 +3748,11 @@ func (m *Manager) SendKick(name string, message string) error {
 // (crash detect + waitForCLIReadyForAgent + waitForInputPromptForAgent) —
 // this function does no readiness checking of its own.
 func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string) {
+	// Archive the PREVIOUS kick's scrollback and clear the history before any
+	// input touches the pane, so each archived kick log is cleanly delimited
+	// (#4296). Must be the first thing this function does.
+	m.rotateKickLogOnKickLocked(agent)
+
 	// Clear stale input before kick (Ctrl+C then Ctrl+U).
 	// Goose 1.37 exits on ^C — skip clear for goose backend.
 	if agent.Config.Backend != "goose" && agent.BackendOverride != "goose" {
@@ -3787,6 +3804,9 @@ func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string
 	agent.LastKickMessage = message
 	agent.KickRefused = false
 	agent.KickRefusalReason = ""
+	// The session now holds this kick's output; the next rotation point
+	// (kick, restart, shutdown) must archive it before it is destroyed.
+	agent.kickLogPending = true
 
 	// Arm the post-kick watchdog for inference agents: the watcher loop
 	// sends a "continue" nudge if the pane freezes at an idle prompt, and
@@ -7045,6 +7065,13 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 		}
 	}
 
+	// Archive the outgoing session's kick output before the session is killed
+	// below — kill-session destroys the scrollback (#4295/#4296).
+	if agent.kickLogPending {
+		m.archiveKickLogLocked(agent, "restart")
+		agent.kickLogPending = false
+	}
+
 	// Terminate the agent's CLI process(es) before recreating the session.
 	// reapAgentCLI matches by the HIVE_AGENT env marker, so it works whether or
 	// not UID isolation is enabled. killAgentProcesses (UID-based) is only safe
@@ -7328,6 +7355,14 @@ func (m *Manager) Restart(ctx context.Context, name string) error {
 		if agent.cancel != nil {
 			agent.cancel()
 		}
+	}
+
+	// Archive the outgoing session's kick output BEFORE anything below kills
+	// the CLI or the session — kill-session destroys the scrollback and with
+	// it the only record of the previous run (#4295/#4296).
+	if agent.kickLogPending {
+		m.archiveKickLogLocked(agent, "restart")
+		agent.kickLogPending = false
 	}
 
 	// Terminate the agent's CLI process(es) before recreating the session.

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -68,6 +68,11 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	// Full retained scrollback of an agent's latest run, as plain text (#3693).
 	// Backs the Terminal's "view / download full log" controls.
 	s.mux.HandleFunc("GET /api/agents/{name}/log", s.handleAgentFullLog)
+	// Durable per-kick run-log history (#4296, #4295): list archived kick
+	// logs, fetch one, and a minimal HTML index page linked from agent cards.
+	s.mux.HandleFunc("GET /api/agents/{name}/kicks", s.handleAgentKickLogList)
+	s.mux.HandleFunc("GET /api/agents/{name}/kicks/{id}", s.handleAgentKickLog)
+	s.mux.HandleFunc("GET /agents/{name}/kicks", s.handleAgentKickHistoryPage)
 
 	s.mux.HandleFunc("GET /api/role", s.handleRole)
 

--- a/src/pkg/dashboard/kick_logs.go
+++ b/src/pkg/dashboard/kick_logs.go
@@ -1,0 +1,117 @@
+package dashboard
+
+// Kick-history endpoints (#4296, #4295): durable per-kick agent run logs.
+//
+// The existing /api/agents/{name}/log endpoint serves the LIVE tmux
+// scrollback of the agent's current session only — a restart or a hive
+// upgrade destroys every previous run's log. pkg/agent archives each kick's
+// scrollback to a durable file under /data (see agent/kick_logs.go); these
+// handlers list and serve those archives so an operator can read the log of
+// a run several kicks ago.
+//
+// All three are read-only GETs, so any authenticated role may call them —
+// the same rule as handleAgentFullLog and the /terminal proxy.
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"time"
+)
+
+// handleAgentKickLogList serves GET /api/agents/{name}/kicks: a JSON array of
+// the agent's archived kick logs, newest first. An agent with no history yet
+// gets an empty array — never an error (#4296's "less history than normal"
+// compatibility requirement).
+func (s *Server) handleAgentKickLogList(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		http.Error(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	name := s.resolveAgentParam(r.PathValue("name"))
+	infos, err := s.deps.AgentMgr.ListKickLogs(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(infos)
+}
+
+// handleAgentKickLog serves GET /api/agents/{name}/kicks/{id}: one archived
+// kick log as plain, selectable, searchable text. ?download=1 sets a
+// Content-Disposition attachment, mirroring handleAgentFullLog.
+func (s *Server) handleAgentKickLog(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		http.Error(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	name := s.resolveAgentParam(r.PathValue("name"))
+	id := r.PathValue("id")
+	log, err := s.deps.AgentMgr.ReadKickLog(name, id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// SECURITY: archives hold raw pane content; like every other pane surface,
+	// tokens and device-auth codes are stripped before the bytes leave the
+	// server (see redactTokens).
+	log = redactTokens(log)
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if r.URL.Query().Get("download") != "" {
+		fname := fmt.Sprintf("hive-%s-%s", sanitizeLogFilename(name), sanitizeLogFilename(id)+".log")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fname))
+	}
+	_, _ = w.Write([]byte(log))
+}
+
+// handleAgentKickHistoryPage serves GET /agents/{name}/kicks: a minimal HTML
+// index of the agent's run-log history — the live log of the current run
+// first, then every archived kick, newest first, each with view and download
+// links. It follows the dashboard's open-in-a-new-tab pattern for logs
+// rather than embedding a viewer.
+func (s *Server) handleAgentKickHistoryPage(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		http.Error(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	name := s.resolveAgentParam(r.PathValue("name"))
+	infos, err := s.deps.AgentMgr.ListKickLogs(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	esc := html.EscapeString(name)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+
+	fmt.Fprintf(w, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>%s — kick log history</title>
+<style>
+body{font-family:ui-monospace,monospace;background:#0d1117;color:#c9d1d9;margin:2rem}
+h1{font-size:1.1rem}a{color:#58a6ff;text-decoration:none}a:hover{text-decoration:underline}
+table{border-collapse:collapse;margin-top:1rem}td,th{padding:.3rem .9rem;text-align:left;border-bottom:1px solid #21262d}
+.muted{color:#8b949e}
+</style></head><body><h1>🕘 %s — kick log history</h1>
+<p><a href="/api/agents/%s/log" target="_blank">📄 live log (current run)</a> <span class="muted">— the running session's scrollback; archived here when the next kick or a restart rotates it out</span></p>
+`, esc, esc, esc)
+
+	if len(infos) == 0 {
+		fmt.Fprint(w, `<p class="muted">No archived kick logs yet. Archives appear after the agent's next kick, restart, or a hive shutdown.</p>`)
+	} else {
+		fmt.Fprint(w, `<table><tr><th>archived (UTC)</th><th>trigger</th><th>size</th><th></th></tr>`)
+		for _, info := range infos {
+			id := html.EscapeString(info.ID)
+			fmt.Fprintf(w,
+				`<tr><td>%s</td><td>%s</td><td>%d B</td><td><a href="/api/agents/%s/kicks/%s" target="_blank">view</a> · <a href="/api/agents/%s/kicks/%s?download=1">download</a></td></tr>`,
+				info.Timestamp.UTC().Format(time.RFC3339), html.EscapeString(info.Reason), info.SizeBytes, esc, id, esc, id)
+		}
+		fmt.Fprint(w, `</table>`)
+	}
+	fmt.Fprint(w, `</body></html>`)
+}

--- a/src/pkg/dashboard/kick_logs_test.go
+++ b/src/pkg/dashboard/kick_logs_test.go
@@ -1,0 +1,179 @@
+package dashboard
+
+// Tests for the kick-history endpoints (#4296, #4295): list archived kick
+// logs, fetch one (with redaction and download support), and the HTML index
+// page — plus the no-manager and unknown-agent failure contracts, mirroring
+// terminal_log_test.go.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/agent"
+)
+
+// kickHistoryServer wires apiServer's manager at a temp archive dir and
+// plants one archived kick log for the "scanner" agent.
+func kickHistoryServer(t *testing.T, content string) (*Server, string) {
+	t.Helper()
+	s, deps := apiServer(t)
+	dir := t.TempDir()
+	deps.AgentMgr.SetKickLogDir(dir)
+	id := "20260820-070000.000-kick.log"
+	agentDir := filepath.Join(dir, "scanner")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, id), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return s, id
+}
+
+func TestHandleAgentKickLogList_UnknownAgent(t *testing.T) {
+	s, _ := apiServer(t)
+	rec := doGet(s, "/api/agents/nonexistent/kicks")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+// A known agent with no archive directory yet gets an empty JSON array, never
+// an error — the "less history than normal" requirement from #4296.
+func TestHandleAgentKickLogList_NoHistoryYet(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.AgentMgr.SetKickLogDir(t.TempDir())
+	rec := doGet(s, "/api/agents/scanner/kicks")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var infos []agent.KickLogInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &infos); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, rec.Body.String())
+	}
+	if len(infos) != 0 {
+		t.Fatalf("archives = %d, want 0", len(infos))
+	}
+}
+
+func TestHandleAgentKickLogList_ReturnsArchives(t *testing.T) {
+	s, id := kickHistoryServer(t, "old run output")
+	rec := doGet(s, "/api/agents/scanner/kicks")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var infos []agent.KickLogInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &infos); err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 1 || infos[0].ID != id || infos[0].Reason != "kick" {
+		t.Fatalf("infos = %+v, want the planted archive", infos)
+	}
+}
+
+func TestHandleAgentKickLog_ServesContent(t *testing.T) {
+	s, id := kickHistoryServer(t, "old run output")
+	rec := doGet(s, "/api/agents/scanner/kicks/"+id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "old run output") {
+		t.Errorf("body missing archive content: %s", rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+}
+
+// Archived pane content is redacted exactly like the live full log — an
+// archive must never become a token-exfiltration bypass.
+func TestHandleAgentKickLog_RedactsTokens(t *testing.T) {
+	secret := "ghp_" + strings.Repeat("a", 36)
+	s, id := kickHistoryServer(t, "token: "+secret+"\n")
+	rec := doGet(s, "/api/agents/scanner/kicks/"+id)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Error("archived token served unredacted")
+	}
+}
+
+func TestHandleAgentKickLog_Download(t *testing.T) {
+	s, id := kickHistoryServer(t, "content")
+	rec := doGet(s, "/api/agents/scanner/kicks/"+id+"?download=1")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	cd := rec.Header().Get("Content-Disposition")
+	if !strings.HasPrefix(cd, "attachment;") || !strings.Contains(cd, "scanner") {
+		t.Errorf("Content-Disposition = %q", cd)
+	}
+}
+
+func TestHandleAgentKickLog_NotFoundAndTraversal(t *testing.T) {
+	s, _ := kickHistoryServer(t, "content")
+	for _, id := range []string{"20990101-000000.000-kick.log", "..%2F..%2Fetc%2Fpasswd", "evil.txt"} {
+		rec := doGet(s, "/api/agents/scanner/kicks/"+id)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("id %q: status = %d, want 404", id, rec.Code)
+		}
+	}
+}
+
+func TestHandleAgentKickLog_NoManager(t *testing.T) {
+	s, _ := apiServer(t)
+	s.deps.AgentMgr = nil
+	for _, path := range []string{
+		"/api/agents/scanner/kicks",
+		"/api/agents/scanner/kicks/x.log",
+		"/agents/scanner/kicks",
+	} {
+		rec := doGet(s, path)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("%s: status = %d, want 503", path, rec.Code)
+		}
+	}
+}
+
+func TestHandleAgentKickHistoryPage(t *testing.T) {
+	s, id := kickHistoryServer(t, "content")
+	rec := doGet(s, "/agents/scanner/kicks")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"kick log history",
+		"/api/agents/scanner/log",         // live-log link first
+		"/api/agents/scanner/kicks/" + id, // archived kick link
+		"download",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestHandleAgentKickHistoryPage_EmptyHistory(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.AgentMgr.SetKickLogDir(t.TempDir())
+	rec := doGet(s, "/agents/scanner/kicks")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "No archived kick logs yet") {
+		t.Errorf("empty-history page missing placeholder:\n%s", rec.Body.String())
+	}
+	rec = doGet(s, "/agents/nonexistent/kicks")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown agent: status = %d, want 404", rec.Code)
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4333,6 +4333,7 @@
           <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>
           <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>
           <a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>
+          <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Browse archived logs of this agent's previous kicks — history survives restarts and hive upgrades">🕘 past kicks</a>
           <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill this agent's tmux session — supervisor will respawn it with fresh context">↻ restart</button>
           <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" style="font-size:1rem;opacity:0.7" title="Open configuration dialog for this agent (cadences, model, pipeline, hooks, etc.)">⚙️</button>
           <button class="btn" data-action="kickEmpty" data-agent="${esc(a.name)}" style="margin-left:auto" title="Kick this agent now with its default prompt, bypassing the governor cadence timer">kick</button>
@@ -5849,6 +5850,18 @@
       return `${proto}//${host}/api/agents/${encodeURIComponent(agentName)}/log${qs ? '?' + qs : ''}`;
     }
 
+    // kickHistoryUrl points at the server-rendered index of the agent's
+    // durable per-kick log archives (issue #4296): the last several kicks'
+    // logs, surviving agent restarts and hive upgrades. The token param
+    // mirrors fullLogUrl so it authenticates on direct-route spokes.
+    function kickHistoryUrl(agentName) {
+      const proto = window.location.protocol;
+      const host = window.location.host;
+      const t = localStorage.getItem('hive-token');
+      const tok = t ? `?token=${encodeURIComponent(t)}` : '';
+      return `${proto}//${host}/agents/${encodeURIComponent(agentName)}/kicks${tok}`;
+    }
+
     /* SINGLE source of truth for the 🔑 "needs login" badge. Mirrors the
        server-side precedence rule in pkg/agent/authprobe.go:
 
@@ -5937,7 +5950,7 @@
         const configTarget = a.replicaBase || a.name;
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Archived logs of previous kicks — survives restarts and upgrades">🕘 past kicks</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';


### PR DESCRIPTION
## Use case (#4296, from @MikeSpreitzer)

> I want to understand why an agent misbehaved the last time that it did not run out of dollar budget in the LiteLLM gateway. That was not the most recent kick. That was not the previous kick. I suspect that it was two kicks ago. But right now I can only see the log from the latest kick. [...] I want logs organized by kicks. I want access to logs from the last several kicks. [...] Upgrades to new versions of hive should not defeat log access.

Root cause (investigated in #4295): the dashboard's run log is a live `capture-pane` of the agent's **current** tmux session, and both a restart and every hive upgrade destroy the previous run's scrollback — run logs had effectively zero retention.

## Design

**Archive the scrollback before anything destroys it**, into durable per-kick files:

- **On kick delivery** (`deliverKickLocked`, first thing, before any input touches the pane): the previous kick's output is snapshotted to a file and the tmux history is then cleared — so each archive covers **exactly one kick**, fixing the "multiple kicks blur together in one buffer" limitation `CaptureFullLog` documented.
- **On restart** (`Restart` and the bootstrap-override restart path): the snapshot runs **before** `kill-session`.
- **On graceful shutdown** (SIGTERM — pod roll / hive upgrade): `ArchiveAllKickLogs` snapshots every agent with un-archived kick output, so the in-flight run's log survives the upgrade too.

**Storage**: `/data/logs/kicks/<agent>/<timestamp>-<reason>.log` (`reason` is `kick`, `restart`, or `shutdown`), beside the other durable log roots on the `/data` PVC — survives agent restarts, pod rolls, and hive image upgrades. Each file carries a small header (agent, archive time, reason, kick start time, prompt snippet). Files are owner-only (0600/0700) since raw pane content is only redacted at serve time.

**Retention** (named constants, env-overridable — no magic numbers):
- keep the newest **10** archives per agent (`HIVE_KICK_LOG_RETENTION`; `0` disables archiving),
- within a **64 MiB** per-agent size cap (`HIVE_KICK_LOG_MAX_BYTES`), pruning oldest first and never deleting the newest archive,
- root overridable via `HIVE_KICK_LOG_DIR`.
- Less history than normal (fresh install, lowered retention) lists fewer entries — **never an error** (#4296's compatibility requirement).

**Dashboard**:
- `GET /api/agents/{name}/kicks` — JSON list of archives, newest first.
- `GET /api/agents/{name}/kicks/{id}` — one archive as `text/plain` (`?download=1` for attachment), passed through the same token redaction as the live full log.
- `GET /agents/{name}/kicks` — a minimal HTML index (live log first, then archived kicks with view/download links), linked from a new `🕘 past kicks` control on both agent-card templates. All read-only GETs behind the existing global auth middleware, same rule as `/api/agents/{name}/log`.

Sandbox-executor kicks have no tmux session and are out of scope; documented in `docs/agent-logging.md` along with the new "Per-kick log history" section.

## Tests

- capture-then-clear-then-input ordering on kick delivery; no rotation on a fresh session's first kick
- snapshot-on-restart lands (with reason `restart`) even when the relaunch itself fails
- shutdown archives only agents with pending output
- retention pruning by count and by size cap (newest always kept)
- archive header/content round-trip, empty-capture skip, capture-error tolerance, retention-0 disable
- env-override parsing incl. invalid values
- kick-log ID validation (path traversal, separators, bad suffix)
- dashboard endpoints: list/fetch/download/redaction/404s/503-without-manager/HTML page (populated and empty history)

`go build ./... && go vet ./...` clean; `go test ./pkg/agent/ ./pkg/dashboard/ ./cmd/hive/ -count=1` green.

Fixes #4296
Fixes #4295
