### PR TITLE
fix(rotation): fail over high-volume agents after metered exhaustion

### DIFF
--- a/src/pkg/rotation/rotation.go
+++ b/src/pkg/rotation/rotation.go
@@ -386,8 +386,10 @@ func (m *Manager) NextBackend(agentName, currentBackend string) string {
 	return m.nextBackend(agentName, currentBackend, 0)
 }
 
-// NextBackendForCadence is NextBackend with the agent's cadence applied, so
-// high-volume agents are never offered a subscription provider.
+// NextBackendForCadence is NextBackend with the agent's cadence applied.
+// High-volume agents avoid subscription providers during normal operation, but
+// may use one as an availability failover when their current metered provider
+// is positively measured exhausted.
 func (m *Manager) NextBackendForCadence(agentName, currentBackend string, cadenceS int) string {
 	return m.nextBackend(agentName, currentBackend, cadenceS)
 }
@@ -395,6 +397,19 @@ func (m *Manager) NextBackendForCadence(agentName, currentBackend string, cadenc
 func (m *Manager) nextBackend(agentName, currentBackend string, cadenceS int) string {
 	currentProvider := m.providerForBackend(currentBackend)
 	highVolume := cadenceS > 0 && cadenceS <= m.cfg.EffectiveHighVolumeCadenceS()
+
+	// A high-cadence agent normally must not consume a subscription pool: it
+	// can exhaust a weekly allowance and take the operator's own CLI down with
+	// it. But stranding that same agent after a positively measured prepaid
+	// provider exhaustion is worse: the available subscription alternatives are
+	// exactly the failover path. This exception is deliberately narrow:
+	// metered current provider, successful probe, and unavailable headroom.
+	// Probe errors remain fail-open and never trigger a rotation.
+	allowSubscriptionFailover := false
+	if current, ok := m.cfg.Providers[currentProvider]; ok && current.Class == ClassMetered {
+		h := m.HeadroomFor(currentProvider)
+		allowSubscriptionFailover = h.ProbeErr == nil && !h.Available
+	}
 
 	type candidate struct {
 		provider string
@@ -415,8 +430,9 @@ func (m *Manager) nextBackend(agentName, currentBackend string, cadenceS int) st
 		if len(pc.Backends) == 0 {
 			continue
 		}
-		if highVolume && pc.Class == ClassSubscription {
-			// High-volume agents must never land on subscription providers.
+		if highVolume && pc.Class == ClassSubscription && !allowSubscriptionFailover {
+			// Preserve the subscription guard unless a confirmed exhausted
+			// metered provider leaves this high-volume agent without service.
 			continue
 		}
 		h := m.HeadroomFor(name)

--- a/src/pkg/rotation/rotation_test.go
+++ b/src/pkg/rotation/rotation_test.go
@@ -151,6 +151,19 @@ func TestManager_HighVolumeCadence(t *testing.T) {
 	}
 }
 
+func TestManager_HighVolumeMeteredExhaustionFailsOverToSubscription(t *testing.T) {
+	m := NewManager(rotationTestConfig())
+	// worker is on the metered DeepSeek/litellm rung. Its balance is positively
+	// measured exhausted, while Codex/OpenAI has headroom. A high-cadence
+	// agent must fail over rather than strand.
+	m.SetHeadroom(Headroom{Provider: "deepseek", Available: false, PctRemaining: 0})
+	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false})
+	m.SetHeadroom(Headroom{Provider: "openai", Available: true, PctRemaining: 90})
+	if got := m.NextBackendForCadence("worker", "litellm", 300); got != "codex" {
+		t.Errorf("NextBackendForCadence = %q, want %q (metered exhaustion must fail over)", got, "codex")
+	}
+}
+
 func TestManager_StrandRecovered(t *testing.T) {
 	m := NewManager(rotationTestConfig())
 	m.SetHeadroom(Headroom{Provider: "anthropic", Available: false})


### PR DESCRIPTION
## Problem\n\nHigh-volume agents are currently forbidden from every subscription provider. When their current prepaid/metered provider (for example DeepSeek) is positively measured exhausted, all alternatives are rejected and the agent strands/pauses instead of failing over.\n\n## Fix\n\nKeep the normal high-volume subscription guard, but waive it narrowly when the **current provider is metered and a successful probe reports it unavailable**. This enables a DeepSeek agent to rotate to a positively measured healthy Codex/Claude/Agy fallback. Probe errors remain fail-open; subscription-to-subscription exhaustion still retains the guard.\n\n## Test\n\nAdds a 300s-cadence DeepSeek/litellm -> Codex regression test.\n\nVerified with `TMPDIR=/mnt/HC_Volume_106441607/containers-james/go-test-tmp go test ./pkg/rotation`.