### PR TITLE
🐛 validate caveman_mode enum in handleAgentCreate

### DIFF
--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -717,6 +717,19 @@ const ExplainLinePrefix = "EXPLAIN:"
 // ValidateExplainMode reports whether v is an accepted explain_mode value.
 func ValidateExplainMode(v string) bool { return ValidExplainModes[v] }
 
+// ValidCavemanModes are the accepted caveman_mode values. "" means "caveman
+// disabled"; it is valid on an agent but is not a mode in itself.
+var ValidCavemanModes = map[string]bool{
+	"":       true,
+	"lite":   true,
+	"full":   true,
+	"ultra":  true,
+	"wenyan": true,
+}
+
+// ValidateCavemanMode reports whether v is an accepted caveman_mode value.
+func ValidateCavemanMode(v string) bool { return ValidCavemanModes[v] }
+
 type AgentConfig struct {
 	ID           string `yaml:"id" json:"id,omitempty"`
 	Backend      string `yaml:"backend" json:"backend,omitempty"`
@@ -4455,8 +4468,7 @@ func (c *Config) validate() error {
 		if err := c.Governor.ValidateBackend(agent.Backend); err != nil {
 			return fmt.Errorf("agent %s: %w", name, err)
 		}
-		validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
-		if !validCavemanModes[agent.CavemanMode] {
+		if !ValidateCavemanMode(agent.CavemanMode) {
 			return fmt.Errorf("agent %s: invalid caveman_mode %q (must be lite, full, ultra, or wenyan)", name, agent.CavemanMode)
 		}
 		if !ValidateExplainMode(agent.ExplainMode) {

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -3267,8 +3267,9 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	if v, ok := body["cavemanMode"]; ok {
 		if s, ok := v.(string); ok {
 			s = sanitizeString(s)
-			validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
-			if !validCavemanModes[s] {
+			// Same gate as config.Validate, so the write path cannot persist a
+			// value that would fail the next config load.
+			if !config.ValidateCavemanMode(s) {
 				jsonError(w, "caveman_mode must be one of: lite, full, ultra, wenyan (or empty to disable)", http.StatusBadRequest)
 				return
 			}

--- a/src/pkg/dashboard/api_agents.go
+++ b/src/pkg/dashboard/api_agents.go
@@ -82,6 +82,14 @@ func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Same reasoning for caveman_mode: reject at the request rather than
+	// persisting a value the config loader would fail on later (#4531,
+	// flagged as a follow-up in #3897).
+	if !config.ValidateCavemanMode(body.Agent.CavemanMode) {
+		jsonError(w, "caveman_mode must be one of: lite, full, ultra, wenyan (or empty to disable)", http.StatusBadRequest)
+		return
+	}
+
 	if _, exists := s.deps.Config.Agents[body.Name]; exists {
 		jsonError(w, "agent already exists", http.StatusConflict)
 		return

--- a/src/pkg/dashboard/caveman_mode_validation_test.go
+++ b/src/pkg/dashboard/caveman_mode_validation_test.go
@@ -1,0 +1,98 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// These tests pin caveman_mode enum validation on both agent write paths
+// (#4531, flagged as a follow-up in #3897): the create handler must reject an
+// invalid value with a 400 naming the allowed set instead of persisting it and
+// letting the NEXT config load fail far from the request that caused it, and
+// the update handler's existing gate must keep doing the same.
+
+const cavemanModeErr = "caveman_mode must be one of: lite, full, ultra, wenyan (or empty to disable)"
+
+func TestHandleAgentCreate_InvalidCavemanMode(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Data.AgentsDir = t.TempDir()
+
+	for _, mode := range []string{"mega", "LITE", " full", "off", "true"} {
+		rec := doPost(s, "/api/agents", map[string]interface{}{
+			"name":  "caveman-bad",
+			"agent": map[string]interface{}{"backend": "claude", "caveman_mode": mode},
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("caveman_mode=%q: expected 400, got %d", mode, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), cavemanModeErr) {
+			t.Errorf("caveman_mode=%q: error must name the allowed set, got %s", mode, rec.Body.String())
+		}
+		if _, ok := deps.Config.Agents["caveman-bad"]; ok {
+			t.Fatalf("caveman_mode=%q: invalid agent must not be persisted", mode)
+		}
+	}
+}
+
+func TestHandleAgentCreate_ValidCavemanModes(t *testing.T) {
+	for _, mode := range []string{"lite", "full", "ultra", "wenyan"} {
+		s, deps := apiServer(t)
+		deps.Config.Data.AgentsDir = t.TempDir()
+
+		rec := doPost(s, "/api/agents", map[string]interface{}{
+			"name":  "caveman-" + mode,
+			"agent": map[string]interface{}{"backend": "claude", "caveman_mode": mode},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("caveman_mode=%q: expected 200, got %d: %s", mode, rec.Code, rec.Body.String())
+		}
+		if got := deps.Config.Agents["caveman-"+mode].CavemanMode; got != mode {
+			t.Errorf("caveman_mode=%q: persisted %q", mode, got)
+		}
+	}
+}
+
+func TestHandleAgentCreate_CavemanModeAbsentOrEmpty(t *testing.T) {
+	// "" (and absent, which unmarshals to "") means "caveman disabled" and must
+	// stay accepted — it is the default for every agent created from the UI.
+	for name, agent := range map[string]map[string]interface{}{
+		"caveman-absent": {"backend": "claude"},
+		"caveman-empty":  {"backend": "claude", "caveman_mode": ""},
+	} {
+		s, deps := apiServer(t)
+		deps.Config.Data.AgentsDir = t.TempDir()
+
+		rec := doPost(s, "/api/agents", map[string]interface{}{"name": name, "agent": agent})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d: %s", name, rec.Code, rec.Body.String())
+		}
+		if got := deps.Config.Agents[name].CavemanMode; got != "" {
+			t.Errorf("%s: expected empty caveman_mode, got %q", name, got)
+		}
+	}
+}
+
+func TestAgentConfigGeneral_InvalidCavemanMode(t *testing.T) {
+	s := acfgServer(t)
+	rec := doPut(s, "/api/config/agent/scanner/general", map[string]any{"cavemanMode": "mega"})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), cavemanModeErr) {
+		t.Errorf("error must name the allowed set, got %s", rec.Body.String())
+	}
+}
+
+func TestAgentConfigGeneral_ValidCavemanModes(t *testing.T) {
+	s := acfgServer(t)
+	for _, mode := range []string{"lite", "full", "ultra", "wenyan", ""} {
+		rec := doPut(s, "/api/config/agent/scanner/general", map[string]any{"cavemanMode": mode})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("cavemanMode=%q: expected 200, got %d: %s", mode, rec.Code, rec.Body.String())
+		}
+		if got := s.deps.Config.Agents["scanner"].CavemanMode; got != mode {
+			t.Errorf("cavemanMode=%q: persisted %q", mode, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4531

## What

`handleAgentCreate` (`POST /api/agents`) validated `explain_mode` but not `caveman_mode` — an invalid value was written to the agent file and only surfaced at the next config load, far from the request that caused it. Flagged as a follow-up in #3897.

## Changes

- `config.ValidCavemanModes` / `config.ValidateCavemanMode` added as the single source of truth, mirroring `ValidExplainModes`/`ValidateExplainMode`; `config.Validate` and the dashboard update path (`PUT /api/config/agent/{name}/general`) now share it instead of duplicating inline maps.
- `handleAgentCreate` rejects an invalid `caveman_mode` with **400** naming the allowed set — `lite, full, ultra, wenyan (or empty to disable)` — same message as the existing update-path gate.

## Tests

`src/pkg/dashboard/caveman_mode_validation_test.go` covers both write paths: each valid value persists, invalid values (incl. near-misses `LITE`, ` full`, `off`, `true`) get 400 + the allowed-set message with nothing persisted, and empty/absent stays accepted as the default.

## Validation

- `go build ./...`, `go vet`, `gofmt` clean on touched files
- `go test ./pkg/dashboard/` full package green, coverage **83.3%** (floor 78)
- `go test ./pkg/config/ -run 'Caveman|Validate'` green (two pre-existing `gh_app_token_script` shell-test failures reproduce identically on clean `origin/v4` in this environment; untouched by this PR)