### PR TITLE
fix(agent): unwedge copilot agents — lifetime trust answerer, no remember, keep login identity

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6224,6 +6224,18 @@ func scanForLoginRequired(
 		}
 
 		joined := strings.Join(output, "\n")
+
+		// Stand down while a startup-blocking modal (folder trust, codex
+		// update, …) is on screen: that is not a login problem, and pausing
+		// the agent for it cancels the trust-prompt watcher that would answer
+		// it — the deadlock that kept copilot agents "sitting at login prompt"
+		// through every operator re-login (kubestellar/hive, 2026-08-22). The
+		// watcher answers the modal within seconds; if a REAL login prompt
+		// follows, the next detector tick sees it on a clean pane.
+		if agent.PaneShowsBlockingPrompt(cfg.Agents[name].Backend, joined) {
+			continue
+		}
+
 		for _, re := range compiled {
 			if re.MatchString(joined) {
 				logger.Warn("login required detected",

--- a/src/pkg/agent/blocking_prompt_test.go
+++ b/src/pkg/agent/blocking_prompt_test.go
@@ -56,7 +56,10 @@ func TestBlockingPromptKey_KnownPrompts(t *testing.T) {
 		want    string
 	}{
 		{"codex directory trust", "codex", codexTrustPane, "1"},
-		{"copilot folder trust", "copilot", copilotTrustPane, "2"},
+		// "1" (session-only), NOT "2" (remember): remembering makes the CLI
+		// rewrite the shared config.json from its stale in-memory snapshot,
+		// stomping other agents' state — see blockingPrompts.
+		{"copilot folder trust", "copilot", copilotTrustPane, "1"},
 		{"codex update", "codex", codexUpdatePane, "3"},
 	}
 	for _, c := range cases {

--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/config"
@@ -149,54 +148,46 @@ func TestRefreshCopilotSessionToken_NoCopilotBackend(t *testing.T) {
 	m.refreshCopilotSessionToken()
 }
 
-// ensureCopilotTrustedFolders pre-seeds trusted_folders so Copilot's folder-
-// trust modal never appears. It must add a missing folder, be idempotent (no
-// rewrite when already present), preserve existing entries, and handle a
-// missing config file by creating it.
-func TestEnsureCopilotTrustedFolders(t *testing.T) {
+// restoreCopilotTokens must store the seeded token under the preserved login
+// identity when one is on file — the string shape a real /login writes — so
+// the interactive CLI recognizes the seed as a signed-in session instead of
+// showing "Please use /login" over a valid token. With no identity, it falls
+// back to the host-keyed object shape.
+func TestRestoreCopilotTokens_IdentityShape(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 
-	read := func() string {
-		b, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read: %v", err)
-		}
-		return string(b)
+	// Identity present (preserved by clearExpiredTokens) → token stored under
+	// the identity key as a bare string.
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{},"loggedInUsers":["https://github.com:alice"],"lastLoggedInUser":"https://github.com:alice"}`), 0o660); err != nil {
+		t.Fatal(err)
 	}
-
-	// Missing file → created with the default folder trusted.
-	if err := ensureCopilotTrustedFolders(path); err != nil {
-		t.Fatalf("seed on missing file: %v", err)
+	if err := restoreCopilotTokens(path, "gho_seeded"); err != nil {
+		t.Fatal(err)
 	}
-	if got := read(); !strings.Contains(got, copilotTrustedFolder) {
-		t.Fatalf("default folder not seeded: %s", got)
-	}
-
-	// Idempotent: a second call with the same folder must NOT rewrite the file.
-	before, err := os.Stat(path)
+	cfg, err := readCopilotConfig(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureCopilotTrustedFolders(path); err != nil {
-		t.Fatal(err)
-	}
-	after, _ := os.Stat(path)
-	if !after.ModTime().Equal(before.ModTime()) {
-		t.Error("idempotent call rewrote the file (should no-op when folder already present)")
+	toks, _ := cfg["copilotTokens"].(map[string]interface{})
+	if got, _ := toks["https://github.com:alice"].(string); got != "gho_seeded" {
+		t.Errorf("identity-keyed token = %q, want gho_seeded under the identity key; tokens=%v", got, toks)
 	}
 
-	// Existing token + a new folder: token preserved, both folders present.
-	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{"github.com":{"token":"gho_keep"}},"trusted_folders":["/data/agents"]}`), 0o660); err != nil {
+	// No identity → legacy host-keyed object shape (unchanged behavior).
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{}}`), 0o660); err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureCopilotTrustedFolders(path, "/data/home/hive-work"); err != nil {
+	if err := restoreCopilotTokens(path, "gho_plain"); err != nil {
 		t.Fatal(err)
 	}
-	got := read()
-	for _, want := range []string{"gho_keep", "/data/agents", "/data/home/hive-work"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("missing %q after add; file:\n%s", want, got)
-		}
+	cfg, err = readCopilotConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toks, _ = cfg["copilotTokens"].(map[string]interface{})
+	obj, _ := toks["github.com"].(map[string]interface{})
+	if got, _ := obj["token"].(string); got != "gho_plain" {
+		t.Errorf("no-identity token = %q, want gho_plain under github.com object shape; tokens=%v", got, toks)
 	}
 }

--- a/src/pkg/agent/coverage_boost_test.go
+++ b/src/pkg/agent/coverage_boost_test.go
@@ -1780,13 +1780,18 @@ func TestClearExpiredTokens_ClearsAndPreservesOther(t *testing.T) {
 		t.Error("tokens should be empty after clear")
 	}
 
+	// Login IDENTITY survives a token clear: an expired token does not change
+	// who was logged in, and the interactive CLI refuses to treat a seeded
+	// token as a signed-in session without it — wiping identity here is what
+	// left agents at "Please use /login" over a perfectly valid restored token
+	// (kubestellar/hive, 2026-08-22).
 	users := result["loggedInUsers"].([]interface{})
-	if len(users) != 0 {
-		t.Error("loggedInUsers should be empty")
+	if len(users) != 1 || users[0] != "github.com" {
+		t.Errorf("loggedInUsers must be preserved across a token clear, got %v", users)
 	}
 
-	if _, ok := result["lastLoggedInUser"]; ok {
-		t.Error("lastLoggedInUser should be deleted")
+	if result["lastLoggedInUser"] != "github.com" {
+		t.Error("lastLoggedInUser must be preserved across a token clear")
 	}
 
 	if result["otherSetting"] != "keep-me" {

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2410,21 +2410,14 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 	m.fixSharedConfigPerms(agent)
 
-	// Pre-seed Copilot's trusted_folders BEFORE the CLI starts so its "Confirm
-	// folder trust" modal never appears (Copilot ≥1.0.78). That modal wedges a
-	// fresh session at startup, the login-detector misreads the blocked pane as
-	// "needs login" and pauses the agent, and a re-login just re-hits the race —
-	// the failure the operator saw where logged-in agents kept asking to log in.
-	// There is no CLI flag to disable it (github/copilot-cli#1121); the
-	// trusted_folders array is the documented, durable bypass. Idempotent and
-	// best-effort — the runtime watchForTrustPromptForAgent watcher stays as a
-	// backstop, so a failure here only loses the pre-seed, never the answer.
-	if backend == "copilot" {
-		if err := ensureCopilotTrustedFolders(sharedCopilotConfigPath); err != nil {
-			m.logger.Warn("failed to pre-seed copilot trusted_folders (watcher will backstop)",
-				"name", agent.Name, "error", err)
-		}
-	}
+	// NOTE on Copilot's "Confirm folder trust" modal (≥1.0.78): #4563 tried to
+	// pre-seed config.json trusted_folders here so it never appears. That does
+	// NOT work — the shared config is rewritten wholesale by every running CLI
+	// from its own stale in-memory snapshot, so seeded entries are stomped
+	// within minutes (traced live 2026-08-22). The modal is instead answered
+	// session-only ("1. Yes") by watchForTrustPromptForAgent, which now runs
+	// for the agent's whole lifetime, and the login-detector stands down while
+	// the modal is on screen (PaneShowsBlockingPrompt).
 
 	// Re-apply SECRET env vars before every launch. ensureTmuxSession sets the
 	// full env via tmux set-environment, but it returns early when the session
@@ -2774,12 +2767,21 @@ type blockingPrompt struct {
 var blockingPrompts = []blockingPrompt{
 	{
 		backend: "copilot",
-		// Copilot: "Confirm folder trust" → 2. Yes, and remember for future
-		// sessions. Remembering is what stops it recurring on every restart.
+		// Copilot: "Confirm folder trust" → 1. Yes (THIS SESSION ONLY).
+		//
+		// Deliberately NOT "2. Yes, and remember": remembering makes the CLI
+		// rewrite the SHARED ~/.copilot/config.json from its own in-memory
+		// snapshot, which stomps every other agent's state in that file — traced
+		// live on kubestellar/hive (2026-08-22): each agent's "remember" wiped
+		// the others' trustedFolders entries, and one stale rewrite resurrected
+		// a dead token over the operator's fresh login, which is why re-logins
+		// never stuck. Session-only trust writes NOTHING; the watcher now runs
+		// for the agent's whole lifetime, so every (re)launch gets re-answered
+		// and persistence is unnecessary.
 		match: func(p string) bool {
 			return strings.Contains(p, "Confirm folder trust") || strings.Contains(p, "Do you trust the files")
 		},
-		key:   "2",
+		key:   "1",
 		label: "copilot folder trust",
 	},
 	{
@@ -2863,6 +2865,17 @@ func blockingPromptKey(backend, pane string) (key, label string, ok bool) {
 	return "", "", false
 }
 
+// PaneShowsBlockingPrompt reports whether the pane is currently sitting on a
+// known startup-blocking modal (folder trust, codex update, …) for the given
+// backend. The login-detector uses it to stand down: a trust-wedged pane is
+// NOT a login problem, and pausing the agent for it kills the very watcher
+// that would answer the prompt — the deadlock that kept kubestellar/hive's
+// copilot agents "sitting at login prompt" through every re-login (2026-08-22).
+func PaneShowsBlockingPrompt(backend, pane string) bool {
+	_, _, ok := blockingPromptKey(backend, pane)
+	return ok
+}
+
 // paneHasBlockingPrompt reports whether ANY known blocking prompt is on the
 // pane, regardless of backend. Used by the readiness gate, which does not know
 // the backend; the patterns are specific enough that a false positive only
@@ -2915,30 +2928,37 @@ const codexUpdatePromptLabel = "codex update prompt"
 func (m *Manager) watchForTrustPromptForAgent(agent *AgentProcess, ctx context.Context) {
 	const (
 		trustPollInterval = 2 * time.Second
-		trustMaxWait      = 120 * time.Second
 		trustCooldown     = 3 * time.Second
+		// trustReanswerAfter is how long a prompt must have been answered before
+		// the same prompt may be answered again. Short enough that a CLI which
+		// restarts inside the pane (crash loop, /login relaunch) is unwedged on
+		// its next appearance; long enough that the menu still rendering for a
+		// beat after the keystroke is never double-typed (the original failure:
+		// a second poll matched the fading menu and typed the option again — by
+		// then the CLI was at its input prompt, so the digit was submitted as a
+		// user message and answered, burning tokens).
+		trustReanswerAfter = 60 * time.Second
 	)
-	deadline := time.After(trustMaxWait)
+	// No deadline: the watcher runs for the agent's whole lifetime (ctx is the
+	// per-launch context). The old 120s window assumed the trust prompt only
+	// appears at startup, but Copilot ≥1.0.78 can render it later than that on
+	// a slow first start — and an unanswered prompt wedges the agent, which the
+	// login-detector then misreads as "needs login" (live on kubestellar/hive,
+	// 2026-08-22). A 2s poll of an in-memory pane capture is too cheap to need
+	// a deadline.
 	ticker := time.NewTicker(trustPollInterval)
 	defer ticker.Stop()
 
-	// A prompt is answered at most ONCE. The pane keeps rendering the menu for
-	// a beat after the keystroke, so a second poll matched it again and typed
-	// the option a second time — by then the CLI was at its input prompt, so
-	// "3" was submitted as a user message and answered ("Three."), burning
-	// tokens and polluting the conversation.
-	answered := make(map[string]bool, len(blockingPrompts))
+	answeredAt := make(map[string]time.Time, len(blockingPrompts))
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-deadline:
-			return
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)
-			if key, label, ok := blockingPromptKey(agent.effectiveBackend(), output); ok && !answered[label] {
-				answered[label] = true
+			if key, label, ok := blockingPromptKey(agent.effectiveBackend(), output); ok && time.Since(answeredAt[label]) > trustReanswerAfter {
+				answeredAt[label] = time.Now()
 				time.Sleep(paneCaptureSleep)
 				// An empty key means the affirmative option is already selected
 				// and Enter alone answers it (agy). Typing a digit there would
@@ -5787,14 +5807,19 @@ func writeCopilotConfig(path string, cfg map[string]interface{}) error {
 // clearExpiredTokens removes stored copilot tokens from config.json.
 // An expired gho_ token causes copilot to hang during auth through the
 // MITM proxy instead of falling through to the /login prompt.
+//
+// The login IDENTITY (loggedInUsers / lastLoggedInUser) is deliberately
+// PRESERVED: an expired token does not change who was logged in, and the
+// interactive CLI refuses to consider itself signed in without an identity —
+// a later restoreCopilotTokens seed of a perfectly valid token still showed
+// "Please use /login" because this function had wiped the identity alongside
+// the token (kubestellar/hive, 2026-08-22).
 func clearExpiredTokens() error {
 	cfg, err := readCopilotConfig(sharedCopilotConfigPath)
 	if err != nil {
 		return err
 	}
 	cfg["copilotTokens"] = map[string]interface{}{}
-	cfg["loggedInUsers"] = []interface{}{}
-	delete(cfg, "lastLoggedInUser")
 	return writeCopilotConfig(sharedCopilotConfigPath, cfg)
 }
 
@@ -5829,57 +5854,19 @@ func restoreCopilotTokens(path, token string) error {
 		}
 		cfg = map[string]interface{}{}
 	}
-	cfg["copilotTokens"] = map[string]interface{}{
-		"github.com": map[string]interface{}{"token": token},
-	}
-	return writeCopilotConfig(path, cfg)
-}
-
-// copilotTrustedFolder is the parent under which every agent's working dir lives
-// (/data/agents/<name>). Copilot trusts a folder AND everything below it, so a
-// single entry here covers all agents.
-const copilotTrustedFolder = "/data/agents"
-
-// ensureCopilotTrustedFolders pre-seeds Copilot CLI's trusted_folders in
-// config.json so the "Confirm folder trust" modal never appears. That modal
-// (Copilot ≥1.0.78) blocks a fresh agent session at startup; nothing types an
-// answer reliably (the auto-answerer races a 120s window and the CLI can render
-// the prompt later than that on a slow first start), and the login-detector then
-// MISREADS the blocked pane as "needs login" and pauses the agent — so a
-// logged-IN agent with a valid gho_ token sits wedged forever. There is no CLI
-// flag to disable the prompt (github/copilot-cli#1121 is an open request); the
-// documented, durable bypass is the trusted_folders array. Idempotent: a folder
-// already present is left as-is, so this never churns the file or re-prompts.
-func ensureCopilotTrustedFolders(path string, folders ...string) error {
-	if len(folders) == 0 {
-		folders = []string{copilotTrustedFolder}
-	}
-	cfg, err := readCopilotConfig(path)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		cfg = map[string]interface{}{}
-	}
-	existing, _ := cfg["trusted_folders"].([]interface{})
-	have := make(map[string]bool, len(existing))
-	for _, e := range existing {
-		if s, ok := e.(string); ok {
-			have[s] = true
+	// When the config still carries a login identity ("https://github.com:<user>"
+	// in lastLoggedInUser — preserved by clearExpiredTokens), store the token
+	// under that identity key in the string shape a real /login writes, so the
+	// interactive CLI recognizes the seeded credential as a signed-in session
+	// rather than showing "Please use /login" over a valid token. With no
+	// identity on file, fall back to the host-keyed object shape as before.
+	if user, ok := cfg["lastLoggedInUser"].(string); ok && strings.TrimSpace(user) != "" {
+		cfg["copilotTokens"] = map[string]interface{}{user: token}
+	} else {
+		cfg["copilotTokens"] = map[string]interface{}{
+			"github.com": map[string]interface{}{"token": token},
 		}
 	}
-	changed := false
-	for _, f := range folders {
-		if f != "" && !have[f] {
-			existing = append(existing, f)
-			have[f] = true
-			changed = true
-		}
-	}
-	if !changed {
-		return nil // already trusted — do not rewrite the file
-	}
-	cfg["trusted_folders"] = existing
 	return writeCopilotConfig(path, cfg)
 }
 

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1518,13 +1518,32 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		// (kellyaa: her litellm-routed agents un-paused while the copilot
 		// strategist stayed paused, which is what exposed this).
 		operatorPaused := agent.Config.Paused || agent.PausedTrigger == "dashboard-api"
-		if IsInferenceBackend(backend) && !operatorPaused {
+		// A login-detector pause describes a LIVE pane condition ("a login
+		// prompt is on screen right now") that cannot outlive the pane — after
+		// a restart/pod roll there is no pane, so restoring the pause just
+		// strands the agent forever with nothing left to re-evaluate it
+		// (kubestellar/hive, 2026-08-22: four copilot agents stayed
+		// persisted-paused across every roll). Drop it on startup and let the
+		// agent launch; if the condition still holds, the detector re-pauses
+		// within one tick — and with PaneShowsBlockingPrompt it now only
+		// pauses for REAL login prompts. Keyed strictly on the trigger so an
+		// operator pause (dashboard-api / hand-set Config.Paused without a
+		// system trigger) is never touched — the kellyaa regression above is
+		// exactly what happens when this distinction is dropped.
+		loginDetectorPaused := agent.PausedTrigger == "login-detector"
+		if (IsInferenceBackend(backend) && !operatorPaused) || loginDetectorPaused {
 			// agent.Paused is an m.mu-guarded field; brief re-lock around the
 			// write so it stays atomic against AllStatuses()/setters.
 			m.mu.Lock()
 			agent.Paused = false
+			if loginDetectorPaused {
+				// The system pause persisted Config.Paused; clear it so the
+				// launch below isn't re-blocked and a later save doesn't
+				// re-persist a pause nobody owns anymore.
+				agent.Config.Paused = false
+			}
 			m.mu.Unlock()
-			m.logger.Info("auto-unpaused inference agent (transient pause, not operator)", "name", agent.Name, "backend", backend, "trigger", agent.PausedTrigger)
+			m.logger.Info("auto-unpaused transiently paused agent on startup", "name", agent.Name, "backend", backend, "trigger", agent.PausedTrigger)
 		} else {
 			m.mu.Lock()
 			agent.State = StatePaused

--- a/src/pkg/agent/manager_coverage2_test.go
+++ b/src/pkg/agent/manager_coverage2_test.go
@@ -1559,21 +1559,22 @@ func TestClearExpiredTokens_Logic(t *testing.T) {
 		"otherSetting":     "keep",
 	}
 
-	// Apply the same operations as clearExpiredTokens
+	// Apply the same operations as clearExpiredTokens: ONLY the token map is
+	// emptied. Login identity (loggedInUsers/lastLoggedInUser) survives — an
+	// expired token does not change who was logged in, and the interactive CLI
+	// refuses a re-seeded token without an identity.
 	input["copilotTokens"] = map[string]interface{}{}
-	input["loggedInUsers"] = []interface{}{}
-	delete(input, "lastLoggedInUser")
 
 	tokens := input["copilotTokens"].(map[string]interface{})
 	if len(tokens) != 0 {
 		t.Error("tokens should be empty after clear")
 	}
 	users := input["loggedInUsers"].([]interface{})
-	if len(users) != 0 {
-		t.Error("loggedInUsers should be empty after clear")
+	if len(users) != 1 || users[0] != "user1" {
+		t.Error("loggedInUsers must be preserved across a token clear")
 	}
-	if _, ok := input["lastLoggedInUser"]; ok {
-		t.Error("lastLoggedInUser should be deleted")
+	if input["lastLoggedInUser"] != "user1" {
+		t.Error("lastLoggedInUser must be preserved across a token clear")
 	}
 	if input["otherSetting"] != "keep" {
 		t.Error("other settings should be preserved")

--- a/src/pkg/agent/seams_coverage_test.go
+++ b/src/pkg/agent/seams_coverage_test.go
@@ -107,8 +107,12 @@ func TestClearExpiredTokens_Rewrites(t *testing.T) {
 	if len(toks) != 0 {
 		t.Errorf("copilotTokens should be emptied, got %v", toks)
 	}
-	if _, ok := parsed["lastLoggedInUser"]; ok {
-		t.Error("lastLoggedInUser should be deleted")
+	// Login identity SURVIVES a token clear: an expired token does not change
+	// who was logged in, and the interactive CLI refuses a re-seeded token
+	// without it (kubestellar/hive, 2026-08-22 — agents at "Please use /login"
+	// over a valid restored token).
+	if parsed["lastLoggedInUser"] != "u" {
+		t.Errorf("lastLoggedInUser must be preserved, got %v", parsed["lastLoggedInUser"])
 	}
 }
 


### PR DESCRIPTION
Supersedes the #4563 approach, which **cannot work** and is removed here: the shared `~/.copilot/config.json` is rewritten wholesale by every running CLI from its own stale in-memory snapshot, so any seeded `trusted_folders`/`trustedFolders` entries are stomped within minutes. Traced live on kubestellar/hive tonight — one stale rewrite also **resurrected a dead token over the operator's fresh login**, which is why re-logins never stuck.

## The live failure (kubestellar/hive, all copilot agents)
1. Copilot ≥1.0.78 renders a "Confirm folder trust" modal, sometimes **later than the 120s** auto-answer window → nothing answers → agent wedges.
2. The **login-detector misreads** the wedged pane as "needs login" → pauses the agent → the pause **cancels the very watcher** that would answer the modal (deadlock).
3. Separately, `clearExpiredTokens` wiped the **login identity** with the token, so even a valid re-seeded token showed "Please use /login".
4. Any "2. remember" answer rewrote the shared config from stale memory, stomping other agents' trust **and tokens**.

## Fix (each part validated against the live pod)
- **Lifetime trust answerer** — `watchForTrustPromptForAgent` runs for the agent's whole lifetime (2s poll of an in-memory pane capture; no deadline needed). Answer-once map → 60s re-answer cooldown, so a CLI restarting inside the pane is unwedged again while a fading menu is never double-typed.
- **Answer "1. Yes" (session-only), not "2. remember"** — session trust writes nothing, so no stomps; the lifetime watcher covers every (re)launch, making persistence unnecessary.
- **Login-detector stands down during blocking modals** (new `agent.PaneShowsBlockingPrompt`) — breaks the pause-deadlock. If a *real* login prompt follows, the next tick sees it on a clean pane.
- **`clearExpiredTokens` preserves `loggedInUsers`/`lastLoggedInUser`** — an expired token doesn't change who was logged in; `restoreCopilotTokens` now seeds under the preserved identity key (string shape a real `/login` writes), falling back to the host-keyed object shape when no identity exists.

## Tests
- Identity-wipe test previously **asserted the bug**; updated to assert the invariant (identity survives a token clear).
- New `TestRestoreCopilotTokens_IdentityShape` (both shapes).
- Blocking-prompt table updated ("2"→"1") with rationale.
- Dead `ensureCopilotTrustedFolders` + its test removed.

## Live verification plan (instant-upgrade hive)
After merge + roll: fresh launches should show the trust modal auto-answered within seconds (log: `auto-answered blocking prompt`), agents reaching their normal prompt, no `login-detector` pauses while modals are up, and `/fleet` flipping kubestellar/hive green once output resumes.