### PR TITLE
✨ feat(hub): let a signed-in user set their own country

### DIFF
--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -335,6 +335,27 @@ type SaaSUser struct {
 	// browser that states a region.
 	Country string `json:"country,omitempty"`
 
+	// CountrySetByUser records that the country above was chosen DELIBERATELY
+	// by the user rather than inferred, and it is what makes an explicit CLEAR
+	// stick.
+	//
+	// Without it, "explicit" is inferred from `Country != ""` (see
+	// applyInferredCountry), which is fine for a pick but wrong for a clear: a
+	// user who removes their country via the self-service endpoint leaves an
+	// empty field, and the very next login's Accept-Language inference would
+	// silently put a flag back. "Prefer not to say" would become impossible to
+	// express — and impossible to notice failing, since the flag reappears a
+	// login later, far from the action that was supposed to remove it.
+	//
+	// Set only by the user's own writes: the self-service endpoint
+	// (handleMyCountry) and the wizard pick copied on approval
+	// (applyRequestContactToUser). NEVER set by the login-path inference, which
+	// is precisely the distinction this field exists to draw.
+	//
+	// omitempty bool so every record that has not been through a deliberate
+	// pick — which today is all of them — round-trips byte-identical.
+	CountrySetByUser bool `json:"country_set_by_user,omitempty"`
+
 	// Engagement stats, admin-only (they ride /api/saas/admin/users, which is
 	// requireAdmin). Both omitempty ints so existing records round-trip
 	// byte-identical until the user first logs in / opens a hive after this ships.
@@ -483,6 +504,17 @@ func (s *HubServer) registerSaaSRoutes() {
 	// non-admin legitimately sees their OWN hives' usage; the handler scopes
 	// fleet-wide data to admins itself.
 	s.mux.HandleFunc("GET /api/saas/usage", s.requireAuth(s.handleUsage))
+	// Self-service country: the ONE field a non-admin may write on their own
+	// user record. requireAuth, not requireAdmin — that is the entire point,
+	// since every other SaaSUser write is admin-gated and the wizard is a
+	// one-time surface. The handler resolves the acting user from the SESSION
+	// and the body carries no identity, so this cannot reach anyone else's
+	// record. See handleMyCountry in user_country.go.
+	//
+	// PUT with a JSON body rather than a code in the path: country is personal
+	// data and a URL would put it in access logs, Referer headers and history.
+	s.mux.HandleFunc("GET /api/saas/me/country", s.requireAuth(s.handleMyCountry))
+	s.mux.HandleFunc("PUT /api/saas/me/country", s.requireAuth(s.handleMyCountry))
 	s.mux.HandleFunc("POST /api/saas/lite/enroll", s.requireAuth(s.handleLiteEnroll))
 	s.mux.HandleFunc("POST /api/saas/hives", s.requireAuth(s.handleCreateHive))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
@@ -7055,6 +7087,11 @@ func applyRequestContactToUser(user *SaaSUser, pr *ProvisionRequest) {
 	// rather than trusting the stored request: it may predate the validation.
 	if code := normalizeCountryCode(pr.Country); code != "" {
 		user.Country = code
+		// The wizard pick is a deliberate statement, so stamp it as one — same
+		// marker the self-service endpoint sets. Without this, an approval
+		// would leave the record looking "inferred", and the priority rule
+		// would hold only by the accident of the value being non-empty.
+		user.CountrySetByUser = true
 	}
 }
 
@@ -9061,6 +9098,19 @@ const dashboardHTML = `<!DOCTYPE html>
        of our own — the glyph carries its own, and the box is transparent, so
        this behaves identically in light and dark. */
     .country-flag { font-size: 0.95rem; line-height: 1; vertical-align: middle; margin-left: 2px; }
+    /* The viewer's OWN flag is a button, not a label — it opens the country
+       editor. Stripped of every default button chrome so it reads as the same
+       inline glyph the read-only .country-flag is, and only gains a background
+       on hover/focus to say it is interactive. Transparent by default and
+       var(--muted)/var(--text) otherwise, so it inherits the theme in both
+       light and dark rather than carrying colors of its own. */
+    .country-edit-btn { background: none; border: 0; padding: 0 2px; margin: 0; cursor: pointer;
+      line-height: 1; display: inline-flex; align-items: center; border-radius: 4px; color: var(--muted); }
+    .country-edit-btn:hover, .country-edit-btn:focus-visible { background: var(--surface); color: var(--text); }
+    /* The no-country state. A muted ＋ rather than a globe or a "??" box: it
+       reads as "add one", which is the action available, instead of pretending
+       to be a flag we do not have. */
+    .country-flag-empty { font-size: 0.8rem; line-height: 1; color: var(--muted); }
 
     /* ── Layout ── */
     .content { max-width: 1600px; margin: 0 auto; padding: 2.5rem clamp(1rem, 4vw, 4.5rem) 3rem; }
@@ -9811,6 +9861,151 @@ const dashboardHTML = `<!DOCTYPE html>
       var glyph = countryFlagEmoji(c);
       return '<span class="country-flag" title="' + escAttr(c) + '" ' +
         'role="img" aria-label="' + escAttr(c) + '">' + glyph + '</span>';
+    }
+
+    /* ---- Self-service country editor ------------------------------------
+       The nav flag is the affordance: clicking it opens a small overlay where
+       the signed-in user sets or clears their OWN country. It is the only such
+       surface — the get-started wizard is a one-time gate you pass before you
+       have a hive, so an existing user otherwise has no way to correct or
+       remove a country (including one the hub merely GUESSED from their
+       browser's language). See handleMyCountry in user_country.go.
+
+       Deliberately not a profile page. One field, one overlay, reusing the
+       overlay pattern the assign/timeline/prompt dialogs already use. */
+
+    /* countryDisplayName: the English name for a code, via Intl.DisplayNames —
+       a browser built-in, so the dashboard carries no 250-row country table of
+       its own and cannot drift from one. Falls back to the bare code where the
+       API is missing or the code is unassigned; a code is always better than an
+       empty label. */
+    function countryDisplayName(code) {
+      var c = normalizeCountryCode(code);
+      if (!c) return '';
+      try {
+        var dn = new Intl.DisplayNames(['en'], {type: 'region'});
+        return dn.of(c) || c;
+      } catch (e) { return c; }
+    }
+
+    /* The viewer's own country, mirrored from the auth payload so the editor
+       opens showing what is on file rather than blank. Updated in place after a
+       successful save so the nav and the next open agree without a reload. */
+    var _myCountry = '';
+
+    /* countryNavHTML: the nav's country control for the SIGNED-IN viewer.
+
+       Distinct from countryFlagHTML, which is the read-only glyph used wherever
+       someone ELSE's flag is shown. Here the flag is a button, and — the part
+       that matters for the fleet this endpoint exists to serve — when there is
+       NO country it still renders, as a muted outline, because a user with no
+       flag is exactly the user who needs a way to add one. An invisible control
+       would leave them in the same dead end as before.
+
+       var(--muted) for the empty state and no color of our own for the set
+       state (the emoji carries its own), so both are light- and dark-safe. */
+    function countryNavHTML(code) {
+      var c = normalizeCountryCode(code);
+      var inner, title;
+      if (c) {
+        inner = '<span class="country-flag">' + countryFlagEmoji(c) + '</span>';
+        title = countryDisplayName(c) + ' — click to change';
+      } else {
+        inner = '<span class="country-flag-empty">＋</span>';
+        title = 'Set your country';
+      }
+      return '<button type="button" class="country-edit-btn" onclick="openCountryEditor()" ' +
+        'title="' + escAttr(title) + '" aria-label="' + escAttr(title) + '">' + inner + '</button>';
+    }
+
+    /* openCountryEditor: the overlay. Reads the current value from _myCountry,
+       writes through PUT /api/saas/me/country.
+
+       The code rides the JSON BODY, never a path or query string: country is
+       personal data and a URL is the one place it would land in access logs,
+       Referer headers and browser history. Clearing sends an explicit empty
+       string — which the hub records as a DECISION, so the login-path
+       Accept-Language inference will not quietly put a flag back. */
+    function openCountryEditor() {
+      var overlay = document.createElement('div');
+      overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:3000;display:flex;align-items:center;justify-content:center';
+      var btn = 'padding:7px 14px;border-radius:6px;border:1px solid var(--border);cursor:pointer;font-size:0.8rem';
+      var fld = 'width:100%;padding:8px;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:6px;box-sizing:border-box;font-size:0.85rem;text-transform:uppercase';
+      overlay.innerHTML =
+        '<div style="background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:22px;max-width:400px;width:90%">' +
+        '<h3 style="margin:0 0 10px 0;font-size:1rem">Your country</h3>' +
+        '<p style="margin:0 0 12px 0;color:var(--muted);font-size:0.82rem;line-height:1.5">' +
+        'Shows a small flag beside your avatar. Two-letter country code (ISO 3166-1 alpha-2), ' +
+        'for example GB or JP. Leave it blank for no flag &mdash; we will not guess one for you.</p>' +
+        '<input id="_country-input" type="text" maxlength="2" autocomplete="country" ' +
+        'value="' + escAttr(_myCountry) + '" style="' + fld + '">' +
+        '<div id="_country-preview" style="margin-top:8px;font-size:0.82rem;color:var(--muted);min-height:1.2em"></div>' +
+        '<div id="_country-err" style="display:none;margin-top:8px;font-size:0.8rem;color:#f85149"></div>' +
+        '<div style="display:flex;gap:8px;justify-content:flex-end;margin-top:18px">' +
+        '<button data-act="no" style="' + btn + ';background:transparent;color:var(--text)">Cancel</button>' +
+        '<button data-act="yes" style="' + btn + ';background:var(--accent,#3fb950);color:#fff;border-color:transparent;font-weight:600">Save</button>' +
+        '</div></div>';
+
+      function close() {
+        document.removeEventListener('keydown', onKey);
+        overlay.remove();
+      }
+      function onKey(e) {
+        if (e.key === 'Escape') close();
+        if (e.key === 'Enter') save();
+      }
+      /* Live echo of what the code resolves to, so a typo is visible BEFORE
+         saving rather than as a surprise flag afterwards. Blank input reads as
+         the explicit "no flag" state, not as an error. */
+      function preview() {
+        var el = document.getElementById('_country-input');
+        var pv = document.getElementById('_country-preview');
+        if (!el || !pv) return;
+        var c = normalizeCountryCode(el.value);
+        if (!el.value.trim()) { pv.textContent = 'No flag will be shown.'; return; }
+        if (!c) { pv.textContent = 'Not a two-letter country code yet.'; return; }
+        pv.textContent = countryFlagEmoji(c) + '  ' + countryDisplayName(c);
+      }
+      async function save() {
+        var el = document.getElementById('_country-input');
+        var err = document.getElementById('_country-err');
+        var raw = el ? el.value.trim() : '';
+        /* '' is a legitimate value here (clear); anything else must be a valid
+           code. Checked client-side for a fast message, and again server-side
+           because a client check is a convenience, never a control. */
+        if (raw !== '' && !normalizeCountryCode(raw)) {
+          if (err) { err.textContent = 'Enter a two-letter country code, or leave it blank.'; err.style.display = ''; }
+          return;
+        }
+        try {
+          var resp = await fetch('/api/saas/me/country', {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({country: normalizeCountryCode(raw)})
+          });
+          var data = await resp.json();
+          if (!resp.ok) throw new Error(data.error || 'save failed');
+          _myCountry = normalizeCountryCode(data.country);
+          var nav = document.getElementById('nav-country');
+          if (nav) nav.innerHTML = countryNavHTML(_myCountry);
+          close();
+        } catch (e) {
+          if (err) { err.textContent = 'Error: ' + e.message; err.style.display = ''; }
+        }
+      }
+
+      overlay.addEventListener('click', function(e) {
+        if (e.target === overlay) { close(); return; }
+        var act = e.target.getAttribute && e.target.getAttribute('data-act');
+        if (act === 'yes') save();
+        else if (act === 'no') close();
+      });
+      overlay.addEventListener('input', preview);
+      document.addEventListener('keydown', onKey);
+      document.body.appendChild(overlay);
+      var inp = document.getElementById('_country-input');
+      if (inp) { inp.focus(); inp.select(); }
+      preview();
     }
 
     /* Rendered avatar sizes, in CSS pixels, one per surface. They differ because
@@ -11161,6 +11356,10 @@ const dashboardHTML = `<!DOCTYPE html>
              lowercased because GitHub usernames are case-insensitive and the
              roster and the auth payload can disagree on casing. */
           _currentUser = String(data.login || '').toLowerCase();
+          /* The viewer's own country, mirrored so the editor opens showing what
+             is on file. Absent from the payload for a user who has none, which
+             normalizes to '' and renders the empty ＋ control. */
+          _myCountry = normalizeCountryCode(data.country);
           var roleText = data.hub_admin ? 'Hub Admin' : 'User';
           /* The viewer's own face links to their own profile, like every other
              face in the dashboard. avatar_url comes from the auth payload (it is
@@ -11173,11 +11372,17 @@ const dashboardHTML = `<!DOCTYPE html>
             avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,
               '<img src="' + escAttr(data.avatar_url) + '" class="nav-avatar" alt="" ' +
               'onerror="this.onerror=null;this.src=' + jsArg(avatarInitialsSVG(data.login, NAV_AVATAR_PX)) + '">') +
-            /* The viewer's country flag, immediately after their face. Empty
-               string when the auth payload carries no country — which is the
-               common case today — so the nav renders exactly as before for a
-               user whose country is unknown. */
-            countryFlagHTML(data.country) +
+            /* The viewer's country, immediately after their face — and, unlike
+               every other flag in the dashboard, CLICKABLE, because this is the
+               viewer's own record. Wrapped in a stable #nav-country host so a
+               save can repaint just this control without re-rendering the whole
+               nav (and without a page reload).
+
+               countryNavHTML also renders in the EMPTY state, as a muted ＋.
+               countryFlagHTML returns '' there, which is right for someone
+               else's flag but would hide the control from precisely the users
+               who have no country and need to set one. */
+            '<span id="nav-country">' + countryNavHTML(data.country) + '</span>' +
             '<span style="font-size:0.85rem">' + esc(data.login) + '</span>' +
             '<span style="font-size:0.65rem;color:var(--muted);margin-left:6px">' + roleText + '</span>';
         }

