### PR TITLE
fix(hub): exception-first fleet view + fix legacy/placeholder false alarms

### DIFF
--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -151,6 +151,7 @@ type agentVerdict struct {
 	Stuck          bool   // expected active but not actually working
 	Impotent       bool   // actually running but not able
 	QuietByDesign  bool   // paused or expected-off — never a fault
+	Problem        bool   // THE alarm: governor expects it on, it can't deliver (any reason)
 	CapabilityTier string // tierGreen | tierAmber | tierRed | tierGray
 	BlockedReason  string // one human sentence; empty when Able
 }
@@ -221,9 +222,17 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	v.QuietByDesign = v.RunState == runQuietByDesign
 
 	// --- ABLE leg. ---
-	// Unknown for a legacy spoke: it reports no capabilities, so we cannot
-	// claim it is unable — leave Able=false, tier gray, and never mark Impotent.
+	// Unknown for a legacy spoke: it reports no capabilities or expected/enabled
+	// signals, so we cannot claim it is unable — leave Able=false, tier gray,
+	// and never mark Impotent. Its bare state="running" is NOT trustworthy as
+	// "working" here either: without the new signals we cannot tell working from
+	// impotent, and rendering "working" next to a gray capability badge reads as
+	// a contradiction (the Bluefin "off + working + ✗✗✗" confusion). Force the
+	// whole row to UNKNOWN so a legacy spoke never looks like either health or a
+	// fault — it looks like what it is: not yet reporting.
 	if legacy {
+		v.RunState = runUnknown
+		v.QuietByDesign = false
 		v.markUnknown()
 		return v
 	}
@@ -300,6 +309,15 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 		}
 	}
 
+	// PROBLEM is the ONE signal the operator scans for: the governor is calling
+	// this agent (expected active) AND it cannot do its work — for ANY reason
+	// (stuck at login, zombie session, dead, blocked, or running-but-impotent).
+	// It deliberately unifies Stuck and Impotent so the view has a single "is
+	// this a problem?" per agent. It is FALSE for paused/off-schedule agents
+	// (quiet by design — the operator's own choice, not called) and for legacy/
+	// unknown rows (returned early above — can't-verify is not broken).
+	v.Problem = a.ExpectedActive && !v.QuietByDesign && !v.Able
+
 	return v
 }
 
@@ -313,13 +331,23 @@ func (v *agentVerdict) markUnknown() {
 }
 
 // agentFleetRollup is the per-spoke divergence summary: the three counts the
-// header shows plus the two delta totals.
+// header shows, the delta totals, and the single Problems count that drives the
+// hive's health dot and its sort position.
 type agentFleetRollup struct {
 	Expected int `json:"expected"`
 	Running  int `json:"running"`
 	Able     int `json:"able"`
 	Stuck    int `json:"stuck"`
 	Impotent int `json:"impotent"`
+	// Problems is how many agents the governor expects on that cannot deliver
+	// (any reason) — THE alarm count. >0 → the hive's dot is red and it sorts to
+	// the top.
+	Problems int `json:"problems"`
+	// Known is how many agents reported the new divergence signals (non-legacy).
+	// When Known==0 the whole hive is UNKNOWN (a spoke not yet rolled to this
+	// build) and its dot is gray, never green — absence of a problem we cannot
+	// see is not health.
+	Known int `json:"known"`
 }
 
 // AgentVerdictJSON is the per-agent row the fleet view renders. It carries the
@@ -349,7 +377,12 @@ type AgentVerdictJSON struct {
 	Stuck          bool   `json:"stuck,omitempty"`
 	Impotent       bool   `json:"impotent,omitempty"`
 	QuietByDesign  bool   `json:"quietByDesign,omitempty"`
-	BlockedReason  string `json:"blockedReason,omitempty"`
+	// Problem is THE alarm: governor expects this agent on and it can't deliver.
+	Problem bool `json:"problem,omitempty"`
+	// Unknown means the spoke did not report the new divergence signals (legacy
+	// build). The frontend renders these rows as "unknown", never as off/✗.
+	Unknown       bool   `json:"unknown,omitempty"`
+	BlockedReason string `json:"blockedReason,omitempty"`
 }
 
 // buildAgentVerdicts derives the per-agent verdict rows for one hive, skipping
