### PR TITLE
🐛 fix hub hive search filtering

### DIFF
--- a/src/pkg/hub/health_check_detail_test.go
+++ b/src/pkg/hub/health_check_detail_test.go
@@ -140,7 +140,8 @@ func TestFilterComposition(t *testing.T) {
 		{"clear resets check filter", "_dashFailingCheckFilter = '';"},
 		// Placeholder scoping is unchanged and still splits before filtering.
 		{"placeholder split retained", "(isPlaceholderHive(allHives[_si]) ? unassignedAll : assignedAll)"},
-		{"filters applied to assigned only", "applyDashFilters(assignedAll).concat(unassignedAll)"},
+		{"filters applied to assigned only", "var filteredAssigned = applyDashFilters(assignedAll);"},
+		{"search scopes unassigned rows", "unassignedAll.filter(hiveMatchesSearch)"},
 		// Any-active must account for the check filter so the Clear button
 		// shows. The per-filter OR chain was replaced by activeFilterCount(),
 		// which also drives the "N filters active" summary; the check filter now

--- a/src/pkg/hub/my_hives_query.go
+++ b/src/pkg/hub/my_hives_query.go
@@ -21,7 +21,7 @@ import (
 const maxMyHivesPerPage = 500
 
 type myHivesQuery struct {
-	q       string // case-insensitive substring across id/name/org/project/owner/repo
+	q       string // case-insensitive substring across id/name/org/project/owner/repo/cluster
 	status  string // "online", "offline", or an exact provStatus (available, assigned, provisioning, error, ...)
 	cluster string // ClusterID or ClusterName, case-insensitive
 	sortKey string // id | name | org | owner | cluster | status | last_seen
@@ -62,6 +62,7 @@ func entryMatches(e *MyHiveEntry, q myHivesQuery) bool {
 		needle := strings.ToLower(q.q)
 		hay := strings.ToLower(strings.Join([]string{
 			e.ID, e.Name, e.Org, e.ProjectName, e.Owner, e.PrimaryRepo,
+			strings.Join(e.Repos, " "), e.ClusterID, e.ClusterName,
 		}, "\x00"))
 		if !strings.Contains(hay, needle) {
 			return false

--- a/src/pkg/hub/my_hives_query_test.go
+++ b/src/pkg/hub/my_hives_query_test.go
@@ -26,8 +26,18 @@ func testMyHivesEntries() []MyHiveEntry {
 		return e
 	}
 	return []MyHiveEntry{
-		mk("hosted-alpha", "acme", "alice", "vllm-d", "assigned", "2026-08-20T10:00:00Z", true),
-		mk("hosted-beta", "acme", "bob", "hive-oke", statusAvailable, "", false),
+		func() MyHiveEntry {
+			e := mk("hosted-alpha", "acme", "alice", "vllm-d", "assigned", "2026-08-20T10:00:00Z", true)
+			e.ClusterName = "VLLM Dallas"
+			e.Repos = []string{"alpha-api", "alpha-ui"}
+			return e
+		}(),
+		func() MyHiveEntry {
+			e := mk("hosted-beta", "acme", "bob", "hive-oke", statusAvailable, "", false)
+			e.ClusterName = "OKE East"
+			e.Repos = []string{"beta-worker"}
+			return e
+		}(),
 		mk("hosted-gamma", "zorg", "alice", "vllm-d", "provisioning", "2026-08-20T12:00:00Z", false),
 		mk("hosted-delta", "zorg", "carol", "vllm-d", "assigned", "2026-08-20T11:00:00Z", true),
 	}
@@ -61,6 +71,14 @@ func TestApplyMyHivesQueryFilters(t *testing.T) {
 	_, matched = applyMyHivesQuery(entries, mhq(t, "cluster=hive-oke"))
 	if matched != 1 {
 		t.Errorf("cluster=hive-oke matched %d, want 1", matched)
+	}
+	_, matched = applyMyHivesQuery(entries, mhq(t, "q=OKE East"))
+	if matched != 1 {
+		t.Errorf("q=OKE East matched %d, want 1", matched)
+	}
+	_, matched = applyMyHivesQuery(entries, mhq(t, "q=alpha-ui"))
+	if matched != 1 {
+		t.Errorf("q=alpha-ui matched %d, want 1", matched)
 	}
 	_, matched = applyMyHivesQuery(entries, mhq(t, "q=alice&cluster=vllm-d&status=online"))
 	if matched != 1 {

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -13866,8 +13866,11 @@ const dashboardHTML = `<!DOCTYPE html>
         : '';
     }
 
-    /* applyDashFilters filters the hives the caller wants rendered.
-       Placeholder (unassigned) rows bypass every filter — see isPlaceholderHive.
+    /* applyDashFilters filters the assigned hives the caller wants rendered.
+       Unassigned pool placeholders are handled separately in renderHives:
+       health/status/facet filters do not hide inventory, but the search box
+       still narrows every displayed row so typing text cannot leave unrelated
+       placeholders visible under an active search.
        For assigned rows all four narrowing mechanisms compose as an AND: the
        status chips (by state), the alert-type filter (hives carrying that
        alert), the search box and the facets. That is what "click an alert type
@@ -13875,7 +13878,6 @@ const dashboardHTML = `<!DOCTYPE html>
        active. */
     function applyDashFilters(hives) {
       return (hives || []).filter(function(h) {
-        if (isPlaceholderHive(h)) return true;
         return hiveMatchesFilters(h) && hiveMatchesAlertFilter(h) &&
           hiveMatchesSearch(h) && hiveMatchesFacets(h);
       });
@@ -15477,12 +15479,14 @@ const dashboardHTML = `<!DOCTYPE html>
         '|' + _dashFacetTrayOpen;
       if (!force && sig === _lastHivesJSON) return;
       _lastHivesJSON = sig;
-      /* Status filters describe ASSIGNED hives only. An unassigned placeholder
-         has no GitHub App, no tokens and no real health to speak of, so every
-         chip would appear to "hide" the whole pool — and filtering to e.g.
-         Degraded made the Unassigned section vanish, which reads as the
-         placeholders having been deleted. Split first, filter only the assigned
-         side, and leave the pool alone. */
+      /* Status/facet filters describe ASSIGNED hives only. An unassigned
+         placeholder has no GitHub App, no tokens and no real health to speak of,
+         so every chip would appear to "hide" the whole pool — and filtering to
+         e.g. Degraded made the Unassigned section vanish, which reads as the
+         placeholders having been deleted. The free-text search is different:
+         it promises to filter the displayed rows by visible metadata, so it
+         also scopes placeholders by name/id/cluster/repo instead of leaving
+         unrelated inventory visible while the header says a search is active. */
       var assignedAll = [], unassignedAll = [];
       for (var _si = 0; _si < allHives.length; _si++) {
         (isPlaceholderHive(allHives[_si]) ? unassignedAll : assignedAll).push(allHives[_si]);
@@ -15492,7 +15496,11 @@ const dashboardHTML = `<!DOCTYPE html>
          _upgradingHives from here on, so they cannot observe each other's
          mutations and the pill can no longer disagree with the badge. */
       normalizeUpgradeStates(assignedAll);
-      var hives = applyDashFilters(assignedAll).concat(unassignedAll);
+      var filteredAssigned = applyDashFilters(assignedAll);
+      var filteredUnassigned = (_dashSearchQuery || '').trim()
+        ? unassignedAll.filter(hiveMatchesSearch)
+        : unassignedAll;
+      var hives = filteredAssigned.concat(filteredUnassigned);
       var filterBar = document.getElementById('hive-filter-bar');
       if (filterBar) filterBar.style.display = allHives.length ? '' : 'none';
       var searchRow = document.getElementById('hive-search-row');
@@ -15510,7 +15518,7 @@ const dashboardHTML = `<!DOCTYPE html>
       if (viewBar) viewBar.style.display = allHives.length ? '' : 'none';
       renderViewBar();
       /* Counts are over the assigned set only, matching what the chips filter. */
-      renderStatusFilterBar(assignedAll, hives.length - unassignedAll.length);
+      renderStatusFilterBar(assignedAll, filteredAssigned.length);
       /* Facets are offered over the assigned set for the same reason the chips
          are: a placeholder carries no cluster, role or branch worth faceting. */
       renderFacetRail(assignedAll);
@@ -15545,12 +15553,11 @@ const dashboardHTML = `<!DOCTYPE html>
       }
       if (!hives.length) {
         /* Hives exist, but every one was filtered out — say so, and offer the
-           way back rather than looking like the list failed to load. Only
-           assigned hives can be hidden, so report that count, not the total. */
+           way back rather than looking like the list failed to load. */
         document.getElementById('hives-container').innerHTML =
           '<div class="empty-state">' +
           '<p style="font-size:1.2rem;margin-bottom:8px">No hives match these filters</p>' +
-          '<p>' + assignedAll.length + (assignedAll.length === 1 ? ' hive is' : ' hives are') + ' hidden by the search, facets or status filters.</p>' +
+          '<p>' + allHives.length + (allHives.length === 1 ? ' hive is' : ' hives are') + ' hidden by the search, facets or status filters.</p>' +
           /* clearAllHiveFilters, not clearStatusFilters: a search term, a facet
              or an alert drill-down can empty the list too, and a button that
              only clears the chips would leave the operator stuck looking at an

--- a/src/pkg/hub/saas_dashboard_myhives_ux_test.go
+++ b/src/pkg/hub/saas_dashboard_myhives_ux_test.go
@@ -131,20 +131,22 @@ func TestDashboardRenderCacheSignature(t *testing.T) {
 	}
 }
 
-// TestDashboardPlaceholdersBypassFilters asserts the scoping rule shared by the
-// chips, the search box and the facets: an unassigned placeholder is never
-// filtered out, so the pool an admin is about to assign from cannot vanish
-// while they type.
-func TestDashboardPlaceholdersBypassFilters(t *testing.T) {
+// TestDashboardPlaceholdersBypassNonSearchFilters asserts the split scoping
+// rule: status/facet filters do not hide unassigned inventory, but free-text
+// search still narrows placeholders so the visible rows match the search box.
+func TestDashboardPlaceholdersBypassNonSearchFilters(t *testing.T) {
 	html := dashScript(t)
-	const want = "if (isPlaceholderHive(h)) return true;"
+	const want = "var filteredUnassigned = (_dashSearchQuery || '').trim()"
 	if !strings.Contains(html, want) {
-		t.Error("applyDashFilters must let placeholder hives bypass every filter")
+		t.Error("renderHives must apply free-text search to unassigned placeholders")
 	}
-	// Each predicate is checked independently: applyDashFilters ANDs these
-	// together, but other features (e.g. the fleet-alert drill-down) add their
-	// own terms to the same chain, so pinning one exact expression would break
-	// on every such addition without indicating a real regression.
+	if !strings.Contains(html, "var hives = filteredAssigned.concat(filteredUnassigned);") {
+		t.Error("renderHives must render the search-filtered placeholder set")
+	}
+	// Each assigned-row predicate is checked independently: applyDashFilters
+	// ANDs these together, but other features (e.g. the fleet-alert drill-down)
+	// add their own terms to the same chain, so pinning one exact expression
+	// would break on every such addition without indicating a real regression.
 	for _, pred := range []string{
 		"hiveMatchesFilters(h)",
 		"hiveMatchesSearch(h)",


### PR DESCRIPTION
## Summary
- make the Hive HUB dashboard free-text search filter unassigned placeholder rows as well as assigned rows
- keep status/facet/alert filters scoped to assigned hives so inventory is not hidden by non-search controls
- extend server-side `/api/saas/my-hives?q=` matching to include all repos plus cluster ID/name

## Root cause
The dashboard split assigned hives from unassigned placeholders before rendering and appended all placeholders after filtering assigned rows. That preserved pool visibility for status/facet filters, but it also let unrelated placeholders remain visible while the search box and header indicated an active text filter.

## Validation
- `cd src && go test ./pkg/hub -run 'TestApplyMyHivesQueryFilters|TestDashboardPlaceholdersBypassNonSearchFilters|TestDashboardRenderCacheSignature'`
- `cd src && go test ./pkg/hub`
- `cd src && go build ./...`
- `cd src && go vet ./...`
