### PR TITLE
🐛 fix(dashboard): budget window reset crashed on undefined renderAll and mislabeled success as failure

### DIFF
--- a/src/pkg/dashboard/budget_reset_ui_test.go
+++ b/src/pkg/dashboard/budget_reset_ui_test.go
@@ -1,0 +1,41 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression guard for the budget "reset window now" button: the success path
+// once called an undefined renderAll(), so Safari threw "Can't find variable:
+// renderAll" inside the surrounding try/catch and the operator saw BOTH a
+// success toast and a "Failed to reset budget window" error toast for a reset
+// that had actually succeeded server-side (v4 build 9f31439).
+func TestBudgetResetHandlerHasNoStaleCallees(t *testing.T) {
+	b, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	html := string(b)
+
+	// Stale callees: functions that were never defined in any inline script
+	// block. Calling them throws ReferenceError at click time, which nearby
+	// catch blocks then mislabel as an action failure.
+	for _, stale := range []string{"renderAll(", "hiveToast("} {
+		if strings.Contains(html, stale) {
+			t.Errorf("index.html calls %q, which is never defined — use refreshStatus()/showToast() instead", stale)
+		}
+	}
+
+	// The reset handler must refresh the budget bar/banners in place after a
+	// successful reset (no page reload), and the refresh must not be able to
+	// surface as a reset failure.
+	for _, snippet := range []string{
+		"function refreshStatus()",
+		"Budget window reset — spend restarts at 0, suppressed kicks resume",
+		"refreshStatus(); // repaint budget bar/banners in place; errors swallowed inside",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q", snippet)
+		}
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -5482,7 +5482,7 @@
       if (!s || !e || !s.value || !e.value) return;
       const start = new Date(s.value).getTime();
       const end = new Date(e.value).getTime();
-      if (!(end > start)) { hiveToast('Custom range: end must be after start', 'error'); return; }
+      if (!(end > start)) { showToast('Custom range: end must be after start', 'error'); return; }
       _costCustom = { start, end };
       try { localStorage.setItem('hiveCostCustom', JSON.stringify(_costCustom)); } catch {}
       if (_lastCost) renderCost(_lastCost);
@@ -6594,7 +6594,7 @@
       var raw = (input && input.value || '').trim();
       var id = parseInt(raw, 10);
       if (!raw || isNaN(id) || id <= 0) {
-        if (typeof hiveToast === 'function') hiveToast('Enter the numeric installation ID (from github.com/settings/installations/<ID>)', 'error');
+        showToast('Enter the numeric installation ID (from github.com/settings/installations/<ID>)', 'error');
         return;
       }
       if (btn) { btn.disabled = true; btn.textContent = 'Saving...'; }
@@ -6608,22 +6608,22 @@
         });
         var data = await resp.json().catch(function(){ return {}; });
         if (!resp.ok) {
-          if (typeof hiveToast === 'function') hiveToast('Failed: ' + (data.error || resp.status), 'error');
+          showToast('Failed: ' + (data.error || resp.status), 'error');
           return;
         }
         if (data.reinit === 'ok') {
-          if (typeof hiveToast === 'function') hiveToast('Installation ID set and GitHub App connected', 'success');
+          showToast('Installation ID set and GitHub App connected', 'success');
           var banner = document.getElementById('gh-app-install-banner');
           if (banner) { banner.classList.remove('perm-issue'); banner.setAttribute('hidden', ''); banner.style.cssText = 'display:none'; }
         } else if (data.reinit === 'failed') {
-          if (typeof hiveToast === 'function') hiveToast('ID saved, but connect failed: ' + (data.reinit_error || 'check app install/permissions'), 'error');
+          showToast('ID saved, but connect failed: ' + (data.reinit_error || 'check app install/permissions'), 'error');
         } else {
           // Saved but reinit not attempted (e.g. app key missing) — re-check
           // will surface the remaining gap.
-          if (typeof hiveToast === 'function') hiveToast('Installation ID saved. Click Re-check to verify.', 'success');
+          showToast('Installation ID saved. Click Re-check to verify.', 'success');
         }
       } catch(e) {
-        if (typeof hiveToast === 'function') hiveToast('Error: ' + e.message, 'error');
+        showToast('Error: ' + e.message, 'error');
       } finally {
         if (btn) { btn.disabled = false; btn.textContent = 'Save Installation ID'; }
       }
@@ -7096,10 +7096,19 @@
     let budgetIgnored = false;
     // fetch('/api/budget-ignore') — deferred to _deferredInit
 
