### PR TITLE
🐛 Run the caveman installer as the agent user; stop it clobbering .claude.json

### DIFF
--- a/src/pkg/agent/caveman_install_test.go
+++ b/src/pkg/agent/caveman_install_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCavemanInstallArgvRunsAsAgentUser pins the fix for the caveman clobber:
+// the installer spawns the backend's own CLI (`claude plugin list` / `plugin
+// install`), and Claude Code rewrites $HOME/.claude.json wholesale on every
+// invocation. Run as the hive user with the agent's HOME, that CLI cannot
+// read the agent-owned 0600 session file, treats the home as a fresh
+// install, and replaces the signed-in session with a blank skeleton — the
+// agent drops to the login menu on its next start (#4596 reintroduced from
+// inside the manager, through the per-agent layout #4619 built to end it).
+// Every per-UID install must therefore be wrapped in su-exec, exactly like
+// tmuxCmd and setupCodexHome.
+func TestCavemanInstallArgvRunsAsAgentUser(t *testing.T) {
+	backends := []string{"claude", "copilot", "gemini", "goose", "codex", "aider"}
+	for _, backend := range backends {
+		argv := cavemanInstallArgv(backend, "full", "hive-scanner")
+		if len(argv) < 3 || argv[0] != "su-exec" || argv[1] != "hive-scanner" {
+			t.Errorf("backend %s: per-UID install must run via su-exec as the agent user, got %v", backend, argv)
+			continue
+		}
+		if argv[2] != "npx" {
+			t.Errorf("backend %s: expected npx after the su-exec prefix, got %v", backend, argv)
+		}
+	}
+}
+
+// TestCavemanInstallArgvSharedUIDStaysDirect pins the UID==0 path: agents
+// without an allocated UID run as the hive user, so there is no user to
+// switch to and no su-exec prefix (su-exec may not even exist on such
+// deployments).
+func TestCavemanInstallArgvSharedUIDStaysDirect(t *testing.T) {
+	argv := cavemanInstallArgv("claude", "minimal", "")
+	if len(argv) == 0 || argv[0] != "npx" {
+		t.Errorf("shared-UID install must invoke npx directly, got %v", argv)
+	}
+	for _, a := range argv {
+		if a == "su-exec" {
+			t.Errorf("shared-UID install must not use su-exec: %v", argv)
+		}
+	}
+}
+
+func TestCavemanInstallArgvUnsupportedBackend(t *testing.T) {
+	if argv := cavemanInstallArgv("mystery", "full", "hive-x"); argv != nil {
+		t.Errorf("unsupported backend must return nil, got %v", argv)
+	}
+}
+
+// TestCavemanNpmCachePathReplacesForeignOwnedCache covers the migration
+// burn: caches written back when the install ran as the hive user are owned
+// by the hive UID, and npm run as the agent UID EACCESes on those shards
+// (the same failure class as #2284). A cache owned by another UID must be
+// removed so the agent-owned install starts clean.
+func TestCavemanNpmCachePathReplacesForeignOwnedCache(t *testing.T) {
+	agentDir := t.TempDir()
+	cache := filepath.Join(agentDir, ".npm-caveman-cache")
+	if err := os.MkdirAll(filepath.Join(cache, "_cacache"), 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+
+	// Any UID other than the one that owns the dir we just made.
+	foreignUID := os.Getuid() + 1
+	got := cavemanNpmCachePath(agentDir, foreignUID)
+	if got != cache {
+		t.Errorf("removable foreign cache should be replaced in place, got %q", got)
+	}
+	if _, err := os.Stat(cache); !os.IsNotExist(err) {
+		t.Errorf("foreign-owned cache should have been removed, stat err = %v", err)
+	}
+}
+
+func TestCavemanNpmCachePathKeepsOwnCache(t *testing.T) {
+	agentDir := t.TempDir()
+	cache := filepath.Join(agentDir, ".npm-caveman-cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	if got := cavemanNpmCachePath(agentDir, os.Getuid()); got != cache {
+		t.Errorf("cache already owned by the agent must be kept, got %q", got)
+	}
+	if _, err := os.Stat(cache); err != nil {
+		t.Errorf("agent-owned cache must not be removed: %v", err)
+	}
+}
+
+// TestCavemanNpmCachePathFallsBackWhenRemovalFails pins the last-resort
+// path: a foreign-owned cache that cannot be removed is sidestepped with a
+// per-UID dir rather than allowed to fail the install with EACCES.
+func TestCavemanNpmCachePathFallsBackWhenRemovalFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — removal cannot be made to fail with permissions")
+	}
+	agentDir := t.TempDir()
+	cache := filepath.Join(agentDir, ".npm-caveman-cache")
+	if err := os.MkdirAll(filepath.Join(cache, "_cacache"), 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	// Read-only parent makes the unlink inside RemoveAll fail.
+	if err := os.Chmod(agentDir, 0o500); err != nil {
+		t.Fatalf("chmod agent dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(agentDir, 0o755) })
+
+	foreignUID := os.Getuid() + 1
+	got := cavemanNpmCachePath(agentDir, foreignUID)
+	want := fmt.Sprintf("%s-u%d", cache, foreignUID)
+	if got != want {
+		t.Errorf("unremovable foreign cache must fall back to a per-UID path: got %q want %q", got, want)
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2572,6 +2572,43 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 
 	m.logger.Info("installing caveman", "agent", agent.Name, "backend", backend, "mode", mode)
 
+	// The installer must run AS THE AGENT USER, not as the hive user. Caveman
+	// spawns the backend's own CLI (`claude plugin list` / `plugin install`,
+	// caveman bin/install.js), and Claude Code rewrites $HOME/.claude.json
+	// wholesale on every invocation. Run as the hive user with the agent's
+	// HOME, that CLI cannot read the agent-owned 0600 session file, treats
+	// the home as a fresh install, and replaces the signed-in session with a
+	// blank skeleton — the agent drops to the login menu on its next start.
+	// This is the #4596 wholesale-rewrite clobber reintroduced from inside
+	// the manager, through the per-agent home layout that #4619 built to end
+	// it. su-exec here matches every other command that touches the per-agent
+	// HOME (tmuxCmd, setupCodexHome).
+	userSpec := ""
+	if agent.UID > 0 {
+		userSpec = m.agentExecUserSpec(agent)
+	}
+	argv := cavemanInstallArgv(backend, mode, userSpec)
+	if argv == nil {
+		m.logger.Info("caveman not supported for backend", "backend", backend)
+		return
+	}
+
+	agentDir := filepath.Join("/data/agents", agent.Name)
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Dir = agentDir
+	npmCache := cavemanNpmCachePath(agentDir, agent.UID)
+	cmd.Env = append(os.Environ(), "HOME="+home, "npm_config_cache="+npmCache)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		m.logger.Warn("caveman install failed", "agent", agent.Name, "error", err, "output", string(out))
+	}
+}
+
+// cavemanInstallArgv builds the argv for a backend's caveman installer, or
+// nil for backends caveman does not support. A non-empty userSpec prefixes
+// the command with su-exec so the whole install — including the backend CLIs
+// caveman spawns — runs as the agent user (see installCavemanForAgent for
+// why that is load-bearing).
+func cavemanInstallArgv(backend, mode, userSpec string) []string {
 	// Pinned: unpinned HEAD broke every install on 2026-07-27 when upstream
 	// removed the --mode flag. Bump deliberately, after checking `--help`.
 	// v1.9.1 IS commit 0d95a81d35a9 — the SHA form is deliberately not used
@@ -2580,6 +2617,7 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 	// 0d95a81d35a9"), which broke every install on a live hive. Tags clone
 	// cleanly; bump the tag, never a raw SHA.
 	const cavemanRef = "github:JuliusBrussee/caveman#v1.9.1"
+	const skillsRef = "JuliusBrussee/caveman#v1.9.1"
 	// Upstream replaced `--mode full|minimal` with `--all` / `--minimal`
 	// (--all = hooks + init).
 	modeFlag := "--all"
@@ -2587,35 +2625,57 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 		modeFlag = "--minimal"
 	}
 
-	var cmd *exec.Cmd
+	var argv []string
 	switch backend {
 	case "claude":
-		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "claude", modeFlag)
+		argv = []string{"npx", "-y", cavemanRef, "--", "--only", "claude", modeFlag}
 	case "copilot":
-		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "copilot", "--with-init", modeFlag)
+		argv = []string{"npx", "-y", cavemanRef, "--", "--only", "copilot", "--with-init", modeFlag}
 	case "gemini":
-		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "gemini", modeFlag)
+		argv = []string{"npx", "-y", cavemanRef, "--", "--only", "gemini", modeFlag}
 	case "goose":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "goose", "-y")
