### PR TITLE
feat(contribute): supported path to move a relay to another machine (#4408)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -322,6 +322,21 @@ jobs:
       - name: Contributor K8s Workload Generation
         working-directory: .
         run: bash src/deploy/test_contribute_k8s_workload.sh
+
+      # #4408: `just contribute-move` relocates an already-registered
+      # contributor identity to a new machine. The properties that matter are
+      # not visible in the Justfile text — that the positional HIVE_HUB /
+      # HIVE_REGISTRATION_TOKEN / CONTRIBUTOR_ID lists come out aligned and in
+      # the same order is a property of the loop, and bin/contributor-relay.sh
+      # pairs those lists by index (it refuses to start on a length mismatch and
+      # sends the wrong token to the wrong hive on a transposed one). Getting the
+      # partial-failure path wrong is worse: a reissued token cannot be
+      # reprinted, so dropping it locks the contributor out of that hive. This
+      # runs the real recipe against a fake hub with a stubbed gh and a
+      # throwaway HOME — no network, no real credential.
+      - name: Contributor identity relocation (#4408)
+        working-directory: .
+        run: bash src/deploy/test_contribute_move.sh
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -326,7 +326,36 @@ contribute-setup backend="claude": check-version (contribute-check-backend backe
           source "{{config_dir}}/contributor.env"
           echo "Already registered — ${GH_USER} (${CONTRIBUTOR_ID:-unknown})"
         else
-          echo "ERROR: Already registered but no local config found."
+          # THE "SAME IDENTITY, NEW MACHINE" DEAD END (#4408). /api/contribute/
+          # register is unauthenticated, so it correctly refuses to hand back an
+          # existing contributor's token — otherwise POSTing any known username
+          # would be an account-takeover primitive. That refusal is right; what
+          # was missing is what to do next. This used to be a bare
+          # "Already registered but no local config found." and exit 1, with no
+          # supported path named here or in the docs.
+          echo "ERROR: ${GH_USER} is already registered on ${HUB_HTTP}, and this"
+          echo "       machine has no {{config_dir}}/contributor.env to reuse."
+          echo ""
+          echo "That is expected: register is unauthenticated, so it will never"
+          echo "hand an existing contributor's token to whoever asks. You are"
+          echo "moving an identity, not creating one. Two supported ways forward:"
+          echo ""
+          echo "  1. KEEP the credential — copy it from the old machine:"
+          echo "       scp old-machine:{{config_dir}}/contributor.env {{config_dir}}/"
+          echo "       scp old-machine:{{config_dir}}/gh-auth.env      {{config_dir}}/"
+          echo "       chmod 600 {{config_dir}}/contributor.env {{config_dir}}/gh-auth.env"
+          echo "     The hub stores only a HASH of the registration token and clears"
+          echo "     the plaintext after first read, so copying the file is the ONLY"
+          echo "     way to reuse the credential — it can never be printed again."
+          echo "     Delete the files on the old machine afterwards."
+          echo ""
+          echo "  2. ROTATE the credential — reissue it here:"
+          echo "       just contribute-move {{backend}}"
+          echo "     Proves identity with your GitHub token, reissues one token per"
+          echo "     hub, preserves EVERY hub entry in order, and writes gh-auth.env."
+          echo "     The old machine's relay stops working the moment this runs."
+          echo ""
+          echo "See src/docs/contributor-relay.md → 'Moving the relay to another machine'."
           exit 1
         fi
       else
@@ -334,10 +363,47 @@ contribute-setup backend="claude": check-version (contribute-check-backend backe
         exit 1
       fi
     else
+      # MULTI-HUB PRESERVATION (#4408). contributor.env carries positional,
+      # comma-separated HIVE_HUB / HIVE_REGISTRATION_TOKEN / CONTRIBUTOR_ID
+      # lists (bin/contributor-relay.sh pairs them by index). This block used to
+      # `cat >` a SINGLE-hub file unconditionally, so a two-hive contributor who
+      # ran contribute-setup against a hive they had not registered with yet
+      # silently lost the credential for the first one — a live token that the
+      # hub can never reprint. Registering an ADDITIONAL hub now appends to the
+      # existing lists instead, and the previous file is backed up either way.
+      _PREV_HUBS=""; _PREV_TOKENS=""; _PREV_IDS=""
+      if [[ -f "{{config_dir}}/contributor.env" ]]; then
+        _PREV_HUBS=$(grep -m1 '^HIVE_HUB=' "{{config_dir}}/contributor.env" | cut -d= -f2- || true)
+        _PREV_TOKENS=$(grep -m1 '^HIVE_REGISTRATION_TOKEN=' "{{config_dir}}/contributor.env" | cut -d= -f2- || true)
+        _PREV_IDS=$(grep -m1 '^CONTRIBUTOR_ID=' "{{config_dir}}/contributor.env" | cut -d= -f2- || true)
+        cp "{{config_dir}}/contributor.env" "{{config_dir}}/contributor.env.bak"
+        chmod 600 "{{config_dir}}/contributor.env.bak"
+      fi
+      _OUT_HUBS="${_HUB}"; _OUT_TOKENS="${TOKEN}"; _OUT_IDS="${CID}"
+      if [[ -n "$_PREV_HUBS" ]] && ! printf '%s' ",${_PREV_HUBS}," | grep -qF ",${_HUB},"; then
+        # Only append when the three lists are already the same length; a
+        # mismatched file is malformed and appending would misalign every pair.
+        _N_HUBS=$(printf '%s' "$_PREV_HUBS" | tr ',' '\n' | grep -c . || true)
+        _N_TOKENS=$(printf '%s' "$_PREV_TOKENS" | tr ',' '\n' | grep -c . || true)
+        _N_IDS=$(printf '%s' "$_PREV_IDS" | tr ',' '\n' | grep -c . || true)
+        if [[ "$_N_HUBS" == "$_N_TOKENS" && "$_N_HUBS" == "$_N_IDS" ]]; then
+          _OUT_HUBS="${_PREV_HUBS},${_HUB}"
+          _OUT_TOKENS="${_PREV_TOKENS},${TOKEN}"
+          _OUT_IDS="${_PREV_IDS},${CID}"
+          echo "Added ${_HUB} to your existing ${_N_HUBS}-hub configuration."
+          echo "  (previous file kept at {{config_dir}}/contributor.env.bak)"
+        else
+          echo "WARNING: the positional lists in the existing contributor.env do not line up"
+          echo "         (${_N_HUBS} hub(s), ${_N_TOKENS} token(s), ${_N_IDS} id(s)). Appending to a"
+          echo "         malformed file would transpose every hub/token pair after the"
+          echo "         mismatch, so this run writes a single-hub file instead."
+          echo "         Previous file kept at {{config_dir}}/contributor.env.bak."
+        fi
+      fi
       cat > "{{config_dir}}/contributor.env" <<EOF
-    HIVE_REGISTRATION_TOKEN=${TOKEN}
-    HIVE_HUB=${_HUB}
-    CONTRIBUTOR_ID=${CID}
+    HIVE_REGISTRATION_TOKEN=${_OUT_TOKENS}
+    HIVE_HUB=${_OUT_HUBS}
+    CONTRIBUTOR_ID=${_OUT_IDS}
     CONTRIBUTOR_USERNAME=${GH_USER}
     AGENT_BACKEND={{backend}}
     EOF
@@ -383,6 +449,273 @@ contribute-setup backend="claude": check-version (contribute-check-backend backe
     echo "  Hub:     ${_HUB:-{{hive_hub}}}"
     echo ""
     echo "Run 'just contribute-hive' to start contributing."
+
+# Move an ALREADY-REGISTERED contributor identity onto this machine (#4408).
+# Usage: HIVE_HUB=wss://a/contribute,wss://b/contribute just contribute-move claude
+#        just contribute-move claude          (re-uses the hubs already in contributor.env)
+#
+# WHY THIS EXISTS. contribute-setup can only bootstrap a NEW identity: the
+# register endpoint is unauthenticated, so it refuses — correctly — to hand an
+# existing contributor's token to whoever asks for it. On a second machine that
+# left `ERROR: Already registered but no local config found.` and nothing else.
+# Nothing in hive prevents running the relay from a different machine (auth is a
+# plain token-hash lookup: no device binding, no IP pinning, no session
+# affinity) — only the setup path was missing.
+#
+# WHAT IT DOES. Everything contribute-setup does — backend preflight, gh auth,
+# gh-auth.env, CLI config staging — except that instead of REGISTERING it
+# REISSUES, once per hub, proving identity with your GitHub token
+# (POST /api/contribute/reissue-token). It then writes contributor.env with the
+# positional HIVE_HUB / HIVE_REGISTRATION_TOKEN / CONTRIBUTOR_ID lists aligned
+# in the SAME ORDER, which is what bin/contributor-relay.sh pairs by index. A
+# multi-hive contributor doing this by hand had to rotate per hub and rebuild
+# those lists without transposing them; the relay refuses to start if the
+# lengths disagree and misbehaves silently if the order is wrong.
+#
+# THIS ROTATES. Reissuing overwrites the stored hash, so the old machine's relay
+# stops authenticating the moment this succeeds. That is the point — it is what
+# makes the move safe to run from a machine you do not fully trust yet. If you
+# want to KEEP the credential and switch back and forth, copy contributor.env
+# and gh-auth.env (mode 0600) instead; the hub stores only a hash and clears the
+# plaintext after first read, so a copy is the only way to reuse a token.
+#
+# SECURITY: this sends your GitHub token to each hub. contribute-setup
+# deliberately does NOT (H7/CWE-522) because it derives the hub URL from a
+# registry entry's dashboardUrl, which a poisoned registry controls. Here the
+# URL comes from YOUR HIVE_HUB or YOUR existing contributor.env, and
+# reissue-token authenticates by GitHub token by design — so the token has to
+# go. The two guards below are what keep that honest: TLS is required for any
+# non-loopback host, and every receiving host is printed and confirmed before
+# anything is sent. HIVE_MOVE_ASSUME_YES=1 skips the prompt for scripted runs.
+contribute-move backend="claude": check-version (contribute-check-backend backend)
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    for _tool in curl jq; do
+      if ! command -v "$_tool" &>/dev/null; then
+        echo "ERROR: ${_tool} not found — required to talk to the hub."
+        exit 1
+      fi
+    done
+
+    CONF="{{config_dir}}/contributor.env"
+    mkdir -p "{{config_dir}}"
+    echo "=== Move contributor identity to this machine (ClankeR) ==="
+    echo "✓ Preflight passed — {{backend}} CLI is ready."
+    echo ""
+
+    # ── Which hubs ──
+    # Read the existing file with grep rather than `source`: sourcing would
+    # clobber the caller's HIVE_HUB (making the two sources indistinguishable)
+    # and would execute whatever the file contains.
+    _ENV_HUBS="${HIVE_HUB:-}"
+    _FILE_HUBS=""; _FILE_USER=""
+    if [[ -f "$CONF" ]]; then
+      _FILE_HUBS=$(grep -m1 '^HIVE_HUB=' "$CONF" | cut -d= -f2- || true)
+      _FILE_USER=$(grep -m1 '^CONTRIBUTOR_USERNAME=' "$CONF" | cut -d= -f2- || true)
+    fi
+    if [[ -n "$_ENV_HUBS" ]]; then
+      HUBS="$_ENV_HUBS"; HUBS_FROM="HIVE_HUB"
+    elif [[ -n "$_FILE_HUBS" ]]; then
+      HUBS="$_FILE_HUBS"; HUBS_FROM="the existing contributor.env"
+    else
+      echo "ERROR: no hubs to move. Set HIVE_HUB to the hive(s) you contribute to:"
+      echo "    export HIVE_HUB=wss://<hive>/contribute"
+      echo "  or, for more than one, comma-separated in the order you want them:"
+      echo "    export HIVE_HUB=wss://<hive-a>/contribute,wss://<hive-b>/contribute"
+      echo ""
+      echo "  Your hub URLs are the HIVE_HUB line of contributor.env on the old"
+      echo "  machine, or the 'Connect' snippet on each hive's /contribute page."
+      exit 1
+    fi
+    declare -a HUB_LIST=()
+    while IFS= read -r _h; do
+      _h="$(printf '%s' "$_h" | tr -d '[:space:]')"
+      [[ -n "$_h" ]] && HUB_LIST+=("$_h")
+    done < <(printf '%s\n' "$HUBS" | tr ',' '\n')
+    if [[ "${#HUB_LIST[@]}" -eq 0 ]]; then
+      echo "ERROR: could not parse any hub URL out of '${HUBS}' (from ${HUBS_FROM})."
+      exit 1
+    fi
+
+    # ── Step 1: GitHub authentication (same as contribute-setup) ──
+    echo "── Step 1/3: GitHub Authentication ──"
+    if ! command -v gh &>/dev/null; then
+      echo "ERROR: gh CLI not found. Install: brew install gh"
+      exit 1
+    fi
+    if gh auth status &>/dev/null; then
+      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+      echo "Already authenticated as: ${GH_USER}"
+    else
+      echo "Logging into GitHub..."
+      gh auth login --web --scopes "repo,read:org"
+      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+      echo "Authenticated as: ${GH_USER}"
+    fi
+    GH_TOKEN=$(gh auth token 2>/dev/null || echo "")
+    if [[ -z "$GH_USER" || -z "$GH_TOKEN" ]]; then
+      echo "ERROR: could not read your GitHub identity or token from gh."
+      echo "  Try: gh auth login --web --scopes 'repo,read:org'"
+      exit 1
+    fi
+    # gh-auth.env is the second file contribute-hive hard-requires, and nothing
+    # used to say so — it exits with the same "Not set up yet. Run: just
+    # contribute-setup <cli>" when it is missing, pointing at the command that
+    # cannot run on this machine. Written here so the move produces a machine
+    # that can actually start the relay.
+    echo "GH_TOKEN=${GH_TOKEN}" > "{{config_dir}}/gh-auth.env"
+    chmod 600 "{{config_dir}}/gh-auth.env"
+    if [[ -n "$_FILE_USER" && "$_FILE_USER" != "$GH_USER" ]]; then
+      echo ""
+      echo "WARNING: the contributor.env already here belongs to ${_FILE_USER},"
+      echo "         but gh is authenticated as ${GH_USER}. Continuing would"
+      echo "         replace it with ${GH_USER}'s identity."
+    fi
+    echo ""
+
+    # ── Step 2: confirm, then reissue per hub ──
+    echo "── Step 2/3: Reissue (${#HUB_LIST[@]} hub(s), from ${HUBS_FROM}) ──"
+    declare -a HTTP_LIST=()
+    for _hub in "${HUB_LIST[@]}"; do
+      _http=$(printf '%s' "$_hub" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
+      case "$_http" in
+        https://*) : ;;
+        http://127.0.0.1*|http://localhost*|http://[::1]*|http://0.0.0.0*)
+          # Loopback only: a plaintext hop that never leaves the machine. Any
+          # other http:// host would put the GitHub token on the wire in clear.
+          : ;;
+        http://*)
+          echo "ERROR: ${_hub} is not TLS-protected."
+          echo "       Reissuing sends your GitHub token to that host, so this"
+          echo "       refuses anything but wss:// (or loopback for local testing)."
+          exit 1 ;;
+        *)
+          echo "ERROR: could not derive an HTTP base from '${_hub}'."
+          echo "       Expected wss://<host>/contribute."
+          exit 1 ;;
+      esac
+      HTTP_LIST+=("$_http")
+    done
+    echo "Your GitHub token will be sent to, and a NEW registration token issued by:"
+    for _http in "${HTTP_LIST[@]}"; do echo "  - ${_http}"; done
+    echo ""
+    echo "This ROTATES the credential. Any relay still running elsewhere with the"
+    echo "old token stops authenticating as soon as this completes."
+    if [[ "${HIVE_MOVE_ASSUME_YES:-}" != "1" ]]; then
+      # `|| _ANS=""` matters: read returns non-zero at EOF (a piped or
+      # </dev/null stdin), and under `set -e` that would kill the recipe before
+      # it could say why it stopped.
+      read -r -p "Continue? [y/N] " _ANS || _ANS=""
+      if [[ ! "${_ANS:-}" =~ ^[Yy]$ ]]; then
+        echo "Aborted — nothing was sent and nothing was changed."
+        exit 1
+      fi
+    fi
+    echo ""
+
+    # Rotations take effect on the hub as they happen, so a later failure must
+    # NOT discard the tokens already issued — that would lock the contributor
+    # out of the hubs that succeeded, with no way to reprint those tokens. Every
+    # success is written; the failures are named and the exit status is red.
+    NEW_TOKENS=""; NEW_IDS=""; OK_HUBS=""; FAILED=""
+    for _i in "${!HUB_LIST[@]}"; do
+      _hub="${HUB_LIST[$_i]}"; _http="${HTTP_LIST[$_i]}"
+      printf '  %s ... ' "$_http"
+      # Deliberately NOT `curl -f`: -f discards the response body on an HTTP
+      # error, and the body is where the hub says WHY — "Not registered as a
+      # contributor", "Account revoked", "Invalid or missing GitHub token".
+      # Those three need three different actions, and collapsing them into one
+      # "request failed" is what sends people to read the Go source.
+      _BODY=$(mktemp)
+      _CODE=$(curl -s --max-time 20 -o "$_BODY" -w '%{http_code}' \
+        -X POST "${_http}/api/contribute/reissue-token" \
+        -H "Authorization: Bearer ${GH_TOKEN}" 2>/dev/null) || _CODE="000"
+      _RESP=$(cat "$_BODY"); rm -f "$_BODY"
+      if [[ "$_CODE" == "000" ]]; then
+        echo "FAILED (unreachable)"
+        FAILED="${FAILED}\n    ${_hub} — could not connect"
+        continue
+      fi
+      _T=""; _C=""; _E=""
+      if printf '%s' "$_RESP" | jq empty 2>/dev/null; then
+        _T=$(printf '%s' "$_RESP" | jq -r '.registration_token // empty')
+        _C=$(printf '%s' "$_RESP" | jq -r '.contributor_id // empty')
+        _E=$(printf '%s' "$_RESP" | jq -r '.error // .message // empty')
+      else
+        _E="non-JSON response: ${_RESP:0:120}"
+      fi
+      if [[ "$_CODE" != "200" || -z "$_T" || -z "$_C" ]]; then
+        echo "FAILED (HTTP ${_CODE})"
+        FAILED="${FAILED}\n    ${_hub} — HTTP ${_CODE}: ${_E:-no token in response}"
+        continue
+      fi
+      echo "reissued (${_C})"
+      OK_HUBS="${OK_HUBS:+${OK_HUBS},}${_hub}"
+      NEW_TOKENS="${NEW_TOKENS:+${NEW_TOKENS},}${_T}"
+      NEW_IDS="${NEW_IDS:+${NEW_IDS},}${_C}"
+    done
+    echo ""
+
+    if [[ -z "$OK_HUBS" ]]; then
+      echo "ERROR: no hub reissued a token — contributor.env was NOT written."
+      printf 'Failures:%b\n' "$FAILED"
+      echo ""
+      echo "  * 'Not registered as a contributor' means this identity has no profile"
+      echo "    on that hive yet — that is a first-time setup: just contribute-setup {{backend}}"
+      echo "  * A 401 means gh is authenticated as someone else, or the token lacks"
+      echo "    the read:org scope."
+      exit 1
+    fi
+
+    # ── Step 3: write contributor.env, preserving hub ORDER and extra keys ──
+    echo "── Step 3/3: Writing ${CONF} ──"
+    if [[ -f "$CONF" ]]; then
+      cp "$CONF" "${CONF}.bak"
+      chmod 600 "${CONF}.bak"
+      echo "  previous file kept at ${CONF}.bak"
+    fi
+    # Keys this recipe owns are rewritten; anything else an operator or an
+    # earlier setup put in the file (HIVE_LITELLM_ENDPOINT, for one) is carried
+    # across verbatim rather than silently dropped.
+    EXTRA=""
+    if [[ -f "${CONF}.bak" ]]; then
+      EXTRA=$(grep -vE '^(HIVE_REGISTRATION_TOKEN|HIVE_HUB|CONTRIBUTOR_ID|CONTRIBUTOR_USERNAME|AGENT_BACKEND)=' "${CONF}.bak" || true)
+    fi
+    {
+      printf 'HIVE_REGISTRATION_TOKEN=%s\n' "$NEW_TOKENS"
+      printf 'HIVE_HUB=%s\n' "$OK_HUBS"
+      printf 'CONTRIBUTOR_ID=%s\n' "$NEW_IDS"
+      printf 'CONTRIBUTOR_USERNAME=%s\n' "$GH_USER"
+      printf 'AGENT_BACKEND=%s\n' "{{backend}}"
+      [[ -n "$EXTRA" ]] && printf '%s\n' "$EXTRA"
+    } > "$CONF"
+    chmod 600 "$CONF"
+
+    # Same CLI config staging contribute-setup does (Colima cannot bind-mount files).
+    if [[ "{{backend}}" == "claude" ]] && [[ -f "${HOME}/.claude.json" ]]; then
+      cp "${HOME}/.claude.json" "{{config_dir}}/claude-config.json"
+      chmod 600 "{{config_dir}}/claude-config.json"
+      echo "  Claude config staged for the container."
+    fi
+
+    echo ""
+    if [[ -n "$FAILED" ]]; then
+      echo "⚠ Moved with errors."
+      printf '  These hubs did NOT rotate and are not in contributor.env:%b\n' "$FAILED"
+      echo "  The ones that did are written and usable. Re-run to retry the rest."
+    else
+      echo "✓ Move complete!"
+    fi
+    echo "  GitHub:  ${GH_USER}"
+    echo "  CLI:     {{backend}}"
+    echo "  Hubs:    ${OK_HUBS}"
+    echo ""
+    echo "The old machine's relay no longer authenticates. Stop it and delete"
+    echo "${CONF} and {{config_dir}}/gh-auth.env there."
+    echo ""
+    echo "Run 'just contribute-hive' to start contributing from here."
+    if [[ -n "$FAILED" ]]; then exit 1; fi
 
 # Start contributing — containerized (default; docker or podman) or local mode
 # Usage: just contribute-hive              (container, default CLI from setup)

--- a/src/deploy/test_contribute_move.sh
+++ b/src/deploy/test_contribute_move.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# Tests `just contribute-move` — the supported "same identity, new machine"
+# path (kubestellar/hive#4408) — and the two contribute-setup behaviours that
+# issue names alongside it.
+#
+# WHY THIS EXECUTES THE RECIPE. The properties that matter here are not visible
+# in the Justfile text. That the positional HIVE_HUB / HIVE_REGISTRATION_TOKEN /
+# CONTRIBUTOR_ID lists come out ALIGNED and IN THE SAME ORDER is a property of
+# the loop, not of any line in it; bin/contributor-relay.sh pairs those lists by
+# index, refuses to start when the lengths disagree, and misbehaves silently
+# when the order is transposed. Likewise "a later hub failing must not discard
+# the tokens already reissued" is a control-flow property — and getting it wrong
+# locks a contributor out of the hives that succeeded, with no way to reprint
+# those tokens. So this runs the real recipe against a fake hub, exactly as
+# test_contribute_k8s_workload.sh (#2549) runs the real contribute-k8s.
+#
+# Nothing here touches a real hub, a real GitHub account, or the caller's
+# ~/.config/hive: `gh` and the hub are stubs, and HOME is a throwaway directory.
+# Placeholder credential values only.
+#
+# Run: bash src/deploy/test_contribute_move.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && [ -n "${2:-}" ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then pass "$label"; else fail "$label" "want: '$want'  got: '$got'"; fi
+}
+contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then pass "$label"
+  else fail "$label" "missing: '$needle'"; fi
+}
+lacks() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then fail "$label" "unexpectedly present: '$needle'"
+  else pass "$label"; fi
+}
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+for tool in just python3 curl jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "  SKIP: '$tool' not installed; cannot exercise the recipe"
+    exit 0
+  fi
+done
+
+echo "=== contribute-move: identity relocation tests (#4408) ==="
+
+WORK="$(mktemp -d)"
+cleanup() {
+  for pidfile in "$WORK"/hub-*.pid; do
+    [ -f "$pidfile" ] && kill "$(cat "$pidfile")" 2>/dev/null
+  done
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# ── A fake hub ───────────────────────────────────────────────────────────────
+# Answers the two endpoints the recipes call. `mode` selects the behaviour a
+# given instance presents, so a partial-failure run is a real HTTP failure from
+# a real second hub rather than a mocked branch.
+cat > "$WORK/fakehub.py" <<'PY'
+import json, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = int(sys.argv[1])
+MODE = sys.argv[2]            # ok | notregistered | registered-already | fresh
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+        if self.path == "/api/contribute/reissue-token":
+            if not self.headers.get("Authorization"):
+                self._send(401, {"error": "Invalid or missing GitHub token."})
+                return
+            if MODE == "notregistered":
+                self._send(404, {"error": "Not registered as a contributor — register first"})
+                return
+            self._send(200, {
+                "contributor_id": "c-%d" % PORT,
+                "registration_token": "reissued-token-%d" % PORT,
+                "message": "Token reissued",
+            })
+            return
+        if self.path == "/api/contribute/register":
+            if MODE == "fresh":
+                self._send(200, {
+                    "contributor_id": "c-%d" % PORT,
+                    "registration_token": "fresh-token-%d" % PORT,
+                    "message": "Registered",
+                })
+            else:
+                self._send(200, {
+                    "contributor_id": "c-%d" % PORT,
+                    "message": "Already registered — to rotate your token, POST /api/contribute/reissue-token",
+                })
+            return
+        self._send(404, {"error": "no such endpoint"})
+
+HTTPServer(("127.0.0.1", PORT), H).serve_forever()
+PY
+
+free_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+start_hub() { # $1 = mode -> echoes the port
+  local mode="$1" port
+  port="$(free_port)"
+  python3 "$WORK/fakehub.py" "$port" "$mode" >/dev/null 2>&1 &
+  echo $! > "$WORK/hub-${port}.pid"
+  for _ in $(seq 1 50); do
+    if curl -sf -o /dev/null -X POST "http://127.0.0.1:${port}/api/contribute/register" \
+         -H 'Content-Type: application/json' -d '{"github_username":"probe"}' 2>/dev/null; then
+      echo "$port"; return 0
+    fi
+    sleep 0.1
+  done
+  echo "  FAIL: fake hub on ${port} never came up" >&2
+  return 1
+}
+
+# ── Stub gh (and nothing else) on PATH ───────────────────────────────────────
+# The `copilot` backend preflight is satisfied by `gh` alone, so this one stub
+# covers the whole dependency chain without faking an agent CLI.
+STUB="$WORK/bin"
+mkdir -p "$STUB"
+cat > "$STUB/gh" <<'SH'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "auth status") exit 0 ;;
+  "auth token")  echo "gho_stub_github_token" ;;
+  "api user")    echo "${STUB_GH_USER:-mover}" ;;
+  *)             exit 0 ;;
+esac
+SH
+chmod +x "$STUB/gh"
+
+FAKE_HOME="$WORK/home"
+mkdir -p "$FAKE_HOME/.config/hive"
+CONF="$FAKE_HOME/.config/hive/contributor.env"
+
+# `env -u HIVE_HUB` is not optional: a real contributor's shell exports
+# HIVE_HUB, and inheriting it would silently steer the recipe at their live
+# hives instead of the fake hub below.
+run_move() { # $1 = HIVE_HUB value ("" = unset), rest = extra `env` assignments
+  local hub="$1"; shift
+  ( cd "$REPO_ROOT" && env -u HIVE_HUB HOME="$FAKE_HOME" PATH="$STUB:$PATH" \
+      HIVE_SKIP_VERSION_CHECK=true HIVE_MOVE_ASSUME_YES=1 \
+      ${hub:+HIVE_HUB="$hub"} "$@" \
+      just contribute-move copilot 2>&1 )
+}
+
+# ── 1. Single hub: the whole point — a machine with no contributor.env ───────
+echo ""
+echo "-- a fresh machine with no local config --"
+PORT_A="$(start_hub ok)" || exit 1
+OUT="$(run_move "ws://127.0.0.1:${PORT_A}/contribute")"; RC=$?
+check "exits 0" "0" "$RC"
+contains "reports the reissue" "$OUT" "reissued (c-${PORT_A})"
+contains "says the old machine is now deauthorized" "$OUT" "no longer authenticates"
+check "token is the reissued one" "reissued-token-${PORT_A}" \
+      "$(grep -m1 '^HIVE_REGISTRATION_TOKEN=' "$CONF" | cut -d= -f2-)"
+check "hub is recorded" "ws://127.0.0.1:${PORT_A}/contribute" \
+      "$(grep -m1 '^HIVE_HUB=' "$CONF" | cut -d= -f2-)"
+check "contributor id is recorded" "c-${PORT_A}" \
+      "$(grep -m1 '^CONTRIBUTOR_ID=' "$CONF" | cut -d= -f2-)"
+check "username comes from gh" "mover" \
+      "$(grep -m1 '^CONTRIBUTOR_USERNAME=' "$CONF" | cut -d= -f2-)"
+check "backend is recorded" "copilot" \
+      "$(grep -m1 '^AGENT_BACKEND=' "$CONF" | cut -d= -f2-)"
+check "contributor.env is 0600" "600" "$(stat -c '%a' "$CONF" 2>/dev/null || stat -f '%Lp' "$CONF")"
+# gh-auth.env is the second required file contribute-hive checks for and that
+# nothing used to mention (#4408 item 4).
+GHENV="$FAKE_HOME/.config/hive/gh-auth.env"
+if [ -f "$GHENV" ]; then
+  pass "gh-auth.env is written too (contribute-hive hard-requires it)"
+  check "gh-auth.env is 0600" "600" "$(stat -c '%a' "$GHENV" 2>/dev/null || stat -f '%Lp' "$GHENV")"
+else
+  fail "gh-auth.env is written too (contribute-hive hard-requires it)"
+fi
+
+# ── 2. Multi-hub: alignment and ORDER are the contract ───────────────────────
+echo ""
+echo "-- two hubs: positional lists must stay aligned and in order --"
+PORT_B="$(start_hub ok)" || exit 1
+rm -f "$CONF" "$CONF.bak"
+OUT="$(run_move "ws://127.0.0.1:${PORT_A}/contribute,ws://127.0.0.1:${PORT_B}/contribute")"; RC=$?
+check "exits 0" "0" "$RC"
+check "hubs keep the given order" \
+      "ws://127.0.0.1:${PORT_A}/contribute,ws://127.0.0.1:${PORT_B}/contribute" \
+      "$(grep -m1 '^HIVE_HUB=' "$CONF" | cut -d= -f2-)"
+check "tokens are in the SAME order as the hubs" \
+      "reissued-token-${PORT_A},reissued-token-${PORT_B}" \
+      "$(grep -m1 '^HIVE_REGISTRATION_TOKEN=' "$CONF" | cut -d= -f2-)"
+check "ids are in the SAME order as the hubs" "c-${PORT_A},c-${PORT_B}" \
+      "$(grep -m1 '^CONTRIBUTOR_ID=' "$CONF" | cut -d= -f2-)"
+# The relay's own guard: one token per hub, or it refuses to start.
+N_HUBS=$(grep -m1 '^HIVE_HUB=' "$CONF" | cut -d= -f2- | tr ',' '\n' | grep -c .)
+N_TOKS=$(grep -m1 '^HIVE_REGISTRATION_TOKEN=' "$CONF" | cut -d= -f2- | tr ',' '\n' | grep -c .)
+check "list lengths agree (bin/contributor-relay.sh exits 1 otherwise)" "$N_HUBS" "$N_TOKS"
+
+# ── 3. Switching back: hubs come from the existing file, extras survive ──────
+echo ""
+echo "-- re-run with no HIVE_HUB: hubs read from contributor.env, extras kept --"
+printf 'HIVE_LITELLM_ENDPOINT=https://litellm.example/v1\n' >> "$CONF"
+OUT="$(run_move "")"; RC=$?
+check "exits 0" "0" "$RC"
+contains "says where the hub list came from" "$OUT" "the existing contributor.env"
+check "both hubs are still there, in order" \
+      "ws://127.0.0.1:${PORT_A}/contribute,ws://127.0.0.1:${PORT_B}/contribute" \
+      "$(grep -m1 '^HIVE_HUB=' "$CONF" | cut -d= -f2-)"
+contains "unmanaged keys are carried across, not dropped" \
+         "$(cat "$CONF")" "HIVE_LITELLM_ENDPOINT=https://litellm.example/v1"
+if [ -f "$CONF.bak" ]; then pass "the previous file is backed up"; else fail "the previous file is backed up"; fi
+
+# ── 4. TLS guard: the GitHub token must not go out in clear ─────────────────
+echo ""
+echo "-- a non-loopback http:// hub is refused before anything is sent --"
+cp "$CONF" "$WORK/before-tls.env"
+OUT="$(run_move "ws://hub.example.com/contribute")"; RC=$?
+check "exits non-zero" "1" "$RC"
+contains "names the reason" "$OUT" "not TLS-protected"
+check "contributor.env is untouched" "$(cat "$WORK/before-tls.env")" "$(cat "$CONF")"
+
+# ── 5. Partial failure must keep the rotations that already happened ────────
+echo ""
+echo "-- one hub reissues, one refuses: keep what was issued, name what failed --"
+PORT_BAD="$(start_hub notregistered)" || exit 1
+rm -f "$CONF" "$CONF.bak"
+OUT="$(run_move "ws://127.0.0.1:${PORT_A}/contribute,ws://127.0.0.1:${PORT_BAD}/contribute")"; RC=$?
+check "exits non-zero so CI/scripts see the partial failure" "1" "$RC"
+contains "says it moved with errors" "$OUT" "Moved with errors"
+contains "names the hub that failed" "$OUT" "127.0.0.1:${PORT_BAD}"
+contains "reports the hub's own reason" "$OUT" "Not registered as a contributor"
+check "the token that WAS reissued is written (it cannot be reprinted)" \
+      "reissued-token-${PORT_A}" \
+      "$(grep -m1 '^HIVE_REGISTRATION_TOKEN=' "$CONF" | cut -d= -f2-)"
+check "the failed hub is not left in the hub list" \
+      "ws://127.0.0.1:${PORT_A}/contribute" \
+      "$(grep -m1 '^HIVE_HUB=' "$CONF" | cut -d= -f2-)"
+
+# ── 6. Every hub fails: write nothing, explain both causes ──────────────────
+echo ""
+echo "-- no hub reissues: contributor.env must not be clobbered --"
+cp "$CONF" "$WORK/before-allfail.env"
+OUT="$(run_move "ws://127.0.0.1:${PORT_BAD}/contribute")"; RC=$?
+check "exits non-zero" "1" "$RC"
+contains "says nothing was written" "$OUT" "was NOT written"
+contains "points a never-registered identity at contribute-setup" "$OUT" "just contribute-setup"
+check "contributor.env is untouched" "$(cat "$WORK/before-allfail.env")" "$(cat "$CONF")"
+
+# ── 7. No hubs to move at all ──────────────────────────────────────────────
+echo ""
+echo "-- no HIVE_HUB and no local config --"
+EMPTY_HOME="$WORK/empty-home"
+mkdir -p "$EMPTY_HOME/.config/hive"
+OUT="$( cd "$REPO_ROOT" && env -u HIVE_HUB HOME="$EMPTY_HOME" PATH="$STUB:$PATH" \
+        HIVE_SKIP_VERSION_CHECK=true HIVE_MOVE_ASSUME_YES=1 \
+        just contribute-move copilot 2>&1 )"; RC=$?
+check "exits non-zero" "1" "$RC"
+contains "tells the contributor how to name their hubs" "$OUT" "export HIVE_HUB=wss://<hive>/contribute"
+contains "explains where to find the hub URLs" "$OUT" "contributor.env on the old"
+
+# ── 8. Consent is required unless explicitly waived ────────────────────────
+echo ""
+echo "-- the rotation is confirmed before the GitHub token is sent --"
+OUT="$( cd "$REPO_ROOT" && env -u HIVE_HUB HOME="$WORK/consent-home" PATH="$STUB:$PATH" \
+        HIVE_SKIP_VERSION_CHECK=true HIVE_HUB="ws://127.0.0.1:${PORT_A}/contribute" \
+        just contribute-move copilot </dev/null 2>&1 )"; RC=$?
+check "declining (empty answer) aborts" "1" "$RC"
+contains "warns that this rotates the credential" "$OUT" "This ROTATES the credential"
+contains "lists the host that would receive the GitHub token" "$OUT" "http://127.0.0.1:${PORT_A}"
+contains "says nothing was sent" "$OUT" "nothing was sent"
+if [ -f "$WORK/consent-home/.config/hive/contributor.env" ]; then
+  fail "no contributor.env is written when the prompt is declined"
+else
+  pass "no contributor.env is written when the prompt is declined"
+fi
+
+# ── 9. contribute-setup's dead end now names the supported paths ───────────
+echo ""
+echo "-- contribute-setup on a new machine points at the move --"
+SETUP_HOME="$WORK/setup-home"
+mkdir -p "$SETUP_HOME/.config/hive"
+OUT="$( cd "$REPO_ROOT" && env -u HIVE_HUB HOME="$SETUP_HOME" PATH="$STUB:$PATH" \
+        HIVE_SKIP_VERSION_CHECK=true HIVE_HUB="ws://127.0.0.1:${PORT_A}/contribute" \
+        just contribute-setup copilot 2>&1 )"; RC=$?
+check "still fails (register must not hand back a token)" "1" "$RC"
+lacks "no longer a bare dead end" "$OUT" "Already registered but no local config found."
+contains "offers the copy path" "$OUT" "KEEP the credential"
+contains "names both files to copy" "$OUT" "gh-auth.env"
+contains "explains why copying is the only reuse" "$OUT" "never be printed again"
+contains "offers the rotate path" "$OUT" "just contribute-move"
+contains "points at the doc" "$OUT" "contributor-relay.md"
+
+# ── 10. contribute-setup must not flatten an existing multi-hub config ─────
+echo ""
+echo "-- registering an ADDITIONAL hive keeps the hive already configured --"
+PORT_NEW="$(start_hub fresh)" || exit 1
+ADD_HOME="$WORK/add-home"
+mkdir -p "$ADD_HOME/.config/hive"
+cat > "$ADD_HOME/.config/hive/contributor.env" <<EOF
+HIVE_REGISTRATION_TOKEN=existing-token-1,existing-token-2
+HIVE_HUB=wss://hive-a.example/contribute,wss://hive-b.example/contribute
+CONTRIBUTOR_ID=c-aaa,c-bbb
+CONTRIBUTOR_USERNAME=mover
+AGENT_BACKEND=copilot
+EOF
+OUT="$( cd "$REPO_ROOT" && env -u HIVE_HUB HOME="$ADD_HOME" PATH="$STUB:$PATH" \
+        HIVE_SKIP_VERSION_CHECK=true HIVE_HUB="ws://127.0.0.1:${PORT_NEW}/contribute" \
+        just contribute-setup copilot 2>&1 )"; RC=$?
+ADD_CONF="$ADD_HOME/.config/hive/contributor.env"
+check "exits 0" "0" "$RC"
+contains "says it appended" "$OUT" "to your existing 2-hub configuration"
+check "the two existing hubs survive, with the new one appended" \
+      "wss://hive-a.example/contribute,wss://hive-b.example/contribute,ws://127.0.0.1:${PORT_NEW}/contribute" \
+      "$(grep -m1 '^HIVE_HUB=' "$ADD_CONF" | cut -d= -f2-)"
+check "their tokens survive, in the same order" \
+      "existing-token-1,existing-token-2,fresh-token-${PORT_NEW}" \
+      "$(grep -m1 '^HIVE_REGISTRATION_TOKEN=' "$ADD_CONF" | cut -d= -f2-)"
+check "their ids survive, in the same order" "c-aaa,c-bbb,c-${PORT_NEW}" \
+      "$(grep -m1 '^CONTRIBUTOR_ID=' "$ADD_CONF" | cut -d= -f2-)"
+if [ -f "$ADD_CONF.bak" ]; then pass "the previous file is backed up"; else fail "the previous file is backed up"; fi
+check "contributor.env is still 0600" "600" \
+      "$(stat -c '%a' "$ADD_CONF" 2>/dev/null || stat -f '%Lp' "$ADD_CONF")"
+
+# The ordinary first-time path must be untouched by the append logic: no
+# existing file, so a plain single-hub contributor.env and no .bak.
+echo ""
+echo "-- a first-time registration still writes a plain single-hub file --"
+NEW_HOME="$WORK/new-home"
+mkdir -p "$NEW_HOME/.config/hive"
+OUT="$( cd "$REPO_ROOT" && env -u HIVE_HUB HOME="$NEW_HOME" PATH="$STUB:$PATH" \
+        HIVE_SKIP_VERSION_CHECK=true HIVE_HUB="ws://127.0.0.1:${PORT_NEW}/contribute" \
+        just contribute-setup copilot 2>&1 )"; RC=$?
+NEW_CONF="$NEW_HOME/.config/hive/contributor.env"
+check "exits 0" "0" "$RC"
+check "single hub" "ws://127.0.0.1:${PORT_NEW}/contribute" \
+      "$(grep -m1 '^HIVE_HUB=' "$NEW_CONF" | cut -d= -f2-)"
+check "single token" "fresh-token-${PORT_NEW}" \
+      "$(grep -m1 '^HIVE_REGISTRATION_TOKEN=' "$NEW_CONF" | cut -d= -f2-)"
+check "single id" "c-${PORT_NEW}" "$(grep -m1 '^CONTRIBUTOR_ID=' "$NEW_CONF" | cut -d= -f2-)"
+check "contributor.env is 0600" "600" \
+      "$(stat -c '%a' "$NEW_CONF" 2>/dev/null || stat -f '%Lp' "$NEW_CONF")"
+lacks "no append chatter on a first-time setup" "$OUT" "to your existing"
+if [ -f "$NEW_CONF.bak" ]; then
+  fail "no .bak is created when there was no previous file"
+else
+  pass "no .bak is created when there was no previous file"
+fi
+
+# A malformed file (lists of different lengths) must NOT be appended to —
+# appending would transpose every hub/token pair after the first mismatch.
+echo ""
+echo "-- a misaligned existing file is not appended to --"
+BAD_HOME="$WORK/bad-home"
+mkdir -p "$BAD_HOME/.config/hive"
+cat > "$BAD_HOME/.config/hive/contributor.env" <<EOF
+HIVE_REGISTRATION_TOKEN=only-one-token
+HIVE_HUB=wss://hive-a.example/contribute,wss://hive-b.example/contribute
+CONTRIBUTOR_ID=c-aaa,c-bbb
+EOF
+OUT="$( cd "$REPO_ROOT" && env -u HIVE_HUB HOME="$BAD_HOME" PATH="$STUB:$PATH" \
+        HIVE_SKIP_VERSION_CHECK=true HIVE_HUB="ws://127.0.0.1:${PORT_NEW}/contribute" \
+        just contribute-setup copilot 2>&1 )"
+contains "warns that the lists do not line up" "$OUT" "do not line up"
+check "writes a single-hub file rather than a misaligned one" \
+      "ws://127.0.0.1:${PORT_NEW}/contribute" \
+      "$(grep -m1 '^HIVE_HUB=' "$BAD_HOME/.config/hive/contributor.env" | cut -d= -f2-)"
+if [ -f "$BAD_HOME/.config/hive/contributor.env.bak" ]; then
+  pass "the malformed file is preserved as .bak (its tokens cannot be reprinted)"
+else
+  fail "the malformed file is preserved as .bak (its tokens cannot be reprinted)"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -36,7 +36,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 
 ## Contributors and access
 
