### PR TITLE
🐛 respect agent kick cadence in idle verdict

### DIFF
--- a/src/cmd/hive/heartbeat_idle_cadence_test.go
+++ b/src/cmd/hive/heartbeat_idle_cadence_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/governor"
+)
+
+func TestHeartbeatKickIntervalOnlyForGovernorKickedAgents(t *testing.T) {
+	govState := governor.State{Cadences: map[string]governor.AgentCadence{
+		"quality": {Agent: "quality", Interval: 2 * time.Hour},
+	}}
+	proc := &agent.AgentProcess{Name: "quality", Config: config.AgentConfig{}}
+	if got := heartbeatKickInterval(govState, "quality", proc, nil); got != 2*time.Hour {
+		t.Fatalf("implicit kick channel interval = %v, want 2h", got)
+	}
+
+	proc.Config.Channels = []config.ChannelConfig{{Type: "webhook"}}
+	if got := heartbeatKickInterval(govState, "quality", proc, nil); got != 0 {
+		t.Fatalf("non-kick channel interval = %v, want 0", got)
+	}
+
+	proc.Config.Channels = []config.ChannelConfig{{Type: "kick"}}
+	if got := heartbeatKickInterval(govState, "quality", proc, map[string]bool{"quality": true}); got != 0 {
+		t.Fatalf("pack on-demand interval = %v, want 0", got)
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -150,7 +150,7 @@ const reachStatePath = "/data/reach-state.json"
 // tell a deliberately-paused agent from one that is running but unable to
 // work. Shared by both heartbeat build sites so the ordinary beat and the
 // upgrade beat can never report different pictures of the same agent.
-func agentActivityFor(mgr *agent.Manager, cfg *config.Config, currentMode, name string, proc *agent.AgentProcess, onDemandFromPack map[string]bool) hub.AgentActivity {
+func agentActivityFor(mgr *agent.Manager, cfg *config.Config, govState governor.State, currentMode, name string, proc *agent.AgentProcess, onDemandFromPack map[string]bool) hub.AgentActivity {
 	act := hub.AgentActivity{
 		Paused: proc.Paused,
 		// Pause provenance (#4041): ride WHO/WHY/WHEN to the hub so the
@@ -168,6 +168,7 @@ func agentActivityFor(mgr *agent.Manager, cfg *config.Config, currentMode, name 
 	if proc.StartedAt != nil {
 		act.StartedAt = *proc.StartedAt
 	}
+	act.KickInterval = heartbeatKickInterval(govState, name, proc, onDemandFromPack)
 
 	// EXPECTED leg: does the governor's current mode schedule this agent on a
 	// kicking cadence right now? Shared with the dashboard's offByCadence via
@@ -197,6 +198,17 @@ func agentActivityFor(mgr *agent.Manager, cfg *config.Config, currentMode, name 
 	}
 
 	return act
+}
+
+func heartbeatKickInterval(govState governor.State, name string, proc *agent.AgentProcess, onDemandFromPack map[string]bool) time.Duration {
+	if proc == nil || !proc.Config.UsesGovernorKick() || proc.Config.OnDemand || onDemandFromPack[name] {
+		return 0
+	}
+	cadence, ok := govState.Cadences[name]
+	if !ok || cadence.Paused || cadence.Interval <= 0 {
+		return 0
+	}
+	return cadence.Interval
 }
 
 // prospectiveGitHubIdentity returns the GitHub identity the spoke WOULD hold
@@ -3370,7 +3382,7 @@ func main() {
 					mode = "on_demand"
 				}
 				agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
-					agentActivityFor(agentMgr, cfg, currentMode, name, proc, onDemandFromPack)))
+					agentActivityFor(agentMgr, cfg, govState, currentMode, name, proc, onDemandFromPack)))
 			}
 			acmmLvl := 0
 			if cfg.ACMMLevel != nil {
@@ -3886,7 +3898,8 @@ func main() {
 					return nil
 				}
 				statuses := agentMgr.AllStatuses()
-				currentMode := strings.ToLower(string(gov.GetState().Mode))
+				govState := gov.GetState()
+				currentMode := strings.ToLower(string(govState.Mode))
 				agents := make([]hub.AgentSummary, 0, len(statuses))
 				for name, proc := range statuses {
 					mode := ""
@@ -3894,7 +3907,7 @@ func main() {
 						mode = "on_demand"
 					}
 					agents = append(agents, hub.NewAgentSummary(name, string(proc.State), mode,
-						agentActivityFor(agentMgr, cfg, currentMode, name, proc, onDemandFromPack)))
+						agentActivityFor(agentMgr, cfg, govState, currentMode, name, proc, onDemandFromPack)))
 				}
 				acmmLvl := 0
 				if cfg.ACMMLevel != nil {

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -261,6 +261,20 @@ func TestVerdict_CadenceIdleIsWorkingUntilCadenceMissed(t *testing.T) {
 	}
 }
 
