### PR TITLE
fix(hub): label run-state 'working' as 'should be working'

### DIFF
--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -181,9 +181,24 @@ function toggleHTML(a) {
   if (a.enabled) return '<span><span class="dot on"></span>on</span>';
   return '<span><span class="dot off"></span>off</span>';
 }
+// Display labels for each run-state machine value. "working" reads as an
+// overclaim ("this agent IS producing") when the capability column may say
+// otherwise, so it is shown as "should be working": the governor has it on and
+// its pane is alive — whether it actually is delivering is answered by the
+// PROBLEM / capability column beside it. The machine value stays "working"
+// (CSS class, JSON, tests) — only the human label changes.
+var RUN_STATE_LABELS = {
+  "working": "should be working",
+  "idle-at-prompt": "idle",
+  "stuck-at-login": "stuck at login",
+  "session-gone": "session gone",
+  "dead": "down",
+  "quiet-by-design": "quiet by design",
+  "unknown": "unknown"
+};
 function runStateHTML(a) {
   var rs = a.unknown ? "unknown" : (a.runState || "unknown");
-  var label = rs.replace(/-/g, " ");
+  var label = RUN_STATE_LABELS[rs] || rs.replace(/-/g, " ");
   var rel = a.lastActivityAt ? ' <span class="rel">' + esc(relTime(a.lastActivityAt)) + '</span>' : "";
   return '<span class="rs ' + esc(rs) + '"><span class="swatch"></span>' + esc(label) + '</span>' + rel;
 }


### PR DESCRIPTION
Operator feedback on the fleet view: the run-state **"working"** contradicts the capability column. On a login-stuck hive every agent showed **"● working"** next to **"PROBLEM: sitting at login prompt"** — which flatly contradict.

**Why it happens:** `runWorking` means expected-active + pane alive. The shared `classifyInactiveAgent` only flags login-stuck **after a 20-min grace**, so early on an agent parked at a login prompt still reports `runWorking` while the capability path (which sees `NeedsLogin` immediately) correctly says PROBLEM.

**Fix (label only):** reframe from a productivity claim to an expectation — **"should be working"** = the governor has it on and its pane is alive; whether it's *actually* delivering is answered by the PROBLEM/capability column. So **"should be working — PROBLEM: sitting at login"** now reads coherently instead of as a bug.

Frontend-only label map (`RUN_STATE_LABELS`). The machine value stays `working` — CSS class `rs.working`, JSON `runState`, and all Go tests unchanged. Also tidies the sibling labels (idle, down, stuck at login, session gone).

JS `node --check` clean; DCO-signed.

Per operator: keeping the classifier's grace as-is this pass (label change only).