### PR TITLE
🌱 fix(quality): validate end-to-end coverage evidence

### DIFF
--- a/src/pkg/policies/defaults/quality-advisory.md
+++ b/src/pkg/policies/defaults/quality-advisory.md
@@ -26,7 +26,8 @@ After analyzing the codebase, record each finding as a bead using `bd create`. *
 
 **STOP CHECK before every `bd create`**: if your title contains placeholder text, DO NOT run the command.
 
-Priority levels: 0 (critical — untested auth/data mutation), 1 (high — major business logic gap), 2 (medium — significant gap), 3 (low — nice-to-have)
+Priority levels for non-coverage findings: 0 (critical), 1 (high), 2 (medium), 3 (low).
+For `coverage-gap` findings, use the mandatory coverage evidence and priority rules below; a coverage gap is never priority 0.
 
 Then add detail metadata:
 
@@ -36,7 +37,33 @@ bd update <bead-id> --set-metadata detail="<real explanation>"
 bd update <bead-id> --set-metadata file="<real-file-path>"
 ```
 
-Finding types: `coverage-gap`, `missing-fixture`, `regression-risk`, `test-quality`
+Finding types: `coverage-gap`, `coverage-reporting`, `test-infrastructure`, `missing-fixture`, `regression-risk`, `test-quality`
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -61,12 +88,13 @@ ${PR_LIST}
    - At the end, print a single summary line: `Reap: <N> open, <M> closed this cycle`
 
    For each open bead:
+   - Reapply the mandatory coverage evidence gate above; do not retain or close a finding from unit coverage alone.
    - Check the `external_ref` (file path) — has test coverage been added for this gap?
    - If the coverage gap has been addressed, close the bead:
      ```bash
      bd close <bead-id>
      ```
-3. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+3. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 4. Identify the top coverage gaps by impact
 5. Create a bead for each finding with `bd create`
 6. Summarize what you found (new findings and reaped stale ones) — keep it concise, no raw tables

--- a/src/pkg/policies/defaults/quality-full.md
+++ b/src/pkg/policies/defaults/quality-full.md
@@ -62,7 +62,34 @@ bd create --title "<specific coverage gap title>" \
   --type advisory --priority <0-3> --actor quality --external-ref "path/to/untested/file.go"
 ```
 
-Priority: 0 (critical untested path), 1 (major logic gap), 2 (significant gap), 3 (minor/nice-to-have)
+Priority for non-coverage findings: 0 (critical), 1 (high), 2 (medium), 3 (low).
+For `coverage-gap` findings, use the mandatory evidence and priority rules below. A coverage gap is never priority 0.
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -77,7 +104,7 @@ ${PR_LIST}
 ## Workflow
 
 1. Read the kick message
-2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+2. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 3. Identify top coverage gaps by impact
 4. Create a bead for each finding
 5. For high-priority findings, open a GitHub issue

--- a/src/pkg/policies/defaults/quality-holdgated.md
+++ b/src/pkg/policies/defaults/quality-holdgated.md
@@ -93,10 +93,8 @@ bd create --title "Short description of the coverage gap" \
 ```
 
 ### Priority levels
-- **0** (critical) — critical untested code path (auth, data mutation, error handling)
-- **1** (high) — major gap in business logic coverage
-- **2** (medium) — significant gap worth addressing
-- **3** (low) — minor gap, nice-to-have test
+- For non-coverage findings: **0** (critical), **1** (high), **2** (medium), **3** (low).
+- For `coverage-gap` findings, use the mandatory evidence and priority rules below. A coverage gap is never priority 0.
 
 Then add detail metadata:
 
@@ -105,6 +103,32 @@ bd update <bead-id> --set-metadata finding_type=coverage-gap
 bd update <bead-id> --set-metadata detail="Detailed explanation of what needs testing"
 bd update <bead-id> --set-metadata file="path/to/file.go"
 ```
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -119,7 +143,7 @@ ${PR_LIST}
 ## Workflow
 
 1. Read the kick message
-2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+2. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 3. Identify the top coverage gaps by impact
 4. Create a bead for each finding with `bd create`
 5. For high-priority findings, open a GitHub issue

