### PR TITLE
🐛 fix(hub): alert operators when the hub never delivered a hive's App key

### DIFF
--- a/src/docs/hub-deployment.md
+++ b/src/docs/hub-deployment.md
@@ -99,6 +99,64 @@ The hub's SaaS provisioner creates or records:
 
 For heartbeat-only clusters where the hub cannot run `kubectl`, follow the manifest-level workflow in `manual-provisioning.md`; this guide intentionally keeps the hub setup consistent with that battle-tested path.
 
+## Cluster GitHub App keys (and the `app-creds-undelivered` alert)
+
+The hub is the authority for GitHub App private keys. Each cluster has one PEM
+in the hub's own store:
+
+```
+/data/saas/app-keys/<clusterID>.pem
+```
+
+At claim time the hub delivers the App *identity* (`app_id`) to the spoke, and
+then reconciles the *key* to it on every heartbeat. **If the hub holds no key
+for that cluster, the identity is delivered with `key_delivered=false` and every
+subsequent beat resolves to "no cluster key" and delivers nothing — forever,
+until an operator uploads one.** The spoke sits in `key-missing`, does no work,
+and burns no tokens.
+
+Upload a key for a cluster:
+
+```bash
+curl -X PUT \
+  -H "Authorization: Bearer $HUB_ADMIN_TOKEN" \
+  --data-binary @app-private-key.pem \
+  https://<hub>/api/saas/admin/cluster-app-keys/<clusterID>
+```
+
+List which clusters currently have one:
+
+```bash
+curl -H "Authorization: Bearer $HUB_ADMIN_TOKEN" \
+  https://<hub>/api/saas/admin/cluster-app-keys
+```
+
+Both routes are hub-admin only.
+
+### Why this has its own alert
+
+These credential states are classified **operator-side**, because the key is
+hub-distributed and the hive's owner cannot fix it. Every owner-facing surface
+therefore deliberately stands down: the spoke banner says "no action needed from
+you", journey nudges are suppressed, and advisory staleness is not flagged. All
+of that is correct — and the combined effect was that nobody was told at all.
+One hosted hive sat in `key-missing` for eight days with zero tokens consumed
+before an operator happened to hover its fleet row
+([#4316](https://github.com/kubestellar/hive/issues/4316)).
+
+The fleet now raises a **critical** `app-creds-undelivered` alert for a claimed
+hive reporting an operator-side App state, and the alert text names the upload
+endpoint above, with the cluster id filled in. It clears by itself once the key
+reaches the spoke.
+
+The three states it covers need different repairs:
+
+| State | What it means | Repair |
+| --- | --- | --- |
+| `key-missing` | No key ever reached the spoke; the hub holds none for the cluster. | Upload the PEM. |
+| `key-invalid` | A key is present but signs a JWT GitHub rejects — it belongs to a *different* App. | Upload the key for the App this hive is actually assigned. Re-uploading the same key does nothing. |
+| `no-app-assigned` | The hive still carries the placeholder `app_id`; no App was ever assigned. | Assign an App to the hive first, *then* upload the key. |
+
 ## API surface to know
 
 The hub registers heartbeat, registry, SaaS, contributor, OAuth, webhook, backup, and callback-related routes from the Go hub packages. Operators normally interact through the dashboard, but the important external contracts are:

--- a/src/pkg/hub/alerts.go
+++ b/src/pkg/hub/alerts.go
@@ -121,6 +121,23 @@ const (
 	// only after several consecutive 401s and clears on the next success — so
 	// the alert self-heals when the key is fixed.
 	AlertTypeInferenceAuthFailed = "inference-auth-failed"
+	// AlertTypeAppCredsUndelivered — the hive needs a GitHub App credential the
+	// HUB never delivered: key-missing, key-invalid, or no-app-assigned.
+	//
+	// This exists because those states are classified operator-side, and every
+	// other surface then correctly stands down. The owner banner says "no action
+	// needed from you", journey nudges are blocked, and advisory staleness is
+	// suppressed — all right, because the App private key is hub-distributed and
+	// the owner cannot fix it. The effect is that the ONLY actor who can repair
+	// it is the one actor no signal reached. kelly-headwaters was provisioned on
+	// 2026-08-12 and found degraded on 2026-08-20, eight days and zero tokens
+	// later, by an operator who happened to hover a fleet row.
+	//
+	// Critical, not warning: this is not a degraded hive, it is a hive that has
+	// provably never worked and cannot work until someone uploads a key. The
+	// reason carries the remedy, because an alert that names a condition an
+	// operator has to go research is most of the way to the silence it replaces.
+	AlertTypeAppCredsUndelivered = "app-creds-undelivered"
 )
 
 // --- Thresholds. Every one is a named constant with a rationale. ---
@@ -525,6 +542,16 @@ type alertHive struct {
 	// the alert when it is non-empty and drops it when it clears. Never carries
 	// key material.
 	InferenceAuthError string
+
+	// GitHubAppRequired / GitHubAppState / ClusterID back the
+	// app-creds-undelivered rule (#4316). Carried verbatim from the entry like
+	// every pair above: appStateIsOperatorSide is the single predicate the
+	// journey and drift paths already use, so the alert cannot disagree with the
+	// surfaces that deliberately stand down for these states. ClusterID is here
+	// only so the reason can name the exact upload endpoint.
+	GitHubAppRequired bool
+	GitHubAppState    string
+	ClusterID         string
 }
 
 // alertHiveFromEntry projects a MyHiveEntry into the evaluator's view.
@@ -554,6 +581,9 @@ func alertHiveFromEntry(h MyHiveEntry) alertHive {
 		InactiveAgentsReason: h.InactiveAgentsReason,
 
 		InferenceAuthError: h.InferenceAuthError,
+		GitHubAppRequired:  h.GitHubAppRequired,
+		GitHubAppState:     h.GitHubAppState,
+		ClusterID:          h.ClusterID,
 	}
 }
 
@@ -906,6 +936,24 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 			}
 		}
 
