### PR TITLE
feat(agents): write claim + review request files so relays fire

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -354,6 +354,10 @@ jobs:
         working-directory: .
         run: bash bin/test_hive_open_issue.sh
 
+      - name: hive-review helper tests
+        working-directory: .
+        run: bash bin/test_hive_review.sh
+
       # The guard that keeps the three steps above from being the last time
       # anyone notices: it fails when a bin/ suite exists and nothing runs it.
       # Each omission it catches is individually invisible, because nothing

--- a/bin/README.md
+++ b/bin/README.md
@@ -43,6 +43,7 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `git-credential-hive.sh` | Credentials | Git credential helper that serves cached GitHub App tokens and honors the host requested by Git. |
 | `gh-wrapper.sh` | Enforcement | `gh` wrapper that injects App tokens and enforces global/per-agent restriction rules from `/etc/hive/restrictions/<agent-id>.json`. |
 | `hive-open-pr.sh` | Enforcement | Agent-side wrapper for PR creation requests. It writes a request file for the Hive watcher so PRs are opened by the GitHub App bot and pass the same ACMM authorization checks. |
+| `hive-review.sh` | Enforcement | Agent-side wrapper for `gh pr review`. Writes a review-request file the Hive submits with the App token and audits as `agent_pr_reviewed`, so PR-review activity is attributed and visible to hive-health (a direct `gh pr review` is invisible). |
 | `setup-proxy-iptables.sh` | Enforcement | Installs iptables rules in the container to force GitHub HTTPS traffic through the ACMM proxy even if an agent unsets proxy variables. |
 | `agent-env-scrub.sh` | Enforcement | Sourced (never executed) at the start of every shell in an agent's process tree, via `BASH_ENV`/`ENV` from `agent-launch.sh` and an `/etc/bash.bashrc` guard, to unset the live GitHub credentials backend CLIs re-export into agent tool shells (#4045). |
 | `hive-config.sh` | Config | Shared shell config reader that exposes project, repo, agent, dashboard, health, and policy values parsed from `hive-project.yaml`. |

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -987,6 +987,32 @@ if [[ -n "$AGENT_NAME" ]]; then
       exit $rc
       ;;
     issue/edit|pr/edit)
+      # ── Issue self-claim → hive/claimed-by-<agent> label ──
+      # An App bot cannot be a GitHub assignee (Issues.AddAssignees silently
+      # drops it), so `gh issue edit <n> --add-assignee @me` would be a no-op —
+      # the agent thinks it claimed the issue but nothing is recorded. Relay it
+      # to hive-open-issue claim, which applies a visible, AUDITED
+      # hive/claimed-by-<agent> label (agent_issue_claimed). Only for a plain
+      # self-claim on an issue; anything else falls through to the label path.
+      if [ "$subcmd" = "issue" ] && ! _contributor_mode && command -v hive-open-issue >/dev/null 2>&1; then
+        _claim_self=false
+        _prev_arg=""
+        for a in "${args[@]}"; do
+          case "$a" in
+            --add-assignee=@me|--add-assignee=@self) _claim_self=true ;;
+            @me|@self) [ "$_prev_arg" = "--add-assignee" ] && _claim_self=true ;;
+          esac
+          _prev_arg="$a"
+        done
+        if $_claim_self; then
+          _extract_item
+          if [ -n "$item_num" ]; then
+            _claim_repo=""
+            [ -n "$item_repo" ] && _claim_repo="--repo $item_repo"
+            exec hive-open-issue claim $_claim_repo "$item_num"
+          fi
+        fi
+      fi
       _ensure_labels
       # Label injection is provenance metadata, not a security gate. gh applies
       # an edit atomically, so a missing label (repo not yet ensured, create
@@ -1011,13 +1037,27 @@ if [[ -n "$AGENT_NAME" ]]; then
       fi
       exec "$REAL_GH" "$@"
       ;;
