### PR TITLE
🐛 Proxy /gh-setup through the gateway so the App install callback works

### DIFF
--- a/src/proxy/gh_setup_proxy.test.js
+++ b/src/proxy/gh_setup_proxy.test.js
@@ -1,0 +1,129 @@
+// The GitHub App setup callback must reach the Go API through the gateway.
+//
+// After the operator installs the App, GitHub redirects their browser to
+// /gh-setup?installation_id=...&setup_action=install. The Go API's
+// GET /gh-setup handler verifies the installation and persists the
+// installation_id. Before this route existed the gateway had no proxy for
+// /gh-setup, so the request fell through to the SPA fallback: the dashboard
+// rendered at the /gh-setup URL, the Go handler never ran, and the
+// documented setup flow silently did nothing — measured on a live gateway
+// deployment, where the operator had to paste the installation ID by hand.
+// This test drives the exact redirect request through the real proxy and
+// pins that it reaches the backend with its query string intact.
+import { createServer, request as httpRequest } from 'http';
+import { strict as assert } from 'assert';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROXY_PORT = 19031;
+const GO_PORT = 19032;
+const TTYD_PORT = 19033;
+
+let goServer, ttydServer, proxyProcess;
+const seenRequests = [];
+
+// Go-API stand-in that implements the real handler's observable behavior:
+// record the request, answer 303 to /?ghSetup=ok — the redirect the browser
+// must receive for the flow to complete.
+function setupMockGoBackend() {
+  const server = createServer((req, res) => {
+    if (req.url.startsWith('/gh-setup')) {
+      seenRequests.push(req.url);
+      res.writeHead(303, { Location: '/?ghSetup=ok' });
+      res.end();
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  });
+  return new Promise(resolve => server.listen(GO_PORT, () => resolve(server)));
+}
+
+function setupMockTtyd() {
+  const server = createServer((req, res) => {
+    res.writeHead(200);
+    res.end('ttyd');
+  });
+  return new Promise(resolve => server.listen(TTYD_PORT, () => resolve(server)));
+}
+
+function startProxy() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', ['server.js'], {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        HIVE_PROXY_PORT: String(PROXY_PORT),
+        HIVE_API_PORT: String(GO_PORT),
+        HIVE_TTYD_PORT: String(TTYD_PORT),
+        HIVE_DASHBOARD_TOKEN: '',
+        HIVE_STATIC_DIR: __dirname,
+        NODE_ENV: 'test',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let started = false;
+    proc.stdout.on('data', (d) => {
+      if (!started && d.toString().includes('hive-proxy')) {
+        started = true;
+        resolve(proc);
+      }
+    });
+    proc.on('error', reject);
+    setTimeout(() => { if (!started) reject(new Error('proxy start timeout')); }, 10000);
+  });
+}
+
+function get(reqPath) {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({
+      host: '127.0.0.1',
+      port: PROXY_PORT,
+      path: reqPath,
+    }, (res) => {
+      let body = '';
+      res.on('data', d => { body += d; });
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function main() {
+  goServer = await setupMockGoBackend();
+  ttydServer = await setupMockTtyd();
+  proxyProcess = await startProxy();
+  await new Promise(r => setTimeout(r, 500));
+
+  // The exact URL shape GitHub redirects to after an App install.
+  const callback = '/gh-setup?installation_id=156191969&setup_action=install';
+  const res = await get(callback);
+
+  // Without the proxy route this fell through to the SPA fallback (a 200
+  // with HTML, or a 404 from static) and the backend never saw the request.
+  assert.equal(res.status, 303,
+    `gh-setup callback must be proxied to the Go API and return its redirect, got ${res.status}`);
+  assert.equal(res.headers.location, '/?ghSetup=ok',
+    `redirect must carry the Go handler's Location, got ${res.headers.location}`);
+  assert.equal(seenRequests.length, 1, 'backend must have seen exactly one gh-setup request');
+  assert.equal(seenRequests[0], callback,
+    `query string must survive the proxy intact, backend saw ${seenRequests[0]}`);
+
+  console.log('gh_setup_proxy: all assertions passed');
+}
+
+// Cleanup must run BEFORE process.exit — an exit inside .then() skips
+// .finally(), leaving the spawned proxy orphaned on its port where it serves
+// later runs of this test regardless of what server.js on disk says.
+function cleanup() {
+  if (proxyProcess) proxyProcess.kill();
+  if (goServer) goServer.close();
+  if (ttydServer) ttydServer.close();
+}
+
+main()
+  .then(() => { cleanup(); process.exit(0); })
+  .catch((err) => { console.error(err); cleanup(); process.exit(1); });

--- a/src/proxy/gh_setup_proxy.test.js
+++ b/src/proxy/gh_setup_proxy.test.js
@@ -112,6 +112,15 @@ async function main() {
   assert.equal(seenRequests[0], callback,
     `query string must survive the proxy intact, backend saw ${seenRequests[0]}`);
 
+  // Scoping pin: the mount must cover ONLY the /gh-setup segment. A sibling
+  // path that merely shares the prefix must fall through to static (404 here,
+  // no SPA index in the test static dir) and must never reach the backend.
+  const stray = await get('/gh-setupx?installation_id=1');
+  assert.equal(stray.status, 404,
+    `paths outside /gh-setup must not be proxied, got ${stray.status}`);
+  assert.equal(seenRequests.length, 1,
+    `backend must not see requests outside /gh-setup, saw ${JSON.stringify(seenRequests)}`);
+
   console.log('gh_setup_proxy: all assertions passed');
 }
 

--- a/src/proxy/package.json
+++ b/src/proxy/package.json
@@ -7,7 +7,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node server.test.js && node health_probe.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node csp_token_injection.test.js && node csp_script_src_elem.test.js && node ttyd_auth_retry.test.js"
+    "test": "node server.test.js && node health_probe.test.js && node session_cookie_v2.test.js && node session_cookie_v3.test.js && node session_pubkey_rotation.test.js && node terminal_cookie_verify.test.js && node redoc_pin.test.js && node csp_token_injection.test.js && node csp_script_src_elem.test.js && node ttyd_auth_retry.test.js && node gh_setup_proxy.test.js"
   },
   "dependencies": {
     "express": "^5.2.0",

--- a/src/proxy/server.js
+++ b/src/proxy/server.js
@@ -930,6 +930,32 @@ app.get('/api-docs', (_req, res) => {
 
 app.use('/api', apiProxy);
 
+// GitHub App setup callback. After the operator installs the App, GitHub
+// redirects their browser to /gh-setup?installation_id=...&setup_action=...,
+// and the Go API's GET /gh-setup handler verifies the installation with the
+// App key and persists installation_id. This route was missing here: the
+// request fell through to the SPA fallback below, the dashboard rendered at
+// the /gh-setup URL, and the documented setup flow silently did nothing on
+// every gateway deployment — the operator had to find and paste the
+// installation ID by hand. Proxy it to the Go API exactly like /api.
+app.use('/gh-setup', createProxyMiddleware({
+  target: GO_API_URL,
+  changeOrigin: true,
+  // The express mount strips the /gh-setup prefix (same as /api above);
+  // re-prepend it, collapsing the bare "/" express leaves before a query
+  // string so the Go mux pattern "GET /gh-setup" still matches.
+  pathRewrite: (p) => '/gh-setup' + p.replace(/^\/(?=\?|$)/, ''),
+  on: {
+    error(err, req, res) {
+      console.error(`[gh-setup-proxy] ${req.method} ${req.url} → ${err.message}`);
+      if (res.writeHead) {
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end('GitHub App setup endpoint unavailable');
+      }
+    },
+  },
+}));
+
 const ttydProxy = createProxyMiddleware({
   target: TTYD_URL,
   changeOrigin: true,


### PR DESCRIPTION
## What

The gateway has no route for `/gh-setup`, so GitHub's post-install redirect — `​/gh-setup?installation_id=...&setup_action=install`, the callback the [GitHub App setup doc](../blob/v4/src/docs/github-app-setup.md) builds the whole `/gh-setup` flow around — never reaches the Go API's `GET /gh-setup` handler on gateway deployments. It falls through to the SPA fallback, the dashboard renders at the `/gh-setup` URL, and the install silently doesn't complete.

## Observed live

Rootless podman hive, personal GitHub account. Operator created the App, installed it on the repo, GitHub redirected to `localhost:3001/gh-setup?installation_id=156191969&setup_action=install` — and the browser showed the dashboard with the "GitHub App Not Installed" banner still up. The Go handler never logged a callback. The flow only completed after the installation ID was saved by hand via `PUT /api/config/github`.

## Fix

Proxy `/gh-setup` to the Go API, mirroring `apiProxy` — including the `pathRewrite` that re-prepends the prefix the express mount strips. One subtlety: for a bare `/gh-setup?query`, express leaves `/?query`, and the lone slash must collapse (`/gh-setup?query`, not `/gh-setup/?query`) or the Go 1.22 mux pattern `GET /gh-setup` does not match.

## Test

`gh_setup_proxy.test.js` drives GitHub's exact callback URL through the real spawned `server.js` against a Go-API mock, asserting: the backend receives the request, the handler's `303 → /?ghSetup=ok` passes through, and the query string arrives intact. Verified it fails (404, backend never reached) with the route removed. Wired into the `package.json` test chain; full proxy suite green.

Related: the same live investigation found installation auto-discovery unable to help here either — see the companion PR on the discovery-cache Re-check path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

