### PR TITLE
🐛 fix(dashboard): make a disabled agent's row say it is configurable, and show its mode

### DIFF
--- a/src/pkg/dashboard/disabled_agent_enable_test.go
+++ b/src/pkg/dashboard/disabled_agent_enable_test.go
@@ -53,12 +53,52 @@ func TestDisabledAgentSidebarEnableWiring(t *testing.T) {
 		`window._configuredAgents = data.configuredAgents || [];`,
 		`if (!configured.enabled && !runtimeNames.has(configured.name))`,
 		`class="oc-nav-item disabled-agent"`,
-		`data-tab="General" title="Configure and enable`,
+		// Wiring, not prose: the button must open the agent config dialog on the
+		// General tab. The visible label deliberately leads with a gear so the
+		// row reads as configurable rather than as a one-click state toggle.
+		`data-tab="General" title="Configure `,
+		`>⚙ Enable…</button>`,
 		`id="cfg-agent-enabled"`,
 		`data-key="enabled"`,
 	} {
 		if !strings.Contains(html, snippet) {
 			t.Errorf("index.html is missing disabled-agent enable wiring %q", snippet)
 		}
+	}
+}
+
+// TestConfiguredAgentsCarryResolvedMode pins the field the sidebar needs to
+// show what a disabled agent WOULD do once enabled. A disabled agent has no
+// runtime entry, so if buildConfiguredAgents omits the mode the badge silently
+// renders nothing — dead markup that looks fine in review.
+//
+// Both branches matter: an explicit per-agent Mode must win, and an agent that
+// sets none must still report the ACMM level default rather than empty.
+func TestConfiguredAgentsCarryResolvedMode(t *testing.T) {
+	level := 3
+	cfg := &config.Config{
+		ACMMLevel: &level,
+		Agents: map[string]config.AgentConfig{
+			"explicit": {Enabled: false, Mode: "ADVISORY"},
+			"default":  {Enabled: false},
+		},
+	}
+
+	got := map[string]FrontendConfiguredAgent{}
+	for _, a := range buildConfiguredAgents(cfg) {
+		got[a.Name] = a
+	}
+
+	if got["explicit"].Mode != "ADVISORY" {
+		t.Errorf("explicit Mode override must win: got %q, want ADVISORY", got["explicit"].Mode)
+	}
+	if got["explicit"].ModeEmoji == "" {
+		t.Error("explicit agent must carry a mode emoji for the sidebar badge")
+	}
+	if got["default"].Mode == "" {
+		t.Error("agent with no Mode override must still report the ACMM level default, not empty")
+	}
+	if got["default"].ModeEmoji == "" {
+		t.Error("level-default agent must carry a mode emoji too")
 	}
 }

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -495,6 +495,13 @@ type FrontendConfiguredAgent struct {
 	Enabled      bool   `json:"enabled"`
 	ModelOwner   string `json:"modelOwner,omitempty"`
 	BackendOwner string `json:"backendOwner,omitempty"`
+	// Mode/ModeEmoji are resolved the same way buildAgents resolves them for a
+	// running agent: the agent's own Mode override if set, else the ACMM level
+	// default. A disabled agent has no runtime entry, so without these the
+	// sidebar cannot say what the agent WOULD do once enabled — which is the
+	// one thing an operator wants to check before enabling it.
+	Mode      string `json:"mode,omitempty"`
+	ModeEmoji string `json:"modeEmoji,omitempty"`
 }
 
 type FrontendGovernor struct {

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4546,7 +4546,15 @@
         const ownerBits = [a.backendOwner && `backend: ${a.backendOwner}`, a.modelOwner && `model: ${a.modelOwner}`].filter(Boolean);
         const title = `Configured but disabled${ownerBits.length ? ' — ' + ownerBits.join(', ') : ''}`;
         const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
-        return `<div class="oc-nav-item disabled-agent" data-agent-nav="${esc(a.name)}" title="${esc(title)}"><span class="oc-agent-dot off"></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span><button class="oc-enable-agent" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" data-tab="General" title="Configure and enable ${esc(label)}">Enable…</button><span class="oc-nav-actions"><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></div>`;
+        // Mode badge on the disabled row too: the mode an agent WOULD run in is
+        // exactly what you want to check before turning it on, and it is the one
+        // field the enable dialog cannot show you from the sidebar.
+        const modeHtml = (a.modeEmoji || a.mode) ? `<span class="oc-nav-mode" title="${esc(a.mode || '')}">${a.modeEmoji || modeEmoji(a.mode)}</span>` : '';
+        // The gear matches the ⚙ on enabled rows on purpose. This button opens the
+        // SAME agent config dialog they do — enabling is one field inside it, not a
+        // one-click flip — and a bare "Enable…" read as a state toggle, so nobody
+        // discovered that a disabled agent is fully configurable before it runs.
+        return `<div class="oc-nav-item disabled-agent" data-agent-nav="${esc(a.name)}" title="${esc(title)}"><span class="oc-agent-dot off"></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span>${modeHtml}<button class="oc-enable-agent" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" data-tab="General" title="Configure ${esc(label)} — review its settings and enable it from the General tab">⚙ Enable…</button><span class="oc-nav-actions"><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></div>`;
       }
       const isOnDemand = a.onDemand === true;
       // Manual/persisted pause wins over offByCadence — see the agent-detail

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -287,14 +287,28 @@ func buildConfiguredAgents(cfg *config.Config) []FrontendConfiguredAgent {
 		return names[i] < names[j]
 	})
 
