### PR TITLE
fix(github): sniff secondary-limit 403 bodies — Retry-After is not reliable

### DIFF
--- a/src/pkg/github/slowstart.go
+++ b/src/pkg/github/slowstart.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"bytes"
+	"io"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -120,14 +122,16 @@ func (t *slowStartTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 	resp, err := t.inner.RoundTrip(req)
 
-	// A real secondary-limit 403 carries Retry-After. Enter (or extend) the
-	// caution window to its reset plus the slow-start tail.
+	// Detect a secondary-limit 403 and enter (or extend) the caution window to
+	// its reset plus the slow-start tail. GitHub does NOT reliably attach
+	// Retry-After to secondary blocks (observed live: the 2026-08-23 re-trip
+	// happened with header-only detection armed — caution never engaged and the
+	// reset-boundary stampede fired anyway), so match the way go-github itself
+	// does: the documented "secondary rate limit" phrase in the 403 body. The
+	// body is peeked and restored so downstream error decoding still sees it.
 	if err == nil && resp != nil && resp.StatusCode == http.StatusForbidden {
-		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			after := slowStartDefaultRetryAfter
-			if secs, perr := strconv.Atoi(ra); perr == nil && secs >= 0 {
-				after = time.Duration(secs) * time.Second
-			}
+		after, secondary := secondaryLimitBackoff(resp)
+		if secondary {
 			until := time.Now().Add(after + st.window)
 			st.mu.Lock()
 			if until.After(st.cautiousUntil) {
@@ -137,4 +141,38 @@ func (t *slowStartTransport) RoundTrip(req *http.Request) (*http.Response, error
 		}
 	}
 	return resp, err
+}
+
+// secondaryLimitSniffBytes bounds how much of a 403 body is peeked for the
+// secondary-limit phrase. GitHub's abuse/secondary payloads are a couple
+// hundred bytes; 2 KiB is generous without buffering real content responses.
+const secondaryLimitSniffBytes = 2048
+
+// secondaryLimitBackoff reports whether resp is a secondary-rate-limit 403 and
+// how long GitHub asked us to back off. Retry-After is honored when present;
+// otherwise the 403 body is peeked (and RESTORED onto resp.Body) for the
+// "secondary rate limit" phrase, with the default backoff covering a full
+// window. A plain permission 403 returns false.
+func secondaryLimitBackoff(resp *http.Response) (time.Duration, bool) {
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		after := slowStartDefaultRetryAfter
+		if secs, err := strconv.Atoi(ra); err == nil && secs >= 0 {
+			after = time.Duration(secs) * time.Second
+		}
+		return after, true
+	}
+	if resp.Body == nil {
+		return 0, false
+	}
+	peek := make([]byte, secondaryLimitSniffBytes)
+	n, _ := io.ReadFull(resp.Body, peek)
+	rest := resp.Body
+	resp.Body = struct {
+		io.Reader
+		io.Closer
+	}{io.MultiReader(bytes.NewReader(peek[:n]), rest), rest}
+	if bytes.Contains(bytes.ToLower(peek[:n]), []byte("secondary rate limit")) {
+		return slowStartDefaultRetryAfter, true
+	}
+	return 0, false
 }

--- a/src/pkg/github/slowstart_test.go
+++ b/src/pkg/github/slowstart_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -104,5 +105,39 @@ func TestSlowStart_Plain403AndNormalTrafficUnpaced(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("plain 403s must not engage pacing; 3 requests took %v", elapsed)
+	}
+}
+
+// A secondary-limit 403 WITHOUT Retry-After (GitHub does not reliably send
+// it — the 2026-08-23 re-trip slipped past header-only detection) must still
+// engage caution via the body phrase, and the peeked body must be restored
+// intact for downstream error decoding.
+func TestSlowStart_BodySniffEngagesCaution(t *testing.T) {
+	body := `{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again.","documentation_url":"x"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // deliberately no Retry-After
+		io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	tr := newSlowStartTransport(http.DefaultTransport)
+	tr.state.window = time.Hour
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(got) != body {
+		t.Errorf("peeked body not restored: got %q", got)
+	}
+
+	tr.state.mu.Lock()
+	cautious := time.Now().Before(tr.state.cautiousUntil)
+	tr.state.mu.Unlock()
+	if !cautious {
+		t.Fatal("body-sniffed secondary 403 must engage the caution window")
 	}
 }


### PR DESCRIPTION
Follow-up to #4640, from live verification tonight: with the slow-start deployed, console **still re-tripped** one window (20:51 → 21:51 EDT). Root cause: caution engaged only on a `Retry-After` header, but **GitHub does not reliably attach one** to secondary/abuse 403s — the original 403 carried none, caution never armed, and the reset-boundary stampede fired exactly as before.

## Fix
Detect secondary 403s the way go-github itself does: the documented **"secondary rate limit" phrase in the 403 body**. The body is peeked (2 KiB cap) and **restored** onto `resp.Body`, so downstream error decoding sees it untouched. `Retry-After` still takes precedence when present; plain permission 403s (no phrase, no header) never engage pacing.

## Test
`TestSlowStart_BodySniffEngagesCaution`: header-less secondary 403 engages the caution window AND the body round-trips intact.