### PR TITLE
✨ feat(convergence): expose blocked/unknown/partial admission diagnostics (default off)

### DIFF
--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -67,6 +67,9 @@ type Config struct {
 	// AgentSandbox configures the phase-1 credential-free sandbox runner. It is
 	// disabled by default and agents must opt in individually.
 	AgentSandbox AgentSandboxConfig `yaml:"agent_sandbox,omitempty" json:"agent_sandbox,omitempty"`
+	// Convergence toggles the convergence-driven admission surfaces
+	// (kubestellar/hive#3845 follow-ons). Default off → zero behaviour change.
+	Convergence ConvergenceConfig `yaml:"convergence,omitempty" json:"convergence,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
 	// TOMBSTONE list, and it exists because deletion had no durable record

--- a/src/pkg/config/convergence.go
+++ b/src/pkg/config/convergence.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// ConvergenceConfig is the operator-facing feature toggle for Hive's
+// convergence-driven admission surfaces (kubestellar/hive#3845).
+//
+// Everything the convergence follow-on increments add — admission DIAGNOSTICS
+// (#4246) and internal-kick admission observation (#4247) — ships behind this
+// toggle, DEFAULT OFF, so an existing v4 hive sees zero behaviour change until
+// an operator opts in. #4263 will formalise the full off/shadow/enforce
+// rollout; until then only the two conservative modes below exist:
+//
+//   - "off" (default): no convergence decisions are surfaced or applied by the
+//     gated code paths; they are entirely inert.
+//   - "shadow": decisions are computed and surfaced as read-only diagnostics
+//     (API/SSE fields, log lines) but NEVER enforced — no kick is withheld, no
+//     queue row changes, no routing changes.
+//
+// This toggle does NOT govern the contributor-neutral admission already landed
+// by #3857/#3904 (ReadyQueue/selectTask dependency gating) — that is existing,
+// shipped v4 behaviour and is unchanged in either mode.
+type ConvergenceConfig struct {
+	// Mode is "off" or "shadow". Any other value (including empty) resolves to
+	// "off" — the fail-safe direction is always "do nothing new".
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
+}
+
+const (
+	// ConvergenceModeOff disables every toggle-gated convergence surface.
+	ConvergenceModeOff = "off"
+	// ConvergenceModeShadow computes and surfaces decisions as diagnostics
+	// only; nothing is enforced.
+	ConvergenceModeShadow = "shadow"
+
+	// ConvergenceModeEnvVar overrides the configured mode at the process level,
+	// so an operator can flip shadow on/off without editing hive.yaml.
+	ConvergenceModeEnvVar = "HIVE_CONVERGENCE_MODE"
+)
+
+// ConvergenceMode resolves the effective convergence mode: the
+// HIVE_CONVERGENCE_MODE environment variable wins when it names a known mode,
+// then the configured convergence.mode, and anything unrecognised — a typo, a
+// future mode this build does not know, an empty value — resolves to "off".
+// Nil-safe: a nil Config is "off".
+func (c *Config) ConvergenceMode() string {
+	if env, ok := normalizeConvergenceMode(os.Getenv(ConvergenceModeEnvVar)); ok {
+		return env
+	}
+	if c == nil {
+		return ConvergenceModeOff
+	}
+	if mode, ok := normalizeConvergenceMode(c.Convergence.Mode); ok {
+		return mode
+	}
+	return ConvergenceModeOff
+}
+
+// normalizeConvergenceMode maps a raw operator-supplied string to a known mode.
+// The second return is false when the value names no known mode (callers fall
+// through to the next source, ultimately "off").
+func normalizeConvergenceMode(raw string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case ConvergenceModeOff:
+		return ConvergenceModeOff, true
+	case ConvergenceModeShadow:
+		return ConvergenceModeShadow, true
+	default:
+		return "", false
+	}
+}

--- a/src/pkg/config/convergence_test.go
+++ b/src/pkg/config/convergence_test.go
@@ -1,0 +1,65 @@
+package config
+
+import "testing"
+
+// ── kubestellar/hive#3845 convergence feature toggle ───────────────────────────
+//
+// The overriding rollout requirement is DEFAULT OFF: an operator who configured
+// nothing, or anything unrecognised, must resolve to "off" so existing v4 hives
+// see zero behaviour change. The env override exists so shadow can be flipped
+// per-process without editing hive.yaml.
+
+func TestConvergenceMode_DefaultIsOff(t *testing.T) {
+	t.Setenv(ConvergenceModeEnvVar, "")
+	var nilCfg *Config
+	if got := nilCfg.ConvergenceMode(); got != ConvergenceModeOff {
+		t.Fatalf("nil config resolved %q, want off", got)
+	}
+	if got := (&Config{}).ConvergenceMode(); got != ConvergenceModeOff {
+		t.Fatalf("zero config resolved %q, want off", got)
+	}
+}
+
+func TestConvergenceMode_ConfiguredShadow(t *testing.T) {
+	t.Setenv(ConvergenceModeEnvVar, "")
+	cfg := &Config{Convergence: ConvergenceConfig{Mode: "shadow"}}
+	if got := cfg.ConvergenceMode(); got != ConvergenceModeShadow {
+		t.Fatalf("resolved %q, want shadow", got)
+	}
+	// Case/whitespace-insensitive: operators type YAML by hand.
+	cfg.Convergence.Mode = "  Shadow "
+	if got := cfg.ConvergenceMode(); got != ConvergenceModeShadow {
+		t.Fatalf("resolved %q, want shadow", got)
+	}
+}
+
+func TestConvergenceMode_UnrecognisedValueFailsSafeToOff(t *testing.T) {
+	t.Setenv(ConvergenceModeEnvVar, "")
+	for _, raw := range []string{"enforce", "on", "true", "garbage"} {
+		cfg := &Config{Convergence: ConvergenceConfig{Mode: raw}}
+		if got := cfg.ConvergenceMode(); got != ConvergenceModeOff {
+			t.Fatalf("mode %q resolved %q, want off", raw, got)
+		}
+	}
+}
+
+func TestConvergenceMode_EnvOverridesConfig(t *testing.T) {
+	cfg := &Config{Convergence: ConvergenceConfig{Mode: "off"}}
+	t.Setenv(ConvergenceModeEnvVar, "shadow")
+	if got := cfg.ConvergenceMode(); got != ConvergenceModeShadow {
+		t.Fatalf("env=shadow over config=off resolved %q, want shadow", got)
+	}
+
+	cfg.Convergence.Mode = "shadow"
+	t.Setenv(ConvergenceModeEnvVar, "off")
+	if got := cfg.ConvergenceMode(); got != ConvergenceModeOff {
+		t.Fatalf("env=off over config=shadow resolved %q, want off", got)
+	}
+
+	// An unrecognised env value must NOT clobber a valid configured mode —
+	// the env only wins when it names a mode this build knows.
+	t.Setenv(ConvergenceModeEnvVar, "enforce")
+	if got := cfg.ConvergenceMode(); got != ConvergenceModeShadow {
+		t.Fatalf("unrecognised env over config=shadow resolved %q, want shadow", got)
+	}
+}

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -6475,10 +6475,21 @@ func (s *Server) handleContributeFleet(w http.ResponseWriter, r *http.Request) {
 // the SSE "hello" frame carries, so the queue renders even if the stream drops.
 func (s *Server) handleContributeQueue(w http.ResponseWriter, r *http.Request) {
 	queue := []ReadyQueueItem{}
+	resp := map[string]any{}
 	if s.contributeHub != nil {
-		queue = s.contributeHub.ReadyQueue(readyQueueDefaultLimit)
+		// One snapshot serves the queue and — only when the convergence toggle
+		// is in shadow mode (#4246, default off) — the additive withheld /
+		// coverage diagnostics from the SAME sweep. With the toggle off the
+		// response is exactly the pre-diagnostics payload.
+		diag := s.convergenceDiagnosticsEnabled()
+		snap := s.contributeHub.admissionQueueSnapshot(readyQueueDefaultLimit, diag)
+		queue = snap.queue
+		if diag {
+			resp["withheld"] = snap.withheld
+			resp["admission_coverage"] = snap.coverage
+		}
 	}
-	resp := map[string]any{"queue": queue}
+	resp["queue"] = queue
 	// Label-affinity (#2637): if we can identify the viewer server-side and they
 	// have declared label interests, personalise THIS response — tag matching
 	// issues and float them to the front for them. Soft signal only: nothing is

--- a/src/pkg/dashboard/contribute_admission_diagnostics.go
+++ b/src/pkg/dashboard/contribute_admission_diagnostics.go
@@ -1,0 +1,147 @@
+package dashboard
+
+import (
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/convergence"
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// ── #4246: blocked / unknown / partial admission diagnostics ──────────────────
+//
+// Operators could see WHICH work was offerable (ReadyQueue) but not WHY a
+// candidate was excluded: the rejected convergence.Decision was computed on the
+// queue's own sweep and then discarded. This file retains it — the SAME
+// Decision from the SAME captured sweep, never a re-evaluation — and surfaces
+// it additively on GET /api/contribute/queue and the SSE hello frame.
+//
+// Everything here is gated by the convergence feature toggle
+// (config.ConvergenceMode, kubestellar/hive#3845 rollout): with mode "off"
+// (the default) no diagnostics are collected or emitted and both payloads are
+// byte-for-byte what they were; with mode "shadow" the withheld collection and
+// coverage snapshot appear as read-only diagnostics. Nothing is EVER enforced
+// by this surface in either mode — a withheld row is a candidate the existing
+// #3857/#3904 admission already excluded; the diagnostics only stop discarding
+// the explanation.
+//
+// Deliberate non-facts: no condition the evaluator did not compute is emitted
+// (no Converged, no HumanDecisionRequired, no quiescence, no generic
+// Degraded), decisions are never cached across passes, and nothing is
+// persisted — every request/hydration recomputes from current authoritative
+// in-memory bead state through the queue's own sweep.
+
+// AdmissionWithheldItem is one candidate the contributor-neutral convergence
+// admission withheld from the offerable queue, with the exact facts the
+// evaluator computed on the queue's captured sweep: the stable reason, the
+// blocker IDs, the observed record/generation, and the Observed/Ready
+// tri-state conditions. It exposes nothing the live path did not already
+// compute.
+//
+// Open-PR-claim refusals are NOT represented here: they are a different,
+// pre-convergence gate with their own surface, and #4246 owns only the
+// blocked/unknown/partial convergence diagnostics.
+type AdmissionWithheldItem struct {
+	Repo   string `json:"repo"`
+	Number int    `json:"number,omitempty"`
+	// Key is the candidate's canonical, source-aware identity
+	// (kubestellar/hive#4245): "owner/repo#42" for GitHub-backed work.
+	Key   string `json:"key,omitempty"`
+	Title string `json:"title,omitempty"`
+	URL   string `json:"url,omitempty"`
+	// Reason is the stable machine-readable convergence reason
+	// (convergence.ReasonWaitingForDependency / ReasonDependencyUnknown / a
+	// degraded-observation reason).
+	Reason string `json:"reason"`
+	// Blockers are the dependency IDs that prevented admission, already sorted
+	// by the evaluator.
+	Blockers []string `json:"blockers,omitempty"`
+	// ObservedRecord / ObservedGeneration echo which revision of desired state
+	// the judgment was made against.
+	ObservedRecord     string `json:"observed_record,omitempty"`
+	ObservedGeneration string `json:"observed_generation,omitempty"`
+	// Observed / Ready are the tri-state condition statuses ("True" | "False" |
+	// "Unknown") the evaluator set, so an operator can distinguish a definite
+	// blocker (Ready=False) from irreducible uncertainty (Ready=Unknown).
+	Observed string `json:"observed,omitempty"`
+	Ready    string `json:"ready,omitempty"`
+}
+
+// AdmissionCoverage reports, per snapshot, how much of the bead ledger the
+// queue's sweep could actually read — the partial-ledger compromise that was
+// previously visible only in a log line. Policy states the final #3904 rule in
+// force so a partial view is never mistaken for authoritative proof of absence.
+type AdmissionCoverage struct {
+	// Partial is true when at least one configured bead store could not be
+	// read, so a lookup miss is not fully trustworthy.
+	Partial bool `json:"partial"`
+	// StoresRead / StoresFailed count the configured stores the sweep read and
+	// the ones that failed to load at startup.
+	StoresRead   int `json:"stores_read"`
+	StoresFailed int `json:"stores_failed,omitempty"`
+	// Policy is the fixed statement of the final #3904 partial-ledger rule.
+	Policy string `json:"policy"`
+}
+
+// admissionCoveragePolicy is the current (final #3904) partial-ledger policy,
+// stated verbatim on every snapshot: candidates whose record WAS readable stay
+// fully gated, while unmapped lookup misses remain admitted — a miss under
+// reduced coverage is never presented as authoritative proof of absence.
+const admissionCoveragePolicy = "readable blocked records are gated; unmapped lookup misses are admitted (kubestellar/hive#3904)"
+
+// queueAdmissionSnapshot is ONE read-only, ephemeral admission pass: the
+// offerable queue, the withheld diagnostics for convergence-blocked/unknown
+// candidates, and the sweep's ledger coverage — all from the SAME captured
+// sweep, so queue and diagnostics cannot disagree about the state they judged.
+// It lives for exactly one request/hydration and is never cached.
+type queueAdmissionSnapshot struct {
+	queue    []ReadyQueueItem
+	withheld []AdmissionWithheldItem
+	coverage AdmissionCoverage
+}
+
+// convergenceDiagnosticsEnabled reports whether the #4246 diagnostics surface
+// is on: convergence mode "shadow". With the default "off" the withheld
+// collection is never built and every payload is unchanged. Nil-safe.
+func (s *Server) convergenceDiagnosticsEnabled() bool {
+	if s == nil || s.deps == nil || s.deps.Config == nil {
+		return false
+	}
+	return s.deps.Config.ConvergenceMode() == config.ConvergenceModeShadow
+}
+
+// admissionCoverageFromSweep projects the sweep's ledger-coverage facts into
+// the snapshot-level report.
+func (h *ContributeWSHub) admissionCoverageFromSweep(sweep *contributorAdmissionSweep) AdmissionCoverage {
+	cov := AdmissionCoverage{Policy: admissionCoveragePolicy}
+	if sweep != nil && sweep.deps != nil {
+		cov.Partial = sweep.deps.partial
+		cov.StoresRead = sweep.deps.stores
+	}
+	if h != nil && h.server != nil && h.server.deps != nil {
+		cov.StoresFailed = h.server.deps.BeadStoreLoadFailures
+	}
+	return cov
+}
+
+// withheldItemFromDecision renders one convergence-withheld candidate from the
+// exact Decision the queue's sweep produced. It reads conditions out of the
+// decision rather than recomputing anything — retaining, not re-evaluating.
+func withheldItemFromDecision(repoFull string, ref worksource.Ref, title, url string, d convergence.Decision) AdmissionWithheldItem {
+	item := AdmissionWithheldItem{
+		Repo:               repoFull,
+		Number:             ref.Number,
+		Key:                ref.Key(),
+		Title:              title,
+		URL:                url,
+		Reason:             d.Reason,
+		Blockers:           d.Blockers,
+		ObservedRecord:     d.ObservedRecord,
+		ObservedGeneration: d.ObservedGeneration,
+	}
+	if c, ok := d.Condition(convergence.ConditionObserved); ok {
+		item.Observed = string(c.Status)
+	}
+	if c, ok := d.Condition(convergence.ConditionReady); ok {
+		item.Ready = string(c.Status)
+	}
+	return item
+}

--- a/src/pkg/dashboard/contribute_admission_diagnostics_test.go
+++ b/src/pkg/dashboard/contribute_admission_diagnostics_test.go
@@ -1,0 +1,390 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/beads"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/convergence"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// ── #4246: blocked / unknown / partial admission diagnostics ──────────────────
+//
+// These tests pin the strict acceptance matrix on the PRODUCTION read paths
+// (GET /api/contribute/queue, the SSE hello frame, and the shared snapshot
+// behind both) — not on a helper. Two invariants dominate:
+//
+//   1. DEFAULT OFF: with the convergence toggle unset the payloads carry no
+//      diagnostics fields at all — byte-for-byte compatible surface.
+//   2. SAME DECISION: a withheld row carries the exact convergence.Decision the
+//      queue's own sweep computed; blocked work is never represented as ready.
+
+// diagShadow flips the convergence toggle to shadow for one test, clearing any
+// ambient env override first so the test is hermetic.
+func diagShadow(t *testing.T, s *Server) {
+	t.Helper()
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	s.deps.Config.Convergence.Mode = config.ConvergenceModeShadow
+}
+
+func withheldNumbers(items []AdmissionWithheldItem) []int {
+	out := []int{}
+	for _, it := range items {
+		out = append(out, it.Number)
+	}
+	return out
+}
+
+// TestAdmissionDiagnostics_OffModeAddsNothing pins the default-off guarantee on
+// both HTTP payloads: no "withheld", no "admission_coverage", queue unchanged,
+// and blocked work still absent (the pre-existing #3857/#3904 gate is NOT
+// toggled by the diagnostics feature).
+func TestAdmissionDiagnostics_OffModeAddsNothing(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	// The existing gate still withholds #601 with the toggle off.
+	assertQueue(t, hub, 700)
+	assertAssigns(t, hub, 700)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/queue", nil)
+	rec := httptest.NewRecorder()
+	s.handleContributeQueue(rec, req)
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad queue JSON: %v", err)
+	}
+	if _, ok := resp["withheld"]; ok {
+		t.Fatal("mode=off must not add a withheld field to /api/contribute/queue")
+	}
+	if _, ok := resp["admission_coverage"]; ok {
+		t.Fatal("mode=off must not add admission_coverage to /api/contribute/queue")
+	}
+
+	// Snapshot without diagnostics collects nothing beyond the queue.
+	snap := hub.admissionQueueSnapshot(readyQueueDefaultLimit, false)
+	if snap.withheld != nil {
+		t.Fatalf("withDiagnostics=false must not collect withheld rows, got %v", snap.withheld)
+	}
+}
+
+// TestAdmissionDiagnostics_BlockedDependencyIsExplained covers the core rows:
+// a candidate with an OPEN dependency is absent from queue and assignment, and
+// the shadow diagnostics carry Ready=False, reason WaitingForDependency, and
+// name the exact blocker — from the same sweep that built the queue.
+func TestAdmissionDiagnostics_BlockedDependencyIsExplained(t *testing.T) {
+	store := depTestStore(t)
+	blockerID := seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+
+	// Blocked work stays out of queue and assignment (never represented ready).
+	assertQueue(t, hub, 700)
+	assertAssigns(t, hub, 700)
+
+	snap := hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	if got := queueNumbers(snap.queue); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("queue offered %v, want [700]", got)
+	}
+	if got := withheldNumbers(snap.withheld); len(got) != 1 || got[0] != 601 {
+		t.Fatalf("withheld %v, want [601]", got)
+	}
+	w := snap.withheld[0]
+	if w.Reason != convergence.ReasonWaitingForDependency {
+		t.Fatalf("reason %q, want WaitingForDependency", w.Reason)
+	}
+	if w.Ready != string(convergence.ConditionFalse) {
+		t.Fatalf("Ready %q, want False", w.Ready)
+	}
+	if w.Observed != string(convergence.ConditionTrue) {
+		t.Fatalf("Observed %q, want True (a record exists)", w.Observed)
+	}
+	if len(w.Blockers) != 1 || w.Blockers[0] != blockerID {
+		t.Fatalf("blockers %v, want [%s]", w.Blockers, blockerID)
+	}
+	if w.ObservedRecord == "" || w.ObservedGeneration == "" {
+		t.Fatalf("expected observed record+generation, got %q / %q", w.ObservedRecord, w.ObservedGeneration)
+	}
+	if w.Key != "projectbluefin/dakota#601" {
+		t.Fatalf("key %q, want canonical identity", w.Key)
+	}
+	if w.Repo != "projectbluefin/dakota" || w.Title != "dependent work" {
+		t.Fatalf("unexpected candidate reference: %+v", w)
+	}
+
+	// Coverage: one store read, full ledger, policy stated.
+	if snap.coverage.Partial || snap.coverage.StoresRead != 1 || snap.coverage.StoresFailed != 0 {
+		t.Fatalf("coverage %+v, want full single-store coverage", snap.coverage)
+	}
+	if snap.coverage.Policy != admissionCoveragePolicy {
+		t.Fatalf("policy %q, want the fixed #3904 statement", snap.coverage.Policy)
+	}
+}
+
+// TestAdmissionDiagnostics_UnknownDependencyIsUnknownNotFalse: an unresolvable,
+// non-retired dependency yields Ready=Unknown / DependencyUnknown — distinct
+// from an established blocker — and the candidate is still withheld.
+func TestAdmissionDiagnostics_UnknownDependencyIsUnknownNotFalse(t *testing.T) {
+	store := depTestStore(t)
+	dependent, err := store.Create("dependent work", beads.TypeTask, beads.PriorityMedium, "scanner",
+		"gh-projectbluefin/dakota#601")
+	if err != nil {
+		t.Fatalf("creating dependent: %v", err)
+	}
+	if err := store.Update(dependent.ID, func(b *beads.Bead) {
+		b.DependsOn = []string{"bd-nonexistent"}
+	}); err != nil {
+		t.Fatalf("adding dangling dependency: %v", err)
+	}
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+
+	assertQueue(t, hub, 700)
+	snap := hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	if got := withheldNumbers(snap.withheld); len(got) != 1 || got[0] != 601 {
+		t.Fatalf("withheld %v, want [601]", got)
+	}
+	w := snap.withheld[0]
+	if w.Reason != convergence.ReasonDependencyUnknown {
+		t.Fatalf("reason %q, want DependencyUnknown", w.Reason)
+	}
+	if w.Ready != string(convergence.ConditionUnknown) {
+		t.Fatalf("Ready %q, want Unknown — an unknown must never be reported False", w.Ready)
+	}
+}
+
+// TestAdmissionDiagnostics_PositiveControls: a terminal-retired dependency and a
+// candidate with no record at all are both ADMITTED — present in the queue,
+// absent from withheld — so the diagnostics cannot drift into reject-everything.
+func TestAdmissionDiagnostics_PositiveControls(t *testing.T) {
+	store := depTestStore(t)
+	blockerID := seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	if err := store.Close(blockerID); err != nil {
+		t.Fatalf("closing blocker: %v", err)
+	}
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+
+	// #601's dependency is satisfied; #700 has no record. Both admitted.
+	snap := hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	if got := queueNumbers(snap.queue); len(got) != 2 || got[0] != 601 || got[1] != 700 {
+		t.Fatalf("queue offered %v, want [601 700]", got)
+	}
+	if len(snap.withheld) != 0 {
+		t.Fatalf("nothing should be withheld, got %v", snap.withheld)
+	}
+}
+
+// TestAdmissionDiagnostics_FlipsWithoutRestart: closing the blocker moves the
+// candidate from withheld to queue on the NEXT snapshot — no restart, no cached
+// decision — and reopening it moves it back.
+func TestAdmissionDiagnostics_FlipsWithoutRestart(t *testing.T) {
+	store := depTestStore(t)
+	blockerID := seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+
+	snap := hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	if got := withheldNumbers(snap.withheld); len(got) != 1 || got[0] != 601 {
+		t.Fatalf("withheld %v, want [601]", got)
+	}
+
+	if err := store.Close(blockerID); err != nil {
+		t.Fatalf("closing blocker: %v", err)
+	}
+	snap = hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	if len(snap.withheld) != 0 {
+		t.Fatalf("withheld %v after satisfaction, want none", snap.withheld)
+	}
+	if got := queueNumbers(snap.queue); len(got) != 2 {
+		t.Fatalf("queue %v after satisfaction, want both items", got)
+	}
+
+	if err := store.Update(blockerID, func(b *beads.Bead) {
+		b.Status = beads.StatusOpen
+		b.ClosedAt = nil
+	}); err != nil {
+		t.Fatalf("reopening blocker: %v", err)
+	}
+	snap = hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	if got := withheldNumbers(snap.withheld); len(got) != 1 || got[0] != 601 {
+		t.Fatalf("withheld %v after reopening, want [601] — no latched status", got)
+	}
+}
+
+// TestAdmissionDiagnostics_PartialLedgerCoverage: with one configured store
+// unreadable the snapshot REPORTS reduced coverage (partial, counts, policy)
+// while behaviour keeps the final #3904 compromise — readable blocked records
+// stay withheld, unmapped misses stay admitted.
+func TestAdmissionDiagnostics_PartialLedgerCoverage(t *testing.T) {
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	s.deps.BeadStoreLoadFailures = 1
+	diagShadow(t, s)
+
+	snap := hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	cov := snap.coverage
+	if !cov.Partial || cov.StoresRead != 1 || cov.StoresFailed != 1 {
+		t.Fatalf("coverage %+v, want partial with 1 read / 1 failed", cov)
+	}
+	if cov.Policy != admissionCoveragePolicy {
+		t.Fatalf("policy %q missing", cov.Policy)
+	}
+	// Readable blocked record stays gated; unmapped miss (#700) stays admitted.
+	if got := withheldNumbers(snap.withheld); len(got) != 1 || got[0] != 601 {
+		t.Fatalf("withheld %v, want [601]", got)
+	}
+	if got := queueNumbers(snap.queue); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("queue %v, want [700] — misses are admitted, not proof of absence", got)
+	}
+}
+
+// TestAdmissionDiagnostics_QueueEndpointShadowPayload drives the real HTTP
+// handler in shadow mode and asserts the additive fields appear alongside an
+// unchanged queue field.
+func TestAdmissionDiagnostics_QueueEndpointShadowPayload(t *testing.T) {
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+	_ = hub
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/queue", nil)
+	rec := httptest.NewRecorder()
+	s.handleContributeQueue(rec, req)
+
+	var resp struct {
+		Queue    []ReadyQueueItem        `json:"queue"`
+		Withheld []AdmissionWithheldItem `json:"withheld"`
+		Coverage *AdmissionCoverage      `json:"admission_coverage"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad queue JSON: %v", err)
+	}
+	if got := queueNumbers(resp.Queue); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("queue %v, want [700]", got)
+	}
+	if got := withheldNumbers(resp.Withheld); len(got) != 1 || got[0] != 601 {
+		t.Fatalf("withheld %v, want [601]", got)
+	}
+	if resp.Withheld[0].Reason != convergence.ReasonWaitingForDependency {
+		t.Fatalf("withheld reason %q", resp.Withheld[0].Reason)
+	}
+	if resp.Coverage == nil || resp.Coverage.Policy != admissionCoveragePolicy {
+		t.Fatalf("admission_coverage missing or wrong: %+v", resp.Coverage)
+	}
+}
+
+// TestAdmissionDiagnostics_SSEHelloCarriesWithheld asserts the SSE hydration
+// path carries the same additive diagnostics in shadow mode.
+func TestAdmissionDiagnostics_SSEHelloCarriesWithheld(t *testing.T) {
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/events", nil).WithContext(ctx)
+	rec := newSyncRecorder()
+	go s.handleContributeEvents(rec, req)
+
+	waitFor(t, func() bool {
+		b := rec.BodyString()
+		return strings.Contains(b, `"type":"hello"`) &&
+			strings.Contains(b, `"withheld"`) &&
+			strings.Contains(b, `"admission_coverage"`) &&
+			strings.Contains(b, convergence.ReasonWaitingForDependency)
+	}, "hello frame with withheld diagnostics")
+}
+
+// TestAdmissionDiagnostics_SSEHelloOffModeOmitsFields: with the toggle off the
+// hello frame must not mention the diagnostics keys at all.
+func TestAdmissionDiagnostics_SSEHelloOffModeOmitsFields(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/events", nil).WithContext(ctx)
+	rec := newSyncRecorder()
+	go s.handleContributeEvents(rec, req)
+
+	waitFor(t, func() bool {
+		return strings.Contains(rec.BodyString(), `"type":"hello"`)
+	}, "hello frame")
+	b := rec.BodyString()
+	if strings.Contains(b, `"withheld"`) || strings.Contains(b, `"admission_coverage"`) {
+		t.Fatal("mode=off hello frame must not carry diagnostics fields")
+	}
+}
+
+// TestAdmissionDiagnostics_OpenPRClaimIsNotAConvergenceDiagnostic: an open-PR
+// claim refusal is a different gate with a zero convergence Decision; it must
+// not appear in the withheld collection (which would fabricate conditions).
+func TestAdmissionDiagnostics_OpenPRClaimIsNotAConvergenceDiagnostic(t *testing.T) {
+	store := depTestStore(t)
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+	s.deps.IssueClaimed = func(repo string, number int) (ghpkg.IssueClaim, bool) {
+		if number == 601 {
+			return ghpkg.IssueClaim{PRNumber: 999}, true
+		}
+		return ghpkg.IssueClaim{}, false
+	}
+
+	snap := hub.admissionQueueSnapshot(readyQueueDefaultLimit, true)
+	if got := queueNumbers(snap.queue); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("queue %v, want [700]", got)
+	}
+	if len(snap.withheld) != 0 {
+		t.Fatalf("open-PR-claim refusal leaked into convergence withheld: %v", snap.withheld)
+	}
+}
+
+// TestWithheldItemFromDecision_DegradedObservation pins the mapping for a
+// degraded observer: Ready=Unknown with the degraded reason, never admitted,
+// and no condition the evaluator did not compute.
+func TestWithheldItemFromDecision_DegradedObservation(t *testing.T) {
+	d := convergence.Evaluate(convergence.Observation{
+		Subject:        convergence.Subject{Repo: "o/r", Number: 5},
+		Degraded:       true,
+		DegradedReason: "BeadLedgerPartial",
+	})
+	if d.Admitted {
+		t.Fatal("degraded observation must never admit")
+	}
+	item := withheldItemFromDecision("o/r", worksource.Ref{Repo: "o/r", Number: 5}, "t", "u", d)
+	if item.Ready != string(convergence.ConditionUnknown) || item.Observed != string(convergence.ConditionUnknown) {
+		t.Fatalf("degraded mapping %+v, want Unknown/Unknown", item)
+	}
+	if item.Reason != "BeadLedgerPartial" {
+		t.Fatalf("reason %q", item.Reason)
+	}
+}
+
+// TestAdmissionDiagnostics_WithheldIsBounded: the withheld collection is capped
+// at the queue limit so a pathological ledger cannot blow out the payload.
+func TestAdmissionDiagnostics_WithheldIsBounded(t *testing.T) {
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	diagShadow(t, s)
+
+	snap := hub.admissionQueueSnapshot(1, true)
+	if len(snap.withheld) > 1 {
+		t.Fatalf("withheld exceeded limit: %d", len(snap.withheld))
+	}
+}

