### PR TITLE
✨ add fleet advisory issue staleness

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3369,9 +3369,16 @@ func main() {
 			// equally means "window just rolled" and "nothing consumed"), so
 			// the three travel together or not at all.
 			var budgetSpend *int64
+			var budgetLimit *int64
+			var budgetIgnored *bool
 			var budgetWindowStartsAt, budgetWindowEndsAt string
+			budget := gov.GetBudget()
+			limit := budget.WeeklyLimit
+			ignored := budget.IgnoreAll
+			budgetLimit = &limit
+			budgetIgnored = &ignored
 			if start, end, ok := gov.BudgetWindow(); ok {
-				spend := gov.GetBudget().CurrentSpend
+				spend := budget.CurrentSpend
 				budgetSpend = &spend
 				budgetWindowStartsAt = start.UTC().Format(time.RFC3339)
 				budgetWindowEndsAt = end.UTC().Format(time.RFC3339)
@@ -3429,9 +3436,11 @@ func main() {
 			return &hub.HeartbeatPayload{
 				AgentsWithModel:      &agentsWithModel,
 				BudgetCurrentSpend:   budgetSpend,
+				BudgetLimit:          budgetLimit,
 				BudgetWindowStartsAt: budgetWindowStartsAt,
 				BudgetWindowEndsAt:   budgetWindowEndsAt,
 				BudgetExhausted:      budgetExhausted,
+				BudgetIgnored:        budgetIgnored,
 				HoldTotal:            holdTotal,
 				AwaitingReview:       awaitingReview,
 				SLAViolations:        slaViolations,

--- a/src/pkg/hub/advisory_issue_activity.go
+++ b/src/pkg/hub/advisory_issue_activity.go
@@ -1,0 +1,115 @@
+package hub
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	advisoryIssueBucketFresh   = "fresh"
+	advisoryIssueBucketAging   = "aging"
+	advisoryIssueBucketStale   = "stale"
+	advisoryIssueBucketUnknown = "unknown"
+
+	advisoryIssueAgingAfterEnv = "HIVE_ADVISORY_ISSUE_AGING_AFTER"
+	advisoryIssueStaleAfterEnv = "HIVE_ADVISORY_ISSUE_STALE_AFTER"
+
+	// advisoryIssueAgingAfter is the first threshold where advisory/issue output
+	// becomes suspect. A day leaves room for low-volume repos and quiet work
+	// windows, while still making a silent Security Agent visible before trust is
+	// lost.
+	advisoryIssueAgingAfter = 24 * time.Hour
+	// advisoryIssueStaleAfter is the operator-action threshold: after three days
+	// without a digest post or actionable-issue count movement, the output stream
+	// is stale enough to imply stuck/paused/broken agents rather than normal quiet.
+	advisoryIssueStaleAfter = 72 * time.Hour
+)
+
+type AdvisoryIssueActivity struct {
+	LastActivityAt string `json:"lastActivityAt,omitempty"`
+	Bucket         string `json:"bucket"`
+}
+
+func advisoryIssueActivityFor(e RegistryEntry, now time.Time) AdvisoryIssueActivity {
+	last, ok := advisoryIssueLastActivity(e)
+	if e.AdvisoryError != "" && !appAwaitingDelivery(e) {
+		out := AdvisoryIssueActivity{Bucket: advisoryIssueBucketStale}
+		if ok {
+			out.LastActivityAt = last.UTC().Format(time.RFC3339)
+		}
+		return out
+	}
+	if !ok {
+		return AdvisoryIssueActivity{Bucket: advisoryIssueBucketUnknown}
+	}
+	agingAfter, staleAfter := advisoryIssueThresholds()
+	bucket := advisoryIssueBucketFresh
+	age := now.Sub(last)
+	switch {
+	case age > staleAfter:
+		bucket = advisoryIssueBucketStale
+	case age > agingAfter:
+		bucket = advisoryIssueBucketAging
+	}
+	return AdvisoryIssueActivity{
+		LastActivityAt: last.UTC().Format(time.RFC3339),
+		Bucket:         bucket,
+	}
+}
+
+func advisoryIssueThresholds() (agingAfter, staleAfter time.Duration) {
+	agingAfter = durationEnvOrDefault(advisoryIssueAgingAfterEnv, advisoryIssueAgingAfter)
+	staleAfter = durationEnvOrDefault(advisoryIssueStaleAfterEnv, advisoryIssueStaleAfter)
+	if staleAfter <= agingAfter {
+		return advisoryIssueAgingAfter, advisoryIssueStaleAfter
+	}
+	return agingAfter, staleAfter
+}
+
+func durationEnvOrDefault(name string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
+}
+
+func advisoryIssueLastActivity(e RegistryEntry) (time.Time, bool) {
+	var last time.Time
+	if t, err := time.Parse(time.RFC3339, e.AdvisoryLastPostedAt); err == nil {
+		last = t
+	}
+	if t, ok := lastIssueHistoryActivity(e.IssueHistory); ok && t.After(last) {
+		last = t
+	}
+	if last.IsZero() {
+		return time.Time{}, false
+	}
+	return last, true
+}
+
+func lastIssueHistoryActivity(points []SparkPoint) (time.Time, bool) {
+	if len(points) == 0 {
+		return time.Time{}, false
+	}
+	var last int64
+	prev := points[0].V
+	if prev > 0 {
+		last = points[0].T
+	}
+	for _, p := range points[1:] {
+		if p.V != prev {
+			last = p.T
+			prev = p.V
+		}
+	}
+	if last <= 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(last, 0).UTC(), true
+}

--- a/src/pkg/hub/advisory_issue_activity_test.go
+++ b/src/pkg/hub/advisory_issue_activity_test.go
@@ -104,6 +104,8 @@ func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
 		Org:                  "acme",
 		Online:               true,
 		AdvisoryLastPostedAt: now.Add(-advisoryIssueStaleAfter - time.Hour).Format(time.RFC3339),
+		BudgetCurrentSpend:   int64ptr(87),
+		BudgetLimit:          int64ptr(100),
 	}}
 
 	rec := httptest.NewRecorder()
@@ -116,6 +118,7 @@ func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
 		Hives []struct {
 			ID                    string                `json:"id"`
 			AdvisoryIssueActivity AdvisoryIssueActivity `json:"advisoryIssueActivity"`
+			BudgetHealth          BudgetHealth          `json:"budgetHealth"`
 		} `json:"hives"`
 		Summary map[string]int `json:"hives_summary"`
 	}
