### PR TITLE
✨ feat(convergence): fenced mutation ownership and idempotent operation journal (default-off)

### DIFF
--- a/src/pkg/convergence/mutation/claim.go
+++ b/src/pkg/convergence/mutation/claim.go
@@ -1,0 +1,137 @@
+// Package mutation implements the fenced mutation ownership and idempotent
+// operation journal accepted on kubestellar/hive#4255 (parent epic #3845,
+// issue #4256), for exactly ONE mutation class: contributor task-lease-backed
+// repository mutations, with ONE external effect named by the accepted C2
+// binding — GitHub pull-request creation for the assigned task.
+//
+// It owns two durable truths and deliberately nothing more:
+//
+//   - the claim ledger: WHO currently owns a semantic mutation resource, at
+//     WHICH monotonically increasing per-claim epoch, in WHICH lifecycle
+//     state — the durable authority the in-memory contributor lease
+//     (contribute_ws.go taskLease) never was; and
+//
+//   - the operation journal: for each logical operation — identified WITHOUT
+//     owner or epoch, so retry or reassignment of the same desired effect
+//     always finds the same entry — whether its external effect was planned,
+//     applied, not applied, or left uncertain, with every authorized attempt
+//     and its owner epoch recorded inside the entry.
+//
+// Only the current durable claim epoch may authorize or acknowledge the
+// external effect, validated at the actual mutation boundary and again before
+// acknowledgment. After a timeout, crash, restart, or reassignment, current
+// authoritative external state reconciles the SAME logical operation —
+// Applied, NotApplied, or Unknown — before any retry; a replacement owner
+// adopts the existing operation under its newer epoch and can never mint a
+// second logical ID for unchanged effect inputs.
+//
+// The package is inert by default: nothing creates, reads, or consults a
+// ledger or journal unless the convergence mode toggle (convergence.mode /
+// HIVE_CONVERGENCE_MODE) resolves to a non-off mode, and only exact enforce
+// mode fences — shadow records and reports but never withholds an effect.
+// Existing PR-creation dedupe and exact-head merge guards remain mandatory
+// defense-in-depth the journal never replaces.
+package mutation
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Claim types, exactly the closed set accepted on #4255. Adding a type is a
+// new accepted contract, never a silent extension.
+const (
+	// ClaimTypeRepo is the repository-wide/top claim: it conflicts with every
+	// claim in the same canonical repository, so a broad mutation can never
+	// bypass narrower claims.
+	ClaimTypeRepo = "repo"
+	// ClaimTypeTask claims one work item's mutation: the canonical
+	// source-aware subject key ("owner/repo#N" or "owner/repo!KEY").
+	ClaimTypeTask = "task"
+)
+
+// claimKeyPrefix namespaces claim keys apart from every other key family in
+// Hive ("#", "!", "@" work/outcome keys never carry a "mutation:" prefix).
+const claimKeyPrefix = "mutation:"
+
+// Claim is the canonical semantic mutation resource accepted on #4255.
+// Claims are only ever minted from the hub's own lease tuple and
+// worksource.Ref.Key() — never from client-supplied strings — which is what
+// keeps spelling aliases from bypassing overlap.
+type Claim struct {
+	// Type is ClaimTypeRepo or ClaimTypeTask.
+	Type string `json:"type"`
+	// Repo is the canonical owner/repo spelling the lease records.
+	Repo string `json:"repo"`
+	// Subject is empty for a repo claim, and the canonical work key
+	// (worksource.Ref.Key()) for a task claim.
+	Subject string `json:"subject,omitempty"`
+}
+
+// Validate reports why a Claim cannot serve as a canonical resource identity.
+func (c Claim) Validate() error {
+	if c.Repo == "" || strings.Count(c.Repo, "/") != 1 || strings.ContainsAny(c.Repo, "@ \t") {
+		return fmt.Errorf("claim repo %q is not a canonical owner/repo spelling", c.Repo)
+	}
+	switch c.Type {
+	case ClaimTypeRepo:
+		if c.Subject != "" {
+			return fmt.Errorf("a repo claim carries no subject, got %q", c.Subject)
+		}
+	case ClaimTypeTask:
+		if c.Subject == "" {
+			return fmt.Errorf("a task claim requires a canonical subject key")
+		}
+		if !strings.HasPrefix(c.Subject, c.Repo) || len(c.Subject) <= len(c.Repo) {
+			return fmt.Errorf("task subject %q does not belong to repo %q", c.Subject, c.Repo)
+		}
+		switch c.Subject[len(c.Repo)] {
+		case '#', '!':
+			// the two canonical work-key separators worksource reserves
+		default:
+			return fmt.Errorf("task subject %q is not a canonical work key", c.Subject)
+		}
+	default:
+		return fmt.Errorf("claim type %q is not in the accepted set {repo, task}", c.Type)
+	}
+	return nil
+}
+
+// Key returns the canonical claim key — "mutation:<repo>" for a repo claim,
+// "mutation:<subject>" for a task claim — or "" for a claim that fails
+// Validate, mirroring the worksource/outcome contract that "" is never a key.
+func (c Claim) Key() string {
+	if err := c.Validate(); err != nil {
+		return ""
+	}
+	if c.Type == ClaimTypeRepo {
+		return claimKeyPrefix + c.Repo
+	}
+	return claimKeyPrefix + c.Subject
+}
+
+// Overlaps applies the entire accepted overlap algebra: equal keys conflict;
+// a repo claim conflicts with every claim in the same canonical repository;
+// everything else is disjoint. No path math, no glob.
+func (c Claim) Overlaps(other Claim) bool {
+	ck, ok := c.Key(), other.Key()
+	if ck == "" || ok == "" {
+		// An unidentifiable claim overlaps nothing and can never be held.
+		return false
+	}
+	if ck == ok {
+		return true
+	}
+	if c.Repo != other.Repo {
+		return false
+	}
+	return c.Type == ClaimTypeRepo || other.Type == ClaimTypeRepo
+}
+
+// RepoClaim mints the repository-wide/top claim for a canonical repo.
+func RepoClaim(repo string) Claim { return Claim{Type: ClaimTypeRepo, Repo: repo} }
+
+// TaskClaim mints the task claim for a canonical repo and work key.
+func TaskClaim(repo, subjectKey string) Claim {
+	return Claim{Type: ClaimTypeTask, Repo: repo, Subject: subjectKey}
+}

--- a/src/pkg/convergence/mutation/claim_test.go
+++ b/src/pkg/convergence/mutation/claim_test.go
@@ -1,0 +1,129 @@
+package mutation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestClaimKey_CanonicalForms(t *testing.T) {
+	repo := RepoClaim("acme/widgets")
+	if got := repo.Key(); got != "mutation:acme/widgets" {
+		t.Fatalf("repo key = %q", got)
+	}
+	task := TaskClaim("acme/widgets", "acme/widgets#7")
+	if got := task.Key(); got != "mutation:acme/widgets#7" {
+		t.Fatalf("task key = %q", got)
+	}
+	external := TaskClaim("acme/widgets", "acme/widgets!ENG-42")
+	if got := external.Key(); got != "mutation:acme/widgets!ENG-42" {
+		t.Fatalf("external task key = %q", got)
+	}
+}
+
+func TestClaimValidate_RefusesAliasesAndForgeries(t *testing.T) {
+	cases := []Claim{
+		{Type: ClaimTypeRepo, Repo: ""},
+		{Type: ClaimTypeRepo, Repo: "no-slash"},
+		{Type: ClaimTypeRepo, Repo: "a/b/c"},
+		{Type: ClaimTypeRepo, Repo: "acme/widgets", Subject: "acme/widgets#7"},
+		{Type: ClaimTypeTask, Repo: "acme/widgets"},
+		{Type: ClaimTypeTask, Repo: "acme/widgets", Subject: "other/repo#7"},
+		{Type: ClaimTypeTask, Repo: "acme/widgets", Subject: "acme/widgets"},
+		{Type: ClaimTypeTask, Repo: "acme/widgets", Subject: "acme/widgets@outcome"},
+		{Type: "path", Repo: "acme/widgets", Subject: "acme/widgets#7"},
+	}
+	for _, c := range cases {
+		if err := c.Validate(); err == nil {
+			t.Errorf("claim %+v must be invalid", c)
+		}
+		if key := c.Key(); key != "" {
+			t.Errorf("invalid claim %+v must have no key, got %q", c, key)
+		}
+	}
+}
+
+// The complete accepted overlap algebra: equal keys conflict; the repo-top
+// claim conflicts with every claim in that repo; everything else is disjoint.
+func TestOverlaps_AcceptedAlgebra(t *testing.T) {
+	repoA := RepoClaim("acme/widgets")
+	taskA7 := TaskClaim("acme/widgets", "acme/widgets#7")
+	taskA9 := TaskClaim("acme/widgets", "acme/widgets#9")
+	repoB := RepoClaim("acme/gadgets")
+	taskB7 := TaskClaim("acme/gadgets", "acme/gadgets#7")
+
+	cases := []struct {
+		a, b Claim
+		want bool
+	}{
+		{taskA7, taskA7, true},   // equal keys
+		{repoA, taskA7, true},    // top claim cannot be bypassed
+		{taskA7, repoA, true},    // symmetric
+		{repoA, repoA, true},     // equal repo claims
+		{taskA7, taskA9, false},  // disjoint tasks, same repo
+		{repoA, repoB, false},    // different repos
+		{taskA7, taskB7, false},  // same number, different repos
+		{repoA, taskB7, false},   // top claim scoped to its repo
+		{Claim{}, taskA7, false}, // invalid overlaps nothing
+	}
+	for _, c := range cases {
+		if got := c.a.Overlaps(c.b); got != c.want {
+			t.Errorf("Overlaps(%s, %s) = %v, want %v", c.a.Key(), c.b.Key(), got, c.want)
+		}
+		if got := c.b.Overlaps(c.a); got != c.want {
+			t.Errorf("overlap must be symmetric for (%s, %s)", c.a.Key(), c.b.Key())
+		}
+	}
+}
+
+func TestEffectLogicalID_ExcludesOwnerAndEpoch(t *testing.T) {
+	e := testEffect()
+	id := e.LogicalID()
+	if id == "" || !strings.HasPrefix(id, "op:") {
+		t.Fatalf("logical id = %q", id)
+	}
+	// Identical inputs → identical ID regardless of who retries.
+	if e.LogicalID() != id {
+		t.Fatal("logical id must be deterministic")
+	}
+	// Any load-bearing input change → a DIFFERENT logical operation.
+	gen := e
+	gen.DesiredGeneration = 2
+	head := e
+	head.Inputs = map[string]string{"repo": "acme/widgets", "head": "feature-2", "base": "main"}
+	for _, other := range []Effect{gen, head} {
+		if other.LogicalID() == id {
+			t.Fatalf("changed inputs must produce a distinct logical id")
+		}
+	}
+}
+
+func TestEffectValidate_Refusals(t *testing.T) {
+	bad := []Effect{
+		{},
+		func() Effect { e := testEffect(); e.Kind = "github.merge-pr/v1"; return e }(),
+		func() Effect { e := testEffect(); e.DesiredGeneration = 0; return e }(),
+		func() Effect { e := testEffect(); e.Inputs = nil; return e }(),
+		func() Effect { e := testEffect(); e.ClaimKey = ""; return e }(),
+	}
+	for _, e := range bad {
+		if err := e.Validate(); err == nil || !errors.Is(err, ErrInvalidEffect) {
+			t.Errorf("effect %+v must be invalid", e)
+		}
+		if e.LogicalID() != "" {
+			t.Errorf("invalid effect must have no id")
+		}
+	}
+}
+
+func testEffect() Effect {
+	return Effect{
+		OutcomeKey:        "default/acme/widgets@ship-green",
+		DesiredGeneration: 1,
+		Transition:        "contribute.open-pr",
+		Subject:           "acme/widgets#7",
+		ClaimKey:          TaskClaim("acme/widgets", "acme/widgets#7").Key(),
+		Kind:              EffectCreatePR,
+		Inputs:            map[string]string{"repo": "acme/widgets", "head": "feature-1", "base": "main"},
+	}
+}

