### PR TITLE
fix(image): launch agy/claude under umask 007 for shared-$HOME fleets

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -562,5 +562,20 @@ RUN find / -xdev -type f \( -perm -4000 -o -perm -2000 \) \
       exit 1; \
     fi
 
+
+# --- Layer 8.26: shared-$HOME state hygiene (umask 007 wrappers) ---
+# Agent CLIs rewrite their credential/settings state as mode 600 owned by the
+# writing agent (agy: antigravity-cli/*.json + oauth token; claude:
+# .credentials.json). With a shared $HOME (/data/home) that breaks every other
+# agent on the same provider (EACCES -> login/onboarding screens). Launch
+# through wrappers that set umask 007 so shared state stays group-readable.
+# See RFC #4665.
+RUN for b in agy claude; do \
+      [ -e "/usr/local/bin/$b" ] || continue; \
+      mv "/usr/local/bin/$b" "/usr/local/bin/$b.real"; \
+      printf '#!/bin/sh\numask 007\nexec /usr/local/bin/%s.real "$@"\n' "$b" > "/usr/local/bin/$b"; \
+      chmod 755 "/usr/local/bin/$b"; \
+    done
+
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["--config", "/etc/hive/hive.yaml"]


### PR DESCRIPTION
## Problem

Hive agents can share a single `$HOME` (e.g. `/data/home` on the tuna-os spoke). Both agy and claude rewrite their credential/state files **as mode 600 owned by the writing agent** on token refresh / state save:

- agy: `antigravity-cli/settings.json`, `cache/onboarding.json`, `antigravity-oauth-token`
- claude: `.credentials.json`

The next agent on the same provider then hits `EACCES`, falls back to defaults, and re-shows first-run onboarding / `Login expired` screens — the dashboard still reports `running`. Observed live 2026-08-23: architect's claude rewrote `.credentials.json` as `-rw------- hive-architect`, breaking every other claude agent until an operator chmod'd it.

## Fix

Wrap both binaries in a one-line shim that sets `umask 007` before exec:

```sh
#!/bin/sh
umask 007
exec /usr/local/bin/<bin>.real "$@"
```

Shared-state writes then stay group-readable (`660`/group `770`); ownership may change per refresh but access no longer does. Verified in the rebuilt image: running agy processes report `Umask: 0007` and create `-rw-rw----` files. See RFC #4665 for the broader self-healing watchdog design this unblocks.