### PR TITLE
fix(agent): pre-seed Copilot trusted_folders so agents stop wedging at trust prompt

### DIFF
--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/config"
@@ -146,4 +147,56 @@ func TestRefreshCopilotSessionToken_NoCopilotBackend(t *testing.T) {
 	m.copilotAuthToken = "gho_held"
 	// Should return without panicking or touching the shared/durable paths.
 	m.refreshCopilotSessionToken()
+}
+
+// ensureCopilotTrustedFolders pre-seeds trusted_folders so Copilot's folder-
+// trust modal never appears. It must add a missing folder, be idempotent (no
+// rewrite when already present), preserve existing entries, and handle a
+// missing config file by creating it.
+func TestEnsureCopilotTrustedFolders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	read := func() string {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		return string(b)
+	}
+
+	// Missing file → created with the default folder trusted.
+	if err := ensureCopilotTrustedFolders(path); err != nil {
+		t.Fatalf("seed on missing file: %v", err)
+	}
+	if got := read(); !strings.Contains(got, copilotTrustedFolder) {
+		t.Fatalf("default folder not seeded: %s", got)
+	}
+
+	// Idempotent: a second call with the same folder must NOT rewrite the file.
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureCopilotTrustedFolders(path); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.Stat(path)
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("idempotent call rewrote the file (should no-op when folder already present)")
+	}
+
+	// Existing token + a new folder: token preserved, both folders present.
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{"github.com":{"token":"gho_keep"}},"trusted_folders":["/data/agents"]}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureCopilotTrustedFolders(path, "/data/home/hive-work"); err != nil {
+		t.Fatal(err)
+	}
+	got := read()
+	for _, want := range []string{"gho_keep", "/data/agents", "/data/home/hive-work"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q after add; file:\n%s", want, got)
+		}
+	}
 }

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2410,6 +2410,22 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 	m.fixSharedConfigPerms(agent)
 
+	// Pre-seed Copilot's trusted_folders BEFORE the CLI starts so its "Confirm
+	// folder trust" modal never appears (Copilot ≥1.0.78). That modal wedges a
+	// fresh session at startup, the login-detector misreads the blocked pane as
+	// "needs login" and pauses the agent, and a re-login just re-hits the race —
+	// the failure the operator saw where logged-in agents kept asking to log in.
+	// There is no CLI flag to disable it (github/copilot-cli#1121); the
+	// trusted_folders array is the documented, durable bypass. Idempotent and
+	// best-effort — the runtime watchForTrustPromptForAgent watcher stays as a
+	// backstop, so a failure here only loses the pre-seed, never the answer.
+	if backend == "copilot" {
+		if err := ensureCopilotTrustedFolders(sharedCopilotConfigPath); err != nil {
+			m.logger.Warn("failed to pre-seed copilot trusted_folders (watcher will backstop)",
+				"name", agent.Name, "error", err)
+		}
+	}
+
 	// Re-apply SECRET env vars before every launch. ensureTmuxSession sets the
 	// full env via tmux set-environment, but it returns early when the session
 	// already exists, so on a relaunch (restart, model change, crash recovery)
@@ -5816,6 +5832,54 @@ func restoreCopilotTokens(path, token string) error {
 	cfg["copilotTokens"] = map[string]interface{}{
 		"github.com": map[string]interface{}{"token": token},
 	}
+	return writeCopilotConfig(path, cfg)
+}
+
+// copilotTrustedFolder is the parent under which every agent's working dir lives
+// (/data/agents/<name>). Copilot trusts a folder AND everything below it, so a
+// single entry here covers all agents.
+const copilotTrustedFolder = "/data/agents"
+
+// ensureCopilotTrustedFolders pre-seeds Copilot CLI's trusted_folders in
+// config.json so the "Confirm folder trust" modal never appears. That modal
+// (Copilot ≥1.0.78) blocks a fresh agent session at startup; nothing types an
+// answer reliably (the auto-answerer races a 120s window and the CLI can render
+// the prompt later than that on a slow first start), and the login-detector then
+// MISREADS the blocked pane as "needs login" and pauses the agent — so a
+// logged-IN agent with a valid gho_ token sits wedged forever. There is no CLI
+// flag to disable the prompt (github/copilot-cli#1121 is an open request); the
+// documented, durable bypass is the trusted_folders array. Idempotent: a folder
+// already present is left as-is, so this never churns the file or re-prompts.
+func ensureCopilotTrustedFolders(path string, folders ...string) error {
+	if len(folders) == 0 {
+		folders = []string{copilotTrustedFolder}
+	}
+	cfg, err := readCopilotConfig(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		cfg = map[string]interface{}{}
+	}
+	existing, _ := cfg["trusted_folders"].([]interface{})
+	have := make(map[string]bool, len(existing))
+	for _, e := range existing {
+		if s, ok := e.(string); ok {
+			have[s] = true
+		}
+	}
+	changed := false
+	for _, f := range folders {
+		if f != "" && !have[f] {
+			existing = append(existing, f)
+			have[f] = true
+			changed = true
+		}
+	}
+	if !changed {
+		return nil // already trusted — do not rewrite the file
+	}
+	cfg["trusted_folders"] = existing
 	return writeCopilotConfig(path, cfg)
 }
 


### PR DESCRIPTION
## Symptom (live, kubestellar/hive)
Every copilot agent (scanner, sec-check, guide, quality) showed **"PROBLEM: sitting at login prompt"** on `/fleet` and **"needs login"** on the spoke dashboard. Logging in via the dashboard cleared it momentarily, then **all agents asked to log in again immediately.** The CLI actually had a valid `gho_` token the whole time.

## Root cause
The agent panes were wedged on Copilot CLI's **"Confirm folder trust"** modal (Copilot ≥1.0.78), not a login prompt:
- The modal blocks the fresh session at startup.
- The runtime auto-answerer (`watchForTrustPromptForAgent`) only watches for **120s** and the CLI can render the prompt *later* than that on a slow first start → nothing answers it.
- The **login-detector then misreads the blocked pane as "needs login"**, pauses the agent, and the UI shows "needs login." A re-login just re-hits the same race.

There is **no CLI flag** to disable the modal — [github/copilot-cli#1121](https://github.com/github/copilot-cli/issues/1121) is an open feature request. The documented, durable bypass is the `config.json` **`trusted_folders`** array.

## Fix
`ensureCopilotTrustedFolders` pre-seeds `trusted_folders` with `/data/agents` (Copilot trusts a folder *and everything below*, so one entry covers every agent's `/data/agents/<name>` working dir) into the shared Copilot config **before the CLI launches**, so the prompt never appears. Idempotent — never rewrites the file when the folder is already trusted (no config churn, no re-prompt). The existing 120s watcher stays as a backstop.

## Test
`TestEnsureCopilotTrustedFolders`: seeds on a missing file, is idempotent (no rewrite when present, asserted via mtime), and preserves an existing token while adding a new folder.

## Note
This is the real cause of the recurring "agents keep asking to log in" reports — it is a *trust*-prompt wedge misclassified as a login problem, not a token-durability issue (#4519's durable-token promotion is working correctly; the `gho_` was present throughout).