### PR TITLE
🌱 ci(podman): prove the arm64 image pulls and the service starts

### DIFF
--- a/.github/workflows/podman-arm64-lane.yml
+++ b/.github/workflows/podman-arm64-lane.yml
@@ -1,0 +1,187 @@
+name: Podman arm64 Lane
+
+# The arm64 image pull and service-startup lane (#4336), lane 3 of the map in
+# src/docs/podman-ci-runner-map.md (#4211).
+#
+# Every Podman result before this one is amd64 only — #4199 and #4200 both
+# record arm64 as unproven. This lane closes that on the two questions #4188
+# actually asks of arm64: does the published arm64 image come down, and does
+# the service start from it.
+#
+# SCOPE, AND THE FAILURE MODE IT AVOIDS. #4211 names a duplicated full matrix
+# as the thing not to build here: the probe it ran found the two architectures
+# capability-identical, so re-running the egress-gate cases on arm64 doubles
+# cost for coverage that result says will not diverge. The gate lives on the
+# amd64 lanes — #4334 rootless, #4335 rootful. This lane runs four checks and
+# no more:
+#
+#   manifest   the tag advertises a linux/arm64 image
+#   pull       that image comes down and really is arm64
+#   exec       /usr/local/bin/hive runs
+#   startup    the container answers GET /api/health
+#
+# The probe runs the container with HIVE_PROXY_ADVISORY_OK=true so the egress
+# gate is taken OUT of the picture rather than quietly re-measured here.
+# Without it the entrypoint fails closed with exit 77 and nothing about startup
+# would be tested at all. If the architectures ever DO diverge, that is the
+# signal to widen this lane — not a reason to widen it now.
+#
+# WHY PULL RATHER THAN BUILD. #4188 asks for "build/pull plus startup", and the
+# arm64 BUILD is already a per-push gate: .github/workflows/docker.yml builds
+# linux/arm64 on this same runner label on every branch and asserts the
+# embedded commit matches the built SHA. What no lane covered is the other
+# half — that the published arm64 artifact pulls under Podman and starts. So
+# this lane pulls, and per #4336's stop condition it does NOT build an image ad
+# hoc: a missing arm64 manifest is reported and fails the job, because the fix
+# for that belongs in the publisher, not in a lane papering over it.
+#
+# A MISSING arm64 MANIFEST IS A FAILURE, NOT A SKIP. An arm64 lane that steps
+# aside when the arm64 image is absent reports green while proving nothing —
+# and "arm64 is unproven" is the exact condition this lane exists to end.
+#
+# Safety boundaries, from the map: contents: read and nothing more, no secrets,
+# no pull_request_target, no engine socket mounted. The probe pulls into a
+# throwaway store with a private graphroot and runroot, so nothing touches the
+# runner's default Podman storage, and it removes only the container it
+# created, by name.
+#
+# No path filters, on purpose. #4339 is what a guard scoped into silence looks
+# like. The cost here is one image pull and one container.
+
+on:
+  push:
+    branches:
+      - v2
+      - v4
+  pull_request:
+    branches:
+      - v2
+      - v4
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Image to probe (default ghcr.io/kubestellar/hive:v4-latest)'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: podman-arm64-lane-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  arm64-probe:
+    name: arm64 image pull and service startup
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Assert the environment, do not assume it. Podman is preinstalled on
+      # this runner image, so there is no setup step — which is exactly why the
+      # architecture and the Podman stack have to be checked: a runner-image or
+      # label change is silent, and an arm64 lane that quietly started running
+      # on amd64 would still go green while measuring nothing new.
+      #
+      # AC: runtime and network backend are printed for comparison against the
+      # amd64 lanes. #4211's claim is that the two architectures are
+      # capability-identical; these are the fields that claim would be
+      # falsified by, so they are reported on every run rather than assumed to
+      # still hold.
+      - name: Assert the arm64 Podman stack this lane depends on
+        env:
+          RECORDED_PODMAN: '5.8.4'
+        run: |
+          # shellcheck disable=SC2016 # the --format strings stay single-quoted:
+          # those are Go template braces for Podman, not shell expansions.
+          set -euo pipefail
+
+          if ! command -v podman >/dev/null 2>&1; then
+            echo "::error::podman is not installed on this runner; #4211 recorded it preinstalled at /usr/local/bin/podman on ubuntu-24.04-arm"
+            exit 1
+          fi
+
+          version="$(podman info --format '{{.Version.Version}}')"
+          arch="$(podman info --format '{{.Host.Arch}}')"
+          rootless="$(podman info --format '{{.Host.Security.Rootless}}')"
+          cgroups="$(podman info --format '{{.Host.CgroupsVersion}}')"
+          runtime="$(podman info --format '{{.Host.OCIRuntime.Name}}')"
+          backend="$(podman info --format '{{.Host.NetworkBackend}}')"
+          rootlessnet="$(podman info --format '{{.Host.RootlessNetworkCmd}}')"
+
+          printf 'podman       %s (%s)\n' "$version" "$(command -v podman)"
+          printf 'arch         %s (uname %s)\n' "$arch" "$(uname -m)"
+          printf 'rootless     %s\n' "$rootless"
+          printf 'cgroups      %s\n' "$cgroups"
+          printf 'runtime      %s\n' "$runtime"
+          printf 'backend      %s / %s\n' "$backend" "$rootlessnet"
+
+          # THE assertion of this lane. Everything below is only interesting
+          # because it happens on arm64.
+          if [ "$arch" != "arm64" ]; then
+            echo "::error::podman reports arch=${arch}; this lane must run on arm64 (the amd64 coverage is #4334/#4335)"
+            exit 1
+          fi
+
+          if [ "$version" != "$RECORDED_PODMAN" ]; then
+            echo "::notice::runner Podman is ${version}; src/docs/podman-ci-runner-map.md recorded ${RECORDED_PODMAN} on both architectures. Re-check the map if this lane starts behaving differently."
+          fi
+
+          {
+            printf '### arm64 Podman lane environment\n\n'
+            printf '| | |\n| --- | --- |\n'
+            printf '| Podman | `%s` (map recorded `%s`) |\n' "$version" "$RECORDED_PODMAN"
+            printf '| Architecture | `%s` |\n' "$arch"
+            printf '| Root mode | rootless=`%s` |\n' "$rootless"
+            printf '| cgroups | `%s` |\n' "$cgroups"
+            printf '| OCI runtime | `%s` |\n' "$runtime"
+            printf '| Network backend | `%s` / `%s` |\n' "$backend" "$rootlessnet"
+            printf '| Runner | `%s`, image `%s` |\n' "$RUNNER_OS" "${ImageVersion:-unknown}"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      # The probe's exit status is the result. 0 means the arm64 image pulled
+      # and the service started; 1 means one of the four checks failed — a
+      # missing arm64 manifest lands here rather than skipping; 78 means a
+      # prerequisite was missing, which is a broken lane rather than a passing
+      # one and must be just as loud.
+      #
+      # There is deliberately no continue-on-error and no `|| true`.
+      - name: arm64 image pull and service startup (#4336)
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          set -uo pipefail
+
+          args=""
+          if [ -n "${IMAGE:-}" ]; then
+            args="--image ${IMAGE}"
+          fi
+
+          # The runner invokes this with `bash -e`, so errexit has to come off
+          # deliberately: the probe's exit status IS the result and has to
+          # survive to the diagnosis below.
+          set +e
+          # shellcheck disable=SC2086 # args is a deliberate optional flag pair
+          bash src/deploy/probe_arm64_image_startup.sh $args
+          status=$?
+          set -e
+
+          case "$status" in
+            0)
+              echo "::notice::the arm64 image pulled and the service started"
+              printf '\n✅ The published arm64 image pulled, `/usr/local/bin/hive` ran, and the service answered `GET /api/health`.\n' >>"$GITHUB_STEP_SUMMARY"
+              ;;
+            78)
+              echo "::error::the probe could not run — a prerequisite is missing (EX_CONFIG). A lane that cannot run is not a lane that passed."
+              printf '\n❌ Prerequisite missing (exit 78). See the log for which one.\n' >>"$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "::error::the arm64 pull/startup lane failed (exit ${status})"
+              printf '\n❌ The arm64 pull/startup lane failed (exit %s).\n' "$status" >>"$GITHUB_STEP_SUMMARY"
+              ;;
+          esac
+
+          exit "$status"

