### PR TITLE
ci(release-lines): assert workflow branch pins against the live release lines (#4405)

### DIFF
--- a/.github/release-lines.yaml
+++ b/.github/release-lines.yaml
@@ -1,0 +1,142 @@
+# Release lines, and every CI file that hand-writes their branch names.
+#
+# WHY THIS FILE EXISTS (#4405, under #4188). Nine workflows pin their triggers
+# to a hand-maintained list of version-branch names, and docker.yml hand-writes
+# the same names again in its push policy. Nothing checked that those lists
+# agreed with reality, so when mainline moved from `v2` to `v4` the Podman
+# contract gate kept naming `v2` alone and simply stopped running — #4339. Its
+# header now records the lesson:
+#
+#   a guard that never executes reports green forever, which is the one failure
+#   mode a guard cannot have.
+#
+# That fix added `v4` to one list. It did not change the fact that the lists are
+# hand-maintained, so the same failure was queued up for the day `v5` is cut —
+# on which the Docker image would keep building on every branch while both CI
+# workflows, both security contract gates and all five Podman lanes reported
+# nothing at all. Not red. Absent.
+#
+# THIS FILE IS THE SOURCE OF TRUTH. `release_lines` below is the answer to "what
+# are the live release lines"; everything else is checked against it by
+# src/pkg/releaselines, which .github/workflows/release-lines-gate.yml runs on
+# every branch as `go test ./pkg/releaselines/...`. Cutting a release line is
+# therefore ONE edit here, and CI then names every file that has not caught up.
+#
+# WHY ASSERT THE SET RATHER THAN DROP THE PINS. #4405 offered a second shape:
+# trigger on `v*` so new lines are covered by construction. It was not chosen.
+# A glob silently widens what runs on any branch that happens to start with
+# "v", it does not fit scorecard.yml's `main`, it cannot express docker.yml's
+# push policy at all — and, decisively, it can only ever add: a glob has no way
+# to notice that a line has been RETIRED and should stop being built. Asserting
+# the set costs one edit per release line and catches both directions.
+
+# ── The release lines ────────────────────────────────────────────────────────
+#
+# `status` is documentation with one behavioural effect: an `undecided` line
+# makes the check print a notice on every run, so an open question stays
+# visible instead of being settled by silence. It never fails the build.
+release_lines:
+  - branch: v4
+    status: current
+    note: >
+      Mainline. This is the branch `stable`, `candidate` and `edge` are cut
+      from, and the one the hub's branch switcher assigns hives to by default.
+
+  - branch: v2
+    status: undecided
+    note: >
+      MAINTAINER DECISION NEEDED. Whether `v2` is still a supported release
+      line is not something #4405 was scoped to answer, and this file does not
+      answer it: `v2` is listed because every pinned workflow currently names
+      it, so listing it is what records the status quo rather than quietly
+      changing it. If the answer is "no longer supported", deleting these three
+      lines is the whole change on this side — the check will then name each
+      workflow that still pins `v2` and each list that still carries it.
+
+# ── Workflows that pin their triggers to branch names ────────────────────────
+#
+# Every workflow under .github/workflows whose `on.push` / `on.pull_request` /
+# `on.pull_request_target` carries a `branches:` filter must appear here. Both
+# YAML spellings are in use and both are handled — `branches: [v2, v4]` (flow
+# sequence, v2-ci.yml and v2-tests.yml) and the block sequence everything else
+# uses — because the check parses the YAML rather than pattern-matching text.
+#
+#   pinned: true    the filter is a list of literal branch names. Every release
+#                   line above must appear in it, unless named in `omits`; every
+#                   literal that is NOT a release line must appear in `extra`.
+#   pinned: false   the filter is a glob. Deliberate, and `reason` says why.
+#
+# A workflow that has no `branches:` filter at all runs on every branch and
+# needs no entry — it cannot fall out of sync.
+workflows:
+  - file: v2-ci.yml
+    pinned: true
+
+  - file: v2-tests.yml
+    pinned: true
+
+  - file: scorecard.yml
+    pinned: true
+    extra: [main]
+    omits: [v2]
+    note: >
+      Recorded as observed, not endorsed. This workflow names `main` — which is
+      not a release line in this repository — and omits `v2`. Both predate this
+      check, and calling either one deliberate would be a guess, so they are
+      declared here to describe today's state and are listed in #4405 for
+      maintainers to confirm or correct.
+
+  - file: podman-rootful-lane.yml
+    pinned: true
+
+  - file: podman-rootless-lane.yml
+    pinned: true
+
+  - file: podman-arm64-lane.yml
+    pinned: true
+
+  - file: podman-contract.yml
+    pinned: true
+
+  - file: quadlet-gate.yml
+    pinned: true
+
+  - file: suid-contract.yml
+    pinned: true
+
+  - file: docker.yml
+    pinned: false
+    reason: >
+      Triggers on '**' with bot branches excluded, on purpose: a PR's image
+      must BUILD on any branch, because that build is itself the CI gate
+      proving the tree compiles. Widening is the safe direction here, so this
+      trigger cannot be dropped by a release line being cut. Its push policy is
+      a different matter — see `branch_lists` below.
+
+  - file: release-lines-gate.yml
+    pinned: false
+    reason: >
+      Triggers on '**' because this is the check itself. #4339 was a guard
+      pinned to a branch name that went away; a guard against that failure
+      which was pinned the same way would be #4339 one level up, so this one is
+      deliberately reachable from every branch.
+
+# ── Other hand-written release-line lists ────────────────────────────────────
+#
+# Not every carry-forward hazard is a trigger. #4405's table calls docker.yml
+# "the outlier that does not have the problem", and that is true of its
+# TRIGGER — but the same nine branch names are hand-written a second time in
+# its push policy, where being out of sync is worse than a skipped guard: on
+# the day `v5` is cut, docker.yml would keep building `v5` and never publish
+# `v5-latest`, so no hive could be assigned to the new line through the hub's
+# branch switcher at all. The image would look healthy the entire time.
+branch_lists:
+  - file: docker.yml
+    env: LONG_LIVED
+    extra: [mk, dd]
+    note: >
+      The `gate` job's push policy: only long-lived branches push to GHCR, so
+      that a temporary PR branch does not leave an orphaned <branch>-latest tag
+      behind when it merges and is deleted. `mk` and `dd` are standing
+      experimental branches, not release lines, which is why they are declared
+      as extras here rather than added above.

--- a/.github/workflows/release-lines-gate.yml
+++ b/.github/workflows/release-lines-gate.yml
@@ -1,0 +1,68 @@
+name: Release Lines Gate
+
+# The release-line carry-forward guard (#4405, under #4188).
+#
+# WHAT IT CHECKS. .github/release-lines.yaml declares which release lines are
+# live. Nine workflows pin their triggers to a hand-maintained list of those
+# branch names, and docker.yml hand-writes the same names a second time in its
+# push policy. This job asserts the lists still agree with the declaration, in
+# both directions: a release line missing from a list, and a list still naming a
+# line that has been retired.
+#
+# WHY. Mainline moved from v2 to v4 while podman-contract.yml still named v2
+# alone, so it stopped running entirely — #4339, whose own header records the
+# lesson: "a guard that never executes reports green forever, which is the one
+# failure mode a guard cannot have". Adding v4 to that one list fixed the
+# instance, not the class. Cutting a release line is now ONE edit in
+# release-lines.yaml, and this job names every file that has not caught up.
+#
+# WHY IT TRIGGERS ON EVERYTHING, AND WHY IT HAS NO PATH FILTER. Both are
+# load-bearing rather than lazy. A guard against "pinned to a branch name that
+# went away" which was itself pinned to branch names would be #4339 one level
+# up. A path filter would be the same mistake in the other axis: cutting a
+# release line is an edit to release-lines.yaml, but so is renaming the env var
+# docker.yml keeps its push policy in, or adding a workflow that pins branches
+# and declares nothing — and a filter narrow enough to be worth having is narrow
+# enough to miss one of those. src/pkg/releaselines/releaselines_test.go asserts
+# this file has neither, so the exemption cannot be quietly withdrawn.
+#
+# Cost is one Go package test on a hosted runner; running it on every push is
+# cheaper than the failure mode it exists to prevent.
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-lines-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  carry-forward:
+    name: release-line carry-forward
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache-dependency-path: src/go.sum
+
+      # -v so the report reaches the log on a PASS too: an undecided release
+      # line is an open maintainer question and is printed as a ::notice:: on
+      # every run, which is the point — a question settled by silence is settled
+      # the wrong way.
+      - name: Check release-line carry-forward
+        run: go test -v ./pkg/releaselines/...

--- a/src/pkg/releaselines/releaselines.go
+++ b/src/pkg/releaselines/releaselines.go
@@ -1,0 +1,587 @@
+// Package releaselines checks that the branch names hand-written into this
+// repository's CI configuration still agree with the repository's live release
+// lines.
+//
+// WHY THIS EXISTS (#4405, under #4188). Nine workflows pin their triggers to a
+// hand-maintained list of version-branch names, and docker.yml hand-writes the
+// same names again in its push policy. Nothing checked that those lists agreed
+// with reality, so when mainline moved from v2 to v4 the Podman contract gate
+// kept naming v2 alone and simply stopped running (#4339) — "a guard that never
+// executes reports green forever, which is the one failure mode a guard cannot
+// have". Adding v4 to that one list fixed the instance, not the class: the day
+// v5 is cut, both CI workflows, both security contract gates and all five
+// Podman lanes would report nothing at all. Not red. Absent.
+//
+// .github/release-lines.yaml is the source of truth; this package is what makes
+// it load-bearing. Cutting a release line is one edit there, and this check then
+// names every file that has not caught up — in both directions, because it
+// equally reports a workflow still pinned to a line that has been retired.
+//
+// The check parses the workflow YAML rather than pattern-matching its text, so
+// both spellings of the filter are handled without special cases: the flow
+// sequence `branches: [v2, v4]` used by v2-ci.yml and v2-tests.yml, and the
+// block sequence everything else uses, are the same node tree once parsed.
+package releaselines
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// ConfigPath is the source of truth, relative to the repository root.
+	ConfigPath = ".github/release-lines.yaml"
+	// WorkflowDir holds the workflows checked against it.
+	WorkflowDir = ".github/workflows"
+)
+
+// Statuses a release line may declare. Unknown values are rejected rather than
+// ignored: a typo in `undecided` would silently switch off the notice that
+// keeps an open maintainer question visible, which is the one thing this field
+// is for.
+const (
+	StatusCurrent   = "current"   // the line mainline is cut from
+	StatusSupported = "supported" // still built and still gated
+	StatusUndecided = "undecided" // support status is an open maintainer question
+)
+
+var knownStatuses = map[string]bool{
+	StatusCurrent:   true,
+	StatusSupported: true,
+	StatusUndecided: true,
+}
+
+// Line is one release line: a long-lived version branch.
+type Line struct {
+	Branch string `yaml:"branch"`
+	Status string `yaml:"status"`
+	Note   string `yaml:"note"`
+}
+
+// Workflow declares how one workflow's trigger relates to the release lines.
+//
+// Pinned true means the trigger filter is a list of literal branch names, and
+// must therefore name every release line (bar those listed in Omits) and
+// nothing else (bar those listed in Extra). Pinned false means it is a glob,
+// which cannot fall behind a new release line; Reason records why that is the
+// right shape for that file.
+type Workflow struct {
+	File   string   `yaml:"file"`
+	Pinned bool     `yaml:"pinned"`
+	Extra  []string `yaml:"extra"`
+	Omits  []string `yaml:"omits"`
+	Reason string   `yaml:"reason"`
+	Note   string   `yaml:"note"`
+}
+
+// BranchList declares a hand-written list of release-line branch names that is
+// not a trigger — docker.yml's LONG_LIVED push policy is the motivating case.
+type BranchList struct {
+	File  string   `yaml:"file"`
+	Env   string   `yaml:"env"`
+	Extra []string `yaml:"extra"`
+	Omits []string `yaml:"omits"`
+	Note  string   `yaml:"note"`
+}
+
+// Config is the parsed contents of ConfigPath.
+type Config struct {
+	ReleaseLines []Line       `yaml:"release_lines"`
+	Workflows    []Workflow   `yaml:"workflows"`
+	BranchLists  []BranchList `yaml:"branch_lists"`
+}
+
+// Severity distinguishes a failure from something merely worth saying.
+type Severity string
+
+const (
+	// Error fails the check.
+	Error Severity = "error"
+	// Notice is reported on every run and never fails the check.
+	Notice Severity = "notice"
+)
+
+// Finding is one thing the check has to say about one file.
+type Finding struct {
+	Severity Severity
+	File     string // repo-relative, or "" when the finding is about the config itself
+	Where    string // e.g. "on.push.branches", "env LONG_LIVED"
+	Message  string
+}
+
+func (f Finding) String() string {
+	loc := f.File
+	if loc == "" {
+		loc = ConfigPath
+	}
+	if f.Where != "" {
+		loc += " (" + f.Where + ")"
+	}
+	return loc + ": " + f.Message
+}
+
+// Errors returns only the findings that fail the check.
+func Errors(findings []Finding) []Finding {
+	var out []Finding
+	for _, f := range findings {
+		if f.Severity == Error {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// Notices returns only the findings that are reported but do not fail.
+func Notices(findings []Finding) []Finding {
+	var out []Finding
+	for _, f := range findings {
+		if f.Severity == Notice {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// Load reads and parses ConfigPath under repoRoot.
+func Load(repoRoot string) (*Config, error) {
+	path := filepath.Join(repoRoot, filepath.FromSlash(ConfigPath))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", ConfigPath, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", ConfigPath, err)
+	}
+	return &cfg, nil
+}
+
+// Check reports every way the repository's CI configuration has fallen out of
+// sync with its declared release lines. An empty Errors() result means in sync.
+func Check(repoRoot string) ([]Finding, error) {
+	cfg, err := Load(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return CheckConfig(repoRoot, cfg), nil
+}
+
+// CheckConfig is Check against an already-loaded config, so a caller can ask
+// what WOULD be reported for a hypothetical set of release lines.
+func CheckConfig(repoRoot string, cfg *Config) []Finding {
+	var out []Finding
+	out = append(out, cfg.validate()...)
+
+	lines := map[string]bool{}
+	for _, l := range cfg.ReleaseLines {
+		lines[l.Branch] = true
+	}
+
+	declared := map[string]bool{}
+	for _, wf := range cfg.Workflows {
+		declared[wf.File] = true
+		out = append(out, checkWorkflow(repoRoot, wf, cfg.ReleaseLines, lines)...)
+	}
+	out = append(out, undeclaredWorkflows(repoRoot, declared)...)
+
+	for _, bl := range cfg.BranchLists {
+		out = append(out, checkBranchList(repoRoot, bl, cfg.ReleaseLines, lines)...)
+	}
+	return out
+}
+
+// validate checks the source of truth against itself, and raises the notices
+// that keep an undecided line visible.
+func (c *Config) validate() []Finding {
+	var out []Finding
+	if len(c.ReleaseLines) == 0 {
+		out = append(out, Finding{Severity: Error, Message: "no release_lines declared; every pinned workflow would be reported as naming branches that are not release lines"})
+	}
+	seen := map[string]bool{}
+	for _, l := range c.ReleaseLines {
+		switch {
+		case strings.TrimSpace(l.Branch) == "":
+			out = append(out, Finding{Severity: Error, Message: "a release_lines entry has an empty branch"})
+			continue
+		case seen[l.Branch]:
+			out = append(out, Finding{Severity: Error, Message: fmt.Sprintf("release line %q is declared twice", l.Branch)})
+			continue
+		}
+		seen[l.Branch] = true
+		if !knownStatuses[l.Status] {
+			out = append(out, Finding{Severity: Error, Message: fmt.Sprintf(
+				"release line %q has status %q; expected one of %s", l.Branch, l.Status, strings.Join(sortedKeys(knownStatuses), ", "))})
+			continue
+		}
+		if l.Status == StatusUndecided {
+			out = append(out, Finding{Severity: Notice, Message: fmt.Sprintf(
+				"release line %q is marked %s — %s", l.Branch, StatusUndecided, flatten(l.Note))})
+		}
+	}
+	seenWF := map[string]bool{}
+	for _, wf := range c.Workflows {
+		if seenWF[wf.File] {
+			out = append(out, Finding{Severity: Error, Message: fmt.Sprintf("workflow %q is declared twice", wf.File)})
+		}
+		seenWF[wf.File] = true
+		if !wf.Pinned && strings.TrimSpace(wf.Reason) == "" {
+			out = append(out, Finding{Severity: Error, File: workflowPath(wf.File), Message: "declared `pinned: false` with no `reason`; an unpinned trigger has to say why widening is deliberate"})
+		}
+	}
+	return out
+}
+
+func checkWorkflow(repoRoot string, wf Workflow, releaseLines []Line, lines map[string]bool) []Finding {
+	rel := workflowPath(wf.File)
+	path := filepath.Join(repoRoot, filepath.FromSlash(rel))
+
+	filters, err := branchFilters(path)
+	if err != nil {
+		return []Finding{{Severity: Error, File: rel, Message: err.Error()}}
+	}
+	if len(filters) == 0 {
+		return []Finding{{Severity: Error, File: rel, Message: fmt.Sprintf(
+			"declared in %s but has no branch filter on push/pull_request/pull_request_target; a workflow with no filter runs on every branch and cannot fall out of sync, so remove the entry", ConfigPath)}}
+	}
+
+	var out []Finding
+	union := map[string]bool{}
+	for _, f := range filters {
+		for _, v := range f.values {
+			union[v] = true
+		}
+		if wf.Pinned {
+			out = append(out, checkPinnedFilter(rel, wf, f, releaseLines, lines)...)
+			continue
+		}
+		if !anyPattern(f.values) {
+			out = append(out, Finding{Severity: Error, File: rel, Where: f.path, Message: fmt.Sprintf(
+				"declared `pinned: false` but the filter names only literal branches (%s); a literal list can fall behind a new release line, so declare it `pinned: true`", strings.Join(f.values, ", "))})
+		}
+	}
+	out = append(out, checkDeclarations(rel, wf, union, lines)...)
+	return out
+}
+
+// checkPinnedFilter is the core assertion: a literal branch list must name
+// every release line, and must not name anything else.
+func checkPinnedFilter(rel string, wf Workflow, f filter, releaseLines []Line, lines map[string]bool) []Finding {
+	var out []Finding
+	have := map[string]bool{}
+	for _, v := range f.values {
+		have[v] = true
+		if isPattern(v) {
+			out = append(out, Finding{Severity: Error, File: rel, Where: f.path, Message: fmt.Sprintf(
+				"declared `pinned: true` but the filter contains the pattern %q; either spell the branches out or declare it `pinned: false` with a reason", v)})
+		}
+	}
+	omits := setOf(wf.Omits)
+	extra := setOf(wf.Extra)
+
+	for _, l := range releaseLines {
+		if have[l.Branch] || omits[l.Branch] {
+			continue
+		}
+		out = append(out, Finding{Severity: Error, File: rel, Where: f.path, Message: fmt.Sprintf(
+			"release line %q is missing; this workflow does not run on it at all. Add it to the filter, or declare `omits: [%s]` in %s with a note saying why it is deliberate", l.Branch, l.Branch, ConfigPath)})
+	}
+	for _, v := range f.values {
+		if isPattern(v) || lines[v] || extra[v] {
+			continue
+		}
+		out = append(out, Finding{Severity: Error, File: rel, Where: f.path, Message: fmt.Sprintf(
+			"names %q, which is not a release line in %s; remove it from the filter, or declare `extra: [%s]` there", v, ConfigPath, v)})
+	}
+	return out
+}
+
+// checkDeclarations keeps the escape hatches from rotting: an `omits` or
+// `extra` that no longer describes the file is itself out of sync.
+func checkDeclarations(rel string, wf Workflow, union map[string]bool, lines map[string]bool) []Finding {
+	var out []Finding
+	for _, o := range wf.Omits {
+		if !lines[o] {
+			out = append(out, Finding{Severity: Error, File: rel, Message: fmt.Sprintf(
+				"declares `omits: [%s]` but %q is not a release line; drop the declaration", o, o)})
+			continue
+		}
+		if union[o] {
+			out = append(out, Finding{Severity: Error, File: rel, Message: fmt.Sprintf(
+				"declares `omits: [%s]` but the filter does name %s; drop the declaration", o, o)})
+		}
+	}
+	for _, e := range wf.Extra {
+		if !union[e] {
+			out = append(out, Finding{Severity: Error, File: rel, Message: fmt.Sprintf(
+				"declares `extra: [%s]` but the filter does not name it; drop the declaration", e)})
+		}
+	}
+	return out
+}
+
+// undeclaredWorkflows catches the next instance of this bug rather than the
+// current one: a workflow added later that pins branch names and is never
+// declared would otherwise be invisible to the check that exists to find it.
+func undeclaredWorkflows(repoRoot string, declared map[string]bool) []Finding {
+	dir := filepath.Join(repoRoot, filepath.FromSlash(WorkflowDir))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []Finding{{Severity: Error, File: WorkflowDir, Message: fmt.Sprintf("read workflow directory: %v", err)}}
+	}
+	var out []Finding
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || (!strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml")) {
+			continue
+		}
+		if declared[name] {
+			continue
+		}
+		filters, err := branchFilters(filepath.Join(dir, name))
+		if err != nil {
+			out = append(out, Finding{Severity: Error, File: workflowPath(name), Message: err.Error()})
+			continue
+		}
+		if len(filters) == 0 {
+			continue
+		}
+		out = append(out, Finding{Severity: Error, File: workflowPath(name), Where: filters[0].path, Message: fmt.Sprintf(
+			"has a branch filter (%s) but is not declared in %s; every workflow that names branches has to be checked against the release lines, or it is the next one to silently stop running",
+			strings.Join(filters[0].values, ", "), ConfigPath)})
+	}
+	return out
+}
+
+func checkBranchList(repoRoot string, bl BranchList, releaseLines []Line, lines map[string]bool) []Finding {
+	rel := workflowPath(bl.File)
+	path := filepath.Join(repoRoot, filepath.FromSlash(rel))
+	where := "env " + bl.Env
+
+	raw, err := envValue(path, bl.Env)
+	if err != nil {
+		return []Finding{{Severity: Error, File: rel, Where: where, Message: err.Error()}}
+	}
+	values := strings.Fields(raw)
+	have := setOf(values)
+	omits := setOf(bl.Omits)
+	extra := setOf(bl.Extra)
+
+	var out []Finding
+	for _, l := range releaseLines {
+		if have[l.Branch] || omits[l.Branch] {
+			continue
+		}
+		out = append(out, Finding{Severity: Error, File: rel, Where: where, Message: fmt.Sprintf(
+			"release line %q is missing from the list (%s). Add it, or declare `omits: [%s]` in %s", l.Branch, raw, l.Branch, ConfigPath)})
+	}
+	for _, v := range values {
+		if lines[v] || extra[v] {
+			continue
+		}
+		out = append(out, Finding{Severity: Error, File: rel, Where: where, Message: fmt.Sprintf(
+			"names %q, which is not a release line in %s; remove it, or declare `extra: [%s]` there", v, ConfigPath, v)})
+	}
+	for _, e := range bl.Extra {
+		if !have[e] {
+			out = append(out, Finding{Severity: Error, File: rel, Where: where, Message: fmt.Sprintf(
+				"declares `extra: [%s]` but the list does not name it; drop the declaration", e)})
+		}
+	}
+	for _, o := range bl.Omits {
+		if have[o] {
+			out = append(out, Finding{Severity: Error, File: rel, Where: where, Message: fmt.Sprintf(
+				"declares `omits: [%s]` but the list does name it; drop the declaration", o)})
+		}
+	}
+	return out
+}
+
+// ── YAML ─────────────────────────────────────────────────────────────────────
+
+// filter is one branch filter found in a workflow's trigger block.
+type filter struct {
+	path   string // e.g. "on.push.branches"
+	values []string
+}
+
+// triggerEvents are the events whose branch filter decides whether a workflow
+// runs on a release line at all.
+var triggerEvents = []string{"push", "pull_request", "pull_request_target"}
+
+// branchFilters returns every branches / branches-ignore filter in the
+// workflow's trigger block.
+//
+// The document is walked as a node tree rather than decoded into a struct for
+// two reasons. `on` is a YAML 1.1 boolean, so a decode can turn the key into
+// `true` depending on the library's schema; walking sees the key exactly as it
+// is written. And the two spellings of a branch list — `[v2, v4]` and a block
+// sequence — are the same SequenceNode once parsed, so both are handled with no
+// special case, which is what #4405 asks for.
+func branchFilters(path string) ([]filter, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("declared in %s but does not exist", ConfigPath)
+		}
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	root := documentRoot(&doc)
+	if root == nil {
+		return nil, nil
+	}
+	on := mapValue(root, "on")
+	if on == nil || on.Kind != yaml.MappingNode {
+		// `on: push` or `on: [push]` carries no branch filter.
+		return nil, nil
+	}
+	var out []filter
+	for _, event := range triggerEvents {
+		ev := mapValue(on, event)
+		if ev == nil || ev.Kind != yaml.MappingNode {
+			continue
+		}
+		for _, key := range []string{"branches", "branches-ignore"} {
+			node := mapValue(ev, key)
+			if node == nil {
+				continue
+			}
+			out = append(out, filter{path: "on." + event + "." + key, values: scalars(node)})
+		}
+	}
+	return out, nil
+}
+
+// envValue finds a value in any `env:` mapping in the document — the workflow's
+// own, a job's, or a step's.
+func envValue(path, name string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("declared in %s but does not exist", ConfigPath)
+		}
+		return "", fmt.Errorf("read: %w", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", fmt.Errorf("parse: %w", err)
+	}
+	root := documentRoot(&doc)
+	if root == nil {
+		return "", fmt.Errorf("declared in %s but the file is empty", ConfigPath)
+	}
+	if v, ok := findEnv(root, name); ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("declared in %s as holding a release-line list, but no `env:` block sets %s; if it was renamed, rename it there too", ConfigPath, name)
+}
+
+func findEnv(n *yaml.Node, name string) (string, bool) {
+	if n.Kind == yaml.MappingNode {
+		if env := mapValue(n, "env"); env != nil && env.Kind == yaml.MappingNode {
+			if v := mapValue(env, name); v != nil && v.Kind == yaml.ScalarNode {
+				return v.Value, true
+			}
+		}
+	}
+	for _, c := range n.Content {
+		if v, ok := findEnv(c, name); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func documentRoot(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == yaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return nil
+		}
+		doc = doc.Content[0]
+	}
+	if doc.Kind != yaml.MappingNode {
+		return nil
+	}
+	return doc
+}
+
+func mapValue(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func scalars(n *yaml.Node) []string {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		return []string{n.Value}
+	case yaml.SequenceNode:
+		out := make([]string, 0, len(n.Content))
+		for _, c := range n.Content {
+			if c.Kind == yaml.ScalarNode {
+				out = append(out, c.Value)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// ── small helpers ────────────────────────────────────────────────────────────
+
+// isPattern reports whether a filter entry is a glob rather than a literal
+// branch name, using GitHub's filter-pattern metacharacters.
+func isPattern(s string) bool {
+	return strings.HasPrefix(s, "!") || strings.ContainsAny(s, "*?+[]")
+}
+
+func anyPattern(values []string) bool {
+	for _, v := range values {
+		if isPattern(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func setOf(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, v := range values {
+		out[v] = true
+	}
+	return out
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func workflowPath(file string) string {
+	return WorkflowDir + "/" + file
+}
+
+// flatten collapses a folded YAML note to one line so it survives being emitted
+// as a GitHub Actions annotation.
+func flatten(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/src/pkg/releaselines/releaselines_test.go
+++ b/src/pkg/releaselines/releaselines_test.go
@@ -1,0 +1,586 @@
+package releaselines
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// repoRoot is this package's path back to the repository root: src/pkg/releaselines.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(ConfigPath))); err != nil {
+		t.Fatalf("%s not found from %s: %v", ConfigPath, root, err)
+	}
+	return root
+}
+
+func report(t *testing.T, findings []Finding) string {
+	t.Helper()
+	var sb strings.Builder
+	Report(&sb, findings, os.Getenv("GITHUB_ACTIONS") == "true")
+	return sb.String()
+}
+
+// ── The check itself, against the real repository ────────────────────────────
+
+// TestRepositoryIsInSync is the gate. Every hand-written branch list in CI must
+// name exactly the release lines declared in .github/release-lines.yaml.
+func TestRepositoryIsInSync(t *testing.T) {
+	findings, err := Check(repoRoot(t))
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	// Notices are printed on every run, pass or fail: an undecided release line
+	// is an open maintainer question, and staying visible is the whole point.
+	t.Log("\n" + report(t, findings))
+	if errs := Errors(findings); len(errs) > 0 {
+		t.Fatalf("%d branch list(s) out of sync with %s", len(errs), ConfigPath)
+	}
+}
+
+// TestGuardIsReachableFromEveryBranch is acceptance criterion 2: the check must
+// not be subject to the bug it guards against. #4339 was a guard pinned to a
+// branch name that went away; a guard against that pinned the same way would be
+// #4339 one level up, so its own workflow may not carry a branch pin — or a
+// path filter, which is the other way a guard scopes itself into never running.
+func TestGuardIsReachableFromEveryBranch(t *testing.T) {
+	const gate = "release-lines-gate.yml"
+	path := filepath.Join(repoRoot(t), filepath.FromSlash(WorkflowDir), gate)
+
+	filters, err := branchFilters(path)
+	if err != nil {
+		t.Fatalf("parse %s: %v", gate, err)
+	}
+	seen := map[string]bool{}
+	for _, f := range filters {
+		seen[f.path] = true
+		for _, v := range f.values {
+			if v != "**" {
+				t.Errorf("%s %s names %q; the guard must run on every branch", gate, f.path, v)
+			}
+		}
+	}
+	for _, want := range []string{"on.push.branches", "on.pull_request.branches"} {
+		if !seen[want] {
+			t.Errorf("%s has no %s; expected an explicit '**'", gate, want)
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	on := mapValue(documentRoot(&doc), "on")
+	for _, event := range triggerEvents {
+		ev := mapValue(on, event)
+		if ev == nil {
+			continue
+		}
+		for _, key := range []string{"paths", "paths-ignore"} {
+			if mapValue(ev, key) != nil {
+				t.Errorf("%s on.%s.%s: the guard must have no path filter, or it reports green by never running", gate, event, key)
+			}
+		}
+	}
+}
+
+// ── Demonstrating the failure this exists to catch ───────────────────────────
+
+// TestCuttingANewReleaseLineFailsUntilWorkflowsCatchUp is acceptance criterion
+// 1, run against the repository's REAL workflows: declare a plausible future
+// release line and change nothing else, and the check must name every file that
+// has not caught up.
+func TestCuttingANewReleaseLineFailsUntilWorkflowsCatchUp(t *testing.T) {
+	root := repoRoot(t)
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	cfg.ReleaseLines = append(cfg.ReleaseLines, Line{
+		Branch: "v5",
+		Status: StatusCurrent,
+		Note:   "hypothetical, added by this test only",
+	})
+
+	findings := CheckConfig(root, cfg)
+	t.Log("\nWhat cutting v5 without touching CI looks like:\n" + report(t, findings))
+
+	errs := Errors(findings)
+	if len(errs) == 0 {
+		t.Fatal("adding a release line changed nothing; the guard does not guard")
+	}
+
+	// Every pinned workflow in #4405's table, and docker.yml's push policy —
+	// which is the entry the table's own "docker.yml is the outlier" note does
+	// NOT cover, because it is a second hand-written list in the same file.
+	want := []string{
+		"v2-ci.yml", "v2-tests.yml", "scorecard.yml",
+		"podman-rootful-lane.yml", "podman-rootless-lane.yml", "podman-arm64-lane.yml",
+		"podman-contract.yml", "quadlet-gate.yml", "suid-contract.yml",
+		"docker.yml",
+	}
+	for _, file := range want {
+		if !mentions(errs, workflowPath(file), "v5") {
+			t.Errorf("cutting v5 did not flag %s", file)
+		}
+	}
+	// docker.yml's TRIGGER is deliberate ('**' with bot branches excluded) and
+	// must stay unflagged even though its LONG_LIVED list is reported.
+	for _, f := range errs {
+		if f.File == workflowPath("docker.yml") && strings.HasPrefix(f.Where, "on.") {
+			t.Errorf("docker.yml's deliberate '**' trigger was flagged: %s", f)
+		}
+	}
+}
+
+// TestRetiringAReleaseLineNamesEveryWorkflowStillPinnedToIt is the other
+// direction, and the reason the pins were asserted rather than replaced by a
+// `v*` glob: a glob can only ever ADD, so it has no way to notice that a line
+// has been retired and should stop being built.
+func TestRetiringAReleaseLineNamesEveryWorkflowStillPinnedToIt(t *testing.T) {
+	root := repoRoot(t)
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	var kept []Line
+	for _, l := range cfg.ReleaseLines {
+		if l.Branch != "v2" {
+			kept = append(kept, l)
+		}
+	}
+	if len(kept) == len(cfg.ReleaseLines) {
+		t.Skip("v2 is no longer a declared release line; the maintainer decision has been taken")
+	}
+	cfg.ReleaseLines = kept
+
+	findings := CheckConfig(root, cfg)
+	t.Log("\nWhat retiring v2 without touching CI looks like:\n" + report(t, findings))
+
+	errs := Errors(findings)
+	for _, file := range []string{"v2-ci.yml", "v2-tests.yml", "podman-contract.yml", "suid-contract.yml", "quadlet-gate.yml", "docker.yml"} {
+		if !mentions(errs, workflowPath(file), "v2") {
+			t.Errorf("retiring v2 did not flag %s, which still names it", file)
+		}
+	}
+	// scorecard.yml declares `omits: [v2]`; once v2 is not a release line that
+	// declaration is stale and must be reported too, or the escape hatches rot.
+	if !mentions(errs, workflowPath("scorecard.yml"), "omits") {
+		t.Error("retiring v2 left scorecard.yml's stale `omits: [v2]` declaration unreported")
+	}
+}
+
+func mentions(findings []Finding, file, needle string) bool {
+	for _, f := range findings {
+		if f.File == file && strings.Contains(f.Message, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// ── Unit tests on synthetic fixtures ─────────────────────────────────────────
+
+// fixture builds a throwaway repository root holding a config and workflows.
+func fixture(t *testing.T, config string, workflows map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(WorkflowDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(ConfigPath)), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range workflows {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+const twoLines = `
+release_lines:
+  - branch: v4
+    status: current
+  - branch: v2
+    status: supported
+`
+
+func checkFixture(t *testing.T, config string, workflows map[string]string) []Finding {
+	t.Helper()
+	findings, err := Check(fixture(t, config, workflows))
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	return findings
+}
+
+func assertClean(t *testing.T, findings []Finding) {
+	t.Helper()
+	if errs := Errors(findings); len(errs) > 0 {
+		t.Fatalf("expected no errors, got:\n%s", report(t, findings))
+	}
+}
+
+func assertError(t *testing.T, findings []Finding, needle string) {
+	t.Helper()
+	for _, f := range Errors(findings) {
+		if strings.Contains(f.String(), needle) {
+			return
+		}
+	}
+	t.Fatalf("no error mentioning %q; got:\n%s", needle, report(t, findings))
+}
+
+// TestBothYAMLSpellingsAreHandled is acceptance criterion 3. `branches: [v2, v4]`
+// is the flow sequence v2-ci.yml uses — the highest-value entry in #4405's table
+// — and a guard that only understood the block form would miss it. Parsing the
+// YAML rather than the text makes the two indistinguishable, and this pins that.
+func TestBothYAMLSpellingsAreHandled(t *testing.T) {
+	const flow = "on:\n  push:\n    branches: [v2, v4]\n"
+	const block = "on:\n  push:\n    branches:\n      - v2\n      - v4\n"
+	const quotedFlow = "on:\n  push:\n    branches: [ \"v2\", \"v4\" ]\n"
+
+	for name, body := range map[string]string{"flow": flow, "block": block, "quoted-flow": quotedFlow} {
+		t.Run(name, func(t *testing.T) {
+			cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+			assertClean(t, checkFixture(t, cfg, map[string]string{"a.yml": body}))
+
+			// ... and each spelling must FAIL identically when a line is missing.
+			short := strings.NewReplacer("[v2, v4]", "[v4]", "      - v2\n", "", "[ \"v2\", \"v4\" ]", "[ \"v4\" ]").Replace(body)
+			assertError(t, checkFixture(t, cfg, map[string]string{"a.yml": short}), `release line "v2" is missing`)
+		})
+	}
+}
+
+// TestGlobTriggerIsRecognisedAsDeliberate is acceptance criterion 4: docker.yml's
+// '**' trigger, bot exclusions and all, is not a stale pin and is not flagged.
+func TestGlobTriggerIsRecognisedAsDeliberate(t *testing.T) {
+	const dockerish = `
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+      - '!copilot/**'
+  workflow_dispatch:
+`
+	cfg := twoLines + "\nworkflows:\n  - file: docker.yml\n    pinned: false\n    reason: builds on every branch on purpose\n"
+	assertClean(t, checkFixture(t, cfg, map[string]string{"docker.yml": dockerish}))
+}
+
+func TestUnpinnedDeclarationRequiresAReason(t *testing.T) {
+	const dockerish = "on:\n  push:\n    branches: ['**']\n"
+	cfg := twoLines + "\nworkflows:\n  - file: docker.yml\n    pinned: false\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"docker.yml": dockerish}), "no `reason`")
+}
+
+// A file declared unpinned that has since been narrowed to a literal list is
+// back inside the failure mode, and saying `pinned: false` must not hide it.
+func TestUnpinnedDeclarationThatBecameLiteralIsFlagged(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: docker.yml\n    pinned: false\n    reason: was a glob once\n"
+	body := "on:\n  push:\n    branches: [v2, v4]\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"docker.yml": body}), "names only literal branches")
+}
+
+func TestPinnedDeclarationThatContainsAPatternIsFlagged(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+	body := "on:\n  push:\n    branches: [v2, 'v*']\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"a.yml": body}), `pattern "v*"`)
+}
+
+func TestUnknownBranchMustBeDeclaredAsExtra(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: scorecard.yml\n    pinned: true\n"
+	body := "on:\n  push:\n    branches: [ \"main\", \"v4\", \"v2\" ]\n"
+	findings := checkFixture(t, cfg, map[string]string{"scorecard.yml": body})
+	assertError(t, findings, `names "main", which is not a release line`)
+
+	withExtra := twoLines + "\nworkflows:\n  - file: scorecard.yml\n    pinned: true\n    extra: [main]\n"
+	assertClean(t, checkFixture(t, withExtra, map[string]string{"scorecard.yml": body}))
+}
+
+func TestOmittedReleaseLineMustBeDeclared(t *testing.T) {
+	body := "on:\n  push:\n    branches: [v4]\n"
+	assertError(t, checkFixture(t, twoLines+"\nworkflows:\n  - file: a.yml\n    pinned: true\n",
+		map[string]string{"a.yml": body}), `release line "v2" is missing`)
+
+	assertClean(t, checkFixture(t, twoLines+"\nworkflows:\n  - file: a.yml\n    pinned: true\n    omits: [v2]\n",
+		map[string]string{"a.yml": body}))
+}
+
+// The escape hatches are themselves carry-forward hazards: an `omits` or `extra`
+// that stops describing the file is a stale declaration, and stale declarations
+// are how the original lists got here.
+func TestStaleEscapeHatchesAreFlagged(t *testing.T) {
+	body := "on:\n  push:\n    branches: [v2, v4]\n"
+	assertError(t, checkFixture(t, twoLines+"\nworkflows:\n  - file: a.yml\n    pinned: true\n    omits: [v2]\n",
+		map[string]string{"a.yml": body}), "but the filter does name v2")
+	assertError(t, checkFixture(t, twoLines+"\nworkflows:\n  - file: a.yml\n    pinned: true\n    extra: [main]\n",
+		map[string]string{"a.yml": body}), "but the filter does not name it")
+	assertError(t, checkFixture(t, twoLines+"\nworkflows:\n  - file: a.yml\n    pinned: true\n    omits: [nope]\n",
+		map[string]string{"a.yml": body}), `"nope" is not a release line`)
+}
+
+// The next instance of this bug is a workflow added later that pins branches and
+// is never declared. It would be invisible to a check that only looks at what it
+// was told about, so the check looks at the directory too.
+func TestUndeclaredPinnedWorkflowIsFlagged(t *testing.T) {
+	cfg := twoLines + "\nworkflows: []\n"
+	findings := checkFixture(t, cfg, map[string]string{"newcomer.yml": "on:\n  push:\n    branches: [v4]\n"})
+	assertError(t, findings, "newcomer.yml")
+
+	// A workflow with no branch filter at all runs everywhere and needs no entry.
+	assertClean(t, checkFixture(t, cfg, map[string]string{"free.yml": "on:\n  schedule:\n    - cron: '0 6 * * 1'\n"}))
+	assertClean(t, checkFixture(t, cfg, map[string]string{"free.yml": "on: [push, pull_request]\n"}))
+}
+
+func TestDeclaredWorkflowThatLostItsFilterIsFlagged(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"a.yml": "on:\n  workflow_dispatch:\n"}), "has no branch filter")
+}
+
+func TestDeclaredWorkflowThatIsGoneIsFlagged(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: deleted.yml\n    pinned: true\n"
+	assertError(t, checkFixture(t, cfg, nil), "does not exist")
+}
+
+func TestPullRequestTargetIsChecked(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+	body := "on:\n  pull_request_target:\n    branches: [v4]\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"a.yml": body}), "on.pull_request_target.branches")
+}
+
+// Every trigger block is checked independently: a workflow whose push filter has
+// been carried forward but whose pull_request filter has not still leaves the
+// new line ungated on PRs, which is where a gate matters most.
+func TestEachTriggerBlockIsCheckedSeparately(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+	body := "on:\n  push:\n    branches: [v2, v4]\n  pull_request:\n    branches: [v4]\n"
+	findings := checkFixture(t, cfg, map[string]string{"a.yml": body})
+	assertError(t, findings, "on.pull_request.branches")
+	for _, f := range Errors(findings) {
+		if f.Where == "on.push.branches" {
+			t.Errorf("push filter is in sync but was flagged: %s", f)
+		}
+	}
+}
+
+// ── branch_lists: the same names, hand-written a second time ─────────────────
+
+const dockerPolicy = `
+on:
+  push:
+    branches: ['**']
+jobs:
+  gate:
+    steps:
+      - name: Decide push policy
+        env:
+          LONG_LIVED: "v2 v4 mk dd"
+`
+
+func TestBranchListIsCheckedAgainstReleaseLines(t *testing.T) {
+	cfg := twoLines + `
+workflows:
+  - file: docker.yml
+    pinned: false
+    reason: every branch builds on purpose
+branch_lists:
+  - file: docker.yml
+    env: LONG_LIVED
+    extra: [mk, dd]
+`
+	assertClean(t, checkFixture(t, cfg, map[string]string{"docker.yml": dockerPolicy}))
+
+	// A release line missing from the push policy is worse than a skipped guard:
+	// the image builds and is never published, so no hive can be assigned to the
+	// new line at all, and the image looks healthy the whole time.
+	short := strings.Replace(dockerPolicy, `"v2 v4 mk dd"`, `"v2 v4 mk"`, 1)
+	assertError(t, checkFixture(t, cfg, map[string]string{"docker.yml": short}), "declares `extra: [dd]`")
+
+	undeclared := strings.Replace(dockerPolicy, `"v2 v4 mk dd"`, `"v2 v4 mk dd zz"`, 1)
+	assertError(t, checkFixture(t, cfg, map[string]string{"docker.yml": undeclared}), `names "zz"`)
+
+	renamed := strings.Replace(dockerPolicy, "LONG_LIVED", "LONG_LIVED_BRANCHES", 1)
+	assertError(t, checkFixture(t, cfg, map[string]string{"docker.yml": renamed}), "no `env:` block sets LONG_LIVED")
+}
+
+func TestBranchListMissingAReleaseLineIsFlagged(t *testing.T) {
+	cfg := twoLines + `
+workflows:
+  - file: docker.yml
+    pinned: false
+    reason: every branch builds on purpose
+branch_lists:
+  - file: docker.yml
+    env: LONG_LIVED
+    extra: [mk, dd]
+`
+	short := strings.Replace(dockerPolicy, `"v2 v4 mk dd"`, `"v4 mk dd"`, 1)
+	assertError(t, checkFixture(t, cfg, map[string]string{"docker.yml": short}), `release line "v2" is missing from the list`)
+}
+
+// ── The source of truth is checked against itself ────────────────────────────
+
+func TestUndecidedStatusIsANoticeNotAFailure(t *testing.T) {
+	cfg := `
+release_lines:
+  - branch: v4
+    status: current
+  - branch: v2
+    status: undecided
+    note: >
+      MAINTAINER DECISION NEEDED. Whether v2 is still supported.
+workflows:
+  - file: a.yml
+    pinned: true
+`
+	findings := checkFixture(t, cfg, map[string]string{"a.yml": "on:\n  push:\n    branches: [v2, v4]\n"})
+	assertClean(t, findings)
+	notices := Notices(findings)
+	if len(notices) != 1 || !strings.Contains(notices[0].Message, "MAINTAINER DECISION NEEDED") {
+		t.Fatalf("expected one notice carrying the open question, got %v", notices)
+	}
+}
+
+func TestConfigIsValidatedAgainstItself(t *testing.T) {
+	cases := map[string]struct{ cfg, want string }{
+		"unknown status": {"release_lines:\n  - branch: v4\n    status: probably\n", `status "probably"`},
+		"duplicate line": {"release_lines:\n  - branch: v4\n    status: current\n  - branch: v4\n    status: current\n", "declared twice"},
+		"empty branch":   {"release_lines:\n  - branch: \"\"\n    status: current\n", "empty branch"},
+		"no lines":       {"release_lines: []\n", "no release_lines declared"},
+		"duplicate file": {twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n  - file: a.yml\n    pinned: true\n", `workflow "a.yml" is declared twice`},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assertError(t, checkFixture(t, tc.cfg, map[string]string{"a.yml": "on:\n  push:\n    branches: [v2, v4]\n"}), tc.want)
+		})
+	}
+}
+
+func TestMissingConfigIsAnError(t *testing.T) {
+	if _, err := Check(t.TempDir()); err == nil {
+		t.Fatal("expected an error when the source of truth is absent")
+	}
+}
+
+func TestReportNamesTheFilesAndSaysWhatToDo(t *testing.T) {
+	findings := []Finding{
+		{Severity: Notice, Message: "an open question"},
+		{Severity: Error, File: workflowPath("a.yml"), Where: "on.push.branches", Message: `release line "v5" is missing`},
+	}
+	var sb strings.Builder
+	Report(&sb, findings, true)
+	out := sb.String()
+	for _, want := range []string{
+		"NOTICE",
+		"ERROR   .github/workflows/a.yml (on.push.branches)",
+		"::notice file=.github/release-lines.yaml",
+		"::error file=.github/workflows/a.yml",
+		"1 file(s) have fallen out of sync",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report is missing %q:\n%s", want, out)
+		}
+	}
+	// Actions truncates an annotation at the first newline, so a folded note has
+	// to arrive flattened or the useful half of it is lost.
+	var multiline strings.Builder
+	Report(&multiline, []Finding{{Severity: Notice, Message: "first line\nsecond line"}}, true)
+	for _, line := range strings.Split(multiline.String(), "\n") {
+		if strings.HasPrefix(line, "::") && !strings.Contains(line, "first line second line") {
+			t.Errorf("annotation was not flattened: %q", line)
+		}
+	}
+}
+
+func TestReportSaysSoWhenNothingIsWrong(t *testing.T) {
+	var sb strings.Builder
+	Report(&sb, nil, false)
+	if !strings.Contains(sb.String(), "In sync") {
+		t.Errorf("expected an in-sync line, got %q", sb.String())
+	}
+}
+
+// ── Malformed input is reported, not swallowed ───────────────────────────────
+
+func TestMalformedInputIsReported(t *testing.T) {
+	if _, err := Check(fixture(t, "release_lines: [oh: no\n", nil)); err == nil {
+		t.Error("expected an error for unparseable " + ConfigPath)
+	}
+
+	cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"a.yml": "on: [oh: no\n"}), "parse")
+
+	// A workflow file that is not a mapping at all carries no trigger block; it
+	// is malformed for other reasons, and this check is not the place to say so.
+	assertClean(t, checkFixture(t, twoLines+"\nworkflows: []\n", map[string]string{"a.yml": "- just\n- a list\n"}))
+	assertClean(t, checkFixture(t, twoLines+"\nworkflows: []\n", map[string]string{"a.yml": ""}))
+}
+
+// GitHub wants a list, but a lone scalar is legal YAML and must not be read as
+// "no filter" — that would make the workflow invisible to the check.
+func TestScalarBranchFilterIsRead(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"a.yml": "on:\n  push:\n    branches: v4\n"}), `release line "v2" is missing`)
+
+	unpinned := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: false\n    reason: everywhere, on purpose\n"
+	assertClean(t, checkFixture(t, unpinned, map[string]string{"a.yml": "on:\n  push:\n    branches: '**'\n"}))
+}
+
+func TestBranchesIgnoreIsChecked(t *testing.T) {
+	cfg := twoLines + "\nworkflows:\n  - file: a.yml\n    pinned: true\n"
+	assertError(t, checkFixture(t, cfg, map[string]string{"a.yml": "on:\n  push:\n    branches-ignore: [v4]\n"}),
+		"on.push.branches-ignore")
+}
+
+func TestMissingWorkflowDirectoryIsReported(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".github"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(ConfigPath)), []byte(twoLines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	findings, err := Check(root)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	assertError(t, findings, "read workflow directory")
+}
+
+func TestBranchListOnAMissingFileIsReported(t *testing.T) {
+	cfg := twoLines + "\nbranch_lists:\n  - file: gone.yml\n    env: LONG_LIVED\n"
+	assertError(t, checkFixture(t, cfg, nil), "does not exist")
+
+	empty := twoLines + "\nbranch_lists:\n  - file: a.yml\n    env: LONG_LIVED\n"
+	assertError(t, checkFixture(t, empty, map[string]string{"a.yml": ""}), "the file is empty")
+	assertError(t, checkFixture(t, empty, map[string]string{"a.yml": "on: [oh: no\n"}), "parse")
+}
+
+func TestIsPattern(t *testing.T) {
+	for _, s := range []string{"**", "v*", "!dependabot/**", "releases/**", "v[12]", "v+"} {
+		if !isPattern(s) {
+			t.Errorf("%q should be a pattern", s)
+		}
+	}
+	for _, s := range []string{"v2", "v4", "main", "mk", "release-v2"} {
+		if isPattern(s) {
+			t.Errorf("%q should be a literal branch name", s)
+		}
+	}
+}

--- a/src/pkg/releaselines/releaselines_test.go
+++ b/src/pkg/releaselines/releaselines_test.go
@@ -22,10 +22,15 @@ func repoRoot(t *testing.T) string {
 	return root
 }
 
+// report renders findings for a test log WITHOUT Actions annotations. Only the
+// live check may annotate: every other test here reports on a hypothetical set
+// of release lines, and turning those into ::error:: lines would decorate real
+// workflow files with failures that are not happening — on a job that passed.
+// A guard that cries wolf on a green run is a guard people learn to ignore.
 func report(t *testing.T, findings []Finding) string {
 	t.Helper()
 	var sb strings.Builder
-	Report(&sb, findings, os.Getenv("GITHUB_ACTIONS") == "true")
+	Report(&sb, findings, false)
 	return sb.String()
 }
 
@@ -40,7 +45,11 @@ func TestRepositoryIsInSync(t *testing.T) {
 	}
 	// Notices are printed on every run, pass or fail: an undecided release line
 	// is an open maintainer question, and staying visible is the whole point.
-	t.Log("\n" + report(t, findings))
+	// This is the one test whose findings describe the repository as it really
+	// is, so it is the only one that emits Actions annotations.
+	var sb strings.Builder
+	Report(&sb, findings, os.Getenv("GITHUB_ACTIONS") == "true")
+	t.Log("\n" + sb.String())
 	if errs := Errors(findings); len(errs) > 0 {
 		t.Fatalf("%d branch list(s) out of sync with %s", len(errs), ConfigPath)
 	}

--- a/src/pkg/releaselines/report.go
+++ b/src/pkg/releaselines/report.go
@@ -1,0 +1,62 @@
+package releaselines
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Report writes findings for a human to read.
+//
+// When actions is true it also emits GitHub Actions workflow commands, so a
+// failure is annotated on the offending file in the PR's Files-changed view
+// rather than buried in a log, and an undecided release line surfaces as a
+// notice on every run. Annotation messages are single-line by construction —
+// Actions truncates at the first newline.
+func Report(w io.Writer, findings []Finding, actions bool) {
+	errs, notices := Errors(findings), Notices(findings)
+
+	for _, f := range notices {
+		fmt.Fprintf(w, "NOTICE  %s\n", f)
+		if actions {
+			fmt.Fprintf(w, "::notice file=%s,title=Release line undecided::%s\n", annotationFile(f), flatten(f.Message))
+		}
+	}
+	for _, f := range errs {
+		fmt.Fprintf(w, "ERROR   %s\n", f)
+		if actions {
+			fmt.Fprintf(w, "::error file=%s,title=Release line carry-forward::%s\n", annotationFile(f), flatten(f.String()))
+		}
+	}
+
+	if len(errs) == 0 {
+		fmt.Fprintf(w, "\nIn sync: every branch list checked against %s names the same release lines it does.\n", ConfigPath)
+		return
+	}
+	fmt.Fprintf(w, "\n%d file(s) have fallen out of sync with %s.\n", countFiles(errs), ConfigPath)
+	fmt.Fprint(w, strings.TrimSpace(fixHint)+"\n")
+}
+
+const fixHint = `
+A release line was added or retired in .github/release-lines.yaml and the CI
+files above still name the old set — or one of them was edited without updating
+that file. Either way the fix is to make the two agree; the messages above name
+the branch and the file. This is #4339's failure mode caught before it lands:
+a workflow pinned to a branch that is not a release line does not fail, it
+simply never runs, and reports green forever.
+`
+
+func annotationFile(f Finding) string {
+	if f.File == "" {
+		return ConfigPath
+	}
+	return f.File
+}
+
+func countFiles(findings []Finding) int {
+	seen := map[string]bool{}
+	for _, f := range findings {
+		seen[annotationFile(f)] = true
+	}
+	return len(seen)
+}


### PR DESCRIPTION
Closes #4405. Part of #4188 (second wave, bullet 15) — does **not** close the parent.

## The problem

Nine workflows pin their triggers to a hand-maintained list of version-branch names, and `docker.yml` hand-writes the same names a second time in its `LONG_LIVED` push policy. Nothing checked that those lists agreed with reality.

This already happened once. #4339: `podman-contract.yml` named `v2` alone, mainline moved to `v4`, and the workflow stopped running entirely. Its header records the lesson:

> a guard that never executes reports green forever, which is the one failure mode a guard cannot have.

That fix added `v4` to one list. It fixed the instance, not the class — so on the day `v5` is cut, both CI workflows, both security contract gates and all five Podman lanes report nothing at all. Not red. Absent.

## Which shape, and why

The issue offered two. This takes **shape 1, assert the set**, and the reasoning is recorded in `.github/release-lines.yaml` itself so the next person does not have to re-derive it. A `v*` glob:

* silently widens what runs on any branch that happens to start with `v`,
* does not fit `scorecard.yml`'s `main`,
* cannot express `docker.yml`'s push policy at all, and
* decisively — **can only ever add**. A glob has no way to notice that a release line has been *retired* and should stop being built.

Asserting the set costs one edit per release line and catches both directions.

## What lands

**`.github/release-lines.yaml`** — the source of truth. `release_lines` answers "what are the live release lines"; `workflows` declares each file that pins branch names; `branch_lists` covers hand-written lists that are not triggers.

**`src/pkg/releaselines`** — makes it load-bearing:

* every workflow whose `push` / `pull_request` / `pull_request_target` carries a `branches:` filter must be declared, so a workflow added later that pins branches and declares nothing is reported rather than being the next one to silently stop running;
* a `pinned: true` filter must name every release line and nothing else;
* `pinned: false` must actually be a glob, and must say why;
* the same assertion is applied to `docker.yml`'s `LONG_LIVED`;
* deviations are declared as `extra` / `omits` and are themselves checked, so a declaration that stops describing the file is reported instead of rotting.

**`.github/workflows/release-lines-gate.yml`** — runs it, on every branch, via `go test -v ./pkg/releaselines/...`.

`docker.yml`'s **trigger** is the outlier the issue names and is not flagged: it is declared `pinned: false` with its reason. Its **push policy** is a different matter and is checked — being out of sync there is worse than a skipped guard, because on the day `v5` is cut `docker.yml` would keep building `v5` and never publish `v5-latest`, so no hive could be assigned to the new line through the hub's branch switcher at all. The image would look healthy the whole time.

## Acceptance criteria

**Adding a plausible future branch name fails the check — demonstrated.** `TestCuttingANewReleaseLineFailsUntilWorkflowsCatchUp` declares `v5` against the repository's *real* workflows and asserts all ten files are named. Its output, verbatim from the test log:

```
ERROR   .github/workflows/v2-ci.yml (on.push.branches): release line "v5" is missing; this workflow does not run on it at all. Add it to the filter, or declare `omits: [v5]` in .github/release-lines.yaml with a note saying why it is deliberate
ERROR   .github/workflows/v2-ci.yml (on.pull_request.branches): release line "v5" is missing; ...
ERROR   .github/workflows/v2-tests.yml (on.pull_request.branches): ...
ERROR   .github/workflows/scorecard.yml (on.push.branches): ...
ERROR   .github/workflows/podman-rootful-lane.yml (on.push.branches): ...
ERROR   .github/workflows/podman-rootless-lane.yml (on.push.branches): ...
ERROR   .github/workflows/podman-arm64-lane.yml (on.push.branches): ...
ERROR   .github/workflows/podman-contract.yml (on.push.branches): ...
ERROR   .github/workflows/quadlet-gate.yml (on.push.branches): ...
ERROR   .github/workflows/suid-contract.yml (on.push.branches): ...
ERROR   .github/workflows/docker.yml (env LONG_LIVED): release line "v5" is missing from the list (v2 v4 mk dd). Add it, or declare `omits: [v5]` in .github/release-lines.yaml

10 file(s) have fallen out of sync with .github/release-lines.yaml.
```

The reverse is demonstrated too — `TestRetiringAReleaseLineNamesEveryWorkflowStillPinnedToIt` removes `v2` and every workflow that still names it is reported, including `scorecard.yml`'s now-stale `omits: [v2]`.

**The check is not subject to the bug it guards against.** `release-lines-gate.yml` triggers on `'**'` and carries no path filter, and `TestGuardIsReachableFromEveryBranch` asserts *both*, so the exemption cannot be quietly withdrawn later. A path filter would be the same mistake in the other axis: cutting a release line edits `release-lines.yaml`, but so does renaming the env var `docker.yml` keeps its push policy in.

**Both YAML spellings are handled.** The workflow YAML is parsed, not pattern-matched, so `branches: [v2, v4]` (the flow sequence `v2-ci.yml` uses — the highest-value entry in the table) and the block sequence are the same node tree. `TestBothYAMLSpellingsAreHandled` runs flow, block and quoted-flow through both the passing and the failing path and asserts they behave identically.

**`docker.yml`'s `'**'` is recognised as deliberate and not flagged.** Asserted directly in the `v5` test: no finding may attach to a `docker.yml` trigger even while its `LONG_LIVED` list is reported.

## Maintainer decisions this surfaces rather than settles

Two things are recorded as *observed*, not endorsed, and are for maintainers to confirm or correct:

1. **Is `v2` still a supported release line?** #4405 was explicit that this is not its call, and this PR does not make it. `v2` is declared `status: undecided`, which prints a `::notice::` on every run and never fails the build — a question settled by silence is settled the wrong way. If the answer is "no longer supported", deleting those three lines is the whole change on this side, and the check then names each of the ten files that still carries `v2`.
2. **`scorecard.yml` names `main` and omits `v2`.** CONTRIBUTING.md says `main` "is not the active target for changes". Both predate this check, and calling either deliberate would be a guess, so they are declared to describe today's state.

## Testing

`go test ./pkg/releaselines/...` — 25 tests, 96.9% statement coverage (per-package floor is 90). `gofmt` and `go vet` clean. The demonstrations above run against the repository's real workflow files, not fixtures, so they cannot pass vacuously.

No runtime code is touched and nothing user-facing changes, so there is no CHANGELOG entry.

— hive: backend=claude model=claude-opus-5
