### PR TITLE
✨ feat(convergence): first exact-subject GitHub proof vertical (default-off)

### DIFF
--- a/src/pkg/convergence/proof/proof.go
+++ b/src/pkg/convergence/proof/proof.go
@@ -1,0 +1,321 @@
+// Package proof implements the first exact-subject GitHub proof vertical
+// accepted on kubestellar/hive#4252 (parent epic #3845, issue #4253).
+//
+// It owns exactly one predicate — github.checks.exact-head-green/v1: "all
+// required (non-meta) check runs for exact head SHA X of PR N in repo R
+// concluded success" — and one durable receipt shape: a proof Record binding
+// the complete accepted fingerprint (outcome key, predicate ID, desired
+// generation, repo, PR, exact candidate head SHA, bounded base observation,
+// check-policy identity, producer authority) to a tri-state result, a bounded
+// provenance handle, and an observation instant with a freshness rule.
+//
+// Only a valid CURRENT proof whose complete fingerprint matches the exact
+// evaluation context satisfies the predicate. A repaired head Y can never be
+// authorized by evidence for head X; generation G's receipt can never satisfy
+// G+1; movement of any declared input (base, check policy) invalidates only
+// receipts declaring that input. Missing, stale, malformed, unauthorized, or
+// conflicting evidence is Unknown — never satisfaction.
+//
+// The package is inert by default. Nothing records or consults proofs unless
+// the convergence mode toggle (convergence.mode / HIVE_CONVERGENCE_MODE,
+// #4246/#4263) resolves to a non-off mode; and even then, shadow mode only
+// records and reports — a proof verdict gates a dependent transition ONLY in
+// enforce mode, and only for the one transition explicitly declared to depend
+// on it. Existing merge, CI, review, queue-approval (#3152), and automerge
+// guards are mandatory positive guards this receipt never replaces.
+package proof
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PredicateExactHeadGreen is the ONE predicate this vertical implements, as
+// selected and accepted on #4252. The identifier is versioned: a schema or
+// semantics change is a NEW predicate ID, never a silent reinterpretation of
+// receipts recorded under this one.
+const PredicateExactHeadGreen = "github.checks.exact-head-green/v1"
+
+// ProducerGitHubChecksAPI is the sole accepted producer authority for the
+// exact-head-green predicate: the GitHub Checks API of the subject repository.
+// Producer identity is explicit — another vendor's checks, or Hive's own
+// review harness, is NOT this producer, and multiplicity of producers is
+// never inferred to be independence.
+const ProducerGitHubChecksAPI = "github-checks-api"
+
+// keyFieldSeparator joins the load-bearing fingerprint fields into the
+// receipt key. "|" cannot appear in an outcome key ("project/repo@outcome"
+// forbids whitespace and reserves separators), a predicate ID, a decimal
+// generation, or a hex SHA, so the key is unambiguous by construction.
+const keyFieldSeparator = "|"
+
+// shaPattern is the exact shape of a full git object name. Fingerprints pin
+// FULL 40-hex SHAs: an abbreviated SHA is a lookup convenience, not an
+// immutable subject identity.
+var shaPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// Result is the producer's classified conclusion for the predicate's check
+// set at the fingerprinted head. It is deliberately the same three-way
+// classification EnrichCIStatus already computes from check-run conclusions.
+type Result string
+
+const (
+	// ResultSuccess: every required (non-meta) check run for the exact head
+	// completed with a passing conclusion.
+	ResultSuccess Result = "success"
+	// ResultFailure: at least one required check run for the exact head
+	// concluded failure or action_required.
+	ResultFailure Result = "failure"
+	// ResultPending: required check runs exist but have not all completed,
+	// or no counted check run exists at all (no evidence is never success).
+	ResultPending Result = "pending"
+)
+
+// validResult reports whether r is one of the three declared classifications.
+// Anything else in a persisted or constructed record is malformed evidence,
+// and malformed evidence can never satisfy.
+func validResult(r Result) bool {
+	return r == ResultSuccess || r == ResultFailure || r == ResultPending
+}
+
+// Fingerprint is the complete immutable subject binding accepted on #4252.
+// EVERY field is REQUIRED and load-bearing: a receipt satisfies the predicate
+// only when every field matches the current evaluation context exactly, so
+// removing or ignoring any one of them transfers proof across subjects,
+// generations, or assumptions — the exact failure the invariant forbids.
+type Fingerprint struct {
+	// OutcomeKey is the canonical "project/repo@outcome" identity of the
+	// accepted #4251 outcome this proof serves. A receipt for another outcome
+	// never transfers.
+	OutcomeKey string `json:"outcome_key"`
+	// PredicateID names the predicate and its schema version. This vertical
+	// only ever writes PredicateExactHeadGreen.
+	PredicateID string `json:"predicate_id"`
+	// DesiredGeneration is the outcome ledger's current desired generation at
+	// evidence time. G's receipt can never satisfy G+1.
+	DesiredGeneration int `json:"desired_generation"`
+	// Repo is the canonical "owner/repo" spelling, byte-identical to the
+	// spelling worksource.Ref.Repo and outcome.Ref.Repo use.
+	Repo string `json:"repo"`
+	// PRNumber is the exact pull request the candidate head belongs to.
+	PRNumber int `json:"pr_number"`
+	// HeadSHA is the exact candidate head — THE immutability anchor. A commit
+	// SHA is content-addressed, so evidence bound to X can never describe a
+	// repaired head Y.
+	HeadSHA string `json:"head_sha"`
+	// BaseSHA is the bounded base-reference observation: the PR base ref's
+	// commit SHA at observation time. It declares the dependency — base
+	// movement invalidates ONLY receipts declaring this field. It is an
+	// observation bound, not a claim that CI ran against that merge-base.
+	BaseSHA string `json:"base_sha"`
+	// CheckPolicyID identifies WHICH check runs count: see CheckPolicyID().
+	// A policy or classifier change invalidates receipts declaring the old
+	// policy — nothing else.
+	CheckPolicyID string `json:"check_policy_id"`
+	// Producer is the explicit producer authority; this vertical only ever
+	// writes ProducerGitHubChecksAPI.
+	Producer string `json:"producer"`
+}
+
+// Validate reports why a Fingerprint cannot serve as an immutable subject
+// binding. Every field is required; a fingerprint that fails Validate has no
+// key and can never be recorded or satisfied.
+func (f Fingerprint) Validate() error {
+	if f.OutcomeKey == "" {
+		return fmt.Errorf("proof fingerprint requires an outcome key")
+	}
+	if strings.ContainsAny(f.OutcomeKey, keyFieldSeparator+" \t") {
+		return fmt.Errorf("outcome key %q may not contain %q or whitespace", f.OutcomeKey, keyFieldSeparator)
+	}
+	if f.PredicateID != PredicateExactHeadGreen {
+		return fmt.Errorf("predicate %q is not implemented by this vertical (only %s)", f.PredicateID, PredicateExactHeadGreen)
+	}
+	if f.DesiredGeneration < 1 {
+		return fmt.Errorf("desired generation %d is impossible (generations start at 1)", f.DesiredGeneration)
+	}
+	if f.Repo == "" || strings.Count(f.Repo, "/") != 1 || strings.ContainsAny(f.Repo, keyFieldSeparator+"@#! \t") {
+		return fmt.Errorf("repo %q is not a canonical owner/repo spelling", f.Repo)
+	}
+	if f.PRNumber < 1 {
+		return fmt.Errorf("pr number %d is not a real pull request", f.PRNumber)
+	}
+	if !shaPattern.MatchString(f.HeadSHA) {
+		return fmt.Errorf("head sha %q is not a full 40-hex commit id", f.HeadSHA)
+	}
+	if !shaPattern.MatchString(f.BaseSHA) {
+		return fmt.Errorf("base sha %q is not a full 40-hex commit id", f.BaseSHA)
+	}
+	if f.CheckPolicyID == "" {
+		return fmt.Errorf("proof fingerprint requires a check-policy id")
+	}
+	if strings.ContainsAny(f.CheckPolicyID, keyFieldSeparator+" \t") {
+		return fmt.Errorf("check-policy id %q may not contain %q or whitespace", f.CheckPolicyID, keyFieldSeparator)
+	}
+	if f.Producer != ProducerGitHubChecksAPI {
+		return fmt.Errorf("producer %q is not the accepted authority %s", f.Producer, ProducerGitHubChecksAPI)
+	}
+	return nil
+}
+
+// Key returns the accepted dedup/serialization key —
+// "outcomeKey|predicateID|generation|headSHA" — or "" for a fingerprint that
+// fails Validate, mirroring the worksource/outcome contract that "" means
+// "not identifiable, never a key". Duplicate identical evidence deduplicates
+// deterministically on this key, and concurrent writers serialize on it.
+func (f Fingerprint) Key() string {
+	if err := f.Validate(); err != nil {
+		return ""
+	}
+	return strings.Join([]string{
+		f.OutcomeKey, f.PredicateID, fmt.Sprintf("%d", f.DesiredGeneration), f.HeadSHA,
+	}, keyFieldSeparator)
+}
+
+// Provenance is the bounded replay handle: enough to re-issue the exact
+// observation and audit which runs were counted — deliberately NOT a log
+// archive.
+type Provenance struct {
+	// CheckRunIDs are the check-run IDs counted toward the result, sorted.
+	CheckRunIDs []int64 `json:"check_run_ids,omitempty"`
+	// Query names the observation call shape, e.g.
+	// "ListCheckRunsForRef@<headSHA>".
+	Query string `json:"query"`
+}
+
+// Record is one durable proof receipt: the complete fingerprint, the
+// producer's classified result, the bounded provenance handle, and the
+// observation instant its freshness rule is anchored to. Records are
+// immutable once written; a re-observation writes a superseding record under
+// the same key, never an in-place edit.
+type Record struct {
+	Fingerprint Fingerprint `json:"fingerprint"`
+	Result      Result      `json:"result"`
+	Provenance  Provenance  `json:"provenance"`
+	// ObservedAt is the observation instant, RFC3339 in the persisted file.
+	ObservedAt time.Time `json:"observed_at"`
+}
+
+// Validate reports why a Record cannot serve as evidence. Malformed evidence
+// is refused at the write seam and treated as Unknown at the read seam — it
+// can never become satisfaction.
+func (r Record) Validate() error {
+	if err := r.Fingerprint.Validate(); err != nil {
+		return err
+	}
+	if !validResult(r.Result) {
+		return fmt.Errorf("result %q is not a known classification", r.Result)
+	}
+	if r.ObservedAt.IsZero() {
+		return fmt.Errorf("proof record requires an observation instant")
+	}
+	return nil
+}
+
+// Key returns the record's dedup/serialization key (see Fingerprint.Key).
+func (r Record) Key() string { return r.Fingerprint.Key() }
+
+// clone returns a detached deep copy so readers can never race or mutate the
+// store's own record.
+func (r Record) clone() Record {
+	out := r
+	out.Provenance.CheckRunIDs = append([]int64(nil), r.Provenance.CheckRunIDs...)
+	return out
+}
+
+// equivalent reports whether two records are the SAME evidence — identical
+// fingerprint, result, and provenance. ObservedAt is deliberately excluded:
+// re-reading unchanged evidence a second later is a duplicate, and duplicates
+// deduplicate without duplicating state or effects.
+func (r Record) equivalent(other Record) bool {
+	if r.Fingerprint != other.Fingerprint || r.Result != other.Result || r.Provenance.Query != other.Provenance.Query {
+		return false
+	}
+	if len(r.Provenance.CheckRunIDs) != len(other.Provenance.CheckRunIDs) {
+		return false
+	}
+	for i, id := range r.Provenance.CheckRunIDs {
+		if other.Provenance.CheckRunIDs[i] != id {
+			return false
+		}
+	}
+	return true
+}
+
+// CheckPolicyID derives the check-policy identity field: a sha256 over the
+// classifier version and the SORTED set of check-run names that counted. The
+// classifier version names the meta/ignorable ruleset revision (the
+// isMetaCheck family), so EITHER a change to which checks a repo runs OR a
+// change to the classifier itself yields a different policy ID — and
+// therefore invalidates exactly the receipts that declared the old policy.
+func CheckPolicyID(classifierVersion string, checkNames []string) string {
+	names := append([]string(nil), checkNames...)
+	sort.Strings(names)
+	h := sha256.New()
+	h.Write([]byte(classifierVersion))
+	for _, n := range names {
+		h.Write([]byte{0})
+		h.Write([]byte(n))
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// CheckConclusion is one counted check run's state as reported by the
+// producer, in the shape the existing EnrichCIStatus classification reads.
+type CheckConclusion struct {
+	// ID is the producer's check-run ID (provenance).
+	ID int64
+	// Name is the check-run name (policy identity).
+	Name string
+	// Completed reports whether the run reached a terminal status.
+	Completed bool
+	// Conclusion is the terminal conclusion when Completed
+	// ("success", "failure", "action_required", "neutral", "skipped", ...).
+	Conclusion string
+}
+
+// NormalizeCheckEvidence turns one authoritative check-run observation for an
+// exact head into a proof Record, classifying conclusions with EXACTLY the
+// semantics EnrichCIStatus applies to real CI checks: any failure or
+// action_required conclusion is failure; any incomplete run is pending; an
+// EMPTY counted set is pending (no evidence is never success); otherwise
+// success. The caller has already excluded meta/ignorable checks — the
+// fingerprint's CheckPolicyID is derived from the counted names, so the
+// exclusion decision is itself part of the immutable subject binding.
+func NormalizeCheckEvidence(fp Fingerprint, checks []CheckConclusion, observedAt time.Time) (Record, error) {
+	if err := fp.Validate(); err != nil {
+		return Record{}, err
+	}
+	result := ResultSuccess
+	if len(checks) == 0 {
+		result = ResultPending
+	}
+	ids := make([]int64, 0, len(checks))
+	for _, c := range checks {
+		ids = append(ids, c.ID)
+		switch {
+		case c.Completed && (c.Conclusion == "failure" || c.Conclusion == "action_required"):
+			result = ResultFailure
+		case !c.Completed && result != ResultFailure:
+			result = ResultPending
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	rec := Record{
+		Fingerprint: fp,
+		Result:      result,
+		Provenance: Provenance{
+			CheckRunIDs: ids,
+			Query:       "ListCheckRunsForRef@" + fp.HeadSHA,
+		},
+		ObservedAt: observedAt,
+	}
+	if err := rec.Validate(); err != nil {
+		return Record{}, err
+	}
+	return rec, nil
+}

--- a/src/pkg/convergence/proof/proof_test.go
+++ b/src/pkg/convergence/proof/proof_test.go
@@ -1,0 +1,677 @@
+package proof
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/convergence"
+)
+
+const (
+	headX = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	headY = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	baseA = "cccccccccccccccccccccccccccccccccccccccc"
+	baseB = "dddddddddddddddddddddddddddddddddddddddd"
+)
+
+var testObservedAt = time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+func testFingerprint() Fingerprint {
+	return Fingerprint{
+		OutcomeKey:        "default/kubestellar/hive@ship-proof-vertical",
+		PredicateID:       PredicateExactHeadGreen,
+		DesiredGeneration: 3,
+		Repo:              "kubestellar/hive",
+		PRNumber:          4253,
+		HeadSHA:           headX,
+		BaseSHA:           baseA,
+		CheckPolicyID:     CheckPolicyID("meta-v1", []string{"build", "test"}),
+		Producer:          ProducerGitHubChecksAPI,
+	}
+}
+
+func testRecord() Record {
+	return Record{
+		Fingerprint: testFingerprint(),
+		Result:      ResultSuccess,
+		Provenance:  Provenance{CheckRunIDs: []int64{11, 22}, Query: "ListCheckRunsForRef@" + headX},
+		ObservedAt:  testObservedAt,
+	}
+}
+
+func testContext() Context {
+	return Context{Required: testFingerprint(), Now: testObservedAt.Add(time.Minute), MaxAge: time.Hour}
+}
+
+// ─── Fingerprint identity ───────────────────────────────────────────────────
+
+func TestFingerprintKeyBindsLoadBearingFields(t *testing.T) {
+	fp := testFingerprint()
+	key := fp.Key()
+	want := fp.OutcomeKey + "|" + PredicateExactHeadGreen + "|3|" + headX
+	if key != want {
+		t.Fatalf("key = %q, want %q", key, want)
+	}
+	if rec := testRecord(); rec.Key() != key {
+		t.Fatalf("record key %q != fingerprint key %q", rec.Key(), key)
+	}
+}
+
+func TestFingerprintValidateRejectsEveryMissingOrBogusField(t *testing.T) {
+	mutations := map[string]func(*Fingerprint){
+		"empty outcome key":     func(f *Fingerprint) { f.OutcomeKey = "" },
+		"separator in outcome":  func(f *Fingerprint) { f.OutcomeKey = "a|b" },
+		"foreign predicate":     func(f *Fingerprint) { f.PredicateID = "github.review.aggregate/v1" },
+		"zero generation":       func(f *Fingerprint) { f.DesiredGeneration = 0 },
+		"empty repo":            func(f *Fingerprint) { f.Repo = "" },
+		"repo without owner":    func(f *Fingerprint) { f.Repo = "hive" },
+		"zero pr":               func(f *Fingerprint) { f.PRNumber = 0 },
+		"abbreviated head sha":  func(f *Fingerprint) { f.HeadSHA = "abc123" },
+		"uppercase head sha":    func(f *Fingerprint) { f.HeadSHA = strings.ToUpper(headX) },
+		"abbreviated base sha":  func(f *Fingerprint) { f.BaseSHA = "def456" },
+		"empty check policy":    func(f *Fingerprint) { f.CheckPolicyID = "" },
+		"separator in policy":   func(f *Fingerprint) { f.CheckPolicyID = "sha256:x|y" },
+		"unaccepted producer":   func(f *Fingerprint) { f.Producer = "other-vendor-checks" },
+		"whitespace in outcome": func(f *Fingerprint) { f.OutcomeKey = "a b" },
+		"reserved char in repo": func(f *Fingerprint) { f.Repo = "kubestellar/hi@ve" },
+		"negative generation":   func(f *Fingerprint) { f.DesiredGeneration = -1 },
+		"empty head sha":        func(f *Fingerprint) { f.HeadSHA = "" },
+		"empty base sha":        func(f *Fingerprint) { f.BaseSHA = "" },
+	}
+	for name, mutate := range mutations {
+		fp := testFingerprint()
+		mutate(&fp)
+		if err := fp.Validate(); err == nil {
+			t.Errorf("%s: Validate accepted a malformed fingerprint", name)
+		}
+		if key := fp.Key(); key != "" {
+			t.Errorf("%s: malformed fingerprint produced key %q; must be \"\"", name, key)
+		}
+	}
+}
+
+func TestCheckPolicyIDIsOrderInsensitiveButNameAndVersionSensitive(t *testing.T) {
+	a := CheckPolicyID("meta-v1", []string{"build", "test"})
+	b := CheckPolicyID("meta-v1", []string{"test", "build"})
+	if a != b {
+		t.Fatalf("policy id must not depend on name order: %s vs %s", a, b)
+	}
+	if CheckPolicyID("meta-v2", []string{"build", "test"}) == a {
+		t.Fatal("classifier version change must change the policy id")
+	}
+	if CheckPolicyID("meta-v1", []string{"build", "test", "lint"}) == a {
+		t.Fatal("check-set change must change the policy id")
+	}
+	if !strings.HasPrefix(a, "sha256:") {
+		t.Fatalf("policy id %q is not a bounded sha256 handle", a)
+	}
+	// The digest boundary is unambiguous: moving a byte between the two
+	// inputs must not collide.
+	if CheckPolicyID("meta-v1x", []string{"build"}) == CheckPolicyID("meta-v1", []string{"xbuild"}) {
+		t.Fatal("version/name boundary must be delimited")
+	}
+}
+
+// ─── Evidence normalization ─────────────────────────────────────────────────
+
+func TestNormalizeCheckEvidenceClassification(t *testing.T) {
+	fp := testFingerprint()
+	cases := []struct {
+		name   string
+		checks []CheckConclusion
+		want   Result
+	}{
+		{"all green", []CheckConclusion{
+			{ID: 2, Name: "test", Completed: true, Conclusion: "success"},
+			{ID: 1, Name: "build", Completed: true, Conclusion: "success"},
+		}, ResultSuccess},
+		{"one failure", []CheckConclusion{
+			{ID: 1, Name: "build", Completed: true, Conclusion: "success"},
+			{ID: 2, Name: "test", Completed: true, Conclusion: "failure"},
+		}, ResultFailure},
+		{"action_required is failure", []CheckConclusion{
+			{ID: 1, Name: "build", Completed: true, Conclusion: "action_required"},
+		}, ResultFailure},
+		{"incomplete is pending", []CheckConclusion{
+			{ID: 1, Name: "build", Completed: true, Conclusion: "success"},
+			{ID: 2, Name: "test", Completed: false},
+		}, ResultPending},
+		{"failure beats pending", []CheckConclusion{
+			{ID: 1, Name: "build", Completed: true, Conclusion: "failure"},
+			{ID: 2, Name: "test", Completed: false},
+		}, ResultFailure},
+		{"no evidence is never success", nil, ResultPending},
+	}
+	for _, tc := range cases {
+		rec, err := NormalizeCheckEvidence(fp, tc.checks, testObservedAt)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if rec.Result != tc.want {
+			t.Errorf("%s: result = %s, want %s", tc.name, rec.Result, tc.want)
+		}
+		if rec.Provenance.Query != "ListCheckRunsForRef@"+headX {
+			t.Errorf("%s: provenance query %q does not name the observation call", tc.name, rec.Provenance.Query)
+		}
+	}
+	// Provenance IDs are sorted for determinism.
+	rec, err := NormalizeCheckEvidence(fp, cases[0].checks, testObservedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Provenance.CheckRunIDs[0] != 1 || rec.Provenance.CheckRunIDs[1] != 2 {
+		t.Fatalf("provenance ids %v are not sorted", rec.Provenance.CheckRunIDs)
+	}
+}
+
+func TestNormalizeCheckEvidenceRefusesMalformedFingerprint(t *testing.T) {
+	fp := testFingerprint()
+	fp.HeadSHA = "short"
+	if _, err := NormalizeCheckEvidence(fp, nil, testObservedAt); err == nil {
+		t.Fatal("malformed fingerprint must never normalize into a receipt")
+	}
+	if _, err := NormalizeCheckEvidence(testFingerprint(), nil, time.Time{}); err == nil {
+		t.Fatal("a receipt without an observation instant must be refused")
+	}
+}
+
+// ─── Verification: the fingerprint-match truth table ────────────────────────
+
+func TestVerifyMatchingCurrentProofSatisfies(t *testing.T) {
+	v := testRecord().VerifyAgainst(testContext())
+	if !v.Satisfied() || v.Status != convergence.ConditionTrue || v.Reason != ReasonProofCurrent {
+		t.Fatalf("complete fresh matching success must satisfy: %+v", v)
+	}
+}
+
+// TestVerifyEachFieldMismatchRejects is the core RED matrix: every single
+// load-bearing fingerprint field, when it differs from the current context,
+// must independently prevent satisfaction — removing any one of these checks
+// fails this test.
+func TestVerifyEachFieldMismatchRejects(t *testing.T) {
+	mutations := map[string]func(*Fingerprint){
+		"outcome key":        func(f *Fingerprint) { f.OutcomeKey = "default/kubestellar/hive@other-outcome" },
+		"desired generation": func(f *Fingerprint) { f.DesiredGeneration = 4 },
+		"repo":               func(f *Fingerprint) { f.Repo = "kubestellar/other" },
+		"pr number":          func(f *Fingerprint) { f.PRNumber = 4254 },
+		"head sha (X vs Y)":  func(f *Fingerprint) { f.HeadSHA = headY },
+		"base sha":           func(f *Fingerprint) { f.BaseSHA = baseB },
+		"check policy":       func(f *Fingerprint) { f.CheckPolicyID = CheckPolicyID("meta-v2", []string{"build", "test"}) },
+	}
+	for name, mutate := range mutations {
+		ctx := testContext()
+		mutate(&ctx.Required) // the WORLD moved; the receipt did not
+		v := testRecord().VerifyAgainst(ctx)
+		if v.Satisfied() {
+			t.Errorf("%s mismatch still satisfied: %+v", name, v)
+			continue
+		}
+		if v.Status != convergence.ConditionUnknown || v.Reason != ReasonFingerprintMismatch {
+			t.Errorf("%s mismatch must be Unknown/FingerprintMismatch, got %+v", name, v)
+		}
+	}
+}
+
+func TestVerifyRepairedHeadNeverSatisfiedByOldProof(t *testing.T) {
+	// Proof was recorded for head X; the PR was repaired to head Y. The
+	// current context now requires Y.
+	ctx := testContext()
+	ctx.Required.HeadSHA = headY
+	v := testRecord().VerifyAgainst(ctx)
+	if v.Satisfied() {
+		t.Fatal("evidence for head X authorized repaired head Y")
+	}
+	if !strings.Contains(v.Detail, headY) || !strings.Contains(v.Detail, headX) {
+		t.Fatalf("mismatch detail must name both heads: %q", v.Detail)
+	}
+}
+
+func TestVerifyGenerationSupersessionInvalidates(t *testing.T) {
+	ctx := testContext()
+	ctx.Required.DesiredGeneration = 4 // G → G+1
+	if v := testRecord().VerifyAgainst(ctx); v.Satisfied() {
+		t.Fatal("generation-3 receipt satisfied generation 4")
+	}
+}
+
+func TestVerifyStaleProofExpires(t *testing.T) {
+	ctx := testContext()
+	ctx.Now = testObservedAt.Add(2 * time.Hour) // MaxAge is 1h
+	v := testRecord().VerifyAgainst(ctx)
+	if v.Satisfied() || v.Reason != ReasonProofExpired || v.Status != convergence.ConditionUnknown {
+		t.Fatalf("stale proof must be Unknown/ProofExpired: %+v", v)
+	}
+	// Zero MaxAge is the conservative direction: nothing is ever fresh.
+	ctx = testContext()
+	ctx.MaxAge = 0
+	if v := testRecord().VerifyAgainst(ctx); v.Satisfied() {
+		t.Fatal("zero freshness window still satisfied")
+	}
+}
+
+func TestVerifyResultMapping(t *testing.T) {
+	rec := testRecord()
+	rec.Result = ResultFailure
+	if v := rec.VerifyAgainst(testContext()); v.Status != convergence.ConditionFalse || v.Reason != ReasonPredicateFailed {
+		t.Fatalf("failure evidence must be a definite False: %+v", v)
+	}
+	rec.Result = ResultPending
+	if v := rec.VerifyAgainst(testContext()); v.Status != convergence.ConditionUnknown || v.Reason != ReasonEvidencePending {
+		t.Fatalf("pending evidence must be Unknown: %+v", v)
+	}
+}
+
+func TestVerifyMalformedEvidenceNeverSatisfies(t *testing.T) {
+	rec := testRecord()
+	rec.Result = "greenish" // conflicting/nonsense classification
+	if v := rec.VerifyAgainst(testContext()); v.Satisfied() || v.Reason != ReasonProofMalformed {
+		t.Fatalf("malformed evidence must be Unknown/ProofMalformed: %+v", v)
+	}
+	rec = testRecord()
+	rec.ObservedAt = time.Time{}
+	if v := rec.VerifyAgainst(testContext()); v.Satisfied() {
+		t.Fatal("a receipt without an observation instant satisfied")
+	}
+	// A malformed REQUIRED context also establishes nothing.
+	ctx := testContext()
+	ctx.Required.HeadSHA = "not-a-sha"
+	if v := testRecord().VerifyAgainst(ctx); v.Satisfied() {
+		t.Fatal("a malformed required fingerprint satisfied")
+	}
+}
+
+func TestVerifyLookupMissesAndNilStore(t *testing.T) {
+	if v := Verify(nil, testContext()); v.Satisfied() || v.Reason != ReasonProofMissing {
+		t.Fatalf("nil store must be Unknown/ProofMissing: %+v", v)
+	}
+	s := openTestStore(t)
+	if v := Verify(s, testContext()); v.Satisfied() || v.Reason != ReasonProofMissing {
+		t.Fatalf("empty store must be Unknown/ProofMissing: %+v", v)
+	}
+	if _, err := s.Put(testRecord()); err != nil {
+		t.Fatal(err)
+	}
+	if v := Verify(s, testContext()); !v.Satisfied() {
+		t.Fatalf("stored matching proof must satisfy through Verify: %+v", v)
+	}
+}
+
+// ─── Production-path admission gating through convergence.Evaluate ──────────
+
+// observationWithProof is the production shape: the one candidate explicitly
+// declared to depend on the proof carries the projected Dependency edge.
+func observationWithProof(dep *convergence.Dependency) convergence.Observation {
+	obs := convergence.Observation{
+		Subject:  convergence.Subject{Repo: "kubestellar/hive", Number: 4253},
+		Found:    true,
+		RecordID: "bead-4253",
+	}
+	if dep != nil {
+		obs.Dependencies = append(obs.Dependencies, *dep)
+	}
+	return obs
+}
+
+func TestEnforceModeGatesTheDeclaredTransitionOnly(t *testing.T) {
+	s := openTestStore(t)
+	if _, err := s.Put(testRecord()); err != nil {
+		t.Fatal(err)
+	}
+	ctx := testContext()
+
+	// Matching current proof: the declared dependent transition is admitted.
+	v := Verify(s, ctx)
+	dec := convergence.Evaluate(observationWithProof(v.AdmissionDependency(ModeEnforce, ctx)))
+	if !dec.Admitted {
+		t.Fatalf("matching proof must admit the dependent transition: %+v", dec)
+	}
+
+	// Repaired head Y: X's receipt never admits Y's transition.
+	ctxY := ctx
+	ctxY.Required.HeadSHA = headY
+	vy := Verify(s, ctxY)
+	decY := convergence.Evaluate(observationWithProof(vy.AdmissionDependency(ModeEnforce, ctxY)))
+	if decY.Admitted {
+		t.Fatalf("repaired head admitted on head-X proof: %+v", decY)
+	}
+	if decY.Reason != convergence.ReasonDependencyUnknown {
+		t.Fatalf("mismatched proof must block as Unknown, got %q", decY.Reason)
+	}
+
+	// Definite red CI: blocks as an established-unsatisfied dependency.
+	red := testRecord()
+	red.Result = ResultFailure
+	red.ObservedAt = testObservedAt.Add(time.Second)
+	if _, err := s.Put(red); err != nil {
+		t.Fatal(err)
+	}
+	vr := Verify(s, ctx)
+	decR := convergence.Evaluate(observationWithProof(vr.AdmissionDependency(ModeEnforce, ctx)))
+	if decR.Admitted || decR.Reason != convergence.ReasonWaitingForDependency {
+		t.Fatalf("failed predicate must block definitively: %+v", decR)
+	}
+
+	// Positive control: a candidate that declares NO proof dependency is
+	// evaluated by the ordinary rules and stays admissible throughout.
+	control := convergence.Evaluate(observationWithProof(nil))
+	if !control.Admitted {
+		t.Fatalf("unrelated transition lost admissibility: %+v", control)
+	}
+}
+
+func TestOffAndShadowModesNeverEnforce(t *testing.T) {
+	s := openTestStore(t)
+	red := testRecord()
+	red.Result = ResultFailure
+	if _, err := s.Put(red); err != nil {
+		t.Fatal(err)
+	}
+	ctx := testContext()
+	v := Verify(s, ctx)
+	// The verdict itself is reportable in shadow (recorded/reported…)
+	if v.Status != convergence.ConditionFalse {
+		t.Fatalf("shadow verdict must still be computed for reporting: %+v", v)
+	}
+	// …but no mode other than enforce ever yields a gating edge.
+	for _, mode := range []string{ModeOff, ModeShadow, "", "SHADOW", "banana", "enforce "} {
+		if dep := v.AdmissionDependency(mode, ctx); dep != nil {
+			t.Errorf("mode %q produced a gating dependency; only exact %q may", mode, ModeEnforce)
+		}
+	}
+	dec := convergence.Evaluate(observationWithProof(v.AdmissionDependency(ModeOff, ctx)))
+	if !dec.Admitted {
+		t.Fatalf("off mode changed admission behavior: %+v", dec)
+	}
+}
+
+func TestModeResolutionIsDefaultOff(t *testing.T) {
+	if RecordingEnabled(ModeOff) || RecordingEnabled("") || RecordingEnabled("bogus") {
+		t.Fatal("recording must be default-off")
+	}
+	if !RecordingEnabled(ModeShadow) || !RecordingEnabled(ModeEnforce) {
+		t.Fatal("shadow and enforce must enable recording")
+	}
+	if EnforcementEnabled(ModeShadow) || EnforcementEnabled(ModeOff) || EnforcementEnabled("Enforce") {
+		t.Fatal("only exact enforce may enforce")
+	}
+	if !EnforcementEnabled(ModeEnforce) {
+		t.Fatal("enforce must enforce")
+	}
+}
+
+// ─── Durable store ──────────────────────────────────────────────────────────
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "proofs.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestStoreRestartReconstructsSameReceipt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proofs.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Put(testRecord()); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("restart failed to reconstruct: %v", err)
+	}
+	got, ok := reopened.Get(testRecord().Key())
+	if !ok {
+		t.Fatal("receipt lost across restart")
+	}
+	if !got.equivalent(testRecord()) || !got.ObservedAt.Equal(testObservedAt) {
+		t.Fatalf("restart reconstructed a different receipt: %+v", got)
+	}
+	if v := Verify(reopened, testContext()); !v.Satisfied() {
+		t.Fatalf("reconstructed receipt must satisfy identically: %+v", v)
+	}
+}
+
+func TestStoreDuplicateEvidenceDeduplicates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proofs.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Put(testRecord()); err != nil {
+		t.Fatal(err)
+	}
+	firstBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same evidence re-observed later: dedupe, no state duplication, and the
+	// stored receipt (including its original instant) is what comes back.
+	dup := testRecord()
+	dup.ObservedAt = testObservedAt.Add(time.Minute)
+	got, err := s.Put(dup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.ObservedAt.Equal(testObservedAt) {
+		t.Fatalf("dedup must return the stored receipt, got instant %s", got.ObservedAt)
+	}
+	if got.Key() != testRecord().Key() || len(s.List()) != 1 {
+		t.Fatalf("duplicate evidence duplicated state: %d records", len(s.List()))
+	}
+	secondBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstBytes) != string(secondBytes) {
+		t.Fatal("dedup re-persisted the file; a duplicate must have no effects")
+	}
+}
+
+func TestStoreOutOfOrderEvidenceCannotRegress(t *testing.T) {
+	s := openTestStore(t)
+	newer := testRecord()
+	newer.Result = ResultFailure
+	newer.ObservedAt = testObservedAt.Add(time.Hour)
+	if _, err := s.Put(newer); err != nil {
+		t.Fatal(err)
+	}
+	// An OLDER green receipt arrives late; it must not overwrite current truth.
+	older := testRecord() // success at testObservedAt
+	if _, err := s.Put(older); !errors.Is(err, ErrEvidenceRegression) {
+		t.Fatalf("late old evidence must be refused, got %v", err)
+	}
+	got, _ := s.Get(newer.Key())
+	if got.Result != ResultFailure {
+		t.Fatalf("current truth regressed to %s by arrival order", got.Result)
+	}
+	// A genuinely newer re-observation supersedes deterministically.
+	newest := testRecord()
+	newest.ObservedAt = testObservedAt.Add(2 * time.Hour)
+	if _, err := s.Put(newest); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.Get(newest.Key())
+	if got.Result != ResultSuccess {
+		t.Fatal("newer re-observation failed to supersede")
+	}
+}
+
+func TestStoreRefusesMalformedRecord(t *testing.T) {
+	s := openTestStore(t)
+	bad := testRecord()
+	bad.Fingerprint.HeadSHA = "nope"
+	if _, err := s.Put(bad); !errors.Is(err, ErrMalformedRecord) {
+		t.Fatalf("malformed record must be refused: %v", err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatal("malformed record was stored")
+	}
+}
+
+func TestStoreCorruptFileIsARefusalNeverSatisfaction(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "proofs.json")
+	if err := os.WriteFile(path, []byte("{corrupt"), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(path); err == nil {
+		t.Fatal("corrupt store opened silently")
+	}
+	// The bytes are left exactly as found for inspection.
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "{corrupt" {
+		t.Fatalf("corrupt bytes were altered: %q %v", data, err)
+	}
+
+	// A parseable file holding a malformed or duplicate receipt likewise
+	// refuses to open rather than inventing truth.
+	bad := testRecord()
+	bad.Fingerprint.HeadSHA = "zzz"
+	writeStoreFile(t, path, []Record{bad})
+	if _, err := Open(path); err == nil {
+		t.Fatal("malformed persisted receipt opened silently")
+	}
+	writeStoreFile(t, path, []Record{testRecord(), testRecord()})
+	if _, err := Open(path); err == nil {
+		t.Fatal("conflicting duplicate receipts opened silently")
+	}
+}
+
+func writeStoreFile(t *testing.T, path string, recs []Record) {
+	t.Helper()
+	data, err := json.Marshal(persistedStore{Version: storeFormatVersion, Records: recs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o660); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStoreConcurrentWritersSerializeToOneDeterministicResult(t *testing.T) {
+	s := openTestStore(t)
+	const writers = 16
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rec := testRecord()
+			rec.ObservedAt = testObservedAt.Add(time.Duration(i) * time.Second)
+			_, _ = s.Put(rec) // regressions among the racers are legitimately refused
+		}(i)
+	}
+	wg.Wait()
+	all := s.List()
+	if len(all) != 1 {
+		t.Fatalf("racing writers produced %d records for one key", len(all))
+	}
+	// Whatever won, the store and its file agree (restart check).
+	reopened, err := Open(s.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := reopened.Get(all[0].Key())
+	if !ok || !got.ObservedAt.Equal(all[0].ObservedAt) {
+		t.Fatalf("disk and memory disagree after race: %+v vs %+v", got, all[0])
+	}
+}
+
+func TestStoreGetUnknownAndEmptyKey(t *testing.T) {
+	s := openTestStore(t)
+	if _, ok := s.Get(""); ok {
+		t.Fatal("empty key returned a record")
+	}
+	if _, ok := s.Get("default/x/y@z|" + PredicateExactHeadGreen + "|1|" + headX); ok {
+		t.Fatal("unknown key returned a record")
+	}
+}
+
+func TestStoreDistinctSubjectsCoexist(t *testing.T) {
+	// An unrelated proof (different head = different key) remains valid as a
+	// positive control while another subject's receipt churns.
+	s := openTestStore(t)
+	if _, err := s.Put(testRecord()); err != nil {
+		t.Fatal(err)
+	}
+	other := testRecord()
+	other.Fingerprint.HeadSHA = headY
+	other.Provenance.Query = "ListCheckRunsForRef@" + headY
+	if _, err := s.Put(other); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.List()) != 2 {
+		t.Fatalf("distinct subjects collided: %d records", len(s.List()))
+	}
+	if v := Verify(s, testContext()); !v.Satisfied() {
+		t.Fatalf("unrelated write invalidated a valid receipt: %+v", v)
+	}
+}
+
+func TestStorePersistFailureRollsBackMemory(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "proofs.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Put(testRecord()); err != nil {
+		t.Fatal(err)
+	}
+	// Make the tmp write fail: the store's directory disappears.
+	s.path = filepath.Join(dir, "gone", "proofs.json")
+	newer := testRecord()
+	newer.Result = ResultFailure
+	newer.ObservedAt = testObservedAt.Add(time.Hour)
+	if _, err := s.Put(newer); err == nil {
+		t.Fatal("persist into a missing directory succeeded")
+	}
+	got, ok := s.Get(testRecord().Key())
+	if !ok || got.Result != ResultSuccess {
+		t.Fatalf("failed persist left memory and disk disagreeing: %+v", got)
+	}
+	// A failed FIRST write for a new key likewise leaves no phantom record.
+	fresh := testRecord()
+	fresh.Fingerprint.HeadSHA = headY
+	if _, err := s.Put(fresh); err == nil {
+		t.Fatal("persist into a missing directory succeeded")
+	}
+	if _, ok := s.Get(fresh.Key()); ok {
+		t.Fatal("failed first persist left a phantom in-memory receipt")
+	}
+}
+
+func TestRecordEquivalenceIsEvidenceIdentity(t *testing.T) {
+	base := testRecord()
+	same := base.clone()
+	same.ObservedAt = testObservedAt.Add(time.Minute) // instant excluded
+	if !base.equivalent(same) {
+		t.Fatal("identical evidence at a later instant must be equivalent")
+	}
+	differentQuery := base.clone()
+	differentQuery.Provenance.Query = "other"
+	differentIDs := base.clone()
+	differentIDs.Provenance.CheckRunIDs = []int64{11, 99}
+	fewerIDs := base.clone()
+	fewerIDs.Provenance.CheckRunIDs = []int64{11}
+	differentResult := base.clone()
+	differentResult.Result = ResultFailure
+	for name, other := range map[string]Record{
+		"query": differentQuery, "run ids": differentIDs,
+		"run count": fewerIDs, "result": differentResult,
+	} {
+		if base.equivalent(other) {
+			t.Errorf("%s difference treated as duplicate evidence", name)
+		}
+	}
+}

--- a/src/pkg/convergence/proof/store.go
+++ b/src/pkg/convergence/proof/store.go
@@ -1,0 +1,180 @@
+package proof
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+)
+
+// Sentinel errors. Callers match with errors.Is; the wrapped detail names the
+// offending key and instants for logs.
+var (
+	// ErrEvidenceRegression: a Put carried an observation OLDER than the
+	// receipt already stored under the same key. Arrival order can never
+	// regress current truth — the late evidence is refused, and the caller's
+	// next re-observation of current state decides, not delivery order.
+	ErrEvidenceRegression = errors.New("older evidence cannot replace a newer receipt")
+	// ErrMalformedRecord: the record fails validation and can never be
+	// recorded (a malformed receipt read back from disk likewise refuses Open).
+	ErrMalformedRecord = errors.New("proof record is malformed")
+)
+
+// storeFileMode is 0660 (group-writable) for the same reason the outcome
+// ledger and beads.Store.persist use it: the file lives under the shared
+// /data root and more than one node-group member may legitimately rewrite it.
+const storeFileMode = 0o660
+
+// storeFormatVersion is the persisted schema version, written so a future
+// widening is a deliberate, reviewable migration rather than an accident.
+const storeFormatVersion = 1
+
+// Store is the durable proof-receipt owner: an in-memory index over one JSON
+// file, reloaded on boot, rewritten atomically on every accepted write. No
+// process memory is authoritative — restart reconstruction IS the file. The
+// ONLY authorized writer is the proof observer normalizing current
+// authoritative producer evidence; nothing else holds a Put seam.
+type Store struct {
+	path    string
+	mu      sync.Mutex
+	records map[string]*Record
+}
+
+// persistedStore is the on-disk shape, named separately so the file format is
+// a deliberate artifact (the persistedLedger/persistedGenerations convention).
+type persistedStore struct {
+	Version int      `json:"version"`
+	Records []Record `json:"records"`
+}
+
+// Open loads the proof store at path, creating an empty one if the file does
+// not exist. A file that exists but cannot be parsed or validated is a
+// REFUSAL: Open fails, the bytes are left exactly as found for operator
+// inspection, and no handle exists through which a write could replace them —
+// corrupt durable state must be visible and can never become satisfaction or
+// silently reset to an empty truth (the accepted #4249/#4251 failure
+// behavior, following the hub generations quarantine rationale).
+func Open(path string) (*Store, error) {
+	s := &Store{path: path, records: make(map[string]*Record)}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return s, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading proof store %s: %w", path, err)
+	}
+	var persisted persistedStore
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return nil, fmt.Errorf("proof store %s is unparseable and is left untouched for inspection: %w", path, err)
+	}
+	for i := range persisted.Records {
+		rec := persisted.Records[i]
+		if err := rec.Validate(); err != nil {
+			return nil, fmt.Errorf("proof store %s holds a malformed receipt: %w", path, err)
+		}
+		key := rec.Key()
+		if _, dup := s.records[key]; dup {
+			return nil, fmt.Errorf("proof store %s holds conflicting receipts for %s", path, key)
+		}
+		stored := rec.clone()
+		s.records[key] = &stored
+	}
+	return s, nil
+}
+
+// Get returns a detached copy of the receipt stored under key. The copy is
+// the read seam: verifiers hold immutable values and can never race a writer.
+func (s *Store) Get(key string) (Record, bool) {
+	if key == "" {
+		return Record{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.records[key]
+	if !ok {
+		return Record{}, false
+	}
+	return rec.clone(), true
+}
+
+// List returns detached copies of every receipt, sorted by key for
+// deterministic projections and tests.
+func (s *Store) List() []Record {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Record, 0, len(s.records))
+	for _, rec := range s.records {
+		out = append(out, rec.clone())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key() < out[j].Key() })
+	return out
+}
+
+// Put records one normalized observation under its fingerprint key. The
+// rules, in order:
+//
+//  1. A malformed record is refused (never stored, never satisfaction).
+//  2. Duplicate identical evidence deduplicates: the stored receipt is
+//     returned unchanged and nothing is persisted or re-emitted.
+//  3. Evidence observed BEFORE the stored receipt's instant is refused
+//     (ErrEvidenceRegression): out-of-order delivery cannot regress current
+//     truth. Conflicting results therefore never resolve by arrival order —
+//     only a genuinely newer re-observation of current state supersedes.
+//  4. Otherwise the record supersedes the stored receipt atomically
+//     (marshal → *.tmp → rename), install-after-persist, under the store
+//     mutex — which is the explicit serialization rule for racing writers:
+//     one deterministic winner per key, no interleaved bytes, no subject
+//     collisions.
+func (s *Store) Put(rec Record) (Record, error) {
+	if err := rec.Validate(); err != nil {
+		return Record{}, fmt.Errorf("%w: %v", ErrMalformedRecord, err)
+	}
+	key := rec.Key()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if stored, ok := s.records[key]; ok {
+		if stored.equivalent(rec) {
+			return stored.clone(), nil
+		}
+		if rec.ObservedAt.Before(stored.ObservedAt) {
+			return Record{}, fmt.Errorf("%s: stored %s vs offered %s: %w",
+				key, stored.ObservedAt.Format("2006-01-02T15:04:05Z07:00"),
+				rec.ObservedAt.Format("2006-01-02T15:04:05Z07:00"), ErrEvidenceRegression)
+		}
+	}
+	work := rec.clone()
+	prior, hadPrior := s.records[key]
+	s.records[key] = &work
+	if err := s.persistLocked(); err != nil {
+		if hadPrior {
+			s.records[key] = prior
+		} else {
+			delete(s.records, key)
+		}
+		return Record{}, err
+	}
+	return work.clone(), nil
+}
+
+// persistLocked writes the whole store: marshal → *.tmp → rename, exactly the
+// beads.Store.persist / outcome ledger idiom. Callers hold s.mu, which is
+// what keeps two writers from interleaving bytes in the same tmp path.
+func (s *Store) persistLocked() error {
+	all := make([]Record, 0, len(s.records))
+	for _, rec := range s.records {
+		all = append(all, rec.clone())
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].Key() < all[j].Key() })
+
+	data, err := json.MarshalIndent(persistedStore{Version: storeFormatVersion, Records: all}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling proof store: %w", err)
+	}
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, storeFileMode); err != nil {
+		return fmt.Errorf("writing tmp proof store: %w", err)
+	}
+	return os.Rename(tmpPath, s.path)
+}

