### PR TITLE
✨ Rename the fleet page route to /fleet, matching its nav button

### DIFF
--- a/src/pkg/hub/fleet_route_test.go
+++ b/src/pkg/hub/fleet_route_test.go
@@ -1,0 +1,39 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The fleet page moved from /my-hives to /fleet to match the "Fleet" nav
+// button that opens it. /fleet must serve the page; /my-hives must
+// permanently redirect (query string preserved) so old bookmarks, shared
+// links, and OAuth redirect params keep working. The API endpoint
+// /api/saas/my-hives is intentionally unchanged.
+func TestFleetRouteServesPageAndMyHivesRedirects(t *testing.T) {
+	t.Setenv("HUB_DATA_DIR", t.TempDir())
+	srv := NewHubServer(0, slog.Default(), "test", "v4")
+
+	req := httptest.NewRequest("GET", "/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /fleet: expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "<html") {
+		t.Error("GET /fleet: expected the fleet page HTML shell")
+	}
+
+	req = httptest.NewRequest("GET", "/my-hives?view=quadrant", nil)
+	w = httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("GET /my-hives: expected 301, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/fleet?view=quadrant" {
+		t.Errorf("GET /my-hives: Location = %q, want /fleet?view=quadrant", loc)
+	}
+}

--- a/src/pkg/hub/hub_coverage_boost_test.go
+++ b/src/pkg/hub/hub_coverage_boost_test.go
@@ -1966,7 +1966,7 @@ func TestHandleMyHivesWithBearerAndCache(t *testing.T) {
 		ghTokenCacheMu.Unlock()
 	}()
 
-	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_test")
 	w := httptest.NewRecorder()
 	srv.handleMyHives(w, req)

--- a/src/pkg/hub/hub_coverage_deep_test.go
+++ b/src/pkg/hub/hub_coverage_deep_test.go
@@ -519,7 +519,7 @@ func TestHandleMyHivesAdminWithBearer(t *testing.T) {
 	}
 	srv.mu.Unlock()
 
-	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_admin_my")
 	w := httptest.NewRecorder()
 	srv.handleMyHives(w, req)

--- a/src/pkg/hub/hub_coverage_extra_test.go
+++ b/src/pkg/hub/hub_coverage_extra_test.go
@@ -550,7 +550,7 @@ func TestHandleMyHivesAdminSeesAllHives(t *testing.T) {
 	}
 	srv.mu.Unlock()
 
-	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_admin_myhives")
 	w := httptest.NewRecorder()
 	srv.handleMyHives(w, req)

--- a/src/pkg/hub/hub_filesystem_extra_test.go
+++ b/src/pkg/hub/hub_filesystem_extra_test.go
@@ -188,7 +188,7 @@ func TestHandleMyHivesWithSaaSHivesOnly(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_saas")
 	w := httptest.NewRecorder()
 	srv.handleMyHives(w, req)
@@ -241,7 +241,7 @@ func TestHandleMyHivesWithErrorHive(t *testing.T) {
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
-	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_err")
 	w := httptest.NewRecorder()
 	srv.handleMyHives(w, req)
@@ -286,7 +286,7 @@ func TestHandleMyHivesAdminSeesAll(t *testing.T) {
 	}
 	srv.mu.Unlock()
 
-	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_admin_all")
 	w := httptest.NewRecorder()
 	srv.handleMyHives(w, req)

--- a/src/pkg/hub/hub_filesystem_test.go
+++ b/src/pkg/hub/hub_filesystem_test.go
@@ -529,7 +529,7 @@ func TestHandleMyHivesWithFilesystem(t *testing.T) {
 	}
 	srv.mu.Unlock()
 
-	req := httptest.NewRequest("GET", "/my-hives", nil)
+	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_fs")
 	w := httptest.NewRecorder()
 	srv.handleMyHives(w, req)

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -9760,7 +9760,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <a href="/reading">Reading</a>
       <a href="/get-started">Get Started</a>
       <a href="/dashboard" style="color:var(--amber)">My Hives</a>
-      <a href="/my-hives" id="nav-fleet" style="display:none" title="Fleet health — agents the governor expects on but that can't work">Fleet</a>
+      <a href="/fleet" id="nav-fleet" style="display:none" title="Fleet health — agents the governor expects on but that can't work">Fleet</a>
       <a href="/api/docs" target="_blank">API</a>
       <a href="https://kubestellar.io/docs/hive/overview/introduction" target="_blank" rel="noopener">Docs</a>
       <span id="nav-user" class="nav-user"></span>

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -1432,7 +1432,18 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	// unauthenticated like every other static page; all sensitive data comes
 	// from GET /api/saas/my-hives, which is requireAuth-gated. On a 401 the page
 	// redirects to the OAuth login (see static/my-hives.html).
-	s.mux.HandleFunc("GET /my-hives", s.serveStatic("static/my-hives.html"))
+	// The page lives at /fleet — matching the "Fleet" nav button that opens it.
+	// /my-hives (the original path) permanently redirects so old bookmarks,
+	// OAuth redirect params, and shared links keep working; the API endpoint
+	// /api/saas/my-hives is unchanged.
+	s.mux.HandleFunc("GET /fleet", s.serveStatic("static/my-hives.html"))
+	s.mux.HandleFunc("GET /my-hives", func(w http.ResponseWriter, r *http.Request) {
+		target := "/fleet"
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusMovedPermanently)
+	})
 	s.mux.HandleFunc("GET /{$}", s.serveStatic("static/index.html"))
 	// Open Graph preview image for shared links. Registered here rather than in
 	// registerOAuth because that function returns early when OAuth is

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -350,7 +350,7 @@ function load() {
   fetch("/api/saas/my-hives", { credentials: "same-origin", headers: { "Accept": "application/json" } })
     .then(function (r) {
       if (r.status === 401) {
-        window.location.href = "/login?redirect=" + encodeURIComponent("/my-hives");
+        window.location.href = "/login?redirect=" + encodeURIComponent("/fleet");
         throw new Error("redirecting to login");
       }
       if (!r.ok) throw new Error("HTTP " + r.status);
@@ -360,7 +360,7 @@ function load() {
     .catch(function (e) {
       if (e && e.message === "redirecting to login") return;
       var c = document.getElementById("statusCell");
-      if (c) c.innerHTML = "Failed to load: " + esc(e.message) + ' — <a class="reload" href="/my-hives">retry</a>';
+      if (c) c.innerHTML = "Failed to load: " + esc(e.message) + ' — <a class="reload" href="/fleet">retry</a>';
     });
 }
 wireControls();


### PR DESCRIPTION
The **Fleet** nav button opened a page living at `/my-hives`. The page is now served at **/fleet**; `/my-hives` returns a 301 to `/fleet` (query string preserved) so old bookmarks, shared links, and OAuth `redirect` params keep working.

- `GET /fleet` → fleet page (static/my-hives.html)
- `GET /my-hives` → 301 → `/fleet`
- API endpoint `/api/saas/my-hives` unchanged
- Nav link + in-page self-references updated
- New route-level regression test `TestFleetRouteServesPageAndMyHivesRedirects`
- Full `go test ./pkg/hub` green