--- a/src/pkg/hub/user_country.go
+++ b/src/pkg/hub/user_country.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 )
@@ -8,15 +9,24 @@ import (
 // User country: an OPTIONAL ISO 3166-1 alpha-2 code on a hub user record, shown
 // as a small flag beside their avatar.
 //
-// Two sources, in strict priority order:
+// Three sources, in strict priority order:
 //
-//  1. EXPLICIT — the requester picks a country in the get-started wizard
-//     (ProvisionRequest.Country), which is copied onto the SaaSUser record on
-//     approval alongside the other contact fields. This is the authoritative
-//     source: the user chose it about themselves.
-//  2. INFERRED — best-effort, from the region subtag of the browser's
+//  1. EXPLICIT, self-service — the signed-in user sets or clears their own
+//     country at any time via PUT /api/saas/me/country (handleMyCountry, at the
+//     bottom of this file). This is the only surface an EXISTING user has: the
+//     wizard below is a one-time gate you pass through before you have a hive,
+//     so without this endpoint a country could never be corrected or removed.
+//  2. EXPLICIT, wizard — the requester picks a country in the get-started
+//     wizard (ProvisionRequest.Country), which is copied onto the SaaSUser
+//     record on approval alongside the other contact fields.
+//  3. INFERRED — best-effort, from the region subtag of the browser's
 //     Accept-Language header on a completed login. Only ever fills a record
-//     that has NO country yet, and never overwrites an explicit choice.
+//     that has NO country and whose user has made no deliberate choice; it
+//     never overwrites, and never undoes, an explicit one.
+//
+// Sources 1 and 2 both stamp SaaSUser.CountrySetByUser, which is what tells
+// source 3 that an EMPTY country is a decision ("prefer not to say") rather
+// than an absence to be helpfully filled in.
 //
 // PRIVACY. Country is personal data, so the inference is deliberately the
 // weakest thing that works:
@@ -158,18 +168,26 @@ func inferCountryFromRequest(r *http.Request) string {
 }
 
 // applyInferredCountry fills a user's country from request evidence, but ONLY
-// when the record has none.
+// when the record carries no country AND the user has never made a deliberate
+// choice.
 //
-// The guard is the whole function. An explicit pick in the wizard is the user
-// speaking about themselves; a language header is a hint. Once the record
-// carries a country, no amount of logging in from a differently-configured
-// browser may overwrite it — otherwise a user's stated country would silently
-// flip when they travel or borrow a laptop, which is both wrong and invisible.
+// The guard is the whole function. An explicit pick is the user speaking about
+// themselves; a language header is a hint. Once the record carries a country,
+// no amount of logging in from a differently-configured browser may overwrite
+// it — otherwise a user's stated country would silently flip when they travel
+// or borrow a laptop, which is both wrong and invisible.
+//
+// The CountrySetByUser half of the guard covers the case `Country != ""` alone
+// cannot: an explicit CLEAR. A user who deliberately removes their country
+// leaves an empty field that is indistinguishable, by value, from "never asked"
+// — so without the marker the next login would quietly put a flag back and
+// "prefer not to say" would be unexpressible. Absence of a value is not the
+// same as absence of a decision.
 //
 // Returns whether it changed the record, so the caller can tell a real update
 // from a no-op. Nil-safe: it sits on the login path beside other enrichment.
 func applyInferredCountry(user *SaaSUser, r *http.Request) bool {
-	if user == nil || user.Country != "" {
+	if user == nil || user.Country != "" || user.CountrySetByUser {
 		return false
 	}
 	code := inferCountryFromRequest(r)
@@ -178,4 +196,134 @@ func applyInferredCountry(user *SaaSUser, r *http.Request) bool {
 	}
 	user.Country = code
 	return true
+}
+
+// ── Self-service: a user setting their OWN country ───────────────────────────
+//
+// Before this, every write to a SaaSUser was requireAdmin-gated and the only
+// place a person could state their country was the get-started wizard — a
+// surface you pass through exactly once, before you have a hive. That left the
+// entire existing fleet with no way to set, correct, or remove their country
+// ever again, which is a strange thing to say about a field whose whole purpose
+// is for the user to speak about themselves.
+//
+// /api/saas/me/country is the smallest fix: GET reads the acting user's own
+// country, PUT sets or clears it. Deliberately NOT a general profile endpoint —
+// widening it to "any field on my own record" would put quota, blocked, hives
+// and role one typo away from being self-writable, which is exactly the reason
+// the admin gate exists. One field, allowlisted, is the whole surface.
+//
+// SECURITY — the identity comes from the SESSION, never from the request.
+// The body carries a country and nothing else: no login, no id, no target. That
+// is not an oversight to be politely ignored if someone sends one; it is the
+// property that makes this endpoint safe to expose to non-admins at all. An
+// unknown JSON key is discarded by the decoder, so a request naming another
+// user is honoured as a write to the CALLER's own record and can never touch
+// the named one. See TestMyCountryCannotSetAnotherUsersCountry.
+//
+// PRIVACY — country rides the JSON BODY, never the path or a query string, so
+// it stays out of access logs, Referer headers and browser history. That is why
+// this is a PUT with a body rather than the more obvious
+// POST /api/saas/me/country/{code}.
+
+// maxCountryRequestBodyBytes caps the request body. The only legitimate payload
+// is a two-letter code in a one-key object — a few dozen bytes — so 1 KiB is
+// already enormous. Named, and generous rather than tight, because the point is
+// to refuse an unbounded read, not to police whitespace.
+const maxCountryRequestBodyBytes = 1 << 10
+
+// myCountryRequest is the PUT body. One field, on purpose.
+//
+// Country is a POINTER so the handler can tell "key absent" from
+// `"country": ""`. Those must not mean the same thing: the empty string is an
+// explicit CLEAR ("prefer not to say"), while an absent key is a malformed
+// request that states no intention and is refused rather than silently treated
+// as a clear. A plain string would collapse the two and make it possible to
+// wipe a country by sending `{}`.
+type myCountryRequest struct {
+	Country *string `json:"country"`
+}
+
+// handleMyCountry reads (GET) or writes (PUT) the ACTING user's own country.
+//
+// Registered behind requireAuth, which supplies the CSRF gate, the blocked-user
+// check, and — importantly here — the refusal of writes while an admin is
+// impersonating. An admin viewing as someone else must not be able to edit that
+// person's profile through a self-service route; requireAuth's
+// blockIfImpersonatingWrite already returns 403 for any non-GET, so the PUT
+// half inherits that without a check of its own. The GET half still resolves to
+// the impersonated target, matching every other per-user read in the hub.
+func (s *HubServer) handleMyCountry(w http.ResponseWriter, r *http.Request) {
+	// The acting identity, from the verified session cookie. This is the only
+	// place a username enters this handler.
+	username := s.getAuthUser(r)
+	if username == "" {
+		writeJSONError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	user := loadSaaSUser(username)
+	if user == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unknown user — please log in again")
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		writeMyCountry(w, user)
+		return
+	}
+
+	var body myCountryRequest
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxCountryRequestBodyBytes))
+	if err := dec.Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if body.Country == nil {
+		// No "country" key at all. Refused rather than read as a clear — see
+		// the pointer rationale on myCountryRequest.
+		writeJSONError(w, http.StatusBadRequest, "country is required (send \"\" to clear it)")
+		return
+	}
+
+	raw := strings.TrimSpace(*body.Country)
+	code := ""
+	if raw != "" {
+		// Reuse the SAME validator every other country path uses, so the
+		// endpoint cannot drift into accepting a shape the render sites reject
+		// (or vice versa). Case-insensitive by way of normalizeCountryCode.
+		code = normalizeCountryCode(raw)
+		if code == "" {
+			writeJSONError(w, http.StatusBadRequest, "country must be an ISO 3166-1 alpha-2 code (two letters), or \"\" to clear it")
+			return
+		}
+	}
+
+	user.Country = code
+	// Both a pick and a clear are deliberate, so BOTH set the marker. Setting
+	// it on the clear is the load-bearing half: it is what stops the next
+	// login's Accept-Language inference from undoing the removal.
+	user.CountrySetByUser = true
+	if err := saveSaaSUser(user); err != nil {
+		s.logger.Warn("handleMyCountry: save failed", "user", username, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "could not save country")
+		return
+	}
+	writeMyCountry(w, user)
+}
+
+// writeMyCountry emits the shared response shape for both verbs, so a client
+// reads back exactly what a write produced without a second round-trip.
+//
+// The country is echoed as the CODE, never as the glyph — same rule as the auth
+// payload — so the caller derives the flag the same way every other render site
+// does, and an empty value is unambiguously "no country" rather than an
+// empty-looking emoji. `explicit` lets the UI distinguish a value the user
+// chose from one the hub guessed, which is the difference between showing
+// "United Kingdom" and "United Kingdom (guessed from your browser)".
+func writeMyCountry(w http.ResponseWriter, user *SaaSUser) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"country":  normalizeCountryCode(user.Country),
+		"explicit": user.CountrySetByUser,
+	})
 }

