### PR TITLE
fix(dashboard): state the budget window phase and answer it in the Cost panel

### DIFF
--- a/src/pkg/dashboard/budget_phase_ui_test.go
+++ b/src/pkg/dashboard/budget_phase_ui_test.go
@@ -1,0 +1,130 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4686: an operator who configured "1B tokens every 2 days" asked two things
+// the dashboard could not answer — WHEN does the window reset (the phase, not a
+// countdown), and how much had been spent at each past reset — and asked them
+// from the Cost panel, where the answer did not exist at all.
+//
+// The data and the per-window chart already existed (#4298/#4320) but lived
+// only under Governor, and the reset was rendered solely as "37h until reset",
+// which cannot be lined up against a calendar. These tests pin both halves of
+// the fix: the phase is stated absolutely, and the Cost panel answers the
+// token-budget question in tokens.
+
+// TestBudgetWindowPhaseIsStatedAbsolutely pins the phase fix. A countdown alone
+// is what #4686 reported as unanswerable.
+func TestBudgetWindowPhaseIsStatedAbsolutely(t *testing.T) {
+	html := indexHTML(t)
+
+	for _, def := range []string{
+		"function budgetWindowBounds(",
+		"function budgetWindowPhaseText(",
+		"function budgetWindowPhaseTitle(",
+		"function fmtWindowStamp(",
+	} {
+		if !strings.Contains(html, def) {
+			t.Errorf("index.html does not define %q — a referenced-but-undefined name throws at render time", def)
+		}
+	}
+
+	// The absolute bounds come from the live status fields, which are the only
+	// source that knows when THIS window opened.
+	for _, field := range []string{"WINDOW_STARTS_AT", "WINDOW_ENDS_AT"} {
+		if !strings.Contains(html, field) {
+			t.Errorf("index.html never reads %s — the window phase cannot be derived without it", field)
+		}
+	}
+
+	// The budget bar must render the phase helper rather than a bare countdown.
+	if !strings.Contains(html, "budgetWindowPhaseText(budget, hoursLeft)") {
+		t.Error("the budget bar does not render the phase — #4686's 'I want to know the phase' is unanswered")
+	}
+	if strings.Contains(html, "<span>${hoursLeft}h until reset</span>") {
+		t.Error("the budget bar still shows only the bare countdown — a countdown cannot be compared against a calendar")
+	}
+}
+
+// TestBudgetPhaseToleratesMissingBounds: WINDOW_STARTS_AT/ENDS_AT are optional
+// (empty until a limit is set and a window has opened). Rendering "Invalid Date"
+// at an operator would be worse than the countdown this replaced, so the
+// fallback must be present.
+func TestBudgetPhaseToleratesMissingBounds(t *testing.T) {
+	html := indexHTML(t)
+
+	if !strings.Contains(html, "if (!start && !end) return `${hoursLeft}h until reset`;") {
+		t.Error("budgetWindowPhaseText has no no-bounds fallback — an unopened window would render Invalid Date")
+	}
+	if !strings.Contains(html, "isNaN(d.getTime()) ? null : d") {
+		t.Error("budgetWindowBounds does not reject unparseable timestamps")
+	}
+}
+
+// TestCostPanelAnswersTokenBudget is the discoverability half. The operator went
+// to the Cost panel; the token budget must be answerable there.
+func TestCostPanelAnswersTokenBudget(t *testing.T) {
+	html := indexHTML(t)
+
+	if !strings.Contains(html, "function costTokenBudgetHtml(") {
+		t.Fatal("index.html does not define costTokenBudgetHtml")
+	}
+	if !strings.Contains(html, "${costTokenBudgetHtml()}") {
+		t.Error("the Cost panel never renders the token budget — #4686 was filed from that panel")
+	}
+
+	// It must reuse the SAME window history the Governor chart draws. A second
+	// source of truth here would let the two panels disagree about the same
+	// budget, which is the class of bug #4699 was.
+	if !strings.Contains(html, "${budgetHistoryChart()}\n        </div>\n      </div>`;") &&
+		!strings.Contains(html, "budgetHistoryChart()") {
+		t.Error("the Cost panel does not reuse budgetHistoryChart — per-reset spend would be missing or duplicated")
+	}
+	if !strings.Contains(html, "window._lastBudget") {
+		t.Error("the Cost panel does not read _lastBudget — it could disagree with the Governor bar")
+	}
+}
+
+// TestCostPanelSaysDollarsAreNotTheLimit pins the unit correction. The reporter
+// discarded every dollar figure because the hive does not know the true price
+// and does not regulate on dollars — so a Cost panel that shows only dollars
+// must say what the limit IS denominated in.
+func TestCostPanelSaysDollarsAreNotTheLimit(t *testing.T) {
+	html := indexHTML(t)
+
+	if !strings.Contains(html, "tokens, not dollars") {
+		t.Error("the Cost panel does not distinguish the enforced token limit from the dollar estimates")
+	}
+	// With no budget configured the panel must say so and point at the setting,
+	// rather than silently showing nothing — "I did not find answers" was the
+	// report, and an empty panel reproduces it.
+	if !strings.Contains(html, "No token budget configured") {
+		t.Error("the Cost panel is silent when no token budget is set — the operator cannot tell configured-and-zero from unconfigured")
+	}
+}
+
+// TestBudgetPhaseAddsNoInlineHandlers guards the CSP contract (#3848/ADR-0016)
+// for the markup added here: script-src-attr is 'none', so an inline on*=
+// attribute is dead on arrival and its control silently does nothing.
+func TestBudgetPhaseAddsNoInlineHandlers(t *testing.T) {
+	html := indexHTML(t)
+
+	start := strings.Index(html, "function costTokenBudgetHtml(")
+	if start < 0 {
+		t.Fatal("costTokenBudgetHtml not found")
+	}
+	end := strings.Index(html[start:], "function renderCost(")
+	if end < 0 {
+		t.Fatal("could not bound costTokenBudgetHtml")
+	}
+	block := html[start : start+end]
+
+	for _, attr := range []string{" onclick=", " onchange=", " oninput=", " onkeyup=", " onmouseover="} {
+		if strings.Contains(block, attr) {
+			t.Errorf("costTokenBudgetHtml emits an inline %q handler, which CSP blocks — wire it through data-action dispatch", strings.TrimSpace(attr))
+		}
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -7274,6 +7274,49 @@
       </div>`;
     }
 
+    // ── Budget window PHASE (#4686) ─────────────────────────────────────────
+    // "37h until reset" says how long is left but never says WHEN — and an
+    // operator who configured "1B tokens every 2 days" is asking exactly that:
+    // which 2-day window am I in, and when does the next one start? A countdown
+    // cannot be lined up against a calendar, so the absolute bounds are stated
+    // and the countdown kept as the at-a-glance number.
+    //
+    // WINDOW_STARTS_AT / WINDOW_ENDS_AT are RFC3339 from the live status and
+    // are both optional — they are empty until a limit is set and a window has
+    // opened. Every caller must survive that, so these degrade to the bare
+    // countdown rather than rendering "Invalid Date".
+    function budgetWindowBounds(budget) {
+      const parse = (s) => {
+        if (!s) return null;
+        const d = new Date(s);
+        return isNaN(d.getTime()) ? null : d;
+      };
+      return { start: parse(budget && budget.WINDOW_STARTS_AT), end: parse(budget && budget.WINDOW_ENDS_AT) };
+    }
+
+    // fmtWindowStamp keeps the inline label short — a full toLocaleString() on
+    // both ends does not fit the budget bar. The tooltip carries the full,
+    // unambiguous timestamps.
+    function fmtWindowStamp(d) {
+      return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+    }
+
+    function budgetWindowPhaseText(budget, hoursLeft) {
+      const { start, end } = budgetWindowBounds(budget);
+      if (!start && !end) return `${hoursLeft}h until reset`;
+      if (start && end) return `Window ${fmtWindowStamp(start)} → ${fmtWindowStamp(end)} · ${hoursLeft}h left`;
+      return `Resets ${fmtWindowStamp(end || start)} · ${hoursLeft}h left`;
+    }
+
+    function budgetWindowPhaseTitle(budget) {
+      const { start, end } = budgetWindowBounds(budget);
+      if (!start && !end) return 'The budget window has not opened yet — it opens when a token limit is set and the governor first evaluates.';
+      const parts = [];
+      if (start) parts.push(`This window opened ${start.toLocaleString()}`);
+      if (end) parts.push(`spend resets to 0 at ${end.toLocaleString()}`);
+      return parts.join('; ') + '. Window length is governor.budget.period_days.';
+    }
+
     function renderBudgetBar(budget) {
       if (!budget || !budget.BUDGET_WEEKLY) return '';
       const PCT_SAFE = 50;
@@ -7314,7 +7357,7 @@
       return `<div class="budget-bar">
         <div class="budget-bar-label">
           <span>Used: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${pctUsed}%)${ignoreCheck}</span>
-          <span>${hoursLeft}h until reset</span>
+          <span title="${esc(budgetWindowPhaseTitle(budget))}">${budgetWindowPhaseText(budget, hoursLeft)}</span>
         </div>
         <div class="budget-bar-track"><div class="budget-bar-fill ${usedFillCls}" style="width:${Math.min(pctUsed, 100)}%"></div></div>
         <div style="display:flex;justify-content:space-between;font-size:0.68rem;color:var(--muted);margin-top:4px">
@@ -8489,6 +8532,47 @@ function burnAreaChart() {
       return rows.slice().sort((a, b) => costCmp(a, b, s.key, s.dir, fallback));
     }
 
+    // costTokenBudgetHtml renders the TOKEN budget inside the Cost panel (#4686).
+    //
+    // The budget bar and the per-window history already existed, but only under
+    // Governor. An operator asking "how close is this hive to my token budget?"
+    // opens 💵 Cost — and found all-time dollar estimates and cumulative token
+    // tables, none of which answer it. Worse, the answer is denominated in the
+    // wrong unit: a hive with a token budget does not regulate on dollars and
+    // does not know the true price, so the dollar figures are explicitly not
+    // what the limit is enforced against.
+    //
+    // This reuses the same /api/budget/history payload the Governor chart reads
+    // (fetched globally on an interval, so it is populated regardless of which
+    // section is open) rather than adding a second source of truth.
+    function costTokenBudgetHtml() {
+      // _lastBudget is the same object renderBudgetBar reads, refreshed on every
+      // status poll — so the Cost panel cannot disagree with the Governor bar.
+      const budget = window._lastBudget || null;
+      const limit = budget && budget.BUDGET_WEEKLY;
+      if (!limit) {
+        return `<div class="cost-subtitle" style="margin-top:10px">No token budget configured — set <b>Total Tokens</b> and <b>Period Days</b> under Settings → Governor to track spend against a limit. The figures above are dollar ESTIMATES and are not what any limit is enforced against.</div>`;
+      }
+      const used = budget.BUDGET_USED || 0;
+      const pctUsed = budget.BUDGET_PCT_USED || 0;
+      const hoursLeft = budget.HOURS_REMAINING || 0;
+      const exhausted = !!budget.BUDGET_EXHAUSTED;
+      const PCT_BUDGET_WARN = 90;
+      const fill = exhausted ? 'danger' : pctUsed >= PCT_BUDGET_WARN ? 'warning' : 'safe';
+      return `<div class="cost-token-budget" style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border)">
+        <div class="cost-subtitle" style="margin-bottom:6px"><b>Token budget</b> — this is the limit the governor actually enforces (tokens, not dollars). Spend resets to 0 at the end of each window.</div>
+        <div class="budget-bar">
+          <div class="budget-bar-label">
+            <span>Used this window: ${fmtTokens(used)} / ${fmtTokens(limit)} (${pctUsed}%)</span>
+            <span title="${esc(budgetWindowPhaseTitle(budget))}">${budgetWindowPhaseText(budget, hoursLeft)}</span>
+          </div>
+          <div class="budget-bar-track"><div class="budget-bar-fill ${fill}" style="width:${Math.min(pctUsed, 100)}%"></div></div>
+          ${exhausted ? '<div style="font-size:0.68rem;margin-top:3px;color:var(--red)">Budget exhausted — agent kicks are suspended until the window resets.</div>' : ''}
+          ${budgetHistoryChart()}
+        </div>
+      </div>`;
+    }
+
     function renderCost(cost) {
       const el = document.getElementById('cost-panel');
       if (!el) return;
@@ -8687,6 +8771,7 @@ function burnAreaChart() {
           ${sandboxTable}
           ${sessionTable}
           ${unpricedNote}
+          ${costTokenBudgetHtml()}
           <div class="cost-disclaimer">${esc(cost.disclaimer || '')} vLLM / self-hosted figures are estimated (reflect list price, not your infra cost).</div>
         </div>
       </div>`;


### PR DESCRIPTION
Fixes #4686.

## What I found first

Most of the answer already existed. **#4298/#4320** built the per-window history — one bar per window, the limit in force drawn as a marker, reset times on the x-axis — and `renderBudgetBar` shows used/limit and percent. That is a good answer to "how close have I been coming to the limit".

But all of it renders inside `renderGovernor`, and this report was filed from `#section-cost-panel`. The Cost panel carries all-time dollar estimates and cumulative token tables and says nothing about the budget at all. **The feature was not missing; it was unreachable from where the question gets asked.** So this PR does not rebuild it — it fixes the two things that actually left the reporter without answers.

## 1. Phase

> *"When is the hive's token spend reset? I set the period, I want to know the phase."*

The reset was rendered only as `37h until reset`. That is a countdown, and a countdown cannot be lined up against a calendar — which is precisely what "I want to know the phase" asks for.

`WINDOW_STARTS_AT` / `WINDOW_ENDS_AT` were **already** on the live status and already used by the exhausted-state message, so no backend change was needed. The bar now reads:

```
Window Aug 23, 09:14 → Aug 25, 09:14 · 37h left
```

with the full unambiguous timestamps in the tooltip. Both fields are optional — empty until a limit is set and a window opens — so the helpers degrade to the bare countdown rather than rendering `Invalid Date`. There is a test for that fallback specifically.

## 2. Discoverability, and the unit

The Cost panel now carries the token budget: used against the limit, the window phase, and **the same `budgetHistoryChart()`** the Governor bar draws.

Reusing that function and `_lastBudget` is deliberate rather than convenient — two panels with independent views of one budget is exactly the failure mode #4699 was, and I would rather not ship a second one in the same week.

**The unit matters and is now stated.** The reporter discarded every dollar figure because *"this hive does not know the true price and is not regulating based on dollars"* — which is correct: the governor enforces a **token** limit. A panel showing only dollars has to say what the limit is actually denominated in. And when no token budget is configured it now says so and points at the setting, rather than rendering nothing and reproducing *"I did not find answers"*.

## What I deliberately did not change

The report says *"there is no indication of the time range on the horizontal axis"*. I checked which chart that is before touching anything:

- The **dollar** trend chart already has range pills (hourly/daily/weekly/monthly/custom) and first/mid/last x-axis labels. It is fine — the reporter had simply discounted it as dollars.
- The graph in the screenshot is one of the small **axis-less token sparklines** beside the model/agent rows. Those carry their range in a hover `<title>`, which #4298 chose deliberately: *"graphs with no axes are impossible to read — these are too small for drawn axes"*.

Giving those real axes is a real improvement but a different change, with a layout question attached (they are ~90px strips). The budget question is now answered above them, in tokens, which is what the reporter was actually trying to get from them.

## Verification

```
go build ./...                       ok
go vet ./pkg/dashboard/              ok
gofmt -l (new test)                  clean
go test ./pkg/dashboard/             ok (full package)
node --check (extracted SPA script)  ok — modified and baseline both parse
```

The SPA is one 1.1MB inline script, so a syntax error blanks the whole dashboard; I extracted and parsed it rather than trusting that Go tests would notice.

Five tests in `budget_phase_ui_test.go`, following the sibling `budget_history_ui_test.go` from #4298 — including its wired-but-undefined-function guard, since the embedded SPA has historically shipped calls to functions that were never defined. One of them pins that this markup adds **no inline `on*=` handlers**, because `script-src-attr` is `'none'` and such a handler would be silently dead.

— hive: backend=claude model=claude-opus-5