### PR TITLE
✨ Sortable Cost tables; session list defaults to newest-first

### DIFF
--- a/src/pkg/dashboard/cost.go
+++ b/src/pkg/dashboard/cost.go
@@ -143,8 +143,8 @@ type costSessionEntry struct {
 
 // maxCostSessions caps how many per-session rows the /api/cost payload carries,
 // so a long-lived fleet with thousands of scanned sessions can't bloat the
-// response. The most-expensive sessions are kept (the UI sorts by cost), which
-// is what an operator hunting a cost spike wants to see first.
+// response. The newest-started sessions are kept, matching the Cost page's
+// default session ordering.
 const maxCostSessions = 200
 
 const costEstimateDisclaimer = "Estimated from token counts × published list prices. " +
@@ -218,9 +218,9 @@ func (s *Server) estimatedCost() costEstimated {
 // show cost per session (and, via the Agent field, group sessions by sandbox).
 // It is a pure function of the summary — each session's own token splits are
 // priced at list price, identically to the aggregate rows. The result is sorted
-// most-expensive first and capped at maxCostSessions so the payload stays
-// bounded on a large fleet. Returns an empty (non-nil) slice when there is no
-// session data.
+// by start time descending, then agent name ascending, and capped at
+// maxCostSessions so the payload stays bounded on a large fleet. Returns an
+// empty (non-nil) slice when there is no session data.
 func estimatedSessions(summary *tokens.AggregateSummary) []costSessionEntry {
 	if summary == nil {
 		return []costSessionEntry{}
@@ -243,9 +243,15 @@ func estimatedSessions(summary *tokens.AggregateSummary) []costSessionEntry {
 			LastActive: sess.LastActive,
 		})
 	}
-	// Most-expensive first — that's what an operator hunting a cost spike wants,
-	// and it makes the maxCostSessions cap keep the rows that matter.
-	sort.Slice(out, func(i, j int) bool { return out[i].USD > out[j].USD })
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Started != out[j].Started {
+			return out[i].Started > out[j].Started
+		}
+		if out[i].Agent != out[j].Agent {
+			return out[i].Agent < out[j].Agent
+		}
+		return out[i].SessionID < out[j].SessionID
+	})
 	if len(out) > maxCostSessions {
 		out = out[:maxCostSessions]
 	}

--- a/src/pkg/dashboard/cost_pure_functions_test.go
+++ b/src/pkg/dashboard/cost_pure_functions_test.go
@@ -152,23 +152,25 @@ func TestEstimatedSessions_EmptySessions(t *testing.T) {
 	}
 }
 
