### PR TITLE
✨ feat(budget): draw the budget-window history graph and label the trend-graph axes

### DIFF
--- a/src/pkg/dashboard/budget_history_ui_test.go
+++ b/src/pkg/dashboard/budget_history_ui_test.go
@@ -1,0 +1,90 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4298 asked for a graph of token usage over time with a visual marker for
+// the configured budget and reset times. #4320 landed the data layer
+// (GET /api/budget/history); these tests pin the dashboard actually drawing
+// it — and pin the wiring, because the embedded SPA has shipped calls to
+// functions that were never defined (the renderAll/hiveToast class of bug).
+func TestBudgetHistoryChartWiredIntoDashboard(t *testing.T) {
+	b, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	html := string(b)
+
+	// Every function the chart path calls must be DEFINED in the document —
+	// a referenced-but-undefined name throws ReferenceError at render time.
+	for _, def := range []string{
+		"function fetchBudgetHistory(",
+		"function budgetHistoryChart(",
+		"function renderBudgetBar(",
+		"function fmtSparkVal(",
+		"function axisSparkSvg(",
+	} {
+		if !strings.Contains(html, def) {
+			t.Errorf("index.html does not define %q", def)
+		}
+	}
+
+	// The chart must read the durable per-window series #4320 added, not a
+	// client-side reconstruction that would be empty for closed windows.
+	if !strings.Contains(html, "fetch('/api/budget/history')") {
+		t.Error("index.html never fetches /api/budget/history — the chart would have no closed-window data")
+	}
+
+	// The chart must actually be rendered where the budget is shown, fetched
+	// at startup, and refetched after a manual reset (a reset closes a window,
+	// which is exactly the event the chart exists to record).
+	for _, snippet := range []string{
+		"${budgetHistoryChart()}",
+		"() => fetchBudgetHistory().then(() => { setInterval(fetchBudgetHistory, HISTORY_REFRESH_MS); })",
+		"fetchBudgetHistory(); // a reset closes a window",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q", snippet)
+		}
+	}
+
+	// The issue's two named markers: the configured budget (per-window limit
+	// line) and the reset times (x-axis labels). Pin the explanatory copy so
+	// the axes stay labeled — unlabeled graphs are what #4298 called
+	// "impossible to understand".
+	for _, snippet := range []string{
+		"dashed red line = the limit in force for that window",
+		"x-axis labels = when each window reset",
+		"no closed windows yet",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html budget history chart is missing %q", snippet)
+		}
+	}
+}
+
+// The cost-section trend graphs in the issue's screenshot "lack horizontal
+// and vertical axes, making them impossible to understand". Pin that the
+// 30-day fact/cost charts render through the axis-labeled helper and that
+// the tiny inline sparklines carry a scale tooltip (they are too small for
+// drawn axes).
+func TestSparklinesCarryAxesOrScaleTooltips(t *testing.T) {
+	b, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	html := string(b)
+
+	for _, snippet := range []string{
+		"axisSparkSvg(_factHistory",
+		"axisSparkSvg(_costHistory",
+		// sparkSvg + miniSparkSvg embed an SVG <title> stating the range.
+		"<title>range ${fmtSparkVal(min)}",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q", snippet)
+		}
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4803,6 +4803,18 @@
     }
     const SPARK_W = 80, SPARK_H = 20;
 
+    // Compact axis-value formatter for sparkline scale labels/tooltips. NOT
+    // fmtTokens (which is billions-denominated and unreadable for small
+    // counts like "5 issues") — this adapts to the magnitude of the series.
+    function fmtSparkVal(v) {
+      if (typeof v !== 'number' || !isFinite(v)) return '—';
+      const a = Math.abs(v);
+      if (a >= 1e9) return (v / 1e9).toFixed(1) + 'B';
+      if (a >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+      if (a >= 1e3) return (v / 1e3).toFixed(1) + 'k';
+      return Number.isInteger(v) ? String(v) : v.toFixed(2);
+    }
+
     function sparkSvg(rawValues, color) {
       if (!rawValues || rawValues.length < 2) return '';
       // Fill zero gaps: carry forward last non-zero value through consecutive zeros
@@ -4820,7 +4832,10 @@
         const y = SPARK_H - ((v - min) / range) * (SPARK_H - 2) - 1;
         return `${x.toFixed(1)},${y.toFixed(1)}`;
       });
