### PR TITLE
fix(dashboard): surface and enable configured disabled agents

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -2528,17 +2528,13 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	proc, err := s.deps.AgentMgr.GetStatus(name)
-	if err != nil {
-		jsonError(w, err.Error(), http.StatusNotFound)
-		return
-	}
 
 	cli := agentCfg.Backend
-	if proc.BackendOverride != "" {
+	if err == nil && proc.BackendOverride != "" {
 		cli = proc.BackendOverride
 	}
 	model := agentCfg.Model
-	if proc.ModelOverride != "" {
+	if err == nil && proc.ModelOverride != "" {
 		model = proc.ModelOverride
 	}
 
@@ -2594,7 +2590,12 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 		models[modeName] = ""
 	}
 
-	lastPrompt := proc.LastKickMessage
+	lastPrompt := ""
+	pinnedCLI := agentCfg.CLIPinned
+	if err == nil {
+		lastPrompt = proc.LastKickMessage
+		pinnedCLI = pinnedCLI || proc.PinnedCLI != ""
+	}
 
 	// Read restrictions from agent work dir files
 	restrictions := s.loadAgentRestrictions(name)
@@ -2615,11 +2616,14 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 
 	jsonResponse(w, map[string]interface{}{
 		"general": map[string]interface{}{
+			"enabled":          agentCfg.Enabled,
 			"launchCmd":        launchCmd,
 			"displayName":      displayName,
 			"description":      agentCfg.Description,
-			"cliPinned":        agentCfg.CLIPinned || proc.PinnedCLI != "",
+			"cliPinned":        pinnedCLI,
 			"cliPinValue":      cli,
+			"modelOwner":       agentCfg.ModelOwner,
+			"backendOwner":     agentCfg.BackendOwner,
 			"staleTimeout":     staleTimeout,
 			"restartStrategy":  restartStrategy,
 			"model":            model,

--- a/src/pkg/dashboard/disabled_agent_enable_test.go
+++ b/src/pkg/dashboard/disabled_agent_enable_test.go
@@ -1,0 +1,64 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+func TestAgentConfigGetWorksForConfiguredDisabledAgent(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Agents["guide"] = config.AgentConfig{
+		Backend:      "claude",
+		Model:        "sonnet",
+		Enabled:      false,
+		DisplayName:  "Guide",
+		ModelOwner:   config.FieldOwnerPack,
+		BackendOwner: config.FieldOwnerOperator,
+	}
+
+	rec := doGet(s, "/api/config/agent/guide")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for configured agent without a process: %s", rec.Code, rec.Body.String())
+	}
+	general := decodeJSON(t, rec)["general"].(map[string]any)
+	if enabled, ok := general["enabled"].(bool); !ok || enabled {
+		t.Fatalf("general.enabled = %#v, want false", general["enabled"])
+	}
+	if general["modelOwner"] != config.FieldOwnerPack || general["backendOwner"] != config.FieldOwnerOperator {
+		t.Fatalf("ownership markers missing from config response: %#v", general)
+	}
+}
+
+func TestConfiguredAgentsIncludesDisabledAgentsWithoutProcesses(t *testing.T) {
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{
+		"running": {Enabled: true, SortOrder: 20},
+		"guide":   {Enabled: false, SortOrder: 10, DisplayName: "Guide", ModelOwner: config.FieldOwnerPack},
+	}}
+
+	agents := buildConfiguredAgents(cfg)
+	if len(agents) != 2 {
+		t.Fatalf("configured agents = %d, want 2", len(agents))
+	}
+	if agents[0].Name != "guide" || agents[0].Enabled || agents[0].DisplayName != "Guide" {
+		t.Fatalf("first configured agent = %#v, want disabled guide sorted first", agents[0])
+	}
+}
+
+func TestDisabledAgentSidebarEnableWiring(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		`window._configuredAgents = data.configuredAgents || [];`,
+		`if (!configured.enabled && !runtimeNames.has(configured.name))`,
+		`class="oc-nav-item disabled-agent"`,
+		`data-tab="General" title="Configure and enable`,
+		`id="cfg-agent-enabled"`,
+		`data-key="enabled"`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing disabled-agent enable wiring %q", snippet)
+		}
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -283,15 +283,16 @@ type StatusPayload struct {
 	// StatusInstance identifies the server process that produced the seq.
 	// Seqs restart at 1 when the spoke restarts; the frontend resets its
 	// guard counters when the instance changes instead of dropping forever.
-	StatusInstance string           `json:"statusInstance"`
-	HiveID         string           `json:"hiveId"`
-	Agents         []FrontendAgent  `json:"agents"`
-	Governor       FrontendGovernor `json:"governor"`
-	Tokens         FrontendTokens   `json:"tokens"`
-	Repos          []FrontendRepo   `json:"repos"`
-	Beads          FrontendBeads    `json:"beads"`
-	Planning       FrontendPlanning `json:"planning"`
-	Health         map[string]any   `json:"health"`
+	StatusInstance   string                    `json:"statusInstance"`
+	HiveID           string                    `json:"hiveId"`
+	Agents           []FrontendAgent           `json:"agents"`
+	ConfiguredAgents []FrontendConfiguredAgent `json:"configuredAgents"`
+	Governor         FrontendGovernor          `json:"governor"`
+	Tokens           FrontendTokens            `json:"tokens"`
+	Repos            []FrontendRepo            `json:"repos"`
+	Beads            FrontendBeads             `json:"beads"`
+	Planning         FrontendPlanning          `json:"planning"`
+	Health           map[string]any            `json:"health"`
 	// DeepHealth carries the spoke's own deep health checks (HealthSummary:
 	// ready, github_auth, agents, …) — the same checks the heartbeat reports
 	// to the hub. The dashboard's header Health pill renders from these, NOT
@@ -479,6 +480,21 @@ type FrontendAgent struct {
 	LastError        string `json:"lastError,omitempty"`
 	StallNudges      int    `json:"stallNudges,omitempty"`
 	ActionNudges     int    `json:"actionNudges,omitempty"`
+}
+
+// FrontendConfiguredAgent is the secret-free config inventory used by the
+// dashboard to surface agents that have no runtime process (notably agents
+// configured with enabled: false). Runtime details remain in FrontendAgent.
+type FrontendConfiguredAgent struct {
+	Name         string `json:"name"`
+	DisplayName  string `json:"displayName,omitempty"`
+	Description  string `json:"description,omitempty"`
+	SortOrder    int    `json:"sortOrder"`
+	Emoji        string `json:"emoji,omitempty"`
+	Color        string `json:"color,omitempty"`
+	Enabled      bool   `json:"enabled"`
+	ModelOwner   string `json:"modelOwner,omitempty"`
+	BackendOwner string `json:"backendOwner,omitempty"`
 }
 
 type FrontendGovernor struct {

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -200,6 +200,13 @@
     }
     .oc-nav-actions button:hover { background: var(--border); color: var(--text); }
     .oc-nav-actions .oc-nav-delete:hover { background: var(--oc-accent-light); color: var(--oc-accent); }
+    .oc-nav-item.disabled-agent { opacity: 0.58; cursor: default; }
+    .oc-nav-item.disabled-agent:hover { color: var(--muted); }
+    .oc-enable-agent {
+      border: 1px solid var(--border); border-radius: 4px; background: var(--panel);
+      color: var(--muted); cursor: pointer; font-size: 0.62rem; padding: 1px 5px;
+    }
+    .oc-enable-agent:hover { color: var(--green); border-color: var(--green); }
     .mode-badge { font-size: 0.7rem; margin-left: 2px; opacity: 0.8; }
     /* Active nav — amber accent bar (brand chrome), both modes.
        --oc-accent stays red for non-nav uses (delete affordances). */
@@ -4486,6 +4493,13 @@
     }
 
     function _sidebarRenderAgent(a) {
+      if (a.configDisabled === true) {
+        const label = a.displayName || a.name;
+        const ownerBits = [a.backendOwner && `backend: ${a.backendOwner}`, a.modelOwner && `model: ${a.modelOwner}`].filter(Boolean);
+        const title = `Configured but disabled${ownerBits.length ? ' — ' + ownerBits.join(', ') : ''}`;
+        const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
+        return `<div class="oc-nav-item disabled-agent" data-agent-nav="${esc(a.name)}" title="${esc(title)}"><span class="oc-agent-dot off"></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span><button class="oc-enable-agent" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" data-tab="General" title="Configure and enable ${esc(label)}">Enable…</button><span class="oc-nav-actions"><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></div>`;
+      }
       const isOnDemand = a.onDemand === true;
       // Manual/persisted pause wins over offByCadence — see the agent-detail
       // renderer for the incident this ordering prevents.
@@ -4759,7 +4773,7 @@
     function ocUpdateSidebarAgents() {
       const tree = document.getElementById('oc-agent-tree');
       if (!tree) return;
-      const agents = window._lastAgents || [];
+      const agents = _sidebarAgents();
       const agentMap = {};
       agents.forEach(a => { agentMap[a.name] = a; });
       const groups = _sidebarBuildGroups(agents);
@@ -4798,6 +4812,17 @@
         }
       });
       _sidebarAttachDragHandlers();
+    }
+
+    function _sidebarAgents() {
+      const runtime = [...(window._lastAgents || [])];
+      const runtimeNames = new Set(runtime.map(a => a.name));
+      for (const configured of (window._configuredAgents || [])) {
+        if (!configured.enabled && !runtimeNames.has(configured.name)) {
+          runtime.push({ ...configured, configDisabled: true });
+        }
+      }
+      return runtime;
     }
 
     applyLayout(getLayout());