--- a/src/pkg/dashboard/contribute_sse.go
+++ b/src/pkg/dashboard/contribute_sse.go
@@ -62,6 +62,13 @@ type sseEvent struct {
 	Activity *ActivityEntry   `json:"activity,omitempty"` // set when Type=="activity"
 	Replay   []ActivityEntry  `json:"replay,omitempty"`   // set when Type=="hello"
 	Queue    []ReadyQueueItem `json:"queue,omitempty"`    // set when Type=="hello"
+	// Withheld and AdmissionCoverage are the #4246 convergence admission
+	// diagnostics, set on the "hello" frame ONLY when the convergence toggle is
+	// in shadow mode (default off → both absent, payload unchanged). They come
+	// from the SAME sweep that produced Queue, so the two cannot disagree.
+	// Existing SSE clients ignore additive fields.
+	Withheld          []AdmissionWithheldItem `json:"withheld,omitempty"`
+	AdmissionCoverage *AdmissionCoverage      `json:"admission_coverage,omitempty"`
 }
 
 // ReadyQueueItem is one admissible/ready issue in the "queue waiting to be picked
@@ -208,19 +215,35 @@ func (h *ContributeWSHub) broadcastActivity(entry ActivityEntry) {
 // draws from, minus the per-contributor own-work reshuffle. That is the documented
 // "simple recent/top-N is acceptable" fallback the spec permits.
 func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
+	return h.admissionQueueSnapshot(limit, false).queue
+}
+
+// admissionQueueSnapshot is the single admission pass behind ReadyQueue and the
+// #4246 diagnostics surface. One sweep produces BOTH the offerable queue and —
+// when withDiagnostics is true (convergence shadow mode) — the withheld
+// collection for convergence-blocked/unknown candidates, retaining the exact
+// Decision each refusal computed rather than re-evaluating it. The snapshot is
+// ephemeral: built per call, never cached, so every request re-observes current
+// authoritative state.
+func (h *ContributeWSHub) admissionQueueSnapshot(limit int, withDiagnostics bool) queueAdmissionSnapshot {
 	if limit <= 0 {
 		limit = readyQueueDefaultLimit
 	}
-	out := []ReadyQueueItem{}
+	snap := queueAdmissionSnapshot{queue: []ReadyQueueItem{}}
+	if withDiagnostics {
+		snap.withheld = []AdmissionWithheldItem{}
+		snap.coverage.Policy = admissionCoveragePolicy
+	}
+	out := snap.queue
 	if h == nil || h.server == nil {
-		return out
+		return snap
 	}
 
 	h.server.statusMu.RLock()
 	status := h.server.status
 	h.server.statusMu.RUnlock()
 	if status == nil {
-		return out
+		return snap
 	}
 
 	// Which issues are already being worked right now — exclude them from "ready"
@@ -248,6 +271,9 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 	// candidate — so the dependency gate stays cheap, and discarded when the pass
 	// ends so the next call re-observes current state.
 	sweep := h.newAdmissionSweep()
+	if withDiagnostics {
+		snap.coverage = h.admissionCoverageFromSweep(sweep)
+	}
 
 	for _, repo := range status.Repos {
 		if len(repo.ActionableIssues) == 0 {
@@ -323,6 +349,19 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 				ref:      ref,
 			})
 			if !decision.admitted {
+				// #4246: retain the convergence Decision behind this refusal
+				// instead of discarding it. Only convergence refusals are
+				// collected (an open-PR claim never reaches the dependency gate
+				// and carries a zero Decision), only in shadow mode, and only up
+				// to the same bound as the queue so a pathological ledger can
+				// never blow out the payload. Blocked/unknown work stays OUT of
+				// the queue and out of assignment exactly as before.
+				if withDiagnostics && decision.reason != contributorAdmissionReasonOpenPRClaim && len(snap.withheld) < limit {
+					title, _ := issue["title"].(string)
+					url, _ := issue["url"].(string)
+					snap.withheld = append(snap.withheld,
+						withheldItemFromDecision(repo.Full, ref, title, url, decision.convergence))
+				}
 				continue
 			}
 			title, _ := issue["title"].(string)
@@ -385,7 +424,8 @@ func (h *ContributeWSHub) ReadyQueue(limit int) []ReadyQueueItem {
 	// operator's parked rows off-screen — the operator must always be able to see and
 	// Resume what they held.
 	out = append(out, heldItems...)
-	return out
+	snap.queue = out
+	return snap
 }
 
 // queueOrderIndex builds a "owner/repo#number" -> priority-rank map from the
@@ -510,10 +550,19 @@ func (s *Server) handleContributeEvents(w http.ResponseWriter, r *http.Request) 
 	if len(replay) > sseReplayCap {
 		replay = replay[len(replay)-sseReplayCap:]
 	}
+	// One snapshot feeds queue AND (in shadow mode) the #4246 diagnostics, so
+	// the hello frame's queue and withheld collections come from the same sweep.
+	diag := s.convergenceDiagnosticsEnabled()
+	snap := s.contributeHub.admissionQueueSnapshot(readyQueueDefaultLimit, diag)
 	hello := sseEvent{
 		Type:   "hello",
 		Replay: replay,
-		Queue:  s.contributeHub.ReadyQueue(readyQueueDefaultLimit),
+		Queue:  snap.queue,
+	}
+	if diag {
+		hello.Withheld = snap.withheld
+		cov := snap.coverage
+		hello.AdmissionCoverage = &cov
 	}
 	if !writeSSE(w, hello) {
 		return


### PR DESCRIPTION
Closes #4246
Part of #3845

## What

Operators can now see **why** a candidate is not admitted, using the **same `convergence.Decision`** the shared contributor-neutral evaluator produces for `ReadyQueue`/`selectTask` — no second evaluator, no re-evaluation, no cached or persisted status.

- The existing `ReadyQueue` pass is refactored into one read-only, ephemeral **admission snapshot** (`admissionQueueSnapshot`) that retains, per pass:
  - the offerable queue (unchanged; `ReadyQueue` remains the compatibility view over the admitted portion),
  - a separate **withheld** collection for convergence-blocked/unknown candidates carrying the exact facts already computed: candidate reference, stable reason, blockers, observed record/generation, and `Observed`/`Ready` tri-state conditions,
  - snapshot-level **partial-ledger coverage**: partial flag, stores read/failed, and the final #3904 policy stated verbatim (`readable blocked records are gated; unmapped lookup misses are admitted`).
- Fields are added **additively** to `GET /api/contribute/queue` and the SSE hello payload. Blocked/unknown work stays outside `queue` and assignment. Open-PR-claim refusals are not represented (different gate, zero Decision). No uncomputed condition (`Converged`, `HumanDecisionRequired`, quiescence, generic `Degraded`) is ever emitted.

## Default-off guarantee (maintainer requirement)

All of this ships behind a conservative feature toggle, **default off**, ahead of #4263's off/shadow/enforce formalisation:

```yaml
convergence:
  mode: "off"   # or "shadow"; env override HIVE_CONVERGENCE_MODE
```

- **off (default):** no diagnostics are collected or emitted; the `/api/contribute/queue` and SSE hello payloads are byte-for-byte unchanged. Existing v4 users see **zero behavior change**; unrecognised values fail safe to off.
- **shadow:** decisions are surfaced as read-only diagnostics only — nothing is enforced by this surface in any mode. (The #3857/#3904 queue/assignment dependency gate is pre-existing shipped behavior and is not toggled.)

## Tests

Strict-matrix production-path tests in `contribute_admission_diagnostics_test.go` (blocked → `Ready=False`/`WaitingForDependency` + named blocker; unknown → `Ready=Unknown`/`DependencyUnknown`; terminal-retired and no-record positive controls; unrelated-ready control; partial-ledger coverage report with #3904 policy preserved; flip-without-restart / no latching; off-mode payload unchanged on both HTTP and SSE; shadow payloads on both; open-PR-claim exclusion; degraded-observation mapping; bounded withheld). Toggle resolution pinned in `pkg/config/convergence_test.go` (default off, env override, fail-safe on unknown values). `go test -race` clean on the touched admission tests; `pkg/dashboard` at 83.3% (floor 78).