### PR TITLE
feat(hub): ACMM-banded hive-health verdict on /my-hives

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3392,6 +3392,20 @@ func main() {
 					fleetStatsCollectedAt = t.UTC().Format(time.RFC3339)
 				}
 			}
+			// Per-repo output-activity summary (hive-health): map the dashboard
+			// collector's snapshot into the plain hub wire structs. Nil when the
+			// collector hasn't produced a snapshot yet, so the hub carries the
+			// last one forward rather than seeing a fabricated empty summary.
+			var repoActivity []hub.RepoActivityWire
+			repoActivityCollectedAt := ""
+			repoActivityWindowHours := 0
+			if asnap, ok := activityCollector.Snapshot(); ok {
+				repoActivity = buildRepoActivityWire(asnap.Repos)
+				repoActivityWindowHours = asnap.WindowHours
+				if t := activityCollector.CollectedAt(); !t.IsZero() {
+					repoActivityCollectedAt = t.UTC().Format(time.RFC3339)
+				}
+			}
 			// Count agents with a method/model assigned for the hub's
 			// user-journey stage detection. Always a non-nil pointer from a
 			// spoke new enough to compute it, so the hub can distinguish
@@ -3695,10 +3709,13 @@ func main() {
 					}
 					return hub.CollectClusterHealth(logger)
 				}(),
-				PRsMerged90d:          prsMerged,
-				PRsRejected90d:        prsRejected,
-				CVEsClosed:            cvesClosed,
-				FleetStatsCollectedAt: fleetStatsCollectedAt,
+				PRsMerged90d:            prsMerged,
+				PRsRejected90d:          prsRejected,
+				CVEsClosed:              cvesClosed,
+				FleetStatsCollectedAt:   fleetStatsCollectedAt,
+				RepoActivity:            repoActivity,
+				RepoActivityCollectedAt: repoActivityCollectedAt,
+				RepoActivityWindowHours: repoActivityWindowHours,
 				// Report WHICH App key we hold, never the key. The hub compares
 				// this against its per-cluster key and pushes a correction only
 				// on a mismatch, so a spoke already holding the right key costs
@@ -4622,6 +4639,35 @@ const (
 	// our token allowance" from "the gateway will not spend more money".
 	providerBudgetAlertID = "provider-budget-exceeded"
 )
+
+// buildRepoActivityWire maps the dashboard activity collector's per-repo
+// snapshot into the plain hub wire structs the heartbeat carries. Kept here (in
+// the one package that imports both hub and dashboard) so pkg/hub never has to
+// import pkg/dashboard back — that would be an import cycle, since dashboard
+// already imports hub. A field-by-field copy, mirroring how the fleet-stat
+// scalars are lifted out of their snapshot at the beat's build site.
+func buildRepoActivityWire(repos []dashboard.RepoActivity) []hub.RepoActivityWire {
+	if len(repos) == 0 {
+		return nil
+	}
+	stat := func(s dashboard.ActivityActionStat) hub.ActivityStatWire {
+		return hub.ActivityStatWire{Count: s.Count, NewestAt: s.NewestAt}
+	}
+	out := make([]hub.RepoActivityWire, 0, len(repos))
+	for _, r := range repos {
+		out = append(out, hub.RepoActivityWire{
+			Repo:     r.Repo,
+			Issues:   stat(r.Issues),
+			PRs:      stat(r.PRs),
+			Comments: stat(r.Comments),
+			Merges:   stat(r.Merges),
+			Claims:   stat(r.Claims),
+			Reviews:  stat(r.Reviews),
+			Advisory: stat(r.Advisory),
+		})
+	}
+	return out
+}
 
 // providerBudgetNotify is the one-shot guard for the provider spend-rebuff
 // notification (#4294). runEvalCycle sees the CONDITION every cycle for as long

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -227,17 +227,6 @@ func maxRFC3339(a, b string) string {
 	return b
 }
 
