### PR TITLE
🌱 ci(podman): gate Quadlet unit generation in both root modes

### DIFF
--- a/.github/workflows/quadlet-gate.yml
+++ b/.github/workflows/quadlet-gate.yml
@@ -1,0 +1,157 @@
+name: Quadlet Generator Gate
+
+# The Quadlet generator syntax gate (#4338), lane 5 of the map in
+# src/docs/podman-ci-runner-map.md (#4211).
+#
+# ADR-0017 chose Quadlet `.container`/`.pod` units as the Podman persistent
+# lifecycle. A unit that fails to generate should fail CI rather than surface
+# at deploy time, so this job runs `quadlet --dryrun` in BOTH modes the ADR
+# installs into — rootful and `--user` — over whatever Quadlet units the
+# repository holds.
+#
+# THE TRAP #4211 NAMES. The generator is a separate binary from `podman`, and
+# the hosted runner has podman WITHOUT it: the runner image carries a
+# hand-installed /usr/local/bin/podman rather than the distribution package, so
+# /usr/libexec/podman/quadlet does not exist. A gate that runs `quadlet` only
+# when it happens to be there reports green while testing nothing. This job
+# therefore installs the generator, verifies it, and has no skip path at all —
+# every failure mode below is a red build.
+#
+# WHY THE GENERATOR COMES FROM A CONTAINER IMAGE. Two other ways to get it were
+# available and neither works:
+#
+#   * `apt-get install podman` on ubuntu-24.04 installs the generator, but at
+#     podman 4.9.3 (measured: `apt-cache policy podman`). ADR-0017's binding
+#     constraint is 5.0.0 — `.pod` units and `Notify=healthy` both first
+#     shipped there — so the packaged generator cannot express the layout this
+#     gate exists to check.
+#   * The runner's own podman 5.8.4 ships no generator to borrow.
+#
+# The official Podman image carries a matched generator (5.8.4, the same
+# version every #4201/#4202/#4203 spike measured), and pinning it by digest
+# makes the version this gate ran against explicit and reproducible instead of
+# something that drifts silently with the runner image. Only the generator
+# BINARY is used — no container is started by the gate, nothing is nested.
+#
+# WHAT THIS GATE IS NOT. `quadlet --dryrun` is a syntax and reference check,
+# not a semantic one. ADR-0017 records three things it exits 0 on:
+# `Notify=healthy` with no `HealthCmd`, `PublishPort=` on a pod member, and a
+# short-name image. The first two need Hive's own assertions and stay out of
+# scope; the third IS caught, because the generator warns about it while still
+# exiting 0 — so the gate fails on any generator diagnostic, not just on a
+# non-zero exit.
+#
+# NO UNITS YET, AND THE JOB SAYS SO. The repository holds no Quadlet units —
+# the deployment asset is a separate slice downstream of ADR-0017, and #4338's
+# boundary is explicitly a syntax gate rather than a unit. Per its stop
+# condition the gate covers the generator's presence and dry-run capability
+# only. That is not a vacuous pass: the script runs known-good AND known-bad
+# units through the same path the real ones will take, so the gate proves it
+# can fail today. When units land anywhere in the tree they are picked up with
+# no change to this workflow.
+#
+# No path filters, on purpose. #4339 is what a guard scoped into silence looks
+# like. No secrets, no pull_request_target, contents: read.
+
+on:
+  push:
+    branches:
+      - v2
+      - v4
+  pull_request:
+    branches:
+      - v2
+      - v4
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quadlet-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quadlet-gate:
+    name: quadlet --dryrun, rootful and --user
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # quay.io/podman/stable, podman 5.8.4. Pinned by index digest so the
+      # generator version is a property of this file rather than of whatever
+      # the tag points at today. To move it: pull the new tag, take
+      # `skopeo inspect --format '{{.Digest}}' docker://quay.io/podman/stable`,
+      # and update the version in this comment to match.
+      PODMAN_IMAGE: quay.io/podman/stable@sha256:312a77be1ff51c7a124da1ffd0456802f11aeb338319b3b8b9d37358f9903fc7
+      QUADLET_PATH: /usr/libexec/podman/quadlet
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install the Quadlet generator
+        run: |
+          set -euo pipefail
+          podman pull -q "$PODMAN_IMAGE"
+          echo "pulled $PODMAN_IMAGE"
+
+      # AC: the job fails if the generator is missing rather than passing
+      # vacuously. This is its own step so that "the generator is there" is a
+      # visible, separately-reported fact and not something buried in the gate
+      # script's output.
+      - name: Verify the generator is present
+        id: verify
+        run: |
+          set -uo pipefail
+
+          if ! podman run --rm "$PODMAN_IMAGE" test -x "$QUADLET_PATH"; then
+            echo "::error::${PODMAN_IMAGE} has no executable at ${QUADLET_PATH}. #4211 names this as the trap: podman can be present without its generator, and a gate that skips here would report green while checking nothing."
+            exit 1
+          fi
+
+          version="$(podman run --rm "$PODMAN_IMAGE" "$QUADLET_PATH" -version 2>/dev/null | tr -d '[:space:]')"
+          if [ -z "$version" ]; then
+            echo "::error::the generator at ${QUADLET_PATH} did not report a version"
+            exit 1
+          fi
+
+          printf 'quadlet %s at %s\n' "$version" "$QUADLET_PATH"
+          echo "version=${version}" >>"$GITHUB_OUTPUT"
+
+          {
+            printf '### Quadlet generator gate\n\n'
+            printf '| | |\n| --- | --- |\n'
+            printf '| Generator | `quadlet %s` |\n' "$version"
+            printf '| Source | `%s` |\n' "$PODMAN_IMAGE"
+            printf '| Modes | rootful and `--user` |\n'
+            printf '| ADR-0017 floor | requires `5.0.0`, recommends `5.6.0` |\n'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      # The gate's exit status is the result and this step does not swallow it:
+      # no continue-on-error, no `|| true`. The repository is mounted read-only
+      # — the gate reads units and writes its fixtures to the container's own
+      # /tmp, so it has no reason to touch the checkout. No SELinux relabeling
+      # flag is needed: #4211 measured hosted runners as having no SELinux at
+      # all (AppArmor instead).
+      - name: Run the gate
+        run: |
+          set -uo pipefail
+
+          set +e
+          podman run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace:ro" \
+            -w /workspace \
+            "$PODMAN_IMAGE" \
+            bash src/deploy/test_quadlet_generator_gate.sh
+          status=$?
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            echo "::notice::the Quadlet generator gate passed (quadlet ${{ steps.verify.outputs.version }})"
+            printf '\n✅ Generator present, and `--dryrun` proven able to fail in both modes.\n' >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::the Quadlet generator gate failed (exit ${status}); see the log for which assertion"
+            printf '\n❌ The Quadlet gate failed (exit %s).\n' "$status" >>"$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit "$status"

--- a/src/deploy/test_quadlet_generator_gate.sh
+++ b/src/deploy/test_quadlet_generator_gate.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Quadlet generator syntax gate (kubestellar/hive#4338).
+#
+# ADR-0017 chose Quadlet `.container`/`.pod` units as the Podman persistent
+# lifecycle. A unit that fails to generate should fail CI, not surface at
+# deploy time — so this gate runs the Podman systemd generator over whatever
+# Quadlet units the repository holds, in BOTH modes the ADR installs into:
+# rootful (system manager search path) and `--user` (per-user manager).
+#
+# WHAT THIS GATE IS NOT. `quadlet --dryrun` is a syntax and reference check,
+# never a semantic one. ADR-0017 records three things it exits 0 on:
+# `Notify=healthy` with no `HealthCmd`, `PublishPort=` on a pod member, and a
+# short-name image. The first two need Hive's own assertions and are out of
+# this gate's scope; the third IS caught here, because the generator emits a
+# `Warning:` for it even while exiting 0 — see the warning rule below.
+#
+# THE TRAP THIS GATE IS BUILT AROUND (#4211). The generator is a separate
+# binary from `podman`, and a runner can have podman without it — the hosted
+# GitHub runners are exactly that case, because they carry a hand-installed
+# /usr/local/bin/podman rather than the distribution package. A gate that
+# merely skips when the generator is absent reports green while testing
+# nothing. So there is NO skip path in this script: a missing generator is a
+# failure, not a skip.
+#
+# EXIT STATUS IS NOT THE ONLY SIGNAL. The generator exits 0 while printing
+# `Warning: ... not a fully qualified image name`, and ADR-0017 requires fully
+# qualified references because `podman auto-update` cannot resolve a short
+# name — a deploy-time failure the exit status would wave through. This gate
+# therefore fails on ANY generator diagnostic, not just a non-zero exit: after
+# the always-present "Loading source unit file" debug lines are filtered out,
+# `--dryrun` writes to stderr only when it has something to complain about.
+# The rule is deliberately conservative in the failing direction; a new benign
+# stderr line upstream would show up as a red build rather than as silently
+# reduced coverage, which is the correct way round for a gate.
+#
+# NO UNITS YET. At the time of writing the repository holds no Quadlet units —
+# the deployment asset is a separate slice downstream of ADR-0017. Per #4338's
+# stop condition the gate then covers the generator's PRESENCE and DRY-RUN
+# CAPABILITY only, and says so out loud rather than reporting a vacuous pass.
+# The self-tests below are what make that meaningful: they run known-good and
+# known-bad units through the same code path the real units will take, so the
+# gate proves it can FAIL today, before there is anything real to catch. When
+# units land anywhere in the tree, they are picked up with no change here.
+#
+# Usage:
+#   src/deploy/test_quadlet_generator_gate.sh [options]
+#
+#   --quadlet PATH  generator binary (default: search the usual locations)
+#   --units DIR     gate this directory instead of scanning the repository
+#
+# Exit codes: 0 the gate passed, 1 the gate failed. There is no skip code.
+
+set -uo pipefail
+
+QUADLET_BIN="${QUADLET_BIN:-}"
+UNITS_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quadlet) QUADLET_BIN="${2:?--quadlet needs a value}"; shift 2 ;;
+    --units)   UNITS_DIR="${2:?--units needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) printf 'ERROR: unknown argument %q\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORK="$(mktemp -d)"
+# shellcheck disable=SC2329 # invoked through the EXIT trap below
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+failures=0
+fail() { printf '  FAIL: %s\n' "$1"; [[ $# -gt 1 ]] && printf '        %s\n' "$2"; failures=$((failures + 1)); }
+pass() { printf '  PASS: %s\n' "$1"; }
+
+printf '=== Quadlet generator syntax gate (#4338) ===\n\n'
+
+# ── 1. The generator must be present. A missing one fails. ──────────────────
+printf -- '--- generator ---\n'
+if [[ -z "$QUADLET_BIN" ]]; then
+  for candidate in \
+    /usr/libexec/podman/quadlet \
+    /usr/lib/podman/quadlet \
+    /usr/lib/systemd/system-generators/podman-system-generator \
+    /usr/local/libexec/podman/quadlet; do
+    if [[ -x "$candidate" ]]; then QUADLET_BIN="$candidate"; break; fi
+  done
+fi
+if [[ -z "$QUADLET_BIN" ]] && command -v quadlet >/dev/null 2>&1; then
+  QUADLET_BIN="$(command -v quadlet)"
+fi
+
+if [[ -z "$QUADLET_BIN" || ! -x "$QUADLET_BIN" ]]; then
+  fail "the Quadlet generator is installed" \
+       "not found in the usual locations. #4211: podman can be present without it — the runner image carries a hand-installed podman and no generator. A gate that skips here tests nothing, so this is a failure."
+  printf '\nSUMMARY: %d failure(s)\n' "$failures"
+  exit 1
+fi
+pass "generator found at ${QUADLET_BIN}"
+
+version="$("$QUADLET_BIN" -version 2>/dev/null | tr -d '[:space:]')"
+if [[ -z "$version" ]]; then
+  fail "generator reports a version" "\`${QUADLET_BIN} -version\` printed nothing"
+else
+  pass "generator version ${version}"
+fi
+
+# ADR-0017's binding constraint: `.pod` units and `Notify=healthy` both first
+# shipped in 5.0.0, so a pod-based layout with a readiness gate is not
+# expressible below it. 5.6.0 is the ADR's recommended floor (the #26105
+# wrong-`--pod`-name fix); below that is reported, not failed, because Hive's
+# layout sets PodName= explicitly and is outside that regression window.
+q_major="${version%%.*}"; q_rest="${version#*.}"; q_minor="${q_rest%%.*}"
+if [[ "${q_major:-0}" =~ ^[0-9]+$ ]]; then
+  if (( q_major < 5 )); then
+    fail "generator meets ADR-0017's 5.0.0 requirement" \
+         "found ${version}; .pod units and Notify=healthy both need 5.0.0, so this generator cannot express the chosen layout"
+  else
+    pass "generator meets ADR-0017's 5.0.0 requirement"
+    if (( q_major == 5 && ${q_minor:-0} < 6 )); then
+      printf '  NOTE: %s is below ADR-0017'"'"'s recommended 5.6.0 floor (podman#26105).\n' "$version"
+    fi
+  fi
+fi
+
+# ── 2. Dry-run capability, in both modes, proven able to fail ───────────────
+# Every fixture is generated here rather than committed: #4338's boundary is a
+# syntax gate and explicitly not a deployment unit, and a unit file living in
+# the tree is exactly the thing that could later be mistaken for one.
+mkfixture() {
+  local name="$1"; shift
+  local dir="${WORK}/fx-${name}"
+  mkdir -p "$dir"
+  cat >"${dir}/gate-fixture.container"
+  printf '%s' "$dir"
+}
+
+# Sets RC and DIAG (the generator's stderr with its unconditional
+# "Loading source unit file" debug lines removed).
+run_quadlet() {
+  local mode="$1" dirs="$2"
+  local errf="${WORK}/stderr"
+  if [[ "$mode" == "user" ]]; then
+    QUADLET_UNIT_DIRS="$dirs" "$QUADLET_BIN" --user --dryrun >"${WORK}/stdout" 2>"$errf"
+  else
+    QUADLET_UNIT_DIRS="$dirs" "$QUADLET_BIN" --dryrun >"${WORK}/stdout" 2>"$errf"
+  fi
+  RC=$?
+  DIAG="$(grep -v 'Loading source unit file' "$errf" | grep -v '^[[:space:]]*$' || true)"
+}
+
+# A unit is clean only when the generator both exits 0 AND says nothing.
+quadlet_clean() { [[ "$RC" -eq 0 && -z "$DIAG" ]]; }
+
+good_dir="$(mkfixture good <<'EOF'
+[Unit]
+Description=Quadlet gate fixture — known good
+
+[Container]
+Image=ghcr.io/kubestellar/hive:v4-latest
+ContainerName=hive-quadlet-gate-fixture
+PublishPort=127.0.0.1:13001:3001
+
+[Install]
+WantedBy=default.target
+EOF
+)"
+
+# Rejected outright by the generator (non-zero exit).
+badkey_dir="$(mkfixture unsupported-key <<'EOF'
+[Container]
+Image=ghcr.io/kubestellar/hive:v4-latest
+ThisKeyDoesNotExist=true
+EOF
+)"
+
+dangling_dir="$(mkfixture dangling-pod <<'EOF'
+[Container]
+Image=ghcr.io/kubestellar/hive:v4-latest
+Pod=no-such-unit.pod
+EOF
+)"
+
+# The one that matters most: the generator exits 0 here and only WARNS. If this
+# gate ever regressed to trusting the exit status, this is the case that would
+# start sailing through — and a short name is what breaks `podman auto-update`,
+# which ADR-0017 depends on.
+shortname_dir="$(mkfixture short-name <<'EOF'
+[Container]
+Image=hive:v4-latest
+EOF
+)"
+
+for mode in system user; do
+  printf -- '\n--- dry-run capability: %s mode ---\n' "$mode"
+
+  run_quadlet "$mode" "$good_dir"
+  if quadlet_clean; then
+    pass "${mode}: a well-formed unit generates cleanly"
+  else
+    fail "${mode}: a well-formed unit generates cleanly" \
+         "exit ${RC}${DIAG:+; }${DIAG}"
+  fi
+
+  # The generated unit must actually be a systemd service, not empty output.
+  if ! grep -q '^ExecStart=' "${WORK}/stdout"; then
+    fail "${mode}: the dry-run emitted a service unit" \
+         "no ExecStart= in the generated output — the generator ran but produced nothing usable"
+  else
+    pass "${mode}: the dry-run emitted a service unit with an ExecStart"
+  fi
+
+  run_quadlet "$mode" "$badkey_dir"
+  if quadlet_clean; then
+    fail "${mode}: an unsupported key is rejected" \
+         "the generator accepted ThisKeyDoesNotExist= — this gate cannot catch a malformed unit"
+  else
+    pass "${mode}: an unsupported key is rejected (exit ${RC})"
+  fi
+
+  run_quadlet "$mode" "$dangling_dir"
+  if quadlet_clean; then
+    fail "${mode}: a dangling .pod reference is rejected" \
+         "the generator accepted Pod=no-such-unit.pod — a unit that cannot start would reach deploy"
+  else
+    pass "${mode}: a dangling .pod reference is rejected (exit ${RC})"
+  fi
+
+  run_quadlet "$mode" "$shortname_dir"
+  if [[ "$RC" -eq 0 && -z "$DIAG" ]]; then
+    fail "${mode}: a short-name image is caught" \
+         "the generator neither failed nor warned. ADR-0017 requires fully qualified references for podman auto-update, so this gate would let a deploy-time failure through."
+  elif [[ "$RC" -eq 0 ]]; then
+    pass "${mode}: a short-name image is caught by the warning rule, not the exit status"
+  else
+    pass "${mode}: a short-name image is rejected (exit ${RC})"
+  fi
+done
+
+# ── 3. The repository's own Quadlet units ───────────────────────────────────
+printf -- '\n--- repository units ---\n'
+if [[ -n "$UNITS_DIR" ]]; then
+  unit_dirs="$UNITS_DIR"
+  mapfile -t units < <(find "$UNITS_DIR" -maxdepth 1 -type f \
+    \( -name '*.container' -o -name '*.pod' -o -name '*.volume' \
+       -o -name '*.network' -o -name '*.kube' -o -name '*.build' \) | sort)
+else
+  # Scanned repo-wide on purpose. Pinning one directory would mean units that
+  # land somewhere else are silently ungated — the same vacuous-pass failure
+  # mode as skipping on a missing generator.
+  mapfile -t units < <(find "$REPO_ROOT" \
+    \( -name .git -o -name node_modules -o -name vendor \) -prune -o \
+    -type f \( -name '*.container' -o -name '*.pod' -o -name '*.volume' \
+       -o -name '*.network' -o -name '*.kube' -o -name '*.build' \) -print | sort)
+  unit_dirs=""
+  for u in "${units[@]}"; do
+    d="$(dirname "$u")"
+    case ":${unit_dirs}:" in *":${d}:"*) ;; *) unit_dirs="${unit_dirs:+${unit_dirs}:}${d}" ;; esac
+  done
+fi
+
+if [[ "${#units[@]}" -eq 0 ]]; then
+  printf '  none found.\n'
+  printf '  This gate therefore covers the generator'"'"'s PRESENCE and DRY-RUN CAPABILITY\n'
+  printf '  only — #4338'"'"'s stop condition — and not any Hive unit, because the\n'
+  printf '  deployment asset is a separate slice downstream of ADR-0017. The\n'
+  printf '  self-tests above are what keep that from being a vacuous pass.\n'
+else
+  printf '  %d unit(s) found:\n' "${#units[@]}"
+  printf '    %s\n' "${units[@]#"${REPO_ROOT}/"}"
+  # All unit directories are passed together so a .container joining a .pod
+  # resolves its reference the way it will on a real host.
+  for mode in system user; do
+    run_quadlet "$mode" "$unit_dirs"
+    if quadlet_clean; then
+      pass "${mode}: every repository unit generates cleanly"
+    else
+      fail "${mode}: every repository unit generates cleanly" \
+           "exit ${RC}${DIAG:+; }${DIAG}"
+    fi
+  done
+fi
+
+printf '\nSUMMARY: %d failure(s)\n' "$failures"
+[[ "$failures" -eq 0 ]] || exit 1
+exit 0