+		// --- Rule: the hub never delivered the App credential. ---
+		// The condition is NOT re-derived here: the spoke reports
+		// GitHubAppState, and appStateIsOperatorSide is the same predicate the
+		// journey and drift paths already use to decide "the owner cannot fix
+		// this" — so the alert cannot disagree with the surfaces that stood down.
+		// It self-heals: once a key is uploaded and reaches the spoke, the next
+		// beat reports a non-operator-side state and the alert clears.
+		//
+		// Deliberately NOT gated on the hive being online. An offline hive raises
+		// its own offline alert, and gating here would drop the credential alert
+		// exactly when the hive is worst off — still keyless, and now not even
+		// heartbeating. The two alerts answer different questions and an operator
+		// needs both.
+		if !h.IsPlaceholder && h.GitHubAppRequired && appStateIsOperatorSide(h.GitHubAppState) {
+			add(h.ID, h.Name, AlertTypeAppCredsUndelivered, AlertSeverityCritical,
+				appCredsUndeliveredReason(h.GitHubAppState, h.ClusterID))
+		}
+
 		// --- Rule: agents are running but not working. ---
 		// The condition is NOT re-derived here: it is precomputed by
 		// evaluateInactiveAgents(), which already excludes paused and
@@ -1250,6 +1298,51 @@ var knownAlertTypes = map[string]bool{
 	AlertTypeURLUnreachable:      true,
 	AlertTypeURLPrivateNetwork:   true,
 	AlertTypeInferenceAuthFailed: true,
+	AlertTypeAppCredsUndelivered: true,
 }
 
 func isKnownAlertType(t string) bool { return knownAlertTypes[t] }
+
+// appCredsUndeliveredReason renders the operator-facing cause for
+// AlertTypeAppCredsUndelivered (kubestellar/hive#4316).
+//
+// It names the remedy, not just the condition. The endpoint that fixes this
+// (PUT /api/saas/admin/cluster-app-keys/{clusterID}) exists but is documented
+// nowhere and has no UI, so an alert that said only "credentials undelivered"
+// would leave the operator exactly as stuck as the silence did — they would
+// have to go read cluster_app_key.go to find out what to do.
+//
+// The three states have genuinely different repairs, so they get genuinely
+// different sentences rather than one generic line:
+//
+//   - key-missing: the hub holds no key for this hive's cluster. Upload one.
+//   - key-invalid: a key IS present but signs a JWT GitHub rejects, i.e. it
+//     belongs to a different App than the hive claims to be. Replacing it is
+//     the fix; uploading the same key again is not.
+//   - no-app-assigned: the hive still carries the placeholder app_id and was
+//     never assigned a real App at all, which a key upload alone does not fix.
+//
+// clusterID is interpolated when known so the operator can act without first
+// looking it up; when the record carries none, the path is shown with its
+// placeholder rather than a misleading empty segment.
+func appCredsUndeliveredReason(state, clusterID string) string {
+	target := strings.TrimSpace(clusterID)
+	if target == "" {
+		target = "{clusterID}"
+	}
+	upload := "upload the App private key: PUT /api/saas/admin/cluster-app-keys/" + target
+
+	switch strings.TrimSpace(state) {
+	case appStateKeyMissingToken:
+		return "GitHub App key was never delivered by the hub — the hive cannot authenticate and will do no work until it is; " + upload
+	case appStateKeyInvalidToken:
+		return "GitHub App key delivered by the hub is rejected by GitHub (it signs a JWT for a different App) — " + upload + " with the key for the App this hive is assigned"
+	case appStateNoAppAssignedToken:
+		return "hive was never assigned a GitHub App (still on the placeholder app_id) — assign an App to this hive, then " + upload
+	default:
+		// Not reached while the caller gates on appStateIsOperatorSide, but a
+		// future token added to that set must still produce a usable sentence
+		// rather than an empty reason.
+		return "GitHub App credentials are undelivered (state " + state + ") — " + upload
+	}
+}

