### PR TITLE
docs(podman): execute the reboot-persistence rows in both root modes (#4413)

### DIFF
--- a/src/docs/podman-host-execution-gap.md
+++ b/src/docs/podman-host-execution-gap.md
@@ -1,11 +1,15 @@
 # Host-execution capability matrix: what this execution environment can actually do
 
 [#4188](https://github.com/kubestellar/hive/issues/4188) requires "Boot persistence
-... tested for the chosen Podman lifecycle", and
-[podman-quadlet-lifecycle.md](podman-quadlet-lifecycle.md) records both reboot rows
+... tested for the chosen Podman lifecycle", and when this page was written
+[podman-quadlet-lifecycle.md](podman-quadlet-lifecycle.md) recorded both reboot rows
 as **NOT executed**. Before anyone proposes a new execution runtime on the strength
 of "the current execution paths cannot run this work", that claim deserves to be
 measured rather than asserted. This page is the measurement.
+
+Those rows have since been executed, on a host that could be rebooted. That is not
+a contradiction of what follows, it is the remedy this page implies: what stopped
+them running *here* is topology, and the answer to topology is a different host.
 
 **It is one environment, measured once.** Every row below is a command that was run
 here, with its real exit status and its verbatim output. Nothing is inferred from a
@@ -15,8 +19,8 @@ neighbouring row, and nothing is generalised to any other host — see
 The headline result was not the expected one. Most of these capabilities are
 **present**, including the two that matter most for a disposable-guest proposal:
 `/dev/kvm` is usable and passwordless `sudo` works. And the reason
-[#4413](https://github.com/kubestellar/hive/issues/4413) cannot run here turns out
-not to be a permission gap at all.
+[#4413](https://github.com/kubestellar/hive/issues/4413) could not run here turns
+out not to be a permission gap at all.
 
 ## Which execution path this was
 
@@ -139,16 +143,19 @@ polkit authorises this user to reboot, and `systemctl --dry-run reboot` — whic
 prints what it would do — exits 0. **No reboot was performed**; #4413 explicitly
 reserves that.
 
-This corrects the expectation #4441 itself carried. The reason #4413's rows are
-unexecuted is **not** that reboot is forbidden here. It is that this session runs *on
-the host that would be rebooted*, exactly as
-[podman-quadlet-lifecycle.md](podman-quadlet-lifecycle.md) states:
+This corrects the expectation #4441 itself carried. The reason #4413's rows could
+not be executed here is **not** that reboot is forbidden. It is that this session runs
+*on the host that would be rebooted*, exactly as
+[podman-quadlet-lifecycle.md](podman-quadlet-lifecycle.md) put it while those rows
+were still open:
 
 > The host this was measured on could not be rebooted: it was the host running the
 > session doing the measuring, and a reboot would have ended it mid-run.
 
 That is a **topology** problem, not a permission one — and it is the single most
 useful thing this page establishes, because the two have entirely different remedies.
+Taking the topology remedy is how #4413's rows were eventually run: on a host that
+was not the one running the session doing the measuring.
 
 ### User lingering — authorised, currently off
 
@@ -166,8 +173,9 @@ Lingering is **off** right now, and polkit **would permit** this user to turn it
 `loginctl enable-linger` was deliberately **not run**: it reconfigures the host, which
 #4441 places out of scope. So this row establishes authorisation, not a completed
 enable — and per the precedent [#4377](https://github.com/kubestellar/hive/issues/4377)
-set, authorisation is *not* evidence that units would survive a boot. Only #4413 can
-establish that.
+set, authorisation is *not* evidence that units would survive a boot. Only an actual
+reboot can establish that. #4413 has since done so, on another host and with
+`Linger=yes` — the enable this row deliberately did not perform.
 
 ### SELinux — enforcing, and it is the host's policy
 
@@ -292,8 +300,9 @@ capability; it is the ceiling, not a grant.
   relay's own `HIVE_AGENT_SESSION` matching this probe's tmux session.
 - `/dev/kvm` opens read-write, on a host that is itself a KVM guest — so nested
   virtualisation is available here.
-- Reboot is authorised. #4413 is unrunnable here for a **topology** reason (the
-  session lives on the host that would restart), not a permission one.
+- Reboot is authorised. #4413 was unrunnable here for a **topology** reason (the
+  session lives on the host that would restart), not a permission one — and it
+  ran elsewhere on that basis.
 - Lingering is off but authorisable; rootful podman is reachable via passwordless
   `sudo`; SELinux is the host's, enforcing, unconfined; the process holds no
   capabilities but user namespaces work.
@@ -308,8 +317,9 @@ capability; it is the ceiling, not a grant.
   runner, a hosted spoke, or another contributor's machine may differ in every row —
   `/dev/kvm` in particular is commonly absent on hosted runners.
 - **That boot persistence works.** Lingering being *authorisable* is not evidence
-  that units survive a boot. #4377 set that precedent explicitly and #4413 is the
-  task that can settle it; this page does not.
+  that units survive a boot. #4377 set that precedent explicitly and #4413 settled
+  it on a host that could be rebooted; nothing measured here contributed to that
+  result.
 - **That anything should be built.** This is evidence for judging a proposal, not a
   proposal. A disposable-guest design should be argued against these numbers, not
   the other way round.

--- a/src/docs/podman-host-execution-gap.md
+++ b/src/docs/podman-host-execution-gap.md
@@ -322,8 +322,8 @@ rather than performing it.
 ## Related
 
 - [#4188](https://github.com/kubestellar/hive/issues/4188) — the umbrella, and its boot-persistence requirement
-- [#4413](https://github.com/kubestellar/hive/issues/4413) — the reboot rows this page explains but does not execute
-- [podman-quadlet-lifecycle.md](podman-quadlet-lifecycle.md) — where those rows are recorded as NOT executed
+- [#4413](https://github.com/kubestellar/hive/issues/4413) — the reboot rows this page explains but does not execute; now executed in both root modes
+- [podman-quadlet-lifecycle.md](podman-quadlet-lifecycle.md) — where those rows are recorded, measured
 - [podman-selinux-avc-evidence.md](podman-selinux-avc-evidence.md) — container SELinux behaviour, which is *not* what this environment shows
 - [net-admin-requirement.md](net-admin-requirement.md) — why `NET_ADMIN` matters
 - [podman-support-matrix.md](podman-support-matrix.md) — rootful/rootless × enforcing/advisory support levels

--- a/src/docs/podman-quadlet-lifecycle.md
+++ b/src/docs/podman-quadlet-lifecycle.md
@@ -343,9 +343,11 @@ completed. Hence boot 2 finishing in 9.2s with Hive not healthy until 18.5s.
 The consequence is worth stating plainly, because it is the operational cost of
 choosing rootful: a Hive that never becomes healthy holds a rootful boot for its
 `TimeoutStartSec` — 5min for `hive.service`, 2min for `hive-gateway.service`.
-That is not hypothetical; the first rootful start attempt here sat in
-`activating` for the full 120s before timing out. On rootless the same failure
-delays nothing but Hive itself.
+The 120s is not hypothetical — the first rootful start attempt here sat in
+`activating` for exactly that before timing out — though it was reached from an
+interactive `systemctl start`, not from a boot; a deliberately-broken rootful
+boot was not executed. On rootless the same failure delays nothing but Hive
+itself. Filed as #4478, since which mode an operator picks may turn on it.
 
 ### The tag moved mid-experiment, and that is why the rows are pinned
 

--- a/src/docs/podman-quadlet-lifecycle.md
+++ b/src/docs/podman-quadlet-lifecycle.md
@@ -9,8 +9,9 @@ lifecycle those two decisions implied, exercised.
 
 Scope is lifecycle only: stop, start, restart, recreate, and boot persistence,
 in both root modes. Every row is now executed: the two reboot rows this page
-once recorded as **not executed** were closed by #4413 and are below. Update and rollback are their own slice and are now written
-down in [podman-quadlet-update-rollback.md](podman-quadlet-update-rollback.md)
+once recorded as **not executed** were executed by #4413 and are below. Update
+and rollback are their own slice and are now written down in
+[podman-quadlet-update-rollback.md](podman-quadlet-update-rollback.md)
 (#4378) — including what a unit looks like while a bad update is timing out,
 which is a lifecycle state this page does not produce. Auto-update is a later
 slice again, as are backup, restore, and migration.

--- a/src/docs/podman-quadlet-lifecycle.md
+++ b/src/docs/podman-quadlet-lifecycle.md
@@ -1,13 +1,15 @@
 # Quadlet lifecycle: stop, start, restart, recreate, and boot persistence
 
 What the Hive Quadlet units actually do when an operator drives them, measured
-rather than inferred (#4377). [ADR-0017](adr/0017-podman-quadlet-lifecycle.md)
+rather than inferred (#4377, and the reboot rows in #4413).
+[ADR-0017](adr/0017-podman-quadlet-lifecycle.md)
 chose Quadlet for the persistent lifecycle and
 [#4354](podman-standalone-quadlet.md) shipped the units; this page is the
 lifecycle those two decisions implied, exercised.
 
 Scope is lifecycle only: stop, start, restart, recreate, and boot persistence,
-in both root modes. Update and rollback are their own slice and are now written
+in both root modes. Every row is now executed: the two reboot rows this page
+once recorded as **not executed** were closed by #4413 and are below. Update and rollback are their own slice and are now written
 down in [podman-quadlet-update-rollback.md](podman-quadlet-update-rollback.md)
 (#4378) — including what a unit looks like while a bad update is timing out,
 which is a lifecycle state this page does not produce. Auto-update is a later
@@ -189,44 +191,215 @@ One artifact worth recording because it nearly became a wrong result:
 about**, so querying state C that way reported the unit as active and recreated
 its marker file. The table above was re-measured without any `-M` query.
 
-## Reboot persistence: NOT executed here
+## Reboot persistence: executed, both modes
 
-Per #4377's stop condition, recorded as not executed rather than inferred.
+#4413, on a host that could actually be rebooted. Two reboots, one per root
+mode: both `hive-gateway.container` units carry `PublishPort=3001:3001`, and
+rootless can bind 3001 because it is above 1024, so the two stacks contend for
+the port and cannot be staged together.
 
-| | Status |
-| --- | --- |
-| rootless, lingering enabled, actual reboot | **not executed** |
-| rootful via the system manager, actual reboot | **not executed** |
+| | Came back | Healthy after boot | `hive-data` marker |
+| --- | --- | --- | --- |
+| rootless, lingering enabled, actual reboot | **yes** | **11.6s** after the user manager started | **identical** |
+| rootful via the system manager, actual reboot | **yes** | **16.1s** after userspace started | **identical** |
 
-The host this was measured on could not be rebooted: it was the host running
-the session doing the measuring, and a reboot would have ended it mid-run. The
-issue anticipates exactly this and calls for the row to be recorded as not
-executed, which is what this is. `is-enabled` was **not** used as a substitute
-— see above for why it could not have been one.
+Both figures are time-to-*healthy*, not time-to-spawned: `Notify=healthy` holds
+the unit in `activating` until `/api/health` answers, which is the whole reason
+ADR-0017 chose Quadlet.
 
-What *is* established without a reboot is every link in the chain except the
-boot itself: the generator installs the `default.target.wants/` symlink in both
-modes; `default.target` is reached in both managers; lingering starts a
-sessionless user manager and its enabled units in 305ms, and its absence stops
-them. What remains unproven is the composition of those links across an actual
-kernel boot.
+Host: Bluefin (Fedora Silverblue) 44.20260818, kernel 7.1.4, podman 5.8.4,
+cgroup v2, netavark, SELinux enforcing. Both rows ran the same image —
+`d465287054`, `sha256:73d88c4c…` — which took a deliberate step; see
+[the tag moved](#the-tag-moved-mid-experiment-and-that-is-why-the-rows-are-pinned).
 
-To close it, on a host that can be rebooted:
+### What "came back" was taken to mean
+
+Not `is-active`, and not the probe alone. The container serves on two ports and
+the unit's `HealthCmd` probes one of them: 3002, the Go API. The Node auth proxy
+on 3001 — what `nginx.conf`'s `upstream hive_api { server hive:3001; }` points
+at, and therefore what an operator reaches — is not probed at all (#4476). That
+was found the hard way while staging the rootful row: with `HIVE_DASHBOARD_TOKEN`
+unset, the proxy refused to start, and `hive.service` reported `active` with its
+container `healthy` for the entire two minutes in which the deployment was
+unusable.
+
+So a green `boot-check` alone would not have been evidence. Each row was
+recorded only after all four of:
 
 ```sh
-bin/hive-podman-lifecycle-probe.sh check              # confirm the wiring first
-bin/hive-podman-lifecycle-probe.sh check --rootful
-sudo systemctl reboot
-# after boot, in a fresh login:
-bin/hive-podman-lifecycle-probe.sh boot-check
-bin/hive-podman-lifecycle-probe.sh boot-check --rootful
+bin/hive-podman-lifecycle-probe.sh boot-check [--rootful]
+systemctl [--user] is-active hive.service hive-gateway.service \
+                             hive-network.service hive-data-volume.service
+curl -sf http://127.0.0.1:3001/api/health          # through the published gateway
+podman exec hive cat /data/reboot-marker.txt       # armed before the reboot
 ```
 
-`boot-check` reports `is-active` and how long after userspace started the unit
-became active, and — because `Notify=healthy` — that figure is time-to-healthy
-rather than time-to-spawned. It refuses to present a delta larger than ten
-minutes as boot evidence, since a unit started by hand hours after boot also
-has an `ActiveEnterTimestamp` later than boot.
+Both rows passed all four. On both boots the 3001 and 3002 probes agreed — but
+that agreement is a result here, not an assumption.
+
+### rootful
+
+```
+$ bin/hive-podman-lifecycle-probe.sh boot-check --rootful
+
+Boot persistence -- rootful (system manager)
+        uptime      up 1 minute
+        booted at   2026-08-21 14:11:33
+        is-active   active
+        state       active/running/success/0
+  PASS  hive.service is active after boot
+        became active 16s after userspace started
+        (Notify=healthy, so that is time-to-HEALTHY, not time-to-spawned)
+
+Result
+  no findings
+```
+
+Measured against `UserspaceTimestampMonotonic=2.304s`:
+
+| Unit | Active at | After userspace |
+| --- | --- | --- |
+| `hive-network.service` | 6.500s | +4.14s |
+| `hive-data-volume.service` | 6.499s | +4.14s |
+| `hive.service` | 18.503s | **+16.15s** |
+| `hive-gateway.service` | 19.211s | **+16.85s** |
+
+```
+$ curl -sf http://127.0.0.1:3001/api/health
+{"status":"ok"}
+$ podman exec hive cat /data/reboot-marker.txt
+2026-08-21T18:05:09+00:00        # armed before the reboot, byte-identical after
+```
+
+### rootless, with lingering
+
+Lingering was enabled before the reboot and survived it. #4441 measured
+`Linger=no` on this host and deliberately left it; the rootless row is
+meaningless without it, since a rootless result without lingering proves the
+negative case rather than the positive one.
+
+```
+$ loginctl show-user "$USER" -p Linger
+Linger=yes
+
+$ bin/hive-podman-lifecycle-probe.sh boot-check
+
+Boot persistence -- rootless (user manager, uid 1000)
+        uptime      up 1 minute
+        booted at   2026-08-21 14:19:30
+        is-active   active
+        state       active/running/success/0
+  PASS  hive.service is active after boot
+        became active 11s after userspace started
+        (Notify=healthy, so that is time-to-HEALTHY, not time-to-spawned)
+
+Result
+  no findings
+```
+
+| Unit | Active at | After `user@1000` | After userspace |
+| --- | --- | --- | --- |
+| `user@1000.service` | 6.052s | — | +3.75s |
+| `hive-network.service` | 6.453s | +0.40s | +4.15s |
+| `hive-data-volume.service` | 6.459s | +0.41s | +4.15s |
+| `hive.service` | 17.620s | **+11.57s** | +15.32s |
+| `hive-gateway.service` | 18.503s | +12.45s | +16.20s |
+
+The probe's "11s" is measured from the user manager, which is the honest
+reference for a rootless unit: nothing could have started before `user@1000`
+existed, and logind only created it because `Linger=yes`.
+
+```
+$ curl -sf http://127.0.0.1:3001/api/health
+{"status":"ok"}
+$ podman exec hive cat /data/reboot-marker.txt
+2026-08-21T18:18:18+00:00        # armed before the reboot, byte-identical after
+```
+
+The two `hive-data` volumes are in different stores — the rootful one under
+`/var/lib/containers`, the rootless one under `~/.local/share/containers` — so
+the two markers are two independent proofs, not one volume read twice.
+
+### Rootful Hive is inside the system boot transaction; rootless is not
+
+Not something either row set out to measure, but it fell out of the timings and
+it is the sharpest behavioural difference between the modes.
+
+| | userspace | total boot | Hive healthy at |
+| --- | --- | --- | --- |
+| boot 1, **rootful** | 16.854s | 19.211s | gateway 19.2107s |
+| boot 2, **rootless** | 6.928s | 9.233s | gateway 18.503s |
+
+On the rootful boot, `systemd`'s own `FinishTimestampMonotonic` was
+**19.2112s** — 549µs after `hive-gateway.service` became active. The boot was
+not declared finished until Hive was serving. Both units carry
+`WantedBy=default.target`, and in the system manager that target is the boot
+transaction, so a rootful Hive is on its critical path.
+
+In the user manager the same `WantedBy=default.target` resolves to the *user*
+manager's default target, which logind starts after the system boot has already
+completed. Hence boot 2 finishing in 9.2s with Hive not healthy until 18.5s.
+
+The consequence is worth stating plainly, because it is the operational cost of
+choosing rootful: a Hive that never becomes healthy holds a rootful boot for its
+`TimeoutStartSec` — 5min for `hive.service`, 2min for `hive-gateway.service`.
+That is not hypothetical; the first rootful start attempt here sat in
+`activating` for the full 120s before timing out. On rootless the same failure
+delays nothing but Hive itself.
+
+### The tag moved mid-experiment, and that is why the rows are pinned
+
+`ghcr.io/kubestellar/hive:stable` was pulled twice, once per store:
+
+```
+rootful  store, pulled 17:46:43Z -> sha256:73d88c4c…  (image d46528705417)
+rootless store, pulled 18:07:53Z -> sha256:461ae71a…  (image 880525a77498)
+```
+
+Twenty-one minutes apart, two different images. Left alone, the two rows would
+have differed in root mode *and* in what they ran, and a rootless failure could
+not have been attributed to either. This is exactly the floating-tag problem
+[the update and rollback doc](podman-quadlet-update-rollback.md) exists for.
+
+The rootless row was therefore pinned to the digest the rootful row had already
+run, through the documented drop-in rather than an edit to the unit:
+
+```
+$ bin/hive-podman-update.sh pin ghcr.io/kubestellar/hive@sha256:73d88c4c…
+  PASS  wrote ~/.config/containers/systemd/hive.container.d/10-image.conf
+  PASS  restart returned 0 after 10s, state active/running/success
+$ podman inspect hive --format '{{.Image}}'
+d46528705417c049d79cc02d230070ac5264bf93ba29d981743db9e14f18673d   # == rootful
+```
+
+The pin survived the reboot along with everything else. #4413 says not to change
+the units, and this does not: the base `hive.container` is untouched and still
+names the floating tag.
+
+### What this does not cover
+
+- **One host, one distribution.** Fedora Silverblue with SELinux enforcing and
+  cgroup v2. Nothing here says what a SELinux-permissive or cgroup v1 host does.
+- **Two boots, not a sample.** Each row is a single reboot. The times are what
+  those boots did, not a distribution.
+- **A clean shutdown.** Both reboots were `systemctl reboot`. Neither row says
+  what a power cut does to `hive-data` mid-write.
+- **The dashboard was reached, not exercised.** `/api/health` answered through
+  the gateway; no agent work was driven across the boot.
+
+To re-run it, arm and check first — `boot-check` refuses to present a delta
+larger than ten minutes as boot evidence, since a unit started by hand hours
+after boot also has an `ActiveEnterTimestamp` later than boot:
+
+```sh
+podman exec hive sh -c 'date -Is > /data/reboot-marker.txt'   # arm
+bin/hive-podman-lifecycle-probe.sh check [--rootful]          # confirm the wiring
+sudo systemctl reboot
+# then, promptly, in a fresh login:
+bin/hive-podman-lifecycle-probe.sh boot-check [--rootful]
+curl -sf http://127.0.0.1:3001/api/health
+podman exec hive cat /data/reboot-marker.txt
+```
 
 ## The two unit changes, and why they come as a pair
 

--- a/src/docs/podman-standalone-quadlet.md
+++ b/src/docs/podman-standalone-quadlet.md
@@ -784,11 +784,12 @@ Recorded honestly rather than left implied:
   and the rootful half of `%E` (`/etc`) was read from `systemd.unit(5)` rather
   than measured; the rootless half (`/home/<user>/.config`) was measured
   directly with a probe unit. #4377 closed both, as recorded above.
-- **No reboot has been performed** in either root mode. The boot *wiring* is
-  measured — the generator's `default.target.wants/` symlink, `default.target`
-  being reached, and lingering starting a sessionless user manager — but their
-  composition across an actual kernel boot is not. See
-  [the lifecycle page](podman-quadlet-lifecycle.md#reboot-persistence-not-executed-here).
+- **No reboot was performed by this slice**, in either root mode. The boot
+  *wiring* is measured here — the generator's `default.target.wants/` symlink,
+  `default.target` being reached, and lingering starting a sessionless user
+  manager — but their composition across an actual kernel boot is not. #4413
+  executed that composition in both modes, on a host that could be rebooted:
+  [the lifecycle page](podman-quadlet-lifecycle.md#reboot-persistence-executed-both-modes).
 - The live runs used a scratch directory for `hive.yaml`, `secrets/`,
   `hive.env`, and `nginx.conf` instead of `%E/hive`, so they could not touch a
   real operator configuration. Nothing else in the units differed.


### PR DESCRIPTION
Executes #4413. **Deliberately no closing keyword** — see "Closing" at the bottom.

## What was open

`src/docs/podman-quadlet-lifecycle.md` carried two rows recorded as **not executed**, honestly rather than inferred: the host being measured was the host running the session doing the measuring. #4377's stop condition called for recording the row, and explicitly refused `is-enabled` as a substitute.

Both rows are now executed, on a host that could actually be rebooted.

## Result

| Row | Came back | Healthy after boot | `hive-data` marker |
|---|---|---|---|
| rootless, **lingering enabled**, actual reboot | **yes** | **11.6s** after the user manager started | **identical** |
| rootful via the system manager, actual reboot | **yes** | **16.1s** after userspace started | **identical** |

Two reboots, one per root mode — both `hive-gateway.container` units carry `PublishPort=3001:3001` and rootless can bind it, so the stacks cannot be staged together. Both figures are time-to-**healthy**, not time-to-spawned.

Host: Bluefin (Fedora Silverblue) 44.20260818, kernel 7.1.4, podman 5.8.4, cgroup v2, netavark, SELinux enforcing.

## Acceptance criteria

**Both rows filled, rootless with lingering.** `Linger=yes` was set before the reboot and survived it. #4441 measured `Linger=no` here and deliberately left it; `user@1000.service` came up at +3.75s *because* lingering was on, and the probe's 11.6s is measured from there — the honest reference for a rootless unit, since nothing could start before the user manager existed.

**Confirmed healthy, not merely `active`** — and deliberately not by the probe alone. The container serves on two ports, and `HealthCmd` probes one: 3002, the Go API. The Node auth proxy on 3001 that `nginx.conf` actually reaches is not probed at all. So each row was recorded only after all four of `boot-check`, `is-active` on all four units, a `/api/health` reach-through via the published gateway port, and the marker. Both rows passed all four; the 3001/3002 agreement is a **result** here, not an assumption.

**`hive-data` confirmed with a marker**, per the #4378 technique — and twice over, since the rootful and rootless volumes live in different stores (`/var/lib/containers` vs `~/.local/share/containers`). Two independent proofs, not one volume read twice.

**No unit changes.** The base `hive.container` is untouched and still names the floating tag.

## Three defects found, filed not fixed

Per the issue's "record it and file the defect — do not adjust the unit until it passes":

- **#4476** — `hive.service` reported `active` with its container `healthy` for the entire two minutes in which the deployment was unusable, because `HealthCmd` probes 3002 and never the 3001 auth proxy the gateway needs. **This is why this PR's evidence standard is four checks and not one:** `boot-check` reads `hive.service`, so a reboot result taken on the probe alone could be green and wrong.
- **#4478** — rootful Hive sits inside the system boot transaction and rootless does not. systemd's `FinishTimestampMonotonic` on the rootful boot was **549µs** after `hive-gateway.service` became active; the rootless boot finished at 9.2s with Hive not healthy until 18.5s. Same `WantedBy=default.target` in both, meaning two different things depending on which manager generated it. Written up here; filed there for a maintainer decision.
- **#4477** — not Podman, found sideways: the README's *default* Docker Compose quick start writes `.env` where Compose never reads it and never sets `HIVE_DASHBOARD_TOKEN`.

## One methodological correction

`ghcr.io/kubestellar/hive:stable` **moved between the two pulls**, 21 minutes apart:

```
rootful  store, pulled 17:46:43Z -> sha256:73d88c4c…  (image d46528705417)
rootless store, pulled 18:07:53Z -> sha256:461ae71a…  (image 880525a77498)
```

Left alone the rows would have differed in image as well as root mode, and a rootless failure could not have been attributed to either. The rootless row is pinned to the digest the rootful row ran, via `bin/hive-podman-update.sh pin` and the #4378 drop-in — `hive.container.d/10-image.conf`, so the base unit is untouched. Verified identical image IDs; the pin survived the reboot. That tag move is itself the concrete argument for why #4378's pin exists, and it is recorded.

## What the rows do not cover

Stated in the doc rather than left to be assumed: one host and one distribution; two boots rather than a sample; clean `systemctl reboot` shutdowns only, so nothing here says what a power cut does to `hive-data` mid-write; and a dashboard reached but not exercised.

## Also updated

`podman-host-execution-gap.md`'s cross-reference to "where those rows are recorded as NOT executed".

## Closing

**This does not close #4188**, and is not marked to. #4413 is a sub-issue of that umbrella, so closing it may sweep the parent — and the parent is wanted open for a full-suite scan. This PR therefore uses no closing keyword on either; #4413 is best closed by hand once that scan has landed whatever it finds.

## Cross-references the rename invalidated

Executing the rows renamed a heading and removed a paragraph that three other
places still pointed at. Healed in a follow-up commit; no measurement changes.

- `podman-standalone-quadlet.md` linked
  `podman-quadlet-lifecycle.md#reboot-persistence-not-executed-here` — a **dead
  anchor** as of this PR, since that heading is now "Reboot persistence:
  executed, both modes". Repointed, and its bullet scoped to what it really
  claims: no reboot was performed *by that slice*.
- `podman-host-execution-gap.md` still opened with "records both reboot rows as
  **NOT executed**" while this PR's own edit to its Related list said "recorded,
  measured" — the same file asserting both. It also quoted "the host this was
  measured on could not be rebooted" as something the lifecycle page *states*,
  after this PR removed that passage. Both now say when they were true.

  That page's finding is untouched and still scoped to its own environment:
  reboot is authorised there, and what blocks the rows there is topology. Only
  the forward-references that treated #4413 as still-pending changed.

— hive: backend=claude model=claude-opus-5

