### PR TITLE
🐛 fix(advisory): heal the #4464 worktree/read-access finding phrasings

### DIFF
--- a/src/pkg/advisory/heal.go
+++ b/src/pkg/advisory/heal.go
@@ -107,6 +107,12 @@ const repoAccessHealedCloseReason = "auto-closed: the hive verified an advisory-
 // omitted Contents:read and the credential helper blocked fetches), and agents
 // word them freely, so the patterns tolerate drift.
 //
+// #4464 added two more phrasings from the same hive: "Repository worktree not
+// provisioned for guide agent despite include_repos=true configuration" and
+// "Quality agent lacks read access to repository for coverage analysis" —
+// both filed by a build that predated #4291, both escaping every pattern
+// below, so they survived in the digest forever after the read path healed.
+//
 // Like appAuthFindingPatterns they must stay directional: every pattern
 // requires the LACK language ("no/missing/lacks/cannot") adjacent to the
 // access/clone subject, so a CODE finding that merely mentions repository
@@ -125,8 +131,19 @@ var repoAccessFindingPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without|unavailable)\b[^.\n]*\brepo(sitory)?\s+(read\s+)?access\b[^.\n]*\b(mechanism|infrastructure|capabilit|path|method|provision)`),
 	// "repository access infrastructure missing"
 	regexp.MustCompile(`(?i)\brepo(sitory)?\s+(read\s+)?access\b[^.\n]*\b(mechanism|infrastructure|capabilit|path|method|provision)[a-z]*\b[^.\n]*\b(missing|unavailable|absent|lacking|not\s+available)\b`),
-	// "no repository workspace provisioning for advisory agents"
-	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without)\b[^.\n]*\brepo(sitory)?\s+workspace\s+provisioning\b`),
+	// "no repository workspace provisioning for advisory agents",
+	// "missing repository worktree provisioning"
+	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without)\b[^.\n]*\brepo(sitory)?\s+work(space|tree)\s+provision`),
+	// "Repository worktree not provisioned for guide agent" (#4464) — the
+	// trailing-negation form of the previous pattern. "worktree/workspace …
+	// not provisioned" only ever describes the agent's own missing checkout,
+	// never repository code, so the match is safe to keep this loose.
+	regexp.MustCompile(`(?i)\brepo(sitory)?\s+work(space|tree)\b[^.\n]*\b(not|never)\s+(been\s+)?provisioned\b`),
+	// "Quality agent lacks read access to repository for coverage analysis"
+	// (#4464). READ is required, not optional: "lacks write access to
+	// repository" is the app-auth family, and a Contents READ verification
+	// must never close a WRITE-access finding.
+	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without)\b[^.\n]*\bread(-only)?\s+access\s+to\b[^.\n]*\brepo(sitory)?\b`),
 	// "guide agent cannot access target repository", "unable to clone the repository"
 	regexp.MustCompile(`(?i)\b(cannot|can't|unable\s+to)\s+(access|read|clone|fetch)\b[^.\n]*\brepo(sitory)?\b`),
 }

--- a/src/pkg/advisory/heal_test.go
+++ b/src/pkg/advisory/heal_test.go
@@ -297,10 +297,25 @@ var gee4veeRepoAccessTitles = []struct{ title, ref string }{
 	{"Guide agent blocked: No repository access mechanism in L2 advisory mode", "github.ibm.com/devx-prod/epx-vscode-ext-poc"},
 }
 
