### PR TITLE
📖 docs: correct DASHBOARD_AUTH_TOKEN semantics and finish README PAT scope notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ cp src/deploy/nginx.conf "$CONF/nginx.conf"
 cp src/deploy/quadlet/hive.env.example "$CONF/hive.env"
 chmod 600 "$CONF/hive.env"
 printf 'HIVE_DASHBOARD_TOKEN=%s\n' "$(openssl rand -hex 32)" >> "$CONF/hive.env"
+# Classic PAT: `repo` scope (`public_repo` for public-only), plus `workflow` at
+# L5/L6 if agent PRs may touch `.github/workflows/`. See
+# src/docs/github-app-setup.md#personal-access-token-pat-scopes
 printf 'HIVE_GITHUB_TOKEN=%s\n'    'ghp_...'                 >> "$CONF/hive.env"
 
 # Pull before starting. The generated ExecStart pulls a missing image itself and
@@ -209,6 +212,11 @@ kubectl -n hive create secret generic hive-secrets \
   --from-literal=HIVE_DASHBOARD_TOKEN="$(openssl rand -hex 32)"
 ```
 
+The PAT needs the classic `repo` scope (`public_repo` for public-only repos),
+plus `workflow` at L5/L6 if agent PRs may touch `.github/workflows/`. Scopes are
+never validated at startup, so a wrong-scoped token fails later as a generic
+GitHub 403 — see [Personal access token (PAT) scopes](src/docs/github-app-setup.md#personal-access-token-pat-scopes).
+
 The dashboard token is an opaque shared secret with no server-side strength
 check — always generate it with a CSPRNG as above, never a hand-typed value.
 See [Generating and rotating `HIVE_DASHBOARD_TOKEN`](src/docs/env-vars.md#generating-and-rotating-hive_dashboard_token).
@@ -220,6 +228,10 @@ kubectl -n hive create secret generic hive-secrets \
   --from-literal=HIVE_GITHUB_TOKEN=ghp_... \
   --from-file=gh-app-key.pem=/path/to/key.pem
 ```
+
+With `github.app_id`/`key_file` set, the App path supplies repository
+permissions and the PAT is only a fallback; see
+[GitHub App setup](src/docs/github-app-setup.md) for both paths.
 
 #### 3. Create ConfigMap from hive.yaml
 
