### PR TITLE
cleanup: drop the gateway-upstream volume, which was never read (#4416)

### DIFF
--- a/src/deploy/test_standalone_runtime_parity.sh
+++ b/src/deploy/test_standalone_runtime_parity.sh
@@ -191,15 +191,6 @@ EXCEPTIONS = {
         "systemctl reports success — and would restart under Compose. Tracked "
         "in #4415; not fixed here, #4404 is the check and not the fixes.",
     ),
-    "mount-target:gateway:/etc/nginx/upstream": (
-        "defect-tracked",
-        "Compose mounts the named volume gateway-upstream at /etc/nginx/upstream "
-        "and the units have no equivalent. NOTHING in the repository reads that "
-        "path — src/deploy/nginx.conf declares `upstream hive_api` inline and "
-        "states it has no include — so the Quadlet side is likely correct and "
-        "the Compose volume vestigial. #4404 says explicitly not to delete it "
-        "here; tracked for separate disposal in #4416.",
-    ),
 }
 
 # Exceptions that fired. Anything left over at the end is stale.

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -18,14 +18,6 @@ services:
       - "3001:3001"
     volumes:
       - ./deploy/nginx.conf:/etc/nginx/nginx.conf:ro
-      # APPEARS TO BE DEAD (#4416). Nothing in this repository reads
-      # /etc/nginx/upstream: deploy/nginx.conf declares `upstream hive_api`
-      # inline and states it carries no include, and the Podman gateway
-      # (deploy/quadlet/hive-gateway.container) has no equivalent mount. Left in
-      # place deliberately — #4404 was the parity CHECK and explicitly not the
-      # fixes; deploy/test_standalone_runtime_parity.sh carries this as a
-      # defect-tracked exception until #4416 disposes of it.
-      - gateway-upstream:/etc/nginx/upstream
     depends_on:
       hive:
         condition: service_healthy
@@ -199,4 +191,3 @@ networks:
 
 volumes:
   hive-data:
-  gateway-upstream:


### PR DESCRIPTION
Closes #4416.

## The verdict: it was born dead

#4416 asked for the git history before deleting anything, since "if it is *not* dead ... the Quadlet gateway is missing a mount and the Podman deployment is the broken one." The history settles it, and more definitively than "nothing reads it today".

The volume arrived in **f1bfec5b, "feat: blue-green deploy with nginx gateway" (#482)** — whose commit message describes swapping the nginx upstream for a zero-downtime reload, so a file under `/etc/nginx/upstream` is a *plausible* design. It is not the design that shipped. At that very commit:

- `deploy/nginx.conf` declared `upstream hive_api { server hive:3001; }` **inline**, with no `include` of anything;
- `deploy/blue-green-deploy.sh` swapped the upstream by rewriting the **whole** `nginx.conf` with `sed`, `docker cp`-ing it to `hive-gateway:/etc/nginx/nginx.conf`, and reloading.

Neither file ever named `/etc/nginx/upstream` — not in that revision, not in any since. The volume was declared alongside an approach that was never taken and has been inert for its entire life. This isn't a vestige of something that used to work; it never did.

Today's tree confirms it from the other end. The only four references anywhere were the compose mount, the compose top-level declaration, the explanatory comment #4417 left on the mount, and the parity exception — all four removed here. `nginx.conf` still declares its upstream inline and still states in its own body that it has no `include /etc/nginx/conf.d/*.conf`; the current blue-green script no longer rewrites the config at all, relying on Docker DNS re-resolving `hive` after a rename plus `nginx -s reload`.

## Verified positively, not just by absence

Absence of evidence is what #4416 explicitly did not want to rely on, so the pinned gateway image was run with **only** the `nginx.conf` mount and no `/etc/nginx/upstream`:

```
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful

--- is /etc/nginx/upstream present at all? ---
ls: /etc/nginx/upstream: No such file or directory
```

The directory **does not exist in the base image**. The mount was creating an empty directory nothing in the image expects. That rules out the case the issue flagged as worth ruling out explicitly — had the path been load-bearing, the fix would have been the other direction (add a `Volume=` to `hive-gateway.container`). It isn't, so Podman was right and Compose carried the vestige.

## The #4404 reverse sweep, again

With the mount gone and the exception left in place, the parity suite reported:

```
FAIL: every exception still corresponds to a live divergence
      stale: ['mount-target:gateway:/etc/nginx/upstream'] — the divergence is gone, so delete the entry
```

Removing it moves the mounts axis from *excepted* to *passing* — the gateway now has exactly one mount on both runtimes, compared directly with no carve-out.

## Operator impact: none, and no migration step

`docker compose up -d` simply recreates the gateway without the mount. An existing host keeps an orphaned `<project>_gateway-upstream` volume that compose no longer manages; it holds nothing and can be removed at leisure:

```sh
docker volume rm <project>_gateway-upstream
```

## ⚠️ Expect a trivial conflict with #4428

My open **#4428** (`Restart=always` for the gateway, closing #4415) deletes the *other* entry from the same `# --- defect-tracked ---` section of the exception table. The two blocks are adjacent, so **whichever merges second will conflict** — I verified this with a trial merge rather than leaving you to discover it.

The resolution is to take **both** deletions: after both land, the `# --- defect-tracked ---` section has no entries under it, which is correct — both tracked defects are then fixed. The header comment can stay as documentation of the kind, or go; nothing reads it. Neither PR depends on the other, and either order works.

## Verification

Parity 32/0/8, service-contract 12/0, watchtower-socket 21/0, image-refs 19/19, supply-chain pins 17/0, quadlet port-boundary 18/0, config-coupling 7/7. `docker compose config` still renders the stack including the auto-update profile.

— hive: backend=claude model=claude-opus-5
