### PR TITLE
🐛 Recover from a rotated dashboard token instead of failing every write silently

### DIFF
--- a/src/pkg/dashboard/stale_token_recovery_test.go
+++ b/src/pkg/dashboard/stale_token_recovery_test.go
@@ -1,0 +1,84 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// A dashboard token that the server REJECTS must not be a permanent, silent
+// dead end.
+//
+// The SPA's fetch wrapper stores the token in localStorage and attaches it to
+// every mutation. It used to prompt only when it had NO token, and it never
+// looked at the response — so once the operator rotated HIVE_DASHBOARD_TOKEN,
+// a browser holding the old value 401'd on every write forever, with no
+// prompt and no error. Each feature surfaced that differently (a "Failed:
+// Unauthorized" toast, a Re-check button that did nothing, a confirm dialog
+// that closed as if it had worked), so it read as several unrelated broken
+// features rather than one bad credential. Measured on a live hive: writes
+// failed for a full day across four features after a rotation.
+//
+// These tests pin the structure of the recovery path in the embedded
+// static/index.html. The browser behavior itself (localStorage, window.prompt,
+// a real 401) cannot execute here; what is honestly guaranteed is that the
+// recovery branch, its single-retry guard, and the stored-token precondition
+// survive future edits — matching the convention of the other index.html
+// structure tests in this package.
+
+// TestStaleTokenTriggersRecovery asserts the wrapper reacts to a rejected
+// token at all: it inspects mutation responses for 401/403, drops the stored
+// value, and re-prompts. Losing any piece restores the silent-failure bug.
+func TestStaleTokenTriggersRecovery(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"res.status === 401 || res.status === 403",
+		"localStorage.removeItem('hive-token')",
+		"_authRejected = true;",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — a rotated dashboard token silently fails every write again", snippet)
+		}
+	}
+}
+
+// TestStaleTokenRetriesExactlyOnce asserts the retry is guarded. A token that
+// is simply WRONG (operator pastes garbage) must fail and stop, not loop
+// prompting forever.
+func TestStaleTokenRetriesExactlyOnce(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"!opts.__hiveAuthRetried",
+		"__hiveAuthRetried: true",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — the auth retry is unguarded and can loop", snippet)
+		}
+	}
+}
+
+// TestStaleTokenRecoveryRequiresAStoredToken asserts the recovery only runs
+// when a token was actually SENT. On a hosted/hub-proxied hive identity comes
+// from the hub login and no token exists: a 401/403 there is a genuine
+// authorization denial, and clearing storage or prompting for a token the
+// operator was never given would be wrong.
+func TestStaleTokenRecoveryRequiresAStoredToken(t *testing.T) {
+	html := indexHTML(t)
+	const guard = "if (isMutation && _authToken && !opts.__hiveAuthRetried &&"
+	if !strings.Contains(html, guard) {
+		t.Errorf("index.html is missing the %q guard — hosted hives would clear/prompt on a real authorization denial", guard)
+	}
+}
+
+// TestStaleTokenPromptExplainsItself asserts the re-prompt says WHY it is
+// asking. The first-run prompt and the rejected-token prompt are the same
+// dialog otherwise, and an operator who sees the generic text again has no
+// way to know their saved token was the problem.
+func TestStaleTokenPromptExplainsItself(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "was rejected") {
+		t.Error("index.html: the re-prompt does not tell the operator the stored token was rejected")
+	}
+	if !strings.Contains(html, "_authRejected\n") && !strings.Contains(html, "_authRejected ?") {
+		t.Error("index.html: the prompt text is not conditioned on _authRejected")
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -3547,6 +3547,9 @@
       // this path simply never triggers a prompt.
       let _authToken = localStorage.getItem('hive-token') || null;
       let _authConfigured = null; // null=unknown, true/false once checked
+      // Set only while re-prompting after the server rejected a stored token,
+      // so the prompt can say WHY it is asking again.
+      let _authRejected = false;
       async function _ensureAuthToken() {
         if (_authToken) return _authToken;
         if (_authConfigured === null) {
@@ -3569,7 +3572,9 @@
           } catch {}
           // Self-hosted hive with a token configured but none stored locally:
           // ask the operator to paste it once. It persists in localStorage.
-          const entered = window.prompt('This hive requires its dashboard token to make changes. Paste HIVE_DASHBOARD_TOKEN:');
+          const entered = window.prompt(_authRejected
+            ? 'The stored dashboard token was rejected — it is probably stale (rotated since this browser saved it). Paste the current HIVE_DASHBOARD_TOKEN:'
+            : 'This hive requires its dashboard token to make changes. Paste HIVE_DASHBOARD_TOKEN:');
           if (entered && entered.trim()) {
             _authToken = entered.trim();
             try { localStorage.setItem('hive-token', _authToken); } catch {}
@@ -3578,10 +3583,20 @@
         return _authToken;
       }
       const _origFetch = window.fetch;
+      function _attachAuthHeader(opts) {
+        if (!_authToken) return;
+        opts.headers = opts.headers || {};
+        if (opts.headers instanceof Headers) {
+          opts.headers.set('Authorization', 'Bearer ' + _authToken);
+        } else {
+          opts.headers['Authorization'] = 'Bearer ' + _authToken;
+        }
+      }
       window.fetch = async function(url, opts) {
         opts = opts || {};
         const method = (opts.method || 'GET').toUpperCase();
-        if (['PUT','POST','PATCH','DELETE'].includes(method)) {
+        const isMutation = ['PUT','POST','PATCH','DELETE'].includes(method);
+        if (isMutation) {
           await _ensureAuthToken();
           if (_authToken) {
             opts.headers = opts.headers || {};
@@ -3592,7 +3607,40 @@
             }
           }
         }
-        return _origFetch(url, opts);
+        const res = await _origFetch(url, opts);
+        // A STORED token that the server rejects is stale — the operator
+        // rotated HIVE_DASHBOARD_TOKEN since this browser saved it. Without
+        // this branch that state is permanent and SILENT: the wrapper only
+        // ever prompts when it has no token at all, so every mutation 401s
+        // forever while each feature reports the failure in its own idiom (a
+        // toast, a no-op button, a confirm dialog that closes as if it
+        // worked). Measured on a live hive: a browser window kept failing
+        // Save / Re-check / terminal auth / pack-apply for a full day after a
+        // rotation. Drop the bad token, re-prompt once saying why, retry once.
+        //
+        // Retry exactly once (__hiveAuthRetried): a genuinely wrong token
+        // must not loop. Only when a token was actually SENT — on a hosted
+        // hive identity comes from the hub login, where 401/403 is a real
+        // authorization denial and clearing anything would be wrong.
+        if (isMutation && _authToken && !opts.__hiveAuthRetried &&
+            (res.status === 401 || res.status === 403)) {
+          try { localStorage.removeItem('hive-token'); } catch {}
+          _authToken = null;
+          _authRejected = true;
+          try {
+            await _ensureAuthToken();
+          } finally {
+            _authRejected = false;
+          }
+          if (_authToken) {
+            const retryOpts = Object.assign({}, opts, { __hiveAuthRetried: true });
+            if (opts.headers instanceof Headers) retryOpts.headers = new Headers(opts.headers);
+            else if (opts.headers) retryOpts.headers = Object.assign({}, opts.headers);
+            _attachAuthHeader(retryOpts);
+            return _origFetch(url, retryOpts);
+          }
+        }
+        return res;
       };
     })();
 