-    issue/comment|pr/comment|pr/review)
+    pr/review)
+      _inject_identity
+      # ── Relay reviews through the hive (review-request watcher) ──
+      # A direct `gh pr review` lands under the agent's own shell token, is
+      # never audited, and so PR-review activity is invisible to the hive-health
+      # output signal. hive-review writes a request file the hive submits with
+      # the App token and records as agent_pr_reviewed — same rationale as
+      # issue/create, and gated by the SAME per-agent authorization + UID
+      # forge-resistance. Contributors are EXEMPT (they review under their own
+      # identity), mirroring the hive-open-pr / hive-open-issue redirects.
+      if ! _contributor_mode && command -v hive-review >/dev/null 2>&1; then
+        exec hive-review "${args[@]}"
+      fi
+      # No relay available: fall through to real gh so a review is never lost.
+      exec "$REAL_GH" "$@"
+      ;;
+    issue/comment|pr/comment)
       _inject_identity
       _extract_item
       # ── Relay comments through the hive (same rationale as issue/create) ──
-      # A lost review/triage comment is a lost work product. pr/review keeps
-      # the direct path: its approve/request-changes event semantics don't map
-      # to a plain comment.
+      # A lost review/triage comment is a lost work product.
       if [ "$action" = "comment" ] && ! _contributor_mode && command -v hive-open-issue >/dev/null 2>&1; then
         exec hive-open-issue comment "${args[@]}"
       fi

--- a/bin/hive-open-issue.sh
+++ b/bin/hive-open-issue.sh
@@ -18,6 +18,12 @@
 # Usage (drop-in for the common gh shapes):
 #   hive-open-issue --repo <owner/repo> --title "<t>" [--body "<b>"|--body-file f] [--label a,b]
 #   hive-open-issue comment --repo <owner/repo> <number|url> --body "<b>"
+#   hive-open-issue claim   --repo <owner/repo> <number|url>
+#
+# "claim" records that this agent is starting work on an issue: the watcher
+# applies a `hive/claimed-by-<agent>` LABEL (App bots cannot be GitHub
+# assignees, so a label is the visible, auditable ownership signal) and audits
+# it as agent_issue_claimed. No body/title needed.
 #
 # On success it prints the request path and returns 0. The issue/comment is
 # created asynchronously (within one ~10s watcher tick); poll the .result.json
@@ -28,7 +34,10 @@ set -euo pipefail
 REQ_DIR="/var/run/hive-metrics/issue-requests"
 
 KIND="issue"
-if [ "${1:-}" = "comment" ]; then KIND="comment"; shift; fi
+case "${1:-}" in
+  comment) KIND="comment"; shift;;
+  claim) KIND="claim"; shift;;
+esac
 
 REPO=""; TITLE=""; BODY=""; BODY_FILE=""; NUMBER=""
 LABELS=()
@@ -51,8 +60,8 @@ while [ $# -gt 0 ]; do
     --assignee|-a|--milestone|-m|--project|-p|--template|-T) shift 2;;
     --web|-w|--editor|-e) shift;;
     *)
-      # A bare positional for a comment is the issue/PR number or URL.
-      if [ "$KIND" = "comment" ] && [ -z "$NUMBER" ]; then
+      # A bare positional for a comment/claim is the issue/PR number or URL.
+      if { [ "$KIND" = "comment" ] || [ "$KIND" = "claim" ]; } && [ -z "$NUMBER" ]; then
         case "$1" in
           http://*|https://*) NUMBER="$(printf '%s' "$1" | sed -n 's#.*/\(issues\|pull\)/\([0-9][0-9]*\).*#\2#p')";;
           [0-9]*) NUMBER="$1";;
@@ -79,6 +88,12 @@ if [ "$KIND" = "issue" ]; then
   # agent bug, and catching it here beats a watcher-side .bad quarantine.
   if [ -z "$REPO" ] || [ -z "$TITLE" ] || [ -z "$BODY" ]; then
     echo "hive-open-issue: --repo, --title, and --body are required" >&2
+    exit 2
+  fi
+elif [ "$KIND" = "claim" ]; then
+  # A claim just needs the issue to point at — no body/title.
+  if [ -z "$REPO" ] || [ -z "$NUMBER" ]; then
+    echo "hive-open-issue: claim requires --repo and a number (or URL)" >&2
     exit 2
   fi
 else