--- a/src/pkg/hub/alerts_app_creds_test.go
+++ b/src/pkg/hub/alerts_app_creds_test.go
@@ -1,0 +1,170 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── app-creds-undelivered (#4316) ───────────────────────────────────────────
+//
+// kelly-headwaters was provisioned 2026-08-12 and found degraded 2026-08-20 —
+// eight days, zero tokens, nobody told. The states involved are operator-side,
+// so the owner banner, the journey nudges and advisory staleness all correctly
+// stand down; the effect was that the one actor who could fix it was the one
+// actor no signal reached. These tests pin that the fleet alert closes that gap
+// without re-opening the surfaces that were right to stay quiet.
+
+func appCredsHive(state string, required bool) alertHive {
+	return alertHive{
+		ID:                "hosted-kelly-headwaters",
+		Name:              "kelly-headwaters",
+		Online:            true,
+		LastHeartbeat:     rfc3339(fixedNow),
+		GitHubAppRequired: required,
+		GitHubAppState:    state,
+		ClusterID:         "oke-260812",
+	}
+}
+
+// TestAppCredsAlertFiresForEveryOperatorSideState is the core of the fix: all
+// three states the owner cannot repair must reach the operator.
+func TestAppCredsAlertFiresForEveryOperatorSideState(t *testing.T) {
+	for _, state := range []string{appStateKeyMissingToken, appStateKeyInvalidToken, appStateNoAppAssignedToken} {
+		t.Run(state, func(t *testing.T) {
+			got := evaluateAlerts(newAlertState(), []alertHive{appCredsHive(state, true)}, nil, fixedNow)
+
+			a, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeAppCredsUndelivered)
+			if !ok {
+				t.Fatalf("no app-creds-undelivered alert for state %q — the operator gets no signal, which is the bug", state)
+			}
+			if a.Severity != AlertSeverityCritical {
+				t.Errorf("severity = %q, want critical: the hive provably cannot work at all", a.Severity)
+			}
+			if !strings.Contains(a.Reason, "cluster-app-keys/oke-260812") {
+				t.Errorf("reason does not name the remedy endpoint with the cluster id: %q", a.Reason)
+			}
+		})
+	}
+}
+
+// TestAppCredsAlertIgnoresOwnerFixableStates is the guard that keeps this from
+// re-opening what the other surfaces deliberately closed. A state the OWNER can
+// fix (App not installed yet) is not an operator problem and must not page an
+// operator — the journey nudge already handles it.
+func TestAppCredsAlertIgnoresOwnerFixableStates(t *testing.T) {
+	for _, state := range []string{"not-installed", "installed", "", "ok", "suspended"} {
+		t.Run("state="+state, func(t *testing.T) {
+			got := evaluateAlerts(newAlertState(), []alertHive{appCredsHive(state, true)}, nil, fixedNow)
+			if a, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeAppCredsUndelivered); ok {
+				t.Fatalf("state %q is not operator-side; alerting on it pages an operator for something the OWNER fixes: %q", state, a.Reason)
+			}
+		})
+	}
+}
+
+// TestAppCredsAlertRequiresTheAppToBeRequired pins that a hive not using a
+// GitHub App at all never raises this, whatever stale state string it carries.
+func TestAppCredsAlertRequiresTheAppToBeRequired(t *testing.T) {
+	got := evaluateAlerts(newAlertState(), []alertHive{appCredsHive(appStateKeyMissingToken, false)}, nil, fixedNow)
+	if a, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeAppCredsUndelivered); ok {
+		t.Fatalf("a hive that does not require an App must not alert: %q", a.Reason)
+	}
+}
+
+// TestAppCredsAlertSkipsPlaceholders pins the guard every claimed-hive rule
+// applies: an unassigned pool slot has no App and no owner, and flagging it
+// would bury the real ones.
+func TestAppCredsAlertSkipsPlaceholders(t *testing.T) {
+	h := appCredsHive(appStateKeyMissingToken, true)
+	h.IsPlaceholder = true
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	if a, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeAppCredsUndelivered); ok {
+		t.Fatalf("an unassigned pool slot must not alert: %q", a.Reason)
+	}
+}
+
+// TestAppCredsAlertSelfHeals pins that uploading a key clears the alert on the
+// next beat, with no hub-side timer to keep in sync.
+func TestAppCredsAlertSelfHeals(t *testing.T) {
+	state := newAlertState()
+
+	got := evaluateAlerts(state, []alertHive{appCredsHive(appStateKeyMissingToken, true)}, nil, fixedNow)
+	if _, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeAppCredsUndelivered); !ok {
+		t.Fatal("expected the alert to fire while the key is missing")
+	}
+
+	// Operator uploads the key; the spoke now reports a healthy state.
+	got = evaluateAlerts(state, []alertHive{appCredsHive("installed", true)}, nil, fixedNow)
+	if a, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeAppCredsUndelivered); ok {
+		t.Fatalf("the alert must clear once the credential lands, got %q", a.Reason)
+	}
+}
+
+// TestAppCredsAlertFiresWhileOffline pins a deliberate deviation from the
+// issue's wording, which said "claimed, ONLINE hive".
+//
+// Gating on online would drop the credential alert exactly when the hive is
+// worst off — still keyless AND no longer heartbeating. The offline rule raises
+// its own alert for the second half; this one is the only thing that says WHY
+// the hive never worked, and an operator needs both.
+func TestAppCredsAlertFiresWhileOffline(t *testing.T) {
+	h := appCredsHive(appStateKeyMissingToken, true)
+	h.Online = false
+	h.LastHeartbeat = rfc3339(fixedNow.Add(-2 * alertOfflineThreshold))
+
+	got := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	if _, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeAppCredsUndelivered); !ok {
+		t.Fatal("an offline keyless hive still needs its key uploaded; the credential alert must not be suppressed by being offline")
+	}
+	if _, ok := findAlert(got.Alerts, "hosted-kelly-headwaters", AlertTypeOffline); !ok {
+		t.Error("the offline rule should still fire independently — the two answer different questions")
+	}
+}
+
+// TestAppCredsReasonNamesTheRightRepair pins that the three states get
+// different sentences. They have genuinely different repairs, and a generic
+// "credentials undelivered" would leave an operator as stuck as the silence
+// did — the upload endpoint is documented nowhere and has no UI.
+func TestAppCredsReasonNamesTheRightRepair(t *testing.T) {
+	missing := appCredsUndeliveredReason(appStateKeyMissingToken, "c1")
+	invalid := appCredsUndeliveredReason(appStateKeyInvalidToken, "c1")
+	noApp := appCredsUndeliveredReason(appStateNoAppAssignedToken, "c1")
+
+	if missing == invalid || invalid == noApp || missing == noApp {
+		t.Fatal("the three states have different repairs and must not share one sentence")
+	}
+	// key-invalid must not read as "upload the key" — the same key again is not
+	// the fix.
+	if !strings.Contains(invalid, "different App") {
+		t.Errorf("key-invalid reason should say the key belongs to another App: %q", invalid)
+	}
+	// no-app-assigned needs an App assigned first; a key upload alone is not enough.
+	if !strings.Contains(noApp, "assign") {
+		t.Errorf("no-app-assigned reason should say to assign an App: %q", noApp)
+	}
+	for _, r := range []string{missing, invalid, noApp} {
+		if !strings.Contains(r, "PUT /api/saas/admin/cluster-app-keys/c1") {
+			t.Errorf("reason does not carry the actionable endpoint: %q", r)
+		}
+	}
+}
+
+// TestAppCredsReasonWithoutClusterID pins that a record with no cluster id
+// still yields a usable sentence rather than a path with an empty segment.
+func TestAppCredsReasonWithoutClusterID(t *testing.T) {
+	r := appCredsUndeliveredReason(appStateKeyMissingToken, "")
+	if strings.Contains(r, "cluster-app-keys/ ") || strings.HasSuffix(r, "cluster-app-keys/") {
+		t.Fatalf("empty cluster id produced a malformed endpoint: %q", r)
+	}
+	if !strings.Contains(r, "{clusterID}") {
+		t.Errorf("expected the placeholder when the cluster is unknown: %q", r)
+	}
+}
+
+// TestAppCredsAlertTypeIsRegistered pins the ack/severity pipeline wiring: an
+// unregistered type is dropped, so the alert would never reach an operator.
+func TestAppCredsAlertTypeIsRegistered(t *testing.T) {
+	if !knownAlertTypes[AlertTypeAppCredsUndelivered] {
+		t.Fatal("app-creds-undelivered is not in knownAlertTypes — it would be filtered out before anyone saw it")
+	}
+}


