### PR TITLE
🌱 ci(coverage): gate ./cmd/... coverage in both halves of the coverage gate

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -83,7 +83,7 @@ jobs:
         id: cover
         continue-on-error: true
         run: |
-          go test ./pkg/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s \
+          go test ./pkg/... ./cmd/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s \
             2>&1 | tee race-run.log
           exit "${PIPESTATUS[0]}"
 
@@ -151,7 +151,24 @@ jobs:
             [ioscan]=96
             [sandbox]=98
             [pushbroker]=99
+
+            # ── ./cmd/... floors (#4701) ─────────────────────────────────────
+            # CI never ran ./cmd/... at all before #4701 — four cmd/bd tests
+            # were merged already-failing and stayed red undetected. cmd keys
+            # are prefixed ("cmd/<name>") so cmd/hivectl can never collide with
+            # pkg/hivectl's floor. Recorded just below what v4 measures after
+            # #4700/#4719 so the ratchet can turn as CLI tests land.
+            [cmd/bd]=58       # 60.4% after #4700's kb-CLI tests
+            [cmd/hive]=17     # 18.8% after #4719's merge-authz tests; bulk is main()/run-loop wiring
+            [cmd/apiproxy]=13 # 14.7%
           )
+
+          # Thin flag-parsing mains with no test files, wrapping packages the
+          # gate already floors (pkg/hivectl at 88, pkg/hubbackup at the 90
+          # default). Exempt from the NO TEST FILES hard failure by name so any
+          # NEW untested cmd package still fails the gate. Remove an entry the
+          # moment its package gains a test file.
+          UNTESTED_CMD_MAINS='cmd/hive-backup cmd/hivectl'
 
           # Capture the full `go test -cover` output ONCE, then classify every
           # line. The previous version piped through `grep '^ok'`, which silently
@@ -163,12 +180,24 @@ jobs:
           # Both were therefore incapable of failing the gate, so adding a
           # package with zero tests was the one guaranteed way to stay green.
           # They are now hard failures in their own right.
-          go test -cover ./pkg/... -short -count=1 -timeout 600s 2>&1 | tee cover-run.log || true
+          go test -cover ./pkg/... ./cmd/... -short -count=1 -timeout 600s 2>&1 | tee cover-run.log || true
+
+          # Floor-map key for a package import path: cmd packages are keyed
+          # with a "cmd/" prefix so cmd/hivectl can never resolve to
+          # pkg/hivectl's floor (#4701); everything else keeps the historical
+          # bare-basename key.
+          floor_key() {
+            case "$1" in
+              */cmd/*) echo "cmd/${1##*/}" ;;
+              *)       echo "${1##*/}" ;;
+            esac
+          }
 
           while IFS= read -r line; do
             case "$line" in
               ok*)
-                pkg=$(echo "$line" | awk '{print $2}' | sed 's/.*\///')
+                pkgpath=$(echo "$line" | awk '{print $2}')
+                pkg=$(floor_key "$pkgpath")
                 pct=$(echo "$line" | grep -o '[0-9]*\.[0-9]*%' | tr -d '%')
                 if [ -z "$pct" ]; then continue; fi
                 int_pct=$(echo "$pct" | cut -d. -f1)
@@ -179,17 +208,26 @@ jobs:
                 REPORT="${REPORT}${pkg}: ${pct}%\n"
                 ;;
               FAIL*)
-                pkg=$(echo "$line" | awk '{print $2}' | sed 's/.*\///')
+                pkgpath=$(echo "$line" | awk '{print $2}')
                 # Ignore the bare trailing "FAIL" summary line, which has no pkg.
-                if [ -n "$pkg" ] && [ "$pkg" != "FAIL" ]; then
+                if [ -n "$pkgpath" ] && [ "$pkgpath" != "FAIL" ]; then
+                  pkg=$(floor_key "$pkgpath")
                   BROKEN="${BROKEN}${pkg}: TESTS FAILING\n"
                   REPORT="${REPORT}${pkg}: FAIL\n"
                 fi
                 ;;
               \?*)
-                pkg=$(echo "$line" | awk '{print $2}' | sed 's/.*\///')
-                BROKEN="${BROKEN}${pkg}: NO TEST FILES\n"
-                REPORT="${REPORT}${pkg}: no tests\n"
+                pkgpath=$(echo "$line" | awk '{print $2}')
+                pkg=$(floor_key "$pkgpath")
+                case " $UNTESTED_CMD_MAINS " in
+                  *" $pkg "*)
+                    REPORT="${REPORT}${pkg}: no tests (exempt thin main)\n"
+                    ;;
+                  *)
+                    BROKEN="${BROKEN}${pkg}: NO TEST FILES\n"
+                    REPORT="${REPORT}${pkg}: no tests\n"
+                    ;;
+                esac
                 ;;
             esac
           done < cover-run.log

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -385,7 +385,21 @@ jobs:
             [ioscan]=96
             [sandbox]=98
             [pushbroker]=99