--- a/src/pkg/convergence/mutation/executor.go
+++ b/src/pkg/convergence/mutation/executor.go
@@ -1,0 +1,121 @@
+package mutation
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/convergence/proof"
+)
+
+// Convergence mode gating mirrors the proof package's resolved-mode contract
+// (#4246/#4263): anything that is not an exact recognised enabling mode is
+// OFF. The mode values are shared with pkg/convergence/proof so the two
+// verticals can never disagree about what "off" means.
+
+// JournalingEnabled reports whether the resolved convergence mode records
+// mutation claims and journal entries at all (shadow or enforce).
+func JournalingEnabled(mode string) bool { return proof.RecordingEnabled(mode) }
+
+// FencingEnabled reports whether a stale epoch may actually withhold an
+// external effect. ONLY the exact enforce mode fences — shadow records and
+// reports, never withholds.
+func FencingEnabled(mode string) bool { return proof.EnforcementEnabled(mode) }
+
+// EffectFunc performs the one external effect and returns bounded provenance
+// of the applied result (e.g. the created PR URL). An error means the effect
+// outcome is UNCERTAIN — it may or may not have taken place externally — and
+// the operation must be reconciled before any retry.
+type EffectFunc func() (result string, err error)
+
+// Executor binds the durable claim ledger and operation journal around the
+// actual mutation boundary for the selected effect. It adds fencing and
+// idempotency; it never replaces the effect's own guards (CreatePR's
+// open-PR-by-head dedupe and 422 recovery remain mandatory defense-in-depth).
+type Executor struct {
+	Ledger  *Ledger
+	Journal *Journal
+	// Mode is the resolved convergence mode; the executor is a transparent
+	// passthrough at off, records-but-never-fences at shadow, and fences at
+	// enforce.
+	Mode string
+	// Now supplies the clock; nil means time.Now.
+	Now func() time.Time
+}
+
+func (x Executor) now() time.Time {
+	if x.Now != nil {
+		return x.Now()
+	}
+	return time.Now()
+}
+
+// Execute performs one logical operation under one claimed epoch:
+//
+//  1. mode off → the effect runs directly; no ledger or journal is touched
+//     (byte-identical legacy behavior, the default);
+//  2. epoch validation at the ACTUAL mutation boundary (fenced at enforce;
+//     recorded but not fenced at shadow);
+//  3. operation intent persisted durably BEFORE the effect (Begin), finding
+//     the same logical entry on retry/reassignment;
+//  4. the external effect;
+//  5. epoch validation AGAIN before authoritative acknowledgment — a hold
+//     that expired or was reassigned mid-effect may not acknowledge at
+//     enforce: the result is recorded as Unknown for reconciliation instead;
+//  6. the observed result persisted (RecordResult).
+//
+// An effect error records Unknown — never NotApplied, because an errored call
+// may still have taken effect externally — and returns the error; Reconcile
+// against authoritative external state then resolves the same logical
+// operation before any retry.
+func (x Executor) Execute(e Effect, epoch uint64, holder string, effect EffectFunc) (Operation, error) {
+	if !JournalingEnabled(x.Mode) {
+		result, err := effect()
+		if err != nil {
+			return Operation{}, err
+		}
+		return Operation{Status: StatusApplied, Result: result}, nil
+	}
+	if x.Ledger == nil || x.Journal == nil {
+		return Operation{}, fmt.Errorf("mutation executor requires a ledger and journal when mode is enabled")
+	}
+	claimKey := e.ClaimKey
+	now := x.now()
+
+	// Boundary check 1: only the current durable epoch may authorize.
+	if err := x.Ledger.ValidateEpoch(claimKey, epoch, now); err != nil {
+		if FencingEnabled(x.Mode) {
+			return Operation{}, fmt.Errorf("mutation boundary fenced: %w", err)
+		}
+		// Shadow observes the violation but never withholds.
+	}
+
+	// Intent before effect, durably.
+	op, err := x.Journal.Begin(e, epoch, holder, now)
+	if err != nil {
+		return Operation{}, err
+	}
+
+	result, effectErr := effect()
+	after := x.now()
+
+	if effectErr != nil {
+		// Uncertain: the call failed but the effect may exist externally.
+		if _, recErr := x.Journal.RecordResult(op.LogicalID, epoch, StatusUnknown, "", after); recErr != nil {
+			return Operation{}, fmt.Errorf("recording uncertain effect: %v (effect error: %w)", recErr, effectErr)
+		}
+		return Operation{}, fmt.Errorf("effect outcome uncertain, reconciliation required: %w", effectErr)
+	}
+
+	// Boundary check 2: only the current durable epoch may ACKNOWLEDGE.
+	if err := x.Ledger.ValidateEpoch(claimKey, epoch, after); err != nil && FencingEnabled(x.Mode) {
+		// The effect happened but this owner may no longer speak for it:
+		// record Unknown so the CURRENT owner reconciles the same logical
+		// operation from authoritative external state — never a duplicate.
+		if _, recErr := x.Journal.RecordResult(op.LogicalID, epoch, StatusUnknown, "", after); recErr != nil {
+			return Operation{}, fmt.Errorf("recording unacknowledgeable effect: %v (fence: %w)", recErr, err)
+		}
+		return Operation{}, fmt.Errorf("acknowledgment fenced, reconciliation required: %w", err)
+	}
+
+	return x.Journal.RecordResult(op.LogicalID, epoch, StatusApplied, result, after)
+}

