### PR TITLE
🐛 Surface login-stuck and idle-with-work agents in fleet verdicts

### DIFF
--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -199,6 +199,17 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	switch {
 	case paused:
 		v.RunState = runQuietByDesign
+	case kind == agentInactiveNeedsLogin:
+		// A login prompt outranks the off-schedule quiet branch below: a
+		// wedged interactive credential is a HIVE-wide fault (every kick to
+		// this backend will fail), not a scheduling choice — and spokes that
+		// omit expectedActive on the wire (seen live: EPM + alchemy-logging,
+		// three copilot agents each sitting at "Please use /login" with 40+
+		// queued items) read as green "quiet by design" without this, which
+		// is the exact at-a-glance failure the verdict exists to prevent.
+		// classifyInactiveAgent already applies the paused check, the
+		// running-state gate, and the 20-minute login grace.
+		v.RunState = runStuckAtLogin
 	case !legacy && !a.ExpectedActive:
 		// Not scheduled to run in this mode: off by design, not a fault —
 		// REGARDLESS of the reported session state. Spokes keep persistent
@@ -214,8 +225,6 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 		v.RunState = runQuietByDesign
 	case kind == agentInactiveSessionMissing:
 		v.RunState = runSessionGone
-	case kind == agentInactiveNeedsLogin:
-		v.RunState = runStuckAtLogin
 	case kind == agentInactiveIdleWithWork:
 		v.RunState = runIdleAtPrompt
 	case running:
@@ -312,9 +321,14 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	// neither stuck nor impotent.
 	if !v.QuietByDesign {
 		switch v.RunState {
-		case runDead, runStuckAtLogin, runSessionGone, runIdleAtPrompt:
+		case runDead, runSessionGone, runIdleAtPrompt:
 			// Only "stuck" when the governor actually expects it active now.
 			v.Stuck = a.ExpectedActive
+		case runStuckAtLogin:
+			// A wedged login is stuck regardless of the schedule: the broken
+			// credential is hive-wide and the wire may omit expectedActive
+			// entirely (the EPM/alchemy case) — gating on it hid the fault.
+			v.Stuck = true
 		}
 		// IMPOTENT: running but not capable of its mission (blocked/gated). Uses
 		// `capable`, not v.Able, because v.Able already requires runWorking —
@@ -332,7 +346,11 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	// this a problem?" per agent. It is FALSE for paused/off-schedule agents
 	// (quiet by design — the operator's own choice, not called) and for legacy/
 	// unknown rows (returned early above — can't-verify is not broken).
-	v.Problem = a.ExpectedActive && !v.QuietByDesign && !v.Able
+	//
+	// runStuckAtLogin bypasses the expectedActive gate: the credential fault is
+	// real whether or not the wire carries the schedule bit (see the ACTUAL-leg
+	// ordering above).
+	v.Problem = (a.ExpectedActive || v.RunState == runStuckAtLogin) && !v.QuietByDesign && !v.Able
 
 	return v
 }
@@ -359,6 +377,20 @@ type agentFleetRollup struct {
 	// (any reason) — THE alarm count. >0 → the hive's dot is red and it sorts to
 	// the top.
 	Problems int `json:"problems"`
+	// LoginStuck is how many of the Problems are interactive agents wedged at a
+	// login prompt. When every problem is a login block, the hive verdict can
+	// name the single actionable cause ("re-login needed") instead of the
+	// generic "N agent(s) blocked".
+	LoginStuck int `json:"loginStuck,omitempty"`
+	// IdleWithWork is how many of the Problems are running agents sitting idle
+	// past the threshold while the hive has queued work. Named separately so
+	// the verdict can say "idle with work queued" — the remedy (kick/schedule)
+	// differs from a dead session or a login wedge.
+	IdleWithWork int `json:"idleWithWork,omitempty"`
+	// DeadOrGone is how many of the Problems have no live session at all
+	// (dead, or running-with-session-missing zombies). When every problem is
+	// in this class the verdict keeps the familiar "no agents running".
+	DeadOrGone int `json:"deadOrGone,omitempty"`
 	// Known is how many agents reported the new divergence signals (non-legacy).
 	// When Known==0 the whole hive is UNKNOWN (a spoke not yet rolled to this
 	// build) and its dot is gray, never green — absence of a problem we cannot
@@ -478,6 +510,14 @@ func rollupAgents(agents []AgentSummary, blockers hiveBlockers, queuedWork int, 
 		}
 		if v.Problem {
 			r.Problems++
+			switch v.RunState {
+			case runStuckAtLogin:
+				r.LoginStuck++
+			case runIdleAtPrompt:
+				r.IdleWithWork++
+			case runDead, runSessionGone:
+				r.DeadOrGone++
+			}
 		}
 	}
 	return r

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -200,6 +200,79 @@ func TestVerdict_IssuesOnlyAgentIsAble(t *testing.T) {
 	}
 }
 
