### PR TITLE
🐛 provision: stop pinning github.key_file at a file the manifest never creates

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -53,6 +53,18 @@ jobs:
       - name: Entrypoint NET_ADMIN ambient-cap tests (#3760)
         run: bash deploy/test_entrypoint_netadmin_ambient.sh
 
+      # #4368: the entrypoint warns when the overlay's github.key_file names a
+      # PEM that is not on disk — and used to look only at /data/, while the
+      # provisioning template seeded /secrets/gh-app-key.pem for every App-using
+      # hive and created that Secret entry only for hives provisioned WITH an
+      # inline key. Four hives shipped naming a file that would never exist,
+      # under the one prefix the check skipped, so the detector written for
+      # exactly that symptom stayed silent and the fault first surfaced as
+      # github_auth: fail. EXECUTES the real merge block extracted from the
+      # shipped entrypoint, so a regression fails the PR rather than a hive.
+      - name: Entrypoint dangling key_file tests (#4368)
+        run: bash deploy/test_entrypoint_dangling_keyfile.sh
+
       # Supply-chain pins regress SILENTLY. The PI_VERSION pin (#3443) landed on
       # v2, and a sync/v2-into-v4-* merge resolved the conflict in favour of the
       # older side and restored `ARG PI_VERSION=latest` — the fix commit is an

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2746,12 +2746,29 @@ func main() {
 		// app_id/installation_id at construction, so without this a corrected
 		// installation_id in hive.yaml keeps minting tokens for the OLD
 		// installation until the pod restarts.
+		//
+		// RESOLVE the key file rather than reading cfg.GitHub.KeyFile raw. An
+		// unset key_file is the CORRECT steady state on a hosted spoke — the
+		// heartbeat apply path deliberately does not persist one, because the
+		// path is derivable from app_id and a stored value outlives the App it
+		// was derived for. Gating on the raw field therefore skipped the rebuild
+		// entirely on exactly the hives that need it: a corrected
+		// installation_id saved to hive.yaml kept minting tokens for the old
+		// installation until the pod restarted. Startup (resolveAppKeyFile
+		// above), the heartbeat rebuild, and the dashboard's Set ID handler
+		// (#2459) all already resolve here; this was the last raw reader.
+		//
+		// Comparing RESOLVED paths also catches a change the raw comparison
+		// cannot see: a per-app-id key arriving on the PVC changes which key
+		// this process should sign with while cfg.GitHub.KeyFile stays "".
+		prevKeyFile := resolveAppKeyFile(prevGitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), prevGitHub.AppID)
+		nextKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
 		if prevGitHub.AppID != cfg.GitHub.AppID ||
 			prevGitHub.InstallationID != cfg.GitHub.InstallationID ||
-			prevGitHub.KeyFile != cfg.GitHub.KeyFile ||
+			prevKeyFile != nextKeyFile ||
 			prevGitHub.APIURL != cfg.GitHub.APIURL {
-			if cfg.GitHub.HasUsableApp() && cfg.GitHub.KeyFile != "" {
-				newAppAuth, appErr := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile, logger, cfg.GitHub.ResolvedAPIURL())
+			if cfg.GitHub.HasUsableApp() && nextKeyFile != "" {
+				newAppAuth, appErr := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, nextKeyFile, logger, cfg.GitHub.ResolvedAPIURL())
 				if appErr != nil {
 					logger.Error("github app auth rebuild after config reload failed", "error", appErr)
 				} else {
@@ -2775,6 +2792,7 @@ func main() {
 					logger.Info("github app auth rebuilt after config reload",
 						"app_id", cfg.GitHub.AppID,
 						"installation_id", cfg.GitHub.InstallationID,
+						"key_file", nextKeyFile,
 					)
 				}
 			}

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -203,11 +203,25 @@ elif overlay_has_real_app:
     # PEM it names actually exists on this PVC. A dangling reference
     # (e.g. an interrupted key write) must not silently authenticate with
     # a missing/placeholder file; fail loud instead of 401-looping quietly.
+    #
+    # BOTH delivery locations, not just the PVC (#4368). /secrets is the
+    # provisioning mount, and the provisioning template used to seed
+    # key_file=/secrets/gh-app-key.pem for every App-using hive while creating
+    # that Secret entry only for hives provisioned WITH an inline private key.
+    # Four hives shipped naming a file that would never exist — under the one
+    # prefix this check did not look at, so the warning written for exactly
+    # this symptom stayed silent on every one of them, and the fault first
+    # surfaced as github_auth: fail hours later. A path outside both prefixes
+    # is an operator's own location and is deliberately not second-guessed.
     key_file = overlay_gh.get('key_file') or ''
-    if isinstance(key_file, str) and key_file.startswith('/data/') and not os.path.isfile(key_file):
+    if isinstance(key_file, str) and key_file.startswith(('/data/', '/secrets/')) and not os.path.isfile(key_file):
+        where = 'the PVC' if key_file.startswith('/data/') else 'the provisioning secret mount'
         sys.stderr.write(
             "[entrypoint] WARNING: overlay github.key_file=%s does not exist on "
-            "the PVC — GitHub App auth will fail until it is re-installed\n" % key_file
+            "%s — GitHub App auth will fail until it is re-installed. An explicit "
+            "key_file also short-circuits the fallback that would otherwise find a "
+            "delivered key; leaving it unset lets the path be derived from app_id\n"
+            % (key_file, where)
         )
 
 # The dashboard OVERLAY wins for acmm_level: the ConfigMap seed only ever

--- a/src/deploy/test_entrypoint_dangling_keyfile.sh
+++ b/src/deploy/test_entrypoint_dangling_keyfile.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Tests the overlay/seed github merge in entrypoint.sh, and specifically its
+# dangling-key_file warning (#4368).
+#
+# The warning existed before this and still missed the fault it was written for:
+# it only looked at /data/, while the provisioning template seeded
+# key_file=/secrets/gh-app-key.pem for every App-using hive and created that
+# Secret entry only for hives provisioned WITH an inline private key. Four hives
+# in the 2026-08-12 batch named a file that would never exist, under the one
+# prefix the check skipped, so nothing said a word until github_auth: fail.
+#
+# Rather than grepping the script, this EXTRACTS the real python block from the
+# shipped entrypoint and executes it against real files, so the assertions fail
+# if the logic regresses rather than if the wording changes.
+#
+# Run: bash src/deploy/test_entrypoint_dangling_keyfile.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+DEPLOY_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTRYPOINT="$DEPLOY_DIR/entrypoint.sh"
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+echo "=== entrypoint dangling key_file tests (#4368) ==="
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  SKIP: python3 not available"
+  exit 0
+fi
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "  SKIP: python3 yaml module not available"
+  exit 0
+fi
+
+# Extract the merge block verbatim from the entrypoint: everything between the
+# heredoc opener and its terminator. This is the shipped code, not a copy.
+MERGE="$(mktemp)"
+trap 'rm -f "$MERGE"' EXIT
+awk '/^import os, sys, yaml$/ {on=1} on {print} /^PYEOF$/ {if (on) exit}' "$ENTRYPOINT" \
+  | sed '/^PYEOF$/d' > "$MERGE"
+
+if [ ! -s "$MERGE" ]; then
+  fail "could not extract the overlay-merge block from $ENTRYPOINT"
+  exit 1
+fi
+if ! grep -q "key_file" "$MERGE"; then
+  fail "extracted block does not mention key_file — the extraction markers moved"
+  exit 1
+fi
+pass "extracted the real overlay-merge block from entrypoint.sh"
+
+# run_merge <key_file-value> <create-the-file?>
+# Renders a seed and an overlay carrying the given key_file, runs the real merge
+# block over them, and prints its stderr.
+run_merge() {
+  local key_file="$1" create="$2"
+  local dir
+  dir="$(mktemp -d)"
+
+  local resolved="$key_file"
+  if [ "$create" = "create" ]; then
+    # Relocate the path under the temp dir so a test never depends on, or
+    # writes to, a real /data or /secrets.
+    resolved="$dir/$(basename "$key_file")"
+    printf 'not-a-real-key\n' > "$resolved"
+  fi
+
+  cat > "$dir/seed.yaml" <<YAML
+project:
+  org: kubestellar
+agents:
+  guide:
+    backend: copilot
+github:
+  app_id: 3568013
+  installation_id: 12345
+YAML
+  cat > "$dir/overlay.yaml" <<YAML
+project:
+  org: kubestellar
+agents:
+  guide:
+    backend: copilot
+github:
+  app_id: 3568013
+  installation_id: 12345
+  key_file: $resolved
+YAML
+
+  python3 - "$dir/seed.yaml" "$dir/overlay.yaml" < "$MERGE" 2>&1 >/dev/null || true
+  rm -rf "$dir"
+}
+
+# --- the regression itself --------------------------------------------------
+
+out="$(run_merge /secrets/gh-app-key.pem missing)"
+if printf '%s' "$out" | grep -q "key_file=/secrets/gh-app-key.pem"; then
+  pass "a missing /secrets key_file is reported (the #4368 shape)"
+else
+  fail "a missing /secrets key_file is reported (the #4368 shape)" \
+       "no warning named it; stderr was: ${out:-<empty>}"
+fi
+
+# --- the case that already worked, which must keep working ------------------
+
+out="$(run_merge /data/gh-app-key.pem missing)"
+if printf '%s' "$out" | grep -q "key_file=/data/gh-app-key.pem"; then
+  pass "a missing /data key_file is still reported"
+else
+  fail "a missing /data key_file is still reported" \
+       "no warning named it; stderr was: ${out:-<empty>}"
+fi
+
+# --- no false positives -----------------------------------------------------
+
+out="$(run_merge /secrets/gh-app-key.pem create)"
+if printf '%s' "$out" | grep -q "does not exist"; then
+  fail "a key_file that EXISTS is not reported" "stderr was: $out"
+else
+  pass "a key_file that exists is not reported"
+fi
+
+out="$(run_merge /opt/operator/custom.pem missing)"
+if printf '%s' "$out" | grep -q "does not exist"; then
+  fail "an operator path outside both prefixes is left alone" "stderr was: $out"
+else
+  pass "an operator path outside both prefixes is left alone"
+fi
+
+echo
+echo "SUMMARY: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/pkg/config/dangling_keyfile_test.go
+++ b/src/pkg/config/dangling_keyfile_test.go
@@ -116,3 +116,83 @@ func TestContainsFold(t *testing.T) {
 		}
 	}
 }
+
+// TestDanglingKeyFile_SecretsMount covers the prefix this predicate used to skip
+// (#4368).
+//
+// The provisioning template seeded key_file=/secrets/gh-app-key.pem for every
+// App-using hive but created that Secret entry only for hives provisioned with
+// an inline private key. Four hives shipped naming a file that would never
+// exist — and because the check looked only at /data/, the detector written for
+// exactly this symptom returned false for all four, so nothing surfaced until
+// the first App call failed.
+func TestDanglingKeyFile_SecretsMount(t *testing.T) {
+	// A missing file under the provisioning mount is dangling. Named uniquely so
+	// the assertion cannot be perturbed by whatever the host has at /secrets.
+	missing := "/secrets/missing-4368-" + t.Name() + ".pem"
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Skipf("%s unexpectedly exists on this host", missing)
+	}
+	if !DanglingKeyFile(GitHubConfig{KeyFile: missing}) {
+		t.Errorf("a missing key under /secrets/ must be dangling; this is the #4368 shape")
+	}
+
+	// An operator path outside both delivery locations is still left alone: they
+	// are entitled to keep a key somewhere this build has never heard of.
+	if DanglingKeyFile(GitHubConfig{KeyFile: "/opt/operator/custom-" + t.Name() + ".pem"}) {
+		t.Error("a path outside /data/ and /secrets/ must not be reported as dangling")
+	}
+
+	// A short path that merely shares a prefix character must not panic or match.
+	for _, short := range []string{"/sec", "/secrets", "/dat", ""} {
+		if DanglingKeyFile(GitHubConfig{KeyFile: short}) {
+			t.Errorf("DanglingKeyFile(%q) = true, want false", short)
+		}
+	}
+}
+
+// TestDanglingKeyFile_SecretsMountExisting proves the widened prefix does not
+// invent a fault when the projected Secret entry IS present — the healthy shape
+// for a hive provisioned with an inline key.
+func TestDanglingKeyFile_SecretsMountExisting(t *testing.T) {
+	dir := "/secrets/test-dangling-4368-" + t.Name()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Skipf("cannot create %s: %v", dir, err)
+	}
+	defer os.RemoveAll(dir)
+
+	existing := filepath.Join(dir, "gh-app-key.pem")
+	if err := os.WriteFile(existing, []byte("pem-data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if DanglingKeyFile(GitHubConfig{KeyFile: existing}) {
+		t.Error("an existing key under /secrets must not be dangling")
+	}
+}
+
+// TestHasPrefix covers the helper DanglingKeyFile's prefix test is built on.
+// The two mount-point tests above can only assert the exists-branch on a host
+// where /data or /secrets is writable, and skip everywhere else — so the prefix
+// logic itself is pinned here, where nothing can skip it.
+func TestHasPrefix(t *testing.T) {
+	tests := []struct {
+		s, prefix string
+		want      bool
+	}{
+		{"/data/gh-app-key.pem", "/data/", true},
+		{"/secrets/gh-app-key.pem", "/secrets/", true},
+		{"/secrets/gh-app-key.pem", "/data/", false},
+		{"/data/gh-app-key.pem", "/secrets/", false},
+		{"/opt/keys/app.pem", "/data/", false},
+		// Shorter than the prefix: must be false, not a slice panic.
+		{"/dat", "/data/", false},
+		{"/secrets", "/secrets/", false},
+		{"", "/data/", false},
+		{"anything", "", true},
+	}
+	for _, tc := range tests {
+		if got := hasPrefix(tc.s, tc.prefix); got != tc.want {
+			t.Errorf("hasPrefix(%q, %q) = %v, want %v", tc.s, tc.prefix, got, tc.want)
+		}
+	}
+}