--- a/src/pkg/convergence/mutation/executor_test.go
+++ b/src/pkg/convergence/mutation/executor_test.go
@@ -1,0 +1,196 @@
+package mutation
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/convergence/proof"
+)
+
+func newExecutor(t *testing.T, mode string) (Executor, Claim, time.Time) {
+	t.Helper()
+	dir := t.TempDir()
+	l, err := OpenLedger(filepath.Join(dir, "claims.json"), 0)
+	if err != nil {
+		t.Fatalf("OpenLedger: %v", err)
+	}
+	j, err := OpenJournal(filepath.Join(dir, "journal.json"))
+	if err != nil {
+		t.Fatalf("OpenJournal: %v", err)
+	}
+	now := time.Now()
+	return Executor{Ledger: l, Journal: j, Mode: mode, Now: func() time.Time { return now }},
+		TaskClaim("acme/widgets", "acme/widgets#7"), now
+}
+
+// Row: the current epoch holder executes the selected effect — it occurs once
+// with durable result/provenance; a disjoint claim/effect proceeds as the
+// positive control.
+func TestExecutor_CurrentEpochExecutesOnce(t *testing.T) {
+	x, c, now := newExecutor(t, proof.ModeEnforce)
+	g, err := x.Ledger.Acquire(c, "alice", ttl, now)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	calls := 0
+	op, err := x.Execute(testEffect(), g.Epoch, "alice", func() (string, error) {
+		calls++
+		return "acme/widgets#101", nil
+	})
+	if err != nil || op.Status != StatusApplied || op.Result != "acme/widgets#101" || calls != 1 {
+		t.Fatalf("execute: %+v calls=%d err=%v", op, calls, err)
+	}
+	// The exact same desired effect can never run twice.
+	if _, err := x.Execute(testEffect(), g.Epoch, "alice", func() (string, error) {
+		calls++
+		return "dup", nil
+	}); !errors.Is(err, ErrAlreadyApplied) || calls != 1 {
+		t.Fatalf("duplicate execute must be refused before the effect runs: %v calls=%d", err, calls)
+	}
+
+	// Positive control: a disjoint claim and effect proceed.
+	c9 := TaskClaim("acme/gadgets", "acme/gadgets#1")
+	g9, err := x.Ledger.Acquire(c9, "bob", ttl, now)
+	if err != nil {
+		t.Fatalf("disjoint acquire: %v", err)
+	}
+	e9 := testEffect()
+	e9.Subject = "acme/gadgets#1"
+	e9.ClaimKey = c9.Key()
+	if op, err := x.Execute(e9, g9.Epoch, "bob", func() (string, error) { return "acme/gadgets#5", nil }); err != nil || op.Status != StatusApplied {
+		t.Fatalf("disjoint effect must proceed: %+v %v", op, err)
+	}
+}
+
+// Row: stale-owner mutation and acknowledgment are fenced at the real
+// boundary — before the effect runs at all.
+func TestExecutor_StaleEpochFencedBeforeEffect(t *testing.T) {
+	x, c, now := newExecutor(t, proof.ModeEnforce)
+	g1, _ := x.Ledger.Acquire(c, "alice", ttl, now)
+	if _, err := x.Ledger.Wait(c.Key(), g1.Epoch, now); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	g2, err := x.Ledger.Acquire(c, "bob", ttl, now)
+	if err != nil {
+		t.Fatalf("reacquire: %v", err)
+	}
+
+	calls := 0
+	if _, err := x.Execute(testEffect(), g1.Epoch, "alice", func() (string, error) {
+		calls++
+		return "", nil
+	}); !errors.Is(err, ErrStaleEpoch) || calls != 0 {
+		t.Fatalf("stale epoch must be fenced BEFORE the effect: %v calls=%d", err, calls)
+	}
+	// The current owner proceeds.
+	if op, err := x.Execute(testEffect(), g2.Epoch, "bob", func() (string, error) { return "acme/widgets#101", nil }); err != nil || op.Status != StatusApplied {
+		t.Fatalf("current epoch must proceed: %+v %v", op, err)
+	}
+}
+
+// Row: ownership changes while the effect is in flight — the stale owner may
+// not ACKNOWLEDGE; the result is recorded Unknown and the new owner
+// reconciles the SAME logical operation from authoritative external state.
+func TestExecutor_AckFencedMidFlight_NewOwnerAdopts(t *testing.T) {
+	x, c, now := newExecutor(t, proof.ModeEnforce)
+	g1, _ := x.Ledger.Acquire(c, "alice", ttl, now)
+
+	e := testEffect()
+	if _, err := x.Execute(e, g1.Epoch, "alice", func() (string, error) {
+		// Mid-effect: the hold enters a wait (revocation path) and bob takes
+		// over — g1 is fenced by the time acknowledgment is attempted.
+		if _, err := x.Ledger.Wait(c.Key(), g1.Epoch, now); err != nil {
+			t.Fatalf("mid-flight wait: %v", err)
+		}
+		if _, err := x.Ledger.Acquire(c, "bob", ttl, now); err != nil {
+			t.Fatalf("mid-flight reacquire: %v", err)
+		}
+		return "acme/widgets#101", nil // the external effect DID happen
+	}); !errors.Is(err, ErrStaleEpoch) {
+		t.Fatalf("stale owner must not acknowledge: %v", err)
+	}
+
+	op, ok := x.Journal.Get(e.LogicalID())
+	if !ok || op.Status != StatusUnknown {
+		t.Fatalf("unacknowledgeable effect must be Unknown pending reconciliation: %+v", op)
+	}
+	// The new owner adopts and reconciles the SAME logical operation: the
+	// authoritative query finds the created PR — Applied, no duplicate.
+	rec, err := x.Journal.Reconcile(e.LogicalID(), ExternalState{Known: true, Applied: true, Result: "acme/widgets#101"}, now)
+	if err != nil || rec.Status != StatusApplied {
+		t.Fatalf("adoption reconciliation: %+v %v", rec, err)
+	}
+	if _, err := x.Journal.Begin(e, 2, "bob", now); !errors.Is(err, ErrAlreadyApplied) {
+		t.Fatalf("unchanged inputs can never become a second operation: %v", err)
+	}
+}
+
+// Row: an uncertain effect (error) records Unknown; retry without
+// reconciliation is refused; reconciliation to NotApplied authorizes exactly
+// one retry under the current epoch.
+func TestExecutor_UncertainEffectReconcilesBeforeRetry(t *testing.T) {
+	x, c, now := newExecutor(t, proof.ModeEnforce)
+	g, _ := x.Ledger.Acquire(c, "alice", ttl, now)
+	e := testEffect()
+
+	if _, err := x.Execute(e, g.Epoch, "alice", func() (string, error) {
+		return "", fmt.Errorf("connection reset mid-request")
+	}); err == nil {
+		t.Fatal("uncertain effect must surface an error")
+	}
+	// Blind retry refused.
+	if _, err := x.Execute(e, g.Epoch, "alice", func() (string, error) { return "dup", nil }); !errors.Is(err, ErrNeedsReconciliation) {
+		t.Fatalf("retry before reconciliation must be refused: %v", err)
+	}
+	// Authoritative state: not applied → one retry proceeds.
+	if _, err := x.Journal.Reconcile(e.LogicalID(), ExternalState{Known: true, Applied: false}, now); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	op, err := x.Execute(e, g.Epoch, "alice", func() (string, error) { return "acme/widgets#101", nil })
+	if err != nil || op.Status != StatusApplied || len(op.Attempts) != 2 {
+		t.Fatalf("reconciled retry must adopt the same operation: %+v %v", op, err)
+	}
+}
+
+// Row: mode inertness. Off touches neither ledger nor journal and runs the
+// effect directly (byte-identical legacy behavior); shadow records but never
+// fences — even a stale epoch executes.
+func TestExecutor_ModeGating(t *testing.T) {
+	// Off: no ledger/journal needed at all.
+	off := Executor{Mode: proof.ModeOff}
+	calls := 0
+	op, err := off.Execute(testEffect(), 0, "", func() (string, error) {
+		calls++
+		return "legacy", nil
+	})
+	if err != nil || op.Result != "legacy" || calls != 1 {
+		t.Fatalf("off mode must be a passthrough: %+v %v", op, err)
+	}
+	for _, mode := range []string{"", "ENFORCE", "on", "bogus"} {
+		if _, err := (Executor{Mode: mode}).Execute(testEffect(), 0, "", func() (string, error) { return "x", nil }); err != nil {
+			t.Fatalf("unrecognised mode %q must fail safe to off: %v", mode, err)
+		}
+	}
+
+	// Shadow: records, never withholds — a stale epoch still executes.
+	x, c, now := newExecutor(t, proof.ModeShadow)
+	g1, _ := x.Ledger.Acquire(c, "alice", ttl, now)
+	if _, err := x.Ledger.Wait(c.Key(), g1.Epoch, now); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	op, err = x.Execute(testEffect(), g1.Epoch, "alice", func() (string, error) { return "shadow-pr", nil })
+	if err != nil || op.Status != StatusApplied {
+		t.Fatalf("shadow must never withhold: %+v %v", op, err)
+	}
+	if _, ok := x.Journal.Get(testEffect().LogicalID()); !ok {
+		t.Fatal("shadow must still record the operation")
+	}
+
+	// Enabled modes require the durable stores.
+	if _, err := (Executor{Mode: proof.ModeEnforce}).Execute(testEffect(), 1, "a", func() (string, error) { return "", nil }); err == nil {
+		t.Fatal("enforce without stores must refuse")
+	}
+}