+// The live EPM/alchemy-logging shape: the spoke reports enabled+running+
+// needsLogin with capabilities but OMITS expectedActive. The wedged credential
+// is a hive-wide fault; the off-schedule quiet branch must not swallow it.
+func TestVerdict_LoginStuckWithoutExpectedActive(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.Name, a.Backend = "quality", "copilot"
+	a.ExpectedActive = false
+	a.CanMerge = false
+	a.NeedsLogin = true
+	v := deriveAgentVerdict(a, hiveBlockers{}, 40, now)
+	if v.RunState != runStuckAtLogin {
+		t.Errorf("runState = %v, want stuck-at-login (not quiet-by-design)", v.RunState)
+	}
+	if v.QuietByDesign {
+		t.Error("a login-stuck agent is never quiet by design")
+	}
+	if !v.Stuck {
+		t.Error("login-stuck must be STUCK even when expectedActive is absent")
+	}
+	if !v.Problem {
+		t.Error("login-stuck must be a PROBLEM even when expectedActive is absent")
+	}
+}
+
+// A genuinely off-schedule agent without a login prompt keeps the quiet branch:
+// the login carve-out above must not resurrect the surge-mode false alarm.
+func TestVerdict_OffScheduleWithoutLoginStaysQuiet(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.ExpectedActive = false
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runQuietByDesign || v.Problem {
+		t.Errorf("off-schedule running agent must stay quiet-by-design; got %v problem=%v", v.RunState, v.Problem)
+	}
+}
+
+func TestRollup_LoginStuckCount(t *testing.T) {
+	now := time.Now()
+	stuck := modernWorking(now)
+	stuck.Name, stuck.NeedsLogin = "quality", true
+	down := modernWorking(now)
+	down.Name, down.State = "guide", "stopped"
+	r := rollupAgents([]AgentSummary{modernWorking(now), stuck, down}, hiveBlockers{}, 5, now)
+	if r.Problems != 2 {
+		t.Fatalf("problems = %d, want 2", r.Problems)
+	}
+	if r.LoginStuck != 1 {
+		t.Errorf("loginStuck = %d, want 1 (only the login-wedged agent)", r.LoginStuck)
+	}
+	if r.DeadOrGone != 1 {
+		t.Errorf("deadOrGone = %d, want 1 (the stopped agent)", r.DeadOrGone)
+	}
+}
+
+// TestParseAgentTime_CompactWireFormat pins the colonless timestamp variant
+// spokes emit live ("2026-08-22T024118Z"). RFC3339-only parsing returned !ok
+// for every such value, which silently disabled the needs-login grace and the
+// idle rule fleet-wide — login-wedged agents read as healthy.
+func TestParseAgentTime_CompactWireFormat(t *testing.T) {
+	got, ok := parseAgentTime("2026-08-22T024118Z")
+	if !ok {
+		t.Fatal("compact wire timestamp did not parse")
+	}
+	want := time.Date(2026, 8, 22, 2, 41, 18, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("parsed %v, want %v", got, want)
+	}
+	if _, ok := parseAgentTime("garbage"); ok {
+		t.Error("garbage parsed as a time")
+	}
+}
+
 func TestRollup_Counts(t *testing.T) {
 	now := time.Now()
 	working := modernWorking(now)

--- a/src/pkg/hub/agent_inactivity.go
+++ b/src/pkg/hub/agent_inactivity.go
@@ -187,7 +187,16 @@ const (
 // UNKNOWN. A future timestamp is clock skew, not activity, and must not be
 // read as either fresh or stale.
 func parseAgentTime(s string) (time.Time, bool) {
-	t, err := time.Parse(time.RFC3339, strings.TrimSpace(s))
+	s = strings.TrimSpace(s)
+	t, err := time.Parse(time.RFC3339, s)
+	if err == nil {
+		return t, true
+	}
+	// Compact wire variant seen live from spokes ("2026-08-22T024118Z" — time
+	// colons stripped). RFC3339-only parsing silently returned !ok for every
+	// such timestamp, which defeated the needs-login grace check and let
+	// login-wedged agents (EPM, alchemy-logging) read as healthy fleet-wide.
+	t, err = time.Parse("2006-01-02T150405Z", s)
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -108,14 +108,32 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 			v.Reason = "budget exhausted — agents halted"
 			return v
 		}
+		if rollup.Problems > 0 {
+			v.State = HealthStateRed
+			switch {
+			case rollup.LoginStuck == rollup.Problems:
+				// Every blocked agent is wedged at a login prompt: name the one
+				// actionable cause (operator re-login) instead of the generic
+				// count — the EPM/alchemy at-a-glance case.
+				v.Reason = fmt.Sprintf("%d agent(s) stuck at login — re-login needed", rollup.LoginStuck)
+			case rollup.DeadOrGone == rollup.Problems && rollup.Running == 0:
+				// Nothing alive at all: keep the familiar wording so a fully
+				// down hive reads the same as before the cause split.
+				v.Reason = "no agents running"
+			case rollup.IdleWithWork == rollup.Problems:
+				// Sessions are alive but every scheduled agent is sitting past
+				// the idle threshold while work is queued. "no agents running"
+				// here was factually wrong (they ARE running) and pointed the
+				// operator at restarts instead of the kick/schedule path.
+				v.Reason = fmt.Sprintf("%d agent(s) idle with work queued", rollup.IdleWithWork)
+			default:
+				v.Reason = fmt.Sprintf("%d agent(s) blocked", rollup.Problems)
+			}
+			return v
+		}
 		if rollup.Expected > 0 && rollup.Running == 0 {
 			v.State = HealthStateRed
 			v.Reason = "no agents running"
-			return v
-		}
-		if rollup.Problems > 0 {
-			v.State = HealthStateRed
-			v.Reason = fmt.Sprintf("%d agent(s) blocked", rollup.Problems)
 			return v
 		}
 	}

--- a/src/pkg/hub/health_verdict_reasons_test.go
+++ b/src/pkg/hub/health_verdict_reasons_test.go
@@ -82,6 +82,47 @@ func TestHiveHealthForReasons(t *testing.T) {
 			wantReason: "2 agent(s) blocked",
 		},
 		{
+			// EPM/alchemy live case: every problem is a wedged interactive
+			// login, so the reason names the one actionable cause.
+			name:   "L3 all problems login-stuck — red names the re-login",
+			entry:  base(3),
+			rollup: agentFleetRollup{Expected: 0, Running: 1, Known: 4, Problems: 3, LoginStuck: 3},
+			app:    okApp(), queued: 43,
+			wantState:  HealthStateRed,
+			wantReason: "3 agent(s) stuck at login — re-login needed",
+		},
+		{
+			// Mixed causes keep the generic count: naming only the login half
+			// would hide the rest.
+			name:   "L3 mixed blocked causes — generic blocked count",
+			entry:  base(3),
+			rollup: agentFleetRollup{Expected: 2, Running: 1, Known: 4, Problems: 3, LoginStuck: 1},
+			app:    okApp(), queued: 5,
+			wantState:  HealthStateRed,
+			wantReason: "3 agent(s) blocked",
+		},
+		{
+			// Live sessions sitting past the idle threshold with a backlog:
+			// "no agents running" was factually wrong for this shape and sent
+			// operators down the restart path instead of the kick path.
+			name:   "L3 all problems idle-with-work — red names the idleness",
+			entry:  base(3),
+			rollup: agentFleetRollup{Expected: 3, Running: 0, Known: 5, Problems: 3, IdleWithWork: 3},
+			app:    okApp(), queued: 8,
+			wantState:  HealthStateRed,
+			wantReason: "3 agent(s) idle with work queued",
+		},
+		{
+			// Every problem is a dead/vanished session and nothing is alive:
+			// the familiar full-outage wording is preserved by the cause split.
+			name:   "L3 all problems dead — keeps no-agents-running wording",
+			entry:  base(3),
+			rollup: agentFleetRollup{Expected: 2, Running: 0, Known: 2, Problems: 2, DeadOrGone: 2},
+			app:    okApp(), queued: 3,
+			wantState:  HealthStateRed,
+			wantReason: "no agents running",
+		},
+		{
 			name:      "L4 recent create — reason humanizes the age",
 			entry:     withActivity(writer(base(4)), ractivity("o/r", rfc(now.Add(-3*time.Hour)), "", "", "")),
 			rollup:    okRollup(),


### PR DESCRIPTION
Three at-a-glance gaps found live (EPM + alchemy-logging: agents at
"Please use /login" for days while /fleet read green):

1. Login wedge outranks quiet-by-design: spokes that omit expectedActive
   sent login-stuck agents into the off-schedule branch — Problems=0,
   verdict green "no output expected". needsLogin now classifies before
   the schedule check, is Stuck regardless of schedule, and counts as a
   Problem.

2. parseAgentTime only accepted RFC3339, but spokes emit a colonless
   variant ("2026-08-22T024118Z") — every startedAt/lastActivityAt
   failed to parse, silently disabling the needs-login grace AND the
   idle rule fleet-wide. Added the compact layout.

3. With timestamps parseable, the verdict's "no agents running" wording
   became wrong for live-but-idle sessions. Rollup now counts problem
   causes (LoginStuck / IdleWithWork / DeadOrGone) and the verdict names
   the dominant one: "N agent(s) stuck at login — re-login needed",
   "N agent(s) idle with work queued", or keeps "no agents running"
   only when nothing is alive; mixed causes stay "N agent(s) blocked".

Verified against the live hub registry: EPM and alchemy-logging turn
red with the login reason; idle backlogs across ~10 hives surface with
the kick-path wording instead of the restart-path one.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Andy Anderson <andy@clubanderson.com>

Part of the fleet at-a-glance diagnosis work (follows #4571, #4573).