+func TestVerdict_WriteIncapableAdvisoryAgentNotIdleWithWork(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{
+		Name: "guide", State: "running", Backend: "bob",
+		Enabled: true, ExpectedActive: true,
+		StartedAt: settled(now), LastActivityAt: activeAt(now, 3*time.Hour),
+	}
+
+	v := deriveAgentVerdict(a, hiveBlockers{}, 9, now)
+	if v.RunState != runWorking || !v.Able || v.Problem {
+		t.Fatalf("write-incapable advisory agent must be working/able/non-problem, got %+v", v)
+	}
+}
+
 func TestRollup_LoginStuckCount(t *testing.T) {
 	now := time.Now()
 	stuck := modernWorking(now)

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -237,6 +237,30 @@ func TestVerdict_OffScheduleWithoutLoginStaysQuiet(t *testing.T) {
 	}
 }
 
+func TestVerdict_CadenceIdleIsWorkingUntilCadenceMissed(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.Name = "quality"
+	a.LastActivityAt = activeAt(now, time.Hour)
+	a.KickIntervalSec = int64(2 * time.Hour / time.Second)
+
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runWorking || v.Problem {
+		t.Fatalf("cadence-idle agent before next run must stay working/non-problem, got %+v", v)
+	}
+
+	a.LastActivityAt = activeAt(now, 2*time.Hour+inactiveAgentCadenceSlack+time.Minute)
+	v = deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runIdleAtPrompt || !v.Problem {
+		t.Fatalf("agent past cadence+slack must be idle-at-prompt problem, got %+v", v)
+	}
+
+	r := rollupAgents([]AgentSummary{a}, hiveBlockers{}, 5, now)
+	if r.IdleWithWork != 1 || r.Problems != 1 {
+		t.Fatalf("rollup must count missed-cadence idle-with-work, got %+v", r)
+	}
+}
+
 func TestRollup_LoginStuckCount(t *testing.T) {
 	now := time.Now()
 	stuck := modernWorking(now)

--- a/src/pkg/hub/agent_inactivity.go
+++ b/src/pkg/hub/agent_inactivity.go
@@ -166,6 +166,13 @@ func classifyInactiveAgent(a AgentSummary, queuedWork int, now time.Time) agentI
 	if onDemand || queuedWork < inactiveAgentMinQueued {
 		return agentInactiveNone
 	}
+	if !legacyAgent(a) && !agentCanDrainQueuedWork(a) {
+		// Advisory-only agents (katamari/ibm-aiops-orchestrator at L2) cannot
+		// drain queued issues/PRs by design. Their health is the advisory
+		// stream's freshness; counting backlog against a write-incapable agent
+		// turns a healthy fresh digest into "idle with work queued".
+		return agentInactiveNone
+	}
 	lastActivity, activityOK := parseAgentTime(a.LastActivityAt)
 	if !activityOK {
 		// The spoke has never observed a pane change for this agent. That is
@@ -178,6 +185,10 @@ func classifyInactiveAgent(a AgentSummary, queuedWork int, now time.Time) agentI
 		return agentInactiveIdleWithWork
 	}
 	return agentInactiveNone
+}
+
+func agentCanDrainQueuedWork(a AgentSummary) bool {
+	return a.CanOpenIssue || a.CanOpenPR || a.CanMerge
 }
 
 func idleThresholdForAgent(a AgentSummary) time.Duration {

--- a/src/pkg/hub/agent_inactivity.go
+++ b/src/pkg/hub/agent_inactivity.go
@@ -48,6 +48,13 @@ const (
 	// Idleness ALONE is never reported — see queuedWorkForInactivity.
 	inactiveAgentIdleThreshold = 45 * time.Minute
 
+	// inactiveAgentCadenceSlack is added to a spoke-reported governor cadence
+	// before calling a scheduled agent idle. This preserves genuine faults
+	// (missed cadence + queued work) while keeping healthy interval agents
+	// quiet between kicks; flashsystems/ess showed 2h/4h cadences with fresh
+	// next-run/advisory data but panes quiet longer than 45 minutes by design.
+	inactiveAgentCadenceSlack = 30 * time.Minute
+
 	// inactiveAgentMinQueued is how much actionable work must be waiting
 	// before an idle agent is called a problem. A hive with an empty queue is
 	// SUPPOSED to have idle agents; reporting those would light the facet on
@@ -167,10 +174,24 @@ func classifyInactiveAgent(a AgentSummary, queuedWork int, now time.Time) agentI
 		// every agent on every hive that has not upgraded yet.
 		return agentInactiveNone
 	}
-	if now.Sub(lastActivity) >= inactiveAgentIdleThreshold {
+	if now.Sub(lastActivity) >= idleThresholdForAgent(a) {
 		return agentInactiveIdleWithWork
 	}
 	return agentInactiveNone
+}
+
+func idleThresholdForAgent(a AgentSummary) time.Duration {
+	threshold := inactiveAgentIdleThreshold
+	if a.KickIntervalSec <= 0 {
+		// Legacy or non-interval spokes do not provide cadence evidence, so the
+		// historical 45-minute rule remains the only safe signal the hub has.
+		return threshold
+	}
+	cadenceThreshold := time.Duration(a.KickIntervalSec)*time.Second + inactiveAgentCadenceSlack
+	if cadenceThreshold > threshold {
+		return cadenceThreshold
+	}
+	return threshold
 }
 
 // Wire values for the agent fields the classifier reads. Named so a typo

--- a/src/pkg/hub/agent_inactivity_test.go
+++ b/src/pkg/hub/agent_inactivity_test.go
@@ -133,6 +133,34 @@ func TestIdleRuleRespectsThresholdAndOnDemand(t *testing.T) {
 	}
 }
 
