### PR TITLE
🐛 Never promote the CLI's masked "******" token placeholder

### DIFF
--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -36,6 +36,14 @@ func TestExtractCopilotToken(t *testing.T) {
 	if got := extractCopilotToken(filepath.Join(dir, "nope.json")); got != "" {
 		t.Errorf("missing file: got %q, want \"\"", got)
 	}
+	// masked placeholder (the CLI redacts a rejected token as asterisks) must
+	// never be extracted — promoting it would overwrite the durable token.
+	if got := extractCopilotToken(write(`{"copilotTokens":{"github.com":"******"}}`)); got != "" {
+		t.Errorf("masked string shape: got %q, want \"\"", got)
+	}
+	if got := extractCopilotToken(write(`{"copilotTokens":{"github.com":{"token":"********"}}}`)); got != "" {
+		t.Errorf("masked object shape: got %q, want \"\"", got)
+	}
 }
 
 func TestWriteDurableCopilotToken(t *testing.T) {
@@ -120,6 +128,35 @@ func TestSyncCopilotToken_Seed(t *testing.T) {
 	}
 	if !copilotCredentialFileHasTokens(cfg) {
 		t.Error("config must be re-seeded")
+	}
+}
+
+// MASKED-ONLY config: the CLI has redacted its token to "******" (rejected
+// credential — the live EPM shape). Must take the SEED path (restore the valid
+// durable token over the placeholder), NOT promote the asterisks into the
+// durable store, which would destroy the one good credential.
+func TestSyncCopilotToken_MaskedConfigSeedsNotPromotes(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.json")
+	dur := filepath.Join(dir, "durable")
+	if err := os.WriteFile(cfg, []byte(copilotConfigHeader+`{"copilotTokens":{"github.com":"******"},"lastLoggedInUser":"https://github.com:me","loggedInUsers":["https://github.com:me"]}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dur, []byte("ghu_valid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := testManager(5)
+	m.agents["scanner"] = &AgentProcess{Name: "scanner", Config: config.AgentConfig{Backend: "copilot"}}
+	m.copilotAuthToken = "ghu_valid"
+	if act := m.syncCopilotToken(cfg, dur); act != copilotSyncSeed {
+		t.Fatalf("action = %v, want seed (masked placeholder is not a token)", act)
+	}
+	b, _ := os.ReadFile(dur)
+	if string(b) != "ghu_valid" {
+		t.Errorf("durable file = %q — masked garbage was promoted over the valid token", string(b))
+	}
+	if got := extractCopilotToken(cfg); got != "ghu_valid" {
+		t.Errorf("config token after seed = %q, want ghu_valid", got)
 	}
 }
 

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -5758,7 +5758,25 @@ func copilotCredentialFileHasTokens(path string) bool {
 		if !ok {
 			return false
 		}
-		return len(tokensMap) > 0
+		// Count only USABLE tokens. The CLI masks a token it refuses to use
+		// (foreign/expired) as a literal run of asterisks; a config holding
+		// only masked entries must read as empty so the sync takes the SEED
+		// path (restore the valid durable token) instead of the PROMOTE path
+		// — promoting would overwrite the durable file with "******" and
+		// destroy the one good credential (seen live on the EPM hive).
+		for _, v := range tokensMap {
+			switch t := v.(type) {
+			case string:
+				if copilotTokenValueUsable(t) {
+					return true
+				}
+			case map[string]interface{}:
+				if s, ok := t["token"].(string); ok && copilotTokenValueUsable(s) {
+					return true
+				}
+			}
+		}
+		return false
 	}
 	// apps.json / hosts.json shape: host -> {oauth_token: ...}
 	if strings.HasSuffix(path, "apps.json") || strings.HasSuffix(path, "hosts.json") {
@@ -5907,18 +5925,30 @@ func extractCopilotToken(path string) string {
 	for _, v := range tokens {
 		switch t := v.(type) {
 		case string:
-			if s := strings.TrimSpace(t); s != "" {
+			if s := strings.TrimSpace(t); copilotTokenValueUsable(s) {
 				return s
 			}
 		case map[string]interface{}:
 			if s, ok := t["token"].(string); ok {
-				if s = strings.TrimSpace(s); s != "" {
+				if s = strings.TrimSpace(s); copilotTokenValueUsable(s) {
 					return s
 				}
 			}
 		}
 	}
 	return ""
+}
+
+// copilotTokenValueUsable reports whether a copilotTokens value is a real
+// credential. The CLI redacts tokens it has rejected by rewriting them as a
+// run of asterisks ("******"); treating that placeholder as a token let the
+// promote path mirror garbage over the durable user token.
+func copilotTokenValueUsable(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	return strings.ContainsFunc(s, func(r rune) bool { return r != '*' })
 }
 
 // writeDurableCopilotToken persists token to durablePath via a temp file +


### PR DESCRIPTION
The Copilot CLI redacts a token it has rejected (foreign/expired) by
rewriting the copilotTokens value as a literal run of asterisks. Both
sync-path readers took that placeholder at face value (seen live on the
EPM hive):

- copilotCredentialFileHasTokens counted the masked entry, so
  syncCopilotToken took the PROMOTE path and would mirror "******" over
  the durable /data/copilot-user-token — destroying the one valid
  credential that survives upgrades.
- extractCopilotToken returned the asterisks as the token.

copilotTokenValueUsable now rejects empty and all-asterisk values, so a
masked-only config reads as empty and the sync takes the SEED path
instead: the valid durable token is restored over the placeholder
(under the preserved login identity from #4573), which is the actual
self-heal for the wedge. Also makes the auth probe and the pane
login-restart gate see masked configs truthfully.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Signed-off-by: Andy Anderson <andy@clubanderson.com>

Follow-up to #4573; closes the residual promote-of-masked-garbage hazard found live on the EPM hive.