+    // Re-fetch /api/status and re-render so the budget bar/banners reflect the
+    // new server state without a full page reload. Render errors are swallowed:
+    // callers use this after an action already succeeded, so a refresh hiccup
+    // must never be reported as a failure of that action (the next SSE/poll
+    // cycle repaints anyway).
+    function refreshStatus() {
+      return fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+    }
+
     function toggleBudgetIgnore() {
       budgetIgnored = !budgetIgnored;
       fetch('/api/budget-ignore', { method: 'POST', headers: _inceptionAuthHeaders(), body: JSON.stringify({ ignored: budgetIgnored }) })
-        .then(r => r.json()).then(d => { budgetIgnored = d.ignored; renderAll(); });
+        .then(r => r.json()).then(d => { budgetIgnored = d.ignored; refreshStatus(); });
     }
 
     // Opens a fresh budget window: spend re-anchors at 0, the exhausted gate
@@ -7107,18 +7116,24 @@
     // genuinely spent) budget is suppressing kicks — unlike "ignore budget",
     // which turns enforcement off entirely.
     async function resetBudgetWindow() {
+      // The try/catch covers only the API call: once the server has reset the
+      // window, a post-success UI refresh failure must not be mislabeled as
+      // "Failed to reset budget window" (that exact double-toast shipped once,
+      // when the success path called an undefined render helper).
+      let r;
       try {
-        const r = await fetch('/api/config/governor/budget/reset', { method: 'POST', headers: _inceptionAuthHeaders() });
-        if (!r.ok) {
-          const d = await r.json().catch(() => ({}));
-          showToast(d.error || ('Failed to reset budget window (HTTP ' + r.status + ')'), 'error');
-          return;
-        }
-        showToast('Budget window reset — spend restarts at 0, suppressed kicks resume', 'success');
-        renderAll();
+        r = await fetch('/api/config/governor/budget/reset', { method: 'POST', headers: _inceptionAuthHeaders() });
       } catch (e) {
         showToast('Failed to reset budget window: ' + e.message, 'error');
+        return;
       }
+      if (!r.ok) {
+        const d = await r.json().catch(() => ({}));
+        showToast(d.error || ('Failed to reset budget window (HTTP ' + r.status + ')'), 'error');
+        return;
+      }
+      showToast('Budget window reset — spend restarts at 0, suppressed kicks resume', 'success');
+      refreshStatus(); // repaint budget bar/banners in place; errors swallowed inside
     }
 
     function renderBudgetBar(budget) {
@@ -11488,18 +11503,18 @@ function burnAreaChart() {
       var q = (document.getElementById('audit-search').value || '').trim();
       if (!q) return;
       var saved = loadAuditSearches();
-      if (saved.indexOf(q) !== -1) { hiveToast('Search already saved', 'info'); return; }
+      if (saved.indexOf(q) !== -1) { showToast('Search already saved', 'info'); return; }
       saved.unshift(q);
       var MAX_SAVED_SEARCHES = 20;
       if (saved.length > MAX_SAVED_SEARCHES) saved = saved.slice(0, MAX_SAVED_SEARCHES);
       localStorage.setItem(AUDIT_SEARCHES_KEY, JSON.stringify(saved));
       renderAuditSearchDatalist();
-      hiveToast('Search saved', 'success');
+      showToast('Search saved', 'success');
     }
     function clearAuditSearches() {
       localStorage.removeItem(AUDIT_SEARCHES_KEY);
       renderAuditSearchDatalist();
-      hiveToast('Saved searches cleared', 'info');
+      showToast('Saved searches cleared', 'info');
     }
     renderAuditSearchDatalist();
 


### PR DESCRIPTION
Fixes #4314

Clicking **reset window now** on an exhausted budget bar produced two simultaneous toasts on a live hosted dashboard (v4 build 9f31439): ✅ "Budget window reset — spend restarts at 0, suppressed kicks resume" **and** ❌ "Failed to reset budget window: Can't find variable: renderAll". The server reset succeeded; the frontend success path called `renderAll()`, which is never defined, and the handler's try/catch conflated that post-success ReferenceError with an API failure. The exhausted banner also lingered until a full page reload because the refresh crashed.

## Changes
- Add `refreshStatus()` — the codebase-standard `/api/status` refetch + `render()` (errors swallowed) — and use it in `resetBudgetWindow()` and `toggleBudgetIgnore()`, so the budget bar/banners repaint in place without a page reload.
- Scope `resetBudgetWindow()`'s catch to the API call only: a post-success render hiccup can never again be reported as a reset failure.
- Fix the same stale-callee class elsewhere: `hiveToast()` was never defined — one unguarded call in `costCustomChanged()` threw at runtime, and the `typeof`-guarded calls in the GitHub App installation-ID flow and saved-searches flow silently never showed a toast. All now use `showToast()`.
- Add `budget_reset_ui_test.go` (embedded-index string-assertion pattern, like `time_cadence_ui_test.go`) guarding against `renderAll(`/`hiveToast(` reappearing and asserting the in-place refresh.

## Verification
- `go build ./... && go vet ./pkg/dashboard/` clean
- `go test ./pkg/dashboard/` — full package passes
- `node .github/scripts/check-inline-js.js src/pkg/dashboard/static/index.html` — all script blocks pass