### PR DESCRIPTION
Refs #4316. Picks up the main ask left after #4318 (merged) fixed the `github_auth` health check and added the WARN — neither of which is an alert.

## The gap

kelly-headwaters: provisioned 2026-08-12, found **Degraded** 2026-08-20. Eight days, zero tokens ever consumed, discovered because an operator happened to hover a fleet row.

That was structural. The `key-missing` / `key-invalid` / `no-app-assigned` states are classified **operator-side** — correctly, since the App private key is hub-distributed and the owner cannot fix it. Every owner-facing surface then deliberately stands down: the spoke banner says "no action needed from you", journey nudges are blocked, advisory staleness is suppressed. Each of those is right *on its own*. Together they meant the only actor who could repair it was the only actor no signal reached.

## What this adds

`AlertTypeAppCredsUndelivered`, raised **critical** for a claimed hive reporting `GitHubAppRequired` with an operator-side `GitHubAppState`, flowing through the existing ack/severity pipeline in `evaluateAlerts`.

Critical rather than warning because this isn't a degraded hive — it's one that has provably never worked and cannot until someone uploads a key.

**The condition is not re-derived.** It reuses `appStateIsOperatorSide`, the same predicate the journey and drift paths already use, so the alert cannot drift apart from the surfaces that stood down. It self-heals: once a key reaches the spoke the next beat reports a healthy state and the alert clears — no hub-side timer to keep in sync.

