### PR TITLE
fix(dashboard): resolve claude credentials per-UID in model discovery

### DIFF
--- a/src/pkg/agent/authprobe.go
+++ b/src/pkg/agent/authprobe.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/kubestellar/hive/pkg/claude"
@@ -117,6 +118,70 @@ func containsPath(list []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// ClaudeCredentialCandidatePaths returns every .credentials.json worth trying
+// for a BACKEND-level "is claude authenticated on this hive?" question —
+// per-UID agent homes first, the shared legacy path last.
+//
+// It exists so that question has exactly ONE answer (#4699). The per-UID fix
+// this file's header describes was applied here and NOT to the dashboard's
+// model-discovery probe, which kept stat'ing only the shared path. On a hive
+// where the two disagree the operator sees a self-contradicting UI: the agent
+// card reads "✓ logged in" from this probe while every model in the dropdown
+// reads "(common alias, unverified)" from that one. Both now resolve paths
+// through this function, so they cannot drift apart again.
+//
+// Backend-level, so ANY agent's fresh token answers it: a model catalog is a
+// property of the provider, not of the agent that asked. Ordering is
+// deterministic (agents sorted by name) because m.agents iterates randomly and
+// a probe that consulted a different credential on each call would be
+// untestable and would make an expired token an intermittent failure.
+//
+// A nil Manager yields the shared path alone, which is the pre-per-UID
+// behavior — callers without an agent manager are no worse off than before.
+func (m *Manager) ClaudeCredentialCandidatePaths() []string {
+	if m == nil {
+		return []string{sharedClaudeCredentialPath}
+	}
+
+	type agentRef struct {
+		name    string
+		backend string
+		uid     int
+	}
+	m.mu.RLock()
+	refs := make([]agentRef, 0, len(m.agents))
+	for name, proc := range m.agents {
+		if proc == nil {
+			continue
+		}
+		backend := proc.Config.Backend
+		if proc.BackendOverride != "" {
+			backend = proc.BackendOverride
+		}
+		if backend != "claude" {
+			continue
+		}
+		refs = append(refs, agentRef{name: name, backend: backend, uid: proc.UID})
+	}
+	m.mu.RUnlock()
+	sort.Slice(refs, func(i, j int) bool { return refs[i].name < refs[j].name })
+
+	paths := []string{}
+	for _, r := range refs {
+		for _, p := range agentClaudeCredentialPaths(r.name, r.uid, r.backend) {
+			if !containsPath(paths, p) {
+				paths = append(paths, p)
+			}
+		}
+	}
+	// Always reachable even with no claude agents registered: a hive that has
+	// not started its agents yet still has a shared login worth checking.
+	if !containsPath(paths, sharedClaudeCredentialPath) {
+		paths = append(paths, sharedClaudeCredentialPath)
+	}
+	return paths
 }
 
 // agentCopilotConfigPaths returns the Copilot credential locations to try for

--- a/src/pkg/agent/claude_credential_paths_test.go
+++ b/src/pkg/agent/claude_credential_paths_test.go
@@ -1,0 +1,180 @@
+package agent
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// claude_credential_paths_test.go covers ClaudeCredentialCandidatePaths, the
+// single answer to "where do this hive's claude credentials live?" (#4699).
+//
+// It exists because that question previously had TWO answers. This package's
+// auth probe learned about per-UID agent homes; the dashboard's model-discovery
+// probe did not, and kept stat'ing only the shared path. On a per-UID fleet the
+// two disagreed and the operator got a self-contradicting UI — "✓ logged in"
+// beside a model list where every entry read "(common alias, unverified)".
+
+// withTestAgentHomes redirects the per-agent home root at a temp dir so these
+// tests never depend on a real /data volume.
+func withTestAgentHomes(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	orig := sharedAgentHome
+	sharedAgentHome = root
+	t.Cleanup(func() { sharedAgentHome = orig })
+	return root
+}
+
+func claudeAgent(name string, uid int) *AgentProcess {
+	return &AgentProcess{Name: name, UID: uid, Config: config.AgentConfig{Backend: "claude"}}
+}
+
+func indexOfPath(paths []string, want string) int {
+	for i, p := range paths {
+		if p == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestClaudeCredentialCandidatePathsPerUIDFirst is the fix: the per-UID home an
+// agent's own CLI writes to must be tried BEFORE the shared legacy path. On a
+// per-UID spoke the shared path is empty while the agent is authenticated, so
+// ordering is what separates "found the token" from the all-unverified list.
+func TestClaudeCredentialCandidatePathsPerUIDFirst(t *testing.T) {
+	withTestAgentHomes(t)
+	m := testManager(4)
+	m.agents["scanner"] = claudeAgent("scanner", 2007)
+
+	paths := m.ClaudeCredentialCandidatePaths()
+
+	perUID := filepath.Join(AgentHome("scanner", 2007, "claude"), ".claude", ".credentials.json")
+	pi, si := indexOfPath(paths, perUID), indexOfPath(paths, sharedClaudeCredentialPath)
+	if pi < 0 {
+		t.Fatalf("per-UID path %q absent from %v — this is the #4699 bug", perUID, paths)
+	}
+	if si < 0 {
+		t.Fatalf("shared path absent from %v", paths)
+	}
+	if pi > si {
+		t.Errorf("per-UID path at %d comes AFTER the shared path at %d — the agent's own credential must win", pi, si)
+	}
+}
+
+// TestClaudeCredentialCandidatePathsMatchesAuthProbe pins the anti-drift
+// property that is the whole reason this helper exists: whatever
+// agentClaudeCredentialPaths would try for an agent, the backend-level list
+// must also try. If these two ever diverge again, the dashboard and the agent
+// card go back to disagreeing.
+func TestClaudeCredentialCandidatePathsMatchesAuthProbe(t *testing.T) {
+	withTestAgentHomes(t)
+	m := testManager(4)
+	m.agents["scanner"] = claudeAgent("scanner", 2007)
+
+	got := m.ClaudeCredentialCandidatePaths()
+	for _, want := range agentClaudeCredentialPaths("scanner", 2007, "claude") {
+		if indexOfPath(got, want) < 0 {
+			t.Errorf("auth probe would try %q but model discovery would not — the two probes have drifted (%v)", want, got)
+		}
+	}
+}
+
+// TestClaudeCredentialCandidatePathsNoAgents: a hive whose agents have not
+// started yet still has a shared login worth checking.
+func TestClaudeCredentialCandidatePathsNoAgents(t *testing.T) {
+	withTestAgentHomes(t)
+	m := testManager(4)
+
+	got := m.ClaudeCredentialCandidatePaths()
+	if len(got) != 1 || got[0] != sharedClaudeCredentialPath {
+		t.Errorf("got %v, want just the shared path — an agentless hive must still probe it", got)
+	}
+}
+
+// TestClaudeCredentialCandidatePathsNilManager: callers without an agent
+// manager must be no worse off than before the change.
+func TestClaudeCredentialCandidatePathsNilManager(t *testing.T) {
+	var m *Manager
+	got := m.ClaudeCredentialCandidatePaths()
+	if len(got) != 1 || got[0] != sharedClaudeCredentialPath {
+		t.Errorf("got %v, want the shared path alone (pre-per-UID behavior)", got)
+	}
+}
+
+// TestClaudeCredentialCandidatePathsSkipsOtherBackends: a copilot agent's home
+// holds no claude credential, so probing it is a wasted stat that would also
+// make the list grow with every unrelated agent.
+func TestClaudeCredentialCandidatePathsSkipsOtherBackends(t *testing.T) {
+	withTestAgentHomes(t)
+	m := testManager(4)
+	m.agents["ci"] = &AgentProcess{Name: "ci", UID: 2010, Config: config.AgentConfig{Backend: "copilot"}}
+
+	got := m.ClaudeCredentialCandidatePaths()
+	for _, p := range got {
+		if strings.Contains(p, "/ci/") {
+			t.Errorf("copilot agent's home %q probed for a claude credential (%v)", p, got)
+		}
+	}
+}
+
+// TestClaudeCredentialCandidatePathsHonoursBackendOverride: an agent overridden
+// to claude at runtime is a claude agent for this purpose — the same
+// effective-backend rule the auth probe applies.
+func TestClaudeCredentialCandidatePathsHonoursBackendOverride(t *testing.T) {
+	withTestAgentHomes(t)
+	m := testManager(4)
+	m.agents["quality"] = &AgentProcess{
+		Name: "quality", UID: 2011,
+		Config:          config.AgentConfig{Backend: "copilot"},
+		BackendOverride: "claude",
+	}
+
+	got := m.ClaudeCredentialCandidatePaths()
+	want := filepath.Join(AgentHome("quality", 2011, "claude"), ".claude", ".credentials.json")
+	if indexOfPath(got, want) < 0 {
+		t.Errorf("override to claude not honoured: %q absent from %v", want, got)
+	}
+}
+
+// TestClaudeCredentialCandidatePathsDeterministic: m.agents iterates randomly,
+// so without sorting the probe would consult a different credential per call —
+// making an expired token an intermittent failure and this suite flaky.
+func TestClaudeCredentialCandidatePathsDeterministic(t *testing.T) {
+	withTestAgentHomes(t)
+	m := testManager(4)
+	for _, n := range []string{"scanner", "quality", "guide", "ci-maintainer"} {
+		m.agents[n] = claudeAgent(n, 2000+len(n))
+	}
+
+	first := strings.Join(m.ClaudeCredentialCandidatePaths(), "\n")
+	for i := 0; i < 20; i++ {
+		if got := strings.Join(m.ClaudeCredentialCandidatePaths(), "\n"); got != first {
+			t.Fatalf("order changed between calls:\n%s\nvs\n%s", first, got)
+		}
+	}
+}
+
+// TestClaudeCredentialCandidatePathsDedupes: under HIVE_SHARED_AGENT_HOME every
+// agent resolves to the same home, so without dedup the list would repeat one
+// path per agent and the probe would stat it N times.
+func TestClaudeCredentialCandidatePathsDedupes(t *testing.T) {
+	withTestAgentHomes(t)
+	t.Setenv("HIVE_SHARED_AGENT_HOME", "1")
+	m := testManager(4)
+	for _, n := range []string{"scanner", "quality", "guide"} {
+		m.agents[n] = claudeAgent(n, 2000+len(n))
+	}
+
+	got := m.ClaudeCredentialCandidatePaths()
+	seen := map[string]bool{}
+	for _, p := range got {
+		if seen[p] {
+			t.Errorf("duplicate path %q in %v", p, got)
+		}
+		seen[p] = true
+	}
+}

--- a/src/pkg/dashboard/cli_models.go
+++ b/src/pkg/dashboard/cli_models.go
@@ -947,12 +947,29 @@ var anthropicModelsEndpoint = anthropicModelsURL
 // returns fallback=true with an empty list so the caller substitutes the
 // static list. The stored token is NEVER refreshed here (see file header).
 func (s *Server) discoverClaudeModels() cliModelResult {
-	header, value, ok := claudeAPICredential()
+	candidates := s.agentClaudeCredentialPaths()
+	header, value, ok := claudeAPICredential(candidates)
 	if !ok {
 		// No API key and no fresh OAuth token. Skip the HTTP call entirely —
 		// on copilot-only spokes the credentials file can sit expired for
 		// weeks, and refreshing it is forbidden (it would rotate the token
 		// out from under the claude CLI's own login).
+		//
+		// #4699: this return used to be SILENT while the credential-found-
+		// but-call-failed path below logged, so from outside the process the
+		// two causes of an all-"unverified" dropdown were indistinguishable —
+		// and the silent one is the likelier. Naming the paths that were
+		// actually stat'ed is the whole diagnostic: it distinguishes "no
+		// credential anywhere" from "looked in the wrong home". Paths only —
+		// never the token.
+		// Guarded: unlike the failure path below, this branch is the COMMON
+		// one, so a manager-less embedding with no logger must not start
+		// panicking on it.
+		if s.logger != nil {
+			s.logger.Info("claude model discovery: no usable credential, using the static alias list",
+				"paths_tried", strings.Join(claudeCredentialCandidatePaths(candidates), ", "),
+				"anthropic_api_key_set", os.Getenv("ANTHROPIC_API_KEY") != "")
+		}
 		return cliModelResult{fallback: true}
 	}
 	models, err := fetchClaudeModels(anthropicModelsEndpoint, header, value)
@@ -971,11 +988,13 @@ func (s *Server) discoverClaudeModels() cliModelResult {
 // the freshest non-expired OAuth access token from the Claude CLI credentials
 // file is used as a bearer. ok=false means no usable credential. Secret —
 // never log the value.
-func claudeAPICredential() (header, value string, ok bool) {
+// agentPaths are per-UID agent credential locations resolved by the agent
+// manager; nil is valid and reduces this to the pre-#4699 shared-path probe.
+func claudeAPICredential(agentPaths []string) (header, value string, ok bool) {
 	if k := os.Getenv("ANTHROPIC_API_KEY"); k != "" {
 		return "x-api-key", k, true
 	}
-	for _, path := range claudeCredentialCandidatePaths() {
+	for _, path := range claudeCredentialCandidatePaths(agentPaths) {
 		if tok := readFreshClaudeToken(path); tok != "" {
 			return "Authorization", "Bearer " + tok, true
 		}
@@ -983,20 +1002,58 @@ func claudeAPICredential() (header, value string, ok bool) {
 	return "", "", false
 }
 
-// claudeCredentialCandidatePaths returns the credentials-file locations to
-// try, in order: the hosted-pod shared home (the same /data/home the agent
-// manager uses for agent homes), then $HOME/.claude/.credentials.json for
-// non-hosted spokes. Computed per call — never cached — because the claude
-// CLI rewrites the file whenever it runs and the probe must see the freshest
-// token.
-func claudeCredentialCandidatePaths() []string {
-	paths := []string{claudePodCredentialsPath}
+// agentClaudeCredentialPaths asks the agent manager where the fleet's claude
+// credentials actually live, so model discovery resolves them exactly the way
+// the auth probe does (#4699). Returns nil when there is no manager — tests and
+// any manager-less embedding then keep the previous shared-path-only behavior.
+func (s *Server) agentClaudeCredentialPaths() []string {
+	if s == nil || s.deps == nil || s.deps.AgentMgr == nil {
+		return nil
+	}
+	return s.deps.AgentMgr.ClaudeCredentialCandidatePaths()
+}
+
+// claudeCredentialCandidatePaths returns the credentials-file locations to try.
+//
+// agentPaths come first (#4699). They are the PER-UID homes the agents' own
+// CLIs write to, and on a per-UID fleet they are the only place a token exists:
+// this probe previously stat'ed just the two shared locations below, so it
+// reported "no credential" — an all-"unverified" model dropdown — on hives
+// where pkg/agent's probe simultaneously reported the agent logged in, because
+// only that one had been taught about per-UID homes.
+//
+// Then the hosted-pod shared home (the same /data/home the agent manager uses),
+// then $HOME/.claude/.credentials.json for non-hosted spokes. Note that $HOME
+// here is the DASHBOARD process's home, which is why it cannot stand in for an
+// agent's.
+//
+// Computed per call — never cached — because the claude CLI rewrites the file
+// whenever it runs and the probe must see the freshest token.
+func claudeCredentialCandidatePaths(agentPaths []string) []string {
+	paths := make([]string, 0, len(agentPaths)+2)
+	for _, p := range agentPaths {
+		if p != "" && !containsString(paths, p) {
+			paths = append(paths, p)
+		}
+	}
+	if !containsString(paths, claudePodCredentialsPath) {
+		paths = append(paths, claudePodCredentialsPath)
+	}
 	if home := os.Getenv("HOME"); home != "" {
-		if p := filepath.Join(home, ".claude", ".credentials.json"); p != claudePodCredentialsPath {
+		if p := filepath.Join(home, ".claude", ".credentials.json"); !containsString(paths, p) {
 			paths = append(paths, p)
 		}
 	}
 	return paths
+}
+
+func containsString(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
 }
 
 // readFreshClaudeToken reads and parses one credentials file and returns its

--- a/src/pkg/dashboard/cli_models_agent_creds_test.go
+++ b/src/pkg/dashboard/cli_models_agent_creds_test.go
@@ -1,0 +1,132 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/claude"
+)
+
+// cli_models_agent_creds_test.go pins the #4699 fix on the dashboard side:
+// model discovery must find a credential that exists ONLY in a per-agent home.
+//
+// The operator-visible symptom was a self-contradicting dashboard — the agent
+// card showing "✓ logged in" (from pkg/agent's per-UID-aware probe) beside a
+// model dropdown where every entry read "(common alias, unverified)" (from this
+// probe, which knew only the shared path).
+
+// writeCredsAt writes a credentials file in the CLI's on-disk shape at path.
+func writeCredsAt(t *testing.T, path, token string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(claude.Credentials{ClaudeAIOAuth: &claude.OAuthTokens{
+		AccessToken: token,
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestClaudeAPICredentialFindsPerAgentToken is the regression itself. The token
+// lives only where a per-UID agent's own CLI would have written it: nothing is
+// at the shared path, and nothing is under the DASHBOARD process's $HOME.
+//
+// Before the fix the probe consulted only those two, found nothing, and
+// returned "no credential" — the all-unverified dropdown — on a hive that was
+// fully authenticated.
+func TestClaudeAPICredentialFindsPerAgentToken(t *testing.T) {
+	withoutClaudeCredentials(t) // shared path and $HOME both empty
+
+	agentHome := t.TempDir()
+	agentCreds := filepath.Join(agentHome, ".claude", ".credentials.json")
+	writeCredsAt(t, agentCreds, "per-agent-token")
+
+	// The pre-fix probe: shared paths only.
+	if _, _, ok := claudeAPICredential(nil); ok {
+		t.Fatal("precondition: no credential should be reachable without the agent paths")
+	}
+
+	header, value, ok := claudeAPICredential([]string{agentCreds})
+	if !ok {
+		t.Fatal("per-agent credential not found — #4699 has regressed")
+	}
+	if header != "Authorization" {
+		t.Errorf("header = %q, want Authorization (subscription OAuth bearer, not an API key)", header)
+	}
+	if value != "Bearer per-agent-token" {
+		t.Errorf("value = %q, want the per-agent token as a bearer", value)
+	}
+}
+
+// TestClaudeCredentialCandidatePathsOrdersAgentPathsFirst: the per-UID file is
+// the one the agent's CLI actually writes, so it must be consulted before the
+// shared legacy path — the same ordering pkg/agent's probe uses.
+func TestClaudeCredentialCandidatePathsOrdersAgentPathsFirst(t *testing.T) {
+	withoutClaudeCredentials(t)
+	agentPath := filepath.Join(t.TempDir(), ".claude", ".credentials.json")
+
+	got := claudeCredentialCandidatePaths([]string{agentPath})
+
+	if len(got) == 0 || got[0] != agentPath {
+		t.Fatalf("got %v, want the agent path first", got)
+	}
+	var sawShared bool
+	for _, p := range got {
+		if p == claudePodCredentialsPath {
+			sawShared = true
+		}
+	}
+	if !sawShared {
+		t.Errorf("shared path dropped from %v — a correctly-bridged hive must still work", got)
+	}
+}
+
+// TestClaudeCredentialCandidatePathsNilAgentPathsUnchanged: a manager-less
+// embedding keeps exactly the pre-#4699 behavior.
+func TestClaudeCredentialCandidatePathsNilAgentPathsUnchanged(t *testing.T) {
+	withoutClaudeCredentials(t)
+
+	got := claudeCredentialCandidatePaths(nil)
+	if len(got) == 0 || got[0] != claudePodCredentialsPath {
+		t.Fatalf("got %v, want the shared pod path first", got)
+	}
+}
+
+// TestClaudeCredentialCandidatePathsDedupes: the agent manager may hand back a
+// path that equals the shared one (a shared-home hive), and stat'ing it twice
+// is pure waste.
+func TestClaudeCredentialCandidatePathsDedupes(t *testing.T) {
+	withoutClaudeCredentials(t)
+
+	got := claudeCredentialCandidatePaths([]string{claudePodCredentialsPath, claudePodCredentialsPath})
+	seen := map[string]bool{}
+	for _, p := range got {
+		if seen[p] {
+			t.Errorf("duplicate %q in %v", p, got)
+		}
+		seen[p] = true
+	}
+}
+
+// TestClaudeAPICredentialPrefersAPIKey: ANTHROPIC_API_KEY still wins over any
+// file. The per-UID search must not have reordered the documented precedence.
+func TestClaudeAPICredentialPrefersAPIKey(t *testing.T) {
+	withoutClaudeCredentials(t)
+	agentCreds := filepath.Join(t.TempDir(), ".claude", ".credentials.json")
+	writeCredsAt(t, agentCreds, "per-agent-token")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+
+	header, value, ok := claudeAPICredential([]string{agentCreds})
+	if !ok || header != "x-api-key" || value != "sk-test" {
+		t.Errorf("got (%q, %q, %v), want the API key to win", header, value, ok)
+	}
+}

--- a/src/pkg/dashboard/cli_models_claude_test.go
+++ b/src/pkg/dashboard/cli_models_claude_test.go
@@ -120,7 +120,7 @@ func TestClaudeAPICredential_EnvKeyPrecedence(t *testing.T) {
 	// A valid OAuth file exists, but ANTHROPIC_API_KEY must win with x-api-key.
 	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api-key")
-	header, value, ok := claudeAPICredential()
+	header, value, ok := claudeAPICredential(nil)
 	if !ok || header != "x-api-key" || value != "sk-ant-api-key" {
 		t.Fatalf("env key must win: got %q=%q ok=%v", header, value, ok)
 	}
@@ -129,7 +129,7 @@ func TestClaudeAPICredential_EnvKeyPrecedence(t *testing.T) {
 func TestClaudeAPICredential_OAuthBearerFromHome(t *testing.T) {
 	writeClaudeCredentials(t, "oauth-token", futureExpiryMs())
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	header, value, ok := claudeAPICredential()
+	header, value, ok := claudeAPICredential(nil)
 	if !ok || header != "Authorization" || value != "Bearer oauth-token" {
 		t.Fatalf("expected bearer from $HOME credentials: got %q=%q ok=%v", header, value, ok)
 	}
@@ -137,7 +137,7 @@ func TestClaudeAPICredential_OAuthBearerFromHome(t *testing.T) {
 
 func TestClaudeAPICredential_NoneAvailable(t *testing.T) {
 	withoutClaudeCredentials(t)
-	if _, _, ok := claudeAPICredential(); ok {
+	if _, _, ok := claudeAPICredential(nil); ok {
 		t.Fatal("no env key and no file must yield ok=false")
 	}
 }

--- a/src/pkg/dashboard/cli_models_claude_test.go
+++ b/src/pkg/dashboard/cli_models_claude_test.go
@@ -1,7 +1,9 @@
 package dashboard
 
 import (
+	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -248,6 +250,37 @@ func TestDiscoverClaudeModels_ExpiredSkipsHTTP(t *testing.T) {
 	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
 	if r := s.discoverClaudeModels(); !r.fallback {
 		t.Fatalf("expired token must fall back, got %+v", r)
+	}
+}
+
+func TestDiscoverClaudeModelsLogsDoNotLeakCredentials(t *testing.T) {
+	const oauthToken = "sk-ant-oat-do-not-log"
+	writeClaudeCredentials(t, oauthToken, time.Now().Add(-time.Hour).UnixMilli())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	var logs bytes.Buffer
+	s := &Server{
+		cliModels: newCLIModelCache(),
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+	if r := s.discoverClaudeModels(); !r.fallback {
+		t.Fatalf("expired token must fall back, got %+v", r)
+	}
+	if got := logs.String(); strings.Contains(got, oauthToken) || strings.Contains(got, "Bearer "+oauthToken) {
+		t.Fatalf("logs leaked credential material: %s", got)
+	}
+
+	logs.Reset()
+	const apiKey = "sk-ant-api-key-do-not-log"
+	t.Setenv("ANTHROPIC_API_KEY", apiKey)
+	ts := claudeModelsTestServer(t, http.StatusUnauthorized, `{"error":{"type":"authentication_error"}}`, nil)
+	redirectAnthropicEndpoint(t, ts.URL)
+
+	if r := s.discoverClaudeModels(); !r.fallback {
+		t.Fatalf("unauthorized API-key probe must fall back, got %+v", r)
+	}
+	if got := logs.String(); strings.Contains(got, apiKey) {
+		t.Fatalf("logs leaked API key material: %s", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #4699.

## The asymmetry

Two probes answer "is the claude backend authenticated on this hive?" and resolved paths differently. `pkg/agent/authprobe.go` was written specifically to fix per-UID resolution; `pkg/dashboard/cli_models.go` still carried the pre-fix logic — so the operator sees **"✓ logged in"** on the agent card beside a model dropdown where every entry reads **"(common alias, unverified)"**.

`claudeCredentialCandidatePaths` returned exactly two paths: the shared `/data/home/...`, and `$HOME/.claude/.credentials.json` — where `$HOME` is the **dashboard process's** home, not any agent's. No agent home was ever consulted.

## The fix: one helper, not a second copy

The issue offered "patch it" or "factor it out", and noted the recurrence of this bug in a second location is itself the argument for de-duplicating. I took that: `Manager.ClaudeCredentialCandidatePaths` in `pkg/agent` is now the single answer, and model discovery consumes it. The ordering rule — per-UID homes first (the file the agent's CLI actually writes), shared legacy path last — lives in exactly one place.

`TestClaudeCredentialCandidatePathsMatchesAuthProbe` pins that anti-drift property directly: whatever `agentClaudeCredentialPaths` would try for an agent, the backend-level list must also try. If the two diverge again, that test fails rather than an operator filing this issue a third time.

Design points worth a look:

- **Backend-level, so any agent's fresh token answers it.** A model catalog is a property of the provider, not of the agent that asked — the issue's "first-fresh-token-wins is fine".
- **Deterministic order.** `m.agents` iterates randomly, so agents are sorted by name. Without this the probe would consult a different credential per call, making an expired token an *intermittent* failure and the suite flaky.
- **Nil manager → shared path alone**, i.e. exactly the pre-change behavior, so manager-less embeddings and existing tests are unaffected.
- Backend override honoured, non-claude agents skipped, paths deduped.

## The silent return

The no-credential path returned `fallback: true` **without logging**, while the credential-found-but-call-failed path logged — so from outside the process the two causes of an all-unverified dropdown were indistinguishable, and the silent one is the likelier. It now logs the paths actually stat'ed, which is precisely what separates *"no credential anywhere"* from *"looked in the wrong home"*.

Paths only, never the token. Guarded on a nil logger, because unlike the existing failure log this branch is the **common** one and must not become a new panic surface for a manager-less embedding.

## Verification

The headline test is the bug: a token written **only** where a per-UID agent's CLI would put it, with the shared path and `$HOME` both empty. `claudeAPICredential(nil)` (pre-fix behavior) finds nothing; the fixed call finds it as an OAuth bearer — which also confirms the issue's point that an API key is *not* required for a subscription login.

Verified load-bearing by mutation rather than assumed: dropping the agent paths from the candidate list fails both `FindsPerAgentToken` and `OrdersAgentPathsFirst`.

```
go build ./...                                    ok
go vet ./pkg/agent/ ./pkg/dashboard/              ok
gofmt -l (changed files)                          clean
go test ./pkg/dashboard/                          ok (full package)
go test ./pkg/agent/                              see note
```

**Note on the agent package:** the full run showed one failure, `TestSendKick_RestartsCrashedCLIThenDelivers`, which spawns real tmux and waits for a CLI to become ready. It passes in isolation (17s, 19s on two consecutive runs) and failed only under full-suite load at 67s — a resource-contention timeout, and unrelated to this change, which touches credential path resolution and one log line. Flagging it rather than burying it.

## Deliberately not in scope

- The copilot/goose probes hardcode `HOME=/data/home` the same way (`cli_models.go:142`, `:228`). The issue raises these as *"consider whether"* rather than a report, and they are different credential shapes — better as their own PR than smuggled in here.
- Distinguishing *"no credential to verify with"* from *"checked and unknown"* in the dropdown label is a UI change in `index.html`; the log above already makes the state diagnosable, which was the issue's stated minimum.

## One thing the issue asked for that I could not do

The issue's verification note asks for `podman exec <hive-container> ls -l /data/home/.claude/.credentials.json` on the affected host to confirm this divergence produced *that* operator's screenshot, versus a found-but-expired credential. I have no access to that host. The asymmetry between the two probes is verifiable in-tree and is a defect on its own terms — which is what this PR fixes — but if that check comes back *present*, the operator's specific symptom is the other cause and needs its own issue. The new log makes that check answerable from the logs next time instead of by hand.

— hive: backend=claude model=claude-opus-5