### PR TITLE
fix(terminal): say when the agent CLI owns the scroll, not a bare "[live]"

### DIFF
--- a/bin/ttyd-tmux.sh
+++ b/bin/ttyd-tmux.sh
@@ -15,18 +15,57 @@
 # /usr/local/bin/ttyd-tmux.sh by src/Dockerfile), which additionally resolves
 # per-agent tmux sockets across UIDs via su-exec. This copy is a simpler
 # standalone helper kept in sync for local/non-UID-isolated use.
+#
+# "Kept in sync" is now ENFORCED rather than promised: this file had silently
+# missed the whole #4399 scrollback-status change, so a local terminal attached
+# through it had no status line at all — no scroll position and no clock, the
+# #4681 symptom. src/deploy/test_terminal_scrollback_status.sh asserts that the
+# status format and the wheel rebind here match manager.go byte for byte.
 set -euo pipefail
 
 SESSION=${1:-supervisor}
 TTYD_HISTORY_LIMIT="${HIVE_TTYD_HISTORY_LIMIT:-50000}"
+
+# Scrollback state legibility (#4399, #4681). Kept character-for-character
+# identical to src/deploy/ttyd-tmux.sh and to tmuxStatusRight in
+# src/pkg/agent/manager.go — test_terminal_scrollback_status.sh asserts all
+# three match, because a terminal that scrolls differently depending on which
+# wrapper attached is worse than one that is uniformly wrong.
+TTYD_STATUS_RIGHT="${HIVE_TTYD_STATUS_RIGHT:-#{?pane_in_mode,[SCROLLBACK #{scroll_position}/#{history_size} lines back - not following live output - press q to resume] ,#{?mouse_any_flag,[live - this app handles its own scrolling#, so tmux has no line position] ,[live] }}now %H:%M:%S }"
+TTYD_STATUS_INTERVAL="${HIVE_TTYD_STATUS_INTERVAL:-2}"
+# tmux truncates status-right to status-right-length, DEFAULT 40 columns, which
+# cuts the message above off mid-word.
+TTYD_STATUS_RIGHT_LENGTH="${HIVE_TTYD_STATUS_RIGHT_LENGTH:-140}"
+
 PREV_MOUSE=$(tmux show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
 PREV_HISTORY=$(tmux show-option -t "$SESSION" -gv history-limit 2>/dev/null || echo "")
+PREV_STATUS=$(tmux show-option -t "$SESSION" -gv status-right 2>/dev/null || echo "")
+PREV_STATUS_LEN=$(tmux show-option -t "$SESSION" -gv status-right-length 2>/dev/null || echo "")
+PREV_INTERVAL=$(tmux show-option -t "$SESSION" -gv status-interval 2>/dev/null || echo "")
 tmux set-option -t "$SESSION" mouse on 2>/dev/null || true
 tmux set-option -t "$SESSION" history-limit "$TTYD_HISTORY_LIMIT" 2>/dev/null || true
+tmux set-option -gt "$SESSION" status-right "$TTYD_STATUS_RIGHT" 2>/dev/null || true
+tmux set-option -gt "$SESSION" status-right-length "$TTYD_STATUS_RIGHT_LENGTH" 2>/dev/null || true
+tmux set-option -gt "$SESSION" status-interval "$TTYD_STATUS_INTERVAL" 2>/dev/null || true
+# #4399: hide tmux's unlabelled black-on-yellow copy-mode marker; the labelled
+# status line above carries the position instead. tmux's own default
+# WheelUpPane binding with only -H added (tmux >= 3.2; older tmux rejects the
+# flag, hence || true, and simply keeps the marker). Server-wide by nature and
+# deliberately not restored on detach, so the NEXT wheel scroll also hides it.
+tmux bind-key -n WheelUpPane if-shell -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' 'send-keys -M' 'copy-mode -eH' 2>/dev/null || true
 EXIT_CODE=0
 tmux attach-session -t "$SESSION" || EXIT_CODE=$?
 tmux set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
 if [ -n "$PREV_HISTORY" ]; then
   tmux set-option -t "$SESSION" history-limit "$PREV_HISTORY" 2>/dev/null || true
+fi
+if [ -n "$PREV_STATUS" ]; then
+  tmux set-option -gt "$SESSION" status-right "$PREV_STATUS" 2>/dev/null || true
+fi
+if [ -n "$PREV_STATUS_LEN" ]; then
+  tmux set-option -gt "$SESSION" status-right-length "$PREV_STATUS_LEN" 2>/dev/null || true
+fi
+if [ -n "$PREV_INTERVAL" ]; then
+  tmux set-option -gt "$SESSION" status-interval "$PREV_INTERVAL" 2>/dev/null || true
 fi
 exit $EXIT_CODE

--- a/src/deploy/test_terminal_scrollback_status.sh
+++ b/src/deploy/test_terminal_scrollback_status.sh
@@ -63,6 +63,21 @@ else
        "the manager and the attach path have drifted"
 fi
 
+# ...and so must the standalone local helper. It calls itself "kept in sync"
+# but nothing checked, and it had silently missed the entire #4399 change: no
+# status-right, no length, no wheel rebind. A terminal attached through it
+# showed no scroll position and no clock — the #4681 symptom, from a file whose
+# own comment claimed otherwise. Checked here so the claim cannot rot again.
+BIN_ATTACH="${ROOT}/bin/ttyd-tmux.sh"
+if [ ! -f "$BIN_ATTACH" ]; then
+  fail "bin/ttyd-tmux.sh exists" "the local helper moved; this check needs updating"
+elif grep -qF -- "$STATUS_FMT" "$BIN_ATTACH"; then
+  pass "bin/ttyd-tmux.sh applies the identical format on attach"
+else
+  fail "bin/ttyd-tmux.sh applies the identical format on attach" \
+       "the local helper has drifted from manager.go"
+fi
+
 WORK="$(mktemp -d)"
 SOCK="${WORK}/sock"
 cleanup() { tmux -S "$SOCK" kill-server 2>/dev/null; tmux -S "${WORK}/viewer-sock" kill-server 2>/dev/null; rm -rf "$WORK"; }
@@ -131,6 +146,70 @@ printf '%s' "$SCROLLED" | grep -qE "[0-9]+/[0-9]+ lines back" \
   && pass "the two states are visibly different" \
   || fail "the two states are visibly different" "both rendered: ${LIVE}"
 
+# --- a pane whose APPLICATION owns the wheel (#4681) --------------------------
+# The two states above are not exhaustive, and the gap is what #4681 reported.
+#
+# The wheel rebind only enters copy-mode when the running program has NOT
+# grabbed the mouse. Every agent CLI is a full-screen TUI that enables mouse
+# reporting, so `mouse_any_flag` is 1, the wheel goes to the APPLICATION, and
+# the pane never enters copy-mode. `pane_in_mode` stays 0 forever, so the
+# status line reported a bare "[live]" however far back the operator had
+# scrolled inside the agent's own buffer — and because the rebind also hides
+# tmux's native "HH:MM [pos/total]" marker, no position and no content
+# timestamp appeared anywhere on screen.
+#
+# A session that turns mouse reporting on is the reproduction: the escape is
+# what a TUI sends, not something tmux has to be told.
+tmux -S "$SOCK" new-session -d -s m -x 80 -y 10 \
+  'printf "\033[?1000h\033[?1006h"; i=0; while :; do i=$((i+1)); echo "line $i"; sleep 0.2; done' 2>/dev/null
+sleep 1
+MOUSE_FLAG="$(tmux -S "$SOCK" display-message -p -t m '#{mouse_any_flag}' 2>/dev/null)"
+[ "$MOUSE_FLAG" = "1" ] \
+  && pass "a pane running a mouse-reporting TUI sets mouse_any_flag (the agent-CLI case)" \
+  || fail "the repro pane grabs the mouse" "mouse_any_flag=${MOUSE_FLAG} — cannot test the #4681 state"
+
+# The wheel binding's own condition decides this; ask tmux which branch it takes
+# rather than restating the rule and testing the restatement.
+WHEEL_COND='#{||:#{pane_in_mode},#{mouse_any_flag}}'
+TAKES="$(tmux -S "$SOCK" display-message -p -t m "#{?${WHEEL_COND},app,tmux}" 2>/dev/null)"
+[ "$TAKES" = "app" ] \
+  && pass "the wheel is forwarded to the application, so copy-mode is unreachable there" \
+  || fail "the wheel goes to the app in this state" "branch=${TAKES}"
+
+APPSCROLL="$(tmux -S "$SOCK" display-message -p -t m "$STATUS_FMT" 2>/dev/null)"
+echo "     app-owns-scroll renders: '${APPSCROLL}'"
+printf '%s' "$APPSCROLL" | grep -qiE "scrollback" \
+  && fail "this state must not claim to be tmux scrollback" "got: ${APPSCROLL}" \
+  || pass "this state does not claim to be tmux scrollback"
+# The regression itself: a bare "[live]" asserts the viewport is at the bottom
+# of live output, which is false while the operator scrolls the app's buffer
+# and unfalsifiable from their side.
+[ "$APPSCROLL" != "$LIVE" ] \
+  && pass "it is distinguishable from a genuinely-live pane (not a bare '[live]')" \
+  || fail "it is distinguishable from a genuinely-live pane" \
+          "both rendered '${LIVE}' — #4681 has regressed"
+printf '%s' "$APPSCROLL" | grep -qi "scrolling" \
+  && pass "and says the application is the thing doing the scrolling" \
+  || fail "says who owns the scrolling" "got: ${APPSCROLL}"
+# tmux has no position to give here; saying so is the fix. Claiming a number
+# would be worse than admitting the absence.
+printf '%s' "$APPSCROLL" | grep -qE "[0-9]+/[0-9]+ lines back" \
+  && fail "it must NOT invent a tmux line position" "got: ${APPSCROLL}" \
+  || pass "it does not invent a line position tmux cannot know"
+printf '%s' "$APPSCROLL" | grep -qi "now" \
+  && pass "the labelled wall clock is still present" \
+  || fail "the labelled clock is present" "got: ${APPSCROLL}"
+# Unexpanded format text is the failure mode a nested conditional invites: the
+# prose comma inside the new branch must be escaped as '#,' or tmux truncates
+# the branch at it.
+printf '%s' "$APPSCROLL" | grep -q '#{' \
+  && fail "the nested conditional is well-formed" "unexpanded format left in: ${APPSCROLL}" \
+  || pass "the nested conditional is well-formed (the '#,' escape holds)"
+printf '%s' "$APPSCROLL" | grep -q "so tmux has no line position" \
+  && pass "the escaped comma did not truncate the branch" \
+  || fail "the escaped comma did not truncate the branch" "got: ${APPSCROLL}"
+tmux -S "$SOCK" kill-session -t m 2>/dev/null
+
 # --- the reported symptom, reproduced ----------------------------------------
 # This is the part that made the terminal look broken: a frozen pane, which
 # survives closing and reopening the browser.
@@ -197,15 +276,22 @@ fi
 # is unintelligible" from #4399. The wheel rebind enters copy-mode with -H so
 # the marker is hidden; the labelled status line above carries the position.
 if tmux -S "$SOCK" list-commands copy-mode 2>/dev/null | grep -qE '\[-[a-zA-Z]*H'; then
-  # Plain copy-mode (already entered above) shows the marker in the top-right
-  # of what the CLIENT draws.
+  # Plain copy-mode shows the marker in the top-right of what the CLIENT draws
+  # — but only once the pane is actually SCROLLED. At position 0 tmux renders a
+  # bare "0" instead of "[pos/total]", so a control that merely enters copy-mode
+  # measures the wrong thing and fails for a reason that has nothing to do with
+  # the -H flag under test. Scroll first, and let the client repaint.
+  tmux -S "$SOCK" send-keys -t t -X scroll-up 2>/dev/null
+  sleep 1
   VIS="$(tmux -S "$VSOCK" capture-pane -p -t viewer 2>/dev/null | head -1)"
   printf '%s' "$VIS" | grep -qE '\[[0-9]+/[0-9]+\]' \
     && pass "control: plain copy-mode draws the unlabelled [pos/total] marker" \
     || fail "control: plain copy-mode draws the marker" "top line: '${VIS}'"
-  # Re-enter through the rebind's command: the marker must be gone.
+  # Re-enter through the rebind's command and scroll the SAME way, so the two
+  # captures differ only by -H.
   tmux -S "$SOCK" send-keys -t t -X cancel 2>/dev/null
   tmux -S "$SOCK" copy-mode -eH -t t 2>/dev/null
+  tmux -S "$SOCK" send-keys -t t -X scroll-up 2>/dev/null
   sleep 1
   HID="$(tmux -S "$VSOCK" capture-pane -p -t viewer 2>/dev/null | head -1)"
   printf '%s' "$HID" | grep -qE '\[[0-9]+/[0-9]+\]' \
@@ -219,6 +305,10 @@ if tmux -S "$SOCK" list-commands copy-mode 2>/dev/null | grep -qE '\[-[a-zA-Z]*H
   grep -q "copy-mode -eH" "$ATTACH" \
     && pass "src/deploy/ttyd-tmux.sh applies the identical rebind on attach" \
     || fail "ttyd-tmux.sh carries the wheel rebind"
+  grep -q "copy-mode -eH" "$BIN_ATTACH" \
+    && pass "bin/ttyd-tmux.sh applies the identical rebind on attach" \
+    || fail "bin/ttyd-tmux.sh carries the wheel rebind" \
+            "the local helper hides the marker differently from the container"
 else
   echo "  SKIP: this tmux predates copy-mode -H (3.2) — marker-hiding assertions skipped"
 fi

--- a/src/deploy/ttyd-tmux.sh
+++ b/src/deploy/ttyd-tmux.sh
@@ -112,7 +112,11 @@ TTYD_HISTORY_LIMIT="${HIVE_TTYD_HISTORY_LIMIT:-50000}"
 # created before that change, or outside the manager. Saved and restored around
 # the attach so an agent CLI that manages its own status line is not permanently
 # altered.
-TTYD_STATUS_RIGHT="${HIVE_TTYD_STATUS_RIGHT:-#{?pane_in_mode,[SCROLLBACK #{scroll_position}/#{history_size} lines back - not following live output - press q to resume] ,[live] }now %H:%M:%S }"
+#   * a pane whose application grabbed the mouse never enters copy-mode at all
+#     (the wheel rebind below forwards the wheel to the app), so the status line
+#     claimed a bare "[live]" no matter how far back the operator had scrolled
+#     inside the agent CLI's own buffer, and the position was nowhere (#4681).
+TTYD_STATUS_RIGHT="${HIVE_TTYD_STATUS_RIGHT:-#{?pane_in_mode,[SCROLLBACK #{scroll_position}/#{history_size} lines back - not following live output - press q to resume] ,#{?mouse_any_flag,[live - this app handles its own scrolling#, so tmux has no line position] ,[live] }}now %H:%M:%S }"
 TTYD_STATUS_INTERVAL="${HIVE_TTYD_STATUS_INTERVAL:-2}"
 # tmux truncates status-right to status-right-length, DEFAULT 40 columns —
 # which cut the message above off mid-word. Raised to fit the longest

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -141,7 +141,34 @@ const (
 	// (`#{scroll_position}/#{history_size} lines back`) because the wheel
 	// rebind below hides tmux's own black-on-yellow marker — this is where
 	// that information now lives, with a label.
-	tmuxStatusRight = "#{?pane_in_mode,[SCROLLBACK #{scroll_position}/#{history_size} lines back - not following live output - press q to resume] ,[live] }now %H:%M:%S "
+	//
+	// THE THIRD STATE (#4681). The two branches above are not exhaustive, and
+	// the gap swallowed the position indicator entirely for the panes that
+	// matter most. The wheel rebind below only enters copy-mode when the
+	// running program has NOT grabbed the mouse:
+	//
+	//	if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' 'send-keys -M' 'copy-mode -eH'
+	//
+	// Every agent CLI is a full-screen TUI that turns mouse reporting ON, so
+	// `mouse_any_flag` is 1 and the wheel is forwarded to the APPLICATION. The
+	// pane therefore never enters copy-mode, `pane_in_mode` stays 0, and the
+	// status line reported a bare `[live]` however far back the operator had
+	// scrolled inside the agent's own buffer. Combined with the `-H` that hides
+	// tmux's native `HH:MM [pos/total]` marker, that left no position and no
+	// content timestamp anywhere on screen — #4681's "I never saw an indication
+	// of my scroll position or timestamp", and why it read as a regression:
+	// before `-H` the native marker was at least SOMETIMES there.
+	//
+	// tmux genuinely cannot report a position here — the scrollback being moved
+	// belongs to the application, not to the pane — so this says exactly that
+	// instead of claiming `[live]`. Naming the reason is the point: `[live]`
+	// asserts the viewport is at the bottom of live output, which is false and
+	// unfalsifiable from the operator's side.
+	//
+	// The `#,` is an ESCAPED COMMA. tmux splits `#{?cond,a,b}` on unescaped
+	// commas, so prose commas inside a branch must be written `#,` or the
+	// branch silently truncates at the comma.
+	tmuxStatusRight = "#{?pane_in_mode,[SCROLLBACK #{scroll_position}/#{history_size} lines back - not following live output - press q to resume] ,#{?mouse_any_flag,[live - this app handles its own scrolling#, so tmux has no line position] ,[live] }}now %H:%M:%S "
 
 	// tmuxStatusRightLength bounds how many columns status-right may occupy.
 	// tmux's DEFAULT is 40, which silently truncated the message above to

--- a/src/pkg/agent/tmux_scrollback_legibility_test.go
+++ b/src/pkg/agent/tmux_scrollback_legibility_test.go
@@ -47,15 +47,28 @@ func TestNewSessionCommandsScrollbackLegibility(t *testing.T) {
 	if got, want := cmds[lenIdx+1], strconv.Itoa(tmuxStatusRightLength); got != want {
 		t.Fatalf("status-right-length value = %q, want %q", got, want)
 	}
-	// Longest realistic expansion: both counters at 6 digits on a deep buffer.
-	longest := strings.NewReplacer(
-		"#{?pane_in_mode,", "", ",[live] }", "",
-		"#{scroll_position}", "999999", "#{history_size}", "999999",
-		"%H:%M:%S", "23:59:59",
-	).Replace(tmuxStatusRight)
-	if tmuxStatusRightLength < len(longest) {
-		t.Fatalf("tmuxStatusRightLength (%d) < longest expansion (%d chars: %q) — the message would be truncated again",
-			tmuxStatusRightLength, len(longest), longest)
+	// Longest realistic expansion, over EVERY branch: both counters at 6 digits
+	// on a deep buffer. Enumerated by walking the conditionals rather than by
+	// string-replacing the syntax away — the previous version hard-coded the
+	// literal ",[live] }" tail, so adding the #4681 mouse_any_flag branch left
+	// unexpanded format text in the "expansion" and measured 194 chars for a
+	// message that renders in 90.
+	vars := map[string]string{
+		"scroll_position": "999999",
+		"history_size":    "999999",
+	}
+	expansions := tmuxFormatExpansions(strings.ReplaceAll(tmuxStatusRight, "%H:%M:%S", "23:59:59"), vars)
+	if len(expansions) < 3 {
+		t.Errorf("expected at least 3 status states (scrollback, app-owns-scroll, live), got %d: %q", len(expansions), expansions)
+	}
+	for _, e := range expansions {
+		if strings.Contains(e, "#{") {
+			t.Errorf("expansion %q still contains unexpanded format syntax — the format is malformed or the expander is wrong", e)
+		}
+		if tmuxStatusRightLength < len(e) {
+			t.Fatalf("tmuxStatusRightLength (%d) < expansion (%d chars: %q) — the message would be truncated again",
+				tmuxStatusRightLength, len(e), e)
+		}
 	}
 
 	// (3) the rebind is present, is the stock binding + -H, and follows
@@ -71,4 +84,111 @@ func TestNewSessionCommandsScrollbackLegibility(t *testing.T) {
 	if bindIdx < newIdx {
 		t.Fatalf("bind-key must FOLLOW new-session so an old tmux rejecting -H still creates the session: %v", cmds)
 	}
+}
+
+// tmuxFormatExpansions returns every string a tmux format can render to, one
+// per combination of its `#{?cond,then,else}` branches, with `#{var}` replaced
+// from vars and the `#,` escape resolved to a literal comma.
+//
+// It exists because the status line now has THREE states (#4681) and the test
+// above must bound the longest of them against status-right-length. Deriving
+// them from the real format is the point: a hand-maintained list of expected
+// strings would keep passing after the format it describes had changed.
+//
+// This understands only the subset the status line uses — conditionals,
+// variables, and the comma escape — which is deliberate. A fuller tmux format
+// evaluator would be a second implementation to keep correct, and the shell
+// test alongside this one already renders the format through real tmux.
+func tmuxFormatExpansions(format string, vars map[string]string) []string {
+	open := tmuxFindToken(format)
+	if open < 0 {
+		return []string{strings.ReplaceAll(format, "#,", ",")}
+	}
+	close := tmuxMatchBrace(format, open)
+	if close < 0 {
+		return []string{format} // unbalanced: surface it rather than guess
+	}
+	head, body, tail := format[:open], format[open+2:close], format[close+1:]
+
+	var middles []string
+	if strings.HasPrefix(body, "?") {
+		args := tmuxSplitArgs(body[1:])
+		if len(args) < 3 {
+			return []string{format}
+		}
+		// args[0] is the condition; every remaining arg is a reachable branch.
+		middles = args[1:]
+	} else {
+		v, ok := vars[body]
+		if !ok {
+			v = "#{" + body + "}" // unknown var: leave it visible to the caller
+		}
+		middles = []string{v}
+	}
+
+	var out []string
+	for _, m := range middles {
+		for _, mid := range tmuxFormatExpansions(m, vars) {
+			for _, rest := range tmuxFormatExpansions(tail, vars) {
+				out = append(out, strings.ReplaceAll(head, "#,", ",")+mid+rest)
+			}
+		}
+	}
+	return out
+}
+
+// tmuxFindToken returns the index of the first unescaped "#{", or -1.
+func tmuxFindToken(s string) int {
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] != '#' {
+			continue
+		}
+		if s[i+1] == '{' {
+			return i
+		}
+		i++ // "#," and friends: skip the escaped byte
+	}
+	return -1
+}
+
+// tmuxMatchBrace returns the index of the "}" closing the "#{" at open.
+func tmuxMatchBrace(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch {
+		case s[i] == '#' && i+1 < len(s) && s[i+1] == '{':
+			depth++
+			i++
+		case s[i] == '#' && i+1 < len(s):
+			i++ // escape: the next byte is literal
+		case s[i] == '}':
+			if depth--; depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// tmuxSplitArgs splits a conditional body on commas that are neither escaped
+// (`#,`) nor inside a nested `#{...}` — the same rule tmux applies, and the
+// reason a prose comma in a branch has to be written `#,`.
+func tmuxSplitArgs(s string) []string {
+	var parts []string
+	depth, start := 0, 0
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == '#' && i+1 < len(s) && s[i+1] == '{':
+			depth++
+			i++
+		case s[i] == '#' && i+1 < len(s):
+			i++
+		case s[i] == '}' && depth > 0:
+			depth--
+		case s[i] == ',' && depth == 0:
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	return append(parts, s[start:])
 }


### PR DESCRIPTION
Fixes #4681.

## Root cause

The report reads as a regression, and it is one. "Previously there was usually a line number and sometimes a timestamp" is tmux's native copy-mode marker, which renders in the top-right as:

```
line 67                                              07:06 [1/67]
```

A timestamp **and** a line position — exactly what the issue describes. #4399 hid it with `copy-mode -eH` and moved the position into a labelled status line instead. But that status line only renders a position in its `pane_in_mode` branch:

```
#{?pane_in_mode,[SCROLLBACK n/m lines back - ... - press q to resume] ,[live] }now %H:%M:%S
```

and those two branches **are not exhaustive**. The wheel rebind only enters copy-mode when the running program has not grabbed the mouse:

```
if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' 'send-keys -M' 'copy-mode -eH'
```

Every agent CLI is a full-screen TUI that turns mouse reporting on. I measured both branches on real tmux:

| pane | `mouse_any_flag` | wheel does |
|---|---|---|
| plain shell | `0` | `copy-mode -eH` — tmux scrollback |
| agent TUI | `1` | `send-keys -M` — **the app gets the wheel** |

So for the pane the operator actually looks at, copy-mode is unreachable, `pane_in_mode` stays `0` forever, and the status line reported a bare `[live]` however far back they had scrolled inside the agent's own buffer. Combined with the `-H` that hides the native marker, **no position and no content timestamp were anywhere on screen** — the reported symptom, and why it looked like something had been taken away.

## The fix

tmux genuinely cannot report a position here — the buffer being scrolled belongs to the application, not the pane. So the status line says that, instead of claiming `[live]`:

```
[SCROLLBACK 999999/999999 lines back - not following live output - press q to resume] now 23:59:59
[live - this app handles its own scrolling, so tmux has no line position] now 23:59:59
[live] now 23:59:59
```

A bare `[live]` asserts the viewport is at the bottom of live output. While the operator scrolls the agent's buffer that is false, and unfalsifiable from their side. Naming the owner of the scroll is the honest answer, and it is the same principle #4399 already applied to copy-mode.

I deliberately did **not** invent a position number for this state. Claiming one tmux cannot know would be worse than admitting the absence, and there is a test asserting the branch never emits `n/m lines back`.

## Second defect found on the way: `bin/ttyd-tmux.sh` had drifted

It describes itself as "a simpler standalone helper **kept in sync**", but it had silently missed the entire #4399 change — no `status-right`, no length raise, no wheel rebind. A terminal attached through it had no status line at all: no scroll position, no clock. The same symptom as this issue, from a file whose own comment claimed otherwise. Nothing checked, because the existing test only looked at `src/deploy/ttyd-tmux.sh`.

The container is unaffected (`src/Dockerfile` installs the `src/deploy/` copy), so this is the local/non-UID-isolated path only — but it is the identical bug and worth closing. The test now asserts **both** attach paths carry the manager's format and rebind byte for byte, so "kept in sync" is enforced rather than promised.

## Two tests that were not testing what they claimed

Found while adding coverage; both fixed here.

**The marker control was failing, and its neighbour was passing vacuously.** The shell test asserted plain copy-mode draws `[pos/total]` — but entered copy-mode without ever scrolling. At position 0 tmux renders a bare `0`, so the control failed on its own (visible on unmodified `v4`, 21 passed / 1 failed) and the `-H` assertion beside it passed for free, since *both* states trivially lacked the marker. Scrolling first makes the two captures differ only by `-H`, which is the thing under test.

**The Go length guard hard-coded the format's tail.** It stripped syntax with `strings.NewReplacer("#{?pane_in_mode,", "", ",[live] }", "", …)`. Adding a third branch left unexpanded format text inside the "expansion" and measured **194 chars** for a message that renders in **99** — it would have blocked this change for a truncation that does not exist. Replaced with a small expander that walks the conditionals and returns every reachable branch, so the guard survives the next format edit. Cross-checked against real tmux output; longest expansion is 99 chars against the 140 limit.

## Verification

```
bash src/deploy/test_terminal_scrollback_status.sh    33 passed, 0 failed   (was 21/1 on v4)
go test ./pkg/agent/                                  ok (456s)
go build ./... ; go vet ./pkg/agent/ ; gofmt -l       clean
```

The shell test drives a real mouse-reporting pane for the new state and pins: distinguishable from live, names who owns the scrolling, does not invent a position, keeps the labelled clock, and the `#,` escape survives — an unescaped prose comma truncates the branch silently, which is the failure mode a nested `#{?...}` invites.

## Note for maintainers

The wording of the new state is a UX call. I kept it factual and short enough for the 140-column budget, but if you would rather it named a recovery action the way the SCROLLBACK branch does ("press q to resume"), the equivalent here is bypassing mouse reporting — I left that out because the exact modifier through ttyd + xterm.js + tmux + the agent TUI is not something I could verify from here, and a wrong instruction is worse than none.

— hive: backend=claude model=claude-opus-5