### PR TITLE
📖 docs: link the eight unlinked src/docs pages from the index

### DIFF
--- a/.github/workflows/docs-index-reminder.yml
+++ b/.github/workflows/docs-index-reminder.yml
@@ -1,0 +1,146 @@
+name: Docs Index Reminder
+
+# Why this exists
+#
+# src/docs/README.md is the index readers actually navigate from, and a page
+# that is not linked from it is, in practice, a page nobody finds. That gap
+# recurs the same way every time: a PR adds a doc, the index is not updated,
+# and nothing notices until an agent sweeps the directory by hand. #4617 was
+# one such sweep — it found six unlinked pages, and a re-sweep found eight.
+#
+# It is ADVISORY ON PURPOSE, and modelled deliberately on
+# changelog-reminder.yml (#4429, #4440). A hard gate would be wrong here: a
+# page can be legitimately unlinked for a while — a draft landing ahead of the
+# section that will hold it, or a doc indexed from a subdirectory README rather
+# than the top-level index — and failing those trains authors to add a
+# throwaway link just to make the check green, which is worse than the gap.
+#
+# It reports only pages THIS PR adds, never the pre-existing backlog: a
+# reminder that relists work the author did not create is noise, and noise is
+# how the previous convention died.
+#
+# Scope is deliberately the top level of src/docs/ only. src/docs/adr/ and any
+# other subdirectory carry their own README index and are linked from the
+# top-level index as a directory, so requiring each ADR to appear in the
+# top-level index would be a false positive by design.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  remind:
+    name: docs index reminder
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'copilot-swe-agent[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find docs added by this PR that the index does not link
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+
+          index='src/docs/README.md'
+          if [ ! -f "$index" ]; then
+            echo "no $index in this tree — nothing to check"
+            echo "missing=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Only files this PR ADDED, and only at the top level of src/docs/.
+          # Paginate: a missed page would silently skip a new doc.
+          added="$(gh api --paginate "repos/$REPO/pulls/$PR/files" \
+            --jq '.[] | select(.status == "added") | .filename' 2>/dev/null \
+            | grep -E '^src/docs/[^/]+\.md$' || true)"
+
+          missing=''
+          for path in $added; do
+            base="$(basename "$path")"
+            [ "$base" = 'README.md' ] && continue
+            # Substring match on the filename is what a reader's link must
+            # contain, whether the entry is a relative link or a full URL.
+            grep -qF "$base" "$index" || missing="$missing $base"
+          done
+
+          echo "missing=${missing# }" >> "$GITHUB_OUTPUT"
+
+      - name: Remind once
+        if: steps.check.outputs.missing != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          MISSING: ${{ steps.check.outputs.missing }}
+        run: |
+          # NOT `set -e`, for the reason recorded at length in
+          # changelog-reminder.yml: GITHUB_TOKEN is read-only on `pull_request`
+          # events from forks whatever `permissions:` asks for, so a comment
+          # POST 403s there, and `bash -e` would turn an advisory reminder into
+          # a red check on exactly the contributions least likely to know the
+          # convention.
+          set -uo pipefail
+
+          marker='<!-- docs-index-reminder -->'
+
+          list=''
+          for f in $MISSING; do
+            list="$list- \`$f\`
+          "
+          done
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          $marker
+          **Docs index:** this PR adds page(s) under \`src/docs/\` that
+          \`src/docs/README.md\` does not link:
+
+          $list
+          A page missing from the index is one readers do not find. Please add a
+          line in the section a reader would actually look in, matching the
+          format of its neighbours.
+
+          If the page is indexed from a subdirectory README, or is deliberately
+          unlisted for now, ignore this. It is a reminder, not a gate; it never
+          blocks a merge.
+          EOF
+          sed -i 's/^          //' "$body_file"
+
+          # Deliver somewhere that always works first — the job summary and a
+          # ::notice:: annotation need no write permission, so they reach fork
+          # PRs and same-repo branches identically.
+          {
+            printf '### Docs index reminder\n\n'
+            grep -v "^${marker}$" "$body_file"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          echo "::notice title=Docs index reminder::New src/docs pages not linked from src/docs/README.md:${MISSING}. Not a gate."
+
+          if [ "${IS_FORK:-false}" = "true" ]; then
+            echo "fork PR — reminder delivered as a job summary and annotation instead of a comment"
+            exit 0
+          fi
+
+          # Only ever once. A failed dedupe READ must not skip the comment, and
+          # must not fail the job either.
+          if gh api --paginate "repos/$REPO/issues/$PR/comments" --jq '.[].body' 2>/dev/null \
+              | grep -qF "$marker"; then
+            echo "already reminded"
+            exit 0
+          fi
+
+          if ! gh api "repos/$REPO/issues/$PR/comments" -F body=@"$body_file"; then
+            echo "::notice::could not post the reminder as a PR comment; it is in this job's summary instead"
+          fi
+          exit 0

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -55,6 +55,11 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [GitHub App setup](https://github.com/kubestellar/hive/blob/v4/src/docs/github-app-setup.md) — the Forge App on GitHub and GitHub Enterprise: app creation, permissions, Setup URL, and `/gh-setup`.
 - [ACMM policy matrix](acmm-policy-matrix.md) — capability levels and policy modes.
 - [Inception](https://github.com/kubestellar/hive/blob/v4/src/docs/inception.md) — operator guide to the L1 brainstorm/inception workflow: phases, API, and template variables.
+- [Planning intelligence](planning-intelligence.md) — how a large GitHub issue becomes an epic the architect lane decomposes into child beads, the human plan-review gate that withholds those children until approved, and stall-replan.
+- [Review swarm](review-swarm.md) — the five review perspectives, the verdict collector and its report contract, and the opt-in merge-gate integration and bounded auto-fix cycle for review findings.
+- [Retro lane](retro-lane.md) — the opt-in (`retro.enabled`) post-completion pass that reconstructs a record for each closed bead and flags patterns such as excessive fix attempts or kicks; deterministic by default, with LLM analysis separately opt-in.
+- [Linear agent integration](linear-agent.md) — joining a Linear workspace as a first-class agent member: webhook verification, the 10-second session acknowledgement, which hive agent takes sessions, and narrating completion back as agent activities.
+- [Lite enrollment](lite-enrollment.md) — the zero-repo-secret on-ramp: `hivectl enroll OWNER/REPO` adds a repo to a spoke's `project.repos`, with prerequisites and the hosted lite-spoke path.
 - [ACMM policy fragments](https://github.com/kubestellar/hive/blob/v4/examples/acmm/README.md) — per-level ACMM policy references.
 - [Sandbox isolation and agent guardrails](https://github.com/kubestellar/hive/blob/v4/src/docs/sandbox-isolation.md) — isolation layers and operator guardrail notes.
 - [Per-agent gh restrictions](https://github.com/kubestellar/hive/blob/v4/config/restrictions/README.md) — file-based wrapper denials in `/etc/hive/restrictions/`.
@@ -71,6 +76,8 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Architecture and design
 
 - [Architecture](architecture.md) — process model, governor loop, guardrails, hub/spoke, and walkthrough.
+- [Public roadmap](roadmap.md) — the v4 direction as Now / Next / Later, with the tracking issue behind each item. Directional rather than a promise, maintained by pull request; check the date in its header before relying on the ordering.
+- [Landscape and positioning](landscape.md) — how Hive's operations-plane design compares to nearby agentic orchestration tools, with public references per project. Explicitly time-sensitive; check the conducted date in its header before quoting product details.
 - [CNCF reference architecture](https://github.com/kubestellar/hive/blob/v4/src/docs/cncf-reference-architecture.md) — CNCF submission/reference template.
 - [Podman CI runner map](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-ci-runner-map.md) — measured hosted-runner capabilities and which Podman lane goes where; SELinux is the only lane needing non-hosted infrastructure.
 - [Knowledge system design](https://github.com/kubestellar/hive/blob/v4/src/docs/design/knowledge-system.md) — llm-wiki layers, subscriptions, and APIs.
@@ -86,6 +93,7 @@ Some documents describe planned or design-only work rather than live features. T
 
 - [Security model — operator guide](security-model.md) — Ed25519-only sessions/SSO, per-hive keys, master key rotation, forced proxy egress and `CAP_NET_ADMIN`, privilege model, and supply-chain posture.
 - [Security threat model](https://github.com/kubestellar/hive/blob/v4/src/docs/security-threat-model.md) — actors, boundaries, layered defenses, known gaps, and reporting.
+- [Heartbeat bearer cutover](heartbeat-bearer-cutover.md) — retiring the fleet-wide heartbeat bearer, whose possession proves only "some provisioned spoke" and lets any spoke heartbeat as any hive, in favour of the per-hive key — without re-provisioning the fleet, and the precondition that gates the removal.
 - [Rootless Podman startup and exit-77 behavior](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootless-startup-spike.md) — measured rootless matrix: fail-closed exit 77, gate installation under `--cap-add NET_ADMIN`, proven interception, and what is still unproven.
 - [IPv6 egress-gate bypass](podman-ipv6-egress-bypass.md) — measured: the forced-proxy redirect is IPv4-only, so agent traffic to `:443` over IPv6 never meets it (5 IPv6 connections, 0 redirects; 5 IPv4 connections, 5 redirects, same run). Names the fix slice.
 - [Rootful Podman egress-gate baseline](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-rootful-egress-baseline.md) — the rootful baseline the rootless result is measured against: fail-closed exit 77, redirect and ambient-capability evidence, and `SO_MARK` isolated from the owner-UID exemption.


### PR DESCRIPTION
Fixes #4617

`src/docs/README.md` is the index readers actually navigate from, so a page missing from it is, in practice, a page nobody finds.

## The sweep found eight, not six

Re-running the sweep against `origin/v4` rather than trusting the issue's list: the issue named six, but **two more were unlinked** — `roadmap.md` and `landscape.md`. Fixing only the six would have left the same gap open.

I also swept `src/docs/adr/` and `src/docs/design/` recursively. The ADRs are **correctly** out of scope: `adr/` has its own `README.md`, and the index links that directory README (records 0001-0017), so requiring each ADR in the top-level index would be a false positive. (`design/` has three files not linked from anywhere and no directory README — a real but separate directory-level gap, not this issue; left alone.)

## Where each entry went, and why

Placed in the section a reader would look in, not a dumping ground:

**Configuration and agents** — the five feature/config pages an operator reaches for when turning something on:
- `planning-intelligence.md`, `review-swarm.md`, `retro-lane.md`, `linear-agent.md`, `lite-enrollment.md`

**Security (v4)** — `heartbeat-bearer-cutover.md`. It is not a general operations how-to: it retires a credential derived from the hub master whose possession proves only "some provisioned spoke", letting any spoke heartbeat as any hive. That is a security-model change, and it sits next to the threat model.

**Architecture and design** — `roadmap.md` and `landscape.md`. These are project-direction documents, not operator how-tos, so they do not belong beside `retro-lane.md` or `lite-enrollment.md`.

Descriptions are written from reading each file, in the index's established voice.

## Link format: relative, and here is how I determined it

The obvious hypothesis — "in-directory files use relative links" — is **false**. Both formats are used for same-directory `src/docs/*.md` files (25 relative, ~43 absolute), and both appear on the same dates, so it is not purely chronological either.

What settles it is what recent commits that *added* an entry chose. Of the six most recent index commits, five added a **relative** link. The single absolute one (`43a601fb`) did not choose the format — it edited an existing absolute line in place, inheriting it. So relative is the live convention for new entries, and that is what these use. `roadmap.md` itself independently corroborates this: it links sibling docs relatively.

I did not restructure the index or rewrite any existing entry.

## Currency caveats — my call

Both `roadmap.md` ("Directional, not a promise") and `landscape.md` ("This document will rot") self-date in their own headers. I decided the index entries **should** carry a hint of that, pointing the reader at the in-file date rather than presenting either as settled fact — the index is where someone decides whether to trust a page before opening it, and a bare description would imply currency neither document claims.

## Guard: added, advisory only

Added `.github/workflows/docs-index-reminder.yml`, modelled on `changelog-reminder.yml` (#4429, #4440) — including the hard-won lessons from that file: no `set -e`, and delivery via job summary + `::notice::` **first** so it works on fork PRs where `GITHUB_TOKEN` is read-only and a comment POST 403s.

The check is deterministic and cheap (does the index contain the filename?), which is why I judged it worth shipping rather than skipping as fragile. Kept non-noisy by design:
- **Reports only pages the PR adds** — never relists the pre-existing backlog, which would be noise the author did not create.
- **Top level of `src/docs/` only** — subdirectories like `adr/` carry their own README, so including them would cry wolf.
- **Advisory, comments once, never blocks.** A page can be legitimately unlinked for a while; a hard gate would train authors to add throwaway links to go green, which is worse than the gap.

I verified the YAML parses and exercised the detection loop against a stubbed file list: it flags a genuinely new unlinked page, and correctly ignores ADR/design subdirectory files, `README.md` itself, non-docs files, and `roadmap.md` now that it is linked.

## CHANGELOG

Skipped deliberately. `CHANGELOG.md`'s own guidance is to record user-visible features, fixes, security changes, migrations and deprecations, and to exclude routine work. This changes no behavior and ships no feature — it makes existing pages findable. The advisory workflow is CI-only. (The reminder workflow will not fire here either: this PR adds no `src/docs/*.md`.)

## Verification

Post-change sweep over every top-level `src/docs/*.md` is clean — zero unlinked. No internal cluster names introduced. Docs and CI only; no Go code touched.