### PR TITLE
🐛 advisory-only ACMM levels are not a PROBLEM; exhausted budget beats missing numbers

### DIFF
--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -247,14 +247,22 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	// blocker cannot make it "partial".
 	modeGrantsWrite := a.CanOpenPR || a.CanMerge
 
+	// advisoryOnly: the ACMM level grants this agent NO GitHub writes at all —
+	// not even opening issues. That is the operator's chosen maturity level,
+	// not a fault: at these levels the agent's whole mission is advisory
+	// (findings flow to the digest), so "cannot write" must never read as a
+	// PROBLEM. Before this, every working advisory agent on an L1/L2 hive was
+	// flagged "PROBLEM: no write capability at this ACMM level" on the fleet
+	// page, drowning out real problems.
+	advisoryOnly := !a.CanOpenIssue && !modeGrantsWrite
+
 	// capable = "if this agent were working, could it exercise its FULL mission?"
 	// The CanOpen*/CanMerge booleans already encode the mode's ceiling (an
 	// advisory issues-only agent simply reports CanMerge=false — not being able
-	// to merge is not a fault for it). The only things that TAKE AWAY a granted
-	// capability are an interactive login block or a hive-level blocker. We
-	// require CanOpenIssue as the floor: an agent that cannot even open an issue
-	// at this ACMM level has no reachable mission.
-	capable := a.CanOpenIssue && !blocked
+	// to merge is not a fault for it, and an advisory-only agent's mission
+	// needs no GitHub write at all). The only things that TAKE AWAY a granted
+	// capability are an interactive login block or a hive-level blocker.
+	capable := (a.CanOpenIssue || advisoryOnly) && !blocked
 
 	// Able = actually able to fulfill its mission RIGHT NOW: capable AND truly
 	// working. A capable-but-stopped or capable-but-paused agent is not doing
@@ -263,25 +271,25 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	// running ⊇ able) and makes IMPOTENT = running − able coherent.
 	v.Able = capable && v.RunState == runWorking
 
-	// Reason + tier.
+	// Reason + tier. An unblocked advisory-only agent carries NO reason: its
+	// lack of write capability is the ACMM level working as designed.
 	switch {
 	case loginBlocked:
 		v.BlockedReason = "sitting at login prompt"
 	case hiveBlocked:
 		v.BlockedReason = blockers.reason()
-	case !a.CanOpenIssue && !a.CanOpenPR && !a.CanMerge:
-		v.BlockedReason = "no write capability at this ACMM level"
 	}
 
 	// Tier reflects CAPABILITY (would it work if running), not liveness — a
 	// healthy-but-paused agent still shows green so the badge answers "can this
 	// agent do its job" independent of the run-state column beside it.
 	//
-	//   green — fully capable of its mission.
+	//   green — fully capable of its mission (for an advisory-only agent, the
+	//           mission is the digest — no GitHub write required).
 	//   amber — can still open issues, but a blocker takes away a WRITE its mode
 	//           would otherwise grant (partial: half its job works).
-	//   red   — cannot even open an issue (blocked at the floor, or no capability
-	//           at this ACMM level).
+	//   red   — cannot even open an issue despite its mode granting it (blocked
+	//           at the floor).
 	switch {
 	case capable:
 		v.CapabilityTier = tierGreen

--- a/src/pkg/hub/agent_capability_coverage_test.go
+++ b/src/pkg/hub/agent_capability_coverage_test.go
@@ -114,8 +114,13 @@ func TestVerdict_SessionGoneAndIdle(t *testing.T) {
 	}
 }
 