@@ -303,7 +315,7 @@ Long timeouts are needed for SSE streaming connections to the dashboard.
 ```bash
 kubectl apply -f src/deploy/k8s/namespace.yaml
 kubectl -n hive create secret generic hive-secrets \
-  --from-literal=HIVE_GITHUB_TOKEN=ghp_...
+  --from-literal=HIVE_GITHUB_TOKEN=ghp_...   # classic PAT: repo scope — see src/docs/github-app-setup.md#personal-access-token-pat-scopes
 kubectl create configmap hive-config -n hive --from-file=hive.yaml=hive.yaml
 kubectl apply -f src/deploy/k8s/pvc.yaml
 kubectl apply -f src/deploy/k8s/deployment.yaml

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -12,7 +12,7 @@ This reference is generated from the v2 source, deployment manifests, and the to
 | `HIVE_SINGLETON_LOCK` | No | `/var/run/hive-metrics/hive.singleton.lock` when available, otherwise OS temp dir | Overrides the process singleton lock path. Set exactly `off` only for local development where duplicate processes are intentional. |
 | `HIVE_GITHUB_TOKEN` | Required unless GitHub App auth is configured | none | Main PAT fallback for `github.token`; also used by fleet/stat fallback paths and some deployment manifests. Missing PAT scopes surface as request-time 403s — see [Required PAT scopes](github-app-setup.md#personal-access-token-pat-scopes). |
 | `GH_APP_KEY_FILE` | No | configured `github.key_file`, then `/data/gh-app-key.pem` or `/secrets/gh-app-key.pem` in provisioned paths | GitHub App private-key file fallback. |
-| `DASHBOARD_AUTH_TOKEN` | No | none | Kubernetes/provisioned secret name for the dashboard shared token; used before `HIVE_DASHBOARD_TOKEN` when `dashboard.auth_token` is empty. |
+| `DASHBOARD_AUTH_TOKEN` | No | none | Dashboard shared-token **value** used by Kubernetes/provisioned deployments; read before `HIVE_DASHBOARD_TOKEN` when `dashboard.auth_token` is empty. Same format rules as `HIVE_DASHBOARD_TOKEN` — see [Generating and rotating `HIVE_DASHBOARD_TOKEN`](#generating-and-rotating-hive_dashboard_token). |
 | `HIVE_DASHBOARD_TOKEN` | No | none | Dashboard/API shared-token fallback and default `hivectl --token-env` variable. See [Generating and rotating `HIVE_DASHBOARD_TOKEN`](#generating-and-rotating-hive_dashboard_token). |
 | `HIVE_AUTHORIZED_USERS` | No | none | Comma-separated direct-route dashboard allowlist, with optional `user:role` entries. Used when `dashboard.authorized_users` is empty. |
 | `HIVE_REPO` | No | none | Bootstrap shortcut in `owner/repo` form; fills `project.org`, `project.repos`, and `project.primary_repo` if missing. |
@@ -55,6 +55,28 @@ to) is an opaque shared secret. The server does **not** enforce any format:
 - **Empty value**: leaving it unset leaves the dashboard API unauthenticated
   (unless direct-route per-user authorization is configured). Never deploy an
   internet-reachable hive without it.
+
+### Precedence: `dashboard.auth_token`, `DASHBOARD_AUTH_TOKEN`, `HIVE_DASHBOARD_TOKEN`
+
+Three sources can supply the same one shared token. The first non-empty value
+wins and the rest are ignored:
+
+1. `dashboard.auth_token` in `hive.yaml` (note that the shipped manifests set it
+   to the `${HIVE_DASHBOARD_TOKEN}` placeholder, which the config resolver
+   expands — so in those deployments the env var is what actually supplies it).
+2. `DASHBOARD_AUTH_TOKEN` environment variable.
+3. `HIVE_DASHBOARD_TOKEN` environment variable.
+
+**Both env vars hold the token *value*, not a Kubernetes Secret name.** In
+`src/deploy/k8s/deployment.yaml` the *name* of the Secret is `hive-secrets`; the
+env var is populated from a key inside it via `secretKeyRef`. Setting either var
+to something like `hive-secrets` configures that literal string as your
+dashboard password.
+
+Because both resolve to the same field, setting them to *different* values is
+never useful — the lower-precedence one is silently discarded, which is a common
+source of "I rotated the token but the old one still works" confusion. Pick one
+variable per deployment and rotate that one.
 
 Generate a strong value with a CSPRNG; 32 bytes (256 bits) of entropy is
 recommended:


### PR DESCRIPTION
## Summary

Follow-up to #4419, which landed the PAT-scope and dashboard-token docs for #4390 / #4391. Reviewing the merged result against the source turned up two residual gaps.

### 1. `DASHBOARD_AUTH_TOKEN` was documented with the wrong semantics

`src/docs/env-vars.md` described it as a "Kubernetes/provisioned secret **name**". The code disagrees — `src/pkg/config/config.go` reads it with `os.Getenv` and assigns it directly to `c.Dashboard.AuthToken`, which is later compared byte-for-byte against the request `Authorization` header:

```go
if c.Dashboard.AuthToken == "" {
    if v := os.Getenv("DASHBOARD_AUTH_TOKEN"); v != "" {
        c.Dashboard.AuthToken = v
    }
}
```

It holds the token **value**. In `src/deploy/k8s/deployment.yaml` the Secret *name* is `hive-secrets`; the env var is populated from a key inside it via `secretKeyRef`. An operator following the old wording and setting the var to `hive-secrets` would configure that literal string as their dashboard password.

Also adds an explicit precedence subsection for the three sources that collapse onto the same field (`dashboard.auth_token` > `DASHBOARD_AUTH_TOKEN` > `HIVE_DASHBOARD_TOKEN`), because the lower-precedence value is silently discarded — a plausible cause of "I rotated the token but the old one still works".

### 2. README PAT scope notes were incomplete

The Quick Start has five `HIVE_GITHUB_TOKEN=ghp_...` spots; #4419 annotated one. This adds scope notes to the Quadlet, k8s secret, and quick-apply blocks, and points the App-auth variant at the App path so operators know which guidance applies.

## Related issues

Refs #4390
Refs #4391

(Both were closed by #4419; this only corrects residue, so it deliberately does not use a closing keyword.)

## Testing

- [x] Other / not run (explain): documentation-only. Claims verified against `src/pkg/config/config.go` (env fallback order and the `redactedForPersist` value-comparison) and `src/deploy/k8s/deployment.yaml` (`secretKeyRef` shape).

## Contributor checklist

- [x] PR targets `v4`.
- [x] Title uses the repo emoji convention.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] No secrets, credentials, or local runtime state are committed; token examples are placeholders.