### PR TITLE
🐛 fix(contributor): load bob hive knowledge

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -91,6 +91,65 @@ fetch_knowledge_export() {
   return 1
 }
 
+link_backend_knowledge() {
+  local backend="$1"
+  local agent_md="$2"
+
+  case "$backend" in
+    claude|litellm)
+      ln -sf "$agent_md" "${HOME}/CLAUDE.md"
+      ;;
+    copilot)
+      mkdir -p "${HOME}/.copilot"
+      ln -sf "$agent_md" "${HOME}/copilot-instructions.md"
+      ln -sf "$agent_md" "${HOME}/COPILOT.md"
+      ln -sf "$agent_md" "${HOME}/CLAUDE.md"
+      ;;
+    goose)
+      # Goose reads AGENTS.md and .goosehints; .goose-instructions.md / CLAUDE.md
+      # are NOT names it looks for (unless CONTEXT_FILE_NAMES is overridden), so
+      # without these two the knowledge export downloaded above never reached the
+      # model. Keep the old names for backward-compat, but add the ones Goose
+      # actually reads. (kubestellar/hive#2393 item 1.)
+      ln -sf "$agent_md" "${HOME}/AGENTS.md"
+      ln -sf "$agent_md" "${HOME}/.goosehints"
+      ln -sf "$agent_md" "${HOME}/.goose-instructions.md"
+      ln -sf "$agent_md" "${HOME}/CLAUDE.md"
+      mkdir -p "${HOME}/.config/goose"
+      # Write the config only if the contributor/derived image hasn't provided one,
+      # so a downstream can add Goose extensions (MCP servers) or other settings
+      # without it being clobbered on every start. (kubestellar/hive#2393 item 3.)
+      if [ ! -f "${HOME}/.config/goose/config.yaml" ]; then
+        cat > "${HOME}/.config/goose/config.yaml" <<GOOSECFG
+GOOSE_PROVIDER: ${GOOSE_PROVIDER:-ollama}
+GOOSE_MODEL: ${GOOSE_MODEL:-phi4}
+GOOSECFG
+        echo "Goose config: provider=${GOOSE_PROVIDER:-ollama} model=${GOOSE_MODEL:-phi4}"
+      else
+        echo "Goose config: keeping existing ${HOME}/.config/goose/config.yaml"
+      fi
+      ;;
+    codex|pi)
+      ln -sf "$agent_md" "${HOME}/AGENTS.md"
+      ln -sf "$agent_md" "${HOME}/CLAUDE.md"
+      ;;
+    bob)
+      # Bobshell 1.0.6 defaults to AGENTS.md and documents ~/.bob/AGENTS.md as
+      # its global context file. It does not load ~/CLAUDE.md. Keep the latter
+      # compatibility link while also installing the export where Bob reads it.
+      mkdir -p "${HOME}/.bob"
+      ln -sf "$agent_md" "${HOME}/.bob/AGENTS.md"
+      ln -sf "$agent_md" "${HOME}/CLAUDE.md"
+      ;;
+    agy)
+      ln -sf "$agent_md" "${HOME}/CLAUDE.md"
+      ;;
+    *)
+      ln -sf "$agent_md" "${HOME}/CLAUDE.md"
+      ;;
+  esac
+}
+
 # Task-delivery mode (kubestellar/hive#2538). "interactive" (default) launches
 # the CLI in a tmux pane and the relay types tasks into it; "headless" skips the
 # tmux/CLI launch entirely and the relay drives a one-shot CLI per task with no
@@ -170,6 +229,11 @@ if [[ "${HIVE_CONTRIBUTOR_AGENT_TEST_KNOWLEDGE_FETCH:-}" == "1" ]]; then
   rm -f "$AGENT_MD"
   echo "knowledge_fetch=unavailable"
   exit 1
+fi
+
+if [[ "${HIVE_CONTRIBUTOR_AGENT_TEST_LINK_KNOWLEDGE:-}" == "1" ]]; then
+  link_backend_knowledge "$AGENT_BACKEND" "${HIVE_CONTRIBUTOR_AGENT_TEST_KNOWLEDGE_DEST:-${HOME}/agent.md}"
+  exit 0
 fi
 
 codex_auth_file() {
@@ -383,56 +447,8 @@ KNOWLEDGE_REFRESH_SECS=600
   done
 ) &
 
