### PR TITLE
fix(rotation): probe claude via OAuth API and codex via app-server JSON-RPC

### DIFF
--- a/src/pkg/rotation/rotation.go
+++ b/src/pkg/rotation/rotation.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/claude"
 	"github.com/kubestellar/hive/pkg/config"
 )
 
@@ -130,6 +131,11 @@ type ClaudeProber struct {
 const claudeUsageBaseURL = "https://api.anthropic.com"
 const claudeOAuthBeta = "oauth-2025-04-20"
 
+// sharedCLIHome is the durable shared CLI home on the PVC — the HOME the
+// manager gives agent tmux sessions and where fleet-level CLI auth state
+// (.claude, .codex, .copilot) persists across pod restarts.
+const sharedCLIHome = "/data/home"
+
 type claudeCredentials struct {
 	ClaudeAiOauth struct {
 		AccessToken string `json:"accessToken"`
@@ -149,11 +155,21 @@ func (p ClaudeProber) Provider() string { return "anthropic" }
 func (p ClaudeProber) Probe(ctx context.Context) Headroom {
 	credPath := p.CredentialsPath
 	if credPath == "" {
+		// The hive main process runs with HOME=/home/dev (Dockerfile), but the
+		// durable OAuth credentials live in the shared CLI home on the PVC —
+		// claude.CredentialsPath (/data/home/.claude/.credentials.json), the
+		// same canonical location authprobe and the session watcher use. Try
+		// $HOME first (dev shells, tests), then fall back to the shared home.
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return failOpen(p.Provider(), err)
 		}
 		credPath = filepath.Join(home, ".claude", ".credentials.json")
+		if _, statErr := os.Stat(credPath); statErr != nil {
+			if _, sharedErr := os.Stat(claude.CredentialsPath); sharedErr == nil {
+				credPath = claude.CredentialsPath
+			}
+		}
 	}
 	raw, err := os.ReadFile(credPath)
 	if err != nil {
@@ -250,6 +266,13 @@ func (p CodexProber) Probe(ctx context.Context) Headroom {
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout+5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "codex", "app-server")
+	// The hive main process runs with HOME=/home/dev, but codex auth state
+	// lives in the shared CLI home on the PVC (/data/home/.codex — the HOME
+	// the manager gives agent sessions). Point the app-server there when it
+	// exists so the probe sees the fleet's real login, not an empty home.
+	if fi, err := os.Stat(sharedCLIHome); err == nil && fi.IsDir() {
+		cmd.Env = append(os.Environ(), "HOME="+sharedCLIHome)
+	}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return failOpen(p.Provider(), err)
@@ -262,7 +285,12 @@ func (p CodexProber) Probe(ctx context.Context) Headroom {
 	if err := cmd.Start(); err != nil {
 		return failOpen(p.Provider(), err)
 	}
-	defer cmd.Process.Kill()
+	// Kill AND reap: without Wait the killed app-server stays a zombie for the
+	// life of the hive process, one per probe cycle.
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
 	send := func(id int, method string, params any) error {
 		msg := struct {
 			ID     int    `json:"id"`

--- a/src/pkg/rotation/rotation.go
+++ b/src/pkg/rotation/rotation.go
@@ -4,12 +4,17 @@
 package rotation
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -98,56 +103,235 @@ func failOpen(provider string, err error) Headroom {
 	return Headroom{Provider: provider, Available: true, ProbeErr: err}
 }
 
-// ClaudeProber probes Anthropic subscription usage via `claude /usage`.
+// ClaudeProber probes Anthropic subscription usage via the OAuth usage API.
+//
+// `claude /usage` no longer renders the weekly-quota block (current builds
+// show session stats only) and headless `/status` is unavailable, so the probe
+// uses the same undocumented endpoint Claude Code's own HUD polls:
+//
+//	GET https://api.anthropic.com/api/oauth/usage
+//	Authorization: Bearer <accessToken from ~/.claude/.credentials.json>
+//	anthropic-beta: oauth-2025-04-20        (required, else 401)
+//
+// The `limits` array carries per-kind percent + resets_at (session /
+// weekly_all / weekly_scoped); the binding limit is the max percent. The
+// endpoint rate-limits aggressively, so a 429/401/parse failure is fail-open
+// (never evidence of exhaustion).
 type ClaudeProber struct {
 	ThresholdPct int
+	// BaseURL overrides the API endpoint (tests). Default production host.
+	BaseURL string
+	// Client overrides the HTTP client (tests).
+	Client *http.Client
+	// CredentialsPath overrides the default ~/.claude/.credentials.json.
+	CredentialsPath string
 }
 
-var claudeUsageRe = regexp.MustCompile(`Current week \(all models\)[^\d]*(\d+)%`)
+const claudeUsageBaseURL = "https://api.anthropic.com"
+const claudeOAuthBeta = "oauth-2025-04-20"
+
+type claudeCredentials struct {
+	ClaudeAiOauth struct {
+		AccessToken string `json:"accessToken"`
+	} `json:"claudeAiOauth"`
+}
+
+type claudeUsageResponse struct {
+	Limits []struct {
+		Kind     string     `json:"kind"`
+		Percent  *float64   `json:"percent"`
+		ResetsAt *time.Time `json:"resets_at"`
+	} `json:"limits"`
+}
 
 func (p ClaudeProber) Provider() string { return "anthropic" }
 
 func (p ClaudeProber) Probe(ctx context.Context) Headroom {
-	out, err := runCLI(ctx, "claude", "/usage", "--output-format", "text")
+	credPath := p.CredentialsPath
+	if credPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return failOpen(p.Provider(), err)
+		}
+		credPath = filepath.Join(home, ".claude", ".credentials.json")
+	}
+	raw, err := os.ReadFile(credPath)
+	if err != nil {
+		return failOpen(p.Provider(), fmt.Errorf("claude credentials: %w", err))
+	}
+	var creds claudeCredentials
+	if err := json.Unmarshal(raw, &creds); err != nil {
+		return failOpen(p.Provider(), fmt.Errorf("claude credentials parse: %w", err))
+	}
+	if creds.ClaudeAiOauth.AccessToken == "" {
+		// An empty token is the signature of an expired OAuth session; the
+		// CLI reports "Login expired" and serves nothing. Not exhaustion.
+		return failOpen(p.Provider(), errors.New("claude credentials: empty accessToken"))
+	}
+	base := p.BaseURL
+	if base == "" {
+		base = claudeUsageBaseURL
+	}
+	client := p.Client
+	if client == nil {
+		client = &http.Client{Timeout: probeTimeout}
+	}
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/api/oauth/usage", nil)
 	if err != nil {
 		return failOpen(p.Provider(), err)
 	}
-	m := claudeUsageRe.FindStringSubmatch(out)
-	if m == nil {
-		return failOpen(p.Provider(), fmt.Errorf("claude usage output did not match"))
+	req.Header.Set("Authorization", "Bearer "+creds.ClaudeAiOauth.AccessToken)
+	req.Header.Set("anthropic-beta", claudeOAuthBeta)
+	resp, err := client.Do(req)
+	if err != nil {
+		return failOpen(p.Provider(), err)
 	}
-	used, _ := strconv.Atoi(m[1])
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return failOpen(p.Provider(), fmt.Errorf("claude usage HTTP %d", resp.StatusCode))
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	var parsed claudeUsageResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	used := 0
+	var resetAt time.Time
+	for _, l := range parsed.Limits {
+		if l.Percent == nil {
+			continue
+		}
+		pct := int(*l.Percent)
+		if pct > used {
+			used = pct
+			if l.ResetsAt != nil {
+				resetAt = *l.ResetsAt
+			}
+		}
+	}
 	return Headroom{
 		Provider:     p.Provider(),
 		Available:    used < p.ThresholdPct,
 		PctRemaining: fullPct - used,
+		ResetAt:      resetAt,
 	}
 }
 
-// CodexProber probes OpenAI subscription usage via `codex /status`.
+// CodexProber probes OpenAI subscription usage via the codex app-server
+// JSON-RPC interface.
+//
+// `codex /status` is TUI-only: current builds reject `--output-format` and
+// headless invocations die with "stdin is not a terminal", so the probe drives
+// the app-server protocol directly: spawn `codex app-server`, exchange an
+// initialize handshake, then call `account/rateLimits/read`. The reply carries
+// rateLimits.primary (the binding window) with usedPercent + resetsAt. A probe
+// failure is fail-open: never evidence of exhaustion.
 type CodexProber struct {
 	ThresholdPct int
 }
 
-var codexWeeklyRe = regexp.MustCompile(`Weekly limit:[^\d]*(\d+)%`)
+type codexRateLimitsResult struct {
+	RateLimits struct {
+		Primary struct {
+			UsedPercent int   `json:"usedPercent"`
+			ResetsAt    int64 `json:"resetsAt"`
+		} `json:"primary"`
+	} `json:"rateLimits"`
+}
 
 func (p CodexProber) Provider() string { return "openai" }
 
 func (p CodexProber) Probe(ctx context.Context) Headroom {
-	out, err := runCLI(ctx, "codex", "/status", "--output-format", "text")
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout+5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "codex", "app-server")
+	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return failOpen(p.Provider(), err)
 	}
-	m := codexWeeklyRe.FindStringSubmatch(out)
-	if m == nil {
-		return failOpen(p.Provider(), fmt.Errorf("codex status output did not match"))
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return failOpen(p.Provider(), err)
 	}
-	remaining, _ := strconv.Atoi(m[1])
-	return Headroom{
-		Provider:     p.Provider(),
-		Available:    fullPct-remaining < p.ThresholdPct,
-		PctRemaining: remaining,
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return failOpen(p.Provider(), err)
 	}
+	defer cmd.Process.Kill()
+	send := func(id int, method string, params any) error {
+		msg := struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+			Params any    `json:"params,omitempty"`
+		}{ID: id, Method: method, Params: params}
+		b, err := json.Marshal(msg)
+		if err != nil {
+			return err
+		}
+		_, err = stdin.Write(append(b, '\n'))
+		return err
+	}
+	if err := send(0, "initialize", map[string]any{
+		"clientInfo": map[string]string{"name": "hive-rotation", "title": "Hive Rotation", "version": "1.0"},
+	}); err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	handshake := false
+	sc := bufio.NewScanner(stdout)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var m struct {
+			ID     int              `json:"id"`
+			Result json.RawMessage  `json:"result"`
+			Error  *json.RawMessage `json:"error"`
+		}
+		if err := json.Unmarshal(line, &m); err != nil {
+			continue // keepalives / config warnings that are not JSON objects
+		}
+		if m.Error != nil {
+			return failOpen(p.Provider(), fmt.Errorf("codex app-server error: %s", string(*m.Error)))
+		}
+		if m.ID == 0 && !handshake {
+			handshake = true
+			if err := send(1, "account/rateLimits/read", map[string]any{}); err != nil {
+				return failOpen(p.Provider(), err)
+			}
+			continue
+		}
+		if m.ID == 1 {
+			used, resetAt, err := parseCodexRateLimits(m.Result)
+			if err != nil {
+				return failOpen(p.Provider(), err)
+			}
+			return Headroom{
+				Provider:     p.Provider(),
+				Available:    used < p.ThresholdPct,
+				PctRemaining: fullPct - used,
+				ResetAt:      resetAt,
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return failOpen(p.Provider(), err)
+	}
+	return failOpen(p.Provider(), errors.New("codex app-server: no rateLimits response"))
+}
+
+func parseCodexRateLimits(result json.RawMessage) (usedPct int, resetAt time.Time, err error) {
+	var res codexRateLimitsResult
+	if err := json.Unmarshal(result, &res); err != nil {
+		return 0, time.Time{}, err
+	}
+	return res.RateLimits.Primary.UsedPercent,
+		time.Unix(res.RateLimits.Primary.ResetsAt, 0).UTC(), nil
 }
 
 // AgyProber probes Google usage via `agy --print "/usage"`.

--- a/src/pkg/rotation/rotation_probe_test.go
+++ b/src/pkg/rotation/rotation_probe_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,13 +28,48 @@ func fakeCLI(t *testing.T, name, output string, exitCode int) {
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
+// claudeCredsFile writes a credentials file holding the given token and
+// returns its path.
+func claudeCredsFile(t *testing.T, token string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	body := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":%q}}`, token)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// claudeUsageServer serves /api/oauth/usage and verifies the Authorization
+// and anthropic-beta headers the probe must send.
+func claudeUsageServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/oauth/usage" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want Bearer test-token", got)
+		}
+		if got := r.Header.Get("anthropic-beta"); got != "oauth-2025-04-20" {
+			t.Errorf("anthropic-beta = %q, want oauth-2025-04-20", got)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 func TestClaudeProber_UsedBelowThreshold(t *testing.T) {
-	fakeCLI(t, "claude", "Current week (all models): 40% used", 0)
-	p := ClaudeProber{ThresholdPct: 80}
-	h := p.Probe(context.Background())
+	srv := claudeUsageServer(t, http.StatusOK, `{"limits":[
+		{"kind":"session","percent":11,"resets_at":"2026-08-23T16:49:59Z"},
+		{"kind":"weekly_all","percent":40,"resets_at":"2026-08-26T23:00:00Z"}]}`)
+	p := ClaudeProber{ThresholdPct: 80, BaseURL: srv.URL, CredentialsPath: claudeCredsFile(t, "test-token")}
 	if p.Provider() != "anthropic" {
 		t.Errorf("Provider = %q, want anthropic", p.Provider())
 	}
+	h := p.Probe(context.Background())
 	if h.ProbeErr != nil {
 		t.Fatalf("ProbeErr = %v", h.ProbeErr)
 	}
@@ -43,11 +79,14 @@ func TestClaudeProber_UsedBelowThreshold(t *testing.T) {
 	if h.PctRemaining != 60 {
 		t.Errorf("PctRemaining = %d, want 60", h.PctRemaining)
 	}
+	if h.ResetAt.IsZero() {
+		t.Error("ResetAt unset, want the weekly resets_at")
+	}
 }
 
 func TestClaudeProber_Exhausted(t *testing.T) {
-	fakeCLI(t, "claude", "Current week (all models): 95% used", 0)
-	h := ClaudeProber{ThresholdPct: 80}.Probe(context.Background())
+	srv := claudeUsageServer(t, http.StatusOK, `{"limits":[{"kind":"weekly_all","percent":95,"resets_at":"2026-08-26T23:00:00Z"}]}`)
+	h := ClaudeProber{ThresholdPct: 80, BaseURL: srv.URL, CredentialsPath: claudeCredsFile(t, "test-token")}.Probe(context.Background())
 	if h.ProbeErr != nil {
 		t.Fatalf("ProbeErr = %v", h.ProbeErr)
 	}
@@ -56,30 +95,53 @@ func TestClaudeProber_Exhausted(t *testing.T) {
 	}
 }
 
-func TestClaudeProber_UnparseableOutput(t *testing.T) {
-	fakeCLI(t, "claude", "unexpected output", 0)
-	h := ClaudeProber{ThresholdPct: 80}.Probe(context.Background())
+func TestClaudeProber_Unauthenticated(t *testing.T) {
+	srv := claudeUsageServer(t, http.StatusUnauthorized, `{"error":{"type":"authentication_error"}}`)
+	h := ClaudeProber{ThresholdPct: 80, BaseURL: srv.URL, CredentialsPath: claudeCredsFile(t, "test-token")}.Probe(context.Background())
 	if h.ProbeErr == nil {
-		t.Fatal("ProbeErr = nil, want parse error")
+		t.Fatal("ProbeErr = nil, want error")
 	}
 	if !h.Available {
 		t.Error("Available = false, want true (fail-open)")
 	}
 }
 
-func TestClaudeProber_CommandFailure(t *testing.T) {
-	fakeCLI(t, "claude", "boom", 1)
-	h := ClaudeProber{ThresholdPct: 80}.Probe(context.Background())
-	if h.ProbeErr == nil {
-		t.Fatal("ProbeErr = nil, want command error")
+func TestClaudeProber_EmptyToken(t *testing.T) {
+	h := ClaudeProber{ThresholdPct: 80, CredentialsPath: claudeCredsFile(t, "")}.Probe(context.Background())
+	if h.ProbeErr == nil || !h.Available {
+		t.Error("want fail-open with error on empty accessToken")
 	}
-	if !h.Available {
-		t.Error("Available = false, want true (fail-open)")
+}
+
+func TestClaudeProber_MissingCredentials(t *testing.T) {
+	h := ClaudeProber{ThresholdPct: 80, CredentialsPath: filepath.Join(t.TempDir(), "nope.json")}.Probe(context.Background())
+	if h.ProbeErr == nil || !h.Available {
+		t.Error("want fail-open with error on missing credentials file")
 	}
+}
+
+// fakeCodexAppServer installs a `codex` script that speaks the app-server
+// JSON-RPC protocol: it answers the initialize handshake, then the
+// account/rateLimits/read call with the given primary window.
+func fakeCodexAppServer(t *testing.T, usedPercent int, resetsAt int64) {
+	t.Helper()
+	reply := fmt.Sprintf(`{"id":1,"result":{"rateLimits":{"primary":{"usedPercent":%d,"resetsAt":%d}}}}`,
+		usedPercent, resetsAt)
+	script := "#!/bin/sh\n" +
+		"IFS= read -r line\n" +
+		"printf '%s\\n' '{\"id\":0,\"result\":{\"userAgent\":\"fake/1\"}}'\n" +
+		"IFS= read -r line\n" +
+		fmt.Sprintf("printf '%%s\\n' '%s'\n", reply) +
+		"exit 0\n"
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestCodexProber(t *testing.T) {
-	fakeCLI(t, "codex", "Weekly limit: 70% remaining", 0)
+	fakeCodexAppServer(t, 30, 1787968245)
 	p := CodexProber{ThresholdPct: 80}
 	if p.Provider() != "openai" {
 		t.Errorf("Provider = %q, want openai", p.Provider())
@@ -94,22 +156,29 @@ func TestCodexProber(t *testing.T) {
 	if h.PctRemaining != 70 {
 		t.Errorf("PctRemaining = %d, want 70", h.PctRemaining)
 	}
+	if want := time.Unix(1787968245, 0).UTC(); !h.ResetAt.Equal(want) {
+		t.Errorf("ResetAt = %v, want %v", h.ResetAt, want)
+	}
 }
 
 func TestCodexProber_ExhaustedAndErrors(t *testing.T) {
-	fakeCLI(t, "codex", "Weekly limit: 5% remaining", 0)
+	fakeCodexAppServer(t, 95, 1787968245)
 	h := CodexProber{ThresholdPct: 80}.Probe(context.Background())
+	if h.ProbeErr != nil {
+		t.Fatalf("ProbeErr = %v", h.ProbeErr)
+	}
 	if h.Available {
 		t.Error("Available = true, want false (95 used >= 80 threshold)")
 	}
 
+	// A codex that exits without answering the rate-limits call is fail-open.
 	fakeCLI(t, "codex", "garbage", 0)
 	h = CodexProber{ThresholdPct: 80}.Probe(context.Background())
 	if h.ProbeErr == nil || !h.Available {
-		t.Error("want fail-open with parse error on garbage output")
+		t.Error("want fail-open with error on garbage output")
 	}
 
-	fakeCLI(t, "codex", "x", 2)
+	fakeCLI(t, "codex", "", 3)
 	h = CodexProber{ThresholdPct: 80}.Probe(context.Background())
 	if h.ProbeErr == nil || !h.Available {
 		t.Error("want fail-open with error on non-zero exit")

--- a/src/pkg/rotation/rotation_probe_test.go
+++ b/src/pkg/rotation/rotation_probe_test.go
@@ -440,3 +440,88 @@ func TestRunCLI_MissingBinary(t *testing.T) {
 		t.Fatalf("err = nil, out = %q; want lookup error", out)
 	}
 }
+
+// The default (no CredentialsPath override) must resolve $HOME/.claude/
+// .credentials.json — the same file the claude CLI itself writes — before
+// falling back to the shared /data/home location the hive main process needs
+// in production (where HOME=/home/dev holds no CLI state).
+func TestClaudeProber_DefaultCredentialsFromHome(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"claudeAiOauth":{"accessToken":"test-token"}}`
+	if err := os.WriteFile(filepath.Join(home, ".claude", ".credentials.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	srv := claudeUsageServer(t, http.StatusOK, `{"limits":[{"kind":"weekly_all","percent":10,"resets_at":"2026-08-26T23:00:00Z"}]}`)
+	h := ClaudeProber{ThresholdPct: 80, BaseURL: srv.URL}.Probe(context.Background())
+	if h.ProbeErr != nil {
+		t.Fatalf("ProbeErr = %v", h.ProbeErr)
+	}
+	if !h.Available || h.PctRemaining != 90 {
+		t.Errorf("got (avail=%v, pct=%d), want (true, 90)", h.Available, h.PctRemaining)
+	}
+}
+
+func TestClaudeProber_CorruptCredentials(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := ClaudeProber{ThresholdPct: 80, CredentialsPath: path}.Probe(context.Background())
+	if h.ProbeErr == nil || !h.Available {
+		t.Error("want fail-open with error on corrupt credentials JSON")
+	}
+}
+
+func TestClaudeProber_MalformedUsageBody(t *testing.T) {
+	srv := claudeUsageServer(t, http.StatusOK, `{"limits": not-json`)
+	h := ClaudeProber{ThresholdPct: 80, BaseURL: srv.URL, CredentialsPath: claudeCredsFile(t, "test-token")}.Probe(context.Background())
+	if h.ProbeErr == nil || !h.Available {
+		t.Error("want fail-open with error on unparseable usage body")
+	}
+}
+
+// Limits without a percent (some kinds omit it) must be skipped, not counted
+// as 0% used — the binding limit is the max percent among those that have one.
+func TestClaudeProber_SkipsLimitsWithoutPercent(t *testing.T) {
+	srv := claudeUsageServer(t, http.StatusOK, `{"limits":[
+		{"kind":"session"},
+		{"kind":"weekly_all","percent":85,"resets_at":"2026-08-26T23:00:00Z"}]}`)
+	h := ClaudeProber{ThresholdPct: 80, BaseURL: srv.URL, CredentialsPath: claudeCredsFile(t, "test-token")}.Probe(context.Background())
+	if h.ProbeErr != nil {
+		t.Fatalf("ProbeErr = %v", h.ProbeErr)
+	}
+	if h.Available {
+		t.Error("Available = true, want false (85 >= 80 threshold from the percented limit)")
+	}
+}
+
+// An app-server that answers with a JSON-RPC error object (auth failure,
+// unsupported method) is a failed measurement — fail-open, never exhaustion.
+func TestCodexProber_AppServerError(t *testing.T) {
+	script := "#!/bin/sh\n" +
+		"IFS= read -r line\n" +
+		"printf '%s\\n' '{\"id\":0,\"error\":{\"code\":-32000,\"message\":\"not logged in\"}}'\n" +
+		"exit 0\n"
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	h := CodexProber{ThresholdPct: 80}.Probe(context.Background())
+	if h.ProbeErr == nil || !h.Available {
+		t.Error("want fail-open with error on app-server JSON-RPC error")
+	}
+	if h.ProbeErr != nil && !strings.Contains(h.ProbeErr.Error(), "not logged in") {
+		t.Errorf("ProbeErr = %v, want the app-server error surfaced", h.ProbeErr)
+	}
+}
+
+func TestParseCodexRateLimits_Invalid(t *testing.T) {
+	if _, _, err := parseCodexRateLimits([]byte("not-json")); err == nil {
+		t.Error("err = nil, want parse error")
+	}
+}


### PR DESCRIPTION
## Problem

Both CLI-based headroom probes target output the CLIs no longer produce, so anthropic and openai headroom are **permanently unknown** (every probe fails open):

- `claude /usage --output-format text` — current builds render **session stats only** (Total cost / duration / token counts); the `Current week (all models) N% used` block the regex matches no longer exists.
- `codex /status --output-format text` — current codex **rejects `--output-format`** (`unexpected argument`) and `/status` is TUI-only (`stdin is not a terminal`).

## Fix

Use the same sources the CLIs' own HUDs use:

- **Claude**: `GET https://api.anthropic.com/api/oauth/usage` with the access token from `~/.claude/.credentials.json` (`.claudeAiOauth.accessToken`) and the `anthropic-beta: oauth-2025-04-20` header (required, else 401). The response's `limits[]` array carries per-kind `percent` + `resets_at` (session / weekly_all / weekly_scoped); the binding limit is the max percent. Fail-open on 401/429/parse/empty-token — an expired OAuth session is `Login expired`, not exhaustion.
- **Codex**: spawn `codex app-server`, exchange the `initialize` handshake, then call `account/rateLimits/read`. `rateLimits.primary` carries `usedPercent` + `resetsAt`. Fail-open on any process/protocol failure (e.g. sandbox EPERM on restricted hosts).

## Tests

- Claude: httptest server verifying the Authorization + anthropic-beta headers; used/exhausted/401/empty-token/missing-credentials paths.
- Codex: a fake `codex` script speaking the JSON-RPC protocol (handshake then rate-limits reply); exhausted and fail-open paths.

Verified locally with `TMPDIR=... go test ./pkg/rotation` and `go build ./...`.