### PR TITLE
✨ feat(hub): report where hub users are — country column and fleet rollup

### DIFF
--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -551,6 +551,11 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", s.requireAdmin(s.handleDenyProvision))
 	s.mux.HandleFunc("GET /api/saas/admin/available-placeholders", s.requireAdmin(s.handleAvailablePlaceholders))
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
+	// Aggregate geographic rollup of the user base (counts only, no usernames).
+	// Admin-gated like the rest of the CRM/Users surface: country is personal
+	// data, so even the aggregate stays behind requireAdmin. Takes no query
+	// parameters — no country ever appears in a URL. See user_country_rollup.go.
+	s.mux.HandleFunc("GET /api/saas/admin/user-countries", s.requireAdmin(s.handleAdminUserCountries))
 	// #3234: fleet readiness for removing the N1/N2 legacy compatibility lanes.
 	s.mux.HandleFunc("GET /api/saas/admin/auth-rollout", s.requireAdmin(s.handleAuthRollout))
 	// Master-secret rotation (src/docs/design/master-key-rotation.md). Both are
@@ -9527,6 +9532,15 @@ const dashboardHTML = `<!DOCTYPE html>
       </div>
       <div id="admin-users-body" style="display:none">
         <div id="users-container"><div class="loading">Loading users...</div></div>
+        <!-- Fleet-wide geographic rollup of the user base. Lives directly under
+             the Users table because it is the same data aggregated: the table
+             answers "who", this answers "where, overall". Inside
+             admin-users-body so it collapses with the section, and admin-gated
+             twice over — the section is display:none until the admin check
+             passes, and the endpoint it reads is behind requireAdmin.
+             Rendered as a plain ranked bar list; no map, no charting library,
+             no external asset (the hub forbids external CDNs/images). -->
+        <div id="user-countries-container" style="margin-top:20px"></div>
       </div>
     </div>
 
@@ -17462,6 +17476,10 @@ const dashboardHTML = `<!DOCTYPE html>
         var data = await resp.json();
         _allUsers = data.users || [];
         try { applySortUsers(); } catch(re) { console.error('renderUsers error:', re); }
