### PR TITLE
✨ feat(convergence): observe shared admission at the internal agent kick boundary (default off)

### DIFF
--- a/src/cmd/hive/convergence_kick.go
+++ b/src/cmd/hive/convergence_kick.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"log/slog"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard"
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+// observeConvergenceKickAdmission is the #4247 eval-cycle seam: it runs the
+// shared convergence dependency admission (the SAME observer + pure evaluator
+// the contributor queue and selectTask consume, via
+// dashboard.ConvergenceKickProjection) over the issue population that is about
+// to be cached for manual kicks and rendered into scheduled kicks.
+//
+// Rollout contract (maintainer requirement, ahead of #4263):
+//
+//   - convergence.mode "off" (DEFAULT): return before touching anything — no
+//     sweep is built, no decision is computed, the kick path is byte-for-byte
+//     the pre-#4247 path. Zero behaviour change for existing v4 hives.
+//   - convergence.mode "shadow": compute the projection ONCE on a fresh sweep
+//     and LOG which candidates the shared evaluator would have withheld from
+//     internal kicks, with the decision's stable reason, blockers, and observed
+//     record/generation. NOTHING is enforced: the caller always passes the raw
+//     actionable result to Scheduler.SetLastActionable and BuildKickMessages,
+//     so scheduled kicks, cached manual/dashboard kicks, governor counts,
+//     prompts, ordering, and PR/review dispatch are all unchanged.
+//
+// The function never mutates actionable. It is nil-safe on every input so a
+// hive booted without a dashboard (or a test harness) cannot panic here.
+func observeConvergenceKickAdmission(cfg *config.Config, dashSrv *dashboard.Server, actionable *github.ActionableResult, logger *slog.Logger) {
+	if cfg.ConvergenceMode() != config.ConvergenceModeShadow {
+		return // off (default): entirely inert
+	}
+	if dashSrv == nil || actionable == nil || logger == nil {
+		return
+	}
+	admitted, withheld := dashSrv.ConvergenceKickProjection(actionable.Issues.Items)
+	if len(withheld) == 0 {
+		logger.Debug("convergence shadow: every enumerated issue is admitted for internal kicks",
+			"issues", len(actionable.Issues.Items))
+		return
+	}
+	for _, f := range withheld {
+		logger.Info("convergence shadow: candidate would be WITHHELD from internal agent kicks (not enforced)",
+			"repo", f.Issue.Repo,
+			"number", f.Issue.Number,
+			"reason", f.Decision.Reason,
+			"blockers", f.Decision.Blockers,
+			"observed_record", f.Decision.ObservedRecord,
+			"observed_generation", f.Decision.ObservedGeneration,
+		)
+	}
+	logger.Info("convergence shadow kick projection complete",
+		"raw_issues", len(actionable.Issues.Items),
+		"admitted", len(admitted),
+		"withheld", len(withheld),
+		"enforced", false,
+	)
+}