+func TestIdleRuleRespectsKickCadence(t *testing.T) {
+	now := time.Now()
+	base := AgentSummary{
+		Name: "ci-maintainer", State: "running",
+		StartedAt:       settled(now),
+		LastActivityAt:  activeAt(now, time.Hour),
+		KickIntervalSec: int64(4 * time.Hour / time.Second),
+	}
+
+	// flashsystems/ess runs on 2h/4h governor kicks; a pane quiet for an hour
+	// with queued work is healthy between kicks, not "idle at prompt".
+	if got := classifyInactiveAgent(base, inactiveAgentMinQueued, now); got != agentInactiveNone {
+		t.Fatalf("cadence-idle agent classified %v; want none", got.label())
+	}
+
+	missed := base
+	missed.LastActivityAt = activeAt(now, 4*time.Hour+inactiveAgentCadenceSlack+time.Minute)
+	if got := classifyInactiveAgent(missed, inactiveAgentMinQueued, now); got != agentInactiveIdleWithWork {
+		t.Fatalf("agent past cadence+slack classified %v; want idle-with-work", got.label())
+	}
+
+	legacy := base
+	legacy.KickIntervalSec = 0
+	if got := classifyInactiveAgent(legacy, inactiveAgentMinQueued, now); got != agentInactiveIdleWithWork {
+		t.Fatalf("legacy agent classified %v; want historical idle-with-work", got.label())
+	}
+}
+
 // TestUnknownActivityIsNotIdle guards the upgrade path: a spoke too old to
 // report lastActivityAt must not make every one of its agents alarm.
 func TestUnknownActivityIsNotIdle(t *testing.T) {

--- a/src/pkg/hub/agent_inactivity_test.go
+++ b/src/pkg/hub/agent_inactivity_test.go
@@ -161,6 +161,23 @@ func TestIdleRuleRespectsKickCadence(t *testing.T) {
 	}
 }
 
