### PR TITLE
🐛 fix(sandbox): close the IPv6 egress-gate bypass

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -867,12 +867,91 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
       echo "[entrypoint] ERROR: iptables not found — cannot force proxy egress"
     fi
 
-    if [ "$_iptables_ok" != "true" ]; then
+    # ── IPv6 egress gate (#4319) ────────────────────────────────────────────
+    # The redirect above exists ONLY in the IPv4 nat table. On any network that
+    # gives the container a global IPv6 address, an agent that resolves an AAAA
+    # record reaches :443 over IPv6 and never meets it — a SILENT bypass of the
+    # capability model (no ADVISORY-ONLY warning fires, because the IPv4 gate
+    # installed successfully). The proxy listens on 127.0.0.1 only
+    # (proxy.GitHubProxy listenAddr), so mirroring the REDIRECT with ip6tables
+    # could not deliver the traffic anywhere; the IPv6 family is instead CLOSED
+    # with a filter-table REJECT carrying the SAME three exemptions — xt_owner
+    # and xt_mark are family-agnostic, and SO_MARK (stamped by the Go proxy's
+    # markDialer) marks IPv6 packets identically, so the proxy's own upstream
+    # dials stay exempt on IPv6-capable networks.
+    #
+    # REJECT --reject-with tcp-reset rather than DROP: dual-stack clients get an
+    # immediate RST and fall back to IPv4 (Happy Eyeballs), landing in the IPv4
+    # redirect above, instead of hanging through a timeout on every dial.
+    #
+    # sysctl net.ipv6.conf.all.disable_ipv6=1 was REJECTED as the mechanism:
+    # the image depends on IPv6 loopback internally (the gateway nginx binds
+    # `listen [::]:PORT` for ::1 clients — gateway_nginx_dualstack_test.go —
+    # and the proxy's self-lookup reads /proc/net/tcp6), and /proc/sys is
+    # read-only in most container runtimes anyway.
+    #
+    # A kernel with no IPv6 stack at all (/proc/sys/net/ipv6 absent) has no
+    # IPv6 route to gate; that case passes vacuously rather than failing a
+    # container that cannot carry the traffic in the first place.
+    _ip6tables_ok=false
+    if [ ! -d /proc/sys/net/ipv6 ]; then
+      echo "[entrypoint] IPv6 stack absent from kernel — no IPv6 egress to gate"
+      _ip6tables_ok=true
+    else
+      # Same binary-selection rationale as IPT above: prefer the explicit nft
+      # frontend on nft-mode kernels (OKE, OpenShift/RHEL9).
+      IP6T=""
+      if command -v ip6tables-nft >/dev/null 2>&1; then
+        IP6T="ip6tables-nft"
+      elif command -v ip6tables >/dev/null 2>&1; then
+        IP6T="ip6tables"
+      fi
+      if [ -n "$IP6T" ]; then
+        # Same jittered chain-creation retry as the IPv4 gate: one-shot
+        # creation turns transient netlink/xtables contention into a
+        # fail-closed crash-loop (see the 2026-08-13 note above).
+        _ip6_chain_ok=false
+        _ip6_try=0
+        while [ "$_ip6_try" -lt 5 ]; do
+          _ip6_try=$((_ip6_try + 1))
+          if $IP6T -nL HIVE_PROXY6 >/dev/null 2>&1; then
+            $IP6T -F HIVE_PROXY6 2>/dev/null || true
+            _ip6_chain_ok=true
+            break
+          fi
+          if $IP6T -w 10 -N HIVE_PROXY6 2>/tmp/hive-ip6t-err.log; then
+            _ip6_chain_ok=true
+            break
+          fi
+          echo "[entrypoint] WARN: ip6tables chain creation attempt ${_ip6_try}/5 failed: $(cat /tmp/hive-ip6t-err.log 2>/dev/null) — retrying"
+          sleep $(( _ip6_try * 2 + $$ % 3 ))
+        done
+        if [ "$_ip6_chain_ok" = "true" ]; then
+          # Exemptions mirror the IPv4 chain exactly, in the same order, for
+          # the same two-platform reasons (owner-UID where xt_owner exists,
+          # packet mark where it does not). `|| true` on the owner lines keeps
+          # their failure non-fatal on hosts without xt_owner.
+          $IP6T -A HIVE_PROXY6 -m owner --uid-owner 0 -j RETURN || true
+          $IP6T -A HIVE_PROXY6 -m owner --uid-owner "$PROXY_UID" -j RETURN || true
+          $IP6T -A HIVE_PROXY6 -m mark --mark "$HIVE_PROXY_EGRESS_MARK" -j RETURN
+          $IP6T -A HIVE_PROXY6 -p tcp --dport 443 -j REJECT --reject-with tcp-reset
+          $IP6T -A OUTPUT -j HIVE_PROXY6
+          echo "[entrypoint] ip6tables ($IP6T): outbound IPv6 :443 REJECTed (proxy has no IPv6 listener; proxy UID ${PROXY_UID} + egress mark ${HIVE_PROXY_EGRESS_MARK} exempt)"
+          _ip6tables_ok=true
+        else
+          echo "[entrypoint] ERROR: ip6tables chain creation failed after ${_ip6_try} attempts: $(cat /tmp/hive-ip6t-err.log 2>/dev/null)"
+        fi
+      else
+        echo "[entrypoint] ERROR: ip6tables not found — IPv6 egress cannot be gated"
+      fi
+    fi
+
+    if [ "$_iptables_ok" != "true" ] || [ "$_ip6tables_ok" != "true" ]; then
       if [ "$PROXY_ADVISORY_OK" = "true" ]; then
         echo "[entrypoint] WARN: proxy egress enforcement is ADVISORY-ONLY (HIVE_PROXY_ADVISORY_OK=true set). Agents can bypass the MITM proxy — capability model is NOT enforced."
       else
