### PR TITLE
feat(dashboard): spoke activity collector for per-repo output health

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2013,6 +2013,16 @@ func main() {
 	fleetStatsCollector.EnablePersistence("/data/fleet-stats.json")
 	go fleetStatsCollector.Start(ctx)
 
+	// Per-repo output-activity collector: reads the local audit log (no GitHub
+	// calls) and summarizes issues/PRs/comments/merges/claims/reviews per repo
+	// with recency, so the hub can tell — from the heartbeat alone — whether each
+	// hive is producing output back to its work source. Persisted to the /data
+	// PVC so a restart resumes the last summary; the collector loop reads
+	// /data/audit.jsonl every few minutes.
+	activityCollector := dashboard.NewActivityCollector(dashSrv.GetAudit(), "", logger)
+	activityCollector.EnablePersistence("/data/activity.json")
+	go activityCollector.Start(ctx)
+
 	// Persistent hourly metrics behind the Operations + Leaderboard sparklines
 	// (queue depth, tasks/hour, fleet size, per-contributor completions). The
 	// store loads any prior 7-day history from the /data PVC on first use and the

--- a/src/pkg/dashboard/activity_collector.go
+++ b/src/pkg/dashboard/activity_collector.go
@@ -1,0 +1,258 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"regexp"
+	"sync"
+	"time"
+)
+
+// activityCollectInterval is how often the spoke recomputes its per-repo output
+// activity from the audit log. Unlike the fleet-stats collector this makes ZERO
+// GitHub calls (it reads /data/audit.jsonl), so it can run frequently and needs
+// no jitter or search-quota backoff.
+var activityCollectInterval = 5 * time.Minute
+
+// activityWindow is the rolling window over which activity is counted. The hub's
+// health verdict cares about the last 12h; we retain a wider window so the hub
+// can compute freshness itself from NewestAt and so a slightly-late collect
+// never drops a just-inside-12h event.
+const activityWindow = 14 * 24 * time.Hour
+
+// activityHealthWindowHours is advertised to the hub as the intended freshness
+// window (the hub still computes recency from NewestAt).
+const activityHealthWindowHours = 12
+
+// Audit action names the collector counts as OUTPUT to a work source. Kept in
+// sync with pkg/github/attribution.go. Advisory is counted separately because it
+// is the L2 output signal.
+var activityOutputActions = map[string]bool{
+	"agent_issue_created":   true,
+	"agent_pr_created":      true,
+	"agent_comment_created": true,
+	"pr_merged":             true,
+	"agent_issue_claimed":   true,
+	"agent_pr_reviewed":     true,
+	"advisory_commented":    true,
+}
+
+// ActivityActionStat is one action's count within the window plus the newest
+// timestamp seen for it (RFC3339). NewestAt lets the hub compute "within 12h"
+// itself.
+type ActivityActionStat struct {
+	Count    int    `json:"count"`
+	NewestAt string `json:"newest_at,omitempty"`
+}
+
+// RepoActivity is per-repo output activity over the window.
+type RepoActivity struct {
+	Repo     string             `json:"repo"`
+	Issues   ActivityActionStat `json:"issues"`
+	PRs      ActivityActionStat `json:"prs"`
+	Comments ActivityActionStat `json:"comments"`
+	Merges   ActivityActionStat `json:"merges"`
+	Claims   ActivityActionStat `json:"claims"`
+	Reviews  ActivityActionStat `json:"reviews"`
+	Advisory ActivityActionStat `json:"advisory"`
+}
+
+// ActivitySnapshot is the full per-hive activity summary the collector produces
+// and the heartbeat ships.
+type ActivitySnapshot struct {
+	Repos       []RepoActivity `json:"repos"`
+	WindowHours int            `json:"window_hours"`
+	CollectedAt time.Time      `json:"collected_at"`
+}
+
+// auditReader is the subset of *AuditLog the collector needs, so it can be
+// faked in tests without a full dashboard Server.
+type auditReader interface {
+	OutputActionsSince(since time.Time, actions map[string]bool, filePath string) []AuditEntry
+}
+
+// ActivityCollector summarizes the spoke's audit-log output activity per repo.
+// Mirrors FleetStatsCollector's lifecycle (EnablePersistence/Start/Snapshot/
+// CollectedAt) but reads the local audit file instead of the GitHub API.
+type ActivityCollector struct {
+	mu          sync.Mutex
+	audit       auditReader
+	auditPath   string // "" → the default auditLogPath (used by OutputActionsSince)
+	logger      *slog.Logger
+	nowFn       func() time.Time
+	persistPath string
+
+	snap        ActivitySnapshot
+	ready       bool
+	collectedAt time.Time
+}
+
+// persistedActivity is the on-disk sidecar shape.
+type persistedActivity struct {
+	Snapshot    ActivitySnapshot `json:"snapshot"`
+	CollectedAt time.Time        `json:"collected_at"`
+}
+
+// NewActivityCollector builds a collector over the given audit reader. audit nil
+// makes it inert (Snapshot ready=false). auditPath is where OutputActionsSince
+// reads ("" → the production audit log).
+func NewActivityCollector(audit auditReader, auditPath string, logger *slog.Logger) *ActivityCollector {
+	return &ActivityCollector{
+		audit:     audit,
+		auditPath: auditPath,
+		logger:    logger,
+		nowFn:     time.Now,
+	}
+}
+
+// EnablePersistence mirrors each collect to path and restores whatever is there
+// now, so the first heartbeat after a restart reports the last summary rather
+// than nil. Missing file = clean first boot; corrupt = logged + ignored. Call
+// once before Start.
+func (ac *ActivityCollector) EnablePersistence(path string) {
+	if ac == nil {
+		return
+	}
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	ac.persistPath = path
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) && ac.logger != nil {
+			ac.logger.Warn("activity store unreadable — starting fresh", "path", path, "error", err)
+		}
+		return
+	}
+	var stored persistedActivity
+	if err := json.Unmarshal(data, &stored); err != nil {
+		if ac.logger != nil {
+			ac.logger.Warn("activity store corrupt — starting fresh", "path", path, "error", err)
+		}
+		return
+	}
+	if stored.CollectedAt.IsZero() {
+		return
+	}
+	ac.snap = stored.Snapshot
+	ac.collectedAt = stored.CollectedAt
+	ac.ready = true
+}
+
+func (ac *ActivityCollector) persistLocked() {
+	if ac.persistPath == "" {
+		return
+	}
+	data, err := json.Marshal(persistedActivity{Snapshot: ac.snap, CollectedAt: ac.collectedAt})
+	if err != nil {
+		return
+	}
+	tmp := ac.persistPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		if ac.logger != nil {
+			ac.logger.Warn("failed to write activity store", "path", ac.persistPath, "error", err)
+		}
+		return
+	}
+	if err := os.Rename(tmp, ac.persistPath); err != nil && ac.logger != nil {
+		ac.logger.Warn("failed to replace activity store", "path", ac.persistPath, "error", err)
+	}
+}
+
+// Start runs the collect loop until ctx is cancelled — once up front, then every
+// activityCollectInterval. Inert (returns) when there is no audit reader.
+func (ac *ActivityCollector) Start(ctx context.Context) {
+	if ac == nil || ac.audit == nil {
+		return
+	}
+	ac.collect()
+	ticker := time.NewTicker(activityCollectInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ac.collect()
+		}
+	}
+}
+
+// repoRe extracts repo=<org/name> from an audit detail string ("k=v, k=v").
+var repoRe = regexp.MustCompile(`(?:^|[,\s])repo=([^,\s]+)`)
+
+// collect reads the window of output actions from the audit log and rebuilds the
+// per-repo summary.
+func (ac *ActivityCollector) collect() {
+	now := ac.nowFn()
+	since := now.Add(-activityWindow)
+	entries := ac.audit.OutputActionsSince(since, activityOutputActions, ac.auditPath)
+
+	byRepo := map[string]*RepoActivity{}
+	bump := func(stat *ActivityActionStat, ts string) {
+		stat.Count++
+		if ts > stat.NewestAt { // RFC3339 is lexically sortable
+			stat.NewestAt = ts
+		}
+	}
+	for _, e := range entries {
+		m := repoRe.FindStringSubmatch(e.Detail)
+		if m == nil {
+			continue // no repo → not attributable output (e.g. a lifecycle event)
+		}
+		repo := m[1]
+		ra := byRepo[repo]
+		if ra == nil {
+			ra = &RepoActivity{Repo: repo}
+			byRepo[repo] = ra
+		}
+		switch e.Action {
+		case "agent_issue_created":
+			bump(&ra.Issues, e.Timestamp)
+		case "agent_pr_created":
+			bump(&ra.PRs, e.Timestamp)
+		case "agent_comment_created":
+			bump(&ra.Comments, e.Timestamp)
+		case "pr_merged":
+			bump(&ra.Merges, e.Timestamp)
+		case "agent_issue_claimed":
+			bump(&ra.Claims, e.Timestamp)
+		case "agent_pr_reviewed":
+			bump(&ra.Reviews, e.Timestamp)
+		case "advisory_commented":
+			bump(&ra.Advisory, e.Timestamp)
+		}
+	}
+	repos := make([]RepoActivity, 0, len(byRepo))
+	for _, ra := range byRepo {
+		repos = append(repos, *ra)
+	}
+
+	ac.mu.Lock()
+	ac.snap = ActivitySnapshot{Repos: repos, WindowHours: activityHealthWindowHours, CollectedAt: now}
+	ac.collectedAt = now
+	ac.ready = true
+	ac.persistLocked()
+	ac.mu.Unlock()
+}
+
+// Snapshot returns the last computed summary and whether a collect has succeeded.
+func (ac *ActivityCollector) Snapshot() (ActivitySnapshot, bool) {
+	if ac == nil {
+		return ActivitySnapshot{}, false
+	}
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	return ac.snap, ac.ready
+}
+
+// CollectedAt returns when the summary was last computed.
+func (ac *ActivityCollector) CollectedAt() time.Time {
+	if ac == nil {
+		return time.Time{}
+	}
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	return ac.collectedAt
+}