+func TestIdleRuleSkipsWriteIncapableAdvisoryAgents(t *testing.T) {
+	now := time.Now()
+	a := AgentSummary{
+		Name: "quality", State: "running", Backend: "bob",
+		Enabled: true, ExpectedActive: true,
+		StartedAt: settled(now), LastActivityAt: activeAt(now, 3*time.Hour),
+	}
+	if got := classifyInactiveAgent(a, 9, now); got != agentInactiveNone {
+		t.Fatalf("write-incapable advisory agent classified %v; want none", got.label())
+	}
+
+	a.CanOpenIssue = true
+	if got := classifyInactiveAgent(a, 9, now); got != agentInactiveIdleWithWork {
+		t.Fatalf("write-capable idle agent classified %v; want idle-with-work", got.label())
+	}
+}
+
 // TestUnknownActivityIsNotIdle guards the upgrade path: a spoke too old to
 // report lastActivityAt must not make every one of its agents alarm.
 func TestUnknownActivityIsNotIdle(t *testing.T) {

--- a/src/pkg/hub/agent_summary_coverage_test.go
+++ b/src/pkg/hub/agent_summary_coverage_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -92,6 +93,27 @@ func TestAgentSummaryZeroTimestampsOmittedFromJSON(t *testing.T) {
 	}
 	if strings.Contains(string(b), "0001-01-01") {
 		t.Errorf("year-1 timestamp leaked onto the wire: %s", b)
+	}
+	if strings.Contains(string(b), "kickIntervalSec") {
+		t.Errorf("zero kick interval leaked onto the wire: %s", b)
+	}
+}
+
+func TestNewAgentSummaryCarriesKickInterval(t *testing.T) {
+	want := int64(2 * time.Hour / time.Second)
+	as := NewAgentSummary("quality", agentStateRunning, "continuous", AgentActivity{
+		KickInterval: 2 * time.Hour,
+	})
+	if as.KickIntervalSec != want {
+		t.Fatalf("KickIntervalSec = %d, want %d", as.KickIntervalSec, want)
+	}
+
+	b, err := json.Marshal(as)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"kickIntervalSec":`+strconv.FormatInt(want, 10)) {
+		t.Fatalf("kick interval missing from heartbeat JSON: %s", b)
 	}
 }
 

--- a/src/pkg/hub/health_verdict_reasons_test.go
+++ b/src/pkg/hub/health_verdict_reasons_test.go
@@ -180,6 +180,40 @@ func TestHiveHealthForReasons(t *testing.T) {
 	}
 }
 
+func TestHiveHealth_L2FreshAdvisoryIgnoresWriteIncapableIdleAgents(t *testing.T) {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	rfc := func(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+	agent := func(name, state string, paused bool) AgentSummary {
+		return AgentSummary{
+			Name: name, State: state, Backend: "bob",
+			Enabled: true, ExpectedActive: !paused, Paused: paused,
+			StartedAt: settled(now), LastActivityAt: activeAt(now, 3*time.Hour),
+		}
+	}
+	e := RegistryEntry{
+		Online:               true,
+		ACMMLevel:            2,
+		AdvisoryLastPostedAt: rfc(now.Add(-4 * time.Minute)),
+		Agents: []AgentSummary{
+			agent("quality", agentStateRunning, false),
+			agent("guide", agentStateRunning, false),
+			agent("scanner", agentStatePaused, true),
+			agent("supervisor", agentStatePaused, true),
+			agent("brainstorm", agentStatePaused, true),
+		},
+	}
+
+	rollup := rollupAgents(e.Agents, hiveBlockers{}, 9, now)
+	if rollup.Problems != 0 || rollup.IdleWithWork != 0 {
+		t.Fatalf("write-incapable L2 agents must not create idle-with-work problems, got %+v", rollup)
+	}
+
+	v := hiveHealthFor(e, rollup, okApp(), 9, now)
+	if v.State != HealthStateGreen || !strings.Contains(v.Reason, "advisory 4m ago") {
+		t.Fatalf("fresh L2 advisory should stay healthy, got state=%s reason=%q", v.State, v.Reason)
+	}
+}
+
 func TestMaxRFC3339(t *testing.T) {
 	early, late := "2026-08-22T01:00:00Z", "2026-08-22T09:00:00Z"
 	cases := []struct{ a, b, want string }{

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -300,6 +300,11 @@ type AgentSummary struct {
 	// "running and working" from "running and producing nothing" — State,
 	// StartedAt and the kick log all keep their values while a CLI sits idle.
 	LastActivityAt string `json:"lastActivityAt,omitempty"`
+	// KickIntervalSec is the governor's CURRENT-mode interval for this agent.
+	// It lets the hub distinguish a fault from a scheduled-cadence agent that
+	// is correctly idle between kicks (flashsystems/ess: 2h/4h cadences looked
+	// idle after the generic 45-minute pane-activity threshold).
+	KickIntervalSec int64 `json:"kickIntervalSec,omitempty"`
 
 	// --- Fleet-divergence signals (the EXPECTED and ABLE legs) ---
 	// These let the hub show the gap between what the GOVERNOR expects running,
@@ -350,6 +355,7 @@ type AgentActivity struct {
 	SessionMissing bool
 	StartedAt      time.Time
 	LastActivityAt time.Time
+	KickInterval   time.Duration
 	// Fleet-divergence signals — see the matching AgentSummary fields.
 	ExpectedActive bool
 	CanOpenIssue   bool
@@ -388,6 +394,9 @@ func NewAgentSummary(name, state, mode string, act AgentActivity) AgentSummary {
 	}
 	if !act.LastActivityAt.IsZero() {
 		as.LastActivityAt = act.LastActivityAt.UTC().Format(time.RFC3339)
+	}
+	if act.KickInterval > 0 {
+		as.KickIntervalSec = int64(act.KickInterval / time.Second)
 	}
 	return as
 }


### PR DESCRIPTION
## Summary
- add KickIntervalSec to agent heartbeat summaries from the governor's current interval cadence
- gate hub idle-with-work on max(45m, kick interval + 30m) so healthy cadence agents stay green between kicks
- ignore queued-work idleness for advisory-only/write-incapable agents; L2 remains judged by advisory freshness
- keep legacy/unknown cadence spokes on the historical threshold and keep missed-cadence/write-capable idle agents red

## Root cause
PR #4574 made compact spoke timestamps parse correctly, which re-enabled classifyInactiveAgent. For cadence agents, LastActivityAt is pane-change time, so 2h/4h scheduled agents like flashsystems/ess legitimately looked idle after 45m. A second live L2 case (katamari/ibm-aiops-orchestrator) showed queued issues/PRs being counted against Bob advisory agents with no issue/PR/merge grant, even though their health signal is fresh advisory output.

## Tests
- go test ./pkg/hub -count=1
- go test ./cmd/hive -run TestHeartbeatKickIntervalOnlyForGovernorKickedAgents -count=1