### PR TITLE
✨ Hub scale Phase 1: fleet-scale efficiency, capacity gates, paginated My Hives

### DIFF
--- a/src/pkg/hub/hive_capacity.go
+++ b/src/pkg/hub/hive_capacity.go
@@ -1,5 +1,9 @@
 package hub
 
+// capacityHeadroomWarnPct is the remaining-slots percentage below which the
+// hub logs a low-headroom warning for a cluster (see buildSingleClusterHealth).
+const capacityHeadroomWarnPct = 10
+
 // Per-hive scheduling footprint used for "room for ~N more hives" capacity
 // estimates on the Cluster Health section. These are derived at package init
 // from the provisioning template's resources.requests (cpuRequest and
@@ -39,4 +43,36 @@ func hiveSlotsForNode(cpuAllocatableMillis, memAllocatableBytes, cpuRequestedMil
 		return memSlots
 	}
 	return cpuSlots
+}
+
+// clusterHiveCount counts the hosted-hive records (assigned AND pooled
+// placeholders — both consume a namespace, PVC and route) that live on the
+// given cluster. SaaS records are the authoritative source: every
+// hub-provisioned hive has one, stamped with its ClusterID at provision time.
+// Records with an empty ClusterID predate multi-cluster and are counted
+// against the default cluster, matching how every kubectl path routes them.
+func clusterHiveCount(clusterID string) int {
+	n := 0
+	for _, h := range listSaaSHives() {
+		cid := h.ClusterID
+		if cid == "" {
+			cid = defaultClusterID
+		}
+		if cid == clusterID {
+			n++
+		}
+	}
+	return n
+}
+
+// clusterAtMaxHives reports whether the cluster has reached its configured
+// max_hives ceiling (0 = unlimited), returning the current count for the
+// error message / log line. This is the hard per-cluster provisioning gate;
+// callers must check it before creating a new SaaS record on the cluster.
+func clusterAtMaxHives(cluster *ClusterConfig) (bool, int) {
+	if cluster == nil || cluster.MaxHives <= 0 {
+		return false, 0
+	}
+	n := clusterHiveCount(cluster.ID)
+	return n >= cluster.MaxHives, n
 }

--- a/src/pkg/hub/hive_capacity_gate_test.go
+++ b/src/pkg/hub/hive_capacity_gate_test.go
@@ -1,0 +1,54 @@
+package hub
+
+import "testing"
+
+// TestClusterAtMaxHives covers the per-cluster provisioning ceiling: counting
+// by ClusterID (with the empty-ID → default-cluster fallback) and the
+// unlimited-when-zero contract.
+func TestClusterAtMaxHives(t *testing.T) {
+	dir := t.TempDir()
+	origDir := saasHivesDir
+	saasHivesDir = dir
+	t.Cleanup(func() { saasHivesDir = origDir })
+
+	// Two hives on cluster-a, one legacy record with no ClusterID (counts
+	// against the default cluster), one on cluster-b.
+	for _, h := range []*SaaSHive{
+		{ID: "a1", ClusterID: "cluster-a", Status: statusAvailable},
+		{ID: "a2", ClusterID: "cluster-a", Status: statusAssigned},
+		{ID: "legacy", Status: statusAssigned},
+		{ID: "b1", ClusterID: "cluster-b", Status: statusAvailable},
+	} {
+		if err := saveSaaSHive(h); err != nil {
+			t.Fatalf("save %s: %v", h.ID, err)
+		}
+	}
+
+	if n := clusterHiveCount("cluster-a"); n != 2 {
+		t.Errorf("clusterHiveCount(cluster-a) = %d, want 2", n)
+	}
+	if n := clusterHiveCount(defaultClusterID); n != 1 {
+		t.Errorf("clusterHiveCount(default) = %d, want 1 (legacy empty ClusterID)", n)
+	}
+
+	cases := []struct {
+		name     string
+		cluster  *ClusterConfig
+		wantFull bool
+	}{
+		{"zero max is unlimited", &ClusterConfig{ID: "cluster-a", MaxHives: 0}, false},
+		{"below the ceiling", &ClusterConfig{ID: "cluster-a", MaxHives: 3}, false},
+		{"at the ceiling", &ClusterConfig{ID: "cluster-a", MaxHives: 2}, true},
+		{"over the ceiling", &ClusterConfig{ID: "cluster-a", MaxHives: 1}, true},
+		{"nil cluster never gates", nil, false},
+		{"other cluster counts separately", &ClusterConfig{ID: "cluster-b", MaxHives: 2}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			full, _ := clusterAtMaxHives(tc.cluster)
+			if full != tc.wantFull {
+				t.Errorf("clusterAtMaxHives = %v, want %v", full, tc.wantFull)
+			}
+		})
+	}
+}

--- a/src/pkg/hub/kubectl_executor.go
+++ b/src/pkg/hub/kubectl_executor.go
@@ -1,0 +1,87 @@
+package hub
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+)
+
+// Bounded kubectl execution.
+//
+// Every hub → cluster interaction shells out to kubectl. At fleet scale the
+// unbounded fan-out (health collection, reconcilers, provisioning, upgrade
+// sweeps all spawning subprocesses concurrently) can exhaust hub pod CPU,
+// file descriptors and the target API server's client budget. This executor
+// caps concurrent kubectl processes PER CLUSTER with a semaphore acquired at
+// execution time (Output/CombinedOutput/Run), so command CONSTRUCTION stays
+// cheap and call sites are unchanged.
+
+// defaultKubectlMaxPerCluster is the per-cluster concurrent kubectl process
+// cap when HIVE_KUBECTL_MAX_PER_CLUSTER is unset or invalid.
+const defaultKubectlMaxPerCluster = 8
+
+var (
+	kubectlSlotCapOnce sync.Once
+	kubectlSlotCap     int
+
+	kubectlSlotsMu sync.Mutex
+	kubectlSlots   = map[string]chan struct{}{}
+)
+
+// kubectlMaxPerCluster returns the per-cluster concurrency cap, overridable
+// via HIVE_KUBECTL_MAX_PER_CLUSTER (values < 1 fall back to the default).
+func kubectlMaxPerCluster() int {
+	kubectlSlotCapOnce.Do(func() {
+		kubectlSlotCap = defaultKubectlMaxPerCluster
+		if v := os.Getenv("HIVE_KUBECTL_MAX_PER_CLUSTER"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+				kubectlSlotCap = n
+			}
+		}
+	})
+	return kubectlSlotCap
+}
+
+// acquireKubectlSlot blocks until a per-cluster execution slot is free and
+// returns its release func. Blocking is acceptable: callers already block on
+// the subprocess itself, and slots are always released on command completion.
+func acquireKubectlSlot(clusterID string) (release func()) {
+	kubectlSlotsMu.Lock()
+	sem, ok := kubectlSlots[clusterID]
+	if !ok {
+		sem = make(chan struct{}, kubectlMaxPerCluster())
+		kubectlSlots[clusterID] = sem
+	}
+	kubectlSlotsMu.Unlock()
+	sem <- struct{}{}
+	return func() { <-sem }
+}
+
+// kubectlCmd wraps exec.Cmd so that the blocking execution methods acquire a
+// per-cluster slot first. Field access (Args, Stdin, Env, ...) is promoted
+// from the embedded Cmd, so existing call sites work unchanged. Callers must
+// use Output/CombinedOutput/Run — Start/Wait on the embedded Cmd would bypass
+// the bound.
+type kubectlCmd struct {
+	*exec.Cmd
+	clusterID string
+}
+
+func (c *kubectlCmd) Output() ([]byte, error) {
+	release := acquireKubectlSlot(c.clusterID)
+	defer release()
+	return c.Cmd.Output()
+}
+
+func (c *kubectlCmd) CombinedOutput() ([]byte, error) {
+	release := acquireKubectlSlot(c.clusterID)
+	defer release()
+	return c.Cmd.CombinedOutput()
+}
+
+func (c *kubectlCmd) Run() error {
+	release := acquireKubectlSlot(c.clusterID)
+	defer release()
+	return c.Cmd.Run()
+}

