### PR TITLE
✨ Surface GitHub App health on fleet page

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -605,6 +605,24 @@ func describeKeySource(v string) string {
 	return v
 }
 
+func githubAppTokenHeartbeatFields(cfg *config.Config, detail string) (status, lastMintAt, lastErr string) {
+	if cfg == nil || !cfg.GitHub.HasApp() {
+		return "", "", ""
+	}
+	info, err := os.Stat(github.TokenCachePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return hub.GitHubAppTokenStatusMissing, "", detail
+		}
+		return hub.GitHubAppTokenStatusError, "", err.Error()
+	}
+	lastMintAt = info.ModTime().UTC().Format(time.RFC3339)
+	if time.Since(info.ModTime()) > hub.GitHubAppTokenStaleAfter {
+		return hub.GitHubAppTokenStatusStale, lastMintAt, detail
+	}
+	return hub.GitHubAppTokenStatusOK, lastMintAt, ""
+}
+
 // githubAuth is the outcome of resolving this hive's GitHub credentials at
 // startup. Every field is optional: a hive with no usable credentials is a
 // legitimate, bootable state.
@@ -3636,10 +3654,22 @@ func main() {
 				// base_url and api_url — a GHE placeholder with base_url:"" but
 				// api_url: github.ibm.com must report github.ibm.com, not be
 				// silently rendered as github.com in the spokes table.
-				GitHubHost:              cfg.GitHub.HostLabel(),
-				GitHubAppRequired:       dashSrv.IsGitHubAppRequired(),
-				GitHubAppPermIssue:      dashSrv.GetGitHubAppPermIssue(),
-				GitHubAppState:          dashSrv.GetGitHubAppState(),
+				GitHubHost:         cfg.GitHub.HostLabel(),
+				GitHubAppRequired:  dashSrv.IsGitHubAppRequired(),
+				GitHubAppPermIssue: dashSrv.GetGitHubAppPermIssue(),
+				GitHubAppState:     dashSrv.GetGitHubAppState(),
+				GitHubAppTokenStatus: func() string {
+					status, _, _ := githubAppTokenHeartbeatFields(cfg, dashSrv.GetGitHubAppPermIssue())
+					return status
+				}(),
+				GitHubAppTokenLastMintAt: func() string {
+					_, lastMintAt, _ := githubAppTokenHeartbeatFields(cfg, dashSrv.GetGitHubAppPermIssue())
+					return lastMintAt
+				}(),
+				GitHubAppTokenError: func() string {
+					_, _, errMsg := githubAppTokenHeartbeatFields(cfg, dashSrv.GetGitHubAppPermIssue())
+					return errMsg
+				}(),
 				PendingGitHubAppInstall: dashSrv.IsPendingGitHubAppInstall(),
 				AutoUpgrade:             cfg.Hub.AutoUpgrade,
 				ClusterHealth: func() *hub.HeartbeatClusterHealthReport {

--- a/src/pkg/hub/advisory_issue_activity_test.go
+++ b/src/pkg/hub/advisory_issue_activity_test.go
@@ -119,6 +119,7 @@ func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
 			ID                    string                `json:"id"`
 			AdvisoryIssueActivity AdvisoryIssueActivity `json:"advisoryIssueActivity"`
 			BudgetHealth          BudgetHealth          `json:"budgetHealth"`
+			GitHubAppHealth       GitHubAppHealth       `json:"githubAppHealth"`
 		} `json:"hives"`
 		Summary map[string]int `json:"hives_summary"`
 	}
@@ -127,9 +128,11 @@ func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
 	}
 	byID := map[string]AdvisoryIssueActivity{}
 	budgetByID := map[string]BudgetHealth{}
