### PR TITLE
✨ Fleet title-line: user avatars+hovercards, agent cadence, alpha sort, roster-mismatch warning

### DIFF
--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -1,8 +1,12 @@
 package hub
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 // Fleet-divergence derivation.
@@ -404,27 +408,28 @@ type agentFleetRollup struct {
 // capability, deltas). runState is a string so the frontend never re-derives
 // the state machine.
 type AgentVerdictJSON struct {
-	Name           string `json:"name"`
-	Backend        string `json:"backend,omitempty"`
-	Mode           string `json:"mode,omitempty"`
-	Enabled        bool   `json:"enabled"`
-	ExpectedActive bool   `json:"expectedActive"`
-	State          string `json:"state,omitempty"`
-	RunState       string `json:"runState"`
-	LastActivityAt string `json:"lastActivityAt,omitempty"`
-	Paused         bool   `json:"paused,omitempty"`
-	PausedBy       string `json:"pausedBy,omitempty"`
-	PausedTrigger  string `json:"pausedTrigger,omitempty"`
-	PausedReason   string `json:"pausedReason,omitempty"`
-	PausedAt       string `json:"pausedAt,omitempty"`
-	CanOpenIssue   bool   `json:"canOpenIssue"`
-	CanOpenPR      bool   `json:"canOpenPR"`
-	CanMerge       bool   `json:"canMerge"`
-	Able           bool   `json:"able"`
-	CapabilityTier string `json:"capabilityTier"`
-	Stuck          bool   `json:"stuck,omitempty"`
-	Impotent       bool   `json:"impotent,omitempty"`
-	QuietByDesign  bool   `json:"quietByDesign,omitempty"`
+	Name            string `json:"name"`
+	Backend         string `json:"backend,omitempty"`
+	Mode            string `json:"mode,omitempty"`
+	Enabled         bool   `json:"enabled"`
+	ExpectedActive  bool   `json:"expectedActive"`
+	KickIntervalSec int64  `json:"kickIntervalSec,omitempty"`
+	State           string `json:"state,omitempty"`
+	RunState        string `json:"runState"`
+	LastActivityAt  string `json:"lastActivityAt,omitempty"`
+	Paused          bool   `json:"paused,omitempty"`
+	PausedBy        string `json:"pausedBy,omitempty"`
+	PausedTrigger   string `json:"pausedTrigger,omitempty"`
+	PausedReason    string `json:"pausedReason,omitempty"`
+	PausedAt        string `json:"pausedAt,omitempty"`
+	CanOpenIssue    bool   `json:"canOpenIssue"`
+	CanOpenPR       bool   `json:"canOpenPR"`
+	CanMerge        bool   `json:"canMerge"`
+	Able            bool   `json:"able"`
+	CapabilityTier  string `json:"capabilityTier"`
+	Stuck           bool   `json:"stuck,omitempty"`
+	Impotent        bool   `json:"impotent,omitempty"`
+	QuietByDesign   bool   `json:"quietByDesign,omitempty"`
 	// Problem is THE alarm: governor expects this agent on and it can't deliver.
 	Problem bool `json:"problem,omitempty"`
 	// Unknown means the spoke did not report the new divergence signals (legacy
@@ -443,33 +448,105 @@ func buildAgentVerdicts(agents []AgentSummary, blockers hiveBlockers, queuedWork
 		}
 		v := deriveAgentVerdict(a, blockers, queuedWork, now)
 		out = append(out, AgentVerdictJSON{
-			Name:           a.Name,
-			Backend:        a.Backend,
-			Mode:           a.Mode,
-			Enabled:        a.Enabled,
-			ExpectedActive: a.ExpectedActive,
-			State:          a.State,
-			RunState:       v.RunState.String(),
-			LastActivityAt: a.LastActivityAt,
-			Paused:         a.Paused,
-			PausedBy:       a.PausedBy,
-			PausedTrigger:  a.PausedTrigger,
-			PausedReason:   a.PausedReason,
-			PausedAt:       a.PausedAt,
-			CanOpenIssue:   v.CanOpenIssue,
-			CanOpenPR:      v.CanOpenPR,
-			CanMerge:       v.CanMerge,
-			Able:           v.Able,
-			CapabilityTier: v.CapabilityTier,
-			Stuck:          v.Stuck,
-			Impotent:       v.Impotent,
-			QuietByDesign:  v.QuietByDesign,
-			Problem:        v.Problem,
-			Unknown:        v.CapabilityTier == tierGray,
-			BlockedReason:  v.BlockedReason,
+			Name:            a.Name,
+			Backend:         a.Backend,
+			Mode:            a.Mode,
+			Enabled:         a.Enabled,
+			ExpectedActive:  a.ExpectedActive,
+			KickIntervalSec: a.KickIntervalSec,
+			State:           a.State,
+			RunState:        v.RunState.String(),
+			LastActivityAt:  a.LastActivityAt,
+			Paused:          a.Paused,
+			PausedBy:        a.PausedBy,
+			PausedTrigger:   a.PausedTrigger,
+			PausedReason:    a.PausedReason,
+			PausedAt:        a.PausedAt,
+			CanOpenIssue:    v.CanOpenIssue,
+			CanOpenPR:       v.CanOpenPR,
+			CanMerge:        v.CanMerge,
+			Able:            v.Able,
+			CapabilityTier:  v.CapabilityTier,
+			Stuck:           v.Stuck,
+			Impotent:        v.Impotent,
+			QuietByDesign:   v.QuietByDesign,
+			Problem:         v.Problem,
+			Unknown:         v.CapabilityTier == tierGray,
+			BlockedReason:   v.BlockedReason,
 		})
 	}
+	sort.Slice(out, func(i, j int) bool {
+		li, lj := strings.ToLower(out[i].Name), strings.ToLower(out[j].Name)
+		if li == lj {
+			return out[i].Name < out[j].Name
+		}
+		return li < lj
+	})
 	return out
+}
+
+// agentRosterMismatch is the additive warning shown when a hive's reported
+// agent names drift from the ACMM pack that defines its expected roster.
+type agentRosterMismatch struct {
+	Level      int      `json:"level"`
+	Missing    []string `json:"missing,omitempty"`
+	Unexpected []string `json:"unexpected,omitempty"`
+	Reason     string   `json:"reason"`
+}
+
+func computeAgentRosterMismatch(level int, agents []AgentSummary) *agentRosterMismatch {
+	if level <= 0 || len(agents) == 0 {
+		return nil
+	}
+	pack, err := config.ACMMPackByLevel(level)
+	if err != nil {
+		return nil
+	}
+	expected := make(map[string]struct{}, len(pack.Agents))
+	for _, a := range pack.Agents {
+		name := strings.TrimSpace(a.Name)
+		if name == "" || a.Hidden {
+			continue
+		}
+		expected[name] = struct{}{}
+	}
+	actual := make(map[string]struct{}, len(agents))
+	for _, a := range agents {
+		name := strings.TrimSpace(a.Name)
+		if name == "" {
+			continue
+		}
+		actual[name] = struct{}{}
+	}
+	var missing, unexpected []string
+	for name := range expected {
+		if _, ok := actual[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	for name := range actual {
+		if _, ok := expected[name]; !ok {
+			unexpected = append(unexpected, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+	parts := make([]string, 0, 2)
+	if len(missing) > 0 {
+		parts = append(parts, "missing "+strings.Join(missing, ", "))
+	}
+	if len(unexpected) > 0 {
+		parts = append(parts, "unexpected: "+strings.Join(unexpected, ", "))
+	}
+	return &agentRosterMismatch{
+		Level:      level,
+		Missing:    missing,
+		Unexpected: unexpected,
+		Reason:     fmt.Sprintf("agent roster mismatch for L%d: %s", level, strings.Join(parts, "; ")),
+	}
 }
 
 // rollupAgents summarizes a hive's agents into the divergence counts. It counts

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -360,6 +360,67 @@ func TestBuildAgentVerdicts_ShapeAndSkipBlank(t *testing.T) {
 	}
 }
 
+func TestBuildAgentVerdicts_SortedByAgentName(t *testing.T) {
+	now := time.Now()
+	z := modernWorking(now)
+	z.Name = "zeta"
+	a := modernWorking(now)
+	a.Name = "alpha"
+	m := modernWorking(now)
+	m.Name = "middle"
+
+	out := buildAgentVerdicts([]AgentSummary{z, m, a}, hiveBlockers{}, 5, now)
+	got := []string{out[0].Name, out[1].Name, out[2].Name}
+	want := []string{"alpha", "middle", "zeta"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("agent verdict order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestComputeAgentRosterMismatch_WarningReason(t *testing.T) {
+	agents := []AgentSummary{
+		{Name: "scanner"},
+		{Name: "quality"},
+		{Name: "guide"},
+		{Name: "supervisor"},
+		{Name: "outreach"},
+	}
+	got := computeAgentRosterMismatch(2, agents)
+	if got == nil {
+		t.Fatal("expected mismatch warning")
+	}
+	if got.Reason != "agent roster mismatch for L2: missing brainstorm; unexpected: outreach" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	if len(got.Missing) != 1 || got.Missing[0] != "brainstorm" {
+		t.Fatalf("missing = %v, want [brainstorm]", got.Missing)
+	}
+	if len(got.Unexpected) != 1 || got.Unexpected[0] != "outreach" {
+		t.Fatalf("unexpected = %v, want [outreach]", got.Unexpected)
+	}
+}
+
+func TestComputeAgentRosterMismatch_NoWarningForMatchingOrUnknown(t *testing.T) {
+	matching := []AgentSummary{
+		{Name: "brainstorm"},
+		{Name: "guide"},
+		{Name: "quality"},
+		{Name: "scanner"},
+		{Name: "supervisor"},
+	}
+	if got := computeAgentRosterMismatch(2, matching); got != nil {
+		t.Fatalf("matching roster got warning %+v", got)
+	}
+	if got := computeAgentRosterMismatch(99, []AgentSummary{{Name: "scanner"}}); got != nil {
+		t.Fatalf("unknown level got warning %+v", got)
+	}
+	if got := computeAgentRosterMismatch(2, nil); got != nil {
+		t.Fatalf("missing legacy agent data got warning %+v", got)
+	}
+}
+
 // PROBLEM = governor expects it on AND it can't deliver, for any reason. It
 // unifies stuck/impotent/blocked and never fires on paused/off/legacy agents.
 func TestVerdict_ProblemFlag(t *testing.T) {

--- a/src/pkg/hub/fleet_titleline_ui_test.go
+++ b/src/pkg/hub/fleet_titleline_ui_test.go
@@ -1,0 +1,46 @@
+package hub
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func fleetStaticHTML(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("static/my-hives.html")
+	if err != nil {
+		t.Fatalf("read fleet static html: %v", err)
+	}
+	return string(b)
+}
+
+func TestFleetTitleLineReusesAccessAvatarHelpers(t *testing.T) {
+	html := fleetStaticHTML(t)
+	for _, want := range []string{
+		"function accessAvatarTitle(a)",
+		"function inlineAccessAvatar(a)",
+		"function hiveAccessAvatars(h)",
+		"return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a),",
+		"hiveNameHTML(h) + hiveAccessAvatars(h)",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("fleet static html missing %q", want)
+		}
+	}
+}
+
+func TestFleetShowsCadenceAndRosterWarning(t *testing.T) {
+	html := fleetStaticHTML(t)
+	for _, want := range []string{
+		`rs === "working" && a.kickIntervalSec`,
+		"function formatCadence(seconds)",
+		"function rosterMismatchChipHTML(h)",
+		"agent roster mismatch",
+		`if (h.agentRosterMismatch && h.agentRosterMismatch.reason) add("agent roster"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("fleet static html missing %q", want)
+		}
+	}
+}

--- a/src/pkg/hub/heartbeat_logic_coverage_test.go
+++ b/src/pkg/hub/heartbeat_logic_coverage_test.go
@@ -29,6 +29,7 @@ func TestNewAgentSummary_AllFields(t *testing.T) {
 		SessionMissing: true,
 		StartedAt:      started,
 		LastActivityAt: lastAct,
+		KickInterval:   4 * time.Hour,
 	}
 	as := NewAgentSummary("scanner", "running", "auto", act)
 	if as.Name != "scanner" {
@@ -54,6 +55,9 @@ func TestNewAgentSummary_AllFields(t *testing.T) {
 	}
 	if as.LastActivityAt != "2026-01-15T11:00:00Z" {
 		t.Errorf("LastActivityAt = %q, want 2026-01-15T11:00:00Z", as.LastActivityAt)
+	}
+	if as.KickIntervalSec != int64((4 * time.Hour / time.Second)) {
+		t.Errorf("KickIntervalSec = %d, want 14400", as.KickIntervalSec)
 	}
 }
 

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3150,6 +3150,12 @@ type MyHiveEntry struct {
 	FleetRollup   *agentFleetRollup  `json:"fleetRollup,omitempty"`
 	AgentVerdicts []AgentVerdictJSON `json:"agentVerdicts,omitempty"`
 
+	// AgentRosterMismatch is an additive warning when the spoke's reported
+	// agent list no longer matches the ACMM pack roster for its level. It does
+	// not change the red/green hive verdict; red production failures still
+	// outrank this yellow configuration-drift signal.
+	AgentRosterMismatch *agentRosterMismatch `json:"agentRosterMismatch,omitempty"`
+
 	// HealthVerdict is the at-a-glance hive-health verdict (hive-health): does
 	// this spoke have RECENT OUTPUT back to its work source, banded by ACMM
 	// level? green/red/unknown with a WHY reason, computed on read from the same
@@ -3654,6 +3660,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			rollup := rollupAgents(result[i].Agents, blockers, queuedWork, journeyNow)
 			result[i].FleetRollup = &rollup
 			result[i].AgentVerdicts = buildAgentVerdicts(result[i].Agents, blockers, queuedWork, journeyNow)
+			result[i].AgentRosterMismatch = computeAgentRosterMismatch(result[i].ACMMLevel, result[i].Agents)
 
 			// Hive-health verdict: reuse the rollup + app-health + queue depth we
 			// just computed. Only for real (non-placeholder) hives with reported

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -166,7 +166,9 @@
      broken hive reads at a glance. */
   .why-chip { display: inline-block; margin-left: 6px; padding: 1px 7px; border-radius: 9px; font-size: 10.5px; color: var(--gray); border: 1px solid var(--border, rgba(128,128,128,.3)); vertical-align: 1px; }
   .why-chip.bad { color: var(--red); border-color: rgba(229,72,77,.45); background: rgba(229,72,77,.06); }
+  .why-chip.warn { color: var(--amber); border-color: rgba(224,168,0,.55); background: rgba(224,168,0,.08); }
   .why-chip.unknown { color: var(--gray); border-style: dashed; }
+  .hive-access-faces a:hover img { filter: brightness(1.12); }
   /* Attach chip: one-click copy of the kubectl+tmux attach command for the
      hive's spoke pod, so an operator can jump from a problematic /fleet row
      straight into the pod for root-causing. Shows cluster · namespace on
@@ -321,6 +323,15 @@ function esc(s) {
     return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
   });
 }
+function escAttr(s) { return esc(s).replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
+function jsArg(s) {
+  var lit = "'" + String(s === null || s === undefined ? "" : s)
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n") + "'";
+  return esc(lit);
+}
 function relTime(iso) {
   if (!iso) return "";
   var t = Date.parse(iso);
@@ -333,6 +344,113 @@ function relTime(iso) {
 }
 function acmmBadge(lvl) { return '<span class="badge">L' + esc(lvl == null ? "?" : lvl) + '</span>'; }
 function modeBadge(m) { return '<span class="badge">' + esc(m || "—") + '</span>'; }
+
+var AVATAR_HIDPI_SCALE = 2;
+var INLINE_ACCESS_AVATAR_MAX = 4;
+var INLINE_ACCESS_AVATAR_PX = 16;
+var ACCESS_ROLE_COLORS = {"owner": "#d29922", "merger": "#a371f7", "read-write": "#3fb950"};
+var ACCESS_ROLE_COLOR_DEFAULT = "#6b7280";
+var AVATAR_FALLBACK_HUES = [0, 25, 50, 145, 175, 200, 230, 260, 290, 330];
+var _liveHiveUsers = new Set();
+
+function accessRoleColor(role) {
+  return ACCESS_ROLE_COLORS[role] || ACCESS_ROLE_COLOR_DEFAULT;
+}
+function ghProfileURL(username) {
+  return "https://github.com/" + encodeURIComponent(String(username || ""));
+}
+function avatarInitials(username) {
+  var clean = String(username || "").replace(/[^A-Za-z0-9]/g, "");
+  if (!clean) return "?";
+  return clean.length === 1 ? clean.charAt(0).toUpperCase() : (clean.charAt(0) + clean.charAt(clean.length - 1)).toUpperCase();
+}
+function avatarFallbackHue(username) {
+  var s = String(username || ""), hash = 0;
+  for (var i = 0; i < s.length; i++) hash = (hash * 31 + s.charCodeAt(i)) >>> 0;
+  return AVATAR_FALLBACK_HUES[hash % AVATAR_FALLBACK_HUES.length];
+}
+function avatarInitialsSVG(username, px) {
+  var initials = avatarInitials(username), hue = avatarFallbackHue(username);
+  var r = px / 2, fontSize = Math.round(px * 0.42);
+  var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + px + '" height="' + px + '" viewBox="0 0 ' + px + ' ' + px + '">' +
+    '<circle cx="' + r + '" cy="' + r + '" r="' + r + '" fill="hsl(' + hue + ',45%,32%)"/>' +
+    '<text x="50%" y="50%" dy="0.35em" text-anchor="middle" font-family="system-ui,sans-serif" font-size="' + fontSize + '" font-weight="600" fill="#fff">' +
+    initials + '</text></svg>';
+  return "data:image/svg+xml;charset=UTF-8," + encodeURIComponent(svg);
+}
+function isUserLive(username) {
+  try { return _liveHiveUsers && _liveHiveUsers.has(String(username || "").toLowerCase()); }
+  catch (e) { return false; }
+}
+function avatarProfileLink(username, label, avatarHTML) {
+  var uname = String(username || "");
+  if (!uname) return avatarHTML;
+  var title = label || uname;
+  if (isUserLive(uname)) title = title + "\n● Logged into their hive now";
+  return '<a href="' + escAttr(ghProfileURL(uname)) + '" target="_blank" rel="noopener noreferrer" ' +
+    'title="' + escAttr(title) + '" aria-label="' + escAttr(label || uname) + '" ' +
+    'style="display:inline-block;line-height:0;text-decoration:none">' + avatarHTML + "</a>";
+}
+function avatarImg(username, px, extraStyle) {
+  var img = '<img src="' + escAttr(ghProfileURL(username)) + '.png?size=' + (px * AVATAR_HIDPI_SCALE) + '" alt="" ' +
+    'style="width:' + px + 'px;height:' + px + 'px;border-radius:50%;vertical-align:middle;' + (extraStyle || "") + '" ' +
+    'onerror="this.onerror=null;this.src=' + jsArg(avatarInitialsSVG(username, px)) + '">';
+  if (isUserLive(username)) {
+    var RING_GAP = 2, RING_W = 3, box = px + 2 * (RING_GAP + RING_W);
+    return '<span style="display:inline-block;box-sizing:border-box;width:' + box + 'px;height:' + box + 'px;' +
+      'padding:' + RING_GAP + 'px;border:' + RING_W + 'px dashed var(--green);border-radius:50%;' +
+      'vertical-align:middle;line-height:0">' + img + "</span>";
+  }
+  return img;
+}
+function linkedAvatar(username, px, label, extraStyle) {
+  return avatarProfileLink(username, label, avatarImg(username, px, extraStyle));
+}
+function fmtHours(secs) {
+  secs = Number(secs) || 0;
+  if (secs <= 0) return "0h";
+  var h = secs / 3600;
+  return h >= 10 ? Math.round(h) + "h" : h.toFixed(1).replace(/\.0$/, "") + "h";
+}
+function fmtUserTS(ts) { return ts ? relTime(ts) : ""; }
+function userTaskActivity() { return {done: 0, failed: 0}; }
+function userVerdict() { return null; }
+function accessAvatarTitle(a) {
+  var uname = String((a || {}).username || "");
+  var role = String((a || {}).role || "");
+  var lines = [uname + (role ? " — " + role : "")];
+  if (a && a.full_name) lines.push(String(a.full_name));
+  if (a && a.slack_id) lines.push("Slack: " + String(a.slack_id));
+  if (a && a.notes) lines.push("Notes: " + String(a.notes));
+  if (a && a.login_count) lines.push("Logins: " + a.login_count);
+  if (a && a.session_seconds) lines.push("Time in hive: " + fmtHours(a.session_seconds));
+  if (a && a.engaged_seconds) lines.push("Engaged time: " + fmtHours(a.engaged_seconds));
+  if (a && a.last_action_at) lines.push("Last real action: " + fmtUserTS(a.last_action_at));
+  return lines.join("\n");
+}
+function inlineAccessAvatar(a) {
+  var uname = String((a || {}).username || "");
+  var role = String((a || {}).role || "");
+  return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a),
+    "border:1px solid " + accessRoleColor(role) + ";background:var(--panel);flex:0 0 auto");
+}
+function hiveAccessAvatars(h) {
+  var members = (h && h.access) || [];
+  if (!members.length) return "";
+  var shown = members.slice(0, INLINE_ACCESS_AVATAR_MAX);
+  var faces = "";
+  for (var i = 0; i < shown.length; i++) faces += inlineAccessAvatar(shown[i]);
+  var overflow = members.length - shown.length;
+  if (overflow > 0) {
+    var hiddenNames = [];
+    for (var j = shown.length; j < members.length; j++) hiddenNames.push(String(members[j].username || ""));
+    faces += '<span title="' + escAttr(hiddenNames.join(", ")) + '" ' +
+      'style="font-size:0.62rem;color:var(--muted);font-weight:600;white-space:nowrap;cursor:help">+' + overflow + "</span>";
+  }
+  var label = members.length === 1 ? "1 user with access" : members.length + " users with access";
+  return '<span class="hive-access-faces" aria-label="' + escAttr(label) + '" ' +
+    'style="display:inline-flex;align-items:center;gap:2px;margin-left:6px;vertical-align:middle">' + faces + "</span>";
+}
 
 function rollupHTML(r) {
   if (!r) return '<span class="output">no agents reported</span>';
@@ -476,6 +594,7 @@ function diagnosisHTML(h) {
     add("blocked agents", blocked.map(function (a) { return esc(a.name) + ": " + esc(a.blockedReason); }).join(" · "), true);
   }
   if (h.inactiveAgentsReason) add("inactive agents", esc(h.inactiveAgentsReason), true);
+  if (h.agentRosterMismatch && h.agentRosterMismatch.reason) add("agent roster", esc(h.agentRosterMismatch.reason), false);
   if (h.urlUnreachableReason) add("dashboard url", esc(h.urlUnreachableReason), true);
   if (!h.online && h.lastHeartbeat) add("last heartbeat", esc(relTime(h.lastHeartbeat)), true);
   if (!rows.length) return "";
@@ -564,7 +683,16 @@ function runStateHTML(a) {
   var rs = a.unknown ? "unknown" : (a.runState || "unknown");
   var label = RUN_STATE_LABELS[rs] || rs.replace(/-/g, " ");
   var rel = a.lastActivityAt ? ' <span class="rel">' + esc(relTime(a.lastActivityAt)) + '</span>' : "";
-  return '<span class="rs ' + esc(rs) + '"><span class="swatch"></span>' + esc(label) + '</span>' + rel;
+  var cadence = rs === "working" && a.kickIntervalSec ? ' <span class="rel">· ' + esc(formatCadence(a.kickIntervalSec)) + '</span>' : "";
+  return '<span class="rs ' + esc(rs) + '"><span class="swatch"></span>' + esc(label) + '</span>' + cadence + rel;
+}
+function formatCadence(seconds) {
+  var s = Number(seconds) || 0;
+  if (s <= 0) return "";
+  if (s % 86400 === 0) return (s / 86400) + "d";
+  if (s % 3600 === 0) return (s / 3600) + "h";
+  if (s % 60 === 0) return (s / 60) + "m";
+  return s + "s";
 }
 function capHTML(a) {
   // Unknown (legacy): a single "unknown" chip, NOT red ✗ ticks — we cannot see
@@ -632,6 +760,11 @@ function whyChipHTML(h, health) {
   if (!v || !v.reason) return "";
   var cls = v.state === "red" ? "why-chip bad" : (v.state === "unknown" ? "why-chip unknown" : "why-chip");
   return '<span class="' + cls + '" title="' + esc(v.outputKind ? "output judged on: " + v.outputKind : "hive-health") + '">' + esc(v.reason) + '</span>';
+}
+function rosterMismatchChipHTML(h) {
+  var m = h.agentRosterMismatch || {};
+  if (!m.reason) return "";
+  return '<span class="why-chip warn" title="' + esc(m.reason) + '">agent roster mismatch</span>';
 }
 
 // Expand state persists across the 30s refresh (keyed by hive id) so an open
@@ -714,7 +847,7 @@ function renderHives(hives) {
     tr.className = "spoke health-" + health + (open ? " open" : "");
     tr.innerHTML =
       '<td><span class="chev">▶</span></td>' +
-      '<td><span class="hdot ' + health + '" title="' + health + '"></span>' + hiveNameHTML(h) + (health === "parked" ? '<span class="parked-chip" title="every agent is paused or off-schedule — hive not in use">parked</span>' : "") + whyChipHTML(h, health) + attachChipHTML(h) + '</td>' +
+      '<td><span class="hdot ' + health + '" title="' + health + '"></span>' + hiveNameHTML(h) + hiveAccessAvatars(h) + (health === "parked" ? '<span class="parked-chip" title="every agent is paused or off-schedule — hive not in use">parked</span>' : "") + whyChipHTML(h, health) + rosterMismatchChipHTML(h) + attachChipHTML(h) + '</td>' +
       '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
       '<td>' + modeBadge(h.governorMode) + '</td>' +
       '<td>' + versionHTML(h) + '</td>' +
@@ -723,6 +856,9 @@ function renderHives(hives) {
     tb.appendChild(tr);
     var link = tr.querySelector(".hive-link");
     if (link) link.addEventListener("click", function (e) { e.stopPropagation(); });
+    tr.querySelectorAll(".hive-access-faces a").forEach(function (a) {
+      a.addEventListener("click", function (e) { e.stopPropagation(); });
+    });
 
     var verdicts = h.agentVerdicts || [];
     var subRows = [];
@@ -739,9 +875,9 @@ function renderHives(hives) {
       tb.appendChild(drow);
       subRows.push(drow);
     }
-    // In an expanded problem hive, float the problem agents to the top.
+    // Agent rows stay alphabetical so the same agent is always in the same place.
     var ordered = verdicts.slice().sort(function (a, b) {
-      return (b.problem ? 1 : 0) - (a.problem ? 1 : 0);
+      return String(a.name || "").localeCompare(String(b.name || ""));
     });
     ordered.forEach(function (a) {
       var sub = document.createElement("tr");


### PR DESCRIPTION
## Summary
- add access avatars on /fleet hive title lines using the same access avatar helpers/data as My Hives
- carry per-agent kick cadence as kickIntervalSec and show it on should-be-working agent sub-rows
- sort agent verdict sub-rows alphabetically and add ACMM pack roster mismatch warnings without overriding red verdicts

## Tests
- go test ./pkg/hub/...
- go test ./cmd/hive

Code review: no significant issues found.