--- a/src/pkg/hub/kubectl_executor_test.go
+++ b/src/pkg/hub/kubectl_executor_test.go
@@ -1,0 +1,62 @@
+package hub
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestAcquireKubectlSlotBoundsConcurrency verifies the per-cluster semaphore
+// never admits more than the configured cap simultaneously and that separate
+// clusters get independent pools.
+func TestAcquireKubectlSlotBoundsConcurrency(t *testing.T) {
+	cap := kubectlMaxPerCluster()
+	if cap < 1 {
+		t.Fatalf("kubectlMaxPerCluster() = %d, want >= 1", cap)
+	}
+
+	var inFlight, peak int64
+	var wg sync.WaitGroup
+	for i := 0; i < cap*4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release := acquireKubectlSlot("test-cluster-bound")
+			defer release()
+			n := atomic.AddInt64(&inFlight, 1)
+			for {
+				p := atomic.LoadInt64(&peak)
+				if n <= p || atomic.CompareAndSwapInt64(&peak, p, n) {
+					break
+				}
+			}
+			atomic.AddInt64(&inFlight, -1)
+		}()
+	}
+	wg.Wait()
+	if peak > int64(cap) {
+		t.Errorf("peak concurrency %d exceeded cap %d", peak, cap)
+	}
+
+	// Different clusters must not share a semaphore: filling one cluster's
+	// slots must not block another's acquire.
+	releases := make([]func(), 0, cap)
+	for i := 0; i < cap; i++ {
+		releases = append(releases, acquireKubectlSlot("test-cluster-a"))
+	}
+	done := make(chan struct{})
+	go func() {
+		r := acquireKubectlSlot("test-cluster-b")
+		r()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("acquire on independent cluster blocked by another cluster's slots")
+	}
+	for _, r := range releases {
+		r()
+	}
+}