--- a/src/cmd/hive/convergence_kick_test.go
+++ b/src/cmd/hive/convergence_kick_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/beads"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard"
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+// ── #4247 eval-cycle seam: observeConvergenceKickAdmission ─────────────────────
+//
+// The rollout contract under test: with convergence.mode "off" (the DEFAULT)
+// the seam is entirely inert — no projection, no log, no mutation; with
+// "shadow" the shared evaluator's would-be withholdings are logged and the
+// actionable population is still never touched (observed, never enforced).
+
+func kickTestActionable() *github.ActionableResult {
+	return &github.ActionableResult{
+		Issues: github.IssueResult{
+			Count: 2,
+			Items: []github.Issue{
+				{Repo: "projectbluefin/dakota", Number: 601, Title: "dependent work"},
+				{Repo: "projectbluefin/dakota", Number: 700, Title: "unrelated ready work"},
+			},
+		},
+	}
+}
+
+// kickTestDashboard wires a real dashboard server whose contribute hub reads a
+// real on-disk bead store in which dakota#601 depends on an OPEN blocker — the
+// exact production observer/evaluator stack, not a stub.
+func kickTestDashboard(t *testing.T) *dashboard.Server {
+	t.Helper()
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("creating bead store: %v", err)
+	}
+	blocker, err := store.Create("blocking work", beads.TypeTask, beads.PriorityMedium, "scanner", "")
+	if err != nil {
+		t.Fatalf("creating blocker: %v", err)
+	}
+	dependent, err := store.Create("dependent work", beads.TypeTask, beads.PriorityMedium, "scanner",
+		"gh-projectbluefin/dakota#601")
+	if err != nil {
+		t.Fatalf("creating dependent: %v", err)
+	}
+	if err := store.AddDependency(dependent.ID, blocker.ID); err != nil {
+		t.Fatalf("adding dependency: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := dashboard.NewServer(0, logger)
+	srv.RegisterAPI(&dashboard.Dependencies{
+		Config:     &config.Config{},
+		BeadStores: map[string]*beads.Store{"scanner": store},
+	})
+	return srv
+}
+
+// TestObserveConvergenceKickAdmission_OffModeIsInert pins the default-off
+// guarantee: no log line is emitted and the actionable population is untouched.
+func TestObserveConvergenceKickAdmission_OffModeIsInert(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	actionable := kickTestActionable()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	observeConvergenceKickAdmission(&config.Config{}, srv, actionable, logger)
+
+	if buf.Len() != 0 {
+		t.Fatalf("mode=off must log nothing, got: %s", buf.String())
+	}
+	if len(actionable.Issues.Items) != 2 || actionable.Issues.Items[0].Number != 601 {
+		t.Fatalf("mode=off must not touch actionable: %+v", actionable.Issues.Items)
+	}
+
+	// A nil config is also off (fail-safe) — and must not panic.
+	observeConvergenceKickAdmission(nil, srv, actionable, logger)
+	if buf.Len() != 0 {
+		t.Fatal("nil config must resolve to off and log nothing")
+	}
+}
+
+// TestObserveConvergenceKickAdmission_ShadowLogsButNeverEnforces: in shadow the
+// shared evaluator's withholding is visible in the log — with the stable reason
+// — while the actionable issue list handed onward is byte-for-byte unchanged.
+func TestObserveConvergenceKickAdmission_ShadowLogsButNeverEnforces(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	actionable := kickTestActionable()
+	cfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeShadow}}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	observeConvergenceKickAdmission(cfg, srv, actionable, logger)
+
+	out := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte("WITHHELD")) {
+		t.Fatalf("shadow mode must log the would-be withholding, got: %s", out)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("WaitingForDependency")) {
+		t.Fatalf("log must carry the evaluator's stable reason, got: %s", out)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("enforced=false")) {
+		t.Fatalf("log must state nothing was enforced, got: %s", out)
+	}
+	// NEVER enforced: the raw population is intact for SetLastActionable /
+	// BuildKickMessages.
+	if len(actionable.Issues.Items) != 2 || actionable.Issues.Items[0].Number != 601 {
+		t.Fatalf("shadow mode must not touch actionable: %+v", actionable.Issues.Items)
+	}
+}
+
+// TestObserveConvergenceKickAdmission_ShadowAllAdmitted: when nothing is
+// withheld, shadow says so at debug and enforces nothing.
+func TestObserveConvergenceKickAdmission_ShadowAllAdmitted(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := dashboard.NewServer(0, logger)
+	srv.RegisterAPI(&dashboard.Dependencies{Config: &config.Config{}})
+	actionable := kickTestActionable()
+	cfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeShadow}}
+
+	var buf bytes.Buffer
+	captured := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	observeConvergenceKickAdmission(cfg, srv, actionable, captured)
+	if bytes.Contains(buf.Bytes(), []byte("WITHHELD")) {
+		t.Fatalf("nothing should be withheld with no ledger records: %s", buf.String())
+	}
+	if len(actionable.Issues.Items) != 2 {
+		t.Fatalf("actionable mutated: %+v", actionable.Issues.Items)
+	}
+}
+
+// TestObserveConvergenceKickAdmission_NilInputsAreSafe: a hive booted without a
+// dashboard (or with nothing enumerated) cannot panic here in any mode.
+func TestObserveConvergenceKickAdmission_NilInputsAreSafe(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	cfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeShadow}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	observeConvergenceKickAdmission(cfg, nil, kickTestActionable(), logger)
+	observeConvergenceKickAdmission(cfg, kickTestDashboard(t), nil, logger)
+	observeConvergenceKickAdmission(cfg, kickTestDashboard(t), kickTestActionable(), nil)
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -5314,6 +5314,16 @@ func runEvalCycle(
 		}
 	}
 
