### PR TITLE
🐛 fix(quality): make coverage analysis repository-aware

### DIFF
--- a/src/pkg/policies/defaults/quality-advisory.md
+++ b/src/pkg/policies/defaults/quality-advisory.md
@@ -43,18 +43,13 @@ Finding types: `coverage-gap`, `coverage-reporting`, `test-infrastructure`, `mis
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -63,7 +58,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 

--- a/src/pkg/policies/defaults/quality-full.md
+++ b/src/pkg/policies/defaults/quality-full.md
@@ -69,18 +69,13 @@ For `coverage-gap` findings, use the mandatory evidence and priority rules below
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -89,7 +84,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 

--- a/src/pkg/policies/defaults/quality-holdgated.md
+++ b/src/pkg/policies/defaults/quality-holdgated.md
@@ -108,18 +108,13 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -128,7 +123,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 

--- a/src/pkg/policies/defaults/quality-measured.md
+++ b/src/pkg/policies/defaults/quality-measured.md
@@ -73,18 +73,13 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -93,7 +88,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 

--- a/src/pkg/policies/quality_coverage_evidence_test.go
+++ b/src/pkg/policies/quality_coverage_evidence_test.go
@@ -19,12 +19,18 @@ func TestQualityPoliciesRequireCombinedCoverageEvidence(t *testing.T) {
 	}
 	required := [][]byte{
 		[]byte("## Coverage Evidence and Priority (MANDATORY)"),
+		[]byte("Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format"),
+		[]byte("mechanism the repository actually uses"),
+		[]byte("combine their raw data at statement/line granularity"),
+		[]byte("go tool covdata merge"),
+		[]byte("same code revision with compatible build metadata"),
+		[]byte("Do not infer missing end-to-end coverage from a unit `coverprofile`"),
+		[]byte("suite and command or job, code revision, and run URL/ID or artifact timestamp"),
+		[]byte("Never assign priority 0 (critical) to a `coverage-gap`"),
+	}
+	forbidden := [][]byte{
 		[]byte("gh run list"),
 		[]byte("gh run download"),
-		[]byte("Combine unit and end-to-end coverage evidence"),
-		[]byte("Do not infer missing end-to-end coverage from a unit `coverprofile`"),
-		[]byte("including the workflow run ID and SHA used"),
-		[]byte("Never assign priority 0 (critical) to a `coverage-gap`"),
 	}
 
 	for _, name := range policyNames {
@@ -46,6 +52,11 @@ func TestQualityPoliciesRequireCombinedCoverageEvidence(t *testing.T) {
 			for _, marker := range required {
 				if !bytes.Contains(embedded, marker) {
 					t.Errorf("policy is missing coverage guardrail %q", marker)
+				}
+			}
+			for _, marker := range forbidden {
+				if bytes.Contains(embedded, marker) {
+					t.Errorf("policy assumes GitHub Actions coverage discovery %q", marker)
 				}
 			}
 		})

--- a/src/policies/quality-advisory.md
+++ b/src/policies/quality-advisory.md
@@ -43,18 +43,13 @@ Finding types: `coverage-gap`, `coverage-reporting`, `test-infrastructure`, `mis
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -63,7 +58,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 

--- a/src/policies/quality-full.md
+++ b/src/policies/quality-full.md
@@ -69,18 +69,13 @@ For `coverage-gap` findings, use the mandatory evidence and priority rules below
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -89,7 +84,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 

--- a/src/policies/quality-holdgated.md
+++ b/src/policies/quality-holdgated.md
@@ -108,18 +108,13 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -128,7 +123,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 

--- a/src/policies/quality-measured.md
+++ b/src/policies/quality-measured.md
@@ -73,18 +73,13 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 
 Before creating, retaining, reprioritizing, or closing a `coverage-gap` finding:
 
