### PR TITLE
📖 docs: retire stale v2 disclaimers in architecture and legacy troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,7 +3,7 @@
 > **Legacy v1/systemd documentation.** This page troubleshoots the original
 > supervisor/tmux/systemd deployment (`bin/supervisor.sh`, `systemctl`, and
 > `/etc/hive/agent.env`). For current containerized Go operations (branch `v4`; code under `src/`), use
-> [v2 troubleshooting](../src/docs/troubleshooting.md) and the
+> [current troubleshooting](../src/docs/troubleshooting.md) and the
 > [`src/docs/README.md`](../src/docs/README.md) index.
 
 

--- a/src/docs/architecture.md
+++ b/src/docs/architecture.md
@@ -11,10 +11,12 @@ merge-gating, permission enforcement) from **judgment calls** (reading code,
 reasoning about a fix, writing a PR). Deterministic work runs in Go and shell
 before any LLM sees the task; agents only handle the judgment.
 
-> This document describes the `v2` branch. Automatic goal decomposition, plan
-> review, and stall-triggered re-planning are not implemented in v2 HEAD; treat
-> any mention of those capabilities outside this page as future/design-only
-> material unless the code grows matching planner/replan paths.
+> Automatic goal decomposition, plan review, and stall-triggered re-planning are
+> **not** covered on this page — they are the planning-intelligence lane, and
+> every entry point is gated at ACMM **L5+**, because the architect agent that
+> decomposes epics has no cadence below L5. See
+> [`planning-intelligence.md`](planning-intelligence.md) and
+> [ADR-0006](adr/0006-planning-intelligence.md).
 
 ---
 

--- a/src/docs/architecture.md
+++ b/src/docs/architecture.md
@@ -11,11 +11,13 @@ merge-gating, permission enforcement) from **judgment calls** (reading code,
 reasoning about a fix, writing a PR). Deterministic work runs in Go and shell
 before any LLM sees the task; agents only handle the judgment.
 
-> Automatic goal decomposition, plan review, and stall-triggered re-planning are
-> **not** covered on this page — they are the planning-intelligence lane, and
-> every entry point is gated at ACMM **L5+**, because the architect agent that
-> decomposes epics has no cadence below L5. See
-> [`planning-intelligence.md`](planning-intelligence.md) and
+> Goal decomposition, plan review, and stall-triggered re-planning are **not**
+> covered on this page — they are the planning-intelligence lane. Plan review and
+> the stall-replan lane run automatically (replan is on by default); decomposition
+> is gated at ACMM **L5+**, because the architect that decomposes epics has no
+> cadence below L5, and its final step — turning the architect's plan into child
+> beads — currently runs through the `bd decompose` CLI rather than automatically.
+> See [`planning-intelligence.md`](planning-intelligence.md) and
 > [ADR-0006](adr/0006-planning-intelligence.md).
 
 ---


### PR DESCRIPTION
## Problem

`src/docs/architecture.md` lines 14–17 opened with a blockquote making **two** independent claims. The issue flagged one; both were stale.

1. **"This document describes the `v2` branch"** — stale. v2 was retired in August 2026; this file lives under `src/` on `v4` and documents the current architecture. `src/docs/README.md` line 3 already states the current line correctly.
2. **"Automatic goal decomposition, plan review, and stall-triggered re-planning are not implemented in v2 HEAD"** — also stale, and the more consequential half. It told operators that a shipped, documented feature does not exist.

Swapping `v2` → `v4` would have preserved the misleading half, so the blockquote was rewritten against the code instead.

## What the code says today

All three capabilities are **implemented on `v4`**, gated at **ACMM L5+**:

| Capability | Implemented | Gate / default |
|---|---|---|
| Goal decomposition | Request side yes — `src/pkg/planning/issue.go` (`RequestDecompose`, `DecomposeState`, `decompose_pending`). **Fulfillment step is not wired into the daemon** — see the correction comment below | ACMM **L5+**. `PlanningMinACMMLevel = 5` (`src/pkg/planning/issue.go:206`); `plan_from_label` is opt-in (default off) and inert below L5. Architect output → child beads currently runs via the `bd decompose` CLI |
| Plan review | Yes — decomposed epic starts `plan_status=draft`, children withheld from `Ready()` until approval. Enforced at the lowest level in `beads.Ready()` → `planGated()` (`src/pkg/beads/beads.go:543,573`), fail-closed on a missing parent | Review required in practice. `PlanAutoApproveForLevel` (`src/pkg/config/acmm_packs.go:69`) resolves false L1–L4 / true L5–L6, but has **no non-test production caller**; only the CLI's `--auto-approve` (default false) sets it. The gate is therefore stronger than first described |
| Stall-triggered re-planning | Yes, and fully wired — `ReplanConfig` (`src/pkg/config/config.go:1794`), lane constructed and ticked at `src/cmd/hive/main.go:4535-4553`, `:4678-4679` | **On by default** (`IsEnabled()` — nil `Enabled` counts as enabled, only explicit `false` disables). No ACMM gate. Defaults: 30m scan, 6h stall threshold, cap of 5 replans |

Supporting evidence: `src/docs/planning-intelligence.md`, `src/docs/adr/0006-planning-intelligence.md`, `src/pkg/config/replan_default_test.go`, `src/pkg/config/acmm_packs_planapprove_test.go`, and `FrontendPlanning.Available = planning.PlanningAllowedAtLevel(acmmLevel)` (`src/pkg/dashboard/status_builder.go:1177`).

The gating detail matters: **"exists but only at L5+"** is a materially different statement from **"not implemented"**, which is what the page claimed. But the reverse error matters just as much — a follow-up verification pass found decomposition's final step is not automatic, so the wording was hedged in 842871a9. **See the correction comment below for the verified detail; the table above reflects it.**

## What changed

**`src/docs/architecture.md`** — the blockquote is replaced rather than deleted. `architecture.md` genuinely does *not* describe planning anywhere (no decompose/replan content in the body), so a reader arriving with that question still needs somewhere to go. The note now scopes the topic out of the page, separates the two lanes that genuinely run automatically (plan review, stall-replan) from decomposition, names the real gate (L5+, because the architect has no cadence below L5), and flags that the architect-output → child-beads step runs through `bd decompose` rather than automatically. Links to `planning-intelligence.md` and ADR-0006; both targets verified to exist.

**`docs/troubleshooting.md`** (root, legacy v1/systemd — `Fixes #4625`) — the banner sentence already correctly said "branch `v4`; code under `src/`", then labelled its own link **"v2 troubleshooting"**, contradicting itself. The target path `../src/docs/troubleshooting.md` was correct, so only the visible label changed, to "current troubleshooting". **The "Legacy v1/systemd documentation" banner is left fully intact** — it is correct and is the house pattern for that file.

## Sweep results

- `git grep -n 'v2' origin/v4 -- 'src/docs/architecture.md'` → only lines 14–15, both fixed. Nothing else in the file's 406 lines is v2-era.
- `git grep -n '\[v2 ' origin/v4 -- 'docs/' 'src/docs/'` → `docs/troubleshooting.md:6` is the only genuine hit, plus a broader regex for `v2` inside any link label, which found no additional cases.

**Deliberately left alone** — every remaining hit is `v2` legitimately meaning the git branch or the historical version, not a stale reference:

- `src/docs/README.md:3` — "The `v2` branch was retired in August 2026" (correct history)
- `src/docs/README.md:20` and the `[v2 → v4 migration]` links — the migration guide, correct as-is
- `src/docs/README.md:74` — "v1 to v2 migration", already explicitly marked **historical**
- Root `docs/architecture.md` — a different, legacy v1/systemd file that already carries its own correct banner; untouched

## Notes

- Docs-only; no Go code touched. `src/docs/` is the source of truth — no synced copy elsewhere was hand-edited.
- No internal cluster names introduced.
- **No CHANGELOG entry**, per the file's own guidance: this corrects documentation accuracy and changes no user-visible behavior, so it falls under the "do not include routine … changes unless they affect users" rule. Happy to add one if maintainers read it differently.
- The advisory `docs-index-reminder` workflow should not fire — this adds no new page.

Fixes #4624
Fixes #4625
