### PR TITLE
🌱 ci: cut v2-tests.yml cron from every 15 minutes to hourly at :30 (#4650)

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -2,7 +2,15 @@ name: v2 Tests
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    # Hourly, at :30 — deliberately offset from coverage-hourly.yml's :00 run
+    # so the two scheduled nets alternate every half hour instead of firing
+    # together. This schedule is the post-merge safety net for the default
+    # branch (there is no push trigger; pull_request below is the real gate),
+    # and it is what keeps create-issue-on-failure armed. It ran every 15
+    # minutes until #4650: ~96 runs/day at ~3m15s each — ~5 runner-hours/day —
+    # almost all on an unchanged, already-gated SHA, while coverage-hourly
+    # re-ran the identical suite with the same floors every hour anyway.
+    - cron: '30 * * * *'
   workflow_dispatch:
   # Gate PRs, not just the cron. `go test ./pkg/...` runs nowhere else — v2-ci.yml
   # builds and vets but never runs the unit tests — so before this, a Go
@@ -295,7 +303,7 @@ jobs:
 
   # Per-package coverage-floor gate (#4112): parse-only, consumes the shard
   # artifacts — it runs no tests, so PRs run the suite exactly once. PR-only:
-  # on the 15-minute schedule the hourly coverage workflow remains the
+  # on the hourly schedule the coverage-hourly workflow remains the
   # monitoring + issue-filing authority.
   #
   # Scoring is computed from the coverage PROFILES, not from the `ok ...


### PR DESCRIPTION
## Summary

Fixes #4650. Cuts `v2-tests.yml`'s cron from `*/15 * * * *` to `30 * * * *` — hourly, offset to :30 — and updates the one comment that referred to "the 15-minute schedule".

The `*/15` schedule ran the full sharded suite ~96 times/day at ~3m15s each (~5 runner-hours/day), almost entirely on an unchanged v4 SHA the `pull_request` gate had already tested, while `coverage-hourly.yml` re-runs the identical `-short -race` suite with the same coverage floors every hour on top of that (the issue's evidence: five consecutive green scheduled runs on one unchanged commit; 29/30 recent v4 runs green).

## Why hourly rather than dropping the cron

The issue offers both. Two facts argue for keeping an hourly schedule:

- **`v2-tests.yml` has no `push` trigger** — its scheduled run is the only direct execution of the test suite on merged v4 code. Post-merge breakage (e.g. a semantic conflict between two individually-green PRs) is otherwise only caught indirectly by `coverage-hourly.yml`, where a failing package surfaces as a coverage-floor drop rather than as a named test failure.
- **`create-issue-on-failure` is gated on `github.event_name == 'schedule'`** — deleting the cron leaves that issue-filing job permanently dead.

Hourly keeps both signals at 1/4 the spend: ~96 → 24 runs/day, ~5 → ~1.3 runner-hours/day.

## Why :30

`coverage-hourly.yml` fires at :00. Offsetting this run to :30 makes the two scheduled nets alternate every half hour instead of firing together — worst-case detection latency for a post-merge breakage stays ~30 minutes instead of doubling to a full hour, and the two suite runs stop competing for runners at the top of the hour.

## Verification

- YAML parses (`yaml.safe_load`).
- `src/scripts/check-release-lines.sh` — PASS (`v2-tests.yml` is a `pinned` workflow; its branch filters are untouched).
- Repo-wide grep for `*/15` / "15-minute": no other reference documents this workflow's cadence (remaining hits are unrelated subsystems — heartbeat sampling, env-reconcile sweeps, agent cadence examples).

Note from the issue: the filing ci-maintainer agent could not ship this itself — its App token lacks the `workflows` permission. This PR comes from a user fork with `workflow` scope. Same blocker applies to the parked patch on #4623 (concurrency cancellation, same file), which stays separate so each change can be judged on its own.

— hive: backend=claude model=claude-Fable-5
