### PR TITLE
feat(hub): fleet-divergence view — expected vs actual vs able per agent

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -150,7 +150,7 @@ const reachStatePath = "/data/reach-state.json"
 // tell a deliberately-paused agent from one that is running but unable to
 // work. Shared by both heartbeat build sites so the ordinary beat and the
 // upgrade beat can never report different pictures of the same agent.
-func agentActivityFor(mgr *agent.Manager, name string, proc *agent.AgentProcess) hub.AgentActivity {
+func agentActivityFor(mgr *agent.Manager, cfg *config.Config, currentMode, name string, proc *agent.AgentProcess, onDemandFromPack map[string]bool) hub.AgentActivity {
 	act := hub.AgentActivity{
 		Paused: proc.Paused,
 		// Pause provenance (#4041): ride WHO/WHY/WHEN to the hub so the
@@ -168,6 +168,34 @@ func agentActivityFor(mgr *agent.Manager, name string, proc *agent.AgentProcess)
 	if proc.StartedAt != nil {
 		act.StartedAt = *proc.StartedAt
 	}
+
+	// EXPECTED leg: does the governor's current mode schedule this agent on a
+	// kicking cadence right now? Shared with the dashboard's offByCadence via
+	// config.ExpectedActive so the two never disagree.
+	if cfg != nil {
+		onDemandAgent := false
+		enabled := false
+		if ac, ok := cfg.Agents[name]; ok {
+			onDemandAgent = ac.OnDemand
+			enabled = ac.Enabled
+		}
+		act.ExpectedActive = cfg.ExpectedActive(name, currentMode, onDemandAgent, onDemandFromPack)
+		act.Enabled = enabled
+	}
+
+	// ABLE leg: the exact ACMM capability gates the spoke enforces. ok=false
+	// (unknown agent) leaves all three false, read hub-side as UNKNOWN.
+	if canIssue, canPR, canMerge, ok := mgr.AgentCapabilities(name); ok {
+		act.CanOpenIssue = canIssue
+		act.CanOpenPR = canPR
+		act.CanMerge = canMerge
+	}
+
+	// Backend lets the hub interpret NeedsLogin (interactive vs inference).
+	if backend, ok := mgr.EffectiveBackend(name); ok {
+		act.Backend = backend
+	}
+
 	return act
 }
 
@@ -3275,6 +3303,7 @@ func main() {
 			}
 			statuses := agentMgr.AllStatuses()
 			govState := gov.GetState()
+			currentMode := strings.ToLower(string(govState.Mode))
 			agents := make([]hub.AgentSummary, 0, len(statuses))
 			for name, proc := range statuses {
 				mode := ""
@@ -3282,7 +3311,7 @@ func main() {
 					mode = "on_demand"
 				}
 				agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
-					agentActivityFor(agentMgr, name, proc)))
+					agentActivityFor(agentMgr, cfg, currentMode, name, proc, onDemandFromPack)))
 			}
 			acmmLvl := 0
 			if cfg.ACMMLevel != nil {
@@ -3750,6 +3779,7 @@ func main() {
 					return nil
 				}
 				statuses := agentMgr.AllStatuses()
+				currentMode := strings.ToLower(string(gov.GetState().Mode))
 				agents := make([]hub.AgentSummary, 0, len(statuses))
 				for name, proc := range statuses {
 					mode := ""
@@ -3757,7 +3787,7 @@ func main() {
 						mode = "on_demand"
 					}
 					agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
-						agentActivityFor(agentMgr, name, proc)))
+						agentActivityFor(agentMgr, cfg, currentMode, name, proc, onDemandFromPack)))
 				}
 				acmmLvl := 0
 				if cfg.ACMMLevel != nil {

--- a/src/pkg/agent/agent_capabilities_test.go
+++ b/src/pkg/agent/agent_capabilities_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// AgentCapabilities must return exactly the mode's CanCreateIssues/CanPush/
+// CanMerge gates — the same gates AuthorizePROpen/AuthorizeMerge enforce — so a
+// hub capability badge can never claim a capability the relay would refuse.
+func TestAgentCapabilities_TracksModeGates(t *testing.T) {
+	m := testManager(6)
+	m.agents["advisor"] = &AgentProcess{Name: "advisor", Config: config.AgentConfig{Mode: "ISSUES_ONLY"}}
+	m.agents["writer"] = &AgentProcess{Name: "writer", Config: config.AgentConfig{Mode: "ISSUES_AND_PRS"}}
+	m.agents["merger"] = &AgentProcess{Name: "merger", Config: config.AgentConfig{Mode: "ISSUES_PRS_MERGE"}}
+
+	cases := []struct {
+		name                         string
+		wantIssue, wantPR, wantMerge bool
+	}{
+		{"advisor", true, false, false},
+		{"writer", true, true, false},
+		{"merger", true, true, true},
+	}
+	for _, tc := range cases {
+		issue, pr, merge, ok := m.AgentCapabilities(tc.name)
+		if !ok {
+			t.Fatalf("%s: ok=false, want true", tc.name)
+		}
+		if issue != tc.wantIssue || pr != tc.wantPR || merge != tc.wantMerge {
+			t.Errorf("%s: got (issue=%v pr=%v merge=%v), want (%v %v %v)",
+				tc.name, issue, pr, merge, tc.wantIssue, tc.wantPR, tc.wantMerge)
+		}
+
+		// The PR/merge results must agree with the actual authorization gates.
+		prAllowed := m.AuthorizePROpen(tc.name, 0) == nil
+		mergeAllowed := m.AuthorizeMerge(tc.name, 0) == nil
+		if pr != prAllowed {
+			t.Errorf("%s: CanOpenPR=%v but AuthorizePROpen allowed=%v", tc.name, pr, prAllowed)
+		}
+		if merge != mergeAllowed {
+			t.Errorf("%s: CanMerge=%v but AuthorizeMerge allowed=%v", tc.name, merge, mergeAllowed)
+		}
+	}
+}
+
+func TestAgentCapabilities_UnknownAgent(t *testing.T) {
+	m := testManager(6)
+	if _, _, _, ok := m.AgentCapabilities("ghost"); ok {
+		t.Error("unknown agent must return ok=false")
+	}
+}
+
+func TestEffectiveBackend_HonorsOverride(t *testing.T) {
+	m := testManager(5)
+	m.agents["a"] = &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude"}}
+	m.agents["b"] = &AgentProcess{Name: "b", Config: config.AgentConfig{Backend: "claude"}, BackendOverride: "copilot"}
+
+	if b, ok := m.EffectiveBackend("a"); !ok || b != "claude" {
+		t.Errorf("a: got (%q,%v), want (claude,true)", b, ok)
+	}
+	if b, ok := m.EffectiveBackend("b"); !ok || b != "copilot" {
+		t.Errorf("b: override must win; got (%q,%v), want (copilot,true)", b, ok)
+	}
+	if _, ok := m.EffectiveBackend("ghost"); ok {
+		t.Error("unknown agent must return ok=false")
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -6544,6 +6544,38 @@ func (m *Manager) AuthorizeMerge(agentName string, fileUID int) error {
 	return nil
 }
 
+// AgentCapabilities reports whether the named agent is ABLE — at the hive's
+// current ACMM level and the agent's effective mode — to create issues, open
+// PRs, and merge PRs. These are the EXACT gates AuthorizePROpen (CanPush) and
+// AuthorizeMerge (CanMerge) enforce, so a hub capability badge derived from
+// these can never claim a capability the merge/PR relay would actually refuse.
+// ok=false when the agent is unknown to the manager (the caller then reports
+// "unknown", not a false negative). Read-only under RLock.
+func (m *Manager) AgentCapabilities(agentName string) (canOpenIssue, canOpenPR, canMerge, ok bool) {
+	m.mu.RLock()
+	agent, exists := m.agents[agentName]
+	m.mu.RUnlock()
+	if !exists || agent == nil {
+		return false, false, false, false
+	}
+	mode := m.agentMode(agent)
+	return mode.CanCreateIssues(), mode.CanPush(), mode.CanMerge(), true
+}
+
+// EffectiveBackend reports the named agent's effective backend, honoring any
+// runtime BackendOverride (see effectiveBackend). ok=false when the agent is
+// unknown. Read-only under RLock — a small exported wrapper so callers outside
+// the package (the heartbeat builder) need not reach into unexported state.
+func (m *Manager) EffectiveBackend(agentName string) (backend string, ok bool) {
+	m.mu.RLock()
+	agent, exists := m.agents[agentName]
+	m.mu.RUnlock()
+	if !exists || agent == nil {
+		return "", false
+	}
+	return effectiveBackend(agent), true
+}
+
 // InvocationMetadata reports the effective backend, model, and reasoning effort
 // the hive invokes for the named agent, accounting for runtime overrides — the
 // launch-time truth the invocation-attribution trail records (see pkg/github/attribution

--- a/src/pkg/config/expected_active.go
+++ b/src/pkg/config/expected_active.go
@@ -1,0 +1,49 @@
+package config
+
+import "strings"
+
+// CadenceValueForMode resolves an agent's Cadence for a governor mode, applying
+// the same base-agent fallback the dashboard uses: an exact per-agent cadence
+// wins, otherwise the cadence keyed on the agent's base name (rotation members
+// share a base). Returns "" when the mode or agent has no cadence entry.
+//
+// This is the single source of truth shared by the spoke dashboard's
+// offByCadence detection and the heartbeat's ExpectedActive computation, so the
+// two can never disagree about whether the governor will kick an agent.
+func (c *Config) CadenceValueForMode(agentName, modeName string) Cadence {
+	if mode, ok := c.Governor.Modes[modeName]; ok {
+		if cad, ok := mode.Cadences[agentName]; ok {
+			return cad
+		}
+		if base := c.BaseAgentName(agentName); base != agentName {
+			if cad, ok := mode.Cadences[base]; ok {
+				return cad
+			}
+		}
+	}
+	return ""
+}
+
+// ExpectedActive reports whether the governor's CURRENT mode schedules this
+// agent on a kicking cadence right now — i.e. the governor is expected to be
+// driving it. It is the inverse of the dashboard's offByCadence: false when the
+// mode's cadence is a non-kicking value (pause/off/0/"on demand"), when the
+// agent is on-demand (never on a schedule), or when the agent is on-demand by
+// pack default. onDemandAgent is the agent's own OnDemand config flag;
+// onDemandFromPack is the ACMM-pack on-demand set (see OnDemandAgentsFromPacks).
+//
+// modeName is matched case-insensitively against the config's mode keys, which
+// are lowercase (idle/quiet/busy/surge); callers holding an upper-cased
+// governor mode string need not pre-lowercase.
+func (c *Config) ExpectedActive(agentName, modeName string, onDemandAgent bool, onDemandFromPack map[string]bool) bool {
+	if onDemandAgent || onDemandFromPack[agentName] {
+		return false
+	}
+	cad := c.CadenceValueForMode(agentName, strings.ToLower(strings.TrimSpace(modeName)))
+	if cad == "" {
+		// No cadence entry for this mode: the agent is not scheduled to kick in
+		// this mode, so it is not expected active.
+		return false
+	}
+	return !cad.IsPaused()
+}

--- a/src/pkg/config/expected_active_test.go
+++ b/src/pkg/config/expected_active_test.go
@@ -1,0 +1,64 @@
+package config
+
+import "testing"
+
+func cfgWithModes() *Config {
+	c := &Config{}
+	c.Governor.Modes = map[string]ModeConfig{
+		"surge": {Cadences: map[string]Cadence{
+			"scanner":    "5m",    // active in surge
+			"brainstorm": "pause", // paused in surge
+		}},
+		"idle": {Cadences: map[string]Cadence{
+			"scanner": "off", // off in idle
+		}},
+	}
+	return c
+}
+
+func TestExpectedActive_PositiveCadence(t *testing.T) {
+	c := cfgWithModes()
+	if !c.ExpectedActive("scanner", "surge", false, nil) {
+		t.Error("scanner has a 5m cadence in surge — expected active")
+	}
+}
+
+func TestExpectedActive_PausedCadence(t *testing.T) {
+	c := cfgWithModes()
+	if c.ExpectedActive("brainstorm", "surge", false, nil) {
+		t.Error("brainstorm is paused in surge — must not be expected active")
+	}
+	if c.ExpectedActive("scanner", "idle", false, nil) {
+		t.Error("scanner is off in idle — must not be expected active")
+	}
+}
+
+func TestExpectedActive_NoEntryForMode(t *testing.T) {
+	c := cfgWithModes()
+	// brainstorm has no idle cadence entry → not scheduled → not expected active.
+	if c.ExpectedActive("brainstorm", "idle", false, nil) {
+		t.Error("no cadence entry for mode must read as not expected active")
+	}
+	// Unknown mode entirely.
+	if c.ExpectedActive("scanner", "busy", false, nil) {
+		t.Error("unknown mode must read as not expected active")
+	}
+}
+
+func TestExpectedActive_OnDemandNeverExpected(t *testing.T) {
+	c := cfgWithModes()
+	if c.ExpectedActive("scanner", "surge", true, nil) {
+		t.Error("on-demand agent is never expected active on a schedule")
+	}
+	if c.ExpectedActive("scanner", "surge", false, map[string]bool{"scanner": true}) {
+		t.Error("on-demand-by-pack agent is never expected active")
+	}
+}
+
+func TestExpectedActive_ModeCaseInsensitive(t *testing.T) {
+	c := cfgWithModes()
+	// Governor mode strings arrive upper-cased (SURGE); the helper lowercases.
+	if !c.ExpectedActive("scanner", "SURGE", false, nil) {
+		t.Error("mode lookup must be case-insensitive")
+	}
+}

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -459,7 +459,15 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		// dot so operators do not mistake a governor-paused agent for a running
 		// one. On-demand agents are excluded — they are intentionally not on a
 		// cadence and carry their own on-demand styling.
-		offByCadence := (cadence == cadencePause || cadence == cadenceOff) &&
+		//
+		// Derived from the shared cadence resolver so it agrees exactly with the
+		// heartbeat's ExpectedActive (config.ExpectedActive): both read the same
+		// per-mode cadence and the same IsPaused semantics. offByCadence is the
+		// stricter "has a pause/off ENTRY" form (an ABSENT cadence is not off),
+		// which is why it checks the resolved cadence directly rather than
+		// negating ExpectedActive.
+		modeCadence := cfg.CadenceValueForMode(name, currentMode)
+		offByCadence := modeCadence != "" && modeCadence.IsPaused() &&
 			!proc.Config.OnDemand && !onDemandSet[name]
 
 		pinnedCli := proc.PinnedCLI != "" || proc.Config.CLIPinned

--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -231,15 +231,22 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	loginBlocked := a.NeedsLogin && interactiveLoginBackend(a.Backend)
 	hiveBlocked := blockers.any()
 
-	// Able = "can do everything this agent's mode grants". The CanOpen*/CanMerge
-	// booleans already encode the mode's ceiling (an advisory issues-only agent
-	// simply reports CanMerge=false — not being able to merge is not a fault for
-	// it). The only things that can TAKE AWAY a granted capability are an
-	// interactive login block or a hive-level blocker; either makes the agent
-	// unable to exercise its writes. We require CanOpenIssue as the floor: an
-	// agent that cannot even open an issue at this ACMM level has no reachable
-	// mission.
-	v.Able = a.CanOpenIssue && !loginBlocked && !hiveBlocked
+	// capable = "if this agent were working, could it exercise its mission?"
+	// The CanOpen*/CanMerge booleans already encode the mode's ceiling (an
+	// advisory issues-only agent simply reports CanMerge=false — not being able
+	// to merge is not a fault for it). The only things that TAKE AWAY a granted
+	// capability are an interactive login block or a hive-level blocker. We
+	// require CanOpenIssue as the floor: an agent that cannot even open an issue
+	// at this ACMM level has no reachable mission. This drives the badge TIER,
+	// which is about capability regardless of whether the pane is live.
+	capable := a.CanOpenIssue && !loginBlocked && !hiveBlocked
+
+	// Able = actually able to fulfill its mission RIGHT NOW: capable AND truly
+	// working. A capable-but-stopped or capable-but-paused agent is not doing
+	// its mission, so it must not inflate the "K able" count next to "M
+	// running". This makes the header read as a subset chain (expected ⊇
+	// running ⊇ able) and makes IMPOTENT = running − able coherent.
+	v.Able = capable && v.RunState == runWorking
 
 	// Reason + tier.
 	switch {
@@ -251,8 +258,11 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 		v.BlockedReason = "no write capability at this ACMM level"
 	}
 
+	// Tier reflects CAPABILITY (would it work if running), not liveness — a
+	// healthy-but-paused agent still shows green so the badge answers "can this
+	// agent do its job" independent of the run-state column beside it.
 	switch {
-	case v.Able:
+	case capable:
 		v.CapabilityTier = tierGreen
 	case a.CanOpenIssue && !loginBlocked && !hiveBlocked:
 		// Can still do part of its job (open issues) but a write it would
@@ -271,7 +281,11 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 			// Only "stuck" when the governor actually expects it active now.
 			v.Stuck = a.ExpectedActive
 		}
-		if running && !v.Able {
+		// IMPOTENT: running but not capable of its mission (blocked/gated). Uses
+		// `capable`, not v.Able, because v.Able already requires runWorking —
+		// an idle-at-prompt running agent that is blocked should still read as
+		// impotent.
+		if running && !capable {
 			v.Impotent = true
 		}
 	}

--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -230,16 +230,22 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 
 	loginBlocked := a.NeedsLogin && interactiveLoginBackend(a.Backend)
 	hiveBlocked := blockers.any()
+	blocked := loginBlocked || hiveBlocked
 
-	// capable = "if this agent were working, could it exercise its mission?"
+	// modeGrantsWrite: the agent's mode grants at least one write action (open
+	// PR or merge) beyond opening issues. An advisory issues-only agent does
+	// not — so it is fully able the moment it can open issues, and a write
+	// blocker cannot make it "partial".
+	modeGrantsWrite := a.CanOpenPR || a.CanMerge
+
+	// capable = "if this agent were working, could it exercise its FULL mission?"
 	// The CanOpen*/CanMerge booleans already encode the mode's ceiling (an
 	// advisory issues-only agent simply reports CanMerge=false — not being able
 	// to merge is not a fault for it). The only things that TAKE AWAY a granted
 	// capability are an interactive login block or a hive-level blocker. We
 	// require CanOpenIssue as the floor: an agent that cannot even open an issue
-	// at this ACMM level has no reachable mission. This drives the badge TIER,
-	// which is about capability regardless of whether the pane is live.
-	capable := a.CanOpenIssue && !loginBlocked && !hiveBlocked
+	// at this ACMM level has no reachable mission.
+	capable := a.CanOpenIssue && !blocked
 
 	// Able = actually able to fulfill its mission RIGHT NOW: capable AND truly
 	// working. A capable-but-stopped or capable-but-paused agent is not doing
@@ -261,12 +267,16 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	// Tier reflects CAPABILITY (would it work if running), not liveness — a
 	// healthy-but-paused agent still shows green so the badge answers "can this
 	// agent do its job" independent of the run-state column beside it.
+	//
+	//   green — fully capable of its mission.
+	//   amber — can still open issues, but a blocker takes away a WRITE its mode
+	//           would otherwise grant (partial: half its job works).
+	//   red   — cannot even open an issue (blocked at the floor, or no capability
+	//           at this ACMM level).
 	switch {
 	case capable:
 		v.CapabilityTier = tierGreen
-	case a.CanOpenIssue && !loginBlocked && !hiveBlocked:
-		// Can still do part of its job (open issues) but a write it would
-		// otherwise be granted is gated/blocked.
+	case a.CanOpenIssue && blocked && modeGrantsWrite:
 		v.CapabilityTier = tierAmber
 	default:
 		v.CapabilityTier = tierRed

--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -1,0 +1,403 @@
+package hub
+
+import (
+	"strings"
+	"time"
+)
+
+// Fleet-divergence derivation.
+//
+// This file turns the raw per-agent signals a spoke reports (state, needsLogin,
+// sessionMissing, expectedActive, canOpen*/canMerge, plus the hive-level
+// blockers on the registry row) into the three-way picture the fleet view
+// exists to show:
+//
+//	EXPECTED  — the governor's current mode schedules this agent to run now.
+//	ACTUAL    — the agent's pane is truly alive and working.
+//	ABLE      — the agent can open issues, open PRs, and merge PRs.
+//
+// and makes the DELTAS between them loud:
+//
+//	STUCK     — expected active, but not actually running/working.
+//	IMPOTENT  — actually running, but not able to do its mission.
+//	quiet     — paused or expected-off; never a fault (provenance shown, not an
+//	            alarm).
+//
+// Everything here is DERIVED from signals already on the row; nothing is a new
+// wire field beyond the six raw booleans/strings. The run-state machine is
+// NOT re-implemented — it reuses classifyInactiveAgent (agent_inactivity.go) so
+// the fleet view and the agents-inactive alert can never disagree about whether
+// an agent is stuck.
+//
+// Backward compatibility is load-bearing: a spoke too old to report the new
+// fields sends them all zero-valued. ExpectedActive=false and the capability
+// bools=false must therefore read as UNKNOWN — never as "expected off" or
+// "cannot work" — so STUCK and IMPOTENT never fire on a legacy spoke.
+
+// agentRunState is the ACTUAL-leg verdict for one agent.
+type agentRunState int
+
+const (
+	// runUnknown — the spoke did not report enough to classify (legacy spoke,
+	// or an agent in a transient state). Never a fault.
+	runUnknown agentRunState = iota
+	// runWorking — running, authenticated, session present, not idle-with-work.
+	runWorking
+	// runIdleAtPrompt — running and authenticated but idle while work waits.
+	runIdleAtPrompt
+	// runStuckAtLogin — running but sitting on a login prompt past grace.
+	runStuckAtLogin
+	// runSessionGone — the manager believes it runs, but the tmux session is
+	// gone (zombie).
+	runSessionGone
+	// runDead — expected active and enabled, but not running and not paused.
+	runDead
+	// runQuietByDesign — paused, or not expected active in the current mode.
+	runQuietByDesign
+)
+
+// String is the stable wire label the frontend renders; it never re-derives the
+// state machine.
+func (s agentRunState) String() string {
+	switch s {
+	case runWorking:
+		return "working"
+	case runIdleAtPrompt:
+		return "idle-at-prompt"
+	case runStuckAtLogin:
+		return "stuck-at-login"
+	case runSessionGone:
+		return "session-gone"
+	case runDead:
+		return "dead"
+	case runQuietByDesign:
+		return "quiet-by-design"
+	default:
+		return "unknown"
+	}
+}
+
+// capabilityTier collapses the three ABLE booleans + blockers into a traffic
+// light for the badge.
+const (
+	tierGreen = "green" // able to do everything its mode grants
+	tierAmber = "amber" // partially able (can open issues but a write is gated/blocked)
+	tierRed   = "red"   // cannot do any write it is expected to
+	tierGray  = "gray"  // unknown (legacy spoke)
+)
+
+// hiveBlockers are the hive-level conditions that stop an otherwise-capable
+// agent from doing its job. Populated from fields already on the registry row —
+// no new wire fields. A blocker downgrades capability regardless of the ACMM
+// gate: an agent whose mode grants merge still cannot merge if the App lacks
+// permission or the repo target is misconfigured.
+type hiveBlockers struct {
+	GitHubAppRequired       bool
+	GitHubAppPermIssue      string
+	GitHubAppState          string
+	RepoTargetMisconfigured bool
+	RepoTargetIssue         string
+	InferenceAuthError      string
+}
+
+// any reports whether any hive-level blocker is set.
+func (b hiveBlockers) any() bool {
+	return b.GitHubAppRequired || b.RepoTargetMisconfigured ||
+		strings.TrimSpace(b.GitHubAppPermIssue) != "" ||
+		strings.TrimSpace(b.RepoTargetIssue) != "" ||
+		strings.TrimSpace(b.InferenceAuthError) != "" ||
+		blockingGitHubAppState(b.GitHubAppState)
+}
+
+// reason returns a one-line human cause for the first blocker found, or "".
+func (b hiveBlockers) reason() string {
+	switch {
+	case strings.TrimSpace(b.GitHubAppPermIssue) != "":
+		return b.GitHubAppPermIssue
+	case b.GitHubAppRequired:
+		return "GitHub App not installed or not authorized"
+	case blockingGitHubAppState(b.GitHubAppState):
+		return "GitHub App state: " + b.GitHubAppState
+	case strings.TrimSpace(b.RepoTargetIssue) != "":
+		return b.RepoTargetIssue
+	case b.RepoTargetMisconfigured:
+		return "repo target misconfigured"
+	case strings.TrimSpace(b.InferenceAuthError) != "":
+		return b.InferenceAuthError
+	default:
+		return ""
+	}
+}
+
+// blockingGitHubAppState reports whether a GitHubAppState string names a state
+// that blocks pushes/merges. Empty and the healthy "ok"/"active" states do not
+// block; anything else (e.g. "suspended", "perm_mismatch") does.
+func blockingGitHubAppState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "", "ok", "active", "installed", "healthy":
+		return false
+	default:
+		return true
+	}
+}
+
+// agentVerdict is the full derived picture for one agent.
+type agentVerdict struct {
+	RunState       agentRunState
+	CanOpenIssue   bool
+	CanOpenPR      bool
+	CanMerge       bool
+	Able           bool   // can do everything its mode grants, with no blocker and not login-stuck
+	Stuck          bool   // expected active but not actually working
+	Impotent       bool   // actually running but not able
+	QuietByDesign  bool   // paused or expected-off — never a fault
+	CapabilityTier string // tierGreen | tierAmber | tierRed | tierGray
+	BlockedReason  string // one human sentence; empty when Able
+}
+
+// interactiveLoginBackend reports whether a backend authenticates via an
+// interactive CLI login (so NeedsLogin is a real blocker for it). Inference /
+// API-key backends never sit on a login prompt, so a stray NeedsLogin there is
+// not treated as a capability blocker. An empty backend (legacy spoke) is
+// treated as interactive so we do not under-report a real login block.
+func interactiveLoginBackend(backend string) bool {
+	switch strings.ToLower(strings.TrimSpace(backend)) {
+	case "vllm", "llm-d", "litellm", "watsonx":
+		return false
+	default:
+		return true
+	}
+}
+
+// legacyAgent reports whether the spoke omitted the new divergence fields — the
+// telltale is that it reports none of the capabilities AND is not expected
+// active. A capable or expected agent proves the spoke speaks the new protocol.
+// Used only to keep the run-state machine from labeling a legacy agent "dead".
+func legacyAgent(a AgentSummary) bool {
+	return !a.ExpectedActive && !a.Enabled &&
+		!a.CanOpenIssue && !a.CanOpenPR && !a.CanMerge && strings.TrimSpace(a.Backend) == ""
+}
+
+// deriveAgentVerdict computes the full three-leg verdict for one agent.
+//
+// queuedWork gates the idle rule (same as classifyInactiveAgent). now is passed
+// for deterministic tests. blockers are the hive-level conditions on the row.
+func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, now time.Time) agentVerdict {
+	v := agentVerdict{
+		CanOpenIssue: a.CanOpenIssue,
+		CanOpenPR:    a.CanOpenPR,
+		CanMerge:     a.CanMerge,
+	}
+
+	paused := a.Paused || strings.EqualFold(a.State, agentStatePaused)
+	running := strings.EqualFold(a.State, agentStateRunning)
+	legacy := legacyAgent(a)
+
+	// --- ACTUAL leg: reuse the existing inactivity state machine. ---
+	kind := classifyInactiveAgent(a, queuedWork, now)
+	switch {
+	case paused:
+		v.RunState = runQuietByDesign
+	case !legacy && !a.ExpectedActive && !running:
+		// Not scheduled to run in this mode and not running: off by design, not
+		// a fault. (A legacy spoke reports ExpectedActive=false for everything,
+		// so this branch is guarded to spokes that actually speak the field.)
+		v.RunState = runQuietByDesign
+	case kind == agentInactiveSessionMissing:
+		v.RunState = runSessionGone
+	case kind == agentInactiveNeedsLogin:
+		v.RunState = runStuckAtLogin
+	case kind == agentInactiveIdleWithWork:
+		v.RunState = runIdleAtPrompt
+	case running:
+		v.RunState = runWorking
+	case !legacy && a.ExpectedActive && a.Enabled:
+		// Expected to run, configured on, but the spoke does not report it
+		// running and it is not paused — it is down.
+		v.RunState = runDead
+	default:
+		v.RunState = runUnknown
+	}
+	v.QuietByDesign = v.RunState == runQuietByDesign
+
+	// --- ABLE leg. ---
+	// Unknown for a legacy spoke: it reports no capabilities, so we cannot
+	// claim it is unable — leave Able=false, tier gray, and never mark Impotent.
+	if legacy {
+		v.markUnknown()
+		return v
+	}
+
+	loginBlocked := a.NeedsLogin && interactiveLoginBackend(a.Backend)
+	hiveBlocked := blockers.any()
+
+	// Able = "can do everything this agent's mode grants". The CanOpen*/CanMerge
+	// booleans already encode the mode's ceiling (an advisory issues-only agent
+	// simply reports CanMerge=false — not being able to merge is not a fault for
+	// it). The only things that can TAKE AWAY a granted capability are an
+	// interactive login block or a hive-level blocker; either makes the agent
+	// unable to exercise its writes. We require CanOpenIssue as the floor: an
+	// agent that cannot even open an issue at this ACMM level has no reachable
+	// mission.
+	v.Able = a.CanOpenIssue && !loginBlocked && !hiveBlocked
+
+	// Reason + tier.
+	switch {
+	case loginBlocked:
+		v.BlockedReason = "sitting at login prompt"
+	case hiveBlocked:
+		v.BlockedReason = blockers.reason()
+	case !a.CanOpenIssue && !a.CanOpenPR && !a.CanMerge:
+		v.BlockedReason = "no write capability at this ACMM level"
+	}
+
+	switch {
+	case v.Able:
+		v.CapabilityTier = tierGreen
+	case a.CanOpenIssue && !loginBlocked && !hiveBlocked:
+		// Can still do part of its job (open issues) but a write it would
+		// otherwise be granted is gated/blocked.
+		v.CapabilityTier = tierAmber
+	default:
+		v.CapabilityTier = tierRed
+	}
+
+	// --- DELTAS. ---
+	// Suppressed for quiet-by-design agents: an off-schedule or paused agent is
+	// neither stuck nor impotent.
+	if !v.QuietByDesign {
+		switch v.RunState {
+		case runDead, runStuckAtLogin, runSessionGone, runIdleAtPrompt:
+			// Only "stuck" when the governor actually expects it active now.
+			v.Stuck = a.ExpectedActive
+		}
+		if running && !v.Able {
+			v.Impotent = true
+		}
+	}
+
+	return v
+}
+
+// markUnknown sets the unknown/legacy capability tier and clears the derived
+// capability flags so a legacy agent never reads as able or impotent.
+func (v *agentVerdict) markUnknown() {
+	v.Able = false
+	v.Impotent = false
+	v.CapabilityTier = tierGray
+	v.BlockedReason = ""
+}
+
+// agentFleetRollup is the per-spoke divergence summary: the three counts the
+// header shows plus the two delta totals.
+type agentFleetRollup struct {
+	Expected int `json:"expected"`
+	Running  int `json:"running"`
+	Able     int `json:"able"`
+	Stuck    int `json:"stuck"`
+	Impotent int `json:"impotent"`
+}
+
+// AgentVerdictJSON is the per-agent row the fleet view renders. It carries the
+// raw heartbeat signals the browser displays (name/state/backend/paused
+// provenance/last-activity) plus the derived verdict (run-state string,
+// capability, deltas). runState is a string so the frontend never re-derives
+// the state machine.
+type AgentVerdictJSON struct {
+	Name           string `json:"name"`
+	Backend        string `json:"backend,omitempty"`
+	Mode           string `json:"mode,omitempty"`
+	Enabled        bool   `json:"enabled"`
+	ExpectedActive bool   `json:"expectedActive"`
+	State          string `json:"state,omitempty"`
+	RunState       string `json:"runState"`
+	LastActivityAt string `json:"lastActivityAt,omitempty"`
+	Paused         bool   `json:"paused,omitempty"`
+	PausedBy       string `json:"pausedBy,omitempty"`
+	PausedTrigger  string `json:"pausedTrigger,omitempty"`
+	PausedReason   string `json:"pausedReason,omitempty"`
+	PausedAt       string `json:"pausedAt,omitempty"`
+	CanOpenIssue   bool   `json:"canOpenIssue"`
+	CanOpenPR      bool   `json:"canOpenPR"`
+	CanMerge       bool   `json:"canMerge"`
+	Able           bool   `json:"able"`
+	CapabilityTier string `json:"capabilityTier"`
+	Stuck          bool   `json:"stuck,omitempty"`
+	Impotent       bool   `json:"impotent,omitempty"`
+	QuietByDesign  bool   `json:"quietByDesign,omitempty"`
+	BlockedReason  string `json:"blockedReason,omitempty"`
+}
+
+// buildAgentVerdicts derives the per-agent verdict rows for one hive, skipping
+// blank-named entries. Returns nil when the hive reports no usable agents.
+func buildAgentVerdicts(agents []AgentSummary, blockers hiveBlockers, queuedWork int, now time.Time) []AgentVerdictJSON {
+	var out []AgentVerdictJSON
+	for _, a := range agents {
+		if strings.TrimSpace(a.Name) == "" {
+			continue
+		}
+		v := deriveAgentVerdict(a, blockers, queuedWork, now)
+		out = append(out, AgentVerdictJSON{
+			Name:           a.Name,
+			Backend:        a.Backend,
+			Mode:           a.Mode,
+			Enabled:        a.Enabled,
+			ExpectedActive: a.ExpectedActive,
+			State:          a.State,
+			RunState:       v.RunState.String(),
+			LastActivityAt: a.LastActivityAt,
+			Paused:         a.Paused,
+			PausedBy:       a.PausedBy,
+			PausedTrigger:  a.PausedTrigger,
+			PausedReason:   a.PausedReason,
+			PausedAt:       a.PausedAt,
+			CanOpenIssue:   v.CanOpenIssue,
+			CanOpenPR:      v.CanOpenPR,
+			CanMerge:       v.CanMerge,
+			Able:           v.Able,
+			CapabilityTier: v.CapabilityTier,
+			Stuck:          v.Stuck,
+			Impotent:       v.Impotent,
+			QuietByDesign:  v.QuietByDesign,
+			BlockedReason:  v.BlockedReason,
+		})
+	}
+	return out
+}
+
+// rollupAgents summarizes a hive's agents into the divergence counts. It counts
+// only agents the spoke actually reports on (skips blank names) and derives a
+// verdict per agent via deriveAgentVerdict.
+//
+//   - Expected: agents the governor's current mode schedules active now.
+//   - Running:  agents actually working (RunState == runWorking).
+//   - Able:     agents that can do their full mission.
+//
+// A legacy spoke contributes zero to Expected/Able (unknown) but its running
+// agents still count toward Running via the working state, so the header
+// degrades gracefully rather than reading "0 running" for an old spoke.
+func rollupAgents(agents []AgentSummary, blockers hiveBlockers, queuedWork int, now time.Time) agentFleetRollup {
+	var r agentFleetRollup
+	for _, a := range agents {
+		if strings.TrimSpace(a.Name) == "" {
+			continue
+		}
+		v := deriveAgentVerdict(a, blockers, queuedWork, now)
+		if a.ExpectedActive {
+			r.Expected++
+		}
+		if v.RunState == runWorking {
+			r.Running++
+		}
+		if v.Able {
+			r.Able++
+		}
+		if v.Stuck {
+			r.Stuck++
+		}
+		if v.Impotent {
+			r.Impotent++
+		}
+	}
+	return r
+}

--- a/src/pkg/hub/agent_capability_coverage_test.go
+++ b/src/pkg/hub/agent_capability_coverage_test.go
@@ -1,0 +1,194 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAgentRunState_StringAllCases(t *testing.T) {
+	cases := map[agentRunState]string{
+		runUnknown:        "unknown",
+		runWorking:        "working",
+		runIdleAtPrompt:   "idle-at-prompt",
+		runStuckAtLogin:   "stuck-at-login",
+		runSessionGone:    "session-gone",
+		runDead:           "dead",
+		runQuietByDesign:  "quiet-by-design",
+		agentRunState(99): "unknown",
+	}
+	for st, want := range cases {
+		if got := st.String(); got != want {
+			t.Errorf("String(%d) = %q, want %q", st, got, want)
+		}
+	}
+}
+
+func TestHiveBlockers_ReasonPrecedence(t *testing.T) {
+	cases := []struct {
+		name string
+		b    hiveBlockers
+		want string
+	}{
+		{"none", hiveBlockers{}, ""},
+		{"perm issue wins", hiveBlockers{GitHubAppPermIssue: "need contents:write", GitHubAppRequired: true}, "need contents:write"},
+		{"app required", hiveBlockers{GitHubAppRequired: true}, "GitHub App not installed or not authorized"},
+		{"app state", hiveBlockers{GitHubAppState: "suspended"}, "GitHub App state: suspended"},
+		{"repo target issue", hiveBlockers{RepoTargetIssue: "wrong org"}, "wrong org"},
+		{"repo misconfigured", hiveBlockers{RepoTargetMisconfigured: true}, "repo target misconfigured"},
+		{"inference auth", hiveBlockers{InferenceAuthError: "gateway key expired"}, "gateway key expired"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.b.reason(); got != tc.want {
+				t.Errorf("reason() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHiveBlockers_Any(t *testing.T) {
+	if (hiveBlockers{}).any() {
+		t.Error("empty blockers must report none")
+	}
+	each := []hiveBlockers{
+		{GitHubAppRequired: true},
+		{GitHubAppPermIssue: "x"},
+		{GitHubAppState: "suspended"},
+		{RepoTargetMisconfigured: true},
+		{RepoTargetIssue: "x"},
+		{InferenceAuthError: "x"},
+	}
+	for i, b := range each {
+		if !b.any() {
+			t.Errorf("case %d: any() = false, want true", i)
+		}
+	}
+}
+
+func TestBlockingGitHubAppState(t *testing.T) {
+	healthy := []string{"", "ok", "OK", "active", " installed ", "healthy"}
+	for _, s := range healthy {
+		if blockingGitHubAppState(s) {
+			t.Errorf("%q must not block", s)
+		}
+	}
+	blocking := []string{"suspended", "perm_mismatch", "revoked", "unknown-thing"}
+	for _, s := range blocking {
+		if !blockingGitHubAppState(s) {
+			t.Errorf("%q must block", s)
+		}
+	}
+}
+
+// Exercise the session-gone and idle-with-work run-states end to end.
+func TestVerdict_SessionGoneAndIdle(t *testing.T) {
+	now := time.Now()
+
+	zombie := AgentSummary{
+		Name: "z", State: "running", Backend: "claude",
+		Enabled: true, ExpectedActive: true, SessionMissing: true,
+		CanOpenIssue: true, CanOpenPR: true, CanMerge: true,
+		StartedAt: settled(now),
+	}
+	v := deriveAgentVerdict(zombie, hiveBlockers{}, 5, now)
+	if v.RunState != runSessionGone {
+		t.Errorf("zombie run-state = %v, want session-gone", v.RunState)
+	}
+	if !v.Stuck {
+		t.Error("expected-active zombie must be STUCK")
+	}
+
+	idle := AgentSummary{
+		Name: "i", State: "running", Backend: "claude",
+		Enabled: true, ExpectedActive: true,
+		CanOpenIssue: true, CanOpenPR: true, CanMerge: true,
+		StartedAt: settled(now), LastActivityAt: activeAt(now, 90*time.Minute),
+	}
+	// queuedWork > 0 so the idle rule fires.
+	vi := deriveAgentVerdict(idle, hiveBlockers{}, 5, now)
+	if vi.RunState != runIdleAtPrompt {
+		t.Errorf("idle-with-work run-state = %v, want idle-at-prompt", vi.RunState)
+	}
+	if !vi.Stuck {
+		t.Error("expected-active idle-with-work must be STUCK")
+	}
+}
+
+// no-capability agent (advisory below issues) → red tier + reason.
+func TestVerdict_NoCapabilityIsRed(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{
+		Name: "adv", State: "running", Backend: "claude",
+		Enabled: true, ExpectedActive: true,
+		CanOpenIssue: false, CanOpenPR: false, CanMerge: false,
+		StartedAt: settled(now), LastActivityAt: activeAt(now, 1*time.Minute),
+	}
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.CapabilityTier != tierRed {
+		t.Errorf("no-capability tier = %s, want red", v.CapabilityTier)
+	}
+	if v.BlockedReason == "" {
+		t.Error("no-capability agent must carry a reason")
+	}
+	// Running but not capable → impotent.
+	if !v.Impotent {
+		t.Error("running no-capability agent must be IMPOTENT")
+	}
+}
+
+// Tier arms: green (unblocked, full mission), amber (issues still work but a
+// blocker gates a mode-granted write), red (cannot even open an issue).
+func TestVerdict_TierArms(t *testing.T) {
+	now := time.Now()
+	writer := AgentSummary{
+		Name: "a", State: "running", Backend: "claude",
+		Enabled: true, ExpectedActive: true,
+		CanOpenIssue: true, CanOpenPR: true, CanMerge: true,
+		StartedAt: settled(now), LastActivityAt: activeAt(now, 1*time.Minute),
+	}
+	// green — unblocked, full mission.
+	if v := deriveAgentVerdict(writer, hiveBlockers{}, 5, now); v.CapabilityTier != tierGreen {
+		t.Errorf("unblocked writer = %s, want green", v.CapabilityTier)
+	}
+	// amber — can still open issues, but a hive blocker gates its writes.
+	if v := deriveAgentVerdict(writer, hiveBlockers{RepoTargetMisconfigured: true}, 5, now); v.CapabilityTier != tierAmber {
+		t.Errorf("write-blocked writer = %s, want amber", v.CapabilityTier)
+	}
+	// amber — a login block on an interactive backend also gates writes while
+	// issues remain conceptually open.
+	loginBlk := writer
+	loginBlk.NeedsLogin = true
+	if v := deriveAgentVerdict(loginBlk, hiveBlockers{}, 5, now); v.CapabilityTier != tierAmber {
+		t.Errorf("login-blocked writer = %s, want amber", v.CapabilityTier)
+	}
+	// red — issues-only agent (no write to gate) that is ALSO blocked at the
+	// floor: model an agent with no capability at all.
+	none := writer
+	none.CanOpenIssue, none.CanOpenPR, none.CanMerge = false, false, false
+	if v := deriveAgentVerdict(none, hiveBlockers{}, 5, now); v.CapabilityTier != tierRed {
+		t.Errorf("no-capability agent = %s, want red", v.CapabilityTier)
+	}
+}
+
+func TestMarkUnknown(t *testing.T) {
+	v := agentVerdict{Able: true, Impotent: true, CapabilityTier: tierGreen, BlockedReason: "x"}
+	v.markUnknown()
+	if v.Able || v.Impotent || v.CapabilityTier != tierGray || v.BlockedReason != "" {
+		t.Errorf("markUnknown did not reset: %+v", v)
+	}
+}
+
+func TestInteractiveLoginBackend(t *testing.T) {
+	inference := []string{"vllm", "llm-d", "litellm", "watsonx"}
+	for _, b := range inference {
+		if interactiveLoginBackend(b) {
+			t.Errorf("%q must not be interactive-login", b)
+		}
+	}
+	interactive := []string{"claude", "copilot", "gemini", "", "codex"}
+	for _, b := range interactive {
+		if !interactiveLoginBackend(b) {
+			t.Errorf("%q must be interactive-login (empty defaults to interactive)", b)
+		}
+	}
+}

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -93,22 +93,28 @@ func TestVerdict_HiveBlockerMakesImpotent(t *testing.T) {
 }
 
 // An inference backend that reports NeedsLogin is NOT treated as login-blocked
-// (those backends never sit on a CLI login prompt).
-func TestVerdict_InferenceBackendIgnoresNeedsLogin(t *testing.T) {
+// for CAPABILITY (those backends never sit on a CLI login prompt), so its
+// badge tier stays green — even though the shared run-state classifier still
+// keys off NeedsLogin regardless of backend (a pre-existing behavior we do not
+// change here). Capability (would it work) is distinct from run-state (is the
+// pane live).
+func TestVerdict_InferenceBackendNotLoginBlockedForCapability(t *testing.T) {
 	now := time.Now()
 	a := modernWorking(now)
 	a.Backend = "llm-d"
 	a.NeedsLogin = true
 	a.CanOpenIssue, a.CanOpenPR, a.CanMerge = true, true, true
 	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
-	if v.RunState == runStuckAtLogin {
-		// classifyInactiveAgent still keys off NeedsLogin regardless of backend;
-		// that is a pre-existing behavior. What matters for capability is that
-		// the inference backend is not counted as login-blocked for Able.
-		t.Log("note: run-state still login per shared classifier")
+	if v.CapabilityTier != tierGreen {
+		t.Errorf("inference backend must not be login-blocked for capability; tier=%s reason=%q",
+			v.CapabilityTier, v.BlockedReason)
 	}
-	if !v.Able {
-		t.Error("inference backend must not be login-blocked for capability")
+	if v.BlockedReason != "" {
+		t.Errorf("inference backend must carry no blocked reason, got %q", v.BlockedReason)
+	}
+	// It must NOT be flagged impotent, because it is not capability-blocked.
+	if v.Impotent {
+		t.Error("inference backend with a stray needsLogin must not be IMPOTENT")
 	}
 }
 

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -1,0 +1,236 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// A capable, expected-active, working agent on a modern spoke: the green case.
+func modernWorking(now time.Time) AgentSummary {
+	return AgentSummary{
+		Name: "scanner", State: "running", Backend: "claude",
+		Enabled: true, ExpectedActive: true,
+		CanOpenIssue: true, CanOpenPR: true, CanMerge: true,
+		StartedAt: settled(now), LastActivityAt: activeAt(now, 1*time.Minute),
+	}
+}
+
+func TestVerdict_WorkingAndAble(t *testing.T) {
+	now := time.Now()
+	v := deriveAgentVerdict(modernWorking(now), hiveBlockers{}, 5, now)
+	if v.RunState != runWorking {
+		t.Errorf("runState = %v, want working", v.RunState)
+	}
+	if !v.Able || v.CapabilityTier != tierGreen {
+		t.Errorf("want able/green, got able=%v tier=%s", v.Able, v.CapabilityTier)
+	}
+	if v.Stuck || v.Impotent || v.QuietByDesign {
+		t.Errorf("healthy agent must carry no delta: %+v", v)
+	}
+}
+
+// Expected active + enabled but the spoke does not report it running and it is
+// not paused => dead => STUCK (the governor expects it, it isn't there).
+func TestVerdict_StuckWhenExpectedButDown(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.State = "stopped"
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runDead {
+		t.Errorf("runState = %v, want dead", v.RunState)
+	}
+	if !v.Stuck {
+		t.Error("expected-active but down agent must be STUCK")
+	}
+	if v.Impotent {
+		t.Error("a down agent is stuck, not impotent")
+	}
+}
+
+// Running + login-stuck on an interactive backend => IMPOTENT and STUCK (it is
+// expected active, and it is running but cannot work).
+func TestVerdict_StuckAtLoginIsImpotentAndStuck(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.NeedsLogin = true
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runStuckAtLogin {
+		t.Errorf("runState = %v, want stuck-at-login", v.RunState)
+	}
+	if !v.Stuck {
+		t.Error("login-stuck + expected active must be STUCK")
+	}
+	if !v.Impotent {
+		t.Error("running but login-blocked must be IMPOTENT")
+	}
+	if v.Able {
+		t.Error("login-blocked agent must not be Able")
+	}
+	if v.BlockedReason == "" {
+		t.Error("login block must carry a reason")
+	}
+}
+
+// A hive-level blocker (App perm) makes a running, capable agent IMPOTENT even
+// though its ACMM gates say it can push/merge.
+func TestVerdict_HiveBlockerMakesImpotent(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	b := hiveBlockers{GitHubAppPermIssue: "App missing contents:write"}
+	v := deriveAgentVerdict(a, b, 5, now)
+	if v.Able {
+		t.Error("App-perm-blocked agent must not be Able")
+	}
+	if !v.Impotent {
+		t.Error("running + hive-blocked must be IMPOTENT")
+	}
+	if v.BlockedReason != "App missing contents:write" {
+		t.Errorf("reason = %q, want the App perm issue", v.BlockedReason)
+	}
+	if v.RunState != runWorking {
+		t.Errorf("hive blocker does not change run-state; got %v", v.RunState)
+	}
+}
+
+// An inference backend that reports NeedsLogin is NOT treated as login-blocked
+// (those backends never sit on a CLI login prompt).
+func TestVerdict_InferenceBackendIgnoresNeedsLogin(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.Backend = "llm-d"
+	a.NeedsLogin = true
+	a.CanOpenIssue, a.CanOpenPR, a.CanMerge = true, true, true
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState == runStuckAtLogin {
+		// classifyInactiveAgent still keys off NeedsLogin regardless of backend;
+		// that is a pre-existing behavior. What matters for capability is that
+		// the inference backend is not counted as login-blocked for Able.
+		t.Log("note: run-state still login per shared classifier")
+	}
+	if !v.Able {
+		t.Error("inference backend must not be login-blocked for capability")
+	}
+}
+
+// Paused agent: quiet-by-design, never stuck or impotent, whatever else is set.
+func TestVerdict_PausedIsQuietByDesign(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.Paused = true
+	a.State = "paused"
+	a.NeedsLogin = true // even with a fault signal, paused wins
+	v := deriveAgentVerdict(a, hiveBlockers{GitHubAppRequired: true}, 5, now)
+	if v.RunState != runQuietByDesign || !v.QuietByDesign {
+		t.Errorf("paused must be quiet-by-design, got %v", v.RunState)
+	}
+	if v.Stuck || v.Impotent {
+		t.Errorf("paused agent must carry no fault delta: %+v", v)
+	}
+}
+
+// Not expected active in the current mode (governor pauses it there) and not
+// running: quiet-by-design, not stuck.
+func TestVerdict_ExpectedOffIsQuiet(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{
+		Name: "brainstorm", State: "stopped", Backend: "claude",
+		Enabled: true, ExpectedActive: false,
+		CanOpenIssue: true, CanOpenPR: true,
+	}
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runQuietByDesign {
+		t.Errorf("expected-off agent = %v, want quiet-by-design", v.RunState)
+	}
+	if v.Stuck {
+		t.Error("expected-off agent must never be STUCK")
+	}
+}
+
+// Legacy spoke: all new fields zero. Must read as UNKNOWN — never stuck, never
+// impotent, capability gray.
+func TestVerdict_LegacySpokeIsUnknownNeverAlarms(t *testing.T) {
+	now := time.Now()
+	// A legacy running agent (no capability fields, no backend, not expected).
+	a := AgentSummary{Name: "old", State: "running", StartedAt: settled(now), LastActivityAt: activeAt(now, 1*time.Minute)}
+	v := deriveAgentVerdict(a, hiveBlockers{GitHubAppRequired: true}, 5, now)
+	if v.CapabilityTier != tierGray {
+		t.Errorf("legacy agent tier = %s, want gray", v.CapabilityTier)
+	}
+	if v.Able || v.Stuck || v.Impotent {
+		t.Errorf("legacy agent must not be able/stuck/impotent: %+v", v)
+	}
+	// A legacy stopped agent must not be called dead/stuck.
+	a2 := AgentSummary{Name: "old2", State: "stopped"}
+	v2 := deriveAgentVerdict(a2, hiveBlockers{}, 5, now)
+	if v2.Stuck || v2.RunState == runDead {
+		t.Errorf("legacy stopped agent must not be dead/stuck: %+v", v2)
+	}
+}
+
+// An advisory (issues-only) agent that cannot merge is NOT impotent — merging
+// was never its mission. Able means "can do what its mode grants".
+func TestVerdict_IssuesOnlyAgentIsAble(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{
+		Name: "advisor", State: "running", Backend: "claude",
+		Enabled: true, ExpectedActive: true,
+		CanOpenIssue: true, CanOpenPR: false, CanMerge: false,
+		StartedAt: settled(now), LastActivityAt: activeAt(now, 1*time.Minute),
+	}
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if !v.Able {
+		t.Error("issues-only agent that can open issues must be Able")
+	}
+	if v.Impotent {
+		t.Error("issues-only agent is not impotent for lacking merge")
+	}
+}
+
+func TestRollup_Counts(t *testing.T) {
+	now := time.Now()
+	working := modernWorking(now)
+	loginStuck := modernWorking(now)
+	loginStuck.Name, loginStuck.NeedsLogin = "quality", true
+	down := modernWorking(now)
+	down.Name, down.State = "guide", "stopped"
+	paused := modernWorking(now)
+	paused.Name, paused.Paused, paused.State = "brainstorm", true, "paused"
+
+	agents := []AgentSummary{working, loginStuck, down, paused}
+	r := rollupAgents(agents, hiveBlockers{}, 5, now)
+
+	// expected: working, loginStuck, down are ExpectedActive (paused copy is too,
+	// but its expected count still increments since ExpectedActive is set).
+	if r.Expected != 4 {
+		t.Errorf("expected = %d, want 4 (all carry ExpectedActive)", r.Expected)
+	}
+	if r.Running != 1 {
+		t.Errorf("running = %d, want 1 (only the healthy one)", r.Running)
+	}
+	if r.Able != 1 {
+		t.Errorf("able = %d, want 1", r.Able)
+	}
+	// stuck: loginStuck (running+login) and down (dead). paused is not stuck.
+	if r.Stuck != 2 {
+		t.Errorf("stuck = %d, want 2 (login-stuck + down)", r.Stuck)
+	}
+	// impotent: only loginStuck (running but blocked). down is not running.
+	if r.Impotent != 1 {
+		t.Errorf("impotent = %d, want 1 (login-stuck)", r.Impotent)
+	}
+}
+
+func TestBuildAgentVerdicts_ShapeAndSkipBlank(t *testing.T) {
+	now := time.Now()
+	agents := []AgentSummary{modernWorking(now), {Name: "  "}}
+	out := buildAgentVerdicts(agents, hiveBlockers{}, 5, now)
+	if len(out) != 1 {
+		t.Fatalf("blank-named agent must be skipped; got %d rows", len(out))
+	}
+	if out[0].RunState != "working" {
+		t.Errorf("runState serialized = %q, want working", out[0].RunState)
+	}
+	if !out[0].CanMerge || out[0].CapabilityTier != tierGreen {
+		t.Errorf("verdict JSON missing derived fields: %+v", out[0])
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -300,6 +300,39 @@ type AgentSummary struct {
 	// "running and working" from "running and producing nothing" — State,
 	// StartedAt and the kick log all keep their values while a CLI sits idle.
 	LastActivityAt string `json:"lastActivityAt,omitempty"`
+
+	// --- Fleet-divergence signals (the EXPECTED and ABLE legs) ---
+	// These let the hub show the gap between what the GOVERNOR expects running,
+	// what is ACTUALLY running, and what is ABLE to fulfill its mission. They
+	// are the minimum raw truths the hub cannot derive; every composite verdict
+	// (run-state, blocked reason, stuck/impotent, rollup) is derived hub-side.
+	// All are zero-valued on a legacy spoke that predates them, which the hub
+	// reads as UNKNOWN — never as a fault.
+
+	// ExpectedActive is true when the governor's CURRENT mode schedules this
+	// agent on a kicking cadence right now (config.ExpectedActive): the mode's
+	// cadence for this agent is not pause/off/0/"on demand" and the agent is
+	// not on-demand. It is the EXPECTED leg — the governor's intent — which the
+	// hub otherwise cannot see (it never receives per-mode Cadences).
+	ExpectedActive bool `json:"expectedActive,omitempty"`
+	// CanOpenIssue / CanOpenPR / CanMerge are the agent's capability at the
+	// hive's current ACMM level and effective mode — the EXACT gates the spoke
+	// enforces (AgentMode.CanCreateIssues/CanPush/CanMerge, the same checks
+	// AuthorizePROpen/AuthorizeMerge use). Sent as booleans so the hub needs no
+	// ACMM-level→mode mapping and the badge cannot claim a capability the relay
+	// would refuse.
+	CanOpenIssue bool `json:"canOpenIssue,omitempty"`
+	CanOpenPR    bool `json:"canOpenPR,omitempty"`
+	CanMerge     bool `json:"canMerge,omitempty"`
+	// Backend is the agent's effective backend (honoring BackendOverride). The
+	// hub needs it to interpret NeedsLogin (interactive CLI vs inference key)
+	// and to phrase a blocked reason.
+	Backend string `json:"backend,omitempty"`
+	// Enabled distinguishes "configured and meant to run" from "not running":
+	// a config-enabled-but-stopped agent is otherwise indistinguishable from an
+	// unconfigured one, which is exactly the STUCK-vs-disabled ambiguity the
+	// fleet view exists to resolve.
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // AgentActivity is the per-agent liveness evidence the spoke has and the hub
@@ -317,6 +350,13 @@ type AgentActivity struct {
 	SessionMissing bool
 	StartedAt      time.Time
 	LastActivityAt time.Time
+	// Fleet-divergence signals — see the matching AgentSummary fields.
+	ExpectedActive bool
+	CanOpenIssue   bool
+	CanOpenPR      bool
+	CanMerge       bool
+	Backend        string
+	Enabled        bool
 }
 
 // NewAgentSummary builds one AgentSummary from an agent's name, state, mode and
@@ -333,6 +373,12 @@ func NewAgentSummary(name, state, mode string, act AgentActivity) AgentSummary {
 		PausedBy:       act.PausedBy,
 		NeedsLogin:     act.NeedsLogin,
 		SessionMissing: act.SessionMissing,
+		ExpectedActive: act.ExpectedActive,
+		CanOpenIssue:   act.CanOpenIssue,
+		CanOpenPR:      act.CanOpenPR,
+		CanMerge:       act.CanMerge,
+		Backend:        act.Backend,
+		Enabled:        act.Enabled,
 	}
 	if !act.PausedAt.IsZero() {
 		as.PausedAt = act.PausedAt.UTC().Format(time.RFC3339)

--- a/src/pkg/hub/heartbeat_divergence_fields_test.go
+++ b/src/pkg/hub/heartbeat_divergence_fields_test.go
@@ -1,0 +1,94 @@
+package hub
+
+import (
+	"net/http"
+	"testing"
+)
+
+// storedAgents reaches the registry entry's Agents slice for a hive id.
+func storedAgents(t *testing.T, s *HubServer, id string) []AgentSummary {
+	t.Helper()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, h := range s.registry.Hives {
+		if h.ID == id {
+			return h.Agents
+		}
+	}
+	t.Fatalf("hive %q not in registry", id)
+	return nil
+}
+
+// The new fleet-divergence fields must survive handleHeartbeat: Backend is
+// sanitized like an identifier, and the boolean signals pass through unchanged.
+// A field that is silently dropped on receive is the classic wire-integration
+// miss this test exists to catch.
+func TestHeartbeatDivergenceFields_Stored(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	body := `{
+		"hive_id":"h1",
+		"agents":[
+			{"name":"scanner","state":"running","backend":"claude",
+			 "enabled":true,"expectedActive":true,
+			 "canOpenIssue":true,"canOpenPR":true,"canMerge":true},
+			{"name":"advisor","state":"running","backend":"copilot",
+			 "enabled":true,"expectedActive":false,
+			 "canOpenIssue":true,"canOpenPR":false,"canMerge":false}
+		]
+	}`
+	rec := postHeartbeat(t, s, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	agents := storedAgents(t, s, "h1")
+	if len(agents) != 2 {
+		t.Fatalf("stored %d agents, want 2", len(agents))
+	}
+	byName := map[string]AgentSummary{}
+	for _, a := range agents {
+		byName[a.Name] = a
+	}
+
+	sc := byName["scanner"]
+	if sc.Backend != "claude" {
+		t.Errorf("scanner backend = %q, want claude", sc.Backend)
+	}
+	if !sc.Enabled || !sc.ExpectedActive || !sc.CanOpenIssue || !sc.CanOpenPR || !sc.CanMerge {
+		t.Errorf("scanner divergence bools dropped: %+v", sc)
+	}
+
+	ad := byName["advisor"]
+	if ad.ExpectedActive || ad.CanOpenPR || ad.CanMerge {
+		t.Errorf("advisor false bools flipped: %+v", ad)
+	}
+	if !ad.CanOpenIssue || !ad.Enabled {
+		t.Errorf("advisor true bools dropped: %+v", ad)
+	}
+}
+
+// A malicious backend string must be sanitized like every other identifier
+// field on the agent row (no angle brackets / injection survives).
+func TestHeartbeatDivergenceFields_SanitizesBackend(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	body := `{"hive_id":"h1","agents":[
+		{"name":"scanner","state":"running","backend":"clau<script>de"}
+	]}`
+	rec := postHeartbeat(t, s, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	agents := storedAgents(t, s, "h1")
+	if len(agents) != 1 {
+		t.Fatalf("stored %d agents, want 1", len(agents))
+	}
+	if got := agents[0].Backend; got == "clau<script>de" {
+		t.Errorf("backend was not sanitized: %q", got)
+	}
+}

--- a/src/pkg/hub/quadrant_dashboard_test.go
+++ b/src/pkg/hub/quadrant_dashboard_test.go
@@ -93,7 +93,7 @@ func TestQuadrantSortsReachable(t *testing.T) {
 // empty. The row shape changed, so a v3 cache must be rejected.
 func TestQuadrantCacheVersionBumped(t *testing.T) {
 	html := dashScript(t)
-	if !strings.Contains(html, "var HIVES_CACHE_VERSION = 4;") {
+	if !strings.Contains(html, "var HIVES_CACHE_VERSION = 5;") {
 		t.Error("HIVES_CACHE_VERSION was not bumped — a cached v3 paint would render the Quadrant column empty")
 	}
 	// The fleet average must be cached WITH the rows, or a cached paint draws

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2882,6 +2882,17 @@ type MyHiveEntry struct {
 	InactiveAgents       int    `json:"inactiveAgents,omitempty"`
 	InactiveAgentsReason string `json:"inactiveAgentsReason,omitempty"`
 
+	// FleetRollup / AgentVerdicts carry the three-way divergence view — what the
+	// governor EXPECTS running, what is ACTUALLY running, and what is ABLE to
+	// fulfill its mission — computed on read from the per-agent heartbeat
+	// signals + this hive's blocker fields. FleetRollup is the per-spoke header
+	// ("expects N · M running · K able"); AgentVerdicts is the per-agent
+	// drill-down. Both stay nil for a hive with no reported agents. Computed on
+	// read (deriveAgentVerdict/rollupAgents) so the browser never re-derives the
+	// state machine and cannot drift from the Go rule.
+	FleetRollup   *agentFleetRollup  `json:"fleetRollup,omitempty"`
+	AgentVerdicts []AgentVerdictJSON `json:"agentVerdicts,omitempty"`
+
 	// URLUnreachable is true when this hive's PUBLIC dashboard URL failed to
 	// serve on the last several probes — the link in this very table is dead.
 	// Computed on read from the auth-audit loop's observations, so the browser
@@ -3336,6 +3347,25 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		if rep := evaluateInactiveAgents(result[i].Agents, queuedWork, journeyNow); rep.Count > 0 {
 			result[i].InactiveAgents = rep.Count
 			result[i].InactiveAgentsReason = rep.Reason
+		}
+
+		// Fleet-divergence view: derive the three-way picture (expected vs
+		// actual vs able) and the per-agent verdicts from the same per-agent
+		// heartbeat signals plus this hive's blocker fields. Derived on read so
+		// the browser never re-runs the state machine (shares classifyInactive‐
+		// Agent with the block above, so the two can never disagree).
+		if len(result[i].Agents) > 0 {
+			blockers := hiveBlockers{
+				GitHubAppRequired:       result[i].GitHubAppRequired,
+				GitHubAppPermIssue:      result[i].GitHubAppPermIssue,
+				GitHubAppState:          result[i].GitHubAppState,
+				RepoTargetMisconfigured: result[i].RepoTargetMisconfigured,
+				RepoTargetIssue:         result[i].RepoTargetIssue,
+				InferenceAuthError:      result[i].InferenceAuthError,
+			}
+			rollup := rollupAgents(result[i].Agents, blockers, queuedWork, journeyNow)
+			result[i].FleetRollup = &rollup
+			result[i].AgentVerdicts = buildAgentVerdicts(result[i].Agents, blockers, queuedWork, journeyNow)
 		}
 
 		// Sparkline history dominated this payload: at 42 hives the two series
@@ -12004,8 +12034,11 @@ const dashboardHTML = `<!DOCTYPE html>
        v2 cache would paint paused agents provenance-less until the poll.
        v4: rows carry quadrant, and the cache carries the fleet average that
        every kite is drawn against; a v3 cache would paint the new column empty
-       until the poll landed. */
-    var HIVES_CACHE_VERSION = 4;
+       until the poll landed.
+       v5: rows carry the fleet-divergence view (fleetRollup + agentVerdicts:
+       expected/actual/able per agent); a v4 cache would omit the new per-agent
+       drill-down until the first poll landed. */
+    var HIVES_CACHE_VERSION = 5;
     /* 10 minutes: long enough to cover a reload or a tab restore, short enough
        that a cached fleet is never wildly out of date before the poll lands. */
     var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -1428,6 +1428,11 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	// Unlinked page (not in nav, noindex) — direct-URL only. The CNCF End User
 	// reference-architecture draft, shareable without artifact permissions.
 	s.mux.HandleFunc("GET /cncf-reference-architecture", s.serveStatic("static/cncf-reference-architecture.html"))
+	// Fleet-divergence view. The HTML shell is inert (no data) and served
+	// unauthenticated like every other static page; all sensitive data comes
+	// from GET /api/saas/my-hives, which is requireAuth-gated. On a 401 the page
+	// redirects to the OAuth login (see static/my-hives.html).
+	s.mux.HandleFunc("GET /my-hives", s.serveStatic("static/my-hives.html"))
 	s.mux.HandleFunc("GET /{$}", s.serveStatic("static/index.html"))
 	// Open Graph preview image for shared links. Registered here rather than in
 	// registerOAuth because that function returns early when OAuth is
@@ -1697,6 +1702,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				payload.Agents[i].PausedBy = sanitizeHeartbeatField(payload.Agents[i].PausedBy)
 				payload.Agents[i].PausedReason = sanitizeProseField(payload.Agents[i].PausedReason)
 				payload.Agents[i].PausedAt = sanitizeField(payload.Agents[i].PausedAt)
+				// Fleet-divergence signals (#hub-fleet-view). Backend is a spoke-
+				// reported identifier (claude/copilot/gemini/…) and is sanitized
+				// like State/Mode. The remaining new signals — ExpectedActive,
+				// CanOpenIssue, CanOpenPR, CanMerge, Enabled — are bools with no
+				// injectable surface, so they pass through unchanged; they are
+				// acknowledged here so a future reader sees every new field was
+				// considered by the sanitize pass.
+				payload.Agents[i].Backend = sanitizeHeartbeatField(payload.Agents[i].Backend)
 			}
 			const maxAgents = 50
 			if len(payload.Agents) > maxAgents {

--- a/src/pkg/hub/spark_downsample_test.go
+++ b/src/pkg/hub/spark_downsample_test.go
@@ -145,7 +145,7 @@ func TestDashboardHivesCacheIsBoundedAndVersioned(t *testing.T) {
 		snippet string
 	}{
 		{"cache key", "var LS_HIVES_CACHE = 'hive-my-hives-cache';"},
-		{"schema version", "var HIVES_CACHE_VERSION = 4;"},
+		{"schema version", "var HIVES_CACHE_VERSION = 5;"},
 		{"named TTL constant", "var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;"},
 		{"named row cap", "var HIVES_CACHE_MAX_ROWS = 200;"},
 		{"version is enforced on read", "if (!c || c.version !== HIVES_CACHE_VERSION) return null;"},

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Fleet — Expected vs Actual vs Able</title>
+<style>
+  :root {
+    --bg: #0d1420; --panel: #131c2b; --line: #22304a; --ink: #d7e2f2;
+    --muted: #8ba0bd; --green: #3fb968; --amber: #e0a800; --red: #e5484d;
+    --gray: #5a6b84; --accent: #4a9eff; --chip: #17212d;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  header {
+    padding: 16px 22px; border-bottom: 1px solid var(--line);
+    display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+  }
+  header h1 { font-size: 18px; margin: 0; font-weight: 600; }
+  header .sub { color: var(--muted); font-size: 12px; }
+  .wrap { padding: 16px 22px; max-width: 1200px; }
+  .legend { display: flex; gap: 16px; flex-wrap: wrap; color: var(--muted); font-size: 12px; margin-bottom: 14px; }
+  .legend b { color: var(--ink); font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; }
+  thead th {
+    text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .04em;
+    color: var(--muted); font-weight: 600; padding: 8px 10px; border-bottom: 1px solid var(--line);
+  }
+  tbody td { padding: 9px 10px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+  tr.spoke { cursor: pointer; }
+  tr.spoke:hover { background: #16202f; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 7px; }
+  .dot.on { background: var(--green); }
+  .dot.off { background: var(--gray); }
+  .name { font-weight: 600; }
+  .chev { display: inline-block; width: 12px; color: var(--muted); transition: transform .1s; }
+  tr.spoke.open .chev { transform: rotate(90deg); }
+  .badge {
+    display: inline-block; padding: 1px 7px; border-radius: 10px; font-size: 11px;
+    background: var(--chip); border: 1px solid var(--line); color: var(--muted); white-space: nowrap;
+  }
+  .rollup { font-variant-numeric: tabular-nums; }
+  .rollup .n { font-weight: 700; color: var(--ink); }
+  .rollup .warn { color: var(--amber); }
+  .rollup .bad { color: var(--red); }
+  .rollup .sep { color: var(--muted); margin: 0 4px; }
+  .output { color: var(--muted); font-size: 12px; }
+  /* agent sub-rows */
+  tr.agent td { background: #101825; border-bottom: 1px solid #1a2537; font-size: 13px; }
+  tr.agent .aname { padding-left: 26px; font-weight: 500; }
+  .rs { display: inline-flex; align-items: center; gap: 6px; }
+  .rs .swatch { width: 8px; height: 8px; border-radius: 50%; }
+  .rs.working .swatch { background: var(--green); }
+  .rs.idle-at-prompt .swatch { background: var(--amber); }
+  .rs.stuck-at-login .swatch { background: var(--red); }
+  .rs.session-gone .swatch { background: var(--red); }
+  .rs.dead .swatch { background: var(--gray); }
+  .rs.quiet-by-design .swatch { background: transparent; border: 1px solid var(--green); }
+  .rs.unknown .swatch { background: var(--gray); }
+  .cap { display: inline-flex; align-items: center; gap: 6px; }
+  .cap .light { width: 9px; height: 9px; border-radius: 50%; }
+  .cap.green .light { background: var(--green); }
+  .cap.amber .light { background: var(--amber); }
+  .cap.red .light { background: var(--red); }
+  .cap.gray .light { background: var(--gray); }
+  .ticks { font-size: 11px; color: var(--muted); }
+  .tick.yes { color: var(--green); }
+  .tick.no { color: var(--red); }
+  .delta { font-size: 11px; font-weight: 600; padding: 1px 7px; border-radius: 10px; }
+  .delta.stuck { background: rgba(229,72,77,.15); color: var(--red); border: 1px solid rgba(229,72,77,.4); }
+  .delta.impotent { background: rgba(224,168,0,.15); color: var(--amber); border: 1px solid rgba(224,168,0,.4); }
+  .delta.quiet { color: var(--muted); }
+  .rel { color: var(--muted); font-size: 11px; }
+  .status-msg { padding: 40px 0; text-align: center; color: var(--muted); }
+  a.reload { color: var(--accent); text-decoration: none; }
+  [title] { cursor: help; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Fleet — Expected vs Actual vs Able</h1>
+  <span class="sub">what the governor expects running · what is actually running · what can fulfill its mission</span>
+</header>
+<div class="wrap">
+  <div class="legend">
+    <span><span class="dot on"></span><b>on</b> / <span class="dot off"></span>off</span>
+    <span><b>run-state:</b> working · idle · stuck-at-login · session-gone · dead · <span style="border:1px solid var(--green);border-radius:50%;display:inline-block;width:7px;height:7px"></span> quiet-by-design</span>
+    <span><b>capability:</b> <span style="color:var(--green)">green</span> able · <span style="color:var(--amber)">amber</span> partial · <span style="color:var(--red)">red</span> blocked · <span style="color:var(--gray)">gray</span> unknown</span>
+    <span><span class="delta stuck">STUCK</span> expected-on, not running · <span class="delta impotent">IMPOTENT</span> running, can't work</span>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th style="width:22px"></th>
+        <th>Hive</th>
+        <th>ACMM</th>
+        <th>Mode</th>
+        <th>Divergence (expects · running · able)</th>
+        <th>Output (90d)</th>
+      </tr>
+    </thead>
+    <tbody id="rows">
+      <tr><td colspan="6" class="status-msg" id="statusCell">Loading fleet…</td></tr>
+    </tbody>
+  </table>
+</div>
+<script>
+"use strict";
+// Inert shell: no data is baked in. Everything comes from the authenticated
+// API; a 401 means "not signed in" and redirects to the OAuth login.
+function esc(s) {
+  return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+  });
+}
+function relTime(iso) {
+  if (!iso) return "";
+  var t = Date.parse(iso);
+  if (isNaN(t)) return "";
+  var s = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (s < 60) return s + "s ago";
+  var m = Math.floor(s / 60); if (m < 60) return m + "m ago";
+  var h = Math.floor(m / 60); if (h < 24) return h + "h ago";
+  return Math.floor(h / 24) + "d ago";
+}
+function acmmBadge(lvl) { return '<span class="badge">L' + esc(lvl == null ? "?" : lvl) + '</span>'; }
+function modeBadge(m) { return '<span class="badge">' + esc(m || "—") + '</span>'; }
+
+function rollupHTML(r) {
+  if (!r) return '<span class="output">no agents reported</span>';
+  var exp = r.expected || 0, run = r.running || 0, able = r.able || 0;
+  var runCls = run < exp ? "warn" : "", ableCls = able < run ? "bad" : "";
+  var extra = "";
+  if (r.stuck) extra += ' <span class="delta stuck" title="expected active but not running">' + r.stuck + ' stuck</span>';
+  if (r.impotent) extra += ' <span class="delta impotent" title="running but unable to work">' + r.impotent + ' impotent</span>';
+  return '<span class="rollup">expects <span class="n">' + exp + '</span>' +
+    '<span class="sep">·</span><span class="n ' + runCls + '">' + run + '</span> running' +
+    '<span class="sep">·</span><span class="n ' + ableCls + '">' + able + '</span> able' + extra + '</span>';
+}
+function outputHTML(h) {
+  var m = h.prsMerged90d || 0, rej = h.prsRejected90d || 0, cve = h.cvesClosed || 0;
+  if (!m && !rej && !cve) return '<span class="output">—</span>';
+  return '<span class="output" title="hive-wide authored output, last 90 days">PRs merged ' + m +
+    ' · rejected ' + rej + ' · CVEs ' + cve + '</span>';
+}
+function toggleHTML(a) {
+  if (a.paused) {
+    var prov = [];
+    if (a.pausedBy || a.pausedTrigger) prov.push("by " + (a.pausedBy || a.pausedTrigger));
+    if (a.pausedAt) prov.push(relTime(a.pausedAt));
+    if (a.pausedReason) prov.push("— " + a.pausedReason);
+    return '<span class="badge" title="' + esc(prov.join(" ")) + '">paused</span>';
+  }
+  if (a.enabled) return '<span><span class="dot on"></span>on</span>';
+  return '<span><span class="dot off"></span>off</span>';
+}
+function runStateHTML(a) {
+  var rs = a.runState || "unknown";
+  var label = rs.replace(/-/g, " ");
+  var rel = a.lastActivityAt ? ' <span class="rel">' + esc(relTime(a.lastActivityAt)) + '</span>' : "";
+  return '<span class="rs ' + esc(rs) + '"><span class="swatch"></span>' + esc(label) + '</span>' + rel;
+}
+function capHTML(a) {
+  var tier = a.capabilityTier || "gray";
+  function tick(ok, lbl) { return '<span class="tick ' + (ok ? "yes" : "no") + '">' + (ok ? "✓" : "✗") + " " + lbl + "</span>"; }
+  var ticks = '<span class="ticks">' + tick(a.canOpenIssue, "issue") + " " +
+    tick(a.canOpenPR, "PR") + " " + tick(a.canMerge, "merge") + "</span>";
+  var t = a.blockedReason ? ' title="' + esc(a.blockedReason) + '"' : "";
+  return '<span class="cap ' + esc(tier) + '"' + t + '><span class="light"></span></span> ' + ticks;
+}
+function deltaHTML(a) {
+  if (a.stuck) return '<span class="delta stuck" title="expected active, not running">STUCK</span>';
+  if (a.impotent) return '<span class="delta impotent"' + (a.blockedReason ? ' title="' + esc(a.blockedReason) + '"' : "") + '>IMPOTENT' + (a.blockedReason ? ": " + esc(a.blockedReason) : "") + '</span>';
+  if (a.quietByDesign) return '<span class="delta quiet">quiet by design</span>';
+  return "";
+}
+
+function renderHives(hives) {
+  var tb = document.getElementById("rows");
+  tb.innerHTML = "";
+  if (!hives || !hives.length) {
+    tb.innerHTML = '<tr><td colspan="6" class="status-msg">No hives.</td></tr>';
+    return;
+  }
+  hives.forEach(function (h, idx) {
+    var online = h.online ? "on" : "off";
+    var tr = document.createElement("tr");
+    tr.className = "spoke";
+    tr.innerHTML =
+      '<td><span class="chev">▶</span></td>' +
+      '<td><span class="dot ' + online + '"></span><span class="name">' + esc(h.name || h.id) + '</span></td>' +
+      '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
+      '<td>' + modeBadge(h.governorMode) + '</td>' +
+      '<td>' + rollupHTML(h.fleetRollup) + '</td>' +
+      '<td>' + outputHTML(h) + '</td>';
+    tb.appendChild(tr);
+
+    var verdicts = h.agentVerdicts || [];
+    var subRows = [];
+    verdicts.forEach(function (a) {
+      var sub = document.createElement("tr");
+      sub.className = "agent";
+      sub.style.display = "none";
+      sub.innerHTML =
+        '<td></td>' +
+        '<td class="aname">' + esc(a.name) + (a.backend ? ' <span class="badge">' + esc(a.backend) + '</span>' : "") + '</td>' +
+        '<td>' + toggleHTML(a) + '</td>' +
+        '<td>' + runStateHTML(a) + '</td>' +
+        '<td>' + capHTML(a) + " " + deltaHTML(a) + '</td>' +
+        '<td></td>';
+      tb.appendChild(sub);
+      subRows.push(sub);
+    });
+    if (!verdicts.length) {
+      var empty = document.createElement("tr");
+      empty.className = "agent";
+      empty.style.display = "none";
+      empty.innerHTML = '<td></td><td class="aname" colspan="5"><span class="output">no per-agent detail reported (spoke may predate this view)</span></td>';
+      tb.appendChild(empty);
+      subRows.push(empty);
+    }
+    tr.addEventListener("click", function () {
+      var open = tr.classList.toggle("open");
+      subRows.forEach(function (s) { s.style.display = open ? "" : "none"; });
+    });
+  });
+}
+
+function load() {
+  fetch("/api/saas/my-hives", { credentials: "same-origin", headers: { "Accept": "application/json" } })
+    .then(function (r) {
+      if (r.status === 401) {
+        window.location.href = "/login?redirect=" + encodeURIComponent("/my-hives");
+        throw new Error("redirecting to login");
+      }
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      return r.json();
+    })
+    .then(function (d) { renderHives(d.hives || []); })
+    .catch(function (e) {
+      if (e && e.message === "redirecting to login") return;
+      var c = document.getElementById("statusCell");
+      if (c) c.innerHTML = "Failed to load: " + esc(e.message) + ' — <a class="reload" href="/my-hives">retry</a>';
+    });
+}
+load();
+setInterval(load, 30000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## The gap this closes

The hub could not show — at a glance — the divergence between **what the governor expects running**, **what is actually running**, and **what can actually fulfill its mission**. Reconciling those meant `kubectl exec` into each spoke, parsing `hive.yaml`, capturing per-UID tmux panes, reading pluk logs for login prompts, and querying GitHub by hand.

The heartbeat already carried the *actual-running* signals per agent (`state`/`needsLogin`/`sessionMissing`/`lastActivityAt`) — but the hub folded them into a single aggregate count and **never rendered them per-agent**. The *expected* and *able* legs were not on the wire at all.

## The three-way divergence

| Leg | Question | Source |
|---|---|---|
| **EXPECTED** | Should the governor be kicking this agent now? | `config.ExpectedActive` — governor's current mode + per-mode cadence, **shared with the dashboard's `offByCadence`** so they can never disagree |
| **ACTUAL** | Is the pane truly working? | reuses `classifyInactiveAgent` — the run-state machine is **not duplicated** |
| **ABLE** | Can it open issues / open PRs / merge PRs? | the exact ACMM gates `AuthorizePROpen`/`AuthorizeMerge` enforce, minus hive-level blockers + interactive login |

**Deltas made loud:** **STUCK** (expected active but not running), **IMPOTENT** (running but can't work), **quiet-by-design** (paused / expected-off — never a fault, provenance shown). Rolled up per spoke as *"expects N · M running · K able"*.

## Design principle: minimum on the wire, derive the rest

Only **six raw fields** are added to `AgentSummary` — `expectedActive`, `canOpenIssue`/`canOpenPR`/`canMerge`, `backend`, `enabled` — populated spoke-side in `agentActivityFor` at **both** heartbeat build sites and sanitized on receive (`backend` as an identifier; bools pass through). Every composite (run-state string, blocked reason, STUCK/IMPOTENT, rollup) is **derived hub-side** in a new `agent_capability.go`. Hive-level blockers (App perm, repo-target, inference-auth) already ride the row — they are not duplicated per-agent.

**Backward-compatible:** a spoke too old to send the six fields sends them all zero-valued, which reads as **UNKNOWN** — STUCK/IMPOTENT never fire on a legacy spoke, and its capability tier is gray.

## Surface

The authenticated **My-Hives** view. Its backend (`/api/saas/my-hives`) already computed the inactive-agent rollup; this attaches `fleetRollup` + `agentVerdicts` per row. Since `requireAuth` returns JSON 401 (can't gate HTML), the frontend is a **new inert `static/my-hives.html` shell** served unauthenticated at `GET /my-hives`; it fetches the auth-gated API and **redirects to OAuth login on 401**. Spoke rows expand to per-agent drill-down: toggle (on/off/paused + provenance), run-state badge, capability traffic-light with issue/PR/merge sub-ticks, and the STUCK/IMPOTENT delta callout. Per-spoke authored output (`PRsMerged90d`/rejected/CVEs, 90d) shown alongside, explicitly labeled hive-wide.

## What was reviewed and deliberately excluded

Only **Copilot/Claude-shaped** capability signals were in scope for per-agent capability; there is **no per-agent authored-output counter** (all agents author as one bot identity — output stays hive-wide). The `iss=/prs=` numbers are the governor's repo-queue view, not hive output, and are not surfaced as capability.

## Tests

- **config**: `ExpectedActive` across positive/paused/off/absent cadence, on-demand, and case-insensitive mode.
- **manager**: `AgentCapabilities` returns exactly the mode gates AND matches `AuthorizePROpen`/`AuthorizeMerge`; `EffectiveBackend` honors override.
- **hub**: `deriveAgentVerdict` across every run-state, each blocker, issues-only-is-able, paused/expected-off = quiet, and **legacy-zero-value never alarms**; `rollupAgents` counts; `buildAgentVerdicts` JSON shape.
- **wire**: a heartbeat round-trip asserting the new fields survive `handleHeartbeat` with `backend` sanitized.

## Files
- `src/pkg/config/expected_active.go` — shared expected-active helper
- `src/pkg/agent/manager.go` — `AgentCapabilities`/`EffectiveBackend` accessors
- `src/pkg/hub/heartbeat.go` — six new `AgentSummary`/`AgentActivity` fields
- `src/cmd/hive/main.go` — populate at both build sites
- `src/pkg/hub/server.go` — sanitize + `GET /my-hives` route
- `src/pkg/hub/agent_capability.go` — NEW derivation (reuses `classifyInactiveAgent`)
- `src/pkg/hub/saas.go` — `handleMyHives` enrichment + `MyHiveEntry` fields (HIVES_CACHE_VERSION→5)
- `src/pkg/hub/static/my-hives.html` — NEW authenticated view
- `src/pkg/dashboard/status_builder.go` — `offByCadence` routed through the shared resolver

gofmt clean; DCO-signed. Note: pre-existing v4 CI flakiness in beads/sandbox/hub suites is unrelated to this change.