--- a/src/pkg/policies/defaults/quality-measured.md
+++ b/src/pkg/policies/defaults/quality-measured.md
@@ -58,10 +58,8 @@ bd create --title "Short description of the coverage gap" \
 ```
 
 ### Priority levels
-- **0** (critical) — critical untested code path (auth, data mutation, error handling)
-- **1** (high) — major gap in business logic coverage
-- **2** (medium) — significant gap worth addressing
-- **3** (low) — minor gap, nice-to-have test
+- For non-coverage findings: **0** (critical), **1** (high), **2** (medium), **3** (low).
+- For `coverage-gap` findings, use the mandatory evidence and priority rules below. A coverage gap is never priority 0.
 
 Then add detail metadata:
 
@@ -70,6 +68,32 @@ bd update <bead-id> --set-metadata finding_type=coverage-gap
 bd update <bead-id> --set-metadata detail="Detailed explanation of what needs testing"
 bd update <bead-id> --set-metadata file="path/to/file.go"
 ```
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -84,7 +108,7 @@ ${PR_LIST}
 ## Workflow
 
 1. Read the kick message
-2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+2. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 3. Identify the top coverage gaps by impact
 4. Create a bead for each finding with `bd create`
 5. For high-priority findings, open a GitHub issue

--- a/src/pkg/policies/quality_coverage_evidence_test.go
+++ b/src/pkg/policies/quality_coverage_evidence_test.go
@@ -1,0 +1,53 @@
+package policies
+
+import (
+	"bytes"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+)
+
+func TestQualityPoliciesRequireCombinedCoverageEvidence(t *testing.T) {
+	t.Parallel()
+
+	policyNames := []string{
+		"quality-advisory.md",
+		"quality-measured.md",
+		"quality-holdgated.md",
+		"quality-full.md",
+	}
+	required := [][]byte{
+		[]byte("## Coverage Evidence and Priority (MANDATORY)"),
+		[]byte("gh run list"),
+		[]byte("gh run download"),
+		[]byte("Combine unit and end-to-end coverage evidence"),
+		[]byte("Do not infer missing end-to-end coverage from a unit `coverprofile`"),
+		[]byte("including the workflow run ID and SHA used"),
+		[]byte("Never assign priority 0 (critical) to a `coverage-gap`"),
+	}
+
+	for _, name := range policyNames {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			embedded, err := DefaultPolicies.ReadFile(path.Join("defaults", name))
+			if err != nil {
+				t.Fatalf("read embedded policy: %v", err)
+			}
+			source, err := os.ReadFile(filepath.Join("..", "..", "policies", name))
+			if err != nil {
+				t.Fatalf("read source policy: %v", err)
+			}
+			if !bytes.Equal(source, embedded) {
+				t.Fatal("source policy and embedded default differ")
+			}
+			for _, marker := range required {
+				if !bytes.Contains(embedded, marker) {
+					t.Errorf("policy is missing coverage guardrail %q", marker)
+				}
+			}
+		})
+	}
+}

--- a/src/policies/quality-advisory.md
+++ b/src/policies/quality-advisory.md
@@ -26,7 +26,8 @@ After analyzing the codebase, record each finding as a bead using `bd create`. *
 
 **STOP CHECK before every `bd create`**: if your title contains placeholder text, DO NOT run the command.
 
-Priority levels: 0 (critical — untested auth/data mutation), 1 (high — major business logic gap), 2 (medium — significant gap), 3 (low — nice-to-have)
+Priority levels for non-coverage findings: 0 (critical), 1 (high), 2 (medium), 3 (low).
+For `coverage-gap` findings, use the mandatory coverage evidence and priority rules below; a coverage gap is never priority 0.
 
 Then add detail metadata:
 
@@ -36,7 +37,33 @@ bd update <bead-id> --set-metadata detail="<real explanation>"
 bd update <bead-id> --set-metadata file="<real-file-path>"
 ```
 
-Finding types: `coverage-gap`, `missing-fixture`, `regression-risk`, `test-quality`
+Finding types: `coverage-gap`, `coverage-reporting`, `test-infrastructure`, `missing-fixture`, `regression-risk`, `test-quality`
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -61,12 +88,13 @@ ${PR_LIST}
    - At the end, print a single summary line: `Reap: <N> open, <M> closed this cycle`
 
    For each open bead:
+   - Reapply the mandatory coverage evidence gate above; do not retain or close a finding from unit coverage alone.
    - Check the `external_ref` (file path) — has test coverage been added for this gap?
    - If the coverage gap has been addressed, close the bead:
      ```bash
      bd close <bead-id>
      ```
-3. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+3. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 4. Identify the top coverage gaps by impact
 5. Create a bead for each finding with `bd create`
 6. Summarize what you found (new findings and reaped stale ones) — keep it concise, no raw tables

--- a/src/policies/quality-full.md
+++ b/src/policies/quality-full.md
@@ -62,7 +62,34 @@ bd create --title "<specific coverage gap title>" \
   --type advisory --priority <0-3> --actor quality --external-ref "path/to/untested/file.go"
 ```
 
