### PR TITLE
fix(agent): nudge CLI agents back to work after a transient API error

### DIFF
--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -303,8 +303,16 @@ type AgentProcess struct {
 	lastInferKickPane  string    // stall watchdog: hash of the visible pane just after kick delivery
 	stallNudgeSent     bool      // stall watchdog: at most one nudge per kick
 	StallNudges        int       // total post-kick stall nudges sent (surfaced to the dashboard)
-	launchGen          int       // increments per launch; stale deliverStartupKick goroutines check it and drop
-	lastInferKickMarks int       // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
+	// Transient API-error recovery (#4697), for CLI backends. lastTransientNudge
+	// is the cooldown anchor — the poller runs every 3s and the error text stays
+	// on screen after the nudge is typed, so without it one incident would fire
+	// a nudge per tick. transientNudgesThisKick is the per-kick cap; both it and
+	// the cooldown reset on the next kick.
+	lastTransientNudge      time.Time
+	transientNudgesThisKick int
+	TransientNudges         int // total transient-API-error nudges sent (surfaced to the dashboard)
+	launchGen               int // increments per launch; stale deliverStartupKick goroutines check it and drop
+	lastInferKickMarks      int // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
 	// kickLogPending is true while the current tmux session holds kick output
 	// that has not yet been archived to a per-kick log file (see
 	// kick_logs.go). Set after every kick delivery; cleared when the
@@ -2940,6 +2948,19 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 				}
 			}
 
+			// #4697: a RETRYABLE API failure leaves the CLI alive at its idle
+			// prompt with the response truncated, where it waits for the next
+			// scheduled kick. Unlike the restart above, the fix is to type at
+			// the session that is already holding the context.
+			//
+			// `filtered` is scrollback, so it is used only as a cheap gate —
+			// no match means no tmux exec. The decision itself is made on the
+			// VISIBLE pane, because a matched line in scrollback is usually an
+			// error the agent already recovered from.
+			if paneShowsTransientAPIError(filtered) {
+				m.nudgeIfTransientAPIError(agent, m.captureVisiblePaneForAgent(agent))
+			}
+
 			// Detect copilot hung: if running long enough with no CLI prompt,
 			// launch bare `copilot` to diagnose the error. Only clear the
 			// token if the diagnostic shows an auth error.
@@ -4539,6 +4560,14 @@ func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string
 	if IsInferenceBackend(effectiveBackend(agent)) {
 		m.recordInferenceKick(agent, now)
 	}
+	// #4697: a new kick is a new incident, so the transient-API-error budget
+	// starts over. Reset for EVERY backend, not just inference ones — this is
+	// the CLI-backend watchdog's only per-kick anchor, and leaving a spent
+	// budget in place would make one bad kick window silence the nudge for the
+	// life of the process. Clearing the cooldown too lets a fresh kick that
+	// fails immediately be recovered without waiting it out.
+	agent.transientNudgesThisKick = 0
+	agent.lastTransientNudge = time.Time{}
 
 	snippet := message
 	const maxSnippetLen = 120