-        echo "[entrypoint] FATAL: could not establish forced proxy egress (iptables redirect). The ACMM capability model would be advisory-only, allowing agents with raw tokens to bypass the MITM proxy." >&2
-        echo "[entrypoint] FATAL: refusing to start. Grant NET_ADMIN + install iptables, or set HIVE_PROXY_ADVISORY_OK=true to deliberately run in advisory mode." >&2
+        echo "[entrypoint] FATAL: could not establish forced proxy egress (IPv4 redirect established: ${_iptables_ok}; IPv6 gate established: ${_ip6tables_ok}). The ACMM capability model would be advisory-only for the failed family, allowing agents with raw tokens to bypass the MITM proxy." >&2
+        echo "[entrypoint] FATAL: refusing to start. Grant NET_ADMIN + install iptables/ip6tables, or set HIVE_PROXY_ADVISORY_OK=true to deliberately run in advisory mode." >&2
         # Distinguish root cause by exit code (#3760 follow-up): netfilter
         # chain manipulation itself requires CAP_NET_ADMIN, so if the
         # bounding set lacks it, that absence is BY ITSELF sufficient to

--- a/src/deploy/probe_podman_ipv6_egress.sh
+++ b/src/deploy/probe_podman_ipv6_egress.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# probe_podman_ipv6_egress.sh — does the forced-proxy egress gate hold over
+# IPv6? (kubestellar/hive#4319)
+#
+# The gate's IPv4 redirect lives in the nat table; #4319 asks whether an
+# agent-UID process on a dual-stack network can reach a :443 endpoint over
+# IPv6 without traversing the proxy. This probe answers it OBSERVATIONALLY:
+#
+#   1. creates a throwaway dual-stack (IPv4 + ULA IPv6) podman network,
+#   2. runs a TARGET container on it whose :443 sends a family-stamped banner
+#      on accept and closes,
+#   3. runs Hive on the same network with --cap-add NET_ADMIN so the gate
+#      installs normally,
+#   4. from inside Hive, AS AN AGENT UID, dials the target's IPv4 and IPv6
+#      addresses on :443 and reports which family (if either) reached the
+#      target directly.
+#
+# The banner is the family evidence #4319 asks for: the target only speaks
+# first, so an agent that READS it reached the target without traversing the
+# proxy (the proxy never volunteers data on accept). The IPv4 dial is made in
+# the same run, so a negative IPv6 result cannot be confused with a gate that
+# failed to install.
+#
+# A ULA network is sufficient: the redirect/reject decision happens in this
+# netns's OUTPUT hook, which cannot tell a ULA destination from a global one —
+# no globally routable IPv6 is required.
+#
+# STORAGE SAFETY. As in probe_podman_rootful_netadmin.sh, this probe NEVER
+# touches the host's rootful store: every podman call is pinned to a throwaway
+# --root/--runroot. Cleanup removes only the containers and the network this
+# script created, by exact name, and only deletes a store it created itself.
+#
+# Exit codes:
+#   0  the gate held on BOTH families (IPv4 redirected, IPv6 blocked)
+#   1  a bypass was observed (or the IPv4 gate itself did not install)
+#  78  a prerequisite is missing (EX_CONFIG)
+
+set -uo pipefail
+
+IMAGE="${IMAGE:-ghcr.io/kubestellar/hive:v4-latest}"
+GATE_TIMEOUT="${GATE_TIMEOUT:-120}"
+PROBE_PREFIX="hive-ipv6-probe-$$"
+NET_NAME="${PROBE_PREFIX}-net"
+SUBNET4="${SUBNET4:-10.89.77.0/24}"
+SUBNET6="${SUBNET6:-fd77:4319::/64}"
+STORE="${STORE:-}"
+OWN_STORE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --store) STORE="$2"; shift 2 ;;
+    --image) IMAGE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,37p' "$0"; exit 0 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+
+fail_prereq() {
+  printf 'PREREQUISITE MISSING: %s\n' "$1" >&2
+  exit 78
+}
+
+command -v podman >/dev/null 2>&1 || fail_prereq "podman is not installed or not on PATH"
+[[ "$(id -u)" -eq 0 ]] || fail_prereq "this probe must run as root (it mirrors the rootful baseline of #4200); re-run with sudo"
+
+if [[ -z "$STORE" ]]; then
+  STORE="$(mktemp -d -p /var/tmp hive-ipv6-probe-store-XXXXXX)"
+  OWN_STORE="true"
+fi
+mkdir -p "${STORE}/graph" "${STORE}/run"
+
+host_graph="$(podman info --format '{{.Store.GraphRoot}}' 2>/dev/null || true)"
+case "$STORE" in
+  /var/lib/containers*|/run/containers*)
+    fail_prereq "refusing to use ${STORE}: that is the host's rootful store" ;;
+esac
+if [[ -n "$host_graph" && "${STORE}/graph" == "$host_graph" ]]; then
+  fail_prereq "refusing to use ${STORE}/graph: that is the host's graphRoot"
+fi
+
+# An ARRAY, not a function: `timeout` execs its argument and cannot run a
+# shell function (see probe_podman_rootful_netadmin.sh).
+POD=(podman --root "${STORE}/graph" --runroot "${STORE}/run")
+pod() { "${POD[@]}" "$@"; }
+
+WORK="$(mktemp -d)"
+# shellcheck disable=SC2329 # invoked through the EXIT trap below
+cleanup() {
+  pod rm -f "${PROBE_PREFIX}-target" "${PROBE_PREFIX}-hive" >/dev/null 2>&1
+  pod network rm -f "$NET_NAME" >/dev/null 2>&1
+  rm -rf "$WORK"
+  # Only a store this script created is removed. A --store passed in is kept.
+  if [[ "$OWN_STORE" == "true" && -n "$STORE" ]]; then
+    rm -rf "$STORE" 2>/dev/null
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+# The gate lives behind "at least one agent is configured"; this config makes
+# it install and creates agent UID 2001 (HIVE_UID_BASE) for the dials below.
+cat >"${WORK}/hive.yaml" <<'EOF'
+project:
+  org: kubestellar
+  repos:
+    - kubestellar/hive
+github:
+  token: "ghp_probe_not_a_real_token"
+agents:
+  probe:
+    backend: claude
+EOF
+
+printf '== Hive IPv6 egress-gate probe (#4319) ==\n'
+pod info --format 'podman={{.Version.Version}} rootless={{.Host.Security.Rootless}} cgroups={{.Host.CgroupsVersion}} netbackend={{.Host.NetworkBackend}} runtime={{.Host.OCIRuntime.Name}}'
+printf 'store=%s (throwaway=%s)\nimage=%s\nnetwork=%s subnets=%s,%s\n\n' \
+  "$STORE" "$OWN_STORE" "$IMAGE" "$NET_NAME" "$SUBNET4" "$SUBNET6"
+
+rootless="$(pod info --format '{{.Host.Security.Rootless}}' 2>/dev/null)"
+[[ "$rootless" == "false" ]] || \
+  fail_prereq "podman reports rootless=${rootless:-unknown}; this probe requires ROOTFUL podman"
+
+pod pull -q "$IMAGE" >/dev/null 2>&1 || fail_prereq "cannot pull ${IMAGE} into the throwaway store"
+
+pod network create --ipv6 --subnet "$SUBNET4" --subnet "$SUBNET6" "$NET_NAME" >/dev/null \
+  || fail_prereq "cannot create a dual-stack network (${SUBNET4} + ${SUBNET6})"
+
+failures=0
+note_fail() { printf '  RESULT: BYPASS/FAILURE — %s\n' "$1"; failures=$((failures + 1)); }
+note_ok()   { printf '  RESULT: gate held — %s\n' "$1"; }
+
+# ── Target: dual-stack :443 banner server ───────────────────────────────────
+# Speaks FIRST on accept, stamping the family of the peer address, then
+# closes. Reading the banner therefore proves a direct, un-proxied reach.
+pod run -d --name "${PROBE_PREFIX}-target" --network "$NET_NAME" \
+  --entrypoint python3 "$IMAGE" -u -c '
+import socket
+s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+s.bind(("::", 443))
+s.listen(16)
+print("target listening dual-stack :443", flush=True)
+while True:
+    c, a = s.accept()
+    fam = "V4" if a[0].startswith("::ffff:") else "V6"
+    try:
+        c.sendall(("TARGET-%s\n" % fam).encode())
+    finally:
+        c.close()
+' >/dev/null || fail_prereq "target container failed to start"
+
+target_v4="$(pod inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${PROBE_PREFIX}-target")"
+target_v6="$(pod inspect -f '{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}' "${PROBE_PREFIX}-target")"
+printf -- '--- target addresses ---\n  v4=%s\n  v6=%s\n\n' "${target_v4:-NONE}" "${target_v6:-NONE}"
+[[ -n "$target_v4" && -n "$target_v6" ]] || \
+  fail_prereq "the network did not assign both families to the target; a dual-stack endpoint cannot be provided here"
+
+# ── Hive with NET_ADMIN on the same dual-stack network ──────────────────────
+pod run -d --name "${PROBE_PREFIX}-hive" --network "$NET_NAME" \
+  --cap-add NET_ADMIN \
+  -v "${WORK}/hive.yaml:/etc/hive/hive.yaml:ro,Z" "$IMAGE" >/dev/null \
+  || fail_prereq "hive container failed to start"
+
+printf -- '--- waiting for the gate (max %ss) ---\n' "$GATE_TIMEOUT"
+gate4=""; gate6=""
+for (( i = 0; i < GATE_TIMEOUT; i += 3 )); do
+  log="$(pod logs "${PROBE_PREFIX}-hive" 2>&1)"
+  gate4="$(grep -m1 'outbound :443 -> :18443' <<<"$log" || true)"
+  gate6="$(grep -m1 'outbound IPv6 :443' <<<"$log" || true)"
+  [[ -n "$gate4" ]] && break
+  pod container exists "${PROBE_PREFIX}-hive" || break
+  sleep 3
+done
+printf '  ipv4: %s\n' "${gate4:-NOT INSTALLED}"
+printf '  ipv6: %s\n' "${gate6:-NOT INSTALLED (pre-#4319 entrypoint, or ip6tables failed)}"
+if [[ -z "$gate4" ]]; then
+  note_fail "the IPv4 gate never installed; nothing below is meaningful"
+  printf '\n== VERDICT: cannot evaluate (IPv4 gate absent) — %d failure(s) ==\n' "$failures"
+  exit 1
+fi
+
+# ── Dials from an agent UID ─────────────────────────────────────────────────
+# UID 2001 is the first agent UID (HIVE_UID_BASE) — the exact identity the
+# gate exists to confine. The dialer prints BANNER (direct reach), SILENT
+# (connected but nothing spoke: the redirect delivered us to the MITM proxy,
+# which waits for the client), or BLOCKED (reset/refused/timeout).
+dial_as_agent() {
+  local addr="$1"
+  pod exec -u 2001 "${PROBE_PREFIX}-hive" python3 -c '
+import socket, sys
+addr = sys.argv[1]
+fam = socket.AF_INET6 if ":" in addr else socket.AF_INET
+s = socket.socket(fam, socket.SOCK_STREAM)
+s.settimeout(8)
+try:
+    s.connect((addr, 443))
+    try:
+        data = s.recv(64)
+    except OSError as e:
+        print("BLOCKED post-connect %s: %s" % (type(e).__name__, e)); sys.exit(0)
+    if data:
+        print("BANNER %s" % data.decode(errors="replace").strip())
+    else:
+        print("SILENT (connected, peer sent nothing)")
+except OSError as e:
+    print("BLOCKED %s: %s" % (type(e).__name__, e))
+finally:
+    s.close()
+' "$addr" 2>&1
+}
+
+printf -- '\n--- agent-UID dial: IPv4 %s:443 ---\n' "$target_v4"
+r4="$(dial_as_agent "$target_v4")"
+printf '  %s\n' "$r4"
+case "$r4" in
+  *"BANNER TARGET-V4"*) note_fail "agent reached the target DIRECTLY over IPv4 — the redirect did not apply" ;;
+  *SILENT*|*BLOCKED*)   note_ok "IPv4 dial did not reach the target (redirected into the proxy, as documented)" ;;
+  *)                    note_fail "unexpected IPv4 dial outcome: $r4" ;;
+esac
+
+printf -- '\n--- agent-UID dial: IPv6 [%s]:443 ---\n' "$target_v6"
+r6="$(dial_as_agent "$target_v6")"
+printf '  %s\n' "$r6"
+case "$r6" in
+  *"BANNER TARGET-V6"*) note_fail "agent reached the target DIRECTLY over IPv6 — the #4319 bypass is REAL on this host" ;;
+  *BLOCKED*)            note_ok "IPv6 dial was blocked (ip6tables REJECT held)" ;;
+  *SILENT*)             note_fail "IPv6 dial CONNECTED (no redirect target exists on IPv6; a connect is an escape even without the banner)" ;;
+  *)                    note_fail "unexpected IPv6 dial outcome: $r6" ;;
+esac
+
+printf '\n== VERDICT: %s — %d failure(s) ==\n' \
+  "$( ((failures == 0)) && echo 'gate held on both families' || echo 'bypass or gate failure observed' )" \
+  "$failures"
+(( failures == 0 )) && exit 0 || exit 1

