### PR TITLE
🐛 fix(tokens): nil-safe NewCollector logger — dashboard suite panicked on live hive hosts

### DIFF
--- a/src/pkg/dashboard/status_builder_test.go
+++ b/src/pkg/dashboard/status_builder_test.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -875,8 +876,12 @@ func TestBuildBudget_BurnRate(t *testing.T) {
 func TestBuildBudget_WithTokenCollectorSummary(t *testing.T) {
 	cfg := config.GovernorConfig{}
 	gov := governor.New(cfg, map[string]config.AgentConfig{}, nil)
-	// No weekly limit — should use totalTokens as used but no percentage calc
-	collector := tokens.NewCollector("/nonexistent", nil)
+	// No weekly limit — should use totalTokens as used but no percentage calc.
+	// Real logger + redirected persist path: the collector's lazy snapshot
+	// restore would otherwise read the live /data/token-summary.json on a hive
+	// host and, before NewCollector was nil-safe, panic on the nil logger (#4664).
+	collector := tokens.NewCollector("/nonexistent", slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	collector.SetPersistPath(filepath.Join(t.TempDir(), "token-summary.json"))
 	fb := buildBudget(gov, collector)
 	// With no spend and no limit, used should be 0 or whatever the collector says
 	if fb.PctUsed != 0 {

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -106,6 +106,12 @@ type Collector struct {
 }
 
 func NewCollector(sessionsDir string, logger *slog.Logger) *Collector {
+	// A nil logger must not become a latent panic: loadSnapshot logs on the
+	// first successful restore, which only happens on hosts where the snapshot
+	// file exists — exactly the environments where a crash hurts most (#4664).
+	if logger == nil {
+		logger = slog.Default()
+	}
 	c := &Collector{
 		sessionsDir:  sessionsDir,
 		persistPath:  defaultPersistPath,

--- a/src/pkg/tokens/collector_extra_test.go
+++ b/src/pkg/tokens/collector_extra_test.go
@@ -22,6 +22,29 @@ func TestNewCollector(t *testing.T) {
 	}
 }
 
+// A nil logger must never panic — the failure mode is nasty because it only
+// fires on hosts where the snapshot file EXISTS (loadSnapshot logs on a
+// successful restore), i.e. live hive hosts but not clean CI runners (#4664).
+// This test recreates exactly that environment: nil logger + a real snapshot
+// at the persist path, then forces the lazy load via Summary.
+func TestNewCollector_NilLoggerSafeOnSnapshotLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "token-summary.json")
+	if err := os.WriteFile(path, []byte(`{"session_count":3,"total_tokens":42}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCollector("/tmp/nonexistent-sessions", nil)
+	if c.logger == nil {
+		t.Fatal("NewCollector must default a nil logger, got nil")
+	}
+	c.SetPersistPath(path)
+
+	summary := c.Summary() // triggers loadSnapshot's success-path logging
+	if summary == nil || summary.TotalTokens != 42 {
+		t.Errorf("Summary = %+v, want restored snapshot with TotalTokens=42", summary)
+	}
+}
+
 func TestCollector_Summary_Initially(t *testing.T) {
 	// Redirect the snapshot path away from the live /data location so the
 	// lazy initial load cannot pick up production state on a hive host (#4585).


### PR DESCRIPTION
Fixes #4664

## What
`TestBuildBudget_WithTokenCollectorSummary` passed a nil `*slog.Logger` into `tokens.NewCollector`; on any host where the token-summary snapshot exists at the persist path, `loadSnapshot`'s success-path `logger.Info` dereferenced nil and took down the whole pkg/dashboard suite — while clean CI runners never hit the log line and stayed green.

## Fix (all three of the issue's recommendations)
1. **Hardening**: `NewCollector` defaults a nil logger to `slog.Default()` — the silent-until-deployed panic class is closed for every future caller.
2. **Test fix**: the dashboard test now passes a real error-level logger AND redirects the persist path to a temp dir (hermetic against live `/data`, per the #4585 family).
3. **Regression pin**: `TestNewCollector_NilLoggerSafeOnSnapshotLoad` recreates the exact live-host trigger (nil logger + existing snapshot + lazy load via `Summary`) and asserts the snapshot is restored. Mutation-checked: disabling the nil default fails it.

Checked all `NewCollector` call sites: the dashboard test was the only nil-logger caller; production (cmd/hive/main.go) always passes a real logger.

Coverage after: tokens 92.7%, dashboard 83.5% (floors 90/82). `go vet` clean.