### PR TITLE
🐛 Relay agent issue/comment creation through a durable hive-side watcher

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -947,12 +947,33 @@ if [[ -n "$AGENT_NAME" ]]; then
         *) [[ -z "$item_num" ]] && item_num="$arg" ;;
       esac
     done
+    # Explicit success: the loop's last iteration is often `[[ -z set ]] && …`
+    # (a trailing positional like a --body value), which evaluates false. Under
+    # `set -e` that non-zero return killed the whole wrapper — comments with a
+    # trailing free-text arg died with a silent exit 1.
+    return 0
   }
 
   case "$subcmd/$action" in
     issue/create|pr/create)
-      _ensure_labels
       _inject_identity
+      # ── Relay issue creation through the hive (issue-request watcher) ──
+      # The direct path rode the agent's shell tool: one GHE secondary-rate-
+      # limit stall, network blip, or mangled multiline command and the
+      # finding was silently lost (root-caused live 2026-08-21: sec-check's
+      # creates timed out mid-flight, repeatedly, and survived only as beads).
+      # hive-open-issue writes a request file (milliseconds, no network); the
+      # hive creates the issue server-side with the App token — retried with
+      # backoff, deduped by exact open-issue title, and gated by the SAME
+      # CanCreateIssues mode check + UID forge-resistance as this wrapper.
+      # Mode gates (NO_GITHUB/ADVISORY capture) have already run above, so an
+      # advisory agent's finding still lands in the digest, never the queue.
+      # Contributors are EXEMPT (they file under their own identity), mirroring
+      # the hive-open-pr redirect.
+      if [ "$subcmd" = "issue" ] && ! _contributor_mode && command -v hive-open-issue >/dev/null 2>&1; then
+        exec hive-open-issue "${args[@]}" --label "$LABELS_CSV"
+      fi
+      _ensure_labels
       # `|| rc=$?` (not `cmd; rc=$?`): this script runs under `set -e`, so a
       # bare failing gh exited the wrapper BEFORE rc was ever read — the
       # unlabeled retry below was dead code, and a missing injected label
@@ -991,9 +1012,16 @@ if [[ -n "$AGENT_NAME" ]]; then
       exec "$REAL_GH" "$@"
       ;;
     issue/comment|pr/comment|pr/review)
-      _ensure_labels
       _inject_identity
       _extract_item
+      # ── Relay comments through the hive (same rationale as issue/create) ──
+      # A lost review/triage comment is a lost work product. pr/review keeps
+      # the direct path: its approve/request-changes event semantics don't map
+      # to a plain comment.
+      if [ "$action" = "comment" ] && ! _contributor_mode && command -v hive-open-issue >/dev/null 2>&1; then
+        exec hive-open-issue comment "${args[@]}"
+      fi
+      _ensure_labels
       "$REAL_GH" "${args[@]}"
       exit_code=$?
       if [[ $exit_code -eq 0 && -n "$item_num" ]]; then

--- a/bin/hive-open-issue.sh
+++ b/bin/hive-open-issue.sh
@@ -74,8 +74,11 @@ if [ -n "$BODY_FILE" ]; then
 fi
 
 if [ "$KIND" = "issue" ]; then
-  if [ -z "$REPO" ] || [ -z "$TITLE" ]; then
-    echo "hive-open-issue: --repo and --title are required" >&2
+  # --body stays required (matching the original shim contract pinned by
+  # bin/test_hive_open_issue.sh): an issue with an empty body is always an
+  # agent bug, and catching it here beats a watcher-side .bad quarantine.
+  if [ -z "$REPO" ] || [ -z "$TITLE" ] || [ -z "$BODY" ]; then
+    echo "hive-open-issue: --repo, --title, and --body are required" >&2
     exit 2
   fi
 else
@@ -122,8 +125,9 @@ if kind == "comment":
 else:
     req["title"] = title
     req["body"] = body
-    if labels:
-        req["labels"] = labels
+    # Always present (even empty) — the original shim contract, pinned by
+    # bin/test_hive_open_issue.sh; the watcher accepts both shapes.
+    req["labels"] = labels
 with open(temporary, "w") as fh:
     json.dump(req, fh)
 os.replace(temporary, path)

--- a/bin/hive-open-issue.sh
+++ b/bin/hive-open-issue.sh
@@ -1,16 +1,36 @@
 #!/bin/bash
-# hive-open-issue.sh — request an issue through the Hive lifecycle writer.
+# hive-open-issue.sh — create an issue (or post a comment) via the HIVE, not gh.
 #
-# Agents run this helper instead of writing to GitHub directly. The request
-# file is owned by the agent UID; Hive verifies that ownership and the current
-# ACMM mode, then performs deterministic duplicate checks before using the App
-# token to create the issue.
+# Agents call this INSTEAD of `gh issue create` / `gh issue comment`. It writes
+# a request file that the hive's issue-request watcher executes with the App
+# installation token — server-side, retried with backoff, deduped by exact
+# open-issue title. The direct path rode the agent's shell tool: one GHE
+# secondary-rate-limit stall, network blip, or mangled multiline command and
+# the finding was silently lost (root-caused live 2026-08-21 on a hosted hive:
+# sec-check's `gh issue create` timed out mid-flight — repeatedly — and the
+# findings survived only as beads). This path makes the agent's job "record
+# the request" (a local file write, milliseconds, cannot fail on network); the
+# hive owns delivery.
+#
+# The watcher enforces the SAME per-agent mode gate (CanCreateIssues) + UID
+# forge-resistance as the gh wrapper; this shim adds no privilege.
+#
+# Usage (drop-in for the common gh shapes):
+#   hive-open-issue --repo <owner/repo> --title "<t>" [--body "<b>"|--body-file f] [--label a,b]
+#   hive-open-issue comment --repo <owner/repo> <number|url> --body "<b>"
+#
+# On success it prints the request path and returns 0. The issue/comment is
+# created asynchronously (within one ~10s watcher tick); poll the .result.json
+# next to the request for the number/URL.
 
 set -euo pipefail
 
 REQ_DIR="/var/run/hive-metrics/issue-requests"
 
-REPO=""; TITLE=""; BODY=""; BODY_FILE=""
+KIND="issue"
+if [ "${1:-}" = "comment" ]; then KIND="comment"; shift; fi
+
+REPO=""; TITLE=""; BODY=""; BODY_FILE=""; NUMBER=""
 LABELS=()
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -19,12 +39,26 @@ while [ $# -gt 0 ]; do
     --body|-b) BODY="$2"; shift 2;;
     --body-file|-F) BODY_FILE="$2"; shift 2;;
     --label|-l) LABELS+=("$2"); shift 2;;