+	// #4247 (parent #3845): observe the shared convergence admission at the
+	// internal-kick dispatch boundary — AFTER governor policy evaluated the raw
+	// queue, BEFORE the scheduler caches and renders issues. Gated by the
+	// convergence feature toggle: with mode "off" (the default) this is
+	// entirely inert, and even in "shadow" it only LOGS what the shared
+	// evaluator would withhold — the raw actionable population is always what
+	// SetLastActionable and BuildKickMessages receive. Enforcement is a later,
+	// explicit increment (#4263).
+	observeConvergenceKickAdmission(cfg, dashSrv, actionable, logger)
+
 	sched.SetLastActionable(actionable)
 	reviewPlan := planReviewDispatch(cfg, actionable, agentMgr, logger)
 	messages := sched.BuildKickMessages(actionable, agentsDue)

--- a/src/pkg/dashboard/convergence_kick.go
+++ b/src/pkg/dashboard/convergence_kick.go
@@ -1,0 +1,105 @@
+package dashboard
+
+import (
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/convergence"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// ── #4247: shared convergence admission for internal agent kicks ──────────────
+//
+// Contributor offerability and assignment already withhold a dependency-blocked
+// or unknown candidate (#3857/#3904), but scheduled and cached manual internal-
+// agent kicks render the raw enumerated issue set. This file provides the ONE
+// read-only admitted-issue projection the eval-cycle dispatch boundary consumes,
+// built from the SAME observer (observeCandidateDependencies) and the SAME pure
+// evaluator (convergence.Evaluate) the contributor paths use — one normalized
+// observation/evaluator contract, never a reimplementation in scheduler code.
+//
+// Rollout (maintainer requirement, precedes #4263): callers gate on the
+// convergence feature toggle. With mode "off" (default) this projection is
+// never invoked — the kick path is entirely inert and unchanged. With mode
+// "shadow" the caller computes the projection and LOGS what would have been
+// withheld, but always dispatches the raw population — observed, never
+// enforced. Enforcement is a later, explicit increment.
+//
+// Deliberate scope, per the #4247 contract:
+//   - CONVERGENCE admission only. The open-PR claim ledger is not consulted
+//     here: internal kicks already have their own claim policy
+//     (applyDuplicatePRGuard honours hive-authored claims only, #3792), and
+//     re-applying the contributor-side any-claim rule would silently change it.
+//   - Nothing is cached across passes; every call builds a fresh sweep from
+//     current authoritative bead state, so the judgment is level-triggered and
+//     reconstructs identically after a restart.
+//   - The raw actionable population remains authoritative for governor queue
+//     counts/mode/cadence, dashboard status, PR/review dispatch, escalation,
+//     and merge eligibility — this projection covers the ISSUE list only.
+
+// ConvergenceKickFinding is one issue the shared convergence admission would
+// withhold from internal agent kicks, with the exact Decision that judged it.
+type ConvergenceKickFinding struct {
+	Issue    ghpkg.Issue
+	Decision convergence.Decision
+}
+
+// ConvergenceKickProjection evaluates the shared contributor-neutral
+// convergence dependency admission for every enumerated issue, on ONE fresh
+// ledger sweep, and returns the admitted projection plus the withheld findings.
+//
+// Read-only and side-effect free: it assigns nothing, mutates nothing, and the
+// input slice is never modified (admitted is a new slice). A hub with no
+// contribute hub or no bead ledger wired admits everything — identical to the
+// contributor path's behaviour in the same state. Non-GitHub-backed items skip
+// the GitHub-only bead observer and are admitted on its behalf, exactly as
+// evaluateContributorNeutralAdmission does (kubestellar/hive#4245 boundary).
+func (s *Server) ConvergenceKickProjection(issues []ghpkg.Issue) (admitted []ghpkg.Issue, withheld []ConvergenceKickFinding) {
+	admitted = make([]ghpkg.Issue, 0, len(issues))
+	if s == nil || s.contributeHub == nil {
+		return append(admitted, issues...), nil
+	}
+	hub := s.contributeHub
+	// One sweep for the whole pass — the same per-pass snapshot discipline the
+	// contributor paths use, so every candidate in this projection is judged
+	// against one consistent view of current ledger state.
+	sweep := hub.newAdmissionSweep()
+	for _, issue := range issues {
+		candidate := kickAdmissionCandidate(issue)
+		if !candidate.isGitHubBacked() {
+			admitted = append(admitted, issue)
+			continue
+		}
+		decision := convergence.Evaluate(hub.observeCandidateDependencies(sweep, candidate))
+		if decision.Admitted {
+			admitted = append(admitted, issue)
+			continue
+		}
+		withheld = append(withheld, ConvergenceKickFinding{Issue: issue, Decision: decision})
+	}
+	return admitted, withheld
+}
+
+// kickAdmissionCandidate normalises one enumerated issue into the shared
+// admission candidate shape. Repo carries whatever spelling the enumerator
+// recorded; the bare tail is supplied as repoName so bead identity lookup tries
+// both spellings, mirroring candidateIdentityKeys' contract for the contributor
+// path (the #2648 key-mismatch class of bug, avoided the same way).
+func kickAdmissionCandidate(issue ghpkg.Issue) contributorAdmissionCandidate {
+	repoName := issue.Repo
+	if i := strings.LastIndex(issue.Repo, "/"); i >= 0 {
+		repoName = issue.Repo[i+1:]
+	}
+	return contributorAdmissionCandidate{
+		repoFull: issue.Repo,
+		repoName: repoName,
+		number:   issue.Number,
+		ref: worksource.Ref{
+			SourceType: issue.SourceType,
+			Repo:       issue.Repo,
+			ExternalID: issue.ExternalID,
+			Number:     issue.Number,
+			URL:        issue.URL,
+		},
+	}
+}

--- a/src/pkg/dashboard/convergence_kick_test.go
+++ b/src/pkg/dashboard/convergence_kick_test.go
@@ -1,0 +1,259 @@
+package dashboard
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/beads"
+	"github.com/kubestellar/hive/pkg/convergence"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+// ── #4247: shared convergence admission for internal agent kicks ──────────────
+//
+// These tests pin the admitted-issue projection the eval-cycle dispatch
+// boundary consumes. The load-bearing invariants:
+//
+//   1. SAME CONTRACT: the projection reaches the same judgment as the
+//      contributor paths (ReadyQueue / selectTask) under unchanged authoritative
+//      state, because it consumes the same observer and pure evaluator on the
+//      same per-pass sweep discipline — not an independent filter.
+//   2. LEVEL-TRIGGERED: nothing is latched; the next call derives from current
+//      bead/retirement state, and a restart reconstructs the same answer.
+//   3. READ-ONLY: the input population is never mutated.
+
+func kickIssues() []ghpkg.Issue {
+	return []ghpkg.Issue{
+		{Repo: "projectbluefin/dakota", Number: 601, Title: "dependent work"},
+		{Repo: "projectbluefin/dakota", Number: 700, Title: "unrelated ready work"},
+	}
+}
+
+func admittedNumbers(issues []ghpkg.Issue) []int {
+	out := []int{}
+	for _, is := range issues {
+		out = append(out, is.Number)
+	}
+	return out
+}
+
+// TestKickProjection_BlockedDependencyIsWithheld: A depends on open B → A is
+// absent from the admitted kick projection with the evaluator's own decision,
+// while unrelated C stays admitted; and the CONTRIBUTOR paths agree on the same
+// authoritative state (shared-contract parity, not coincidence).
+func TestKickProjection_BlockedDependencyIsWithheld(t *testing.T) {
+	store := depTestStore(t)
+	blockerID := seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	hub, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	admitted, withheld := s.ConvergenceKickProjection(kickIssues())
+	if got := admittedNumbers(admitted); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("admitted %v, want [700]", got)
+	}
+	if len(withheld) != 1 || withheld[0].Issue.Number != 601 {
+		t.Fatalf("withheld %+v, want dakota#601", withheld)
+	}
+	d := withheld[0].Decision
+	if d.Reason != convergence.ReasonWaitingForDependency {
+		t.Fatalf("reason %q, want WaitingForDependency", d.Reason)
+	}
+	if len(d.Blockers) != 1 || d.Blockers[0] != blockerID {
+		t.Fatalf("blockers %v, want [%s]", d.Blockers, blockerID)
+	}
+
+	// Parity: the contributor queue and live assignment withhold the same
+	// candidate under the same unchanged state.
+	assertQueue(t, hub, 700)
+	assertAssigns(t, hub, 700)
+}
+
+// TestKickProjection_FlipsWithoutRestart: closing the blocker admits the
+// dependent on the NEXT pass, reopening withholds it again — no latched
+// decision in either direction.
+func TestKickProjection_FlipsWithoutRestart(t *testing.T) {
+	store := depTestStore(t)
+	blockerID := seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	if admitted, _ := s.ConvergenceKickProjection(kickIssues()); len(admitted) != 1 {
+		t.Fatalf("expected 601 withheld initially, admitted %v", admittedNumbers(admitted))
+	}
+	if err := store.Close(blockerID); err != nil {
+		t.Fatalf("closing blocker: %v", err)
+	}
+	if admitted, withheld := s.ConvergenceKickProjection(kickIssues()); len(admitted) != 2 || len(withheld) != 0 {
+		t.Fatalf("after satisfaction: admitted %v withheld %d, want both admitted", admittedNumbers(admitted), len(withheld))
+	}
+	if err := store.Update(blockerID, func(b *beads.Bead) {
+		b.Status = beads.StatusOpen
+		b.ClosedAt = nil
+	}); err != nil {
+		t.Fatalf("reopening blocker: %v", err)
+	}
+	if admitted, _ := s.ConvergenceKickProjection(kickIssues()); len(admitted) != 1 {
+		t.Fatalf("after reopening: admitted %v, want [700] — decision must not latch", admittedNumbers(admitted))
+	}
+}
+
+// TestKickProjection_UnknownDependencyIsWithheldAsUnknown: an unresolvable,
+// non-retired dependency withholds the candidate with Ready=Unknown, and
+// unrelated work stays dispatchable.
+func TestKickProjection_UnknownDependencyIsWithheldAsUnknown(t *testing.T) {
+	store := depTestStore(t)
+	dependent, err := store.Create("dependent work", beads.TypeTask, beads.PriorityMedium, "scanner",
+		"gh-projectbluefin/dakota#601")
+	if err != nil {
+		t.Fatalf("creating dependent: %v", err)
+	}
+	if err := store.Update(dependent.ID, func(b *beads.Bead) {
+		b.DependsOn = []string{"bd-nonexistent"}
+	}); err != nil {
+		t.Fatalf("adding dangling dependency: %v", err)
+	}
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	admitted, withheld := s.ConvergenceKickProjection(kickIssues())
+	if got := admittedNumbers(admitted); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("admitted %v, want [700]", got)
+	}
+	if len(withheld) != 1 || withheld[0].Decision.Reason != convergence.ReasonDependencyUnknown {
+		t.Fatalf("withheld %+v, want DependencyUnknown", withheld)
+	}
+}
+
+// TestKickProjection_PositiveControls: a terminal-retired dependency and a
+// candidate with no record at all are both admitted, so the projection cannot
+// drift into reject-everything.
+func TestKickProjection_PositiveControls(t *testing.T) {
+	store := depTestStore(t)
+	blockerID := seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	if err := store.Close(blockerID); err != nil {
+		t.Fatalf("closing blocker: %v", err)
+	}
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	admitted, withheld := s.ConvergenceKickProjection(kickIssues())
+	if len(admitted) != 2 || len(withheld) != 0 {
+		t.Fatalf("admitted %v withheld %d, want both admitted", admittedNumbers(admitted), len(withheld))
+	}
+}
+
+// TestKickProjection_SurvivesRestart: a fresh store loaded from the same
+// directory (process restart) reconstructs the same withholding from durable
+// state — no process-only verdict.
+func TestKickProjection_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+
+	reloaded, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("reloading store: %v", err)
+	}
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": reloaded})
+	admitted, withheld := s.ConvergenceKickProjection(kickIssues())
+	if got := admittedNumbers(admitted); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("admitted %v after restart, want [700]", got)
+	}
+	if len(withheld) != 1 || withheld[0].Issue.Number != 601 {
+		t.Fatalf("withheld %+v after restart, want dakota#601", withheld)
+	}
+}
+
+// TestKickProjection_PartialLedgerKeepsFinalPolicy: readable blocked records
+// stay withheld while unmapped misses remain admitted — the final #3904
+// compromise, unchanged by this projection.
+func TestKickProjection_PartialLedgerKeepsFinalPolicy(t *testing.T) {
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+	s.deps.BeadStoreLoadFailures = 1
+
+	admitted, withheld := s.ConvergenceKickProjection(kickIssues())
+	if got := admittedNumbers(admitted); len(got) != 1 || got[0] != 700 {
+		t.Fatalf("admitted %v, want unmapped miss #700 admitted", got)
+	}
+	if len(withheld) != 1 || withheld[0].Issue.Number != 601 {
+		t.Fatalf("withheld %+v, want readable blocked record still gated", withheld)
+	}
+}
+
+// TestKickProjection_NonGitHubItemsAreAdmitted: a string-keyed external item
+// (no positive issue number) skips the GitHub-only bead observer and is
+// admitted, exactly as the contributor path treats it (#4245 boundary).
+func TestKickProjection_NonGitHubItemsAreAdmitted(t *testing.T) {
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	issues := []ghpkg.Issue{
+		{Repo: "projectbluefin/dakota", Number: 0, SourceType: "linear", ExternalID: "ENG-42", Title: "external"},
+	}
+	admitted, withheld := s.ConvergenceKickProjection(issues)
+	if len(admitted) != 1 || len(withheld) != 0 {
+		t.Fatalf("external item must be admitted: admitted %d withheld %d", len(admitted), len(withheld))
+	}
+}
+
+// TestKickProjection_NilSafety: a nil server or a server with no contribute hub
+// admits everything rather than panicking or silently withholding.
+func TestKickProjection_NilSafety(t *testing.T) {
+	var nilServer *Server
+	admitted, withheld := nilServer.ConvergenceKickProjection(kickIssues())
+	if len(admitted) != 2 || len(withheld) != 0 {
+		t.Fatalf("nil server: admitted %d withheld %d, want all admitted", len(admitted), len(withheld))
+	}
+}
+
+// TestKickProjection_DoesNotMutateInput: the projection is read-only over the
+// caller's slice.
+func TestKickProjection_DoesNotMutateInput(t *testing.T) {
+	store := depTestStore(t)
+	seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	in := kickIssues()
+	_, _ = s.ConvergenceKickProjection(in)
+	if len(in) != 2 || in[0].Number != 601 || in[1].Number != 700 {
+		t.Fatalf("input mutated: %+v", in)
+	}
+}
+
+// TestKickProjection_IsRaceFreeAgainstConcurrentWriters: bead writers racing the
+// projection must be race-free under -race — only copied projection values
+// escape the store lock (same contract the contributor sweep pins).
+func TestKickProjection_IsRaceFreeAgainstConcurrentWriters(t *testing.T) {
+	store := depTestStore(t)
+	blockerID := seedDependentBead(t, store, "gh-projectbluefin/dakota#601")
+	_, s := depTestHub(t, map[string]*beads.Store{"scanner": store})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = store.Update(blockerID, func(b *beads.Bead) {
+				if b.Status == beads.StatusOpen {
+					b.Status = beads.StatusClosed
+				} else {
+					b.Status = beads.StatusOpen
+					b.ClosedAt = nil
+				}
+			})
+		}
+	}()
+	for i := 0; i < 50; i++ {
+		_, _ = s.ConvergenceKickProjection(kickIssues())
+	}
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
Closes #4247
Part of #3845 — builds on #4356 (#4246 diagnostics) and the merged #4245 source-aware identity (#4292).

