### PR TITLE
🐛 Fix spoke dashboard self-upgrade auth

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -913,6 +913,11 @@ func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 	upgradeURL := hubURL + "/api/saas/hives/" + url.PathEscape(hiveID) + "/upgrade"
 
+	user := r.Header.Get("X-Hive-User")
+	proof := s.authToken
+	if proof == "" && s.deps.Config.Dashboard.AuthToken != "" {
+		proof = s.deps.Config.Dashboard.AuthToken
+	}
 	cookie, _ := r.Cookie("hive_hub_user")
 	const upgradeTimeout = 30 * time.Second
 	client := &http.Client{Timeout: upgradeTimeout}
@@ -923,6 +928,15 @@ func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 	if cookie != nil {
 		req.AddCookie(cookie)
+	}
+	if user != "" {
+		req.Header.Set("X-Hive-User", user)
+	}
+	if role != "" {
+		req.Header.Set("X-Hive-Role", role)
+	}
+	if proof != "" {
+		req.Header.Set(proxyAuthHeader, proof)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Origin", "https://hive.kubestellar.io")

--- a/src/pkg/dashboard/dashboard_config_download_test.go
+++ b/src/pkg/dashboard/dashboard_config_download_test.go
@@ -234,6 +234,52 @@ func TestHandleSelfUpgradeWithHubURL(t *testing.T) {
 	}
 }
 
+func TestHandleSelfUpgradeForwardsSpokeSessionProof(t *testing.T) {
+	const (
+		user       = "alice"
+		role       = "owner"
+		proofToken = "spoke-dashboard-token"
+	)
+
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Hive-User"); got != user {
+			t.Errorf("X-Hive-User = %q, want %q", got, user)
+		}
+		if got := r.Header.Get("X-Hive-Role"); got != role {
+			t.Errorf("X-Hive-Role = %q, want %q", got, role)
+		}
+		if got := r.Header.Get(proxyAuthHeader); got != proofToken {
+			t.Errorf("%s = %q, want %q", proxyAuthHeader, got, proofToken)
+		}
+		if _, err := r.Cookie("hive_hub_user"); err == nil {
+			t.Fatal("test request unexpectedly depended on hub cookie auth")
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"upgrading"}`))
+	}))
+	defer hub.Close()
+
+	cfg := &config.Config{
+		Project:   config.ProjectConfig{Org: "testorg", Name: "test", PrimaryRepo: "testrepo"},
+		Agents:    map[string]config.AgentConfig{},
+		Hub:       config.HubConfig{URL: hub.URL},
+		HiveID:    "test-hive-123",
+		Dashboard: config.DashboardConfig{AuthToken: proofToken},
+	}
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{Config: cfg, Logger: slog.Default()}
+
+	req := httptest.NewRequest("POST", "/api/self-upgrade", nil)
+	req.Header.Set("X-Hive-User", user)
+	markOwnerRequest(req)
+	w := httptest.NewRecorder()
+	srv.handleSelfUpgrade(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
 func TestHandleSelfUpgradeHubUnreachable(t *testing.T) {
 	cfg := &config.Config{
 		Project: config.ProjectConfig{Org: "testorg", Name: "test", PrimaryRepo: "testrepo"},

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -568,7 +568,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// handleOpenHive does its own auth check + login redirect.
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/open", s.handleOpenHive)
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}", s.requireAuth(s.handleDeleteHive))
-	s.mux.HandleFunc("POST /api/saas/hives/{id}/upgrade", s.requireAuth(s.handleUpgradeHive))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/upgrade", s.requireAuthOrSpokeUpgrade(s.handleUpgradeHive))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/switch-branch", s.requireAuth(s.handleSwitchBranch))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", s.requireAuth(s.handleToggleVisibility))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", s.requireAuth(s.handleToggleAutoUpgrade))
@@ -803,6 +803,69 @@ func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 		next(w, r)
 	}
+}
+
+// requireAuthOrSpokeUpgrade accepts the normal hub session for hub-dashboard
+// clicks and, for a hosted spoke dashboard, the spoke's server-to-server proof
+// plus the already-authenticated operator identity injected by that spoke.
+func (s *HubServer) requireAuthOrSpokeUpgrade(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isCSRFSafe(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":"CSRF check failed"}`))
+			return
+		}
+		if s.blockIfImpersonatingWrite(w, r) {
+			return
+		}
+		username := s.getAuthUser(r)
+		if username == "" {
+			if _, ok := s.trustedSpokeUpgradeUser(r, r.PathValue("id")); ok {
+				next(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"not authenticated"}`))
+			return
+		}
+		user := loadSaaSUser(username)
+		if user == nil {
+			ensureSaaSUser(username)
+			user = loadSaaSUser(username)
+		}
+		if user == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"unknown user — please log in again"}`))
+			return
+		}
+		if user.Blocked {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error":"account blocked"}`))
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (s *HubServer) trustedSpokeUpgradeUser(r *http.Request, hiveID string) (string, bool) {
+	username := r.Header.Get("X-Hive-User")
+	if username == "" || hiveID == "" || r.Header.Get("X-Hive-Role") != saasRoleOwner {
+		return "", false
+	}
+	proof := r.Header.Get(proxyAuthHeader)
+	expected := s.spokeProxyAuthToken(hiveID)
+	if proof == "" || expected == "" || !secureCompareHub(proof, expected) {
+		return "", false
+	}
+	user := loadSaaSUser(username)
+	if user == nil || user.Blocked {
+		return "", false
+	}
+	return username, true
 }
 
 // isCSRFSafe reports whether a request may be allowed to MUTATE state.
@@ -4308,6 +4371,9 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	username := s.getAuthUser(r)
+	if username == "" {
+		username, _ = s.trustedSpokeUpgradeUser(r, id)
+	}
 	h := loadSaaSHive(id)
 	if h == nil {
 		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)

--- a/src/pkg/hub/spoke_upgrade_auth_test.go
+++ b/src/pkg/hub/spoke_upgrade_auth_test.go
@@ -112,3 +112,130 @@ func TestSpokeUpgradeProofRejectsNonOwner(t *testing.T) {
 		t.Fatalf("status/body = %d %q, want owner denial", rec.Code, rec.Body.String())
 	}
 }
