### PR TITLE
📝 docs(troubleshooting): point agent-behaviour debugging at explain mode

### DIFF
--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -118,6 +118,54 @@ Liveness is judged by the governor's in-process health check, so an agent that k
 1. **Read the work counts, not just liveness.** If an agent reports "Issues triaged: 0" cycle after cycle in the logs, that is the signal — `kubectl -n hive logs deploy/hive | grep <agent>` or attach to the session.
 2. **Cross-check an external surface.** Confirm the effect the agent is supposed to produce (a GitHub API query for the PRs/issues it claims to have handled) rather than trusting its self-reported state.
 
+## An agent runs, but not the way I expect — why did it do that?
+
+Agents are told to act, not narrate: every policy carries an "Output Rules —
+Terse Mode" block, and on inference backends the agent manager appends an
+explicit `EXECUTE, DO NOT NARRATE` instruction to each kick. That rule earns
+its keep — weak models otherwise answer a kick with a plan for someone else to
+run — but it means the log shows *what* an agent did and never *why*, which is
+the one thing you need when the behaviour is wrong rather than absent.
+
+**Turn on explain mode for that one agent.** It asks the agent to record the
+reason for each tool call without relaxing the rule for anything else:
+
+```yaml
+agents:
+  scanner:
+    backend: claude
+    explain_mode: brief     # off | brief | full
+```
+
+`brief` adds one `EXPLAIN:` line before each tool call. `full` adds a closing
+block covering the goal as understood, the approach chosen, and the
+alternatives rejected. `HIVE_EXPLAIN_MODE` sets a hive-wide default for agents
+that leave the field unset.
+
+The explanation lands in the agent's ordinary log behind an `EXPLAIN:` prefix,
+so it is a read-time choice rather than a second stream:
+
+```sh
+# Just the reasoning
+curl -s "$HIVE/api/agents/<name>/log?explain=only"
+
+# The log as it would read with explanation off
+curl -s "$HIVE/api/agents/<name>/log?explain=hide"
+```
+
+`grep EXPLAIN:` works the same way on a log you have already downloaded.
+
+Two things worth knowing before you reach for it:
+
+- **It costs tokens on every kick**, which is why it is per-agent and off by
+  default. Turn it on for the agent you are debugging, not for the fleet.
+- **The agent still has to act.** A response containing only explanation is a
+  failure, and the prose-only watchdog still fires — explain mode does not
+  license narrating instead of working.
+
+Full reference, including the tri-state inheritance rules:
+[agent-configuration.md](agent-configuration.md#explain-mode-debugging-agent-behaviour).
+
 ## Switching an agent's model
 
 Model selection is a per-agent config field (`agent.<name>.model`), applied at **launch time** as the CLI's `--model` flag (`src/pkg/agent/manager.go`). There is no live in-session `/model` slash command sent over tmux; changing the model means changing the config and relaunching the agent. Do this through the supported paths, which handle the restart for you:


### PR DESCRIPTION
## What

Adds one section to `src/docs/troubleshooting.md` pointing anyone debugging
agent behaviour at explain mode. Documentation only; no behaviour change.

## Why this, and not the feature

The feature already landed. #3897 merged at **22:24 UTC** today, shipping
`explain_mode`, `HIVE_EXPLAIN_MODE`, the `?explain=` log filters, and reference
docs in `agent-configuration.md`.

@MikeSpreitzer then commented on #3887 that he saw *"no control over explanation
in the agent nor hive configuration"*, naming the commit he was reading:
`9f31439`. That commit is dated **16:39 UTC** — about six hours before #3897
merged. So the first half of that report was a timing artifact and is now
resolved on `v4`; nothing to fix there.

His second comment does outlive it: *"I also see nothing about control over
explanation in kubestellar.io/docs/hive."* Explain mode is documented where you
go to **configure** an agent. His use case, quoted in the issue, is the other
one:

> I am trying to modify an agent. It is not doing what I expect. I am having
> trouble understanding why.

Someone in that position opens troubleshooting. `src/docs/troubleshooting.md`
is the current v4 page — the top-level `docs/troubleshooting.md` is flagged
legacy v1/systemd and already redirects here — and it had a section for an
agent that does nothing, and one for an agent that looks alive but silently
no-ops, and **nothing for an agent that acts wrongly**, which is precisely the
case the feature was built for.

## The section

Placed next to the no-op one. It covers why the log records *what* an agent did
and never *why*, the per-agent knob, the hive-wide default, the
`?explain=only` / `?explain=hide` read-time filters, and links onward to
`agent-configuration.md` for the tri-state inheritance rules rather than
duplicating them.

## Claims checked against the code, not copied

Both caveats in the section are verified, since a troubleshooting page that is
subtly wrong is worse than one that is silent:

- **"The prose-only watchdog still fires."** True: `countToolMarkers` calls
  `stripExplainLines` first (`src/pkg/agent/manager.go`), so an agent quoting a
  tool marker inside an explanation cannot be mistaken for one making a tool
  call. The kick suffix itself reads `EXPLAIN MODE (brief) — DEBUGGING AID, NOT
  A LICENCE TO NARRATE`.
- **The route and query values.** Read off `GET /api/agents/{name}/log`
  (`src/pkg/dashboard/api.go:70`) and `filterExplainLines`' `only` / `hide`
  cases (`src/pkg/dashboard/terminal_log.go:99`), not assumed from the other
  page.

The link anchor resolves to the existing
`## Explain mode (debugging agent behaviour)` heading.

## Scope

`Refs #3887` rather than `Closes` — the feature work is #3897's, already
merged. Whether this issue closes is the maintainer's call, and if the
kubestellar.io site publishes from somewhere other than `src/docs/` there may
be a further step outside this repo.

— hive: backend=claude model=claude-opus-5
