### PR TITLE
🐛 fix(hub): alert the operator when a hosted hive is stuck on operator-side App-credential states

### DIFF
--- a/src/docs/github-app-setup.md
+++ b/src/docs/github-app-setup.md
@@ -71,3 +71,46 @@ The setup endpoint is intentionally public because GitHub opens it in a browser 
 ## Rotation and recovery
 
 To rotate a private key, generate a new key in GitHub, mount it at the configured `key_file`, restart Hive, then delete the old key in GitHub after the new one is confirmed working. If an installation was replaced, use `/gh-setup` again or update `github.installation_id` and restart/reload the hive.
+
+## Hub-distributed App keys (hosted fleet) — operator runbook
+
+On a hosted fleet the hub — not the hive owner — is the App-key authority. The hub keeps one PEM per cluster at `/data/saas/app-keys/<clusterID>.pem` (owner-only file modes, on the same PVC as the hub's other secrets) and reconciles it to every spoke on that cluster over the heartbeat. A claimed hive whose cluster has no stored key is delivered `key_delivered=false` at claim time and then receives nothing on any beat — it stays `Degraded` on `key-missing` forever until an operator uploads a key. **The hive owner cannot see, supply, or fix this key**; every owner-facing surface deliberately stays silent for the operator-side states (`key-missing`, `key-invalid`, `no-app-assigned`).
+
+### Uploading (or replacing) a cluster's App key
+
+The upload endpoint is the ONLY way key material enters the hub. Admin-gated:
+
+```
+PUT /api/saas/admin/cluster-app-keys/{clusterID}
+Content-Type: application/json
+
+{"private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----", "app_id": 123456}
+```
+
+- `private_key` (required) — the GitHub App's PEM private key. Validated before it is persisted; a non-PEM or unparsable key is rejected with 400 and nothing is stored.
+- `app_id` (optional) — the App's numeric ID; when supplied it is persisted alongside in `clusters.json` so the cluster carries a complete identity.
+- An unknown `{clusterID}` returns 404.
+
+The response echoes back only the key's **fingerprint** (never the key), so you can verify the right key landed:
+
+```json
+{"cluster_id": "oke-frankfurt-1", "app_id": 123456, "has_key": true, "fingerprint": "sha256:..."}
+```
+
+Compare that fingerprint with one computed locally from the PEM you meant to upload. Delivery to the spokes then happens automatically on the next heartbeats — no restart needed.
+
+### Checking which clusters hold a key
+
+```
+GET /api/saas/admin/cluster-app-keys
+```
+
+returns `[{cluster_id, app_id, has_key, fingerprint}, ...]` for every cluster. A cluster with `has_key: false` will strand the first App-requiring hive claimed onto it — check this *before* pointing a pool at a new cluster.
+
+### The `app-creds-undelivered` fleet alert
+
+When a claimed, online hive reports an operator-side App-credential state, the hub raises a **critical** fleet alert (type `app-creds-undelivered`) in the dashboard's "Attention needed" panel. The alert names the hive and its cluster, shows how long it has been stranded, and carries the exact `PUT` remedy above. One alert per hive; it clears automatically once the key is delivered and the spoke reports healthy. The states it covers:
+
+- `key-missing` — no key ever reached the spoke (usually: the cluster has no stored PEM — upload one).
+- `key-invalid` — a key is present but GitHub rejects the JWTs it signs (it belongs to a different App — replace it with the correct PEM).
+- `no-app-assigned` — the hive still carries the placeholder `app_id` and was never assigned a real App (assign the cluster's App and upload its key).

--- a/src/pkg/hub/alerts.go
+++ b/src/pkg/hub/alerts.go
@@ -121,6 +121,23 @@ const (
 	// only after several consecutive 401s and clears on the next success — so
 	// the alert self-heals when the key is fixed.
 	AlertTypeInferenceAuthFailed = "inference-auth-failed"
+	// AlertTypeAppCredsUndelivered — a claimed, online hive requires GitHub App
+	// auth but reports an OPERATOR-SIDE credential state (key-missing,
+	// key-invalid or no-app-assigned; see operatorSideAppStates in journey.go).
+	// The hive owner cannot see, supply or correct the App private key — it is
+	// hub-distributed — so every owner-facing surface deliberately stands down
+	// for these states (the spoke banner says "no action needed from you", the
+	// journey never nudges, advisory staleness is suppressed). That made the
+	// condition structurally silent: kelly-headwaters sat Degraded on
+	// key-missing for 8 days with zero tokens ever consumed before an operator
+	// happened to hover the fleet row (#4316). This alert is the ACTIVE signal
+	// to the only actor who can fix it. Critical, because the hive provably
+	// cannot work at all until the key lands. The reason names the cluster and
+	// carries the exact remedy (PUT /api/saas/admin/cluster-app-keys/{id});
+	// FirstSeen shows the operator how long the hive has been stranded. Clears
+	// on its own once the key is delivered and the spoke reports a healthy
+	// state.
+	AlertTypeAppCredsUndelivered = "app-creds-undelivered"
 )
 
 // --- Thresholds. Every one is a named constant with a rationale. ---
@@ -525,6 +542,20 @@ type alertHive struct {
 	// the alert when it is non-empty and drops it when it clears. Never carries
 	// key material.
 	InferenceAuthError string
+
+	// GitHubAppRequired / GitHubAppState are the spoke's own report of whether
+	// its config demands App auth and, when App auth is failing, WHY (the
+	// github.AppAuthState wire token). Carried verbatim: the spoke owns the
+	// classification, and appStateIsOperatorSide (journey.go) owns which tokens
+	// mean "only the hub operator can fix this". ClusterID names the cluster
+	// whose key store is the remedy. ClusterHasKey is hub-observed fact — set
+	// by fleetAlerts from the per-cluster PEM store, never by
+	// alertHiveFromEntry — so the reason can say whether the fix is "upload a
+	// key" (none exists) or "the delivered key is wrong / not arriving".
+	GitHubAppRequired bool
+	GitHubAppState    string
+	ClusterID         string
+	ClusterHasKey     bool
 }
 
 // alertHiveFromEntry projects a MyHiveEntry into the evaluator's view.
@@ -554,6 +585,12 @@ func alertHiveFromEntry(h MyHiveEntry) alertHive {
 		InactiveAgentsReason: h.InactiveAgentsReason,
 
 		InferenceAuthError: h.InferenceAuthError,
+
+		GitHubAppRequired: h.GitHubAppRequired,
+		GitHubAppState:    h.GitHubAppState,
+		ClusterID:         h.ClusterID,
+		// ClusterHasKey is NOT set here: it is hub-observed (the PEM store on
+		// disk), not entry-carried. fleetAlerts fills it in.
 	}
 }
 
@@ -706,6 +743,45 @@ func withoutAuthClassChecks(names []string) []string {
 		}
 	}
 	return kept
