### PR TITLE
📖 docs: retire stale v2 wording in federation-design; index hub DR and four other unlinked docs

### DIFF
--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -4,9 +4,13 @@
 
 Hive Federation lets independent Hive instances publish themselves in a registry so contributors can discover projects and connect a local ClankeR contributor relay to one or more hubs. The registry is a directory, not a control plane: every hive keeps its own credentials, queue, agents, contributor registry, and trust policy.
 
-## Current v2 implementation
+## Current implementation
 
-The v2 Go dashboard API implements the federation endpoints in `src/pkg/dashboard/api_contribute.go`:
+> This section was originally written while the source lived under the retired
+> `v2/` tree (v2 was retired in August 2026). The endpoints it describes are
+> live on the current `v4` branch, under `src/`.
+
+The Go dashboard API implements the federation endpoints in `src/pkg/dashboard/api_contribute.go`:
 
 - `GET /api/hives` — list registered hives.
 - `POST /api/hives/register` — add or update a hive entry.
@@ -14,11 +18,11 @@ The v2 Go dashboard API implements the federation endpoints in `src/pkg/dashboar
 - `DELETE /api/hives/:id` — remove a hive.
 - `POST /api/hives/onboard` — generate starter deployment/config text.
 
-Registry storage defaults to `/data/federation/registry.json` in v2 and can be overridden for tests with `HIVE_FEDERATION_REGISTRY_PATH`.
+Registry storage defaults to `/data/federation/registry.json` and can be overridden for tests with `HIVE_FEDERATION_REGISTRY_PATH`.
 
 ## Project onboarding
 
-A project maintainer installs/configures GitHub auth for their Hive, generates or writes v2 config, deploys the Hive, and registers it:
+A project maintainer installs/configures GitHub auth for their Hive, generates or writes the hive config (`hive.yaml`), deploys the Hive, and registers it:
 
 ```bash
 curl -X POST https://hive.kubestellar.io/api/hives/register \

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -28,6 +28,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [`bd` beads CLI](https://github.com/kubestellar/hive/blob/v4/src/docs/beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
 - [Backup and restore](https://github.com/kubestellar/hive/blob/v4/src/docs/backup-restore.md) — `hive-backup`, Kubernetes CronJob, spoke backup scope, and setting the backup encryption key from Governor Config (hosted flow). Host-level backup, restore, and `docker compose down -v` are given per runtime: Docker Compose, and Podman/Quadlet with the executed backup → wipe → restore cycle in both root modes, the rootless mapped-UID trap that makes a host-shell `tar` skip the GitHub App key, and the Docker→Podman migration (the two volume stores are never shared).
+- [Hub disaster recovery](https://github.com/kubestellar/hive/blob/v4/docs/HUB_DISASTER_RECOVERY.md) — the hub-level runbook that goes beyond per-hive backup: hub backup and key escrow, spoke fleet recovery, Slack blast, and the full rebuild-from-zero procedure after a catastrophic loss.
 - [Deployment helper scripts](https://github.com/kubestellar/hive/blob/v4/src/docs/deployment-scripts.md) — the all-in-one LXC setup, Proxmox LXC, and blue-green Compose helpers. All are Docker-only; the page states each script's runtime scope and where a Podman operator should go instead.
 - [`bin/` pipeline script index](https://github.com/kubestellar/hive/blob/v4/bin/README.md) — map of the 45 deterministic pipeline and operational shell/Python scripts, grouped by function.
 - [Dashboard API reference](https://github.com/kubestellar/hive/blob/v4/src/docs/api-reference.md) — pragmatic route index for dashboard and hub endpoints.
@@ -37,6 +38,8 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 
 ## Contributors and access
 
+- [Getting started as a first-time contributor](https://github.com/kubestellar/hive/blob/v4/docs/getting-started-contributing.md) — the end-to-end path for a first code or documentation contribution, tying the reference docs together and answering the Hive-specific questions they don't.
+- [Local development](https://github.com/kubestellar/hive/blob/v4/docs/development.md) — the local workflow for contributing to the Go codebase on `v4`: prerequisites, build, and test loop.
 - [ClankeR contributor relay](contributor-relay.md) — local contributor setup, multi-hub subscriptions, moving a relay to another machine, and role requests.
 - [Contributor trust tiers and delegated agent roles](https://github.com/kubestellar/hive/blob/v4/src/docs/contributor-trust-and-roles.md) — newcomer/contributor/trusted/merger/advisor semantics, **Acting as**, grants, and delegatable roles.
 - [Credly badges](https://github.com/kubestellar/hive/blob/v4/src/docs/credly-badges.md) — planned integration design; currently a placeholder mapping only.
@@ -72,11 +75,13 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [CLI backend setup](https://github.com/kubestellar/hive/blob/v4/docs/backend-setup.md) — setup notes for Claude, Copilot, Goose, Bob, Pi, Codex, and Aider.
 - [Inference backends](https://github.com/kubestellar/hive/blob/v4/docs/inference-backends.md) — vLLM, llm-d, LiteLLM, and Model Gateway troubleshooting.
 - [apiproxy](https://github.com/kubestellar/hive/blob/v4/src/docs/apiproxy.md) — Anthropic-compatible proxy logging and deployment notes.
+- [Outreach anti-spam ruleset](https://github.com/kubestellar/hive/blob/v4/docs/outreach-antispam.md) — the deduplication and anti-spam rules the outreach agent operates under across awesome lists, project issues, directories, and community threads.
 - [v1 to v2 migration](https://github.com/kubestellar/hive/blob/v4/docs/migration-v1-v2.md) — **historical.** Both ends of this migration are retired; v2 was retired in August 2026. Kept for operators still on v1, who should read it alongside [v2 → v4 migration](migration-v2-v4.md) above. New deployments do not need it.
 
 ## Architecture and design
 
 - [Architecture](architecture.md) — process model, governor loop, guardrails, hub/spoke, and walkthrough.
+- [Hive federation design](https://github.com/kubestellar/hive/blob/v4/docs/federation-design.md) — the multi-hive registry: live `/api/hives` endpoints, project onboarding, contributor flow across hubs, and what remains future design work.
 - [Public roadmap](roadmap.md) — the v4 direction as Now / Next / Later, with the tracking issue behind each item. Directional rather than a promise, maintained by pull request; check the date in its header before relying on the ordering.
 - [Landscape and positioning](landscape.md) — how Hive's operations-plane design compares to nearby agentic orchestration tools, with public references per project. Explicitly time-sensitive; check the conducted date in its header before quoting product details.
 - [CNCF reference architecture](https://github.com/kubestellar/hive/blob/v4/src/docs/cncf-reference-architecture.md) — CNCF submission/reference template.

--- a/src/docs/backup-restore.md
+++ b/src/docs/backup-restore.md
@@ -2,6 +2,8 @@
 
 Hive has two backup paths with different scopes: nightly encrypted hub disaster-recovery archives, and on-demand per-spoke backups an owner can download from the dashboard.
 
+> **See also:** [Hub disaster recovery](https://github.com/kubestellar/hive/blob/v4/docs/HUB_DISASTER_RECOVERY.md) — the full hub-level runbook (key escrow, spoke fleet recovery, Slack blast, rebuild from zero) that the `hive-backup` archives described here feed into.
+
 ## Hub disaster recovery: `hive-backup`
 
 `src/cmd/hive-backup` creates encrypted hub disaster-recovery archives — everything needed to rebuild a hub. It captures:


### PR DESCRIPTION
Fixes #4663
Fixes #4662

## #4663 — federation-design.md stale v2 terminology

The doc's **"Current v2 implementation"** section describes the *live v4* code (`src/pkg/dashboard/api_contribute.go`) — v2 was retired in August 2026, so the qualifier misled readers into thinking this was a retired code path. Careful rewrite, not a blind sed:

- Heading → **"Current implementation"**, with a short note that the section was written during the v2 era and the endpoints are live on the current `v4` branch under `src/` (the header note the issue recommended).
- "Registry storage defaults to … **in v2**" → qualifier dropped (the default is current behavior).
- "generates or writes **v2 config**" → "the hive config (`hive.yaml`)".
- The one remaining "v2" in the file is the deliberate historical note.

## #4662 — HUB_DISASTER_RECOVERY.md missing from the docs index

`docs/HUB_DISASTER_RECOVERY.md` (693-line hub rebuild runbook) was reachable only from one root-README sentence. Now:

- Listed in `src/docs/README.md` **Operations**, directly after the Backup and restore entry, in the index's one-line style.
- `src/docs/backup-restore.md` gains the **see-also** the issue asked for — the two docs covered adjacent ground and never cross-referenced.

## While-there sweep: other unlinked `docs/*.md`

Checked all 13 top-level `docs/*.md` against the index. **Added** (current, useful, previously invisible):

| Doc | Index section |
|---|---|
| `getting-started-contributing.md` | Contributors and access |
| `development.md` | Contributors and access |
| `federation-design.md` | Architecture and design |
| `outreach-antispam.md` | Configuration and agents |

**Deliberately not added**: `advisory-staleness.md` and `architecture.md` are pure redirect stubs pointing into pages the index already lists; `macos.md`, `troubleshooting.md`, and `LEGACY-v1-architecture.md` are legacy v1/systemd pages whose own headers redirect readers to the current docs — indexing them would put retired operational guidance back in front of operators.

Docs-only; all added links verified against the tree; no forbidden phrases.