### PR TITLE
🌱 test(agent): seal the live-host leaks the hermetic seams missed

### DIFF
--- a/src/pkg/agent/agent_bootstrap_test.go
+++ b/src/pkg/agent/agent_bootstrap_test.go
@@ -514,7 +514,7 @@ func TestSyncModeFilesLevel3(t *testing.T) {
 	m.SyncModeFiles(3)
 
 	// Check mode files were written
-	scannerMode, _ := os.ReadFile("/tmp/.hive-mode-scanner")
+	scannerMode, _ := os.ReadFile(filepath.Join(agentStateDir, ".hive-mode-scanner"))
 	_ = scannerMode
 }
 

--- a/src/pkg/agent/converse_capability_test.go
+++ b/src/pkg/agent/converse_capability_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -125,7 +126,7 @@ func TestAgentCapabilitiesResolution(t *testing.T) {
 // which is the failure mode worth a test of its own.
 func TestWriteAgentCapsFileRevokes(t *testing.T) {
 	name := "capsprobe-4492"
-	path := "/tmp/.hive-caps-" + name
+	path := filepath.Join(agentStateDir, ".hive-caps-"+name)
 	t.Cleanup(func() { os.Remove(path) })
 
 	m := &Manager{logger: discardLogger()}

--- a/src/pkg/agent/coverage_boost_test.go
+++ b/src/pkg/agent/coverage_boost_test.go
@@ -353,7 +353,7 @@ func TestSyncModeFiles_WritesCorrectMode(t *testing.T) {
 
 	m.SyncModeFiles(4)
 
-	data, err := os.ReadFile("/tmp/.hive-mode-scanner")
+	data, err := os.ReadFile(filepath.Join(agentStateDir, ".hive-mode-scanner"))
 	if err != nil {
 		t.Skipf("could not read mode file: %v", err)
 	}

--- a/src/pkg/agent/diag_coverage_test.go
+++ b/src/pkg/agent/diag_coverage_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -76,10 +77,10 @@ func TestLaunchInTmux_GooseBootstrap(t *testing.T) {
 	}
 	defer cleanupAgent(t, m, "cxa")
 	// Bootstrap file should have been written for goose.
-	if _, err := os.Stat("/tmp/.hive-bootstrap-a.txt"); err != nil {
+	if _, err := os.Stat(filepath.Join(agentStateDir, ".hive-bootstrap-a.txt")); err != nil {
 		t.Logf("goose bootstrap file: %v", err)
 	}
-	os.Remove("/tmp/.hive-bootstrap-a.txt")
+	os.Remove(filepath.Join(agentStateDir, ".hive-bootstrap-a.txt"))
 }
 
 // TestLaunchInTmux_GooseNoBootstrap covers the minimal --text branch for goose
@@ -98,7 +99,7 @@ func TestLaunchInTmux_GooseNoBootstrap(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	defer cleanupAgent(t, m, "cxa")
-	os.Remove("/tmp/.hive-bootstrap-a.txt")
+	os.Remove(filepath.Join(agentStateDir, ".hive-bootstrap-a.txt"))
 }
 
 // TestLaunchInTmux_ClaudeIssuesOnly / DefaultMode cover the claude mode switch

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -828,6 +828,20 @@ var agentTokenCacheDir = "/var/run/hive-metrics/agent-tokens"
 // agentTokenCachePerms restricts a per-agent credential file to owner-only.
 const agentTokenCachePerms = 0o600
 
+// agentStateDir is the directory holding the per-agent runtime state files:
+// .hive-mode-<name> / .hive-caps-<name> (the enforcement files gh-wrapper.sh
+// and the proxy read) and .hive-bootstrap-<name>.txt (the goose bootstrap
+// prompt, cat'ed by a launch command built from this same value, so writer and
+// reader can never disagree).
+//
+// A var (not const) as a TEST SEAM, matching the
+// ModeFileGlob/CapsFileGlob/SharedRepoParent convention: a test suite running
+// on a host that also runs a live hive must never write the live enforcement
+// files under /tmp — rewriting /tmp/.hive-mode-<agent> from a test would
+// change a REAL agent's GitHub enforcement mode (#4737/#4738). TestMain points
+// this at the per-run temp tree. Production value is unchanged.
+var agentStateDir = "/tmp"
+
 // AgentMintTokenCachePath returns the per-agent mint-token cache file path. It
 // sits beside the GitHub App token cache but is a distinct file so the two
 // credentials never collide — an agent reads the App token for GitHub and the
@@ -2452,7 +2466,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		// deliverStartupKick above, so no /tmp/.hive-bootstrap-<name>.txt is
 		// written for them. bob used to land here and get a file nothing ever
 		// read; that dead write is gone with the deferral above.
-		promptFile := fmt.Sprintf("/tmp/.hive-bootstrap-%s.txt", agent.Name)
+		promptFile := filepath.Join(agentStateDir, fmt.Sprintf(".hive-bootstrap-%s.txt", agent.Name))
 		// N15: owner-only + O_NOFOLLOW (see writeAgentStateFile).
 		if err := writeAgentStateFile(promptFile, []byte(bootstrapPrompt)); err != nil {
 			m.logger.Warn("failed to write bootstrap prompt", "name", agent.Name, "error", err)
@@ -2465,7 +2479,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	// Without bootstrap, use a minimal --text prompt so goose output is
 	// visible to tmux capture-pane (--instructions - uses hidden TUI).
 	if backend == "goose" && bootstrapPrompt == "" {
-		minimalPrompt := fmt.Sprintf("/tmp/.hive-bootstrap-%s.txt", agent.Name)
+		minimalPrompt := filepath.Join(agentStateDir, fmt.Sprintf(".hive-bootstrap-%s.txt", agent.Name))
 		if err := writeAgentStateFile(minimalPrompt, []byte("You are an AI agent. Wait for instructions from the supervisor.")); err != nil {
 			m.logger.Warn("failed to write minimal bootstrap prompt", "name", agent.Name, "error", err)
 		}
@@ -7524,7 +7538,7 @@ func (m *Manager) SyncModeFiles(level int) {
 				mode = parsed
 			}
 		}
-		modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", name)
+		modeFile := filepath.Join(agentStateDir, ".hive-mode-"+name)
 		if err := writeAgentStateFile(modeFile, []byte(mode.String())); err != nil {
 			m.logger.Warn("SyncModeFiles: write failed", "file", modeFile, "error", err)
 		}
@@ -7556,7 +7570,7 @@ func (m *Manager) agentCapabilities(agent *AgentProcess) AgentCapabilities {
 // a cleared `converse` actually revokes: leaving a stale file behind would keep
 // granting the capability after the operator turned it off.
 func (m *Manager) writeAgentCapsFile(name string, caps AgentCapabilities) {
-	capsFile := fmt.Sprintf("/tmp/.hive-caps-%s", name)
+	capsFile := filepath.Join(agentStateDir, ".hive-caps-"+name)
 	if err := writeAgentStateFile(capsFile, []byte(caps.String())); err != nil {
 		m.logger.Warn("caps file write failed", "file", capsFile, "error", err)
 	}
@@ -7899,7 +7913,7 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	} else {
 		vars = append(vars, agentEnvPair{"HIVE_AGENT_MODE", mode.String(), false})
 	}
-	modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", agent.Name)
+	modeFile := filepath.Join(agentStateDir, ".hive-mode-"+agent.Name)
 	if err := writeAgentStateFile(modeFile, []byte(mode.String())); err != nil {
 		m.logger.Warn("agentBootstrapEnv: mode file write failed", "file", modeFile, "error", err)
 	}

--- a/src/pkg/agent/manager_coverage_test.go
+++ b/src/pkg/agent/manager_coverage_test.go
@@ -387,7 +387,10 @@ func TestNewManager_CustomWorkDir(t *testing.T) {
 }
 
 func TestNewManager_DefaultWorkDir(t *testing.T) {
-	os.Unsetenv("HIVE_WORK_DIR")
+	// "" (not Unsetenv) so TestMain's package-wide HIVE_WORK_DIR guard
+	// (#4737/#4738) is restored after this test instead of leaking an unset
+	// var to the rest of the run.
+	t.Setenv("HIVE_WORK_DIR", "")
 	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	if m.workDir != "/data/agents" {
 		t.Errorf("workDir = %q, want /data/agents", m.workDir)

--- a/src/pkg/agent/manager_test.go
+++ b/src/pkg/agent/manager_test.go
@@ -34,6 +34,11 @@ func testEnvPairs(ap *AgentProcess) []agentEnvPair {
 // hermetic temp tree. Pin tests on the production config read this.
 var productionWatchedHomeDirs []string
 
+// productionPlukRunDir is the production default of plukRunDir, snapshotted by
+// TestMain before it redirects the run dir into the hermetic temp tree. Pin
+// tests on the production path read this.
+var productionPlukRunDir string
+
 func TestMain(m *testing.M) {
 	defaultTmuxSocket = fmt.Sprintf("ht%d", os.Getpid())
 
@@ -94,6 +99,12 @@ func TestMain(m *testing.M) {
 	// /data trees when they exist. Point every walk root into the temp tree so
 	// no test can touch live agent data or spend minutes walking real dirs.
 	permRoot := filepath.Join(dir, "perm")
+	// The state-file writers (mode/caps/bootstrap below) need the directory to
+	// exist, exactly as /tmp always does in production.
+	if err := os.MkdirAll(permRoot, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: MkdirAll permRoot: %v\n", err)
+		os.Exit(1)
+	}
 	// Snapshot the production list first: TestWatchedHomeDirsIncludesBob pins
 	// the production default (bob's /data/home/.bob entry), not the override.
 	productionWatchedHomeDirs = append([]string(nil), WatchedHomeDirs...)
@@ -102,6 +113,15 @@ func TestMain(m *testing.M) {
 	GooseLogsDir = filepath.Join(permRoot, "home", ".local", "state", "goose", "logs", "cli")
 	ModeFileGlob = filepath.Join(permRoot, ".hive-mode-*")
 	CapsFileGlob = filepath.Join(permRoot, ".hive-caps-*")
+	// The mode/caps/bootstrap WRITERS must land where the globs above scan —
+	// and never in the real /tmp, where a live hive's gh-wrapper reads
+	// .hive-mode-<agent>: a test rewriting that file would change a REAL
+	// agent's enforcement mode (#4737/#4738).
+	agentStateDir = permRoot
+	// pluk is on PATH on live-hive hosts, so the launch path would otherwise
+	// mkdir /var/run/pluk and create session logs there (#4737/#4738).
+	productionPlukRunDir = plukRunDir
+	plukRunDir = filepath.Join(dir, "pluk")
 
 	// Pacing shrink (#4717/#4688): the suite's 440 tests pay production pacing
 	// (1-3s sleeps, 60-120s poll deadlines) against stub CLIs that render
@@ -136,7 +156,28 @@ func TestMain(m *testing.M) {
 	diagnosticTimeoutSec = 3
 	diagnosticPollSec = 1
 
+	// Env-resolved default paths (#4737/#4738): NewManager's default workDir is
+	// /data/agents and the kick-log archive default is /data/logs/kicks — a test
+	// that forgets to set these launches into (and the permission fixer walks)
+	// LIVE agent workspaces on a host that runs a hive. Guard package-wide;
+	// tests pinning the production defaults t.Setenv these to "" explicitly.
+	originalWorkDir, hadWorkDir := os.LookupEnv("HIVE_WORK_DIR")
+	originalKickLogDir, hadKickLogDir := os.LookupEnv(kickLogDirEnv)
+	os.Setenv("HIVE_WORK_DIR", filepath.Join(dir, "work"))
+	os.Setenv(kickLogDirEnv, filepath.Join(dir, "kicks"))
+
 	code := m.Run()
+
+	if hadWorkDir {
+		os.Setenv("HIVE_WORK_DIR", originalWorkDir)
+	} else {
+		os.Unsetenv("HIVE_WORK_DIR")
+	}
+	if hadKickLogDir {
+		os.Setenv(kickLogDirEnv, originalKickLogDir)
+	} else {
+		os.Unsetenv(kickLogDirEnv)
+	}
 
 	os.Setenv("PATH", originalPath)
 	if originalTMUX == "" {

--- a/src/pkg/agent/pluk_dirs.go
+++ b/src/pkg/agent/pluk_dirs.go
@@ -6,9 +6,14 @@ import (
 	"path/filepath"
 )
 
-const (
-	plukRunDir = "/var/run/pluk"
-)
+// plukRunDir is where pluk's run state and per-session logs live.
+//
+// A var (not const) as a TEST SEAM, matching the agentTokenCacheDir
+// convention: `pluk` is on PATH on any host running a live hive, so a test
+// that launches an agent would otherwise try to create /var/run/pluk and
+// session logs on the live host (#4737/#4738). TestMain points this at the
+// per-run temp tree. Production value is unchanged.
+var plukRunDir = "/var/run/pluk"
 
 // pluk runs from per-agent tmux servers. Agent UIDs differ, but they all share
 // the node group, so setgid keeps new entries group-owned without opening the

--- a/src/pkg/agent/pluk_publisher_test.go
+++ b/src/pkg/agent/pluk_publisher_test.go
@@ -88,7 +88,7 @@ func TestPlukPipePaneCmdQuotesEveryOperand(t *testing.T) {
 // "<plukLogDir>/hive-brainstorm.jsonl" and hive-panes.sh globs
 // "$LOG_DIR"/hive-*.jsonl. If this drifts, both go quiet without erroring.
 func TestPlukSessionLogPathMatchesItsConsumers(t *testing.T) {
-	got := plukSessionLogPath(plukRunDir, "hive-brainstorm")
+	got := plukSessionLogPath(productionPlukRunDir, "hive-brainstorm")
 	const want = "/var/run/pluk/logs/hive-brainstorm.jsonl"
 	if got != want {
 		t.Fatalf("log path = %q, want %q — the inception watcher tails the literal %q",


### PR DESCRIPTION
Fixes #4737
Fixes #4738

Both issues were filed against v4 @ 3838f09 — the #4728 seams merge itself — so they describe genuinely unsealed paths, not stale pre-#4728 runs. The #4728/#4724 seams isolated the SCANNERS and tmux; this seals the writers and env-resolved defaults the reports caught on a live-hive host:

## What leaked

- **Live enforcement files**: `SyncModeFiles`, `writeAgentCapsFile` and `agentBootstrapEnv` wrote `/tmp/.hive-mode-<agent>` / `/tmp/.hive-caps-<agent>` with hardcoded sprintf paths — the very files a live hive's gh-wrapper and proxy read. The observed `permission denied` warnings were the host *defending itself*; on a permissive host a test would have rewritten a real agent's GitHub enforcement mode.
- **`/var/run/pluk`**: `pluk` is on PATH on any live-hive host, so the launch path tried to mkdir the real run dir and create session logs.
- **`/data/agents` + `/data/logs/kicks`**: the `HIVE_WORK_DIR` and `HIVE_KICK_LOG_DIR` defaults meant any test that forgot to set them launched into — and let the permission fixer walk — live agent workspaces.

## The fix (same seam style, production values unchanged)

- New `agentStateDir` var seam ("/tmp" in production) used by all mode/caps/bootstrap writers; TestMain points it at the same per-run temp root the existing `ModeFileGlob`/`CapsFileGlob` scanners already use, so writer and scanner can never diverge. The goose launch command is built from the same value, so the `--text "$(cat …)"` reader moves with the writer.
- `plukRunDir` const → var seam; TestMain repoints it, and the production-path pins in pluk_publisher_test read a `productionPlukRunDir` snapshot (the `productionWatchedHomeDirs` pattern).
- TestMain guards `HIVE_WORK_DIR`/`HIVE_KICK_LOG_DIR` package-wide (restored after the run). `TestNewManager_DefaultWorkDir` switches from `os.Unsetenv` — which silently stripped the guard for every later test in the run — to `t.Setenv("")`, which pins the same default and restores.

Full `pkg/agent` suite green in 279s (well under the 600s budget).

— reviewed lane fix-forward