### PR TITLE
🌱 ci(podman): run the rootless startup, exit-77, and egress-gate matrix per PR

### DIFF
--- a/.github/workflows/podman-rootless-lane.yml
+++ b/.github/workflows/podman-rootless-lane.yml
@@ -1,0 +1,186 @@
+name: Podman Rootless Lane
+
+# The rootless Podman lane on hosted amd64 (#4334), lane 1 of the map in
+# src/docs/podman-ci-runner-map.md (#4211).
+#
+# It runs the three-case matrix that #4199 measured by hand:
+#
+#   default    rootless, no added capability  -> fail closed, exit 77
+#   netadmin   rootless + --cap-add NET_ADMIN -> egress redirect installed
+#   advisory   HIVE_PROXY_ADVISORY_OK=true    -> starts with the explicit warning
+#
+# The probe itself is src/deploy/probe_podman_rootless_netadmin.sh and is not
+# modified by this lane — it already exits non-zero when a case stops matching
+# the contract recorded in src/docs/podman-rootless-startup-spike.md. This
+# workflow is the wrapper that makes it run per PR instead of by hand.
+#
+# WHAT A GREEN TICK HERE DOES AND DOES NOT MEAN. The probe pulls a published
+# image, so this lane asserts that the *published* image's egress gate still
+# behaves and that the runner still provides a working rootless stack. It does
+# NOT build the PR's own image, so a change to src/deploy/entrypoint.sh is not
+# covered until that change is published. Probing a PR-built image is a
+# separate lane (the map's lane 3 covers build/pull) and deliberately out of
+# #4334's boundary, which is "wrap the existing probe in a workflow".
+#
+# No path filters, on purpose. #4339 is what a skipped guard looks like: a
+# workflow scoped so narrowly that it reports green by never running. This lane
+# is cheap enough (one image pull, three short container runs) to run on every
+# pull request rather than only on the ones that look relevant.
+#
+# Safety boundaries, from the map's "Permissions and safety boundaries":
+# contents: read and nothing more, no secrets, and no pull_request_target —
+# fork PRs are the coverage that matters most and they get no secrets anyway.
+# No engine socket is mounted anywhere. The probe builds its own throwaway
+# store with a private graphroot and runroot, so nothing touches the runner's
+# default Podman storage, and cleanup removes only the containers it created,
+# by name.
+
+on:
+  push:
+    branches:
+      - v2
+      - v4
+  pull_request:
+    branches:
+      - v2
+      - v4
+  workflow_dispatch:
+    inputs:
+      bypass:
+        description: 'Also probe interception from an agent UID (needs outbound egress)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: podman-rootless-lane-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rootless-probe:
+    name: rootless startup, exit-77, and egress gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Assert the environment, do not assume it. Podman is preinstalled on
+      # this runner image, so there is no setup step — which is exactly why the
+      # version and root mode have to be checked: a runner-image change is
+      # silent, and would otherwise turn a real regression into a test that
+      # quietly stopped covering anything.
+      #
+      # The floor is asserted; the exact version is reported. Pinning the exact
+      # version would make every benign runner bump a red build, so a
+      # difference from the version #4211 recorded is surfaced as a notice
+      # instead — visible, not fatal.
+      - name: Assert the rootless Podman stack this lane depends on
+        env:
+          RECORDED_PODMAN: '5.8.4'
+        run: |
+          # The --format strings stay single-quoted: those are Go template braces
+          # for Podman, and the shell must not touch them.
+          set -euo pipefail
+
+          if ! command -v podman >/dev/null 2>&1; then
+            echo "::error::podman is not installed on this runner; #4211 recorded it preinstalled at /usr/local/bin/podman"
+            exit 1
+          fi
+
+          version="$(podman info --format '{{.Version.Version}}')"
+          rootless="$(podman info --format '{{.Host.Security.Rootless}}')"
+          cgroups="$(podman info --format '{{.Host.CgroupsVersion}}')"
+          backend="$(podman info --format '{{.Host.NetworkBackend}}')"
+          rootlessnet="$(podman info --format '{{.Host.RootlessNetworkCmd}}')"
+          runtime="$(podman info --format '{{.Host.OCIRuntime.Name}}')"
+
+          printf 'podman      %s (%s)\n' "$version" "$(command -v podman)"
+          printf 'rootless    %s\n' "$rootless"
+          printf 'cgroups     %s\n' "$cgroups"
+          printf 'backend     %s / %s\n' "$backend" "$rootlessnet"
+          printf 'runtime     %s\n' "$runtime"
+
+          # Root mode is the assertion that decides whether this lane is
+          # testing what it claims to. Rootful is #4200's lane; if this runner
+          # ever came back rootful, every case below would still pass and would
+          # mean something else entirely.
+          if [ "$rootless" != "true" ]; then
+            echo "::error::podman reports rootless=${rootless}; this lane must run rootless (rootful is #4200)"
+            exit 1
+          fi
+
+          if [ "$cgroups" != "v2" ]; then
+            echo "::error::cgroups=${cgroups}; the rootless stack this lane probes assumes cgroup v2"
+            exit 1
+          fi
+
+          # A floor, not a pin. 4.x is the oldest series that gives rootless
+          # containers a usable --cap-add NET_ADMIN, which is the capability the
+          # whole matrix turns on.
+          major="${version%%.*}"
+          if [ "${major:-0}" -lt 4 ]; then
+            echo "::error::podman ${version} is below the 4.x floor this lane needs for rootless --cap-add NET_ADMIN"
+            exit 1
+          fi
+
+          if [ "$version" != "$RECORDED_PODMAN" ]; then
+            echo "::notice::runner Podman is ${version}; src/docs/podman-ci-runner-map.md recorded ${RECORDED_PODMAN}. Re-check the map if this lane starts behaving differently."
+          fi
+
+          {
+            printf '### Rootless Podman lane environment\n\n'
+            printf '| | |\n| --- | --- |\n'
+            printf '| Podman | `%s` (map recorded `%s`) |\n' "$version" "$RECORDED_PODMAN"
+            printf '| Root mode | rootless=`%s` |\n' "$rootless"
+            printf '| cgroups | `%s` |\n' "$cgroups"
+            printf '| Network backend | `%s` / `%s` |\n' "$backend" "$rootlessnet"
+            printf '| OCI runtime | `%s` |\n' "$runtime"
+            printf '| Runner | `%s`, image `%s` |\n' "$RUNNER_OS" "${ImageVersion:-unknown}"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      # The probe's exit status is the result. 0 means every case matched the
+      # documented contract; 1 means one did not — a gate that failed to
+      # install lands here; 78 means a prerequisite was missing, which is a
+      # broken lane rather than a passing one and must be just as loud.
+      #
+      # There is deliberately no continue-on-error and no `|| true`: the whole
+      # point of the lane is that a regression fails the job.
+      - name: Rootless startup, exit-77, and egress-gate matrix (#4199)
+        env:
+          BYPASS: ${{ inputs.bypass }}
+        run: |
+          set -uo pipefail
+
+          args=""
+          if [ "${BYPASS:-false}" = "true" ]; then
+            args="--bypass"
+          fi
+
+          # The runner invokes this with `bash -e`, so errexit has to come off
+          # deliberately: the probe's exit status IS the result, and it has to
+          # survive to the diagnosis below instead of aborting the step early.
+          set +e
+          # shellcheck disable=SC2086 # args is a deliberate single optional flag
+          bash src/deploy/probe_podman_rootless_netadmin.sh $args
+          status=$?
+          set -e
+
+          case "$status" in
+            0)
+              echo "::notice::rootless matrix matched the documented contract"
+              printf '\n✅ The three-case rootless matrix matched the contract in `src/docs/podman-rootless-startup-spike.md`.\n' >>"$GITHUB_STEP_SUMMARY"
+              ;;
+            78)
+              echo "::error::the probe could not run — a prerequisite is missing (EX_CONFIG). A lane that cannot run is not a lane that passed."
+              printf '\n❌ Prerequisite missing (exit 78). See the log for which one.\n' >>"$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "::error::the rootless matrix no longer matches the documented contract (exit ${status})"
+              printf '\n❌ The rootless matrix did not match the contract (exit %s).\n' "$status" >>"$GITHUB_STEP_SUMMARY"
+              ;;
+          esac
+
+          exit "$status"