+}
+
+// appCredsUndeliveredReason builds the operator-facing reason for an
+// app-creds-undelivered alert. It names the failing state, the cluster, and —
+// critically — the exact remedy, because the upload endpoint was undocumented
+// for long enough that a stranded hive sat unnoticed for 8 days (#4316). The
+// string is deterministic for a given hive state, so the alert never appears
+// to churn between polls. It never carries key material; ClusterHasKey and the
+// state token are the only key-related facts referenced.
+func appCredsUndeliveredReason(h alertHive) string {
+	cluster := strings.TrimSpace(h.ClusterID)
+	clusterLabel := cluster
+	if clusterLabel == "" {
+		clusterLabel = "its cluster"
+	}
+	pathID := cluster
+	if pathID == "" {
+		// No cluster reported (a spoke too old, or a registry gap): the remedy
+		// still names the endpoint, with the placeholder the operator must
+		// fill in.
+		pathID = "{clusterID}"
+	}
+	remedy := "PUT /api/saas/admin/cluster-app-keys/" + pathID + " with the App's PEM private key"
+
+	switch strings.TrimSpace(h.GitHubAppState) {
+	case appStateKeyInvalidToken:
+		return "GitHub App private key on this spoke does not match the App it authenticates as, so GitHub rejects every JWT it signs — " +
+			"only an operator can fix this: replace the key for " + clusterLabel + " via " + remedy
+	case appStateNoAppAssignedToken:
+		return "No real GitHub App was ever assigned to this hive (it still carries the placeholder app_id) — " +
+			"only an operator can fix this: assign the cluster's App and upload its key via " + remedy
+	default: // appStateKeyMissingToken, and any future operator-side token.
+		if h.ClusterHasKey {
+			return "GitHub App private key has not reached this spoke even though the hub holds a key for " + clusterLabel + " — " +
+				"check heartbeat delivery, or re-upload via " + remedy
+		}
+		return "GitHub App private key was never delivered: the hub holds no key for " + clusterLabel + " — " +
+			"only an operator can fix this: upload it via " + remedy
+	}
 }
 
 // fleetMedianTokens returns the median TotalTokens24h across claimed, online
