### PR TITLE
🐛 Health verdict: no-on-duty-writers is quiet by design + restore advisory pill on upgraded spokes

### DIFF
--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -140,6 +141,9 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 	case e.ACMMLevel >= acmmMergeMin:
 		// L6: judged on MERGES. A create that never merges, with work still
 		// queued, is the failure this level exists to catch.
+		if !anyOnDutyGrant(e.Agents, func(a AgentSummary) bool { return a.CanMerge }) {
+			return noWritersOnDuty(v, "merge")
+		}
 		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string { return r.Merges.NewestAt })
 		return bandFreshness(v, last, ok, queuedWork, now, "merge")
 
@@ -147,11 +151,40 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 		// L3–L5: judged on CREATES (issues or PRs). Merges are the human's job
 		// here, so an unmerged PR is not a fault — only a stalled creation
 		// stream (with work queued) is.
+		if !anyOnDutyGrant(e.Agents, func(a AgentSummary) bool { return a.CanOpenIssue || a.CanOpenPR }) {
+			return noWritersOnDuty(v, "create")
+		}
 		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string {
 			return maxRFC3339(r.Issues.NewestAt, r.PRs.NewestAt)
 		})
 		return bandFreshness(v, last, ok, queuedWork, now, "create")
 	}
+}
+
+// anyOnDutyGrant reports whether any agent the governor currently expects to
+// work carries the given write grant. Paused and off-schedule agents cannot
+// produce output no matter what their grants say, so they don't count.
+func anyOnDutyGrant(agents []AgentSummary, grant func(AgentSummary) bool) bool {
+	for _, a := range agents {
+		if a.ExpectedActive && grant(a) {
+			return true
+		}
+	}
+	return false
+}
+
+// noWritersOnDuty is the verdict when no on-duty agent holds the write grant
+// the level is judged on (live case: a QUIET-mode L3 hive whose only running
+// agent had no issue/PR grants read "no create output" red — but a hive that
+// CANNOT write by mode/pause configuration is quiet by design, not failing;
+// same spine as L1 "no output expected"). Absence of output the configuration
+// does not permit is never a fault. The grant chips on the agent rows already
+// show the ✗s, so an operator who MEANT it to write can see exactly why it
+// doesn't.
+func noWritersOnDuty(v HealthVerdict, verb string) HealthVerdict {
+	v.State = HealthStateGreen
+	v.Reason = fmt.Sprintf("no %s-capable agent on duty — no output expected", verb)
+	return v
 }
 
 // bandFreshness applies the recency window to a create/merge output stream:
@@ -175,7 +208,9 @@ func bandFreshness(v HealthVerdict, last time.Time, ok bool, queuedWork int, now
 		}
 	case ok:
 		v.State = HealthStateRed
