### PR TITLE
✨ fleet: parked state for all-quiet hives, nav avatar + menu, quiet-aware advisory staleness

### DIFF
--- a/src/pkg/hub/advisory_diagnostics.go
+++ b/src/pkg/hub/advisory_diagnostics.go
@@ -43,6 +43,10 @@ const (
 	// advisoryClassAppCannotWrite: an aged timestamp suppressed because the App
 	// cannot write and the spoke reported no error to prove it even tried.
 	advisoryClassAppCannotWrite = "suppressed-app-cannot-write"
+	// advisoryClassAgentsQuiet: an aged timestamp suppressed because EVERY
+	// agent on the hive is deliberately quiet (paused / off-schedule) — no
+	// agents, no findings, no digest: the operator's own choice, not a wedge.
+	advisoryClassAgentsQuiet = "suppressed-agents-quiet"
 	// advisoryClassUnknownTimestamp: a reported post time that will not parse.
 	advisoryClassUnknownTimestamp = "unknown-timestamp"
 )
@@ -131,6 +135,10 @@ func diagnoseAdvisory(e RegistryEntry, now time.Time) AdvisoryDiagnosis {
 	case !appCanWriteForAdvisory(e):
 		d.Class = advisoryClassAppCannotWrite
 		d.Reason = "aged digest suppressed because the GitHub App cannot write"
+		d.HiddenStale = aged
+	case allAgentsQuietByDesign(e):
+		d.Class = advisoryClassAgentsQuiet
+		d.Reason = "aged digest suppressed because every agent is paused or off-schedule"
 		d.HiddenStale = aged
 	case parseErr != nil:
 		d.Class = advisoryClassUnknownTimestamp

--- a/src/pkg/hub/advisory_staleness.go
+++ b/src/pkg/hub/advisory_staleness.go
@@ -1,6 +1,9 @@
 package hub
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // advisoryStaleThreshold is how long a hive's advisory digest may go without a
 // successful update before the hub flags it as stale. Advisory digests are
@@ -79,6 +82,39 @@ func appAwaitingDelivery(e RegistryEntry) bool {
 	}
 }
 
+// allAgentsQuietByDesign reports whether EVERY agent this hive reports is
+// deliberately quiet — paused by the operator, or not expected active in the
+// current governor mode. Advisory findings come from agents; with all of them
+// intentionally off there is nothing new to digest, so an advisory timestamp
+// that merely AGES in that state is the operator's own choice, not a wedge,
+// and must not light the stale pill (a reported post ERROR still does — a
+// broken post path is broken regardless of who is paused).
+//
+// Deliberately conservative in the unknowns' favor: a hive reporting NO agents
+// (legacy spoke, or the field lost in transit) returns false, so this gate
+// never suppresses a real alarm on a spoke we cannot read. A legacy agent
+// entry (none of the new protocol fields) also returns false for the same
+// reason. The pause detection mirrors deriveAgentVerdict's quiet-by-design
+// arms: Paused/state=paused, or a new-protocol agent that is not expected
+// active and not running.
+func allAgentsQuietByDesign(e RegistryEntry) bool {
+	if len(e.Agents) == 0 {
+		return false
+	}
+	for _, a := range e.Agents {
+		if legacyAgent(a) {
+			return false
+		}
+		paused := a.Paused || strings.EqualFold(a.State, agentStatePaused)
+		running := strings.EqualFold(a.State, agentStateRunning)
+		offByDesign := !a.ExpectedActive && !running
+		if !paused && !offByDesign {
+			return false
+		}
+	}
+	return true
+}
+
 // carryAdvisoryPostTime preserves the last known advisory-post time on a
 // heartbeat that reports none (#4167).
 //
