### PR TITLE
🧪 test: cover inception watcher loops

### DIFF
--- a/src/pkg/dashboard/inception_watcher.go
+++ b/src/pkg/dashboard/inception_watcher.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	inceptionWatchIntervalS     = 5 * time.Second
 	inceptionBeadRefPrefix      = "inception/"
 	minQuestionsForAdvance      = 5
 	minFactsForAdvance          = 3
@@ -31,6 +30,20 @@ const (
 	agentIdleThreshold          = 30 * time.Second // agent must be idle this long before fallback
 )
 
+var (
+	inceptionWatchIntervalS    = 5 * time.Second
+	inceptionFastPollInterval  = 2 * time.Second
+	plukSubscriberPollInterval = 500 * time.Millisecond
+	plukSubscriberSeekEnd      = true
+	plukLogFile                = func() string { return fmt.Sprintf("%s/hive-brainstorm.jsonl", plukLogDir) }
+)
+
+type inceptionAgentManager interface {
+	GetBufferOutput(name string, lines int) ([]string, error)
+	SendKick(name string, message string) error
+	RestartWithBootstrap(ctx context.Context, name, prompt string) error
+}
+
 // InceptionWatcher polls brainstorm beads and bridges them into the inception
 // state machine. It detects question beads (capture → clarify) and fact beads
 // (structure → scaffold), advancing phases automatically.