@@ -123,8 +126,10 @@ func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
 		t.Fatalf("unmarshal my-hives: %v", err)
 	}
 	byID := map[string]AdvisoryIssueActivity{}
+	budgetByID := map[string]BudgetHealth{}
 	for _, h := range resp.Hives {
 		byID[h.ID] = h.AdvisoryIssueActivity
+		budgetByID[h.ID] = h.BudgetHealth
 	}
 	if byID["h1"].Bucket != advisoryIssueBucketStale || byID["h1"].LastActivityAt == "" {
 		t.Fatalf("h1 activity = %+v, want stale with timestamp", byID["h1"])
@@ -134,5 +139,14 @@ func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
 	}
 	if resp.Summary["advisory_issue_stale"] != 1 || resp.Summary["advisory_issue_unknown"] != 1 {
 		t.Fatalf("summary = %#v, want stale=1 unknown=1", resp.Summary)
+	}
+	if budgetByID["h1"].Bucket != budgetBucketWarning || budgetByID["h1"].UsedTokens != 87 || budgetByID["h1"].LimitTokens != 100 {
+		t.Fatalf("h1 budget = %+v, want warning with numbers", budgetByID["h1"])
+	}
+	if budgetByID["hosted-empty"].Bucket != budgetBucketUnknown {
+		t.Fatalf("placeholder budget = %+v, want unknown/n/a", budgetByID["hosted-empty"])
+	}
+	if resp.Summary["budget_warning"] != 1 || resp.Summary["budget_unknown"] != 1 {
+		t.Fatalf("summary = %#v, want budget_warning=1 budget_unknown=1", resp.Summary)
 	}
 }

