### PR TITLE
🐛 fix(dashboard): live allowlist role in handlers still reading the frozen session role (v2 port)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -451,8 +451,15 @@ func (s *Server) handleRole(w http.ResponseWriter, r *http.Request) {
 	role := r.Header.Get("X-Hive-Role")
 	user := r.Header.Get("X-Hive-User")
 	if sess := s.sessionFromRequest(r); sess != nil {
-		user = sess.Username
-		role = sess.Role
+		// Live allowlist role, never the role frozen into the session at login
+		// (session_live_role.go): this endpoint drives what the UI believes the
+		// user may do, so a Manage Access grant/downgrade must show up here the
+		// moment the heartbeat delivers it — the same rule authenticate applies
+		// to every gated request. A revoked session reports no identity.
+		if live, ok := s.liveSessionRole(sess); ok {
+			user = sess.Username
+			role = live
+		}
 	}
 	if role == "" {
 		role = "owner"
@@ -1659,9 +1666,15 @@ func (s *Server) handleGHUserAuthStatus(w http.ResponseWriter, r *http.Request) 
 	// persisted token. On a direct-route spoke, resolving from the per-user
 	// session is the only correct answer — otherwise every visitor would see
 	// the last-authenticated user's identity (the reported vulnerability).
+	// The role is the LIVE allowlist role (session_live_role.go), not the one
+	// frozen into the session at login, so the UI's idea of the user's
+	// capabilities always matches what the gated endpoints will enforce; a
+	// revoked session reports logged-out rather than a ghost identity.
 	if sess := s.sessionFromRequest(r); sess != nil {
-		jsonResponse(w, map[string]interface{}{"logged_in": true, "username": sess.Username, "role": sess.Role})
-		return
+		if live, ok := s.liveSessionRole(sess); ok {
+			jsonResponse(w, map[string]interface{}{"logged_in": true, "username": sess.Username, "role": live})
+			return
+		}
 	}
 	// Hub-proxied path: nginx injects the per-user X-Hive-User/X-Hive-Role, so
 	// report THAT user rather than the single shared persisted token (which
@@ -5967,7 +5980,12 @@ func (s *Server) persistGitHubSetupInstallation(r *http.Request, installationID 
 
 func (s *Server) requestHasGitHubSetupAdmin(r *http.Request) bool {
 	if sess := s.sessionFromRequest(r); sess != nil {
-		return config.RoleAtLeast(sess.Role, config.RoleReadWrite)
+		// Authz decision: use the LIVE allowlist role (session_live_role.go),
+		// never the role frozen into the session at login — a downgrade or
+		// revocation must strip GitHub-setup admin immediately, and a granted
+		// owner must gain it without re-login (same class as #4299).
+		live, ok := s.liveSessionRole(sess)
+		return ok && config.RoleAtLeast(live, config.RoleReadWrite)
 	}
 	role := r.Header.Get("X-Hive-Role")
 	if !config.RoleAtLeast(role, config.RoleReadWrite) {

--- a/v2/pkg/dashboard/live_role_residual_4299_test.go
+++ b/v2/pkg/dashboard/live_role_residual_4299_test.go
@@ -1,0 +1,115 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Follow-up regression tests for #4299: after the middleware fix (#4302),
+// four handlers still re-read the RAW session and preferred the role frozen
+// at login over the live allowlist — handleRole and handleGHUserAuthStatus
+// (what the UI believes the user may do), requestHasGitHubSetupAdmin (a real
+// authz decision), and handleBannerDismissed. Daniel's second symptom
+// ("Failed to save advisory: owner access required" while the hive CREATOR
+// passed) is the same class: the creator's session was minted as owner, the
+// grantee's session predates the grant. These tests pin the advisory endpoint
+// and the residual handlers to the live allowlist.
+
+func do4299(s *Server, method, target, body, sid string) *httptest.ResponseRecorder {
+	var rdr *strings.Reader
+	if body == "" {
+		rdr = strings.NewReader("")
+	} else {
+		rdr = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, target, rdr)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+// handleRole drives the UI's idea of the user's capabilities; it must report
+// the live allowlist role, not the one frozen into the session.
+func TestRoleEndpoint4299_ReportsLiveRole(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:read-write")
+	sid := s.createUserSession("dwaddington", "read-write")
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:owner"}
+
+	w := do4299(s, http.MethodGet, "/api/role", "", sid)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/api/role = %d; body=%q", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["role"] != "owner" {
+		t.Fatalf("role = %q, want owner (live grant, not frozen session role)", resp["role"])
+	}
+}
+
+// handleGHUserAuthStatus must report the live role, and a revoked session must
+// read logged-out instead of a ghost identity.
+func TestGHUserAuthStatus4299_LiveRoleAndRevocation(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:read")
+	sid := s.createUserSession("dwaddington", "read")
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:owner"}
+
+	w := do4299(s, http.MethodGet, "/api/gh-user-auth/status", "", sid)
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("status %d, body %q: %v", w.Code, w.Body.String(), err)
+	}
+	if resp["role"] != "owner" {
+		t.Fatalf("auth-status role = %v, want owner", resp["role"])
+	}
+
+	// Revoke: the same session must no longer present an identity.
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner"}
+	w = do4299(s, http.MethodGet, "/api/gh-user-auth/status", "", sid)
+	// The authenticate middleware already rejects the revoked session with 401
+	// before the handler runs; either that or a logged_in=false body is
+	// acceptable — what must NOT happen is logged_in=true.
+	if w.Code == http.StatusOK {
+		var revoked map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &revoked); err != nil {
+			t.Fatal(err)
+		}
+		if loggedIn, _ := revoked["logged_in"].(bool); loggedIn {
+			t.Fatalf("revoked session still reports logged_in=true: %q", w.Body.String())
+		}
+	} else if w.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked auth-status = %d, want 200 logged_out or 401; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// requestHasGitHubSetupAdmin is a real authz decision: a live downgrade to
+// read must strip it, and a live grant must confer it, on a stale session.
+func TestGitHubSetupAdmin4299_FollowsLiveRole(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson:owner", "dwaddington:read")
+	sid := s.createUserSession("dwaddington", "read")
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:owner"}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	if !s.requestHasGitHubSetupAdmin(req) {
+		t.Fatal("live owner grant must confer GitHub-setup admin on a stale read session")
+	}
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner", "dwaddington:read"}
+	if s.requestHasGitHubSetupAdmin(req) {
+		t.Fatal("live downgrade to read must strip GitHub-setup admin despite an owner-minted session")
+	}
+
+	s.deps.Config.Dashboard.AuthorizedUsers = []string{"clubanderson:owner"}
+	if s.requestHasGitHubSetupAdmin(req) {
+		t.Fatal("revoked user must not keep GitHub-setup admin from a stale session")
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -1317,10 +1317,14 @@ func (s *Server) handleBannerDismissed(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve the acting user: a direct-route spoke has a per-user session
 	// cookie; a hub-proxied spoke gets identity injected as X-Hive-User /
-	// X-Hive-Role by nginx. Either establishes an authenticated user.
+	// X-Hive-Role by nginx. Either establishes an authenticated user. The role
+	// is the LIVE allowlist role (session_live_role.go): a revoked session
+	// must not keep dismissing banners under its stale identity.
 	username, role := "", ""
 	if sess := s.sessionFromRequest(r); sess != nil {
-		username, role = sess.Username, sess.Role
+		if live, ok := s.liveSessionRole(sess); ok {
+			username, role = sess.Username, live
+		}
 	} else if hubUser := r.Header.Get("X-Hive-User"); hubUser != "" {
 		username, role = hubUser, r.Header.Get("X-Hive-Role")
 	}


### PR DESCRIPTION
v2 port of #4309 (follow-up to #4302/#4303, issue #4299). Same four handlers on v2 read the frozen sess.Role, sidestepping the authenticate fix: handleRole, handleGHUserAuthStatus, requestHasGitHubSetupAdmin (a real authz decision), handleBannerDismissed. All now resolve through liveSessionRole; revoked sessions present no identity. Same regression tests minus the advisory-endpoint test (the Advisory settings tab does not exist on v2). Full go build/vet/test ./pkg/dashboard/ green.

Ref #4299
