### PR TITLE
🐛 Surface and prevent bead-store lockout that silently emptied advisories

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -496,6 +496,19 @@ if [ "$(id -u)" = "0" ]; then
       chown -R dev:node /data/beads 2>/dev/null || true
       chmod -R g+rwX /data/beads 2>/dev/null || true
     fi
+    # UNCONDITIONAL group repair (fma incident, llm-d-fast-model-actuation):
+    # OpenShift's restricted SCC assigns the namespace a random fsGroup
+    # (e.g. 1001670000); kubelet chgrps the PVC to it WITH setgid on mount, so
+    # bead dirs created afterwards inherit that foreign gid at mode 0770. The
+    # hive server drops to dev (groups node + hive-launch) at privilege drop,
+    # losing the fsGroup supplementary group, and then EACCESes on every store
+    # at startup — the advisory digest builds empty and silently goes stale
+    # while agents keep writing findings. The DATA_OWNER-gated chown above
+    # never fires (fsGroup changes group, not owner), so re-group the beads
+    # tree to node on every boot while we are still root. The tree is small
+    # (JSON ledgers), so the recursive walk is cheap even on NFS.
+    chgrp -R node /data/beads 2>/dev/null || true
+    chmod -R g+rwX /data/beads 2>/dev/null || true
   fi
 
   # Shared CLI auth/cache lives in /data/home (persistent volume).

--- a/src/pkg/beads/beads.go
+++ b/src/pkg/beads/beads.go
@@ -152,6 +152,16 @@ func NewStore(dir string) (*Store, error) {
 	// silently requests plain 0770 — the setgid bit is dropped before the
 	// syscall, with no error — which is why the dir came out drwxrwx--- and the
 	// regression test caught it only on Linux (where the assertion is guarded).
+	//
+	// Re-group BEFORE the chmod (fma incident): on OpenShift the PVC root
+	// carries the namespace's random fsGroup with setgid, so a freshly created
+	// dir INHERITS that foreign gid — and at 0770 the hive server (which drops
+	// the fsGroup supplementary group at privilege drop) can never traverse
+	// it, silently losing the whole store at the next boot. The creator owns
+	// the dir and shares the node group with every hive UID, so pin the group
+	// to the creator's egid. Best-effort, like the chmod; chown can clear
+	// setgid on some platforms, so it must come first.
+	_ = os.Chown(dir, -1, os.Getegid())
 	_ = os.Chmod(dir, 0o770|os.ModeSetgid)
 
 	s := &Store{

--- a/src/pkg/beads/beads_perms_test.go
+++ b/src/pkg/beads/beads_perms_test.go
@@ -71,6 +71,31 @@ func TestNewStore_CreatesGroupWritableDir(t *testing.T) {
 	}
 }
 
+// The bead dir's GROUP must be the creator's egid, not whatever a setgid
+// parent hands down. Live incident (fma): OpenShift's fsGroup put the PVC root
+// at a random namespace gid with setgid, bead dirs inherited it at 0770, and
+// the hive server — which is not in that group — lost every store at startup.
+func TestNewStore_PinsDirGroupToCreatorEgid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX ownership is not meaningful on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "beads", "scanner")
+	if _, err := NewStore(dir); err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("no syscall.Stat_t on this platform")
+	}
+	if int(st.Gid) != os.Getegid() {
+		t.Errorf("bead dir gid = %d, want creator egid %d", st.Gid, os.Getegid())
+	}
+}
+
 // umaskAllowsGroupWrite reports whether the process umask leaves the group-write
 // bit (0020) unmasked, so a group-writable create can actually land it. It reads
 // and restores the umask non-destructively.

