### PR TITLE
🐛 fix(hub): make the registry save loop joinable so it cannot outlive its server

### DIFF
--- a/src/pkg/hub/delete_hive_registry_test.go
+++ b/src/pkg/hub/delete_hive_registry_test.go
@@ -50,6 +50,7 @@ func helperDeleteHiveEnv(t *testing.T) (*HubServer, *http.ServeMux) {
 	})
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	t.Cleanup(srv.StopSaveLoop)
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
 	return srv, mux
@@ -412,6 +413,7 @@ func TestRemoveRegistryEntryPersistsSynchronously(t *testing.T) {
 	_, _ = helperDeleteHiveEnv(t)
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	t.Cleanup(srv.StopSaveLoop)
 	const keepID = "keep-me-hive"
 	const dropID = "drop-me-hive"
 	srv.mu.Lock()
@@ -456,6 +458,7 @@ func TestKubectlUnreachableHiveIsNotReaped(t *testing.T) {
 	_, _ = helperDeleteHiveEnv(t)
 
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	t.Cleanup(srv.StopSaveLoop)
 	const unreachableID = "hosted-unreachable-spoke-hive"
 	// Beat recently enough to be well inside staleRemoveAge, but old enough to
 	// be marked offline: exactly what an unreachable-but-alive hive looks like.

--- a/src/pkg/hub/heartbeat_visibility_preserve_test.go
+++ b/src/pkg/hub/heartbeat_visibility_preserve_test.go
@@ -42,6 +42,7 @@ func TestHeartbeatPreservesHubSetPrivate(t *testing.T) {
 	}
 
 	srv := NewHubServer(0, slog.Default(), "test", "v4")
+	t.Cleanup(srv.StopSaveLoop)
 	srv.setHubSecret("")
 
 	// The placeholder spoke reports its provisioning default: is_public=true.
@@ -111,6 +112,7 @@ func TestHeartbeatPreservesHubSetPrivateOnFirstBeat(t *testing.T) {
 	}
 
 	srv := NewHubServer(0, slog.Default(), "test", "v4")
+	t.Cleanup(srv.StopSaveLoop)
 	srv.setHubSecret("")
 
 	body := `{"hive_id":"` + hiveID + `","org":"available-oke-260812-fresh","is_public":true}`

--- a/src/pkg/hub/save_loop_join_test.go
+++ b/src/pkg/hub/save_loop_join_test.go
@@ -1,0 +1,66 @@
+package hub
+
+// save_loop_join_test.go pins the fix for kubestellar/hive#4774: the debounced
+// registry-save goroutine used to be unjoinable, so a hub constructed in a test
+// could wake up to registrySaveDelay after the test returned and recreate
+// registry files inside a t.TempDir the test framework was already removing —
+// the intermittent "TempDir RemoveAll cleanup: directory not empty" pkg/hub
+// failure.
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStopSaveLoopJoinsAndFlushesPendingSave is the regression pin. It must:
+//  1. return promptly (well inside registrySaveDelay — proving the debounce
+//     sleep is cancelable, not merely waited out),
+//  2. flush the pending save rather than abandon it, and
+//  3. be idempotent.
+//
+// If StopSaveLoop ever stops joining the goroutine, the 2s timeout fails this
+// test rather than letting the leak back in silently.
+func TestStopSaveLoopJoinsAndFlushesPendingSave(t *testing.T) {
+	t.Setenv("HIVE_HUB_SECRET", "save-loop-join-test-secret")
+	oldRegistry := registryPath
+	registryPath = filepath.Join(t.TempDir(), "hub-registry.json")
+	t.Cleanup(func() { registryPath = oldRegistry })
+
+	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{{ID: "pending-at-stop"}}
+	s.mu.Unlock()
+	s.requestSave()
+
+	done := make(chan struct{})
+	go func() {
+		s.StopSaveLoop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("#4774: StopSaveLoop did not join the save loop promptly — the goroutine would outlive its test and race t.TempDir cleanup")
+	}
+
+	data, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("the save pending at stop was abandoned instead of flushed: %v", err)
+	}
+	if !strings.Contains(string(data), "pending-at-stop") {
+		t.Fatalf("flushed registry is missing the pending entry: %s", data)
+	}
+
+	// Idempotent: a second stop (e.g. explicit test cleanup after a Shutdown
+	// that already stopped the loop) must neither panic nor block.
+	s.StopSaveLoop()
+
+	// Bare test literals never start the loop; StopSaveLoop must be nil-safe
+	// for them.
+	bare := &HubServer{logger: slog.Default()}
+	bare.StopSaveLoop()
+}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -842,6 +842,18 @@ type HubServer struct {
 	mu       sync.RWMutex
 	logger   *slog.Logger
 	saveCh   chan struct{}
+	// saveLoopStop / saveLoopDone make the debounced saveLoop goroutine
+	// joinable (#4774). A hub built by NewHubServer used to leak its saveLoop
+	// forever: in tests, the loop could wake up to registrySaveDelay after the
+	// test returned and recreate registry files inside a t.TempDir the test
+	// framework was already removing — "TempDir RemoveAll cleanup: directory
+	// not empty" flakes. StopSaveLoop closes saveLoopStop and blocks on
+	// saveLoopDone, so a test that stops the server KNOWS no further registry
+	// write can happen. Both are nil on bare &HubServer{} test literals, which
+	// never start the loop; StopSaveLoop is a no-op for them.
+	saveLoopStop     chan struct{}
+	saveLoopDone     chan struct{}
+	saveLoopStopOnce sync.Once
 
 	// authProviders is the enabled human-login provider set (GitHub OAuth plus any
 	// configured OIDC providers — Google/IBMid/Red Hat/Microsoft/custom). Built
@@ -1292,6 +1304,8 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		mux:          http.NewServeMux(),
 		logger:       logger,
 		saveCh:       make(chan struct{}, 1),
+		saveLoopStop: make(chan struct{}),
+		saveLoopDone: make(chan struct{}),
 		registryPath: registryPath,
 		hubGitHash:   gitHash,
 		hubGitBranch: gitBranch,
@@ -1507,6 +1521,9 @@ func (s *HubServer) Start(port int) error {
 }
 
 func (s *HubServer) Shutdown(timeout time.Duration) error {
+	// Join the registry save loop first, flushing any pending debounced write
+	// (#4774) — after this, no background registry I/O remains.
+	s.StopSaveLoop()
 	// Flush the reach history's final partial save interval (#3995) — the
 	// same durability courtesy the registry gets from its synchronous saves.
 	// Before the listener check: a server shut down before Start still owes
@@ -3775,24 +3792,55 @@ func (s *HubServer) requestSave() {
 }
 
 func (s *HubServer) saveLoop() {
-	for range s.saveCh {
-		time.Sleep(registrySaveDelay)
-		s.mu.RLock()
-		data, err := json.MarshalIndent(s.registry, "", "  ")
-		s.mu.RUnlock()
-		if err != nil {
-			s.logger.Warn("hub registry marshal failed", "error", err)
-			continue
+	defer close(s.saveLoopDone)
+	for {
+		select {
+		case <-s.saveLoopStop:
+			// A request already queued when stop wins the select must still be
+			// flushed — both channels can be ready at once and select picks
+			// randomly, so drain deterministically.
+			select {
+			case <-s.saveCh:
+				s.saveLoopFlush()
+			default:
+			}
+			return
+		case <-s.saveCh:
 		}
-		tmpPath := s.registryPath + ".tmp"
-		if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
-			s.logger.Warn("hub registry save failed", "path", tmpPath, "error", err)
-			continue
+		// Debounce, but stay cancelable: a stop during the delay flushes the
+		// pending request synchronously instead of abandoning it, so shutdown
+		// keeps the durability the delayed write was promising.
+		select {
+		case <-s.saveLoopStop:
+			s.saveLoopFlush()
+			return
+		case <-time.After(registrySaveDelay):
 		}
-		if err := os.Rename(tmpPath, s.registryPath); err != nil {
-			s.logger.Warn("hub registry rename failed", "error", err)
-		}
+		s.saveLoopFlush()
 	}
+}
+
+// saveLoopFlush is one debounced write, with saveLoop's historical
+// warn-and-continue error handling (a failed periodic save is retried by the
+// next requestSave; it must not kill the loop).
+func (s *HubServer) saveLoopFlush() {
+	if err := s.saveRegistryNow(); err != nil {
+		s.logger.Warn("hub registry save failed", "path", s.regPath(), "error", err)
+	}
+}
+
+// StopSaveLoop stops the debounced registry-save goroutine and waits for it to
+// exit, flushing any pending save request first (#4774). After it returns, no
+// further registry write can come from this server — which is what a test
+// holding the registry in a t.TempDir needs before the framework removes it.
+// Safe to call multiple times, and a no-op on bare &HubServer{} literals that
+// never started the loop.
+func (s *HubServer) StopSaveLoop() {
+	if s.saveLoopStop == nil {
+		return
+	}
+	s.saveLoopStopOnce.Do(func() { close(s.saveLoopStop) })
+	<-s.saveLoopDone
 }
 
 func (s *HubServer) findContributeHive() *RegistryEntry {

--- a/src/pkg/hub/upgrade_recovery_test.go
+++ b/src/pkg/hub/upgrade_recovery_test.go
@@ -79,6 +79,10 @@ func TestNewHubServerRecoversArmedUpgradesFromDisk(t *testing.T) {
 	}
 
 	s := NewHubServer(0, slog.Default(), "test", "v2")
+	// Join the save loop before t.TempDir cleanup: recovery arms a requestSave,
+	// and an unjoined loop would recreate the registry inside the TempDir while
+	// the framework removes it (#4774).
+	t.Cleanup(s.StopSaveLoop)
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
Fixes #4774

The debounced registry-save goroutine `NewHubServer` starts was unjoinable — nothing could stop it or wait for it. In tests, a server whose `registryPath` sits in a `t.TempDir` leaked its saveLoop, which could wake up to `registrySaveDelay` (5s) later and recreate `hub-registry.json.tmp` while the framework removed the directory: the intermittent `TempDir RemoveAll cleanup: directory not empty` / `hub registry save failed … no such file or directory` pkg/hub failure.

## Fix — synchronization, not sleeps

- `saveLoop` selects on a stop channel at **both** wait points (the request wait and the debounce sleep) and closes a done channel on exit.
- A stop during the debounce — or racing an already-queued request (both select cases ready; Go picks randomly, so the stop path drains deterministically) — **flushes the pending save synchronously** instead of abandoning it, keeping the durability the delayed write promised. The write itself now reuses `saveRegistryNow` instead of a duplicated body.
- `StopSaveLoop` joins the goroutine; idempotent; nil-safe for bare `&HubServer{}` test literals that never start a loop. `Shutdown` calls it first, so production shutdown also stops leaking the goroutine and flushes.
- `TestNewHubServerRecoversArmedUpgradesFromDisk` (the reported failing test — recovery arms a `requestSave`) and every other test constructing a full server over a TempDir registry now `t.Cleanup` the join.

## Verification

- New `save_loop_join_test.go` pins: prompt join (2s budget vs the 5s debounce — proves cancelable, not waited out), pending-save flush, idempotent second stop, nil-safety. **Mutation-checked**: gutting the join in `StopSaveLoop` fails the test.
- `-count=20 -race` on the pin, `-count=10 -race` on the recovery/delete/requestSave cluster, and the full `pkg/hub` suite (125s) all green.