@@ -122,6 +137,10 @@ req = {"kind": kind, "repo": repo, "agent": agent}
 if kind == "comment":
     req["number"] = int(number)
     req["body"] = body
+elif kind == "claim":
+    # The watcher applies the hive/claimed-by-<agent> label; number is all it
+    # needs. No body/title/labels.
+    req["number"] = int(number)
 else:
     req["title"] = title
     req["body"] = body
@@ -135,6 +154,8 @@ PY
 
 if [ "$KIND" = "comment" ]; then
   echo "hive-open-issue: requested comment on $REPO#$NUMBER as the App bot"
+elif [ "$KIND" = "claim" ]; then
+  echo "hive-open-issue: requested claim of $REPO#$NUMBER (hive/claimed-by-$AGENT label)"
 else
   echo "hive-open-issue: requested issue on $REPO as the App bot: $TITLE"
 fi

--- a/bin/hive-review.sh
+++ b/bin/hive-review.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# hive-review.sh — submit a PR review via the HIVE, not gh.
+#
+# Agents call this INSTEAD of `gh pr review`. It writes a request file that the
+# hive's review-request watcher submits with the App installation token —
+# server-side, retried, and AUDITED as agent_pr_reviewed. The direct `gh pr
+# review` path is invisible to the hive: the review lands under the agent's own
+# shell token with no audit entry, so PR-review activity never shows up in the
+# hive-health output signal. This shim makes the agent's job "record the review
+# request" (a local file write) and lets the hive own delivery + attribution.
+#
+# The watcher enforces the SAME per-agent authorization (a review is a PR-write,
+# gated by AuthorizePROpen) + UID forge-resistance as the other request shims;
+# this adds no privilege.
+#
+# Usage (drop-in for `gh pr review`):
+#   hive-review [<number>|<url>] --repo <owner/repo> --approve
+#   hive-review [<number>|<url>] --repo <owner/repo> --request-changes --body "<b>"
+#   hive-review [<number>|<url>] --repo <owner/repo> --comment --body "<b>"
+#
+# request_changes and comment REQUIRE a body (GitHub rejects an empty one);
+# approve may omit it. On success it prints the request path and returns 0; the
+# review is submitted within one watcher tick.
+
+set -euo pipefail
+
+REQ_DIR="/var/run/hive-metrics/review-requests"
+
+REPO=""; NUMBER=""; EVENT=""; BODY=""; BODY_FILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo|-R) REPO="$2"; shift 2;;
+    --repo=*) REPO="${1#*=}"; shift;;
+    --body|-b) BODY="$2"; shift 2;;
+    --body=*) BODY="${1#*=}"; shift;;
+    --body-file|-F) BODY_FILE="$2"; shift 2;;
+    --body-file=*) BODY_FILE="${1#*=}"; shift;;
+    --approve|-a) EVENT="approve"; shift;;
+    --request-changes|-r) EVENT="request_changes"; shift;;
+    --comment|-c) EVENT="comment"; shift;;
+    *)
+      # A bare positional is the PR number or URL.
+      if [ -z "$NUMBER" ]; then
+        case "$1" in
+          http://*|https://*) NUMBER="$(printf '%s' "$1" | sed -n 's#.*/\(issues\|pull\)/\([0-9][0-9]*\).*#\2#p')";;
+          [0-9]*) NUMBER="$1";;
+        esac
+      fi
+      shift;;
+  esac
+done
+
+if [ -n "$BODY_FILE" ]; then
+  if [ "$BODY_FILE" = "-" ]; then
+    BODY="$(cat)"
+  elif [ -f "$BODY_FILE" ]; then
+    BODY="$(cat "$BODY_FILE")"
+  else
+    echo "hive-review: body file not found: $BODY_FILE" >&2
+    exit 2
+  fi
+fi
+
+if [ -z "$REPO" ] || [ -z "$NUMBER" ] || [ -z "$EVENT" ]; then
+  echo "hive-review: --repo, a PR number (or URL), and one of --approve/--request-changes/--comment are required" >&2
+  exit 2
+fi
+if [ "$EVENT" != "approve" ] && [ -z "$BODY" ]; then
+  echo "hive-review: --request-changes and --comment require --body" >&2
+  exit 2
+fi
+
+AGENT="${HIVE_AGENT:-agent}"
+UID_NOW="$(id -u 2>/dev/null || echo 0)"
+UID_MAP="/var/run/hive/uid-map.json"
+if [ "$UID_NOW" -ge 2001 ] && [ -f "$UID_MAP" ] && command -v python3 >/dev/null 2>&1; then
+  MAPPED="$(python3 -c "
+import json
+try:
+    m=json.load(open('$UID_MAP')).get('agents',{})
+    for n,u in m.items():
+        if u==$UID_NOW: print(n); break
+except Exception: pass
+" 2>/dev/null || true)"
+  [ -n "$MAPPED" ] && AGENT="$MAPPED"
+fi
+
+mkdir -p "$REQ_DIR" 2>/dev/null || true
+REQ_FILE="$REQ_DIR/${AGENT}-$(date +%s%N).json"
+TEMP_FILE="${REQ_FILE}.tmp"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "hive-review: python3 is required to encode the review request safely" >&2
+  exit 1
+fi
+
+python3 - "$TEMP_FILE" "$REQ_FILE" "$REPO" "$NUMBER" "$EVENT" "$BODY" "$AGENT" <<'PY'
+import json, os, sys
+temporary, path, repo, number, event, body, agent = sys.argv[1:8]
+req = {"repo": repo, "number": int(number), "event": event, "agent": agent}
+if body:
+    req["body"] = body
+with open(temporary, "w") as fh:
+    json.dump(req, fh)
+os.replace(temporary, path)
+PY
+
+echo "hive-review: requested $EVENT review on $REPO#$NUMBER as the App bot"
+echo "hive-review: request $REQ_FILE (Hive submits it within one watcher tick)"

