### PR TITLE
🐛 Post empty advisory freshness digests

### DIFF
--- a/src/cmd/hive/advisory_wedge_test.go
+++ b/src/cmd/hive/advisory_wedge_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubestellar/hive/pkg/advisory"
+	"github.com/kubestellar/hive/pkg/beads"
 	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/dashboard"
 	"github.com/kubestellar/hive/pkg/github"
@@ -46,6 +48,46 @@ func TestAdvisoryIssueUnresolved(t *testing.T) {
 	}
 	if advisoryIssueUnresolved(issues, "org/ok") {
 		t.Error("a resolved issue number must not trigger a re-ensure")
+	}
+}
+
+func TestEmptyAdvisoryDigestRequiresExistingIssueAndClient(t *testing.T) {
+	client := &github.Client{}
+
+	if !shouldBuildAdvisoryDigest(nil, client, true) {
+		t.Fatal("empty digest should still be built for an existing advisory issue")
+	}
+	if shouldBuildAdvisoryDigest(nil, client, false) {
+		t.Fatal("empty digest must not create advisory participation from nothing")
+	}
+	if shouldBuildAdvisoryDigest(nil, nil, true) {
+		t.Fatal("empty digest requires a GitHub client capable of attempting the write")
+	}
+	if !shouldBuildAdvisoryDigest(map[string]*beads.Store{"scanner": nil}, nil, false) {
+		t.Fatal("non-empty store set should still build so missing-issue errors can be reported")
+	}
+}
+
+func TestEmptyAdvisoryDigestPostsOnlyToExistingIssue(t *testing.T) {
+	client := &github.Client{}
+	empty := &advisory.Digest{}
+	withFinding := &advisory.Digest{TotalCount: 1}
+	withResolved := &advisory.Digest{RecentlyResolved: []advisory.ResolvedFinding{{Title: "fixed"}}}
+
+	if !shouldPostAdvisoryDigest(empty, client, true) {
+		t.Fatal("empty digest should post as a freshness marker when a pinned issue exists")
+	}
+	if shouldPostAdvisoryDigest(empty, client, false) {
+		t.Fatal("empty digest must not post without an existing pinned issue")
+	}
+	if shouldPostAdvisoryDigest(empty, nil, true) {
+		t.Fatal("empty digest must not post without a GitHub client")
+	}
+	if !shouldPostAdvisoryDigest(withFinding, nil, false) {
+		t.Fatal("findings must still flow to the missing-issue error path")
+	}
+	if !shouldPostAdvisoryDigest(withResolved, nil, false) {
+		t.Fatal("recently resolved findings must still flow to the missing-issue error path")
 	}
 }
 

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -5224,6 +5224,28 @@ func advisoryIssueUnresolved(advisoryIssues map[string]int, repo string) bool {
 	return !ok || num <= 0
 }
 
+func advisoryIssueNumber(advisoryIssues map[string]int, repo string) (int, bool) {
+	num, ok := advisoryIssues[repo]
+	return num, ok && num > 0
+}
+
+func shouldBuildAdvisoryDigest(beadStores map[string]*beads.Store, ghClient *github.Client, hasExistingPinnedIssue bool) bool {
+	if len(beadStores) > 0 {
+		return true
+	}
+	return ghClient != nil && hasExistingPinnedIssue
+}
+
+func shouldPostAdvisoryDigest(digest *advisory.Digest, ghClient *github.Client, hasPinnedIssue bool) bool {
+	if digest == nil {
+		return false
+	}
+	if digest.TotalCount > 0 || len(digest.RecentlyResolved) > 0 {
+		return true
+	}
+	return ghClient != nil && hasPinnedIssue
+}
+
 // advisoryIssueMissingError is the error recorded (and reported to the hub) when
 // a hive has findings to publish but no advisory issue to publish them to. It is
 // deliberately an ERROR rather than a silent skip: the hub's staleness gate
