### PR TITLE
📖 ci: resolve the infra-sync clobber of scorecard.yml's release-line pin (#4616)

### DIFF
--- a/.github/release-lines.yml
+++ b/.github/release-lines.yml
@@ -53,6 +53,17 @@ pinned:
   # recorded as an exclusion rather than quietly corrected, because turning
   # OpenSSF Scorecard on for a release line is a maintainer decision, not a
   # side effect of adding a CI guard. See the note at the bottom of this file.
+  #
+  # scorecard.yml is ALSO the one pinned workflow that the automated workflow
+  # sync from kubestellar/infra used to overwrite (#4616): the synced copy pins
+  # `[main]` only, so every `sync/workflows-from-infra` branch arrived with
+  # this guard red, and merging one would have silently stopped Scorecard on
+  # v4 — #4339 again. The sync now skips scorecard.yml for this repo
+  # (kubestellar/infra `caller-workflows/workflow-exclusions.yml`); this file
+  # is the pin the exclusion protects. If a sync branch ever goes red on this
+  # entry again, the exclusion has been lost upstream — restore it there; do
+  # not merge the sync branch, and do not "fix" it by widening this entry.
+  # See src/docs/release-line-guard.md, "The infra workflow sync".
   scorecard.yml: [main, -v2]
   suid-contract.yml: []
   v2-ci.yml: []

--- a/src/docs/release-line-guard.md
+++ b/src/docs/release-line-guard.md
@@ -165,7 +165,9 @@ The resolution ([#4616](https://github.com/kubestellar/hive/issues/4616),
 recommendation 2): the sync tool supports per-repo exclusions in
 kubestellar/infra `caller-workflows/workflow-exclusions.yml`, and hive's
 `scorecard.yml` is excluded there
-([kubestellar/infra#145](https://github.com/kubestellar/infra/pull/145)). This
+([kubestellar/infra#146](https://github.com/kubestellar/infra/pull/146); the
+equivalent [kubestellar/infra#145](https://github.com/kubestellar/infra/pull/145)
+was superseded by it). This
 repo maintains `scorecard.yml` locally and bumps its pinned
 `reusable-scorecard.yml` SHA deliberately.
 

--- a/src/docs/release-line-guard.md
+++ b/src/docs/release-line-guard.md
@@ -139,6 +139,41 @@ The workflow runs the self-test *before* the check, because a checker that has
 quietly stopped detecting anything would otherwise pass the real check for the
 wrong reason.
 
+## The infra workflow sync ([#4616](https://github.com/kubestellar/hive/issues/4616))
+
+`scorecard.yml` is not only pinned — it is also one of the files the automated
+workflow sync from [kubestellar/infra](https://github.com/kubestellar/infra)
+distributes to every repo in the org (`sync-workflows.yml`, pushing branch
+`sync/workflows-from-infra`). The infra copy pins `push.branches: [ "main" ]`
+only; it cannot know about this repository's release-line manifest. So every
+sync used to arrive with this guard red:
+
+```
+FAIL: scorecard.yml:7 branches: has [main], expected [main,v4] — missing: v4
+```
+
+That red is the guard doing its job. Merging such a sync branch as-is would
+have silently stopped OpenSSF Scorecard running on `v4` — a workflow that
+stops *triggering* reports nothing, which is exactly the #4339 failure mode
+this guard exists to catch. The same sync also reverts other deliberate local
+hardening (immutable-SHA pins on the cross-repo reusable workflows back to
+`@main`, `pull_request` → `pull_request_target` with `secrets: inherit`), which
+this guard does not check — a red guard on a sync branch is a reason to review
+the whole sync diff, not just the line the guard names.
+
+The resolution ([#4616](https://github.com/kubestellar/hive/issues/4616),
+recommendation 2): the sync tool supports per-repo exclusions in
+kubestellar/infra `caller-workflows/workflow-exclusions.yml`, and hive's
+`scorecard.yml` is excluded there
+([kubestellar/infra#145](https://github.com/kubestellar/infra/pull/145)). This
+repo maintains `scorecard.yml` locally and bumps its pinned
+`reusable-scorecard.yml` SHA deliberately.
+
+If a `sync/workflows-from-infra` branch ever goes guard-red on `scorecard.yml`
+again, the upstream exclusion has been lost — restore it in
+kubestellar/infra's `workflow-exclusions.yml`. Do not merge the sync branch,
+and do not widen this repo's manifest entry to make the guard pass.
+
 ## Open: should `v2` still be in these lists?
 
 Deliberately **not** answered by this guard — it is a maintainer call about


### PR DESCRIPTION
## Summary

Resolves #4616 in two halves, implementing the issue's **recommendation 2** (the narrowest of the three it records):

1. **The fix, upstream**: kubestellar/infra#145 adds `hive: [scorecard.yml]` to the sync tool's existing per-repo exclusion mechanism (`caller-workflows/workflow-exclusions.yml`, same shape as the `console`/`pr-verifier.yml` precedent already in that file). With it merged, the infra→hive sync stops overwriting `scorecard.yml`, so sync branches stop arriving Release-Line-Guard-red and hive maintains its `scorecard.yml` locally, bumping the pinned `reusable-scorecard.yml` SHA deliberately.
2. **This PR, in hive**: records the interaction where the pin is defined, so the story survives in-repo:
   - `.github/release-lines.yml` — the `scorecard.yml` entry now notes it is the pin the upstream exclusion protects, and gives the play if a sync branch ever goes red on it again (the exclusion was lost upstream — restore it there; never merge the sync branch or widen the manifest entry to quiet the guard).
   - `src/docs/release-line-guard.md` — new section "The infra workflow sync": why every sync arrived red, why that red is the guard working as designed, and why a red sync branch warrants reviewing the **whole** sync diff, not just the guard's line.

## Why recommendation 2

- Recommendation 1 (add `v4` to infra's shared `caller-workflows/scorecard.yml`) would push a hive-specific branch name at every synced repo in the org.
- Recommendation 3 (teach the sync to preserve target-local `branches:` pins) is a larger tooling change; it remains open upstream, and if ever built, the exclusion becomes unnecessary rather than harmful.
- Recommendation 2 uses a mechanism the sync tool already supports, affects only hive, and is one line plus a comment.

## What reviewing the sync diff shows (context, no action here)

The guard only checks branch filters, but the current `sync/workflows-from-infra` diff also reverts other deliberate hive hardening the guard cannot see: every cross-repo reusable-workflow ref goes from an immutable commit SHA back to mutable `@main` (deleting the in-file SECURITY comment that explains the pin), several workflows swap `pull_request` for `pull_request_target` while adding `secrets: inherit`, and `pr-verifier.yml`'s pinned-image inline job is replaced by a `@main` reusable call. That is consistent with the last two sync PRs (#4611, #3932) being closed unmerged. The new doc section says exactly this: a red guard on a sync branch is a signal to review the entire sync, not to patch the one flagged line.

## Verification

- `src/scripts/check-release-lines.sh` — PASS with the manifest comment in place (comments in `pinned:` are already part of the file's grammar; `scorecard.yml:7 branches: main,v4` still asserted).
- `src/scripts/test-release-lines-guard.sh` — PASS (the guard still catches a stale allow-list).
- Docs-only otherwise; no workflow behavior changes in this PR.

Until kubestellar/infra#145 merges, sync branches keep arriving red — the guard keeps correctly blocking them, and the new documentation tells the reader why and what to do.

— hive: backend=claude model=claude-Fable-5