--- a/bin/test_hive_open_issue.sh
+++ b/bin/test_hive_open_issue.sh
@@ -271,6 +271,45 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+rm -rf "$REQ_DIR"
+mkdir -p "$REQ_DIR"
+
+# --- Section 9: claim kind ---
+echo ""
+echo "--- claim kind ---"
+
+# claim requires --repo and a number
+check_exit "claim without number exits 2" 2 \
+  env HIVE_AGENT=x bash "$MODIFIED_SCRIPT" claim --repo "org/repo"
+check_exit "claim without repo exits 2" 2 \
+  env HIVE_AGENT=x bash "$MODIFIED_SCRIPT" claim 42
+
+run_script "claimbot" claim --repo "org/repo" 77
+REQ_FILE="$(find_req claimbot)"
+if [ -n "$REQ_FILE" ]; then
+  GOT_KIND="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['kind'])" "$REQ_FILE")"
+  check "claim kind field" "claim" "$GOT_KIND"
+  GOT_NUM="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['number'])" "$REQ_FILE")"
+  check "claim number field" "77" "$GOT_NUM"
+  GOT_AGENT="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['agent'])" "$REQ_FILE")"
+  check "claim agent field" "claimbot" "$GOT_AGENT"
+else
+  echo "  FAIL: claim request file not created"
+  FAIL=$((FAIL + 3))
+fi
+
+# claim accepts a PR/issue URL as the number
+rm -rf "$REQ_DIR"; mkdir -p "$REQ_DIR"
+run_script "urlbot" claim --repo "org/repo" "https://github.com/org/repo/issues/91"
+REQ_FILE="$(find_req urlbot)"
+if [ -n "$REQ_FILE" ]; then
+  GOT_NUM="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['number'])" "$REQ_FILE")"
+  check "claim parses number from URL" "91" "$GOT_NUM"
+else
+  echo "  FAIL: claim-from-URL request not created"
+  FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/bin/test_hive_review.sh
+++ b/bin/test_hive_review.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Tests for bin/hive-review.sh — the agent PR-review chokepoint.
+#
+# Validates CLI argument parsing, required-field validation, event mapping,
+# body requirements, and JSON request file structure.
+#
+# Run: bash bin/test_hive_review.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/hive-review.sh"
+
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"; echo "        want: '$want'"; echo "        got:  '$got'"; FAIL=$((FAIL + 1))
+  fi
+}
+
+check_exit() {
+  local label="$1" want_exit="$2"; shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$want_exit" -eq "$actual_exit" ]; then
+    echo "  PASS: $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"; echo "        want exit: $want_exit"; echo "        got exit:  $actual_exit"; FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== hive-review.sh tests ==="
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+REQ_DIR="$TMPDIR_ROOT/review-requests"
+
+MODIFIED_SCRIPT="$TMPDIR_ROOT/hive-review-test.sh"
+sed -e "s|REQ_DIR=.*|REQ_DIR=\"$REQ_DIR\"|" \
+    -e 's|UID_MAP=.*|UID_MAP="/nonexistent/uid-map.json"|' \
+    "$SCRIPT" > "$MODIFIED_SCRIPT"
+chmod +x "$MODIFIED_SCRIPT"
+
+run_script() { local agent="$1"; shift; env HIVE_AGENT="$agent" bash "$MODIFIED_SCRIPT" "$@" 2>/dev/null; }
+find_req() {
+  local agent="$1"; local files=("$REQ_DIR"/${agent}-*.json)
+  [ -f "${files[0]}" ] && echo "${files[0]}"
+}
+field() { python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get(sys.argv[2],''))" "$1" "$2"; }
+
+# --- Required argument validation ---
+echo ""
+echo "--- Required argument validation ---"
+mkdir -p "$REQ_DIR"
+check_exit "missing event exits 2" 2 \
+  env HIVE_AGENT=x bash "$MODIFIED_SCRIPT" --repo org/repo 5
+check_exit "missing number exits 2" 2 \
+  env HIVE_AGENT=x bash "$MODIFIED_SCRIPT" --repo org/repo --approve
+check_exit "missing repo exits 2" 2 \
+  env HIVE_AGENT=x bash "$MODIFIED_SCRIPT" 5 --approve
+check_exit "request-changes without body exits 2" 2 \
+  env HIVE_AGENT=x bash "$MODIFIED_SCRIPT" --repo org/repo 5 --request-changes
+check_exit "comment without body exits 2" 2 \
+  env HIVE_AGENT=x bash "$MODIFIED_SCRIPT" --repo org/repo 5 --comment
+
+# --- approve (no body needed) ---
+echo ""
+echo "--- approve ---"
+rm -rf "$REQ_DIR"; mkdir -p "$REQ_DIR"
+run_script "revbot" --repo "org/repo" 12 --approve
+REQ_FILE="$(find_req revbot)"
+if [ -n "$REQ_FILE" ]; then
+  check "approve repo" "org/repo" "$(field "$REQ_FILE" repo)"
+  check "approve number" "12" "$(field "$REQ_FILE" number)"
+  check "approve event" "approve" "$(field "$REQ_FILE" event)"
+  check "approve agent" "revbot" "$(field "$REQ_FILE" agent)"
+else
+  echo "  FAIL: approve request not created"; FAIL=$((FAIL + 4))
+fi
+
+# --- request_changes with body ---
+echo ""
+echo "--- request_changes ---"
+rm -rf "$REQ_DIR"; mkdir -p "$REQ_DIR"
+run_script "rcbot" --repo "org/repo" 13 --request-changes --body "please fix the null deref"
+REQ_FILE="$(find_req rcbot)"
+if [ -n "$REQ_FILE" ]; then
+  check "request_changes event" "request_changes" "$(field "$REQ_FILE" event)"
+  check "request_changes body" "please fix the null deref" "$(field "$REQ_FILE" body)"
+else
+  echo "  FAIL: request_changes request not created"; FAIL=$((FAIL + 2))
+fi
+
+# --- comment maps + URL positional ---
+echo ""
+echo "--- comment + URL positional ---"
+rm -rf "$REQ_DIR"; mkdir -p "$REQ_DIR"
+run_script "cbot" --repo "org/repo" "https://github.com/org/repo/pull/44" --comment --body "nit"
+REQ_FILE="$(find_req cbot)"
+if [ -n "$REQ_FILE" ]; then
+  check "comment event" "comment" "$(field "$REQ_FILE" event)"
+  check "number parsed from PR URL" "44" "$(field "$REQ_FILE" number)"
+else
+  echo "  FAIL: comment request not created"; FAIL=$((FAIL + 2))
+fi
+
+# --- atomic write leaves no .tmp ---
+echo ""
+echo "--- atomic write ---"
+rm -rf "$REQ_DIR"; mkdir -p "$REQ_DIR"
+run_script "atombot" --repo "org/repo" 9 --approve
+TMP_FILES=("$REQ_DIR"/*.tmp)
+if [ -e "${TMP_FILES[0]}" ]; then
+  echo "  FAIL: .tmp file remains after successful write"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS: no .tmp file remains (atomic replace)"; PASS=$((PASS + 1))
+fi
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -381,6 +381,7 @@ COPY bin/agent-env-scrub.sh /usr/local/bin/agent-env-scrub.sh
 COPY bin/hive-open-pr.sh /usr/local/bin/hive-open-pr
 COPY bin/hive-open-issue.sh /usr/local/bin/hive-open-issue
 COPY bin/hive-merge.sh /usr/local/bin/hive-merge
+COPY bin/hive-review.sh /usr/local/bin/hive-review
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
 # SDK-based copilot model discovery helper (see Layer 3b). Invoked as
 # `node /usr/local/bin/copilot-models.mjs` by the dashboard, so no exec bit.
@@ -388,7 +389,7 @@ COPY bin/copilot-models.mjs /usr/local/bin/copilot-models.mjs
 COPY config/backends.conf /usr/local/etc/hive/backends.conf
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/hive-panes /usr/local/bin/gh-app-token.sh \
     /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
-    /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-open-issue /usr/local/bin/hive-merge
+    /usr/local/bin/git-credential-hive.sh /usr/local/bin/hive-open-pr /usr/local/bin/hive-open-issue /usr/local/bin/hive-merge /usr/local/bin/hive-review
 
 # SECURITY (#4045): interactive-shell arm of the agent credential scrub.
 # BASH_ENV (exported by agent-launch.sh) only reaches NON-interactive shells;


### PR DESCRIPTION
Completes the hive-health audit trail. **Part A (#4538)** added the issue-**claim** and PR-**review** relay watchers, but nothing on the agent side produced the request files they consume — so `agent_issue_claimed` / `agent_pr_reviewed` audit entries never appeared, and hive-health saw no claim/review output. This wires the producers.

## Changes
- **`bin/hive-review.sh`** (new) — writes a review-request `{repo,number,event,body,agent}` to `/var/run/hive-metrics/review-requests`. The gh-wrapper `pr/review` arm now relays through it (contributors exempt), instead of the invisible direct `gh pr review` that lands under the agent's own token with no audit. Falls back to real gh if the shim is absent so a review is never lost.
- **`hive-open-issue.sh`** gains a `claim` kind → `{kind:"claim",repo,number,agent}`; the watcher applies the `hive/claimed-by-<agent>` **label** (App bots can't be GitHub assignees) and audits `agent_issue_claimed`.
- **gh-wrapper `issue/edit`** arm relays `--add-assignee @me` → `hive-open-issue claim`, so a self-assign gesture that would silently no-op becomes a visible, audited claim label.
- **Dockerfile** installs `hive-review` (+ chmod); bin/README row.

## Tests
- `bin/test_hive_review.sh` (new, wired into v2-ci): event mapping (approve/request_changes/comment), body-required for non-approve, PR-URL positional parsing, atomic write.
- Claim cases added to `bin/test_hive_open_issue.sh` (kind/number/agent fields, URL parsing, required-arg validation).

## Note
The relay is transparent — any agent running `gh pr review …` or `gh issue edit --add-assignee @me` is now attributed and audited without prompt changes. A lighter follow-up can add explicit "claim the issue when you start" guidance to the agent prompts (today they only claim beads, not GitHub).