### PR TITLE
fix(ci): changelog reminder must not fail a fork PR (#4440)

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -14,6 +14,16 @@ name: Changelog Reminder
 # dependency churn, so a hard gate would fail honest work and train people to
 # ignore it — or worse, to add noise entries just to make it green. It comments
 # once and always succeeds; the judgement stays with the author.
+#
+# "Always succeeds" is load-bearing and was not true (#4440): on a fork PR the
+# comment POST 403s, because GitHub caps GITHUB_TOKEN at read-only for
+# `pull_request` events from forks whatever the permissions: block requests, and
+# `bash -e` turned that into a red check on every external contribution. The
+# reminder is now delivered as a JOB SUMMARY and a ::notice:: annotation, which
+# need no write permission and therefore reach forks and same-repo branches
+# alike; the PR comment is attempted on top of that and its failure is
+# tolerated. src/deploy/test_changelog_reminder.sh executes the real step script
+# against a stubbed `gh` that 403s and asserts it still exits 0.
 
 on:
   pull_request:
@@ -64,16 +74,25 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          set -euo pipefail
+          # NOT `set -e` (#4440). This step delivers a REMINDER, and the header
+          # above promises it "always succeeds" and "never blocks a merge". It
+          # did neither on a pull request from a FORK: GitHub caps GITHUB_TOKEN
+          # at read-only for `pull_request` events raised from forks, whatever
+          # the permissions: block asks for, so the comment POST answered
+          #
+          #   gh: Resource not accessible by integration (HTTP 403)
+          #
+          # and `shell: bash -e` turned that into a failed check. The result was
+          # the exact thing the header set out to avoid — an advisory reminder
+          # behaving as a gate — on every external contribution, which is the
+          # population least likely to know the convention and most in need of
+          # the nudge. They got a red check and no reminder.
+          set -uo pipefail
+
           marker='<!-- changelog-reminder -->'
-          # Only ever comment once per PR. A reminder that reappears on every
-          # push is noise, and noise is how the previous convention died.
-          if gh api --paginate "repos/$REPO/issues/$PR/comments" --jq '.[].body' \
-              | grep -qF "$marker"; then
-            echo "already reminded"
-            exit 0
-          fi
+
           # Body built in a heredoc rather than inline: the text starts a line
           # with '**', which YAML would read as an alias in a plain scalar.
           body_file="$(mktemp)"
@@ -91,4 +110,39 @@ jobs:
           EOF
           # Strip the YAML block indentation the heredoc preserved.
           sed -i 's/^          //' "$body_file"
-          gh api "repos/$REPO/issues/$PR/comments" -F body=@"$body_file"
+
+          # DELIVER IT SOMEWHERE THAT ALWAYS WORKS, FIRST. The job summary and a
+          # ::notice:: annotation need no write permission at all, so they reach
+          # fork PRs and same-repo branches identically. This is the delivery the
+          # reminder can actually rely on; the PR comment below is a nicety on
+          # top of it.
+          {
+            printf '### Changelog reminder\n\n'
+            grep -v "^${marker}$" "$body_file"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          echo "::notice title=Changelog reminder::This PR changes code but does not touch CHANGELOG.md. If it is user-visible, please add a line under '## Unreleased'. Not a gate."
+
+          # A fork PR cannot post, so do not try: a 403 in the log invites the
+          # next reader to debug a permission that is working as designed.
+          if [ "${IS_FORK:-false}" = "true" ]; then
+            echo "fork PR — GITHUB_TOKEN is read-only here, so the reminder was delivered as a job summary and annotation instead of a comment"
+            exit 0
+          fi
+
+          # Same-repo PR: a comment is nicer, and only ever once. A reminder that
+          # reappears on every push is noise, and noise is how the previous
+          # convention died. A failed dedupe READ must not skip the comment, and
+          # must not fail the job either.
+          if gh api --paginate "repos/$REPO/issues/$PR/comments" --jq '.[].body' 2>/dev/null \
+              | grep -qF "$marker"; then
+            echo "already reminded"
+            exit 0
+          fi
+
+          # Tolerated, not asserted. Even on a same-repo PR an org policy can
+          # narrow GITHUB_TOKEN, and the reminder has already been delivered
+          # above either way.
+          if ! gh api "repos/$REPO/issues/$PR/comments" -F body=@"$body_file"; then
+            echo "::notice::could not post the reminder as a PR comment; it is in this job's summary instead"
+          fi
+          exit 0

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -6,13 +6,13 @@ on:
     # bin/** is in scope because the gh wrapper is a SECURITY boundary (it is the
     # merge gate behind the proxy hard-deny) and previously matched no path
     # filter at all — a change to it triggered no CI whatsoever.
-    paths: ['src/**', 'bin/**', '.github/workflows/v2-ci.yml']
+    paths: ['src/**', 'bin/**', '.github/workflows/v2-ci.yml', '.github/workflows/changelog-reminder.yml']
   pull_request:
     branches: [v2, v4]
     # bin/** is in scope because the gh wrapper is a SECURITY boundary (it is the
     # merge gate behind the proxy hard-deny) and previously matched no path
     # filter at all — a change to it triggered no CI whatsoever.
-    paths: ['src/**', 'bin/**', '.github/workflows/v2-ci.yml']
+    paths: ['src/**', 'bin/**', '.github/workflows/v2-ci.yml', '.github/workflows/changelog-reminder.yml']
 
 permissions:
   contents: read
@@ -348,6 +348,17 @@ jobs:
       - name: Terminal scrollback legibility (#4399)
         working-directory: .
         run: bash src/deploy/test_terminal_scrollback_status.sh
+
+      # #4440: the changelog reminder promises it "always succeeds" and "never
+      # blocks a merge", and it did neither on a fork PR — GITHUB_TOKEN is
+      # read-only there, the comment POST 403s, and `bash -e` made that a red
+      # check on every external contribution. This EXTRACTS the real step script
+      # out of the workflow and runs it against a stub gh that 403s, because the
+      # bug was an exit status and a grep over the YAML would pass on a script
+      # that still dies on the first non-zero command.
+      - name: Changelog reminder never blocks a merge (#4440)
+        working-directory: .
+        run: bash src/deploy/test_changelog_reminder.sh
 
       # #4408: `just contribute-move` relocates an already-registered
       # contributor identity to a new machine. The properties that matter are

--- a/src/deploy/test_changelog_reminder.sh
+++ b/src/deploy/test_changelog_reminder.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# The changelog reminder must never fail a PR (#4440).
+# Run: bash src/deploy/test_changelog_reminder.sh
+#
+# WHY THIS EXECUTES THE STEP RATHER THAN GREPPING IT. The bug was not a missing
+# line, it was an exit status: `gh api ... comments` answered
+# `Resource not accessible by integration (HTTP 403)` on every fork PR, and
+# `shell: bash -e` turned that into a red check. A grep over the YAML would
+# happily pass on a script that still dies on the first non-zero command. So
+# this EXTRACTS the real `run:` block out of the workflow and runs it, with a
+# stub `gh` that fails exactly the way GitHub does.
+#
+# The workflow's own header makes two promises — "it comments once and always
+# succeeds" and "it never blocks a merge". Each case below is one of those
+# promises, checked against the shipped script.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; [ $# -gt 1 ] && echo "        $2"; FAIL=$((FAIL + 1)); }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WF="${ROOT}/.github/workflows/changelog-reminder.yml"
+
+echo "=== changelog reminder never blocks a merge (#4440) ==="
+
+if [ ! -f "$WF" ]; then
+  fail "the workflow exists" "not found at $WF"
+  echo ""; echo "=== Results: $PASS passed, $FAIL failed ==="; exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "  SKIP: python3 + PyYAML unavailable — cannot extract the step script"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# THE SCRIPT UNDER TEST IS THE SHIPPED ONE. Extracted from the workflow, never
+# restated here — a copy would keep passing after the real step regressed, which
+# is the failure mode this repo keeps hitting.
+if ! python3 - "$WF" >"${WORK}/step.sh" <<'PY'
+import sys, yaml
+wf = yaml.safe_load(open(sys.argv[1]))
+steps = wf["jobs"]["remind"]["steps"]
+for s in steps:
+    if s.get("name") == "Remind once":
+        sys.stdout.write(s["run"])
+        sys.exit(0)
+sys.exit(1)
+PY
+then
+  fail "extract the 'Remind once' step from the workflow" "the step name or job id moved"
+  echo ""; echo "=== Results: $PASS passed, $FAIL failed ==="; exit 1
+fi
+pass "the 'Remind once' script was extracted from the workflow (not restated here)"
+
+STUB="${WORK}/bin"; mkdir -p "$STUB"
+
+# A stub gh that reproduces GitHub's fork behaviour: reads succeed, writes 403.
+make_gh() { # $1 = post behaviour: forbidden | ok
+  cat >"${STUB}/gh" <<SH
+#!/usr/bin/env bash
+printf 'gh %s\n' "\$*" >>"${WORK}/gh-calls.log"
+# A POST is any invocation carrying -F (the body upload).
+for a in "\$@"; do
+  if [ "\$a" = "-F" ]; then
+    if [ "$1" = "forbidden" ]; then
+      echo 'gh: Resource not accessible by integration (HTTP 403)' >&2
+      exit 1
+    fi
+    echo '{"id":1}'
+    exit 0
+  fi
+done
+# Reads: return no existing comments so the dedupe does not short-circuit.
+exit 0
+SH
+  chmod +x "${STUB}/gh"
+}
+
+run_step() { # $1 = IS_FORK value
+  : >"${WORK}/gh-calls.log"
+  : >"${WORK}/summary.md"
+  OUT="$(cd "$WORK" && env PATH="${STUB}:${PATH}" \
+    GH_TOKEN=stub PR=4439 REPO=kubestellar/hive IS_FORK="$1" \
+    GITHUB_STEP_SUMMARY="${WORK}/summary.md" \
+    bash "${WORK}/step.sh" 2>&1)"
+  RC=$?
+  SUMMARY="$(cat "${WORK}/summary.md" 2>/dev/null)"
+  CALLS="$(cat "${WORK}/gh-calls.log" 2>/dev/null)"
+}
+
+# --- the bug: a fork PR must not fail ------------------------------------------
+echo ""
+echo "-- fork PR (GITHUB_TOKEN is read-only: the #4440 case) --"
+make_gh forbidden
+run_step true
+[ "$RC" -eq 0 ] && pass "exits 0 — the check does not block the merge" \
+                || fail "exits 0" "rc=$RC, output: $OUT"
+printf '%s' "$SUMMARY" | grep -q "Changelog reminder" \
+  && pass "the reminder IS delivered, as a job summary" \
+  || fail "the reminder is delivered as a job summary" "summary was: '${SUMMARY}'"
+printf '%s' "$SUMMARY" | grep -q "CHANGELOG.md" \
+  && pass "the summary carries the actual advice" \
+  || fail "the summary carries the advice" "got: '${SUMMARY}'"
+printf '%s' "$OUT" | grep -q "::notice title=Changelog reminder::" \
+  && pass "and as a check annotation" \
+  || fail "emits a ::notice:: annotation" "got: $OUT"
+printf '%s' "$CALLS" | grep -q '\-F' \
+  && fail "a fork PR must not attempt the POST" "it called: $CALLS" \
+  || pass "no doomed POST attempted — no misleading 403 in the log"
+printf '%s' "$SUMMARY" | grep -q '<!-- changelog-reminder -->' \
+  && fail "the HTML dedupe marker must not leak into the summary" "got: '${SUMMARY}'" \
+  || pass "the HTML dedupe marker is kept out of the summary"
+
+# --- same-repo PR: still comments ----------------------------------------------
+echo ""
+echo "-- same-repo PR (token can write) --"
+make_gh ok
+run_step false
+[ "$RC" -eq 0 ] && pass "exits 0" || fail "exits 0" "rc=$RC"
+printf '%s' "$CALLS" | grep -q '\-F' \
+  && pass "still posts the PR comment where it can" \
+  || fail "posts the PR comment on a same-repo PR" "calls: $CALLS"
+printf '%s' "$SUMMARY" | grep -q "Changelog reminder" \
+  && pass "and still writes the summary, so both surfaces agree" \
+  || fail "writes the summary too"
+
+# --- same-repo PR where the POST fails anyway ----------------------------------
+# An org policy can narrow GITHUB_TOKEN even on a same-repo PR. The reminder has
+# already been delivered by then, so a failed POST must still not fail the job.
+echo ""
+echo "-- same-repo PR, POST refused by policy --"
+make_gh forbidden
+run_step false
+[ "$RC" -eq 0 ] \
+  && pass "a refused POST is tolerated, not fatal" \
+  || fail "a refused POST must not fail the job" "rc=$RC, output: $OUT"
+printf '%s' "$OUT" | grep -q "could not post" \
+  && pass "and says where the reminder went instead" \
+  || fail "explains the fallback" "got: $OUT"
+
+# --- the promise, stated as a property -----------------------------------------
+echo ""
+echo "-- the step never uses errexit, which is what made a 403 fatal --"
+grep -qE '^[[:space:]]*set -e|^[[:space:]]*set -[a-z]*e[a-z]*o?' "${WORK}/step.sh" \
+  && fail "the step must not run under errexit" "a non-zero gh call would kill it again" \
+  || pass "the step does not enable errexit"
+grep -q 'set -uo pipefail' "${WORK}/step.sh" \
+  && pass "it still keeps nounset and pipefail" \
+  || fail "nounset/pipefail retained"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #4440.

## The contract the workflow states, and did not keep

`changelog-reminder.yml` says it twice — in its header:

> It comments once and **always succeeds**; the judgement stays with the author.

and in the comment it posts:

> This is a reminder, not a gate; it never blocks a merge.

On a pull request **from a fork** it did neither. GitHub caps `GITHUB_TOKEN` at read-only for `pull_request` events raised from forks, whatever the `permissions:` block asks for, so the final step answered:

```
gh: Resource not accessible by integration (HTTP 403)
##[error]Process completed with exit code 1.
```

and `shell: bash -e` + `set -euo pipefail` turned that into a failed check. The result was exactly what the header set out to avoid — an advisory reminder behaving as a hard gate, on honest work — and on **every external contribution**, the population least likely to know the changelog convention and most in need of the nudge. They got a red check and no reminder. (Observed on #4439, [run 32489915826](https://github.com/kubestellar/hive/actions/runs/32489915826/job/96794884705).)

## Two things were wrong; both fixed

**Delivery.** The reminder now goes to the **job summary** and a **`::notice::` annotation** first. Neither needs write permission, so both reach fork PRs and same-repo branches identically — this is the delivery the reminder can actually rely on. The PR comment becomes a nicety layered on top: skipped outright on a fork (a 403 in the log invites the next reader to debug a permission that is working as designed), attempted elsewhere, and tolerated if an org policy narrows the token anyway. The once-only dedupe is unchanged for the comment path, and the HTML marker is kept out of the summary.

**Exit status.** The step drops `errexit` and ends `exit 0`. `nounset` and `pipefail` stay — the intent is "a failed delivery is not a failed PR", not "ignore everything".

Same-repo PRs see no behaviour change beyond the added summary: still commented, still only once.

## Tested by executing the step, not grepping the YAML

The bug was an **exit status**. A grep over the workflow would pass on a script that still dies on the first non-zero command, so `src/deploy/test_changelog_reminder.sh` **extracts the real `run:` block out of the workflow** — never restating it, so a copy cannot keep passing after the step regresses — and runs it against a stub `gh` that fails exactly the way GitHub does.

14 assertions across three shapes:

| shape | asserted |
|---|---|
| fork PR (the #4440 case) | exits 0; reminder delivered as summary **and** annotation; no doomed POST attempted; dedupe marker kept out of the summary |
| same-repo PR | still posts the comment; still writes the summary, so both surfaces agree |
| same-repo PR, POST refused by org policy | tolerated, not fatal; says where the reminder went instead |

Plus the property that caused it: the step must not run under `errexit`, while keeping `nounset`/`pipefail`.

**Mutation-checked.** Run against the *unfixed* workflow, **10 of the 14 fail** and reproduce the reported error verbatim:

```
FAIL: a refused POST must not fail the job
      rc=1, output: gh: Resource not accessible by integration (HTTP 403)
```

So they test the bug, not the implementation.

## One gap closed on the way

`changelog-reminder.yml` is added to `v2-ci.yml`'s path filters. Without it, a change to the file this guard protects would not run the guard — the same class of gap #4414 closed for `test_ambient_cap_runtime.sh`, which was missing from its own job's filters.

No changelog entry: this is CI-only, which the changelog's own guidance excludes — and the reminder agrees, since its `code=` check treats `.github/` as not user-facing.

— hive: backend=claude model=claude-opus-5