-# Make agent.md visible to each CLI backend
-case "$AGENT_BACKEND" in
-  claude|litellm)
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    ;;
-  copilot)
-    mkdir -p "${HOME}/.copilot"
-    ln -sf "$AGENT_MD" "${HOME}/copilot-instructions.md"
-    ln -sf "$AGENT_MD" "${HOME}/COPILOT.md"
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    ;;
-  goose)
-    # Goose reads AGENTS.md and .goosehints; .goose-instructions.md / CLAUDE.md
-    # are NOT names it looks for (unless CONTEXT_FILE_NAMES is overridden), so
-    # without these two the knowledge export downloaded above never reached the
-    # model. Keep the old names for backward-compat, but add the ones Goose
-    # actually reads. (kubestellar/hive#2393 item 1.)
-    ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"
-    ln -sf "$AGENT_MD" "${HOME}/.goosehints"
-    ln -sf "$AGENT_MD" "${HOME}/.goose-instructions.md"
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    mkdir -p "${HOME}/.config/goose"
-    # Write the config only if the contributor/derived image hasn't provided one,
-    # so a downstream can add Goose extensions (MCP servers) or other settings
-    # without it being clobbered on every start. (kubestellar/hive#2393 item 3.)
-    if [ ! -f "${HOME}/.config/goose/config.yaml" ]; then
-      cat > "${HOME}/.config/goose/config.yaml" <<GOOSECFG
-GOOSE_PROVIDER: ${GOOSE_PROVIDER:-ollama}
-GOOSE_MODEL: ${GOOSE_MODEL:-phi4}
-GOOSECFG
-      echo "Goose config: provider=${GOOSE_PROVIDER:-ollama} model=${GOOSE_MODEL:-phi4}"
-    else
-      echo "Goose config: keeping existing ${HOME}/.config/goose/config.yaml"
-    fi
-    ;;
-  codex)
-    ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    ;;
-  pi)
-    ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    ;;
-  agy)
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    ;;
-  *)
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    ;;
-esac
+# Make agent.md visible to the selected CLI backend.
+link_backend_knowledge "$AGENT_BACKEND" "$AGENT_MD"
 
 # Prepare a concrete workspace directory for the agent (kubestellar/hive#2545).
 # Previously the tmux session inherited the bare $HOME (/home/dev in the stock

--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -192,6 +192,28 @@ done
 echo "contributor-agent hook override tests passed"
 echo "contributor-agent knowledge fetch tests passed"
 
+rm -f "${HOME_DIR}/CLAUDE.md"
+rm -rf "${HOME_DIR}/.bob"
+BOB_AGENT_MD="${HOME_DIR}/agent.md"
+env -i \
+  PATH="${PATH}" \
+  HOME="$HOME_DIR" \
+  HIVE_REGISTRATION_TOKEN="test-token" \
+  HIVE_CONTRIBUTOR_AGENT_TEST_LINK_KNOWLEDGE=1 \
+  HIVE_CONTRIBUTOR_AGENT_TEST_KNOWLEDGE_DEST="$BOB_AGENT_MD" \
+  AGENT_BACKEND=bob \
+  bash "${ROOT_DIR}/bin/contributor-agent.sh"
+
+if [[ "$(readlink "${HOME_DIR}/.bob/AGENTS.md")" != "$BOB_AGENT_MD" ]]; then
+  echo "expected bob global AGENTS.md to link to the hive knowledge export" >&2
+  exit 1
+fi
+if [[ "$(readlink "${HOME_DIR}/CLAUDE.md")" != "$BOB_AGENT_MD" ]]; then
+  echo "expected bob's compatibility CLAUDE.md link to be retained" >&2
+  exit 1
+fi
+echo "contributor-agent bob knowledge link tests passed"
+
 codex_flags_output="$(
   env -i \
     PATH="${PATH}" \

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -91,8 +91,9 @@ mode fixed for Goose in [#2393](https://github.com/kubestellar/hive/issues/2393)
 | `goose` | `AGENTS.md`, `.goosehints`, `.goose-instructions.md`, `CLAUDE.md` |
 | `codex` | `AGENTS.md`, `CLAUDE.md` |
 | `pi` | `AGENTS.md`, `CLAUDE.md` |
+| `bob` | `.bob/AGENTS.md`, `CLAUDE.md` (compatibility) |
 | `agy` | `CLAUDE.md` |
-| anything else (incl. `bob`) | `CLAUDE.md` only — the `*` fallback |
+| anything else | `CLAUDE.md` only — the `*` fallback |
 
 A backend that reads neither `CLAUDE.md` nor one of the names above falls into
 the `*` branch and runs with no hive knowledge at all. When adding a backend,


### PR DESCRIPTION
## Summary

- give `bob` an explicit contributor knowledge mapping
- link the hive export to bobshell's documented global context path, `~/.bob/AGENTS.md`
- retain `~/CLAUDE.md` as a compatibility link and document the resolved mapping
- cover the Bob symlink contract in `contributor-agent.test.sh`

## Verification

- inspected Hive's checksum-pinned bobshell 1.0.6 bundle; its bundled configuration docs identify `~/.bob/AGENTS.md` as the global context file and its code defaults to `AGENTS.md`
- `bash bin/contributor-agent.test.sh`
- `shellcheck bin/contributor-agent.sh bin/contributor-agent.test.sh`
- `bash -n bin/contributor-agent.sh bin/contributor-agent.test.sh`
- `git diff --check`

Closes #4750.

— hive: backend=codex
