### PR TITLE
🐛 Surface provider spending-limit / quota exhaustion in fleet verdicts

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -160,6 +160,7 @@ func agentActivityFor(mgr *agent.Manager, cfg *config.Config, govState governor.
 		PausedBy:       proc.PausedBy,
 		PausedAt:       proc.PausedAt,
 		NeedsLogin:     proc.NeedsLogin,
+		QuotaExhausted: proc.QuotaExhausted,
 		LastActivityAt: proc.LastPaneChange,
 		// A missing tmux session is only meaningful for an agent the manager
 		// believes is running; SessionMissing enforces that itself.
@@ -3581,6 +3582,20 @@ func main() {
 				InferenceAuthError: func() string {
 					errMsg, _ := dashSrv.InferenceAuthState()
 					return errMsg
+				}(),
+				ProviderLimitReason: func() string {
+					errMsg, _, _, rebuffs := dashboard.InferenceBudgetExceeded()
+					if errMsg == "" {
+						return ""
+					}
+					if rebuffs > 1 {
+						return fmt.Sprintf("provider spending limit reached — %d refused calls: %s", rebuffs, errMsg)
+					}
+					return "provider spending limit reached — " + errMsg
+				}(),
+				ProviderLimitRebuffs: func() int {
+					_, _, _, rebuffs := dashboard.InferenceBudgetExceeded()
+					return rebuffs
 				}(),
 				RepoTargetMisconfigured: repoTargetMisconfigured(),
 				RepoTargetIssue:         repoTargetIssueMessage(),

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -212,6 +212,46 @@ func heartbeatKickInterval(govState governor.State, name string, proc *agent.Age
 	return cadence.Interval
 }
 
+func quotaExhaustedAgentCount(agents []hub.AgentSummary) int {
+	count := 0
+	for _, a := range agents {
+		if a.QuotaExhausted && !a.Paused &&
+			!strings.EqualFold(a.State, "paused") &&
+			strings.EqualFold(a.State, "running") {
+			count++
+		}
+	}
+	return count
+}
+
+func quotaExhaustedProcessCount(statuses map[string]*agent.AgentProcess) int {
+	count := 0
+	for _, proc := range statuses {
+		if proc != nil && proc.QuotaExhausted && !proc.Paused && proc.State == agent.StateRunning {
+			count++
+		}
+	}
+	return count
+}
+
+func quotaExhaustedAgentReason(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d agent(s) out of provider quota", count)
+}
+
+func providerLimitHeartbeatFields(agents []hub.AgentSummary) (reason string, rebuffs int) {
+	errMsg, _, _, rebuffs := dashboard.InferenceBudgetExceeded()
+	if errMsg != "" {
+		if rebuffs > 1 {
+			return fmt.Sprintf("provider spending limit reached — %d refused calls: %s", rebuffs, errMsg), rebuffs
+		}
+		return "provider spending limit reached — " + errMsg, rebuffs
+	}
+	return quotaExhaustedAgentReason(quotaExhaustedAgentCount(agents)), 0
+}
+
 // prospectiveGitHubIdentity returns the GitHub identity the spoke WOULD hold
 // after adopting ghCfg, or nil when the push speaks to no identity field and
 // there is nothing to validate.
@@ -3502,6 +3542,8 @@ func main() {
 				tasksCompleted7d = &n
 			}
 
+			providerLimitReason, providerLimitRebuffs := providerLimitHeartbeatFields(agents)
+
 			return &hub.HeartbeatPayload{
 				AgentsWithModel:      &agentsWithModel,
 				BudgetCurrentSpend:   budgetSpend,
@@ -3583,20 +3625,8 @@ func main() {
 					errMsg, _ := dashSrv.InferenceAuthState()
 					return errMsg
 				}(),
-				ProviderLimitReason: func() string {
-					errMsg, _, _, rebuffs := dashboard.InferenceBudgetExceeded()
-					if errMsg == "" {
-						return ""
-					}
-					if rebuffs > 1 {
-						return fmt.Sprintf("provider spending limit reached — %d refused calls: %s", rebuffs, errMsg)
-					}
-					return "provider spending limit reached — " + errMsg
-				}(),
-				ProviderLimitRebuffs: func() int {
-					_, _, _, rebuffs := dashboard.InferenceBudgetExceeded()
-					return rebuffs
-				}(),
+				ProviderLimitReason:     providerLimitReason,
+				ProviderLimitRebuffs:    providerLimitRebuffs,
 				RepoTargetMisconfigured: repoTargetMisconfigured(),
 				RepoTargetIssue:         repoTargetIssueMessage(),
 				Repos:                   cfg.Project.Repos,
@@ -3928,6 +3958,7 @@ func main() {
 				if cfg.ACMMLevel != nil {
 					acmmLvl = *cfg.ACMMLevel
 				}
+				providerLimitReason, providerLimitRebuffs := providerLimitHeartbeatFields(agents)
 				return &hub.HeartbeatPayload{
 					HiveID:                  cfg.HiveID,
 					Org:                     cfg.Project.Org,
@@ -3940,6 +3971,8 @@ func main() {
 					Version:                 "3.0.0",
 					RepoTargetMisconfigured: repoTargetMisconfigured(),
 					RepoTargetIssue:         repoTargetIssueMessage(),
+					ProviderLimitReason:     providerLimitReason,
+					ProviderLimitRebuffs:    providerLimitRebuffs,
 				}
 			}, targetSHA, logger)
 
@@ -5621,7 +5654,11 @@ func runEvalCycle(
 		dashSrv.AddSystemAlert(providerBudgetAlertID, "error", msg)
 		providerBudgetCause = msg
 	} else {
-		dashSrv.ClearSystemAlert(providerBudgetAlertID)
+		if reason := quotaExhaustedAgentReason(quotaExhaustedProcessCount(agentMgr.AllStatuses())); reason != "" {
+			dashSrv.AddSystemAlert(providerBudgetAlertID, "error", "provider quota exhausted — "+reason)
+		} else {
+			dashSrv.ClearSystemAlert(providerBudgetAlertID)
+		}
 	}
 	// Notify ONCE per latch, not once per cycle. The deduped banner above
 	// already carries the ongoing state; a high-priority notification repeated

--- a/src/cmd/hive/provider_budget_probe_test.go
+++ b/src/cmd/hive/provider_budget_probe_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard"
+	"github.com/kubestellar/hive/pkg/hub"
 )
 
 // TestProviderBudgetSuppressionProbesRatherThanDeadlocks is the regression test
@@ -233,5 +235,23 @@ func TestProviderBudgetNotifyResetReportsRecoveryOnce(t *testing.T) {
 		if st.reset() {
 			t.Fatalf("healthy cycle %d reported the recovery again", i+2)
 		}
+	}
+}
+
+func TestProviderLimitHeartbeatFieldsFallsBackToAgentQuota(t *testing.T) {
+	dashboard.SetInferenceBudgetProvider(nil)
+	t.Cleanup(func() { dashboard.SetInferenceBudgetProvider(nil) })
+
+	reason, rebuffs := providerLimitHeartbeatFields([]hub.AgentSummary{
+		{Name: "guide", State: "running", QuotaExhausted: true},
+		{Name: "scanner", State: "running", QuotaExhausted: true},
+		{Name: "paused", State: "paused", Paused: true, QuotaExhausted: true},
+		{Name: "supervisor"},
+	})
+	if rebuffs != 0 {
+		t.Fatalf("rebuffs = %d, want 0 for pane-derived quota", rebuffs)
+	}
+	if reason != "2 agent(s) out of provider quota" {
+		t.Fatalf("reason = %q, want provider quota count", reason)
 	}
 }

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -6143,7 +6143,11 @@ var quotaExhaustionPatterns = []string{
 	"budget has been exceeded",
 	"provider spending limit reached",
 	"refused the request on a spending limit",
+	"gone over your budget allowance",
+	"bobcoins",
 }
+
+var quotaExhaustionStatusPattern = regexp.MustCompile(`\b\d+(?:\.\d+)?/\d+(?:\.\d+)?\s*\(0%\)\s*\|`)
 
 func paneShowsQuotaExhausted(lines []string) bool {
 	for _, line := range lines {
@@ -6152,6 +6156,9 @@ func paneShowsQuotaExhausted(lines []string) bool {
 			if strings.Contains(lower, pat) {
 				return true
 			}
+		}
+		if quotaExhaustionStatusPattern.MatchString(line) {
+			return true
 		}
 	}
 	return false

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -241,6 +241,7 @@ type AgentProcess struct {
 	LastError         string    // captured from bare copilot diagnostic launch
 	lastTokenRestart  time.Time // cooldown for auto-restart after token detection
 	NeedsLogin        bool      // true when pane shows a login prompt
+	QuotaExhausted    bool      // true when pane shows provider/monthly quota exhaustion
 	// LastPaneChange is when the agent's tmux pane content last CHANGED, as
 	// observed by the 3s pane poller. It is the spoke's only evidence of an
 	// agent actually doing something: State says what the manager intends,
@@ -2651,7 +2652,9 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			if tailStart < 0 {
 				tailStart = 0
 			}
-			showsLogin := paneShowsLoginPrompt(filtered[tailStart:])
+			tail := filtered[tailStart:]
+			showsLogin := paneShowsLoginPrompt(tail)
+			quotaExhausted := paneShowsQuotaExhausted(tail)
 			if showsLogin {
 				loginStreak++
 			} else {
@@ -2670,6 +2673,7 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			}
 			agent.lastPaneCapture = filtered
 			agent.NeedsLogin = showsLogin
+			agent.QuotaExhausted = quotaExhausted
 			agent.paneMu.Unlock()
 
 			// Auto-restart agents stuck on the login prompt when a valid
@@ -5390,6 +5394,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 	copy(pane, a.lastPaneCapture)
 	// NeedsLogin and LastPaneChange are written by the pane poller under paneMu.
 	needsLogin := a.NeedsLogin
+	quotaExhausted := a.QuotaExhausted
 	lastPaneChange := a.LastPaneChange
 	a.paneMu.RUnlock()
 	return AgentProcess{
@@ -5414,6 +5419,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		KickHistory:     history,
 		LastKickMessage: a.LastKickMessage,
 		NeedsLogin:      needsLogin,
+		QuotaExhausted:  quotaExhausted,
 		LastPaneChange:  lastPaneChange,
 		StallNudges:     a.StallNudges,
 		ActionNudges:    a.ActionNudges,
@@ -6130,6 +6136,27 @@ func lineShowsUpstreamAuthorizationError(line string) bool {
 	return false
 }
 
+var quotaExhaustionPatterns = []string{
+	"exceeded your monthly quota",
+	"used all your copilot free chat requests",
+	"budget_exceeded",
+	"budget has been exceeded",
+	"provider spending limit reached",
+	"refused the request on a spending limit",
+}
+
+func paneShowsQuotaExhausted(lines []string) bool {
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		for _, pat := range quotaExhaustionPatterns {
+			if strings.Contains(lower, pat) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // paneShowsLoginPrompt returns true if any line in the pane output matches a
 // known login/authentication prompt pattern.
 //
@@ -6155,7 +6182,7 @@ func paneShowsLoginPrompt(lines []string) bool {
 	for _, line := range lines {
 		// An upstream authorization failure is not a login prompt, whatever
 		// the CLI decorated it with.
-		if lineShowsUpstreamAuthorizationError(line) {
+		if lineShowsUpstreamAuthorizationError(line) || paneShowsQuotaExhausted([]string{line}) {
 			continue
 		}
 		if lineHasLoginDirective(line) {

--- a/src/pkg/agent/quota_exhaustion_test.go
+++ b/src/pkg/agent/quota_exhaustion_test.go
@@ -9,6 +9,8 @@ func TestPaneShowsQuotaExhausted(t *testing.T) {
 		`API Error: 429 {"error":{"type":"budget_exceeded","message":"Budget has been exceeded!"}}`,
 		"provider spending limit reached (682 refused calls since Fri)",
 		"litellm refused the request on a spending limit (429)",
+		"Oh no! It looks like you've gone over your budget allowance of 1000 Bobcoins. Give me feedback using about my performance and I'll make sure you get rewarded with some extra credits!",
+		"💰 1000.01/1000 (0%) | Current 💬: 0.00",
 	}
 	for _, line := range cases {
 		if !paneShowsQuotaExhausted([]string{line}) {

--- a/src/pkg/agent/quota_exhaustion_test.go
+++ b/src/pkg/agent/quota_exhaustion_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import "testing"
+
+func TestPaneShowsQuotaExhausted(t *testing.T) {
+	cases := []string{
+		"You have exceeded your monthly quota",
+		"You've used all your Copilot Free chat requests for the month",
+		`API Error: 429 {"error":{"type":"budget_exceeded","message":"Budget has been exceeded!"}}`,
+		"provider spending limit reached (682 refused calls since Fri)",
+		"litellm refused the request on a spending limit (429)",
+	}
+	for _, line := range cases {
+		if !paneShowsQuotaExhausted([]string{line}) {
+			t.Fatalf("paneShowsQuotaExhausted(%q) = false, want true", line)
+		}
+	}
+}
+
+func TestQuotaExhaustionIsNotLoginPrompt(t *testing.T) {
+	line := "Please run /login · You've used all your Copilot Free chat requests for the month"
+	if !paneShowsQuotaExhausted([]string{line}) {
+		t.Fatalf("quota line was not detected")
+	}
+	if paneShowsLoginPrompt([]string{line}) {
+		t.Fatalf("quota exhaustion must not be classified as a login prompt")
+	}
+}
+
+func TestPaneShowsQuotaExhaustedIgnoresOrdinaryRateLimit(t *testing.T) {
+	if paneShowsQuotaExhausted([]string{"API Error: 429 rate limit exceeded, try again later"}) {
+		t.Fatalf("ordinary transient rate limit must not be quota exhaustion")
+	}
+}

--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -51,6 +51,8 @@ const (
 	runIdleAtPrompt
 	// runStuckAtLogin — running but sitting on a login prompt past grace.
 	runStuckAtLogin
+	// runQuotaExhausted — running but the provider/monthly quota is exhausted.
+	runQuotaExhausted
 	// runSessionGone — the manager believes it runs, but the tmux session is
 	// gone (zombie).
 	runSessionGone
@@ -70,6 +72,8 @@ func (s agentRunState) String() string {
 		return "idle-at-prompt"
 	case runStuckAtLogin:
 		return "stuck-at-login"
+	case runQuotaExhausted:
+		return "quota-exhausted"
 	case runSessionGone:
 		return "session-gone"
 	case runDead:
@@ -102,6 +106,7 @@ type hiveBlockers struct {
 	RepoTargetMisconfigured bool
 	RepoTargetIssue         string
 	InferenceAuthError      string
+	ProviderLimitReason     string
 }
 
 // any reports whether any hive-level blocker is set.
@@ -110,6 +115,7 @@ func (b hiveBlockers) any() bool {
 		strings.TrimSpace(b.GitHubAppPermIssue) != "" ||
 		strings.TrimSpace(b.RepoTargetIssue) != "" ||
 		strings.TrimSpace(b.InferenceAuthError) != "" ||
+		strings.TrimSpace(b.ProviderLimitReason) != "" ||
 		blockingGitHubAppState(b.GitHubAppState)
 }
 
@@ -126,6 +132,8 @@ func (b hiveBlockers) reason() string {
 		return b.RepoTargetIssue
 	case b.RepoTargetMisconfigured:
 		return "repo target misconfigured"
+	case strings.TrimSpace(b.ProviderLimitReason) != "":
+		return b.ProviderLimitReason
 	case strings.TrimSpace(b.InferenceAuthError) != "":
 		return b.InferenceAuthError
 	default:
@@ -180,7 +188,8 @@ func interactiveLoginBackend(backend string) bool {
 // Used only to keep the run-state machine from labeling a legacy agent "dead".
 func legacyAgent(a AgentSummary) bool {
 	return !a.ExpectedActive && !a.Enabled &&
-		!a.CanOpenIssue && !a.CanOpenPR && !a.CanMerge && strings.TrimSpace(a.Backend) == ""
+		!a.CanOpenIssue && !a.CanOpenPR && !a.CanMerge &&
+		!a.NeedsLogin && !a.QuotaExhausted && strings.TrimSpace(a.Backend) == ""
 }
 
 // deriveAgentVerdict computes the full three-leg verdict for one agent.
@@ -203,6 +212,8 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	switch {
 	case paused:
 		v.RunState = runQuietByDesign
+	case a.QuotaExhausted:
+		v.RunState = runQuotaExhausted
 	case kind == agentInactiveNeedsLogin:
 		// A login prompt outranks the off-schedule quiet branch below: a
 		// wedged interactive credential is a HIVE-wide fault (every kick to
@@ -259,8 +270,9 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	}
 
 	loginBlocked := a.NeedsLogin && interactiveLoginBackend(a.Backend)
+	quotaBlocked := a.QuotaExhausted
 	hiveBlocked := blockers.any()
-	blocked := loginBlocked || hiveBlocked
+	blocked := loginBlocked || quotaBlocked || hiveBlocked
 
 	// modeGrantsWrite: the agent's mode grants at least one write action (open
 	// PR or merge) beyond opening issues. An advisory issues-only agent does
@@ -297,6 +309,8 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	switch {
 	case loginBlocked:
 		v.BlockedReason = "sitting at login prompt"
+	case quotaBlocked:
+		v.BlockedReason = "provider quota exhausted"
 	case hiveBlocked:
 		v.BlockedReason = blockers.reason()
 	}
@@ -333,6 +347,10 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 			// credential is hive-wide and the wire may omit expectedActive
 			// entirely (the EPM/alchemy case) — gating on it hid the fault.
 			v.Stuck = true
+		case runQuotaExhausted:
+			// Provider quota exhaustion is a hive/provider fault even if the
+			// schedule bit is absent on the wire.
+			v.Stuck = true
 		}
 		// IMPOTENT: running but not capable of its mission (blocked/gated). Uses
 		// `capable`, not v.Able, because v.Able already requires runWorking —
@@ -354,7 +372,7 @@ func deriveAgentVerdict(a AgentSummary, blockers hiveBlockers, queuedWork int, n
 	// runStuckAtLogin bypasses the expectedActive gate: the credential fault is
 	// real whether or not the wire carries the schedule bit (see the ACTUAL-leg
 	// ordering above).
-	v.Problem = (a.ExpectedActive || v.RunState == runStuckAtLogin) && !v.QuietByDesign && !v.Able
+	v.Problem = (a.ExpectedActive || v.RunState == runStuckAtLogin || v.RunState == runQuotaExhausted) && !v.QuietByDesign && !v.Able
 
 	return v
 }
@@ -395,6 +413,8 @@ type agentFleetRollup struct {
 	// (dead, or running-with-session-missing zombies). When every problem is
 	// in this class the verdict keeps the familiar "no agents running".
 	DeadOrGone int `json:"deadOrGone,omitempty"`
+	// QuotaExhausted is how many Problems are provider/monthly quota limited.
+	QuotaExhausted int `json:"quotaExhausted,omitempty"`
 	// Known is how many agents reported the new divergence signals (non-legacy).
 	// When Known==0 the whole hive is UNKNOWN (a spoke not yet rolled to this
 	// build) and its dot is gray, never green — absence of a problem we cannot
@@ -422,6 +442,7 @@ type AgentVerdictJSON struct {
 	PausedTrigger   string `json:"pausedTrigger,omitempty"`
 	PausedReason    string `json:"pausedReason,omitempty"`
 	PausedAt        string `json:"pausedAt,omitempty"`
+	QuotaExhausted  bool   `json:"quotaExhausted,omitempty"`
 	CanOpenIssue    bool   `json:"canOpenIssue"`
 	CanOpenPR       bool   `json:"canOpenPR"`
 	CanMerge        bool   `json:"canMerge"`
@@ -462,6 +483,7 @@ func buildAgentVerdicts(agents []AgentSummary, blockers hiveBlockers, queuedWork
 			PausedTrigger:   a.PausedTrigger,
 			PausedReason:    a.PausedReason,
 			PausedAt:        a.PausedAt,
+			QuotaExhausted:  a.QuotaExhausted,
 			CanOpenIssue:    v.CanOpenIssue,
 			CanOpenPR:       v.CanOpenPR,
 			CanMerge:        v.CanMerge,
@@ -592,6 +614,8 @@ func rollupAgents(agents []AgentSummary, blockers hiveBlockers, queuedWork int, 
 				r.LoginStuck++
 			case runIdleAtPrompt:
 				r.IdleWithWork++
+			case runQuotaExhausted:
+				r.QuotaExhausted++
 			case runDead, runSessionGone:
 				r.DeadOrGone++
 			}

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -71,6 +71,27 @@ func TestVerdict_StuckAtLoginIsImpotentAndStuck(t *testing.T) {
 	}
 }
 
+func TestVerdict_QuotaExhaustedOutranksIdle(t *testing.T) {
+	now := time.Now()
+	a := modernWorking(now)
+	a.LastActivityAt = activeAt(now, 2*time.Hour)
+	a.QuotaExhausted = true
+	v := deriveAgentVerdict(a, hiveBlockers{}, 5, now)
+	if v.RunState != runQuotaExhausted {
+		t.Fatalf("runState = %v, want quota-exhausted", v.RunState)
+	}
+	if !v.Problem || !v.Stuck || !v.Impotent {
+		t.Fatalf("quota-exhausted expected-active agent must be a stuck/impotent problem: %+v", v)
+	}
+	if v.BlockedReason != "provider quota exhausted" {
+		t.Fatalf("blockedReason = %q, want provider quota exhausted", v.BlockedReason)
+	}
+	r := rollupAgents([]AgentSummary{a}, hiveBlockers{}, 5, now)
+	if r.QuotaExhausted != 1 || r.IdleWithWork != 0 {
+		t.Fatalf("rollup quota=%d idle=%d, want quota=1 idle=0", r.QuotaExhausted, r.IdleWithWork)
+	}
+}
+
 // A hive-level blocker (App perm) makes a running, capable agent IMPOTENT even
 // though its ACMM gates say it can push/merge.
 func TestVerdict_HiveBlockerMakesImpotent(t *testing.T) {

--- a/src/pkg/hub/budget_health.go
+++ b/src/pkg/hub/budget_health.go
@@ -1,6 +1,10 @@
 package hub
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 const (
 	budgetBucketOK        = "ok"
@@ -16,17 +20,25 @@ const (
 )
 
 type BudgetHealth struct {
-	UsedTokens     int64   `json:"usedTokens,omitempty"`
-	LimitTokens    int64   `json:"limitTokens,omitempty"`
-	PercentUsed    float64 `json:"percentUsed,omitempty"`
-	Bucket         string  `json:"bucket"`
-	Exhausted      bool    `json:"exhausted,omitempty"`
-	Ignored        bool    `json:"ignored,omitempty"`
-	WindowStartsAt string  `json:"windowStartsAt,omitempty"`
-	WindowEndsAt   string  `json:"windowEndsAt,omitempty"`
+	UsedTokens      int64   `json:"usedTokens,omitempty"`
+	LimitTokens     int64   `json:"limitTokens,omitempty"`
+	PercentUsed     float64 `json:"percentUsed,omitempty"`
+	Bucket          string  `json:"bucket"`
+	Exhausted       bool    `json:"exhausted,omitempty"`
+	ProviderLimited bool    `json:"providerLimited,omitempty"`
+	Reason          string  `json:"reason,omitempty"`
+	Ignored         bool    `json:"ignored,omitempty"`
+	WindowStartsAt  string  `json:"windowStartsAt,omitempty"`
+	WindowEndsAt    string  `json:"windowEndsAt,omitempty"`
 }
 
 func budgetHealthFor(e RegistryEntry) BudgetHealth {
+	if reason := providerLimitHealthReason(e.ProviderLimitReason, e.ProviderLimitRebuffs); reason != "" {
+		return BudgetHealth{Bucket: budgetBucketExhausted, Exhausted: true, ProviderLimited: true, Reason: reason}
+	}
+	if n := quotaExhaustedAgentCountForBudget(e.Agents); n > 0 {
+		return BudgetHealth{Bucket: budgetBucketExhausted, Exhausted: true, ProviderLimited: true, Reason: fmt.Sprintf("%d agent(s) out of provider quota", n)}
+	}
 	if e.BudgetIgnored != nil && *e.BudgetIgnored {
 		return BudgetHealth{Bucket: budgetBucketUnknown, Ignored: true}
 	}
@@ -81,6 +93,18 @@ func budgetHealthFor(e RegistryEntry) BudgetHealth {
 		out.Bucket = budgetBucketWarning
 	}
 	return out
+}
+
+func quotaExhaustedAgentCountForBudget(agents []AgentSummary) int {
+	count := 0
+	for _, a := range agents {
+		if a.QuotaExhausted && !a.Paused &&
+			!strings.EqualFold(a.State, agentStatePaused) &&
+			strings.EqualFold(a.State, agentStateRunning) {
+			count++
+		}
+	}
+	return count
 }
 
 func formatOptionalTime(t time.Time) string {

--- a/src/pkg/hub/budget_health_test.go
+++ b/src/pkg/hub/budget_health_test.go
@@ -59,6 +59,44 @@ func TestBudgetHealthExhaustedFlagWinsWithoutNumbers(t *testing.T) {
 	}
 }
 
+func TestBudgetHealthProviderLimitWinsWithoutLocalBudget(t *testing.T) {
+	got := budgetHealthFor(RegistryEntry{
+		ProviderLimitReason: "1 agent(s) out of provider quota",
+	})
+	if got.Bucket != budgetBucketExhausted || !got.Exhausted || !got.ProviderLimited {
+		t.Fatalf("provider-limited budget health = %+v, want exhausted provider-limited", got)
+	}
+	if got.Reason != "1 agent(s) out of provider quota" {
+		t.Fatalf("reason = %q, want provider quota reason", got.Reason)
+	}
+
+	got = budgetHealthFor(RegistryEntry{
+		ProviderLimitReason:  "litellm refused the request on a spending limit (429)",
+		ProviderLimitRebuffs: 682,
+		BudgetIgnored:        boolptr(true),
+	})
+	if got.Bucket != budgetBucketExhausted || !got.ProviderLimited || got.Ignored {
+		t.Fatalf("provider limit should outrank ignored local budget, got %+v", got)
+	}
+	if got.Reason != "provider spending limit reached — 682 refused calls" {
+		t.Fatalf("reason = %q, want refused-call provider limit", got.Reason)
+	}
+}
+
+func TestBudgetHealthAgentQuotaExhaustionWinsWithoutReason(t *testing.T) {
+	got := budgetHealthFor(RegistryEntry{Agents: []AgentSummary{
+		{Name: "guide", State: agentStateRunning, QuotaExhausted: true},
+		{Name: "scanner", State: agentStateRunning, QuotaExhausted: true},
+		{Name: "paused", State: agentStatePaused, Paused: true, QuotaExhausted: true},
+	}})
+	if got.Bucket != budgetBucketExhausted || !got.Exhausted || !got.ProviderLimited {
+		t.Fatalf("agent quota budget health = %+v, want exhausted provider-limited", got)
+	}
+	if got.Reason != "2 agent(s) out of provider quota" {
+		t.Fatalf("reason = %q, want provider quota count", got.Reason)
+	}
+}
+
 func TestBudgetHealthUnknownWithoutConfiguredBudget(t *testing.T) {
 	cases := []RegistryEntry{
 		{},

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -99,6 +99,11 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 			}
 			return v
 		}
+		if reason := strings.TrimSpace(e.ProviderLimitReason); reason != "" {
+			v.State = HealthStateRed
+			v.Reason = providerLimitHealthReason(reason, e.ProviderLimitRebuffs)
+			return v
+		}
 		// Budget exhaustion halts every agent, so no output stream can move.
 		// The chip must say THAT instead of the downstream "no write in Nh" —
 		// the operator's remedy (raise budget or wait for the window) is
@@ -111,6 +116,8 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 		if rollup.Problems > 0 {
 			v.State = HealthStateRed
 			switch {
+			case rollup.QuotaExhausted == rollup.Problems:
+				v.Reason = fmt.Sprintf("%d agent(s) out of provider quota", rollup.QuotaExhausted)
 			case rollup.LoginStuck == rollup.Problems:
 				// Every blocked agent is wedged at a login prompt: name the one
 				// actionable cause (operator re-login) instead of the generic
@@ -388,4 +395,12 @@ func humanizeAge(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%dd ago", int(d.Hours())/24)
 	}
+}
+
+func providerLimitHealthReason(reason string, rebuffs int) string {
+	reason = strings.TrimSpace(reason)
+	if rebuffs > 0 && !strings.Contains(reason, "refused calls") {
+		return fmt.Sprintf("provider spending limit reached — %d refused calls", rebuffs)
+	}
+	return reason
 }

--- a/src/pkg/hub/health_verdict_reasons_test.go
+++ b/src/pkg/hub/health_verdict_reasons_test.go
@@ -82,6 +82,40 @@ func TestHiveHealthForReasons(t *testing.T) {
 			wantReason: "2 agent(s) blocked",
 		},
 		{
+			name: "L3 provider spending limit outranks idle agents",
+			entry: func() RegistryEntry {
+				e := base(3)
+				e.ProviderLimitReason = "provider spending limit reached — 682 refused calls: litellm refused the request on a spending limit (429)"
+				e.ProviderLimitRebuffs = 682
+				return e
+			}(),
+			rollup: agentFleetRollup{Expected: 3, Running: 0, Known: 3, Problems: 3, IdleWithWork: 3},
+			app:    okApp(), queued: 43,
+			wantState:  HealthStateRed,
+			wantReason: "provider spending limit reached — 682 refused calls: litellm refused the request on a spending limit (429)",
+		},
+		{
+			name: "L3 provider limit count is named when reason lacks refused-call count",
+			entry: func() RegistryEntry {
+				e := base(3)
+				e.ProviderLimitReason = "litellm refused the request on a spending limit (429)"
+				e.ProviderLimitRebuffs = 682
+				return e
+			}(),
+			rollup: agentFleetRollup{Expected: 3, Running: 0, Known: 3, Problems: 3, IdleWithWork: 3},
+			app:    okApp(), queued: 43,
+			wantState:  HealthStateRed,
+			wantReason: "provider spending limit reached — 682 refused calls",
+		},
+		{
+			name:   "L3 all problems quota-exhausted — red names provider quota",
+			entry:  base(3),
+			rollup: agentFleetRollup{Expected: 1, Running: 0, Known: 1, Problems: 1, QuotaExhausted: 1, IdleWithWork: 1},
+			app:    okApp(), queued: 8,
+			wantState:  HealthStateRed,
+			wantReason: "1 agent(s) out of provider quota",
+		},
+		{
 			// EPM/alchemy live case: every problem is a wedged interactive
 			// login, so the reason names the one actionable cause.
 			name:   "L3 all problems login-stuck — red names the re-login",

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -283,6 +283,11 @@ type AgentSummary struct {
 	// session is alive, the CLI process is alive, and the agent still cannot do
 	// any work. It is invisible in State, which reads "running" throughout.
 	NeedsLogin bool `json:"needsLogin,omitempty"`
+	// QuotaExhausted is true when the agent pane shows a provider/monthly quota
+	// refusal ("monthly quota", Copilot Free requests exhausted, LiteLLM
+	// budget_exceeded). Unlike NeedsLogin, re-authentication will not help; the
+	// agent cannot buy tokens until the provider quota resets or is raised.
+	QuotaExhausted bool `json:"quotaExhausted,omitempty"`
 	// SessionMissing is true when the manager expected a live tmux session for
 	// a running agent and did not find one — the zombie case. Reported
 	// explicitly rather than inferred hub-side, because only the spoke can see
@@ -352,6 +357,7 @@ type AgentActivity struct {
 	PausedBy       string
 	PausedAt       time.Time
 	NeedsLogin     bool
+	QuotaExhausted bool
 	SessionMissing bool
 	StartedAt      time.Time
 	LastActivityAt time.Time
@@ -378,6 +384,7 @@ func NewAgentSummary(name, state, mode string, act AgentActivity) AgentSummary {
 		PausedReason:   act.PausedReason,
 		PausedBy:       act.PausedBy,
 		NeedsLogin:     act.NeedsLogin,
+		QuotaExhausted: act.QuotaExhausted,
 		SessionMissing: act.SessionMissing,
 		ExpectedActive: act.ExpectedActive,
 		CanOpenIssue:   act.CanOpenIssue,
@@ -629,9 +636,15 @@ type HeartbeatPayload struct {
 	// inference-auth alert whose ROOT cause an operator sees directly, distinct
 	// from a GitHub-post advisory staleness. It clears the moment an inference
 	// call succeeds, so a fixed hive self-heals. Never carries key material.
-	InferenceAuthError string         `json:"inference_auth_error,omitempty"`
-	Health             map[string]any `json:"health"`
-	DashboardURL       string         `json:"dashboard_url"`
+	InferenceAuthError string `json:"inference_auth_error,omitempty"`
+	// ProviderLimitReason is the spoke's current provider-side spending/quota
+	// refusal banner (distinct from hive-local governor budget). Empty means no
+	// signal or an old spoke. ProviderLimitRebuffs counts matched refused calls
+	// while latched, when known.
+	ProviderLimitReason  string         `json:"provider_limit_reason,omitempty"`
+	ProviderLimitRebuffs int            `json:"provider_limit_rebuffs,omitempty"`
+	Health               map[string]any `json:"health"`
+	DashboardURL         string         `json:"dashboard_url"`
 	// PublicURLSelfCheck is the spoke's own end-to-end probe of the dashboard
 	// URL it is advertising to the hub. It exists because the hub's public
 	// network can be the wrong vantage point for private-network hives: a URL

--- a/src/pkg/hub/heartbeat_divergence_fields_test.go
+++ b/src/pkg/hub/heartbeat_divergence_fields_test.go
@@ -92,3 +92,33 @@ func TestHeartbeatDivergenceFields_SanitizesBackend(t *testing.T) {
 		t.Errorf("backend was not sanitized: %q", got)
 	}
 }
+
+func TestHeartbeatProviderLimitAndQuotaFields_Stored(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	body := `{
+		"hive_id":"h1",
+		"provider_limit_reason":"provider spending limit reached — 682 refused calls",
+		"provider_limit_rebuffs":682,
+		"agents":[{"name":"scanner","state":"running","quotaExhausted":true}]
+	}`
+	rec := postHeartbeat(t, s, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.registry.Hives) != 1 {
+		t.Fatalf("stored %d hives, want 1", len(s.registry.Hives))
+	}
+	h := s.registry.Hives[0]
+	if h.ProviderLimitReason != "provider spending limit reached — 682 refused calls" || h.ProviderLimitRebuffs != 682 {
+		t.Fatalf("provider limit fields not stored: reason=%q rebuffs=%d", h.ProviderLimitReason, h.ProviderLimitRebuffs)
+	}
+	if len(h.Agents) != 1 || !h.Agents[0].QuotaExhausted {
+		t.Fatalf("agent quota flag not stored: %+v", h.Agents)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3656,6 +3656,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 				RepoTargetMisconfigured: result[i].RepoTargetMisconfigured,
 				RepoTargetIssue:         result[i].RepoTargetIssue,
 				InferenceAuthError:      result[i].InferenceAuthError,
+				ProviderLimitReason:     result[i].ProviderLimitReason,
 			}
 			rollup := rollupAgents(result[i].Agents, blockers, queuedWork, journeyNow)
 			result[i].FleetRollup = &rollup

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -145,8 +145,13 @@ type RegistryEntry struct {
 	// hive, also trips advisory staleness immediately with this cause. Self-
 	// clears when inference recovers. Never carries key material.
 	InferenceAuthError string `json:"inferenceAuthError,omitempty"`
-	PrimaryRepo        string `json:"primaryRepo"`
-	DashboardURL       string `json:"dashboardUrl"`
+	// ProviderLimitReason is the spoke-reported provider spending/quota refusal
+	// banner. It is separate from BudgetExhausted, which is hive-local governor
+	// budget; this means the upstream provider is refusing token purchases.
+	ProviderLimitReason  string `json:"providerLimitReason,omitempty"`
+	ProviderLimitRebuffs int    `json:"providerLimitRebuffs,omitempty"`
+	PrimaryRepo          string `json:"primaryRepo"`
+	DashboardURL         string `json:"dashboardUrl"`
 	// PublicURLSelfCheck is the spoke's own reachability verdict for
 	// DashboardURL. It is intentionally separate from the hub-side probe:
 	// private-network hives may be unreachable from the public hub while alive
@@ -1668,12 +1673,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AdvisoryError:         sanitizeProseField(payload.AdvisoryError),
 		// Inference-backend auth-failure signal. Sanitized like every other
 		// spoke-reported string; empty is preserved as empty (no signal).
-		InferenceAuthError: sanitizeField(payload.InferenceAuthError),
-		DashboardURL:       payload.DashboardURL,
-		PublicURLSelfCheck: sanitizePublicURLSelfCheck(payload.PublicURLSelfCheck),
-		RouteExists:        sanitizeRouteExistenceCheck(payload.RouteExists),
-		SnapshotURL:        payload.SnapshotURL,
-		ACMMLevel:          clampInt(payload.ACMMLevel, 0, 6),
+		InferenceAuthError:   sanitizeField(payload.InferenceAuthError),
+		ProviderLimitReason:  sanitizeProseField(payload.ProviderLimitReason),
+		ProviderLimitRebuffs: clampInt(payload.ProviderLimitRebuffs, 0, 1_000_000),
+		DashboardURL:         payload.DashboardURL,
+		PublicURLSelfCheck:   sanitizePublicURLSelfCheck(payload.PublicURLSelfCheck),
+		RouteExists:          sanitizeRouteExistenceCheck(payload.RouteExists),
+		SnapshotURL:          payload.SnapshotURL,
+		ACMMLevel:            clampInt(payload.ACMMLevel, 0, 6),
 		AgentCount: func() int {
 			count := 0
 			for _, a := range payload.Agents {

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -612,11 +612,12 @@ function budgetHealthHTML(b) {
   b = b || {};
   var bucket = b.bucket || "unknown";
   var pct = Math.round(b.percentUsed || 0);
-  var label = bucket === "unknown" ? (b.ignored ? "budget ignored" : "budget n/a") : "budget " + pct + "%";
+  var label = b.providerLimited ? "provider quota exhausted" : (bucket === "unknown" ? (b.ignored ? "budget ignored" : "budget n/a") : "budget " + pct + "%");
   var title = bucket === "unknown"
     ? label
     : "budget " + pct + "% used this window (" + (b.usedTokens || 0) + " / " + (b.limitTokens || 0) + " tokens)";
-  if (b.exhausted) title += " — exhausted; governor may throttle";
+  if (b.providerLimited) title = b.reason || label;
+  if (b.exhausted && !b.providerLimited) title += " — exhausted; governor may throttle";
   return '<span class="budget-health ' + esc(bucket) + '" title="' + esc(title) + '">' +
     '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
 }


### PR DESCRIPTION
## Summary
- wire spoke provider spending-limit latch into heartbeat/registry
- detect per-agent quota-exhaustion pane text and surface it as quota-exhausted
- cover Copilot monthly quota, Copilot Free exhaustion, LiteLLM budget_exceeded, and bob Bobcoins/status-bar exhaustion
- prioritize provider/quota verdicts above idle-with-work on /fleet
- make the /fleet budget chip red `provider quota exhausted` instead of gray `budget n/a` for provider-side quota

## Live notes
- LiteLLM provider-limit state already lived in `inferenceBudgetState` and dashboard alerts, but was not carried in heartbeat/registry.
- Laredo/Copilot and bob cases are pane-derived, so the spoke now raises the same provider-limit surface from `QuotaExhausted` agents even without a proxy latch.

## Tests
- go test ./pkg/hub/... ./pkg/agent/...
- go test ./cmd/hive -run TestProviderLimitHeartbeatFieldsFallsBackToAgentQuota -count=1