### PR TITLE
✨ show commits behind stable v4

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -608,10 +608,11 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 	cached := s.cachedLatestHash
 	cachedMsg := s.cachedLatestMessage
 	cacheAge := time.Since(s.cachedLatestAt)
+	stableV4 := s.cachedStableV4Hash
+	stableV4Age := time.Since(s.cachedStableV4At)
 	s.versionMu.RUnlock()
 
-	const versionCacheTTL = 5 * time.Minute
-	if cacheAge > versionCacheTTL || cached == "" {
+	if cacheAge > dashboardVersionTipCacheTTL || cached == "" {
 		if latest, err := s.fetchLatestRemoteHash(); err == nil && latest != "" {
 			msg := s.fetchCommitMessage(latest)
 			s.versionMu.Lock()
@@ -621,6 +622,17 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 			s.versionMu.Unlock()
 			cached = latest
 			cachedMsg = msg
+		}
+	}
+	if upstreamBranch() == dashboardStableReleaseBranch {
+		stableV4 = cached
+	} else if stableV4Age > dashboardVersionTipCacheTTL || stableV4 == "" {
+		if latest, err := s.fetchRemoteHashForBranch(dashboardStableReleaseBranch); err == nil && latest != "" {
+			s.versionMu.Lock()
+			s.cachedStableV4Hash = latest
+			s.cachedStableV4At = time.Now()
+			s.versionMu.Unlock()
+			stableV4 = latest
 		}
 	}
 
@@ -639,11 +651,86 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 			resp["latestMessage"] = cachedMsg
 		}
 	}
+	if stableV4 != "" {
+		stableShort := shortSHADashboard(stableV4)
+		resp["stableV4Hash"] = stableV4
+		resp["stableV4Short"] = stableShort
+		if sameCommitDashboard(versionHash, stableV4) {
+			resp["commitsBehind"] = 0
+		} else if ghcrTagExistsCached(stableShort) {
+			if count, ok := s.commitsBehindStableTip(versionHash, stableV4); ok {
+				resp["commitsBehind"] = count
+			}
+		}
+	}
 
 	jsonResponse(w, resp)
 }
 
