### PR TITLE
✨ Cover five verified failure/edge paths in the podman update suite

### DIFF
--- a/bin/test_hive_podman_update.sh
+++ b/bin/test_hive_podman_update.sh
@@ -275,6 +275,11 @@ check "a reference that is already a digest contacts no registry" \
 reset_env; export FAKE_SKOPEO_RC=1 FAKE_TAG_REF="${REPO}:nope" HIVE_UPDATE_SKOPEO=skopeo
 export FAKE_PULL_FAIL_SUBSTR="nope"
 case_expect "an unresolvable tag is a finding, not a silent tag pin" 78 "could not resolve" resolve "${REPO}:nope"
+# image_repo carries a deliberate comment about why `${ref%:*}` would eat
+# everything after `localhost` in a ported registry ref; this is the case that
+# keeps that comment honest.
+reset_env; export FAKE_TAG_REF="localhost:5000/hive:v1"
+case_expect "resolve keeps a registry port in the repo part" 0 "localhost:5000/hive@${DIGEST_NEW}" resolve "localhost:5000/hive:v1"
 
 echo
 echo "== pin =="
@@ -352,6 +357,24 @@ before="$(cat "$(dropin)")"
 case_expect "a rollback target that no longer pulls refuses" 78 "nothing has been changed" rollback
 check "and leaves the drop-in byte-identical" '[ "$before" = "$(cat "$(dropin)")" ]'
 check "and restarts nothing" '! grep -q "systemctl restart" "$SYSTEMCTL_CALL_LOG"'
+# The worst state the tool can leave a host in: the rollback target ALSO never
+# becomes healthy, and Hive stays DOWN. The report must say so, and the history
+# must not pretend the restored pin worked.
+reset_env; export FAKE_RESTART_RC=1
+seed_dropin "${REPO}@${DIGEST_BAD}" \
+  "failed  2026-08-21T10:00:00Z ${DIGEST_BAD} ${REPO}:stable" \
+  "healthy 2026-08-20T10:00:00Z ${DIGEST_OLD} ${REPO}:b35e9cc"
+case_expect "a rollback target that also fails to become healthy exits 78" 78 "did not become healthy either" rollback
+check "a double failure marks the restored pin failed, not healthy" \
+  'grep -q "^# HIVE-PIN failed .* ${DIGEST_OLD} " "$(dropin)"'
+# An interrupted pin leaves a `pending` entry on top of the history. rollback
+# must skip it the same way it skips `failed`: pending was never seen healthy.
+reset_env
+seed_dropin "${REPO}@${DIGEST_BAD}" \
+  "failed  2026-08-21T10:00:00Z ${DIGEST_BAD} ${REPO}:stable" \
+  "pending 2026-08-21T09:00:00Z ${DIGEST_NEW} ${REPO}:stable" \
+  "healthy 2026-08-20T10:00:00Z ${DIGEST_OLD} ${REPO}:b35e9cc"
+case_expect "rollback skips a pending entry from an interrupted pin" 0 "rolled back to ${DIGEST_OLD}" rollback
 
 echo
 echo "== history =="
@@ -377,12 +400,27 @@ case_expect "unpin warns that the floating tag cannot be rolled back to" 0 "cann
 check "unpin removes the drop-in" '[ ! -f "$(dropin)" ]'
 reset_env
 case_expect "unpin with nothing pinned is not an error" 0 "no drop-in to remove" unpin
+# unpin removes the pin BEFORE restarting, so a restart that fails leaves the
+# unit on the floating tag and down. That must be an exit-78 finding, not a 0.
+reset_env; export FAKE_RESTART_RC=1
+seed_dropin "${REPO}@${DIGEST_OLD}" "healthy 2026-08-20T00:00:00Z ${DIGEST_OLD} ${REPO}:stable"
+case_expect "unpin whose restart fails exits 78" 78 "" unpin
 
 echo
 echo "== rootful drives the system manager through sudo =="
 reset_env
 run_update status --rootful >/dev/null
 check "rootful reads the system manager through sudo" 'grep -q "sudo systemctl" "$SUDO_CALL_LOG"'
+# The write path, not just the read one: write_dropin and mark_top_outcome must
+# go through `sudo install` and still land the same pinned Image=. The drop-in
+# directory is pre-created because seed-less writes into a missing directory
+# are the BSD-install nuance the pin cases already own; this case is about
+# sudo, not about -D.
+reset_env
+mkdir -p "$(dirname "$(dropin)")"
+run_update pin "${REPO}:stable" --rootful >/dev/null
+check "rootful pin writes the drop-in through sudo install" \
+  'grep -q "sudo install" "$SUDO_CALL_LOG" && grep -q "^Image=${REPO}@${DIGEST_NEW}\$" "$(dropin)"'
 
 echo
 echo "== autoupdate (#4411) =="


### PR DESCRIPTION
Closes #4410.

Adds the five cases from #4410 to `bin/test_hive_podman_update.sh` (71 → 78 assertions), following the suite's existing conventions and mocks:

1. **Rollback double-failure** — the rollback target also never becomes healthy: exit 78 with "did not become healthy either", and the restored pin is marked `failed`, not `healthy`.
2. **Rollback skips `pending`** — an interrupted pin's `pending` history entry is skipped the same way `failed` is.
3. **Registry port in `image_repo`** — `resolve localhost:5000/hive:v1` keeps the port in the repo part, keeping the deliberate `${ref%:*}` comment honest.
4. **Rootful write path** — `pin --rootful` drives `write_dropin`/`mark_top_outcome` through `sudo install` and still lands the pinned `Image=`. The drop-in dir is pre-created so the case is about sudo, not the BSD `install -D` nuance the existing pin cases own (CI GNU install stays authoritative there).
5. **`unpin` restart failure** — exits 78 when the restart after removing the pin fails.

All five verified green locally (only the 4 pre-existing BSD-install local failures remain, unchanged). `bin/test_hive_podman_cleanup.sh` contract passes (127 assertions). Suite remains wired in v2-ci.yml.

Refs #4407, #4420.