### PR TITLE
feat(agent): refresh Copilot session token so agents don't hang at /login

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1490,6 +1490,12 @@ func main() {
 	// upgrade roll" outage — into an immediate Audit Log signal instead of a
 	// silent multi-hour stall.
 	go agentMgr.StartCredentialWatchdog(ctx)
+	// Keep the Copilot CLI's config.json copilotTokens populated from the
+	// durable user token, so agents never sit stuck at "Please use /login"
+	// while a valid token exists (CLI 1.0.78 does not re-populate the emptied
+	// store from the injected env token on its own). Self-gates on a copilot
+	// backend and only writes when the store is empty; never runs a login.
+	go agentMgr.StartCopilotSessionRefresh(ctx)
 	if ghClient != nil {
 		agentMgr.SetSandboxPRClient(ghClient)
 	}

--- a/src/pkg/agent/copilot_session_refresh_test.go
+++ b/src/pkg/agent/copilot_session_refresh_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+func TestCopilotSessionRefreshInterval(t *testing.T) {
+	t.Setenv(CopilotSessionRefreshIntervalEnv, "")
+	if got := copilotSessionRefreshInterval(); got != defaultCopilotSessionRefreshInterval {
+		t.Errorf("default = %v, want %v", got, defaultCopilotSessionRefreshInterval)
+	}
+	t.Setenv(CopilotSessionRefreshIntervalEnv, "2m")
+	if got := copilotSessionRefreshInterval(); got != 2*time.Minute {
+		t.Errorf("override = %v, want 2m", got)
+	}
+	t.Setenv(CopilotSessionRefreshIntervalEnv, "garbage")
+	if got := copilotSessionRefreshInterval(); got != defaultCopilotSessionRefreshInterval {
+		t.Errorf("invalid override should fall back to default, got %v", got)
+	}
+}
+
+// restoreCopilotTokens must populate copilotTokens (which the credential reader
+// then sees as present), preserve the JSONC header, and no-op on a blank token.
+func TestRestoreCopilotTokens(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Seed an emptied config, as clearExpiredTokens / a roll would leave it.
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+"{\n  \"copilotTokens\": {}\n}\n"), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if copilotCredentialFileHasTokens(path) {
+		t.Fatal("precondition: emptied config must have no tokens")
+	}
+
+	if err := restoreCopilotTokens(path, "ghu_validtoken"); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if !copilotCredentialFileHasTokens(path) {
+		t.Error("after restore, config must report a token present")
+	}
+	raw, _ := os.ReadFile(path)
+	if len(raw) < len(copilotConfigHeader) || string(raw[:len(copilotConfigHeader)]) != copilotConfigHeader {
+		t.Error("JSONC header must be preserved on rewrite")
+	}
+
+	// Blank token is a no-op and must not error or wipe an existing token.
+	if err := restoreCopilotTokens(path, "   "); err != nil {
+		t.Fatalf("blank restore should be a no-op, got %v", err)
+	}
+	if !copilotCredentialFileHasTokens(path) {
+		t.Error("blank restore must not clear an existing token")
+	}
+}
+
+// The round-trip: clear empties, restore re-populates.
+func TestClearThenRestoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	orig := sharedCopilotConfigPath
+	sharedCopilotConfigPath = path
+	defer func() { sharedCopilotConfigPath = orig }()
+
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{"github.com":{"token":"gho_old"}}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if err := clearExpiredTokens(); err != nil {
+		t.Fatal(err)
+	}
+	if copilotConfigHasTokens() {
+		t.Error("clearExpiredTokens must empty the token map")
+	}
+	if err := restoreCopilotTokens(path, "ghu_new"); err != nil {
+		t.Fatal(err)
+	}
+	if !copilotConfigHasTokens() {
+		t.Error("restore must re-populate the token map")
+	}
+}
+
+// refreshCopilotSessionToken must: no-op without a copilot backend; no-op when
+// tokens are already present; and re-seed an empty store when a copilot agent
+// exists and the manager holds a user token.
+func TestRefreshCopilotSessionToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	orig := sharedCopilotConfigPath
+	sharedCopilotConfigPath = path
+	defer func() { sharedCopilotConfigPath = orig }()
+	writeEmpty := func() {
+		if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{}}`), 0o660); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// (a) No copilot backend → no-op even with a token held.
+	writeEmpty()
+	m := testManager(5)
+	m.agents["a"] = &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude"}}
+	m.copilotAuthToken = "ghu_held"
+	m.refreshCopilotSessionToken()
+	if copilotConfigHasTokens() {
+		t.Error("no copilot backend: must not seed tokens")
+	}
+
+	// (b) Copilot backend + held token + empty store → re-seed.
+	m2 := testManager(5)
+	m2.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m2.copilotAuthToken = "ghu_held"
+	writeEmpty()
+	m2.refreshCopilotSessionToken()
+	if !copilotConfigHasTokens() {
+		t.Error("copilot backend + held token + empty store: must re-seed")
+	}
+
+	// (c) Copilot backend but NO held token → no-op (genuine logout, manual login).
+	m3 := testManager(5)
+	m3.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m3.copilotAuthToken = ""
+	writeEmpty()
+	m3.refreshCopilotSessionToken()
+	if copilotConfigHasTokens() {
+		t.Error("no held token: must not fabricate a credential")
+	}
+
+	// (d) Already-populated store → must NOT overwrite (no clobbering a live session).
+	m4 := testManager(5)
+	m4.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m4.copilotAuthToken = "ghu_held"
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{"github.com":{"token":"gho_cli_owned"}}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	m4.refreshCopilotSessionToken()
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "gho_cli_owned") {
+		t.Error("must not overwrite an already-present token")
+	}
+}

--- a/src/pkg/agent/copilot_session_refresh_test.go
+++ b/src/pkg/agent/copilot_session_refresh_test.go
@@ -57,6 +57,19 @@ func TestRestoreCopilotTokens(t *testing.T) {
 	if !copilotCredentialFileHasTokens(path) {
 		t.Error("blank restore must not clear an existing token")
 	}
+
+	// A MISSING config file is seeded fresh (not an error) — a fresh agent pod
+	// whose CLI never wrote config.json still gets a usable credential.
+	fresh := filepath.Join(dir, "sub", "config.json")
+	if err := os.MkdirAll(filepath.Dir(fresh), 0o770); err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreCopilotTokens(fresh, "ghu_fresh"); err != nil {
+		t.Fatalf("restore into a missing file should seed it, got %v", err)
+	}
+	if !copilotCredentialFileHasTokens(fresh) {
+		t.Error("restore must create + populate a missing config")
+	}
 }
 
 // The round-trip: clear empties, restore re-populates.

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -966,6 +966,88 @@ func (m *Manager) StartCredentialWatchdog(ctx context.Context) {
 	}
 }
 
+// defaultCopilotSessionRefreshInterval is how often the Copilot session-token
+// refresh loop ensures the CLI's config.json copilotTokens map is populated
+// from the durable user token. Chosen well under the ~hour that a stored token
+// stays fresh so an emptied map is re-seeded long before an agent next reads
+// it, and low-cost (a small file read + conditional write) so a tight interval
+// is cheap.
+const defaultCopilotSessionRefreshInterval = 10 * time.Minute
+
+// CopilotSessionRefreshIntervalEnv overrides the interval with a Go duration.
+const CopilotSessionRefreshIntervalEnv = "HIVE_COPILOT_SESSION_REFRESH_INTERVAL"
+
+func copilotSessionRefreshInterval() time.Duration {
+	if v := os.Getenv(CopilotSessionRefreshIntervalEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultCopilotSessionRefreshInterval
+}
+
+// StartCopilotSessionRefresh keeps the Copilot CLI's config.json copilotTokens
+// map populated from the durable user token, so agents never sit stuck at
+// "Please use /login" while a VALID token exists.
+//
+// The failure it fixes: clearExpiredTokens (on an auth-error diagnostic) and a
+// config rewrite on an upgrade roll leave copilotTokens EMPTY, and CLI 1.0.78
+// does NOT re-populate it from the injected COPILOT_GITHUB_TOKEN on its own —
+// it just prompts /login. A restart does not help (it re-reads the empty map).
+// Every roll churns fresh agent pods, so absent this the whole hive can go dark
+// on Copilot with a perfectly good token sitting on disk.
+//
+// It is NOT a login: it never runs a device flow and never mints or fetches a
+// token. It only re-uses the token the operator already provided (m.copilotAuth‐
+// Token / the durable file), writing it into the store the CLI reads. When the
+// hive holds no Copilot token it does nothing — recovery there is still the
+// operator's manual dashboard login.
+//
+// Gating: only runs on hives with a copilot-backend agent. Only writes when the
+// store is EMPTY (or absent) — it never overwrites a token the CLI itself wrote
+// and is still using, so it can't clobber a live session.
+func (m *Manager) StartCopilotSessionRefresh(ctx context.Context) {
+	ticker := time.NewTicker(copilotSessionRefreshInterval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.refreshCopilotSessionToken()
+		}
+	}
+}
+
+// refreshCopilotSessionToken seeds config.json's copilotTokens from the durable
+// user token when the map is empty on a copilot-backend hive. One tick's work;
+// safe to call from the timer or ad hoc.
+func (m *Manager) refreshCopilotSessionToken() {
+	if !m.backendInUse("copilot") {
+		return
+	}
+	// Already populated (the CLI's own token or a prior restore is in place):
+	// leave it alone so we never overwrite a live session.
+	if copilotConfigHasTokens() {
+		return
+	}
+	m.mu.RLock()
+	token := m.copilotAuthToken
+	m.mu.RUnlock()
+	if strings.TrimSpace(token) == "" {
+		// No token to restore from — this is the genuinely-logged-out case the
+		// StartCredentialWatchdog alert covers; recovery is a manual login.
+		return
+	}
+	if err := restoreCopilotTokens(sharedCopilotConfigPath, token); err != nil {
+		m.logger.Warn("copilot session refresh: failed to restore copilotTokens",
+			"path", sharedCopilotConfigPath, "error", err)
+		return
+	}
+	m.logger.Info("copilot session refresh: re-seeded empty copilotTokens from durable user token",
+		"path", sharedCopilotConfigPath)
+}
+
 // evalCredentialWatch runs one backend's probe (only if that backend is in
 // use) and emits a transition-edge log + audit event. lastUnusable carries the
 // previous observation per backend across ticks.
@@ -5542,35 +5624,98 @@ func copilotCredentialFileHasTokens(path string) bool {
 	return false
 }
 
-// clearExpiredTokens removes stored copilot tokens from config.json.
-// An expired gho_ token causes copilot to hang during auth through the
-// MITM proxy instead of falling through to the /login prompt.
-func clearExpiredTokens() error {
-	data, err := os.ReadFile(sharedCopilotConfigPath)
+// copilotConfigHeader is the two-line // preamble the Copilot CLI writes atop
+// its JSONC config.json. We preserve it byte-for-byte on every rewrite so the
+// file keeps reading as the CLI's own managed file rather than a foreign one.
+const copilotConfigHeader = "// User settings belong in settings.json.\n// This file is managed automatically.\n"
+
+// readCopilotConfig loads config.json, strips the CLI's // comment lines, and
+// unmarshals the remainder. Returns an empty (non-nil) map when the file is
+// absent so a caller can populate a fresh config.
+func readCopilotConfig(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		if os.IsNotExist(err) {
+			return map[string]interface{}{}, nil
+		}
+		return nil, err
 	}
 	var cleaned []byte
 	for _, line := range strings.Split(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "//") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
 			continue
 		}
 		cleaned = append(cleaned, []byte(line+"\n")...)
 	}
 	var cfg map[string]interface{}
 	if err := json.Unmarshal(cleaned, &cfg); err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		cfg = map[string]interface{}{}
+	}
+	return cfg, nil
+}
+
+// writeCopilotConfig marshals cfg back to config.json with the CLI's // header
+// preserved and the CLI-expected mode. Written via a temp file + rename so a
+// concurrent CLI read never sees a half-written file.
+func writeCopilotConfig(path string, cfg map[string]interface{}) error {
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	content := copilotConfigHeader + string(out)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), sharedConfigDesiredMode); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// clearExpiredTokens removes stored copilot tokens from config.json.
+// An expired gho_ token causes copilot to hang during auth through the
+// MITM proxy instead of falling through to the /login prompt.
+func clearExpiredTokens() error {
+	cfg, err := readCopilotConfig(sharedCopilotConfigPath)
+	if err != nil {
 		return err
 	}
 	cfg["copilotTokens"] = map[string]interface{}{}
 	cfg["loggedInUsers"] = []interface{}{}
 	delete(cfg, "lastLoggedInUser")
-	out, err := json.MarshalIndent(cfg, "", "  ")
+	return writeCopilotConfig(sharedCopilotConfigPath, cfg)
+}
+
+// restoreCopilotTokens writes token into config.json's copilotTokens map so the
+// Copilot CLI has a usable credential without an interactive /login.
+//
+// This closes the loop that leaves agents stuck at "Please use /login" while a
+// VALID user token exists: clearExpiredTokens (and a config rewrite on roll)
+// leave copilotTokens EMPTY, and CLI 1.0.78 does NOT re-populate it from the
+// injected COPILOT_GITHUB_TOKEN on its own — it just prompts /login. Seeding
+// copilotTokens from the durable user token gives the CLI the credential it
+// would otherwise wait for a human to supply. It never performs a device-flow
+// login (that stays the operator's manual path); it only re-uses a token the
+// operator already provided.
+//
+// The token is stored under the "github.com" host key in the object shape the
+// CLI reads ({"github.com":{"token":"…"}}) — the same shape the credential
+// reader (copilotCredentialFileHasTokens) already accepts. A blank token is a
+// no-op (nothing to restore); use clearExpiredTokens to empty the map.
+func restoreCopilotTokens(path, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	cfg, err := readCopilotConfig(path)
 	if err != nil {
 		return err
 	}
-	content := "// User settings belong in settings.json.\n// This file is managed automatically.\n" + string(out)
-	return os.WriteFile(sharedCopilotConfigPath, []byte(content), sharedConfigDesiredMode)
+	cfg["copilotTokens"] = map[string]interface{}{
+		"github.com": map[string]interface{}{"token": token},
+	}
+	return writeCopilotConfig(path, cfg)
 }
 
 // cliReadyIndicators prove copilot finished startup.
@@ -5793,11 +5938,30 @@ func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess)
 				continue
 			}
 			if matchesAuthError(output) {
-				m.logger.Warn("diagnostic: auth error detected, clearing token",
-					"agent", agent.Name, "output_snippet", truncateStr(output, 200))
 				agent.LastError = "auth token expired or invalid"
-				if err := clearExpiredTokens(); err != nil {
-					m.logger.Warn("diagnostic: failed to clear tokens", "error", err)
+				// Prefer to RESTORE the stored token over merely clearing it: an
+				// empty copilotTokens leaves CLI 1.0.78 stuck at /login (it does
+				// not re-populate from the injected env token), and every roll
+				// re-hits this. If we hold a durable user token, seed it so the
+				// relaunch below comes up authenticated; otherwise fall back to
+				// the historical clear (which lets the CLI reach /login instead
+				// of hanging on the MITM proxy on a stale token).
+				m.mu.RLock()
+				userTok := m.copilotAuthToken
+				m.mu.RUnlock()
+				if strings.TrimSpace(userTok) != "" {
+					m.logger.Warn("diagnostic: auth error detected, restoring token from durable user token",
+						"agent", agent.Name, "output_snippet", truncateStr(output, 200))
+					if err := restoreCopilotTokens(sharedCopilotConfigPath, userTok); err != nil {
+						m.logger.Warn("diagnostic: failed to restore tokens, clearing instead", "error", err)
+						_ = clearExpiredTokens()
+					}
+				} else {
+					m.logger.Warn("diagnostic: auth error detected, clearing token (no durable token to restore)",
+						"agent", agent.Name, "output_snippet", truncateStr(output, 200))
+					if err := clearExpiredTokens(); err != nil {
+						m.logger.Warn("diagnostic: failed to clear tokens", "error", err)
+					}
 				}
 			} else if paneShowsCLIReady(strings.Split(output, "\n")) {
 				m.logger.Info("diagnostic: copilot started successfully in bare mode", "agent", agent.Name)

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -5630,14 +5630,13 @@ func copilotCredentialFileHasTokens(path string) bool {
 const copilotConfigHeader = "// User settings belong in settings.json.\n// This file is managed automatically.\n"
 
 // readCopilotConfig loads config.json, strips the CLI's // comment lines, and
-// unmarshals the remainder. Returns an empty (non-nil) map when the file is
-// absent so a caller can populate a fresh config.
+// unmarshals the remainder. A read error (including a missing file) is returned
+// to the caller — clearExpiredTokens relies on that to no-op when there is no
+// config to clear; restoreCopilotTokens handles the missing-file case itself by
+// starting from an empty map.
 func readCopilotConfig(path string) (map[string]interface{}, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return map[string]interface{}{}, nil
-		}
 		return nil, err
 	}
 	var cleaned []byte
@@ -5710,7 +5709,13 @@ func restoreCopilotTokens(path, token string) error {
 	}
 	cfg, err := readCopilotConfig(path)
 	if err != nil {
-		return err
+		// A missing/unreadable config is not fatal here: we are writing the
+		// token store fresh. A malformed-but-present file returns a non-IsNot‐
+		// Exist error we still honor rather than clobbering unknown content.
+		if !os.IsNotExist(err) {
+			return err
+		}
+		cfg = map[string]interface{}{}
 	}
 	cfg["copilotTokens"] = map[string]interface{}{
 		"github.com": map[string]interface{}{"token": token},


### PR DESCRIPTION
## Root cause (diagnosed live on ks/hive)

Agents sit stuck at **"Please use /login to sign in to use Copilot"** while the durable `ghu_` user token is **valid at every layer** — file, injected `COPILOT_GITHUB_TOKEN`, and through the pluk MITM proxy all return **200**. The operator re-logged in via the dashboard button and it worked, then broke again hours later; a restart made no difference.

**Why:** CLI 1.0.78 reads its credential from `config.json`'s **`copilotTokens`** map. But:
- `clearExpiredTokens` (fired by the auth-error diagnostic) sets `copilotTokens` to `{}`, and
- a config rewrite on an upgrade roll also leaves it `{}`,

and the CLI does **not** re-populate that map from the injected env token on its own — it just prompts `/login`. A restart re-reads the same empty map. Since ks/hive rolls every ~15–30 min, the whole hive goes dark on Copilot with a perfectly good token sitting on disk. (Confirmed live: `config.json` line 5 was literally `"copilotTokens": {}`.)

## Fix — keep `copilotTokens` populated from the token the operator already provided

**Never runs a login. Never mints or fetches a token. Only re-uses a token already on disk.** The manual-login rule stays intact.

- **`restoreCopilotTokens(path, token)`** — writes the durable user token into `copilotTokens` in the shape the CLI reads (`{"github.com":{"token":…}}`), preserving the JSONC `//` header, via temp-file + rename. The read/decomment and header-preserving write are factored into `readCopilotConfig`/`writeCopilotConfig`, which `clearExpiredTokens` now reuses.
- **`StartCopilotSessionRefresh`** — a 10-min loop (`HIVE_COPILOT_SESSION_REFRESH_INTERVAL`) that, on a copilot-backend hive, re-seeds `copilotTokens` from `m.copilotAuthToken` **only when the store is empty** — it never overwrites a token the CLI itself wrote and is using, and does nothing when the hive holds no token (that genuine-logout case stays the `StartCredentialWatchdog` alert + manual login). Launched in `main` alongside the other token loops.
- The **auth-error diagnostic path** now **restores** from the held token instead of only clearing, so the forced relaunch comes up authenticated; it still falls back to clearing when no durable token is held.

## Why the earlier watchdog (#4424) didn't catch this
That one alerts only when the token **file is missing**. Here the file is present and valid — the failure is the empty `copilotTokens` map, which this PR keeps populated.

## Tests
`copilot_session_refresh_test.go`: interval resolution; `restoreCopilotTokens` (populate / header preserved / blank no-op); clear→restore round trip; `refreshCopilotSessionToken` across no-backend / seed-on-empty / no-held-token / **already-populated (no clobber)**.

## Files
- `src/pkg/agent/manager.go` — helpers, `restoreCopilotTokens`, `StartCopilotSessionRefresh`/`refreshCopilotSessionToken`, diagnostic-path restore
- `src/cmd/hive/main.go` — launch the loop
- `src/pkg/agent/copilot_session_refresh_test.go` — tests

gofmt clean; DCO-signed. Pre-existing v4 beads/sandbox/hub flakiness is unrelated.