### PR TITLE
🐛 fix(hub): keep the app-creds-undelivered alert raised while the stranded hive is offline

### DIFF
--- a/src/pkg/hub/alerts.go
+++ b/src/pkg/hub/alerts.go
@@ -121,7 +121,7 @@ const (
 	// only after several consecutive 401s and clears on the next success — so
 	// the alert self-heals when the key is fixed.
 	AlertTypeInferenceAuthFailed = "inference-auth-failed"
-	// AlertTypeAppCredsUndelivered — a claimed, online hive requires GitHub App
+	// AlertTypeAppCredsUndelivered — a claimed hive requires GitHub App
 	// auth but reports an OPERATOR-SIDE credential state (key-missing,
 	// key-invalid or no-app-assigned; see operatorSideAppStates in journey.go).
 	// The hive owner cannot see, supply or correct the App private key — it is
@@ -983,17 +983,26 @@ func evaluateAlerts(state *alertState, hives []alertHive, driftAlerts []Alert, n
 		}
 
 		// --- Rule: GitHub App credentials are in an operator-side state. ---
-		// Claimed and ONLINE only: a placeholder has no App by design, and an
-		// offline hive's last-reported state is stale (and already raises
-		// offline, which is the actionable fact). Gated on the spoke's OWN
-		// GitHubAppRequired verdict plus an operator-side GitHubAppState
-		// (key-missing / key-invalid / no-app-assigned) — the exact states
-		// every owner-facing surface deliberately silences, which is why an
-		// operator alert is the ONLY active signal for them (#4316). Critical:
-		// the hive provably cannot work until the hub delivers a usable key.
-		// Self-clears once the key lands and the spoke stops reporting the
-		// state; the standard retention pass drops the condition and its ack.
-		if !h.IsPlaceholder && h.Online && h.GitHubAppRequired && appStateIsOperatorSide(h.GitHubAppState) {
+		// Claimed only: a placeholder has no App by design. Gated on the
+		// spoke's OWN GitHubAppRequired verdict plus an operator-side
+		// GitHubAppState (key-missing / key-invalid / no-app-assigned) — the
+		// exact states every owner-facing surface deliberately silences, which
+		// is why an operator alert is the ONLY active signal for them (#4316).
+		//
+		// Deliberately NOT gated on the hive being online (Danathar, #4322):
+		// an offline hive raises its own offline alert, but that alert cannot
+		// say WHY the hive never worked — and gating here would drop the
+		// credential alert exactly when the hive is worst off, still keyless
+		// and now not even heartbeating. The two answer different questions
+		// and an operator needs both. This also matches every other
+		// spoke-state rule above (health-check, advisory, inference), none of
+		// which gate on Online.
+		//
+		// Critical: the hive provably cannot work until the hub delivers a
+		// usable key. Self-clears once the key lands and the spoke stops
+		// reporting the state; the standard retention pass drops the
+		// condition and its ack.
+		if !h.IsPlaceholder && h.GitHubAppRequired && appStateIsOperatorSide(h.GitHubAppState) {
 			add(h.ID, h.Name, AlertTypeAppCredsUndelivered, AlertSeverityCritical,
 				appCredsUndeliveredReason(h))
 		}

--- a/src/pkg/hub/alerts_app_creds_test.go
+++ b/src/pkg/hub/alerts_app_creds_test.go
@@ -37,7 +37,7 @@ func TestEvaluateAlerts_AppCredsUndeliveredRule(t *testing.T) {
 		{name: "an empty state does not fire", mutate: func(h *alertHive) { h.GitHubAppState = "" }, want: false},
 		{name: "a hive that never asked for App auth does not fire", mutate: func(h *alertHive) { h.GitHubAppRequired = false }, want: false},
 		{name: "a placeholder does not fire", mutate: func(h *alertHive) { h.IsPlaceholder = true }, want: false},
-		{name: "an offline hive does not fire on its stale state", mutate: func(h *alertHive) { h.Online = false }, want: false},
+		{name: "an offline stranded hive still fires", mutate: func(h *alertHive) { h.Online = false }, want: true},
 	}
 
 	for _, tc := range tests {
@@ -53,6 +53,26 @@ func TestEvaluateAlerts_AppCredsUndeliveredRule(t *testing.T) {
 				t.Errorf("severity = %q, want %q — the hive provably cannot work", a.Severity, AlertSeverityCritical)
 			}
 		})
+	}
+}
+
+// TestAppCredsUndelivered_FiresAlongsideOfflineForAStrandedOfflineHive pins
+// the deliberate deviation from #4316's wording ("claimed, ONLINE hive"),
+// adopted from Danathar's #4322: an offline keyless hive is worst off — still
+// keyless AND no longer heartbeating — and the offline alert alone cannot say
+// WHY the hive never worked. The two alerts answer different questions and an
+// operator needs both.
+func TestAppCredsUndelivered_FiresAlongsideOfflineForAStrandedOfflineHive(t *testing.T) {
+	h := appCredsHive("h1", appStateKeyMissingToken)
+	h.Online = false
+	h.LastHeartbeat = rfc3339(fixedNow.Add(-2 * alertOfflineThreshold))
+
+	summary := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+	if !hasAlert(summary.Alerts, "h1", AlertTypeAppCredsUndelivered) {
+		t.Error("an offline keyless hive still needs its key uploaded; being offline must not suppress the credential alert")
+	}
+	if !hasAlert(summary.Alerts, "h1", AlertTypeOffline) {
+		t.Error("the offline rule must still fire independently — the two answer different questions")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #4323, adopting the one design point @Danathar's parallel implementation (#4322) got **better**.

#4323 gated the `app-creds-undelivered` alert on the hive being **online** (per #4316's literal wording). #4322's rationale for NOT gating is correct:

- An offline keyless hive is *worst off* — still keyless AND no longer heartbeating. Gating drops the credential alert at exactly that moment, hiding the WHY behind a generic `offline` row.
- The two alerts answer different questions (is it reachable / can it ever work) and an operator needs both.
- No other spoke-state rule (health-check, advisory-stale, inference-auth) gates on Online — the gate was the convention outlier.

Changes: drop the `h.Online` gate (comment credits the rationale), flip the offline test to the new semantics, and add #4322's dual-alert offline test (both `app-creds-undelivered` and `offline` must fire together).

Credit: adopted from #4322 (Co-authored-by preserved), which pre-dates #4323 and now conflicts with it; that PR is superseded rather than merged twice.