+// gee4veeWorktreeTitles are the two exact finding titles from the #4464
+// screenshot (same hive as #2575, a build predating #4291): the guide agent's
+// "worktree not provisioned" phrasing and the quality agent's "lacks read
+// access" phrasing, both of which escaped every pre-#4464 pattern and so
+// survived in the digest after the read path healed.
+var gee4veeWorktreeTitles = []struct{ title, ref string }{
+	{"Repository worktree not provisioned for guide agent despite include_repos=true configuration", "/data/agents/guide (empty directory)"},
+	{"Quality agent lacks read access to repository for coverage analysis", "devx-prod/epx-vscode-ext-poc"},
+}
+
 func TestIsRepoAccessFinding(t *testing.T) {
 	for _, f := range gee4veeRepoAccessTitles {
 		if !IsRepoAccessFinding(f.title) {
 			t.Errorf("IsRepoAccessFinding(%q) = false, want true (the #2575 family must match)", f.title)
+		}
+	}
+	for _, f := range gee4veeWorktreeTitles {
+		if !IsRepoAccessFinding(f.title) {
+			t.Errorf("IsRepoAccessFinding(%q) = false, want true (the #4464 family must match)", f.title)
 		}
 	}
 	// Drift the agents plausibly produce must still match.
@@ -309,6 +324,9 @@ func TestIsRepoAccessFinding(t *testing.T) {
 		"clone mechanism unavailable for L2 guide agents",
 		"Guide agent unable to fetch the target repository",
 		"Agent workspace lacks a git clone mechanism",
+		"Repository workspace never provisioned for advisory agents",
+		"Missing repository worktree provisioning for guide agent",
+		"Scanner agent has no read-only access to the repository",
 	}
 	for _, title := range drift {
 		if !IsRepoAccessFinding(title) {
@@ -324,6 +342,12 @@ func TestIsRepoAccessFinding(t *testing.T) {
 		"Add repository access checks to the admin API",
 		"Overly permissive repository access granted to all org members",
 		"Insufficient repo permissions", // app-auth family, handled by the other healer
+		// WRITE-access lack is the app-auth family too — a verified Contents
+		// READ must never close it.
+		"Guide agent lacks write access to repository for issue filing",
+		// A worktree that exists but is dirty/stale is a real operational
+		// finding, not a missing read path.
+		"Repository worktree contains uncommitted changes from previous session",
 		"",
 	}
 	for _, title := range negatives {
@@ -372,6 +396,14 @@ func TestCloseHealedRepoAccessFindings(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// The #4464 pair heals through the same gate: the guide finding's ref
+	// ("/data/agents/guide (empty directory)") parses as no-repo → primary,
+	// and the quality finding's ref names the verified GHE repo.
+	for _, f := range gee4veeWorktreeTitles {
+		if _, err := store.Create(f.title, beads.TypeAdvisory, beads.PriorityHigh, "guide", f.ref); err != nil {
+			t.Fatal(err)
+		}
+	}
 	// A repo-access finding about a repo the verifier CANNOT read: real
 	// condition, must survive the heal.
 	locked, err := store.Create("Guide agent cannot access target repository - no clone mechanism available",
@@ -394,10 +426,11 @@ func TestCloseHealedRepoAccessFindings(t *testing.T) {
 	}
 
 	healed := CloseHealedRepoAccessFindings(stores, canRead)
-	if len(healed) != len(gee4veeRepoAccessTitles) {
-		t.Fatalf("healed %d findings (%v), want the %d from #2575", len(healed), healed, len(gee4veeRepoAccessTitles))
+	wantHealed := len(gee4veeRepoAccessTitles) + len(gee4veeWorktreeTitles)
+	if len(healed) != wantHealed {
+		t.Fatalf("healed %d findings (%v), want the %d from #2575 + #4464", len(healed), healed, wantHealed)
 	}
-	for _, f := range gee4veeRepoAccessTitles {
+	for _, f := range append(append([]struct{ title, ref string }{}, gee4veeRepoAccessTitles...), gee4veeWorktreeTitles...) {
 		found := false
 		for _, h := range healed {
 			if h == f.title {


### PR DESCRIPTION
## Root cause

#4464's screenshot shows two advisory-digest findings that never go away:

- **guide**: `Repository worktree not provisioned for guide agent despite include_repos=true configuration` (`/data/agents/guide (empty directory)`)
- **quality**: `Quality agent lacks read access to repository for coverage analysis` (`devx-prod/epx-vscode-ext-poc`)

These are the **#2575 repo-access finding family**. They were *true* when filed: the reporter's build was `9f314392` — exactly **one commit before #4291** gave advisory-tier agents a repo read path (Contents:read + credential-helper fetch). `include_repos: true` only controls whether the repos section is appended to kick messages (`ShouldIncludeRepos`, pkg/config/config.go); the hive never pre-provisions a worktree at `/data/agents/<agent>` — advisory agents clone the repo themselves (guide-advisory.md, workflow step 2), which works since #4291.

#4306 added a self-healer (`CloseHealedRepoAccessFindings`) that retires exactly this family once an advisor-scoped Contents read is verified — **but both #4464 phrasings escape every pattern in `repoAccessFindingPatterns`** (verified with a repro test: both return `false` from `IsRepoAccessFinding`). So the beads survive in the digest forever, even on current v4 where the read path is healthy. That persistent digest entry is the "error about repository worktree" the reporter sees.

## Fix

Two new directional patterns in `pkg/advisory/heal.go`:
- `repository worktree/workspace … not/never provisioned` — trailing-negation form of the existing provisioning pattern, which also gains the `worktree` spelling.
- `no/missing/lacks/without … read access to … repository` — **READ is mandatory**, so a `lacks write access` (app-auth family) finding is never closed by a Contents-read verification.

## Tests

- Both exact #4464 titles pinned in `TestIsRepoAccessFinding`, plus new drift cases.
- New negatives guarding directionality: `lacks write access to repository`, `worktree contains uncommitted changes`.
- End-to-end through `TestCloseHealedRepoAccessFindings`, including the `/data/agents/guide (empty directory)` ref parsing as no-repo → primary-repo verification.
- `go test ./pkg/advisory/... -cover` → **92.6%**, all green.

Fixes #4464