+      // <title> gives every tiny sparkline a hover scale (#4298: graphs with
+      // no axes are impossible to read — these are too small for drawn axes).
       return `<span class="sparkline"><svg width="${SPARK_W}" height="${SPARK_H}" viewBox="0 0 ${SPARK_W} ${SPARK_H}">` +
+        `<title>range ${fmtSparkVal(min)}–${fmtSparkVal(max)} · latest ${fmtSparkVal(values[values.length - 1])} · ${values.length} points, oldest → newest</title>` +
         `<polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
         `<circle cx="${pts[pts.length-1].split(',')[0]}" cy="${pts[pts.length-1].split(',')[1]}" r="2" fill="${color}"/>` +
         `</svg></span>`;
@@ -4871,37 +4886,57 @@
 
     // ── Fact count sparkline (30-day server-side history) ──
     let _factHistory = [];
-    const FACT_SPARKLINE_W = 100, FACT_SPARKLINE_H = 24;
     async function fetchFactHistory() {
       try {
         const r = await fetch('/api/knowledge/fact-history');
         _factHistory = await r.json();
       } catch { /* non-critical */ }
     }
-    function factSparkSvg() {
-      if (!_factHistory || _factHistory.length < 2) return '';
-      const values = _factHistory.map(e => e.count);
+    // axisSparkSvg renders a time series WITH axes (#4298: the dashboard's
+    // trend graphs "lack horizontal and vertical axes, making them impossible
+    // to understand"). Vertical axis: max/min value labels. Horizontal axis:
+    // first/last timestamps. entries need a value (getV) and an epoch-ms
+    // timestamp (getT); fmtV formats the axis value labels.
+    const AXIS_SPARK_W = 170, AXIS_SPARK_H = 46;
+    function axisSparkSvg(entries, getV, getT, fmtV, color, title) {
+      if (!entries || entries.length < 2) return '';
+      const W = AXIS_SPARK_W, H = AXIS_SPARK_H;
+      const PAD_L = 36, PAD_R = 4, PAD_T = 5, PAD_B = 12;
+      const plotW = W - PAD_L - PAD_R, plotH = H - PAD_T - PAD_B;
+      const values = entries.map(getV);
       const max = Math.max(...values);
       const min = Math.min(...values);
       const range = (max - min) || max || 1;
       const pts = values.map((v, i) => {
-        const x = (i / (values.length - 1)) * FACT_SPARKLINE_W;
-        const y = FACT_SPARKLINE_H - ((v - min) / range) * (FACT_SPARKLINE_H - 2) - 1;
+        const x = PAD_L + (i / (values.length - 1)) * plotW;
+        const y = PAD_T + plotH - ((v - min) / range) * plotH;
         return `${x.toFixed(1)},${y.toFixed(1)}`;
       });
       const lastPt = pts[pts.length - 1].split(',');
-      return `<span class="sparkline" style="margin-left:0;margin-top:4px"><svg width="${FACT_SPARKLINE_W}" height="${FACT_SPARKLINE_H}" viewBox="0 0 ${FACT_SPARKLINE_W} ${FACT_SPARKLINE_H}">` +
-        `<polyline points="${pts.join(' ')}" fill="none" stroke="var(--blue)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
-        `<circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="2" fill="var(--blue)"/>` +
+      const fmtDate = t => { const d = new Date(t); return isNaN(d) ? '' : `${d.getMonth() + 1}/${d.getDate()}`; };
+      const t0 = fmtDate(getT(entries[0])), t1 = fmtDate(getT(entries[entries.length - 1]));
+      const AXIS_TXT = `font-size="7" fill="var(--muted)"`;
+      return `<span class="sparkline" style="margin-left:0;margin-top:4px" title="${title}"><svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">` +
+        `<line x1="${PAD_L}" y1="${PAD_T}" x2="${PAD_L}" y2="${PAD_T + plotH}" stroke="var(--border)" stroke-width="1"/>` +
+        `<line x1="${PAD_L}" y1="${PAD_T + plotH}" x2="${W - PAD_R}" y2="${PAD_T + plotH}" stroke="var(--border)" stroke-width="1"/>` +
+        `<text x="${PAD_L - 3}" y="${PAD_T + 6}" text-anchor="end" ${AXIS_TXT}>${fmtV(max)}</text>` +
+        `<text x="${PAD_L - 3}" y="${PAD_T + plotH}" text-anchor="end" ${AXIS_TXT}>${fmtV(min)}</text>` +
+        `<text x="${PAD_L}" y="${H - 3}" text-anchor="start" ${AXIS_TXT}>${t0}</text>` +
+        `<text x="${W - PAD_R}" y="${H - 3}" text-anchor="end" ${AXIS_TXT}>${t1}</text>` +
+        `<polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
+        `<circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="2" fill="${color}"/>` +
         `</svg></span>`;
+    }
+    function factSparkSvg() {
+      return axisSparkSvg(_factHistory, e => e.count, e => e.t, fmtSparkVal, 'var(--blue)',
+        'Knowledge facts over time (last 30d) — vertical axis: fact count, horizontal axis: date');
     }
     // fetchFactHistory() — deferred to _deferredInit
 
     // ── Estimated-cost sparkline (30-day server-side history) ──
-    // Mirrors the fact sparkline: same dimensions, same min/max scaling,
+    // Mirrors the fact sparkline: same axis treatment,
     // reads /api/cost/history which parallels /api/knowledge/fact-history.
     let _costHistory = [];
-    const COST_SPARKLINE_W = FACT_SPARKLINE_W, COST_SPARKLINE_H = FACT_SPARKLINE_H;
     async function fetchCostHistory() {
       try {
         const r = await fetch('/api/cost/history');
@@ -4909,21 +4944,8 @@
       } catch { /* non-critical */ }
     }
     function costSparkSvg() {
-      if (!_costHistory || _costHistory.length < 2) return '';
-      const values = _costHistory.map(e => e.usd);
-      const max = Math.max(...values);
-      const min = Math.min(...values);
-      const range = (max - min) || max || 1;
-      const pts = values.map((v, i) => {
-        const x = (i / (values.length - 1)) * COST_SPARKLINE_W;
-        const y = COST_SPARKLINE_H - ((v - min) / range) * (COST_SPARKLINE_H - 2) - 1;
-        return `${x.toFixed(1)},${y.toFixed(1)}`;
-      });
-      const lastPt = pts[pts.length - 1].split(',');
-      return `<span class="sparkline" style="margin-left:0;margin-top:4px" title="Estimated cost over time (last 30d)"><svg width="${COST_SPARKLINE_W}" height="${COST_SPARKLINE_H}" viewBox="0 0 ${COST_SPARKLINE_W} ${COST_SPARKLINE_H}">` +
-        `<polyline points="${pts.join(' ')}" fill="none" stroke="var(--green)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
-        `<circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="2" fill="var(--green)"/>` +
-        `</svg></span>`;
+      return axisSparkSvg(_costHistory, e => e.usd, e => e.t ?? e.timestamp, v => '$' + fmtSparkVal(v), 'var(--green)',
+        'Estimated cost over time (last 30d) — vertical axis: cumulative USD, horizontal axis: date');
     }
     // fetchCostHistory() is invoked alongside fetchCost() (see below).
 