-- [ClankeR contributor relay](contributor-relay.md) — local contributor setup, multi-hub subscriptions, and role requests.
+- [ClankeR contributor relay](contributor-relay.md) — local contributor setup, multi-hub subscriptions, moving a relay to another machine, and role requests.
 - [Contributor trust tiers and delegated agent roles](https://github.com/kubestellar/hive/blob/v4/src/docs/contributor-trust-and-roles.md) — newcomer/contributor/trusted/merger/advisor semantics, **Acting as**, grants, and delegatable roles.
 - [Credly badges](https://github.com/kubestellar/hive/blob/v4/src/docs/credly-badges.md) — planned integration design; currently a placeholder mapping only.
 

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -136,6 +136,58 @@ The lists are positional: the first token belongs to the first hub, the second t
 
 The relay keeps a WebSocket and heartbeat for each subscribed hub, but shares one CLI/tmux session and works on only one task at a time. It rotates to another hub when the active hub has no assignable work. A task that is blocked on human action stays with its owning hub; the relay does not mix task state across hubs.
 
+## Moving the relay to another machine
+
+Nothing binds a contributor identity to a machine. Authentication is a plain token-hash lookup — no device binding, no IP pinning, no session affinity — so the same `contributor.env` authenticates from anywhere. Only one relay should run at a time per identity, but *which* machine it runs on is yours to choose: a desktop today, a VM or a sandbox tomorrow, and back again.
+
+What you cannot do is re-run `contribute-setup` on the new machine. `POST /api/contribute/register` is unauthenticated and identifies you by a self-asserted GitHub username, so it will never hand back an existing contributor's token — otherwise POSTing someone else's username would be an account takeover. It answers "already registered" and stops. That is correct; the two supported ways round it are below.
+
+### Option 1 — copy the credential (keeps the old machine working)
+
+Copy both files. `contribute-hive` hard-requires each of them and refuses to start without either:
+
+```bash
+scp old-machine:~/.config/hive/contributor.env ~/.config/hive/
+scp old-machine:~/.config/hive/gh-auth.env     ~/.config/hive/
+chmod 600 ~/.config/hive/contributor.env ~/.config/hive/gh-auth.env
+```
+
+**Copying is the only way to *reuse* a registration token.** The hive stores only a SHA-256 hash of it and clears the plaintext after the first read, so no endpoint can print it again — not the dashboard, not the API, not the hive administrator.
+
+Use this when you want to switch back and forth, or to try the VM before committing to it. The cost is that the credential now exists in two places: delete both files on the machine you are moving off once the new one works.
+
+### Option 2 — reissue the credential (`just contribute-move`)
+
+```bash
+export HIVE_HUB=wss://hive.example.com/contribute
+just contribute-move claude
+```
+
+`contribute-move` does everything `contribute-setup` does — backend preflight, `gh auth`, `gh-auth.env`, CLI config staging — except that instead of registering it calls `POST /api/contribute/reissue-token`, which authenticates with your GitHub token and therefore *can* prove you own the identity. It then writes `contributor.env` for you.
+
+**This rotates the credential.** Reissuing overwrites the stored hash, so a relay still running on the old machine stops authenticating the moment this succeeds. That is the point when you are moving off a machine you no longer want holding the token — but it means this is not the way to switch back and forth.
+
+Three things it does that a hand-rolled rotation makes easy to get wrong:
+
+- **It preserves every hub, in order.** For more than one hive, list them comma-separated and it reissues against each, writing the positional `HIVE_HUB` / `HIVE_REGISTRATION_TOKEN` / `CONTRIBUTOR_ID` lists aligned in the same order. Doing this by hand means rotating per hub and rebuilding three lists without transposing them; the relay refuses to start when the lengths disagree, and sends the wrong token to the wrong hive when the order is wrong.
+
+  ```bash
+  export HIVE_HUB='wss://hive-a.example.com/contribute,wss://hive-b.example.com/contribute'
+  just contribute-move claude
+  ```
+
+  Re-run it later with `HIVE_HUB` unset and it reuses the hub list already in `contributor.env`.
+
+- **A partial failure keeps what it got.** If the second hive is unreachable, the first one's rotation has already happened on that hive and its new token can never be reprinted — so every token it did receive is written, the failures are named, and the exit status is non-zero. Re-run to retry the rest.
+
+- **It asks before sending your GitHub token.** It prints every host that will receive it and requires confirmation, and it refuses any non-loopback `http://` hub outright. (`contribute-setup` deliberately never sends your GitHub token, because it derives the hub URL from a public registry entry that a poisoned registry would control. `contribute-move` takes the URL from *you* and reissue-token authenticates by GitHub token by design — hence the prompt.) Set `HIVE_MOVE_ASSUME_YES=1` for scripted runs.
+
+Keys `contribute-move` does not manage — `HIVE_LITELLM_ENDPOINT`, for instance — are carried across from the previous file rather than dropped, and the previous file is kept at `contributor.env.bak`.
+
+### Adding another hive to an existing setup
+
+That is not a move: run `contribute-setup` against the new hive with `HIVE_HUB` pointing at it. It appends to the hub, token, and id lists already in `contributor.env` rather than replacing them, so a working multi-hive setup survives. The previous file is kept at `contributor.env.bak`.
+
 ## Acting as a spoke agent role
 
 Set `HIVE_AGENT_ROLE` to request a delegated role, or use the **Acting as** control in `/contribute` where available:


### PR DESCRIPTION
Closes #4408.

## The problem

Nothing in hive prevents running a relay from another machine — auth is a plain token-hash lookup across profiles, with no device binding, no IP pinning, no session affinity, and only one relay runs at a time. **The capability was already there; the setup path was what was missing.** On a second machine the flow dead-ended at:

```
ERROR: Already registered but no local config found.
```

and neither that message nor `contributor-relay.md` said what to do next. The refusal itself is right — `/api/contribute/register` is unauthenticated and identifies by a self-asserted username, so handing back an existing contributor's token would be an account-takeover primitive. What was missing was the way round it.

## `just contribute-move`

Does everything `contribute-setup` does — backend preflight, `gh auth`, `gh-auth.env`, CLI config staging — but calls `POST /api/contribute/reissue-token`, which authenticates by GitHub token and therefore *can* prove identity.

```bash
export HIVE_HUB='wss://hive-a.example.com/contribute,wss://hive-b.example.com/contribute'
just contribute-move claude
```

Three things it gets right that a hand-rolled rotation does not:

- **It preserves every hub, in order.** `contributor.env` carries positional `HIVE_HUB` / `HIVE_REGISTRATION_TOKEN` / `CONTRIBUTOR_ID` lists that `bin/contributor-relay.sh` pairs *by index* — it refuses to start when the lengths disagree, and sends the wrong token to the wrong hive when the order is transposed. Rotating a two-hive identity by hand meant rebuilding three lists without making either mistake. Re-run with `HIVE_HUB` unset and it reuses the hub list already in the file; unmanaged keys (`HIVE_LITELLM_ENDPOINT`) are carried across rather than dropped.
- **A partial failure keeps what it got.** A reissued token can never be reprinted — the hub stores only a hash and clears the plaintext — so discarding tokens already issued because a *later* hub failed would lock the contributor out of the hives that succeeded. Every success is written, the failures are named, the exit status is red.
- **It asks before sending your GitHub token**, prints every host that will receive it, and refuses any non-loopback `http://` hub outright.

### On sending the GitHub token — please sanity-check this call

`contribute-setup` deliberately does **not** forward the contributor's PAT (H7/CWE-522), because it derives the hub URL from a public registry entry's `dashboardUrl` that a poisoned registry would control. `contribute-move` has to send it, because that is how `reissue-token` authenticates. I judged the risk materially different — here the URL comes from *the contributor's own* `HIVE_HUB` or their existing `contributor.env`, not from a registry lookup — and added two guards rather than relying on that alone: **TLS is required** for any non-loopback host, and **every receiving host is printed and confirmed** before anything is sent (`HIVE_MOVE_ASSUME_YES=1` for scripted runs). If you'd rather this refused to run without an explicit opt-in flag, say so and I'll tighten it.

## Two fixes the issue names alongside it

**The dead end is now actionable.** It prints both supported paths — copy `contributor.env` **and** `gh-auth.env` (0600) to keep the credential, or `contribute-move` to rotate it — and states that copying is the only way to *reuse* a token, since the plaintext is cleared after first read and can never be printed again. `gh-auth.env` is the second file `contribute-hive` hard-requires (issue item 4), and nothing mentioned it; `contribute-move` writes it.

**`contribute-setup` no longer flattens a multi-hub config.** Registering an *additional* hive used to `cat >` a single-hub file unconditionally — silently destroying a live token for the first hive that the hub can never reprint. It now appends to the existing lists, backs the previous file up either way, and refuses to append to a file whose lists are already misaligned (appending there would transpose every pair after the mismatch). This is the one change that touches the main onboarding path, so it has explicit regression coverage: a first-time registration still writes a plain single-hub file with no `.bak` and no append chatter.

## Verification

`src/deploy/test_contribute_move.sh` executes the **real recipes** against a fake hub, with a stubbed `gh` and a throwaway `HOME` — no network, no real credential, placeholder values only. It follows `test_contribute_k8s_workload.sh` (#2549) in shape and is wired next to it in `v2-ci.yml`.

Grepping the Justfile would prove none of this: that the positional lists come out aligned and in order is a property of the loop, not of any line in it, and "a later failure must not discard the tokens already reissued" is control flow.

**66 assertions, 0 failures**, covering: the fresh machine (both files written, 0600); multi-hub order and alignment; re-running with the hub list read from `contributor.env`; unmanaged keys surviving; the TLS refusal leaving the file untouched; partial failure (keeps the reissued token, names the failed hub, reports the hub's *own* reason, exits non-zero); total failure not clobbering `contributor.env`; the consent prompt including EOF on stdin; the reworded dead end; multi-hub append; first-time registration; and the misaligned-file case.

Two real bugs were caught by writing the test rather than by reading the code — a `while read` loop that dropped the last hub because `printf '%s'` emitted no trailing newline, and `read -p` at EOF killing the recipe under `set -e` before it could print why it stopped. Both fixed.

`shellcheck` clean. `test_contribute_k8s_workload.sh`, `bin/test_bin_suites_wired.sh` and `check-podman-contract.sh` (which parses the Justfile) all still pass.

## Scope

Contributor tooling and docs only — no hub-side handler, endpoint, or policy change, exactly as the issue's compatibility note says. `contributor-relay.md` gains a "Moving the relay to another machine" section covering both directions plus the multi-hub caveat and the "adding another hive is not a move" case; there was no section for this at all, and `reissue-token` appeared only as a bare row in `api-reference.md`. I left `api-reference.md` alone since it is a generated index.

— hive: backend=claude model=claude-opus-5