@@ -906,6 +982,22 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 			}
 		}
 
+		// --- Rule: GitHub App credentials are in an operator-side state. ---
+		// Claimed and ONLINE only: a placeholder has no App by design, and an
+		// offline hive's last-reported state is stale (and already raises
+		// offline, which is the actionable fact). Gated on the spoke's OWN
+		// GitHubAppRequired verdict plus an operator-side GitHubAppState
+		// (key-missing / key-invalid / no-app-assigned) — the exact states
+		// every owner-facing surface deliberately silences, which is why an
+		// operator alert is the ONLY active signal for them (#4316). Critical:
+		// the hive provably cannot work until the hub delivers a usable key.
+		// Self-clears once the key lands and the spoke stops reporting the
+		// state; the standard retention pass drops the condition and its ack.
+		if !h.IsPlaceholder && h.Online && h.GitHubAppRequired && appStateIsOperatorSide(h.GitHubAppState) {
+			add(h.ID, h.Name, AlertTypeAppCredsUndelivered, AlertSeverityCritical,
+				appCredsUndeliveredReason(h))
+		}
+
 		// --- Rule: agents are running but not working. ---
 		// The condition is NOT re-derived here: it is precomputed by
 		// evaluateInactiveAgents(), which already excludes paused and
@@ -1076,6 +1168,24 @@ func (s *HubServer) fleetAlerts(entries []MyHiveEntry) AlertSummary {
 	hives := make([]alertHive, 0, len(entries))
 	for _, e := range entries {
 		hives = append(hives, alertHiveFromEntry(e))
+	}
+	// ClusterHasKey is hub-observed fact (the per-cluster PEM store on disk),
+	// so it is stamped here rather than in alertHiveFromEntry, which must stay
+	// constructible in unit tests without a HubServer or a filesystem. One
+	// read per DISTINCT cluster per evaluation, not per hive — a fleet shares
+	// a handful of clusters.
+	keyByCluster := map[string]bool{}
+	for i := range hives {
+		cid := strings.TrimSpace(hives[i].ClusterID)
+		if cid == "" {
+			continue
+		}
+		hasKey, seen := keyByCluster[cid]
+		if !seen {
+			hasKey = loadClusterAppKey(cid) != ""
+			keyByCluster[cid] = hasKey
+		}
+		hives[i].ClusterHasKey = hasKey
 	}
 	// driftAlerts is nil today. When the config-drift evaluator lands, its
 	// signals are passed here and flow through the same ordering, ack and
@@ -1250,6 +1360,7 @@ var knownAlertTypes = map[string]bool{
 	AlertTypeURLUnreachable:      true,
 	AlertTypeURLPrivateNetwork:   true,
 	AlertTypeInferenceAuthFailed: true,
+	AlertTypeAppCredsUndelivered: true,
 }
 
 func isKnownAlertType(t string) bool { return knownAlertTypes[t] }

--- a/src/pkg/hub/alerts_app_creds_test.go
+++ b/src/pkg/hub/alerts_app_creds_test.go
@@ -1,0 +1,242 @@
+package hub
+
+// Tests for the app-creds-undelivered alert (#4316): a claimed, online hive
+// reporting an OPERATOR-SIDE GitHub App credential state must actively alert
+// the hub operator, because every owner-facing surface deliberately stands
+// down for these states — kelly-headwaters sat Degraded on key-missing for 8
+// days with zero signal reaching the only actor who could fix it.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// appCredsHive is baseHive plus the App-credential fields under test.
+func appCredsHive(id, state string) alertHive {
+	h := baseHive(id)
+	h.GitHubAppRequired = true
+	h.GitHubAppState = state
+	h.ClusterID = "oke-frankfurt-1"
+	return h
+}
+
+func TestEvaluateAlerts_AppCredsUndeliveredRule(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*alertHive)
+		want   bool
+	}{
+		{name: "key-missing on a claimed online hive fires", mutate: func(h *alertHive) {}, want: true},
+		{name: "key-invalid fires", mutate: func(h *alertHive) { h.GitHubAppState = appStateKeyInvalidToken }, want: true},
+		{name: "no-app-assigned fires", mutate: func(h *alertHive) { h.GitHubAppState = appStateNoAppAssignedToken }, want: true},
+		{name: "state token survives surrounding whitespace", mutate: func(h *alertHive) { h.GitHubAppState = "  key-missing  " }, want: true},
+		{name: "an owner-side state does not fire", mutate: func(h *alertHive) { h.GitHubAppState = "not-installed" }, want: false},
+		{name: "an empty state does not fire", mutate: func(h *alertHive) { h.GitHubAppState = "" }, want: false},
+		{name: "a hive that never asked for App auth does not fire", mutate: func(h *alertHive) { h.GitHubAppRequired = false }, want: false},
+		{name: "a placeholder does not fire", mutate: func(h *alertHive) { h.IsPlaceholder = true }, want: false},
+		{name: "an offline hive does not fire on its stale state", mutate: func(h *alertHive) { h.Online = false }, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := appCredsHive("h1", appStateKeyMissingToken)
+			tc.mutate(&h)
+			summary := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+			a, got := findAlert(summary.Alerts, "h1", AlertTypeAppCredsUndelivered)
+			if got != tc.want {
+				t.Fatalf("alert fired = %v, want %v", got, tc.want)
+			}
+			if got && a.Severity != AlertSeverityCritical {
+				t.Errorf("severity = %q, want %q — the hive provably cannot work", a.Severity, AlertSeverityCritical)
+			}
+		})
+	}
+}
+
+// TestAppCredsUndeliveredReason_CarriesTheRemedy locks the operator-facing
+// content: every variant must name the exact PUT endpoint (the remedy was
+// undocumented, which is half of how #4316 stayed silent), and the key-missing
+// text must say whether the hub even holds a key for the cluster.
+func TestAppCredsUndeliveredReason_CarriesTheRemedy(t *testing.T) {
+	const remedy = "PUT /api/saas/admin/cluster-app-keys/oke-frankfurt-1"
+
+	tests := []struct {
+		name    string
+		state   string
+		hasKey  bool
+		want    []string
+		notWant []string
+	}{
+		{
+			name:  "key-missing with no hub key says upload",
+			state: appStateKeyMissingToken,
+			want:  []string{remedy, "holds no key for oke-frankfurt-1", "only an operator can fix this"},
+		},
+		{
+			name:    "key-missing with a hub key says delivery is stuck, not upload-a-key",
+			state:   appStateKeyMissingToken,
+			hasKey:  true,
+			want:    []string{remedy, "even though the hub holds a key"},
+			notWant: []string{"holds no key"},
+		},
+		{
+			name:  "key-invalid says replace",
+			state: appStateKeyInvalidToken,
+			want:  []string{remedy, "does not match the App", "replace the key"},
+		},
+		{
+			name:  "no-app-assigned says assign",
+			state: appStateNoAppAssignedToken,
+			want:  []string{remedy, "placeholder app_id", "assign the cluster's App"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := appCredsHive("h1", tc.state)
+			h.ClusterHasKey = tc.hasKey
+			reason := appCredsUndeliveredReason(h)
+			for _, w := range tc.want {
+				if !strings.Contains(reason, w) {
+					t.Errorf("reason %q does not contain %q", reason, w)
+				}
+			}
+			for _, nw := range tc.notWant {
+				if strings.Contains(reason, nw) {
+					t.Errorf("reason %q must not contain %q", reason, nw)
+				}
+			}
+		})
+	}
+}
+
+// TestAppCredsUndeliveredReason_UnknownClusterStillNamesTheEndpoint covers a
+// spoke too old (or too wedged) to report its cluster: the remedy must still
+// name the endpoint, with the path placeholder the operator has to fill in.
+func TestAppCredsUndeliveredReason_UnknownClusterStillNamesTheEndpoint(t *testing.T) {
+	h := appCredsHive("h1", appStateKeyMissingToken)
+	h.ClusterID = ""
+	reason := appCredsUndeliveredReason(h)
+	if !strings.Contains(reason, "PUT /api/saas/admin/cluster-app-keys/{clusterID}") {
+		t.Errorf("reason %q must still name the upload endpoint", reason)
+	}
+	if !strings.Contains(reason, "its cluster") {
+		t.Errorf("reason %q must not render a blank cluster name", reason)
+	}
+}
+
+// TestAppCredsUndelivered_DedupesToOneAlertPerHive is the dedupe guarantee:
+// re-evaluating the same stranded hive produces exactly one alert with a
+// STABLE FirstSeen, so the panel shows one row whose age keeps growing — never
+// a fresh-looking alert every poll (8 days of degradation must read as 8 days).
+func TestAppCredsUndelivered_DedupesToOneAlertPerHive(t *testing.T) {
+	state := newAlertState()
+	h := appCredsHive("h1", appStateKeyMissingToken)
+
+	first := evaluateAlerts(state, []alertHive{h}, nil, fixedNow)
+	later := evaluateAlerts(state, []alertHive{h}, nil, fixedNow.Add(8*24*time.Hour))
+
+	count := 0
+	for _, a := range later.Alerts {
+		if a.HiveID == "h1" && a.Type == AlertTypeAppCredsUndelivered {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("alert count = %d, want exactly 1", count)
+	}
+	a1, _ := findAlert(first.Alerts, "h1", AlertTypeAppCredsUndelivered)
+	a2, _ := findAlert(later.Alerts, "h1", AlertTypeAppCredsUndelivered)
+	if !a1.FirstSeen.Equal(a2.FirstSeen) {
+		t.Errorf("FirstSeen moved from %v to %v while the condition held", a1.FirstSeen, a2.FirstSeen)
+	}
+}
+
+// TestAppCredsUndelivered_ClearsWhenTheKeyLands is the self-heal guarantee: the
+// moment the spoke stops reporting an operator-side state (the key was
+// delivered and works), the alert disappears — and its acknowledgement is
+// forgotten, so a RE-occurrence alerts again rather than staying silenced.
+func TestAppCredsUndelivered_ClearsWhenTheKeyLands(t *testing.T) {
+	state := newAlertState()
+	stranded := appCredsHive("h1", appStateKeyMissingToken)
+
+	summary := evaluateAlerts(state, []alertHive{stranded}, nil, fixedNow)
+	if !hasAlert(summary.Alerts, "h1", AlertTypeAppCredsUndelivered) {
+		t.Fatal("precondition: alert must fire while stranded")
+	}
+	if !state.setAck("h1", AlertTypeAppCredsUndelivered, "op", fixedNow) {
+		t.Fatal("precondition: ack must succeed on a live condition")
+	}
+
+	// The key lands: the spoke reports App auth healthy.
+	healed := appCredsHive("h1", "")
+	healed.GitHubAppRequired = true
+	summary = evaluateAlerts(state, []alertHive{healed}, nil, fixedNow.Add(time.Minute))
+	if hasAlert(summary.Alerts, "h1", AlertTypeAppCredsUndelivered) {
+		t.Fatal("alert must clear once the spoke reports a healthy state")
+	}
+
+	// It breaks again (key rotated to a wrong one): the old ack must not
+	// silence the new occurrence.
+	broken := appCredsHive("h1", appStateKeyInvalidToken)
+	summary = evaluateAlerts(state, []alertHive{broken}, nil, fixedNow.Add(2*time.Minute))
+	a, ok := findAlert(summary.Alerts, "h1", AlertTypeAppCredsUndelivered)
+	if !ok {
+		t.Fatal("alert must re-fire on a re-occurrence")
+	}
+	if a.Acknowledged {
+		t.Error("a cleared condition's ack must not silence its re-occurrence")
+	}
+}
+
+// TestFleetAlerts_StampsClusterHasKey verifies the hub-observed half of the
+// reason: fleetAlerts consults the per-cluster PEM store so key-missing reads
+// "the hub holds no key" only when that is actually true on disk.
+func TestFleetAlerts_StampsClusterHasKey(t *testing.T) {
+	dir := withTempAppKeyDir(t)
+	if err := os.WriteFile(filepath.Join(dir, "with-key.pem"),
+		[]byte("-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestAlertServer()
+	mk := func(id, clusterID string) MyHiveEntry {
+		var e MyHiveEntry
+		e.ID = id
+		e.Name = "org/" + id
+		e.Online = true
+		e.LastHeartbeat = rfc3339(time.Now())
+		e.GitHubAppRequired = true
+		e.GitHubAppState = appStateKeyMissingToken
+		e.ClusterID = clusterID
+		return e
+	}
+
+	summary := s.fleetAlerts([]MyHiveEntry{mk("h1", "with-key"), mk("h2", "no-key")})
+
+	withKey, ok := findAlert(summary.Alerts, "h1", AlertTypeAppCredsUndelivered)
+	if !ok {
+		t.Fatal("h1 must alert")
+	}
+	if !strings.Contains(withKey.Reason, "even though the hub holds a key") {
+		t.Errorf("h1 reason %q must reflect the stored key", withKey.Reason)
+	}
+	noKey, ok := findAlert(summary.Alerts, "h2", AlertTypeAppCredsUndelivered)
+	if !ok {
+		t.Fatal("h2 must alert")
+	}
+	if !strings.Contains(noKey.Reason, "holds no key for no-key") {
+		t.Errorf("h2 reason %q must say the hub holds no key", noKey.Reason)
+	}
+}
+
+// TestAppCredsUndeliveredAlertHasADashboardLabel mirrors the failed-upgrade
+// guard: without a label the chip renders the raw key 'app-creds-undelivered'.
+func TestAppCredsUndeliveredAlertHasADashboardLabel(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "'"+AlertTypeAppCredsUndelivered+"': 'App credentials undelivered'") {
+		t.Errorf("ALERT_TYPE_LABELS has no entry for %q", AlertTypeAppCredsUndelivered)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -12010,7 +12010,12 @@ const dashboardHTML = `<!DOCTYPE html>
       /* The hive's inference gateway is rejecting every call with 401 (a stale
          key) — the ROOT cause of an otherwise silent outage where the hive
          looks online but every agent is dead in the water. */
-      'inference-auth-failed': 'Inference auth failing'
+      'inference-auth-failed': 'Inference auth failing',
+      /* GitHub App credentials are in an operator-side state (key-missing /
+         key-invalid / no-app-assigned). The owner cannot fix these — the App
+         key is hub-distributed — so this alert is the operator's only active
+         signal (#4316). The reason carries the PUT remedy. */
+      'app-creds-undelivered': 'App credentials undelivered'
     };
 
     /* How many alert rows are listed before the panel collapses the remainder


### PR DESCRIPTION
## What

Closes #4316.

kelly-headwaters sat **Degraded on `key-missing` for 8 days** with zero tokens ever consumed, because the operator-side App-credential states (`key-missing` / `key-invalid` / `no-app-assigned`) are structurally silent: the owner surfaces deliberately stand down (correct — the owner cannot fix a hub-distributed key), no fleet alert type existed, and `github_auth` passed while the key was missing (fixed in #4318). The only actor who can fix it — the hub operator — was the only actor no signal reached.

## Alert design

New **critical** fleet alert type `app-creds-undelivered` (`src/pkg/hub/alerts.go`), flowing through the existing `evaluateAlerts` pipeline exactly like every other type:

- **Raise**: claimed (non-placeholder), **online** hive with `GitHubAppRequired` and an operator-side `GitHubAppState` (`appStateIsOperatorSide`, journey.go — the single shared predicate).
- **Reason carries the remedy**: names the cluster and the exact fix, `PUT /api/saas/admin/cluster-app-keys/{clusterID}`. `fleetAlerts` stamps hub-observed `ClusterHasKey` from the per-cluster PEM store (one disk read per **distinct** cluster per evaluation), so `key-missing` reads *"the hub holds no key for X — upload it"* vs *"a key exists but is not arriving — check delivery / re-upload"*; `key-invalid` says replace; `no-app-assigned` says assign the App.
- **Duration**: `FirstSeen` stays stable while the condition holds (existing `markCondition` state), so the panel's age renders true degradation time — 8 days reads as 8 days.
- **Dedupe / clear**: one alert per hive per pass by construction; the standard retention pass drops the condition **and its ack** the moment the spoke reports healthy, so a re-occurrence alerts again.
- **Ack + chip**: registered in `knownAlertTypes` (guarded by `TestKnownAlertTypesCoversEveryAlertType`) and `ALERT_TYPE_LABELS` ('App credentials undelivered') so the dashboard's Attention-needed panel renders the row/chip like every other type.

## Docs

`docs/github-app-setup.md` gains a **hosted-fleet operator runbook**: the `/data/saas/app-keys/<clusterID>.pem` store, the previously undocumented `PUT` upload endpoint (body shape, validation, 404/400 behaviour), fingerprint verification from the response, the `GET` `has_key` pre-claim check, and what each alert state means.

## Tests

`alerts_app_creds_test.go`: raise for all three states / non-raise for owner-side, placeholder, offline, not-required; reason content per state incl. `ClusterHasKey` variants and the unknown-cluster fallback; dedupe with stable `FirstSeen` across 8 simulated days; clear-on-heal including ack invalidation on re-occurrence; `fleetAlerts` PEM-store stamping via the redirected key dir; dashboard label guard.

Verified: `go build ./... && go vet ./... && go test ./pkg/hub/ -count=1`.