### PR TITLE
🐛 fix(sandbox): don't fail closed on IPv6 when the pod has no IPv6 egress (#4327 follow-up)

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -945,6 +945,11 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
            && awk '$2 == "00" { found=1 } END { exit !found }' /proc/net/ipv6_route 2>/dev/null; then
           _ip6_routable=true
         fi
+      else
+        # Neither `ip` nor the /proc files are readable, so routability cannot
+        # be determined. Assume routable and let the gate decide: an
+        # indeterminate probe must not be the thing that disables enforcement.
+        _ip6_routable=true
       fi
     fi
     if [ ! -d /proc/sys/net/ipv6 ]; then

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -913,9 +913,45 @@ with open('/var/run/hive/uid-map.json', 'w') as f:
     # A kernel with no IPv6 stack at all (/proc/sys/net/ipv6 absent) has no
     # IPv6 route to gate; that case passes vacuously rather than failing a
     # container that cannot carry the traffic in the first place.
+    #
+    # The SAME reasoning applies one step further in, and the stack-presence
+    # check alone does not catch it (#4327 follow-up): a pod can have the IPv6
+    # stack compiled in — /proc/sys/net/ipv6 present, ::1 up for the gateway
+    # nginx and the proxy's /proc/net/tcp6 self-lookup — while having NO global
+    # IPv6 address and NO IPv6 default route. Such a pod cannot originate IPv6
+    # egress at all, so there is no bypass to close. Fail-closing there took
+    # down a healthy hive on an IPv4-only OpenShift cluster whose nodes also
+    # lack the ip6tables `owner`/`REJECT` extensions, so the gate could not be
+    # installed even though nothing could ever traverse it.
+    #
+    # Routability, not stack presence, is the property that decides whether an
+    # IPv6 bypass is reachable — so that is what is tested. A pod that later
+    # gains a global address gets the gate on its next start, and any pod that
+    # HAS IPv6 egress still fails closed exactly as before.
     _ip6tables_ok=false
+    _ip6_routable=false
+    if [ -d /proc/sys/net/ipv6 ]; then
+      # A global-scope address AND a default route are both required to send
+      # IPv6 off-host. Prefer `ip`; fall back to /proc for minimal images.
+      if command -v ip >/dev/null 2>&1; then
+        if ip -6 addr show scope global 2>/dev/null | grep -q 'inet6' \
+           && ip -6 route show default 2>/dev/null | grep -q .; then
+          _ip6_routable=true
+        fi
+      elif [ -r /proc/net/if_inet6 ] && [ -r /proc/net/ipv6_route ]; then
+        # if_inet6 scope 0x00 == global; ipv6_route holds a ::/0 default when
+        # the destination prefix length field (col 2) is 00.
+        if awk '$4 == "00" { found=1 } END { exit !found }' /proc/net/if_inet6 2>/dev/null \
+           && awk '$2 == "00" { found=1 } END { exit !found }' /proc/net/ipv6_route 2>/dev/null; then
+          _ip6_routable=true
+        fi
+      fi
+    fi
     if [ ! -d /proc/sys/net/ipv6 ]; then
       echo "[entrypoint] IPv6 stack absent from kernel — no IPv6 egress to gate"
+      _ip6tables_ok=true
+    elif [ "$_ip6_routable" != "true" ]; then
+      echo "[entrypoint] IPv6 present but not routable (no global address and/or no default route) — no IPv6 egress to gate"
       _ip6tables_ok=true
     else
       # Same binary-selection rationale as IPT above: prefer the explicit nft

--- a/src/pkg/config/egress_gate_ipv6_test.go
+++ b/src/pkg/config/egress_gate_ipv6_test.go
@@ -117,6 +117,32 @@ func runEgressGate(t *testing.T, env map[string]string, shims []string, ipv6Stac
 			t.Fatal(err)
 		}
 	}
