### PR TITLE
test(github): cover the three write-request watcher loops

### DIFF
--- a/src/pkg/github/merge_request_watcher.go
+++ b/src/pkg/github/merge_request_watcher.go
@@ -35,7 +35,7 @@ func mergeRequestDir() string {
 // Merges are more latency-sensitive than opens (an eligible PR should land
 // quickly), but a tight loop risks GitHub secondary-rate-limits when a batch is
 // pending, so keep it modest.
-const mergeRequestPollInterval = 10 * time.Second
+var mergeRequestPollInterval = 10 * time.Second
 
 // mergeRequestMaxAttempts bounds retries on a transient merge failure before the
 // request is quarantined. A PR that is genuinely un-mergeable (failing required

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -34,7 +34,7 @@ func prRequestDir() string {
 // prRequestPollInterval is how often the watcher scans PRRequestDir. PR opens
 // are not latency-critical (the agent has already pushed and moved on), so a
 // modest interval keeps the API/log noise low.
-const prRequestPollInterval = 10 * time.Second
+var prRequestPollInterval = 10 * time.Second
 
 // PRRequest is the JSON an agent writes to PRRequestDir to ask the hive to open
 // a PR on its behalf. Repo may be "owner/repo" or a bare repo name; Base

--- a/src/pkg/github/watcher_loops_test.go
+++ b/src/pkg/github/watcher_loops_test.go
@@ -1,0 +1,333 @@
+package github
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The three Start*Watcher goroutines drive the hive's highest-privilege write
+// paths — App-authored merges, PR opens and reviews — and had 0% coverage even
+// though pkg/github sits at 90% overall and every helper they call is tested.
+// What was untested is the wiring: ticker cadence, context cancellation, and
+// whether a single bad request file stops the loop for everything behind it.
+//
+// That gap is quiet in the worst way. A watcher that silently returns on its
+// first scan error, or ignores cancellation, breaks every agent write while the
+// whole existing suite stays green.
+
+// The shared mock helpers in this package count with a plain *int, which is
+// fine for tests that read the counter only after the server is closed. These
+// loops are polled while the handler is still serving, so the counter is read
+// and written concurrently and has to be atomic — otherwise the test itself is
+// the data race, not the code under test.
+func countingServer(t *testing.T, hits *atomic.Int64, match func(*http.Request) bool, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if match(r) {
+			hits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, body)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[]`)
+	}))
+}
+
+func mergeServer(t *testing.T, hits *atomic.Int64) *httptest.Server {
+	return countingServer(t, hits, func(r *http.Request) bool {
+		return r.Method == "PUT" && strings.HasSuffix(r.URL.Path, "/merge")
+	}, `{"sha":"deadbeef","merged":true,"message":"merged"}`)
+}
+
+func prServer(t *testing.T, hits *atomic.Int64) *httptest.Server {
+	return countingServer(t, hits, func(r *http.Request) bool {
+		return r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls")
+	}, `{"number":42,"html_url":"https://github.example/o/r/pull/42"}`)
+}
+
+func reviewServer(t *testing.T, hits *atomic.Int64) *httptest.Server {
+	return countingServer(t, hits, func(r *http.Request) bool {
+		return r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/reviews")
+	}, `{"id":1,"state":"APPROVED"}`)
+}
+
+// drainAfter stops the watcher and waits for its goroutine to be gone before
+// the test's other cleanups run.
+//
+// t.Cleanup is LIFO, so this must be registered *after* the dir and interval
+// helpers: their restores would otherwise write the package globals while a
+// live watcher goroutine is still reading them on each tick, which the race
+// detector correctly flags — the test would be the data race, not the code.
+func drainAfter(t *testing.T, cancel context.CancelFunc) {
+	t.Helper()
+	t.Cleanup(func() {
+		cancel()
+		// Comfortably more than the 15ms test tick even under -race, which
+		// slows every scan down, so the loop has observed cancellation and
+		// returned before anything it reads is restored.
+		time.Sleep(750 * time.Millisecond)
+	})
+}
+
+// withReviewDirForLoop mirrors withMergeDir; see its comment.
+func withReviewDirForLoop(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	reviewRequestDirForTest = dir
+	return dir
+}
+
+// waitFor polls cond until it holds or the deadline passes.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}
+
+// fastTick shortens a watcher's poll interval for the duration of the test.
+func fastTick(t *testing.T, set func(time.Duration), restore time.Duration) {
+	t.Helper()
+	set(15 * time.Millisecond)
+	t.Cleanup(func() { set(restore) })
+}
+
+// withMergeDir points the watcher at a temp dir and deliberately does NOT
+// restore the previous value.
+//
+// Start*Watcher gives the caller no way to know its goroutine has exited —
+// cancelling the context signals it, but nothing reports when the loop is
+// actually gone. The dir hook is read on *every* tick (inside
+// processMergeRequests), so a cleanup that restored it would be writing a
+// global that a possibly-still-live goroutine is reading, and the race
+// detector flags it. That race is in the test, not the code.
+//
+// Leaving the value set is safe here: every test in this package assigns the
+// hook before using it (see the existing watcher tests, which each set it and
+// reset to ""), so nothing inherits it. The poll interval, by contrast, is read
+// once when the ticker is created, so restoring that is fine and fastTick does.
+func withMergeDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mergeRequestDirForTest = dir
+	return dir
+}
+
+// withPRDirForLoop mirrors withMergeDir; see its comment for why the previous
+// value is not restored.
+func withPRDirForLoop(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	return dir
+}
+
+// --- merge ------------------------------------------------------------------
+
+func TestStartMergeRequestWatcher_DispatchesQueuedRequest(t *testing.T) {
+	var merges atomic.Int64
+	srv := mergeServer(t, &merges)
+	t.Cleanup(srv.Close)
+	c := testMergeClient(t, srv.URL)
+	dir := withMergeDir(t)
+	fastTick(t, func(d time.Duration) { mergeRequestPollInterval = d }, mergeRequestPollInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	drainAfter(t, cancel)
+	c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+
+	if _, err := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 1, Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 5*time.Second, func() bool { return merges.Load() > 0 }) {
+		t.Fatal("the ticker loop never picked up a queued merge request")
+	}
+}
+
+func TestStartMergeRequestWatcher_StopsOnContextCancel(t *testing.T) {
+	var merges atomic.Int64
+	srv := mergeServer(t, &merges)
+	t.Cleanup(srv.Close)
+	c := testMergeClient(t, srv.URL)
+	dir := withMergeDir(t)
+	fastTick(t, func(d time.Duration) { mergeRequestPollInterval = d }, mergeRequestPollInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	drainAfter(t, cancel)
+	c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+	cancel()
+	// Give the loop time to observe cancellation before queueing work.
+	time.Sleep(80 * time.Millisecond)
+
+	if _, err := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 2, Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if merges.Load() != 0 {
+		t.Fatalf("watcher kept processing after cancellation (merges=%d)", merges.Load())
+	}
+}
+
+// A malformed file must not wedge the queue behind it. Before, an unreadable or
+// unparseable request could stop the scan and every later request would sit
+// unprocessed with nothing reporting why.
+func TestStartMergeRequestWatcher_SurvivesMalformedRequest(t *testing.T) {
+	var merges atomic.Int64
+	srv := mergeServer(t, &merges)
+	t.Cleanup(srv.Close)
+	c := testMergeClient(t, srv.URL)
+	dir := withMergeDir(t)
+	fastTick(t, func(d time.Duration) { mergeRequestPollInterval = d }, mergeRequestPollInterval)
+
+	if err := os.WriteFile(filepath.Join(dir, "aaa-broken.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	drainAfter(t, cancel)
+	c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+
+	if _, err := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 3, Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 5*time.Second, func() bool { return merges.Load() > 0 }) {
+		t.Fatal("a malformed request file stopped the loop from reaching a valid one")
+	}
+}
+
+// --- pr ---------------------------------------------------------------------
+
+func TestStartPRRequestWatcher_DispatchesQueuedRequest(t *testing.T) {
+	var created atomic.Int64
+	srv := prServer(t, &created)
+	t.Cleanup(srv.Close)
+	c := testClient(t, srv.URL)
+	dir := withPRDirForLoop(t)
+	fastTick(t, func(d time.Duration) { prRequestPollInterval = d }, prRequestPollInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	drainAfter(t, cancel)
+	c.StartPRRequestWatcher(ctx, func(string, int) error { return nil }, nil, nil)
+
+	if _, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "f", Base: "main", Title: "t", Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 5*time.Second, func() bool { return created.Load() > 0 }) {
+		t.Fatal("the ticker loop never picked up a queued PR request")
+	}
+}
+
+func TestStartPRRequestWatcher_StopsOnContextCancel(t *testing.T) {
+	var created atomic.Int64
+	srv := prServer(t, &created)
+	t.Cleanup(srv.Close)
+	c := testClient(t, srv.URL)
+	dir := withPRDirForLoop(t)
+	fastTick(t, func(d time.Duration) { prRequestPollInterval = d }, prRequestPollInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	drainAfter(t, cancel)
+	c.StartPRRequestWatcher(ctx, func(string, int) error { return nil }, nil, nil)
+	cancel()
+	time.Sleep(80 * time.Millisecond)
+
+	if _, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "g", Base: "main", Title: "t", Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if created.Load() != 0 {
+		t.Fatalf("watcher kept processing after cancellation (created=%d)", created.Load())
+	}
+}
+
+// --- review -----------------------------------------------------------------
+
+func TestStartReviewRequestWatcher_DispatchesQueuedRequest(t *testing.T) {
+	var reviewed atomic.Int64
+	srv := reviewServer(t, &reviewed)
+	t.Cleanup(srv.Close)
+	c := reviewTestClient(t, srv.URL)
+	dir := withReviewDirForLoop(t)
+	fastTick(t, func(d time.Duration) { reviewRequestPollInterval = d }, reviewRequestPollInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	drainAfter(t, cancel)
+	c.StartReviewRequestWatcher(ctx, func(string, int) error { return nil }, nil)
+
+	if _, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 1, Event: "approve", Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 5*time.Second, func() bool { return reviewed.Load() > 0 }) {
+		t.Fatal("the ticker loop never picked up a queued review request")
+	}
+}
+
+func TestStartReviewRequestWatcher_StopsOnContextCancel(t *testing.T) {
+	var reviewed atomic.Int64
+	srv := reviewServer(t, &reviewed)
+	t.Cleanup(srv.Close)
+	c := reviewTestClient(t, srv.URL)
+	dir := withReviewDirForLoop(t)
+	fastTick(t, func(d time.Duration) { reviewRequestPollInterval = d }, reviewRequestPollInterval)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	drainAfter(t, cancel)
+	c.StartReviewRequestWatcher(ctx, func(string, int) error { return nil }, nil)
+	cancel()
+	time.Sleep(80 * time.Millisecond)
+
+	if _, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 2, Event: "approve", Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if reviewed.Load() != 0 {
+		t.Fatalf("watcher kept processing after cancellation (reviewed=%d)", reviewed.Load())
+	}
+}
+
+// A watcher whose request dir cannot be created must disable itself quietly
+// rather than panic or leave a goroutine spinning on a directory that is not
+// there.
+func TestStartWatchers_UncreatableDirDisablesQuietly(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	oldMerge, oldPR, oldReview := mergeRequestDirForTest, prRequestDirForTest, reviewRequestDirForTest
+	mergeRequestDirForTest = filepath.Join(blocker, "merge")
+	prRequestDirForTest = filepath.Join(blocker, "pr")
+	reviewRequestDirForTest = filepath.Join(blocker, "review")
+	t.Cleanup(func() {
+		mergeRequestDirForTest, prRequestDirForTest, reviewRequestDirForTest = oldMerge, oldPR, oldReview
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.StartMergeRequestWatcher(ctx, nil, nil)
+	c.StartPRRequestWatcher(ctx, nil, nil, nil)
+	c.StartReviewRequestWatcher(ctx, nil, nil)
+}


### PR DESCRIPTION
Closes #4733.

## Coverage

| Entry point | Before | After |
|---|---|---|
| `StartMergeRequestWatcher` | 0% | **88.9%** |
| `StartPRRequestWatcher` | 0% | **93.8%** |
| `StartReviewRequestWatcher` | 0% | **88.9%** |
| `pkg/github` total | 90.3% | **90.9%** |

Eight tests covering the three behaviours the issue asked for, per watcher where it applies: a queued request is dispatched within a couple of ticks; the loop exits on context cancellation; a malformed request file is skipped without wedging the queue behind it. Plus one that all three disable themselves quietly when the request dir cannot be created.

## Two small production changes

`mergeRequestPollInterval` and `prRequestPollInterval` were `const`; they are now `var`, so a test can shorten the tick. This is not a new pattern — `issueRequestPollInterval` and `reviewRequestPollInterval` are **already** `var` and `issue_request_watcher_test.go:358` already overrides one. Merge and PR were the two that had been left behind, which is exactly why they were the untested ones.

No behaviour change: both keep the same 10s default and the comments explaining the cadence are untouched.

## The part that took the longest, and is worth knowing

`Start*Watcher` gives the caller **no way to know its goroutine has exited**. Cancelling the context signals it; nothing reports when the loop is actually gone.

That matters for the tests because the `…DirForTest` hook is read on *every* tick, inside `processMergeRequests`. A cleanup that restored it would be writing a package global while a possibly-still-live goroutine reads it, and `-race` flags that — correctly. The race would have been in my test, not in your code.

I went through three wrong versions before getting this right:

1. counting mock hits with a plain `*int` (the shared mock helpers do this, which is fine for tests that read after the server closes, but not for a loop polled while the handler is serving) — now `atomic.Int64` with local mock servers;
2. `defer srv.Close()`, which runs *before* `t.Cleanup`, so an in-flight request outlived the drain — the server close now joins the cleanup chain;
3. restoring the dir hook at all — the loop helpers now deliberately do not restore it.

That last one is safe because every test in this package assigns the hook before using it (the existing watcher tests each set it and reset to `""`), so nothing inherits a stale value. The poll interval *is* restored, because it is read once when the ticker is created rather than per tick. The reasoning is written into the helper's doc comment so a later change has to argue with it.

**Worth considering separately:** if `Start*Watcher` returned a `<-chan struct{}` closed on exit, or took a `*sync.WaitGroup`, none of the above would be necessary — and production shutdown would gain a way to know the watchers have actually stopped rather than assuming. Happy to open that as its own issue if you want it; it felt beyond "add tests".

## Verified

`go test ./pkg/github/` and `go test -race ./pkg/github/` both pass, the latter also at `-count=3` on the new tests specifically. `go vet` clean, `gofmt` clean.
