### PR TITLE
fix(escalation): escalate red PRs whose SHA never moves once nudges run out

### DIFF
--- a/src/pkg/escalation/escalation.go
+++ b/src/pkg/escalation/escalation.go
@@ -171,10 +171,20 @@ func (s *Store) Sweep(obs []Observation, threshold int) map[string]Result {
 			e.LastExcerpt = o.Excerpt
 		}
 		e.UpdatedAt = s.now()
+		// A PR whose CURRENT red SHA has exhausted its re-engagement budget has
+		// had every automated nudge it is going to get. If no new SHA ever
+		// appears — fix attempts are not even being PUSHED, e.g. the agents lost
+		// their write credentials (kubestellar/console, 2026-08-22: eight red
+		// PRs re-engaged every cycle for 15h with zero pushes) — the distinct-SHA
+		// count can never advance, so without this clause the PR sits in limbo
+		// forever: nudged, never fixed, never handed to a human. Budget
+		// exhaustion on an unchanged red SHA is therefore escalation-worthy in
+		// its own right.
+		exhausted := e.ReEngagements >= MaxReEngagements
 		results[key] = Result{
 			Attempts:    len(e.RedSHAs),
 			Escalated:   e.Escalated,
-			NewlyEscala: !e.Escalated && len(e.RedSHAs) >= threshold,
+			NewlyEscala: !e.Escalated && (len(e.RedSHAs) >= threshold || exhausted),
 		}
 	}
 	// Prune PRs that left the open set (merged or closed).

--- a/src/pkg/escalation/escalation_test.go
+++ b/src/pkg/escalation/escalation_test.go
@@ -187,3 +187,44 @@ func TestTryReEngage_EmptySHAReusesTrackedSHA(t *testing.T) {
 		t.Fatal("empty-SHA re-engagement must respect the cap on the tracked SHA")
 	}
 }
+
+// A PR whose red SHA NEVER changes (fix attempts are not even pushed — e.g.
+// agents lost write credentials) must still escalate once its re-engagement
+// budget is exhausted. Without this, the distinct-SHA count never advances and
+// the PR is nudged forever without ever reaching a human (kubestellar/console,
+// 2026-08-22: eight red PRs re-engaged every cycle for 15h with zero pushes).
+func TestSweep_EscalatesWhenReEngagementBudgetExhaustedOnUnchangedSHA(t *testing.T) {
+	s := Load(filepath.Join(t.TempDir(), "streaks.json"))
+
+	// One red SHA, observed; re-engage to the cap without the SHA ever moving.
+	s.Sweep([]Observation{obs("org/repo", 9, "frozen", true)}, 3)
+	for i := 0; i < MaxReEngagements; i++ {
+		if !s.TryReEngage("org/repo", 9, "frozen") {
+			t.Fatalf("re-engage %d should be allowed", i+1)
+		}
+	}
+	if s.TryReEngage("org/repo", 9, "frozen") {
+		t.Fatal("cap must halt further re-engagements")
+	}
+
+	// Next sweep: still the same red SHA, one distinct attempt — but the
+	// budget is exhausted, so escalation must fire now.
+	r := s.Sweep([]Observation{obs("org/repo", 9, "frozen", true)}, 3)
+	got := r[Key("org/repo", 9)]
+	if got.Attempts != 1 || !got.NewlyEscala {
+		t.Fatalf("exhausted budget on unchanged SHA must escalate: got %+v", got)
+	}
+
+	// A pushed fix (new SHA) resets the budget — a freshly-moving PR must NOT
+	// be treated as exhausted.
+	s2 := Load(filepath.Join(t.TempDir(), "s2.json"))
+	s2.Sweep([]Observation{obs("org/repo", 11, "a", true)}, 3)
+	for i := 0; i < MaxReEngagements; i++ {
+		s2.TryReEngage("org/repo", 11, "a")
+	}
+	r = s2.Sweep([]Observation{obs("org/repo", 11, "b", true)}, 3) // branch moved
+	got = r[Key("org/repo", 11)]
+	if got.NewlyEscala {
+		t.Fatalf("new SHA resets the budget; must not escalate yet: got %+v", got)
+	}
+}


### PR DESCRIPTION
Closes the limbo gap found while investigating console's dead merge lane (15h, eight red PRs, `stuck=8/8` every cycle).

## The gap
The fix-loop breaker escalates on **distinct red head SHAs** (failed fix attempts). But when fix attempts are never even *pushed* — e.g. agents lost their scoped write credentials (the #4575 mint-ctx bug) — the SHA never changes, so the distinct count never advances: the PR is **re-engaged every cycle, never fixed, and never handed to a human**. `needs-human` never fired on any of console's stuck PRs.

## Fix
Exhausting the per-SHA re-engagement budget (`MaxReEngagements`) on an **unchanged** red SHA is now escalation-worthy in its own right — the PR has had every automated nudge it is going to get. A pushed fix (new SHA) still resets the budget, so an actively-worked PR is never affected.

## Test
`TestSweep_EscalatesWhenReEngagementBudgetExhaustedOnUnchangedSHA`: frozen SHA + exhausted budget → escalates; branch movement resets → does not.

## Context
The *ideal* path is agents self-healing (console's spoke now runs the #4575 token fix, so pushes should resume) — this is the backstop so nothing can sit in limbo silently again.