--- a/src/pkg/config/layers.go
+++ b/src/pkg/config/layers.go
@@ -359,17 +359,35 @@ func gitHubLooksPlaceholder(gh GitHubConfig) bool {
 	return containsFold(gh.KeyFile, "PLACEHOLDER")
 }
 
-// DanglingKeyFile reports whether gh names a PVC key file that does not exist.
+// DanglingKeyFile reports whether gh names a key file, in either of the two
+// locations a hive's App key is ever delivered to, that does not exist.
 // The entrypoint warns rather than fails here, because the alternative is a
 // silent 401 loop against GitHub. Surfaced through provenance so the condition
 // is visible without reading pod logs.
+//
+// BOTH prefixes, not just the PVC (#4368). /secrets is the provisioning mount,
+// and the provisioning template used to seed key_file=/secrets/gh-app-key.pem
+// for every App-using hive while creating that Secret entry only for hives
+// provisioned with an inline private key. Four hives shipped naming a file that
+// would never exist — under the one prefix this predicate did not look at, so
+// the detector written for precisely that symptom returned false for every one
+// of them. A path outside both prefixes is an operator's own location and is
+// left alone: they are entitled to keep a key somewhere this build has never
+// heard of.
 func DanglingKeyFile(gh GitHubConfig) bool {
-	const pvcPrefix = "/data/"
-	if len(gh.KeyFile) < len(pvcPrefix) || gh.KeyFile[:len(pvcPrefix)] != pvcPrefix {
+	if !hasPrefix(gh.KeyFile, "/data/") && !hasPrefix(gh.KeyFile, "/secrets/") {
 		return false
 	}
 	_, err := os.Stat(gh.KeyFile)
 	return os.IsNotExist(err)
+}
+
+// hasPrefix is strings.HasPrefix, spelled out because this file imports only
+// log and os — the same reason the original code compared the prefix by slice
+// rather than calling into strings. Length-checked first, so a KeyFile shorter
+// than the prefix returns false instead of panicking on the slice.
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
 
 // containsFold reports whether s contains substr, ASCII case-insensitively.

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	cryptoRand "crypto/rand"
 	"encoding/base64"
@@ -1834,6 +1835,139 @@ func provisionAdditionalAppKeys(fleetKeys map[int64]fleetAppKey, primaryAppID st
 	return out
 }
 
+// spokeSecretsMountPrefix is where the hive-secrets Secret is projected in the
+// spoke pod. A key_file under this prefix can only resolve to an entry the same
+// manifest puts in that Secret — nothing else ever writes there, because the
+// projection is a read-only tmpfs.
+const spokeSecretsMountPrefix = "/secrets/"
+
+// assertSpokeManifestKeyFile rejects a rendered manifest whose hive.yaml seed
+// pins github.key_file at a /secrets path the SAME manifest does not create.
+//
+// THE BUG THIS EXISTS FOR (#4368)
+//
+// The ConfigMap seed used to emit `key_file: /secrets/gh-app-key.pem` for every
+// App-using hive — gated on UseApp. The hive-secrets Secret creates that entry
+// gated on UseAppFull, which additionally requires an installation_id AND an
+// inline private key at request time. A hive provisioned with an App id but
+// without the key inline (the normal case when the key arrives later through
+// the heartbeat delivery lane) therefore got a seed pointing at a file that
+// would never exist.
+//
+// It then failed in the worst available way. An explicit key_file wins outright
+// in resolveAppKeyFile (cmd/hive/main.go) — deliberately, because a path an
+// operator typed must not be silently redirected — so the key that DID arrive,
+// at /data/gh-app-key-<app_id>.pem, was never even tried. The whole 2026-08-12
+// batch (four hives) reported github_auth: fail with the right key sitting on
+// the PVC, and the hub's own alert text blamed an undelivered key.
+//
+// The template no longer pins key_file at all: it is derivable from app_id, and
+// resolveAppKeyFile's last fallback is /secrets/gh-app-key.pem, so a hive
+// provisioned WITH an inline key still resolves to exactly the file it used to
+// be pinned to. This check is what keeps the coupling from coming back — a
+// future pin is fine, but only if the manifest also creates what it names.
+//
+// Deliberately narrow. Only /secrets paths are checkable at render time: /data
+// is an empty PVC until the first key delivery, so a /data pin is not wrong
+// here, merely unverifiable, and any other path is an operator's own location.
+func assertSpokeManifestKeyFile(manifest string) error {
+	pinned := manifestKeyFilePins(manifest)
+	if len(pinned) == 0 {
+		return nil
+	}
+	created := manifestSecretKeys(manifest, "hive-secrets")
+	for _, p := range pinned {
+		if !strings.HasPrefix(p, spokeSecretsMountPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(p, spokeSecretsMountPrefix)
+		if _, ok := created[name]; !ok {
+			return fmt.Errorf(
+				"hive.yaml seeds github.key_file=%s but the hive-secrets Secret has no %q entry — "+
+					"the spoke would pin an explicit key path that never exists, and an explicit "+
+					"key_file short-circuits the fallback that would otherwise find the delivered key (#4368)",
+				p, name)
+		}
+	}
+	return nil
+}
+
+// manifestKeyFilePins returns every github.key_file value the rendered manifest
+// seeds. Commented-out lines are ignored: the template documents the absent pin
+// in a YAML comment, and a comment is not a pin.
+func manifestKeyFilePins(manifest string) []string {
+	var out []string
+	for _, line := range strings.Split(manifest, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		const key = "key_file:"
+		if !strings.HasPrefix(trimmed, key) {
+			continue
+		}
+		v := strings.TrimSpace(strings.TrimPrefix(trimmed, key))
+		if i := strings.Index(v, " #"); i >= 0 {
+			v = strings.TrimSpace(v[:i])
+		}
+		v = strings.Trim(v, `"'`)
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// manifestSecretKeys returns the data/stringData key names of the named Secret
+// document in a multi-document manifest, as a set.
+//
+// Scoped to one document on purpose: the manifest carries several Secrets
+// (hive-tls among them), and matching a key name against the wrong one would
+// make this assertion agree with something it never checked.
+func manifestSecretKeys(manifest, secretName string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, doc := range strings.Split(manifest, "\n---") {
+		if !strings.Contains(doc, "kind: Secret") {
+			continue
+		}
+		if !strings.Contains(doc, "name: "+secretName+"\n") {
+			continue
+		}
+		inData := false
+		for _, line := range strings.Split(doc, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "data:" || trimmed == "stringData:" {
+				inData = true
+				continue
+			}
+			if !inData {
+				continue
+			}
+			// A non-indented line ends the block.
+			if line != "" && !strings.HasPrefix(line, " ") {
+				inData = false
+				continue
+			}
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			// Entries are exactly two spaces in; anything deeper is a value
+			// continuation line of a block scalar (the PEM bodies).
+			if !strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "   ") {
+				continue
+			}
+			name, _, found := strings.Cut(trimmed, ":")
+			if !found {
+				continue
+			}
+			if name = strings.TrimSpace(name); name != "" {
+				out[name] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
 // fleetKeys carries every GitHub App private key the fleet knows, keyed by
 // app_id, so a freshly provisioned spoke starts life holding ALL of them rather
 // than waiting for the heartbeat's additional-key delivery to catch up. Pass nil
@@ -2081,14 +2215,33 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		return fmt.Errorf("template parse: %w", err)
 	}
 
+	// Render to memory first so the manifest can be CHECKED before it is
+	// applied. #4368 shipped four hives whose seed named a key file the same
+	// manifest never created; the failure was invisible until the first App
+	// call, hours later and on a different machine. Rendering into a buffer
+	// costs nothing here (every value is already in memory in `data`) and is
+	// what makes assertSpokeManifestKeyFile possible at all.
+	var manifestBuf bytes.Buffer
+	if err := tmpl.Execute(&manifestBuf, data); err != nil {
+		return fmt.Errorf("template exec: %w", err)
+	}
+	if err := assertSpokeManifestKeyFile(manifestBuf.String()); err != nil {
+		// Refuse to create a hive that cannot load its own App key. A hive that
+		// never provisions is a visible failure the admin can retry; one that
+		// provisions broken is a silent github_auth: fail nobody looks at until
+		// an agent needs the App.
+		logger.Error("refusing to apply spoke manifest", "hive", h.ID, "error", err)
+		return fmt.Errorf("spoke manifest rejected: %w", err)
+	}
+
 	manifestPath := filepath.Join(dir, "all.yaml")
 	f, err := os.Create(manifestPath)
 	if err != nil {
 		return fmt.Errorf("create manifest: %w", err)
 	}
-	if err := tmpl.Execute(f, data); err != nil {
+	if _, err := f.Write(manifestBuf.Bytes()); err != nil {
 		f.Close()
-		return fmt.Errorf("template exec: %w", err)
+		return fmt.Errorf("write manifest: %w", err)
 	}
 	f.Close()
 
@@ -2452,7 +2605,10 @@ data:
 {{- if .UseApp}}
       app_id: {{.AppID}}
       installation_id: {{.InstallationID}}
-      key_file: /secrets/gh-app-key.pem
+      # key_file is deliberately NOT pinned here: it is derivable from app_id,
+      # and an explicit value short-circuits resolveAppKeyFile before the key
+      # that actually arrived can be found. See assertSpokeManifestKeyFile
+      # below for the full account (#4368).
 {{- else}}
       token: "${HIVE_GITHUB_TOKEN}"
 {{- end}}

--- a/src/pkg/hub/saas_provision_key_file_test.go
+++ b/src/pkg/hub/saas_provision_key_file_test.go
@@ -1,0 +1,184 @@
+package hub
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// #4368: the provisioning seed pinned github.key_file at /secrets/gh-app-key.pem
+// for every App-using hive, while the hive-secrets Secret created that entry only
+// for hives provisioned with an inline private key. The four hives in the
+// 2026-08-12 batch got a config naming a file that would never exist — and
+// because an explicit key_file short-circuits resolveAppKeyFile, the key that
+// DID arrive at /data/gh-app-key-<app_id>.pem was never tried. github_auth: fail
+// with the correct key already on the PVC.
+//
+// These tests render the REAL template, so they fail on the template text rather
+// than on a copy of it.
+
+// renderProvisionManifest executes k8sManifestTemplate with the App-related
+// fields under test and inert values for everything else.
+func renderProvisionManifest(t *testing.T, useApp, useAppFull bool) string {
+	t.Helper()
+	tmpl, err := template.New("manifests").Parse(k8sManifestTemplate)
+	if err != nil {
+		t.Fatalf("template does not parse: %v", err)
+	}
+	data := map[string]any{
+		"ID":                "test-hive",
+		"Namespace":         "hive-hosted-test-hive",
+		"ImageTag":          "v4-latest",
+		"ImagePullPolicy":   "Always",
+		"RequiresSCC":       false,
+		"InitContainerUID":  "1001",
+		"InitContainerGID":  "1000",
+		"TerminalPort":      7681,
+		"DashboardPort":     3002,
+		"CPURequest":        "500m",
+		"MemRequest":        "1Gi",
+		"CPULimit":          "2",
+		"MemLimit":          "4Gi",
+		"StorageSize":       "10Gi",
+		"StorageClass":      "standard",
+		"HeartbeatKey":      "hb",
+		"SessionKey":        "sk",
+		"SSOPublicKey":      "pk",
+		"TerminalKey":       "tk",
+		"DashboardToken":    "dt",
+		"AuthorizedUsers":   "alice:owner",
+		"IsNginxIngress":    false,
+		"Host":              "test-hive.hive.kubestellar.io",
+		"Owner":             "alice",
+		"Org":               "kubestellar",
+		"Repos":             "[]",
+		"PrimaryRepo":       "kubestellar/hive",
+		"HubURL":            "https://hive.kubestellar.io",
+		"DashboardURL":      "https://test-hive.hive.kubestellar.io",
+		"HiveType":          "hosted",
+		"IsPublic":          false,
+		"ACMMLevel":         3,
+		"UseApp":            useApp,
+		"UseAppFull":        useAppFull,
+		"AppID":             3568013,
+		"InstallationID":    "12345",
+		"AppPrivateKey":     "    -----BEGIN RSA PRIVATE KEY-----\n    dGVzdA==\n    -----END RSA PRIVATE KEY-----",
+		"AdditionalAppKeys": []provisionAppKey{},
+		"Token":             "ghp_test",
+		"HasPlaceholderIDs": false,
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template does not execute: %v", err)
+	}
+	return buf.String()
+}
+
+// TestProvisionSeedDoesNotPinKeyFile is the direct regression guard. key_file is
+// derivable from app_id, and resolveAppKeyFile's last fallback is the very path
+// the seed used to name — so a hive provisioned WITH an inline key resolves to
+// the same file it used to be pinned to, and one provisioned without a key can
+// now reach the key that is actually delivered.
+func TestProvisionSeedDoesNotPinKeyFile(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		useApp, useAppFull bool
+	}{
+		{"app-with-inline-key", true, true},
+		{"app-without-inline-key", true, false},
+		{"token-auth", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := renderProvisionManifest(t, tc.useApp, tc.useAppFull)
+			if pins := manifestKeyFilePins(manifest); len(pins) != 0 {
+				t.Errorf("provisioning seed pins github.key_file=%v; it is derivable from app_id "+
+					"and an explicit value short-circuits resolveAppKeyFile (#4368)", pins)
+			}
+		})
+	}
+}
+
+// TestProvisionManifestKeyFileAssertion is the invariant rather than the current
+// value: a future pin is allowed, but only if the manifest also creates the file
+// it names. This is the check that would have stopped the 2026-08-12 batch.
+func TestProvisionManifestKeyFileAssertion(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		useApp, useAppFull bool
+	}{
+		{"app-with-inline-key", true, true},
+		{"app-without-inline-key", true, false},
+		{"token-auth", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := assertSpokeManifestKeyFile(renderProvisionManifest(t, tc.useApp, tc.useAppFull)); err != nil {
+				t.Errorf("rendered manifest rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestProvisionManifestKeyFileAssertionCatchesTheBug reproduces the exact defect
+// by putting the old line back into a rendered manifest, and proves the guard
+// fails it. Without this the assertion could be vacuous and nobody would know.
+func TestProvisionManifestKeyFileAssertionCatchesTheBug(t *testing.T) {
+	// UseApp without UseAppFull: app_id present, no inline key, so the Secret
+	// carries no gh-app-key.pem entry. This is the 2026-08-12 shape.
+	manifest := renderProvisionManifest(t, true, false)
+	if strings.Contains(manifest, "gh-app-key.pem:") {
+		t.Fatal("fixture is wrong: a hive provisioned without an inline key must not get a gh-app-key.pem Secret entry")
+	}
+	broken := strings.Replace(manifest,
+		"      installation_id: 12345",
+		"      installation_id: 12345\n      key_file: /secrets/gh-app-key.pem", 1)
+	if broken == manifest {
+		t.Fatal("could not inject the historical key_file pin — the seed's shape changed")
+	}
+
+	err := assertSpokeManifestKeyFile(broken)
+	if err == nil {
+		t.Fatal("assertSpokeManifestKeyFile accepted a seed pinning /secrets/gh-app-key.pem " +
+			"when the manifest creates no such Secret entry — this is exactly #4368")
+	}
+	if !strings.Contains(err.Error(), "gh-app-key.pem") {
+		t.Errorf("error does not name the missing entry: %v", err)
+	}
+
+	// The same pin is legitimate when the manifest DOES create the file, which
+	// keeps the guard about the coupling rather than about the literal path.
+	full := renderProvisionManifest(t, true, true)
+	if !strings.Contains(full, "gh-app-key.pem: |") {
+		t.Fatal("fixture is wrong: a hive provisioned WITH an inline key must get a gh-app-key.pem Secret entry")
+	}
+	okPin := strings.Replace(full,
+		"      installation_id: 12345",
+		"      installation_id: 12345\n      key_file: /secrets/gh-app-key.pem", 1)
+	if err := assertSpokeManifestKeyFile(okPin); err != nil {
+		t.Errorf("a pin the manifest actually creates was rejected: %v", err)
+	}
+}
+
+// TestManifestSecretKeysScopedToHiveSecrets pins the scoping. The manifest holds
+// several Secrets; reading key names out of the wrong one would make the
+// assertion above agree with something it never checked.
+func TestManifestSecretKeysScopedToHiveSecrets(t *testing.T) {
+	manifest := renderProvisionManifest(t, true, true)
+	keys := manifestSecretKeys(manifest, "hive-secrets")
+	if _, ok := keys["gh-app-key.pem"]; !ok {
+		t.Errorf("hive-secrets keys %v do not include gh-app-key.pem", keys)
+	}
+	if _, ok := keys["dashboard-token"]; !ok {
+		t.Errorf("hive-secrets keys %v do not include dashboard-token", keys)
+	}
+	// PEM body lines are indented further than an entry name and must not be
+	// mistaken for one.
+	for k := range keys {
+		if strings.Contains(k, "BEGIN") || strings.Contains(k, "END") {
+			t.Errorf("PEM body line %q was read as a Secret key name", k)
+		}
+	}
+	if len(manifestSecretKeys(manifest, "no-such-secret")) != 0 {
+		t.Error("manifestSecretKeys matched a Secret that does not exist")
+	}
+}


### PR DESCRIPTION
Fixes #4368.

## The bug is a coupling written twice

The spoke ConfigMap seeds `key_file` gated on **`UseApp`**:

```yaml
{{- if .UseApp}}
      app_id: {{.AppID}}
      installation_id: {{.InstallationID}}
      key_file: /secrets/gh-app-key.pem      # ← was here
```

The `hive-secrets` Secret creates that entry gated on **`UseAppFull`**:

```go
useApp     := req.AuthMethod == "app" && req.AppID != ""
useAppFull := useApp && req.InstallationID != "" && req.AppPrivateKey != ""
```

So a hive provisioned with an App id but **without the key inline** — the normal case, since the key usually arrives later through the heartbeat delivery lane — got a config naming a file that would never exist. Two conditions on one fact, in two places, free to disagree. They did, for the whole 2026-08-12 batch.

It then failed in the worst available way. An explicit `key_file` wins outright in `resolveAppKeyFile` — deliberately, because a path an operator typed must not be silently redirected — so the key that **did** arrive, at `/data/gh-app-key-<app_id>.pem`, was never even tried. Four hives reporting `github_auth: fail` with the correct key sitting on the PVC, and the hub's alert blaming an undelivered key.

## The fix: don't pin it (option 1 in the issue)

`key_file` is derivable from `app_id`. That is not my opinion — it is the position `cmd/hive/main.go` already takes, at the point where it refuses to persist the path after a delivery:

> `Deliberately NOT cfg.GitHub.KeyFile = keyPath.` … *key_file is DERIVABLE from app_id … Persisting the path turns a derived value into a stored one that outlives the App it was derived for.*

Provisioning was the last writer still pinning it.

**Nothing regresses for a hive provisioned *with* an inline key.** `resolveAppKeyFile`'s final fallback is `/secrets/gh-app-key.pem` — literally the path that was being pinned — so those hives resolve to exactly the same file. The only behaviour that changes is the case that was broken, where the chain now reaches the delivered key instead of stopping at a path that does not exist.

## Making it unrepresentable

`provisionHive` now renders the manifest to a buffer and runs `assertSpokeManifestKeyFile` **before** `kubectl apply`. A future pin is fine — but only if the manifest also creates what it names; otherwise provisioning fails loudly.

That is deliberate about which failure is preferable: a hive that never provisions is a visible error an admin retries, whereas one that provisions broken is a `github_auth: fail` nobody looks at until an agent needs the App. This is the issue's suggested post-provision assertion, moved to the one moment when both halves of the coupling are in the same place. The check is narrow on purpose — only `/secrets` paths are verifiable at render time; `/data` is an empty PVC until first delivery, and anything else is an operator's own location.

## The detector that should have caught this

Both dangling-`key_file` checks looked only at `/data/`:

| | before | after |
|---|---|---|
| `src/deploy/entrypoint.sh` boot warning | `key_file.startswith('/data/')` | `('/data/', '/secrets/')` |
| `config.DanglingKeyFile` | `const pvcPrefix = "/data/"` | both delivery locations |

The four hives named a path under `/secrets/` — the one prefix neither examined. The check written for precisely this symptom returned false for every one of them, and nothing surfaced until the first App call. A path outside both prefixes is still left alone: an operator may keep a key somewhere this build has never heard of.

## One more raw reader

The config-reload rebuild in `main.go` gated on `cfg.GitHub.KeyFile != ""` and passed the raw value to `NewAppAuth`. An unset `key_file` is the correct steady state on a hosted spoke, so that path skipped the rebuild on exactly the hives that need it — a corrected `installation_id` saved to `hive.yaml` kept minting tokens for the old installation until the pod restarted.

Startup, the heartbeat rebuild, and the dashboard's Set ID handler all already resolve; this was the last one that did not. The identical bug with the identical cause was fixed in the dashboard handler under #2459, whose comment describes this exact scenario. Not strictly required by the template change — but it is the path that an unset `key_file` now travels on every newly provisioned hive, so shipping the template change without it would have widened a live latent fault.

## Verified

- **New Go tests render the real template.** No pin in any of the three provisioning shapes (app+inline key, app without inline key, token auth); the guard accepts all three; and the load-bearing one — injecting the historical `key_file: /secrets/gh-app-key.pem` line into a manifest that creates no such Secret entry is **rejected**, while the same pin against a manifest that *does* create it is accepted. Without that last case the assertion could be vacuous and nobody would know.
- **`src/deploy/test_entrypoint_dangling_keyfile.sh`** extracts the real python merge block from the shipped `entrypoint.sh` and executes it against fixtures, following the convention `test_entrypoint_runtime_config.sh` set. It **fails against the unpatched entrypoint** on exactly the `/secrets` case (`4 passed, 1 failed`) and passes after — a regression test, not a description. Wired into `v2-ci.yml`.
- `go build ./...`, `go vet ./...`, `gofmt`, `shellcheck -x` all clean.
- `./pkg/hub` (92s, full) and `./cmd/hive` pass in full. `pkg/config`'s `TestGateFailsClosedWithoutIP6Tables` fails identically on unmodified `upstream/v4` in this environment — it needs root/NET_ADMIN — so it is pre-existing and unrelated; I checked rather than assumed.

## Not fixed here

The four live hives still need their configs repaired offline; this stops the next batch being created broken. `8yiz` additionally has its repo missing from the App installation, which #4368 records as an independent fault.

Part of the hosted-provisioning correctness work; does not close any parent.

— hive: backend=claude model=claude-opus-5