+	acmmLevel := 0
+	if cfg.ACMMLevel != nil {
+		acmmLevel = *cfg.ACMMLevel
+	}
+
 	agents := make([]FrontendConfiguredAgent, 0, len(names))
 	for _, name := range names {
 		agentCfg := cfg.Agents[name]
+		// Same resolution buildAgents uses: explicit per-agent Mode wins,
+		// otherwise the ACMM level default for this agent.
+		mode := agent.DefaultAgentMode(name, acmmLevel)
+		if modeStr := agentCfg.Mode; modeStr != "" {
+			if parsed, ok := agent.ParseAgentMode(modeStr); ok {
+				mode = parsed
+			}
+		}
 		agents = append(agents, FrontendConfiguredAgent{
 			Name: name, DisplayName: agentCfg.DisplayName,
 			Description: agentCfg.Description, SortOrder: agentCfg.GetSortOrder(),
 			Emoji: agentCfg.Emoji, Color: agentCfg.Color, Enabled: agentCfg.Enabled,
 			ModelOwner: agentCfg.ModelOwner, BackendOwner: agentCfg.BackendOwner,
+			Mode: mode.String(), ModeEmoji: mode.Emoji(),
 		})
 	}
 	return agents


### PR DESCRIPTION
Follow-up to #4743 (merged), from an operator reading the sidebar rather than
the code.

## "Enable…" hid the thing it does

The button already opened the **same** agent config dialog the `⚙` on an
enabled row opens — `openConfigDialog` with `data-tab="General"`. Enabling is
one field inside that dialog, not a one-click flip. But a bare "Enable…" reads
as a state toggle, so the answer to "can I configure a disabled agent before
turning it on?" looked like *no* when it was already *yes*.

Lead the label with the same gear the enabled rows use: `⚙ Enable…`.

## A disabled row could not show its mode

`FrontendConfiguredAgent` carried no mode at all. A disabled agent has no
runtime entry, so the sidebar could not say what it **would** do once enabled —
arguably the one thing worth checking before enabling something. `quality`
showing 🔧 (ISSUES_AND_PRS) next to an advisory 📝 agent is exactly the signal
that matters, and disabled agents were missing it.

Resolved the same way `buildAgents` resolves it for a running agent: an
explicit per-agent `Mode` wins, otherwise the ACMM level default.

## Tests

`TestConfiguredAgentsCarryResolvedMode` covers **both** branches. The
level-default branch is the one that matters: without it an agent that sets no
`Mode` reports empty, the badge renders nothing, and the result is dead markup
that reviews clean.

`TestDisabledAgentSidebarEnableWiring` pinned the old title prose. It now
asserts the durable part — the dialog opens on the General tab — plus the gear
label.

Full `pkg/dashboard` suite passes; `go vet` clean.

Refs #4729