### PR TITLE
fix(hub): stop fleet-view status dots squishing into ovals

### DIFF
--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -51,8 +51,12 @@
   /* agent sub-rows */
   tr.agent td { background: #101825; border-bottom: 1px solid #1a2537; font-size: 13px; }
   tr.agent .aname { padding-left: 26px; font-weight: 500; }
-  .rs { display: inline-flex; align-items: center; gap: 6px; }
-  .rs .swatch { width: 8px; height: 8px; border-radius: 50%; }
+  /* align-items:flex-start + a small top offset keeps the dot round and at the
+     first line when the label wraps to 2-3 lines in a narrow cell (e.g. "should
+     be working"). flex-shrink:0 stops the flexbox squeezing the fixed-size dot
+     into an oval. */
+  .rs { display: inline-flex; align-items: flex-start; gap: 6px; }
+  .rs .swatch { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 8px; margin-top: 5px; }
   .rs.working .swatch { background: var(--green); }
   .rs.idle-at-prompt .swatch { background: var(--amber); }
   .rs.stuck-at-login .swatch { background: var(--red); }
@@ -61,7 +65,7 @@
   .rs.quiet-by-design .swatch { background: transparent; border: 1px solid var(--green); }
   .rs.unknown .swatch { background: var(--gray); }
   .cap { display: inline-flex; align-items: center; gap: 6px; }
-  .cap .light { width: 9px; height: 9px; border-radius: 50%; }
+  .cap .light { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 9px; }
   .cap.green .light { background: var(--green); }
   .cap.amber .light { background: var(--amber); }
   .cap.red .light { background: var(--red); }


### PR DESCRIPTION
The run-state swatch and capability light in the fleet view render as **ovals** when their cell label wraps (e.g. "should be working" over 3 lines).

**Cause:** both dots are fixed-size children of an `inline-flex` container. Flex items shrink by default, so a narrow wrapping cell squeezed the dot horizontally, and `align-items:center` floated it against the middle of the wrapped text.

**Fix (CSS-only):** `flex:0 0 <size>` so the dots never shrink; `.rs` switched to `align-items:flex-start` with a small `margin-top` so the dot sits round at the first line of a wrapped label. JS unchanged.

node --check clean; DCO-signed.