### PR TITLE
fix(agent): validate seeded login identity; resolve token owner when absent

### DIFF
--- a/src/pkg/agent/copilot_token_promote_test.go
+++ b/src/pkg/agent/copilot_token_promote_test.go
@@ -228,6 +228,50 @@ func TestRestoreCopilotTokens_IdentityShape(t *testing.T) {
 		t.Errorf("object-identity token = %q, want gho_obj under https://github.com:bob; tokens=%v", got, toks)
 	}
 
+	// JUNK identity (a bare "github.com" string, observed live from the
+	// polluted shared-config lineage) must NOT be used as a key: with the
+	// owner lookup also failing, fall back to the legacy shape.
+	origLookup := githubTokenLogin
+	githubTokenLogin = func(string) string { return "" }
+	defer func() { githubTokenLogin = origLookup }()
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{},"lastLoggedInUser":"github.com"}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreCopilotTokens(path, "gho_junkid"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = readCopilotConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toks, _ = cfg["copilotTokens"].(map[string]interface{})
+	if _, bad := toks["github.com"].(string); bad {
+		t.Error("junk identity must not become a bare string token key")
+	}
+
+	// No valid identity but the owner lookup SUCCEEDS → full canonical
+	// identity written from the token's true owner.
+	githubTokenLogin = func(string) string { return "alice" }
+	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{}}`), 0o660); err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreCopilotTokens(path, "gho_resolved"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = readCopilotConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toks, _ = cfg["copilotTokens"].(map[string]interface{})
+	if got, _ := toks["https://github.com:alice"].(string); got != "gho_resolved" {
+		t.Errorf("resolved owner should key the token, got %v", toks)
+	}
+	id, _ := cfg["lastLoggedInUser"].(map[string]interface{})
+	if id["login"] != "alice" || id["host"] != "https://github.com" {
+		t.Errorf("canonical identity not written: %v", cfg["lastLoggedInUser"])
+	}
+	githubTokenLogin = func(string) string { return "" }
+
 	// No identity → legacy host-keyed object shape (unchanged behavior).
 	if err := os.WriteFile(path, []byte(copilotConfigHeader+`{"copilotTokens":{}}`), 0o660); err != nil {
 		t.Fatal(err)

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/user"
@@ -5943,17 +5944,29 @@ func restoreCopilotTokens(path, token string) error {
 		}
 		cfg = map[string]interface{}{}
 	}
-	// When the config still carries a login identity (preserved by
+	// When the config still carries a VALID login identity (preserved by
 	// clearExpiredTokens), store the token under the "<host>:<login>" key a
 	// real /login writes, so the interactive CLI recognizes the seeded
 	// credential as a signed-in session rather than showing "Please use
 	// /login" over a valid token. The CLI has written lastLoggedInUser in two
 	// shapes across versions — a bare "https://github.com:user" string and a
 	// {"host":…,"login":…} object (the shape observed in a working 1.0.78
-	// config) — accept both. With no identity on file, fall back to the
-	// host-keyed object shape as before.
+	// config) — accept both.
+	//
+	// With no valid identity on file (missing, or junk inherited from the
+	// shared config's polluted lineage), resolve the token's TRUE owner from
+	// the GitHub API and write the full canonical identity. This makes the
+	// seed self-sufficient: whatever garbage the file has decayed into, a
+	// valid token always produces a signed-in config. Only when the lookup
+	// itself fails (offline, revoked token) fall back to the legacy host-keyed
+	// object shape — no worse than before.
 	if key := copilotIdentityKey(cfg["lastLoggedInUser"]); key != "" {
 		cfg["copilotTokens"] = map[string]interface{}{key: token}
+	} else if login := githubTokenLogin(token); login != "" {
+		identity := map[string]interface{}{"host": "https://github.com", "login": login}
+		cfg["copilotTokens"] = map[string]interface{}{"https://github.com:" + login: token}
+		cfg["lastLoggedInUser"] = identity
+		cfg["loggedInUsers"] = []interface{}{identity}
 	} else {
 		cfg["copilotTokens"] = map[string]interface{}{
 			"github.com": map[string]interface{}{"token": token},
@@ -5962,19 +5975,56 @@ func restoreCopilotTokens(path, token string) error {
 	return writeCopilotConfig(path, cfg)
 }
 
+// githubTokenLogin resolves the GitHub login that owns token via GET /user, or
+// "" on any failure. Short-timeout, one call — used only on the rare seed path
+// where the config lacks a valid identity. Overridable in tests.
+var githubTokenLogin = func(token string) string {
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var body struct {
+		Login string `json:"login"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&body) != nil {
+		return ""
+	}
+	return strings.TrimSpace(body.Login)
+}
+
 // copilotIdentityKey renders a lastLoggedInUser value — string or
 // {"host","login"} object — as the "<host>:<login>" copilotTokens key the CLI
 // uses for a signed-in session, or "" when there is no usable identity.
+//
+// VALIDATION is the point, not just shape conversion: the shared config's
+// lineage accumulates junk identities (a bare "github.com" string was observed
+// live — kubestellar/hive, 2026-08-22 — inherited from stale rewrites), and a
+// junk identity keyed a seeded VALID token under a key the CLI rejects, leaving
+// every agent at "Please use /login" over working credentials. Only a
+// "https://<host>:<login>" string (scheme + host + login = at least two
+// colons) or a {host,login} object whose host looks like a URL qualifies.
 func copilotIdentityKey(v interface{}) string {
 	switch id := v.(type) {
 	case string:
-		if s := strings.TrimSpace(id); s != "" {
+		s := strings.TrimSpace(id)
+		if strings.HasPrefix(s, "http") && strings.Count(s, ":") >= 2 {
 			return s
 		}
 	case map[string]interface{}:
 		host, _ := id["host"].(string)
 		login, _ := id["login"].(string)
-		if strings.TrimSpace(host) != "" && strings.TrimSpace(login) != "" {
+		if strings.HasPrefix(strings.TrimSpace(host), "http") && strings.TrimSpace(login) != "" {
 			return host + ":" + login
 		}
 	}


### PR DESCRIPTION
Root cause #7 in the agent-auth saga. The shared copilot config's lineage accumulates **junk identities** (a bare `"github.com"` string observed live today), and `restoreCopilotTokens` keyed a seeded *valid* token under that junk — the CLI rejected the session, every agent sat at "Please use /login" over working credentials, and the token-restart loop churned scanner to **restart_count=182**.

## Fix
- `copilotIdentityKey` now **validates**: only `https://<host>:<login>` strings or `{host,login}` objects with URL-shaped hosts qualify — junk can never key a token again.
- With no valid identity, `restoreCopilotTokens` resolves the token's **true owner** via `GET /user` (5s timeout, fires only on the rare seed path) and writes the full canonical identity (`copilotTokens` under `<host>:<login>`, object-shaped `lastLoggedInUser`/`loggedInUsers`). The seed becomes **self-sufficient regardless of what the file has decayed into**. Lookup failure → legacy fallback, no worse than before.

## Tests
Junk-identity rejection + resolved-owner canonical write + existing shape cases (lookup stubbed via the `githubTokenLogin` var).

Live config was hand-repaired to canonical shapes as interim relief; this makes the repair permanent.