### PR TITLE
🐛 Stop sticky 'Model removed' toast storms on model-discovery failure

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -6768,10 +6768,19 @@ var inferenceStaticModelAliases = []string{
 }
 
 func (s *Server) queryInferenceModels(backend string) []string {
+	models, _ := s.queryInferenceModelsDetailed(backend)
+	return models
+}
+
+// queryInferenceModelsDetailed additionally reports whether the returned
+// list is the static FALLBACK (discovery failed and no env override) rather
+// than a live-discovered or operator-configured set. Callers surfacing
+// model add/remove events must ignore diffs against a fallback list.
+func (s *Server) queryInferenceModelsDetailed(backend string) ([]string, bool) {
 	if endpoints, ok := s.getInferenceEndpoints(backend); ok {
 		models := fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
 		if len(models) > 0 {
-			return models
+			return models, false
 		}
 	}
 	envVar := "HIVE_VLLM_MODELS"
@@ -6782,11 +6791,11 @@ func (s *Server) queryInferenceModels(backend string) []string {
 		envVar = "HIVE_LITELLM_MODELS"
 	}
 	if val := os.Getenv(envVar); val != "" {
-		return inferenceModelsFromEnv(envVar, "")
+		return inferenceModelsFromEnv(envVar, ""), false
 	}
 	// Discovery failed or the backend is unconfigured — fall back to the
 	// common static aliases (unverified against any endpoint/key).
-	return inferenceStaticModelAliases
+	return inferenceStaticModelAliases, true
 }
 
 const inferenceModelQueryTimeout = 5 * time.Second

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -401,6 +401,11 @@ type InferenceBackend struct {
 	Name      string   `json:"name"`
 	Inference bool     `json:"inference"`
 	Models    []string `json:"models"`
+	// ModelsFallback is true when Models is the static alias list because
+	// live /v1/models discovery failed (endpoint down, 403, etc). The UI
+	// must not treat a fallback list as evidence that models were actually
+	// added or removed (#toast storm on litellm 403).
+	ModelsFallback bool `json:"models_fallback,omitempty"`
 }
 
 type FrontendAgent struct {
@@ -793,17 +798,18 @@ func (s *Server) buildInferenceBackends() []InferenceBackend {
 		{"vllm", "vLLM (self-hosted)"},
 		{"llm-d", "llm-d (self-hosted)"},
 	} {
-		models := s.queryInferenceModels(b.id)
+		models, fallback := s.queryInferenceModelsDetailed(b.id)
 		backends = append(backends, InferenceBackend{
-			ID: b.id, Name: b.name, Inference: true, Models: models,
+			ID: b.id, Name: b.name, Inference: true, Models: models, ModelsFallback: fallback,
 		})
 	}
 	// litellm has no in-cluster default — include it only when an endpoint
 	// is registered, so an unconfigured backend isn't SSE-pushed empty.
 	if endpoints, ok := s.getInferenceEndpoints("litellm"); ok && len(endpoints) > 0 {
+		models, fallback := s.queryInferenceModelsDetailed("litellm")
 		backends = append(backends, InferenceBackend{
 			ID: "litellm", Name: "LiteLLM (proxy)", Inference: true,
-			Models: s.queryInferenceModels("litellm"),
+			Models: models, ModelsFallback: fallback,
 		})
 	}
 	return backends

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -7713,6 +7713,20 @@
     function updateInferenceModelsFromSSE(inferenceBackends) {
       if (!inferenceBackends) return;
       for (const b of inferenceBackends) {
+        /* A fallback list means /v1/models discovery FAILED (endpoint down,
+           gateway 403, ...) and the server substituted static aliases. That
+           is not evidence any model was added or removed — diffing against
+           it once flooded the dashboard with ~25 sticky "Model removed"
+           toasts when a litellm key lost /v1/models access. Keep the last
+           REAL list as the diff baseline so recovery diffs stay accurate,
+           and skip the toast machinery entirely. */
+        if (b.models_fallback) {
+          const fallbackModels = (b.models || []).map(m => ({ value: m, label: m.split('/').pop() }));
+          INFERENCE_MODELS[b.id] = fallbackModels;
+          _inferenceModelCache[b.id] = { models: fallbackModels, ts: Date.now() };
+          if (b.id === 'litellm') refreshLitellmDefaultModelField();
+          continue;
+        }
         const currentIds = (b.models || []).sort();
         const prevIds = (_lastKnownModels[b.id] || []).sort();
 
@@ -7728,10 +7742,16 @@
           });
 
           removed.forEach(m => {
-            showToast(`Model removed from ${b.id}: ${m.split('/').pop()}`, 'error');
+            /* Dedupe like additions, and auto-dismiss after 20s: a removed
+               model is worth a glance, not a permanent sticky requiring a
+               click per model — bulk removals otherwise wallpaper the UI. */
+            const key = `removed:${b.id}:${m}`;
+            if (_dismissedModelBanners.has(key)) return;
+            _dismissedModelBanners.add(key);
+            showToast(`Model removed from ${b.id}: ${m.split('/').pop()}`, 'error', false, TOAST_MODEL_CHANGE_MS);
             if (window._lastAgents) {
               (window._lastAgents || []).filter(a => a.cli === b.id && a.model === m).forEach(a => {
-                showToast(`⚠ ${a.displayName || a.name} uses removed model ${m.split('/').pop()} — update its model selection`, 'error');
+                showToast(`⚠ ${a.displayName || a.name} uses removed model ${m.split('/').pop()} — update its model selection`, 'error', false, TOAST_MODEL_CHANGE_MS);
               });
             }
           });
@@ -13533,6 +13553,9 @@ function burnAreaChart() {
 
     const TOAST_DURATION_MS = 3000;
     const TOAST_PROGRESS_MAX_MS = 60000;
+    /* Model add/remove notices: informational errors that self-clear — long
+       enough to read, never a permanent sticky per model. */
+    const TOAST_MODEL_CHANGE_MS = 20000;
     function hiveConfirm(message, title) {
       return new Promise(resolve => {
         const overlay = document.createElement('div');
@@ -13587,7 +13610,7 @@ function burnAreaChart() {
       el.appendChild(close);
       el.addEventListener('click', () => dismissToast(el, null, null, true));
     }
-    function showToast(msg, type = 'info', persistent = false) {
+    function showToast(msg, type = 'info', persistent = false, autoDismissMs = 0) {
       const container = document.getElementById('toast-container');
       const el = document.createElement('div');
       el.className = `toast ${type}`;
@@ -13603,9 +13626,13 @@ function burnAreaChart() {
       }
       if (type === 'error') {
         makeToastSticky(el);
+        /* autoDismissMs opts an error toast out of stick-forever: it keeps
+           the × for early dismissal but self-clears after the deadline
+           (forced — dismissToast ignores sticky toasts otherwise). */
+        if (autoDismissMs > 0) setTimeout(() => { if (el.parentNode) dismissToast(el, null, null, true); }, autoDismissMs);
         return el;
       }
-      setTimeout(() => dismissToast(el), TOAST_DURATION_MS);
+      setTimeout(() => dismissToast(el), autoDismissMs > 0 ? autoDismissMs : TOAST_DURATION_MS);
       return el;
     }
     function handleGitHubSetupToast() {


### PR DESCRIPTION
## Problem
A litellm gateway 403 on `/v1/models` ("Virtual key is not allowed to call this route") makes model discovery silently fall back to the 7 static aliases. The dashboard diffs that against the previous ~25 live models and emits one **sticky** error toast per "removed" model — they never auto-dismiss, wallpapering the UI until each is clicked away.

## Fix (three parts)
1. **Server**: `InferenceBackend` gains `models_fallback` — set when the list is the static fallback because discovery failed (no env override). A failed probe is not evidence models were removed.
2. **Frontend**: skip add/remove diffing for fallback lists; keep the last REAL list as the diff baseline so recovery produces accurate diffs (and no spurious "added" storm).
3. **Toasts**: model-removal notices now dedupe (like additions already did) and auto-dismiss after 20s via a new `autoDismissMs` opt-out of stick-forever — the × remains for early dismissal.

Full dashboard suite green.