### PR TITLE
🐛 Health verdict: judge writes at L3–L5 and name off-duty responsible agents

### DIFF
--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -116,6 +116,12 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 
 	case e.ACMMLevel == acmmAdvisoryMax:
 		// L2 Advisory: freshness of the advisory stream is the health signal.
+		// Every agent contributes to the advisory stream, so if none are on
+		// duty (all paused/off-schedule), staleness is caused by that — say so
+		// instead of a bare "advisory stale" red.
+		if roster := grantRosterFor(e.Agents, func(AgentSummary) bool { return true }); len(roster.onDuty) == 0 {
+			return noWritersOnDuty(v, "advisory", roster)
+		}
 		// Reuse the existing advisory/issue-activity bucketing rather than the
 		// per-repo activity collector.
 		adv := advisoryIssueActivityFor(e, now)
@@ -141,36 +147,64 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 	case e.ACMMLevel >= acmmMergeMin:
 		// L6: judged on MERGES. A create that never merges, with work still
 		// queued, is the failure this level exists to catch.
-		if !anyOnDutyGrant(e.Agents, func(a AgentSummary) bool { return a.CanMerge }) {
-			return noWritersOnDuty(v, "merge")
+		if roster := grantRosterFor(e.Agents, func(a AgentSummary) bool { return a.CanMerge }); len(roster.onDuty) == 0 {
+			return noWritersOnDuty(v, "merge", roster)
 		}
 		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string { return r.Merges.NewestAt })
 		return bandFreshness(v, last, ok, queuedWork, now, "merge")
 
 	default:
-		// L3–L5: judged on CREATES (issues or PRs). Merges are the human's job
-		// here, so an unmerged PR is not a fault — only a stalled creation
-		// stream (with work queued) is.
-		if !anyOnDutyGrant(e.Agents, func(a AgentSummary) bool { return a.CanOpenIssue || a.CanOpenPR }) {
-			return noWritersOnDuty(v, "create")
+		// L3–L5: judged on authored WRITES to the work source — issue/PR
+		// creates, comments, and reviews. Merges are the human's job here, so
+		// an unmerged PR is not a fault — only a fully stalled write stream
+		// (with work queued) is. Comments/reviews count because an agent
+		// triaging a backlog (dismissing false positives, reviewing held PRs)
+		// is producing real output even on a kick that creates nothing; the
+		// operator: "if it's writing comments then that is output".
+		roster := grantRosterFor(e.Agents, func(a AgentSummary) bool { return a.CanOpenIssue || a.CanOpenPR })
+		if len(roster.onDuty) == 0 {
+			return noWritersOnDuty(v, "create", roster)
 		}
 		last, ok := newestOutput(e.RepoActivity, func(r RepoActivityWire) string {
-			return maxRFC3339(r.Issues.NewestAt, r.PRs.NewestAt)
+			return maxRFC3339(maxRFC3339(r.Issues.NewestAt, r.PRs.NewestAt),
+				maxRFC3339(r.Comments.NewestAt, r.Reviews.NewestAt))
 		})
-		return bandFreshness(v, last, ok, queuedWork, now, "create")
+		return bandFreshness(v, last, ok, queuedWork, now, "write")
 	}
 }
 
