### PR TITLE
🐛 fix(tests): hermetic scheduler/tokens/proxy tests on live hive hosts

### DIFF
--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -126,15 +126,27 @@ func (s *Scheduler) GetLastActionable() *github.ActionableResult {
 // always uses the fixed /data/policies path that handleAgentPromptSave writes to.
 var userSavedPolicyDir = "/data/policies"
 
+// agentHomeDir is where per-agent homes live on a hive host; the per-agent
+// CLAUDE.md (<agentHomeDir>/<name>/CLAUDE.md) is checked first by
+// loadPromptTemplate. It is a var (not a const) only so tests can point it at
+// a temp dir; production always uses the fixed /data/agents path.
+var agentHomeDir = "/data/agents"
+
+// clonedPoliciesDir is the root of the git-cloned policies repo checkout on a
+// hive host (…/<root>/examples/kubestellar/agents/). Like userSavedPolicyDir,
+// it is a var only so tests can point it at a temp dir; production always
+// uses /data/policies.
+var clonedPoliciesDir = "/data/policies"
+
 // loadPromptTemplate searches standard paths for an agent's policy template.
 // It checks on-disk paths first, then falls back to embedded default policies.
 func (s *Scheduler) loadPromptTemplate(agentName string) string {
 	paths := []string{
-		fmt.Sprintf("/data/agents/%s/CLAUDE.md", agentName),
+		fmt.Sprintf("%s/%s/CLAUDE.md", agentHomeDir, agentName),
 		// User-saved override from the dashboard prompt editor wins over the
 		// git-cloned examples copy and embedded defaults (#3239).
 		fmt.Sprintf("%s/%s.md", userSavedPolicyDir, agentName),
-		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s.md", agentName),
+		fmt.Sprintf("%s/examples/kubestellar/agents/%s.md", clonedPoliciesDir, agentName),
 	}
 	if s.cfg.Policies.LocalDir != "" {
 		paths = append(paths,
@@ -163,7 +175,7 @@ func (s *Scheduler) loadNamedTemplate(templateName string) string {
 		// agent has a kick_template set (e.g. quality-advisory.md at ACMM L2) the
 		// edit lands here and must be picked up on the next kick.
 		fmt.Sprintf("%s/%s", userSavedPolicyDir, templateName),
-		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s", templateName),
+		fmt.Sprintf("%s/examples/kubestellar/agents/%s", clonedPoliciesDir, templateName),
 	}
 	if s.cfg.Policies.LocalDir != "" {
 		paths = append(paths,

--- a/src/pkg/scheduler/scheduler_coverage_test.go
+++ b/src/pkg/scheduler/scheduler_coverage_test.go
@@ -295,7 +295,27 @@ func TestSubstituteTemplate_TimestampPresent(t *testing.T) {
 // loadPromptTemplate — test with temp file
 // ---------------------------------------------------------------------------
 
+// redirectPolicySeams points every /data policy seam (agentHomeDir,
+// userSavedPolicyDir, clonedPoliciesDir) at fresh empty temp dirs so the
+// template loaders can never read live production state on a hive host
+// (#4585). Restores the originals via t.Cleanup.
+func redirectPolicySeams(t *testing.T) {
+	t.Helper()
+	prevAgentHome := agentHomeDir
+	prevUserSaved := userSavedPolicyDir
+	prevCloned := clonedPoliciesDir
+	agentHomeDir = t.TempDir()
+	userSavedPolicyDir = t.TempDir()
+	clonedPoliciesDir = t.TempDir()
+	t.Cleanup(func() {
+		agentHomeDir = prevAgentHome
+		userSavedPolicyDir = prevUserSaved
+		clonedPoliciesDir = prevCloned
+	})
+}
+
 func TestLoadPromptTemplate_FromPoliciesDir(t *testing.T) {
+	redirectPolicySeams(t)
 	tmpDir := t.TempDir()
 	// Use an agent name that cannot exist in the live /data/agents or
 	// /data/policies paths, which loadPromptTemplate consults first; a real
@@ -320,6 +340,7 @@ func TestLoadPromptTemplate_FromPoliciesDir(t *testing.T) {
 }
 
 func TestLoadPromptTemplate_NotFound(t *testing.T) {
+	redirectPolicySeams(t)
 	cfg := &config.Config{
 		Policies: config.PoliciesConfig{
 			LocalDir: "/nonexistent",
@@ -337,6 +358,7 @@ func TestLoadPromptTemplate_NotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildAgentMessage_UsesTemplate(t *testing.T) {
+	redirectPolicySeams(t)
 	tmpDir := t.TempDir()
 	templatePath := tmpDir + "/examples/kubestellar/agents/custom-agent.md"
 	os.MkdirAll(tmpDir+"/examples/kubestellar/agents", 0o755)

--- a/src/pkg/scheduler/scheduler_template_test.go
+++ b/src/pkg/scheduler/scheduler_template_test.go
@@ -40,6 +40,7 @@ func TestBuildAgentMessageWithKickTemplate(t *testing.T) {
 }
 
 func TestBuildAgentMessageWithPromptTemplate(t *testing.T) {
+	redirectPolicySeams(t)
 	dir := t.TempDir()
 	agentsDir := filepath.Join(dir, "examples", "kubestellar", "agents")
 	os.MkdirAll(agentsDir, 0755)
@@ -66,6 +67,7 @@ func TestBuildAgentMessageWithPromptTemplate(t *testing.T) {
 }
 
 func TestBuildAgentMessageWithACMMPackTemplate(t *testing.T) {
+	redirectPolicySeams(t)
 	dir := t.TempDir()
 	agentsDir := filepath.Join(dir, "examples", "kubestellar", "agents")
 	os.MkdirAll(agentsDir, 0755)
@@ -94,6 +96,7 @@ func TestBuildAgentMessageWithACMMPackTemplate(t *testing.T) {
 }
 
 func TestLoadNamedTemplateFromLocalDir(t *testing.T) {
+	redirectPolicySeams(t)
 	dir := t.TempDir()
 	agentsDir := filepath.Join(dir, "examples", "kubestellar", "agents")
 	os.MkdirAll(agentsDir, 0755)
@@ -125,6 +128,7 @@ func TestLoadNamedTemplateNotFound(t *testing.T) {
 }
 
 func TestLoadPromptTemplateFromLocalDir(t *testing.T) {
+	redirectPolicySeams(t)
 	dir := t.TempDir()
 	agentsDir := filepath.Join(dir, "examples", "kubestellar", "agents")
 	os.MkdirAll(agentsDir, 0755)

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -72,8 +72,12 @@ type AggregateSummary struct {
 
 const (
 	defaultScanInterval = 30 * time.Second
-	defaultPersistPath  = "/data/token-summary.json"
 )
+
+// defaultPersistPath is the PVC location of the token summary snapshot.
+// It is a var (not a const) only so tests can point it at a temp path;
+// production always uses the fixed /data/token-summary.json location.
+var defaultPersistPath = "/data/token-summary.json"
 
 type Collector struct {
 	sessionsDir               string
@@ -91,6 +95,14 @@ type Collector struct {
 	prevSessionCount          int
 	prevTotalTokens           int64
 	prevByAgent               map[string]int64
+
+	// loadOnce guards the one-time restore of the persisted snapshot. The
+	// load is deferred until first read (see Summary) instead of happening in
+	// NewCollector so callers may redirect defaultPersistPath or call
+	// SetPersistPath after construction — otherwise the constructor eagerly
+	// reads the live /data/token-summary.json on a hive host and tests see
+	// production data instead of a clean initial state (#4585).
+	loadOnce sync.Once
 }
 
 func NewCollector(sessionsDir string, logger *slog.Logger) *Collector {
@@ -103,11 +115,13 @@ func NewCollector(sessionsDir string, logger *slog.Logger) *Collector {
 		scanInterval: defaultScanInterval,
 		prevByAgent:  make(map[string]int64),
 	}
-	c.loadSnapshot()
 	return c
 }
 
 // SetPersistPath overrides the default path for the token summary snapshot.
+// Safe to call after construction and before first use: the persisted
+// snapshot is loaded lazily on first Summary/scan, so the override wins even
+// when set later than NewCollector (#4585).
 func (c *Collector) SetPersistPath(path string) {
 	c.persistPath = path
 }
@@ -164,6 +178,12 @@ func (c *Collector) Start(stop <-chan struct{}) {
 }
 
 func (c *Collector) scan() {
+	// Restore the persisted snapshot once, BEFORE the first scan overwrites
+	// c.latest, preserving the original constructor-time load order (#4585).
+	c.mu.Lock()
+	c.loadOnce.Do(c.loadSnapshot)
+	c.mu.Unlock()
+
 	agg, err := CollectFromDir(c.sessionsDir, c.detector)
 	if err != nil {
 		c.logger.Warn("token scan failed", "error", err)
@@ -234,6 +254,12 @@ func (c *Collector) scan() {
 }
 
 func (c *Collector) Summary() *AggregateSummary {
+	// Restore the persisted snapshot once, on first read, under the write
+	// lock so a concurrent reader never observes the load mid-write.
+	c.mu.Lock()
+	c.loadOnce.Do(c.loadSnapshot)
+	c.mu.Unlock()
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.latest

--- a/src/pkg/tokens/collector_extra_test.go
+++ b/src/pkg/tokens/collector_extra_test.go
@@ -23,20 +23,13 @@ func TestNewCollector(t *testing.T) {
 }
 
 func TestCollector_Summary_Initially(t *testing.T) {
-	// NewCollector loads a persisted snapshot from the fixed
-	// /data/token-summary.json path, which exists on a live hive host and
-	// would make Summary non-nil. Build the collector with a persist path in
-	// a temp dir so "no snapshot on disk" is actually true for this test.
-	c := &Collector{
-		sessionsDir:  "/tmp/nonexistent-sessions",
-		persistPath:  filepath.Join(t.TempDir(), "absent-token-summary.json"),
-		detector:     DefaultAgentDetector,
-		logger:       testLogger(),
-		issueCosts:   make(map[string]int64),
-		scanInterval: defaultScanInterval,
-		prevByAgent:  make(map[string]int64),
-	}
-	c.loadSnapshot()
+	// Redirect the snapshot path away from the live /data location so the
+	// lazy initial load cannot pick up production state on a hive host (#4585).
+	prev := defaultPersistPath
+	defaultPersistPath = filepath.Join(t.TempDir(), "token-summary.json")
+	t.Cleanup(func() { defaultPersistPath = prev })
+
+	c := NewCollector("/tmp/nonexistent-sessions", testLogger())
 	summary := c.Summary()
 	if summary != nil {
 		t.Errorf("expected nil summary initially, got %v", summary)


### PR DESCRIPTION
Fixes #4585

## What changed

Three hermeticity fixes so the suites in `pkg/scheduler`, `pkg/tokens`, and `pkg/proxy` no longer depend on (or damage) live `/data` state on hive hosts:

**pkg/scheduler** (`scheduler.go`)
- Promoted the two remaining inline `/data/...` path prefixes in `loadPromptTemplate`/`loadNamedTemplate` to package-level seam vars `agentHomeDir` and `clonedPoliciesDir`, mirroring the existing `userSavedPolicyDir` pattern.
- Added a `redirectPolicySeams(t)` test helper that points all three seams at fresh temp dirs; applied it to the template-loading tests.

**pkg/tokens** (`collector.go`)
- `NewCollector` no longer eagerly loads `/data/token-summary.json`. The snapshot restore is deferred to first `Summary()`/`scan()` via `sync.Once` (load happens under the write lock, before any scan overwrite, preserving original ordering semantics).
- `defaultPersistPath` is now a documented var seam; `SetPersistPath` now wins regardless of when it is called relative to construction.

**pkg/proxy** (`proxy_deep2_test.go`, `proxy_deep3_test.go`)
- `TestNewGitHubProxy` previously created `/data` if missing and then wrote **and deleted** `CACertPath` — on a writable hive host that overwrites and removes the production MITM CA. It now redirects `CACertPath`/`caKeyPath` to `t.TempDir()` via the existing seam vars.
- `TestNewGitHubProxyWithWritableDir` had dead code hinting at the same intent (`certPath` built but unused, stale "can't override the const" comment). Now actually uses the seam.

## Why

On a hive host with live state, these tests read real agent policies, load the production token summary into `latest` (breaking initial-state assertions), or fail on read-only `/data` — and in the worst case overwrite/delete the live proxy CA. CI stayed green only because runners have no `/data`.

## How tested

- `go build ./pkg/scheduler/... ./pkg/tokens/... ./pkg/proxy/...`
- `go test -short ./pkg/scheduler/... ./pkg/tokens/...` — ok
- `go test ./pkg/proxy/` — ok
- Reproduced the issue conditions on a host that genuinely has live `/data` state: on pristine `v4`, `TestLoadPromptTemplate_FromPoliciesDir` fails because `/data/agents/scanner/CLAUDE.md` shadows the test fixture; with this patch it passes.
- Full-repo `go test ./...`: only pre-existing environment-specific failures remain (identical with and without this patch).