@@ -5292,17 +5314,19 @@ func runEvalCycle(
 	// error recorded below can name the CAUSE (e.g. Issues disabled on a fork,
 	// #4329) instead of only the symptom.
 	var advisoryEnsureErr error
-	if primaryRepo := primaryAdvisoryRepo(cfg); primaryRepo != "" && ghClient != nil {
-		if advisoryIssueUnresolved(advisoryIssues, primaryRepo) {
-			num, retryErr := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
+	primaryRepoAtCycleStart := primaryAdvisoryRepo(cfg)
+	_, hadPinnedAdvisoryIssueAtCycleStart := advisoryIssueNumber(advisoryIssues, primaryRepoAtCycleStart)
+	if primaryRepoAtCycleStart != "" && ghClient != nil {
+		if advisoryIssueUnresolved(advisoryIssues, primaryRepoAtCycleStart) {
+			num, retryErr := ghClient.EnsureAdvisoryIssue(ctx, primaryRepoAtCycleStart)
 			if retryErr == nil {
-				advisoryIssues[primaryRepo] = num
+				advisoryIssues[primaryRepoAtCycleStart] = num
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
-				logger.Info("advisory issue resolved on retry", "repo", primaryRepo, "number", num)
+				logger.Info("advisory issue resolved on retry", "repo", primaryRepoAtCycleStart, "number", num)
 			} else {
 				advisoryEnsureErr = retryErr
 				logger.Warn("advisory issue still unresolved — digest cannot be posted this cycle",
-					"repo", primaryRepo, "error", retryErr)
+					"repo", primaryRepoAtCycleStart, "error", retryErr)
 			}
 		}
 	}
@@ -5786,7 +5810,12 @@ func runEvalCycle(
 	}
 
 	// Advisory digest: build from beads (the source of truth) before status broadcast.
-	if len(beadStores) > 0 {
+	primaryRepo := primaryAdvisoryRepo(cfg)
+	issueNum, hasPinnedAdvisoryIssue := advisoryIssueNumber(advisoryIssues, primaryRepo)
+	hasExistingPinnedIssueForEmptyDigest := hasPinnedAdvisoryIssue &&
+		primaryRepo == primaryRepoAtCycleStart &&
+		hadPinnedAdvisoryIssueAtCycleStart
+	if shouldBuildAdvisoryDigest(beadStores, ghClient, hasExistingPinnedIssueForEmptyDigest) {
 		// Retire findings no agent has re-reported inside the staleness window
 		// BEFORE the digest is built, so a stale finding never appears in the
 		// comment one last time after it has been proven gone. Agents re-file a
@@ -5810,12 +5839,13 @@ func runEvalCycle(
 		dashSrv.SetAdvisoryDigest(digest)
 		statusPayload.AdvisoryDigest = digest
 
-		// Post whenever there is something CURRENT to say: open findings, or
-		// recently resolved ones. The latter matters for healing (#2575): when
-		// the last finding resolves, TotalCount drops to 0 but the pinned
-		// digest comment must still be rewritten — otherwise it freezes on its
-		// last non-empty state and keeps showing the healed finding forever.
-		if digest.TotalCount > 0 || len(digest.RecentlyResolved) > 0 {
+		// Post whenever there is something CURRENT to say: open findings,
+		// recently resolved ones, or an empty evaluation for a hive that already
+		// has a pinned advisory issue. The resolved and empty cases matter for
+		// freshness: otherwise the pinned comment and AdvisoryLastPostedAt
+		// freeze after the last finding disappears, and the hub reports a stale
+		// advisory loop even though the agents are running cleanly.
+		if shouldPostAdvisoryDigest(digest, ghClient, hasExistingPinnedIssueForEmptyDigest) {
 			// Log severity breakdown and contributing agents
 			bySeverity := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 			agentNames := make([]string, 0, len(digest.ByAgent))
@@ -5834,8 +5864,11 @@ func runEvalCycle(
 				"agents", strings.Join(agentNames, ", "),
 				"resolved_count", len(digest.RecentlyResolved),
 			)
+			if digest.TotalCount == 0 && len(digest.RecentlyResolved) == 0 {
+				logger.Info("advisory digest empty — posting freshness marker",
+					"repo", primaryRepo, "issue", issueNum)
+			}
 
-			primaryRepo := primaryAdvisoryRepo(cfg)
 			// Repo entries may be org-qualified ("org/repo"); the digest
 			// linkifier needs the bare repo name alongside the org.
 			org, repoName := cfg.Project.Org, primaryRepo
@@ -5890,10 +5923,11 @@ func runEvalCycle(
 				MaxFindings: digestOpts.MaxFindings,
 				ShowAll:     digestOpts.ShowAll,
 				Org:         org,
+				ShowEmpty:   digest.TotalCount == 0 && len(digest.RecentlyResolved) == 0,
 				PrimaryRepo: repoName,
 			})
 			if md != "" {
-				if issueNum, ok := advisoryIssues[primaryRepo]; ok && issueNum > 0 {
+				if hasPinnedAdvisoryIssue {
 					// Prefer the App client as the PRIMARY poster. The App
 					// authored the advisory-digest comment and always holds
 					// issues:write, so it is the correct identity to edit it.

--- a/src/pkg/advisory/advisory.go
+++ b/src/pkg/advisory/advisory.go
@@ -361,6 +361,10 @@ type DigestOptions struct {
 	// ShowAll bypasses MaxFindings — the owner opt-in for the full list.
 	ShowAll bool
 	Org     string
+	// ShowEmpty renders a freshness-marker digest even when there are no
+	// open or recently resolved findings. Callers should only enable this when
+	// updating an existing advisory participant's pinned issue/comment.
+	ShowEmpty bool
 	// PrimaryRepo is the repo the digest is posted to, used to resolve
 	// repo-less "gh-123" references.
 	PrimaryRepo string
@@ -764,19 +768,24 @@ func VerifyFindingPaths(d *Digest, exists func(path string) bool) {
 func FormatDigestMarkdown(d *Digest, opts DigestOptions) string {
 	org, primaryRepo := opts.Org, opts.PrimaryRepo
 	if d.TotalCount == 0 {
-		// No open findings. If nothing was recently resolved either, there is
-		// nothing to say — return "" so no digest comment is created. But when
-		// findings WERE just resolved, an updated digest must still be posted:
-		// otherwise the pinned comment freezes on its last non-empty state and
-		// keeps showing healed findings forever (#2575).
-		if len(d.RecentlyResolved) == 0 {
+		// No open findings. If findings WERE just resolved, an updated digest
+		// must still be posted: otherwise the pinned comment freezes on its last
+		// non-empty state and keeps showing healed findings forever (#2575).
+		// If nothing was recently resolved either, render only when the caller is
+		// deliberately refreshing an existing advisory participant's pinned issue;
+		// otherwise keep returning "" so no digest comment is created.
+		if len(d.RecentlyResolved) == 0 && !opts.ShowEmpty {
 			return ""
 		}
 		var b strings.Builder
 		b.WriteString(fmt.Sprintf("## 🐝 Advisory Digest — %s\n\n", d.GeneratedAt.Format("2006-01-02 15:04 MST")))
 		b.WriteString("> Automated code review findings from [Hive](https://github.com/kubestellar/hive) agents. ")
 		b.WriteString("This comment is updated periodically.\n\n")
-		b.WriteString("**Findings:** 0 — all previously reported findings are resolved. ✅\n\n")
+		if len(d.RecentlyResolved) == 0 {
+			b.WriteString(fmt.Sprintf("**Findings:** 0 — ✅ No open advisory findings · evaluated %s.\n\n", d.GeneratedAt.Format(time.RFC3339)))
+		} else {
+			b.WriteString("**Findings:** 0 — all previously reported findings are resolved. ✅\n\n")
+		}
 		writeRecentlyResolved(&b, d, org, primaryRepo)
 		writeAnalyzedFooter(&b, d)
 		return NeutralizeMentions(b.String())

--- a/src/pkg/advisory/advisory_test.go
+++ b/src/pkg/advisory/advisory_test.go
@@ -71,6 +71,20 @@ func TestFormatDigestMarkdownEmpty(t *testing.T) {
 	}
 }
 
+func TestFormatDigestMarkdownEmptyFreshnessMarker(t *testing.T) {
+	d := BuildDigest(nil, "idle")
+	md := FormatDigestMarkdown(d, DigestOptions{Org: "", PrimaryRepo: "", ShowEmpty: true})
+	if md == "" {
+		t.Fatal("expected non-empty markdown for an explicit empty freshness marker")
+	}
+	if !contains(md, "✅ No open advisory findings") {
+		t.Errorf("missing no-findings freshness marker:\n%s", md)
+	}
+	if !contains(md, "evaluated ") {
+		t.Errorf("missing evaluation timestamp:\n%s", md)
+	}
+}
+
 func TestFormatDigestMarkdownWithResolved(t *testing.T) {
 	d := &Digest{
 		GeneratedAt: time.Now(),


### PR DESCRIPTION
## Summary
- build/post an empty advisory digest freshness marker when a hive already had a pinned advisory issue
- render the marker as a no-open-findings digest and still call RecordAdvisoryPost(0) through the existing success path
- keep missing-issue errors for non-empty digests and avoid creating advisory participation for empty-only hives

## Validation
- go test ./pkg/advisory ./cmd/hive
- go build ./...
- go vet ./...
- go test -race ./pkg/advisory ./cmd/hive
- go test ./... (fails pre-existing cmd/bd TestResolveDirFallbackCwd path canonicalization on Darwin: /private/var vs /var)