### PR TITLE
fix(contributor): prevent unattended Codex approval prompts

### DIFF
--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -232,6 +232,74 @@ case "$codex_reviewer_override_output" in
     ;;
 esac
 
+# An EXPLICITLY EMPTY reviewer must drop the -c key while KEEPING the sandbox.
+# This is the escape hatch for a Codex release that rejects the unknown
+# approvals_reviewer config key at startup: without it the only way out is
+# HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1, i.e. no sandbox at all.
+# ${VAR:-default} would defeat this by treating empty as unset, so the guard is
+# the parameter expansion as much as the branch.
+codex_reviewer_disabled_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_CODEX_APPROVALS_REVIEWER= \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/workspace" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+case "$codex_reviewer_disabled_output" in
+  *"approvals_reviewer"* )
+    echo "expected an empty HIVE_CODEX_APPROVALS_REVIEWER to drop the -c key; got:" >&2
+    echo "$codex_reviewer_disabled_output" >&2
+    exit 1
+    ;;
+esac
+# ...but the sandbox posture and the workspace grant must survive.
+case "$codex_reviewer_disabled_output" in
+  *"backend_perm_flag=--ask-for-approval on-request --sandbox workspace-write --add-dir ${WORK_DIR}/workspace"* ) ;;
+  *)
+    echo "expected the sandbox posture to survive a disabled reviewer; got:" >&2
+    echo "$codex_reviewer_disabled_output" >&2
+    exit 1
+    ;;
+esac
+
+# A workspace path containing whitespace CANNOT be expressed: the caller
+# word-splits this string (agent-launch.sh: read -r -a PERM_ARGS <<< ...), so
+# "--add-dir /work space" would arrive as three argv words and grant Codex the
+# wrong directory. The flag must be omitted, not silently corrupted.
+mkdir -p "${WORK_DIR}/work space"
+codex_spaced_workspace_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/work space" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh" 2>/dev/null
+)"
+case "$codex_spaced_workspace_output" in
+  *"--add-dir"* )
+    echo "expected --add-dir to be omitted for a whitespace workspace path; got:" >&2
+    echo "$codex_spaced_workspace_output" >&2
+    exit 1
+    ;;
+esac
+# The sandbox posture still applies — only the ungrantable flag is dropped.
+case "$codex_spaced_workspace_output" in
+  *"backend_perm_flag=--ask-for-approval on-request --sandbox workspace-write -c approvals_reviewer=auto_review"* ) ;;
+  *)
+    echo "expected the sandbox posture to survive a whitespace workspace path; got:" >&2
+    echo "$codex_spaced_workspace_output" >&2
+    exit 1
+    ;;
+esac
+
 codex_bypass_output="$(
   env -i \
     PATH="${PATH}" \

--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -197,15 +197,37 @@ codex_flags_output="$(
     HOME="$HOME_DIR" \
     HIVE_REGISTRATION_TOKEN="test-token" \
     HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/workspace" \
     HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
     AGENT_BACKEND=codex \
     bash "${ROOT_DIR}/bin/contributor-agent.sh"
 )"
 case "$codex_flags_output" in
-  *"backend_perm_flag=--ask-for-approval on-request --sandbox workspace-write"* ) ;;
+  *"backend_perm_flag=--ask-for-approval on-request --sandbox workspace-write -c approvals_reviewer=auto_review --add-dir ${WORK_DIR}/workspace"* ) ;;
   *)
-    echo "expected codex default posture to be explicit and non-bypass; got:" >&2
+    echo "expected codex default posture to auto-review and include the task workspace; got:" >&2
     echo "$codex_flags_output" >&2
+    exit 1
+    ;;
+esac
+
+codex_reviewer_override_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_CODEX_APPROVALS_REVIEWER=user \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/workspace" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=codex \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+case "$codex_reviewer_override_output" in
+  *"-c approvals_reviewer=user --add-dir ${WORK_DIR}/workspace"* ) ;;
+  *)
+    echo "expected codex reviewer override to be preserved; got:" >&2
+    echo "$codex_reviewer_override_output" >&2
     exit 1
     ;;
 esac