--- a/src/pkg/hub/my_hives_query.go
+++ b/src/pkg/hub/my_hives_query.go
@@ -1,0 +1,185 @@
+package hub
+
+import (
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Server-side filter / sort / pagination for /api/saas/my-hives.
+//
+// At fleet scale the My Hives payload is the hub's hottest endpoint and used
+// to ship EVERY visible row on every poll. The set-wide computations (drift
+// norm, fleet alerts, cluster-outage suppression) are properties of the whole
+// visible set and still run over it — this layer scopes only what goes on the
+// WIRE afterwards. With no query parameters the response is byte-compatible
+// with the old behavior (all rows), so existing dashboards keep working.
+
+// maxMyHivesPerPage caps per_page so a caller cannot ask for a pathological
+// page size; 0/absent per_page means "no pagination" (full set, back-compat).
+const maxMyHivesPerPage = 500
+
+type myHivesQuery struct {
+	q       string // case-insensitive substring across id/name/org/project/owner/repo
+	status  string // "online", "offline", or an exact provStatus (available, assigned, provisioning, error, ...)
+	cluster string // ClusterID or ClusterName, case-insensitive
+	sortKey string // id | name | org | owner | cluster | status | last_seen
+	desc    bool
+	page    int // 1-based; 0 = no pagination
+	perPage int
+}
+
+// active reports whether the request asked for any server-side scoping at all;
+// when false the handler returns the full set exactly as before.
+func (q myHivesQuery) active() bool {
+	return q.q != "" || q.status != "" || q.cluster != "" || q.sortKey != "" || q.perPage > 0
+}
+
+func parseMyHivesQuery(v url.Values) myHivesQuery {
+	q := myHivesQuery{
+		q:       strings.TrimSpace(v.Get("q")),
+		status:  strings.ToLower(strings.TrimSpace(v.Get("status"))),
+		cluster: strings.TrimSpace(v.Get("cluster")),
+		sortKey: strings.ToLower(strings.TrimSpace(v.Get("sort"))),
+		desc:    strings.EqualFold(strings.TrimSpace(v.Get("order")), "desc"),
+	}
+	if n, err := strconv.Atoi(v.Get("per_page")); err == nil && n > 0 {
+		if n > maxMyHivesPerPage {
+			n = maxMyHivesPerPage
+		}
+		q.perPage = n
+		q.page = 1
+	}
+	if n, err := strconv.Atoi(v.Get("page")); err == nil && n > 1 && q.perPage > 0 {
+		q.page = n
+	}
+	return q
+}
+
+func entryMatches(e *MyHiveEntry, q myHivesQuery) bool {
+	if q.q != "" {
+		needle := strings.ToLower(q.q)
+		hay := strings.ToLower(strings.Join([]string{
+			e.ID, e.Name, e.Org, e.ProjectName, e.Owner, e.PrimaryRepo,
+		}, "\x00"))
+		if !strings.Contains(hay, needle) {
+			return false
+		}
+	}
+	switch q.status {
+	case "":
+	case "online":
+		if !e.Online {
+			return false
+		}
+	case "offline":
+		if e.Online {
+			return false
+		}
+	default:
+		if !strings.EqualFold(e.ProvStatus, q.status) {
+			return false
+		}
+	}
+	if q.cluster != "" &&
+		!strings.EqualFold(e.ClusterID, q.cluster) &&
+		!strings.EqualFold(e.ClusterName, q.cluster) {
+		return false
+	}
+	return true
+}
+
+// applyMyHivesQuery filters, sorts and pages the assembled entry set. It
+// returns the wire view plus the matched count (pre-pagination) so the client
+// can render "showing X of Y". The input slice is not mutated; sorting
+// operates on the filtered copy.
+func applyMyHivesQuery(entries []MyHiveEntry, q myHivesQuery) (view []MyHiveEntry, matched int) {
+	filtered := make([]MyHiveEntry, 0, len(entries))
+	for i := range entries {
+		if entryMatches(&entries[i], q) {
+			filtered = append(filtered, entries[i])
+		}
+	}
+	matched = len(filtered)
+
+	if q.sortKey != "" {
+		key := func(e *MyHiveEntry) string {
+			switch q.sortKey {
+			case "id":
+				return e.ID
+			case "name":
+				if e.Name != "" {
+					return e.Name
+				}
+				return e.ID
+			case "org":
+				return e.Org
+			case "owner":
+				return e.Owner
+			case "cluster":
+				return e.ClusterName + "\x00" + e.ClusterID
+			case "status":
+				return e.ProvStatus
+			case "last_seen":
+				// RFC3339 sorts lexically; empty (never beat) sorts first asc.
+				return e.LastHeartbeat
+			default:
+				return ""
+			}
+		}
+		sort.SliceStable(filtered, func(i, j int) bool {
+			a, b := strings.ToLower(key(&filtered[i])), strings.ToLower(key(&filtered[j]))
+			if q.desc {
+				return a > b
+			}
+			return a < b
+		})
+	}
+
+	if q.perPage > 0 {
+		start := (q.page - 1) * q.perPage
+		if start >= len(filtered) {
+			return []MyHiveEntry{}, matched
+		}
+		end := start + q.perPage
+		if end > len(filtered) {
+			end = len(filtered)
+		}
+		return filtered[start:end], matched
+	}
+	return filtered, matched
+}
+
+// myHivesSummary aggregates fleet-level counts over the caller's FULL visible
+// set (never the filtered page) so summary tiles stay truthful regardless of
+// the active filter. Rides every response — it is a handful of ints.
+func myHivesSummary(entries []MyHiveEntry) map[string]int {
+	s := map[string]int{"total": len(entries)}
+	for i := range entries {
+		e := &entries[i]
+		if e.Online {
+			s["online"]++
+		} else {
+			s["offline"]++
+		}
+		switch e.ProvStatus {
+		case statusAvailable:
+			s["pool_available"]++
+		case "provisioning":
+			s["provisioning"]++
+		case "error":
+			s["errors"]++
+		}
+		if e.AssignedUnclaimed {
+			s["assigned_unclaimed"]++
+		}
+		if e.Upgrading {
+			s["upgrading"]++
+		}
+		if e.UpgradeFailed {
+			s["upgrade_failed"]++
+		}
+	}
+	return s
+}

--- a/src/pkg/hub/my_hives_query_test.go
+++ b/src/pkg/hub/my_hives_query_test.go
@@ -1,0 +1,118 @@
+package hub
+
+import (
+	"net/url"
+	"testing"
+)
+
+func mhq(t *testing.T, raw string) myHivesQuery {
+	t.Helper()
+	v, err := url.ParseQuery(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return parseMyHivesQuery(v)
+}
+
+func testMyHivesEntries() []MyHiveEntry {
+	mk := func(id, org, owner, cluster, prov, beat string, online bool) MyHiveEntry {
+		e := MyHiveEntry{ProvStatus: prov}
+		e.ID = id
+		e.Org = org
+		e.Owner = owner
+		e.ClusterID = cluster
+		e.Online = online
+		e.LastHeartbeat = beat
+		return e
+	}
+	return []MyHiveEntry{
+		mk("hosted-alpha", "acme", "alice", "vllm-d", "assigned", "2026-08-20T10:00:00Z", true),
+		mk("hosted-beta", "acme", "bob", "hive-oke", statusAvailable, "", false),
+		mk("hosted-gamma", "zorg", "alice", "vllm-d", "provisioning", "2026-08-20T12:00:00Z", false),
+		mk("hosted-delta", "zorg", "carol", "vllm-d", "assigned", "2026-08-20T11:00:00Z", true),
+	}
+}
+
+func TestMyHivesQueryInactiveByDefault(t *testing.T) {
+	if mhq(t, "").active() {
+		t.Error("empty query must be inactive (full-set back-compat)")
+	}
+	if !mhq(t, "q=alpha").active() || !mhq(t, "per_page=10").active() {
+		t.Error("q / per_page must activate scoping")
+	}
+}
+
+func TestApplyMyHivesQueryFilters(t *testing.T) {
+	entries := testMyHivesEntries()
+
+	view, matched := applyMyHivesQuery(entries, mhq(t, "q=ALPHA"))
+	if matched != 1 || len(view) != 1 || view[0].ID != "hosted-alpha" {
+		t.Errorf("q=ALPHA: got %d matched, view %v", matched, view)
+	}
+
+	_, matched = applyMyHivesQuery(entries, mhq(t, "status=online"))
+	if matched != 2 {
+		t.Errorf("status=online matched %d, want 2", matched)
+	}
+	_, matched = applyMyHivesQuery(entries, mhq(t, "status=available"))
+	if matched != 1 {
+		t.Errorf("status=available matched %d, want 1", matched)
+	}
+	_, matched = applyMyHivesQuery(entries, mhq(t, "cluster=hive-oke"))
+	if matched != 1 {
+		t.Errorf("cluster=hive-oke matched %d, want 1", matched)
+	}
+	_, matched = applyMyHivesQuery(entries, mhq(t, "q=alice&cluster=vllm-d&status=online"))
+	if matched != 1 {
+		t.Errorf("combined filter matched %d, want 1", matched)
+	}
+}
+
+func TestApplyMyHivesQuerySortAndPage(t *testing.T) {
+	entries := testMyHivesEntries()
+
+	view, _ := applyMyHivesQuery(entries, mhq(t, "sort=last_seen&order=desc"))
+	if view[0].ID != "hosted-gamma" || view[len(view)-1].ID != "hosted-beta" {
+		t.Errorf("last_seen desc order wrong: %s ... %s", view[0].ID, view[len(view)-1].ID)
+	}
+
+	view, matched := applyMyHivesQuery(entries, mhq(t, "sort=id&per_page=2&page=2"))
+	if matched != 4 {
+		t.Errorf("matched = %d, want 4 (pre-pagination)", matched)
+	}
+	if len(view) != 2 || view[0].ID != "hosted-delta" || view[1].ID != "hosted-gamma" {
+		t.Errorf("page 2 wrong: %v", []string{view[0].ID, view[1].ID})
+	}
+
+	view, matched = applyMyHivesQuery(entries, mhq(t, "per_page=2&page=99"))
+	if matched != 4 || len(view) != 0 {
+		t.Errorf("past-the-end page: matched %d view %d, want 4/0", matched, len(view))
+	}
+}
+
+func TestParseMyHivesQueryCapsPerPage(t *testing.T) {
+	q := mhq(t, "per_page=999999")
+	if q.perPage != maxMyHivesPerPage {
+		t.Errorf("perPage = %d, want capped %d", q.perPage, maxMyHivesPerPage)
+	}
+	if q.page != 1 {
+		t.Errorf("page defaults to 1 when per_page set, got %d", q.page)
+	}
+}
+
+func TestMyHivesSummary(t *testing.T) {
+	entries := testMyHivesEntries()
+	entries[3].AssignedUnclaimed = true
+	entries[0].Upgrading = true
+	s := myHivesSummary(entries)
+	want := map[string]int{
+		"total": 4, "online": 2, "offline": 2,
+		"pool_available": 1, "provisioning": 1,
+		"assigned_unclaimed": 1, "upgrading": 1,
+	}
+	for k, v := range want {
+		if s[k] != v {
+			t.Errorf("summary[%s] = %d, want %d", k, s[k], v)
+		}
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2467,6 +2467,17 @@ func buildSingleClusterHealth(cluster *ClusterConfig, hiveCount int, logger *slo
 		}
 		slots := int(totalSlots)
 		hiveCapacityRemaining = &slots
+		// Headroom alert: warn operators before the cluster fills. Fires when
+		// fewer than 10% of total estimated slots (current hives + remaining)
+		// are left. Cheap to emit here — this path is cached for 30s and only
+		// runs on health page loads.
+		if total := hiveCount + slots; total > 0 && logger != nil {
+			if slots*100 < total*capacityHeadroomWarnPct {
+				logger.Warn("cluster hive capacity headroom low",
+					"cluster", cluster.ID, "hives", hiveCount,
+					"slots_remaining", slots, "headroom_pct", slots*100/total)
+			}
+		}
 	}
 
 	// Build summary.
@@ -3621,6 +3632,15 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	cluster, clusterFound := s.clusters[clusterID]
 	if !clusterFound {
 		http.Error(w, `{"error":"unknown cluster_id"}`, http.StatusBadRequest)
+		return
+	}
+	// Per-cluster ceiling — checked after the global cap so the more specific
+	// error wins only when the global gate passes.
+	if full, n := clusterAtMaxHives(&cluster); full {
+		s.logger.Warn("provision rejected — cluster at max_hives",
+			"cluster", cluster.ID, "count", n, "max_hives", cluster.MaxHives)
+		http.Error(w, fmt.Sprintf(`{"error":"cluster %s is at capacity (%d/%d hives) — pick another cluster or raise max_hives"}`,
+			cluster.ID, n, cluster.MaxHives), http.StatusServiceUnavailable)
 		return
 	}
 	subdomain := hiveID + "." + cluster.Domain

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3351,13 +3351,30 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	// let the header polygon disagree with the rows it summarises.
 	fleetQuadrant := attachQuadrants(result, isAdmin, journeyNow)
 
+	// Server-side scoping (filter/sort/pagination) happens LAST, after every
+	// set-wide computation above (drift norm, alerts, outage suppression,
+	// quadrant percentiles) has run over the caller's full visible set — the
+	// page is a wire-level view, not a different fleet. No query params →
+	// full set, exactly as before.
+	hivesView := result
+	query := parseMyHivesQuery(r.URL.Query())
+	matched := len(result)
+	if query.active() {
+		hivesView, matched = applyMyHivesQuery(result, query)
+	}
+
 	resp := map[string]any{
-		"hives": result,
+		"hives": hivesView,
 		// The fleet average backs the reference polygon drawn behind every
 		// row's kite and the aggregate at the top of the dashboard. It is an
 		// aggregate over many hives and identifies none of them, so unlike the
 		// per-hive scores it is not gated on the caller's role.
-		"fleet_quadrant":           fleetQuadrant,
+		"fleet_quadrant": fleetQuadrant,
+		// Summary counts over the FULL visible set (never the page) so
+		// dashboard tiles stay truthful under any filter.
+		"hives_summary":            myHivesSummary(result),
+		"hives_total":              len(result),
+		"hives_matched":            matched,
 		"saas_quota":               user.SaaSQuota,
 		"saas_used":                saasCount,
 		"is_admin":                 isAdmin,
@@ -9306,6 +9323,18 @@ const dashboardHTML = `<!DOCTYPE html>
        normal state of the screen rather than an absence the eye has to infer.
        --alert-color is set inline per severity so one rule serves all three. */
     #fleet-alerts-panel { margin-bottom: 16px; }
+    /* ── Fleet summary tiles ── */
+    /* One-line fleet inventory above the alerts panel, fed by the server's
+       hives_summary (computed over the caller's FULL visible set, never the
+       current filter/page). Shown only past SUMMARY_TILES_MIN_HIVES so a
+       two-hive user never sees a dashboard cosplaying as a fleet console. */
+    #fleet-summary-tiles { margin-bottom: 12px; }
+    .fleet-tiles { display: flex; gap: 8px; flex-wrap: wrap; }
+    .fleet-tile { border: 1px solid var(--border); border-radius: 10px; background: var(--surface); padding: 8px 14px; min-width: 84px; text-align: center; }
+    .fleet-tile-n { font-size: 1.15rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+    .fleet-tile-label { font-size: 0.62rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+    .fleet-tile.warn { border-color: rgba(245,158,11,0.4); }
+    .fleet-tile.bad { border-color: rgba(248,81,73,0.45); }
     .alert-panel { border: 1px solid var(--border); border-radius: 10px; background: var(--surface); padding: 12px 16px; }
     .alert-panel.has-critical { border-color: rgba(248,81,73,0.45); background: rgba(248,81,73,0.06); }
     .alert-panel.has-warning { border-color: rgba(245,158,11,0.4); background: rgba(245,158,11,0.05); }
@@ -9705,6 +9734,7 @@ const dashboardHTML = `<!DOCTYPE html>
          sit directly adjacent with no unrelated card between them. -->
     <div id="usage-panel" style="display:none;margin-bottom:24px"></div>
     <div id="hive-drift-summary" style="display:none"></div>
+    <div id="fleet-summary-tiles" style="display:none"></div>
     <div id="fleet-alerts-panel" style="display:none"></div>
     <div id="hive-view-bar" style="display:none"></div>
     <div id="hive-filter-bar" style="display:none"></div>
@@ -12680,6 +12710,9 @@ const dashboardHTML = `<!DOCTYPE html>
     var EMPTY_ALERT_SUMMARY = {alerts: [], countsBySeverity: {}, countsByType: {}, total: 0, acknowledgedTotal: 0};
 
     var _fleetAlerts = EMPTY_ALERT_SUMMARY;
+    /* Server-computed fleet inventory counts (hives_summary on the my-hives
+       payload). Null until the first load; renderSummaryTiles guards. */
+    var _hivesSummary = null;
     /* Active alert-type filter: '' = no alert filtering. Single-select, unlike
        the status chips — "show me the crash-looping hives" is a drill-down, and
        OR-ing several alert types back together just reproduces the full list. */
@@ -12923,6 +12956,47 @@ const dashboardHTML = `<!DOCTYPE html>
          it was deleted between the alert being evaluated and now). Say so rather
          than leaving a click that silently did nothing. */
       hiveToast('Could not find ' + (hiveName || hiveId) + ' in the hive list', 'error');
+    }
+
+    /* SUMMARY_TILES_MIN_HIVES gates the fleet tiles strip: below this many
+       visible hives the tiles restate what the eye already sees in the table,
+       so they stay hidden and the page keeps its small-user simplicity. */
+    var SUMMARY_TILES_MIN_HIVES = 8;
+
+    /* renderSummaryTiles draws the fleet inventory strip above the alerts
+       panel from the server-computed hives_summary — always the caller's FULL
+       visible set, never the active filter, so the numbers stay truthful
+       during any drill-down. Zero-count exception tiles self-suppress. */
+    function renderSummaryTiles() {
+      var el = document.getElementById('fleet-summary-tiles');
+      if (!el) return;
+      var s = _hivesSummary;
+      if (!s || (Number(s.total) || 0) < SUMMARY_TILES_MIN_HIVES) {
+        el.style.display = 'none';
+        return;
+      }
+      /* [key, label, css-class-when-nonzero, always-show] */
+      var defs = [
+        ['total', 'Hives', '', true],
+        ['online', 'Online', '', true],
+        ['offline', 'Offline', 'warn', true],
+        ['pool_available', 'Pool', '', false],
+        ['assigned_unclaimed', 'Unclaimed', 'warn', false],
+        ['provisioning', 'Provisioning', '', false],
+        ['upgrading', 'Upgrading', '', false],
+        ['upgrade_failed', 'Upgrade failed', 'bad', false],
+        ['errors', 'Errors', 'bad', false]
+      ];
+      var tiles = '';
+      for (var i = 0; i < defs.length; i++) {
+        var n = Number(s[defs[i][0]]) || 0;
+        if (!n && !defs[i][3]) continue;
+        var cls = n && defs[i][2] ? ' ' + defs[i][2] : '';
+        tiles += '<div class="fleet-tile' + cls + '"><div class="fleet-tile-n">' + n +
+          '</div><div class="fleet-tile-label">' + esc(defs[i][1]) + '</div></div>';
+      }
+      el.innerHTML = '<div class="fleet-tiles">' + tiles + '</div>';
+      el.style.display = '';
     }
 
     /* renderAlertsPanel draws the "Attention needed" panel above the hive list.
@@ -14533,6 +14607,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Alerts ride along on the same payload — see handleMyHives. Normalise
            to the empty summary so every consumer can iterate without guarding. */
         _fleetAlerts = data.alerts || EMPTY_ALERT_SUMMARY;
+        _hivesSummary = data.hives_summary || null;
         _latestSHA = data.latest_sha || _latestSHA;
         if (data.latest_shas) _latestSHAs = data.latest_shas;
         if (data.tracked_branches) _trackedBranchesList = data.tracked_branches;
@@ -15338,6 +15413,7 @@ const dashboardHTML = `<!DOCTYPE html>
       /* Drawn BEFORE the empty-state early-returns below: a fleet whose every
          hive is filtered out still has alerts worth showing, and the panel is
          how the operator gets back out of a drill-down. */
+      renderSummaryTiles();
       renderAlertsPanel();
       if (!allHives.length) {
         var driftEl0 = document.getElementById('hive-drift-summary');

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -5372,11 +5372,14 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// Clear Upgrading flags orphaned by spoke pods that vanished mid-upgrade.
 	// Runs alongside — not inside — triggerAutoUpgrades because that function
 	// only ever considers hives with AutoUpgrade enabled, while the flag is set
-	// by the admin and bulk upgrade paths for any hive.
-	s.sweepOrphanedUpgrades()
+	// by the admin and bulk upgrade paths for any hive. Throttled internally to
+	// orphanedUpgradeSweepInterval — corrective work, not a hot path.
+	s.sweepOrphanedUpgradesIfDue()
 	// Auto-reset any placeholder wedged at assigned && !claim_delivered past the
 	// timeout, so an assigned-but-unclaimed slot can never dead-end silently.
-	s.sweepStuckAssignments()
+	// Throttled internally to stuckAssignmentSweepInterval — a wedge only
+	// becomes actionable after assignStuckResetTimeout, far longer than a tick.
+	s.sweepStuckAssignmentsIfDue()
 	// Repair pre-#1222 NET_ADMIN securityContext drift so the F5 fatal-egress
 	// image (#2664) can't crash-loop drifted hives. Throttled internally to
 	// netAdminReconcileInterval — this poller ticks far more often than the
@@ -5426,8 +5429,8 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		}
 		// Always check for pending auto-upgrades (retries failed/missed hives).
 		s.triggerAutoUpgrades()
-		s.sweepOrphanedUpgrades()
-		s.sweepStuckAssignments()
+		s.sweepOrphanedUpgradesIfDue()
+		s.sweepStuckAssignmentsIfDue()
 		s.reconcileNetAdminIfDue()
 		s.reconcilePerHiveEnvIfDue()
 		s.retireExpiredGenerationsIfDue()

--- a/src/pkg/hub/saas_hive_cache.go
+++ b/src/pkg/hub/saas_hive_cache.go
@@ -1,0 +1,94 @@
+package hub
+
+import (
+	"os"
+	"sync"
+	"time"
+)
+
+// ── meta.json read cache ─────────────────────────────────────────────────────
+//
+// Nearly every hub control loop and API handler walks the whole fleet through
+// listSaaSHives()/loadSaaSHive(), and each walk used to open, read and parse
+// every hive's meta.json from the PVC. At tens of hives that was invisible; at
+// hundreds it is thousands of file reads per poller tick and per dashboard
+// load, all against the same network-backed volume.
+//
+// This cache keeps the RAW BYTES of each meta.json in memory, keyed by file
+// path and validated against the file's (mtime, size) on every access. Hits
+// skip the read entirely; the caller still unmarshals a fresh SaaSHive from
+// the cached bytes, so every caller keeps today's semantics exactly — an
+// independent, mutation-safe copy — and no deep-copy code has to be maintained
+// as fields are added to the struct.
+//
+// Deliberately NOT a parsed-struct cache: SaaSHive carries slices and pointers
+// (Repos, IssueFilter, PendingAppConfig, PendingRequests), so handing the same
+// parsed value to concurrent callers would let one caller's in-place mutation
+// taint every other reader. Unmarshal-per-access costs microseconds and buys
+// total isolation.
+//
+// Freshness:
+//   - The hub's own writes always land here via storeHiveMeta (called by
+//     saveSaaSHive after the tmp+rename), so hub-written state is never stale.
+//   - External/direct writes (tests writing meta.json with os.WriteFile) are
+//     caught by the stat check: a changed mtime or size is a miss and the file
+//     is re-read. The stat is taken BEFORE the read, so if a writer replaces
+//     the file between stat and read we record the OLD mtime with the NEW
+//     bytes — the next access sees a newer mtime, misses, and re-reads. The
+//     failure direction is an extra read, never stale data.
+//   - A stat failure (file deleted) evicts the entry, so removed hives do not
+//     linger in memory.
+type hiveMetaEntry struct {
+	mtime time.Time
+	size  int64
+	data  []byte
+}
+
+var (
+	hiveMetaMu    sync.RWMutex
+	hiveMetaCache = map[string]hiveMetaEntry{}
+)
+
+// readHiveMeta returns the current contents of the meta.json at path, serving
+// from the cache when the file is unchanged since it was last read.
+func readHiveMeta(path string) ([]byte, bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		evictHiveMeta(path)
+		return nil, false
+	}
+	hiveMetaMu.RLock()
+	e, ok := hiveMetaCache[path]
+	hiveMetaMu.RUnlock()
+	if ok && e.size == fi.Size() && e.mtime.Equal(fi.ModTime()) {
+		return e.data, true
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		evictHiveMeta(path)
+		return nil, false
+	}
+	hiveMetaMu.Lock()
+	hiveMetaCache[path] = hiveMetaEntry{mtime: fi.ModTime(), size: fi.Size(), data: data}
+	hiveMetaMu.Unlock()
+	return data, true
+}
+
+// storeHiveMeta records bytes just written to path so the hub's own saves are
+// immediate cache hits. Called after the tmp+rename in saveSaaSHive.
+func storeHiveMeta(path string, data []byte) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	hiveMetaMu.Lock()
+	hiveMetaCache[path] = hiveMetaEntry{mtime: fi.ModTime(), size: fi.Size(), data: append([]byte(nil), data...)}
+	hiveMetaMu.Unlock()
+}
+
+// evictHiveMeta drops the cache entry for path (deleted or unreadable hives).
+func evictHiveMeta(path string) {
+	hiveMetaMu.Lock()
+	delete(hiveMetaCache, path)
+	hiveMetaMu.Unlock()
+}

--- a/src/pkg/hub/saas_hive_cache_test.go
+++ b/src/pkg/hub/saas_hive_cache_test.go
@@ -1,0 +1,92 @@
+package hub
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestHiveMetaCacheServesAndInvalidates covers the cache contract end-to-end
+// through the real loadSaaSHive/saveSaaSHive/removeHiveRecord paths: hub
+// writes are immediate hits, external rewrites are detected via stat, and
+// deletion evicts.
+func TestHiveMetaCacheServesAndInvalidates(t *testing.T) {
+	dir := t.TempDir()
+	origDir := saasHivesDir
+	saasHivesDir = dir
+	t.Cleanup(func() { saasHivesDir = origDir })
+
+	// Save through the hub path — the cache must be warm immediately.
+	h := &SaaSHive{ID: "cache-h1", Owner: "alice", Status: statusAvailable}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatalf("saveSaaSHive: %v", err)
+	}
+	got := loadSaaSHive("cache-h1")
+	if got == nil || got.Owner != "alice" {
+		t.Fatalf("loadSaaSHive after save = %+v, want owner alice", got)
+	}
+
+	// Callers must get independent copies: mutating one load must never be
+	// visible through the next. This is the property that makes a parsed-struct
+	// cache unsafe and is the reason bytes are cached instead.
+	got.Owner = "mallory"
+	got.Repos = append(got.Repos, "tainted/repo")
+	again := loadSaaSHive("cache-h1")
+	if again.Owner != "alice" || len(again.Repos) != 0 {
+		t.Fatalf("cache returned a tainted copy: %+v", again)
+	}
+
+	// An EXTERNAL rewrite (not via saveSaaSHive — as tests and manual pokes do)
+	// must be picked up via the stat check.
+	path := filepath.Join(dir, "cache-h1", "meta.json")
+	external := []byte(`{"id":"cache-h1","owner":"bob","status":"assigned"}`)
+	// Ensure the mtime moves even on filesystems with coarse timestamps.
+	past := time.Now().Add(-2 * time.Second)
+	if err := os.WriteFile(path, external, 0o644); err != nil {
+		t.Fatalf("external write: %v", err)
+	}
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	fresh := loadSaaSHive("cache-h1")
+	if fresh == nil || fresh.Owner != "bob" {
+		t.Fatalf("external rewrite not observed: %+v", fresh)
+	}
+
+	// Deletion through the hub path evicts; a stale entry must not resurrect
+	// the hive.
+	removeHiveRecord("cache-h1", slog.Default())
+	if loadSaaSHive("cache-h1") != nil {
+		t.Fatal("loadSaaSHive returned a record after removeHiveRecord")
+	}
+	if hives := listSaaSHives(); len(hives) != 0 {
+		t.Fatalf("listSaaSHives = %d entries after removal, want 0", len(hives))
+	}
+}
+
+// TestHiveMetaCacheList exercises listSaaSHives against a mixed directory:
+// cached entries, an uncached external write, and a non-hive file.
+func TestHiveMetaCacheList(t *testing.T) {
+	dir := t.TempDir()
+	origDir := saasHivesDir
+	saasHivesDir = dir
+	t.Cleanup(func() { saasHivesDir = origDir })
+
+	for _, id := range []string{"l1", "l2", "l3"} {
+		if err := saveSaaSHive(&SaaSHive{ID: id, Status: statusAvailable}); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+	// A stray file at the top level must be ignored (only dirs are hives).
+	os.WriteFile(filepath.Join(dir, "README"), []byte("x"), 0o644)
+
+	if hives := listSaaSHives(); len(hives) != 3 {
+		t.Fatalf("listSaaSHives = %d, want 3", len(hives))
+	}
+	// Second pass is served from cache — must be identical.
+	if hives := listSaaSHives(); len(hives) != 3 {
+		t.Fatalf("cached listSaaSHives = %d, want 3", len(hives))
+	}
+}

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -162,26 +162,33 @@ var clustersConfigPath = "/data/saas/clusters.json"
 // hive spokes onto. Each cluster has its own kubeconfig, storage backend,
 // ingress style, and optional platform-specific settings (OCI, OpenShift).
 type ClusterConfig struct {
-	ID                string `json:"id" yaml:"id"`
-	Name              string `json:"name" yaml:"name"`
-	KubeconfigPath    string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
-	Context           string `json:"context" yaml:"context"`
-	InCluster         bool   `json:"in_cluster" yaml:"in_cluster"`
-	StorageClass      string `json:"storage_class" yaml:"storage_class"`
-	StorageType       string `json:"storage_type" yaml:"storage_type"`
-	NFSMountIP        string `json:"nfs_mount_ip,omitempty" yaml:"nfs_mount_ip,omitempty"`
-	IngressType       string `json:"ingress_type" yaml:"ingress_type"`
-	IngressClass      string `json:"ingress_class,omitempty" yaml:"ingress_class,omitempty"`
-	CertIssuer        string `json:"cert_issuer,omitempty" yaml:"cert_issuer,omitempty"`
-	Domain            string `json:"domain" yaml:"domain"`
-	DomainPrefix      string `json:"domain_prefix,omitempty" yaml:"domain_prefix,omitempty"`
-	OCICompartment    string `json:"oci_compartment,omitempty" yaml:"oci_compartment,omitempty"`
-	OCIAvailDomain    string `json:"oci_avail_domain,omitempty" yaml:"oci_avail_domain,omitempty"`
-	OCIMountTarget    string `json:"oci_mount_target,omitempty" yaml:"oci_mount_target,omitempty"`
-	OCIExportSet      string `json:"oci_export_set,omitempty" yaml:"oci_export_set,omitempty"`
-	RequiresSCC       bool   `json:"requires_scc" yaml:"requires_scc"`
-	SCCName           string `json:"scc_name,omitempty" yaml:"scc_name,omitempty"`
-	HasGPU            bool   `json:"has_gpu" yaml:"has_gpu"`
+	ID             string `json:"id" yaml:"id"`
+	Name           string `json:"name" yaml:"name"`
+	KubeconfigPath string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
+	Context        string `json:"context" yaml:"context"`
+	InCluster      bool   `json:"in_cluster" yaml:"in_cluster"`
+	StorageClass   string `json:"storage_class" yaml:"storage_class"`
+	StorageType    string `json:"storage_type" yaml:"storage_type"`
+	NFSMountIP     string `json:"nfs_mount_ip,omitempty" yaml:"nfs_mount_ip,omitempty"`
+	IngressType    string `json:"ingress_type" yaml:"ingress_type"`
+	IngressClass   string `json:"ingress_class,omitempty" yaml:"ingress_class,omitempty"`
+	CertIssuer     string `json:"cert_issuer,omitempty" yaml:"cert_issuer,omitempty"`
+	Domain         string `json:"domain" yaml:"domain"`
+	DomainPrefix   string `json:"domain_prefix,omitempty" yaml:"domain_prefix,omitempty"`
+	OCICompartment string `json:"oci_compartment,omitempty" yaml:"oci_compartment,omitempty"`
+	OCIAvailDomain string `json:"oci_avail_domain,omitempty" yaml:"oci_avail_domain,omitempty"`
+	OCIMountTarget string `json:"oci_mount_target,omitempty" yaml:"oci_mount_target,omitempty"`
+	OCIExportSet   string `json:"oci_export_set,omitempty" yaml:"oci_export_set,omitempty"`
+	RequiresSCC    bool   `json:"requires_scc" yaml:"requires_scc"`
+	SCCName        string `json:"scc_name,omitempty" yaml:"scc_name,omitempty"`
+	HasGPU         bool   `json:"has_gpu" yaml:"has_gpu"`
+	// MaxHives caps how many hosted hives (SaaS records, assigned or pooled)
+	// may exist on this cluster. 0 = unlimited. This is the HARD per-cluster
+	// gate: the bin-packed capacity estimate (hiveSlotsForNode) is advisory
+	// and can be optimistic, but routes/PVCs/namespaces and image-pull
+	// bandwidth all scale with hive COUNT, so operators need an explicit
+	// ceiling they can set per cluster as the fleet grows.
+	MaxHives          int    `json:"max_hives,omitempty" yaml:"max_hives,omitempty"`
 	Arch              string `json:"arch" yaml:"arch"`
 	ImageTag          string `json:"image_tag" yaml:"image_tag"`
 	ImagePullPolicy   string `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -345,17 +345,25 @@ func clusterDefaultForge(c *ClusterConfig) string {
 	return publicForgeHost
 }
 
-// kubectlForCluster builds an exec.Cmd that targets a specific cluster.
-// For in-cluster configs (InCluster == true) it runs plain kubectl;
-// for remote clusters it injects --kubeconfig and --context flags.
-func kubectlForCluster(cluster *ClusterConfig, args ...string) *exec.Cmd {
-	return exec.Command("kubectl", kubectlArgsForCluster(cluster, args...)...)
+// kubectlForCluster builds a bounded kubectl command that targets a specific
+// cluster. For in-cluster configs (InCluster == true) it runs plain kubectl;
+// for remote clusters it injects --kubeconfig and --context flags. Execution
+// (Output/CombinedOutput/Run) acquires a per-cluster concurrency slot — see
+// kubectl_executor.go.
+func kubectlForCluster(cluster *ClusterConfig, args ...string) *kubectlCmd {
+	return &kubectlCmd{
+		Cmd:       exec.Command("kubectl", kubectlArgsForCluster(cluster, args...)...),
+		clusterID: cluster.ID,
+	}
 }
 
 // kubectlForClusterContext is like kubectlForCluster but lets callers bound the
 // command lifetime with a context.
-func kubectlForClusterContext(ctx context.Context, cluster *ClusterConfig, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, "kubectl", kubectlArgsForCluster(cluster, args...)...)
+func kubectlForClusterContext(ctx context.Context, cluster *ClusterConfig, args ...string) *kubectlCmd {
+	return &kubectlCmd{
+		Cmd:       exec.CommandContext(ctx, "kubectl", kubectlArgsForCluster(cluster, args...)...),
+		clusterID: cluster.ID,
+	}
 }
 
 // unreachableKubeconfigSentinel is aimed at instead of a real kubeconfig when a

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -1622,8 +1622,8 @@ func loadSaaSHive(id string) *SaaSHive {
 		return nil
 	}
 	path := filepath.Join(saasHivesDir, id, "meta.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
+	data, ok := readHiveMeta(path)
+	if !ok {
 		return nil
 	}
 	var h SaaSHive
@@ -1648,7 +1648,11 @@ func saveSaaSHive(h *SaaSHive) error {
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmpPath, path)
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	storeHiveMeta(path, data)
+	return nil
 }
 
 // removeHiveRecord durably purges the hub-side, on-disk record for a deleted
@@ -1673,6 +1677,7 @@ func removeHiveRecord(id string, logger *slog.Logger) {
 		return
 	}
 	hiveDir := filepath.Join(saasHivesDir, id)
+	evictHiveMeta(filepath.Join(hiveDir, "meta.json"))
 	if err := os.RemoveAll(hiveDir); err != nil {
 		logger.Warn("removeHiveRecord: failed to remove hive directory", "path", hiveDir, "error", err)
 	}

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -28,8 +28,20 @@ const (
 	maxHivesPerUser   = 3
 	maxSaaSHivesTotal = 0 // 0 = unlimited
 	provisionTimeout  = 5 * time.Minute
-	cpuRequest        = "500m"
-	cpuLimit          = "2000m"
+	// cpuRequest/memRequest are the SCHEDULING footprint (what the scheduler
+	// reserves per hive) and directly set fleet density; the limits below are
+	// the burst ceiling and are unchanged. Right-sized 2026-08 from live fleet
+	// measurement (59 hives across vllm-d + hive-oke via kubectl top):
+	//   CPU:    p50 29-65m,   p90 0.5-1.7 cores, max 1.9  → 250m request
+	//   Memory: p50 0.8-1.1Gi, p90 1.3-2.9Gi,    max 3Gi  → 2Gi request
+	// Halving both doubles schedulable density on existing clusters (500
+	// hives: 125 vCPU + 1 TiB requested instead of 250 vCPU + 2 TiB). CPU is
+	// compressible so under-request only slows, never kills; memory bursts
+	// above 2Gi ride the 16Gi limit, with node overcommit bounded by the p90.
+	// Applies to NEW provisions; existing deployments keep their requests
+	// until their manifest is next re-applied.
+	cpuRequest = "250m"
+	cpuLimit   = "2000m"
 	// memRequest/memLimit size the spoke pod for the WHOLE agent fleet, not just
 	// the Go hive process. Each active coding agent (Copilot/Claude CLI) grows to
 	// ~2GB RSS, and an L6 hive runs 5-6 concurrently plus the hive process, so an
@@ -39,7 +51,7 @@ const (
 	// and the PR pipeline stalls (observed 2026-08-06: 9 OOM kills, whole fleet
 	// down ~4.5h on console-4vkt). 16Gi gives each agent headroom; OKE nodes have
 	// ~90GiB allocatable, so this is comfortably schedulable.
-	memRequest            = "4Gi"
+	memRequest            = "2Gi"
 	memLimit              = "16Gi"
 	nfsStorageCapacity    = "50Gi"
 	nfsMountTargetIP      = "10.0.10.30"

--- a/src/pkg/hub/saas_reset_assignment.go
+++ b/src/pkg/hub/saas_reset_assignment.go
@@ -261,6 +261,32 @@ func (s *HubServer) handleResetAssignment(w http.ResponseWriter, r *http.Request
 // created longer ago than the timeout is auto-reset, and a fresh assign always
 // carries an AssignedAt anyway so it takes the precise path. A wedge with neither
 // stamp is left for the operator's manual Reset (still reachable via the UI/API).
+// stuckAssignmentSweepInterval throttles sweepStuckAssignments. A wedge is
+// only actionable once it is older than assignStuckResetTimeout (tens of
+// minutes), so sweeping every 2-min poller tick buys nothing but a full fleet
+// scan; a wedge is still reset well within one timeout of becoming eligible.
+// 7 minutes is deliberately co-prime with the sibling throttled lanes so the
+// sweeps drift apart instead of stacking onto the same poller tick.
+const stuckAssignmentSweepInterval = 7 * time.Minute
+
+// sweepStuckAssignmentsIfDue runs the stuck-assignment sweep only if at least
+// stuckAssignmentSweepInterval has elapsed since the last run. Safe to call
+// from the poller loop every tick; same throttle pattern and same guarding
+// mutex as reconcileNetAdminIfDue.
+func (s *HubServer) sweepStuckAssignmentsIfDue() {
+	s.clusterUnreachableMu.Lock()
+	due := s.lastStuckAssignmentSweep.IsZero() ||
+		time.Since(s.lastStuckAssignmentSweep) >= stuckAssignmentSweepInterval
+	if due {
+		s.lastStuckAssignmentSweep = time.Now()
+	}
+	s.clusterUnreachableMu.Unlock()
+	if !due {
+		return
+	}
+	s.sweepStuckAssignments()
+}
+
 func (s *HubServer) sweepStuckAssignments() {
 	now := time.Now()
 

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -977,6 +977,14 @@ type HubServer struct {
 	// grant stops being honored at read time via loadSaaSUser's prune, on the
 	// wall clock, whether or not this sweep ever runs.
 	lastAccessExpirySweep time.Time
+	// lastOrphanedUpgradeSweep throttles the orphaned-upgrade latch sweep
+	// (stale_upgrade.go). Same rationale and same guarding mutex as the sweeps
+	// above: poller-loop-only state.
+	lastOrphanedUpgradeSweep time.Time
+	// lastStuckAssignmentSweep throttles the stuck-assignment reset sweep
+	// (saas_reset_assignment.go). Same rationale and same guarding mutex as the
+	// sweeps above: poller-loop-only state.
+	lastStuckAssignmentSweep time.Time
 	// perHiveEnvSeen is the Deployment-SOURCED convergence view backing
 	// PerHiveEnvSnapshot: hive ID → what the hub last actually read off that
 	// hive's Deployment. Deliberately NOT derived from heartbeat recency (see

--- a/src/pkg/hub/stale_upgrade.go
+++ b/src/pkg/hub/stale_upgrade.go
@@ -216,6 +216,32 @@ func evaluateOrphanedUpgrade(entry *RegistryEntry, now time.Time, latestSHA stri
 // SUPPRESSING delivery, since every upgrade path skips a hive it believes is
 // mid-upgrade. UpgradeTarget is preserved for observability, and the event is
 // logged and written to the hive's timeline.
+// orphanedUpgradeSweepInterval throttles sweepOrphanedUpgrades. The sweep
+// repairs stale upgrade latches and re-arms missed deliveries — corrective
+// work on the scale of minutes, not a hot path — so the 2-min SHA poller must
+// not pay a full registry evaluation every tick as the fleet grows. 9 minutes
+// is deliberately co-prime with the sibling 10/15-minute lanes so the throttled
+// sweeps drift apart instead of stacking onto the same poller tick.
+const orphanedUpgradeSweepInterval = 9 * time.Minute
+
+// sweepOrphanedUpgradesIfDue runs the orphaned-upgrade sweep only if at least
+// orphanedUpgradeSweepInterval has elapsed since the last run. Safe to call
+// from the poller loop every tick; same throttle pattern and same guarding
+// mutex as reconcileNetAdminIfDue.
+func (s *HubServer) sweepOrphanedUpgradesIfDue() {
+	s.clusterUnreachableMu.Lock()
+	due := s.lastOrphanedUpgradeSweep.IsZero() ||
+		time.Since(s.lastOrphanedUpgradeSweep) >= orphanedUpgradeSweepInterval
+	if due {
+		s.lastOrphanedUpgradeSweep = time.Now()
+	}
+	s.clusterUnreachableMu.Unlock()
+	if !due {
+		return
+	}
+	s.sweepOrphanedUpgrades()
+}
+
 func (s *HubServer) sweepOrphanedUpgrades() {
 	// Admin kill switch: while spoke upgrades are paused nothing is being
 	// delivered, so this sweep must not run — it re-arms heartbeatUpgrade


### PR DESCRIPTION
## Summary

Phase 1 of the hub scale plan (target: 500 hosted spokes on existing clusters, 1000-ready). Six focused commits:

1. **meta.json read cache** (`saas_hive_cache.go`) — bytes-level cache validated by stat mtime+size; kills per-request directory rescans in `listSaaSHives()` while preserving caller isolation (unmarshal per access).
2. **Poller sweep throttles** — `sweepOrphanedUpgrades` (9 min) and `sweepStuckAssignments` (7 min) move to the house IfDue pattern instead of running every 2-minute tick.
3. **Per-cluster max_hives capacity gate** — new `ClusterConfig.max_hives` (0 = unlimited) enforced at provision time with a clear 503; low-headroom (<10% of bin-packed slots) warning in cluster health collection.
4. **Bounded kubectl executor** — `kubectlForCluster`/`kubectlForClusterContext` return a wrapper whose Output/CombinedOutput/Run acquire a per-cluster semaphore (default 8, `HIVE_KUBECTL_MAX_PER_CLUSTER` override). Zero call-site changes.
5. **Server-side filter/sort/pagination for `/api/saas/my-hives`** — `q`, `status`, `cluster`, `sort`, `order`, `page`, `per_page` (cap 500). No params → full set (back-compatible). Set-wide computations (drift, alerts, outage suppression) still run over the full visible set; scoping is wire-level only. Payload gains `hives_summary`/`hives_total`/`hives_matched`.
6. **Fleet summary tiles** — inventory strip above the Attention panel from `hives_summary`; hidden below 8 visible hives.

## Testing
- New tests: meta cache, capacity gate, kubectl slot bounding (with -race), query filter/sort/pagination/summary.
- Full `./pkg/hub` suite passes after each commit.