### PR TITLE
fix(preflight): teach the host check the Quadlet layout (#4422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ cd hive
 # that times out five minutes later.
 bin/hive-podman-preflight.sh
 bin/hive-podman-preflight-ids.sh
-# (hive-podman-preflight-host.sh checks SELinux labels and port 3001 too, but
-#  reads the source-tree layout rather than this one — see #4422.)
 
 CONF=~/.config/hive                       # rootful: CONF=/etc/hive
 mkdir -p "$CONF/secrets" && chmod 750 "$CONF/secrets"
@@ -106,6 +104,10 @@ printf 'HIVE_DASHBOARD_TOKEN=%s\n' "$(openssl rand -hex 32)" >> "$CONF/hive.env"
 # L5/L6 if agent PRs may touch `.github/workflows/`. See
 # src/docs/github-app-setup.md#personal-access-token-pat-scopes
 printf 'HIVE_GITHUB_TOKEN=%s\n'    'ghp_...'                 >> "$CONF/hive.env"
+
+# Now the host preflight, which checks what the steps above just created:
+# SELinux labels on the bind sources, secrets reachability, hive.env, port 3001.
+HIVE_SRC_DIR="$CONF" bin/hive-podman-preflight-host.sh
 
 # Pull before starting. The generated ExecStart pulls a missing image itself and
 # that pull is spent inside TimeoutStartSec; the Hive image is ~3.8GB.

--- a/bin/hive-podman-preflight-host.sh
+++ b/bin/hive-podman-preflight-host.sh
@@ -181,18 +181,95 @@ hive_podman_check_selinux() {
 
 # --- 2. Mount labeling -------------------------------------------------------
 #
-# The three bind-mount sources in src/docker-compose.yaml. Each is consumed by
-# exactly one container, so the private (:Z) form is always available; the
-# read-only configuration files are called out as shared (:z) candidates
-# because :Z stamps a per-container MCS category onto a file that is part of
-# the operator's checkout and is likely read by other tooling.
+# TWO LAYOUTS, AND THE DIFFERENCE IS NOT COSMETIC (#4422).
+#
+# This check knew only the source-tree layout — the one the Compose stack mounts
+# out of a checkout, where the gateway config sits at `deploy/nginx.conf`. The
+# Quadlet install (src/docs/podman-standalone-quadlet.md) puts the operator's
+# files in `%E/hive` with `nginx.conf` FLAT, so pointing this script at that
+# directory reported
+#
+#   ✗ Gateway config: <dir>/deploy/nginx.conf does not exist
+#
+# and exited 78 with the file sitting right there, one level up. That landed on
+# the one install path where this check is most useful: SELinux labelling of
+# those binds is exactly the class of problem that otherwise surfaces as a
+# 300-second start timeout with the container already `--rm`'d away. A non-zero
+# exit also invites an operator to stop reading a report whose other rows —
+# mount labels, the secrets group-traverse check, port 3001 — they still need.
+#
+# The recommended relabel option differs by layout too, and getting THAT
+# backwards would be worse than the path bug:
+#
+#   source-tree   the config files are part of the operator's CHECKOUT and are
+#                 likely read by other tooling, so `:z` (shared) is right and
+#                 `:Z` would stamp a per-container MCS category onto a tracked
+#                 file.
+#   quadlet       the config files are operator-owned files in %E/hive read by
+#                 exactly ONE container, and the shipped units mount all three
+#                 `:ro,Z`. Recommending `:z` there would contradict the units.
 #
 # Format: relative-path|description|recommended-option
-HIVE_PODMAN_BIND_SOURCES=(
+HIVE_PODMAN_BIND_SOURCES_SOURCE=(
   "hive.yaml|Hive configuration|z"
   "deploy/nginx.conf|gateway configuration|z"
   "secrets|secrets directory|Z"
 )
+HIVE_PODMAN_BIND_SOURCES_QUADLET=(
+  "hive.yaml|Hive configuration|Z"
+  "nginx.conf|gateway configuration|Z"
+  "secrets|secrets directory|Z"
+)
+
+# Which layout HIVE_SRC_DIR holds: auto | source | quadlet. `auto` decides from
+# what is on disk; the explicit values are for a directory mid-install that has
+# neither gateway config in place yet.
+HIVE_PODMAN_LAYOUT="${HIVE_PODMAN_LAYOUT:-auto}"
+
+# Resolved once by _pfh_resolve_layout, read by every check below.
+HIVE_PFH_LAYOUT=""
+HIVE_PFH_NGINX_REL=""
+HIVE_PODMAN_BIND_SOURCES=()
+
+# Decides the layout and populates the three globals above. Detection keys on
+# the gateway config, the only file whose PATH differs between the two layouts;
+# `hive.env` is the tiebreak for a Quadlet directory that has not had nginx.conf
+# copied in yet, since nothing in the source tree carries that name.
+_pfh_resolve_layout() {
+  local dir="$HIVE_SRC_DIR" chosen="$HIVE_PODMAN_LAYOUT"
+
+  if [[ "$chosen" == "auto" ]]; then
+    if [[ -e "${dir}/deploy/nginx.conf" ]]; then
+      chosen="source"
+    elif [[ -e "${dir}/nginx.conf" ]]; then
+      chosen="quadlet"
+    elif [[ -e "${dir}/hive.env" ]]; then
+      chosen="quadlet"
+    else
+      # Neither shape is on disk. Stay on the historical default rather than
+      # guess; the config check reports the missing files by name either way.
+      chosen="source"
+    fi
+  fi
+
+  case "$chosen" in
+    source)
+      HIVE_PFH_LAYOUT="source"
+      HIVE_PFH_NGINX_REL="deploy/nginx.conf"
+      HIVE_PODMAN_BIND_SOURCES=("${HIVE_PODMAN_BIND_SOURCES_SOURCE[@]}")
+      ;;
+    quadlet)
+      HIVE_PFH_LAYOUT="quadlet"
+      HIVE_PFH_NGINX_REL="nginx.conf"
+      HIVE_PODMAN_BIND_SOURCES=("${HIVE_PODMAN_BIND_SOURCES_QUADLET[@]}")
+      ;;
+    *)
+      printf 'ERROR: HIVE_PODMAN_LAYOUT must be auto, source, or quadlet (got %q)\n' \
+        "$HIVE_PODMAN_LAYOUT" >&2
+      exit 64
+      ;;
+  esac
+}
 
 # --- Reading an SELinux label ------------------------------------------------
 #