@@ -383,6 +416,8 @@ func buildAgentVerdicts(agents []AgentSummary, blockers hiveBlockers, queuedWork
 			Stuck:          v.Stuck,
 			Impotent:       v.Impotent,
 			QuietByDesign:  v.QuietByDesign,
+			Problem:        v.Problem,
+			Unknown:        v.CapabilityTier == tierGray,
 			BlockedReason:  v.BlockedReason,
 		})
 	}
@@ -407,6 +442,9 @@ func rollupAgents(agents []AgentSummary, blockers hiveBlockers, queuedWork int, 
 			continue
 		}
 		v := deriveAgentVerdict(a, blockers, queuedWork, now)
+		if v.CapabilityTier != tierGray {
+			r.Known++
+		}
 		if a.ExpectedActive {
 			r.Expected++
 		}
@@ -421,6 +459,9 @@ func rollupAgents(agents []AgentSummary, blockers hiveBlockers, queuedWork int, 
 		}
 		if v.Impotent {
 			r.Impotent++
+		}
+		if v.Problem {
+			r.Problems++
 		}
 	}
 	return r

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -165,6 +165,14 @@ func TestVerdict_LegacySpokeIsUnknownNeverAlarms(t *testing.T) {
 	if v.Able || v.Stuck || v.Impotent {
 		t.Errorf("legacy agent must not be able/stuck/impotent: %+v", v)
 	}
+	// Legacy agent must be run-state UNKNOWN (not "working" off a bare state
+	// field) and never a Problem — this is the Bluefin "off+working+✗✗✗" fix.
+	if v.RunState != runUnknown {
+		t.Errorf("legacy agent run-state = %v, want unknown", v.RunState)
+	}
+	if v.Problem {
+		t.Error("legacy/unknown agent must never be a PROBLEM (can't-verify ≠ broken)")
+	}
 	// A legacy stopped agent must not be called dead/stuck.
 	a2 := AgentSummary{Name: "old2", State: "stopped"}
 	v2 := deriveAgentVerdict(a2, hiveBlockers{}, 5, now)
@@ -238,5 +246,60 @@ func TestBuildAgentVerdicts_ShapeAndSkipBlank(t *testing.T) {
 	}
 	if !out[0].CanMerge || out[0].CapabilityTier != tierGreen {
 		t.Errorf("verdict JSON missing derived fields: %+v", out[0])
+	}
+}
+
+// PROBLEM = governor expects it on AND it can't deliver, for any reason. It
+// unifies stuck/impotent/blocked and never fires on paused/off/legacy agents.
+func TestVerdict_ProblemFlag(t *testing.T) {
+	now := time.Now()
+	// Expected + login-stuck → problem.
+	stuck := modernWorking(now)
+	stuck.NeedsLogin = true
+	if v := deriveAgentVerdict(stuck, hiveBlockers{}, 5, now); !v.Problem {
+		t.Error("expected + login-stuck must be a PROBLEM")
+	}
+	// Expected + hive-blocked (running but impotent) → problem.
+	blk := modernWorking(now)
+	if v := deriveAgentVerdict(blk, hiveBlockers{RepoTargetMisconfigured: true}, 5, now); !v.Problem {
+		t.Error("expected + blocked must be a PROBLEM")
+	}
+	// Expected + working + able → NOT a problem.
+	if v := deriveAgentVerdict(modernWorking(now), hiveBlockers{}, 5, now); v.Problem {
+		t.Error("healthy agent must not be a PROBLEM")
+	}
+	// Paused (even if it carries ExpectedActive) → NOT a problem.
+	paused := modernWorking(now)
+	paused.Paused, paused.State = true, "paused"
+	if v := deriveAgentVerdict(paused, hiveBlockers{}, 5, now); v.Problem {
+		t.Error("paused agent must never be a PROBLEM")
+	}
+	// Not expected active → NOT a problem even if it can't work.
+	off := modernWorking(now)
+	off.ExpectedActive, off.State = false, "stopped"
+	if v := deriveAgentVerdict(off, hiveBlockers{}, 5, now); v.Problem {
+		t.Error("off-schedule agent must never be a PROBLEM")
+	}
+}
+
+func TestRollup_ProblemsAndKnown(t *testing.T) {
+	now := time.Now()
+	healthy := modernWorking(now)
+	stuck := modernWorking(now)
+	stuck.Name, stuck.NeedsLogin = "quality", true
+	legacy := AgentSummary{Name: "old", State: "running", StartedAt: settled(now)}
+
+	r := rollupAgents([]AgentSummary{healthy, stuck, legacy}, hiveBlockers{}, 5, now)
+	if r.Problems != 1 {
+		t.Errorf("problems = %d, want 1 (the login-stuck one)", r.Problems)
+	}
+	if r.Known != 2 {
+		t.Errorf("known = %d, want 2 (legacy agent excluded)", r.Known)
+	}
+
+	// All-legacy hive: Known==0 so the frontend renders it UNKNOWN, not "0 able".
+	allLegacy := rollupAgents([]AgentSummary{legacy}, hiveBlockers{}, 5, now)
+	if allLegacy.Known != 0 || allLegacy.Problems != 0 {
+		t.Errorf("all-legacy hive must be known=0 problems=0, got %+v", allLegacy)
 	}
 }

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3354,7 +3354,15 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// heartbeat signals plus this hive's blocker fields. Derived on read so
 		// the browser never re-runs the state machine (shares classifyInactive‐
 		// Agent with the block above, so the two can never disagree).