+    --number) NUMBER="$2"; shift 2;;
     --repo=*) REPO="${1#*=}"; shift;;
     --title=*) TITLE="${1#*=}"; shift;;
     --body=*) BODY="${1#*=}"; shift;;
     --body-file=*) BODY_FILE="${1#*=}"; shift;;
     --label=*) LABELS+=("${1#*=}"); shift;;
-    *) shift;;
+    --number=*) NUMBER="${1#*=}"; shift;;
+    # Tolerate gh flags we don't need; skip a following value only for flags
+    # that take one, so a bare flag can't swallow the next real argument.
+    --assignee|-a|--milestone|-m|--project|-p|--template|-T) shift 2;;
+    --web|-w|--editor|-e) shift;;
+    *)
+      # A bare positional for a comment is the issue/PR number or URL.
+      if [ "$KIND" = "comment" ] && [ -z "$NUMBER" ]; then
+        case "$1" in
+          http://*|https://*) NUMBER="$(printf '%s' "$1" | sed -n 's#.*/\(issues\|pull\)/\([0-9][0-9]*\).*#\2#p')";;
+          [0-9]*) NUMBER="$1";;
+        esac
+      fi
+      shift;;
   esac
 done
 
@@ -39,9 +73,16 @@ if [ -n "$BODY_FILE" ]; then
   fi
 fi
 
-if [ -z "$REPO" ] || [ -z "$TITLE" ] || [ -z "$BODY" ]; then
-  echo "hive-open-issue: --repo, --title, and --body are required" >&2
-  exit 2
+if [ "$KIND" = "issue" ]; then
+  if [ -z "$REPO" ] || [ -z "$TITLE" ]; then
+    echo "hive-open-issue: --repo and --title are required" >&2
+    exit 2
+  fi
+else
+  if [ -z "$REPO" ] || [ -z "$NUMBER" ] || [ -z "$BODY" ]; then
+    echo "hive-open-issue: comment requires --repo, a number (or URL), and --body" >&2
+    exit 2
+  fi
 fi
 
 AGENT="${HIVE_AGENT:-agent}"
@@ -68,17 +109,29 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-LABELS_JSON="$(printf '%s\n' "${LABELS[@]}" | python3 -c 'import json,sys; print(json.dumps([x.rstrip("\n") for x in sys.stdin if x.rstrip("\n")]))')"
-python3 - "$TEMP_FILE" "$REQ_FILE" "$REPO" "$TITLE" "$BODY" "$AGENT" "$LABELS_JSON" <<'PY'
+LABELS_JSON="$(printf '%s\n' "${LABELS[@]:-}" | python3 -c 'import json,sys; print(json.dumps([x.rstrip("\n") for x in sys.stdin if x.rstrip("\n")]))')"
+python3 - "$TEMP_FILE" "$REQ_FILE" "$KIND" "$REPO" "$TITLE" "$BODY" "$AGENT" "$LABELS_JSON" "${NUMBER:-0}" <<'PY'
 import json, os, sys
-temporary, path, repo, title, body, agent, labels = sys.argv[1:8]
+temporary, path, kind, repo, title, body, agent, labels, number = sys.argv[1:10]
 labels = [part.strip() for value in json.loads(labels)
           for part in value.split(",") if part.strip()]
+req = {"kind": kind, "repo": repo, "agent": agent}
+if kind == "comment":
+    req["number"] = int(number)
+    req["body"] = body
+else:
+    req["title"] = title
+    req["body"] = body
+    if labels:
+        req["labels"] = labels
 with open(temporary, "w") as fh:
-    json.dump({"repo": repo, "title": title, "body": body,
-               "labels": labels, "agent": agent}, fh)
+    json.dump(req, fh)
 os.replace(temporary, path)
 PY
 
-echo "hive-open-issue: requested issue on $REPO as the App bot"
+if [ "$KIND" = "comment" ]; then
+  echo "hive-open-issue: requested comment on $REPO#$NUMBER as the App bot"
+else
+  echo "hive-open-issue: requested issue on $REPO as the App bot: $TITLE"
+fi
 echo "hive-open-issue: request $REQ_FILE (Hive validates and fulfills it within one watcher tick; result appears at ${REQ_FILE%.json}.result.json)"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -379,6 +379,7 @@ COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credenti
 # bit on purpose: it must only ever be sourced.
 COPY bin/agent-env-scrub.sh /usr/local/bin/agent-env-scrub.sh
 COPY bin/hive-open-pr.sh /usr/local/bin/hive-open-pr
+COPY bin/hive-open-issue.sh /usr/local/bin/hive-open-issue
 COPY bin/hive-merge.sh /usr/local/bin/hive-merge
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
 # SDK-based copilot model discovery helper (see Layer 3b). Invoked as
@@ -387,7 +388,7 @@ COPY bin/copilot-models.mjs /usr/local/bin/copilot-models.mjs
 COPY config/backends.conf /usr/local/etc/hive/backends.conf
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bin/gh-app-token.sh \
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
-    /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-merge
+    /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-open-issue /usr/local/bin/hive-merge
 
 # SECURITY (#4045): interactive-shell arm of the agent credential scrub.
 # BASH_ENV (exported by agent-launch.sh) only reaches NON-interactive shells;

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1544,6 +1544,16 @@ func main() {
 			return l >= acmmHoldGatedMinLevel && l <= acmmHoldGatedMaxLevel
 		}
 		ghClient.StartPRRequestWatcher(ctx, agentMgr.AuthorizePROpen, holdLabel, nil)
+		// Issue relay: agents request issue creation and comments by dropping a
+		// file (hive-open-issue via the gh wrapper) instead of calling GitHub
+		// from their own shell. The agent-side call used to ride the agent's
+		// shell tool — one GHE secondary-rate-limit stall or mangled multiline
+		// command and the finding was silently lost (root-caused live
+		// 2026-08-21: sec-check's creates timed out and survived only as
+		// beads). The watcher executes server-side with the App token, retries
+		// with backoff, dedupes by exact open-issue title, and enforces the
+		// same forge-resistance + CanCreateIssues mode gate the wrapper does.
+		ghClient.StartIssueRequestWatcher(ctx, agentMgr.AuthorizeIssueOpen, nil)
 		// Merge relay: agents request merges by dropping a file (hive-merge)
 		// instead of calling the GitHub MCP merge_pull_request tool, whose GraphQL
 		// mutation GitHub rejects for App tokens ("Resource not accessible by

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -6715,6 +6715,38 @@ func (m *Manager) AuthorizePROpen(agentName string, fileUID int) error {
 	return nil
 }
 
