### PR TITLE
✨ feat(hub): show a country flag beside the user's avatar

### DIFF
--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -538,6 +538,13 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	if displayName != "" {
 		saasUser.DisplayName = displayName
 	}
+	// Best-effort country inference, source 2 of 2 (see user_country.go). Reads
+	// only the Accept-Language header this request already carried — no IP
+	// geolocation, no third-party lookup, nothing sent off-box — and fills the
+	// field ONLY when the record has none, so an explicit pick in the wizard is
+	// never overwritten by a browser's language setting. Cannot fail: with no
+	// region subtag it stores nothing and no flag renders.
+	applyInferredCountry(saasUser, r)
 	// A completed callback IS a login — count it here and nowhere else.
 	// ensureSaaSUser already refreshed LastLogin; the count is the engagement
 	// signal the admin Users card reads. Persist unconditionally below so a login
@@ -944,6 +951,15 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	setSessionCookies(w, r, sessionValue)
 	isAdmin := isHubAdmin(username)
 	displayLogin, avatar := s.displayIdentity(username)
+	// The viewer's own country, for the flag beside their nav avatar. Sent as
+	// the alpha-2 CODE, not the glyph, so the dashboard derives the emoji the
+	// same way every other render site does — and so an empty value is
+	// unambiguously "we do not know" rather than an empty-looking glyph.
+	// Absent from the payload entirely when unset (omitted below).
+	var country string
+	if u := loadSaaSUser(username); u != nil {
+		country = normalizeCountryCode(u.Country)
+	}
 	// Fold impersonation status into the auth payload the dashboard already
 	// fetches, so the "Viewing as … read-only" banner renders without a second
 	// round-trip. When an admin is impersonating, report the effective identity
@@ -956,11 +972,27 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		"avatar_url":    avatar,
 		"hub_admin":     isAdmin,
 	}
