### PR TITLE
🐛 fix(github): backoff + give-up for PR-open/review request retries

### DIFF
--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -88,6 +88,11 @@ type Client struct {
 	// watcher (in-memory; reset on restart). Guarded by issueRetryMu.
 	issueRetryMu sync.Mutex
 	issueRetries map[string]*issueRetryState
+	// prRetries / reviewRetries apply the same per-request-file backoff +
+	// give-up policy to the PR-open and PR-review watchers (request_retry.go).
+	// Zero values are ready to use.
+	prRetries     retryTracker
+	reviewRetries retryTracker
 	// mergerAuthz gates the label-queued auto-merge sweep on WHO queued the
 	// merge: it reports whether a login holds at least config.RoleMerger (audit
 	// F3). nil fails closed — SweepQueuedAutoMerges merges nothing. Guarded

--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -41,10 +41,11 @@ func issueRequestDir() string {
 // A var (not const) so tests can drive the real ticker loop quickly.
 var issueRequestPollInterval = 10 * time.Second
 
-// issueRetryBase and issueRetryMax bound the per-request retry backoff. Unlike
-// the PR watcher (retry every tick forever), a persistently failing issue
-// request backs off exponentially so a poisoned-but-parseable request cannot
-// hammer the forge every 10 seconds for the life of the pod.
+// issueRetryBase and issueRetryMax bound the per-request retry backoff: a
+// persistently failing issue request backs off exponentially so a
+// poisoned-but-parseable request cannot hammer the forge every 10 seconds for
+// the life of the pod. The PR-open and review watchers apply the same policy
+// via the shared retryTracker (request_retry.go).
 const (
 	issueRetryBase = 30 * time.Second
 	issueRetryMax  = 15 * time.Minute

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -164,6 +164,9 @@ func (c *Client) ProcessPRRequestsOnce(ctx context.Context) {
 }
 
 func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func() time.Time) {
+	if !c.prRetries.allows(path, nowFn()) {
+		return
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return // vanished between ReadDir and here — fine
@@ -174,6 +177,7 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		// retried every tick, and leave a result explaining why.
 		c.writePRResult(path, PRResponse{OK: false, Error: "invalid JSON: " + err.Error(), At: nowFn().UTC().Format(time.RFC3339)})
 		_ = os.Rename(path, path+".bad")
+		c.prRetries.clear(path)
 		c.logger.Warn("pr-request watcher: bad request file quarantined",
 			slog.String("path", path), slog.String("error", err.Error()))
 		return
@@ -208,12 +212,24 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, body)
 	resp := PRResponse{At: nowFn().UTC().Format(time.RFC3339)}
 	if err != nil {
-		// Leave the request in place so the next tick retries (transient API
-		// errors, main not yet pushed, etc.), but record the last error.
+		// Leave the request in place so a later tick retries (transient API
+		// errors, main not yet pushed, etc.) — but with exponential backoff, and
+		// quarantine once the give-up horizon passes. Retrying every tick
+		// forever let ~10 poisoned requests generate thousands of junk create
+		// calls an hour, tripping the org-wide secondary rate limit
+		// (request_retry.go).
 		resp.OK = false
 		resp.Error = err.Error()
 		c.writePRResult(path, resp)
-		c.logger.Warn("pr-request watcher: open failed, will retry",
+		if c.prRetries.noteFailure(path, nowFn()) {
+			_ = os.Rename(path, path+".failed")
+			c.prRetries.clear(path)
+			c.logger.Error("pr-request watcher: request exceeded retry horizon, quarantined",
+				slog.String("path", path), slog.String("repo", req.Repo),
+				slog.String("head", req.Head), slog.String("error", err.Error()))
+			return
+		}
+		c.logger.Warn("pr-request watcher: open failed, will retry with backoff",
 			slog.String("repo", req.Repo), slog.String("head", req.Head), slog.String("error", err.Error()))
 		return
 	}
@@ -257,6 +273,7 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	// Success (or reuse of an existing PR) — consume the request so it isn't
 	// reprocessed.
 	_ = os.Remove(path)
+	c.prRetries.clear(path)
 	c.logger.Info("pr-request watcher: PR opened by App bot",
 		slog.String("repo", req.Repo), slog.String("head", req.Head),
 		slog.Int("number", res.Number), slog.Bool("reused", res.AlreadyExisted),
@@ -270,6 +287,7 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 func (c *Client) denyPRRequest(path string, req PRRequest, reason string, nowFn func() time.Time) {
 	c.writePRResult(path, PRResponse{OK: false, Error: "authorization denied: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
 	_ = os.Rename(path, path+".denied")
+	c.prRetries.clear(path)
 	c.logger.Warn("pr-request watcher: DENIED (policy)",
 		slog.String("agent", req.Agent), slog.String("repo", req.Repo),
 		slog.String("head", req.Head), slog.String("reason", reason))

--- a/src/pkg/github/pr_request_watcher_test.go
+++ b/src/pkg/github/pr_request_watcher_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // mock GitHub API for PR create + list. created counts POST /pulls calls.
@@ -258,5 +259,114 @@ func TestPRRequestWatcher_HoldLabelApplied(t *testing.T) {
 				t.Errorf("hold label applied=%v, want %v (labels seen: %v)", gotHold, tc.wantHold, added)
 			}
 		})
+	}
+}
+
+// newPRFailingMockServer fails the first `fails` POST /pulls calls with a 500,
+// then behaves like newPRMockServer. The dedupe GET always returns empty.
+func newPRFailingMockServer(t *testing.T, created *int, fails *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			if *fails > 0 {
+				*fails--
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if created != nil {
+				*created++
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":42,"html_url":"https://github.com/o/r/pull/42"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// Transient failure: the request survives with its error recorded, retries are
+// suppressed inside the backoff window (NOT re-attempted every tick — the
+// every-tick loop is what burned the org's secondary rate limit), and the
+// request succeeds once the backoff elapses.
+func TestPRRequestWatcher_RetriesWithBackoff(t *testing.T) {
+	created, fails := 0, 1
+	srv := newPRFailingMockServer(t, &created, &fails)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	reqPath, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/fix-1", Title: "[scanner] fix", Agent: "scanner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	c.processPRRequests(context.Background(), clock)
+	if created != 0 {
+		t.Fatalf("first attempt should have failed")
+	}
+	if _, err := os.Stat(reqPath); err != nil {
+		t.Fatalf("request must survive a transient failure: %v", err)
+	}
+	// Within backoff: skipped entirely.
+	c.processPRRequests(context.Background(), clock)
+	if created != 0 {
+		t.Fatalf("retry must be suppressed inside the backoff window")
+	}
+	// After backoff: retried and succeeds; request consumed.
+	now = now.Add(requestRetryBase + time.Second)
+	c.processPRRequests(context.Background(), clock)
+	if created != 1 {
+		t.Fatalf("expected creation on post-backoff retry, got %d", created)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("request should be consumed after eventual success")
+	}
+}
+
+// Give-up horizon: a request still failing past requestRetryMaxAge is
+// quarantined as .failed and never retried again.
+func TestPRRequestWatcher_QuarantinesAfterMaxAge(t *testing.T) {
+	created, fails := 0, 1000000
+	srv := newPRFailingMockServer(t, &created, &fails)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	reqPath, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/never-lands", Title: "[scanner] never", Agent: "scanner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	c.processPRRequests(context.Background(), clock) // first failure starts the horizon clock
+	now = now.Add(requestRetryMaxAge + time.Hour)
+	c.processPRRequests(context.Background(), clock) // exceeds horizon -> quarantine
+
+	if _, err := os.Stat(reqPath + ".failed"); err != nil {
+		t.Fatalf("expected .failed quarantine: %v", err)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("original request should be renamed away")
+	}
+	// And it is never attempted again even after more time passes.
+	before := created
+	now = now.Add(time.Hour)
+	c.processPRRequests(context.Background(), clock)
+	if created != before {
+		t.Errorf("quarantined request must not be retried")
 	}
 }

--- a/src/pkg/github/request_retry.go
+++ b/src/pkg/github/request_retry.go
@@ -1,0 +1,82 @@
+package github
+
+import (
+	"sync"
+	"time"
+)
+
+// Shared retry policy for the request-file watchers (PR-open and PR-review).
+//
+// A request whose API call fails must not be retried every 10s tick for the
+// life of the pod: ~10 permanently failing PR-open requests at 2 API calls
+// each per tick is ~7,000 content-generating requests/hour of pure junk —
+// enough on its own to trip GitHub's secondary rate limit and take the whole
+// App installation (every spoke in the org) dark for an hour at a time
+// (observed live on kubestellar/console, 2026-08-25: four consecutive hourly
+// trips). Failures back off exponentially per request file, and a request
+// that still has not succeeded after the give-up horizon is quarantined
+// (.failed) so the queue stays finite. The issue-request watcher carries an
+// earlier per-watcher copy of this same policy; the merge watcher caps
+// attempts via .exhausted.
+const (
+	requestRetryBase   = 30 * time.Second
+	requestRetryMax    = 15 * time.Minute
+	requestRetryMaxAge = 24 * time.Hour
+)
+
+// retryState is one request file's failure history.
+type retryState struct {
+	attempts int
+	nextTry  time.Time
+	firstTry time.Time
+}
+
+// retryTracker holds per-request-file backoff state. The zero value is ready
+// to use. State is in-memory only: a pod restart retries everything once,
+// then backs off again — acceptable, same as the issue watcher.
+type retryTracker struct {
+	mu sync.Mutex
+	m  map[string]*retryState
+}
+
+// allows reports whether the request at path is eligible for an attempt now
+// (its backoff window has elapsed, or it has never failed).
+func (t *retryTracker) allows(path string, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	st := t.m[path]
+	if st == nil {
+		return true
+	}
+	return !now.Before(st.nextTry)
+}
+
+// noteFailure records a failed attempt, schedules the next eligible try with
+// exponential backoff, and returns true when the request has exceeded the
+// give-up horizon and should be quarantined.
+func (t *retryTracker) noteFailure(path string, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.m == nil {
+		t.m = map[string]*retryState{}
+	}
+	st := t.m[path]
+	if st == nil {
+		st = &retryState{firstTry: now}
+		t.m[path] = st
+	}
+	st.attempts++
+	backoff := requestRetryBase << uint(min(st.attempts-1, 30))
+	if backoff > requestRetryMax || backoff <= 0 {
+		backoff = requestRetryMax
+	}
+	st.nextTry = now.Add(backoff)
+	return now.Sub(st.firstTry) > requestRetryMaxAge
+}
+
+// clear drops the tracked state for path (request consumed or quarantined).
+func (t *retryTracker) clear(path string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.m, path)
+}

--- a/src/pkg/github/review_request_watcher.go
+++ b/src/pkg/github/review_request_watcher.go
@@ -140,6 +140,9 @@ func (c *Client) ProcessReviewRequestsOnce(ctx context.Context) {
 }
 
 func (c *Client) handleOneReviewRequest(ctx context.Context, path string, nowFn func() time.Time) {
+	if !c.reviewRetries.allows(path, nowFn()) {
+		return
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return // vanished between ReadDir and here
@@ -148,6 +151,7 @@ func (c *Client) handleOneReviewRequest(ctx context.Context, path string, nowFn 
 	if err := json.Unmarshal(data, &req); err != nil {
 		c.writeReviewResult(path, ReviewResponse{OK: false, Error: "invalid JSON: " + err.Error(), At: nowFn().UTC().Format(time.RFC3339)})
 		_ = os.Rename(path, path+".bad")
+		c.reviewRetries.clear(path)
 		c.logger.Warn("review-request watcher: bad request file quarantined",
 			slog.String("path", path), slog.String("error", err.Error()))
 		return
@@ -168,6 +172,7 @@ func (c *Client) handleOneReviewRequest(ctx context.Context, path string, nowFn 
 	if shapeErr != "" {
 		c.writeReviewResult(path, ReviewResponse{OK: false, Error: shapeErr, At: nowFn().UTC().Format(time.RFC3339)})
 		_ = os.Rename(path, path+".bad")
+		c.reviewRetries.clear(path)
 		c.logger.Warn("review-request watcher: malformed request quarantined",
 			slog.String("path", path), slog.String("reason", shapeErr))
 		return
@@ -199,10 +204,21 @@ func (c *Client) handleOneReviewRequest(ctx context.Context, path string, nowFn 
 	_, _, err = c.client.PullRequests.CreateReview(ctx, owner, repoName, req.Number, reviewReq)
 	resp := ReviewResponse{At: nowFn().UTC().Format(time.RFC3339)}
 	if err != nil {
+		// Retry with exponential backoff and quarantine at the give-up horizon
+		// (request_retry.go) — an every-tick retry loop on a poisoned request
+		// burns secondary-rate-limit budget for the whole App installation.
 		resp.OK = false
 		resp.Error = err.Error()
 		c.writeReviewResult(path, resp)
-		c.logger.Warn("review-request watcher: review failed, will retry",
+		if c.reviewRetries.noteFailure(path, nowFn()) {
+			_ = os.Rename(path, path+".failed")
+			c.reviewRetries.clear(path)
+			c.logger.Error("review-request watcher: request exceeded retry horizon, quarantined",
+				slog.String("path", path), slog.String("repo", req.Repo),
+				slog.Int("number", req.Number), slog.String("error", err.Error()))
+			return
+		}
+		c.logger.Warn("review-request watcher: review failed, will retry with backoff",
 			slog.String("repo", req.Repo), slog.Int("number", req.Number), slog.String("error", err.Error()))
 		return
 	}
@@ -216,6 +232,7 @@ func (c *Client) handleOneReviewRequest(ctx context.Context, path string, nowFn 
 		"state", state)
 	c.writeReviewResult(path, resp)
 	_ = os.Remove(path)
+	c.reviewRetries.clear(path)
 	c.logger.Info("review-request watcher: review submitted by App bot",
 		slog.String("repo", req.Repo), slog.Int("number", req.Number),
 		slog.String("state", state), slog.String("agent", req.Agent))
@@ -224,6 +241,7 @@ func (c *Client) handleOneReviewRequest(ctx context.Context, path string, nowFn 
 func (c *Client) denyReviewRequest(path string, req ReviewRequest, reason string, nowFn func() time.Time) {
 	c.writeReviewResult(path, ReviewResponse{OK: false, Error: "authorization denied: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
 	_ = os.Rename(path, path+".denied")
+	c.reviewRetries.clear(path)
 	c.logger.Warn("review-request watcher: DENIED (policy)",
 		slog.String("agent", req.Agent), slog.String("repo", req.Repo),
 		slog.Int("number", req.Number), slog.String("reason", reason))

--- a/src/pkg/github/review_request_watcher_test.go
+++ b/src/pkg/github/review_request_watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newReviewMockServer(t *testing.T, reviewed *int, lastEvent *string) *httptest.Server {
@@ -147,5 +148,92 @@ func TestReviewRequestWatcher_AuthzFailsClosed(t *testing.T) {
 	}
 	if _, err := os.Stat(reqPath + ".denied"); err != nil {
 		t.Errorf("denied review should be quarantined .denied")
+	}
+}
+
+// newReviewFailingMockServer fails the first `fails` review POSTs with a 500,
+// then succeeds.
+func newReviewFailingMockServer(t *testing.T, reviewed *int, fails *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/reviews") {
+			if *fails > 0 {
+				*fails--
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if reviewed != nil {
+				*reviewed++
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":1,"state":"APPROVED"}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+// Transient failure: retries are suppressed inside the backoff window and the
+// request succeeds after it elapses — never an every-tick retry loop.
+func TestReviewRequestWatcher_RetriesWithBackoff(t *testing.T) {
+	reviewed, fails := 0, 1
+	srv := newReviewFailingMockServer(t, &reviewed, &fails)
+	defer srv.Close()
+	c := reviewTestClient(t, srv.URL)
+	dir := withReviewDir(t)
+
+	reqPath, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 7, Event: "approve", Agent: "reviewer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	c.processReviewRequests(context.Background(), clock)
+	if reviewed != 0 {
+		t.Fatalf("first attempt should have failed")
+	}
+	if _, err := os.Stat(reqPath); err != nil {
+		t.Fatalf("request must survive a transient failure: %v", err)
+	}
+	c.processReviewRequests(context.Background(), clock)
+	if reviewed != 0 {
+		t.Fatalf("retry must be suppressed inside the backoff window")
+	}
+	now = now.Add(requestRetryBase + time.Second)
+	c.processReviewRequests(context.Background(), clock)
+	if reviewed != 1 {
+		t.Fatalf("expected review on post-backoff retry, got %d", reviewed)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("request should be consumed after eventual success")
+	}
+}
+
+// Give-up horizon: a review request still failing past requestRetryMaxAge is
+// quarantined as .failed and never retried again.
+func TestReviewRequestWatcher_QuarantinesAfterMaxAge(t *testing.T) {
+	reviewed, fails := 0, 1000000
+	srv := newReviewFailingMockServer(t, &reviewed, &fails)
+	defer srv.Close()
+	c := reviewTestClient(t, srv.URL)
+	dir := withReviewDir(t)
+
+	reqPath, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 7, Event: "approve", Agent: "reviewer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	c.processReviewRequests(context.Background(), clock)
+	now = now.Add(requestRetryMaxAge + time.Hour)
+	c.processReviewRequests(context.Background(), clock)
+
+	if _, err := os.Stat(reqPath + ".failed"); err != nil {
+		t.Fatalf("expected .failed quarantine: %v", err)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("original request should be renamed away")
 	}
 }


### PR DESCRIPTION
## Problem

The pr-request and review-request watchers retry every failed request **every 10s tick, forever** — only bad-JSON and authz denials are quarantined. On the console spoke, ~10 permanently failing PR-open requests (each retry = a dedupe GET + a create POST) generated thousands of junk content-creating API calls per hour.

GitHub's secondary rate limit is shared across the App installation, so this took **every kubestellar spoke's** GitHub output dark. Observed live 2026-08-25 (EDT): four consecutive hourly trips — resets at 00:54 → 01:54 → 02:54 → 03:54 — with the hive operating only ~40–50 min of each hour. The slow-start pacer (#4640/#4674) correctly prevented reset-boundary stampedes, but pacing can't help when the steady-state junk volume itself exceeds the limit.

## Fix

Port the issue-request watcher's existing policy (its comment even documented this gap: *"Unlike the PR watcher (retry every tick forever)"*) to both remaining watchers via a shared `retryTracker` (`request_retry.go`):

- exponential per-request-file backoff: 30s doubling, capped at 15m
- 24h give-up horizon → request quarantined as `.failed` with its last error preserved in the `.result.json`
- tracker state cleared on success, quarantine, and denial

State is in-memory, matching the issue watcher: a pod restart retries everything once, then backs off again.

## Tests

- `TestPRRequestWatcher_RetriesWithBackoff` / `TestReviewRequestWatcher_RetriesWithBackoff` — first failure recorded, retry suppressed inside the window, success after backoff elapses consumes the request
- `TestPRRequestWatcher_QuarantinesAfterMaxAge` / `TestReviewRequestWatcher_QuarantinesAfterMaxAge` — horizon exceeded → `.failed`, never retried again

🤖 Generated with [Claude Code](https://claude.com/claude-code)