### PR TITLE
📖 docs: retire stale v2 branch references across src/docs

### DIFF
--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -245,7 +245,7 @@ agents:
 
 - **The agent still acts.** The instruction states that tool execution remains the requirement and that a response containing only explanation is a failure. It is appended *after* the `EXECUTE, DO NOT NARRATE` block, so it reads as a qualification of that rule rather than a replacement for it.
 - **Terse mode is suspended on `EXPLAIN:` lines only.** A caveman-compressed explanation would be useless to the human reading it, but the agent's real output — log lines, bead titles, PR descriptions — keeps whatever compression you configured.
-- **It is per-kick, not a prompt edit.** Nothing in `v2/policies/` or `examples/*/agents/*.md` changes, so toggling it does not alter any agent's actual instructions and does not require a redeploy.
+- **It is per-kick, not a prompt edit.** Nothing in `src/policies/` or `examples/*/agents/*.md` changes, so toggling it does not alter any agent's actual instructions and does not require a redeploy.
 
 ### Reading the explanation
 

--- a/src/docs/beads-cli.md
+++ b/src/docs/beads-cli.md
@@ -16,7 +16,7 @@
 | `bd reset [--reason "..."]` | Close all open/in-progress/blocked beads with an audit reason. |
 | `bd remember "fact"` | Quick-add an advisory bead authored by `system`. |
 | `bd init` | No-op compatibility command; opening the store creates it. |
-| `bd dolt push` | No-op compatibility command; v2 data is already persisted on disk. |
+| `bd dolt push` | No-op compatibility command; bead data is already persisted on disk. |
 
 Examples:
 

--- a/src/docs/deployment-scripts.md
+++ b/src/docs/deployment-scripts.md
@@ -53,9 +53,14 @@ capability drop), then starts SSH. Tunable flags include `--ctid`, `--hostname`,
 `--password`, `--disk`, `--memory`, and `--cores`.
 
 `deploy/bootstrap-lxc.sh` runs inside that LXC. It installs Docker Engine and the
-Compose plugin, clones the `v2` branch to `/opt/hive`, builds the Hive image, and
+Compose plugin, clones the repository to `/opt/hive`, builds the Hive image, and
 writes `/opt/hive/.env` with placeholders for GitHub, dashboard, model, and
 notification credentials.
+
+**Known defect.** The script still hardcodes `git clone --branch v2`, and `v2` is
+a retired branch — so it provisions a retired release line rather than mainline
+`v4`. Until that is fixed in the script, pass the branch you want explicitly or
+re-point `/opt/hive` at `v4` after bootstrap.
 
 Use this path when you operate Hive on Proxmox or another LXC-first host and want
 a lightweight VM-like container that still runs the normal Docker Compose

--- a/src/docs/design/knowledge-system.md
+++ b/src/docs/design/knowledge-system.md
@@ -263,9 +263,9 @@ ACMM Level 4:   testMode = "tdd"
 
 ---
 
-## 4. v2 Architecture Integration
+## 4. Architecture Integration
 
-Hive v2 is a Go binary with structured packages under `src/pkg/`. The knowledge system adds a new `pkg/knowledge/` package and extends existing packages.
+Hive is a Go binary with structured packages under `src/pkg/`. The knowledge system adds a new `pkg/knowledge/` package and extends existing packages.
 
 ### New package: `src/pkg/knowledge/`
 