@@ -5051,7 +5073,7 @@
       const range = (max - min) || max || 1;
       const pts = values.map((v, i) =>
         `${(i / (values.length - 1) * W).toFixed(1)},${(H - ((v - min) / range) * (H - 2) - 1).toFixed(1)}`);
-      return `<svg class="cell-spark" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}"><polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+      return `<svg class="cell-spark" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}"><title>range ${fmtSparkVal(min)}–${fmtSparkVal(max)} · latest ${fmtSparkVal(values[values.length - 1])} · oldest → newest</title><polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
     }
 
     // Cumulative series for one model's field ('i' input, 'o' output, 'usd')
@@ -7133,7 +7155,72 @@
         return;
       }
       showToast('Budget window reset — spend restarts at 0, suppressed kicks resume', 'success');
+      fetchBudgetHistory(); // a reset closes a window → new history row; refetch so the chart shows it
       refreshStatus(); // repaint budget bar/banners in place; errors swallowed inside
+    }
+
+    // ── Budget window history chart (#4298) ──────────────────────────────
+    // "Did the budget stop the hive while I was gone?" — a bar per budget
+    // window from GET /api/budget/history (#4320's durable series), with the
+    // per-window limit drawn as a marker and reset times on the x-axis.
+    let _budgetHistory = null; // null until first fetch; {windows:[closed, newest first], current:{...}}
+    async function fetchBudgetHistory() {
+      try {
+        const r = await fetch('/api/budget/history');
+        if (!r.ok) return;
+        _budgetHistory = await r.json();
+      } catch { /* non-critical; chart shows its empty state until the next fetch */ }
+    }
+
+    function budgetHistoryChart() {
+      const h = _budgetHistory;
+      if (!h) return '';
+      // Closed windows arrive newest-first (epoch-ms bounds); chart reads oldest → newest.
+      const wins = (Array.isArray(h.windows) ? h.windows.slice().reverse() : [])
+        .map(w => ({ start: w.windowStart, end: w.windowEnd, limit: w.limit || 0, used: w.used || 0, pctUsed: w.pctUsed || 0, exhausted: !!w.exhausted, open: false }));
+      const cur = h.current;
+      if (cur && cur.limit > 0) {
+        // The open window bounds itself with RFC3339 strings (live status), not epoch ms.
+        wins.push({ start: cur.windowStart ? Date.parse(cur.windowStart) : NaN, end: cur.windowEnd ? Date.parse(cur.windowEnd) : NaN,
+          limit: cur.limit, used: cur.used || 0, pctUsed: cur.pctUsed || 0, exhausted: !!cur.exhausted, open: true });
+      }
+      if (!wins.length) return '';
+      const hasClosed = wins.some(w => !w.open);
+      if (!hasClosed) {
+        return `<div style="font-size:0.66rem;color:var(--muted);margin-top:5px" title="One bar per budget window will appear here after the first window reset — see GET /api/budget/history">Budget history: no closed windows yet — the chart fills in after the first window reset.</div>`;
+      }
+      const PCT_BUDGET_WARN = 90; // mirrors governor.BudgetWarnPct
+      const BAR_SLOT = 30, BAR_W = 20, PAD_L = 40, PAD_R = 4, PAD_T = 6, PAD_B = 14;
+      const plotH = 52;
+      const W = PAD_L + wins.length * BAR_SLOT + PAD_R, H = PAD_T + plotH + PAD_B;
+      const yMax = Math.max(...wins.map(w => Math.max(w.limit, w.used)), 1);
+      const yPx = v => PAD_T + plotH - (Math.min(v, yMax) / yMax) * plotH;
+      const fmtDate = t => { const d = new Date(t); return isNaN(d) ? '?' : `${d.getMonth() + 1}/${d.getDate()}`; };
+      const AXIS_TXT = `font-size="7" fill="var(--muted)"`;
+      const bars = wins.map((w, i) => {
+        const x = PAD_L + i * BAR_SLOT + (BAR_SLOT - BAR_W) / 2;
+        const yUsed = yPx(w.used);
+        const fill = w.exhausted ? 'var(--red)' : w.pctUsed >= PCT_BUDGET_WARN ? 'var(--yellow)' : 'var(--green)';
+        const tip = `${w.open ? 'OPEN window' : 'window'} ${new Date(w.start).toLocaleString()} → ${new Date(w.end).toLocaleString()}\nused ${fmtTokens(w.used)} of ${fmtTokens(w.limit)} (${Math.round(w.pctUsed)}%)${w.exhausted ? '\nEXHAUSTED — agent kicks were suspended' : ''}`;
+        // Per-window limit marker: the limit in force FOR THAT window, so a
+        // later limit change doesn't redraw history.
+        const yLim = yPx(w.limit);
+        return `<g><title>${esc(tip)}</title>` +
+          `<rect x="${x.toFixed(1)}" y="${yUsed.toFixed(1)}" width="${BAR_W}" height="${(PAD_T + plotH - yUsed).toFixed(1)}" fill="${fill}" opacity="${w.open ? '0.45' : '0.85'}" rx="1"/>` +
+          (w.limit > 0 ? `<line x1="${(x - 2).toFixed(1)}" y1="${yLim.toFixed(1)}" x2="${(x + BAR_W + 2).toFixed(1)}" y2="${yLim.toFixed(1)}" stroke="var(--red)" stroke-width="1" stroke-dasharray="3,2"/>` : '') +
+          `<text x="${(x + BAR_W / 2).toFixed(1)}" y="${H - 4}" text-anchor="middle" ${AXIS_TXT}>${w.open ? 'open' : fmtDate(w.end)}</text>` +
+          `</g>`;
+      }).join('');
+      return `<div style="margin-top:6px">
+        <div style="font-size:0.66rem;color:var(--muted);margin-bottom:2px" title="One bar per budget window (from /api/budget/history). Bar height = tokens used; dashed red line = the limit in force for that window; x-axis labels = when each window reset. Red bar = window exhausted (kicks were suspended); the translucent bar is the still-open window.">Budget window history — used vs. limit per window, labeled by reset time</div>
+        <div style="overflow-x:auto"><svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+          <line x1="${PAD_L}" y1="${PAD_T}" x2="${PAD_L}" y2="${PAD_T + plotH}" stroke="var(--border)" stroke-width="1"/>
+          <line x1="${PAD_L}" y1="${PAD_T + plotH}" x2="${W - PAD_R}" y2="${PAD_T + plotH}" stroke="var(--border)" stroke-width="1"/>
+          <text x="${PAD_L - 3}" y="${PAD_T + 6}" text-anchor="end" ${AXIS_TXT}>${fmtTokens(yMax)}</text>
+          <text x="${PAD_L - 3}" y="${PAD_T + plotH}" text-anchor="end" ${AXIS_TXT}>0</text>
+          ${bars}
+        </svg></div>
+      </div>`;
     }
 
     function renderBudgetBar(budget) {
@@ -7184,6 +7271,7 @@
           <span>Projected: ${fmtTokens(used + burnRate * hoursLeft)} (${projPct}%)</span>
         </div>
         <div style="font-size:0.68rem;margin-top:3px">${govAction}</div>
+        ${budgetHistoryChart()}
       </div>`;
     }
 
@@ -8088,7 +8176,7 @@ function burnAreaChart() {
             const rng = (mx - mn) || mx || 1;
             const pts = act.map((v, i) => `${(i / (act.length - 1)) * MINI_W},${MINI_H - ((v - mn) / rng) * (MINI_H - 2) - 1}`).join(' ');
             const clr = _getAgentColor(s.agent);
-            miniSpark = `<span class="sparkline" style="margin-left:4px"><svg width="${MINI_W}" height="${MINI_H}" viewBox="0 0 ${MINI_W} ${MINI_H}"><polyline points="${pts}" fill="none" stroke="${clr}" stroke-width="1.2" opacity="0.7"/></svg></span>`;
+            miniSpark = `<span class="sparkline" style="margin-left:4px"><svg width="${MINI_W}" height="${MINI_H}" viewBox="0 0 ${MINI_W} ${MINI_H}"><title>session activity per interval — range ${fmtSparkVal(mn)}–${fmtSparkVal(mx)}, oldest → newest</title><polyline points="${pts}" fill="none" stroke="${clr}" stroke-width="1.2" opacity="0.7"/></svg></span>`;
           }
           return `<div class="token-session-row" style="padding-left:12px">
             <span class="sid">${esc(s.id)}</span>
@@ -22012,6 +22100,7 @@ function burnAreaChart() {
           () => fetchTrendHistory().then(() => fetchHistory()).then(() => { setInterval(fetchHistory, HISTORY_REFRESH_MS); }),
           () => fetchIssueCosts().then(() => { setInterval(fetchIssueCosts, ISSUE_COSTS_REFRESH_MS); }),
           () => fetch('/api/budget-ignore').then(r => r.json()).then(d => { budgetIgnored = d.ignored; }).catch(() => {}),
+          () => fetchBudgetHistory().then(() => { setInterval(fetchBudgetHistory, HISTORY_REFRESH_MS); }),
           () => fetchNousStatus().then(() => { setInterval(fetchNousStatus, NOUS_POLL_MS); }),
           () => fetchKnowledgeStats().then(() => { setInterval(fetchKnowledgeStats, KB_POLL_MS); }),
           () => fetchAuditLog().then(() => { setInterval(fetchAuditLog, AUDIT_POLL_MS); }),


### PR DESCRIPTION
Closes #4298.

## What was still missing after #4320

#4320 landed the durable per-window series (`GET /api/budget/history`, `/data/budget-window-history.json`, high-water-mark semantics) and explicitly deferred two things the issue asks for:

1. **The graph itself** — token usage over time *with a visual marker for the configured budget and reset times*.
2. **The axes** — the cost-section trend graphs in the issue's screenshot "lack horizontal and vertical axes, making them impossible to understand".

This PR is that follow-up. Frontend only — the data layer is untouched.

## 1. Budget window history chart

Rendered directly under the budget bar, fed by `GET /api/budget/history`:

- **One bar per window**, oldest → newest; bar height = tokens used, vertical axis labeled 0 → max.
- **Budget marker**: a dashed red line across each bar at the limit *in force for that window* — a later limit change does not redraw history (same rationale as the per-window `limit` field in #4320).
- **Reset times**: each closed window's x-axis label is the date it reset; the still-open window renders translucent and labeled `open`.
- **Exhausted windows are red** — the vacation question ("did the budget stop the hive while I was gone?") is answered at a glance; hover any bar for the full window bounds, used/limit, and whether kicks were suspended.
- **Compatibility** (named requirement in #4298): a hive that has never rolled a window shows an explicit "no closed windows yet" state; a failed/absent fetch renders nothing rather than crashing. Refreshes on the shared `HISTORY_REFRESH_MS` cadence and refetches after a manual window reset.

## 2. Axes on the trend graphs

- The 30-day **fact** and **cost** charts now render through a shared `axisSparkSvg` helper: min/max value labels on the vertical axis, first/last dates on the horizontal, axis lines drawn.
- The tiny inline sparklines (cost-table cells, per-model chips, session activity) are too small for drawn axes, so each now carries an SVG `<title>` scale tooltip — range, latest value, and direction (oldest → newest).
- New `fmtSparkVal` formats axis values by magnitude — *not* `fmtTokens`, which is billions-denominated and would render "5 issues" as "0.000B".

## Guarding the renderAll/hiveToast bug class

The embedded SPA has shipped calls to functions that were never defined (#4315). `budget_history_ui_test.go` pins: every function the chart path calls is defined in the document, the chart is wired into `renderBudgetBar`/deferred-init/reset paths, the fetch targets `/api/budget/history`, and the axis labels stay present.

## Testing

- `go build ./...` clean; full `go test ./pkg/dashboard/` green (39s).
- Inline JS syntax-checked (both script blocks parse).
- Chart smoke-tested against: null history, current-window-only (empty state), mixed exhausted/healthy closed windows + open window (3 bars, 3 limit markers, no NaN in output).

— hive: backend=copilot