--- a/src/pkg/convergence/proof/verify.go
+++ b/src/pkg/convergence/proof/verify.go
@@ -1,0 +1,214 @@
+package proof
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/convergence"
+)
+
+// Convergence mode values, mirroring the convergence.mode /
+// HIVE_CONVERGENCE_MODE toggle surface (#4246, formalised by #4263). The
+// resolution rule is the same default-off one used by config.ConvergenceMode
+// and pkg/convergence/outcome: anything that is not an exact recognised mode
+// is OFF. Callers pass config.ConvergenceMode()'s resolved value through.
+const (
+	// ModeOff disables every proof surface: nothing is recorded, verified,
+	// reported, or gated. Byte-identical behavior to today.
+	ModeOff = "off"
+	// ModeShadow records and reports proof verdicts but NEVER enforces one:
+	// no transition is withheld on a proof in shadow.
+	ModeShadow = "shadow"
+	// ModeEnforce lets a proof verdict gate ONLY the one dependent transition
+	// explicitly declared to depend on it. It is never a default and never
+	// selected by fallback.
+	ModeEnforce = "enforce"
+)
+
+// RecordingEnabled reports whether the resolved convergence mode enables
+// observing and recording proof receipts at all (shadow or enforce).
+// Default-off: only an exact recognised enabling mode answers true.
+func RecordingEnabled(mode string) bool {
+	return mode == ModeShadow || mode == ModeEnforce
+}
+
+// EnforcementEnabled reports whether a proof verdict may gate its one
+// declared dependent transition. ONLY the exact enforce mode answers true —
+// shadow reports, never enforces.
+func EnforcementEnabled(mode string) bool {
+	return mode == ModeEnforce
+}
+
+// Verdict reasons. Stable machine-readable strings; callers log and test
+// against them, so treat them as API.
+const (
+	// ReasonProofCurrent: a valid receipt matches the complete current
+	// fingerprint, its result is success, and its freshness rule holds.
+	ReasonProofCurrent = "ProofCurrent"
+	// ReasonProofMissing: no receipt exists for the required subject.
+	ReasonProofMissing = "ProofMissing"
+	// ReasonProofMalformed: the receipt in hand fails validation.
+	ReasonProofMalformed = "ProofMalformed"
+	// ReasonFingerprintMismatch: at least one load-bearing fingerprint field
+	// differs from the current evaluation context — a repaired head, a
+	// superseded generation, a moved base, a changed check policy, a
+	// different outcome/predicate/producer. Evidence for another subject
+	// never transfers.
+	ReasonFingerprintMismatch = "FingerprintMismatch"
+	// ReasonProofExpired: the receipt's observation is older than the
+	// freshness window; it must be re-observed before it can satisfy again.
+	ReasonProofExpired = "ProofExpired"
+	// ReasonPredicateFailed: current evidence establishes the predicate as
+	// NOT satisfied (a definite red, not an unknown).
+	ReasonPredicateFailed = "PredicateFailed"
+	// ReasonEvidencePending: the producer has not finished producing evidence
+	// for the exact subject.
+	ReasonEvidencePending = "EvidencePending"
+)
+
+// Context is the CURRENT evaluation context a receipt must match to satisfy
+// the predicate: the fingerprint current truth requires (current desired
+// generation, current head, current base observation, current check policy),
+// the evaluation instant, and the freshness window. It is supplied fresh on
+// every evaluation — proofs are level-triggered, never event-latched.
+type Context struct {
+	// Required is the complete fingerprint the CURRENT state of the world
+	// demands. Every field must match the receipt exactly.
+	Required Fingerprint
+	// Now is the evaluation instant.
+	Now time.Time
+	// MaxAge is the freshness window: a receipt observed more than MaxAge
+	// before Now is expired and must be re-observed. Zero or negative means
+	// no receipt is ever fresh — the conservative direction.
+	MaxAge time.Duration
+}
+
+// Verdict is the tri-state judgment of one receipt against one Context, in
+// the same True/False/Unknown vocabulary convergence.Evaluate consumes.
+// Satisfied is true ONLY for a current, complete, matching, successful proof.
+type Verdict struct {
+	// Status is True (predicate proven), False (predicate established
+	// unsatisfied by current evidence), or Unknown (nothing established:
+	// missing, mismatched, stale, malformed, or pending evidence).
+	Status convergence.ConditionStatus
+	// Reason is one of the Reason* constants above.
+	Reason string
+	// Detail is a short human-readable note naming the mismatched field or
+	// instants for logs and operator-facing messages.
+	Detail string
+}
+
+// Satisfied reports whether the verdict proves the predicate. It is the ONLY
+// thing a dependent gate may key on.
+func (v Verdict) Satisfied() bool { return v.Status == convergence.ConditionTrue }
+
+// VerifyAgainst judges a receipt held in hand against the current context.
+// The rules, in order — every early return is a refusal to satisfy:
+//
+//  1. A malformed receipt establishes nothing (Unknown, ProofMalformed).
+//  2. ANY fingerprint field mismatch establishes nothing for THIS subject
+//     (Unknown, FingerprintMismatch, naming the first differing field).
+//     Head X→Y, generation G→G+1, base movement, policy change, another
+//     outcome/predicate/producer — all land here, unconditionally.
+//  3. An expired receipt establishes nothing (Unknown, ProofExpired).
+//  4. A fresh matching receipt then maps its result: success → True,
+//     failure → False (PredicateFailed), pending → Unknown (EvidencePending).
+func (r Record) VerifyAgainst(ctx Context) Verdict {
+	if err := r.Validate(); err != nil {
+		return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonProofMalformed, Detail: err.Error()}
+	}
+	if err := ctx.Required.Validate(); err != nil {
+		return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonProofMalformed,
+			Detail: "required fingerprint is malformed: " + err.Error()}
+	}
+	if field, ok := firstMismatch(r.Fingerprint, ctx.Required); ok {
+		return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonFingerprintMismatch,
+			Detail: "receipt does not bind the current subject: " + field}
+	}
+	if ctx.MaxAge <= 0 || ctx.Now.Sub(r.ObservedAt) > ctx.MaxAge {
+		return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonProofExpired,
+			Detail: fmt.Sprintf("observed %s is outside the freshness window ending %s",
+				r.ObservedAt.Format(time.RFC3339), ctx.Now.Format(time.RFC3339))}
+	}
+	switch r.Result {
+	case ResultSuccess:
+		return Verdict{Status: convergence.ConditionTrue, Reason: ReasonProofCurrent,
+			Detail: "all required checks green for exact head " + r.Fingerprint.HeadSHA}
+	case ResultFailure:
+		return Verdict{Status: convergence.ConditionFalse, Reason: ReasonPredicateFailed,
+			Detail: "required checks failed for exact head " + r.Fingerprint.HeadSHA}
+	default:
+		return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonEvidencePending,
+			Detail: "required checks incomplete for exact head " + r.Fingerprint.HeadSHA}
+	}
+}
+
+// firstMismatch names the first load-bearing field on which the receipt's
+// fingerprint differs from the required one. Field-by-field (rather than a
+// struct compare) so the verdict can SAY which assumption moved — the seed
+// selective invalidation (B3) grows from.
+func firstMismatch(got, want Fingerprint) (string, bool) {
+	switch {
+	case got.OutcomeKey != want.OutcomeKey:
+		return fmt.Sprintf("outcome key %q != required %q", got.OutcomeKey, want.OutcomeKey), true
+	case got.PredicateID != want.PredicateID:
+		return fmt.Sprintf("predicate %q != required %q", got.PredicateID, want.PredicateID), true
+	case got.DesiredGeneration != want.DesiredGeneration:
+		return fmt.Sprintf("desired generation %d != required %d", got.DesiredGeneration, want.DesiredGeneration), true
+	case got.Repo != want.Repo:
+		return fmt.Sprintf("repo %q != required %q", got.Repo, want.Repo), true
+	case got.PRNumber != want.PRNumber:
+		return fmt.Sprintf("pr %d != required %d", got.PRNumber, want.PRNumber), true
+	case got.HeadSHA != want.HeadSHA:
+		return fmt.Sprintf("head %s != required %s", got.HeadSHA, want.HeadSHA), true
+	case got.BaseSHA != want.BaseSHA:
+		return fmt.Sprintf("base %s != required %s", got.BaseSHA, want.BaseSHA), true
+	case got.CheckPolicyID != want.CheckPolicyID:
+		return fmt.Sprintf("check policy %s != required %s", got.CheckPolicyID, want.CheckPolicyID), true
+	case got.Producer != want.Producer:
+		return fmt.Sprintf("producer %q != required %q", got.Producer, want.Producer), true
+	}
+	return "", false
+}
+
+// Verify looks up the receipt for the required subject in the store and
+// judges it against the context. A missing store or missing receipt is
+// Unknown (ProofMissing) — an absent proof can never satisfy, and a missing
+// or unreadable store is a visible failure, never satisfaction.
+func Verify(s *Store, ctx Context) Verdict {
+	if s == nil {
+		return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonProofMissing,
+			Detail: "no proof store is available"}
+	}
+	key := ctx.Required.Key()
+	rec, ok := s.Get(key)
+	if !ok {
+		return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonProofMissing,
+			Detail: "no receipt exists for " + key}
+	}
+	return rec.VerifyAgainst(ctx)
+}
+
+// AdmissionDependency projects a verdict into the existing convergence
+// Evaluate seam as one Dependency edge, gated by the convergence mode toggle.
+//
+// It returns nil unless the mode is EXACTLY enforce — and a nil Dependency
+// contributes nothing to an Observation, which is the default-off and
+// shadow-never-enforces guarantee in one place: with the toggle off nothing
+// is consulted at all, and in shadow the verdict is recorded and reportable
+// (the caller may surface it) but can never withhold a transition. Only the
+// one candidate whose observer explicitly declares this proof dependency is
+// ever gated; every other candidate never receives the edge and retains
+// existing admission behavior through convergence.Evaluate's ordinary rules —
+// True passes, False blocks (WaitingForDependency), Unknown blocks as
+// Unknown (DependencyUnknown), exactly rule 3/4 of the existing evaluator.
+func (v Verdict) AdmissionDependency(mode string, ctx Context) *convergence.Dependency {
+	if !EnforcementEnabled(mode) {
+		return nil
+	}
+	return &convergence.Dependency{
+		ID:     "proof:" + ctx.Required.Key(),
+		Status: v.Status,
+		Detail: v.Reason + ": " + v.Detail,
+	}
+}