+		argv = []string{"npx", "-y", "skills", "add", skillsRef, "-a", "goose", "-y"}
 	case "codex":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "codex", "-y")
+		argv = []string{"npx", "-y", "skills", "add", skillsRef, "-a", "codex", "-y"}
 	case "aider":
-		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman#v1.9.1", "-a", "aider-desk", "-y")
+		argv = []string{"npx", "-y", "skills", "add", skillsRef, "-a", "aider-desk", "-y"}
 	default:
-		m.logger.Info("caveman not supported for backend", "backend", backend)
-		return
+		return nil
 	}
+	if userSpec != "" {
+		argv = append([]string{"su-exec", userSpec}, argv...)
+	}
+	return argv
+}
 
-	cmd.Dir = filepath.Join("/data/agents", agent.Name)
-	// The shared npm cache under /data/home accumulates content-addressed
-	// entries owned by whichever agent UID wrote them first; npx run as the
-	// hive user then fails with EACCES on those shards and the agent launches
-	// without its proxy. A per-agent cache can never collide across UIDs.
-	npmCache := filepath.Join("/data/agents", agent.Name, ".npm-caveman-cache")
-	cmd.Env = append(os.Environ(), "HOME="+home, "npm_config_cache="+npmCache)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		m.logger.Warn("caveman install failed", "agent", agent.Name, "error", err, "output", string(out))
+// cavemanNpmCachePath returns the npm cache dir for an agent's caveman
+// install. The shared npm cache under /data/home accumulates
+// content-addressed entries owned by whichever UID wrote them first; npx
+// then fails with EACCES on those shards and the agent launches without its
+// proxy. A per-agent cache can never collide across UIDs.
+//
+// Caches written before the install ran as the agent user are owned by the
+// hive user, and npm EACCESes on them the same way — so a cache owned by
+// another UID is removed (best-effort; the hive user owns the old one and
+// can), and one that cannot be removed is sidestepped with a per-UID path
+// rather than allowed to fail the install.
+func cavemanNpmCachePath(agentDir string, uid int) string {
+	cache := filepath.Join(agentDir, ".npm-caveman-cache")
+	if uid <= 0 {
+		return cache
 	}
+	info, err := os.Stat(cache)
+	if err != nil {
+		return cache
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(st.Uid) == uid {
+		return cache
+	}
+	if err := os.RemoveAll(cache); err == nil {
+		return cache
+	}
+	return fmt.Sprintf("%s-u%d", cache, uid)
 }
 
 // samePaneCapture reports whether two pane captures are identical line for

--- a/src/pkg/agent/stuck_login_diagnosis.go
+++ b/src/pkg/agent/stuck_login_diagnosis.go
@@ -62,10 +62,20 @@ func (m *Manager) diagnoseStuckLogin(agent *AgentProcess) string {
 			credPath, session.Path, claudeOAuthAccountKey, home)
 
 	case credValid && session.State == claudeSessionUnreadable:
+		// Unreadable means unreadable BY THE HIVE PROCESS. Under the
+		// per-agent home layout that is the NORMAL state of a healthy
+		// signed-in agent — the CLI rewrites its session file agent-owned at
+		// 0600, which the hive user cannot read — so nothing about the
+		// agent's own view can be concluded from here. An earlier version of
+		// this message claimed the CLI itself could not load the identity,
+		// and that claim sent a real investigation down a permissions
+		// rabbit hole on a file the agent could read fine.
 		return fmt.Sprintf(
-			"credential at %s is present and valid, but the Claude session state at %s cannot be read "+
-				"(permission). The CLI shows the login menu because it cannot load the signed-in "+
-				"identity, not because the credential is missing. See kubestellar/hive#4596",
+			"credential at %s is present and valid, but the Claude session state at %s is not readable "+
+				"by the hive process (normal when the agent's CLI owns it at 0600), so whether it carries "+
+				"a signed-in identity cannot be determined from here — the agent itself may read it fine. "+
+				"Check the agent terminal before treating this as a permission problem. "+
+				"See kubestellar/hive#4596",
 			credPath, session.Path)
 
 	case credValid && session.State == claudeSessionSignedIn:

--- a/src/pkg/agent/stuck_login_diagnosis_test.go
+++ b/src/pkg/agent/stuck_login_diagnosis_test.go
@@ -345,3 +345,41 @@ func TestDiagnoseStuckLoginNonClaudeBackendStaysGeneric(t *testing.T) {
 		t.Errorf("diagnosis should name the backend:\n%s", got)
 	}
 }
