### PR TITLE
🐛 fix(health): stop github_auth passing while a required App's key was never delivered

### DIFF
--- a/src/pkg/dashboard/github_auth_operator_states_test.go
+++ b/src/pkg/dashboard/github_auth_operator_states_test.go
@@ -1,0 +1,144 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+// These tests pin the config-truth rule for the OPERATOR-SIDE credential
+// states (githubAppCredsUndelivered), the sibling of the not-installed rule in
+// github_auth_config_truth_test.go: a required App whose private key never
+// arrived (key-missing / no-app-assigned) or cannot sign for it (key-invalid)
+// must fail github_auth in BOTH health surfaces, even while a live token-based
+// GHClient still exists. A token client is exactly what let a key-missing hive
+// (kelly-headwaters, 2026-08-12 → 2026-08-20) show github_auth ✓ "token-based"
+// for 8 days while no agent could act as the App.
+
+// operatorStateServer builds a full test server carrying a live (non-nil)
+// GHClient and the given operator-side App auth state.
+func operatorStateServer(t *testing.T, state string) *Server {
+	t.Helper()
+	srv := newFullServer(t)
+	srv.MarkReady()
+
+	// A real, reachable token client — it must NOT mask the config truth.
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("{}"))
+	}))
+	t.Cleanup(gh.Close)
+	srv.deps.GHClient = ghpkg.NewClientForTest(gh.URL, "testorg", []string{"testrepo"}, covBLogger())
+
+	srv.SetGitHubAppRequired(true)
+	srv.SetGitHubAppState(state)
+	return srv
+}
+
+func deepGitHubAuth(t *testing.T, srv *Server) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/health/deep", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealthDeep(w, req)
+
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	checks, ok := result["checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing checks in %v", result)
+	}
+	ga, ok := checks["github_auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing github_auth check in %v", checks)
+	}
+	return ga
+}
+
+func TestHealthDeep_GitHubAuthFailsOnOperatorSideStates_DespiteLiveClient(t *testing.T) {
+	cases := []struct {
+		state      string
+		wantDetail string
+	}{
+		{"key-missing", "not delivered by the hub"},
+		{"no-app-assigned", "not delivered by the hub"},
+		{"key-invalid", "does not match the App"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.state, func(t *testing.T) {
+			srv := operatorStateServer(t, tc.state)
+			ga := deepGitHubAuth(t, srv)
+			if ga["status"] != "fail" {
+				t.Errorf("github_auth status = %v, want fail (a token client must not mask undelivered App credentials)", ga["status"])
+			}
+			detail, _ := ga["detail"].(string)
+			if !strings.Contains(detail, tc.wantDetail) {
+				t.Errorf("github_auth detail = %q, want it to contain %q", detail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestHealthSummary_GitHubAuthFailsOnKeyMissing_DespiteLiveClient(t *testing.T) {
+	srv := operatorStateServer(t, "key-missing")
+
+	sum := srv.HealthSummary()
+	raw, err := json.Marshal(sum)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	var parsed struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal summary: %v", err)
+	}
+	found := false
+	for _, c := range parsed.Checks {
+		if c.Name != "github_auth" {
+			continue
+		}
+		found = true
+		if c.Status != "fail" {
+			t.Errorf("github_auth status = %q, want fail (a token client must not mask undelivered App credentials)", c.Status)
+		}
+		if !strings.Contains(c.Detail, "not delivered by the hub") {
+			t.Errorf("github_auth detail = %q, want it to name the undelivered credentials", c.Detail)
+		}
+	}
+	if !found {
+		t.Fatalf("no github_auth check in summary: %s", raw)
+	}
+}
+
+// The contrast cases: the same live client must pass once the operator-side
+// state clears (key delivered), and an operator-side token with the App NOT
+// required must not fail — proving the failures above come from the
+// config-truth branch and nothing else.
+func TestGitHubAuth_PassesOnceOperatorStateClears(t *testing.T) {
+	srv := operatorStateServer(t, "key-missing")
+	srv.SetGitHubAppState("")
+
+	ga := deepGitHubAuth(t, srv)
+	if ga["status"] != "pass" {
+		t.Errorf("github_auth status = %v, want pass once the key-missing state is cleared", ga["status"])
+	}
+}
+
+func TestGitHubAuth_KeyMissingWithoutAppRequiredDoesNotFail(t *testing.T) {
+	srv := operatorStateServer(t, "key-missing")
+	srv.SetGitHubAppRequired(false)
+
+	ga := deepGitHubAuth(t, srv)
+	if ga["status"] != "pass" {
+		t.Errorf("github_auth status = %v, want pass when the App is not required", ga["status"])
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -1643,6 +1643,39 @@ func (s *Server) githubAppNotInstalled() bool {
 	return s.githubAppRequired && s.githubAppState == githubAppStateNotInstalledToken
 }
 
+// Operator-side pkg/github AppAuthState wire tokens (AppAuthState.
+// OperatorActionable()): credential failures only the hub operator can fix.
+// Kept as literals for the same reason as githubAppStateNotInstalledToken.
+const (
+	githubAppStateKeyMissingToken    = "key-missing"
+	githubAppStateKeyInvalidToken    = "key-invalid"
+	githubAppStateNoAppAssignedToken = "no-app-assigned"
+)
+
+// githubAppCredsUndelivered is the config-truth rule for the OPERATOR-SIDE
+// credential states, the exact sibling of githubAppNotInstalled: an App whose
+// private key never arrived (or cannot sign for it) can never mint, so
+// github_auth must fail in BOTH health surfaces even while a token-based
+// GHClient still works. Before this, a hive stuck on key-missing showed
+// github_auth ✓ ("token-based") for 8 days while its agents could not act as
+// the App at all — the green check is what let kelly-headwaters sit degraded
+// and unexamined (2026-08-12 → 2026-08-20). Returns the failure detail, or ""
+// when no operator-side state is in force.
+func (s *Server) githubAppCredsUndelivered() string {
+	s.githubAppMu.RLock()
+	defer s.githubAppMu.RUnlock()
+	if !s.githubAppRequired {
+		return ""
+	}
+	switch s.githubAppState {
+	case githubAppStateKeyMissingToken, githubAppStateNoAppAssignedToken:
+		return "GitHub App credentials not delivered by the hub — agents cannot act as the App (operator action; no action needed from the hive owner)"
+	case githubAppStateKeyInvalidToken:
+		return "GitHub App private key does not match the App it authenticates as — GitHub rejects its JWT (operator must push the correct key)"
+	}
+	return ""
+}
+
 func (s *Server) SetGitHubAppRequired(required bool) {
 	s.githubAppMu.Lock()
 	defer s.githubAppMu.Unlock()
@@ -1947,9 +1980,14 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 		failCount++
 	}
 
-	// 2. GitHub auth — config truth first (see githubAppNotInstalled).
+	// 2. GitHub auth — config truth first (see githubAppNotInstalled and
+	// githubAppCredsUndelivered).
 	if s.githubAppNotInstalled() {
 		checks["github_auth"] = map[string]any{"status": "fail", "detail": "GitHub App not installed — no installation for this org"}
+		overall = "degraded"
+		failCount++
+	} else if detail := s.githubAppCredsUndelivered(); detail != "" {
+		checks["github_auth"] = map[string]any{"status": "fail", "detail": detail}
 		overall = "degraded"
 		failCount++
 	} else if s.deps != nil && s.deps.GHAppAuth != nil {
@@ -2664,9 +2702,13 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		fails++
 	}
 
-	// 2. GitHub auth — config truth first (see githubAppNotInstalled).
+	// 2. GitHub auth — config truth first (see githubAppNotInstalled and
+	// githubAppCredsUndelivered).
 	if s.githubAppNotInstalled() {
 		checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "GitHub App not installed — no installation for this org"})
+		fails++
+	} else if detail := s.githubAppCredsUndelivered(); detail != "" {
+		checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: detail})
 		fails++
 	} else if s.deps != nil && s.deps.GHAppAuth != nil {
 		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err != nil {

--- a/src/pkg/hub/cluster_app_key.go
+++ b/src/pkg/hub/cluster_app_key.go
@@ -1393,6 +1393,23 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		if strings.TrimSpace(payload.GitHubAppKeyFingerprint) != "" {
 			s.noteAppKeyConverged(payload.HiveID)
 		}
+		// A spoke POSITIVELY reporting it never received an App key, answered
+		// with no key: the hive is dead until an operator uploads one, and this
+		// beat is the ONLY place that fact is knowable. It used to pass in
+		// silence — no log line, no alert — which is how kelly-headwaters sat
+		// degraded on key-missing for 8 days (provisioned 2026-08-12, noticed
+		// 2026-08-20) while the hub answered nothing every 30 seconds. Said out
+		// loud with a remedy, exactly like the placeholder-sentinel warn above
+		// it in appKeyConfigForHeartbeat: an undeliverable state must never be
+		// the quiet case.
+		if s.logger != nil && payload.GitHubAppRequired && strings.TrimSpace(payload.GitHubAppState) == appStateKeyMissingToken {
+			s.logger.Warn("heartbeat: spoke reports its github app key was never delivered and the hub holds no key to deliver — hive cannot work until an operator uploads the App key",
+				"hive_id", payload.HiveID,
+				"cluster_id", clusterID,
+				"spoke_app_id", payload.GitHubAppID,
+				"remedy", "PUT /api/saas/admin/cluster-app-keys/"+clusterID+" with the App's PEM private key",
+			)
+		}
 		if cfg == nil {
 			// Nothing else to deliver: check for the one fault a converged app
 			// identity can still hide — a stale installation_id left behind by an

--- a/src/pkg/hub/key_missing_warn_test.go
+++ b/src/pkg/hub/key_missing_warn_test.go
@@ -1,0 +1,79 @@
+package hub
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// These tests pin the "say it out loud" rule for the undeliverable key state:
+// a spoke POSITIVELY reporting key-missing on a required App, answered by a
+// hub that holds no key for it, must produce a WARN naming the hive and the
+// remedy. Before this, that beat returned nil in complete silence — no log,
+// no alert — which is how a hosted hive (kelly-headwaters) sat degraded on
+// key-missing for 8 days (2026-08-12 → 2026-08-20) with nothing anywhere
+// telling the operator a key upload was owed.
+
+func keyMissingWarnServer(t *testing.T, buf *bytes.Buffer) *HubServer {
+	t.Helper()
+	withTempAppKeyDir(t) // deliberately EMPTY: the hub holds no key to deliver
+	return &HubServer{
+		clusters: map[string]ClusterConfig{
+			"oke-test": {ID: "oke-test"},
+		},
+		logger: slog.New(slog.NewTextHandler(buf, nil)),
+	}
+}
+
+func TestAppKeySync_WarnsWhenSpokeReportsKeyMissingAndHubHoldsNoKey(t *testing.T) {
+	var buf bytes.Buffer
+	s := keyMissingWarnServer(t, &buf)
+
+	cfg := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+		HiveID:            "kelly-headwaters",
+		ClusterID:         "oke-test",
+		GitHubAppRequired: true,
+		GitHubAppState:    "key-missing",
+	})
+	if cfg != nil && cfg.PrivateKey != "" {
+		t.Fatalf("a keyless hub delivered a key: %+v", cfg)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "never delivered") {
+		t.Errorf("no WARN for the undeliverable key-missing state; log = %q", logged)
+	}
+	if !strings.Contains(logged, "kelly-headwaters") {
+		t.Errorf("WARN does not name the hive; log = %q", logged)
+	}
+	if !strings.Contains(logged, "/api/saas/admin/cluster-app-keys/oke-test") {
+		t.Errorf("WARN does not name the remedy endpoint; log = %q", logged)
+	}
+}
+
+// The quiet cases stay quiet: a spoke not reporting key-missing (an ordinary
+// keyless-cluster beat, the overwhelming majority) must not produce the WARN.
+func TestAppKeySync_NoWarnWithoutPositiveKeyMissingReport(t *testing.T) {
+	for name, payload := range map[string]*HeartbeatPayload{
+		"no app state reported": {
+			HiveID: "quiet-1", ClusterID: "oke-test", GitHubAppRequired: true,
+		},
+		"app not required": {
+			HiveID: "quiet-2", ClusterID: "oke-test", GitHubAppState: "key-missing",
+		},
+		"user-side state": {
+			HiveID: "quiet-3", ClusterID: "oke-test", GitHubAppRequired: true,
+			GitHubAppState: "not-installed",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			s := keyMissingWarnServer(t, &buf)
+			s.appKeySyncForHeartbeat(payload)
+			if logged := buf.String(); strings.Contains(logged, "never delivered") {
+				t.Errorf("unexpected key-missing WARN; log = %q", logged)
+			}
+		})
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -10627,7 +10627,7 @@ const dashboardHTML = `<!DOCTYPE html>
            about an installation that is already correct. */
         lines.push(h.githubAppState === GH_APP_STATE_KEY_INVALID
           ? '⚠ GitHub App: key does not match the App (operator must push the correct key)'
-          : '⚠ GitHub App: credentials not yet delivered by the hub (operator action)');
+          : '⚠ GitHub App: credentials not yet delivered by the hub (operator action: upload the App key — PUT /api/saas/admin/cluster-app-keys/{cluster})');
         st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel;
       }
       else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: ' + ghAppPermIssueLabel(h.githubAppState)); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }


### PR DESCRIPTION
Fixes #4317. Companion design gap (operator fleet alert): #4316.

## Field case

Hosted hive **kelly-headwaters** (provisioned 2026-08-12) was found Degraded on 2026-08-20 — 8 days, zero tokens ever — stuck on the operator-side `key-missing` App state, while its fleet row showed `✓ github_auth` and the hub logs said nothing.

## Changes (one per silent surface)

1. **Spoke health, both surfaces** (`pkg/dashboard/server.go`): the config-truth rule that already fails `github_auth` for `not-installed` now also covers the operator-side states `key-missing` / `key-invalid` / `no-app-assigned`. A live token-based `GHClient` no longer masks a required App with no usable key. Detail text names the operator-side cause (and tells the owner no action is needed from them).
2. **Fleet hover** (`pkg/hub/saas.go`): the `(operator action)` line now names the action: `upload the App key — PUT /api/saas/admin/cluster-app-keys/{cluster}`.
3. **Heartbeat reconcile** (`pkg/hub/cluster_app_key.go`): when a spoke positively reports `key-missing` on a required App and the hub answers with no key (`appKeyReasonNoClusterKey` etc.), a WARN with the remedy endpoint is logged — mirroring the existing placeholder-sentinel "cannot repair" precedent — instead of returning nil in silence every beat.

## Tests

- `pkg/dashboard/github_auth_operator_states_test.go` — both health surfaces fail on all three operator-side states despite a live token client; contrast cases (state cleared / App not required) still pass.
- `pkg/hub/key_missing_warn_test.go` — WARN fires with hive + remedy for a positive key-missing report on a keyless hub; ordinary keyless-cluster beats and user-side states stay quiet.
- Full `go test ./pkg/hub/ ./pkg/dashboard/` green locally; `go vet` clean.