### PR TITLE
🐛 podman quadlet doc: install a config that exists, on the port HealthCmd probes

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -94,6 +94,20 @@ jobs:
       - name: Standalone service deployment contract (#4204)
         run: bash deploy/test_standalone_service_contract.sh
 
+      # #4367: the Quadlet unit's HealthCmd= probes a port that lives in the
+      # OPERATOR's hive.yaml, and nothing at install time notices when the two
+      # disagree — the config parses, the generator exits 0, the container
+      # starts and is genuinely healthy on the other port, and Notify=healthy
+      # correctly holds the unit in `activating` until TimeoutStartSec=300
+      # expires and --rm deletes the evidence. Five minutes and no artifact for
+      # one wrong digit. Same shape as the guards above: invisible when it
+      # breaks, and no dry-run can catch it. Also asserts the install steps name
+      # files the repo actually TRACKS, which is the bug itself: the doc said
+      # `cp src/hive.yaml`, a gitignored path that exists only in a checkout
+      # where someone already followed the README.
+      - name: Quadlet config-coupling contract (#4367)
+        run: bash deploy/test_quadlet_config_contract.sh
+
       # bin/gh-wrapper.sh is the merge gate standing behind the proxy hard-deny:
       # if its argument parsing is wrong, a prompt-injected agent merges
       # unvetted code. It had NO tests and matched no CI path filter. This

--- a/src/deploy/quadlet/hive.container
+++ b/src/deploy/quadlet/hive.container
@@ -90,6 +90,15 @@ EnvironmentFile=%E/hive/hive.env
 # READINESS. HealthCmd is required for Notify=healthy to mean anything; see the
 # header. /api/health is the same endpoint the Kubernetes readiness probe and
 # the Compose healthcheck use, so "healthy" means the same thing on all three.
+#
+# THE PORT BELOW IS COUPLED TO `dashboard.port` IN THE MOUNTED hive.yaml, and
+# nothing enforces the coupling. 3002 is the Go default (defaultDashboardPort in
+# pkg/config/config.go), what src/deploy/hive.yaml sets, and what the Compose
+# healthcheck probes — but src/hive.yaml.example ships 3001 for source runs.
+# Install that file unchanged and Hive serves on 3001, this probe never answers,
+# and Notify=healthy correctly holds the unit in `activating` for the whole
+# TimeoutStartSec below before --rm deletes the evidence. Change one, change the
+# other (#4367).
 Notify=healthy
 HealthCmd=curl -sf http://127.0.0.1:3002/api/health
 HealthInterval=10s

--- a/src/deploy/test_quadlet_config_contract.sh
+++ b/src/deploy/test_quadlet_config_contract.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Contract test for the Quadlet unit's config coupling (#4367).
+# Run: bash src/deploy/test_quadlet_config_contract.sh
+#
+# The unit's HealthCmd= probes a port that lives in the operator's hive.yaml,
+# and NOTHING at install time notices when the two disagree. The config parses,
+# the Quadlet generator exits 0, the container starts and is genuinely healthy —
+# on the other port. Notify=healthy then does exactly what it should and holds
+# the unit in `activating` until TimeoutStartSec=300 expires, at which point the
+# generated `--rm` deletes the container that held the evidence. Five minutes,
+# no artifact, one wrong digit.
+#
+# That is the shape the repo already gates rather than reviews: invisible when
+# it breaks, and no dry-run can catch it. So this asserts the coupling directly.
+# Pure string analysis: nothing is started, no registry is contacted.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+UNIT="src/deploy/quadlet/hive.container"
+DOC="src/docs/podman-standalone-quadlet.md"
+COMPOSE="src/docker-compose.yaml"
+DEPLOY_CONF="src/deploy/hive.yaml"
+EXAMPLE_CONF="src/hive.yaml.example"
+GO_CONFIG="src/pkg/config/config.go"
+
+pass_count=0
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+ok() {
+  pass_count=$((pass_count + 1))
+}
+
+need_file() {
+  if [[ ! -f "${ROOT}/$1" ]]; then
+    fail "$1: expected file is missing"
+    return 1
+  fi
+  return 0
+}
+
+# --- 1. The port the unit probes -------------------------------------------
+
+health_port=""
+if need_file "$UNIT"; then
+  health_port="$(
+    grep -E '^HealthCmd=' "${ROOT}/${UNIT}" \
+      | grep -oE '127\.0\.0\.1:[0-9]+' \
+      | cut -d: -f2 \
+      | head -n1
+  )"
+  if [[ -z "$health_port" ]]; then
+    fail "${UNIT}: no HealthCmd= probing http://127.0.0.1:<port>/api/health. Notify=healthy without a healthcheck reports \"started\" the moment conmon is up."
+  else
+    ok
+  fi
+fi
+
+# --- 2. The Go default, which is what an omitted dashboard.port gives -------
+
+go_default=""
+if need_file "$GO_CONFIG"; then
+  go_default="$(
+    grep -oE 'defaultDashboardPort[[:space:]]*=[[:space:]]*[0-9]+' "${ROOT}/${GO_CONFIG}" \
+      | grep -oE '[0-9]+$' \
+      | head -n1
+  )"
+  if [[ -z "$go_default" ]]; then
+    fail "${GO_CONFIG}: could not read defaultDashboardPort"
+  elif [[ -n "$health_port" && "$go_default" != "$health_port" ]]; then
+    fail "${GO_CONFIG}: defaultDashboardPort is ${go_default} but ${UNIT} probes ${health_port}. An operator who omits dashboard.port would then never reach healthy."
+  else
+    ok
+  fi
+fi
+
+# --- 3. yaml configs that ship a dashboard.port ----------------------------
+
+# Reads the `port:` immediately under the top-level `dashboard:` key. Good
+# enough for these files and deliberately not a YAML parser: the gate must run
+# with nothing installed but bash.
+dashboard_port() {
+  awk '
+    /^dashboard:/ { in_dash = 1; next }
+    in_dash && /^[^[:space:]#]/ { in_dash = 0 }
+    in_dash && $1 == "port:" { print $2; exit }
+  ' "$1"
+}
+
+if need_file "$DEPLOY_CONF"; then
+  deploy_port="$(dashboard_port "${ROOT}/${DEPLOY_CONF}")"
+  if [[ -z "$deploy_port" ]]; then
+    fail "${DEPLOY_CONF}: no dashboard.port found"
+  elif [[ -n "$health_port" && "$deploy_port" != "$health_port" ]]; then
+    fail "${DEPLOY_CONF}: dashboard.port is ${deploy_port} but ${UNIT} probes ${health_port}"
+  else
+    ok
+  fi
+fi
+
+# --- 4. The Compose healthcheck, so all three container paths agree --------
+
+if need_file "$COMPOSE"; then
+  # Scoped to the `hive:` service on purpose: the `gateway:` service probes
+  # /api/health too, on its own published port, and matching that one instead
+  # would make this assertion agree with the wrong thing.
+  compose_port="$(
+    awk '
+      /^  [a-zA-Z0-9_-]+:$/ { svc = $1; sub(/:$/, "", svc) }
+      svc == "hive" && /127\.0\.0\.1:[0-9]+\/api\/health/ {
+        match($0, /127\.0\.0\.1:[0-9]+/)
+        port = substr($0, RSTART, RLENGTH)
+        sub(/.*:/, "", port)
+        print port
+        exit
+      }
+    ' "${ROOT}/${COMPOSE}"
+  )"
+  if [[ -z "$compose_port" ]]; then
+    fail "${COMPOSE}: no /api/health healthcheck found for the hive service"
+  elif [[ -n "$health_port" && "$compose_port" != "$health_port" ]]; then
+    fail "${COMPOSE}: the hive healthcheck probes ${compose_port} but ${UNIT} probes ${health_port}"
+  else
+    ok
+  fi
+fi
+
+# --- 5. The unit names the config key it is coupled to ---------------------
+
+if [[ -f "${ROOT}/${UNIT}" ]]; then
+  if grep -q 'dashboard\.port' "${ROOT}/${UNIT}"; then
+    ok
+  else
+    fail "${UNIT}: the HealthCmd comment no longer names dashboard.port. The coupling is invisible from the unit again."
+  fi
+fi
+
+# --- 6. Every repo path the doc tells an operator to copy is TRACKED -------
+#
+# This is the #4367 defect itself: the install step said `cp src/hive.yaml`,
+# and src/hive.yaml is gitignored — it is the file the operator creates, not
+# one the repo ships.
+#
+# Tracked, not merely present on disk. A contributor who has followed the
+# README has an untracked src/hive.yaml sitting in their checkout, so a plain
+# existence test passes for them and fails for the operator who cloned the
+# repo and did nothing else — which is precisely the reader this step is for.
+
+tracked_in_repo() {
+  git -C "$ROOT" ls-files --error-unmatch -- "$1" >/dev/null 2>&1
+}
+
+if need_file "$DOC"; then
+  if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    printf 'SKIP: not a git checkout, cannot tell tracked files from local ones\n'
+  else
+    doc_paths="$(
+      grep -oE '(cp|install)[[:space:]]+(-Dm644[[:space:]]+)?src/[A-Za-z0-9._/-]+' "${ROOT}/${DOC}" \
+        | grep -oE 'src/[A-Za-z0-9._/-]+' \
+        | sort -u
+    )"
+    missing=0
+    while IFS= read -r doc_path; do
+      [[ -z "$doc_path" ]] && continue
+      if ! tracked_in_repo "$doc_path"; then
+        fail "${DOC}: tells the operator to copy ${doc_path}, which the repo does not ship (untracked or absent)"
+        missing=1
+      fi
+    done <<<"$doc_paths"
+    [[ "$missing" -eq 0 ]] && ok
+  fi
+fi
+
+# --- 7. The doc does not hand the operator the example's port unchanged ----
+#
+# src/hive.yaml.example ships 3001 for source runs and is the file an operator
+# reaches for. If the doc installs it, it must also change the port, or the
+# start hangs for the full TimeoutStartSec.
+
+if [[ -f "${ROOT}/${DOC}" && -f "${ROOT}/${EXAMPLE_CONF}" && -n "$health_port" ]]; then
+  example_port="$(dashboard_port "${ROOT}/${EXAMPLE_CONF}")"
+  if [[ -z "$example_port" ]]; then
+    fail "${EXAMPLE_CONF}: no dashboard.port found"
+  elif [[ "$example_port" == "$health_port" ]]; then
+    # The example agrees with the unit; no correction is owed by the doc.
+    ok
+  elif grep -q "${EXAMPLE_CONF}" "${ROOT}/${DOC}"; then
+    if grep -qE "port: ${health_port}" "${ROOT}/${DOC}"; then
+      ok
+    else
+      fail "${DOC}: installs ${EXAMPLE_CONF} (dashboard.port ${example_port}) but never sets port ${health_port}. Following it literally hangs the start for TimeoutStartSec."
+    fi
+  else
+    ok
+  fi
+fi
+
+# --- Summary ----------------------------------------------------------------
+
+if [[ "$failures" -gt 0 ]]; then
+  printf '\nFAILED: %d assertion(s) — see src/docs/podman-standalone-quadlet.md (#4367)\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'PASS: %d Quadlet config-coupling assertions (health port %s)\n' "$pass_count" "${health_port:-?}"