+	// Only ship the key when there is a country to ship. An absent key and an
+	// empty string both render no flag, but omitting it keeps the payload for
+	// the (currently vast) majority of users byte-identical to before.
+	if country != "" {
+		payload["country"] = country
+	}
 	if grant, ok := s.activeImpersonationGrant(r); ok {
 		targetLogin, targetAvatar := s.displayIdentity(grant.Target)
 		payload["login"] = targetLogin
 		payload["avatar_url"] = targetAvatar
 		payload["hub_admin"] = false
+		// Every per-user view renders AS the target, so the flag must follow the
+		// target too — otherwise the admin's own flag would sit beside the
+		// impersonated user's face. Delete rather than blank it when the target
+		// has no country, so no stale flag survives the swap.
+		delete(payload, "country")
+		if tu := loadSaaSUser(grant.Target); tu != nil {
+			if tc := normalizeCountryCode(tu.Country); tc != "" {
+				payload["country"] = tc
+			}
+		}
 		payload["impersonating"] = true
 		payload["viewing_as"] = targetLogin
 		payload["real_user"] = displayLogin

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -318,6 +318,23 @@ type SaaSUser struct {
 	SlackID  string `json:"slack_id,omitempty"`
 	Notes    string `json:"notes,omitempty"`
 
+	// Country is an OPTIONAL ISO 3166-1 alpha-2 code (uppercase, e.g. "GB"),
+	// rendered as a small flag beside the user's avatar. Two sources, in
+	// priority order: the explicit dropdown in the get-started wizard (copied
+	// here on approval, like FullName/SlackID above), else a best-effort
+	// inference from the Accept-Language region subtag at login, which only
+	// ever fills an EMPTY value. See user_country.go for the full rationale and
+	// the privacy posture.
+	//
+	// Stored as the code, never as the glyph: the flag is derived at render
+	// time from regional-indicator code points, so no external image host is
+	// involved and an unknown country renders nothing at all.
+	//
+	// omitempty so the thousands of existing records on the PVC round-trip
+	// byte-identical until a user actually picks a country or logs in from a
+	// browser that states a region.
+	Country string `json:"country,omitempty"`
+
 	// Engagement stats, admin-only (they ride /api/saas/admin/users, which is
 	// requireAdmin). Both omitempty ints so existing records round-trip
 	// byte-identical until the user first logs in / opens a hive after this ships.
@@ -6876,6 +6893,18 @@ type ProvisionRequest struct {
 	FullName string `json:"full_name,omitempty"`
 	SlackID  string `json:"slack_id,omitempty"`
 
+	// Country is the requester's OPTIONAL self-declared ISO 3166-1 alpha-2
+	// code, picked from the wizard's dropdown. Like the two fields above it
+	// reuses the SaaSUser key of the same name and is copied onto the user
+	// record on approval (applyRequestContactToUser) — asking and then dropping
+	// the answer would be worse than not asking.
+	//
+	// This is the AUTHORITATIVE source of a user's country: they chose it about
+	// themselves. The Accept-Language inference on the login path is only a
+	// fallback for records that never got one. omitempty so requests filed
+	// before this field existed round-trip unchanged.
+	Country string `json:"country,omitempty"`
+
 	// Decision audit. Previously a request only carried its final Status, so
 	// once it left "pending" there was no record of WHO decided, WHEN, or —
 	// for an approval — which hive the requester actually got. That made the
@@ -7020,6 +7049,13 @@ func applyRequestContactToUser(user *SaaSUser, pr *ProvisionRequest) {
 	if user.SlackID == "" && pr.SlackID != "" {
 		user.SlackID = truncateRunes(strings.TrimSpace(pr.SlackID), maxContactSlackIDLen)
 	}
+	// The explicit pick outranks anything Accept-Language inferred at login, so
+	// unlike the two fields above this one overwrites a value already on the
+	// record — but only when the request actually carries a choice. Re-normalize
+	// rather than trusting the stored request: it may predate the validation.
+	if code := normalizeCountryCode(pr.Country); code != "" {
+		user.Country = code
+	}
 }
 
 func loadProvisionRequest(username string) *ProvisionRequest {
@@ -7105,6 +7141,7 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		AuthMethod  string `json:"auth_method"`
 		FullName    string `json:"full_name"`
 		SlackID     string `json:"slack_id"`
+		Country     string `json:"country"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
@@ -7127,6 +7164,12 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 	// check, not a regex.
 	body.FullName = truncateRunes(strings.TrimSpace(body.FullName), maxContactNameLen)
 	body.SlackID = truncateRunes(strings.TrimSpace(body.SlackID), maxContactSlackIDLen)
+	// Country is OPTIONAL and normalized rather than rejected: a malformed or
+	// absent code stores "", which renders no flag at all. Validating here (the
+	// last point before the PVC) means the render sites can trust that a stored
+	// country is two uppercase letters, and a client that never sends the field
+	// behaves exactly as before this shipped.
+	body.Country = normalizeCountryCode(body.Country)
 	// Accept a pasted org/repo URL, not just a bare name. Users read
 	// "GitHub Organization" and paste the org's URL; the old validator rejected
 	// ":" and "/" and returned a bare "invalid org name" that explained nothing.
@@ -7256,6 +7299,7 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		AuthMethod:  body.AuthMethod,
 		FullName:    body.FullName,
 		SlackID:     body.SlackID,
+		Country:     body.Country,
 		RequestedAt: time.Now().UTC().Format(time.RFC3339),
 		Status:      provisionStatusPending,
 	}
@@ -9011,6 +9055,12 @@ const dashboardHTML = `<!DOCTYPE html>
     .header-right { display: flex; align-items: center; gap: .8rem; justify-self: end; }
     .nav-user { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; color: var(--text); }
     .nav-avatar { width: 28px; height: 28px; border-radius: 50%; }
+    /* The country flag beside an avatar. Sized just under the surrounding text
+       so it reads as a marker rather than as a second avatar, and given a fixed
+       line-height so a tall emoji cannot stretch the row it sits in. No color
+       of our own — the glyph carries its own, and the box is transparent, so
+       this behaves identically in light and dark. */
+    .country-flag { font-size: 0.95rem; line-height: 1; vertical-align: middle; margin-left: 2px; }
 
     /* ── Layout ── */
     .content { max-width: 1600px; margin: 0 auto; padding: 2.5rem clamp(1rem, 4vw, 4.5rem) 3rem; }
@@ -9710,6 +9760,57 @@ const dashboardHTML = `<!DOCTYPE html>
           'onerror="this.onerror=null;this.src=' + jsArg(avatarInitialsSVG(label, px)) + '">';
       }
       return '<img src="' + escAttr(avatarInitialsSVG(label, px)) + '" alt="" style="' + style + '">';
+    }
+
+    /* ---- Country flag ---------------------------------------------------
+       A user's OPTIONAL country renders as a small flag beside their avatar.
+
+       The glyph is DERIVED from the stored ISO 3166-1 alpha-2 code, never
+       fetched: a flag emoji is just the two regional-indicator code points for
+       the code's letters (REGIONAL INDICATOR SYMBOL LETTER A is U+1F1E6), so
+       the hub needs no image assets and no external image host.
+
+       Mirrors normalizeCountryCode / countryFlagEmoji in user_country.go. The
+       server already normalizes before storing, so this is defence in depth for
+       a legacy record or a hand-edited file — and it is what guarantees the
+       render sites can never emit half a code point.
+
+       Unknown or unset country renders NOTHING. No globe placeholder, no "??"
+       box: absence of evidence must look like absence, not like a broken flag. */
+    var REGIONAL_INDICATOR_BASE = 0x1F1E6;  /* U+1F1E6 REGIONAL INDICATOR SYMBOL LETTER A */
+    var COUNTRY_CODE_LEN = 2;               /* ISO 3166-1 alpha-2 */
+
+    function normalizeCountryCode(code) {
+      var c = String(code == null ? '' : code).trim().toUpperCase();
+      if (c.length !== COUNTRY_CODE_LEN) return '';
+      /* Shape check only — two ASCII letters. The hub does not adjudicate which
+         territories exist; it just refuses anything that would break a render. */
+      if (!/^[A-Z]{2}$/.test(c)) return '';
+      return c;
+    }
+
+    function countryFlagEmoji(code) {
+      var c = normalizeCountryCode(code);
+      if (!c) return '';
+      return String.fromCodePoint(
+        REGIONAL_INDICATOR_BASE + (c.charCodeAt(0) - 65),
+        REGIONAL_INDICATOR_BASE + (c.charCodeAt(1) - 65));
+    }
+
+    /* countryFlagHTML: the flag as an inline <span>, or '' when there is no
+       country. Every caller appends the result unconditionally, so returning ''
+       is what makes an unknown country render as silence.
+
+       The code is escaped into the title/aria-label even though it is already
+       normalized to [A-Z]{2} — the render path must not depend on the validator
+       upstream of it staying correct. Colors come from theme tokens; the glyph
+       is the emoji's own, so only the sizing is ours. */
+    function countryFlagHTML(code) {
+      var c = normalizeCountryCode(code);
+      if (!c) return '';
+      var glyph = countryFlagEmoji(c);
+      return '<span class="country-flag" title="' + escAttr(c) + '" ' +
+        'role="img" aria-label="' + escAttr(c) + '">' + glyph + '</span>';
     }
 
     /* Rendered avatar sizes, in CSS pixels, one per surface. They differ because
@@ -11072,6 +11173,11 @@ const dashboardHTML = `<!DOCTYPE html>
             avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,
               '<img src="' + escAttr(data.avatar_url) + '" class="nav-avatar" alt="" ' +
               'onerror="this.onerror=null;this.src=' + jsArg(avatarInitialsSVG(data.login, NAV_AVATAR_PX)) + '">') +
+            /* The viewer's country flag, immediately after their face. Empty
+               string when the auth payload carries no country — which is the
+               common case today — so the nav renders exactly as before for a
+               user whose country is unknown. */
+            countryFlagHTML(data.country) +
             '<span style="font-size:0.85rem">' + esc(data.login) + '</span>' +
             '<span style="font-size:0.65rem;color:var(--muted);margin-left:6px">' + roleText + '</span>';
         }

--- a/src/pkg/hub/static/get-started.html
+++ b/src/pkg/hub/static/get-started.html
@@ -414,6 +414,26 @@
             &mdash; leave it blank and we will use GitHub instead.
           </p>
         </div>
+        <!-- Country is OPTIONAL and self-declared. It is the AUTHORITATIVE
+             source for the flag shown beside your avatar: the hub otherwise
+             falls back to a best-effort guess from your browser's language
+             setting, which is a hint about a language, not about a person. An
+             explicit pick here replaces that guess; leaving it blank shows no
+             flag at all rather than a wrong one. Options are filled by
+             populateCountrySelect() so the code carries one list, not two. -->
+        <div style="margin-top:1rem">
+          <label for="req-country" style="display:block;font-size:0.86rem;color:var(--muted);margin-bottom:6px">
+            Country <span style="color:var(--muted);font-weight:400">(optional)</span>
+          </label>
+          <select id="req-country" onchange="updateSummary()"
+            style="width:100%;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
+            <option value="">Prefer not to say</option>
+          </select>
+          <p style="font-size:0.8rem;margin-top:6px;margin-bottom:0">
+            Shows a small flag next to your avatar in the hub. Leave it blank and we show none &mdash;
+            we will not guess a country we have no evidence for.
+          </p>
+        </div>
         <div id="contact-err" style="display:none;margin-top:8px;font-size:0.8rem;color:var(--red)"></div>
 
         <div id="request-summary" style="margin:20px 0;padding:16px;background:#080b0f85;border:1px solid var(--line);border-radius:.7rem;font-size:0.85rem">
@@ -423,6 +443,7 @@
           <div style="color:var(--muted)">ACMM Level: <span id="summary-acmm" style="color:var(--text)"></span></div>
           <div style="color:var(--muted)">Name: <span id="summary-name" style="color:var(--text)">&mdash;</span></div>
           <div style="color:var(--muted)">Slack ID: <span id="summary-slack" style="color:var(--text)">&mdash;</span></div>
+          <div style="color:var(--muted)">Country: <span id="summary-country" style="color:var(--text)">&mdash;</span></div>
         </div>
         <!-- The wizard no longer asks anyone to install the GitHub App. This
              note is the handoff to where that now happens: after provisioning,
@@ -614,6 +635,17 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
       var sl = contactValue('req-slack-id', CONTACT_MAX_SLACK);
       document.getElementById('summary-name').textContent = nm || em;
       document.getElementById('summary-slack').textContent = sl || em;
+      /* Country reads back as "flag Name", or the em-dash when nothing was
+         picked — the same "no evidence renders as nothing" rule the hub uses. */
+      var ctryEl = document.getElementById('summary-country');
+      if (ctryEl) {
+        var cc = selectedCountry();
+        var cname = '';
+        for (var ci = 0; ci < COUNTRIES.length; ci++) {
+          if (COUNTRIES[ci][0] === cc) { cname = COUNTRIES[ci][1]; break; }
+        }
+        ctryEl.textContent = cc ? (countryFlagEmoji(cc) + ' ' + cname) : em;
+      }
       // Surface the forge so the choice is explicit before the user submits — a
       // GHE host (from a pasted enterprise repo URL) reads "github.ibm.com", a
       // plain github.com request reads "github.com". Never blank/ambiguous.
@@ -746,6 +778,98 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
       return ((el && el.value) || '').trim().slice(0, cap);
     }
 
+    /* ---- Country (optional, self-declared) ------------------------------
+       The list is ISO 3166-1 alpha-2 code + English name. It is deliberately
+       DATA, not markup: 200-odd hand-written <option> tags would be unreadable
+       and would drift from the codes the server validates.
+
+       The flag glyph beside each name is derived from the code itself — a flag
+       emoji is the two regional-indicator code points for its letters (U+1F1E6
+       is REGIONAL INDICATOR SYMBOL LETTER A) — so the wizard, like the
+       dashboard, needs no flag images and no external host. Mirrors
+       countryFlagEmoji in pkg/hub/user_country.go. */
+    var REGIONAL_INDICATOR_BASE = 0x1F1E6;
+    function countryFlagEmoji(code) {
+      var c = String(code || '').trim().toUpperCase();
+      if (!/^[A-Z]{2}$/.test(c)) return '';
+      return String.fromCodePoint(
+        REGIONAL_INDICATOR_BASE + (c.charCodeAt(0) - 65),
+        REGIONAL_INDICATOR_BASE + (c.charCodeAt(1) - 65));
+    }
+
+    var COUNTRIES = [
+      ['AD','Andorra'],['AE','United Arab Emirates'],['AF','Afghanistan'],['AG','Antigua and Barbuda'],
+      ['AL','Albania'],['AM','Armenia'],['AO','Angola'],['AR','Argentina'],['AT','Austria'],
+      ['AU','Australia'],['AZ','Azerbaijan'],['BA','Bosnia and Herzegovina'],['BB','Barbados'],
+      ['BD','Bangladesh'],['BE','Belgium'],['BF','Burkina Faso'],['BG','Bulgaria'],['BH','Bahrain'],
+      ['BI','Burundi'],['BJ','Benin'],['BN','Brunei'],['BO','Bolivia'],['BR','Brazil'],['BS','Bahamas'],
+      ['BT','Bhutan'],['BW','Botswana'],['BY','Belarus'],['BZ','Belize'],['CA','Canada'],
+      ['CD','Congo (DRC)'],['CF','Central African Republic'],['CG','Congo'],['CH','Switzerland'],
+      ['CI','Côte d\'Ivoire'],['CL','Chile'],['CM','Cameroon'],['CN','China'],['CO','Colombia'],
+      ['CR','Costa Rica'],['CU','Cuba'],['CV','Cabo Verde'],['CY','Cyprus'],['CZ','Czechia'],
+      ['DE','Germany'],['DJ','Djibouti'],['DK','Denmark'],['DM','Dominica'],['DO','Dominican Republic'],
+      ['DZ','Algeria'],['EC','Ecuador'],['EE','Estonia'],['EG','Egypt'],['ER','Eritrea'],['ES','Spain'],
+      ['ET','Ethiopia'],['FI','Finland'],['FJ','Fiji'],['FM','Micronesia'],['FR','France'],['GA','Gabon'],
+      ['GB','United Kingdom'],['GD','Grenada'],['GE','Georgia'],['GH','Ghana'],['GM','Gambia'],
+      ['GN','Guinea'],['GQ','Equatorial Guinea'],['GR','Greece'],['GT','Guatemala'],['GW','Guinea-Bissau'],
+      ['GY','Guyana'],['HK','Hong Kong'],['HN','Honduras'],['HR','Croatia'],['HT','Haiti'],['HU','Hungary'],
+      ['ID','Indonesia'],['IE','Ireland'],['IL','Israel'],['IN','India'],['IQ','Iraq'],['IR','Iran'],
+      ['IS','Iceland'],['IT','Italy'],['JM','Jamaica'],['JO','Jordan'],['JP','Japan'],['KE','Kenya'],
+      ['KG','Kyrgyzstan'],['KH','Cambodia'],['KI','Kiribati'],['KM','Comoros'],['KN','Saint Kitts and Nevis'],
+      ['KP','North Korea'],['KR','South Korea'],['KW','Kuwait'],['KZ','Kazakhstan'],['LA','Laos'],
+      ['LB','Lebanon'],['LC','Saint Lucia'],['LI','Liechtenstein'],['LK','Sri Lanka'],['LR','Liberia'],
+      ['LS','Lesotho'],['LT','Lithuania'],['LU','Luxembourg'],['LV','Latvia'],['LY','Libya'],
+      ['MA','Morocco'],['MC','Monaco'],['MD','Moldova'],['ME','Montenegro'],['MG','Madagascar'],
+      ['MH','Marshall Islands'],['MK','North Macedonia'],['ML','Mali'],['MM','Myanmar'],['MN','Mongolia'],
+      ['MR','Mauritania'],['MT','Malta'],['MU','Mauritius'],['MV','Maldives'],['MW','Malawi'],
+      ['MX','Mexico'],['MY','Malaysia'],['MZ','Mozambique'],['NA','Namibia'],['NE','Niger'],
+      ['NG','Nigeria'],['NI','Nicaragua'],['NL','Netherlands'],['NO','Norway'],['NP','Nepal'],
+      ['NR','Nauru'],['NZ','New Zealand'],['OM','Oman'],['PA','Panama'],['PE','Peru'],
+      ['PG','Papua New Guinea'],['PH','Philippines'],['PK','Pakistan'],['PL','Poland'],['PS','Palestine'],
+      ['PT','Portugal'],['PW','Palau'],['PY','Paraguay'],['QA','Qatar'],['RO','Romania'],['RS','Serbia'],
+      ['RU','Russia'],['RW','Rwanda'],['SA','Saudi Arabia'],['SB','Solomon Islands'],['SC','Seychelles'],
+      ['SD','Sudan'],['SE','Sweden'],['SG','Singapore'],['SI','Slovenia'],['SK','Slovakia'],
+      ['SL','Sierra Leone'],['SM','San Marino'],['SN','Senegal'],['SO','Somalia'],['SR','Suriname'],
+      ['SS','South Sudan'],['ST','Sao Tome and Principe'],['SV','El Salvador'],['SY','Syria'],
+      ['SZ','Eswatini'],['TD','Chad'],['TG','Togo'],['TH','Thailand'],['TJ','Tajikistan'],
+      ['TL','Timor-Leste'],['TM','Turkmenistan'],['TN','Tunisia'],['TO','Tonga'],['TR','Türkiye'],
+      ['TT','Trinidad and Tobago'],['TV','Tuvalu'],['TW','Taiwan'],['TZ','Tanzania'],['UA','Ukraine'],
+      ['UG','Uganda'],['US','United States'],['UY','Uruguay'],['UZ','Uzbekistan'],['VA','Holy See'],
+      ['VC','Saint Vincent and the Grenadines'],['VE','Venezuela'],['VN','Vietnam'],['VU','Vanuatu'],
+      ['WS','Samoa'],['XK','Kosovo'],['YE','Yemen'],['ZA','South Africa'],['ZM','Zambia'],['ZW','Zimbabwe']
+    ];
+
+    /* Fill the country <select>. Built with createElement + textContent rather
+       than an innerHTML string: the names are static, but building options as
+       DOM keeps the one free-text-shaped surface in this wizard out of the
+       markup parser for good.
+
+       The blank "Prefer not to say" option is already in the markup and stays
+       SELECTED — the wizard never preselects a country. Preselecting one from
+       the browser's locale would turn a guess into something the user appears
+       to have declared, which is exactly the failure this feature avoids. */
+    function populateCountrySelect() {
+      var sel = document.getElementById('req-country');
+      if (!sel) return;
+      for (var i = 0; i < COUNTRIES.length; i++) {
+        var code = COUNTRIES[i][0], name = COUNTRIES[i][1];
+        var opt = document.createElement('option');
+        opt.value = code;
+        var flag = countryFlagEmoji(code);
+        opt.textContent = (flag ? flag + '  ' : '') + name;
+        sel.appendChild(opt);
+      }
+    }
+
+    /* The selected alpha-2 code, or '' for "prefer not to say". Validated to
+       the same shape the server enforces, so a tampered <option> value cannot
+       put anything else in the request body. */
+    function selectedCountry() {
+      var sel = document.getElementById('req-country');
+      var c = ((sel && sel.value) || '').trim().toUpperCase();
+      return /^[A-Z]{2}$/.test(c) ? c : '';
+    }
+
     function clearRepoError() {
       var err = document.getElementById('repo-manual-err');
       if (err) err.style.display = 'none';
@@ -875,7 +999,11 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
             // the hub copies these onto the user record, which is what the
             // admin users panel and the Slack sender read.
             full_name: fullName,
-            slack_id: slackID
+            slack_id: slackID,
+            // Optional, and sent in the JSON BODY — never as a query parameter.
+            // Country is personal data and a URL is the one place it would end
+            // up in access logs, Referer headers and browser history.
+            country: selectedCountry()
           })
         });
         var data = await resp.json();