-1. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
-2. Inspect `.github/workflows` to identify end-to-end jobs and the coverage artifacts they upload.
-3. Inspect recent successful runs and download the relevant artifacts. For example:
-   ```bash
-   gh run list --repo "$HIVE_REPO" --status success --limit 20 \
-     --json databaseId,name,workflowName,headBranch,headSha,createdAt
-   gh run download <run-id> --repo "$HIVE_REPO" --dir /tmp/hive-quality-coverage-<run-id>
-   ```
-   Select runs for the repository's default branch and record the run ID, commit SHA, and artifact timestamp.
-4. Combine unit and end-to-end coverage evidence before deciding whether the path is uncovered.
+1. Discover the repository's unit, integration, and end-to-end test suites and their coverage outputs from its documentation, test configuration, CI definitions, and available knowledge. Do not assume a particular language, CI provider, branch, workflow, artifact name, or coverage format.
+2. Generate or read unit-test coverage (`go test -coverprofile=coverage.out ./...` or the project's equivalent).
+3. Obtain the most recent relevant integration/end-to-end coverage evidence from the mechanism the repository actually uses (for example, a local test command, CI artifact, or coverage service). Record reproducible provenance: the suite and command or job, code revision, and run URL/ID or artifact timestamp when available.
+4. When suites expose compatible machine-readable coverage, combine their raw data at statement/line granularity before deciding whether a path is uncovered. Prefer the toolchain's supported merge mechanism (for example, `go tool covdata merge` for Go coverage-data directories), and only merge data produced for the same code revision with compatible build metadata. Do not substitute a textual function summary for raw data that can be combined.
+5. If evidence cannot be combined, analyze each coverage source separately and state that limitation in the finding.
 
-Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end artifacts are unavailable, expired, stale, or cannot be downloaded, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
+Do not infer missing end-to-end coverage from a unit `coverprofile`. If end-to-end evidence is unavailable, stale, or inaccessible, do not claim that the path lacks end-to-end coverage. Record a separate `coverage-reporting` or `test-infrastructure` finding instead.
 
 Apply these maximum priorities to `coverage-gap` findings, regardless of code impact:
 
@@ -93,7 +88,7 @@ Apply these maximum priorities to `coverage-gap` findings, regardless of code im
 - **Priority 3 (low)**: covered by end-to-end tests but not unit tests.
 - **No coverage-gap finding**: covered by both unit and end-to-end tests.
 
-Every coverage-gap detail must state the unit evidence and the end-to-end evidence, including the workflow run ID and SHA used. Never assign priority 0 (critical) to a `coverage-gap`.
+Every coverage-gap detail must state the unit evidence, the end-to-end evidence, and the reproducible provenance described above. Never assign priority 0 (critical) to a `coverage-gap`.
 
 ## Work List
 


### PR DESCRIPTION
## Summary

- make quality-agent coverage discovery follow each repository's actual test and reporting setup instead of prescribing GitHub Actions commands and default-branch artifacts
- require compatible machine-readable unit and end-to-end coverage to be merged at statement/line granularity before declaring a gap
- preserve provenance, unavailable-evidence, and severity safeguards from the earlier fixes
- extend the policy regression test across all four quality modes and reject reintroduction of the GitHub-Actions-specific commands

## Problem

PR #4749 correctly required unit and end-to-end evidence, but its workflow elevated the FMA repository's particular experiment into a universal pattern: inspect `.github/workflows`, query recent successful default-branch runs, and download their artifacts. Repositories can use different CI providers, local suites, coverage services, branches, artifact names, languages, and output formats.

That prescription also stopped at comparing coverage reports. When unit and end-to-end suites publish compatible raw coverage data, their evidence should be combined at source statement/line granularity so overlapping execution is evaluated accurately.

## Changes

- discover test suites and coverage sources from repository documentation, test configuration, CI definitions, and hive knowledge
- obtain evidence through the mechanism the repository actually uses, with reproducible suite/job, revision, and run/artifact provenance
- merge compatible raw coverage for the same revision and compatible build metadata, using the language toolchain's supported mechanism (for example, `go tool covdata merge`)
- analyze sources separately and disclose the limitation when merging is not possible
- retain the rule that missing end-to-end evidence cannot be inferred from unit coverage and cannot support an end-to-end gap claim
- keep source policy files and embedded defaults synchronized

## Testing

- `env CGO_ENABLED=0 GOCACHE=/tmp/hive-4734-gocache go test ./pkg/policies`
- `env CGO_ENABLED=0 GOCACHE=/tmp/hive-4734-gocache go test ./pkg/scheduler`
- byte-for-byte comparison of all four `src/policies/quality-*.md` files with their embedded `src/pkg/policies/defaults/` copies
- `git diff --check`

Fixes #4734

— hive: backend=codex