**The reason carries the remedy.** `PUT /api/saas/admin/cluster-app-keys/{clusterID}` exists but is documented nowhere and has no UI, so an alert naming only the condition would leave the operator as stuck as the silence did. The cluster id is interpolated so they can act without looking it up.

The three states get three different sentences because they have three genuinely different repairs — re-uploading the same key does nothing for `key-invalid`, and `no-app-assigned` needs an App assigned *before* a key helps at all.

## One deliberate deviation, flagged for you

The issue specifies "a claimed, **online** hive". **I did not gate on online.**

Gating there would drop the credential alert exactly when the hive is worst off — still keyless *and* no longer heartbeating. The offline rule raises its own alert for that half; this one is the only thing that says *why* the hive never worked, and an operator needs both. A test pins that they fire together.

Trivial to add the gate if you disagree — say so and I'll push it.

## Docs

An operator runbook in `hub-deployment.md`: the PEM store path, both admin endpoints with working `curl`, why the alert exists, and a table mapping each state to its actual repair.

Written from the code, not the issue — I verified `requireAdmin` gating on both routes and `clusterAppKeyDir = "/data/saas/app-keys"` before documenting them.

## Not done

The **optional** `has_key=false` column on the admin clusters view, so a keyless cluster is visible *before* the first claim strands a hive. That's UI work, marked optional in the issue, and complements this rather than substituting for it.

## Tests

The negative cases are the ones that matter — this must not re-open what the other surfaces correctly closed:

| Case | Expected |
|---|---|
| `key-missing`, `key-invalid`, `no-app-assigned` | **alert**, critical, remedy in the reason |
| `not-installed`, `installed`, `""`, `ok`, `suspended` | **no alert** — owner-fixable, the journey nudge owns those |
| Placeholder (unassigned pool slot) | no alert |
| App not required | no alert |
| Key uploaded → healthy state | alert clears |
| Offline + keyless | credential alert **and** offline alert |
| Registered in `knownAlertTypes` | yes — without it the alert is filtered out before anyone sees it |

Verified genuinely RED by disabling the rule (5 tests fail). `go test ./pkg/hub/` green (92s, full suite); `go vet` clean.

— hive: backend=claude model=claude-opus-5
