### PR TITLE
fix(github): slow-start pacing after secondary rate limits

### DIFF
--- a/src/pkg/github/proxytrust.go
+++ b/src/pkg/github/proxytrust.go
@@ -231,7 +231,9 @@ func (t *proxyTrustPool) sharedTransport() *http.Transport {
 // underneath — the part that owns sockets — is shared and reaped, see
 // sharedTransport.
 func proxyTrustingHTTPClient(timeout time.Duration) *http.Client {
-	return &http.Client{Transport: sharedProxyTrust.sharedTransport(), Timeout: timeout}
+	// slowStartWrap paces requests globally after a secondary-rate-limit 403
+	// so the post-reset retry wave cannot re-trip the limit (see slowstart.go).
+	return &http.Client{Transport: slowStartWrap(sharedProxyTrust.sharedTransport()), Timeout: timeout}
 }
 
 // newJWTClient builds a go-github client authenticated with an App JWT whose

--- a/src/pkg/github/proxytrust_test.go
+++ b/src/pkg/github/proxytrust_test.go
@@ -157,9 +157,15 @@ func TestProxyTrustingHTTPClient_UsesPool(t *testing.T) {
 	if client.Timeout != mintClientTimeout {
 		t.Errorf("timeout = %v want %v", client.Timeout, mintClientTimeout)
 	}
-	tr, ok := client.Transport.(*http.Transport)
+	// The transport is now wrapped by the slow-start pacer (see slowstart.go);
+	// the proxy-trust guarantee lives on its INNER transport.
+	ss, ok := client.Transport.(*slowStartTransport)
 	if !ok {
-		t.Fatalf("transport type = %T", client.Transport)
+		t.Fatalf("transport type = %T, want *slowStartTransport wrapper", client.Transport)
+	}
+	tr, ok := ss.inner.(*http.Transport)
+	if !ok {
+		t.Fatalf("inner transport type = %T", ss.inner)
 	}
 	if tr.TLSClientConfig == nil || tr.TLSClientConfig.RootCAs == nil {
 		t.Fatal("expected RootCAs pool to be set on the mint client")

--- a/src/pkg/github/proxytrust_transport_leak_test.go
+++ b/src/pkg/github/proxytrust_transport_leak_test.go
@@ -36,8 +36,19 @@ func TestProxyTrustingHTTPClient_SharesTransport(t *testing.T) {
 	if c1 == c2 {
 		t.Fatal("clients must be per-call wrappers (they carry per-call timeouts)")
 	}
-	if c1.Transport != c2.Transport {
-		t.Fatal("mint clients must share ONE transport — a transport per call orphans a socket per call (#3875)")
+	// Each client gets its own slow-start wrapper (cheap, stateless beyond the
+	// shared pacing ledger); the SOCKET-POOL guarantee (#3875) lives on the
+	// wrapper's INNER transport, which must be one shared instance.
+	s1, ok1 := c1.Transport.(*slowStartTransport)
+	s2, ok2 := c2.Transport.(*slowStartTransport)
+	if !ok1 || !ok2 {
+		t.Fatalf("transport types = %T / %T, want *slowStartTransport wrappers", c1.Transport, c2.Transport)
+	}
+	if s1.inner != s2.inner {
+		t.Fatal("mint clients must share ONE inner transport — a transport per call orphans a socket per call (#3875)")
+	}
+	if s1.state != s2.state {
+		t.Fatal("slow-start pacing state must be shared — per-client state would let the retry herd stampede in aggregate")
 	}
 }
 

--- a/src/pkg/github/slowstart.go
+++ b/src/pkg/github/slowstart.go
@@ -1,0 +1,131 @@
+package github
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Slow-start pacing after a GitHub SECONDARY rate limit.
+//
+// GitHub's secondary limit throttles BURST/concurrency, not hourly volume.
+// When the hive trips it, go-github records the reset time and synthesizes
+// 403s client-side until then ("not making remote request") — but the moment
+// the window expires, every queued caller (pr-request watcher retries, the
+// enumeration pass, the automerge sweep, stats) fires SIMULTANEOUSLY, GitHub
+// sees the burst, and the limit re-trips for another hour. Observed live on
+// kubestellar/console (2026-08-23): three consecutive hourly re-trips —
+// 07:49 → 08:49 → 09:49 — with the spoke's entire GitHub output dark the
+// whole time. The client backed off correctly; it just un-backed-off as a
+// stampede.
+//
+// slowStartTransport breaks the loop at the one place all callers converge:
+// the shared HTTP transport. When a REAL secondary-limit 403 passes through
+// (identified by the Retry-After header GitHub attaches to abuse/secondary
+// blocks — permission 403s do not carry it), it enters a caution window
+// extending past the limit's reset. While cautious, requests are globally
+// serialized with a ~2s jittered gap — the post-reset wave becomes a trickle
+// the secondary limiter tolerates, and normal concurrency resumes when the
+// window ends.
+const (
+	// slowStartWindow is how long past the limit's reset the pacing lasts.
+	// Long enough for the queued backlog to drain gently; short enough that
+	// full throughput returns within one governor cycle.
+	slowStartWindow = 10 * time.Minute
+	// slowStartGap is the minimum spacing between requests while cautious.
+	slowStartGap = 2 * time.Second
+	// slowStartJitter is added (0..jitter) per request so even multiple
+	// spokes behind one App key do not phase-lock.
+	slowStartJitter = time.Second
+	// slowStartDefaultRetryAfter is assumed when a secondary 403 carries an
+	// unparseable Retry-After: cover a full secondary window.
+	slowStartDefaultRetryAfter = time.Hour
+)
+
+type slowStartTransport struct {
+	inner http.RoundTripper
+	// gap/jitter/window default from the package consts; fields so tests can
+	// use millisecond values without minute-long sleeps.
+	gap    time.Duration
+	jitter time.Duration
+	window time.Duration
+
+	mu            sync.Mutex
+	cautiousUntil time.Time
+	nextSlot      time.Time
+}
+
+func newSlowStartTransport(inner http.RoundTripper) *slowStartTransport {
+	return &slowStartTransport{
+		inner:  inner,
+		gap:    slowStartGap,
+		jitter: slowStartJitter,
+		window: slowStartWindow,
+	}
+}
+
+// sharedSlowStart wraps the process-wide proxy-trusting transport exactly once
+// so pacing is GLOBAL: the herd is a cross-caller phenomenon, and per-client
+// pacing would still stampede in aggregate.
+var (
+	sharedSlowStartOnce sync.Once
+	sharedSlowStartRT   *slowStartTransport
+)
+
+func slowStartWrap(inner http.RoundTripper) http.RoundTripper {
+	sharedSlowStartOnce.Do(func() {
+		sharedSlowStartRT = newSlowStartTransport(inner)
+	})
+	return sharedSlowStartRT
+}
+
+func (t *slowStartTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Pacing: while cautious, hand each request the next free slot and sleep
+	// until it. Slots are claimed under the lock; the sleep happens outside it
+	// so pacing serializes REQUEST STARTS, not the lock.
+	t.mu.Lock()
+	var wait time.Duration
+	now := time.Now()
+	if now.Before(t.cautiousUntil) {
+		gap := t.gap + time.Duration(rand.Int63n(int64(t.jitter)+1))
+		slot := t.nextSlot
+		if slot.Before(now) {
+			slot = now
+		}
+		t.nextSlot = slot.Add(gap)
+		wait = slot.Sub(now)
+	}
+	t.mu.Unlock()
+
+	if wait > 0 {
+		timer := time.NewTimer(wait)
+		select {
+		case <-req.Context().Done():
+			timer.Stop()
+			return nil, req.Context().Err()
+		case <-timer.C:
+		}
+	}
+
+	resp, err := t.inner.RoundTrip(req)
+
+	// A real secondary-limit 403 carries Retry-After. Enter (or extend) the
+	// caution window to its reset plus the slow-start tail.
+	if err == nil && resp != nil && resp.StatusCode == http.StatusForbidden {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			after := slowStartDefaultRetryAfter
+			if secs, perr := strconv.Atoi(ra); perr == nil && secs >= 0 {
+				after = time.Duration(secs) * time.Second
+			}
+			until := time.Now().Add(after + t.window)
+			t.mu.Lock()
+			if until.After(t.cautiousUntil) {
+				t.cautiousUntil = until
+			}
+			t.mu.Unlock()
+		}
+	}
+	return resp, err
+}

--- a/src/pkg/github/slowstart.go
+++ b/src/pkg/github/slowstart.go
@@ -44,8 +44,14 @@ const (
 	slowStartDefaultRetryAfter = time.Hour
 )
 
-type slowStartTransport struct {
-	inner http.RoundTripper
+// slowStartState is the shared pacing ledger. It is deliberately SEPARATE
+// from the wrapper that carries the inner transport: pacing must be global
+// (the herd is a cross-caller phenomenon — per-client pacing would still
+// stampede in aggregate), but the inner transport must be whatever is CURRENT
+// at wrap time. An earlier design cached the first inner in a sync.Once,
+// which pinned the process to a stale transport after the proxy-trust layer
+// rebuilt it (new CA) — every later client silently used dead TLS roots.
+type slowStartState struct {
 	// gap/jitter/window default from the package consts; fields so tests can
 	// use millisecond values without minute-long sleeps.
 	gap    time.Duration
@@ -57,47 +63,50 @@ type slowStartTransport struct {
 	nextSlot      time.Time
 }
 
-func newSlowStartTransport(inner http.RoundTripper) *slowStartTransport {
-	return &slowStartTransport{
-		inner:  inner,
+type slowStartTransport struct {
+	inner http.RoundTripper
+	state *slowStartState
+}
+
+func newSlowStartState() *slowStartState {
+	return &slowStartState{
 		gap:    slowStartGap,
 		jitter: slowStartJitter,
 		window: slowStartWindow,
 	}
 }
 
-// sharedSlowStart wraps the process-wide proxy-trusting transport exactly once
-// so pacing is GLOBAL: the herd is a cross-caller phenomenon, and per-client
-// pacing would still stampede in aggregate.
-var (
-	sharedSlowStartOnce sync.Once
-	sharedSlowStartRT   *slowStartTransport
-)
+func newSlowStartTransport(inner http.RoundTripper) *slowStartTransport {
+	return &slowStartTransport{inner: inner, state: newSlowStartState()}
+}
+
+// sharedSlowStartState is the process-wide pacing ledger every wrapped client
+// shares. The wrapper itself is cheap and constructed per client around the
+// CURRENT inner transport.
+var sharedSlowStartState = newSlowStartState()
 
 func slowStartWrap(inner http.RoundTripper) http.RoundTripper {
-	sharedSlowStartOnce.Do(func() {
-		sharedSlowStartRT = newSlowStartTransport(inner)
-	})
-	return sharedSlowStartRT
+	return &slowStartTransport{inner: inner, state: sharedSlowStartState}
 }
 
 func (t *slowStartTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Pacing: while cautious, hand each request the next free slot and sleep
 	// until it. Slots are claimed under the lock; the sleep happens outside it
 	// so pacing serializes REQUEST STARTS, not the lock.
-	t.mu.Lock()
+	st := t.state
+	st.mu.Lock()
 	var wait time.Duration
 	now := time.Now()
-	if now.Before(t.cautiousUntil) {
-		gap := t.gap + time.Duration(rand.Int63n(int64(t.jitter)+1))
-		slot := t.nextSlot
+	if now.Before(st.cautiousUntil) {
+		gap := st.gap + time.Duration(rand.Int63n(int64(st.jitter)+1))
+		slot := st.nextSlot
 		if slot.Before(now) {
 			slot = now
 		}
-		t.nextSlot = slot.Add(gap)
+		st.nextSlot = slot.Add(gap)
 		wait = slot.Sub(now)
 	}
-	t.mu.Unlock()
+	st.mu.Unlock()
 
 	if wait > 0 {
 		timer := time.NewTimer(wait)
@@ -119,12 +128,12 @@ func (t *slowStartTransport) RoundTrip(req *http.Request) (*http.Response, error
 			if secs, perr := strconv.Atoi(ra); perr == nil && secs >= 0 {
 				after = time.Duration(secs) * time.Second
 			}
-			until := time.Now().Add(after + t.window)
-			t.mu.Lock()
-			if until.After(t.cautiousUntil) {
-				t.cautiousUntil = until
+			until := time.Now().Add(after + st.window)
+			st.mu.Lock()
+			if until.After(st.cautiousUntil) {
+				st.cautiousUntil = until
 			}
-			t.mu.Unlock()
+			st.mu.Unlock()
 		}
 	}
 	return resp, err

--- a/src/pkg/github/slowstart_test.go
+++ b/src/pkg/github/slowstart_test.go
@@ -33,9 +33,9 @@ func TestSlowStart_PacesAfterSecondaryLimit(t *testing.T) {
 	defer srv.Close()
 
 	tr := newSlowStartTransport(http.DefaultTransport)
-	tr.gap = 60 * time.Millisecond
-	tr.jitter = time.Millisecond
-	tr.window = time.Second
+	tr.state.gap = 60 * time.Millisecond
+	tr.state.jitter = time.Millisecond
+	tr.state.window = time.Second
 	client := &http.Client{Transport: tr}
 
 	// Trip the limit.
@@ -69,8 +69,8 @@ func TestSlowStart_PacesAfterSecondaryLimit(t *testing.T) {
 	// for scheduler slop).
 	for i := 2; i < len(starts); i++ {
 		d := starts[i].Sub(starts[i-1])
-		if d < tr.gap-10*time.Millisecond {
-			t.Errorf("requests %d->%d only %v apart, want >= %v (stampede not paced)", i-1, i, d, tr.gap)
+		if d < tr.state.gap-10*time.Millisecond {
+			t.Errorf("requests %d->%d only %v apart, want >= %v (stampede not paced)", i-1, i, d, tr.state.gap)
 		}
 	}
 }
@@ -84,8 +84,8 @@ func TestSlowStart_Plain403AndNormalTrafficUnpaced(t *testing.T) {
 	defer srv.Close()
 
 	tr := newSlowStartTransport(http.DefaultTransport)
-	tr.gap = time.Hour // if pacing engaged, the test would hang far past its deadline
-	tr.window = time.Hour
+	tr.state.gap = time.Hour // if pacing engaged, the test would hang far past its deadline
+	tr.state.window = time.Hour
 	client := &http.Client{Transport: tr}
 
 	start := time.Now()

--- a/src/pkg/github/slowstart_test.go
+++ b/src/pkg/github/slowstart_test.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A secondary-limit 403 (Retry-After present) must engage the caution window,
+// and cautious requests must be globally paced — the post-reset wave becomes a
+// trickle instead of the stampede that re-tripped the limit hourly on
+// kubestellar/console (2026-08-23).
+func TestSlowStart_PacesAfterSecondaryLimit(t *testing.T) {
+	var mu sync.Mutex
+	var starts []time.Time
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		n := hits
+		starts = append(starts, time.Now())
+		mu.Unlock()
+		if n == 1 {
+			// First request trips the secondary limit.
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := newSlowStartTransport(http.DefaultTransport)
+	tr.gap = 60 * time.Millisecond
+	tr.jitter = time.Millisecond
+	tr.window = time.Second
+	client := &http.Client{Transport: tr}
+
+	// Trip the limit.
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// Burst: with Retry-After=0 the reset is immediate; the caution window is
+	// what must pace the burst.
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, gerr := client.Get(srv.URL)
+			if gerr == nil {
+				r.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(starts) != 5 {
+		t.Fatalf("want 5 requests, got %d", len(starts))
+	}
+	// The 4 cautious requests (2..5) must be spaced by >= gap (small epsilon
+	// for scheduler slop).
+	for i := 2; i < len(starts); i++ {
+		d := starts[i].Sub(starts[i-1])
+		if d < tr.gap-10*time.Millisecond {
+			t.Errorf("requests %d->%d only %v apart, want >= %v (stampede not paced)", i-1, i, d, tr.gap)
+		}
+	}
+}
+
+// A permissions-style 403 (no Retry-After) must NOT engage pacing, and
+// requests outside a caution window run unpaced.
+func TestSlowStart_Plain403AndNormalTrafficUnpaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // no Retry-After
+	}))
+	defer srv.Close()
+
+	tr := newSlowStartTransport(http.DefaultTransport)
+	tr.gap = time.Hour // if pacing engaged, the test would hang far past its deadline
+	tr.window = time.Hour
+	client := &http.Client{Transport: tr}
+
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("plain 403s must not engage pacing; 3 requests took %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Live incident (kubestellar/console, today)
The spoke tripped GitHub's **secondary rate limit**, and then re-tripped it **three consecutive times** (07:49 → 08:49 → 09:49 EDT), keeping its entire GitHub output (advisories, PR creation, enumeration, stats) dark for 4+ hours. The go-github client backed off correctly each window — but at every reset boundary, all queued callers (pr-request watcher retries, enumeration pass, automerge sweep, stats) fired **simultaneously**, GitHub saw the burst, and the limit re-tripped. A self-sustaining thundering herd.

## Fix
`slowStartTransport`, wrapped once around the **shared** proxy-trusting transport (the herd is cross-caller; per-client pacing would still stampede in aggregate):
- A real secondary 403 — identified by the `Retry-After` header GitHub attaches to abuse/secondary blocks (permission 403s carry none) — opens a **caution window** extending 10 min past the reset.
- While cautious, requests are globally serialized with a **~2s jittered gap**: the post-reset wave becomes a trickle the secondary limiter tolerates.
- Full concurrency resumes when the window closes. Normal traffic is untouched (zero overhead outside caution).

## Tests
- `TestSlowStart_PacesAfterSecondaryLimit`: burst after a Retry-After 403 is spaced ≥gap.
- `TestSlowStart_Plain403AndNormalTrafficUnpaced`: permission 403s never engage pacing.