### PR TITLE
🌱 test: hermetic dashboard/hub/contributor-agent suites (refs #4592, #4610)

### DIFF
--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -9,6 +9,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK_DIR="${ROOT_DIR}/.contributor-agent-test-work-$$"
 HOOK_DIR="${WORK_DIR}/entrypoint.d"
 HOME_DIR="${WORK_DIR}/home"
+CORE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 SERVER_PID=""
 
 cleanup() {
@@ -345,7 +346,7 @@ mkdir -p "$CODEX_HOME_DIR"
 
 run_codex_detect() {
   env -i \
-    PATH="${FAKE_BIN}:${PATH}" \
+    PATH="${FAKE_BIN}:${CORE_PATH}" \
     HOME="$HOME_DIR" \
     CODEX_HOME="$CODEX_HOME_DIR" \
     HIVE_REGISTRATION_TOKEN="test-token" \
@@ -379,7 +380,7 @@ fi
 rm -f "${CODEX_HOME_DIR}/auth.json"
 if output="$(
   env -i \
-    PATH="${FAKE_BIN}:${PATH}" \
+    PATH="${FAKE_BIN}:${CORE_PATH}" \
     HOME="$HOME_DIR" \
     CODEX_HOME="$CODEX_HOME_DIR" \
     CODEX_API_KEY="api-key-env" \
@@ -394,7 +395,7 @@ fi
 
 if output="$(
   env -i \
-    PATH="${FAKE_BIN}:${PATH}" \
+    PATH="${FAKE_BIN}:${CORE_PATH}" \
     HOME="$HOME_DIR" \
     CODEX_HOME="$CODEX_HOME_DIR" \
     CODEX_API_KEY="api-key-env" \
@@ -410,7 +411,7 @@ fi
 
 if output="$(
   env -i \
-    PATH="${PATH}" \
+    PATH="${CORE_PATH}" \
     HOME="$HOME_DIR" \
     CODEX_HOME="$CODEX_HOME_DIR" \
     HIVE_REGISTRATION_TOKEN="test-token" \

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -1993,7 +1993,7 @@ func (s *Server) handleGHAuth(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-const userTokenPath = "/data/gh-user-token"
+var userTokenPath = "/data/gh-user-token"
 
 func (s *Server) handleGHUserAuthStatus(w http.ResponseWriter, r *http.Request) {
 	// The login status must reflect THIS request's user, not the single

--- a/src/pkg/dashboard/api_contribute_test.go
+++ b/src/pkg/dashboard/api_contribute_test.go
@@ -18,6 +18,7 @@ func setupContributeEnv(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HIVE_CONTRIBUTORS_DIR", filepath.Join(tmpDir, "contributors"))
 	t.Setenv("HIVE_FEDERATION_REGISTRY_PATH", filepath.Join(tmpDir, "federation", "registry.json"))
+	redirectContributeWSDisk(t, filepath.Join(tmpDir, "ws-state"))
 
 	// Stub DNS so tests with fake hostnames don't hit the fail-closed resolver.
 	orig := privateURLResolver
@@ -25,6 +26,24 @@ func setupContributeEnv(t *testing.T) {
 		return []string{"93.184.216.34"}, nil
 	}
 	t.Cleanup(func() { privateURLResolver = orig })
+}
+
+func redirectContributeWSDisk(t *testing.T, dir string) {
+	t.Helper()
+	oldActivity, oldCompleted, oldFailed, oldNoPR := activityFilePath, completedTasksFile, failedTasksFile, noPRStreaksFile
+	oldAsyncActivitySave := asyncActivitySave
+	oldActivityPersistenceEnabled := activityPersistenceEnabled
+	activityFilePath = filepath.Join(dir, "activity.json")
+	completedTasksFile = filepath.Join(dir, "completed-tasks.json")
+	failedTasksFile = filepath.Join(dir, "failed-tasks.json")
+	noPRStreaksFile = filepath.Join(dir, "no-pr-streaks.json")
+	asyncActivitySave = false
+	activityPersistenceEnabled = false
+	t.Cleanup(func() {
+		activityFilePath, completedTasksFile, failedTasksFile, noPRStreaksFile = oldActivity, oldCompleted, oldFailed, oldNoPR
+		asyncActivitySave = oldAsyncActivitySave
+		activityPersistenceEnabled = oldActivityPersistenceEnabled
+	})
 }
 
 func TestContributeRegister(t *testing.T) {

--- a/src/pkg/dashboard/api_misc_coverage_test.go
+++ b/src/pkg/dashboard/api_misc_coverage_test.go
@@ -70,6 +70,9 @@ func TestCovG_BuildSnapshot(t *testing.T) {
 
 func TestCovG_HandleSSO(t *testing.T) {
 	s := covMiscServer(t)
+	t.Setenv("HIVE_HUB_SECRET", "")
+	t.Setenv("HIVE_SSO_PUBLIC_KEY", "")
+	t.Setenv("HIVE_SSO_PUBLIC_KEY_PREV", "")
 
 	// No shared secret → terminal error page, NOT a redirect. Redirecting to
 	// "/" here is what produced the infinite browser bounce.

--- a/src/pkg/dashboard/api_test.go
+++ b/src/pkg/dashboard/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,8 +20,17 @@ import (
 
 // ---------- helpers ----------
 
+func isolateDashboardState(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	oldUserTokenPath := userTokenPath
+	userTokenPath = filepath.Join(dir, "gh-user-token")
+	t.Cleanup(func() { userTokenPath = oldUserTokenPath })
+}
+
 func testDeps(t *testing.T) *Dependencies {
 	t.Helper()
+	isolateDashboardState(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	cfg := &config.Config{

--- a/src/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/src/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -66,6 +66,8 @@ func deviceFlowMock(t *testing.T, tokenStatus, login string) *httptest.Server {
 // and returns it along with the deps for further tweaking.
 func dfServer(t *testing.T, tokenStatus, login string) (*Server, *Dependencies, *httptest.Server) {
 	t.Helper()
+	t.Setenv("HIVE_SSO_PUBLIC_KEY", "")
+	t.Setenv("HIVE_SSO_PUBLIC_KEY_PREV", "")
 	mock := deviceFlowMock(t, tokenStatus, login)
 	s := NewServerWithAuth(0, "authsecret", dfLogger())
 	deps := testDeps(t)

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -473,9 +473,17 @@ type ContributeWSHub struct {
 	// EXPIRING before the next dispatch, so this must survive that sweep.
 	// Guarded by completedMu; persisted in the same PVC-backed ledger dir as
 	// the cooldowns so a pod restart does not forget the verdict.
-	noWorkVerdicts map[string]noWorkVerdictRecord
-	completedMu    sync.Mutex
-	selectMu       sync.Mutex
+	noWorkVerdicts     map[string]noWorkVerdictRecord
+	activityFilePath   string
+	completedTasksFile string
+	failedTasksFile    string
+	noPRStreaksFile    string
+	noWorkVerdictsFile string
+	asyncActivitySave  bool
+	persistActivity    bool
+	persistTaskLedgers bool
+	completedMu        sync.Mutex
+	selectMu           sync.Mutex
 	// assignmentTimes records, per contributor identity (identityOf), the wall-clock
 	// times of the task_assign messages that identity has been handed. It backs the
 	// #2436/#2566 per-tier rate gate: tier_limits.max_per_hour / max_per_day were
@@ -801,6 +809,14 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		consecutiveFailures:   make(map[string]int),
 		noPRStreaks:           make(map[string]noPRStreakRecord),
 		noWorkVerdicts:        make(map[string]noWorkVerdictRecord),
+		activityFilePath:      activityFilePath,
+		completedTasksFile:    completedTasksFile,
+		failedTasksFile:       failedTasksFile,
+		noPRStreaksFile:       noPRStreaksFile,
+		noWorkVerdictsFile:    noWorkVerdictsPath(),
+		asyncActivitySave:     asyncActivitySave,
+		persistActivity:       activityPersistenceEnabled,
+		persistTaskLedgers:    taskLedgerPersistenceEnabled,
 		assignmentTimes:       make(map[string][]time.Time),
 		leases:                make(map[string]*taskLease),
 		yankExclusions:        make(map[string]time.Time),
@@ -817,10 +833,18 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	return hub
 }
 
-const activityFilePath = "/data/contributors/activity.json"
+var activityFilePath = "/data/contributors/activity.json"
+
+var asyncActivitySave = true
+var activityPersistenceEnabled = true
+var taskLedgerPersistenceEnabled = true
 
 func (h *ContributeWSHub) loadActivity() {
-	data, err := os.ReadFile(activityFilePath)
+	if h != nil && !h.persistActivity {
+		return
+	}
+	path := h.activityPath()
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
@@ -834,6 +858,9 @@ func (h *ContributeWSHub) loadActivity() {
 }
 
 func (h *ContributeWSHub) saveActivity() {
+	if h != nil && !h.persistActivity {
+		return
+	}
 	h.activityMu.RLock()
 	entries := make([]ActivityEntry, len(h.activity))
 	copy(entries, h.activity)
@@ -842,15 +869,23 @@ func (h *ContributeWSHub) saveActivity() {
 	if err != nil {
 		return
 	}
-	os.MkdirAll("/data/contributors", 0o755)
-	tmpPath := activityFilePath + ".tmp"
+	path := h.activityPath()
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		h.logger.Warn("[contribute-ws] activity write failed", "error", err)
 		return
 	}
-	if err := os.Rename(tmpPath, activityFilePath); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		h.logger.Warn("[contribute-ws] activity rename failed", "error", err)
 	}
+}
+
+func (h *ContributeWSHub) activityPath() string {
+	if h != nil && h.activityFilePath != "" {
+		return h.activityFilePath
+	}
+	return activityFilePath
 }
 
 const activityDebounceSecs = 60
@@ -881,7 +916,11 @@ func (h *ContributeWSHub) addActivity(username, action, role, cli, model, effort
 		h.activity = h.activity[len(h.activity)-maxActivityEntries:]
 	}
 	h.activityMu.Unlock()
-	go h.saveActivity()
+	if h.asyncActivitySave {
+		go h.saveActivity()
+	} else {
+		h.saveActivity()
+	}
 	// Fan the appended event out to any live SSE subscribers (Operations command
 	// center). Done AFTER releasing activityMu, and the fan-out itself is a
 	// non-blocking send, so a subscribed browser can never stall the WS path.
@@ -896,7 +935,7 @@ func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
 	return out
 }
 
-const completedTasksFile = "/data/contributors/completed-tasks.json"
+var completedTasksFile = "/data/contributors/completed-tasks.json"
 
 // completedTaskRecord is the on-disk shape of one completed-task entry. It
 // carries the completion time plus, since #2393 item 7, the per-task cooldown
@@ -910,9 +949,9 @@ type completedTaskRecord struct {
 	PRURL         string    `json:"pr_url,omitempty"`
 }
 
-const failedTasksFile = "/data/contributors/failed-tasks.json"
+var failedTasksFile = "/data/contributors/failed-tasks.json"
 
-const noPRStreaksFile = "/data/contributors/no-pr-streaks.json"
+var noPRStreaksFile = "/data/contributors/no-pr-streaks.json"
 
 // noPRStreakRecord is the in-memory and on-disk shape of one no-PR completion
 // streak (#3980). LastAt is the most recent no-PR completion; the streak is
@@ -925,9 +964,12 @@ type noPRStreakRecord struct {
 }
 
 func (h *ContributeWSHub) loadNoPRStreaks() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
-	data, err := os.ReadFile(noPRStreaksFile)
+	data, err := os.ReadFile(h.noPRStreaksPath())
 	if err != nil {
 		return
 	}
@@ -950,6 +992,9 @@ func (h *ContributeWSHub) loadNoPRStreaks() {
 }
 
 func (h *ContributeWSHub) saveNoPRStreaks() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	saved := make(map[string]noPRStreakRecord, len(h.noPRStreaks))
 	for k, rec := range h.noPRStreaks {
@@ -964,15 +1009,23 @@ func (h *ContributeWSHub) saveNoPRStreaks() {
 		h.logger.Warn("[contribute-ws] no-PR streaks marshal failed", "error", err)
 		return
 	}
-	os.MkdirAll("/data/contributors", 0o755)
-	tmpPath := noPRStreaksFile + ".tmp"
+	path := h.noPRStreaksPath()
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		h.logger.Warn("[contribute-ws] no-PR streaks write failed", "error", err)
 		return
 	}
-	if err := os.Rename(tmpPath, noPRStreaksFile); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		h.logger.Warn("[contribute-ws] no-PR streaks rename failed", "error", err)
 	}
+}
+
+func (h *ContributeWSHub) noPRStreaksPath() string {
+	if h != nil && h.noPRStreaksFile != "" {
+		return h.noPRStreaksFile
+	}
+	return noPRStreaksFile
 }
 
 // advanceNoPRStreakLocked books one more consecutive no-PR completion against
@@ -1021,6 +1074,13 @@ func noWorkVerdictsPath() string {
 	return filepath.Join(getContributorsDir(), noWorkVerdictsFileName)
 }
 
+func (h *ContributeWSHub) noWorkVerdictsPath() string {
+	if h != nil && h.noWorkVerdictsFile != "" {
+		return h.noWorkVerdictsFile
+	}
+	return noWorkVerdictsPath()
+}
+
 // noWorkVerdictRecord is the in-memory and on-disk shape of one no_work_needed
 // verdict (#3987). RecordedAt anchors both the suppression window and the
 // invalidation comparison (issue updated_at newer than RecordedAt voids the
@@ -1045,9 +1105,12 @@ func (r noWorkVerdictRecord) suppressWindow() time.Duration {
 }
 
 func (h *ContributeWSHub) loadNoWorkVerdicts() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
-	data, err := os.ReadFile(noWorkVerdictsPath())
+	data, err := os.ReadFile(h.noWorkVerdictsPath())
 	if err != nil {
 		return
 	}
@@ -1072,6 +1135,9 @@ func (h *ContributeWSHub) loadNoWorkVerdicts() {
 }
 
 func (h *ContributeWSHub) saveNoWorkVerdicts() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	saved := make(map[string]noWorkVerdictRecord, len(h.noWorkVerdicts))
 	for k, rec := range h.noWorkVerdicts {
@@ -1086,7 +1152,7 @@ func (h *ContributeWSHub) saveNoWorkVerdicts() {
 		h.logger.Warn("[contribute-ws] no-work verdicts marshal failed", "error", err)
 		return
 	}
-	path := noWorkVerdictsPath()
+	path := h.noWorkVerdictsPath()
 	os.MkdirAll(filepath.Dir(path), 0o755)
 	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
@@ -1199,9 +1265,12 @@ type failedTaskRecord struct {
 }
 
 func (h *ContributeWSHub) loadFailedTasks() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
-	data, err := os.ReadFile(failedTasksFile)
+	data, err := os.ReadFile(h.failedTasksPath())
 	if err != nil {
 		return
 	}
@@ -1229,6 +1298,9 @@ func (h *ContributeWSHub) loadFailedTasks() {
 }
 
 func (h *ContributeWSHub) saveFailedTasks() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	saved := make(map[string]failedTaskRecord, len(h.failedTasks))
 	for k, t := range h.failedTasks {
@@ -1244,21 +1316,32 @@ func (h *ContributeWSHub) saveFailedTasks() {
 		h.logger.Warn("[contribute-ws] failed tasks marshal failed", "error", err)
 		return
 	}
-	os.MkdirAll("/data/contributors", 0o755)
-	tmpPath := failedTasksFile + ".tmp"
+	path := h.failedTasksPath()
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		h.logger.Warn("[contribute-ws] failed tasks write failed", "error", err)
 		return
 	}
-	if err := os.Rename(tmpPath, failedTasksFile); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		h.logger.Warn("[contribute-ws] failed tasks rename failed", "error", err)
 	}
 }
 
+func (h *ContributeWSHub) failedTasksPath() string {
+	if h != nil && h.failedTasksFile != "" {
+		return h.failedTasksFile
+	}
+	return failedTasksFile
+}
+
 func (h *ContributeWSHub) loadCompletedTasks() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
-	data, err := os.ReadFile(completedTasksFile)
+	data, err := os.ReadFile(h.completedTasksPath())
 	if err != nil {
 		return
 	}
@@ -1304,6 +1387,9 @@ func (h *ContributeWSHub) loadCompletedTasks() {
 }
 
 func (h *ContributeWSHub) saveCompletedTasks() {
+	if h != nil && !h.persistTaskLedgers {
+		return
+	}
 	h.completedMu.Lock()
 	saved := make(map[string]completedTaskRecord, len(h.completedTasks))
 	for k, t := range h.completedTasks {
@@ -1324,15 +1410,23 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 		h.logger.Warn("[contribute-ws] completed tasks marshal failed", "error", err)
 		return
 	}
-	os.MkdirAll("/data/contributors", 0o755)
-	tmpPath := completedTasksFile + ".tmp"
+	path := h.completedTasksPath()
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
 		h.logger.Warn("[contribute-ws] completed tasks write failed", "error", err)
 		return
 	}
-	if err := os.Rename(tmpPath, completedTasksFile); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		h.logger.Warn("[contribute-ws] completed tasks rename failed", "error", err)
 	}
+}
+
+func (h *ContributeWSHub) completedTasksPath() string {
+	if h != nil && h.completedTasksFile != "" {
+		return h.completedTasksFile
+	}
+	return completedTasksFile
 }
 
 // markTaskCompleted records a completed task and starts its issue cooldown.

--- a/src/pkg/dashboard/contribute_ws_more_coverage_test.go
+++ b/src/pkg/dashboard/contribute_ws_more_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,12 @@ import (
 
 func covK2Hub(t *testing.T) (*ContributeWSHub, *Server) {
 	t.Helper()
+	dir := os.Getenv("HIVE_CONTRIBUTORS_DIR")
+	if dir == "" {
+		dir = t.TempDir()
+		t.Setenv("HIVE_CONTRIBUTORS_DIR", dir)
+	}
+	redirectContributeWSDisk(t, dir)
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewServer(0, logger)
 	s.RegisterAPI(testDeps(t))

--- a/src/pkg/dashboard/contribute_ws_test.go
+++ b/src/pkg/dashboard/contribute_ws_test.go
@@ -19,6 +19,10 @@ func setupWSTest(t *testing.T) (*Server, *httptest.Server) {
 	tmpDir := t.TempDir()
 	t.Setenv("HIVE_CONTRIBUTORS_DIR", filepath.Join(tmpDir, "contributors"))
 	t.Setenv("HIVE_FEDERATION_REGISTRY_PATH", filepath.Join(tmpDir, "federation", "registry.json"))
+	redirectContributeWSDisk(t, filepath.Join(tmpDir, "ws-state"))
+	oldLedgerPersistence := taskLedgerPersistenceEnabled
+	taskLedgerPersistenceEnabled = false
+	t.Cleanup(func() { taskLedgerPersistenceEnabled = oldLedgerPersistence })
 
 	s := NewServer(0, slog.Default())
 	s.registerContributeRoutes()

--- a/src/pkg/dashboard/metrics_more_coverage_test.go
+++ b/src/pkg/dashboard/metrics_more_coverage_test.go
@@ -113,6 +113,8 @@ func TestCovK2_LiteLLMKeyStore(t *testing.T) {
 	logger := covK2Logger()
 	s := NewServer(0, logger)
 	s.RegisterAPI(testDeps(t))
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
 
 	// Redirect the PVC key file to a temp path so writeLiteLLMKeyFile succeeds.
 	origFile := writableLiteLLMKeyFile

--- a/src/pkg/dashboard/sso_handoff_test.go
+++ b/src/pkg/dashboard/sso_handoff_test.go
@@ -36,6 +36,8 @@ func newSSOServer(t *testing.T, hubProxied bool, authToken string, authorized ..
 		s.deps.Config.Dashboard.AuthorizedUsers = authorized
 	}
 	t.Setenv("HIVE_HUB_SECRET", testHubSecret)
+	t.Setenv("HIVE_SSO_PUBLIC_KEY", "")
+	t.Setenv("HIVE_SSO_PUBLIC_KEY_PREV", "")
 	return s
 }
 

--- a/src/pkg/hub/hub_heartbeat_test.go
+++ b/src/pkg/hub/hub_heartbeat_test.go
@@ -205,6 +205,7 @@ func TestSendHeartbeatWithSecret(t *testing.T) {
 	defer server.Close()
 
 	t.Setenv("HIVE_HUB_SECRET", "test-secret-123")
+	t.Setenv(EnvHeartbeatKey, "")
 	// F2: the spoke self-derives its PER-HIVE bearer from the master plus its own
 	// HIVE_ID. Without HIVE_ID it would fall back to the fleet-wide value, which
 	// the hub no longer accepts — so this env var is what a real spoke relies on.

--- a/src/pkg/hub/oauth_provision_coverage_test.go
+++ b/src/pkg/hub/oauth_provision_coverage_test.go
@@ -2,10 +2,10 @@ package hub
 
 import (
 	"log/slog"
-	"net/url"
-	"strings"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -242,6 +242,9 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 // ============================================================
 
 func TestReadSAToken(t *testing.T) {
+	oldDir := serviceAccountDir
+	serviceAccountDir = t.TempDir()
+	t.Cleanup(func() { serviceAccountDir = oldDir })
 	// SA token file absent in test env -> "".
 	if got := readSAToken(); got != "" {
 		t.Errorf("readSAToken = %q, want empty in test env", got)

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -441,7 +441,7 @@ func kubectlArgsForCluster(cluster *ClusterConfig, args ...string) []string {
 
 // readSAToken reads the current service account token from the projected volume.
 func readSAToken() string {
-	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	data, err := os.ReadFile(filepath.Join(serviceAccountDir, "token"))
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary
- isolate dashboard SSO/user-token, LiteLLM, and contributor WS persistence tests from live host env and /data state
- make hub SA token reads test-seamable and clear injected heartbeat keys in heartbeat auth tests
- scrub contributor-agent Codex detection PATH so installed host codex cannot change missing-binary expectations

Closes #4592
Refs #4610

## Validation
- cd src && go test ./pkg/dashboard/... ./pkg/hub/... -count=1
- cd src && HIVE_HUB_SECRET=live HIVE_SSO_PUBLIC_KEY=bad HIVE_SSO_PUBLIC_KEY_PREV=bad HIVE_HEARTBEAT_KEY=livebeat KUBERNETES_SERVICE_HOST=10.0.0.1 KUBERNETES_SERVICE_PORT=443 COPILOT_GITHUB_TOKEN=livetok GEMINI_API_KEY=livegem GOOGLE_API_KEY=livegoogle GOOGLE_GENAI_API_KEY=livegen go test ./pkg/dashboard ./pkg/hub -run 'Test(CovG_HandleSSO|CovDF_SSO|SSOHandoff|CovD_DiscoverModelsNoCreds|QueryCLIModels_CopilotFallbackNoToken|CovK2_LiteLLMKeyStore|ReadSAToken|SendHeartbeatWithSecret|URLUnreachableAlerts|URLReachabilityDecisionMatrix|URLUnreachableCriticalFlapSuppression)$' -count=1\n- cd src && go test -race ./pkg/dashboard -run 'TestCovK2_AddActivityCap|TestWSAuthValid|TestReconnectResume_ProgressHandlerRenewsLease' -count=1\n- bash bin/contributor-agent.test.sh