--- a/src/pkg/dashboard/beadstore_fold_test.go
+++ b/src/pkg/dashboard/beadstore_fold_test.go
@@ -1,0 +1,75 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Bead-store LOAD failures fold into AdvisoryError so the hub's stale gate
+// fires immediately with the cause. Live incident (fma /
+// llm-d-fast-model-actuation): /data/beads worker dirs were group-owned by a
+// foreign gid, the server hit EACCES on every store at startup and silently
+// dropped them, every digest built empty, and the advisory aged for 3 days
+// with agents visibly working — nothing on the hub said why.
+func TestAdvisoryState_FoldsBeadStoreFailuresForParticipant(t *testing.T) {
+	s := newAdvisoryTestServer()
+	s.deps = &Dependencies{BeadStoreLoadFailures: 3}
+	s.RecordAdvisoryPost(3) // participant with a fresh post time
+
+	_, _, errMsg := s.AdvisoryState()
+	if errMsg == "" {
+		t.Fatalf("an advisory participant with dropped bead stores must surface it as AdvisoryError")
+	}
+	if !strings.Contains(errMsg, "3 bead store(s) failed to load") {
+		t.Fatalf("fold must name the dropped-store count, got %q", errMsg)
+	}
+}
+
+// Participation gate: a hive that has never posted a digest must not be
+// false-alarmed as advisory-stale by a bead-store failure — the failure still
+// surfaces through dependency-admission coverage on the spoke, but the
+// advisory pill belongs to advisory participants only.
+func TestAdvisoryState_BeadStoreFoldSkipsNonParticipant(t *testing.T) {
+	s := newAdvisoryTestServer()
+	s.deps = &Dependencies{BeadStoreLoadFailures: 3}
+
+	postedAt, _, errMsg := s.AdvisoryState()
+	if !postedAt.IsZero() {
+		t.Fatalf("precondition: a fresh server has never posted")
+	}
+	if errMsg != "" {
+		t.Fatalf("a non-participant must not have bead-store failures folded in, got %q", errMsg)
+	}
+}
+
+// Precedence: a real post error and the inference-auth cause are both more
+// specific than the bead-store fold and must win.
+func TestAdvisoryState_BeadStoreFoldIsOutrankedBySpecificCauses(t *testing.T) {
+	s := newAdvisoryTestServer()
+	s.deps = &Dependencies{BeadStoreLoadFailures: 1}
+	s.RecordAdvisoryPost(3)
+
+	s.RecordAdvisoryError("403 Resource not accessible by integration")
+	if _, _, errMsg := s.AdvisoryState(); errMsg != "403 Resource not accessible by integration" {
+		t.Fatalf("a recorded post error must outrank the bead-store fold, got %q", errMsg)
+	}
+
+	s.RecordAdvisoryError("") // clear; now test inference precedence
+	setInferenceAuthForTest(t, "litellm inference backend auth failed (401)", time.Now())
+	if _, _, errMsg := s.AdvisoryState(); !strings.Contains(errMsg, "inference backend auth failed") {
+		t.Fatalf("the inference-auth fold must outrank the bead-store fold, got %q", errMsg)
+	}
+}
+
+// Self-heal: a restart that loads every store reports zero failures, so the
+// fold disappears without operator action.
+func TestAdvisoryState_BeadStoreFoldSelfHealsAtZero(t *testing.T) {
+	s := newAdvisoryTestServer()
+	s.deps = &Dependencies{BeadStoreLoadFailures: 0}
+	s.RecordAdvisoryPost(3)
+
+	if _, _, errMsg := s.AdvisoryState(); errMsg != "" {
+		t.Fatalf("zero load failures must leave AdvisoryError empty, got %q", errMsg)
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -2724,6 +2724,13 @@ func (s *Server) RecordAdvisoryError(errMsg string) {
 // more specific cause; the inference-auth fold only fills an otherwise-empty
 // error. It self-clears the moment inference recovers, because the provider
 // stops reporting the signal.
+//
+// Bead-store LOAD failures fold the same way (fma incident: /data/beads dirs
+// group-owned by a foreign gid locked the server out at startup, so every
+// digest built empty and the advisory silently aged for 3 days while the
+// agents kept writing findings). Gated on participation like the inference
+// fold, and outranked by both a real post error and the inference cause —
+// which are more specific. Self-clears on a restart that loads all stores.
 func (s *Server) AdvisoryState() (lastPostedAt time.Time, lastFindings int, lastError string) {
 	s.advisoryMu.RLock()
 	postedAt, findings, errMsg := s.advisoryLastPostedAt, s.advisoryLastFindings, s.advisoryLastError
@@ -2732,6 +2739,8 @@ func (s *Server) AdvisoryState() (lastPostedAt time.Time, lastFindings int, last
 	if errMsg == "" && !postedAt.IsZero() {
 		if infErr, _ := InferenceAuthError(); infErr != "" {
 			errMsg = infErr
+		} else if s.deps != nil && s.deps.BeadStoreLoadFailures > 0 {
+			errMsg = fmt.Sprintf("%d bead store(s) failed to load at startup (check /data/beads ownership) — advisory digest is built from the stores that DID load", s.deps.BeadStoreLoadFailures)
 		}
 	}
 	return postedAt, findings, errMsg


### PR DESCRIPTION
## The fma incident
llm-d-incubation/llm-d-fast-model-actuation sat **advisories stale · 3d** with agents visibly working, gh app ok, budget fine — and nothing anywhere said why. Root cause: OpenShift's restricted SCC assigns the namespace a random fsGroup (`1001670000`); kubelet chgrps the PVC to it **with setgid** on mount; bead dirs created afterwards inherit that foreign gid at 0770; the hive server drops the fsGroup supplementary group at privilege drop and EACCESes on every store at startup — every digest builds empty, the advisory silently ages, agents keep writing findings into ledgers nobody reads.

## Three layers
1. **entrypoint**: re-group `/data/beads` to `node` unconditionally on every boot while still root. The existing repair was gated on `DATA_OWNER != 1001`, which fsGroup never trips (it changes group, not owner). **Heals every already-broken hive on its next restart.**
2. **beads.NewStore**: pin the new dir's group to the creator's egid before the setgid chmod — a setgid parent can never again hand a bead dir a gid the rest of the pod doesn't share. Regression test included.
3. **dashboard AdvisoryState**: fold `BeadStoreLoadFailures` into `AdvisoryError` (participant-gated, outranked by real post errors and the inference-auth cause — same pattern as the inference fold), so /fleet alarms **with the cause** within one heartbeat instead of silently going stale for days.

Tests: pkg/beads, pkg/dashboard full suites green; deploy/test_entrypoint_symlinks.sh green; entrypoint bash -n clean.