@@ -282,9 +282,9 @@ src/pkg/knowledge/
   promote_test.go
 ```
 
-### How it integrates with existing v2 packages
+### How it integrates with existing packages
 
-| v2 Package | Integration |
+| Package | Integration |
 |------------|-------------|
 | `pkg/config/` | Add `Knowledge` section to `hive.yaml` (layers, wiki paths, curator schedule, primer config) |
 | `pkg/snapshot/` | Add `Knowledge []Fact` field to snapshot state — primed facts per work item |
@@ -294,9 +294,9 @@ src/pkg/knowledge/
 | `pkg/dashboard/` | Add `/api/knowledge/*` endpoints proxying to llm-wiki MCP; Knowledge tab in frontend |
 | `pkg/agent/` | Include primed facts in agent work orders |
 
-### Pipeline flow (v2)
+### Pipeline flow
 
-In v2, the pipeline is Go code, not shell scripts:
+The pipeline is Go code, not shell scripts:
 
 ```
 snapshot.Build()

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -246,8 +246,8 @@ With two or more providers configured, `/login` renders a provider picker; with 
 The table above was cross-checked with these mechanical searches from the repository root:
 
 ```sh
-rg 'os\.(Getenv|LookupEnv)\(' v2 --glob '*.go'
-rg '\bHIVE_[A-Z0-9_]+\b|\bBD_DIR\b|\bGH_APP_KEY_FILE\b|\bAGENT_BACKEND\b' v2 bin config Justfile
-rg '\b(ANTHROPIC|COPILOT|GOOSE|BOBSHELL|OCI|KUBERNETES|POD|NAMESPACE|DASHBOARD|PROXY|SLACK|DISCORD|NTFY)_[A-Z0-9_]+\b' v2 bin config Justfile
+rg 'os\.(Getenv|LookupEnv)\(' src --glob '*.go'
+rg '\bHIVE_[A-Z0-9_]+\b|\bBD_DIR\b|\bGH_APP_KEY_FILE\b|\bAGENT_BACKEND\b' src bin config Justfile
+rg '\b(ANTHROPIC|COPILOT|GOOSE|BOBSHELL|OCI|KUBERNETES|POD|NAMESPACE|DASHBOARD|PROXY|SLACK|DISCORD|NTFY)_[A-Z0-9_]+\b' src bin config Justfile
 rg 'HIVE_[A-Z0-9_]+|BD_DIR|GH_APP_KEY_FILE|AGENT_BACKEND' src/deploy
 ```

--- a/src/docs/notifications.md
+++ b/src/docs/notifications.md
@@ -52,7 +52,7 @@ Use a Discord **webhook URL**, not a bot token, for notification delivery.
 
 ## What triggers notifications
 
-The v2 Go process sends notifications for these events:
+The Hive Go process sends notifications for these events:
 
 | Event | Priority | Source |
 |---|---|---|
@@ -62,7 +62,7 @@ The v2 Go process sends notifications for these events:
 | A running agent pane matches a configured login-required pattern; Hive pauses that agent and sends the backend-specific login instruction. | high | `scanForLoginRequired` in `src/cmd/hive/main.go` |
 | Trajectory review detects divergence and either pauses the agent or flags the divergence. | high | `src/pkg/dashboard/trajectory_sink.go` and `src/pkg/trajectory/lane.go` |
 
-The legacy shell scripts in `bin/` also use `bin/notify.sh` for events such as stale agents, rate limits, backend switches, and kick status when those scripts are deployed. Those scripts read environment variables (`NTFY_TOPIC`, `NTFY_SERVER`, `SLACK_WEBHOOK`, `DISCORD_WEBHOOK`) rather than the v2 YAML block.
+The legacy shell scripts in `bin/` also use `bin/notify.sh` for events such as stale agents, rate limits, backend switches, and kick status when those scripts are deployed. Those scripts read environment variables (`NTFY_TOPIC`, `NTFY_SERVER`, `SLACK_WEBHOOK`, `DISCORD_WEBHOOK`) rather than the `notifications:` YAML block.
 
 ## Testing delivery
 
@@ -93,4 +93,4 @@ Webhook notifications are the `notifications.discord.webhook` field above.
 
 The repository also contains a separate Discord bot under [`../../discord/`](../../discord/). That bot is a Node.js service using `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_PRIMARY` to connect to Discord, route commands, and bridge dashboard/pipeline status. It is not required for webhook notifications, and a bot token cannot replace `notifications.discord.webhook`.
 
-For the v2 Go process, bot startup uses `notifications.discord.bot_token` and `notifications.discord.channel_id` when both are set. Those fields start the bot integration; they do not send ordinary webhook notifications unless `notifications.discord.webhook` is also configured.
+For the Hive Go process, bot startup uses `notifications.discord.bot_token` and `notifications.discord.channel_id` when both are set. Those fields start the bot integration; they do not send ordinary webhook notifications unless `notifications.discord.webhook` is also configured.

--- a/src/docs/tls-setup.md
+++ b/src/docs/tls-setup.md
@@ -1,6 +1,6 @@
 # TLS, HTTPS, and certificates
 
-Hive v2 does not implement native TLS configuration in `hive.yaml`. The dashboard and hub servers call Go `ListenAndServe`, and the bundled Docker gateway listens with plain HTTP. Production HTTPS is therefore an edge concern: terminate TLS at an ingress controller, OpenShift Route, load balancer, or reverse proxy, then proxy HTTP to Hive.
+Hive does not implement native TLS configuration in `hive.yaml`. The dashboard and hub servers call Go `ListenAndServe`, and the bundled Docker gateway listens with plain HTTP. Production HTTPS is therefore an edge concern: terminate TLS at an ingress controller, OpenShift Route, load balancer, or reverse proxy, then proxy HTTP to Hive.
 
 ## What the spoke serves
 

--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -50,7 +50,7 @@ In Kubernetes, edit the ConfigMap/Secret source and restart the pod; dashboard e
 
 ## GitHub credentials are missing or invalid
 
-When no token or App credentials are usable, v2 starts the dashboard but disables write-capable GitHub work. The code logs these exact messages from `src/cmd/hive/main.go` depending on the state:
+When no token or App credentials are usable, Hive starts the dashboard but disables write-capable GitHub work. The code logs these exact messages from `src/cmd/hive/main.go` depending on the state:
 
 - `no GitHub token configured (set github.token or github.app_id in config) — starting in dashboard-only mode`
 - `GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.`
@@ -70,7 +70,7 @@ On GitHub Enterprise, a 404 from the install link usually means the hive is poin
 
 ## Agents are stuck, paused, or need CLI login
 
-Agents run in tmux sessions named `hive-<agent>` managed by the v2 agent manager. There is no v1 `AGENT_READY_MARKER` or `bin/supervisor.sh` loop: the manager drives each agent by delivering a *kick* (its next work prompt) directly into the session and, once running, auto-dismisses the CLI's own startup consent screens.
+Agents run in tmux sessions named `hive-<agent>` managed by Hive's agent manager. There is no v1 `AGENT_READY_MARKER` or `bin/supervisor.sh` loop: the manager drives each agent by delivering a *kick* (its next work prompt) directly into the session and, once running, auto-dismisses the CLI's own startup consent screens.
 
 The login detector (`scanForLoginRequired` in `src/cmd/hive/main.go`) scans recent tmux pane output for the regexes in `governor.sensing.login_patterns`. On a match it logs `login required detected`, pauses the agent, and sends a high-priority notification telling you to attach to `hive-<agent>` and run that backend's login command.
 


### PR DESCRIPTION
Fixes #4643

Fourth and (intentionally) final filing of one pattern — after #4604, #4626, #4632, the guide agent kept finding stale `v2` references two at a time. This sweeps the whole `src/docs/` surface so the next sweep finds nothing.

**Every capability claim was verified against the code before editing.** Twice already the naive `v2` → `v4` swap would have preserved a false statement while making it look freshly reviewed (architecture.md claimed unimplemented features that had shipped; ioscan.md denied a shipped, default-ON security package).

## Per-file verdicts

| File | Verdict | Evidence |
|---|---|---|
| `troubleshooting.md:53` | **stale** → "Hive" | Dashboard-only mode is current v4 behavior; all five log strings live at `src/cmd/hive/main.go:737,755,804,811,818`. Substance correct, name retired. |
| `troubleshooting.md:73` | **stale** → "Hive's agent manager" | tmux sessions named `hive-<agent>` are built in `src/pkg/agent/manager.go:1371,3851,3921` on v4. Substance correct, name retired. |
| `env-vars.md:249-251` | **stale, highest impact** | Three `rg ... v2 ...` audit commands. `v2` is not a directory any more, so these returned **empty and looked successful** — worse than failing loudly. Repointed to `src`. |
| `agent-configuration.md:248` | **stale** | `v2/policies/` does not exist; the directory is `src/policies/` (confirmed by `ls`, and by `supervisor.md:62-63` which already says `src/policies/`). |
| `design/knowledge-system.md:266,268,285,287,297,299` | **stale, internally contradictory** | Said "Hive v2 is a Go binary with structured packages under `src/pkg/`" — v2 name, v4 path, in one sentence. Dropped the version qualifier; all cited packages exist under `src/pkg/`. |
| `notifications.md:55,65,96` | **stale** (not in the original issue; found by sweep) | "The v2 Go process" describes the current process — every Source cell already cites `src/cmd/hive/main.go` and `src/pkg/`. Also replaced the vague "v2 YAML block" with the actual `notifications:` block. |
| `beads-cli.md:19` | **still-true, name retired only** | `bd dolt push` is genuinely a no-op compatibility command and bead data is genuinely on disk. Only "v2 data" → "bead data". |
| `tls-setup.md:3` | **CAPABILITY CLAIM RE-VERIFIED — still true** | Zero `ListenAndServeTLS` in the tree; zero `yaml:"tls...` config keys; the three real servers (`src/pkg/dashboard/server.go:910`, `src/pkg/hub/server.go:1506`, `src/pkg/proxy/github_proxy.go:1994`) all call plain `ListenAndServe`. Native TLS is still absent, so the substance is kept **verbatim** and only "Hive v2" → "Hive". |
| `deployment-scripts.md:56` | **CODE bug, not a doc bug** | See below. |
| `deployment-scripts.md:37` | **left alone — quote is accurate** | See below. |

## `deployment-scripts.md:56` — this one is a code bug

The doc was **right** and the script is **wrong**:

```
src/deploy/bootstrap-lxc.sh:10:#   2. Clones the hive repo (v2 branch)
src/deploy/bootstrap-lxc.sh:57:  git clone --branch v2 --single-branch https://github.com/kubestellar/hive.git "${HIVE_DIR}"
```

The script really does clone the retired `v2` branch, so a Proxmox/LXC bootstrap today provisions a retired release line instead of mainline `v4`. Rewriting the sentence to say "v4" would have made the doc lie about what the script does.

This PR is docs-only, so the fix here keeps the prose accurate and adds a short **Known defect** note pointing at the hardcoded branch. **The script itself still needs a code fix** — worth a separate issue.

## `deployment-scripts.md:37` — deliberately left alone

The line quotes the installer's own header: `("a Hive v2 instance (Docker-based)")`. That string is verbatim real —

```
bin/hive-setup.sh:2:# hive-setup.sh — Bootstrap a fresh Ubuntu 24.04 LXC into a Hive v2 instance (Docker-based).
bin/hive-setup.sh:100:log "Hive v2 Setup (Docker-based)"
```

— and the surrounding sentence explicitly calls the header "the honest description of what it builds". Editing a quotation to not match the thing quoted would introduce a new error while fixing an old one. Same underlying code staleness as above; also a script-side fix.

## Final sweep

Every remaining `v2` in `src/docs/` is a legitimate meaning. Deliberately left:

- **Unrelated senses of "v2"** — `cgroups v2` (podman-*.md, incl. the line-wrapped one at `podman-support-matrix.md:65`), `restricted-v2` OpenShift SCC, `hive-session-v2`, `controller-runtime v2`, `-v2` HMAC key labels in `design/master-key-rotation.md:36,38`.
- **Deliberately correct statements about the retirement** — `operator-reference.md:87` (`v2-latest` is the retired rolling tag, do not use it), `security-threat-model.md:4` (`the v2 branch is retired`).
- **CI workflow filenames and branch triggers** — `v2-ci.yml`, `v2-tests.yml`, and `release-line-guard.md` / `podman-ci-runner-map.md:218,276` / `podman-preflight-host.md:235`, which discuss on purpose that workflows still fire on `v2` and whether they should. `release-line-guard.md:142` is literally titled "Open: should `v2` still be in these lists?".
- **Historical narration of the `v2/` → `src/` rename** — `contributor-relay.md:354`, and `design/pr-reach-telemetry.md:83,103` which records legacy `v2/pkg/...` path mappings on purpose.
- **The v2 → v4 migration guide** and `README.md` lines 3/20/74.

No ambiguous cases were left unresolved.

Docs-only; no Go code changed. `src/docs/` is source of truth — no synced copy hand-edited.