+        /* Rollup rides the same admin poll as the table it sits under, so the
+           two can never disagree about the roster. Not awaited: a slow or
+           failed rollup must not delay or break the users table. */
+        loadUserCountries();
       } catch(e) {
         if (!_adminLoaded) document.getElementById('admin-section').style.display = 'none';
       } finally {
@@ -17471,6 +17489,103 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function filterUsers() {
       applySortUsers();
+    }
+
+    /* ---- Fleet country rollup -------------------------------------------
+       Where the hub's user base is, in aggregate. Reads
+       /api/saas/admin/user-countries, which is requireAdmin and returns COUNTS
+       only — no usernames — so this surface cannot be used to look up an
+       individual.
+
+       Deliberately NOT a map and NOT a chart: the hub ships no external CDN and
+       no external images, so a map would mean vendoring geometry and a charting
+       library would mean a script tag we cannot serve. A ranked bar list says
+       the same thing in less space and is readable at a glance.
+
+       The unknown bucket is rendered as its own row, always, with the same
+       weight as a country. Country is optional and best-effort, so early on
+       unknown IS the majority; hiding it would turn "3 of 200 users told us
+       they're in DE" into something that looks like "the fleet is German". */
+
+    /* Width of the widest bar, in percent of the list. The bars are scaled
+       against the LARGEST bucket rather than the total so the smaller
+       countries stay visible when one bucket dominates — which it will, since
+       unknown starts at ~100%. */
+    var COUNTRY_BAR_MAX_PCT = 100;
+
+    /* countryRollupRow renders one bucket. label is pre-built HTML (a flag+code
+       chip, or the plain "Unknown" text); everything else is numeric. */
+    function countryRollupRow(label, count, max, total) {
+      /* max is guaranteed >= 1 by the caller — see renderCountryRollup, which
+         returns early on an empty population. Guarding again here anyway
+         because a zero would silently produce NaN% and a bar that vanishes
+         rather than an error anyone would notice. */
+      var pct = (max > 0) ? Math.round((count / max) * COUNTRY_BAR_MAX_PCT) : 0;
+      var share = (total > 0) ? Math.round((count / total) * 100) : 0;
+      return '<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">' +
+        '<div style="flex:none;width:72px;font-size:0.72rem;color:var(--text)">' + label + '</div>' +
+        '<div style="flex:1;height:8px;background:var(--border);border-radius:4px;overflow:hidden">' +
+          '<div style="width:' + pct + '%;height:100%;background:var(--accent)"></div>' +
+        '</div>' +
+        '<div style="flex:none;width:84px;text-align:right;font-size:0.7rem;color:var(--muted)">' +
+          count + ' &middot; ' + share + '%</div>' +
+      '</div>';
+    }
+
+    function renderCountryRollup(data) {
+      var el = document.getElementById('user-countries-container');
+      if (!el) return;
+      var countries = (data && data.countries) || [];
+      var unknown = Number(data && data.unknown) || 0;
+      var total = Number(data && data.total) || 0;
+      /* No users at all is the only case with nothing to say. An all-unknown
+         population is NOT this case: it still renders, as a single 100% Unknown
+         bar, which is exactly the state the operator needs to see on day one. */
+      if (total <= 0) {
+        el.innerHTML = '<div style="font-size:0.75rem;color:var(--muted)">No users yet.</div>';
+        return;
+      }
+      /* Scale against the biggest bucket, unknown included, so no bar can ever
+         exceed 100%. Floored at 1 so the divide is safe even if a future caller
+         reaches here with all-zero counts. */
+      var max = unknown;
+      countries.forEach(function(c) { if (Number(c.count) > max) max = Number(c.count); });
+      if (max < 1) max = 1;
+
+      var rows = countries.map(function(c) {
+        /* The server normalizes before sending; normalizing again is what
+           guarantees a legacy or hand-edited record can never emit half a code
+           point into the flag. A code that fails the check is dropped rather
+           than rendered raw. */
+        var code = normalizeCountryCode(c && c.code);
+        if (!code) return '';
+        var label = '<span style="display:inline-flex;align-items:center;gap:4px">' +
+          countryFlagHTML(code) + esc(code) + '</span>';
+        return countryRollupRow(label, Number(c.count) || 0, max, total);
+      }).join('');
+
+      /* Unknown is last (it is not a country and should not head a ranked list
+         of them) but always present, and labelled in --muted so it reads as an
+         absence rather than as a place. */
+      var unknownLabel = '<span style="color:var(--muted)">Unknown</span>';
+      rows += countryRollupRow(unknownLabel, unknown, max, total);
+
+      el.innerHTML =
+        '<div style="font-size:0.85rem;color:var(--accent);font-weight:600;margin-bottom:8px">' +
+          'Where users are &mdash; ' + countries.length + ' countr' + (countries.length === 1 ? 'y' : 'ies') +
+          ', ' + unknown + ' unknown of ' + total +
+        '</div>' + rows;
+    }
+
+    async function loadUserCountries() {
+      try {
+        var resp = await fetch('/api/saas/admin/user-countries');
+        /* 403 means not admin. Leave the container empty rather than writing an
+           error: a non-admin should learn nothing about this surface, not even
+           that it exists and refused them. */
+        if (!resp.ok) return;
+        renderCountryRollup(await resp.json());
+      } catch(e) {}
     }
 
     // --- Admin Users: contact / CRM fields -------------------------------
@@ -17484,7 +17599,8 @@ const dashboardHTML = `<!DOCTYPE html>
 
     // Number of columns in the admin users table. Panel/expand rows span the
     // full width, so this must track the <th> count in renderUsers.
-    var USERS_TABLE_COLSPAN = 8;
+    // 9 since the Country column landed.
+    var USERS_TABLE_COLSPAN = 9;
     // Rows of the notes textarea. Big enough for a short paragraph without
     // pushing the next user off screen. It is the only free-form prose field,
     // so it gets the height as well as the width; still user-resizable.
@@ -17643,6 +17759,28 @@ const dashboardHTML = `<!DOCTYPE html>
         ' style="display:inline-flex;align-items:center;gap:4px;padding:1px 7px;border-radius:9999px;' +
         'font-size:0.6rem;font-weight:600;color:' + meta.color + ';background:' + meta.bg + '">' +
         (logo ? logo : '') + esc(meta.label) + '</span>';
+    }
+
+    /* countryCell renders the user's country in the admin Users table as
+       flag + alpha-2 code, following the providerBadge chip above rather than
+       inventing a second visual language for a per-row attribute: same
+       inline-flex chip, same 4px gap, same small type.
+
+       Unknown or unset renders NOTHING — an empty cell, no globe, no dash, no
+       "unknown" chip. That is #4371's rule and it matters most here, where a
+       column of placeholders would read as data we have. The rollup below the
+       table is where the size of the unknown bucket is stated explicitly; the
+       row is not the place to repeat it 200 times.
+
+       countryFlagHTML already normalizes and escapes; the code is escaped again
+       for the visible text because the render path must not depend on the
+       validator upstream of it staying correct. Color is the --muted theme
+       token so the code recedes next to the name in both light and dark. */
+    function countryCell(u) {
+      var code = normalizeCountryCode(u && u.country);
+      if (!code) return '';
+      return '<span style="display:inline-flex;align-items:center;gap:4px;font-size:0.7rem;color:var(--muted)">' +
+        countryFlagHTML(code) + esc(code) + '</span>';
     }
 
     // renderContactCell is the collapsed summary shown in the main user row.