@@ -127,7 +163,10 @@ func carryAdvisoryPostTime(entry *RegistryEntry, prev RegistryEntry) {
 //     operator must see, even though the same failure raises the App banner.
 //     - an AGED timestamp is suppressed whenever the App cannot write at all
 //     (appCanWriteForAdvisory): with no error reported there is no proof the
-//     hive even tried, so its silence is expected.
+//     hive even tried, so its silence is expected. It is also suppressed when
+//     EVERY agent is deliberately quiet (allAgentsQuietByDesign): paused/off
+//     agents produce no findings, so an ageing digest is the operator's own
+//     pause, not a wedge.
 //
 // An empty/unparseable AdvisoryLastPostedAt with no AdvisoryError is UNKNOWN and
 // returns false — never a false alarm — matching the rule the codebase already
@@ -155,6 +194,14 @@ func advisoryStale(e RegistryEntry, now time.Time) (stale bool, reason string) {
 	// Gate 2b: with no error reported, an App that cannot write is expected to
 	// be quiet, not broken.
 	if !appCanWriteForAdvisory(e) {
+		return false, ""
+	}
+
+	// Gate 2c: with no error reported and EVERY agent deliberately quiet
+	// (paused / off-schedule), an ageing digest is the expected consequence of
+	// the operator's own pause — findings come from agents, and none are
+	// running to produce them. Not a fault, never a pill.
+	if allAgentsQuietByDesign(e) {
 		return false, ""
 	}
 

--- a/src/pkg/hub/advisory_staleness_test.go
+++ b/src/pkg/hub/advisory_staleness_test.go
@@ -48,6 +48,70 @@ func TestAdvisoryStale_PastThresholdIsStale(t *testing.T) {
 	}
 }
 
+// pausedAgent / offScheduleAgent / activeAgent build the AgentSummary shapes
+// the quiet-by-design gate discriminates. ExpectedActive/Enabled/CanOpenIssue
+// are set so none of them read as legacy (legacyAgent must return false).
+func pausedAgent(name string) AgentSummary {
+	return AgentSummary{Name: name, State: agentStatePaused, Paused: true, Enabled: true, CanOpenIssue: true}
+}
+func offScheduleAgent(name string) AgentSummary {
+	return AgentSummary{Name: name, State: "idle", ExpectedActive: false, Enabled: true, CanOpenIssue: true}
+}
+func activeAgent(name string) AgentSummary {
+	return AgentSummary{Name: name, State: agentStateRunning, ExpectedActive: true, Enabled: true, CanOpenIssue: true}
+}
+
+// An aged digest on a hive whose EVERY agent is deliberately quiet (paused or
+// off-schedule) is the operator's own pause, not a wedge — never a pill.
+func TestAdvisoryStale_AllAgentsQuietSuppressesAgedTimestamp(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Hour)
+	e.Agents = []AgentSummary{pausedAgent("scanner"), offScheduleAgent("guide")}
+	if stale, reason := advisoryStale(e, advNow); stale {
+		t.Fatalf("all agents quiet by design must suppress the aged-digest alarm, got %q", reason)
+	}
+}
+
+// A reported post ERROR is a broken post path regardless of who is paused —
+// the quiet gate must not swallow it.
+func TestAdvisoryStale_AllAgentsQuietDoesNotSuppressError(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryError = "403 posting digest comment"
+	e.Agents = []AgentSummary{pausedAgent("scanner"), pausedAgent("guide")}
+	if stale, _ := advisoryStale(e, advNow); !stale {
+		t.Fatalf("a reported post error must stay stale even with every agent paused")
+	}
+}
+
+// One working agent means findings are expected — the aged alarm stands.
+func TestAdvisoryStale_OneActiveAgentKeepsAgedAlarm(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Hour)
+	e.Agents = []AgentSummary{pausedAgent("scanner"), activeAgent("guide")}
+	if stale, _ := advisoryStale(e, advNow); !stale {
+		t.Fatalf("an active agent must keep the aged-digest alarm")
+	}
+}
+
+// Unknowns never suppress: no reported agents, or a legacy agent that reports
+// none of the new protocol fields, must leave the alarm in place.
+func TestAdvisoryStale_UnknownAgentsNeverSuppress(t *testing.T) {
+	aged := func() RegistryEntry {
+		e := advisoryModeEntry()
+		e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Hour)
+		return e
+	}
+	e := aged() // no agents reported at all
+	if stale, _ := advisoryStale(e, advNow); !stale {
+		t.Fatalf("a hive reporting no agents must not have the alarm suppressed")
+	}
+	e = aged()
+	e.Agents = []AgentSummary{{Name: "old"}} // legacy shape: no new-protocol fields
+	if stale, _ := advisoryStale(e, advNow); !stale {
+		t.Fatalf("a legacy agent entry must not suppress the alarm")
+	}
+}
+
 func TestAdvisoryStale_ErrorIsStaleWithCause(t *testing.T) {
 	e := advisoryModeEntry() // fresh timestamp, but the last attempt errored
 	e.AdvisoryError = "403 Resource not accessible by integration"

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2983,6 +2983,14 @@ type MyHiveEntry struct {
 	InactiveAgents       int    `json:"inactiveAgents,omitempty"`
 	InactiveAgentsReason string `json:"inactiveAgentsReason,omitempty"`
 
+	// AllAgentsQuiet is true when EVERY agent this hive reports is deliberately
+	// quiet — paused or off-schedule. This is "hive not in use": nothing is
+	// broken, nothing will be produced, and the same condition suppresses the
+	// advisory-staleness pill (allAgentsQuietByDesign). Computed on read so the
+	// browser never re-derives the pause/off-schedule rule; the fleet page
+	// renders it as a distinct state chip rather than health or fault.
+	AllAgentsQuiet bool `json:"allAgentsQuiet,omitempty"`
+
 	// FleetRollup / AgentVerdicts carry the three-way divergence view — what the
 	// governor EXPECTS running, what is ACTUALLY running, and what is ABLE to
 	// fulfill its mission — computed on read from the per-agent heartbeat
@@ -3457,6 +3465,12 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			result[i].InactiveAgents = rep.Count
 			result[i].InactiveAgentsReason = rep.Reason
 		}
+
+		// "Hive not in use": every reported agent deliberately quiet. Same
+		// predicate that suppresses the advisory-stale pill, surfaced as its
+		// own state so an entirely-parked hive reads as PARKED, not healthy
+		// and not broken.
+		result[i].AllAgentsQuiet = allAgentsQuietByDesign(result[i].RegistryEntry)
 
 		// Fleet-divergence view: derive the three-way picture (expected vs
 		// actual vs able) and the per-agent verdicts from the same per-agent

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -159,6 +159,19 @@
   .hdot.ok { background: var(--green); }
   .hdot.unknown { background: var(--gray); }
   .hdot.offline { background: transparent; border: 1px solid var(--gray); }
+  .hdot.parked { background: transparent; border: 1px dashed var(--gray); }
+  .parked-chip { display: inline-block; margin-left: 6px; padding: 1px 7px; border-radius: 9px; font-size: 10.5px; color: var(--gray); border: 1px dashed var(--gray); vertical-align: 1px; }
+  /* Signed-in avatar + its menu, matching the spoke dashboard's nav avatar:
+     the image is the affordance, the dialog is right-anchored so extra width
+     grows leftward and stays on screen. Shown on hover AND kept open by
+     click (touch/keyboard operable), never hover-only. */
+  #nav-avatar { width: 28px; height: 28px; border-radius: 50%; cursor: pointer; border: 2px solid var(--green, #46a758); vertical-align: middle; }
+  #nav-user-menu { display: none; position: absolute; right: 0; top: 34px; background: var(--panel, #16181d); border: 1px solid var(--line, #2a2e37); border-radius: 8px; padding: 4px 0; min-width: 170px; max-width: min(280px, calc(100vw - 24px)); z-index: 9999; box-shadow: 0 8px 24px rgba(0,0,0,.4); text-align: left; }
+  #nav-avatar-wrap.open #nav-user-menu, #nav-avatar-wrap:hover #nav-user-menu { display: block; }
+  #nav-user-menu > div#nav-menu-user { padding: 8px 16px; border-bottom: 1px solid var(--line, #2a2e37); font-weight: 600; font-size: .85rem; }
+  #nav-user-menu > div#nav-menu-role { padding: 2px 16px 6px; border-bottom: 1px solid var(--line, #2a2e37); font-size: .72rem; color: var(--gray); }
+  #nav-user-menu > a, #nav-user-menu > button { display: block; width: 100%; box-sizing: border-box; text-align: left; padding: 8px 16px; background: none; border: none; color: inherit; text-decoration: none; font-size: .82rem; cursor: pointer; }
+  #nav-user-menu > a:hover, #nav-user-menu > button:hover { background: rgba(255,255,255,.06); }
   /* Problem hives get a red left border so the eye lands on them. */
   tr.spoke.health-problem td:first-child { border-left: 3px solid var(--red); }
   tr.spoke.health-problem { background: rgba(229,72,77,.05); }
@@ -195,6 +208,17 @@
   </nav>
   <div class="header-right">
     <span id="hub-version"></span>
+    <span id="nav-avatar-wrap" style="display:none;position:relative">
+      <img id="nav-avatar" src="" alt="" title="">
+      <div id="nav-user-menu" role="menu">
+        <div id="nav-menu-user"></div>
+        <div id="nav-menu-role" style="display:none"></div>
+        <a href="#" id="nav-menu-profile" target="_blank" rel="noopener noreferrer" style="display:none">GitHub profile ↗</a>
+        <a href="/dashboard">My Hives</a>
+        <a href="/api/docs" target="_blank" rel="noopener noreferrer">API Docs ↗</a>
+        <button type="button" id="nav-menu-signout">Sign out</button>
+      </div>
+    </span>
     <a href="#" class="header-link" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
   </div>
 </header>
@@ -238,7 +262,7 @@
 </header>
 <div class="wrap">
   <div class="legend">
-    <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting)</span>
+    <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting) · <span class="hdot parked"></span> parked (all agents quiet by design — hive not in use)</span>
     <span><b>advisory output:</b> <span class="advisory-activity fresh"><span class="light"></span>fresh</span> · <span class="advisory-activity aging"><span class="light"></span>aging</span> · <span class="advisory-activity stale"><span class="light"></span>stale</span> · <span class="advisory-activity unknown"><span class="light"></span>n/a</span></span>
     <span><b>budget:</b> <span class="budget-health ok"><span class="light"></span>ok</span> · <span class="budget-health warning"><span class="light"></span>warning</span> · <span class="budget-health critical"><span class="light"></span>critical</span> · <span class="budget-health exhausted"><span class="light"></span>exhausted</span> · <span class="budget-health unknown"><span class="light"></span>n/a</span></span>
     <span><b>gh app:</b> <span class="github-app-health ok"><span class="light"></span>ok</span> · <span class="github-app-health degraded"><span class="light"></span>stale</span> · <span class="github-app-health broken"><span class="light"></span>broken</span> · <span class="github-app-health unknown"><span class="light"></span>n/a</span></span>