--- a/src/docs/net-admin-requirement.md
+++ b/src/docs/net-admin-requirement.md
@@ -24,7 +24,10 @@ The hive process runs as a **non-root** user (`dev`). The MITM proxy uses
 `CAP_NET_ADMIN` to `setsockopt(SO_MARK)` on its **own** upstream dials, which is
 how the proxy's traffic is exempted from the **forced-proxy-egress** gate: the
 entrypoint installs an iptables `REDIRECT` of all outbound `:443` through the
-proxy, and on OpenShift/OVN — where the `-m owner` UID match is unavailable —
+proxy (and, since #4319, an `ip6tables` `REJECT` of outbound IPv6 `:443` with
+the same exemptions, so a dual-stack network cannot carry agent traffic around
+the redirect — the proxy listens on `127.0.0.1` only, so the IPv6 family is
+closed rather than redirected), and on OpenShift/OVN — where the `-m owner` UID match is unavailable —
 the `SO_MARK` packet mark is the **only** self-exemption. `setsockopt(SO_MARK)`
 requires `CAP_NET_ADMIN` in the calling process's **effective** set.
 

--- a/src/docs/podman-rootful-egress-baseline.md
+++ b/src/docs/podman-rootful-egress-baseline.md
@@ -125,11 +125,13 @@ exemptions should stay.
 
 ## What remains unproven
 