-func parseRFC3339(s string) (time.Time, bool) {
-	if s == "" {
-		return time.Time{}, false
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return time.Time{}, false
-	}
-	return t, true
-}
-
 // advisoryAge renders a short age phrase for the advisory reason chip.
 func advisoryAge(adv AdvisoryIssueActivity, now time.Time) string {
 	if t, ok := parseRFC3339(adv.LastActivityAt); ok {

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -1,0 +1,263 @@
+package hub
+
+import (
+	"fmt"
+	"time"
+)
+
+// Hive-health verdict: does this spoke have RECENT OUTPUT back to its work
+// source, banded by ACMM level? Computed on read in handleMyHives from signals
+// already on the registry entry — no new spoke work. The spine (operator's
+// definition): a hive is HEALTHY when it has recent output for the level it is
+// AT. Absence of output a level does not produce is NEVER a fault:
+//
+//	L1 Inception : no output at all      → preconditions only, never red for "no output"
+//	L2 Advisory  : advisory digest       → healthy when advisory is fresh
+//	L3–L5        : issues/PRs CREATED     → healthy when a create is recent; "not merged" is NOT a problem
+//	L6           : creates AND merges     → healthy when a merge is recent (created-but-unmerged + queued = red)
+//
+// Recent output is only POSSIBLE when three preconditions hold — GitHub App
+// green, ≥1 agent logged in, ≥1 agent running at cadence — so when output is
+// absent those three explain WHY. A hive with an empty work queue can't produce
+// and must not be faulted for it (the queue-gate). A hive we cannot see (old
+// spoke / silent) is UNKNOWN, never green.
+
+const (
+	HealthStateGreen   = "green"
+	HealthStateRed     = "red"
+	HealthStateUnknown = "unknown"
+)
+
+// healthRecencyWindow is how recent output must be to count as "recent". The
+// operator set 12h; the spoke advertises the same via RepoActivityWindowHours,
+// but the hub owns the decision so a spoke can't widen it.
+const healthRecencyWindow = 12 * time.Hour
+
+// ACMM level bands. The registry stores a 0..6 integer; these name the
+// operator's output tiers so the verdict reads in those terms.
+const (
+	acmmInceptionMax = 1 // ≤1 → Inception: no output expected
+	acmmAdvisoryMax  = 2 // ==2 → Advisory: fresh advisory is the output
+	acmmMergeMin     = 6 // ≥6 → also merges; below 6, unmerged PRs are fine
+	// L3..L5 (create-but-don't-merge) is everything between advisory and merge.
+)
+
+// HealthVerdict is the at-a-glance answer for one hive, surfaced on MyHiveEntry.
+type HealthVerdict struct {
+	State string `json:"state"` // green | red | unknown
+	// Reason is a short human phrase for the WHY chip ("last output 3h ago",
+	// "GitHub App broken", "no agents running", "queue empty — idle").
+	Reason string `json:"reason"`
+	// OutputKind names what output this level is judged on: "advisory",
+	// "creates", "merges", or "none" (Inception).
+	OutputKind string `json:"outputKind"`
+	// LastOutputAt is the newest relevant output timestamp (RFC3339), "" if none.
+	LastOutputAt string `json:"lastOutputAt,omitempty"`
+	// QueuedWork is the actionable backlog (issues+PRs) that output would drain;
+	// zero means "nothing to do", which makes "no output" healthy.
+	QueuedWork int `json:"queuedWork"`
+}
+
+// hiveHealthFor computes the verdict for one registry entry. rollup is the
+// already-computed agent fleet rollup (Known/Running/Expected/Problems);
+// queuedWork is ActionableIssues+ActionablePRs; app is the GitHub App health.
+func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth, queuedWork int, now time.Time) HealthVerdict {
+	v := HealthVerdict{QueuedWork: queuedWork}
+
+	// --- Unknown gates first: never claim health for a hive we can't see. ---
+	if !e.Online {
+		v.State = HealthStateUnknown
+		v.Reason = "not reporting (offline)"
+		v.OutputKind = outputKindForLevel(e.ACMMLevel)
+		return v
+	}
+	if rollup.Known == 0 {
+		// Old spoke that predates the divergence signals — we cannot tell able
+		// from stuck, so we cannot assert health.
+		v.State = HealthStateUnknown
+		v.Reason = "spoke too old to report health"
+		v.OutputKind = outputKindForLevel(e.ACMMLevel)
+		return v
+	}
+
+	v.OutputKind = outputKindForLevel(e.ACMMLevel)
+
+	// --- Precondition reds: output is IMPOSSIBLE, so say why. These apply at
+	// every level that is expected to produce anything (L2+). At L1 there is no
+	// output to enable, so a precondition gap is not a health fault. ---
+	if e.ACMMLevel > acmmInceptionMax {
+		if app.Bucket == ghAppBucketBroken {
+			v.State = HealthStateRed
+			v.Reason = "GitHub App broken"
+			return v
+		}
+		if rollup.Expected > 0 && rollup.Running == 0 {
+			v.State = HealthStateRed
+			v.Reason = "no agents running"
+			return v
+		}
+		if rollup.Problems > 0 {
+			v.State = HealthStateRed
+			v.Reason = fmt.Sprintf("%d agent(s) blocked", rollup.Problems)
+			return v
+		}
+	}
+
+	// --- ACMM-banded output freshness. ---
+	switch {
+	case e.ACMMLevel <= acmmInceptionMax:
+		// L1 Inception: no output is produced by design. Preconditions were the
+		// only thing to check and (being L1) we don't even fault those. Green so
+		// long as it is reporting — it is doing exactly what its level allows.
+		v.State = HealthStateGreen
+		v.Reason = "inception — no output expected"
+		return v
+
+	case e.ACMMLevel == acmmAdvisoryMax:
+		// L2 Advisory: freshness of the advisory stream is the health signal.
+		// Reuse the existing advisory/issue-activity bucketing rather than the
+		// per-repo activity collector.
+		adv := advisoryIssueActivityFor(e, now)
+		v.LastOutputAt = adv.LastActivityAt
+		switch adv.Bucket {
+		case advisoryIssueBucketFresh, advisoryIssueBucketAging:
+			v.State = HealthStateGreen
+			v.Reason = "advisory " + advisoryAge(adv, now)
+		case advisoryIssueBucketStale:
+			v.State = HealthStateRed
+			v.Reason = "advisory stale"
+		default: // unknown
+			if queuedWork == 0 {
+				v.State = HealthStateGreen
+				v.Reason = "queue empty — idle"
+			} else {
+				v.State = HealthStateUnknown
+				v.Reason = "no advisory yet"
+			}
+		}
+		return v
+
+	case e.ACMMLevel >= acmmMergeMin:
+		// L6: judged on MERGES. A create that never merges, with work still
+		// queued, is the failure this level exists to catch.
+		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string { return r.Merges.NewestAt })
+		return bandFreshness(v, last, ok, queuedWork, now, "merge")
+
+	default:
+		// L3–L5: judged on CREATES (issues or PRs). Merges are the human's job
+		// here, so an unmerged PR is not a fault — only a stalled creation
+		// stream (with work queued) is.
+		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string {
+			return maxRFC3339(r.Issues.NewestAt, r.PRs.NewestAt)
+		})
+		return bandFreshness(v, last, ok, queuedWork, now, "create")
+	}
+}
+
+// bandFreshness applies the recency window to a create/merge output stream:
+// recent → green; nothing/old but queue empty → green (nothing to do); old with
+// work queued → red. verb is "create" or "merge" for the reason phrase.
+func bandFreshness(v HealthVerdict, last time.Time, ok bool, queuedWork int, now time.Time, verb string) HealthVerdict {
+	if ok {
+		v.LastOutputAt = last.UTC().Format(time.RFC3339)
+	}
+	switch {
+	case ok && now.Sub(last) <= healthRecencyWindow:
+		v.State = HealthStateGreen
+		v.Reason = fmt.Sprintf("last %s %s", verb, humanizeAge(now.Sub(last)))
+	case queuedWork == 0:
+		// No output, but nothing to produce — idle, not broken.
+		v.State = HealthStateGreen
+		if ok {
+			v.Reason = "queue empty — idle"
+		} else {
+			v.Reason = "queue empty — no output yet"
+		}
+	case ok:
+		v.State = HealthStateRed
+		v.Reason = fmt.Sprintf("no %s in %s (%d queued)", verb, humanizeAge(now.Sub(last)), queuedWork)
+	default:
+		v.State = HealthStateRed
+		v.Reason = fmt.Sprintf("no %s output (%d queued)", verb, queuedWork)
+	}
+	return v
+}
+
+// outputKindForLevel names the output a level is judged on, for the UI.
+func outputKindForLevel(level int) string {
+	switch {
+	case level <= acmmInceptionMax:
+		return "none"
+	case level == acmmAdvisoryMax:
+		return "advisory"
+	case level >= acmmMergeMin:
+		return "merges"
+	default:
+		return "creates"
+	}
+}
+
+// newestOutput returns the newest parseable timestamp produced by pick across
+// all repos, and whether any was found.
+func newestOutput(repos []RepoActivityWire, pick func(RepoActivityWire) string) (time.Time, bool) {
+	var newest time.Time
+	found := false
+	for _, r := range repos {
+		if t, ok := parseRFC3339(pick(r)); ok {
+			if !found || t.After(newest) {
+				newest, found = t, true
+			}
+		}
+	}
+	return newest, found
+}
+
+// maxRFC3339 returns the later of two RFC3339 strings (lexical compare is valid
+// for canonical UTC RFC3339); a non-empty value beats an empty one.
+func maxRFC3339(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if a >= b {
+		return a
+	}
+	return b
+}
+
+func parseRFC3339(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// advisoryAge renders a short age phrase for the advisory reason chip.
+func advisoryAge(adv AdvisoryIssueActivity, now time.Time) string {
+	if t, ok := parseRFC3339(adv.LastActivityAt); ok {
+		return humanizeAge(now.Sub(t)) + " ago"
+	}
+	return "fresh"
+}
+
+// humanizeAge renders a duration as a compact "Nm"/"Nh"/"Nd" phrase. Negative
+// (clock skew) is treated as just-now.
+func humanizeAge(d time.Duration) string {
+	if d < time.Minute {
+		return "just now"
+	}
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours())/24)
+	}
+}

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -1,0 +1,208 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// ractivity builds a one-repo RepoActivityWire with the given create/merge
+// timestamps (issue and merge), leaving other stats empty.
+func ractivity(repo, issueAt, prAt, mergeAt, advisoryAt string) RepoActivityWire {
+	return RepoActivityWire{
+		Repo:     repo,
+		Issues:   ActivityStatWire{Count: 1, NewestAt: issueAt},
+		PRs:      ActivityStatWire{Count: 1, NewestAt: prAt},
+		Merges:   ActivityStatWire{Count: 1, NewestAt: mergeAt},
+		Advisory: ActivityStatWire{Count: 1, NewestAt: advisoryAt},
+	}
+}
+
+func okRollup() agentFleetRollup {
+	return agentFleetRollup{Expected: 2, Running: 2, Able: 2, Known: 2, Problems: 0}
+}
+
+func okApp() GitHubAppHealth { return GitHubAppHealth{Bucket: ghAppBucketOK} }
+
+// withActivity attaches a repo-activity summary to an entry and returns it.
+func withActivity(e RegistryEntry, repos ...RepoActivityWire) RegistryEntry {
+	e.RepoActivity = repos
+	return e
+}
+
+// The verdict must band by ACMM level exactly as the operator defined:
+// L1 no-output→green, L2 advisory-fresh→green, L3–L5 creates (unmerged is fine),
+// L6 merges (unmerged+queued→red), with precondition + unknown gates on top.
+func TestHiveHealthFor_ACMMBands(t *testing.T) {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	rfc := func(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+	recent := rfc(now.Add(-1 * time.Hour))   // within 12h
+	oldTs := rfc(now.Add(-30 * time.Hour))   // outside 12h
+	freshAdv := rfc(now.Add(-2 * time.Hour)) // within advisory aging window
+
+	base := func(level int) RegistryEntry {
+		return RegistryEntry{Online: true, ACMMLevel: level}
+	}
+
+	tests := []struct {
+		name      string
+		entry     RegistryEntry
+		rollup    agentFleetRollup
+		app       GitHubAppHealth
+		queued    int
+		wantState string
+		wantKind  string
+	}{
+		{
+			name:      "L1 inception — no output ever, still green",
+			entry:     base(1),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    5,
+			wantState: HealthStateGreen,
+			wantKind:  "none",
+		},
+		{
+			name:      "L1 inception — App broken is NOT a fault (no output to enable)",
+			entry:     base(1),
+			rollup:    okRollup(),
+			app:       GitHubAppHealth{Bucket: ghAppBucketBroken},
+			queued:    5,
+			wantState: HealthStateGreen,
+			wantKind:  "none",
+		},
+		{
+			name: "L2 advisory fresh — green",
+			entry: func() RegistryEntry {
+				e := base(2)
+				e.AdvisoryLastPostedAt = freshAdv
+				return e
+			}(),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    3,
+			wantState: HealthStateGreen,
+			wantKind:  "advisory",
+		},
+		{
+			name:      "L4 creates recent — green (unmerged is fine)",
+			entry:     withActivity(base(4), ractivity("o/r", recent, recent, "", "")),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    4,
+			wantState: HealthStateGreen,
+			wantKind:  "creates",
+		},
+		{
+			name:      "L4 creates STALE with queued work — red",
+			entry:     withActivity(base(4), ractivity("o/r", oldTs, oldTs, "", "")),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    7,
+			wantState: HealthStateRed,
+			wantKind:  "creates",
+		},
+		{
+			name:      "L4 creates stale but queue EMPTY — green (idle, nothing to do)",
+			entry:     withActivity(base(4), ractivity("o/r", oldTs, oldTs, "", "")),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    0,
+			wantState: HealthStateGreen,
+			wantKind:  "creates",
+		},
+		{
+			name:      "L6 merge recent — green",
+			entry:     withActivity(base(6), ractivity("o/r", recent, recent, recent, "")),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    2,
+			wantState: HealthStateGreen,
+			wantKind:  "merges",
+		},
+		{
+			name:      "L6 created but NOT merged, work queued — red (this is what L6 catches)",
+			entry:     withActivity(base(6), ractivity("o/r", recent, recent, oldTs, "")),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    3,
+			wantState: HealthStateRed,
+			wantKind:  "merges",
+		},
+		{
+			name:      "L4 App broken — red precondition (output impossible)",
+			entry:     withActivity(base(4), ractivity("o/r", recent, recent, "", "")),
+			rollup:    okRollup(),
+			app:       GitHubAppHealth{Bucket: ghAppBucketBroken},
+			queued:    3,
+			wantState: HealthStateRed,
+			wantKind:  "creates",
+		},
+		{
+			name:      "L4 no agents running — red precondition",
+			entry:     withActivity(base(4), ractivity("o/r", recent, recent, "", "")),
+			rollup:    agentFleetRollup{Expected: 2, Running: 0, Known: 2},
+			app:       okApp(),
+			queued:    3,
+			wantState: HealthStateRed,
+			wantKind:  "creates",
+		},
+		{
+			name:      "offline — unknown, never green",
+			entry:     func() RegistryEntry { e := base(4); e.Online = false; return e }(),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    3,
+			wantState: HealthStateUnknown,
+			wantKind:  "creates",
+		},
+		{
+			name:      "legacy spoke (Known==0) — unknown, never green",
+			entry:     withActivity(base(4), ractivity("o/r", recent, recent, "", "")),
+			rollup:    agentFleetRollup{Expected: 2, Running: 2, Known: 0},
+			app:       okApp(),
+			queued:    3,
+			wantState: HealthStateUnknown,
+			wantKind:  "creates",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := hiveHealthFor(tc.entry, tc.rollup, tc.app, tc.queued, now)
+			if v.State != tc.wantState {
+				t.Errorf("state = %q, want %q (reason: %q)", v.State, tc.wantState, v.Reason)
+			}
+			if v.OutputKind != tc.wantKind {
+				t.Errorf("outputKind = %q, want %q", v.OutputKind, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestSanitizeRepoActivity(t *testing.T) {
+	// nil in → nil out
+	if got := sanitizeRepoActivity(nil); got != nil {
+		t.Errorf("nil in should be nil out, got %+v", got)
+	}
+	// all-junk rows collapse to nil (not an empty "reported zero" summary)
+	junk := []RepoActivityWire{{Repo: "   "}}
+	if got := sanitizeRepoActivity(junk); got != nil {
+		t.Errorf("all-junk should be nil, got %+v", got)
+	}
+	// negative counts clamp to 0; bad NewestAt → ""; good row survives
+	in := []RepoActivityWire{{
+		Repo:   "org/name",
+		Issues: ActivityStatWire{Count: -5, NewestAt: "not-a-time"},
+		PRs:    ActivityStatWire{Count: 3, NewestAt: "2026-08-22T10:00:00Z"},
+	}}
+	got := sanitizeRepoActivity(in)
+	if len(got) != 1 {
+		t.Fatalf("want 1 row, got %d", len(got))
+	}
+	if got[0].Issues.Count != 0 || got[0].Issues.NewestAt != "" {
+		t.Errorf("negative count / bad ts not sanitized: %+v", got[0].Issues)
+	}
+	if got[0].PRs.Count != 3 || got[0].PRs.NewestAt == "" {
+		t.Errorf("good PR stat mangled: %+v", got[0].PRs)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -696,6 +696,17 @@ type HeartbeatPayload struct {
 	// to report it, which the hub treats as "not stale".
 	FleetStatsCollectedAt string `json:"fleet_stats_collected_at,omitempty"`
 
+	// --- Per-repo output activity (hive-health) ---------------------------
+	// RepoActivity is the spoke's audit-derived summary of output produced
+	// back to each work source (issues/PRs/comments/merges/claims/reviews/
+	// advisory) with counts + recency. It lets the hub decide, from the beat
+	// alone, whether a hive is actually producing — banded by ACMM level in
+	// the health verdict. Nil from a spoke too old to compute it (carried
+	// forward hub-side), like ComponentReach.
+	RepoActivity            []RepoActivityWire `json:"repo_activity,omitempty"`
+	RepoActivityCollectedAt string             `json:"repo_activity_collected_at,omitempty"`
+	RepoActivityWindowHours int                `json:"repo_activity_window_hours,omitempty"`
+
 	// --- Quadrant signals -------------------------------------------------
 	// Cheap, already-computed spoke metrics forwarded so the hub can score the
 	// per-hive quadrant (trust / efficiency / satisfaction / productivity)

--- a/src/pkg/hub/repo_activity.go
+++ b/src/pkg/hub/repo_activity.go
@@ -1,0 +1,90 @@
+package hub
+
+// Bounds for sanitizing a spoke-reported repo-activity summary. Generous
+// enough for any real hive (a spoke tracks a handful of repos, each with
+// bounded audited counts) but a hard ceiling against a hostile or buggy beat.
+const (
+	// maxRepoActivityRepos caps the number of per-repo rows kept from one beat.
+	maxRepoActivityRepos = 256
+	// maxRepoNameRunes caps a repo name ("org/name") length after sanitizing.
+	maxRepoNameRunes = 200
+	// maxRepoActivityCount clamps each action count — far above any real 12h/
+	// 14d output volume, purely defensive.
+	maxRepoActivityCount = 1_000_000
+	// repoActivityMaxWindowHours clamps the reported window (14d in hours is
+	// 336; allow some slack).
+	repoActivityMaxWindowHours = 24 * 30
+)
+
+// sanitizeStatWire validates one action stat: a non-negative clamped count and
+// a canonical-UTC RFC3339 NewestAt (or "" if it doesn't parse — never an epoch).
+func sanitizeStatWire(s ActivityStatWire) ActivityStatWire {
+	return ActivityStatWire{
+		Count:    clampInt(s.Count, 0, maxRepoActivityCount),
+		NewestAt: sanitizeReachTime(s.NewestAt),
+	}
+}
+
+// sanitizeRepoActivity validates, clips, and copies a spoke-reported activity
+// summary for storage on the registry entry. nil in (old spoke / nothing
+// recorded yet) is nil out — "no data", never an error. The result never
+// aliases the caller's payload. Rows past maxRepoActivityRepos are dropped, and
+// a row whose repo name sanitizes to nothing is dropped (it identifies nothing).
+func sanitizeRepoActivity(in []RepoActivityWire) []RepoActivityWire {
+	if in == nil {
+		return nil
+	}
+	if len(in) > maxRepoActivityRepos {
+		in = in[:maxRepoActivityRepos]
+	}
+	out := make([]RepoActivityWire, 0, len(in))
+	for _, r := range in {
+		repo := truncateReachRunes(sanitizeHeartbeatField(r.Repo), maxRepoNameRunes)
+		if repo == "" {
+			continue
+		}
+		out = append(out, RepoActivityWire{
+			Repo:     repo,
+			Issues:   sanitizeStatWire(r.Issues),
+			PRs:      sanitizeStatWire(r.PRs),
+			Comments: sanitizeStatWire(r.Comments),
+			Merges:   sanitizeStatWire(r.Merges),
+			Claims:   sanitizeStatWire(r.Claims),
+			Reviews:  sanitizeStatWire(r.Reviews),
+			Advisory: sanitizeStatWire(r.Advisory),
+		})
+	}
+	if len(out) == 0 {
+		// Every row was junk — treat as "no data" rather than an empty summary
+		// that would read as "reported zero output".
+		return nil
+	}
+	return out
+}
+
+// Hub-side wire mirror of the spoke's dashboard.RepoActivity / ActivitySnapshot.
+// It is defined HERE (not imported from pkg/dashboard) because pkg/dashboard
+// imports pkg/hub — importing back would be a cycle. main.go maps the dashboard
+// snapshot into these plain wire structs field-by-field, exactly as it copies
+// the fleet-stat scalars, so the two packages stay decoupled.
+
+// ActivityStatWire is one action's count within the window plus the newest
+// timestamp seen for it (RFC3339). NewestAt lets the hub compute "within 12h"
+// itself without trusting a spoke-side clamp.
+type ActivityStatWire struct {
+	Count    int    `json:"count"`
+	NewestAt string `json:"newest_at,omitempty"`
+}
+
+// RepoActivityWire is per-repo output activity over the collector's window.
+// Field set mirrors dashboard.RepoActivity.
+type RepoActivityWire struct {
+	Repo     string           `json:"repo"`
+	Issues   ActivityStatWire `json:"issues"`
+	PRs      ActivityStatWire `json:"prs"`
+	Comments ActivityStatWire `json:"comments"`
+	Merges   ActivityStatWire `json:"merges"`
+	Claims   ActivityStatWire `json:"claims"`
+	Reviews  ActivityStatWire `json:"reviews"`
+	Advisory ActivityStatWire `json:"advisory"`
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3002,6 +3002,13 @@ type MyHiveEntry struct {
 	FleetRollup   *agentFleetRollup  `json:"fleetRollup,omitempty"`
 	AgentVerdicts []AgentVerdictJSON `json:"agentVerdicts,omitempty"`
 
+	// Health is the at-a-glance hive-health verdict (hive-health): does this
+	// spoke have RECENT OUTPUT back to its work source, banded by ACMM level?
+	// green/red/unknown with a WHY reason, computed on read from the same
+	// rollup/app-health/queue/advisory/repo-activity signals the row already
+	// carries. nil for placeholder rows (nothing to judge). See health_verdict.go.
+	Health *HealthVerdict `json:"health,omitempty"`
+
 	// URLUnreachable is true when this hive's PUBLIC dashboard URL failed to
 	// serve on the last several probes — the link in this very table is dead.
 	// Computed on read from the auth-audit loop's observations, so the browser
@@ -3497,6 +3504,12 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			rollup := rollupAgents(result[i].Agents, blockers, queuedWork, journeyNow)
 			result[i].FleetRollup = &rollup
 			result[i].AgentVerdicts = buildAgentVerdicts(result[i].Agents, blockers, queuedWork, journeyNow)
+
+			// Hive-health verdict: reuse the rollup + app-health + queue depth we
+			// just computed. Only for real (non-placeholder) hives with reported
+			// agents — a placeholder has nothing to produce.
+			verdict := hiveHealthFor(result[i].RegistryEntry, rollup, result[i].GitHubAppHealth, queuedWork, journeyNow)
+			result[i].Health = &verdict
 		}
 
 		// Sparkline history dominated this payload: at 42 hives the two series

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3002,12 +3002,14 @@ type MyHiveEntry struct {
 	FleetRollup   *agentFleetRollup  `json:"fleetRollup,omitempty"`
 	AgentVerdicts []AgentVerdictJSON `json:"agentVerdicts,omitempty"`
 
-	// Health is the at-a-glance hive-health verdict (hive-health): does this
-	// spoke have RECENT OUTPUT back to its work source, banded by ACMM level?
-	// green/red/unknown with a WHY reason, computed on read from the same
+	// HealthVerdict is the at-a-glance hive-health verdict (hive-health): does
+	// this spoke have RECENT OUTPUT back to its work source, banded by ACMM
+	// level? green/red/unknown with a WHY reason, computed on read from the same
 	// rollup/app-health/queue/advisory/repo-activity signals the row already
-	// carries. nil for placeholder rows (nothing to judge). See health_verdict.go.
-	Health *HealthVerdict `json:"health,omitempty"`
+	// carries. nil for placeholder rows (nothing to judge). Named distinctly
+	// from the embedded RegistryEntry.Health (the raw spoke-reported blob) to
+	// avoid shadowing it. See health_verdict.go.
+	HealthVerdict *HealthVerdict `json:"healthVerdict,omitempty"`
 
 	// URLUnreachable is true when this hive's PUBLIC dashboard URL failed to
 	// serve on the last several probes — the link in this very table is dead.
@@ -3509,7 +3511,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			// just computed. Only for real (non-placeholder) hives with reported
 			// agents — a placeholder has nothing to produce.
 			verdict := hiveHealthFor(result[i].RegistryEntry, rollup, result[i].GitHubAppHealth, queuedWork, journeyNow)
-			result[i].Health = &verdict
+			result[i].HealthVerdict = &verdict
 		}
 
 		// Sparkline history dominated this payload: at 42 hives the two series

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -312,6 +312,18 @@ type RegistryEntry struct {
 	// treated as "not stale" so an upgrade does not blank the strip.
 	FleetStatsCollectedAt time.Time `json:"fleetStatsCollectedAt,omitempty"`
 
+	// RepoActivity is the spoke's audit-derived per-repo output summary
+	// (hive-health), always the sanitized product of sanitizeRepoActivity,
+	// never the raw payload. nil = the spoke is too old to report it ("no
+	// data", never "zero output"); carried forward across beats that omit it,
+	// like ComponentReach, so a restart or minimal upgrade-beat does not blank
+	// the last real summary. RepoActivityCollectedAt / RepoActivityWindowHours
+	// travel with it so the hub can age the summary and know the intended
+	// freshness window (see health_verdict.go).
+	RepoActivity            []RepoActivityWire `json:"repoActivity,omitempty"`
+	RepoActivityCollectedAt time.Time          `json:"repoActivityCollectedAt,omitempty"`
+	RepoActivityWindowHours int                `json:"repoActivityWindowHours,omitempty"`
+
 	// Quadrant signals reported by the spoke (nil = not reported). These back
 	// the per-hive quadrant score; see quadrant.go for how each is used and
 	// why absent evidence must never collapse to zero.
@@ -1803,6 +1815,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// Component reach (#3993): sanitized + clipped, never the raw spoke
 		// report — see sanitizeComponentReach for the bounds. Storage only.
 		ComponentReach: sanitizeComponentReach(payload.ComponentReach),
+		// Per-repo output activity (hive-health): sanitized/clamped, never the
+		// raw payload. The collected-at + window travel with it so the verdict
+		// can age the summary.
+		RepoActivity:            sanitizeRepoActivity(payload.RepoActivity),
+		RepoActivityCollectedAt: parseHeartbeatTime(payload.RepoActivityCollectedAt),
+		RepoActivityWindowHours: clampInt(payload.RepoActivityWindowHours, 0, repoActivityMaxWindowHours),
 	}
 
 	// Fleet error-rate history (#3995, phase 2c): fold this beat's rolling
@@ -2012,6 +2030,17 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			// that gap. Same pattern as the fleet-stat counts above.
 			if entry.ComponentReach == nil && h.ComponentReach != nil {
 				entry.ComponentReach = h.ComponentReach
+			}
+			// Carry the last real repo-activity summary forward when this beat
+			// omits it (minimal upgrade-beat, or a spoke whose collector hasn't
+			// re-warmed from /data/activity.json yet). The collected-at and
+			// window travel WITH the summary — same reasoning as the budget
+			// window: a count aged by a stale timestamp is honest, a count
+			// carried without its timestamp looks current when it isn't.
+			if entry.RepoActivity == nil && h.RepoActivity != nil {
+				entry.RepoActivity = h.RepoActivity
+				entry.RepoActivityCollectedAt = h.RepoActivityCollectedAt
+				entry.RepoActivityWindowHours = h.RepoActivityWindowHours
 			}
 			// Advisory post time survives a spoke restart — see
 			// carryAdvisoryPostTime for why that is the difference between a


### PR DESCRIPTION
**Part C** of the hive-health feature (audit trail → queryable activity → at-a-glance /fleet verdict). Builds on #4538 (relays) + #4544 (activity collector), both merged.

## What
Wires the spoke's per-repo activity summary onto the heartbeat and computes an **at-a-glance health verdict per hive**: *does this spoke have RECENT OUTPUT (≤12h) back to its work source, banded by ACMM level?* — surfaced as `MyHiveEntry.Health` for the `/fleet` page (Part D renders it).

## Banding (the operator's rule — absence of output a level doesn't produce is NEVER a fault)
| ACMM | Judged on | Healthy when |
|---|---|---|
| **L1** Inception | nothing | reporting (App gaps not faulted — no output to enable) |
| **L2** Advisory | advisory freshness (reuses `AdvisoryIssueActivity`) | advisory fresh |
| **L3–L5** | issues/PRs **created** | a create ≤12h; **unmerged PRs are NOT a fault** |
| **L6** | **merges** | a merge ≤12h; created-but-unmerged + queued work → **red** |

**Gates on top:** unknown first (offline / legacy spoke `Known==0` never go green), then precondition reds at L2+ (GitHub App broken / no agents running / blocked agents — output is *impossible*, so say why). **Queue-gate:** an empty actionable backlog makes "no output" green (idle, nothing to do) at every producing level.

## How
- Hub-side wire mirror `RepoActivityWire`/`ActivityStatWire` in `repo_activity.go` — `pkg/dashboard` imports `pkg/hub`, so the reverse would be an import cycle; `main.go` (imports both) maps the collector snapshot field-by-field, exactly like the fleet-stat scalars.
- `HeartbeatPayload` + `RegistryEntry` gain `RepoActivity` + collected-at + window. `handleHeartbeat` sanitizes (`sanitizeRepoActivity`: clamp counts, canonical-UTC timestamps, drop junk rows, all-junk→nil) and **carries the last summary forward with its timestamp+window** across beats that omit it (minimal upgrade-beat / re-warming spoke), mirroring `ComponentReach`.
- Verdict computed on read in `handleMyHives` beside `FleetRollup`, reusing the rollup/app-health/queue we already compute; skipped for placeholders.

## Tests
`health_verdict_test.go`: table across **every** ACMM band + gate (L1 no-output→green, L2 advisory, L4 creates-not-merged→green, L4 stale+queued→red, L4 stale+queue-empty→green, L6 merge-recent→green, L6 unmerged+queued→red, App-broken→red, no-agents→red, offline→unknown, legacy→unknown) + `sanitizeRepoActivity` nil/junk/clamp.

Follow-up: **Part D** re-keys `/fleet`'s `hiveHealth()` to `health.State`, adds the WHY chip + ACMM-aware output cell + repo-activity drill-down.