### PR TITLE
✨ feat(hub): let an admin assign a country to any user

### DIFF
--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -354,7 +354,40 @@ type SaaSUser struct {
 	//
 	// omitempty bool so every record that has not been through a deliberate
 	// pick — which today is all of them — round-trips byte-identical.
+	//
+	// STILL WRITTEN, not deprecated: CountrySource below is the finer-grained
+	// successor, but this boolean is what other readers and every record
+	// already on the PVC speak, so every user-chosen write keeps setting it.
 	CountrySetByUser bool `json:"country_set_by_user,omitempty"`
+
+	// CountrySource is the PROVENANCE of the country above — who put it there.
+	// One of countrySourceInferred / countrySourceAdmin / countrySourceUser, or
+	// "" for a record nothing has ever touched.
+	//
+	// A boolean stopped being enough the moment an ADMIN could assign a country
+	// on someone else's behalf, because that is a third kind of claim and it
+	// sits BETWEEN the two the boolean can express:
+	//
+	//   - It is not user-chosen. Stamping CountrySetByUser for an admin edit
+	//     would assert the user made a statement about themselves that they
+	//     never made, and — since that marker is also what suppresses ever
+	//     asking again — would permanently silence the question for them.
+	//   - But it must still outrank Accept-Language inference. An admin's
+	//     best-effort attribution is a human looking at evidence; the header is
+	//     a language preference. Letting the next login overwrite it would
+	//     re-introduce, in a new form, exactly the silent-clobber bug #4374 was
+	//     opened to fix.
+	//
+	// Precedence, strongest first: user > admin > inferred > unset. See
+	// countryProvenanceRank and mayOverwriteCountry in user_country.go, which
+	// are the single arbiters — no caller compares these strings by hand.
+	//
+	// BACKWARD COMPATIBILITY. Records written before this field exists carry
+	// only CountrySetByUser, so an ABSENT source is read through that boolean:
+	// CountrySetByUser=true with no source means user-chosen (see
+	// effectiveCountrySource). That is why this is omitempty and why nothing
+	// backfills it — an untouched record must still serialize byte-identically.
+	CountrySource string `json:"country_source,omitempty"`
 
 	// Engagement stats, admin-only (they ride /api/saas/admin/users, which is
 	// requireAdmin). Both omitempty ints so existing records round-trip
@@ -1514,6 +1547,18 @@ func (s *HubServer) handleImpersonationStatus(w http.ResponseWriter, r *http.Req
 // They are length-capped here — the last point before the value reaches the
 // PVC — and escaped on every dashboard render path.
 //
+// `country` rides this same body rather than a route of its own. It is the only
+// way the field can be set for the thousands of users who joined before it
+// existed: the wizard is a one-time gate already behind them, and the
+// self-service endpoint reaches only the acting user, so an admin looking at a
+// row with an empty Country column previously had no control at all. It carries
+// ADMIN provenance, never user provenance — see the block on the country branch
+// below, which is the load-bearing decision in this change.
+//
+// PRIVACY: the code rides the JSON BODY, never the path or a query string, for
+// the same reason the self-service endpoint does — a URL lands in access logs,
+// Referer headers and browser history.
+//
 // Registered behind requireAdmin; this handler does no auth of its own.
 func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
 	username := r.PathValue("username")
@@ -1530,11 +1575,21 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 		FullName  *string `json:"full_name"`
 		SlackID   *string `json:"slack_id"`
 		Notes     *string `json:"notes"`
+		// Pointer like the rest, and for a sharper reason here: `""` is an
+		// explicit CLEAR ("remove this country"), while an absent key means the
+		// admin edited some other field and this one must not be touched. A
+		// plain string would collapse the two and let a quota edit silently
+		// wipe a country.
+		Country *string `json:"country"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
+	// Whether the country branch below actually APPLIED, which is not the same
+	// as the key being present: a stronger user-chosen value declines the edit.
+	// Tracked so the audit line records what changed rather than what was asked.
+	countryEdited := false
 	if body.SaaSQuota != nil {
 		u.SaaSQuota = *body.SaaSQuota
 	}
@@ -1552,6 +1607,46 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 	if body.Notes != nil {
 		u.Notes = truncateRunes(strings.TrimSpace(*body.Notes), maxContactNotesLen)
 	}
+	if body.Country != nil {
+		raw := strings.TrimSpace(*body.Country)
+		code := ""
+		if raw != "" {
+			// The SAME validator every other country path uses, so this
+			// endpoint cannot drift into accepting a shape the render sites
+			// reject. Not capped like the free-text fields above: a country is
+			// two letters or it is rejected outright, so there is nothing to
+			// truncate — a bad value must 400 rather than be silently reshaped
+			// into a different country.
+			code = normalizeCountryCode(raw)
+			if code == "" {
+				writeJSONError(w, http.StatusBadRequest, "country must be an ISO 3166-1 alpha-2 code (two letters), or \"\" to clear it")
+				return
+			}
+		}
+		// PROVENANCE — the whole point of this branch, and the easy thing to get
+		// wrong. An admin edit is countrySourceAdmin, NEVER countrySourceUser:
+		//
+		//   - It must not claim the user chose this. They did not; an admin
+		//     inferred it from a conference badge, an email domain, a
+		//     conversation. Marking it user-chosen would fabricate a statement
+		//     and would permanently suppress ever asking them for a real one.
+		//   - It must still outrank the login-path Accept-Language inference,
+		//     or the assignment is silently reverted the next time the user
+		//     signs in from a differently-configured browser — the #4374 bug in
+		//     a new form, and invisible in exactly the same way.
+		//
+		// mayOverwriteCountry is what keeps the admin from stepping on a value
+		// the USER stated about themselves. It is not an error to try: the edit
+		// is simply not applied to the country, the rest of the request still
+		// lands, and the response is still a 200 — the admin has changed
+		// nothing they were entitled to change. A 409 here would fail an
+		// otherwise-valid multi-field save over a field the admin may not even
+		// have meant to touch.
+		if mayOverwriteCountry(u, countrySourceAdmin) {
+			setUserCountry(u, code, countrySourceAdmin)
+			countryEdited = true
+		}
+	}
 	// A failed write is the one outcome the admin MUST hear about: the dashboard
 	// closes the editor on a 2xx, so reporting success here after the PVC write
 	// failed would silently discard the edit.
@@ -1562,8 +1657,19 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 	}
 	// Do not log the note bodies — they are free text and may hold anything an
 	// admin jotted down. Log only that contact fields were touched.
-	s.logger.Info("audit: admin updated user", "target", username, "quota", u.SaaSQuota, "blocked", u.Blocked,
-		"contactEdited", body.FullName != nil || body.SlackID != nil || body.Notes != nil)
+	//
+	// The country VALUE is logged, unlike those bodies: it is a two-letter code
+	// from a closed shape, an admin assigning one on another person's behalf is
+	// exactly the attribution an audit trail exists to record, and "who decided
+	// this user is in GB" is unanswerable from a bare "countryEdited: true".
+	// Logged only when the write actually applied, so the line never claims a
+	// change that mayOverwriteCountry declined.
+	attrs := []any{"target", username, "quota", u.SaaSQuota, "blocked", u.Blocked,
+		"contactEdited", body.FullName != nil || body.SlackID != nil || body.Notes != nil}
+	if countryEdited {
+		attrs = append(attrs, "countryAssigned", u.Country, "countrySource", u.CountrySource)
+	}
+	s.logger.Info("audit: admin updated user", attrs...)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
 }
@@ -7091,12 +7197,12 @@ func applyRequestContactToUser(user *SaaSUser, pr *ProvisionRequest) {
 	// record — but only when the request actually carries a choice. Re-normalize
 	// rather than trusting the stored request: it may predate the validation.
 	if code := normalizeCountryCode(pr.Country); code != "" {
-		user.Country = code
-		// The wizard pick is a deliberate statement, so stamp it as one — same
-		// marker the self-service endpoint sets. Without this, an approval
-		// would leave the record looking "inferred", and the priority rule
-		// would hold only by the accident of the value being non-empty.
-		user.CountrySetByUser = true
+		// The wizard pick is a deliberate statement BY THE USER, so it carries
+		// the same provenance the self-service endpoint stamps. Without this,
+		// an approval would leave the record looking "inferred", and the
+		// priority rule would hold only by the accident of the value being
+		// non-empty.
+		setUserCountry(user, code, countrySourceUser)
 	}
 }
 
@@ -17844,6 +17950,15 @@ const dashboardHTML = `<!DOCTYPE html>
     var CONTACT_W_NOTES_BASIS = '48%';
     var CONTACT_W_NOTES_MIN = '320px';
     var CONTACT_NOTES_GROW = 3;
+    /* Country is a two-letter code plus a live flag preview, so it is the
+       narrowest field in the panel and the only one with a fixed-ish basis: it
+       can never need more room than "GB  United Kingdom" takes to echo. */
+    var CONTACT_W_COUNTRY_BASIS = '12%';
+    var CONTACT_W_COUNTRY_MIN = '150px';
+    /* ISO 3166-1 alpha-2. Mirrors countryCodeLen in user_country.go — the
+       maxlength is a courtesy that stops a third letter being typed at all;
+       normalizeCountryCode on both sides is the actual control. */
+    var CONTACT_MAX_COUNTRY = 2;
 
     // Which users currently have their contact panel open, keyed by username.
     // Re-rendering on the admin poll must not slam a panel shut mid-edit.
@@ -17924,6 +18039,46 @@ const dashboardHTML = `<!DOCTYPE html>
     // id attribute or break querySelector.
     function contactPanelId(username) {
       return 'contact-panel-' + String(username || '').replace(/[^A-Za-z0-9_-]/g, '_');
+    }
+
+    /* Same sanitizing rule as contactPanelId, for the country field's live
+       preview node. Separate id per user because every panel row is emitted for
+       every user up front (hidden until expanded), so a shared id would collide
+       across hundreds of rows and every lookup would find the first one. */
+    function contactCountryPreviewId(username) {
+      return 'contact-country-preview-' + String(username || '').replace(/[^A-Za-z0-9_-]/g, '_');
+    }
+
+    /* countryPreviewHTML: what a typed code resolves to, as flag + English name.
+
+       Reuses countryFlagEmoji / countryDisplayName from the shared block above
+       rather than restating them, so the admin editor and the self-service
+       editor can never disagree about what a code means.
+
+       Three distinct states, deliberately worded so none of them reads as an
+       error the admin caused:
+         blank   -> "No flag" (a legitimate value: clearing the country)
+         partial -> "Two-letter code" (still typing; not a failure)
+         valid   -> the flag and the country's name
+
+       The code is escaped even though normalizeCountryCode has already reduced
+       it to [A-Z]{2}, and the name is escaped because Intl.DisplayNames returns
+       a localized string this render path does not own. */
+    function countryPreviewHTML(raw) {
+      var typed = String(raw == null ? '' : raw).trim();
+      if (!typed) return 'No flag';
+      var c = normalizeCountryCode(typed);
+      if (!c) return 'Two-letter code';
+      return countryFlagEmoji(c) + ' ' + esc(countryDisplayName(c));
+    }
+
+    /* refreshContactCountryPreview re-renders one user's preview from whatever
+       is currently in their input. Called on every keystroke, so it reads the
+       DOM rather than _allUsers — the point is to reflect the UNSAVED text. */
+    function refreshContactCountryPreview(username, value) {
+      var el = document.getElementById(contactCountryPreviewId(username));
+      if (!el) return;
+      el.innerHTML = countryPreviewHTML(value);
     }
 
     /* providerBadge renders the user's login method (auth provider) as a small
@@ -18093,6 +18248,33 @@ const dashboardHTML = `<!DOCTYPE html>
             '<label style="' + lbl + '">Slack ID</label>' +
             '<input type="text" data-contact-user="' + user + '" data-contact-field="slack_id"' +
               ' maxlength="' + CONTACT_MAX_SLACK + '" value="' + escAttr(u.slack_id || '') + '" style="' + fld + '">' +
+          '</div>' +
+          /* Country. An ADMIN ASSIGNMENT, not a statement by the user — the
+             hub records it as such (CountrySource "admin"), which is why the
+             hint says "on their behalf" rather than presenting it as their
+             choice. It is the only route to a country for every user who
+             joined before the field existed: the wizard is behind them and the
+             self-service editor reaches only the person themselves.
+
+             A free-text code rather than a 250-row <select>: the country list
+             lives in get-started.html and duplicating it into this raw string
+             would give the hub two lists to keep in step. The live preview
+             below turns the code into a flag and an English name as it is
+             typed, which is what makes two letters legible without a list. */
+          '<div style="flex:1 1 ' + CONTACT_W_COUNTRY_BASIS + ';min-width:' + CONTACT_W_COUNTRY_MIN + '">' +
+            '<label style="' + lbl + '">Country</label>' +
+            '<input type="text" data-contact-user="' + user + '" data-contact-field="country"' +
+              ' maxlength="' + CONTACT_MAX_COUNTRY + '" placeholder="GB"' +
+              ' aria-describedby="' + contactCountryPreviewId(u.github_username) + '"' +
+              ' value="' + escAttr(normalizeCountryCode(u.country) || '') + '"' +
+              ' style="' + fld + ';text-transform:uppercase">' +
+            /* Echoes what the typed code resolves to, so a typo is visible
+               BEFORE the blur-save rather than as a surprise flag in the row
+               afterwards. Rendered from the stored value on open so the panel
+               agrees with the table's Country column. */
+            '<div id="' + contactCountryPreviewId(u.github_username) + '"' +
+              ' style="margin-top:4px;font-size:0.66rem;color:var(--muted);min-height:1.1em">' +
+              countryPreviewHTML(u.country) + '</div>' +
           '</div>' +
           '<div style="flex:' + CONTACT_NOTES_GROW + ' 1 ' + CONTACT_W_NOTES_BASIS + ';min-width:' + CONTACT_W_NOTES_MIN + '">' +
             '<label style="' + lbl + '">Notes</label>' +
@@ -18273,6 +18455,10 @@ const dashboardHTML = `<!DOCTYPE html>
         el.addEventListener('input', function() {
           markContactEditing();
           _contactDirty[key] = el.value;
+          /* Country is the one field whose stored form (two letters) does not
+             say what it means, so it echoes as you type. The other fields are
+             their own preview. */
+          if (field === 'country') refreshContactCountryPreview(user, el.value);
         });
         // focus/blur also count as activity: tabbing between fields must not
         // leave a gap the poll can render into.
@@ -18351,6 +18537,17 @@ const dashboardHTML = `<!DOCTYPE html>
       var current = _allUsers ? (_allUsers.find(function(x) { return x.github_username === username; }) || {}) : {};
       var previous = (_contactLastSaved[key] !== undefined) ? _contactLastSaved[key] : (current[field] || '');
       var next = (value || '').trim();
+      /* Country is stored upper-cased by the server, so normalize it to the
+         SAME form here before the equality check. Without this, re-opening the
+         panel and typing "gb" over a stored "GB" would read as a change and fire
+         a pointless PUT, and the optimistic cache below would hold a value the
+         server never wrote. A half-typed or invalid code is left alone rather
+         than blanked, so the field still holds what was typed while the server
+         does the actual rejecting. */
+      if (field === 'country') {
+        var norm = normalizeCountryCode(next);
+        if (norm) next = norm;
+      }
       if (next === previous) return Promise.resolve(true);
       _contactLastSaved[key] = next;
       // Keep the in-memory copy in step so the next poll's signature check does

--- a/src/pkg/hub/user_country.go
+++ b/src/pkg/hub/user_country.go
@@ -24,9 +24,17 @@ import (
 //     that has NO country and whose user has made no deliberate choice; it
 //     never overwrites, and never undoes, an explicit one.
 //
+//  4. ADMIN-ASSIGNED — a hub admin sets it for another user from the admin
+//     Users table (handleAdminUpdateUser). This is the only route for the
+//     thousands of users who signed up before the field existed and who will
+//     never open the wizard again; without it their country is unreachable by
+//     anyone but themselves.
+//
 // Sources 1 and 2 both stamp SaaSUser.CountrySetByUser, which is what tells
 // source 3 that an EMPTY country is a decision ("prefer not to say") rather
 // than an absence to be helpfully filled in.
+//
+// Source 4 does NOT stamp it — see the provenance block below.
 //
 // PRIVACY. Country is personal data, so the inference is deliberately the
 // weakest thing that works:
@@ -50,6 +58,125 @@ import (
 // The stored form is the two-letter code; the flag glyph is derived at render
 // time from regional-indicator code points, so the hub never depends on an
 // external image host for a flag.
+
+// ── Provenance ───────────────────────────────────────────────────────────────
+//
+// WHO put the country on the record, which is what decides whether the next
+// writer is allowed to replace it. Stored in SaaSUser.CountrySource.
+//
+// The boolean CountrySetByUser could express only "the user chose this" vs
+// "nobody did", and that was sufficient while the only two writers were the
+// user and the inference. An ADMIN assignment is a third kind of claim that
+// sits between them — a best-effort attribution BY SOMEONE ELSE — and it has to
+// be recorded as such, because the two things we need from it pull in opposite
+// directions on a boolean:
+//
+//   - It must not read as user-chosen. CountrySetByUser is a statement about
+//     what the USER said; setting it for an admin edit fabricates consent, and
+//     it also permanently suppresses the "we don't know, ask them" state, so
+//     the user would never again be prompted for a value they never gave.
+//   - It must still beat inference, or the admin's work is silently undone at
+//     the user's next login from a differently-configured browser. That is the
+//     #4374 bug in a new costume: invisible, and discovered a login later.
+//
+// Hence a small ordered enum. The values are stable strings on disk, so they
+// are named constants and never spelled inline.
+const (
+	// countrySourceInferred — the login path's Accept-Language guess. Weakest:
+	// evidence about a browser's language, not about a person.
+	countrySourceInferred = "inferred"
+	// countrySourceAdmin — a hub admin assigned it on the user's behalf.
+	countrySourceAdmin = "admin"
+	// countrySourceUser — the user said so themselves (self-service endpoint or
+	// the get-started wizard pick). Authoritative; nothing overrides it but
+	// another statement from the same user.
+	countrySourceUser = "user"
+)
+
+// countryProvenanceRank maps a source to its strength. Higher wins.
+//
+// Ranks rather than a chain of if-statements at each call site, so "user beats
+// admin beats inference" is asserted in exactly one place and a future source
+// slots in by picking a number instead of by auditing every comparison.
+func countryProvenanceRank(source string) int {
+	switch source {
+	case countrySourceUser:
+		return 3
+	case countrySourceAdmin:
+		return 2
+	case countrySourceInferred:
+		return 1
+	default:
+		// Unset — nothing has ever claimed this record. Weakest of all, so any
+		// writer may fill it.
+		return 0
+	}
+}
+
+// effectiveCountrySource is the provenance of a record as it should be READ,
+// bridging the pre-CountrySource era.
+//
+// LOAD-BEARING FOR BACKWARD COMPATIBILITY. Every record written before this
+// field existed carries only CountrySetByUser, and nothing backfills them — a
+// migration sweep would rewrite thousands of files on the PVC to encode
+// something derivable for free, and would break the round-trip-byte-identical
+// property the whole SaaSUser struct is built around. So the boolean is read as
+// the legacy spelling of countrySourceUser, which is precisely what it always
+// meant: the user chose this (a pick, or a deliberate clear).
+//
+// A record with a country and neither marker is a login-path inference from
+// before the source field shipped, so it reads as inferred and stays
+// overwritable — which matches how applyInferredCountry has always treated it.
+// Nil-safe: callers sit on the login path.
+func effectiveCountrySource(user *SaaSUser) string {
+	if user == nil {
+		return ""
+	}
+	if user.CountrySource != "" {
+		return user.CountrySource
+	}
+	if user.CountrySetByUser {
+		return countrySourceUser
+	}
+	if user.Country != "" {
+		return countrySourceInferred
+	}
+	return ""
+}
+
+// mayOverwriteCountry reports whether a writer claiming `source` is allowed to
+// replace what is already on the record.
+//
+// Ties are allowed: a user may always correct their own earlier pick, and an
+// admin may always correct an earlier admin assignment. Only a STRICTLY
+// stronger existing claim blocks the write — which is the whole precedence rule
+// (user > admin > inferred > unset) in one line.
+func mayOverwriteCountry(user *SaaSUser, source string) bool {
+	return countryProvenanceRank(source) >= countryProvenanceRank(effectiveCountrySource(user))
+}
+
+// setUserCountry is the ONE place a country and its provenance are written
+// together, so the two can never drift apart — a country stored without its
+// source, or a source stamped without the matching CountrySetByUser, is exactly
+// the state the precedence rules cannot reason about.
+//
+// It also keeps the legacy boolean honest: CountrySetByUser tracks
+// "source == user" in BOTH directions. Setting it for a user write keeps every
+// existing reader of that field correct; CLEARING it when an admin overwrites a
+// user's value is equally load-bearing, since leaving it true would leave a
+// record claiming the user chose a value an admin typed.
+//
+// `code` is stored as given and must already be normalized by the caller (each
+// one validates and reports its own 400), so this cannot become a second,
+// divergent validator.
+func setUserCountry(user *SaaSUser, code, source string) {
+	if user == nil {
+		return
+	}
+	user.Country = code
+	user.CountrySource = source
+	user.CountrySetByUser = source == countrySourceUser
+}
 
 // countryCodeLen is the length of an ISO 3166-1 alpha-2 code. Named because it
 // is load-bearing in three places (validation, the emoji derivation, and the
@@ -177,24 +304,32 @@ func inferCountryFromRequest(r *http.Request) string {
 // it — otherwise a user's stated country would silently flip when they travel
 // or borrow a laptop, which is both wrong and invisible.
 //
-// The CountrySetByUser half of the guard covers the case `Country != ""` alone
+// The provenance half of the guard covers the case `Country != ""` alone
 // cannot: an explicit CLEAR. A user who deliberately removes their country
 // leaves an empty field that is indistinguishable, by value, from "never asked"
-// — so without the marker the next login would quietly put a flag back and
+// — so without a marker the next login would quietly put a flag back and
 // "prefer not to say" would be unexpressible. Absence of a value is not the
 // same as absence of a decision.
+//
+// The guard is expressed through mayOverwriteCountry rather than by reading
+// CountrySetByUser directly, which is what extends it to the ADMIN case: an
+// admin-assigned country is empty-or-not just like a user's, and must survive
+// this pass for the same reason. It STACKS with the `Country != ""` test rather
+// than replacing it: a record that already carries a value is left alone
+// whatever its provenance, so an earlier inference is never re-guessed on a
+// later login from a differently-configured browser.
 //
 // Returns whether it changed the record, so the caller can tell a real update
 // from a no-op. Nil-safe: it sits on the login path beside other enrichment.
 func applyInferredCountry(user *SaaSUser, r *http.Request) bool {
-	if user == nil || user.Country != "" || user.CountrySetByUser {
+	if user == nil || user.Country != "" || !mayOverwriteCountry(user, countrySourceInferred) {
 		return false
 	}
 	code := inferCountryFromRequest(r)
 	if code == "" {
 		return false
 	}
-	user.Country = code
+	setUserCountry(user, code, countrySourceInferred)
 	return true
 }
 
@@ -298,11 +433,17 @@ func (s *HubServer) handleMyCountry(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	user.Country = code
-	// Both a pick and a clear are deliberate, so BOTH set the marker. Setting
-	// it on the clear is the load-bearing half: it is what stops the next
-	// login's Accept-Language inference from undoing the removal.
-	user.CountrySetByUser = true
+	// Both a pick and a clear are deliberate, so BOTH stamp countrySourceUser
+	// (and, through setUserCountry, the legacy CountrySetByUser). Stamping it on
+	// the clear is the load-bearing half: it is what stops the next login's
+	// Accept-Language inference from undoing the removal.
+	//
+	// The user's own statement is the strongest source there is, so this write
+	// is unconditional — it overrides an admin's assignment as well as an
+	// inference. An admin attributing a country on someone's behalf is a
+	// best-effort guess about that person; the person themselves is not
+	// guessing, and must always be able to correct the record about themselves.
+	setUserCountry(user, code, countrySourceUser)
 	if err := saveSaaSUser(user); err != nil {
 		s.logger.Warn("handleMyCountry: save failed", "user", username, "error", err)
 		writeJSONError(w, http.StatusInternalServerError, "could not save country")

--- a/src/pkg/hub/user_country_admin_assign_test.go
+++ b/src/pkg/hub/user_country_admin_assign_test.go
@@ -1,0 +1,517 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Admin-assigned country: a hub admin setting the country for ANOTHER user from
+// the admin Users table, through the existing handleAdminUpdateUser edit path.
+//
+// The whole weight of this suite is on PROVENANCE, because the value is easy to
+// store and easy to store WRONG. An admin edit is a best-effort attribution by
+// someone else, so it has to land in a state that is simultaneously:
+//
+//   - not user-chosen (stamping CountrySetByUser would fabricate a statement by
+//     the user and permanently suppress ever asking them for a real one), and
+//   - stronger than Accept-Language inference (or it is silently reverted at the
+//     user's next login — the #4374 bug wearing a different hat, and invisible
+//     in exactly the same way).
+//
+// Precedence under test, strongest first: user > admin > inferred > unset.
+//
+// Every assertion that something did NOT happen carries a positive control, so
+// none of these can pass because the machinery under them stopped running.
+
+// adminAssignHub builds a hub with temp dirs and an admin record on disk.
+// requireAdmin resolves the cookie through loadSaaSUser, so the admin needs a
+// real record for an authenticated admin request to be possible at all.
+func adminAssignHub(t *testing.T) *HubServer {
+	t.Helper()
+	cleanup := helperSetupTempDirs(t)
+	t.Cleanup(cleanup)
+	ensureSaaSUser(hubAdminUsername)
+	return NewHubServer(0, slog.Default(), "test", "v2")
+}
+
+// adminPut issues the admin edit through the REAL requireAdmin wrapper and the
+// real route pattern, so authorization and path-value extraction are exercised
+// rather than stubbed.
+func adminPut(srv *HubServer, target, body, asUser string) *httptest.ResponseRecorder {
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/saas/admin/users/{username}", srv.requireAdmin(srv.handleAdminUpdateUser))
+	req := httptest.NewRequest(http.MethodPut, "/api/saas/admin/users/"+target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// AUDIT F4: mutations fail closed without Origin/Referer. Same-origin here so
+	// the request reaches the handler and the test asserts about country, not
+	// about CSRF (which csrf_f4_fail_closed_test.go owns).
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	if asUser != "" {
+		req.AddCookie(testAuthCookie(asUser))
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// inferenceLogin is a request whose Accept-Language would infer FR — the
+// "user signs in from a differently-configured browser" event that must not be
+// allowed to undo an admin's assignment.
+func inferenceLogin() *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Accept-Language", "fr-FR,fr;q=0.9")
+	return r
+}
+
+// TestAdminAssignsCountryDoesNotClaimUserChoice is the core provenance
+// assertion: the value persists, and the record does NOT claim the user picked
+// it.
+//
+// CountrySetByUser is the field that says "this person told us". An admin
+// filling in a country from a conference badge has not made the user say
+// anything, and that marker is also what suppresses ever asking — so setting it
+// here would both fabricate consent and permanently silence the question.
+func TestAdminAssignsCountryDoesNotClaimUserChoice(t *testing.T) {
+	s := adminAssignHub(t)
+	mkUser(t, "ada")
+
+	if rec := adminPut(s, "ada", `{"country":"gb"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	u := loadSaaSUser("ada")
+	if u == nil {
+		t.Fatal("user disappeared")
+	}
+	// Normalized on the way in, like every other country path: alpha-2 is
+	// case-insensitive inbound, canonical on disk.
+	if u.Country != "GB" {
+		t.Errorf("Country = %q, want GB", u.Country)
+	}
+	if u.CountrySource != countrySourceAdmin {
+		t.Errorf("CountrySource = %q, want %q — an admin edit must record WHO set it",
+			u.CountrySource, countrySourceAdmin)
+	}
+	if u.CountrySetByUser {
+		t.Error("CountrySetByUser = true after an ADMIN edit — this asserts the user made a choice they never made, and permanently suppresses ever asking them")
+	}
+
+	// POSITIVE CONTROL: the same field on the same handler DOES record a user
+	// choice when the user is the one writing, so the assertion above is about
+	// provenance and not about the marker having quietly stopped working.
+	if rec := putCountry(s, "ada", `{"country":"JP"}`); rec.Code != http.StatusOK {
+		t.Fatalf("positive control: self-service status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if ctl := loadSaaSUser("ada"); ctl == nil || !ctl.CountrySetByUser || ctl.CountrySource != countrySourceUser {
+		t.Fatalf("positive control: self-service write did not mark the record user-chosen (%+v) — the assertion above proves nothing", ctl)
+	}
+}
+
+// TestAdminAssignedCountrySurvivesInference is the regression this feature is
+// most likely to lose: #4374 in its new form.
+//
+// An admin assignment that inference may overwrite is worse than no feature at
+// all — the admin sees it save, and it is quietly reverted a login later, far
+// from anything they can connect it to.
+func TestAdminAssignedCountrySurvivesInference(t *testing.T) {
+	s := adminAssignHub(t)
+	mkUser(t, "ada")
+
+	if rec := adminPut(s, "ada", `{"country":"GB"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("assign: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	login := inferenceLogin()
+
+	u := loadSaaSUser("ada")
+	if changed := applyInferredCountry(u, login); changed {
+		t.Error("inference reported a change to an ADMIN-assigned country")
+	}
+	if u.Country != "GB" {
+		t.Errorf("Country = %q after an inference pass, want GB — an admin assignment must outrank Accept-Language", u.Country)
+	}
+
+	// An admin's explicit CLEAR is a decision too, and it is the half that has
+	// no value to protect it: an empty country is byte-identical to "never
+	// asked", so only the recorded source keeps inference from refilling it.
+	if rec := adminPut(s, "ada", `{"country":""}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	u2 := loadSaaSUser("ada")
+	if u2 == nil {
+		t.Fatal("user disappeared")
+	}
+	if u2.Country != "" {
+		t.Errorf("Country = %q after an admin clear, want empty", u2.Country)
+	}
+	if changed := applyInferredCountry(u2, login); changed || u2.Country != "" {
+		t.Errorf("inference refilled a country an admin had explicitly cleared (changed=%v country=%q)", changed, u2.Country)
+	}
+
+	// POSITIVE CONTROL: the same header and the same helper against a record
+	// nobody has claimed DOES fill in. Without this, both assertions above
+	// would also pass if inference had simply stopped working.
+	fresh := &SaaSUser{GitHubUsername: "fresh", Hives: map[string]string{}}
+	if changed := applyInferredCountry(fresh, login); !changed || fresh.Country != "FR" {
+		t.Fatalf("positive control: inference did not fill an untouched record (changed=%v country=%q) — the assertions above prove nothing",
+			changed, fresh.Country)
+	}
+}
+
+// TestUserOverridesAdminAssignedCountry: the user is the authority on where the
+// user is. An admin's attribution is a guess made on their behalf, and the
+// person themselves must always be able to correct the record about themselves
+// — otherwise a wrong guess is permanent and unappealable.
+func TestUserOverridesAdminAssignedCountry(t *testing.T) {
+	s := adminAssignHub(t)
+	mkUser(t, "ada")
+
+	if rec := adminPut(s, "ada", `{"country":"GB"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("admin assign: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := putCountry(s, "ada", `{"country":"JP"}`); rec.Code != http.StatusOK {
+		t.Fatalf("self-service: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	u := loadSaaSUser("ada")
+	if u == nil {
+		t.Fatal("user disappeared")
+	}
+	if u.Country != "JP" {
+		t.Errorf("Country = %q, want JP — the user must be able to correct an admin's attribution", u.Country)
+	}
+	if u.CountrySource != countrySourceUser || !u.CountrySetByUser {
+		t.Errorf("after a self-service write: CountrySource = %q CountrySetByUser = %v, want %q/true",
+			u.CountrySource, u.CountrySetByUser, countrySourceUser)
+	}
+
+	// And the reverse direction: the admin may NOT then step back on top of a
+	// value the user stated about themselves. The request is not an error — the
+	// rest of a multi-field edit still lands — but the country is left alone.
+	rec := adminPut(s, "ada", `{"country":"DE","full_name":"Ada Lovelace"}`, hubAdminUsername)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin re-edit: status = %d body=%s, want 200 (declining the country is not a request failure)", rec.Code, rec.Body.String())
+	}
+	after := loadSaaSUser("ada")
+	if after == nil {
+		t.Fatal("user disappeared")
+	}
+	if after.Country != "JP" {
+		t.Errorf("Country = %q after an admin re-edit, want JP — a user-chosen country outranks an admin assignment", after.Country)
+	}
+	if after.CountrySetByUser != true || after.CountrySource != countrySourceUser {
+		t.Errorf("declined admin edit corrupted provenance: source=%q setByUser=%v", after.CountrySource, after.CountrySetByUser)
+	}
+	// POSITIVE CONTROL: the SAME request did apply its other field, so the
+	// country was declined specifically — not the whole edit silently dropped.
+	if after.FullName != "Ada Lovelace" {
+		t.Fatalf("positive control: full_name = %q, want %q — the request did not reach the handler at all, so the country assertion proves nothing",
+			after.FullName, "Ada Lovelace")
+	}
+}
+
+// TestLegacyCountrySetByUserStillBeatsAdminAndInference covers every record
+// already on the PVC. They carry ONLY CountrySetByUser — nothing backfills a
+// CountrySource, because rewriting thousands of files to encode something
+// derivable for free would also break the round-trip-byte-identical property.
+//
+// So the boolean must keep reading as exactly what it always meant: the user
+// chose this. If effectiveCountrySource ever stops bridging it, the failure is
+// silent and fleet-wide — every pre-existing explicit choice quietly demotes to
+// "inferred" and becomes overwritable.
+func TestLegacyCountrySetByUserStillBeatsAdminAndInference(t *testing.T) {
+	s := adminAssignHub(t)
+
+	// A record as it exists on disk today: the boolean, no source field.
+	legacy := &SaaSUser{
+		GitHubUsername:   "ada",
+		Hives:            map[string]string{},
+		Country:          "GB",
+		CountrySetByUser: true,
+	}
+	if err := saveSaaSUser(legacy); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+
+	if got := effectiveCountrySource(legacy); got != countrySourceUser {
+		t.Errorf("effectiveCountrySource(legacy) = %q, want %q — a pre-CountrySource record must still read as user-chosen",
+			got, countrySourceUser)
+	}
+
+	// Inference must not touch it.
+	if changed := applyInferredCountry(legacy, inferenceLogin()); changed || legacy.Country != "GB" {
+		t.Errorf("inference overwrote a legacy explicit choice (changed=%v country=%q)", changed, legacy.Country)
+	}
+
+	// Nor may an admin.
+	if rec := adminPut(s, "ada", `{"country":"DE"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("admin edit: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if after := loadSaaSUser("ada"); after == nil || after.Country != "GB" {
+		t.Errorf("admin overwrote a legacy explicit choice: %+v", after)
+	}
+
+	// The legacy CLEAR shape too: CountrySetByUser with an EMPTY country is
+	// "prefer not to say", and is the case a value check alone cannot see.
+	legacyCleared := &SaaSUser{GitHubUsername: "grace", Hives: map[string]string{}, CountrySetByUser: true}
+	if changed := applyInferredCountry(legacyCleared, inferenceLogin()); changed || legacyCleared.Country != "" {
+		t.Errorf("inference refilled a legacy explicit clear (changed=%v country=%q)", changed, legacyCleared.Country)
+	}
+
+	// POSITIVE CONTROL: strip the boolean and the very same record IS writable
+	// by both, so the assertions above are about the legacy bridge and not
+	// about admin/inference having stopped working entirely.
+	ctl := &SaaSUser{GitHubUsername: "ctl", Hives: map[string]string{}}
+	if changed := applyInferredCountry(ctl, inferenceLogin()); !changed || ctl.Country != "FR" {
+		t.Fatalf("positive control: inference did not fill an unmarked record (changed=%v country=%q)", changed, ctl.Country)
+	}
+	mkUser(t, "unmarked")
+	if rec := adminPut(s, "unmarked", `{"country":"DE"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("positive control: admin edit status = %d", rec.Code)
+	}
+	if after := loadSaaSUser("unmarked"); after == nil || after.Country != "DE" {
+		t.Fatalf("positive control: admin could not set a country on an unmarked record (%+v) — the assertions above prove nothing", after)
+	}
+}
+
+// TestAdminCountryValidation: an unusable code is refused with 400 and the
+// stored value is UNCHANGED. A handler that 400s but has already mutated the
+// record is the worst of both — the admin is told it failed and it did not.
+func TestAdminCountryValidation(t *testing.T) {
+	s := adminAssignHub(t)
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"three letters", `{"country":"GBR"}`},
+		{"one letter", `{"country":"G"}`},
+		{"digits", `{"country":"12"}`},
+		{"punctuation", `{"country":"G-"}`},
+		{"markup", `{"country":"<b"}`},
+		{"non-ascii", `{"country":"Ω1"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A fresh record per case, pre-seeded by an admin assignment, so
+			// "unchanged" means something.
+			mkUser(t, "ada")
+			if rec := adminPut(s, "ada", `{"country":"GB"}`, hubAdminUsername); rec.Code != http.StatusOK {
+				t.Fatalf("seed: status = %d", rec.Code)
+			}
+			rec := adminPut(s, "ada", tc.body, hubAdminUsername)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d body=%s, want 400", rec.Code, rec.Body.String())
+			}
+			if u := loadSaaSUser("ada"); u == nil || u.Country != "GB" {
+				t.Errorf("stored country changed on a rejected edit: %+v", u)
+			}
+		})
+	}
+
+	// An explicit clear is NOT an invalid code — it is a legitimate value, and
+	// the one an admin needs when they learn their guess was wrong.
+	mkUser(t, "grace")
+	if rec := adminPut(s, "grace", `{"country":"GB"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("seed: status = %d", rec.Code)
+	}
+	if rec := adminPut(s, "grace", `{"country":"  "}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d body=%s, want 200 — whitespace is a clear, not a bad code", rec.Code, rec.Body.String())
+	}
+	if u := loadSaaSUser("grace"); u == nil || u.Country != "" {
+		t.Errorf("explicit clear did not remove the country: %+v", u)
+	}
+}
+
+// TestAdminCountryKeyAbsentLeavesCountryAlone: the pointer distinction. An edit
+// to some OTHER field must not wipe a country as a side effect — the admin
+// panel saves fields one at a time, so a plain string here would mean every
+// quota change silently cleared the country.
+func TestAdminCountryKeyAbsentLeavesCountryAlone(t *testing.T) {
+	s := adminAssignHub(t)
+	mkUser(t, "ada")
+
+	if rec := adminPut(s, "ada", `{"country":"GB"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("seed: status = %d", rec.Code)
+	}
+	if rec := adminPut(s, "ada", `{"saas_quota":5}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("quota edit: status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	u := loadSaaSUser("ada")
+	if u == nil || u.Country != "GB" {
+		t.Errorf("an edit that never mentioned country changed it: %+v", u)
+	}
+	// POSITIVE CONTROL: that request did land, so the assertion is about the
+	// absent key and not about the edit having been dropped.
+	if u.SaaSQuota != 5 {
+		t.Fatalf("positive control: SaaSQuota = %d, want 5 — the request did not apply", u.SaaSQuota)
+	}
+}
+
+// TestNonAdminCannotSetAnotherUsersCountry is the privilege boundary. The
+// self-service endpoint deliberately gives every user a country write; this
+// asserts that write cannot be aimed at somebody else through the admin route.
+func TestNonAdminCannotSetAnotherUsersCountry(t *testing.T) {
+	s := adminAssignHub(t)
+	mkUser(t, "ada")
+	mkUser(t, "mallory")
+
+	for _, tc := range []struct {
+		name   string
+		asUser string
+	}{
+		{"anonymous", ""},
+		{"non-admin", "mallory"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := adminPut(s, "ada", `{"country":"DE"}`, tc.asUser)
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("status = %d body=%s, want 403", rec.Code, rec.Body.String())
+			}
+			if u := loadSaaSUser("ada"); u == nil || u.Country != "" {
+				t.Errorf("a rejected caller still wrote a country: %+v", u)
+			}
+		})
+	}
+
+	// POSITIVE CONTROL: the identical request from the real admin succeeds, so
+	// the 403s above are authorization and not a handler that refuses everyone.
+	if rec := adminPut(s, "ada", `{"country":"DE"}`, hubAdminUsername); rec.Code != http.StatusOK {
+		t.Fatalf("positive control: admin status = %d body=%s — the 403s prove nothing", rec.Code, rec.Body.String())
+	}
+	if u := loadSaaSUser("ada"); u == nil || u.Country != "DE" {
+		t.Fatalf("positive control: admin write did not land (%+v)", u)
+	}
+}
+
+// TestUntouchedUserJSONRoundTripsByteIdentical is the compatibility guard for
+// every record already on the PVC.
+//
+// CountrySource is new, so it MUST be omitempty: without it every one of the
+// thousands of existing user files would grow a `"country_source":""` key the
+// first time anything loaded and saved it — a fleet-wide rewrite to store
+// nothing. The same property is why CountrySetByUser is omitempty and why
+// nothing backfills either field.
+func TestUntouchedUserJSONRoundTripsByteIdentical(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// A record in the shape production writes today: no country of any kind.
+	original := &SaaSUser{GitHubUsername: "ada", Hives: map[string]string{"h1": "owner"}}
+	before, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, key := range []string{"country", "country_source", "country_set_by_user"} {
+		if strings.Contains(string(before), key) {
+			t.Errorf("untouched user JSON contains %q — the field is not omitempty and every existing record would be rewritten to store nothing: %s",
+				key, before)
+		}
+	}
+
+	// Through the real save/load path, not just the encoder.
+	if err := saveSaaSUser(original); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	loaded := loadSaaSUser("ada")
+	if loaded == nil {
+		t.Fatal("user disappeared")
+	}
+	after, err := json.Marshal(loaded)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("round-trip changed the record:\n before=%s\n  after=%s", before, after)
+	}
+
+	// POSITIVE CONTROL: the keys DO appear once something actually sets them,
+	// so the absence above is omitempty working and not the fields having been
+	// dropped from the struct.
+	set := &SaaSUser{GitHubUsername: "grace", Hives: map[string]string{}}
+	setUserCountry(set, "GB", countrySourceUser)
+	blob, err := json.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, key := range []string{`"country":"GB"`, `"country_source":"user"`, `"country_set_by_user":true`} {
+		if !strings.Contains(string(blob), key) {
+			t.Fatalf("positive control: a populated record is missing %s (%s) — the absence assertions prove nothing", key, blob)
+		}
+	}
+}
+
+// TestCountryProvenancePrecedenceTable states the ordering directly, so the
+// rule is readable in one place rather than only as an emergent property of the
+// handlers above. user > admin > inferred > unset, with ties allowed (a writer
+// may always correct its own earlier claim).
+func TestCountryProvenancePrecedenceTable(t *testing.T) {
+	for _, tc := range []struct {
+		existing string
+		writer   string
+		want     bool
+	}{
+		{"", countrySourceInferred, true},
+		{"", countrySourceAdmin, true},
+		{"", countrySourceUser, true},
+		{countrySourceInferred, countrySourceInferred, true},
+		{countrySourceInferred, countrySourceAdmin, true},
+		{countrySourceInferred, countrySourceUser, true},
+		{countrySourceAdmin, countrySourceInferred, false},
+		{countrySourceAdmin, countrySourceAdmin, true},
+		{countrySourceAdmin, countrySourceUser, true},
+		{countrySourceUser, countrySourceInferred, false},
+		{countrySourceUser, countrySourceAdmin, false},
+		{countrySourceUser, countrySourceUser, true},
+	} {
+		u := &SaaSUser{GitHubUsername: "ada", Country: "GB", CountrySource: tc.existing}
+		if got := mayOverwriteCountry(u, tc.writer); got != tc.want {
+			t.Errorf("mayOverwriteCountry(existing=%q, writer=%q) = %v, want %v",
+				tc.existing, tc.writer, got, tc.want)
+		}
+	}
+}
+
+// TestAdminUsersTableCountryEditorRendered: the control has to be REACHABLE.
+// A handler with no way to call it is the same as no feature, and this is a raw
+// string the compiler never looks at — a typo here is invisible until someone
+// opens the panel and finds nothing there.
+func TestAdminUsersTableCountryEditorRendered(t *testing.T) {
+	html := dashboardHTML
+
+	for _, snippet := range []string{
+		// The input, inside the existing contact editor panel, keyed the same
+		// way full_name / slack_id are so it rides the same save path.
+		`data-contact-field="country"`,
+		// The live preview that turns two letters into a flag and a name.
+		"function countryPreviewHTML(",
+		"function refreshContactCountryPreview(",
+		"function contactCountryPreviewId(",
+		// Built on #4371's helpers, not a second derivation of what a country
+		// looks like.
+		"countryFlagEmoji(c)",
+		"countryDisplayName(c)",
+		// Theme tokens only — the hub dashboard is single-theme, so a hardcoded
+		// color here is a bug, not a shortcut.
+		"color:var(--muted)",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("dashboardHTML is missing %q — the admin country editor is not wired", snippet)
+		}
+	}
+
+	// PRIVACY: country rides the JSON body and never a URL. A query parameter or
+	// a path segment would put personal data into access logs, Referer headers
+	// and browser history. Mirrors the same assertion #4371/#4374 make.
+	for _, banned := range []string{
+		"country=",
+		"?country",
+		"users/' + encodeURIComponent(username) + '/country",
+	} {
+		if strings.Contains(html, banned) {
+			t.Errorf("dashboardHTML contains %q — country must ride the JSON body, never a URL", banned)
+		}
+	}
+}


### PR DESCRIPTION
## The gap

Every user who signed up before the country field existed has no country and **no route to one**. The get-started wizard (#4371) is a one-time gate already behind them, and `/api/saas/me/country` (#4374) reaches only the acting user. An admin looking at an empty Country column (#4373) had no control at all.

## What this adds

Extends the **existing** admin edit path rather than inventing an endpoint. `country` joins `saas_quota` / `blocked` / `full_name` / `slack_id` / `notes` as a pointer field on `handleAdminUpdateUser`:

- validated by #4371's `normalizeCountryCode` — anything else is a 400, and the stored value is unchanged
- `""` is an explicit **clear**; an absent key leaves the country alone (which is why it is a pointer — otherwise every quota edit would silently wipe a country)
- `requireAdmin`-gated, consistent with the rest of the handler
- **JSON body only**, never a path or query string: country is personal data and a URL lands in access logs, Referer headers and browser history

The control lands in the contact-editor panel in the admin Users table, alongside Full name / Slack ID / Notes, with a live flag + English-name preview so two letters are legible as you type. It reuses `countryFlagEmoji` / `countryDisplayName` rather than duplicating them, and reuses the panel's existing blur-save path — no new save machinery.

## The design decision: provenance

`CountrySetByUser` means *the user chose this*. An admin assignment is a **best-effort attribution by someone else**, and it has to satisfy two things a boolean cannot express at once:

- It must **not** read as user-chosen. Stamping the marker would assert a statement the user never made — and since that marker is also what suppresses the "we don't know, ask them" state, it would permanently silence the question for them.
- It must **still beat `Accept-Language` inference**, or the assignment is silently reverted at the user's next login from a differently-configured browser. That is the #4374 bug in a new costume, and invisible in exactly the same way.

So `SaaSUser` gains **`CountrySource`** — `inferred` | `admin` | `user` — with precedence **user > admin > inferred > unset**, arbitrated in one place (`countryProvenanceRank` / `mayOverwriteCountry`) and written in one place (`setUserCountry`, which keeps country and source from ever drifting apart). `applyInferredCountry` now asks `mayOverwriteCountry` instead of reading the boolean directly, which is what extends its guard to the admin case.

An admin edit that would step on a **user-chosen** value is declined without failing the request: the rest of a multi-field save still lands and the response is still 200. A 409 would fail an otherwise-valid edit over a field the admin may not even have meant to touch.

## Backward compatibility

Nothing backfills, and nothing needs to:

- `effectiveCountrySource` reads a bare `CountrySetByUser=true` with no source as the legacy spelling of `user` — which is exactly what it always meant, for a pick *and* for a deliberate clear
- `CountrySetByUser` keeps tracking `source == user` in **both** directions, so every existing reader stays correct — including clearing it when a user's value is replaced, so no record is left claiming a choice the user did not make
- `CountrySource` is `omitempty`, so an untouched record still round-trips **byte-identical** — a migration sweep would rewrite thousands of PVC files to encode something derivable for free

## Tests

Each with a positive control, so none can pass for the wrong reason:

- admin sets a country → persisted, `CountrySetByUser` **not** set (control: the self-service write on the same record *does* set it)
- **admin-assigned value survives an `Accept-Language` inference pass** — value and explicit clear (control: the same header fills an unclaimed record)
- user self-service overrides an admin value, and the admin cannot then step back on top (control: the declined request's `full_name` still applied, so the country was declined specifically)
- legacy `CountrySetByUser=true` with no `CountrySource` still behaves as user-chosen against both inference and admin (control: strip the boolean and both writers succeed)
- invalid codes → 400 with the stored value unchanged; whitespace/empty is a legitimate clear
- an edit that never mentions country does not change it (control: the quota in the same request did apply)
- non-admin and anonymous cannot set another user's country (control: the identical admin request succeeds)
- the precedence table, stated directly
- untouched user JSON round-trips byte-identical (control: the keys appear once something sets them)
- the panel control is actually rendered, built on the existing helpers, theme tokens only, and `country` never appears in a URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)