### PR TITLE
🐛 Create the agent request queues even when the App is not usable at boot

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1577,6 +1577,16 @@ func main() {
 	// Gated on a real client + usable App — with no App there is no bot to author
 	// as, and requests simply accumulate rather than opening under a wrong
 	// identity. ghClient uses the App installation token (see ghAuth wiring).
+	// Create the agent-facing request queues REGARDLESS of App state. The
+	// watchers below stay gated (no App, no bot to author as), but the queues
+	// must exist either way or the "requests simply accumulate" behavior above
+	// is a fiction: hive-open-pr / hive-open-issue run in the AGENT's shell and
+	// hard-fail on a missing directory, discarding the finding instead of
+	// queueing it. App setup routinely completes after boot (operator saves the
+	// installation ID, /gh-setup persists it, auto-discovery finds it later), so
+	// this gap silently disarms agent writes on a hive that looks healthy.
+	github.PrepareRequestDirs(logger)
+
 	if ghClient != nil && cfg.GitHub.HasUsableApp() {
 		// Attribution resolver: effective backend/model from the manager
 		// (runtime overrides included), falling back to the configured values

--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -116,16 +116,10 @@ func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueReques
 	if nowFn == nil {
 		nowFn = time.Now
 	}
-	if err := os.MkdirAll(issueRequestDir(), 0o777); err != nil {
-		c.logger.Warn("issue-request watcher: cannot create request dir; disabled",
-			slog.String("dir", issueRequestDir()), slog.String("error", err.Error()))
+	// Shared with PrepareRequestDirs, which creates this queue unconditionally
+	// at boot so findings can accumulate even before a watcher runs.
+	if !ensureRequestDir(c.logger, "issue", issueRequestDir()) {
 		return
-	}
-	// Same rationale as the PR watcher: agents (UID >= 2001) must be able to
-	// DROP request files; MkdirAll is umask-masked, so force group-write+setgid.
-	if err := os.Chmod(issueRequestDir(), 0o2775); err != nil {
-		c.logger.Warn("issue-request watcher: could not set group-writable perms on request dir; agents may be unable to file issues",
-			slog.String("dir", issueRequestDir()), slog.String("error", err.Error()))
 	}
 	go func() {
 		t := time.NewTicker(issueRequestPollInterval)

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -105,22 +105,10 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 	if nowFn == nil {
 		nowFn = time.Now
 	}
-	if err := os.MkdirAll(prRequestDir(), 0o777); err != nil {
-		c.logger.Warn("pr-request watcher: cannot create request dir; disabled",
-			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
+	// Shared with PrepareRequestDirs, which creates this queue unconditionally
+	// at boot so requests can accumulate even before a watcher runs.
+	if !ensureRequestDir(c.logger, "pr", prRequestDir()) {
 		return
-	}
-	// Agents (UID >= 2001, in the shared "node" group) must be able to DROP request
-	// files here — hive-open-pr runs AS the agent. MkdirAll is masked by umask to
-	// 0755 (not group-writable), so an agent's write gets EACCES and, under the
-	// hard switch, its PR silently fails to open. Force group-write + setgid (like
-	// /data/beads) so agent-written files inherit the node group and the dir is
-	// writable by every agent. The forge-check still holds: the watcher reads each
-	// file's OWNING UID, which is the agent that wrote it — group-writability lets
-	// them write, it does not let one agent forge another's ownership.
-	if err := os.Chmod(prRequestDir(), 0o2775); err != nil {
-		c.logger.Warn("pr-request watcher: could not set group-writable perms on request dir; agents may be unable to open PRs",
-			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
 	}
 	go func() {
 		t := time.NewTicker(prRequestPollInterval)

--- a/src/pkg/github/request_dirs.go
+++ b/src/pkg/github/request_dirs.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"log/slog"
+	"os"
+)
+
+// requestDirMode is the mode every agent-facing request queue must end up with.
+//
+// Agents (UID >= 2001, in the shared "node" group) DROP request files here —
+// hive-open-pr / hive-open-issue run AS the agent. MkdirAll is masked by umask
+// to 0755 (not group-writable), so an agent's write gets EACCES and its PR or
+// issue silently fails to open. Group-write + setgid (like /data/beads) makes
+// the dir writable by every agent and makes agent-written files inherit the
+// node group. The forge-check still holds: each watcher reads a file's OWNING
+// UID, which is the agent that wrote it — group-writability lets agents write,
+// it does not let one agent forge another's ownership.
+const requestDirMode = 0o2775
+
+// ensureRequestDir creates one request queue and opens it to the agent group.
+// Returns false when the directory cannot be created, which is the only state
+// in which the corresponding watcher must disable itself.
+func ensureRequestDir(logger *slog.Logger, kind, dir string) bool {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		if logger != nil {
+			logger.Warn(kind+"-request queue: cannot create request dir",
+				slog.String("dir", dir), slog.String("error", err.Error()))
+		}
+		return false
+	}
+	if err := os.Chmod(dir, requestDirMode); err != nil && logger != nil {
+		logger.Warn(kind+"-request queue: could not set group-writable perms; agents may be unable to queue requests",
+			slog.String("dir", dir), slog.String("error", err.Error()))
+	}
+	return true
+}
+
+// PrepareRequestDirs creates the PR and issue request queues WITHOUT starting
+// their watchers.
+//
+// The watchers are deliberately gated on a usable GitHub App — with no App
+// there is no bot to author as, and the design says requests should "simply
+// accumulate rather than opening under a wrong identity". Accumulating,
+// however, requires somewhere to accumulate IN, and the queues used to be
+// created inside that same gate. So on a hive whose App is not usable at boot
+// the directories did not exist at all, and `hive-open-pr` / `hive-open-issue`
+// hard-failed in the agent's shell: the finding was discarded rather than
+// queued, and the failure was visible only to whoever read that agent's pane.
+//
+// This is not a rare corner. App setup routinely completes AFTER boot — the
+// operator saves the installation ID from the dashboard, /gh-setup persists it,
+// or auto-discovery finds it on a later poll. Every one of those leaves a hive
+// that reports healthy App auth while its agents cannot queue a single write.
+//
+// Creating the queues unconditionally costs two empty directories and makes the
+// documented behavior real: requests wait on disk until a watcher runs.
+func PrepareRequestDirs(logger *slog.Logger) {
+	ensureRequestDir(logger, "pr", prRequestDir())
+	ensureRequestDir(logger, "issue", issueRequestDir())
+}

--- a/src/pkg/github/request_dirs_test.go
+++ b/src/pkg/github/request_dirs_test.go
@@ -1,0 +1,106 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The agent-facing request queues must exist even when no watcher is running.
+//
+// The PR/issue watchers are gated on a usable GitHub App, and the design says
+// that with no App "requests simply accumulate rather than opening under a
+// wrong identity". That was not true: the queues were created INSIDE the same
+// gate, so on a hive whose App was not usable at boot the directories did not
+// exist and hive-open-pr / hive-open-issue hard-failed in the agent's shell —
+// the finding was discarded, not queued, and the only trace was in that
+// agent's terminal pane.
+//
+// Measured on a live L3 hive: the App installation ID was saved from the
+// dashboard AFTER boot, so auto-discovery repaired App auth at runtime and
+// everything reported healthy — while quality had analysed the repo, pushed a
+// branch, composed a PR and an issue, and then had nowhere to put them.
+
+func testQueueDirs(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	pr := filepath.Join(root, "pr-requests")
+	issue := filepath.Join(root, "issue-requests")
+	prev, prevIssue := prRequestDirForTest, issueRequestDirForTest
+	prRequestDirForTest, issueRequestDirForTest = pr, issue
+	t.Cleanup(func() { prRequestDirForTest, issueRequestDirForTest = prev, prevIssue })
+	return pr, issue
+}
+
+// TestPrepareRequestDirsCreatesBothQueues is the regression: both queues exist
+// after PrepareRequestDirs, with no client and no App anywhere in sight.
+func TestPrepareRequestDirsCreatesBothQueues(t *testing.T) {
+	pr, issue := testQueueDirs(t)
+
+	PrepareRequestDirs(quietLogger())
+
+	for name, dir := range map[string]string{"pr": pr, "issue": issue} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("%s queue was not created: %v — agents hard-fail instead of queueing", name, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s queue is not a directory", name)
+		}
+	}
+}
+
+// TestPrepareRequestDirsIsAgentWritable pins the permissions agents depend on.
+// MkdirAll is umask-masked to 0755; without the explicit chmod an agent's drop
+// gets EACCES and the write is lost exactly as if the dir were missing.
+func TestPrepareRequestDirsIsAgentWritable(t *testing.T) {
+	pr, issue := testQueueDirs(t)
+
+	PrepareRequestDirs(quietLogger())
+
+	for name, dir := range map[string]string{"pr": pr, "issue": issue} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("%s queue: %v", name, err)
+		}
+		if perm := info.Mode().Perm(); perm&0o070 != 0o070 {
+			t.Errorf("%s queue perm = %#o, want group rwx — agents cannot drop request files", name, perm)
+		}
+	}
+}
+
+// TestPrepareRequestDirsIsIdempotent: it runs on every boot, and an existing
+// queue holding queued requests must survive untouched.
+func TestPrepareRequestDirsIsIdempotent(t *testing.T) {
+	pr, _ := testQueueDirs(t)
+	if err := os.MkdirAll(pr, 0o2775); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+	queued := filepath.Join(pr, "pending.json")
+	if err := os.WriteFile(queued, []byte(`{"agent":"quality"}`), 0o664); err != nil {
+		t.Fatalf("write queued request: %v", err)
+	}
+
+	PrepareRequestDirs(quietLogger())
+
+	if _, err := os.Stat(queued); err != nil {
+		t.Fatalf("a queued request was lost across PrepareRequestDirs: %v", err)
+	}
+}
+
+// TestEnsureRequestDirReportsFailure: the watcher disables itself only when the
+// queue genuinely cannot be created, so that signal must stay truthful.
+func TestEnsureRequestDirReportsFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — an unwritable parent is still writable")
+	}
+	parent := t.TempDir()
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	if ensureRequestDir(quietLogger(), "pr", filepath.Join(parent, "nope")) {
+		t.Error("ensureRequestDir reported success for an uncreatable directory")
+	}
+}

--- a/src/pkg/github/request_dirs_test.go
+++ b/src/pkg/github/request_dirs_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -102,5 +103,51 @@ func TestEnsureRequestDirReportsFailure(t *testing.T) {
 
 	if ensureRequestDir(quietLogger(), "pr", filepath.Join(parent, "nope")) {
 		t.Error("ensureRequestDir reported success for an uncreatable directory")
+	}
+}
+
+// TestRequestWatchersStayGatedInMain pins the refusal half of the contract at
+// the source level, the layer no behavioural test in this package can see
+// (shape follows f3_trusted_merger_source_test.go, and for the same reason: a
+// sync merge resolving a conflict in favour of an older main.go could ungate
+// the watchers while every test here stays green).
+//
+// PrepareRequestDirs only makes the queues EXIST. Acting on a queued request —
+// opening a PR or issue on GitHub — must remain gated on a usable App: with no
+// App there is no bot identity to author as, and requests must accumulate on
+// disk, never open under a wrong identity.
+func TestRequestWatchersStayGatedInMain(t *testing.T) {
+	raw, err := os.ReadFile("../../cmd/hive/main.go")
+	if err != nil {
+		t.Fatalf("reading cmd/hive/main.go: %v", err)
+	}
+	src := string(raw)
+
+	gate := "if ghClient != nil && cfg.GitHub.HasUsableApp() {"
+	gateIdx := strings.Index(src, gate)
+	if gateIdx < 0 {
+		t.Fatalf("cmd/hive/main.go lost the usable-App gate %q — the request watchers "+
+			"must never start without an App identity to author as", gate)
+	}
+
+	prepIdx := strings.Index(src, "github.PrepareRequestDirs(")
+	if prepIdx < 0 {
+		t.Error("cmd/hive/main.go no longer calls github.PrepareRequestDirs — queues " +
+			"stop existing on App-less boots and agent findings are discarded again (#4713)")
+	} else if prepIdx > gateIdx {
+		t.Error("github.PrepareRequestDirs must be called BEFORE (outside) the usable-App " +
+			"gate — inside it, queues stop existing on App-less boots (#4713)")
+	}
+
+	for _, call := range []string{"ghClient.StartPRRequestWatcher(", "ghClient.StartIssueRequestWatcher("} {
+		idx := strings.Index(src, call)
+		if idx < 0 {
+			t.Errorf("cmd/hive/main.go no longer starts %s — queued requests would accumulate forever", call)
+			continue
+		}
+		if idx < gateIdx {
+			t.Errorf("%s appears before the usable-App gate — a watcher started without a "+
+				"usable App could act on GitHub without the bot identity", call)
+		}
 	}
 }


### PR DESCRIPTION
## What

At L3+ agents do not call `gh pr create` themselves. They push a branch and drop a **request file**; the hive opens the PR or issue server-side with the App token so it is authored by `<slug>[bot]`. The watchers that drain those queues are gated on a usable GitHub App at boot, and that gate's comment states the intent:

> Gated on a real client + usable App — with no App there is no bot to author as, **and requests simply accumulate** rather than opening under a wrong identity.

They cannot accumulate. The queues are created **inside that same gate**, so a hive whose App is not usable at boot has no directories at all — and `hive-open-pr` / `hive-open-issue`, which run in the **agent's** shell, hard-fail on ENOENT. The finding is discarded rather than queued, and the only trace is in that agent's tmux pane.

## Why this is not a corner case

**The shipped config makes PAT→App migration the normal trajectory.** `hive.yaml.example` ships with the token path live and the App path commented out:

```yaml
github:
  # Option 1: Personal access token (simplest)
  token: ${HIVE_GITHUB_TOKEN}

  # Option 2: GitHub App (recommended for production)
  # app_id: 12345
  # installation_id: 67890
```

So a self-hosted operator starts on a PAT, runs for a while, and moves to the App when they want bot-authored writes — which is exactly what `github-app-setup.md` recommends for production. That migration happens on a **running** hive, and every route by which it completes lands the installation ID *after* boot:

- the operator pastes the installation ID into the dashboard banner,
- `/gh-setup` persists it on the install redirect (`installation_id` is documented as optional precisely because this flow fills it in),
- or installation auto-discovery finds it on a later poll.

All three leave a hive that reports healthy App auth, mints installation tokens, and passes its own `POST /api/github-app/recheck` — while **every agent write is silently impossible** until some later restart happens to boot with the App already usable.

Deployment shape decides whether that ever self-corrects. On Kubernetes an init container restores the persisted runtime config over the seed, so a runtime-persisted `installation_id` is present at the next boot. **A podman/quadlet deployment has no init container**: the hive boots from the operator's read-only `hive.yaml`, so an ID that only ever reached `/data/hive.yaml.runtime` is invisible at every subsequent boot — the gate stays closed indefinitely, not just once.

The ACMM level decides whether anyone notices. L1/L2 never open PRs or issues, so the queues are never touched; the defect only surfaces the moment an agent first tries to write, which may be days after the App was set up.

## Measured

Live self-hosted L3 hive. The installation ID was saved from the dashboard after boot, so auto-discovery repaired App auth at runtime and every health surface read green. The quality agent then did its whole job and reported this in its pane:

> "Both request-queue directories under `/var/run/hive-metrics/` are missing — looks host-side, not something I can create myself. **Branch is pushed and the PR/issue bodies are ready to resubmit** once that's fixed."

`ls /var/run/hive-metrics/` confirmed `pr-requests` and `issue-requests` absent while `agent-tokens`, `gh-app-token.cache` and the governor's JSON files were all present. Nothing in the container logs, the dashboard, or `/api/health` indicated a problem. Creating the queues (by restarting once the config carried `installation_id` at boot) was the entire fix.

## Change

Create both queues unconditionally at boot via `PrepareRequestDirs`, with the mkdir+chmod logic extracted into one shared helper the two watchers reuse.

**The watchers stay exactly as gated as before.** This changes only whether there is somewhere for requests to wait — making the documented "simply accumulate" behavior real. Cost is two empty directories.

## Tests

`request_dirs_test.go`, all four failing without the change:

- both queues created with no client and no App present
- group-writable permissions agents depend on — `MkdirAll` is umask-masked to 0755, so without the explicit chmod an agent's drop gets EACCES and is lost exactly as if the directory were missing
- idempotence with a queued request already on disk (this runs on every boot; a pending request must survive)
- `ensureRequestDir` still reports genuine failure — the only signal that legitimately disables a watcher

`go build ./...` clean; full `pkg/github` suite green (42s).

## Follow-up, deliberately not in this PR

Even with the queues present, a hive whose App becomes usable at runtime does not start its watchers until the next restart, so requests accumulate until then. Re-arming the watchers when App config lands is the fuller fix; it needs a decision about how to reach the watcher's context from the config path, so I left it out rather than guess. This PR removes the data-loss half of the problem — nothing is discarded any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

