### PR TITLE
🐛 restore the hub top navbar on the /fleet page

### DIFF
--- a/src/pkg/hub/fleet_route_test.go
+++ b/src/pkg/hub/fleet_route_test.go
@@ -26,6 +26,18 @@ func TestFleetRouteServesPageAndMyHivesRedirects(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "<html") {
 		t.Error("GET /fleet: expected the fleet page HTML shell")
 	}
+	body := w.Body.String()
+	for _, want := range []string{
+		`<header class="site-header">`,
+		`<a href="/">Hives</a>`,
+		`<a href="/dashboard">My Hives</a>`,
+		`<a href="/fleet" id="nav-fleet" class="active" aria-current="page"`,
+		`<a href="/api/docs">API</a>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("GET /fleet: expected navbar to contain %q", want)
+		}
+	}
 
 	req = httptest.NewRequest("GET", "/my-hives?view=quadrant", nil)
 	w = httptest.NewRecorder()

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -8,19 +8,59 @@
   :root {
     --bg: #0d1420; --panel: #131c2b; --line: #22304a; --ink: #d7e2f2;
     --muted: #8ba0bd; --green: #3fb968; --amber: #e0a800; --red: #e5484d;
-    --gray: #5a6b84; --accent: #4a9eff; --chip: #17212d;
+    --gray: #5a6b84; --accent: #4a9eff; --chip: #17212d; --text: #d7e2f2;
   }
   * { box-sizing: border-box; }
   body {
     margin: 0; background: var(--bg); color: var(--ink);
     font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   }
-  header {
+  a { color: inherit; text-decoration: none; }
+  .site-header {
+    z-index: 10;
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    background: #080b0fc7;
+    border-bottom: 1px solid #ffffff14;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1rem clamp(1rem, 4vw, 4.5rem);
+    position: sticky;
+    top: 0;
+  }
+  .brand, .header-link, nav { align-items: center; display: flex; }
+  .brand { letter-spacing: 0; gap: .75rem; font-weight: 800; }
+  .brand-mark {
+    width: 2.5rem; height: 2.5rem;
+    color: var(--amber);
+    background: linear-gradient(145deg, rgba(224, 168, 0, .18), rgba(74, 158, 255, .10));
+    border: 1px solid rgba(224, 168, 0, .42);
+    border-radius: .65rem;
+    place-items: center;
+    font-size: 1.2rem;
+    display: grid;
+  }
+  nav { color: var(--muted); gap: 1.35rem; font-size: .94rem; }
+  nav a:hover, .header-link:hover { color: var(--text); }
+  nav a.active { color: var(--amber); }
+  .header-link {
+    border: 1px solid var(--line);
+    width: fit-content;
+    color: var(--text);
+    border-radius: .55rem;
+    justify-self: end;
+    padding: .72rem 1rem;
+    font-weight: 700;
+  }
+  .header-right { display: flex; align-items: center; gap: .8rem; justify-self: end; }
+  .fleet-header {
     padding: 16px 22px; border-bottom: 1px solid var(--line);
     display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
   }
-  header h1 { font-size: 18px; margin: 0; font-weight: 600; }
-  header .sub { color: var(--muted); font-size: 12px; }
+  .fleet-header h1 { font-size: 18px; margin: 0; font-weight: 600; }
+  .fleet-header .sub { color: var(--muted); font-size: 12px; }
   .wrap { padding: 16px 22px; max-width: 1200px; }
   .legend { display: flex; gap: 16px; flex-wrap: wrap; color: var(--muted); font-size: 12px; margin-bottom: 14px; }
   .legend b { color: var(--ink); font-weight: 600; }
@@ -109,10 +149,37 @@
   .allclear { color: var(--green); font-weight: 600; }
   .controls { margin-left: auto; display: flex; gap: 14px; font-size: 12px; color: var(--muted); }
   .controls label { cursor: pointer; user-select: none; }
+  @media (max-width: 900px) {
+    .site-header { grid-template-columns: 1fr; position: static; }
+    .site-header nav { flex-wrap: wrap; gap: .85rem; }
+    .header-link { justify-self: start; }
+    .header-right { justify-self: start; }
+  }
 </style>
 </head>
 <body>
-<header>
+<header class="site-header">
+  <a href="/" class="brand">
+    <span class="brand-mark">🐝</span>
+    <span>Hive</span>
+  </a>
+  <nav>
+    <a href="/">Hives</a>
+    <a href="/learn">Learn</a>
+    <a href="/reading">Reading</a>
+    <a href="/get-started">Get Started</a>
+    <a href="/dashboard">My Hives</a>
+    <a href="/fleet" id="nav-fleet" class="active" aria-current="page" title="Fleet health — agents the governor expects on but that can't work">Fleet</a>
+    <a href="/api/docs">API</a>
+    <a href="https://kubestellar.io/docs/hive/overview/introduction" target="_blank" rel="noopener">Docs</a>
+    <span id="nav-user" class="nav-user"></span>
+  </nav>
+  <div class="header-right">
+    <span id="hub-version"></span>
+    <a href="#" class="header-link" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
+  </div>
+</header>
+<header class="fleet-header">
   <h1>Fleet health</h1>
   <span class="sub">a hive is a <b>problem</b> when agents cannot work, output is stale, or budget is depleted</span>
   <span id="summary" class="summary"></span>


### PR DESCRIPTION
## Summary
- restore the hub top navbar on the /fleet page with Fleet marked active
- keep the existing fleet controls/content in place under the restored nav
- add route-test assertions that the fleet page includes the nav links

## Validation
- cd src && go build ./pkg/hub && go test ./pkg/hub

Root cause: the fleet HTML shell was introduced standalone in #4437 without the shared hub navbar; the later #4468 route rename only moved /my-hives to /fleet and did not remove a navbar.