### PR TITLE
✨ feat(convergence): canonical outcome identity and desired-generation status (default-off)

### DIFF
--- a/src/pkg/convergence/convergence.go
+++ b/src/pkg/convergence/convergence.go
@@ -144,6 +144,14 @@ type Observation struct {
 	// on one. DegradedReason is a short machine-readable note for logs.
 	Degraded       bool
 	DegradedReason string
+	// Outcome, when non-nil, binds this candidate to a declared canonical
+	// outcome (#4251): its key, the current desired generation, and the
+	// generation the observer read. Nil — every observation today, and every
+	// observation while the convergence mode toggle is off — leaves Evaluate's
+	// behavior byte-identical to the pre-outcome contract. Populated only via
+	// pkg/convergence/outcome.Record.AdmissionStatus, which is itself
+	// toggle-gated.
+	Outcome *OutcomeStatus
 }
 
 // Condition is one tri-state judgment with its reason, in the Kubernetes
@@ -175,6 +183,11 @@ type Decision struct {
 	// judged.
 	ObservedRecord     string
 	ObservedGeneration string
+	// Outcome echoes the bound outcome status the decision was judged
+	// against, as detached immutable values, so a status projection can say
+	// exactly which OutcomeRef, desired generation, and observed generation
+	// were in play. Nil for the (default) unbound case.
+	Outcome *OutcomeStatus
 	// Conditions are the full tri-state judgments, in a stable order
 	// (Observed, then Ready).
 	Conditions []Condition
@@ -248,6 +261,15 @@ func Evaluate(obs Observation) Decision {
 		return d
 	}
 
+	// Rule 1a (additive, #4251): a candidate bound to a declared outcome is
+	// gated on generation comparison BEFORE any dependency judgment. Evidence
+	// observed at any generation other than the current desired generation can
+	// never authorize a transition; removing this check must fail the guard
+	// tests. Unbound candidates (Outcome nil) skip this entirely.
+	if blocked, ok := evaluateOutcomeGate(obs); ok {
+		return blocked
+	}
+
 	// Rule 2: no record for this candidate means no declared dependency.
 	if !obs.Found {
 		d.Admitted = true
@@ -258,7 +280,7 @@ func Evaluate(obs Observation) Decision {
 			{Type: ConditionReady, Status: ConditionTrue, Reason: ReasonNoDeclaredDependencies,
 				Message: "admitted: candidate declares no dependencies"},
 		}
-		return d
+		return finishOutcome(d, obs)
 	}
 
 	observed := Condition{Type: ConditionObserved, Status: ConditionTrue, Reason: ReasonIntentObserved,
@@ -311,7 +333,18 @@ func Evaluate(obs Observation) Decision {
 		}}
 	}
 
-	return d
+	return finishOutcome(d, obs)
+}
+
+// finishOutcome appends the generation-match condition to a decision whose
+// observation carried a bound outcome that PASSED the gate. It changes no
+// verdict: a matched generation establishes only that the current declaration
+// generation was observed.
+func finishOutcome(d Decision, obs Observation) Decision {
+	if obs.Outcome == nil {
+		return d
+	}
+	return appendOutcomeMatch(d, obs.Outcome)
 }
 
 // recordMessage renders the observed-record note, including the generation when

--- a/src/pkg/convergence/generation.go
+++ b/src/pkg/convergence/generation.go
@@ -1,0 +1,116 @@
+package convergence
+
+import "strconv"
+
+// This file is the generation-comparison seam added for kubestellar/hive#4251
+// (parent #3845), consuming the outcome authority accepted on #4249. It is
+// deliberately additive: an Observation whose Outcome field is nil — every
+// observation produced today, and every observation produced while the
+// convergence mode toggle is off — flows through Evaluate exactly as before,
+// byte-identical conditions and all. Only an observer that both holds a
+// declared outcome record AND has the toggle enabled ever populates Outcome
+// (see pkg/convergence/outcome.Record.AdmissionStatus, which returns nil when
+// the mode is off).
+
+// OutcomeStatus binds one candidate to one declared outcome for admission:
+// the canonical outcome key, WHICH generation of desired state is current,
+// and WHICH generation the observer authoritatively read. Values are copied
+// out of the ledger, never shared, so evaluation can never race a writer.
+type OutcomeStatus struct {
+	// Key is the canonical "project/repo@outcome" identity string.
+	Key string
+	// DesiredGeneration is the ledger's current desired generation.
+	DesiredGeneration int
+	// ObservedGeneration is the generation of the declaration the observer
+	// authoritatively read this pass; zero means it was never observed.
+	ObservedGeneration int
+}
+
+// Outcome condition vocabulary. Deliberately narrow: matching generations
+// establishes ONLY that the current declaration generation was observed. It
+// never establishes predicate truth, proof validity, repository Converged, or
+// quiescence — those are later increments (B2/B3), and emitting them here
+// would fabricate satisfaction before anything computes them.
+const (
+	// ConditionOutcomeGenerationObserved reports whether the observed
+	// generation equals the current desired generation of the bound outcome.
+	ConditionOutcomeGenerationObserved = "OutcomeGenerationObserved"
+
+	// ReasonOutcomeGenerationMatch: the declaration was authoritatively
+	// observed at exactly the current desired generation.
+	ReasonOutcomeGenerationMatch = "OutcomeGenerationMatch"
+	// ReasonOutcomeGenerationStale: the observed generation differs from the
+	// current desired generation (including "never observed"). Evidence for
+	// any other generation can never authorize a transition on this one.
+	ReasonOutcomeGenerationStale = "OutcomeGenerationStale"
+)
+
+// evaluateOutcomeGate applies the generation comparison for an
+// outcome-bound observation. It reports (decision, true) when the gate blocks
+// — observed generation differs from desired — and (zero, false) when the
+// gate passes and the ordinary admission rules should run.
+//
+// A mismatch yields Ready=Unknown, not False: nothing is established about
+// the candidate except that the evidence in hand belongs to some other
+// revision of desired state, so the caller should re-observe, not conclude.
+// The stale observed generation remains visible in the decision rather than
+// being erased, so an operator can see exactly which revision was judged.
+func evaluateOutcomeGate(obs Observation) (Decision, bool) {
+	oc := obs.Outcome
+	if oc == nil || oc.ObservedGeneration == oc.DesiredGeneration {
+		return Decision{}, false
+	}
+	msg := outcomeGenerationMessage(oc)
+	d := Decision{
+		ObservedRecord:     obs.RecordID,
+		ObservedGeneration: obs.Generation,
+		Reason:             ReasonOutcomeGenerationStale,
+		Blockers:           []string{oc.Key},
+		Outcome:            copyOutcomeStatus(oc),
+		Conditions: []Condition{
+			{Type: ConditionOutcomeGenerationObserved, Status: ConditionFalse,
+				Reason: ReasonOutcomeGenerationStale, Message: msg},
+			{Type: ConditionReady, Status: ConditionUnknown,
+				Reason:  ReasonOutcomeGenerationStale,
+				Message: "not admitted: " + msg},
+		},
+	}
+	return d, true
+}
+
+// appendOutcomeMatch records, on an already-computed decision, that the bound
+// outcome's declaration was observed at the current desired generation. It
+// adds exactly one condition and the echoed status; it never flips Admitted,
+// because a matched generation authorizes nothing by itself — the ordinary
+// admission rules already ran and their verdict stands.
+func appendOutcomeMatch(d Decision, oc *OutcomeStatus) Decision {
+	d.Outcome = copyOutcomeStatus(oc)
+	d.Conditions = append(d.Conditions, Condition{
+		Type:   ConditionOutcomeGenerationObserved,
+		Status: ConditionTrue,
+		Reason: ReasonOutcomeGenerationMatch,
+		Message: outcomeGenerationMessage(oc) +
+			"; generation match does not establish predicate truth or convergence",
+	})
+	return d
+}
+
+// copyOutcomeStatus detaches the echoed status so the decision holds
+// immutable values of its own.
+func copyOutcomeStatus(oc *OutcomeStatus) *OutcomeStatus {
+	cp := *oc
+	return &cp
+}
+
+func outcomeGenerationMessage(oc *OutcomeStatus) string {
+	if oc.ObservedGeneration == oc.DesiredGeneration {
+		return "outcome " + oc.Key + " observed at current desired generation " + itoa(oc.DesiredGeneration)
+	}
+	if oc.ObservedGeneration == 0 {
+		return "outcome " + oc.Key + " declaration never observed; desired generation is " + itoa(oc.DesiredGeneration)
+	}
+	return "outcome " + oc.Key + " observed at generation " + itoa(oc.ObservedGeneration) +
+		" but desired generation is " + itoa(oc.DesiredGeneration)
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }

