### PR TITLE
🌱 test(agent): hermetic seams and pacing shrink so the suite runs anywhere under 600s

### DIFF
--- a/src/pkg/agent/authprobe_test.go
+++ b/src/pkg/agent/authprobe_test.go
@@ -579,7 +579,7 @@ func TestFixEntryWithSyntheticOwnership(t *testing.T) {
 		name:  "dir",
 		mode:  0o700 | os.ModeDir,
 		isDir: true,
-		sys:   &syscall.Stat_t{Uid: DevUID, Gid: NodeGID},
+		sys:   &syscall.Stat_t{Uid: uint32(DevUID), Gid: uint32(NodeGID)},
 	}, logger)
 	info, err := os.Stat(dir)
 	if err != nil {
@@ -596,7 +596,7 @@ func TestFixEntryWithSyntheticOwnership(t *testing.T) {
 	fixEntry(file, fakeFileInfo{
 		name: "file",
 		mode: 0o600,
-		sys:  &syscall.Stat_t{Uid: DevUID, Gid: NodeGID},
+		sys:  &syscall.Stat_t{Uid: uint32(DevUID), Gid: uint32(NodeGID)},
 	}, logger)
 	info, err = os.Stat(file)
 	if err != nil {
@@ -610,7 +610,7 @@ func TestFixEntryWithSyntheticOwnership(t *testing.T) {
 	fixEntry(file, fakeFileInfo{
 		name: "other-owner",
 		mode: 0o600,
-		sys:  &syscall.Stat_t{Uid: uint32(DevUID + 100), Gid: NodeGID},
+		sys:  &syscall.Stat_t{Uid: uint32(DevUID + 100), Gid: uint32(NodeGID)},
 	}, logger)
 	fixEntry(file, fakeFileInfo{
 		name: "root-owned",

--- a/src/pkg/agent/bob_test.go
+++ b/src/pkg/agent/bob_test.go
@@ -15,15 +15,19 @@ import (
 //
 // bob derives its state dir as path.join(os.homedir(), ".bob") and agents run
 // with HOME=/data/home, which is root-created — so the watcher must own it.
+//
+// It checks productionWatchedHomeDirs — the snapshot TestMain takes before
+// pointing WatchedHomeDirs into the hermetic temp tree — so the pin stays on
+// the production default, not the test override.
 func TestWatchedHomeDirsIncludesBob(t *testing.T) {
 	const bobStateDir = "/data/home/.bob"
-	for _, dir := range WatchedHomeDirs {
+	for _, dir := range productionWatchedHomeDirs {
 		if dir == bobStateDir {
 			return
 		}
 	}
 	t.Fatalf("WatchedHomeDirs must contain %q so bob can create its state dir; got %v",
-		bobStateDir, WatchedHomeDirs)
+		bobStateDir, productionWatchedHomeDirs)
 }
 
 // TestPermissionsWatcher_BobNestedTree covers the nested case explicitly: bob

--- a/src/pkg/agent/helpers_coverage_test.go
+++ b/src/pkg/agent/helpers_coverage_test.go
@@ -127,13 +127,105 @@ func TestUIDMapSave_Success(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestEnsureWatchedDirs_NoPanic(t *testing.T) {
-	// WatchedHomeDirs live under /data which usually can't be created here;
-	// the function logs warnings and never panics.
+	// TestMain points WatchedHomeDirs into the test temp tree, so this
+	// exercises the real mkdir path hermetically instead of warning against
+	// unwritable /data roots.
 	ensureWatchedDirs(discardLogger())
 }
 
-func TestFixPermissions_NoPanic(t *testing.T) {
+// TestFixPermissions_RepairsFixture used to be TestFixPermissions_NoPanic,
+// which called fixPermissions against whatever the HOST had: on a live hive it
+// walked (and could chown/chmod) real /data agent trees for 10+ minutes from a
+// unit test (#4685). TestMain now points every walk root into the test temp
+// tree, and this test upgrades "doesn't panic" to asserting the repair
+// behavior on a fixture it builds itself.
+func TestFixPermissions_RepairsFixture(t *testing.T) {
+	origWatched := WatchedHomeDirs
+	origShared := SharedRepoParent
+	origGoose := GooseLogsDir
+	origDevUID, origNodeGID := DevUID, NodeGID
+	t.Cleanup(func() {
+		WatchedHomeDirs = origWatched
+		SharedRepoParent = origShared
+		GooseLogsDir = origGoose
+		DevUID, NodeGID = origDevUID, origNodeGID
+	})
+
+	// fixEntry only chmods entries owned by DevUID (it refuses to touch other
+	// users' files) and skips the chown when uid/gid already match. Point the
+	// guard at the uid/gid this test process actually runs as, so the repair
+	// path is exercised rather than skipped.
+	DevUID = os.Getuid()
+	NodeGID = os.Getgid()
+
+	root := t.TempDir()
+	watched := filepath.Join(root, "watched")
+	SharedRepoParent = filepath.Join(root, "home")
+	GooseLogsDir = filepath.Join(root, "goose-logs")
+	WatchedHomeDirs = []string{watched}
+
+	// A too-narrow directory and file inside a watched root, and a repo clone
+	// under SharedRepoParent created the way the entrypoint does (0755 → group
+	// has no write, the exact ISSUES_AND_PRS lockout fixPermissions exists to
+	// heal).
+	narrowDir := filepath.Join(watched, "narrow")
+	if err := os.MkdirAll(narrowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	narrowFile := filepath.Join(narrowDir, "settings.json")
+	if err := os.WriteFile(narrowFile, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(SharedRepoParent, "api-server")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoFile := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(repoFile, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink pointing outside the tree must never be followed (CWE-59 guard
+	// in fixEntry): its target's mode must be left alone.
+	outside := filepath.Join(root, "outside.txt")
+	if err := os.WriteFile(outside, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(narrowDir, "planted-link")); err != nil {
+		t.Fatal(err)
+	}
+
 	fixPermissions(discardLogger())
+
+	assertMode := func(path string, wantBits os.FileMode) {
+		t.Helper()
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if info.Mode().Perm()&wantBits != wantBits {
+			t.Errorf("%s mode = %v, missing required bits %v", path, info.Mode().Perm(), wantBits)
+		}
+	}
+	assertMode(narrowDir, DirPerms)   // 0700 dir → at least 0770
+	assertMode(narrowFile, FilePerms) // 0600 file → at least 0660
+	assertMode(repo, DirPerms)        // 0755 clone → group write restored
+	assertMode(repoFile, FilePerms)
+
+	if info, err := os.Stat(outside); err != nil || info.Mode().Perm() != 0o600 {
+		t.Errorf("symlink target outside the tree was touched: mode=%v err=%v — the CWE-59 guard regressed",
+			info.Mode().Perm(), err)
+	}
+
+	// Idempotent: a second run must change nothing (modes already satisfied).
+	before, _ := os.Stat(narrowDir)
+	fixPermissions(discardLogger())
+	after, _ := os.Stat(narrowDir)
+	if before.Mode() != after.Mode() {
+		t.Errorf("second fixPermissions run changed %s: %v -> %v", narrowDir, before.Mode(), after.Mode())
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -49,11 +49,15 @@ type KickRecord struct {
 	Snippet   string    `json:"snippet"`
 }
 
+// paneCaptureSleep is a pacing var, not a const, for the same reason as the
+// pacing block near deliverStartupKick: the pkg/agent TestMain shrinks it so
+// the suite fits the default `go test` timeout. Production value unchanged.
+var paneCaptureSleep = 500 * time.Millisecond
+
 const (
 	outputBufferCapacity = 500
 	kickHistoryCapacity  = 50
 	tmuxCaptureLines     = 2000
-	paneCaptureSleep     = 500 * time.Millisecond
 	proxyListenPort      = 18443
 	proxyCACertPath      = "/data/proxy-ca.pem"
 
@@ -3119,20 +3123,25 @@ const codexUpdatePromptLabel = "codex update prompt"
 // Originally this handled only Copilot's folder-trust dialog. It covers codex's
 // trust and update menus too, because those block startup exactly the same way
 // and the update menu's default answer is actively destructive.
+// Trust-prompt watcher pacing. Vars, not consts, so the pkg/agent TestMain can
+// shrink them (see the pacing block near deliverStartupKick). Production
+// values unchanged; shared by both watchForTrustPrompt variants.
+var (
+	trustPollInterval = 2 * time.Second
+	trustMaxWait      = 120 * time.Second
+	trustCooldown     = 3 * time.Second
+	// trustReanswerAfter is how long a prompt must have been answered before
+	// the same prompt may be answered again. Short enough that a CLI which
+	// restarts inside the pane (crash loop, /login relaunch) is unwedged on
+	// its next appearance; long enough that the menu still rendering for a
+	// beat after the keystroke is never double-typed (the original failure:
+	// a second poll matched the fading menu and typed the option again — by
+	// then the CLI was at its input prompt, so the digit was submitted as a
+	// user message and answered, burning tokens).
+	trustReanswerAfter = 60 * time.Second
+)
+
 func (m *Manager) watchForTrustPromptForAgent(agent *AgentProcess, ctx context.Context) {
-	const (
-		trustPollInterval = 2 * time.Second
-		trustCooldown     = 3 * time.Second
-		// trustReanswerAfter is how long a prompt must have been answered before
-		// the same prompt may be answered again. Short enough that a CLI which
-		// restarts inside the pane (crash loop, /login relaunch) is unwedged on
-		// its next appearance; long enough that the menu still rendering for a
-		// beat after the keystroke is never double-typed (the original failure:
-		// a second poll matched the fading menu and typed the option again — by
-		// then the CLI was at its input prompt, so the digit was submitted as a
-		// user message and answered, burning tokens).
-		trustReanswerAfter = 60 * time.Second
-	)
 	// No deadline: the watcher runs for the agent's whole lifetime (ctx is the
 	// per-launch context). The old 120s window assumed the trust prompt only
 	// appears at startup, but Copilot ≥1.0.78 can render it later than that on
@@ -3174,11 +3183,6 @@ func (m *Manager) watchForTrustPromptForAgent(agent *AgentProcess, ctx context.C
 // watchForTrustPrompt monitors a tmux session for Copilot's "Confirm folder trust"
 // prompt and auto-selects "Yes, and remember for future sessions" (option 2).
 func (m *Manager) watchForTrustPrompt(session string, ctx context.Context) {
-	const (
-		trustPollInterval = 2 * time.Second
-		trustMaxWait      = 120 * time.Second
-		trustCooldown     = 3 * time.Second
-	)
 	deadline := time.After(trustMaxWait)
 	ticker := time.NewTicker(trustPollInterval)
 	defer ticker.Stop()
@@ -5410,11 +5414,28 @@ func (m *Manager) tmuxSendKeysForAgent(agent *AgentProcess, keys ...string) {
 }
 
 const (
+	enterCount = 3
+	chunkSize  = 400
+	// cliBootGraceSeconds is how long after StartedAt a bare pane (no CLI
+	// marker) is tolerated before CheckAndRestartCrashedAgents treats it as a
+	// crash. It matches the production cliReadyTimeout (60s) so a still-booting
+	// CLI is never restarted underneath itself, which would spawn a second
+	// concurrent CLI.
+	cliBootGraceSeconds = 60
+)
+
+// Pacing seams (#4717/#4693/#4688). These are package VARS, not consts, so the
+// pkg/agent TestMain can shrink them for the whole suite: they accumulate to
+// well over the default 10m `go test` timeout when 440 tests pay production
+// pacing (1-3s sleeps, 60-120s poll deadlines) against stub CLIs that render
+// instantly. Production values are unchanged — nothing outside TestMain may
+// mutate them. Relationships the values encode (bobInputHandlerSettleDelay
+// distinct from every tmux-pacing delay, and far below inputPromptTimeout) are
+// pinned by TestBobSettleDelay_* and must be preserved by any test override.
+var (
 	clearBeforeKickDelay    = 2 * time.Second
-	enterCount              = 3
 	enterDelay              = 300 * time.Millisecond
 	textToEnterDelay        = 1 * time.Second
-	chunkSize               = 400
 	chunkDelay              = 1 * time.Second
 	staleCheckDelay         = 1 * time.Second
 	cliReadyPollInterval    = 2 * time.Second
@@ -5439,11 +5460,11 @@ const (
 	// costs one agent a few seconds once per launch while under-waiting
 	// silently loses the bootstrap prompt entirely.
 	bobInputHandlerSettleDelay = 3 * time.Second
-	// cliBootGraceSeconds is how long after StartedAt a bare pane (no CLI
-	// marker) is tolerated before CheckAndRestartCrashedAgents treats it as a
-	// crash. It matches cliReadyTimeout (60s) so a still-booting CLI is never
-	// restarted underneath itself, which would spawn a second concurrent CLI.
-	cliBootGraceSeconds = 60
+	// sessionReadyDelay is how long a freshly created tmux session's shell is
+	// given to initialize before the launch command is typed into it. Without
+	// it, $(cat /tmp/.hive-bootstrap-*.txt) can fail because the shell isn't
+	// ready to process command substitution yet.
+	sessionReadyDelay = 2 * time.Second
 )
 
 func (m *Manager) SeedLastKick(name string, t time.Time) {
@@ -6419,7 +6440,10 @@ func paneShowsLoginPrompt(lines []string) bool {
 	return false
 }
 
-const (
+// Diagnostic pacing. Vars, not consts, so the pkg/agent TestMain can shrink
+// them (see the pacing block near deliverStartupKick). Production values
+// unchanged.
+var (
 	diagnosticTimeoutSec = 20
 	diagnosticPollSec    = 2
 )
@@ -8432,7 +8456,6 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 	// Without this, $(cat /tmp/.hive-bootstrap-*.txt) can fail because the
 	// shell isn't ready to process command substitution yet.
 	// Released the lock before sleeping so other manager operations aren't blocked.
-	const sessionReadyDelay = 2 * time.Second
 	time.Sleep(sessionReadyDelay)
 
 	m.mu.Lock()

--- a/src/pkg/agent/manager_test.go
+++ b/src/pkg/agent/manager_test.go
@@ -29,6 +29,11 @@ func testEnvPairs(ap *AgentProcess) []agentEnvPair {
 	return m.agentEnvPairs(ap)
 }
 
+// productionWatchedHomeDirs is the production default of WatchedHomeDirs,
+// snapshotted by TestMain before it redirects the walk roots into the
+// hermetic temp tree. Pin tests on the production config read this.
+var productionWatchedHomeDirs []string
+
 func TestMain(m *testing.M) {
 	defaultTmuxSocket = fmt.Sprintf("ht%d", os.Getpid())
 
@@ -75,6 +80,61 @@ func TestMain(m *testing.M) {
 	os.Setenv("PATH", dir+":"+originalPath)
 	os.Unsetenv("TMUX")
 	os.Setenv("TMUX_TMPDIR", tmuxDir)
+
+	// Hermeticity seams (#4693/#4685): never read or touch host state.
+	//
+	// NewManager loads UIDMapPath whenever it exists; on a host running a live
+	// hive the production /var/run/hive/uid-map.json maps real agents, so test
+	// agents silently inherit real UIDs and per-UID tmux sockets (su-exec
+	// routing, live-socket targeting, UID-collision assertion failures). Point
+	// it into the test temp tree, where it never exists unless a test creates
+	// it.
+	UIDMapPath = filepath.Join(dir, "uid-map.json")
+	// fixPermissions/ensureWatchedDirs walk (and chown/chmod!) the production
+	// /data trees when they exist. Point every walk root into the temp tree so
+	// no test can touch live agent data or spend minutes walking real dirs.
+	permRoot := filepath.Join(dir, "perm")
+	// Snapshot the production list first: TestWatchedHomeDirsIncludesBob pins
+	// the production default (bob's /data/home/.bob entry), not the override.
+	productionWatchedHomeDirs = append([]string(nil), WatchedHomeDirs...)
+	WatchedHomeDirs = []string{filepath.Join(permRoot, "home", ".claude")}
+	SharedRepoParent = filepath.Join(permRoot, "home")
+	GooseLogsDir = filepath.Join(permRoot, "home", ".local", "state", "goose", "logs", "cli")
+	ModeFileGlob = filepath.Join(permRoot, ".hive-mode-*")
+	CapsFileGlob = filepath.Join(permRoot, ".hive-caps-*")
+
+	// Pacing shrink (#4717/#4688): the suite's 440 tests pay production pacing
+	// (1-3s sleeps, 60-120s poll deadlines) against stub CLIs that render
+	// instantly, which accumulates past the default 10m `go test` timeout and
+	// past coverage-hourly's 600s budget. Shrink the seams package-wide;
+	// pacing-sensitive relationships (TestBobInputHandlerSettleDelay) are
+	// preserved: bobInputHandlerSettleDelay stays distinct from the tmux pacing
+	// delays and far below inputPromptTimeout. Timeout-class values stay in
+	// whole seconds so slow CI runners keep real headroom. Poll intervals that
+	// fork a tmux subprocess per tick (CLI-ready, input-prompt, trust watcher —
+	// the last runs for each launched agent's whole lifetime) are shrunk to
+	// ~100-250ms, NOT to single-digit milliseconds: a 20ms fork loop across the
+	// suite's live agents is a measurable subprocess storm that starves tmux
+	// rendering and flakes pane-content assertions.
+	clearBeforeKickDelay = 20 * time.Millisecond
+	enterDelay = 3 * time.Millisecond
+	textToEnterDelay = 10 * time.Millisecond
+	chunkDelay = 10 * time.Millisecond
+	staleCheckDelay = 10 * time.Millisecond
+	cliReadyPollInterval = 100 * time.Millisecond
+	cliReadyTimeout = 5 * time.Second
+	inputPromptPollInterval = 100 * time.Millisecond
+	inputPromptTimeout = 8 * time.Second
+	preLaunchShellClearDelay = 5 * time.Millisecond
+	bobInputHandlerSettleDelay = 30 * time.Millisecond
+	sessionReadyDelay = 20 * time.Millisecond
+	paneCaptureSleep = 10 * time.Millisecond
+	trustPollInterval = 250 * time.Millisecond
+	trustMaxWait = 5 * time.Second
+	trustCooldown = 30 * time.Millisecond
+	trustReanswerAfter = 600 * time.Millisecond
+	diagnosticTimeoutSec = 3
+	diagnosticPollSec = 1
 
 	code := m.Run()
 

--- a/src/pkg/agent/permissions_watcher.go
+++ b/src/pkg/agent/permissions_watcher.go
@@ -13,13 +13,20 @@ import (
 const (
 	// PermissionFixInterval is how often the watcher scans for wrong ownership.
 	PermissionFixInterval = 10 * time.Second
+)
 
+// DevUID and NodeGID are package variables (not constants) so the test suite
+// can point the permission fixer at fixture trees owned by the test user
+// instead of the live /data agent identities (#4685, #4693).
+var (
 	// DevUID is the uid of the "dev" user that agents run as.
 	DevUID = 1001
 
 	// NodeGID is the gid of the "node" group shared by all agent users.
 	NodeGID = 1000
+)
 
+const (
 	// DirPerms is the minimum permission bits required on directories (u+rwx, g+rwx).
 	// Group access is essential because agents run as different users sharing the node group.
 	DirPerms = 0o770

--- a/src/pkg/agent/tmux_coverage_test.go
+++ b/src/pkg/agent/tmux_coverage_test.go
@@ -547,7 +547,22 @@ func TestConfirmMenuOption_SelectsOption(t *testing.T) {
 		t.Fatal(err)
 	}
 	testTmuxCommand("send-keys", "-t", session, "Enter").Run()
-	time.Sleep(500 * time.Millisecond)
+	// Wait until the shell has actually started and executed the printf: a
+	// fixed 500ms was a knife-edge against shell startup time (a zsh with user
+	// dotfiles takes >2s to first render on some hosts), and confirmMenuOption
+	// treats a pane without the title as "already dismissed" — masking the
+	// race as a wrong-answer failure four Down-keys later.
+	rendered := false
+	for i := 0; i < 100; i++ {
+		if selectedMenuOption(m.captureVisiblePaneForAgent(agent)) != "" {
+			rendered = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !rendered {
+		t.Fatalf("menu never rendered in the pane: %q", m.captureVisiblePaneForAgent(agent))
+	}
 	// want "accept" is on the selected ❯ line -> confirm immediately.
 	if !m.confirmMenuOption(agent, "Bypass Permissions mode", "accept", "Down") {
 		t.Error("should confirm the already-selected wanted option")

--- a/src/pkg/agent/uidmap.go
+++ b/src/pkg/agent/uidmap.go
@@ -9,8 +9,14 @@ import (
 	"sync"
 )
 
+// UIDMapPath is a var, not a const, so the pkg/agent TestMain can point it at
+// a path inside the test temp tree: NewManager loads it whenever it exists, so
+// on a host running a live hive the production map bleeds real agent UIDs into
+// unit tests (#4693). Production value unchanged; nothing outside tests may
+// mutate it.
+var UIDMapPath = "/var/run/hive/uid-map.json"
+
 const (
-	UIDMapPath = "/var/run/hive/uid-map.json"
 	baseAgentUID = 2001
 	proxyUserUID = 1001
 )


### PR DESCRIPTION
Fixes #4717, Fixes #4693, Fixes #4688, Fixes #4685.

## Problem

The pkg/agent suite paid **production pacing** (1–3 s sleeps, 60–120 s poll deadlines) against stub CLIs that render instantly, **walked and chmod'd the live `/data` trees**, and **loaded the production uid-map** on hosts running a real hive. Together that blew `go test`'s default 600 s timeout and made results depend on the host it ran on.

## Fix — seams, not skips (pattern from #4659 / #4724)

- **#4717 (suite >600 s serial):** pacing constants (`clearBeforeKickDelay`, `enterDelay`, `textToEnterDelay`, `chunkDelay`, `staleCheckDelay`, CLI-ready/input-prompt poll+timeout, trust watcher pacing, diagnostic poll, `paneCaptureSleep`, `sessionReadyDelay`, `bobInputHandlerSettleDelay`) become package `var`s; `TestMain` shrinks them for the suite. Fork-heavy poll intervals deliberately stay ≥100 ms — single-digit-ms polls forked tmux subprocess storms (~51 s sys time). Production values unchanged; `TestBobInputHandlerSettleDelay`'s relationship pins still hold.
- **#4693 (non-hermetic uid-map/su-exec bleed):** `UIDMapPath` becomes a `var`; `TestMain` points it into the test temp tree, so a live host's `/var/run/hive/uid-map.json` can no longer route test tmux calls through su-exec and per-UID sockets. (Complements #4724's `forceSharedUID`.)
- **#4685 (TestFixPermissions walks real /data, 10+ min):** `WatchedHomeDirs`/`SharedRepoParent`/`GooseLogsDir`/mode+caps globs and `DevUID`/`NodeGID` are redirected into a temp tree; `TestFixPermissions_NoPanic` is rewritten as `TestFixPermissions_RepairsFixture` — a behavioral fixture asserting chmod repair (dir+file), the CWE-59 symlink skip, and idempotency. Mutation-checked: breaking the dir-chmod, file-chmod, or symlink guard each fails the test. Runs in 0.0 s.
- **#4688 (order-dependent Bob kick flake + coverage-gate timeout):** the order dependency was **not reproducible locally** (full suite passes in any order here); code reading found no in-suite shared state. The reporter's host ran a live hive, so the uid-map bleed above is the identified environmental vector — now sealed. The timeout half is fixed by the pacing shrink. Also hardened `TestConfirmMenuOption_SelectsOption`, which raced shell startup with a fixed 500 ms sleep (>2 s to first render on a zsh-dotfiles host — same fixed-sleep-vs-render-latency mechanism): it now polls for the menu actually rendering.
- `TestWatchedHomeDirsIncludesBob` keeps pinning the **production** default via a TestMain snapshot.

## Numbers (local, macOS)

| | before | after |
|---|---|---|
| `go test ./pkg/agent -short` serial | 462 s (fails >600 s on slower hosts) | **279 s** |
| coverage | 90.9 % | **90.9 %** (floor 89) |

No CI sharding changes on purpose — the 5-way pkg/agent shard in v2-tests.yml could collapse later once runners confirm the margin.