### PR TITLE
🐛 Give the ttyd proxy a non-pooling agent so browser basic-auth can succeed

### DIFF
--- a/src/proxy/package.json
+++ b/src/proxy/package.json
@@ -2,12 +2,12 @@
   "name": "hive-dashboard-proxy",
   "version": "2.0.0",
   "private": true,
-  "description": "Thin proxy: auth + static files → Go binary API",
+  "description": "Thin proxy: auth + static files \u2192 Go binary API",
   "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node health_probe.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node csp_token_injection.test.js && node csp_script_src_elem.test.js"
+    "test": "node server.test.js && node health_probe.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node csp_token_injection.test.js && node csp_script_src_elem.test.js && node ttyd_auth_retry.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/src/proxy/server.js
+++ b/src/proxy/server.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import httpBase from 'http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import path from 'path';
 import fs from 'fs';
@@ -932,6 +933,16 @@ app.use('/api', apiProxy);
 const ttydProxy = createProxyMiddleware({
   target: TTYD_URL,
   changeOrigin: true,
+  // ttyd (libwebsockets) serves ONE request per TCP connection and hangs up
+  // on any reuse. Without an explicit agent, httpxy (the proxy engine) pools
+  // upstream sockets in its own keepAlive:true default agents, so the
+  // browser's basic-auth flow — an unauthenticated request answered 401,
+  // then an authenticated retry — deterministically rode a dead pooled
+  // socket and surfaced as 502 "Terminal unavailable" with the CORRECT
+  // password. A non-pooling agent gives every request a fresh connection;
+  // pooling buys nothing here anyway, because the endpoint's real traffic
+  // is a single long-lived websocket.
+  agent: new httpBase.Agent({ keepAlive: false }),
   pathRewrite: (p) => p.replace(/^\/terminal/, '') || '/',
   on: {
     error(err, req, res) {

--- a/src/proxy/ttyd_auth_retry.test.js
+++ b/src/proxy/ttyd_auth_retry.test.js
@@ -1,0 +1,151 @@
+// The browser basic-auth flow against /terminal must survive ttyd's
+// one-request-per-connection behavior.
+//
+// ttyd (libwebsockets) does not serve a second HTTP request on a reused TCP
+// connection — it hangs up. http-proxy-middleware's engine (httpxy) pools
+// upstream sockets in its own keepAlive:true default agents whenever no
+// explicit agent option is given, so the flow every browser performs — an
+// unauthenticated GET answered 401 (auth dialog), then an authenticated
+// retry — deterministically picked the dead pooled socket and surfaced as
+// 502 "Terminal unavailable" WITH THE CORRECT PASSWORD. Measured on a live
+// hive: unauth 401 → auth 502 → auth 200, repeating (every fresh-socket
+// request pools a socket ttyd then kills, so every second request died).
+// The fix gives ttydProxy a keepAlive:false agent; this test pins the whole
+// sequence through the real proxy against a mock ttyd reproducing the
+// one-request-per-connection behavior.
+import { createServer, request as httpRequest } from 'http';
+import { strict as assert } from 'assert';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROXY_PORT = 19011;
+const GO_PORT = 19012;
+const TTYD_PORT = 19013;
+const CRED = 'Basic ' + Buffer.from('hive:sekrit').toString('base64');
+
+let goServer, ttydServer, proxyProcess;
+
+// Minimal Go-API stand-in: the proxy only needs it to exist.
+function setupMockGoBackend() {
+  const server = createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  });
+  return new Promise(resolve => server.listen(GO_PORT, () => resolve(server)));
+}
+
+// Mock ttyd with the two behaviors under test: basic auth (401 without the
+// credential, 200 with it) and libwebsockets' one-request-per-connection
+// lifecycle — any second request arriving on a reused socket is destroyed
+// without a response, which is what the proxy's pooled socket runs into.
+function setupMockTtyd() {
+  const served = new WeakSet();
+  const server = createServer((req, res) => {
+    if (served.has(req.socket)) {
+      req.socket.destroy();
+      return;
+    }
+    served.add(req.socket);
+    if (req.headers.authorization !== CRED) {
+      res.writeHead(401, { 'WWW-Authenticate': 'Basic realm="ttyd"' });
+      res.end();
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('ttyd-ok');
+  });
+  return new Promise(resolve => server.listen(TTYD_PORT, () => resolve(server)));
+}
+
+function startProxy() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        HIVE_PROXY_PORT: String(PROXY_PORT),
+        HIVE_API_PORT: String(GO_PORT),
+        HIVE_TTYD_PORT: String(TTYD_PORT),
+        HIVE_DASHBOARD_TOKEN: '',
+        HIVE_STATIC_DIR: __dirname,
+        NODE_ENV: 'test',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', (d) => {
+      if (!started && d.toString().includes('hive-proxy')) {
+        started = true;
+        resolve(proc);
+      }
+    });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('proxy start timeout')); }, 10000);
+  });
+}
+
+function get(auth) {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({
+      host: '127.0.0.1',
+      port: PROXY_PORT,
+      path: '/terminal/?arg=hive-scanner',
+      headers: auth ? { Authorization: CRED } : {},
+    }, (res) => {
+      let body = '';
+      res.on('data', d => { body += d; });
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function main() {
+  goServer = await setupMockGoBackend();
+  ttydServer = await setupMockTtyd();
+  proxyProcess = await startProxy();
+  await new Promise(r => setTimeout(r, 500));
+
+  // The browser's exact sequence. Before the fix, step 2 was the 502: the
+  // unauthenticated request left a pooled socket ttyd will not serve again.
+  const first = await get(false);
+  assert.equal(first.status, 401, `unauthenticated GET should pass ttyd's 401 through, got ${first.status}`);
+
+  // Let the upstream socket settle into the agent's free pool — in the real
+  // flow the user spends seconds in the auth dialog, and reuse of a pooled
+  // (dead) socket is exactly the failure under test.
+  await new Promise(r => setTimeout(r, 150));
+
+  const second = await get(true);
+  assert.equal(second.status, 200,
+    `authenticated retry must reach ttyd on a fresh connection, got ${second.status} ` +
+    `(502 here means the proxy reused a pooled socket ttyd already considers dead)`);
+  assert.equal(second.body, 'ttyd-ok');
+
+  // And it must not be luck: every subsequent request pools a socket the
+  // mock kills, so any reuse regression fails on one of these.
+  for (let i = 0; i < 3; i++) {
+    await new Promise(r => setTimeout(r, 150));
+    const again = await get(true);
+    assert.equal(again.status, 200, `repeat authenticated GET #${i + 1} got ${again.status}`);
+  }
+
+  console.log('ttyd_auth_retry: all assertions passed');
+}
+
+// Cleanup must run BEFORE process.exit — an exit inside .then() skips
+// .finally(), leaving the spawned proxy orphaned on its port, where it
+// silently serves every later run of this test regardless of what server.js
+// on disk says (measured: exactly that produced a false pass of this test).
+function cleanup() {
+  if (proxyProcess) proxyProcess.kill();
+  if (goServer) goServer.close();
+  if (ttydServer) ttydServer.close();
+}
+
+main()
+  .then(() => { cleanup(); process.exit(0); })
+  .catch((err) => { console.error(err); cleanup(); process.exit(1); });


### PR DESCRIPTION
## What

The dashboard's `▶ terminal` link dies with 502 "Terminal unavailable" on every browser basic-auth attempt — **with the correct password**. Measured live on a rootless podman hive, deterministically:

```
1 unauth GET  → 401   (browser shows the auth dialog)
2 auth GET    → 502   "Terminal unavailable"
3 auth GET    → 200   (reload works)
… and the pattern repeats
```

## Why

ttyd (libwebsockets) serves **one HTTP request per TCP connection** and hangs up on any reuse. `httpxy` — http-proxy-middleware v4's engine — pools upstream sockets in its own `keepAlive: true` default agents whenever no explicit `agent` option is given (`setupOutgoing`: `options.agent !== void 0 ? … : defaultAgents.http`). So the browser's unauthenticated 401 leaves a pooled socket ttyd will never serve again; the authenticated retry rides it into ECONNRESET (`[ttyd-proxy] … → socket hang up`), which the proxy's error handler renders as 502. Every fresh-connection request re-poisons the pool for the next one, which is why the failure alternates forever instead of clearing.

## Fix

An explicit `agent: new http.Agent({ keepAlive: false })` on `ttydProxy`. httpxy honors an explicit agent, so every proxied request gets a fresh connection. Pooling bought nothing on this route anyway — its real traffic is a single long-lived websocket, which never pooled (`agent = false` on upgrade requests already).

## Test

`ttyd_auth_retry.test.js` drives the browser's exact sequence through the **real proxy** (spawned `server.js`) against a mock ttyd that reproduces the one-request-per-connection behavior (second request on a reused socket → destroy). Verified both directions:

- with the agent line removed, it fails with the exact live symptom: `authenticated retry must reach ttyd on a fresh connection, got 502`
- with the fix, the 401 → auth-retry → repeat sequence is all green

One test-infra finding worth noting: the test kills its spawned proxy **before** `process.exit` — a `process.exit(0)` inside `.then()` skips `.finally()`, and during development the orphaned child kept serving later runs from its port, producing a false pass. The same orphan squatting on ports 19001-19003 is the likely cause of sporadic `C3 test failed: alice (allowlisted) should reach terminal, got 401` failures when `server.test.js` runs are interrupted — with stray children killed, the full proxy suite passes clean, C3 included.

`npm test` (full proxy suite): all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