--- a/src/pkg/hub/advisory_issue_activity_test.go
+++ b/src/pkg/hub/advisory_issue_activity_test.go
@@ -1,0 +1,138 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAdvisoryIssueActivityBuckets(t *testing.T) {
+	t.Setenv(advisoryIssueAgingAfterEnv, "")
+	t.Setenv(advisoryIssueStaleAfterEnv, "")
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	stamp := func(age time.Duration) string { return now.Add(-age).Format(time.RFC3339) }
+	cases := []struct {
+		name string
+		age  time.Duration
+		want string
+	}{
+		{"inside fresh", advisoryIssueAgingAfter - time.Second, advisoryIssueBucketFresh},
+		{"at aging boundary still fresh", advisoryIssueAgingAfter, advisoryIssueBucketFresh},
+		{"past aging", advisoryIssueAgingAfter + time.Second, advisoryIssueBucketAging},
+		{"at stale boundary still aging", advisoryIssueStaleAfter, advisoryIssueBucketAging},
+		{"past stale", advisoryIssueStaleAfter + time.Second, advisoryIssueBucketStale},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := advisoryIssueActivityFor(RegistryEntry{AdvisoryLastPostedAt: stamp(tc.age)}, now)
+			if got.Bucket != tc.want {
+				t.Fatalf("bucket = %q, want %q", got.Bucket, tc.want)
+			}
+			if got.LastActivityAt == "" {
+				t.Fatal("expected lastActivityAt")
+			}
+		})
+	}
+}
+
+func TestAdvisoryIssueActivityUsesIssueHistoryChanges(t *testing.T) {
+	t.Setenv(advisoryIssueAgingAfterEnv, "")
+	t.Setenv(advisoryIssueStaleAfterEnv, "")
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	changed := now.Add(-2 * time.Hour)
+	olderAdvisory := now.Add(-5 * 24 * time.Hour)
+	got := advisoryIssueActivityFor(RegistryEntry{
+		AdvisoryLastPostedAt: olderAdvisory.Format(time.RFC3339),
+		IssueHistory: []SparkPoint{
+			{T: now.Add(-8 * time.Hour).Unix(), V: 1},
+			{T: changed.Unix(), V: 2},
+			{T: now.Add(-time.Hour).Unix(), V: 2},
+		},
+	}, now)
+	if got.Bucket != advisoryIssueBucketFresh {
+		t.Fatalf("bucket = %q, want fresh", got.Bucket)
+	}
+	if got.LastActivityAt != changed.Format(time.RFC3339) {
+		t.Fatalf("lastActivityAt = %q, want %q", got.LastActivityAt, changed.Format(time.RFC3339))
+	}
+}
+
+func TestAdvisoryIssueActivityUnknownWithNoSignal(t *testing.T) {
+	t.Setenv(advisoryIssueAgingAfterEnv, "")
+	t.Setenv(advisoryIssueStaleAfterEnv, "")
+	got := advisoryIssueActivityFor(RegistryEntry{}, time.Now())
+	if got.Bucket != advisoryIssueBucketUnknown || got.LastActivityAt != "" {
+		t.Fatalf("activity = %+v, want unknown with no timestamp", got)
+	}
+}
+
+func TestAdvisoryIssueActivityErrorIsStale(t *testing.T) {
+	got := advisoryIssueActivityFor(RegistryEntry{AdvisoryError: "post failed"}, time.Now())
+	if got.Bucket != advisoryIssueBucketStale {
+		t.Fatalf("bucket = %q, want stale for advisory post error", got.Bucket)
+	}
+}
+
+func TestAdvisoryIssueActivityThresholdEnvOverride(t *testing.T) {
+	t.Setenv(advisoryIssueAgingAfterEnv, "2h")
+	t.Setenv(advisoryIssueStaleAfterEnv, "4h")
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	got := advisoryIssueActivityFor(RegistryEntry{AdvisoryLastPostedAt: now.Add(-3 * time.Hour).Format(time.RFC3339)}, now)
+	if got.Bucket != advisoryIssueBucketAging {
+		t.Fatalf("bucket = %q, want aging with env thresholds", got.Bucket)
+	}
+}
+
+func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
+	t.Setenv(advisoryIssueAgingAfterEnv, "")
+	t.Setenv(advisoryIssueStaleAfterEnv, "")
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", Hives: map[string]string{"h1": "owner", "hosted-empty": "owner"}})
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", Org: "acme", Status: "running"})
+	saveSaaSHive(&SaaSHive{ID: "hosted-empty", Owner: "alice", Org: "available-slot", Status: statusAvailable})
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	s.registry.Hives = []RegistryEntry{{
+		ID:                   "h1",
+		Owner:                "alice",
+		Org:                  "acme",
+		Online:               true,
+		AdvisoryLastPostedAt: now.Add(-advisoryIssueStaleAfter - time.Hour).Format(time.RFC3339),
+	}}
+
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodGet, "/api/saas/my-hives", "", "alice")
+	s.handleMyHives(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("my-hives status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Hives []struct {
+			ID                    string                `json:"id"`
+			AdvisoryIssueActivity AdvisoryIssueActivity `json:"advisoryIssueActivity"`
+		} `json:"hives"`
+		Summary map[string]int `json:"hives_summary"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal my-hives: %v", err)
+	}
+	byID := map[string]AdvisoryIssueActivity{}
+	for _, h := range resp.Hives {
+		byID[h.ID] = h.AdvisoryIssueActivity
+	}
+	if byID["h1"].Bucket != advisoryIssueBucketStale || byID["h1"].LastActivityAt == "" {
+		t.Fatalf("h1 activity = %+v, want stale with timestamp", byID["h1"])
+	}
+	if byID["hosted-empty"].Bucket != advisoryIssueBucketUnknown || byID["hosted-empty"].LastActivityAt != "" {
+		t.Fatalf("placeholder activity = %+v, want unknown/n/a", byID["hosted-empty"])
+	}
+	if resp.Summary["advisory_issue_stale"] != 1 || resp.Summary["advisory_issue_unknown"] != 1 {
+		t.Fatalf("summary = %#v, want stale=1 unknown=1", resp.Summary)
+	}
+}

--- a/src/pkg/hub/budget_health.go
+++ b/src/pkg/hub/budget_health.go
@@ -1,0 +1,74 @@
+package hub
+
+import "time"
+
+const (
+	budgetBucketOK        = "ok"
+	budgetBucketWarning   = "warning"
+	budgetBucketCritical  = "critical"
+	budgetBucketExhausted = "exhausted"
+	budgetBucketUnknown   = "unknown"
+
+	budgetWarningPercent   int64 = 70
+	budgetCriticalPercent  int64 = 90
+	budgetExhaustedPercent int64 = 100
+	percentDenominator     int64 = 100
+)
+
+type BudgetHealth struct {
+	UsedTokens     int64   `json:"usedTokens,omitempty"`
+	LimitTokens    int64   `json:"limitTokens,omitempty"`
+	PercentUsed    float64 `json:"percentUsed,omitempty"`
+	Bucket         string  `json:"bucket"`
+	Exhausted      bool    `json:"exhausted,omitempty"`
+	Ignored        bool    `json:"ignored,omitempty"`
+	WindowStartsAt string  `json:"windowStartsAt,omitempty"`
+	WindowEndsAt   string  `json:"windowEndsAt,omitempty"`
+}
+
+func budgetHealthFor(e RegistryEntry) BudgetHealth {
+	if e.BudgetIgnored != nil && *e.BudgetIgnored {
+		return BudgetHealth{Bucket: budgetBucketUnknown, Ignored: true}
+	}
+	if e.BudgetCurrentSpend == nil || e.BudgetLimit == nil || *e.BudgetLimit <= 0 {
+		return BudgetHealth{Bucket: budgetBucketUnknown}
+	}
+	used := *e.BudgetCurrentSpend
+	if used < 0 {
+		used = 0
+	}
+	limit := *e.BudgetLimit
+	out := BudgetHealth{
+		UsedTokens:     used,
+		LimitTokens:    limit,
+		PercentUsed:    float64(used) * float64(percentDenominator) / float64(limit),
+		Bucket:         budgetBucketOK,
+		WindowStartsAt: formatOptionalTime(e.BudgetWindowStartsAt),
+		WindowEndsAt:   formatOptionalTime(e.BudgetWindowEndsAt),
+	}
+	if e.BudgetExhausted != nil && *e.BudgetExhausted {
+		out.Bucket = budgetBucketExhausted
+		out.Exhausted = true
+		return out
+	}
+	if used*percentDenominator >= limit*budgetExhaustedPercent {
+		out.Bucket = budgetBucketExhausted
+		out.Exhausted = true
+		return out
+	}
+	if used*percentDenominator > limit*budgetCriticalPercent {
+		out.Bucket = budgetBucketCritical
+		return out
+	}
+	if used*percentDenominator >= limit*budgetWarningPercent {
+		out.Bucket = budgetBucketWarning
+	}
+	return out
+}
+
+func formatOptionalTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/src/pkg/hub/budget_health_test.go
+++ b/src/pkg/hub/budget_health_test.go
@@ -1,0 +1,80 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+func int64ptr(v int64) *int64 { return &v }
+func boolptr(v bool) *bool    { return &v }
+
+func TestBudgetHealthBuckets(t *testing.T) {
+	cases := []struct {
+		name      string
+		used      int64
+		limit     int64
+		exhausted bool
+		want      string
+	}{
+		{"under warning is ok", budgetWarningPercent - 1, percentDenominator, false, budgetBucketOK},
+		{"at warning boundary warns", budgetWarningPercent, percentDenominator, false, budgetBucketWarning},
+		{"at critical boundary still warning", budgetCriticalPercent, percentDenominator, false, budgetBucketWarning},
+		{"past critical is critical", budgetCriticalPercent + 1, percentDenominator, false, budgetBucketCritical},
+		{"at exhausted boundary exhausted", budgetExhaustedPercent, percentDenominator, false, budgetBucketExhausted},
+		{"governor exhausted flag wins", 1, percentDenominator, true, budgetBucketExhausted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := RegistryEntry{BudgetCurrentSpend: int64ptr(tc.used), BudgetLimit: int64ptr(tc.limit)}
+			if tc.exhausted {
+				e.BudgetExhausted = boolptr(true)
+			}
+			got := budgetHealthFor(e)
+			if got.Bucket != tc.want {
+				t.Fatalf("bucket = %q, want %q", got.Bucket, tc.want)
+			}
+		})
+	}
+}
+
+func TestBudgetHealthUnknownWithoutConfiguredBudget(t *testing.T) {
+	cases := []RegistryEntry{
+		{},
+		{BudgetCurrentSpend: int64ptr(10)},
+		{BudgetCurrentSpend: int64ptr(10), BudgetLimit: int64ptr(0)},
+	}
+	for _, e := range cases {
+		got := budgetHealthFor(e)
+		if got.Bucket != budgetBucketUnknown {
+			t.Fatalf("budgetHealthFor(%+v) bucket = %q, want unknown", e, got.Bucket)
+		}
+	}
+}
+
+func TestBudgetHealthIncludesNumbersAndWindow(t *testing.T) {
+	start := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	got := budgetHealthFor(RegistryEntry{
+		BudgetCurrentSpend:   int64ptr(25),
+		BudgetLimit:          int64ptr(100),
+		BudgetWindowStartsAt: start,
+		BudgetWindowEndsAt:   end,
+	})
+	if got.UsedTokens != 25 || got.LimitTokens != 100 || got.PercentUsed != 25 {
+		t.Fatalf("numbers = used %d limit %d pct %f, want 25/100/25", got.UsedTokens, got.LimitTokens, got.PercentUsed)
+	}
+	if got.WindowStartsAt != start.Format(time.RFC3339) || got.WindowEndsAt != end.Format(time.RFC3339) {
+		t.Fatalf("window = %q..%q, want %q..%q", got.WindowStartsAt, got.WindowEndsAt, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	}
+}
+
+func TestBudgetHealthIgnoredIsUnknown(t *testing.T) {
+	got := budgetHealthFor(RegistryEntry{
+		BudgetCurrentSpend: int64ptr(100),
+		BudgetLimit:        int64ptr(100),
+		BudgetIgnored:      boolptr(true),
+	})
+	if got.Bucket != budgetBucketUnknown || !got.Ignored {
+		t.Fatalf("ignored budget health = %+v, want unknown ignored", got)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -715,6 +715,7 @@ type HeartbeatPayload struct {
 	// anything fixed — so consumers must normalise (e.g. per day) before
 	// comparing against the 90-day PR counters above.
 	BudgetCurrentSpend   *int64 `json:"budget_current_spend,omitempty"`
+	BudgetLimit          *int64 `json:"budget_limit,omitempty"`
 	BudgetWindowStartsAt string `json:"budget_window_starts_at,omitempty"`
 	BudgetWindowEndsAt   string `json:"budget_window_ends_at,omitempty"`
 	// BudgetExhausted reports that the governor is actively suppressing agent
@@ -722,6 +723,7 @@ type HeartbeatPayload struct {
 	// productivity signal: throughput near zero means something very different
 	// when the hive is being throttled than when it is merely idle.
 	BudgetExhausted *bool `json:"budget_exhausted,omitempty"`
+	BudgetIgnored   *bool `json:"budget_ignored,omitempty"`
 
 	// HoldTotal is issues and PRs parked behind a hold label awaiting human
 	// review, and AwaitingReview is plans blocked on a human decision. Both

--- a/src/pkg/hub/my_hives_query.go
+++ b/src/pkg/hub/my_hives_query.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"fmt"
 	"net/url"
 	"sort"
 	"strconv"
@@ -22,9 +23,9 @@ const maxMyHivesPerPage = 500
 
 type myHivesQuery struct {
 	q       string // case-insensitive substring across id/name/org/project/owner/repo/cluster
-	status  string // "online", "offline", advisory issue bucket, or exact provStatus (available, assigned, provisioning, error, ...)
+	status  string // "online", "offline", advisory/budget bucket, or exact provStatus (available, assigned, provisioning, error, ...)
 	cluster string // ClusterID or ClusterName, case-insensitive
-	sortKey string // id | name | org | owner | cluster | status | last_seen | advisory_activity
+	sortKey string // id | name | org | owner | cluster | status | last_seen | advisory_activity | budget
 	desc    bool
 	page    int // 1-based; 0 = no pagination
 	perPage int
@@ -82,6 +83,10 @@ func entryMatches(e *MyHiveEntry, q myHivesQuery) bool {
 		if e.AdvisoryIssueActivity.Bucket != strings.TrimPrefix(q.status, "advisory-") {
 			return false
 		}
+	case "budget-ok", "budget-warning", "budget-critical", "budget-exhausted", "budget-unknown":
+		if e.BudgetHealth.Bucket != strings.TrimPrefix(q.status, "budget-") {
+			return false
+		}
 	default:
 		if !strings.EqualFold(e.ProvStatus, q.status) {
 			return false
@@ -131,6 +136,8 @@ func applyMyHivesQuery(entries []MyHiveEntry, q myHivesQuery) (view []MyHiveEntr
 				return e.LastHeartbeat
 			case "advisory_activity":
 				return e.AdvisoryIssueActivity.LastActivityAt
+			case "budget":
+				return fmt.Sprintf("%012.6f", e.BudgetHealth.PercentUsed)
 			default:
 				return ""
 			}
@@ -196,6 +203,18 @@ func myHivesSummary(entries []MyHiveEntry) map[string]int {
 			s["advisory_issue_stale"]++
 		default:
 			s["advisory_issue_unknown"]++
+		}
+		switch e.BudgetHealth.Bucket {
+		case budgetBucketOK:
+			s["budget_ok"]++
+		case budgetBucketWarning:
+			s["budget_warning"]++
+		case budgetBucketCritical:
+			s["budget_critical"]++
+		case budgetBucketExhausted:
+			s["budget_exhausted"]++
+		default:
+			s["budget_unknown"]++
 		}
 	}
 	return s

--- a/src/pkg/hub/my_hives_query.go
+++ b/src/pkg/hub/my_hives_query.go
@@ -22,9 +22,9 @@ const maxMyHivesPerPage = 500
 
 type myHivesQuery struct {
 	q       string // case-insensitive substring across id/name/org/project/owner/repo/cluster
-	status  string // "online", "offline", or an exact provStatus (available, assigned, provisioning, error, ...)
+	status  string // "online", "offline", advisory issue bucket, or exact provStatus (available, assigned, provisioning, error, ...)
 	cluster string // ClusterID or ClusterName, case-insensitive
-	sortKey string // id | name | org | owner | cluster | status | last_seen
+	sortKey string // id | name | org | owner | cluster | status | last_seen | advisory_activity
 	desc    bool
 	page    int // 1-based; 0 = no pagination
 	perPage int
@@ -78,6 +78,10 @@ func entryMatches(e *MyHiveEntry, q myHivesQuery) bool {
 		if e.Online {
 			return false
 		}
+	case "advisory-fresh", "advisory-aging", "advisory-stale", "advisory-unknown":
+		if e.AdvisoryIssueActivity.Bucket != strings.TrimPrefix(q.status, "advisory-") {
+			return false
+		}
 	default:
 		if !strings.EqualFold(e.ProvStatus, q.status) {
 			return false
@@ -125,6 +129,8 @@ func applyMyHivesQuery(entries []MyHiveEntry, q myHivesQuery) (view []MyHiveEntr
 			case "last_seen":
 				// RFC3339 sorts lexically; empty (never beat) sorts first asc.
 				return e.LastHeartbeat
+			case "advisory_activity":
+				return e.AdvisoryIssueActivity.LastActivityAt
 			default:
 				return ""
 			}
@@ -180,6 +186,16 @@ func myHivesSummary(entries []MyHiveEntry) map[string]int {
 		}
 		if e.UpgradeFailed {
 			s["upgrade_failed"]++
+		}
+		switch e.AdvisoryIssueActivity.Bucket {
+		case advisoryIssueBucketFresh:
+			s["advisory_issue_fresh"]++
+		case advisoryIssueBucketAging:
+			s["advisory_issue_aging"]++
+		case advisoryIssueBucketStale:
+			s["advisory_issue_stale"]++
+		default:
+			s["advisory_issue_unknown"]++
 		}
 	}
 	return s

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2866,6 +2866,13 @@ type MyHiveEntry struct {
 	// modal; this is only the hover preview.
 	RecentEvents []TimelineEvent `json:"recentEvents,omitempty"`
 
+	// AdvisoryIssueActivity is the fleet row's advisory/issue output freshness:
+	// the newest successful advisory digest post or actionable-issue count
+	// movement already reported to the hub, bucketed on read. Placeholders and
+	// old/non-advisory spokes with no signal still get the field with bucket
+	// "unknown" so every row renders an explicit n/a instead of disappearing.
+	AdvisoryIssueActivity AdvisoryIssueActivity `json:"advisoryIssueActivity"`
+
 	// AdvisoryStale is true when this hive SHOULD be posting advisory digests
 	// but its digest has quietly gone stale — computed on read by advisoryStale()
 	// so the browser never re-derives the threshold or the gating (advisory-mode
@@ -3341,6 +3348,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		st := s.journey.get(result[i].ID)
 		status := JourneyStatusFor(&result[i].RegistryEntry, st, journeyNow)
 		result[i].Journey = &status
+		result[i].AdvisoryIssueActivity = advisoryIssueActivityFor(result[i].RegistryEntry, journeyNow)
 
 		// Advisory-staleness pill, computed on read (same as Journey) so the
 		// gating — advisory-mode participation, app-can-write, past-threshold —

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2873,6 +2873,11 @@ type MyHiveEntry struct {
 	// "unknown" so every row renders an explicit n/a instead of disappearing.
 	AdvisoryIssueActivity AdvisoryIssueActivity `json:"advisoryIssueActivity"`
 
+	// BudgetHealth is this hive's current governor budget-window usage, bucketed
+	// for the fleet row. It includes the underlying spend/limit/window numbers so
+	// the UI can explain the dot without reverse-engineering RegistryEntry.
+	BudgetHealth BudgetHealth `json:"budgetHealth"`
+
 	// AdvisoryStale is true when this hive SHOULD be posting advisory digests
 	// but its digest has quietly gone stale — computed on read by advisoryStale()
 	// so the browser never re-derives the threshold or the gating (advisory-mode
@@ -3349,6 +3354,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		status := JourneyStatusFor(&result[i].RegistryEntry, st, journeyNow)
 		result[i].Journey = &status
 		result[i].AdvisoryIssueActivity = advisoryIssueActivityFor(result[i].RegistryEntry, journeyNow)
+		result[i].BudgetHealth = budgetHealthFor(result[i].RegistryEntry)
 
 		// Advisory-staleness pill, computed on read (same as Journey) so the
 		// gating — advisory-mode participation, app-can-write, past-threshold —

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -319,9 +319,11 @@ type RegistryEntry struct {
 	// governor.budget.period_days (default 7d), so it must be normalised before
 	// being compared with the 90-day PR counters above.
 	BudgetCurrentSpend   *int64    `json:"budgetCurrentSpend,omitempty"`
+	BudgetLimit          *int64    `json:"budgetLimit,omitempty"`
 	BudgetWindowStartsAt time.Time `json:"budgetWindowStartsAt,omitempty"`
 	BudgetWindowEndsAt   time.Time `json:"budgetWindowEndsAt,omitempty"`
 	BudgetExhausted      *bool     `json:"budgetExhausted,omitempty"`
+	BudgetIgnored        *bool     `json:"budgetIgnored,omitempty"`
 	// HoldTotal / AwaitingReview / SLAViolations measure work stalled on a
 	// human or aging past its threshold; TasksCompleted7d is relay throughput
 	// summed on the spoke from its hourly buckets.
@@ -1759,9 +1761,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// being clamped to zero, which would be indistinguishable from a real
 		// measurement and would quietly drag the hive's score.
 		BudgetCurrentSpend:   clampQuadrantSpend(payload.BudgetCurrentSpend),
+		BudgetLimit:          clampQuadrantSpend(payload.BudgetLimit),
 		BudgetWindowStartsAt: parseHeartbeatTime(payload.BudgetWindowStartsAt),
 		BudgetWindowEndsAt:   parseHeartbeatTime(payload.BudgetWindowEndsAt),
 		BudgetExhausted:      payload.BudgetExhausted,
+		BudgetIgnored:        payload.BudgetIgnored,
 		HoldTotal:            clampFleetCount(payload.HoldTotal),
 		AwaitingReview:       clampFleetCount(payload.AwaitingReview),
 		SLAViolations:        clampFleetCount(payload.SLAViolations),
@@ -1963,8 +1967,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				entry.BudgetWindowStartsAt = h.BudgetWindowStartsAt
 				entry.BudgetWindowEndsAt = h.BudgetWindowEndsAt
 			}
+			if entry.BudgetLimit == nil && h.BudgetLimit != nil {
+				entry.BudgetLimit = h.BudgetLimit
+			}
 			if entry.BudgetExhausted == nil && h.BudgetExhausted != nil {
 				entry.BudgetExhausted = h.BudgetExhausted
+			}
+			if entry.BudgetIgnored == nil && h.BudgetIgnored != nil {
+				entry.BudgetIgnored = h.BudgetIgnored
 			}
 			if entry.HoldTotal == nil && h.HoldTotal != nil {
 				entry.HoldTotal = h.HoldTotal

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -79,6 +79,12 @@
   .advisory-activity.aging .light { background: var(--amber); }
   .advisory-activity.stale .light { background: var(--red); box-shadow: 0 0 0 3px rgba(229,72,77,.18); }
   .advisory-activity.unknown .light { background: var(--gray); }
+  .budget-health { display: inline-flex; align-items: center; gap: 5px; margin-top: 3px; }
+  .budget-health .light { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+  .budget-health.ok .light { background: var(--green); }
+  .budget-health.warning .light { background: var(--amber); }
+  .budget-health.critical .light, .budget-health.exhausted .light { background: var(--red); box-shadow: 0 0 0 3px rgba(229,72,77,.18); }
+  .budget-health.unknown .light { background: var(--gray); }
   .status-msg { padding: 40px 0; text-align: center; color: var(--muted); }
   a.reload { color: var(--accent); text-decoration: none; }
   [title] { cursor: help; }
@@ -102,7 +108,7 @@
 <body>
 <header>
   <h1>Fleet health</h1>
-  <span class="sub">a hive is a <b>problem</b> when agents cannot work or advisory/issue output is stale</span>
+  <span class="sub">a hive is a <b>problem</b> when agents cannot work, output is stale, or budget is depleted</span>
   <span id="summary" class="summary"></span>
   <span class="controls">
     <label><input type="checkbox" id="problemsOnly"> problems only</label>
@@ -116,13 +122,24 @@
         <option value="fresh">fresh</option>
       </select>
     </label>
+    <label>budget
+      <select id="budgetFilter">
+        <option value="">all</option>
+        <option value="exhausted">exhausted</option>
+        <option value="critical">critical</option>
+        <option value="warning">warning</option>
+        <option value="unknown">unknown/n/a</option>
+        <option value="ok">ok</option>
+      </select>
+    </label>
   </span>
 </header>
 <div class="wrap">
   <div class="legend">
     <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting)</span>
     <span><b>advisory output:</b> <span class="advisory-activity fresh"><span class="light"></span>fresh</span> · <span class="advisory-activity aging"><span class="light"></span>aging</span> · <span class="advisory-activity stale"><span class="light"></span>stale</span> · <span class="advisory-activity unknown"><span class="light"></span>n/a</span></span>
-    <span><span class="delta problem">PROBLEM</span> agents cannot work or output is stale · <span class="delta quiet">quiet</span> paused / off by schedule</span>
+    <span><b>budget:</b> <span class="budget-health ok"><span class="light"></span>ok</span> · <span class="budget-health warning"><span class="light"></span>warning</span> · <span class="budget-health critical"><span class="light"></span>critical</span> · <span class="budget-health exhausted"><span class="light"></span>exhausted</span> · <span class="budget-health unknown"><span class="light"></span>n/a</span></span>
+    <span><span class="delta problem">PROBLEM</span> agents cannot work, output is stale, or budget is depleted · <span class="delta quiet">quiet</span> paused / off by schedule</span>
     <span><b>capability:</b> <span style="color:var(--green)">green</span> able · <span style="color:var(--amber)">amber</span> partial · <span style="color:var(--red)">red</span> blocked · <span style="color:var(--gray)">gray</span> unknown</span>
   </div>
   <table>
@@ -193,6 +210,18 @@ function advisoryActivityHTML(a) {
   return '<span class="advisory-activity ' + esc(bucket) + '" title="advisory/issue activity ' + esc(rel) + '">' +
     '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
 }
+function budgetHealthHTML(b) {
+  b = b || {};
+  var bucket = b.bucket || "unknown";
+  var pct = Math.round(b.percentUsed || 0);
+  var label = bucket === "unknown" ? (b.ignored ? "budget ignored" : "budget n/a") : "budget " + pct + "%";
+  var title = bucket === "unknown"
+    ? label
+    : "budget " + pct + "% used this window (" + (b.usedTokens || 0) + " / " + (b.limitTokens || 0) + " tokens)";
+  if (b.exhausted) title += " — exhausted; governor may throttle";
+  return '<span class="budget-health ' + esc(bucket) + '" title="' + esc(title) + '">' +
+    '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
+}
 function toggleHTML(a) {
   // A legacy/unknown spoke did not report enabled/paused meaningfully — render
   // "unknown", never "off" (the Bluefin false-off bug).
@@ -254,6 +283,8 @@ function deltaHTML(a) {
 // every agent stuck.
 function hiveHealth(h) {
   if (((h.advisoryIssueActivity || {}).bucket || "") === "stale") return "problem";
+  var budget = ((h.budgetHealth || {}).bucket || "");
+  if (budget === "critical" || budget === "exhausted") return "problem";
   var r = h.fleetRollup;
   if (!r) return h.online ? "unknown" : "offline";
   if ((r.problems || 0) > 0) return "problem";
@@ -269,6 +300,7 @@ var expanded = {};      // hive id -> true when its agent rows are open
 var problemsOnly = false;
 var showHealthy = false; // when false, healthy hives are hidden to cut noise
 var advisoryFilter = "";
+var budgetFilter = "";
 
 function hiveKey(h) { return h.id || h.name; }
 
@@ -294,6 +326,7 @@ function renderHives(hives) {
     if (problemsOnly && health !== "problem") return;
     if (!problemsOnly && !showHealthy && health === "ok") return;
     if (advisoryFilter && ((h.advisoryIssueActivity || {}).bucket || "unknown") !== advisoryFilter) return;
+    if (budgetFilter && ((h.budgetHealth || {}).bucket || "unknown") !== budgetFilter) return;
     shown++;
 
     var isProblem = health === "problem";
@@ -311,7 +344,7 @@ function renderHives(hives) {
       '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
       '<td>' + modeBadge(h.governorMode) + '</td>' +
       '<td>' + rollupHTML(h.fleetRollup) + '</td>' +
-      '<td>' + outputHTML(h) + '</td>';
+      '<td>' + outputHTML(h) + '<br>' + budgetHealthHTML(h.budgetHealth) + '</td>';
     tb.appendChild(tr);
 
     var verdicts = h.agentVerdicts || [];
@@ -374,6 +407,8 @@ function wireControls() {
   if (sh) sh.addEventListener("change", function () { showHealthy = sh.checked; load(); });
   var af = document.getElementById("advisoryFilter");
   if (af) af.addEventListener("change", function () { advisoryFilter = af.value; renderHives(lastHives); });
+  var bf = document.getElementById("budgetFilter");
+  if (bf) bf.addEventListener("change", function () { budgetFilter = bf.value; renderHives(lastHives); });
 }
 
 var lastHives = [];

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -73,6 +73,12 @@
   .delta.problem { background: rgba(229,72,77,.16); color: var(--red); border: 1px solid rgba(229,72,77,.45); }
   .delta.quiet { color: var(--muted); }
   .rel { color: var(--muted); font-size: 11px; }
+  .advisory-activity { display: inline-flex; align-items: center; gap: 5px; margin-top: 3px; }
+  .advisory-activity .light { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+  .advisory-activity.fresh .light { background: var(--green); }
+  .advisory-activity.aging .light { background: var(--amber); }
+  .advisory-activity.stale .light { background: var(--red); box-shadow: 0 0 0 3px rgba(229,72,77,.18); }
+  .advisory-activity.unknown .light { background: var(--gray); }
   .status-msg { padding: 40px 0; text-align: center; color: var(--muted); }
   a.reload { color: var(--accent); text-decoration: none; }
   [title] { cursor: help; }
@@ -96,17 +102,27 @@
 <body>
 <header>
   <h1>Fleet health</h1>
-  <span class="sub">a hive is a <b>problem</b> when the governor expects an agent on but it can't do its work</span>
+  <span class="sub">a hive is a <b>problem</b> when agents cannot work or advisory/issue output is stale</span>
   <span id="summary" class="summary"></span>
   <span class="controls">
     <label><input type="checkbox" id="problemsOnly"> problems only</label>
     <label><input type="checkbox" id="showHealthy"> show healthy</label>
+    <label>advisory output
+      <select id="advisoryFilter">
+        <option value="">all</option>
+        <option value="stale">stale</option>
+        <option value="aging">aging</option>
+        <option value="unknown">unknown/n/a</option>
+        <option value="fresh">fresh</option>
+      </select>
+    </label>
   </span>
 </header>
 <div class="wrap">
   <div class="legend">
     <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting)</span>
-    <span><span class="delta problem">PROBLEM</span> governor expects it on, it can't work · <span class="delta quiet">quiet</span> paused / off by schedule</span>
+    <span><b>advisory output:</b> <span class="advisory-activity fresh"><span class="light"></span>fresh</span> · <span class="advisory-activity aging"><span class="light"></span>aging</span> · <span class="advisory-activity stale"><span class="light"></span>stale</span> · <span class="advisory-activity unknown"><span class="light"></span>n/a</span></span>
+    <span><span class="delta problem">PROBLEM</span> agents cannot work or output is stale · <span class="delta quiet">quiet</span> paused / off by schedule</span>
     <span><b>capability:</b> <span style="color:var(--green)">green</span> able · <span style="color:var(--amber)">amber</span> partial · <span style="color:var(--red)">red</span> blocked · <span style="color:var(--gray)">gray</span> unknown</span>
   </div>
   <table>
@@ -163,9 +179,19 @@ function rollupHTML(r) {
 }
 function outputHTML(h) {
   var m = h.prsMerged90d || 0, rej = h.prsRejected90d || 0, cve = h.cvesClosed || 0;
-  if (!m && !rej && !cve) return '<span class="output">—</span>';
-  return '<span class="output" title="hive-wide authored output, last 90 days">PRs merged ' + m +
-    ' · rejected ' + rej + ' · CVEs ' + cve + '</span>';
+  var out = (!m && !rej && !cve)
+    ? '<span class="output">—</span>'
+    : '<span class="output" title="hive-wide authored output, last 90 days">PRs merged ' + m +
+      ' · rejected ' + rej + ' · CVEs ' + cve + '</span>';
+  return out + '<br>' + advisoryActivityHTML(h.advisoryIssueActivity);
+}
+function advisoryActivityHTML(a) {
+  a = a || {};
+  var bucket = a.bucket || "unknown";
+  var rel = a.lastActivityAt ? relTime(a.lastActivityAt) : "n/a";
+  var label = bucket === "unknown" ? "n/a" : bucket + " · " + rel;
+  return '<span class="advisory-activity ' + esc(bucket) + '" title="advisory/issue activity ' + esc(rel) + '">' +
+    '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
 }
 function toggleHTML(a) {
   // A legacy/unknown spoke did not report enabled/paused meaningfully — render
@@ -227,6 +253,7 @@ function deltaHTML(a) {
 // → unknown; else ok. Online/offline is NOT health — a spoke can be online with
 // every agent stuck.
 function hiveHealth(h) {
+  if (((h.advisoryIssueActivity || {}).bucket || "") === "stale") return "problem";
   var r = h.fleetRollup;
   if (!r) return h.online ? "unknown" : "offline";
   if ((r.problems || 0) > 0) return "problem";
@@ -241,6 +268,7 @@ function hiveHealth(h) {
 var expanded = {};      // hive id -> true when its agent rows are open
 var problemsOnly = false;
 var showHealthy = false; // when false, healthy hives are hidden to cut noise
+var advisoryFilter = "";
 
 function hiveKey(h) { return h.id || h.name; }
 
@@ -265,6 +293,7 @@ function renderHives(hives) {
     // Exception-first filtering.
     if (problemsOnly && health !== "problem") return;
     if (!problemsOnly && !showHealthy && health === "ok") return;
+    if (advisoryFilter && ((h.advisoryIssueActivity || {}).bucket || "unknown") !== advisoryFilter) return;
     shown++;
 
     var isProblem = health === "problem";
@@ -330,7 +359,7 @@ function renderHives(hives) {
   }
   if (!shown) {
     var msg = problemsOnly
-      ? "No problems — every governor-expected agent is delivering."
+      ? "No problems — every governor-expected agent is delivering and advisory output is current."
       : (problemCount === 0 && !showHealthy ? "No problems. Healthy hives hidden — toggle “show healthy”." : "No hives.");
     var trE = document.createElement("tr");
     trE.innerHTML = '<td colspan="6" class="status-msg">' + esc(msg) + '</td>';
@@ -343,6 +372,8 @@ function wireControls() {
   if (po) po.addEventListener("change", function () { problemsOnly = po.checked; load(); });
   var sh = document.getElementById("showHealthy");
   if (sh) sh.addEventListener("change", function () { showHealthy = sh.checked; load(); });
+  var af = document.getElementById("advisoryFilter");
+  if (af) af.addEventListener("change", function () { advisoryFilter = af.value; renderHives(lastHives); });
 }
 
 var lastHives = [];


### PR DESCRIPTION
## Summary
- add per-row advisory/issue activity freshness to `/api/saas/my-hives`
- add per-row governor budget health with spend/limit/window numbers
- bucket indicators for every row, including placeholder rows with unknown/n/a signal
- render advisory-output and budget dots/badges on the fleet page with natural filters

## Data sources
- Advisory/issue activity uses existing hub data: `AdvisoryLastPostedAt`, advisory post errors, and actionable-issue count changes from `IssueHistory`.
- Budget health uses governor budget-window heartbeat data: current spend, limit, window bounds, exhausted flag, and ignore-budget flag.

## Thresholds
- Advisory/issue activity: fresh ≤24h, aging >24h, stale >72h; env-overridable via `HIVE_ADVISORY_ISSUE_AGING_AFTER` / `HIVE_ADVISORY_ISSUE_STALE_AFTER`.
- Budget health: ok <70%, warning 70–90%, critical >90%, exhausted ≥100% or governor exhausted flag; unknown when no budget data/config or budget is ignored.

## Validation
- `go test ./pkg/hub`
- `go build ./...`
- `go vet ./...`