@@ -895,9 +1023,25 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
       }
     }
 
+    /* Fill the country list once, at load, before any auth answer arrives — the
+       dropdown is inert markup until it has options and does not depend on
+       being signed in. */
+    populateCountrySelect();
+
     fetch('/api/auth/user').then(function(r) { return r.json(); }).then(function(d) {
       if (d.authenticated) {
         _user = d;
+        /* Preselect the country the hub ALREADY holds for this user, so the
+           wizard shows what is on file rather than silently re-asking. That
+           value may itself be the Accept-Language inference — which is the
+           point: it puts the guess in front of the person who can correct it,
+           and submitting turns it into an explicit, authoritative choice.
+           Absent country leaves "Prefer not to say" selected. */
+        var ctrySel = document.getElementById('req-country');
+        if (ctrySel && /^[A-Za-z]{2}$/.test(String(d.country || ''))) {
+          ctrySel.value = String(d.country).toUpperCase();
+          updateSummary();
+        }
         document.getElementById('nav-login').style.display = 'none';
         document.getElementById('nav-logout').style.display = '';
         document.getElementById('nav-dashboard').style.display = '';

--- a/src/pkg/hub/user_country.go
+++ b/src/pkg/hub/user_country.go
@@ -1,0 +1,181 @@
+package hub
+
+import (
+	"net/http"
+	"strings"
+)
+
+// User country: an OPTIONAL ISO 3166-1 alpha-2 code on a hub user record, shown
+// as a small flag beside their avatar.
+//
+// Two sources, in strict priority order:
+//
+//  1. EXPLICIT — the requester picks a country in the get-started wizard
+//     (ProvisionRequest.Country), which is copied onto the SaaSUser record on
+//     approval alongside the other contact fields. This is the authoritative
+//     source: the user chose it about themselves.
+//  2. INFERRED — best-effort, from the region subtag of the browser's
+//     Accept-Language header on a completed login. Only ever fills a record
+//     that has NO country yet, and never overwrites an explicit choice.
+//
+// PRIVACY. Country is personal data, so the inference is deliberately the
+// weakest thing that works:
+//
+//   - Accept-Language is already on the request. Nothing new is collected, no
+//     IP is geolocated, no third-party geo/analytics service is called, and no
+//     user identifier leaves the box. A GeoIP database or a lookup API would
+//     each have been a new dependency shipping user data (or a user's IP) off
+//     the hub, so neither is used — see the PR description.
+//   - It is a language preference, not a location. "en-GB" says the browser
+//     asked for British English, which is evidence of a GB association but is
+//     not proof the person is in GB. That is exactly why it is the FALLBACK
+//     and the dropdown is the authority, and why a bare "en" (no region)
+//     infers nothing at all rather than guessing US.
+//   - The value is never put in a URL query string; it rides JSON bodies and
+//     the user's own record.
+//   - Inference is non-blocking: parseAcceptLanguageCountry cannot fail a
+//     login. It returns "" for anything it does not understand and the login
+//     proceeds exactly as before.
+//
+// The stored form is the two-letter code; the flag glyph is derived at render
+// time from regional-indicator code points, so the hub never depends on an
+// external image host for a flag.
+
+// countryCodeLen is the length of an ISO 3166-1 alpha-2 code. Named because it
+// is load-bearing in three places (validation, the emoji derivation, and the
+// Accept-Language region check), not because two is hard to read.
+const countryCodeLen = 2
+
+// regionalIndicatorBase is the Unicode code point of REGIONAL INDICATOR SYMBOL
+// LETTER A (U+1F1E6). A flag emoji is the two regional indicators for the
+// country's alpha-2 letters, so the glyph for "GB" is the pair at base+('G'-'A')
+// and base+('B'-'A'). This is why no image asset is needed.
+const regionalIndicatorBase = 0x1F1E6
+
+// normalizeCountryCode validates an ISO 3166-1 alpha-2 code and returns it
+// upper-cased, or "" if it is not two ASCII letters.
+//
+// Deliberately a SHAPE check, not a membership check against a list of assigned
+// codes: the hub does not need to adjudicate which territories exist, the list
+// changes over time, and an unassigned-but-well-formed code renders a harmless
+// pair of regional indicators. What this does reject is everything that would
+// break a render or a filename — digits, punctuation, whitespace, and any
+// length other than two.
+func normalizeCountryCode(code string) string {
+	code = strings.TrimSpace(code)
+	if len(code) != countryCodeLen {
+		return ""
+	}
+	code = strings.ToUpper(code)
+	for _, r := range code {
+		if r < 'A' || r > 'Z' {
+			return ""
+		}
+	}
+	return code
+}
+
+// countryFlagEmoji returns the regional-indicator flag glyph for an alpha-2
+// code, or "" when the code is not usable.
+//
+// Empty in, empty out is the load-bearing case: an unknown or unset country
+// must render NOTHING — no globe placeholder, no "??" box, no tofu. Every
+// render site appends this result unconditionally, so returning "" is what
+// makes "we do not know" look like silence rather than like a broken image.
+func countryFlagEmoji(code string) string {
+	code = normalizeCountryCode(code)
+	if code == "" {
+		return ""
+	}
+	var sb strings.Builder
+	for _, r := range code {
+		sb.WriteRune(rune(regionalIndicatorBase + (r - 'A')))
+	}
+	return sb.String()
+}
+
+// parseAcceptLanguageCountry extracts a country from an Accept-Language header,
+// best effort, or "" when the header offers no region evidence.
+//
+// Accept-Language is a q-weighted list, highest preference first:
+//
+//	en-GB,en;q=0.9,fr-FR;q=0.8
+//
+// The tags are scanned IN ORDER and the first one carrying a region subtag
+// wins, so the browser's own stated preference order decides. The q-values are
+// not parsed: browsers emit the list already sorted by descending q, and a
+// hand-rolled q parser would be more code and more failure modes for a signal
+// this soft.
+//
+// What is deliberately NOT inferred:
+//
+//   - A tag with no region ("en", "fr") yields "". Mapping a bare language to
+//     its "main" country is exactly the guess this feature must not make: "en"
+//     is not US, "es" is not ES, "pt" is not PT. No evidence, no flag.
+//   - "*" (the wildcard) and malformed tags yield "".
+//   - A script subtag is skipped, so "zh-Hans-CN" resolves to CN rather than
+//     reading "Hans" as a region: the region subtag is the alpha-2 one.
+//
+// Never errors. The caller is a login path and must not be able to fail on a
+// header a browser sent.
+func parseAcceptLanguageCountry(header string) string {
+	if header == "" {
+		return ""
+	}
+	for _, tag := range strings.Split(header, ",") {
+		// Drop any q-value / parameters, then split the tag into subtags.
+		if i := strings.IndexByte(tag, ';'); i >= 0 {
+			tag = tag[:i]
+		}
+		tag = strings.TrimSpace(tag)
+		if tag == "" || tag == "*" {
+			continue
+		}
+		parts := strings.Split(tag, "-")
+		// parts[0] is the language; the region is a later alpha-2 subtag. Scan
+		// past a script subtag (4 letters, e.g. "Hans") to find it.
+		for _, sub := range parts[1:] {
+			if code := normalizeCountryCode(sub); code != "" {
+				return code
+			}
+		}
+	}
+	return ""
+}
+
+// inferCountryFromRequest is the single inference entry point: the best-effort
+// country for the browser making this request, or "" when there is no evidence.
+//
+// Kept as its own function so every caller reads one name and so the set of
+// signals consulted is auditable in one place. Today that set is exactly one
+// header the browser already sends. Adding an IP-geolocation source here would
+// change the privacy posture of the feature and must not be done silently.
+func inferCountryFromRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return parseAcceptLanguageCountry(r.Header.Get("Accept-Language"))
+}
+
+// applyInferredCountry fills a user's country from request evidence, but ONLY
+// when the record has none.
+//
+// The guard is the whole function. An explicit pick in the wizard is the user
+// speaking about themselves; a language header is a hint. Once the record
+// carries a country, no amount of logging in from a differently-configured
+// browser may overwrite it — otherwise a user's stated country would silently
+// flip when they travel or borrow a laptop, which is both wrong and invisible.
+//
+// Returns whether it changed the record, so the caller can tell a real update
+// from a no-op. Nil-safe: it sits on the login path beside other enrichment.
+func applyInferredCountry(user *SaaSUser, r *http.Request) bool {
+	if user == nil || user.Country != "" {
+		return false
+	}
+	code := inferCountryFromRequest(r)
+	if code == "" {
+		return false
+	}
+	user.Country = code
+	return true
+}

--- a/src/pkg/hub/user_country_test.go
+++ b/src/pkg/hub/user_country_test.go
@@ -1,0 +1,400 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The country flag is a small feature with three ways to be silently wrong:
+// deriving the wrong glyph, guessing a country nobody claimed, and quietly
+// disturbing the thousands of existing user records on the PVC. These tests
+// pin all three, plus the dashboard wiring that has no Go function to call.
+
+// TestNormalizeCountryCode pins the shape validator, including the cases that
+// must be REJECTED. A validator that accepted a one-letter or three-letter
+// value would let a half-formed pair of regional indicators reach a render.
+func TestNormalizeCountryCode(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		// Canonical form passes through.
+		{"GB", "GB"},
+		{"US", "US"},
+		// Lowercase is normalized UP — a hand-edited record or an older client
+		// may hold "gb", and it must render the same flag as "GB".
+		{"gb", "GB"},
+		{"jp", "JP"},
+		{"Fr", "FR"},
+		// Surrounding whitespace is not a different country.
+		{"  DE  ", "DE"},
+		{"\tIT\n", "IT"},
+		// Everything below is invalid and must normalize to "" so that no flag
+		// renders at all.
+		{"", ""},
+		{"U", ""},       // too short
+		{"USA", ""},     // alpha-3, not alpha-2
+		{"12", ""},      // digits
+		{"U1", ""},      // mixed
+		{"U S", ""},     // internal space
+		{"--", ""},      // punctuation
+		{"🇬🇧", ""},      // the GLYPH is not the code; we store codes
+		{"<b", ""},      // markup-shaped
+		{"'; DROP", ""}, // injection-shaped
+		{"ÉE", ""},      // non-ASCII letters
+	} {
+		if got := normalizeCountryCode(tc.in); got != tc.want {
+			t.Errorf("normalizeCountryCode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCountryFlagEmoji pins the alpha-2 → regional-indicator derivation. The
+// expected values are written as explicit code-point pairs rather than pasted
+// glyphs so the test states WHAT it expects rather than depending on this
+// file's own encoding surviving an editor.
+func TestCountryFlagEmoji(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		// G=U+1F1EC, B=U+1F1E7
+		{"GB", "\U0001F1EC\U0001F1E7"},
+		// Lowercase must derive the SAME glyph as uppercase — this is the case
+		// a naive implementation gets wrong, because 'g' is not 'G' and the
+		// arithmetic would run off the end of the regional-indicator block.
+		{"gb", "\U0001F1EC\U0001F1E7"},
+		// J=U+1F1EF, P=U+1F1F5
+		{"JP", "\U0001F1EF\U0001F1F5"},
+		// U=U+1F1FA, S=U+1F1F8
+		{"us", "\U0001F1FA\U0001F1F8"},
+	} {
+		if got := countryFlagEmoji(tc.in); got != tc.want {
+			t.Errorf("countryFlagEmoji(%q) = %q (% x), want %q", tc.in, got, got, tc.want)
+		}
+	}
+
+	// An invalid or unset code renders NOTHING. Not a globe, not a replacement
+	// character, not a lone regional indicator — the empty string, so the
+	// render sites that append it unconditionally emit nothing at all.
+	for _, bad := range []string{"", "U", "USA", "12", "??", "  ", "🇬🇧"} {
+		if got := countryFlagEmoji(bad); got != "" {
+			t.Errorf("countryFlagEmoji(%q) = %q, want \"\" — an unknown country must render nothing", bad, got)
+		}
+	}
+}
+
+// TestParseAcceptLanguageCountry pins the ONLY inference signal. The negative
+// half matters more than the positive half: inferring a country from a bare
+// language tag would attach a flag to a user who never claimed one.
+func TestParseAcceptLanguageCountry(t *testing.T) {
+	for _, tc := range []struct {
+		name, header, want string
+	}{
+		{"simple region", "en-GB", "GB"},
+		{"first tag wins over later ones", "en-GB,en;q=0.9,fr-FR;q=0.8", "GB"},
+		{"q-values stripped", "fr-FR;q=0.9", "FR"},
+		{"lowercase region normalized", "pt-br", "BR"},
+		{"script subtag skipped", "zh-Hans-CN", "CN"},
+		{"falls through a region-less first tag", "en,de-DE;q=0.9", "DE"},
+		{"whitespace tolerated", " ja-JP , en ", "JP"},
+
+		// --- No evidence: must infer NOTHING ---
+		{"empty header", "", ""},
+		{"bare language is not a country", "en", ""},
+		{"bare language, several", "en,fr,de", ""},
+		{"wildcard", "*", ""},
+		{"garbage", ";;;", ""},
+		{"alpha-3 region is not alpha-2", "en-USA", ""},
+		{"numeric UN region code", "es-419", ""},
+	} {
+		if got := parseAcceptLanguageCountry(tc.header); got != tc.want {
+			t.Errorf("%s: parseAcceptLanguageCountry(%q) = %q, want %q", tc.name, tc.header, got, tc.want)
+		}
+	}
+}
+
+// TestApplyInferredCountryNeverOverwritesExplicit is the privacy/correctness
+// invariant of the whole fallback: a browser's language setting must never
+// overwrite a country the user chose. Without this guard, a user's declared
+// country would silently flip when they travel or borrow a laptop.
+func TestApplyInferredCountryNeverOverwritesExplicit(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Language", "fr-FR")
+
+	// Explicit value present → untouched, and reported as no change.
+	u := &SaaSUser{GitHubUsername: "ada", Country: "GB"}
+	if changed := applyInferredCountry(u, req); changed {
+		t.Error("applyInferredCountry reported a change to a record that already had a country")
+	}
+	if u.Country != "GB" {
+		t.Errorf("Country = %q, want %q — an explicit choice must outrank Accept-Language", u.Country, "GB")
+	}
+
+	// Empty value → filled from the header.
+	u2 := &SaaSUser{GitHubUsername: "ada"}
+	if changed := applyInferredCountry(u2, req); !changed {
+		t.Error("applyInferredCountry reported no change while filling an empty country")
+	}
+	if u2.Country != "FR" {
+		t.Errorf("Country = %q, want %q", u2.Country, "FR")
+	}
+
+	// No evidence → still empty. Never a guess.
+	u3 := &SaaSUser{GitHubUsername: "ada"}
+	bare := httptest.NewRequest(http.MethodGet, "/", nil)
+	bare.Header.Set("Accept-Language", "en")
+	if changed := applyInferredCountry(u3, bare); changed {
+		t.Error("applyInferredCountry reported a change for a header with no region subtag")
+	}
+	if u3.Country != "" {
+		t.Errorf("Country = %q, want empty — a bare language tag is not evidence of a country", u3.Country)
+	}
+
+	// Nil-safe on both sides: this runs on the login path and must not panic.
+	if applyInferredCountry(nil, req) {
+		t.Error("applyInferredCountry(nil, req) reported a change")
+	}
+	if applyInferredCountry(&SaaSUser{}, nil) {
+		t.Error("applyInferredCountry(user, nil) reported a change")
+	}
+}
+
+// TestSaaSUserCountryRoundTrip is the PVC-compatibility guard. Every existing
+// user record on disk must survive load→save byte-identical, which means the
+// new field has to be absent from the JSON when unset, and has to not disturb
+// its neighbours when set.
+func TestSaaSUserCountryRoundTrip(t *testing.T) {
+	// A record as it exists on the PVC today — no country key at all.
+	const legacy = `{"github_username":"ada","created_at":"2020-01-01T00:00:00Z","last_login":"2020-01-02T00:00:00Z","hives":{"h1":"owner"},"saas_quota":3,"blocked":false,"full_name":"Ada Lovelace","slack_id":"U01ABCDEF23","login_count":7}`
+
+	var u SaaSUser
+	if err := json.Unmarshal([]byte(legacy), &u); err != nil {
+		t.Fatalf("unmarshal legacy record: %v", err)
+	}
+	if u.Country != "" {
+		t.Errorf("Country = %q on a record that never had one, want empty", u.Country)
+	}
+	// The other fields must be intact — a struct edit that shifted a tag would
+	// show up here rather than as a mystery in production.
+	if u.GitHubUsername != "ada" || u.FullName != "Ada Lovelace" || u.SlackID != "U01ABCDEF23" ||
+		u.SaaSQuota != 3 || u.LoginCount != 7 || u.Hives["h1"] != "owner" {
+		t.Errorf("legacy record did not round-trip its existing fields: %+v", u)
+	}
+
+	// Re-marshalled, the record must still carry NO country key. omitempty is
+	// what keeps thousands of untouched files from being rewritten.
+	out, err := json.Marshal(&u)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "country") {
+		t.Errorf("re-marshalled legacy record grew a country key: %s", out)
+	}
+
+	// With a country set, the key appears — and nothing else changes.
+	u.Country = "GB"
+	out2, err := json.Marshal(&u)
+	if err != nil {
+		t.Fatalf("marshal with country: %v", err)
+	}
+	if !strings.Contains(string(out2), `"country":"GB"`) {
+		t.Errorf("country not persisted: %s", out2)
+	}
+	var back SaaSUser
+	if err := json.Unmarshal(out2, &back); err != nil {
+		t.Fatalf("unmarshal round two: %v", err)
+	}
+	if back.Country != "GB" || back.FullName != "Ada Lovelace" || back.SlackID != "U01ABCDEF23" ||
+		back.SaaSQuota != 3 || back.LoginCount != 7 {
+		t.Errorf("setting Country disturbed other fields: %+v", back)
+	}
+}
+
+// TestProvisionRequestCountryRoundTrip mirrors the guard above for the request
+// record, which has its own file per pending request on the same PVC.
+func TestProvisionRequestCountryRoundTrip(t *testing.T) {
+	const legacy = `{"username":"ada","org":"acme","repos":"widget","primary_repo":"widget","acmm_level":1,"auth_method":"app","requested_at":"2020-01-01T00:00:00Z","status":"pending","full_name":"Ada Lovelace"}`
+
+	var pr ProvisionRequest
+	if err := json.Unmarshal([]byte(legacy), &pr); err != nil {
+		t.Fatalf("unmarshal legacy request: %v", err)
+	}
+	if pr.Country != "" {
+		t.Errorf("Country = %q on a request that never had one, want empty", pr.Country)
+	}
+	out, err := json.Marshal(&pr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "country") {
+		t.Errorf("re-marshalled legacy request grew a country key: %s", out)
+	}
+}
+
+// TestApplyRequestContactToUserCountry pins the priority rule at the point the
+// wizard's answer lands on the user record: an explicit pick REPLACES an
+// inferred value (unlike FullName/SlackID, which only backfill), and a request
+// carrying no country leaves whatever is there alone.
+func TestApplyRequestContactToUserCountry(t *testing.T) {
+	// Explicit pick overrides a previously inferred country.
+	u := &SaaSUser{GitHubUsername: "ada", Country: "FR"} // e.g. inferred at login
+	applyRequestContactToUser(u, &ProvisionRequest{Country: "GB"})
+	if u.Country != "GB" {
+		t.Errorf("Country = %q, want GB — the wizard pick is authoritative over an inference", u.Country)
+	}
+
+	// Lowercase in a stored request is normalized on the way in.
+	u2 := &SaaSUser{GitHubUsername: "ada"}
+	applyRequestContactToUser(u2, &ProvisionRequest{Country: "jp"})
+	if u2.Country != "JP" {
+		t.Errorf("Country = %q, want JP", u2.Country)
+	}
+
+	// A request with no country (the common case, and every request filed
+	// before this shipped) must not blank an existing value.
+	u3 := &SaaSUser{GitHubUsername: "ada", Country: "GB"}
+	applyRequestContactToUser(u3, &ProvisionRequest{})
+	if u3.Country != "GB" {
+		t.Errorf("Country = %q, want GB — an empty request must not clear a stored country", u3.Country)
+	}
+
+	// An invalid stored value is dropped rather than rendered.
+	u4 := &SaaSUser{GitHubUsername: "ada"}
+	applyRequestContactToUser(u4, &ProvisionRequest{Country: "USA"})
+	if u4.Country != "" {
+		t.Errorf("Country = %q, want empty — a malformed code must not reach a render", u4.Country)
+	}
+
+	// Nil-safe, like the rest of this helper.
+	applyRequestContactToUser(nil, &ProvisionRequest{Country: "GB"})
+	applyRequestContactToUser(&SaaSUser{}, nil)
+}
+
+// TestDashboardCountryFlagWiring guards the dashboard half, which lives inside
+// the dashboardHTML raw string and so has no Go function to exercise. House
+// style: assert the symbols and the exact wiring, because a typo here is
+// invisible to the compiler and shows up only as a missing flag.
+func TestDashboardCountryFlagWiring(t *testing.T) {
+	html := dashScript(t)
+
+	for _, snippet := range []string{
+		// The derivation helpers must exist...
+		"function normalizeCountryCode(code)",
+		"function countryFlagEmoji(code)",
+		"function countryFlagHTML(code)",
+		// ...and the base code point must be the real one. A wrong base yields
+		// plausible-looking but wrong glyphs (letters, not flags).
+		"var REGIONAL_INDICATOR_BASE = 0x1F1E6;",
+		// ...and the flag must actually be rendered beside the nav avatar,
+		// reading the country off the auth payload.
+		"countryFlagHTML(data.country)",
+		// The CSS class the glyph is wrapped in must exist, or the flag renders
+		// at whatever size the surrounding text happens to be.
+		".country-flag {",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — the avatar country flag is not wired", snippet)
+		}
+	}
+
+	// The flag must come from a DERIVED glyph, never from an external image
+	// host — that is the whole reason for the regional-indicator approach.
+	for _, banned := range []string{
+		"flagcdn.com",
+		"flagsapi.com",
+		"country-flags",
+	} {
+		if strings.Contains(html, banned) {
+			t.Errorf("dashboardHTML references %q — flags must be derived Unicode, not remote images", banned)
+		}
+	}
+
+	// Ordering: the helper must be DEFINED before the nav render that calls it.
+	// Both live in the same script, so a definition that drifted below its use
+	// inside an unhoisted expression would break the first paint.
+	def := strings.Index(html, "function countryFlagHTML(code)")
+	use := strings.Index(html, "countryFlagHTML(data.country)")
+	if def < 0 || use < 0 {
+		t.Fatalf("could not locate countryFlagHTML definition (%d) and use (%d)", def, use)
+	}
+	if def > use {
+		t.Error("countryFlagHTML is defined after the nav render that calls it")
+	}
+}
+
+// TestAuthUserPayloadOmitsEmptyCountry pins the payload shape: a user with no
+// country must produce the same JSON the dashboard has always received, so the
+// (currently vast) majority of sessions are unaffected by this feature.
+func TestAuthUserPayloadOmitsEmptyCountry(t *testing.T) {
+	// Exercised at the marshalling level the handler uses — the handler itself
+	// needs a verified session cookie, which the neighbouring handler tests
+	// build; this asserts the invariant the handler's `if country != ""` guard
+	// exists to produce.
+	payload := map[string]any{
+		"authenticated": true,
+		"login":         "ada",
+		"avatar_url":    "https://example.invalid/a.png",
+		"hub_admin":     false,
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "country") {
+		t.Errorf("payload for a user with no country carries a country key: %s", out)
+	}
+
+	payload["country"] = "GB"
+	out2, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out2), `"country":"GB"`) {
+		t.Errorf("country missing from payload: %s", out2)
+	}
+}
+
+// TestGetStartedWizardCountryWiring guards the wizard half — the only surface
+// where a user can state their country explicitly. It is a static file, so the
+// same substring discipline applies.
+func TestGetStartedWizardCountryWiring(t *testing.T) {
+	// Read from the embedded FS, not from disk, so this asserts against the
+	// bytes actually shipped in the binary (same discipline as
+	// collectInTreeJSSources in request_provision_callers_test.go).
+	b, err := staticFS.ReadFile("static/get-started.html")
+	if err != nil {
+		t.Fatalf("read embedded static/get-started.html: %v", err)
+	}
+	wizard := string(b)
+
+	for _, snippet := range []string{
+		// The control itself, and the blank option that must remain the default.
+		`id="req-country"`,
+		`<option value="">Prefer not to say</option>`,
+		// The list and the helpers that fill it.
+		"function populateCountrySelect()",
+		"function selectedCountry()",
+		"populateCountrySelect();",
+		// The value must ride the POST body.
+		"country: selectedCountry()",
+	} {
+		if !strings.Contains(wizard, snippet) {
+			t.Errorf("get-started.html is missing %q — the country dropdown is not wired", snippet)
+		}
+	}
+
+	// PRIVACY: country must never be put in a URL. A query parameter would leak
+	// it into access logs, Referer headers and browser history.
+	for _, banned := range []string{
+		"country=",
+		"?country",
+		"&country",
+	} {
+		if strings.Contains(wizard, banned) {
+			t.Errorf("get-started.html contains %q — country must ride the JSON body, never a URL", banned)
+		}
+	}
+}


