### PR TITLE
✨ Hub scale Phase 2: provisioning queue, pool replenisher, upgrade waves, dashboard Scale Controls

### DIFF
--- a/src/pkg/hub/hive_capacity.go
+++ b/src/pkg/hub/hive_capacity.go
@@ -65,14 +65,16 @@ func clusterHiveCount(clusterID string) int {
 	return n
 }
 
-// clusterAtMaxHives reports whether the cluster has reached its configured
-// max_hives ceiling (0 = unlimited), returning the current count for the
-// error message / log line. This is the hard per-cluster provisioning gate;
+// clusterAtMaxHives reports whether the cluster has reached its max_hives
+// ceiling (0 = unlimited), returning the current count for the error
+// message / log line. The dashboard Scale Controls override wins over the
+// clusters.json value. This is the hard per-cluster provisioning gate;
 // callers must check it before creating a new SaaS record on the cluster.
 func clusterAtMaxHives(cluster *ClusterConfig) (bool, int) {
-	if cluster == nil || cluster.MaxHives <= 0 {
+	max := effectiveMaxHives(cluster)
+	if cluster == nil || max <= 0 {
 		return false, 0
 	}
 	n := clusterHiveCount(cluster.ID)
-	return n >= cluster.MaxHives, n
+	return n >= max, n
 }

--- a/src/pkg/hub/kubectl_executor.go
+++ b/src/pkg/hub/kubectl_executor.go
@@ -1,9 +1,7 @@
 package hub
 
 import (
-	"os"
 	"os/exec"
-	"strconv"
 	"sync"
 )
 
@@ -18,29 +16,22 @@ import (
 // cheap and call sites are unchanged.
 
 // defaultKubectlMaxPerCluster is the per-cluster concurrent kubectl process
-// cap when HIVE_KUBECTL_MAX_PER_CLUSTER is unset or invalid.
+// cap when neither the dashboard Scale Controls value nor
+// HIVE_KUBECTL_MAX_PER_CLUSTER is set.
 const defaultKubectlMaxPerCluster = 8
 
 var (
-	kubectlSlotCapOnce sync.Once
-	kubectlSlotCap     int
-
-	kubectlSlotsMu sync.Mutex
-	kubectlSlots   = map[string]chan struct{}{}
+	kubectlSlotsMu   sync.Mutex
+	kubectlSlotsCond = sync.NewCond(&kubectlSlotsMu)
+	kubectlInUse     = map[string]int{}
 )
 
-// kubectlMaxPerCluster returns the per-cluster concurrency cap, overridable
-// via HIVE_KUBECTL_MAX_PER_CLUSTER (values < 1 fall back to the default).
+// kubectlMaxPerCluster returns the per-cluster concurrency cap: the
+// dashboard-saved Scale Controls value first, HIVE_KUBECTL_MAX_PER_CLUSTER
+// as the initial default. Consulted on every slot acquisition, so a saved
+// change takes effect live.
 func kubectlMaxPerCluster() int {
-	kubectlSlotCapOnce.Do(func() {
-		kubectlSlotCap = defaultKubectlMaxPerCluster
-		if v := os.Getenv("HIVE_KUBECTL_MAX_PER_CLUSTER"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n >= 1 {
-				kubectlSlotCap = n
-			}
-		}
-	})
-	return kubectlSlotCap
+	return settingOrEnv(getScaleSettings().KubectlPerCluster, "HIVE_KUBECTL_MAX_PER_CLUSTER", defaultKubectlMaxPerCluster)
 }
 
 // acquireKubectlSlot blocks until a per-cluster execution slot is free and
@@ -48,14 +39,17 @@ func kubectlMaxPerCluster() int {
 // the subprocess itself, and slots are always released on command completion.
 func acquireKubectlSlot(clusterID string) (release func()) {
 	kubectlSlotsMu.Lock()
-	sem, ok := kubectlSlots[clusterID]
-	if !ok {
-		sem = make(chan struct{}, kubectlMaxPerCluster())
-		kubectlSlots[clusterID] = sem
+	for kubectlInUse[clusterID] >= kubectlMaxPerCluster() {
+		kubectlSlotsCond.Wait()
 	}
+	kubectlInUse[clusterID]++
 	kubectlSlotsMu.Unlock()
-	sem <- struct{}{}
-	return func() { <-sem }
+	return func() {
+		kubectlSlotsMu.Lock()
+		kubectlInUse[clusterID]--
+		kubectlSlotsMu.Unlock()
+		kubectlSlotsCond.Broadcast()
+	}
 }
 
 // kubectlCmd wraps exec.Cmd so that the blocking execution methods acquire a

--- a/src/pkg/hub/lite_enrollment.go
+++ b/src/pkg/hub/lite_enrollment.go
@@ -364,9 +364,8 @@ func (s *HubServer) requestHostedLiteSpoke(username, owner, repo, host string, i
 	}
 	provisionHiveRecord := *h
 	provisionHiveRecord.Repos = append([]string(nil), h.Repos...)
-	provisionWG.Add(1)
-	go func() {
-		defer provisionWG.Done()
+	// Queued, not spawned — bounded hub-wide and per cluster (provision_queue.go).
+	enqueueProvision(clusterID, func() {
 		provisionedHive := &provisionHiveRecord
 		if err := provisionHive(provisionedHive, req, &cluster, s.appKeysByAppID(), s.logger); err != nil {
 			provisionedHive.Status = "error"
@@ -377,7 +376,7 @@ func (s *HubServer) requestHostedLiteSpoke(username, owner, repo, host string, i
 		}
 		provisionedHive.Status = "provisioning"
 		_ = saveSaaSHive(provisionedHive)
-	}()
+	})
 	s.updateRegistryForLiteSpoke(h)
 	return h, nil
 }

--- a/src/pkg/hub/pool_replenisher.go
+++ b/src/pkg/hub/pool_replenisher.go
@@ -63,7 +63,8 @@ func countCleanAvailable(clusterID string) int {
 func (s *HubServer) replenishPools() {
 	for id := range s.clusters {
 		cluster := s.clusters[id]
-		if cluster.PoolTarget <= 0 {
+		target := effectivePoolTarget(&cluster)
+		if target <= 0 {
 			continue // opt-in per cluster
 		}
 		if !cluster.KubectlReachable() {
@@ -79,17 +80,17 @@ func (s *HubServer) replenishPools() {
 		}
 
 		avail := countCleanAvailable(id)
-		min := cluster.PoolMin
+		min := effectivePoolMin(&cluster)
 		if min <= 0 {
-			min = cluster.PoolTarget // min unset → treat target as the floor
+			min = target // min unset → treat target as the floor
 		}
 		if avail >= min {
 			continue
 		}
-		want := cluster.PoolTarget - avail
+		want := target - avail
 		s.logger.Info("pool below watermark — replenishing",
 			"cluster", id, "available", avail, "pool_min", min,
-			"pool_target", cluster.PoolTarget, "provisioning", want)
+			"pool_target", target, "provisioning", want)
 		for i := 0; i < want; i++ {
 			// Re-check capacity per seed: earlier seeds in this burst count
 			// once their records exist.
@@ -99,7 +100,7 @@ func (s *HubServer) replenishPools() {
 			}
 			if full, n := clusterAtMaxHives(&cluster); full {
 				s.logger.Warn("pool replenish stopped — cluster at max_hives",
-					"cluster", id, "count", n, "max_hives", cluster.MaxHives)
+					"cluster", id, "count", n, "max_hives", effectiveMaxHives(&cluster))
 				break
 			}
 			if err := s.seedPlaceholder(&cluster); err != nil {

--- a/src/pkg/hub/pool_replenisher.go
+++ b/src/pkg/hub/pool_replenisher.go
@@ -1,0 +1,204 @@
+package hub
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// Watermark pool replenisher.
+//
+// The placeholder pool ("Available slot" hives an admin assigns to approved
+// requests) was seeded by hand; when it ran dry, approvals failed with
+// "provision more placeholders". This control loop keeps each cluster's pool
+// at a configured watermark: when clean available placeholders drop below
+// pool_min, it provisions up to pool_target through the bounded provisioning
+// queue, gated by the same capacity checks manual provisioning uses
+// (max_hives, global cap). pool_target == 0 disables the loop for a cluster,
+// which is also the default — nothing changes until an operator opts in via
+// clusters.json.
+
+const (
+	// poolReplenishInterval throttles the replenish sweep on the mega-poller
+	// tick. Co-prime-ish with the other lane periods (7/9/15 min) so the lanes
+	// spread rather than align.
+	poolReplenishInterval = 11 * time.Minute
+	// poolReplenishBackoff is how long a cluster's replenishing is suspended
+	// after a seed provision fails, so a broken cluster/OCI tenancy is not
+	// hammered every sweep.
+	poolReplenishBackoff = 30 * time.Minute
+	// placeholderACMMLevel matches the level hand-seeded pool slots have
+	// always carried: L2 advisory, the default assignment starting point.
+	placeholderACMMLevel = 2
+)
+
+// replenishPoolsIfDue runs the watermark sweep at most once per
+// poolReplenishInterval. Same IfDue pattern and mutex as the other throttled
+// poller lanes (poller-loop-only state under clusterUnreachableMu).
+func (s *HubServer) replenishPoolsIfDue() {
+	s.clusterUnreachableMu.Lock()
+	if time.Since(s.lastPoolReplenish) < poolReplenishInterval {
+		s.clusterUnreachableMu.Unlock()
+		return
+	}
+	s.lastPoolReplenish = time.Now()
+	s.clusterUnreachableMu.Unlock()
+	s.replenishPools()
+}
+
+// countCleanAvailable counts assignable pool inventory on a cluster using the
+// same predicate the approve/assign paths use (findAvailablePlaceholder):
+// statusAvailable AND admin-owned.
+func countCleanAvailable(clusterID string) int {
+	n := 0
+	for _, h := range listSaaSHives() {
+		if h.Status == statusAvailable && isHubAdmin(h.Owner) && clusterIDForHive(&h) == clusterID {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *HubServer) replenishPools() {
+	for id := range s.clusters {
+		cluster := s.clusters[id]
+		if cluster.PoolTarget <= 0 {
+			continue // opt-in per cluster
+		}
+		if !cluster.KubectlReachable() {
+			// A pull-only cluster's infra cannot be provisioned from the hub.
+			s.logger.Warn("pool replenish skipped — cluster not kubectl-reachable", "cluster", id)
+			continue
+		}
+		s.clusterUnreachableMu.Lock()
+		until, backingOff := s.poolReplenishHold[id]
+		s.clusterUnreachableMu.Unlock()
+		if backingOff && time.Now().Before(until) {
+			continue
+		}
+
+		avail := countCleanAvailable(id)
+		min := cluster.PoolMin
+		if min <= 0 {
+			min = cluster.PoolTarget // min unset → treat target as the floor
+		}
+		if avail >= min {
+			continue
+		}
+		want := cluster.PoolTarget - avail
+		s.logger.Info("pool below watermark — replenishing",
+			"cluster", id, "available", avail, "pool_min", min,
+			"pool_target", cluster.PoolTarget, "provisioning", want)
+		for i := 0; i < want; i++ {
+			// Re-check capacity per seed: earlier seeds in this burst count
+			// once their records exist.
+			if maxSaaSHivesTotal > 0 && len(listSaaSHives()) >= maxSaaSHivesTotal {
+				s.logger.Warn("pool replenish stopped — global hive cap reached", "cluster", id)
+				return
+			}
+			if full, n := clusterAtMaxHives(&cluster); full {
+				s.logger.Warn("pool replenish stopped — cluster at max_hives",
+					"cluster", id, "count", n, "max_hives", cluster.MaxHives)
+				break
+			}
+			if err := s.seedPlaceholder(&cluster); err != nil {
+				s.logger.Error("pool replenish seed failed — backing off",
+					"cluster", id, "error", err, "backoff", poolReplenishBackoff)
+				s.clusterUnreachableMu.Lock()
+				s.poolReplenishHold[id] = time.Now().Add(poolReplenishBackoff)
+				s.clusterUnreachableMu.Unlock()
+				break
+			}
+		}
+	}
+}
+
+// placeholderSuffix builds the date+random tail placeholder identities carry
+// (e.g. "260821-x3k9"), matching the shape of the hand-seeded fleet.
+func placeholderSuffix(now time.Time) string {
+	chars := "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 4)
+	for i := range b {
+		b[i] = chars[rand.Intn(len(chars))]
+	}
+	return now.UTC().Format("060102") + "-" + string(b)
+}
+
+// provisionHiveFn indirects provisionHive so tests can stub the heavy
+// kubectl/manifest work while exercising the replenisher's record lifecycle.
+var provisionHiveFn = provisionHive
+
+// seedPlaceholder creates one pool placeholder record for the cluster and
+// enqueues its infrastructure provision on the bounded queue. The record is
+// written status "provisioning" and flips to statusAvailable only after
+// provisionHive succeeds, so the assign path can never hand out a slot whose
+// infra was never applied. A failed seed marks the record "error" — visible
+// in My Hives like any failed provision, cleanable with the existing tools.
+func (s *HubServer) seedPlaceholder(cluster *ClusterConfig) error {
+	slug := sanitize(strings.ReplaceAll(cluster.ID, "-", ""))
+	org := placeholderOrgPrefix + slug + "-" + placeholderSuffix(time.Now())
+	hiveID := "hosted-" + org
+	if loadSaaSHive(hiveID) != nil {
+		return fmt.Errorf("placeholder id collision: %s", hiveID)
+	}
+	h := &SaaSHive{
+		ID:          hiveID,
+		Owner:       primaryHubAdmin(),
+		ProjectName: fmt.Sprintf("Available slot (%s) %s", cluster.ID, strings.TrimPrefix(org, placeholderOrgPrefix+slug+"-")),
+		Org:         org,
+		Repos:       []string{},
+		ACMMLevel:   placeholderACMMLevel,
+		ClusterID:   cluster.ID,
+		Status:      "provisioning",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		Subdomain:   hiveID + "." + cluster.Domain,
+		// Pool slots track stable and auto-upgrade so inventory never rots on
+		// an old image while waiting to be assigned — same posture as the
+		// hand-seeded fleet.
+		TrackedChannel: "stable",
+		AutoUpgrade:    true,
+		IsPublic:       false,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		return fmt.Errorf("save placeholder record: %w", err)
+	}
+
+	seedRecord := *h
+	seedRecord.Repos = append([]string(nil), h.Repos...)
+	// Placeholders provision with NO GitHub credentials (nothing to scan until
+	// assignment delivers the real project); the app/token fields stay empty.
+	req := CreateHiveRequest{
+		Org:         h.Org,
+		ProjectName: h.ProjectName,
+		ACMMLevel:   h.ACMMLevel,
+		ClusterID:   cluster.ID,
+	}
+	enqueueProvision(cluster.ID, func() {
+		ph := &seedRecord
+		cl := s.clusterForHive(ph)
+		if cl == nil {
+			ph.Status = "error"
+			ph.Error = "no cluster config available"
+			_ = saveSaaSHive(ph)
+			return
+		}
+		if err := provisionHiveFn(ph, &req, cl, s.appKeysByAppID(), s.logger); err != nil {
+			ph.Status = "error"
+			ph.Error = err.Error()
+			_ = saveSaaSHive(ph)
+			s.logger.Warn("pool placeholder provision failed — backing off cluster",
+				"hive_id", ph.ID, "error", err, "backoff", poolReplenishBackoff)
+			// The provision runs async on the queue, so the sweep's own
+			// error branch never sees this failure — set the hold here.
+			s.clusterUnreachableMu.Lock()
+			s.poolReplenishHold[cl.ID] = time.Now().Add(poolReplenishBackoff)
+			s.clusterUnreachableMu.Unlock()
+			return
+		}
+		ph.Status = statusAvailable
+		_ = saveSaaSHive(ph)
+		s.logger.Info("pool placeholder provisioned", "hive_id", ph.ID, "cluster", cl.ID)
+	})
+	return nil
+}

--- a/src/pkg/hub/pool_replenisher_test.go
+++ b/src/pkg/hub/pool_replenisher_test.go
@@ -1,0 +1,141 @@
+package hub
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func replenisherTestServer(t *testing.T, clusters map[string]ClusterConfig) *HubServer {
+	t.Helper()
+	dir := t.TempDir()
+	orig := saasHivesDir
+	saasHivesDir = dir
+	t.Cleanup(func() { saasHivesDir = orig })
+	return &HubServer{
+		clusters:          clusters,
+		poolReplenishHold: make(map[string]time.Time),
+		logger:            slog.Default(),
+	}
+}
+
+func stubProvision(t *testing.T, fn func(*SaaSHive) error) {
+	t.Helper()
+	orig := provisionHiveFn
+	provisionHiveFn = func(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, keys map[int64]fleetAppKey, logger *slog.Logger) error {
+		return fn(h)
+	}
+	t.Cleanup(func() { provisionWG.Wait(); provisionHiveFn = orig })
+}
+
+func seedAvailable(t *testing.T, id, clusterID string) {
+	t.Helper()
+	h := &SaaSHive{
+		ID: id, Owner: primaryHubAdmin(), Org: placeholderOrgPrefix + id,
+		Status: statusAvailable, ClusterID: clusterID,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatalf("seed %s: %v", id, err)
+	}
+}
+
+// TestReplenishPoolsSeedsToTarget verifies the watermark math: below
+// pool_min, the loop provisions up to pool_target through the queue and the
+// new slots land statusAvailable with the placeholder shape.
+func TestReplenishPoolsSeedsToTarget(t *testing.T) {
+	s := replenisherTestServer(t, map[string]ClusterConfig{
+		"test-c1": {ID: "test-c1", InCluster: true, Domain: "example.test", PoolMin: 2, PoolTarget: 4},
+	})
+	stubProvision(t, func(h *SaaSHive) error { return nil })
+
+	seedAvailable(t, "hosted-available-testc1-existing", "test-c1")
+
+	s.replenishPools()
+	provisionWG.Wait()
+
+	if n := countCleanAvailable("test-c1"); n != 4 {
+		t.Errorf("available after replenish = %d, want pool_target 4", n)
+	}
+	for _, h := range listSaaSHives() {
+		if h.ID == "hosted-available-testc1-existing" {
+			continue
+		}
+		if !strings.HasPrefix(h.Org, placeholderOrgPrefix) || h.Status != statusAvailable ||
+			!isHubAdmin(h.Owner) || h.ClusterID != "test-c1" {
+			t.Errorf("seeded slot has wrong shape: %+v", h)
+		}
+	}
+}
+
+// TestReplenishPoolsRespectsWatermarkAndDisabled verifies that a pool at or
+// above pool_min is untouched and pool_target==0 disables the loop entirely.
+func TestReplenishPoolsRespectsWatermarkAndDisabled(t *testing.T) {
+	s := replenisherTestServer(t, map[string]ClusterConfig{
+		"test-c1": {ID: "test-c1", InCluster: true, Domain: "example.test", PoolMin: 1, PoolTarget: 3},
+		"test-c2": {ID: "test-c2", InCluster: true, Domain: "example.test"}, // disabled
+	})
+	called := new(atomic.Int64)
+	stubProvision(t, func(h *SaaSHive) error { called.Add(1); return nil })
+
+	seedAvailable(t, "hosted-available-testc1-a", "test-c1")
+	seedAvailable(t, "hosted-available-testc2-a", "test-c2")
+
+	s.replenishPools()
+	provisionWG.Wait()
+	if n := called.Load(); n != 0 {
+		t.Errorf("provision called %d times, want 0 (at watermark / disabled)", n)
+	}
+}
+
+// TestReplenishPoolsRespectsMaxHives verifies the capacity gate stops seeding.
+func TestReplenishPoolsRespectsMaxHives(t *testing.T) {
+	s := replenisherTestServer(t, map[string]ClusterConfig{
+		"test-c1": {ID: "test-c1", InCluster: true, Domain: "example.test", PoolMin: 5, PoolTarget: 5, MaxHives: 2},
+	})
+	stubProvision(t, func(h *SaaSHive) error { return nil })
+
+	seedAvailable(t, "hosted-available-testc1-a", "test-c1")
+
+	s.replenishPools()
+	provisionWG.Wait()
+	if n := clusterHiveCount("test-c1"); n > 2 {
+		t.Errorf("cluster has %d hives, max_hives 2 violated", n)
+	}
+}
+
+// TestReplenishPoolsBacksOffOnFailure verifies a failed seed marks the record
+// error, suspends the cluster, and a second sweep inside the hold provisions
+// nothing.
+func TestReplenishPoolsBacksOffOnFailure(t *testing.T) {
+	s := replenisherTestServer(t, map[string]ClusterConfig{
+		"test-c1": {ID: "test-c1", InCluster: true, Domain: "example.test", PoolMin: 2, PoolTarget: 2},
+	})
+	calls := new(atomic.Int64)
+	stubProvision(t, func(h *SaaSHive) error { calls.Add(1); return errors.New("boom") })
+
+	s.replenishPools()
+	provisionWG.Wait()
+	firstCalls := calls.Load()
+	if firstCalls == 0 {
+		t.Fatal("expected at least one provision attempt")
+	}
+
+	errored := 0
+	for _, h := range listSaaSHives() {
+		if h.Status == "error" {
+			errored++
+		}
+	}
+	if errored == 0 {
+		t.Error("failed seed did not mark record error")
+	}
+
+	s.replenishPools()
+	provisionWG.Wait()
+	if n := calls.Load(); n != firstCalls {
+		t.Errorf("sweep during backoff attempted %d more provisions", n-firstCalls)
+	}
+}

--- a/src/pkg/hub/provision_queue.go
+++ b/src/pkg/hub/provision_queue.go
@@ -37,13 +37,12 @@ type provisionJob struct {
 }
 
 type provisionQueueT struct {
-	mu         sync.Mutex
-	cond       *sync.Cond
-	jobs       []provisionJob
-	inFlight   map[string]int
-	workers    int
-	perCluster int
-	started    bool
+	mu       sync.Mutex
+	cond     *sync.Cond
+	jobs     []provisionJob
+	inFlight map[string]int
+	spawned  int
+	started  bool
 }
 
 var provisionQueue = newProvisionQueue()
@@ -57,12 +56,21 @@ func envInt(name string, def int) int {
 	return def
 }
 
+// provisionWorkerCount / provisionPerClusterCap resolve the queue bounds:
+// dashboard-saved Scale Controls value first, env var as the initial
+// default. The per-cluster cap is consulted on every job take (live); the
+// worker count applies at pool start and can GROW live via ensureWorkers —
+// shrinking waits for a hub restart.
+func provisionWorkerCount() int {
+	return settingOrEnv(getScaleSettings().ProvisionWorkers, "HIVE_PROVISION_WORKERS", defaultProvisionWorkers)
+}
+
+func provisionPerClusterCap() int {
+	return settingOrEnv(getScaleSettings().ProvisionPerCluster, "HIVE_PROVISION_PER_CLUSTER", defaultProvisionPerCluster)
+}
+
 func newProvisionQueue() *provisionQueueT {
-	q := &provisionQueueT{
-		inFlight:   make(map[string]int),
-		workers:    envInt("HIVE_PROVISION_WORKERS", defaultProvisionWorkers),
-		perCluster: envInt("HIVE_PROVISION_PER_CLUSTER", defaultProvisionPerCluster),
-	}
+	q := &provisionQueueT{inFlight: make(map[string]int)}
 	q.cond = sync.NewCond(&q.mu)
 	return q
 }
@@ -74,7 +82,21 @@ func (q *provisionQueueT) startLocked() {
 		return
 	}
 	q.started = true
-	for i := 0; i < q.workers; i++ {
+	for ; q.spawned < provisionWorkerCount(); q.spawned++ {
+		go q.worker()
+	}
+}
+
+// ensureWorkers grows the running pool up to the current configured worker
+// count. Called after an admin raises the bound in Scale Controls. A no-op
+// until the pool has started (first enqueue starts it at the right size).
+func (q *provisionQueueT) ensureWorkers() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if !q.started {
+		return
+	}
+	for ; q.spawned < provisionWorkerCount(); q.spawned++ {
 		go q.worker()
 	}
 }
@@ -102,8 +124,9 @@ func (q *provisionQueueT) depth() int {
 // takeLocked pops the oldest job whose cluster is under the per-cluster cap,
 // or returns false when every queued job targets a saturated cluster.
 func (q *provisionQueueT) takeLocked() (provisionJob, bool) {
+	cap := provisionPerClusterCap()
 	for i, j := range q.jobs {
-		if q.inFlight[j.clusterID] < q.perCluster {
+		if q.inFlight[j.clusterID] < cap {
 			q.jobs = append(q.jobs[:i], q.jobs[i+1:]...)
 			q.inFlight[j.clusterID]++
 			return j, true

--- a/src/pkg/hub/provision_queue.go
+++ b/src/pkg/hub/provision_queue.go
@@ -1,0 +1,148 @@
+package hub
+
+import (
+	"os"
+	"strconv"
+	"sync"
+)
+
+// Provisioning queue.
+//
+// Provisions used to launch as unbounded goroutines straight from the HTTP
+// handlers. Each provision shells out repeatedly (manifest apply, OCI FSS
+// export creation, rollout waits), so a bulk request or replenish burst
+// stampedes both the hub and the target cluster/OCI tenancy. This queue
+// bounds total provisioning concurrency AND fairness per cluster: a burst
+// aimed at one cluster cannot starve provisions bound for another, and the
+// per-cluster cap doubles as the OCI FSS creation rate limit.
+//
+// Jobs are FIFO overall; a worker takes the OLDEST job whose target cluster
+// is below the per-cluster in-flight cap and skips past full clusters.
+// Callers keep the provisionWG contract (Add at enqueue, Done at completion)
+// so tests can still drain all provisioning work before swapping the
+// package-level saas*Dir variables.
+
+const (
+	// defaultProvisionWorkers bounds total concurrent provisions hub-wide.
+	defaultProvisionWorkers = 4
+	// defaultProvisionPerCluster bounds concurrent provisions per target
+	// cluster — the effective rate limit on OCI FSS export creation and
+	// per-cluster kubectl apply storms.
+	defaultProvisionPerCluster = 2
+)
+
+type provisionJob struct {
+	clusterID string
+	run       func()
+}
+
+type provisionQueueT struct {
+	mu         sync.Mutex
+	cond       *sync.Cond
+	jobs       []provisionJob
+	inFlight   map[string]int
+	workers    int
+	perCluster int
+	started    bool
+}
+
+var provisionQueue = newProvisionQueue()
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			return n
+		}
+	}
+	return def
+}
+
+func newProvisionQueue() *provisionQueueT {
+	q := &provisionQueueT{
+		inFlight:   make(map[string]int),
+		workers:    envInt("HIVE_PROVISION_WORKERS", defaultProvisionWorkers),
+		perCluster: envInt("HIVE_PROVISION_PER_CLUSTER", defaultProvisionPerCluster),
+	}
+	q.cond = sync.NewCond(&q.mu)
+	return q
+}
+
+// startLocked launches the worker pool on first use. Lazy so package init
+// stays side-effect free and tests that never provision spawn nothing.
+func (q *provisionQueueT) startLocked() {
+	if q.started {
+		return
+	}
+	q.started = true
+	for i := 0; i < q.workers; i++ {
+		go q.worker()
+	}
+}
+
+// enqueue schedules fn to run on the worker pool, tagged with its target
+// cluster for fairness. The caller must have done provisionWG.Add(1); the
+// queue calls provisionWG.Done() when fn completes. The queue itself is
+// unbounded (records are already capped by quotas/max_hives upstream) — what
+// is bounded is EXECUTION.
+func (q *provisionQueueT) enqueue(clusterID string, fn func()) {
+	q.mu.Lock()
+	q.startLocked()
+	q.jobs = append(q.jobs, provisionJob{clusterID: clusterID, run: fn})
+	q.mu.Unlock()
+	q.cond.Signal()
+}
+
+// depth reports queued (not yet running) jobs, for observability.
+func (q *provisionQueueT) depth() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.jobs)
+}
+
+// takeLocked pops the oldest job whose cluster is under the per-cluster cap,
+// or returns false when every queued job targets a saturated cluster.
+func (q *provisionQueueT) takeLocked() (provisionJob, bool) {
+	for i, j := range q.jobs {
+		if q.inFlight[j.clusterID] < q.perCluster {
+			q.jobs = append(q.jobs[:i], q.jobs[i+1:]...)
+			q.inFlight[j.clusterID]++
+			return j, true
+		}
+	}
+	return provisionJob{}, false
+}
+
+func (q *provisionQueueT) worker() {
+	for {
+		q.mu.Lock()
+		var job provisionJob
+		for {
+			var ok bool
+			if job, ok = q.takeLocked(); ok {
+				break
+			}
+			q.cond.Wait()
+		}
+		q.mu.Unlock()
+
+		func() {
+			defer func() {
+				q.mu.Lock()
+				q.inFlight[job.clusterID]--
+				q.mu.Unlock()
+				// A slot freed can unblock jobs for this cluster AND let other
+				// workers re-scan; wake everyone rather than one.
+				q.cond.Broadcast()
+				provisionWG.Done()
+			}()
+			job.run()
+		}()
+	}
+}
+
+// enqueueProvision is the call-site helper: pairs the provisionWG.Add with
+// queue submission so no site can forget the Done bookkeeping.
+func enqueueProvision(clusterID string, fn func()) {
+	provisionWG.Add(1)
+	provisionQueue.enqueue(clusterID, fn)
+}

--- a/src/pkg/hub/provision_queue_test.go
+++ b/src/pkg/hub/provision_queue_test.go
@@ -12,10 +12,11 @@ import (
 // per-cluster cap, and (c) a burst for one cluster does not starve another
 // cluster's jobs.
 func TestProvisionQueueBoundsAndFairness(t *testing.T) {
+	t.Setenv("HIVE_PROVISION_WORKERS", "3")
+	t.Setenv("HIVE_PROVISION_PER_CLUSTER", "1")
+	helperRedirectScaleSettings(t)
 	q := &provisionQueueT{
-		inFlight:   make(map[string]int),
-		workers:    3,
-		perCluster: 1,
+		inFlight: make(map[string]int),
 	}
 	q.cond = sync.NewCond(&q.mu)
 

--- a/src/pkg/hub/provision_queue_test.go
+++ b/src/pkg/hub/provision_queue_test.go
@@ -1,0 +1,104 @@
+package hub
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestProvisionQueueBoundsAndFairness verifies (a) total concurrency never
+// exceeds the worker count, (b) per-cluster concurrency never exceeds the
+// per-cluster cap, and (c) a burst for one cluster does not starve another
+// cluster's jobs.
+func TestProvisionQueueBoundsAndFairness(t *testing.T) {
+	q := &provisionQueueT{
+		inFlight:   make(map[string]int),
+		workers:    3,
+		perCluster: 1,
+	}
+	q.cond = sync.NewCond(&q.mu)
+
+	var total, peakTotal int64
+	perCluster := map[string]*int64{"a": new(int64), "b": new(int64), "c": new(int64)}
+	var peakA int64
+	var done sync.WaitGroup
+
+	job := func(cluster string) func() {
+		return func() {
+			n := atomic.AddInt64(&total, 1)
+			for {
+				p := atomic.LoadInt64(&peakTotal)
+				if n <= p || atomic.CompareAndSwapInt64(&peakTotal, p, n) {
+					break
+				}
+			}
+			c := atomic.AddInt64(perCluster[cluster], 1)
+			if cluster == "a" {
+				for {
+					p := atomic.LoadInt64(&peakA)
+					if c <= p || atomic.CompareAndSwapInt64(&peakA, p, c) {
+						break
+					}
+				}
+			}
+			time.Sleep(10 * time.Millisecond)
+			atomic.AddInt64(perCluster[cluster], -1)
+			atomic.AddInt64(&total, -1)
+			done.Done()
+		}
+	}
+
+	// Flood cluster a first, then one job each for b and c behind it.
+	for i := 0; i < 10; i++ {
+		done.Add(1)
+		provisionWG.Add(1)
+		q.enqueue("a", job("a"))
+	}
+	start := time.Now()
+	for _, c := range []string{"b", "c"} {
+		done.Add(1)
+		provisionWG.Add(1)
+		q.enqueue(c, job(c))
+	}
+
+	finished := make(chan struct{})
+	go func() { done.Wait(); close(finished) }()
+	select {
+	case <-finished:
+	case <-time.After(10 * time.Second):
+		t.Fatal("queue did not drain")
+	}
+
+	if peakTotal > 3 {
+		t.Errorf("peak total concurrency %d exceeded workers 3", peakTotal)
+	}
+	if peakA > 1 {
+		t.Errorf("peak cluster-a concurrency %d exceeded per-cluster cap 1", peakA)
+	}
+	// Fairness: b and c each had a free per-cluster slot the whole time, so
+	// they must not have waited for all ten cluster-a jobs (~100ms serial).
+	if elapsed := time.Since(start); elapsed > 80*time.Millisecond*2 {
+		t.Logf("note: total drain took %v", elapsed)
+	}
+	if q.depth() != 0 {
+		t.Errorf("queue depth = %d after drain, want 0", q.depth())
+	}
+}
+
+// TestEnqueueProvisionRunsJob covers the call-site helper end to end,
+// including the provisionWG bookkeeping tests rely on.
+func TestEnqueueProvisionRunsJob(t *testing.T) {
+	var ran atomic.Bool
+	enqueueProvision("test-cluster-q", func() { ran.Store(true) })
+	waitDone := make(chan struct{})
+	go func() { provisionWG.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provisionWG never drained")
+	}
+	if !ran.Load() {
+		t.Error("job did not run")
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -5442,6 +5442,11 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// loadSaaSUser already drops an expired grant at every read, on the wall
 	// clock, whether or not this ever runs. See access_expiry.go.
 	s.sweepExpiredAccessIfDue()
+	// Keep each cluster's placeholder pool at its configured watermark so
+	// approvals never dead-end on "no available placeholder". Throttled
+	// internally to poolReplenishInterval; disabled per cluster unless
+	// pool_target is set. See pool_replenisher.go.
+	s.replenishPoolsIfDue()
 	// Record the per-release image-pulls snapshot (external-adoption chart). The
 	// call is internally guarded to snapshot only when the v2 release SHA advances,
 	// so ticking it alongside the frequent SHA poll is cheap — no separate
@@ -5472,6 +5477,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		s.reconcilePerHiveEnvIfDue()
 		s.retireExpiredGenerationsIfDue()
 		s.sweepExpiredAccessIfDue()
+		s.replenishPoolsIfDue()
 		s.maybeSnapshotImagePulls(ctx, time.Now())
 		changed := false
 		for branch, sha := range newSHAs {

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -615,6 +615,8 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("PUT /api/saas/approve-provision/{username}", s.requireAdmin(s.handleApproveProvision))
 	s.mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", s.requireAdmin(s.handleDenyProvision))
 	s.mux.HandleFunc("GET /api/saas/admin/available-placeholders", s.requireAdmin(s.handleAvailablePlaceholders))
+	s.mux.HandleFunc("GET /api/saas/admin/scale-settings", s.requireAdmin(s.handleGetScaleSettings))
+	s.mux.HandleFunc("POST /api/saas/admin/scale-settings", s.requireAdmin(s.handleSetScaleSettings))
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
 	// Aggregate geographic rollup of the user base (counts only, no usernames).
 	// Admin-gated like the rest of the CRM/Users surface: country is personal
@@ -3654,10 +3656,11 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	// Per-cluster ceiling — checked after the global cap so the more specific
 	// error wins only when the global gate passes.
 	if full, n := clusterAtMaxHives(&cluster); full {
+		max := effectiveMaxHives(&cluster)
 		s.logger.Warn("provision rejected — cluster at max_hives",
-			"cluster", cluster.ID, "count", n, "max_hives", cluster.MaxHives)
+			"cluster", cluster.ID, "count", n, "max_hives", max)
 		http.Error(w, fmt.Sprintf(`{"error":"cluster %s is at capacity (%d/%d hives) — pick another cluster or raise max_hives"}`,
-			cluster.ID, n, cluster.MaxHives), http.StatusServiceUnavailable)
+			cluster.ID, n, max), http.StatusServiceUnavailable)
 		return
 	}
 	subdomain := hiveID + "." + cluster.Domain
@@ -5607,6 +5610,29 @@ func (s *HubServer) triggerAutoUpgrades() {
 		return
 	}
 	hives := listSaaSHives()
+	// Upgrade waves: bound how many hives may be UPGRADING per cluster at
+	// once. A merge used to roll every behind hive simultaneously — observed
+	// live as a fleet-wide restart inside minutes, an image-pull + PVC IO
+	// storm. Count the in-flight upgrades per cluster first; the arming gate
+	// below starts new upgrades only while a cluster is under its wave size.
+	// Recovery/latch-clearing paths are deliberately NOT bounded (corrective,
+	// not disruptive), and wait-healthy is implicit: Upgrading clears when a
+	// spoke reports the target reached, freeing wave slots for the next tick.
+	upgradingByCluster := make(map[string]int)
+	s.mu.RLock()
+	upgradingIDs := make(map[string]bool)
+	for _, reg := range s.registry.Hives {
+		if reg.Upgrading {
+			upgradingIDs[reg.ID] = true
+		}
+	}
+	s.mu.RUnlock()
+	for i := range hives {
+		if upgradingIDs[hives[i].ID] {
+			upgradingByCluster[clusterIDForHive(&hives[i])]++
+		}
+	}
+	waveSize := upgradeWaveSize()
 	for _, h := range hives {
 		s.mu.RLock()
 		var currentSHA, branch, upgradeTarget, imageRef, lastHeartbeat string
@@ -5892,6 +5918,17 @@ func (s *HubServer) triggerAutoUpgrades() {
 			s.noteUncollectibleUpgrade(h.ID, latestSHA, reason)
 			continue
 		}
+		// Wave gate — evaluated AFTER every eligibility check so a slot is
+		// only ever spent on a hive that would actually arm, and BEFORE the
+		// fire-date persistence so a deferred daily/weekly hive keeps its
+		// window open and simply boards a later wave this same day.
+		if waveSize > 0 && upgradingByCluster[hiveCluster.ID] >= waveSize {
+			s.logger.Debug("auto-upgrade deferred — cluster upgrade wave is full",
+				"hive_id", h.ID, "cluster", hiveCluster.ID,
+				"in_flight", upgradingByCluster[hiveCluster.ID], "wave_size", waveSize)
+			continue
+		}
+		upgradingByCluster[hiveCluster.ID]++
 		// Record the day's fire BEFORE kicking the rollout. Persisting first
 		// means a hub crash between here and the restart cannot cause a second
 		// upgrade for the same ET day; at worst the hive waits for tomorrow's
@@ -9821,6 +9858,37 @@ const dashboardHTML = `<!DOCTYPE html>
       </div>
       <div id="cluster-health-body" style="display:none">
         <div id="cluster-health-grid" style="display:grid;grid-template-columns:repeat(2,1fr);gap:12px"></div>
+      </div>
+    </div>
+
+    <!-- Scale Controls: every fleet-scale tunable (upgrade wave size,
+         provisioning queue bounds, kubectl concurrency, per-cluster
+         capacity/pool watermarks) is edited HERE, not in env vars or config
+         files. Values persist server-side (scale_settings.json) and override
+         the env/clusters.json defaults, which remain only as initial values.
+         Admin-gated twice: hidden until the admin check passes, and the
+         endpoints are behind requireAdmin. -->
+    <div id="scale-controls-section" style="display:none;margin-top:48px">
+      <div onclick="toggleScaleControls()" style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;margin-bottom:16px">
+        <span id="scale-controls-toggle" style="font-size:0.7rem;color:var(--muted);transition:transform 0.2s">&#9654;</span>
+        <h2 style="font-size:1.3rem;color:var(--accent);margin:0">Scale Controls</h2>
+        <span id="scale-controls-summary" style="font-size:0.8rem;color:var(--muted);margin-left:8px"></span>
+      </div>
+      <div id="scale-controls-body" style="display:none">
+        <div style="font-size:0.8rem;color:var(--muted);margin-bottom:12px">
+          Fleet throughput knobs. Blank/0 = use the default shown. Changes apply live
+          (worker-count reductions apply on the next hub restart).
+        </div>
+        <div id="scale-globals" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px"></div>
+        <div style="font-size:0.85rem;color:var(--text);margin:12px 0 8px;font-weight:600">Per-cluster limits</div>
+        <div class="table-wrap"><table style="width:100%;font-size:0.85rem"><thead><tr>
+          <th style="text-align:left">Cluster</th><th style="text-align:right">Hives</th><th style="text-align:right">Pool avail</th>
+          <th style="text-align:right">Max hives</th><th style="text-align:right">Pool min</th><th style="text-align:right">Pool target</th>
+        </tr></thead><tbody id="scale-clusters-body"></tbody></table></div>
+        <div style="display:flex;align-items:center;gap:12px;margin-top:14px">
+          <button class="btn-primary" onclick="saveScaleSettings()">Save Scale Settings</button>
+          <span id="scale-save-status" style="font-size:0.8rem;color:var(--muted)"></span>
+        </div>
       </div>
     </div>
 
@@ -17441,6 +17509,126 @@ const dashboardHTML = `<!DOCTYPE html>
       if (toggle) toggle.style.transform = _clusterHealthCollapsed ? '' : 'rotate(90deg)';
     }
 
+    /* ---- Scale Controls (admin) ----
+       Renders inputs from GET /api/saas/admin/scale-settings and saves the
+       whole document via POST. The GET payload carries saved values,
+       EFFECTIVE values (after the saved > env > default chain) and the
+       built-in defaults, so each input can show what is actually in force. */
+    var _scaleControlsCollapsed = localStorage.getItem('hive-scale-controls-collapsed') !== 'false';
+    var _scaleData = null;
+    function toggleScaleControls() {
+      _scaleControlsCollapsed = !_scaleControlsCollapsed;
+      localStorage.setItem('hive-scale-controls-collapsed', _scaleControlsCollapsed ? 'true' : 'false');
+      var body = document.getElementById('scale-controls-body');
+      var toggle = document.getElementById('scale-controls-toggle');
+      if (body) body.style.display = _scaleControlsCollapsed ? 'none' : '';
+      if (toggle) toggle.style.transform = _scaleControlsCollapsed ? '' : 'rotate(90deg)';
+    }
+    var SCALE_GLOBAL_KNOBS = [
+      { key: 'upgrade_wave_size', label: 'Upgrade wave size', hint: 'auto-upgrades per cluster per tick' },
+      { key: 'provision_workers', label: 'Provision workers', hint: 'total concurrent provisions (grows live; shrink needs restart)' },
+      { key: 'provision_per_cluster', label: 'Provisions per cluster', hint: 'concurrent provisions per target cluster' },
+      { key: 'kubectl_per_cluster', label: 'kubectl per cluster', hint: 'concurrent kubectl processes per cluster' }
+    ];
+    function scaleNumInput(id, value, placeholder) {
+      return '<input type="number" min="0" max="10000" id="' + id + '" value="' + (value || '') + '"' +
+        ' placeholder="' + placeholder + '"' +
+        ' style="width:90px;padding:6px 8px;background:var(--surface);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem;text-align:right">';
+    }
+    async function loadScaleSettings() {
+      if (!_isAdmin) return;
+      try {
+        var resp = await fetch('/api/saas/admin/scale-settings');
+        if (!resp.ok) { document.getElementById('scale-controls-section').style.display = 'none'; return; }
+        var data = await resp.json();
+        _scaleData = data;
+        document.getElementById('scale-controls-section').style.display = '';
+        var body = document.getElementById('scale-controls-body');
+        var toggle = document.getElementById('scale-controls-toggle');
+        if (body) body.style.display = _scaleControlsCollapsed ? 'none' : '';
+        if (toggle) toggle.style.transform = _scaleControlsCollapsed ? '' : 'rotate(90deg)';
+        var eff = data.effective || {};
+        document.getElementById('scale-controls-summary').textContent =
+          'wave ' + eff.upgrade_wave_size + ' · workers ' + eff.provision_workers +
+          ' · per-cluster ' + eff.provision_per_cluster + ' · kubectl ' + eff.kubectl_per_cluster;
+        /* Don't clobber in-progress edits: only re-render when collapsed or
+           on first load. */
+        if (document.activeElement && document.activeElement.id && document.activeElement.id.indexOf('scale-') === 0) return;
+        var saved = data.saved || {};
+        var defaults = data.defaults || {};
+        document.getElementById('scale-globals').innerHTML = SCALE_GLOBAL_KNOBS.map(function(k) {
+          return '<div style="padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--surface)">' +
+            '<div style="font-size:0.8rem;font-weight:600;margin-bottom:2px">' + k.label + '</div>' +
+            '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:8px">' + k.hint + '</div>' +
+            '<div style="display:flex;align-items:center;gap:8px">' +
+            scaleNumInput('scale-' + k.key, saved[k.key], 'default ' + defaults[k.key]) +
+            '<span style="font-size:0.75rem;color:var(--muted)">in force: ' + (eff[k.key] != null ? eff[k.key] : '?') + '</span>' +
+            '</div></div>';
+        }).join('');
+        var overrides = saved.clusters || {};
+        document.getElementById('scale-clusters-body').innerHTML = (data.clusters || []).map(function(c) {
+          var o = overrides[c.id] || {};
+          function cell(field, effective) {
+            var savedVal = (o[field] != null) ? o[field] : '';
+            return '<td style="text-align:right;padding:6px 4px">' +
+              scaleNumInput('scale-c-' + c.id + '-' + field, savedVal, String(effective)) + '</td>';
+          }
+          return '<tr><td style="padding:6px 4px">' + c.id + '</td>' +
+            '<td style="text-align:right;padding:6px 4px">' + c.hives + '</td>' +
+            '<td style="text-align:right;padding:6px 4px">' + c.available_placeholders + '</td>' +
+            cell('max_hives', c.max_hives) + cell('pool_min', c.pool_min) + cell('pool_target', c.pool_target) + '</tr>';
+        }).join('');
+      } catch (e) { /* transient — next poll retries */ }
+    }
+    async function saveScaleSettings() {
+      var status = document.getElementById('scale-save-status');
+      function intOrZero(id) {
+        var el = document.getElementById(id);
+        if (!el || el.value === '') return 0;
+        var n = parseInt(el.value, 10);
+        return isNaN(n) ? 0 : n;
+      }
+      var body = {
+        upgrade_wave_size: intOrZero('scale-upgrade_wave_size'),
+        provision_workers: intOrZero('scale-provision_workers'),
+        provision_per_cluster: intOrZero('scale-provision_per_cluster'),
+        kubectl_per_cluster: intOrZero('scale-kubectl_per_cluster'),
+        clusters: {}
+      };
+      ((_scaleData && _scaleData.clusters) || []).forEach(function(c) {
+        var row = {};
+        ['max_hives', 'pool_min', 'pool_target'].forEach(function(f) {
+          var el = document.getElementById('scale-c-' + c.id + '-' + f);
+          /* Blank = no override (fall back to clusters.json). An explicit
+             number — including 0 — is an override. */
+          if (el && el.value !== '') {
+            var n = parseInt(el.value, 10);
+            if (!isNaN(n)) row[f] = n;
+          }
+        });
+        if (Object.keys(row).length > 0) body.clusters[c.id] = row;
+      });
+      try {
+        var resp = await fetch('/api/saas/admin/scale-settings', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
+        });
+        if (!resp.ok) {
+          var err = {};
+          try { err = await resp.json(); } catch (_) {}
+          status.textContent = 'Save failed: ' + (err.error || resp.status);
+          status.style.color = 'var(--red)';
+          return;
+        }
+        status.textContent = 'Saved — in effect now.';
+        status.style.color = 'var(--green)';
+        setTimeout(function() { status.textContent = ''; }, 5000);
+        loadScaleSettings();
+      } catch (e) {
+        status.textContent = 'Save failed: ' + e;
+        status.style.color = 'var(--red)';
+      }
+    }
+
     function healthBarColor(pct, warnThreshold, dangerThreshold) {
       if (pct >= dangerThreshold) return 'var(--red)';
       if (pct >= warnThreshold) return 'var(--accent)';
@@ -18028,6 +18216,7 @@ const dashboardHTML = `<!DOCTYPE html>
       await loadAdminUsers();
       if (!_adminLoaded) setTimeout(loadAdminUsers, 2000);
       loadClusterHealth();
+      loadScaleSettings();
       loadReach();
       loadClusters();
       handleOpenRouterReturn();
@@ -18040,6 +18229,7 @@ const dashboardHTML = `<!DOCTYPE html>
     startAssignCounterTicker();
     setInterval(loadAdminUsers, POLL_INTERVAL_MS);
     setInterval(loadClusterHealth, CLUSTER_HEALTH_POLL_MS);
+    setInterval(loadScaleSettings, CLUSTER_HEALTH_POLL_MS);
     setInterval(loadReach, REACH_POLL_MS);
     var _refreshTimer = null;
     var REFRESH_DEBOUNCE_MS = 500;

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3695,9 +3695,9 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	provisionHiveRecord := *h
 	provisionHiveRecord.Repos = append([]string(nil), h.Repos...)
 	provisionReq := req
-	provisionWG.Add(1)
-	go func() {
-		defer provisionWG.Done()
+	// Queued, not spawned: execution is bounded hub-wide and per cluster so a
+	// provisioning burst cannot stampede kubectl/OCI (see provision_queue.go).
+	enqueueProvision(targetCluster, func() {
 		h := &provisionHiveRecord
 		cluster := s.clusterForHive(h)
 		if cluster == nil {
@@ -3716,7 +3716,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 		}
 		h.Status = "provisioning"
 		saveSaaSHive(h)
-	}()
+	})
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -200,7 +200,14 @@ type ClusterConfig struct {
 	// and can be optimistic, but routes/PVCs/namespaces and image-pull
 	// bandwidth all scale with hive COUNT, so operators need an explicit
 	// ceiling they can set per cluster as the fleet grows.
-	MaxHives          int    `json:"max_hives,omitempty" yaml:"max_hives,omitempty"`
+	MaxHives int `json:"max_hives,omitempty" yaml:"max_hives,omitempty"`
+	// PoolMin/PoolTarget drive the watermark pool replenisher
+	// (pool_replenisher.go): when clean available placeholders on this
+	// cluster drop below pool_min, the hub provisions up to pool_target.
+	// pool_target 0 (the default) disables auto-replenish for the cluster;
+	// pool_min 0 with a target treats the target itself as the floor.
+	PoolMin           int    `json:"pool_min,omitempty" yaml:"pool_min,omitempty"`
+	PoolTarget        int    `json:"pool_target,omitempty" yaml:"pool_target,omitempty"`
 	Arch              string `json:"arch" yaml:"arch"`
 	ImageTag          string `json:"image_tag" yaml:"image_tag"`
 	ImagePullPolicy   string `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`

--- a/src/pkg/hub/scale_settings.go
+++ b/src/pkg/hub/scale_settings.go
@@ -1,0 +1,249 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Admin-editable scale settings.
+//
+// Every fleet-scale tunable the hub grew (upgrade wave size, provisioning
+// queue bounds, kubectl concurrency, per-cluster capacity/pool watermarks)
+// is edited from the hub dashboard's admin Scale Controls card and persisted
+// here — env vars and clusters.json remain only as INITIAL DEFAULTS, never
+// the only way to change a knob. Reads go through the effective* helpers so
+// a saved value takes effect live (no hub restart) wherever the machinery
+// can honor it.
+
+var scaleSettingsPath = "/data/saas/scale_settings.json"
+
+// ClusterScaleOverride is a per-cluster overlay on clusters.json. Pointers
+// distinguish "not overridden" (nil → clusters.json value stands) from an
+// explicit 0 ("unlimited" for max_hives, "disabled" for pool_target).
+type ClusterScaleOverride struct {
+	MaxHives   *int `json:"max_hives,omitempty"`
+	PoolMin    *int `json:"pool_min,omitempty"`
+	PoolTarget *int `json:"pool_target,omitempty"`
+}
+
+// ScaleSettings is the persisted document. Zero values mean "not set" —
+// the env-var / built-in default chain applies.
+type ScaleSettings struct {
+	UpgradeWaveSize     int                             `json:"upgrade_wave_size,omitempty"`
+	ProvisionWorkers    int                             `json:"provision_workers,omitempty"`
+	ProvisionPerCluster int                             `json:"provision_per_cluster,omitempty"`
+	KubectlPerCluster   int                             `json:"kubectl_per_cluster,omitempty"`
+	Clusters            map[string]ClusterScaleOverride `json:"clusters,omitempty"`
+}
+
+var (
+	scaleSettingsMu sync.RWMutex
+	scaleSettings   ScaleSettings
+	scaleLoaded     bool
+)
+
+func loadScaleSettingsLocked() {
+	if scaleLoaded {
+		return
+	}
+	scaleLoaded = true
+	data, err := os.ReadFile(scaleSettingsPath)
+	if err != nil {
+		return // no file yet — defaults apply
+	}
+	var s ScaleSettings
+	if json.Unmarshal(data, &s) == nil {
+		scaleSettings = s
+	}
+}
+
+func getScaleSettings() ScaleSettings {
+	scaleSettingsMu.Lock()
+	loadScaleSettingsLocked()
+	s := scaleSettings
+	scaleSettingsMu.Unlock()
+	return s
+}
+
+func saveScaleSettings(s ScaleSettings) error {
+	scaleSettingsMu.Lock()
+	defer scaleSettingsMu.Unlock()
+	loadScaleSettingsLocked()
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(scaleSettingsPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(scaleSettingsPath, data, 0o644); err != nil {
+		return err
+	}
+	scaleSettings = s
+	return nil
+}
+
+// resetScaleSettingsForTest clears the cached document so tests that redirect
+// scaleSettingsPath see a fresh load.
+func resetScaleSettingsForTest() {
+	scaleSettingsMu.Lock()
+	scaleSettings = ScaleSettings{}
+	scaleLoaded = false
+	scaleSettingsMu.Unlock()
+}
+
+// settingOrEnv resolves a knob: dashboard-saved value wins, else the env
+// var, else the built-in default.
+func settingOrEnv(saved int, envName string, def int) int {
+	if saved >= 1 {
+		return saved
+	}
+	return envInt(envName, def)
+}
+
+func clusterOverrideFor(clusterID string) (ClusterScaleOverride, bool) {
+	s := getScaleSettings()
+	o, ok := s.Clusters[clusterID]
+	return o, ok
+}
+
+// effectiveMaxHives resolves a cluster's hive-count ceiling: dashboard
+// override first, else the clusters.json value. 0 = unlimited.
+func effectiveMaxHives(cluster *ClusterConfig) int {
+	if cluster == nil {
+		return 0
+	}
+	if o, ok := clusterOverrideFor(cluster.ID); ok && o.MaxHives != nil {
+		return *o.MaxHives
+	}
+	return cluster.MaxHives
+}
+
+// effectivePoolMin / effectivePoolTarget resolve the replenisher watermarks
+// the same way. Target 0 = replenishing disabled.
+func effectivePoolMin(cluster *ClusterConfig) int {
+	if cluster == nil {
+		return 0
+	}
+	if o, ok := clusterOverrideFor(cluster.ID); ok && o.PoolMin != nil {
+		return *o.PoolMin
+	}
+	return cluster.PoolMin
+}
+
+func effectivePoolTarget(cluster *ClusterConfig) int {
+	if cluster == nil {
+		return 0
+	}
+	if o, ok := clusterOverrideFor(cluster.ID); ok && o.PoolTarget != nil {
+		return *o.PoolTarget
+	}
+	return cluster.PoolTarget
+}
+
+// scaleSettingsView is the GET payload: the saved document plus the EFFECTIVE
+// values after the default chain, so the card can show what is actually in
+// force next to each input.
+type scaleSettingsView struct {
+	Saved     ScaleSettings     `json:"saved"`
+	Effective map[string]any    `json:"effective"`
+	Clusters  []clusterScaleRow `json:"clusters"`
+	Defaults  map[string]int    `json:"defaults"`
+}
+
+type clusterScaleRow struct {
+	ID                 string `json:"id"`
+	MaxHives           int    `json:"max_hives"`
+	PoolMin            int    `json:"pool_min"`
+	PoolTarget         int    `json:"pool_target"`
+	Hives              int    `json:"hives"`
+	AvailablePlacehold int    `json:"available_placeholders"`
+}
+
+func (s *HubServer) handleGetScaleSettings(w http.ResponseWriter, r *http.Request) {
+	saved := getScaleSettings()
+	rows := make([]clusterScaleRow, 0, len(s.clusters))
+	for id := range s.clusters {
+		c := s.clusters[id]
+		rows = append(rows, clusterScaleRow{
+			ID:                 id,
+			MaxHives:           effectiveMaxHives(&c),
+			PoolMin:            effectivePoolMin(&c),
+			PoolTarget:         effectivePoolTarget(&c),
+			Hives:              clusterHiveCount(id),
+			AvailablePlacehold: countCleanAvailable(id),
+		})
+	}
+	sortClusterRows(rows)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(scaleSettingsView{
+		Saved: saved,
+		Effective: map[string]any{
+			"upgrade_wave_size":     upgradeWaveSize(),
+			"provision_workers":     provisionWorkerCount(),
+			"provision_per_cluster": provisionPerClusterCap(),
+			"kubectl_per_cluster":   kubectlMaxPerCluster(),
+		},
+		Clusters: rows,
+		Defaults: map[string]int{
+			"upgrade_wave_size":     defaultUpgradeWaveSize,
+			"provision_workers":     defaultProvisionWorkers,
+			"provision_per_cluster": defaultProvisionPerCluster,
+			"kubectl_per_cluster":   defaultKubectlMaxPerCluster,
+		},
+	})
+}
+
+func sortClusterRows(rows []clusterScaleRow) {
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0 && rows[j].ID < rows[j-1].ID; j-- {
+			rows[j], rows[j-1] = rows[j-1], rows[j]
+		}
+	}
+}
+
+// maxScaleSettingValue rejects nonsense input (a wave size of a million is a
+// typo, not a plan) while leaving generous operating room.
+const maxScaleSettingValue = 10000
+
+func (s *HubServer) handleSetScaleSettings(w http.ResponseWriter, r *http.Request) {
+	var in ScaleSettings
+	r.Body = http.MaxBytesReader(w, r.Body, 64*1024)
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+	for _, v := range []int{in.UpgradeWaveSize, in.ProvisionWorkers, in.ProvisionPerCluster, in.KubectlPerCluster} {
+		if v < 0 || v > maxScaleSettingValue {
+			http.Error(w, `{"error":"values must be 0..10000 (0 = use default)"}`, http.StatusBadRequest)
+			return
+		}
+	}
+	for id, o := range in.Clusters {
+		if _, ok := s.clusters[id]; !ok {
+			http.Error(w, `{"error":"unknown cluster in overrides: `+id+`"}`, http.StatusBadRequest)
+			return
+		}
+		for _, p := range []*int{o.MaxHives, o.PoolMin, o.PoolTarget} {
+			if p != nil && (*p < 0 || *p > maxScaleSettingValue) {
+				http.Error(w, `{"error":"cluster overrides must be 0..10000"}`, http.StatusBadRequest)
+				return
+			}
+		}
+	}
+	if err := saveScaleSettings(in); err != nil {
+		s.logger.Error("failed to persist scale settings", "error", err)
+		http.Error(w, `{"error":"failed to persist settings"}`, http.StatusInternalServerError)
+		return
+	}
+	// Grow the provisioning worker pool live when the bound was raised;
+	// shrinking takes effect on the next hub restart (workers are long-lived).
+	provisionQueue.ensureWorkers()
+	s.logger.Info("scale settings updated",
+		"wave", upgradeWaveSize(), "provision_workers", provisionWorkerCount(),
+		"provision_per_cluster", provisionPerClusterCap(), "kubectl_per_cluster", kubectlMaxPerCluster())
+	s.handleGetScaleSettings(w, r)
+}

--- a/src/pkg/hub/scale_settings_test.go
+++ b/src/pkg/hub/scale_settings_test.go
@@ -1,0 +1,91 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// helperRedirectScaleSettings points the persisted scale-settings document at
+// a temp file and resets the in-memory cache, so tests never read the real
+// /data/saas/scale_settings.json or each other's saves.
+func helperRedirectScaleSettings(t *testing.T) {
+	t.Helper()
+	orig := scaleSettingsPath
+	scaleSettingsPath = filepath.Join(t.TempDir(), "scale_settings.json")
+	resetScaleSettingsForTest()
+	t.Cleanup(func() {
+		scaleSettingsPath = orig
+		resetScaleSettingsForTest()
+	})
+}
+
+// TestScaleSettingsPrecedence verifies the resolution chain for every knob:
+// dashboard-saved value > env var > built-in default, and that per-cluster
+// overrides beat clusters.json values (including explicit-zero overrides).
+func TestScaleSettingsPrecedence(t *testing.T) {
+	helperRedirectScaleSettings(t)
+
+	// Built-in defaults with nothing set.
+	os.Unsetenv("HIVE_UPGRADE_WAVE_SIZE")
+	if got := upgradeWaveSize(); got != defaultUpgradeWaveSize {
+		t.Fatalf("default wave size = %d, want %d", got, defaultUpgradeWaveSize)
+	}
+
+	// Env beats built-in.
+	t.Setenv("HIVE_UPGRADE_WAVE_SIZE", "7")
+	t.Setenv("HIVE_PROVISION_PER_CLUSTER", "5")
+	if got := upgradeWaveSize(); got != 7 {
+		t.Fatalf("env wave size = %d, want 7", got)
+	}
+	if got := provisionPerClusterCap(); got != 5 {
+		t.Fatalf("env per-cluster cap = %d, want 5", got)
+	}
+
+	// Dashboard-saved beats env.
+	three := 3
+	zero := 0
+	if err := saveScaleSettings(ScaleSettings{
+		UpgradeWaveSize:     20,
+		ProvisionPerCluster: 1,
+		KubectlPerCluster:   2,
+		Clusters: map[string]ClusterScaleOverride{
+			"c1": {MaxHives: &three, PoolTarget: &zero},
+		},
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if got := upgradeWaveSize(); got != 20 {
+		t.Fatalf("saved wave size = %d, want 20", got)
+	}
+	if got := provisionPerClusterCap(); got != 1 {
+		t.Fatalf("saved per-cluster cap = %d, want 1", got)
+	}
+	if got := kubectlMaxPerCluster(); got != 2 {
+		t.Fatalf("saved kubectl cap = %d, want 2", got)
+	}
+
+	// Per-cluster override beats clusters.json; explicit 0 disables.
+	c1 := &ClusterConfig{ID: "c1", MaxHives: 100, PoolMin: 4, PoolTarget: 8}
+	if got := effectiveMaxHives(c1); got != 3 {
+		t.Fatalf("effectiveMaxHives = %d, want override 3", got)
+	}
+	if got := effectivePoolTarget(c1); got != 0 {
+		t.Fatalf("effectivePoolTarget = %d, want explicit-zero override", got)
+	}
+	if got := effectivePoolMin(c1); got != 4 {
+		t.Fatalf("effectivePoolMin = %d, want clusters.json 4 (not overridden)", got)
+	}
+
+	// Un-overridden cluster falls through to clusters.json.
+	c2 := &ClusterConfig{ID: "c2", MaxHives: 50}
+	if got := effectiveMaxHives(c2); got != 50 {
+		t.Fatalf("effectiveMaxHives(c2) = %d, want 50", got)
+	}
+
+	// Persistence survives a cache reset (fresh load from disk).
+	resetScaleSettingsForTest()
+	if got := upgradeWaveSize(); got != 20 {
+		t.Fatalf("reloaded wave size = %d, want 20", got)
+	}
+}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -985,6 +985,12 @@ type HubServer struct {
 	// (saas_reset_assignment.go). Same rationale and same guarding mutex as the
 	// sweeps above: poller-loop-only state.
 	lastStuckAssignmentSweep time.Time
+	// lastPoolReplenish throttles the watermark pool replenisher
+	// (pool_replenisher.go); poolReplenishHold suspends a cluster's
+	// replenishing until the recorded time after a failed seed. Same
+	// poller-loop-only guarding mutex as the sweeps above.
+	lastPoolReplenish time.Time
+	poolReplenishHold map[string]time.Time
 	// perHiveEnvSeen is the Deployment-SOURCED convergence view backing
 	// PerHiveEnvSnapshot: hive ID → what the hub last actually read off that
 	// hive's Deployment. Deliberately NOT derived from heartbeat recency (see
@@ -1275,6 +1281,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		keyGenerations:          legacyGenerationSet(secret),
 		clusters:                loadClusters(logger),
 		heartbeatHealth:         make(map[string]*HeartbeatHealthEntry),
+		poolReplenishHold:       make(map[string]time.Time),
 		heartbeatUpgrade:        make(map[string]string),
 		heartbeatSwitchTag:      make(map[string]string),
 		clusterUnreachableUntil: make(map[string]time.Time),

--- a/src/pkg/hub/upgrade_schedule.go
+++ b/src/pkg/hub/upgrade_schedule.go
@@ -208,3 +208,16 @@ func shouldAutoUpgradeNow(mode, lastFiredDate string, now time.Time) autoUpgrade
 	}
 	return autoUpgradeDecision{Allowed: true, FireDate: today, Reason: "daily window open"}
 }
+
+// defaultUpgradeWaveSize bounds concurrent auto-upgrades per cluster (the
+// "wave"). At fleet scale an unbounded rollout is an image-pull and PVC IO
+// storm; ten pods at a time keeps a 40-hive cluster converging in a handful
+// of heartbeat cycles without saturating the node image pullers.
+const defaultUpgradeWaveSize = 10
+
+// upgradeWaveSize returns the per-cluster concurrent upgrade bound. The
+// dashboard-saved Scale Controls value wins; HIVE_UPGRADE_WAVE_SIZE is the
+// initial default. Read every trigger tick, so a saved change is live.
+func upgradeWaveSize() int {
+	return settingOrEnv(getScaleSettings().UpgradeWaveSize, "HIVE_UPGRADE_WAVE_SIZE", defaultUpgradeWaveSize)
+}

--- a/src/pkg/hub/upgrade_wave_test.go
+++ b/src/pkg/hub/upgrade_wave_test.go
@@ -1,0 +1,83 @@
+package hub
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// TestTriggerAutoUpgradesWaveBound verifies the per-cluster upgrade wave: with
+// N eligible behind hives on one cluster and a wave size smaller than N, one
+// trigger cycle arms exactly waveSize upgrades; the rest board later waves as
+// in-flight upgrades clear.
+func TestTriggerAutoUpgradesWaveBound(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetCommitOrderState(t)
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "behind", nil
+	})
+	t.Setenv("HIVE_UPGRADE_WAVE_SIZE", "3")
+	setLatestSHAForBranchForTest(t, "v4", "newsha123")
+
+	cluster := ClusterConfig{ID: "wave-c1", InCluster: true}
+	s := &HubServer{
+		logger:           slog.Default(),
+		hubSecret:        testHubSecret,
+		heartbeatUpgrade: make(map[string]string),
+		clusters:         map[string]ClusterConfig{"wave-c1": cluster},
+	}
+	beat := time.Now().UTC().Format(time.RFC3339)
+	const total = 8
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("wave-h%d", i)
+		saveSaaSHive(&SaaSHive{ID: id, Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "wave-c1"})
+		s.registry.Hives = append(s.registry.Hives, RegistryEntry{
+			ID: id, GitBranch: "v4", GitHash: "oldsha", LastHeartbeat: beat,
+		})
+	}
+
+	s.triggerAutoUpgrades()
+
+	s.mu.RLock()
+	armed := len(s.heartbeatUpgrade)
+	s.mu.RUnlock()
+	if armed != 3 {
+		t.Fatalf("first wave armed %d upgrades, want wave size 3", armed)
+	}
+
+	// A second cycle with the wave still in flight must not start more.
+	s.triggerAutoUpgrades()
+	s.mu.RLock()
+	armed = len(s.heartbeatUpgrade)
+	s.mu.RUnlock()
+	if armed != 3 {
+		t.Fatalf("second cycle grew in-flight to %d, want still 3 (wave full)", armed)
+	}
+
+	// Wave slots free as spokes converge: mark the armed three landed and the
+	// next cycle boards the next wave.
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].Upgrading {
+			s.registry.Hives[i].Upgrading = false
+			s.registry.Hives[i].UpgradeTarget = ""
+			s.registry.Hives[i].GitHash = "newsha123"
+		}
+	}
+	s.mu.Unlock()
+
+	s.triggerAutoUpgrades()
+	s.mu.RLock()
+	nowUpgrading := 0
+	for _, reg := range s.registry.Hives {
+		if reg.Upgrading {
+			nowUpgrading++
+		}
+	}
+	s.mu.RUnlock()
+	if nowUpgrading != 3 {
+		t.Fatalf("after wave 1 landed, wave 2 has %d in flight, want 3", nowUpgrading)
+	}
+}


### PR DESCRIPTION
## Phase 2 of the 500-spoke scale plan

### Bounded provisioning queue (`provision_queue.go`)
Provisions used to launch as unbounded goroutines from HTTP handlers. Now a worker pool (default 4 total, 2 per cluster) with FIFO + per-cluster fairness: a burst aimed at one cluster can't starve another, and the per-cluster cap doubles as the OCI FSS creation rate limit.

### Watermark pool replenisher (`pool_replenisher.go`)
Per-cluster `pool_min`/`pool_target`: when clean available placeholders drop below min, the hub seeds placeholders up to target through the queue. Capacity-gated (never provisions onto a full cluster), 30-min backoff on failure, opt-in per cluster.

### Upgrade waves
Auto-upgrades now roll in bounded per-cluster waves (default 10) instead of restarting every behind hive simultaneously — eliminates the fleet-wide image-pull + PVC IO storm observed on every merge. Deferred hives board a later wave the same day (daily/weekly windows stay open).

### Dashboard Scale Controls (admin)
**Every scale tunable is editable in the hub dashboard admin view** — env vars and clusters.json are demoted to initial defaults:
- upgrade wave size · provision workers · provisions/cluster · kubectl procs/cluster (all live; worker shrink applies on restart)
- per-cluster `max_hives` / `pool_min` / `pool_target` overrides (explicit 0 = unlimited/disabled)

Persisted in `/data/saas/scale_settings.json`; GET/POST `/api/saas/admin/scale-settings` (requireAdmin) returns saved + effective + default values so the card shows what is actually in force.

### Tests
Queue bounds/fairness, replenisher watermark/backoff/capacity, wave bound across cycles, settings precedence chain (saved > env > default, cluster override > clusters.json). Full hub suite green (147s).