### PR TITLE
🐛 fix Bob cost usage tracking

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1902,6 +1902,7 @@ func main() {
 	tokenCollector := tokens.NewCollector(cfg.Data.MetricsDir, logger)
 	tokenCollector.SetClaudeSessionsDir(cfg.Data.ClaudeSessionsDir)
 	tokenCollector.SetCopilotSessionsDir(cfg.Data.CopilotSessionsDir)
+	tokenCollector.SetBobSessionsDir(cfg.Data.BobSessionsDir)
 	if len(savedIssueCosts) > 0 {
 		tokenCollector.SeedIssueCosts(savedIssueCosts)
 		logger.Info("issue costs restored", "entries", len(savedIssueCosts))

--- a/src/docs/token-tracking.md
+++ b/src/docs/token-tracking.md
@@ -9,6 +9,7 @@ The collector starts from `data.metrics_dir` and rescans every 30 seconds. It me
 - Hive JSONL session files in `data.metrics_dir` (`*.jsonl`) using the flat `SessionEntry` schema.
 - Claude Code session JSONL under `data.claude_sessions_dir` when configured. It reads assistant `message.usage` blocks from recent files (30-day mtime window).
 - Copilot CLI `events.jsonl` under `data.copilot_sessions_dir` when configured. It reads `session.shutdown.modelMetrics` and avoids double-counting sessions already captured live by the proxy.
+- Bob CLI chat recordings under `data.bob_sessions_dir` (default `/data/home/.bob`) when configured. It reads `tmp/*/chats/*.json`, maps Bob project hashes back to trusted agent folders, and records explicit `tokens` fields (falling back to content-size estimates only when a recording has no token data).
 - Inference usage files written by `InferenceSink` as `inference-<agent>.jsonl` under `data.metrics_dir` for `vllm`, `llm-d`, `litellm`, and live Copilot proxy usage.
 
 A flat session entry can include `role`, `agent`, `model`, `input_tokens`, `output_tokens`, `cache_read`, and `cache_creation`. When `agent` is absent, Hive infers the agent from session path or configured detection keywords.

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -3469,6 +3469,7 @@ type DataConfig struct {
 	LogsDir            string `yaml:"logs_dir"`
 	ClaudeSessionsDir  string `yaml:"claude_sessions_dir"`
 	CopilotSessionsDir string `yaml:"copilot_sessions_dir"`
+	BobSessionsDir     string `yaml:"bob_sessions_dir"`
 	AgentsDir          string `yaml:"agents_dir"`
 }
 
@@ -3943,6 +3944,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Data.CopilotSessionsDir == "" {
 		c.Data.CopilotSessionsDir = "/data/home/.copilot/session-state"
+	}
+	if c.Data.BobSessionsDir == "" {
+		c.Data.BobSessionsDir = "/data/home/.bob"
 	}
 	if c.Data.AgentsDir == "" {
 		c.Data.AgentsDir = "/data/agent-configs"

--- a/src/pkg/config/config_test.go
+++ b/src/pkg/config/config_test.go
@@ -206,6 +206,9 @@ func TestApplyDefaults_DataDirs(t *testing.T) {
 	if cfg.Data.LogsDir != "/data/logs" {
 		t.Errorf("Data.LogsDir = %q, want %q", cfg.Data.LogsDir, "/data/logs")
 	}
+	if cfg.Data.BobSessionsDir != "/data/home/.bob" {
+		t.Errorf("Data.BobSessionsDir = %q, want %q", cfg.Data.BobSessionsDir, "/data/home/.bob")
+	}
 }
 
 func TestApplyDefaults_AgentBeadsDir(t *testing.T) {
@@ -872,6 +875,9 @@ func TestApplyDefaults_AllGovernorDefaults(t *testing.T) {
 	}
 	if cfg.Data.LogsDir != "/data/logs" {
 		t.Errorf("logs_dir = %q", cfg.Data.LogsDir)
+	}
+	if cfg.Data.BobSessionsDir != "/data/home/.bob" {
+		t.Errorf("bob_sessions_dir = %q", cfg.Data.BobSessionsDir)
 	}
 	if len(cfg.Governor.Labels.Exempt) == 0 {
 		t.Error("expected default exempt labels")

--- a/src/pkg/tokens/bob_scanner.go
+++ b/src/pkg/tokens/bob_scanner.go
@@ -1,7 +1,9 @@
 package tokens
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +30,7 @@ import (
 //	}
 type bobChatSession struct {
 	SessionID   string           `json:"sessionId"`
+	ProjectHash string           `json:"projectHash"`
 	StartTime   string           `json:"startTime"`
 	LastUpdated string           `json:"lastUpdated"`
 	Messages    []bobChatMessage `json:"messages"`
@@ -88,6 +91,14 @@ const maxBobSessionAge = 30 * 24 * time.Hour
 // directory (typically /data/home/.bob or ~/.bob) and returns an
 // AggregateSummary. It walks tmp/*/chats/*.json looking for session recordings.
 func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
+	return scanBobSessions(bobHomeDir, nil)
+}
+
+func ScanBobSessionsWithLogger(bobHomeDir string, logger *slog.Logger) (*AggregateSummary, error) {
+	return scanBobSessions(bobHomeDir, logger)
+}
+
+func scanBobSessions(bobHomeDir string, logger *slog.Logger) (*AggregateSummary, error) {
 	agg := &AggregateSummary{
 		ByAgent:       make(map[string]int64),
 		ByModel:       make(map[string]int64),
@@ -106,6 +117,7 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 	}
 
 	cutoff := time.Now().Add(-maxBobSessionAge)
+	agentsByHash := bobTrustedAgentsByProjectHash(bobHomeDir)
 
 	for _, path := range matches {
 		info, err := os.Stat(path)
@@ -121,6 +133,9 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 
 		sess, err := parseBobChatFile(path)
 		if err != nil || sess == nil {
+			if logger != nil {
+				logger.Warn("bob session parse failed", "path", path, "error", err)
+			}
 			continue
 		}
 
@@ -179,7 +194,11 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 			model = "bob-unknown"
 		}
 
-		const agentName = "bob"
+		projectHash := strings.TrimSpace(sess.ProjectHash)
+		if projectHash == "" {
+			projectHash = extractBobProjectHash(path)
+		}
+		agentName := bobAgentName(projectHash, agentsByHash)
 		agg.TotalTokens += total
 		agg.TotalMessages += messageCount
 		agg.SessionCount++
@@ -217,10 +236,78 @@ func ScanBobSessions(bobHomeDir string) (*AggregateSummary, error) {
 			CacheRead:    cachedTokens,
 			TotalTokens:  total,
 			Messages:     messageCount,
+			LastActive:   bobSessionLastActive(sess),
 		})
 	}
 
 	return agg, nil
+}
+
+func bobSessionLastActive(sess *bobChatSession) int64 {
+	if sess == nil {
+		return 0
+	}
+	for _, raw := range []string{sess.LastUpdated, sess.StartTime} {
+		if ts, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(raw)); err == nil {
+			return ts.UnixMilli()
+		}
+	}
+	return 0
+}
+
+type bobTrustedFolders map[string]string
+
+func bobTrustedAgentsByProjectHash(bobHomeDir string) map[string]string {
+	out := make(map[string]string)
+	if bobHomeDir == "" {
+		return out
+	}
+	data, err := os.ReadFile(filepath.Join(bobHomeDir, "trustedFolders.json"))
+	if err != nil {
+		return out
+	}
+	var folders bobTrustedFolders
+	if err := json.Unmarshal(data, &folders); err != nil {
+		return out
+	}
+	for folder := range folders {
+		folder = strings.TrimSpace(folder)
+		if folder == "" {
+			continue
+		}
+		sum := sha256.Sum256([]byte(folder))
+		if agent := strings.TrimSpace(filepath.Base(folder)); agent != "" && agent != "." && agent != string(filepath.Separator) {
+			out[hexLower(sum[:])] = agent
+		}
+	}
+	return out
+}
+
+func hexLower(b []byte) string {
+	const digits = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, v := range b {
+		out[i*2] = digits[v>>4]
+		out[i*2+1] = digits[v&0x0f]
+	}
+	return string(out)
+}
+
+func bobAgentName(projectHash string, agentsByHash map[string]string) string {
+	if agent := agentsByHash[strings.TrimSpace(projectHash)]; agent != "" {
+		return agent
+	}
+	return "bob"
+}
+
+func extractBobProjectHash(path string) string {
+	dir := filepath.Dir(path) // .../chats
+	dir = filepath.Dir(dir)   // .../<projectHash>
+	base := filepath.Base(dir)
+	if base == "." || base == "/" || base == "tmp" {
+		return ""
+	}
+	return base
 }
 
 func parseBobChatFile(path string) (*bobChatSession, error) {

--- a/src/pkg/tokens/bob_scanner_test.go
+++ b/src/pkg/tokens/bob_scanner_test.go
@@ -1,10 +1,12 @@
 package tokens
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestScanBobSessions_RealSchema(t *testing.T) {
@@ -168,6 +170,62 @@ func TestScanBobSessions_PerMessageModel(t *testing.T) {
 	if agg.ByModel["premium"] != 450 {
 		t.Errorf("ByModel[premium] = %d, want 450", agg.ByModel["premium"])
 	}
+}
+
+func TestScanBobSessions_AttributesTrustedFolderAgent(t *testing.T) {
+	dir := t.TempDir()
+	agentPath := "/data/agents/sec-check"
+	projectHash := sha256.Sum256([]byte(agentPath))
+	hash := hexLower(projectHash[:])
+
+	trusted, _ := json.Marshal(map[string]string{agentPath: "TRUST_FOLDER"})
+	if err := os.WriteFile(filepath.Join(dir, "trustedFolders.json"), trusted, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chatDir := filepath.Join(dir, "tmp", hash, "chats")
+	if err := os.MkdirAll(chatDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sess := bobChatSession{
+		SessionID:   "agent-session",
+		LastUpdated: "2026-08-21T16:33:10.357Z",
+		Messages: []bobChatMessage{
+			{Type: "user", Content: "scan"},
+			{Type: "bob-shell", Content: "done", Model: "premium",
+				Tokens: &bobTokens{Input: 1000, Output: 50}},
+		},
+	}
+	data, _ := json.Marshal(sess)
+	if err := os.WriteFile(filepath.Join(chatDir, "session.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agg, err := ScanBobSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.ByAgent["sec-check"] != 1050 {
+		t.Fatalf("ByAgent[sec-check] = %d, want 1050 (all agents must not collapse under bob)", agg.ByAgent["sec-check"])
+	}
+	if _, ok := agg.ByAgent["bob"]; ok {
+		t.Fatalf("unexpected fallback bob bucket: %+v", agg.ByAgent)
+	}
+	if len(agg.Sessions) != 1 || agg.Sessions[0].Agent != "sec-check" {
+		t.Fatalf("session agent = %+v, want sec-check", agg.Sessions)
+	}
+	wantLastActive := mustParseMillis(t, "2026-08-21T16:33:10.357Z")
+	if agg.Sessions[0].LastActive != wantLastActive {
+		t.Fatalf("LastActive = %d, want %d", agg.Sessions[0].LastActive, wantLastActive)
+	}
+}
+
+func mustParseMillis(t *testing.T, raw string) int64 {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts.UnixMilli()
 }
 
 func TestExtractBobSessionID(t *testing.T) {

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -185,7 +185,7 @@ func (c *Collector) scan() {
 	}
 
 	if c.bobSessionsDir != "" {
-		bobAgg, err := ScanBobSessions(c.bobSessionsDir)
+		bobAgg, err := ScanBobSessionsWithLogger(c.bobSessionsDir, c.logger)
 		if err != nil {
 			c.logger.Warn("bob session scan failed", "error", err)
 		} else if bobAgg != nil && bobAgg.SessionCount > 0 {


### PR DESCRIPTION
## Summary
- wire Bob CLI session recordings into the token collector via `data.bob_sessions_dir` default `/data/home/.bob`
- attribute Bob project hashes back to trusted agent folders so Cost shows usage by sandbox/session instead of dropping/collapsing usage
- log malformed Bob session files while continuing collection, and document Bob token collection

## Live evidence
- live pod `/data/token-summary.json` was zero tokens / zero sessions while `/data/home/.bob/tmp/*/chats/*.json` contained 309 recent Bob chat recordings
- live config had Claude/Copilot dirs but no Bob sessions dir wired
- read-only aggregation of live Bob chats found 200,919,801 tokens (199,215,486 input + 1,704,315 output), including recent active sessions
- existing `/data/cost-history.json` had one historical non-zero Bob spike ($246.59 on 2026-08-12) followed by zeros, consistent with Bob collection no longer being wired

## Validation
- `go test ./pkg/tokens ./pkg/dashboard`
- `go test ./pkg/config -run 'TestApplyDefaults'`
- `go build ./...`
- `go vet ./...`

Note: full `go test ./pkg/config` was not used as the validation gate because pre-existing GH app token cache tests failed unrelated to these changes (`TestExportEmitsShellExportOnBothPaths`, `TestSharedCacheIsCreatedPrivate`).
