### PR TITLE
ci(release-lines): assert docker.yml's LONG_LIVED push policy against the release lines (#4462)

### DIFF
--- a/.github/release-lines.yml
+++ b/.github/release-lines.yml
@@ -9,13 +9,23 @@
 # Adding `v4` fixed that instance and left the mechanism intact, so the same
 # failure was queued up for the day `v5` is cut. #4405 asks for the guard.
 #
+# The names are also hand-written a SECOND time, outside any trigger: the gate
+# job in docker.yml carries them in a `LONG_LIVED` env var as its GHCR push
+# policy (#4462). That one is not a branch filter, so the trigger check cannot
+# see it — and its failure mode is worse than a skipped workflow. On the day
+# `v5` is cut, docker.yml still triggers on `'**'` so the image keeps BUILDING
+# on v5, while the push policy never publishes `v5-latest`; no hive could be
+# assigned to the new line through the hub's branch switcher, and the image
+# looks healthy the whole time. Green, not absent. `env_lists` below covers it.
+#
 # src/scripts/check-release-lines.sh asserts this file against
 # .github/workflows/*.yml, and .github/workflows/release-line-guard.yml runs it
 # on every branch. See src/docs/release-line-guard.md.
 #
 # CUTTING A NEW RELEASE LINE: add the branch name to `release_lines` below AND
-# to every workflow listed under `pinned`. The guard fails until both are done —
-# that is the whole point, so do not "fix" it by only editing one side.
+# to every workflow listed under `pinned` AND to every list under `env_lists`.
+# The guard fails until all three are done — that is the whole point, so do not
+# "fix" it by only editing one side.
 
 # The release lines CI is expected to cover.
 release_lines: [v2, v4]
@@ -57,6 +67,21 @@ unpinned:
   # The guard itself. It must run on any branch, or it is #4339 one level up.
   release-line-guard.yml: '**'
 
+# Hand-written release-line lists that are NOT trigger filters, and so are
+# invisible to the branch-filter check above. Each key is `<workflow> <ENV>`;
+# the value uses the same grammar as `pinned` — extras, and `-name` for a
+# release line the list deliberately omits.
+#
+# The variable must appear exactly once in the workflow. Zero means the list was
+# renamed or removed and the guard is asserting nothing; more than one means the
+# guard cannot tell which occurrence is the policy. Both fail rather than
+# guessing.
+env_lists:
+  # docker.yml's gate job: only long-lived branches push to GHCR. `mk` and `dd`
+  # are standing experimental branches — not release lines, but branches a hive
+  # can be assigned to, so they legitimately publish a `<branch>-latest` tag.
+  docker.yml LONG_LIVED: [mk, dd]
+
 # MAINTAINER DECISION — deliberately NOT answered here (#4405).
 #
 # Should `v2` still be in these allow-lists? Mainline is `v4`, yet eight of the
@@ -68,8 +93,11 @@ unpinned:
 #   - if `v2` IS still supported, scorecard.yml's `-v2` exclusion should be
 #     dropped and `v2` added to that workflow;
 #   - if it is NOT, remove `v2` from `release_lines` above and from the eight
-#     workflows that name it (and drop the now-redundant `-v2`).
+#     workflows that name it plus docker.yml's `LONG_LIVED` (and drop the
+#     now-redundant `-v2`).
 #
 # Either way it is one edit to `release_lines` plus the workflows, and this
-# guard proves the edit is complete. Until a maintainer says otherwise, the
-# current behaviour stands unchanged.
+# guard proves the edit is complete — in both directions: retiring a line names
+# every list that still carries it, exactly as cutting one names every list that
+# does not. Until a maintainer says otherwise, the current behaviour stands
+# unchanged.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,12 @@ jobs:
   # The long-lived branch set is defined ONCE below (LONG_LIVED). To add or
   # remove one, edit only that list — the whole workflow derives from this job's
   # output, so nothing else changes.
+  #
+  # It is not a trigger filter, so it hand-writes the release lines a second
+  # time, and going stale here fails GREEN: the image would keep building on a
+  # new release line and never publish its <branch>-latest tag (#4462). The
+  # release-line guard asserts this list against .github/release-lines.yml —
+  # see the `env_lists` entry there and src/docs/release-line-guard.md.
   gate:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release-line-guard.yml
+++ b/.github/workflows/release-line-guard.yml
@@ -10,6 +10,11 @@ name: Release Line Guard
 # single source of truth in .github/release-lines.yml, so cutting `v5` becomes
 # one edit that CI enforces rather than nine edits nobody is reminded to make.
 #
+# It also covers the same names where they are hand-written OUTSIDE a trigger:
+# docker.yml's `LONG_LIVED` GHCR push policy (#4462). A stale list there is
+# worse than a skipped workflow, because it is green — the image keeps building
+# on the new release line and simply never publishes `<branch>-latest`.
+#
 # TRIGGERS ON EVERY BRANCH ON PURPOSE. A guard against branch-pinned workflows
 # must not itself be branch-pinned, or it is #4339 one level up — hence the
 # `'**'` here and the `unpinned` entry for this file in the manifest, which the