### PR DESCRIPTION
## What

A dashboard token the server rejects — **rotated, mistyped, or truncated on paste** — permanently and **silently** breaks every dashboard write in that browser.

The SPA's fetch wrapper (`static/index.html`) stores the token in `localStorage`, attaches it to every mutation, prompts only when it has **no** token, and never inspects the response. After a rotation the stored token is stale, so every `PUT`/`POST`/`PATCH`/`DELETE` 401s — with no prompt, no banner, and nothing pointing at the credential.

## Why it is worse than one broken call

Each feature renders the same 401 in its own idiom, so it looks like several unrelated bugs:

| Feature | What the operator sees |
| --- | --- |
| Save Installation ID (Forge App banner) | "Failed: Unauthorized" toast |
| Re-check (same banner) | button appears to do nothing |
| Apply ACMM level | confirm dialog closes as though it worked; level unchanged |
| Terminal | ttyd auth fails |

Measured on a live self-hosted hive, twice, from two different causes:

1. After a routine token rotation, one browser window kept failing writes across all four of those for a **full day** while the symptoms were chased individually.
2. On a freshly cleared browser, the operator pasted the token and lost the leading character — 63 chars instead of 64. Every write 401'd again. The stored value *looked* right at a glance (`afc6b6b10283…` vs `bafc6b6b1028…`), and only a console check of `.length` found it.

Case 2 matters because it needs no rotation at all: a first-time operator can land in the permanent-silent-failure state on day one, during setup, from one bad paste. Nothing in the UI ever suggests the saved token is the problem — and the server does not log rejected tokens either, so `podman logs` is silent too.

## Fix

When a mutation that **carried a stored token** returns 401/403: drop the token, re-prompt once with text saying it was rejected and is probably stale, retry the request once.

Two guards are load-bearing:

- **Retry exactly once** (`__hiveAuthRetried`) — a genuinely wrong token must fail and stop, not loop prompting.
- **Only when a token was actually sent** (`_authToken`) — on a hosted/hub-proxied hive identity comes from the hub login and no token exists; a 401/403 there is a real authorization denial, and clearing storage or prompting for a token the operator was never issued would be wrong.

## Tests

`stale_token_recovery_test.go` pins the recovery branch, the single-retry guard, the stored-token precondition, and that the re-prompt explains itself — following the existing `index.html` structure-test convention in this package (`agent_scroll_anchor_test.go`, `clickable_avatars_test.go`), since browser behavior can't execute in Go. **All four fail without the change.**

Beyond structure, the patched wrapper was extracted and executed against a mock backend that 401s anything but the fresh token:

```
final status      : 200
headers sent      : ["Bearer STALE","Bearer FRESH"]
prompts shown     : 1
prompt said stale : true
token now stored  : FRESH
```

`go build ./...` clean; neighboring `index.html` structure tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