+
+// TestDiagnoseStuckLoginUnreadableDoesNotBlameTheAgent pins the perspective
+// of the unreadable-session diagnosis. Under the per-agent home layout the
+// agent's CLI rewrites .claude.json agent-owned at 0600, which the hive
+// process cannot read — the NORMAL state of a healthy signed-in agent. An
+// earlier wording claimed "the CLI cannot load the signed-in identity",
+// which is a statement about the AGENT's view made from a process that
+// merely could not look; it sent a real investigation chasing a permission
+// problem on a file the agent read fine.
+func TestDiagnoseStuckLoginUnreadableDoesNotBlameTheAgent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — mode 0000 is still readable, so this cannot be measured")
+	}
+	home := t.TempDir()
+	agent := claudeHomeAgent(t, home)
+	m := &Manager{logger: slog.Default()}
+
+	credPath := writeClaudeCredential(t, home, time.Now().Add(6*time.Hour))
+	sessionPath := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(sessionPath, []byte(`{"oauthAccount":{"accountUuid":"a-1"}}`), 0o000); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	got := m.diagnoseStuckLogin(agent)
+	for _, want := range []string{credPath, sessionPath, "hive process"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diagnosis does not mention %q:\n%s", want, got)
+		}
+	}
+	// The message must not assert what the agent's own CLI can or cannot
+	// load — that is exactly the overclaim being removed.
+	if strings.Contains(got, "cannot load") {
+		t.Errorf("diagnosis must not claim the agent's CLI cannot load the identity:\n%s", got)
+	}
+	if !strings.Contains(got, "cannot be determined") {
+		t.Errorf("diagnosis should say the identity is undetermined from the hive's view:\n%s", got)
+	}
+}


