### PR TITLE
🐛 Off-schedule agents with live sessions are quiet by design

### DIFF
--- a/src/pkg/hub/advisory_staleness.go
+++ b/src/pkg/hub/advisory_staleness.go
@@ -106,8 +106,11 @@ func allAgentsQuietByDesign(e RegistryEntry) bool {
 			return false
 		}
 		paused := a.Paused || strings.EqualFold(a.State, agentStatePaused)
-		running := strings.EqualFold(a.State, agentStateRunning)
-		offByDesign := !a.ExpectedActive && !running
+		// Off-schedule counts as quiet REGARDLESS of session state: spokes
+		// keep persistent agent sessions alive between kicks, so an agent the
+		// governor expects off still reports state=running while idle (same
+		// rule as deriveAgentVerdict's quiet-by-design arm).
+		offByDesign := !a.ExpectedActive
 		if !paused && !offByDesign {
 			return false
 		}

--- a/src/pkg/hub/advisory_staleness_test.go
+++ b/src/pkg/hub/advisory_staleness_test.go
@@ -63,6 +63,21 @@ func activeAgent(name string) AgentSummary {
 
 // An aged digest on a hive whose EVERY agent is deliberately quiet (paused or
 // off-schedule) is the operator's own pause, not a wedge — never a pill.
+// An off-schedule agent whose persistent session is still alive
+// (state=running) is quiet all the same — the suppression must not require
+// the session to be torn down.
+func TestAdvisoryStale_OffScheduleRunningSessionStillSuppresses(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Hour)
+	e.Agents = []AgentSummary{
+		pausedAgent("supervisor"),
+		{Name: "scanner", State: agentStateRunning, ExpectedActive: false, Enabled: true, CanOpenIssue: true},
+	}
+	if stale, reason := advisoryStale(e, advNow); stale {
+		t.Fatalf("an off-schedule idle session must still count as quiet, got %q", reason)
+	}
+}
+
 func TestAdvisoryStale_AllAgentsQuietSuppressesAgedTimestamp(t *testing.T) {
 	e := advisoryModeEntry()
 	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Hour)

--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -199,10 +199,18 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	switch {
 	case paused:
 		v.RunState = runQuietByDesign
-	case !legacy && !a.ExpectedActive && !running:
-		// Not scheduled to run in this mode and not running: off by design, not
-		// a fault. (A legacy spoke reports ExpectedActive=false for everything,
-		// so this branch is guarded to spokes that actually speak the field.)
+	case !legacy && !a.ExpectedActive:
+		// Not scheduled to run in this mode: off by design, not a fault —
+		// REGARDLESS of the reported session state. Spokes keep persistent
+		// agent sessions alive between kicks, so an off-schedule agent still
+		// reports state=running while it sits idle; labeling that "should be
+		// working" contradicted the hive's own dashboard, which shows the
+		// agent OFF in the current mode (seen live: a surge-mode hive with
+		// every agent off rendered "4 running · should be working" on /fleet).
+		// The governor's expectation is the schedule truth here, not the
+		// session's existence. (A legacy spoke reports ExpectedActive=false
+		// for everything, so this branch is guarded to spokes that actually
+		// speak the field.)
 		v.RunState = runQuietByDesign
 	case kind == agentInactiveSessionMissing:
 		v.RunState = runSessionGone

--- a/src/pkg/hub/agent_capability_coverage_test.go
+++ b/src/pkg/hub/agent_capability_coverage_test.go
@@ -120,6 +120,42 @@ func TestVerdict_SessionGoneAndIdle(t *testing.T) {
 // never count as impotent/problem. (Fleet rows at L1/L2 previously flagged
 // every working advisory agent "PROBLEM: no write capability at this ACMM
 // level".)
+// A persistent agent session idling OFF-SCHEDULE is quiet by design, never
+// "should be working". Live case (EPM/cdo-data-model-documentation): a
+// surge-mode hive with every agent off in that mode still reported
+// state=running for its parked sessions, and /fleet rendered "4 running ·
+// should be working" against a dashboard showing every agent OFF. The
+// governor's expectation is the schedule truth; the session's existence is
+// not.
+func TestVerdict_OffScheduleRunningSessionIsQuietByDesign(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{
+		Name: "scanner", State: "running", Backend: "bob",
+		Enabled: true, ExpectedActive: false,
+		CanOpenIssue: true,
+		StartedAt:    settled(now), LastActivityAt: activeAt(now, 1*time.Minute),
+	}
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runQuietByDesign {
+		t.Errorf("off-schedule agent with a live session: RunState = %v, want quiet-by-design", v.RunState)
+	}
+	if !v.QuietByDesign {
+		t.Error("off-schedule agent with a live session must be QuietByDesign")
+	}
+	if v.Problem {
+		t.Error("off-schedule agent with a live session must never be a PROBLEM")
+	}
+	// The rollup must not count it as running: "expects 0 · 4 running" was the
+	// visible contradiction.
+	r := rollupAgents([]AgentSummary{a}, hiveBlockers{}, 5, now)
+	if r.Running != 0 {
+		t.Errorf("rollup Running = %d, want 0 for an off-schedule idle session", r.Running)
+	}
+	if r.Expected != 0 {
+		t.Errorf("rollup Expected = %d, want 0", r.Expected)
+	}
+}
+
 func TestVerdict_AdvisoryOnlyLevelIsNotAProblem(t *testing.T) {
 	now := time.Now()
 	a := AgentSummary{


### PR DESCRIPTION
Spokes keep persistent agent sessions alive between scheduled kicks, so an off-schedule agent reports `state=running` while idling at the prompt. The verdict machine let `running` win over `!ExpectedActive`, so a surge-mode hive with every agent off still showed **expects 0 · 4 running · should be working** on /fleet — contradicting the hive dashboard (seen live on EPM/cdo-data-model-documentation and ibm/alchemy-logging).

## Changes
- `deriveAgentVerdict`: off-schedule (`!ExpectedActive`) always derives quiet-by-design, regardless of session state — the governor's schedule expectation is the truth, the session's existence is not.
- Fleet rollup no longer counts idle off-schedule sessions as `Running` (fixes the `expects 0 · N running` contradiction).
- `allAgentsQuietByDesign` (advisory staleness suppression, #4528) no longer requires the session to be torn down.
- Regression tests pinning verdict, rollup counts, and staleness suppression for the running-but-off-schedule case.

Hub-side computation on read — every affected hive corrects at once on hub redeploy, no spoke rollouts needed.

Full `go test ./pkg/hub` green.