### PR TITLE
📖 docs: correct stale v2 provenance and link CHANGELOG from entry points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,7 @@ The sign-off adds a `Signed-off-by:` trailer certifying that you have the right 
 - Include `Fixes #<issue>` lines for issues the PR closes.
 - Describe what changed, why, and how you tested it.
 - Include the relevant command output or a short note such as `Not run (docs only)` when tests are not applicable.
+- Add a [CHANGELOG.md](CHANGELOG.md) entry under `Unreleased` for user-visible changes — features, fixes, security changes, migrations, deprecations, and breaking changes. Routine refactors, test-only changes, and dependency churn are explicitly out of scope; see the guidance at the top of that file. A GitHub Actions job leaves a one-time advisory comment when a PR touches code without touching the changelog: it is a reminder, not a merge gate, and an entry is not required when the change is not user-visible.
 - Expect maintainers to ask for focused follow-up changes rather than broad drive-by edits.
 
 ## Maintainer resources

--- a/README.md
+++ b/README.md
@@ -543,6 +543,8 @@ See the [Hive Hub](https://hive.kubestellar.io) to browse registered hives, view
 
 To contribute to Hive itself, see [CONTRIBUTING.md](CONTRIBUTING.md) and open issues or PRs on this repository.
 
+Recent user-visible changes are recorded in [CHANGELOG.md](CHANGELOG.md).
+
 ## Security
 
 Please see [SECURITY.md](SECURITY.md) for the vulnerability disclosure process. Do not report security vulnerabilities through public issues or pull requests.

--- a/docs/migration-v1-v2.md
+++ b/docs/migration-v1-v2.md
@@ -1,5 +1,12 @@
 # Migrating from Hive v1 to v2
 
+> **Historical documentation.** Both ends of this migration are retired: v2 was
+> retired in August 2026. This page is kept for operators still running v1, who
+> will land on a retired v2 and should continue with
+> [`src/docs/migration-v2-v4.md`](../src/docs/migration-v2-v4.md). For the
+> current line (branch `v4`; code under `src/`), start with the
+> [`src/docs/README.md`](../src/docs/README.md) index.
+
 This guide is practical rather than automatic: v2 changes the runtime layout, config model, and agent policy system enough that you should migrate deliberately.
 
 ## Before you start

--- a/src/deploy/README.md
+++ b/src/deploy/README.md
@@ -1,4 +1,4 @@
-# v2 deployment scripts
+# Deployment scripts
 
 This directory contains Kubernetes/LXC manifests plus runtime helper scripts used by the Hive container. The dashboard terminal pane uses two small helpers that are easy to miss:
 

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -11,6 +11,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [`CAP_NET_ADMIN` and self-hosted spokes](https://github.com/kubestellar/hive/blob/v4/src/docs/net-admin-requirement.md) — the container runs with or without `NET_ADMIN`; granting it (`--cap-add NET_ADMIN` / `securityContext.capabilities.add`) enables the full forced-proxy-egress gate, and what the degraded best-effort mode means without it.
 - [Config layering](https://github.com/kubestellar/hive/blob/v4/src/docs/config-layering.md) — how ConfigMap seed, PVC dashboard overlay, and runtime config interact.
 - [Operator reference](https://github.com/kubestellar/hive/blob/v4/src/docs/operator-reference.md) — top-level config blocks, hive flags/env, GitHub token scopes, and image provenance.
+- [Changelog](https://github.com/kubestellar/hive/blob/v4/CHANGELOG.md) — recent user-visible changes and release notes.
 - [Release channels](release-channels.md) — `stable`/`candidate`/`edge` moving image tags, switching a hive to a channel, and the `stable (v4)` version pill.
 - [The `auto-update` Compose profile](https://github.com/kubestellar/hive/blob/v4/src/docs/auto-update-profile.md) — what unattended Watchtower updates cost you, what the Docker socket proxy does and does **not** fix, and why Kubernetes should not use this profile at all.
 - [Environment variable reference](https://github.com/kubestellar/hive/blob/v4/src/docs/env-vars.md) — centralized list of runtime, deployment, hub, backup, and contributor environment variables.

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -33,7 +33,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Dashboard API reference](https://github.com/kubestellar/hive/blob/v4/src/docs/api-reference.md) — pragmatic route index for dashboard and hub endpoints.
 - [Dashboard OpenAPI spec](https://github.com/kubestellar/hive/blob/v4/dashboard/openapi.json) — machine-readable REST API reference for integrations.
 - [ioscan status](https://github.com/kubestellar/hive/blob/v4/src/docs/ioscan.md) — the untrusted-input scanner/canary feature (live and default-on in v4).
-- [Deployment scripts](https://github.com/kubestellar/hive/blob/v4/src/deploy/README.md) — inventory of v2 deployment helpers, including dashboard TTY panes and `hive-panes`.
+- [Deployment scripts](https://github.com/kubestellar/hive/blob/v4/src/deploy/README.md) — inventory of deployment helpers, including dashboard TTY panes and `hive-panes`.
 
 ## Contributors and access
 
@@ -66,7 +66,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [CLI backend setup](https://github.com/kubestellar/hive/blob/v4/docs/backend-setup.md) — setup notes for Claude, Copilot, Goose, Bob, Pi, Codex, and Aider.
 - [Inference backends](https://github.com/kubestellar/hive/blob/v4/docs/inference-backends.md) — vLLM, llm-d, LiteLLM, and Model Gateway troubleshooting.
 - [apiproxy](https://github.com/kubestellar/hive/blob/v4/src/docs/apiproxy.md) — Anthropic-compatible proxy logging and deployment notes.
-- [v1 to v2 migration](https://github.com/kubestellar/hive/blob/v4/docs/migration-v1-v2.md) — migration checklist and rollback notes.
+- [v1 to v2 migration](https://github.com/kubestellar/hive/blob/v4/docs/migration-v1-v2.md) — **historical.** Both ends of this migration are retired; v2 was retired in August 2026. Kept for operators still on v1, who should read it alongside [v2 → v4 migration](migration-v2-v4.md) above. New deployments do not need it.
 
 ## Architecture and design
 

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -1,6 +1,6 @@
 # Environment variable reference
 
-This reference is generated from the v2 source, deployment manifests, and the top-level helper scripts. The code is authoritative: `hive.yaml` may also expand arbitrary `${NAME}` placeholders through the config resolver, but only the variables below have built-in behavior.
+This reference is compiled by hand from the Go source under `src/`, the deployment manifests, and the top-level helper scripts. The code is authoritative: `hive.yaml` may also expand arbitrary `${NAME}` placeholders through the config resolver, but only the variables below have built-in behavior.
 
 ## Core `hive` runtime
 

--- a/src/docs/network-requirements.md
+++ b/src/docs/network-requirements.md
@@ -1,6 +1,6 @@
 # Network and port requirements
 
-This page is derived from the v2 code and manifests. Treat it as the operator-facing firewall matrix for standalone Docker Compose, Kubernetes spokes, and hub deployments.
+This page is derived from the Go code under `src/` and the deployment manifests. Treat it as the operator-facing firewall matrix for standalone Docker Compose, Kubernetes spokes, and hub deployments.
 
 ## Inbound listeners
 


### PR DESCRIPTION
Two verified documentation fixes.

## #4597 — stale `v2` provenance in `src/docs/env-vars.md`

Line 3 read:

> This reference is generated from the v2 source, deployment manifests, and the top-level helper scripts.

That sentence was wrong twice over.

**The directory no longer exists.** The `v2/` tree was renamed to `src/`, so the sentence pointed anyone trying to check the reference against the code at a path that is gone.

**It is not generated.** I checked before rewording rather than mechanically swapping `v2` → `v4`:

```
git grep -n 'env-vars' origin/v4 -- 'scripts/' 'Makefile' 'justfile' '.github/'
```

returns nothing, and a repo-wide `git grep -rn 'env-vars' origin/v4` turns up only prose cross-links from `README.md`, `src/docs/README.md`, `hivectl.md`, `hub-deployment.md`, `linear-agent.md`, and `operator-reference.md` — no generator, no template, no CI job that writes the file. Claiming it "is generated" is the same class of error as the `v2` reference: it tells a reader to look for machinery that does not exist, and invites someone to "fix" the file by regenerating it. Reworded to *"compiled by hand from the Go source under `src/`, the deployment manifests, and the top-level helper scripts."*

## Other stale-v2 provenance found

`src/docs/network-requirements.md` line 3 carried the same wording — *"derived from the v2 code and manifests"* — and is fixed identically.

Deliberately **not** touched, because `v2` there refers to the branch/version rather than the retired source directory:

- `src/docs/README.md` — the *"v2 → v4 migration"* index entry.
- `README.md` line 412 — *"All v2 runtime config lives in a single `hive.yaml`"*, plus its `docs/migration-v1-v2.md` and `src/docs/migration-v2-v4.md` links.
- `src/docs/contributor-relay.md` — narrates the `v2/` → `src/` rename as history (a stale tmux cwd from a pre-rename clone). Rewriting it would destroy the point.
- `src/docs/design/pr-reach-telemetry.md` — records historical `v2/pkg/...` path-to-component mappings in a design note.

## #4599 — `CHANGELOG.md` linked from nowhere

Confirmed: no mention in `README.md`, `CONTRIBUTING.md`, or the docs index. Added three links, each where a reader would actually look:

- **`README.md`** — one line in *Contributing*, next to the existing `CONTRIBUTING.md` pointer.
- **`CONTRIBUTING.md`** — a bullet in *Pull requests*, where a contributor learns they may need an entry.
- **`src/docs/README.md`** — an *Operations* entry, for operators upgrading who want to know what changed.

The CONTRIBUTING bullet is worded to match how the repo actually behaves. It asks for an entry for user-visible changes, repeats the changelog's own exclusions (routine refactors, test-only changes, dependency churn), and describes the `.github/workflows/changelog-reminder.yml` job from #4429 as a one-time advisory comment — explicitly *"a reminder, not a merge gate"*. The workflow's own header comments confirm this is deliberate: it warns that a blocking gate would train contributors to ignore it "or worse, to add noise entries just to make it green." Nothing here implies an entry is mandatory.

## #4603 — the docs index advertised a v1 → v2 migration guide

`src/docs/README.md` line 68 listed *"v1 to v2 migration"* as an ordinary entry, sitting just above *Architecture and design* as though it were current guidance. Both ends of that migration are retired — v2 was retired in August 2026 — so it is a path from one retired line to another.

**Kept and marked historical rather than dropped.** Dropping the line would hide the guide from the operators who still need it: someone genuinely on v1 has to pass through v2 to reach v4, and the index is where they would look. The repo already has a house pattern for exactly this — root `docs/architecture.md` carries a *"Legacy v1/systemd documentation"* banner — so I followed it rather than inventing a convention.

Two changes:

- **Index entry** now leads with **historical.**, states that both ends are retired, points at the `v2 → v4 migration` entry directly above as the continuation, and says new deployments do not need it.
- **`docs/migration-v1-v2.md` itself** gets the matching banner, so the marking holds for anyone arriving by direct link or search rather than through the index. Without it, the index caveat is invisible to most readers who reach the page.

The guide is **not** deleted — retired-but-real history stays on disk, as instructed.

Lines 3 and 19 of `src/docs/README.md`, which handle the current v2 → v4 story correctly, are untouched. The diff on that file is exactly two lines (36 and 69).

## `src/deploy/README.md` title — agreed, stale-directory sense

Not part of #4603; verified before changing. The file was titled `# v2 deployment scripts`, and `src/docs/README.md` line 35 called it an *"inventory of v2 deployment helpers"*.

The body settles it. It documents **only current machinery** — Podman Quadlet units (ADR-0017), the `#4478` boot-transaction coupling fix, SELinux volume-persistence probes for `#4376`, `ttyd-tmux.sh`, `hive-panes.sh` — and cross-references `src/pkg/agent/manager.go`, a path that exists only *after* the `v2/` → `src/` rename. `grep -n 'v2' src/deploy/README.md` returns exactly one hit: the title. Nothing in the file describes a retired v2 branch or contrasts v2 with v4.

So this is the same stale-directory error as `env-vars.md` and `network-requirements.md`, not the branch sense I left alone elsewhere. Retitled to `# Deployment scripts` and the index description adjusted to match.

## No CHANGELOG entry for this PR

Per the file's own guidance — entries are for user-visible features, fixes, security changes, migrations, deprecations, and breaking changes, and explicitly not routine churn. This PR corrects stale provenance sentences, adds navigation links, and marks a retired migration guide historical; it changes no behavior an operator or contributor would upgrade into. Adding an entry would be exactly the noise the changelog-reminder workflow's authors warned about.

Docs-only. No Go code touched. Only `src/docs/` (the source of truth) was edited — no synced copy in the docs repo was hand-edited. No internal cluster names introduced.

Tests: Not run (docs only).

Fixes #4597
Fixes #4599
Fixes #4603
