### PR TITLE
🐛 ci(tests): auto-filed failure issues name the real branch, not retired v2 (#4569)

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -467,6 +467,10 @@ jobs:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const sha = context.sha.substring(0, 7);
+            // The scheduled run executes on the DEFAULT branch (v4) — name the
+            // real branch instead of the workflow's historical "v2" label,
+            // which sent operators to the retired v2 line (#4569).
+            const branch = context.ref.replace('refs/heads/', '');
             const results = [
               '${{ needs.test-hub.result }}',
               '${{ needs.test-agent.result }}',
@@ -475,7 +479,7 @@ jobs:
             ];
             const wasCancelled = results.includes('cancelled');
             const kind = wasCancelled ? 'cancelled (likely timed out)' : 'failure';
-            const title = `[Tests] v2 test ${wasCancelled ? 'cancelled' : 'failure'} on ${sha}`;
+            const title = `[Tests] ${branch} test ${wasCancelled ? 'cancelled' : 'failure'} on ${sha}`;
 
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -484,7 +488,7 @@ jobs:
               labels: 'ci-failure',
               per_page: 10,
             });
-            const dup = existing.data.find(i => i.title.startsWith('[Tests] v2 test'));
+            const dup = existing.data.find(i => i.title.startsWith(`[Tests] ${branch} test`) || i.title.startsWith('[Tests] v2 test'));
             if (dup) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -499,6 +503,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title,
-              body: `## Test ${wasCancelled ? 'Cancelled' : 'Failure'}\n\n- **Commit:** \`${context.sha}\`\n- **Run:** ${runUrl}\n- **Branch:** v2\n\nScheduled test run was ${kind}. See the [workflow run](${runUrl}) for details.`,
+              body: `## Test ${wasCancelled ? 'Cancelled' : 'Failure'}\n\n- **Commit:** \`${context.sha}\`\n- **Run:** ${runUrl}\n- **Branch:** ${branch}\n\nScheduled test run was ${kind}. See the [workflow run](${runUrl}) for details.`,
               labels: ['ci-failure', 'kind/bug'],
             });


### PR DESCRIPTION
Fixes #4569.

**What actually happened**: the "v2 test failure on 5f72752" was NOT a retired-v2 problem. The 15-minute cron of `v2-tests.yml` runs on the **default branch (v4)** — the failing commit 5f727523 is on v4 — but the auto-filer hardcodes `Branch: v2`, mislabeling every scheduled failure as retired-branch bitrot.

**The underlying test failure** was a merge race between #4562 (new health-verdict reason tests) and #4564 (verb create→write + capability gates, merged minutes later without adapting the new test file). Already fixed on v4 by ed65c134 (#4567) — the next scheduled run (32551121711) passed. Nothing to fix on v2; no scheduled workflow targets v2 at all.

**This PR** fixes the labeler: branch derived from `context.ref`; issue title becomes `[Tests] v4 test failure on …`; dedupe accepts both new and legacy title prefixes so open legacy issues still absorb comments. Workflow/check names stay `v2 Tests` on purpose — branch protection and tide key on them (in-file comment at the check-name warning).

YAML parse-checked; script is data-only changes to the github-script step.