### PR DESCRIPTION
Closes #4253
Part of #3845

Implements the predicate and immutable fingerprint **accepted on #4252** (decision packet, comment 5362851925): `github.checks.exact-head-green/v1` — all required (non-meta) check runs for exact head SHA X of PR N concluded success, producer = GitHub Checks API.

## What

New package `pkg/convergence/proof` (nothing else touched):

- **Fingerprint** — every accepted REQUIRED field, all load-bearing: OutcomeKey (`project/repo@outcome`, #4251), PredicateID, DesiredGeneration, Repo, PRNumber, exact HeadSHA (full 40-hex), bounded BaseSHA observation, CheckPolicyID (sha256 over classifier version + sorted counted check names), Producer. Receipt key = `outcome|predicate|generation|headSHA`; a fingerprint that fails validation has no key and can never be recorded or satisfied.
- **Record + NormalizeCheckEvidence** — normalizes one authoritative check-run observation into a durable receipt with EnrichCIStatus's exact classification (failure/action_required → failure, incomplete → pending, empty counted set → pending, else success), sorted provenance run IDs, and the observation call named in provenance.
- **Store** — durable receipt owner following the #4362 outcome-ledger idioms exactly: one JSON file, marshal → tmp → rename, persist-then-install with rollback, refusal (never reset) on corrupt/malformed/duplicate persisted state, restart reconstruction from disk only, mutex+key serialization, deterministic dedup of identical evidence (ObservedAt excluded from evidence identity), and `ErrEvidenceRegression` refusal of arrival-order regressions — conflicting results never resolve by delivery order.
- **VerifyAgainst / Verify** — tri-state verdict in `convergence.ConditionStatus` vocabulary. Rules in order: malformed ⇒ Unknown; **any single fingerprint field mismatch ⇒ Unknown/FingerprintMismatch naming the moved field** (head X→Y, G→G+1, base movement, policy change, foreign outcome/predicate/producer all land here); expired freshness window ⇒ Unknown/ProofExpired (zero window = never fresh, the conservative direction); then success→True, failure→False, pending→Unknown. Missing store/receipt ⇒ Unknown/ProofMissing.
- **AdmissionDependency** — projects a verdict into the existing `convergence.Evaluate` seam as one `Dependency` edge, **only in exact `enforce` mode and only for the one candidate whose observer explicitly declares the proof dependency**; Evaluate's existing rules 3/4 then gate (False blocks, Unknown blocks-as-Unknown). No second evaluator, no provider framework, no new scheduler.

## Default-off guarantee (maintainer requirement)

- `convergence.mode=off` (default): nothing is recorded, verified, reported, or gated — a nil dependency contributes nothing and admission is byte-identical to today.
- `shadow`: verdicts are computed and reportable, **never enforced** (`AdmissionDependency` returns nil).
- `enforce`: gates only the explicitly declared dependent transition. Unrecognised values fail safe to off, matching `config.ConvergenceMode` (#4372).
- Existing merge, CI, review, queue-approval (#3152), and automerge guards are untouched mandatory positive guards; the receipt never replaces them.

## RED acceptance matrix → tests

| Row | Test |
|---|---|
| Matching fingerprint admits; unrelated transition positive control | `TestEnforceModeGatesTheDeclaredTransitionOnly` (through production `convergence.Evaluate`) |
| Head X→Y never authorized | `TestVerifyRepairedHeadNeverSatisfiedByOldProof`, mismatch matrix |
| G→G+1 never satisfied | `TestVerifyGenerationSupersessionInvalidates` |
| Each load-bearing input mismatch rejects independently | `TestVerifyEachFieldMismatchRejects` (outcome, generation, repo, PR, head, base, policy) |
| Stale/missing/malformed/conflicting ⇒ Unknown, with valid-receipt positive control | `TestVerifyStaleProofExpires`, `TestVerifyMalformedEvidenceNeverSatisfies`, `TestVerifyLookupMissesAndNilStore`, `TestStoreDistinctSubjectsCoexist` |
| Duplicate evidence dedups without state/effects | `TestStoreDuplicateEvidenceDeduplicates` (byte-identical file asserted) |
| Out-of-order arrival cannot regress truth | `TestStoreOutOfOrderEvidenceCannotRegress` |
| Racing writers serialize to one deterministic result | `TestStoreConcurrentWritersSerializeToOneDeterministicResult` (-race) |
| Restart reconstructs the same durable receipt | `TestStoreRestartReconstructsSameReceipt` |
| Missing/corrupt storage is visible refusal, never satisfaction | `TestStoreCorruptFileIsARefusalNeverSatisfaction`, `TestStorePersistFailureRollsBackMemory` |
| Producer multiplicity ≠ independence | producer is a validated fixed authority; mismatch rejected in validation + mismatch matrix |
| Off/shadow never enforce | `TestOffAndShadowModesNeverEnforce`, `TestModeResolutionIsDefaultOff` |

## Verification

- `go test -race -cover ./pkg/convergence/proof/` — **ok, 97.7% coverage** (≥ the 90% default floor)
- `go test ./pkg/convergence/...` — all green (core, outcome, proof)
- `go build ./...`, `go vet`, `gofmt` clean