### PR TITLE
🐛 fix(hub): app-key delivery resolves the cluster hub-record-first, like the alert and registry

### DIFF
--- a/src/pkg/hub/app_key_cluster_precedence_test.go
+++ b/src/pkg/hub/app_key_cluster_precedence_test.go
@@ -1,0 +1,78 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// A spoke provisioned under an old cluster ID keeps reporting that ID in every
+// heartbeat. The hub's OWN record — the one the registry stamps, the
+// app-creds-undelivered alert checks the PEM store under, and the PUT
+// /api/saas/admin/cluster-app-keys/{id} remedy names — can meanwhile say the
+// hive belongs to a different cluster. Key delivery used to trust the spoke's
+// report first, so the operator could do exactly what the alert said (upload
+// the key under the hub record's cluster, "hive-oke"), have the alert confirm
+// "the hub holds a key" — and still watch every beat look the key up under the
+// spoke's stale ID ("oke-260812-8yiz") and deliver nothing, forever
+// (kelly-headwaters, #4316/#4323). The hub record must win on disagreement.
+func TestAppKeySyncForHeartbeatHubRecordClusterWinsOverStaleSpokeReport(t *testing.T) {
+	withTempAppKeyDir(t)
+	oldHives := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = oldHives })
+
+	keyPEM := testAppKeyPEM(t)
+	// The key lives where the alert told the operator to put it: the cluster
+	// the hub records for this hive.
+	if err := storeClusterAppKey("hive-oke", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &HubServer{
+		logger: appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{
+			"hive-oke": {ID: "hive-oke", GitHubAppID: 3568013, GitHubAppSlug: "kubestellar-hive"},
+		},
+	}
+
+	// The hub's record: kelly-headwaters belongs to hive-oke.
+	if err := saveSaaSHive(&SaaSHive{
+		ID:        "kelly-headwaters",
+		ClusterID: "hive-oke",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("stale spoke-reported cluster does not block delivery", func(t *testing.T) {
+		// The spoke still reports the cluster ID it was provisioned under,
+		// which the hub's cluster registry no longer knows a key for.
+		got := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:            "kelly-headwaters",
+			ClusterID:         "oke-260812-8yiz",
+			GitHubAppRequired: true,
+			GitHubAppState:    appStateKeyMissingToken,
+		})
+		if got == nil {
+			t.Fatal("no key delivered: the spoke's stale cluster ID overrode the hub's own record, the exact undelivered-key wedge")
+		}
+		if got.AppID != 3568013 {
+			t.Errorf("AppID = %d, want 3568013", got.AppID)
+		}
+		if strings.TrimSpace(got.PrivateKey) != strings.TrimSpace(keyPEM) {
+			t.Error("delivered key is not the key stored for the hub-recorded cluster")
+		}
+	})
+
+	t.Run("spoke report still serves hives without a hub record", func(t *testing.T) {
+		got := s.appKeySyncForHeartbeat(&HeartbeatPayload{
+			HiveID:    "byo-spoke-no-record",
+			ClusterID: "hive-oke",
+		})
+		if got == nil {
+			t.Fatal("a hive with no SaaS record must still resolve its cluster from the spoke's report")
+		}
+		if got.AppID != 3568013 {
+			t.Errorf("AppID = %d, want 3568013", got.AppID)
+		}
+	})
+}

--- a/src/pkg/hub/cluster_app_key.go
+++ b/src/pkg/hub/cluster_app_key.go
@@ -1322,22 +1322,43 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 	if s == nil || payload == nil {
 		return nil
 	}
-	clusterID := payload.ClusterID
 	// Load the hive's own meta once: it carries the GitHub-host pin
 	// (github_base_url) that decides whether this hive is public github.com, and
-	// it is also the fallback source for the cluster ID when the spoke did not
-	// report one.
+	// it is the AUTHORITATIVE source for the cluster ID — see below.
 	sh := loadSaaSHive(payload.HiveID)
