### PR TITLE
✨ feat(github): detect repos the App installation does not cover

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2422,6 +2422,20 @@ func main() {
 					dashSrv.AuditLog("system", "github_app_check", "result=no GitHub client: "+appAuthFailure, "")
 					return false
 				}
+				// #4360: ask about repo COVERAGE before attempting a read.
+				// A repo the installation does not cover answers 404, which is
+				// indistinguishable from "no such repo" and used to be reported
+				// as "app not installed / no read" — sending the operator after
+				// credentials that were never broken. Checking first means the
+				// specific, correct message wins over the generic one.
+				if raise, diag, state := classifyGitHubAppRepoCoverage(ctx, ghClient.AppAuth(), cfg.Project.Org, cfg.Project.Repos, logger); raise {
+					dashSrv.SetGitHubAppPermIssue(diag)
+					dashSrv.SetGitHubAppState(state.String())
+					logger.Warn("github app recheck: installation does not cover every configured repo",
+						"org", cfg.Project.Org, "state", state.String(), "detail", diag)
+					dashSrv.AuditLog("system", "github_app_check", "result=repos not in installation: "+diag, "")
+					return false
+				}
 				num, err := ghClient.EnsureAdvisoryIssue(ctx, recheckRepo)
 				if err != nil {
 					logger.Debug("github app recheck: not accessible", "repo", recheckRepo, "error", err)
@@ -4893,6 +4907,51 @@ func classifyGitHubAppWriteForbidden(ctx context.Context, appAuth *github.AppAut
 		Repo:            repo,
 	}
 	return d.Message(), github.AppStateWriteForbidden
+}
+
+// classifyGitHubAppRepoCoverage (#4360) asks the deterministic question the
+// other classifiers cannot: does this installation actually COVER the repos
+// this hive is configured to work on?
+//
+// Everything else here reasons from a failed call. diagnoseGitHubApp inspects
+// installation-level PERMISSIONS and never repo scope, and
+// classifyGitHubAppWriteForbidden infers scope from a 403 after a write has
+// already failed. Neither can see the case that prompted this: a hive pointed
+// at a second repo in the right org, on the right installation, simply not
+// ticked in the App's selected repos. GitHub answers 404 for that — the same
+// answer it gives for a repo that does not exist — so the read path reported
+// "app not installed / no read" and the dashboard blamed an undelivered
+// private key that had in fact arrived. The operator was sent to re-upload a
+// key, which could not possibly help.
+//
+// An error here is NOT a verdict. If the listing cannot be fetched the
+// credentials themselves are the more likely story, and the existing checks
+// tell it better; this returns raise=false and lets them run.
+func classifyGitHubAppRepoCoverage(ctx context.Context, appAuth *github.AppAuth, org string, repos []string, logger *slog.Logger) (raise bool, msg string, state github.AppAuthState) {
+	if appAuth == nil || len(repos) == 0 {
+		return false, "", github.AppStateUnknown
+	}
+
+	cov, err := appAuth.InstallationCoverage(ctx)
+	if err != nil {
+		logger.Debug("github app repo coverage: could not list installation repositories — deferring to the credential checks",
+			"org", org, "error", err)
+		return false, "", github.AppStateUnknown
+	}
+
+	missing := cov.Missing(org, repos)
+	if len(missing) == 0 {
+		return false, "", github.AppStateOK
+	}
+
+	d := github.AppAuthDiagnosis{
+		State:           github.AppStateRepoNotCovered,
+		ExpectedAccount: org,
+		InstallationID:  appAuth.InstallationID(),
+		APIURL:          appAuth.APIURL(),
+		Repos:           missing,
+	}
+	return true, d.Message(), github.AppStateRepoNotCovered
 }
 
 // primaryAdvisoryRepo returns the repo the advisory digest is posted to: the