@@ -12485,6 +12510,7 @@ function burnAreaChart() {
       window._healthData = data.health || {};
       window._tokensByAgent = (data.tokens || {}).byAgent || {};
       window._lastAgents = data.agents || [];
+      window._configuredAgents = data.configuredAgents || [];
       window._lastStatus = data;
       if (window._acmmOverride) {
         if (data.acmmLevel === window._acmmOverride.level) {
@@ -15145,6 +15171,7 @@ function burnAreaChart() {
         try {
           const payload = JSON.parse(e.data);
           window._lastAgents = payload.agents || [];
+          window._configuredAgents = payload.configuredAgents || window._configuredAgents || [];
           if (window._lastStatus) {
             window._lastStatus.agents = payload.agents || [];
           }
@@ -17692,6 +17719,11 @@ function burnAreaChart() {
           <label>Name <span style="color:var(--red)">*</span> <span class="config-info">i<span class="config-tooltip">The agent's internal name used as its ID, config file name, and tmux session. Lowercase, hyphens allowed.</span></span></label>
           <input type="text" id="cfg-create-name" value="" placeholder="e.g. docs-writer, sec-scanner" data-change-action="markDirty" data-arg0="_create" data-arg1="name" data-arg-types="s,s,v">
           <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lowercase, hyphens allowed. Used as the agent ID.</div>
+        </div>`;
+      } else {
+        html += `<div class="config-toggle">
+          <div class="config-toggle-switch ${g.enabled ? 'on' : ''}" id="cfg-agent-enabled" data-action="toggleConfigSwitch" data-section="general" data-key="enabled"></div>
+          <span class="config-toggle-label">Enabled <span class="config-info">i<span class="config-tooltip">Disabled agents remain configured but do not run. Enable this agent and Save to start it.</span></span></span>
         </div>`;
       }
       html += `

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -204,9 +204,10 @@ func InferenceAuthError() (errMsg string, since time.Time) {
 // AgentStatusPayload is a lightweight payload containing only agent metadata,
 // broadcast on a fast cadence (every ~10s) independent of the full eval cycle.
 type AgentStatusPayload struct {
-	Timestamp string          `json:"timestamp"`
-	Agents    []FrontendAgent `json:"agents"`
-	GovMode   string          `json:"govMode"`
+	Timestamp        string                    `json:"timestamp"`
+	Agents           []FrontendAgent           `json:"agents"`
+	ConfiguredAgents []FrontendConfiguredAgent `json:"configuredAgents"`
+	GovMode          string                    `json:"govMode"`
 }
 
 // BuildAgentOnlyStatus builds a lightweight agent-only status from in-memory
@@ -217,9 +218,10 @@ func BuildAgentOnlyStatus(
 	cfg *config.Config,
 ) *AgentStatusPayload {
 	return &AgentStatusPayload{
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Agents:    buildAgents(agentStatuses, cfg, govState),
-		GovMode:   strings.ToLower(string(govState.Mode)),
+		Timestamp:        time.Now().UTC().Format(time.RFC3339),
+		Agents:           buildAgents(agentStatuses, cfg, govState),
+		ConfiguredAgents: buildConfiguredAgents(cfg),
+		GovMode:          strings.ToLower(string(govState.Mode)),
 	}
 }
 
@@ -246,6 +248,7 @@ func BuildFrontendStatus(
 		Timestamp:           time.Now().UTC().Format(time.RFC3339),
 		HiveID:              cfg.HiveID,
 		Agents:              buildAgents(agentStatuses, cfg, govState),
+		ConfiguredAgents:    buildConfiguredAgents(cfg),
 		Governor:            buildGovernor(govState, cfg),
 		Tokens:              buildTokens(tokenCollector),
 		Repos:               buildRepos(cfg, actionable),
@@ -266,6 +269,35 @@ func BuildFrontendStatus(
 		Security:            buildSecurity(cfg),
 	}
 	return payload
+}
+
+func buildConfiguredAgents(cfg *config.Config) []FrontendConfiguredAgent {
+	if cfg == nil {
+		return []FrontendConfiguredAgent{}
+	}
+	names := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		left, right := cfg.Agents[names[i]], cfg.Agents[names[j]]
+		if left.GetSortOrder() != right.GetSortOrder() {
+			return left.GetSortOrder() < right.GetSortOrder()
+		}
+		return names[i] < names[j]
+	})
+
+	agents := make([]FrontendConfiguredAgent, 0, len(names))
+	for _, name := range names {
+		agentCfg := cfg.Agents[name]
+		agents = append(agents, FrontendConfiguredAgent{
+			Name: name, DisplayName: agentCfg.DisplayName,
+			Description: agentCfg.Description, SortOrder: agentCfg.GetSortOrder(),
+			Emoji: agentCfg.Emoji, Color: agentCfg.Color, Enabled: agentCfg.Enabled,
+			ModelOwner: agentCfg.ModelOwner, BackendOwner: agentCfg.BackendOwner,
+		})
+	}
+	return agents
 }
 
 // buildSecurity summarizes operator-facing security posture from effective


### PR DESCRIPTION
Closes #4729.

## What operators saw

Agents configured with `enabled: false` disappeared completely from the dashboard because `/api/status` only described processes known to the agent manager. The **+ agent** control could not fill the gap: it is an import/create flow, so using it for an existing configured name risks a conflicting definition instead of enabling the dormant one.

There was a second blocker behind that UI gap. `GET /api/config/agent/{name}` first found the disabled agent in `Config.Agents`, but then returned 404 when `AgentMgr.GetStatus(name)` found no process. That meant the existing configuration dialog could not be populated for exactly the agents that needed an enable path.

## What changed

### Publish configured-agent inventory separately from runtime status

Both full status snapshots and fast agent-status SSE events now include a small, secret-free `configuredAgents` inventory. It contains the identity and ordering fields needed by the sidebar, the enabled bit, and the existing model/backend ownership markers. Runtime state remains in the existing `agents` array, so disabled entries do not masquerade as crashed processes or affect health, cards, token accounting, or agent-detail behavior.

The inventory is sorted with the same configured sort order/name rules as the runtime list. The sidebar merges only configured-disabled entries that are absent from runtime status, rendering them as muted rows with a visible **Enable…** action. Existing sidebar groups continue to work because the disabled rows participate in the same name-based layout mapping.

### Make config reads work without a process

`handleAgentConfigGet` now treats process status as optional after the configuration lookup succeeds. When a process exists, live backend/model overrides, the last prompt, and runtime CLI pin state still win as before. When it does not, the response uses the persisted config and neutral runtime-only defaults instead of returning 404.

The General response now also carries `enabled`, `modelOwner`, and `backendOwner`. The ownership values are surfaced in the disabled-row tooltip, so operators can see whether pack or operator choices protect the backend/model before enabling the agent.

### Reuse the existing save/reconcile path

The existing agent General tab now has an **Enabled** switch for configured agents. **Enable…** opens that tab pre-populated from the dormant agent's real configuration; toggling Enabled and clicking Save sends the existing general-config PUT. No new mutation endpoint or duplicate creation path was introduced. The handler's existing `ReconcileAgents`, `Start`, governor update, persistence, and status refresh logic makes the newly enabled agent live.

The switch is intentionally absent from Create Agent, whose payload already creates enabled agents.

## Tests

- Added a regression test proving a configured disabled agent with no manager process returns 200 from the config GET, including `enabled: false` and ownership markers.
- Added coverage for the complete configured-agent inventory and deterministic ordering.
- Added an embedded-dashboard wiring test for inventory consumption, disabled-row rendering, the Enable action, and the General-tab switch.
- Ran `go test ./pkg/dashboard` successfully.

— hive: backend=codex
