### PR TITLE
✨ feat(budget): record per-window token budget history so past resets are visible

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1202,6 +1202,17 @@ func main() {
 		}
 	}
 
+	// #4298: restore per-budget-window history so past resets survive a restart.
+	// A missing or unparseable file is ordinary on a hive upgrading into this
+	// feature — it simply starts with no history rather than failing to boot.
+	const budgetWindowHistoryPath = "/data/budget-window-history.json"
+	var pendingBudgetWindowSeed []dashboard.BudgetWindowEntry
+	if budgetData, err := os.ReadFile(budgetWindowHistoryPath); err == nil {
+		if err := json.Unmarshal(budgetData, &pendingBudgetWindowSeed); err == nil && len(pendingBudgetWindowSeed) > 0 {
+			logger.Info("budget window history loaded", "entries", len(pendingBudgetWindowSeed))
+		}
+	}
+
 	// Restore governor/repo/beads/system trend history from disk so those
 	// sparklines survive restarts and render for any viewer (previously kept
 	// only in the browser's localStorage).
@@ -1737,6 +1748,11 @@ func main() {
 	if len(pendingCostSeed) > 0 {
 		dashSrv.SeedCostHistory(pendingCostSeed)
 		logger.Info("cost history restored", "entries", len(pendingCostSeed))
+	}
+
+	if len(pendingBudgetWindowSeed) > 0 {
+		dashSrv.SeedBudgetWindowHistory(pendingBudgetWindowSeed)
+		logger.Info("budget window history restored", "entries", len(pendingBudgetWindowSeed))
 	}
 
 	if len(pendingTrendSeed) > 0 {
@@ -5909,6 +5925,16 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			trendData, err := json.Marshal(trendHist)
 			if err == nil {
 				atomicWrite("/data/trend-history.json", trendData)
+			}
+		}
+
+		// #4298: per-budget-window history. Written on the same cadence as the
+		// other series so a pod roll cannot lose more of one than the others.
+		budgetHist := dashSrv.BudgetWindowHistory()
+		if len(budgetHist) > 0 {
+			budgetData, err := json.Marshal(budgetHist)
+			if err == nil {
+				atomicWrite("/data/budget-window-history.json", budgetData)
 			}
 		}
 	}

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -94,6 +94,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/tokens", s.handleTokens)
 	s.mux.HandleFunc("GET /api/cost", s.handleCost)
 	s.mux.HandleFunc("GET /api/cost/history", s.handleCostHistory)
+	// #4298: "for every recent reset, how much of the budget had been used".
+	s.mux.HandleFunc("GET /api/budget/history", s.handleBudgetHistory)
 	s.mux.HandleFunc("GET /api/trend/history", s.handleTrendHistory)
 	s.mux.HandleFunc("GET /api/timeseries", s.handleTimeSeries)
 	s.mux.HandleFunc("GET /api/issue-costs", s.handleIssueCosts)
@@ -7161,6 +7163,47 @@ func (s *Server) handleCostHistory(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleTrendHistory(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, s.TrendHistory())
+}
+
+// handleBudgetHistory serves the per-budget-window report (#4298): one row per
+// CLOSED window, newest first, plus the window still open so an operator sees
+// the whole picture in one response rather than joining two endpoints.
+//
+// `windows` is ALWAYS an array, never null — a hive that has not yet seen a
+// roll returns `[]`, which a client renders as "no history yet" rather than
+// crashing on a nil. That is the compatibility requirement #4298 names: new
+// code must not break an environment that was never keeping this history.
+func (s *Server) handleBudgetHistory(w http.ResponseWriter, r *http.Request) {
+	windows := s.BudgetWindowHistory()
+	if windows == nil {
+		windows = []BudgetWindowEntry{}
+	}
+
+	resp := map[string]any{"windows": windows}
+
+	// The open window, straight from the live status, so the report reads
+	// continuously from "now" back through the closed rows.
+	s.statusMu.RLock()
+	status := s.status
+	s.statusMu.RUnlock()
+	if status != nil {
+		b := status.Budget
+		current := map[string]any{
+			"limit":     b.WeeklyBudget,
+			"used":      b.Used,
+			"pctUsed":   b.PctUsed,
+			"exhausted": b.Exhausted,
+		}
+		if b.WindowStartsAt != "" {
+			current["windowStart"] = b.WindowStartsAt
+		}
+		if b.WindowEndsAt != "" {
+			current["windowEnd"] = b.WindowEndsAt
+		}
+		resp["current"] = current
+	}
+
+	jsonResponse(w, resp)
 }
 
 // handleTimeSeries is the unified read endpoint over the sparkline histories.

