### PR TITLE
🐛 fix(advisory): never adopt a foreign-authored digest comment the App can never edit

### DIFF
--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -242,12 +242,47 @@ func (c *Client) findDigestComment(ctx context.Context, owner, repo string, issu
 	if err != nil {
 		return 0, err
 	}
+	var botAuthored int64
 	for _, comment := range comments {
-		if strings.HasPrefix(comment.GetBody(), advisoryDigestPrefix) {
+		if !strings.HasPrefix(comment.GetBody(), advisoryDigestPrefix) {
+			continue
+		}
+		if c.appAuth == nil {
+			// Token (PAT) client: historical prefix-only match. The credential
+			// may legitimately be the human who authored the comment, and
+			// authorship cannot be verified without an extra /user round trip.
 			return int(comment.GetID()), nil
 		}
+		login := comment.GetUser().GetLogin()
+		if c.appBotLogin != "" && login == c.appBotLogin {
+			// Exactly our own bot comment — the one credential-safe choice.
+			return int(comment.GetID()), nil
+		}
+		if strings.HasSuffix(login, "[bot]") || comment.GetUser().GetType() == "Bot" {
+			// Bot-authored but not provably ours (bot login unknown, or a slug
+			// mismatch between config and the real App). Remember the first as
+			// a fallback rather than skipping it: refusing our own comment on
+			// a misconfigured slug would create a duplicate every cycle.
+			if botAuthored == 0 {
+				botAuthored = comment.GetID()
+			}
+			continue
+		}
+		// A digest comment this App can never edit — e.g. one left behind by
+		// the removed user-token fallback (#1927), authored by a human. GitHub
+		// hard-forbids an App from editing a foreign-authored comment (403
+		// "Resource not accessible by integration") no matter what the
+		// installation grants, so adopting it wedges the digest forever
+		// (kalantar-msb/soft-reflective#1). Skip it; if no bot-authored digest
+		// comment exists a fresh App-authored one is created and every later
+		// cycle edits THAT one, so nothing is duplicated per cycle.
+		c.logger.Warn("skipping advisory digest comment not authored by this App — an installation token can never edit it",
+			slog.String("repo", owner+"/"+repo),
+			slog.Int("issue", issueNum),
+			slog.Int64("comment_id", comment.GetID()),
+			slog.String("author", login))
 	}
-	return 0, nil
+	return int(botAuthored), nil
 }
 
 func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int, error) {

--- a/src/pkg/github/advisory_foreign_comment_test.go
+++ b/src/pkg/github/advisory_foreign_comment_test.go
@@ -1,0 +1,140 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// digestCommentMux serves an advisory issue whose comment list is fixed, and
+// records whether the digest path PATCHed an existing comment or POSTed a new
+// one.
+func digestCommentMux(org, repo string, comments []map[string]any, patched map[int64]bool, created *bool) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/10/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			json.NewEncoder(w).Encode(comments)
+		case "POST":
+			*created = true
+			json.NewEncoder(w).Encode(map[string]any{"id": 9999, "user": map[string]any{"login": "hive-app[bot]"}})
+		}
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			var id int64
+			fmt.Sscanf(r.URL.Path, fmt.Sprintf("/repos/%s/%s/issues/comments/%%d", org, repo), &id)
+			patched[id] = true
+			json.NewEncoder(w).Encode(map[string]any{"id": id, "user": map[string]any{"login": "hive-app[bot]"}})
+		}
+	})
+	return mux
+}
+
+func newAppTestClient(t *testing.T, server *httptest.Server, org, repo, botLogin string) *Client {
+	t.Helper()
+	c := newTestClient(t, server, org, []string{repo})
+	// Promote the token test client to an App-authenticated one: only the
+	// presence of appAuth and the bot login matter to the digest author gate.
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = botLogin
+	return c
+}
+
+// A digest comment left behind by the removed user-token fallback (#1927) is
+// authored by a HUMAN. GitHub hard-forbids an App from editing any
+// foreign-authored comment (403 "Resource not accessible by integration"), so
+// the App must never adopt it: it posts a fresh comment of its own instead of
+// PATCHing the human's forever (kalantar-msb/soft-reflective#1).
+func TestPostAdvisoryDigest_SkipsHumanAuthoredDigestComment(t *testing.T) {
+	org, repo := "kalantar-msb", "soft-reflective"
+	patched := map[int64]bool{}
+	var created bool
+	server := httptest.NewServer(digestCommentMux(org, repo, []map[string]any{
+		{"id": 5243180833, "body": advisoryDigestPrefix + " — legacy user-token digest", "user": map[string]any{"login": "kalantar", "type": "User"}},
+	}, patched, &created))
+	defer server.Close()
+
+	c := newAppTestClient(t, server, org, repo, "hive-app[bot]")
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, advisoryDigestPrefix+" — new"); err != nil {
+		t.Fatalf("PostAdvisoryDigest: %v", err)
+	}
+	if patched[5243180833] {
+		t.Error("App PATCHed a human-authored comment — GitHub always 403s this")
+	}
+	if !created {
+		t.Error("expected a fresh App-authored digest comment to be created")
+	}
+}
+
+// The App's own digest comment (author == appBotLogin) is still updated in
+// place — no duplicates per cycle — and wins over an earlier foreign one.
+func TestPostAdvisoryDigest_UpdatesOwnBotComment(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	patched := map[int64]bool{}
+	var created bool
+	server := httptest.NewServer(digestCommentMux(org, repo, []map[string]any{
+		{"id": 111, "body": advisoryDigestPrefix + " — human leftover", "user": map[string]any{"login": "someone", "type": "User"}},
+		{"id": 222, "body": advisoryDigestPrefix + " — ours", "user": map[string]any{"login": "hive-app[bot]", "type": "Bot"}},
+	}, patched, &created))
+	defer server.Close()
+
+	c := newAppTestClient(t, server, org, repo, "hive-app[bot]")
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, advisoryDigestPrefix+" — new"); err != nil {
+		t.Fatalf("PostAdvisoryDigest: %v", err)
+	}
+	if !patched[222] {
+		t.Error("expected the App's own digest comment to be updated in place")
+	}
+	if created || patched[111] {
+		t.Errorf("wrong write path: created=%v patchedForeign=%v", created, patched[111])
+	}
+}
+
+// With the bot login unknown (older config), a bot-authored digest comment is
+// still adopted — refusing our own comment on a missing slug would create a
+// duplicate every cycle — while a human-authored one is still skipped.
+func TestPostAdvisoryDigest_BotLoginUnknownAdoptsBotComment(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	patched := map[int64]bool{}
+	var created bool
+	server := httptest.NewServer(digestCommentMux(org, repo, []map[string]any{
+		{"id": 111, "body": advisoryDigestPrefix + " — human leftover", "user": map[string]any{"login": "someone", "type": "User"}},
+		{"id": 333, "body": advisoryDigestPrefix + " — bot", "user": map[string]any{"login": "some-app[bot]", "type": "Bot"}},
+	}, patched, &created))
+	defer server.Close()
+
+	c := newAppTestClient(t, server, org, repo, "")
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, advisoryDigestPrefix+" — new"); err != nil {
+		t.Fatalf("PostAdvisoryDigest: %v", err)
+	}
+	if !patched[333] {
+		t.Error("expected the bot-authored digest comment to be updated")
+	}
+	if created || patched[111] {
+		t.Errorf("wrong write path: created=%v patchedForeign=%v", created, patched[111])
+	}
+}
+
+// A token (PAT) client keeps the historical prefix-only match: the credential
+// may be the very human who authored the comment.
+func TestPostAdvisoryDigest_TokenClientKeepsPrefixMatch(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	patched := map[int64]bool{}
+	var created bool
+	server := httptest.NewServer(digestCommentMux(org, repo, []map[string]any{
+		{"id": 444, "body": advisoryDigestPrefix + " — mine", "user": map[string]any{"login": "kalantar", "type": "User"}},
+	}, patched, &created))
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, advisoryDigestPrefix+" — new"); err != nil {
+		t.Fatalf("PostAdvisoryDigest: %v", err)
+	}
+	if !patched[444] || created {
+		t.Errorf("token client behavior changed: patched=%v created=%v", patched[444], created)
+	}
+}