### PR DESCRIPTION
## What

The caveman installer runs as the hive user with `HOME=` the agent's per-agent home. Caveman spawns the backend's own CLI (`claude plugin list` / `plugin marketplace add` / `plugin install` — caveman `bin/install.js:460-473`), and Claude Code rewrites `$HOME/.claude.json` wholesale on every invocation. Run as a uid that cannot read the agent-owned 0600 session file, the CLI treats the home as a fresh install and replaces the signed-in session with a blank skeleton. The agent drops to the login menu on its next start, and every re-login is destroyed again at the next launch — the #4596 wholesale-rewrite clobber reintroduced from inside the manager, through the per-agent layout #4619 built to end it.

This PR wraps the install in `su-exec` as the agent user whenever the agent has an allocated UID, matching every other command that touches the per-agent HOME (`tmuxCmd`, `setupCodexHome`).

## Observed on a live hive

Rootless podman deployment, three claude agents, current `:stable` (`64dd28e`). One agent (the one that had originally held the fleet's login, so its session files were agent-owned 0600) came back from every restart at the login menu:

- Its per-agent home accumulated `.claude.json.tmp.<pid>.<hash>` debris **owned by the hive uid** — Claude Code's atomic-write signature, from a process that should never write that file.
- Each clobber timestamped exactly at an `installing caveman` log line for that agent (three token-triggered restarts → three clobbers at 11:05, 11:10, 11:11; container restart → another at 11:19).
- Three operator re-seeds of `oauthAccount`/`hasCompletedOnboarding` into the file were each destroyed within seconds of the next agent launch. The file's `firstStartTime` was reset to the boot time on every clobber — a fresh-install write, not a merge.
- Agents whose session files had gone through `seedClaudeSessionForAgent` (written 0666, readable by the hive uid) survived every restart: the spawned CLI could read them and merged instead of resetting. The failure needs exactly one condition: a session file the hive process cannot read, which is what the agent's own CLI produces on every rewrite.

Making the file readable to the hive uid (mode 0666) on the live hive stopped the clobber immediately and the agent authenticated on the next start — confirming the read-failure → fresh-install-rewrite mechanism.

## Changes

- `installCavemanForAgent`: build the argv via a new `cavemanInstallArgv(backend, mode, userSpec)` and prefix it with `su-exec <agent-user>` when `agent.UID > 0`. UID-0 (shared-home) deployments are unchanged — no su-exec, same argv as before.
- npm cache: the per-agent `.npm-caveman-cache` was written by the hive uid until now, and npm run as the agent uid EACCESes on foreign-owned cacache shards (same failure class as #2284). `cavemanNpmCachePath` removes a foreign-owned cache (the hive uid owns the old one, so it can), falling back to a per-UID path when removal fails.
- `diagnoseStuckLogin`, unreadable-session case: the message claimed "the CLI shows the login menu because it cannot load the signed-in identity" — but *unreadable* is measured from the hive process, and under per-agent homes an agent-owned 0600 session file is the **normal** state of a healthy signed-in agent. That wording sent the live investigation above down a permissions rabbit hole on a file the agent read fine. It now states the hive-process perspective explicitly and stops asserting what the agent's own CLI can or cannot read.

## Tests

- `TestCavemanInstallArgvRunsAsAgentUser` — every supported backend's per-UID install is su-exec-wrapped.
- `TestCavemanInstallArgvSharedUIDStaysDirect` / `TestCavemanInstallArgvUnsupportedBackend` — UID-0 stays direct; unknown backends return nil.
- `TestCavemanNpmCachePathReplacesForeignOwnedCache` / `KeepsOwnCache` / `FallsBackWhenRemovalFails` — the cache migration matrix.
- `TestDiagnoseStuckLoginUnreadableDoesNotBlameTheAgent` — the diagnosis names the hive-process perspective and no longer claims the agent cannot load its identity.

Existing caveman guard tests (`TestCavemanPinIsNotBareSHA`, `TestCavemanSkillsAddIsHeadless`) still pass — the refactor keeps the refs and `skills add -y` shapes in `manager.go` where they scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Fable 5, high reasoning effort.