--- a/src/docs/podman-ci-runner-map.md
+++ b/src/docs/podman-ci-runner-map.md
@@ -160,6 +160,17 @@ SELinux at all.
 
 ### 5. Quadlet generator gate
 
+> **Built (#4338):** `.github/workflows/quadlet-gate.yml` runs
+> `src/deploy/test_quadlet_generator_gate.sh` per PR on `ubuntu-latest`. It
+> takes the generator from the official Podman image pinned by digest rather
+> than from `apt` — Ubuntu 24.04 packages podman 4.9.3, below the 5.0.0 that
+> ADR-0017 derives as its binding constraint — verifies the binary is present
+> before running anything, and dry-runs both rootful and `--user`. It fails on
+> any generator diagnostic rather than on the exit status alone, because the
+> generator warns about a short-name image while still exiting 0. No Quadlet
+> units exist yet, so what it gates today is the generator's presence and
+> dry-run capability; known-bad fixtures keep that from being a vacuous pass.
+
 Small and hosted, but it needs its own issue precisely because of the
 generator-absent finding. The lane must install the generator (the distribution
 `podman` package, or the generator binary alone) and then **verify it is


### PR DESCRIPTION
## What

Adds a per-PR gate that runs the Podman systemd generator over the
repository's Quadlet units, in both modes ADR-0017 installs into:

- `.github/workflows/quadlet-gate.yml` — installs the generator, verifies it,
  runs the gate on `ubuntu-latest`.
- `src/deploy/test_quadlet_generator_gate.sh` — the gate itself, runnable by
  hand on any host that has the generator.

ADR-0017 (#4325, PR #4342) chose Quadlet `.container`/`.pod` units as the
Podman persistent lifecycle, so a unit that fails to generate should fail CI
rather than surface at deploy time. Nothing ran the generator per PR.

## Acceptance criteria

**The job fails if the generator is missing rather than passing vacuously.**
This is the trap #4211 names, and it is not hypothetical — the hosted runner
has podman *without* the generator, because its `/usr/local/bin/podman` is
hand-installed rather than the distribution package, so
`/usr/libexec/podman/quadlet` does not exist. There is no skip path anywhere in
either file: a missing generator is a failure. Presence is verified in its own
workflow step so it is a separately reported fact, and the script re-checks it
rather than trusting the caller.

**Both `--user` and rootful dry-runs are exercised.** Every check below runs
twice, once per mode. They are genuinely different code paths — rootful
generates `Wants=network-online.target`, `--user` generates
`Wants=podman-user-wait-network-online.service`.

**A generator warning that would become a deploy-time failure fails the job.**
Exit status alone is not enough, and this is measured rather than assumed:

```
$ QUADLET_UNIT_DIRS=... quadlet --user --dryrun   # unit with Image=alpine
quadlet-generator[…]: Warning: u.container specifies the image "alpine" which
not a fully qualified image name. …
exit 0
```

ADR-0017 requires fully qualified references because `podman auto-update`
cannot resolve a short name, so that warning *is* a deploy-time failure and the
exit status waves it through. The gate therefore fails on any generator
diagnostic, after filtering the unconditional `Loading source unit file` debug
lines that `--dryrun` always emits. The rule is deliberately conservative in
the failing direction: a new benign stderr line upstream shows up as a red
build rather than as silently reduced coverage, which is the correct way round
for a gate.

## Where the generator comes from, and why not `apt`

Two other sources were checked and neither works:

| Source | Generator | Verdict |
| --- | --- | --- |
| Runner's own podman 5.8.4 | none | hand-installed binary, no `/usr/libexec/podman/quadlet` — the #4211 finding |
| `apt-get install podman` on ubuntu-24.04 | 4.9.3 | below ADR-0017's binding constraint |
| `quay.io/podman/stable`, digest-pinned | 5.8.4 | used |

4.9.3 is measured (`apt-cache policy podman`), not recalled. ADR-0017's floor is
5.0.0 because `.pod` units and `Notify=healthy` both first shipped there, so the
packaged generator cannot express the layout this gate exists to check. The
image is pinned by digest so the generator version is a property of this
workflow rather than something that drifts with the runner image, and 5.8.4 is
the same version every #4201/#4202/#4203 spike measured. Only the generator
*binary* is used — the gate starts no containers, so nothing is nested.

## Stop condition: no units exist yet

The repository holds no Quadlet units; the deployment asset is a separate slice
downstream of ADR-0017, and #4338's boundary is explicitly a syntax gate and
not a unit. Per the stop condition the gate covers the generator's presence and
dry-run capability, and **says so in its own output** rather than reporting a
silent pass:

```
--- repository units ---
  none found.
  This gate therefore covers the generator's PRESENCE and DRY-RUN CAPABILITY
  only — #4338's stop condition — and not any Hive unit, because the
  deployment asset is a separate slice downstream of ADR-0017. The
  self-tests above are what keep that from being a vacuous pass.
```

That last sentence is the point. The gate runs known-good **and known-bad**
units through the same code path the real ones will take, so it demonstrably
fails today, before there is anything real to catch:

| Fixture | Generator behaviour | Gate |
| --- | --- | --- |
| well-formed unit | exit 0, silent, emits an `ExecStart=` | must pass |
| unsupported key | exit 1 | must catch |
| dangling `.pod` reference | exit 1 | must catch |
| short-name image | **exit 0** + `Warning:` | must catch *via the warning rule* |

If any of those stops behaving, the gate fails — including the good one, so a
generator that rejects everything cannot look like a clean run. Fixtures are
generated at runtime rather than committed, so nothing in the tree can be
mistaken for the deployment unit this issue is not adding.

Units landing anywhere in the repository are picked up with no change here: the
scan is repo-wide rather than pinned to one directory, since a unit added
somewhere unexpected would otherwise be silently ungated — the same vacuous-pass
failure mode as skipping on a missing generator.

## Verified locally

Both files were exercised against a real generator (podman 5.8.4, Fedora), on
the host and inside the pinned image:

| Case | Exit |
| --- | --- |
| repo scan, generator present | `0` |
| `--quadlet /nonexistent/quadlet` | `1` |
| `--units` pointing at a unit with an unsupported key | `1` |
| `--units` pointing at a unit with a short-name image | `1` (warning rule, generator exited 0) |
| `--units` pointing at a well-formed unit | `0` |
| whole gate inside `quay.io/podman/stable@sha256:312a77…` | `0` |

## What this gate is not

`quadlet --dryrun` is a syntax and reference check, never a semantic one.
ADR-0017 records three things it exits 0 on: `Notify=healthy` with no
`HealthCmd`, `PublishPort=` on a pod member, and a short-name image. The third
is caught here through the warning rule; the first two need Hive's own
assertions and are deliberately out of scope. Also unchanged: no deployment
units, no Docker behaviour, `contents: read`, no secrets, no
`pull_request_target`.

`src/docs/podman-ci-runner-map.md` lane 5 gets a "Built (#4338)" note, matching
how lanes 1 and 2 are recorded.

Part of #4188 — this PR does not close the parent. Closes #4338.

— hive: backend=claude model=claude-opus-5
