### PR TITLE
🔒 fix(security): keep the MITM CA private key out of agent-writable /data

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -333,6 +333,26 @@ if [ "$(id -u)" = "0" ]; then
   chown dev:node /home/dev 2>/dev/null || true
   chown dev:node /etc/hive/hive.yaml 2>/dev/null || true
 
+  # Keep the MITM CA private key out of /data's agent-writable namespace.
+  # /data contains shared agent state and may be group-writable on PVCs. The
+  # certificate remains at /data/proxy-ca.pem because agents need to trust it,
+  # but the private key lives below an owner-only directory. If the legacy key
+  # is present, discard the old CA pair so a key that may already have been
+  # copied by an agent can never remain trusted. Reject symlinks so the proxy
+  # cannot be redirected to an attacker-controlled path.
+  mkdir -p /data/.hive && chown dev:node /data/.hive 2>/dev/null || true
+  chmod 700 /data/.hive 2>/dev/null || true
+  if [ -L /data/.hive/proxy-ca-key.pem ]; then
+    rm -f -- /data/.hive/proxy-ca-key.pem 2>/dev/null || true
+  fi
+  if [ -L /data/proxy-ca-key.pem ] || [ -f /data/proxy-ca-key.pem ]; then
+    # A key that was exposed in the old location may already have been copied
+    # by an agent. Do not migrate it: discard the old key and certificate so
+    # the proxy creates a fresh CA pair on this boot.
+    rm -f -- /data/proxy-ca-key.pem /data/proxy-ca.pem /data/proxy-ca-bundle.pem 2>/dev/null || true
+  fi
+  chmod 600 /data/.hive/proxy-ca-key.pem 2>/dev/null || true
+
   # Ensure the PVC secrets dir the dashboard writes API keys into
   # (/data/secrets/litellm_api_key) exists and is owned by the dev user.
   # The Go binary runs as non-root (uid 1001) and CANNOT chown, so if this

--- a/src/docs/security-model.md
+++ b/src/docs/security-model.md
@@ -142,6 +142,7 @@ The entrypoint installs an iptables REDIRECT of all outbound `:443` through the 
 
 - The hive/proxy process runs as user `dev` (UID 1001); each agent runs as its own UID from `HIVE_UID_BASE=2001` upward.
 - `su-exec` is mode **4750 `root:hive-launch`** — only root and members of the pinned `hive-launch` group (GID 1002) can exec it. This closes the earlier world-executable-setuid hole where any agent UID could become root in the pod. `HIVE_LAUNCH_GID=1002` is part of the deployment contract: Kubernetes `fsGroup` and Secret `defaultMode: 0440` rely on the numeric GID, and it must stay in sync across `src/deploy/k8s/*.yaml` and hub provisioning.
+- The MITM CA certificate is readable at `/data/proxy-ca.pem` so agent clients can trust forged certificates, but the CA private key is stored at `/data/.hive/proxy-ca-key.pem` in a `0700` directory with mode `0600`. It is never intentionally kept directly under the shared, agent-writable `/data` namespace. A legacy `/data/proxy-ca-key.pem` causes the old CA pair to be discarded on startup, because its key may already have been copied.
 
 ### Supply chain
 

--- a/src/pkg/proxy/github_proxy.go
+++ b/src/pkg/proxy/github_proxy.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -129,11 +130,14 @@ func warnSockMarkOnce(mark int, err error) {
 }
 
 // CACertPath and caKeyPath are the PVC locations of the persisted MITM CA.
+// The certificate is intentionally in /data because agents need to trust it.
+// The private key is kept in a dedicated owner-only directory: /data contains
+// agent-readable state and must not be treated as a suitable secret directory.
 // They are vars rather than consts solely so tests can redirect the CA
 // read/write to a temporary directory; production never reassigns them.
 var (
 	CACertPath = "/data/proxy-ca.pem"
-	caKeyPath  = "/data/proxy-ca-key.pem"
+	caKeyPath  = "/data/.hive/proxy-ca-key.pem"
 )
 
 // GitHubProxy is an HTTP CONNECT proxy that performs MITM TLS
@@ -1444,6 +1448,16 @@ func loadOrGenerateCA(logger *slog.Logger) (tls.Certificate, *x509.Certificate, 
 		return tls.Certificate{}, nil, fmt.Errorf("marshal CA key: %w", err)
 	}
 	caKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: caKeyDER})