-// anyOnDutyGrant reports whether any agent the governor currently expects to
-// work carries the given write grant. Paused and off-schedule agents cannot
-// produce output no matter what their grants say, so they don't count.
-func anyOnDutyGrant(agents []AgentSummary, grant func(AgentSummary) bool) bool {
+// grantRoster splits a hive's agents holding a write grant into the ones the
+// governor currently expects to work and the ones that are off (paused or
+// off-schedule). The off list carries names so a verdict caused by "the
+// responsible agent is off" can SAY so — the operator's ask: when the agent
+// responsible for creating/commenting/merging is off and that is the reason,
+// indicate the correlation.
+type grantRoster struct {
+	onDuty []string
+	off    []string
+}
+
+func grantRosterFor(agents []AgentSummary, grant func(AgentSummary) bool) grantRoster {
+	var r grantRoster
 	for _, a := range agents {
-		if a.ExpectedActive && grant(a) {
-			return true
+		if !grant(a) {
+			continue
+		}
+		if a.ExpectedActive {
+			r.onDuty = append(r.onDuty, a.Name)
+		} else {
+			r.off = append(r.off, a.Name)
 		}
 	}
-	return false
+	return r
+}
+
+// nameList renders up to three agent names, then "+N more".
+func nameList(names []string) string {
+	if len(names) <= 3 {
+		return strings.Join(names, ", ")
+	}
+	return strings.Join(names[:3], ", ") + fmt.Sprintf(" +%d more", len(names)-3)
 }
 
 // noWritersOnDuty is the verdict when no on-duty agent holds the write grant
@@ -178,12 +212,17 @@ func anyOnDutyGrant(agents []AgentSummary, grant func(AgentSummary) bool) bool {
 // agent had no issue/PR grants read "no create output" red — but a hive that
 // CANNOT write by mode/pause configuration is quiet by design, not failing;
 // same spine as L1 "no output expected"). Absence of output the configuration
-// does not permit is never a fault. The grant chips on the agent rows already
-// show the ✗s, so an operator who MEANT it to write can see exactly why it
-// doesn't.
-func noWritersOnDuty(v HealthVerdict, verb string) HealthVerdict {
+// does not permit is never a fault. When grant-holding agents EXIST but are
+// paused/off-schedule, the reason names them — that correlation ("the agent
+// responsible for this output is off") is the answer to the operator's next
+// question, so put it in the chip instead of making them hunt the agent rows.
+func noWritersOnDuty(v HealthVerdict, verb string, roster grantRoster) HealthVerdict {
 	v.State = HealthStateGreen
-	v.Reason = fmt.Sprintf("no %s-capable agent on duty — no output expected", verb)
+	if len(roster.off) > 0 {
+		v.Reason = fmt.Sprintf("no output expected — %s-capable agent(s) off: %s", verb, nameList(roster.off))
+	} else {
+		v.Reason = fmt.Sprintf("no %s-capable agent configured — no output expected", verb)
+	}
 	return v
 }
 

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -55,8 +56,9 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 		rollup    agentFleetRollup
 		app       GitHubAppHealth
 		queued    int
-		wantState string
-		wantKind  string
+		wantState  string
+		wantKind   string
+		wantReason string // substring match, "" = don't check
 	}{
 		{
 			name:      "L1 inception — no output ever, still green",
@@ -113,6 +115,37 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 			rollup:    okRollup(),
 			app:       okApp(),
 			queued:    0,
+			wantState: HealthStateGreen,
+			wantKind:  "creates",
+		},
+		{
+			// The operator: "if it's writing comments then that is output".
+			// An agent triaging a backlog — dismissing false positives in
+			// comments, reviewing held PRs — is producing real output even on
+			// a kick that creates nothing (live case: flashsystems/ess quality
+			// read red while actively commenting through 28 queued items).
+			name: "L4 creates stale but COMMENT recent, work queued — green",
+			entry: func() RegistryEntry {
+				r := ractivity("o/r", oldTs, oldTs, "", "")
+				r.Comments = ActivityStatWire{Count: 3, NewestAt: recent}
+				return withActivity(base(4), r)
+			}(),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    7,
+			wantState: HealthStateGreen,
+			wantKind:  "creates",
+		},
+		{
+			name: "L4 creates stale but REVIEW recent, work queued — green",
+			entry: func() RegistryEntry {
+				r := ractivity("o/r", oldTs, oldTs, "", "")
+				r.Reviews = ActivityStatWire{Count: 1, NewestAt: recent}
+				return withActivity(base(4), r)
+			}(),
+			rollup:    okRollup(),
+			app:       okApp(),
+			queued:    7,
 			wantState: HealthStateGreen,
 			wantKind:  "creates",
 		},
@@ -187,11 +220,12 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 				}
 				return e
 			}(),
-			rollup:    okRollup(),
-			app:       okApp(),
-			queued:    4,
-			wantState: HealthStateGreen,
-			wantKind:  "creates",
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     4,
+			wantState:  HealthStateGreen,
+			wantKind:   "creates",
+			wantReason: "create-capable agent(s) off: sec-check",
 		},
 		{
 			// L6 twin: a merge-judged hive whose on-duty agents can create but
@@ -205,11 +239,32 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 				}
 				return e
 			}(),