@@ -18316,6 +18454,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td style="font-size:0.75rem;color:var(--muted)">' + esc(fmtUserTS(u.created_at)) + '</td>' +
           '<td style="font-size:0.75rem;color:var(--muted)">' + esc(fmtUserTS(u.last_login)) + '</td>' +
           '<td style="text-align:left">' + renderContactCell(u) + '</td>' +
+          '<td>' + countryCell(u) + '</td>' +
           '<td>' + statusCell + '</td>' +
           '<td><input type="number" min="0" max="10" value="' + (u.saas_quota || 0) + '" style="width:50px;padding:4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);text-align:center" onchange="updateUser(\'' + esc(u.github_username) + '\',{saas_quota:parseInt(this.value)||0})"></td>' +
           '<td>' + (hiveCount > 0 ? '<a href="#" onclick="toggleAdminExpand(\'' + esc(u.github_username) + '\');return false" style="color:var(--blue);font-size:0.8rem">' + hiveCount + ' hive' + (hiveCount > 1 ? 's' : '') + '</a>' : '<span style="color:var(--muted)">0</span>') + '</td>' +
@@ -18324,7 +18463,7 @@ const dashboardHTML = `<!DOCTYPE html>
       }).join('');
       document.getElementById('users-container').innerHTML =
         '<table class="hive-table"><thead><tr>' +
-        '<th onclick="sortUsers(\'github_username\')" style="cursor:pointer">User ⇅</th><th onclick="sortUsers(\'created_at\')" style="cursor:pointer">Joined ⇅</th><th onclick="sortUsers(\'last_login\')" style="cursor:pointer">Last Login ⇅</th><th onclick="sortUsers(\'full_name\')" style="cursor:pointer">Contact ⇅</th><th onclick="sortUsers(\'status\')" style="cursor:pointer">Status ⇅</th><th onclick="sortUsers(\'saas_quota\')" style="cursor:pointer">Quota ⇅</th><th onclick="sortUsers(\'hiveCount\')" style="cursor:pointer">Hives ⇅</th><th>Actions</th>' +
+        '<th onclick="sortUsers(\'github_username\')" style="cursor:pointer">User ⇅</th><th onclick="sortUsers(\'created_at\')" style="cursor:pointer">Joined ⇅</th><th onclick="sortUsers(\'last_login\')" style="cursor:pointer">Last Login ⇅</th><th onclick="sortUsers(\'full_name\')" style="cursor:pointer">Contact ⇅</th><th onclick="sortUsers(\'country\')" style="cursor:pointer">Country ⇅</th><th onclick="sortUsers(\'status\')" style="cursor:pointer">Status ⇅</th><th onclick="sortUsers(\'saas_quota\')" style="cursor:pointer">Quota ⇅</th><th onclick="sortUsers(\'hiveCount\')" style="cursor:pointer">Hives ⇅</th><th>Actions</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
       // The contact panels are built as raw HTML above; wire their listeners
       // once the rows are actually in the DOM. Inline on* handlers are avoided

--- a/src/pkg/hub/user_country_rollup.go
+++ b/src/pkg/hub/user_country_rollup.go
@@ -1,0 +1,110 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+)
+
+// Fleet-wide country rollup: how many hub users we can place in each country,
+// plus how many we cannot place at all.
+//
+// This is ADOPTION REPORTING. The operator's question is "where is our user
+// base?", and the honest answer to that question has two halves: the ranked
+// countries AND the size of the unknown bucket. Country is optional and
+// best-effort (see user_country.go), so early on the unknown bucket is expected
+// to be the MAJORITY of the roster. A rollup that quietly dropped it would
+// report a distribution over a self-selected subset while looking like a
+// distribution over everyone — which is how you end up confidently reading a
+// 3-user sample as a fleet trend. So unknown is a first-class, always-emitted
+// field, never a row that can be filtered out or sorted away.
+//
+// PRIVACY. This surface is aggregate-only and admin-gated (registered behind
+// requireAdmin, like the rest of the CRM/Users surface). It emits COUNTS, never
+// usernames, so it cannot be used to look up an individual's country — the
+// per-user value is already visible to the same admin in the Users table, and
+// to nobody else. Nothing is written, nothing is inferred here, and no country
+// ever appears in a URL or query string: the response is a JSON body on a GET
+// with no parameters.
+
+// countryRollupEntry is one country's share of the roster.
+//
+// Code is the normalized ISO 3166-1 alpha-2 code; the flag glyph is NOT sent.
+// The client derives it from the code with the same regional-indicator
+// arithmetic every other render site uses (countryFlagHTML in the dashboard),
+// so there is exactly one place that decides what a country looks like and a
+// malformed code degrades to silence at the render site rather than shipping a
+// broken glyph down the wire.
+type countryRollupEntry struct {
+	Code  string `json:"code"`
+	Count int    `json:"count"`
+}
+
+// countryRollup is the whole answer: the ranked known countries and the count
+// we could not place.
+//
+// Unknown has NO omitempty, deliberately. Zero unknown is a real and meaningful
+// state ("we know where everyone is"), and it must be distinguishable from
+// "this build forgot to send the field". Countries is likewise always present
+// as an array — see buildCountryRollup for why it is never nil.
+type countryRollup struct {
+	Countries []countryRollupEntry `json:"countries"`
+	Unknown   int                  `json:"unknown"`
+	// Total is every user counted, known and unknown. Sent rather than left to
+	// the client to re-add, so the percentage the UI draws and the counts it
+	// lists can never disagree about the denominator.
+	Total int `json:"total"`
+}
+
+// buildCountryRollup aggregates a user list into the rollup.
+//
+// Split out from the handler so the aggregation is testable without a server,
+// and so the ordering rule lives in one readable place.
+//
+// Ordering: count DESCENDING, then code ASCENDING as the tie-break. The
+// tie-break is not cosmetic — Go map iteration is randomized, so without it two
+// countries with equal counts would swap places on every poll and the list
+// would visibly shuffle while nothing changed.
+//
+// Countries is always a non-nil slice. A nil slice marshals to JSON `null`,
+// and `null.length` throws in the browser where `[].length` is 0 — so an
+// all-unknown population (the expected state on day one) would take out the
+// whole rollup render rather than showing "0 known, N unknown". Allocating the
+// empty slice is what makes the empty case boring.
+func buildCountryRollup(users []SaaSUser) countryRollup {
+	counts := make(map[string]int)
+	unknown := 0
+	for i := range users {
+		// normalizeCountryCode is the single arbiter of "usable country" — the
+		// same one the storage and render paths use. A legacy or hand-edited
+		// record holding junk therefore counts as UNKNOWN here rather than
+		// creating a phantom country of one, which keeps the rollup's total
+		// equal to the roster size no matter what is on disk.
+		if code := normalizeCountryCode(users[i].Country); code != "" {
+			counts[code]++
+			continue
+		}
+		unknown++
+	}
+	entries := make([]countryRollupEntry, 0, len(counts))
+	for code, n := range counts {
+		entries = append(entries, countryRollupEntry{Code: code, Count: n})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Count != entries[j].Count {
+			return entries[i].Count > entries[j].Count
+		}
+		return entries[i].Code < entries[j].Code
+	})
+	return countryRollup{Countries: entries, Unknown: unknown, Total: len(users)}
+}
+
+// handleAdminUserCountries serves the rollup. Registered behind requireAdmin,
+// so a non-admin gets the gate's 403 and no data at all — not an empty rollup,
+// which would be indistinguishable from "nobody has a country yet" and would
+// still confirm the roster size via Total.
+func (s *HubServer) handleAdminUserCountries(w http.ResponseWriter, r *http.Request) {
+	rollup := buildCountryRollup(listAllSaaSUsers())
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(rollup)
+}

--- a/src/pkg/hub/user_country_rollup_test.go
+++ b/src/pkg/hub/user_country_rollup_test.go
@@ -1,0 +1,403 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Tests for the geographic REPORTING surface: the Country column in the admin
+// Users table and the fleet-wide rollup beneath it.
+//
+// Two halves, matching the two kinds of code involved:
+//
+//   - buildCountryRollup is real Go and is tested by calling it.
+//   - The table cell and the rollup list live inside the dashboardHTML raw
+//     string, so they are guarded house-style (see
+//     saas_dashboard_hive_sort_test.go): assert on the rendered markup, because
+//     a typo in there is invisible to the compiler and only shows up as a blank
+//     column or a dead click in a browser.
+
+// mkUserCountry writes a user carrying a country, so the rollup and the render
+// tests have a roster with real geography on it.
+func mkUserCountry(t *testing.T, username, country string) {
+	t.Helper()
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: username,
+		Country:        country,
+		Hives:          map[string]string{},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser(%s): %v", username, err)
+	}
+}
+
+// --- The Country column -----------------------------------------------------
+
+// TestUsersTableCountryColumnRendersFlagAndCode asserts the row cell exists and
+// is built from #4371's helpers rather than a second, duplicate derivation.
+//
+// The specific failure this guards: someone adds a country column that emits a
+// raw code with no flag, or hand-rolls its own regional-indicator arithmetic
+// that then drifts from countryFlagEmoji. There must be exactly one place that
+// decides what a country looks like.
+func TestUsersTableCountryColumnRendersFlagAndCode(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		// The cell renderer itself.
+		"function countryCell(u)",
+		// Flag comes from #4371's helper, not from a fresh implementation.
+		"countryFlagHTML(code)",
+		// ...and the alpha-2 code renders beside it, escaped.
+		"esc(code)",
+		// The cell is actually placed in the row. Without this the function
+		// exists, the tests on it pass, and the column never appears.
+		"'<td>' + countryCell(u) + '</td>'",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — the Users table country cell is not wired", snippet)
+		}
+	}
+}
+
+// TestUsersTableCountryUnknownRendersNothing is the negative half, and the one
+// that is easy to regress: a user with NO country must render an empty cell —
+// no globe, no em dash, no "unknown" chip. That is #4371's rule, and it matters
+// most in a column, where a screenful of placeholders reads as data we have.
+//
+// Asserted by pinning the early return: countryCell bails before emitting any
+// markup when normalizeCountryCode yields "".
+func TestUsersTableCountryUnknownRendersNothing(t *testing.T) {
+	html := dashScript(t)
+	i := strings.Index(html, "function countryCell(u)")
+	if i < 0 {
+		t.Fatal("countryCell is missing from dashboardHTML")
+	}
+	// Bound the search to the function body so a matching string elsewhere in
+	// the 20k-line dashboard cannot make this pass for the wrong reason.
+	body := html[i:]
+	if j := strings.Index(body, "\n    }"); j > 0 {
+		body = body[:j]
+	}
+	if !strings.Contains(body, "if (!code) return '';") {
+		t.Error("countryCell does not return '' for an unknown country — an unset country must render NOTHING, no placeholder glyph")
+	}
+	// Positive control: the same body must still be capable of rendering a
+	// flag. Without this, deleting the whole function body would pass the
+	// assertion above by accident.
+	if !strings.Contains(body, "countryFlagHTML(") {
+		t.Error("countryCell no longer renders a flag at all — the assertion above would pass vacuously")
+	}
+}
+
+// TestUsersTableCountryColumnSortableAndColspan asserts the column follows the
+// table's existing mechanisms instead of adding new ones.
+//
+// The colspan is the sharp edge: the contact-editor and hive-expand rows span
+// USERS_TABLE_COLSPAN, so a new <th> that does not bump it leaves those rows
+// one column short and the table visibly ragged.
+func TestUsersTableCountryColumnSortableAndColspan(t *testing.T) {
+	html := dashScript(t)
+	if !strings.Contains(html, `sortUsers(\'country\')`) {
+		t.Error("the Country header is not sortable — neighbouring columns are, so it must use the same sortUsers mechanism")
+	}
+	if !strings.Contains(html, "var USERS_TABLE_COLSPAN = 9;") {
+		t.Error("USERS_TABLE_COLSPAN was not bumped to 9 for the Country column — panel/expand rows will be one column short")
+	}
+}
+
+// --- The rollup aggregation -------------------------------------------------
+
+// TestBuildCountryRollupGroupsAndRanks covers the core aggregation: counts group
+// per country, the list is ranked descending, and the unknown bucket is both
+// present and correct.
+func TestBuildCountryRollupGroupsAndRanks(t *testing.T) {
+	users := []SaaSUser{
+		{GitHubUsername: "a", Country: "US"},
+		{GitHubUsername: "b", Country: "US"},
+		{GitHubUsername: "c", Country: "US"},
+		{GitHubUsername: "d", Country: "GB"},
+		{GitHubUsername: "e", Country: "GB"},
+		{GitHubUsername: "f", Country: "DE"},
+		// Unknown, three different ways: never set, blank, and a malformed
+		// legacy value. All three must land in the unknown bucket rather than
+		// inventing a phantom country.
+		{GitHubUsername: "g"},
+		{GitHubUsername: "h", Country: "   "},
+		{GitHubUsername: "i", Country: "XYZ"},
+	}
+	got := buildCountryRollup(users)
+
+	if got.Total != len(users) {
+		t.Errorf("Total = %d, want %d — the rollup must account for every user", got.Total, len(users))
+	}
+	if got.Unknown != 3 {
+		t.Errorf("Unknown = %d, want 3 (unset, blank, malformed)", got.Unknown)
+	}
+	want := []countryRollupEntry{
+		{Code: "US", Count: 3},
+		{Code: "GB", Count: 2},
+		{Code: "DE", Count: 1},
+	}
+	if len(got.Countries) != len(want) {
+		t.Fatalf("Countries = %+v, want %+v", got.Countries, want)
+	}
+	for i := range want {
+		if got.Countries[i] != want[i] {
+			t.Errorf("Countries[%d] = %+v, want %+v (descending by count)", i, got.Countries[i], want[i])
+		}
+	}
+	// The counted totals must reconcile with Total, or the percentages the UI
+	// draws are over a denominator that does not match the list.
+	sum := got.Unknown
+	for _, c := range got.Countries {
+		sum += c.Count
+	}
+	if sum != got.Total {
+		t.Errorf("counts sum to %d but Total = %d — a user was dropped or double-counted", sum, got.Total)
+	}
+}
+
+// TestBuildCountryRollupNormalizesCase asserts a lowercase or padded stored code
+// folds into the same bucket as its canonical form. Two buckets for "us" and
+// "US" would split a country's count in half and quietly understate it.
+func TestBuildCountryRollupNormalizesCase(t *testing.T) {
+	got := buildCountryRollup([]SaaSUser{
+		{GitHubUsername: "a", Country: "us"},
+		{GitHubUsername: "b", Country: "US"},
+		{GitHubUsername: "c", Country: " Us "},
+	})
+	if len(got.Countries) != 1 || got.Countries[0] != (countryRollupEntry{Code: "US", Count: 3}) {
+		t.Fatalf("Countries = %+v, want a single US bucket of 3", got.Countries)
+	}
+	if got.Unknown != 0 {
+		t.Errorf("Unknown = %d, want 0", got.Unknown)
+	}
+}
+
+// TestBuildCountryRollupAllUnknown is the day-one state and the one most likely
+// to break something: nobody has a country yet.
+//
+// Two invariants. Unknown must equal the roster (not be hidden), and Countries
+// must be an EMPTY slice rather than nil — a nil slice marshals to JSON null,
+// and `null.length` throws in the browser where `[].length` is 0, so the whole
+// rollup would fail to render exactly when the operator most needs to see that
+// the data is empty.
+func TestBuildCountryRollupAllUnknown(t *testing.T) {
+	users := []SaaSUser{{GitHubUsername: "a"}, {GitHubUsername: "b"}, {GitHubUsername: "c"}}
+	got := buildCountryRollup(users)
+
+	if got.Unknown != 3 || got.Total != 3 {
+		t.Errorf("Unknown=%d Total=%d, want 3 and 3", got.Unknown, got.Total)
+	}
+	if got.Countries == nil {
+		t.Fatal("Countries is nil — it must be an empty slice so it marshals to [] not null")
+	}
+	if len(got.Countries) != 0 {
+		t.Errorf("Countries = %+v, want empty", got.Countries)
+	}
+	blob, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(blob), `"countries":null`) {
+		t.Errorf("rollup marshalled countries as null: %s", blob)
+	}
+	// Unknown must survive the wire even at zero, so "we know where everyone
+	// is" stays distinguishable from "this build forgot the field".
+	empty, err := json.Marshal(buildCountryRollup(nil))
+	if err != nil {
+		t.Fatalf("Marshal(empty): %v", err)
+	}
+	if !strings.Contains(string(empty), `"unknown":0`) {
+		t.Errorf("empty rollup dropped the unknown field: %s", empty)
+	}
+}
+
+// --- The rollup endpoint ----------------------------------------------------
+
+// TestHandleAdminUserCountriesServesRollup exercises the handler end to end
+// against real stored users, so a break in listAllSaaSUsers wiring is caught
+// here and not only in the pure aggregation test.
+func TestHandleAdminUserCountriesServesRollup(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUserCountry(t, "alpha", "US")
+	mkUserCountry(t, "bravo", "US")
+	mkUserCountry(t, "charlie", "GB")
+	mkUser(t, "delta") // no country
+
+	rec := httptest.NewRecorder()
+	s.handleAdminUserCountries(rec, httptest.NewRequest(http.MethodGet, "/api/saas/admin/user-countries", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	var got countryRollup
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body=%q)", err, rec.Body.String())
+	}
+	if got.Total != 4 {
+		t.Errorf("Total = %d, want 4", got.Total)
+	}
+	if got.Unknown != 1 {
+		t.Errorf("Unknown = %d, want 1", got.Unknown)
+	}
+	if len(got.Countries) != 2 || got.Countries[0].Code != "US" || got.Countries[0].Count != 2 {
+		t.Fatalf("Countries = %+v, want US:2 then GB:1", got.Countries)
+	}
+	// PRIVACY: the rollup is an aggregate. No username may ride the response,
+	// or an "aggregate" surface quietly becomes a per-user country lookup.
+	for _, name := range []string{"alpha", "bravo", "charlie", "delta"} {
+		if strings.Contains(rec.Body.String(), name) {
+			t.Errorf("rollup response leaked username %q — it must emit counts only: %s", name, rec.Body.String())
+		}
+	}
+}
+
+// TestHandleAdminUserCountriesAdminGated is the access-control regression.
+//
+// It asserts the gate on the SOURCE — the route must be registered inside
+// requireAdmin — and then proves the gate actually refuses a non-admin. The
+// source assertion matters on its own: a future refactor that registers the
+// route bare would leave every user's country distribution readable by any
+// logged-in user, and no behavioral test of the handler function itself would
+// notice, because the handler is not where the gate lives.
+func TestHandleAdminUserCountriesAdminGated(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// 1. The route is wired behind requireAdmin. Read from source the same way
+	// the neighbouring route assertions do (assigned_not_placeholder_test.go),
+	// because the registration is a mux call with no runtime handle to inspect.
+	src, err := os.ReadFile("saas.go")
+	if err != nil {
+		t.Fatalf("read saas.go: %v", err)
+	}
+	if !strings.Contains(string(src), `s.requireAdmin(s.handleAdminUserCountries)`) {
+		t.Error("GET /api/saas/admin/user-countries is not registered behind requireAdmin — the country rollup would be readable by any logged-in user")
+	}
+
+	// 2. The gate refuses a non-admin, with no data in the body.
+	s := newHandlerHub()
+	mkUser(t, hubAdminUsername)
+	mkUserCountry(t, "someone", "US")
+	mkUser(t, "notanadmin")
+
+	gated := s.requireAdmin(s.handleAdminUserCountries)
+
+	rec := httptest.NewRecorder()
+	gated(rec, reqWithUser(http.MethodGet, "/api/saas/admin/user-countries", "", "notanadmin"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin GET: code = %d, want 403; body=%q", rec.Code, rec.Body.String())
+	}
+	// A 403 that still shipped the rollup would be worse than useless.
+	if strings.Contains(rec.Body.String(), `"countries"`) || strings.Contains(rec.Body.String(), `"total"`) {
+		t.Errorf("non-admin got rollup data in a 403 body: %q", rec.Body.String())
+	}
+
+	// 3. Positive control. Without it, a requireAdmin that rejected EVERYONE
+	// would satisfy the check above while breaking the feature outright.
+	rec = httptest.NewRecorder()
+	gated(rec, reqWithUser(http.MethodGet, "/api/saas/admin/user-countries", "", hubAdminUsername))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin GET: code = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"US"`) {
+		t.Errorf("admin GET did not return the rollup: %q", rec.Body.String())
+	}
+}
+
+// --- The rollup UI ----------------------------------------------------------
+
+// TestCountryRollupUIWired asserts the rollup actually renders somewhere an
+// admin will see it, and that it does so without an external dependency.
+func TestCountryRollupUIWired(t *testing.T) {
+	html := dashScript(t)
+	for _, snippet := range []string{
+		// The container, inside the admin section so it inherits its gating
+		// and its collapse.
+		`id="user-countries-container"`,
+		"function renderCountryRollup(data)",
+		"function loadUserCountries()",
+		// Fetched from the admin-gated endpoint...
+		"fetch('/api/saas/admin/user-countries')",
+		// ...and actually invoked on the admin poll. Without this the whole
+		// surface is dead code that every other assertion here still passes.
+		"loadUserCountries();",
+		// Flags in the rollup come from #4371's helper too.
+		"countryFlagHTML(code)",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — the country rollup is not wired", snippet)
+		}
+	}
+}
+
+// TestCountryRollupShowsUnknownBucket pins the invariant the operator called out:
+// the unknown count is reported, not hidden. Early on it will be nearly the
+// whole roster, and a ranked list of three known countries with no denominator
+// would misrepresent a 3-user sample as the fleet's geography.
+func TestCountryRollupShowsUnknownBucket(t *testing.T) {
+	html := dashScript(t)
+	i := strings.Index(html, "function renderCountryRollup(data)")
+	if i < 0 {
+		t.Fatal("renderCountryRollup is missing from dashboardHTML")
+	}
+	body := html[i:]
+	if j := strings.Index(body, "\n    async function loadUserCountries"); j > 0 {
+		body = body[:j]
+	}
+	// The unknown bucket must be rendered as its own row, unconditionally —
+	// appended outside any `if`, the same way an unknown country renders as
+	// silence in the table but as a NUMBER here.
+	if !strings.Contains(body, "rows += countryRollupRow(unknownLabel, unknown, max, total);") {
+		t.Error("renderCountryRollup does not unconditionally append the unknown bucket row")
+	}
+	// ...and it must be summarized in the heading, so the ratio is legible
+	// without reading the bars.
+	if !strings.Contains(body, "' unknown of '") {
+		t.Error("the rollup heading does not state the unknown count against the total")
+	}
+}
+
+// TestCountryRollupHandlesEmptyAndAllUnknown guards the two degenerate
+// populations against a divide-by-zero and against a broken/empty render.
+//
+// An all-unknown roster is NOT the empty case: it must still draw, as a single
+// 100% Unknown bar. Only a genuinely empty roster short-circuits.
+func TestCountryRollupHandlesEmptyAndAllUnknown(t *testing.T) {
+	html := dashScript(t)
+	i := strings.Index(html, "function renderCountryRollup(data)")
+	if i < 0 {
+		t.Fatal("renderCountryRollup is missing from dashboardHTML")
+	}
+	body := html[i:]
+	if j := strings.Index(body, "\n    async function loadUserCountries"); j > 0 {
+		body = body[:j]
+	}
+	// Only an empty roster short-circuits...
+	if !strings.Contains(body, "if (total <= 0)") {
+		t.Error("renderCountryRollup does not handle an empty roster")
+	}
+	// ...and the bar scale is floored, so an all-zero population cannot divide
+	// by zero into NaN% bars.
+	if !strings.Contains(body, "if (max < 1) max = 1;") {
+		t.Error("the bar scale is not floored at 1 — an all-zero population would divide by zero")
+	}
+	// The row helper guards its own divide too, so it is safe independent of
+	// its caller.
+	if !strings.Contains(html, "var pct = (max > 0) ? Math.round((count / max) * COUNTRY_BAR_MAX_PCT) : 0;") {
+		t.Error("countryRollupRow does not guard its percentage divide")
+	}
+	// No external dependency: the hub serves no CDN and no external images, so
+	// the rollup must be plain markup rather than a charting library or a map.
+	for _, banned := range []string{"cdn.jsdelivr", "unpkg.com", "chart.js", "d3.min.js"} {
+		if strings.Contains(html, banned) {
+			t.Errorf("dashboardHTML references %q — the rollup must not pull an external asset", banned)
+		}
+	}
+}


### PR DESCRIPTION
## Stacks on #4371 — merge that first

This is built on `feat/hub-user-country-flag` (#4371) and is **based against that branch**, so the diff here shows only the reporting work. #4371 adds the optional ISO 3166-1 alpha-2 `Country` field on `SaaSUser` and the regional-indicator flag derivation; this PR consumes both and re-implements neither. **Do not merge this before #4371.** Once #4371 lands, this retargets to `v4` cleanly.

A separate PR adds a self-service country picker on top of #4371 independently. This one is **read/reporting only** — no new write endpoints, no profile-menu changes.

## Why

> "We need to start identifying where logged-in users are from."

Adoption reporting. #4371 made the hub *store* a country; this makes it *answerable* — per user in the admin table, and in aggregate across the fleet.

## Users table

A **Country** column between Contact and Status, showing flag + alpha-2 code.

- Follows the existing **provider-badge** chip pattern exactly (same inline-flex, same gap, same small type) rather than inventing a second visual language for a per-row attribute.
- **Sortable** via the table's existing `sortUsers` mechanism — the generic `a[key]` branch handles `country` as-is, so no new sort machinery.
- `USERS_TABLE_COLSPAN` 8 → 9, so the contact-editor and hive-expand rows still span the table.
- **Unknown renders nothing.** No globe, no dash, no "unknown" chip — #4371's rule. It matters most in a column, where a screenful of placeholders reads as data we have.

Flag glyph and code validity both come from #4371's `countryFlagHTML` / `normalizeCountryCode`, so exactly one place decides what a country looks like.

## Fleet rollup

`GET /api/saas/admin/user-countries` → counts per country descending, an explicit unknown bucket, and the total. Rendered directly under the Users table as a compact ranked bar list.

**No map, no charting library** — the hub serves no external CDN and no external images, so this is plain markup with theme tokens (`--accent`, `--muted`, `--border`, `--text`); light and dark both work, nothing hardcoded.

**The unknown bucket is first-class and always emitted.** Country is optional and best-effort, so early on unknown will be the large majority of the roster. A rollup that dropped it would present a distribution over a self-selected subset while looking like a distribution over everyone — which is how three users in DE become a fleet trend. It's stated in the heading *and* drawn as a bar.

Degenerate populations are where a view like this breaks, so each is handled deliberately:

- an **all-unknown roster still renders** (one 100% Unknown bar) — it is not the empty case, and it is the day-one state;
- only a **genuinely empty roster** short-circuits;
- the bar scale is **floored at 1**, and `countryRollupRow` guards its own divide, so no NaN% bars;
- `Countries` is always an **empty slice**, never nil — a nil slice marshals to `null`, and `null.length` throws in the browser exactly when the operator most needs to see that the data is empty;
- `Unknown` has no `omitempty`, so "we know where everyone is" stays distinguishable from "this build forgot the field";
- ties break on code ascending, because Go map iteration is randomized and the list would otherwise visibly shuffle on every poll while nothing changed.

## Privacy

Country is personal data, so the aggregate is treated as carefully as the field.

- **Admin-gated**: registered behind `requireAdmin`, consistent with the rest of the CRM/Users surface. A non-admin gets the gate's 403 and no data — not an empty rollup, which would still confirm the roster size.
- **Counts only, never usernames** — asserted by a test, so this cannot quietly become a per-user country lookup.
- **No country in any URL or query string**: the endpoint takes no parameters.
- Nothing is inferred or written here, no tracking scripts, nothing leaves the box.
- One user's country is never exposed to another non-admin user.

## Tests

House style — assertions on rendered markup (cf. `saas_dashboard_hive_sort_test.go`) for the SPA, direct calls for the Go aggregation.

- a user **with** a country renders flag+code in the row; a user **without** one renders nothing (with a positive control, so an emptied function body can't pass vacuously)
- rollup grouping, descending rank, case/whitespace folding into one bucket, and malformed legacy codes counted as unknown rather than becoming a phantom country of one
- counts reconcile against `Total`, so no user is dropped or double-counted
- **admin gate asserted twice**: on the route source (a refactor registering it bare would leave the distribution readable by any logged-in user, and no handler-level test would notice) and behaviorally, plus a positive control so a reject-everyone regression can't pass
- all-unknown and empty populations: no divide-by-zero, no `null` list, no broken render

Note: `pkg/hub` tests have known pre-existing macOS-only failures; Linux CI is the gate.