--- a/src/pkg/convergence/mutation/journal.go
+++ b/src/pkg/convergence/mutation/journal.go
@@ -1,0 +1,409 @@
+package mutation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// EffectCreatePR is the ONE external effect this vertical implements, exactly
+// as named by the accepted #4255 C2 binding: GitHub pull-request creation for
+// the assigned task. The identifier is versioned; a semantics change is a new
+// effect kind, never a silent reinterpretation of journal entries.
+const EffectCreatePR = "github.create-pr/v1"
+
+// Operation statuses: the reconstructable record distinguishing an external
+// effect that was planned, applied, not applied, or left uncertain.
+const (
+	// StatusPlanned: intent is durably recorded; the effect may not yet have
+	// been attempted, or an attempt is in flight.
+	StatusPlanned = "Planned"
+	// StatusApplied: authoritative external state (or an acknowledged
+	// current-epoch result) proves the effect took place. Terminal truth —
+	// a later duplicate, out-of-order, or stale-epoch result can never
+	// regress it.
+	StatusApplied = "Applied"
+	// StatusNotApplied: authoritative external state proves the effect did
+	// NOT take place; the same logical operation may retry through a new
+	// authorized attempt under the current epoch.
+	StatusNotApplied = "NotApplied"
+	// StatusUnknown: the external result is ambiguous or the observer was
+	// unavailable. No retry is authorized until reconciliation against
+	// authoritative external state resolves the SAME logical operation.
+	StatusUnknown = "Unknown"
+)
+
+// Journal sentinel errors; callers match with errors.Is.
+var (
+	// ErrNeedsReconciliation: the operation has an unresolved attempt
+	// (Planned or Unknown); authoritative external state must reconcile the
+	// same logical operation before any retry is authorized. This is what
+	// makes retry-after-uncertainty reconcile rather than duplicate.
+	ErrNeedsReconciliation = errors.New("operation must be reconciled against authoritative external state before retry")
+	// ErrAlreadyApplied: the effect already took place; a new attempt can
+	// never be authorized for the same logical operation.
+	ErrAlreadyApplied = errors.New("operation effect is already applied")
+	// ErrResultRegression: a result or acknowledgment arrived that would
+	// regress terminal journal truth or overwrite a newer attempt from an
+	// older epoch.
+	ErrResultRegression = errors.New("result cannot regress terminal journal truth")
+	// ErrUnknownOperation: no journal entry exists for the logical ID.
+	ErrUnknownOperation = errors.New("no journal entry exists for this operation")
+	// ErrInvalidEffect: the effect description fails validation.
+	ErrInvalidEffect = errors.New("effect description is invalid")
+)
+
+const journalFileMode = 0o660
+const journalFormatVersion = 1
+
+// Effect is the complete description of one desired external effect. Its
+// LogicalID deliberately EXCLUDES the owner and epoch: retry or reassignment
+// of the same desired effect must find the same journal entry, and a
+// replacement owner can never mint a second logical ID for unchanged inputs.
+// Changing any load-bearing input (desired generation, subject head, ...)
+// produces a DIFFERENT logical operation.
+type Effect struct {
+	// OutcomeKey is the accepted #4249/#4251 outcome identity
+	// ("project/repo@outcome") this effect serves.
+	OutcomeKey string `json:"outcome_key"`
+	// DesiredGeneration is the outcome's desired generation at planning time.
+	DesiredGeneration int `json:"desired_generation"`
+	// Transition names the Hive transition performing the effect.
+	Transition string `json:"transition"`
+	// Subject is the canonical source-aware work key ("owner/repo#N").
+	Subject string `json:"subject"`
+	// ClaimKey is the canonical mutation claim key authorizing the effect.
+	ClaimKey string `json:"claim_key"`
+	// Kind is the effect kind; this vertical only ever writes EffectCreatePR.
+	Kind string `json:"kind"`
+	// Inputs are ALL load-bearing effect inputs (head branch, base branch,
+	// repository, title digest, ...), canonicalized by the caller.
+	Inputs map[string]string `json:"inputs"`
+}
+
+// Validate reports why an Effect cannot be journaled.
+func (e Effect) Validate() error {
+	if e.OutcomeKey == "" || e.Transition == "" || e.Subject == "" || e.ClaimKey == "" {
+		return fmt.Errorf("%w: outcome key, transition, subject, and claim key are all required", ErrInvalidEffect)
+	}
+	if e.DesiredGeneration < 1 {
+		return fmt.Errorf("%w: desired generation %d is impossible", ErrInvalidEffect, e.DesiredGeneration)
+	}
+	if e.Kind != EffectCreatePR {
+		return fmt.Errorf("%w: effect kind %q is not implemented by this vertical (only %s)", ErrInvalidEffect, e.Kind, EffectCreatePR)
+	}
+	if len(e.Inputs) == 0 {
+		return fmt.Errorf("%w: an external effect declares its inputs", ErrInvalidEffect)
+	}
+	return nil
+}
+
+// LogicalID derives the stable logical operation identity: a sha256 over the
+// canonical serialization of every field above — and nothing else. Returns ""
+// for an effect that fails Validate ("" is never an ID).
+func (e Effect) LogicalID() string {
+	if err := e.Validate(); err != nil {
+		return ""
+	}
+	h := sha256.New()
+	write := func(parts ...string) {
+		for _, p := range parts {
+			h.Write([]byte(p))
+			h.Write([]byte{0})
+		}
+	}
+	write(e.OutcomeKey, fmt.Sprintf("%d", e.DesiredGeneration), e.Transition, e.Subject, e.ClaimKey, e.Kind)
+	names := make([]string, 0, len(e.Inputs))
+	for k := range e.Inputs {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	for _, k := range names {
+		write(k, e.Inputs[k])
+	}
+	return "op:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// Attempt is one authorized attempt at the effect, recorded INSIDE the
+// operation entry with its owner epoch — never in the logical ID.
+type Attempt struct {
+	Epoch  uint64    `json:"epoch"`
+	Holder string    `json:"holder"`
+	At     time.Time `json:"at"`
+	// Outcome is the attempt's locally observed conclusion: "applied",
+	// "unknown", or "not-applied" once known; empty while in flight.
+	Outcome string `json:"outcome,omitempty"`
+}
+
+// Operation is one durable journal entry for one logical operation.
+type Operation struct {
+	LogicalID string    `json:"logical_id"`
+	Effect    Effect    `json:"effect"`
+	Status    string    `json:"status"`
+	Attempts  []Attempt `json:"attempts"`
+	// Result is bounded provenance of the observed external result (e.g. the
+	// created PR URL/number) — enough to audit, not a log archive.
+	Result string `json:"result,omitempty"`
+	// UpdatedAt is the instant of the last accepted journal transition.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type persistedJournal struct {
+	Version    int         `json:"version"`
+	Operations []Operation `json:"operations"`
+}
+
+// Journal is the durable idempotent operation record: an in-memory index over
+// one JSON file, reloaded on boot, rewritten atomically on every accepted
+// transition, serialized per logical-ID under the journal mutex. Process
+// memory is never authority.
+type Journal struct {
+	path string
+	mu   sync.Mutex
+	ops  map[string]*Operation
+}
+
+// OpenJournal loads the operation journal at path, creating an empty one when
+// the file does not exist; a corrupt file is a refusal that leaves the bytes
+// untouched for inspection.
+func OpenJournal(path string) (*Journal, error) {
+	j := &Journal{path: path, ops: make(map[string]*Operation)}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return j, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading mutation journal %s: %w", path, err)
+	}
+	var persisted persistedJournal
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return nil, fmt.Errorf("mutation journal %s is unparseable and is left untouched for inspection: %w", path, err)
+	}
+	for i := range persisted.Operations {
+		op := persisted.Operations[i]
+		want := op.Effect.LogicalID()
+		if want == "" || want != op.LogicalID {
+			return nil, fmt.Errorf("mutation journal %s holds an entry whose id does not derive from its effect", path)
+		}
+		if _, dup := j.ops[op.LogicalID]; dup {
+			return nil, fmt.Errorf("mutation journal %s holds conflicting entries for %s", path, op.LogicalID)
+		}
+		cp := op.clone()
+		j.ops[op.LogicalID] = &cp
+	}
+	return j, nil
+}
+
+func (o Operation) clone() Operation {
+	out := o
+	out.Attempts = append([]Attempt(nil), o.Attempts...)
+	out.Effect.Inputs = make(map[string]string, len(o.Effect.Inputs))
+	for k, v := range o.Effect.Inputs {
+		out.Effect.Inputs[k] = v
+	}
+	return out
+}
+
+// Get returns a detached copy of the operation for a logical ID.
+func (j *Journal) Get(id string) (Operation, bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	op, ok := j.ops[id]
+	if !ok {
+		return Operation{}, false
+	}
+	return op.clone(), true
+}
+
+// Begin persists operation INTENT — durably, BEFORE the external effect — and
+// records the authorized attempt with its owner epoch inside the entry. The
+// rules, in order:
+//
+//  1. An invalid effect is refused.
+//  2. A new logical ID creates the entry (Planned) with attempt #1.
+//  3. An existing entry already Applied refuses a new attempt
+//     (ErrAlreadyApplied): the same desired effect can never run twice.
+//  4. An existing entry with an unresolved attempt (Planned/Unknown) refuses
+//     (ErrNeedsReconciliation): retry after uncertainty must reconcile the
+//     SAME logical operation against authoritative external state first.
+//  5. An entry reconciled to NotApplied accepts a new attempt — the
+//     replacement owner ADOPTS the existing entry under its (newer) epoch;
+//     unchanged inputs can never mint a second logical ID because the ID is
+//     derived from the effect alone.
+func (j *Journal) Begin(e Effect, epoch uint64, holder string, now time.Time) (Operation, error) {
+	if err := e.Validate(); err != nil {
+		return Operation{}, err
+	}
+	id := e.LogicalID()
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if op, ok := j.ops[id]; ok {
+		switch op.Status {
+		case StatusApplied:
+			return Operation{}, fmt.Errorf("%s: %w", id, ErrAlreadyApplied)
+		case StatusPlanned, StatusUnknown:
+			return Operation{}, fmt.Errorf("%s is %s: %w", id, op.Status, ErrNeedsReconciliation)
+		}
+		// NotApplied: adopt the SAME entry under the new attempt's epoch.
+		work := op.clone()
+		work.Status = StatusPlanned
+		work.Attempts = append(work.Attempts, Attempt{Epoch: epoch, Holder: holder, At: now})
+		work.UpdatedAt = now
+		return j.commit(id, work)
+	}
+	work := Operation{
+		LogicalID: id,
+		Effect:    e,
+		Status:    StatusPlanned,
+		Attempts:  []Attempt{{Epoch: epoch, Holder: holder, At: now}},
+		UpdatedAt: now,
+	}
+	return j.commit(id, work)
+}
+
+// RecordResult records the observed conclusion of the LATEST attempt, keyed
+// by the attempt's epoch. Rules:
+//
+//   - Only the latest attempt's epoch may record: an older epoch's late
+//     result can never overwrite the current attempt (ErrResultRegression).
+//   - An Applied entry is terminal: nothing regresses it, though the
+//     IDENTICAL applied acknowledgment deduplicates silently.
+//   - status must be StatusApplied, StatusNotApplied, or StatusUnknown.
+func (j *Journal) RecordResult(id string, epoch uint64, status, result string, now time.Time) (Operation, error) {
+	if status != StatusApplied && status != StatusNotApplied && status != StatusUnknown {
+		return Operation{}, fmt.Errorf("%w: %q is not a recordable status", ErrInvalidEffect, status)
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	op, ok := j.ops[id]
+	if !ok {
+		return Operation{}, fmt.Errorf("%s: %w", id, ErrUnknownOperation)
+	}
+	if op.Status == StatusApplied {
+		if status == StatusApplied && op.Result == result {
+			return op.clone(), nil // duplicate acknowledgment deduplicates
+		}
+		return Operation{}, fmt.Errorf("%s is Applied: %w", id, ErrResultRegression)
+	}
+	last := op.Attempts[len(op.Attempts)-1]
+	if last.Epoch != epoch {
+		return Operation{}, fmt.Errorf("%s latest attempt epoch %d, presented %d: %w",
+			id, last.Epoch, epoch, ErrResultRegression)
+	}
+	work := op.clone()
+	work.Status = status
+	work.Attempts[len(work.Attempts)-1].Outcome = attemptOutcome(status)
+	if result != "" {
+		work.Result = result
+	}
+	work.UpdatedAt = now
+	return j.commit(id, work)
+}
+
+// ExternalState is one authoritative observation of whether the effect took
+// place, produced by querying the external system itself (for EffectCreatePR:
+// the existing open-PR-by-head lookup CreatePR already performs).
+type ExternalState struct {
+	// Known reports whether the observation was authoritative.
+	Known bool
+	// Applied reports, when Known, whether the effect exists externally.
+	Applied bool
+	// Result is bounded provenance of the found effect (PR URL/number).
+	Result string
+}
+
+// Reconcile resolves the SAME logical operation after timeout, crash,
+// restart, or reassignment, from current authoritative external state —
+// BEFORE any retry:
+//
+//   - Known+Applied  → StatusApplied, recording the exact found effect,
+//     WITHOUT repeating it;
+//   - Known+!Applied → StatusNotApplied, authorizing a retry attempt through
+//     Begin under the current epoch;
+//   - !Known         → StatusUnknown: no duplicate retry is authorized.
+//
+// Reconciliation may be performed by any current owner (adoption); it never
+// regresses an Applied entry to NotApplied — terminal truth stands, and a
+// disagreeing later observation is a refusal, not a rewrite.
+func (j *Journal) Reconcile(id string, state ExternalState, now time.Time) (Operation, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	op, ok := j.ops[id]
+	if !ok {
+		return Operation{}, fmt.Errorf("%s: %w", id, ErrUnknownOperation)
+	}
+	if op.Status == StatusApplied {
+		if state.Known && !state.Applied {
+			return Operation{}, fmt.Errorf("%s is Applied but external state disagrees: %w", id, ErrResultRegression)
+		}
+		return op.clone(), nil
+	}
+	work := op.clone()
+	switch {
+	case state.Known && state.Applied:
+		work.Status = StatusApplied
+		if state.Result != "" {
+			work.Result = state.Result
+		}
+	case state.Known:
+		work.Status = StatusNotApplied
+	default:
+		work.Status = StatusUnknown
+	}
+	if n := len(work.Attempts); n > 0 && work.Attempts[n-1].Outcome == "" {
+		work.Attempts[n-1].Outcome = attemptOutcome(work.Status)
+	}
+	work.UpdatedAt = now
+	return j.commit(id, work)
+}
+
+func attemptOutcome(status string) string {
+	switch status {
+	case StatusApplied:
+		return "applied"
+	case StatusNotApplied:
+		return "not-applied"
+	default:
+		return "unknown"
+	}
+}
+
+// commit installs the updated operation and persists atomically, rolling back
+// the in-memory index when the durable write fails. Callers hold j.mu.
+func (j *Journal) commit(id string, work Operation) (Operation, error) {
+	prior, hadPrior := j.ops[id]
+	cp := work.clone()
+	j.ops[id] = &cp
+	if err := j.persistLocked(); err != nil {
+		if hadPrior {
+			j.ops[id] = prior
+		} else {
+			delete(j.ops, id)
+		}
+		return Operation{}, err
+	}
+	return work.clone(), nil
+}
+
+func (j *Journal) persistLocked() error {
+	all := make([]Operation, 0, len(j.ops))
+	for _, op := range j.ops {
+		all = append(all, op.clone())
+	}
+	sort.Slice(all, func(i, k int) bool { return all[i].LogicalID < all[k].LogicalID })
+	data, err := json.MarshalIndent(persistedJournal{Version: journalFormatVersion, Operations: all}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling mutation journal: %w", err)
+	}
+	tmpPath := j.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, journalFileMode); err != nil {
+		return fmt.Errorf("writing tmp mutation journal: %w", err)
+	}
+	return os.Rename(tmpPath, j.path)
+}

