### PR TITLE
fix(terminal): say when the terminal is scrolled back, not live (#4399)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -338,6 +338,17 @@ jobs:
         working-directory: .
         run: bash src/deploy/test_contribute_k8s_workload.sh
 
+      # #4399: the browser terminal must say when it is NOT showing live output.
+      # The fix is a tmux FORMAT STRING, and a malformed one does not fail — it
+      # renders as garbage or leaves the literal `#{?...}` on screen. So this
+      # sets it on a scratch tmux server and reads back what tmux actually
+      # renders, in both the live and scrolled-back states, and reproduces the
+      # reported "halt" (a copy-mode pane stops following output, and survives
+      # closing the browser). Skips cleanly where tmux is absent.
+      - name: Terminal scrollback legibility (#4399)
+        working-directory: .
+        run: bash src/deploy/test_terminal_scrollback_status.sh
+
       # #4408: `just contribute-move` relocates an already-registered
       # contributor identity to a new machine. The properties that matter are
       # not visible in the Justfile text — that the positional HIVE_HUB /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ### Fixed
 
+- The agent Terminal now says when it is showing scrollback rather than live output. Scrolling with the mouse wheel puts the pane into tmux copy-mode, which stops it following new output — and because that state lives on the server, closing and reopening the terminal returned to the same frozen view, so an idle-looking agent was indistinguishable from a stuck one. The status bar now reads `[live]` or `[SCROLLBACK - not following live output - press q to resume]`, and the clock beside it is labelled `now` so it is not mistaken for a timestamp of the content on screen ([#4399](https://github.com/kubestellar/hive/issues/4399)).
 - `DASHBOARD_AUTH_TOKEN` was documented as holding a Kubernetes secret *name*; it holds the token *value* itself. An operator following the old wording would have set their dashboard token to the literal name of the Secret ([#4427](https://github.com/kubestellar/hive/pull/4427)).
 
 ## 2026-08-21

--- a/src/deploy/test_terminal_scrollback_status.sh
+++ b/src/deploy/test_terminal_scrollback_status.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# The browser terminal must say when it is NOT showing live output (#4399).
+# Run: bash src/deploy/test_terminal_scrollback_status.sh
+#
+# WHY THIS RUNS REAL TMUX. The fix is a tmux FORMAT STRING, and a malformed one
+# does not fail — it renders as garbage, or renders the literal `#{?...}` text,
+# and the only way to find out is to look at a terminal. Asserting the string
+# appears in the source would pass on a format that displays nothing useful. So
+# this sets the option on a scratch tmux server and reads back what tmux
+# actually renders, in both pane states.
+#
+# What #4399 reported, and what each assertion below pins:
+#
+#   "No more output appeared for a few minutes ... Closing and re-opening the
+#    terminal exposed no more output."
+#     -> a pane in copy-mode STOPS following live output, and copy-mode is pane
+#        state on the SERVER, so reopening the browser re-attaches to a pane that
+#        is still frozen. Measured here, both halves.
+#
+#   "black-on-yellow text in the upper right ... contains some line position/
+#    counter information and, usually, a timestamp. It is not obvious which
+#    point in the terminal corresponds with that timestamp."
+#     -> the timestamp is tmux's DEFAULT status-right, a live WALL CLOCK. It
+#        corresponds to no line of content and never can. The fix labels it.
+#
+# Nothing here touches the operator's own tmux: a private socket under a
+# throwaway directory, killed on exit.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; [ $# -gt 1 ] && echo "        $2"; FAIL=$((FAIL + 1)); }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "=== terminal scrollback legibility (#4399) ==="
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "  SKIP: tmux not installed — this test renders a real status line"
+  exit 0
+fi
+
+# The format under test is read from the shipped sources, never restated here:
+# a copy would keep passing after the real one regressed.
+MANAGER="${ROOT}/src/pkg/agent/manager.go"
+ATTACH="${ROOT}/src/deploy/ttyd-tmux.sh"
+STATUS_FMT="$(sed -n 's/^\ttmuxStatusRight = "\(.*\)"$/\1/p' "$MANAGER" | head -1)"
+if [ -z "$STATUS_FMT" ]; then
+  fail "extract tmuxStatusRight from manager.go" "the anchor moved — this test cannot verify the real format"
+  echo ""
+  echo "=== Results: $PASS passed, $FAIL failed ==="
+  exit 1
+fi
+pass "status format extracted from src/pkg/agent/manager.go (not restated here)"
+
+# The attach path must carry the SAME format, or a session created before the
+# manager change gets a different terminal than one created after.
+if grep -qF -- "$STATUS_FMT" "$ATTACH"; then
+  pass "src/deploy/ttyd-tmux.sh applies the identical format on attach"
+else
+  fail "src/deploy/ttyd-tmux.sh applies the identical format on attach" \
+       "the manager and the attach path have drifted"
+fi
+
+WORK="$(mktemp -d)"
+SOCK="${WORK}/sock"
+cleanup() { tmux -S "$SOCK" kill-server 2>/dev/null; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# -f /dev/null: ignore the developer's own ~/.tmux.conf so this measures the
+# shipped format and not their customisations.
+tmux -S "$SOCK" -f /dev/null new-session -d -s t -x 80 -y 10 \
+  'i=0; while :; do i=$((i+1)); echo "line $i"; sleep 0.2; done' 2>/dev/null
+if ! tmux -S "$SOCK" has-session -t t 2>/dev/null; then
+  fail "start a scratch tmux session" "cannot verify without one"
+  echo ""
+  echo "=== Results: $PASS passed, $FAIL failed ==="
+  exit 1
+fi
+tmux -S "$SOCK" set-option -g status-right "$STATUS_FMT" 2>/dev/null
+
+render() { tmux -S "$SOCK" display-message -p -t t "$STATUS_FMT" 2>/dev/null; }
+
+# --- live pane ---------------------------------------------------------------
+sleep 1
+LIVE="$(render)"
+echo "     live pane renders:      '${LIVE}'"
+if [ -z "$LIVE" ]; then
+  fail "the format renders at all when live"
+elif printf '%s' "$LIVE" | grep -q '#{'; then
+  fail "the format is well-formed" "unexpanded tmux format left in the output: ${LIVE}"
+else
+  pass "the format is well-formed and renders when live"
+fi
+printf '%s' "$LIVE" | grep -qi "live" \
+  && pass "a live pane says so" \
+  || fail "a live pane says so" "got: ${LIVE}"
+printf '%s' "$LIVE" | grep -qiE "scrollback" \
+  && fail "a live pane must NOT claim to be scrollback" "got: ${LIVE}" \
+  || pass "a live pane does not claim to be scrollback"
+# The clock is labelled, so it cannot be read as a timestamp OF THE CONTENT.
+printf '%s' "$LIVE" | grep -qi "now" \
+  && pass "the wall clock is labelled 'now', not left to read as a content timestamp" \
+  || fail "the wall clock is labelled" "got: ${LIVE}"
+
+# --- scrolled-back pane ------------------------------------------------------
+tmux -S "$SOCK" copy-mode -t t 2>/dev/null
+tmux -S "$SOCK" send-keys -t t -X scroll-up 2>/dev/null
+IN_MODE="$(tmux -S "$SOCK" display-message -p -t t '#{pane_in_mode}' 2>/dev/null)"
+[ "$IN_MODE" = "1" ] && pass "the mouse wheel's copy-mode is reachable and detectable" \
+  || fail "pane reports copy-mode" "pane_in_mode=${IN_MODE}"
+
+SCROLLED="$(render)"
+echo "     scrolled-back renders:  '${SCROLLED}'"
+printf '%s' "$SCROLLED" | grep -qi "scrollback" \
+  && pass "a scrolled-back pane SAYS it is scrollback" \
+  || fail "a scrolled-back pane says it is scrollback" "got: ${SCROLLED}"
+printf '%s' "$SCROLLED" | grep -qi "not following live" \
+  && pass "and says the consequence — output is not being followed" \
+  || fail "says output is not being followed" "got: ${SCROLLED}"
+printf '%s' "$SCROLLED" | grep -qi "q to resume" \
+  && pass "and says how to get back to live" \
+  || fail "says how to get back" "got: ${SCROLLED}"
+[ "$LIVE" != "$SCROLLED" ] \
+  && pass "the two states are visibly different" \
+  || fail "the two states are visibly different" "both rendered: ${LIVE}"
+
+# --- the reported symptom, reproduced ----------------------------------------
+# This is the part that made the terminal look broken: a frozen pane, which
+# survives closing and reopening the browser.
+BEFORE="$(tmux -S "$SOCK" capture-pane -p -t t 2>/dev/null | tail -1)"
+sleep 2
+AFTER="$(tmux -S "$SOCK" capture-pane -p -t t 2>/dev/null | tail -1)"
+[ "$BEFORE" = "$AFTER" ] \
+  && pass "a scrolled-back pane genuinely stops following live output (the reported 'halt')" \
+  || fail "expected the pane to stop following output while in copy-mode"
+
+tmux -S "$SOCK" detach-client -s t 2>/dev/null
+STILL="$(tmux -S "$SOCK" display-message -p -t t '#{pane_in_mode}' 2>/dev/null)"
+[ "$STILL" = "1" ] \
+  && pass "copy-mode survives detach — reopening the browser does NOT clear it (#4399's 're-opening exposed no more output')" \
+  || fail "copy-mode should survive a detach" "pane_in_mode=${STILL}"
+
+# Leaving copy-mode resumes following, which is what the status line now tells
+# the operator to do.
+tmux -S "$SOCK" send-keys -t t -X cancel 2>/dev/null
+LEFT="$(tmux -S "$SOCK" display-message -p -t t '#{pane_in_mode}' 2>/dev/null)"
+[ "$LEFT" = "0" ] \
+  && pass "leaving copy-mode clears the scrollback state" \
+  || fail "leaving copy-mode should clear it" "pane_in_mode=${LEFT}"
+# Compare the whole visible pane, not just the last line: a pane's tail is
+# usually blank padding, so tail -1 can be equal in both samples while the
+# content above it is advancing.
+R1="$(tmux -S "$SOCK" capture-pane -p -t t 2>/dev/null | grep . | tail -1)"
+sleep 2
+R2="$(tmux -S "$SOCK" capture-pane -p -t t 2>/dev/null | grep . | tail -1)"
+[ -n "$R2" ] && [ "$R1" != "$R2" ] \
+  && pass "leaving copy-mode resumes live output (the advice the status line gives is correct)" \
+  || fail "leaving copy-mode should resume live output" "before='${R1}' after='${R2}'"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/src/deploy/ttyd-tmux.sh
+++ b/src/deploy/ttyd-tmux.sh
@@ -58,20 +58,57 @@ CURRENT_UID=$(id -u)
 # HIVE_TTYD_HISTORY_LIMIT overrides the scrollback depth applied on attach.
 TTYD_HISTORY_LIMIT="${HIVE_TTYD_HISTORY_LIMIT:-50000}"
 
+# Scrollback state legibility (issue #4399). Two things sit in the top-right of
+# this terminal and neither says what it is:
+#
+#   * tmux's DEFAULT status-right is a live WALL CLOCK. An operator read it as a
+#     timestamp OF THE CONTENT and tried to line it up with the scrollback,
+#     which can never work — it is simply the time now.
+#   * copy-mode draws a black-on-yellow [position/total] counter, which is the
+#     only hint that the pane is scrolled back and reads like a line counter
+#     rather than a warning.
+#
+# copy-mode is the state that matters: while a pane is in it the pane STOPS
+# FOLLOWING LIVE OUTPUT, and because the mouse mode above puts the wheel into
+# copy-mode, an operator gets there by scrolling. copy-mode is PANE state on the
+# server, so closing the browser tab and reopening it re-attaches to a pane that
+# is still frozen — the exact "no more output, and reopening showed no more
+# output" report in #4399.
+#
+# The authoritative setting is applied at SESSION creation by the agent manager
+# (newSessionCommands in src/pkg/agent/manager.go). This attach-time set is the
+# same defense in depth as the history-limit raise above: it reaches sessions
+# created before that change, or outside the manager. Saved and restored around
+# the attach so an agent CLI that manages its own status line is not permanently
+# altered.
+TTYD_STATUS_RIGHT="${HIVE_TTYD_STATUS_RIGHT:-#{?pane_in_mode,[SCROLLBACK - not following live output - press q to resume] ,[live] }now %H:%M:%S }"
+TTYD_STATUS_INTERVAL="${HIVE_TTYD_STATUS_INTERVAL:-2}"
+
 # attach_with runs the attach lifecycle. $1 is an optional command prefix
 # (e.g. "su-exec <spec>") so the same logic serves both the owner and non-owner
 # paths without duplication.
 attach_with() {
   local run=("$@")
   local prev_mouse prev_history exit_code=0
+  local prev_status prev_interval
   prev_mouse=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
   prev_history=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -gv history-limit 2>/dev/null || echo "")
+  prev_status=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -gv status-right 2>/dev/null || echo "")
+  prev_interval=$("${run[@]}" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -gv status-interval 2>/dev/null || echo "")
   "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse on 2>/dev/null || true
   "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" history-limit "$TTYD_HISTORY_LIMIT" 2>/dev/null || true
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -gt "$SESSION" status-right "$TTYD_STATUS_RIGHT" 2>/dev/null || true
+  "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -gt "$SESSION" status-interval "$TTYD_STATUS_INTERVAL" 2>/dev/null || true
   "${run[@]}" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || exit_code=$?
   "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$prev_mouse" 2>/dev/null || true
   if [ -n "$prev_history" ]; then
     "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" history-limit "$prev_history" 2>/dev/null || true
+  fi
+  if [ -n "$prev_status" ]; then
+    "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -gt "$SESSION" status-right "$prev_status" 2>/dev/null || true
+  fi
+  if [ -n "$prev_interval" ]; then
+    "${run[@]}" tmux -S "$TMUX_SOCKET" set-option -gt "$SESSION" status-interval "$prev_interval" 2>/dev/null || true
   fi
   return "$exit_code"
 }

--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -118,6 +118,25 @@ Liveness is judged by the governor's in-process health check, so an agent that k
 1. **Read the work counts, not just liveness.** If an agent reports "Issues triaged: 0" cycle after cycle in the logs, that is the signal — `kubectl -n hive logs deploy/hive | grep <agent>` or attach to the session.
 2. **Cross-check an external surface.** Confirm the effect the agent is supposed to produce (a GitHub API query for the PRs/issues it claims to have handled) rather than trusting its self-reported state.
 
+## The terminal looks frozen — no new output, and reopening it doesn't help
+
+You are almost certainly **scrolled back**, not looking at a halted agent.
+
+The browser terminal is a live `tmux` attach, and the mouse wheel scrolls by entering tmux's copy-mode. **While a pane is in copy-mode it stops following live output.** Copy-mode is state held by the tmux server, not the browser, so closing the tab and reopening it re-attaches to the same scrolled-back pane and still shows nothing new — which is what makes it look like the agent died.
+
+Look at the right-hand end of the status bar:
+
+```
+[SCROLLBACK - not following live output - press q to resume]   now 14:22:07
+[live]                                                          now 14:22:07
+```
+
+Press **`q`** (or `Esc`) to leave copy-mode and resume following output.
+
+**The timestamp there is a clock, not a content timestamp.** It is the time *now*, which is why it never lines up with any particular line of scrollback. The black-on-yellow `[12/4837]` box in the top-right corner is tmux's copy-mode **scroll position**, not a line timestamp either.
+
+If the status bar shows `[live]` and output really has stopped, the agent is idle between kicks — check its next scheduled run on the dashboard before assuming a fault.
+
 ## An agent runs, but not the way I expect — why did it do that?
 
 Agents are told to act, not narrate: every policy carries an "Output Rules —

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -106,6 +106,42 @@ const (
 	// whenever -x is given, so it is pinned here rather than left to the 24-row
 	// default.
 	defaultTmuxPaneHeight = 50
+
+	// tmuxStatusRight is the status line agent tmux sessions carry (#4399).
+	//
+	// THE PROBLEM IT SOLVES. Two things sat in the top-right of the browser
+	// terminal and neither said what it was:
+	//
+	//   * tmux's DEFAULT status-right is a live WALL CLOCK
+	//     (`"#{=21:pane_title}" %H:%M %d-%b-%y`). An operator reasonably read it
+	//     as a timestamp OF THE CONTENT and tried to line it up with the
+	//     scrollback — which can never work, because it is simply the time now.
+	//   * copy-mode draws a black-on-yellow `[position/total]` counter (tmux's
+	//     `mode-style bg=yellow,fg=black`). That is the only on-screen hint that
+	//     the pane is scrolled back, and it looks like a line counter, not a
+	//     warning.
+	//
+	// And copy-mode is the important state: while a pane is in it the pane
+	// STOPS FOLLOWING LIVE OUTPUT. #3694 deliberately turned mouse mode on so
+	// the wheel scrolls history, which means an operator reaches that state by
+	// doing the most natural thing in a terminal. Worse, copy-mode is PANE
+	// state held by the tmux server, so closing the browser tab and reopening
+	// it re-attaches to a pane that is still frozen — exactly the "no more
+	// output appeared, and reopening showed no more output" report in #4399.
+	//
+	// So: say which state the pane is in, and label the clock as the current
+	// time rather than leaving it to be misread as a content timestamp.
+	// Deliberately plain ASCII with no `#[...]` style blocks — style specs are
+	// comma-separated and a comma inside a `#{?...}` branch has to be escaped,
+	// which is exactly the kind of format-string subtlety that renders as
+	// garbage instead of failing loudly.
+	tmuxStatusRight = "#{?pane_in_mode,[SCROLLBACK - not following live output - press q to resume] ,[live] }now %H:%M:%S "
+
+	// tmuxStatusInterval is how often (seconds) tmux redraws the status line.
+	// tmux's default is 15s, which would leave the SCROLLBACK marker above up
+	// to 15 seconds stale — long enough for an operator to scroll, see nothing
+	// change, and conclude the terminal is broken.
+	tmuxStatusInterval = 2
 )
 
 var defaultTmuxSocket string
@@ -1230,6 +1266,14 @@ func tmuxPaneWidth() int {
 func newSessionCommands(session, dir string) []string {
 	return []string{
 		"set-option", "-g", "history-limit", strconv.Itoa(tmuxHistoryLimit()), ";",
+		// #4399: set the status line BEFORE new-session so the pane carries it
+		// from its first frame. Global (-g) rather than per-session because each
+		// agent runs on its own tmux socket under its own UID
+		// (/tmp/tmux-2007/hive-scanner), so "global" is scoped to that one
+		// agent's server — and a global set also reaches panes created later in
+		// the session, which a per-session set would not.
+		"set-option", "-g", "status-right", tmuxStatusRight, ";",
+		"set-option", "-g", "status-interval", strconv.Itoa(tmuxStatusInterval), ";",
 		"new-session", "-d", "-s", session, "-c", dir,
 		"-x", strconv.Itoa(tmuxPaneWidth()), "-y", strconv.Itoa(defaultTmuxPaneHeight),
 	}


### PR DESCRIPTION
Addresses #4399. Not marked as closing it — the third report in that issue is a scheduling question, not a terminal one, and is called out below rather than swept in.

## The terminal wasn't halted. It was scrolled back.

@MikeSpreitzer reported two things that turn out to be the same root cause, and it's measurable rather than a matter of taste.

> No more output appeared for a few minutes ... Closing and re-opening the terminal exposed no more output.

The browser terminal is a live `tmux` attach. #3694 deliberately turned mouse mode **on** so the wheel scrolls history — and the wheel scrolls by entering tmux's **copy-mode**. While a pane is in copy-mode it **stops following live output**. Measured:

```
in copy-mode: pane_in_mode=1
visible tail now:      line 7
visible tail 3s later: line 7      >>> pane STOPPED following live output
```

And copy-mode is **pane state on the tmux server**, not browser state — so closing the tab and reopening re-attaches to the same frozen pane, which is exactly why reopening exposed no more output:

```
after detach + reattach, still in copy-mode: 1
```

> black-on-yellow text in the upper right ... line position/counter information and, usually, a timestamp. It is not obvious which point in the terminal corresponds with that timestamp.

Because it corresponds to none of them, and never can. Two unrelated things sit adjacent in that corner and neither says what it is. Measured on the stock config:

```
status-right  "#{?window_bigger,...}\"#{=21:pane_title}\" %H:%M %d-%b-%y"   ← a WALL CLOCK: the time now
mode-style    noattr,bg=yellow,fg=black                                     ← the black-on-yellow box: SCROLL POSITION
```

This repo ships **no tmux status configuration at all**, so operators were seeing tmux's stock status line. The clock is the time *now*; it can't line up with any line of scrollback.

## The fix

Agent sessions now carry a status line that names the state:

```
[live]                                                        now 14:22:07
[SCROLLBACK - not following live output - press q to resume]   now 14:22:07
```

That answers both reports: a frozen pane announces itself and says how to resume, and the clock is labelled `now` so it isn't read as a timestamp of the content.

Applied at **session creation** (`newSessionCommands`) so a pane carries it from its first frame, and again at **attach** (`ttyd-tmux.sh`) with save/restore — the same defense-in-depth split the existing `history-limit` raise uses, so sessions created before this change or outside the manager get it too, and an agent CLI managing its own status line isn't permanently altered. `status-interval` drops to 2s; tmux's 15s default would leave the SCROLLBACK marker stale long enough for someone to scroll, see nothing change, and conclude it's broken.

The format is deliberately plain ASCII with no `#[...]` style blocks — style specs are comma-separated and a comma inside a `#{?...}` branch needs escaping, which is exactly the subtlety that renders as garbage instead of failing loudly.

## Tested against real tmux, not by grepping the source

A malformed tmux format **does not fail** — it renders wrong, or leaves the literal `#{?...}` on screen. Asserting the string exists in the source would pass on a format that displays nothing useful. So the test sets it on a scratch tmux server and reads back what tmux actually renders:

```
live pane renders:      '[live] now 09:58:51 '
scrolled-back renders:  '[SCROLLBACK - not following live output - press q to resume] now 09:58:51 '
```

**15 assertions**, including reproducing the reported symptom end to end — a copy-mode pane stops advancing, stays in copy-mode across a detach, and resumes when copy-mode is left. The format is **extracted from `manager.go`** rather than restated, and the test asserts `ttyd-tmux.sh` carries the identical string, so the two paths cannot drift. Skips cleanly where tmux is absent; wired into `v2-ci.yml`.

Also adds the troubleshooting entry someone hitting this would actually search for ("The terminal looks frozen — no new output, and reopening it doesn't help"), including that the yellow box is a scroll position and the timestamp is a clock.

`go build ./...`, `go vet`, `gofmt` and the `pkg/agent` session tests all clean, run with the repo's own pinned toolchain.

## Not addressed here — worth its own issue

> the quality agent ... doing some work at 01:47 on Aug 21 ... the dashboard section for that agent said its last run was 8/20 8:12 PM EDT and its next run would be 8/21 2:12 AM EDT.

That's a scheduling/cadence question, not terminal rendering. It needs its own investigation (what triggered the run, and whether the dashboard's "next run" is computed from the same source the scheduler uses), and bolting it onto a display fix would give it neither the right reviewer nor the right test. Happy to open it as a separate issue if you'd like — @MikeSpreitzer, the answer may also be simpler than it looks if something other than the cadence timer kicked that agent.

— hive: backend=claude model=claude-opus-5