+const dashboardVersionTipCacheTTL = 5 * time.Minute
+const dashboardStableReleaseBranch = "v4"
+
+func (s *Server) commitsBehindStableTip(base, head string) (int, bool) {
+	base = shortSHADashboard(base)
+	head = shortSHADashboard(head)
+	if base == "" || head == "" {
+		return 0, false
+	}
+	if sameCommitDashboard(base, head) {
+		return 0, true
+	}
+	key := base + "..." + head
+	s.versionMu.RLock()
+	if s.commitBehindCache != nil {
+		if count, ok := s.commitBehindCache[key]; ok {
+			s.versionMu.RUnlock()
+			return count, true
+		}
+	}
+	s.versionMu.RUnlock()
+	if s.deps == nil || s.deps.GHClient == nil || s.deps.Ctx == nil {
+		return 0, false
+	}
+	count, err := s.deps.GHClient.CompareAheadBy(s.deps.Ctx, "kubestellar", "hive", base, head)
+	if err != nil {
+		s.logger.Warn("failed to compare commits behind stable tip", "base", base, "head", head, "error", err)
+		return 0, false
+	}
+	s.versionMu.Lock()
+	if s.commitBehindCache == nil {
+		s.commitBehindCache = map[string]int{}
+	}
+	s.commitBehindCache[key] = count
+	s.versionMu.Unlock()
+	return count, true
+}
+
+func shortSHADashboard(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > hub.StandardSHALen {
+		return s[:hub.StandardSHALen]
+	}
+	return s
+}
+
+func sameCommitDashboard(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	return strings.EqualFold(a[:n], b[:n])
+}
+
 func (s *Server) fetchLatestRemoteHash() (string, error) {
+	return s.fetchRemoteHashForBranch(upstreamBranch())
+}
+
+func (s *Server) fetchRemoteHashForBranch(branch string) (string, error) {
 	if s.deps == nil || s.deps.GHClient == nil {
 		return "", fmt.Errorf("no github client")
 	}
@@ -651,7 +738,7 @@ func (s *Server) fetchLatestRemoteHash() (string, error) {
 	if ctx == nil {
 		return "", fmt.Errorf("no context")
 	}
-	return s.deps.GHClient.LatestCommitHash(ctx, "kubestellar", "hive", upstreamBranch())
+	return s.deps.GHClient.LatestCommitHash(ctx, "kubestellar", "hive", branch)
 }
 
 // fetchCommitMessage returns the first line of the commit message for a given SHA.

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -202,6 +202,9 @@ type Server struct {
 	cachedLatestHash    string
 	cachedLatestMessage string
 	cachedLatestAt      time.Time
+	cachedStableV4Hash  string
+	cachedStableV4At    time.Time
+	commitBehindCache   map[string]int
 
 	contributeHub *ContributeWSHub
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -14816,6 +14816,9 @@ function burnAreaChart() {
           html += ` <span title="${escapeHtml(pillTitle)}" style="display:inline-block;padding:1px 7px;margin-left:6px;border-radius:999px;font-size:0.62rem;font-weight:600;background:color-mix(in srgb, var(--accent) 16%, transparent);border:1px solid color-mix(in srgb, var(--accent) 40%, transparent);color:var(--accent);vertical-align:middle">${escapeHtml(pillText)}</span>`;
         }
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
+        const commitsBehindText = v.commitsBehind != null && v.commitsBehind > 0
+          ? ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Stable v4 tip: ${escapeHtml(v.stableV4Short || '?')}">${escapeHtml(String(v.commitsBehind))} behind</span>`
+          : (v.commitsBehind == null && v.stableV4Hash && String(v.short || '').toLowerCase() !== String(v.stableV4Short || '').toLowerCase() ? ` <span class="git-behind" title="Could not compare this commit with stable v4 tip ${escapeHtml(v.stableV4Short || '?')}">? behind</span>` : '');
         if (_upgradeInProgress && v.hash !== _upgradeTargetHash) {
           html += ` <span class="git-behind" title="Upgrading to ${escapeHtml(v.latestShort || '?')}">⬆ upgrading</span>`;
         } else if (_upgradeInProgress && v.hash === _upgradeTargetHash) {
@@ -14824,7 +14827,7 @@ function burnAreaChart() {
           showToast('Upgrade complete!', 'success');
           html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';
         } else if (v.behind) {
-          html += ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆</span>`;
+          html += commitsBehindText || ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆</span>`;
           if (v.autoUpgrade) {
             // Hub-managed: the hub rolls the upgrade automatically, so no manual
             // button — a passive state badge, worded to match the hub dashboard's
@@ -14839,6 +14842,7 @@ function burnAreaChart() {
         } else if (v.latestHash) {
           html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';
         }
+        if (!v.behind) html += commitsBehindText;
         el.innerHTML = html;
         if (ocEl) ocEl.innerHTML = html;
       } catch (_) {}

--- a/src/pkg/dashboard/version_behind_test.go
+++ b/src/pkg/dashboard/version_behind_test.go
@@ -1,0 +1,70 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+func TestHandleVersionIncludesCommitsBehindAndCaches(t *testing.T) {
+	origHash, origShort := versionHash, versionShort
+	versionHash, versionShort = "old11112222", "old1111"
+	t.Cleanup(func() { versionHash, versionShort = origHash, origShort })
+	ghcrCacheMu.Lock()
+	ghcrCacheResult["abc1234"] = true
+	ghcrCacheExpiry["abc1234"] = time.Now().Add(time.Hour)
+	ghcrCacheMu.Unlock()
+	t.Cleanup(func() {
+		ghcrCacheMu.Lock()
+		delete(ghcrCacheResult, "abc1234")
+		delete(ghcrCacheExpiry, "abc1234")
+		ghcrCacheMu.Unlock()
+	})
+
+	compareCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/kubestellar/hive/git/ref/heads/v4", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ref":    "refs/heads/v4",
+			"object": map[string]any{"sha": "abc1234567890abcdef1234567890abcdef123456"},
+		})
+	})
+	mux.HandleFunc("/repos/kubestellar/hive/commits/abc1234567890abcdef1234567890abcdef123456", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"commit": map[string]any{"message": "tip\nbody"}})
+	})
+	mux.HandleFunc("/repos/kubestellar/hive/compare/old1111...abc1234", func(w http.ResponseWriter, r *http.Request) {
+		compareCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"ahead_by": 5})
+	})
+	ghSrv := httptest.NewServer(mux)
+	defer ghSrv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewServer(0, logger)
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ghSrv.URL, "myorg", []string{"repo1"}, logger)
+	s.RegisterAPI(deps)
+
+	for i := 0; i < 2; i++ {
+		rec := doGet(s, "/api/version")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if body["commitsBehind"] != float64(5) {
+			t.Fatalf("commitsBehind = %v, want 5", body["commitsBehind"])
+		}
+	}
+	if compareCalls != 1 {
+		t.Fatalf("compare calls = %d, want 1 cached call", compareCalls)
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -1204,6 +1204,20 @@ func (c *Client) LatestCommitHash(ctx context.Context, owner, repo, branch strin
 	return ref.GetObject().GetSHA(), nil
 }
 
+// CompareAheadBy returns how many commits head is ahead of base according to
+// GitHub's compare endpoint. When head is the release tip and base is a running
+// build SHA, this is the "commits behind" count for that build.
+func (c *Client) CompareAheadBy(ctx context.Context, owner, repo, base, head string) (int, error) {
+	if c == nil || c.client == nil {
+		return 0, ErrNoGitHubClient
+	}
+	cmp, _, err := c.client.Repositories.CompareCommits(ctx, owner, repo, base, head, nil)
+	if err != nil {
+		return 0, fmt.Errorf("comparing commits %s/%s %s...%s: %w", owner, repo, base, head, err)
+	}
+	return cmp.GetAheadBy(), nil
+}
+
 // CommitMessage returns the first line of the commit message for the given SHA.
 func (c *Client) CommitMessage(ctx context.Context, owner, repo, sha string) (string, error) {
 	commit, _, err := c.client.Repositories.GetCommit(ctx, owner, repo, sha, nil)

--- a/src/pkg/github/compare_test.go
+++ b/src/pkg/github/compare_test.go
@@ -1,0 +1,28 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCompareAheadBy(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/kubestellar/hive/compare/base111...head999", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ahead_by": 4})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := NewClientForTest(ts.URL, "kubestellar", []string{"hive"}, slog.Default())
+	got, err := c.CompareAheadBy(context.Background(), "kubestellar", "hive", "base111", "head999")
+	if err != nil {
+		t.Fatalf("CompareAheadBy: %v", err)
+	}
+	if got != 4 {
+		t.Fatalf("CompareAheadBy = %d, want 4", got)
+	}
+}

