### PR TITLE
✨ feat(convergence): non-monotonic selective proof invalidation (default-off)

### DIFF
--- a/src/pkg/convergence/proof/assumptions.go
+++ b/src/pkg/convergence/proof/assumptions.go
@@ -1,0 +1,113 @@
+package proof
+
+import (
+	"fmt"
+	"sort"
+)
+
+// This file adds the explicit non-monotonic input-assumption declaration for
+// kubestellar/hive#4254 (parent epic #3845), consuming exactly the load-bearing
+// inputs the accepted #4252 fingerprint selected for the first proof vertical
+// (#4253): the bounded base-reference observation (BaseSHA) and the
+// check-policy identity (CheckPolicyID).
+//
+// A declared assumption is the seam selective invalidation keys on: when the
+// CURRENT authoritative value of a declared input differs from the value a
+// receipt's judgment load-bears on, ONLY receipts declaring that exact
+// assumption become non-current. A receipt that does not declare the moved
+// assumption — a different repository's base, a different policy identity —
+// remains valid, which is what keeps "main moved somewhere" from discarding
+// unrelated evidence. Declarations are derived deterministically from the
+// immutable fingerprint and persisted on the receipt, so the same
+// invalidated/current status reconstructs from durable state after a restart:
+// no verdict is ever cached, and historical closed work can never latch an
+// outcome true.
+
+// Assumption kinds. The v1 predicate load-bears on exactly these two inputs;
+// a new predicate version declares its own set, never a silent extension of
+// this one.
+const (
+	// AssumptionBaseSHA is the bounded base-reference observation input: the
+	// PR base ref's commit SHA at observation time.
+	AssumptionBaseSHA = "base-sha"
+	// AssumptionCheckPolicy is the check-policy identity input: WHICH check
+	// runs count, including the classifier ruleset revision.
+	AssumptionCheckPolicy = "check-policy"
+)
+
+// assumptionSeparator joins an assumption kind to the repository scope it is
+// observed in. ":" cannot appear in a canonical owner/repo spelling (Validate
+// rejects whitespace and reserved separators, and a repo is exactly one "/"),
+// so an assumption name is unambiguous by construction.
+const assumptionSeparator = ":"
+
+// Assumption is one explicitly declared load-bearing input of a proof
+// judgment: the named input instance and the exact value the judgment rests
+// on. Movement of the CURRENT authoritative value away from Value makes every
+// receipt declaring this assumption non-current — and touches nothing else.
+type Assumption struct {
+	// Name identifies the input instance, scoped so unrelated instances can
+	// never collide: "base-sha:owner/repo", "check-policy:owner/repo".
+	Name string `json:"name"`
+	// Value is the exact input value the judgment load-bears on.
+	Value string `json:"value"`
+}
+
+// AssumptionName builds the scoped input-instance name for a kind observed in
+// a repository.
+func AssumptionName(kind, repo string) string {
+	return kind + assumptionSeparator + repo
+}
+
+// DeclaredAssumptions derives the load-bearing input assumptions of the v1
+// predicate from its immutable fingerprint: the base observation and the
+// check-policy identity, both scoped to the subject repository. The
+// derivation is deterministic, so durable receipts alone reconstruct the same
+// declarations after a restart. Returns nil for a fingerprint that fails
+// Validate — an unidentifiable subject declares nothing.
+func (f Fingerprint) DeclaredAssumptions() []Assumption {
+	if err := f.Validate(); err != nil {
+		return nil
+	}
+	out := []Assumption{
+		{Name: AssumptionName(AssumptionBaseSHA, f.Repo), Value: f.BaseSHA},
+		{Name: AssumptionName(AssumptionCheckPolicy, f.Repo), Value: f.CheckPolicyID},
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// declaredAssumptions returns the record's effective declaration set: the
+// persisted declarations when present, otherwise the deterministic derivation
+// from the fingerprint. The fallback is the explicit additive-migration rule
+// for receipts persisted before declarations existed: the v1 predicate has
+// ALWAYS load-borne on both inputs, so a legacy receipt is treated as
+// declaring exactly what its fingerprint proves it rested on — never as
+// declaring nothing, which would exempt it from invalidation.
+func (r Record) declaredAssumptions() []Assumption {
+	if len(r.Assumptions) > 0 {
+		return r.Assumptions
+	}
+	return r.Fingerprint.DeclaredAssumptions()
+}
+
+// validateAssumptions refuses a persisted declaration set that disagrees with
+// the fingerprint the judgment actually rested on. A receipt claiming
+// different assumptions than its own immutable evidence is malformed — it
+// could otherwise dodge invalidation by under-declaring, or invalidate
+// unrelated proofs by over-declaring.
+func (r Record) validateAssumptions() error {
+	if len(r.Assumptions) == 0 {
+		return nil
+	}
+	want := r.Fingerprint.DeclaredAssumptions()
+	if len(r.Assumptions) != len(want) {
+		return fmt.Errorf("declared assumptions do not match the fingerprint's load-bearing inputs")
+	}
+	for i, a := range r.Assumptions {
+		if a != want[i] {
+			return fmt.Errorf("declared assumption %q disagrees with the fingerprint (%q)", a.Name, want[i].Name)
+		}
+	}
+	return nil
+}

--- a/src/pkg/convergence/proof/assumptions_test.go
+++ b/src/pkg/convergence/proof/assumptions_test.go
@@ -1,0 +1,209 @@
+package proof
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test fixtures shared by the #4254 selective-invalidation suite. Two
+// unrelated subjects in two repositories: proofA is the candidate under test,
+// proofB is the standing positive control that must survive every
+// invalidation aimed at A's inputs.
+
+const (
+	shaHeadA  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	shaHeadA2 = "a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2"
+	shaBaseA  = "1111111111111111111111111111111111111111"
+	shaBaseA2 = "2222222222222222222222222222222222222222"
+	shaHeadB  = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	shaBaseB  = "3333333333333333333333333333333333333333"
+)
+
+func fpA() Fingerprint {
+	return Fingerprint{
+		OutcomeKey:        "default/acme/widgets@ship-green",
+		PredicateID:       PredicateExactHeadGreen,
+		DesiredGeneration: 1,
+		Repo:              "acme/widgets",
+		PRNumber:          7,
+		HeadSHA:           shaHeadA,
+		BaseSHA:           shaBaseA,
+		CheckPolicyID:     CheckPolicyID("v1", []string{"build", "test"}),
+		Producer:          ProducerGitHubChecksAPI,
+	}
+}
+
+func fpB() Fingerprint {
+	return Fingerprint{
+		OutcomeKey:        "default/acme/gadgets@ship-green",
+		PredicateID:       PredicateExactHeadGreen,
+		DesiredGeneration: 1,
+		Repo:              "acme/gadgets",
+		PRNumber:          9,
+		HeadSHA:           shaHeadB,
+		BaseSHA:           shaBaseB,
+		CheckPolicyID:     CheckPolicyID("v1", []string{"build"}),
+		Producer:          ProducerGitHubChecksAPI,
+	}
+}
+
+func greenRecord(t *testing.T, fp Fingerprint, at time.Time) Record {
+	t.Helper()
+	rec, err := NormalizeCheckEvidence(fp, []CheckConclusion{
+		{ID: 1, Name: "build", Completed: true, Conclusion: "success"},
+		{ID: 2, Name: "test", Completed: true, Conclusion: "success"},
+	}, at)
+	if err != nil {
+		t.Fatalf("NormalizeCheckEvidence: %v", err)
+	}
+	return rec
+}
+
+// currentInputs is the healthy snapshot in which every declared input of both
+// subjects still holds the value the receipts rest on.
+func currentInputs() InputObservation {
+	a, b := fpA(), fpB()
+	return InputObservation{
+		Current: map[string]string{
+			AssumptionName(AssumptionBaseSHA, a.Repo):     a.BaseSHA,
+			AssumptionName(AssumptionCheckPolicy, a.Repo): a.CheckPolicyID,
+			AssumptionName(AssumptionBaseSHA, b.Repo):     b.BaseSHA,
+			AssumptionName(AssumptionCheckPolicy, b.Repo): b.CheckPolicyID,
+		},
+		Observed: map[string]bool{
+			AssumptionName(AssumptionBaseSHA, a.Repo):     true,
+			AssumptionName(AssumptionCheckPolicy, a.Repo): true,
+			AssumptionName(AssumptionBaseSHA, b.Repo):     true,
+			AssumptionName(AssumptionCheckPolicy, b.Repo): true,
+		},
+	}
+}
+
+func TestDeclaredAssumptions_DerivedFromFingerprintInputs(t *testing.T) {
+	got := fpA().DeclaredAssumptions()
+	if len(got) != 2 {
+		t.Fatalf("v1 predicate declares exactly base+policy, got %v", got)
+	}
+	wantBase := AssumptionName(AssumptionBaseSHA, "acme/widgets")
+	wantPolicy := AssumptionName(AssumptionCheckPolicy, "acme/widgets")
+	found := map[string]string{}
+	for _, a := range got {
+		found[a.Name] = a.Value
+	}
+	if found[wantBase] != shaBaseA {
+		t.Fatalf("base assumption = %q, want %q", found[wantBase], shaBaseA)
+	}
+	if found[wantPolicy] != fpA().CheckPolicyID {
+		t.Fatalf("policy assumption = %q, want fingerprint policy", found[wantPolicy])
+	}
+}
+
+func TestDeclaredAssumptions_InvalidFingerprintDeclaresNothing(t *testing.T) {
+	bad := fpA()
+	bad.HeadSHA = "short"
+	if got := bad.DeclaredAssumptions(); got != nil {
+		t.Fatalf("unidentifiable subject must declare nothing, got %v", got)
+	}
+}
+
+func TestNormalizeCheckEvidence_PersistsDeclarations(t *testing.T) {
+	rec := greenRecord(t, fpA(), time.Now())
+	if len(rec.Assumptions) != 2 {
+		t.Fatalf("normalized receipt must carry its declarations, got %v", rec.Assumptions)
+	}
+}
+
+// RED guard: a receipt whose persisted declarations disagree with its own
+// fingerprint is malformed — it can neither dodge invalidation by
+// under-declaring nor invalidate unrelated proofs by over-declaring.
+func TestValidate_RefusesForgedDeclarations(t *testing.T) {
+	rec := greenRecord(t, fpA(), time.Now())
+
+	under := rec.clone()
+	under.Assumptions = under.Assumptions[:1]
+	if err := under.Validate(); err == nil {
+		t.Fatal("under-declared receipt must be malformed")
+	}
+
+	forged := rec.clone()
+	forged.Assumptions[0].Value = shaBaseA2
+	if err := forged.Validate(); err == nil {
+		t.Fatal("receipt declaring a value its fingerprint never rested on must be malformed")
+	}
+
+	alien := rec.clone()
+	alien.Assumptions[0].Name = AssumptionName(AssumptionBaseSHA, "acme/gadgets")
+	if err := alien.Validate(); err == nil {
+		t.Fatal("receipt declaring another subject's input must be malformed")
+	}
+}
+
+// Legacy receipts persisted before the assumptions field existed fall back to
+// the fingerprint derivation: additive migration can never exempt old
+// evidence from invalidation.
+func TestLegacyReceipt_StillDeclaresViaFingerprint(t *testing.T) {
+	rec := greenRecord(t, fpA(), time.Now())
+	rec.Assumptions = nil // as read back from a pre-#4254 file
+	if err := rec.Validate(); err != nil {
+		t.Fatalf("legacy receipt must remain valid: %v", err)
+	}
+	got := rec.declaredAssumptions()
+	if len(got) != 2 {
+		t.Fatalf("legacy receipt must still declare base+policy, got %v", got)
+	}
+	moved := currentInputs()
+	moved.Current[AssumptionName(AssumptionBaseSHA, "acme/widgets")] = shaBaseA2
+	if v, demoted := rec.JudgeAssumptions(moved); !demoted || v.Reason != ReasonAssumptionInvalidated {
+		t.Fatalf("legacy receipt must invalidate on declared input movement, got %+v demoted=%v", v, demoted)
+	}
+}
+
+func TestStore_RoundTripsDeclarations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proofs.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := s.Put(greenRecord(t, fpA(), time.Now())); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	rec, ok := reopened.Get(fpA().Key())
+	if !ok {
+		t.Fatal("receipt lost across restart")
+	}
+	if len(rec.Assumptions) != 2 {
+		t.Fatalf("declarations must reconstruct from durable state, got %v", rec.Assumptions)
+	}
+}
+
+func TestStore_DeclaringAssumption_EnumeratesSelectively(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proofs.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	now := time.Now()
+	if _, err := s.Put(greenRecord(t, fpA(), now)); err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	if _, err := s.Put(greenRecord(t, fpB(), now)); err != nil {
+		t.Fatalf("Put B: %v", err)
+	}
+	baseA := AssumptionName(AssumptionBaseSHA, "acme/widgets")
+	keys := s.DeclaringAssumption(baseA)
+	if len(keys) != 1 || !strings.Contains(keys[0], "acme/widgets") {
+		t.Fatalf("only A declares %s, got %v", baseA, keys)
+	}
+	if got := s.DeclaringAssumption(""); got != nil {
+		t.Fatalf("empty name enumerates nothing, got %v", got)
+	}
+	if got := s.DeclaringAssumption("base-sha:acme/unrelated"); got != nil {
+		t.Fatalf("undeclared input enumerates nothing, got %v", got)
+	}
+}

--- a/src/pkg/convergence/proof/invalidate.go
+++ b/src/pkg/convergence/proof/invalidate.go
@@ -1,0 +1,136 @@
+package proof
+
+import (
+	"github.com/kubestellar/hive/pkg/convergence"
+)
+
+// This file is the selective, non-monotonic invalidation judgment for
+// kubestellar/hive#4254 (parent epic #3845). It is level-triggered by
+// construction, exactly like convergence.Evaluate: the caller re-observes the
+// CURRENT authoritative value of each declared input on every evaluation and
+// the judgment is a pure function of (durable receipt, current inputs), so
+// arrival order can never latch or regress truth, a duplicate or out-of-order
+// input event changes nothing (the next evaluation re-reads current state),
+// and a process restart reconstructs the identical invalidated/current status
+// from the durable receipt alone. Historical work closure is not an input:
+// nothing here consults a work record, so a closed task can never hold an
+// outcome true after its evidence's assumptions moved.
+
+// Verdict reasons added by selective invalidation. Stable machine-readable
+// strings; callers log and test against them, so treat them as API.
+const (
+	// ReasonAssumptionInvalidated: the CURRENT authoritative value of an
+	// input this receipt explicitly declares differs from the value its
+	// judgment load-bears on. Only receipts declaring that assumption land
+	// here; everything else is untouched.
+	ReasonAssumptionInvalidated = "AssumptionInvalidated"
+	// ReasonAssumptionUnknown: a declared input's current value could not be
+	// observed authoritatively. Nothing is established (never satisfaction),
+	// and per the accepted #4250 contract the effect is local to receipts
+	// declaring that input — an unrelated proof remains available.
+	ReasonAssumptionUnknown = "AssumptionUnknown"
+)
+
+// InputObservation is the current authoritative state of the declared input
+// instances the caller could observe, keyed by scoped assumption name
+// ("base-sha:owner/repo", "check-policy:owner/repo"). It is a snapshot, never
+// a subscription: the caller re-observes on every evaluation.
+type InputObservation struct {
+	// Current maps an assumption name to its current authoritative value.
+	Current map[string]string
+	// Degraded maps an assumption name to a short reason when its observer
+	// could not answer authoritatively (unavailable source, expired
+	// freshness). A degraded input never invalidates and never confirms — it
+	// makes ONLY the receipts declaring it Unknown.
+	Degraded map[string]string
+	// Observed marks input names the caller actually attempted. An input
+	// absent from Observed is outside this snapshot entirely: the caller did
+	// not look, so nothing about it can change any judgment. This keeps a
+	// partial observation from silently confirming assumptions nobody
+	// re-checked.
+	Observed map[string]bool
+}
+
+// JudgeAssumptions judges this receipt's explicitly declared load-bearing
+// inputs against the current input snapshot. It returns (verdict, true) when
+// a declared assumption demotes the receipt — invalidated or unknown — and
+// (zero, false) when every observed declared input still matches, in which
+// case the ordinary fingerprint/freshness/result judgment stands.
+//
+// Selectivity is structural: the loop ranges over THIS receipt's declared
+// assumptions only, so movement of an input the receipt never declared —
+// another repository's base, a policy it does not rest on — cannot reach it.
+// A definite mismatch is reported in preference to a degraded observer, the
+// same "definite blocker first" ordering convergence.Evaluate applies.
+func (r Record) JudgeAssumptions(inputs InputObservation) (Verdict, bool) {
+	var degraded *Verdict
+	for _, a := range r.declaredAssumptions() {
+		if !inputs.Observed[a.Name] {
+			continue
+		}
+		if reason, ok := inputs.Degraded[a.Name]; ok {
+			if degraded == nil {
+				degraded = &Verdict{Status: convergence.ConditionUnknown, Reason: ReasonAssumptionUnknown,
+					Detail: "declared input " + a.Name + " could not be observed authoritatively: " + reason}
+			}
+			continue
+		}
+		if current, ok := inputs.Current[a.Name]; ok && current != a.Value {
+			return Verdict{Status: convergence.ConditionUnknown, Reason: ReasonAssumptionInvalidated,
+				Detail: "declared input " + a.Name + " moved from " + a.Value + " to " + current +
+					"; this judgment is no longer current"}, true
+		}
+	}
+	if degraded != nil {
+		return *degraded, true
+	}
+	return Verdict{}, false
+}
+
+// VerifyCurrent is the production judgment seam for an assumption-declaring
+// proof: the ordinary exact-subject verification (missing, malformed,
+// fingerprint mismatch, freshness, result) with selective invalidation
+// applied to any receipt that would otherwise speak. A receipt whose declared
+// input moved establishes NOTHING — not truth, not falsity — so its dependent
+// transition is withheld through the existing evaluator rules (Unknown blocks
+// as DependencyUnknown), while every receipt not declaring the moved input
+// keeps the verdict Verify alone would give.
+//
+// Restoration is the same function: once a NEW receipt binding the new input
+// value is accepted (a new fingerprint, a new key), its declared values match
+// the current snapshot again and the predicate speaks — exactly that
+// predicate, nothing else.
+func VerifyCurrent(s *Store, ctx Context, inputs InputObservation) Verdict {
+	if s == nil {
+		return Verify(s, ctx)
+	}
+	rec, ok := s.Get(ctx.Required.Key())
+	if !ok {
+		return Verify(s, ctx)
+	}
+	if v, demoted := rec.JudgeAssumptions(inputs); demoted {
+		return v
+	}
+	return rec.VerifyAgainst(ctx)
+}
+
+// DeclaringAssumption returns the keys of every stored receipt that declares
+// the named input instance, sorted. It is the enumeration seam a status
+// projection or an operator uses to answer "what does this input movement
+// invalidate?" — and its complement proves selectivity: a receipt absent from
+// this list is untouched by that input by construction.
+func (s *Store) DeclaringAssumption(name string) []string {
+	if name == "" {
+		return nil
+	}
+	var out []string
+	for _, rec := range s.List() {
+		for _, a := range rec.declaredAssumptions() {
+			if a.Name == name {
+				out = append(out, rec.Key())
+				break
+			}
+		}
+	}
+	return out
+}

--- a/src/pkg/convergence/proof/invalidate_test.go
+++ b/src/pkg/convergence/proof/invalidate_test.go
@@ -1,0 +1,344 @@
+package proof
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/convergence"
+)
+
+// The #4254 strict RED matrix, exercised through the production seams: the
+// durable store (Open/Put/Get), the current-truth judgment (VerifyCurrent),
+// the mode-gated dependency projection (AdmissionDependency), and the
+// production evaluator gate (convergence.Evaluate).
+
+const freshness = time.Hour
+
+// gateDecision runs one candidate through the REAL dependent-transition gate:
+// verdict → mode-gated dependency edge → convergence.Evaluate.
+func gateDecision(t *testing.T, s *Store, ctx Context, inputs InputObservation, mode string) convergence.Decision {
+	t.Helper()
+	v := VerifyCurrent(s, ctx, inputs)
+	obs := convergence.Observation{
+		Subject:  convergence.Subject{Repo: ctx.Required.Repo, Number: ctx.Required.PRNumber},
+		Found:    true,
+		RecordID: "intent-" + ctx.Required.Repo,
+	}
+	if dep := v.AdmissionDependency(mode, ctx); dep != nil {
+		obs.Dependencies = append(obs.Dependencies, *dep)
+	}
+	return convergence.Evaluate(obs)
+}
+
+func seededStore(t *testing.T) (*Store, time.Time) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "proofs.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	now := time.Now()
+	if _, err := s.Put(greenRecord(t, fpA(), now)); err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	if _, err := s.Put(greenRecord(t, fpB(), now)); err != nil {
+		t.Fatalf("Put B: %v", err)
+	}
+	return s, now
+}
+
+// Row 1: proof current at desired generation G with declared input I — its
+// dependent transition is admitted; the unrelated proof and candidate remain
+// admitted as positive controls.
+func TestRow_CurrentProofAdmits_WithPositiveControls(t *testing.T) {
+	s, now := seededStore(t)
+	inputs := currentInputs()
+	ctxA := Context{Required: fpA(), Now: now, MaxAge: freshness}
+	ctxB := Context{Required: fpB(), Now: now, MaxAge: freshness}
+
+	if d := gateDecision(t, s, ctxA, inputs, ModeEnforce); !d.Admitted {
+		t.Fatalf("current proof must admit its transition: %+v", d)
+	}
+	if d := gateDecision(t, s, ctxB, inputs, ModeEnforce); !d.Admitted {
+		t.Fatalf("positive-control proof must admit: %+v", d)
+	}
+}
+
+// Row 2: ONLY declared input I changes (base moves) while the historical work
+// record remains closed — the dependent predicate becomes Unknown and its
+// transition is withheld. Historical closure is not an input to the judgment,
+// so nothing can latch the outcome true.
+func TestRow_DeclaredInputChange_InvalidatesAndWithholds(t *testing.T) {
+	s, now := seededStore(t)
+	moved := currentInputs()
+	moved.Current[AssumptionName(AssumptionBaseSHA, "acme/widgets")] = shaBaseA2
+	ctxA := Context{Required: fpA(), Now: now, MaxAge: freshness}
+
+	v := VerifyCurrent(s, ctxA, moved)
+	if v.Status != convergence.ConditionUnknown || v.Reason != ReasonAssumptionInvalidated {
+		t.Fatalf("moved declared input must invalidate: %+v", v)
+	}
+	if !strings.Contains(v.Detail, shaBaseA2) || !strings.Contains(v.Detail, shaBaseA) {
+		t.Fatalf("verdict must name the movement: %s", v.Detail)
+	}
+	d := gateDecision(t, s, ctxA, moved, ModeEnforce)
+	if d.Admitted {
+		t.Fatalf("invalidated predicate must withhold its transition: %+v", d)
+	}
+	if d.Reason != convergence.ReasonDependencyUnknown {
+		t.Fatalf("withheld as Unknown, never False satisfaction: %+v", d)
+	}
+}
+
+// Row 3: the same input change does not touch a proof that never declared it.
+func TestRow_UndeclaredProofSurvivesInputChange(t *testing.T) {
+	s, now := seededStore(t)
+	moved := currentInputs()
+	moved.Current[AssumptionName(AssumptionBaseSHA, "acme/widgets")] = shaBaseA2
+	ctxB := Context{Required: fpB(), Now: now, MaxAge: freshness}
+
+	v := VerifyCurrent(s, ctxB, moved)
+	if !v.Satisfied() {
+		t.Fatalf("proof not declaring the moved input must stay current: %+v", v)
+	}
+	if d := gateDecision(t, s, ctxB, moved, ModeEnforce); !d.Admitted {
+		t.Fatalf("unrelated transition must remain admitted: %+v", d)
+	}
+}
+
+// Row 4: new exact-subject evidence for the new input value restores exactly
+// the dependent predicate — a new receipt under a new fingerprint, never an
+// edit of history.
+func TestRow_NewEvidenceRestoresOnlyThatPredicate(t *testing.T) {
+	s, now := seededStore(t)
+	moved := currentInputs()
+	baseName := AssumptionName(AssumptionBaseSHA, "acme/widgets")
+	moved.Current[baseName] = shaBaseA2
+
+	// Re-observation at the new base: new fingerprint (new head after rebase
+	// is typical, but even same-head/new-base is a distinct subject binding).
+	fpNew := fpA()
+	fpNew.BaseSHA = shaBaseA2
+	fpNew.HeadSHA = shaHeadA2
+	later := now.Add(time.Minute)
+	if _, err := s.Put(greenRecord(t, fpNew, later)); err != nil {
+		t.Fatalf("Put new evidence: %v", err)
+	}
+
+	ctxNew := Context{Required: fpNew, Now: later, MaxAge: freshness}
+	if v := VerifyCurrent(s, ctxNew, moved); !v.Satisfied() {
+		t.Fatalf("new exact-subject evidence must restore the predicate: %+v", v)
+	}
+	// The OLD receipt remains durably stored, still invalidated — history is
+	// retained, never latched back to true.
+	ctxOld := Context{Required: fpA(), Now: later, MaxAge: freshness}
+	if v := VerifyCurrent(s, ctxOld, moved); v.Status != convergence.ConditionUnknown {
+		t.Fatalf("old judgment must stay non-current: %+v", v)
+	}
+}
+
+// Rows 5+6: subject identity is untouched by #4254 — head X never authorizes
+// Y and generation G never satisfies G+1, through the same VerifyCurrent seam.
+func TestRow_HeadAndGenerationStillFence(t *testing.T) {
+	s, now := seededStore(t)
+	inputs := currentInputs()
+
+	headMoved := fpA()
+	headMoved.HeadSHA = shaHeadA2
+	if v := VerifyCurrent(s, Context{Required: headMoved, Now: now, MaxAge: freshness}, inputs); v.Satisfied() {
+		t.Fatalf("X's receipt must never authorize Y: %+v", v)
+	}
+
+	genMoved := fpA()
+	genMoved.DesiredGeneration = 2
+	if v := VerifyCurrent(s, Context{Required: genMoved, Now: now, MaxAge: freshness}, inputs); v.Satisfied() {
+		t.Fatalf("G's receipt must never satisfy G+1: %+v", v)
+	}
+}
+
+// Row 7: duplicate or out-of-order input events cannot regress or latch
+// truth — the judgment is a pure function of the CURRENT snapshot, so
+// re-evaluating with the current snapshot after any event sequence yields the
+// current answer, and an event replaying an OLD value is just a snapshot the
+// next evaluation overrides.
+func TestRow_ArrivalOrderCannotLatch(t *testing.T) {
+	s, now := seededStore(t)
+	ctxA := Context{Required: fpA(), Now: now, MaxAge: freshness}
+	baseName := AssumptionName(AssumptionBaseSHA, "acme/widgets")
+
+	moved := currentInputs()
+	moved.Current[baseName] = shaBaseA2
+	stale := currentInputs() // an out-of-order replay of the old value
+
+	// moved → stale replay → moved again: each evaluation answers ONLY for
+	// its snapshot; nothing persists a verdict anywhere.
+	if v := VerifyCurrent(s, ctxA, moved); v.Reason != ReasonAssumptionInvalidated {
+		t.Fatalf("moved snapshot must invalidate: %+v", v)
+	}
+	if v := VerifyCurrent(s, ctxA, stale); !v.Satisfied() {
+		t.Fatalf("judgment is level-triggered on the snapshot in hand: %+v", v)
+	}
+	if v := VerifyCurrent(s, ctxA, moved); v.Reason != ReasonAssumptionInvalidated {
+		t.Fatalf("current authoritative state must win after any order: %+v", v)
+	}
+}
+
+// Row 8: restart. The invalidated/current status reconstructs from the
+// durable receipt and a fresh observation alone — no process memory.
+func TestRow_RestartReconstructsStatus(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proofs.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	now := time.Now()
+	if _, err := s.Put(greenRecord(t, fpA(), now)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	moved := currentInputs()
+	moved.Current[AssumptionName(AssumptionBaseSHA, "acme/widgets")] = shaBaseA2
+	ctxA := Context{Required: fpA(), Now: now, MaxAge: freshness}
+
+	before := VerifyCurrent(s, ctxA, moved)
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	after := VerifyCurrent(reopened, ctxA, moved)
+	if before != after || after.Reason != ReasonAssumptionInvalidated {
+		t.Fatalf("restart must reconstruct the same status: before=%+v after=%+v", before, after)
+	}
+	healthy := VerifyCurrent(reopened, ctxA, currentInputs())
+	if !healthy.Satisfied() {
+		t.Fatalf("restart must not invent invalidation either: %+v", healthy)
+	}
+}
+
+// Row 9: racing input writers and verifiers serialize on the store's existing
+// key seams; run under -race in CI.
+func TestRow_ConcurrentJudgmentsAreSafe(t *testing.T) {
+	s, now := seededStore(t)
+	moved := currentInputs()
+	moved.Current[AssumptionName(AssumptionBaseSHA, "acme/widgets")] = shaBaseA2
+	ctxA := Context{Required: fpA(), Now: now, MaxAge: freshness}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(alt bool) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				if alt {
+					_ = VerifyCurrent(s, ctxA, moved)
+				} else {
+					_ = VerifyCurrent(s, ctxA, currentInputs())
+				}
+			}
+		}(i%2 == 0)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fpNew := fpA()
+		fpNew.BaseSHA = shaBaseA2
+		fpNew.HeadSHA = shaHeadA2
+		_, _ = s.Put(greenRecord(t, fpNew, now.Add(time.Second)))
+	}()
+	wg.Wait()
+}
+
+// Row 10: a declared input whose observer is unavailable makes ONLY the
+// declaring receipt Unknown; the unrelated positive control stays available.
+func TestRow_DegradedInputObserverIsLocal(t *testing.T) {
+	s, now := seededStore(t)
+	inputs := currentInputs()
+	baseName := AssumptionName(AssumptionBaseSHA, "acme/widgets")
+	delete(inputs.Current, baseName)
+	inputs.Degraded = map[string]string{baseName: "base observer unavailable"}
+
+	vA := VerifyCurrent(s, Context{Required: fpA(), Now: now, MaxAge: freshness}, inputs)
+	if vA.Status != convergence.ConditionUnknown || vA.Reason != ReasonAssumptionUnknown {
+		t.Fatalf("degraded declared input must be Unknown, never satisfaction: %+v", vA)
+	}
+	vB := VerifyCurrent(s, Context{Required: fpB(), Now: now, MaxAge: freshness}, inputs)
+	if !vB.Satisfied() {
+		t.Fatalf("failure domain must stay local: %+v", vB)
+	}
+}
+
+// A definite invalidation outranks a degraded observer, mirroring the
+// evaluator's "definite blocker first" ordering.
+func TestJudgeAssumptions_DefiniteMismatchBeatsDegraded(t *testing.T) {
+	s, now := seededStore(t)
+	rec, _ := s.Get(fpA().Key())
+	_ = now
+	inputs := currentInputs()
+	inputs.Current[AssumptionName(AssumptionCheckPolicy, "acme/widgets")] = "sha256:other"
+	baseName := AssumptionName(AssumptionBaseSHA, "acme/widgets")
+	delete(inputs.Current, baseName)
+	inputs.Degraded = map[string]string{baseName: "unavailable"}
+
+	v, demoted := rec.JudgeAssumptions(inputs)
+	if !demoted || v.Reason != ReasonAssumptionInvalidated {
+		t.Fatalf("definite movement must be reported over degradation: %+v", v)
+	}
+}
+
+// An input outside the snapshot (never observed) changes nothing: a partial
+// observation cannot silently confirm OR deny assumptions nobody re-checked.
+func TestJudgeAssumptions_UnobservedInputIsOutsideTheSnapshot(t *testing.T) {
+	s, now := seededStore(t)
+	rec, _ := s.Get(fpA().Key())
+	inputs := InputObservation{
+		// A stale map value exists but the input was NOT marked observed.
+		Current: map[string]string{AssumptionName(AssumptionBaseSHA, "acme/widgets"): shaBaseA2},
+	}
+	if v, demoted := rec.JudgeAssumptions(inputs); demoted {
+		t.Fatalf("unobserved input must not reach the judgment: %+v", v)
+	}
+	_ = now
+}
+
+// Row 11 (bypass RED): the checked seams must actually be load-bearing.
+func TestRow_BypassesFail(t *testing.T) {
+	s, now := seededStore(t)
+	moved := currentInputs()
+	moved.Current[AssumptionName(AssumptionBaseSHA, "acme/widgets")] = shaBaseA2
+	ctxA := Context{Required: fpA(), Now: now, MaxAge: freshness}
+
+	// If VerifyCurrent skipped the assumption judgment it would answer True
+	// here — the invalidation seam is proven load-bearing by row 2; this row
+	// proves the DEPENDENT GATE is load-bearing: with the edge projected, the
+	// production evaluator withholds; with the mode not exactly enforce, no
+	// edge exists and admission is byte-identical to today.
+	if d := gateDecision(t, s, ctxA, moved, ModeEnforce); d.Admitted {
+		t.Fatalf("enforce mode must withhold on an invalidated proof: %+v", d)
+	}
+	for _, mode := range []string{ModeOff, ModeShadow, "", "ENFORCE", "on"} {
+		if d := gateDecision(t, s, ctxA, moved, mode); !d.Admitted {
+			t.Fatalf("mode %q must be inert (default-off / shadow-never-enforces): %+v", mode, d)
+		}
+	}
+}
+
+// Row 12: a nil store or missing receipt keeps the existing #4253 verdicts —
+// selective invalidation adds no new authority over absent evidence.
+func TestVerifyCurrent_MissingEvidenceUnchanged(t *testing.T) {
+	now := time.Now()
+	ctxA := Context{Required: fpA(), Now: now, MaxAge: freshness}
+	if v := VerifyCurrent(nil, ctxA, currentInputs()); v.Reason != ReasonProofMissing {
+		t.Fatalf("nil store: %+v", v)
+	}
+	path := filepath.Join(t.TempDir(), "proofs.json")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if v := VerifyCurrent(s, ctxA, currentInputs()); v.Reason != ReasonProofMissing {
+		t.Fatalf("empty store: %+v", v)
+	}
+}

