### PR TITLE
✨ Link fleet hive names to dashboards

### DIFF
--- a/src/pkg/hub/provision_approve_coverage_test.go
+++ b/src/pkg/hub/provision_approve_coverage_test.go
@@ -176,7 +176,7 @@ func TestHandleMyHives(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	// A registry entry for the same hive to exercise the merge path.
-	s.registry.Hives = []RegistryEntry{{ID: "h1", Owner: "alice", Org: "acme", GitHash: "abc", Online: true}}
+	s.registry.Hives = []RegistryEntry{{ID: "h1", Owner: "alice", Org: "acme", GitHash: "abc", Online: true, DashboardURL: "https://h1.example.com"}}
 
 	rec := httptest.NewRecorder()
 	req := reqWithUser(http.MethodGet, "/api/saas/my-hives", "", "alice")
@@ -187,5 +187,17 @@ func TestHandleMyHives(t *testing.T) {
 	var resp map[string]json.RawMessage
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal my-hives: %v", err)
+	}
+	var typed struct {
+		Hives []MyHiveEntry `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &typed); err != nil {
+		t.Fatalf("unmarshal typed my-hives: %v", err)
+	}
+	if len(typed.Hives) != 1 {
+		t.Fatalf("hives len = %d, want 1", len(typed.Hives))
+	}
+	if got := typed.Hives[0].DashboardURL; got != "https://h1.example.com" {
+		t.Errorf("dashboard URL = %q, want registry value", got)
 	}
 }

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -76,6 +76,8 @@
   .dot.on { background: var(--green); }
   .dot.off { background: var(--gray); }
   .name { font-weight: 600; }
+  a.name { color: inherit; text-decoration: none; }
+  a.name:hover { text-decoration: underline; }
   .chev { display: inline-block; width: 12px; color: var(--muted); transition: transform .1s; }
   tr.spoke.open .chev { transform: rotate(90deg); }
   .badge {
@@ -389,6 +391,12 @@ var advisoryFilter = "";
 var budgetFilter = "";
 
 function hiveKey(h) { return h.id || h.name; }
+function hiveNameHTML(h) {
+  var label = esc(h.name || h.id);
+  var dashboardURL = h.dashboardUrl || h.url || "";
+  if (!dashboardURL) return '<span class="name">' + label + '</span>';
+  return '<a class="name hive-link" href="' + esc(dashboardURL) + '" target="_blank" rel="noopener">' + label + '</a>';
+}
 
 function renderHives(hives) {
   var tb = document.getElementById("rows");
@@ -426,13 +434,15 @@ function renderHives(hives) {
     tr.className = "spoke health-" + health + (open ? " open" : "");
     tr.innerHTML =
       '<td><span class="chev">▶</span></td>' +
-      '<td><span class="hdot ' + health + '" title="' + health + '"></span><span class="name">' + esc(h.name || h.id) + '</span></td>' +
+      '<td><span class="hdot ' + health + '" title="' + health + '"></span>' + hiveNameHTML(h) + '</td>' +
       '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
       '<td>' + modeBadge(h.governorMode) + '</td>' +
       '<td>' + versionHTML(h) + '</td>' +
       '<td>' + rollupHTML(h.fleetRollup) + '</td>' +
       '<td>' + outputHTML(h) + '<br>' + budgetHealthHTML(h.budgetHealth) + '</td>';
     tb.appendChild(tr);
+    var link = tr.querySelector(".hive-link");
+    if (link) link.addEventListener("click", function (e) { e.stopPropagation(); });
 
     var verdicts = h.agentVerdicts || [];
     var subRows = [];


### PR DESCRIPTION
## Summary
- link fleet hive names to their dashboard URLs when known
- keep row/arrow expansion behavior by stopping propagation on the link
- assert /api/saas/my-hives carries dashboardUrl from registry entries

## Validation
- cd src && go build ./pkg/hub && go test ./pkg/hub