### PR TITLE
📖 docs: index src/docs/design/ so design records are reachable

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -80,14 +80,14 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Landscape and positioning](landscape.md) — how Hive's operations-plane design compares to nearby agentic orchestration tools, with public references per project. Explicitly time-sensitive; check the conducted date in its header before quoting product details.
 - [CNCF reference architecture](https://github.com/kubestellar/hive/blob/v4/src/docs/cncf-reference-architecture.md) — CNCF submission/reference template.
 - [Podman CI runner map](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-ci-runner-map.md) — measured hosted-runner capabilities and which Podman lane goes where; SELinux is the only lane needing non-hosted infrastructure.
-- [Knowledge system design](https://github.com/kubestellar/hive/blob/v4/src/docs/design/knowledge-system.md) — llm-wiki layers, subscriptions, and APIs.
+- [Design documents](design/README.md) — longer-form design records with the full reasoning behind a decision, indexed with a status each (shipped / partly shipped / design only / historical) so a proposal is not mistaken for current behaviour: master secret rotation, wrapped master delivery to pull-only spokes, PR reach telemetry, and the knowledge system.
 - [Podman Compose-provider selection spike](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-compose-provider-spike.md) — why `podman compose` must name its provider explicitly, and which provider needs no Docker tooling.
 - [Trajectory review](https://github.com/kubestellar/hive/blob/v4/src/docs/trajectory-review.md) — trajectory safety lane and review signals.
 - [Podman Quadlet `.container`/`.pod` spike](https://github.com/kubestellar/hive/blob/v4/src/docs/podman-quadlet-container-pod-spike.md) — feasibility result for explicit Quadlet units: readiness via `Notify=healthy`, the startup-timeout trap, and what the generator does not validate.
 
 ## Historical/design notes
 
-Some documents describe planned or design-only work rather than live features. Those pages are marked at the top, for example [Credly badges](https://github.com/kubestellar/hive/blob/v4/src/docs/credly-badges.md).
+Some documents describe planned or design-only work rather than live features. Those pages are marked at the top, for example [Credly badges](https://github.com/kubestellar/hive/blob/v4/src/docs/credly-badges.md). The longer-form design records under [`design/`](design/README.md) are a whole directory of these: each entry in that index carries a status, because those pages are the reference record of a decision and are deliberately not rewritten as later stages ship.
 
 ## Security (v4)
 

--- a/src/docs/design/README.md
+++ b/src/docs/design/README.md
@@ -1,0 +1,72 @@
+# Design documents
+
+Longer-form design records for work that needed a written argument before it was
+built: the problem, the constraint that shaped the answer, and the phases the
+work was cut into. They are the reference record for a decision, not operator
+documentation — the operator-facing page for a shipped feature lives in
+[`src/docs/`](../README.md) and is the one to read first.
+
+Unlike an [ADR](../adr/README.md), which is deliberately short and captures one
+decision, a design document here carries the full reasoning and is **not
+rewritten as later stages ship**. So each entry below states its status, and
+that status is the thing to check before treating a page as current behaviour:
+
+- **Shipped** — the described behaviour is live.
+- **Partly shipped** — some phases landed; the page still describes work that
+  does not exist yet, and says which.
+- **Design only** — accepted plan, no implementation. Read it as intent.
+- **Historical** — kept as an accurate record of something already decided;
+  details reflect the era they were written in, on purpose.
+
+## Records
+
+- [Hub master secret rotation](master-key-rotation.md) — **partly shipped.** Why
+  every signing value on the platform (heartbeat bearer, session cookie, session
+  and SSO Ed25519 seeds, impersonate, terminal, invite keys) is a pure function
+  of one master with no generation marker, which makes rotation a fleet-wide
+  flag day, and the generations design that ends it. The foundational
+  generations code and the session-cookie domain have landed
+  (`src/pkg/hub/hub_generations*.go`, `hub_cookie_generations.go`); the
+  remaining per-domain adoptions listed under "Follow-on PRs" are still pending.
+- [Wrapped master delivery to pull-only spokes](master-delivery-wrapped.md) —
+  **partly shipped**, and page-level **design only**. Read it after
+  master-key-rotation.md: rotation is complete on the hub and delivers nothing to
+  the two thirds of the fleet on pull-only clusters, which the hub cannot write
+  to by design. Records Option D — the spoke generates a keypair, publishes the
+  public half over its own outbound heartbeat, and the hub seals each new master
+  to it — and why Options A and B were rejected. The sealing primitive and the
+  spoke-side wrapping-key lifecycle have since landed (`src/pkg/hub/wrapkey.go`,
+  `wrapkey_store.go`); the page is not updated post hoc as later stages ship, so
+  its own header still reads DESIGN ONLY.
+- [PR reach telemetry](pr-reach-telemetry.md) — **partly shipped.** The design
+  behind attributing merged code to what is actually running, and the anchoring
+  rule that governs it: **merged ≠ deployed ≠ running**, so reach must attribute
+  to the commit executing in the binary, never to the merge or publish event.
+  Phase 1 (version-stamped spans, `hive.component` attribute) and phase 2a
+  (per-component reach counters) have landed; phases 2b (#3994) and 2c (#3995)
+  are pending, and this is the page to read before implementing them. Its
+  `v2/pkg/...` path examples are **deliberately historical** — PRs merged before
+  the `v2/` → `src/` rename report those paths from the forge API forever, and
+  the component mapper still handles both eras (`src/pkg/reach/mapping.go`).
+- [Knowledge system and the ACMM developer journey](knowledge-system.md) —
+  **partly shipped.** The layered llm-wiki knowledge base — layers,
+  subscriptions, the pre-seeded deployment vault, and the extraction/promotion
+  APIs — as the mechanism for making Hive useful from ACMM Level 1 upward. The
+  wiki layers, the seed vault, and programmatic extraction are live; the
+  `scheduler.RunCurator(schedule)` wiring this document plans is **not
+  implemented**, so `knowledge.curator.schedule` is accepted and defaulted but
+  read by nothing. See [Knowledge curator](../knowledge-curator.md) for the
+  programmatic path that does work today.
+
+## Adding a document here
+
+Add the page, then add a line above saying what a reader gets from it **and its
+status**. A design document that outlives its implementation is normal and fine;
+a design document a reader mistakes for current behaviour is not, which is what
+the status is for.
+
+Pages in this directory are reached through this index rather than through
+[`src/docs/README.md`](../README.md) directly, the same delegation
+[`adr/`](../adr/README.md) uses. That is also why the docs-index reminder
+workflow does not flag them: it is scoped to the top level of `src/docs/` on
+purpose, so a directory with its own README never trips it.


### PR DESCRIPTION
Fixes #4652

## The gap is the directory, not the file

The issue names `src/docs/design/pr-reach-telemetry.md` as unlinked. It is — but it is not alone, and fixing it alone would leave the next one to recur.

`src/docs/design/` holds four documents and **no `README.md`**. Two are genuinely linked from navigable pages. Two are orphans:

| File | Apparent inbound refs | Reality |
|---|---|---|
| `knowledge-system.md` | 8 | genuinely linked (index, architecture, roadmap, ADR-0011, …) |
| `master-key-rotation.md` | 14 | genuinely linked |
| `pr-reach-telemetry.md` | 2 | **orphan** — both are string literals in component-mapping test tables (`src/pkg/reach/mapping_test.go:38,39`, `src/pkg/hub/reach_api_test.go:145`), asserting the path maps to `ComponentUnattributable`. Not navigation. |
| `master-delivery-wrapped.md` | 1 | **orphan** — sole ref is a Go comment (`src/pkg/hub/wrapkey_test.go:18`) citing the design. Not navigation. |

### Why both went unnoticed

The `docs-index-reminder` workflow (#4618) is scoped to `^src/docs/[^/]+\.md$` — top level only. That scoping is correct and deliberate: `src/docs/adr/` carries its own README which the main index links as a directory, so requiring each ADR in the top-level index would be a false positive by design.

`design/` had no such README. So it fell between the two mechanisms — it got neither the delegation pattern's coverage nor the guard's. That is the actual defect.

## The fix

1. **`src/docs/design/README.md`** — new, following the shape of `src/docs/adr/README.md` (the established house pattern for a delegated directory index): purpose, how it differs from an ADR, records, and a short "adding a document here" note.
2. **`src/docs/README.md`** — the lone `design/knowledge-system.md` entry is replaced by a link to the new directory index, exactly as `adr/` is linked, completing the delegation chain. The *Historical/design notes* section now also points at `design/` as a whole directory of such pages.

`design/` now behaves like `adr/`, and any future doc added there is indexed by the same convention rather than by remembering to touch the top-level file.

## Statuses were checked against code, not against each page's own header

These pages have been undiscoverable, so nobody has corrected them; each index entry says what the reader gets **and** its status, so a proposal is not read as current behaviour.

- **`master-key-rotation.md` — partly shipped.** Generations foundation and the session-cookie domain are live (`hub_generations*.go`, `hub_cookie_generations.go`); the "Follow-on PRs" per-domain adoptions are pending, which matches its header.
- **`master-delivery-wrapped.md` — partly shipped, page-level design only.** Its header still reads `DESIGN ONLY. No implementation.`, but the Option D sealing primitive and spoke wrap-key lifecycle have landed (`src/pkg/hub/wrapkey.go`, `wrapkey_store.go`). The page says outright that it is not updated post hoc as stages ship, so the index records **both** facts rather than silently trusting the header or editing the record.
- **`pr-reach-telemetry.md` — partly shipped.** Phase 1 and 2a landed; 2b (#3994) / 2c (#3995) pending. **Its `v2/pkg/...` examples were left exactly as they are** and the index entry marks them *deliberately historical*: PRs merged before the `v2/`→`src/` rename report those paths from the forge API forever, and `src/pkg/reach/mapping.go` still maps both eras — `mapping_test.go` asserts both spellings side by side. "Fixing" them to `src/...` would have documented away live legacy behaviour.
- **`knowledge-system.md` — partly shipped.** Wiki layers, seed vault, and programmatic extraction are live; the planned `scheduler.RunCurator(schedule)` wiring is **not** implemented — `knowledge.curator.schedule` is defaulted (`config.go:4199`) and validated but read by no scheduler. The entry says so and points at `knowledge-curator.md` for the path that works today.

## Decision on widening the guard: leave it alone

Considered and declined. The guard's whole value is that it never cries wolf — its own header comment records that the previous convention died of noise. A "subdirectory gained a `.md` but has no README" check would need to distinguish a directory that legitimately has no index yet from one that has regressed, on `pull_request` diffs where the README may exist already and simply not be in the diff. That is the fragile kind of extension that produces exactly the false positives the current scoping was written to avoid.

The README + delegation is sufficient here, and structurally better: it removes the gap rather than detecting it. With this PR, **every** subdirectory of `src/docs/` has a README that the top-level index links — `adr/` and `design/` are the only two, and both are now covered. A future third subdirectory following the same pattern needs no workflow change.

## Notes

- Docs-only. No Go code touched.
- `src/docs/` is the source of truth; no synced copy hand-edited.
- No internal cluster names — the delivery design's own fleet table already describes clusters by role rather than by name, and the new index adds none.
- Relative links used for the new entries, per the live convention.