### PR TITLE
fix(agent): pin caveman by tag (v1.9.1), not raw SHA — SHA breaks the skills CLI clone

### DIFF
--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2098,7 +2098,12 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 
 	// Pinned: unpinned HEAD broke every install on 2026-07-27 when upstream
 	// removed the --mode flag. Bump deliberately, after checking `--help`.
-	const cavemanRef = "github:JuliusBrussee/caveman#0d95a81d35a9"
+	// v1.9.1 IS commit 0d95a81d35a9 — the SHA form is deliberately not used
+	// because the `skills` CLI clones with `git clone --branch <ref>`, and
+	// git cannot clone a bare SHA as a branch ("Could not find remote branch
+	// 0d95a81d35a9"), which broke every install on a live hive. Tags clone
+	// cleanly; bump the tag, never a raw SHA.
+	const cavemanRef = "github:JuliusBrussee/caveman#v1.9.1"
 	// Upstream replaced `--mode full|minimal` with `--all` / `--minimal`
 	// (--all = hooks + init).
 	modeFlag := "--all"
@@ -2115,11 +2120,11 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 	case "gemini":
 		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "gemini", modeFlag)
 	case "goose":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#0d95a81d35a9", "-a", "goose")
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "goose")
 	case "codex":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#0d95a81d35a9", "-a", "codex")
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "codex")
 	case "aider":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#0d95a81d35a9", "-a", "aider-desk")
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "aider-desk")
 	default:
 		m.logger.Info("caveman not supported for backend", "backend", backend)
 		return


### PR DESCRIPTION
## Problem

Every agent kick on a live hive logs a failed caveman install:

```
◇  Source: https://github.com/JuliusBrussee/caveman.git @ 0d95a81d35a9
■  Failed to clone repository
│  Failed to clone https://github.com/JuliusBrussee/caveman.git: ...
│  warning: Could not find remote branch 0d95a81d35a9 to clone.
│  fatal: Remote branch 0d95a81d35a9 not found in upstream origin
```

The `skills` CLI clones with `git clone --depth 1 --branch <ref>` (`src/dist/cli.mjs`, `cloneRepo`), and git cannot clone a bare commit SHA as a branch — only branch/tag names work. The hive pins `github:JuliusBrussee/caveman#0d95a81d35a9` (a SHA), so the install fails for every backend that goes through `skills add` (goose/codex/aider) and the skill never lands.

## Fix

Pin by **tag** instead: `#v1.9.1`. `v1.9.1` resolves to exactly commit `0d95a81d35a9` (checked via the repo's tag listing), so this is a pure mechanical change — identical skill content, now cloneable. Tags clone cleanly via `--branch`.

Applies to all four install paths (npx direct for claude/copilot/gemini, `skills add` for goose/codex/aider).

## Verified

- `npx skills add JuliusBrussee/caveman#v1.9.1` completes (`Done!`) and records `ref=v1.9.1` in `skills-lock.json`; the `#0d95a81d35a9` form fails with the clone error above.
- `go build ./pkg/agent/` passes.

## Notes

Keep bumping the **tag** deliberately (per the existing comment about the 2026-07-27 `--mode` breakage); a raw SHA pin will silently break again if anyone re-introduces one.