### PR TITLE
🐛 dashboard: restart-count reset flickers back to stale value — guard status renders with a monotonic snapshot seq

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1907,6 +1907,12 @@ func main() {
 
 	var lastActionable atomic.Pointer[github.ActionableResult]
 	refreshDashboard := func() {
+		// Capture the mutation epoch BEFORE reading any state: if a mutation
+		// (e.g. a restart-count or budget-window reset) lands while this
+		// snapshot is being built, UpdateStatusIfFresh drops it so the stale
+		// values never overwrite what the mutation's own refresh will publish
+		// (#4348 — the restart-count flicker).
+		buildEpoch := dashSrv.BeginStatusSnapshot()
 		actionable := lastActionable.Load()
 		govState := gov.GetState()
 		agentStatuses := agentMgr.AllStatuses()
@@ -1925,7 +1931,7 @@ func main() {
 		if d := dashSrv.GetAdvisoryDigest(); d != nil {
 			payload.AdvisoryDigest = d
 		}
-		dashSrv.UpdateStatus(payload)
+		dashSrv.UpdateStatusIfFresh(payload, buildEpoch)
 	}
 
 	const cachedActionablePath = "/data/last-actionable.json"
@@ -5142,6 +5148,10 @@ func runEvalCycle(
 	// Scan agent panes for login-required patterns and pause + notify if detected
 	scanForLoginRequired(ctx, cfg, agentMgr, notifier, dashSrv, logger)
 
+	// Epoch captured before reading agent/governor state so a mutation that
+	// lands mid-build (restart-count/budget reset) drops this snapshot instead
+	// of letting it revert the mutation on the dashboard (#4348).
+	buildEpoch := dashSrv.BeginStatusSnapshot()
 	agentStatuses := agentMgr.AllStatuses()
 
 	statusPayload := dashboard.BuildFrontendStatus(
@@ -5487,7 +5497,7 @@ func runEvalCycle(
 		statusPayload.AdvisoryDigest = d
 	}
 
-	dashSrv.UpdateStatus(statusPayload)
+	dashSrv.UpdateStatusIfFresh(statusPayload, buildEpoch)
 
 	if agentStats := dashboard.CollectAgentStats(statusPayload); len(agentStats) > 0 {
 		gov.AttachAgentStats(agentStats)

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -409,9 +409,20 @@ func (s *Server) resolveAgentParam(nameOrID string) string {
 }
 
 func (s *Server) refreshAfterMutation() {
+	s.refreshAfterMutationSeq()
+}
+
+// refreshAfterMutationSeq bumps the mutation epoch (so any in-flight snapshot
+// rebuild that started before this mutation is dropped at publish, #4348),
+// kicks an async rebuild, and returns the minimum StatusSeq of snapshots
+// guaranteed to reflect the mutation. Handlers whose UI patches the DOM
+// optimistically should return that floor to the frontend.
+func (s *Server) refreshAfterMutationSeq() uint64 {
+	floor := s.noteStatusMutation()
 	if s.deps != nil && s.deps.RefreshFunc != nil {
 		go s.deps.RefreshFunc()
 	}
+	return floor
 }
 
 func (s *Server) persistAfterMutation() {
@@ -421,11 +432,19 @@ func (s *Server) persistAfterMutation() {
 }
 
 func (s *Server) refreshAndPersist() {
-	s.refreshAfterMutation()
+	s.refreshAndPersistSeq()
+}
+
+// refreshAndPersistSeq is refreshAndPersist returning the post-mutation
+// StatusSeq floor (see refreshAfterMutationSeq).
+func (s *Server) refreshAndPersistSeq() uint64 {
+	floor := s.refreshAfterMutationSeq()
 	s.persistAfterMutation()
+	return floor
 }
 
 func (s *Server) refreshAndPersistSync() {
+	s.noteStatusMutation()
 	if s.deps != nil && s.deps.RefreshFunc != nil {
 		s.deps.RefreshFunc()
 	}
@@ -1719,8 +1738,11 @@ func (s *Server) handleResetRestarts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.deps.Logger.Info("audit: restart count reset", "agent", name, "trigger", "dashboard-api")
-	s.refreshAndPersist()
-	okResponse(w, map[string]string{"status": "reset", "agent": name})
+	floor := s.refreshAndPersistSeq()
+	// minStatusSeq: status snapshots below this seq were built before the
+	// reset — the dashboard drops them so the zeroed counter can't flicker
+	// back to the stale value (#4348).
+	jsonResponse(w, map[string]any{"ok": true, "status": "reset", "agent": name, "minStatusSeq": floor})
 }
 
 // --- Token access audit log ---
@@ -4591,8 +4613,10 @@ func (s *Server) handleGovernorBudgetReset(w http.ResponseWriter, r *http.Reques
 	}
 	s.deps.Governor.ResetBudgetWindow()
 	s.auditFromRequest(r, "governor_budget_window_reset", auditDetail("section", "budget"), "")
-	s.refreshAndPersist()
-	okResponse(w, map[string]string{"status": "reset"})
+	floor := s.refreshAndPersistSeq()
+	// minStatusSeq: see handleResetRestarts — lets the dashboard discard
+	// pre-reset status snapshots so the budget bar can't revert (#4348).
+	jsonResponse(w, map[string]any{"ok": true, "status": "reset", "minStatusSeq": floor})
 }
 
 func (s *Server) handleGovernorNotifications(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -105,6 +106,16 @@ type Server struct {
 
 	// lastFullBroadcast is guarded by statusMu (set/read alongside s.status).
 	lastFullBroadcast time.Time
+
+	// statusSeq / statusMutationEpoch power the stale-snapshot guard (#4348).
+	// statusSeq increments on every published full snapshot and travels in the
+	// payload so the frontend can drop out-of-order status responses.
+	// statusMutationEpoch increments on every state mutation; a snapshot
+	// rebuild that STARTED before the latest mutation is dropped at publish
+	// time, so no published snapshot can revert a mutation the operator has
+	// already been told succeeded. Both guarded by statusMu.
+	statusSeq           uint64
+	statusMutationEpoch uint64
 
 	// fact/cost histories were migrated to the generic timeSeries store (#2041);
 	// the trend history (#2039) remains a dedicated buffer for now.
@@ -246,8 +257,17 @@ type Server struct {
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
 type StatusPayload struct {
-	Timestamp string           `json:"timestamp"`
-	HiveID    string           `json:"hiveId"`
+	Timestamp string `json:"timestamp"`
+	// StatusSeq is a monotonic publish sequence (#4348): the frontend drops
+	// any status payload whose seq is older than the last one it rendered,
+	// so a stale in-flight poll/SSE response can never repaint over a newer
+	// snapshot (e.g. reverting a just-reset restart counter).
+	StatusSeq uint64 `json:"statusSeq"`
+	// StatusInstance identifies the server process that produced the seq.
+	// Seqs restart at 1 when the spoke restarts; the frontend resets its
+	// guard counters when the instance changes instead of dropping forever.
+	StatusInstance string           `json:"statusInstance"`
+	HiveID         string           `json:"hiveId"`
 	Agents    []FrontendAgent  `json:"agents"`
 	Governor  FrontendGovernor `json:"governor"`
 	Tokens    FrontendTokens   `json:"tokens"`
@@ -1451,7 +1471,41 @@ func (s *Server) roleEnforcement(next http.Handler) http.Handler {
 	})
 }
 
+// BeginStatusSnapshot returns the current mutation epoch. Callers that build
+// a full status snapshot should capture this BEFORE reading any state and
+// pass it to UpdateStatusIfFresh, which drops the snapshot if a mutation
+// landed while it was being built (#4348).
+func (s *Server) BeginStatusSnapshot() uint64 {
+	s.statusMu.RLock()
+	defer s.statusMu.RUnlock()
+	return s.statusMutationEpoch
+}
+
+// noteStatusMutation records that server-side state just changed. It returns
+// the minimum StatusSeq a published snapshot must carry to be guaranteed to
+// reflect the mutation — any snapshot published with a lower seq was built
+// before it. Mutation handlers hand this floor to the frontend so it can
+// discard stale in-flight status responses (#4348).
+func (s *Server) noteStatusMutation() uint64 {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	s.statusMutationEpoch++
+	return s.statusSeq + 1
+}
+
+// UpdateStatus publishes a snapshot unconditionally (epoch captured at entry).
+// Prefer BeginStatusSnapshot + UpdateStatusIfFresh when the snapshot build is
+// slow enough for a mutation to race it.
 func (s *Server) UpdateStatus(status *StatusPayload) {
+	s.UpdateStatusIfFresh(status, s.BeginStatusSnapshot())
+}
+
+// UpdateStatusIfFresh publishes the snapshot unless a state mutation happened
+// after buildEpoch was captured — a stale build must not overwrite (and then
+// broadcast) pre-mutation values the operator has already seen change.
+// Returns whether the snapshot was published; the mutation's own
+// refresh-after-mutation rebuild repaints shortly after a drop.
+func (s *Server) UpdateStatusIfFresh(status *StatusPayload, buildEpoch uint64) bool {
 	if s.deps != nil && s.deps.Config != nil {
 		status.ACMMLevel = detectACMMLevel(s.deps.Config)
 		status.ACMMPackAgents = buildACMMPackAgents(s.deps.Config)
@@ -1525,6 +1579,19 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.hubBannerMu.RUnlock()
 
 	s.statusMu.Lock()
+	if buildEpoch < s.statusMutationEpoch {
+		// A mutation landed after this snapshot's build began: its data may
+		// predate the mutation. Drop it — the mutation's own refresh rebuild
+		// (which began after the epoch bump) publishes the fresh state.
+		curEpoch := s.statusMutationEpoch
+		s.statusMu.Unlock()
+		s.logger.Debug("dropping stale status snapshot built before a mutation",
+			"buildEpoch", buildEpoch, "mutationEpoch", curEpoch)
+		return false
+	}
+	s.statusSeq++
+	status.StatusSeq = s.statusSeq
+	status.StatusInstance = strconv.FormatInt(s.startedAt.UnixNano(), 10)
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	s.status = status
 	s.lastFullBroadcast = time.Now()
@@ -1539,10 +1606,11 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	data, err := json.Marshal(status)
 	if err != nil {
 		s.logger.Warn("failed to marshal status for SSE", "error", err)
-		return
+		return true
 	}
 
 	s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
+	return true
 }
 
 // AddSystemAlert adds a critical alert visible on the dashboard.

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -7154,6 +7154,11 @@
         showToast(d.error || ('Failed to reset budget window (HTTP ' + r.status + ')'), 'error');
         return;
       }
+      // Same stale-snapshot race as the restart counter (#4348): raise the
+      // floor so a pre-reset poll can't repaint the exhausted budget bar
+      // before the post-reset snapshot lands. Body parse is best-effort.
+      const ok = await r.json().catch(() => ({}));
+      noteStatusMutation(ok.minStatusSeq);
       showToast('Budget window reset — spend restarts at 0, suppressed kicks resume', 'success');
       fetchBudgetHistory(); // a reset closes a window → new history row; refetch so the chart shows it
       refreshStatus(); // repaint budget bar/banners in place; errors swallowed inside
@@ -12120,6 +12125,21 @@ function burnAreaChart() {
     }
 
     let _hashScrollPending = false;
+
+    // ── Stale-snapshot guard state (#4348) ─────────────────────────────
+    // _lastStatusSeq: highest statusSeq applied to the DOM. _statusSeqFloor:
+    // snapshots below this were built before a mutation this client has
+    // already confirmed (e.g. restart-count / budget-window reset) and must
+    // never be rendered. See the guard at the top of render().
+    let _lastStatusSeq = 0;
+    let _statusSeqFloor = 0;
+    let _statusInstance = '';
+    // noteStatusMutation raises the floor from a mutation response's
+    // minStatusSeq so in-flight pre-mutation polls/SSE frames are discarded.
+    function noteStatusMutation(minSeq) {
+      const n = Number(minSeq);
+      if (Number.isFinite(n) && n > _statusSeqFloor) _statusSeqFloor = n;
+    }
     var SCROLL_SETTLE_DELAY_MS = 500;
     var _deferredLoadPromise = null;
     function _afterPaint(callback) {
@@ -12145,6 +12165,27 @@ function burnAreaChart() {
 
     function render(data) {
       if (!data || data.error || data.status === 'initializing') return;
+      // ── Stale-snapshot guard (#4348) ──────────────────────────────────
+      // Status payloads arrive from several racing sources (SSE pushes,
+      // periodic refetches, post-action refreshStatus calls). Two drops:
+      //  1. out-of-order: a response older than the newest one already
+      //     rendered must not repaint the page backwards;
+      //  2. pre-mutation: after a reset button confirms success, snapshots
+      //     built before that mutation (statusSeq below the server-supplied
+      //     minStatusSeq floor) would revert the optimistic 0 — discard them
+      //     until a post-mutation snapshot arrives.
+      // Payloads without statusSeq (older spoke server) apply as before.
+      if (data.statusSeq != null) {
+        if (data.statusInstance && data.statusInstance !== _statusInstance) {
+          // New server process: seqs restarted at 1 — reset the guard so a
+          // spoke restart doesn't freeze the page on pre-restart state.
+          _statusInstance = data.statusInstance;
+          _lastStatusSeq = 0;
+          _statusSeqFloor = 0;
+        }
+        if (data.statusSeq < _statusSeqFloor || data.statusSeq < _lastStatusSeq) return;
+        _lastStatusSeq = data.statusSeq;
+      }
       if (document.body.style.opacity === '0') document.body.style.opacity = '1';
       const scrollY = window.scrollY;
       const tsDt = new Date(data.timestamp);
@@ -13679,11 +13720,17 @@ function burnAreaChart() {
       const res = await fetch(`/api/reset-restarts/${agent}`, { method: 'POST' });
       const data = await res.json();
       if (!data.ok) { dismissToast(toast, `Reset failed: ${data.error || 'unknown'}`, 'error'); return; }
+      // Raise the stale-snapshot floor BEFORE the optimistic patch so an
+      // in-flight pre-reset poll/SSE frame can't flip the counter back to
+      // the old value (#4348), then refetch so the real post-reset snapshot
+      // repaints everything; errors swallowed inside refreshStatus.
+      noteStatusMutation(data.minStatusSeq);
       const btn = document.querySelector(`.restart-reset[data-agent="${agent}"]`);
       if (btn) {
         const el = btn.closest('.value');
         if (el) { el.className = 'value'; el.innerHTML = '0<span class="restart-label">24h</span><span class="restart-spark"></span>'; }
       }
+      refreshStatus();
       dismissToast(toast, `${agent} restart counter reset`, 'success');
     }
 

--- a/src/pkg/dashboard/status_seq_test.go
+++ b/src/pkg/dashboard/status_seq_test.go
@@ -1,0 +1,169 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// Regression tests for #4348: the restart-count reset flickered back to the
+// stale value because the cached status snapshot is rebuilt asynchronously
+// after a mutation — a poll/SSE frame carrying the pre-reset snapshot
+// repainted the old count over the optimistic 0. The guard is a monotonic
+// StatusSeq on every published snapshot plus a mutation epoch that drops
+// in-flight rebuilds started before the mutation.
+
+// Every published snapshot must carry a strictly increasing StatusSeq and the
+// process instance ID so the frontend can order responses (and detect a spoke
+// restart, which restarts seqs at 1).
+func TestUpdateStatusAssignsMonotonicSeq(t *testing.T) {
+	s := newTestServer()
+
+	s.UpdateStatus(minimalPayload())
+	first := s.status.StatusSeq
+	if first == 0 {
+		t.Fatal("first published snapshot has StatusSeq 0, want >= 1")
+	}
+	if s.status.StatusInstance == "" {
+		t.Error("published snapshot has empty StatusInstance")
+	}
+
+	s.UpdateStatus(minimalPayload())
+	if s.status.StatusSeq <= first {
+		t.Errorf("second StatusSeq = %d, want > %d", s.status.StatusSeq, first)
+	}
+}
+
+// A snapshot whose build began before a mutation must be dropped: publishing
+// it would overwrite (and broadcast) pre-mutation values, reverting what the
+// operator was just told succeeded.
+func TestUpdateStatusIfFreshDropsSnapshotBuiltBeforeMutation(t *testing.T) {
+	s := newTestServer()
+
+	fresh := minimalPayload()
+	fresh.Agents = []FrontendAgent{{Name: "scanner", Restarts: 0}}
+	s.UpdateStatus(fresh)
+	published := s.status
+
+	// A slow periodic rebuild captured its epoch, then a mutation landed.
+	staleEpoch := s.BeginStatusSnapshot()
+	s.noteStatusMutation()
+
+	stale := minimalPayload()
+	stale.Agents = []FrontendAgent{{Name: "scanner", Restarts: 7}} // pre-reset value
+	if s.UpdateStatusIfFresh(stale, staleEpoch) {
+		t.Fatal("stale snapshot (built before mutation) was published")
+	}
+	if s.status != published {
+		t.Error("stale snapshot replaced the cached status")
+	}
+
+	// A rebuild started after the mutation publishes normally.
+	if !s.UpdateStatusIfFresh(minimalPayload(), s.BeginStatusSnapshot()) {
+		t.Error("fresh snapshot (built after mutation) was dropped")
+	}
+}
+
+// noteStatusMutation returns the floor: the minimum StatusSeq a snapshot must
+// carry to be guaranteed post-mutation. The next published fresh snapshot must
+// meet it, and a dropped stale snapshot must not consume a seq below it.
+func TestNoteStatusMutationFloorIsMetByNextFreshSnapshot(t *testing.T) {
+	s := newTestServer()
+	s.UpdateStatus(minimalPayload())
+
+	staleEpoch := s.BeginStatusSnapshot()
+	floor := s.noteStatusMutation()
+	if floor != s.status.StatusSeq+1 {
+		t.Errorf("floor = %d, want %d (last published seq + 1)", floor, s.status.StatusSeq+1)
+	}
+
+	// Dropped snapshots must not burn a sequence number.
+	s.UpdateStatusIfFresh(minimalPayload(), staleEpoch)
+	if !s.UpdateStatusIfFresh(minimalPayload(), s.BeginStatusSnapshot()) {
+		t.Fatal("post-mutation snapshot was dropped")
+	}
+	if s.status.StatusSeq < floor {
+		t.Errorf("post-mutation snapshot seq = %d, below floor %d", s.status.StatusSeq, floor)
+	}
+	if s.status.StatusSeq != floor {
+		t.Errorf("post-mutation snapshot seq = %d, want exactly floor %d (drops must not consume seqs)", s.status.StatusSeq, floor)
+	}
+}
+
+// The reset-restarts endpoint must hand the frontend the minStatusSeq floor so
+// it can discard in-flight pre-reset status responses.
+func TestResetRestartsResponseCarriesMinStatusSeq(t *testing.T) {
+	s, _ := apiServer(t)
+	s.UpdateStatus(minimalPayload())
+	seqBefore := s.status.StatusSeq
+
+	rec := doPost(s, "/api/reset-restarts/scanner", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		OK           bool   `json:"ok"`
+		MinStatusSeq uint64 `json:"minStatusSeq"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if !body.OK {
+		t.Error("response ok = false")
+	}
+	if body.MinStatusSeq <= seqBefore {
+		t.Errorf("minStatusSeq = %d, want > last published seq %d", body.MinStatusSeq, seqBefore)
+	}
+}
+
+// The budget-window reset shares the same race class (#4315/#4320 surface) and
+// must carry the same floor.
+func TestBudgetResetResponseCarriesMinStatusSeq(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Governor.SetBudgetLimit(100)
+	s.UpdateStatus(minimalPayload())
+	seqBefore := s.status.StatusSeq
+
+	rec := doPost(s, "/api/config/governor/budget/reset", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		OK           bool   `json:"ok"`
+		MinStatusSeq uint64 `json:"minStatusSeq"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if !body.OK {
+		t.Error("response ok = false")
+	}
+	if body.MinStatusSeq <= seqBefore {
+		t.Errorf("minStatusSeq = %d, want > last published seq %d", body.MinStatusSeq, seqBefore)
+	}
+}
+
+// /api/status must serve the seq-stamped snapshot so late poll responses are
+// orderable client-side.
+func TestHandleStatusServesStatusSeq(t *testing.T) {
+	s, _ := apiServer(t)
+	s.UpdateStatus(minimalPayload())
+
+	rec := doGet(s, "/api/status")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var body struct {
+		StatusSeq      uint64 `json:"statusSeq"`
+		StatusInstance string `json:"statusInstance"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if body.StatusSeq == 0 {
+		t.Error("served snapshot has statusSeq 0, want >= 1")
+	}
+	if body.StatusInstance == "" {
+		t.Error("served snapshot has empty statusInstance")
+	}
+}

--- a/src/pkg/dashboard/status_seq_ui_test.go
+++ b/src/pkg/dashboard/status_seq_ui_test.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression guard for #4348: clicking ✕ on an agent's restart count zeroed
+// the display, then it flickered BACK to the stale value before settling at 0.
+// The cached /api/status snapshot is rebuilt asynchronously after a mutation,
+// so an in-flight poll/SSE frame carrying the pre-reset snapshot repainted the
+// old count over the optimistic patch. The fix is a stale-snapshot guard in
+// render(): out-of-order statusSeq payloads are dropped, and after a confirmed
+// mutation everything below the server-supplied minStatusSeq floor is
+// discarded. These checks pin the wiring so the guard (or one of its callees)
+// can't silently vanish — the renderAll()/hiveToast() bug class where an
+// undefined callee turns a success path into a runtime error.
+func TestStatusSeqGuardWiring(t *testing.T) {
+	b, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	html := string(b)
+
+	// Every function the guard path calls must be defined in the page.
+	for _, def := range []string{
+		"function noteStatusMutation(",
+		"function render(",
+		"function refreshStatus()",
+		"function showToast(",
+		"function dismissToast(",
+	} {
+		if !strings.Contains(html, def) {
+			t.Errorf("index.html is missing definition %q", def)
+		}
+	}
+
+	// Guard state and the render() drop logic.
+	for _, snippet := range []string{
+		"let _lastStatusSeq = 0;",
+		"let _statusSeqFloor = 0;",
+		"let _statusInstance = '';",
+		"if (data.statusSeq < _statusSeqFloor || data.statusSeq < _lastStatusSeq) return;",
+		"_lastStatusSeq = data.statusSeq;",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing stale-snapshot guard snippet %q", snippet)
+		}
+	}
+
+	// A spoke restart resets statusSeq to 1; the guard must reset with it or
+	// the page freezes on pre-restart state forever.
+	for _, snippet := range []string{
+		"data.statusInstance !== _statusInstance",
+		"_statusInstance = data.statusInstance;",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing instance-change reset snippet %q", snippet)
+		}
+	}
+
+	// Both reset flows must raise the floor from the mutation response and the
+	// restart-count flow must refetch so the real snapshot repaints.
+	for _, snippet := range []string{
+		"noteStatusMutation(data.minStatusSeq);",
+		"noteStatusMutation(ok.minStatusSeq);",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing mutation-floor call %q", snippet)
+		}
+	}
+
+	// resetRestarts must refetch after the optimistic patch — the guard drops
+	// stale frames, so without a refetch the page would wait a full SSE cycle.
+	resetFn := html[strings.Index(html, "async function resetRestarts("):]
+	if end := strings.Index(resetFn, "\n    }"); end > 0 {
+		resetFn = resetFn[:end]
+	}
+	for _, snippet := range []string{"noteStatusMutation(data.minStatusSeq);", "refreshStatus();"} {
+		if !strings.Contains(resetFn, snippet) {
+			t.Errorf("resetRestarts() is missing %q", snippet)
+		}
+	}
+
+	// Stale callees from the historic bug class must stay dead.
+	for _, stale := range []string{"renderAll(", "hiveToast("} {
+		if strings.Contains(html, stale) {
+			t.Errorf("index.html calls %q, which is never defined", stale)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4348

## Root cause

Clicking ✕ on an agent restart count showed 0, flipped back to the stale value, then settled at 0. `handleResetRestarts` zeroes the counter synchronously but rebuilds the cached `/api/status` snapshot **asynchronously** (`go RefreshFunc()`, includes GitHub calls) — so for several seconds every SSE full push and `fetch('/api/status').then(render)` still carried the pre-reset snapshot and repainted the old count over the optimistic patch. Budget-window reset (#4315/#4320 surface) shared the race: its post-reset `refreshStatus()` read the same stale cache.

## Fix (whole stale-poll class)

**Server** (`server.go`, `api.go`, `cmd/hive/main.go`):
- Every published snapshot carries a monotonic `statusSeq` plus a per-process `statusInstance`.
- A mutation epoch (`noteStatusMutation`) is bumped by every refresh-after-mutation; snapshot rebuilds that **started before** a mutation are dropped at publish (`UpdateStatusIfFresh`), so a slow periodic eval-cycle build can never overwrite fresh state. `refreshDashboard` and `runEvalCycle` capture their build epoch before reading state.
- `/api/reset-restarts/{agent}` and `/api/config/governor/budget/reset` return `minStatusSeq` — the floor a snapshot must carry to be guaranteed post-mutation.

**Client** (`static/index.html`):
- `render()` (single choke point for SSE + fetch payloads) drops out-of-order payloads (`statusSeq < _lastStatusSeq`) and, after a confirmed mutation, anything below `_statusSeqFloor`.
- `resetRestarts` / `resetBudgetWindow` raise the floor from the response and refetch. Guard resets when `statusInstance` changes so a spoke restart (seq back to 1) cannot freeze the page. Older servers without `statusSeq` behave as before.

## Tests

- `status_seq_test.go`: monotonic seq, stale-build drop, floor semantics (drops don't burn seqs), both reset endpoints carry `minStatusSeq`, `/api/status` serves seq+instance.
- `status_seq_ui_test.go`: wiring regression in the `budget_reset_ui_test.go` style — all callees defined (renderAll/hiveToast bug class), guard/floor/instance-reset snippets pinned.
- `go build ./... && go test ./pkg/dashboard/...` green, coverage **83.3%** (floor 78%).
