### PR TITLE
🐛 fix(hub): stop multiplying one org's PR counts in the public fleet total

### DIFF
--- a/src/pkg/hub/fleet_stats_test.go
+++ b/src/pkg/hub/fleet_stats_test.go
@@ -584,3 +584,225 @@ func TestFleetStatsLKG_PersistsAcrossReload(t *testing.T) {
 		t.Errorf("CollectedAt = %v, want %v", reloaded.FleetStatsLKG.CollectedAt, collectedAt)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Org dedupe of the org-scoped contribution counters.
+//
+// FleetStatsCollector counts AI-author PRs across a whole ORG, so every hive in
+// that org reports the org's entire output as its own. Summing them multiplies
+// one org's work by its hive count into a PUBLIC landing-page figure. These
+// tests pin that a group contributes once, and — the positive controls — that
+// dedupe does not simply collapse the whole fleet into one contribution.
+// ---------------------------------------------------------------------------
+
+// coHive builds a reporting hive in the given (org, ai-author) counting group.
+// Repos must be unique per hive or the eligibility gate skips it; they do not
+// affect the PR/CVE counters under test.
+func coHive(id, org, author string, merged int) RegistryEntry {
+	return RegistryEntry{
+		ID: id, IsPublic: true, Online: true, Org: org, AIAuthor: author,
+		Repos: []string{org + "/" + id}, PRsMerged90d: ptrInt(merged),
+		FleetStatsCollectedAt: time.Now(),
+	}
+}
+
+// TestFleetStatsCollapsesSameOrgCounts is the live bug: three hives in one org
+// each reported the org's whole 3746 merged PRs and the public total showed
+// 11238. It must show 3746.
+func TestFleetStatsCollapsesSameOrgCounts(t *testing.T) {
+	// The value measured on the live 62-hive fleet, reported identically by
+	// three hives sharing one org.
+	const sharedOrgMerged = 3746
+
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		coHive("h1", "acme", "ai-bot", sharedOrgMerged),
+		coHive("h2", "acme", "ai-bot", sharedOrgMerged),
+		coHive("h3", "acme", "ai-bot", sharedOrgMerged),
+	}
+
+	got := s.computeFleetStats()
+	if got.PRsMerged != sharedOrgMerged {
+		t.Errorf("PRsMerged = %d, want %d (one org's output counted once, not %d times)",
+			got.PRsMerged, sharedOrgMerged, len(s.registry.Hives))
+	}
+	// Positive control on the counterfactual: without dedupe this would be
+	// 11238, so the assertion above is actually testing something.
+	if got.PRsMerged == sharedOrgMerged*len(s.registry.Hives) {
+		t.Errorf("PRsMerged = %d, which is exactly the tripled value — dedupe did not run",
+			got.PRsMerged)
+	}
+	// Coverage counters stay per-hive: all three DID report, and collapsing
+	// them would understate how much of the fleet is collecting successfully.
+	if got.Reporting != 3 || got.Eligible != 3 {
+		t.Errorf("Reporting/Eligible = %d/%d, want 3/3 (coverage is per-hive, not per-org)",
+			got.Reporting, got.Eligible)
+	}
+}
+
+// TestFleetStatsSumsDistinctOrgsIndependently is the positive control for the
+// test above: a dedupe that collapsed EVERYTHING to one contribution would pass
+// the same-org test and be badly wrong. Different orgs, and same org with
+// different AI authors, are genuinely distinct work and must still add up.
+func TestFleetStatsSumsDistinctOrgsIndependently(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		coHive("h1", "acme", "ai-bot", 100),
+		coHive("h2", "globex", "ai-bot", 20),
+		// Same ORG as h1 but a different AI author — two teams in one org
+		// running different agents produce genuinely distinct output, so the
+		// group key is (org, author) and these must not collapse together.
+		coHive("h3", "acme", "other-bot", 3),
+	}
+
+	got := s.computeFleetStats()
+	if want := 123; got.PRsMerged != want {
+		t.Errorf("PRsMerged = %d, want %d (distinct (org, author) groups must sum independently)",
+			got.PRsMerged, want)
+	}
+}
+
+// TestFleetStatsGroupTakesMax pins that same-org hives whose collectors ran at
+// slightly different moments collapse to the LARGEST count, not the first seen
+// and not the smallest — over a fixed trailing window the freshest collect is
+// the largest, so the most complete measurement should stand rather than
+// collection order deciding the public number.
+func TestFleetStatsGroupTakesMax(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		coHive("h1", "acme", "ai-bot", 3740),
+		coHive("h2", "acme", "ai-bot", 3746),
+		coHive("h3", "acme", "ai-bot", 3742),
+	}
+
+	got := s.computeFleetStats()
+	if want := 3746; got.PRsMerged != want {
+		t.Errorf("PRsMerged = %d, want %d (group must collapse to its max)", got.PRsMerged, want)
+	}
+}
+
+// TestFleetStatsDedupeKeepsNilOutOfTotals guards the nil-vs-zero discipline the
+// *int counters exist for. A hive that never computed a counter must stay
+// invisible to it — dedupe must not materialize a group entry worth zero, and
+// must not let a nil sibling suppress a real value.
+func TestFleetStatsDedupeKeepsNilOutOfTotals(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		// Reports merged only; CVEs never computed.
+		coHive("h1", "acme", "ai-bot", 50),
+		// Same group, reports NOTHING for merged but does report CVEs. Its nil
+		// must not become a participating zero that could win the max, and its
+		// presence must not erase h1's 50.
+		{ID: "h2", IsPublic: true, Online: true, Org: "acme", AIAuthor: "ai-bot",
+			Repos: []string{"acme/r2"}, CVEsClosed: ptrInt(7),
+			FleetStatsCollectedAt: time.Now()},
+	}
+
+	got := s.computeFleetStats()
+	if got.PRsMerged != 50 {
+		t.Errorf("PRsMerged = %d, want 50 (a nil sibling must not suppress a real value)", got.PRsMerged)
+	}
+	if got.CVEsClosed != 7 {
+		t.Errorf("CVEsClosed = %d, want 7", got.CVEsClosed)
+	}
+	// Positive control: a group with NO reported value for a counter must
+	// contribute nothing to it rather than a fabricated zero. PRsRejected90d is
+	// nil on both hives here, so the total must be zero AND that zero must come
+	// from absence, which the Reporting pair distinguishes.
+	if got.PRsRejected != 0 {
+		t.Errorf("PRsRejected = %d, want 0 (neither hive reported it)", got.PRsRejected)
+	}
+	if got.Reporting != 2 {
+		t.Errorf("Reporting = %d, want 2 (both hives reported SOME counter)", got.Reporting)
+	}
+}
+
+// TestFleetStatsStaleGroupStillExcluded pins that dedupe did not smuggle a
+// stale count past the ageing rule. Staleness is evaluated PER HIVE before the
+// group is formed, so a group is represented by its FRESHEST surviving members
+// and a group with no fresh member contributes nothing at all.
+func TestFleetStatsStaleGroupStillExcluded(t *testing.T) {
+	stale := time.Now().Add(-2 * fleetStatsMaxAge)
+
+	t.Run("wholly stale group contributes nothing", func(t *testing.T) {
+		s := &HubServer{logger: slog.Default()}
+		h1 := coHive("h1", "acme", "ai-bot", 3746)
+		h1.FleetStatsCollectedAt = stale
+		h2 := coHive("h2", "acme", "ai-bot", 3746)
+		h2.FleetStatsCollectedAt = stale
+		s.registry.Hives = []RegistryEntry{h1, h2}
+
+		got := s.computeFleetStats()
+		if got.PRsMerged != 0 {
+			t.Errorf("PRsMerged = %d, want 0 (every member of the group is stale)", got.PRsMerged)
+		}
+		if got.Stale != 2 || got.Reporting != 0 {
+			t.Errorf("Stale/Reporting = %d/%d, want 2/0", got.Stale, got.Reporting)
+		}
+	})
+
+	// Positive control: one fresh member is enough to speak for the group, and
+	// a stale sibling's LARGER count must not ride in on the group's max — that
+	// is precisely how dedupe could have re-admitted aged-out data.
+	t.Run("fresh member represents group and stale sibling does not inflate it", func(t *testing.T) {
+		s := &HubServer{logger: slog.Default()}
+		fresh := coHive("h1", "acme", "ai-bot", 10)
+		aged := coHive("h2", "acme", "ai-bot", 999)
+		aged.FleetStatsCollectedAt = stale
+		s.registry.Hives = []RegistryEntry{fresh, aged}
+
+		got := s.computeFleetStats()
+		if got.PRsMerged != 10 {
+			t.Errorf("PRsMerged = %d, want 10 (stale sibling must not win the group max)", got.PRsMerged)
+		}
+		if got.Stale != 1 || got.Reporting != 1 {
+			t.Errorf("Stale/Reporting = %d/%d, want 1/1", got.Stale, got.Reporting)
+		}
+	})
+}
+
+// TestFleetStatsUngroupedHivesCountIndividually pins the safe default: a hive
+// whose org or AI author is unknown cannot be SHOWN to duplicate anyone, so it
+// counts on its own. Collapsing all unknowns into one bucket would silently
+// delete real work from the public total.
+func TestFleetStatsUngroupedHivesCountIndividually(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		// No AIAuthor -> ungrouped, even though the org matches.
+		{ID: "h1", IsPublic: true, Online: true, Org: "acme", Repos: []string{"acme/r1"},
+			PRsMerged90d: ptrInt(5), FleetStatsCollectedAt: time.Now()},
+		{ID: "h2", IsPublic: true, Online: true, Org: "acme", Repos: []string{"acme/r2"},
+			PRsMerged90d: ptrInt(7), FleetStatsCollectedAt: time.Now()},
+	}
+
+	got := s.computeFleetStats()
+	if want := 12; got.PRsMerged != want {
+		t.Errorf("PRsMerged = %d, want %d (unknown author means ungrouped, count each once)",
+			got.PRsMerged, want)
+	}
+}
+
+// TestFleetStatsDedupeAppliesToAllThreeCounters pins that the fix covers
+// PRsRejected90d and CVEsClosed too, not just the counter the bug was spotted
+// on. CVEsClosed has a different window (all-time, and a free-text "CVE-"
+// search) but it is collected by the same org-scoped query, so it multiplies
+// identically and is deduped identically.
+func TestFleetStatsDedupeAppliesToAllThreeCounters(t *testing.T) {
+	withAll := func(id string, merged, rejected, cves int) RegistryEntry {
+		e := coHive(id, "acme", "ai-bot", merged)
+		e.PRsRejected90d = ptrInt(rejected)
+		e.CVEsClosed = ptrInt(cves)
+		return e
+	}
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		withAll("h1", 100, 20, 5),
+		withAll("h2", 100, 20, 5),
+	}
+
+	got := s.computeFleetStats()
+	if got.PRsMerged != 100 || got.PRsRejected != 20 || got.CVEsClosed != 5 {
+		t.Errorf("merged/rejected/cves = %d/%d/%d, want 100/20/5 (all three counters dedupe)",
+			got.PRsMerged, got.PRsRejected, got.CVEsClosed)
+	}
+}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -3065,9 +3065,14 @@ func isAvailableRegistryEntry(h RegistryEntry) bool {
 // repos are counted across hives (deduplicated by org/repo reference) so two
 // hives on the same repo don't double-count it.
 //
+// The PR and CVE counters are deduplicated the same way, for the same reason:
+// they are ORG-scoped, so several hives in one org each report that org's whole
+// output and summing them multiplies it. See fleetCountAccumulator.
+//
 // Caller must hold s.mu (read or write).
 func (s *HubServer) computeFleetStats() FleetStats {
 	var fs FleetStats
+	var counts fleetCountAccumulator
 	repoSet := make(map[string]struct{})
 	for _, h := range s.registry.Hives {
 		// An UNASSIGNED hive is a pre-provisioned placeholder nobody has claimed
@@ -3160,18 +3165,116 @@ func (s *HubServer) computeFleetStats() FleetStats {
 			continue
 		}
 		fs.Reporting++
-		if h.PRsMerged90d != nil {
-			fs.PRsMerged += *h.PRsMerged90d
-		}
-		if h.PRsRejected90d != nil {
-			fs.PRsRejected += *h.PRsRejected90d
-		}
-		if h.CVEsClosed != nil {
-			fs.CVEsClosed += *h.CVEsClosed
-		}
+		// Accumulate into the (org, ai-author) group rather than straight into
+		// the total. Only the group's MAX is summed at the end, so an org-wide
+		// counter reported by several hives lands in the public figure once.
+		//
+		// Reporting/Eligible/Stale above stay PER-HIVE on purpose: they measure
+		// collection coverage ("how much of the fleet answered"), which is a
+		// question about hives, not about work. Deduping them would understate
+		// how much of the fleet is healthy.
+		group := fleetCountGroup(h)
+		counts.add(group, h.PRsMerged90d, h.PRsRejected90d, h.CVEsClosed)
 	}
+	fs.PRsMerged, fs.PRsRejected, fs.CVEsClosed = counts.totals()
 	fs.ReposManaged = len(repoSet)
 	return fs
+}
+
+// fleetCountAccumulator sums org-scoped contribution counters while collapsing
+// hives that report the SAME underlying work down to a single contribution.
+//
+// Needed because FleetStatsCollector counts AI-author PRs across a whole ORG
+// (see NewFleetStatsCollector), so every hive in an org reports that org's
+// entire output as its own. Summing those with += multiplies one org's number
+// by its hive count — measured live, three hives each reported prsMerged90d
+// = 3746 and the public landing-page total carried 11238 for work done once.
+//
+// Grouping is by fleetCountGroup, the same (org, ai-author) key the quadrant's
+// population dedupe uses, so the two surfaces cannot drift into disagreeing
+// about which hives are duplicates of each other.
+type fleetCountAccumulator struct {
+	// merged/rejected/cves map a group key to the largest value seen for it.
+	// Absent key means no hive in that group has reported that counter, which
+	// is NOT the same as a reported zero — see add.
+	merged   map[string]int
+	rejected map[string]int
+	cves     map[string]int
+	// ungrouped holds the running sum for hives whose group is unknown. They
+	// cannot be shown to duplicate anyone, so each counts on its own.
+	ungroupedMerged   int
+	ungroupedRejected int
+	ungroupedCVEs     int
+}
+
+// add folds one reporting hive's counters in. Each counter is handled
+// independently because a hive may report some and not others.
+//
+// nil means "this hive never computed that counter" and is skipped entirely, so
+// dedupe can never turn an unreported counter into a participating zero — the
+// nil-vs-zero discipline the *int pointers exist to preserve. A group whose
+// members are all nil for a counter contributes nothing to it, exactly as
+// before dedupe.
+func (a *fleetCountAccumulator) add(group string, merged, rejected, cves *int) {
+	if group == "" {
+		if merged != nil {
+			a.ungroupedMerged += *merged
+		}
+		if rejected != nil {
+			a.ungroupedRejected += *rejected
+		}
+		if cves != nil {
+			a.ungroupedCVEs += *cves
+		}
+		return
+	}
+	// Keep the MAXIMUM, not the first or the mean. The counter is org-wide and
+	// identical by construction, so in the healthy case every choice agrees;
+	// they differ only when the group's collectors ran at different moments,
+	// and over a fixed trailing window the freshest collect is the largest.
+	// Taking the max therefore lets the most complete measurement stand instead
+	// of letting collection timing pick the answer.
+	//
+	// Staleness needs no separate group-level rule: the ageing check above runs
+	// PER HIVE before this point, so a stale member is already dropped and the
+	// group is represented by its surviving fresh members. A group whose
+	// members are ALL stale contributes no value at all and is counted in
+	// fs.Stale, which is the conservative reading — the group is excluded
+	// exactly when nothing fresh remains to speak for it.
+	a.merged = maxInto(a.merged, group, merged)
+	a.rejected = maxInto(a.rejected, group, rejected)
+	a.cves = maxInto(a.cves, group, cves)
+}
+
+// maxInto records v as group's representative if it beats what is already
+// stored, lazily allocating m. A nil v records nothing, so an unreported
+// counter never creates a zero-valued entry.
+func maxInto(m map[string]int, group string, v *int) map[string]int {
+	if v == nil {
+		return m
+	}
+	if m == nil {
+		m = make(map[string]int)
+	}
+	if cur, seen := m[group]; !seen || *v > cur {
+		m[group] = *v
+	}
+	return m
+}
+
+// totals sums each group's single representative alongside the ungrouped hives.
+func (a *fleetCountAccumulator) totals() (merged, rejected, cves int) {
+	return a.ungroupedMerged + sumValues(a.merged),
+		a.ungroupedRejected + sumValues(a.rejected),
+		a.ungroupedCVEs + sumValues(a.cves)
+}
+
+func sumValues(m map[string]int) int {
+	var total int
+	for _, v := range m {
+		total += v
+	}
+	return total
 }
 
 // FleetStatsTrustworthy reports whether ANY hive contributed a fresh count.


### PR DESCRIPTION
The public `/api/fleet-stats` total on the landing page multiplies one org's output by the number of hives in that org.

`FleetStatsCollector` counts AI-author PRs across a whole **org** — `NewFleetStatsCollector(ghClient, author, org)`. So every hive in an org reports the org's entire output as its own, and `computeFleetStats` summed those with `+=`.

**Measured on the live 62-hive fleet:** three hives each report `prsMerged90d: 3746`. The next largest values are 208, 60, 53, 30, 3, 3. The published total therefore carried **11238** for work done once — 7492 phantom PRs, more than the entire rest of the fleet combined (357), on a public-facing number.

## Fix

The three org-scoped counters (`PRsMerged90d`, `PRsRejected90d`, `CVEsClosed`) now accumulate per **(org, ai-author)** group; only each group's single representative is summed.

**This is the same root cause as #4521**, which fixed it on the quadrant's scoring population. This PR **reuses that PR's `fleetCountGroup` helper directly** rather than writing a second dedupe rule — two independent notions of "which hives are duplicates" over the same data is exactly how these drift apart. Nothing was re-implemented, nothing copied. #4521 merged while this was being written, so this targets `v4` normally and the helper is already there.

### Why (org, ai-author) and not org alone

That pair is exactly what the collector queries with. Two hives agreeing on both are not two similar measurements, they are one measurement reported twice. Org alone is too coarse — two teams in one org running different AI authors do produce genuinely distinct output. A hive with either half unknown stays **ungrouped and counts once**, the safe default: it cannot be shown to duplicate anyone, and collapsing all unknowns together would silently delete real work.

### Group max, not first or mean

The counter is org-wide and identical by construction, so in the healthy case every choice agrees. They differ only when the group's collectors ran at different moments, and over a fixed trailing window the freshest collect is the largest. Taking the max lets the most complete measurement stand instead of letting collection order pick the public number.

### Staleness

**Unchanged, and deliberately given no separate group-level rule.** The existing `fleetStatsMaxAge` ageing runs **per hive, before** the group is formed, which already yields the conservative reading:

- a stale member is dropped, so the group is represented by its **freshest surviving members**;
- a stale member's larger count can **not** ride in on the group max (regression-tested — that is the specific way dedupe could have re-admitted aged-out data);
- a group whose members are **all** stale contributes nothing and lands in `fs.Stale`, i.e. excluded exactly when nothing fresh remains to speak for it.

### nil-vs-zero preserved

`nil` is skipped entirely, per counter, so dedupe never materializes a group entry worth zero and a nil sibling never suppresses a real value. A group with no reported value for a counter contributes nothing to it, exactly as before.

### Coverage counters stay per-hive

`Reporting` / `Eligible` / `Stale` are **not** deduped. They measure collection coverage — "how much of the fleet answered" — a question about hives, not about work. Deduping them would understate how much of the fleet is healthy and move the trustworthiness gate for the wrong reason.

### CVEsClosed

Deduped identically, because it comes from the same org-scoped query and multiplies the same way. Its differing semantics — all-time rather than 90d, and a free-text `"CVE-"` search that matches PRs *referencing* a CVE — are **out of scope here** and untouched.

## Effect on the measured fleet

The three `3746` hives collapse to one contribution:

| | before | after |
|---|---|---|
| the shared org | 11238 | **3746** |
| rest of fleet | 357 | 357 |
| **public total** | **11595** | **4103** |

A ~2.8x overstatement removed from a public statistic, and the shared org is no longer larger than the whole remaining fleet by 20x.

## Tests

Each with a positive control:

- three hives in one org contribute that org's count **once**, with the tripled value asserted against as the counterfactual so the test cannot pass vacuously
- **distinct orgs still sum independently** — including same-org/different-author, the control against a dedupe that just collapses everything into one
- same-org hives with slightly different counts collapse to the **max**
- a nil-reporting hive does not become a participating zero, and does not suppress a sibling's real value
- a wholly-stale group is still excluded; a fresh member represents the group and a stale sibling's larger count does not win the max
- ungrouped (unknown author) hives each count once
- all three counters dedupe, not just the one the bug was spotted on

Existing `fleet_stats_test.go` fixtures share `Org: "a"` but report no AI author, so they are ungrouped and their expectations are unaffected — the dedupe is inert on them by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)