--- a/src/pkg/convergence/proof/proof.go
+++ b/src/pkg/convergence/proof/proof.go
@@ -198,6 +198,15 @@ type Record struct {
 	Provenance  Provenance  `json:"provenance"`
 	// ObservedAt is the observation instant, RFC3339 in the persisted file.
 	ObservedAt time.Time `json:"observed_at"`
+	// Assumptions are the explicitly declared load-bearing input assumptions
+	// this judgment rests on (#4254): movement of the current authoritative
+	// value of a declared input makes THIS receipt non-current and touches no
+	// receipt that does not declare it. Persisted so the declaration survives
+	// restart; derived deterministically from the fingerprint for the v1
+	// predicate (see DeclaredAssumptions), with legacy receipts persisted
+	// before this field falling back to the same derivation — additive, never
+	// an exemption.
+	Assumptions []Assumption `json:"assumptions,omitempty"`
 }
 
 // Validate reports why a Record cannot serve as evidence. Malformed evidence
@@ -213,6 +222,9 @@ func (r Record) Validate() error {
 	if r.ObservedAt.IsZero() {
 		return fmt.Errorf("proof record requires an observation instant")
 	}
+	if err := r.validateAssumptions(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -224,6 +236,7 @@ func (r Record) Key() string { return r.Fingerprint.Key() }
 func (r Record) clone() Record {
 	out := r
 	out.Provenance.CheckRunIDs = append([]int64(nil), r.Provenance.CheckRunIDs...)
+	out.Assumptions = append([]Assumption(nil), r.Assumptions...)
 	return out
 }
 
@@ -313,6 +326,8 @@ func NormalizeCheckEvidence(fp Fingerprint, checks []CheckConclusion, observedAt
 			Query:       "ListCheckRunsForRef@" + fp.HeadSHA,
 		},
 		ObservedAt: observedAt,
+		// #4254: declare the load-bearing inputs on the durable receipt itself.
+		Assumptions: fp.DeclaredAssumptions(),
 	}
 	if err := rec.Validate(); err != nil {
 		return Record{}, err


### PR DESCRIPTION
Implements #4254 (parent epic #3845) on the merged #4253 proof vertical, consuming exactly the load-bearing inputs the accepted #4252 fingerprint selected: the bounded base-reference observation (`BaseSHA`) and the check-policy identity (`CheckPolicyID`).

## What

- **Explicit assumption declarations on the durable proof receipt**: `Record.Assumptions` carries the named, scoped input instances the judgment load-bears on (`base-sha:owner/repo`, `check-policy:owner/repo`), derived deterministically from the immutable fingerprint, persisted additively, and validated against the fingerprint so a receipt can neither dodge invalidation by under-declaring nor invalidate unrelated proofs by over-declaring. Legacy receipts without the field fall back to the same derivation — migration can never exempt old evidence.
- **Selective, level-triggered invalidation**: `JudgeAssumptions`/`VerifyCurrent` judge the durable receipt against a fresh snapshot of each declared input's CURRENT authoritative value. Movement of a declared input makes ONLY declaring receipts `Unknown` (`AssumptionInvalidated`) and withholds only their dependent transition through the existing `convergence.Evaluate` gate; a proof that never declared the moved input keeps its verdict — "main moved somewhere" can never discard unrelated evidence. A degraded input observer is `Unknown` and failure-domain-local per the accepted #4250 contract.
- **Non-monotonic by construction**: no verdict is cached and historical work closure is not an input, so history never latches an outcome true; restart reconstructs the identical invalidated/current status from the durable receipt and a fresh observation alone. Restoration is the same judgment: only new exact-subject evidence binding the new input value makes exactly that predicate current again.

## Strict RED matrix coverage

Every row exercised through the production seams (durable store, `VerifyCurrent`, mode-gated `AdmissionDependency`, `convergence.Evaluate`): current proof admits with positive controls · declared-input movement invalidates and withholds while history stays closed · undeclared proofs survive · new evidence restores only that predicate · head X→Y and G→G+1 still fence · arrival order cannot latch · restart reconstructs · concurrent judgments race-clean · degraded observer local · bypass/mode-inertness RED rows · missing evidence unchanged.

## Non-goals honored

No generic assumption-graph service, no second evaluator/provider, no global "main moved" invalidation, no reopening historical work. All existing merge/CI/review/queue-approval/automerge guards unchanged.

## Default-off

Inert while `convergence.mode=off`; shadow records and reports but never enforces; only exact `enforce` projects the gating dependency. `pkg/convergence/proof`: 98.2% coverage, race-clean.

Closes #4254
Part of #3845