--- a/src/pkg/convergence/mutation/journal_test.go
+++ b/src/pkg/convergence/mutation/journal_test.go
@@ -1,0 +1,258 @@
+package mutation
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o660)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func openJournal(t *testing.T) *Journal {
+	t.Helper()
+	j, err := OpenJournal(filepath.Join(t.TempDir(), "journal.json"))
+	if err != nil {
+		t.Fatalf("OpenJournal: %v", err)
+	}
+	return j
+}
+
+// Row: crash after intent, before the effect — replay finds the same logical
+// operation; reconciliation to NotApplied authorizes at most one retry.
+func TestJournal_CrashBeforeEffect_ReconcilesThenRetries(t *testing.T) {
+	j := openJournal(t)
+	e := testEffect()
+	now := time.Now()
+
+	op, err := j.Begin(e, 1, "alice", now)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if op.Status != StatusPlanned || len(op.Attempts) != 1 {
+		t.Fatalf("intent must be durable before the effect: %+v", op)
+	}
+	// Replay (same or new owner) finds the SAME entry and may not blindly
+	// retry: the unresolved attempt demands reconciliation first.
+	if _, err := j.Begin(e, 2, "bob", now); !errors.Is(err, ErrNeedsReconciliation) {
+		t.Fatalf("unresolved operation must demand reconciliation: %v", err)
+	}
+	// Authoritative external state: the effect never happened.
+	if _, err := j.Reconcile(op.LogicalID, ExternalState{Known: true, Applied: false}, now); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	// Now exactly one retry proceeds — under the new epoch, same logical ID.
+	retried, err := j.Begin(e, 2, "bob", now)
+	if err != nil {
+		t.Fatalf("post-reconciliation retry: %v", err)
+	}
+	if retried.LogicalID != op.LogicalID || len(retried.Attempts) != 2 {
+		t.Fatalf("retry must adopt the same logical operation: %+v", retried)
+	}
+}
+
+// Row: crash after the effect, before acknowledgment — reconciliation finds
+// the exact effect and records Applied WITHOUT repeating it; the duplicate
+// retry is then refused.
+func TestJournal_CrashAfterEffect_ReconcilesToAppliedWithoutDuplicate(t *testing.T) {
+	j := openJournal(t)
+	e := testEffect()
+	now := time.Now()
+
+	op, err := j.Begin(e, 1, "alice", now)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	// External query finds the PR that the crashed process actually created.
+	rec, err := j.Reconcile(op.LogicalID, ExternalState{Known: true, Applied: true, Result: "acme/widgets#101"}, now)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if rec.Status != StatusApplied || rec.Result != "acme/widgets#101" {
+		t.Fatalf("reconciliation must record the found effect: %+v", rec)
+	}
+	// Any retry of the same desired effect — any owner, any epoch — is refused.
+	if _, err := j.Begin(e, 9, "carol", now); !errors.Is(err, ErrAlreadyApplied) {
+		t.Fatalf("applied operation must never run twice: %v", err)
+	}
+}
+
+// Row: ambiguous external state — the operation stays Unknown and no
+// duplicate retry is authorized; an unrelated operation remains available.
+func TestJournal_AmbiguousReconciliationBlocksRetryLocally(t *testing.T) {
+	j := openJournal(t)
+	e := testEffect()
+	now := time.Now()
+	op, _ := j.Begin(e, 1, "alice", now)
+	if _, err := j.Reconcile(op.LogicalID, ExternalState{Known: false}, now); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, err := j.Begin(e, 2, "bob", now); !errors.Is(err, ErrNeedsReconciliation) {
+		t.Fatalf("unknown operation must not retry: %v", err)
+	}
+	// Positive control: a DISJOINT effect proceeds.
+	other := testEffect()
+	other.Subject = "acme/widgets#9"
+	other.ClaimKey = TaskClaim("acme/widgets", "acme/widgets#9").Key()
+	if _, err := j.Begin(other, 1, "bob", now); err != nil {
+		t.Fatalf("unrelated effect must remain available: %v", err)
+	}
+}
+
+// Row: duplicate/out-of-order results cannot regress terminal truth, and an
+// old epoch cannot overwrite the current attempt's result.
+func TestJournal_ResultsCannotRegressOrCrossEpochs(t *testing.T) {
+	j := openJournal(t)
+	e := testEffect()
+	now := time.Now()
+	op, _ := j.Begin(e, 1, "alice", now)
+
+	// Uncertain first attempt, reconciled NotApplied, retried at epoch 2.
+	if _, err := j.RecordResult(op.LogicalID, 1, StatusUnknown, "", now); err != nil {
+		t.Fatalf("record unknown: %v", err)
+	}
+	if _, err := j.Reconcile(op.LogicalID, ExternalState{Known: true, Applied: false}, now); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if _, err := j.Begin(e, 2, "bob", now); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	// A LATE result from the fenced epoch-1 attempt may not overwrite.
+	if _, err := j.RecordResult(op.LogicalID, 1, StatusApplied, "stale", now); !errors.Is(err, ErrResultRegression) {
+		t.Fatalf("old epoch result must be refused: %v", err)
+	}
+	// Epoch 2 applies.
+	rec, err := j.RecordResult(op.LogicalID, 2, StatusApplied, "acme/widgets#101", now)
+	if err != nil || rec.Status != StatusApplied {
+		t.Fatalf("current epoch result: %+v %v", rec, err)
+	}
+	// The identical duplicate acknowledgment deduplicates...
+	if _, err := j.RecordResult(op.LogicalID, 2, StatusApplied, "acme/widgets#101", now); err != nil {
+		t.Fatalf("duplicate ack must deduplicate: %v", err)
+	}
+	// ...but nothing regresses Applied.
+	if _, err := j.RecordResult(op.LogicalID, 2, StatusUnknown, "", now); !errors.Is(err, ErrResultRegression) {
+		t.Fatalf("terminal truth must not regress: %v", err)
+	}
+	if _, err := j.Reconcile(op.LogicalID, ExternalState{Known: true, Applied: false}, now); !errors.Is(err, ErrResultRegression) {
+		t.Fatalf("disagreeing reconciliation is a refusal, not a rewrite: %v", err)
+	}
+	// A benign re-reconciliation of an Applied entry is a no-op.
+	if rec, err := j.Reconcile(op.LogicalID, ExternalState{Known: true, Applied: true}, now); err != nil || rec.Status != StatusApplied {
+		t.Fatalf("idempotent reconcile: %+v %v", rec, err)
+	}
+}
+
+// Row: restart — journal and pending reconciliation reconstruct from durable
+// state alone.
+func TestJournal_RestartReconstructs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "journal.json")
+	j, err := OpenJournal(path)
+	if err != nil {
+		t.Fatalf("OpenJournal: %v", err)
+	}
+	e := testEffect()
+	now := time.Now()
+	op, _ := j.Begin(e, 1, "alice", now)
+
+	reopened, err := OpenJournal(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got, ok := reopened.Get(op.LogicalID)
+	if !ok || got.Status != StatusPlanned || len(got.Attempts) != 1 {
+		t.Fatalf("pending operation must reconstruct: %+v ok=%v", got, ok)
+	}
+	// The reconstructed entry still demands reconciliation before retry.
+	if _, err := reopened.Begin(e, 2, "bob", now); !errors.Is(err, ErrNeedsReconciliation) {
+		t.Fatalf("restart must not authorize a blind retry: %v", err)
+	}
+}
+
+// Row: corrupt journal refuses visibly; a forged entry (id not derived from
+// its effect) refuses too.
+func TestJournal_CorruptAndForgedRefuse(t *testing.T) {
+	dir := t.TempDir()
+	corrupt := filepath.Join(dir, "corrupt.json")
+	if err := writeFile(corrupt, "]["); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenJournal(corrupt); err == nil {
+		t.Fatal("corrupt journal must refuse")
+	}
+
+	forged := filepath.Join(dir, "forged.json")
+	e := testEffect()
+	body := fmt.Sprintf(`{"version":1,"operations":[{"logical_id":"op:forged","effect":{"outcome_key":%q,"desired_generation":1,"transition":%q,"subject":%q,"claim_key":%q,"kind":%q,"inputs":{"repo":"acme/widgets"}},"status":"Applied","attempts":[],"updated_at":"2026-08-20T00:00:00Z"}]}`,
+		e.OutcomeKey, e.Transition, e.Subject, e.ClaimKey, e.Kind)
+	if err := writeFile(forged, body); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenJournal(forged); err == nil {
+		t.Fatal("an entry whose id does not derive from its effect must refuse")
+	}
+}
+
+// Row: two journal writers race — the per-ID serialization produces one
+// deterministic record; run under -race.
+func TestJournal_ConcurrentWritersSerialize(t *testing.T) {
+	j := openJournal(t)
+	e := testEffect()
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	begins := make(chan Operation, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			if op, err := j.Begin(e, uint64(n+1), fmt.Sprintf("h%d", n), now); err == nil {
+				begins <- op
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(begins)
+	count := 0
+	for range begins {
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("exactly one Begin must win for one logical operation, got %d", count)
+	}
+	got, ok := j.Get(e.LogicalID())
+	if !ok || len(got.Attempts) != 1 {
+		t.Fatalf("one deterministic record: %+v", got)
+	}
+}
+
+func TestJournal_UnknownOperationRefusals(t *testing.T) {
+	j := openJournal(t)
+	now := time.Now()
+	if _, err := j.RecordResult("op:none", 1, StatusApplied, "", now); !errors.Is(err, ErrUnknownOperation) {
+		t.Fatalf("unknown record: %v", err)
+	}
+	if _, err := j.Reconcile("op:none", ExternalState{Known: true}, now); !errors.Is(err, ErrUnknownOperation) {
+		t.Fatalf("unknown reconcile: %v", err)
+	}
+	if _, err := j.RecordResult("op:none", 1, "Bogus", "", now); !errors.Is(err, ErrInvalidEffect) {
+		t.Fatalf("bogus status: %v", err)
+	}
+	if _, err := j.Begin(Effect{}, 1, "alice", now); !errors.Is(err, ErrInvalidEffect) {
+		t.Fatalf("invalid effect: %v", err)
+	}
+}

--- a/src/pkg/convergence/mutation/ledger.go
+++ b/src/pkg/convergence/mutation/ledger.go
@@ -1,0 +1,309 @@
+package mutation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Claim lifecycle states, exactly the accepted #4255 lifecycle.
+const (
+	// StateActiveMutation: the holder owns the resource at the entry's epoch
+	// and consumes one mutation-writer slot. The ONLY state that may
+	// authorize an external effect.
+	StateActiveMutation = "ActiveMutation"
+	// StateWaiting: the holder entered a CI/review/publication/external or
+	// human-decision wait. Capacity is released and the epoch is fenced the
+	// moment this state is entered; any further mutation requires
+	// reacquisition at a strictly higher epoch.
+	StateWaiting = "Waiting"
+	// StateReleased: complete/abandon/revoke/expiry. The entry is retained
+	// with its final epoch for fencing history; the slot is freed.
+	StateReleased = "Released"
+)
+
+// Sentinel errors; callers match with errors.Is.
+var (
+	// ErrClaimHeld: an overlapping claim is actively held; the waiter
+	// consumes no capacity and simply does not acquire.
+	ErrClaimHeld = errors.New("an overlapping mutation claim is actively held")
+	// ErrNoCapacity: the repository's mutation-writer slots are all consumed.
+	ErrNoCapacity = errors.New("no mutation-writer capacity is available")
+	// ErrStaleEpoch: the presented epoch is not the entry's current epoch, or
+	// the entry is not in a state that epoch may act in. Every stale-owner
+	// mutation, progress, completion, and acknowledgment attempt lands here.
+	ErrStaleEpoch = errors.New("stale mutation epoch is fenced")
+	// ErrInvalidClaim: the claim fails Validate and can never be held.
+	ErrInvalidClaim = errors.New("mutation claim is invalid")
+)
+
+// ledgerFileMode matches the outcome/proof/beads persistence idiom.
+const ledgerFileMode = 0o660
+
+// ledgerFormatVersion is the persisted schema version.
+const ledgerFormatVersion = 1
+
+// DefaultMaxWritersPerRepo is the accepted default capacity: one
+// mutation-writer slot per canonical repository.
+const DefaultMaxWritersPerRepo = 1
+
+// Entry is one durable claim record: the canonical claim, its holder, its
+// monotonic epoch (per key, never reused — it survives Released and Waiting
+// so a reacquisition is ALWAYS strictly higher), its lifecycle state, and its
+// window.
+type Entry struct {
+	Claim  Claim  `json:"claim"`
+	Holder string `json:"holder"`
+	// Epoch increases monotonically per claim key on every acquisition and
+	// reacquisition. It is the C2 fencing token.
+	Epoch      uint64    `json:"epoch"`
+	State      string    `json:"state"`
+	AcquiredAt time.Time `json:"acquired_at"`
+	ExpiresAt  time.Time `json:"expires_at"`
+}
+
+// persistedLedger is the on-disk shape.
+type persistedLedger struct {
+	Version int     `json:"version"`
+	Entries []Entry `json:"entries"`
+}
+
+// Ledger is the durable claim/lease owner: an in-memory index over one JSON
+// file, reloaded on boot, rewritten atomically on every accepted transition.
+// Process memory is never authority — restart reconstruction IS the file.
+// Every transition is a CAS on {key, expected epoch, expected state} under
+// the ledger mutex, which is the accepted serialization rule for racing
+// acquirers: one deterministic winner, no interleaved bytes.
+type Ledger struct {
+	path       string
+	maxWriters int
+	mu         sync.Mutex
+	entries    map[string]*Entry
+}
+
+// OpenLedger loads the claim ledger at path, creating an empty one when the
+// file does not exist. maxWritersPerRepo <= 0 selects the accepted default.
+// A file that exists but cannot be parsed or validated is a REFUSAL: the
+// bytes are left exactly as found for inspection and no handle exists through
+// which a write could replace them — corrupt durable ownership must be
+// visible and can never silently reset (the accepted #4249/#4251 failure
+// behavior).
+//
+// Restart reconciliation: an entry read back in ActiveMutation whose window
+// expired while the process was down reconciles to Waiting — fenced, never
+// silently Released, never re-authorized at the old epoch.
+func OpenLedger(path string, maxWritersPerRepo int) (*Ledger, error) {
+	if maxWritersPerRepo <= 0 {
+		maxWritersPerRepo = DefaultMaxWritersPerRepo
+	}
+	l := &Ledger{path: path, maxWriters: maxWritersPerRepo, entries: make(map[string]*Entry)}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return l, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading mutation claim ledger %s: %w", path, err)
+	}
+	var persisted persistedLedger
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return nil, fmt.Errorf("mutation claim ledger %s is unparseable and is left untouched for inspection: %w", path, err)
+	}
+	for i := range persisted.Entries {
+		e := persisted.Entries[i]
+		if err := e.Claim.Validate(); err != nil {
+			return nil, fmt.Errorf("mutation claim ledger %s holds an invalid claim: %w", path, err)
+		}
+		key := e.Claim.Key()
+		if _, dup := l.entries[key]; dup {
+			return nil, fmt.Errorf("mutation claim ledger %s holds conflicting entries for %s", path, key)
+		}
+		cp := e
+		l.entries[key] = &cp
+	}
+	return l, nil
+}
+
+// reconcileExpiredLocked fences an ActiveMutation entry whose window has
+// passed: it moves to Waiting at its OWN epoch (retained for history), so the
+// old owner is fenced and the slot is freed, but ownership is never silently
+// released. Callers hold l.mu.
+func (l *Ledger) reconcileExpiredLocked(now time.Time) {
+	for _, e := range l.entries {
+		if e.State == StateActiveMutation && now.After(e.ExpiresAt) {
+			e.State = StateWaiting
+		}
+	}
+}
+
+// activeWritersLocked counts consumed mutation-writer slots in a repo:
+// ONLY ActiveMutation consumes; Waiting and Released are structural zeros.
+func (l *Ledger) activeWritersLocked(repo string) int {
+	n := 0
+	for _, e := range l.entries {
+		if e.State == StateActiveMutation && e.Claim.Repo == repo {
+			n++
+		}
+	}
+	return n
+}
+
+// Acquire takes (or retakes) a claim for holder, minting a strictly higher
+// epoch than the key has ever carried. The rules, in order:
+//
+//  1. An invalid claim can never be held.
+//  2. Any actively held overlapping claim refuses acquisition (ErrClaimHeld):
+//     exactly one owner per overlap set. The refused acquirer consumes no
+//     capacity — it simply does not acquire.
+//  3. A repo with all writer slots consumed refuses (ErrNoCapacity), unless
+//     the acquisition is the reacquisition of this exact key (its own prior
+//     hold is the one being replaced).
+//  4. Otherwise the entry moves to ActiveMutation at epoch prev+1, persisted
+//     before the grant is returned (durable-before-authoritative).
+func (l *Ledger) Acquire(c Claim, holder string, ttl time.Duration, now time.Time) (Entry, error) {
+	if err := c.Validate(); err != nil {
+		return Entry{}, fmt.Errorf("%w: %v", ErrInvalidClaim, err)
+	}
+	if holder == "" {
+		return Entry{}, fmt.Errorf("%w: a claim requires a holder identity", ErrInvalidClaim)
+	}
+	key := c.Key()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.reconcileExpiredLocked(now)
+
+	for otherKey, e := range l.entries {
+		if e.State != StateActiveMutation {
+			continue
+		}
+		if otherKey == key {
+			return Entry{}, fmt.Errorf("%s is actively held by %s at epoch %d: %w", key, e.Holder, e.Epoch, ErrClaimHeld)
+		}
+		if e.Claim.Overlaps(c) {
+			return Entry{}, fmt.Errorf("%s overlaps active %s (held by %s at epoch %d): %w",
+				key, otherKey, e.Holder, e.Epoch, ErrClaimHeld)
+		}
+	}
+	if l.activeWritersLocked(c.Repo) >= l.maxWriters {
+		return Entry{}, fmt.Errorf("repo %s writers exhausted (max %d): %w", c.Repo, l.maxWriters, ErrNoCapacity)
+	}
+
+	var prevEpoch uint64
+	if prior, ok := l.entries[key]; ok {
+		prevEpoch = prior.Epoch
+	}
+	next := &Entry{
+		Claim:      c,
+		Holder:     holder,
+		Epoch:      prevEpoch + 1,
+		State:      StateActiveMutation,
+		AcquiredAt: now,
+		ExpiresAt:  now.Add(ttl),
+	}
+	prior, hadPrior := l.entries[key]
+	l.entries[key] = next
+	if err := l.persistLocked(); err != nil {
+		if hadPrior {
+			l.entries[key] = prior
+		} else {
+			delete(l.entries, key)
+		}
+		return Entry{}, err
+	}
+	return *next, nil
+}
+
+// transitionLocked applies one CAS state transition for key at expectedEpoch.
+func (l *Ledger) transition(key string, expectedEpoch uint64, from map[string]bool, to string, now time.Time) (Entry, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.reconcileExpiredLocked(now)
+	e, ok := l.entries[key]
+	if !ok || e.Epoch != expectedEpoch || !from[e.State] {
+		return Entry{}, fmt.Errorf("%s: expected epoch %d in %v: %w", key, expectedEpoch, keysOf(from), ErrStaleEpoch)
+	}
+	priorState := e.State
+	e.State = to
+	if err := l.persistLocked(); err != nil {
+		e.State = priorState
+		return Entry{}, err
+	}
+	return *e, nil
+}
+
+// Wait moves an active hold into the Waiting state: the writer slot is freed
+// and the epoch is fenced — before another mutation the holder MUST
+// reacquire, which mints a strictly higher epoch.
+func (l *Ledger) Wait(key string, expectedEpoch uint64, now time.Time) (Entry, error) {
+	return l.transition(key, expectedEpoch, map[string]bool{StateActiveMutation: true}, StateWaiting, now)
+}
+
+// Release retires a hold on any release path (complete, abandon, revoke).
+// The entry is retained with its final epoch for fencing history.
+func (l *Ledger) Release(key string, expectedEpoch uint64, now time.Time) (Entry, error) {
+	return l.transition(key, expectedEpoch,
+		map[string]bool{StateActiveMutation: true, StateWaiting: true}, StateReleased, now)
+}
+
+// ValidateEpoch reports whether epoch is the CURRENT authorized epoch for
+// key: the entry exists, is in ActiveMutation, is unexpired, and carries
+// exactly this epoch. This is the check the executor applies at the actual
+// mutation boundary and again before acknowledgment. Duplicate or
+// out-of-order commands cannot manufacture authority: the answer is computed
+// from current durable state, never from the caller's history.
+func (l *Ledger) ValidateEpoch(key string, epoch uint64, now time.Time) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.reconcileExpiredLocked(now)
+	e, ok := l.entries[key]
+	if !ok {
+		return fmt.Errorf("%s has no claim entry: %w", key, ErrStaleEpoch)
+	}
+	if e.State != StateActiveMutation {
+		return fmt.Errorf("%s is %s, not actively held: %w", key, e.State, ErrStaleEpoch)
+	}
+	if e.Epoch != epoch {
+		return fmt.Errorf("%s current epoch is %d, presented %d: %w", key, e.Epoch, epoch, ErrStaleEpoch)
+	}
+	return nil
+}
+
+// Get returns a copy of the entry stored under key.
+func (l *Ledger) Get(key string) (Entry, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e, ok := l.entries[key]
+	if !ok {
+		return Entry{}, false
+	}
+	return *e, true
+}
+
+func (l *Ledger) persistLocked() error {
+	all := make([]Entry, 0, len(l.entries))
+	for _, e := range l.entries {
+		all = append(all, *e)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].Claim.Key() < all[j].Claim.Key() })
+	data, err := json.MarshalIndent(persistedLedger{Version: ledgerFormatVersion, Entries: all}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling mutation claim ledger: %w", err)
+	}
+	tmpPath := l.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, ledgerFileMode); err != nil {
+		return fmt.Errorf("writing tmp mutation claim ledger: %w", err)
+	}
+	return os.Rename(tmpPath, l.path)
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/src/pkg/convergence/mutation/ledger_test.go
+++ b/src/pkg/convergence/mutation/ledger_test.go
@@ -1,0 +1,247 @@
+package mutation
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+const ttl = time.Hour
+
+func openLedger(t *testing.T) *Ledger {
+	t.Helper()
+	l, err := OpenLedger(filepath.Join(t.TempDir(), "claims.json"), 0)
+	if err != nil {
+		t.Fatalf("OpenLedger: %v", err)
+	}
+	return l
+}
+
+// Row: two claimants race — one epoch wins; the loser cannot mutate.
+func TestLedger_TwoClaimantsRace_OneEpochWins(t *testing.T) {
+	l := openLedger(t)
+	c := TaskClaim("acme/widgets", "acme/widgets#7")
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	wins := make(chan Entry, 2)
+	for _, holder := range []string{"alice", "bob"} {
+		wg.Add(1)
+		go func(h string) {
+			defer wg.Done()
+			if g, err := l.Acquire(c, h, ttl, now); err == nil {
+				wins <- g
+			}
+		}(holder)
+	}
+	wg.Wait()
+	close(wins)
+	var grants []Entry
+	for g := range wins {
+		grants = append(grants, g)
+	}
+	if len(grants) != 1 {
+		t.Fatalf("exactly one claimant must win, got %d", len(grants))
+	}
+	if err := l.ValidateEpoch(c.Key(), grants[0].Epoch, now); err != nil {
+		t.Fatalf("winner's epoch must validate: %v", err)
+	}
+}
+
+// Row: overlap — a repo-top claim conflicts with any narrower claim; disjoint
+// claims proceed concurrently as the positive control... except when the
+// writer capacity (default 1 per repo) is consumed, in which case the second
+// same-repo writer waits WITHOUT consuming capacity.
+func TestLedger_OverlapAndCapacity(t *testing.T) {
+	// Capacity 2 so overlap (not capacity) is what refuses the top claim.
+	l, err := OpenLedger(filepath.Join(t.TempDir(), "claims.json"), 2)
+	if err != nil {
+		t.Fatalf("OpenLedger: %v", err)
+	}
+	now := time.Now()
+	task7 := TaskClaim("acme/widgets", "acme/widgets#7")
+	task9 := TaskClaim("acme/widgets", "acme/widgets#9")
+	other := TaskClaim("acme/gadgets", "acme/gadgets#1")
+
+	if _, err := l.Acquire(task7, "alice", ttl, now); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if _, err := l.Acquire(RepoClaim("acme/widgets"), "carol", ttl, now); !errors.Is(err, ErrClaimHeld) {
+		t.Fatalf("repo-top claim must conflict with a held task claim: %v", err)
+	}
+	if _, err := l.Acquire(task9, "bob", ttl, now); err != nil {
+		t.Fatalf("disjoint same-repo claim within capacity must proceed: %v", err)
+	}
+	if _, err := l.Acquire(other, "dave", ttl, now); err != nil {
+		t.Fatalf("disjoint other-repo claim must proceed: %v", err)
+	}
+	// Both widgets slots consumed now: a third disjoint claim is a capacity
+	// wait, not an overlap conflict.
+	task11 := TaskClaim("acme/widgets", "acme/widgets#11")
+	if _, err := l.Acquire(task11, "erin", ttl, now); !errors.Is(err, ErrNoCapacity) {
+		t.Fatalf("exhausted writer slots must refuse with ErrNoCapacity: %v", err)
+	}
+}
+
+// Row: a repo-top hold blocks every narrower claim in that repo.
+func TestLedger_TopClaimBlocksNarrower(t *testing.T) {
+	l := openLedger(t)
+	now := time.Now()
+	if _, err := l.Acquire(RepoClaim("acme/widgets"), "release-bot", ttl, now); err != nil {
+		t.Fatalf("acquire top: %v", err)
+	}
+	if _, err := l.Acquire(TaskClaim("acme/widgets", "acme/widgets#7"), "alice", ttl, now); !errors.Is(err, ErrClaimHeld) {
+		t.Fatalf("narrow claim must not bypass the top claim: %v", err)
+	}
+	// Unrelated repo proceeds: reject-everything control.
+	if _, err := l.Acquire(TaskClaim("acme/gadgets", "acme/gadgets#1"), "bob", ttl, now); err != nil {
+		t.Fatalf("unrelated repo must proceed: %v", err)
+	}
+}
+
+// Row: waiting releases capacity and fences the epoch; reacquisition mints a
+// strictly higher epoch; every stale-epoch action is fenced.
+func TestLedger_WaitReleasesCapacityAndFences(t *testing.T) {
+	l := openLedger(t)
+	now := time.Now()
+	c := TaskClaim("acme/widgets", "acme/widgets#7")
+	g1, err := l.Acquire(c, "alice", ttl, now)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	// Enter CI/review wait: slot freed, epoch fenced.
+	if _, err := l.Wait(c.Key(), g1.Epoch, now); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if err := l.ValidateEpoch(c.Key(), g1.Epoch, now); !errors.Is(err, ErrStaleEpoch) {
+		t.Fatalf("a waiting hold must not authorize mutation: %v", err)
+	}
+	// The freed slot is usable by a disjoint claim (waiters consume nothing).
+	gBob, err := l.Acquire(TaskClaim("acme/widgets", "acme/widgets#9"), "bob", ttl, now)
+	if err != nil {
+		t.Fatalf("freed capacity must be available: %v", err)
+	}
+	if _, err := l.Release(TaskClaim("acme/widgets", "acme/widgets#9").Key(), gBob.Epoch, now); err != nil {
+		t.Fatalf("release bob: %v", err)
+	}
+	if _, err := l.Release(c.Key()+"", g1.Epoch, now); err == nil {
+		// Release from Waiting is allowed at the SAME epoch (it is the
+		// recorded epoch), so this must succeed.
+	} else {
+		t.Fatalf("release from waiting: %v", err)
+	}
+
+	// Reacquire: strictly higher epoch; the old epoch stays fenced forever.
+	g2, err := l.Acquire(c, "alice", ttl, now)
+	if err != nil {
+		t.Fatalf("reacquire: %v", err)
+	}
+	if g2.Epoch <= g1.Epoch {
+		t.Fatalf("reacquisition must mint a strictly higher epoch: %d then %d", g1.Epoch, g2.Epoch)
+	}
+	if err := l.ValidateEpoch(c.Key(), g1.Epoch, now); !errors.Is(err, ErrStaleEpoch) {
+		t.Fatalf("old epoch must remain fenced: %v", err)
+	}
+	if err := l.ValidateEpoch(c.Key(), g2.Epoch, now); err != nil {
+		t.Fatalf("current epoch must validate: %v", err)
+	}
+	// A stale-epoch state transition is fenced too.
+	if _, err := l.Wait(c.Key(), g1.Epoch, now); !errors.Is(err, ErrStaleEpoch) {
+		t.Fatalf("stale wait must be fenced: %v", err)
+	}
+}
+
+// Row: lease expiry — the expired hold is fenced (Waiting, never silently
+// Released) and the replacement receives a strictly higher epoch.
+func TestLedger_ExpiryFencesAndReplacementIsHigher(t *testing.T) {
+	l := openLedger(t)
+	now := time.Now()
+	c := TaskClaim("acme/widgets", "acme/widgets#7")
+	g1, err := l.Acquire(c, "alice", time.Minute, now)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	later := now.Add(2 * time.Minute)
+	if err := l.ValidateEpoch(c.Key(), g1.Epoch, later); !errors.Is(err, ErrStaleEpoch) {
+		t.Fatalf("expired hold must be fenced: %v", err)
+	}
+	e, _ := l.Get(c.Key())
+	if e.State != StateWaiting {
+		t.Fatalf("expiry reconciles to Waiting (fenced), never silent release: %s", e.State)
+	}
+	g2, err := l.Acquire(c, "bob", ttl, later)
+	if err != nil {
+		t.Fatalf("replacement acquire: %v", err)
+	}
+	if g2.Epoch <= g1.Epoch {
+		t.Fatalf("replacement epoch must be strictly higher")
+	}
+}
+
+// Row: restart — claim, epoch, and state reconstruct from durable state; an
+// entry active at shutdown whose window lapsed reconciles fenced.
+func TestLedger_RestartReconstructs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claims.json")
+	l, err := OpenLedger(path, 0)
+	if err != nil {
+		t.Fatalf("OpenLedger: %v", err)
+	}
+	now := time.Now()
+	c := TaskClaim("acme/widgets", "acme/widgets#7")
+	g, err := l.Acquire(c, "alice", time.Minute, now)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	reopened, err := OpenLedger(path, 0)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if err := reopened.ValidateEpoch(c.Key(), g.Epoch, now); err != nil {
+		t.Fatalf("fresh hold must survive restart: %v", err)
+	}
+	// After the window lapses across a restart, the old owner is fenced and
+	// a replacement mints a higher epoch — process memory was never authority.
+	later := now.Add(2 * time.Minute)
+	if err := reopened.ValidateEpoch(c.Key(), g.Epoch, later); !errors.Is(err, ErrStaleEpoch) {
+		t.Fatalf("lapsed hold must be fenced after restart: %v", err)
+	}
+	g2, err := reopened.Acquire(c, "bob", ttl, later)
+	if err != nil {
+		t.Fatalf("post-restart reacquire: %v", err)
+	}
+	if g2.Epoch <= g.Epoch {
+		t.Fatalf("epoch monotonicity must survive restart")
+	}
+}
+
+// Row: corrupt durable ownership refuses visibly; the bytes stay untouched.
+func TestLedger_CorruptFileRefuses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claims.json")
+	if err := writeFile(path, "{not json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenLedger(path, 0); err == nil {
+		t.Fatal("corrupt ledger must refuse to open")
+	}
+	if got := readFile(t, path); got != "{not json" {
+		t.Fatalf("corrupt bytes must be left for inspection, got %q", got)
+	}
+}
+
+func TestLedger_InvalidClaimAndHolderRefused(t *testing.T) {
+	l := openLedger(t)
+	now := time.Now()
+	if _, err := l.Acquire(Claim{}, "alice", ttl, now); !errors.Is(err, ErrInvalidClaim) {
+		t.Fatalf("invalid claim: %v", err)
+	}
+	if _, err := l.Acquire(RepoClaim("acme/widgets"), "", ttl, now); !errors.Is(err, ErrInvalidClaim) {
+		t.Fatalf("empty holder: %v", err)
+	}
+	if err := l.ValidateEpoch("mutation:acme/none", 1, now); !errors.Is(err, ErrStaleEpoch) {
+		t.Fatalf("unknown key can never authorize: %v", err)
+	}
+}


