### PR TITLE
📖 docs: retire stale "v2 HEAD" references and correct the ioscan denial

### DIFF
--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -81,7 +81,7 @@ Each hive owns:
 
 ## Design-future items
 
-These are not complete in v2 HEAD and should be treated as future design work:
+These are not complete today and should be treated as future design work:
 
 - A polished web UI for joining hives from project cards.
 - Screenshot-level GitHub App installation guide.

--- a/docs/inference-backends.md
+++ b/docs/inference-backends.md
@@ -1,6 +1,6 @@
 # Inference backends
 
-Hive can route agents through OpenAI-compatible model gateways instead of a subscription CLI model. The supported gateway backend IDs in v2 HEAD are `vllm`, `llm-d`, `litellm`, `watsonx`, and named Model Gateways such as `openrouter`.
+Hive can route agents through OpenAI-compatible model gateways instead of a subscription CLI model. The supported gateway backend IDs are `vllm`, `llm-d`, `litellm`, `watsonx`, and named Model Gateways such as `openrouter`.
 
 ## How routing works
 

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -290,7 +290,7 @@ Leave it off outside of debugging: the explanation is extra output tokens on eve
 | `ultra` | Telegraphic compression. | High-volume lanes where compact summaries are more important than nuance. |
 | `wenyan` | Classical Chinese-style compression. | Specialized/experimental mode; use only when readers and downstream tools can tolerate it. |
 
-Implementation notes from v2 HEAD:
+Implementation notes:
 
 - Config validation accepts only `lite`, `full`, `ultra`, `wenyan`, or empty.
 - `claude`, `copilot`, and `gemini` are auto-wired before first message.

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -1,6 +1,6 @@
 # Dashboard REST API reference
 
-Pragmatic v1 endpoint index generated from route registrations in `pkg/dashboard/*.go` and `pkg/hub/*.go` on v2 HEAD (tests excluded). It lists method, path, coarse auth level, and one-line purpose. Request/response schemas are intentionally not hand-written here; see the handler source for exact payloads and validation.
+Pragmatic v1 endpoint index compiled by hand from route registrations in `src/pkg/dashboard/*.go` and `src/pkg/hub/*.go` (tests excluded). There is no generator; update this page in the same change that adds or renames a route. It lists method, path, coarse auth level, and one-line purpose. Request/response schemas are intentionally not hand-written here; see the handler source for exact payloads and validation.
 
 Auth levels are derived from dashboard middleware (`isPublicPath`, dashboard token/session auth, and the `/api/v1` GitHub-token wrapper) or from hub route wrappers such as `requireAuth`. Hub rows marked handler-specific have no dashboard middleware; check the named handler for bearer secrets, admin checks, or public behavior.
 

--- a/src/docs/ioscan.md
+++ b/src/docs/ioscan.md
@@ -1,29 +1,36 @@
-# ioscan status in v2
+# ioscan
 
-`ioscan` is not present in v2 HEAD. There is no `ioscan` package, no `ioscan:` config block in `src/hive.yaml.example`, and no canary/fail-mode implementation wired into the v2 kick path.
+`ioscan` protects the untrusted-text boundary before GitHub issue, PR, label, author, and comment text enters an agent kick. The implementation is `src/pkg/ioscan`, gated by the `ioscan:` block in `src/hive.yaml.example` and wired into the kick path from `src/cmd/hive/main.go`.
 
-If you are reading older notes that mention:
+## Configuration
 
 ```yaml
 ioscan:
-  enabled: true
-  fail_mode: open
-  canaries: false
+  enabled: true                 # default: true; scans untrusted text before agent kicks
+  fail_mode: open               # open (default) redacts; closed blocks Critical injection kicks and canary leaks
+  canaries: false               # default: false; plant per-kick exfiltration canaries and scan agent egress
+  classifier:
+    enabled: false              # default: false; optional LLM judge for semantic plain-English injections
+    model: ""                   # empty uses governor.litellm default_model, then gpt-4o-mini
+    warn_threshold: 0.55        # advisory bead/audit threshold
+    block_threshold: 0.85       # open=redact, closed=block kick
 ```
 
-that configuration is stale for v2 and has no effect unless a downstream fork has added its own scanner.
+Scanning is on by default. `fail_mode` and the classifier are owner-only settings; the dashboard exposes them under Governor Config → Security.
 
-## What exists today
+## What it does
+
+- **Deterministic rules** normalize Unicode steganography, decode suspicious base64, and detect known prompt-injection phrasing, dangerous directives, and secret shapes. These rules are always the floor when `ioscan` is enabled.
+- **Redaction.** Blocked text is replaced with `[ioscan: content withheld — ...]`; the raw segment is not injected into the kick.
+- **Canaries** (`ioscan.canaries`) plant per-kick exfiltration markers and scan agent egress. A trip writes an `ioscan_canary_leak` audit entry and, in `fail_mode: closed`, blocks the affected path.
+- **Semantic classification** (`ioscan.classifier.enabled`) sends only already-redacted untrusted segments to an OpenAI-compatible LLM judge. The classifier fails open on errors and timeouts, so deterministic rules and canaries remain in force. Scores above `block_threshold` redact under `fail_mode: open` and block the kick under `fail_mode: closed`.
+
+The classifier sits behind `Classifier.Score(ctx, text)` so a local ONNX/DeBERTa backend can replace the current LLM judge without changing the scheduler path.
+
+## Related boundaries
+
+These fail-closed behaviors are separate from `ioscan` and apply regardless of its setting:
 
 - Prompt and agent-definition sourcing fail closed on unallowlisted GitHub repositories.