### PR DESCRIPTION
## Live alert
`kalantar-msb/soft-reflective`: *"last advisory post failed: updating advisory digest comment on soft-reflective#1: PATCH .../issues/comments/5243180833: 403 Resource not accessible by integration"*

## Root cause (verified live)
Comment `5243180833` on soft-reflective#1 is authored by the **human user `kalantar`** — a leftover from the user-token digest fallback removed in #1927. `findDigestComment` matches by body prefix only, so the App adopts that comment and PATCHes it every cycle. GitHub hard-forbids a GitHub App from editing any foreign-authored issue comment (403 "Resource not accessible by integration" no matter what the installation grants), so the digest is wedged permanently and no installation-side action can clear it.

## Fix
Author gate in `findDigestComment` for App-authenticated clients:
- comment authored exactly as our bot login → update in place (unchanged happy path)
- bot login unknown → any bot-authored digest comment is still adopted (refusing our own comment on a slug mismatch would duplicate a comment every cycle)
- human-authored digest comment → skipped with a loud log; the App posts ONE fresh comment and edits that from then on (no per-cycle duplication)
- token (PAT) clients keep the historical prefix-only match

## Tests
4 new regression tests in `advisory_foreign_comment_test.go`; full `./pkg/github` suite green.

## Follow-up for the repo owner (optional)
The stale kalantar-authored digest comment on soft-reflective#1 will simply stop being updated; the owner may delete it for clarity.