### PR TITLE
🐛 fix(advisory): name Issues-disabled repos in the stale-advisory alert

### DIFF
--- a/src/cmd/hive/advisory_wedge_test.go
+++ b/src/cmd/hive/advisory_wedge_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/dashboard"
+	"github.com/kubestellar/hive/pkg/github"
 )
 
 func TestPrimaryAdvisoryRepo(t *testing.T) {
@@ -51,7 +54,7 @@ func TestAdvisoryIssueUnresolved(t *testing.T) {
 // post time nor an error and the hub read it as "not an advisory participant" —
 // a wedged digest that was indistinguishable from a healthy PR-only hive.
 func TestMissingAdvisoryIssueIsReportedAsPostError(t *testing.T) {
-	msg := advisoryIssueMissingError("org/repo")
+	msg := advisoryIssueMissingError("org/repo", nil)
 	if !strings.Contains(msg, "org/repo") {
 		t.Fatalf("the recorded error must name the repo, got %q", msg)
 	}
@@ -74,5 +77,34 @@ func TestMissingAdvisoryIssueIsReportedAsPostError(t *testing.T) {
 	srv.RecordAdvisoryPost(3)
 	if _, _, errMsg := srv.AdvisoryState(); errMsg != "" {
 		t.Fatalf("a successful post must clear the advisory error, got %q", errMsg)
+	}
+}
+
+// #4329: when the ensure failed because the target repo has Issues DISABLED
+// (has_issues=false — the fork case), the recorded post error must carry that
+// cause into the fleet stale-advisory alert text, so the operator reads the
+// repo-settings remedy instead of suspecting App auth.
+func TestMissingAdvisoryIssueNamesIssuesDisabledCause(t *testing.T) {
+	cause := &github.IssuesDisabledError{Repo: "jeejz/incubator-kie-drools", Fork: true}
+	msg := advisoryIssueMissingError("jeejz/incubator-kie-drools", cause)
+	if !strings.Contains(msg, "no advisory issue resolved") {
+		t.Fatalf("the base symptom text must be preserved for the hub's staleness matcher, got %q", msg)
+	}
+	if !strings.Contains(msg, "Issues are disabled") || !strings.Contains(msg, "Settings > General > Features") {
+		t.Fatalf("the alert text must name the Issues-disabled cause and remedy, got %q", msg)
+	}
+
+	// A wrapped cause must still be recognized.
+	wrapped := fmt.Errorf("ensuring advisory issue: %w", cause)
+	if got := advisoryIssueMissingError("jeejz/incubator-kie-drools", wrapped); !strings.Contains(got, "Issues are disabled") {
+		t.Fatalf("a wrapped IssuesDisabledError must still fold into the alert, got %q", got)
+	}
+
+	// Any OTHER ensure failure (403 App-permission, rate limit, 5xx) keeps the
+	// unadorned symptom text — those classes have their own banner/diagnosis
+	// paths and must remain distinguishable.
+	forbidden := errors.New("403 Resource not accessible by integration")
+	if got := advisoryIssueMissingError("org/repo", forbidden); got != advisoryIssueMissingError("org/repo", nil) {
+		t.Fatalf("a non-Issues-disabled cause must not change the alert text, got %q", got)
 	}
 }

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -4791,8 +4791,17 @@ func advisoryIssueUnresolved(advisoryIssues map[string]int, repo string) bool {
 // treats a hive reporting neither a post time nor an error as "not an advisory
 // participant" and never alarms, which is how a wedged digest went unnoticed for
 // six days in #4167.
-func advisoryIssueMissingError(repo string) string {
-	return fmt.Sprintf("no advisory issue resolved for %s — digest not posted", repo)
+func advisoryIssueMissingError(repo string, cause error) string {
+	base := fmt.Sprintf("no advisory issue resolved for %s — digest not posted", repo)
+	// Issues-disabled is the one ensure failure with a remedy the OPERATOR of
+	// the target repo owns (#4329): flipping a repo setting, not fixing App
+	// auth. Fold its actionable message into the alert text so the fleet
+	// stale-advisory pill says so instead of reading like an auth failure.
+	var disabled *github.IssuesDisabledError
+	if errors.As(cause, &disabled) {
+		return base + ": " + disabled.Error()
+	}
+	return base
 }
 
 func runEvalCycle(
@@ -4839,6 +4848,11 @@ func runEvalCycle(
 	// whatever it last said. Retrying here is cheap (one search per eval cycle
 	// only while unresolved, nothing once resolved) and is the difference
 	// between a transient boot error and a permanently wedged digest.
+	//
+	// advisoryEnsureErr keeps this cycle's ensure failure so the post-path
+	// error recorded below can name the CAUSE (e.g. Issues disabled on a fork,
+	// #4329) instead of only the symptom.
+	var advisoryEnsureErr error
 	if primaryRepo := primaryAdvisoryRepo(cfg); primaryRepo != "" && ghClient != nil {
 		if advisoryIssueUnresolved(advisoryIssues, primaryRepo) {
 			num, retryErr := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
@@ -4847,6 +4861,7 @@ func runEvalCycle(
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
 				logger.Info("advisory issue resolved on retry", "repo", primaryRepo, "number", num)
 			} else {
+				advisoryEnsureErr = retryErr
 				logger.Warn("advisory issue still unresolved — digest cannot be posted this cycle",
 					"repo", primaryRepo, "error", retryErr)
 			}
@@ -5461,7 +5476,7 @@ func runEvalCycle(
 					// that looked exactly like a healthy PR-only hive. Record it
 					// as a post FAILURE so the hub flags the hive stale with the
 					// real cause, and log it once per cycle for the operator.
-					msg := advisoryIssueMissingError(primaryRepo)
+					msg := advisoryIssueMissingError(primaryRepo, advisoryEnsureErr)
 					dashSrv.RecordAdvisoryError(msg)
 					logger.Warn("advisory digest not posted: no pinned advisory issue",
 						"repo", primaryRepo, "findings", digest.TotalCount)

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -110,6 +110,12 @@ quietly:
   publish, the spoke records a post error — `no advisory issue resolved for
   <repo>` — so the hub flags the hive's digest stale with that cause instead of
   reading it as a hive that simply does not post advisories.
+- **The repo has Issues disabled.** Forks have `has_issues=false` by default —
+  there is no Issues tab, so the pinned issue can neither be found nor created.
+  The hive checks the flag before attempting the create and records a distinct
+  post error naming the remedy: enable Issues in the repo's **Settings >
+  General > Features**, or point the hive at the upstream repo. This is not an
+  App-permission problem; the App banner stays down.
 - **Someone closed the pinned issue.** The hive reopens the existing issue rather
   than filing a new one. Filing a new one splits the digest: the hive writes to
   the new issue while everyone subscribed to the old one watches a comment that

--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -20,6 +20,30 @@ const (
 	advisoryLabelClr  = "0e8a16"
 )
 
+// IssuesDisabledError reports that the advisory issue cannot be created or
+// resolved because the target repo has its Issues feature turned off
+// (has_issues=false). GitHub disables Issues on forks by default, so this is
+// the common failure mode when a hive is pointed at a fork (#4329). It is a
+// distinct class from the 403 "Resource not accessible by integration"
+// App-permission failure: no amount of App reconfiguration fixes it, only a
+// repo-settings change (or repointing the hive) does, so the message names
+// that remedy.
+type IssuesDisabledError struct {
+	// Repo is the owner/name of the repo with Issues disabled.
+	Repo string
+	// Fork records whether the repo is a GitHub fork, the usual reason
+	// Issues are off.
+	Fork bool
+}
+
+func (e *IssuesDisabledError) Error() string {
+	why := "common on forks"
+	if e.Fork {
+		why = "it is a fork, and GitHub disables Issues on forks by default"
+	}
+	return fmt.Sprintf("Issues are disabled on %s (%s) — enable Issues in the repo's Settings > General > Features, or point the hive at the upstream repo", e.Repo, why)
+}
+
 // EnsureAdvisoryIssue finds or creates the pinned advisory issue for a repo.
 // Returns the issue number.
 func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, error) {
@@ -39,6 +63,21 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 	if num > 0 {
 		c.logger.Info("found existing advisory issue", slog.String("repo", repo), slog.Int("number", num))
 		return num, nil
+	}
+
+	// Before attempting to create, check whether the repo can hold issues at
+	// all. A fork (or any repo with the Issues feature off) has no Issues tab:
+	// the create below would fail with a 410 that reads like an auth problem,
+	// and the fleet alert would blame the App. Name the real cause instead
+	// (#4329). A failed metadata probe fails OPEN — the create attempt then
+	// produces its own, real error.
+	if ghRepo, _, repoErr := c.client.Repositories.Get(ctx, owner, repo); repoErr == nil {
+		if ghRepo != nil && !ghRepo.GetHasIssues() {
+			return 0, &IssuesDisabledError{Repo: owner + "/" + repo, Fork: ghRepo.GetFork()}
+		}
+	} else {
+		c.logger.Warn("could not check repo has_issues before advisory issue create",
+			slog.String("repo", repo), slog.String("error", repoErr.Error()))
 	}
 
 	c.logger.Info("creating advisory issue", slog.String("repo", repo))

--- a/src/pkg/github/advisory_issues_disabled_test.go
+++ b/src/pkg/github/advisory_issues_disabled_test.go
@@ -1,0 +1,145 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// #4329: a fork with has_issues=false has no Issues tab. The ensure path must
+// return a DISTINCT, actionable error naming the repo-settings remedy — not
+// fall through to a create whose 410 reads like an App-auth failure.
+
+// muxNoAdvisoryIssue wires the find fallbacks so findAdvisoryIssue resolves
+// nothing: search and every list return empty.
+func muxNoAdvisoryIssue(mux *http.ServeMux, org, repo string, onCreate func()) {
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "items": []any{}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			if onCreate != nil {
+				onCreate()
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"number": 7, "title": advisoryTitle})
+			return
+		}
+		json.NewEncoder(w).Encode([]map[string]any{})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/labels", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"name": advisoryLabelName})
+	})
+}
+
+func TestEnsureAdvisoryIssue_IssuesDisabledOnFork(t *testing.T) {
+	org, repo := "jeejz", "incubator-kie-drools"
+	var createAttempted bool
+	mux := http.NewServeMux()
+	muxNoAdvisoryIssue(mux, org, repo, func() { createAttempted = true })
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"full_name":  org + "/" + repo,
+			"has_issues": false,
+			"fork":       true,
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	_, err := c.EnsureAdvisoryIssue(context.Background(), org+"/"+repo)
+	if err == nil {
+		t.Fatal("expected an error for a repo with Issues disabled")
+	}
+	var disabled *IssuesDisabledError
+	if !errors.As(err, &disabled) {
+		t.Fatalf("error must be an *IssuesDisabledError, got %T: %v", err, err)
+	}
+	if disabled.Repo != org+"/"+repo {
+		t.Errorf("error repo = %q, want %q", disabled.Repo, org+"/"+repo)
+	}
+	if !disabled.Fork {
+		t.Error("error must record that the repo is a fork")
+	}
+	for _, want := range []string{"Issues are disabled", org + "/" + repo, "Settings > General > Features", "upstream repo", "fork"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message must contain %q, got %q", want, err.Error())
+		}
+	}
+	if createAttempted {
+		t.Error("no create must be attempted against a repo with Issues disabled")
+	}
+}
+
+// Happy path: has_issues=true — the probe answers, and the create proceeds
+// exactly as before the check existed.
+func TestEnsureAdvisoryIssue_HasIssuesTrueStillCreates(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var createAttempted bool
+	mux := http.NewServeMux()
+	muxNoAdvisoryIssue(mux, org, repo, func() { createAttempted = true })
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"full_name":  org + "/" + repo,
+			"has_issues": true,
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	num, err := c.EnsureAdvisoryIssue(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("EnsureAdvisoryIssue: %v", err)
+	}
+	if num != 7 {
+		t.Errorf("issue number = %d, want 7", num)
+	}
+	if !createAttempted {
+		t.Error("the create must proceed when has_issues=true")
+	}
+}
+
+// The has_issues probe fails OPEN: a metadata fetch error (rate limit, 5xx)
+// must not block the create, whose own error is the real, classifiable one.
+func TestEnsureAdvisoryIssue_HasIssuesProbeFailureFailsOpen(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var createAttempted bool
+	mux := http.NewServeMux()
+	muxNoAdvisoryIssue(mux, org, repo, func() { createAttempted = true })
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	num, err := c.EnsureAdvisoryIssue(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("EnsureAdvisoryIssue: %v", err)
+	}
+	if num != 7 {
+		t.Errorf("issue number = %d, want 7", num)
+	}
+	if !createAttempted {
+		t.Error("a failed has_issues probe must not block the create")
+	}
+}
+
+func TestIssuesDisabledError_MessageNonFork(t *testing.T) {
+	err := &IssuesDisabledError{Repo: "org/repo"}
+	msg := err.Error()
+	if !strings.Contains(msg, "common on forks") {
+		t.Errorf("non-fork message should hedge with %q, got %q", "common on forks", msg)
+	}
+	if !strings.Contains(msg, "Settings > General > Features") {
+		t.Errorf("message must name the settings remedy, got %q", msg)
+	}
+}


### PR DESCRIPTION
Closes #4329

## Problem
Hosted hive for `jeejz/incubator-kie-drools` showed the fleet alert `last advisory post failed: no advisory issue resolved for incubator-kie-drools — digest not posted`. The repo is a GitHub fork with `has_issues=false` — no Issues tab — so the advisory issue can neither be found nor created. The generic alert text was indistinguishable from an App-auth failure.

## Fix
- `EnsureAdvisoryIssue` checks the target repo's `has_issues` flag (`GET /repos/{owner}/{repo}`) before attempting the create, and returns a distinct `IssuesDisabledError`: *Issues are disabled on <repo> (it is a fork…) — enable Issues in the repo's Settings > General > Features, or point the hive at the upstream repo.* A failed metadata probe fails **open** so transient errors don't block the create.
- The eval-cycle re-ensure keeps this cycle's ensure failure; `advisoryIssueMissingError` folds an Issues-disabled cause into the recorded post error, so the hub's stale-advisory alert names the operator-ownable remedy. The base `no advisory issue resolved` text is preserved for the hub's staleness matcher.
- The 403 `Resource not accessible by integration` App-permission class is untouched — any non-Issues-disabled cause keeps the unadorned symptom text and its existing banner/diagnosis paths.
- Docs: `docs/advisory.md` gains the Issues-disabled failure mode.

## Deferred
Fallback-to-PR-comment posting (posting the digest somewhere other than an issue) is deliberately **not** implemented — the alert-text remedy is the deliverable here; the fallback can be a follow-up if wanted.

## Tests
- `TestEnsureAdvisoryIssue_IssuesDisabledOnFork` — distinct error, no create attempted
- `TestEnsureAdvisoryIssue_HasIssuesTrueStillCreates` — happy path unchanged
- `TestEnsureAdvisoryIssue_HasIssuesProbeFailureFailsOpen`
- `TestMissingAdvisoryIssueNamesIssuesDisabledCause` — cause folds into alert text (incl. wrapped), 403 class unchanged
- `go test ./pkg/github/... ./cmd/hive/...` green; `pkg/github` coverage 88.3% (floor 88)