### PR TITLE
📖 docs: dashboard-token generation, PAT scopes per ACMM tier, and CHANGELOG catch-up

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,5 @@ Fixes #
 - [ ] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
 - [ ] Commits include DCO sign-off (`git commit -s`).
 - [ ] Docs, examples, and policies are updated when behavior changes.
+- [ ] `CHANGELOG.md` has an entry for user-visible changes (features, fixes, new env vars, behavior changes), or the change is not user-facing.
 - [ ] No secrets, credentials, or local runtime state are committed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,39 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 No notable user-facing changes have been recorded since the dated entries below.
 
+## 2026-08-21
+
+Covers user-facing changes merged between 2026-08-11 and 2026-08-21 (the previous dated entry closed at 2026-08-10). This section was reconstructed from merged-PR history after the record fell behind.
+
+### Added
+
+- Convergence engine (default **off**): a new `convergence.mode` rollout knob (`off`/`shadow`/`enforce`) with admission diagnostics, canonical outcome identity and desired-generation status, exact-subject GitHub proof, selective proof invalidation, and a fenced, idempotent mutation journal ([#4356](https://github.com/kubestellar/hive/pull/4356), [#4362](https://github.com/kubestellar/hive/pull/4362), [#4366](https://github.com/kubestellar/hive/pull/4366), [#4372](https://github.com/kubestellar/hive/pull/4372), [#4382](https://github.com/kubestellar/hive/pull/4382), [#4388](https://github.com/kubestellar/hive/pull/4388), [#4389](https://github.com/kubestellar/hive/pull/4389)). Behavior is unchanged unless the mode is turned on.
+- Podman deployment path: host preflight checks (engine, root mode, cgroups, SELinux, mounts, secrets, ports, subordinate IDs), Quadlet units for the Hive service, gateway, network boundary, and data volume, a rootful/rootless × enforcing/advisory support matrix, digest-pinned manual update and rollback, and backup/restore plus Docker-to-Podman migration guidance ([#4284](https://github.com/kubestellar/hive/pull/4284), [#4286](https://github.com/kubestellar/hive/pull/4286), [#4307](https://github.com/kubestellar/hive/pull/4307), [#4340](https://github.com/kubestellar/hive/pull/4340), [#4342](https://github.com/kubestellar/hive/pull/4342), [#4355](https://github.com/kubestellar/hive/pull/4355), [#4380](https://github.com/kubestellar/hive/pull/4380), [#4383](https://github.com/kubestellar/hive/pull/4383), [#4385](https://github.com/kubestellar/hive/pull/4385), [#4407](https://github.com/kubestellar/hive/pull/4407), [#4409](https://github.com/kubestellar/hive/pull/4409)).
+- `just contribute-move`: a supported path to move a contributor relay to another machine by reissuing its credential, instead of hand-copying `contributor.env` ([#4418](https://github.com/kubestellar/hive/pull/4418)).
+- Explain mode: per-agent `explain_mode: brief|full` asks the agent to record its own reasoning in its run log for debugging, with `?explain=only|hide` log filters ([#3897](https://github.com/kubestellar/hive/pull/3897)).
+- Budget history: per-window token budget history is recorded so past resets stay visible, and the dashboard draws a budget-window history graph with labeled trend axes ([#4320](https://github.com/kubestellar/hive/pull/4320), [#4331](https://github.com/kubestellar/hive/pull/4331)). Operators can also reset the budget window from the dashboard ([#3614](https://github.com/kubestellar/hive/pull/3614)).
+- Release channels: stable/candidate/edge image channels are published from `v4`, with a channel badge and picker in the hub and spoke dashboards ([#3702](https://github.com/kubestellar/hive/pull/3702), [#3703](https://github.com/kubestellar/hive/pull/3703), [#3762](https://github.com/kubestellar/hive/pull/3762)).
+- Work sources (Phase 1): read-only adapters for GitHub Projects v2, Jira Cloud, and Linear alongside the default GitHub Issues source, with a Work Source settings tab ([#4189](https://github.com/kubestellar/hive/pull/4189)–[#4196](https://github.com/kubestellar/hive/pull/4196)).
+- Hub Manage Access improvements: user search, provider identity icons, GitHub display names/avatars, last-active timestamps, bulk role change/remove, CSV export, time-limited grants, and an append-only permission audit log ([#4138](https://github.com/kubestellar/hive/pull/4138)–[#4163](https://github.com/kubestellar/hive/pull/4163)).
+- Multi-provider human login on the hub, including OIDC providers, with enriched user identities ([#3664](https://github.com/kubestellar/hive/pull/3664), [#4115](https://github.com/kubestellar/hive/pull/4115)).
+- `project.issue_filter`: label-gate which issues agents may initiate work on ([#4040](https://github.com/kubestellar/hive/pull/4040)).
+- Durable per-kick agent run logs with history in the dashboard ([#4308](https://github.com/kubestellar/hive/pull/4308)), and model/reasoning-effort attribution on PRs and Live Activity events ([#4088](https://github.com/kubestellar/hive/pull/4088), [#4091](https://github.com/kubestellar/hive/pull/4091)).
+- Weekly (Tuesday 1pm ET) auto-upgrade mode for hosted hives ([#4381](https://github.com/kubestellar/hive/pull/4381)).
+- Documentation: a v2 → v4 migration guide ([#4300](https://github.com/kubestellar/hive/pull/4300)) and a beginner "Zero to Automation" getting-started guide ([#4090](https://github.com/kubestellar/hive/pull/4090) and follow-ups).
+
+### Fixed
+
+- Hosted App-key delivery resolves the cluster hub-record-first, matching the alert and registry, so a claimed hive receives its App key on the first heartbeat instead of stalling on `key-missing` ([#4333](https://github.com/kubestellar/hive/pull/4333)).
+- Advisory alerts: the stale-advisory alert names repos with Issues disabled ([#4330](https://github.com/kubestellar/hive/pull/4330)), the digest never adopts a foreign-authored comment the App cannot edit ([#4332](https://github.com/kubestellar/hive/pull/4332)), and Hive detects repos the App installation does not cover instead of blaming an undelivered key ([#4364](https://github.com/kubestellar/hive/pull/4364)).
+- Dashboard restart-count and budget-window resets no longer flicker back to stale values after a successful reset ([#4315](https://github.com/kubestellar/hive/pull/4315), [#4351](https://github.com/kubestellar/hive/pull/4351)).
+- Contributor relay reliability: completion/idle detection across Codex, agy, and Gemini backends, in-flight task resume on reconnect, and pane-stall handling no longer interrupts a live CLI ([#4026](https://github.com/kubestellar/hive/pull/4026), [#4067](https://github.com/kubestellar/hive/pull/4067), [#4086](https://github.com/kubestellar/hive/pull/4086), [#4265](https://github.com/kubestellar/hive/pull/4265), [#4287](https://github.com/kubestellar/hive/pull/4287)).
+
+### Security
+
+- Sandbox egress gate: closed the IPv6 bypass of the IPv4-only forced-proxy gate ([#4327](https://github.com/kubestellar/hive/pull/4327)), without failing closed on pods that have no IPv6 egress ([#4350](https://github.com/kubestellar/hive/pull/4350)).
+- A multi-wave security audit (2026-08-10 → 2026-08-14) hardened hub/spoke authentication (per-hive heartbeat bearers, revocable Ed25519 sessions, master-key generations and rotation), restored owner-only dashboard gates, closed SSRF/symlink/redirect holes, and digest-pinned supply-chain images; the accompanying documentation sweep is in [#3830](https://github.com/kubestellar/hive/pull/3830).
+- `/metrics` fails closed when `HIVE_METRICS_TOKEN` is unset ([#3804](https://github.com/kubestellar/hive/pull/3804)).
+
 ## 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/kubestellar/hive.git
 cd hive
 
 cp src/hive.yaml.example src/hive.yaml
-echo "HIVE_GITHUB_TOKEN=ghp_..." > .env
+echo "HIVE_GITHUB_TOKEN=ghp_..." > .env   # classic PAT: repo scope (see src/docs/github-app-setup.md#personal-access-token-pat-scopes)
 docker compose -f src/docker-compose.yaml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,12 @@ kubectl create namespace hive
 ```bash
 kubectl -n hive create secret generic hive-secrets \
   --from-literal=HIVE_GITHUB_TOKEN=ghp_... \
-  --from-literal=HIVE_DASHBOARD_TOKEN=your-dashboard-auth-token
+  --from-literal=HIVE_DASHBOARD_TOKEN="$(openssl rand -hex 32)"
 ```
+
+The dashboard token is an opaque shared secret with no server-side strength
+check — always generate it with a CSPRNG as above, never a hand-typed value.
+See [Generating and rotating `HIVE_DASHBOARD_TOKEN`](src/docs/env-vars.md#generating-and-rotating-hive_dashboard_token).
 
 For GitHub App auth (recommended for production), add the private key:
 

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -13,7 +13,7 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `HIVE_GITHUB_TOKEN` | Required unless GitHub App auth is configured | none | Main PAT fallback for `github.token`; also used by fleet/stat fallback paths and some deployment manifests. |
 | `GH_APP_KEY_FILE` | No | configured `github.key_file`, then `/data/gh-app-key.pem` or `/secrets/gh-app-key.pem` in provisioned paths | GitHub App private-key file fallback. |
 | `DASHBOARD_AUTH_TOKEN` | No | none | Kubernetes/provisioned secret name for the dashboard shared token; used before `HIVE_DASHBOARD_TOKEN` when `dashboard.auth_token` is empty. |
-| `HIVE_DASHBOARD_TOKEN` | No | none | Dashboard/API shared-token fallback and default `hivectl --token-env` variable. |
+| `HIVE_DASHBOARD_TOKEN` | No | none | Dashboard/API shared-token fallback and default `hivectl --token-env` variable. See [Generating and rotating `HIVE_DASHBOARD_TOKEN`](#generating-and-rotating-hive_dashboard_token). |
 | `HIVE_AUTHORIZED_USERS` | No | none | Comma-separated direct-route dashboard allowlist, with optional `user:role` entries. Used when `dashboard.authorized_users` is empty. |
 | `HIVE_REPO` | No | none | Bootstrap shortcut in `owner/repo` form; fills `project.org`, `project.repos`, and `project.primary_repo` if missing. |
 | `HIVE_LEVEL` | No | config/pack value | ACMM level bootstrap/override used by hosted flows and the entrypoint pack selection. |
@@ -34,6 +34,48 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `HIVE_FEDERATION_REGISTRY_PATH` | No | `/data/federation/registry.json` | Federation registry path override. |
 | `HIVE_WEBHOOK_SECRET` | No | none | HMAC secret for the spoke `/webhook` channel. |
 | `GITHUB_WEBHOOK_SECRET` | No | `/data/saas/webhook-secret.key` when present | Hub GitHub webhook HMAC secret. |
+
+## Generating and rotating `HIVE_DASHBOARD_TOKEN`
+
+`HIVE_DASHBOARD_TOKEN` (and the `dashboard.auth_token` config key it falls back
+to) is an opaque shared secret. The server does **not** enforce any format:
+
+- **Format**: any non-empty string is accepted. It is not parsed as a UUID,
+  JWT, or hex value — it is compared byte-for-byte (in constant time) against
+  the `Authorization: ******` value on each API request.
+- **Validation**: there is no startup validation and no minimum-length or
+  entropy check. A weak or predictable value is accepted silently, so the
+  burden of picking a strong value is entirely on the operator.
+- **What it protects**: on a self-hosted (non-direct-route) hive this token is
+  the *only* API credential — it gates agent logs, kick controls, and config
+  reads/writes, and it doubles as the server-to-server `X-Hive-Internal`
+  credential used by the local proxy. Treat it like a root password for the
+  hive. On direct-route or hub-proxied spokes identity is per-user and the
+  shared token is server-to-server only.
+- **Empty value**: leaving it unset leaves the dashboard API unauthenticated
+  (unless direct-route per-user authorization is configured). Never deploy an
+  internet-reachable hive without it.
+
+Generate a strong value with a CSPRNG; 32 bytes (256 bits) of entropy is
+recommended:
+
+```sh
+openssl rand -hex 32
+# or
+head -c 32 /dev/urandom | base64 | tr -d '=+/'
+```
+
+Placeholders like `your-dashboard-auth-token` in deployment examples must be
+replaced — any string "works", but a guessable token is a full-access
+credential.
+
+**Rotation**: the token is read at process start and compared per request, so
+rotating is: update the env var / Kubernetes Secret / `config.env`, then
+restart the container or pod. The old token stops being accepted as soon as
+the process restarts with the new value; there is no separate session
+invalidation step (browser device-flow sessions use their own cookies and are
+unaffected). Update any `hivectl` environments and other API clients to the
+new value at the same time.
 
 ## Deployment entrypoint and proxy knobs
 

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -10,7 +10,7 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `HIVE_MODE` | No | spoke/dashboard mode | Set to `hub` to run the hub server instead of the spoke dashboard. |
 | `HIVE_HUB_PORT` | No | `3001` | Hub listen port when `HIVE_MODE=hub`. |
 | `HIVE_SINGLETON_LOCK` | No | `/var/run/hive-metrics/hive.singleton.lock` when available, otherwise OS temp dir | Overrides the process singleton lock path. Set exactly `off` only for local development where duplicate processes are intentional. |
-| `HIVE_GITHUB_TOKEN` | Required unless GitHub App auth is configured | none | Main PAT fallback for `github.token`; also used by fleet/stat fallback paths and some deployment manifests. |
+| `HIVE_GITHUB_TOKEN` | Required unless GitHub App auth is configured | none | Main PAT fallback for `github.token`; also used by fleet/stat fallback paths and some deployment manifests. Missing PAT scopes surface as request-time 403s — see [Required PAT scopes](github-app-setup.md#personal-access-token-pat-scopes). |
 | `GH_APP_KEY_FILE` | No | configured `github.key_file`, then `/data/gh-app-key.pem` or `/secrets/gh-app-key.pem` in provisioned paths | GitHub App private-key file fallback. |
 | `DASHBOARD_AUTH_TOKEN` | No | none | Kubernetes/provisioned secret name for the dashboard shared token; used before `HIVE_DASHBOARD_TOKEN` when `dashboard.auth_token` is empty. |
 | `HIVE_DASHBOARD_TOKEN` | No | none | Dashboard/API shared-token fallback and default `hivectl --token-env` variable. See [Generating and rotating `HIVE_DASHBOARD_TOKEN`](#generating-and-rotating-hive_dashboard_token). |

--- a/src/docs/github-app-setup.md
+++ b/src/docs/github-app-setup.md
@@ -4,6 +4,40 @@
 
 Hive can authenticate with either a personal access token or a GitHub App. Use a GitHub App for production hives because installation tokens are scoped to selected repositories and can author PRs as the app bot when `github.app_authored_prs` is enabled.
 
+## Personal access token (PAT) scopes
+
+The PAT path is `HIVE_GITHUB_TOKEN` (or `github.token` in `hive.yaml`); the App path is `github.app_id`/`github.key_file` as described below. If you set `app_id`/`key_file` this section does not apply — the App permission table further down does.
+
+Hive never validates token scopes at startup. A PAT with missing scopes fails **at request time** with generic GitHub 403 responses (fine-grained PATs typically say `Resource not accessible by personal access token`). The visible symptoms are agents reporting no actionable work, advisory digests not appearing on the tracking issue, empty fleet-stats widgets, or failed issue/PR writes in agent logs — none of which name the missing scope. If you see unexplained 403s, check the scopes below first.
+
+### Classic PATs
+
+Classic scopes are coarse, so one scope covers every ACMM tier:
+
+| ACMM tier | Minimum classic scopes | Why |
+| --- | --- | --- |
+| L1–L2 (advisory) | `repo` (private repos) or `public_repo` (public repos only) | Read issues/PRs/contents; post advisory digest comments to the pinned tracking issue (an issues **write**, even though the tier is otherwise read-only). |
+| L3–L4 (issue filing) | same | Create, label, comment on, and close issues. |
+| L5–L6 (PR/merge) | same, plus `workflow` if agent PRs may touch `.github/workflows/` | Push branches, open/update/merge PRs, read checks/statuses. GitHub rejects workflow-file pushes without `workflow`. |
+
+Add `read:org` when Hive should identify org members and contributor roles (recommended for org-owned hives).
+
+### Fine-grained PATs
+
+Fine-grained PATs are supported — the token is sent as a plain bearer, same as a classic PAT. Grant the token access to every repository the hive works on, with repository permissions mirroring the App table below:
+
+| Permission | L1–L2 (advisory) | L3–L4 (issues) | L5–L6 (PR/merge) |
+| --- | --- | --- | --- |
+| Metadata | Read | Read | Read |
+| Contents | Read | Read | Read and write |
+| Issues | Read and write | Read and write | Read and write |
+| Pull requests | Read | Read | Read and write |
+| Checks | Read | Read | Read |
+| Actions | Read | Read | Read |
+| Commit statuses | Read | Read | Read |
+
+Organization permission: **Members: Read** where contributor/owner identification is configured. Note that Issues read-and-write is needed even at advisory tiers because digests are posted as issue comments.
+
 ## Create the app
 
 In GitHub, open **Settings → Developer settings → GitHub Apps → New GitHub App** (or the equivalent organization settings page). On **GitHub Enterprise**, do this on your enterprise host (`https://<your-ghe-host>/settings/apps/new`), not github.com — the app, its install page (`https://<your-ghe-host>/github-apps/<app-slug>`), and the source control host Hive is configured for must all be the same host.

--- a/src/docs/hivectl.md
+++ b/src/docs/hivectl.md
@@ -10,7 +10,9 @@ operates it.
 go build -o bin/hivectl ./cmd/hivectl
 
 # Point at a server (default: http://127.0.0.1:3001) and provide the token
-# via an environment variable, never as a flag value.
+# via an environment variable, never as a flag value. The value must match the
+# server's dashboard token — see "Generating and rotating HIVE_DASHBOARD_TOKEN"
+# in env-vars.md (generate with: openssl rand -hex 32).
 export HIVE_DASHBOARD_TOKEN="..."
 bin/hivectl system status
 

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -191,7 +191,7 @@ installation instead of broadening the PAT.
 
 | Name | Purpose |
 |---|---|
-| `HIVE_GITHUB_TOKEN` | Main PAT fallback when `github.token` is empty; also used for token identity/fleet stats fallback. |
+| `HIVE_GITHUB_TOKEN` | Main PAT fallback when `github.token` is empty; also used for token identity/fleet stats fallback. Wrong-scope tokens fail with generic 403s at request time — see [github-app-setup.md](github-app-setup.md#personal-access-token-pat-scopes) for the required scopes per ACMM tier. |
 | `GH_APP_KEY_FILE` | GitHub App private-key path fallback when `github.key_file` is empty. |
 | `HIVE_DASHBOARD_TOKEN` | Shared dashboard/API token fallback for `dashboard.auth_token`. Any non-empty string is accepted with no strength check — generate one with `openssl rand -hex 32`; see [env-vars.md](env-vars.md#generating-and-rotating-hive_dashboard_token). |
 

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -193,7 +193,7 @@ installation instead of broadening the PAT.
 |---|---|
 | `HIVE_GITHUB_TOKEN` | Main PAT fallback when `github.token` is empty; also used for token identity/fleet stats fallback. |
 | `GH_APP_KEY_FILE` | GitHub App private-key path fallback when `github.key_file` is empty. |
-| `HIVE_DASHBOARD_TOKEN` | Shared dashboard/API token fallback for `dashboard.auth_token`. |
+| `HIVE_DASHBOARD_TOKEN` | Shared dashboard/API token fallback for `dashboard.auth_token`. Any non-empty string is accepted with no strength check — generate one with `openssl rand -hex 32`; see [env-vars.md](env-vars.md#generating-and-rotating-hive_dashboard_token). |
 
 ### Hosted-spoke and fleet metadata
 


### PR DESCRIPTION
## Summary

Resolves the three guide-agent documentation issues:

- **HIVE_DASHBOARD_TOKEN** (#4391): new *Generating and rotating* section in `env-vars.md` documenting the actual contract — any non-empty string, no format/length validation, request-time constant-time compare only — with secure generation (`openssl rand -hex 32`) and rotation steps (update secret, restart; no session-invalidation step). Cross-linked from `hivectl.md`, `operator-reference.md`, and the README, whose `your-dashboard-auth-token` placeholder now uses a CSPRNG.
- **HIVE_GITHUB_TOKEN PAT scopes** (#4390): new *Personal access token (PAT) scopes* section in `github-app-setup.md` — classic minimums per ACMM tier (`repo`/`public_repo`, `workflow` at L5/L6, `read:org`), the fine-grained per-tier repository-permission table mirroring the App table (Issues write needed even at advisory tiers for digest comments), the cryptic request-time 403 symptoms, and the PAT-vs-App path distinction. Cross-linked from `env-vars.md`, `operator-reference.md`, and the README quick start.
- **CHANGELOG catch-up** (#4392): new dated `2026-08-21` section explicitly covering 2026-08-11 → 2026-08-21, reconstructed from merged-PR history and limited to user-facing changes (convergence engine default-off, Podman/Quadlet stack, `just contribute-move`, explain mode, budget history, release channels, work sources, Manage Access, advisory/app-key/flicker/relay fixes, IPv6 egress-gate close, security-audit waves). Adds a CHANGELOG item to the PR template checklist.

## Related issues

Closes #4390
Closes #4391
Closes #4392

## Testing

- [ ] `cd src && go build ./...`
- [ ] `cd src && go test ./...`
- [x] Other / not run (explain): documentation-only change; all claims verified against the code (`src/pkg/dashboard/server.go` secureCompare, `src/pkg/config/config.go` env fallbacks, `src/pkg/github` API surface) and against actual merged-PR titles.

## Contributor checklist

- [x] PR targets `v4` as requested by the filing issues.
- [x] Title uses the repo emoji convention.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes.
- [x] No secrets, credentials, or local runtime state are committed.