+// AuthorizeIssueOpen enforces the policy for the issue-request watcher,
+// mirroring AuthorizePROpen with the mode gates that govern the direct gh
+// paths: "issue" requests need CanCreateIssues() (mode >= ISSUES_ONLY);
+// "comment" requests need the same (commenting is an issue-write). The same
+// UID forge-resistance applies: the request file's owner must BE the claimed
+// agent. A nil manager or unknown agent is denied.
+func (m *Manager) AuthorizeIssueOpen(agentName string, fileUID int, kind string) error {
+	if strings.TrimSpace(agentName) == "" {
+		return fmt.Errorf("no agent named in the request")
+	}
+	if m.uidMap != nil && fileUID > 0 {
+		owner := m.uidMap.LookupByUID(fileUID)
+		if owner == "" {
+			return fmt.Errorf("request file owned by unknown uid %d (not a registered agent)", fileUID)
+		}
+		if owner != agentName {
+			return fmt.Errorf("request claims agent %q but file is owned by agent %q (uid %d)", agentName, owner, fileUID)
+		}
+	}
+	m.mu.RLock()
+	agent := m.agents[agentName]
+	m.mu.RUnlock()
+	if agent == nil {
+		return fmt.Errorf("unknown agent %q", agentName)
+	}
+	if !m.agentMode(agent).CanCreateIssues() {
+		return fmt.Errorf("agent %q may not create issues or comments at this ACMM level (mode %s)",
+			agentName, m.agentMode(agent).String())
+	}
+	return nil
+}
+
 // AuthorizeMerge enforces the policy for the hive-merges-PR watcher, mirroring
 // AuthorizePROpen but with the stricter CanMerge() gate: the request's agent
 // must own the request file (forge-resistance) AND be merge-capable at the