+	ghAppByID := map[string]GitHubAppHealth{}
 	for _, h := range resp.Hives {
 		byID[h.ID] = h.AdvisoryIssueActivity
 		budgetByID[h.ID] = h.BudgetHealth
+		ghAppByID[h.ID] = h.GitHubAppHealth
 	}
 	if byID["h1"].Bucket != advisoryIssueBucketStale || byID["h1"].LastActivityAt == "" {
 		t.Fatalf("h1 activity = %+v, want stale with timestamp", byID["h1"])
@@ -148,5 +151,11 @@ func TestHandleMyHivesIncludesAdvisoryIssueActivity(t *testing.T) {
 	}
 	if resp.Summary["budget_warning"] != 1 || resp.Summary["budget_unknown"] != 1 {
 		t.Fatalf("summary = %#v, want budget_warning=1 budget_unknown=1", resp.Summary)
+	}
+	if ghAppByID["h1"].Bucket != ghAppBucketUnknown || ghAppByID["hosted-empty"].Bucket != ghAppBucketUnknown {
+		t.Fatalf("github app health = %#v, want unknown/n/a for rows without token signal", ghAppByID)
+	}
+	if resp.Summary["github_app_unknown"] != 2 {
+		t.Fatalf("summary = %#v, want github_app_unknown=2", resp.Summary)
 	}
 }

--- a/src/pkg/hub/github_app_health.go
+++ b/src/pkg/hub/github_app_health.go
@@ -1,0 +1,123 @@
+package hub
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const (
+	ghAppBucketOK       = "ok"
+	ghAppBucketDegraded = "degraded"
+	ghAppBucketBroken   = "broken"
+	ghAppBucketUnknown  = "unknown"
+
+	GitHubAppTokenStatusOK      = "ok"
+	GitHubAppTokenStatusStale   = "stale"
+	GitHubAppTokenStatusMissing = "missing"
+	GitHubAppTokenStatusError   = "error"
+
+	// GitHub App installation tokens expire after one hour. The spoke refreshes
+	// them before expiry, so a cache minted more than 45 minutes ago means the
+	// refresh path is already lagging and should be amber before agents hit 401s.
+	GitHubAppTokenStaleAfter = 45 * time.Minute
+)
+
+type GitHubAppHealth struct {
+	Bucket          string `json:"bucket"`
+	Status          string `json:"status,omitempty"`
+	LastTokenMintAt string `json:"lastTokenMintAt,omitempty"`
+	Detail          string `json:"detail,omitempty"`
+}
+
+func githubAppHealthFor(e RegistryEntry, now time.Time) GitHubAppHealth {
+	out := GitHubAppHealth{
+		Bucket:          ghAppBucketUnknown,
+		Status:          strings.TrimSpace(e.GitHubAppTokenStatus),
+		LastTokenMintAt: strings.TrimSpace(e.GitHubAppTokenLastMintAt),
+		Detail:          strings.TrimSpace(e.GitHubAppTokenError),
+	}
+	if out.Detail == "" {
+		out.Detail = githubAuthHealthDetail(e.Health)
+	}
+	if e.GitHubAppPermIssue != "" {
+		out.Detail = e.GitHubAppPermIssue
+	}
+
+	state := strings.TrimSpace(e.GitHubAppState)
+	switch {
+	case e.GitHubAppRequired || (state != "" && state != GitHubAppTokenStatusOK && state != "unknown"):
+		out.Bucket = ghAppBucketBroken
+		if out.Status == "" {
+			out.Status = state
+		}
+		return out
+	}
+
+	switch out.Status {
+	case GitHubAppTokenStatusOK:
+		out.Bucket = ghAppBucketOK
+	case GitHubAppTokenStatusStale:
+		out.Bucket = ghAppBucketDegraded
+	case GitHubAppTokenStatusMissing, GitHubAppTokenStatusError:
+		out.Bucket = ghAppBucketBroken
+	case "":
+		if state == GitHubAppTokenStatusOK {
+			out.Bucket = ghAppBucketOK
+			out.Status = GitHubAppTokenStatusOK
+		}
+	default:
+		out.Bucket = ghAppBucketUnknown
+	}
+
+	if out.Bucket == ghAppBucketOK && out.LastTokenMintAt != "" {
+		if t, err := time.Parse(time.RFC3339, out.LastTokenMintAt); err == nil && now.Sub(t) > GitHubAppTokenStaleAfter {
+			out.Bucket = ghAppBucketDegraded
+			out.Status = GitHubAppTokenStatusStale
+		}
+	}
+	return out
+}
+
+func githubAuthHealthDetail(health map[string]any) string {
+	checks, ok := health["checks"]
+	if !ok {
+		return ""
+	}
+	v := reflect.ValueOf(checks)
+	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
+		return ""
+	}
+	for i := 0; i < v.Len(); i++ {
+		item := v.Index(i).Interface()
+		if name, status, detail := healthCheckFields(item); name == "github_auth" && status == "fail" {
+			return detail
+		}
+	}
+	return ""
+}
+
+func healthCheckFields(item any) (name, status, detail string) {
+	if m, ok := item.(map[string]any); ok {
+		if m["detail"] == nil {
+			return fmt.Sprint(m["name"]), fmt.Sprint(m["status"]), ""
+		}
+		return fmt.Sprint(m["name"]), fmt.Sprint(m["status"]), fmt.Sprint(m["detail"])
+	}
+	v := reflect.ValueOf(item)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return "", "", ""
+	}
+	field := func(n string) string {
+		f := v.FieldByName(n)
+		if !f.IsValid() || f.Kind() != reflect.String {
+			return ""
+		}
+		return f.String()
+	}
+	return field("Name"), field("Status"), field("Detail")
+}

