### PR TITLE
🌱 test(agent): stop TestConcurrentPauseResume launching real CLIs — suite no longer blows go test's 600s timeout (#4628)

### DIFF
--- a/src/pkg/agent/launch_coverage_test.go
+++ b/src/pkg/agent/launch_coverage_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -25,14 +24,18 @@ func TestStart_CLIAlreadyRunning(t *testing.T) {
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
 
-	// Pre-create the session and render a CLI marker.
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	// Pre-create the session and render a CLI marker. This must land on the
+	// package test tmux server (-L defaultTmuxSocket) — the same server the
+	// manager inspects. A bare `tmux` exec would hit the default-socket server
+	// instead, where the manager never looks, so the adopt branch under test
+	// would silently never trigger (#4628).
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	// Inject a marker; forceRelaunch defaults to false.
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": goose is ready").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": goose is ready").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 
 	if err := m.Start(context.Background(), "cxa"); err != nil {
@@ -62,12 +65,13 @@ func TestStart_InferenceCLIAlreadyRunning(t *testing.T) {
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
 
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	// Same-server requirement as TestStart_CLIAlreadyRunning above.
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": esc to interrupt bypass permissions on Claude").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": esc to interrupt bypass permissions on Claude").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 
 	if err := m.Start(context.Background(), "cxa"); err != nil {
@@ -91,12 +95,13 @@ func TestStart_CopilotAdoptsRunning(t *testing.T) {
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
 
-	if err := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
+	// Same-server requirement as TestStart_CLIAlreadyRunning above.
+	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
 		t.Skipf("cannot create tmux session: %v", err)
 	}
-	defer exec.Command("tmux", "kill-session", "-t", agent.tmuxSession).Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "-l", ": Copilot ready").Run()
-	exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": Copilot ready").Run()
+	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "Enter").Run()
 	time.Sleep(500 * time.Millisecond)
 
 	if err := m.Start(context.Background(), "cxa"); err != nil {

--- a/src/pkg/agent/manager_coverage2_test.go
+++ b/src/pkg/agent/manager_coverage2_test.go
@@ -1769,10 +1769,21 @@ func TestValidateTmuxKillSessionArgs(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestConcurrentPauseResume_NoPanic(t *testing.T) {
+	// Sandbox-enabled agents keep every Pause/Resume cycle a pure in-memory
+	// state transition — which is all this test pins: the pause/resume mutex
+	// accounting under concurrency. Without the sandbox gate, each Resume of a
+	// StatePaused agent takes the relaunch path (ensureTmuxSession +
+	// launchInTmux): a REAL tmux session create plus CLI launch per cycle,
+	// ~250 launches per run, none of them cleaned up. On hosts with a writable
+	// HIVE_WORK_DIR that took 220s+ alone and pushed the whole package past
+	// go test's 600s default timeout (#4628).
+	sandboxOn := true
+	sandbox := &config.AgentSandboxOverride{Enabled: &sandboxOn}
 	m := NewManager(map[string]config.AgentConfig{
-		"a": {Backend: "claude"},
-		"b": {Backend: "claude"},
+		"a": {Backend: "claude", Sandbox: sandbox},
+		"b": {Backend: "claude", Sandbox: sandbox},
 	}, discardLogger(), ProjectContext{})
+	m.SetSandboxConfig(config.AgentSandboxConfig{Enabled: true})
 
 	done := make(chan struct{})
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
## Summary

Fixes #4628 — `go test ./pkg/agent/ -count=1` blowing go test's 600s default timeout on live hive hosts.

The dominant cost was a single test. `TestConcurrentPauseResume_NoPanic` pins the pause/resume **mutex accounting** under concurrency (5 goroutines × 50 cycles), but its agents were plain non-sandbox configs, so every `Resume` of a `StatePaused` agent took the full relaunch path — `ensureTmuxSession` + `launchInTmux`: a **real tmux session create plus a real CLI launch per cycle**, ~250 launches per run, none of them cleaned up. That is exactly the tmux-exec storm the issue describes, and it reproduces off live hosts too: on an otherwise idle dev box, the moment `HIVE_WORK_DIR` points somewhere writable (as it does on every live hive host), the test alone takes **223.57s**; under live-host load that becomes the observed 420s and the package blows the 600s budget, aborting coverage profile writes (the false 0% on `stuck_login_diagnosis.go`).

## What changed

**1. `TestConcurrentPauseResume_NoPanic` is now exec-free** (`manager_coverage2_test.go`)

The test's agents are now sandbox-enabled (`AgentSandboxOverride` + `SetSandboxConfig`), which routes `Pause`/`Resume` through the sandbox branch: every cycle is a pure in-memory state transition — precisely the accounting the test exists to hammer, per the issue's own triage ("the race it pins is in the mutex accounting, not in tmux").

- Measured: **223.57s → 0.01s** (same box, writable `HIVE_WORK_DIR`, `-race` clean).
- No coverage lost on the real relaunch path: `relaunch_race_guard_test.go` already stresses concurrent `Resume` racing through the actual unlock/mint/relock dance, with stubs and cleanup.
- Side benefit: the test no longer reaches `launchInTmux`'s `reapAgentCLI` (which kills processes matched by `HIVE_AGENT` env) or leaves an uncleaned `hive-a` session plus ~250 launches' worth of leaked poll goroutines exec'ing tmux for the remainder of the suite.

**2. Fixed a tmux server mismatch hiding a coverage gap** (`launch_coverage_test.go`)

This is the issue's bullet 2 (audit tests that exec the real tmux binary). The three adopt-running-CLI tests (`TestStart_CLIAlreadyRunning`, `TestStart_InferenceCLIAlreadyRunning`, `TestStart_CopilotAdoptsRunning`) pre-created their marker sessions with **bare `exec.Command("tmux", ...)`** — the default-socket server — while the manager inspects the package test server (`-L defaultTmuxSocket`, per-pid, set by `TestMain`). The pre-created session was invisible to the manager, so `ensureTmuxSession` created a fresh empty pane and each test silently did a **full launch** instead of exercising the adopt branch it documents.

Verified with `-coverprofile` both ways: the CLI-already-running block in `manager.go` (the adopt body, including the trust-prompt and inference-dismiss sub-branches) had **0 hits** from these tests before, full hits after. They now use `testTmuxCommand`.

**3. Audit results (no further changes needed)**

- Every other tmux exec in `pkg/agent` tests goes through `testTmuxCommand` or the manager's socket-aware helpers.
- `TestMain` already isolates the socket name (per-pid `-L ht<pid>`) **and** `TMUX_TMPDIR`, so package tests cannot reach the live server's `hive-<agent>` sessions even via bare execs — the live-host interaction risk is load (CPU from launch storms), which item 1 removes.
- su-exec paths in tests are stubbed (`relaunch_mint_test.go`) or assert argv without running (`branches_coverage_test.go`).
- On `-timeout` headroom / `t.Parallel()` (issue bullet 3): CI runs the package in 5 shards each far below the budget, and with item 1 the serial suite fits comfortably inside go test's 600s default (see timing below), so no CI workflow change is needed. `t.Parallel()` was deliberately avoided: the wall-clock diagnostic tests share the global stub binaries via `overrideStub`, which is not parallel-safe.

## Verification

Both trees run with identical live-host-style conditions (ambient writable `HIVE_WORK_DIR`, `go test ./pkg/agent/ -count=1`, go test's default 600s timeout):

| | unmodified v4 | this branch |
|---|---|---|
| `TestConcurrentPauseResume_NoPanic` alone | 223.57s | **0.01s** (`-race` clean) |
| Full suite | **`panic: test timed out after 10m0s`** — the issue's exact symptom | **completes in 522–537s**, no panic, coverage profiles write |
| Failures before the timeout | 3 (`TestStart_AgyLaunchCommandLine` 37.36s, `TestSendKick_RestartsCrashedCLIThenDelivers` 67.19s, `TestRestartThenSendKick_CleanSlateThenDelivers` 67.19s) | 2 — a strict subset, same tests, same timings |

The residual failures are pre-existing and out of this issue's scope: they fail on the untouched baseline with identical timings, pass individually under the same env (`TestSendKick_RestartsCrashedCLIThenDelivers` is also flaky in isolation: 1 fail / 2 pass across three identical runs), sit in files this PR does not touch, and belong to the ambient-state hermeticity class tracked by #4581/#4631. This branch strictly reduces the failure set and removes the timeout.

Also verified: `gofmt` clean, `go vet ./pkg/agent/` clean, and the three adopt tests plus the concurrency test pass with `-race`.

Companion PR #4627 (live-host `TestAgentAuthState_*` failures) touches different tests; together they move the package toward green and bounded on live hosts.

— hive: backend=claude model=claude-Fable-5
