### PR TITLE
fix(advisory): rank live findings above since-removed ones in the digest

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -5949,9 +5949,63 @@ func runEvalCycle(
 					"count", len(pruned), "staleness_days", advCfg.StalenessDays, "titles", strings.Join(pruned, "; "))
 			}
 		}
+		// Repo entries may be org-qualified ("org/repo"); the digest linkifier
+		// needs the bare repo name alongside the org.
+		org, repoName := cfg.Project.Org, primaryRepo
+		if parts := strings.SplitN(primaryRepo, "/", 2); len(parts) == 2 {
+			org, repoName = parts[0], parts[1]
+		}
+
+		// #3704: pin the digest to ONE repo commit. Resolve the target repo's
+		// latest commit ONCE here (invariants 1 & 3), cite it in the rendered
+		// comment (invariant 2, via the footer FormatDigestMarkdown emits when
+		// AnalyzedSnapshot is set), and verify each finding's file path against
+		// that exact commit so a since-removed path (e.g. "docs/install.md") is
+		// flagged as outdated rather than cited as live. Best-effort: if the SHA
+		// cannot be resolved, fall back to the previous unpinned behavior rather
+		// than skip the digest.
+		//
+		// This is resolved BEFORE the digest is built because the top-N cap
+		// consumes it: ranking cannot prefer a live finding over a since-removed
+		// one unless it knows which is which at ranking time (#2364).
 		digestOpts := advisory.DigestOptions{
 			MaxFindings: advCfg.MaxFindings,
 			ShowAll:     advCfg.ShowAll,
+		}
+		if ghClient != nil && org != "" && repoName != "" {
+			branch := cfg.Policies.Branch
+			if branch == "" {
+				if r, _, rerr := ghClient.GetRepo(ctx, org, repoName); rerr == nil {
+					branch = r.GetDefaultBranch()
+				} else {
+					logger.Warn("advisory: could not resolve default branch for snapshot", "repo", primaryRepo, "error", rerr)
+				}
+			}
+			if branch != "" {
+				if sha, serr := ghClient.LatestCommitHash(ctx, org, repoName, branch); serr == nil && sha != "" {
+					digestOpts.Snapshot = &advisory.Snapshot{
+						Owner:  org,
+						Repo:   repoName,
+						Branch: branch,
+						SHA:    sha,
+					}
+					digestOpts.VerifyPath = func(path string) bool {
+						exists, verr := ghClient.PathExistsAtRef(ctx, org, repoName, path, sha)
+						if verr != nil {
+							// Inconclusive check (network/rate-limit, not a 404):
+							// treat as existing so a transient error never
+							// mislabels a real path as outdated — and never
+							// costs a real finding its top-N slot.
+							logger.Warn("advisory: path existence check failed", "path", path, "repo", primaryRepo, "sha", sha, "error", verr)
+							return true
+						}
+						return exists
+					}
+					logger.Info("advisory digest pinned to commit", "repo", primaryRepo, "branch", branch, "sha", sha)
+				} else if serr != nil {
+					logger.Warn("advisory: could not resolve latest commit for snapshot", "repo", primaryRepo, "branch", branch, "error", serr)
+				}
+			}
 		}
 		digest := advisory.BuildDigestFromBeads(beadStores, string(govState.Mode), digestOpts)
 		if advisoryStore != nil {
@@ -5988,56 +6042,6 @@ func runEvalCycle(
 			if digest.TotalCount == 0 && len(digest.RecentlyResolved) == 0 {
 				logger.Info("advisory digest empty — posting freshness marker",
 					"repo", primaryRepo, "issue", issueNum)
-			}
-
-			// Repo entries may be org-qualified ("org/repo"); the digest
-			// linkifier needs the bare repo name alongside the org.
-			org, repoName := cfg.Project.Org, primaryRepo
-			if parts := strings.SplitN(primaryRepo, "/", 2); len(parts) == 2 {
-				org, repoName = parts[0], parts[1]
-			}
-
-			// #3704: pin the digest to ONE repo commit. Resolve the target repo's
-			// latest commit ONCE here (invariants 1 & 3), cite it in the rendered
-			// comment (invariant 2, via the footer FormatDigestMarkdown emits when
-			// AnalyzedSnapshot is set), and verify each finding's file path against
-			// that exact commit so a since-removed path (e.g. "docs/install.md") is
-			// flagged as outdated rather than cited as live. Best-effort: if the SHA
-			// cannot be resolved, fall back to the previous unpinned behavior rather
-			// than skip the digest.
-			if ghClient != nil && org != "" && repoName != "" {
-				branch := cfg.Policies.Branch
-				if branch == "" {
-					if r, _, rerr := ghClient.GetRepo(ctx, org, repoName); rerr == nil {
-						branch = r.GetDefaultBranch()
-					} else {
-						logger.Warn("advisory: could not resolve default branch for snapshot", "repo", primaryRepo, "error", rerr)
-					}
-				}
-				if branch != "" {
-					if sha, serr := ghClient.LatestCommitHash(ctx, org, repoName, branch); serr == nil && sha != "" {
-						digest.AnalyzedSnapshot = &advisory.Snapshot{
-							Owner:  org,
-							Repo:   repoName,
-							Branch: branch,
-							SHA:    sha,
-						}
-						advisory.VerifyFindingPaths(digest, func(path string) bool {
-							exists, verr := ghClient.PathExistsAtRef(ctx, org, repoName, path, sha)
-							if verr != nil {
-								// Inconclusive check (network/rate-limit, not a 404):
-								// treat as existing so a transient error never
-								// mislabels a real path as outdated.
-								logger.Warn("advisory: path existence check failed", "path", path, "repo", primaryRepo, "sha", sha, "error", verr)
-								return true
-							}
-							return exists
-						})
-						logger.Info("advisory digest pinned to commit", "repo", primaryRepo, "branch", branch, "sha", sha)
-					} else if serr != nil {
-						logger.Warn("advisory: could not resolve latest commit for snapshot", "repo", primaryRepo, "branch", branch, "error", serr)
-					}
-				}
 			}
 
 			md := advisory.FormatDigestMarkdown(digest, advisory.DigestOptions{

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -108,7 +108,8 @@ low. Stale findings are set aside rather than dropped, and backfill any slot no
 live finding of that severity claims, so the digest never renders short.
 
 This ordering requires a pinned `AnalyzedSnapshot`, which the governor resolves
-once per post cycle. Without one (no GitHub client, or the commit could not be
+once per evaluation cycle (so the dashboard and status digests are snapshot-pinned
+too, not only the posted comment). Without one (no GitHub client, or the commit could not be
 resolved) the ranking falls back to severity-then-recency and no path is
 checked. Path lookups are cached per commit and stop as soon as the cap is
 filled, so ranking the full finding set costs roughly what verifying only the

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -72,9 +72,10 @@ the staleness window.
 ## How much the digest shows
 
 By default the digest renders the **top 10** findings, ranked by severity
-(critical → high → medium → low → minor) and then by recency within a severity,
-across all agents at once. Ranking globally rather than per agent is deliberate:
-an owner cares which findings matter most, not which agent produced them.
+(critical → high → medium → low → minor), then by whether the finding's file
+still exists at the analyzed commit, and then by recency, across all agents at
+once. Ranking globally rather than per agent is deliberate: an owner cares which
+findings matter most, not which agent produced them.
 
 - `governor.advisory.max_findings` — default `10`, minimum `1`.
 - `governor.advisory.show_all` — default `false`. `true` bypasses the cap
@@ -97,6 +98,21 @@ budget. A separate, unconditional cap still limits how many findings one agent
 may render under one finding type in a single severity section — that one exists
 to keep the comment inside GitHub's 65,536-character limit and is not
 configurable.
+
+For the same reason, a finding whose file no longer exists at the analyzed
+commit — the ones captioned *"file path not found at analyzed commit — finding
+may be outdated"* — does not take a slot ahead of a live finding of the **same
+severity**. Freshness only breaks ties within a severity band: a path that moved
+does not prove the problem is gone, so a stale critical still outranks a live
+low. Stale findings are set aside rather than dropped, and backfill any slot no
+live finding of that severity claims, so the digest never renders short.
+
+This ordering requires a pinned `AnalyzedSnapshot`, which the governor resolves
+once per post cycle. Without one (no GitHub client, or the commit could not be
+resolved) the ranking falls back to severity-then-recency and no path is
+checked. Path lookups are cached per commit and stop as soon as the cap is
+filled, so ranking the full finding set costs roughly what verifying only the
+rendered ones used to.
 
 ## The digest stopped updating
 

--- a/src/pkg/advisory/advisory.go
+++ b/src/pkg/advisory/advisory.go
@@ -368,6 +368,16 @@ type DigestOptions struct {
 	// PrimaryRepo is the repo the digest is posted to, used to resolve
 	// repo-less "gh-123" references.
 	PrimaryRepo string
+	// Snapshot pins the digest to one repo commit. BuildDigestFromBeads copies
+	// it to Digest.AnalyzedSnapshot so the rendered comment cites the exact tree
+	// the findings were checked against (#3704).
+	Snapshot *Snapshot
+	// VerifyPath reports whether a repo file path exists at Snapshot. When set,
+	// BuildDigestFromBeads consults it while ranking so a finding whose file is
+	// gone loses its top-N slot to a live one (#2364). It is called only for
+	// file-path refs, only for findings the ranking actually reaches, and at
+	// most once per distinct path. nil disables verification entirely.
+	VerifyPath func(path string) bool
 }
 
 // effectiveCap returns the number of findings to render, or 0 for "no cap".
@@ -384,10 +394,24 @@ func (o DigestOptions) effectiveCap() int {
 // The ranking is global rather than per-agent on purpose: a repo owner cares
 // which findings matter most, not which agent produced them, and a per-agent
 // quota would let a chatty agent's low-severity items displace another agent's
-// critical one. Ordering is severity first, then most-recent-first within a
-// severity — the newest report of an equally severe problem is the one still
-// happening.
-func applyTopN(byAgent map[string][]Finding, cap int) (map[string][]Finding, int) {
+// critical one. Ordering is severity first, then — when verify is supplied —
+// findings whose file still exists, then most-recent-first: the newest report of
+// an equally severe problem is the one still happening.
+//
+// verify, when non-nil, reports whether a finding's file path still exists at
+// the analyzed snapshot. A finding whose path is gone is one the renderer must
+// caption "may be outdated" (#3704), so it does not hold a top-N slot ahead of
+// a live finding of the SAME severity — it is set aside and used only to
+// backfill slots no fresh finding of that severity claims. This is the same
+// principle as capping AFTER collapseNearDuplicates: a scarce top-N is spent on
+// distinct, current problems or it is not worth reading. Freshness deliberately
+// does not cross severity bands (see the loop below).
+//
+// Verification is on-demand and ordered: the ranked list is walked from the top
+// and verify is called only until cap findings are in hand, at most once per
+// distinct path. Ranking the full set therefore costs about as many lookups as
+// verifying the survivors alone did, not one per finding.
+func applyTopN(byAgent map[string][]Finding, cap int, verify func(path string) bool) (map[string][]Finding, int) {
 	if cap <= 0 {
 		return byAgent, 0
 	}
@@ -413,8 +437,59 @@ func applyTopN(byAgent map[string][]Finding, cap int) (map[string][]Finding, int
 		}
 		return all[i].Title < all[j].Title
 	})
+
 	overflow := len(all) - cap
-	kept := all[:cap]
+	var kept []Finding
+	if verify == nil {
+		kept = all[:cap]
+	} else {
+		checked := make(map[string]bool)
+		markStale := func(f *Finding) {
+			if !isFilePathRef(f.File) {
+				return
+			}
+			path := splitFilePathRef(f.File)
+			ok, seen := checked[path]
+			if !seen {
+				ok = verify(path)
+				checked[path] = ok
+			}
+			f.PathStale = !ok
+		}
+		// Walk severity band by severity band, highest first. Freshness only
+		// breaks ties WITHIN a band: PathStale means the cited path moved, not
+		// that the problem is gone, so a stale critical must still outrank a
+		// live low — demoting across bands would let a cosmetic nit displace a
+		// security finding whose file was merely renamed.
+		for i := 0; i < len(all) && len(kept) < cap; {
+			rank := severityRank(all[i].Severity)
+			j := i
+			for j < len(all) && severityRank(all[j].Severity) == rank {
+				j++
+			}
+			// Stale findings in this band are set aside rather than dropped so
+			// they can backfill slots no fresh finding of equal severity claims
+			// — rendering 6 findings under a cap of 10 would hide work for no
+			// reason.
+			var stale []Finding
+			for _, f := range all[i:j] {
+				if len(kept) == cap {
+					break
+				}
+				markStale(&f)
+				if f.PathStale {
+					stale = append(stale, f)
+					continue
+				}
+				kept = append(kept, f)
+			}
+			for k := 0; len(kept) < cap && k < len(stale); k++ {
+				kept = append(kept, stale[k])
+			}
+			i = j
+		}
+	}
+
 	capped := make(map[string][]Finding, len(byAgent))
 	for _, f := range kept {
 		capped[f.Agent] = append(capped[f.Agent], f)
@@ -497,8 +572,10 @@ func BuildDigestFromBeads(stores map[string]*beads.Store, mode string, opts Dige
 		total += len(byAgent[agent])
 	}
 	// Cap AFTER collapsing: a top-10 built from uncollapsed restatements would
-	// spend its ten slots on one recurring problem.
-	byAgent, overflow := applyTopN(byAgent, opts.effectiveCap())
+	// spend its ten slots on one recurring problem. For the same reason the cap
+	// is staleness-aware (opts.VerifyPath) — a finding whose file no longer
+	// exists is not worth a slot a live finding could have had (#2364).
+	byAgent, overflow := applyTopN(byAgent, opts.effectiveCap(), opts.VerifyPath)
 	if overflow > 0 {
 		total -= overflow
 	}
@@ -509,7 +586,7 @@ func BuildDigestFromBeads(stores map[string]*beads.Store, mode string, opts Dige
 	if len(resolved) > maxRecentlyResolved {
 		resolved = resolved[:maxRecentlyResolved]
 	}
-	return &Digest{
+	d := &Digest{
 		GeneratedAt:      time.Now(),
 		Mode:             mode,
 		ByAgent:          byAgent,
@@ -517,7 +594,15 @@ func BuildDigestFromBeads(stores map[string]*beads.Store, mode string, opts Dige
 		RecentlyResolved: resolved,
 		Capped:           overflow > 0,
 		OverflowCount:    overflow,
+		AnalyzedSnapshot: opts.Snapshot,
 	}
+	// When the cap was not reached, applyTopN returned early and never verified
+	// anything, so the surviving findings still need their paths checked before
+	// the renderer cites them as live.
+	if opts.VerifyPath != nil && overflow == 0 {
+		VerifyFindingPaths(d, opts.VerifyPath)
+	}
+	return d
 }
 
 // normalizedFindingKey collapses a finding title to a duplicate-detection key:

--- a/src/pkg/advisory/topn_stale_test.go
+++ b/src/pkg/advisory/topn_stale_test.go
@@ -1,0 +1,354 @@
+package advisory
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/beads"
+)
+
+// The digest's top-N is a scarce resource: the 2026-08-24 advisory comment on
+// kubestellar/hive#2364 spent 4 of its 10 critical slots on findings the
+// renderer itself captioned "file path not found at analyzed commit — finding
+// may be outdated", while 262 other findings went unshown. Staleness was
+// computed only AFTER the cap had already been applied, so it could not
+// influence which findings won a slot. These tests pin the ranking rule that
+// fixes it.
+
+// staleBase is a fixed clock for these tests: applyTopN breaks severity ties by
+// recency, so findings need distinct, predictable timestamps.
+var staleBase = time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+
+// finding builds a Finding with a file ref, at an age expressed in minutes
+// before staleBase — smaller age means more recent, so it ranks higher.
+func finding(agent, sev, title, file string, ageMinutes int) Finding {
+	return Finding{
+		Agent:     agent,
+		Severity:  sev,
+		Title:     title,
+		File:      file,
+		Timestamp: staleBase.Add(-time.Duration(ageMinutes) * time.Minute),
+	}
+}
+
+// existsExcept returns a verify func reporting every path as present except the
+// named ones, and a pointer to the count of lookups it performed.
+func existsExcept(missing ...string) (func(string) bool, *int) {
+	gone := make(map[string]bool, len(missing))
+	for _, m := range missing {
+		gone[m] = true
+	}
+	calls := 0
+	return func(path string) bool {
+		calls++
+		return !gone[path]
+	}, &calls
+}
+
+// keptTitles flattens an applyTopN result into a sorted title list so tests can
+// assert on membership without depending on per-agent map ordering.
+func keptTitles(byAgent map[string][]Finding) []string {
+	var out []string
+	for _, fs := range byAgent {
+		for _, f := range fs {
+			out = append(out, f.Title)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func keptFinding(t *testing.T, byAgent map[string][]Finding, title string) Finding {
+	t.Helper()
+	for _, fs := range byAgent {
+		for _, f := range fs {
+			if f.Title == title {
+				return f
+			}
+		}
+	}
+	t.Fatalf("finding %q not in the kept set (kept: %v)", title, keptTitles(byAgent))
+	return Finding{}
+}
+
+func sameTitles(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ── freshness within a severity band ────────────────────────────────────────
+
+// TestApplyTopNPrefersFreshOverStaleWithinSeverity is the core fix: among
+// equally-severe findings, the ones whose file still exists win the slots. The
+// two stale findings here are the MOST RECENT, so under the old severity+recency
+// ranking they would have taken both slots and rendered as "may be outdated".
+func TestApplyTopNPrefersFreshOverStaleWithinSeverity(t *testing.T) {
+	byAgent := map[string][]Finding{
+		"quality": {
+			finding("quality", "critical", "stale-newest", "src/pkg/gone.go", 1),
+			finding("quality", "critical", "stale-newer", "src/pkg/removed.go", 2),
+			finding("quality", "critical", "live-older", "src/pkg/agent/manager.go", 3),
+			finding("quality", "critical", "live-oldest", "src/pkg/hub/oauth.go", 4),
+		},
+	}
+	verify, calls := existsExcept("src/pkg/gone.go", "src/pkg/removed.go")
+
+	kept, overflow := applyTopN(byAgent, 2, verify)
+
+	if overflow != 2 {
+		t.Errorf("overflow = %d, want 2", overflow)
+	}
+	got := keptTitles(kept)
+	want := []string{"live-older", "live-oldest"}
+	if !sameTitles(got, want) {
+		t.Errorf("kept = %v, want %v — the live findings must take the slots even though the stale ones are newer", got, want)
+	}
+	if *calls != 4 {
+		t.Errorf("verify called %d times, want 4 (one per distinct path examined)", *calls)
+	}
+}
+
+// TestApplyTopNBackfillsWithStaleWhenFreshRunsOut: staleness demotes, it does
+// not disqualify. A path that moved does not prove the problem is gone, so a
+// slot no fresh finding claims still goes to a stale one rather than rendering
+// a short digest.
+func TestApplyTopNBackfillsWithStaleWhenFreshRunsOut(t *testing.T) {
+	byAgent := map[string][]Finding{
+		"quality": {
+			finding("quality", "critical", "stale-a", "src/gone-a.go", 1),
+			finding("quality", "critical", "stale-b", "src/gone-b.go", 2),
+			finding("quality", "critical", "live", "src/here.go", 3),
+		},
+	}
+	verify, _ := existsExcept("src/gone-a.go", "src/gone-b.go")
+
+	kept, overflow := applyTopN(byAgent, 2, verify)
+
+	if overflow != 1 {
+		t.Errorf("overflow = %d, want 1", overflow)
+	}
+	got := keptTitles(kept)
+	want := []string{"live", "stale-a"}
+	if !sameTitles(got, want) {
+		t.Errorf("kept = %v, want %v — the free slot backfills with the newest stale finding", got, want)
+	}
+}
+
+// TestApplyTopNKeepsStaleMarkOnBackfilled: a stale finding that backfills a slot
+// must still carry PathStale, or the renderer would cite a dead path as live —
+// the exact #3704 regression this ranking must not reintroduce.
+func TestApplyTopNKeepsStaleMarkOnBackfilled(t *testing.T) {
+	byAgent := map[string][]Finding{
+		"quality": {
+			finding("quality", "critical", "stale", "src/gone.go", 1),
+			finding("quality", "critical", "live", "src/here.go", 2),
+			finding("quality", "high", "filler", "src/other.go", 3),
+		},
+	}
+	verify, _ := existsExcept("src/gone.go")
+
+	kept, _ := applyTopN(byAgent, 2, verify)
+
+	if f := keptFinding(t, kept, "stale"); !f.PathStale {
+		t.Error("backfilled finding has PathStale = false, want true so the renderer captions it as outdated")
+	}
+	if f := keptFinding(t, kept, "live"); f.PathStale {
+		t.Error("live finding has PathStale = true, want false")
+	}
+}
+
+// ── severity still dominates ────────────────────────────────────────────────
+
+// TestApplyTopNSeverityBeatsFreshness guards the deliberate limit on the fix: a
+// stale CRITICAL outranks a live LOW. PathStale means the cited path moved, not
+// that the problem is gone, so letting freshness cross severity bands would let
+// a cosmetic nit displace a security finding whose file was merely renamed.
+func TestApplyTopNSeverityBeatsFreshness(t *testing.T) {
+	byAgent := map[string][]Finding{
+		"sec-check": {finding("sec-check", "critical", "stale-critical", "src/moved.go", 5)},
+		"guide": {
+			finding("guide", "low", "live-low-a", "docs/a.md", 1),
+			finding("guide", "low", "live-low-b", "docs/b.md", 2),
+		},
+	}
+	verify, _ := existsExcept("src/moved.go")
+
+	kept, overflow := applyTopN(byAgent, 1, verify)
+
+	if overflow != 2 {
+		t.Errorf("overflow = %d, want 2", overflow)
+	}
+	got := keptTitles(kept)
+	if !sameTitles(got, []string{"stale-critical"}) {
+		t.Errorf("kept = %v, want [stale-critical] — severity must outrank freshness across bands", got)
+	}
+}
+
+// ── lookup cost ─────────────────────────────────────────────────────────────
+
+// TestApplyTopNVerifiesEachPathOnce: the same file commonly backs several
+// findings, and existence at a fixed commit is stable for the whole cycle.
+func TestApplyTopNVerifiesEachPathOnce(t *testing.T) {
+	byAgent := map[string][]Finding{
+		"quality": {
+			finding("quality", "critical", "a", "src/same.go", 1),
+			finding("quality", "critical", "b", "src/same.go", 2),
+			finding("quality", "critical", "c", "src/same.go", 3),
+		},
+	}
+	verify, calls := existsExcept()
+
+	if _, overflow := applyTopN(byAgent, 2, verify); overflow != 1 {
+		t.Errorf("overflow = %d, want 1", overflow)
+	}
+	if *calls != 1 {
+		t.Errorf("verify called %d times, want 1 — results must be cached per distinct path", *calls)
+	}
+}
+
+// TestApplyTopNStopsVerifyingOnceCapIsFilled bounds the added network cost:
+// ranking the full set must not cost one lookup per finding. Verification walks
+// in rank order and stops as soon as the cap is satisfied.
+func TestApplyTopNStopsVerifyingOnceCapIsFilled(t *testing.T) {
+	byAgent := map[string][]Finding{"quality": {}}
+	for i := 0; i < 50; i++ {
+		byAgent["quality"] = append(byAgent["quality"],
+			finding("quality", "critical", string(rune('a'+i%26))+string(rune('a'+i/26)), "src/f"+string(rune('a'+i%26))+string(rune('a'+i/26))+".go", i))
+	}
+	verify, calls := existsExcept()
+
+	applyTopN(byAgent, 3, verify)
+
+	if *calls != 3 {
+		t.Errorf("verify called %d times for a cap of 3 over 50 findings, want 3 — the walk must early-exit", *calls)
+	}
+}
+
+// TestApplyTopNSkipsVerifyForIssueRefs: a "gh-123" or "owner/repo#1" ref is not
+// a repo path, so it must never trigger a path lookup.
+func TestApplyTopNSkipsVerifyForIssueRefs(t *testing.T) {
+	byAgent := map[string][]Finding{
+		"scanner": {
+			finding("scanner", "critical", "issue-ref", "gh-4581", 1),
+			finding("scanner", "critical", "inline-ref", "kubestellar/hive#3344", 2),
+			finding("scanner", "critical", "no-ref", "", 3),
+			finding("scanner", "critical", "path-ref", "src/real.go", 4),
+		},
+	}
+	verify, calls := existsExcept()
+
+	kept, _ := applyTopN(byAgent, 3, verify)
+
+	if *calls != 0 {
+		t.Errorf("verify called %d times, want 0 — only the path ref could qualify and the cap fills before it", *calls)
+	}
+	if got := keptTitles(kept); len(got) != 3 {
+		t.Errorf("kept %d findings, want 3", len(got))
+	}
+}
+
+// TestApplyTopNNilVerifyKeepsSeverityRecencyOrder pins backward compatibility:
+// with no verifier the ranking is exactly the previous severity-then-recency
+// behavior, so callers that never resolve a snapshot are unaffected.
+func TestApplyTopNNilVerifyKeepsSeverityRecencyOrder(t *testing.T) {
+	byAgent := map[string][]Finding{
+		"quality": {
+			finding("quality", "critical", "newest", "src/gone.go", 1),
+			finding("quality", "critical", "older", "src/also-gone.go", 2),
+			finding("quality", "high", "high-one", "src/here.go", 3),
+		},
+	}
+
+	kept, overflow := applyTopN(byAgent, 2, nil)
+
+	if overflow != 1 {
+		t.Errorf("overflow = %d, want 1", overflow)
+	}
+	got := keptTitles(kept)
+	if !sameTitles(got, []string{"newest", "older"}) {
+		t.Errorf("kept = %v, want [newest older] — without a verifier, severity+recency alone decides", got)
+	}
+}
+
+// ── through BuildDigestFromBeads ────────────────────────────────────────────
+
+// TestBuildDigestRanksFreshOverStale is the end-to-end version of the fix: the
+// digest a repo owner actually reads must not spend its cap on findings it then
+// captions as outdated.
+func TestBuildDigestRanksFreshOverStale(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	// Distinct subject words: collapseNearDuplicates merges titles that share
+	// their normalized key, and that runs before the cap under test.
+	refs := map[string]string{
+		"cache invalidation is wrong":  "src/pkg/gone.go",
+		"token refresh is wrong":       "src/pkg/removed.go",
+		"queue draining is wrong":      "src/pkg/agent/manager.go",
+		"clock skew handling is wrong": "src/pkg/hub/oauth.go",
+	}
+	for title, ref := range refs {
+		if _, err := store.Create(title, beads.TypeAdvisory, severityToPriority("critical"), "quality", ref); err != nil {
+			t.Fatalf("creating bead: %v", err)
+		}
+	}
+	verify, _ := existsExcept("src/pkg/gone.go", "src/pkg/removed.go")
+
+	d := BuildDigestFromBeads(map[string]*beads.Store{"quality": store}, "advisory", DigestOptions{
+		MaxFindings: 2,
+		VerifyPath:  verify,
+		Snapshot:    &Snapshot{Owner: "kubestellar", Repo: "hive", SHA: "deadbeef"},
+	})
+
+	if !d.Capped || d.OverflowCount != 2 {
+		t.Errorf("Capped = %v, OverflowCount = %d; want true, 2", d.Capped, d.OverflowCount)
+	}
+	if d.AnalyzedSnapshot == nil || d.AnalyzedSnapshot.SHA != "deadbeef" {
+		t.Errorf("AnalyzedSnapshot = %+v, want the snapshot passed in opts", d.AnalyzedSnapshot)
+	}
+	for _, f := range digestFindings(d) {
+		if f.PathStale {
+			t.Errorf("finding %q kept despite a missing path — live findings of equal severity were available", f.Title)
+		}
+	}
+}
+
+// TestBuildDigestVerifiesPathsWhenUnderCap covers the branch applyTopN cannot:
+// when nothing overflows it returns before verifying anything, so the survivors
+// still need their paths checked or the renderer would cite a dead path as live.
+func TestBuildDigestVerifiesPathsWhenUnderCap(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	if _, err := store.Create("cache invalidation is wrong", beads.TypeAdvisory, severityToPriority("critical"), "quality", "src/pkg/gone.go"); err != nil {
+		t.Fatalf("creating bead: %v", err)
+	}
+	verify, _ := existsExcept("src/pkg/gone.go")
+
+	d := BuildDigestFromBeads(map[string]*beads.Store{"quality": store}, "advisory", DigestOptions{
+		MaxFindings: 10,
+		VerifyPath:  verify,
+		Snapshot:    &Snapshot{Owner: "kubestellar", Repo: "hive", SHA: "deadbeef"},
+	})
+
+	if d.Capped {
+		t.Fatalf("digest capped unexpectedly (overflow %d)", d.OverflowCount)
+	}
+	all := digestFindings(d)
+	if len(all) != 1 {
+		t.Fatalf("got %d findings, want 1", len(all))
+	}
+	if !all[0].PathStale {
+		t.Error("PathStale = false, want true — an uncapped digest must still verify its findings' paths")
+	}
+}


### PR DESCRIPTION
## The problem

The digest's top-N is a scarce resource, but staleness was computed only **after** the cap had already been applied, so it could not influence which findings won a slot.

`BuildDigestFromBeads` calls `applyTopN`, and only later — back in `runEvalCycle` — did `VerifyFindingPaths` mark the *survivors* whose file no longer exists at the analyzed commit. By then the losers were already discarded. So a finding could take a critical slot on severity and recency alone, and then be rendered with `_(file path not found at analyzed commit — finding may be outdated)_` hanging off it, while a live finding of the same severity went unshown.

This is visible on this issue right now. The 2026-08-24 digest comment on #2364 spends **4 of its 10 critical slots** on findings it then captions as outdated, while the note underneath reads *"262 more exist."*

## The fix

Resolve the snapshot **before** the digest is built and pass it through `DigestOptions`, so the cap can consult it:

- Within a severity band, findings whose file still exists take the slots first.
- Stale ones are **set aside, not dropped** — they backfill any slot no live finding of that severity claims, so the digest never renders short.
- Backfilled findings keep `PathStale`, so the renderer still captions them. This must not reintroduce #3704.

**Freshness deliberately does not cross severity bands.** `PathStale` means the cited path *moved*, not that the problem is gone — a stale critical still outranks a live low. Demoting across bands would let a cosmetic nit displace a security finding whose file was merely renamed. There is a test pinning this.

## Lookup cost

Ranking the full set costs roughly what verifying only the rendered findings used to:

- results cached per distinct path,
- the walk stops as soon as the cap is filled (a cap of 3 over 50 findings costs 3 lookups — tested),
- non-path refs (`gh-123`, `owner/repo#1`) never trigger one.

One honest tradeoff worth a maintainer's eye: snapshot resolution now runs once per eval cycle rather than only on cycles that post, adding at most one `GetRepo` and one `LatestCommitHash` to a non-posting cycle. In exchange, the digest handed to the dashboard and the status payload is now snapshot-pinned and path-verified too — previously only the posted comment was.

## Compatibility

With no snapshot — no GitHub client, or the commit could not be resolved — `VerifyPath` is nil and ranking falls back to the exact previous severity-then-recency behavior. A test pins that. `VerifyFindingPaths` stays exported and unchanged; `BuildDigestFromBeads` still calls it when nothing overflowed, since `applyTopN` returns early in that case and verifies nothing.

## Verification

```
go build ./...                                    ok
go vet ./pkg/advisory/... ./cmd/hive/...          ok
gofmt -l pkg/advisory/ cmd/hive/main.go           clean
go test ./pkg/advisory/... ./cmd/hive/... \
        ./pkg/github/... ./pkg/hub/...            ok (all 4 packages)
```

11 new tests in `src/pkg/advisory/topn_stale_test.go` cover: fresh-beats-stale within a band, stale backfill when live findings run out, `PathStale` preserved on backfilled findings, severity beating freshness across bands, per-path caching, early exit, issue-refs skipped, nil-verify back-compat, and two end-to-end cases through `BuildDigestFromBeads` (capped and under-cap).

`src/docs/advisory.md` "How much the digest shows" updated to describe the new ordering and its limits.

## Scope note

I checked the other findings in the current digest before picking this one. The `AuthorizeIssueOpen` coverage gap (3 of the 10 slots, same finding under three wordings) is already addressed by open PRs #4690 and #4692. The remaining criticals are stale: the `src/test` network-coupling finding is fixed at HEAD (`//go:build integration` + a `TestMain` reachability gate), the SSRF/`requireOwnerRole` regression finding is fixed (`ssrf_guard.go` present and wired, guards on both beads-reset handlers), the dashboard `audit.go` and hub `oauth.go` coverage findings name functions that no longer exist and files that now have tests, and the `heartbeatBearerOK` finding retracts itself in its own detail text. That pattern — most of the visible top-10 being stale — is what pointed at the ranking bug.

Refs #2364. Related: #3704 (the path-verification this builds on).

— hive: backend=claude model=claude-fable-5