+
+func TestSpokeUpgradeMiddlewareStillAcceptsHubSession(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const (
+		hiveID = "hosted-hub-session-upgrade"
+		user   = "alice"
+		branch = "v4"
+	)
+
+	s := newHandlerHub()
+	s.hubGitBranch = branch
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: user, ClusterID: "hive-oke", GitBranch: branch}}
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: user, ClusterID: "hive-oke"}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: user, Hives: map[string]string{}}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	latestSHAMu.Lock()
+	prev, hadPrev := latestSHAByBranch[branch]
+	latestSHAByBranch[branch] = branchSHAInfo{SHA: "feed1234"}
+	latestSHAMu.Unlock()
+	defer func() {
+		latestSHAMu.Lock()
+		if hadPrev {
+			latestSHAByBranch[branch] = prev
+		} else {
+			delete(latestSHAByBranch, branch)
+		}
+		latestSHAMu.Unlock()
+	}()
+
+	req := setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/"+hiveID+"/upgrade", "", user), "id", hiveID)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	rec := httptest.NewRecorder()
+	s.requireAuthOrSpokeUpgrade(s.handleUpgradeHive)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSpokeUpgradeMiddlewareRejectsMissingAndInvalidProof(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const (
+		hiveID = "hosted-spoke-upgrade-bad-proof"
+		user   = "alice"
+		token  = "spoke-dashboard-token"
+	)
+
+	s := newHandlerHub()
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: user, ClusterID: "hive-oke"}}
+	s.spokeProxyAuthCache = map[string]spokeProxyAuthEntry{
+		hiveID: {token: token, expires: time.Now().Add(time.Hour)},
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: user, Hives: map[string]string{hiveID: "owner"}}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	for _, proof := range []string{"", "wrong"} {
+		req := setPathValue(httptest.NewRequest(http.MethodPost, "/api/saas/hives/"+hiveID+"/upgrade", nil), "id", hiveID)
+		req.Header.Set("Origin", "https://hive.kubestellar.io")
+		req.Header.Set("X-Hive-User", user)
+		req.Header.Set("X-Hive-Role", "owner")
+		req.Header.Set(proxyAuthHeader, proof)
+
+		rec := httptest.NewRecorder()
+		s.requireAuthOrSpokeUpgrade(s.handleUpgradeHive)(rec, req)
+
+		if rec.Code != http.StatusUnauthorized || !strings.Contains(rec.Body.String(), "not authenticated") {
+			t.Fatalf("proof %q: status/body = %d %q, want unauthenticated", proof, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestSpokeUpgradeMiddlewareRejectsBlockedSpokeUser(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const (
+		hiveID = "hosted-spoke-upgrade-blocked"
+		user   = "alice"
+		token  = "spoke-dashboard-token"
+	)
+
+	s := newHandlerHub()
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: user, ClusterID: "hive-oke"}}
+	s.spokeProxyAuthCache = map[string]spokeProxyAuthEntry{
+		hiveID: {token: token, expires: time.Now().Add(time.Hour)},
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: user, Hives: map[string]string{hiveID: "owner"}, Blocked: true}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	req := setPathValue(httptest.NewRequest(http.MethodPost, "/api/saas/hives/"+hiveID+"/upgrade", nil), "id", hiveID)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	req.Header.Set("X-Hive-User", user)
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, token)
+
+	rec := httptest.NewRecorder()
+	s.requireAuthOrSpokeUpgrade(s.handleUpgradeHive)(rec, req)
+
+	if rec.Code != http.StatusUnauthorized || !strings.Contains(rec.Body.String(), "not authenticated") {
+		t.Fatalf("status/body = %d %q, want unauthenticated", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSpokeUpgradeMiddlewareKeepsCSRFGate(t *testing.T) {
+	s := newHandlerHub()
+	req := httptest.NewRequest(http.MethodPost, "/api/saas/hives/h1/upgrade", nil)
+	req.Header.Set("X-Hive-User", "alice")
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, "token")
+
+	rec := httptest.NewRecorder()
+	s.requireAuthOrSpokeUpgrade(s.handleUpgradeHive)(rec, req)
+
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "CSRF") {
+		t.Fatalf("status/body = %d %q, want CSRF denial", rec.Code, rec.Body.String())
+	}
+}

--- a/src/pkg/hub/spoke_upgrade_auth_test.go
+++ b/src/pkg/hub/spoke_upgrade_auth_test.go
@@ -1,0 +1,114 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSpokeUpgradeProofAllowsOwnerWithoutHubCookie(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const (
+		hiveID = "hosted-spoke-upgrade"
+		user   = "alice"
+		token  = "spoke-dashboard-token"
+		branch = "v4"
+	)
+
+	s := newHandlerHub()
+	s.hubGitBranch = branch
+	s.registry.Hives = []RegistryEntry{{
+		ID:        hiveID,
+		Owner:     user,
+		ClusterID: "hive-oke",
+		GitBranch: branch,
+	}}
+	s.spokeProxyAuthCache = map[string]spokeProxyAuthEntry{
+		hiveID: {token: token, expires: time.Now().Add(time.Hour)},
+	}
+	if err := saveSaaSHive(&SaaSHive{
+		ID:          hiveID,
+		Owner:       user,
+		ClusterID:   "hive-oke",
+		Org:         "org",
+		PrimaryRepo: "repo",
+	}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: user,
+		Hives:          map[string]string{hiveID: "owner"},
+	}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	latestSHAMu.Lock()
+	prev, hadPrev := latestSHAByBranch[branch]
+	latestSHAByBranch[branch] = branchSHAInfo{SHA: "012e54f8"}
+	latestSHAMu.Unlock()
+	defer func() {
+		latestSHAMu.Lock()
+		if hadPrev {
+			latestSHAByBranch[branch] = prev
+		} else {
+			delete(latestSHAByBranch, branch)
+		}
+		latestSHAMu.Unlock()
+	}()
+
+	req := setPathValue(httptest.NewRequest(http.MethodPost, "/api/saas/hives/"+hiveID+"/upgrade", nil), "id", hiveID)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	req.Header.Set("X-Hive-User", user)
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, token)
+
+	rec := httptest.NewRecorder()
+	s.requireAuthOrSpokeUpgrade(s.handleUpgradeHive)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := s.heartbeatUpgrade[hiveID]; got != "012e54f8" {
+		t.Fatalf("heartbeatUpgrade[%q] = %q, want target SHA", hiveID, got)
+	}
+}
+
+func TestSpokeUpgradeProofRejectsNonOwner(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const (
+		hiveID = "hosted-spoke-upgrade-deny"
+		user   = "reader"
+		token  = "spoke-dashboard-token"
+	)
+
+	s := newHandlerHub()
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: "alice", ClusterID: "hive-oke"}}
+	s.spokeProxyAuthCache = map[string]spokeProxyAuthEntry{
+		hiveID: {token: token, expires: time.Now().Add(time.Hour)},
+	}
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: "alice", ClusterID: "hive-oke"}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: user, Hives: map[string]string{hiveID: "read"}}); err != nil {
+		t.Fatalf("save user: %v", err)
+	}
+
+	req := setPathValue(httptest.NewRequest(http.MethodPost, "/api/saas/hives/"+hiveID+"/upgrade", nil), "id", hiveID)
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+	req.Header.Set("X-Hive-User", user)
+	req.Header.Set("X-Hive-Role", "owner")
+	req.Header.Set(proxyAuthHeader, token)
+
+	rec := httptest.NewRecorder()
+	s.requireAuthOrSpokeUpgrade(s.handleUpgradeHive)(rec, req)
+
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "only the owner can upgrade") {
+		t.Fatalf("status/body = %d %q, want owner denial", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- forward spoke-authenticated operator identity and per-hive proxy proof on dashboard self-upgrade
- allow the hub upgrade endpoint to accept that verified spoke proof while still enforcing hive ownership
- add dashboard and hub tests for the no hub-cookie path

## Validation
- cd src && go test -race ./pkg/dashboard ./pkg/hub
- cd src && go build ./... && go vet ./... && go test -race ./pkg/dashboard