### PR TITLE
🌱 ci: 6-hourly v2-tests cron and PR-only concurrency cancellation (#4650, #4623)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -31,6 +31,17 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded PR runs only (#4623). A new push to a PR makes the
+# in-flight run's verdict irrelevant, so cancelling it is pure runner-minute
+# savings. Push-to-v4 (post-merge) runs must NEVER be cancelable: they feed
+# the docker publish gate and the coverage/monitoring surface — cancelling
+# one on a merge burst would silently skip a merged commit. Keying the
+# non-PR group on run_id gives every such run its own group, so they can
+# neither cancel each other nor queue behind one another.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -2,7 +2,12 @@ name: v2 Tests
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    # Four scheduled runs a day (#4650). The scheduled run exists to catch
+    # merge races and flakes that slip past per-PR runs on v4 — a 6-hour
+    # cadence bounds detection latency at 6h while cutting ~96 redundant
+    # full-suite runs/day to 4. Minute 17 avoids the top-of-hour scheduler
+    # rush, when GitHub delays or drops cron runs.
+    - cron: '17 */6 * * *'
   workflow_dispatch:
   # Gate PRs, not just the cron. `go test ./pkg/...` runs nowhere else — v2-ci.yml
   # builds and vets but never runs the unit tests — so before this, a Go
@@ -19,6 +24,17 @@ on:
 permissions:
   contents: read
   issues: write
+
+# Cancel superseded PR runs only (#4623). A new push to a PR makes the
+# in-flight run's verdict irrelevant, so cancelling it is pure runner-minute
+# savings. Scheduled and workflow_dispatch runs must NEVER be cancelable:
+# the scheduled run feeds create-issue-on-failure (the merge-race/flake
+# auto-filer) — cancelling one blinds it for that window. Keying the non-PR
+# group on run_id gives every such run its own group, so they can neither
+# cancel each other nor queue behind one another.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # ── Sharding layout (#4118) ──────────────────────────────────────────────────
 # The suite is split so PR wall-clock ≈ the slowest single piece, not the sum.
@@ -295,7 +311,7 @@ jobs:
 
   # Per-package coverage-floor gate (#4112): parse-only, consumes the shard
   # artifacts — it runs no tests, so PRs run the suite exactly once. PR-only:
-  # on the 15-minute schedule the hourly coverage workflow remains the
+  # on the 6-hourly schedule the hourly coverage workflow remains the
   # monitoring + issue-filing authority.
   #
   # Scoring is computed from the coverage PROFILES, not from the `ok ...


### PR DESCRIPTION
## Summary

Two [ci-maintainer] runner-spend fixes, combined because they touch the same two workflow files:

**#4650 — v2-tests.yml cron cadence.** `*/15 * * * *` (~96 scheduled full-suite runs/day) → `17 */6 * * *` (4/day). The scheduled run exists to catch merge races and flakes on v4; a 6-hour bound on detection latency keeps that property while cutting the redundant spend ~24×. Minute 17 avoids the top-of-hour cron rush where GitHub delays/drops scheduled runs. The workflow **name is unchanged** (branch protection + tide key on the 'v2 Tests' check name — in-file warning respected). The failure auto-filer (#4572) is cadence-independent: it dedupes by open `ci-failure` issue **title prefix** (`[Tests] <branch> test`), not by time window, so repeated failures at the new cadence still fold into one issue with follow-up comments.

**#4623 — concurrency cancellation, PR runs only.** Both v2-ci.yml and v2-tests.yml gain:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Superseded PR pushes cancel the stale run. Non-PR runs (push-to-v4, schedule, workflow_dispatch) key their group on `run_id`, making each its **own** group — deliberately stronger than just `cancel-in-progress: false`, because a shared non-cancelable group still lets a *newer pending* run replace an *older pending* one on a merge burst, which would silently skip a merged commit's docker/coverage run. Per-run groups can neither cancel nor queue-supersede each other, so the post-merge surface and the scheduled auto-filer stay blind-spot free.

Verified: actionlint clean (two SC2024/SC2034 warnings pre-existing on v4 tip, untouched lines), release-line guard PASS (no branch filters changed).

No CHANGELOG entry per its own guideline (CI-internal, not user-visible).

Fixes #4650
Fixes #4623