### PR TITLE
feat(agent): promote in-agent Copilot login to the durable token store

### DIFF
--- a/src/pkg/agent/copilot_session_refresh_test.go
+++ b/src/pkg/agent/copilot_session_refresh_test.go
@@ -142,16 +142,25 @@ func TestRefreshCopilotSessionToken(t *testing.T) {
 		t.Error("no held token: must not fabricate a credential")
 	}
 
-	// (d) Already-populated store → must NOT overwrite (no clobbering a live session).
+	// (d) Config already populated with a token the hive does NOT hold → the
+	// config token is PRESERVED (never clobbered) AND promoted to the durable
+	// store (bidirectional sync). Uses syncCopilotToken with a temp durable path
+	// so the promote write does not target the production /data path.
 	m4 := testManager(5)
 	m4.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
 	m4.copilotAuthToken = "ghu_held"
+	dur := filepath.Join(dir, "durable")
 	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{"github.com":{"token":"gho_cli_owned"}}}`), 0o660); err != nil {
 		t.Fatal(err)
 	}
-	m4.refreshCopilotSessionToken()
+	if act := m4.syncCopilotToken(path, dur); act != copilotSyncPromote {
+		t.Errorf("differing config token must promote, got action %v", act)
+	}
 	raw, _ := os.ReadFile(path)
 	if !strings.Contains(string(raw), "gho_cli_owned") {
-		t.Error("must not overwrite an already-present token")
+		t.Error("config token must not be overwritten by a promote")
+	}
+	if b, _ := os.ReadFile(dur); string(b) != "gho_cli_owned" {
+		t.Errorf("durable file = %q, want gho_cli_owned (promoted)", string(b))
 	}
 }

--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -1,0 +1,149 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// extractCopilotToken must handle both value shapes the CLI writes: a bare
+// string and a {"token":…} object; and return "" when there is none.
+func TestExtractCopilotToken(t *testing.T) {
+	dir := t.TempDir()
+	write := func(body string) string {
+		p := filepath.Join(dir, "config.json")
+		if err := os.WriteFile(p, []byte(copilotConfigHeader+body), 0o660); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// bare-string shape (in-agent /login on 1.0.78)
+	if got := extractCopilotToken(write(`{"copilotTokens":{"https://github.com:me":"gho_bare"}}`)); got != "gho_bare" {
+		t.Errorf("string shape: got %q, want gho_bare", got)
+	}
+	// object shape (restoreCopilotTokens / other CLI versions)
+	if got := extractCopilotToken(write(`{"copilotTokens":{"github.com":{"token":"gho_obj"}}}`)); got != "gho_obj" {
+		t.Errorf("object shape: got %q, want gho_obj", got)
+	}
+	// empty map
+	if got := extractCopilotToken(write(`{"copilotTokens":{}}`)); got != "" {
+		t.Errorf("empty map: got %q, want \"\"", got)
+	}
+	// missing file
+	if got := extractCopilotToken(filepath.Join(dir, "nope.json")); got != "" {
+		t.Errorf("missing file: got %q, want \"\"", got)
+	}
+}
+
+func TestWriteDurableCopilotToken(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "copilot-user-token")
+	if err := writeDurableCopilotToken(p, "ghu_dur"); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(p)
+	if string(b) != "ghu_dur" {
+		t.Errorf("durable file = %q, want ghu_dur", string(b))
+	}
+	// blank is a no-op (must not create/overwrite)
+	if err := writeDurableCopilotToken(p, "   "); err != nil {
+		t.Fatalf("blank should no-op, got %v", err)
+	}
+	b, _ = os.ReadFile(p)
+	if string(b) != "ghu_dur" {
+		t.Error("blank write must not overwrite an existing token")
+	}
+}
+
+// syncCopilotToken PROMOTE: a token in config but none held by the hive → the
+// token is mirrored to the durable file AND SetCopilotToken updates memory.
+// This is the "logged in inside the agent" case the operator hit.
+func TestSyncCopilotToken_Promote(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"copilotTokens":{"https://github.com:me":"gho_fromcli"}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	m := testManager(5)
+	m.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m.copilotAuthToken = "" // hive holds nothing (in-agent login bypassed the hive)
+
+	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncPromote {
+		t.Fatalf("action = %v, want promote", act)
+	}
+	b, _ := os.ReadFile(dur)
+	if string(b) != "gho_fromcli" {
+		t.Errorf("durable file = %q, want gho_fromcli (promoted from config)", string(b))
+	}
+	if m.CopilotToken() != "gho_fromcli" {
+		t.Errorf("in-memory token = %q, want gho_fromcli (SetCopilotToken)", m.CopilotToken())
+	}
+}
+
+// PROMOTE no-op when the hive already holds exactly the CLI's token.
+func TestSyncCopilotToken_PromoteNoopWhenAlreadyHeld(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"copilotTokens":{"github.com":{"token":"gho_same"}}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	m := testManager(5)
+	m.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m.copilotAuthToken = "gho_same"
+	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncNoop {
+		t.Fatalf("action = %v, want noop (already held)", act)
+	}
+	if _, err := os.Stat(dur); !os.IsNotExist(err) {
+		t.Error("durable file must not be written when nothing changed")
+	}
+}
+
+// SEED: config empty but hive holds a token → config re-populated (the #4494
+// direction still works through the merged path).
+func TestSyncCopilotToken_Seed(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"copilotTokens":{}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	m := testManager(5)
+	m.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m.copilotAuthToken = "ghu_held"
+	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncSeed {
+		t.Fatalf("action = %v, want seed", act)
+	}
+	if !copilotCredentialFileHasTokens(cfg) {
+		t.Error("config must be re-seeded")
+	}
+}
+
+// Both empty → noop (genuine logout; watchdog alert + manual login covers it).
+func TestSyncCopilotToken_BothEmptyNoop(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"copilotTokens":{}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	m := testManager(5)
+	m.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m.copilotAuthToken = ""
+	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncNoop {
+		t.Fatalf("action = %v, want noop", act)
+	}
+}
+
+// refreshCopilotSessionToken no-ops entirely without a copilot backend.
+func TestRefreshCopilotSessionToken_NoCopilotBackend(t *testing.T) {
+	m := testManager(5)
+	m.agents["a"] = &AgentProcess{Name: "a", Config: config.AgentConfig{Backend: "claude"}}
+	m.copilotAuthToken = "gho_held"
+	// Should return without panicking or touching the shared/durable paths.
+	m.refreshCopilotSessionToken()
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1019,33 +1019,81 @@ func (m *Manager) StartCopilotSessionRefresh(ctx context.Context) {
 	}
 }
 
-// refreshCopilotSessionToken seeds config.json's copilotTokens from the durable
-// user token when the map is empty on a copilot-backend hive. One tick's work;
-// safe to call from the timer or ad hoc.
+// refreshCopilotSessionToken keeps the Copilot credential in sync between the
+// CLI's config.json copilotTokens map and the hive's durable store, in BOTH
+// directions, on a copilot-backend hive. One tick's work; safe from the timer
+// or ad hoc.
+//
+//   - PROMOTE (config → durable): if the CLI has a token (someone logged in
+//     INSIDE an agent with /login) but the hive's in-memory/durable token is
+//     missing or stale, mirror the CLI's token to the durable file +
+//     SetCopilotToken. This makes an in-agent login as durable as a dashboard
+//     login — it survives rolls and arms the seed direction below — closing the
+//     gap where a local /login unstuck agents now but was lost on the next roll.
+//   - SEED (durable → config): if the CLI's map is EMPTY but the hive holds a
+//     token, restore it so the CLI is not left stuck at /login (the #4494 case).
+//
+// It never runs a device flow and never mints a token; it only mirrors a token
+// that already exists. The manual-login rule is intact.
 func (m *Manager) refreshCopilotSessionToken() {
 	if !m.backendInUse("copilot") {
 		return
 	}
-	// Already populated (the CLI's own token or a prior restore is in place):
-	// leave it alone so we never overwrite a live session.
-	if copilotConfigHasTokens() {
-		return
-	}
+	m.syncCopilotToken(sharedCopilotConfigPath, CopilotUserTokenPath)
+}
+
+// copilotSyncAction names what one syncCopilotToken call did, for logging and
+// deterministic tests.
+type copilotSyncAction int
+
+const (
+	copilotSyncNoop    copilotSyncAction = iota
+	copilotSyncPromote                   // config token mirrored to the durable store
+	copilotSyncSeed                      // durable token restored into an empty config
+)
+
+// syncCopilotToken reconciles the CLI's config.json copilotTokens map with the
+// hive's durable/in-memory token, in both directions. Parameterized on both
+// paths so it is testable without touching /data. See refreshCopilotSessionToken
+// for the promote/seed rationale.
+func (m *Manager) syncCopilotToken(configPath, durablePath string) copilotSyncAction {
 	m.mu.RLock()
-	token := m.copilotAuthToken
+	held := strings.TrimSpace(m.copilotAuthToken)
 	m.mu.RUnlock()
-	if strings.TrimSpace(token) == "" {
-		// No token to restore from — this is the genuinely-logged-out case the
-		// StartCredentialWatchdog alert covers; recovery is a manual login.
-		return
+
+	if copilotCredentialFileHasTokens(configPath) {
+		// PROMOTE: the CLI has a token; mirror it to the durable store unless the
+		// hive already holds exactly it.
+		cliTok := extractCopilotToken(configPath)
+		if cliTok == "" || cliTok == held {
+			return copilotSyncNoop
+		}
+		if err := writeDurableCopilotToken(durablePath, cliTok); err != nil {
+			m.logger.Warn("copilot session refresh: failed to promote CLI token to durable file",
+				"path", durablePath, "error", err)
+			return copilotSyncNoop
+		}
+		m.SetCopilotToken(cliTok)
+		m.logger.Info("copilot session refresh: promoted in-agent login token to the durable store",
+			"path", durablePath)
+		return copilotSyncPromote
 	}
-	if err := restoreCopilotTokens(sharedCopilotConfigPath, token); err != nil {
+
+	// SEED: the CLI map is empty; restore from the held token so agents are not
+	// left stuck at /login.
+	if held == "" {
+		// Genuinely logged out — the StartCredentialWatchdog alert covers this;
+		// recovery is a manual login.
+		return copilotSyncNoop
+	}
+	if err := restoreCopilotTokens(configPath, held); err != nil {
 		m.logger.Warn("copilot session refresh: failed to restore copilotTokens",
-			"path", sharedCopilotConfigPath, "error", err)
-		return
+			"path", configPath, "error", err)
+		return copilotSyncNoop
 	}
 	m.logger.Info("copilot session refresh: re-seeded empty copilotTokens from durable user token",
-		"path", sharedCopilotConfigPath)
+		"path", configPath)
+	return copilotSyncSeed
 }
 
 // evalCredentialWatch runs one backend's probe (only if that backend is in
@@ -5721,6 +5769,55 @@ func restoreCopilotTokens(path, token string) error {
 		"github.com": map[string]interface{}{"token": token},
 	}
 	return writeCopilotConfig(path, cfg)
+}
+
+// extractCopilotToken pulls the first usable token string out of a config.json
+// copilotTokens map, or "" when there is none. The Copilot CLI stores entries
+// in two shapes across versions/login routes — a bare string
+// ({"host:user":"gho_…"}) and an object ({"github.com":{"token":"gho_…"}}) —
+// and this accepts both. It is the inverse of restoreCopilotTokens: the reader
+// side of promoting a CLI-written token back to the hive's durable store.
+func extractCopilotToken(path string) string {
+	cfg, err := readCopilotConfig(path)
+	if err != nil {
+		return ""
+	}
+	tokens, ok := cfg["copilotTokens"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	for _, v := range tokens {
+		switch t := v.(type) {
+		case string:
+			if s := strings.TrimSpace(t); s != "" {
+				return s
+			}
+		case map[string]interface{}:
+			if s, ok := t["token"].(string); ok {
+				if s = strings.TrimSpace(s); s != "" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// writeDurableCopilotToken persists token to durablePath via a temp file +
+// rename, matching the dashboard login's saveCopilotToken write. The production
+// caller passes CopilotUserTokenPath — the file that survives upgrade rolls and
+// that the hive reads at boot into m.copilotAuthToken; the path is a parameter
+// so tests can target a temp file.
+func writeDurableCopilotToken(durablePath, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	tmp := durablePath + ".tmp"
+	if err := os.WriteFile(tmp, []byte(token), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, durablePath)
 }
 
 // cliReadyIndicators prove copilot finished startup.


### PR DESCRIPTION
Follow-up to #4494, answering the operator's question: **why doesn't a local `/login` inside an agent update the durable file?**

## Why the gap exists

The in-agent `/login` is run by the **upstream Copilot CLI**, which knows nothing about the hive's durable file (`/data/copilot-user-token`) or in-memory token — it only writes its own `config.json` `copilotTokens`. So logging in inside an agent unstuck agents *right now*, but the durable file (which survives upgrade rolls and feeds the #4494 seed loop) stayed stale — and the agents re-stuck on the next roll. The dashboard button is the only route that writes the durable file, because the *hive* runs that device-flow.

The hive can bridge this, and this PR does.

## Fix — make the session-refresh reconcile BOTH directions

`syncCopilotToken(configPath, durablePath)`:
- **PROMOTE (config → durable):** when the CLI has a token the hive does not hold, mirror it to the durable file + `SetCopilotToken`. An **in-agent login now becomes as durable as a dashboard login**, and arms the seed direction below.
- **SEED (durable → config):** the existing #4494 behavior — restore an emptied `copilotTokens` from the held token — unchanged.

So **any** login route (dashboard button *or* `/login` inside an agent) now: unsticks agents, survives rolls, and keeps itself re-seeded.

**Never runs a device flow, never mints a token — only mirrors a token that already exists.** The manual-login rule is intact.

- `extractCopilotToken` handles both CLI value shapes (bare string `{"host:user":"gho_…"}` and object `{"github.com":{"token":"gho_…"}}`).
- `writeDurableCopilotToken` matches the dashboard `saveCopilotToken` write (temp + rename).
- `syncCopilotToken` is parameterized on both paths so it is testable without touching `/data`.

## Tests
`copilot_token_promote_test.go`: extract (both shapes / empty / missing); durable write (+ blank no-op); **promote** (mirrors to durable + SetCopilotToken); promote no-op when already held; seed; both-empty no-op; no-copilot-backend no-op. Also updated #4494's case (d) for the new bidirectional behavior (config token preserved AND promoted).

## Files
- `src/pkg/agent/manager.go` — `extractCopilotToken`, `writeDurableCopilotToken(path,…)`, `syncCopilotToken`, bidirectional `refreshCopilotSessionToken`
- `src/pkg/agent/copilot_token_promote_test.go` — tests
- `src/pkg/agent/copilot_session_refresh_test.go` — updated case (d)

gofmt clean; DCO-signed. Pre-existing v4 beads/sandbox/hub flakiness + the transient bobshell-download build flake are unrelated (re-run if they hit).