### PR TITLE
ci: guard the release-line carry-forward — nine workflows are pinned to branch names (#4405)

### DIFF
--- a/.github/release-lines.yml
+++ b/.github/release-lines.yml
@@ -1,0 +1,75 @@
+# Release-line branch allow-lists — the single source of truth for which
+# version branches CI is expected to cover.
+#
+# Nine workflows pin their `push` / `pull_request` triggers to an explicit list
+# of version-branch names. That list is hand-maintained, and it has already
+# failed once: podman-contract.yml named `v2` alone, mainline moved to `v4`, and
+# the workflow stopped running entirely (#4339). A guard that never executes
+# reports green forever, which is the one failure mode a guard cannot have.
+# Adding `v4` fixed that instance and left the mechanism intact, so the same
+# failure was queued up for the day `v5` is cut. #4405 asks for the guard.
+#
+# src/scripts/check-release-lines.sh asserts this file against
+# .github/workflows/*.yml, and .github/workflows/release-line-guard.yml runs it
+# on every branch. See src/docs/release-line-guard.md.
+#
+# CUTTING A NEW RELEASE LINE: add the branch name to `release_lines` below AND
+# to every workflow listed under `pinned`. The guard fails until both are done —
+# that is the whole point, so do not "fix" it by only editing one side.
+
+# The release lines CI is expected to cover.
+release_lines: [v2, v4]
+
+# Workflows whose branch filters are pinned to the release lines.
+#
+# The value adjusts `release_lines` for that workflow:
+#   `[]`      release lines and nothing else
+#   `[name]`  an EXTRA branch this workflow legitimately allows
+#   `[-name]` a release line this workflow deliberately does NOT cover
+# EVERY `branches:` list in the file must equal `release_lines`, plus the
+# extras, minus the exclusions — exactly, no more and no less. An exclusion has
+# to be written down, which is the point: it turns a silent gap into a line
+# somebody has to justify, and a new release line still has to be added or
+# explicitly excluded here before the guard goes green again.
+pinned:
+  podman-arm64-lane.yml: []
+  podman-contract.yml: []
+  podman-rootful-lane.yml: []
+  podman-rootless-lane.yml: []
+  quadlet-gate.yml: []
+  # scorecard.yml also runs on `main`, which is not a release line and does not
+  # fit a `v*` pattern — this is why the guard asserts a set rather than
+  # replacing the pins with a wildcard. It has also never run on `v2`; that is
+  # recorded as an exclusion rather than quietly corrected, because turning
+  # OpenSSF Scorecard on for a release line is a maintainer decision, not a
+  # side effect of adding a CI guard. See the note at the bottom of this file.
+  scorecard.yml: [main, -v2]
+  suid-contract.yml: []
+  v2-ci.yml: []
+  v2-tests.yml: []
+
+# Workflows that deliberately do NOT pin to the release lines. Each must keep a
+# wildcard branch filter; if one is ever narrowed to a fixed list, the guard
+# fails and asks for it to be reclassified as `pinned`.
+unpinned:
+  # Builds a PR's image on every branch on purpose, with bot branches excluded.
+  docker.yml: '**'
+  # The guard itself. It must run on any branch, or it is #4339 one level up.
+  release-line-guard.yml: '**'
+
+# MAINTAINER DECISION — deliberately NOT answered here (#4405).
+#
+# Should `v2` still be in these allow-lists? Mainline is `v4`, yet eight of the
+# nine pinned workflows still fire on `v2` pushes and PRs — and the ninth,
+# scorecard.yml, never has, which is the inconsistency this guard surfaced on
+# its first run. Whether `v2` is still a supported release line is a maintainer
+# call, so this file records the status quo rather than picking a side:
+#
+#   - if `v2` IS still supported, scorecard.yml's `-v2` exclusion should be
+#     dropped and `v2` added to that workflow;
+#   - if it is NOT, remove `v2` from `release_lines` above and from the eight
+#     workflows that name it (and drop the now-redundant `-v2`).
+#
+# Either way it is one edit to `release_lines` plus the workflows, and this
+# guard proves the edit is complete. Until a maintainer says otherwise, the
+# current behaviour stands unchanged.

--- a/.github/workflows/podman-contract.yml
+++ b/.github/workflows/podman-contract.yml
@@ -11,7 +11,9 @@ name: Podman Rootless Contract
 # guard that never executes reports green forever, which is the one failure
 # mode a guard cannot have. The branch list and the self-referencing path entry
 # below mirror .github/workflows/suid-contract.yml, the sibling static contract
-# check.
+# check. The branch list is no longer trusted to stay correct by hand: it is
+# asserted against .github/release-lines.yml by release-line-guard.yml (#4405),
+# so cutting the next release line fails CI until this block is updated too.
 on:
   push:
     branches:

--- a/.github/workflows/release-line-guard.yml
+++ b/.github/workflows/release-line-guard.yml
@@ -1,0 +1,57 @@
+name: Release Line Guard
+
+# Guards the release-line carry-forward (#4405).
+#
+# Nine workflows pin their push/pull_request triggers to a hand-maintained list
+# of version-branch names. That list has already gone stale once: when mainline
+# moved from v2 to v4, podman-contract.yml was left naming `v2` alone and
+# stopped running entirely (#4339). Not red — absent, which is the one failure
+# mode a guard cannot have. This asserts every one of those lists against the
+# single source of truth in .github/release-lines.yml, so cutting `v5` becomes
+# one edit that CI enforces rather than nine edits nobody is reminded to make.
+#
+# TRIGGERS ON EVERY BRANCH ON PURPOSE. A guard against branch-pinned workflows
+# must not itself be branch-pinned, or it is #4339 one level up — hence the
+# `'**'` here and the `unpinned` entry for this file in the manifest, which the
+# guard checks on itself.
+#
+# The path filter is safe in a way a branch filter would not be: this invariant
+# can only be broken by editing a workflow, the manifest, or the checker, and
+# all three are matched below.
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/**'
+      - '.github/release-lines.yml'
+      - 'src/scripts/check-release-lines.sh'
+      - 'src/scripts/test-release-lines-guard.sh'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/**'
+      - '.github/release-lines.yml'
+      - 'src/scripts/check-release-lines.sh'
+      - 'src/scripts/test-release-lines-guard.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-lines-in-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Self-test first: it proves the checker still FAILS on a stale
+      # allow-list. A checker that has quietly stopped detecting anything would
+      # otherwise pass the step below for the wrong reason.
+      - name: Prove the guard still catches a stale allow-list
+        run: src/scripts/test-release-lines-guard.sh
+
+      - name: Check workflow branch filters against .github/release-lines.yml
+        run: src/scripts/check-release-lines.sh

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -102,3 +102,4 @@ Some documents describe planned or design-only work rather than live features. T
 - [Architecture Decision Records](https://github.com/kubestellar/hive/blob/v4/src/docs/adr/README.md) — lightweight ADR process and records 0001-0017.
 - [Intent verification](https://github.com/kubestellar/hive/blob/v4/src/docs/intent-verification.md) — tier-based change authorization for merge eligibility.
 - [Rootless Podman CI seam](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-ci.md) — documented test intent and static contract for contributor-container runtime handling.
+- [Release-line carry-forward guard](release-line-guard.md) — the nine workflows pinned to hardcoded version-branch names, the single source of truth they are asserted against, and what to edit when a new release line is cut.

--- a/src/docs/release-line-guard.md
+++ b/src/docs/release-line-guard.md
@@ -1,0 +1,122 @@
+# Release-line carry-forward guard (#4405)
+
+## Why this exists
+
+Nine workflows pin their `push` / `pull_request` triggers to a hardcoded list of
+version-branch names. That list is hand-maintained, and it has already gone
+stale once. `podman-contract.yml` named `v2` alone, mainline moved to `v4`, and
+the workflow stopped running entirely
+([#4339](https://github.com/kubestellar/hive/issues/4339)). Its own header
+records the lesson:
+
+> a guard that never executes reports green forever, which is the one failure
+> mode a guard cannot have.
+
+That fix added `v4` to the list. It did not change the fact that the list is
+hand-maintained, so the same failure was simply queued up for the day `v5` is
+cut. `docker.yml` is the outlier that does not have the problem — it triggers on
+`'**'` with bot branches excluded, deliberately, so a PR's image always builds.
+
+So on the day `v5` branches, without this guard: the Docker image keeps building
+on every branch, while both CI workflows, both security contract gates and all
+five Podman guards report nothing at all. Not red — *absent*.
+
+## What the guard is
+
+Three files:
+
+| File | Role |
+|---|---|
+| `.github/release-lines.yml` | Single source of truth: the release lines, and how each workflow relates to them. |
+| `src/scripts/check-release-lines.sh` | Asserts every workflow's branch filters against that manifest. |
+| `.github/workflows/release-line-guard.yml` | Runs it, on **every** branch. |
+
+The [issue](https://github.com/kubestellar/hive/issues/4405) offered two shapes.
+This is shape 1, *assert the set*, and not shape 2, *remove the pins* (trigger
+on `v*`). Two reasons:
+
+- `scorecard.yml` triggers on `main`, which is not a release line and does not
+  match `v*`. A pattern cannot express it, so a pattern would leave the workflow
+  pinned anyway — the guard would still be needed, for a smaller set.
+- A `v*` pattern silently widens what runs. Any branch someone happens to name
+  `validate-thing` starts running the Podman lanes. Coverage would be correct by
+  construction, but nobody would be able to see what it covers.
+
+Asserting the set keeps the trigger blocks saying literally what they run on,
+and turns cutting `v5` into one edit that CI enforces.
+
+## Cutting a new release line
+
+1. Add the branch name to `release_lines` in `.github/release-lines.yml`.
+2. Add it to the trigger block of every workflow listed under `pinned`.
+
+Doing only step 1 fails the guard, naming each workflow that would not run on
+the new branch. That is the demonstration
+`src/scripts/test-release-lines-guard.sh` performs in CI, against the real
+workflow files:
+
+```
+FAIL: v2-ci.yml:5 branches: has [v2,v4], expected [v2,v4,v5] — missing: v5.
+      A release line named here but absent from the workflow means that
+      workflow does not run on it at all.
+```
+
+## What it checks
+
+- **Both YAML spellings.** `branches: [v2, v4]` (v2-ci.yml, v2-tests.yml) and
+  the block sequence used by the Podman lanes and the contract gates. A checker
+  that understood only block sequences would silently skip the two highest-value
+  entries.
+- **Every branch filter in a file**, not the first one — `push` and
+  `pull_request` blocks drift apart independently.
+- **Classification is mandatory.** A workflow with a branch filter that appears
+  in neither `pinned` nor `unpinned` fails. The next pinned workflow somebody
+  adds is the next #4339.
+- **Deliberate wildcards stay deliberate.** `docker.yml` is declared `unpinned`
+  and is not flagged — but if its `'**'` is ever narrowed to a fixed list, that
+  *is* flagged, and asks for it to be reclassified.
+- **Stale manifest entries.** An entry naming a workflow that no longer exists,
+  or one that has lost its branch filter, fails. A guard checking a file with
+  nothing left to check is green for no reason.
+
+`pinned` values adjust the expected set per workflow: `[main]` is an extra
+branch the workflow legitimately allows, `[-v2]` a release line it deliberately
+does not cover. An exclusion has to be written down, which is the point — it
+turns a silent gap into a line somebody has to justify.
+
+## The guard is not subject to the bug it guards against
+
+`release-line-guard.yml` triggers on `branches: ['**']`, and is itself listed
+under `unpinned` in the manifest, so the guard checks that fact about itself on
+every run. A branch-pinned guard against branch-pinned workflows would be #4339
+one level up.
+
+Its path filter (`.github/**`, the manifest, the two scripts) is safe in a way a
+branch filter would not be: this invariant can only be broken by editing a
+workflow, the manifest, or the checker.
+
+The workflow runs the self-test *before* the check, because a checker that has
+quietly stopped detecting anything would otherwise pass the real check for the
+wrong reason.
+
+## Open: should `v2` still be in these lists?
+
+Deliberately **not** answered by this guard — it is a maintainer call about
+release-line support, and the issue asks for it to be surfaced rather than
+settled. What the guard surfaced on its first run is that the repository is not
+currently consistent about it: mainline is `v4`, eight of the nine pinned
+workflows still fire on `v2`, and the ninth — `scorecard.yml` — never has. That
+gap is recorded as `-v2` in the manifest rather than quietly corrected, because
+turning OpenSSF Scorecard on for a release line is a decision, not a side effect
+of adding a CI guard.
+
+Either resolution is one edit to `release_lines` plus the workflows, and the
+guard proves the edit is complete. See the note at the bottom of
+`.github/release-lines.yml`.
+
+## Running it locally
+
+```sh
+src/scripts/check-release-lines.sh          # assert the repository is in sync
+src/scripts/test-release-lines-guard.sh     # prove the checker still fails when it should
+```

--- a/src/scripts/check-release-lines.sh
+++ b/src/scripts/check-release-lines.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# check-release-lines.sh — release-line carry-forward guard (#4405).
+#
+# Nine workflows pin their push/pull_request triggers to a hand-maintained list
+# of version-branch names. When mainline moved from v2 to v4, one of them was
+# left naming `v2` alone and stopped running entirely (#4339) — absent, not red.
+# This asserts every pinned workflow against the single source of truth in
+# .github/release-lines.yml, so cutting a new release line is one edit that CI
+# enforces instead of nine edits nobody is reminded to make.
+#
+# It reads both YAML spellings of a branch filter:
+#
+#   branches: [v2, v4]          # flow sequence  (v2-ci.yml, v2-tests.yml)
+#   branches:                   # block sequence (the podman lanes, scorecard's
+#     - v2                      #                 siblings, suid-contract)
+#     - v4
+#
+# A workflow that carries a branch filter must be classified in the manifest as
+# either `pinned` (its list must equal release_lines, plus any declared extras,
+# minus any declared `-exclusions`) or `unpinned` (it must keep a wildcard, e.g.
+# docker.yml's '**'). An unclassified one fails: a new pinned workflow is
+# exactly the thing that goes stale next.
+#
+# Usage: src/scripts/check-release-lines.sh [manifest] [workflows-dir]
+#   manifest        default .github/release-lines.yml
+#   workflows-dir   default .github/workflows
+#
+# Exit 0 = in sync, 1 = out of sync (or the inputs are unreadable).
+set -uo pipefail
+
+MANIFEST="${1:-.github/release-lines.yml}"
+WORKFLOW_DIR="${2:-.github/workflows}"
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "ERROR: manifest not found at ${MANIFEST}" >&2
+  exit 1
+fi
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+  echo "ERROR: workflow directory not found at ${WORKFLOW_DIR}" >&2
+  exit 1
+fi
+
+fail=0
+
+note_fail() { echo "  FAIL: $*"; fail=1; }
+note_ok()   { echo "  ok: $*"; }
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+# Strip a YAML flow sequence "[a, b]" (or "[]") down to a comma-free word list.
+flow_items() {
+  local raw="$1"
+  raw="${raw#*[}"
+  raw="${raw%%]*}"
+  raw="${raw//,/ }"
+  raw="${raw//\"/}"
+  raw="${raw//\'/}"
+  echo $raw
+}
+
+# Normalise a branch set: sorted, de-duplicated, comma-joined.
+normalise() {
+  if [[ $# -eq 0 ]]; then
+    echo ""
+    return
+  fi
+  printf '%s\n' "$@" | LC_ALL=C sort -u | paste -sd, -
+}
+
+RELEASE_LINES=()
+declare -A PINNED_EXTRAS=()
+UNPINNED=()
+
+section=""
+while IFS= read -r line; do
+  # Comments are stripped only where they cannot be inside a value; every value
+  # in this manifest is a flow sequence or a quoted scalar on one line.
+  case "$line" in
+    \#*|"") continue ;;
+  esac
+  if [[ "$line" =~ ^release_lines:[[:space:]]*(.*)$ ]]; then
+    read -r -a RELEASE_LINES <<< "$(flow_items "${BASH_REMATCH[1]}")"
+    section=""
+    continue
+  fi
+  if [[ "$line" =~ ^pinned:[[:space:]]*$ ]];   then section="pinned";   continue; fi
+  if [[ "$line" =~ ^unpinned:[[:space:]]*$ ]]; then section="unpinned"; continue; fi
+  if [[ "$line" =~ ^[^[:space:]] ]]; then section=""; continue; fi
+
+  # Indented entry: "  name.yml: value"
+  [[ "$line" =~ ^[[:space:]]+([^[:space:]#][^:]*):[[:space:]]*(.*)$ ]] || continue
+  entry="${BASH_REMATCH[1]}"
+  value="${BASH_REMATCH[2]}"
+  case "$section" in
+    pinned)   PINNED_EXTRAS["$entry"]="$(flow_items "$value")" ;;
+    unpinned) UNPINNED+=("$entry") ;;
+  esac
+done < "$MANIFEST"
+
+if [[ ${#RELEASE_LINES[@]} -eq 0 ]]; then
+  echo "ERROR: ${MANIFEST} declares no release_lines" >&2
+  exit 1
+fi
+
+echo "== Release-line carry-forward guard =="
+echo "manifest:  ${MANIFEST}"
+echo "workflows: ${WORKFLOW_DIR}"
+echo "release lines: $(normalise "${RELEASE_LINES[@]}")"
+echo
+
+# ---------------------------------------------------------------------------
+# Workflow branch filters
+# ---------------------------------------------------------------------------
+
+# Emits one TSV record per branch filter found:
+#   <file>\t<line-number>\t<key>\t<comma-joined branch entries>
+# An empty final field means an empty list, which is itself a finding.
+extract_branch_filters() {
+  awk '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function unquote(s,  c) {
+      s = trim(s)
+      if (length(s) >= 2) {
+        c = substr(s, 1, 1)
+        if ((c == "\"" || c == "'"'"'") && substr(s, length(s), 1) == c)
+          return substr(s, 2, length(s) - 2)
+      }
+      return s
+    }
+    # Drop a trailing YAML comment without touching a "#" inside quotes.
+    function strip_comment(s,  i, c, q, out) {
+      q = ""; out = ""
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (q != "") { out = out c; if (c == q) q = ""; continue }
+        if (c == "\"" || c == "'"'"'") { q = c; out = out c; continue }
+        if (c == "#") break
+        out = out c
+      }
+      return out
+    }
+    function indent_of(s,  i, c) {
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (c != " " && c != "\t") return i - 1
+      }
+      return length(s)
+    }
+    function flush(  i, joined) {
+      if (!pending) return
+      joined = ""
+      for (i = 1; i <= n; i++) joined = joined (i > 1 ? "," : "") items[i]
+      printf "%s\t%d\t%s\t%s\n", fname, startline, key, joined
+      pending = 0; n = 0; inblock = 0
+    }
+    FNR == 1 { flush() }
+    {
+      raw = strip_comment($0)
+      if (pending && inblock) {
+        if (raw ~ /^[[:space:]]*$/) next
+        if (indent_of(raw) > blockind && match(raw, /^[[:space:]]*-[[:space:]]*/)) {
+          items[++n] = unquote(substr(raw, RSTART + RLENGTH))
+          next
+        }
+        flush()
+      }
+      if (match(raw, /^[[:space:]]*(branches|branches-ignore):[[:space:]]*/)) {
+        key = raw; sub(/:.*$/, "", key); key = trim(key)
+        rest = trim(substr(raw, RSTART + RLENGTH))
+        fname = FILENAME; startline = FNR; pending = 1; n = 0
+        if (rest == "") { inblock = 1; blockind = indent_of(raw); next }
+        if (substr(rest, 1, 1) == "[") {
+          inner = substr(rest, 2, index(rest, "]") - 2)
+          cnt = split(inner, parts, ",")
+          for (i = 1; i <= cnt; i++) if (trim(parts[i]) != "") items[++n] = unquote(parts[i])
+        } else {
+          items[++n] = unquote(rest)   # single scalar, e.g. `branches: v4`
+        }
+        flush()
+      }
+    }
+    END { flush() }
+  ' "$@"
+}
+
+shopt -s nullglob
+workflow_files=("$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml)
+shopt -u nullglob
+if [[ ${#workflow_files[@]} -eq 0 ]]; then
+  echo "ERROR: no workflow files under ${WORKFLOW_DIR}" >&2
+  exit 1
+fi
+
+records="$(extract_branch_filters "${workflow_files[@]}")"
+
+declare -A SEEN_FILTERS=()
+while IFS=$'\t' read -r path lineno key branches; do
+  [[ -n "$path" ]] || continue
+  base="${path##*/}"
+  SEEN_FILTERS["$base"]=1
+
+  expected_extras="${PINNED_EXTRAS[$base]-__unset__}"
+  is_unpinned=0
+  for u in "${UNPINNED[@]}"; do [[ "$u" == "$base" ]] && is_unpinned=1; done
+
+  if [[ "$expected_extras" != "__unset__" && $is_unpinned -eq 1 ]]; then
+    note_fail "${base} is listed under BOTH pinned and unpinned in ${MANIFEST}"
+    continue
+  fi
+
+  IFS=',' read -r -a actual <<< "$branches"
+  actual_set="$(normalise "${actual[@]}")"
+
+  if [[ $is_unpinned -eq 1 ]]; then
+    if [[ "$branches" == *'*'* ]]; then
+      note_ok "${base}:${lineno} ${key}: wildcard kept (${actual_set}) — deliberately unpinned"
+    else
+      note_fail "${base}:${lineno} ${key}: declared unpinned in ${MANIFEST} but the filter is now a fixed list (${actual_set:-<empty>}). Reclassify it under 'pinned', or restore the wildcard."
+    fi
+    continue
+  fi
+
+  if [[ "$expected_extras" == "__unset__" ]]; then
+    note_fail "${base}:${lineno} ${key}: workflow has a branch filter (${actual_set:-<empty>}) but is not classified in ${MANIFEST}. Add it under 'pinned' (with any extra branches) or 'unpinned'."
+    continue
+  fi
+
+  # A manifest value may carry `-name` entries: release lines this workflow
+  # deliberately does not cover. Expected = release_lines + extras - exclusions.
+  extras=()
+  excluded=()
+  for token in $expected_extras; do
+    if [[ "$token" == -* ]]; then excluded+=("${token#-}"); else extras+=("$token"); fi
+  done
+
+  expected=()
+  for rl in "${RELEASE_LINES[@]}"; do
+    skip=0
+    for ex in ${excluded[@]+"${excluded[@]}"}; do [[ "$ex" == "$rl" ]] && skip=1; done
+    [[ $skip -eq 0 ]] && expected+=("$rl")
+  done
+  expected+=(${extras[@]+"${extras[@]}"})
+
+  bad_exclusion=0
+  for ex in ${excluded[@]+"${excluded[@]}"}; do
+    found=0
+    for rl in "${RELEASE_LINES[@]}"; do [[ "$ex" == "$rl" ]] && found=1; done
+    if [[ $found -eq 0 ]]; then
+      note_fail "${base}: ${MANIFEST} excludes '-${ex}', which is not a declared release line. Drop the stale exclusion."
+      bad_exclusion=1
+    fi
+  done
+  [[ $bad_exclusion -eq 1 ]] && continue
+
+  if [[ ${#expected[@]} -eq 0 ]]; then
+    note_fail "${base}:${lineno} ${key}: ${MANIFEST} excludes every release line and declares no extras, so nothing is asserted. Move it to 'unpinned' or fix the entry."
+    continue
+  fi
+
+  expected_set="$(normalise "${expected[@]}")"
+
+  if [[ "$actual_set" == "$expected_set" ]]; then
+    note_ok "${base}:${lineno} ${key}: ${actual_set}"
+    continue
+  fi
+
+  missing="$(comm -23 \
+    <(printf '%s\n' "${expected[@]}" | LC_ALL=C sort -u) \
+    <(printf '%s\n' "${actual[@]}" | LC_ALL=C sort -u) | paste -sd, -)"
+  unexpected="$(comm -13 \
+    <(printf '%s\n' "${expected[@]}" | LC_ALL=C sort -u) \
+    <(printf '%s\n' "${actual[@]}" | LC_ALL=C sort -u) | paste -sd, -)"
+
+  detail=""
+  [[ -n "$missing" ]] && detail="missing: ${missing}"
+  [[ -n "$unexpected" ]] && detail="${detail:+${detail}; }unexpected: ${unexpected}"
+  note_fail "${base}:${lineno} ${key}: has [${actual_set:-<empty>}], expected [${expected_set}] — ${detail}. A release line named here but absent from the workflow means that workflow does not run on it at all."
+done <<< "$records"
+
+# A manifest entry whose workflow lost its branch filter (or its file) is just
+# as dangerous as a stale list: it means the guard silently checks nothing.
+for base in "${!PINNED_EXTRAS[@]}"; do
+  [[ -n "${SEEN_FILTERS[$base]-}" ]] && continue
+  if [[ -f "${WORKFLOW_DIR}/${base}" ]]; then
+    note_fail "${base}: listed as 'pinned' in ${MANIFEST} but no branch filter was found in it."
+  else
+    note_fail "${base}: listed as 'pinned' in ${MANIFEST} but ${WORKFLOW_DIR}/${base} does not exist."
+  fi
+done
+for base in "${UNPINNED[@]}"; do
+  [[ -n "${SEEN_FILTERS[$base]-}" ]] && continue
+  if [[ -f "${WORKFLOW_DIR}/${base}" ]]; then
+    note_fail "${base}: listed as 'unpinned' in ${MANIFEST} but no branch filter was found in it."
+  else
+    note_fail "${base}: listed as 'unpinned' in ${MANIFEST} but ${WORKFLOW_DIR}/${base} does not exist."
+  fi
+done
+
+echo
+if [[ $fail -ne 0 ]]; then
+  echo "RESULT: FAIL — workflow branch filters are out of sync with ${MANIFEST}."
+  echo "Cutting a release line takes two edits: the manifest AND every workflow"
+  echo "listed under 'pinned'. Fixing only the manifest leaves those workflows"
+  echo "not running on the new branch at all (#4339)."
+  exit 1
+fi
+echo "RESULT: PASS — every pinned workflow covers the declared release lines."

--- a/src/scripts/test-release-lines-guard.sh
+++ b/src/scripts/test-release-lines-guard.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# test-release-lines-guard.sh — executes src/scripts/check-release-lines.sh
+# against fixtures to prove it still detects the failures it exists to catch.
+#
+# #4405 asks for the demonstration explicitly: "Adding a plausible future branch
+# name to the repository's release lines without updating the workflows fails
+# the check. Demonstrate the failure." Case 2 below is that demonstration, run
+# in CI against the REAL workflows rather than pasted into a PR description, so
+# it keeps being true.
+#
+# The rest cover the ways the guard could rot into a green no-op: a checker that
+# only understands one of the two YAML spellings of `branches:` silently stops
+# covering v2-ci.yml, the highest-value entry in the table.
+#
+# Usage: src/scripts/test-release-lines-guard.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+GUARD="${HERE}/check-release-lines.sh"
+REAL_MANIFEST="${REPO_ROOT}/.github/release-lines.yml"
+REAL_WORKFLOWS="${REPO_ROOT}/.github/workflows"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+pass() { echo "  ok: $*"; }
+bad()  { echo "  FAIL: $*"; fail=1; }
+
+# expect <expected-exit> <description> -- <guard args...>
+# On an unexpected result the guard's own output is echoed, since that output is
+# the thing under test.
+expect() {
+  local want="$1" desc="$2"; shift 3
+  local out rc
+  out="$(bash "$GUARD" "$@" 2>&1)"; rc=$?
+  if [[ $rc -eq $want ]]; then
+    LAST_OUT="$out"
+    pass "$desc"
+    return 0
+  fi
+  bad "$desc (guard exited ${rc}, expected ${want})"
+  echo "$out" | sed 's/^/      | /'
+  LAST_OUT="$out"
+  return 1
+}
+
+expect_mentions() {
+  local needle="$1" desc="$2"
+  if grep -qF -- "$needle" <<< "$LAST_OUT"; then
+    pass "$desc"
+  else
+    bad "$desc (no mention of '${needle}' in the guard's output)"
+    echo "$LAST_OUT" | sed 's/^/      | /'
+  fi
+}
+
+echo "== Release-line guard self-test =="
+
+# ---------------------------------------------------------------------------
+# 1. The repository as it stands is in sync.
+# ---------------------------------------------------------------------------
+expect 0 "repository is in sync with its own manifest" -- "$REAL_MANIFEST" "$REAL_WORKFLOWS"
+
+# ---------------------------------------------------------------------------
+# 2. THE DEMONSTRATION (#4405 acceptance criterion 1). Add a plausible future
+#    release line to the manifest and change nothing else: every pinned
+#    workflow must be reported as not covering it.
+# ---------------------------------------------------------------------------
+sed 's/^release_lines:.*/release_lines: [v2, v4, v5]/' "$REAL_MANIFEST" > "${TMP}/v5-manifest.yml"
+expect 1 "a new release line with no workflow edits fails the check" -- \
+  "${TMP}/v5-manifest.yml" "$REAL_WORKFLOWS"
+expect_mentions "missing: v5" "the failure names the branch that would not be covered"
+for wf in v2-ci.yml v2-tests.yml podman-contract.yml podman-rootful-lane.yml \
+          podman-rootless-lane.yml podman-arm64-lane.yml quadlet-gate.yml \
+          suid-contract.yml scorecard.yml; do
+  expect_mentions "FAIL: ${wf}" "${wf} is reported"
+done
+# docker.yml is deliberately unpinned and must NOT be dragged into the failure.
+if grep -q "FAIL: docker.yml" <<< "$LAST_OUT"; then
+  bad "docker.yml's '**' trigger was flagged; it is deliberate"
+else
+  pass "docker.yml's '**' trigger is recognised as deliberate, not flagged"
+fi
+
+# ---------------------------------------------------------------------------
+# Fixtures for the remaining cases.
+# ---------------------------------------------------------------------------
+mk_manifest() {
+  cat > "$1" <<'EOF'
+release_lines: [v2, v4]
+pinned:
+  flow-form.yml: []
+  block-form.yml: []
+unpinned:
+  wild.yml: '**'
+EOF
+}
+
+WFDIR="${TMP}/workflows"
+mkdir -p "$WFDIR"
+
+write_flow()  { printf 'on:\n  push:\n    branches: [%s]\n' "$1" > "${WFDIR}/flow-form.yml"; }
+write_block() {
+  { printf 'on:\n  push:\n    branches:\n'
+    for b in $1; do printf '      - %s\n' "$b"; done
+  } > "${WFDIR}/block-form.yml"
+}
+write_wild()  { printf 'on:\n  push:\n    branches:\n      - %s\n' "$1" > "${WFDIR}/wild.yml"; }
+
+MANIFEST="${TMP}/manifest.yml"
+mk_manifest "$MANIFEST"
+
+# 3. Both spellings in sync -> pass.
+write_flow "v2, v4"; write_block "v2 v4"; write_wild "'**'"
+expect 0 "flow sequence and block sequence both parse when in sync" -- "$MANIFEST" "$WFDIR"
+
+# 4. Flow spelling (`branches: [v2, v4]`) out of sync is caught. This is the
+#    v2-ci.yml shape — a guard that only reads block sequences misses it.
+write_flow "v2"
+expect 1 "a stale flow-sequence list is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "FAIL: flow-form.yml" "the flow-sequence workflow is named"
+expect_mentions "missing: v4" "the flow-sequence failure names the missing branch"
+write_flow "v2, v4"
+
+# 5. Block spelling out of sync is caught.
+write_block "v2"
+expect 1 "a stale block-sequence list is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "FAIL: block-form.yml" "the block-sequence workflow is named"
+write_block "v2 v4"
+
+# 6. Quoted entries and inline comments do not confuse the parser.
+write_flow '"v2", "v4"'
+expect 0 "quoted flow entries parse" -- "$MANIFEST" "$WFDIR"
+{ printf 'on:\n  push:\n    branches:\n'
+  printf "      - 'v2'   # oldest supported line\n"
+  printf '      - v4\n'
+} > "${WFDIR}/block-form.yml"
+expect 0 "quoted block entries with inline comments parse" -- "$MANIFEST" "$WFDIR"
+write_block "v2 v4"
+
+# 7. A workflow that carries a branch filter but is in neither manifest list is
+#    reported: the next pinned workflow somebody adds is the next #4339.
+printf 'on:\n  push:\n    branches: [v4]\n' > "${WFDIR}/newcomer.yml"
+expect 1 "an unclassified pinned workflow is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "not classified" "the unclassified workflow explains what to do"
+rm "${WFDIR}/newcomer.yml"
+
+# 8. A workflow declared unpinned that loses its wildcard is caught, so
+#    docker.yml cannot quietly acquire the very problem this guards against.
+write_wild "v4"
+expect 1 "an unpinned workflow narrowed to a fixed list is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "FAIL: wild.yml" "the narrowed workflow is named"
+write_wild "'**'"
+
+# 9. A manifest entry whose workflow lost its branch filter is caught: a guard
+#    that checks a file with nothing to check reports green for no reason.
+printf 'on:\n  workflow_dispatch:\n' > "${WFDIR}/flow-form.yml"
+expect 1 "a pinned workflow with no branch filter at all is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "no branch filter" "the missing filter is explained"
+write_flow "v2, v4"
+
+# 10. A manifest entry naming a workflow that no longer exists is caught.
+rm "${WFDIR}/block-form.yml"
+expect 1 "a manifest entry for a deleted workflow is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "does not exist" "the deleted workflow is explained"
+write_block "v2 v4"
+
+echo
+if [[ $fail -ne 0 ]]; then
+  echo "RESULT: FAIL — the release-line guard is not detecting what it claims to."
+  exit 1
+fi
+echo "RESULT: PASS — the release-line guard still catches a stale allow-list."


### PR DESCRIPTION
Fixes #4405.

## What was exposed

Nine workflows pin their `push` / `pull_request` triggers to a hand-maintained list of version-branch names. That list has already gone stale once: `podman-contract.yml` named `v2` alone, mainline moved to `v4`, and the workflow stopped running entirely (#4339) — not red, **absent**, which is the one failure mode a guard cannot have. Adding `v4` fixed that instance and left the mechanism intact, so the same failure was queued up for the day `v5` is cut.

## Which shape, and why

Shape **1 — assert the set**, not shape 2 (trigger on `v*`):

- `scorecard.yml` triggers on `main`, which is not a release line and does not match `v*`. A pattern cannot express it, so a pattern would leave that workflow pinned anyway — the guard would still be needed, for a smaller set.
- A `v*` pattern silently widens what runs. Any branch someone happens to name `validate-thing` starts running the five Podman lanes. Coverage would be correct by construction, but nobody could see what it covers.

Asserting the set keeps each trigger block saying literally what it runs on, and turns cutting `v5` into one edit that CI enforces.

## What lands

| File | Role |
|---|---|
| `.github/release-lines.yml` | Single source of truth: the release lines, and how each workflow relates to them |
| `src/scripts/check-release-lines.sh` | Asserts every workflow's branch filters against the manifest |
| `src/scripts/test-release-lines-guard.sh` | Proves the checker still fails when it should |
| `.github/workflows/release-line-guard.yml` | Runs both, on **every** branch |
| `src/docs/release-line-guard.md` | What it checks, and what to edit when a release line is cut |

`podman-contract.yml`'s header gains one sentence pointing at the guard. **No existing workflow's triggers change.**

## Acceptance criteria

**Adding a plausible future branch name without updating the workflows fails the check — demonstrated.** Case 2 of the self-test does exactly this in CI, against the real workflow files, so it keeps being true rather than being a paste in a PR description:

```
$ sed 's/^release_lines:.*/release_lines: [v2, v4, v5]/' .github/release-lines.yml > /tmp/m.yml
$ src/scripts/check-release-lines.sh /tmp/m.yml .github/workflows
  FAIL: v2-ci.yml:5 branches: has [v2,v4], expected [v2,v4,v5] — missing: v5. A release
        line named here but absent from the workflow means that workflow does not run on
        it at all.
  ... same for v2-tests.yml, scorecard.yml, suid-contract.yml, quadlet-gate.yml and all
      four podman lanes (13 filters across 9 workflows)
RESULT: FAIL — workflow branch filters are out of sync with /tmp/m.yml.
$ echo $?
1
```

**The check is not subject to the bug it guards against.** `release-line-guard.yml` triggers on `branches: ['**']` and is itself listed under `unpinned` in the manifest, so the guard checks that fact about itself on every run. Its path filter (`.github/**`, the manifest, the two scripts) is safe where a branch filter would not be: this invariant can only be broken by editing a workflow, the manifest, or the checker. The self-test runs *before* the real check, because a checker that had quietly stopped detecting anything would otherwise pass for the wrong reason.

**Both YAML spellings are handled.** `branches: [v2, v4]` (v2-ci.yml, v2-tests.yml) and the block sequence used by the Podman lanes and the contract gates, including quoted entries and inline comments. Dedicated fixture cases cover each; a checker that read only block sequences would silently skip the two highest-value entries.

**`docker.yml`'s `'**'` is recognised as deliberate and not flagged** — it is declared `unpinned` with the reason. The reverse is checked too: if that wildcard is ever narrowed to a fixed list, the guard fails and asks for it to be reclassified as `pinned`.

**Whether `v2` should remain is raised, not answered.** It is a maintainer call about release-line support. What the guard surfaced on its first run is that the repo is not currently consistent about it: mainline is `v4`, eight of the nine pinned workflows still fire on `v2`, and the ninth — `scorecard.yml` — never has. That gap is recorded as an explicit `-v2` exclusion in the manifest rather than quietly corrected, because turning OpenSSF Scorecard on for a release line is a decision, not a side effect of adding a CI guard. Either resolution is one edit to `release_lines` plus the workflows, and the guard proves the edit is complete. The manifest ends with the question written out.

## Beyond the stated criteria (cheap, same parser)

- **Every** branch filter in a file, not the first — `push` and `pull_request` blocks drift apart independently (13 filters across the 9 workflows).
- **Classification is mandatory.** A workflow carrying a branch filter that is in neither list fails: the next pinned workflow somebody adds is the next #4339.
- **Stale manifest entries fail** — an entry naming a deleted workflow, or one that has lost its branch filter. A guard checking a file with nothing left to check is green for no reason.

## Verification

```
$ src/scripts/check-release-lines.sh
RESULT: PASS — every pinned workflow covers the declared release lines.

$ src/scripts/test-release-lines-guard.sh
RESULT: PASS — the release-line guard still catches a stale allow-list.   (29 assertions)

$ shellcheck -S warning src/scripts/check-release-lines.sh src/scripts/test-release-lines-guard.sh
$ python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')+['.github/release-lines.yml']]"
```

No `CHANGELOG.md` entry: CI-only, not user-visible, which that file's own guidance excludes.

Part of #4188 (second wave, bullet 15). Does not close the parent.

— hive: backend=claude model=claude-opus-5