### PR DESCRIPTION
Implements #4256 (parent epic #3845) exactly per the **accepted #4255 decision packet**: mutation class = contributor task-lease-backed repository mutations; typed semantic resource keys with the closed `{repo, task}` type set and the accepted overlap algebra (equal keys conflict, the repo-wide top claim conflicts with all claims in that repo, everything else disjoint); per-repo mutation-writer capacity consumed only in `ActiveMutation`; and ONE external effect named by the C2 binding — GitHub PR creation for the assigned task (`github.create-pr/v1`).

## What

- **Durable claim ledger** (`pkg/convergence/mutation`): claim/lease owner with a monotonically increasing per-claim **epoch** (never reused; survives `Waiting`/`Released` and restarts), CAS state transitions, atomic tmp+rename persistence, corrupt-file refusal. Waiting (CI/review/publication/human decision) frees the writer slot and **fences the epoch**; reacquisition always mints strictly higher; expiry reconciles to `Waiting` — fenced, never silently released.
- **Idempotent operation journal**: logical operation ID derived from `{OutcomeRef key, desired generation, transition, exact subject, canonical claim key, effect kind, all effect inputs}` — owner and epoch deliberately **excluded** from the ID and recorded per-attempt inside the entry, so retry/restart/reassignment always finds the same entry and a replacement owner **adopts** rather than duplicates. Intent persisted durably **before** the effect; `Applied` is terminal (duplicate acks deduplicate; stale-epoch or out-of-order results refused); uncertain effects demand reconciliation against authoritative external state before any retry.
- **Fenced executor** at the actual mutation boundary: epoch validated before the effect AND again before authoritative acknowledgment; a mid-flight ownership change records `Unknown` for the new owner to reconcile — never a duplicate. Existing `CreatePR` dedupe/422-recovery and exact-head merge guards remain mandatory defense-in-depth the journal never replaces.

## Strict RED matrix coverage (-race)

Two-claimant race yields one epoch · top-claim/overlap/capacity rows with disjoint positive controls · waiting releases capacity and fences · expiry/replacement strictly-higher epoch · stale-owner mutation AND acknowledgment fenced at the real boundary · crash-before-effect replays the same logical operation · crash-after-effect reconciles to `Applied` without repeating · ambiguous external state blocks retry locally while unrelated effects proceed · stale-epoch/out-of-order results cannot regress terminal truth · restart reconstructs ledger, journal, and pending reconciliation · concurrent writers serialize deterministically · mode-inertness rows.

## Default-off

Inert at `convergence.mode=off` (transparent passthrough — no ledger or journal exists); shadow records and reports but never fences; only exact `enforce` withholds. No second mutation class, no generic transaction engine, no parallel queue or admission authority. `pkg/convergence/mutation`: 91.7% coverage, race-clean.

Closes #4256
Part of #3845