### PR TITLE
fix(podman): gateway Restart=always, so a clean exit does not leave :3001 down (#4415)

### DIFF
--- a/src/deploy/quadlet/hive-gateway.container
+++ b/src/deploy/quadlet/hive-gateway.container
@@ -110,7 +110,29 @@ HealthStartPeriod=30s
 # is smaller than hive.container's 300s because this unit only starts after
 # Hive is already healthy; nginx itself is up in under a second.
 TimeoutStartSec=120
-Restart=on-failure
+
+# Restart=always, matching Compose's `restart: unless-stopped` and the sibling
+# hive.container (#4415). They are the same statement: systemd never restarts a
+# unit that a `systemctl stop` job stopped, so a deliberate stop still stays
+# stopped, while an out-of-band removal is recovered after RestartSec.
+#
+# on-failure was strictly weaker HERE IN PARTICULAR, because this unit holds the
+# ONLY PUBLISHED PORT ON THE HOST. The pinned nginx image carries
+# `STOPSIGNAL SIGQUIT` — nginx's graceful shutdown — so an external
+# `podman stop hive-gateway` is a CLEAN, EXIT-0 shutdown. Measured on podman
+# 5.8.4 with this image and this [Service] block:
+#
+#   Restart=on-failure   inactive/dead/success, ExecMainStatus=0,
+#                        `systemctl is-failed` -> `inactive`, container never
+#                        returns. :3001 refuses connections and NOTHING is red.
+#   Restart=always       back up within RestartSec, unit stays active/running.
+#
+# NOTE the difference from hive.container, and do not copy its extra line here.
+# That unit needs `SuccessExitStatus=143 SIGTERM` because the Hive entrypoint
+# traps SIGTERM and exits 143, which is NOT in systemd's default success set.
+# nginx exits 0, which already is — so this unit needs the restart policy and
+# nothing else.
+Restart=always
 RestartSec=30
 
 [Install]

--- a/src/deploy/test_standalone_runtime_parity.sh
+++ b/src/deploy/test_standalone_runtime_parity.sh
@@ -179,18 +179,6 @@ EXCEPTIONS = {
     ),
 
     # --- defect-tracked -------------------------------------------------------
-    "restart:gateway": (
-        "defect-tracked",
-        "Compose says unless-stopped, the unit says Restart=on-failure. "
-        "hive.container learned in #4377 that a clean external stop must still "
-        "be recovered and uses Restart=always (systemd never restarts a unit a "
-        "`systemctl stop` job stopped, so that is the exact equivalent of "
-        "unless-stopped); the gateway did not get the same treatment. A gateway "
-        "that exits 0 stays down under on-failure — nginx exits 0 on a clean "
-        "SIGTERM, so the only published port on the host goes away while "
-        "systemctl reports success — and would restart under Compose. Tracked "
-        "in #4415; not fixed here, #4404 is the check and not the fixes.",
-    ),
     "mount-target:gateway:/etc/nginx/upstream": (
         "defect-tracked",
         "Compose mounts the named volume gateway-upstream at /etc/nginx/upstream "


### PR DESCRIPTION
Closes #4415.

## The defect, reproduced

`hive-gateway.container` shipped `Restart=on-failure` where the Compose gateway says `restart: unless-stopped` and the sibling `hive.container` says `Restart=always`. Those are not the same claim, and the asymmetry landed on the process holding **the only published port on the host**.

The issue notes `Restart=` is not observable from a dry-run — `quadlet --dryrun` exits 0 on either value — so this was measured. Podman 5.8.4, systemd user manager, the repository's own pinned gateway image and this unit's `[Service]` block, driven by an external `podman stop`:

```
############ Restart=on-failure ############   (as shipped)
  running      : active/running/success   container=Up 4 seconds
  -- external 'podman stop' (SIGQUIT -> nginx exits 0) --
  t+2s   inactive/dead/success            container=
  t+15s  inactive/dead/success            container=
  is-failed    : inactive
  VERDICT      : STILL DOWN — port would refuse connections

############ Restart=always ############       (this PR)
  t+2s   active/running/success           container=Up 1 second
  t+15s  active/running/success           container=Up 10 seconds
  is-failed    : active
  VERDICT      : RECOVERED — gateway is back up
```

Under `on-failure` the port is gone and **nothing is red anywhere** — `ActiveState` is `inactive`, `Result` is `success`, `ExecMainStatus` is `0`, and `systemctl is-failed` answers `inactive`. Monitoring keyed on any of those does not fire.

## Why it is exit 0, which is the part that matters

The pinned gateway image carries **`STOPSIGNAL SIGQUIT`** — nginx's graceful shutdown — so an out-of-band stop is a *clean, exit-0* shutdown. `on-failure` could never have covered it, with or without `SuccessExitStatus`.

That also settles what **not** to do: this unit does **not** get `hive.container`'s `SuccessExitStatus=143 SIGTERM`. That line exists because the Hive entrypoint traps SIGTERM and exits 143, which is not in systemd's default success set. nginx's 0 already is, so the gateway needs the restart policy and nothing else. The unit now says so in place, so the next reader doesn't add it by symmetry.

`Restart=always` is the exact systemd equivalent of `unless-stopped`: systemd never restarts a unit a `systemctl stop` job stopped, so a deliberate stop still stays stopped and clean, while an out-of-band removal is recovered after `RestartSec`.

I took the issue's first option (bring the gateway to `Restart=always`) rather than the second (document why it's an exception), because the measurement shows there is no defensible exception — the failure mode is silent and lands on the one port operators are told to trust.

## The #4404 anti-rot mechanism, exercised for real

`src/deploy/test_standalone_runtime_parity.sh` carried `restart:gateway` as a `defect-tracked` exception. That table is swept in **reverse** — an entry that no longer matches a real divergence is itself a failure — specifically so a fix cannot leave behind a permanent note claiming something is still broken.

This is its first real exercise, and it worked. With the unit fixed and the entry still in place:

```
FAIL: every exception still corresponds to a live divergence
      stale: ['restart:gateway'] — the divergence is gone, so delete the entry
=== Results: 32 passed, 1 failed, 8 accepted exceptions ===
```

With the entry removed, the restart axis **passes on its own merits** instead of being excepted:

```
--- axis: restart policy ---
  PASS: hive: restart policies agree (compose unless-stopped == systemd Restart=always)
  PASS: gateway: restart policies agree (compose unless-stopped == systemd Restart=always)
=== Results: 33 passed, 0 failed, 8 accepted exceptions ===     (was 32/0/9)
```

## Verification

The real Quadlet generator (podman 5.8.4) generates all four units cleanly in both rootful and `--user` modes, and the **generated** `hive-gateway.service` carries the change — confirmed downstream of the file rather than in it:

```
---hive-gateway.service---        ---hive.service---
TimeoutStartSec=120               TimeoutStartSec=300
Restart=always                    SuccessExitStatus=143 SIGTERM
RestartSec=30                     Restart=always
```

That is the intended asymmetry: both recover, only the one that exits 143 declares 143 a success.

Suites: parity 33/0, port-boundary 18/0, config-coupling 7/7, image-reference 19/19, service-contract 12/0, lifecycle-probe 19/0, update 71/0, bin-suite-wiring 16 suites / 0 orphaned. No behaviour change to Docker, to `hive.container`, or to any other unit.

## One observation, not fixed here

`bin/hive-podman-lifecycle-probe.sh` hardcodes `UNIT="hive.service"` and never looks at the gateway, which is part of why this survived — it *has* a `Restart=` grading rule that would have flagged this, pointed at the wrong unit. Its grading is also tuned to `hive.container`'s situation (it treats bare `on-failure` as a warning because a 143 exit would still restart), which under-grades a unit whose clean exit is 0. Out of scope for this fix, and #4404's parity guard now covers the specific divergence; flagging it in case you want the probe widened.

— hive: backend=claude model=claude-opus-5