--- a/src/pkg/hub/commit_behind.go
+++ b/src/pkg/hub/commit_behind.go
@@ -1,0 +1,111 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+const (
+	stableReleaseBranch        = "v4"
+	commitBehindCompareTimeout = 10 * time.Second
+	commitBehindCacheMax       = 1024
+)
+
+type commitBehindKey struct {
+	base string
+	head string
+}
+
+type commitBehindValue struct {
+	count int
+	known bool
+}
+
+var (
+	commitBehindMu       sync.Mutex
+	commitBehindCache    = map[commitBehindKey]commitBehindValue{}
+	commitBehindInFlight = map[commitBehindKey]bool{}
+)
+
+var fetchCommitBehindCount = func(base, head string, logger *slog.Logger) (count int, known bool, err error) {
+	client := &http.Client{Timeout: commitBehindCompareTimeout}
+	compareURL := fmt.Sprintf("%s/repos/kubestellar/hive/compare/%s...%s",
+		githubAPIBase, url.PathEscape(base), url.PathEscape(head))
+	req, err := http.NewRequest(http.MethodGet, compareURL, nil)
+	if err != nil {
+		return 0, false, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return 0, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, false, fmt.Errorf("compare %s...%s: HTTP %d", base, head, resp.StatusCode)
+	}
+	var result struct {
+		AheadBy int `json:"ahead_by"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, false, err
+	}
+	return result.AheadBy, true, nil
+}
+
+func commitsBehindStableV4(base string, logger *slog.Logger) (int, bool) {
+	head := getLatestSHAForBranch(stableReleaseBranch)
+	if sameCommit(base, head) {
+		return 0, true
+	}
+	base = shortSHA(base)
+	head = shortSHA(head)
+	if base == "" || head == "" {
+		return 0, false
+	}
+	key := commitBehindKey{base: base, head: head}
+
+	commitBehindMu.Lock()
+	if v, ok := commitBehindCache[key]; ok {
+		commitBehindMu.Unlock()
+		return v.count, v.known
+	}
+	if commitBehindInFlight[key] {
+		commitBehindMu.Unlock()
+		return 0, false
+	}
+	commitBehindInFlight[key] = true
+	fetch := fetchCommitBehindCount
+	commitBehindMu.Unlock()
+
+	go resolveCommitBehind(key, fetch, logger)
+	return 0, false
+}
+
+func resolveCommitBehind(key commitBehindKey, fetch func(base, head string, logger *slog.Logger) (int, bool, error), logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	count, known, err := fetch(key.base, key.head, logger)
+
+	commitBehindMu.Lock()
+	defer commitBehindMu.Unlock()
+	delete(commitBehindInFlight, key)
+	if err != nil {
+		logger.Debug("commit-behind resolve failed (will retry on a later request)",
+			"base", key.base, "head", key.head, "error", err)
+		return
+	}
+	if len(commitBehindCache) >= commitBehindCacheMax {
+		commitBehindCache = map[commitBehindKey]commitBehindValue{}
+	}
+	commitBehindCache[key] = commitBehindValue{count: count, known: known}
+}

--- a/src/pkg/hub/commit_behind_test.go
+++ b/src/pkg/hub/commit_behind_test.go
@@ -1,0 +1,124 @@
+package hub
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func resetCommitBehindState(t *testing.T) {
+	t.Helper()
+	commitBehindMu.Lock()
+	origFetch := fetchCommitBehindCount
+	commitBehindCache = map[commitBehindKey]commitBehindValue{}
+	commitBehindInFlight = map[commitBehindKey]bool{}
+	commitBehindMu.Unlock()
+	latestSHAMu.Lock()
+	oldLatest, hadLatest := latestSHAByBranch[stableReleaseBranch]
+	latestSHAByBranch[stableReleaseBranch] = branchSHAInfo{SHA: "head999"}
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		commitBehindMu.Lock()
+		fetchCommitBehindCount = origFetch
+		commitBehindCache = map[commitBehindKey]commitBehindValue{}
+		commitBehindInFlight = map[commitBehindKey]bool{}
+		commitBehindMu.Unlock()
+		latestSHAMu.Lock()
+		if hadLatest {
+			latestSHAByBranch[stableReleaseBranch] = oldLatest
+		} else {
+			delete(latestSHAByBranch, stableReleaseBranch)
+		}
+		latestSHAMu.Unlock()
+	})
+}
+
+func TestResolveCommitBehindCachesKnownAndUnknown(t *testing.T) {
+	resetCommitBehindState(t)
+	key := commitBehindKey{base: "base111", head: "head999"}
+	resolveCommitBehind(key, func(base, head string, logger *slog.Logger) (int, bool, error) {
+		return 12, true, nil
+	}, nil)
+	if got, known := commitsBehindStableV4("base111", nil); !known || got != 12 {
+		t.Fatalf("known cached count = %d,%v; want 12,true", got, known)
+	}
+
+	unknownKey := commitBehindKey{base: "fork123", head: "head999"}
+	resolveCommitBehind(unknownKey, func(base, head string, logger *slog.Logger) (int, bool, error) {
+		return 0, false, nil
+	}, nil)
+	if _, known := commitsBehindStableV4("fork123", nil); known {
+		t.Fatal("unknown compare result must stay unknown")
+	}
+}
+
+func TestResolveCommitBehindErrorNotCached(t *testing.T) {
+	resetCommitBehindState(t)
+	key := commitBehindKey{base: "base111", head: "head999"}
+	resolveCommitBehind(key, func(base, head string, logger *slog.Logger) (int, bool, error) {
+		return 0, false, errors.New("rate limited")
+	}, nil)
+	commitBehindMu.Lock()
+	_, cached := commitBehindCache[key]
+	inFlight := commitBehindInFlight[key]
+	commitBehindMu.Unlock()
+	if cached {
+		t.Fatal("transient compare errors must not poison the cache")
+	}
+	if inFlight {
+		t.Fatal("failed compare must clear in-flight")
+	}
+}
+
+func TestFetchCommitBehindCountHTTP(t *testing.T) {
+	oldBase := githubAPIBase
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/kubestellar/hive/compare/base111...head999" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"ahead_by":7}`))
+	}))
+	defer ts.Close()
+	githubAPIBase = ts.URL
+	t.Cleanup(func() { githubAPIBase = oldBase })
+
+	got, known, err := fetchCommitBehindCount("base111", "head999", nil)
+	if err != nil || !known || got != 7 {
+		t.Fatalf("fetch count = %d,%v,%v; want 7,true,nil", got, known, err)
+	}
+}
+
+func TestHandleMyHivesIncludesCommitsBehind(t *testing.T) {
+	resetCommitBehindState(t)
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", Hives: map[string]string{"h1": "owner"}})
+	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", Org: "acme", Status: "running"})
+	commitBehindMu.Lock()
+	commitBehindCache[commitBehindKey{base: "base111", head: "head999"}] = commitBehindValue{count: 3, known: true}
+	commitBehindMu.Unlock()
+
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+	s.registry.Hives = []RegistryEntry{{ID: "h1", Owner: "alice", Org: "acme", GitHash: "base111", Online: true}}
+
+	rec := httptest.NewRecorder()
+	req := reqWithUser(http.MethodGet, "/api/saas/my-hives", "", "alice")
+	s.handleMyHives(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("my-hives status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Hives []struct {
+			CommitsBehindStableV4 *int `json:"commitsBehindStableV4"`
+		} `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal my-hives: %v", err)
+	}
+	if len(resp.Hives) != 1 || resp.Hives[0].CommitsBehindStableV4 == nil || *resp.Hives[0].CommitsBehindStableV4 != 3 {
+		t.Fatalf("commitsBehindStableV4 response = %+v, want 3", resp.Hives)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2882,6 +2882,7 @@ type MyHiveEntry struct {
 	// what both the alert evaluator (alertHiveFromEntry) and the JSON payload
 	// read. The spoke owns the consecutive-failure threshold and the self-heal,
 	// so there is nothing to compute on read the way AdvisoryStale is computed.
+	CommitsBehindStableV4 *int `json:"commitsBehindStableV4,omitempty"`
 
 	// InactiveAgents is how many of this hive's agents are RUNNING but not
 	// doing any work — session gone, sitting on a login prompt, or producing
@@ -3338,6 +3339,10 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	// stalled where. Derived on read; never persisted on the registry entry.
 	journeyNow := time.Now()
 	for i := range result {
+		if count, known := commitsBehindStableV4(result[i].GitHash, s.logger); known {
+			result[i].CommitsBehindStableV4 = &count
+		}
+
 		st := s.journey.get(result[i].ID)
 		status := JourneyStatusFor(&result[i].RegistryEntry, st, journeyNow)
 		result[i].Journey = &status
@@ -3434,6 +3439,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		"saas_used":                saasCount,
 		"is_admin":                 isAdmin,
 		"latest_sha":               getLatestSHA(),
+		"stable_v4_sha":            getLatestSHAForBranch(stableReleaseBranch),
 		"latest_shas":              getDisplaySHAs(),
 		"latest_sha_messages":      getDisplaySHAMessages(),
 		"latest_sha_image_status":  getImageStatuses(),
@@ -11940,6 +11946,7 @@ const dashboardHTML = `<!DOCTYPE html>
        leak — every name it can show was already in h.access. */
     var _currentUser = '';
     var _latestSHA = '';
+    var _stableV4SHA = '';
     var _latestSHAs = {};
     var _latestSHAMessages = {};
     var _latestImageStatus = {};
@@ -14742,6 +14749,7 @@ const dashboardHTML = `<!DOCTYPE html>
         _fleetAlerts = data.alerts || EMPTY_ALERT_SUMMARY;
         _hivesSummary = data.hives_summary || null;
         _latestSHA = data.latest_sha || _latestSHA;
+        _stableV4SHA = data.stable_v4_sha || _stableV4SHA;
         if (data.latest_shas) _latestSHAs = data.latest_shas;
         if (data.tracked_branches) _trackedBranchesList = data.tracked_branches;
         if (data.release_channels) _releaseChannels = data.release_channels;
@@ -15921,7 +15929,14 @@ const dashboardHTML = `<!DOCTYPE html>
           /* The drift dot rides on the SHA line, right of the current/behind
              glyph: "what commit is this hive on, and does it match the fleet" is
              one thought. It sets no extra line, so a drifting hive is no taller. */
-          var shaLine = '<span style="font-family:monospace;color:var(--muted)" title="' + escAttr(shaMsg) + '">' + esc(sha) + '</span>' + status + (driftDot ? ' ' + driftDot : '');
+          var behindKnown = h.commitsBehindStableV4 !== undefined && h.commitsBehindStableV4 !== null;
+          var behindBadge = '';
+          if (behindKnown && h.commitsBehindStableV4 > 0) {
+            behindBadge = ' <span style="display:inline-block;padding:1px 6px;border-radius:999px;font-size:0.6rem;background:rgba(210,153,34,0.14);color:var(--yellow);border:1px solid rgba(210,153,34,0.35);white-space:nowrap" title="' + escAttr(h.commitsBehindStableV4 + ' commits behind stable v4 tip ' + (_stableV4SHA || '')) + '">' + esc(h.commitsBehindStableV4) + ' behind</span>';
+          } else if (!behindKnown && _stableV4SHA && sha && !sameShaJS(sha, _stableV4SHA)) {
+            behindBadge = ' <span style="display:inline-block;padding:1px 6px;border-radius:999px;font-size:0.6rem;background:rgba(210,153,34,0.10);color:var(--yellow);border:1px solid rgba(210,153,34,0.25);white-space:nowrap" title="' + escAttr('Could not compare this commit with stable v4 tip ' + _stableV4SHA) + '">? behind</span>';
+          }
+          var shaLine = '<span style="font-family:monospace;color:var(--muted)" title="' + escAttr(shaMsg) + '">' + esc(sha) + '</span>' + status + behindBadge + (driftDot ? ' ' + driftDot : '');
           versionCell = '<div style="' + STACKED_CELL_STYLE + '">' +
             '<div style="' + STACKED_LINE_STYLE + '">' + branch + '</div>' +
             '<div style="' + STACKED_LINE_STYLE + '">' + shaLine + '</div>' +

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -116,12 +116,13 @@
         <th>Hive</th>
         <th>ACMM</th>
         <th>Mode</th>
+        <th>Version</th>
         <th>Divergence (expects · running · able)</th>
         <th>Output (90d)</th>
       </tr>
     </thead>
     <tbody id="rows">
-      <tr><td colspan="6" class="status-msg" id="statusCell">Loading fleet…</td></tr>
+      <tr><td colspan="7" class="status-msg" id="statusCell">Loading fleet…</td></tr>
     </tbody>
   </table>
 </div>
@@ -166,6 +167,18 @@ function outputHTML(h) {
   if (!m && !rej && !cve) return '<span class="output">—</span>';
   return '<span class="output" title="hive-wide authored output, last 90 days">PRs merged ' + m +
     ' · rejected ' + rej + ' · CVEs ' + cve + '</span>';
+}
+function versionHTML(h) {
+  var sha = h.gitHash || "";
+  if (!sha) return '<span class="output">—</span>';
+  var behind = h.commitsBehindStableV4;
+  var badge = "";
+  if (behind != null && behind > 0) {
+    badge = ' <span class="badge" title="' + esc(behind) + ' commits behind stable v4 tip">' + esc(behind) + ' behind</span>';
+  } else if (behind == null) {
+    badge = ' <span class="badge" title="Could not compare this commit with stable v4 tip">? behind</span>';
+  }
+  return '<span style="font-family:monospace;color:var(--muted)">' + esc(sha) + '</span>' + badge;
 }
 function toggleHTML(a) {
   // A legacy/unknown spoke did not report enabled/paused meaningfully — render
@@ -281,6 +294,7 @@ function renderHives(hives) {
       '<td><span class="hdot ' + health + '" title="' + health + '"></span><span class="name">' + esc(h.name || h.id) + '</span></td>' +
       '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
       '<td>' + modeBadge(h.governorMode) + '</td>' +
+      '<td>' + versionHTML(h) + '</td>' +
       '<td>' + rollupHTML(h.fleetRollup) + '</td>' +
       '<td>' + outputHTML(h) + '</td>';
     tb.appendChild(tr);
@@ -300,6 +314,7 @@ function renderHives(hives) {
         '<td class="aname">' + esc(a.name) + (a.backend ? ' <span class="badge">' + esc(a.backend) + '</span>' : "") + '</td>' +
         '<td>' + toggleHTML(a) + '</td>' +
         '<td>' + runStateHTML(a) + '</td>' +
+        '<td></td>' +
         '<td>' + capHTML(a) + " " + deltaHTML(a) + '</td>' +
         '<td></td>';
       tb.appendChild(sub);
@@ -309,7 +324,7 @@ function renderHives(hives) {
       var empty = document.createElement("tr");
       empty.className = "agent";
       empty.style.display = open ? "" : "none";
-      empty.innerHTML = '<td></td><td class="aname" colspan="5"><span class="output">no per-agent detail (spoke not yet reporting)</span></td>';
+      empty.innerHTML = '<td></td><td class="aname" colspan="6"><span class="output">no per-agent detail (spoke not yet reporting)</span></td>';
       tb.appendChild(empty);
       subRows.push(empty);
     }
@@ -333,7 +348,7 @@ function renderHives(hives) {
       ? "No problems — every governor-expected agent is delivering."
       : (problemCount === 0 && !showHealthy ? "No problems. Healthy hives hidden — toggle “show healthy”." : "No hives.");
     var trE = document.createElement("tr");
-    trE.innerHTML = '<td colspan="6" class="status-msg">' + esc(msg) + '</td>';
+    trE.innerHTML = '<td colspan="7" class="status-msg">' + esc(msg) + '</td>';
     tb.appendChild(trE);
   }
 }


### PR DESCRIPTION
## Summary
- add cached stable-v4 commit-behind comparison for hub fleet rows
- surface commits-behind counts in My Hives version SHA area and spoke navbar
- add compare/count tests for hub, dashboard, and GitHub client

## Validation
- go build ./...
- go vet ./...
- go test ./pkg/hub ./pkg/dashboard
- go test ./pkg/github