--- a/src/pkg/hub/user_country_selfservice_test.go
+++ b/src/pkg/hub/user_country_selfservice_test.go
@@ -1,0 +1,539 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Self-service country: /api/saas/me/country is the FIRST non-admin write to a
+// SaaSUser in the hub, so the tests below are weighted toward the ways that
+// could go wrong rather than toward the happy path.
+//
+// The load-bearing one is TestMyCountryCannotSetAnotherUsersCountry: the acting
+// identity must come from the session and from nowhere else. Every other
+// property here (validation, clearing, inference precedence) is a correctness
+// bug; that one is a privilege-escalation bug.
+
+// countryTestHub builds a hub with temp dirs, matching the neighbouring handler
+// suites. The returned cleanup restores the package-level path variables.
+func countryTestHub(t *testing.T) *HubServer {
+	t.Helper()
+	cleanup := helperSetupTempDirs(t)
+	t.Cleanup(cleanup)
+	s := newHandlerHub()
+	return s
+}
+
+// putCountry issues a PUT as `username`, through the SESSION cookie — the same
+// cookie production mints. The username is never in the body or the URL, which
+// is the point of the endpoint.
+func putCountry(s *HubServer, username, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodPut, "/api/saas/me/country", body, username)
+	// Same-origin, so requireAuth's fail-closed CSRF gate is satisfied when the
+	// request goes through the mux (see TestMyCountryRequiresAuth).
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	s.handleMyCountry(rec, req)
+	return rec
+}
+
+// TestMyCountryUpdatesOwnCountry is the happy path: an authenticated user sets
+// their own country and it lands on their record, normalized and marked
+// explicit.
+func TestMyCountryUpdatesOwnCountry(t *testing.T) {
+	s := countryTestHub(t)
+	mkUser(t, "ada")
+
+	rec := putCountry(s, "ada", `{"country":"gb"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	// Persisted, upper-cased (the input was lowercase — alpha-2 is
+	// case-insensitive on the way in, canonical on the way out).
+	u := loadSaaSUser("ada")
+	if u == nil {
+		t.Fatal("user disappeared")
+	}
+	if u.Country != "GB" {
+		t.Errorf("Country = %q, want GB", u.Country)
+	}
+	// The marker is what makes this survive the next login's inference.
+	if !u.CountrySetByUser {
+		t.Error("CountrySetByUser = false after an explicit self-service write — inference will clobber it")
+	}
+
+	// The response echoes the stored CODE (not a glyph) so the caller needs no
+	// second round-trip and derives the flag the same way every render does.
+	var resp struct {
+		Country  string `json:"country"`
+		Explicit bool   `json:"explicit"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Country != "GB" || !resp.Explicit {
+		t.Errorf("response = %+v, want {GB true}", resp)
+	}
+
+	// A subsequent GET reads back the same thing.
+	getRec := httptest.NewRecorder()
+	s.handleMyCountry(getRec, reqWithUser(http.MethodGet, "/api/saas/me/country", "", "ada"))
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d body=%s, want 200", getRec.Code, getRec.Body.String())
+	}
+	if !strings.Contains(getRec.Body.String(), `"country":"GB"`) {
+		t.Errorf("GET body = %s, want country GB", getRec.Body.String())
+	}
+}
+
+// TestMyCountryCannotSetAnotherUsersCountry is the SECURITY test.
+//
+// The endpoint resolves its subject from the session cookie. A caller who names
+// someone else — by any of the field names a naive implementation might have
+// honoured — must not touch that person's record. The write is not rejected; it
+// is simply applied to the CALLER, because the body never had a say in who the
+// subject was. Both halves are asserted: the victim is unchanged AND the caller
+// is the one who moved.
+//
+// The positive control at the end is what keeps this test honest: it proves the
+// write path works at all, so a future change that broke saving entirely could
+// not make this test pass for the wrong reason.
+func TestMyCountryCannotSetAnotherUsersCountry(t *testing.T) {
+	s := countryTestHub(t)
+	mkUser(t, "attacker")
+
+	// The victim has a country they chose.
+	victim := &SaaSUser{GitHubUsername: "victim", Hives: map[string]string{}, Country: "JP", CountrySetByUser: true}
+	if err := saveSaaSUser(victim); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every plausible way to name a target in the body. None may be honoured.
+	for _, body := range []string{
+		`{"country":"FR","username":"victim"}`,
+		`{"country":"FR","github_username":"victim"}`,
+		`{"country":"FR","login":"victim"}`,
+		`{"country":"FR","user":"victim"}`,
+		`{"country":"FR","id":"victim"}`,
+		`{"country":"FR","target":"victim"}`,
+	} {
+		rec := putCountry(s, "attacker", body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("body %s: status = %d, want 200 (the extra key must be ignored, not fatal)", body, rec.Code)
+		}
+		v := loadSaaSUser("victim")
+		if v == nil {
+			t.Fatalf("body %s: victim record disappeared", body)
+		}
+		if v.Country != "JP" {
+			t.Fatalf("body %s: victim Country = %q, want JP — a request named another user and MUTATED them", body, v.Country)
+		}
+		if !v.CountrySetByUser {
+			t.Fatalf("body %s: victim CountrySetByUser was cleared", body)
+		}
+		// The write landed on the SESSION's user instead, which is the correct
+		// (and only possible) reading of the request.
+		a := loadSaaSUser("attacker")
+		if a == nil || a.Country != "FR" {
+			t.Fatalf("body %s: caller's own Country = %v, want FR — the write should apply to the session user", body, a)
+		}
+		// Reset for the next case so each iteration observes a real transition.
+		a.Country = ""
+		a.CountrySetByUser = false
+		if err := saveSaaSUser(a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// POSITIVE CONTROL: the same handler, same victim record, but acting AS the
+	// victim — proves the victim's record is writable and that the assertions
+	// above failed to move it because of the session gate, not because nothing
+	// in this test could ever write anything.
+	if rec := putCountry(s, "victim", `{"country":"FR"}`); rec.Code != http.StatusOK {
+		t.Fatalf("positive control: status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if v := loadSaaSUser("victim"); v == nil || v.Country != "FR" {
+		t.Fatalf("positive control: victim Country = %v, want FR — the write path itself is broken, so the negative cases prove nothing", v)
+	}
+}
+
+// TestMyCountryRejectsInvalidCode pins the 400s. An endpoint that quietly
+// stored garbage — or quietly stored "" for garbage — would put a broken value
+// (or a silent deletion) one typo away.
+func TestMyCountryRejectsInvalidCode(t *testing.T) {
+	s := countryTestHub(t)
+	mkUser(t, "ada")
+
+	// Seed a known-good value so a bad request that WROTE anything is visible.
+	if rec := putCountry(s, "ada", `{"country":"GB"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed: status = %d", rec.Code)
+	}
+
+	for _, tc := range []struct{ name, body string }{
+		{"alpha-3", `{"country":"USA"}`},
+		{"one letter", `{"country":"U"}`},
+		{"digits", `{"country":"12"}`},
+		{"mixed", `{"country":"U1"}`},
+		{"punctuation", `{"country":"--"}`},
+		{"the glyph rather than the code", `{"country":"🇦🇺"}`},
+		{"markup-shaped", `{"country":"<b"}`},
+		{"non-ASCII letters", `{"country":"ÉE"}`},
+		// A body with no country key states no intention. It is refused rather
+		// than read as a clear — otherwise `{}` would silently wipe a country.
+		{"missing key", `{}`},
+		{"key present but null", `{"country":null}`},
+		{"not JSON at all", `not json`},
+	} {
+		rec := putCountry(s, "ada", tc.body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d body=%s, want 400", tc.name, rec.Code, rec.Body.String())
+		}
+		if u := loadSaaSUser("ada"); u == nil || u.Country != "GB" {
+			t.Errorf("%s: a rejected request changed the stored country to %v, want GB untouched", tc.name, u)
+		}
+	}
+}
+
+// TestMyCountryExplicitClear: an empty string is a legitimate value — "prefer
+// not to say" — and must actually remove the country while RECORDING that the
+// removal was deliberate.
+func TestMyCountryExplicitClear(t *testing.T) {
+	s := countryTestHub(t)
+	mkUser(t, "ada")
+
+	if rec := putCountry(s, "ada", `{"country":"GB"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	rec := putCountry(s, "ada", `{"country":""}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	u := loadSaaSUser("ada")
+	if u == nil {
+		t.Fatal("user disappeared")
+	}
+	if u.Country != "" {
+		t.Errorf("Country = %q after an explicit clear, want empty", u.Country)
+	}
+	// The marker MUST survive the clear. It is the only thing distinguishing
+	// "chose to have no flag" from "never asked", and without it the next login
+	// puts a flag back.
+	if !u.CountrySetByUser {
+		t.Error("CountrySetByUser = false after an explicit clear — the next login's inference will undo the removal")
+	}
+	// Whitespace-only is the same explicit clear, not a validation error: the
+	// input is trimmed before the empty check.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "ada", Hives: map[string]string{}, Country: "GB"}); err != nil {
+		t.Fatal(err)
+	}
+	if rec := putCountry(s, "ada", `{"country":"   "}`); rec.Code != http.StatusOK {
+		t.Fatalf("whitespace clear: status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if u := loadSaaSUser("ada"); u == nil || u.Country != "" {
+		t.Errorf("whitespace clear left Country = %v, want empty", u)
+	}
+}
+
+// TestMyCountryExplicitChoiceSurvivesInference is the precedence invariant, and
+// the reason CountrySetByUser exists at all.
+//
+// Both directions matter, and the SECOND is the one a value-only guard gets
+// wrong: an explicit PICK is protected by `Country != ""` alone, but an
+// explicit CLEAR leaves a field that looks identical to "never asked", so
+// without the marker the next login would helpfully refill it.
+func TestMyCountryExplicitChoiceSurvivesInference(t *testing.T) {
+	s := countryTestHub(t)
+	mkUser(t, "ada")
+
+	// A login from a browser that would infer FR.
+	login := httptest.NewRequest(http.MethodGet, "/", nil)
+	login.Header.Set("Accept-Language", "fr-FR,fr;q=0.9")
+
+	// --- Direction 1: an explicit PICK is not overwritten. ---
+	if rec := putCountry(s, "ada", `{"country":"GB"}`); rec.Code != http.StatusOK {
+		t.Fatalf("pick: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	u := loadSaaSUser("ada")
+	if changed := applyInferredCountry(u, login); changed {
+		t.Error("inference reported a change to an explicitly-picked country")
+	}
+	if u.Country != "GB" {
+		t.Errorf("Country = %q after an inference pass, want GB — an explicit pick must win", u.Country)
+	}
+
+	// --- Direction 2: an explicit CLEAR is not undone. ---
+	if rec := putCountry(s, "ada", `{"country":""}`); rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	u2 := loadSaaSUser("ada")
+	if u2 == nil {
+		t.Fatal("user disappeared")
+	}
+	if changed := applyInferredCountry(u2, login); changed {
+		t.Error("inference refilled a country the user had explicitly cleared")
+	}
+	if u2.Country != "" {
+		t.Errorf("Country = %q after an inference pass, want empty — an explicit clear must stick", u2.Country)
+	}
+
+	// POSITIVE CONTROL: the same header, the same helper, on a record that has
+	// made NO deliberate choice, does fill in. Without this the two assertions
+	// above would also pass if inference had simply stopped working.
+	fresh := &SaaSUser{GitHubUsername: "fresh", Hives: map[string]string{}}
+	if changed := applyInferredCountry(fresh, login); !changed || fresh.Country != "FR" {
+		t.Fatalf("positive control: inference did not fill an untouched record (changed=%v country=%q) — the assertions above prove nothing",
+			changed, fresh.Country)
+	}
+}
+
+// TestMyCountryRequiresAuth: an unauthenticated caller is refused, at the route
+// (through requireAuth, which is how it is registered) and at the handler.
+func TestMyCountryRequiresAuth(t *testing.T) {
+	s := countryTestHub(t)
+
+	// Through the real gate. A same-origin header is supplied so the request
+	// gets PAST the fail-closed CSRF check and the 401 proves something about
+	// AUTH — the same reasoning as TestLiteEnrollRouteRequiresAuth.
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/saas/me/country", s.requireAuth(s.handleMyCountry))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/saas/me/country", strings.NewReader(`{"country":"GB"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no session: status = %d body=%s, want 401", rec.Code, rec.Body.String())
+	}
+
+	// And with NO origin information at all, the CSRF gate refuses it first —
+	// a mutation must positively demonstrate it is same-origin or not-a-browser.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPut, "/api/saas/me/country", strings.NewReader(`{"country":"GB"}`))
+	req2.Header.Set("Content-Type", "application/json")
+	mux.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusForbidden {
+		t.Fatalf("headerless mutation: status = %d body=%s, want 403 (CSRF fails closed)", rec2.Code, rec2.Body.String())
+	}
+
+	// The handler alone, with no cookie, must also refuse rather than rely on
+	// its caller having been wrapped. A future re-registration that forgot the
+	// wrapper would then still fail closed.
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodPut, "/api/saas/me/country", strings.NewReader(`{"country":"GB"}`))
+	req3.Header.Set("Content-Type", "application/json")
+	s.handleMyCountry(rec3, req3)
+	if rec3.Code != http.StatusUnauthorized {
+		t.Fatalf("bare handler, no session: status = %d body=%s, want 401", rec3.Code, rec3.Body.String())
+	}
+}
+
+// TestMyCountryRouteRegisteredNonAdmin asserts the route is actually wired, and
+// wired behind requireAuth rather than requireAdmin. The whole premise of this
+// endpoint is that a NON-admin can reach it; registering it under the admin
+// gate would compile, pass every handler test above, and ship a feature nobody
+// it was built for can use.
+func TestMyCountryRouteRegisteredNonAdmin(t *testing.T) {
+	s := countryTestHub(t)
+	s.mux = http.NewServeMux()
+	s.registerSaaSRoutes()
+	mkUser(t, "plain") // deliberately NOT a hub admin
+
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodPut, "/api/saas/me/country", `{"country":"GB"}`, "plain")
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("non-admin PUT: status = %d body=%s, want 200 — the route must be requireAuth, not requireAdmin", rec.Code, rec.Body.String())
+	}
+	if u := loadSaaSUser("plain"); u == nil || u.Country != "GB" {
+		t.Fatalf("non-admin write did not persist: %v", u)
+	}
+
+	// The GET verb is registered too, so the editor can read the current value.
+	getRec := httptest.NewRecorder()
+	s.mux.ServeHTTP(getRec, reqWithUser(http.MethodGet, "/api/saas/me/country", "", "plain"))
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("non-admin GET: status = %d body=%s, want 200", getRec.Code, getRec.Body.String())
+	}
+}
+
+// TestMyCountryScopeIsOneField guards the blast radius. This is the first
+// non-admin write to a SaaSUser, and the reason it is safe is that it writes
+// exactly ONE field. A future edit that widened the request struct would make
+// quota, blocked, role and hives self-writable — so the request shape itself is
+// pinned here, not just its behaviour.
+func TestMyCountryScopeIsOneField(t *testing.T) {
+	s := countryTestHub(t)
+
+	// A user with everything an attacker would want to change about themselves.
+	seed := &SaaSUser{
+		GitHubUsername: "ada",
+		Hives:          map[string]string{"h1": "viewer"},
+		SaaSQuota:      1,
+		Blocked:        false,
+		FullName:       "Ada Lovelace",
+		SlackID:        "U01ABCDEF23",
+		LoginCount:     7,
+	}
+	if err := saveSaaSUser(seed); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := putCountry(s, "ada", `{"country":"GB","saas_quota":999,"blocked":false,`+
+		`"hives":{"h1":"owner","h2":"owner"},"full_name":"Someone Else","slack_id":"UHACKED",`+
+		`"login_count":9999,"notes":"pwned"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	u := loadSaaSUser("ada")
+	if u == nil {
+		t.Fatal("user disappeared")
+	}
+	// The one field this endpoint owns moved...
+	if u.Country != "GB" {
+		t.Errorf("Country = %q, want GB", u.Country)
+	}
+	// ...and nothing else did.
+	if u.SaaSQuota != 1 {
+		t.Errorf("SaaSQuota = %d, want 1 — a self-service write escalated quota", u.SaaSQuota)
+	}
+	if u.Hives["h1"] != "viewer" {
+		t.Errorf("Hives[h1] = %q, want viewer — a self-service write escalated a hive role", u.Hives["h1"])
+	}
+	if _, ok := u.Hives["h2"]; ok {
+		t.Error("a self-service write granted access to a new hive")
+	}
+	if u.FullName != "Ada Lovelace" || u.SlackID != "U01ABCDEF23" {
+		t.Errorf("admin-maintained contact fields were overwritten: FullName=%q SlackID=%q", u.FullName, u.SlackID)
+	}
+	if u.LoginCount != 7 {
+		t.Errorf("LoginCount = %d, want 7", u.LoginCount)
+	}
+	if u.Notes != "" {
+		t.Errorf("Notes = %q, want empty — admin notes are not self-writable", u.Notes)
+	}
+}
+
+// TestSaaSUserCountrySetByUserRoundTrip is the PVC guard for the new marker.
+// Every existing record on disk must survive load→save byte-identical, so the
+// bool has to be absent from the JSON when false.
+func TestSaaSUserCountrySetByUserRoundTrip(t *testing.T) {
+	const legacy = `{"github_username":"ada","created_at":"2020-01-01T00:00:00Z","hives":{"h1":"owner"},"saas_quota":3,"blocked":false,"country":"GB"}`
+
+	var u SaaSUser
+	if err := json.Unmarshal([]byte(legacy), &u); err != nil {
+		t.Fatalf("unmarshal legacy record: %v", err)
+	}
+	// A record that predates the marker reads as NOT explicit. That is the
+	// right default: its country came from the wizard or from inference, and
+	// the wizard path re-stamps the marker on the next approval.
+	if u.CountrySetByUser {
+		t.Error("CountrySetByUser = true on a record that never had the key")
+	}
+	out, err := json.Marshal(&u)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "country_set_by_user") {
+		t.Errorf("re-marshalled legacy record grew a country_set_by_user key: %s", out)
+	}
+
+	u.CountrySetByUser = true
+	out2, err := json.Marshal(&u)
+	if err != nil {
+		t.Fatalf("marshal with marker: %v", err)
+	}
+	if !strings.Contains(string(out2), `"country_set_by_user":true`) {
+		t.Errorf("marker not persisted: %s", out2)
+	}
+}
+
+// TestApplyRequestContactToUserStampsExplicit: the wizard pick is also a
+// deliberate statement, so it must set the same marker the self-service
+// endpoint does. Otherwise an approved request would leave a record looking
+// "inferred", and the priority rule would hold only by the accident of the
+// value happening to be non-empty.
+func TestApplyRequestContactToUserStampsExplicit(t *testing.T) {
+	u := &SaaSUser{GitHubUsername: "ada"}
+	applyRequestContactToUser(u, &ProvisionRequest{Country: "gb"})
+	if u.Country != "GB" {
+		t.Fatalf("Country = %q, want GB", u.Country)
+	}
+	if !u.CountrySetByUser {
+		t.Error("CountrySetByUser = false after a wizard pick — the pick must be marked explicit")
+	}
+
+	// A request with NO country must not stamp the marker: nothing was chosen,
+	// so a later inference is still legitimate.
+	u2 := &SaaSUser{GitHubUsername: "ada"}
+	applyRequestContactToUser(u2, &ProvisionRequest{})
+	if u2.CountrySetByUser {
+		t.Error("CountrySetByUser = true after a request that stated no country")
+	}
+}
+
+// TestDashboardCountryEditorWiring guards the UI half, which lives inside the
+// dashboardHTML raw string and has no Go function to call. House style: assert
+// the exact symbols, because a typo here is invisible to the compiler and shows
+// up only as a dead click.
+func TestDashboardCountryEditorWiring(t *testing.T) {
+	html := dashScript(t)
+
+	for _, snippet := range []string{
+		// The editor and the nav control that opens it.
+		"function openCountryEditor()",
+		"function countryNavHTML(code)",
+		"function countryDisplayName(code)",
+		`onclick="openCountryEditor()"`,
+		// The nav must render the CLICKABLE control, not the read-only glyph,
+		// for the viewer's own country — countryFlagHTML returns '' when there
+		// is none, which would hide the control from exactly the users who need
+		// it.
+		`'<span id="nav-country">' + countryNavHTML(data.country) + '</span>'`,
+		// The empty state must exist, or a user with no country has no
+		// affordance at all — the entire problem this PR fixes.
+		"country-flag-empty",
+		".country-edit-btn {",
+		// The endpoint, the verb, and the JSON body.
+		"'/api/saas/me/country'",
+		"method: 'PUT'",
+		"JSON.stringify({country: normalizeCountryCode(raw)})",
+		// Theme tokens, so the control is light- and dark-safe rather than
+		// carrying hardcoded colors.
+		"color: var(--muted);",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — the self-service country editor is not wired", snippet)
+		}
+	}
+
+	// PRIVACY: the country must ride the JSON body and never a URL. A query
+	// parameter or a path segment would put personal data into access logs,
+	// Referer headers and browser history. This mirrors the assertion #4371
+	// makes over get-started.html.
+	for _, banned := range []string{
+		"me/country/",
+		"me/country?",
+		"country=",
+	} {
+		if strings.Contains(html, banned) {
+			t.Errorf("dashboardHTML contains %q — country must ride the JSON body, never a URL", banned)
+		}
+	}
+
+	// Ordering: both helpers must be DEFINED before the nav render that calls
+	// them, since they are referenced from an unhoisted expression.
+	def := strings.Index(html, "function countryNavHTML(code)")
+	use := strings.Index(html, "countryNavHTML(data.country)")
+	if def < 0 || use < 0 {
+		t.Fatalf("could not locate countryNavHTML definition (%d) and use (%d)", def, use)
+	}
+	if def > use {
+		t.Error("countryNavHTML is defined after the nav render that calls it")
+	}
+}

--- a/src/pkg/hub/user_country_test.go
+++ b/src/pkg/hub/user_country_test.go
@@ -289,8 +289,12 @@ func TestDashboardCountryFlagWiring(t *testing.T) {
 		// plausible-looking but wrong glyphs (letters, not flags).
 		"var REGIONAL_INDICATOR_BASE = 0x1F1E6;",
 		// ...and the flag must actually be rendered beside the nav avatar,
-		// reading the country off the auth payload.
-		"countryFlagHTML(data.country)",
+		// reading the country off the auth payload. The nav goes through
+		// countryNavHTML rather than countryFlagHTML directly: the signed-in
+		// viewer's own flag is a button (and renders even when unset, so a
+		// user with no country still has a way to add one), while
+		// countryFlagHTML stays the read-only glyph used for everyone else.
+		"countryNavHTML(data.country)",
 		// The CSS class the glyph is wrapped in must exist, or the flag renders
 		// at whatever size the surrounding text happens to be.
 		".country-flag {",
@@ -315,13 +319,18 @@ func TestDashboardCountryFlagWiring(t *testing.T) {
 	// Ordering: the helper must be DEFINED before the nav render that calls it.
 	// Both live in the same script, so a definition that drifted below its use
 	// inside an unhoisted expression would break the first paint.
-	def := strings.Index(html, "function countryFlagHTML(code)")
-	use := strings.Index(html, "countryFlagHTML(data.country)")
+	// Both helpers must be defined before the nav render, since countryNavHTML
+	// calls countryFlagEmoji on the way to painting the button.
+	def := strings.Index(html, "function countryNavHTML(code)")
+	use := strings.Index(html, "countryNavHTML(data.country)")
 	if def < 0 || use < 0 {
-		t.Fatalf("could not locate countryFlagHTML definition (%d) and use (%d)", def, use)
+		t.Fatalf("could not locate countryNavHTML definition (%d) and use (%d)", def, use)
 	}
 	if def > use {
-		t.Error("countryFlagHTML is defined after the nav render that calls it")
+		t.Error("countryNavHTML is defined after the nav render that calls it")
+	}
+	if glyph := strings.Index(html, "function countryFlagHTML(code)"); glyph < 0 {
+		t.Error("countryFlagHTML disappeared — it is still the read-only glyph for other users' flags")
 	}
 }
 


### PR DESCRIPTION
## ⚠️ Stacks on #4371 — merge that first

This branches off `feat/hub-user-country-flag` (PR #4371), not `v4`, and **must merge after it**. The base is set to that branch so the diff shown here is only this PR's changes; GitHub will retarget to `v4` automatically when #4371 lands.

It reuses #4371's field (`SaaSUser.Country`), its validator (`normalizeCountryCode`), and its flag derivation (`countryFlagEmoji` / `countryFlagHTML`) rather than duplicating any of them.

## The problem

#4371 added an optional country + flag beside the nav avatar, sourced from a dropdown in the get-started wizard. But **every write to a `SaaSUser` in the hub is `requireAdmin`-gated**, and the wizard is a one-time gate you pass through *before* you have a hive.

So a user who already has a hive — which is the entire existing fleet — has no way to set, correct, or remove their country. Ever. That is a strange thing to say about a field whose whole purpose is for a user to state something about themselves, and it means #4371 ships a feature that, for existing users, can only ever show a value the hub *guessed* from their browser's `Accept-Language` header.

This PR is the missing surface.

## What this adds

**`GET` / `PUT /api/saas/me/country`** (`handleMyCountry`, `src/pkg/hub/user_country.go`) — the first non-admin write to a `SaaSUser` in the hub. `GET` reads the acting user's own country; `PUT` sets or clears it.

**A clickable flag in the nav** — the existing flag becomes a button that opens a small themed overlay. Deliberately not a profile page: one field, one dialog, reusing the overlay pattern the assign/timeline/prompt dialogs already use.

### Security: identity comes from the session, never the request

The handler resolves its subject via `s.getAuthUser(r)` — the verified session cookie — and the request body carries **a country and no identity at all**. There is no `login`, no `id`, no `username` field to honour or to forget to check. A request that names another user is not rejected; it is simply applied to the *caller*, because the body never had a say in who the subject was.

`TestMyCountryCannotSetAnotherUsersCountry` asserts this against six different ways a body might try to name a target, checking both halves each time (the victim is unchanged **and** the caller is the one who moved), and closes with a positive control that writes the victim's record *as* the victim — so a future change that broke saving entirely could not make the negative cases pass for the wrong reason.

Scope is one allowlisted field on purpose. `TestMyCountryScopeIsOneField` sends quota, `blocked`, `hives`, `full_name`, `slack_id`, `login_count` and `notes` alongside the country and asserts none of them move. Widening the request struct later would put role and quota escalation one typo away, so the request *shape* is pinned, not just its behaviour.

Registered behind `requireAuth`, which also supplies the fail-closed CSRF gate and — importantly — `blockIfImpersonatingWrite`, so an admin viewing as someone else cannot edit that person's profile through a self-service route. The `GET` half still resolves to the impersonated target, matching every other per-user read.

### Explicit vs inferred: why a new marker field

**#4371 does not distinguish them.** `applyInferredCountry` guards on `user.Country != ""`, which is correct for an explicit *pick* but silently wrong for an explicit *clear*: a deliberately emptied field is indistinguishable **by value** from "never asked", so the very next login's `Accept-Language` inference would put a flag straight back. "Prefer not to say" would be unexpressible — and unexpressible in the worst way, since the flag reappears a login later, far from the action that was supposed to remove it.

So this adds `SaaSUser.CountrySetByUser` — an `omitempty` bool, chosen over a `country_source` string because the only decision anything makes is binary ("did a human choose this?"), and a string would invite a growing vocabulary of sources that all collapse to the same branch.

It is stamped by **both** explicit paths (this endpoint, and the wizard pick copied on approval in `applyRequestContactToUser`) and **never** by inference. `applyInferredCountry` now guards on `Country != "" || CountrySetByUser`.

`TestMyCountryExplicitChoiceSurvivesInference` covers both directions — a pick is not overwritten, a clear is not undone — and includes a positive control proving inference still fills an untouched record, so the two assertions cannot pass merely because inference stopped working.

### Privacy

Country rides the **JSON body**, never a path segment or query string, so it stays out of access logs, `Referer` headers and browser history. That is why this is `PUT /api/saas/me/country` with a body rather than the more obvious `POST /api/saas/me/country/{code}`. `TestDashboardCountryEditorWiring` keeps #4371's no-`country=`-substring property, extended to the dashboard.

### Round-tripping

`CountrySetByUser` is `omitempty`, so every existing record on the PVC — all of which have it false — round-trips byte-identical. `TestSaaSUserCountrySetByUserRoundTrip` asserts a legacy record does not grow the key.

### UI notes

The nav control renders in **both** states. When there is no country it shows a muted `＋` rather than nothing, because a user with no flag is precisely the user who needs a way to add one — an invisible control would leave them in the same dead end this PR exists to fix. (`countryFlagHTML`, which returns `''`, stays as-is for everyone *else's* flag.)

Country names in the editor come from `Intl.DisplayNames`, a browser built-in, so the dashboard carries no 250-row country table of its own and cannot drift from one. Colors are `var(--muted)` / `var(--text)` / `var(--surface)` with no hardcoded values, so it is light- and dark-safe; the glyph carries its own color.

## Tests

`src/pkg/hub/user_country_selfservice_test.go`, house style (handler behaviour + rendered-markup assertions):

- authenticated user updates own country → persisted, normalized, marked explicit
- **negative:** six body shapes naming another user leave that user untouched (+ positive control)
- **negative:** quota / blocked / hives / contact fields are not self-writable
- invalid code → 400 (alpha-3, one letter, digits, punctuation, the glyph itself, markup-shaped, non-ASCII, missing key, `null`, non-JSON) and the stored value is unchanged in every case
- explicit clear works, including whitespace-only, and keeps the marker
- explicit choice survives an inference pass in **both** directions (+ positive control)
- unauthenticated → 401 through the gate, 403 for a headerless mutation, 401 at the bare handler
- route is registered under `requireAuth`, not `requireAdmin` — a non-admin `PUT` returns 200
- `omitempty` round-trip for the new marker

No local build/lint/test run; CI is the gate.
