### PR TITLE
🐛 Multi-repo hives: rotate agent coverage across ALL project repos

### DIFF
--- a/src/pkg/policies/defaults/sec-check-holdgated.md
+++ b/src/pkg/policies/defaults/sec-check-holdgated.md
@@ -13,10 +13,19 @@ You are the **sec-check** agent in a Hive instance operating in **ISSUES_AND_PRS
 7. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `sec-check`
 8. **Never expose secrets** — do not print tokens, keys, or credentials in any output
 
+## Multi-Repo Coverage
+
+`$HIVE_REPOS` lists EVERY authorized repo (comma-separated); `$HIVE_REPO` is only the PRIMARY repo, and your workdir is a clone of the primary only. All repos are in scope. Each session:
+
+1. List the repos: `echo "$HIVE_REPOS"`
+2. Pick the repo you have LEAST RECENTLY scanned (check your beads and existing `[sec-check]` issues in each repo)
+3. If it is not your workdir repo, clone it: `git clone <host>/<org>/<repo> /tmp/<repo> && cd /tmp/<repo>`
+4. Use that repo explicitly in every `gh` command below — never default to `$HIVE_REPO` out of habit
+
 ## Opening Issues
 
 ```bash
-gh issue create --repo "$HIVE_REPO" \
+gh issue create --repo "<org>/<target-repo>" \
   --title "[sec-check] <specific description of the vulnerability>" \
   --body "## Security Finding
 
@@ -46,7 +55,7 @@ gh issue create --repo "$HIVE_REPO" \
 4. Push and open a PR with `hold` label — **NEVER merge**:
 
 ```bash
-gh pr create --repo "$HIVE_REPO" \
+gh pr create --repo "<org>/<target-repo>" \
   --title "[sec-check] fix: <short description>" \
   --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "security,hold"
@@ -68,9 +77,10 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 
 1. Read the kick message
 2. **Reap stale findings** — re-verify open beads and close resolved ones
-3. Scan: `gh api /repos/$HIVE_REPO/dependabot/alerts`, `trivy`, `semgrep`, or `grype` as available
-4. Review: secrets in code, RBAC permissions, unsafe API patterns, dependency versions
-5. Create a GitHub issue for each confirmed vulnerability
-6. For findings with a clear safe fix, create a worktree and open a hold-gated PR
-7. Create a bead for each finding
-8. Summarize security posture in your response
+3. Pick this session's target repo per **Multi-Repo Coverage** above (rotate — do not rescan the same repo every session)
+4. Scan: `gh api /repos/<org>/<target-repo>/dependabot/alerts`, `trivy`, `semgrep`, or `grype` as available
+5. Review: secrets in code, RBAC permissions, unsafe API patterns, dependency versions
+6. Create a GitHub issue for each confirmed vulnerability — in the target repo (`--repo "<org>/<target-repo>"`)
+7. For findings with a clear safe fix, create a worktree and open a hold-gated PR
+8. Create a bead for each finding
+9. Summarize security posture in your response, naming which repo you covered

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -529,6 +529,26 @@ func (s *Scheduler) buildReposSection() string {
 	}
 	b.WriteString("⛔ NEVER access, search, list, file issues in, or open PRs on repos not listed above.\n")
 	b.WriteString(fmt.Sprintf("⛔ Every repo above is on %s. This hive is single-host — never touch a repo on a different GitHub host.\n", host))
+	// Multi-repo projects: the agent workdir is a clone of the PRIMARY repo
+	// only, and the shipped templates' examples say --repo "$HIVE_REPO"
+	// (primary). Without an explicit rotation instruction agents lock onto
+	// the primary repo forever and the other project repos are never
+	// touched (root-caused on a live 3-repo hive: sec-check scanned only
+	// the primary across every session). The kick is the one place every
+	// agent/template combination sees, so the instruction lives here.
+	if len(s.cfg.Project.Repos) > 1 {
+		primary := s.cfg.Project.PrimaryRepo
+		if primary == "" {
+			primary = s.cfg.Project.Repos[0]
+		}
+		b.WriteString(fmt.Sprintf(`🔁 MULTI-REPO COVERAGE — REQUIRED: this project has %d authorized repos; ALL of them are in scope, not just the primary (%s).
+Your workdir is a clone of the primary repo only. Each session, pick the authorized repo you have LEAST RECENTLY covered (check your beads and the [<your-role>] issues you previously filed in each repo) and work THAT repo this session:
+  - If it is not your workdir repo, clone it first: git clone %s/<org>/<repo> /tmp/<repo> && cd /tmp/<repo>
+  - Pass the chosen repo EXPLICITLY to every gh command: --repo "<org>/<repo>" (do not rely on $HIVE_REPO, which always names the primary repo).
+  - $HIVE_REPOS lists every authorized repo, comma-separated.
+⛔ Do NOT default to the primary repo every session — repos you never visit accumulate unseen problems.
+`, len(s.cfg.Project.Repos), org+"/"+primary, strings.TrimRight(host, "/")))
+	}
 	return b.String()
 }
 

