### PR TITLE
🐛 fix(proxy): resolve litellm model-id drift to the exact entitled gateway id

### DIFF
--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -162,15 +162,26 @@ entitled:    aws/claude-sonnet-4-6
                  ^^^^         ^
 ```
 
-`.` versus `-`, and a missing `aws/` prefix, are each enough for a 403. Hive passes
-inference-backend model ids through **verbatim** on purpose — the gateway is the only
-thing that knows its own naming, so hive rewriting the id would produce a model the
-team is not entitled to. Fix it in the agent's `model:` setting, not in hive.
+`.` versus `-`, and a missing `aws/` prefix, are each enough for a 403. For plain
+`vllm`/`llm-d` backends hive passes model ids through **verbatim** on purpose — the
+server is the only thing that knows its own naming — so fix drift there in the
+agent's `model:` setting.
+
+For **`litellm`** gateways this drift now self-heals
+([#4400](https://github.com/kubestellar/hive/issues/4400)): hive learns the key's
+entitled model set (from a key-info probe, or from the first team-scope 403 itself)
+and, when the configured id differs from **exactly one** entitled id only by
+separator (`.`/`-`), case, or provider-prefix drift, forwards that exact entitled id
+instead. The first request after a fresh start may still 403 (that 403 is what
+teaches the entitled set); subsequent requests resolve. An id that matches nothing —
+or matches more than one entitled id — is still sent verbatim, so correct the
+agent's `model:` setting to an id from the allowed list in that case.
 
 **Why one agent fails and another with "the same" model does not:** they are not the
 same string. Compare the two agents' configured `model:` values directly rather than
 the model each was *meant* to use — a single separator differs and only one of them
-matches the gateway.
+matches the gateway. (Note the dashboard's model dropdown matches tolerantly, so both
+agents can *display* the same selection while their stored ids differ.)
 
 Before [#4400](https://github.com/kubestellar/hive/issues/4400) hive read that line as
 a login prompt: it badged the agent 🔑, and — because a valid token was on disk —

--- a/src/pkg/proxy/entitlement.go
+++ b/src/pkg/proxy/entitlement.go
@@ -200,6 +200,60 @@ func (e *entitlementStore) get(endpoint string) (models []string, source string,
 	return out, entry.source, true, time.Since(entry.at) > entitlementTTL
 }
 
+// entitledModelKey reduces a model id to a drift-insensitive comparison key:
+// the segment after the last provider prefix "/" with every "." folded to "-",
+// case-insensitively. This is the same tolerance the dashboard's preselect
+// matcher applies (prefix-stripped tail + dot/hyphen normalization, #4262) —
+// but here it is used to RESOLVE the outbound id, never to mask drift.
+func entitledModelKey(id string) string {
+	tail := id
+	if i := strings.LastIndex(id, "/"); i >= 0 {
+		tail = id[i+1:]
+	}
+	return strings.ToLower(strings.ReplaceAll(tail, ".", "-"))
+}
+
+// resolveEntitledModelID maps a stored model id onto the exact entitled
+// gateway id it drifted from. LiteLLM matches the request model VERBATIM
+// against the team's entitled set — "claude-sonnet-4.6" is refused with a
+// team-scope 403 even when "aws/claude-sonnet-4-6" is entitled (#4400: a
+// default agent carried its copilot-spelled dotted model id into a litellm
+// backend switch and 403'd forever, while an agent added later with an id
+// picked from discovery worked — same model, different spelling).
+//
+// Resolution is deliberately conservative:
+//   - an id already present verbatim in the entitled set is returned as-is;
+//   - otherwise, if EXACTLY ONE entitled id shares the model's comparison key
+//     (entitledModelKey: prefix-stripped, dot/hyphen-folded, case-folded),
+//     that entitled id is returned;
+//   - zero or multiple candidates return the input unchanged — an ambiguous
+//     rewrite could silently bill a different provider's deployment.
+func resolveEntitledModelID(entitled []string, model string) (string, bool) {
+	if model == "" || len(entitled) == 0 {
+		return model, false
+	}
+	for _, id := range entitled {
+		if id == model {
+			return model, false
+		}
+	}
+	key := entitledModelKey(model)
+	match := ""
+	for _, id := range entitled {
+		if entitledModelKey(id) != key {
+			continue
+		}
+		if match != "" {
+			return model, false // ambiguous — never guess between providers
+		}
+		match = id
+	}
+	if match == "" {
+		return model, false
+	}
+	return match, true
+}
+
 // parseTeam403Models extracts the entitled model ids from a LiteLLM
 // "team not allowed to access model" 403 body. It returns nil when the body is
 // not a team-scope denial or carries no models=[...] list, so callers can

--- a/src/pkg/proxy/entitlement_test.go
+++ b/src/pkg/proxy/entitlement_test.go
@@ -255,3 +255,116 @@ func TestRecordInferenceError_IgnoresProviderErrorsAndOtherBackends(t *testing.T
 		t.Fatalf("vllm 403 must not record entitlements")
 	}
 }
+
+// resolveEntitledModelID maps separator/prefix drift onto the exact entitled
+// gateway id — the #4400 field case: a default agent's copilot-spelled
+// "claude-sonnet-4.6" must resolve to the team's entitled
+// "aws/claude-sonnet-4-6", because LiteLLM matches the request model verbatim
+// and 403s anything else. Ambiguity or no candidate leaves the id untouched.
+func TestResolveEntitledModelID(t *testing.T) {
+	fmaSet := []string{
+		"gemini-2.5-pro", "gemini-2.5-flash",
+		"gcp/gemini-3.1-pro-preview", "aws/claude-sonnet-4-6", "aws/claude-opus-4-7",
+	}
+	cases := []struct {
+		name     string
+		entitled []string
+		model    string
+		want     string
+		wantOK   bool
+	}{
+		{"field case: dotted copilot spelling resolves to entitled aws id",
+			fmaSet, "claude-sonnet-4.6", "aws/claude-sonnet-4-6", true},
+		{"verbatim entitled id passes through",
+			fmaSet, "aws/claude-sonnet-4-6", "aws/claude-sonnet-4-6", false},
+		{"prefixless dashed spelling resolves",
+			fmaSet, "claude-sonnet-4-6", "aws/claude-sonnet-4-6", true},
+		{"stored prefix drifts to entitled prefixless id",
+			[]string{"gpt-4o"}, "Azure/gpt-4o", "gpt-4o", true},
+		{"case drift resolves",
+			fmaSet, "AWS/Claude-Sonnet-4-6", "aws/claude-sonnet-4-6", true},
+		{"no candidate stays unchanged",
+			fmaSet, "claude-sonnet-4-5", "claude-sonnet-4-5", false},
+		{"ambiguous providers stay unchanged",
+			[]string{"aws/claude-sonnet-4-6", "gcp/claude-sonnet-4.6"},
+			"claude-sonnet-4-6", "claude-sonnet-4-6", false},
+		{"empty model stays unchanged", fmaSet, "", "", false},
+		{"empty entitled set stays unchanged", nil, "claude-sonnet-4.6", "claude-sonnet-4.6", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := resolveEntitledModelID(tc.entitled, tc.model)
+			if got != tc.want || ok != tc.wantOK {
+				t.Fatalf("resolveEntitledModelID(%v, %q) = (%q, %v), want (%q, %v)",
+					tc.entitled, tc.model, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// routeWithEntitledModel rewrites the FORWARDED route only: a known entitled
+// set plus resolvable drift yields a copy carrying the exact entitled id,
+// while the stored route (what the dashboard and persistence see) is never
+// mutated. Unknown entitlements, non-litellm backends, and unresolvable ids
+// pass the original route through by identity.
+func TestRouteWithEntitledModel(t *testing.T) {
+	p := &GitHubProxy{
+		logger:       slog.Default(),
+		inference:    newInferenceRouter(),
+		entitlements: newEntitlementStore(),
+	}
+	route := &InferenceRoute{
+		Backend:  "litellm",
+		Endpoint: "https://gw.example.com",
+		Model:    "claude-sonnet-4.6", // copilot-spelled drift (#4400)
+		APIKey:   "sk-team",
+	}
+	p.inference.Set("scanner", route)
+
+	// Entitled set unknown yet: pass-through by identity.
+	if got := p.routeWithEntitledModel(route, "scanner"); got != route {
+		t.Fatalf("unknown entitlements must pass the route through unchanged")
+	}
+
+	// A team-scope 403 teaches the entitled set (the self-heal trigger).
+	p.recordInferenceError(route, "scanner", http.StatusForbidden,
+		[]byte(`team not allowed to access model. This team can only access `+
+			`models=['gemini-2.5-pro','aws/claude-sonnet-4-6','aws/claude-opus-4-7']`))
+
+	got := p.routeWithEntitledModel(route, "scanner")
+	if got == route {
+		t.Fatalf("resolvable drift must return a rewritten copy")
+	}
+	if got.Model != "aws/claude-sonnet-4-6" {
+		t.Fatalf("forwarded model = %q, want aws/claude-sonnet-4-6", got.Model)
+	}
+	if got.Endpoint != route.Endpoint || got.APIKey != route.APIKey || got.Backend != route.Backend {
+		t.Fatalf("rewrite must only touch Model: %+v", got)
+	}
+	// Stored route untouched — the rewrite is per-request, never persisted.
+	if p.inference.Get("scanner").Model != "claude-sonnet-4.6" {
+		t.Fatalf("stored route must not be mutated")
+	}
+
+	// A verbatim-entitled model passes through by identity.
+	entitledRoute := &InferenceRoute{Backend: "litellm", Endpoint: "https://gw.example.com",
+		Model: "aws/claude-sonnet-4-6", APIKey: "sk-team"}
+	if got := p.routeWithEntitledModel(entitledRoute, "quality"); got != entitledRoute {
+		t.Fatalf("entitled model must pass through unchanged")
+	}
+
+	// Non-litellm backends never rewrite (vllm/llm-d ids are authoritative).
+	vllm := &InferenceRoute{Backend: "vllm", Endpoint: "https://gw.example.com", Model: "claude-sonnet-4.6"}
+	if got := p.routeWithEntitledModel(vllm, "scanner"); got != vllm {
+		t.Fatalf("non-litellm backend must pass through unchanged")
+	}
+
+	// Nil route / nil entitlement store are safe pass-throughs.
+	if got := p.routeWithEntitledModel(nil, "scanner"); got != nil {
+		t.Fatalf("nil route must return nil")
+	}
+	bare := &GitHubProxy{logger: slog.Default()}
+	if got := bare.routeWithEntitledModel(route, "scanner"); got != route {
+		t.Fatalf("nil entitlement store must pass through unchanged")
+	}
+}

--- a/src/pkg/proxy/github_proxy.go
+++ b/src/pkg/proxy/github_proxy.go
@@ -1618,6 +1618,41 @@ func (p *GitHubProxy) recordInferenceError(route *InferenceRoute, agentName stri
 		"agent", agentName, "endpoint", route.Endpoint, "count", len(entitled), "model", route.Model)
 }
 
+// routeWithEntitledModel returns the route to actually forward with: when the
+// gateway's entitled model set is known (key-info probe or a prior team-scope
+// 403) and the route's stored model differs from an entitled id only by
+// provider-prefix / dot-hyphen spelling drift, a COPY of the route carrying
+// the exact entitled id is returned. LiteLLM matches the request model string
+// verbatim, so without this a stored copilot-spelled id (e.g.
+// "claude-sonnet-4.6" vs entitled "aws/claude-sonnet-4-6") 403s on every call
+// forever (#4400) — while the dashboard's tolerant preselect matcher shows the
+// agent on a perfectly valid model. Self-healing: the first 403 teaches the
+// entitled set (recordInferenceError), so the next request resolves.
+//
+// The stored route is never mutated: the rewrite is per-request, so a
+// key/team change that re-entitles the verbatim id takes effect immediately,
+// and concurrent requests race on nothing. Unknown entitlements, verbatim
+// matches, and ambiguous candidates all pass the route through unchanged.
+func (p *GitHubProxy) routeWithEntitledModel(route *InferenceRoute, agentName string) *InferenceRoute {
+	if route == nil || route.Backend != "litellm" || p.entitlements == nil {
+		return route
+	}
+	entitled, _, known := p.EntitledModels(route.Endpoint)
+	if !known {
+		return route
+	}
+	resolved, ok := resolveEntitledModelID(entitled, route.Model)
+	if !ok {
+		return route
+	}
+	p.logger.Info("inference model resolved to entitled gateway id",
+		"agent", agentName, "endpoint", route.Endpoint,
+		"configured", route.Model, "resolved", resolved)
+	rewritten := *route
+	rewritten.Model = resolved
+	return &rewritten
+}
+
 // recordInferenceSuccess records a successful inference call so a previously
 // latched auth-failure signal clears — the self-heal for the inference-auth
 // health signal. Called from every inference forward path on a 2xx response.
@@ -1699,6 +1734,7 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 			http.Error(w, `{"type":"error","error":{"type":"api_error","message":"no inference route for agent"}}`, http.StatusBadGateway)
 			return
 		}
+		route = p.routeWithEntitledModel(route, agentName)
 
 		body, err := io.ReadAll(r.Body)
 		if r.Body != nil {
@@ -1895,6 +1931,7 @@ func (p *GitHubProxy) handleAnthropicReroute(conn net.Conn, r *http.Request, hos
 // handleInferenceRequest translates a single Anthropic API request and
 // forwards it to the inference backend.
 func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, agentName string, route *InferenceRoute) {
+	route = p.routeWithEntitledModel(route, agentName)
 	conn.SetReadDeadline(time.Now().Add(httpReadTimeout))
 	body, err := io.ReadAll(req.Body)
 	conn.SetReadDeadline(time.Time{})


### PR DESCRIPTION
## Summary

Root-cause fix for #4400 — the remaining mystery after #4446: **why the scanner got a 403 on a model the quality agent used fine.**

### Root cause
LiteLLM matches the request model string **verbatim** against the team's entitled set. The FMA scanner's stored model id was the copilot-spelled `claude-sonnet-4.6` (dotted — the shipped default-agent spelling), while the team's entitled id is `aws/claude-sonnet-4-6`. Same underlying model, different string → `team not allowed to access model` 403 on every call. The quality agent was added later with an id picked from live discovery, so its string matched.

The dashboard **masked** the asymmetry twice over: its tolerant preselect matcher (prefix-stripped tail + dot/hyphen folding, #4262) displays both agents on the same valid selection, and the same tolerance in the auto-heal availability check meant reconcile (#1848) never considered the scanner's model missing — so nothing ever healed it.

### Fix
On both inference forward paths (the :18444 translator and the MITM reroute), when the gateway's entitled set is known — from the key-info probe or a prior team-scope 403 — and the route's model differs from **exactly one** entitled id only by separator/case/provider-prefix drift, forward that exact entitled id.

- **Self-healing:** the first 403 teaches the entitled set (`recordInferenceError`), so the very next request resolves — no operator action.
- **Conservative:** verbatim-entitled ids pass through untouched; ambiguous candidates (two providers offering the same tail) are never guessed; vllm/llm-d ids stay authoritative and are never rewritten; the stored route is never mutated (per-request rewrite, so a re-entitled verbatim id takes effect immediately).

### Validation
- `go vet ./pkg/proxy/` clean, `go test ./pkg/proxy/ -count=1 -cover` → **89.8%** (floor 89).
- New tests cover the exact FMA field case (dotted → `aws/`-prefixed entitled id), verbatim pass-through, ambiguity, case/prefix drift, stored-route immutability, and nil-safety.
- `docs/troubleshooting.md` (added by #4446) updated for the new self-heal behavior.

Closes #4400