--- a/src/docs/network-requirements.md
+++ b/src/docs/network-requirements.md
@@ -15,7 +15,7 @@ This page is derived from the v2 code and manifests. Treat it as the operator-fa
 
 Notes:
 
-- `hive.yaml.example` defaults `dashboard.port` to 3001 for local/source runs. The Kubernetes ConfigMap sets it to 3002 because the cluster Service/Ingress owns the public edge.
+- `hive.yaml.example` defaults `dashboard.port` to 3001 for local/source runs. The Kubernetes ConfigMap sets it to 3002 because the cluster Service/Ingress owns the public edge. The Go default is 3002 (`defaultDashboardPort`), and the container deployments assume it: the Compose `hive` healthcheck and the Podman Quadlet unit's `HealthCmd=` both probe 3002, so a container install that keeps the example's 3001 never reports healthy — see [the Quadlet page](podman-standalone-quadlet.md#traps-measured-not-guessed).
 - Docker Compose publishes 3001 and 7681 from the `gateway` container and only `expose`s 3001/3002/7681 on the `hive` container.
 - The hub is also a Go HTTP server on 3001 unless `HIVE_HUB_PORT` is set. Contributor relay defaults to `wss://hive.kubestellar.io:3001/contribute`.
 

--- a/src/docs/podman-standalone-quadlet.md
+++ b/src/docs/podman-standalone-quadlet.md
@@ -120,7 +120,19 @@ CONF=~/.config/hive
 # rootful:  CONF=/etc/hive
 
 mkdir -p "$CONF/secrets"
-cp src/hive.yaml "$CONF/hive.yaml"      # then edit it
+
+# src/hive.yaml is NOT in the repo — src/.gitignore excludes it, because it is
+# the file you create. Start from the shipped example, the way every other Hive
+# install does.
+cp src/hive.yaml.example "$CONF/hive.yaml"
+
+# REQUIRED, and not cosmetic. The example ships `dashboard.port: 3001` for local
+# source runs; this unit's HealthCmd probes 3002. Skipping this line costs a
+# silent 300-second hang with no container left to inspect — see Traps.
+sed -i 's/^  port: 3001$/  port: 3002/' "$CONF/hive.yaml"
+grep -A1 '^dashboard:' "$CONF/hive.yaml"        # -> dashboard: / port: 3002
+
+# then edit the rest of "$CONF/hive.yaml" for your project
 
 # The container reads keys as dev (1001) through the hive-launch group (1002),
 # so the directory needs the group traverse bit — 0700 would exclude the
@@ -130,6 +142,16 @@ chmod 750 "$CONF/secrets"
 podman unshare chown -R 0:1002 "$CONF/secrets"
 # rootful instead:  chgrp -R 1002 "$CONF/secrets"
 ```
+
+**`dashboard.port` has to agree with the port in `HealthCmd=`.** The unit probes
+`http://127.0.0.1:3002/api/health`. 3002 is where the Go default puts the API
+(`defaultDashboardPort` in `src/pkg/config/config.go`), where the `hive`
+service's healthcheck in `src/docker-compose.yaml` looks for it, and what
+`src/deploy/hive.yaml` sets. Deleting the `port:` line outright works too, since
+3002 is what the default gives you. What does not work is keeping the example's
+3001, and nothing in the install catches it: the config parses, the generator is
+happy, the container starts, and the failure arrives five minutes later. That is
+why the `sed` above is a step rather than a remark.
 
 **`$CONF/hive.env` must exist**, even if it is empty:
 
@@ -160,7 +182,8 @@ unauthenticated. Refusing to start. Set HIVE_DASHBOARD_TOKEN.
 With `Notify=healthy` that refusal surfaces the way it should: the unit stays
 in `activating` and then fails on timeout, rather than reporting a started
 service that is not serving. If a start hangs, this is the first thing to check
-— `journalctl --user -u hive.service` shows the line above.
+— `journalctl --user -u hive.service` shows the line above. The second thing to
+check is `dashboard.port`; see [Traps](#traps-measured-not-guessed).
 
 ### 2. The units
 
@@ -215,6 +238,20 @@ survive a reboot. Verify with `loginctl show-user "$USER" -p Linger`.
 
 ## Traps, measured not guessed
 
+**`dashboard.port` must be 3002, the port `HealthCmd=` probes.**
+`src/hive.yaml.example` sets it to 3001 for source runs, and that is the file an
+operator reaches for — `src/docs/network-requirements.md` describes it as the
+one "for local/source runs", which is what a standalone Podman install reads as.
+Install it unchanged and Hive comes up serving on 3001, so
+`curl -sf http://127.0.0.1:3002/api/health` never answers and `Notify=healthy`
+does exactly what it should: the unit stays in `activating` until
+`TimeoutStartSec=300` expires. The generated `ExecStart` carries `--rm`, so the
+container that would have shown you a perfectly healthy API on the wrong port is
+deleted on the way out. What is left is `Job for hive.service failed because a
+timeout was exceeded`, an empty `podman ps -a`, and a five-minute feedback loop
+per attempt. Measured on Fedora 44, Podman 5.8.4 rootless, SELinux enforcing
+(#4367).
+
 **`EnvironmentFile=` does not take systemd's `-` prefix.** Writing
 `EnvironmentFile=-%E/hive/hive.env` generates cleanly and then resolves to
 `<unit directory>/-%E/hive/hive.env`, a path that will never exist: the `-`
@@ -251,6 +288,15 @@ Dry-run generation is gated in CI: `.github/workflows/quadlet-gate.yml` runs
 `--user` modes, and fails on any generator diagnostic rather than on exit
 status alone. These units are picked up by it automatically.
 
+The generator gate cannot see the config coupling, because a mismatched
+`dashboard.port` generates perfectly — so that has its own gate.
+`src/deploy/test_quadlet_config_contract.sh` runs in `v2-ci.yml` and asserts the
+port in `HealthCmd=` against the Go default, `src/deploy/hive.yaml`, and the
+Compose healthcheck, that the unit still names `dashboard.port` where a reader
+will meet it, and that every file this page tells you to copy is one the repo
+actually tracks. Change any one of those and the PR fails instead of the
+operator's start (#4367).
+
 A **live rootless start was performed** on Fedora 44, Podman 5.8.4, cgroup v2,
 SELinux enforcing, against the real `ghcr.io/kubestellar/hive:stable` image:
 
@@ -269,6 +315,15 @@ half. On a first attempt with no `HIVE_DASHBOARD_TOKEN`, Hive refused to start,
 `ActiveState=activating` / `SubState=start` and never reported started. That is
 the behaviour ADR-0017 chose Quadlet for: a service that is not serving does
 not get to look started.
+
+#4367 confirmed it negatively a second time, from the other direction and on the
+same host. With `src/hive.yaml.example` installed as `$CONF/hive.yaml` — API on
+3001, probe on 3002, nothing else changed — the start failed after **300s** with
+`Result=timeout` and `podman ps -a` empty. With `dashboard.port: 3002` it
+returned **0 in 11s**, `ActiveState=active`, and `podman ps` showed
+`Up 11 seconds (healthy)`. (11s rather than the 52s above because the image was
+already pulled.) The unit was not changed between the two runs; only the port
+in the config was.
 
 Recorded honestly rather than left implied:
 


### PR DESCRIPTION
Fixes #4367.

## The bug

`src/docs/podman-standalone-quadlet.md` told the operator to install the config with:

```sh
cp src/hive.yaml "$CONF/hive.yaml"      # then edit it
```

`src/.gitignore:3` excludes `hive.yaml`. It is the file an operator *creates*, not one the repo ships, so the step fails outright in a fresh checkout.

The obvious substitute is worse than the missing file. `src/hive.yaml.example` is what the rest of the docs point at and what `src/docs/network-requirements.md:18` calls the config "for local/source runs" — and it sets `dashboard.port: 3001`, while the unit probes `http://127.0.0.1:3002/api/health`. Install it unchanged and Hive comes up serving, healthily, on the wrong port:

| | |
| --- | --- |
| the probe | never answers |
| `Notify=healthy` | correctly holds the unit in `activating` — a service that is not serving does not get to look started |
| `TimeoutStartSec=300` | expires five minutes later |
| generated `--rm` | deletes the container that held the evidence |

Leaving `Job for hive.service failed because a timeout was exceeded`, an empty `podman ps -a`, and a five-minute feedback loop per attempt — for a one-digit config mistake the document told them to make.

## What changed

Documentation and comments. **No change to the unit's readiness design** — #4367 measured `Notify=healthy` behaving correctly in both directions, and that is not what needed fixing.

- **The install step now names a file the repo ships.** It copies `src/hive.yaml.example`, corrects the port in the same block, and prints the check that proves it took.
- **The `dashboard.port` / `HealthCmd=` coupling is stated where the operator meets it**, and added to *Traps, measured not guessed* beside the `EnvironmentFile=` dash trap and the `GlobalArgs=` healthcheck trap — the same shape as both: generates cleanly, fails at runtime, no dry-run can catch it.
- **The unit's `HealthCmd` comment names the config key it is coupled to**, so the coupling is visible from `hive.container` as well as from the page (suggested fix item 4 in the issue).
- **`network-requirements.md`**, which already recorded the 3001/3002 divergence, now says what the container deployments do with it.

3002 is not an arbitrary pick: it is the Go default (`defaultDashboardPort` in `src/pkg/config/config.go:3817`), what `src/deploy/hive.yaml` sets, and what the `hive` service's healthcheck in `src/docker-compose.yaml` probes. Deleting the `port:` line entirely works too, for the first reason.

## And a gate, because "the two must not be able to drift silently"

A coupling a reviewer has to remember is one that drifts. `src/deploy/test_quadlet_config_contract.sh` (new, wired into `v2-ci.yml` next to the other deployment-contract guards) asserts:

1. `HealthCmd=` probes some `127.0.0.1:<port>/api/health` at all;
2. that port equals `defaultDashboardPort` — so an operator who *omits* `dashboard.port` still reaches healthy;
3. it equals `src/deploy/hive.yaml`'s `dashboard.port`;
4. it equals the **`hive`** service's Compose healthcheck (scoped to that service on purpose — `gateway` probes `/api/health` too, on its own port);
5. the unit still names `dashboard.port` where a reader will meet it;
6. every file the page tells an operator to copy is one **git tracks** — not merely one present on disk. That distinction is the bug: a contributor who followed the README has an untracked `src/hive.yaml` in their checkout, so a plain existence test passes for them and fails for the operator who cloned and did nothing else, which is exactly the reader that step is for;
7. the page never installs `hive.yaml.example` without correcting the port.

The Quadlet generator gate cannot cover any of this — a mismatched port generates perfectly.

## Verified

- The new contract test passes, and **fails on each regression injected one at a time**: unit port drifted to 3001 (3 assertions fire), the doc naming an untracked `src/hive.yaml` (the original defect), the doc installing the example without the correction, and the unit comment dropping the key.
- `src/deploy/test_quadlet_generator_gate.sh` — 0 failures, both rootful and `--user`, against quadlet 5.8.4.
- `src/deploy/test_standalone_image_refs.sh` — 17 assertions pass.
- `shellcheck -x` clean on the new script; it runs from `src/` as CI invokes it.
- The documented `cp` / `sed` / `grep` sequence was run against the real `src/hive.yaml.example`: `  port: 3001` occurs exactly once in that file, and the result is `dashboard: / port: 3002` with no 3001 left.

## Acceptance criteria

| From #4367 | |
| --- | --- |
| install step names a file that exists in the repo | `src/hive.yaml.example`, and gated (assertion 6) |
| following the document literally produces a service that reaches `active` | the port correction is a copy-pasteable step in the same block, with its own verification, and gated (assertion 7) |
| the coupling is stated where an operator meets it | install section, Traps, the unit comment, and `network-requirements.md` |
| no change to the unit's readiness design | none — only comments changed in `hive.container` |

Part of #4188; this does not close the parent.

— hive: backend=claude model=claude-opus-5