### PR DESCRIPTION
## What

Shows a small country flag next to a user's avatar in the hub dashboard nav.

The flag is derived from an **optional** ISO 3166-1 alpha-2 code stored on the user record. Nothing about a user changes unless they pick a country or log in from a browser that states a region.

## Which signals are used

Two sources, in strict priority order:

**1. Explicit — a country dropdown in the get-started wizard.** This is the authoritative source: the user chose it about themselves. It rides the existing `POST /api/saas/request-provision` JSON body as `country`, and is copied onto the `SaaSUser` record on approval, exactly the way `full_name` / `slack_id` already are. The wizard preselects whatever the hub already holds, so an inferred value is shown to the one person who can correct it — and submitting turns that guess into an explicit choice.

**2. Inferred — the region subtag of `Accept-Language`, at login.** This is the only inference signal. On a completed OAuth callback the hub reads the header the browser already sent and, **only if the record has no country**, stores the region subtag of the first tag that carries one (`en-GB,en;q=0.9` → `GB`).

The inference can never overwrite an explicit pick. That guard is the point: without it, a user's declared country would silently flip when they travel or borrow a laptop.

## What happens when country is unknown

Nothing renders. No placeholder globe, no `??` box, no tofu, no broken glyph — the helper returns the empty string and every render site appends it unconditionally, so absence of evidence looks like absence.

