### PR TITLE
📖 docs: record today's merges and remind PRs that skip the changelog

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,0 +1,94 @@
+name: Changelog Reminder
+
+# Why this exists
+#
+# CHANGELOG.md states its own rule — "maintainers should add notable user-facing
+# changes as PRs land" — and that rule quietly stopped being followed: the file
+# went eleven days and roughly a hundred and thirty merges without an entry, and
+# only a docs-sweep agent noticed. Backfilling it resets the clock but does not
+# stop the drift, so this reminds at the one moment somebody can act cheaply:
+# while the PR is still open.
+#
+# It is ADVISORY ON PURPOSE. Most PRs genuinely do not belong in a changelog
+# whose own guidance excludes routine refactors, test-only changes and
+# dependency churn, so a hard gate would fail honest work and train people to
+# ignore it — or worse, to add noise entries just to make it green. It comments
+# once and always succeeds; the judgement stays with the author.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  remind:
+    name: changelog reminder
+    # Drafts and bots are excluded: a draft is not ready for this question, and
+    # dependency bumps are exactly what the changelog guidance excludes.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'copilot-swe-agent[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether this PR touches CHANGELOG.md
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Paginate: a large PR can exceed one page, and a missed page would
+          # produce a false reminder on a PR that did update the changelog.
+          files="$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -qx 'CHANGELOG.md'; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "touched=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Docs-only and CI-only changes are not user-facing in the sense the
+          # changelog means, so they are never worth a reminder.
+          if printf '%s\n' "$files" | grep -qvE '^(src/docs/|docs/|\.github/|README\.md$|CHANGELOG\.md$)'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Remind once
+        if: steps.check.outputs.touched == 'false' && steps.check.outputs.code == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker='<!-- changelog-reminder -->'
+          # Only ever comment once per PR. A reminder that reappears on every
+          # push is noise, and noise is how the previous convention died.
+          if gh api --paginate "repos/$REPO/issues/$PR/comments" --jq '.[].body' \
+              | grep -qF "$marker"; then
+            echo "already reminded"
+            exit 0
+          fi
+          # Body built in a heredoc rather than inline: the text starts a line
+          # with '**', which YAML would read as an alias in a plain scalar.
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          $marker
+          **Changelog:** this PR changes code but does not touch \`CHANGELOG.md\`.
+
+          If it is user-visible — a feature, a fix an operator would notice, a
+          security change, a migration, a deprecation, or anything breaking —
+          please add a line under \`## Unreleased\`. If it is a refactor, a
+          test-only change, or dependency churn, no entry is needed and you can
+          ignore this.
+
+          This is a reminder, not a gate; it never blocks a merge.
+          EOF
+          # Strip the YAML block indentation the heredoc preserved.
+          sed -i 's/^          //' "$body_file"
+          gh api "repos/$REPO/issues/$PR/comments" -F body=@"$body_file"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ## Unreleased
 
-No notable user-facing changes have been recorded since the dated entries below.
+### Added
+
+- Hive quadrant: every hive is scored on four axes — trust, efficiency, satisfaction and productivity — shown as a small shape in the hub's hive table, as a labelled chart with scores when you hover it, and as a fleet aggregate above the table that follows whatever filter is applied. Scores are percentiles against the hives in the current view rather than absolute grades, so the picture recalibrates as the fleet moves, and any axis can be sorted on to pull a worklist ("weakest efficiency" first). An axis with too little evidence renders as a collapsed spoke and reports why, rather than scoring zero — a new hive is never marked down for data it has not had time to produce. Satisfaction currently reports no signal by design: nothing in the platform measures it yet, and it is left visibly empty rather than filled with a proxy ([#4384](https://github.com/kubestellar/hive/pull/4384)). Seven already-collected spoke metrics now ride the heartbeat to feed it, adding no GitHub API calls.
+- User location: hub users can carry a country, shown as a flag beside their avatar. It is set from a dropdown when a hive is requested, changed later by the signed-in user, or assigned by an admin from the Users table for accounts that predate the feature; where nothing is stated it is inferred from the browser's language header, and an unknown country renders nothing rather than a guess. A deliberate choice always outranks an admin's, which outranks an inference, so nobody's stated country is quietly overwritten. The admin Users table gains a country column and a fleet breakdown that reports how many users are still unknown ([#4371](https://github.com/kubestellar/hive/pull/4371), [#4374](https://github.com/kubestellar/hive/pull/4374), [#4373](https://github.com/kubestellar/hive/pull/4373), [#4386](https://github.com/kubestellar/hive/pull/4386)).
+
+### Fixed
+
+- `DASHBOARD_AUTH_TOKEN` was documented as holding a Kubernetes secret *name*; it holds the token *value* itself. An operator following the old wording would have set their dashboard token to the literal name of the Secret ([#4427](https://github.com/kubestellar/hive/pull/4427)).
 
 ## 2026-08-21
 


### PR DESCRIPTION
## What this does

**Records six merges the changelog is missing.** #4419 caught the file up through 2026-08-21, but these landed after it was written:

- the hive quadrant (#4384)
- the four user-location PRs (#4371, #4374, #4373, #4386)
- the `DASHBOARD_AUTH_TOKEN` semantics correction (#4427)

**Adds an advisory reminder so it stops drifting.** The backlog was never the real problem. `CHANGELOG.md` states its own rule — *"maintainers should add notable user-facing changes as PRs land"* — and that rule quietly stopped being followed for eleven days and ~130 merges, until a docs-sweep agent filed #4392. Backfilling alone resets the clock and guarantees a repeat.

## Why it is advisory, not a gate

The changelog's own guidance excludes routine refactors, test-only changes and dependency churn. A blocking check would fail honest work that legitimately needs no entry, and would train people either to ignore it or to add noise entries to make it green — both worse than the status quo.

So it comments **once** per PR and always succeeds. It skips drafts, bots, and docs- or CI-only changes. The judgement stays with the author.

## Notes

- File listing is paginated; a missed page would produce a false reminder on a PR that *did* update the changelog.
- The comment body is built in a heredoc because the text starts a line with `**`, which YAML reads as an alias in a plain scalar. Validated by parsing the workflow and rendering the body.

Fixes #4392