-		if len(result[i].Agents) > 0 {
+		//
+		// SKIP placeholders/pool hives entirely: an unclaimed placeholder runs
+		// its default agents against no real repo, so they legitimately report
+		// "expected N · 0 able · N impotent" — a cascade of FALSE alarms that
+		// would drown the one signal the view exists for. No verdicts → the
+		// frontend has nothing to render for them and they carry no problem
+		// count. (isPlaceholderEntry is the same authoritative test computeFleet‐
+		// Stats and the alert layer use.)
+		if len(result[i].Agents) > 0 && !isPlaceholderEntry(result[i]) {
 			blockers := hiveBlockers{
 				GitHubAppRequired:       result[i].GitHubAppRequired,
 				GitHubAppPermIssue:      result[i].GitHubAppPermIssue,
@@ -9737,6 +9745,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <a href="/reading">Reading</a>
       <a href="/get-started">Get Started</a>
       <a href="/dashboard" style="color:var(--amber)">My Hives</a>
+      <a href="/my-hives" id="nav-fleet" style="display:none" title="Fleet health — agents the governor expects on but that can't work">Fleet</a>
       <a href="/api/docs" target="_blank">API</a>
       <a href="https://kubestellar.io/docs/hive/overview/introduction" target="_blank" rel="noopener">Docs</a>
       <span id="nav-user" class="nav-user"></span>
@@ -18412,6 +18421,8 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         _adminLoaded = true;
         document.getElementById('admin-section').style.display = '';
+        var navFleet = document.getElementById('nav-fleet');
+        if (navFleet) navFleet.style.display = '';
         /* The section is display:none until the admin check passes, so this is
            the first point at which the persisted collapse state can be pushed
            onto real DOM. Idempotent, so running it on every poll is fine. */

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -70,26 +70,44 @@
   .tick.yes { color: var(--green); }
   .tick.no { color: var(--red); }
   .delta { font-size: 11px; font-weight: 600; padding: 1px 7px; border-radius: 10px; }
-  .delta.stuck { background: rgba(229,72,77,.15); color: var(--red); border: 1px solid rgba(229,72,77,.4); }
-  .delta.impotent { background: rgba(224,168,0,.15); color: var(--amber); border: 1px solid rgba(224,168,0,.4); }
+  .delta.problem { background: rgba(229,72,77,.16); color: var(--red); border: 1px solid rgba(229,72,77,.45); }
   .delta.quiet { color: var(--muted); }
   .rel { color: var(--muted); font-size: 11px; }
   .status-msg { padding: 40px 0; text-align: center; color: var(--muted); }
   a.reload { color: var(--accent); text-decoration: none; }
   [title] { cursor: help; }
+  /* Health dot (left of hive name) — reflects PROBLEMS, not online/offline. */
+  .hdot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 8px; vertical-align: middle; }
+  .hdot.problem { background: var(--red); box-shadow: 0 0 0 3px rgba(229,72,77,.18); }
+  .hdot.ok { background: var(--green); }
+  .hdot.unknown { background: var(--gray); }
+  .hdot.offline { background: transparent; border: 1px solid var(--gray); }
+  /* Problem hives get a red left border so the eye lands on them. */
+  tr.spoke.health-problem td:first-child { border-left: 3px solid var(--red); }
+  tr.spoke.health-problem { background: rgba(229,72,77,.05); }
+  tr.agent.is-problem td { background: rgba(229,72,77,.07); }
+  /* Header summary + controls. */
+  .summary { font-size: 13px; }
+  .allclear { color: var(--green); font-weight: 600; }
+  .controls { margin-left: auto; display: flex; gap: 14px; font-size: 12px; color: var(--muted); }
+  .controls label { cursor: pointer; user-select: none; }
 </style>
 </head>
 <body>
 <header>
-  <h1>Fleet — Expected vs Actual vs Able</h1>
-  <span class="sub">what the governor expects running · what is actually running · what can fulfill its mission</span>
+  <h1>Fleet health</h1>
+  <span class="sub">a hive is a <b>problem</b> when the governor expects an agent on but it can't do its work</span>
+  <span id="summary" class="summary"></span>
+  <span class="controls">
+    <label><input type="checkbox" id="problemsOnly"> problems only</label>
+    <label><input type="checkbox" id="showHealthy"> show healthy</label>
+  </span>
 </header>
 <div class="wrap">
   <div class="legend">
-    <span><span class="dot on"></span><b>on</b> / <span class="dot off"></span>off</span>
-    <span><b>run-state:</b> working · idle · stuck-at-login · session-gone · dead · <span style="border:1px solid var(--green);border-radius:50%;display:inline-block;width:7px;height:7px"></span> quiet-by-design</span>
+    <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting)</span>
+    <span><span class="delta problem">PROBLEM</span> governor expects it on, it can't work · <span class="delta quiet">quiet</span> paused / off by schedule</span>
     <span><b>capability:</b> <span style="color:var(--green)">green</span> able · <span style="color:var(--amber)">amber</span> partial · <span style="color:var(--red)">red</span> blocked · <span style="color:var(--gray)">gray</span> unknown</span>
-    <span><span class="delta stuck">STUCK</span> expected-on, not running · <span class="delta impotent">IMPOTENT</span> running, can't work</span>
   </div>
   <table>
     <thead>
@@ -131,14 +149,17 @@ function modeBadge(m) { return '<span class="badge">' + esc(m || "—") + '</spa
 
 function rollupHTML(r) {
   if (!r) return '<span class="output">no agents reported</span>';
+  // Legacy spoke: nothing known → say so, don't render "expects 0 · 0 able".
+  if ((r.known || 0) === 0) return '<span class="output">unknown (spoke not yet reporting)</span>';
   var exp = r.expected || 0, run = r.running || 0, able = r.able || 0;
   var runCls = run < exp ? "warn" : "", ableCls = able < run ? "bad" : "";
-  var extra = "";
-  if (r.stuck) extra += ' <span class="delta stuck" title="expected active but not running">' + r.stuck + ' stuck</span>';
-  if (r.impotent) extra += ' <span class="delta impotent" title="running but unable to work">' + r.impotent + ' impotent</span>';
+  var alarm = "";
+  if ((r.problems || 0) > 0) {
+    alarm = ' <span class="delta problem" title="governor expects these agents on but they cannot work">' + r.problems + ' PROBLEM' + (r.problems > 1 ? "S" : "") + '</span>';
+  }
   return '<span class="rollup">expects <span class="n">' + exp + '</span>' +
     '<span class="sep">·</span><span class="n ' + runCls + '">' + run + '</span> running' +
-    '<span class="sep">·</span><span class="n ' + ableCls + '">' + able + '</span> able' + extra + '</span>';
+    '<span class="sep">·</span><span class="n ' + ableCls + '">' + able + '</span> able' + alarm + '</span>';
 }
 function outputHTML(h) {
   var m = h.prsMerged90d || 0, rej = h.prsRejected90d || 0, cve = h.cvesClosed || 0;
@@ -147,6 +168,9 @@ function outputHTML(h) {
     ' · rejected ' + rej + ' · CVEs ' + cve + '</span>';
 }
 function toggleHTML(a) {
+  // A legacy/unknown spoke did not report enabled/paused meaningfully — render
+  // "unknown", never "off" (the Bluefin false-off bug).
+  if (a.unknown) return '<span class="rel">unknown</span>';
   if (a.paused) {
     var prov = [];
     if (a.pausedBy || a.pausedTrigger) prov.push("by " + (a.pausedBy || a.pausedTrigger));
@@ -158,12 +182,15 @@ function toggleHTML(a) {
   return '<span><span class="dot off"></span>off</span>';
 }
 function runStateHTML(a) {
-  var rs = a.runState || "unknown";
+  var rs = a.unknown ? "unknown" : (a.runState || "unknown");
   var label = rs.replace(/-/g, " ");
   var rel = a.lastActivityAt ? ' <span class="rel">' + esc(relTime(a.lastActivityAt)) + '</span>' : "";
   return '<span class="rs ' + esc(rs) + '"><span class="swatch"></span>' + esc(label) + '</span>' + rel;
 }
 function capHTML(a) {
+  // Unknown (legacy): a single "unknown" chip, NOT red ✗ ticks — we cannot see
+  // its capability, and rendering ✗ reads as a hard failure it may not have.
+  if (a.unknown) return '<span class="cap gray" title="spoke has not reported capability yet"><span class="light"></span></span> <span class="ticks">unknown</span>';
   var tier = a.capabilityTier || "gray";
   function tick(ok, lbl) { return '<span class="tick ' + (ok ? "yes" : "no") + '">' + (ok ? "✓" : "✗") + " " + lbl + "</span>"; }
   var ticks = '<span class="ticks">' + tick(a.canOpenIssue, "issue") + " " +
@@ -172,26 +199,71 @@ function capHTML(a) {
   return '<span class="cap ' + esc(tier) + '"' + t + '><span class="light"></span></span> ' + ticks;
 }
 function deltaHTML(a) {
-  if (a.stuck) return '<span class="delta stuck" title="expected active, not running">STUCK</span>';
-  if (a.impotent) return '<span class="delta impotent"' + (a.blockedReason ? ' title="' + esc(a.blockedReason) + '"' : "") + '>IMPOTENT' + (a.blockedReason ? ": " + esc(a.blockedReason) : "") + '</span>';
-  if (a.quietByDesign) return '<span class="delta quiet">quiet by design</span>';
+  // THE alarm first: governor expects it on, it can't deliver (any reason).
+  if (a.problem) {
+    var why = a.blockedReason || (a.runState || "").replace(/-/g, " ") || "can't work";
+    return '<span class="delta problem" title="governor expects this agent on, but it cannot work">PROBLEM: ' + esc(why) + '</span>';
+  }
+  if (a.quietByDesign) return '<span class="delta quiet">quiet</span>';
   return "";
 }
+// hiveHealth returns "problem" | "ok" | "unknown" for the left dot, from the
+// rollup: any problem agent → problem; else if nothing is known (legacy spoke)
+// → unknown; else ok. Online/offline is NOT health — a spoke can be online with
+// every agent stuck.
+function hiveHealth(h) {
+  var r = h.fleetRollup;
+  if (!r) return h.online ? "unknown" : "offline";
+  if ((r.problems || 0) > 0) return "problem";
+  if ((r.known || 0) === 0) return "unknown";
+  if (!h.online) return "offline";
+  return "ok";
+}
+
+// Expand state persists across the 30s refresh (keyed by hive id) so an open
+// section does not collapse under the operator. "problems only" and "show all
+// hives" toggles persist in the same in-memory state.
+var expanded = {};      // hive id -> true when its agent rows are open
+var problemsOnly = false;
+var showHealthy = false; // when false, healthy hives are hidden to cut noise
+
+function hiveKey(h) { return h.id || h.name; }
 
 function renderHives(hives) {
   var tb = document.getElementById("rows");
   tb.innerHTML = "";
-  if (!hives || !hives.length) {
-    tb.innerHTML = '<tr><td colspan="6" class="status-msg">No hives.</td></tr>';
-    return;
-  }
-  hives.forEach(function (h, idx) {
-    var online = h.online ? "on" : "off";
+  hives = hives || [];
+
+  // Rank: problems first, then unknown, then ok; stable within a rank by name.
+  var rank = { problem: 0, unknown: 1, offline: 2, ok: 3 };
+  var rows = hives.map(function (h) { return { h: h, health: hiveHealth(h) }; });
+  rows.sort(function (a, b) {
+    var d = (rank[a.health] || 9) - (rank[b.health] || 9);
+    if (d) return d;
+    return String(a.h.name || a.h.id).localeCompare(String(b.h.name || b.h.id));
+  });
+
+  var problemCount = rows.filter(function (r) { return r.health === "problem"; }).length;
+  var shown = 0;
+  rows.forEach(function (row) {
+    var h = row.h, health = row.health;
+    // Exception-first filtering.
+    if (problemsOnly && health !== "problem") return;
+    if (!problemsOnly && !showHealthy && health === "ok") return;
+    shown++;
+
+    var isProblem = health === "problem";
+    var key = hiveKey(h);
+    // Problem hives auto-expand the first time they appear; the operator can
+    // still collapse them (tracked in `expanded`).
+    if (isProblem && !(key in expanded)) expanded[key] = true;
+    var open = !!expanded[key];
+
     var tr = document.createElement("tr");
-    tr.className = "spoke";
+    tr.className = "spoke health-" + health + (open ? " open" : "");
     tr.innerHTML =
       '<td><span class="chev">▶</span></td>' +
-      '<td><span class="dot ' + online + '"></span><span class="name">' + esc(h.name || h.id) + '</span></td>' +
+      '<td><span class="hdot ' + health + '" title="' + health + '"></span><span class="name">' + esc(h.name || h.id) + '</span></td>' +
       '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
       '<td>' + modeBadge(h.governorMode) + '</td>' +
       '<td>' + rollupHTML(h.fleetRollup) + '</td>' +
@@ -200,10 +272,14 @@ function renderHives(hives) {
 
     var verdicts = h.agentVerdicts || [];
     var subRows = [];
-    verdicts.forEach(function (a) {
+    // In an expanded problem hive, float the problem agents to the top.
+    var ordered = verdicts.slice().sort(function (a, b) {
+      return (b.problem ? 1 : 0) - (a.problem ? 1 : 0);
+    });
+    ordered.forEach(function (a) {
       var sub = document.createElement("tr");
-      sub.className = "agent";
-      sub.style.display = "none";
+      sub.className = "agent" + (a.problem ? " is-problem" : "");
+      sub.style.display = open ? "" : "none";
       sub.innerHTML =
         '<td></td>' +
         '<td class="aname">' + esc(a.name) + (a.backend ? ' <span class="badge">' + esc(a.backend) + '</span>' : "") + '</td>' +
@@ -217,18 +293,44 @@ function renderHives(hives) {
     if (!verdicts.length) {
       var empty = document.createElement("tr");
       empty.className = "agent";
-      empty.style.display = "none";
-      empty.innerHTML = '<td></td><td class="aname" colspan="5"><span class="output">no per-agent detail reported (spoke may predate this view)</span></td>';
+      empty.style.display = open ? "" : "none";
+      empty.innerHTML = '<td></td><td class="aname" colspan="5"><span class="output">no per-agent detail (spoke not yet reporting)</span></td>';
       tb.appendChild(empty);
       subRows.push(empty);
     }
     tr.addEventListener("click", function () {
-      var open = tr.classList.toggle("open");
-      subRows.forEach(function (s) { s.style.display = open ? "" : "none"; });
+      expanded[key] = !expanded[key];
+      var o = expanded[key];
+      tr.classList.toggle("open", o);
+      subRows.forEach(function (s) { s.style.display = o ? "" : "none"; });
     });
   });
+
+  // Header summary + empty-state messaging.
+  var hdr = document.getElementById("summary");
+  if (hdr) {
+    hdr.innerHTML = problemCount > 0
+      ? '<span class="delta problem">' + problemCount + ' hive' + (problemCount > 1 ? "s" : "") + ' need attention</span>'
+      : '<span class="allclear">✓ all hives clear</span>';
+  }
+  if (!shown) {
+    var msg = problemsOnly
+      ? "No problems — every governor-expected agent is delivering."
+      : (problemCount === 0 && !showHealthy ? "No problems. Healthy hives hidden — toggle “show healthy”." : "No hives.");
+    var trE = document.createElement("tr");
+    trE.innerHTML = '<td colspan="6" class="status-msg">' + esc(msg) + '</td>';
+    tb.appendChild(trE);
+  }
 }
 
+function wireControls() {
+  var po = document.getElementById("problemsOnly");
+  if (po) po.addEventListener("change", function () { problemsOnly = po.checked; load(); });
+  var sh = document.getElementById("showHealthy");
+  if (sh) sh.addEventListener("change", function () { showHealthy = sh.checked; load(); });
+}
+
+var lastHives = [];
 function load() {
   fetch("/api/saas/my-hives", { credentials: "same-origin", headers: { "Accept": "application/json" } })
     .then(function (r) {
@@ -239,13 +341,14 @@ function load() {
       if (!r.ok) throw new Error("HTTP " + r.status);
       return r.json();
     })
-    .then(function (d) { renderHives(d.hives || []); })
+    .then(function (d) { lastHives = d.hives || []; renderHives(lastHives); })
     .catch(function (e) {
       if (e && e.message === "redirecting to login") return;
       var c = document.getElementById("statusCell");
       if (c) c.innerHTML = "Failed to load: " + esc(e.message) + ' — <a class="reload" href="/my-hives">retry</a>';
     });
 }
+wireControls();
 load();
 setInterval(load, 30000);
 </script>


### PR DESCRIPTION
Follow-up to #4437. The operator tried to use the fleet view and hit exactly the failures below — the view enumerated agents instead of **surfacing the one thing that matters: is the governor calling an agent that can't do its work?** — and it raised false alarms that made it untrustworthy.

## The core reframe: exception-first

A hive is a **PROBLEM** when the governor **expects an agent on** but it **can't do its work — for any reason** (stuck at login, zombie session, dead, blocked, running-but-impotent). That single signal now drives everything:
- the **left dot** (red = problem, green = all clear, gray = unknown/not reporting) — it used to mean *online*, which is why a hive could show a green dot with 4 impotent agents
- the **rollup pill** (`expects N · M running · K able · **P PROBLEMS**`)
- **sort order** — problem hives float to the top and auto-expand; problem agents float to the top within a hive
- a **"problems only" / "show healthy"** filter so healthy hives don't compete for attention (healthy hidden by default)

`PROBLEM = expectedActive && !able`, suppressed for paused / off-schedule / legacy agents (their own choice or can't-verify — never a fault).

## False alarms fixed (these made it unusable)

1. **Placeholder/pool hives** (unclaimed, no real repo) showed `expects 4 · 0 able · 4 impotent` across ~20 rows. Now **skipped entirely** in `handleMyHives` via the authoritative `isPlaceholderEntry` — no verdicts, no false problem count. (Frontend also filters them belt-and-suspenders.)

2. **Legacy spokes** (not yet rolled to #4437) rendered agents as **"off + working + ✗✗✗"** — the operator's "Bluefin confusion." Root cause: `enabled=false` absent → "off", but the old `state=running` → "working", plus red capability ticks. Now forced to **UNKNOWN end to end**: run-state unknown, tier gray, toggle + capability render "unknown" (never off / red ✗). A hive where nothing is known reads **"unknown"**, not "expects 0 · 0 able". STUCK/IMPOTENT/PROBLEM never fire on a legacy spoke.

## Other fixes

3. **Expand state persists across the 30s auto-refresh** (keyed by hive id) — it used to collapse any section the operator had opened.

4. **Admin-only "Fleet" nav link in `/dashboard`** — revealed on the same admin check that reveals the admin section, so the view is reachable from where operators already are (the nav "My Hives" tab goes to `/dashboard`, and the fleet view was previously an orphan page).

## Tests
- `Problem` flag across stuck / blocked / paused / off-schedule / healthy
- rollup `Problems` + `Known` counts (legacy agents excluded from Known; all-legacy hive → known=0)
- legacy agent → run-state UNKNOWN + never a PROBLEM (the Bluefin regression)
- existing verdict/tier/rollup tests still hold

## Files
- `src/pkg/hub/agent_capability.go` — `Problem` flag, `Problems`/`Known` rollup counts, `Unknown` JSON, legacy → run-state unknown
- `src/pkg/hub/saas.go` — skip placeholders in verdict derivation; admin "Fleet" nav link + reveal
- `src/pkg/hub/static/my-hives.html` — exception-first render, health dot, sort, problems-only/show-healthy filters, expand persistence, unknown rendering
- `src/pkg/hub/agent_capability_test.go` — new tests

gofmt clean; JS `node --check` clean; DCO-signed. Pre-existing v4 beads/sandbox/hub flakiness is unrelated.