### PR TITLE
✨ feat(github): validate PAT scopes at startup and name the missing capability

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -595,6 +595,12 @@ type githubAuth struct {
 	// owner for a key WE failed to provision is precisely the mistake
 	// github.AppAuthState exists to prevent.
 	State github.AppAuthState
+	// TokenScopes is the boot-time PAT scope probe (see
+	// github.CheckTokenScopes). Zero value / ScopeStatusSkipped on the App
+	// path. It is advisory: a ScopeStatusMissing result never blocks startup,
+	// it only gives github_auth a specific detail string instead of leaving the
+	// operator to decode a runtime 403.
+	TokenScopes github.ScopeResult
 }
 
 // initGitHubAuth resolves this hive's GitHub credentials.
@@ -666,6 +672,21 @@ func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger
 	switch {
 	case ghToken != "":
 		out.Client = github.NewClient(ghToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
+		// PAT path only: introspect the token's granted scopes ONCE, here, so a
+		// too-narrow token is named at boot instead of surfacing hours later as
+		// a generic 403 inside an agent — or, worse, as an empty backlog that
+		// looks like "no work to do". Fail-soft and bounded (see
+		// CheckTokenScopes); it never blocks or fails startup. The App branch
+		// above returns before this point: Apps have permissions, not scopes.
+		// An unset acmm_level is passed through as github.ACMMLevelUnset rather
+		// than inferACMMLevel's L1 default: L1 requires no scopes at all, so
+		// defaulting to it would silently suppress every warning on exactly the
+		// hives whose intent we cannot read. See ACMMLevelUnset.
+		scopeLevel := github.ACMMLevelUnset
+		if cfg.ACMMLevel != nil {
+			scopeLevel = *cfg.ACMMLevel
+		}
+		out.TokenScopes = out.Client.LogTokenScopeCheck(ctx, logger, scopeLevel)
 	case out.Failure != "":
 		// Real App, unusable key. Already logged; leave Client nil so nothing
 		// tries to act on GitHub with credentials that do not work.
@@ -2270,6 +2291,7 @@ func main() {
 		Governor:         gov,
 		GHClient:         ghClient,
 		GHAppAuth:        appAuth,
+		GHTokenScopes:    ghAuth.TokenScopes,
 		Tokens:           tokenCollector,
 		Knowledge:        knowledgeAPI,
 		Inception:        inceptionEngine,

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -21,11 +21,18 @@ import (
 )
 
 type Dependencies struct {
-	Config           *config.Config
-	AgentMgr         *agent.Manager
-	Governor         *governor.Governor
-	GHClient         *ghpkg.Client
-	GHAppAuth        *ghpkg.AppAuth
+	Config    *config.Config
+	AgentMgr  *agent.Manager
+	Governor  *governor.Governor
+	GHClient  *ghpkg.Client
+	GHAppAuth *ghpkg.AppAuth
+	// GHTokenScopes is the boot-time PAT scope probe result (see
+	// ghpkg.CheckTokenScopes). It is set only on the token-auth path; the App
+	// path leaves it at ScopeStatusSkipped because Apps carry permissions, not
+	// OAuth scopes. github_auth reports it as a DETAIL on an otherwise-passing
+	// check: a narrow token still authenticates, so failing the check would
+	// misreport the fault — what is broken is a capability, not the auth.
+	GHTokenScopes    ghpkg.ScopeResult
 	Tokens           *tokens.Collector
 	Knowledge        *knowledge.KnowledgeAPI
 	Inception        *knowledge.InceptionEngine

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -276,13 +276,13 @@ type StatusPayload struct {
 	// guard counters when the instance changes instead of dropping forever.
 	StatusInstance string           `json:"statusInstance"`
 	HiveID         string           `json:"hiveId"`
-	Agents    []FrontendAgent  `json:"agents"`
-	Governor  FrontendGovernor `json:"governor"`
-	Tokens    FrontendTokens   `json:"tokens"`
-	Repos     []FrontendRepo   `json:"repos"`
-	Beads     FrontendBeads    `json:"beads"`
-	Planning  FrontendPlanning `json:"planning"`
-	Health    map[string]any   `json:"health"`
+	Agents         []FrontendAgent  `json:"agents"`
+	Governor       FrontendGovernor `json:"governor"`
+	Tokens         FrontendTokens   `json:"tokens"`
+	Repos          []FrontendRepo   `json:"repos"`
+	Beads          FrontendBeads    `json:"beads"`
+	Planning       FrontendPlanning `json:"planning"`
+	Health         map[string]any   `json:"health"`
 	// DeepHealth carries the spoke's own deep health checks (HealthSummary:
 	// ready, github_auth, agents, …) — the same checks the heartbeat reports
 	// to the hub. The dashboard's header Health pill renders from these, NOT
@@ -2091,7 +2091,15 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 			failCount++
 		}
 	} else if s.deps != nil && s.deps.GHClient != nil {
-		checks["github_auth"] = map[string]any{"status": "pass", "detail": "token-based"}
+		// Stays "pass": a too-narrow PAT authenticates fine, so the auth is not
+		// what is broken — a capability is. Reporting it as a fail would send
+		// an operator to re-issue working credentials. The detail carries the
+		// specific missing scope so the diagnosis is not left to a runtime 403.
+		detail := "token-based"
+		if s.deps.GHTokenScopes.Status == github.ScopeStatusMissing {
+			detail = "token-based — " + s.deps.GHTokenScopes.Detail
+		}
+		checks["github_auth"] = map[string]any{"status": "pass", "detail": detail}
 	} else {
 		checks["github_auth"] = map[string]any{"status": "fail", "detail": "no GitHub auth configured"}
 		overall = "degraded"
@@ -2816,7 +2824,12 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 			checks = append(checks, check{Name: "github_auth", Status: "pass"})
 		}
 	} else if s.deps != nil && s.deps.GHClient != nil {
-		checks = append(checks, check{Name: "github_auth", Status: "pass", Detail: "token"})
+		// See the /health counterpart above: pass with a scope-specific detail.
+		detail := "token"
+		if s.deps.GHTokenScopes.Status == github.ScopeStatusMissing {
+			detail = "token — " + s.deps.GHTokenScopes.Detail
+		}
+		checks = append(checks, check{Name: "github_auth", Status: "pass", Detail: detail})
 	} else {
 		checks = append(checks, check{Name: "github_auth", Status: "fail", Detail: "no auth"})
 		fails++

--- a/src/pkg/github/tokenscopes.go
+++ b/src/pkg/github/tokenscopes.go
@@ -1,0 +1,397 @@
+package github
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ── Why this file exists ────────────────────────────────────────────────────
+//
+// A classic PAT with too few scopes does not fail at boot. It fails much later
+// and far from the cause: the scanner reports "no actionable work" because a
+// search 403'd, or an agent's PR creation dies inside gh-wrapper with a generic
+// "403 Resource not accessible". Nothing in that chain names the missing scope,
+// so an operator has to reverse-engineer which capability was denied from a
+// symptom that looks like an empty backlog.
+//
+// GitHub hands us the answer for free. Every authenticated REST response
+// carries X-OAuth-Scopes (the scopes the token was granted) and
+// X-Accepted-OAuth-Scopes (what the endpoint wanted). One cheap authenticated
+// call at boot turns a silent, delayed, mis-attributed failure into a specific
+// startup line naming the scope AND the capability it costs.
+//
+// This check is a DIAGNOSTIC and must never become a failure mode of its own:
+// it fails soft in every direction (see CheckTokenScopes).
+
+const (
+	// scopeCheckTimeout bounds the single boot-time probe. Startup must not be
+	// held hostage by a slow or blackholed api.github.com — under forced proxy
+	// egress a misconfigured proxy can hang a connection indefinitely. Five
+	// seconds is far above the p99 for a /rate_limit call yet short enough to
+	// be invisible in a boot sequence that already takes seconds.
+	scopeCheckTimeout = 5 * time.Second
+
+	// oauthScopesHeader carries the scopes actually granted to a classic PAT.
+	// It is ABSENT (not empty-but-present) for GitHub App installation tokens
+	// and is present-but-empty for fine-grained PATs, which carry repository
+	// permissions instead of scopes. That distinction is the whole reason
+	// ScopeResult separates "not determinable" from "missing".
+	oauthScopesHeader = "X-OAuth-Scopes"
+)
+
+// Scope names GitHub uses for classic PATs. Named rather than inlined so the
+// requirement table below reads as capabilities, not string literals.
+const (
+	scopeRepo       = "repo"
+	scopePublicRepo = "public_repo"
+	scopeReadOrg    = "read:org"
+	scopeWorkflow   = "workflow"
+	scopeRepoStatus = "repo:status"
+)
+
+// ScopeStatus classifies the outcome of the boot-time scope probe.
+type ScopeStatus string
+
+const (
+	// ScopeStatusOK means the granted scopes cover everything this hive needs
+	// at its configured ACMM level.
+	ScopeStatusOK ScopeStatus = "ok"
+	// ScopeStatusMissing means the token IS a classic PAT, we read its granted
+	// scopes, and a required one is genuinely absent. This is the only status
+	// that asserts a defect.
+	ScopeStatusMissing ScopeStatus = "missing"
+	// ScopeStatusUndetermined means we could not learn the token's scopes:
+	// a fine-grained PAT (no X-OAuth-Scopes), an App token, a network error,
+	// or a non-GitHub API endpoint. Absence of evidence — reported as such and
+	// never as evidence of absence.
+	ScopeStatusUndetermined ScopeStatus = "undetermined"
+	// ScopeStatusSkipped means the check did not apply — App auth, or no
+	// client at all.
+	ScopeStatusSkipped ScopeStatus = "skipped"
+)
+
+// ScopeResult is the outcome of the boot-time probe, in a shape both the
+// startup log and the dashboard's github_auth health check can render.
+type ScopeResult struct {
+	Status ScopeStatus
+	// Granted is the scope list read from X-OAuth-Scopes. Only meaningful for
+	// ScopeStatusOK / ScopeStatusMissing.
+	Granted []string
+	// Missing lists required scopes that were not granted, in the order the
+	// requirement table declares them (most consequential first).
+	Missing []string
+	// Detail is the operator-facing sentence. For ScopeStatusMissing it names
+	// the scope AND the capability lost, because "insufficient permissions" is
+	// exactly the unhelpful message this check exists to replace.
+	Detail string
+	// Reason explains an Undetermined result so an operator can tell "your
+	// token is fine-grained, we can't introspect it" from "we couldn't reach
+	// GitHub".
+	Reason string
+}
+
+// scopeRequirement binds one scope to the capability an operator loses without
+// it and the lowest ACMM level at which the hive actually exercises that
+// capability.
+type scopeRequirement struct {
+	// scope is the classic-PAT scope name.
+	scope string
+	// alternatives are scopes that also satisfy this requirement. GitHub's
+	// scope hierarchy is not a simple set-membership test: a token granted
+	// "repo" implicitly covers "public_repo", "repo:status", and the Actions
+	// read surface, and GitHub reports only the broader scope in
+	// X-OAuth-Scopes. Without this a perfectly good "repo" token would be
+	// warned at for "missing" repo:status — a false alarm of exactly the kind
+	// this check must not produce.
+	alternatives []string
+	// minLevel is the lowest ACMM level whose agents exercise the capability.
+	// Below it the scope is genuinely unnecessary and warning about it would
+	// be noise on a correctly-configured read-only hive.
+	minLevel int
+	// capability is the operator-facing consequence, phrased as what breaks.
+	capability string
+}
+
+// ACMM level boundaries at which new GitHub capabilities switch on. These
+// mirror the level packs in pkg/config/packs/: L1 Inception, L2 Advisory
+// (read + comment), L3 Quality-Gated, L4 Security-Aware (issue filing),
+// L5 Semi-Autonomous (PR creation), L6 Fully Autonomous (auto-merge).
+const (
+	// acmmLevelAdvisory (L2) is where agents first read repositories and post
+	// advisory comments — the lowest level that touches GitHub at all.
+	acmmLevelAdvisory = 2
+	// acmmLevelSecurityAware (L4) is where agents file issues and manage
+	// labels rather than only commenting.
+	acmmLevelSecurityAware = 4
+	// acmmLevelSemiAutonomous (L5) is where agents open pull requests.
+	acmmLevelSemiAutonomous = 5
+
+	// ACMMLevelUnset is passed by callers whose config carries no acmm_level.
+	// It resolves to the MOST capable level, deliberately: an unset level means
+	// we cannot know what the hive will attempt, and under-warning (staying
+	// silent about a genuinely missing scope) is precisely the failure this
+	// check exists to eliminate. The cost of over-warning is one actionable log
+	// line. Note this is why the caller must not reuse inferACMMLevel's L1
+	// default here — L1 requires no scopes, so it would suppress everything.
+	ACMMLevelUnset = -1
+
+	// acmmLevelFullyAutonomous (L6) is the ceiling, and what ACMMLevelUnset
+	// resolves to.
+	acmmLevelFullyAutonomous = 6
+)
+
+// scopeRequirements maps the GitHub REST surface this hive actually calls to
+// the classic-PAT scopes those calls need.
+//
+// DERIVED FROM THE CODE, not from documentation-by-guesswork. The call sites
+// backing each entry are named so a future reader can re-verify the mapping
+// when the API surface changes — this is the table most likely to drift.
+var scopeRequirements = []scopeRequirement{
+	{
+		// pullrequest.go PullRequests.Create; automerge_sweep.go
+		// PullRequests.Merge; client.go Issues.CreateComment;
+		// advisory.go Issues.Create. Every write path against a private repo
+		// needs full "repo"; GitHub grants no narrower write scope.
+		scope:        scopeRepo,
+		alternatives: []string{},
+		minLevel:     acmmLevelSemiAutonomous,
+		capability:   "agents will fail to create or merge pull requests",
+	},
+	{
+		// advisory.go Issues.Create + Issues.AddLabelsToIssue /
+		// Issues.CreateLabel. Issue filing on a public repo is satisfied by
+		// public_repo; a private repo needs full repo, which subsumes it.
+		scope:        scopePublicRepo,
+		alternatives: []string{scopeRepo},
+		minLevel:     acmmLevelSecurityAware,
+		capability:   "agents will fail to file issues or apply labels",
+	},
+	{
+		// client.go fetchIssues (Issues.ListByRepo), Search.Issues, and
+		// advisory.go Issues.CreateComment — the read + advise surface. Public
+		// repos need public_repo; private repos need repo.
+		scope:        scopePublicRepo,
+		alternatives: []string{scopeRepo},
+		minLevel:     acmmLevelAdvisory,
+		capability:   "the scanner will see no actionable issues and agents cannot post advisory comments",
+	},
+	{
+		// health.go FetchWorkflowHealth (Actions.ListWorkflows /
+		// ListWorkflowRunsByID / ListWorkflowJobs) and automerge_sweep.go
+		// commitGreen (Checks.ListCheckRunsForRef,
+		// Repositories.GetCombinedStatus).
+		//
+		// minLevel is acmmLevelAdvisory, NOT L5, even though the merge
+		// consequence is an L5+ concern: FetchWorkflowHealth is ungated and
+		// runs at EVERY level, so an L2 hive with a token that cannot read
+		// Actions loses its workflow-health dashboard silently. Gating this at
+		// L5 would have left exactly that hive unwarned. The capability string
+		// therefore names the read loss first, which is what is true at every
+		// level.
+		//
+		// "workflow" is NOT required: it governs mutating workflow FILES, which
+		// this hive only ever does through PR contents. It is listed as an
+		// alternative because a token that has it also reads Actions fine.
+		scope:        scopeRepoStatus,
+		alternatives: []string{scopeRepo, scopePublicRepo, scopeWorkflow},
+		minLevel:     acmmLevelAdvisory,
+		capability:   "CI status is unreadable — workflow health shows unknown, and at L5+ the auto-merge sweep will never merge a green PR",
+	},
+	{
+		// client.go ListContributors and the org-scoped Search.Issues in
+		// fleet_stats.go / pr_issue_counts.go. Reading org membership and
+		// private org repos requires read:org; "repo" alone does not grant it.
+		//
+		// Deliberately NOT justified by app_discovery.go's org lookups
+		// (Apps.FindOrganizationInstallation): those run on a JWT App client,
+		// never on a PAT, so they are irrelevant to a scope check that only
+		// runs on the token path.
+		scope:        scopeReadOrg,
+		alternatives: []string{},
+		minLevel:     acmmLevelSecurityAware,
+		capability:   "org-scoped issue search and contributor lookups will return empty results",
+	},
+}
+
+// requiredScopesForLevel returns the deduplicated requirements that apply at
+// the given ACMM level, preserving table order so the most consequential
+// capability is reported first.
+func requiredScopesForLevel(level int) []scopeRequirement {
+	if level == ACMMLevelUnset {
+		level = acmmLevelFullyAutonomous
+	}
+	var out []scopeRequirement
+	seen := make(map[string]bool)
+	for _, r := range scopeRequirements {
+		if level < r.minLevel || seen[r.scope] {
+			continue
+		}
+		seen[r.scope] = true
+		out = append(out, r)
+	}
+	return out
+}
+
+// satisfied reports whether the granted set covers this requirement, honouring
+// the scope hierarchy via alternatives.
+func (r scopeRequirement) satisfied(granted map[string]bool) bool {
+	if granted[r.scope] {
+		return true
+	}
+	for _, alt := range r.alternatives {
+		if granted[alt] {
+			return true
+		}
+	}
+	return false
+}
+
+// parseScopeHeader splits the comma-separated X-OAuth-Scopes value. GitHub
+// emits ", " separators; entries are trimmed and empties dropped so a header
+// of "" or ", " yields an empty slice rather than phantom scopes.
+func parseScopeHeader(v string) []string {
+	var out []string
+	for _, part := range strings.Split(v, ",") {
+		if s := strings.TrimSpace(part); s != "" {
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// CheckTokenScopes probes the token's granted scopes and compares them against
+// what this hive needs at acmmLevel.
+//
+// FAIL-SOFT IN EVERY DIRECTION. It returns a result and never an error; no
+// input, no network condition, and no API response can make it report a
+// problem it did not actually observe:
+//
+//   - App auth (c.appAuth != nil) → Skipped. An App has PERMISSIONS, not
+//     scopes; X-OAuth-Scopes does not apply and warning about a PAT that is
+//     not in use would be pure noise.
+//   - Header absent or empty → Undetermined, NEVER Missing. Fine-grained PATs
+//     carry repository permissions and report no scopes at all, so a
+//     fail-closed reading here would raise a false alarm on every
+//     fine-grained-token deployment — and if it gated startup, would brick
+//     them. Absence of evidence is not evidence of absence.
+//   - Network error or timeout → Undetermined. The check is a diagnostic; it
+//     must never invent a new way for a hive to fail to boot.
+//
+// It issues exactly ONE authenticated request, at boot only. The fleet shares a
+// rate-limit budget, so this must not become a periodic probe. /rate_limit is
+// deliberately chosen as the probe endpoint: it is authenticated (so GitHub
+// returns the scope headers), needs no scopes of its own (so it cannot 403 for
+// the very reason we are investigating), and does not itself consume quota.
+func (c *Client) CheckTokenScopes(ctx context.Context, acmmLevel int) ScopeResult {
+	if c == nil || c.client == nil {
+		return ScopeResult{Status: ScopeStatusSkipped, Reason: "no github client configured"}
+	}
+	if c.appAuth != nil {
+		return ScopeResult{
+			Status: ScopeStatusSkipped,
+			Reason: "GitHub App authentication in use — Apps carry permissions, not OAuth scopes",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, scopeCheckTimeout)
+	defer cancel()
+
+	req, err := c.client.NewRequest(http.MethodGet, "rate_limit", nil)
+	if err != nil {
+		return ScopeResult{Status: ScopeStatusUndetermined, Reason: "could not build scope probe request: " + err.Error()}
+	}
+	resp, err := c.client.Do(ctx, req, nil)
+	if err != nil && resp == nil {
+		// No response at all: DNS, dial, TLS, or timeout. We learned nothing.
+		return ScopeResult{Status: ScopeStatusUndetermined, Reason: "could not reach GitHub to read token scopes: " + err.Error()}
+	}
+	if resp == nil || resp.Response == nil {
+		return ScopeResult{Status: ScopeStatusUndetermined, Reason: "no response headers available to read token scopes"}
+	}
+
+	// The header may be present-and-empty (fine-grained PAT) or wholly absent
+	// (App token, non-GitHub endpoint). Both mean "not introspectable", and
+	// both must read as Undetermined. Note that an error response is still
+	// useful here — GitHub sets the scope headers on 401/403 too — so we read
+	// the header before considering err.
+	raw, present := resp.Response.Header[http.CanonicalHeaderKey(oauthScopesHeader)]
+	if !present {
+		if err != nil {
+			return ScopeResult{Status: ScopeStatusUndetermined, Reason: "GitHub returned no scope header: " + err.Error()}
+		}
+		return ScopeResult{
+			Status: ScopeStatusUndetermined,
+			Reason: "GitHub returned no " + oauthScopesHeader + " header — the token is not a classic PAT (fine-grained PATs carry repository permissions, not scopes)",
+		}
+	}
+
+	granted := parseScopeHeader(strings.Join(raw, ","))
+	if len(granted) == 0 {
+		// Present but empty is the fine-grained-PAT signature. Saying "missing
+		// repo" here would be a false alarm on a working deployment.
+		return ScopeResult{
+			Status: ScopeStatusUndetermined,
+			Reason: "GitHub reported no OAuth scopes for this token — it is a fine-grained PAT, whose repository permissions cannot be read from " + oauthScopesHeader + "; verify its permissions in GitHub settings",
+		}
+	}
+
+	grantedSet := make(map[string]bool, len(granted))
+	for _, s := range granted {
+		grantedSet[s] = true
+	}
+
+	var missing []string
+	var details []string
+	for _, r := range requiredScopesForLevel(acmmLevel) {
+		if r.satisfied(grantedSet) {
+			continue
+		}
+		missing = append(missing, r.scope)
+		details = append(details, `github token is missing the "`+r.scope+`" scope — `+r.capability)
+	}
+
+	if len(missing) == 0 {
+		return ScopeResult{Status: ScopeStatusOK, Granted: granted}
+	}
+	return ScopeResult{
+		Status:  ScopeStatusMissing,
+		Granted: granted,
+		Missing: missing,
+		Detail:  strings.Join(details, "; "),
+	}
+}
+
+// LogTokenScopeCheck runs the probe and reports the outcome at the severity the
+// operator needs, then returns the result so a caller can also surface it in
+// the dashboard's github_auth health check.
+//
+// Never logs token material — only scope NAMES and capability consequences.
+// A silent pass is intentional: a correctly-scoped token produces no output,
+// so any line from this check is actionable by construction.
+func (c *Client) LogTokenScopeCheck(ctx context.Context, logger *slog.Logger, acmmLevel int) ScopeResult {
+	res := c.CheckTokenScopes(ctx, acmmLevel)
+	if logger == nil {
+		return res
+	}
+	switch res.Status {
+	case ScopeStatusMissing:
+		logger.Warn("github token scope check failed",
+			"detail", res.Detail,
+			"missing_scopes", strings.Join(res.Missing, ","),
+			"granted_scopes", strings.Join(res.Granted, ","),
+			"acmm_level", acmmLevel,
+		)
+	case ScopeStatusUndetermined:
+		// Debug, not Warn. We observed nothing wrong; a fine-grained PAT is a
+		// perfectly valid configuration and must not be nagged at every boot.
+		logger.Debug("github token scopes could not be determined", "reason", res.Reason)
+	case ScopeStatusSkipped, ScopeStatusOK:
+		// Silent by design — requirement 5, zero noise when nothing is wrong.
+	}
+	return res
+}

--- a/src/pkg/github/tokenscopes_test.go
+++ b/src/pkg/github/tokenscopes_test.go
@@ -1,0 +1,334 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// scopeTestServer returns a client pointed at a test server whose /rate_limit
+// response carries the given X-OAuth-Scopes header. setHeader=false omits the
+// header entirely (the App-token / non-GitHub shape); setHeader=true with an
+// empty value is the fine-grained-PAT shape, which is the case most likely to
+// regress into a false alarm.
+func scopeTestServer(t *testing.T, setHeader bool, scopes string) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if setHeader {
+			w.Header().Set(oauthScopesHeader, scopes)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resources":{}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return NewClientForTest(srv.URL, "kubestellar", []string{"hive"}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+}
+
+func TestCheckTokenScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		setHeader  bool
+		scopes     string
+		level      int
+		wantStatus ScopeStatus
+		// wantDetailContains asserts the message NAMES the scope and the
+		// capability. A generic "insufficient permissions" is the exact failure
+		// this feature removes, so an empty-detail pass is not acceptable.
+		wantDetailContains []string
+		wantMissing        []string
+	}{
+		{
+			// Positive control's counterpart: a full-scope token at the highest
+			// level must be silent.
+			name:       "sufficient scopes at L6 produce no warning",
+			setHeader:  true,
+			scopes:     "repo, read:org, workflow",
+			level:      6,
+			wantStatus: ScopeStatusOK,
+		},
+		{
+			// POSITIVE CONTROL for the case above: same level, narrower token,
+			// must warn AND name "repo" plus the PR capability.
+			name:               "missing repo at L6 warns naming scope and capability",
+			setHeader:          true,
+			scopes:             "read:org",
+			level:              6,
+			wantStatus:         ScopeStatusMissing,
+			wantMissing:        []string{scopeRepo},
+			wantDetailContains: []string{`"repo"`, "pull requests"},
+		},
+		{
+			// THE MOST IMPORTANT CASE. Fine-grained PATs report no scopes.
+			// Reporting "missing" here would spam a false alarm at every boot of
+			// every fine-grained-token deployment.
+			name:       "empty X-OAuth-Scopes reports undetermined not missing",
+			setHeader:  true,
+			scopes:     "",
+			level:      6,
+			wantStatus: ScopeStatusUndetermined,
+		},
+		{
+			name:       "absent X-OAuth-Scopes header reports undetermined",
+			setHeader:  false,
+			level:      6,
+			wantStatus: ScopeStatusUndetermined,
+		},
+		{
+			// ACMM tiering: read-only advisory needs far less than PR creation.
+			// public_repo alone is fine at L2 …
+			name:       "public_repo alone is sufficient at L2",
+			setHeader:  true,
+			scopes:     "public_repo",
+			level:      2,
+			wantStatus: ScopeStatusOK,
+		},
+		{
+			// … and the SAME token warns at L5. This pair is what proves the
+			// level actually gates the requirement rather than the check being
+			// level-blind.
+			name:               "same public_repo token warns at L5",
+			setHeader:          true,
+			scopes:             "public_repo",
+			level:              5,
+			wantStatus:         ScopeStatusMissing,
+			wantMissing:        []string{scopeRepo, scopeReadOrg},
+			wantDetailContains: []string{`"repo"`, `"read:org"`},
+		},
+		{
+			// Scope hierarchy: "repo" implicitly covers public_repo and
+			// repo:status, and GitHub reports only the broader scope. Without
+			// the alternatives table this would false-alarm.
+			name:       "repo subsumes public_repo and repo:status",
+			setHeader:  true,
+			scopes:     "repo, read:org",
+			level:      5,
+			wantStatus: ScopeStatusOK,
+		},
+		{
+			// L1 exercises no GitHub capability, so nothing is required.
+			name:       "L1 requires no scopes",
+			setHeader:  true,
+			scopes:     "public_repo",
+			level:      1,
+			wantStatus: ScopeStatusOK,
+		},
+		{
+			// An unset level must resolve to the MOST capable level, not the
+			// least — defaulting low would silently suppress real findings.
+			name:        "unset level is evaluated at the highest level",
+			setHeader:   true,
+			scopes:      "public_repo",
+			level:       ACMMLevelUnset,
+			wantStatus:  ScopeStatusMissing,
+			wantMissing: []string{scopeRepo, scopeReadOrg},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := scopeTestServer(t, tt.setHeader, tt.scopes)
+			got := c.CheckTokenScopes(context.Background(), tt.level)
+
+			if got.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q (detail=%q reason=%q)", got.Status, tt.wantStatus, got.Detail, got.Reason)
+			}
+			for _, want := range tt.wantMissing {
+				if !contains(got.Missing, want) {
+					t.Errorf("missing scopes %v does not include %q", got.Missing, want)
+				}
+			}
+			for _, sub := range tt.wantDetailContains {
+				if !strings.Contains(got.Detail, sub) {
+					t.Errorf("detail %q does not contain %q", got.Detail, sub)
+				}
+			}
+			// An OK result must never carry a warning payload — that is what
+			// "zero noise when correct" means concretely.
+			if got.Status == ScopeStatusOK && (got.Detail != "" || len(got.Missing) > 0) {
+				t.Errorf("OK result carried detail=%q missing=%v, want both empty", got.Detail, got.Missing)
+			}
+			// Undetermined must NEVER assert a missing scope.
+			if got.Status == ScopeStatusUndetermined && len(got.Missing) > 0 {
+				t.Errorf("undetermined result claimed missing scopes %v — absence of evidence is not evidence of absence", got.Missing)
+			}
+			if got.Status == ScopeStatusUndetermined && got.Reason == "" {
+				t.Error("undetermined result gave no reason, leaving the operator with nothing to act on")
+			}
+		})
+	}
+}
+
+// TestCheckTokenScopesSkipsAppAuth asserts the App path is skipped entirely.
+// An App has permissions, not scopes; warning about a PAT that is not in use
+// would be noise pointing at the wrong thing.
+func TestCheckTokenScopesSkipsAppAuth(t *testing.T) {
+	c := scopeTestServer(t, true, "") // header says "no scopes" — would be Undetermined on the PAT path
+	c.appAuth = &AppAuth{}
+
+	got := c.CheckTokenScopes(context.Background(), 6)
+	if got.Status != ScopeStatusSkipped {
+		t.Fatalf("status = %q, want %q", got.Status, ScopeStatusSkipped)
+	}
+	if len(got.Missing) > 0 || got.Detail != "" {
+		t.Errorf("App path produced a PAT warning: missing=%v detail=%q", got.Missing, got.Detail)
+	}
+
+	// POSITIVE CONTROL: the identical server WITHOUT appAuth must not skip,
+	// proving the skip came from App detection and not from the server shape.
+	c2 := scopeTestServer(t, true, "")
+	if got2 := c2.CheckTokenScopes(context.Background(), 6); got2.Status == ScopeStatusSkipped {
+		t.Error("token path also skipped — the test cannot distinguish App auth from any other skip")
+	}
+}
+
+// TestCheckTokenScopesNetworkFailureIsSoft asserts a dead endpoint yields a
+// skip-shaped result and, critically, that execution PROCEEDS — the check must
+// never become a new startup failure mode.
+func TestCheckTokenScopesNetworkFailureIsSoft(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	url := srv.URL
+	srv.Close() // closed: connections are refused
+
+	c := NewClientForTest(url, "kubestellar", []string{"hive"}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	proceeded := false
+	got := c.CheckTokenScopes(context.Background(), 6)
+	proceeded = true // reaching here at all is the assertion: no panic, no exit
+
+	if !proceeded {
+		t.Fatal("startup did not proceed past the scope check")
+	}
+	if got.Status != ScopeStatusUndetermined {
+		t.Fatalf("status = %q, want %q", got.Status, ScopeStatusUndetermined)
+	}
+	if len(got.Missing) > 0 {
+		t.Errorf("unreachable GitHub produced missing scopes %v — a network fault must never be reported as a token defect", got.Missing)
+	}
+}
+
+// TestCheckTokenScopesNilReceiver covers the dashboard-only boot: a hive with
+// no usable credentials runs with a nil *Client for the life of the process.
+func TestCheckTokenScopesNilReceiver(t *testing.T) {
+	var c *Client
+	if got := c.CheckTokenScopes(context.Background(), 6); got.Status != ScopeStatusSkipped {
+		t.Fatalf("status = %q, want %q", got.Status, ScopeStatusSkipped)
+	}
+}
+
+// TestLogTokenScopeCheckNeverLogsTokenMaterial is the security assertion: the
+// diagnostic may name scopes and capabilities, never credentials.
+func TestLogTokenScopeCheckNeverLogsTokenMaterial(t *testing.T) {
+	const secret = "ghp_supersecrettokenvalue000000000000"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(oauthScopesHeader, "public_repo")
+		_, _ = w.Write([]byte(`{"resources":{}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// NewClientForTest hardcodes a placeholder token, so build the real client
+	// with the secret and then retarget its BaseURL at the test server — the
+	// point of this test is that a REAL token value never reaches the log.
+	c := NewClient(secret, "kubestellar", []string{"hive"}, logger, "")
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse test url: %v", err)
+	}
+	c.client.BaseURL = base
+
+	res := c.LogTokenScopeCheck(context.Background(), logger, 6)
+
+	// POSITIVE CONTROL: the logger must actually have been exercised, otherwise
+	// "no token in the log" would pass trivially on an empty buffer.
+	if res.Status != ScopeStatusMissing {
+		t.Fatalf("expected a warning to be emitted, got status %q", res.Status)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "repo") {
+		t.Fatalf("log did not contain the expected scope warning, so the no-secret assertion is vacuous: %q", out)
+	}
+
+	if strings.Contains(out, secret) {
+		t.Error("log contained the full token")
+	}
+	// Prefixes and suffixes are token material too — a 12-char slice of a PAT
+	// is still a credential fragment.
+	const fragment = 12
+	if strings.Contains(out, secret[:fragment]) {
+		t.Error("log contained a token prefix")
+	}
+	if strings.Contains(out, secret[len(secret)-fragment:]) {
+		t.Error("log contained a token suffix")
+	}
+}
+
+// TestLogTokenScopeCheckSilentWhenCorrect pins requirement 5: a correctly
+// scoped token produces no output at all, so any line from this check is
+// actionable by construction.
+func TestLogTokenScopeCheckSilentWhenCorrect(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	c := scopeTestServer(t, true, "repo, read:org")
+	if res := c.LogTokenScopeCheck(context.Background(), logger, 6); res.Status != ScopeStatusOK {
+		t.Fatalf("status = %q, want %q (reason=%q)", res.Status, ScopeStatusOK, res.Reason)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("correctly-scoped token produced log output: %q", buf.String())
+	}
+
+	// POSITIVE CONTROL: the same logger DOES emit for a narrow token, proving
+	// the silence above is the check's judgement and not a dead logger.
+	buf.Reset()
+	c2 := scopeTestServer(t, true, "public_repo")
+	if res := c2.LogTokenScopeCheck(context.Background(), logger, 6); res.Status != ScopeStatusMissing {
+		t.Fatalf("control: status = %q, want %q", res.Status, ScopeStatusMissing)
+	}
+	if buf.Len() == 0 {
+		t.Error("control: narrow token produced no log output, so the silence assertion proves nothing")
+	}
+}
+
+func TestParseScopeHeader(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{",", nil},
+		{", ", nil},
+		{"repo", []string{"repo"}},
+		{"repo, read:org", []string{"read:org", "repo"}},
+		{"  repo ,, read:org  ", []string{"read:org", "repo"}},
+	}
+	for _, tt := range tests {
+		got := parseScopeHeader(tt.in)
+		if len(got) != len(tt.want) {
+			t.Errorf("parseScopeHeader(%q) = %v, want %v", tt.in, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("parseScopeHeader(%q) = %v, want %v", tt.in, got, tt.want)
+				break
+			}
+		}
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

`HIVE_GITHUB_TOKEN` is the PAT auth path, and there was **no scope validation anywhere in the tree** — no `X-OAuth-Scopes` handling, no `CheckTokenScopes`, no `validateToken`.

A token with insufficient scopes therefore fails at *runtime*, as a generic 403, often much later and far from the cause: the scanner reports no actionable work because a search 403'd, or an agent's PR creation dies with "403 Resource not accessible". Nothing in that chain names the missing scope, so an operator has to reverse-engineer a denied capability from a symptom that looks like an empty backlog.

Related context: #4390 (operator impact). This PR is the **code** change and complements the docs PR on `docs/token-env-var-scopes`, which documents the required scopes and closes that issue.

## Approach

GitHub returns a classic PAT's granted scopes in the `X-OAuth-Scopes` header on any authenticated REST call. One cheap authenticated request at boot yields the token's actual scopes, which we compare against what this hive needs **at its configured ACMM level**.

New `pkg/github/tokenscopes.go`: `Client.CheckTokenScopes` / `Client.LogTokenScopeCheck`, wired at the PAT branch of `initGitHubAuth` and surfaced as a `github_auth` health detail.

The message names the scope **and** the capability it costs:

```
github token is missing the "repo" scope — agents will fail to create or merge pull requests
```

A generic "insufficient permissions" is exactly the failure being fixed.

## Design constraints (all load-bearing)

- **PAT path only.** The App branch returns before the probe — an App carries *permissions*, not scopes, so `X-OAuth-Scopes` does not apply and warning about an unused PAT would be noise.
- **Fails soft in every direction.** Absent or empty `X-OAuth-Scopes` reports **"could not determine", never "missing"**. Fine-grained PATs carry repository permissions and report no scopes at all, so a fail-closed reading would raise a false alarm on every fine-grained-token deployment — and a fail-closed *gate* would brick them. Absence of evidence is not evidence of absence.
- **Never blocks startup.** Network error or timeout is a skip with a debug log. The check is a diagnostic and must never become a new failure mode.
- **Bounded and cheap.** 5s timeout. Probes `/rate_limit` deliberately: it is authenticated (so the scope headers come back), requires no scopes of its own (so it cannot 403 for the very reason under investigation), and consumes no quota. Exactly **one** request, at boot — no per-heartbeat or periodic probe, since the fleet shares a rate-limit budget.
- **Silent when correct**, so any line from this check is actionable by construction.
- **Never logs token material** — scope names and capability consequences only.

## Scope→capability mapping: derived vs. stated conservatively

The requirement table is derived from the actual call sites in `pkg/github/` and **names them inline**, because it is the part most likely to drift. Two findings from that derivation changed the design:

1. **`FetchWorkflowHealth`'s Actions calls are ungated by ACMM** and run at *every* level. The CI-read requirement therefore starts at **L2, not L5** — gating it at L5 (the level where the auto-merge consequence bites) would have left exactly the affected L2 hive unwarned about a silently blank workflow-health dashboard.
2. **`read:org` is justified only by the PAT-path** org search (`fleet_stats.go`, `pr_issue_counts.go`) and `ListContributors` — *not* by `app_discovery.go`'s org lookups, which run on a JWT App client and are irrelevant to a token-path check.

Stated **conservatively** rather than derived:
- **`repo` vs `public_repo`** — the code does not know whether the target repos are private, and GitHub grants no narrower write scope than `repo`. `public_repo` is accepted as an alternative wherever a public repo would suffice.
- **Scope hierarchy** (`repo` implicitly covers `public_repo` / `repo:status`) is encoded from GitHub's documented behavior; GitHub reports only the broader scope, so without this a perfectly good `repo` token would be warned at for "missing `repo:status`".
- **`workflow` is not required** — it governs mutating workflow *files*, which this hive only does via PR contents. Listed as an alternative, not a requirement.
- **Unset `acmm_level` resolves to the most capable level**, not `inferACMMLevel`'s L1 default: L1 requires no scopes, so reusing that default would silently suppress every warning on precisely the hives whose intent we cannot read.

## Surfacing

Used the existing surface rather than inventing one:
- **Startup log** via `LogTokenScopeCheck` (warn on missing, debug on undetermined, silent otherwise).
- **`github_auth` health check** — both the `/health` deep surface and the summary surface, at the existing `"token-based"` / `"token"` PAT branch.

`github_auth` stays **`pass`** with a specific detail rather than flipping to `fail`: a narrow token still authenticates, so what is broken is a *capability*, not the auth. Failing would misreport the fault and send an operator to re-issue working credentials.

## Tests

`pkg/github/tokenscopes_test.go`, table-driven, each with a positive control so it cannot pass for the wrong reason:

- sufficient scopes → no warning **/ control:** insufficient → warning naming the specific missing scope and capability
- **empty `X-OAuth-Scopes` (fine-grained PAT) → "could not determine", NOT "missing"** — the most important case; a regression here would spam every fine-grained-token deployment with a false alarm
- absent header → undetermined
- App auth → skipped entirely **/ control:** the identical server *without* `appAuth` does not skip, proving the skip came from App detection and not the server shape
- network error → skip, and the test asserts execution **proceeds**
- ACMM tiering: `public_repo` is fine at L2 and the **same token** warns at L5
- `repo` subsumes `public_repo` / `repo:status` (no false alarm on the hierarchy)
- no token material in log output **/ control:** asserts the log was actually written, so the no-secret check is not vacuous
- silent when correctly scoped **/ control:** the same logger *does* emit for a narrow token

Also asserts invariants directly: an `OK` result carries no warning payload, and an `Undetermined` result never claims a missing scope.

## Verification

`gofmt` clean on touched files; `go vet` clean on `pkg/github`, `pkg/dashboard`, `cmd/hive`. New tests pass (15 subtests), and the pre-existing `github_auth` dashboard tests still pass — the change only appends detail when a scope is genuinely missing. Linux CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)