### PR TITLE
🐛 fix(ci): run the Podman rootless contract check on mainline

### DIFF
--- a/.github/workflows/podman-contract.yml
+++ b/.github/workflows/podman-contract.yml
@@ -6,21 +6,31 @@ name: Podman Rootless Contract
 # live-runner test would add. Does NOT change the runtime auto-detect
 # default (Option A is explicitly deferred pending broader coverage).
 
+# Triggers cover both maintained branches. This workflow used to name `v2`
+# alone; mainline moved to `v4` and it stopped running entirely (#4339) — a
+# guard that never executes reports green forever, which is the one failure
+# mode a guard cannot have. The branch list and the self-referencing path entry
+# below mirror .github/workflows/suid-contract.yml, the sibling static contract
+# check.
 on:
   push:
     branches:
       - v2
+      - v4
     paths:
       - 'Justfile'
       - 'src/scripts/check-podman-contract.sh'
       - 'src/docs/podman-rootless-ci.md'
+      - '.github/workflows/podman-contract.yml'
   pull_request:
     branches:
       - v2
+      - v4
     paths:
       - 'Justfile'
       - 'src/scripts/check-podman-contract.sh'
       - 'src/docs/podman-rootless-ci.md'
+      - '.github/workflows/podman-contract.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

`.github/workflows/podman-contract.yml` triggered on `v2` alone. Mainline is
`v4`, so its last execution was **2026-08-12** — since then it has been passing
by never running, which is the one failure mode a guard cannot have.

Part of #4188 (does not close the parent). Closes #4339.

## The fix

Ten added lines, no deletions. Both changes mirror
`.github/workflows/suid-contract.yml`, the sibling static contract check:

1. **Branches become `v2` and `v4`.** Not a swap — `v2` is still receiving
   commits (most recent: today), so it keeps its coverage rather than trading
   one blind spot for another. `v2 + v4` is what `suid-contract.yml`,
   `v2-ci.yml`, and `v2-tests.yml` all use.
2. **The workflow's own path is added to both path filters.** This is the part
   that is easy to miss: the existing filters cover `Justfile`,
   `check-podman-contract.sh`, and `podman-rootless-ci.md`, so a PR touching
   only the workflow would **not** run it — the trigger fix could not be
   observed executing on the PR that makes it, and future edits to the workflow
   would go unchecked for the same reason. `suid-contract.yml` already lists
   itself for exactly this reason.

## What is not changed

The job, its single step, and `src/scripts/check-podman-contract.sh` are
untouched, so the contract asserted is identical — the diff contains no
deletions at all. The path filters still scope the workflow to the files it
guards.

Verified locally against the `v4` `Justfile`: all six checks pass
(`--userns=keep-id`, `:Z`, the macOS carve-out, no `docker.sock`, no
`podman.sock`, docker-before-podman auto-detect). The **Podman Rootless
Contract** check on this PR is the observed run the issue asks for, and it is
running because of change 2.

## One thing noticed, deliberately not folded in

`check-podman-contract.sh` emits `grep: warning: stray \ before -` from the
`'\-\-userns=keep-id'` pattern. It is cosmetic — the match is identical — but
it will now appear in CI logs. The issue's boundary is the triggers, so it is
left alone here rather than quietly bundled into a CI fix.

— hive: backend=claude model=claude-opus-5