Specifically, **a bare language tag infers nothing**. `en` does not become `US`, `es` does not become `ES`, `pt` does not become `PT`. Mapping a language to its "main" country is precisely the guess this feature must not make. Also ignored: `*`, malformed tags, alpha-3 regions (`en-USA`), and numeric UN region codes (`es-419`). A script subtag is skipped, so `zh-Hans-CN` correctly resolves to `CN` rather than reading `Hans` as a region.

The `/api/auth/user` payload omits the `country` key entirely when unset, so for the (currently vast) majority of sessions the response is byte-identical to before.

## Privacy tradeoffs deliberately avoided

- **No GeoIP database and no geolocation API.** Either would have been a new dependency, and the API form would have meant sending a user's IP to a third party on every login. Neither is used. `Accept-Language` was chosen precisely because it is *already on the request* — nothing new is collected, and no user identifier leaves the box.
- **No third-party tracking or analytics script** was added, and no user data is sent to any external service to obtain a country.
- **Country never appears in a URL.** It rides JSON request bodies only, keeping it out of access logs, `Referer` headers and browser history. A test asserts the wizard contains no `country=` / `?country` / `&country` substring.
- **No flag images.** Glyphs are derived from the alpha-2 code as Unicode regional-indicator pairs (`U+1F1E6` + letter offset), so the hub depends on no external image host and ships no assets. A test fails the build if `flagcdn.com`-style hosts ever appear in the dashboard.
- **Inference is non-blocking and cannot fail a login.** `parseAcceptLanguageCountry` never errors; an unparseable header stores nothing and the callback proceeds unchanged.
- **The dropdown does not preselect from locale.** Preselecting a guessed country would make it *look* like the user declared it. The blank "Prefer not to say" option stays selected until the user acts.