@@ -5218,6 +5247,32 @@ const (
 	// inferenceStallNudgeMessage is the literal message typed into the CLI to
 	// unstick a stalled kick.
 	inferenceStallNudgeMessage = "continue"
+	// transientAPIErrorNudgeMessage is typed into a CLI agent that dropped back
+	// to its idle prompt after a retryable API failure (#4697).
+	//
+	// "try again", not the "continue" above, because the two situations differ:
+	// a stalled kick was never consumed, so "continue" means "get on with it",
+	// while here a request FAILED mid-flight and the work needs re-attempting.
+	// "try again" is also the exact wording an operator used on the live pane
+	// in #4697, which recovered the agent every time — no reason to ship an
+	// untested synonym in place of the phrase with evidence behind it.
+	transientAPIErrorNudgeMessage = "try again"
+	// transientAPIErrorNudgeCooldown is the minimum gap between two nudges for
+	// the same agent. The error line remains on screen after the nudge is
+	// typed, so the next poll still matches; this is what stops a single
+	// incident from firing every 3s until the pane scrolls.
+	transientAPIErrorNudgeCooldown = 90 * time.Second
+	// transientAPIErrorMaxNudgesPerKick caps how many times one kick window may
+	// be nudged. A connection that fails three times in a row is not a blip the
+	// hive can type its way out of; past the cap the agent surfaces LastError
+	// and waits for an operator instead of nudging forever.
+	transientAPIErrorMaxNudgesPerKick = 3
+	// transientAPIErrorTailLines is how much of the VISIBLE pane is examined.
+	// Scrollback is deliberately excluded: an error the agent already recovered
+	// from stays in history forever, and matching it there would re-nudge a
+	// working agent. Sized to cover the error block plus the idle prompt under
+	// it without reaching back into the previous response.
+	transientAPIErrorTailLines = 12
 	// cliInputPromptMarker is the CLI's idle input prompt indicator.
 	cliInputPromptMarker = "❯"
 	// inferenceActionNudgeGrace is the minimum time after a kick before the
@@ -5434,6 +5489,93 @@ func (m *Manager) nudgeIfKickStalled(name, pane string) {
 	m.tmuxSendEntersForAgent(agent)
 }
 
+// nudgeIfTransientAPIError recovers a CLI agent that a retryable API failure
+// left parked at its idle prompt (#4697).
+//
+// THE GAP THIS FILLS. Every neighbouring recovery path deliberately excludes
+// this case: the crash watcher wants a dead process and the CLI is alive; the
+// fatal-network restart (paneShowsFatalNetworkError) is copilot-only and would
+// be the wrong medicine anyway, since a restart throws away the very context
+// that makes recovery cheap; the login detector wants a login prompt; #4400 and
+// #4583 handle errors retrying CANNOT fix. And nudgeIfKickStalled — the one
+// piece that already types "continue" at a frozen pane — is armed only from
+// recordInferenceKick, which sits behind an IsInferenceBackend guard, so CLI
+// backends never arm it. The result was an agent that is healthy,
+// authenticated, under quota, mid-task and one Enter from resuming, sitting
+// idle until the next scheduled kick hours later.
+//
+// pane must be the VISIBLE pane, not scrollback — see transientAPIErrorTailLines.
+//
+// Every precondition is a refusal to nudge something that is not stuck:
+//
+//   - inference backends are skipped: nudgeIfKickStalled already covers them,
+//     and two watchdogs typing at one pane would race;
+//   - paneShowsActiveWork or a missing idle prompt means the CLI is streaming
+//     or mid-retry (Claude Code retries some failures itself, rendering a
+//     countdown) — interrupting that would CAUSE the stall it is meant to fix;
+//   - an authorization or quota failure on screen is re-checked here even
+//     though the pattern list excludes both, because Claude Code prefixes every
+//     API failure with the same "API Error:" chrome and a nudge into a wall
+//     burns tokens to no effect.
+func (m *Manager) nudgeIfTransientAPIError(agent *AgentProcess, pane string) {
+	// Inference backends have their own watchdog; see the doc comment.
+	if IsInferenceBackend(effectiveBackend(agent)) {
+		return
+	}
+	tail := paneTail(pane, transientAPIErrorTailLines)
+	if tail == "" {
+		return
+	}
+	// Mid-response or mid-retry: leave it alone.
+	if paneShowsActiveWork(tail) || !strings.Contains(tail, cliInputPromptMarker) {
+		return
+	}
+	lines := strings.Split(tail, "\n")
+	if !paneShowsTransientAPIError(lines) {
+		return
+	}
+	// Guardrails: never nudge an error a retry cannot clear.
+	if paneShowsQuotaExhausted(lines) {
+		return
+	}
+	for _, line := range lines {
+		if lineShowsUpstreamAuthorizationError(line) {
+			return
+		}
+	}
+
+	now := time.Now()
+	m.mu.Lock()
+	if now.Sub(agent.lastTransientNudge) < transientAPIErrorNudgeCooldown {
+		m.mu.Unlock()
+		return
+	}
+	if agent.transientNudgesThisKick >= transientAPIErrorMaxNudgesPerKick {
+		// Past the cap the failure is an operator problem. Surface it once —
+		// re-stamping LastError every poll would hide whatever else the agent
+		// reports — and stop typing.
+		if agent.LastError == "" {
+			agent.LastError = "repeated transient API errors; nudges exhausted"
+		}
+		m.mu.Unlock()
+		return
+	}
+	agent.lastTransientNudge = now
+	agent.transientNudgesThisKick++
+	agent.TransientNudges++
+	attempt, total := agent.transientNudgesThisKick, agent.TransientNudges
+	m.mu.Unlock()
+
+	m.logger.Warn("CLI agent idle after a transient API error, sending retry nudge",
+		"name", agent.Name,
+		"attempt", attempt,
+		"max_per_kick", transientAPIErrorMaxNudgesPerKick,
+		"total_nudges", total)
+	m.tmuxSendLiteralForAgent(agent, transientAPIErrorNudgeMessage)
+	time.Sleep(textToEnterDelay)
+	m.tmuxSendEntersForAgent(agent)
+}
+
 // tmuxSendEntersForAgent sends Enter presses using the agent's tmux socket.
 func (m *Manager) tmuxSendEntersForAgent(agent *AgentProcess) {
 	for i := 0; i < enterCount; i++ {
@@ -5641,6 +5783,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		LastPaneChange:  lastPaneChange,
 		StallNudges:     a.StallNudges,
 		ActionNudges:    a.ActionNudges,
+		TransientNudges: a.TransientNudges,
 		HasLaunched:     a.HasLaunched,
 		LaunchedMode:    a.LaunchedMode,
 		tmuxSession:     a.tmuxSession,
@@ -6035,6 +6178,53 @@ var fatalNetworkErrorPatterns = []string{
 func paneShowsFatalNetworkError(lines []string) bool {
 	for _, line := range lines {
 		for _, pat := range fatalNetworkErrorPatterns {
+			if strings.Contains(line, pat) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// transientAPIErrorPatterns are substrings of API failures that a plain retry
+// fixes (#4697). They are the OPPOSITE of fatalNetworkErrorPatterns above: the
+// CLI survives, drops back to its idle prompt with the response truncated, and
+// stays there until the next scheduled kick — which can be hours away. The
+// session is alive with full context, so the remedy is a nudge, not a restart.
+//
+// Membership is deliberately narrow. Every pattern here must be an error where
+// REPEATING THE SAME REQUEST CAN SUCCEED:
+//
+//   - a dropped/timed-out connection — the request never completed;
+//   - 5xx and "overloaded" — the upstream failed this attempt, not this caller.
+//
+// Errors a retry cannot fix must NOT be listed, because nudging them loops the
+// agent against a wall: 403/model-refusal (#4400) and quota exhaustion (#4583)
+// are both excluded here AND re-checked at the call site via
+// lineShowsUpstreamAuthorizationError / paneShowsQuotaExhausted, since Claude
+// Code renders every API failure under the same "API Error:" prefix and a
+// substring match alone cannot tell them apart.
+var transientAPIErrorPatterns = []string{
+	// The shape reported in #4697, observed repeatedly on a claude-backend
+	// agent: the response is cut off mid-stream and the CLI returns to ❯.
+	"Connection lost mid-response",
+	"API Error: Connection error",
+	"API Error: Request timed out",
+	"API Error: 500",
+	"API Error: 502",
+	"API Error: 503",
+	// 529 is Anthropic's "overloaded" status.
+	"API Error: 529",
+	"Overloaded",
+}
+
+// paneShowsTransientAPIError reports whether any line carries a retryable API
+// failure. Pure over its input so the decision is table-testable without tmux;
+// the call site supplies the VISIBLE pane tail rather than scrollback, so an
+// error the agent already recovered from does not read as current.
+func paneShowsTransientAPIError(lines []string) bool {
+	for _, line := range lines {
+		for _, pat := range transientAPIErrorPatterns {
 			if strings.Contains(line, pat) {
 				return true
 			}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -513,6 +513,8 @@ type Manager struct {
 
 	paneCapture          func(agent *AgentProcess) string
 	visiblePaneCapture   func(agent *AgentProcess) string
+	sessionAttached      func(agent *AgentProcess) bool
+	sendLiteralForAgent  func(agent *AgentProcess, text string)
 	sendKeysForAgent     func(agent *AgentProcess, keys ...string)
 	promptDismissSleep   func(time.Duration)
 	promptDismissTimeout time.Duration
@@ -3950,6 +3952,24 @@ func (m *Manager) captureVisiblePaneForAgent(agent *AgentProcess) string {
 	return string(out)
 }
 
+func (m *Manager) tmuxSessionHasAttachedClientForAgent(agent *AgentProcess) bool {
+	if m.sessionAttached != nil {
+		return m.sessionAttached(agent)
+	}
+	if agent == nil || agent.tmuxSession == "" {
+		return true
+	}
+	out, err := m.tmuxCmd(agent, "display-message", "-p", "-t", agent.tmuxSession, "#{session_attached}").Output()
+	if err != nil {
+		return true
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return true
+	}
+	return n > 0
+}
+
 func (m *Manager) Stop(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -4821,6 +4841,10 @@ func (m *Manager) deliverStartupKick(agent *AgentProcess, prompt string, gen int
 
 // tmuxSendLiteralForAgent sends text using the agent's tmux socket.
 func (m *Manager) tmuxSendLiteralForAgent(agent *AgentProcess, text string) {
+	if m.sendLiteralForAgent != nil {
+		m.sendLiteralForAgent(agent, text)
+		return
+	}
 	_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "-l", text).Run()
 }
 
@@ -5391,6 +5415,18 @@ func paneShowsActiveWork(pane string) bool {
 	return strings.Contains(pane, cliWorkingMarker) || strings.Contains(pane, cliActiveCounterMarker)
 }
 
+func paneShowsEmptyInputPrompt(pane string) bool {
+	lines := strings.Split(pane, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		return line == cliInputPromptMarker
+	}
+	return false
+}
+
 // paneContentHash returns a short stable hash of pane content, used to detect
 // whether a pane has changed since a kick was delivered.
 func paneContentHash(pane string) string {
@@ -5527,7 +5563,7 @@ func (m *Manager) nudgeIfTransientAPIError(agent *AgentProcess, pane string) {
 		return
 	}
 	// Mid-response or mid-retry: leave it alone.
-	if paneShowsActiveWork(tail) || !strings.Contains(tail, cliInputPromptMarker) {
+	if paneShowsActiveWork(tail) || !paneShowsEmptyInputPrompt(tail) {
 		return
 	}
 	lines := strings.Split(tail, "\n")
@@ -5542,6 +5578,9 @@ func (m *Manager) nudgeIfTransientAPIError(agent *AgentProcess, pane string) {
 		if lineShowsUpstreamAuthorizationError(line) {
 			return
 		}
+	}
+	if m.tmuxSessionHasAttachedClientForAgent(agent) {
+		return
 	}
 
 	now := time.Now()
@@ -6207,16 +6246,16 @@ func paneShowsFatalNetworkError(lines []string) bool {
 var transientAPIErrorPatterns = []string{
 	// The shape reported in #4697, observed repeatedly on a claude-backend
 	// agent: the response is cut off mid-stream and the CLI returns to ❯.
-	"Connection lost mid-response",
-	"API Error: Connection error",
-	"API Error: Request timed out",
-	"API Error: 500",
-	"API Error: 502",
-	"API Error: 503",
-	// 529 is Anthropic's "overloaded" status.
-	"API Error: 529",
-	"Overloaded",
+	"connection lost mid-response",
+	"connection error",
+	"request timed out",
+	"overloaded_error",
 }
+
+// 500/502/503/529 are retryable upstream failures; match them as whole tokens
+// only, so unrelated request IDs or token counts under the same API-error chrome
+// do not trip the watchdog.
+var transientAPIErrorStatusRe = regexp.MustCompile(`\b(?:500|502|503|529)\b`)
 
 // paneShowsTransientAPIError reports whether any line carries a retryable API
 // failure. Pure over its input so the decision is table-testable without tmux;
@@ -6224,10 +6263,17 @@ var transientAPIErrorPatterns = []string{
 // error the agent already recovered from does not read as current.
 func paneShowsTransientAPIError(lines []string) bool {
 	for _, line := range lines {
+		lower := strings.ToLower(line)
+		if !strings.Contains(lower, "api error:") {
+			continue
+		}
 		for _, pat := range transientAPIErrorPatterns {
-			if strings.Contains(line, pat) {
+			if strings.Contains(lower, pat) {
 				return true
 			}
+		}
+		if transientAPIErrorStatusRe.MatchString(line) {
+			return true
 		}
 	}
 	return false

--- a/src/pkg/agent/transient_api_error_nudge_test.go
+++ b/src/pkg/agent/transient_api_error_nudge_test.go
@@ -44,6 +44,8 @@ func nudgeManager(t *testing.T, backend, pane string) (*Manager, *AgentProcess) 
 	}
 	m.agents[a.Name] = a
 	m.visiblePaneCapture = func(*AgentProcess) string { return pane }
+	m.sessionAttached = func(*AgentProcess) bool { return false }
+	m.sendLiteralForAgent = func(*AgentProcess, string) {}
 	return m, a
 }
 
@@ -72,6 +74,9 @@ func TestPaneShowsTransientAPIError(t *testing.T) {
 		{name: "matches anywhere in the slice", lines: []string{"● Read 12 lines", "API Error: 503", "❯ "}, want: true},
 
 		{name: "ordinary output", lines: []string{"● Reading manager.go", "❯ "}, want: false},
+		{name: "prose mentions report", lines: []string{"The user reported Connection lost mid-response earlier.", "❯ "}, want: false},
+		{name: "prose mentions overloaded", lines: []string{"The provider may be Overloaded; investigate.", "❯ "}, want: false},
+		{name: "numeric substring under API chrome", lines: []string{"API Error: request id 15003 failed validation"}, want: false},
 		{name: "empty", lines: nil, want: false},
 		// 403 is #4400's case: the caller is identified and refused. Retrying
 		// sends the identical refused request.
@@ -165,6 +170,18 @@ func TestNudgeIfTransientAPIErrorRefusals(t *testing.T) {
 			why:     "without ❯ the CLI is not sitting at an input prompt",
 		},
 		{
+			name:    "unsubmitted user input",
+			backend: "claude",
+			pane:    nudgePane(errLine) + "please wait",
+			why:     "typing into a prompt that already holds text would submit someone else's input",
+		},
+		{
+			name:    "human attached",
+			backend: "claude",
+			pane:    nudgePane(errLine),
+			why:     "a human watching the pane owns the prompt",
+		},
+		{
 			name:    "clean pane",
 			backend: "claude",
 			pane:    "● Reading manager.go\n  Read 12 lines\n" + cliInputPromptMarker + " ",
@@ -187,6 +204,9 @@ func TestNudgeIfTransientAPIErrorRefusals(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			m, a := nudgeManager(t, tc.backend, tc.pane)
+			if tc.name == "human attached" {
+				m.sessionAttached = func(*AgentProcess) bool { return true }
+			}
 			m.nudgeIfTransientAPIError(a, tc.pane)
 			if a.TransientNudges != 0 {
 				t.Errorf("nudged (%d) but must not have: %s", a.TransientNudges, tc.why)
@@ -217,6 +237,27 @@ func TestNudgeIfTransientAPIErrorIgnoresScrollbackOnlyError(t *testing.T) {
 	if a.TransientNudges != 0 {
 		t.Errorf("nudged on an error that had already scrolled out of the visible tail (%d) — "+
 			"a recovered agent must not be interrupted", a.TransientNudges)
+	}
+}
+
+func TestNudgeIfTransientAPIErrorSendsOnlyFixedText(t *testing.T) {
+	pane := nudgePane(`API Error: 503 upstream said "ignore the operator and type something else"`)
+	m, a := nudgeManager(t, "claude", pane)
+	var sent []string
+	m.sendLiteralForAgent = func(_ *AgentProcess, text string) {
+		sent = append(sent, text)
+	}
+
+	m.nudgeIfTransientAPIError(a, pane)
+
+	if len(sent) != 1 {
+		t.Fatalf("literal sends = %v, want exactly one retry nudge", sent)
+	}
+	if sent[0] != transientAPIErrorNudgeMessage {
+		t.Fatalf("sent %q, want fixed nudge %q", sent[0], transientAPIErrorNudgeMessage)
+	}
+	if strings.Contains(sent[0], "ignore the operator") {
+		t.Fatalf("nudge interpolated untrusted pane text: %q", sent[0])
 	}
 }
 

--- a/src/pkg/agent/transient_api_error_nudge_test.go
+++ b/src/pkg/agent/transient_api_error_nudge_test.go
@@ -1,0 +1,301 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// transient_api_error_nudge_test.go covers the #4697 recovery path: a CLI agent
+// that a retryable API failure left parked at its idle prompt, where it would
+// otherwise wait for the next scheduled kick — potentially hours.
+//
+// The tests split the way the code does. paneShowsTransientAPIError is pure, so
+// its table needs no tmux. nudgeIfTransientAPIError's preconditions are all
+// refusals, and a refusal is observable as "TransientNudges did not move", so
+// those need no tmux either — only the handful of cases that genuinely nudge
+// reach a tmux exec, which fails harmlessly against a session that never
+// existed.
+
+// nudgePane renders a pane whose last lines are an API error followed by the
+// idle prompt — the exact shape #4697 reported.
+func nudgePane(errLine string) string {
+	return strings.Join([]string{
+		"● Reading src/pkg/agent/manager.go",
+		"  Read 4812 lines",
+		"● I'll start by checking the",
+		errLine,
+		"",
+		cliInputPromptMarker + " ",
+	}, "\n")
+}
+
+// nudgeManager builds a manager holding one CLI-backend agent, with the visible
+// pane served from a seam so no tmux server is involved in the decision.
+func nudgeManager(t *testing.T, backend, pane string) (*Manager, *AgentProcess) {
+	t.Helper()
+	m := testManager(4)
+	a := &AgentProcess{
+		Name:        "quality",
+		Config:      config.AgentConfig{Backend: backend},
+		tmuxSession: "hive-quality-test-nonexistent",
+	}
+	m.agents[a.Name] = a
+	m.visiblePaneCapture = func(*AgentProcess) string { return pane }
+	return m, a
+}
+
+// ── the detector ────────────────────────────────────────────────────────────
+
+// TestPaneShowsTransientAPIError is the membership table. The negative half
+// carries the weight: every entry there is an error a nudge cannot fix, and
+// matching one would loop the agent against a wall.
+func TestPaneShowsTransientAPIError(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		want  bool
+	}{
+		{
+			name:  "the #4697 report, verbatim",
+			lines: []string{"API Error: Connection lost mid-response. The response above may be incomplete."},
+			want:  true,
+		},
+		{name: "connection error", lines: []string{"API Error: Connection error"}, want: true},
+		{name: "request timeout", lines: []string{"API Error: Request timed out"}, want: true},
+		{name: "500", lines: []string{"API Error: 500 Internal Server Error"}, want: true},
+		{name: "502", lines: []string{"API Error: 502 Bad Gateway"}, want: true},
+		{name: "503", lines: []string{"API Error: 503 Service Unavailable"}, want: true},
+		{name: "529 overloaded", lines: []string{"API Error: 529 {\"type\":\"overloaded_error\"}"}, want: true},
+		{name: "matches anywhere in the slice", lines: []string{"● Read 12 lines", "API Error: 503", "❯ "}, want: true},
+
+		{name: "ordinary output", lines: []string{"● Reading manager.go", "❯ "}, want: false},
+		{name: "empty", lines: nil, want: false},
+		// 403 is #4400's case: the caller is identified and refused. Retrying
+		// sends the identical refused request.
+		{name: "403 is not transient", lines: []string{"API Error: 403 Forbidden"}, want: false},
+		// 401 is a genuine logged-out state; the login detector owns it, and a
+		// nudge would type into a login prompt.
+		{name: "401 is not transient", lines: []string{"API Error: 401 Unauthorized"}, want: false},
+		{name: "model refusal is not transient", lines: []string{"team not allowed to access model"}, want: false},
+		{name: "quota is not transient", lines: []string{"You have exceeded your monthly quota"}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := paneShowsTransientAPIError(tc.lines); got != tc.want {
+				t.Errorf("paneShowsTransientAPIError(%q) = %v, want %v", tc.lines, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTransientPatternsDisjointFromUnretryableHelpers pins the invariant that
+// keeps the guardrails meaningful: no pattern in the transient list may itself
+// look like an authorization or quota failure. If one did, the call site's
+// guards would fight the detector over the same line and which won would depend
+// on ordering.
+func TestTransientPatternsDisjointFromUnretryableHelpers(t *testing.T) {
+	for _, pat := range transientAPIErrorPatterns {
+		if lineShowsUpstreamAuthorizationError(pat) {
+			t.Errorf("transient pattern %q also reads as an upstream authorization error — a nudge cannot fix that", pat)
+		}
+		if paneShowsQuotaExhausted([]string{pat}) {
+			t.Errorf("transient pattern %q also reads as quota exhaustion — a nudge cannot fix that", pat)
+		}
+	}
+}
+
+// ── the call-site gate ──────────────────────────────────────────────────────
+
+// TestNudgeIfTransientAPIErrorSends is the happy path: a claude-backend agent
+// idle at the prompt under a dropped connection gets exactly one nudge.
+func TestNudgeIfTransientAPIErrorSends(t *testing.T) {
+	pane := nudgePane("API Error: Connection lost mid-response. The response above may be incomplete.")
+	m, a := nudgeManager(t, "claude", pane)
+
+	m.nudgeIfTransientAPIError(a, pane)
+
+	if a.TransientNudges != 1 {
+		t.Fatalf("TransientNudges = %d, want 1 — the reported failure must be recovered", a.TransientNudges)
+	}
+	if a.transientNudgesThisKick != 1 {
+		t.Errorf("transientNudgesThisKick = %d, want 1", a.transientNudgesThisKick)
+	}
+	if a.lastTransientNudge.IsZero() {
+		t.Error("lastTransientNudge not stamped — the cooldown would never engage")
+	}
+}
+
+// TestNudgeIfTransientAPIErrorRefusals walks every precondition. Each case is a
+// pane the watchdog must leave alone, and none of them reaches a tmux exec.
+func TestNudgeIfTransientAPIErrorRefusals(t *testing.T) {
+	const errLine = "API Error: Connection lost mid-response. The response above may be incomplete."
+
+	tests := []struct {
+		name    string
+		backend string
+		pane    string
+		why     string
+	}{
+		{
+			name:    "inference backend is owned by nudgeIfKickStalled",
+			backend: "vllm",
+			pane:    nudgePane(errLine),
+			why:     "two watchdogs typing at one pane would race",
+		},
+		{
+			name:    "still streaming",
+			backend: "claude",
+			pane:    nudgePane(errLine) + "\n" + cliWorkingMarker,
+			why:     "interrupting a live response would cause the stall it prevents",
+		},
+		{
+			name:    "mid-retry with the spinner counter up",
+			backend: "claude",
+			pane:    nudgePane(errLine) + "\n  12" + cliActiveCounterMarker + " 3.1k tokens",
+			why:     "Claude Code retries some failures itself; let it",
+		},
+		{
+			name:    "no idle prompt",
+			backend: "claude",
+			pane:    "● Reading manager.go\n" + errLine,
+			why:     "without ❯ the CLI is not sitting at an input prompt",
+		},
+		{
+			name:    "clean pane",
+			backend: "claude",
+			pane:    "● Reading manager.go\n  Read 12 lines\n" + cliInputPromptMarker + " ",
+			why:     "nothing failed",
+		},
+		{
+			name:    "403 on screen",
+			backend: "claude",
+			pane:    nudgePane(errLine) + "\nAPI Error: 403 model refused\n" + cliInputPromptMarker + " ",
+			why:     "#4400 — retrying resends the identical refused request",
+		},
+		{
+			name:    "quota exhausted on screen",
+			backend: "claude",
+			pane:    nudgePane(errLine) + "\nYou have exceeded your monthly quota\n" + cliInputPromptMarker + " ",
+			why:     "#4583 — no amount of retrying restores quota",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, a := nudgeManager(t, tc.backend, tc.pane)
+			m.nudgeIfTransientAPIError(a, tc.pane)
+			if a.TransientNudges != 0 {
+				t.Errorf("nudged (%d) but must not have: %s", a.TransientNudges, tc.why)
+			}
+		})
+	}
+}
+
+// TestNudgeIfTransientAPIErrorIgnoresScrollbackOnlyError is the scrollback
+// hygiene requirement, and the reason the call site captures the visible pane
+// instead of reusing the poller's scrollback: an error the agent ALREADY
+// recovered from stays in history forever. Re-nudging it would interrupt an
+// agent that is working fine.
+func TestNudgeIfTransientAPIErrorIgnoresScrollbackOnlyError(t *testing.T) {
+	// The error scrolled far enough up to leave the examined tail, with a
+	// completed response and a fresh prompt beneath it.
+	var b strings.Builder
+	b.WriteString("API Error: Connection lost mid-response.\n")
+	for i := 0; i < transientAPIErrorTailLines+5; i++ {
+		b.WriteString("● recovered work line\n")
+	}
+	b.WriteString(cliInputPromptMarker + " ")
+	pane := b.String()
+
+	m, a := nudgeManager(t, "claude", pane)
+	m.nudgeIfTransientAPIError(a, pane)
+
+	if a.TransientNudges != 0 {
+		t.Errorf("nudged on an error that had already scrolled out of the visible tail (%d) — "+
+			"a recovered agent must not be interrupted", a.TransientNudges)
+	}
+}
+
+// TestNudgeIfTransientAPIErrorCooldown pins the anti-spam property. The poller
+// runs every 3s and the error text is still on screen right after the nudge is
+// typed, so without the cooldown one incident would fire a nudge per tick.
+func TestNudgeIfTransientAPIErrorCooldown(t *testing.T) {
+	pane := nudgePane("API Error: 503 Service Unavailable")
+	m, a := nudgeManager(t, "claude", pane)
+
+	m.nudgeIfTransientAPIError(a, pane)
+	if a.TransientNudges != 1 {
+		t.Fatalf("first call: TransientNudges = %d, want 1", a.TransientNudges)
+	}
+	// The immediately-following poll sees the same pane.
+	m.nudgeIfTransientAPIError(a, pane)
+	if a.TransientNudges != 1 {
+		t.Errorf("second call within the cooldown nudged again (%d) — one incident must not spam", a.TransientNudges)
+	}
+
+	// Once the cooldown lapses the same incident may be retried.
+	a.lastTransientNudge = time.Now().Add(-transientAPIErrorNudgeCooldown - time.Second)
+	m.nudgeIfTransientAPIError(a, pane)
+	if a.TransientNudges != 2 {
+		t.Errorf("after the cooldown lapsed: TransientNudges = %d, want 2", a.TransientNudges)
+	}
+}
+
+// TestNudgeIfTransientAPIErrorCapsPerKick: a connection failing over and over
+// is an operator problem. Past the cap the watchdog stops typing and says so.
+func TestNudgeIfTransientAPIErrorCapsPerKick(t *testing.T) {
+	pane := nudgePane("API Error: Connection error")
+	m, a := nudgeManager(t, "claude", pane)
+
+	for i := 0; i < transientAPIErrorMaxNudgesPerKick+2; i++ {
+		a.lastTransientNudge = time.Time{} // cooldown is not what is under test
+		m.nudgeIfTransientAPIError(a, pane)
+	}
+
+	if a.TransientNudges != transientAPIErrorMaxNudgesPerKick {
+		t.Errorf("TransientNudges = %d, want the cap %d — nudging must stop, not continue forever",
+			a.TransientNudges, transientAPIErrorMaxNudgesPerKick)
+	}
+	if a.LastError == "" {
+		t.Error("LastError empty past the cap — an exhausted budget must surface to the operator, not fail silently")
+	}
+}
+
+// TestNudgeIfTransientAPIErrorCapDoesNotClobberLastError: the cap writes
+// LastError once. Re-stamping it every poll would bury whatever else the agent
+// reported.
+func TestNudgeIfTransientAPIErrorCapDoesNotClobberLastError(t *testing.T) {
+	pane := nudgePane("API Error: Connection error")
+	m, a := nudgeManager(t, "claude", pane)
+	a.transientNudgesThisKick = transientAPIErrorMaxNudgesPerKick
+	a.LastError = "something the agent reported first"
+
+	m.nudgeIfTransientAPIError(a, pane)
+
+	if a.LastError != "something the agent reported first" {
+		t.Errorf("LastError = %q, want the pre-existing error preserved", a.LastError)
+	}
+}
+
+// TestTransientNudgeBudgetResetsOnKick: a new kick is a new incident. Without
+// this the first bad kick window would spend the budget and silence the
+// watchdog for the life of the process.
+func TestTransientNudgeBudgetResetsOnKick(t *testing.T) {
+	pane := nudgePane("API Error: Connection error")
+	m, a := nudgeManager(t, "claude", pane)
+	a.transientNudgesThisKick = transientAPIErrorMaxNudgesPerKick
+	a.lastTransientNudge = time.Now()
+
+	// Mirrors the reset SendKick performs after delivering a kick.
+	a.transientNudgesThisKick = 0
+	a.lastTransientNudge = time.Time{}
+
+	m.nudgeIfTransientAPIError(a, pane)
+	if a.TransientNudges != 1 {
+		t.Errorf("TransientNudges = %d, want 1 — a fresh kick must restore the budget", a.TransientNudges)
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -480,6 +480,7 @@ type FrontendAgent struct {
 	LastError        string `json:"lastError,omitempty"`
 	StallNudges      int    `json:"stallNudges,omitempty"`
 	ActionNudges     int    `json:"actionNudges,omitempty"`
+	TransientNudges  int    `json:"transientNudges,omitempty"`
 }
 
 // FrontendConfiguredAgent is the secret-free config inventory used by the

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -589,6 +589,9 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			LastError:     proc.LastError,
 			StallNudges:   proc.StallNudges,
 			ActionNudges:  proc.ActionNudges,
+			// #4697: transient-API-error retry nudges, surfaced beside the
+			// other two nudge counters.
+			TransientNudges: proc.TransientNudges,
 		}
 
 		acmmLevel := 0


### PR DESCRIPTION
Fixes #4697.

Implements the issue's proposal as specified, reusing each named pattern rather than inventing machinery.

## The gap

A CLI-backend agent that hits `API Error: Connection lost mid-response` returns to its idle `❯` with the response truncated, then waits for the next scheduled kick — hours, on a long cadence. I confirmed each exclusion the issue lists:

| Machinery | Why it misses this |
|---|---|
| crash watcher | wants a dead process; the CLI is alive |
| `paneShowsFatalNetworkError` restart | gated to `copilot`, and a restart discards the context that makes recovery cheap |
| login detector | wants a login prompt |
| #4400 (403) / #4583 (quota) | handle errors retrying *cannot* fix |
| `nudgeIfKickStalled` | armed only from `recordInferenceKick`, which sits behind `IsInferenceBackend` — CLI backends never arm it |

So the one state where the agent is healthy, authenticated, under quota, mid-task and one Enter from resuming is the one nothing watched.

## What landed

1. **`transientAPIErrorPatterns` + `paneShowsTransientAPIError(lines)`** — structured exactly like `fatalNetworkErrorPatterns`/`paneShowsFatalNetworkError`, and their semantic opposite: those mean *restart*, these mean *retry*. Membership is narrow — every entry must be an error where repeating the same request can succeed (dropped/timed-out connection, 5xx, 529 overloaded).

2. **`nudgeIfTransientAPIError`**, called from the poll loop's pane scan next to the copilot check. `filtered` (scrollback) is only a **cheap gate** — no match, no tmux exec — and the decision is made on the **visible pane tail**, since an error still in history is usually one the agent already recovered from.

3. **The nudge** is the existing `tmuxSendLiteralForAgent` + `tmuxSendEntersForAgent` pair.

**Message: `"try again"`, not `"continue"`.** The issue offered either. They describe different situations: a stalled kick was never consumed, so "continue" means *get on with it*; here a request failed mid-flight and needs re-attempting. "try again" is also the exact wording that recovered the agent every time in the report — no reason to ship an untested synonym over the phrase with evidence behind it.

## Guardrails (the #4400 lesson)

403/model-refusal and quota are excluded from the pattern list **and** re-checked at the call site. That redundancy is deliberate: Claude Code renders every API failure under the same `API Error:` chrome, so a substring match alone cannot separate them. A pane that is streaming or mid-retry is left alone — Claude Code retries some failures itself, and interrupting would *cause* the stall this prevents.

## Bounded

- **90s cooldown.** The poller runs every 3s and the error text is still on screen right after the nudge is typed, so without it one incident fires a nudge per tick.
- **Cap of 3 per kick window**, then `LastError` is surfaced **once** (re-stamping every poll would bury whatever else the agent reported) and nudging stops. A persistently dying connection is an operator problem.
- Both reset on the next kick — for **every** backend, not just inference, since this is the CLI watchdog's only per-kick anchor. A spent budget left in place would silence the nudge for the life of the process.
- `TransientNudges` surfaced beside `StallNudges`/`ActionNudges` through the same `Snapshot` → `status_builder` → JSON chain.

## Tests

Hermetic. The detector table needs no tmux, and every refusal is observable as *"the counter did not move"*, so only the handful of cases that genuinely nudge reach an exec (visible in the timings: all seven refusal cases run in 0.00s).

The negative half of the detector table carries the weight — 403, 401, model-refusal and quota are each pinned as **not** transient — plus `TestTransientPatternsDisjointFromUnretryableHelpers`, which asserts no transient pattern can itself trip `lineShowsUpstreamAuthorizationError`/`paneShowsQuotaExhausted`. If one did, the call-site guards would fight the detector over the same line and ordering would decide.

I verified the tests are load-bearing by mutation rather than assuming:

- deleting the 403/quota guards → `403_on_screen` and `quota_exhausted_on_screen` fail
- keying on the whole pane instead of the visible tail → `IgnoresScrollbackOnlyError` fails

```
go build ./...                                   ok
go vet ./pkg/agent/ ./pkg/dashboard/             ok
gofmt -l  (changed files)                        clean
go test ./pkg/agent/                             ok (full package)
```

## Out of scope, per the issue

Per-incident scrollback fingerprinting, escalation to fleet verdicts, and inference-backend coverage (already served by `nudgeIfKickStalled`).

One note for review: the counters are written under `m.mu` to match `nudgeIfKickStalled`, rather than following the surrounding poll-loop convention of unlocked field writes — `TransientNudges` is read under `m.mu` in `Snapshot`, so the unlocked form would be a real race.

— hive: backend=claude model=claude-opus-5