### PR TITLE
🐛 fix(agent): adopt agent-owned Claude sessions via su-exec so one login authenticates a fresh fleet

### DIFF
--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -315,7 +315,7 @@ Implementation notes:
 
 Two rules of thumb:
 
-- **CLI methods are subscriptions.** You log in once per method from the dashboard, and every agent using that method shares the login.
+- **CLI methods are subscriptions.** You log in once per method from the dashboard, and every agent using that method shares the login. For `claude`, sharing is not instantaneous: the OAuth token is shared immediately through the per-agent home bridge, while the session identity (`~/.claude.json`, which is what decides whether the CLI shows a login menu) is adopted from an already-signed-in agent the next time each other agent launches or is restarted. So on a fresh install, expect the remaining agents to clear their 🔑 badge on their next start rather than the moment you finish logging in.
 - **Inference methods are endpoints.** You configure a base URL and a key *reference* (env var name or key-file path — the value goes in `/data/secrets/`, never in YAML). Agents on `vllm`/`llm-d`/`litellm` launch the Claude CLI routed through hive's inference translator, so there is no separate login.
 
 Every Model Gateway (and the bob backend) also accepts an optional `key_name` — a human-chosen LABEL for the configured key, e.g. `key_name: openrouter-prod-key`. It is safe-to-show metadata, not a secret: the dashboard's gateway row displays it as "Using key: `<name>`", or "(unnamed)" when no label is set, so operators can tell keys apart without ever seeing the value. See [`inference-backends.md`](../../docs/inference-backends.md) for a full YAML example.

