### PR TITLE
docs: add the Podman standalone quick start to the README (#4412)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ AI agent orchestration for open source projects. A single Go binary enumerates G
 
 Hive separates decisions into two layers: a **deterministic pipeline** of shell scripts handles filtering, classification, merge-gating, and enforcement before any LLM sees the work. Agents only handle judgment calls — reading code, reasoning about fixes, writing PRs.
 
+## Quick Start
+
+Two supported standalone runtimes. **Docker Compose is the default** and is what
+the rest of this README assumes; **Podman** is a parallel supported choice, not
+an experiment and not a recommendation over Docker. Pick one — they install the
+same two services (Hive plus its authenticating gateway) and land the dashboard
+on the same port.
+
+| | [Docker Compose](#quick-start-docker-compose) | [Podman](#quick-start-podman) |
+| --- | --- | --- |
+| Lifecycle | `docker compose up -d` | Quadlet units under systemd |
+| Runs as | the Docker daemon | rootful **or** rootless |
+| Update path | pull and recreate; optional Watchtower profile | [pinned by digest, with rollback](src/docs/podman-quadlet-update-rollback.md) |
+
 ## Quick Start (Docker Compose)
 
 **Prerequisites**
@@ -31,6 +45,130 @@ To build from source instead of pulling the pre-built image:
 docker compose -f src/docker-compose.yaml build
 docker compose -f src/docker-compose.yaml up -d
 ```
+
+## Quick Start (Podman)
+
+Same two services as the Compose stack, run as systemd units through Quadlet, so
+`systemctl start` returning means Hive answered `/api/health` rather than merely
+that a process was spawned. Docker is not required and is not used.
+
+**Prerequisites**
+
+- **Podman 5.0.0+** (ADR-0017 recommends **5.6.0**; the verified floor is
+  unknown — see [the requirements note](src/docs/podman-standalone-quadlet.md#requirements))
+- **systemd**, and **cgroup v2** — `podman info --format '{{.Host.CgroupsVersion}}'`
+- The **Quadlet generator** at `/usr/libexec/podman/quadlet`. It ships with the
+  distribution `podman` package; a hand-installed podman binary may not carry it.
+- **`aardvark-dns`** — `podman info --format '{{.Host.NetworkBackend}}'` should
+  say `netavark`. Without it the gateway starts and cannot resolve `hive`, so
+  `:3001` serves 502s.
+- `git`, `openssl`, and a GitHub token (PAT or App) for the org the hive works on
+
+The block below is **rootless**. For rootful, set `CONF=/etc/hive`, drop the
+`podman unshare` line in favour of the `chgrp` beside it, install the units into
+`/etc/containers/systemd/` with `sudo`, and drop `--user` from every `systemctl`.
+
+```bash
+# Selects the Podman path. WITHOUT THIS the preflights below exit 0 having
+# checked nothing — they default to Docker and skip.
+export HIVE_DEPLOY_RUNTIME=podman
+
+git clone https://github.com/kubestellar/hive.git
+cd hive
+
+# Engine, root mode, cgroups; then subordinate IDs, graphroot, networking.
+# A missing subuid range or cgroup v1 host fails HERE rather than as a start
+# that times out five minutes later.
+bin/hive-podman-preflight.sh
+bin/hive-podman-preflight-ids.sh
+# (hive-podman-preflight-host.sh checks SELinux labels and port 3001 too, but
+#  reads the source-tree layout rather than this one — see #4422.)
+
+CONF=~/.config/hive                       # rootful: CONF=/etc/hive
+mkdir -p "$CONF/secrets" && chmod 750 "$CONF/secrets"
+podman unshare chown -R 0:1002 "$CONF/secrets"    # rootful: chgrp -R 1002 "$CONF/secrets"
+
+cp src/hive.yaml.example "$CONF/hive.yaml"
+# REQUIRED. The example ships 3001 for local source runs; the unit's healthcheck
+# probes 3002. Keeping 3001 costs a silent 300-second hang with no container
+# left to inspect.
+sed -i 's/^  port: 3001$/  port: 3002/' "$CONF/hive.yaml"
+# then edit the rest of "$CONF/hive.yaml" for your project
+
+cp src/deploy/nginx.conf "$CONF/nginx.conf"
+
+# Must EXIST, even if every line stays commented out: EnvironmentFile= becomes
+# `podman run --env-file`, which fails on a missing file.
+cp src/deploy/quadlet/hive.env.example "$CONF/hive.env"
+chmod 600 "$CONF/hive.env"
+printf 'HIVE_DASHBOARD_TOKEN=%s\n' "$(openssl rand -hex 32)" >> "$CONF/hive.env"
+printf 'HIVE_GITHUB_TOKEN=%s\n'    'ghp_...'                 >> "$CONF/hive.env"
+
+# Pull before starting. The generated ExecStart pulls a missing image itself and
+# that pull is spent inside TimeoutStartSec; the Hive image is ~3.8GB.
+podman pull ghcr.io/kubestellar/hive:stable
+
+# All four units — the gateway will not generate without the network it names.
+install -Dm644 src/deploy/quadlet/hive.container         ~/.config/containers/systemd/hive.container
+install -Dm644 src/deploy/quadlet/hive-data.volume       ~/.config/containers/systemd/hive-data.volume
+install -Dm644 src/deploy/quadlet/hive.network           ~/.config/containers/systemd/hive.network
+install -Dm644 src/deploy/quadlet/hive-gateway.container ~/.config/containers/systemd/hive-gateway.container
+systemctl --user daemon-reload
+
+# Starting the gateway pulls Hive, the network and the volume up in order.
+systemctl --user start hive-gateway.service
+```
+
+In a logged-in session the stack may already be up before you reach that last
+line: `daemon-reload` runs the generator, which writes the
+`default.target.wants/` symlinks from `[Install]`, and systemd starts
+newly-wanted units of an already-active target. The `start` is then a no-op that
+returns 0, and is worth running anyway as the confirmation that it did.
+
+Dashboard at `http://localhost:3001`, the same port and the same single
+published port as the Compose stack — Hive's own 3001/3002 and the raw ttyd
+terminal on 7681 stay inside the container network. Confirm the stack end to
+end, which also proves the gateway resolved `hive` over the shared network:
+
+```bash
+curl -sf http://127.0.0.1:3001/api/health     # -> {"status":"ok"}
+```
+
+`daemon-reload` runs the generator, and `[Install] WantedBy=default.target`
+inside the units is what wires them to boot — there is nothing to `systemctl
+enable`, and trying fails, because generated units cannot be enabled. **Rootless
+additionally needs `loginctl enable-linger "$USER"`** or the user manager never
+starts at boot. Check with `bin/hive-podman-lifecycle-probe.sh check`, not with
+`systemctl is-enabled`, which reports `generated` either way.
+
+**Security posture — pick deliberately.** The shipped unit requests
+`CAP_NET_ADMIN`, so the forced-proxy egress gate is *enforced* by default. Where
+that capability is unavailable, `HIVE_PROXY_ADVISORY_OK=true` in `$CONF/hive.env`
+starts Hive with the gate **not installed**; without either, Hive refuses to
+start with exit 77 rather than running an unenforced capability model.
+
+| | Enforcing (default) | Advisory (`HIVE_PROXY_ADVISORY_OK=true`) |
+| --- | --- | --- |
+| **Rootful** | **Supported** | Supported as a deliberate choice, **unenforced** |
+| **Rootless** | **Experimental** | Supported as a deliberate choice, **unenforced** |
+
+Advisory mode is **not** a weaker grade of enforcing and **not** a fallback:
+agents can bypass the MITM proxy and the ACMM capability model is not enforced.
+Choose it knowingly. Full matrix and the evidence behind each cell:
+[src/docs/podman-support-matrix.md](src/docs/podman-support-matrix.md).
+
+To build from source instead of pulling the pre-built image, build and tag it
+under the name the unit already names, then start as above:
+
+```bash
+podman build -t ghcr.io/kubestellar/hive:stable -f src/Dockerfile .
+```
+
+Full install detail — unit search paths, the traps behind each step above, boot
+persistence, and what was measured in both root modes — is in
+**[src/docs/podman-standalone-quadlet.md](src/docs/podman-standalone-quadlet.md)**.
+Update and rollback: [src/docs/podman-quadlet-update-rollback.md](src/docs/podman-quadlet-update-rollback.md).
+Teardown: `bin/hive-podman-teardown.sh`.
 
 ## Kubernetes Deployment
 

--- a/src/docs/podman-standalone-quadlet.md
+++ b/src/docs/podman-standalone-quadlet.md
@@ -126,8 +126,27 @@ remove `HealthCmd=`.
   `hive`, so `:3001` serves 502s. It ships alongside `netavark` on Fedora and
   most distributions; `podman info --format '{{.Host.NetworkBackend}}'` should
   say `netavark`.
-- Run the preflight first: `bin/hive-podman-preflight.sh`,
-  `bin/hive-podman-preflight-ids.sh`, `bin/hive-podman-preflight-host.sh`.
+- Run the preflight first — **and export `HIVE_DEPLOY_RUNTIME=podman` before you
+  do**, or all three exit 0 having checked nothing. Docker is the default
+  runtime, and with it selected they print
+  `Podman preflight: skipped — HIVE_DEPLOY_RUNTIME selects docker` and return
+  success, which reads exactly like a pass:
+
+  ```sh
+  export HIVE_DEPLOY_RUNTIME=podman
+  bin/hive-podman-preflight.sh          # engine, root mode, cgroups
+  bin/hive-podman-preflight-ids.sh      # subordinate IDs, graphroot, networking
+  ```
+
+  `bin/hive-podman-preflight-host.sh` checks SELinux labels, config and secrets
+  readability, and port 3001 — but it looks for the **source-tree** layout
+  (`$HIVE_SRC_DIR/hive.yaml`, `$HIVE_SRC_DIR/deploy/nginx.conf`,
+  `$HIVE_SRC_DIR/secrets`, default `src/`). The Quadlet install below puts
+  `nginx.conf` flat in `%E/hive`, not under a `deploy/` subdirectory, so
+  pointing it at `%E/hive` reports a spurious
+  `✗ Gateway config: …/deploy/nginx.conf does not exist` and exits 78. Run it
+  against the source tree, or read its SELinux and port findings and ignore that
+  one row.
 
 ## Unit search paths
 


### PR DESCRIPTION
Closes #4412. Part of #4188 (second wave, bullet 13) — does not close the parent.

## The gap

`README.md`'s entry point was headed **"Quick Start (Docker Compose)"** — a title implying a sibling that did not exist. Podman appeared nowhere in the root README, so an operator on Fedora/RHEL/an Atomic desktop reached the front door and found only `docker compose up -d`, while the runtime behind it had already shipped across #4354, #4375, #4377, #4207–#4209, #4326 and #4378.

## What ships

A `## Quick Start (Podman)` section parallel in shape and depth to the Docker one, plus a short chooser above both:

| | Docker Compose | Podman |
| --- | --- | --- |
| Lifecycle | `docker compose up -d` | Quadlet units under systemd |
| Runs as | the Docker daemon | rootful **or** rootless |
| Update path | pull and recreate; optional Watchtower | pinned by digest, with rollback |

Docker stays the default and stays put — the Docker block is unchanged and unmoved. Podman reads as a parallel supported choice: not experimental, not recommended over Docker.

The block is **rootless**, with the rootful deltas named inline, and it carries the two things a linked doc would have deferred:

- **The security posture, at the front door.** The shipped unit requests `CAP_NET_ADMIN`, so the egress gate is *enforced* by default. #4324's rootful/rootless × enforcing/advisory matrix is inline, including that advisory mode is a deliberate choice and **not** a weaker grade of enforcing or a fallback — agents can bypass the MITM proxy and the ACMM capability model is not enforced.
- **The traps that cost 300 seconds each** — the `dashboard.port` 3001→3002 rewrite, `hive.env` having to exist, and pulling before starting because the generated `ExecStart`'s pull is spent inside `TimeoutStartSec`.

## Running it, rather than transcribing it, found two defects

#4412 makes "copy-and-paste and complete" an explicit criterion because of #4367. Both of these are that same class — a step that reads fine and silently does nothing:

1. **`HIVE_DEPLOY_RUNTIME` must be exported before the preflights, or all three exit 0 having checked nothing.** Docker is the default runtime; with it selected they print `Podman preflight: skipped — HIVE_DEPLOY_RUNTIME selects docker` and return success, which reads exactly like a pass. The acceptance criterion asks that a missing subordinate-ID or cgroup prerequisite surface as a preflight message — as written, it would not have. The README exports it first, and `podman-standalone-quadlet.md`'s Requirements bullet (which said only "Run the preflight first") now says so too.

2. **`hive-podman-preflight-host.sh` cannot validate a Quadlet install.** It looks for `$HIVE_SRC_DIR/deploy/nginx.conf`; the Quadlet layout puts `nginx.conf` flat in `%E/hive`. Pointed at the config directory it reports a spurious `✗ Gateway config: …/deploy/nginx.conf does not exist` and exits 78, inviting operators to stop reading a report whose other rows (SELinux mount labels, the secrets group-traverse check, port 3001) they actually need. Filed as **#4422**; the README names only the two layout-independent preflights and points at the issue.

Also documented, as observed: in a logged-in session the stack comes up on `daemon-reload`, not on the explicit start — the generator writes the `default.target.wants/` symlinks from `[Install]` and systemd starts newly-wanted units of an already-active target. The `start` is then a no-op returning 0, worth running as the confirmation.

## Verification

Podman 5.8.4 rootless, SELinux enforcing, cgroup v2. Every step in the block was executed in order:

| Step | Result |
|---|---|
| `hive-podman-preflight.sh` | pass 4 / warn 0 / fail 0 |
| `hive-podman-preflight-ids.sh` | pass 4 / warn 0 / fail 0 |
| config staging + `sed` | `dashboard: / port: 3002` confirmed |
| `hive.env` from the tracked example + token | 0600, `HIVE_DASHBOARD_TOKEN` set |
| `podman pull ghcr.io/kubestellar/hive:stable` | 47s, 3.82 GB |
| 4× `install` + `daemon-reload` | all four services `generated` |
| **stack health** | **`hive` healthy in 43s, `hive-gateway` healthy 12s later** |

Those healthchecks *are* the verification commands: `hive.container`'s `HealthCmd` is `curl -sf http://127.0.0.1:3002/api/health`, and the gateway's is `curl -sf http://127.0.0.1:3001/api/health` — which passing also proves the gateway resolved `hive` over the shared network.

## Not executed — stated rather than implied

- **The host was not Docker-free.** #4188's Docker-free-host criterion is *not* demonstrated here. No command in the block invokes docker and none of the verification used it, but that is a weaker claim and I am not dressing it up as the stronger one. My attempt to mask `docker` out of `PATH` failed (it lives in `/usr/bin`, which the block needs), and I did not substitute a fake proof.
- **The explicit `systemctl start` and the `curl`** were not separately run: the verification host is the maintainer's own desktop and the run was halted at their request once the stack was up. The stack had already reached healthy via the `daemon-reload` path above, and everything created was torn down — units, containers, volume, network, and the config directory restored byte-for-byte (it also holds live contributor-relay credentials, backed up before the run).
- **The `podman build` line and the rootful variant** were not exercised.

All links resolve on v4 — including a check that caught me linking `src/docs/podman-auto-update.md`, which exists only in my unmerged #4420; that link is gone. The #4367 config-coupling guard, the port-boundary guard, the runtime-parity guard and the image-reference guard all still pass.

— hive: backend=claude model=claude-opus-5