--- a/src/pkg/github/app_coverage.go
+++ b/src/pkg/github/app_coverage.go
@@ -1,0 +1,199 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// Repository coverage for a GitHub App installation (#4360).
+//
+// A hive can be pointed at a repo its App installation does not cover, and
+// nothing says so. The failure surfaces later and lazily, as an agent action
+// failing, and it is reported as something else entirely — the live case that
+// prompted this reported "the App private key has not reached this spoke",
+// which was false: the key had arrived, and re-uploading it could never help.
+//
+// The distinction from AppStateWriteForbidden matters. That state is the same
+// underlying problem INFERRED from a 403 on a real write, after the fact and
+// only for the one repo something happened to touch. This is the same problem
+// established DIRECTLY, before anything is attempted, for every configured
+// repo at once:
+//
+//	covered    := GET /installation/repositories
+//	configured := project.repos
+//	missing    := configured - covered
+//
+// No error-code inference, and no guessing between "not covered", "renamed",
+// and "does not exist" — GitHub answers 404 for all three when an installation
+// cannot see a repo, which is exactly why the 403/404 path cannot tell them
+// apart and this one can.
+
+// coveragePageSize is the maximum GitHub allows per page.
+const coveragePageSize = 100
+
+// coverageMaxPages bounds the walk. An installation set to "all repositories"
+// on a large org can list thousands, and this check is not worth an unbounded
+// number of round trips. Hitting the cap sets Truncated, and a truncated list
+// deliberately reports NOTHING missing — see Missing.
+const coverageMaxPages = 10
+
+// InstallationCoverage is the set of repositories an App installation can see.
+type InstallationCoverage struct {
+	// Repos holds "owner/name" for every covered repository, lowercased,
+	// because GitHub treats those names case-insensitively.
+	Repos map[string]struct{}
+
+	// Truncated reports that the listing stopped at coverageMaxPages, so the
+	// set is a prefix rather than the whole of it. Absence from a truncated
+	// set proves nothing.
+	Truncated bool
+}
+
+// InstallationCoverage lists what this installation actually covers.
+//
+// It uses the installation token, not the App JWT: /installation/repositories
+// is scoped to the token's own installation, which is precisely the question
+// being asked. A nil receiver or one with no key returns an error rather than
+// an empty set — "we could not ask" must never be mistaken for "it covers
+// nothing", which would accuse every configured repo at once.
+func (a *AppAuth) InstallationCoverage(ctx context.Context) (InstallationCoverage, error) {
+	cov := InstallationCoverage{Repos: map[string]struct{}{}}
+
+	if a == nil || !a.HasKey() {
+		return cov, fmt.Errorf("no GitHub App key loaded")
+	}
+
+	token, err := a.Token(ctx)
+	if err != nil {
+		return cov, fmt.Errorf("minting installation token: %w", err)
+	}
+
+	client := newTokenClient(token, a.apiURL)
+	opts := &gh.ListOptions{PerPage: coveragePageSize}
+
+	for page := 1; page <= coverageMaxPages; page++ {
+		list, resp, err := client.Apps.ListRepos(ctx, opts)
+		if err != nil {
+			return cov, fmt.Errorf("listing installation repositories: %w", err)
+		}
+		if list == nil {
+			return cov, nil
+		}
+		for _, r := range list.Repositories {
+			full := strings.TrimSpace(r.GetFullName())
+			if full == "" {
+				// Older/enterprise payloads occasionally omit full_name;
+				// rebuild it rather than dropping the repo, because a dropped
+				// entry reads as "not covered" and would be an accusation.
+				owner := strings.TrimSpace(r.GetOwner().GetLogin())
+				name := strings.TrimSpace(r.GetName())
+				if owner == "" || name == "" {
+					continue
+				}
+				full = owner + "/" + name
+			}
+			cov.Repos[strings.ToLower(full)] = struct{}{}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return cov, nil
+		}
+		opts.Page = resp.NextPage
+	}
+
+	cov.Truncated = true
+	return cov, nil
+}
+
+// NormalizeRepoRef expands a configured repo reference to "owner/name".
+// Configuration accepts both a bare name and a fully qualified one; comparison
+// needs the qualified form on both sides.
+func NormalizeRepoRef(owner, ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if strings.Contains(ref, "/") {
+		return strings.ToLower(ref)
+	}
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return strings.ToLower(ref)
+	}
+	return strings.ToLower(owner + "/" + ref)
+}
+
+// Missing returns the configured repos this installation does not cover, in
+// "owner/name" form, sorted for stable copy and stable tests.
+//
+// A truncated listing returns nothing. Absence from a partial set is not
+// evidence of absence from the whole, and a false "your App does not include
+// this repo" sends an operator to change a setting that was already correct —
+// the exact class of mistake this whole check exists to stop making.
+func (c InstallationCoverage) Missing(owner string, configured []string) []string {
+	if c.Truncated {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	var missing []string
+	for _, ref := range configured {
+		full := NormalizeRepoRef(owner, ref)
+		if full == "" {
+			continue
+		}
+		if _, ok := c.Repos[full]; ok {
+			continue
+		}
+		if _, dup := seen[full]; dup {
+			continue
+		}
+		seen[full] = struct{}{}
+		missing = append(missing, full)
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+// webBaseFromAPIURL turns a GitHub API base into the web base an operator can
+// click. github.com and GitHub Enterprise spell these differently, and a
+// hardcoded github.com link on a GHE hive sends the operator to an account
+// they may not even have.
+//
+//	https://api.github.com/            -> https://github.com
+//	https://ghe.example.com/api/v3/    -> https://ghe.example.com
+func webBaseFromAPIURL(apiURL string) string {
+	raw := strings.TrimSpace(apiURL)
+	if raw == "" {
+		return "https://github.com"
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	if strings.EqualFold(u.Host, "api.github.com") {
+		return "https://github.com"
+	}
+	// Enterprise: the API lives under /api/v3 on the same host the web UI uses.
+	return u.Scheme + "://" + u.Host
+}
+
+// InstallationSettingsURL is the page that actually fixes AppStateRepoNotCovered:
+// the org's settings for this specific installation, where repository access is
+// ticked. Empty when there is not enough information to build a link that
+// works, because a wrong link is worse than none.
+func (d AppAuthDiagnosis) InstallationSettingsURL() string {
+	org := strings.TrimSpace(d.ExpectedAccount)
+	if org == "" || d.InstallationID == 0 {
+		return ""
+	}
+	base := webBaseFromAPIURL(d.APIURL)
+	if base == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/organizations/%s/settings/installations/%d", base, org, d.InstallationID)
+}

--- a/src/pkg/github/app_coverage_test.go
+++ b/src/pkg/github/app_coverage_test.go
@@ -1,0 +1,234 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// coverageServer serves GET /installation/repositories with the given repo
+// full-names, paginating at perPage so the walk is exercised for real.
+func coverageServer(t *testing.T, full []string, perPage int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		page := 1
+		fmt.Sscanf(r.URL.Query().Get("page"), "%d", &page)
+		if page < 1 {
+			page = 1
+		}
+		start := (page - 1) * perPage
+		if start > len(full) {
+			start = len(full)
+		}
+		end := start + perPage
+		if end > len(full) {
+			end = len(full)
+		}
+		repos := make([]map[string]any, 0, end-start)
+		for _, f := range full[start:end] {
+			repos = append(repos, map[string]any{"full_name": f})
+		}
+		if end < len(full) {
+			w.Header().Set("Link", fmt.Sprintf(`<%s?page=%d>; rel="next"`, r.URL.Path, page+1))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count":  len(full),
+			"repositories": repos,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func coverageAuth(t *testing.T, apiURL string) *AppAuth {
+	t.Helper()
+	a := newTestAppAuth(t, filepath.Join(t.TempDir(), "token-cache.json"))
+	a.apiURL = apiURL
+	// A cached token short-circuits minting, so these tests exercise the
+	// listing rather than the JWT path.
+	a.cachedToken = "test-installation-token"
+	a.tokenExpiry = time.Now().Add(time.Hour)
+	return a
+}
+
+// The live case from #4360: org AI-native-Systems-Research, one installation
+// covering two storage repos, and the hive configured for a third repo that is
+// not ticked. The comparison must yield exactly that repo.
+func TestInstallationCoverage_LiveHeadwatersCase(t *testing.T) {
+	const org = "AI-native-Systems-Research"
+	srv := coverageServer(t, []string{
+		org + "/ai-native-storage-certus",
+		org + "/ai-native-storage-certus-workbench",
+	}, 100)
+
+	cov, err := coverageAuth(t, srv.URL+"/").InstallationCoverage(context.Background())
+	if err != nil {
+		t.Fatalf("InstallationCoverage: %v", err)
+	}
+
+	missing := cov.Missing(org, []string{"headwaters"})
+	want := []string{"ai-native-systems-research/headwaters"}
+	if !reflect.DeepEqual(missing, want) {
+		t.Fatalf("missing = %v, want %v", missing, want)
+	}
+
+	// The covered ones must not be accused.
+	if got := cov.Missing(org, []string{"ai-native-storage-certus"}); len(got) != 0 {
+		t.Fatalf("a covered repo was reported missing: %v", got)
+	}
+}
+
+func TestInstallationCoverage_PaginatesAndComparesCaseInsensitively(t *testing.T) {
+	srv := coverageServer(t, []string{
+		"acme/one", "acme/two", "acme/Three", "acme/four", "acme/five",
+	}, 2)
+
+	cov, err := coverageAuth(t, srv.URL+"/").InstallationCoverage(context.Background())
+	if err != nil {
+		t.Fatalf("InstallationCoverage: %v", err)
+	}
+	if cov.Truncated {
+		t.Fatal("five repos over three pages must not be truncated")
+	}
+	if len(cov.Repos) != 5 {
+		t.Fatalf("got %d repos across pages, want 5", len(cov.Repos))
+	}
+	// GitHub repo names are case-insensitive; a config that spells one
+	// differently must not be accused.
+	if got := cov.Missing("acme", []string{"THREE", "acme/One"}); len(got) != 0 {
+		t.Fatalf("case difference reported as missing: %v", got)
+	}
+}
+
+// A truncated listing must accuse nobody. Absence from a partial set is not
+// evidence of absence, and a false accusation here sends an operator to change
+// a setting that was already correct.
+func TestInstallationCoverage_TruncatedAccusesNobody(t *testing.T) {
+	full := make([]string, 0, coveragePageSize*(coverageMaxPages+2))
+	for i := 0; i < cap(full); i++ {
+		full = append(full, fmt.Sprintf("acme/repo-%d", i))
+	}
+	srv := coverageServer(t, full, coveragePageSize)
+
+	cov, err := coverageAuth(t, srv.URL+"/").InstallationCoverage(context.Background())
+	if err != nil {
+		t.Fatalf("InstallationCoverage: %v", err)
+	}
+	if !cov.Truncated {
+		t.Fatal("a listing beyond the page cap must report Truncated")
+	}
+	if got := cov.Missing("acme", []string{"definitely-not-listed"}); got != nil {
+		t.Fatalf("truncated coverage reported %v missing; it must report nothing", got)
+	}
+}
+
+// "We could not ask" must never become "it covers nothing", which would accuse
+// every configured repo at once.
+func TestInstallationCoverage_ErrorIsNotAnEmptySet(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, err := coverageAuth(t, srv.URL+"/").InstallationCoverage(context.Background())
+	if err == nil {
+		t.Fatal("a failed listing must return an error, not an empty coverage set")
+	}
+
+	var nilAuth *AppAuth
+	if _, err := nilAuth.InstallationCoverage(context.Background()); err == nil {
+		t.Fatal("a nil AppAuth must error rather than report empty coverage")
+	}
+}
+
+func TestNormalizeRepoRef(t *testing.T) {
+	for _, tc := range []struct{ owner, ref, want string }{
+		{"Acme", "widget", "acme/widget"},
+		{"Acme", "Other/Widget", "other/widget"},
+		{"", "widget", "widget"},
+		{"Acme", "  spaced  ", "acme/spaced"},
+		{"Acme", "", ""},
+	} {
+		if got := NormalizeRepoRef(tc.owner, tc.ref); got != tc.want {
+			t.Errorf("NormalizeRepoRef(%q, %q) = %q, want %q", tc.owner, tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestRepoNotCoveredMessage(t *testing.T) {
+	d := AppAuthDiagnosis{
+		State:           AppStateRepoNotCovered,
+		ExpectedAccount: "AI-native-Systems-Research",
+		InstallationID:  140943481,
+		APIURL:          "https://api.github.com/",
+		Repos:           []string{"ai-native-systems-research/headwaters"},
+	}
+	msg := d.Message()
+
+	for _, want := range []string{
+		"ai-native-systems-research/headwaters",
+		"https://github.com/organizations/AI-native-Systems-Research/settings/installations/140943481",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q:\n%s", want, msg)
+		}
+	}
+	// The whole point is not repeating the misdiagnosis this replaces: the
+	// live report blamed an undelivered private key and told the operator to
+	// re-upload it, which could not possibly have helped.
+	for _, never := range []string{
+		"has not reached this spoke",
+		"re-upload",
+		"not installed on",
+		"Issues: Read & Write required",
+		"contact your hub administrator",
+	} {
+		if strings.Contains(msg, never) {
+			t.Errorf("message wrongly blames %q:\n%s", never, msg)
+		}
+	}
+	// It should say plainly what is NOT at fault, because that is the part the
+	// operator got wrong last time.
+	if !strings.Contains(msg, "Nothing is wrong with the App, the organization, or the private key") {
+		t.Errorf("message does not exonerate the credentials:\n%s", msg)
+	}
+
+	// GitHub Enterprise must not be linked to github.com.
+	d.APIURL = "https://ghe.example.com/api/v3/"
+	if got := d.InstallationSettingsURL(); got != "https://ghe.example.com/organizations/AI-native-Systems-Research/settings/installations/140943481" {
+		t.Errorf("enterprise settings URL = %q", got)
+	}
+
+	// Not enough information for a correct link means no link at all.
+	d.InstallationID = 0
+	if got := d.InstallationSettingsURL(); got != "" {
+		t.Errorf("expected no link without an installation id, got %q", got)
+	}
+}
+
+func TestRepoNotCoveredStateWiring(t *testing.T) {
+	if got := AppStateRepoNotCovered.String(); got != "repo-not-covered" {
+		t.Fatalf("wire token = %q", got)
+	}
+	if got := ParseAppAuthState("repo-not-covered"); got != AppStateRepoNotCovered {
+		t.Fatalf("round trip = %v", got)
+	}
+	if !AppStateRepoNotCovered.UserActionable() {
+		t.Error("an org owner can tick the repo, so this must be user-actionable")
+	}
+	if AppStateRepoNotCovered.OperatorActionable() {
+		t.Error("the hub operator cannot fix repository access; this must not be operator-actionable")
+	}
+}

--- a/src/pkg/github/app_state.go
+++ b/src/pkg/github/app_state.go
@@ -87,6 +87,25 @@ const (
 	// installation (or, if using "all repositories", approve any pending
 	// permission update).
 	AppStateWriteForbidden
+
+	// AppStateRepoNotCovered (#4360) means the App authenticated on the right
+	// account and the installation is healthy, but one or more of the repos
+	// this hive is configured to work on are not in the installation's
+	// selected repositories.
+	//
+	// It is the DETERMINISTIC form of what AppStateWriteForbidden infers. That
+	// state is reached after a real write returns 403, for whichever single
+	// repo something happened to touch; this one is established up front, for
+	// every configured repo, by comparing project.repos against
+	// GET /installation/repositories. Where the two agree, prefer this one:
+	// it names every affected repo rather than the first one to fail, and it
+	// does not have to guess, because GitHub answers 404 — not 403 — for a
+	// repo an installation cannot see, which is indistinguishable from the
+	// repo not existing.
+	//
+	// USER-ACTIONABLE (by an org owner): tick the repo in the App
+	// installation's repository access.
+	AppStateRepoNotCovered
 )
 
 // String returns the stable wire token for a state. These tokens cross the
@@ -110,6 +129,8 @@ func (s AppAuthState) String() string {
 		return "no-app-assigned"
 	case AppStateWriteForbidden:
 		return "write-forbidden"
+	case AppStateRepoNotCovered:
+		return "repo-not-covered"
 	default:
 		return "unknown"
 	}
@@ -127,7 +148,8 @@ func (s AppAuthState) OperatorActionable() bool {
 // this state themselves. Only these states justify a "do something" banner.
 func (s AppAuthState) UserActionable() bool {
 	switch s {
-	case AppStateNotInstalled, AppStateWrongInstallation, AppStateInsufficientPerms, AppStateWriteForbidden:
+	case AppStateNotInstalled, AppStateWrongInstallation, AppStateInsufficientPerms,
+		AppStateWriteForbidden, AppStateRepoNotCovered:
 		return true
 	default:
 		return false
@@ -153,6 +175,8 @@ func ParseAppAuthState(s string) AppAuthState {
 		return AppStateKeyInvalid
 	case "no-app-assigned":
 		return AppStateNoAppAssigned
+	case "repo-not-covered":
+		return AppStateRepoNotCovered
 	case "write-forbidden":
 		return AppStateWriteForbidden
 	default:
@@ -262,6 +286,15 @@ type AppAuthDiagnosis struct {
 	// Only AppStateWriteForbidden (#2353) populates it, so the banner can name
 	// the exact repo the operator must add to the App installation.
 	Repo string
+	// Repos, when set, are the configured repositories the installation does
+	// not cover, in "owner/name" form. Only AppStateRepoNotCovered (#4360)
+	// populates it, so the banner can name every repo that needs ticking
+	// rather than only the first one to fail a write.
+	Repos []string
+	// APIURL is the GitHub API base this hive talks to. Carried so copy can
+	// build a web link that is correct on GitHub Enterprise too, instead of
+	// hardcoding github.com.
+	APIURL string
 	// Err is the underlying error, for logs. Never rendered to a user
 	// verbatim, because it can carry raw API text.
 	Err error
@@ -301,6 +334,7 @@ func (a *AppAuth) DiagnoseAppAuth(ctx context.Context, expectedOwner string, key
 		return d
 	}
 	d.InstallationID = a.InstallationID()
+	d.APIURL = a.APIURL()
 
 	// Cheap pre-flight: if we were given key locations and none of them holds
 	// content, the key is missing. No API call needed.
@@ -425,6 +459,26 @@ func (d AppAuthDiagnosis) Message() string {
 			"but a write to %s returned 403 (Resource not accessible by integration). The most likely cause is that "+
 			"%s is not included in the App installation's selected repositories — add it to the installation "+
 			"(or, if a permission update is pending, approve it) at the app installation settings page.", owner, repo, repo)
+
+	case AppStateRepoNotCovered:
+		// #4360. Everything about the credentials is fine: right App, right
+		// org, valid key, healthy installation. The only thing wrong is which
+		// repositories that installation was ticked for. Say exactly that, and
+		// name them — the previous signal for this shape ("the key has not
+		// reached this spoke") pointed at a re-upload that could not possibly
+		// help.
+		repos := strings.Join(d.Repos, ", ")
+		if repos == "" {
+			repos = "one or more configured repositories"
+		}
+		msg := fmt.Sprintf("The GitHub App is installed and authenticated for '%s', but its installation does not include: %s. "+
+			"Nothing is wrong with the App, the organization, or the private key — these repositories are simply not "+
+			"ticked in the installation's repository access, so every call against them returns 404. "+
+			"Add them under the org's App configuration (Settings → Applications → Configure → Repository access).", owner, repos)
+		if link := d.InstallationSettingsURL(); link != "" {
+			msg += " " + link
+		}
+		return msg
 
 	default:
 		return "Could not verify this hive's GitHub App credentials. This is usually transient — " +

--- a/src/pkg/hub/alerts_app_creds_test.go
+++ b/src/pkg/hub/alerts_app_creds_test.go
@@ -260,3 +260,30 @@ func TestAppCredsUndeliveredAlertHasADashboardLabel(t *testing.T) {
 		t.Errorf("ALERT_TYPE_LABELS has no entry for %q", AlertTypeAppCredsUndelivered)
 	}
 }
+
+// TestAppCredsUndelivered_RepoNotCoveredDoesNotFire (#4360) pins the fix for
+// the misdiagnosis this alert produced on kelly-headwaters.
+//
+// That hive's App was correct, its org was correct, and its key had arrived
+// and minted tokens fine. The only thing wrong was that `headwaters` was not
+// ticked in the installation's selected repositories, so every call against it
+// answered 404. Nothing classified that, so the spoke reported an
+// operator-side credential state and this alert told the operator to re-upload
+// a key — a remedy that could not possibly have helped, and which sent the
+// only person who could act down the wrong path.
+//
+// The spoke now reports "repo-not-covered" for that shape. It is owner-side —
+// an org owner ticks a checkbox — so this operator alert must stay silent, and
+// the coverage banner carries the real message instead.
+func TestAppCredsUndelivered_RepoNotCoveredDoesNotFire(t *testing.T) {
+	h := appCredsHive("kelly-headwaters", "repo-not-covered")
+
+	summary := evaluateAlerts(newAlertState(), []alertHive{h}, nil, fixedNow)
+
+	if _, fired := findAlert(summary.Alerts, "kelly-headwaters", AlertTypeAppCredsUndelivered); fired {
+		t.Fatal("repo-not-covered raised app-creds-undelivered: the key is fine and re-uploading it cannot help")
+	}
+	if appStateIsOperatorSide("repo-not-covered") {
+		t.Error("repo-not-covered must not be operator-side: only an org owner can change repository access")
+	}
+}


### PR DESCRIPTION
## What

Asks GitHub directly which repos an App installation covers, and names the
configured ones it does not.

```
covered    := GET /installation/repositories
configured := project.repos
missing    := configured - covered
```

- `src/pkg/github/app_coverage.go` — `AppAuth.InstallationCoverage`, the
  comparison, and the deep link.
- `AppStateRepoNotCovered` — the verdict, wire token `repo-not-covered`.
- `src/cmd/hive/main.go` — `classifyGitHubAppRepoCoverage`, wired into the
  recheck path.

## Why the current signal was worse than nothing

On `kelly - headwaters` the App was correct, the org was correct, and the key
had arrived and minted tokens fine. The only thing wrong was that `headwaters`
was not ticked in the installation's selected repositories.

GitHub answers **404** for a repo an installation cannot see — the same answer
it gives for a repo that does not exist — so the read path reported "app not
installed / no read", and the dashboard raised **app-creds-undelivered**,
telling the operator to re-upload a private key that had never been missing.
The named remedy could not fix the actual problem.

## Where it sits among the existing states

This is the **deterministic** form of what `AppStateWriteForbidden` (#2353)
infers. That state is reached after a real write returns 403, for whichever
single repo something happened to touch. This one is established **before**
anything is attempted, for **every** configured repo at once, and does not have
to guess between "not covered", "renamed", and "does not exist".

So the coverage check runs *before* the advisory-issue read in the recheck
path — the specific message beats the generic one. Both the manual **Re-check**
button and the periodic self-heal loop go through `RecheckGitHubApp`, so both
gain it at once, as the issue suggested.

## Two ways it refuses to accuse

This check's whole purpose is to stop sending operators after the wrong thing,
so it is built not to become a new source of that:

- **An error is not a verdict.** If the listing cannot be fetched, the
  credentials are the likelier story and the existing checks tell it better, so
  it defers. It never returns an empty coverage set on failure — that would
  accuse every configured repo simultaneously.
- **A truncated listing accuses nobody.** An installation set to "all
  repositories" on a large org can list thousands; the walk is capped, and
  hitting the cap reports *nothing* missing. Absence from a partial set is not
  evidence of absence.

## The message

```
The GitHub App is installed and authenticated for 'AI-native-Systems-Research',
but its installation does not include: ai-native-systems-research/headwaters.
Nothing is wrong with the App, the organization, or the private key — these
repositories are simply not ticked in the installation's repository access, so
every call against them returns 404. Add them under the org's App configuration
(Settings → Applications → Configure → Repository access).
https://github.com/organizations/AI-native-Systems-Research/settings/installations/140943481
```

It says what is *not* at fault, because that is the part the previous signal got
wrong. The deep link is built from the API base, so a GitHub Enterprise hive is
not sent to github.com — asserted by test.

## The misleading alert stays silent, by construction

`app-creds-undelivered` is gated on an allowlist of three operator-side tokens
(`appStateIsOperatorSide`). `repo-not-covered` is owner-side — an org owner
ticks a checkbox — so it cannot fire. I added a hub test pinning that against
the hive that produced the original misdiagnosis, rather than relying on the
allowlist staying closed by accident.

## Tests

The live case runs end to end against a stubbed `/installation/repositories`:
the two storage repos covered, `headwaters` configured, exactly `headwaters`
reported missing, and the covered repos not accused. Plus pagination across
pages, case-insensitive repo names (GitHub's are), the truncation guard,
error-is-not-an-empty-set, the GHE link, no-link-without-an-installation-id,
and the wire-token round trip.

`go build ./...`, `go vet`, and full package runs green: `pkg/github`,
`pkg/hub`, `pkg/dashboard`, `cmd/hive`.

## Scope

Detection at **claim/assign time** — the issue's "ideally" — is not here. That
is a hub-side surface with its own state machine, and folding it in would have
made this change hard to review against the one it fixes. The recheck path is
where the issue pointed, and it covers both the manual and self-heal routes.

Automatically adding a repo to the installation is explicitly out of scope: it
requires org admin rights. The ask was that the product name the problem
correctly.

Closes #4360.

— hive: backend=claude model=claude-opus-5
