### PR TITLE
fix(agent): pass -y to skills add so the caveman install actually completes headlessly

### DIFF
--- a/src/pkg/agent/caveman_pin_test.go
+++ b/src/pkg/agent/caveman_pin_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -39,6 +40,37 @@ func TestCavemanPinIsNotBareSHA(t *testing.T) {
 		ref := m[1]
 		if bareSHARe.MatchString(ref) {
 			t.Errorf("caveman ref %q is pinned to a bare commit SHA; `git clone --branch <sha>` cannot clone it, so every install fails. Pin a tag (or branch) that resolves to the wanted commit instead — see PR #4518", m[0])
+		}
+	}
+}
+
+// TestCavemanSkillsAddIsHeadless guards the other silent-failure mode of the
+// same install path: without the skills CLI's own `-y`, `skills add <pkg> -a
+// <agent>` renders an interactive confirmation that auto-cancels in the
+// hive's non-TTY captured-output context — the command exits 0 but installs
+// NOTHING (npx's `-y` only confirms the npx package fetch, not the skills
+// prompts). See PR #4548. Every `skills add` invocation in manager.go must
+// therefore carry a `-y` argument.
+func TestCavemanSkillsAddIsHeadless(t *testing.T) {
+	src, err := os.ReadFile("manager.go")
+	if err != nil {
+		t.Fatalf("reading manager.go: %v", err)
+	}
+
+	addLineRe := regexp.MustCompile(`(?m)^.*"skills",\s*"add".*$`)
+	// Only args AFTER "add" count: npx's own leading `-y` confirms the npx
+	// package fetch, not the skills CLI's prompts.
+	yesRe := regexp.MustCompile(`"(-y|--yes)"`)
+
+	lines := addLineRe.FindAllString(string(src), -1)
+	if len(lines) == 0 {
+		t.Fatal("no `skills add` invocations found in manager.go; if the install moved, update this test to scan the new location")
+	}
+
+	for _, line := range lines {
+		_, afterAdd, _ := strings.Cut(line, `"add"`)
+		if !yesRe.MatchString(afterAdd) {
+			t.Errorf("`skills add` invocation lacks the skills CLI's own -y/--yes flag after `add` (npx's leading -y does not count), so it auto-cancels headlessly and installs nothing (exit 0): %s — see PR #4548", strings.TrimSpace(line))
 		}
 	}
 }

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2546,11 +2546,11 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 	case "gemini":
 		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "gemini", modeFlag)
 	case "goose":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "goose")
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "goose", "-y")
 	case "codex":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "codex")
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "codex", "-y")
 	case "aider":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "aider-desk")
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "aider-desk", "-y")
 	default:
 		m.logger.Info("caveman not supported for backend", "backend", backend)
 		return


### PR DESCRIPTION
Follow-up to #4518 (the tag-pin fix, merged). On a live hive the codex/goose/aider installs exit 0 but write **nothing**: without `-y`, `skills add <pkg> -a codex` renders an interactive multi-select menu, and in the hive's captured-output non-TTY context the menu auto-cancels. The `npx -y` only confirms the npx install itself; the skills CLI needs its own `-y`.

Verified on a live hive: with `-y` the install completes (`Done!`) and writes the skills to the agent's skills dir; without it, exit 0 and no SKILL.md anywhere.