--- a/src/deploy/probe_arm64_image_startup.sh
+++ b/src/deploy/probe_arm64_image_startup.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# arm64 image pull and service-startup probe (kubestellar/hive#4336).
+#
+# Every Podman result so far is amd64 only — #4199 and #4200 both record that
+# as unproven. This probe asks the two questions #4188 asks of arm64, and only
+# those two: does the published arm64 image come down, and does the service
+# actually start from it.
+#
+# DELIBERATELY NOT THE THREE-CASE MATRIX. #4211 names a duplicated full matrix
+# as the failure mode to avoid: the two architectures came back
+# capability-identical, so re-running the egress-gate cases here doubles cost
+# for coverage the identical-capability result says will not diverge. The gate
+# is #4334's lane (rootless) and #4335's (rootful), both on amd64. This probe
+# runs the container with HIVE_PROXY_ADVISORY_OK=true precisely so the gate is
+# taken OUT of the picture rather than silently re-measured: without it the
+# entrypoint fails closed with exit 77 and nothing about startup gets tested.
+# If the two architectures ever DO diverge, that is the signal to widen this
+# lane — not a reason to widen it now.
+#
+# WHY PULL RATHER THAN BUILD. #4188 asks for "build/pull plus startup". The
+# arm64 BUILD is already a per-push CI gate: .github/workflows/docker.yml
+# builds linux/arm64 on ubuntu-24.04-arm on every branch and asserts the
+# embedded commit matches. What no lane covered is the other half — that the
+# published arm64 artifact pulls under Podman and starts. So this probe pulls,
+# and #4336's stop condition applies: if no arm64 image is published for the
+# tag, record it and stop rather than building one ad hoc in CI.
+#
+# Cases:
+#   manifest   the tag advertises a linux/arm64 image        -> required
+#   pull       that image comes down and IS arm64            -> required
+#   exec       /usr/local/bin/hive runs and reports a version -> required
+#   startup    the container serves GET /api/health          -> required
+#
+# The exec case is not filler. #3760 was a binary that shipped as a
+# non-executable overlayfs metacopy redirect at the image path — an image that
+# pulls fine and cannot run. That class of failure is exactly what an
+# architecture-specific lane is for.
+#
+# Usage:
+#   src/deploy/probe_arm64_image_startup.sh [options]
+#
+#   --image REF     image to probe (default ghcr.io/kubestellar/hive:v4-latest)
+#   --arch ARCH     architecture to require and pull (default arm64)
+#   --store DIR     reuse a probe store instead of creating one (kept on exit)
+#   --shared-store  deliberately use the caller's default Podman store
+#   --port PORT     host port for the published API port (default 18402)
+#   --timeout SEC   how long to wait for /api/health (default 180)
+#
+# Exit codes: 0 the image pulled and the service started, 1 it did not,
+# 78 a prerequisite is missing (EX_CONFIG).
+
+set -uo pipefail
+
+IMAGE="ghcr.io/kubestellar/hive:v4-latest"
+ARCH="arm64"
+STORE=""
+SHARED_STORE="false"
+HOST_PORT="18402"
+HEALTH_TIMEOUT="180"
+OWN_STORE="false"
+
+PROBE_NAME="hive-arm64-probe-$$"
+API_PORT="3002"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image) IMAGE="${2:?--image needs a value}"; shift 2 ;;
+    --arch) ARCH="${2:?--arch needs a value}"; shift 2 ;;
+    --store) STORE="${2:?--store needs a value}"; shift 2 ;;
+    --shared-store) SHARED_STORE="true"; shift ;;
+    --port) HOST_PORT="${2:?--port needs a value}"; shift 2 ;;
+    --timeout) HEALTH_TIMEOUT="${2:?--timeout needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,56p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) printf 'ERROR: unknown argument %q\n' "$1" >&2; exit 78 ;;
+  esac
+done
+
+fail_prereq() {
+  printf 'PREREQUISITE MISSING: %s\n' "$1" >&2
+  exit 78
+}
+
+command -v podman >/dev/null 2>&1 || fail_prereq "podman is not installed or not on PATH"
+command -v curl >/dev/null 2>&1 || fail_prereq "curl is not installed or not on PATH"
+
+# This is an arm64 lane. Running it on a foreign architecture would either fail
+# confusingly or quietly measure emulation instead of the thing #4188 asked
+# for, so it refuses rather than pretending.
+host_arch="$(uname -m)"
+case "$host_arch" in
+  aarch64|arm64) host_arch="arm64" ;;
+  x86_64|amd64)  host_arch="amd64" ;;
+esac
+[[ "$host_arch" == "$ARCH" ]] || \
+  fail_prereq "this probe must run ON ${ARCH} (host is ${host_arch}); it measures the native ${ARCH} path, not emulation"
+
+WORK="$(mktemp -d)"
+# shellcheck disable=SC2329 # invoked through the EXIT trap below
+cleanup() {
+  pod rm -f "$PROBE_NAME" >/dev/null 2>&1
+  rm -rf "$WORK"
+  # Files a container wrote are owned by mapped subordinate UIDs, so a plain
+  # rm cannot remove a store this script created. Delete it from inside the
+  # user namespace, and fall back for the pre-container case.
+  if [[ "$OWN_STORE" == "true" && -n "$STORE" ]]; then
+    podman unshare rm -rf "$STORE" 2>/dev/null || rm -rf "$STORE" 2>/dev/null
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+# Isolated storage for anything that pulls, per the runner map. Every podman
+# call goes through pod(); nothing addresses the caller's default store unless
+# --shared-store says so explicitly.
+POD=(podman)
+if [[ "$SHARED_STORE" != "true" ]]; then
+  if [[ -z "$STORE" ]]; then
+    STORE="$(mktemp -d -t hive-arm64-probe-store-XXXXXX)"
+    OWN_STORE="true"
+  fi
+  mkdir -p "${STORE}/graph" "${STORE}/run"
+  POD=(podman --root "${STORE}/graph" --runroot "${STORE}/run")
+fi
+pod() { "${POD[@]}" "$@"; }
+
+failures=0
+note_fail() { printf '  RESULT: FAIL — %s\n' "$1"; failures=$((failures + 1)); }
+note_ok()   { printf '  RESULT: ok — %s\n' "$1"; }
+
+# ── Environment, printed for comparison against the amd64 lanes ─────────────
+# #4211 measured the two architectures capability-identical. These are the
+# fields that claim would be falsified by, so they are reported on every run
+# rather than assumed to still hold.
+printf '== Hive %s image pull and startup probe (#4336) ==\n' "$ARCH"
+pod info --format \
+  'podman={{.Version.Version}} arch={{.Host.Arch}} rootless={{.Host.Security.Rootless}} cgroups={{.Host.CgroupsVersion}} runtime={{.Host.OCIRuntime.Name}} netbackend={{.Host.NetworkBackend}} rootlessnet={{.Host.RootlessNetworkCmd}}'
+printf 'kernel=%s host_arch=%s\n' "$(uname -r)" "$host_arch"
+printf 'store=%s (throwaway=%s)\nimage=%s\n\n' "${STORE:-<caller default>}" "$OWN_STORE" "$IMAGE"
+
+# ── Case 1: the tag must advertise a linux/<arch> image ────────────────────
+# A missing arm64 manifest FAILS. It must not be a skip: an arm64 lane that
+# silently steps aside when the image is not there is the same vacuous pass
+# #4211 warns about, and the whole point of this lane is that arm64 stopped
+# being unproven.
+printf -- '--- case: manifest advertises linux/%s ---\n' "$ARCH"
+manifest="${WORK}/manifest.json"
+
+# A multi-arch tag is an index and lists one entry per platform. A reference
+# that resolves to a single image manifest has no platform entries at all,
+# which is a different finding from "the index omits this architecture" and is
+# reported as such rather than as a blank list.
+advertised() {
+  local found
+  found="$(grep -o '"architecture": *"[^"]*"' "$manifest" \
+    | sed 's/.*"\([^"]*\)"$/\1/' | sort -u | tr '\n' ' ')"
+  if [[ -n "${found// /}" ]]; then
+    printf '%s' "$found"
+  else
+    printf '(none — this reference is a single image manifest, not a multi-arch index)'
+  fi
+}
+
+if ! pod manifest inspect "$IMAGE" >"$manifest" 2>"${WORK}/manifest.err"; then
+  printf '  podman manifest inspect failed:\n'
+  sed 's/^/    /' "${WORK}/manifest.err"
+  note_fail "cannot read the manifest for ${IMAGE}"
+elif grep -q "\"architecture\": *\"${ARCH}\"" "$manifest"; then
+  printf '  architectures advertised: %s\n' "$(advertised)"
+  note_ok "the tag publishes a linux/${ARCH} image"
+else
+  printf '  architectures advertised: %s\n' "$(advertised)"
+  printf '  RECORDED: no linux/%s image is published for %s.\n' "$ARCH" "$IMAGE"
+  printf '            This lane does NOT build one ad hoc — see #4336. Fix the\n'
+  printf '            publisher (.github/workflows/docker.yml builds linux/%s)\n' "$ARCH"
+  printf '            rather than making this lane paper over it.\n'
+  note_fail "no linux/${ARCH} image published for ${IMAGE}"
+fi
+
+# Nothing below can mean anything without the image, so stop here rather than
+# emitting a cascade of failures that all have one cause.
+if [[ "$failures" -ne 0 ]]; then
+  printf '\nSUMMARY: %d failure(s)\n' "$failures"
+  exit 1
+fi
+
+# ── Case 2: the image pulls, and what came down really is <arch> ───────────
+printf -- '\n--- case: pull linux/%s ---\n' "$ARCH"
+if pod pull -q --arch "$ARCH" "$IMAGE" >/dev/null 2>"${WORK}/pull.err"; then
+  pulled_arch="$(pod image inspect "$IMAGE" --format '{{.Architecture}}' 2>/dev/null)"
+  pulled_digest="$(pod image inspect "$IMAGE" --format '{{.Digest}}' 2>/dev/null)"
+  printf '  digest: %s\n  architecture: %s\n' "${pulled_digest:-?}" "${pulled_arch:-?}"
+  if [[ "$pulled_arch" == "$ARCH" ]]; then
+    note_ok "pulled image is ${ARCH}"
+  else
+    note_fail "pulled image reports architecture=${pulled_arch:-unknown}, expected ${ARCH}"
+  fi
+else
+  sed 's/^/    /' "${WORK}/pull.err"
+  note_fail "could not pull ${IMAGE} for ${ARCH}"
+fi
+
+# ── Case 3: the shipped binary actually executes ───────────────────────────
+# #3760: an image can pull cleanly and still carry a /usr/local/bin/hive that
+# the runtime presents as non-executable. Cheap to check, and precisely the
+# kind of thing that can differ per architecture.
+printf -- '\n--- case: the shipped binary executes ---\n'
+if version_out="$(pod run --rm --entrypoint /usr/local/bin/hive "$IMAGE" --version 2>&1)"; then
+  printf '  hive --version: %s\n' "$version_out"
+  note_ok "/usr/local/bin/hive runs on ${ARCH}"
+else
+  printf '  output: %s\n' "$version_out"
+  note_fail "/usr/local/bin/hive did not run (the #3760 shape)"
+fi
+
+# ── Case 4: the service starts and answers its readiness probe ─────────────
+# /api/health is what src/deploy/k8s/deployment.yaml uses as the readiness
+# probe, so "started" here means the same thing it means in production rather
+# than a log line that only proves a process was spawned.
+#
+# HIVE_PROXY_ADVISORY_OK=true is deliberate and is NOT a matrix case: it takes
+# the forced-egress gate out of the picture so what is measured is startup. An
+# agent IS configured, so the startup path exercised is the real one (uid map,
+# agent directories) rather than the shortcut a config with no agents takes.
+printf -- '\n--- case: the service starts (GET /api/health) ---\n'
+cat >"${WORK}/hive.yaml" <<'EOF'
+project:
+  org: kubestellar
+  repos:
+    - kubestellar/hive
+github:
+  token: "ghp_probe_not_a_real_token"
+agents:
+  probe:
+    backend: claude
+EOF
+
+pod rm -f "$PROBE_NAME" >/dev/null 2>&1
+if ! pod run -d --name "$PROBE_NAME" \
+      -e HIVE_PROXY_ADVISORY_OK=true \
+      -v "${WORK}/hive.yaml:/etc/hive/hive.yaml:ro,Z" \
+      -p "127.0.0.1:${HOST_PORT}:${API_PORT}" \
+      "$IMAGE" >/dev/null 2>"${WORK}/run.err"; then
+  sed 's/^/    /' "${WORK}/run.err"
+  note_fail "the container did not start"
+else
+  health=""
+  deadline=$(( SECONDS + HEALTH_TIMEOUT ))
+  while (( SECONDS < deadline )); do
+    health="$(curl -sS -m 5 -o /dev/null -w '%{http_code}' \
+      "http://127.0.0.1:${HOST_PORT}/api/health" 2>/dev/null)"
+    [[ "$health" == "200" ]] && break
+    # A container that has already exited will never become healthy.
+    if [[ "$(pod inspect -f '{{.State.Running}}' "$PROBE_NAME" 2>/dev/null)" != "true" ]]; then
+      break
+    fi
+    sleep 3
+  done
+
+  printf '  entrypoint milestones:\n'
+  pod logs "$PROBE_NAME" 2>&1 | grep -E '^\[entrypoint\] (Starting|WARN: proxy egress)' | sed 's/^/    /'
+
+  if [[ "$health" == "200" ]]; then
+    printf '  GET /api/health -> %s\n' "$health"
+    note_ok "the service started and answered its readiness probe on ${ARCH}"
+  else
+    printf '  GET /api/health -> %s (after %ss)\n' "${health:-no response}" "$HEALTH_TIMEOUT"
+    printf '  container state: %s (exit %s)\n' \
+      "$(pod inspect -f '{{.State.Status}}' "$PROBE_NAME" 2>/dev/null)" \
+      "$(pod inspect -f '{{.State.ExitCode}}' "$PROBE_NAME" 2>/dev/null)"
+    printf '  last 40 log lines:\n'
+    pod logs --tail 40 "$PROBE_NAME" 2>&1 | sed 's/^/    /'
+    note_fail "the service did not answer /api/health within ${HEALTH_TIMEOUT}s"
+  fi
+fi
+
+printf '\nSUMMARY: %d failure(s)\n' "$failures"
+[[ "$failures" -eq 0 ]] || exit 1
+exit 0

