### PR TITLE
test(deploy): compare the Docker and Podman deployment contracts (#4404)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -132,6 +132,21 @@ jobs:
       - name: Quadlet config-coupling contract (#4367)
         run: bash deploy/test_quadlet_config_contract.sh
 
+      # #4404: every guard above looks at ONE runtime. test_standalone_service_
+      # contract.sh parses only docker-compose.yaml and says so in its own header
+      # ("This does NOT claim Docker/Podman parity"); the two Quadlet guards parse
+      # only the units. A property can hold in both and still DIFFER between them,
+      # which is what #4188 asked for: "a change to one runtime must fail CI if
+      # the other runtime's contract was unintentionally left stale". This
+      # compares the two deployment descriptions directly — images, environment,
+      # mounts and modes, published vs exposed ports, capabilities, health checks,
+      # persistence, network exposure, restart policy, labels — and fails on any
+      # divergence not in its exception table, where each entry carries a stated
+      # reason. Entries are swept in reverse too: an exception that no longer
+      # matches a real divergence is itself a failure, so the table cannot rot.
+      - name: Docker/Podman contract parity (#4404)
+        run: bash deploy/test_standalone_runtime_parity.sh
+
       # bin/gh-wrapper.sh is the merge gate standing behind the proxy hard-deny:
       # if its argument parsing is wrong, a prompt-injected agent merges
       # unvetted code. It had NO tests and matched no CI path filter. This

--- a/src/deploy/quadlet/hive.env.example
+++ b/src/deploy/quadlet/hive.env.example
@@ -1,0 +1,53 @@
+# The environment contract for the Podman/Quadlet standalone deployment
+# (kubestellar/hive#4404). Install as %E/hive/hive.env — /etc/hive/hive.env for
+# a rootful unit, ~/.config/hive/hive.env for a --user one — and `chmod 600` it:
+# it holds tokens, and unlike the bind mounts it is read by systemd on the host,
+# so no container label protects it.
+#
+#   cp src/deploy/quadlet/hive.env.example "$CONF/hive.env"
+#   chmod 600 "$CONF/hive.env"
+#
+# THE FILE MUST EXIST, even if every line stays commented out. Quadlet turns
+# `EnvironmentFile=` into `podman run --env-file`, and `podman run` fails when
+# the file is missing. The leading `-` that makes an EnvironmentFile optional in
+# ordinary systemd units does NOT work here; see hive.container's header.
+#
+# WHY THIS FILE IS TRACKED IN THE REPOSITORY. `EnvironmentFile=` is opaque: the
+# unit names a path and nothing in the unit says which variables belong in it.
+# The Docker Compose stack spells its six variables out in `environment:`, so
+# adding a seventh there used to reach Docker and silently never reach Podman —
+# there was no Podman-side artifact to compare against. This file is that
+# artifact. src/deploy/test_standalone_runtime_parity.sh asserts that the names
+# here and the names in src/docker-compose.yaml's `hive` service are the SAME
+# SET, so a variable added to either side and not the other fails CI.
+#
+# Adding a variable: add it to both `environment:` in src/docker-compose.yaml
+# and to this file, commented out unless it has a safe default. Values here are
+# deliberately empty — this is a template, not a configuration.
+
+# The GitHub token Hive uses when no GitHub App is installed. Leave unset to run
+# App-only. `HIVE_GITHUB_TOKEN=` in Compose passes the host's value through; a
+# Quadlet unit has no host environment to inherit, so set it here explicitly.
+#HIVE_GITHUB_TOKEN=
+
+# REQUIRED unless this hive is hub-hosted (no HIVE_SESSION_KEY/HIVE_HUB_SECRET).
+# Hive REFUSES TO START without it — every mutation endpoint would be
+# unauthenticated. With Notify=healthy that refusal surfaces as a unit stuck in
+# `activating` until TimeoutStartSec expires, so set it before the first start:
+#   printf 'HIVE_DASHBOARD_TOKEN=%s\n' "$(openssl rand -hex 32)" >> hive.env
+#HIVE_DASHBOARD_TOKEN=
+
+# ntfy push notifications, read by bin/hive.sh. Both optional; set neither to
+# disable. NTFY_SERVER defaults to https://ntfy.sh when a topic is set.
+#NTFY_SERVER=
+#NTFY_TOPIC=
+
+# ACMM pack level (1-6) auto-applied on FIRST start only. On every later start
+# the persisted config wins and this is just the fallback — see the ApplyPack
+# block in src/cmd/hive/main.go. Normally left unset once hive.yaml has a level.
+#HIVE_LEVEL=
+
+# Bootstrap "org/repo". Fills project.org and project.repos only when the config
+# leaves them empty (applyBootstrapEnv in src/pkg/config/config.go); it never
+# overrides hive.yaml.
+#HIVE_REPO=

--- a/src/deploy/test_quadlet_port_boundary.sh
+++ b/src/deploy/test_quadlet_port_boundary.sh
@@ -12,6 +12,10 @@
 # the same set of invariants for src/deploy/quadlet/, so the two runtimes are
 # guarded rather than one being guarded and the other reviewed.
 #
+# Both of those check one runtime at a time, and a property can hold in each and
+# still DIFFER between them. src/deploy/test_standalone_runtime_parity.sh (#4404)
+# is the cross-runtime comparison; this file stays the Podman-side boundary.
+#
 # What is asserted, and why each one is invisible at runtime when it breaks:
 #
 #   - The gateway publishes host 3001 -> container 3001 and nothing else. A

--- a/src/deploy/test_standalone_runtime_parity.sh
+++ b/src/deploy/test_standalone_runtime_parity.sh
@@ -1,0 +1,760 @@
+#!/usr/bin/env bash
+# Cross-runtime manifest/contract parity (kubestellar/hive#4404).
+# Run: bash src/deploy/test_standalone_runtime_parity.sh
+#
+# WHY
+# ---
+# #4188 asked for this in as many words:
+#
+#     Avoid maintaining two unrelated deployment descriptions by convention
+#     alone. [...] A change to one runtime must fail CI if the other runtime's
+#     contract was unintentionally left stale.
+#
+# Both descriptions exist -- src/docker-compose.yaml and src/deploy/quadlet/* --
+# and until now nothing compared them. Exactly one axis was guarded: image
+# references, via standalone-images.sh and test_standalone_image_refs.sh. Every
+# other axis was convention. The sibling guards each look at ONE runtime:
+# test_standalone_service_contract.sh (#4204) parses only the Compose file and
+# says so in its own header ("This does NOT claim Docker/Podman parity"), and
+# test_quadlet_port_boundary.sh (#4375) parses only the units. A property can
+# hold in both of those and still differ between them.
+#
+# WHAT THIS IS AND IS NOT
+# -----------------------
+# A STATIC comparison of the two deployment descriptions on a named list of
+# runtime-invariant axes. It is not a claim of behavioural equivalence at
+# runtime -- that is what the live CI lanes (#4334, #4335) cover -- and it does
+# not look at the Kubernetes manifest, whose capability set #4379 covers.
+#
+# THE EXCEPTION TABLE IS THE POINT. Some divergences are correct. Encoding them
+# as entries with a stated reason, rather than by not looking at the axis, is
+# what keeps the unexamined cases from hiding among the examined ones. Two kinds
+# exist and they are not the same claim:
+#
+#   deliberate     the two runtimes SHOULD differ here, and why.
+#   defect-tracked they should not, this is a real divergence, and here is the
+#                  issue. It does not fail the build today so that the check can
+#                  land; it is a debt marker with a number on it, not a pass.
+#
+# STALE EXCEPTIONS FAIL. Every entry is checked in reverse: an exception that no
+# longer matches an actual divergence is itself a failure. Fixing a tracked
+# defect therefore forces the entry to be removed, so the table cannot rot into
+# a list of things that used to be true.
+#
+# The Compose side is read as raw YAML rather than through `docker compose
+# config`. Only variable NAMES, ports, mounts, capabilities and probe fields are
+# compared, none of which interpolation changes, and the Podman side has no
+# renderer to match — so requiring Docker here would make the parity guard skip
+# on exactly the Podman-only hosts it exists to protect.
+#
+# Runs without starting a container, like its sibling contract tests.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE="${ROOT}/src/docker-compose.yaml"
+UNIT_DIR="${ROOT}/src/deploy/quadlet"
+ENV_EXAMPLE="${UNIT_DIR}/hive.env.example"
+IMAGES_SH="${ROOT}/src/deploy/standalone-images.sh"
+
+PASS=0
+FAIL=0
+EXCEPTED=0
+
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() {
+  printf '  FAIL: %s\n' "$1"
+  [[ $# -gt 1 && -n "${2:-}" ]] && printf '        %s\n' "$2"
+  FAIL=$((FAIL + 1))
+}
+note() { printf '  %s\n' "$1"; }
+
+printf '=== standalone Docker/Podman contract parity (#4404) ===\n\n'
+
+for required in "$COMPOSE" "$UNIT_DIR" "$ENV_EXAMPLE" "$IMAGES_SH"; do
+  if [[ ! -e "$required" ]]; then
+    printf '  FAIL: %s exists\n' "${required#"${ROOT}/"}"
+    printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$((FAIL + 1))"
+    exit 1
+  fi
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '  SKIP: python3 unavailable — cannot compare the two descriptions structurally\n'
+  exit 0
+fi
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  printf '  SKIP: PyYAML unavailable — cannot parse docker-compose.yaml\n'
+  exit 0
+fi
+
+# Image references are normalised by the SOURCE OF TRUTH's own function rather
+# than by a second copy of the rules here: Docker may spell an image
+# `nginx:alpine` where Podman requires `docker.io/library/nginx:alpine`, and
+# hive_standalone_image_normalize is what already knows the two are equal.
+# shellcheck source=/dev/null
+. "$IMAGES_SH"
+
+canonical_images() {
+  local component
+  while IFS= read -r component; do
+    [[ -n "$component" ]] || continue
+    printf '%s\t%s\n' "$component" \
+      "$(hive_standalone_image_normalize "$(hive_standalone_image "$component")")"
+  done < <(hive_standalone_image_components)
+}
+
+NORMALIZED_SOT="$(canonical_images)"
+
+RESULTS="$(
+  COMPOSE="$COMPOSE" UNIT_DIR="$UNIT_DIR" ENV_EXAMPLE="$ENV_EXAMPLE" \
+  NORMALIZED_SOT="$NORMALIZED_SOT" python3 <<'PY'
+import os, re, sys, yaml
+
+compose_path = os.environ["COMPOSE"]
+unit_dir = os.environ["UNIT_DIR"]
+env_example = os.environ["ENV_EXAMPLE"]
+
+out = []
+def ok(msg):                out.append(("PASS", msg, ""))
+def bad(msg, detail=""):    out.append(("FAIL", msg, detail))
+def info(msg):              out.append(("NOTE", msg, ""))
+def excepted(msg, detail):  out.append(("EXCEPT", msg, detail))
+
+# ── The exception table ──────────────────────────────────────────────────────
+#
+# key -> (kind, reason). `kind` is "deliberate" or "defect-tracked". Every entry
+# is verified to still correspond to a real divergence; see the stale-exception
+# sweep at the end.
+EXCEPTIONS = {
+    # --- deliberate -----------------------------------------------------------
+    "mount-mode:hive:/etc/hive/hive.yaml": (
+        "deliberate",
+        "Podman is STRICTER: the unit mounts it ro,Z, Compose mounts it rw. The "
+        "entrypoint supports both — its Docker-mode branch reads 'Config path is "
+        "read-only — using $HIVE_CONFIG_SOURCE directly' and falls back to "
+        "/data/hive.yaml.runtime, which is the layer that survives a recreate "
+        "anyway (#3961, pinned by src/pkg/config/save_readonly_test.go). The "
+        "asymmetry is allowed in ONE direction only: the check below fails if the "
+        "Podman side ever becomes the looser of the two.",
+    ),
+    "labels:hive:com.centurylinklabs.watchtower.enable": (
+        "deliberate",
+        "Docker-only by design (#4188 Phase 3). The auto-update profile is built "
+        "on the Docker socket and a filtered Docker API proxy and is explicitly "
+        "not repointed at the Podman socket, so a Quadlet unit carrying this "
+        "label would advertise a manager that will never manage it. Asserted "
+        "positively below rather than merely skipped: no unit may carry it.",
+    ),
+    "labels:*:io.kubestellar.hive.*": (
+        "deliberate",
+        "Podman-only by design (#4210). bin/hive-podman-teardown.sh (#4343) "
+        "selects by this label set and nothing else; the Compose stack is torn "
+        "down by project/`container_name` and has no equivalent need.",
+    ),
+    "expose:hive": (
+        "deliberate",
+        "Compose lists expose: 3001/3002/7681; the units deliberately carry no "
+        "ExposeHostPort=. Both are documentation — every member of a netavark "
+        "network can already reach every port of every other member — but "
+        "Quadlet's spelling is `--expose`, which becomes a REAL published port "
+        "the moment anything adds -P. hive-gateway.container's header records "
+        "the decision. Asserted positively below: no unit may carry "
+        "ExposeHostPort=.",
+    ),
+    "healthcheck-start-period:gateway": (
+        "deliberate",
+        "Compose sets no start_period for the gateway; the unit sets "
+        "HealthStartPeriod=30s. The unit needs a start budget because ADR-0017 "
+        "requires TimeoutStartSec to exceed it and Notify=healthy gates the "
+        "start on it; Compose's gateway has no equivalent gate, it just waits "
+        "for hive via depends_on. The probe command and interval/timeout/retries "
+        "are compared strictly and must still match.",
+    ),
+    "build:hive": (
+        "deliberate",
+        "Compose carries a build: section so `docker compose up --build` can "
+        "build from source. Quadlet has no build key for a .container unit at "
+        "all (a .build unit is a separate asset), and the Podman path is "
+        "install-from-registry. Structural, not a contract divergence.",
+    ),
+
+    # --- defect-tracked -------------------------------------------------------
+    "restart:gateway": (
+        "defect-tracked",
+        "Compose says unless-stopped, the unit says Restart=on-failure. "
+        "hive.container learned in #4377 that a clean external stop must still "
+        "be recovered and uses Restart=always (systemd never restarts a unit a "
+        "`systemctl stop` job stopped, so that is the exact equivalent of "
+        "unless-stopped); the gateway did not get the same treatment. A gateway "
+        "that exits 0 stays down under on-failure — nginx exits 0 on a clean "
+        "SIGTERM, so the only published port on the host goes away while "
+        "systemctl reports success — and would restart under Compose. Tracked "
+        "in #4415; not fixed here, #4404 is the check and not the fixes.",
+    ),
+    "mount-target:gateway:/etc/nginx/upstream": (
+        "defect-tracked",
+        "Compose mounts the named volume gateway-upstream at /etc/nginx/upstream "
+        "and the units have no equivalent. NOTHING in the repository reads that "
+        "path — src/deploy/nginx.conf declares `upstream hive_api` inline and "
+        "states it has no include — so the Quadlet side is likely correct and "
+        "the Compose volume vestigial. #4404 says explicitly not to delete it "
+        "here; tracked for separate disposal in #4416.",
+    ),
+}
+
+# Exceptions that fired. Anything left over at the end is stale.
+fired = set()
+
+def diverges(key, msg, detail):
+    """One divergence. Excepted (with its reason) or a failure."""
+    if key in EXCEPTIONS:
+        fired.add(key)
+        kind, reason = EXCEPTIONS[key]
+        excepted(f"[{kind}] {msg}", reason)
+        return
+    bad(msg, detail)
+
+# ── Parsing: Compose ─────────────────────────────────────────────────────────
+doc = yaml.safe_load(open(compose_path)) or {}
+services = doc.get("services") or {}
+top_volumes = doc.get("volumes") or {}
+
+# The two services an operator actually runs. The auto-update profile services
+# are Docker-only by design (#4188 Phase 3) and have no Podman counterpart, so
+# they are not components of the parity comparison; the watchtower label
+# exception above is what records that boundary.
+COMPONENTS = [("hive", "hive.container"), ("gateway", "hive-gateway.container")]
+
+def c_list(svc, key):
+    return list((services.get(svc) or {}).get(key) or [])
+
+def compose_env_names(svc):
+    env = (services.get(svc) or {}).get("environment") or []
+    names = set()
+    if isinstance(env, dict):
+        names.update(str(k) for k in env)
+    else:
+        for item in env:
+            names.add(str(item).split("=", 1)[0])
+    return names
+
+def compose_published(svc):
+    pairs = []
+    for p in c_list(svc, "ports"):
+        if isinstance(p, dict):
+            pairs.append((str(p.get("published") or ""), str(p.get("target") or "")))
+        else:
+            bits = str(p).split("/")[0].split(":")
+            pairs.append((bits[-2] if len(bits) > 1 else "", bits[-1]))
+    return sorted(pairs)
+
+def compose_mounts(svc):
+    """target -> {'ro': bool, 'named': bool, 'source': str, 'raw': str}"""
+    mounts = {}
+    for v in c_list(svc, "volumes"):
+        if isinstance(v, dict):
+            src, target = v.get("source") or "", v.get("target") or ""
+            mounts[target] = {"ro": bool(v.get("read_only")), "source": src,
+                              "named": v.get("type") == "volume", "raw": str(v)}
+        else:
+            bits = str(v).split(":")
+            src = bits[0] if len(bits) > 1 else ""
+            target = bits[1] if len(bits) > 1 else bits[0]
+            opts = bits[2].split(",") if len(bits) > 2 else []
+            mounts[target] = {
+                "ro": "ro" in opts, "source": src,
+                "named": not (src.startswith(".") or src.startswith("/")),
+                "raw": str(v),
+            }
+    return mounts
+
+def compose_health(svc):
+    hc = (services.get(svc) or {}).get("healthcheck") or {}
+    test = hc.get("test") or []
+    if isinstance(test, str):
+        cmd = test
+    else:
+        cmd = " ".join(str(t) for t in test if str(t) not in ("CMD", "CMD-SHELL"))
+    return {
+        "cmd": cmd.strip(),
+        "interval": str(hc.get("interval") or ""),
+        "timeout": str(hc.get("timeout") or ""),
+        "retries": str(hc.get("retries") or ""),
+        "start_period": str(hc.get("start_period") or ""),
+    }
+
+# ── Parsing: Quadlet ─────────────────────────────────────────────────────────
+#
+# systemd treats a line whose first non-blank character is `#` or `;` as a
+# comment and nothing else. Stripping them matters: these units discuss keys
+# like PublishPort= in prose at length, so a grep over the raw text matches the
+# warning not to add one.
+def unit_parse(path):
+    values = {}
+    if not os.path.isfile(path):
+        return values
+    for line in open(path, encoding="utf-8"):
+        line = line.rstrip("\r\n").strip()
+        if not line or line[0] in "#;" or line.startswith("["):
+            continue
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        values.setdefault(k.strip(), []).append(v.strip())
+    return values
+
+def u(units, key):
+    return list(units.get(key) or [])
+
+def u1(units, key, default=""):
+    vals = u(units, key)
+    return vals[0] if vals else default
+
+UNITS = {name: unit_parse(os.path.join(unit_dir, name))
+         for name in os.listdir(unit_dir) if not name.endswith(".example")}
+
+def quadlet_mounts(units):
+    """Volume=SOURCE:TARGET[:OPTS] -> target -> {...}"""
+    mounts = {}
+    for spec in u(units, "Volume"):
+        bits = spec.split(":")
+        if len(bits) < 2:
+            continue
+        src, target = bits[0], bits[1]
+        opts = bits[2].split(",") if len(bits) > 2 else []
+        mounts[target] = {
+            "ro": "ro" in opts, "source": src,
+            # A Volume= source naming a .volume unit is the named-volume form;
+            # anything starting with / or a systemd specifier is a bind mount.
+            "named": src.endswith(".volume"),
+            "raw": spec,
+        }
+    return mounts
+
+def quadlet_published(units):
+    pairs = []
+    for spec in u(units, "PublishPort"):
+        spec = spec.split("/")[0]
+        if ":" in spec:
+            host, container = spec.rsplit(":", 1)
+            host = host.rsplit(":", 1)[-1]
+        else:
+            host, container = "", spec
+        pairs.append((host, container))
+    return sorted(pairs)
+
+def quadlet_health(units):
+    return {
+        "cmd": u1(units, "HealthCmd"),
+        "interval": u1(units, "HealthInterval"),
+        "timeout": u1(units, "HealthTimeout"),
+        "retries": u1(units, "HealthRetries"),
+        "start_period": u1(units, "HealthStartPeriod"),
+    }
+
+def duration_eq(a, b):
+    """`10s` and `10s` — and Compose's `1m30s` vs a unit's `90s`."""
+    def secs(s):
+        s = str(s).strip()
+        if not s:
+            return None
+        total, seen = 0, False
+        for value, unit in re.findall(r"(\d+)\s*(h|m|s|ms)?", s):
+            if not value:
+                continue
+            seen = True
+            total += int(value) * {"h": 3600, "m": 60, "s": 1, "ms": 0, "": 1}[unit or ""]
+        return total if seen else None
+    return secs(a) == secs(b)
+
+missing_units = [unit for _, unit in COMPONENTS if not UNITS.get(unit)]
+if missing_units:
+    bad("both Quadlet component units parse", f"missing or empty: {missing_units!r}")
+    for status, msg, detail in out:
+        print(f"{status}\t{msg}\t{detail}")
+    sys.exit(0)
+
+# ── Axis: image references ───────────────────────────────────────────────────
+info("--- axis: image references ---")
+sot = {}
+for line in os.environ["NORMALIZED_SOT"].splitlines():
+    if "\t" in line:
+        comp, ref = line.split("\t", 1)
+        sot[comp.strip()] = ref.strip()
+
+def normalize_ref(ref):
+    """Mirrors hive_standalone_image_normalize for the assets' own spellings."""
+    if not ref:
+        return ""
+    first = ref.split("/")[0]
+    if "/" in ref and ("." in first or ":" in first or first == "localhost"):
+        return ref
+    return f"docker.io/{ref}" if "/" in ref else f"docker.io/library/{ref}"
+
+for svc, unit in COMPONENTS:
+    c_ref = normalize_ref(str((services.get(svc) or {}).get("image") or ""))
+    q_ref = normalize_ref(u1(UNITS[unit], "Image"))
+    if c_ref and c_ref == q_ref:
+        ok(f"{svc}: both runtimes reference the same image ({c_ref})")
+        if sot.get(svc) and sot[svc] != c_ref:
+            bad(f"{svc}: that shared reference is the one in standalone-images.sh",
+                f"assets agree on {c_ref} but the source of truth says {sot[svc]}")
+    else:
+        diverges(f"image:{svc}", f"{svc}: both runtimes reference the same image",
+                 f"compose={c_ref!r} quadlet={q_ref!r} — one runtime is pulling "
+                 "different code than the other")
+
+# ── Axis: environment variables ──────────────────────────────────────────────
+#
+# EnvironmentFile= names a path and says nothing about what belongs in it, so
+# there is no Podman-side artifact to compare against unless one is tracked.
+# hive.env.example is that artifact; without it this axis is uncheckable and a
+# seventh Compose variable reaches Docker and silently never reaches Podman.
+info("--- axis: environment variables ---")
+env_file_keys = set()
+for line in open(env_example, encoding="utf-8"):
+    line = line.strip()
+    if line.startswith("#"):
+        line = line.lstrip("#").strip()
+    if not line or "=" not in line:
+        continue
+    name = line.split("=", 1)[0].strip()
+    if re.fullmatch(r"[A-Z_][A-Z0-9_]*", name):
+        env_file_keys.add(name)
+
+if not u(UNITS["hive.container"], "EnvironmentFile"):
+    bad("hive.container reads its environment from an EnvironmentFile",
+        "without it hive.env.example describes nothing and this axis is vacuous")
+else:
+    ok("hive.container reads its environment from an EnvironmentFile")
+
+c_env = compose_env_names("hive")
+if not c_env:
+    bad("the compose hive service declares environment variables",
+        "nothing to compare — the parser found no environment: block")
+elif not env_file_keys:
+    bad("hive.env.example enumerates the environment contract",
+        f"parsed no variable names out of {os.path.basename(env_example)}")
+elif c_env == env_file_keys:
+    ok(f"both runtimes declare the same {len(c_env)} environment variables "
+       f"({', '.join(sorted(c_env))})")
+else:
+    only_compose = sorted(c_env - env_file_keys)
+    only_podman = sorted(env_file_keys - c_env)
+    diverges("env:hive",
+             "both runtimes declare the same environment variables",
+             f"only in docker-compose.yaml: {only_compose!r}; only in "
+             f"hive.env.example: {only_podman!r} — a variable added to one "
+             "description reaches that runtime and silently never reaches the "
+             "other")
+
+# ── Axis: mounts and their modes ─────────────────────────────────────────────
+info("--- axis: mounts and their modes ---")
+for svc, unit in COMPONENTS:
+    cm, qm = compose_mounts(svc), quadlet_mounts(UNITS[unit])
+    for target in sorted(set(cm) | set(qm)):
+        in_c, in_q = target in cm, target in qm
+        if in_c and not in_q:
+            diverges(f"mount-target:{svc}:{target}",
+                     f"{svc}: {target} is mounted by both runtimes",
+                     f"docker-compose.yaml mounts it ({cm[target]['raw']!r}); no "
+                     f"Volume= in {unit} does")
+        elif in_q and not in_c:
+            diverges(f"mount-target:{svc}:{target}",
+                     f"{svc}: {target} is mounted by both runtimes",
+                     f"{unit} mounts it ({qm[target]['raw']!r}); no volume in "
+                     "docker-compose.yaml does")
+        elif cm[target]["ro"] != qm[target]["ro"]:
+            # Direction matters. Podman being stricter is a posture choice the
+            # table can accept; Podman being LOOSER is never acceptable, because
+            # the Compose :ro entries are the ones the security guards assert.
+            if qm[target]["ro"] and not cm[target]["ro"]:
+                diverges(f"mount-mode:{svc}:{target}",
+                         f"{svc}: {target} has the same mode in both runtimes",
+                         f"compose rw, quadlet ro")
+            else:
+                bad(f"{svc}: {target} has the same mode in both runtimes",
+                    f"compose ro, quadlet RW — the Podman asset is the LOOSER of "
+                    "the two, which no exception permits: this container must not "
+                    "be able to rewrite what it reads")
+        else:
+            mode = "ro" if cm[target]["ro"] else "rw"
+            ok(f"{svc}: {target} mounted {mode} by both runtimes")
+
+# ── Axis: published vs exposed ports ─────────────────────────────────────────
+#
+# The #4375 invariant, in both assets at once: 3001 published, 7681 never.
+info("--- axis: published vs exposed ports ---")
+for svc, unit in COMPONENTS:
+    cp, qp = compose_published(svc), quadlet_published(UNITS[unit])
+    if cp == qp:
+        ok(f"{svc}: both runtimes publish {cp!r}")
+    else:
+        diverges(f"publish:{svc}", f"{svc}: both runtimes publish the same ports",
+                 f"compose={cp!r} quadlet={qp!r}")
+
+gw_c, gw_q = compose_published("gateway"), quadlet_published(UNITS["hive-gateway.container"])
+if gw_c == [("3001", "3001")] == gw_q:
+    ok("the gateway publishes host 3001 -> container 3001 and nothing else, in both")
+else:
+    bad("the gateway publishes host 3001 -> container 3001 and nothing else, in both",
+        f"compose={gw_c!r} quadlet={gw_q!r}")
+
+# Swept across EVERY service and EVERY unit, not just the two components.
+offenders = []
+for svc in services:
+    offenders += [f"compose:{svc}:{p!r}" for p in compose_published(svc)
+                  if "7681" in p]
+for name, units in UNITS.items():
+    offenders += [f"{name}:{p!r}" for p in quadlet_published(units) if "7681" in p]
+if not offenders:
+    ok("no service and no unit publishes the raw ttyd port 7681")
+else:
+    bad("no service and no unit publishes the raw ttyd port 7681",
+        f"{offenders!r} — this publishes an unauthenticated shell into the "
+        "credential-holding container")
+
+c_expose = [str(p).split("/")[0] for p in c_list("hive", "expose")]
+q_expose = sorted({v for units in UNITS.values() for v in u(units, "ExposeHostPort")})
+if c_expose and not q_expose:
+    diverges("expose:hive", "both runtimes declare the same in-network ports",
+             f"compose expose={c_expose!r}, no ExposeHostPort= in any unit")
+elif c_expose == q_expose:
+    ok(f"both runtimes declare the same in-network ports ({c_expose!r})")
+else:
+    bad("both runtimes declare the same in-network ports",
+        f"compose={c_expose!r} quadlet={q_expose!r}")
+if q_expose:
+    bad("no unit carries ExposeHostPort=",
+        f"{q_expose!r} — Quadlet's spelling of expose is `--expose`, which "
+        "becomes a real published port as soon as anything adds -P")
+else:
+    ok("no unit carries ExposeHostPort= (it turns into a published port under -P)")
+
+# ── Axis: capabilities ───────────────────────────────────────────────────────
+info("--- axis: capabilities ---")
+for svc, unit in COMPONENTS:
+    c_caps = sorted({str(c).upper() for c in c_list(svc, "cap_add")})
+    q_caps = sorted({v.upper() for v in u(UNITS[unit], "AddCapability")})
+    if c_caps == q_caps:
+        ok(f"{svc}: both runtimes add {c_caps or ['<none>']!r}")
+    else:
+        diverges(f"caps:{svc}", f"{svc}: both runtimes add the same capabilities",
+                 f"compose cap_add={c_caps!r} quadlet AddCapability={q_caps!r} — "
+                 "without NET_ADMIN the entrypoint fails closed with exit 77")
+
+# ── Axis: health checks ──────────────────────────────────────────────────────
+info("--- axis: health checks ---")
+for svc, unit in COMPONENTS:
+    ch, qh = compose_health(svc), quadlet_health(UNITS[unit])
+    if not ch["cmd"] or not qh["cmd"]:
+        bad(f"{svc}: both runtimes define a health probe",
+            f"compose={ch['cmd']!r} quadlet={qh['cmd']!r} — readiness is what "
+            "the gateway ordering and Notify=healthy both depend on")
+        continue
+    if ch["cmd"] == qh["cmd"]:
+        ok(f"{svc}: both runtimes probe with `{ch['cmd']}`")
+    else:
+        diverges(f"healthcheck-cmd:{svc}",
+                 f"{svc}: both runtimes probe the same endpoint",
+                 f"compose={ch['cmd']!r} quadlet={qh['cmd']!r}")
+    for field, label in (("interval", "interval"), ("timeout", "timeout"),
+                         ("retries", "retries"), ("start_period", "start period")):
+        a, b = ch[field], qh[field]
+        same = (a == b) if field == "retries" else duration_eq(a, b)
+        if same:
+            ok(f"{svc}: health {label} matches ({a or '<unset>'})")
+        else:
+            key = ("healthcheck-start-period" if field == "start_period"
+                   else f"healthcheck-{field}")
+            diverges(f"{key}:{svc}", f"{svc}: health {label} matches",
+                     f"compose={a or '<unset>'!r} quadlet={b or '<unset>'!r}")
+
+# ── Axis: persistence ────────────────────────────────────────────────────────
+info("--- axis: persistence ---")
+c_data = compose_mounts("hive").get("/data")
+q_data = quadlet_mounts(UNITS["hive.container"]).get("/data")
+if not c_data or not q_data:
+    bad("/data persists on a named volume in both runtimes",
+        f"compose={c_data!r} quadlet={q_data!r}")
+else:
+    if c_data["named"] and q_data["named"]:
+        ok("/data persists on a named volume in both runtimes")
+    else:
+        bad("/data persists on a named volume in both runtimes",
+            f"compose named={c_data['named']} ({c_data['raw']!r}), quadlet named="
+            f"{q_data['named']} ({q_data['raw']!r}) — a bind mount still runs and "
+            "just loses agent state on the next recreate")
+    # The volume NAME is part of the contract: the operator docs, the backup
+    # procedure and bin/hive-podman-teardown.sh all name it.
+    c_name = c_data["source"]
+    q_unit = os.path.join(unit_dir, q_data["source"])
+    q_name = u1(unit_parse(q_unit), "VolumeName") if os.path.isfile(q_unit) else ""
+    if c_name and c_name == q_name:
+        ok(f"both runtimes call the state volume '{c_name}'")
+    else:
+        diverges("volume-name:hive-data",
+                 "both runtimes call the state volume the same thing",
+                 f"compose={c_name!r} quadlet VolumeName={q_name!r} — the backup "
+                 "and teardown docs name one volume for both runtimes")
+    if c_name and c_name not in top_volumes:
+        bad("the compose state volume is declared in the top-level volumes: block",
+            f"'{c_name}' is not")
+
+# ── Axis: network exposure ───────────────────────────────────────────────────
+info("--- axis: network exposure ---")
+# Both components must sit on ONE shared network on each side, and the gateway
+# must be ordered after hive is HEALTHY rather than merely started -- otherwise
+# it serves 502s on the port operators were told to trust.
+q_nets = {unit: set(u(UNITS[unit], "Network")) for _, unit in COMPONENTS}
+shared = set.intersection(*q_nets.values()) if q_nets else set()
+if len(shared) == 1:
+    ok(f"both units join one shared network ({next(iter(shared))})")
+else:
+    bad("both units join one shared network", f"got {q_nets!r}")
+
+for net_unit_name in sorted(shared):
+    net_units = UNITS.get(net_unit_name, {})
+    internal = u1(net_units, "Internal", "false").lower()
+    if internal in ("", "false", "no", "0"):
+        ok(f"{net_unit_name} is not Internal= (agents must reach GitHub and the model APIs)")
+    else:
+        bad(f"{net_unit_name} is not Internal=",
+            f"Internal={internal} — an internal network has no route off the host")
+
+dep = (services.get("gateway") or {}).get("depends_on") or {}
+cond = dep.get("hive", {}).get("condition") if isinstance(dep, dict) else None
+q_after = set(u(UNITS["hive-gateway.container"], "After"))
+q_requires = set(u(UNITS["hive-gateway.container"], "Requires"))
+q_notify = u1(UNITS["hive.container"], "Notify").lower()
+compose_ready = cond == "service_healthy"
+podman_ready = ("hive.service" in q_after and "hive.service" in q_requires
+                and q_notify == "healthy")
+if compose_ready and podman_ready:
+    ok("both runtimes hold the gateway until hive is HEALTHY, not merely started")
+else:
+    diverges("readiness-ordering:gateway",
+             "both runtimes hold the gateway until hive is healthy",
+             f"compose depends_on condition={cond!r}; gateway unit "
+             f"Requires={sorted(q_requires)!r} After={sorted(q_after)!r}; "
+             f"hive.container Notify={q_notify!r}")
+
+# The internal-only auto-update network is the Docker-only counterpart and is
+# asserted here rather than left unexamined: if it ever stops being internal,
+# the unauthenticated Docker API on :2375 becomes routable from the network the
+# hive runs semi-trusted agent code on.
+proxy_net = (doc.get("networks") or {}).get("docker-proxy") or {}
+if proxy_net.get("internal") is True:
+    ok("the Docker-only auto-update network stays internal: true (no Podman counterpart)")
+else:
+    bad("the Docker-only auto-update network stays internal: true",
+        f"got {proxy_net!r} — the filtered Docker API must stay unroutable")
+
+# ── Axis: restart policy ─────────────────────────────────────────────────────
+#
+# Compose `unless-stopped` and systemd `Restart=always` are the same statement:
+# systemd never restarts a unit that a `systemctl stop` job stopped, so "always"
+# means "unless stopped". `on-failure` is a strictly weaker claim.
+info("--- axis: restart policy ---")
+EQUIVALENT = {"unless-stopped": "always", "always": "always"}
+for svc, unit in COMPONENTS:
+    c_restart = str((services.get(svc) or {}).get("restart") or "")
+    q_restart = u1(UNITS[unit], "Restart")
+    want = EQUIVALENT.get(c_restart)
+    if want is None:
+        bad(f"{svc}: the compose restart policy is one this check knows how to map",
+            f"got {c_restart!r} — extend EQUIVALENT before trusting this axis")
+    elif q_restart == want:
+        ok(f"{svc}: restart policies agree (compose {c_restart} == systemd Restart={q_restart})")
+    else:
+        diverges(f"restart:{svc}", f"{svc}: restart policies agree",
+                 f"compose={c_restart!r} maps to Restart={want!r}, unit says "
+                 f"Restart={q_restart!r}")
+
+# ── Axis: labels ─────────────────────────────────────────────────────────────
+info("--- axis: labels ---")
+def compose_labels(svc):
+    labels = (services.get(svc) or {}).get("labels") or []
+    if isinstance(labels, dict):
+        return {str(k): str(v) for k, v in labels.items()}
+    parsed = {}
+    for item in labels:
+        k, _, v = str(item).partition("=")
+        parsed[k.strip().strip('"')] = v.strip().strip('"')
+    return parsed
+
+WATCHTOWER_LABEL = "com.centurylinklabs.watchtower.enable"
+OWNERSHIP_PREFIX = "io.kubestellar.hive."
+
+for svc, unit in COMPONENTS:
+    c_labels = set(compose_labels(svc))
+    q_labels = {v.split("=", 1)[0] for v in u(UNITS[unit], "Label")}
+    for name in sorted(c_labels - q_labels):
+        diverges(f"labels:{svc}:{name}",
+                 f"{svc}: label {name} is set by both runtimes",
+                 "set in docker-compose.yaml, absent from the unit")
+    podman_only = sorted(n for n in (q_labels - c_labels)
+                         if not n.startswith(OWNERSHIP_PREFIX))
+    for name in podman_only:
+        diverges(f"labels:{svc}:{name}", f"{svc}: label {name} is set by both runtimes",
+                 "set in the unit, absent from docker-compose.yaml")
+    if q_labels - c_labels and not podman_only:
+        fired.add("labels:*:io.kubestellar.hive.*")
+        kind, reason = EXCEPTIONS["labels:*:io.kubestellar.hive.*"]
+        excepted(f"[{kind}] {svc}: the unit carries only ownership labels Compose does not",
+                 reason)
+
+# The Docker-only exception, asserted rather than assumed: a unit carrying the
+# Watchtower label would advertise a manager that cannot manage it.
+wt_units = [name for name, units in UNITS.items()
+            if any(v.startswith(WATCHTOWER_LABEL) for v in u(units, "Label"))]
+if not wt_units:
+    ok("no Quadlet unit carries the Watchtower enable label (Docker-only by design)")
+else:
+    bad("no Quadlet unit carries the Watchtower enable label",
+        f"{wt_units!r} — auto-update is Docker-socket-based and is not repointed "
+        "at Podman (#4188 Phase 3)")
+
+# ── Structural: the compose build: section ───────────────────────────────────
+if (services.get("hive") or {}).get("build"):
+    diverges("build:hive", "hive: both runtimes describe the same build inputs",
+             "compose carries build:, the unit has no equivalent key")
+
+# ── Stale exceptions ─────────────────────────────────────────────────────────
+#
+# The table may only describe divergences that are actually there. An entry that
+# stops firing means the underlying difference was resolved, and the entry has to
+# go with it -- otherwise fixing the gateway restart policy would leave a
+# permanent note claiming it is still broken.
+info("--- exception table: every entry still describes a real divergence ---")
+stale = sorted(set(EXCEPTIONS) - fired)
+if not stale:
+    ok(f"all {len(EXCEPTIONS)} exceptions still correspond to a live divergence")
+else:
+    bad("every exception still corresponds to a live divergence",
+        f"stale: {stale!r} — the divergence is gone, so delete the entry (if a "
+        "tracked defect was fixed, close its issue too)")
+
+for status, msg, detail in out:
+    print(f"{status}\t{msg}\t{detail}")
+PY
+)"
+
+while IFS=$'\t' read -r status msg detail; do
+  [[ -n "$status" ]] || continue
+  case "$status" in
+    PASS)   pass "$msg" ;;
+    FAIL)   fail "$msg" "$detail" ;;
+    NOTE)   printf '\n%s\n' "$msg" ;;
+    EXCEPT)
+      printf '  EXCEPTION: %s\n' "$msg"
+      printf '             %s\n' "$detail"
+      EXCEPTED=$((EXCEPTED + 1))
+      ;;
+    *)      note "$status $msg" ;;
+  esac
+done <<<"$RESULTS"
+
+printf '\n=== Results: %d passed, %d failed, %d accepted exceptions ===\n' \
+  "$PASS" "$FAIL" "$EXCEPTED"
+[[ "$FAIL" -eq 0 ]]