--- a/src/policies/sec-check-holdgated.md
+++ b/src/policies/sec-check-holdgated.md
@@ -15,10 +15,19 @@ You are the **sec-check** agent in a Hive instance operating in **ISSUES_AND_PRS
 7. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `sec-check`
 8. **Never expose secrets** — do not print tokens, keys, or credentials in any output
 
+## Multi-Repo Coverage
+
+`$HIVE_REPOS` lists EVERY authorized repo (comma-separated); `$HIVE_REPO` is only the PRIMARY repo, and your workdir is a clone of the primary only. All repos are in scope. Each session:
+
+1. List the repos: `echo "$HIVE_REPOS"`
+2. Pick the repo you have LEAST RECENTLY scanned (check your beads and existing `[sec-check]` issues in each repo)
+3. If it is not your workdir repo, clone it: `git clone <host>/<org>/<repo> /tmp/<repo> && cd /tmp/<repo>`
+4. Use that repo explicitly in every `gh` command below — never default to `$HIVE_REPO` out of habit
+
 ## Opening Issues
 
 ```bash
-gh issue create --repo "$HIVE_REPO" \
+gh issue create --repo "<org>/<target-repo>" \
   --title "[sec-check] <specific description of the vulnerability>" \
   --body "## Security Finding
 
@@ -48,7 +57,7 @@ gh issue create --repo "$HIVE_REPO" \
 4. Push and open a PR with `hold` label — **NEVER merge**:
 
 ```bash
-gh pr create --repo "$HIVE_REPO" \
+gh pr create --repo "<org>/<target-repo>" \
   --title "[sec-check] fix: <short description>" \
   --body "## Security Fix\n\n<what this changes and why>\n\nFixes #<issue-number> (only if this fully resolves it; use Refs #<issue-number> instead if it's an epic/multi-phase tracker)\n\n---\n*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required.*" \
   --label "security,hold"
@@ -70,11 +79,12 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 
 1. Read the kick message
 2. **Reap stale findings** — re-verify open beads and close resolved ones
-3. Scan: `gh api /repos/$HIVE_REPO/dependabot/alerts`, `trivy`, `semgrep`, or `grype` as available
-4. Review: secrets in code, RBAC permissions, unsafe API patterns, dependency versions
-5. Create a GitHub issue for each confirmed vulnerability
-6. For findings with a clear safe fix, create a worktree and open a hold-gated PR
-7. Create a bead for each finding
-8. Summarize security posture in your response
+3. Pick this session's target repo per **Multi-Repo Coverage** above (rotate — do not rescan the same repo every session)
+4. Scan: `gh api /repos/<org>/<target-repo>/dependabot/alerts`, `trivy`, `semgrep`, or `grype` as available
+5. Review: secrets in code, RBAC permissions, unsafe API patterns, dependency versions
+6. Create a GitHub issue for each confirmed vulnerability — in the target repo (`--repo "<org>/<target-repo>"`)
+7. For findings with a clear safe fix, create a worktree and open a hold-gated PR
+8. Create a bead for each finding
+9. Summarize security posture in your response, naming which repo you covered
 
 ${KNOWLEDGE}


### PR DESCRIPTION
## Problem (root-caused on a live 3-repo hosted hive)
A hive configured with 3 repos (`ui`, `ui-framework`, `api-server`, primary `ui`) had its sec-check agent scan **only the primary repo, every session, forever**. The other repos never got a single `[sec-check]` issue.

Why:
- The kick's AUTHORIZED REPOS section lists all repos — but as a **permission fence** ("you may ONLY interact with these"), not a work list
- Every operative command in the shipped templates says `--repo "$HIVE_REPO"`, which always names the **primary** repo
- The agent workdir is a clone of the primary repo only
- Live transcript: *"Working in <org>/ui repo (correct authorized repo)"* → scanned `ui` again

**Systemic**: none of the 30 shipped templates reference `$HIVE_REPOS`. Every multi-repo hive has this bug for every agent. Increasing kick frequency just rescans the primary more often.

## Fix
1. **`buildReposSection`** — multi-repo kicks now carry an explicit `🔁 MULTI-REPO COVERAGE — REQUIRED` instruction: each session pick the LEAST RECENTLY covered authorized repo (via own beads/issues), clone it if absent, and pass it explicitly to every `gh` command. The kick is the one surface every agent/template combination sees, so the generic fix lives there.
2. **`sec-check-holdgated.md`** (both `policies/` and embedded `pkg/policies/defaults/` copies) — new *Multi-Repo Coverage* section; issue/PR/scan examples target `<org>/<target-repo>` instead of `$HIVE_REPO`; workflow requires naming which repo was covered.

## Post-merge
Hives with `/data/policies/sec-check-holdgated.md` copies need a template re-sync (planned, same as the last fleet sync); affected hive will be hot-patched.

Scheduler + policies tests green. (`pkg/config` shell-export/cache test failures are pre-existing on clean v4, unrelated.)