--- a/src/pkg/convergence/generation_test.go
+++ b/src/pkg/convergence/generation_test.go
@@ -1,0 +1,183 @@
+package convergence
+
+import (
+	"reflect"
+	"testing"
+)
+
+// These tests are the #4251 guard rows for the generation-comparison seam.
+// Every blocking assertion here fails if the generation check in Evaluate is
+// removed or bypassed — that is the strict RED acceptance requirement.
+
+func boundObs(desired, observed int) Observation {
+	return Observation{
+		Subject: Subject{Repo: "kubestellar/hive", Number: 42},
+		Outcome: &OutcomeStatus{
+			Key:                "default/kubestellar/hive@nightly-green",
+			DesiredGeneration:  desired,
+			ObservedGeneration: observed,
+		},
+	}
+}
+
+// A transition requiring an outcome whose desired generation is G+1 while the
+// observation is from G is unknown/not admitted; evidence for G can never
+// authorize G+1.
+func TestEvaluate_OutcomeStaleGenerationNeverAdmits(t *testing.T) {
+	obs := boundObs(2, 1)
+	obs.Found = false // even the always-admitting lookup-miss path must not admit
+
+	d := Evaluate(obs)
+	if d.Admitted {
+		t.Fatalf("stale observed generation admitted a transition: %+v", d)
+	}
+	if d.Reason != ReasonOutcomeGenerationStale {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonOutcomeGenerationStale)
+	}
+	ready, ok := d.Condition(ConditionReady)
+	if !ok || ready.Status != ConditionUnknown {
+		t.Fatalf("Ready = %+v, want Unknown (nothing is established, caller should re-observe)", ready)
+	}
+	gen, ok := d.Condition(ConditionOutcomeGenerationObserved)
+	if !ok || gen.Status != ConditionFalse || gen.Reason != ReasonOutcomeGenerationStale {
+		t.Fatalf("OutcomeGenerationObserved = %+v, want False/%s", gen, ReasonOutcomeGenerationStale)
+	}
+	if len(d.Blockers) != 1 || d.Blockers[0] != obs.Outcome.Key {
+		t.Fatalf("blockers = %v, want the outcome key", d.Blockers)
+	}
+	// The stale observed generation stays visible; it is not erased or latched.
+	if d.Outcome == nil || d.Outcome.ObservedGeneration != 1 || d.Outcome.DesiredGeneration != 2 {
+		t.Fatalf("decision must echo the stale generations: %+v", d.Outcome)
+	}
+}
+
+// A never-observed declaration (observedGeneration zero) is stale, not
+// satisfied: absence of observation cannot authorize.
+func TestEvaluate_OutcomeNeverObservedNeverAdmits(t *testing.T) {
+	d := Evaluate(boundObs(1, 0))
+	if d.Admitted {
+		t.Fatalf("never-observed declaration admitted a transition: %+v", d)
+	}
+	if d.Reason != ReasonOutcomeGenerationStale {
+		t.Fatalf("reason = %q, want %q", d.Reason, ReasonOutcomeGenerationStale)
+	}
+}
+
+// A matched generation establishes ONLY that the declaration generation was
+// observed. The ordinary rules still decide admission, no Converged or
+// predicate condition appears, and an unsatisfied dependency still blocks.
+func TestEvaluate_OutcomeMatchIsNotSatisfaction(t *testing.T) {
+	obs := boundObs(3, 3)
+	obs.Found = true
+	obs.RecordID = "bead-1"
+	obs.Dependencies = []Dependency{{ID: "dep-a", Status: ConditionFalse}}
+
+	d := Evaluate(obs)
+	if d.Admitted {
+		t.Fatalf("generation match must not override an unsatisfied dependency: %+v", d)
+	}
+	if d.Reason != ReasonWaitingForDependency {
+		t.Fatalf("reason = %q, want the ordinary dependency verdict", d.Reason)
+	}
+	gen, ok := d.Condition(ConditionOutcomeGenerationObserved)
+	if !ok || gen.Status != ConditionTrue || gen.Reason != ReasonOutcomeGenerationMatch {
+		t.Fatalf("OutcomeGenerationObserved = %+v, want True/%s", gen, ReasonOutcomeGenerationMatch)
+	}
+	for _, c := range d.Conditions {
+		if c.Type == "Converged" || c.Type == "Progressing" {
+			t.Fatalf("uncomputed condition %q emitted from a generation match", c.Type)
+		}
+	}
+	if d.Outcome == nil || d.Outcome.ObservedGeneration != 3 {
+		t.Fatalf("decision must echo the matched status: %+v", d.Outcome)
+	}
+}
+
+// A matched generation on an otherwise-admissible candidate admits through
+// the ordinary rules and records the match condition additively.
+func TestEvaluate_OutcomeMatchPreservesOrdinaryAdmission(t *testing.T) {
+	obs := boundObs(1, 1)
+	d := Evaluate(obs)
+	if !d.Admitted || d.Reason != ReasonNoDeclaredDependencies {
+		t.Fatalf("matched outcome broke the ordinary lookup-miss admission: %+v", d)
+	}
+	if _, ok := d.Condition(ConditionOutcomeGenerationObserved); !ok {
+		t.Fatalf("match condition missing from admitted decision: %+v", d.Conditions)
+	}
+}
+
+// Positive control: a candidate with NO declared outcome flows through
+// Evaluate with byte-identical decisions — legacy admission is unchanged.
+func TestEvaluate_NoDeclaredOutcomeIsByteIdenticalLegacy(t *testing.T) {
+	cases := []Observation{
+		{Subject: Subject{Repo: "o/r", Number: 1}},
+		{Subject: Subject{Repo: "o/r", Number: 2}, Found: true, RecordID: "b",
+			Dependencies: []Dependency{{ID: "x", Status: ConditionFalse}}},
+		{Subject: Subject{Repo: "o/r", Number: 3}, Degraded: true, DegradedReason: "StoreDown"},
+		{Subject: Subject{Repo: "o/r", Number: 4}, Found: true, RecordID: "b2",
+			Dependencies: []Dependency{{ID: "y", Status: ConditionTrue}}},
+	}
+	for _, obs := range cases {
+		d := Evaluate(obs)
+		if d.Outcome != nil {
+			t.Fatalf("unbound candidate grew an outcome echo: %+v", d)
+		}
+		for _, c := range d.Conditions {
+			if c.Type == ConditionOutcomeGenerationObserved {
+				t.Fatalf("unbound candidate grew an outcome condition: %+v", c)
+			}
+		}
+	}
+	// Spot-check full structural equality for the plain admit path.
+	got := Evaluate(cases[0])
+	want := Decision{
+		Admitted: true,
+		Reason:   ReasonNoDeclaredDependencies,
+		Conditions: []Condition{
+			{Type: ConditionObserved, Status: ConditionFalse, Reason: ReasonNoIntentRecord,
+				Message: "no dependency-bearing record exists for o/r#1"},
+			{Type: ConditionReady, Status: ConditionTrue, Reason: ReasonNoDeclaredDependencies,
+				Message: "admitted: candidate declares no dependencies"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("legacy decision changed shape:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// A degraded read still authorizes nothing, even when the observer thinks the
+// generations match: rule 1 stays first, because a non-authoritative read
+// cannot vouch for the generation it claims to have seen.
+func TestEvaluate_DegradedWinsOverOutcomeMatch(t *testing.T) {
+	obs := boundObs(2, 2)
+	obs.Degraded = true
+	obs.DegradedReason = "AuthorityUnavailable:ledger"
+
+	d := Evaluate(obs)
+	if d.Admitted {
+		t.Fatalf("degraded observation admitted: %+v", d)
+	}
+	if d.Reason != "AuthorityUnavailable:ledger" {
+		t.Fatalf("reason = %q, want the degraded reason", d.Reason)
+	}
+	if _, ok := d.Condition(ConditionOutcomeGenerationObserved); ok {
+		t.Fatalf("degraded read must not vouch for a generation match: %+v", d.Conditions)
+	}
+}
+
+// Duplicate/out-of-order evidence cannot latch: Evaluate is pure, so the same
+// stale observation yields the same refusal every time, and a subsequent
+// current observation yields the match — order of calls is irrelevant.
+func TestEvaluate_OutcomeGenerationDoesNotLatch(t *testing.T) {
+	stale := boundObs(2, 1)
+	current := boundObs(2, 2)
+	first := Evaluate(stale)
+	Evaluate(current)
+	second := Evaluate(stale)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("stale decision changed after an interleaved current observation:\n%+v\n%+v", first, second)
+	}
+	if second.Admitted {
+		t.Fatalf("replayed stale evidence admitted")
+	}
+}

--- a/src/pkg/convergence/outcome/ledger.go
+++ b/src/pkg/convergence/outcome/ledger.go
@@ -1,0 +1,360 @@
+package outcome
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Sentinel errors. Callers match with errors.Is; the wrapped detail names the
+// offending key and generations for logs.
+var (
+	// ErrUnauthorizedActor: the actor is not in the configured maintainer
+	// principal set. Agents, contributors, observers, the admission sweep,
+	// bead lifecycle, events, and webhooks are NEVER in that set — this is the
+	// accepted #4249 mutator rule made structural.
+	ErrUnauthorizedActor = errors.New("actor is not an authorized outcome mutator")
+	// ErrGenerationConflict: the caller named a stale expected generation.
+	// The mutation is REFUSED, never merged — a stale writer is fenced, in
+	// the same shape as the hub rotate/retire refusal.
+	ErrGenerationConflict = errors.New("expected generation does not match current desired generation")
+	// ErrOutcomeExists: create named an already-declared outcome.
+	ErrOutcomeExists = errors.New("outcome is already declared")
+	// ErrOutcomeNotFound: the named outcome has never been declared.
+	ErrOutcomeNotFound = errors.New("outcome is not declared")
+	// ErrOutcomeRetired: the outcome is terminally retired; no verb applies.
+	ErrOutcomeRetired = errors.New("outcome is retired")
+	// ErrInvalidTransition: the verb does not apply in the current state
+	// (e.g. accepting an already-accepted generation).
+	ErrInvalidTransition = errors.New("transition not valid in current state")
+)
+
+// ledgerFileMode is 0660 (group-writable) for the same reason beads.Store.persist
+// uses it: the file lives under the shared /data root and more than one
+// node-group member may legitimately rewrite it.
+const ledgerFileMode = 0o660
+
+// ledgerFormatVersion is the persisted schema version, written so a future
+// widening is a deliberate, reviewable migration rather than an accident.
+const ledgerFormatVersion = 1
+
+// Receipt is the write-only audit record handed to the Mirror after a
+// mutation durably persists. The intended mirror posts a human-readable
+// comment to the governing GitHub issue; whatever it does, NOTHING in this
+// package ever reads a mirror back — GitHub content is exhaust, not authority.
+type Receipt struct {
+	Verb       string
+	Key        string
+	Generation int
+	State      State
+	Actor      string
+	Date       time.Time
+	Spec       string
+}
+
+// Options configures a Ledger at Open time.
+type Options struct {
+	// Principals is the exact set of actors authorized to mutate outcomes
+	// (per accepted #4249: maintainer/product principals only, initially
+	// "clubanderson", extensible via config). Empty means NO mutation is
+	// authorized — the safe default; the ledger stays readable.
+	Principals []string
+	// Mirror, when non-nil, receives a Receipt after each successful durable
+	// mutation. It is fire-and-forget: it returns nothing, its failures are
+	// its own to log, and it can never veto or roll back a mutation.
+	Mirror func(Receipt)
+	// Now supplies transition timestamps; nil means time.Now().UTC. A seam
+	// for tests, exactly like the hub store's clock convention.
+	Now func() time.Time
+}
+
+// Ledger is the durable outcome authority: an in-memory index over one JSON
+// file, reloaded on boot, rewritten atomically on every mutation. No process
+// memory is authoritative — restart reconstruction IS the file.
+type Ledger struct {
+	path       string
+	mu         sync.Mutex
+	records    map[string]*Record
+	principals map[string]bool
+	mirror     func(Receipt)
+	now        func() time.Time
+}
+
+// persistedLedger is the on-disk shape, named separately so the file format is
+// a deliberate artifact (the persistedGenerations convention).
+type persistedLedger struct {
+	Version int      `json:"version"`
+	Records []Record `json:"records"`
+}
+
+// Open loads the ledger at path, creating an empty one if the file does not
+// exist. A file that exists but cannot be parsed or validated is a REFUSAL:
+// Open fails, the bytes are left exactly as found for operator inspection,
+// and no handle exists through which a write could replace them — corrupt
+// durable state must be visible and can never invent unmanaged intent or a
+// fresh generation-1 truth (the accepted #4249 failure behavior, following
+// the hub generations quarantine rationale).
+func Open(path string, opts Options) (*Ledger, error) {
+	l := &Ledger{
+		path:       path,
+		records:    make(map[string]*Record),
+		principals: make(map[string]bool, len(opts.Principals)),
+		mirror:     opts.Mirror,
+		now:        opts.Now,
+	}
+	for _, p := range opts.Principals {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			l.principals[p] = true
+		}
+	}
+	if l.now == nil {
+		l.now = func() time.Time { return time.Now().UTC() }
+	}
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return l, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading outcome ledger %s: %w", path, err)
+	}
+	var persisted persistedLedger
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return nil, fmt.Errorf("outcome ledger %s is unparseable and is left untouched for inspection: %w", path, err)
+	}
+	for i := range persisted.Records {
+		rec := persisted.Records[i]
+		key := rec.Ref.Key()
+		if key == "" {
+			return nil, fmt.Errorf("outcome ledger %s holds a record with an invalid ref %+v", path, rec.Ref)
+		}
+		if _, dup := l.records[key]; dup {
+			return nil, fmt.Errorf("outcome ledger %s holds conflicting records for %s", path, key)
+		}
+		if rec.Generation < 1 {
+			return nil, fmt.Errorf("outcome ledger %s holds %s at impossible generation %d", path, key, rec.Generation)
+		}
+		stored := rec.clone()
+		l.records[key] = &stored
+	}
+	return l, nil
+}
+
+// Get returns a detached copy of the record for ref. The copy is the
+// projection seam: readers hold immutable values and can never race a writer.
+func (l *Ledger) Get(ref Ref) (Record, bool) {
+	return l.GetByKey(ref.Key())
+}
+
+// GetByKey is Get for callers holding a canonical key string.
+func (l *Ledger) GetByKey(key string) (Record, bool) {
+	if key == "" {
+		return Record{}, false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	rec, ok := l.records[key]
+	if !ok {
+		return Record{}, false
+	}
+	return rec.clone(), true
+}
+
+// List returns detached copies of every record, sorted by key for
+// deterministic projections and tests.
+func (l *Ledger) List() []Record {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]Record, 0, len(l.records))
+	for _, rec := range l.records {
+		out = append(out, rec.clone())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Ref.Key() < out[j].Ref.Key() })
+	return out
+}
+
+// Create declares a new outcome at generation 1, proposed.
+func (l *Ledger) Create(ref Ref, spec string, workRefs []string, actor string) (Record, error) {
+	if err := ref.Validate(); err != nil {
+		return Record{}, err
+	}
+	if err := validateWorkRefs(workRefs); err != nil {
+		return Record{}, err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.authorize(actor); err != nil {
+		return Record{}, err
+	}
+	key := ref.Key()
+	if _, exists := l.records[key]; exists {
+		return Record{}, fmt.Errorf("%s: %w", key, ErrOutcomeExists)
+	}
+	now := l.now()
+	rec := &Record{
+		Ref:        ref,
+		Generation: 1,
+		State:      StateProposed,
+		Spec:       spec,
+		WorkRefs:   append([]string(nil), workRefs...),
+		History: []Transition{{
+			Verb: "create", Generation: 1, Actor: actor, Date: now, Spec: spec,
+		}},
+	}
+	return l.commit(key, rec, "create")
+}
+
+// Accept records maintainer acceptance of EXACTLY the named generation.
+// Naming any other generation is a refused CAS conflict: acceptance can never
+// drift onto a revision the principal did not read.
+func (l *Ledger) Accept(ref Ref, expectedGeneration int, actor string) (Record, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	rec, err := l.mutable(ref, expectedGeneration, actor)
+	if err != nil {
+		return Record{}, err
+	}
+	if rec.State != StateProposed {
+		return Record{}, fmt.Errorf("accept %s at generation %d in state %s: %w",
+			ref.Key(), rec.Generation, rec.State, ErrInvalidTransition)
+	}
+	rec.State = StateAccepted
+	rec.History = append(rec.History, Transition{
+		Verb: "accept", Generation: rec.Generation, Actor: actor, Date: l.now(),
+	})
+	return l.commit(ref.Key(), rec, "accept")
+}
+
+// Supersede advances the desired generation to N+1 with a new proposed spec.
+// The prior generation is retained in History (its spec snapshot lives on the
+// create/supersede transition that introduced it) and remains visible as
+// stale; it can never again authorize a transition because comparison is
+// against the CURRENT generation only.
+func (l *Ledger) Supersede(ref Ref, expectedGeneration int, spec string, workRefs []string, actor string) (Record, error) {
+	if err := validateWorkRefs(workRefs); err != nil {
+		return Record{}, err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	rec, err := l.mutable(ref, expectedGeneration, actor)
+	if err != nil {
+		return Record{}, err
+	}
+	rec.Generation++
+	rec.State = StateProposed
+	rec.Spec = spec
+	if len(workRefs) > 0 {
+		rec.WorkRefs = append([]string(nil), workRefs...)
+	}
+	rec.History = append(rec.History, Transition{
+		Verb: "supersede", Generation: rec.Generation, Actor: actor, Date: l.now(), Spec: spec,
+	})
+	return l.commit(ref.Key(), rec, "supersede")
+}
+
+// Retire terminally closes the outcome. No verb applies afterwards.
+func (l *Ledger) Retire(ref Ref, expectedGeneration int, actor string) (Record, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	rec, err := l.mutable(ref, expectedGeneration, actor)
+	if err != nil {
+		return Record{}, err
+	}
+	rec.State = StateRetired
+	rec.History = append(rec.History, Transition{
+		Verb: "retire", Generation: rec.Generation, Actor: actor, Date: l.now(),
+	})
+	return l.commit(ref.Key(), rec, "retire")
+}
+
+// authorize enforces the accepted mutator rule. Callers hold l.mu.
+func (l *Ledger) authorize(actor string) error {
+	if !l.principals[strings.TrimSpace(actor)] {
+		return fmt.Errorf("%q: %w", actor, ErrUnauthorizedActor)
+	}
+	return nil
+}
+
+// mutable resolves the record for a mutation: authorized actor, declared
+// outcome, not retired, and a CAS match on the expected generation. It
+// returns a WORKING COPY; the stored record is replaced only by commit, so a
+// failed persist leaves memory and disk agreeing.
+func (l *Ledger) mutable(ref Ref, expectedGeneration int, actor string) (*Record, error) {
+	if err := l.authorize(actor); err != nil {
+		return nil, err
+	}
+	key := ref.Key()
+	if key == "" {
+		return nil, ref.Validate()
+	}
+	stored, ok := l.records[key]
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", key, ErrOutcomeNotFound)
+	}
+	if stored.State == StateRetired {
+		return nil, fmt.Errorf("%s: %w", key, ErrOutcomeRetired)
+	}
+	if stored.Generation != expectedGeneration {
+		return nil, fmt.Errorf("%s: expected generation %d, current is %d: %w",
+			key, expectedGeneration, stored.Generation, ErrGenerationConflict)
+	}
+	work := stored.clone()
+	return &work, nil
+}
+
+// commit persists the mutated record atomically, installs it in memory only
+// after the rename lands (persist-then-install, the hub retirement idiom),
+// and then emits the write-only mirror receipt. Callers hold l.mu.
+func (l *Ledger) commit(key string, rec *Record, verb string) (Record, error) {
+	prior, hadPrior := l.records[key]
+	l.records[key] = rec
+	if err := l.persistLocked(); err != nil {
+		if hadPrior {
+			l.records[key] = prior
+		} else {
+			delete(l.records, key)
+		}
+		return Record{}, err
+	}
+	out := rec.clone()
+	if l.mirror != nil {
+		last := rec.History[len(rec.History)-1]
+		l.mirror(Receipt{
+			Verb:       verb,
+			Key:        key,
+			Generation: rec.Generation,
+			State:      rec.State,
+			Actor:      last.Actor,
+			Date:       last.Date,
+			Spec:       rec.Spec,
+		})
+	}
+	return out, nil
+}
+
+// persistLocked writes the whole ledger: marshal → *.tmp → rename, exactly
+// the beads.Store.persist idiom. Callers hold l.mu, which is what keeps two
+// writers from interleaving bytes in the same tmp path.
+func (l *Ledger) persistLocked() error {
+	all := make([]Record, 0, len(l.records))
+	for _, rec := range l.records {
+		all = append(all, rec.clone())
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].Ref.Key() < all[j].Ref.Key() })
+
+	data, err := json.MarshalIndent(persistedLedger{Version: ledgerFormatVersion, Records: all}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling outcome ledger: %w", err)
+	}
+	tmpPath := l.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, ledgerFileMode); err != nil {
+		return fmt.Errorf("writing tmp outcome ledger: %w", err)
+	}
+	return os.Rename(tmpPath, l.path)
+}

