### PR TITLE
fix(agent): detach Restart from caller cancellation; accept object login identity

### DIFF
--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -174,6 +174,23 @@ func TestRestoreCopilotTokens_IdentityShape(t *testing.T) {
 		t.Errorf("identity-keyed token = %q, want gho_seeded under the identity key; tokens=%v", got, toks)
 	}
 
+	// Object-shaped identity ({"host","login"} — what Copilot 1.0.78 actually
+	// writes) → token stored under "<host>:<login>".
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{},"lastLoggedInUser":{"host":"https://github.com","login":"bob"}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreCopilotTokens(path, "gho_obj"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = readCopilotConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toks, _ = cfg["copilotTokens"].(map[string]interface{})
+	if got, _ := toks["https://github.com:bob"].(string); got != "gho_obj" {
+		t.Errorf("object-identity token = %q, want gho_obj under https://github.com:bob; tokens=%v", got, toks)
+	}
+
 	// No identity → legacy host-keyed object shape (unchanged behavior).
 	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{}}`), 0o660); err != nil {
 		t.Fatal(err)

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -5873,20 +5873,42 @@ func restoreCopilotTokens(path, token string) error {
 		}
 		cfg = map[string]interface{}{}
 	}
-	// When the config still carries a login identity ("https://github.com:<user>"
-	// in lastLoggedInUser — preserved by clearExpiredTokens), store the token
-	// under that identity key in the string shape a real /login writes, so the
-	// interactive CLI recognizes the seeded credential as a signed-in session
-	// rather than showing "Please use /login" over a valid token. With no
-	// identity on file, fall back to the host-keyed object shape as before.
-	if user, ok := cfg["lastLoggedInUser"].(string); ok && strings.TrimSpace(user) != "" {
-		cfg["copilotTokens"] = map[string]interface{}{user: token}
+	// When the config still carries a login identity (preserved by
+	// clearExpiredTokens), store the token under the "<host>:<login>" key a
+	// real /login writes, so the interactive CLI recognizes the seeded
+	// credential as a signed-in session rather than showing "Please use
+	// /login" over a valid token. The CLI has written lastLoggedInUser in two
+	// shapes across versions — a bare "https://github.com:user" string and a
+	// {"host":…,"login":…} object (the shape observed in a working 1.0.78
+	// config) — accept both. With no identity on file, fall back to the
+	// host-keyed object shape as before.
+	if key := copilotIdentityKey(cfg["lastLoggedInUser"]); key != "" {
+		cfg["copilotTokens"] = map[string]interface{}{key: token}
 	} else {
 		cfg["copilotTokens"] = map[string]interface{}{
 			"github.com": map[string]interface{}{"token": token},
 		}
 	}
 	return writeCopilotConfig(path, cfg)
+}
+
+// copilotIdentityKey renders a lastLoggedInUser value — string or
+// {"host","login"} object — as the "<host>:<login>" copilotTokens key the CLI
+// uses for a signed-in session, or "" when there is no usable identity.
+func copilotIdentityKey(v interface{}) string {
+	switch id := v.(type) {
+	case string:
+		if s := strings.TrimSpace(id); s != "" {
+			return s
+		}
+	case map[string]interface{}:
+		host, _ := id["host"].(string)
+		login, _ := id["login"].(string)
+		if strings.TrimSpace(host) != "" && strings.TrimSpace(login) != "" {
+			return host + ":" + login
+		}
+	}
+	return ""
 }
 
 // extractCopilotToken pulls the first usable token string out of a config.json
@@ -8319,6 +8341,18 @@ func killAgentProcesses(uid int, logger *slog.Logger) int {
 }
 
 func (m *Manager) Restart(ctx context.Context, name string) error {
+	// Detach from the caller's cancellation. Restart is routinely invoked from
+	// goroutines whose OWN context is the per-launch agentCtx this function is
+	// about to cancel (pollTmuxOutputForAgent's token-detected and TLS-error
+	// restarts): agent.cancel() below kills that parent, so the relaunch's new
+	// WithCancel context was born dead — launchInTmux still typed the CLI, but
+	// pollTmuxOutputForAgent and watchForTrustPromptForAgent exited instantly,
+	// leaving every restarted agent with NO pane monitors. Live signature
+	// (kubestellar/hive, 2026-08-22): exactly one auto-answered trust prompt
+	// per agent per pod boot, then wedged panes forever after the first
+	// token-detected restart. A relaunch must never be aborted by the
+	// cancellation of the launch it replaces.
+	ctx = context.WithoutCancel(ctx)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -8351,8 +8351,13 @@ func (m *Manager) Restart(ctx context.Context, name string) error {
 	// (kubestellar/hive, 2026-08-22): exactly one auto-answered trust prompt
 	// per agent per pod boot, then wedged panes forever after the first
 	// token-detected restart. A relaunch must never be aborted by the
-	// cancellation of the launch it replaces.
-	ctx = context.WithoutCancel(ctx)
+	// cancellation of the launch it replaces. (Nil-guarded: WithoutCancel
+	// panics on a nil parent, and callers pass nil for "no context".)
+	if ctx == nil {
+		ctx = context.Background()
+	} else {
+		ctx = context.WithoutCancel(ctx)
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 


### PR DESCRIPTION
Two follow-ups from live verification of #4573 on kubestellar/hive — the second and third root causes behind the days-long "agents sitting at login prompt" wedge.

## 1. Restarted agents had NO pane monitors (the real reason agents stayed wedged for days)
`Restart()` is routinely invoked from goroutines whose **own context is the per-launch agentCtx it is about to cancel** — `pollTmuxOutputForAgent`'s token-detected and TLS-error restarts. `agent.cancel()` killed that parent, so the relaunch's `WithCancel` contexts were **born dead**: the CLI was typed into the pane, but `pollTmuxOutputForAgent` and `watchForTrustPromptForAgent` exited instantly. Every restarted agent ran with **no monitors at all**.

**Live signature** (matched exactly on the spoke): one auto-answered trust prompt per agent per pod boot → first token-detected restart → wedged panes forever until the next roll. The #4573 lifetime answerer works, but only for launches whose context is alive — this makes that true for restarts.

Fix: `Restart()` runs under `context.WithoutCancel(ctx)` — a relaunch must never be aborted by the cancellation of the launch it replaces. Single point covers every caller (one caller had already hand-fixed this with `context.Background()`).

## 2. Login identity is an OBJECT
A working-era Copilot 1.0.78 config snapshot shows `lastLoggedInUser`/`loggedInUsers` as `{"host": "https://github.com", "login": "user"}` **objects**, not the `"https://github.com:user"` strings #4573 assumed. `restoreCopilotTokens` now accepts both shapes (`copilotIdentityKey`) and stores the seeded token under the `<host>:<login>` key of a signed-in session.

## Tests
`TestRestoreCopilotTokens_IdentityShape` extended with the object-shape case.

## Verification
After deploy + roll: agents relaunch with live monitors; every trust modal is answered (repeatedly, not once); the seeded token should be recognized as signed in. If the CLI still requires a fresh device-flow, the operator's one terminal `/login` now sticks (no more stomps, monitors survive restarts).