### PR TITLE
📖 docs: federation design is a proposal, not a shipped API

### DIFF
--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -4,9 +4,14 @@
 
 Hive Federation lets independent Hive instances publish themselves in a registry so contributors can discover projects and connect a local ClankeR contributor relay to one or more hubs. The registry is a directory, not a control plane: every hive keeps its own credentials, queue, agents, contributor registry, and trust policy.
 
-## Current v2 implementation
+> **Design only — not implemented.** No federation code exists in `src/pkg/`, and
+> the endpoints below are not served by any route. This page records the intended
+> design; treat it as a proposal, not as behaviour you can call today. (The v2-era
+> version of this page described the same endpoints as shipped; they were not.)
 
-The v2 Go dashboard API implements the federation endpoints in `src/pkg/dashboard/api_contribute.go`:
+## Intended implementation
+
+The design places the federation endpoints in the Go dashboard API:
 
 - `GET /api/hives` — list registered hives.
 - `POST /api/hives/register` — add or update a hive entry.
@@ -14,11 +19,11 @@ The v2 Go dashboard API implements the federation endpoints in `src/pkg/dashboar
 - `DELETE /api/hives/:id` — remove a hive.
 - `POST /api/hives/onboard` — generate starter deployment/config text.
 
-Registry storage defaults to `/data/federation/registry.json` in v2 and can be overridden for tests with `HIVE_FEDERATION_REGISTRY_PATH`.
+Registry storage would default to `/data/federation/registry.json`, overridable for tests with `HIVE_FEDERATION_REGISTRY_PATH`.
 
 ## Project onboarding
 
-A project maintainer installs/configures GitHub auth for their Hive, generates or writes v2 config, deploys the Hive, and registers it:
+A project maintainer installs/configures GitHub auth for their Hive, generates or writes Hive config, deploys the Hive, and registers it:
 
 ```bash
 curl -X POST https://hive.kubestellar.io/api/hives/register \


### PR DESCRIPTION
## The stale label was hiding a stale claim

`docs/federation-design.md` described the federation API in the present tense:

> The **v2** Go dashboard API **implements** the federation endpoints in `src/pkg/dashboard/api_contribute.go`

Issue #4663 correctly flags the `v2` wording. But the obvious fix — retitle "Current v2 implementation" → "Current implementation" — would have been **worse than the problem**, because none of it exists:

| Claimed | Reality on `v4` |
|---|---|
| federation endpoints implemented | no federation code anywhere in `src/pkg/` |
| `/api/hives`, `/register`, `/heartbeat`, `/onboard` | no route serves them |
| `HIVE_FEDERATION_REGISTRY_PATH` | appears nowhere in the tree |
| `src/pkg/dashboard/api_contribute.go` | not at that path |

Retitling would have promoted an unbuilt design to shipped behaviour *and* made the page look freshly reviewed.

## What changed

The section is now **"Intended implementation"** behind a design-only banner stating plainly that no federation code exists, that the endpoints are not served, and that the v2-era page made the same claim and was also wrong. The endpoint list is kept — it is a useful design record — but framed as intent.

## Third instance of this pattern

- `architecture.md` (#4626) — described planner/replan as unimplemented after both shipped
- `ioscan.md` (#4632) — documented a **default-on** injection scanner as absent, and advised against enabling it
- this page — describes an unbuilt API as shipped

In every case a stale `v2` label sat on top of a stale claim, and the mechanical `v2`→`v4` swap would have preserved the damaging half.

## Deliberately out of scope

`docs/inference-backends.md:28` has the same shape — `HIVE_VLLM_ENDPOINT` and its siblings **do not exist** in the tree. I reverted my edit there rather than guess at the real configuration mechanism; filed separately.

`#4662` is **not** a real orphan: `docs/HUB_DISASTER_RECOVERY.md` is linked from `README.md:493`.

Fixes #4663