--- a/src/pkg/convergence/outcome/ledger_test.go
+++ b/src/pkg/convergence/outcome/ledger_test.go
@@ -1,0 +1,545 @@
+package outcome
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+const maintainer = "clubanderson"
+
+func testLedger(t *testing.T, opts Options) (*Ledger, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "outcomes.json")
+	if opts.Principals == nil {
+		opts.Principals = []string{maintainer}
+	}
+	l, err := Open(path, opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return l, path
+}
+
+func ref(project, repo, name string) Ref {
+	return Ref{Project: project, Repo: repo, Outcome: name}
+}
+
+// ── Identity guard rows ─────────────────────────────────────────────────────
+
+// Two outcomes sharing one repository stay distinct.
+func TestRefKey_TwoOutcomesOneRepoDistinct(t *testing.T) {
+	a := ref("default", "kubestellar/hive", "nightly-green").Key()
+	b := ref("default", "kubestellar/hive", "docs-current").Key()
+	if a == b || a == "" || b == "" {
+		t.Fatalf("keys collided or empty: %q vs %q", a, b)
+	}
+	if a != "default/kubestellar/hive@nightly-green" {
+		t.Fatalf("canonical key form changed: %q", a)
+	}
+}
+
+// The same outcome-local name in two accepted scopes stays distinct.
+func TestRefKey_SameNameTwoScopesDistinct(t *testing.T) {
+	byRepo := ref("default", "kubestellar/hive", "nightly-green").Key()
+	otherRepo := ref("default", "kubestellar/console", "nightly-green").Key()
+	otherProject := ref("staging", "kubestellar/hive", "nightly-green").Key()
+	if byRepo == otherRepo || byRepo == otherProject {
+		t.Fatalf("scope did not disambiguate: %q %q %q", byRepo, otherRepo, otherProject)
+	}
+}
+
+// Outcome keys can never be mistaken for persisted work keys: "@" is not a
+// worksource separator, so ParseKey refuses every canonical outcome key, and
+// legacy GitHub work keys are untouched by construction.
+func TestRefKey_CollisionFreeAgainstWorkKeys(t *testing.T) {
+	key := ref("default", "kubestellar/hive", "nightly-green").Key()
+	if _, ok := worksource.ParseKey(key); ok {
+		t.Fatalf("worksource.ParseKey accepted an outcome key %q — namespace collision", key)
+	}
+	// And the reverse: a work key is not a valid outcome ref dimension set.
+	if got := (Ref{Project: "default", Repo: "kubestellar/hive#42", Outcome: "x"}).Key(); got != "" {
+		t.Fatalf("a '#'-bearing repo produced an outcome key %q", got)
+	}
+}
+
+func TestRefValidate_RefusesAmbiguousDimensions(t *testing.T) {
+	bad := []Ref{
+		{},
+		{Project: "default", Repo: "o/r"}, // missing outcome
+		{Project: "a/b", Repo: "o/r", Outcome: "x"},            // '/' in project
+		{Project: "default", Repo: "o/r", Outcome: "Bad Slug"}, // not a slug
+		{Project: "default", Repo: "o/r", Outcome: "x@y"},      // '@' in slug
+		{Project: "default", Repo: "o@r", Outcome: "x"},        // '@' in repo
+		{Project: "def ault", Repo: "o/r", Outcome: "x"},       // whitespace
+		{Project: "default", Repo: "o!r", Outcome: "x"},        // '!' in repo
+		{Project: "default", Repo: "o/r", Outcome: "-leading"}, // slug edge
+	}
+	for _, r := range bad {
+		if err := r.Validate(); err == nil {
+			t.Fatalf("Validate accepted %+v", r)
+		}
+		if r.Key() != "" {
+			t.Fatalf("invalid ref produced key %q", r.Key())
+		}
+	}
+}
+
+// ── Lifecycle and mutator guard rows ────────────────────────────────────────
+
+func TestLedger_CreateAcceptSupersedeLifecycle(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "kubestellar/hive", "nightly-green")
+
+	rec, err := l.Create(r, "nightly workflow green 7 days", []string{"kubestellar/hive#42"}, maintainer)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if rec.Generation != 1 || rec.State != StateProposed {
+		t.Fatalf("create produced %+v, want generation 1 proposed", rec)
+	}
+	if rec.WorkRefs[0] != "kubestellar/hive#42" {
+		t.Fatalf("legacy work key rewritten: %v", rec.WorkRefs)
+	}
+
+	rec, err = l.Accept(r, 1, maintainer)
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if rec.State != StateAccepted || rec.Generation != 1 {
+		t.Fatalf("accept produced %+v", rec)
+	}
+	last := rec.History[len(rec.History)-1]
+	if last.Verb != "accept" || last.Actor != maintainer || last.Date.IsZero() {
+		t.Fatalf("acceptance receipt missing actor/date: %+v", last)
+	}
+
+	rec, err = l.Supersede(r, 1, "green 14 days", nil, maintainer)
+	if err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+	if rec.Generation != 2 || rec.State != StateProposed {
+		t.Fatalf("supersede produced %+v, want generation 2 proposed", rec)
+	}
+	// The prior generation stays visible in history with its spec snapshot.
+	var sawGen1 bool
+	for _, tr := range rec.History {
+		if tr.Generation == 1 && tr.Spec == "nightly workflow green 7 days" {
+			sawGen1 = true
+		}
+	}
+	if !sawGen1 {
+		t.Fatalf("superseded generation 1 lost from history: %+v", rec.History)
+	}
+
+	if _, err := l.Retire(r, 2, maintainer); err != nil {
+		t.Fatalf("Retire: %v", err)
+	}
+	if _, err := l.Supersede(r, 2, "x", nil, maintainer); !errors.Is(err, ErrOutcomeRetired) {
+		t.Fatalf("mutating a retired outcome: err = %v, want ErrOutcomeRetired", err)
+	}
+}
+
+// Only the accepted mutator principals may advance desired state. An agent,
+// observer, or lifecycle actor is refused before any state is read.
+func TestLedger_UnauthorizedActorRefused(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "o/r", "x")
+	if _, err := l.Create(r, "s", nil, "some-agent"); !errors.Is(err, ErrUnauthorizedActor) {
+		t.Fatalf("create by agent: %v", err)
+	}
+	if _, err := l.Create(r, "s", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for _, err := range []error{
+		func() error { _, e := l.Accept(r, 1, "bead-lifecycle"); return e }(),
+		func() error { _, e := l.Supersede(r, 1, "s2", nil, "webhook"); return e }(),
+		func() error { _, e := l.Retire(r, 1, "admission-sweep"); return e }(),
+	} {
+		if !errors.Is(err, ErrUnauthorizedActor) {
+			t.Fatalf("unauthorized mutation allowed: %v", err)
+		}
+	}
+	// No principals configured means no mutation at all — safe default.
+	empty, _ := testLedger(t, Options{Principals: []string{}})
+	empty.principals = map[string]bool{}
+	if _, err := empty.Create(r, "s", nil, maintainer); !errors.Is(err, ErrUnauthorizedActor) {
+		t.Fatalf("empty principal set allowed a mutation: %v", err)
+	}
+}
+
+// Two acceptance writers race: CAS on the expected generation serializes
+// them; the stale writer is refused/fenced, never merged.
+func TestLedger_CASConflictRejected(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "o/r", "x")
+	if _, err := l.Create(r, "g1", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := l.Supersede(r, 1, "g2", nil, maintainer); err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+	// A writer still holding generation 1 is fenced on every verb.
+	if _, err := l.Accept(r, 1, maintainer); !errors.Is(err, ErrGenerationConflict) {
+		t.Fatalf("stale accept: %v", err)
+	}
+	if _, err := l.Supersede(r, 1, "g3", nil, maintainer); !errors.Is(err, ErrGenerationConflict) {
+		t.Fatalf("stale supersede: %v", err)
+	}
+	if _, err := l.Retire(r, 1, maintainer); !errors.Is(err, ErrGenerationConflict) {
+		t.Fatalf("stale retire: %v", err)
+	}
+	rec, _ := l.Get(r)
+	if rec.Generation != 2 || rec.State != StateProposed {
+		t.Fatalf("fenced writers mutated state: %+v", rec)
+	}
+}
+
+// Concurrent racers: exactly one of N supersedes naming the same expected
+// generation wins; run under -race this also proves the lock discipline.
+func TestLedger_ConcurrentCASExactlyOneWinner(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "o/r", "x")
+	if _, err := l.Create(r, "g1", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	const racers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, racers)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = l.Supersede(r, 1, "g2", nil, maintainer)
+		}(i)
+	}
+	wg.Wait()
+	wins := 0
+	for _, err := range errs {
+		if err == nil {
+			wins++
+		} else if !errors.Is(err, ErrGenerationConflict) {
+			t.Fatalf("unexpected racer error: %v", err)
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("wins = %d, want exactly 1", wins)
+	}
+	rec, _ := l.Get(r)
+	if rec.Generation != 2 {
+		t.Fatalf("generation = %d after race, want 2 (monotonic, no double advance)", rec.Generation)
+	}
+}
+
+// ── Durability guard rows ───────────────────────────────────────────────────
+
+// Hive restarts: the same desired generation reconstructs from the file; no
+// process-only counter is truth.
+func TestLedger_RestartReconstructsDesiredGeneration(t *testing.T) {
+	l, path := testLedger(t, Options{})
+	r := ref("default", "kubestellar/hive", "nightly-green")
+	if _, err := l.Create(r, "g1", []string{"kubestellar/hive#42"}, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := l.Accept(r, 1, maintainer); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if _, err := l.Supersede(r, 1, "g2", nil, maintainer); err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+
+	reloaded, err := Open(path, Options{Principals: []string{maintainer}})
+	if err != nil {
+		t.Fatalf("reload Open: %v", err)
+	}
+	rec, ok := reloaded.Get(r)
+	if !ok {
+		t.Fatalf("record lost across restart")
+	}
+	if rec.Generation != 2 || rec.State != StateProposed || rec.Spec != "g2" {
+		t.Fatalf("restart reconstructed %+v, want generation 2 proposed g2", rec)
+	}
+	if len(rec.History) != 3 {
+		t.Fatalf("history lost across restart: %+v", rec.History)
+	}
+	if rec.WorkRefs[0] != "kubestellar/hive#42" {
+		t.Fatalf("work refs lost across restart: %v", rec.WorkRefs)
+	}
+	// And CAS discipline survives: the pre-restart generation still fences.
+	if _, err := reloaded.Accept(r, 1, maintainer); !errors.Is(err, ErrGenerationConflict) {
+		t.Fatalf("restart forgot the current generation: %v", err)
+	}
+}
+
+// A missing file is a fresh ledger; a CORRUPT file is a visible refusal that
+// leaves the bytes untouched and can never invent state.
+func TestLedger_CorruptFileRefusedAndPreserved(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "outcomes.json")
+	corrupt := []byte("{ not json")
+	if err := os.WriteFile(path, corrupt, 0o660); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := Open(path, Options{Principals: []string{maintainer}}); err == nil {
+		t.Fatalf("Open accepted a corrupt ledger")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != string(corrupt) {
+		t.Fatalf("corrupt bytes were not preserved: %q %v", got, err)
+	}
+
+	// Conflicting records (duplicate keys) are equally refused.
+	dup := `{"version":1,"records":[
+	  {"ref":{"project":"default","repo":"o/r","outcome":"x"},"generation":1,"state":"proposed","spec":"a","history":[]},
+	  {"ref":{"project":"default","repo":"o/r","outcome":"x"},"generation":2,"state":"accepted","spec":"b","history":[]}]}`
+	dupPath := filepath.Join(dir, "dup.json")
+	if err := os.WriteFile(dupPath, []byte(dup), 0o660); err != nil {
+		t.Fatalf("seed dup: %v", err)
+	}
+	if _, err := Open(dupPath, Options{}); err == nil || !strings.Contains(err.Error(), "conflicting") {
+		t.Fatalf("conflicting records not refused: %v", err)
+	}
+
+	// An impossible generation is refused rather than trusted.
+	zero := `{"version":1,"records":[{"ref":{"project":"default","repo":"o/r","outcome":"x"},"generation":0,"state":"proposed","spec":"a","history":[]}]}`
+	zeroPath := filepath.Join(dir, "zero.json")
+	if err := os.WriteFile(zeroPath, []byte(zero), 0o660); err != nil {
+		t.Fatalf("seed zero: %v", err)
+	}
+	if _, err := Open(zeroPath, Options{}); err == nil {
+		t.Fatalf("generation 0 record not refused")
+	}
+}
+
+// The persisted write is atomic: after any mutation no *.tmp remains, and the
+// file parses as the deliberate versioned format.
+func TestLedger_AtomicPersistShape(t *testing.T) {
+	l, path := testLedger(t, Options{})
+	if _, err := l.Create(ref("default", "o/r", "x"), "s", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("tmp file left behind: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), `"version": 1`) {
+		t.Fatalf("persisted format missing version: %s", data)
+	}
+}
+
+// ── Mutator-isolation guard rows ────────────────────────────────────────────
+
+// An event, observation, or bead closing/retiring cannot change desired
+// generation: the ledger exposes no verb for them, readers get detached
+// copies, and mutating a returned copy or listed slice touches nothing.
+func TestLedger_ReadersHoldDetachedCopies(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "o/r", "x")
+	if _, err := l.Create(r, "s", []string{"o/r#1"}, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, _ := l.Get(r)
+	got.Generation = 99
+	got.State = StateRetired
+	got.WorkRefs[0] = "o/r#999"
+	got.History[0].Actor = "attacker"
+
+	fresh, _ := l.Get(r)
+	if fresh.Generation != 1 || fresh.State != StateProposed ||
+		fresh.WorkRefs[0] != "o/r#1" || fresh.History[0].Actor != maintainer {
+		t.Fatalf("reader mutation leaked into the ledger: %+v", fresh)
+	}
+	list := l.List()
+	if len(list) != 1 || list[0].Generation != 1 {
+		t.Fatalf("List = %+v", list)
+	}
+}
+
+// Invalid work refs (including the fabricated "#0" identity) are refused.
+func TestLedger_InvalidWorkRefsRefused(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	for _, bad := range []string{"", "o/r#0", "not-a-key", "#5"} {
+		if _, err := l.Create(ref("default", "o/r", "x"), "s", []string{bad}, maintainer); err == nil {
+			t.Fatalf("work ref %q accepted", bad)
+		}
+	}
+}
+
+// The GitHub mirror is write-only exhaust: every durable mutation emits one
+// receipt AFTER persistence, nothing is ever read back, and no mirror is
+// consulted on Open/Get.
+func TestLedger_MirrorIsWriteOnlyExhaust(t *testing.T) {
+	var receipts []Receipt
+	fixed := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	l, path := testLedger(t, Options{
+		Mirror: func(rcpt Receipt) { receipts = append(receipts, rcpt) },
+		Now:    func() time.Time { return fixed },
+	})
+	r := ref("default", "kubestellar/hive", "nightly-green")
+	if _, err := l.Create(r, "g1", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := l.Accept(r, 1, maintainer); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if _, err := l.Accept(r, 5, maintainer); err == nil {
+		t.Fatalf("stale accept succeeded")
+	}
+	if len(receipts) != 2 {
+		t.Fatalf("receipts = %d, want 2 (refused mutations emit nothing)", len(receipts))
+	}
+	if receipts[1].Verb != "accept" || receipts[1].Generation != 1 ||
+		receipts[1].Actor != maintainer || !receipts[1].Date.Equal(fixed) ||
+		receipts[1].Key != r.Key() {
+		t.Fatalf("receipt = %+v", receipts[1])
+	}
+	// Reload without any mirror: state is identical, proving nothing was ever
+	// read back from the mirror side.
+	reloaded, err := Open(path, Options{Principals: []string{maintainer}})
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	rec, _ := reloaded.Get(r)
+	if rec.State != StateAccepted || rec.Generation != 1 {
+		t.Fatalf("mirror-free reload diverged: %+v", rec)
+	}
+}
+
+func TestLedger_VerbsOnUndeclaredOutcome(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "o/r", "ghost")
+	if _, err := l.Accept(r, 1, maintainer); !errors.Is(err, ErrOutcomeNotFound) {
+		t.Fatalf("accept ghost: %v", err)
+	}
+	if _, ok := l.Get(r); ok {
+		t.Fatalf("ghost outcome materialised")
+	}
+	if _, ok := l.GetByKey(""); ok {
+		t.Fatalf("empty key resolved")
+	}
+	if _, err := l.Create(r, "s", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := l.Create(r, "s", nil, maintainer); !errors.Is(err, ErrOutcomeExists) {
+		t.Fatalf("duplicate create: %v", err)
+	}
+	if _, err := l.Accept(r, 1, maintainer); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if _, err := l.Accept(r, 1, maintainer); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("double accept: %v", err)
+	}
+}
+
+// A failed persist must leave memory and disk agreeing: the in-memory install
+// is rolled back, so a later reader cannot see a generation the file never
+// held (no process-only counter becomes truth even transiently).
+func TestLedger_PersistFailureRollsBackMemory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "outcomes.json")
+	l, err := Open(path, Options{Principals: []string{maintainer}})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	r := ref("default", "o/r", "x")
+	if _, err := l.Create(r, "g1", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Make the directory unwritable so the tmp write fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if _, err := l.Supersede(r, 1, "g2", nil, maintainer); err == nil {
+		t.Fatalf("supersede persisted into an unwritable directory")
+	}
+	rec, _ := l.Get(r)
+	if rec.Generation != 1 || rec.Spec != "g1" {
+		t.Fatalf("failed persist leaked into memory: %+v", rec)
+	}
+
+	// And a failed CREATE must not leave a phantom record behind.
+	if _, err := l.Create(ref("default", "o/r", "y"), "s", nil, maintainer); err == nil {
+		t.Fatalf("create persisted into an unwritable directory")
+	}
+	if _, ok := l.Get(ref("default", "o/r", "y")); ok {
+		t.Fatalf("failed create left a phantom record")
+	}
+
+	// Recovery: once writable again, the fenced state advances normally.
+	_ = os.Chmod(dir, 0o700)
+	if _, err := l.Supersede(r, 1, "g2", nil, maintainer); err != nil {
+		t.Fatalf("recovered supersede: %v", err)
+	}
+}
+
+func TestLedger_SupersedeValidatesAndReplacesWorkRefs(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "o/r", "x")
+	if _, err := l.Create(r, "g1", []string{"o/r#1"}, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := l.Supersede(r, 1, "g2", []string{"o/r#0"}, maintainer); err == nil {
+		t.Fatalf("supersede accepted a fabricated work ref")
+	}
+	rec, err := l.Supersede(r, 1, "g2", []string{"o/r#2", "o/r!ENG-9"}, maintainer)
+	if err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+	if len(rec.WorkRefs) != 2 || rec.WorkRefs[0] != "o/r#2" {
+		t.Fatalf("work refs = %v", rec.WorkRefs)
+	}
+	// Superseding with no refs keeps the existing links.
+	rec, err = l.Supersede(r, 2, "g3", nil, maintainer)
+	if err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+	if len(rec.WorkRefs) != 2 {
+		t.Fatalf("empty supersede dropped work refs: %v", rec.WorkRefs)
+	}
+}
+
+func TestLedger_MutationWithInvalidRefRefused(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	if _, err := l.Accept(Ref{}, 1, maintainer); err == nil {
+		t.Fatalf("accept on an invalid ref succeeded")
+	}
+}
+
+func TestLedger_ListIsSortedByKey(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	if _, err := l.Create(ref("default", "o/r", "zeta"), "s", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := l.Create(ref("default", "o/r", "alpha"), "s", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	list := l.List()
+	if len(list) != 2 || list[0].Ref.Outcome != "alpha" || list[1].Ref.Outcome != "zeta" {
+		t.Fatalf("List order = %+v", list)
+	}
+}
+
+// A record persisted with an invalid ref is refused at Open — the file cannot
+// smuggle an unidentifiable outcome past declaration-time validation.
+func TestLedger_OpenRefusesInvalidPersistedRef(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	bad := `{"version":1,"records":[{"ref":{"project":"","repo":"o/r","outcome":"x"},"generation":1,"state":"proposed","spec":"a","history":[]}]}`
+	if err := os.WriteFile(path, []byte(bad), 0o660); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := Open(path, Options{}); err == nil {
+		t.Fatalf("invalid persisted ref accepted")
+	}
+}

--- a/src/pkg/convergence/outcome/observe.go
+++ b/src/pkg/convergence/outcome/observe.go
@@ -1,0 +1,54 @@
+package outcome
+
+import (
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/convergence"
+)
+
+// Convergence mode values, mirroring the convergence.mode /
+// HIVE_CONVERGENCE_MODE toggle surface introduced for #4246. The resolution
+// rule is the same default-off one: anything that is not a recognised
+// enabling mode — a typo, an empty string, a future value — is OFF. When the
+// config-owned toggle lands, callers should pass config.ConvergenceMode()'s
+// resolved value straight through here.
+const (
+	// ModeOff disables every toggle-gated convergence surface. With the mode
+	// off this package hands the Evaluate seam nothing at all, so admission
+	// behavior is byte-identical to today.
+	ModeOff = "off"
+	// ModeShadow computes and surfaces outcome generation status.
+	ModeShadow = "shadow"
+)
+
+// ModeEnabled reports whether the resolved convergence mode enables the
+// outcome surfaces. Default-off: only an exact recognised enabling mode
+// answers true.
+func ModeEnabled(mode string) bool {
+	return strings.EqualFold(strings.TrimSpace(mode), ModeShadow)
+}
+
+// AdmissionStatus projects this record into the convergence Evaluate seam,
+// gated by the convergence mode toggle.
+//
+// It returns nil unless the mode is enabled — and a nil OutcomeStatus makes
+// convergence.Evaluate behave byte-identically to today, which is the
+// default-off guarantee: the ledger is inert unless an operator turns the
+// toggle on, and a candidate with no declared outcome (no record, therefore
+// no status to attach) retains existing admission behavior unconditionally.
+//
+// observedGeneration is whatever generation the caller's observer
+// authoritatively read for this outcome's declaration; zero means "never
+// observed". The record contributes only immutable copied values — the
+// canonical key and the current desired generation — so readers can never
+// race the ledger's writers.
+func (rec Record) AdmissionStatus(mode string, observedGeneration int) *convergence.OutcomeStatus {
+	if !ModeEnabled(mode) {
+		return nil
+	}
+	return &convergence.OutcomeStatus{
+		Key:                rec.Ref.Key(),
+		DesiredGeneration:  rec.Generation,
+		ObservedGeneration: observedGeneration,
+	}
+}

--- a/src/pkg/convergence/outcome/observe_test.go
+++ b/src/pkg/convergence/outcome/observe_test.go
@@ -1,0 +1,82 @@
+package outcome
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/convergence"
+)
+
+// The default-off guarantee, made structural: with the convergence mode off —
+// or anything unrecognised — a record projects NOTHING into the Evaluate
+// seam, so admission cannot even see that an outcome exists.
+func TestAdmissionStatus_DefaultOffProjectsNothing(t *testing.T) {
+	rec := Record{Ref: Ref{Project: "default", Repo: "o/r", Outcome: "x"}, Generation: 3}
+	for _, mode := range []string{"", ModeOff, "OFF", "typo", "on", "enforce", "shadoww"} {
+		if got := rec.AdmissionStatus(mode, 3); got != nil {
+			t.Fatalf("mode %q projected %+v, want nil (default-off)", mode, got)
+		}
+		if ModeEnabled(mode) {
+			t.Fatalf("ModeEnabled(%q) = true", mode)
+		}
+	}
+}
+
+func TestAdmissionStatus_ShadowProjectsCopiedValues(t *testing.T) {
+	rec := Record{Ref: Ref{Project: "default", Repo: "kubestellar/hive", Outcome: "nightly-green"}, Generation: 2}
+	for _, mode := range []string{ModeShadow, " Shadow "} {
+		st := rec.AdmissionStatus(mode, 1)
+		if st == nil {
+			t.Fatalf("mode %q projected nothing", mode)
+		}
+		if st.Key != "default/kubestellar/hive@nightly-green" ||
+			st.DesiredGeneration != 2 || st.ObservedGeneration != 1 {
+			t.Fatalf("projection = %+v", st)
+		}
+	}
+}
+
+// End-to-end through the seam: a ledger record at desired generation 2 with
+// evidence from generation 1 never admits; the same evidence at generation 2
+// falls through to ordinary admission. With the toggle off the exact same
+// candidate is byte-identically legacy.
+func TestAdmissionStatus_EndToEndThroughEvaluate(t *testing.T) {
+	l, _ := testLedger(t, Options{})
+	r := ref("default", "kubestellar/hive", "nightly-green")
+	if _, err := l.Create(r, "g1", nil, maintainer); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := l.Accept(r, 1, maintainer); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if _, err := l.Supersede(r, 1, "g2", nil, maintainer); err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+	rec, _ := l.Get(r)
+
+	subject := convergence.Subject{Repo: "kubestellar/hive", Number: 42}
+
+	stale := convergence.Evaluate(convergence.Observation{
+		Subject: subject, Outcome: rec.AdmissionStatus(ModeShadow, 1),
+	})
+	if stale.Admitted || stale.Reason != convergence.ReasonOutcomeGenerationStale {
+		t.Fatalf("generation-1 evidence against desired 2: %+v", stale)
+	}
+
+	current := convergence.Evaluate(convergence.Observation{
+		Subject: subject, Outcome: rec.AdmissionStatus(ModeShadow, rec.Generation),
+	})
+	if !current.Admitted {
+		t.Fatalf("matched generation blocked ordinary admission: %+v", current)
+	}
+	cond, ok := current.Condition(convergence.ConditionOutcomeGenerationObserved)
+	if !ok || cond.Status != convergence.ConditionTrue {
+		t.Fatalf("match condition = %+v", cond)
+	}
+
+	off := convergence.Evaluate(convergence.Observation{
+		Subject: subject, Outcome: rec.AdmissionStatus(ModeOff, 1),
+	})
+	if !off.Admitted || off.Outcome != nil {
+		t.Fatalf("toggle off is not byte-identical legacy: %+v", off)
+	}
+}

--- a/src/pkg/convergence/outcome/outcome.go
+++ b/src/pkg/convergence/outcome/outcome.go
@@ -1,0 +1,166 @@
+// Package outcome implements the canonical outcome identity and
+// desired-generation authority accepted on kubestellar/hive#4249 and consumed
+// per the ownership contract accepted on #4250 (parent epic #3845, issue
+// #4251).
+//
+// It owns exactly one durable truth: for each declared, bounded GitHub
+// outcome, WHICH revision of its desired state is current. It is a small typed
+// ledger — one JSON file under the durable data root — modeled on the two
+// persistence idioms already proven in-tree: the atomic tmp+rename write of
+// beads.Store.persist and the explicit acceptance/retirement generation
+// lifecycle of the hub key-generation set (hub_generations_store.go).
+//
+// GitHub is a write-only audit mirror: every create/accept/supersede/retire
+// may post a human-readable receipt through the Mirror hook, but nothing in
+// this package ever parses GitHub content back as authority. One authority,
+// one mirror, no reconciliation loop.
+//
+// The package is inert by default. Nothing reads the ledger unless the
+// convergence mode toggle (convergence.mode / HIVE_CONVERGENCE_MODE, #4246)
+// resolves to a non-off mode; see ModeEnabled and Record.AdmissionStatus.
+package outcome
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// keySeparator joins the (project, repo) scope to the outcome-local slug. It
+// is "@" because that character cannot appear in either persisted work-key
+// form — GitHub's "repo#number" or the string-keyed "repo!externalID"
+// (worksource/key.go reserves "#" and "!") — so an outcome key can never be
+// mistaken for, or collide with, any existing work key. This is the same
+// argument externalKeySeparator already documents for "!".
+const keySeparator = "@"
+
+// scopeSeparator joins Project to Repo inside a key.
+const scopeSeparator = "/"
+
+// slugPattern is what an outcome-local name must look like: a stable
+// lowercase slug, unique within (Project, Repo). Enforced at declaration time
+// so a key is never ambiguous and never needs escaping.
+var slugPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
+
+// Ref is the minimal canonical identity of one declared outcome — exactly the
+// dimensions the accepted #4249 contract names, and no more (issue non-goal:
+// no broad ontology). Adding a dimension later widens the key without
+// migrating the GitHub-only positive control.
+type Ref struct {
+	// Project is the hive-instance scope; the positive control uses one fixed
+	// value ("default").
+	Project string `json:"project"`
+	// Repo is the canonical owner/name spelling — the SAME spelling
+	// worksource.Ref.Repo uses, so outcome scope and work identity never
+	// disagree about what a repository is called.
+	Repo string `json:"repo"`
+	// Outcome is a stable slug, unique within (Project, Repo).
+	Outcome string `json:"outcome"`
+}
+
+// Key returns the canonical "project/repo@outcome" identity string, or "" for
+// a Ref that fails Validate — mirroring worksource.Ref.Key's contract that ""
+// means "not identifiable, never a key".
+func (r Ref) Key() string {
+	if err := r.Validate(); err != nil {
+		return ""
+	}
+	return r.Project + scopeSeparator + r.Repo + keySeparator + r.Outcome
+}
+
+// Validate reports why a Ref cannot serve as a canonical identity. Every
+// dimension is required, and no dimension may contain a character that would
+// make the key ambiguous against itself or against a persisted work key.
+func (r Ref) Validate() error {
+	if r.Project == "" || r.Repo == "" || r.Outcome == "" {
+		return fmt.Errorf("outcome ref requires project, repo, and outcome: %+v", r)
+	}
+	if strings.ContainsAny(r.Project, "@#!/ \t") {
+		return fmt.Errorf("outcome project %q may not contain '@', '#', '!', '/', or whitespace", r.Project)
+	}
+	if strings.ContainsAny(r.Repo, "@#! \t") {
+		return fmt.Errorf("outcome repo %q may not contain '@', '#', '!', or whitespace", r.Repo)
+	}
+	if !slugPattern.MatchString(r.Outcome) {
+		return fmt.Errorf("outcome name %q is not a stable slug (%s)", r.Outcome, slugPattern.String())
+	}
+	return nil
+}
+
+// State is the lifecycle state of the CURRENT desired generation. Prior
+// generations survive only in History; a record's State never resurrects them.
+type State string
+
+const (
+	// StateProposed: the generation exists but has not been accepted by an
+	// authorized principal. A proposed generation is still the desired
+	// generation for comparison purposes — an observation of any OTHER
+	// generation can never authorize a transition.
+	StateProposed State = "proposed"
+	// StateAccepted: an authorized principal recorded acceptance of exactly
+	// this generation (actor and date are in History).
+	StateAccepted State = "accepted"
+	// StateRetired is terminal. No further mutation is possible.
+	StateRetired State = "retired"
+)
+
+// Transition is one appended history entry. History only grows; superseded
+// generations are retained here exactly as the hub generation set retains
+// retired key generations, so acceptance can never be silently rewritten by
+// culling.
+type Transition struct {
+	// Verb is create, accept, supersede, or retire.
+	Verb string `json:"verb"`
+	// Generation is the desired generation AFTER this transition.
+	Generation int `json:"generation"`
+	// Actor is the authorized principal who performed the transition.
+	Actor string `json:"actor"`
+	// Date is the transition time, RFC3339 in the persisted file.
+	Date time.Time `json:"date"`
+	// Spec snapshots the desired-state text carried by create/supersede, so a
+	// superseded generation's content remains inspectable forever.
+	Spec string `json:"spec,omitempty"`
+}
+
+// Record is the durable declaration of one outcome: its canonical identity,
+// its monotonic desired generation, and the full transition history.
+type Record struct {
+	Ref Ref `json:"ref"`
+	// Generation is the current desired generation. Monotonic: create sets 1,
+	// supersede sets N+1, nothing ever decreases it. This is the number an
+	// observed generation must equal for a gated transition to proceed.
+	Generation int   `json:"generation"`
+	State      State `json:"state"`
+	// Spec is the accepted desired-state text or pointer. It may reference a
+	// GitHub issue by its worksource key — as provenance, never as authority.
+	Spec string `json:"spec"`
+	// WorkRefs are worksource.Ref.Key() strings linking existing work items to
+	// this outcome. They compose with the merged #4245/#4292 identity: legacy
+	// GitHub "repo#number" keys are carried byte-identically, never rewritten.
+	WorkRefs []string     `json:"work_refs,omitempty"`
+	History  []Transition `json:"history"`
+}
+
+// clone returns a detached deep copy so readers can never race or mutate the
+// ledger's own record (projection uses copied immutable values).
+func (rec Record) clone() Record {
+	out := rec
+	out.WorkRefs = append([]string(nil), rec.WorkRefs...)
+	out.History = append([]Transition(nil), rec.History...)
+	return out
+}
+
+// validateWorkRefs refuses any work reference that is not a well-formed
+// worksource key. A fabricated key here would be exactly the "#0" collapse
+// worksource.Ref exists to prevent.
+func validateWorkRefs(workRefs []string) error {
+	for _, w := range workRefs {
+		if _, ok := worksource.ParseKey(w); !ok {
+			return fmt.Errorf("work ref %q is not a canonical worksource key", w)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #4251
Part of #3845

Implements the smallest end-to-end vertical for canonical outcome identity and desired-generation status, exactly per the **accepted #4249** authority decision (ratified 2026-08-20) and the **accepted #4250** ownership contract (ratified 2026-08-20), on top of the merged #4245 (PR #4292) worksource identity.

## What lands

**`pkg/convergence/outcome` — the durable outcome authority**
- `OutcomeRef{Project, Repo, Outcome}`, canonical key `project/repo@outcome`. `@` is collision-free against every persisted work key (worksource reserves `#` and `!`); validation refuses any dimension that would make a key ambiguous.
- Typed durable ledger: one versioned JSON file, atomic marshal → `*.tmp` → rename (the `beads.Store.persist` idiom), reload on boot, persist-then-install with in-memory rollback on a failed write. A corrupt/conflicting file is a **visible refusal** — Open fails, bytes are left untouched for inspection, no state can be invented.
- Monotonic desired generation: `create`→1 proposed, `accept` records actor+date, `supersede`→N+1 with prior generations retained in history, `retire` terminal. Every mutation is **CAS on the expected generation** — a stale writer is fenced, never merged.
- Mutators are maintainer principals only (default: nobody). Agents, observers, the admission sweep, bead lifecycle, events, and webhooks structurally cannot mutate desired state.
- GitHub is a **write-only audit mirror**: an optional `Mirror` hook receives a receipt after each durable mutation; nothing is ever parsed back as authority.
- `WorkRefs` carry `worksource.Ref.Key()` strings byte-identically (composes with #4292; fabricated `#0` identities refused).

## `pkg/convergence` — additive generation-comparison seam in `Evaluate`
- New optional `Observation.Outcome *OutcomeStatus` (key, desired generation, observed generation — detached copies, race-free).
- Invariant enforced: an observation from **any generation other than the current desired generation can never authorize a transition** (`Ready=Unknown`, reason `OutcomeGenerationStale`, stale generation stays visible, never latched — Evaluate stays pure).
- A **matched** generation establishes only that the declaration generation was observed: one additive condition, ordinary admission rules still decide, no `Converged`/predicate/quiescence is ever emitted (non-goals preserved for B2/B3).

## Default-off guarantee

- `outcome.Record.AdmissionStatus(mode, observedGen)` returns **nil unless the resolved convergence mode is an enabling mode** (`shadow`); anything else — empty, typo, future value — is off.
- A nil `Observation.Outcome` (every observation today, and every observation while the toggle is off) leaves `Evaluate` **byte-identical** to current behavior, proven by a structural-equality positive-control test.
- **No runtime wiring in this PR**: the `convergence.mode` / `HIVE_CONVERGENCE_MODE` toggle surface is landing with #4246 (PR #4356); this library plugs into that resolved mode value without duplicating it. Wiring an observer + projection through the #4246 seam is deferred until that PR merges, so no conflict is possible.

## Guard-row coverage (#4251 strict RED matrix)

Restart durability (write → reload → same desired generation, CAS still fenced), CAS conflict rejection incl. 8-way concurrent racers under `-race` (exactly one winner, no double advance), corrupt-file refusal preserving bytes, duplicate/impossible persisted records refused, persist-failure memory rollback, reader-detachment (mutating a returned copy touches nothing), mirror write-only proof, unauthorized-mutator refusal, stale/never-observed generation never admits (including through the always-admitting lookup-miss path), match ≠ satisfaction (unsatisfied dependency still blocks), degraded read outranks a claimed match, no-latch replay determinism, and unbound-candidate legacy behavior as positive control.

Coverage: `pkg/convergence` 100%, `pkg/convergence/outcome` 98.1% (floors: 90 default). `go vet` clean, full-module build clean, dashboard consumer tests pass.