### PR TITLE
🌱 retire v3 from hub image branch list

### DIFF
--- a/src/pkg/hub/hub_filesystem_test.go
+++ b/src/pkg/hub/hub_filesystem_test.go
@@ -1561,9 +1561,9 @@ func TestPersistAndLoadLatestSHAs(t *testing.T) {
 	savedBranches := latestSHAByBranch
 	savedMsgs := commitMsgBySHA
 	latestSHAByBranch = map[string]branchSHAInfo{
-		"v2":         {SHA: "aaa1111", Message: "v2 commit"},
-		"v3":         {SHA: "bbb2222", Message: "v3 commit"},
-		"old-branch": {SHA: "ccc3333", Message: "untracked commit"},
+		"v2":          {SHA: "aaa1111", Message: "v2 commit"},
+		"live-branch": {SHA: "bbb2222", Message: "live branch commit"},
+		"old-branch":  {SHA: "ccc3333", Message: "untracked commit"},
 	}
 	commitMsgBySHA = map[string]string{}
 	latestSHAMu.Unlock()
@@ -1579,21 +1579,22 @@ func TestPersistAndLoadLatestSHAs(t *testing.T) {
 		t.Fatalf("persistLatestSHAs did not write %s: %v", latestSHAsPath, err)
 	}
 
-	// Simulate a hub restart with a partially failed initial fetch: only v3
+	// Simulate a hub restart with a partially failed initial fetch: only live-branch
 	// was fetched live; v2's fetch was rate-limited so its entry is missing.
+	trackedForTest := []string{"v2", "live-branch"}
 	latestSHAMu.Lock()
 	latestSHAByBranch = map[string]branchSHAInfo{
-		"v3": {SHA: "ddd4444", Message: "newer v3 commit"},
+		"live-branch": {SHA: "ddd4444", Message: "newer live branch commit"},
 	}
 	latestSHAMu.Unlock()
 
-	loadPersistedSHAs(slog.Default(), trackedBranches)
+	loadPersistedSHAs(slog.Default(), trackedForTest)
 
 	if got := getLatestSHAForBranch("v2"); got != "aaa1111" {
 		t.Errorf("v2 SHA not restored from disk: got %q, want aaa1111", got)
 	}
-	if got := getLatestSHAForBranch("v3"); got != "ddd4444" {
-		t.Errorf("live v3 SHA was overwritten by persisted value: got %q, want ddd4444", got)
+	if got := getLatestSHAForBranch("live-branch"); got != "ddd4444" {
+		t.Errorf("live branch SHA was overwritten by persisted value: got %q, want ddd4444", got)
 	}
 	if got := getLatestSHAForBranch("old-branch"); got != "" {
 		t.Errorf("untracked branch restored from disk: got %q, want empty", got)
@@ -1610,7 +1611,7 @@ func TestPersistAndLoadLatestSHAs(t *testing.T) {
 	latestSHAByBranch = map[string]branchSHAInfo{}
 	latestSHAMu.Unlock()
 	persistLatestSHAs(slog.Default())
-	loadPersistedSHAs(slog.Default(), trackedBranches)
+	loadPersistedSHAs(slog.Default(), trackedForTest)
 	if got := getLatestSHAForBranch("v2"); got != "aaa1111" {
 		t.Errorf("empty persist clobbered file: v2 = %q, want aaa1111", got)
 	}
@@ -1622,9 +1623,43 @@ func TestPersistAndLoadLatestSHAs(t *testing.T) {
 	latestSHAMu.Lock()
 	latestSHAByBranch = map[string]branchSHAInfo{}
 	latestSHAMu.Unlock()
-	loadPersistedSHAs(slog.Default(), trackedBranches)
+	loadPersistedSHAs(slog.Default(), trackedForTest)
 	if got := getLatestSHAForBranch("v2"); got != "" {
 		t.Errorf("corrupt file should restore nothing, got v2 = %q", got)
+	}
+}
+
+func TestRetiredV3IsNotAlwaysTracked(t *testing.T) {
+	for _, branch := range trackedBranches {
+		if branch == "v3" {
+			t.Fatal("retired v3 branch must not be in the always-tracked hub image list")
+		}
+	}
+}
+
+func TestTrackedBranchListFiltersRetiredV3(t *testing.T) {
+	imageBranchMu.Lock()
+	savedCache := imageBranchCache
+	savedCachedAt := imageBranchCachedAt
+	imageBranchCache = []string{"v3", "mk"}
+	imageBranchCachedAt = time.Now()
+	imageBranchMu.Unlock()
+	defer func() {
+		imageBranchMu.Lock()
+		imageBranchCache = savedCache
+		imageBranchCachedAt = savedCachedAt
+		imageBranchMu.Unlock()
+	}()
+
+	s := &HubServer{registry: Registry{Hives: []RegistryEntry{
+		{GitBranch: "v3"},
+		{GitBranch: "v2"},
+	}}}
+	got := s.trackedBranchList()
+	for _, branch := range got {
+		if branch == "v3" {
+			t.Fatalf("trackedBranchList() = %v, includes retired v3", got)
+		}
 	}
 }
 

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -4983,10 +4983,15 @@ var (
 	commitMsgBySHA = map[string]string{}
 )
 
-// trackedBranches lists the always-tracked branches that produce Docker
-// images via CI. Personal dev branches (e.g. mk) are tracked dynamically:
-// see HubServer.trackedBranchList.
-var trackedBranches = []string{"v2", "v3"}
+// trackedBranches lists the legacy always-tracked branches that still produce
+// Docker images via CI. Personal dev branches (e.g. mk) are tracked
+// dynamically: see HubServer.trackedBranchList. v3 is retired and must not be
+// offered solely because old image tags or persisted SHA cache entries linger.
+var trackedBranches = []string{"v2"}
+
+var retiredBranches = map[string]struct{}{
+	"v3": {},
+}
 
 // trackedBranchList returns the static CI branches plus every branch some
 // registered hive is assigned to, so a personal dev branch gets SHA polling,
@@ -4997,6 +5002,9 @@ func (s *HubServer) trackedBranchList() []string {
 	seen := make(map[string]bool, len(trackedBranches))
 	out := make([]string, 0, len(trackedBranches))
 	add := func(b string) {
+		if _, retired := retiredBranches[b]; retired {
+			return
+		}
 		if b != "" && !seen[b] {
 			seen[b] = true
 			out = append(out, b)
@@ -5032,7 +5040,7 @@ const imageBranchCacheTTL = 5 * time.Minute
 // ghcr.io/kubestellar/hive:<branch>-latest tags (cached). A tag with a '-'
 // that our sanitizer would have produced can't be reversed unambiguously, so
 // we only surface tags that round-trip: the tag minus the "-latest" suffix.
-// Slashless branches (v2, v3, mk) round-trip exactly; slashed branches
+// Slashless branches (v2, mk) round-trip exactly; slashed branches
 // (feat/x → feat-x-latest) surface as "feat-x", which is still a valid
 // switch target because switch-branch/branchToTag normalize both to the same
 // image tag.


### PR DESCRIPTION
## Summary
- remove retired v3 from the hub always-tracked image branch list
- filter v3 from dynamic branch discovery/registry-driven branch options
- update SHA-cache tests and add a v3 retirement guard

## Tests
- cd src && go test ./pkg/hub
- npm build/lint not applicable: no package.json at repo root