-// no-capability agent (advisory below issues) → red tier + reason.
-func TestVerdict_NoCapabilityIsRed(t *testing.T) {
+// no-capability agent (ACMM level grants no GitHub writes at all) → that is
+// the operator's chosen maturity level, NOT a fault: the agent's mission is
+// advisory (digest), so it must read green, carry no blocked reason, and
+// never count as impotent/problem. (Fleet rows at L1/L2 previously flagged
+// every working advisory agent "PROBLEM: no write capability at this ACMM
+// level".)
+func TestVerdict_AdvisoryOnlyLevelIsNotAProblem(t *testing.T) {
 	now := time.Now()
 	a := AgentSummary{
 		Name: "adv", State: "running", Backend: "claude",
@@ -124,15 +129,20 @@ func TestVerdict_NoCapabilityIsRed(t *testing.T) {
 		StartedAt: settled(now), LastActivityAt: activeAt(now, 1*time.Minute),
 	}
 	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
-	if v.CapabilityTier != tierRed {
-		t.Errorf("no-capability tier = %s, want red", v.CapabilityTier)
+	if v.CapabilityTier != tierGreen {
+		t.Errorf("advisory-only tier = %s, want green", v.CapabilityTier)
 	}
-	if v.BlockedReason == "" {
-		t.Error("no-capability agent must carry a reason")
+	if v.BlockedReason != "" {
+		t.Errorf("advisory-only agent must carry no reason, got %q", v.BlockedReason)
 	}
-	// Running but not capable → impotent.
-	if !v.Impotent {
-		t.Error("running no-capability agent must be IMPOTENT")
+	if v.Impotent {
+		t.Error("working advisory-only agent must NOT be IMPOTENT")
+	}
+	if !v.Able {
+		t.Error("working advisory-only agent must be Able (its mission is the digest)")
+	}
+	if v.Problem {
+		t.Error("advisory-only level must never be a PROBLEM")
 	}
 }
 
@@ -161,12 +171,20 @@ func TestVerdict_TierArms(t *testing.T) {
 	if v := deriveAgentVerdict(loginBlk, hiveBlockers{}, 5, now); v.CapabilityTier != tierAmber {
 		t.Errorf("login-blocked writer = %s, want amber", v.CapabilityTier)
 	}
-	// red — issues-only agent (no write to gate) that is ALSO blocked at the
-	// floor: model an agent with no capability at all.
+	// green — advisory-only agent (ACMM grants no writes): by design, not red.
 	none := writer
 	none.CanOpenIssue, none.CanOpenPR, none.CanMerge = false, false, false
-	if v := deriveAgentVerdict(none, hiveBlockers{}, 5, now); v.CapabilityTier != tierRed {
-		t.Errorf("no-capability agent = %s, want red", v.CapabilityTier)
+	if v := deriveAgentVerdict(none, hiveBlockers{}, 5, now); v.CapabilityTier != tierGreen {
+		t.Errorf("advisory-only agent = %s, want green (level design, not a fault)", v.CapabilityTier)
+	}
+	// red — issues-only agent blocked at the floor: its mode grants issue
+	// writes but a login block takes even that away, leaving no reachable
+	// mission.
+	issuesOnlyBlocked := writer
+	issuesOnlyBlocked.CanOpenPR, issuesOnlyBlocked.CanMerge = false, false
+	issuesOnlyBlocked.NeedsLogin = true
+	if v := deriveAgentVerdict(issuesOnlyBlocked, hiveBlockers{}, 5, now); v.CapabilityTier != tierRed {
+		t.Errorf("floor-blocked issues-only agent = %s, want red", v.CapabilityTier)
 	}
 }
 

--- a/src/pkg/hub/budget_health.go
+++ b/src/pkg/hub/budget_health.go
@@ -30,6 +30,28 @@ func budgetHealthFor(e RegistryEntry) BudgetHealth {
 	if e.BudgetIgnored != nil && *e.BudgetIgnored {
 		return BudgetHealth{Bucket: budgetBucketUnknown, Ignored: true}
 	}
+	// The governor's exhausted flag is authoritative even when the numeric
+	// spend/limit pair is absent or zero: a spoke that reports "budget
+	// reached" without usable numbers (e.g. limit reset to 0 at the window
+	// boundary, or an older heartbeat shape) must show EXHAUSTED, not a gray
+	// "n/a" — a depleted budget rendered as unknown hides the exact condition
+	// the badge exists to surface.
+	if e.BudgetExhausted != nil && *e.BudgetExhausted {
+		out := BudgetHealth{Bucket: budgetBucketExhausted, Exhausted: true,
+			WindowStartsAt: formatOptionalTime(e.BudgetWindowStartsAt),
+			WindowEndsAt:   formatOptionalTime(e.BudgetWindowEndsAt),
+		}
+		if e.BudgetCurrentSpend != nil && e.BudgetLimit != nil && *e.BudgetLimit > 0 {
+			used := *e.BudgetCurrentSpend
+			if used < 0 {
+				used = 0
+			}
+			out.UsedTokens = used
+			out.LimitTokens = *e.BudgetLimit
+			out.PercentUsed = float64(used) * float64(percentDenominator) / float64(*e.BudgetLimit)
+		}
+		return out
+	}
 	if e.BudgetCurrentSpend == nil || e.BudgetLimit == nil || *e.BudgetLimit <= 0 {
 		return BudgetHealth{Bucket: budgetBucketUnknown}
 	}
@@ -45,11 +67,6 @@ func budgetHealthFor(e RegistryEntry) BudgetHealth {
 		Bucket:         budgetBucketOK,
 		WindowStartsAt: formatOptionalTime(e.BudgetWindowStartsAt),
 		WindowEndsAt:   formatOptionalTime(e.BudgetWindowEndsAt),
-	}
-	if e.BudgetExhausted != nil && *e.BudgetExhausted {
-		out.Bucket = budgetBucketExhausted
-		out.Exhausted = true
-		return out
 	}
 	if used*percentDenominator >= limit*budgetExhaustedPercent {
 		out.Bucket = budgetBucketExhausted

--- a/src/pkg/hub/budget_health_test.go
+++ b/src/pkg/hub/budget_health_test.go
@@ -37,6 +37,28 @@ func TestBudgetHealthBuckets(t *testing.T) {
 	}
 }
 
+func TestBudgetHealthExhaustedFlagWinsWithoutNumbers(t *testing.T) {
+	// The governor's exhausted flag is authoritative even when the numeric
+	// spend/limit pair is absent or zeroed (window boundary, older heartbeat
+	// shape): a depleted budget must show EXHAUSTED, never a gray unknown.
+	cases := []RegistryEntry{
+		{BudgetExhausted: boolptr(true)},
+		{BudgetExhausted: boolptr(true), BudgetLimit: int64ptr(0)},
+		{BudgetExhausted: boolptr(true), BudgetCurrentSpend: int64ptr(0), BudgetLimit: int64ptr(0)},
+	}
+	for _, e := range cases {
+		got := budgetHealthFor(e)
+		if got.Bucket != budgetBucketExhausted || !got.Exhausted {
+			t.Fatalf("budgetHealthFor(%+v) = %+v, want exhausted", e, got)
+		}
+	}
+	// But ignored still wins over exhausted.
+	got := budgetHealthFor(RegistryEntry{BudgetExhausted: boolptr(true), BudgetIgnored: boolptr(true)})
+	if got.Bucket != budgetBucketUnknown || !got.Ignored {
+		t.Fatalf("ignored+exhausted = %+v, want unknown ignored", got)
+	}
+}
+
 func TestBudgetHealthUnknownWithoutConfiguredBudget(t *testing.T) {
 	cases := []RegistryEntry{
 		{},


### PR DESCRIPTION
Two fleet-page misclassifications reported from live fleet review:

**1. "PROBLEM: no write capability at this ACMM level" on advisory-only hives.** Agents whose ACMM level grants no GitHub writes (L1/L2) were red/impotent/problem — every working advisory agent on a low-maturity hive read as broken (screenshot: certus + headwaters rows, 3 PROBLEMS each, all of this kind). The capability ceiling is the operator's chosen level working as designed; the agent's mission at that level is the advisory digest. Now: green, able, no blocked reason, no problem. Real blockers (login prompt, hive-level) still classify as before.

**2. Exhausted budget showed gray "budget n/a".** `budgetHealthFor` hit the numeric nil-guard before the governor's exhausted flag, so "budget reached" without usable numbers rendered unknown. The exhausted flag now wins before the guard; `ignored` still wins over both.

Tests updated + new table cases. Full `go test ./pkg/hub` green (128s).