### PR TITLE
🐛 Renew terminal access before opening hosted terminals

### DIFF
--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4340,7 +4340,7 @@
             : !dashboardRoleAtLeast(window._hiveRole || 'read', 'owner')
             ? ''
             : `<button class="btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="${isPaused}" title="${isPaused ? 'Resume this agent — it will start running on its configured cadence' : isOff ? 'Start this agent — it is currently off in this governor mode' : 'Pause this agent — stops governor from kicking it until resumed'}">${isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause'}</button>`}
-          <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>
+          <a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>
           <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>
           <a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>
           <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Browse archived logs of this agent's previous kicks — history survives restarts and hive upgrades">🕘 past kicks</a>
@@ -5858,12 +5858,45 @@
 
     const TMUX_SESSION_PREFIX = 'hive-';
     const TTYD_PORT = 7681;
+    const TERMINAL_ASSERTION_RENEW_PATH = '/api/terminal/assertion/renew';
     function terminalUrl(agentName) {
       const session = TMUX_SESSION_PREFIX + agentName;
       const proto = window.location.protocol;
       const host = window.location.host;
       const t = localStorage.getItem('hive-token'); const tokenParam = t ? `&token=${encodeURIComponent(t)}` : '';
       return `${proto}//${host}/terminal/?arg=${encodeURIComponent(session)}${tokenParam}`;
+    }
+    function isHostedHiveHost() {
+      return (window.location.hostname || '').toLowerCase().endsWith('.hive.kubestellar.io');
+    }
+    async function renewTerminalAssertion() {
+      if (!isHostedHiveHost()) return true;
+      try {
+        const resp = await fetch(TERMINAL_ASSERTION_RENEW_PATH, {
+          method: 'POST',
+          credentials: 'same-origin',
+          cache: 'no-store',
+        });
+        if (resp.status === 204) return true;
+        if (resp.status === 401) showToast('Sign in to this hive before opening a terminal.', 'error');
+        else if (resp.status === 403) showToast('Your current hive role cannot open terminals.', 'error');
+        else showToast('Could not refresh terminal access (HTTP ' + resp.status + ').', 'error');
+      } catch (e) {
+        showToast('Could not refresh terminal access: ' + e.message, 'error');
+      }
+      return false;
+    }
+    async function openTerminal(agentName, href) {
+      const url = href || terminalUrl(agentName);
+      const tab = window.open('about:blank', '_blank');
+      if (tab) tab.opener = null;
+      const ok = await renewTerminalAssertion();
+      if (ok) {
+        if (tab) tab.location.href = url;
+        else window.open(url, '_blank', 'noopener');
+      } else if (tab) {
+        tab.close();
+      }
     }
 
     // fullLogUrl points at the server-side endpoint that captures the agent's
@@ -5982,7 +6015,7 @@
         const configTarget = a.replicaBase || a.name;
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Archived logs of previous kicks — survives restarts and upgrades">🕘 past kicks</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Archived logs of previous kicks — survives restarts and upgrades">🕘 past kicks</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
@@ -13528,6 +13561,7 @@ function burnAreaChart() {
         case 'ocSelectAgent': { if (!e.target.closest('.oc-nav-actions')) ocSelectAgent(agent); } break;
         case 'kick': kick(agent); break;
         case 'kickEmpty': { const inp = document.getElementById('kick-prompt-' + agent); if (inp) inp.value = ''; kick(agent); } break;
+        case 'openTerminal': e.preventDefault(); openTerminal(agent, el.href); break;
         case 'togglePin': togglePin(agent, el.dataset.pinType, el.dataset.unpin === 'true'); break;
         case 'resetRestarts': resetRestarts(agent); break;
         case 'deleteAgentFromConfig': deleteAgentFromConfig(agent); break;
@@ -22266,7 +22300,7 @@ function burnAreaChart() {
     function welcomeOpenTerminal() {
       const name = _welcomeFirstAgentName();
       if (!name) { showToast('No agents yet — terminals open from each agent card', 'info'); return; }
-      window.open(terminalUrl(name), '_blank', 'noopener');
+      openTerminal(name);
     }
     /** Open the GitHub App install page (same URL the banner links to). */
     function welcomeInstallGitHubApp() {

--- a/src/pkg/dashboard/static_index_test.go
+++ b/src/pkg/dashboard/static_index_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -150,5 +151,28 @@ func TestAcceptsGzip(t *testing.T) {
 		if got := acceptsGzip(c.header); got != c.want {
 			t.Errorf("acceptsGzip(%q) = %v, want %v", c.header, got, c.want)
 		}
+	}
+}
+
+func TestStaticTerminalLinksRenewAssertionBeforeOpening(t *testing.T) {
+	body, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	html := string(body)
+	for _, want := range []string{
+		"const TERMINAL_ASSERTION_RENEW_PATH = '/api/terminal/assertion/renew';",
+		"async function renewTerminalAssertion()",
+		"credentials: 'same-origin'",
+		"case 'openTerminal': e.preventDefault(); openTerminal(agent, el.href); break;",
+		"data-action=\"openTerminal\"",
+		"openTerminal(name);",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("static dashboard terminal renewal wiring missing %q", want)
+		}
+	}
+	if strings.Contains(html, "window.open(terminalUrl(name), '_blank', 'noopener');") {
+		t.Fatal("welcome terminal action still opens /terminal directly without renewing the assertion")
 	}
 }


### PR DESCRIPTION
## Summary
- renew hosted terminal assertions via POST /api/terminal/assertion/renew before opening /terminal links
- preserve non-hosted terminal token behavior by only renewing on *.hive.kubestellar.io hosts
- add a static dashboard regression test for terminal renewal wiring

## Diagnosis
Live logs for hosted-kubestellar-console-4vkt showed [terminal] 403 for clubanderson. The spoke config lists clubanderson:owner, but the proxy process has no HIVE_AUTHORIZED_USERS fallback env, so an expired/missing 15-minute terminal assertion falls through to fail-closed 403. The dashboard previously opened /terminal directly and never called the renewal endpoint.

## Tests
- cd src && go test ./pkg/dashboard -count=1
- cd src/proxy && npm test
- cd src/proxy && npm run build --if-present && npm run lint --if-present