-		v.Reason = fmt.Sprintf("no %s in %s (%d queued)", verb, humanizeAge(now.Sub(last)), queuedWork)
+		// TrimSuffix: humanizeAge says "18h ago" for badge use; "no create in
+		// 18h ago" is not English, so drop the suffix here.
+		v.Reason = fmt.Sprintf("no %s in %s (%d queued)", verb, strings.TrimSuffix(humanizeAge(now.Sub(last)), " ago"), queuedWork)
 	default:
 		v.State = HealthStateRed
 		v.Reason = fmt.Sprintf("no %s output (%d queued)", verb, queuedWork)

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -40,7 +40,13 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 	freshAdv := rfc(now.Add(-2 * time.Hour)) // within advisory aging window
 
 	base := func(level int) RegistryEntry {
-		return RegistryEntry{Online: true, ACMMLevel: level}
+		// Every base entry carries one on-duty agent with full write grants so
+		// the freshness bands are actually exercised; the no-writers-on-duty
+		// cases build their own agent sets.
+		return RegistryEntry{Online: true, ACMMLevel: level, Agents: []AgentSummary{
+			{Name: "quality", State: agentStateRunning, Enabled: true, ExpectedActive: true,
+				CanOpenIssue: true, CanOpenPR: true, CanMerge: true},
+		}}
 	}
 
 	tests := []struct {
@@ -163,6 +169,47 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 			queued:    3,
 			wantState: HealthStateUnknown,
 			wantKind:  "creates",
+		},
+		{
+			// Live case (kellyaa/agent-newsletter): QUIET-mode L3 hive — every
+			// create-granted agent paused, the one running agent holds no write
+			// grants. It CANNOT create by configuration, so "no create output"
+			// must not be a fault. Same spine as L1: absence of output the
+			// configuration does not permit is never red.
+			name: "L3 no create-capable agent on duty — green (quiet by design)",
+			entry: func() RegistryEntry {
+				e := base(3)
+				e.Agents = []AgentSummary{
+					// paused, HAS grants — off duty, doesn't count
+					{Name: "sec-check", Enabled: false, ExpectedActive: false, CanOpenIssue: true, CanOpenPR: true},
+					// on duty, NO write grants
+					{Name: "scanner", State: agentStateRunning, Enabled: true, ExpectedActive: true},
+				}
+				return e
+			}(),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    4,
+			wantState: HealthStateGreen,
+			wantKind:  "creates",
+		},
+		{
+			// L6 twin: a merge-judged hive whose on-duty agents can create but
+			// not merge is quiet-by-design for merges, not failing.
+			name: "L6 no merge-capable agent on duty — green (quiet by design)",
+			entry: func() RegistryEntry {
+				e := base(6)
+				e.Agents = []AgentSummary{
+					{Name: "quality", State: agentStateRunning, Enabled: true, ExpectedActive: true,
+						CanOpenIssue: true, CanOpenPR: true, CanMerge: false},
+				}
+				return e
+			}(),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    3,
+			wantState: HealthStateGreen,
+			wantKind:  "merges",
 		},
 	}
 

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -377,8 +377,13 @@ function outputHTML(h) {
     var rel = lead.newestAt ? relTime(lead.newestAt) : "none";
     var parts = 'issues ' + iss.count + ' · PRs ' + prs.count + (isMerge ? ' · merged ' + mer.count : '');
     var leadLabel = isMerge ? 'last merge ' + rel : 'last create ' + rel;
+    // The advisory line rides along at EVERY level, same as the old-spoke
+    // fallback below — reporting repoActivity must not cost a hive its
+    // advisory indicator (post-upgrade regression: upgraded spokes lost the
+    // pill while old images kept it).
     return '<span class="output" title="per-repo output over the last ' + esc((h.repoActivityWindowHours || 12)) + 'h; judged on ' + (isMerge ? 'merges (L6)' : 'creates (L3–L5)') + '">' +
-      esc(parts) + ' <span class="rel">(' + esc(leadLabel) + ')</span></span>';
+      esc(parts) + ' <span class="rel">(' + esc(leadLabel) + ')</span></span>' +
+      '<br>' + advisoryActivityHTML(h.advisoryIssueActivity);
   }
 
   // Fallback: no per-repo activity reported (old spoke) — the prior 90d line.


### PR DESCRIPTION
Three live follow-ups to the ACMM-banded health verdict (#4547):

1. **Quiet-mode false red** (kellyaa/agent-newsletter): a QUIET L3 hive whose only running agent holds no issue/PR grants read `no create output (4 queued)` red. A hive that cannot write by mode/pause configuration is quiet by design — same spine as L1 'no output expected'. L3–L5 now require an on-duty agent with a create grant (L6: a merge grant) before judging freshness; paused/off-schedule agents' grants don't count. Verdict reads green: `no create-capable agent on duty — no output expected`.
2. **Advisory pill vanished on upgraded spokes**: the new `repoActivity` branch of `outputHTML` returned without `advisoryActivityHTML`, while the old-spoke fallback kept it — so upgrading a spoke removed its advisory indicator from /fleet. The advisory line now rides along on both branches.
3. **Grammar**: `no create in 18h ago (28 queued)` → `no create in 18h (28 queued)`.

Full `go test ./pkg/hub` green.