-Priority: 0 (critical untested path), 1 (major logic gap), 2 (significant gap), 3 (minor/nice-to-have)
+Priority for non-coverage findings: 0 (critical), 1 (high), 2 (medium), 3 (low).
+For `coverage-gap` findings, use the mandatory evidence and priority rules below. A coverage gap is never priority 0.
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -77,7 +104,7 @@ ${PR_LIST}
 ## Workflow
 
 1. Read the kick message
-2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+2. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 3. Identify top coverage gaps by impact
 4. Create a bead for each finding
 5. For high-priority findings, open a GitHub issue

--- a/src/policies/quality-holdgated.md
+++ b/src/policies/quality-holdgated.md
@@ -93,10 +93,8 @@ bd create --title "Short description of the coverage gap" \
 ```
 
 ### Priority levels
-- **0** (critical) — critical untested code path (auth, data mutation, error handling)
-- **1** (high) — major gap in business logic coverage
-- **2** (medium) — significant gap worth addressing
-- **3** (low) — minor gap, nice-to-have test
+- For non-coverage findings: **0** (critical), **1** (high), **2** (medium), **3** (low).
+- For `coverage-gap` findings, use the mandatory evidence and priority rules below. A coverage gap is never priority 0.
 
 Then add detail metadata:
 
@@ -105,6 +103,32 @@ bd update <bead-id> --set-metadata finding_type=coverage-gap
 bd update <bead-id> --set-metadata detail="Detailed explanation of what needs testing"
 bd update <bead-id> --set-metadata file="path/to/file.go"
 ```
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -119,7 +143,7 @@ ${PR_LIST}
 ## Workflow
 
 1. Read the kick message
-2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+2. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 3. Identify the top coverage gaps by impact
 4. Create a bead for each finding with `bd create`
 5. For high-priority findings, open a GitHub issue

--- a/src/policies/quality-measured.md
+++ b/src/policies/quality-measured.md
@@ -58,10 +58,8 @@ bd create --title "Short description of the coverage gap" \
 ```
 
 ### Priority levels
-- **0** (critical) — critical untested code path (auth, data mutation, error handling)
-- **1** (high) — major gap in business logic coverage
-- **2** (medium) — significant gap worth addressing
-- **3** (low) — minor gap, nice-to-have test
+- For non-coverage findings: **0** (critical), **1** (high), **2** (medium), **3** (low).
+- For `coverage-gap` findings, use the mandatory evidence and priority rules below. A coverage gap is never priority 0.
 
 Then add detail metadata:
 
@@ -70,6 +68,32 @@ bd update <bead-id> --set-metadata finding_type=coverage-gap
 bd update <bead-id> --set-metadata detail="Detailed explanation of what needs testing"
 bd update <bead-id> --set-metadata file="path/to/file.go"
 ```
+
+## Coverage Evidence and Priority (MANDATORY)
+
+Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
+
+1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
+3. Inspect recent successful runs and download the relevant artifacts. For example:
+   ```bash
+   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
+     --json databaseId,name,workflowName,headBranch,headSha,createdAt
+   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
+   ```
+   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
+4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+
+Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
+
+- **Priority 1 (high)**: covered by neither unit nor end-to-end tests.
+- **Priority 2 (medium)**: covered by unit tests but not end-to-end tests.
+- **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
+- **No coverage-gap finding**: covered by both unit and end-to-end tests.
+
+Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 
@@ -84,7 +108,7 @@ ${PR_LIST}
 ## Workflow
 
 1. Read the kick message
-2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+2. Analyze unit and end-to-end test coverage using the mandatory evidence gate above
 3. Identify the top coverage gaps by impact
 4. Create a bead for each finding with `bd create`
 5. For high-priority findings, open a GitHub issue


### PR DESCRIPTION
## Summary

- require quality agents to combine unit and end-to-end coverage before creating, retaining, reprioritizing, or closing coverage findings
- document how to discover and download successful workflow artifacts and require run/SHA provenance in every coverage-gap finding
- cap coverage-gap severity by the missing coverage layer and prohibit CRITICAL coverage-gap findings
- keep source and embedded policy copies synchronized with a regression test across all ACMM modes

Fixes #4734

## Testing

- `go test ./pkg/policies`
- `go test ./pkg/scheduler`
- validated the documented `gh run list` JSON fields against `kubestellar/hive`

— hive: backend=codex