--- a/src/deploy/test_standalone_service_contract.sh
+++ b/src/deploy/test_standalone_service_contract.sh
@@ -20,7 +20,10 @@
 # by looking wrong, which is why they need a guard.
 #
 # This does NOT claim Docker/Podman parity. It snapshots one subset; further
-# invariants belong in separate small issues.
+# invariants belong in separate small issues. Parity itself -- comparing this
+# file against src/deploy/quadlet/* on a named list of axes -- is
+# src/deploy/test_standalone_runtime_parity.sh (#4404), which quotes the
+# sentence above as its reason for existing.
 #
 # Runs without starting a container.
 # Run: bash src/deploy/test_standalone_service_contract.sh

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -18,6 +18,13 @@ services:
       - "3001:3001"
     volumes:
       - ./deploy/nginx.conf:/etc/nginx/nginx.conf:ro
+      # APPEARS TO BE DEAD (#4416). Nothing in this repository reads
+      # /etc/nginx/upstream: deploy/nginx.conf declares `upstream hive_api`
+      # inline and states it carries no include, and the Podman gateway
+      # (deploy/quadlet/hive-gateway.container) has no equivalent mount. Left in
+      # place deliberately — #4404 was the parity CHECK and explicitly not the
+      # fixes; deploy/test_standalone_runtime_parity.sh carries this as a
+      # defect-tracked exception until #4416 disposes of it.
       - gateway-upstream:/etc/nginx/upstream
     depends_on:
       hive:
@@ -61,6 +68,12 @@ services:
       - ./hive.yaml:/etc/hive/hive.yaml
       - hive-data:/data
       - ./secrets:/secrets:ro
+    # PARITY (#4404): this list and the variable names in
+    # deploy/quadlet/hive.env.example are asserted to be the SAME SET by
+    # deploy/test_standalone_runtime_parity.sh. The Quadlet unit reads its
+    # environment through an opaque `EnvironmentFile=`, so a variable added here
+    # and nowhere else used to reach Docker and silently never reach Podman.
+    # Add to both, or to neither.
     environment:
       - HIVE_GITHUB_TOKEN=${HIVE_GITHUB_TOKEN}
       - HIVE_DASHBOARD_TOKEN=${HIVE_DASHBOARD_TOKEN}

--- a/src/docs/podman-standalone-quadlet.md
+++ b/src/docs/podman-standalone-quadlet.md
@@ -219,10 +219,12 @@ service's healthcheck in `src/docker-compose.yaml` looks for it, and what
 happy, the container starts, and the failure arrives five minutes later. That is
 why the `sed` above is a step rather than a remark.
 
-**`$CONF/hive.env` must exist**, even if it is empty:
+**`$CONF/hive.env` must exist**, even if every line in it stays commented out.
+Start from the tracked template, which lists every variable the Compose stack's
+`environment:` block sets:
 
 ```sh
-touch "$CONF/hive.env"
+cp src/deploy/quadlet/hive.env.example "$CONF/hive.env"
 chmod 600 "$CONF/hive.env"
 ```
 