Also worth stating plainly: `Accept-Language` is a *language preference, not a location*. `en-GB` is evidence of a GB association, not proof of presence in GB. That asymmetry is exactly why it is the fallback and the dropdown is the authority.

## Storage compatibility

`SaaSUser.Country` and `ProvisionRequest.Country` are both `omitempty`, so every existing record on the PVC round-trips **byte-identical** until a user actually gets a country. Tests assert a legacy record neither gains a `country` key on re-marshal nor has any neighbouring field disturbed.

Identity handling is untouched — no change to canonical-ID migration or to bare-login keys.

## Tests

`src/pkg/hub/user_country_test.go`, in the house substring style (`dashScript(t)` + `strings.Contains`):

- alpha-2 → emoji derivation, including **lowercase input** (`gb` must yield the same glyph as `GB`) and **invalid codes** (`U`, `USA`, `12`, `??`, the glyph itself)
- unset/unknown country renders **nothing**
- the full negative set for `Accept-Language` — bare language, wildcard, garbage, alpha-3, numeric region
- an inference never overwrites an explicit choice; nil-safe on both sides
- `SaaSUser` and `ProvisionRequest` round-trip without disturbing other fields
- dashboard nav wiring, the correct regional-indicator base code point, helper-defined-before-use ordering, and the no-remote-image-host guard
- wizard wiring, the blank default option, and the no-country-in-URL privacy guard

CI (Linux) is the gate; per house rules nothing was built, linted or tested locally.

## Files

- `src/pkg/hub/user_country.go` (new) — normalization, emoji derivation, `Accept-Language` parsing, the never-overwrite guard
- `src/pkg/hub/saas.go` — `SaaSUser.Country`, `ProvisionRequest.Country`, request handler + approval copy, `.country-flag` CSS, JS helpers, nav render
- `src/pkg/hub/oauth.go` — login-time inference; `country` folded into `/api/auth/user` (and tracked to the target under impersonation)
- `src/pkg/hub/static/get-started.html` — the country dropdown, summary row, submit wiring
- `src/pkg/hub/user_country_test.go` (new)