--- a/src/pkg/dashboard/budget_history.go
+++ b/src/pkg/dashboard/budget_history.go
@@ -1,0 +1,226 @@
+package dashboard
+
+import (
+	"sync"
+	"time"
+)
+
+// Per-budget-window history (kubestellar/hive#4298).
+//
+// The dashboard has always shown the CURRENT budget window: how much of the
+// weekly limit this window has consumed, and when it rolls. That answers "am I
+// about to run out", and it is the only question it can answer — the moment the
+// window rolls, the previous window's number is gone.
+//
+// The question an administrator actually asks after two weeks away is the other
+// one: "did the budget stop the hive while I was gone?" Nothing in the tree
+// could answer it. The token sparkline records tokens over time but knows
+// nothing about the limit or where the window boundaries fell, and the governor
+// keeps only the open window's spend.
+//
+// This records one row per CLOSED window — when it ran, what the limit was,
+// what was consumed, and whether it hit the limit — so "for every recent reset,
+// how much of the budget had been used" becomes a lookup.
+//
+// COMPATIBILITY. A hive upgrading into this keeps no history it never
+// collected: the list starts empty, every accessor tolerates that, and the
+// first observation merely starts tracking. Nothing here can fail a status
+// build — an unset limit, a zero window, and a governor that has not opened a
+// window yet are ordinary inputs, not errors.
+
+// budgetWindowMaxEntries caps the ring. With a weekly window, 26 entries is
+// half a year — longer than an operator investigates, and trivially small on
+// disk. A named constant so the retention is a deliberate number rather than an
+// accident of the buffer size.
+const budgetWindowMaxEntries = 26
+
+// BudgetWindowEntry is one CLOSED budget window.
+//
+// Timestamps are epoch milliseconds, matching every other history series the
+// dashboard persists, so the frontend parses them the same way.
+type BudgetWindowEntry struct {
+	// WindowStart and WindowEnd bound the window. WindowEnd is when the reset
+	// happened, which is what an operator correlates against "the fortnight I
+	// was away".
+	WindowStart int64 `json:"windowStart"`
+	WindowEnd   int64 `json:"windowEnd"`
+	// Limit is the weekly token limit that was in force FOR THIS WINDOW.
+	// Recorded per window rather than read live, because an operator who raised
+	// the limit after a bad week must still see what the limit was when it bit.
+	Limit int64 `json:"limit"`
+	// Used is the tokens consumed — the high-water mark observed before the
+	// roll, not a post-roll reading, which would always be ~0.
+	Used int64 `json:"used"`
+	// PctUsed is Used/Limit as a percentage; 0 when no limit was set.
+	PctUsed float64 `json:"pctUsed"`
+	// Exhausted records whether the window actually reached its limit. Stored
+	// rather than recomputed, for the same reason Limit is: a later limit
+	// change must not rewrite history and make a past window look fine.
+	Exhausted bool `json:"exhausted"`
+}
+
+// budgetWindowTracker watches the open window and emits an entry when it rolls.
+// A small leaf-locked struct: nothing here calls back into Server, so the mutex
+// is taken and released inside one method.
+type budgetWindowTracker struct {
+	mu sync.Mutex
+	// start/end bound the window being observed. Zero before the first
+	// observation and whenever the governor reports no open window.
+	start int64
+	end   int64
+	limit int64
+	// peakUsed is the HIGH-WATER spend seen in the open window.
+	//
+	// High-water rather than last-seen because the roll is detected on the
+	// observation AFTER it happened, by which time the live spend has already
+	// reset toward zero. Reading it then would record every window as barely
+	// used — precisely the wrong answer for the question this feature exists to
+	// answer.
+	peakUsed int64
+	// exhausted latches for the same reason: the state is transient and the
+	// roll is observed late.
+	exhausted bool
+	// closed holds completed windows, oldest first.
+	closed []BudgetWindowEntry
+}
+
+// observe folds one status reading into the tracker, returning the entry for a
+// window that just closed (nil when none did).
+//
+// windowStart/windowEnd are the open window's bounds in epoch milliseconds. A
+// zero windowEnd means the governor has no window open (no limit configured),
+// which closes any tracked window without starting a new one.
+func (t *budgetWindowTracker) observe(windowStart, windowEnd, limit, used int64, exhausted bool) *BudgetWindowEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Same window still open: accumulate and stop.
+	if windowEnd != 0 && windowEnd == t.end {
+		if used > t.peakUsed {
+			t.peakUsed = used
+		}
+		if exhausted {
+			t.exhausted = true
+		}
+		if limit > 0 {
+			t.limit = limit
+		}
+		return nil
+	}
+
+	// The window changed. Close the tracked one, if there was one.
+	var rolled *BudgetWindowEntry
+	if t.end != 0 {
+		entry := BudgetWindowEntry{
+			WindowStart: t.start,
+			WindowEnd:   t.end,
+			Limit:       t.limit,
+			Used:        t.peakUsed,
+			Exhausted:   t.exhausted,
+		}
+		if t.limit > 0 {
+			const pctMultiplier = 100.0
+			entry.PctUsed = float64(t.peakUsed) / float64(t.limit) * pctMultiplier
+		}
+		t.closed = append(t.closed, entry)
+		if len(t.closed) > budgetWindowMaxEntries {
+			t.closed = t.closed[len(t.closed)-budgetWindowMaxEntries:]
+		}
+		rolled = &entry
+	}
+
+	// Begin tracking the new window. A zero windowEnd leaves the tracker idle
+	// rather than recording an empty row on every status build.
+	if windowEnd == 0 {
+		t.start, t.end, t.limit, t.peakUsed, t.exhausted = 0, 0, 0, 0, false
+		return rolled
+	}
+	t.start, t.end, t.limit = windowStart, windowEnd, limit
+	t.peakUsed, t.exhausted = used, exhausted
+	return rolled
+}
+
+// snapshot returns a copy of the closed windows, newest FIRST — the order an
+// operator reads them in, and the order the API serves.
+func (t *budgetWindowTracker) snapshot() []BudgetWindowEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]BudgetWindowEntry, 0, len(t.closed))
+	for i := len(t.closed) - 1; i >= 0; i-- {
+		out = append(out, t.closed[i])
+	}
+	return out
+}
+
+// seed restores persisted history on startup. Entries arrive newest-first (the
+// order snapshot emits and the API serves) and are stored oldest-first
+// internally, so a save/load round trip preserves order. Over-long input is
+// truncated to the newest entries rather than rejected: a file written by a
+// build with a larger cap must not break startup.
+func (t *budgetWindowTracker) seed(entries []BudgetWindowEntry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = t.closed[:0]
+	for i := len(entries) - 1; i >= 0; i-- {
+		t.closed = append(t.closed, entries[i])
+	}
+	if len(t.closed) > budgetWindowMaxEntries {
+		t.closed = t.closed[len(t.closed)-budgetWindowMaxEntries:]
+	}
+}
+
+// budgetWindowOnceKey guards lazy construction so a zero-value Server — as used
+// in tests that do `&Server{}` — works without a constructor, exactly like
+// initHistories does for the sparkline rings.
+func (s *Server) budgetWindows() *budgetWindowTracker {
+	s.budgetWindowOnce.Do(func() {
+		s.budgetWindowHist = &budgetWindowTracker{}
+	})
+	return s.budgetWindowHist
+}
+
+// ObserveBudgetWindow folds the current status's budget into the per-window
+// history, recording a row when the window has rolled since the last call.
+// Called from UpdateStatus alongside the other history appenders.
+//
+// A nil status, or a status with no open window, is a no-op: a hive with
+// budgeting off records nothing rather than a stream of empty rows.
+func (s *Server) ObserveBudgetWindow(status *StatusPayload) {
+	if status == nil {
+		return
+	}
+	b := status.Budget
+
+	// WindowEndsAt is empty unless a limit is set and a window is open — which
+	// is exactly the "nothing to track" case. An unparseable timestamp is
+	// treated the same way rather than aborting the status build.
+	var startMs, endMs int64
+	if b.WindowEndsAt != "" {
+		if end, err := time.Parse(time.RFC3339, b.WindowEndsAt); err == nil {
+			endMs = end.UnixMilli()
+		}
+	}
+	if b.WindowStartsAt != "" {
+		if start, err := time.Parse(time.RFC3339, b.WindowStartsAt); err == nil {
+			startMs = start.UnixMilli()
+		}
+	}
+
+	rolled := s.budgetWindows().observe(startMs, endMs, b.WeeklyBudget, b.Used, b.Exhausted)
+	if rolled != nil && s.logger != nil {
+		s.logger.Info("budget window rolled",
+			"used", rolled.Used, "limit", rolled.Limit,
+			"pct_used", rolled.PctUsed, "exhausted", rolled.Exhausted)
+	}
+}
+
+// BudgetWindowHistory returns the closed budget windows, newest first. Empty on
+// a hive that has not yet seen a window roll — ordinary, never an error.
+func (s *Server) BudgetWindowHistory() []BudgetWindowEntry {
+	return s.budgetWindows().snapshot()
+}
+
+// SeedBudgetWindowHistory restores persisted per-window history on startup.
+func (s *Server) SeedBudgetWindowHistory(entries []BudgetWindowEntry) {
+	s.budgetWindows().seed(entries)
+}