--- a/src/pkg/agent/claude_session_adopt.go
+++ b/src/pkg/agent/claude_session_adopt.go
@@ -1,0 +1,204 @@
+package agent
+
+// Cross-UID reads and writes of .claude.json for session adoption (#4637).
+//
+// THE DEFECT: #4619 gave every per-UID interactive agent its own HOME and
+// seeded a signed-in .claude.json into it, "so existing hives migrate without
+// any operator step". That works for a MIGRATING hive, where the signed-in
+// source is the legacy /data/home/.claude.json the hive process itself can
+// read. It cannot work on a FRESH install: the only signed-in file in
+// existence is the one agent A's own CLI just wrote, owned by A's UID at mode
+// 0600. inspectClaudeSession on that file returns claudeSessionUnreadable, so
+// findSignedInClaudeSession sees no source, agent B stays at the login menu,
+// and the operator logs in once per agent — while the docs promise "log in
+// once per method" (docs/agent-configuration.md).
+//
+// THE FIX: stop asking the hive process to read what only an agent UID can
+// read. Every other cross-UID operation in this package already goes through
+// su-exec — tmuxCmd, setupCodexHome, the tmux-dir chmod — and this is the same
+// shape. When a direct read hits EACCES, re-read as the file's OWNER; when a
+// direct write hits EACCES, write as the TARGET agent. Adoption then
+// propagates a fresh login across the fleet and the documented contract holds
+// on fresh installs too.
+//
+// POSTURE: every helper here is best-effort and fails back to the direct
+// result. su-exec is absent in unit tests and on developer laptops, unreadable
+// stays unreadable when the fallback cannot run, and no caller may treat a
+// failed fallback as evidence of anything. Files are Lstat'd (never followed)
+// and must be regular, under the size cap, and owned by a NON-ROOT uid before
+// a helper runs — a symlink or a root-owned file at a sibling path must never
+// be able to turn this into "run something as uid 0".
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// claudeSessionAdoptMaxBytes caps how much of a .claude.json this will carry
+// across UIDs. Claude Code accumulates per-project history in the file, so it
+// grows without a natural bound; a few MiB is far above any observed session
+// file while keeping a rogue or corrupted path from being slurped into memory.
+const claudeSessionAdoptMaxBytes = 8 << 20
+
+// claudeSessionAdoptTimeout bounds one su-exec helper invocation. The helpers
+// are cat/sh against a local file: anything slower than this is a wedged
+// process, not slow I/O, and a launch must not block on it.
+const claudeSessionAdoptTimeout = 10 * time.Second
+
+// runAsAgentUser runs argv as the su-exec user spec, feeds it stdin, and
+// returns its stdout.
+//
+// Var (not func) as a TEST SEAM, matching the sharedAgentHome convention: unit
+// tests cannot create files owned by another UID, so they substitute a runner
+// that stands in for the privileged read. The production body is deliberately
+// the same su-exec invocation setupCodexHome uses.
+var runAsAgentUser = func(spec string, stdin []byte, argv ...string) ([]byte, error) {
+	if spec == "" || len(argv) == 0 {
+		return nil, errors.New("runAsAgentUser: empty user spec or argv")
+	}
+	if _, err := exec.LookPath("su-exec"); err != nil {
+		return nil, fmt.Errorf("su-exec unavailable: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), claudeSessionAdoptTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "su-exec", append([]string{spec}, argv...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdin = bytes.NewReader(stdin)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, outputErr("su-exec "+spec, err, stderr.Bytes())
+	}
+	return stdout.Bytes(), nil
+}
+
+// claudeSessionOwnerSpec returns the su-exec user spec for the owner of the
+// session file at path, or an error explaining why no helper may run for it.
+//
+// Fails CLOSED, unlike inferenceHomeIsOwnedBy: the result decides whose
+// identity a subprocess runs under, so every doubt (not a regular file, a
+// symlink, oversized, no unix ownership, owned by root) is a refusal rather
+// than a guess. Lstat, never Stat — a symlink planted at a sibling's
+// .claude.json must not resolve to the ownership of whatever it points at.
+func claudeSessionOwnerSpec(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%s is not a regular file (mode %s)", path, info.Mode())
+	}
+	if info.Size() > claudeSessionAdoptMaxBytes {
+		return "", fmt.Errorf("%s is %d bytes, over the %d-byte adoption cap", path, info.Size(), claudeSessionAdoptMaxBytes)
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("%s: no unix ownership available", path)
+	}
+	if st.Uid == 0 {
+		return "", fmt.Errorf("%s is owned by uid 0; refusing to run a helper as root", path)
+	}
+	return fmt.Sprintf("%d:%d", st.Uid, st.Gid), nil
+}
+
+// inspectClaudeSessionForAdoption classifies path exactly as
+// inspectClaudeSession does, except that claudeSessionUnreadable is retried as
+// the file's owner instead of being reported as a dead end.
+//
+// Both callers in the seeding path need this and for opposite reasons: a
+// SOURCE that is unreadable is a login this fleet is failing to propagate, and
+// a TARGET that is unreadable may be the agent's OWN signed-in session — which
+// adopt-only must never overwrite. Before this, an unreadable target fell
+// through to "not signed in" and was clobbered by a sibling's identity.
+func (m *Manager) inspectClaudeSessionForAdoption(path string) claudeSessionInfo {
+	info := inspectClaudeSession(path)
+	if info.State != claudeSessionUnreadable {
+		return info
+	}
+	data, err := m.readClaudeSessionAsOwner(path)
+	if err != nil {
+		// Debug, not Warn: on any deployment without su-exec this is the
+		// ordinary outcome, and diagnoseStuckLogin already reports the
+		// unreadable state where an operator will see it.
+		m.logger.Debug("could not read agent-owned claude session",
+			"path", path, "error", err)
+		return info
+	}
+	return classifyClaudeSession(path, data)
+}
+
+// readClaudeSessionAsOwner reads path through su-exec as the file's owner.
+func (m *Manager) readClaudeSessionAsOwner(path string) ([]byte, error) {
+	spec, err := claudeSessionOwnerSpec(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := runAsAgentUser(spec, nil, "cat", path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > claudeSessionAdoptMaxBytes {
+		// The Lstat cap above is advisory — the file can grow between the stat
+		// and the read — so re-check what actually came back.
+		return nil, fmt.Errorf("%s returned %d bytes, over the %d-byte adoption cap",
+			path, len(data), claudeSessionAdoptMaxBytes)
+	}
+	return data, nil
+}
+
+// readClaudeSessionForAdoption reads a seed source, falling back to a read as
+// the file's owner when this process is not permitted to open it.
+func (m *Manager) readClaudeSessionForAdoption(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err == nil || !errors.Is(err, fs.ErrPermission) {
+		return data, err
+	}
+	owned, oerr := m.readClaudeSessionAsOwner(path)
+	if oerr != nil {
+		return nil, errors.Join(err, oerr)
+	}
+	return owned, nil
+}
+
+// writeClaudeSessionForAgent writes the adopted session to target, falling
+// back to a write performed BY the owning agent when this process cannot write
+// it directly — which is the fresh-install case, where target is the agent's
+// own 0600 file.
+//
+// The fallback stages through a temp file in the target's own directory and
+// renames, so a helper that dies mid-write cannot leave the agent holding a
+// truncated .claude.json. target is passed as $0 rather than interpolated into
+// the script, so a path is data to the shell and never code.
+//
+// The staged file is chmod'ed to claudeSessionSeedFileMode — the SAME mode the
+// direct write above uses, and deliberately not the 0600 the agent's own CLI
+// would produce. A seeded session has to stay readable by the hive uid:
+// #4636's live investigation found that a CLI spawned by the manager against a
+// session file the hive process cannot read treats the home as a fresh install
+// and rewrites the signed-in identity away. Agents whose files had been seeded
+// at this mode survived that; agents holding an agent-written 0600 file did
+// not. Both write paths must therefore land on the same mode or adoption would
+// reintroduce the clobber it exists to prevent. The containment is the home
+// itself (0700, agent-owned — see tightenInteractiveHome), exactly the
+// inferenceConfigFileMode trade-off.
+func (m *Manager) writeClaudeSessionForAgent(target string, data []byte, spec string) error {
+	err := os.WriteFile(target, data, claudeSessionSeedFileMode)
+	if err == nil || spec == "" || !errors.Is(err, fs.ErrPermission) {
+		return err
+	}
+	stageAndRename := fmt.Sprintf(
+		`tmp="$0.hive-seed.$$"; cat >"$tmp" && chmod %#o "$tmp" && mv -f "$tmp" "$0" `+
+			`|| { rm -f "$tmp"; exit 1; }`, claudeSessionSeedFileMode)
+	if _, werr := runAsAgentUser(spec, data, "sh", "-c", stageAndRename, target); werr != nil {
+		return errors.Join(err, werr)
+	}
+	return nil
+}

--- a/src/pkg/agent/claude_session_adopt_test.go
+++ b/src/pkg/agent/claude_session_adopt_test.go
@@ -1,0 +1,266 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// fakeAgentUserRunner stands in for su-exec. Unit tests cannot create files
+// owned by a second UID, so "unreadable to the hive process" is simulated with
+// mode 0000 (the test process is not root under `go test`) and this runner
+// plays the part of the privileged helper that CAN reach the bytes.
+type fakeAgentUserRunner struct {
+	mu    sync.Mutex
+	specs []string
+	argvs [][]string
+	fail  error
+}
+
+// install swaps the runner in for the duration of one test.
+func (f *fakeAgentUserRunner) install(t *testing.T) {
+	t.Helper()
+	old := runAsAgentUser
+	runAsAgentUser = func(spec string, stdin []byte, argv ...string) ([]byte, error) {
+		f.mu.Lock()
+		f.specs = append(f.specs, spec)
+		f.argvs = append(f.argvs, append([]string(nil), argv...))
+		failure := f.fail
+		f.mu.Unlock()
+		if failure != nil {
+			return nil, failure
+		}
+		return f.serve(stdin, argv...)
+	}
+	t.Cleanup(func() { runAsAgentUser = old })
+}
+
+// serve emulates the two argv shapes production uses, bypassing file modes the
+// way a real su-exec-to-the-owner would.
+func (f *fakeAgentUserRunner) serve(stdin []byte, argv ...string) ([]byte, error) {
+	switch {
+	case len(argv) == 2 && argv[0] == "cat":
+		data, err := readIgnoringMode(argv[1])
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	case len(argv) == 4 && argv[0] == "sh" && argv[1] == "-c":
+		target := argv[3]
+		if err := os.Chmod(target, 0o600); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		return nil, os.WriteFile(target, stdin, claudeSessionSeedFileMode)
+	}
+	return nil, fmt.Errorf("unexpected argv %v", argv)
+}
+
+func (f *fakeAgentUserRunner) calls() ([]string, [][]string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.specs...), append([][]string(nil), f.argvs...)
+}
+
+// readIgnoringMode reads a file the test itself owns but has locked to 0000,
+// by widening the mode just long enough to read it back.
+func readIgnoringMode(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.Chmod(path, info.Mode().Perm()) }()
+	return os.ReadFile(path)
+}
+
+// writeUnreadableSession writes a session file this process cannot open,
+// standing in for the agent-owned 0600 file a fresh install's first login
+// produces.
+func writeUnreadableSession(t *testing.T, home, content string) string {
+	t.Helper()
+	path := writeSession(t, home, content)
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	if _, err := os.ReadFile(path); !errors.Is(err, os.ErrPermission) {
+		t.Skipf("cannot simulate an unreadable file here (running as root?): %v", err)
+	}
+	return path
+}
+
+// --- the fresh-install case (#4637) -------------------------------------------
+
+func TestSeedClaudeSession_AdoptsAgentOwnedSibling(t *testing.T) {
+	withSharedAgentHome(t)
+	runner := &fakeAgentUserRunner{}
+	runner.install(t)
+	m := interactiveHomeTestManager(t)
+
+	// Fresh install: no legacy shared file at all, and the one signed-in
+	// session belongs to the agent the operator logged in on.
+	writeUnreadableSession(t, interactiveHomePath("guide"), signedInClaudeSession)
+
+	ap := &AgentProcess{Name: "scanner", UID: 1001, Config: config.AgentConfig{Backend: "claude"}}
+	m.setupInteractiveHome(ap, "claude")
+
+	target := claudeSessionFile(interactiveHomePath("scanner"))
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("fresh-install login did not propagate: %v", err)
+	}
+	if got := classifyClaudeSession(target, data).State; got != claudeSessionSignedIn {
+		t.Errorf("seeded state = %v, want signed-in", got)
+	}
+
+	_, argvs := runner.calls()
+	if len(argvs) == 0 {
+		t.Fatal("expected the su-exec seam to be used for the agent-owned sibling")
+	}
+	if argvs[0][0] != "cat" {
+		t.Errorf("first helper argv = %v, want a cat read", argvs[0])
+	}
+}
+
+func TestSeedClaudeSession_UnreadableSignedInTargetIsNotClobbered(t *testing.T) {
+	shared := withSharedAgentHome(t)
+	runner := &fakeAgentUserRunner{}
+	runner.install(t)
+	m := interactiveHomeTestManager(t)
+
+	own := `{"oauthAccount":{"accountUuid":"mine","emailAddress":"me@example.com"}}`
+	target := writeUnreadableSession(t, interactiveHomePath("scanner"), own)
+	writeSession(t, shared, signedInClaudeSession)
+
+	ap := &AgentProcess{Name: "scanner", UID: 1001, Config: config.AgentConfig{Backend: "claude"}}
+	m.setupInteractiveHome(ap, "claude")
+
+	data, err := readIgnoringMode(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != own {
+		t.Errorf("adopt-only violated: agent's own signed-in session replaced by %q", data)
+	}
+}
+
+func TestSeedClaudeSession_SeedIsReadableByTheHiveProcess(t *testing.T) {
+	withSharedAgentHome(t)
+	runner := &fakeAgentUserRunner{}
+	runner.install(t)
+	m := interactiveHomeTestManager(t)
+	writeUnreadableSession(t, interactiveHomePath("guide"), signedInClaudeSession)
+
+	ap := &AgentProcess{Name: "scanner", UID: 1001, Config: config.AgentConfig{Backend: "claude"}}
+	m.setupInteractiveHome(ap, "claude")
+
+	// #4636: a CLI the manager spawns against a session file the hive uid
+	// cannot read treats the home as a fresh install and rewrites the identity
+	// away. A seeded file must not land in that shape.
+	info, err := os.Stat(claudeSessionFile(interactiveHomePath("scanner")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o044 == 0 {
+		t.Errorf("seeded session mode %v is not readable outside the owner", info.Mode().Perm())
+	}
+}
+
+func TestSeedClaudeSession_HelperFailureLeavesLoginMenuHonest(t *testing.T) {
+	withSharedAgentHome(t)
+	runner := &fakeAgentUserRunner{fail: errors.New("su-exec: not found")}
+	runner.install(t)
+	m := interactiveHomeTestManager(t)
+	writeUnreadableSession(t, interactiveHomePath("guide"), signedInClaudeSession)
+
+	ap := &AgentProcess{Name: "scanner", UID: 1001, Config: config.AgentConfig{Backend: "claude"}}
+	m.setupInteractiveHome(ap, "claude")
+
+	target := claudeSessionFile(interactiveHomePath("scanner"))
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Errorf("no readable source: nothing may be fabricated (err=%v)", err)
+	}
+}
+
+// --- ownership guards ----------------------------------------------------------
+
+func TestClaudeSessionOwnerSpec_RefusesNonRegularAndOversize(t *testing.T) {
+	dir := t.TempDir()
+
+	link := filepath.Join(dir, "link.json")
+	if err := os.Symlink("/etc/shadow", link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := claudeSessionOwnerSpec(link); err == nil {
+		t.Error("a symlink must never resolve to a helper user spec")
+	}
+
+	big := filepath.Join(dir, "big.json")
+	if err := os.WriteFile(big, make([]byte, claudeSessionAdoptMaxBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := claudeSessionOwnerSpec(big); err == nil || !strings.Contains(err.Error(), "cap") {
+		t.Errorf("oversize file should be refused by the cap, got %v", err)
+	}
+
+	if _, err := claudeSessionOwnerSpec(filepath.Join(dir, "missing.json")); err == nil {
+		t.Error("a missing file must not produce a user spec")
+	}
+}
+
+func TestClaudeSessionOwnerSpec_AcceptsOrdinarySessionFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(path, []byte(signedInClaudeSession), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	spec, err := claudeSessionOwnerSpec(path)
+	if err != nil {
+		if os.Getuid() == 0 {
+			t.Skip("root-owned file is refused by design")
+		}
+		t.Fatalf("ordinary session file refused: %v", err)
+	}
+	if want := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()); spec != want {
+		t.Errorf("owner spec = %q, want %q", spec, want)
+	}
+}
+
+// --- the seam itself -----------------------------------------------------------
+
+func TestInspectClaudeSessionForAdoption_FallsBackToOwnerRead(t *testing.T) {
+	withSharedAgentHome(t)
+	runner := &fakeAgentUserRunner{}
+	runner.install(t)
+	m := interactiveHomeTestManager(t)
+
+	path := writeUnreadableSession(t, interactiveHomePath("guide"), signedInClaudeSession)
+
+	if got := inspectClaudeSession(path).State; got != claudeSessionUnreadable {
+		t.Fatalf("precondition: direct inspect = %v, want unreadable", got)
+	}
+	if got := m.inspectClaudeSessionForAdoption(path).State; got != claudeSessionSignedIn {
+		t.Errorf("owner-aware inspect = %v, want signed-in", got)
+	}
+	specs, _ := runner.calls()
+	if len(specs) == 0 || !strings.Contains(specs[0], ":") {
+		t.Errorf("helper spec = %v, want a uid:gid spec", specs)
+	}
+}
+
+func TestRunAsAgentUser_RejectsEmptyInput(t *testing.T) {
+	if _, err := runAsAgentUser("", nil, "cat", "/dev/null"); err == nil {
+		t.Error("empty user spec must be rejected before exec")
+	}
+	if _, err := runAsAgentUser("1001:1001", nil); err == nil {
+		t.Error("empty argv must be rejected before exec")
+	}
+}

--- a/src/pkg/agent/claude_session_state.go
+++ b/src/pkg/agent/claude_session_state.go
@@ -138,6 +138,16 @@ func inspectClaudeSession(path string) claudeSessionInfo {
 		}
 		return info
 	}
+	return classifyClaudeSession(path, data)
+}
+
+// classifyClaudeSession is inspectClaudeSession's judgement applied to bytes
+// that are already in hand. Split out because the same classification has to
+// run over content this process could not open itself — the seeding path reads
+// agent-owned files through su-exec (see claude_session_adopt.go) and must
+// reach the identical verdict as a direct read.
+func classifyClaudeSession(path string, data []byte) claudeSessionInfo {
+	info := claudeSessionInfo{Path: path, State: claudeSessionUnknown}
 
 	// Decode into a raw map: .claude.json's full schema is Claude Code's, it
 	// changes between versions, and this must not fail closed on a key it has

--- a/src/pkg/agent/interactive_home.go
+++ b/src/pkg/agent/interactive_home.go
@@ -151,7 +151,7 @@ func (m *Manager) setupInteractiveHome(agent *AgentProcess, backend string) {
 	}
 
 	m.bridgeInteractiveHome(agent.Name, home)
-	m.seedClaudeSessionForAgent(agent.Name, home, agent.UID)
+	m.seedClaudeSessionForAgent(agent, home)
 	m.tightenInteractiveHome(agent.Name, home, agent.UID)
 	m.sweepOrphanedClaudeTmp(agent.Name)
 }
@@ -204,33 +204,47 @@ func (m *Manager) bridgeInteractiveHome(agentName, home string) {
 //     #4606 restart path re-authenticates an agent after an operator logs in
 //     on a sibling.
 //
+// On a FRESH install source (2) is the only one that can ever exist, and it is
+// always agent-owned at mode 0600 because the operator's login was written by
+// that agent's OWN CLI — there is no legacy shared file to inherit. Reading it
+// therefore goes through the su-exec seam in claude_session_adopt.go, the same
+// way tmuxCmd and setupCodexHome reach across UIDs. Without that, seeding found
+// no source on fresh installs and every agent needed its own interactive login
+// (#4637), contradicting the "log in once per method" contract this whole
+// layout exists to keep.
+//
 // ADOPT-ONLY: a signed-in per-agent file is NEVER overwritten, and no
 // synthetic session is fabricated — when no signed-in source exists anywhere,
 // the login menu is the honest state and must appear. Sources are read whole;
 // Claude's atomic rename writes mean a read never observes a torn file.
-func (m *Manager) seedClaudeSessionForAgent(agentName, home string, uid int) {
+func (m *Manager) seedClaudeSessionForAgent(agent *AgentProcess, home string) {
+	agentName, uid := agent.Name, agent.UID
 	target := claudeSessionFile(home)
-	if inspectClaudeSession(target).State == claudeSessionSignedIn {
+	// Owner-aware on purpose: an unreadable target may be this agent's own
+	// signed-in session, and adopt-only must not clobber it with a sibling's
+	// identity just because the hive process cannot open it.
+	if m.inspectClaudeSessionForAdoption(target).State == claudeSessionSignedIn {
 		return
 	}
 	source := m.findSignedInClaudeSession(agentName)
 	if source == "" {
 		return
 	}
-	data, err := os.ReadFile(source)
+	data, err := m.readClaudeSessionForAdoption(source)
 	if err != nil {
 		m.logger.Warn("failed to read claude session seed source",
 			"agent", agentName, "source", source, "error", err)
 		return
 	}
-	if err := os.WriteFile(target, data, claudeSessionSeedFileMode); err != nil {
+	if err := m.writeClaudeSessionForAgent(target, data, m.agentExecUserSpec(agent)); err != nil {
 		m.logger.Warn("failed to seed claude session",
 			"agent", agentName, "target", target, "error", err)
 		return
 	}
 	if uid > 0 {
-		// Best-effort: unprivileged deployments cannot chown, and the 0666
-		// mode above already keeps the file usable there.
+		// Best-effort: unprivileged deployments cannot chown, and the seed mode
+		// already keeps the file usable there. A no-op when the write above went
+		// through su-exec, which produced an agent-owned file already.
 		_ = os.Chown(target, uid, -1)
 	}
 	m.logger.Info("adopted signed-in claude session for agent",
@@ -240,9 +254,13 @@ func (m *Manager) seedClaudeSessionForAgent(agentName, home string, uid int) {
 // findSignedInClaudeSession locates a signed-in .claude.json to adopt: legacy
 // shared file first, then siblings (sorted for determinism), skipping the
 // requesting agent's own home.
+//
+// Candidates are classified owner-aware, so an agent-owned 0600 sibling — the
+// ONLY shape a fresh install's first login ever takes — counts as a source
+// instead of reading as claudeSessionUnreadable and being skipped.
 func (m *Manager) findSignedInClaudeSession(agentName string) string {
 	legacy := claudeSessionFile(sharedAgentHome)
-	if inspectClaudeSession(legacy).State == claudeSessionSignedIn {
+	if m.inspectClaudeSessionForAdoption(legacy).State == claudeSessionSignedIn {
 		return legacy
 	}
 	entries, err := os.ReadDir(interactiveHomeRoot())
@@ -258,7 +276,7 @@ func (m *Manager) findSignedInClaudeSession(agentName string) string {
 	sort.Strings(names)
 	for _, name := range names {
 		candidate := claudeSessionFile(interactiveHomePath(name))
-		if inspectClaudeSession(candidate).State == claudeSessionSignedIn {
+		if m.inspectClaudeSessionForAdoption(candidate).State == claudeSessionSignedIn {
 			return candidate
 		}
 	}


### PR DESCRIPTION
## What

Closes #4637 by taking its **option A**: make the "log in once per method" promise in `docs/agent-configuration.md` true on fresh installs, rather than downgrading the docs to "once per agent".

Option A is the one that matches stated design intent — #4619's title is literally *"per-agent HOME for CLI agents — one login authenticates the fleet"*, and `interactive_home.go`'s header says the per-agent seeding exists "so existing hives migrate without any operator step". The seeding path just never worked on a hive that had no legacy shared file to inherit from.

## Why fresh installs need one login per agent today

`seedClaudeSessionForAgent` adopts a signed-in `.claude.json` from the legacy shared home or a sibling. On a **migrating** hive that works: the source is `/data/home/.claude.json`, which the hive process can read.

On a **fresh** install there is no legacy file. The only signed-in session in existence is the one the operator's login made agent A's **own CLI** write — owned by A's UID at mode 0600. `inspectClaudeSession` on it returns `claudeSessionUnreadable`, `findSignedInClaudeSession` reports no source, and agent B stays at the login menu until the operator logs in by hand. Same for C, D, …

## Changes

- **`claude_session_adopt.go` (new)** — an owner-aware read/write seam. A direct read that hits `EACCES` is retried as the file's **owner**; a direct write that hits `EACCES` is performed **by the target agent**. This is the same `su-exec` mechanism every other cross-UID operation in the package already uses (`tmuxCmd`, `setupCodexHome`, the tmux-dir chmod).
- **Adopt-only is now actually enforced for unreadable targets.** `seedClaudeSessionForAgent` classifies its *target* owner-aware too. An unreadable target may be the agent's **own** signed-in session; previously it read as "not signed in" and got overwritten with a sibling's identity.
- **`classifyClaudeSession`** split out of `inspectClaudeSession`, so bytes obtained through the seam reach an identical verdict to a direct read.
- **Docs** — one sentence noting that `claude` sharing is not instantaneous: the token is shared at once through the home bridge, the session identity is adopted at each other agent's next launch/restart.

## Safety posture

- Candidates are `Lstat`'d (never followed) and must be a **regular file**, under an **8 MiB cap**, and owned by a **non-root uid** before any helper runs — a symlink or a root-owned file planted at a sibling path can never turn adoption into "run something as uid 0".
- The write fallback stages through a temp file in the target's own directory and renames, so a helper dying mid-write cannot leave the agent holding a truncated `.claude.json`. The target path is passed as `$0`, never interpolated into the shell script.
- Every helper is **best-effort** and falls back to the direct result. Without `su-exec`, unreadable stays unreadable and the login menu remains the honest state — nothing is fabricated, and no caller treats a failed fallback as evidence of anything.

## Interaction with #4636

They are complementary halves of the same defect family, and I verified they do not collide:

- **No file overlap.** #4636 touches `manager.go` + `stuck_login_diagnosis.go` (+ tests); this touches `interactive_home.go`, `claude_session_state.go`, `claude_session_adopt.go`, and the docs. I test-merged this branch with `pull/4636/head`: it merges cleanly, builds, and both PRs' test sets pass together.
- **One real semantic coupling, handled here.** #4636 observed that agents whose session files had gone through `seedClaudeSessionForAgent` (written at `claudeSessionSeedFileMode`, readable by the hive uid) survived every caveman clobber, while agents holding an agent-written 0600 file did not. So this PR's `su-exec` write deliberately `chmod`s to `claudeSessionSeedFileMode` rather than letting the agent's umask produce 0600 — otherwise adoption would hand back exactly the shape #4636 is fixing. Both write paths land on the same mode by construction, with a comment saying why they must not drift.
- **Merge order does not matter.** Neither depends on the other; each is an improvement on its own.

## Tests

New in `claude_session_adopt_test.go`. "Unreadable to the hive process" is simulated with mode 0000 (unit tests cannot create files owned by a second UID), and a `runAsAgentUser` test seam stands in for the privileged helper.

- `TestSeedClaudeSession_AdoptsAgentOwnedSibling` — the #4637 case itself: no legacy shared file, one agent-owned 0600 signed-in sibling, and the fresh login propagates.
- `TestSeedClaudeSession_UnreadableSignedInTargetIsNotClobbered` — adopt-only holds when the target cannot be read directly.
- `TestSeedClaudeSession_SeedIsReadableByTheHiveProcess` — guards the #4636 coupling above.
- `TestSeedClaudeSession_HelperFailureLeavesLoginMenuHonest` — with no working helper, nothing is fabricated.
- `TestClaudeSessionOwnerSpec_RefusesNonRegularAndOversize` / `AcceptsOrdinarySessionFile` — the symlink / cap / missing-file refusals.
- `TestInspectClaudeSessionForAdoption_FallsBackToOwnerRead`, `TestRunAsAgentUser_RejectsEmptyInput`.

All pre-existing `interactive_home` / `claude_session` / `stuck_login` tests still pass unchanged.

`go build ./...` and `go vet ./pkg/agent/` are clean, and the files touched here are `gofmt`-clean.

**One pre-existing failure, not from this change:** `TestRestartThenSendKick_CleanSlateThenDelivers` fails in my environment (`agent worker CLI not ready after restart`, a tmux timing test). I confirmed it fails identically on unmodified `upstream/v4` with my changes stashed.

— hive: backend=claude model=claude-fable-5