--- a/src/docs/podman-ci-runner-map.md
+++ b/src/docs/podman-ci-runner-map.md
@@ -126,6 +126,16 @@ hosted runners are ephemeral and single-use. It must never be combined with
 
 ### 3. `arm64`, hosted
 
+> **Built (#4336):** `.github/workflows/podman-arm64-lane.yml` runs
+> `src/deploy/probe_arm64_image_startup.sh` per PR on `ubuntu-24.04-arm`. It
+> asserts the runner really is arm64, prints the runtime and network backend
+> for comparison against the amd64 lanes, then checks four things and no more:
+> the tag advertises a `linux/arm64` image, that image pulls and really is
+> arm64, `/usr/local/bin/hive` executes, and the container answers
+> `GET /api/health`. A missing arm64 manifest fails the job rather than
+> skipping, and the lane does not build an image ad hoc — the arm64 build is
+> already a per-push gate in `docker.yml`.
+
 `ubuntu-24.04-arm` is already used by `.github/workflows/docker.yml` for the
 multi-architecture image build, so the runner label is proven in this
 repository. The probe shows it is capability-identical to amd64 for Podman.


### PR DESCRIPTION
## What

Adds the arm64 lane, on `ubuntu-24.04-arm`:

- `.github/workflows/podman-arm64-lane.yml` — asserts the stack, runs the probe.
- `src/deploy/probe_arm64_image_startup.sh` — the probe, runnable by hand on any
  arm64 host.

Every Podman result so far is amd64 only — #4199 and #4200 both record arm64 as
unproven. This closes that on the two questions #4188 actually asks of arm64.

## Scope — four checks, and the failure mode being avoided

#4211 names a duplicated full matrix as the thing not to build here: its probe
found the two architectures capability-identical, so re-running the egress-gate
cases on arm64 doubles cost for coverage that result says will not diverge. The
gate stays on the amd64 lanes (#4334, #4335). This lane runs four checks:

| Check | What it proves |
| --- | --- |
| `manifest` | the tag advertises a `linux/arm64` image |
| `pull` | that image comes down **and really is arm64** |
| `exec` | `/usr/local/bin/hive` runs |
| `startup` | the container answers `GET /api/health` |

`/api/health` is the endpoint `src/deploy/k8s/deployment.yaml` uses as its
readiness probe, so "started" means what it means in production rather than a
log line proving a process was spawned.

The probe sets `HIVE_PROXY_ADVISORY_OK=true`, and that is the opposite of
sneaking in a matrix case: without it the entrypoint fails closed with exit 77
and **nothing about startup gets tested**. Advisory mode takes the egress gate
out of the picture so what is measured is startup. An agent is still configured,
so the startup path exercised is the real one (uid map, agent directories)
rather than the shortcut an agent-less config takes.

The `exec` check is not filler. #3760 was a binary that shipped as a
non-executable overlayfs metacopy redirect at the image path — an image that
pulls fine and cannot run. That is exactly the class of failure a
per-architecture lane exists to catch.

## Acceptance criteria

- **Explicitly scoped to build/pull + startup, no duplicate matrix.** Four
  checks, stated in the workflow header, the probe header, and the table above.
- **A missing arm64 manifest fails the job rather than silently skipping.** An
  arm64 lane that steps aside when the arm64 image is absent reports green while
  proving nothing — which is the exact condition this lane exists to end. The
  probe also asserts the *pulled* image's architecture, so a manifest regression
  cannot hand the lane an amd64 image on an arm64 runner.
- **Runtime and network backend are printed for comparison against the amd64
  lanes.** Both the probe and the workflow summary report Podman version, arch,
  root mode, cgroups, OCI runtime, and network backend / rootless network
  command. #4211's capability-identical claim is what the scoping rests on, so
  the fields that claim would be falsified by are reported on every run rather
  than assumed to still hold.

## Pull, not build — and the stop condition

#4188 asks for "build/pull plus startup". The arm64 **build** is already a
per-push gate: `docker.yml` builds `linux/arm64` on this same runner label on
every branch and asserts the embedded commit matches the built SHA. What no lane
covered is the other half — that the published arm64 artifact pulls under Podman
and starts. So this lane pulls.

The stop condition does not fire: `ghcr.io/kubestellar/hive:v4-latest` publishes
an arm64 image today (`sha256:cc2b1350…`, verified against the registry). If it
ever stops, the lane does **not** build one ad hoc — it records the absence and
fails, pointing at the publisher.

## Verified locally

The probe was run end to end against the real published image with `--arch
amd64`, which exercises every line of the same code path on the architecture I
could run:

```
--- case: manifest advertises linux/amd64 ---
  architectures advertised: amd64 arm64
  RESULT: ok — the tag publishes a linux/amd64 image
--- case: pull linux/amd64 ---
  digest: sha256:ee1c08e58b695e5c74187fcf0caf6fbcb812315a09730355a6770e52fa3444f9
  architecture: amd64
  RESULT: ok — pulled image is amd64
--- case: the shipped binary executes ---
  hive --version: hive 3.0.0 (commit 3207e02, branch v4)
  RESULT: ok — /usr/local/bin/hive runs on amd64
--- case: the service starts (GET /api/health) ---
  entrypoint milestones:
    [entrypoint] WARN: proxy egress enforcement is ADVISORY-ONLY …
    [entrypoint] Starting Go binary on :3002 (uid=1001)
    [entrypoint] Starting Node.js proxy on :3001 → :3002
    [entrypoint] Starting ttyd on 127.0.0.1:7681
  GET /api/health -> 200
  RESULT: ok — the service started and answered its readiness probe on amd64

SUMMARY: 0 failure(s)   (exit 0)
```

The failure paths were exercised too, not just asserted:

| Case | Result |
| --- | --- |
| run on a non-matching host architecture | exit `78`, refuses rather than measuring emulation |
| reference with no image for the target arch | exit `1`, records the absence, stops before the cascade |

The arm64 run itself happens on this PR — `ubuntu-24.04-arm` is not something I
can exercise locally, which is why the workflow asserts `arch=arm64` at runtime
rather than trusting the label.

## Boundaries

The probe pulls into a throwaway store with a private graphroot and runroot and
removes only the container it created, by name. `contents: read`, no secrets, no
`pull_request_target`, no engine socket mounted. No path filters — #4339 is what
a guard scoped into silence looks like; the cost here is one image pull and one
container.

`src/docs/podman-ci-runner-map.md` lane 3 gets a "Built (#4336)" note, matching
how the other lanes are recorded.

Part of #4188 — this PR does not close the parent. Closes #4336.

— hive: backend=claude model=claude-opus-5
