### PR TITLE
✨ feat(convergence): off/shadow/enforce runtime rollout + fixed-commit soak telemetry

### DIFF
--- a/src/cmd/hive/convergence_kick.go
+++ b/src/cmd/hive/convergence_kick.go
@@ -1,49 +1,106 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/convergence"
 	"github.com/kubestellar/hive/pkg/dashboard"
 	"github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/notify"
 )
 
-// observeConvergenceKickAdmission is the #4247 eval-cycle seam: it runs the
-// shared convergence dependency admission (the SAME observer + pure evaluator
-// the contributor queue and selectTask consume, via
-// dashboard.ConvergenceKickProjection) over the issue population that is about
-// to be cached for manual kicks and rendered into scheduled kicks.
+// applyConvergenceKickAdmission is the #4247 eval-cycle seam, formalised by
+// #4263 into the SINGLE mode applicator every enrolled guard consumes (no
+// per-feature booleans). It runs the shared convergence dependency admission
+// (the SAME observer + pure evaluator the contributor queue and selectTask
+// consume, via dashboard.ConvergenceKickProjectionDetailed) over the issue
+// population that is about to be cached for manual kicks and rendered into
+// scheduled kicks, and returns the ActionableResult the scheduler must use.
 //
-// Rollout contract (maintainer requirement, ahead of #4263):
+// Rollout contract (maintainer requirement, kubestellar/hive#4263):
 //
-//   - convergence.mode "off" (DEFAULT): return before touching anything — no
-//     sweep is built, no decision is computed, the kick path is byte-for-byte
-//     the pre-#4247 path. Zero behaviour change for existing v4 hives.
-//   - convergence.mode "shadow": compute the projection ONCE on a fresh sweep
-//     and LOG which candidates the shared evaluator would have withheld from
-//     internal kicks, with the decision's stable reason, blockers, and observed
-//     record/generation. NOTHING is enforced: the caller always passes the raw
-//     actionable result to Scheduler.SetLastActionable and BuildKickMessages,
-//     so scheduled kicks, cached manual/dashboard kicks, governor counts,
-//     prompts, ordering, and PR/review dispatch are all unchanged.
+//   - "off" (DEFAULT): return the input untouched before computing anything —
+//     no sweep, no decision, no telemetry. The kick path is byte-for-byte the
+//     pre-#4247 path; existing v4 hives see ZERO behaviour change.
+//   - "shadow": compute the projection ONCE on a fresh sweep, LOG what would
+//     have been withheld, record one soak telemetry row, and return the RAW
+//     input — observed, never enforced.
+//   - "enforce": the SAME projection from the SAME sweep gates ONLY this
+//     enrolled internal-dispatch path: the returned result carries the
+//     admitted issue projection while PRs, holds, clusters, and per-repo
+//     counts stay untouched. The raw actionable population remains
+//     authoritative for governor policy, cadence, classification, dashboard
+//     status, PR/review dispatch, escalation, and every path not explicitly
+//     enrolled — the caller passes the raw result everywhere else.
 //
