### PR TITLE
🐛 Provision requests: show user ID, demote native provider subject

### DIFF
--- a/src/pkg/hub/clickable_avatars_test.go
+++ b/src/pkg/hub/clickable_avatars_test.go
@@ -23,8 +23,8 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 		{"inline per-hive faces", "return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX,"},
 		{"status-dot hover panel rows", "linkedAvatar(a.username, PANEL_ACCESS_AVATAR_PX,"},
 		{"per-hive pending request rows", "var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');"},
-		{"past requests table", "linkedAvatar(uname, PANEL_ACCESS_AVATAR_PX, uname, 'margin-right:6px')"},
-		{"pending provision cards", "var avatar = linkedAvatar(pr.username, TABLE_AVATAR_PX, pr.username, 'margin-right:8px');"},
+		{"past requests table", "provisionRequesterAvatar(pr, PANEL_ACCESS_AVATAR_PX, 'margin-right:6px')"},
+		{"pending provision cards", "var avatar = provisionRequesterAvatar(pr, TABLE_AVATAR_PX, 'margin-right:8px');"},
 		// The admin users table routes GitHub users through linkedAvatar and OIDC
 		// users through userAvatar (stored provider avatar / initials from the
 		// real display name — provider:sub is not a github.com login).

--- a/src/pkg/hub/hub_filesystem_test.go
+++ b/src/pkg/hub/hub_filesystem_test.go
@@ -350,13 +350,15 @@ func TestProvisionRequestCRUD(t *testing.T) {
 	defer cleanup()
 
 	pr := &ProvisionRequest{
-		Username:    "prov-user",
-		Org:         "myorg",
-		Repos:       "repo1",
-		PrimaryRepo: "repo1",
-		ACMMLevel:   2,
-		RequestedAt: "2024-01-01T00:00:00Z",
-		Status:      provisionStatusPending,
+		Username:     "prov-user",
+		UserID:       "prov-login",
+		UserIDSource: "github",
+		Org:          "myorg",
+		Repos:        "repo1",
+		PrimaryRepo:  "repo1",
+		ACMMLevel:    2,
+		RequestedAt:  "2024-01-01T00:00:00Z",
+		Status:       provisionStatusPending,
 	}
 	if err := saveProvisionRequest(pr); err != nil {
 		t.Fatalf("saveProvisionRequest: %v", err)
@@ -368,6 +370,12 @@ func TestProvisionRequestCRUD(t *testing.T) {
 	}
 	if loaded.Org != "myorg" {
 		t.Errorf("org = %q", loaded.Org)
+	}
+	if loaded.UserID != "prov-login" {
+		t.Errorf("user_id = %q, want %q", loaded.UserID, "prov-login")
+	}
+	if loaded.UserIDSource != "github" {
+		t.Errorf("user_id_source = %q, want %q", loaded.UserIDSource, "github")
 	}
 
 	// List

--- a/src/pkg/hub/provision_context_test.go
+++ b/src/pkg/hub/provision_context_test.go
@@ -134,17 +134,26 @@ func TestEnrichProvisionRequests(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("saveSaaSUser(alice): %v", err)
 	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "ibmid:650001ABCD", LinkedGitHubLogin: "jane-gh", Hives: map[string]string{
+		"hosted-oke-10": "owner",
+	}}); err != nil {
+		t.Fatalf("saveSaaSUser(ibmid): %v", err)
+	}
 	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "bob", Hives: map[string]string{}}); err != nil {
 		t.Fatalf("saveSaaSUser(bob): %v", err)
 	}
 
 	reqs := []ProvisionRequest{
 		{Username: "alice", Status: provisionStatusApproved, AssignedHive: "hosted-oke-06"},
+		{Username: "ibmid:650001ABCD", Status: provisionStatusPending, AssignedHive: "hosted-oke-10"},
 		{Username: "bob", Status: provisionStatusDenied, DenyReason: "no capacity"},
 		{Username: "ghost", Status: provisionStatusApproved, AssignedHive: "hosted-oke-99"},
 	}
 	got := enrichProvisionRequests(reqs)
 
+	if got[0].UserID != "alice" {
+		t.Errorf("alice user_id = %q, want %q", got[0].UserID, "alice")
+	}
 	if got[0].AssignedRole != "owner" {
 		t.Errorf("alice assigned_role = %q, want %q", got[0].AssignedRole, "owner")
 	}