+	// CLUSTER PRECEDENCE: the hub's own SaaS record first, the spoke's
+	// self-report only as a fallback. Every other surface already resolves it
+	// that way — the registry heartbeat handler (server.go) stamps
+	// entry.ClusterID from sh.ClusterID first, and it is THAT ID the
+	// app-creds-undelivered alert checks the PEM store under and names in its
+	// PUT /api/saas/admin/cluster-app-keys/{id} remedy. This delivery path was
+	// the one place that trusted the spoke first, so a spoke provisioned under
+	// an old cluster ID kept reporting it forever and the two paths split:
+	// the operator uploaded the key exactly where the alert said (the hub
+	// record's cluster, "hive-oke"), the alert then confirmed "the hub holds a
+	// key" — and every beat this function looked the key up under the spoke's
+	// stale ID ("oke-260812-8yiz"), found nothing, and delivered nothing.
+	// That is how kelly-headwaters stayed keyless AFTER the operator did the
+	// documented remedy (#4316/#4323). The spoke's report still serves hives
+	// with no SaaS record (bare/BYO spokes).
+	clusterID := ""
+	if sh != nil {
+		clusterID = sh.ClusterID
+	}
 	if clusterID == "" {
-		// The spoke did not report a cluster. Fall back to the hub's own record
-		// for this hive rather than guessing the default cluster: guessing would
-		// aim a GitHub Enterprise key at a public-GitHub hive.
-		if sh != nil {
-			clusterID = sh.ClusterID
-		}
+		clusterID = payload.ClusterID
 	}
 	if clusterID == "" {
 		return nil
+	}
+	if spokeCluster := payload.ClusterID; spokeCluster != "" && spokeCluster != clusterID && s.logger != nil {
+		// Say the disagreement out loud: a spoke carrying a stale cluster ID
+		// is exactly the state that made key delivery silently undeliverable.
+		s.logger.Warn("heartbeat: spoke reports a different cluster than the hub records for it — app-key reconcile follows the hub record",
+			"hive_id", payload.HiveID,
+			"spoke_cluster_id", spokeCluster,
+			"hub_cluster_id", clusterID,
+		)
 	}
 	// Is this hive pinned to public github.com while its cluster defaults to a
 	// GHE App? effectiveGitHubBaseURL honours the hive's github_base_url:"public"


### PR DESCRIPTION
## Live alert
`AI-native-Systems-Research/headwaters` (kelly-headwaters, cluster oke-260812-8yiz / hive-oke): *"GitHub App private key has not reached this spoke even though the hub holds a key for hive-oke — check heartbeat delivery, or re-upload via PUT /api/saas/admin/cluster-app-keys/hive-oke"*

## Root cause
Cluster-ID precedence split between surfaces:
- the registry heartbeat handler (`server.go`), the **app-creds-undelivered alert** (`ClusterHasKey` PEM-store check), and the documented PUT remedy all resolve the hive's cluster **hub-SaaS-record-first** → `hive-oke`, where the operator uploaded the PEM;
- heartbeat **key delivery** (`appKeySyncForHeartbeat`) trusted the **spoke's self-reported** cluster ID first → the stale provisioning-time ID `oke-260812-8yiz`, where no key exists.

So the operator did exactly what the alert said, the alert confirmed "the hub holds a key" — and every 30s beat looked the key up under the stale spoke-reported ID, found nothing, and delivered nothing. The hive sat keyless *after* the documented remedy (#4316, #4323).

## Fix
`appKeySyncForHeartbeat` now resolves the hub record first, falls back to the spoke's report only when no SaaS record exists (bare/BYO spokes), and warns loudly when the two disagree.

## Tests
New regression test `TestAppKeySyncForHeartbeatHubRecordClusterWinsOverStaleSpokeReport`; full `./pkg/hub` suite green (121s).

## Operator note
No re-upload needed: the key already stored under `hive-oke` will be delivered on the first heartbeat after this deploys.