@@ -217,6 +239,7 @@ codex_bypass_output="$(
     HIVE_REGISTRATION_TOKEN="test-token" \
     HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
     HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1 \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/workspace" \
     HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
     AGENT_BACKEND=codex \
     bash "${ROOT_DIR}/bin/contributor-agent.sh"
@@ -225,6 +248,13 @@ case "$codex_bypass_output" in
   *"backend_perm_flag=--dangerously-bypass-approvals-and-sandbox"* ) ;;
   *)
     echo "expected codex dangerous bypass to be opt-in; got:" >&2
+    echo "$codex_bypass_output" >&2
+    exit 1
+    ;;
+esac
+case "$codex_bypass_output" in
+  *"approvals_reviewer="*|*"--add-dir"* )
+    echo "dangerous codex bypass must not retain sandbox-only reviewer/workspace flags; got:" >&2
     echo "$codex_bypass_output" >&2
     exit 1
     ;;

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -93,6 +93,11 @@ const MODE_HEADLESS = 'headless';
 const CONTRIBUTOR_MODE = process.env.CONTRIBUTOR_MODE === MODE_HEADLESS
   ? MODE_HEADLESS
   : MODE_INTERACTIVE;
+// contributor-agent.sh creates and exports this before starting the relay. Pin
+// it at process startup just like CONTRIBUTOR_MODE so a later environment
+// mutation cannot make the one-shot CLI run outside the workspace that was
+// granted to Codex with --add-dir.
+const TASK_WORKSPACE_DIR = process.env.HIVE_WORKSPACE_DIR || process.cwd();
 
 // Where the headless runner records its current lifecycle state as JSON, so a
 // supervising process (or a future K8s liveness/readiness probe reading the