-- **IPv6.** The gate is IPv4-only — the entrypoint has no `ip6tables` path at
-  all. On this configuration the container gets no global IPv6 address, so there
-  is nothing to bypass; on a host or network that does hand out IPv6, an agent
-  could reach `:443` over v6 and miss the redirect entirely. **This is the
-  bypass-resistance test that needs its own follow-up issue.**
+- **IPv6.** ~~The gate is IPv4-only — the entrypoint has no `ip6tables` path at
+  all.~~ *Resolved by #4319:* the entrypoint now closes the IPv6 family with an
+  `ip6tables` filter-table `REJECT` carrying the same three exemptions (the
+  proxy listens on `127.0.0.1` only, so a v6 `REDIRECT` had nowhere to
+  deliver). On this configuration the container gets no global IPv6 address, so
+  there was nothing to bypass here; `src/deploy/probe_podman_ipv6_egress.sh`
+  observes the dual-stack case on a Linux host.
 - **Kernels without `xt_owner`.** Deleting the owner rules emulates the shape
   but not the kernel. This host has `xt_owner`.
 - **Restart, reboot, and recreate.** Single `podman run` only; nothing about

--- a/src/pkg/config/egress_gate_ipv6_test.go
+++ b/src/pkg/config/egress_gate_ipv6_test.go
@@ -1,0 +1,202 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// These tests pin the IPv6 half of the forced-proxy egress gate (#4319).
+//
+// The gate's IPv4 redirect lives in entrypoint.sh's iptables block; before
+// #4319 there was NO ip6tables path at all, so on any dual-stack network an
+// agent resolving an AAAA record reached :443 over IPv6 without ever meeting
+// the redirect — silently, because the IPv4 gate had installed successfully.
+//
+// Like entrypoint_boot_test.go, this extracts and EXECUTES the real gate block
+// rather than grepping for rule text: shim iptables/ip6tables binaries record
+// every invocation, so the assertions cover the branching logic the container
+// actually runs, not a paraphrase of it. Live packet-level verification needs
+// a Linux netns and is covered by src/deploy/probe_podman_ipv6_egress.sh.
+
+// runEgressGate executes ONLY the iptables/ip6tables gate block of
+// entrypoint.sh with shim netfilter binaries, returning the combined script
+// output, the shim invocation log, and the exit code.
+//
+// shims maps binary names (for example "iptables-nft") to an exit-code policy:
+// every invocation is appended to the log and succeeds, except `-nL <chain>`
+// existence probes, which fail so the creation path runs. Binaries absent from
+// the map are absent from PATH. ipv6Stack controls whether the block sees a
+// kernel IPv6 stack (/proc/sys/net/ipv6 is rewritten onto a temp root).
+func runEgressGate(t *testing.T, env map[string]string, shims []string, ipv6Stack bool) (out string, calls string, exitCode int) {
+	t.Helper()
+	src, err := os.ReadFile(entrypointPath)
+	if err != nil {
+		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+	}
+	text := string(src)
+	start := strings.Index(text, "PROXY_PORT=18443")
+	if start < 0 {
+		t.Fatal("could not find the start of the egress gate block (PROXY_PORT=18443); the marker moved and this test would silently cover nothing")
+	}
+	end := strings.Index(text, "# Drop to non-root user")
+	if end < 0 || end < start {
+		t.Fatal("could not find the end of the egress gate block; the marker moved and this test would silently cover nothing")
+	}
+	body := text[start:end]
+	// The block sits inside an enclosing `if` whose opener is above the
+	// extraction start; drop the one unmatched trailing `fi`.
+	body = strings.TrimRight(body, " \t\n")
+	if !strings.HasSuffix(body, "fi") {
+		t.Fatalf("gate block does not end with the enclosing fi; got tail %q", body[len(body)-20:])
+	}
+	body = strings.TrimRight(strings.TrimSuffix(body, "fi"), " \t\n")
+
+	root := t.TempDir()
+	// Rewrite absolute paths onto the temp root so the test never touches the
+	// real /proc or /tmp, and so the IPv6-stack presence check is controllable.
+	body = strings.ReplaceAll(body, "/proc/sys/net/ipv6", root+"/proc/sys/net/ipv6")
+	body = strings.ReplaceAll(body, "/tmp/hive-ipt-err.log", root+"/hive-ipt-err.log")
+	body = strings.ReplaceAll(body, "/tmp/hive-ip6t-err.log", root+"/hive-ip6t-err.log")
+	if ipv6Stack {
+		if err := os.MkdirAll(filepath.Join(root, "proc/sys/net/ipv6"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	callLog := filepath.Join(root, "calls.log")
+	shim := "#!/bin/sh\n" +
+		"echo \"$(basename \"$0\") $*\" >> " + callLog + "\n" +
+		"# Chain-existence probes must fail so the creation path is exercised.\n" +
+		"case \"$*\" in *-nL*) exit 1;; esac\n" +
+		"exit 0\n"
+	for _, name := range shims {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(shim), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// python3 (uid-map bookkeeping) and sleep (retry backoff) as no-ops, and a
+	// real basename for the shim itself.
+	for name, script := range map[string]string{
+		"python3": "#!/bin/sh\nexit 0\n",
+		"sleep":   "#!/bin/sh\nexit 0\n",
+	} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	prelude := "set -e\n" +
+		"PATH=" + binDir + ":/usr/bin:/bin\n" +
+		"EXIT_NET_ADMIN_REQUIRED=77\n" +
+		"_cap_net_admin_in_bset=true\n" +
+		"PROXY_UID=1001\n" +
+		"HIVE_PROXY_EGRESS_MARK=0x1112\n"
+	cmd := exec.Command("sh", "-c", prelude+body)
+	cmd.Env = append(os.Environ(), "HIVE_PROXY_ADVISORY_OK=false")
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	outB, _ := cmd.CombinedOutput()
+	callsB, _ := os.ReadFile(callLog)
+	return string(outB), string(callsB), cmd.ProcessState.ExitCode()
+}
+
+// TestGateInstallsBothFamilies: with iptables AND ip6tables available and an
+// IPv6 stack present, the gate must establish BOTH families — the IPv4
+// redirect (re-confirmed per #4319's acceptance criteria) and the IPv6 REJECT
+// — and start cleanly.
+func TestGateInstallsBothFamilies(t *testing.T) {
+	out, calls, code := runEgressGate(t, nil,
+		[]string{"iptables-nft", "ip6tables-nft"}, true)
+	if code != 0 {
+		t.Fatalf("gate exited %d with both families available:\n%s", code, out)
+	}
+	// IPv4 redirect re-confirmed in the same run.
+	if !strings.Contains(calls, "iptables-nft -t nat -A HIVE_PROXY -p tcp --dport 443 -j REDIRECT --to-ports 18443") {
+		t.Fatalf("IPv4 :443 redirect was not installed:\n%s", calls)
+	}
+	// IPv6 family closed with the same three exemptions, in order, BEFORE the
+	// REJECT, and the chain hooked into OUTPUT.
+	wantSeq := []string{
+		"ip6tables-nft -w 10 -N HIVE_PROXY6",
+		"ip6tables-nft -A HIVE_PROXY6 -m owner --uid-owner 0 -j RETURN",
+		"ip6tables-nft -A HIVE_PROXY6 -m owner --uid-owner 1001 -j RETURN",
+		"ip6tables-nft -A HIVE_PROXY6 -m mark --mark 0x1112 -j RETURN",
+		"ip6tables-nft -A HIVE_PROXY6 -p tcp --dport 443 -j REJECT --reject-with tcp-reset",
+		"ip6tables-nft -A OUTPUT -j HIVE_PROXY6",
+	}
+	pos := -1
+	for _, want := range wantSeq {
+		i := strings.Index(calls, want)
+		if i < 0 {
+			t.Fatalf("missing ip6tables invocation %q:\n%s", want, calls)
+		}
+		if i < pos {
+			t.Fatalf("ip6tables invocation %q out of order (exemptions must precede the REJECT):\n%s", want, calls)
+		}
+		pos = i
+	}
+	if !strings.Contains(out, "outbound IPv6 :443 REJECTed") {
+		t.Fatalf("IPv6 gate success was not logged:\n%s", out)
+	}
+	if strings.Contains(out, "FATAL") {
+		t.Fatalf("unexpected FATAL with both families established:\n%s", out)
+	}
+}
+
+// TestGateFailsClosedWithoutIP6Tables: an IPv6-capable kernel with no
+// ip6tables binary means the IPv6 family CANNOT be gated — that is exactly the
+// silent bypass #4319 describes, so the container must refuse to start (the
+// same F5 fail-closed treatment the IPv4 redirect gets), not warn and proceed.
+func TestGateFailsClosedWithoutIP6Tables(t *testing.T) {
+	out, _, code := runEgressGate(t, nil, []string{"iptables-nft"}, true)
+	if code == 0 {
+		t.Fatalf("gate started with IPv6 unenforced (exit 0):\n%s", out)
+	}
+	if !strings.Contains(out, "ip6tables not found") {
+		t.Fatalf("missing ip6tables was not named as the cause:\n%s", out)
+	}
+	if !strings.Contains(out, "FATAL") {
+		t.Fatalf("no FATAL for an ungated IPv6 family:\n%s", out)
+	}
+}
+
+// TestGateAdvisoryOptOutCoversIPv6: HIVE_PROXY_ADVISORY_OK=true is the single
+// deliberate escape hatch; it must cover an IPv6-gate failure the same way it
+// covers an IPv4 one — with the loud ADVISORY-ONLY warning, never silently.
+func TestGateAdvisoryOptOutCoversIPv6(t *testing.T) {
+	out, _, code := runEgressGate(t,
+		map[string]string{"HIVE_PROXY_ADVISORY_OK": "true"},
+		[]string{"iptables-nft"}, true)
+	if code != 0 {
+		t.Fatalf("advisory opt-in still exited %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, "ADVISORY-ONLY") {
+		t.Fatalf("advisory mode was entered without the ADVISORY-ONLY warning:\n%s", out)
+	}
+}
+
+// TestGatePassesVacuouslyWithoutIPv6Stack: a kernel with IPv6 compiled out or
+// disabled at boot (/proc/sys/net/ipv6 absent) cannot carry IPv6 traffic, so
+// there is nothing to gate; requiring ip6tables there would fail containers
+// that have no bypass to close.
+func TestGatePassesVacuouslyWithoutIPv6Stack(t *testing.T) {
+	out, calls, code := runEgressGate(t, nil, []string{"iptables-nft"}, false)
+	if code != 0 {
+		t.Fatalf("gate exited %d on an IPv6-less kernel:\n%s", code, out)
+	}
+	if !strings.Contains(out, "IPv6 stack absent") {
+		t.Fatalf("the vacuous pass was not logged:\n%s", out)
+	}
+	if regexp.MustCompile(`(?m)^ip6tables`).MatchString(calls) {
+		t.Fatalf("ip6tables was invoked despite no IPv6 stack:\n%s", calls)
+	}
+}


### PR DESCRIPTION
## Why

#4319 (spike series #4188) asked whether the forced-proxy egress gate is bypassable over IPv6. Code analysis confirms the gap is real wherever the container holds a global IPv6 address:

- `src/deploy/entrypoint.sh` built the `HIVE_PROXY` chain with `iptables-nft`/`iptables` only — **zero `ip6tables` references**, and no `disable_ipv6` sysctl anywhere in the deploy path.
- The proxy listens on `127.0.0.1:18443` only (`src/pkg/proxy/github_proxy.go:260`), so IPv6 traffic could not even be redirected into it.
- An agent resolving an AAAA record therefore reached `:443` over IPv6 without meeting the `REDIRECT`, **silently** — the IPv4 gate installs successfully, so no `ADVISORY-ONLY` warning fires.

Per the issue's acceptance criteria, the `ip6tables-nft` equivalents are identical: `xt_owner` (`-m owner --uid-owner`) and `xt_mark` (`-m mark --mark`) are family-agnostic, and `SO_MARK` (set by the Go proxy's markDialer at the socket level) stamps IPv6 packets the same way.

## What

**`src/deploy/entrypoint.sh`** — after the IPv4 redirect, close the IPv6 family with a `HIVE_PROXY6` filter-table chain: the same three exemptions in the same order (owner-UID 0 / owner-UID 1001 with `|| true` for hosts without `xt_owner`, then the packet-mark RETURN), then `-p tcp --dport 443 -j REJECT --reject-with tcp-reset`, hooked into `OUTPUT`.

Design decisions:
- **REJECT, not a mirrored REDIRECT** — the proxy has no IPv6 listener to deliver to.
- **`tcp-reset`, not DROP** — dual-stack clients get an immediate RST and Happy-Eyeballs onto IPv4, landing in the redirect instead of hanging per dial.
- **Not `disable_ipv6`** — the image depends on IPv6 loopback internally (gateway nginx `listen [::]` — `gateway_nginx_dualstack_test.go`; proxy self-lookup reads `/proc/net/tcp6`), and `/proc/sys` is read-only in most runtimes.
- **Fail-closed** (audit F5): an IPv6-capable kernel where the v6 gate cannot establish refuses to start, same as an IPv4 failure, with the same `HIVE_PROXY_ADVISORY_OK` escape hatch. A kernel with no IPv6 stack (`/proc/sys/net/ipv6` absent) passes vacuously. Chain creation reuses the jittered retry (2026-08-13 lockstep incident).
- No Dockerfile change: Debian's `iptables` package (already installed, `src/Dockerfile:86`) ships `ip6tables-nft`.

**`src/pkg/config/egress_gate_ipv6_test.go`** — executes the real extracted gate block with shim netfilter binaries (the `entrypoint_boot_test.go` pattern): both families install with IPv4 re-confirmed in the same run, exemptions ordered before the REJECT, missing `ip6tables` is fail-closed, advisory opt-out covers IPv6, vacuous pass without an IPv6 stack.

**`src/deploy/probe_podman_ipv6_egress.sh`** — live observation for a Linux host (this branch was authored on macOS, where packet-level verification is impossible): throwaway `--root/--runroot` store, dual-stack ULA network, a family-stamped banner target on `:443`, and agent-UID (2001) dials on both families. Shellcheck-clean, self-cleaning by exact name, follows `probe_podman_rootful_netadmin.sh` conventions. A ULA network suffices — the OUTPUT-hook decision cannot tell ULA from global destinations.

**Docs** — `net-admin-requirement.md` and `podman-rootful-egress-baseline.md` updated to reflect the closed family.

## Validation

- `go build ./...` and `go vet` clean; all 4 new tests pass. (Two pre-existing `gh_app_token_script_test.go` failures reproduce on clean `origin/v4` on this machine — unrelated.)
- `shellcheck` — probe clean; `entrypoint.sh` has the same 10 pre-existing findings before and after, none in the new block.

Closes #4319