### PR TITLE
🐛 heal the bare 'Repository not provisioned' repo-access finding wording

### DIFF
--- a/src/pkg/advisory/heal.go
+++ b/src/pkg/advisory/heal.go
@@ -159,6 +159,13 @@ var repoAccessFindingPatterns = []*regexp.Regexp{
 	// the close below is gated on a verified READ, which would be the wrong
 	// proof for a write-access claim (those are the app-auth healer's).
 	regexp.MustCompile(`(?i)\b(no|missing|lacks?|without|unavailable)\b[^.\n]*\b(read-only|read|clone|checkout|fetch)\s+access\s+to\b[^.\n]*\brepo(sitory)?\b`),
+	// #4464, gap 3 (found live on a customer hive AFTER the first two fixes
+	// shipped): "Repository not provisioned for guide agent - cannot perform
+	// documentation audit". The bare repo noun with no workspace/worktree/
+	// checkout qualifier — gap 1's pattern requires that middle noun, so this
+	// escaped. Directional: the "not/never provisioned" claim must attach to
+	// the repo(sitory) subject within the same clause.
+	regexp.MustCompile(`(?i)\brepo(sitory)?\b[^.\n]*\b(not|never|un)provisioned\b|\brepo(sitory)?\b[^.\n]*\b(not|never)\s+provisioned\b`),
 }
 
 // IsRepoAccessFinding reports whether a finding title describes the hive's own

--- a/src/pkg/advisory/heal_test.go
+++ b/src/pkg/advisory/heal_test.go
@@ -306,6 +306,9 @@ var gee4veeRepoAccessTitles = []struct{ title, ref string }{
 var issue4464RepoAccessTitles = []struct{ title, ref string }{
 	{"Repository worktree not provisioned for guide agent despite include_repos=true configuration", "/data/agents/guide (empty directory)"},
 	{"Quality agent lacks read access to repository for coverage analysis", "devx-prod/epx-vscode-ext-poc"},
+	// Gap 3, found live on a customer hive after the first two fixes shipped:
+	// the bare repo noun, no workspace/worktree qualifier.
+	{"Critical: Repository not provisioned for guide agent - cannot perform documentation audit", "/tmp/hive/epx-vscode-ext-poc"},
 }
 
 func TestIsRepoAccessFinding(t *testing.T) {


### PR DESCRIPTION
Gap 3 in the #4464/#2575 repo-access finding family, caught live on a customer hive today **after** the first two #4464 fixes shipped and successfully healed ~15 sibling findings: the digest still pins

> **[advisory]** Critical: Repository not provisioned for guide agent - cannot perform documentation audit

as a permanently-open critical. Gap 1's pattern requires a workspace/worktree/checkout noun between the repo subject and "not provisioned" — this title has none.

Adds one directional pattern (`repo(sitory) … not/never (un)provisioned` within a clause), adds the live title to the `issue4464RepoAccessTitles` test table. All existing positive/negative pattern tests pass (`go test ./pkg/advisory`).