### PR TITLE
🐛 distinguish unreported GitHub App health

### DIFF
--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -350,13 +350,21 @@ function budgetHealthHTML(b) {
   return '<span class="budget-health ' + esc(bucket) + '" title="' + esc(title) + '">' +
     '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
 }
-function githubAppHealthHTML(g) {
+function githubAppHealthHTML(g, h) {
   g = g || {};
+  h = h || {};
   var bucket = g.bucket || "unknown";
   var rel = g.lastTokenMintAt ? relTime(g.lastTokenMintAt) : "n/a";
-  var label = bucket === "unknown" ? "gh app n/a" : "gh app " + (bucket === "degraded" ? "stale" : bucket);
+  var oldSpoke = bucket === "unknown" && h.gitHash && h.commitsBehindStableV4 != null && h.commitsBehindStableV4 > 0;
+  var label = bucket === "unknown" ? (oldSpoke ? "gh app not reported" : "gh app n/a") : "gh app " + (bucket === "degraded" ? "stale" : bucket);
   if (g.lastTokenMintAt) label += " · " + rel;
   var title = g.detail || (g.lastTokenMintAt ? "last token mint " + rel : label);
+  if (oldSpoke && !g.detail) {
+    title = "This spoke has not reported GitHub App token-cache health yet; it is running an older image (" +
+      h.gitHash + ", " + h.commitsBehindStableV4 + " commits behind stable v4).";
+  } else if (bucket === "unknown" && !g.detail) {
+    title = "No GitHub App token-cache health was reported; this usually means no GitHub App is configured for this hive.";
+  }
   return '<span class="github-app-health ' + esc(bucket) + '" title="' + esc(title) + '">' +
     '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
 }
@@ -521,7 +529,7 @@ function renderHives(hives) {
       '<td>' + modeBadge(h.governorMode) + '</td>' +
       '<td>' + versionHTML(h) + '</td>' +
       '<td>' + rollupHTML(h.fleetRollup) + '</td>' +
-      '<td>' + outputHTML(h) + '<br>' + budgetHealthHTML(h.budgetHealth) + '<br>' + githubAppHealthHTML(h.githubAppHealth) + '</td>';
+      '<td>' + outputHTML(h) + '<br>' + budgetHealthHTML(h.budgetHealth) + '<br>' + githubAppHealthHTML(h.githubAppHealth, h) + '</td>';
     tb.appendChild(tr);
     var link = tr.querySelector(".hive-link");
     if (link) link.addEventListener("click", function (e) { e.stopPropagation(); });


### PR DESCRIPTION
## Summary
- clarify the fleet GitHub App health label for old spokes that have not reported the new token-cache heartbeat fields yet
- preserve plain n/a for current spokes with no GitHub App token-cache signal
- keep existing detail tooltips when the hub supplies a specific diagnostic

## Investigation
- live hub registry: 62 hives total; 28 unknown/n/a, all on commits that predate PR #4508 (26 on 69c3c9e, one on 24a8955, one on 9815e68)
- rolled spokes on 012e54f/29efcbd report githubAppTokenStatus; vllmd-06 and vllmd-07 are ok with fresh token cache files
- broken red entries are genuine app/config problems (mostly missing cache + not-installed), not the gray n/a case

## Test
- cd src && go test ./pkg/hub