@@ -230,6 +232,14 @@ chmod 600 "$CONF/hive.env"
 `podman run` fails if the file is missing. Quadlet does **not** honour
 systemd's leading `-` optional-file prefix here — see
 [Traps](#traps-measured-not-guessed).
+
+`hive.env.example` is tracked rather than left to prose because
+`EnvironmentFile=` is opaque: the unit names a path and nothing in the unit says
+what belongs in it, so a variable added to `src/docker-compose.yaml` used to
+reach Docker and silently never reach Podman. `src/deploy/
+test_standalone_runtime_parity.sh` ([#4404](https://github.com/kubestellar/hive/issues/4404))
+asserts the two lists are the same set, so that divergence now fails CI. Add a
+variable to both or to neither.
 
 At minimum set `HIVE_DASHBOARD_TOKEN` in it:
 


### PR DESCRIPTION
Closes #4404. Part of #4188 (second wave, bullet 11) — does not close the parent.

## The gap

Both deployment descriptions exist and nothing compared them. Exactly one axis was guarded — image references, via `standalone-images.sh` + `test_standalone_image_refs.sh`. Every other axis was convention. The sibling guards each look at **one** runtime, and `test_standalone_service_contract.sh` says so in its own header:

> This does NOT claim Docker/Podman parity. It snapshots one subset; further invariants belong in separate small issues.

A property can hold in both of those and still differ between them.

## What this adds

`src/deploy/test_standalone_runtime_parity.sh` — a static comparison on the umbrella's own axis list (images, environment variables, mounts and modes, published vs exposed ports, capabilities, health checks, persistence, network exposure) plus restart policy and labels. Runs without starting a container, like its siblings. Wired into `v2-ci.yml` next to them rather than into a new workflow.

Two design choices worth flagging:

- **The Compose side is read as raw YAML, not through `docker compose config`.** Only names, ports, mounts, capabilities and probe fields are compared, none of which interpolation changes — and requiring Docker would make the parity guard skip on exactly the Podman-only hosts it exists to protect.
- **Image references are normalised by the source of truth's own function.** `standalone-images.sh`'s `hive_standalone_image_normalize` already knows `nginx:alpine` and `docker.io/library/nginx:alpine` are the same image; this sources it rather than carrying a second copy of the rules.

```
=== standalone Docker/Podman contract parity (#4404) ===
--- axis: image references ---      PASS ×2
--- axis: environment variables --- PASS: both runtimes declare the same 6 variables
--- axis: mounts and their modes ---
--- axis: published vs exposed ports ---
--- axis: capabilities ---
--- axis: health checks ---
--- axis: persistence ---           PASS: both runtimes call the state volume 'hive-data'
--- axis: network exposure ---
--- axis: restart policy ---
--- axis: labels ---
--- exception table: every entry still describes a real divergence ---
=== Results: 32 passed, 0 failed, 9 accepted exceptions ===
```

## Divergences are resolved, not omitted

Per the acceptance criteria, every difference is an exception **with a stated reason**, and the table distinguishes two claims that are not the same:

| kind | meaning |
|---|---|
| `deliberate` | the runtimes *should* differ here, and why |
| `defect-tracked` | they should not; here is the issue. A debt marker with a number on it, not a pass |

**Deliberate**, each asserted positively rather than skipped:

- **`/etc/hive/hive.yaml` mode** — `ro,Z` under Podman, `rw` under Compose. Not a break: the entrypoint's Docker-mode branch prints *"Config path is read-only — using `$HIVE_CONFIG_SOURCE` directly"* and falls back to `/data/hive.yaml.runtime`, the layer that survives a recreate anyway (#3961, pinned by `src/pkg/config/save_readonly_test.go`). Podman being **stricter** is accepted **in one direction only** — the check fails if the Podman side ever becomes the looser of the two.
- **Watchtower label** — Docker-only by design (#4188 Phase 3), exactly as the acceptance criteria call out. Asserted, not skipped: **no unit may carry it**, because a Quadlet unit advertising that label names a manager that will never manage it.
- **`io.kubestellar.hive.*` ownership labels** — Podman-only by design (#4210); `bin/hive-podman-teardown.sh` selects by them and nothing else.
- **`expose:`** — Compose lists 3001/3002/7681; the units carry no `ExposeHostPort=`. Both are documentation on a netavark network, but Quadlet's spelling is `--expose`, which becomes a *real* published port the moment anything adds `-P`. Asserted: **no unit may carry `ExposeHostPort=`**.
- **Gateway health start period** and **Compose's `build:` section** — structural; the probe command and interval/timeout/retries are still compared strictly.

**Defect-tracked**, both filed as the criteria require:

- **#4415** — the gateway unit says `Restart=on-failure` where Compose says `unless-stopped` and the sibling `hive.container` says `Restart=always`. nginx exits 0 on a clean SIGTERM, so under `on-failure` the **only published port on the host** goes away while `systemctl` reports success. `hive.container` learned this in #4377; the gateway did not get the same treatment.
- **#4416** — the vestigial `gateway-upstream:/etc/nginx/upstream` mount. Nothing in the repository reads that path: `nginx.conf` declares `upstream hive_api` inline and states it carries no `include`. Per #4404 it is **recorded and not deleted** — a comment now sits on the line in `docker-compose.yaml` saying so.

**Stale exceptions fail.** The table is swept in reverse: an entry that no longer matches a real divergence is itself a failure. Fixing #4415 forces its entry out, so the table cannot rot into a list of things that used to be true. (Demonstrated below.)

## The environment axis needed an artifact

`EnvironmentFile=` names a path and says nothing about what belongs in it, so a seventh variable added to Compose reached Docker and silently never reached Podman — with nothing on the Podman side to diff against. Without some enumerable artifact this axis is simply uncheckable, and the criteria forbid handling that by omitting the axis.

So this ships `src/deploy/quadlet/hive.env.example`: tracked, machine-readable, enumerating the same six variables, with each one's actual behaviour cited to the code that reads it. It changes no Docker behaviour and no runtime behaviour — the unit still reads `%E/hive/hive.env`. It also closes a real documentation gap: the install doc told operators to `touch` an empty file and named only **one** of the six.

## Verified by mutation

A check that passes on the current tree proves nothing about what it would catch. Each of these was applied and reverted; every one turns the job red:

| mutation | result |
|---|---|
| seventh variable in `docker-compose.yaml` only | ❌ `only in docker-compose.yaml: ['HIVE_SEVENTH_SETTING']` — **the criterion's own example** |
| variable in `hive.env.example` only | ❌ caught in the other direction too |
| drop `:ro` from the unit's `nginx.conf` mount | ❌ *"the Podman asset is the LOOSER of the two, which no exception permits"* |
| `PublishPort=7681:7681` on the gateway unit | ❌ 3 assertions, incl. the swept *"no service and no unit publishes the raw ttyd port 7681"* |
| remove `AddCapability=NET_ADMIN` | ❌ *"without NET_ADMIN the entrypoint fails closed with exit 77"* |
| **repair** the gateway restart policy | ❌ `stale: ['restart:gateway'] — the divergence is gone, so delete the entry` |

The published-port boundary is covered in both directions and across every service *and* every unit, not just the two components — `3001` published, `7681` never, the #4375 invariant asserted in both assets at once.

## Also

`shellcheck` clean. All six sibling contract tests still pass. One of them — `test_quadlet_config_contract.sh` (#4367) — caught `hive.env.example` while it was still untracked, since it asserts that install steps name files the repo actually ships. Its assertion did its job unprompted; `git add` was the fix.

Cross-links added from both sibling guards so the next person reading either header finds the parity check.

— hive: backend=claude model=claude-opus-5