--- a/src/pkg/dashboard/activity_collector_test.go
+++ b/src/pkg/dashboard/activity_collector_test.go
@@ -1,0 +1,149 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeAuditFixture writes a JSONL audit file with the given entries.
+func writeAuditFixture(t *testing.T, dir string, entries []AuditEntry) string {
+	t.Helper()
+	p := filepath.Join(dir, "audit.jsonl")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return p
+}
+
+func rfc3339(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+
+// OutputActionsSince filters by action set and since-time, reading the file.
+func TestOutputActionsSince(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	p := writeAuditFixture(t, dir, []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=o/r, number=1"},
+		{Timestamp: rfc3339(now.Add(-30 * time.Hour)), Action: "agent_pr_created", Detail: "repo=o/r, number=2"}, // too old
+		{Timestamp: rfc3339(now.Add(-2 * time.Hour)), Action: "agent_start", Detail: "trigger=startup"},          // not an output action
+		{Timestamp: rfc3339(now.Add(-3 * time.Hour)), Action: "pr_merged", Detail: "repo=o/r, number=3"},
+	})
+	a := &AuditLog{}
+	got := a.OutputActionsSince(now.Add(-24*time.Hour), activityOutputActions, p)
+	if len(got) != 2 {
+		t.Fatalf("want 2 (pr_created + merged within 24h, output actions only), got %d: %+v", len(got), got)
+	}
+}
+
+// collect groups by repo + action with counts and newest timestamps, across
+// multiple repos — the multi-repo case that broke the hand-scraped counts.
+func TestActivityCollector_CountsPerRepo(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	newest := now.Add(-10 * time.Minute)
+	p := writeAuditFixture(t, dir, []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-2 * time.Hour)), Action: "agent_issue_created", Detail: "repo=z/ui, number=1"},
+		{Timestamp: rfc3339(newest), Action: "agent_issue_created", Detail: "repo=z/ui, number=2"},
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=z/api-server, number=9"},
+		{Timestamp: rfc3339(now.Add(-3 * time.Hour)), Action: "pr_merged", Detail: "repo=z/api-server, number=8"},
+		{Timestamp: rfc3339(now.Add(-4 * time.Hour)), Action: "agent_pr_reviewed", Detail: "repo=z/ui, number=5, state=approved"},
+		{Timestamp: rfc3339(now.Add(-5 * time.Hour)), Action: "agent_issue_claimed", Detail: "repo=z/ui-framework, number=3"},
+	})
+	ac := NewActivityCollector(&AuditLog{}, p, nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.collect()
+	snap, ok := ac.Snapshot()
+	if !ok {
+		t.Fatal("snapshot not ready after collect")
+	}
+	if len(snap.Repos) != 3 {
+		t.Fatalf("want 3 repos, got %d", len(snap.Repos))
+	}
+	byRepo := map[string]RepoActivity{}
+	for _, r := range snap.Repos {
+		byRepo[r.Repo] = r
+	}
+	if byRepo["z/ui"].Issues.Count != 2 {
+		t.Errorf("z/ui issues = %d, want 2", byRepo["z/ui"].Issues.Count)
+	}
+	if byRepo["z/ui"].Issues.NewestAt != rfc3339(newest) {
+		t.Errorf("z/ui newest issue = %q, want %q", byRepo["z/ui"].Issues.NewestAt, rfc3339(newest))
+	}
+	if byRepo["z/ui"].Reviews.Count != 1 {
+		t.Errorf("z/ui reviews = %d, want 1", byRepo["z/ui"].Reviews.Count)
+	}
+	if byRepo["z/api-server"].PRs.Count != 1 || byRepo["z/api-server"].Merges.Count != 1 {
+		t.Errorf("z/api-server prs/merges = %d/%d, want 1/1", byRepo["z/api-server"].PRs.Count, byRepo["z/api-server"].Merges.Count)
+	}
+	if byRepo["z/ui-framework"].Claims.Count != 1 {
+		t.Errorf("z/ui-framework claims = %d, want 1", byRepo["z/ui-framework"].Claims.Count)
+	}
+	if snap.WindowHours != activityHealthWindowHours {
+		t.Errorf("window hours = %d, want %d", snap.WindowHours, activityHealthWindowHours)
+	}
+}
+
+// Entries with no repo= are skipped (not attributable output).
+func TestActivityCollector_SkipsNoRepo(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	p := writeAuditFixture(t, dir, []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "advisory_commented", Detail: "flow=advisory-digest"}, // no repo=
+	})
+	ac := NewActivityCollector(&AuditLog{}, p, nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.collect()
+	snap, _ := ac.Snapshot()
+	if len(snap.Repos) != 0 {
+		t.Errorf("entry without repo= must be skipped, got %+v", snap.Repos)
+	}
+}
+
+// EnablePersistence round-trips a snapshot across a restart.
+func TestActivityCollector_PersistRestore(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	p := writeAuditFixture(t, dir, []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=o/r, number=1"},
+	})
+	sidecar := filepath.Join(dir, "activity.json")
+
+	ac := NewActivityCollector(&AuditLog{}, p, nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.EnablePersistence(sidecar)
+	ac.collect()
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+
+	// Fresh collector with NO audit file readable but the sidecar present →
+	// restores the prior snapshot.
+	ac2 := NewActivityCollector(&AuditLog{}, filepath.Join(dir, "gone.jsonl"), nil)
+	ac2.EnablePersistence(sidecar)
+	snap, ok := ac2.Snapshot()
+	if !ok || len(snap.Repos) != 1 || snap.Repos[0].PRs.Count != 1 {
+		t.Errorf("restore failed: ok=%v snap=%+v", ok, snap)
+	}
+}
+
+// Start is inert with a nil audit reader (no panic, returns).
+func TestActivityCollector_NilAuditInert(t *testing.T) {
+	ac := NewActivityCollector(nil, "", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ac.Start(ctx) // must return immediately
+	if _, ok := ac.Snapshot(); ok {
+		t.Error("nil-audit collector must not be ready")
+	}
+}

--- a/src/pkg/dashboard/audit.go
+++ b/src/pkg/dashboard/audit.go
@@ -171,6 +171,49 @@ func (a *AuditLog) LastUserActions() map[string]string {
 	return out
 }
 
+// OutputActionsSince reads the on-disk audit log (auditLogPath) and returns
+// every entry whose Action is in `actions` and whose timestamp is at or after
+// `since`. It reads the FILE, not the in-memory ring, because the ring is capped
+// at auditRingCap (500) and reset on restart — the activity collector needs the
+// full window (e.g. 12h across every repo on a busy hive), which only the
+// lumberjack-rotated file holds. Malformed lines and unparseable timestamps are
+// skipped. Rotated/compressed backups are NOT read: the collector persists its
+// own running totals to a sidecar (see activity_collector.go), so the current
+// file is sufficient for the recent window and the sidecar covers history beyond
+// rotation. A missing file returns an empty slice (clean first-boot).
+//
+// filePath is a parameter (defaulting to auditLogPath when "") so tests can
+// point it at a fixture without touching /data.
+func (a *AuditLog) OutputActionsSince(since time.Time, actions map[string]bool, filePath string) []AuditEntry {
+	if filePath == "" {
+		filePath = auditLogPath
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+	var out []AuditEntry
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var e AuditEntry
+		if json.Unmarshal(line, &e) != nil || e.Timestamp == "" {
+			continue
+		}
+		if len(actions) > 0 && !actions[e.Action] {
+			continue
+		}
+		t, perr := time.Parse(time.RFC3339, e.Timestamp)
+		if perr != nil || t.Before(since) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
 func (a *AuditLog) Recent(n int) []AuditEntry {
 	a.mu.Lock()
 	defer a.mu.Unlock()


### PR DESCRIPTION
**Part B** of the hive-health feature (audit trail → queryable activity → at-a-glance /fleet verdict). Stacked on #4538 (Part A); base will auto-retarget to `v4` when #4538 merges.

## What
Adds `ActivityCollector` (`src/pkg/dashboard/activity_collector.go`): reads `/data/audit.jsonl` — **zero GitHub calls** — every 5m and summarizes per repo the counts + recency (`NewestAt`) of the seven output actions (issues, PRs, comments, merges, claims, reviews, advisory). This is what lets the hub answer, from the heartbeat alone, *"is this hive producing output back to its work source?"* — banded by ACMM level in Part C.

## How
- `AuditLog.OutputActionsSince(since, actions, filePath)` (`audit.go`) reads the **on-disk file**, not the 500-cap in-memory ring, so the full window survives a restart and covers every repo on a busy hive.
- Sidecar `/data/activity.json` (atomic tmp+rename) resumes the last summary across a roll; 14d retention so a slightly-late collect never drops a just-inside-12h event. The hub computes 12h freshness itself from `NewestAt`.
- Wired beside the fleet-stats collector in `main.go`; inert (no panic, ready=false) when the audit reader is nil.

## Tests
`activity_collector_test.go`: multi-repo per-action counts + `NewestAt`, no-repo entries skipped, persist/restore round-trip, nil-audit inert, and `OutputActionsSince` window+action filtering.

Follow-ups (later parts): Part C beat wiring + ACMM-banded health verdict; Part D `/fleet` UI. Agent-side gh-wrapper writing claim/review request files tracked with Part A.