### PR TITLE
fix(agent): run copilot session-refresh once at startup, not only on tick

### DIFF
--- a/src/pkg/agent/copilot_session_startdelay_test.go
+++ b/src/pkg/agent/copilot_session_startdelay_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCopilotSessionRefreshStartDelay(t *testing.T) {
+	t.Setenv(CopilotSessionRefreshStartDelayEnv, "")
+	if got := copilotSessionRefreshStartDelay(); got != defaultCopilotSessionRefreshStartDelay {
+		t.Errorf("default = %v, want %v", got, defaultCopilotSessionRefreshStartDelay)
+	}
+	t.Setenv(CopilotSessionRefreshStartDelayEnv, "0s")
+	if got := copilotSessionRefreshStartDelay(); got != 0 {
+		t.Errorf("0s override = %v, want 0 (tests drive near-zero)", got)
+	}
+	t.Setenv(CopilotSessionRefreshStartDelayEnv, "5s")
+	if got := copilotSessionRefreshStartDelay(); got != 5*time.Second {
+		t.Errorf("5s override = %v, want 5s", got)
+	}
+	t.Setenv(CopilotSessionRefreshStartDelayEnv, "garbage")
+	if got := copilotSessionRefreshStartDelay(); got != defaultCopilotSessionRefreshStartDelay {
+		t.Errorf("invalid override should fall back, got %v", got)
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1007,6 +1007,20 @@ func copilotSessionRefreshInterval() time.Duration {
 // store is EMPTY (or absent) — it never overwrites a token the CLI itself wrote
 // and is still using, so it can't clobber a live session.
 func (m *Manager) StartCopilotSessionRefresh(ctx context.Context) {
+	// Run once shortly after start rather than waiting a full interval for the
+	// first tick. Spokes that roll faster than the interval (ks/hive rolls every
+	// ~15-30m) would otherwise seldom reach the first tick before the pod dies,
+	// so a promote/seed could be perpetually deferred. The short settle delay
+	// lets the agents' CLIs write their config.json first, so a login done just
+	// before/at boot is visible to the promote path. Bounded by ctx so a fast
+	// shutdown does not block.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(copilotSessionRefreshStartDelay()):
+		m.refreshCopilotSessionToken()
+	}
+
 	ticker := time.NewTicker(copilotSessionRefreshInterval())
 	defer ticker.Stop()
 	for {
@@ -1017,6 +1031,25 @@ func (m *Manager) StartCopilotSessionRefresh(ctx context.Context) {
 			m.refreshCopilotSessionToken()
 		}
 	}
+}
+
+// copilotSessionRefreshStartDelay is how long to wait after boot before the
+// first session-token reconcile, giving agent CLIs time to write config.json.
+// Env-overridable (HIVE_COPILOT_SESSION_REFRESH_START_DELAY) mainly so tests
+// can drive it to near-zero.
+const defaultCopilotSessionRefreshStartDelay = 30 * time.Second
+
+// CopilotSessionRefreshStartDelayEnv overrides the start delay with a Go
+// duration. Non-positive/invalid values fall back to the default.
+const CopilotSessionRefreshStartDelayEnv = "HIVE_COPILOT_SESSION_REFRESH_START_DELAY"
+
+func copilotSessionRefreshStartDelay() time.Duration {
+	if v := os.Getenv(CopilotSessionRefreshStartDelayEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+			return d
+		}
+	}
+	return defaultCopilotSessionRefreshStartDelay
 }
 
 // refreshCopilotSessionToken keeps the Copilot credential in sync between the


### PR DESCRIPTION
Observed live on ks/hive while validating #4494/#4519: both deployed correctly, but the promote/seed **had not fired** — because the pod was only 3 min old and the first refresh tick is at **10 min**.

**The weakness:** ks/hive rolls every **~15-30 min** — faster than (or close to) the 10-min interval — so a spoke can seldom reach the first tick before the pod dies. The promote (in-agent login → durable) and seed (durable → empty config) get perpetually deferred, which is exactly why the operator's in-agent token still hadn't promoted to the durable file 3 min after the roll.

**Fix:** run `refreshCopilotSessionToken` **once shortly after boot** (default 30s settle, `HIVE_COPILOT_SESSION_REFRESH_START_DELAY`) before entering the ticker loop — so a login is reconciled within seconds of every pod start instead of up to a full interval later. The short settle lets agent CLIs write `config.json` first; the wait is `ctx`-bounded so shutdown is never blocked.

Completes the #4424 → #4494 → #4519 chain: the fix now acts promptly on every roll, not just on long-lived pods.

Test: start-delay resolver (default / 0s / override / invalid-fallback).

gofmt clean; DCO-signed.