--- a/src/docs/podman-ci-runner-map.md
+++ b/src/docs/podman-ci-runner-map.md
@@ -91,6 +91,15 @@ needs one.
 
 ### 1. Rootless, hosted — the primary lane
 
+> **Built (#4334):** `.github/workflows/podman-rootless-lane.yml` runs the
+> three-case matrix per PR on `ubuntu-latest`. It asserts the discovered Podman
+> version floor, rootless mode, and cgroup version before probing, reports the
+> exact version against the one recorded below, and does not swallow the
+> probe's exit status. What it does *not* do is build the PR's own image — it
+> probes a published one, so an unpublished change to `src/deploy/entrypoint.sh`
+> is not yet covered.
+
+
 Everything in the rootless matrix runs here: default startup and exit 77,
 `--cap-add NET_ADMIN` with the redirect installed, deliberate advisory mode,
 bypass resistance, the preflight checks, and Compose-provider selection.
@@ -209,9 +218,10 @@ Applies to every lane above.
 Deliberately not opened here; a maintainer can file them as-is. Each is
 `Part of #4188` and none should close it.
 
-1. **CI: rootless Podman lane on hosted amd64.** Wrap the #4199 probe script
-   in a workflow on `ubuntu-latest`. Assert the discovered Podman version and root mode. AC: the
-   three-case matrix runs per PR; a gate that fails to install fails the job.
+1. ~~**CI: rootless Podman lane on hosted amd64.**~~ **Done (#4334)** —
+   `.github/workflows/podman-rootless-lane.yml`. Wrapped the #4199 probe script
+   in a workflow on `ubuntu-latest`, asserting the discovered Podman version and
+   root mode.
 2. **CI: rootful Podman lane on hosted amd64.** `sudo podman`, the #4200
    baseline. AC: no secrets, no `pull_request_target`, rootful mode asserted.
 3. **CI: `arm64` build/pull and startup lane.** `ubuntu-24.04-arm`, scoped to

--- a/src/docs/podman-rootless-startup-spike.md
+++ b/src/docs/podman-rootless-startup-spike.md
@@ -49,6 +49,10 @@ verified untouched afterwards.
 src/deploy/probe_podman_rootless_netadmin.sh --bypass
 ```
 
+CI runs exactly this, per pull request, on `ubuntu-latest`:
+`.github/workflows/podman-rootless-lane.yml` (#4334). A case that stops
+matching the contract recorded here fails that job.
+
 It creates its own throwaway store by default, removes only the containers it
 created, by name, and exits non-zero if any case stops matching the contract
 recorded here. It deletes its own store with `podman unshare rm -rf`, because


### PR DESCRIPTION
## What

`.github/workflows/podman-rootless-lane.yml` — lane 1 of the map in
`src/docs/podman-ci-runner-map.md` (#4211). It runs
`src/deploy/probe_podman_rootless_netadmin.sh` (#4199) on `ubuntu-latest`, per
PR. The probe itself is **not modified**.

Part of #4188 (does not close the parent). Closes #4334.

## The three cases, now running per PR

| Case | Expectation |
| --- | --- |
| default rootless | fail closed, **exit 77** |
| `--cap-add NET_ADMIN` | egress redirect **installed** |
| `HIVE_PROXY_ADVISORY_OK=true` | starts with the explicit advisory warning |

The probe already exits non-zero when any case stops matching the contract in
`src/docs/podman-rootless-startup-spike.md`, so the lane is the wrapper that
makes it run instead of sitting there.

## Asserting the environment rather than trusting it

Podman is preinstalled on this runner, so there is no setup step — which is
exactly why the environment needs checking. A runner-image change is silent and
would otherwise turn a real regression into a test that quietly stopped
covering anything.

- **`rootless` must be `true`.** This is the assertion that decides whether the
  lane tests what it claims to: a rootful runner would pass all three cases and
  mean something else entirely (that is #4200's lane).
- **cgroups v2**, and **Podman ≥ 4.x** — the floor for rootless
  `--cap-add NET_ADMIN`.
- Exact version, network backend, rootless helper, OCI runtime, and runner
  image go into the **job summary**, and the version is compared against the
  `5.8.4` #4211 recorded. A mismatch is a `::notice`, not a failure — pinning
  the exact version would make every benign runner bump a red build, so drift
  is made *visible* rather than fatal.

## Not swallowing the result

No `continue-on-error`, no `|| true`. The runner invokes `run:` blocks with
`bash -e`, so errexit is lifted deliberately around the probe call — otherwise
the step would abort before the diagnosis — and the probe's status is then
re-raised as the step's exit code. **Exit 78 (missing prerequisite) fails just
as loudly as exit 1**, because a lane that could not run is not a lane that
passed.

## Safety

`permissions: contents: read` and nothing more, **no secrets**, **no
`pull_request_target`**, no engine socket mounted anywhere. The probe builds its
own throwaway store with a private graphroot and runroot, so the runner's
default Podman storage is untouched. I verified the image pulls **anonymously**
from GHCR (`v4-latest` → HTTP 200 with an anonymous token), so fork PRs — the
coverage that matters most — work without credentials.

**No path filters, deliberately.** #4339 is what a skipped guard looks like; a
lane scoped so narrowly it reports green by never running is the failure mode
worth avoiding, and this one is cheap enough for every PR.

## What a green tick here does and does not mean

Stated in the workflow header rather than left for someone to discover: the
probe pulls a **published** image. Green means the published image's gate still
behaves and the runner still provides a working rootless stack. It does **not**
build the PR's own image, so an unpublished change to `src/deploy/entrypoint.sh`
is not yet covered by this lane. Probing a PR-built image is a separate lane and
outside #4334's boundary of "wrap the existing probe in a workflow".

## Verification

Run locally first on Podman 5.8.4 / netavark + pasta / crun / cgroup v2 — the
same stack #4211 measured on the runner. The capability bounding sets came back
identical to the spike (`…800405fb` without, `…800415fb` with `--cap-add`), and
case 1 reported `exit: 77 … as documented`.

The lane also runs **on this PR**, which is the real check: it exercises the
workflow on `ubuntu-latest` rather than on my Fedora box. I will follow up with
the result.

Docker behavior is unchanged and no Docker workflow is touched.

— hive: backend=claude model=claude-opus-5