+	// The routability probe prefers `ip` and only falls back to /proc, so the
+	// host's real `ip` would decide the result on any runner that has one —
+	// which is why these tests passed on macOS (no `ip`, no /proc, fail-safe
+	// branch) and failed on the IPv4-only Linux CI runner. Always install an
+	// `ip` shim so the fixture decides on every platform: routable by default
+	// for a stack-present pod, overridden to report nothing by "ip-noipv6".
+	if ipv6Stack {
+		hasIPShim := false
+		for _, n := range shims {
+			if n == "ip-noipv6" {
+				hasIPShim = true
+			}
+		}
+		if !hasIPShim {
+			if err := os.WriteFile(filepath.Join(binDir, "ip"), []byte(
+				"#!/bin/sh\n"+
+					"# routable fixture: a global address and a default route\n"+
+					"case \"$*\" in\n"+
+					"  *addr*) echo '    inet6 2001:db8::1/64 scope global';;\n"+
+					"  *route*) echo 'default via fe80::1 dev eth0 metric 1024';;\n"+
+					"esac\n"+
+					"exit 0\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
 	// python3 (uid-map bookkeeping) and sleep (retry backoff) as no-ops, and a
 	// real basename for the shim itself.
 	for name, script := range map[string]string{

--- a/src/pkg/config/egress_gate_ipv6_test.go
+++ b/src/pkg/config/egress_gate_ipv6_test.go
@@ -78,6 +78,17 @@ func runEgressGate(t *testing.T, env map[string]string, shims []string, ipv6Stac
 		"case \"$*\" in *-nL*) exit 1;; esac\n" +
 		"exit 0\n"
 	for _, name := range shims {
+		// "ip-noipv6" is not a netfilter shim: it installs an `ip` that reports
+		// neither a global IPv6 address nor a default route, so the routability
+		// probe sees an IPv4-only pod. Empty output + exit 0 is exactly what
+		// the real `ip -6 addr show scope global` prints there.
+		if name == "ip-noipv6" {
+			if err := os.WriteFile(filepath.Join(binDir, "ip"),
+				[]byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
 		if err := os.WriteFile(filepath.Join(binDir, name), []byte(shim), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -198,5 +209,33 @@ func TestGatePassesVacuouslyWithoutIPv6Stack(t *testing.T) {
 	}
 	if regexp.MustCompile(`(?m)^ip6tables`).MatchString(calls) {
 		t.Fatalf("ip6tables was invoked despite no IPv6 stack:\n%s", calls)
+	}
+}
+
+// TestGatePassesVacuouslyWithoutRoutableIPv6 pins the production outage this
+// check exists for: a pod CAN have the IPv6 stack compiled in — /proc/sys/net/
+// ipv6 present, ::1 up for the gateway nginx and the proxy's /proc/net/tcp6
+// self-lookup — while having NO global IPv6 address and NO default route. It
+// cannot originate IPv6 egress, so there is no bypass to close.
+//
+// Fail-closing there crash-looped a healthy hive (exit 4) on an IPv4-only
+// OpenShift cluster whose nodes ALSO lack the ip6tables `owner`/`REJECT`
+// extensions, so the gate could not have been installed even in principle.
+// Stack presence is not the property that decides whether a bypass is
+// reachable; routability is.
+func TestGatePassesVacuouslyWithoutRoutableIPv6(t *testing.T) {
+	// `ip` present but reporting neither a global address nor a default route
+	// — exactly what `ip -6 addr show scope global` / `ip -6 route show
+	// default` print on the affected pods.
+	out, calls, code := runEgressGate(t, nil,
+		[]string{"iptables-nft", "ip6tables-nft", "ip-noipv6"}, true)
+	if code != 0 {
+		t.Fatalf("gate exited %d on a pod with no routable IPv6 — this is the certus crash-loop:\n%s", code, out)
+	}
+	if !strings.Contains(out, "not routable") {
+		t.Fatalf("the vacuous pass for unroutable IPv6 was not logged:\n%s", out)
+	}
+	if regexp.MustCompile(`(?m)^ip6tables`).MatchString(calls) {
+		t.Fatalf("ip6tables was invoked despite no routable IPv6 egress:\n%s", calls)
 	}
 }

--- a/src/pkg/config/egress_gate_ipv6_test.go
+++ b/src/pkg/config/egress_gate_ipv6_test.go
@@ -59,10 +59,34 @@ func runEgressGate(t *testing.T, env map[string]string, shims []string, ipv6Stac
 	// Rewrite absolute paths onto the temp root so the test never touches the
 	// real /proc or /tmp, and so the IPv6-stack presence check is controllable.
 	body = strings.ReplaceAll(body, "/proc/sys/net/ipv6", root+"/proc/sys/net/ipv6")
+	// Routability is probed via these two files when `ip` is absent. Rewrite
+	// them onto the temp root as well, so the probe is decided by the fixture
+	// rather than by the host: without this the same test passes on a machine
+	// with no /proc (macOS, where the fail-safe branch runs) and fails on an
+	// IPv4-only Linux CI runner, which is exactly the drift that let the
+	// unroutable-IPv6 case reach production.
+	body = strings.ReplaceAll(body, "/proc/net/if_inet6", root+"/proc/net/if_inet6")
+	body = strings.ReplaceAll(body, "/proc/net/ipv6_route", root+"/proc/net/ipv6_route")
 	body = strings.ReplaceAll(body, "/tmp/hive-ipt-err.log", root+"/hive-ipt-err.log")
 	body = strings.ReplaceAll(body, "/tmp/hive-ip6t-err.log", root+"/hive-ip6t-err.log")
 	if ipv6Stack {
 		if err := os.MkdirAll(filepath.Join(root, "proc/sys/net/ipv6"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// A stack-present fixture is ROUTABLE by default: a global-scope
+		// address (if_inet6 scope field 00) and a ::/0 default route
+		// (ipv6_route destination prefix length 00). Tests that want the
+		// unroutable pod pass the "ip-noipv6" shim, which overrides this by
+		// putting an `ip` on PATH that reports neither.
+		if err := os.MkdirAll(filepath.Join(root, "proc/net"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "proc/net/if_inet6"),
+			[]byte("20010db8000000000000000000000001 02 40 00 80 eth0\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "proc/net/ipv6_route"),
+			[]byte("00000000000000000000000000000000 00 00000000000000000000000000000000 00 fe800000000000000000000000000001 00000400 00000000 00000000 00000003 eth0\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
## Incident

`certus` (`ai-native-systems-research`, vllm-d) went to `CrashLoopBackOff` on both the old and new replica, exit code **4** (`EXIT_NET_ADMIN_REQUIRED`), stuck mid-upgrade with 0 ready replicas. Spoke upgrades were paused to stop the blast radius — **every hive that restarts and pulls the retagged `:stable` would hit this**.

## Root cause

#4327 (`8ef269cf`) added the IPv6 egress gate and fail-closes when it cannot be installed. It correctly passes vacuously when the kernel has **no IPv6 stack at all**:

> A kernel with no IPv6 stack at all (`/proc/sys/net/ipv6` absent) has no IPv6 route to gate; that case passes vacuously rather than failing a container that cannot carry the traffic in the first place.

That reasoning is right — but the check is one step too shallow. This pod has the IPv6 stack compiled in (`/proc/sys/net/ipv6` present, `::1` up for the gateway nginx and the proxy's `/proc/net/tcp6` self-lookup) while having **no global IPv6 address and no IPv6 default route**. It cannot originate IPv6 egress, so there is no bypass to close — yet it took the "IPv6 present, gating failed" branch and refused to start.

Compounding it, the nodes are RHEL CoreOS 9.4 without the ip6tables `owner` and `REJECT` extensions, so the gate could not be installed even in principle:

```
Warning: Extension REJECT revision 0 not supported, missing kernel module?
ip6tables v1.8.11 (nf_tables): RULE_APPEND failed (No such file or directory): rule in chain HIVE_PROXY6
```

**Verified live on an affected pod:** 0 global `inet6` addresses, 0 IPv6 default routes, `REJECT` unavailable.

Note this is latent across the fleet, not specific to one hive — healthy pods on the *same node* are simply still running the pre-retag digest.

## Fix

Test **routability** rather than stack presence: require BOTH a global-scope IPv6 address AND an IPv6 default route before insisting the gate be installed. Prefer `ip`, falling back to `/proc/net/if_inet6` (scope `00` == global) and `/proc/net/ipv6_route` (destination prefix length `00` == default) — the affected image has no `iproute2`, so the `/proc` path is the one that actually runs there.

## The security property is preserved

- **Pod WITH IPv6 egress** → gate enforced, fail-closed exactly as before.
- **Pod with link-local only / IPv4-only** → vacuous pass, boots.
- A pod that later gains a global address is gated on its next start.

Verified with positive and negative controls against synthetic `/proc` fixtures, and the negative path verified against the real affected pod.

## Testing

- `sh -n` and `bash -n` clean (this is the fleet entrypoint — syntax was checked first).
- Detection logic executed inside a live affected pod: correctly returns not-routable via the `/proc` fallback.
- Positive control: global address + default route ⇒ routable ⇒ gate enforced.
- Negative control: link-local (scope `20`) is correctly not counted as global.

Refs #4327