@@ -152,18 +161,96 @@ func TestEnrichProvisionRequests(t *testing.T) {
 	if !reflect.DeepEqual(got[0].OtherHives, wantOther) {
 		t.Errorf("alice other_hives = %+v, want %+v", got[0].OtherHives, wantOther)
 	}
+	if got[1].UserID != "jane-gh" {
+		t.Errorf("linked OIDC request user_id = %q, want jane-gh", got[1].UserID)
+	}
+	if got[1].UserIDSource != "github" {
+		t.Errorf("linked OIDC request user_id_source = %q, want github", got[1].UserIDSource)
+	}
 	// A denial assigns nothing, so there is no role to show.
-	if got[1].AssignedRole != "" || got[1].OtherHives != nil {
-		t.Errorf("denied request enriched: role=%q other=%+v", got[1].AssignedRole, got[1].OtherHives)
+	if got[2].AssignedRole != "" || got[2].OtherHives != nil {
+		t.Errorf("denied request enriched: role=%q other=%+v", got[2].AssignedRole, got[2].OtherHives)
 	}
 	// A request whose requester has no user record must not invent access.
-	if got[2].AssignedRole != "" || got[2].OtherHives != nil {
-		t.Errorf("unknown requester enriched: role=%q other=%+v", got[2].AssignedRole, got[2].OtherHives)
+	if got[3].AssignedRole != "" || got[3].OtherHives != nil {
+		t.Errorf("unknown requester enriched: role=%q other=%+v", got[3].AssignedRole, got[3].OtherHives)
 	}
 
 	// Empty input must not blow up or read the roster.
 	if out := enrichProvisionRequests(nil); out != nil {
 		t.Errorf("enrichProvisionRequests(nil) = %+v, want nil", out)
+	}
+}
+
+func TestProvisionRequestUserIDPreference(t *testing.T) {
+	tests := []struct {
+		name            string
+		username        string
+		user            *SaaSUser
+		requestFullName string
+		want            string
+	}{
+		{
+			name:     "linked GitHub login beats raw IBMid subject",
+			username: "ibmid:650001ABCD",
+			user:     &SaaSUser{GitHubUsername: "ibmid:650001ABCD", LinkedGitHubLogin: "jane-gh", Email: "jane@example.com", DisplayName: "Jane Doe"},
+			want:     "jane-gh",
+		},
+		{
+			name:     "plain GitHub login is already a user id",
+			username: "octocat",
+			user:     &SaaSUser{GitHubUsername: "octocat", DisplayName: "The Octocat"},
+			want:     "octocat",
+		},
+		{
+			name:     "email beats opaque provider subject",
+			username: "ibmid:650001ABCD",
+			user:     &SaaSUser{GitHubUsername: "ibmid:650001ABCD", Email: "jane@example.com", DisplayName: "Jane Doe"},
+			want:     "jane@example.com",
+		},
+		{
+			name:     "display name beats opaque provider subject when no email",
+			username: "ibmid:650001ABCD",
+			user:     &SaaSUser{GitHubUsername: "ibmid:650001ABCD", DisplayName: "Jane Doe"},
+			want:     "Jane Doe",
+		},
+		{
+			name:            "request full name helps new records without stored claims",
+			username:        "ibmid:650001ABCD",
+			requestFullName: "Jane Doe",
+			want:            "Jane Doe",
+		},
+		{
+			name:     "fallback keeps native subject for old opaque records",
+			username: "ibmid:650001ABCD",
+			want:     "ibmid:650001ABCD",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := provisionRequestUserID(tt.username, tt.user, tt.requestFullName); got != tt.want {
+				t.Errorf("provisionRequestUserID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvisionRequestUserIDRenderingPinned(t *testing.T) {
+	checks := []string{
+		"function provisionRequesterPrimary(pr)",
+		"var id = String(pr.user_id || '').trim();",
+		"return id || String(pr.username || '').trim();",
+		"function provisionRequesterNativeSubject(pr)",
+		"title=\"Native provider subject\"",
+		"pr && pr.user_id_source === 'github'",
+		"var primary = provisionRequesterPrimary(pr);",
+		"provisionRequesterAvatar(pr, TABLE_AVATAR_PX, 'margin-right:8px')",
+		"provisionRequesterAvatar(pr, PANEL_ACCESS_AVATAR_PX, 'margin-right:6px')",
+	}
+	for _, snippet := range checks {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("dashboardHTML missing provision user-id render snippet %q", snippet)
+		}
 	}
 }
 

--- a/src/pkg/hub/request_contact_fields_test.go
+++ b/src/pkg/hub/request_contact_fields_test.go
@@ -110,6 +110,41 @@ func TestRequestProvisionPersistsContactFields(t *testing.T) {
 	}
 }
 
+func TestRequestProvisionPersistsFriendlyUserID(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	const user = "ibmid:650001ABCD"
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername:    user,
+		LinkedGitHubLogin: "jane-gh",
+		DisplayName:       "Jane Doe",
+		Email:             "jane@example.com",
+	}); err != nil {
+		t.Fatalf("saveSaaSUser: %v", err)
+	}
+	authAsForgeTester(t, "ghp_contact_userid", user)
+
+	w := postProvisionRequest(t, srv, "ghp_contact_userid",
+		helperContactRequestBody(t, "Jane Doe", "U01ABCDEF23"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body %s)", w.Code, w.Body.String())
+	}
+	pr := loadProvisionRequest(user)
+	if pr == nil {
+		t.Fatal("request was not persisted")
+	}
+	if pr.UserID != "jane-gh" {
+		t.Errorf("user_id = %q, want linked GitHub login %q", pr.UserID, "jane-gh")
+	}
+	if pr.UserIDSource != "github" {
+		t.Errorf("user_id_source = %q, want github", pr.UserIDSource)
+	}
+	if pr.Username != user {
+		t.Errorf("username = %q, want native subject %q", pr.Username, user)
+	}
+}
+
 // TestRequestProvisionCapsContactFields pins the length bounds to the SAME
 // constants the admin contact editor uses. Truncation, not rejection, matches
 // handleAdminUpdateUser's existing treatment of these two fields.

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -7463,6 +7463,14 @@ const maxProvisionRequestBodyBytes = 4 * 1024
 
 type ProvisionRequest struct {
 	Username string `json:"username"`
+	// UserID is the human-facing identifier admins should use when reviewing
+	// the request. Username remains the stable auth key/native provider subject
+	// (for example "ibmid:695000VVZ9"); UserID captures the meaningful login or
+	// identity available at request time so the review queue does not headline
+	// opaque SSO subjects. Empty on older records; enrichProvisionRequests fills
+	// it from the user record when possible, and the UI falls back to Username.
+	UserID       string `json:"user_id,omitempty"`
+	UserIDSource string `json:"user_id_source,omitempty"`
 	// GitHubHost is the GitHub instance the org lives on — empty means public
 	// github.com, otherwise a GitHub Enterprise host (github.ibm.com,
 	// github.cisco.com, …). Captured so an admin can see which instance a
@@ -7598,6 +7606,56 @@ func roleForUserOnHive(username, hiveID string, users []SaaSUser) string {
 	return ""
 }
 
+// provisionRequestUserIdentity chooses the operator-facing identifier for a
+// request, plus its source so the UI only links identifiers known to be GitHub
+// logins.
+// The raw request Username is the auth key and can be an opaque provider subject
+// ("ibmid:…"). Prefer a linked GitHub/GHE login when the user has one, then a
+// recognizable GitHub login, then email/name claims, and fall back to the auth
+// key only when no friendlier identity exists.
+func provisionRequestUserIdentity(username string, u *SaaSUser, requestFullName string) (id, source string) {
+	if u != nil {
+		if id := strings.TrimSpace(u.LinkedGitHubLogin); id != "" {
+			return id, "github"
+		}
+		if provider, subject := splitIdentityKey(strings.TrimSpace(u.GitHubUsername)); provider == "" || normalizeIdentityProvider(provider) == legacyProvider {
+			if subject != "" {
+				return subject, "github"
+			}
+		}
+		if id := strings.TrimSpace(u.Email); id != "" {
+			return id, "email"
+		}
+		if id := strings.TrimSpace(u.DisplayName); id != "" {
+			return id, "name"
+		}
+		if id := strings.TrimSpace(u.FullName); id != "" {
+			return id, "name"
+		}
+	}
+	if id := strings.TrimSpace(requestFullName); id != "" {
+		return id, "name"
+	}
+	if provider, subject := splitIdentityKey(strings.TrimSpace(username)); normalizeIdentityProvider(provider) == legacyProvider && subject != "" {
+		return subject, "github"
+	}
+	return strings.TrimSpace(username), "native"
+}
+
+func provisionRequestUserID(username string, u *SaaSUser, requestFullName string) string {
+	id, _ := provisionRequestUserIdentity(username, u, requestFullName)
+	return id
+}
+
+func provisionRequestUserFromRoster(username string, users []SaaSUser) *SaaSUser {
+	for i := range users {
+		if strings.EqualFold(users[i].GitHubUsername, username) {
+			return &users[i]
+		}
+	}
+	return nil
+}
+
 // enrichProvisionRequests fills in the derived AssignedRole / OtherHives fields
 // on every request in place.
 //
@@ -7614,6 +7672,13 @@ func enrichProvisionRequests(requests []ProvisionRequest) []ProvisionRequest {
 	}
 	users := listAllSaaSUsers()
 	for i := range requests {
+		if requests[i].UserID == "" {
+			requests[i].UserID, requests[i].UserIDSource = provisionRequestUserIdentity(requests[i].Username, provisionRequestUserFromRoster(requests[i].Username, users), requests[i].FullName)
+		} else if requests[i].UserIDSource == "" {
+			if requests[i].UserID == requests[i].Username {
+				requests[i].UserIDSource = "native"
+			}
+		}
 		requests[i].AssignedRole = roleForUserOnHive(requests[i].Username, requests[i].AssignedHive, users)
 		requests[i].OtherHives = hivesForUser(requests[i].Username, requests[i].AssignedHive, users)
 	}
@@ -7890,19 +7955,22 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	userID, userIDSource := provisionRequestUserIdentity(username, loadSaaSUser(username), body.FullName)
 	pr := &ProvisionRequest{
-		Username:    username,
-		GitHubHost:  body.GitHubHost,
-		Org:         body.Org,
-		Repos:       body.Repos,
-		PrimaryRepo: primaryRepo,
-		ACMMLevel:   acmm,
-		AuthMethod:  body.AuthMethod,
-		FullName:    body.FullName,
-		SlackID:     body.SlackID,
-		Country:     body.Country,
-		RequestedAt: time.Now().UTC().Format(time.RFC3339),
-		Status:      provisionStatusPending,
+		Username:     username,
+		UserID:       userID,
+		UserIDSource: userIDSource,
+		GitHubHost:   body.GitHubHost,
+		Org:          body.Org,
+		Repos:        body.Repos,
+		PrimaryRepo:  primaryRepo,
+		ACMMLevel:    acmm,
+		AuthMethod:   body.AuthMethod,
+		FullName:     body.FullName,
+		SlackID:      body.SlackID,
+		Country:      body.Country,
+		RequestedAt:  time.Now().UTC().Format(time.RFC3339),
+		Status:       provisionStatusPending,
 	}
 	if err := saveProvisionRequest(pr); err != nil {
 		http.Error(w, `{"error":"failed to save provision request"}`, http.StatusInternalServerError)
@@ -17581,10 +17649,43 @@ const dashboardHTML = `<!DOCTYPE html>
     // github.ibm.com means GitHub Enterprise — hardcoding github.com would send
     // an admin to a 404 (or worse, an unrelated public repo of the same name).
     // Requests with no repo recorded fall back to plain escaped text.
-    /* provisionRequesterLabel renders the requester's real name and Slack ID
-       beside their GitHub login on the review card. Mapping a login to a person
-       is the reason the wizard asks for a name at all, and this is where the
-       operator deciding the request needs it.
+    /* provisionRequesterPrimary returns the identifier admins should scan first
+       on provision-request rows. The durable request key (username) may be an
+       opaque native provider subject such as "ibmid:695000VVZ9"; user_id is the
+       GitHub/GHE login or best human-readable identity captured/enriched by the
+       server. Older records without user_id fall back to username. */
+    function provisionRequesterPrimary(pr) {
+      if (!pr) return '';
+      var id = String(pr.user_id || '').trim();
+      return id || String(pr.username || '').trim();
+    }
+
+    function provisionRequesterNativeSubject(pr) {
+      if (!pr) return '';
+      var native = String(pr.username || '').trim();
+      var primary = provisionRequesterPrimary(pr);
+      return native && primary && native !== primary ? native : '';
+    }
+
+    function provisionNativeSubjectChip(pr) {
+      var native = provisionRequesterNativeSubject(pr);
+      if (!native) return '';
+      return '<span title="Native provider subject" style="font-size:0.68rem;padding:1px 6px;border-radius:999px;border:1px solid var(--border);color:var(--muted);font-family:ui-monospace,monospace">' +
+        esc(native) + '</span>';
+    }
+
+    function provisionRequesterAvatar(pr, px, extraStyle) {
+      var primary = provisionRequesterPrimary(pr);
+      if (pr && pr.user_id_source === 'github') {
+        return linkedAvatar(primary, px, primary, extraStyle);
+      }
+      return userAvatar({display_name: primary, github_username: String((pr && pr.username) || '')}, px, extraStyle);
+    }
+
+    /* provisionRequesterLabel renders the requester's real name, Slack ID, and
+       native provider subject beside the primary user ID on the review card.
+       Mapping a login to a person is the reason the wizard asks for a name at
+       all, and this is where the operator deciding the request needs it.
 
        Both are free text a user typed. esc() everywhere, and the whole label is
        built as a text node's escaped HTML rather than interpolated into an
@@ -17595,10 +17696,14 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!pr) return '';
       var name = (pr.full_name || '').trim();
       var slack = (pr.slack_id || '').trim();
-      if (!name && !slack) return '';
+      var native = provisionRequesterNativeSubject(pr);
+      if (!name && !slack && !native) return '';
+      var primary = provisionRequesterPrimary(pr);
       var bits = [];
-      if (name) bits.push(esc(name));
+      if (name && name !== primary) bits.push(esc(name));
       if (slack) bits.push('slack: ' + esc(slack));
+      if (native) bits.push(provisionNativeSubjectChip(pr));
+      if (!bits.length) return '';
       return '<span style="font-size:0.75rem;color:var(--muted);margin-left:8px">' +
         bits.join(' &middot; ') + '</span>';
     }
@@ -17641,19 +17746,18 @@ const dashboardHTML = `<!DOCTYPE html>
       var rows = decided.map(function(pr) {
         var approved = pr.status === 'approved';
         var color = approved ? 'var(--green)' : 'var(--red)';
-        var uname = pr.username || '';
-        // Link the requester to their GitHub profile. Always github.com: a
-        // profile link is about the person, and the account that signed in to
-        // the hub is a github.com account even when the ORG they asked for
-        // lives on an Enterprise host.
+        var primary = provisionRequesterPrimary(pr);
+        // Link the requester avatar only when the server says the primary user
+        // ID is a GitHub login. Email/name fallbacks get an initials avatar
+        // instead, avoiding bogus github.com links for OIDC subjects.
         //
         // The AVATAR carries that link now. The username used to be a second
         // anchor to the same profile; two controls for one destination is noise,
         // so the name is plain text and the face is the affordance.
         var userCell =
-          linkedAvatar(uname, PANEL_ACCESS_AVATAR_PX, uname, 'margin-right:6px') +
-          (uname
-            ? '<span>' + esc(uname) + '</span>'
+          provisionRequesterAvatar(pr, PANEL_ACCESS_AVATAR_PX, 'margin-right:6px') +
+          (primary
+            ? '<span>' + esc(primary) + '</span>' + provisionRequesterLabel(pr)
             : '<span style="color:var(--muted)">—</span>');
         // Repo link, built by the shared provisionRepoLabel(): github_host is
         // empty for public github.com and otherwise a GitHub Enterprise host
@@ -17740,12 +17844,13 @@ const dashboardHTML = `<!DOCTYPE html>
       _provisionRequestsByUser = {};
       pending.forEach(function(pr) { _provisionRequestsByUser[pr.username] = pr; });
       var rows = pending.map(function(pr) {
-        var avatar = linkedAvatar(pr.username, TABLE_AVATAR_PX, pr.username, 'margin-right:8px');
+        var primary = provisionRequesterPrimary(pr);
+        var avatar = provisionRequesterAvatar(pr, TABLE_AVATAR_PX, 'margin-right:8px');
         return '<div style="display:flex;align-items:center;justify-content:space-between;padding:10px 14px;background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:8px">' +
           '<div style="display:flex;align-items:center;gap:8px">' +
           avatar +
           '<div>' +
-          '<span style="font-size:0.85rem;font-weight:600">' + esc(pr.username) + '</span>' +
+          '<span style="font-size:0.85rem;font-weight:600">' + esc(primary || pr.username) + '</span>' +
           // Who the requester actually IS. Mapping a login to a person is the
           // reason the wizard asks for a name, and this review card is where an
           // operator needs it. esc() only — free text, never markup.


### PR DESCRIPTION
## Summary
- add provision request user_id/user_id_source captured from linked GitHub login, GitHub login, email, or name
- enrich older request records from SaaSUser data while falling back to the native subject
- render Pending and Past Requests with user_id as primary and native provider subject as secondary audit chip

## Tests
- go test ./pkg/hub/... -count=1