+
+            # ── ./cmd/... floors (#4701) ─────────────────────────────────────
+            # See coverage-hourly.yml for the rationale. cmd keys are prefixed
+            # ("cmd/<name>") so cmd/hivectl can never collide with
+            # pkg/hivectl's floor. Recorded just below what v4 measures after
+            # #4700/#4719 so the ratchet can turn as CLI tests land.
+            [cmd/bd]=58       # 60.4% after #4700's kb-CLI tests
+            [cmd/hive]=17     # 18.8% after #4719's merge-authz tests; bulk is main()/run-loop wiring
+            [cmd/apiproxy]=13 # 14.7%
           )
+
+          # Thin flag-parsing mains with no test files, wrapping packages the
+          # gate already floors. KEEP IN SYNC with coverage-hourly.yml. Any NEW
+          # untested cmd package still hard-fails.
+          UNTESTED_CMD_MAINS='cmd/hive-backup cmd/hivectl'
 
           # Merge every shard profile: per-block counts are summed, so the N
           # partial pkg/agent profiles combine into the package's true
@@ -423,16 +437,27 @@ jobs:
           echo "Total coverage (./pkg/...): ${TOTAL:-unavailable}"
 
           # Classify every package exactly once from the combined logs.
-          # Floors apply to ./pkg/... only, matching the historical gate
-          # (./cmd/... lines are ignored here; the shards themselves already
-          # fail on any cmd test failure).
+          # ./cmd/... is scored too (#4701): the shards have run cmd tests
+          # since the partition change, but coverage floors previously applied
+          # to ./pkg/... only, so a CLI package could lose all its tests
+          # without the gate noticing. The TOTAL line remains ./pkg/...-only
+          # for trend continuity.
           cat test-*.log > cover-run.log
           grep -E '^(ok|FAIL|\?)' cover-run.log \
-            | awk '$2 ~ /^github\.com\/kubestellar\/hive\/pkg\// {print $1, $2}' \
+            | awk '$2 ~ /^github\.com\/kubestellar\/hive\/(pkg|cmd)\// {print $1, $2}' \
             | LC_ALL=C sort -u > pkg-states.txt
 
+          # Floor-map key: cmd packages get a "cmd/" prefix so cmd/hivectl can
+          # never resolve to pkg/hivectl's floor; pkg keeps the bare basename.
+          floor_key() {
+            case "$1" in
+              */cmd/*) echo "cmd/${1##*/}" ;;
+              *)       echo "${1##*/}" ;;
+            esac
+          }
+
           while read -r state pkgpath; do
-            pkg=${pkgpath##*/}
+            pkg=$(floor_key "$pkgpath")
             case "$state" in
               ok)
                 # A package that also has a FAIL line anywhere is broken; the
@@ -452,8 +477,15 @@ jobs:
                 REPORT="${REPORT}${pkg}: FAIL\n"
                 ;;
               \?)
-                BROKEN="${BROKEN}${pkg}: NO TEST FILES\n"
-                REPORT="${REPORT}${pkg}: no tests\n"
+                case " $UNTESTED_CMD_MAINS " in
+                  *" $pkg "*)
+                    REPORT="${REPORT}${pkg}: no tests (exempt thin main)\n"
+                    ;;
+                  *)
+                    BROKEN="${BROKEN}${pkg}: NO TEST FILES\n"
+                    REPORT="${REPORT}${pkg}: no tests\n"
+                    ;;
+                esac
                 ;;
             esac
           done < pkg-states.txt


### PR DESCRIPTION
Closes #4701.

The v2-tests shards already RUN `./cmd/...` (partition change), but the coverage gate scored `./pkg/...` only, and `coverage-hourly.yml` never ran cmd at all — so CLI packages could lose all their tests without any gate noticing (the exact failure mode #4701 documents: four cmd/bd tests merged already-failing, bd kb CLI at 0%).

**Changes (both floor maps kept in sync per their KEEP-IN-SYNC comments):**
- `coverage-hourly.yml`: `go test ./pkg/... ./cmd/...` in both the -race run and the scoring run.
- Both gates: cmd packages scored against recorded floors, keyed `cmd/<name>` via a shared `floor_key` helper so `cmd/hivectl` can never collide with `pkg/hivectl`'s 88 floor.
- Floors just below current v4 reality so the ratchet can turn: **cmd/bd 58** (60.4% after #4700), **cmd/hive 17** (18.8% after #4719), **cmd/apiproxy 13** (14.7%).
- `cmd/hive-backup`/`cmd/hivectl` (thin mains, no test files) exempted from the NO-TEST-FILES hard fail **by name** — any NEW untested cmd package still fails.
- v2-tests TOTAL stays pkg-only for trend continuity (documented inline).

**Validation:** gate loop simulated locally with a synthetic log covering all classes (pass-above-floor, exempt mains, new untested cmd → hard fail, failing cmd → hard fail, hivectl collision case) — all behave as intended. actionlint clean. Landed after #4719/#4721 so their tests count toward the recorded floors.

Suite-runtime impact: hourly job +~15s (cmd/hive ~11s dominates); PR shards unchanged (already run cmd).