-// The function never mutates actionable. It is nil-safe on every input so a
-// hive booted without a dashboard (or a test harness) cannot panic here.
-func observeConvergenceKickAdmission(cfg *config.Config, dashSrv *dashboard.Server, actionable *github.ActionableResult, logger *slog.Logger) {
-	if cfg.ConvergenceMode() != config.ConvergenceModeShadow {
-		return // off (default): entirely inert
+// The (mode, generation) pair is captured ONCE at the start of the pass
+// (dashboard.CaptureConvergenceMode); every candidate in this pass is judged
+// and attributed under that captured pair even if an owner flips the setting
+// concurrently — the next pass picks up the change, so a switch is live
+// without a rebuild, restart, queue surgery, or stored-state migration.
+//
+// Mode TRANSITIONS are logged and notified exactly once per crossing (the
+// #4305 probe-notification discipline): never at boot, never once per cycle.
+//
+// The function never mutates its input. It is nil-safe on every dependency so
+// a hive booted without a dashboard (or a test harness) cannot panic here.
+func applyConvergenceKickAdmission(cfg *config.Config, dashSrv *dashboard.Server, actionable *github.ActionableResult, notifier *notify.Notifier, logger *slog.Logger) *github.ActionableResult {
+	// Capture the pass's (mode, generation) pair — one pair for every
+	// candidate in this pass. Without a dashboard there is no tracker (and no
+	// projection below would work either), so resolve the mode directly.
+	var (
+		mode       string
+		generation uint64
+		changed    bool
+		previous   string
+	)
+	mode = cfg.ConvergenceMode()
+	if dashSrv != nil {
+		mode, generation, changed, previous = dashSrv.CaptureConvergenceMode(mode)
+	}
+
+	if changed {
+		// Transition-only: log + notify ONCE on the crossing, whatever the
+		// source (runtime settings PUT, external YAML reload, env override).
+		if logger != nil {
+			logger.Info("convergence rollout mode changed",
+				"mode", mode, "previous", previous, "generation", generation)
+		}
+		if notifier != nil {
+			notifier.Send("Convergence mode changed",
+				fmt.Sprintf("convergence rollout switched from %q to %q (generation %d) — %s",
+					previous, mode, generation, convergenceModeEffect(mode)),
+				notify.PriorityDefault)
+		}
+	}
+
+	if mode == config.ConvergenceModeOff {
+		return actionable // off (default): entirely inert
 	}
 	if dashSrv == nil || actionable == nil || logger == nil {
-		return
+		return actionable
 	}
-	admitted, withheld := dashSrv.ConvergenceKickProjection(actionable.Issues.Items)
-	if len(withheld) == 0 {
-		logger.Debug("convergence shadow: every enumerated issue is admitted for internal kicks",
-			"issues", len(actionable.Issues.Items))
-		return
-	}
+
+	enforced := mode == config.ConvergenceModeEnforce
+	started := time.Now()
+	admitted, withheld, coverage := dashSrv.ConvergenceKickProjectionDetailed(actionable.Issues.Items)
+	latency := time.Since(started)
+
+	blocked, unknown := 0, 0
 	for _, f := range withheld {
-		logger.Info("convergence shadow: candidate would be WITHHELD from internal agent kicks (not enforced)",
+		if f.Decision.Reason == convergence.ReasonWaitingForDependency {
+			blocked++
+		} else {
+			unknown++
+		}
+		verb := "would be WITHHELD from internal agent kicks (not enforced)"
+		if enforced {
+			verb = "WITHHELD from internal agent kicks"
+		}
+		logger.Info("convergence "+mode+": candidate "+verb,
 			"repo", f.Issue.Repo,
 			"number", f.Issue.Number,
 			"reason", f.Decision.Reason,
@@ -52,10 +109,54 @@ func observeConvergenceKickAdmission(cfg *config.Config, dashSrv *dashboard.Serv
 			"observed_generation", f.Decision.ObservedGeneration,
 		)
 	}
-	logger.Info("convergence shadow kick projection complete",
+	logger.Info("convergence kick projection complete",
+		"mode", mode,
+		"generation", generation,
 		"raw_issues", len(actionable.Issues.Items),
 		"admitted", len(admitted),
 		"withheld", len(withheld),
-		"enforced", false,
+		"enforced", enforced,
 	)
+
+	// One bounded soak row per enrolled pass (#4263): the fixed-commit
+	// comparison facts. Recorded in shadow AND enforce so the same workload
+	// can be compared across treatments; commit is stamped by the recorder.
+	dashSrv.RecordConvergenceSoak(dashboard.ConvergenceSoakEntry{
+		Timestamp:         time.Now().UnixMilli(),
+		Mode:              mode,
+		Generation:        generation,
+		RawIssues:         len(actionable.Issues.Items),
+		Admitted:          len(admitted),
+		Blocked:           blocked,
+		Unknown:           unknown,
+		PartialLedger:     coverage.Partial,
+		WouldDiffer:       len(withheld) > 0,
+		Enforced:          enforced,
+		DecisionLatencyMs: latency.Milliseconds(),
+	})
+
+	if !enforced {
+		return actionable // shadow: exact baseline disposition
+	}
+
+	// enforce: gate ONLY the enrolled internal-dispatch path. A shallow copy
+	// carries the admitted issue projection; PRs, holds, clusters, per-repo
+	// totals, and the raw input itself are untouched.
+	gated := *actionable
+	gated.Issues.Items = admitted
+	gated.Issues.Count = len(admitted)
+	return &gated
+}
+
+// convergenceModeEffect is the one-line operator explanation attached to the
+// transition notification.
+func convergenceModeEffect(mode string) string {
+	switch mode {
+	case config.ConvergenceModeShadow:
+		return "decisions are computed and reported only; nothing is enforced"
+	case config.ConvergenceModeEnforce:
+		return "convergence decisions now gate internal scheduled/cached agent kicks"
+	default:
+		return "convergence code paths are inert; behavior is the pre-enrollment baseline"
+	}
 }

--- a/src/cmd/hive/convergence_kick_test.go
+++ b/src/cmd/hive/convergence_kick_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kubestellar/hive/pkg/github"
 )
 
-// ── #4247 eval-cycle seam: observeConvergenceKickAdmission ─────────────────────
+// ── #4247/#4263 eval-cycle seam: applyConvergenceKickAdmission ─────────────────
 //
 // The rollout contract under test: with convergence.mode "off" (the DEFAULT)
 // the seam is entirely inert — no projection, no log, no mutation; with
@@ -72,7 +72,7 @@ func TestObserveConvergenceKickAdmission_OffModeIsInert(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	observeConvergenceKickAdmission(&config.Config{}, srv, actionable, logger)
+	applyConvergenceKickAdmission(&config.Config{}, srv, actionable, nil, logger)
 
 	if buf.Len() != 0 {
 		t.Fatalf("mode=off must log nothing, got: %s", buf.String())
@@ -82,7 +82,7 @@ func TestObserveConvergenceKickAdmission_OffModeIsInert(t *testing.T) {
 	}
 
 	// A nil config is also off (fail-safe) — and must not panic.
-	observeConvergenceKickAdmission(nil, srv, actionable, logger)
+	applyConvergenceKickAdmission(nil, srv, actionable, nil, logger)
 	if buf.Len() != 0 {
 		t.Fatal("nil config must resolve to off and log nothing")
 	}
@@ -100,7 +100,7 @@ func TestObserveConvergenceKickAdmission_ShadowLogsButNeverEnforces(t *testing.T
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	observeConvergenceKickAdmission(cfg, srv, actionable, logger)
+	applyConvergenceKickAdmission(cfg, srv, actionable, nil, logger)
 
 	out := buf.String()
 	if !bytes.Contains(buf.Bytes(), []byte("WITHHELD")) {
@@ -131,7 +131,7 @@ func TestObserveConvergenceKickAdmission_ShadowAllAdmitted(t *testing.T) {
 
 	var buf bytes.Buffer
 	captured := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	observeConvergenceKickAdmission(cfg, srv, actionable, captured)
+	applyConvergenceKickAdmission(cfg, srv, actionable, nil, captured)
 	if bytes.Contains(buf.Bytes(), []byte("WITHHELD")) {
 		t.Fatalf("nothing should be withheld with no ledger records: %s", buf.String())
 	}
@@ -147,7 +147,7 @@ func TestObserveConvergenceKickAdmission_NilInputsAreSafe(t *testing.T) {
 	cfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeShadow}}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	observeConvergenceKickAdmission(cfg, nil, kickTestActionable(), logger)
-	observeConvergenceKickAdmission(cfg, kickTestDashboard(t), nil, logger)
-	observeConvergenceKickAdmission(cfg, kickTestDashboard(t), kickTestActionable(), nil)
+	applyConvergenceKickAdmission(cfg, nil, kickTestActionable(), nil, logger)
+	applyConvergenceKickAdmission(cfg, kickTestDashboard(t), nil, nil, logger)
+	applyConvergenceKickAdmission(cfg, kickTestDashboard(t), kickTestActionable(), nil, nil)
 }

--- a/src/cmd/hive/convergence_rollout_test.go
+++ b/src/cmd/hive/convergence_rollout_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+// ── #4263: enforce mode + captured pair + transition logging + soak rows ──────
+//
+// The rollout contract rows that #4263 adds on top of #4247's shadow seam:
+// enforce gates ONLY the enrolled internal-dispatch path using the same
+// decision shadow computes, off/shadow return the exact baseline population,
+// every pass records one bounded soak row, and a mode transition is logged
+// exactly once on the crossing.
+
+// TestApplyConvergenceKickAdmission_OffReturnsBaselineAndRecordsNothing pins
+// the default-off guarantee at the applicator's return value: the SAME
+// pointer, zero soak rows, zero admission influence.
+func TestApplyConvergenceKickAdmission_OffReturnsBaselineAndRecordsNothing(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	actionable := kickTestActionable()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	got := applyConvergenceKickAdmission(&config.Config{}, srv, actionable, nil, logger)
+	if got != actionable {
+		t.Fatal("mode=off must return the raw actionable result itself")
+	}
+	if len(srv.ConvergenceSoakHistory()) != 0 {
+		t.Fatal("mode=off must not record soak telemetry — the code path is inert")
+	}
+}
+
+// TestApplyConvergenceKickAdmission_ShadowComputesButNeverBlocks: shadow
+// returns the exact baseline population while the soak row records what
+// enforcement would have changed (would_differ=true, enforced=false).
+func TestApplyConvergenceKickAdmission_ShadowComputesButNeverBlocks(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	actionable := kickTestActionable()
+	cfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeShadow}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	got := applyConvergenceKickAdmission(cfg, srv, actionable, nil, logger)
+	if got != actionable {
+		t.Fatal("mode=shadow must return the raw actionable result itself (baseline disposition)")
+	}
+	if len(got.Issues.Items) != 2 {
+		t.Fatalf("shadow must not touch the population: %+v", got.Issues.Items)
+	}
+
+	hist := srv.ConvergenceSoakHistory()
+	if len(hist) != 1 {
+		t.Fatalf("shadow must record exactly one soak row per pass, got %d", len(hist))
+	}
+	row := hist[0]
+	if row.Mode != "shadow" || row.Enforced || !row.WouldDiffer {
+		t.Fatalf("shadow row = %+v, want mode=shadow enforced=false would_differ=true", row)
+	}
+	if row.RawIssues != 2 || row.Admitted != 1 || row.Blocked != 1 || row.Unknown != 0 {
+		t.Fatalf("shadow row counts = %+v, want raw=2 admitted=1 blocked=1 unknown=0", row)
+	}
+	if row.Commit == "" || row.Generation == 0 || row.EnrolledPath == "" {
+		t.Fatalf("soak row missing commit/generation/path attribution: %+v", row)
+	}
+}
+
+// TestApplyConvergenceKickAdmission_EnforceGatesOnlyEnrolledPath: the blocked
+// candidate is absent from the returned (scheduled/cached) issue payload while
+// the unrelated ready control remains present, the raw input is untouched, and
+// the soak row records enforced=true.
+func TestApplyConvergenceKickAdmission_EnforceGatesOnlyEnrolledPath(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	actionable := kickTestActionable()
+	cfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeEnforce}}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	got := applyConvergenceKickAdmission(cfg, srv, actionable, nil, logger)
+	if got == actionable {
+		t.Fatal("enforce must return a gated projection, not the raw result")
+	}
+	if len(got.Issues.Items) != 1 || got.Issues.Items[0].Number != 700 {
+		t.Fatalf("enforce must withhold the blocked candidate and keep ready work: %+v", got.Issues.Items)
+	}
+	if got.Issues.Count != 1 {
+		t.Fatalf("gated count = %d, want 1", got.Issues.Count)
+	}
+	// The RAW population stays authoritative for every non-enrolled consumer.
+	if len(actionable.Issues.Items) != 2 || actionable.Issues.Count != 2 {
+		t.Fatalf("enforce must never mutate the raw actionable result: %+v", actionable.Issues)
+	}
+	if !strings.Contains(buf.String(), "WITHHELD") || strings.Contains(buf.String(), "not enforced") {
+		t.Fatalf("enforce must log an actual withholding: %s", buf.String())
+	}
+
+	hist := srv.ConvergenceSoakHistory()
+	if len(hist) != 1 || !hist[0].Enforced || !hist[0].WouldDiffer || hist[0].Blocked != 1 {
+		t.Fatalf("enforce soak row = %+v, want enforced=true would_differ=true blocked=1", hist)
+	}
+}
+
+// TestApplyConvergenceKickAdmission_EnforceToOffRestoresBaseline: flipping
+// enforce back to off restores the pre-enrollment population on the very next
+// pass — no restart, no queue surgery, no stored-state migration.
+func TestApplyConvergenceKickAdmission_EnforceToOffRestoresBaseline(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	enforceCfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeEnforce}}
+	gated := applyConvergenceKickAdmission(enforceCfg, srv, kickTestActionable(), nil, logger)
+	if len(gated.Issues.Items) != 1 {
+		t.Fatalf("enforce pass must gate: %+v", gated.Issues.Items)
+	}
+
+	offCfg := &config.Config{}
+	baseline := kickTestActionable()
+	restored := applyConvergenceKickAdmission(offCfg, srv, baseline, nil, logger)
+	if restored != baseline || len(restored.Issues.Items) != 2 {
+		t.Fatalf("the next off pass must restore the exact baseline: %+v", restored.Issues.Items)
+	}
+}
+
+// TestApplyConvergenceKickAdmission_TransitionLoggedOnceOnCrossing: a mode
+// change is logged on the crossing and never repeated on later identical
+// passes — the #4305 transition-only discipline.
+func TestApplyConvergenceKickAdmission_TransitionLoggedOnceOnCrossing(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	offCfg := &config.Config{}
+	shadowCfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeShadow}}
+
+	// Boot pass: first capture is NOT a transition.
+	applyConvergenceKickAdmission(offCfg, srv, kickTestActionable(), nil, logger)
+	if strings.Contains(buf.String(), "convergence rollout mode changed") {
+		t.Fatal("the first captured pass after boot must not report a transition")
+	}
+
+	// The flip: exactly one transition line.
+	applyConvergenceKickAdmission(shadowCfg, srv, kickTestActionable(), nil, logger)
+	if got := strings.Count(buf.String(), "convergence rollout mode changed"); got != 1 {
+		t.Fatalf("transition logged %d times, want exactly 1: %s", got, buf.String())
+	}
+
+	// Steady state: no repeat.
+	applyConvergenceKickAdmission(shadowCfg, srv, kickTestActionable(), nil, logger)
+	if got := strings.Count(buf.String(), "convergence rollout mode changed"); got != 1 {
+		t.Fatalf("an unchanged mode must not re-log the transition, got %d", got)
+	}
+}
+
+// TestApplyConvergenceKickAdmission_OnePairPerPass: every soak row a pass
+// records carries the pair captured at the start of that pass; a later flip
+// produces a new generation on the NEXT pass, never a mixed sweep.
+func TestApplyConvergenceKickAdmission_OnePairPerPass(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	shadowCfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeShadow}}
+	enforceCfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeEnforce}}
+
+	applyConvergenceKickAdmission(shadowCfg, srv, kickTestActionable(), nil, logger)
+	applyConvergenceKickAdmission(enforceCfg, srv, kickTestActionable(), nil, logger)
+
+	hist := srv.ConvergenceSoakHistory() // newest first
+	if len(hist) != 2 {
+		t.Fatalf("want 2 soak rows, got %d", len(hist))
+	}
+	if hist[1].Mode != "shadow" || hist[0].Mode != "enforce" {
+		t.Fatalf("rows must carry their own pass's mode: %+v", hist)
+	}
+	if hist[0].Generation <= hist[1].Generation {
+		t.Fatalf("the flip must advance the generation: %d then %d", hist[1].Generation, hist[0].Generation)
+	}
+}
+
+// TestApplyConvergenceKickAdmission_EnforcePreservesNonIssuePayloads: PRs and
+// holds ride through the gated copy untouched — only the enrolled issue
+// payload is filtered.
+func TestApplyConvergenceKickAdmission_EnforcePreservesNonIssuePayloads(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	srv := kickTestDashboard(t)
+	actionable := kickTestActionable()
+	actionable.PRs = github.PRResult{Count: 1, Items: []github.PullRequest{{Repo: "projectbluefin/dakota", Number: 900}}}
+	cfg := &config.Config{Convergence: config.ConvergenceConfig{Mode: config.ConvergenceModeEnforce}}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	got := applyConvergenceKickAdmission(cfg, srv, actionable, nil, logger)
+	if got.PRs.Count != 1 || len(got.PRs.Items) != 1 || got.PRs.Items[0].Number != 900 {
+		t.Fatalf("enforce must not touch the PR payload: %+v", got.PRs)
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1213,6 +1213,17 @@ func main() {
 		}
 	}
 
+	// #4263: restore convergence soak telemetry so a fixed-commit off/shadow/
+	// enforce comparison survives restarts. Missing or unparseable is ordinary
+	// on a hive that never ran with the toggle on — start empty, never fail.
+	const convergenceSoakHistoryPath = "/data/convergence-soak-history.json"
+	var pendingConvergenceSoakSeed []dashboard.ConvergenceSoakEntry
+	if soakData, err := os.ReadFile(convergenceSoakHistoryPath); err == nil {
+		if err := json.Unmarshal(soakData, &pendingConvergenceSoakSeed); err == nil && len(pendingConvergenceSoakSeed) > 0 {
+			logger.Info("convergence soak history loaded", "entries", len(pendingConvergenceSoakSeed))
+		}
+	}
+
 	// Restore governor/repo/beads/system trend history from disk so those
 	// sparklines survive restarts and render for any viewer (previously kept
 	// only in the browser's localStorage).
@@ -1756,6 +1767,10 @@ func main() {
 	if len(pendingBudgetWindowSeed) > 0 {
 		dashSrv.SeedBudgetWindowHistory(pendingBudgetWindowSeed)
 		logger.Info("budget window history restored", "entries", len(pendingBudgetWindowSeed))
+	}
+	if len(pendingConvergenceSoakSeed) > 0 {
+		dashSrv.SeedConvergenceSoak(pendingConvergenceSoakSeed)
+		logger.Info("convergence soak history restored", "entries", len(pendingConvergenceSoakSeed))
 	}
 
 	if len(pendingTrendSeed) > 0 {
@@ -5314,19 +5329,21 @@ func runEvalCycle(
 		}
 	}
 
-	// #4247 (parent #3845): observe the shared convergence admission at the
+	// #4247/#4263 (parent #3845): apply the shared convergence admission at the
 	// internal-kick dispatch boundary — AFTER governor policy evaluated the raw
 	// queue, BEFORE the scheduler caches and renders issues. Gated by the
-	// convergence feature toggle: with mode "off" (the default) this is
-	// entirely inert, and even in "shadow" it only LOGS what the shared
-	// evaluator would withhold — the raw actionable population is always what
-	// SetLastActionable and BuildKickMessages receive. Enforcement is a later,
-	// explicit increment (#4263).
-	observeConvergenceKickAdmission(cfg, dashSrv, actionable, logger)
+	// runtime convergence rollout mode, captured once per pass: with mode "off"
+	// (the DEFAULT) this is entirely inert and kickActionable IS actionable;
+	// "shadow" logs and records what would be withheld but still dispatches the
+	// raw population; only "enforce" gates the scheduled/cached issue payloads
+	// below. The raw actionable population stays authoritative for governor
+	// policy, dashboard status, PR/review dispatch, escalation, and every path
+	// not explicitly enrolled.
+	kickActionable := applyConvergenceKickAdmission(cfg, dashSrv, actionable, notifier, logger)
 
-	sched.SetLastActionable(actionable)
+	sched.SetLastActionable(kickActionable)
 	reviewPlan := planReviewDispatch(cfg, actionable, agentMgr, logger)
-	messages := sched.BuildKickMessages(actionable, agentsDue)
+	messages := sched.BuildKickMessages(kickActionable, agentsDue)
 	reviewKickByMessage := map[string]review.DispatchKick{}
 	for _, k := range append(reviewPlan.ReviewKicks, reviewPlan.FixKicks...) {
 		if !gov.AgentEligibleForCELKick(k.Agent) || agentMgr.IsPaused(k.Agent) {
@@ -6269,6 +6286,17 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			budgetData, err := json.Marshal(budgetHist)
 			if err == nil {
 				atomicWrite("/data/budget-window-history.json", budgetData)
+			}
+		}
+
+		// #4263: convergence soak telemetry, written atomically on the same
+		// cadence as the other series so a pod roll cannot lose more of one
+		// than the others.
+		soakHist := dashSrv.ConvergenceSoakHistory()
+		if len(soakHist) > 0 {
+			soakData, err := json.Marshal(soakHist)
+			if err == nil {
+				atomicWrite("/data/convergence-soak-history.json", soakData)
 			}
 		}
 	}

--- a/src/pkg/config/convergence.go
+++ b/src/pkg/config/convergence.go
@@ -9,23 +9,26 @@ import (
 // convergence-driven admission surfaces (kubestellar/hive#3845).
 //
 // Everything the convergence follow-on increments add — admission DIAGNOSTICS
-// (#4246) and internal-kick admission observation (#4247) — ships behind this
-// toggle, DEFAULT OFF, so an existing v4 hive sees zero behaviour change until
-// an operator opts in. #4263 will formalise the full off/shadow/enforce
-// rollout; until then only the two conservative modes below exist:
+// (#4246), internal-kick admission observation (#4247), and the #4263 rollout
+// formalisation — ships behind this toggle, DEFAULT OFF, so an existing v4
+// hive sees zero behaviour change until an operator opts in. The three modes:
 //
 //   - "off" (default): no convergence decisions are surfaced or applied by the
-//     gated code paths; they are entirely inert.
+//     gated code paths; they are entirely inert. Exact pre-enrollment baseline.
 //   - "shadow": decisions are computed and surfaced as read-only diagnostics
-//     (API/SSE fields, log lines) but NEVER enforced — no kick is withheld, no
-//     queue row changes, no routing changes.
+//     (API/SSE fields, log lines, soak telemetry) but NEVER enforced — no kick
+//     is withheld, no queue row changes, no routing changes.
+//   - "enforce": the SAME decision shadow computes may gate ONLY the explicitly
+//     enrolled path — the #4247 internal scheduled/cached issue-dispatch
+//     boundary. Every path not explicitly enrolled behaves identically in all
+//     three modes.
 //
 // This toggle does NOT govern the contributor-neutral admission already landed
 // by #3857/#3904 (ReadyQueue/selectTask dependency gating) — that is existing,
-// shipped v4 behaviour and is unchanged in either mode.
+// shipped v4 behaviour and is unchanged in every mode.
 type ConvergenceConfig struct {
-	// Mode is "off" or "shadow". Any other value (including empty) resolves to
-	// "off" — the fail-safe direction is always "do nothing new".
+	// Mode is "off", "shadow", or "enforce". Any other value (including empty)
+	// resolves to "off" — the fail-safe direction is always "do nothing new".
 	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
 }
 
@@ -35,6 +38,11 @@ const (
 	// ConvergenceModeShadow computes and surfaces decisions as diagnostics
 	// only; nothing is enforced.
 	ConvergenceModeShadow = "shadow"
+	// ConvergenceModeEnforce applies the SAME decision shadow computes to the
+	// explicitly enrolled internal-dispatch path (#4247's kick boundary) and
+	// nothing else. It is never a default and never selected by fallback: only
+	// an exact, validated operator choice resolves to it.
+	ConvergenceModeEnforce = "enforce"
 
 	// ConvergenceModeEnvVar overrides the configured mode at the process level,
 	// so an operator can flip shadow on/off without editing hive.yaml.
@@ -59,16 +67,31 @@ func (c *Config) ConvergenceMode() string {
 	return ConvergenceModeOff
 }
 
-// normalizeConvergenceMode maps a raw operator-supplied string to a known mode.
-// The second return is false when the value names no known mode (callers fall
-// through to the next source, ultimately "off").
-func normalizeConvergenceMode(raw string) (string, bool) {
+// ConvergenceModes lists the valid modes in rollout order, for settings UIs
+// and validation error messages.
+func ConvergenceModes() []string {
+	return []string{ConvergenceModeOff, ConvergenceModeShadow, ConvergenceModeEnforce}
+}
+
+// NormalizeConvergenceMode maps a raw operator-supplied string to a known mode.
+// The second return is false when the value names no known mode. Runtime
+// setting writers use it to REJECT an invalid mode before any live mutation or
+// persistence; the read path (ConvergenceMode) instead falls through to the
+// next source, ultimately "off" — an invalid value can never silently select
+// enforcement.
+func NormalizeConvergenceMode(raw string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case ConvergenceModeOff:
 		return ConvergenceModeOff, true
 	case ConvergenceModeShadow:
 		return ConvergenceModeShadow, true
+	case ConvergenceModeEnforce:
+		return ConvergenceModeEnforce, true
 	default:
 		return "", false
 	}
+}
+
+func normalizeConvergenceMode(raw string) (string, bool) {
+	return NormalizeConvergenceMode(raw)
 }

--- a/src/pkg/config/convergence_test.go
+++ b/src/pkg/config/convergence_test.go
@@ -35,7 +35,7 @@ func TestConvergenceMode_ConfiguredShadow(t *testing.T) {
 
 func TestConvergenceMode_UnrecognisedValueFailsSafeToOff(t *testing.T) {
 	t.Setenv(ConvergenceModeEnvVar, "")
-	for _, raw := range []string{"enforce", "on", "true", "garbage"} {
+	for _, raw := range []string{"on", "true", "garbage", "enforced", "enforce-all"} {
 		cfg := &Config{Convergence: ConvergenceConfig{Mode: raw}}
 		if got := cfg.ConvergenceMode(); got != ConvergenceModeOff {
 			t.Fatalf("mode %q resolved %q, want off", raw, got)
@@ -58,8 +58,14 @@ func TestConvergenceMode_EnvOverridesConfig(t *testing.T) {
 
 	// An unrecognised env value must NOT clobber a valid configured mode —
 	// the env only wins when it names a mode this build knows.
-	t.Setenv(ConvergenceModeEnvVar, "enforce")
+	t.Setenv(ConvergenceModeEnvVar, "garbage")
 	if got := cfg.ConvergenceMode(); got != ConvergenceModeShadow {
 		t.Fatalf("unrecognised env over config=shadow resolved %q, want shadow", got)
+	}
+
+	// #4263: "enforce" is a known mode and the env override may select it.
+	t.Setenv(ConvergenceModeEnvVar, "enforce")
+	if got := cfg.ConvergenceMode(); got != ConvergenceModeEnforce {
+		t.Fatalf("env=enforce over config=shadow resolved %q, want enforce", got)
 	}
 }

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -163,6 +163,13 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	// lives on the governor Features tab — see api_config_automerge.go.
 	s.mux.HandleFunc("GET /api/config/auto-merge", s.handleAutoMergeGet)
 	s.mux.HandleFunc("PUT /api/config/auto-merge", s.handleAutoMergePut)
+	// convergence is a top-level Config field (not GovernorConfig); its UI
+	// lives on the governor Features tab — see api_config_convergence.go
+	// (#4263 off/shadow/enforce rollout). The soak endpoint is the
+	// fixed-commit telemetry read path (convergence_soak.go).
+	s.mux.HandleFunc("GET /api/config/convergence", s.handleConvergenceConfigGet)
+	s.mux.HandleFunc("PUT /api/config/convergence", s.handleConvergenceConfigPut)
+	s.mux.HandleFunc("GET /api/convergence/soak", s.handleConvergenceSoak)
 	s.mux.HandleFunc("GET /api/config/governor/advisory", s.handleGovernorAdvisoryGet)
 	s.mux.HandleFunc("PUT /api/config/governor/advisory", s.handleGovernorAdvisoryPut)
 	s.mux.HandleFunc("GET /api/config/governor/replan", s.handleGovernorReplanGet)
@@ -4203,6 +4210,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		"features":    featuresSectionResponse(cfg),
 		"review":      cfg.Review,
 		"auto_merge":  autoMergeSectionResponse(cfg),
+		"convergence": s.convergenceSectionResponse(cfg),
 		"advisory":    advisorySectionResponse(cfg),
 		"replan":      replanSectionResponse(cfg),
 		"work_source": workSourceSectionResponse(cfg),

--- a/src/pkg/dashboard/api_config_convergence.go
+++ b/src/pkg/dashboard/api_config_convergence.go
@@ -1,0 +1,104 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// ── #4263: owner-gated runtime control for the convergence rollout mode ────────
+//
+// One top-level `convergence` settings block, following the auto_merge/review
+// top-level precedents: OWNER-ONLY read and update (requireOwnerRole, which
+// only trusts the server-verified live-role marker — a client-supplied role
+// header is never enough), validate BEFORE mutating anything, mutate the live
+// config, persist through saveConfig (which skips the next watcher reload so
+// an older file snapshot cannot immediately overwrite the update), and audit.
+//
+// The change is live: the eval-cycle seam re-captures the effective mode at
+// the start of every pass (CaptureConvergenceMode), so no rebuild or restart
+// is needed, and a pass already in flight finishes under its captured pair.
+// External YAML edits flow through the existing config watcher and the same
+// capture point; HIVE_CONVERGENCE_MODE remains the process-level override and
+// is surfaced (not hidden) by the GET below.
+
+// handleConvergenceConfigGet returns the convergence rollout block plus the
+// resolved effective mode and its captured generation.
+func (s *Server) handleConvergenceConfigGet(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, s.convergenceSectionResponse(s.deps.Config))
+}
+
+// handleConvergenceConfigPut updates convergence.mode. An invalid mode is
+// rejected with 400 BEFORE any live mutation or persistence — the previous
+// effective mode/generation remains active, and an unknown value can never
+// silently select enforcement.
+func (s *Server) handleConvergenceConfigPut(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Mode string `json:"mode"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	// --- validate before mutating anything ---
+	mode, ok := config.NormalizeConvergenceMode(body.Mode)
+	if !ok {
+		jsonError(w, fmt.Sprintf("invalid convergence mode %q: must be one of %s",
+			body.Mode, strings.Join(config.ConvergenceModes(), ", ")), http.StatusBadRequest)
+		return
+	}
+
+	// --- apply ---
+	cfg := s.deps.Config
+	previous := cfg.ConvergenceMode()
+	cfg.Convergence.Mode = mode
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after convergence mode update", "error", err)
+	}
+	s.auditFromRequest(r, "config_convergence",
+		auditDetail("section", "convergence", "mode", mode, "previous_effective", previous), "")
+	if s.logger != nil && previous != cfg.ConvergenceMode() {
+		s.logger.Info("convergence rollout mode updated via runtime settings",
+			"mode", cfg.ConvergenceMode(), "previous", previous)
+	}
+	jsonResponse(w, s.convergenceSectionResponse(cfg))
+}
+
+// convergenceSectionResponse renders the convergence block for the dashboard:
+// the CONFIGURED mode (what the file says), the EFFECTIVE mode (after the
+// HIVE_CONVERGENCE_MODE override), whether that override is in force, and the
+// captured generation the eval loop is judging under.
+func (s *Server) convergenceSectionResponse(cfg *config.Config) map[string]interface{} {
+	configured := config.ConvergenceModeOff
+	if m, ok := config.NormalizeConvergenceMode(cfg.Convergence.Mode); ok {
+		configured = m
+	}
+	effective := cfg.ConvergenceMode()
+	_, envOverride := config.NormalizeConvergenceMode(os.Getenv(config.ConvergenceModeEnvVar))
+	_, generation := s.ConvergenceModeGeneration()
+	return map[string]interface{}{
+		"mode":           configured,
+		"effective_mode": effective,
+		"env_override":   envOverride,
+		"generation":     generation,
+		"modes":          config.ConvergenceModes(),
+	}
+}

--- a/src/pkg/dashboard/convergence_kick.go
+++ b/src/pkg/dashboard/convergence_kick.go
@@ -55,15 +55,27 @@ type ConvergenceKickFinding struct {
 // the GitHub-only bead observer and are admitted on its behalf, exactly as
 // evaluateContributorNeutralAdmission does (kubestellar/hive#4245 boundary).
 func (s *Server) ConvergenceKickProjection(issues []ghpkg.Issue) (admitted []ghpkg.Issue, withheld []ConvergenceKickFinding) {
+	admitted, withheld, _ = s.ConvergenceKickProjectionDetailed(issues)
+	return admitted, withheld
+}
+
+// ConvergenceKickProjectionDetailed is ConvergenceKickProjection plus the
+// sweep's ledger-coverage report (#4263 soak telemetry needs the partial-
+// coverage fact per pass). Same single sweep, same observer, same evaluator —
+// the coverage is projected from the sweep that judged the candidates, so the
+// counts and the coverage cannot disagree about the state they saw.
+func (s *Server) ConvergenceKickProjectionDetailed(issues []ghpkg.Issue) (admitted []ghpkg.Issue, withheld []ConvergenceKickFinding, coverage AdmissionCoverage) {
 	admitted = make([]ghpkg.Issue, 0, len(issues))
+	coverage = AdmissionCoverage{Policy: admissionCoveragePolicy}
 	if s == nil || s.contributeHub == nil {
-		return append(admitted, issues...), nil
+		return append(admitted, issues...), nil, coverage
 	}
 	hub := s.contributeHub
 	// One sweep for the whole pass — the same per-pass snapshot discipline the
 	// contributor paths use, so every candidate in this projection is judged
 	// against one consistent view of current ledger state.
 	sweep := hub.newAdmissionSweep()
+	coverage = hub.admissionCoverageFromSweep(sweep)
 	for _, issue := range issues {
 		candidate := kickAdmissionCandidate(issue)
 		if !candidate.isGitHubBacked() {
@@ -77,7 +89,7 @@ func (s *Server) ConvergenceKickProjection(issues []ghpkg.Issue) (admitted []ghp
 		}
 		withheld = append(withheld, ConvergenceKickFinding{Issue: issue, Decision: decision})
 	}
-	return admitted, withheld
+	return admitted, withheld, coverage
 }
 
 // kickAdmissionCandidate normalises one enumerated issue into the shared

--- a/src/pkg/dashboard/convergence_rollout.go
+++ b/src/pkg/dashboard/convergence_rollout.go
@@ -1,0 +1,108 @@
+package dashboard
+
+import (
+	"sync"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// ── #4263: off/shadow/enforce rollout — captured mode + configuration generation
+//
+// Every enrolled evaluation pass must judge ALL of its candidates under ONE
+// (mode, generation) pair, even when an owner flips the runtime setting midway
+// through the pass — the strict acceptance matrix forbids a mixed-mode sweep.
+// This tracker is that capture point: the eval-cycle seam calls
+// CaptureConvergenceMode exactly once at the start of a pass, uses the returned
+// pair for every candidate, and the NEXT pass picks up any change.
+//
+// The generation is a monotonic, process-local counter that advances only when
+// the EFFECTIVE mode actually changes (API PUT, external YAML reload through
+// the watcher, or an environment override observed at capture time all funnel
+// through the same effective-mode read, so every source is covered uniformly).
+// It exists for soak attribution: a fixed-commit comparison must be able to
+// tell records from "shadow before the flip to enforce and back" apart from
+// "shadow after", even though the mode string is identical.
+//
+// changed is reported ONLY on a genuine transition — never on the first
+// capture after boot — so the caller's one-time notification fires on the
+// crossing, not once per process start and never once per cycle (the #4305
+// probe-notification discipline).
+type convergenceModeTracker struct {
+	mu         sync.Mutex
+	seen       bool
+	mode       string
+	generation uint64
+}
+
+// capture folds the current effective mode into the tracker, returning the
+// pair to use for this pass plus transition facts.
+func (t *convergenceModeTracker) capture(effective string) (mode string, generation uint64, changed bool, previous string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.seen {
+		t.seen = true
+		t.mode = effective
+		t.generation = 1
+		return t.mode, t.generation, false, ""
+	}
+	if effective != t.mode {
+		previous = t.mode
+		t.mode = effective
+		t.generation++
+		return t.mode, t.generation, true, previous
+	}
+	return t.mode, t.generation, false, ""
+}
+
+// current returns the last captured pair without folding a new observation.
+// Before the first capture it reports generation 0 with the given effective
+// mode, so read-only surfaces (the settings API, the soak endpoint) never
+// perturb the generation the eval loop owns.
+func (t *convergenceModeTracker) current(effective string) (string, uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.seen {
+		return effective, 0
+	}
+	return t.mode, t.generation
+}
+
+// convergenceRollout lazily constructs the tracker so a zero-value Server —
+// as used in tests that do `&Server{}` — works without a constructor change,
+// exactly like budgetWindows does for the per-window history.
+func (s *Server) convergenceRollout() *convergenceModeTracker {
+	s.convergenceModeOnce.Do(func() {
+		s.convergenceModeTrk = &convergenceModeTracker{}
+	})
+	return s.convergenceModeTrk
+}
+
+// effectiveConvergenceMode reads the current effective mode through the config
+// resolution chain (env override, then configured value, then "off").
+// Nil-safe: a Server with no config resolves to "off".
+func (s *Server) effectiveConvergenceMode() string {
+	if s == nil || s.deps == nil {
+		return (*config.Config)(nil).ConvergenceMode()
+	}
+	return s.deps.Config.ConvergenceMode()
+}
+
+// CaptureConvergenceMode is the once-per-pass capture point for the enrolled
+// eval-cycle seam (#4247's kick boundary). The caller supplies the effective
+// mode it resolved from the live config (cfg.ConvergenceMode()), so the seam
+// and the tracker cannot disagree about which configuration object is
+// authoritative. Every candidate in the pass that calls this MUST use the
+// returned pair; a concurrent settings change becomes effective on the next
+// pass.
+func (s *Server) CaptureConvergenceMode(effective string) (mode string, generation uint64, changed bool, previous string) {
+	if _, ok := config.NormalizeConvergenceMode(effective); !ok {
+		effective = config.ConvergenceModeOff
+	}
+	return s.convergenceRollout().capture(effective)
+}
+
+// ConvergenceModeGeneration reports the last captured (mode, generation) pair
+// for read-only surfaces, without advancing anything.
+func (s *Server) ConvergenceModeGeneration() (string, uint64) {
+	return s.convergenceRollout().current(s.effectiveConvergenceMode())
+}

--- a/src/pkg/dashboard/convergence_rollout_test.go
+++ b/src/pkg/dashboard/convergence_rollout_test.go
@@ -1,0 +1,244 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// ── #4263: off/shadow/enforce runtime rollout — settings surface, captured
+// mode/generation, and fixed-commit soak telemetry ────────────────────────────
+
+const convergence4263Token = "shared-secret-token-4263"
+
+func convergenceRequest(s *Server, method, path, body string, owner bool) *httptest.ResponseRecorder {
+	var rdr *strings.Reader
+	if body == "" {
+		rdr = strings.NewReader("")
+	} else {
+		rdr = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	req.Header.Set("Content-Type", "application/json")
+	if owner {
+		req.Header.Set("Authorization", "Bearer "+s.authToken)
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+// TestConvergenceConfig_DefaultIsOff pins the compatibility guarantee: a config
+// with no convergence block reads back mode "off" with effective mode "off".
+func TestConvergenceConfig_DefaultIsOff(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	s := newFullServer(t)
+	s.authToken = convergence4263Token
+
+	w := convergenceRequest(s, http.MethodGet, "/api/config/convergence", "", true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if resp["mode"] != "off" || resp["effective_mode"] != "off" {
+		t.Fatalf("default must be off/off, got %v", resp)
+	}
+	modes, _ := resp["modes"].([]interface{})
+	if len(modes) != 3 {
+		t.Fatalf("modes must list off/shadow/enforce, got %v", resp["modes"])
+	}
+}
+
+// TestConvergenceConfig_NonOwnerRejected: both the settings surface and the
+// soak telemetry are owner-only through the full middleware stack.
+func TestConvergenceConfig_NonOwnerRejected(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	s := newFullServer(t)
+	s.authToken = convergence4263Token
+
+	for _, probe := range []struct{ method, path, body string }{
+		{http.MethodGet, "/api/config/convergence", ""},
+		{http.MethodPut, "/api/config/convergence", `{"mode":"enforce"}`},
+		{http.MethodGet, "/api/convergence/soak", ""},
+	} {
+		w := convergenceRequest(s, probe.method, probe.path, probe.body, false)
+		if w.Code == http.StatusOK {
+			t.Fatalf("%s %s without owner credentials must be rejected, got 200", probe.method, probe.path)
+		}
+	}
+	if s.deps.Config.ConvergenceMode() != config.ConvergenceModeOff {
+		t.Fatal("a rejected non-owner PUT must not change the live mode")
+	}
+}
+
+// TestConvergenceConfig_InvalidModeRejectedBeforeMutation: an invalid mode is a
+// 400 and neither the live config nor the persisted overlay changes — the
+// previous effective mode remains active, and an unknown value can never
+// silently select enforcement.
+func TestConvergenceConfig_InvalidModeRejectedBeforeMutation(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	s := newFullServer(t)
+	s.authToken = convergence4263Token
+	s.deps.Config.Convergence.Mode = config.ConvergenceModeShadow
+
+	for _, bad := range []string{"enforced", "on", "garbage", ""} {
+		w := convergenceRequest(s, http.MethodPut, "/api/config/convergence", `{"mode":"`+bad+`"}`, true)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("mode %q = %d, want 400; body=%q", bad, w.Code, w.Body.String())
+		}
+	}
+	if got := s.deps.Config.ConvergenceMode(); got != config.ConvergenceModeShadow {
+		t.Fatalf("live mode after rejected updates = %q, want shadow (unchanged)", got)
+	}
+}
+
+// TestConvergenceConfig_OwnerUpdateIsLiveAndPersisted: a valid owner PUT
+// mutates the live config (the next captured pass sees it — no rebuild or
+// restart) and round-trips through the GET.
+func TestConvergenceConfig_OwnerUpdateIsLiveAndPersisted(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	s := newFullServer(t)
+	s.authToken = convergence4263Token
+
+	w := convergenceRequest(s, http.MethodPut, "/api/config/convergence", `{"mode":" Enforce "}`, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if got := s.deps.Config.ConvergenceMode(); got != config.ConvergenceModeEnforce {
+		t.Fatalf("live mode = %q, want enforce", got)
+	}
+	// The very next captured pass judges under the new mode.
+	mode, gen, _, _ := s.CaptureConvergenceMode(s.deps.Config.ConvergenceMode())
+	if mode != config.ConvergenceModeEnforce || gen == 0 {
+		t.Fatalf("next captured pass = (%q, %d), want enforce with a live generation", mode, gen)
+	}
+
+	var resp map[string]interface{}
+	g := convergenceRequest(s, http.MethodGet, "/api/config/convergence", "", true)
+	if err := json.Unmarshal(g.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if resp["mode"] != "enforce" || resp["effective_mode"] != "enforce" {
+		t.Fatalf("GET after PUT = %v, want enforce", resp)
+	}
+}
+
+// TestConvergenceModeTracker_OnePairPerPassAndTransitionOnce pins the captured
+// (mode, generation) contract: the first capture is not a transition, a real
+// change advances the generation and reports changed exactly once, and an
+// unchanged mode keeps the same pair for every candidate in a pass.
+func TestConvergenceModeTracker_OnePairPerPassAndTransitionOnce(t *testing.T) {
+	s := &Server{}
+
+	mode, gen, changed, _ := s.CaptureConvergenceMode(config.ConvergenceModeOff)
+	if mode != "off" || gen != 1 || changed {
+		t.Fatalf("first capture = (%q,%d,changed=%v), want (off,1,false)", mode, gen, changed)
+	}
+	// Same mode: same pair, no transition.
+	mode, gen, changed, _ = s.CaptureConvergenceMode(config.ConvergenceModeOff)
+	if mode != "off" || gen != 1 || changed {
+		t.Fatalf("repeat capture = (%q,%d,changed=%v), want (off,1,false)", mode, gen, changed)
+	}
+	// Flip to shadow: one transition, one generation bump.
+	mode, gen, changed, prev := s.CaptureConvergenceMode(config.ConvergenceModeShadow)
+	if mode != "shadow" || gen != 2 || !changed || prev != "off" {
+		t.Fatalf("transition = (%q,%d,changed=%v,prev=%q), want (shadow,2,true,off)", mode, gen, changed, prev)
+	}
+	// The next identical pass must NOT report the transition again (no spam).
+	_, _, changed, _ = s.CaptureConvergenceMode(config.ConvergenceModeShadow)
+	if changed {
+		t.Fatal("an unchanged mode must not re-report the transition")
+	}
+	// Flip-flop back to off is distinguishable from never having left it.
+	_, gen, _, _ = s.CaptureConvergenceMode(config.ConvergenceModeOff)
+	if gen != 3 {
+		t.Fatalf("generation after off→shadow→off = %d, want 3", gen)
+	}
+	// An invalid effective value fails safe to off, never to enforcement.
+	mode, _, _, _ = s.CaptureConvergenceMode("garbage")
+	if mode != "off" {
+		t.Fatalf("invalid effective mode captured %q, want off", mode)
+	}
+}
+
+// TestConvergenceSoak_RecordSnapshotSeedBounded pins the telemetry ring:
+// commit attribution is stamped, order is newest-first, a save/load round trip
+// preserves rows across restart, and retention is bounded.
+func TestConvergenceSoak_RecordSnapshotSeedBounded(t *testing.T) {
+	s := &Server{}
+	s.RecordConvergenceSoak(ConvergenceSoakEntry{Timestamp: 1, Mode: "shadow", Generation: 1, RawIssues: 2, Admitted: 1, Blocked: 1})
+	s.RecordConvergenceSoak(ConvergenceSoakEntry{Timestamp: 2, Mode: "enforce", Generation: 2, RawIssues: 2, Admitted: 1, Blocked: 1, Enforced: true, WouldDiffer: true})
+
+	hist := s.ConvergenceSoakHistory()
+	if len(hist) != 2 || hist[0].Timestamp != 2 || hist[1].Timestamp != 1 {
+		t.Fatalf("snapshot must be newest-first: %+v", hist)
+	}
+	if hist[0].Commit == "" || hist[0].EnrolledPath != convergenceSoakEnrolledPath {
+		t.Fatalf("commit/enrolled-path attribution missing: %+v", hist[0])
+	}
+
+	// Durability across restart: marshal → fresh server → seed → same rows.
+	data, err := json.Marshal(hist)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var restored []ConvergenceSoakEntry
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	fresh := &Server{}
+	fresh.SeedConvergenceSoak(restored)
+	got := fresh.ConvergenceSoakHistory()
+	if len(got) != 2 || got[0].Timestamp != 2 || got[0].Mode != "enforce" || !got[0].WouldDiffer {
+		t.Fatalf("restart round trip lost rows: %+v", got)
+	}
+
+	// Bounded retention: overfill keeps only the newest entries.
+	over := &Server{}
+	for i := 0; i < convergenceSoakMaxEntries+10; i++ {
+		over.RecordConvergenceSoak(ConvergenceSoakEntry{Timestamp: int64(i)})
+	}
+	bounded := over.ConvergenceSoakHistory()
+	if len(bounded) != convergenceSoakMaxEntries {
+		t.Fatalf("retention = %d entries, want %d", len(bounded), convergenceSoakMaxEntries)
+	}
+	if bounded[0].Timestamp != int64(convergenceSoakMaxEntries+9) {
+		t.Fatalf("newest entry lost by the cap: %+v", bounded[0])
+	}
+}
+
+// TestConvergenceSoak_EndpointServesAttributedRows: the owner read path serves
+// commit, mode/generation, enrolled path, and the recorded rows.
+func TestConvergenceSoak_EndpointServesAttributedRows(t *testing.T) {
+	t.Setenv(config.ConvergenceModeEnvVar, "")
+	s := newFullServer(t)
+	s.authToken = convergence4263Token
+	s.RecordConvergenceSoak(ConvergenceSoakEntry{Timestamp: 42, Mode: "shadow", Generation: 1, RawIssues: 3, Admitted: 2, Blocked: 1, WouldDiffer: true})
+
+	w := convergenceRequest(s, http.MethodGet, "/api/convergence/soak", "", true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET soak = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Commit       string                 `json:"commit"`
+		Mode         string                 `json:"mode"`
+		EnrolledPath string                 `json:"enrolled_path"`
+		Entries      []ConvergenceSoakEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if resp.Commit == "" || resp.Mode == "" || resp.EnrolledPath != convergenceSoakEnrolledPath {
+		t.Fatalf("missing commit/mode attribution: %+v", resp)
+	}
+	if len(resp.Entries) != 1 || resp.Entries[0].Blocked != 1 || !resp.Entries[0].WouldDiffer {
+		t.Fatalf("rows not served: %+v", resp.Entries)
+	}
+}

--- a/src/pkg/dashboard/convergence_soak.go
+++ b/src/pkg/dashboard/convergence_soak.go
@@ -1,0 +1,174 @@
+package dashboard
+
+import (
+	"net/http"
+	"sync"
+)
+
+// ── #4263: fixed-commit soak telemetry ─────────────────────────────────────────
+//
+// The maintainer's comparison requirement: an owner must be able to hold the
+// Hive commit, models, prompts/policies, and workload constant while changing
+// ONLY the convergence rollout mode, and later compare what each treatment
+// did. That comparison needs durable per-eval-cycle facts attributed to the
+// running commit and the captured (mode, generation) pair — which is exactly
+// one bounded row per enrolled pass, never an unbounded subject-timeseries
+// store (subject-level snapshots stay ephemeral in the #4246 diagnostics).
+//
+// Pattern: budget-window-history.json (#4298) — a small leaf-locked ring,
+// seeded on startup, snapshotted newest-first, persisted atomically by the
+// main persist loop on the same cadence as the other series.
+
+// convergenceSoakMaxEntries caps the ring. At the default 60s eval cadence,
+// 2880 entries is two days of continuous soak per treatment leg — enough to
+// compare off/shadow/enforce runs back to back — while staying a few hundred
+// KB on disk. A named constant so retention is a deliberate number.
+const convergenceSoakMaxEntries = 2880
+
+// convergenceSoakEnrolledPath names the one currently enrolled guard. Later
+// guard enrollments add their own value; the field exists so records from
+// different enrolled paths can never be conflated.
+const convergenceSoakEnrolledPath = "internal_kick_dispatch"
+
+// ConvergenceSoakEntry is one enrolled evaluation pass, as the soak endpoint
+// serves it and the persist loop stores it.
+//
+// Timestamps are epoch milliseconds, matching every other history series the
+// dashboard persists. Commit and Mode/Generation are recorded PER ROW rather
+// than read live, for the same reason budget history stores its limit: a later
+// upgrade or mode flip must not rewrite what past rows ran under.
+type ConvergenceSoakEntry struct {
+	// Timestamp is when the pass completed its convergence projection.
+	Timestamp int64 `json:"timestamp"`
+	// Commit is the ldflags-baked short SHA of the RUNNING binary — the
+	// fixed-commit attribution anchor (pattern: pkg/tracing reach counters).
+	Commit string `json:"commit"`
+	// Mode and Generation are the pair captured at the start of the pass; every
+	// candidate in the pass was judged under them.
+	Mode       string `json:"mode"`
+	Generation uint64 `json:"generation"`
+	// EnrolledPath names the guard this row measured (convergenceSoakEnrolledPath).
+	EnrolledPath string `json:"enrolled_path"`
+	// RawIssues / Admitted / Blocked / Unknown count the pass's candidate
+	// dispositions: the raw enumerated population, the admitted projection, and
+	// the withheld findings split by established-blocked vs irreducibly-unknown.
+	RawIssues int `json:"raw_issues"`
+	Admitted  int `json:"admitted"`
+	Blocked   int `json:"blocked"`
+	Unknown   int `json:"unknown"`
+	// PartialLedger records whether the sweep read less than the full bead
+	// ledger (the #3904 partial-coverage compromise was in force).
+	PartialLedger bool `json:"partial_ledger"`
+	// WouldDiffer is true when enforcement would have changed (or, in enforce,
+	// DID change) the dispatched population — the shadow-vs-baseline fact the
+	// comparison exists to collect.
+	WouldDiffer bool `json:"would_differ"`
+	// Enforced records whether the withheld candidates were actually removed
+	// from the dispatched population (mode "enforce") or only reported.
+	Enforced bool `json:"enforced"`
+	// DecisionLatencyMs is how long the pass's observation + evaluation took,
+	// for cross-treatment overhead comparison.
+	DecisionLatencyMs int64 `json:"decision_latency_ms"`
+}
+
+// convergenceSoakTracker is the bounded ring. Leaf-locked: nothing here calls
+// back into Server, so the mutex is taken and released inside one method.
+type convergenceSoakTracker struct {
+	mu sync.Mutex
+	// entries holds passes oldest-first.
+	entries []ConvergenceSoakEntry
+}
+
+func (t *convergenceSoakTracker) record(e ConvergenceSoakEntry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.entries = append(t.entries, e)
+	if len(t.entries) > convergenceSoakMaxEntries {
+		t.entries = t.entries[len(t.entries)-convergenceSoakMaxEntries:]
+	}
+}
+
+// snapshot returns a copy of the recorded passes, newest FIRST — the order an
+// operator reads them in, and the order the API serves.
+func (t *convergenceSoakTracker) snapshot() []ConvergenceSoakEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]ConvergenceSoakEntry, 0, len(t.entries))
+	for i := len(t.entries) - 1; i >= 0; i-- {
+		out = append(out, t.entries[i])
+	}
+	return out
+}
+
+// seed restores persisted telemetry on startup. Entries arrive newest-first
+// (the order snapshot emits) and are stored oldest-first internally, so a
+// save/load round trip preserves order. Over-long input is truncated to the
+// newest entries rather than rejected. Unlike reach counters, rows from OTHER
+// commits are deliberately KEPT: the whole point of the soak file is comparing
+// treatments across a fixed commit — and detecting when the commit was NOT
+// fixed — so history must survive both restarts and upgrades, attributed row
+// by row.
+func (t *convergenceSoakTracker) seed(entries []ConvergenceSoakEntry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.entries = t.entries[:0]
+	for i := len(entries) - 1; i >= 0; i-- {
+		t.entries = append(t.entries, entries[i])
+	}
+	if len(t.entries) > convergenceSoakMaxEntries {
+		t.entries = t.entries[len(t.entries)-convergenceSoakMaxEntries:]
+	}
+}
+
+// convergenceSoak lazily constructs the tracker so a zero-value Server works
+// in tests without a constructor change (the budgetWindows pattern).
+func (s *Server) convergenceSoak() *convergenceSoakTracker {
+	s.convergenceSoakOnce.Do(func() {
+		s.convergenceSoakTrk = &convergenceSoakTracker{}
+	})
+	return s.convergenceSoakTrk
+}
+
+// RecordConvergenceSoak appends one enrolled pass. The running commit is
+// stamped here so every caller gets consistent attribution; a missing enrolled
+// path gets the current one. Timestamp must be set by the caller (it knows
+// when the pass ran).
+func (s *Server) RecordConvergenceSoak(e ConvergenceSoakEntry) {
+	if e.Commit == "" {
+		e.Commit = versionShort
+	}
+	if e.EnrolledPath == "" {
+		e.EnrolledPath = convergenceSoakEnrolledPath
+	}
+	s.convergenceSoak().record(e)
+}
+
+// ConvergenceSoakHistory returns the recorded passes, newest first. Empty on a
+// hive that has never run with the toggle on — ordinary, never an error.
+func (s *Server) ConvergenceSoakHistory() []ConvergenceSoakEntry {
+	return s.convergenceSoak().snapshot()
+}
+
+// SeedConvergenceSoak restores persisted telemetry on startup.
+func (s *Server) SeedConvergenceSoak(entries []ConvergenceSoakEntry) {
+	s.convergenceSoak().seed(entries)
+}
+
+// handleConvergenceSoak serves GET /api/convergence/soak — the longitudinal
+// read/export path. OWNER-ONLY, matching the settings surface that controls
+// the mode: the soak comparison is an operator concern and the rows carry
+// repository work identifiers.
+func (s *Server) handleConvergenceSoak(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	mode, generation := s.ConvergenceModeGeneration()
+	jsonResponse(w, map[string]interface{}{
+		"commit":        versionShort,
+		"mode":          mode,
+		"generation":    generation,
+		"enrolled_path": convergenceSoakEnrolledPath,
+		"max_entries":   convergenceSoakMaxEntries,
+		"entries":       s.ConvergenceSoakHistory(),
+	})
+}

--- a/src/pkg/dashboard/convergence_ui_test.go
+++ b/src/pkg/dashboard/convergence_ui_test.go
@@ -1,0 +1,54 @@
+package dashboard
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// ── #4263: convergence rollout settings + soak summary UI ──────────────────────
+//
+// Guard for the renderAll()/hiveToast() class of bug: every function the new
+// convergence UI calls must actually be DEFINED in the inline script, so a
+// click cannot throw ReferenceError and get mislabelled as an action failure
+// by a nearby catch block (the budget_reset_ui_test.go pattern).
+func TestConvergenceUIHasNoUndefinedCallees(t *testing.T) {
+	b, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	html := string(b)
+
+	// The Features tab must render the owner-only convergence rollout control
+	// (off/shadow/enforce), dirty-tracked under the 'convergence' section, and
+	// the soak summary surface.
+	for _, snippet := range []string{
+		`data-arg0="convergence" data-arg1="mode"`,
+		`data-action="loadConvergenceSoak"`,
+		`id="convergence-soak-summary"`,
+		`'/api/config/convergence'`,
+		`/api/convergence/soak`,
+		`case 'loadConvergenceSoak': loadConvergenceSoak(); break;`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q", snippet)
+		}
+	}
+
+	// Every function the new UI paths call must be defined somewhere in the
+	// inline script. A dispatch case or handler that names an undefined
+	// function is exactly the renderAll() bug.
+	for _, fn := range []string{
+		"loadConvergenceSoak",
+		"markDirty",
+		"esc",
+		"showToast",
+		"saveErrorMessage",
+		"_inceptionAuthHeaders",
+	} {
+		defined := regexp.MustCompile(`(?:function\s+` + regexp.QuoteMeta(fn) + `\s*\(|(?:const|let|var)\s+` + regexp.QuoteMeta(fn) + `\s*=)`)
+		if !defined.MatchString(html) {
+			t.Errorf("index.html calls %s() from the convergence UI but never defines it", fn)
+		}
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -104,6 +104,14 @@ type Server struct {
 	budgetWindowOnce sync.Once
 	budgetWindowHist *budgetWindowTracker
 
+	// convergenceModeTrk captures one (mode, generation) pair per enrolled
+	// eval pass and detects transitions (#4263). convergenceSoakTrk records the
+	// bounded per-pass soak telemetry. Both lazily built like the rings above.
+	convergenceModeOnce sync.Once
+	convergenceModeTrk  *convergenceModeTracker
+	convergenceSoakOnce sync.Once
+	convergenceSoakTrk  *convergenceSoakTracker
+
 	// lastFullBroadcast is guarded by statusMu (set/read alongside s.status).
 	lastFullBroadcast time.Time
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -13419,6 +13419,7 @@ function burnAreaChart() {
         case 'nousSetMode': nousSetMode(el.dataset.mode || el.dataset.arg0); break;
         case 'nousSetScope': nousSetScope(el.dataset.scope || el.dataset.arg0); break;
         case 'toggleConfigSwitch': toggleConfigSwitch(el, el.dataset.section, el.dataset.key); break;
+        case 'loadConvergenceSoak': loadConvergenceSoak(); break;
         case 'toggleEscalationEnabled': toggleEscalationEnabled(el); break;
         case 'removeListItem': removeListItem(el.dataset.section || el.dataset.arg0, el.dataset.key || el.dataset.arg1, parseInt(el.dataset.index !== undefined ? el.dataset.index : el.dataset.arg2, 10)); break;
         case 'toggleRestriction': { if (el.dataset.index !== undefined) { const cb = el.querySelector('input[type=checkbox]') || el; toggleRestriction(parseInt(el.dataset.index, 10), cb.checked); } else { toggleRestriction(parseInt(el.dataset.arg0, 10), el.checked); } } break;
@@ -19681,6 +19682,7 @@ function burnAreaChart() {
       f = f || {};
       am = am || {};
       rv = rv || {};
+      const cv = (_configState.data || {}).convergence || {};
       const planOn = f.planFromLabel === true;
       const amSelfOn = am.self_authored !== false; // nil/undefined = enabled
       const amChecks = Array.isArray(am.required_checks) ? am.required_checks : [];
@@ -19778,6 +19780,21 @@ function burnAreaChart() {
           <div class="config-field" style="margin-top:10px">
             <label>Fixer agent <span class="config-info">i<span class="config-tooltip">The agent kicked to address reviewer findings before re-review.</span></span></label>
             <input type="text" value="${esc(rv.fixer_agent || '')}" placeholder="fixer" data-change-action="markDirty" data-arg0="review" data-arg1="fixer_agent" data-arg-types="s,s,w">
+          </div>
+        </div>
+
+        <div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--border)">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">Convergence Rollout <span class="config-info">i<span class="config-tooltip">Runtime rollout mode for convergence-driven admission of internal agent kicks (#3845/#4263). Off (default): no change from baseline. Shadow: decisions are computed and recorded but never enforced. Enforce: blocked/unknown work is withheld from internal scheduled/cached kicks. Live — no restart needed.</span></span></div>
+          <div class="config-field">
+            <label>Mode <span class="config-info">i<span class="config-tooltip">Default is off — existing behavior is unchanged until you opt in. Shadow and enforce consume the same decision, so you can soak-compare a fixed commit under each treatment.</span></span></label>
+            <select data-change-action="markDirty" data-arg0="convergence" data-arg1="mode" data-arg-types="s,s,v">
+              ${(Array.isArray(cv.modes) ? cv.modes : ['off','shadow','enforce']).map(m => `<option value="${esc(m)}" ${cv.mode === m ? 'selected' : ''}>${esc(m)}</option>`).join('')}
+            </select>
+            ${cv.env_override ? `<p style="font-size:0.72rem;color:var(--yellow);margin:4px 0 0">HIVE_CONVERGENCE_MODE is set — the effective mode is <strong>${esc(cv.effective_mode || 'off')}</strong> regardless of this setting.</p>` : `<p style="font-size:0.72rem;color:var(--muted);margin:4px 0 0">Effective mode: <strong>${esc(cv.effective_mode || 'off')}</strong> (generation ${cv.generation || 0}).</p>`}
+          </div>
+          <div class="config-field" style="margin-top:10px">
+            <button class="btn" data-action="loadConvergenceSoak">Load soak summary</button>
+            <div id="convergence-soak-summary" style="font-size:0.72rem;color:var(--muted);margin-top:6px"></div>
           </div>
         </div>
 
@@ -20007,6 +20024,39 @@ function burnAreaChart() {
     function toggleConfigSwitch(el, section, key) {
       const isOn = el.classList.toggle('on');
       markDirty(section, key, isOn);
+    }
+
+    // loadConvergenceSoak fetches the owner-only fixed-commit soak telemetry
+    // (#4263) and renders a per-(commit, mode) summary so an operator can
+    // compare off/shadow/enforce treatments of the same workload at a glance.
+    async function loadConvergenceSoak() {
+      const out = document.getElementById('convergence-soak-summary');
+      if (!out) return;
+      out.textContent = 'Loading…';
+      try {
+        const res = await fetch('/api/convergence/soak');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        const entries = Array.isArray(data.entries) ? data.entries : [];
+        if (!entries.length) {
+          out.textContent = 'No soak telemetry recorded yet — set mode to shadow or enforce and let eval cycles run.';
+          return;
+        }
+        const groups = {};
+        for (const e of entries) {
+          const k = `${e.commit || '?'} / ${e.mode || '?'} (gen ${e.generation || 0})`;
+          if (!groups[k]) groups[k] = { passes: 0, admitted: 0, blocked: 0, unknown: 0, differ: 0, latency: 0 };
+          const g = groups[k];
+          g.passes++; g.admitted += e.admitted || 0; g.blocked += e.blocked || 0;
+          g.unknown += e.unknown || 0; g.differ += e.would_differ ? 1 : 0;
+          g.latency += e.decision_latency_ms || 0;
+        }
+        out.innerHTML = Object.entries(groups).map(([k, g]) =>
+          `<div><strong>${esc(k)}</strong>: ${g.passes} passes, ${g.admitted} admitted, ${g.blocked} blocked, ${g.unknown} unknown, ${g.differ} would-differ, avg latency ${(g.latency / g.passes).toFixed(1)}ms</div>`
+        ).join('');
+      } catch (err) {
+        out.textContent = `Failed to load soak telemetry: ${err.message}`;
+      }
     }
 
     // markPromptSourceDirty reads the four GitHub prompt-source inputs and records
@@ -20512,6 +20562,17 @@ function burnAreaChart() {
               body: JSON.stringify(values)
             });
             if (!amRes.ok) throw new Error(await saveErrorMessage(amRes));
+          } else if (_configState.type === 'governor' && section === 'convergence') {
+            // convergence is a TOP-LEVEL config block, not under governor —
+            // it saves through its own owner-only /api/config/convergence
+            // endpoint (#4263 off/shadow/enforce rollout).
+            const cvRes = await fetch('/api/config/convergence', {
+              method: 'PUT',
+              headers: _inceptionAuthHeaders(),
+              body: JSON.stringify(values)
+            });
+            if (!cvRes.ok) throw new Error(await saveErrorMessage(cvRes));
+            _configState.data.convergence = await cvRes.json().catch(() => _configState.data.convergence);
           } else if (_configState.type === 'governor' && section === 'review') {
             // review is a TOP-LEVEL config block, not under governor —
             // it saves through its own /api/config/review endpoint.


### PR DESCRIPTION
Closes #4263
Part of #3845

## What

Formalises the maintainer-requested runtime rollout control (#4263, parent #3845): convergence is now controllable from Hive's **main runtime settings** as `off` / `shadow` / `enforce`, extending — not duplicating — the merged #4246 diagnostics toggle and #4247 kick-boundary seam into **one mode applicator** (`applyConvergenceKickAdmission`) that every later guard enrollment consumes. No per-feature booleans.

### Mode contract
| Mode | Observation/evaluation | Behavioral result |
|---|---|---|
| `off` (default) | Skipped entirely | Exact pre-enrollment baseline — byte-for-byte the pre-#4247 kick path |
| `shadow` | Same observer/evaluator as enforce, once per pass | Baseline dispatch; decision reported in logs + soak telemetry only |
| `enforce` | The **same** decision shadow computes | Gates **only** the enrolled #4247 internal scheduled/cached issue payloads (`SetLastActionable` + `BuildKickMessages`); PRs, holds, governor counts, dashboard status, PR/review dispatch, and every non-enrolled path stay on the raw population |

### Runtime control (owner-gated, live, persisted)
- `GET/PUT /api/config/convergence` following the `auto_merge`/`review` top-level settings precedent: `requireOwnerRole` (server-verified live role), **strict validation before mutation** (invalid mode → 400, previous effective mode/generation stays active — an unknown value can never silently select enforcement), `saveConfig` persistence, audit, governor **Features tab** selector.
- `HIVE_CONVERGENCE_MODE` env override retained and *surfaced* by the GET; external YAML edits flow through the existing config watcher.
- **Live-switchable, no rebuild/restart**: the eval seam captures one `(mode, generation)` pair at the start of every pass; every candidate in a pass is judged and attributed under that captured pair — a concurrent flip takes effect on the next pass, never a mixed-mode sweep. Switching `enforce` → `off` restores the exact baseline on the next pass with no queue surgery or state migration.
- Mode **transitions** are logged + notified exactly once per crossing (the #4305 transition-only discipline — never at boot, never per cycle).

### Fixed-commit soak telemetry (maintainer's comparison requirement)
One bounded row per enrolled pass while in shadow/enforce:
```json
{"timestamp": 0, "commit": "<running short SHA>", "mode": "shadow", "generation": 2,
 "enrolled_path": "internal_kick_dispatch", "raw_issues": 2, "admitted": 1,
 "blocked": 1, "unknown": 0, "partial_ledger": false, "would_differ": true,
 "enforced": false, "decision_latency_ms": 3}
```
Ring bounded at 2880 rows, persisted atomically to `/data/convergence-soak-history.json` on the same cadence as the other history series (budget-window-history pattern), seeded on startup — so an owner can hold Hive commit, models, prompts, and workload constant and compare `off` vs `shadow` vs `enforce`. Read/export: owner-only `GET /api/convergence/soak` + a soak summary in the Features tab.

## Default-off guarantee

**An existing config with no `convergence` block — or any unrecognised value — resolves to `off`, where every gated code path is inert and existing v4 users see zero user-visible change.** The shipped #3857/#3904 contributor dependency admission is existing v4 baseline behavior and is deliberately not governed by this toggle in any mode.

## Tests

Strict-matrix production-path tests: default off (config + API), off = zero enforcement AND zero admission influence (same pointer returned, zero telemetry), shadow computes-but-never-blocks (baseline dispatch + would-differ row), enforce gates blocked/unknown while ready control and PR/hold payloads ride through untouched, enforce→off baseline restore without restart, one captured pair per pass with monotonic generation across flips, transition logged once on the crossing only, telemetry durability across restart (seed round trip) + bounded retention + commit/mode attribution, settings owner-gating through the full middleware stack, invalid-mode rejection before mutation, and a static-HTML guard that every JS function the new UI calls is defined (renderAll/hiveToast bug class). `go test -race` clean on the touched suites; `pkg/dashboard` at 83.3% (floor 78); inline JS passes `check-inline-js.js`.