+	// The parent directory is created with owner-only permissions before the
+	// key is written. /data itself is intentionally group-writable for agent
+	// workspaces, so 0600 on a file directly under /data is not sufficient:
+	// an agent could replace or race the path before the proxy opens it.
+	if err := os.MkdirAll(filepath.Dir(caKeyPath), 0700); err != nil {
+		return tls.Certificate{}, nil, fmt.Errorf("create CA key directory: %w", err)
+	}
+	if err := os.Chmod(filepath.Dir(caKeyPath), 0700); err != nil {
+		return tls.Certificate{}, nil, fmt.Errorf("restrict CA key directory: %w", err)
+	}
 	if err := os.WriteFile(caKeyPath, caKeyPEM, 0600); err != nil {
 		return tls.Certificate{}, nil, fmt.Errorf("write CA key to %s: %w", caKeyPath, err)
 	}

--- a/src/pkg/proxy/github_proxy_coverage_test.go
+++ b/src/pkg/proxy/github_proxy_coverage_test.go
@@ -346,6 +346,16 @@ func TestLoadOrGenerateCA_Roundtrip(t *testing.T) {
 	if _, err := os.Stat(caKeyPath); err != nil {
 		t.Errorf("CA key not written: %v", err)
 	}
+	if info, err := os.Stat(filepath.Dir(caKeyPath)); err != nil {
+		t.Fatalf("CA key directory not written: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o700 {
+		t.Errorf("CA key directory mode = %o, want 700", got)
+	}
+	if info, err := os.Stat(caKeyPath); err != nil {
+		t.Fatalf("stat CA key: %v", err)
+	} else if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("CA key mode = %o, want 600", got)
+	}
 
 	// Second call — should reload from disk (same serial)
 	tlsCert2, x509Cert2, err := loadOrGenerateCA(logger)


### PR DESCRIPTION
Split out of #3895 at @clubanderson's request, carrying **only** the CA-key half.
The `SETUID`/`SETGID` capability drop is deliberately not here — #3895 stays held
for that discussion.

## The problem, still present on `v4`

`src/pkg/proxy/github_proxy.go:136`

```go
caKeyPath  = "/data/proxy-ca-key.pem"
```

`/data` is the shared, agent-writable workspace namespace. `0600` on a file
sitting directly under it is not sufficient: an agent can replace the path, or
race the proxy to it, before the proxy opens it. The MITM CA private key is the
credential that forges every TLS certificate the agents trust, so it is the one
file in the image that most needs to be outside that namespace.

## What this does

- **Moves the key to `/data/.hive/proxy-ca-key.pem`**, in a `0700` directory that
  is created and `chmod`ed *before* the key is written. The certificate stays at
  `/data/proxy-ca.pem` — agents have to be able to read and trust that.
- **Does not migrate a legacy key.** If `/data/proxy-ca-key.pem` exists, the
  entrypoint discards it *and* the certificate so the proxy generates a fresh CA
  pair on that boot. A key that sat in the exposed location may already have been
  copied by an agent; migrating it would keep a possibly-compromised key trusted,
  which is the failure this change exists to prevent.
- **Rejects symlinks** at either path rather than following them, so the proxy
  cannot be redirected to an attacker-controlled file.

## Scope

Four files, and nothing from the capability half:

| file | |
| --- | --- |
| `src/pkg/proxy/github_proxy.go` | path + directory/permission enforcement |
| `src/pkg/proxy/github_proxy_coverage_test.go` | asserts `0700` on the directory, `0600` on the key |
| `src/deploy/entrypoint.sh` | the migration/discard/symlink handling |
| `src/docs/security-model.md` | one added bullet describing the key's location |

`security-model.md` in #3895 also changed the `su-exec` and hosted-fleet bullets;
both of those describe capability-drop behavior, so only the new CA-key bullet is
taken here.

## Verification

- `go build ./...` clean, `go vet ./pkg/proxy/` clean, `go test ./pkg/proxy/` passes.
- Applied cleanly to current `v4` (`9a7e745f`) — no conflicts from the #3895 gap.
- The one `shellcheck` warning in `entrypoint.sh` (SC2043, line 413) is
  pre-existing on clean `v4` and untouched here.

Refs #3895.