--- a/src/pkg/hub/github_app_health_test.go
+++ b/src/pkg/hub/github_app_health_test.go
@@ -1,0 +1,138 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGitHubAppHealthBuckets(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	stamp := func(age time.Duration) string { return now.Add(-age).Format(time.RFC3339) }
+	cases := []struct {
+		name string
+		in   RegistryEntry
+		want string
+	}{
+		{
+			name: "ok token cache",
+			in: RegistryEntry{
+				GitHubAppTokenStatus:     GitHubAppTokenStatusOK,
+				GitHubAppTokenLastMintAt: stamp(time.Minute),
+			},
+			want: ghAppBucketOK,
+		},
+		{
+			name: "ok status with old mint is degraded",
+			in: RegistryEntry{
+				GitHubAppTokenStatus:     GitHubAppTokenStatusOK,
+				GitHubAppTokenLastMintAt: stamp(GitHubAppTokenStaleAfter + time.Second),
+			},
+			want: ghAppBucketDegraded,
+		},
+		{
+			name: "explicit stale token cache",
+			in:   RegistryEntry{GitHubAppTokenStatus: GitHubAppTokenStatusStale},
+			want: ghAppBucketDegraded,
+		},
+		{
+			name: "missing token cache is broken",
+			in:   RegistryEntry{GitHubAppTokenStatus: GitHubAppTokenStatusMissing},
+			want: ghAppBucketBroken,
+		},
+		{
+			name: "token error is broken",
+			in:   RegistryEntry{GitHubAppTokenStatus: GitHubAppTokenStatusError},
+			want: ghAppBucketBroken,
+		},
+		{
+			name: "app required is broken",
+			in:   RegistryEntry{GitHubAppRequired: true, GitHubAppState: "not-installed"},
+			want: ghAppBucketBroken,
+		},
+		{
+			name: "app state ok is ok",
+			in:   RegistryEntry{GitHubAppState: GitHubAppTokenStatusOK},
+			want: ghAppBucketOK,
+		},
+		{
+			name: "unparseable mint time stays ok",
+			in: RegistryEntry{
+				GitHubAppTokenStatus:     GitHubAppTokenStatusOK,
+				GitHubAppTokenLastMintAt: "not-a-time",
+			},
+			want: ghAppBucketOK,
+		},
+		{
+			name: "no signal is unknown",
+			in:   RegistryEntry{},
+			want: ghAppBucketUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := githubAppHealthFor(tc.in, now)
+			if got.Bucket != tc.want {
+				t.Fatalf("bucket = %q, want %q (health=%+v)", got.Bucket, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestGitHubAppHealthDetail(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	type healthCheck struct {
+		Name   string
+		Status string
+		Detail string
+	}
+	cases := []struct {
+		name string
+		in   RegistryEntry
+		want string
+	}{
+		{
+			name: "perm issue wins",
+			in: RegistryEntry{
+				GitHubAppRequired:   true,
+				GitHubAppPermIssue:  "install expired",
+				GitHubAppTokenError: "cache missing",
+			},
+			want: "install expired",
+		},
+		{
+			name: "token error detail",
+			in:   RegistryEntry{GitHubAppTokenStatus: GitHubAppTokenStatusError, GitHubAppTokenError: "connection refused"},
+			want: "connection refused",
+		},
+		{
+			name: "map health detail",
+			in: RegistryEntry{Health: map[string]any{"checks": []any{
+				map[string]any{"name": "ready", "status": "pass"},
+				map[string]any{"name": "github_auth", "status": "fail", "detail": "token error"},
+			}}},
+			want: "token error",
+		},
+		{
+			name: "struct health detail",
+			in: RegistryEntry{Health: map[string]any{"checks": []healthCheck{
+				{Name: "github_auth", Status: "fail", Detail: "no auth"},
+			}}},
+			want: "no auth",
+		},
+		{
+			name: "non failing health ignored",
+			in: RegistryEntry{Health: map[string]any{"checks": []any{
+				map[string]any{"name": "github_auth", "status": "pass", "detail": "ok"},
+			}}},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := githubAppHealthFor(tc.in, now)
+			if got.Detail != tc.want {
+				t.Fatalf("detail = %q, want %q (health=%+v)", got.Detail, tc.want, got)
+			}
+		})
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -651,6 +651,12 @@ type HeartbeatPayload struct {
 	Timestamp          string `json:"timestamp"`
 	GitHubAppRequired  bool   `json:"github_app_required,omitempty"`
 	GitHubAppPermIssue string `json:"github_app_perm_issue,omitempty"`
+	// GitHubAppTokenStatus is the spoke's local view of the shared App token
+	// cache used by GitHub writers ("ok", "stale", "missing", "error").
+	// LastMintAt is the cache file mtime and Error is a log-safe detail.
+	GitHubAppTokenStatus     string `json:"github_app_token_status,omitempty"`
+	GitHubAppTokenLastMintAt string `json:"github_app_token_last_mint_at,omitempty"`
+	GitHubAppTokenError      string `json:"github_app_token_error,omitempty"`
 	// RepoTargetMisconfigured carries an operator-facing config-shape issue
 	// detected by the spoke. It is visibility only: the spoke keeps running and
 	// the hub does not rewrite the project fields.

--- a/src/pkg/hub/my_hives_query.go
+++ b/src/pkg/hub/my_hives_query.go
@@ -216,6 +216,16 @@ func myHivesSummary(entries []MyHiveEntry) map[string]int {
 		default:
 			s["budget_unknown"]++
 		}
+		switch e.GitHubAppHealth.Bucket {
+		case ghAppBucketOK:
+			s["github_app_ok"]++
+		case ghAppBucketDegraded:
+			s["github_app_degraded"]++
+		case ghAppBucketBroken:
+			s["github_app_broken"]++
+		default:
+			s["github_app_unknown"]++
+		}
 	}
 	return s
 }

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2878,6 +2878,11 @@ type MyHiveEntry struct {
 	// the UI can explain the dot without reverse-engineering RegistryEntry.
 	BudgetHealth BudgetHealth `json:"budgetHealth"`
 
+	// GitHubAppHealth is this hive's GitHub App token/auth health for the fleet
+	// row, bucketed server-side so every consumer shares the same thresholds and
+	// problem semantics.
+	GitHubAppHealth GitHubAppHealth `json:"githubAppHealth"`
+
 	// AdvisoryStale is true when this hive SHOULD be posting advisory digests
 	// but its digest has quietly gone stale — computed on read by advisoryStale()
 	// so the browser never re-derives the threshold or the gating (advisory-mode
@@ -3360,6 +3365,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		result[i].Journey = &status
 		result[i].AdvisoryIssueActivity = advisoryIssueActivityFor(result[i].RegistryEntry, journeyNow)
 		result[i].BudgetHealth = budgetHealthFor(result[i].RegistryEntry)
+		result[i].GitHubAppHealth = githubAppHealthFor(result[i].RegistryEntry, journeyNow)
 
 		// Advisory-staleness pill, computed on read (same as Journey) so the
 		// gating — advisory-mode participation, app-can-write, past-threshold —

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -246,14 +246,17 @@ type RegistryEntry struct {
 	// re-armed forever, which looks like progress but never is. Past
 	// maxOrphanedUpgradeSweeps the hub stops retrying and records a failure a
 	// human can see. Reset whenever the hive reaches a target.
-	OrphanedUpgradeSweeps   int          `json:"orphanedUpgradeSweeps,omitempty"`
-	IssueHistory            []SparkPoint `json:"issueHistory,omitempty"`
-	PRHistory               []SparkPoint `json:"prHistory,omitempty"`
-	GitHubAppRequired       bool         `json:"githubAppRequired,omitempty"`
-	GitHubAppPermIssue      string       `json:"githubAppPermIssue,omitempty"`
-	GitHubAppState          string       `json:"githubAppState,omitempty"`
-	RepoTargetMisconfigured bool         `json:"repoTargetMisconfigured,omitempty"`
-	RepoTargetIssue         string       `json:"repoTargetIssue,omitempty"`
+	OrphanedUpgradeSweeps    int          `json:"orphanedUpgradeSweeps,omitempty"`
+	IssueHistory             []SparkPoint `json:"issueHistory,omitempty"`
+	PRHistory                []SparkPoint `json:"prHistory,omitempty"`
+	GitHubAppRequired        bool         `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue       string       `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState           string       `json:"githubAppState,omitempty"`
+	GitHubAppTokenStatus     string       `json:"githubAppTokenStatus,omitempty"`
+	GitHubAppTokenLastMintAt string       `json:"githubAppTokenLastMintAt,omitempty"`
+	GitHubAppTokenError      string       `json:"githubAppTokenError,omitempty"`
+	RepoTargetMisconfigured  bool         `json:"repoTargetMisconfigured,omitempty"`
+	RepoTargetIssue          string       `json:"repoTargetIssue,omitempty"`
 	// ConflictingReporters names two spoke instances that are BOTH reporting
 	// as this hive (e.g. "hive-abc… ↔ hive-def…"), set when their beats
 	// alternate. Non-empty is a critical drift signal: every field in this
@@ -1747,17 +1750,20 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// verbatim ("The GitHub App is configured but has no installation.
 		// Install the app on your org to enable agents.") — the strict
 		// identifier sanitizer stripped every space out of it.
-		GitHubAppPermIssue:      sanitizeProseField(payload.GitHubAppPermIssue),
-		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
-		RepoTargetMisconfigured: payload.RepoTargetMisconfigured,
-		RepoTargetIssue:         sanitizeProseField(payload.RepoTargetIssue),
-		StatusFlipping:          s.noteStatusFlip(payload.HiveID, sanitizeHeartbeatField(payload.GitHubAppState)),
-		GitHubAppID:             payload.GitHubAppID,
-		GitHubAppSlug:           payload.GitHubAppSlug,
-		GitHubInstallationID:    payload.GitHubInstallationID,
-		GitHubAPIURL:            payload.GitHubAPIURL,
-		GitHubBaseURL:           payload.GitHubBaseURL,
-		PendingGitHubAppInstall: payload.PendingGitHubAppInstall,
+		GitHubAppPermIssue:       sanitizeProseField(payload.GitHubAppPermIssue),
+		GitHubAppState:           sanitizeHeartbeatField(payload.GitHubAppState),
+		GitHubAppTokenStatus:     sanitizeHeartbeatField(payload.GitHubAppTokenStatus),
+		GitHubAppTokenLastMintAt: sanitizeField(payload.GitHubAppTokenLastMintAt),
+		GitHubAppTokenError:      sanitizeProseField(payload.GitHubAppTokenError),
+		RepoTargetMisconfigured:  payload.RepoTargetMisconfigured,
+		RepoTargetIssue:          sanitizeProseField(payload.RepoTargetIssue),
+		StatusFlipping:           s.noteStatusFlip(payload.HiveID, sanitizeHeartbeatField(payload.GitHubAppState)),
+		GitHubAppID:              payload.GitHubAppID,
+		GitHubAppSlug:            payload.GitHubAppSlug,
+		GitHubInstallationID:     payload.GitHubInstallationID,
+		GitHubAPIURL:             payload.GitHubAPIURL,
+		GitHubBaseURL:            payload.GitHubBaseURL,
+		PendingGitHubAppInstall:  payload.PendingGitHubAppInstall,
 		PendingGitHubAppInstallAt: func() time.Time {
 			if payload.PendingGitHubAppInstall {
 				return time.Now()

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -131,6 +131,12 @@
   .budget-health.warning .light { background: var(--amber); }
   .budget-health.critical .light, .budget-health.exhausted .light { background: var(--red); box-shadow: 0 0 0 3px rgba(229,72,77,.18); }
   .budget-health.unknown .light { background: var(--gray); }
+  .github-app-health { display: inline-flex; align-items: flex-start; gap: 5px; margin-top: 3px; }
+  .github-app-health .light { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 8px; margin-top: 3px; }
+  .github-app-health.ok .light { background: var(--green); }
+  .github-app-health.degraded .light { background: var(--amber); }
+  .github-app-health.broken .light { background: var(--red); box-shadow: 0 0 0 3px rgba(229,72,77,.18); }
+  .github-app-health.unknown .light { background: var(--gray); }
   .status-msg { padding: 40px 0; text-align: center; color: var(--muted); }
   a.reload { color: var(--accent); text-decoration: none; }
   [title] { cursor: help; }
@@ -181,7 +187,7 @@
 </header>
 <header class="fleet-header">
   <h1>Fleet health</h1>
-  <span class="sub">a hive is a <b>problem</b> when agents cannot work, output is stale, or budget is depleted</span>
+  <span class="sub">a hive is a <b>problem</b> when agents cannot work, output is stale, budget is depleted, or GitHub App auth is broken</span>
   <span id="summary" class="summary"></span>
   <span class="controls">
     <label><input type="checkbox" id="problemsOnly"> problems only</label>
@@ -205,6 +211,15 @@
         <option value="ok">ok</option>
       </select>
     </label>
+    <label>gh app
+      <select id="githubAppFilter">
+        <option value="">all</option>
+        <option value="broken">broken</option>
+        <option value="degraded">degraded/stale</option>
+        <option value="unknown">unknown/n/a</option>
+        <option value="ok">ok</option>
+      </select>
+    </label>
   </span>
 </header>
 <div class="wrap">
@@ -212,7 +227,8 @@
     <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting)</span>
     <span><b>advisory output:</b> <span class="advisory-activity fresh"><span class="light"></span>fresh</span> · <span class="advisory-activity aging"><span class="light"></span>aging</span> · <span class="advisory-activity stale"><span class="light"></span>stale</span> · <span class="advisory-activity unknown"><span class="light"></span>n/a</span></span>
     <span><b>budget:</b> <span class="budget-health ok"><span class="light"></span>ok</span> · <span class="budget-health warning"><span class="light"></span>warning</span> · <span class="budget-health critical"><span class="light"></span>critical</span> · <span class="budget-health exhausted"><span class="light"></span>exhausted</span> · <span class="budget-health unknown"><span class="light"></span>n/a</span></span>
-    <span><span class="delta problem">PROBLEM</span> agents cannot work, output is stale, or budget is depleted · <span class="delta quiet">quiet</span> paused / off by schedule</span>
+    <span><b>gh app:</b> <span class="github-app-health ok"><span class="light"></span>ok</span> · <span class="github-app-health degraded"><span class="light"></span>stale</span> · <span class="github-app-health broken"><span class="light"></span>broken</span> · <span class="github-app-health unknown"><span class="light"></span>n/a</span></span>
+    <span><span class="delta problem">PROBLEM</span> agents cannot work, output is stale, budget is depleted, or GitHub App auth is broken · <span class="delta quiet">quiet</span> paused / off by schedule</span>
     <span><b>capability:</b> <span style="color:var(--green)">green</span> able · <span style="color:var(--amber)">amber</span> partial · <span style="color:var(--red)">red</span> blocked · <span style="color:var(--gray)">gray</span> unknown</span>
   </div>
   <table>
@@ -296,6 +312,16 @@ function budgetHealthHTML(b) {
   return '<span class="budget-health ' + esc(bucket) + '" title="' + esc(title) + '">' +
     '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
 }
+function githubAppHealthHTML(g) {
+  g = g || {};
+  var bucket = g.bucket || "unknown";
+  var rel = g.lastTokenMintAt ? relTime(g.lastTokenMintAt) : "n/a";
+  var label = bucket === "unknown" ? "gh app n/a" : "gh app " + (bucket === "degraded" ? "stale" : bucket);
+  if (g.lastTokenMintAt) label += " · " + rel;
+  var title = g.detail || (g.lastTokenMintAt ? "last token mint " + rel : label);
+  return '<span class="github-app-health ' + esc(bucket) + '" title="' + esc(title) + '">' +
+    '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
+}
 function versionHTML(h) {
   var sha = h.gitHash || "";
   if (!sha) return '<span class="output">—</span>';
@@ -369,6 +395,7 @@ function deltaHTML(a) {
 // every agent stuck.
 function hiveHealth(h) {
   if (((h.advisoryIssueActivity || {}).bucket || "") === "stale") return "problem";
+  if (((h.githubAppHealth || {}).bucket || "") === "broken") return "problem";
   var budget = ((h.budgetHealth || {}).bucket || "");
   if (budget === "critical" || budget === "exhausted") return "problem";
   var r = h.fleetRollup;
@@ -387,6 +414,7 @@ var problemsOnly = false;
 var showHealthy = false; // when false, healthy hives are hidden to cut noise
 var advisoryFilter = "";
 var budgetFilter = "";
+var githubAppFilter = "";
 
 function hiveKey(h) { return h.id || h.name; }
 
@@ -413,6 +441,7 @@ function renderHives(hives) {
     if (!problemsOnly && !showHealthy && health === "ok") return;
     if (advisoryFilter && ((h.advisoryIssueActivity || {}).bucket || "unknown") !== advisoryFilter) return;
     if (budgetFilter && ((h.budgetHealth || {}).bucket || "unknown") !== budgetFilter) return;
+    if (githubAppFilter && ((h.githubAppHealth || {}).bucket || "unknown") !== githubAppFilter) return;
     shown++;
 
     var isProblem = health === "problem";
@@ -431,7 +460,7 @@ function renderHives(hives) {
       '<td>' + modeBadge(h.governorMode) + '</td>' +
       '<td>' + versionHTML(h) + '</td>' +
       '<td>' + rollupHTML(h.fleetRollup) + '</td>' +
-      '<td>' + outputHTML(h) + '<br>' + budgetHealthHTML(h.budgetHealth) + '</td>';
+      '<td>' + outputHTML(h) + '<br>' + budgetHealthHTML(h.budgetHealth) + '<br>' + githubAppHealthHTML(h.githubAppHealth) + '</td>';
     tb.appendChild(tr);
 
     var verdicts = h.agentVerdicts || [];
@@ -497,6 +526,8 @@ function wireControls() {
   if (af) af.addEventListener("change", function () { advisoryFilter = af.value; renderHives(lastHives); });
   var bf = document.getElementById("budgetFilter");
   if (bf) bf.addEventListener("change", function () { budgetFilter = bf.value; renderHives(lastHives); });
+  var gf = document.getElementById("githubAppFilter");
+  if (gf) gf.addEventListener("change", function () { githubAppFilter = gf.value; renderHives(lastHives); });
 }
 
 var lastHives = [];


### PR DESCRIPTION
## Summary
- add spoke heartbeat fields for GitHub App token cache status, last mint time, and error detail
- bucket GitHub App health hub-side and expose it in /api/saas/my-hives
- render gh app row indicators, legend, problem classification, and filter on /fleet

## Validation
- cd src && go build ./...
- cd src && go vet ./...
- cd src && go test ./pkg/hub ./pkg/dashboard ./cmd/hive