### PR TITLE
fix(login-detector): scan the pane tail, not 50 lines of scrollback

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6224,7 +6224,14 @@ func scanForLoginRequired(
 		return
 	}
 
-	const paneLines = 50 // number of recent lines to scan
+	// Scan the pane TAIL only. A login prompt the CLI is genuinely stuck at
+	// sits at the BOTTOM of the pane; the 50-line window this used to read
+	// reached deep into scrollback, where agent WORK OUTPUT that merely
+	// mentions a pattern phrase lives — quality's scan findings quoting
+	// "gh auth login" from auth documentation got the agent paused mid-kick
+	// (kubestellar/hive, 2026-08-22 08:27, on a fully-authenticated CLI).
+	// Same discipline as the poller's tail-only match (#4577).
+	const paneLines = 12
 	statuses := agentMgr.AllStatuses()
 	for name, proc := range statuses {
 		if proc.State != "running" {


### PR DESCRIPTION
Final gap in the false-login family (#4573/#4577). The cmd-side login-detector still matched patterns against **50 pane lines**, deep into scrollback where agent *work output* lives — quality's scan findings, quoting `gh auth login` from the auth documentation it was auditing, got the agent **paused mid-kick on a fully authenticated CLI** (08:27Z today, on the pod running all prior fixes).

A genuinely stuck login prompt sits at the pane **bottom**. Scan the last 12 lines only — the same tail discipline #4577 gave the poller's `showsLogin`. The blocking-modal stand-down (#4573) is unchanged. `GetOutput` → `OutputBuffer.Last(n)` confirms tail semantics.

With this, the complete set: modal answering (lifetime, session-only), detector stand-down during modals, restart-ctx detach, identity shapes, kick-grace + tail + persistence on the poller, boot-drop of stale login pauses, frozen-red escalation — and now tail-only matching in the detector itself.