--- a/src/pkg/github/attribution.go
+++ b/src/pkg/github/attribution.go
@@ -45,6 +45,12 @@ const (
 	// AuditActionAgentPRCreated is the audit action recorded when the
 	// PR-request watcher opens a PR on an agent's behalf.
 	AuditActionAgentPRCreated = "agent_pr_created"
+	// AuditActionAgentIssueCreated is the audit action recorded when the
+	// issue-request watcher creates an issue on an agent's behalf.
+	AuditActionAgentIssueCreated = "agent_issue_created"
+	// AuditActionAgentCommentCreated is the audit action recorded when the
+	// issue-request watcher posts an issue/PR comment on an agent's behalf.
+	AuditActionAgentCommentCreated = "agent_comment_created"
 	// AuditActionHiveIssueCreated is the audit action recorded when the hive
 	// itself creates an issue (advisory issue, ACMM-gap issue).
 	AuditActionHiveIssueCreated = "hive_issue_created"

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -75,6 +75,14 @@ type Client struct {
 	// MergeRequestAuthorizer / F4). nil fails closed. Set by
 	// StartMergeRequestWatcher.
 	mergeAuthz MergeRequestAuthorizer
+	// issueAuthz gates issue-create/comment requests from the issue-request
+	// watcher against the per-agent mode policy (CanCreateIssues) +
+	// forge-resistance. nil fails closed. Set by StartIssueRequestWatcher.
+	issueAuthz IssueRequestAuthorizer
+	// issueRetries tracks per-request-file retry backoff for the issue-request
+	// watcher (in-memory; reset on restart). Guarded by issueRetryMu.
+	issueRetryMu sync.Mutex
+	issueRetries map[string]*issueRetryState
 	// mergerAuthz gates the label-queued auto-merge sweep on WHO queued the
 	// merge: it reports whether a login holds at least config.RoleMerger (audit
 	// F3). nil fails closed — SweepQueuedAutoMerges merges nothing. Guarded

--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -38,7 +38,8 @@ func issueRequestDir() string {
 
 // issueRequestPollInterval mirrors prRequestPollInterval: issue creation is not
 // latency-critical (the agent has already recorded the finding and moved on).
-const issueRequestPollInterval = 10 * time.Second
+// A var (not const) so tests can drive the real ticker loop quickly.
+var issueRequestPollInterval = 10 * time.Second
 
 // issueRetryBase and issueRetryMax bound the per-request retry backoff. Unlike
 // the PR watcher (retry every tick forever), a persistently failing issue

--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -1,0 +1,454 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/pkg/logscrub"
+)
+
+// IssueRequestDir is where agents drop issue-create and comment requests. An
+// agent's `gh issue create` (via the gh wrapper → hive-open-issue) writes a
+// request file here INSTEAD of calling the GitHub API from the agent's shell.
+// The hive's watcher performs the write with the App installation token —
+// server-side, retried, and immune to the agent shell-tool timeouts, GHE
+// secondary-rate-limit stalls, and multiline-command mangling that made direct
+// `gh issue create` silently lose findings (root-caused live 2026-08-21: the
+// sec-check agent's creates timed out mid-flight and the finding survived only
+// as a bead).
+const IssueRequestDir = "/var/run/hive-metrics/issue-requests"
+
+// issueRequestDirForTest lets tests point the watcher at a temp dir.
+var issueRequestDirForTest string
+
+func issueRequestDir() string {
+	if issueRequestDirForTest != "" {
+		return issueRequestDirForTest
+	}
+	return IssueRequestDir
+}
+
+// issueRequestPollInterval mirrors prRequestPollInterval: issue creation is not
+// latency-critical (the agent has already recorded the finding and moved on).
+const issueRequestPollInterval = 10 * time.Second
+
+// issueRetryBase and issueRetryMax bound the per-request retry backoff. Unlike
+// the PR watcher (retry every tick forever), a persistently failing issue
+// request backs off exponentially so a poisoned-but-parseable request cannot
+// hammer the forge every 10 seconds for the life of the pod.
+const (
+	issueRetryBase = 30 * time.Second
+	issueRetryMax  = 15 * time.Minute
+)
+
+// issueRequestMaxAge is the give-up horizon: a request that still has not
+// succeeded after this long is quarantined (.failed) with its last error, so
+// the queue cannot grow without bound. 24h spans any plausible GHE outage
+// while keeping the directory finite.
+const issueRequestMaxAge = 24 * time.Hour
+
+// IssueRequest is the JSON an agent writes to IssueRequestDir. Kind selects the
+// operation: "issue" (default) creates an issue; "comment" posts a comment on
+// an existing issue or PR (Number required).
+type IssueRequest struct {
+	Kind   string   `json:"kind,omitempty"` // "issue" (default) | "comment"
+	Repo   string   `json:"repo"`
+	Title  string   `json:"title,omitempty"`  // issue only
+	Body   string   `json:"body,omitempty"`
+	Labels []string `json:"labels,omitempty"` // issue only
+	Number int      `json:"number,omitempty"` // comment only: issue/PR number
+	Agent  string   `json:"agent,omitempty"`
+}
+
+// IssueResponse is written next to a consumed request as <name>.result.json.
+type IssueResponse struct {
+	OK             bool   `json:"ok"`
+	Number         int    `json:"number,omitempty"`
+	URL            string `json:"url,omitempty"`
+	AlreadyExisted bool   `json:"already_existed,omitempty"`
+	Error          string `json:"error,omitempty"`
+	At             string `json:"at"`
+}
+
+// IssueRequestAuthorizer mirrors PRRequestAuthorizer: it receives the claimed
+// agent name, the request-file owning UID, and the request kind ("issue" or
+// "comment"), and returns nil to authorize. A nil authorizer denies everything
+// (fail closed).
+type IssueRequestAuthorizer func(agent string, fileUID int, kind string) error
+
+// issueRetryState tracks in-memory backoff per request path. Reset on pod
+// restart — acceptable: a restart retries everything once, then backs off again.
+type issueRetryState struct {
+	attempts int
+	nextTry  time.Time
+	firstTry time.Time
+}
+
+// StartIssueRequestWatcher runs the loop that executes issue/comment requests
+// dropped in IssueRequestDir. Same contract as StartPRRequestWatcher: returns
+// immediately, runs until ctx cancel, nil client is a no-op (requests
+// accumulate rather than silently dropping), nil authz fails closed.
+func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueRequestAuthorizer, nowFn func() time.Time) {
+	if c == nil {
+		return
+	}
+	c.issueAuthz = authz
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	if err := os.MkdirAll(issueRequestDir(), 0o777); err != nil {
+		c.logger.Warn("issue-request watcher: cannot create request dir; disabled",
+			slog.String("dir", issueRequestDir()), slog.String("error", err.Error()))
+		return
+	}
+	// Same rationale as the PR watcher: agents (UID >= 2001) must be able to
+	// DROP request files; MkdirAll is umask-masked, so force group-write+setgid.
+	if err := os.Chmod(issueRequestDir(), 0o2775); err != nil {
+		c.logger.Warn("issue-request watcher: could not set group-writable perms on request dir; agents may be unable to file issues",
+			slog.String("dir", issueRequestDir()), slog.String("error", err.Error()))
+	}
+	go func() {
+		t := time.NewTicker(issueRequestPollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				c.processIssueRequests(ctx, nowFn)
+			}
+		}
+	}()
+	c.logger.Info("issue-request watcher started", slog.String("dir", issueRequestDir()))
+}
+
+func (c *Client) processIssueRequests(ctx context.Context, nowFn func() time.Time) {
+	entries, err := os.ReadDir(issueRequestDir())
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
+			continue
+		}
+		path := filepath.Join(issueRequestDir(), name)
+		c.handleOneIssueRequest(ctx, path, nowFn)
+	}
+}
+
+// ProcessIssueRequestsOnce runs a single scan+process pass. Test/CLI entry point.
+func (c *Client) ProcessIssueRequestsOnce(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.processIssueRequests(ctx, time.Now)
+}
+
+func (c *Client) issueBackoffAllows(path string, nowFn func() time.Time) bool {
+	c.issueRetryMu.Lock()
+	defer c.issueRetryMu.Unlock()
+	if c.issueRetries == nil {
+		c.issueRetries = map[string]*issueRetryState{}
+	}
+	st := c.issueRetries[path]
+	if st == nil {
+		return true
+	}
+	return !nowFn().Before(st.nextTry)
+}
+
+// issueNoteFailure records a failed attempt and returns true when the request
+// has exceeded its give-up horizon and should be quarantined.
+func (c *Client) issueNoteFailure(path string, nowFn func() time.Time) bool {
+	c.issueRetryMu.Lock()
+	defer c.issueRetryMu.Unlock()
+	if c.issueRetries == nil {
+		c.issueRetries = map[string]*issueRetryState{}
+	}
+	now := nowFn()
+	st := c.issueRetries[path]
+	if st == nil {
+		st = &issueRetryState{firstTry: now}
+		c.issueRetries[path] = st
+	}
+	st.attempts++
+	backoff := issueRetryBase << uint(min(st.attempts-1, 30))
+	if backoff > issueRetryMax || backoff <= 0 {
+		backoff = issueRetryMax
+	}
+	st.nextTry = now.Add(backoff)
+	return now.Sub(st.firstTry) > issueRequestMaxAge
+}
+
+func (c *Client) issueClearRetry(path string) {
+	c.issueRetryMu.Lock()
+	defer c.issueRetryMu.Unlock()
+	delete(c.issueRetries, path)
+}
+
+func (c *Client) handleOneIssueRequest(ctx context.Context, path string, nowFn func() time.Time) {
+	if !c.issueBackoffAllows(path, nowFn) {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // vanished between ReadDir and here
+	}
+	var req IssueRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		c.writeIssueResult(path, IssueResponse{OK: false, Error: "invalid JSON: " + err.Error(), At: nowFn().UTC().Format(time.RFC3339)})
+		_ = os.Rename(path, path+".bad")
+		c.issueClearRetry(path)
+		c.logger.Warn("issue-request watcher: bad request file quarantined",
+			slog.String("path", path), slog.String("error", err.Error()))
+		return
+	}
+	kind := strings.TrimSpace(strings.ToLower(req.Kind))
+	if kind == "" {
+		kind = "issue"
+	}
+
+	// Validate the request shape BEFORE authorizing or touching the API — a
+	// structurally hopeless request can never succeed and must not retry.
+	var shapeErr string
+	switch kind {
+	case "issue":
+		if strings.TrimSpace(req.Repo) == "" || strings.TrimSpace(req.Title) == "" {
+			shapeErr = "issue request requires repo and title"
+		}
+	case "comment":
+		if strings.TrimSpace(req.Repo) == "" || req.Number <= 0 || strings.TrimSpace(req.Body) == "" {
+			shapeErr = "comment request requires repo, number, and body"
+		}
+	default:
+		shapeErr = "unknown kind " + strconv.Quote(kind)
+	}
+	if shapeErr != "" {
+		c.writeIssueResult(path, IssueResponse{OK: false, Error: shapeErr, At: nowFn().UTC().Format(time.RFC3339)})
+		_ = os.Rename(path, path+".bad")
+		c.issueClearRetry(path)
+		c.logger.Warn("issue-request watcher: malformed request quarantined",
+			slog.String("path", path), slog.String("reason", shapeErr))
+		return
+	}
+
+	// Authorize with the same UID forge-resistance + agent-mode gate as the PR
+	// watcher. A nil authorizer fails closed. Denials quarantine (.denied) —
+	// retrying can never change policy.
+	fileUID := statUID(data, path)
+	if c.issueAuthz == nil {
+		c.denyIssueRequest(path, req, "no authorizer configured (fail closed)", nowFn)
+		return
+	}
+	if err := c.issueAuthz(req.Agent, fileUID, kind); err != nil {
+		c.denyIssueRequest(path, req, err.Error(), nowFn)
+		return
+	}
+
+	meta := c.attributionMeta(req.Agent)
+	body := req.Body
+	if c.attributionTrailerOn() {
+		body = AppendTrailer(body, meta)
+	}
+
+	resp := IssueResponse{At: nowFn().UTC().Format(time.RFC3339)}
+	switch kind {
+	case "comment":
+		err = c.CreateIssueComment(ctx, req.Repo, req.Number, body)
+		if err == nil {
+			resp.OK = true
+			resp.Number = req.Number
+		}
+	default: // "issue"
+		var res CreateIssueResult
+		res, err = c.CreateIssue(ctx, req.Repo, req.Title, body, req.Labels)
+		if err == nil {
+			resp.OK = true
+			resp.Number = res.Number
+			resp.URL = res.URL
+			resp.AlreadyExisted = res.AlreadyExisted
+		}
+	}
+
+	if err != nil {
+		resp.OK = false
+		resp.Error = err.Error()
+		c.writeIssueResult(path, resp)
+		gaveUp := c.issueNoteFailure(path, nowFn)
+		if gaveUp {
+			_ = os.Rename(path, path+".failed")
+			c.issueClearRetry(path)
+			c.logger.Error("issue-request watcher: request exceeded retry horizon, quarantined",
+				slog.String("path", path), slog.String("repo", req.Repo), slog.String("error", err.Error()))
+			return
+		}
+		c.logger.Warn("issue-request watcher: request failed, will retry with backoff",
+			slog.String("repo", req.Repo), slog.String("kind", kind), slog.String("error", err.Error()))
+		return
+	}
+
+	action := AuditActionAgentIssueCreated
+	if kind == "comment" {
+		action = AuditActionAgentCommentCreated
+	}
+	c.recordCreationAudit(action, meta,
+		"repo", req.Repo,
+		"number", strconv.Itoa(resp.Number),
+		"url", resp.URL,
+		"reused", strconv.FormatBool(resp.AlreadyExisted))
+	c.writeIssueResult(path, resp)
+	_ = os.Remove(path)
+	c.issueClearRetry(path)
+	c.logger.Info("issue-request watcher: request completed",
+		slog.String("repo", req.Repo), slog.String("kind", kind),
+		slog.Int("number", resp.Number), slog.Bool("reused", resp.AlreadyExisted),
+		slog.String("agent", req.Agent))
+}
+
+func (c *Client) denyIssueRequest(path string, req IssueRequest, reason string, nowFn func() time.Time) {
+	c.writeIssueResult(path, IssueResponse{OK: false, Error: "authorization denied: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
+	_ = os.Rename(path, path+".denied")
+	c.issueClearRetry(path)
+	c.logger.Warn("issue-request watcher: DENIED (policy)",
+		slog.String("agent", req.Agent), slog.String("repo", req.Repo), slog.String("reason", reason))
+}
+
+func (c *Client) writeIssueResult(reqPath string, resp IssueResponse) {
+	out := strings.TrimSuffix(reqPath, ".json") + ".result.json"
+	if b, err := json.MarshalIndent(resp, "", "  "); err == nil {
+		_ = os.WriteFile(out, b, 0o644)
+	}
+}
+
+// WriteIssueRequest drops a well-formed request file into dir (tests and
+// in-process callers).
+func WriteIssueRequest(dir string, req IssueRequest) (string, error) {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(req, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("%s-%d.json", sanitizeAgentName(req.Agent), time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// CreateIssueResult is what CreateIssue returns.
+type CreateIssueResult struct {
+	Number int
+	URL    string
+	// AlreadyExisted is true when an OPEN issue with the same exact title was
+	// already present in the repo, so we returned it instead of creating a
+	// duplicate. This makes the watcher's retry loop idempotent: a create that
+	// succeeded server-side but crashed before the request file was consumed
+	// (or an agent-side "timed out but actually created" ambiguity) never
+	// yields a second issue.
+	AlreadyExisted bool
+}
+
+// CreateIssue creates an issue as the hive's App bot, ensuring requested labels
+// exist first and deduping by exact open-issue title. repo may be "owner/repo"
+// or bare (owner defaults to the hive org).
+func (c *Client) CreateIssue(ctx context.Context, repo, title, body string, labels []string) (CreateIssueResult, error) {
+	if c == nil || c.client == nil {
+		return CreateIssueResult{}, ErrNoGitHubClient
+	}
+	owner, repoName := c.splitRepo(repo)
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return CreateIssueResult{}, fmt.Errorf("CreateIssue: title is required")
+	}
+	if leak, ok := c.scanCanaryText(title+"\n"+body, "hive-open-issue:"+repo); ok {
+		if c.canaryFailClosed {
+			return CreateIssueResult{}, fmt.Errorf("ioscan canary leak detected: agent=%s source=%s", leak.Agent, leak.Source)
+		}
+	}
+	title = logscrub.ScrubString(title)
+	body = logscrub.ScrubString(body)
+
+	// Idempotency: list recent open issues and reuse an exact-title match.
+	// Issues.ListByRepo is strongly consistent (unlike the Search API, whose
+	// index can lag minutes on GHE — useless against a 10s retry loop).
+	if existing, err := c.findOpenIssueByTitle(ctx, owner, repoName, title); err != nil {
+		c.logger.Warn("CreateIssue: dedupe lookup failed, proceeding to create",
+			slog.String("repo", repoName), slog.String("error", err.Error()))
+	} else if existing != nil {
+		c.logger.Info("CreateIssue: open issue with identical title exists, reusing",
+			slog.String("repo", repoName), slog.Int("number", existing.GetNumber()))
+		return CreateIssueResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), AlreadyExisted: true}, nil
+	}
+
+	// Ensure labels exist; a label that cannot be ensured is dropped (labels
+	// are provenance metadata, not a gate — mirror the gh-wrapper posture).
+	var usable []string
+	for _, l := range labels {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		if err := c.ensureLabel(ctx, owner, repoName, l); err != nil {
+			c.logger.Warn("CreateIssue: could not ensure label, creating without it",
+				slog.String("repo", repoName), slog.String("label", l), slog.String("error", err.Error()))
+			continue
+		}
+		usable = append(usable, l)
+	}
+
+	req := &gh.IssueRequest{Title: gh.Ptr(title), Body: gh.Ptr(body)}
+	if len(usable) > 0 {
+		req.Labels = &usable
+	}
+	issue, _, err := c.client.Issues.Create(ctx, owner, repoName, req)
+	if err != nil {
+		return CreateIssueResult{}, fmt.Errorf("creating issue in %s/%s: %w", owner, repoName, err)
+	}
+	c.logger.Info("CreateIssue: issue created as the App bot",
+		slog.String("repo", repoName), slog.Int("number", issue.GetNumber()))
+	return CreateIssueResult{Number: issue.GetNumber(), URL: issue.GetHTMLURL()}, nil
+}
+
+// findOpenIssueByTitle scans up to the 3 most recent pages of open issues for
+// an exact (whitespace-trimmed) title match. Bounded: agent-filed issues are
+// recent by construction, and an unbounded scan of a busy repo would burn API
+// budget on every create.
+func (c *Client) findOpenIssueByTitle(ctx context.Context, owner, repo, title string) (*gh.Issue, error) {
+	opts := &gh.IssueListByRepoOptions{
+		State:       "open",
+		Sort:        "created",
+		Direction:   "desc",
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+	for page := 1; page <= 3; page++ {
+		opts.ListOptions.Page = page
+		issues, resp, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, is := range issues {
+			if is.IsPullRequest() {
+				continue
+			}
+			if strings.TrimSpace(is.GetTitle()) == title {
+				return is, nil
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+	}
+	return nil, nil
+}

--- a/src/pkg/github/issue_request_watcher_test.go
+++ b/src/pkg/github/issue_request_watcher_test.go
@@ -1,0 +1,326 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newIssueMockServer mocks GET /issues (dedupe list) and POST /issues (create)
+// plus label ensure endpoints. existingTitle, when non-empty, is returned by
+// the list as an open issue titled exactly that. created counts POST /issues.
+// failCreates, when >0, makes the first N create attempts return 502.
+func newIssueMockServer(t *testing.T, existingTitle string, created *int, failCreates *int, commented *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/labels/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"x"}`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/labels"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"x"}`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/comments"):
+			if commented != nil {
+				*commented++
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":1}`)
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"):
+			w.Header().Set("Content-Type", "application/json")
+			if existingTitle != "" {
+				b, _ := json.Marshal([]map[string]any{{
+					"number": 7, "title": existingTitle,
+					"html_url": "https://github.example/o/r/issues/7",
+				}})
+				_, _ = w.Write(b)
+				return
+			}
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			if failCreates != nil && *failCreates > 0 {
+				*failCreates--
+				w.WriteHeader(http.StatusBadGateway)
+				return
+			}
+			if created != nil {
+				*created++
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":99,"html_url":"https://github.example/o/r/issues/99"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func issueTestClient(t *testing.T, srvURL string) *Client {
+	t.Helper()
+	c := testClient(t, srvURL)
+	c.issueAuthz = func(agent string, uid int, kind string) error { return nil }
+	return c
+}
+
+func withIssueDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := issueRequestDirForTest
+	issueRequestDirForTest = dir
+	t.Cleanup(func() { issueRequestDirForTest = old })
+	return dir
+}
+
+// End-to-end: a request file becomes an issue, is consumed, result written.
+func TestIssueRequestWatcher_CreatesAndConsumes(t *testing.T) {
+	created := 0
+	srv := newIssueMockServer(t, "", &created, nil, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{
+		Repo: "o/r", Title: "[sec-check] High: CVE-2026-1", Body: "detail",
+		Labels: []string{"agent/security"}, Agent: "sec-check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ProcessIssueRequestsOnce(context.Background())
+
+	if created != 1 {
+		t.Fatalf("expected 1 issue created, got %d", created)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("request file should be removed after success")
+	}
+	var res IssueResponse
+	b, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatalf("result file missing: %v", err)
+	}
+	if err := json.Unmarshal(b, &res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.Number != 99 || res.AlreadyExisted {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}
+
+// Idempotency: an open issue with the identical title is reused, not duplicated.
+// This is the guard against the "create timed out but actually landed" ambiguity
+// and against watcher crash between create and request-file removal.
+func TestIssueRequestWatcher_DedupesByTitle(t *testing.T) {
+	created := 0
+	srv := newIssueMockServer(t, "[sec-check] already filed", &created, nil, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{
+		Repo: "o/r", Title: "[sec-check] already filed", Body: "detail", Agent: "sec-check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ProcessIssueRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Fatalf("expected 0 issues created (dedupe), got %d", created)
+	}
+	var res IssueResponse
+	b, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatalf("result file missing: %v", err)
+	}
+	_ = json.Unmarshal(b, &res)
+	if !res.OK || !res.AlreadyExisted || res.Number != 7 {
+		t.Errorf("expected reuse of issue 7, got %+v", res)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("request should be consumed on reuse")
+	}
+}
+
+// Transient failure: request survives, error recorded, retried after backoff,
+// then succeeds.
+func TestIssueRequestWatcher_RetriesTransientFailure(t *testing.T) {
+	created := 0
+	fails := 1
+	srv := newIssueMockServer(t, "", &created, &fails, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{
+		Repo: "o/r", Title: "[scanner] flaky forge", Body: "x", Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	c.processIssueRequests(context.Background(), clock)
+	if created != 0 {
+		t.Fatalf("first attempt should have failed")
+	}
+	if _, err := os.Stat(reqPath); err != nil {
+		t.Fatalf("request must survive a transient failure: %v", err)
+	}
+	// Within backoff: skipped.
+	c.processIssueRequests(context.Background(), clock)
+	if created != 0 {
+		t.Fatalf("retry should be suppressed inside the backoff window")
+	}
+	// After backoff: retried and succeeds.
+	now = now.Add(issueRetryBase + time.Second)
+	c.processIssueRequests(context.Background(), clock)
+	if created != 1 {
+		t.Fatalf("expected creation on post-backoff retry, got %d", created)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("request should be consumed after eventual success")
+	}
+}
+
+// Give-up horizon: a request failing past issueRequestMaxAge is quarantined
+// as .failed and never retried again.
+func TestIssueRequestWatcher_QuarantinesAfterMaxAge(t *testing.T) {
+	created := 0
+	fails := 1000
+	srv := newIssueMockServer(t, "", &created, &fails, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{
+		Repo: "o/r", Title: "[scanner] never lands", Body: "x", Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	c.processIssueRequests(context.Background(), clock) // first failure, starts the clock
+	now = now.Add(issueRequestMaxAge + time.Hour)
+	c.processIssueRequests(context.Background(), clock) // exceeds horizon → quarantine
+
+	if _, err := os.Stat(reqPath + ".failed"); err != nil {
+		t.Fatalf("expected .failed quarantine: %v", err)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("original request should be renamed away")
+	}
+}
+
+// Malformed requests (bad JSON, missing fields, unknown kind) are quarantined
+// as .bad immediately — they can never succeed, so they must never retry.
+func TestIssueRequestWatcher_QuarantinesMalformed(t *testing.T) {
+	srv := newIssueMockServer(t, "", nil, nil, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	badJSON := dir + "/agent-1.json"
+	_ = os.WriteFile(badJSON, []byte("{not json"), 0o644)
+	noTitle, _ := WriteIssueRequest(dir, IssueRequest{Repo: "o/r", Agent: "a"})
+	badKind, _ := WriteIssueRequest(dir, IssueRequest{Kind: "wat", Repo: "o/r", Title: "t", Agent: "a"})
+	noNumber, _ := WriteIssueRequest(dir, IssueRequest{Kind: "comment", Repo: "o/r", Body: "b", Agent: "a"})
+
+	c.ProcessIssueRequestsOnce(context.Background())
+
+	for _, p := range []string{badJSON, noTitle, badKind, noNumber} {
+		if _, err := os.Stat(p + ".bad"); err != nil {
+			t.Errorf("expected %s.bad quarantine: %v", p, err)
+		}
+	}
+}
+
+// Policy: a nil authorizer fails closed; a denying authorizer quarantines
+// as .denied. Neither creates anything.
+func TestIssueRequestWatcher_AuthzFailsClosed(t *testing.T) {
+	created := 0
+	srv := newIssueMockServer(t, "", &created, nil, nil)
+	defer srv.Close()
+	dir := withIssueDir(t)
+
+	// nil authorizer
+	c := testClient(t, srv.URL)
+	c.issueAuthz = nil
+	p1, _ := WriteIssueRequest(dir, IssueRequest{Repo: "o/r", Title: "t", Agent: "a"})
+	c.ProcessIssueRequestsOnce(context.Background())
+	if _, err := os.Stat(p1 + ".denied"); err != nil {
+		t.Fatalf("nil authorizer must deny: %v", err)
+	}
+
+	// explicit denial (e.g. advisory-mode agent)
+	c2 := testClient(t, srv.URL)
+	c2.issueAuthz = func(agent string, uid int, kind string) error {
+		return errors.New("agent is advisory-only")
+	}
+	p2, _ := WriteIssueRequest(dir, IssueRequest{Repo: "o/r", Title: "t", Agent: "a"})
+	c2.ProcessIssueRequestsOnce(context.Background())
+	if _, err := os.Stat(p2 + ".denied"); err != nil {
+		t.Fatalf("denial must quarantine: %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("nothing should be created under denial, got %d", created)
+	}
+}
+
+// Comments: kind=comment posts to the comments endpoint and is consumed.
+func TestIssueRequestWatcher_PostsComment(t *testing.T) {
+	commented := 0
+	srv := newIssueMockServer(t, "", nil, nil, &commented)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{
+		Kind: "comment", Repo: "o/r", Number: 41, Body: "triage note", Agent: "quality",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ProcessIssueRequestsOnce(context.Background())
+
+	if commented != 1 {
+		t.Fatalf("expected 1 comment, got %d", commented)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("comment request should be consumed")
+	}
+}
+
+// The authorizer receives the kind, so issue-vs-comment policy can differ.
+func TestIssueRequestWatcher_AuthzSeesKind(t *testing.T) {
+	srv := newIssueMockServer(t, "", nil, nil, nil)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+	var seen []string
+	c.issueAuthz = func(agent string, uid int, kind string) error {
+		seen = append(seen, kind)
+		return errors.New("deny to stop processing")
+	}
+	dir := withIssueDir(t)
+	_, _ = WriteIssueRequest(dir, IssueRequest{Repo: "o/r", Title: "t", Agent: "a"})
+	_, _ = WriteIssueRequest(dir, IssueRequest{Kind: "comment", Repo: "o/r", Number: 3, Body: "b", Agent: "a"})
+
+	c.ProcessIssueRequestsOnce(context.Background())
+
+	got := strings.Join(seen, ",")
+	if !strings.Contains(got, "issue") || !strings.Contains(got, "comment") {
+		t.Fatalf("authorizer should see both kinds, saw %q", got)
+	}
+}

--- a/src/pkg/github/issue_request_watcher_test.go
+++ b/src/pkg/github/issue_request_watcher_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -322,5 +323,138 @@ func TestIssueRequestWatcher_AuthzSeesKind(t *testing.T) {
 	got := strings.Join(seen, ",")
 	if !strings.Contains(got, "issue") || !strings.Contains(got, "comment") {
 		t.Fatalf("authorizer should see both kinds, saw %q", got)
+	}
+}
+
+// StartIssueRequestWatcher lifecycle: nil client is a no-op, the ticker loop
+// drives processing, and ctx cancel stops it.
+func TestIssueRequestWatcher_StartLoop(t *testing.T) {
+	var nilClient *Client
+	nilClient.StartIssueRequestWatcher(context.Background(), nil, nil) // must not panic
+	nilClient.ProcessIssueRequestsOnce(context.Background())           // must not panic
+
+	created := 0
+	srv := newIssueMockServer(t, "", &created, nil, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	oldInterval := issueRequestPollInterval
+	issueRequestPollInterval = 20 * time.Millisecond
+	t.Cleanup(func() { issueRequestPollInterval = oldInterval })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.StartIssueRequestWatcher(ctx, func(agent string, uid int, kind string) error { return nil }, nil)
+
+	if _, err := WriteIssueRequest(dir, IssueRequest{
+		Repo: "o/r", Title: "[sec-check] via ticker", Body: "b", Agent: "sec-check",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for created == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if created != 1 {
+		t.Fatalf("ticker loop never processed the request (created=%d)", created)
+	}
+	cancel() // loop exit path
+	time.Sleep(50 * time.Millisecond)
+}
+
+// The watcher disables itself (no panic, no goroutine) when the request dir
+// cannot be created.
+func TestIssueRequestWatcher_StartWithUncreatableDir(t *testing.T) {
+	srv := newIssueMockServer(t, "", nil, nil, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := issueRequestDirForTest
+	issueRequestDirForTest = filepath.Join(blocker, "issue-requests")
+	t.Cleanup(func() { issueRequestDirForTest = old })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.StartIssueRequestWatcher(ctx, nil, nil) // must return without panicking
+}
+
+// The production path constant is used when no test override is set.
+func TestIssueRequestDirDefault(t *testing.T) {
+	old := issueRequestDirForTest
+	issueRequestDirForTest = ""
+	t.Cleanup(func() { issueRequestDirForTest = old })
+	if got := issueRequestDir(); got != IssueRequestDir {
+		t.Fatalf("issueRequestDir() = %q, want %q", got, IssueRequestDir)
+	}
+}
+
+// WriteIssueRequest surfaces failures instead of losing the request silently.
+func TestWriteIssueRequest_Errors(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteIssueRequest(filepath.Join(blocker, "sub"), IssueRequest{
+		Repo: "o/r", Title: "t", Agent: "a",
+	}); err == nil {
+		t.Fatal("expected error when request dir cannot be created")
+	}
+}
+
+// CreateIssue input validation and degraded-path behavior.
+func TestCreateIssue_ValidationAndDegradedPaths(t *testing.T) {
+	var nilClient *Client
+	if _, err := nilClient.CreateIssue(context.Background(), "o/r", "t", "b", nil); !errors.Is(err, ErrNoGitHubClient) {
+		t.Fatalf("nil client: want ErrNoGitHubClient, got %v", err)
+	}
+
+	created := 0
+	srv := newIssueMockServer(t, "", &created, nil, nil)
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+
+	if _, err := c.CreateIssue(context.Background(), "o/r", "   ", "b", nil); err == nil {
+		t.Fatal("blank title must be rejected")
+	}
+
+	// Blank labels are skipped, usable ones attached; create succeeds.
+	res, err := c.CreateIssue(context.Background(), "o/r", "with labels", "b", []string{" ", "security"})
+	if err != nil || res.Number != 99 {
+		t.Fatalf("create with labels: res=%+v err=%v", res, err)
+	}
+}
+
+// A failing dedupe lookup or label-ensure must degrade, never block the create:
+// losing provenance labels is acceptable, losing the finding is not.
+func TestCreateIssue_DegradesWhenListAndLabelsFail(t *testing.T) {
+	created := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"): // dedupe list
+			w.WriteHeader(http.StatusInternalServerError)
+		case strings.Contains(r.URL.Path, "/labels"): // ensure-label lookups+creates
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			created++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":123,"html_url":"https://github.example/o/r/issues/123"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+
+	res, err := c.CreateIssue(context.Background(), "o/r", "finding", "body", []string{"security"})
+	if err != nil {
+		t.Fatalf("create must survive list/label failures: %v", err)
+	}
+	if created != 1 || res.Number != 123 || res.AlreadyExisted {
+		t.Fatalf("unexpected result: created=%d res=%+v", created, res)
 	}
 }

--- a/src/pkg/github/issue_request_watcher_test.go
+++ b/src/pkg/github/issue_request_watcher_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -333,8 +334,22 @@ func TestIssueRequestWatcher_StartLoop(t *testing.T) {
 	nilClient.StartIssueRequestWatcher(context.Background(), nil, nil) // must not panic
 	nilClient.ProcessIssueRequestsOnce(context.Background())           // must not panic
 
-	created := 0
-	srv := newIssueMockServer(t, "", &created, nil, nil)
+	// The watcher goroutine processes concurrently with this test, so the
+	// counter must be atomic (the shared newIssueMockServer uses a plain int).
+	var created atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/issues"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/issues"):
+			created.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":99,"html_url":"https://github.example/o/r/issues/99"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
 	defer srv.Close()
 	c := issueTestClient(t, srv.URL)
 	dir := withIssueDir(t)
@@ -353,11 +368,11 @@ func TestIssueRequestWatcher_StartLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 	deadline := time.Now().Add(5 * time.Second)
-	for created == 0 && time.Now().Before(deadline) {
+	for created.Load() == 0 && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if created != 1 {
-		t.Fatalf("ticker loop never processed the request (created=%d)", created)
+	if got := created.Load(); got != 1 {
+		t.Fatalf("ticker loop never processed the request (created=%d)", got)
 	}
 	cancel() // loop exit path
 	time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
## Problem
Agents' direct `gh issue create` / `gh issue comment` calls run inside the agent's shell tool. One GHE secondary-rate-limit stall, network blip, or shell-tool timeout and **the finding is silently lost**. Root-caused live 2026-08-21 on a hosted hive: sec-check's issue creates timed out mid-flight (3m36s+, twice); the CVE finding survived only as a bead. Identical commands run outside the burst window succeeded in <1s.

## Fix - mirror the proven hive-open-pr / hive-merge relay
- **gh-wrapper** redirects `issue create` and `issue|pr comment` (non-contributor agents) to a new **hive-open-issue** shim: writes a UID-owned JSON request file in **milliseconds**, no network in the agent's critical path. Contributors and `pr review` keep the direct path. ADVISORY/NO_GITHUB gates still run first.
- **Issue-request watcher** in hive core (10s tick, `/var/run/hive-metrics/issue-requests`) executes server-side with the App token:
  - per-request exponential backoff 30s->15min, 24h give-up -> `.failed` quarantine
  - malformed -> `.bad`, policy-denied -> `.denied`
  - exact-open-title **dedupe** via ListByRepo (GHE search index lags)
  - canary scan + logscrub, attribution trailer, audit actions
- **AuthorizeIssueOpen**: UID forge-resistance (request-file owner must map to the claimed agent) + live `CanCreateIssues()` mode gate; nil authorizer fails closed.
- **Pre-existing `set -e` landmine fixed**: `_extract_item` ended with `[[ -z $item_num ]] && ...` - any free-text arg after the number (`gh issue comment 951 --repo X --body text`) returned 1 and silently killed the wrapper before any API call.

## Live-tested on a hosted hive (before this PR, per requirement)
As the real `hive-sec-check` UID with the agent's exact env:
- create -> request file in **72ms**; watcher filed issue #951 in api-server via App token
- duplicate title -> `already_existed: true`, reused #951
- comments (both wrapper path and shim direct) -> posted on #951
- forged root-owned request claiming sec-check -> **DENIED**, `.denied` quarantine
- all test issues closed after verification

## Tests
- 8 new watcher unit tests (create/consume, dedupe, retry+backoff, max-age and malformed quarantine, fail-closed authz, comments)
- `go test ./pkg/github ./cmd/hive` green; wrapper suites 33+61 pass