@@ -844,7 +849,7 @@ function runHeadlessTask(task) {
     timeout: HEADLESS_TASK_TIMEOUT_MS,
     maxBuffer: HEADLESS_MAX_OUTPUT_BYTES,
     killSignal: 'SIGKILL',
-    cwd: process.env.HIVE_WORKSPACE_DIR || process.cwd(),
+    cwd: TASK_WORKSPACE_DIR,
   }, (err, stdout, stderr) => {
     headlessChild = null;
     // Tokens can appear in agent output; redact before the tail leaves the host.
@@ -855,9 +860,15 @@ function runHeadlessTask(task) {
       // here. err.killed && err.signal signals the timeout; report a real
       // failure either way so the hub can reassign — never a silent hang.
       const timedOut = err.killed === true;
+      // Preserve one bounded, token-redacted diagnostic line. In particular,
+      // Codex automatic-review denial/timeout is an expected terminal outcome
+      // for an unattended run and must reach Hive as an actionable failure,
+      // rather than being flattened to an opaque exit code.
+      const diagnostic = outTail.map(line => line.trim()).filter(Boolean).slice(-1)[0];
+      const diagnosticSuffix = diagnostic ? `: ${diagnostic.slice(0, 500)}` : '';
       const reason = timedOut
         ? `headless task exceeded ${HEADLESS_TASK_TIMEOUT_MS / 60000}min and was killed`
-        : `headless CLI exited with error: ${err.code !== undefined ? `code ${err.code}` : err.message}`;
+        : `headless CLI exited with error: ${err.code !== undefined ? `code ${err.code}` : err.message}${diagnosticSuffix}`;
       finish(() => {
         console.error(`Headless task ${task.task_id} failed: ${reason}`);
         writeHeadlessStatus(HEADLESS_STATE_FAILED, { task_id: task.task_id, reason });

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -25,7 +25,7 @@ const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
 // bash and no WebSocket are ever touched.
 // ---------------------------------------------------------------------------
 
-function loadRelay({ backend = 'copilot', backendBinary = null, model = '', reasoningEffort = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, paneText = null, env = null, cliVersion = null } = {}) {
+function loadRelay({ backend = 'copilot', backendBinary = null, backendPerm = '--allow-all', model = '', reasoningEffort = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, paneText = null, env = null, cliVersion = null } = {}) {
   const commands = [];
   const sent = [];
   // Records every execFile (headless one-shot) invocation: { bin, args, opts }.
@@ -40,7 +40,7 @@ function loadRelay({ backend = 'copilot', backendBinary = null, model = '', reas
     // different BINARY (litellm → claude); it defaults to the identity mapping
     // every other backend has.
     if (/backend_binary/.test(cmd)) return `${backendBinary || backend}\n`;
-    if (/backend_perm_flag/.test(cmd)) return '--allow-all\n';
+    if (/backend_perm_flag/.test(cmd)) return `${backendPerm}\n`;
     if (/capture-pane/.test(cmd)) {
       // paneText, when given, is returned verbatim — for tests that need a
       // REAL pane rendering (e.g. a codex modal menu) rather than one of the
@@ -1614,6 +1614,24 @@ test('a failing headless run reports task_failed rather than hanging', () => {
   } finally { teardown(relay); }
 });
 
+test('a Codex auto-review denial is reported with its actionable diagnostic', () => {
+  const err = new Error('codex failed'); err.code = 1;
+  const relay = loadRelay({
+    backend: 'codex',
+    mode: 'headless',
+    execFileResult: { err, stderr: 'approval automatic review timed out\n' },
+  });
+  try {
+    assignHeadlessTask(relay);
+    const failure = relay.__sent.find(m => m.type === 'task_failed');
+    assert.ok(failure, 'an automatic-review failure must terminate the task');
+    assert.match(failure.reason, /code 1.*automatic review timed out/i,
+      'the redacted CLI diagnostic must reach Hive instead of an opaque exit code');
+    assert.strictEqual(relay.__readHeadlessStatus().reason, failure.reason,
+      'the probe status and hub failure must expose the same terminal reason');
+  } finally { teardown(relay); }
+});
+
 test('a headless timeout kill is reported as a failure, not a completion', () => {
   const err = new Error('timeout'); err.killed = true; err.signal = 'SIGKILL';
   const relay = loadRelay({ backend: 'claude', mode: 'headless', execFileResult: { err } });
@@ -1684,6 +1702,32 @@ test('buildHeadlessArgv maps each supported backend to its one-shot invocation',
         `${tc.backend} must report headless support`);
     } finally { teardown(relay); }
   }
+});
+
+test('Codex headless keeps auto-review bounded to the declared task workspace', () => {
+  const workspace = '/tmp/hive-contributor-workspace';
+  const perm = `--ask-for-approval on-request --sandbox workspace-write -c approvals_reviewer=auto_review --add-dir ${workspace}`;
+  const relay = loadRelay({
+    backend: 'codex',
+    backendPerm: perm,
+    mode: 'headless',
+    env: { HIVE_WORKSPACE_DIR: workspace },
+  });
+  try {
+    const built = relay.buildHeadlessArgv('ship the change');
+    assert.deepStrictEqual(built.args.slice(0, 8), [
+      '--ask-for-approval', 'on-request',
+      '--sandbox', 'workspace-write',
+      '-c', 'approvals_reviewer=auto_review',
+      '--add-dir', workspace,
+    ], `Codex unattended permission argv drifted: ${JSON.stringify(built.args)}`);
+    assignHeadlessTask(relay);
+    const call = relay.__execFileCalls[0];
+    assert.strictEqual(call.opts.cwd, workspace,
+      'the one-shot process cwd and its additional writable root must be the same task workspace');
+    assert.ok(!built.args.includes('--dangerously-bypass-approvals-and-sandbox'),
+      'automatic review must not disable the sandbox');
+  } finally { teardown(relay); }
 });
 
 test('goose headless passes the prompt as -t\'s value and skips --model', () => {

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -83,17 +83,45 @@ backend_perm_flag() {
         # cross its sandbox boundary. Keep the workspace-write sandbox from
         # #3512, but route eligible escalations through Codex's bounded
         # automatic reviewer instead of surfacing an interactive prompt.
-        printf -- '--ask-for-approval %s --sandbox %s -c approvals_reviewer=%s' \
+        printf -- '--ask-for-approval %s --sandbox %s' \
           "${HIVE_CODEX_APPROVAL_POLICY:-on-request}" \
-          "${HIVE_CODEX_SANDBOX_MODE:-workspace-write}" \
-          "${HIVE_CODEX_APPROVALS_REVIEWER:-auto_review}"
+          "${HIVE_CODEX_SANDBOX_MODE:-workspace-write}"
+
+        # ESCAPE HATCH: ${VAR-default} WITHOUT the colon, so an explicitly
+        # EMPTY HIVE_CODEX_APPROVALS_REVIEWER omits the -c key entirely while
+        # an unset one still gets auto_review.
+        #
+        # This matters because `-c approvals_reviewer=` is a Codex CONFIG KEY,
+        # and hive cannot prove every Codex release accepts it. If one rejects
+        # an unknown -c key at startup, every codex contributor task fails at
+        # launch. With `:-` there was no way to turn the key off — the only
+        # escape was HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1,
+        # i.e. the exact unsandboxed posture this block exists to avoid. An
+        # operator can now drop just the reviewer key and keep the sandbox.
+        local _reviewer="${HIVE_CODEX_APPROVALS_REVIEWER-auto_review}"
+        if [[ -n "$_reviewer" ]]; then
+          printf -- ' -c approvals_reviewer=%s' "$_reviewer"
+        fi
 
         # The CLI starts in HIVE_AGENT_CWD because that directory is stable and
         # contains no contributor credentials (#4046/#4168). Assigned repos
         # live under the separate HIVE_WORKSPACE_DIR, so make that exact tree a
         # second writable root rather than broadening the sandbox globally.
+        #
+        # Callers word-split this function's output (agent-launch.sh:
+        # `read -r -a PERM_ARGS <<< "$PERM_FLAG"`), so the contract is
+        # whitespace-separated and CANNOT carry a path containing whitespace:
+        # `--add-dir /work space` would arrive as three argv words and grant
+        # Codex the wrong directory. Refuse to emit a grant we cannot express
+        # correctly, and say so, rather than silently corrupting argv.
         if [[ -n "${HIVE_WORKSPACE_DIR:-}" ]]; then
-          printf -- ' --add-dir %s' "$HIVE_WORKSPACE_DIR"
+          if [[ "$HIVE_WORKSPACE_DIR" == *[[:space:]]* ]]; then
+            echo "WARNING: HIVE_WORKSPACE_DIR contains whitespace (${HIVE_WORKSPACE_DIR});" \
+                 "omitting Codex --add-dir because the flag string is word-split by the caller." \
+                 "Move the workspace to a path without spaces to grant it." >&2
+          else
+            printf -- ' --add-dir %s' "$HIVE_WORKSPACE_DIR"
+          fi
         fi
         printf '\n'
       fi

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -78,7 +78,24 @@ backend_perm_flag() {
       if is_truthy "${HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}"; then
         echo "--dangerously-bypass-approvals-and-sandbox"
       else
-        echo "--ask-for-approval ${HIVE_CODEX_APPROVAL_POLICY:-on-request} --sandbox ${HIVE_CODEX_SANDBOX_MODE:-workspace-write}"
+        # Hive-delivered work is unattended even in the tmux-backed mode: no
+        # operator is guaranteed to be watching the pane when Codex needs to
+        # cross its sandbox boundary. Keep the workspace-write sandbox from
+        # #3512, but route eligible escalations through Codex's bounded
+        # automatic reviewer instead of surfacing an interactive prompt.
+        printf -- '--ask-for-approval %s --sandbox %s -c approvals_reviewer=%s' \
+          "${HIVE_CODEX_APPROVAL_POLICY:-on-request}" \
+          "${HIVE_CODEX_SANDBOX_MODE:-workspace-write}" \
+          "${HIVE_CODEX_APPROVALS_REVIEWER:-auto_review}"
+
+        # The CLI starts in HIVE_AGENT_CWD because that directory is stable and
+        # contains no contributor credentials (#4046/#4168). Assigned repos
+        # live under the separate HIVE_WORKSPACE_DIR, so make that exact tree a
+        # second writable root rather than broadening the sandbox globally.
+        if [[ -n "${HIVE_WORKSPACE_DIR:-}" ]]; then
+          printf -- ' --add-dir %s' "$HIVE_WORKSPACE_DIR"
+        fi
+        printf '\n'
       fi
       ;;
     agy)     echo "--dangerously-skip-permissions" ;;

--- a/config/contributor.env.example
+++ b/config/contributor.env.example
@@ -16,12 +16,16 @@ AGENT_BACKEND=claude
 # AGENT_MODEL=gpt-5.6-luna
 # AGENT_REASONING_EFFORT=low
 
-# Codex approval/sandbox posture. Defaults are explicit and non-bypass:
+# Codex approval/sandbox posture. Defaults are explicit and non-bypass. Hive
+# also routes eligible boundary requests through Codex automatic review and
+# grants only HIVE_WORKSPACE_DIR as an additional writable root:
 #   --ask-for-approval on-request --sandbox workspace-write
+#   -c approvals_reviewer=auto_review --add-dir "$HIVE_WORKSPACE_DIR"
 # Uncomment the dangerous flag only when you intentionally want the old
 # full bypass of approvals and sandboxing.
 # HIVE_CODEX_APPROVAL_POLICY=on-request
 # HIVE_CODEX_SANDBOX_MODE=workspace-write
+# HIVE_CODEX_APPROVALS_REVIEWER=auto_review
 # HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1
 
 # Task-delivery mode (kubestellar/hive#2538). Default: interactive.

--- a/config/contributor.env.example
+++ b/config/contributor.env.example
@@ -26,6 +26,8 @@ AGENT_BACKEND=claude
 # HIVE_CODEX_APPROVAL_POLICY=on-request
 # HIVE_CODEX_SANDBOX_MODE=workspace-write
 # HIVE_CODEX_APPROVALS_REVIEWER=auto_review
+# Set HIVE_CODEX_APPROVALS_REVIEWER= (empty) to drop the -c approvals_reviewer
+# key entirely if your Codex release rejects it; the sandbox posture is kept.
 # HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1
 
 # Task-delivery mode (kubestellar/hive#2538). Default: interactive.

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -12,7 +12,7 @@ Hive validates backend names in `src/pkg/config` and launches CLIs in `src/pkg/a
 | `goose` | `goose` | Install Block Goose and configure provider/model (`GOOSE_PROVIDER`, `GOOSE_MODEL`, or `goose configure`). | Hive launches `goose run -s` and appends `--model` when set. |
 | `pi` | `goose` in the Go manager; `pi` in contributor scripts | In the server-side manager, `backendBinary("pi")` maps to `goose`. Configure Goose for pod agents. The contributor relay image/scripts use a separate `pi` binary. | Server-side pod agents use Goose for `backend: pi`; contributor mode uses the Pi CLI. |
 | `bob` | `bob` | Provide `HIVE_BOB_API_KEY` or `/secrets/bob_api_key` for pods; contributor mode requires `BOBSHELL_API_KEY`. | Hive uses API-key auth headlessly and accepts the Bob license at launch. |
-| `codex` | `codex` | Install `@openai/codex` and run `codex login --device-auth` for subscription/OAuth auth. The CLI stores credentials in `CODEX_HOME/auth.json` (default `${HOME}/.codex/auth.json`); API-key mode can use `CODEX_API_KEY`/`OPENAI_API_KEY` or a populated auth file, but it is not required for subscription users. | Hive gives each agent its own `CODEX_HOME` and probes `auth.json` for OAuth tokens/API-key state (or API-key env presence). Contributor mode defaults to `--ask-for-approval on-request --sandbox workspace-write`; override with `HIVE_CODEX_APPROVAL_POLICY`/`HIVE_CODEX_SANDBOX_MODE`, or set `HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` only when you intentionally want the old bypass posture. `AGENT_REASONING_EFFORT` is passed to Codex as `-c model_reasoning_effort="..."`. |
+| `codex` | `codex` | Install `@openai/codex` and run `codex login --device-auth` for subscription/OAuth auth. The CLI stores credentials in `CODEX_HOME/auth.json` (default `${HOME}/.codex/auth.json`); API-key mode can use `CODEX_API_KEY`/`OPENAI_API_KEY` or a populated auth file, but it is not required for subscription users. | Hive gives each agent its own `CODEX_HOME` and probes `auth.json` for OAuth tokens/API-key state (or API-key env presence). Contributor mode keeps `--ask-for-approval on-request --sandbox workspace-write`, grants the exact `HIVE_WORKSPACE_DIR` tree with `--add-dir`, and defaults `approvals_reviewer` to `auto_review` so an unattended task never waits on the contributor. Override with `HIVE_CODEX_APPROVAL_POLICY`/`HIVE_CODEX_SANDBOX_MODE`/`HIVE_CODEX_APPROVALS_REVIEWER`, or set `HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` only when you intentionally want the old bypass posture. `AGENT_REASONING_EFFORT` is passed to Codex as `-c model_reasoning_effort="..."`. |
 | `aider` | contributor scripts launch `aider`; the server-side Go manager does not launch it | Install Aider and configure its provider/API key normally for contributor mode. | Not supported as a server-side agent backend in this branch: config accepts the name, but `backendBinary("aider")` returns `unknown backend: aider`, so a pod agent will not start. Use contributor mode for Aider. |
 
 ## IBM Bob headless setup
@@ -45,6 +45,14 @@ AGENT_BACKEND=litellm HIVE_LITELLM_ENDPOINT=https://litellm.example.com just con
 ```
 
 `AGENT_BACKEND` selects the CLI, `AGENT_MODEL` optionally pins the model, and `CONTRIBUTOR_MODE` defaults to `interactive` (tmux with a TTY). For Codex, `AGENT_REASONING_EFFORT` optionally pins the reasoning effort. `CONTRIBUTOR_MODE=headless` is reserved for one-shot/no-TTY task delivery.
+
+Both contributor modes are unattended from Codex's perspective: Hive may
+deliver work when nobody is watching the tmux pane. The default automatic
+reviewer evaluates only actions that already cross the `workspace-write`
+boundary. It does not widen that boundary, and the dangerous no-sandbox mode
+remains opt-in. A denied or timed-out automatic review returns to Codex; in
+headless mode a non-zero terminal result is reported to Hive with a bounded,
+token-redacted diagnostic rather than waiting for input.
 
 `just contribute-check <backend>` runs a read-only preflight before registration. It checks that the chosen CLI exists and that obvious auth prerequisites are present.
 

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -74,6 +74,13 @@ Important environment variables:
 | `AGENT_REASONING_EFFORT` | unset | Reasoning effort override. Consumed by `codex` (`-c model_reasoning_effort`) and by `agy` (`--effort low\|medium\|high`, required whenever a model is set, else agy ignores the model). Ignored by other backends. |
 | `CONTRIBUTOR_MODE` | `interactive` | `interactive` keeps a tmux/TTY session. `headless` is for one-shot/no-TTY task delivery. |
 | `HIVE_AGENT_SESSION` | `contributor` | tmux session name for interactive mode. |
+| `HIVE_CODEX_APPROVALS_REVIEWER` | `auto_review` | Codex reviewer for boundary requests. The default prevents Hive-delivered work from waiting on an interactive operator while retaining `workspace-write`; set `user` only for an intentionally attended contributor. |
+
+For Codex, Hive also passes `--add-dir "$HIVE_WORKSPACE_DIR"`. The CLI itself
+starts in the stable, credential-free `HIVE_AGENT_CWD`, while assigned checkouts
+live below the separately bounded writable workspace. Automatic-review denial
+or timeout remains a failure; headless mode reports the redacted terminal
+diagnostic to Hive and returns the contributor to the ready pool.
 
 To change hubs for direct Compose, re-run the registration/setup flow for the target hub or edit `${HOME}/.config/hive/contributor.env` so `HIVE_HUB` and `HIVE_REGISTRATION_TOKEN` stay matched.
 

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -74,13 +74,28 @@ Important environment variables:
 | `AGENT_REASONING_EFFORT` | unset | Reasoning effort override. Consumed by `codex` (`-c model_reasoning_effort`) and by `agy` (`--effort low\|medium\|high`, required whenever a model is set, else agy ignores the model). Ignored by other backends. |
 | `CONTRIBUTOR_MODE` | `interactive` | `interactive` keeps a tmux/TTY session. `headless` is for one-shot/no-TTY task delivery. |
 | `HIVE_AGENT_SESSION` | `contributor` | tmux session name for interactive mode. |
-| `HIVE_CODEX_APPROVALS_REVIEWER` | `auto_review` | Codex reviewer for boundary requests. The default prevents Hive-delivered work from waiting on an interactive operator while retaining `workspace-write`; set `user` only for an intentionally attended contributor. |
+| `HIVE_CODEX_APPROVALS_REVIEWER` | `auto_review` | Codex reviewer for boundary requests. The default prevents Hive-delivered work from waiting on an interactive operator while retaining `workspace-write`; set `user` only for an intentionally attended contributor. Set it to the **empty string** to omit the `-c approvals_reviewer=` key entirely — the escape hatch if a Codex release rejects that config key at startup. Doing so keeps the sandbox posture; it is not the same as the dangerous bypass. |
 
 For Codex, Hive also passes `--add-dir "$HIVE_WORKSPACE_DIR"`. The CLI itself
 starts in the stable, credential-free `HIVE_AGENT_CWD`, while assigned checkouts
 live below the separately bounded writable workspace. Automatic-review denial
 or timeout remains a failure; headless mode reports the redacted terminal
 diagnostic to Hive and returns the contributor to the ready pool.
+
+`HIVE_WORKSPACE_DIR` must not contain whitespace. `backend_perm_flag` returns a
+whitespace-separated flag string that the launcher word-splits, so a path with a
+space cannot be expressed as a single argument — `--add-dir /work space` would
+reach Codex as three separate words and grant the wrong directory. Hive detects
+this, omits `--add-dir`, and warns on stderr rather than corrupting the argv;
+the sandbox posture still applies, but the workspace is not granted. Move the
+workspace to a path without spaces.
+
+Codex config-key compatibility: `approvals_reviewer` is passed with `-c`, so it
+depends on the installed Codex release accepting that key. If a version rejects
+it at startup, set `HIVE_CODEX_APPROVALS_REVIEWER=` (empty) to drop the key
+while keeping `--ask-for-approval`/`--sandbox` — prefer that over
+`HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1`, which removes the
+sandbox altogether.
 
 To change hubs for direct Compose, re-run the registration/setup flow for the target hub or edit `${HOME}/.config/hive/contributor.env` so `HIVE_HUB` and `HIVE_REGISTRATION_TOKEN` stay matched.
 


### PR DESCRIPTION
Closes #4588.

## Summary

- keep Codex on `on-request` plus `workspace-write`, but route eligible boundary requests through its `auto_review` reviewer so unattended Hive work does not pause for a person
- grant the configured `HIVE_WORKSPACE_DIR` as the exact additional writable tree while preserving the dangerous no-sandbox mode as an explicit opt-in
- surface a bounded, token-redacted terminal diagnostic when a headless approval is denied or times out
- cover the default, override, bypass, workspace, and headless failure contracts in the contributor test suites

## Tests

- `PATH=/usr/bin:/bin bash bin/contributor-agent.test.sh`
- `env -u HIVE_AGENT_CWD HIVE_HUB=wss://hive.example.test/contribute node bin/contributor-relay.test.js` (163/163)
- `node --check < bin/contributor-relay.sh`
- `shellcheck --shell=bash --exclude=SC2034 config/backends.conf`
- `shellcheck bin/contributor-agent.test.sh`

— hive: backend=codex
