### PR TITLE
🐛 fix(hub): gate quadrant percentiles on absolute activity

### DIFF
--- a/src/pkg/hub/quadrant.go
+++ b/src/pkg/hub/quadrant.go
@@ -16,16 +16,30 @@ import (
 //
 // Two design rules run through the whole file and must not be relaxed:
 //
-//  1. SCORES ARE FLEET-RELATIVE. An axis is a percentile against the other
-//     hives in the same population, not an absolute grade. This keeps the chart
-//     self-calibrating as the fleet's baseline moves, and it is what makes the
-//     fleet-average polygon a meaningful reference rather than a fixed target.
+//  1. SCORES ARE FLEET-RELATIVE, BUT GATED BY ABSOLUTE ACTIVITY. An axis is a
+//     percentile against the other hives in the same population, which keeps the
+//     chart self-calibrating as the fleet's baseline moves. A percentile ALONE,
+//     however, is blind to magnitude, and on an idle fleet that blindness is
+//     catastrophic: the percentile definition puts a uniformly-tied population
+//     at 50, so when 28 of 62 hives have merged nothing at all, all 28 score ~50
+//     for doing literally nothing, and a hive with THREE merged PRs in ninety
+//     days outranks all of them and lands near the top. The chart then reports a
+//     busy, healthy fleet that does not exist.
 //
-//  2. ABSENT EVIDENCE IS NOT A ZERO. An axis with too little data reports
-//     Scored=false and renders as a collapsed spoke, visually distinct from a
-//     genuine low score. Scoring a brand-new hive's efficiency at 0 because it
-//     has not merged anything yet would be a lie that nags the wrong people.
-//     Every axis is subject to this floor, not just Satisfaction.
+//     Every percentile is therefore multiplied by an ACTIVITY FACTOR derived
+//     from the criterion's raw magnitude (see activityFactor). Zero measured
+//     activity scores at/near zero regardless of rank; activity ramps the
+//     percentile in over a small absolute threshold so one PR does not vault a
+//     hive to the top of the fleet but ten does count fully.
+//
+//  2. ABSENT EVIDENCE IS NOT A ZERO — AND IS NOT THE SAME AS MEASURED ZERO.
+//     An axis with too little data reports Scored=false and renders as a
+//     collapsed spoke. A hive that genuinely reported zero is a different thing:
+//     it IS measured, it DOES score, and rule 1 means it scores LOW rather than
+//     at the median. Collapsing these two cases together is the bug in both
+//     directions — scoring a never-reporting hive at 0 nags the wrong people,
+//     and scoring a measured-zero hive at 50 flatters the whole fleet.
+//     Every axis is subject to the sufficiency floor, not just Satisfaction.
 //
 // Computed on read and never persisted on the registry entry, mirroring the
 // Journey status this file sits alongside.
@@ -94,9 +108,26 @@ type Quadrant struct {
 // evidence; a zero value is a real measurement of zero. Conflating the two is
 // precisely the bug the sufficiency floor exists to prevent.
 type quadrantInputs struct {
+	// countGroup identifies hives whose org-scoped counters measure THE SAME
+	// underlying work. It is the (org, ai-author) pair the spoke's
+	// FleetStatsCollector queries GitHub with: that collector counts AI-author
+	// PRs across the whole org, so every hive enrolled in an org reports that
+	// org's ENTIRE output as its own.
+	//
+	// Three hives in the live fleet each reported prsMerged90d=3746 for this
+	// reason — one org's output counted three times. Left unhandled it does not
+	// merely give those three hives the same score, it stretches the whole
+	// distribution: the population sample gains two phantom members at the top,
+	// pushing every other hive's percentile down and making the fleet's real
+	// spread unreadable.
+	//
+	// Population building therefore counts a group ONCE (see dedupeByGroup).
+	// Empty means "ungrouped" — the hive stands alone and always counts once,
+	// which is the correct default for a hive whose org is unknown.
+	countGroup string
+
 	// --- Trust -----------------------------------------------------------
-	acmmLevel     int    // 1-6; 0 = unknown
-	governorMode  string // observe | advisory | enforce (case-insensitive)
+	acmmLevel     int // 1-6; 0 = unknown
 	reposEnrolled int
 	reposInOrg    int // 0 = unknown, so breadth is unscorable
 
@@ -202,21 +233,124 @@ const (
 	minFleetForPercentile = 5
 )
 
-// normalizeGovernorMode folds the governor posture to a comparable rank.
-// Higher = more trust extended to the hive. Unknown modes rank lowest rather
-// than erroring, since the governor gains modes over time and an unrecognised
-// value must never crash the dashboard.
-func normalizeGovernorMode(mode string) (rank int, known bool) {
-	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case "observe", "observe-only", "off":
-		return 0, true
-	case "advisory", "advise":
-		return 1, true
-	case "enforce", "enforcing", "on":
-		return 2, true
-	default:
-		return 0, false
+// activityFloor is the absolute magnitude at which a criterion's percentile
+// counts in full.
+//
+// It exists because a percentile cannot see magnitude. Below this value the
+// percentile is scaled down toward zero; at or above it the fleet-relative rank
+// stands unmodified. The scale is the criterion's own native unit, which is why
+// each criterion carries its own floor rather than sharing one constant — five
+// merged PRs and five contributor-relay tasks are not the same amount of
+// evidence.
+//
+// activityFloor==0 means the criterion is EXEMPT: its value is a ratio,
+// posture or inverse count where "zero" is not "idle". A rework rate of zero is
+// the BEST possible outcome, not an absence of activity, and gating it would
+// score the cleanest hives worst. The exemption is opt-in per criterion for
+// exactly this reason — a blanket gate would silently invert those axes.
+const (
+	// activityFloorMergedPRs is the merged-PR count at which throughput
+	// percentile counts in full. Ten in ninety days is roughly one a week: a
+	// hive that is genuinely, continuously working rather than one that landed
+	// a couple of things. Below it the ramp means three merged PRs earns about
+	// a third of its rank, which is the intended answer to "a hive with 3
+	// merged PRs must not outrank 28 idle ones and land high".
+	activityFloorMergedPRs = 10
+
+	// activityFloorRelayTasks is the 7-day contributor-relay count at which the
+	// relay reads as genuinely in use. Set at five — under one a day — because
+	// the relay is a lighter-weight action than a merged PR and a lower bar
+	// still distinguishes "in use" from "configured and idle".
+	activityFloorRelayTasks = 5
+
+	// activityFloorOutputPerAgent is merged PRs per agent at which a seat reads
+	// as productive. One over ninety days is a deliberately low bar — the
+	// criterion flags agents that shipped NOTHING, and anything above zero at
+	// least demonstrates the seat works.
+	activityFloorOutputPerAgent = 1
+
+	// activityFloorTokensPerDay is the daily burn at which a hive is doing
+	// enough work for its cost figures to describe anything. A hive burning
+	// almost nothing is not efficient, it is idle — and without this it would
+	// take the top of the lower-is-better cost ranking precisely BECAUSE it
+	// does nothing, which is the same median-for-idleness bug wearing a
+	// different sign. 50k tokens/day is a few agent runs.
+	activityFloorTokensPerDay = 50000
+)
+
+// activityFactor ramps a criterion's absolute magnitude into a 0..1 multiplier
+// on its fleet percentile.
+//
+// The ramp is LINEAR from 0 at zero activity to 1 at the floor, then flat. A
+// linear ramp is deliberate over a step: a step at the floor would create a
+// cliff where the tenth merged PR is worth more than the previous nine put
+// together, which is both unfair and easy to game. A linear ramp makes each
+// unit of real work worth the same amount until the criterion is satisfied.
+//
+// The multiplicative form — score = percentile × factor — is what preserves the
+// fleet-relative property while fixing its blindness. Rank still decides the
+// ORDER among active hives; magnitude decides whether the hive is in the
+// conversation at all. An additive or replacement scheme would throw away the
+// self-calibration that makes the fleet-average polygon meaningful.
+//
+// floor<=0 means the criterion is exempt (see the constants above) and the
+// percentile passes through untouched.
+func activityFactor(value, floor float64) float64 {
+	if floor <= 0 {
+		return 1
 	}
+	if value <= 0 {
+		// Measured zero. NOT unscored — the hive reported, so it scores, and it
+		// scores at the bottom rather than at the fleet median. This single
+		// line is the difference between "28 idle hives at 50" and the truth.
+		return 0
+	}
+	if value >= floor {
+		return 1
+	}
+	return value / floor
+}
+
+// dedupeByGroup collapses values that share a countGroup down to one
+// representative, so an org-wide counter reported by several hives in the same
+// org contributes to a criterion's population ONCE.
+//
+// The representative is the MAXIMUM of the group's reported values rather than
+// the first or the mean. The counter is org-wide and identical by construction,
+// so in the healthy case every choice agrees; they differ only when the hives'
+// collectors ran at different times or one is stale, and the freshest count is
+// the largest over a fixed trailing window. Taking the max therefore keeps the
+// most complete measurement instead of letting collection timing decide.
+//
+// Hives with an empty countGroup are ungrouped and each contribute their own
+// value, which is the right default when the org is unknown.
+//
+// Note this dedupes the POPULATION only. Each hive is still SCORED against that
+// population with its own value, so co-org hives still get identical scores —
+// correctly, since they are reporting the same underlying work. What is fixed
+// is the distribution no longer being stretched by phantom duplicates.
+func dedupeByGroup(values []float64, groups []string) []float64 {
+	out := make([]float64, 0, len(values))
+	best := map[string]int{} // countGroup -> index into out
+	for i, v := range values {
+		g := ""
+		if i < len(groups) {
+			g = strings.TrimSpace(groups[i])
+		}
+		if g == "" {
+			out = append(out, v)
+			continue
+		}
+		if j, seen := best[g]; seen {
+			if v > out[j] {
+				out[j] = v
+			}
+			continue
+		}
+		best[g] = len(out)
+		out = append(out, v)
+	}
+	return out
 }
 
 // percentileRank returns where value sits within population, as 0-100.

--- a/src/pkg/hub/quadrant_attach.go
+++ b/src/pkg/hub/quadrant_attach.go
@@ -76,6 +76,39 @@ func mergeAcceptanceRate(e RegistryEntry) (float64, bool) {
 	return float64(*e.PRsMerged90d) / float64(total), true
 }
 
+// fleetCountGroup identifies hives whose org-scoped counters measure the SAME
+// underlying work, so a criterion's population can count that work once.
+//
+// The key is (org, ai-author) because that is exactly the query the spoke's
+// FleetStatsCollector issues — NewFleetStatsCollector(ghClient, author, org)
+// counts AI-author PRs across the whole org. Two hives agreeing on both fields
+// are therefore not two measurements of similar size, they are one measurement
+// reported twice. Three hives in the live fleet each reported prsMerged90d=3746
+// for precisely this reason.
+//
+// Org alone would be too coarse — two teams in one org running different AI
+// authors do produce genuinely distinct output and must each count. Including
+// the author keeps those separate while still collapsing true duplicates.
+//
+// Returns "" when either half is unknown, which means "ungrouped": the hive
+// counts once on its own, the safe default because it cannot be shown to
+// duplicate anyone. Case is folded since GitHub logins and orgs are
+// case-insensitive and spokes report them as configured.
+func fleetCountGroup(e RegistryEntry) string {
+	org := strings.ToLower(strings.TrimSpace(e.Org))
+	// AIAuthorEffective is who the agents ACTUALLY author as (the App bot login
+	// when ai_author is unset), which is the identity the collector's search
+	// resolves to. Prefer it, and fall back to the configured author.
+	author := strings.ToLower(strings.TrimSpace(e.AIAuthorEffective))
+	if author == "" {
+		author = strings.ToLower(strings.TrimSpace(e.AIAuthor))
+	}
+	if org == "" || author == "" {
+		return ""
+	}
+	return org + "/" + author
+}
+
 // quadrantInputsFor extracts the evidence for one hive.
 //
 // The nil-vs-zero discipline the registry maintains is carried through here
@@ -85,9 +118,12 @@ func mergeAcceptanceRate(e RegistryEntry) (float64, bool) {
 // unreported signal into a genuine low score.
 func quadrantInputsFor(e RegistryEntry, now time.Time) quadrantInputs {
 	in := quadrantInputs{
-		acmmLevel:    e.ACMMLevel,
-		governorMode: e.GovernorMode,
-		agentCount:   e.AgentCount,
+		acmmLevel:  e.ACMMLevel,
+		agentCount: e.AgentCount,
+		// The org-wide counters are collected per (org, ai-author) pair — see
+		// NewFleetStatsCollector — so that pair, not the hive ID, is what makes
+		// two hives' counts the same measurement rather than two of them.
+		countGroup: fleetCountGroup(e),
 		// WorkSource is empty for the DEFAULT GitHub Issues source rather than
 		// unknown, so an empty string is a real answer here: the hive is
 		// reading human-filed issues.

--- a/src/pkg/hub/quadrant_axes.go
+++ b/src/pkg/hub/quadrant_axes.go
@@ -18,10 +18,19 @@ import "fmt"
 // it to a fleet percentile later. higherIsBetter records the direction, since
 // cost-style criteria are better when smaller and a single comparator cannot
 // guess that.
+//
+// activityFloor is the absolute magnitude at which this criterion's percentile
+// counts in full — see activityFactor in quadrant.go. Leaving it zero EXEMPTS
+// the criterion from the absolute gate, which is correct for ratios and
+// postures (where zero is a real, often good, value) and wrong for throughput
+// counters (where zero means idle). Every criterion must make this choice
+// deliberately; the zero default is safe only because an un-gated criterion
+// behaves exactly as it did before the gate existed.
 type subCriterion struct {
 	name           string
 	value          float64
 	higherIsBetter bool
+	activityFloor  float64
 	nudge          string // shown when this criterion is the axis's weakest link
 }
 
@@ -34,10 +43,53 @@ type subCriterion struct {
 // its throughput is modest. Mixing outcome quality in here would make the axis
 // a second productivity score.
 //
-// Note on merge acceptance: the obvious fourth criterion is the agent PR merge
-// rate, but the platform cannot compute it today — see the acmmadvisor note in
-// quadrant.go and the closed-unmerged gap in QUADRANT-DESIGN.md. It is omitted
-// rather than approximated, so Trust scores on three criteria.
+// THE GOVERNOR CRITERION HAS BEEN REMOVED, and Trust now scores on three
+// criteria: autonomy, merge acceptance and breadth.
+//
+// It was built on a misreading of the governor, in two compounding ways.
+//
+// Mechanically it never worked: it matched "observe"/"advisory"/"enforce", but
+// governor.Mode (pkg/governor/governor.go) only ever emits SURGE, BUSY, QUIET
+// or IDLE. Every hive in the fleet fell through to known=false, so the
+// criterion contributed to nothing — one of only three Trust criteria dropped
+// silently, with the axis still rendering a perfectly plausible number.
+//
+// Conceptually it was worse, and this is why it is deleted rather than
+// remapped: those values are WORKLOAD CADENCE — how hard the governor is
+// currently driving agents — not a trust posture. There is no
+// observe/advisory/enforce dimension anywhere in the governor. A hive at SURGE
+// is busy, not trusted; a hive at IDLE is quiet, not distrusted. Mapping
+// cadence onto a trust rank would take a criterion that measured nothing and
+// replace it with one that measures the wrong thing, which is strictly worse
+// because it would then look like it was working.
+//
+// No replacement is substituted, because the hub does not receive one. The
+// codebase has three genuine delegated-authority signals and ALL of them are
+// spoke-side configuration that never travels on the heartbeat:
+//
+//   - config.AutoMergeConfig.SelfAuthored (pkg/config/config.go) — the App
+//     merging its own PRs with no human approval. This is the strongest
+//     delegation bit in the product and would be the ideal trust criterion.
+//   - config.ReviewConfig.RequireApproval — the review gate.
+//   - config.AgentSandboxConfig / AgentConfig.Tools — sandbox and tool
+//     permissions.
+//
+// None appears on HeartbeatPayload or RegistryEntry; each is read only inside
+// cmd/hive/main.go. The hub therefore cannot see whether an operator granted or
+// revoked any of them, and acmmLevel — already the autonomy criterion below —
+// is the single delegation signal that does arrive.
+//
+// Recomputing a gate hub-side from acmmLevel (PlanAutoApproveForLevel,
+// SelfMergeMinACMMLevel) was considered and rejected: it is a pure function of
+// a value this axis ALREADY scores, so it would add no information while
+// double-weighting autonomy and looking like a second, independent criterion.
+// Inventing a proxy to keep the criterion count at three would repeat exactly
+// the mistake being fixed here.
+//
+// The real fix is to report the signal. Adding
+// AutoMerge.SelfAuthoredAutoMergeAllowed(cfg.ACMMLevel) to the heartbeat as a
+// *bool — nil for old spokes, matching every other quadrant pointer field —
+// would give Trust a true delegation criterion. Until then, three.
 func trustCriteria(in quadrantInputs) []subCriterion {
 	var out []subCriterion
 
@@ -49,21 +101,6 @@ func trustCriteria(in quadrantInputs) []subCriterion {
 			value:          float64(in.acmmLevel),
 			higherIsBetter: true,
 			nudge:          fmt.Sprintf("At ACMM L%d — consider trying the next level on one repo", in.acmmLevel),
-		})
-	}
-
-	// Governor posture. observe -> advisory -> enforce is an increasing
-	// willingness to let the governor act rather than merely watch.
-	if rank, known := normalizeGovernorMode(in.governorMode); known {
-		n := ""
-		if rank == 0 {
-			n = "Governor is observe-only — move it to advisory to let it act"
-		}
-		out = append(out, subCriterion{
-			name:           "governor",
-			value:          float64(rank),
-			higherIsBetter: true,
-			nudge:          n,
 		})
 	}
 
@@ -128,11 +165,18 @@ func efficiencyCriteria(in quadrantInputs) []subCriterion {
 	// now properly scoped — a rate rather than a lifetime total — so this is a
 	// genuine comparison rather than the approximate ranking an unnormalised
 	// cumulative figure would give.
+	//
+	// Gated on absolute burn. Without the gate this criterion rewards idleness
+	// outright: it is lower-is-better, so a hive spending nothing takes the top
+	// of the ranking for having done nothing at all. The floor makes a
+	// barely-burning hive score near zero here, and only hives doing real work
+	// compete on how cheaply they do it.
 	if in.tokensPerDay != nil {
 		out = append(out, subCriterion{
 			name:           "tokens_per_day",
 			value:          *in.tokensPerDay,
 			higherIsBetter: false,
+			activityFloor:  activityFloorTokensPerDay,
 			nudge:          "Token burn rate is high relative to the fleet",
 		})
 	}
@@ -186,10 +230,15 @@ func efficiencyCriteria(in quadrantInputs) []subCriterion {
 			n = fmt.Sprintf("%d agents but %d merged PRs — consider pausing idle agents",
 				in.agentCount, *in.prsMerged90d)
 		}
+		// Gated at one merged PR per agent: an agent that has shipped nothing
+		// in ninety days is the definition of idle burn, and this criterion
+		// exists to flag exactly that. Without the gate a fleet where most
+		// agents ship nothing puts them all at the median for it.
 		out = append(out, subCriterion{
 			name:           "output_per_agent",
 			value:          perAgent,
 			higherIsBetter: true,
+			activityFloor:  activityFloorOutputPerAgent,
 			nudge:          n,
 		})
 	}
@@ -224,10 +273,15 @@ func productivityCriteria(in quadrantInputs) []subCriterion {
 				n = "No agent-merged PRs in the last 90 days"
 			}
 		}
+		// The headline gate. A measured zero here scores ZERO, not the fleet
+		// median — this is the criterion where percentile-blindness did the most
+		// damage, since most of the fleet has merged nothing and ties place a
+		// uniformly-idle population at 50.
 		out = append(out, subCriterion{
 			name:           "prs_merged",
 			value:          float64(*in.prsMerged90d),
 			higherIsBetter: true,
+			activityFloor:  activityFloorMergedPRs,
 			nudge:          n,
 		})
 	}
@@ -280,10 +334,12 @@ func productivityCriteria(in quadrantInputs) []subCriterion {
 		if *in.tasksCompleted7d == 0 && in.contributorCount > 0 {
 			n = "Contributor relay is idle"
 		}
+		// Gated: an idle relay is idle whatever the rest of the fleet is doing.
 		out = append(out, subCriterion{
 			name:           "relay_7d",
 			value:          float64(*in.tasksCompleted7d),
 			higherIsBetter: true,
+			activityFloor:  activityFloorRelayTasks,
 			nudge:          n,
 		})
 	}

--- a/src/pkg/hub/quadrant_score.go
+++ b/src/pkg/hub/quadrant_score.go
@@ -42,15 +42,25 @@ func ScoreFleet(inputs []quadrantInputs) []Quadrant {
 	// that declined must not be counted as a zero, or it would drag the whole
 	// fleet's distribution toward the bottom and make everyone else look good
 	// for the wrong reason.
+	//
+	// Each contributed value is tagged with its hive's countGroup so the sample
+	// can be deduped below: several hives in one org report that org's WHOLE
+	// output as their own, and counting it once per hive would let a single
+	// org's activity stretch the distribution as many times as it has hives.
 	type critKey struct{ axis, name string }
 	populations := map[critKey][]float64{}
+	popGroups := map[critKey][]string{}
 	for i := range inputs {
 		for axis, crits := range perHive[i] {
 			for _, c := range crits {
 				k := critKey{axis, c.name}
 				populations[k] = append(populations[k], c.value)
+				popGroups[k] = append(popGroups[k], inputs[i].countGroup)
 			}
 		}
+	}
+	for k, vals := range populations {
+		populations[k] = dedupeByGroup(vals, popGroups[k])
 	}
 
 	// First pass: per-hive, per-axis scores.
@@ -79,7 +89,20 @@ func ScoreFleet(inputs []quadrantInputs) []Quadrant {
 				if len(pop) < minFleetForPercentile {
 					continue
 				}
+				// Rank decides the ORDER among active hives; the absolute
+				// activity factor decides whether the hive is in the
+				// conversation at all. A criterion whose raw magnitude is zero
+				// scores zero here however the rest of the fleet ranks — which
+				// is the whole point: on a mostly-idle fleet a percentile alone
+				// puts everyone who did nothing at the median.
+				//
+				// Note this multiplies, so the hive is still SCORED (it
+				// reported a real measurement of zero); it simply scores low.
+				// Unscored — no measurement at all — is handled above by the
+				// empty-criteria branch and never reaches here.
 				s := percentileRank(c.value, pop, c.higherIsBetter)
+				s = clampScore(int(math.Round(
+					float64(s) * activityFactor(c.value, c.activityFloor))))
 				sum += s
 				n++
 				if c.nudge != "" && s < weakestScore {

--- a/src/pkg/hub/quadrant_test.go
+++ b/src/pkg/hub/quadrant_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // These tests pin the invariants that are SILENT when broken. A quadrant that
@@ -20,7 +21,6 @@ func fleetOf(n int, mut func(i int, in *quadrantInputs)) []quadrantInputs {
 	for i := range out {
 		out[i] = quadrantInputs{
 			acmmLevel:     (i % 5) + 1,
-			governorMode:  []string{"observe", "advisory", "enforce"}[i%3],
 			reposEnrolled: i%4 + 1,
 			reposInOrg:    8,
 		}
@@ -362,6 +362,390 @@ func TestFleetAverageIgnoresUnscored(t *testing.T) {
 	}
 	if avg.ScoredAxes == 0 {
 		t.Error("fleet average scored nothing at all — the reference polygon would be empty")
+	}
+}
+
+// axisOf pulls one axis out of a quadrant, for the tests below.
+func axisOf(q Quadrant, axis string) (AxisScore, bool) {
+	for _, a := range q.Axes {
+		if a.Axis == axis {
+			return a, true
+		}
+	}
+	return AxisScore{}, false
+}
+
+// --- Absolute activity floor (BUG 1) -----------------------------------------
+
+// TestIdleFleetScoresLowNotMedian is the headline regression.
+//
+// A percentile puts a uniformly-tied population at 50 — ties count as half —
+// so before the activity gate a fleet where NOBODY had merged anything scored
+// every hive at ~50 on productivity and reported a healthy, average fleet that
+// did not exist. The live fleet is exactly this shape: 28 of 62 hives at zero
+// merged PRs.
+//
+// The invariant: doing nothing, measured, scores near zero. Not near the median.
+func TestIdleFleetScoresLowNotMedian(t *testing.T) {
+	// Twenty hives, all genuinely idle: they REPORT (so they are scored, not
+	// unscored) and every reported number is zero.
+	idle := ScoreFleet(fleetOf(20, func(i int, in *quadrantInputs) {
+		in.prsMerged90d = iptr(0)
+		in.tasksCompleted7d = iptr(0)
+	}))
+
+	for i, q := range idle {
+		a, ok := axisOf(q, AxisProductivity)
+		if !ok || !a.Scored {
+			t.Fatalf("hive %d: productivity must still be SCORED — a measured zero is "+
+				"a real measurement, not absent evidence", i)
+		}
+		if a.Score >= idleFleetMaxScore {
+			t.Errorf("hive %d: an entirely idle hive scored productivity %d — "+
+				"doing nothing is ranking at or near the fleet median, which is the "+
+				"bug this gate exists to prevent", i, a.Score)
+		}
+	}
+
+	// Positive control. The same fleet shape, but every hive genuinely busy,
+	// MUST produce high scores — otherwise the assertion above would pass on a
+	// scorer that simply returns zero for everything and proves nothing.
+	busy := ScoreFleet(fleetOf(20, func(i int, in *quadrantInputs) {
+		in.prsMerged90d = iptr(activityFloorMergedPRs * (i + 2))
+		in.tasksCompleted7d = iptr(activityFloorRelayTasks * (i + 2))
+	}))
+	top, ok := axisOf(busy[19], AxisProductivity)
+	if !ok || !top.Scored {
+		t.Fatal("positive control: the busiest hive must score productivity")
+	}
+	if top.Score <= idleFleetMaxScore {
+		t.Errorf("positive control failed: the fleet-leading BUSY hive scored only %d — "+
+			"the idle assertion above would pass even on a scorer that always returns 0",
+			top.Score)
+	}
+}
+
+// idleFleetMaxScore is the ceiling an entirely idle hive must stay under.
+//
+// Set well below 50 (the value a tied percentile produces) so the test fails
+// loudly if the gate is removed, but not at 0 — the productivity axis averages
+// several criteria and the exempt ones (work source, human-blocked, SLA) still
+// contribute a real rank to an idle hive, which is correct: a hive with nothing
+// blocked genuinely is not blocked.
+const idleFleetMaxScore = 35
+
+// TestSinglePRDoesNotReachTopDecile pins the ramp's shape.
+//
+// The operator's specific complaint: one hive with THREE merged PRs outranked
+// 28 idle ones and landed high. Rank alone said it beat 28 hives, so it did.
+// With the gate its three PRs earn ~30% of that rank, which keeps it ABOVE the
+// idle hives (it did do more) without putting it near the top of the fleet.
+func TestSinglePRDoesNotReachTopDecile(t *testing.T) {
+	// One hive with a single merged PR among nineteen idle ones — the live
+	// fleet's shape, where a lone PR previously outranked everybody.
+	in := fleetOf(20, func(i int, in *quadrantInputs) {
+		if i == 0 {
+			in.prsMerged90d = iptr(1)
+			return
+		}
+		in.prsMerged90d = iptr(0)
+	})
+	qs := ScoreFleet(in)
+
+	lone, ok := axisOf(qs[0], AxisProductivity)
+	if !ok || !lone.Scored {
+		t.Fatal("the one active hive must score productivity")
+	}
+	if lone.Score >= topDecileScore {
+		t.Errorf("a hive with ONE merged PR scored %d, reaching the top decile — "+
+			"outranking idle hives is not the same as leading the fleet", lone.Score)
+	}
+
+	// It must still be ABOVE the idle hives: the gate scales activity down, it
+	// does not erase the distinction between one PR and none. Without this the
+	// test would pass on a gate that flattened everybody to zero.
+	idle, _ := axisOf(qs[1], AxisProductivity)
+	if lone.Score <= idle.Score {
+		t.Errorf("the hive with one merged PR (%d) did not outscore an idle one (%d) — "+
+			"the gate has erased real activity rather than scaling it", lone.Score, idle.Score)
+	}
+
+	// Positive control: a hive at the activity floor in the SAME fleet shape
+	// does reach the top decile, proving the ceiling above is enforced by the
+	// ramp rather than by the criterion being incapable of scoring high.
+	atFloor := fleetOf(20, func(i int, in *quadrantInputs) {
+		if i == 0 {
+			in.prsMerged90d = iptr(activityFloorMergedPRs)
+			return
+		}
+		in.prsMerged90d = iptr(0)
+	})
+	lead, ok := axisOf(ScoreFleet(atFloor)[0], AxisProductivity)
+	if !ok || lead.Score < topDecileScore {
+		t.Errorf("positive control failed: a hive at the %d-PR activity floor scored only %d — "+
+			"the top decile is unreachable, so the ceiling test proves nothing",
+			activityFloorMergedPRs, lead.Score)
+	}
+}
+
+// topDecileScore is the "top of the fleet" boundary the ramp must keep a
+// barely-active hive out of, and a floor-satisfying hive must be able to reach.
+const topDecileScore = 90
+
+// TestMeasuredZeroStillDiffersFromNil is the load-bearing invariant the
+// activity gate must NOT break.
+//
+// The gate makes measured zero score LOW, which brings it closer to the
+// intuition of "nothing". It must still be categorically different from nil:
+// zero is a measurement and SCORES; nil is absent evidence and stays
+// Scored=false, rendering as a collapsed spoke. Folding them together would
+// tell owners they are failing at something never measured.
+func TestMeasuredZeroStillDiffersFromNil(t *testing.T) {
+	// Every productivity signal absent → unscored.
+	absent := ScoreFleet(fleetOf(10, nil))
+	for i, q := range absent {
+		if a, ok := axisOf(q, AxisProductivity); ok && a.Scored {
+			t.Fatalf("hive %d: productivity scored %d with NO productivity signal reported — "+
+				"absent evidence has collapsed into a measurement", i, a.Score)
+		}
+	}
+
+	// The same fleet reporting a real zero → scored, and scored LOW.
+	measured := ScoreFleet(fleetOf(10, func(i int, in *quadrantInputs) {
+		in.prsMerged90d = iptr(0)
+	}))
+	for i, q := range measured {
+		a, ok := axisOf(q, AxisProductivity)
+		if !ok || !a.Scored {
+			t.Fatalf("hive %d: a reported zero must be SCORED — it is a measurement", i)
+		}
+		if a.Score >= idleFleetMaxScore {
+			t.Errorf("hive %d: measured zero scored %d, near the median", i, a.Score)
+		}
+	}
+}
+
+// --- Org-shared counts (BUG 3) -----------------------------------------------
+
+// TestOrgSharedCountsDoNotMultiply guards the population against one org's
+// output being counted once per hive enrolled in it.
+//
+// FleetStatsCollector counts AI-author PRs across a whole ORG, so every hive in
+// that org reports the org's entire output as its own. Three live hives each
+// reported prsMerged90d=3746 for this reason. Counted three times, that single
+// org adds two phantom members at the top of the distribution and pushes every
+// other hive's percentile down.
+// orgDedupeResidualTolerance is how far a deduped fleet's score may sit from
+// the same fleet with a single hive in the org.
+//
+// It is not zero because dedupe legitimately SHRINKS the population: three rows
+// collapse to one, so the percentile's denominator drops by two and every rank
+// shifts by a point or so. That residual is arithmetic, not multiplication. The
+// bug being guarded moves the score by tens of points, so a few points of slack
+// keeps the test honest without making it brittle to population size.
+const orgDedupeResidualTolerance = 5
+
+func TestOrgSharedCountsDoNotMultiply(t *testing.T) {
+	// A modest hive whose rank we watch, plus one org reported by three hives.
+	const shared = 3746
+	build := func(coOrgHives int) []quadrantInputs {
+		in := fleetOf(10, func(i int, in *quadrantInputs) {
+			in.prsMerged90d = iptr(activityFloorMergedPRs * 2)
+		})
+		for i := 0; i < coOrgHives; i++ {
+			in[i].countGroup = "bigco/ai-bot"
+			in[i].prsMerged90d = iptr(shared)
+		}
+		return in
+	}
+
+	// Hive 9 is an ordinary hive in every case. Its score is the probe: one
+	// org's output must weigh on the distribution the same whether that org is
+	// represented by one hive or by three.
+	one, _ := axisOf(ScoreFleet(build(1))[9], AxisProductivity)
+	three, _ := axisOf(ScoreFleet(build(3))[9], AxisProductivity)
+	if !one.Scored || !three.Scored {
+		t.Fatal("expected the ordinary hive to score productivity in both fleets")
+	}
+
+	// The counterfactual: the SAME three co-org hives left ungrouped, i.e. the
+	// buggy behaviour where one org's output is counted once per hive in it.
+	undeduped := build(3)
+	for i := 0; i < 3; i++ {
+		undeduped[i].countGroup = ""
+	}
+	multiplied, _ := axisOf(ScoreFleet(undeduped)[9], AxisProductivity)
+
+	// Triple-counting must visibly depress an unrelated hive's rank — that is
+	// the harm. If it does not, this test is measuring nothing.
+	if multiplied.Score >= one.Score {
+		t.Fatalf("positive control failed: triple-counting one org left an unrelated hive at "+
+			"%d vs %d — the duplicates are not affecting the distribution at all, so the "+
+			"dedupe assertion below proves nothing", multiplied.Score, one.Score)
+	}
+
+	// And dedupe must undo essentially all of that harm. An exact match with
+	// the single-reporter case is not required: collapsing three rows to one
+	// legitimately shrinks the population by two, which shifts a percentile
+	// slightly. What must not survive is the multiplication.
+	if three.Score <= multiplied.Score {
+		t.Errorf("dedupe did not help: unrelated hive scored %d with dedupe and %d without, "+
+			"against %d when the org had a single hive", three.Score, multiplied.Score, one.Score)
+	}
+	if diff := one.Score - three.Score; diff > orgDedupeResidualTolerance {
+		t.Errorf("an unrelated hive scored %d when one org-hive reported but %d when three "+
+			"co-org hives did (tolerance %d) — one org's output is still being weighed "+
+			"more than once", one.Score, three.Score, orgDedupeResidualTolerance)
+	}
+}
+
+// TestCountGroupKeyedOnOrgAndAuthor pins what makes two counts "the same
+// measurement". Org alone would wrongly merge two teams in one org running
+// different AI authors, whose output genuinely IS distinct.
+func TestCountGroupKeyedOnOrgAndAuthor(t *testing.T) {
+	same := fleetCountGroup(RegistryEntry{Org: "BigCo", AIAuthor: "ai-bot"})
+	if got := fleetCountGroup(RegistryEntry{Org: "bigco", AIAuthor: "AI-Bot"}); got != same {
+		t.Errorf("case difference produced different groups (%q vs %q) — GitHub orgs and "+
+			"logins are case-insensitive, so duplicates would slip through", got, same)
+	}
+	if got := fleetCountGroup(RegistryEntry{Org: "bigco", AIAuthor: "other-bot"}); got == same {
+		t.Error("two different AI authors in one org share a count group — genuinely " +
+			"distinct output is being deduped away")
+	}
+	// Unknown halves must never group: an unidentifiable hive counts once, on
+	// its own, rather than being merged with every other unidentifiable hive.
+	if g := fleetCountGroup(RegistryEntry{Org: "bigco"}); g != "" {
+		t.Errorf("a hive with no AI author got group %q — it cannot be shown to duplicate anyone", g)
+	}
+	if g := fleetCountGroup(RegistryEntry{AIAuthor: "ai-bot"}); g != "" {
+		t.Errorf("a hive with no org got group %q", g)
+	}
+	// AIAuthorEffective is who the agents ACTUALLY author as and must win.
+	eff := fleetCountGroup(RegistryEntry{Org: "bigco", AIAuthor: "cfg", AIAuthorEffective: "app[bot]"})
+	if eff != "bigco/app[bot]" {
+		t.Errorf("effective author ignored: got %q", eff)
+	}
+}
+
+// --- Trust criterion set (BUG 2) ---------------------------------------------
+
+// TestTrustCriteriaSetIsExplicit stops Trust silently dropping a criterion.
+//
+// This is the exact failure being fixed: the governor criterion matched
+// "observe"/"advisory"/"enforce" while governor.Mode only ever emits SURGE,
+// BUSY, QUIET or IDLE, so it contributed to NOTHING on every hive in the fleet
+// — one of three Trust criteria gone, with the axis still rendering a plausible
+// number and nothing anywhere reporting a problem.
+//
+// Asserting the criterion SET by name means any future mismatch of this shape
+// fails loudly here instead of vanishing into a percentile.
+func TestTrustCriteriaSetIsExplicit(t *testing.T) {
+	// A hive reporting every trust signal the hub can receive.
+	full := quadrantInputs{
+		acmmLevel:       4,
+		reposEnrolled:   3,
+		reposInOrg:      9,
+		mergeAcceptance: fptr(0.8),
+	}
+	want := map[string]bool{
+		"autonomy":         true,
+		"merge_acceptance": true,
+		"breadth":          true,
+	}
+	got := map[string]bool{}
+	for _, c := range trustCriteria(full) {
+		got[c.name] = true
+	}
+	for name := range want {
+		if !got[name] {
+			t.Errorf("trust criterion %q did not fire on a hive reporting every trust signal — "+
+				"a criterion is being silently dropped", name)
+		}
+	}
+	for name := range got {
+		if !want[name] {
+			t.Errorf("unexpected trust criterion %q — if it is a real delegation signal, add it "+
+				"to want; if it is a proxy for one, it does not belong on Trust", name)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("trust scored on %d criteria, want %d: got %v", len(got), len(want), got)
+	}
+}
+
+// TestGovernorCadenceIsNotATrustSignal is the regression guard for the
+// conceptual half of the bug. The governor's modes are WORKLOAD CADENCE — how
+// hard it is currently driving agents — and must never be folded into Trust.
+// A hive at SURGE is busy, not trusted; a hive at IDLE is quiet, not
+// distrusted.
+//
+// The check is structural: no trust criterion may vary with the governor's
+// actual emitted modes, which is guaranteed here by quadrantInputs no longer
+// carrying the mode at all. If somebody reintroduces it, this fails.
+func TestGovernorCadenceIsNotATrustSignal(t *testing.T) {
+	for _, mode := range []string{"SURGE", "BUSY", "QUIET", "IDLE"} {
+		e := RegistryEntry{Org: "o", AIAuthor: "a", ACMMLevel: 3, GovernorMode: mode}
+		in := quadrantInputsFor(e, time.Now())
+		base := quadrantInputsFor(RegistryEntry{Org: "o", AIAuthor: "a", ACMMLevel: 3}, time.Now())
+		if len(trustCriteria(in)) != len(trustCriteria(base)) {
+			t.Errorf("governor mode %q changed the trust criteria — workload cadence is "+
+				"being read as a trust posture", mode)
+		}
+	}
+	// Positive control: something that IS a trust signal does change the set,
+	// proving the comparison above can detect a difference at all.
+	withACMM := trustCriteria(quadrantInputs{acmmLevel: 3})
+	without := trustCriteria(quadrantInputs{})
+	if len(withACMM) == len(without) {
+		t.Error("positive control failed: ACMM level did not change the trust criteria, " +
+			"so the cadence assertion above cannot detect anything")
+	}
+}
+
+// --- Activity ramp shape ------------------------------------------------------
+
+// TestActivityFactorRamp pins the ramp itself: zero at zero, linear to the
+// floor, flat above it, and exempt when no floor is set.
+func TestActivityFactorRamp(t *testing.T) {
+	if f := activityFactor(0, 10); f != 0 {
+		t.Errorf("zero activity gave factor %v, want 0 — idle would still rank", f)
+	}
+	if f := activityFactor(5, 10); f != 0.5 {
+		t.Errorf("half the floor gave factor %v, want 0.5 — the ramp is not linear", f)
+	}
+	if f := activityFactor(10, 10); f != 1 {
+		t.Errorf("at the floor the factor was %v, want 1", f)
+	}
+	if f := activityFactor(1000, 10); f != 1 {
+		t.Errorf("far above the floor the factor was %v, want 1 — activity beyond the "+
+			"floor must not keep inflating the rank", f)
+	}
+	// Exemption: ratios and postures where zero is a real (often good) value.
+	// Gating rework_rate would score the CLEANEST hives worst.
+	if f := activityFactor(0, 0); f != 1 {
+		t.Errorf("an exempt criterion was gated (factor %v, want 1) — criteria where zero "+
+			"is a good outcome would be inverted", f)
+	}
+}
+
+// TestCleanHiveNotPunishedByGate is the inversion guard for the exemption. A
+// hive with zero REJECTED PRs has the best possible rework rate; if the gate
+// were applied blanketly its zero would score it worst on efficiency, exactly
+// reversing the axis.
+func TestCleanHiveNotPunishedByGate(t *testing.T) {
+	qs := ScoreFleet(fleetOf(10, func(i int, in *quadrantInputs) {
+		in.prsMerged90d = iptr(20)
+		in.prsRejected90d = iptr(i * 2) // hive 0 clean, hive 9 mostly rework
+	}))
+	clean, ok1 := axisOf(qs[0], AxisEfficiency)
+	messy, ok2 := axisOf(qs[9], AxisEfficiency)
+	if !ok1 || !ok2 || !clean.Scored || !messy.Scored {
+		t.Fatal("expected efficiency to score for both hives")
+	}
+	if clean.Score <= messy.Score {
+		t.Errorf("the clean hive scored %d and the high-rework hive %d — the activity gate "+
+			"has inverted a lower-is-better criterion by treating its zero as idleness",
+			clean.Score, messy.Score)
 	}
 }
 


### PR DESCRIPTION
The quadrant is **live on the hub** and reporting a busy, healthy fleet that does not exist. Three compounding bugs, all from #4384.

Measured against the live registry (62 hives): `agentCount==0` on 13; `prsMerged90d` is nil on 25, zero on 28, and above zero on only 9 — of which three report the same `3746`.

## 1. Percentile blindness to absolute magnitude

Scores were pure fleet-relative percentiles. The standard definition counts ties as half, which puts a uniformly-tied population at **50**. So 28 hives that had merged nothing all scored ~50 *for doing nothing*, and a hive with **3 merged PRs in 90 days** outranked all 28 and landed near the top.

Every percentile is now multiplied by an **activity factor** from the criterion's raw magnitude — 0 at zero activity, linear to a per-criterion absolute floor, flat above it:

| case | before | after |
|---|---|---|
| idle hive, 0 merged PRs | ~50 | **0** |
| hive with 1 merged PR among 19 idle | ~95 | **10** |
| hive at the 10-PR floor | ~98 | **98** |

Multiplicative on purpose: rank still decides the order *among active hives*, magnitude decides whether a hive is in the conversation at all. The linear ramp avoids a cliff where the 10th PR is worth more than the previous nine.

Criteria whose zero is a real and often *good* value — rework rate, engagement ratios, inverse counts like SLA violations — are **explicitly exempt**, since gating them would score the cleanest hives worst and invert the axis. `TestCleanHiveNotPunishedByGate` guards that inversion.

**The scored/unscored distinction is preserved.** A measured zero SCORES (low); a nil stays `Scored=false` and renders as a collapsed spoke.

## 2. The governor criterion never worked, and was the wrong idea

`normalizeGovernorMode` matched `observe`/`advisory`/`enforce`. `governor.Mode` only ever emits `SURGE`/`BUSY`/`QUIET`/`IDLE`, so every hive fell through to `known=false` and **one of three Trust criteria contributed nothing, silently**, while the axis kept rendering a plausible number.

**Removed, not remapped.** Those values are workload *cadence*, not a trust posture — a hive at SURGE is busy, not trusted; one at IDLE is quiet, not distrusted.

No proxy is substituted. I searched for a real delegated-authority signal; all three that exist are spoke-side config that never travels on the heartbeat:

- `config.AutoMergeConfig.SelfAuthored` — the App merging its own PRs unreviewed, the strongest delegation bit in the product
- `config.ReviewConfig.RequireApproval`
- `config.AgentSandboxConfig` / `AgentConfig.Tools`

Recomputing a gate hub-side from `acmmLevel` was considered and rejected: it is a pure function of a value Trust *already* scores, so it adds no information while double-weighting autonomy and looking independent. Trust scores on three criteria and the code says so, with a note that reporting `SelfAuthoredAutoMergeAllowed` as a `*bool` on the heartbeat is what would give it a real fourth.

## 3. Org-shared counts were multiplied

`FleetStatsCollector` counts AI-author PRs across a whole **org**, so every hive in that org reports the org's entire output as its own — hence three hives each reporting `3746`. Counted three times, that one org adds two phantom members at the top and pushes every other hive's percentile down (an unrelated hive drops 45 → 35 in the test fixture).

Populations are now deduped by **(org, ai-author)** — exactly the pair `NewFleetStatsCollector(client, author, org)` queries with. Org alone would be too coarse: two teams in one org running different AI authors do produce genuinely distinct output. The group's **max** is kept, so a stale collector cannot decide the value. Hives with either half unknown stay ungrouped and count once.

This dedupes the *population* only; co-org hives still receive identical scores, which is correct — they are reporting the same underlying work.

## Predicted effect on the 62-hive fleet

- **28 measured-zero hives → ~0 productivity**, not ~50.
- **25 nil hives → unchanged**, still `Scored=false`, still collapsed spokes.
- The **9 active hives** are the only ones with meaningful productivity. The three at `3746` now count once, so they stop stretching the distribution; **208 / 60 / 53 / 30** clear the 10-PR floor and score on rank alone; **3 / 3** ramp to roughly a third of their rank instead of riding above 28 idle hives.
- **Trust** loses its dead criterion and moves for every hive — it was averaging 2 of 3 criteria fleet-wide.
- The fleet-average polygon should shrink noticeably on Productivity and Efficiency. That is the point: it will now show a mostly-idle fleet, because the fleet is mostly idle.

## Tests

Added, each with a positive control: all-idle fleet scores low not ~50; one merged PR does not reach the top decile *but still beats idle*; measured zero still differs from nil; org-shared counts do not multiply (with the triple-count counterfactual as the control); the activity ramp's shape; the clean-hive inversion guard; and `TestTrustCriteriaSetIsExplicit`, which **asserts the Trust criterion set by name** so a future mismatch of this shape fails loudly instead of vanishing into a percentile.

Changed: `fleetOf` no longer seeds `governorMode` with the three values that never existed — that fixture was encoding the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
