### PR TITLE
📖 README: point the Podman quick start at the installer (#4533)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,39 @@ that a process was spawned. Docker is not required and is not used.
   `:3001` serves 502s.
 - `git`, `openssl`, and a GitHub token (PAT or App) for the org the hive works on
 
+### One command
+
+`bin/hive-podman-setup.sh` does everything in the manual sequence below —
+preflights, configuration, the four Quadlet units, the boot wiring, and a final
+check that the **gateway** answers on the published port before it returns.
+
+```bash
+export HIVE_DEPLOY_RUNTIME=podman
+bin/hive-podman-setup.sh --rootless        # or --rootful
+```
+
+It installs no packages and clones nothing, is idempotent, never overwrites an
+existing config without `--force` and never touches `secrets/`. A failing step
+stops the run and names itself; nothing is rolled back, so the partial state is
+there to inspect. It also enforces three couplings that are easy to get wrong by
+hand:
+
+- `dashboard.port` is read out of the unit that will enforce it, and the run
+  stops if the config does not read back agreeing — the 300-second silent hang
+  the manual block warns about below.
+- the volume is created **through its unit**, so it carries the ownership labels
+  that make `bin/hive-podman-teardown.sh` able to see it.
+- the secrets directory gets the right ownership for the root mode, and rootless
+  installs are told when lingering is off and the deployment will not survive a
+  reboot.
+
+Add `--enable-linger` to fix that last one during the install rather than after.
+
+### Or, by hand
+
+Worth reading even if you use the script: the comments below are where the traps
+are documented, and the script enforces the same ones.
+
 The block below is **rootless**. For rootful, set `CONF=/etc/hive`, drop the
 `podman unshare` line in favour of the `chgrp` beside it, install the units into
 `/etc/containers/systemd/` with `sudo`, and drop `--user` from every `systemctl`.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ preflights, configuration, the four Quadlet units, the boot wiring, and a final
 check that the **gateway** answers on the published port before it returns.
 
 ```bash
+git clone https://github.com/kubestellar/hive.git
+cd hive
+
 export HIVE_DEPLOY_RUNTIME=podman
 bin/hive-podman-setup.sh --rootless        # or --rootful
 ```


### PR DESCRIPTION
Closes #4533.

`bin/hive-podman-setup.sh` installs a standalone Podman deployment in one command. It is documented in `CHANGELOG.md`, `podman-standalone-quadlet.md`, `podman-ownership-cleanup.md`, `backup-restore.md` and `podman-quadlet-update-rollback.md` — and **not** in the README, which is where a self-hosting operator lands first.

| README quick start | executable lines |
| --- | --- |
| Docker Compose | **11** |
| Podman | **43** |

A reader comparing runtimes on that page sees an 11-line path and a 43-line path, with nothing indicating the second has a one-command equivalent. That is a reasonable basis on which to pick Docker, reached from incomplete information. #4470's own changelog entry says the script exists *"closing the asymmetry with Docker's `bin/hive-setup.sh`"* — closed in `bin/`, still open in the README.

## The change

A **"One command"** section before the manual sequence, and the existing sequence kept below as **"Or, by hand"**.

Keeping the manual block matters. Its comments are the best documentation of the Podman traps anywhere in the repo — the 300-second hang behind a wrong `dashboard.port`, why `hive.env` must exist even when fully commented out, why a `0700` secrets dir presents as an SELinux denial it is not. Promoting the script by deleting them would lose more than it gained, so the new section says the manual block is worth reading either way and that the script enforces the same couplings.

## Every claim was checked against the script

I wrote the section from the script's behaviour, not from memory, and verified each line:

| claim in the new text | verified against |
| --- | --- |
| `--enable-linger` exists | `--help` |
| installs no packages, clones nothing | `--help` |
| idempotent; no overwrite without `--force`; never touches `secrets/` | `--help` |
| a failing step names itself; nothing is rolled back | `--help` |
| `dashboard.port` read from the unit, run stops on disagreement | step `4/8` (#4367) |
| volume created **through its unit** so it carries ownership labels | `hive-podman-setup.sh:581` (#4485) |
| secrets ownership correct for the root mode | step `5/8` (#4359) |
| rootless told when lingering is off | step `8/8` (#4489) |

That caught one overclaim in my first draft: I had written "leaves the host as it found it", but the script says *"nothing is rolled back"* — partial state deliberately remains for inspection. Corrected to match.

## Verified as printed

A docs change that adds a command should demonstrate the command. Run verbatim on a clean host (no config, no units, no volume, lingering off):

```
EXIT=0
1/8  Runtime selection
2/8  Host preflight (engine, root mode, cgroups; subordinate IDs, storage, networking)
3/8  Configuration in /var/home/dbaggett/.config/hive
4/8  dashboard.port must equal the unit's HealthCmd port (#4367)
5/8  Secrets directory mode and group (#4359)
6/8  Host preflight over what was just written, then install the units
7/8  Start, and confirm HEALTHY rather than started
  PASS  gateway answered on 3001 — healthy end to end
8/8  Boot persistence — will this install survive a reboot?
  FAIL  lingering is OFF for dbaggett — this install will NOT survive a reboot
```

The step-8 failure is the correct result on a host with `Linger=no`, and is exactly the case the new text points at `--enable-linger` for.

## Scope

Docs only — no behaviour change, one file, 33 insertions, nothing removed.

`bin/hive-setup.sh` is likewise absent from the Docker section. I left that alone: the Docker path does not need its installer to look reasonable, since `docker compose up -d` is already the short version. Adding it for symmetry is a fair follow-up but a separate call.

## Provenance

Found while walking all 43 manual lines end to end during the #4188 passes, on Bluefin 44 (Silverblue), SELinux enforcing, Podman 5.8.4, `v4` at `325707ed`. **Both paths work** — this is discoverability, not correctness.