-			rollup:    okRollup(),
-			app:       okApp(),
-			queued:    3,
-			wantState: HealthStateGreen,
-			wantKind:  "merges",
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     3,
+			wantState:  HealthStateGreen,
+			wantKind:   "merges",
+			wantReason: "no merge-capable agent configured",
+		},
+		{
+			// Correlation at L2: all agents paused → advisory staleness is
+			// CAUSED by the pause, so the verdict names the off agents instead
+			// of a bare "advisory stale" red.
+			name: "L2 all agents off — green, reason names them",
+			entry: func() RegistryEntry {
+				e := base(2)
+				e.Agents = []AgentSummary{
+					{Name: "scanner", Enabled: false, ExpectedActive: false},
+					{Name: "quality", Enabled: false, ExpectedActive: false},
+				}
+				return e
+			}(),
+			rollup:     agentFleetRollup{Expected: 0, Running: 0, Able: 0, Known: 2},
+			app:        okApp(),
+			queued:     2,
+			wantState:  HealthStateGreen,
+			wantKind:   "advisory",
+			wantReason: "advisory-capable agent(s) off: scanner, quality",
 		},
 	}
 
@@ -221,6 +276,9 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 			}
 			if v.OutputKind != tc.wantKind {
 				t.Errorf("outputKind = %q, want %q", v.OutputKind, tc.wantKind)
+			}
+			if tc.wantReason != "" && !strings.Contains(v.Reason, tc.wantReason) {
+				t.Errorf("reason = %q, want substring %q", v.Reason, tc.wantReason)
 			}
 		})
 	}

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -234,7 +234,7 @@
 </header>
 <header class="fleet-header">
   <h1>Fleet health</h1>
-  <span class="sub">a hive is a <b>problem</b> when it has no recent output for its ACMM level (L2 advisory · L3–L5 issues/PRs created · L6 merged) with work still queued, or a precondition is broken (agents cannot work / GitHub App auth). Absence of output a level does not produce is never a fault.</span>
+  <span class="sub">a hive is a <b>problem</b> when it has no recent output for its ACMM level (L2 advisory · L3–L5 authored writes: issues/PRs created, comments, reviews · L6 merged) with work still queued, or a precondition is broken (agents cannot work / GitHub App auth). Absence of output a level does not produce is never a fault.</span>
   <span id="summary" class="summary"></span>
   <span class="controls">
     <label><input type="checkbox" id="problemsOnly"> problems only</label>
@@ -554,7 +554,7 @@ function hiveHealth(h) {
 }
 
 // whyChipHTML renders the small "WHY" chip next to a hive's name: the verdict's
-// reason ("last merge 3h ago" / "no create in 30h (7 queued)" / "advisory
+// reason ("last merge 3h ago" / "no write in 30h (7 queued)" / "advisory
 // stale"). Green reasons are muted, red reasons are tinted so a broken hive's
 // cause reads at a glance. Nothing for parked/offline (their own chip/dot say
 // it) or when there is no verdict.


### PR DESCRIPTION
Two operator-driven refinements to the ACMM-banded health verdict (#4547):

## 1. L3–L5 judged on the full write stream
Creates alone under-count real output: an agent triaging a backlog — commenting false-positive dismissals, reviewing held PRs — is working even when a kick creates nothing (live case: flashsystems/ess quality judged 6/8 findings false positives via comments, chip read red 'no create in 18h'). L3–L5 now judges `max(Issues, PRs, Comments, Reviews).NewestAt` with verb **write**.

## 2. Off-duty responsible agents named in the reason
Per-level output expectations align with what the level (via per-agent grants) actually allows. When the agent(s) holding the judged grant are off — paused or off-schedule — that IS the reason there's no output, so the chip says it:

- L3–L5: `no output expected — create-capable agent(s) off: quality`
- L6: same for merge grant
- L2: all agents off → `advisory-capable agent(s) off: scanner, quality` instead of a bare 'advisory stale' red

No grant-holders at all → 'no X-capable agent configured — no output expected'.

Tests: reason-substring assertions added; full `go test ./pkg/hub` green.