--- a/src/pkg/dashboard/budget_history_test.go
+++ b/src/pkg/dashboard/budget_history_test.go
@@ -1,0 +1,261 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// ── Per-budget-window history (#4298) ───────────────────────────────────────
+
+func windowStatus(startsAt, endsAt time.Time, limit, used int64, exhausted bool) *StatusPayload {
+	b := FrontendBudget{WeeklyBudget: limit, Used: used, Exhausted: exhausted}
+	if !endsAt.IsZero() {
+		b.WindowEndsAt = endsAt.UTC().Format(time.RFC3339)
+		b.WindowStartsAt = startsAt.UTC().Format(time.RFC3339)
+	}
+	return &StatusPayload{Budget: b}
+}
+
+// TestWindowRollRecordsPeakNotPostResetReading is the property the whole
+// feature turns on. The roll is only ever observed on the status build AFTER it
+// happened, by which point the live spend has already reset toward zero. If the
+// tracker recorded the reading it sees at that moment, every window in the
+// report would say "barely used" — the exact opposite of the answer the
+// operator needs.
+func TestWindowRollRecordsPeakNotPostResetReading(t *testing.T) {
+	s := &Server{}
+	w1Start := time.Now().Add(-14 * 24 * time.Hour)
+	w1End := w1Start.Add(7 * 24 * time.Hour)
+
+	s.ObserveBudgetWindow(windowStatus(w1Start, w1End, 1_000_000, 10_000, false))
+	s.ObserveBudgetWindow(windowStatus(w1Start, w1End, 1_000_000, 940_000, false))
+	// The window peaked here, then rolled.
+	s.ObserveBudgetWindow(windowStatus(w1Start, w1End, 1_000_000, 1_000_000, true))
+
+	// Next window opens; live spend is near zero again.
+	w2Start := w1End
+	w2End := w2Start.Add(7 * 24 * time.Hour)
+	s.ObserveBudgetWindow(windowStatus(w2Start, w2End, 1_000_000, 12, false))
+
+	hist := s.BudgetWindowHistory()
+	if len(hist) != 1 {
+		t.Fatalf("expected one closed window, got %d: %+v", len(hist), hist)
+	}
+	if hist[0].Used != 1_000_000 {
+		t.Errorf("Used = %d, want the peak 1000000 — a post-reset reading would record ~12", hist[0].Used)
+	}
+	if !hist[0].Exhausted {
+		t.Error("the closed window hit its limit and must be recorded as exhausted")
+	}
+	if hist[0].PctUsed < 99.9 {
+		t.Errorf("PctUsed = %v, want ~100", hist[0].PctUsed)
+	}
+	// The status payload carries RFC3339, which is whole seconds — so the
+	// recorded boundary is the second, not the sub-second instant the test
+	// happened to construct. Compare against what the wire format can actually
+	// preserve rather than pretending it round-trips milliseconds.
+	wantEnd := w1End.UTC().Truncate(time.Second).UnixMilli()
+	if hist[0].WindowEnd != wantEnd {
+		t.Errorf("WindowEnd = %d, want %d", hist[0].WindowEnd, wantEnd)
+	}
+}
+
+// TestHistoryAnswersTheVacationQuestion is the use case verbatim: over several
+// closed windows, which ones hit the budget?
+func TestHistoryAnswersTheVacationQuestion(t *testing.T) {
+	s := &Server{}
+	start := time.Now().Add(-28 * 24 * time.Hour)
+	const limit = int64(1_000_000)
+	week := 7 * 24 * time.Hour
+
+	// Four windows: quiet, exhausted, exhausted, quiet.
+	peaks := []struct {
+		used      int64
+		exhausted bool
+	}{
+		{200_000, false},
+		{limit, true},
+		{limit, true},
+		{350_000, false},
+	}
+	for i, p := range peaks {
+		ws := start.Add(time.Duration(i) * week)
+		we := ws.Add(week)
+		s.ObserveBudgetWindow(windowStatus(ws, we, limit, p.used, p.exhausted))
+	}
+	// One more observation to roll the last one closed.
+	last := start.Add(time.Duration(len(peaks)) * week)
+	s.ObserveBudgetWindow(windowStatus(last, last.Add(week), limit, 0, false))
+
+	hist := s.BudgetWindowHistory()
+	if len(hist) != 4 {
+		t.Fatalf("expected 4 closed windows, got %d", len(hist))
+	}
+	// Newest first.
+	if hist[0].Used != 350_000 {
+		t.Errorf("newest window Used = %d, want 350000 — history must be newest first", hist[0].Used)
+	}
+	exhaustedCount := 0
+	for _, e := range hist {
+		if e.Exhausted {
+			exhaustedCount++
+		}
+	}
+	if exhaustedCount != 2 {
+		t.Errorf("exhausted windows = %d, want 2 — this is the answer to 'did the budget limit activity?'", exhaustedCount)
+	}
+}
+
+// TestLimitIsRecordedPerWindow pins that raising the limit later cannot rewrite
+// history and make a window that genuinely ran out look comfortable.
+func TestLimitIsRecordedPerWindow(t *testing.T) {
+	s := &Server{}
+	ws := time.Now().Add(-14 * 24 * time.Hour)
+	we := ws.Add(7 * 24 * time.Hour)
+
+	s.ObserveBudgetWindow(windowStatus(ws, we, 100_000, 100_000, true))
+	// Operator raises the limit; a new window opens under the new limit.
+	s.ObserveBudgetWindow(windowStatus(we, we.Add(7*24*time.Hour), 5_000_000, 1_000, false))
+
+	hist := s.BudgetWindowHistory()
+	if len(hist) != 1 {
+		t.Fatalf("expected one closed window, got %d", len(hist))
+	}
+	if hist[0].Limit != 100_000 {
+		t.Errorf("Limit = %d, want the 100000 in force at the time, not the raised 5000000", hist[0].Limit)
+	}
+	if !hist[0].Exhausted {
+		t.Error("raising the limit afterwards must not un-exhaust a past window")
+	}
+}
+
+// TestNoBudgetConfiguredRecordsNothing pins the compatibility requirement:
+// budgeting off must not produce a stream of empty rows.
+func TestNoBudgetConfiguredRecordsNothing(t *testing.T) {
+	s := &Server{}
+	for i := 0; i < 5; i++ {
+		s.ObserveBudgetWindow(&StatusPayload{Budget: FrontendBudget{}})
+	}
+	if hist := s.BudgetWindowHistory(); len(hist) != 0 {
+		t.Fatalf("no configured budget must record nothing, got %+v", hist)
+	}
+}
+
+// TestZeroValueServerAndNilStatusAreSafe is the "must not crash when installed
+// into an existing environment" requirement, taken literally.
+func TestZeroValueServerAndNilStatusAreSafe(t *testing.T) {
+	s := &Server{}
+	s.ObserveBudgetWindow(nil)
+	if hist := s.BudgetWindowHistory(); len(hist) != 0 {
+		t.Fatalf("a zero-value Server with no observations must report no history, got %+v", hist)
+	}
+	// A window whose timestamps do not parse must be ignored, not panic.
+	s.ObserveBudgetWindow(&StatusPayload{Budget: FrontendBudget{
+		WeeklyBudget: 10, Used: 5, WindowEndsAt: "not-a-timestamp", WindowStartsAt: "also-not",
+	}})
+	if hist := s.BudgetWindowHistory(); len(hist) != 0 {
+		t.Fatalf("unparseable window bounds must record nothing, got %+v", hist)
+	}
+}
+
+// TestRetentionKeepsNewest pins the ring bound and that it drops the OLDEST.
+func TestRetentionKeepsNewest(t *testing.T) {
+	s := &Server{}
+	start := time.Now().Add(-time.Duration(budgetWindowMaxEntries+10) * 7 * 24 * time.Hour)
+	week := 7 * 24 * time.Hour
+	total := budgetWindowMaxEntries + 5
+	for i := 0; i < total+1; i++ {
+		ws := start.Add(time.Duration(i) * week)
+		s.ObserveBudgetWindow(windowStatus(ws, ws.Add(week), 1000, int64(i), false))
+	}
+
+	hist := s.BudgetWindowHistory()
+	if len(hist) != budgetWindowMaxEntries {
+		t.Fatalf("history = %d entries, want the cap %d", len(hist), budgetWindowMaxEntries)
+	}
+	// Newest first, and the newest closed window is the one before the open one.
+	if hist[0].Used != int64(total-1) {
+		t.Errorf("newest entry Used = %d, want %d — retention must drop the OLDEST", hist[0].Used, total-1)
+	}
+}
+
+// TestSeedRoundTripsThroughJSON pins that what is persisted reloads in the same
+// order, which is what makes the history survive a restart.
+func TestSeedRoundTripsThroughJSON(t *testing.T) {
+	s := &Server{}
+	start := time.Now().Add(-21 * 24 * time.Hour)
+	week := 7 * 24 * time.Hour
+	for i := 0; i < 3; i++ {
+		ws := start.Add(time.Duration(i) * week)
+		s.ObserveBudgetWindow(windowStatus(ws, ws.Add(week), 1000, int64(100+i), false))
+	}
+	last := start.Add(3 * week)
+	s.ObserveBudgetWindow(windowStatus(last, last.Add(week), 1000, 0, false))
+
+	saved := s.BudgetWindowHistory()
+	data, err := json.Marshal(saved)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var reloaded []BudgetWindowEntry
+	if err := json.Unmarshal(data, &reloaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	restarted := &Server{}
+	restarted.SeedBudgetWindowHistory(reloaded)
+	got := restarted.BudgetWindowHistory()
+
+	if len(got) != len(saved) {
+		t.Fatalf("after restart: %d entries, want %d", len(got), len(saved))
+	}
+	for i := range saved {
+		if got[i] != saved[i] {
+			t.Errorf("entry %d changed across the round trip: %+v vs %+v", i, got[i], saved[i])
+		}
+	}
+}
+
+// TestBudgetHistoryEndpointAlwaysReturnsAnArray is the compatibility guard at
+// the wire. A hive with no history must serve `[]`, never `null` — a client
+// that iterates the field would break on nil, which is exactly what #4298 says
+// must not happen when the feature lands in an environment that kept no
+// history.
+func TestBudgetHistoryEndpointAlwaysReturnsAnArray(t *testing.T) {
+	s := NewServer(0, slog.Default())
+	s.RegisterAPI(testDeps(t))
+
+	req := httptest.NewRequest("GET", "/api/budget/history", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Windows []BudgetWindowEntry `json:"windows"`
+	}
+	raw := rec.Body.String()
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("response is not valid JSON: %v\n%s", err, raw)
+	}
+	if body.Windows == nil {
+		t.Errorf("windows must serialize as [] on a fresh hive, not null: %s", raw)
+	}
+	if !containsSub(raw, `"windows":[]`) {
+		t.Errorf("expected an empty array on the wire, got: %s", raw)
+	}
+}
+
+func containsSub(h, n string) bool {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return true
+		}
+	}
+	return false
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -98,6 +98,10 @@ type Server struct {
 	tokenHist *timeSeries[TokenSparklineEntry]
 	factHist  *timeSeries[FactHistoryEntry]
 	costHist  *timeSeries[CostHistoryEntry]
+	// budgetWindowHist records one row per CLOSED budget window (#4298). Lazily
+	// built like the sparkline rings so a zero-value Server works in tests.
+	budgetWindowOnce sync.Once
+	budgetWindowHist *budgetWindowTracker
 
 	// lastFullBroadcast is guarded by statusMu (set/read alongside s.status).
 	lastFullBroadcast time.Time
@@ -556,6 +560,11 @@ type FrontendBudget struct {
 	// WindowEndsAt is when the current budget window rolls (RFC3339);
 	// empty unless a weekly limit is set and a window is open.
 	WindowEndsAt string `json:"WINDOW_ENDS_AT"`
+	// WindowStartsAt is when the current window opened (RFC3339), i.e. the last
+	// reset. Additive (#4298): it is what lets a usage graph mark where the
+	// resets fell, and what bounds each row of the per-window history. Empty
+	// under exactly the same conditions as WindowEndsAt.
+	WindowStartsAt string `json:"WINDOW_STARTS_AT,omitempty"`
 }
 
 type FrontendCadence struct {
@@ -1523,6 +1532,9 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 
 	s.AppendTokenSparkline(status)
 	s.AppendTrendHistory(status)
+	// #4298: fold the budget window into per-window history so a closed window's
+	// consumption survives the reset that erases the live number.
+	s.ObserveBudgetWindow(status)
 
 	data, err := json.Marshal(status)
 	if err != nil {

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -1296,6 +1296,8 @@ func buildBudget(gov *governor.Governor, tokenCollector *tokens.Collector) Front
 		fb.Exhausted = used >= budget.WeeklyLimit
 		if !budget.ResetAt.IsZero() {
 			fb.WindowEndsAt = budget.ResetAt.Add(governor.BudgetWindowDuration).UTC().Format(time.RFC3339)
+			// ResetAt is the START of the current window (#4298).
+			fb.WindowStartsAt = budget.ResetAt.UTC().Format(time.RFC3339)
 		}
 	}
 


### PR DESCRIPTION
Refs #4298.

## The question that couldn't be answered

> I just came back from vacation and wonder whether the hive's configured token budget limited activity while I was gone.

The dashboard shows only the **current** window — how much of the weekly limit this window has consumed, and when it rolls. The moment the window rolls, that number is gone. The token sparkline records tokens over time but knows nothing about the limit or where the window boundaries fell, and the governor keeps only the open window's spend. So there was nowhere to look.

## What this adds

The issue's **"Alternatives considered"** — *a report showing, for every recent reset, how much of the budget had been used* — because it is also the data layer the proposed graph needs. Nothing can plot past resets that were never recorded.

Each status build folds the budget into a tracker that emits one row when the window rolls: bounds, the limit in force, consumption, and whether it was exhausted. Served newest-first from `GET /api/budget/history` alongside the still-open window, persisted to `/data/budget-window-history.json` on the same cadence as the other history series, restored on startup.

## The detail the whole feature turns on

**The recorded consumption is the high-water mark, not the reading taken when the roll is noticed.**

A roll can only ever be observed on the status build *after* it happened — by which point the live spend has already reset toward zero. Recording that reading would report every window as barely used: the exact opposite of the answer being asked for. `exhausted` latches for the same reason.

A test drives a window to its limit, rolls it, and asserts the row says `1000000` rather than the `12` visible at detection time. That test is the one to read if you read one.

The limit is stored **per window** rather than read live, so an operator who raises the limit after a bad week still sees what it was when it bit — and a test pins that raising it later cannot un-exhaust a past window.

## Compatibility

#4298 asks specifically that new code not crash in an environment that was never keeping this history. Each of these is a test, not a claim:

| Condition | Behaviour |
|---|---|
| Fresh hive, no history | `windows: []` on the wire — **never `null`**, so a client that iterates the field can't break |
| Zero-value `Server` | works (lazy init, same as the sparkline rings) |
| `nil` status | no-op |
| Unparseable window bounds | records nothing, no panic |
| Budgeting switched off | records nothing — not a row per status build |
| Missing/corrupt history file at startup | starts empty, does not fail boot |

Also adds `WINDOW_STARTS_AT` to the budget payload — additive and `omitempty`. It bounds each history row, and it's what a usage graph needs to mark where the resets fell.

## What I did not do, and why

**The graph itself, and the missing axes** on the existing cost sparklines that the issue's screenshot calls out ("impossible to understand" — a fair complaint).

Both are frontend work inside the 1.3 MB SPA document and deserve their own review rather than riding along here. What this lands is the durable series they would read, which does not exist today and which no amount of frontend work can reconstruct after the fact — a graph shipped first would have had nothing to draw for any window that had already closed.

Happy to follow up with the axes fix as a separate PR if that's the priority.

## Testing

`go test ./pkg/dashboard/` green (54s, full suite); `go vet ./pkg/dashboard/ ./cmd/hive/` clean.

One note on test honesty: my first version of the roll test compared `WindowEnd` against a millisecond-precision timestamp and failed. That was the *test* being wrong, not the code — the status payload carries RFC3339, which is whole seconds. I fixed the assertion to compare against what the wire format actually preserves rather than loosening it until it passed.

— hive: backend=claude model=claude-opus-5