@@ -408,10 +432,15 @@ function deltaHTML(a) {
 // → unknown; else ok. Online/offline is NOT health — a spoke can be online with
 // every agent stuck.
 function hiveHealth(h) {
-  if (((h.advisoryIssueActivity || {}).bucket || "") === "stale") return "problem";
+  // Parked — every agent deliberately quiet (hive not in use). Checked before
+  // the output-side signals: a hive nobody is running produces no advisories
+  // and burns no budget, so stale/exhausted readings are the pause's own
+  // consequence, not faults. A broken GitHub App still outranks parked — auth
+  // infrastructure is broken whether or not anyone is using the hive.
   if (((h.githubAppHealth || {}).bucket || "") === "broken") return "problem";
-  var budget = ((h.budgetHealth || {}).bucket || "");
-  if (budget === "critical" || budget === "exhausted") return "problem";
+  if (h.allAgentsQuiet) return "parked";
+  if (((h.advisoryIssueActivity || {}).bucket || "") === "stale") return "problem";
+  if (((h.budgetHealth || {}).bucket || "") === "critical" || ((h.budgetHealth || {}).bucket || "") === "exhausted") return "problem";
   var r = h.fleetRollup;
   if (!r) return h.online ? "unknown" : "offline";
   if ((r.problems || 0) > 0) return "problem";
@@ -452,7 +481,7 @@ function renderHives(hives) {
   hives = hives || [];
 
   // Rank: problems first, then unknown, then ok; stable within a rank by name.
-  var rank = { problem: 0, unknown: 1, offline: 2, ok: 3 };
+  var rank = { problem: 0, unknown: 1, offline: 2, parked: 3, ok: 4 };
   var rows = hives.map(function (h) { return { h: h, health: hiveHealth(h) }; });
   rows.sort(function (a, b) {
     var d = (rank[a.health] || 9) - (rank[b.health] || 9);
@@ -487,7 +516,7 @@ function renderHives(hives) {
     tr.className = "spoke health-" + health + (open ? " open" : "");
     tr.innerHTML =
       '<td><span class="chev">▶</span></td>' +
-      '<td><span class="hdot ' + health + '" title="' + health + '"></span>' + hiveNameHTML(h) + '</td>' +
+      '<td><span class="hdot ' + health + '" title="' + health + '"></span>' + hiveNameHTML(h) + (health === "parked" ? '<span class="parked-chip" title="every agent is paused or off-schedule — hive not in use">parked</span>' : "") + '</td>' +
       '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
       '<td>' + modeBadge(h.governorMode) + '</td>' +
       '<td>' + versionHTML(h) + '</td>' +
@@ -587,6 +616,43 @@ function load() {
 wireControls();
 load();
 setInterval(load, 30000);
+
+// Signed-in avatar + menu, same identity source the hub landing page uses
+// (/api/auth/user: login, avatar_url, hub_admin, optional country code).
+(function () {
+  fetch("/api/auth/user", { credentials: "same-origin" })
+    .then(function (r) { return r.json(); })
+    .then(function (d) {
+      if (!d || !d.authenticated) return;
+      var wrap = document.getElementById("nav-avatar-wrap");
+      var img = document.getElementById("nav-avatar");
+      if (!wrap || !img) return;
+      img.src = d.avatar_url || "";
+      img.alt = d.login || "";
+      img.title = d.login || "";
+      // Country code → flag glyph, derived the same way the dashboard does
+      // (two regional-indicator symbols), shown beside the login in the menu.
+      var flag = "";
+      if (d.country && /^[A-Za-z]{2}$/.test(d.country)) {
+        var cc = d.country.toUpperCase();
+        flag = " " + String.fromCodePoint(0x1F1E6 + cc.charCodeAt(0) - 65, 0x1F1E6 + cc.charCodeAt(1) - 65);
+      }
+      document.getElementById("nav-menu-user").textContent = (d.login || "") + flag;
+      var role = document.getElementById("nav-menu-role");
+      if (role) { role.textContent = d.hub_admin ? "hub admin" : "member"; role.style.display = ""; }
+      var prof = document.getElementById("nav-menu-profile");
+      if (prof && d.login) { prof.href = "https://github.com/" + encodeURIComponent(d.login); prof.style.display = ""; }
+      var out = document.getElementById("nav-menu-signout");
+      if (out) out.addEventListener("click", function () {
+        fetch("/api/auth/logout", { method: "POST" }).then(function () { location.href = "/"; });
+      });
+      // Click pins the menu open (touch/keyboard); hover is handled in CSS.
+      img.addEventListener("click", function (e) { e.stopPropagation(); wrap.classList.toggle("open"); });
+      document.addEventListener("click", function () { wrap.classList.remove("open"); });
+      wrap.style.display = "";
+    })
+    .catch(function () {});
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **Quiet-aware advisory staleness**: an aged digest is no longer flagged stale when EVERY agent is deliberately quiet (paused/off-schedule) — a parked hive produces no findings, so its silence is the operator's choice, not a wedge. A reported post error still alarms. Diagnostics gain `suppressed-agents-quiet`.
- **Parked state**: `allAgentsQuiet` exposed in /api/saas/my-hives and rendered on /fleet as a first-class row state — dashed dot + `parked` chip, ranked between offline and ok. A hive not being used at all reads as PARKED, not healthy and not broken. GH App broken still outranks parked.
- **Nav avatar + menu on /fleet**: signed-in user's avatar with the same hover/click dialog the spoke dashboard has (login, role, GitHub profile, My Hives, API docs, sign out), fed by /api/auth/user.

## Validation
- `go build ./pkg/hub`, `go vet`, full `go test ./pkg/hub` green (124s)
- new tests: quiet suppression, error-not-suppressed, one-active-agent keeps alarm, unknown/legacy agents never suppress