## What

Scheduled and cached manual internal-agent kicks previously rendered the **raw** enumerated issue set, so Hive could dispatch a candidate through internal kicks while the contributor queue/assignment correctly withheld it. This PR adds **one** read-only admitted-issue projection at the eval-cycle dispatch boundary:

- `dashboard.ConvergenceKickProjection` — evaluates every enumerated issue on one fresh per-pass ledger sweep through the **same** observer (`observeCandidateDependencies`) and the **same** pure evaluator (`convergence.Evaluate`) that `ReadyQueue`/`selectTask` consume. One normalized observation/evaluator contract; no dependency semantics copied into scheduler code; no decision cached across passes; input never mutated.
- `observeConvergenceKickAdmission` in `runEvalCycle` — invoked **after** governor policy evaluates the raw queue and **before** `Scheduler.SetLastActionable` / `BuildKickMessages`.

Scope kept exactly to the contract: convergence dependency admission only (internal kicks keep their own hive-authored duplicate-PR claim guard, #3792); non-GitHub items skip the GitHub-only bead observer and stay admitted (#4245 boundary); the final #3904 partial-ledger policy is preserved; governor counts/mode/cadence, dashboard status, PR/review dispatch, prompts, ordering, and merge eligibility keep consuming the raw actionable result.

## Default-off guarantee (maintainer requirement)

Gated by the `convergence.mode` toggle introduced in #4356 (`off`|`shadow`, default `off`, env override `HIVE_CONVERGENCE_MODE`), ahead of #4263's off/shadow/enforce formalisation:

- **off (default):** the seam returns before any computation — the kick path is entirely inert and byte-for-byte the pre-#4247 path. Existing v4 users see **zero behavior change**.
- **shadow:** the projection is computed once per eval cycle and the would-be withholdings are **logged only** (stable reason, blockers, observed record/generation, `enforced=false`). Nothing is enforced: the raw population still feeds `SetLastActionable` and `BuildKickMessages`, so no kick, prompt, or routing changes in any mode. Enforcement is deliberately deferred to #4263.

## Tests

`pkg/dashboard/convergence_kick_test.go`: blocked dependency withheld with the evaluator's own Decision + parity with ReadyQueue/selectTask on unchanged state; satisfaction flips both ways without restart (no latching); unknown dependency withheld as Unknown; terminal-retired / no-record positive controls; restart reconstruction from durable stores; partial-ledger #3904 policy; non-GitHub admission; nil-safety; input immutability; concurrent-writer race test (clean under `go test -race`).
`cmd/hive/convergence_kick_test.go`: off mode logs nothing and touches nothing (incl. nil config fail-safe); shadow logs `WITHHELD`/reason/`enforced=false` while the actionable population is untouched; all-admitted and nil-input safety.
Full `pkg/dashboard` (83%+, floor 78) and `cmd/hive` suites pass.