--- a/src/docs/release-line-guard.md
+++ b/src/docs/release-line-guard.md
@@ -1,4 +1,4 @@
-# Release-line carry-forward guard (#4405)
+# Release-line carry-forward guard (#4405, #4462)
 
 ## Why this exists
 
@@ -14,12 +14,23 @@ records the lesson:
 
 That fix added `v4` to the list. It did not change the fact that the list is
 hand-maintained, so the same failure was simply queued up for the day `v5` is
-cut. `docker.yml` is the outlier that does not have the problem — it triggers on
-`'**'` with bot branches excluded, deliberately, so a PR's image always builds.
+cut. `docker.yml` is the outlier whose *trigger* does not have the problem — it
+fires on `'**'` with bot branches excluded, deliberately, so a PR's image always
+builds.
 
 So on the day `v5` branches, without this guard: the Docker image keeps building
 on every branch, while both CI workflows, both security contract gates and all
 five Podman guards report nothing at all. Not red — *absent*.
+
+And the image that keeps building is never published
+([#4462](https://github.com/kubestellar/hive/issues/4462)). The release-line
+names are hand-written a **second** time outside any trigger: `docker.yml`'s
+gate job carries them in a `LONG_LIVED` env var, its GHCR push policy. Only
+branches named there publish a `<branch>-latest` tag. That list going stale is
+the same class of bug reached from the other side, and it is worse than an
+absent workflow, because it is *green*: `v5` builds on every push, `v5-latest`
+never appears, no hive can be assigned to the new line through the hub's branch
+switcher, and the image looks healthy throughout.
 
 ## What the guard is
 
@@ -33,7 +44,7 @@ Three files:
 
 The [issue](https://github.com/kubestellar/hive/issues/4405) offered two shapes.
 This is shape 1, *assert the set*, and not shape 2, *remove the pins* (trigger
-on `v*`). Two reasons:
+on `v*`). Three reasons:
 
 - `scorecard.yml` triggers on `main`, which is not a release line and does not
   match `v*`. A pattern cannot express it, so a pattern would leave the workflow
@@ -41,6 +52,9 @@ on `v*`). Two reasons:
 - A `v*` pattern silently widens what runs. Any branch someone happens to name
   `validate-thing` starts running the Podman lanes. Coverage would be correct by
   construction, but nobody would be able to see what it covers.
+- A pattern cannot express `docker.yml`'s push policy at all: `LONG_LIVED` is a
+  shell word list compared against `github.ref_name`, not a trigger filter, and
+  it deliberately includes two branches that are not release lines.
 
 Asserting the set keeps the trigger blocks saying literally what they run on,
 and turns cutting `v5` into one edit that CI enforces.
@@ -49,9 +63,12 @@ and turns cutting `v5` into one edit that CI enforces.
 
 1. Add the branch name to `release_lines` in `.github/release-lines.yml`.
 2. Add it to the trigger block of every workflow listed under `pinned`.
+3. Add it to every list under `env_lists` — today that is `docker.yml`'s
+   `LONG_LIVED`, without which the new line builds but never publishes.
 
 Doing only step 1 fails the guard, naming each workflow that would not run on
-the new branch. That is the demonstration
+the new branch and each list that would not publish it. That is the
+demonstration
 `src/scripts/test-release-lines-guard.sh` performs in CI, against the real
 workflow files:
 
@@ -59,7 +76,15 @@ workflow files:
 FAIL: v2-ci.yml:5 branches: has [v2,v4], expected [v2,v4,v5] — missing: v5.
       A release line named here but absent from the workflow means that
       workflow does not run on it at all.
+FAIL: docker.yml:56 env LONG_LIVED: has [dd,mk,v2,v4], expected
+      [dd,mk,v2,v4,v5] — missing: v5. This list is not a trigger, so a release
+      line missing from it fails GREEN: the image still builds on that branch
+      and simply never publishes its <branch>-latest tag, leaving no image for
+      a hive to be assigned to.
 ```
+
+The check is an equality in both directions, so *retiring* a line is proven
+complete the same way: every list still naming it is reported as `unexpected`.
 
 ## What it checks
 
@@ -78,6 +103,20 @@ FAIL: v2-ci.yml:5 branches: has [v2,v4], expected [v2,v4,v5] — missing: v5.
 - **Stale manifest entries.** An entry naming a workflow that no longer exists,
   or one that has lost its branch filter, fails. A guard checking a file with
   nothing left to check is green for no reason.
+- **Lists that are not triggers.** Entries under `env_lists`, keyed
+  `<workflow.yml> <ENV_NAME>`, are held to the same set as the pinned triggers.
+  The value takes the same `[extra]` / `[-excluded]` grammar; `mk` and `dd` are
+  declared extras on `LONG_LIVED` — standing experimental branches that are not
+  release lines but that a hive can be assigned to, so they legitimately publish
+  a tag. The value is read in any of the spellings a workflow env can take
+  (`"v2 v4"`, unquoted, or `[v2, v4]`), with trailing comments ignored.
+- **That the env list is still there to check.** The variable must appear
+  exactly once in the workflow. Zero occurrences means it was renamed or
+  removed, so the entry asserts nothing; more than one means the guard cannot
+  tell which is the policy. Both fail rather than checking whichever came first.
+  Prose that merely mentions the name — `docker.yml` has a comment saying the
+  set is "defined ONCE below (LONG_LIVED)", and the gate step reads
+  `$LONG_LIVED` in shell — is not a definition and is not counted.
 
 `pinned` values adjust the expected set per workflow: `[main]` is an extra
 branch the workflow legitimately allows, `[-v2]` a release line it deliberately
@@ -93,7 +132,8 @@ one level up.
 
 Its path filter (`.github/**`, the manifest, the two scripts) is safe in a way a
 branch filter would not be: this invariant can only be broken by editing a
-workflow, the manifest, or the checker.
+workflow, the manifest, or the checker. `docker.yml`'s `LONG_LIVED` lives in a
+workflow file, so it is inside that filter too.
 
 The workflow runs the self-test *before* the check, because a checker that has
 quietly stopped detecting anything would otherwise pass the real check for the

--- a/src/scripts/check-release-lines.sh
+++ b/src/scripts/check-release-lines.sh
@@ -21,6 +21,15 @@
 # docker.yml's '**'). An unclassified one fails: a new pinned workflow is
 # exactly the thing that goes stale next.
 #
+# It also asserts the release-line lists that are NOT trigger filters, declared
+# under `env_lists` (#4462). docker.yml hand-writes the branch names a second
+# time in its gate job's `LONG_LIVED` env var — the GHCR push policy — and no
+# branch-filter check can see it. That list going stale is worse than a skipped
+# workflow: on the day `v5` is cut, docker.yml's `'**'` trigger keeps BUILDING
+# the image on v5 while the policy never publishes `v5-latest`, so no hive can
+# be assigned to the new line and the image looks healthy throughout. Green
+# rather than absent.
+#
 # Usage: src/scripts/check-release-lines.sh [manifest] [workflows-dir]
 #   manifest        default .github/release-lines.yml
 #   workflows-dir   default .github/workflows
@@ -69,8 +78,76 @@ normalise() {
   printf '%s\n' "$@" | LC_ALL=C sort -u | paste -sd, -
 }
 
+# Assert one hand-written release-line list — a workflow's branch filter, or an
+# env list that is not a trigger at all — against the manifest. A manifest value
+# may carry `-name` entries: release lines this list deliberately does not
+# cover. Expected = release_lines + extras - exclusions, exactly.
+#
+#   $1 entry        the manifest key ("v2-ci.yml", "docker.yml LONG_LIVED")
+#   $2 label        what a finding names, e.g. "v2-ci.yml:5 branches:"
+#   $3 spec         the manifest value: extras, and `-name` exclusions
+#   $4 consequence  appended to a mismatch — what actually breaks
+#   $5.. actual     the branch names found in the file
+assert_release_line_set() {
+  local entry="$1" label="$2" spec="$3" consequence="$4"
+  shift 4
+  local actual=("$@")
+  local actual_set
+  actual_set="$(normalise ${actual[@]+"${actual[@]}"})"
+
+  local extras=() excluded=() token
+  for token in $spec; do
+    if [[ "$token" == -* ]]; then excluded+=("${token#-}"); else extras+=("$token"); fi
+  done
+
+  local ex rl found bad_exclusion=0
+  for ex in ${excluded[@]+"${excluded[@]}"}; do
+    found=0
+    for rl in "${RELEASE_LINES[@]}"; do [[ "$ex" == "$rl" ]] && found=1; done
+    if [[ $found -eq 0 ]]; then
+      note_fail "${entry}: ${MANIFEST} excludes '-${ex}', which is not a declared release line. Drop the stale exclusion."
+      bad_exclusion=1
+    fi
+  done
+  [[ $bad_exclusion -eq 1 ]] && return
+
+  local expected=() skip
+  for rl in "${RELEASE_LINES[@]}"; do
+    skip=0
+    for ex in ${excluded[@]+"${excluded[@]}"}; do [[ "$ex" == "$rl" ]] && skip=1; done
+    [[ $skip -eq 0 ]] && expected+=("$rl")
+  done
+  expected+=(${extras[@]+"${extras[@]}"})
+
+  if [[ ${#expected[@]} -eq 0 ]]; then
+    note_fail "${label} ${MANIFEST} excludes every release line for '${entry}' and declares no extras, so nothing is asserted. Fix the entry."
+    return
+  fi
+
+  local expected_set
+  expected_set="$(normalise "${expected[@]}")"
+  if [[ "$actual_set" == "$expected_set" ]]; then
+    note_ok "${label} ${actual_set}"
+    return
+  fi
+
+  local missing unexpected detail
+  missing="$(comm -23 \
+    <(printf '%s\n' "${expected[@]}" | LC_ALL=C sort -u) \
+    <(printf '%s\n' ${actual[@]+"${actual[@]}"} | LC_ALL=C sort -u) | paste -sd, -)"
+  unexpected="$(comm -13 \
+    <(printf '%s\n' "${expected[@]}" | LC_ALL=C sort -u) \
+    <(printf '%s\n' ${actual[@]+"${actual[@]}"} | LC_ALL=C sort -u) | paste -sd, -)"
+
+  detail=""
+  [[ -n "$missing" ]] && detail="missing: ${missing}"
+  [[ -n "$unexpected" ]] && detail="${detail:+${detail}; }unexpected: ${unexpected}"
+  note_fail "${label} has [${actual_set:-<empty>}], expected [${expected_set}] — ${detail}. ${consequence}"
+}
+
 RELEASE_LINES=()
 declare -A PINNED_EXTRAS=()
+declare -A ENV_LISTS=()
 UNPINNED=()
 
 section=""
@@ -85,8 +162,9 @@ while IFS= read -r line; do
     section=""
     continue
   fi
-  if [[ "$line" =~ ^pinned:[[:space:]]*$ ]];   then section="pinned";   continue; fi
-  if [[ "$line" =~ ^unpinned:[[:space:]]*$ ]]; then section="unpinned"; continue; fi
+  if [[ "$line" =~ ^pinned:[[:space:]]*$ ]];    then section="pinned";    continue; fi
+  if [[ "$line" =~ ^unpinned:[[:space:]]*$ ]];  then section="unpinned";  continue; fi
+  if [[ "$line" =~ ^env_lists:[[:space:]]*$ ]]; then section="env_lists"; continue; fi
   if [[ "$line" =~ ^[^[:space:]] ]]; then section=""; continue; fi
 
   # Indented entry: "  name.yml: value"
@@ -94,8 +172,9 @@ while IFS= read -r line; do
   entry="${BASH_REMATCH[1]}"
   value="${BASH_REMATCH[2]}"
   case "$section" in
-    pinned)   PINNED_EXTRAS["$entry"]="$(flow_items "$value")" ;;
-    unpinned) UNPINNED+=("$entry") ;;
+    pinned)    PINNED_EXTRAS["$entry"]="$(flow_items "$value")" ;;
+    unpinned)  UNPINNED+=("$entry") ;;
+    env_lists) ENV_LISTS["$entry"]="$(flow_items "$value")" ;;
   esac
 done < "$MANIFEST"
 
@@ -227,56 +306,9 @@ while IFS=$'\t' read -r path lineno key branches; do
     continue
   fi
 
-  # A manifest value may carry `-name` entries: release lines this workflow
-  # deliberately does not cover. Expected = release_lines + extras - exclusions.
-  extras=()
-  excluded=()
-  for token in $expected_extras; do
-    if [[ "$token" == -* ]]; then excluded+=("${token#-}"); else extras+=("$token"); fi
-  done
-
-  expected=()
-  for rl in "${RELEASE_LINES[@]}"; do
-    skip=0
-    for ex in ${excluded[@]+"${excluded[@]}"}; do [[ "$ex" == "$rl" ]] && skip=1; done
-    [[ $skip -eq 0 ]] && expected+=("$rl")
-  done
-  expected+=(${extras[@]+"${extras[@]}"})
-
-  bad_exclusion=0
-  for ex in ${excluded[@]+"${excluded[@]}"}; do
-    found=0
-    for rl in "${RELEASE_LINES[@]}"; do [[ "$ex" == "$rl" ]] && found=1; done
-    if [[ $found -eq 0 ]]; then
-      note_fail "${base}: ${MANIFEST} excludes '-${ex}', which is not a declared release line. Drop the stale exclusion."
-      bad_exclusion=1
-    fi
-  done
-  [[ $bad_exclusion -eq 1 ]] && continue
-
-  if [[ ${#expected[@]} -eq 0 ]]; then
-    note_fail "${base}:${lineno} ${key}: ${MANIFEST} excludes every release line and declares no extras, so nothing is asserted. Move it to 'unpinned' or fix the entry."
-    continue
-  fi
-
-  expected_set="$(normalise "${expected[@]}")"
-
-  if [[ "$actual_set" == "$expected_set" ]]; then
-    note_ok "${base}:${lineno} ${key}: ${actual_set}"
-    continue
-  fi
-
-  missing="$(comm -23 \
-    <(printf '%s\n' "${expected[@]}" | LC_ALL=C sort -u) \
-    <(printf '%s\n' "${actual[@]}" | LC_ALL=C sort -u) | paste -sd, -)"
-  unexpected="$(comm -13 \
-    <(printf '%s\n' "${expected[@]}" | LC_ALL=C sort -u) \
-    <(printf '%s\n' "${actual[@]}" | LC_ALL=C sort -u) | paste -sd, -)"
-
-  detail=""
-  [[ -n "$missing" ]] && detail="missing: ${missing}"
-  [[ -n "$unexpected" ]] && detail="${detail:+${detail}; }unexpected: ${unexpected}"
-  note_fail "${base}:${lineno} ${key}: has [${actual_set:-<empty>}], expected [${expected_set}] — ${detail}. A release line named here but absent from the workflow means that workflow does not run on it at all."
+  assert_release_line_set "$base" "${base}:${lineno} ${key}:" "$expected_extras" \
+    "A release line named here but absent from the workflow means that workflow does not run on it at all." \
+    ${actual[@]+"${actual[@]}"}
 done <<< "$records"
 
 # A manifest entry whose workflow lost its branch filter (or its file) is just
@@ -298,12 +330,92 @@ for base in "${UNPINNED[@]}"; do
   fi
 done
 
+# ---------------------------------------------------------------------------
+# Hand-written branch lists that are not trigger filters (#4462)
+# ---------------------------------------------------------------------------
+
+# Print every assignment of <var> in a workflow, one per occurrence:
+#   <line-number><TAB><space-separated branch names>
+# Accepts the spellings a workflow env value can take: `VAR: "v2 v4"`, the same
+# unquoted, and `VAR: [v2, v4]`. Comments are dropped outside quotes, so the
+# prose that names the variable is not mistaken for a second definition.
+extract_env_list() {
+  awk -v var="$2" '
+    function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+    function unquote(s,  c) {
+      s = trim(s)
+      if (length(s) >= 2) {
+        c = substr(s, 1, 1)
+        if ((c == "\"" || c == "'"'"'") && substr(s, length(s), 1) == c)
+          return substr(s, 2, length(s) - 2)
+      }
+      return s
+    }
+    function strip_comment(s,  i, c, q, out) {
+      q = ""; out = ""
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (q != "") { out = out c; if (c == q) q = ""; continue }
+        if (c == "\"" || c == "'"'"'") { q = c; out = out c; continue }
+        if (c == "#") break
+        out = out c
+      }
+      return out
+    }
+    BEGIN { pat = "^[[:space:]]*" var ":[[:space:]]*" }
+    {
+      raw = strip_comment($0)
+      if (!match(raw, pat)) next
+      rest = unquote(trim(substr(raw, RSTART + RLENGTH)))
+      if (substr(rest, 1, 1) == "[") rest = substr(rest, 2, index(rest, "]") - 2)
+      gsub(/,/, " ", rest)
+      gsub(/["'"'"']/, "", rest)
+      printf "%d\t%s\n", FNR, trim(rest)
+    }
+  ' "$1"
+}
+
+if [[ ${#ENV_LISTS[@]} -gt 0 ]]; then
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    file="${entry%% *}"
+    var="${entry##* }"
+    if [[ "$file" == "$entry" || -z "$var" ]]; then
+      note_fail "${entry}: an 'env_lists' key in ${MANIFEST} must be '<workflow.yml> <ENV_NAME>'."
+      continue
+    fi
+    if [[ ! -f "${WORKFLOW_DIR}/${file}" ]]; then
+      note_fail "${entry}: listed under 'env_lists' in ${MANIFEST} but ${WORKFLOW_DIR}/${file} does not exist."
+      continue
+    fi
+
+    mapfile -t hits < <(extract_env_list "${WORKFLOW_DIR}/${file}" "$var")
+    if [[ ${#hits[@]} -eq 0 ]]; then
+      note_fail "${entry}: no '${var}:' assignment found in ${file}. It was renamed or removed, so this entry asserts nothing. Update ${MANIFEST} to name the list as it is spelled today."
+      continue
+    fi
+    if [[ ${#hits[@]} -gt 1 ]]; then
+      lines="$(printf '%s\n' "${hits[@]}" | cut -f1 | paste -sd, -)"
+      note_fail "${entry}: '${var}:' is assigned ${#hits[@]} times in ${file} (lines ${lines}), so the guard cannot tell which one is the policy. Define the list once."
+      continue
+    fi
+
+    lineno="${hits[0]%%$'\t'*}"
+    value="${hits[0]#*$'\t'}"
+    read -r -a items <<< "$value"
+    assert_release_line_set "$entry" "${file}:${lineno} env ${var}:" "${ENV_LISTS[$entry]}" \
+      "This list is not a trigger, so a release line missing from it fails GREEN: the image still builds on that branch and simply never publishes its <branch>-latest tag, leaving no image for a hive to be assigned to." \
+      ${items[@]+"${items[@]}"}
+  done < <(printf '%s\n' "${!ENV_LISTS[@]}" | LC_ALL=C sort)
+fi
+
 echo
 if [[ $fail -ne 0 ]]; then
-  echo "RESULT: FAIL — workflow branch filters are out of sync with ${MANIFEST}."
-  echo "Cutting a release line takes two edits: the manifest AND every workflow"
-  echo "listed under 'pinned'. Fixing only the manifest leaves those workflows"
-  echo "not running on the new branch at all (#4339)."
+  echo "RESULT: FAIL — hand-written branch lists are out of sync with ${MANIFEST}."
+  echo "Cutting a release line takes three edits: the manifest, every workflow"
+  echo "listed under 'pinned', and every list under 'env_lists'. Fixing only the"
+  echo "manifest leaves those workflows not running on the new branch at all"
+  echo "(#4339), and leaves the image built on it but never published (#4462)."
   exit 1
 fi
-echo "RESULT: PASS — every pinned workflow covers the declared release lines."
+echo "RESULT: PASS — every pinned workflow and hand-written list covers the declared release lines."

--- a/src/scripts/test-release-lines-guard.sh
+++ b/src/scripts/test-release-lines-guard.sh
@@ -12,6 +12,11 @@
 # only understands one of the two YAML spellings of `branches:` silently stops
 # covering v2-ci.yml, the highest-value entry in the table.
 #
+# Cases 11-15 cover the same demand for the lists that are NOT triggers (#4462)
+# — docker.yml's `LONG_LIVED` push policy. That one can rot in an extra way a
+# branch filter cannot: the variable can be renamed, or defined twice, leaving
+# an entry that asserts nothing while the guard still prints a line about it.
+#
 # Usage: src/scripts/test-release-lines-guard.sh
 set -uo pipefail
 
@@ -62,6 +67,11 @@ echo "== Release-line guard self-test =="
 # 1. The repository as it stands is in sync.
 # ---------------------------------------------------------------------------
 expect 0 "repository is in sync with its own manifest" -- "$REAL_MANIFEST" "$REAL_WORKFLOWS"
+# The manifest side can rot too: dropping docker.yml's `env_lists` entry would
+# leave the run green by having nothing to check. Assert the real run does
+# assert the push policy, so that deletion is a failing test rather than a
+# quieter guard.
+expect_mentions "env LONG_LIVED" "the real run asserts docker.yml's LONG_LIVED push policy"
 
 # ---------------------------------------------------------------------------
 # 2. THE DEMONSTRATION (#4405 acceptance criterion 1). Add a plausible future
@@ -77,12 +87,15 @@ for wf in v2-ci.yml v2-tests.yml podman-contract.yml podman-rootful-lane.yml \
           suid-contract.yml scorecard.yml; do
   expect_mentions "FAIL: ${wf}" "${wf} is reported"
 done
-# docker.yml is deliberately unpinned and must NOT be dragged into the failure.
-if grep -q "FAIL: docker.yml" <<< "$LAST_OUT"; then
+# docker.yml's TRIGGER is deliberately unpinned and must NOT be dragged into the
+# failure — while its push policy, which is not a trigger, must be.
+if grep -Eq "FAIL: docker\.yml:[0-9]+ branches" <<< "$LAST_OUT"; then
   bad "docker.yml's '**' trigger was flagged; it is deliberate"
 else
   pass "docker.yml's '**' trigger is recognised as deliberate, not flagged"
 fi
+expect_mentions "FAIL: docker.yml" "docker.yml's LONG_LIVED push policy is reported (#4462)"
+expect_mentions "env LONG_LIVED" "the push-policy failure names the env list, not a trigger"
 
 # ---------------------------------------------------------------------------
 # Fixtures for the remaining cases.
@@ -95,6 +108,8 @@ pinned:
   block-form.yml: []
 unpinned:
   wild.yml: '**'
+env_lists:
+  envy.yml LONG_LIVED: [mk]
 EOF
 }
 
@@ -108,12 +123,22 @@ write_block() {
   } > "${WFDIR}/block-form.yml"
 }
 write_wild()  { printf 'on:\n  push:\n    branches:\n      - %s\n' "$1" > "${WFDIR}/wild.yml"; }
+# A workflow carrying a hand-written branch list that is NOT a trigger, in the
+# shape docker.yml's gate job uses. It has no branch filter at all, so it is
+# classified by `env_lists` alone.
+write_env()   {
+  { printf 'jobs:\n  gate:\n    steps:\n      - name: Decide push policy\n'
+    printf '        env:\n'
+    printf '          %s\n' "$1"
+  } > "${WFDIR}/envy.yml"
+}
 
 MANIFEST="${TMP}/manifest.yml"
 mk_manifest "$MANIFEST"
 
 # 3. Both spellings in sync -> pass.
 write_flow "v2, v4"; write_block "v2 v4"; write_wild "'**'"
+write_env 'LONG_LIVED: "v2 v4 mk"'
 expect 0 "flow sequence and block sequence both parse when in sync" -- "$MANIFEST" "$WFDIR"
 
 # 4. Flow spelling (`branches: [v2, v4]`) out of sync is caught. This is the
@@ -166,6 +191,80 @@ rm "${WFDIR}/block-form.yml"
 expect 1 "a manifest entry for a deleted workflow is caught" -- "$MANIFEST" "$WFDIR"
 expect_mentions "does not exist" "the deleted workflow is explained"
 write_block "v2 v4"
+
+# ---------------------------------------------------------------------------
+# 11. A hand-written list that is not a trigger, in sync, parses in each of the
+#     spellings a workflow env value can take.
+# ---------------------------------------------------------------------------
+write_env "LONG_LIVED: 'v2 v4 mk'"
+expect 0 "a single-quoted env list parses" -- "$MANIFEST" "$WFDIR"
+write_env 'LONG_LIVED: v2 v4 mk'
+expect 0 "an unquoted env list parses" -- "$MANIFEST" "$WFDIR"
+write_env 'LONG_LIVED: [v2, v4, mk]'
+expect 0 "a flow-sequence env list parses" -- "$MANIFEST" "$WFDIR"
+write_env 'LONG_LIVED: "v2 v4 mk"'
+
+# ---------------------------------------------------------------------------
+# 12. THE #4462 DEMONSTRATION on fixtures: a release line missing from a list
+#     that is not a trigger is caught. Nothing about the workflow's triggers
+#     changes, which is exactly why the branch-filter check cannot see it.
+# ---------------------------------------------------------------------------
+write_env 'LONG_LIVED: "v2 mk"'
+expect 1 "a stale env list is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "FAIL: envy.yml" "the workflow holding the stale list is named"
+expect_mentions "missing: v4" "the env-list failure names the missing branch"
+expect_mentions "env LONG_LIVED" "the failure identifies the list by name"
+
+# A branch the manifest does not declare as an extra is caught too: the check
+# is an equality, so a retired release line left in the list is reported in the
+# same run as one that was never added.
+write_env 'LONG_LIVED: "v2 v4 mk v9"'
+expect 1 "an undeclared extra branch in an env list is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "unexpected: v9" "the surplus branch is named"
+write_env 'LONG_LIVED: "v2 v4 mk"'
+
+# ---------------------------------------------------------------------------
+# 13. The list is renamed or deleted. A branch filter cannot vanish without the
+#     workflow visibly changing shape; an env var can, and the entry would then
+#     assert nothing while still looking checked.
+# ---------------------------------------------------------------------------
+write_env 'PUBLISH_BRANCHES: "v2 v4 mk"'
+expect 1 "an env list that no longer exists under that name is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "no 'LONG_LIVED:' assignment found" "the renamed list is explained"
+write_env 'LONG_LIVED: "v2 v4 mk"'
+
+# ---------------------------------------------------------------------------
+# 14. Defined twice: the guard must refuse to guess which one is the policy
+#     rather than checking the first and reporting green.
+# ---------------------------------------------------------------------------
+{ printf 'jobs:\n  gate:\n    steps:\n      - name: Decide push policy\n'
+  printf '        env:\n          LONG_LIVED: "v2 v4 mk"\n'
+  printf '  other:\n    steps:\n      - env:\n          LONG_LIVED: "v2"\n'
+} > "${WFDIR}/envy.yml"
+expect 1 "an env list defined twice is caught rather than guessed at" -- "$MANIFEST" "$WFDIR"
+expect_mentions "is assigned 2 times" "the ambiguity is explained"
+write_env 'LONG_LIVED: "v2 v4 mk"'
+
+# Prose that merely mentions the variable is not a second definition: the real
+# docker.yml names LONG_LIVED in a comment above the job, and case 1 would fail
+# if that counted.
+{ printf '# The long-lived branch set is defined ONCE below (LONG_LIVED).\n'
+  printf 'jobs:\n  gate:\n    steps:\n      - env:\n'
+  printf '          LONG_LIVED: "v2 v4 mk"   # release lines + standing branches\n'
+  # shellcheck disable=SC2016 # the fixture is shell source, not an expansion
+  printf '        run: for b in $LONG_LIVED; do :; done\n'
+} > "${WFDIR}/envy.yml"
+expect 0 "a comment and a shell reference are not counted as definitions" -- "$MANIFEST" "$WFDIR"
+write_env 'LONG_LIVED: "v2 v4 mk"'
+
+# ---------------------------------------------------------------------------
+# 15. A manifest entry naming a workflow that no longer exists is caught here
+#     too — the same rot as a stale `pinned` entry, in the other section.
+# ---------------------------------------------------------------------------
+rm "${WFDIR}/envy.yml"
+expect 1 "an env_lists entry for a deleted workflow is caught" -- "$MANIFEST" "$WFDIR"
+expect_mentions "does not exist" "the deleted workflow is explained"
+write_env 'LONG_LIVED: "v2 v4 mk"'
 
 echo
 if [[ $fail -ne 0 ]]; then


### PR DESCRIPTION
Closes #4462. Follow-up to #4405 / #4457; part of the #4188 second-wave hardening context — does **not** close the parent.

## The gap

The merged guard asserts every workflow's `branches:` trigger against `.github/release-lines.yml`. The release-line names are hand-written a **second** time outside any trigger: `docker.yml`'s gate job carries them in a `LONG_LIVED` env var, its GHCR push policy. That list is not a branch filter, so the guard never saw it.

It is worse than the skipped-workflow class the guard already catches, because it fails **green rather than absent**. On the day `v5` is cut, `docker.yml` still triggers on `'**'` so the image keeps *building* on v5, while the push policy never publishes `v5-latest` — no hive could be assigned to the new line through the hub's branch switcher, and the image looks healthy the whole time.

## What lands

**`.github/release-lines.yml`** gains an `env_lists` section, keyed `<workflow.yml> <ENV_NAME>` (a colon in the key would collide with YAML's own), taking the same `[extra]` / `[-excluded]` grammar as `pinned`:

```yaml
env_lists:
  docker.yml LONG_LIVED: [mk, dd]
```

`mk` and `dd` are declared extras, as the issue asks: standing experimental branches, not release lines, but branches a hive can be assigned to — so they legitimately publish a `<branch>-latest` tag.

**`src/scripts/check-release-lines.sh`** factors the expected-set comparison out of the branch-filter loop into `assert_release_line_set` and reuses it for these lists, so both are held to the same equality, in both directions: cutting a line names every list that omits it, retiring one names every list that still carries it. The value is read in each spelling a workflow env can take (`"v2 v4"`, unquoted, `[v2, v4]`), with trailing comments dropped outside quotes.

Two rot modes a branch filter does not have are also checked, because the entry would otherwise look checked while asserting nothing:

- the variable must appear **exactly once** — zero means it was renamed or removed, more than one means the guard cannot tell which occurrence is the policy. Both fail rather than guessing;
- prose that merely names it is not a definition. `docker.yml`'s own comment says the set is "defined ONCE below (LONG_LIVED)" and the gate step reads `$LONG_LIVED` in shell; neither is counted.

## Demonstration

Against the repository's real workflows, adding `v5` to `release_lines` and changing nothing else — `docker.yml` now appears in the failure, by its push policy and not by its trigger:

```
FAIL: v2-ci.yml:5 branches: has [v2,v4], expected [v2,v4,v5] — missing: v5. A release line
      named here but absent from the workflow means that workflow does not run on it at all.
...
FAIL: docker.yml:56 env LONG_LIVED: has [dd,mk,v2,v4], expected [dd,mk,v2,v4,v5] — missing:
      v5. This list is not a trigger, so a release line missing from it fails GREEN: the
      image still builds on that branch and simply never publishes its <branch>-latest tag,
      leaving no image for a hive to be assigned to.

RESULT: FAIL — hand-written branch lists are out of sync with .github/release-lines.yml.
Cutting a release line takes three edits: the manifest, every workflow listed under
'pinned', and every list under 'env_lists'.
```

**`docker.yml`'s `'**'` trigger is still recognised as deliberate and is not flagged.** The self-test asserts that as a distinct fact from the push-policy finding (`FAIL: docker.yml:<n> branches` must not appear while `FAIL: docker.yml:<n> env LONG_LIVED` must), so the two halves of that file cannot be confused for one another later.

## Self-test

`src/scripts/test-release-lines-guard.sh` grows six cases: the three env spellings parse; a stale list is caught and names the missing branch; an undeclared surplus branch is caught; a renamed variable is caught; a variable defined twice is refused rather than guessed at; a comment and a shell reference are not counted as definitions; and an `env_lists` entry for a deleted workflow is caught.

Case 1 additionally asserts the **real** run reaches the push policy at all — so deleting the manifest entry is a failing test rather than a quieter guard, which is the one thing a manifest-driven check cannot otherwise notice about itself.

Verified the tests are load-bearing by mutation: disabling the `env_lists` parse in the checker turns them red, rather than the suite passing for the wrong reason.

## Testing

```
src/scripts/check-release-lines.sh        # PASS — 20 lists asserted, including the new one
src/scripts/test-release-lines-guard.sh   # PASS — 47 assertions
shellcheck src/scripts/*.sh               # no new findings (two pre-existing SC2001 style notes)
```

Both run in CI via `release-line-guard.yml`, whose existing `.github/workflows/**` path filter already covers `docker.yml` — no trigger change was needed.

No runtime code is touched and nothing user-facing changes, so there is no CHANGELOG entry.

## Not in scope

Whether `v2` is still a supported release line remains the maintainer decision #4405 deliberately left open. This PR does not answer it; it only adds `docker.yml`'s `LONG_LIVED` to the list of places the note at the bottom of the manifest says a resolution would have to edit.

— hive: backend=claude model=claude-opus-5