-- Prompt fetch failures fail open to the last cached or embedded template so kicks are not blanked by transient GitHub/API outages.
+- Prompt fetch failures fail open to the last cached or embedded template, so kicks are not blanked by transient GitHub/API outages.
 - GitHub PR claim and trust checks generally fail closed where duplicate work or privilege escalation is possible.
-
-## What does not exist today
-
-- No v2 canary injection for kick prompts.
-- No v2 canary-trip handling.
-- No v2 `fail_mode: open` redaction path.
-- No v2 `fail_mode: closed` kick-blocking path.
-
-Operators should not enable ioscan in v2 configs. If ioscan is reintroduced, document the exact package, config schema, fail-open/fail-closed behavior, canary format, logging, and interaction with the deterministic pipeline in this file as part of the same change.

--- a/src/docs/knowledge-curator.md
+++ b/src/docs/knowledge-curator.md
@@ -18,9 +18,9 @@ knowledge:
 
 ## Fields
 
-| Field | Current behavior in v2 HEAD |
+| Field | Current behavior |
 | --- | --- |
-| `schedule` | Defaults to `daily` when knowledge is enabled. The value is stored as `CuratorConfig.Schedule`. No scheduler in v2 HEAD parses or actions it. Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly; see [Scheduling extraction](#scheduling-extraction). |
+| `schedule` | Defaults to `daily` when knowledge is enabled. The value is stored as `CuratorConfig.Schedule`. No scheduler parses or actions it. Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly; see [Scheduling extraction](#scheduling-extraction). |
 | `extract_from` | Sources the curator should inspect. Implemented sources are `pr_comments` and `review_comments`. `ci_failures` appears in the example config/design but is not currently extracted by `Curator.extractFromPR`. |
 | `auto_promote_threshold` | Defaults to `0.9` when knowledge is enabled. `Promoter.AutoPromoteCandidates` selects facts whose llm-wiki page has `status == "verified"` and `confidence >= threshold`. |
 
@@ -40,7 +40,7 @@ Extracted facts are sent to the wiki `/api/ingest` endpoint. Promotion only flow
 
 ## Scheduling extraction
 
-Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly. No scheduler, CLI command, or HTTP endpoint triggers extraction in v2 HEAD.
+Extraction runs only when Go code invokes `Curator.RunExtraction` explicitly. No scheduler, CLI command, or HTTP endpoint triggers extraction.
 
 A Go caller builds a `Curator` with `NewCurator(ghClient, wikiURL, org, repos, config, logger)`. The caller calls `RunExtraction(ctx, since)` with a `since` time. The caller then calls `Ingest(ctx, facts)`. The call POSTs the facts to the wiki `/api/ingest` endpoint:
 
@@ -50,6 +50,6 @@ facts, err := c.RunExtraction(ctx, since)
 err = c.Ingest(ctx, facts)
 ```
 
-The design doc `src/docs/design/knowledge-system.md` plans a `scheduler.RunCurator(schedule)` wiring with a daily or on-merge trigger. This wiring is not implemented in v2 HEAD. The programmatic path above is the only way to run extraction today.
+The design doc `src/docs/design/knowledge-system.md` plans a `scheduler.RunCurator(schedule)` wiring with a daily or on-merge trigger. This wiring is not implemented. The programmatic path above is the only way to run extraction today.
 
 See [Knowledge system design](design/knowledge-system.md) for architecture context; this page documents the implemented operator-facing knobs.


### PR DESCRIPTION
Fixes #4629

The filed issue reports one stale `v2 HEAD` reference in `src/docs/api-reference.md`. A sweep found **nine** across six files. Two of them were not merely stale — a second, independent error was hiding behind the outdated branch name, the same shape as `env-vars.md` (#4604) and `architecture.md` (#4626).

Sweep used:

```
git grep -inE 'v2 HEAD|from the v2|v2 source|generated from v2' origin/v4 -- 'src/docs/' 'docs/' 'README.md' 'CONTRIBUTING.md'
```

## Kind B — capability claims, verified against the code

### `src/docs/ioscan.md` — **FALSE, rewritten**

The page said: *"`ioscan` is not present in v2 HEAD. There is no `ioscan` package, no `ioscan:` config block in `src/hive.yaml.example`, and no canary/fail-mode implementation wired into the v2 kick path."* It went on to list canary injection, canary-trip handling, and both fail-modes under "What does not exist today", and told operators not to enable ioscan.

Every clause is false on v4:

| Claim | Evidence |
|---|---|
| "no `ioscan` package" | `src/pkg/ioscan/` — 12 files, ~1400 non-test lines (`ioscan.go` 682, `classifier.go` 382, `canary.go` 169, `enforce.go` 63, `hook.go` 49) |
| "no `ioscan:` config block" | `src/hive.yaml.example:17` — full block with `enabled`, `fail_mode`, `canaries`, `classifier.*` |
| "no canary/fail-mode implementation wired into the kick path" | `src/cmd/hive/main.go:3042` and `:3049` call `SetCanaryScanner(cfg.Ioscan.IsEnabled() && cfg.Ioscan.Canaries, cfg.Ioscan.FailClosed(), ...)`; leak handler at `:3031`; classifier wiring `:1855`–`:1867`; fail-closed block at `:5902` |
| config plumbing | `src/pkg/config/config.go:59` `Ioscan IoscanConfig`, `:207`–`:260` incl. `FailClosed()` |
| API surface | `src/pkg/dashboard/api_governor_features.go:168`, `api_governor_security.go:21`–`:23` (`ioscanEnabled`, `ioscanFailMode`, `ioscanCanaries`) |

This doc was actively telling readers a shipped security feature does not exist, and advising them to leave it off. A one-line branch-name swap would have left that standing while making the page look freshly reviewed, so the file is rewritten to describe the real feature: configuration block, deterministic rules, redaction marker, canaries, and the fail-open classifier. Content is drawn from `src/pkg/ioscan/README.md`, the config comments, and the example YAML — no behavior was inferred. The three genuinely-separate fail-closed boundaries the old page listed under "What exists today" are kept, relabeled as related boundaries independent of the `ioscan` setting.

### `src/docs/knowledge-curator.md` (:21, :23, :43, :53) — **STILL TRUE, branch name only**

Claims that no scheduler actions `schedule` and that extraction runs only via an explicit `Curator.RunExtraction` call:

- `RunExtraction` is defined at `src/pkg/knowledge/curator.go:58` and has **zero non-test callers** in `src/`.
- No `NewCurator` call exists in `src/cmd/`, `src/pkg/scheduler/`, or `src/pkg/dashboard/`.
- `Schedule` is stored and defaulted only — `src/pkg/config/config.go:4199`–`:4200` sets `defaultCuratorSchedule = "daily"` (`:3916`); nothing reads it.
- No HTTP endpoint triggers extraction.

Substance preserved verbatim; only "in v2 HEAD" retired.

### `docs/federation-design.md:84` — **STILL TRUE, branch name only**

The "design-future" list (web UI, screenshot install guide, cross-hive reputation attestations, stronger abuse controls) holds: `git grep -i attestation -- src/ ` returns nothing outside tests. Note this file is **not** legacy-bannered — it documents live v4 code and cites `src/pkg/dashboard/api_contribute.go`, whose routes are present at `:404`–`:408`. So the `v2 HEAD` reference is stale provenance, not historical narration.

### `docs/inference-backends.md:3` — **STILL TRUE, branch name only**

Backend IDs `vllm`, `llm-d`, `litellm`, `watsonx` are current: `src/pkg/config/config.go:1542`–`:1545` (`GatewayKindLiteLLM`/`VLLM`/`LLMD`/`Watsonx`). Also not a legacy-bannered file. Branch name retired, list unchanged.

## Kind A — stale provenance

### `src/docs/api-reference.md:3` — the filed issue, **plus a hidden second error**

Said *"generated from route registrations in `pkg/dashboard/*.go` and `pkg/hub/*.go` on v2 HEAD"*. Beyond the branch name, **there is no generator** — no `hack/` directory, no doc-gen script, nothing referencing `api-reference` outside the docs tree. "Generated" implied the page self-updates, which is exactly why it drifted. Now states it is compiled by hand from `src/pkg/...` and must be updated in the same change that adds or renames a route.

### `src/docs/agent-configuration.md:293`

"Implementation notes from v2 HEAD:" → "Implementation notes:". Caveman-mode notes below are unchanged.

## Scope

Docs-only; no Go code touched. Deliberately **not** changed: the v2 → v4 migration guide, prose narrating the `v2/`→`src/` rename as history, and `src/docs/README.md` lines 3/20/74, where `v2` correctly means the branch or version. Only `src/docs/` was edited — no synced copy in the docs repo was hand-touched. No CHANGELOG in this repo, so none updated. Post-change sweep returns clean.

## Flagged for follow-up (needs a code change, not docs)

- **`knowledge.curator.schedule` is inert.** It is validated and defaulted to `daily`, and the dashboard accepts it, but nothing reads it — an operator setting it reasonably expects daily extraction and gets none, silently. `src/docs/design/knowledge-system.md` still plans the `scheduler.RunCurator(schedule)` wiring. The docs now say plainly that it does nothing, but the honest fix is either to wire the scheduler or to reject the key. Worth its own issue.
- **`ioscan.md` may warrant a deeper pass by someone who owns the feature.** `src/pkg/ioscan` is substantial (classifier thresholds, canary formats, the `enforce`/`hook` split). I corrected the false denial and documented the configuration surface from the package README and config comments, but did not attempt to document behavior I could not verify from source — operator-facing detail on canary format, audit/logging shape, and classifier tuning is still thinner than the implementation deserves.

Fixes #4630
Fixes #4633