@@ -38,7 +51,7 @@ type InceptionWatcher struct {
 	beadStore *beads.Store
 	inception *knowledge.InceptionEngine
 	scheduler *scheduler.Scheduler
-	agentMgr  *agent.Manager
+	agentMgr  inceptionAgentManager
 	governor  *governor.Governor
 	logger    *slog.Logger
 
@@ -72,28 +85,35 @@ func NewInceptionWatcher(
 	gov *governor.Governor,
 	logger *slog.Logger,
 ) *InceptionWatcher {
-	return &InceptionWatcher{
+	w := &InceptionWatcher{
 		beadStore: beadStore,
 		inception: inception,
 		scheduler: sched,
-		agentMgr:  agentMgr,
 		governor:  gov,
 		logger:    logger,
 	}
+	if agentMgr != nil {
+		w.agentMgr = agentMgr
+	}
+	return w
 }
 
 // Run starts the polling loop and event subscriber. Blocks until ctx is cancelled.
 func (w *InceptionWatcher) Run(ctx context.Context) {
 	w.ctx = ctx
 	w.logger.Info("inception watcher started")
-	ticker := time.NewTicker(inceptionWatchIntervalS)
+	watchInterval := inceptionWatchIntervalS
+	fastPollInterval := inceptionFastPollInterval
+	plukLog := plukLogFile()
+	plukPollInterval := plukSubscriberPollInterval
+	plukSeekEnd := plukSubscriberSeekEnd
+	ticker := time.NewTicker(watchInterval)
 	defer ticker.Stop()
 
 	// Start pluk event subscriber for brainstorm session
-	go w.runPlukSubscriber(ctx)
+	go w.runPlukSubscriberWithSettings(ctx, plukLog, watchInterval, plukPollInterval, plukSeekEnd)
 
-	const fastPollInterval = 2 * time.Second
-	lastInterval := inceptionWatchIntervalS
+	lastInterval := watchInterval
 
 	for {
 		// Adaptive polling: 2s during capture/structure, 5s otherwise
@@ -102,7 +122,7 @@ func (w *InceptionWatcher) Run(ctx context.Context) {
 		if state != nil && (state.Phase == knowledge.PhaseCapture || state.Phase == knowledge.PhaseStructure) {
 			targetInterval = fastPollInterval
 		} else {
-			targetInterval = inceptionWatchIntervalS
+			targetInterval = watchInterval
 		}
 		if targetInterval != lastInterval {
 			ticker.Reset(targetInterval)
@@ -415,8 +435,10 @@ const plukLogDir = "/var/run/pluk/logs"
 // stream and takes immediate action on relevant events. This replaces 5s
 // polling with real-time event-driven reactions.
 func (w *InceptionWatcher) runPlukSubscriber(ctx context.Context) {
-	logFile := fmt.Sprintf("%s/hive-brainstorm.jsonl", plukLogDir)
+	w.runPlukSubscriberWithSettings(ctx, plukLogFile(), inceptionWatchIntervalS, plukSubscriberPollInterval, plukSubscriberSeekEnd)
+}
 
+func (w *InceptionWatcher) runPlukSubscriberWithSettings(ctx context.Context, logFile string, watchInterval, pollInterval time.Duration, seekEnd bool) {
 	// Wait for the log file to exist
 	for {
 		if _, err := os.Stat(logFile); err == nil {
@@ -425,7 +447,7 @@ func (w *InceptionWatcher) runPlukSubscriber(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(inceptionWatchIntervalS):
+		case <-time.After(watchInterval):
 			continue
 		}
 	}
@@ -441,15 +463,15 @@ func (w *InceptionWatcher) runPlukSubscriber(ctx context.Context) {
 	defer f.Close()
 
 	// Seek to end — we only care about new events
-	if _, err := f.Seek(0, 2); err != nil {
-		w.logger.Warn("pluk subscriber: cannot seek to end", "error", err)
+	if seekEnd {
+		if _, err := f.Seek(0, 2); err != nil {
+			w.logger.Warn("pluk subscriber: cannot seek to end", "error", err)
+		}
 	}
 
 	scanner := bufio.NewScanner(f)
 	const plukMaxLineBytes = 1 << 20 // 1 MiB — agent output can exceed 64KB default
 	scanner.Buffer(make([]byte, 0, plukMaxLineBytes), plukMaxLineBytes)
-	const pollInterval = 500 * time.Millisecond
-
 	for {
 		select {
 		case <-ctx.Done():

--- a/src/pkg/dashboard/inception_watcher_loops_test.go
+++ b/src/pkg/dashboard/inception_watcher_loops_test.go
@@ -1,0 +1,217 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/knowledge"
+)
+
+type fakeInceptionAgentManager struct {
+	buffer       []string
+	bufferErr    error
+	sendErr      error
+	restartErr   error
+	sendCount    atomic.Int64
+	restartCount atomic.Int64
+	lastKick     string
+}
+
+func (m *fakeInceptionAgentManager) GetBufferOutput(string, int) ([]string, error) {
+	return append([]string{}, m.buffer...), m.bufferErr
+}
+
+func (m *fakeInceptionAgentManager) SendKick(_ string, message string) error {
+	m.sendCount.Add(1)
+	m.lastKick = message
+	return m.sendErr
+}
+
+func (m *fakeInceptionAgentManager) RestartWithBootstrap(context.Context, string, string) error {
+	m.restartCount.Add(1)
+	return m.restartErr
+}
+
+func withFastInceptionLoops(t *testing.T) {
+	t.Helper()
+	oldWatch, oldFast, oldPoll, oldSeek, oldLog := inceptionWatchIntervalS, inceptionFastPollInterval, plukSubscriberPollInterval, plukSubscriberSeekEnd, plukLogFile
+	inceptionWatchIntervalS = 10 * time.Millisecond
+	inceptionFastPollInterval = 10 * time.Millisecond
+	plukSubscriberPollInterval = 5 * time.Millisecond
+	plukSubscriberSeekEnd = false
+	plukLogFile = func() string { return filepath.Join(t.TempDir(), "missing.jsonl") }
+	t.Cleanup(func() {
+		inceptionWatchIntervalS, inceptionFastPollInterval, plukSubscriberPollInterval, plukSubscriberSeekEnd, plukLogFile = oldWatch, oldFast, oldPoll, oldSeek, oldLog
+	})
+}
+
+func TestInceptionWatcherRunPollsAndStopsOnCancel(t *testing.T) {
+	withFastInceptionLoops(t)
+	w, eng, _ := covFWatcher(t)
+	if _, err := eng.Start("watcher loop idea"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		w.pollMu.Lock()
+		gotSlug := w.lastSlug != ""
+		w.pollMu.Unlock()
+		if gotSlug {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+	w.pollMu.Lock()
+	gotSlug := w.lastSlug
+	w.pollMu.Unlock()
+	if gotSlug == "" {
+		t.Fatal("Run never reached poll loop")
+	}
+}
+
+func TestRunPlukSubscriberReadsConfiguredLogAndHandlesEvent(t *testing.T) {
+	withFastInceptionLoops(t)
+	w, eng, _ := covFWatcher(t)
+	if _, err := eng.Start("pluk subscriber idea"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	logPath := filepath.Join(t.TempDir(), "brainstorm.jsonl")
+	line := `{"type":"raw_output","data":{"line":"bd create --title \"What language should we use?\""}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(line), 0o644); err != nil {
+		t.Fatalf("write pluk log: %v", err)
+	}
+	plukLogFile = func() string { return logPath }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.runPlukSubscriber(ctx)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		w.plukMu.Lock()
+		gotEvent := w.plukEventCount > 0
+		w.plukMu.Unlock()
+		if gotEvent {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runPlukSubscriber did not stop after context cancellation")
+	}
+	w.plukMu.Lock()
+	eventCount := w.plukEventCount
+	questions := append([]knowledge.Question(nil), w.plukQuestions...)
+	w.plukMu.Unlock()
+	if eventCount != 1 {
+		t.Fatalf("expected one handled pluk event, got %d", eventCount)
+	}
+	if len(questions) != 1 || !strings.Contains(questions[0].Text, "language") {
+		t.Fatalf("expected raw_output bd create question to be captured, got %+v", questions)
+	}
+}
+
+func TestRetryKickIfStaleSendsKickWhenBrainstormIsReaping(t *testing.T) {
+	w, _, _ := covFWatcher(t)
+	fake := &fakeInceptionAgentManager{buffer: []string{"reap: close stale beads"}}
+	w.agentMgr = fake
+	state := &knowledge.InceptionState{
+		Phase:     knowledge.PhaseCapture,
+		IdeaText:  "recover stale kick",
+		IdeaSlug:  "recover-stale-kick",
+		StartedAt: time.Now().Add(-2 * kickRetryGracePeriodS),
+	}
+	w.lastKickRetry = time.Now().Add(-2 * kickRetryDelayS)
+
+	w.retryKickIfStale(state)
+
+	if fake.sendCount.Load() != 1 {
+		t.Fatalf("expected SendKick once, got %d", fake.sendCount.Load())
+	}
+	if fake.restartCount.Load() != 0 {
+		t.Fatalf("unexpected RestartWithBootstrap calls: %d", fake.restartCount.Load())
+	}
+	if w.kickRetryCount != 1 {
+		t.Fatalf("kickRetryCount = %d, want 1", w.kickRetryCount)
+	}
+	if !strings.Contains(fake.lastKick, "recover stale kick") {
+		t.Fatalf("kick message did not include idea text: %q", fake.lastKick)
+	}
+}
+
+func TestRetryKickIfStaleFallsBackToBootstrapWhenSendKickFails(t *testing.T) {
+	w, _, _ := covFWatcher(t)
+	fake := &fakeInceptionAgentManager{
+		bufferErr: errors.New("no session"),
+		sendErr:   errors.New("send failed"),
+	}
+	w.agentMgr = fake
+	state := &knowledge.InceptionState{
+		Phase:     knowledge.PhaseStructure,
+		IdeaText:  "recover missing session",
+		IdeaSlug:  "recover-missing-session",
+		StartedAt: time.Now().Add(-2 * kickRetryGracePeriodS),
+		Questions: []knowledge.Question{{ID: "q1", Text: "language?", Category: "language"}},
+		Answers:   map[string]string{"q1": "Go"},
+	}
+	w.lastKickRetry = time.Now().Add(-2 * kickRetryDelayS)
+
+	w.retryKickIfStale(state)
+
+	if fake.sendCount.Load() != 1 {
+		t.Fatalf("expected SendKick once, got %d", fake.sendCount.Load())
+	}
+	if fake.restartCount.Load() != 1 {
+		t.Fatalf("expected RestartWithBootstrap once, got %d", fake.restartCount.Load())
+	}
+}
+
+func TestRetryKickIfStaleSuppressesWhileWorkingOrRateLimited(t *testing.T) {
+	w, _, _ := covFWatcher(t)
+	fake := &fakeInceptionAgentManager{buffer: []string{"extract requirements for inception"}}
+	w.agentMgr = fake
+	state := &knowledge.InceptionState{
+		Phase:     knowledge.PhaseCapture,
+		IdeaText:  "do not kick",
+		StartedAt: time.Now().Add(-2 * kickRetryGracePeriodS),
+	}
+	w.lastKickRetry = time.Now().Add(-2 * kickRetryDelayS)
+
+	w.retryKickIfStale(state)
+	if fake.sendCount.Load() != 0 {
+		t.Fatalf("working output should suppress kicks, got %d", fake.sendCount.Load())
+	}
+
+	fake.buffer = []string{"reap: close stale beads"}
+	w.rateLimitedUntil = time.Now().Add(time.Minute)
+	w.retryKickIfStale(state)
+	if fake.sendCount.Load() != 0 {
+		t.Fatalf("rate limit should suppress kicks, got %d", fake.sendCount.Load())
+	}
+}


### PR DESCRIPTION
Closes #4766.\n\nAdds hermetic tests for the inception watcher Run loop, pluk subscriber, and stale kick retry path. Introduces injectable timing/log/agent seams with production defaults unchanged.\n\nValidation:\n- go test ./pkg/dashboard -run "TestInceptionWatcherRunPollsAndStopsOnCancel|TestRunPlukSubscriberReadsConfiguredLogAndHandlesEvent|TestRetryKickIfStale" -count=1\n- go test ./pkg/dashboard -count=1\n- go vet ./pkg/dashboard\n\nMutation spot-check: disabling the stale-work suppression branch made TestRetryKickIfStaleSuppressesWhileWorkingOrRateLimited fail as expected.\n\nSigned-off-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>