### PR TITLE
feat(github): audit relays for agent issue-claim + PR-review

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1578,6 +1578,13 @@ func main() {
 		// with backoff, dedupes by exact open-issue title, and enforces the
 		// same forge-resistance + CanCreateIssues mode gate the wrapper does.
 		ghClient.StartIssueRequestWatcher(ctx, agentMgr.AuthorizeIssueOpen, nil)
+		// Review relay: agents request PR reviews by dropping a file (hive-review)
+		// instead of running `gh pr review` in their own shell, which the hive
+		// never observes. The watcher submits the review with the App token and
+		// records it on the audit/activity trail, gated by the same
+		// forge-resistance + push-capability (CanPush) check as opening a PR —
+		// reviewing is a PR-write, so AuthorizePROpen is the correct gate.
+		ghClient.StartReviewRequestWatcher(ctx, agentMgr.AuthorizePROpen, nil)
 		// Merge relay: agents request merges by dropping a file (hive-merge)
 		// instead of calling the GitHub MCP merge_pull_request tool, whose GraphQL
 		// mutation GitHub rejects for App tokens ("Resource not accessible by

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -7162,8 +7162,9 @@ func (m *Manager) AuthorizePROpen(agentName string, fileUID int) error {
 // AuthorizeIssueOpen enforces the policy for the issue-request watcher,
 // mirroring AuthorizePROpen with the mode gates that govern the direct gh
 // paths: "issue" requests need CanCreateIssues() (mode >= ISSUES_ONLY);
-// "comment" requests need the same (commenting is an issue-write). The same
-// UID forge-resistance applies: the request file's owner must BE the claimed
+// "comment" and "claim" requests need the same (commenting and claiming an
+// issue are both issue-writes under the same tier). The same UID
+// forge-resistance applies: the request file's owner must BE the claimed
 // agent. A nil manager or unknown agent is denied.
 func (m *Manager) AuthorizeIssueOpen(agentName string, fileUID int, kind string) error {
 	if strings.TrimSpace(agentName) == "" {

--- a/src/pkg/github/attribution.go
+++ b/src/pkg/github/attribution.go
@@ -71,6 +71,18 @@ const (
 	// created → PR created → PR merged) would otherwise count every reconciled
 	// contributor PR as a hive PR creation that never happened.
 	AuditActionPRAttributionReconciled = "pr_attribution_reconciled"
+	// AuditActionIssueClaimed is recorded when an agent claims an issue — the
+	// issue-request watcher applies a `hive/claimed-by-<agent>` label (App bots
+	// cannot be GitHub assignees, so ownership is signaled by a namespaced label
+	// rather than an assignee). It is a countable "this agent took work" signal
+	// on the activity trail.
+	AuditActionIssueClaimed = "agent_issue_claimed"
+	// AuditActionPRReviewed is recorded when the hive submits a PR review as the
+	// App bot: the review-request watcher on an agent's behalf, or the governor's
+	// own auto-merge APPROVE (QueuePRAutoMerge). Detail carries state=
+	// (approved|changes_requested|commented). This makes reviews a first-class
+	// audited activity instead of an invisible agent-CLI write.
+	AuditActionPRReviewed = "agent_pr_reviewed"
 )
 
 // System "agent" names recorded for creations no single coding agent

--- a/src/pkg/github/attribution.go
+++ b/src/pkg/github/attribution.go
@@ -378,6 +378,9 @@ func (c *Client) recordCreationAudit(action string, m InvocationMeta, extra ...s
 		audit(action, detail, m.Agent)
 		return
 	}
+	if c.logger == nil {
+		return // no sink and no logger (e.g. a bare test client) — nothing to do
+	}
 	c.logger.Info("attribution audit (no audit sink wired yet)",
 		slog.String("action", action), slog.String("detail", detail), slog.String("agent", m.Agent))
 }

--- a/src/pkg/github/attribution_test.go
+++ b/src/pkg/github/attribution_test.go
@@ -125,6 +125,12 @@ func TestAttributionDefaults_NilClientAndNilHooks(t *testing.T) {
 	}
 	nilClient.recordCreationAudit(AuditActionAgentPRCreated, InvocationMeta{}) // must not panic
 
+	// A non-nil client with neither an audit sink nor a logger (e.g. a bare
+	// NewClient(...) in a test) must not panic on the fallback branch — this is
+	// the path QueuePRAutoMerge's new approve-audit exercised.
+	bare := NewClient("t", "o", []string{"r"}, nil, "http://127.0.0.1:0")
+	bare.recordCreationAudit(AuditActionPRReviewed, InvocationMeta{Agent: "governor"}) // must not panic
+
 	c := NewClientForTest("http://127.0.0.1:0", "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if !c.attributionTrailerOn() {
 		t.Error("no hooks: trailer should default ON (config default)")

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -75,10 +76,14 @@ type Client struct {
 	// MergeRequestAuthorizer / F4). nil fails closed. Set by
 	// StartMergeRequestWatcher.
 	mergeAuthz MergeRequestAuthorizer
-	// issueAuthz gates issue-create/comment requests from the issue-request
+	// issueAuthz gates issue-create/comment/claim requests from the issue-request
 	// watcher against the per-agent mode policy (CanCreateIssues) +
 	// forge-resistance. nil fails closed. Set by StartIssueRequestWatcher.
 	issueAuthz IssueRequestAuthorizer
+	// reviewAuthz gates PR-review requests from the review-request watcher against
+	// the per-agent push-capability policy + forge-resistance. nil fails closed.
+	// Set by StartReviewRequestWatcher.
+	reviewAuthz ReviewRequestAuthorizer
 	// issueRetries tracks per-request-file retry backoff for the issue-request
 	// watcher (in-memory; reset on restart). Guarded by issueRetryMu.
 	issueRetryMu sync.Mutex
@@ -955,6 +960,12 @@ func (c *Client) QueuePRAutoMerge(ctx context.Context, repo string, number int, 
 	if err != nil {
 		return fmt.Errorf("approving PR: %w", err)
 	}
+	// Audit the review so it counts as activity on the trail. This is the hive's
+	// own auto-merge self-approval (a governor action); agent-authored reviews
+	// come through the review-request watcher, which audits separately.
+	c.recordCreationAudit(AuditActionPRReviewed, InvocationMeta{Agent: AttributionAgentGovernor},
+		"repo", owner+"/"+repoName, "number", strconv.Itoa(number),
+		"agent", queuedBy, "state", "approved")
 	if _, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repoName, number, []string{label}); err != nil {
 		return fmt.Errorf("adding %s label: %w", label, err)
 	}

--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -58,16 +58,27 @@ const issueRequestMaxAge = 24 * time.Hour
 
 // IssueRequest is the JSON an agent writes to IssueRequestDir. Kind selects the
 // operation: "issue" (default) creates an issue; "comment" posts a comment on
-// an existing issue or PR (Number required).
+// an existing issue or PR (Number required); "claim" marks an issue as taken by
+// the agent (Number required) — it applies a `hive/claimed-by-<agent>` LABEL
+// rather than a GitHub assignee, because the hive authors as an App bot and App
+// bots are not valid GitHub assignees (Issues.AddAssignees silently drops them).
+// The claim is filed by the agent when it starts work on an issue, giving a
+// visible, auditable ownership signal the hive can observe.
 type IssueRequest struct {
-	Kind   string   `json:"kind,omitempty"` // "issue" (default) | "comment"
+	Kind   string   `json:"kind,omitempty"` // "issue" (default) | "comment" | "claim"
 	Repo   string   `json:"repo"`
-	Title  string   `json:"title,omitempty"`  // issue only
+	Title  string   `json:"title,omitempty"` // issue only
 	Body   string   `json:"body,omitempty"`
 	Labels []string `json:"labels,omitempty"` // issue only
-	Number int      `json:"number,omitempty"` // comment only: issue/PR number
+	Number int      `json:"number,omitempty"` // comment/claim: issue/PR number
 	Agent  string   `json:"agent,omitempty"`
 }
+
+// claimLabelPrefix is the label namespace applied for a "claim" request. The
+// full label is claimLabelPrefix + <sanitized agent name>, e.g.
+// "hive/claimed-by-scanner". Namespaced so it is easy to filter/sweep and never
+// collides with a project's own labels.
+const claimLabelPrefix = "hive/claimed-by-"
 
 // IssueResponse is written next to a consumed request as <name>.result.json.
 type IssueResponse struct {
@@ -230,6 +241,10 @@ func (c *Client) handleOneIssueRequest(ctx context.Context, path string, nowFn f
 		if strings.TrimSpace(req.Repo) == "" || req.Number <= 0 || strings.TrimSpace(req.Body) == "" {
 			shapeErr = "comment request requires repo, number, and body"
 		}
+	case "claim":
+		if strings.TrimSpace(req.Repo) == "" || req.Number <= 0 || strings.TrimSpace(req.Agent) == "" {
+			shapeErr = "claim request requires repo, number, and agent"
+		}
 	default:
 		shapeErr = "unknown kind " + strconv.Quote(kind)
 	}
@@ -263,6 +278,14 @@ func (c *Client) handleOneIssueRequest(ctx context.Context, path string, nowFn f
 
 	resp := IssueResponse{At: nowFn().UTC().Format(time.RFC3339)}
 	switch kind {
+	case "claim":
+		// Apply a namespaced ownership label (App bots can't be assignees).
+		label := claimLabelPrefix + sanitizeAgentName(req.Agent)
+		err = c.AddLabels(ctx, req.Repo, req.Number, []string{label})
+		if err == nil {
+			resp.OK = true
+			resp.Number = req.Number
+		}
 	case "comment":
 		err = c.CreateIssueComment(ctx, req.Repo, req.Number, body)
 		if err == nil {
@@ -298,8 +321,11 @@ func (c *Client) handleOneIssueRequest(ctx context.Context, path string, nowFn f
 	}
 
 	action := AuditActionAgentIssueCreated
-	if kind == "comment" {
+	switch kind {
+	case "comment":
 		action = AuditActionAgentCommentCreated
+	case "claim":
+		action = AuditActionIssueClaimed
 	}
 	c.recordCreationAudit(action, meta,
 		"repo", req.Repo,

--- a/src/pkg/github/issue_request_watcher_test.go
+++ b/src/pkg/github/issue_request_watcher_test.go
@@ -473,3 +473,59 @@ func TestCreateIssue_DegradesWhenListAndLabelsFail(t *testing.T) {
 		t.Fatalf("unexpected result: created=%d res=%+v", created, res)
 	}
 }
+
+// A "claim" request applies the hive/claimed-by-<agent> label and audits
+// agent_issue_claimed (App bots can't be assignees, so ownership = a label).
+func TestIssueRequestWatcher_ClaimAppliesLabelAndAudits(t *testing.T) {
+	labeled := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/labels") {
+			labeled++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"name":"hive/claimed-by-scanner"}]`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := issueTestClient(t, srv.URL)
+	dir := withIssueDir(t)
+
+	var gotAction, gotDetail string
+	c.SetAttributionAudit(func(action, detail, agent string) { gotAction, gotDetail = action, detail })
+
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{
+		Kind: "claim", Repo: "o/r", Number: 42, Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessIssueRequestsOnce(context.Background())
+
+	if labeled != 1 {
+		t.Fatalf("expected 1 label add, got %d", labeled)
+	}
+	if gotAction != AuditActionIssueClaimed {
+		t.Errorf("audit action = %q, want %q", gotAction, AuditActionIssueClaimed)
+	}
+	if !strings.Contains(gotDetail, "number=42") {
+		t.Errorf("audit detail missing number: %q", gotDetail)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("claim request should be consumed on success")
+	}
+}
+
+// A claim request missing number/agent is quarantined, not retried forever.
+func TestIssueRequestWatcher_ClaimMalformed(t *testing.T) {
+	c := issueTestClient(t, "http://127.0.0.1:0")
+	dir := withIssueDir(t)
+	reqPath, err := WriteIssueRequest(dir, IssueRequest{Kind: "claim", Repo: "o/r", Agent: "scanner"}) // no number
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessIssueRequestsOnce(context.Background())
+	if _, err := os.Stat(reqPath + ".bad"); err != nil {
+		t.Errorf("malformed claim should be quarantined as .bad")
+	}
+}

--- a/src/pkg/github/review_request_watcher.go
+++ b/src/pkg/github/review_request_watcher.go
@@ -1,0 +1,255 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// ReviewRequestDir is where agents drop PR-review requests. An agent that wants
+// to review a PR writes a request file here INSTEAD of running `gh pr review`
+// from its own shell. The hive's watcher submits the review with the App token,
+// so the review is authored by the App bot AND — unlike a direct agent-CLI
+// review, which the hive never observes — it is recorded on the audit/activity
+// trail. This is the review analogue of the PR-request watcher.
+const ReviewRequestDir = "/var/run/hive-metrics/review-requests"
+
+// reviewRequestDirForTest lets tests point the watcher at a temp dir.
+var reviewRequestDirForTest string
+
+func reviewRequestDir() string {
+	if reviewRequestDirForTest != "" {
+		return reviewRequestDirForTest
+	}
+	return ReviewRequestDir
+}
+
+// reviewRequestPollInterval mirrors prRequestPollInterval — reviews are not
+// latency-critical. A var so tests can drive the ticker quickly.
+var reviewRequestPollInterval = 10 * time.Second
+
+// ReviewRequest is the JSON an agent writes to ReviewRequestDir. Event selects
+// the review type: "approve" | "request_changes" | "comment". Body is required
+// for request_changes/comment (GitHub rejects an empty non-approve review) and
+// optional for approve.
+type ReviewRequest struct {
+	Repo   string `json:"repo"`
+	Number int    `json:"number"`
+	Event  string `json:"event"` // approve | request_changes | comment
+	Body   string `json:"body,omitempty"`
+	Agent  string `json:"agent,omitempty"`
+}
+
+// ReviewResponse is written next to a consumed request as <name>.result.json.
+type ReviewResponse struct {
+	OK     bool   `json:"ok"`
+	Number int    `json:"number,omitempty"`
+	State  string `json:"state,omitempty"`
+	Error  string `json:"error,omitempty"`
+	At     string `json:"at"`
+}
+
+// ReviewRequestAuthorizer mirrors PRRequestAuthorizer: it receives the claimed
+// agent name and the request-file owning UID and returns nil to authorize.
+// A nil authorizer denies everything (fail closed). Reviewing is a PR-write, so
+// the caller gates it with the same push-capability check as opening a PR.
+type ReviewRequestAuthorizer func(agent string, fileUID int) error
+
+// reviewEventToAPI maps our lowercase Event to the GitHub review Event verb and
+// the state string we record in the audit trail. ok=false for an unknown event.
+func reviewEventToAPI(event string) (apiEvent, state string, ok bool) {
+	switch strings.TrimSpace(strings.ToLower(event)) {
+	case "approve", "approved":
+		return "APPROVE", "approved", true
+	case "request_changes", "changes_requested", "request-changes":
+		return "REQUEST_CHANGES", "changes_requested", true
+	case "comment", "commented":
+		return "COMMENT", "commented", true
+	default:
+		return "", "", false
+	}
+}
+
+// StartReviewRequestWatcher runs the loop that submits PR reviews for request
+// files dropped in ReviewRequestDir. Same contract as StartPRRequestWatcher:
+// returns immediately, runs until ctx cancel, nil client is a no-op (requests
+// accumulate rather than silently dropping), nil authz fails closed.
+func (c *Client) StartReviewRequestWatcher(ctx context.Context, authz ReviewRequestAuthorizer, nowFn func() time.Time) {
+	if c == nil {
+		return
+	}
+	c.reviewAuthz = authz
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	if err := os.MkdirAll(reviewRequestDir(), 0o777); err != nil {
+		c.logger.Warn("review-request watcher: cannot create request dir; disabled",
+			slog.String("dir", reviewRequestDir()), slog.String("error", err.Error()))
+		return
+	}
+	// Agents (UID >= 2001, shared node group) must be able to DROP request files;
+	// MkdirAll is umask-masked, so force group-write + setgid (same as the PR
+	// watcher). The forge-check still holds via the file's owning UID.
+	if err := os.Chmod(reviewRequestDir(), 0o2775); err != nil {
+		c.logger.Warn("review-request watcher: could not set group-writable perms on request dir; agents may be unable to review",
+			slog.String("dir", reviewRequestDir()), slog.String("error", err.Error()))
+	}
+	go func() {
+		t := time.NewTicker(reviewRequestPollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				c.processReviewRequests(ctx, nowFn)
+			}
+		}
+	}()
+	c.logger.Info("review-request watcher started", slog.String("dir", reviewRequestDir()))
+}
+
+func (c *Client) processReviewRequests(ctx context.Context, nowFn func() time.Time) {
+	entries, err := os.ReadDir(reviewRequestDir())
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
+			continue
+		}
+		c.handleOneReviewRequest(ctx, filepath.Join(reviewRequestDir(), name), nowFn)
+	}
+}
+
+// ProcessReviewRequestsOnce runs a single scan+process pass. Test/CLI entry.
+func (c *Client) ProcessReviewRequestsOnce(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.processReviewRequests(ctx, time.Now)
+}
+
+func (c *Client) handleOneReviewRequest(ctx context.Context, path string, nowFn func() time.Time) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // vanished between ReadDir and here
+	}
+	var req ReviewRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		c.writeReviewResult(path, ReviewResponse{OK: false, Error: "invalid JSON: " + err.Error(), At: nowFn().UTC().Format(time.RFC3339)})
+		_ = os.Rename(path, path+".bad")
+		c.logger.Warn("review-request watcher: bad request file quarantined",
+			slog.String("path", path), slog.String("error", err.Error()))
+		return
+	}
+
+	apiEvent, state, okEvent := reviewEventToAPI(req.Event)
+	// Validate shape BEFORE authorizing or touching the API — a hopeless request
+	// must never retry.
+	var shapeErr string
+	switch {
+	case strings.TrimSpace(req.Repo) == "" || req.Number <= 0:
+		shapeErr = "review request requires repo and number"
+	case !okEvent:
+		shapeErr = "review request event must be approve|request_changes|comment"
+	case apiEvent != "APPROVE" && strings.TrimSpace(req.Body) == "":
+		shapeErr = "review request body is required for request_changes/comment"
+	}
+	if shapeErr != "" {
+		c.writeReviewResult(path, ReviewResponse{OK: false, Error: shapeErr, At: nowFn().UTC().Format(time.RFC3339)})
+		_ = os.Rename(path, path+".bad")
+		c.logger.Warn("review-request watcher: malformed request quarantined",
+			slog.String("path", path), slog.String("reason", shapeErr))
+		return
+	}
+
+	// Authorize: forge-resistance (file UID must be the claimed agent) + the same
+	// push-capability gate as opening a PR. A nil authorizer fails closed.
+	fileUID := statUID(data, path)
+	if c.reviewAuthz == nil {
+		c.denyReviewRequest(path, req, "no authorizer configured (fail closed)", nowFn)
+		return
+	}
+	if err := c.reviewAuthz(req.Agent, fileUID); err != nil {
+		c.denyReviewRequest(path, req, err.Error(), nowFn)
+		return
+	}
+
+	meta := c.attributionMeta(req.Agent)
+	body := req.Body
+	if c.attributionTrailerOn() {
+		body = AppendTrailer(body, meta)
+	}
+
+	owner, repoName := c.splitRepo(req.Repo)
+	reviewReq := &gh.PullRequestReviewRequest{Event: gh.Ptr(apiEvent)}
+	if strings.TrimSpace(body) != "" {
+		reviewReq.Body = gh.Ptr(body)
+	}
+	_, _, err = c.client.PullRequests.CreateReview(ctx, owner, repoName, req.Number, reviewReq)
+	resp := ReviewResponse{At: nowFn().UTC().Format(time.RFC3339)}
+	if err != nil {
+		resp.OK = false
+		resp.Error = err.Error()
+		c.writeReviewResult(path, resp)
+		c.logger.Warn("review-request watcher: review failed, will retry",
+			slog.String("repo", req.Repo), slog.Int("number", req.Number), slog.String("error", err.Error()))
+		return
+	}
+	resp.OK = true
+	resp.Number = req.Number
+	resp.State = state
+
+	c.recordCreationAudit(AuditActionPRReviewed, meta,
+		"repo", req.Repo,
+		"number", strconv.Itoa(req.Number),
+		"state", state)
+	c.writeReviewResult(path, resp)
+	_ = os.Remove(path)
+	c.logger.Info("review-request watcher: review submitted by App bot",
+		slog.String("repo", req.Repo), slog.Int("number", req.Number),
+		slog.String("state", state), slog.String("agent", req.Agent))
+}
+
+func (c *Client) denyReviewRequest(path string, req ReviewRequest, reason string, nowFn func() time.Time) {
+	c.writeReviewResult(path, ReviewResponse{OK: false, Error: "authorization denied: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
+	_ = os.Rename(path, path+".denied")
+	c.logger.Warn("review-request watcher: DENIED (policy)",
+		slog.String("agent", req.Agent), slog.String("repo", req.Repo),
+		slog.Int("number", req.Number), slog.String("reason", reason))
+}
+
+func (c *Client) writeReviewResult(reqPath string, resp ReviewResponse) {
+	out := strings.TrimSuffix(reqPath, ".json") + ".result.json"
+	if b, err := json.MarshalIndent(resp, "", "  "); err == nil {
+		_ = os.WriteFile(out, b, 0o644)
+	}
+}
+
+// WriteReviewRequest is a helper (tests / in-process callers) to drop a
+// well-formed review-request file into ReviewRequestDir.
+func WriteReviewRequest(dir string, req ReviewRequest) (string, error) {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(req, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("%s-%d.json", sanitizeAgentName(req.Agent), time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/src/pkg/github/review_request_watcher_test.go
+++ b/src/pkg/github/review_request_watcher_test.go
@@ -1,0 +1,151 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func newReviewMockServer(t *testing.T, reviewed *int, lastEvent *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/reviews") {
+			if reviewed != nil {
+				*reviewed++
+			}
+			if lastEvent != nil {
+				var body struct {
+					Event string `json:"event"`
+				}
+				b, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(b, &body)
+				*lastEvent = body.Event
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":1,"state":"APPROVED"}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func reviewTestClient(t *testing.T, srvURL string) *Client {
+	t.Helper()
+	c := testClient(t, srvURL)
+	c.reviewAuthz = func(agent string, uid int) error { return nil }
+	return c
+}
+
+func withReviewDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := reviewRequestDirForTest
+	reviewRequestDirForTest = dir
+	t.Cleanup(func() { reviewRequestDirForTest = old })
+	return dir
+}
+
+// End-to-end: an approve review is submitted, consumed, audited as
+// agent_pr_reviewed with state=approved.
+func TestReviewRequestWatcher_ApprovesAndAudits(t *testing.T) {
+	reviewed := 0
+	var apiEvent string
+	srv := newReviewMockServer(t, &reviewed, &apiEvent)
+	defer srv.Close()
+	c := reviewTestClient(t, srv.URL)
+	dir := withReviewDir(t)
+
+	var gotAction, gotDetail string
+	c.SetAttributionAudit(func(action, detail, agent string) { gotAction, gotDetail = action, detail })
+
+	reqPath, err := WriteReviewRequest(dir, ReviewRequest{
+		Repo: "o/r", Number: 5, Event: "approve", Agent: "reviewer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessReviewRequestsOnce(context.Background())
+
+	if reviewed != 1 {
+		t.Fatalf("expected 1 review submitted, got %d", reviewed)
+	}
+	if apiEvent != "APPROVE" {
+		t.Errorf("api event = %q, want APPROVE", apiEvent)
+	}
+	if gotAction != AuditActionPRReviewed {
+		t.Errorf("audit action = %q, want %q", gotAction, AuditActionPRReviewed)
+	}
+	if !strings.Contains(gotDetail, "state=approved") || !strings.Contains(gotDetail, "number=5") {
+		t.Errorf("audit detail wrong: %q", gotDetail)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("review request should be consumed on success")
+	}
+}
+
+// request_changes and comment map to the right API verb + state.
+func TestReviewRequestWatcher_EventMapping(t *testing.T) {
+	cases := []struct{ event, apiEvent, state string }{
+		{"request_changes", "REQUEST_CHANGES", "changes_requested"},
+		{"comment", "COMMENT", "commented"},
+	}
+	for _, tc := range cases {
+		reviewed := 0
+		var apiEvent string
+		srv := newReviewMockServer(t, &reviewed, &apiEvent)
+		c := reviewTestClient(t, srv.URL)
+		dir := withReviewDir(t)
+		var gotDetail string
+		c.SetAttributionAudit(func(action, detail, agent string) { gotDetail = detail })
+		if _, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 9, Event: tc.event, Body: "please fix", Agent: "reviewer"}); err != nil {
+			t.Fatal(err)
+		}
+		c.ProcessReviewRequestsOnce(context.Background())
+		srv.Close()
+		if apiEvent != tc.apiEvent {
+			t.Errorf("%s: api event = %q, want %q", tc.event, apiEvent, tc.apiEvent)
+		}
+		if !strings.Contains(gotDetail, "state="+tc.state) {
+			t.Errorf("%s: detail missing state=%s: %q", tc.event, tc.state, gotDetail)
+		}
+	}
+}
+
+// request_changes/comment without a body is malformed (GitHub rejects it).
+func TestReviewRequestWatcher_RequiresBodyForNonApprove(t *testing.T) {
+	c := reviewTestClient(t, "http://127.0.0.1:0")
+	dir := withReviewDir(t)
+	reqPath, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 9, Event: "comment", Agent: "reviewer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessReviewRequestsOnce(context.Background())
+	if _, err := os.Stat(reqPath + ".bad"); err != nil {
+		t.Errorf("body-less comment review should be quarantined .bad")
+	}
+}
+
+// A nil authorizer denies (fail closed).
+func TestReviewRequestWatcher_AuthzFailsClosed(t *testing.T) {
+	reviewed := 0
+	srv := newReviewMockServer(t, &reviewed, nil)
+	defer srv.Close()
+	c := testClient(t, srv.URL) // testClient sets prAuthz but NOT reviewAuthz → nil
+	dir := withReviewDir(t)
+	reqPath, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 5, Event: "approve", Agent: "reviewer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessReviewRequestsOnce(context.Background())
+	if reviewed != 0 {
+		t.Errorf("nil authorizer must deny; got %d reviews", reviewed)
+	}
+	if _, err := os.Stat(reqPath + ".denied"); err != nil {
+		t.Errorf("denied review should be quarantined .denied")
+	}
+}


### PR DESCRIPTION
Part A of the hive-health work ([plan]: make every 'clanker' write action auditable so the hub can tell whether a hive is producing output back to its work source). On v4, creates/comments/merges already audit; this closes the two remaining gaps.

## Issue claim → label + audit
App bots can't be GitHub assignees (`Issues.AddAssignees` silently drops them) and internal agents have no server-side claim moment, so ownership is a **namespaced label** `hive/claimed-by-<agent>`. Added `Kind:"claim"` to the existing `issue_request_watcher.go` (already multi-kind issue|comment): the agent files a claim request via the relay, the watcher applies the label with the existing `AddLabels` and audits **`agent_issue_claimed`**. Gated by the same `CanCreateIssues` authz as issue/comment.

## PR review → new relay watcher + audit
Real agent reviews run `gh pr review` in the agent's own shell, which the hive never observes. New **`review_request_watcher.go`** mirrors `pr_request_watcher.go`: agents drop a review-request file (`ReviewRequest{Repo,Number,Event,Body,Agent}`), the watcher submits it with the App token via `PullRequests.CreateReview` and audits **`agent_pr_reviewed`** (state=approved|changes_requested|commented). Gated by the same `CanPush` check as opening a PR (reuses `AuthorizePROpen`). Also audits the one pre-existing server-side review — `QueuePRAutoMerge`'s auto-merge APPROVE, previously unlogged.

## Notes
- New audit constants `AuditActionIssueClaimed` / `AuditActionPRReviewed` in attribution.go; both flow through the existing `recordCreationAudit` → dashboard audit.jsonl sink (detail `repo=,number=,agent=,state=`).
- **Agent-side tooling** (the gh-wrapper writing claim/review request files, so agents actually use these) is a deliberate follow-up — this PR lands the server-side relays + audit so the trail is complete the moment agents adopt them.
- These become countable activities feeding the upcoming activity collector + hub health verdict (Parts B/C).

## Tests
claim: applies label + audits `agent_issue_claimed` + malformed-quarantine. review: approve/request_changes/comment API+state mapping, audit, body-required-for-non-approve, authz-fail-closed.

gofmt clean; DCO-signed. Pre-existing v4 beads/sandbox/hub flakiness + transient bobshell build flake unrelated (re-run).