@@ -367,8 +444,9 @@ hive_podman_check_mount_labels() {
   done
 
   if [[ "$checked" -eq 0 ]]; then
-    _pfh_warn "Mount labeling: no bind-mount source found under ${HIVE_SRC_DIR}"
-    _pfh_hint "Set HIVE_SRC_DIR to the directory holding hive.yaml, deploy/, and secrets/."
+    _pfh_warn "Mount labeling: no bind-mount source found under ${HIVE_SRC_DIR} (layout: ${HIVE_PFH_LAYOUT})"
+    _pfh_hint "Set HIVE_SRC_DIR to the directory holding the bind sources: hive.yaml, ${HIVE_PFH_NGINX_REL}, and secrets/."
+    _pfh_hint "A source tree (Compose) has deploy/nginx.conf; a Quadlet install has nginx.conf flat in %E/hive. Force either with HIVE_PODMAN_LAYOUT=source|quadlet."
     return 0
   fi
 
@@ -522,7 +600,40 @@ hive_podman_check_config_secrets() {
   local rc=0
 
   _pfh_check_readable "${HIVE_SRC_DIR}/hive.yaml" "Hive config" "" "required" || rc=1
-  _pfh_check_readable "${HIVE_SRC_DIR}/deploy/nginx.conf" "Gateway config" "" "required" || rc=1
+  _pfh_check_readable "${HIVE_SRC_DIR}/${HIVE_PFH_NGINX_REL}" "Gateway config" "" "required" || rc=1
+
+  # hive.env is Quadlet-only, and deliberately NOT a row in the bind-source
+  # table above: `EnvironmentFile=` is read by systemd ON THE HOST and never
+  # bind-mounted, so it has no container label to judge — podman-volume-
+  # persistence.md records it staying at its ordinary host label. It still earns
+  # a check here, because both ways it goes wrong cost the whole start budget:
+  #
+  #   missing            `EnvironmentFile=` becomes `podman run --env-file`, and
+  #                      `podman run` FAILS outright on a missing file.
+  #   no dashboard token Hive refuses to start unless the hive is hub-hosted —
+  #                      every mutation endpoint would be unauthenticated — and
+  #                      Notify=healthy turns that refusal into a unit stuck in
+  #                      `activating` until TimeoutStartSec expires.
+  if [[ "$HIVE_PFH_LAYOUT" == "quadlet" ]]; then
+    local env_file="${HIVE_SRC_DIR}/hive.env"
+    if [[ ! -e "$env_file" ]]; then
+      _pfh_fail "Environment file: ${env_file} does not exist"
+      _pfh_hint "EnvironmentFile= becomes 'podman run --env-file', which fails on a missing file. Start from the tracked template:"
+      _pfh_hint "  cp src/deploy/quadlet/hive.env.example '${env_file}' && chmod 600 '${env_file}'"
+      rc=1
+    else
+      _pfh_check_readable "$env_file" "Environment file" "600" "required" || rc=1
+      # Presence of a non-empty assignment only. The value is never read out.
+      if grep -qE '^[[:space:]]*HIVE_DASHBOARD_TOKEN[[:space:]]*=[[:space:]]*[^[:space:]]' "$env_file" 2>/dev/null; then
+        _pfh_pass "Dashboard token: HIVE_DASHBOARD_TOKEN is set in hive.env"
+      else
+        _pfh_warn "Dashboard token: HIVE_DASHBOARD_TOKEN is not set in ${env_file}"
+        _pfh_hint "Hive REFUSES TO START without it unless the hive is hub-hosted, and Notify=healthy turns that into a unit stuck in 'activating' for the whole TimeoutStartSec."
+        _pfh_hint "  printf 'HIVE_DASHBOARD_TOKEN=%s\\n' \"\$(openssl rand -hex 32)\" >> '${env_file}'"
+        _pfh_hint "A hub-hosted hive (HIVE_SESSION_KEY / HIVE_HUB_SECRET set) does not need it — that is why this is a warning, not a failure."
+      fi
+    fi
+  fi
 
   if [[ ! -d "$secrets_dir" ]]; then
     # Token-only deployments never create it; a GitHub App deployment must.
@@ -682,6 +793,17 @@ hive_podman_preflight_host_main() {
 
   echo "Podman preflight (SELinux, mounts, secrets, ports)"
 
+  # Resolve the layout BEFORE any check runs — every path below depends on it.
+  # Announced rather than inferred silently: auto-detection that does not say
+  # what it picked is indistinguishable from a check looking in the wrong place,
+  # which is the bug this replaced (#4422).
+  _pfh_resolve_layout
+  if [[ "$HIVE_PODMAN_LAYOUT" == "auto" ]]; then
+    echo "  layout: ${HIVE_PFH_LAYOUT} (detected) — config under ${HIVE_SRC_DIR}, gateway config at ${HIVE_PFH_NGINX_REL}"
+  else
+    echo "  layout: ${HIVE_PFH_LAYOUT} (HIVE_PODMAN_LAYOUT) — config under ${HIVE_SRC_DIR}, gateway config at ${HIVE_PFH_NGINX_REL}"
+  fi
+
   # Each check reports independently: an operator fixing a host wants the whole
   # list, not the first item on it.
   hive_podman_check_selinux
@@ -717,7 +839,13 @@ Runs only when HIVE_DEPLOY_RUNTIME selects podman; with the Docker default it
 reports that it was skipped and exits 0.
 
 Environment:
-  HIVE_SRC_DIR                    directory holding hive.yaml, deploy/, secrets/
+  HIVE_SRC_DIR                    directory holding the deployment's bind sources
+  HIVE_PODMAN_LAYOUT              auto (default) | source | quadlet — which shape
+                                  HIVE_SRC_DIR has. A source tree (Compose) keeps
+                                  the gateway config at deploy/nginx.conf; a
+                                  Quadlet install keeps it flat as nginx.conf in
+                                  %E/hive, alongside hive.env. auto decides from
+                                  what is on disk and prints which it picked.
   HIVE_PODMAN_PREFLIGHT_PORTS     published host ports to check (default 3001)
 
 Exit codes: 0 clean, 64 unusable runtime selection, 78 at least one failure.

--- a/bin/hive-podman-preflight-host.sh
+++ b/bin/hive-podman-preflight-host.sh
@@ -618,7 +618,7 @@ hive_podman_check_config_secrets() {
     local env_file="${HIVE_SRC_DIR}/hive.env"
     if [[ ! -e "$env_file" ]]; then
       _pfh_fail "Environment file: ${env_file} does not exist"
-      _pfh_hint "EnvironmentFile= becomes 'podman run --env-file', which fails on a missing file. Start from the tracked template:"
+      _pfh_hint "EnvironmentFile= becomes '--env-file' on the container command line, which fails on a missing file. Start from the tracked template:"
       _pfh_hint "  cp src/deploy/quadlet/hive.env.example '${env_file}' && chmod 600 '${env_file}'"
       rc=1
     else

--- a/bin/test_hive_podman_preflight_host.sh
+++ b/bin/test_hive_podman_preflight_host.sh
@@ -717,7 +717,7 @@ mv "${QUADLET_FIXTURE}/hive.env" "${TEST_TMP}/hive.env.stash"
 run_preflight_dir "$QUADLET_FIXTURE"
 assert_contains "$RUN_OUT" "Environment file: ${QUADLET_FIXTURE}/hive.env does not exist" \
   "quadlet: a missing hive.env is a failure"
-assert_contains "$RUN_OUT" "podman run --env-file" "and says why podman run would fail"
+assert_contains "$RUN_OUT" "'--env-file' on the container command line" "and says why the container start would fail"
 assert_eq "$RUN_STATUS" 78 "quadlet: a missing hive.env exits 78"
 mv "${TEST_TMP}/hive.env.stash" "${QUADLET_FIXTURE}/hive.env"
 

--- a/bin/test_hive_podman_preflight_host.sh
+++ b/bin/test_hive_podman_preflight_host.sh
@@ -593,4 +593,147 @@ for forbidden in "${FORBIDDEN[@]}"; do
   assert_not_contains "$sweep_out" "$forbidden" "no case ever recommends '${forbidden}'"
 done
 
+# --- Layout detection (#4422) -------------------------------------------------
+#
+# The bug: this check knew only the source-tree layout, so a Quadlet install —
+# where nginx.conf sits FLAT in %E/hive rather than under deploy/ — reported
+# `✗ Gateway config: <dir>/deploy/nginx.conf does not exist` and exited 78 with
+# the file present one level up. These cases pin both layouts, the forced
+# override, and the fact that the two recommend DIFFERENT relabel options.
+
+QUADLET_FIXTURE="${TEST_TMP}/quadlet"
+mkdir -p "${QUADLET_FIXTURE}/secrets"
+echo "levels: []" >"${QUADLET_FIXTURE}/hive.yaml"
+echo "events {}" >"${QUADLET_FIXTURE}/nginx.conf"
+echo "-----BEGIN PRIVATE KEY-----" >"${QUADLET_FIXTURE}/secrets/gh-app-key.pem"
+printf '#HIVE_DASHBOARD_TOKEN=\n' >"${QUADLET_FIXTURE}/hive.env"
+chmod 750 "${QUADLET_FIXTURE}/secrets"
+chmod 600 "${QUADLET_FIXTURE}/secrets/gh-app-key.pem" "${QUADLET_FIXTURE}/hive.env"
+
+label_quadlet_container_readable() {
+  cat >"$STAT_MAP" <<EOF
+${QUADLET_FIXTURE}/hive.yaml||||system_u:object_r:container_file_t:s0
+${QUADLET_FIXTURE}/nginx.conf||||system_u:object_r:container_file_t:s0
+${QUADLET_FIXTURE}/secrets||||system_u:object_r:container_file_t:s0|${MAPPED_LAUNCH_GID}
+${QUADLET_FIXTURE}/secrets/gh-app-key.pem||||system_u:object_r:container_file_t:s0
+EOF
+}
+
+# Same runner, pointed at a chosen HIVE_SRC_DIR. The fixture-immutability
+# assertion in run_preflight only covers SRC_FIXTURE, so this snapshots the
+# quadlet fixture itself to keep "read-only" proven on this path too.
+run_preflight_dir() { # $1 = HIVE_SRC_DIR, rest = extra env
+  local dir="$1"; shift
+  local before after
+  before="$(find "$dir" -mindepth 0 -print0 | sort -z | xargs -0 "$REAL_STAT" -c '%n %a %u %g %s')"
+  : >"$CALL_LOG"
+  set +e
+  RUN_OUT="$(env PATH="$TEST_PATH" PODMAN_CALL_LOG="$CALL_LOG" FAKE_STAT_MAP="$STAT_MAP" \
+    HIVE_SRC_DIR="$dir" HIVE_PFH_SUBGID_FILE="$SUBGID_FIXTURE" \
+    HIVE_PFH_LABEL_PROBES="$LABEL_PROBE" FAKE_LABEL_PROBE="$LABEL_PROBE" \
+    HIVE_DEPLOY_RUNTIME=podman "$@" "$BASH_BIN" "$PREFLIGHT" 2>&1)"
+  RUN_STATUS=$?
+  set -e
+  after="$(find "$dir" -mindepth 0 -print0 | sort -z | xargs -0 "$REAL_STAT" -c '%n %a %u %g %s')"
+  [[ "$before" == "$after" ]] || fail "preflight modified ${dir}"
+  pass_count=$((pass_count + 1))
+}
+
+# THE BUG, as a test: a Quadlet layout must not report a missing gateway config.
+label_quadlet_container_readable
+run_preflight_dir "$QUADLET_FIXTURE"
+assert_contains "$RUN_OUT" "layout: quadlet (detected)" "quadlet layout is auto-detected"
+assert_contains "$RUN_OUT" "Gateway config: ${QUADLET_FIXTURE}/nginx.conf readable" \
+  "quadlet: the flat nginx.conf is found"
+assert_not_contains "$RUN_OUT" "deploy/nginx.conf does not exist" \
+  "quadlet: no false failure about deploy/nginx.conf"
+assert_eq "$RUN_STATUS" 0 "quadlet: a correctly prepared install exits 0, not 78"
+
+# The source tree keeps working exactly as before.
+label_all_container_readable
+run_preflight_dir "$SRC_FIXTURE"
+assert_contains "$RUN_OUT" "layout: source (detected)" "source layout is auto-detected"
+assert_contains "$RUN_OUT" "Gateway config: ${SRC_FIXTURE}/deploy/nginx.conf readable" \
+  "source: deploy/nginx.conf is still where it looks"
+assert_eq "$RUN_STATUS" 0 "source: unchanged, still exits 0"
+
+# Detection keys on the gateway config; hive.env is the tiebreak for a Quadlet
+# directory that has not had nginx.conf copied in yet.
+TIEBREAK_FIXTURE="${TEST_TMP}/tiebreak"
+mkdir -p "$TIEBREAK_FIXTURE"
+printf '#HIVE_DASHBOARD_TOKEN=\n' >"${TIEBREAK_FIXTURE}/hive.env"
+chmod 600 "${TIEBREAK_FIXTURE}/hive.env"
+run_preflight_dir "$TIEBREAK_FIXTURE"
+assert_contains "$RUN_OUT" "layout: quadlet (detected)" \
+  "hive.env alone is enough to identify a Quadlet directory"
+
+# An empty directory stays on the historical default rather than guessing.
+EMPTY_FIXTURE="${TEST_TMP}/empty-layout"
+mkdir -p "$EMPTY_FIXTURE"
+run_preflight_dir "$EMPTY_FIXTURE"
+assert_contains "$RUN_OUT" "layout: source (detected)" \
+  "a directory with neither shape falls back to the historical default"
+
+# The explicit override, for a directory mid-install.
+run_preflight_dir "$EMPTY_FIXTURE" HIVE_PODMAN_LAYOUT=quadlet
+assert_contains "$RUN_OUT" "layout: quadlet (HIVE_PODMAN_LAYOUT)" \
+  "HIVE_PODMAN_LAYOUT=quadlet forces the layout and says so"
+run_preflight_dir "$QUADLET_FIXTURE" HIVE_PODMAN_LAYOUT=source
+assert_contains "$RUN_OUT" "layout: source (HIVE_PODMAN_LAYOUT)" \
+  "HIVE_PODMAN_LAYOUT=source forces the layout even where quadlet would be detected"
+run_preflight_dir "$QUADLET_FIXTURE" HIVE_PODMAN_LAYOUT=sideways
+assert_eq "$RUN_STATUS" 64 "an unknown HIVE_PODMAN_LAYOUT is EX_USAGE"
+assert_contains "$RUN_OUT" "must be auto, source, or quadlet" "and says what the valid values are"
+
+# THE RELABEL RECOMMENDATION FLIPS WITH THE LAYOUT, and getting it backwards
+# would contradict the shipped units, which mount all three :ro,Z.
+cat >"$STAT_MAP" <<EOF
+${QUADLET_FIXTURE}/hive.yaml||||unconfined_u:object_r:config_home_t:s0
+${QUADLET_FIXTURE}/nginx.conf||||unconfined_u:object_r:config_home_t:s0
+${QUADLET_FIXTURE}/secrets||||system_u:object_r:container_file_t:s0|${MAPPED_LAUNCH_GID}
+${QUADLET_FIXTURE}/secrets/gh-app-key.pem||||system_u:object_r:container_file_t:s0
+EOF
+run_preflight_dir "$QUADLET_FIXTURE"
+assert_contains "$RUN_OUT" "Mount it with :Z" "quadlet: config files are recommended :Z, matching the units"
+assert_not_contains "$RUN_OUT" "Mount it with :z so Podman relabels it shared" \
+  "quadlet: never recommends the shared form for an operator-owned config file"
+cat >"$STAT_MAP" <<EOF
+${SRC_FIXTURE}/hive.yaml||||unconfined_u:object_r:user_home_t:s0
+${SRC_FIXTURE}/deploy/nginx.conf||||unconfined_u:object_r:user_home_t:s0
+${SRC_FIXTURE}/secrets||||system_u:object_r:container_file_t:s0|${MAPPED_LAUNCH_GID}
+${SRC_FIXTURE}/secrets/gh-app-key.pem||||system_u:object_r:container_file_t:s0
+EOF
+run_preflight_dir "$SRC_FIXTURE"
+assert_contains "$RUN_OUT" "Mount it with :z so Podman relabels it shared" \
+  "source: a checked-out config file is still recommended :z, not :Z"
+
+# --- hive.env, Quadlet only ---------------------------------------------------
+#
+# Not a bind source — EnvironmentFile= is read by systemd on the host and never
+# mounted, so it has no container label. It is checked because both ways it goes
+# wrong cost the whole start budget.
+label_quadlet_container_readable
+mv "${QUADLET_FIXTURE}/hive.env" "${TEST_TMP}/hive.env.stash"
+run_preflight_dir "$QUADLET_FIXTURE"
+assert_contains "$RUN_OUT" "Environment file: ${QUADLET_FIXTURE}/hive.env does not exist" \
+  "quadlet: a missing hive.env is a failure"
+assert_contains "$RUN_OUT" "podman run --env-file" "and says why podman run would fail"
+assert_eq "$RUN_STATUS" 78 "quadlet: a missing hive.env exits 78"
+mv "${TEST_TMP}/hive.env.stash" "${QUADLET_FIXTURE}/hive.env"
+
+run_preflight_dir "$QUADLET_FIXTURE"
+assert_contains "$RUN_OUT" "HIVE_DASHBOARD_TOKEN is not set" "quadlet: an unset dashboard token is reported"
+assert_eq "$RUN_STATUS" 0 "an unset dashboard token is a WARNING — a hub-hosted hive does not need one"
+
+printf 'HIVE_DASHBOARD_TOKEN=%s\n' "deadbeefcafe" >>"${QUADLET_FIXTURE}/hive.env"
+run_preflight_dir "$QUADLET_FIXTURE"
+assert_contains "$RUN_OUT" "HIVE_DASHBOARD_TOKEN is set in hive.env" "quadlet: a set dashboard token passes"
+assert_not_contains "$RUN_OUT" "deadbeefcafe" "the token VALUE is never printed"
+
+# The source layout has no hive.env and must not grow a check for one.
+label_all_container_readable
+run_preflight_dir "$SRC_FIXTURE"
+assert_not_contains "$RUN_OUT" "Environment file" "source: no hive.env row — it is a Quadlet-only file"
+assert_not_contains "$RUN_OUT" "HIVE_DASHBOARD_TOKEN" "source: no dashboard-token row either"
+
 printf 'PASS: %d Podman host preflight assertions\n' "$pass_count"

--- a/src/docs/podman-standalone-quadlet.md
+++ b/src/docs/podman-standalone-quadlet.md
@@ -138,15 +138,21 @@ remove `HealthCmd=`.
   bin/hive-podman-preflight-ids.sh      # subordinate IDs, graphroot, networking
   ```
 
-  `bin/hive-podman-preflight-host.sh` checks SELinux labels, config and secrets
-  readability, and port 3001 — but it looks for the **source-tree** layout
-  (`$HIVE_SRC_DIR/hive.yaml`, `$HIVE_SRC_DIR/deploy/nginx.conf`,
-  `$HIVE_SRC_DIR/secrets`, default `src/`). The Quadlet install below puts
-  `nginx.conf` flat in `%E/hive`, not under a `deploy/` subdirectory, so
-  pointing it at `%E/hive` reports a spurious
-  `✗ Gateway config: …/deploy/nginx.conf does not exist` and exits 78. Run it
-  against the source tree, or read its SELinux and port findings and ignore that
-  one row.
+  `bin/hive-podman-preflight-host.sh` is the third, and it is worth running
+  **after** step 1 below rather than here, because it checks the files that step
+  creates: SELinux labels on the bind sources, config and secrets readability,
+  `hive.env`, and port 3001. Point it at the configuration directory:
+
+  ```sh
+  HIVE_SRC_DIR="$CONF" bin/hive-podman-preflight-host.sh
+  ```
+
+  It recognises this layout — `nginx.conf` flat in `%E/hive` rather than under a
+  `deploy/` subdirectory — and says which one it picked on its first line
+  (`layout: quadlet (detected)`). It also recommends `:Z` for these files, which
+  is what the units mount them with, rather than the `:z` that suits a checked-out
+  source tree. Force either shape with `HIVE_PODMAN_LAYOUT=source|quadlet` if you
+  run it against a directory that is still mid-install (#4422).
 
 ## Unit search paths
 


### PR DESCRIPTION
Closes #4422.

## The bug, reproduced

`hive-podman-preflight-host.sh` knew only the source-tree layout — the one the Compose stack mounts out of a checkout, where the gateway config sits at `deploy/nginx.conf`. The Quadlet install puts the operator's files in `%E/hive` with `nginx.conf` **flat**. Pointed at a staged Quadlet config directory:

```
  ✓ Hive config: /tmp/…/hive.yaml readable (mode 644, owner dbaggett)
  ✗ Gateway config: /tmp/…/deploy/nginx.conf does not exist
SUMMARY: pass=4 warn=3 fail=1        rc=78
```

…with `nginx.conf` sitting right there, one level up.

That lands on the one install path where this check is *most* useful: SELinux labelling of those binds is exactly the class of problem that otherwise surfaces as a 300-second start timeout with the container already `--rm`'d away. And the non-zero exit invites an operator to stop reading a report whose other rows — mount labels, the secrets group-traverse check, port 3001 — they still need. Leaving `HIVE_SRC_DIR` at its default was no escape: it then checks `src/hive.yaml`, which for a Quadlet install correctly does not exist.

After:

```
  layout: quadlet (detected) — config under /tmp/…, gateway config at nginx.conf
  ✓ Gateway config: /tmp/…/nginx.conf readable (mode 644, owner dbaggett)
  ✓ Environment file: /tmp/…/hive.env readable (mode 600, owner dbaggett)
  △ Dashboard token: HIVE_DASHBOARD_TOKEN is not set in /tmp/…/hive.env
SUMMARY: pass=6 warn=5 fail=0        rc=0
```

## Both options from the issue, because neither alone is right

#4422 offered "probe `deploy/nginx.conf` and fall back to `nginx.conf`, **or** take an explicit layout flag". This does both:

- **Auto-detection** is what an operator mid-install actually needs — they shouldn't have to know a flag exists to get a truthful report. Detection keys on the gateway config, the only file whose *path* differs; `hive.env` is the tiebreak, since nothing in the source tree carries that name. A directory with neither shape stays on the historical default rather than guessing.
- **`HIVE_PODMAN_LAYOUT=source|quadlet`** overrides, for a directory that has neither gateway config in place yet.

Auto-detection that doesn't say what it picked is indistinguishable from a check looking in the wrong place — which is the bug being fixed — so every run now opens with `layout: quadlet (detected)` or `layout: source (HIVE_PODMAN_LAYOUT)`.

## The relabel recommendation flips with the layout

This is the part that would have been worse to get wrong than the path bug, and it isn't mentioned in the issue:

| Layout | Recommends | Why |
|---|---|---|
| source-tree | `:z` | the config files are part of the operator's **checkout** and likely read by other tooling; `:Z` would stamp a per-container MCS category onto a tracked file |
| quadlet | `:Z` | the files are operator-owned, read by exactly **one** container, and the shipped units mount all three `:ro,Z` — recommending `:z` would contradict the units |

Both directions are pinned by test, including that the quadlet path *never* emits the shared-form hint.

## The `hive.env` row the issue asked me to consider

Added, Quadlet-only, and deliberately **not** a bind source: `EnvironmentFile=` is read by systemd on the host and never mounted, so it has no container label to judge (`podman-volume-persistence.md` records it staying at its ordinary host label). It earns a check because both ways it goes wrong cost the whole start budget:

- **missing** → `EnvironmentFile=` becomes `podman run --env-file`, which fails outright. Reported as a failure.
- **no `HIVE_DASHBOARD_TOKEN`** → Hive refuses to start, and `Notify=healthy` turns that into a unit stuck in `activating` until `TimeoutStartSec` expires. Reported as a **warning**, not a failure, because a hub-hosted hive doesn't need one.

The token's *value* is never printed, and a test asserts that.

## Verification

**195 assertions pass** (was 168). The new cases were run against the **unfixed** script and fail on exactly the reported symptom — `✗ Gateway config: .../quadlet/deploy/nginx.conf does not exist`, rc=1 — so they test the bug, not the implementation.

The source-tree path is untouched: same paths, same `:z` recommendation, same output, asserted by test, and the case that a source layout grows *no* `hive.env` or dashboard-token row is asserted too.

Suites: preflight-host 195, preflight 44, preflight-ids 61, bin-suite-wiring 16/0 orphaned, quadlet config-coupling 7/7, port-boundary 18/0, runtime-parity 33/0/8. `shellcheck` clean on both files.

## Docs

Two notes I wrote while filing this are now false and are corrected here:

- `podman-standalone-quadlet.md` described the spurious failure and told operators to run it against the source tree or ignore the row. Replaced with the working invocation, **moved to after step 1**, since it checks the files step 1 creates.
- The README quick start drops its "reads the source-tree layout rather than this one — see #4422" caveat and now runs the host preflight against `$CONF`, where it belongs in the sequence.

— hive: backend=claude model=claude-opus-5