-func TestEstimatedSessions_PricesAndSortsByUSD(t *testing.T) {
+func TestEstimatedSessions_PricesAndSortsByStartThenAgent(t *testing.T) {
 	agg := &tokens.AggregateSummary{
 		Sessions: []tokens.SessionSummary{
 			{
 				SessionID:    "sess-cheap",
-				Agent:        "quality",
+				Agent:        "z-quality",
 				Model:        "claude-haiku-3-20240307",
 				InputTokens:  100,
 				OutputTokens: 50,
+				FirstActive:  200,
 			},
 			{
 				SessionID:    "sess-expensive",
-				Agent:        "sec-check",
+				Agent:        "a-sec-check",
 				Model:        "claude-sonnet-4-20250514",
 				InputTokens:  10000,
 				OutputTokens: 5000,
 				CacheRead:    1000,
+				FirstActive:  200,
 			},
 		},
 	}
@@ -178,16 +180,16 @@ func TestEstimatedSessions_PricesAndSortsByUSD(t *testing.T) {
 		t.Fatalf("len = %d, want 2", len(out))
 	}
 
-	// Most expensive first.
+	// Same start time: agent name ascending, not cost descending.
 	if out[0].SessionID != "sess-expensive" {
-		t.Errorf("first session = %q, want sess-expensive (most expensive first)", out[0].SessionID)
+		t.Errorf("first session = %q, want sess-expensive (agent name tie-break)", out[0].SessionID)
 	}
 	if out[1].SessionID != "sess-cheap" {
 		t.Errorf("second session = %q, want sess-cheap", out[1].SessionID)
 	}
 
 	// Agent and model are preserved.
-	if out[0].Agent != "sec-check" || out[0].Model != "claude-sonnet-4-20250514" {
+	if out[0].Agent != "a-sec-check" || out[0].Model != "claude-sonnet-4-20250514" {
 		t.Errorf("expensive session agent/model = %q/%q", out[0].Agent, out[0].Model)
 	}
 

--- a/src/pkg/dashboard/cost_sessions_test.go
+++ b/src/pkg/dashboard/cost_sessions_test.go
@@ -91,17 +91,18 @@ func TestEstimatedSessions_UnpricedModelSource(t *testing.T) {
 }
 
 // TestEstimatedSessions_CapsRows verifies the payload is bounded at
-// maxCostSessions and keeps the most-expensive rows.
+// maxCostSessions and keeps the newest-started rows.
 func TestEstimatedSessions_CapsRows(t *testing.T) {
 	over := maxCostSessions + 25
 	sessions := make([]tokens.SessionSummary, over)
 	for i := range sessions {
-		// Larger i → more tokens → higher cost, so the top rows are the tail.
+		// Larger i → newer start, so the top rows are the tail.
 		sessions[i] = tokens.SessionSummary{
 			SessionID:   "s",
 			Agent:       "a",
 			Model:       "claude-opus-4.7",
 			InputTokens: int64(i+1) * 1000,
+			FirstActive: int64(i + 1),
 		}
 	}
 	summary := &tokens.AggregateSummary{Sessions: sessions}
@@ -110,10 +111,8 @@ func TestEstimatedSessions_CapsRows(t *testing.T) {
 	if len(got) != maxCostSessions {
 		t.Fatalf("len = %d, want cap %d", len(got), maxCostSessions)
 	}
-	// The single most-expensive session (largest i) must be present at row 0.
-	wantTop, _ := tokens.EstimateCostUSD("claude-opus-4.7", int64(over)*1000, 0, 0, 0)
-	if got[0].USD != wantTop {
-		t.Errorf("row[0] USD = %v, want %v (most-expensive kept after cap)", got[0].USD, wantTop)
+	if got[0].Started != int64(over) {
+		t.Errorf("row[0] started = %d, want %d (newest kept after cap)", got[0].Started, over)
 	}
 }
 
@@ -184,7 +183,9 @@ func TestCostSessionTimeColumnWiring(t *testing.T) {
 	html := string(b)
 	for _, snippet := range []string{
 		"const COST_SESSION_ACTIVE_MS = 5 * 60 * 1000;",
-		">started → ended</th>",
+		"session: { key: 'started', dir: 'desc' }",
+		"costSortTh('session', 'started', 'started → ended'",
+		"data-action=\"costSortTable\"",
 		`cost-session-active">active</span>`,
 		"sn.started ? fmtSessTs(sn.started) : '—'",
 		"(Date.now() - sn.last_active) < COST_SESSION_ACTIVE_MS",

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -1442,6 +1442,9 @@
     .cost-gateway .cgmeter > span { display: block; height: 100%; background: var(--green); }
     .cost-table { width: 100%; border-collapse: collapse; font-size: 0.72rem; }
     .cost-table th { text-align: left; color: var(--muted); font-weight: 600; padding: 4px 8px; border-bottom: 1px solid var(--border); }
+    .cost-table th.cost-sortable { cursor: pointer; user-select: none; }
+    .cost-table th.cost-sortable:hover { color: var(--text); }
+    .cost-sort-ind { display: inline-block; margin-left: 4px; font-size: 0.62rem; color: var(--accent); }
     .cost-table td { padding: 4px 8px; border-bottom: 1px solid rgba(128,128,128,0.08); }
     .cost-table td.cnum { text-align: right; font-family: var(--font-mono); }
     .cost-table td.cmodel { color: var(--purple); font-family: var(--font-mono); }
@@ -8411,6 +8414,48 @@ function burnAreaChart() {
       toggleCostSub(key);
     }
 
+    const COST_SORTS = {
+      model: { key: 'usd', dir: 'desc' },
+      sandbox: { key: 'usd', dir: 'desc' },
+      session: { key: 'started', dir: 'desc' },
+    };
+    function costSortDir(table, key) {
+      const s = COST_SORTS[table];
+      return s && s.key === key ? s.dir : '';
+    }
+    function costSortTh(table, key, label, opts = {}) {
+      const dir = costSortDir(table, key);
+      const title = opts.title ? ` title="${esc(opts.title)}"` : '';
+      const style = opts.align ? ` style="text-align:${opts.align}"` : '';
+      const aria = dir ? ` aria-sort="${dir === 'asc' ? 'ascending' : 'descending'}"` : ' aria-sort="none"';
+      const indicator = dir ? `<span class="cost-sort-ind" aria-hidden="true">${dir === 'asc' ? '▲' : '▼'}</span>` : '';
+      return `<th class="cost-sortable"${style}${title}${aria} role="button" tabindex="0" data-action="costSortTable" data-keydown-action="costSortTable" data-arg-types="e,s,s" data-arg1="${table}" data-arg2="${key}" data-keys="*">${label}${indicator}</th>`;
+    }
+    function costSortTable(ev, table, key) {
+      if (ev && ev.type === 'keydown') {
+        if (ev.key !== 'Enter' && ev.key !== ' ' && ev.key !== 'Spacebar') return;
+        ev.preventDefault();
+      }
+      const s = COST_SORTS[table];
+      if (!s) return;
+      s.dir = s.key === key && s.dir === 'asc' ? 'desc' : 'asc';
+      s.key = key;
+      renderCost(_lastCost);
+    }
+    function costCmp(a, b, key, dir, fallback) {
+      const av = a[key], bv = b[key];
+      const na = typeof av === 'number', nb = typeof bv === 'number';
+      let c;
+      if (na || nb) c = (Number(av) || 0) - (Number(bv) || 0);
+      else c = String(av ?? '').localeCompare(String(bv ?? ''), undefined, { sensitivity: 'base', numeric: true });
+      if (c !== 0) return dir === 'desc' ? -c : c;
+      return fallback ? fallback(a, b) : 0;
+    }
+    function sortCostRows(rows, table, fallback) {
+      const s = COST_SORTS[table] || { key: 'usd', dir: 'desc' };
+      return rows.slice().sort((a, b) => costCmp(a, b, s.key, s.dir, fallback));
+    }
+
     function renderCost(cost) {
       const el = document.getElementById('cost-panel');
       if (!el) return;
@@ -8487,13 +8532,16 @@ function burnAreaChart() {
 
       // Per-model estimated cost table. Every model shows a $ estimate now —
       // exact list price where known, a coarse tier estimate (~) otherwise.
-      const models = (est.by_model || []).slice().sort((a, b) => b.usd - a.usd);
+      const models = sortCostRows((est.by_model || []).map(m => {
+        const users = liveAgentCounts[normModel(m.name)] || [];
+        return { ...m, running: users.length, _users: users };
+      }), 'model', (a, b) => String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base', numeric: true }));
       const modelRows = models.map(m => {
         const approx = m.source === 'unpriced';
         const usdCell = approx
           ? `<span title="tier estimate — no exact list price for this model">~${fmtUSD(m.usd)}</span>`
           : fmtUSD(m.usd);
-        const users = liveAgentCounts[normModel(m.name)] || [];
+        const users = m._users || [];
         const agentsCell = users.length
           ? `<span class="cagents-badge" title="Agents using this model now: ${esc(users.join(', '))}">${users.length}</span>`
           : `<span class="cagents-zero" title="No running agent on this model right now">—</span>`;
@@ -8512,8 +8560,8 @@ function burnAreaChart() {
 
       // ── Per-sandbox (per-agent) estimated cost ──
       // In hive each agent runs in its own sandbox, so "usage by sandbox" is the
-      // per-agent breakdown. Sorted most-expensive first.
-      const bySandbox = (est.by_agent || []).slice().sort((a, b) => b.usd - a.usd);
+      // per-agent breakdown. Default sort remains most-expensive first.
+      const bySandbox = sortCostRows(est.by_agent || [], 'sandbox', (a, b) => String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base', numeric: true }));
       const sandboxRows = bySandbox.map(a => {
         const approx = a.source === 'unpriced';
         const usdCell = approx
@@ -8530,7 +8578,7 @@ function burnAreaChart() {
         <div class="cost-subtable-title cost-sub-toggle" role="button" tabindex="0" aria-expanded="true" aria-controls="cost-sub-sandbox-body" data-action="costSubToggle" data-keydown-action="costSubToggle" data-arg-types="e,s" data-arg1="sandbox" data-keys="*" title="Estimated cost grouped by sandbox — one agent per sandbox (token × list price). Click to collapse / expand."><span class="cost-chevron" aria-hidden="true">▼</span>usage by sandbox</div>
         <div class="cost-sub-body" id="cost-sub-sandbox-body">
         <table class="cost-table">
-          <thead><tr><th>sandbox (agent)</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
+          <thead><tr>${costSortTh('sandbox', 'name', 'sandbox (agent)')}${costSortTh('sandbox', 'input', 'input', { align: 'right' })}${costSortTh('sandbox', 'output', 'output', { align: 'right' })}${costSortTh('sandbox', 'usd', 'est. $', { align: 'right' })}</tr></thead>
           <tbody>${sandboxRows || '<tr><td colspan="4" style="color:var(--muted)">no usage yet</td></tr>'}</tbody>
         </table>
         </div>
@@ -8538,9 +8586,11 @@ function burnAreaChart() {
 
       // ── Cost per session ──
       // Each row is one agent run (session) inside its sandbox, priced from its
-      // own token splits. Backend already sorts most-expensive first and caps
-      // the count; we show the session id (shortened), owning sandbox, and model.
-      const bySession = est.by_session || [];
+      // own token splits. The client owns the visible sort state; default is
+      // newest session start first, then sandbox name ascending.
+      const bySession = sortCostRows(est.by_session || [], 'session', (a, b) =>
+        String(a.agent || '').localeCompare(String(b.agent || ''), undefined, { sensitivity: 'base', numeric: true }) ||
+        String(a.session_id || '').localeCompare(String(b.session_id || ''), undefined, { sensitivity: 'base', numeric: true }));
       const shortId = (id) => {
         const s = String(id || '');
         return s.length > COST_SESSION_ID_CHARS ? s.slice(0, COST_SESSION_ID_CHARS) + '…' : (s || '—');
@@ -8573,10 +8623,10 @@ function burnAreaChart() {
         </tr>`;
       }).join('');
       const sessionTable = `<div class="cost-subsection" data-cost-sub="session">
-        <div class="cost-subtable-title cost-sub-toggle" role="button" tabindex="0" aria-expanded="false" aria-controls="cost-sub-session-body" data-action="costSubToggle" data-keydown-action="costSubToggle" data-arg-types="e,s" data-arg1="session" data-keys="*" title="Estimated cost for each individual agent session (sandbox run), most expensive first (token × list price). Click to collapse / expand."><span class="cost-chevron" aria-hidden="true">▼</span>cost per session</div>
+        <div class="cost-subtable-title cost-sub-toggle" role="button" tabindex="0" aria-expanded="false" aria-controls="cost-sub-session-body" data-action="costSubToggle" data-keydown-action="costSubToggle" data-arg-types="e,s" data-arg1="session" data-keys="*" title="Estimated cost for each individual agent session (sandbox run), sorted by session start newest first by default (token × list price). Click to collapse / expand."><span class="cost-chevron" aria-hidden="true">▼</span>cost per session</div>
         <div class="cost-sub-body" id="cost-sub-session-body">
         <table class="cost-table">
-          <thead><tr><th>session</th><th>sandbox</th><th>model</th><th title="Session start → end, local time (earliest / latest usage event). Hover a row for full timestamps; 'active' means the session had events in the last few minutes.">started → ended</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
+          <thead><tr>${costSortTh('session', 'session_id', 'session')}${costSortTh('session', 'agent', 'sandbox')}${costSortTh('session', 'model', 'model')}${costSortTh('session', 'started', 'started → ended', { title: "Session start → end, local time (earliest / latest usage event). Hover a row for full timestamps; 'active' means the session had events in the last few minutes." })}${costSortTh('session', 'input', 'input', { align: 'right' })}${costSortTh('session', 'output', 'output', { align: 'right' })}${costSortTh('session', 'usd', 'est. $', { align: 'right' })}</tr></thead>
           <tbody>${sessionRows || '<tr><td colspan="7" style="color:var(--muted)">no sessions yet</td></tr>'}</tbody>
         </table>
         </div>
@@ -8598,7 +8648,7 @@ function burnAreaChart() {
           ${costTrendHtml()}
           ${gwCards ? `<div class="cost-gateways">${gwCards}</div>` : ''}
           <table class="cost-table">
-            <thead><tr><th>model</th><th style="text-align:center" title="Running agents on this model right now — hover the count for names">running agents</th><th style="text-align:right">input</th><th style="text-align:right">output</th><th style="text-align:right">est. $</th></tr></thead>
+            <thead><tr>${costSortTh('model', 'name', 'model')}${costSortTh('model', 'running', 'running agents', { align: 'center', title: 'Running agents on this model right now — hover the count for names' })}${costSortTh('model', 'input', 'input', { align: 'right' })}${costSortTh('model', 'output', 'output', { align: 'right' })}${costSortTh('model', 'usd', 'est. $', { align: 'right' })}</tr></thead>
             <tbody>${modelRows || '<tr><td colspan="5" style="color:var(--muted)">no usage yet</td></tr>'}</tbody>
           </table>
           ${sandboxTable}


### PR DESCRIPTION
## Summary
- make all Cost page table headers sortable with client-side asc/desc indicators
- default cost-per-session ordering to started timestamp newest-first, then sandbox/agent name ascending
- align backend session payload cap with newest-session default and update dashboard tests

## Validation
- cd src && go test ./pkg/dashboard/...
- cd src && go build ./...
- node --check on embedded dashboard scripts