### PR TITLE
🐛 fix(github): capture watcher poll intervals before spawning the loop

### DIFF
--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -122,8 +122,13 @@ func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueReques
 	if !ensureRequestDir(c.logger, "issue", issueRequestDir()) {
 		return
 	}
+	// Capture the poll interval BEFORE spawning: the goroutine's first read of
+	// the package-level interval races with a test's fastTick cleanup restoring
+	// it (the race detector flagged exactly that on v4 CI). Reading it here is
+	// sequenced with the caller, and the loop only ever needed it once anyway.
+	interval := issueRequestPollInterval
 	go func() {
-		t := time.NewTicker(issueRequestPollInterval)
+		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
 			select {

--- a/src/pkg/github/merge_request_watcher.go
+++ b/src/pkg/github/merge_request_watcher.go
@@ -165,8 +165,13 @@ func (c *Client) StartMergeRequestWatcher(ctx context.Context, authz MergeReques
 		c.logger.Warn("merge-request watcher: could not set group-writable perms on request dir; agents may be unable to request merges",
 			slog.String("dir", mergeRequestDir()), slog.String("error", err.Error()))
 	}
+	// Capture the poll interval BEFORE spawning: the goroutine's first read of
+	// the package-level interval races with a test's fastTick cleanup restoring
+	// it (the race detector flagged exactly that on v4 CI). Reading it here is
+	// sequenced with the caller, and the loop only ever needed it once anyway.
+	interval := mergeRequestPollInterval
 	go func() {
-		t := time.NewTicker(mergeRequestPollInterval)
+		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
 			select {

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -110,8 +110,13 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 	if !ensureRequestDir(c.logger, "pr", prRequestDir()) {
 		return
 	}
+	// Capture the poll interval BEFORE spawning: the goroutine's first read of
+	// the package-level interval races with a test's fastTick cleanup restoring
+	// it (the race detector flagged exactly that on v4 CI). Reading it here is
+	// sequenced with the caller, and the loop only ever needed it once anyway.
+	interval := prRequestPollInterval
 	go func() {
-		t := time.NewTicker(prRequestPollInterval)
+		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
 			select {

--- a/src/pkg/github/review_request_watcher.go
+++ b/src/pkg/github/review_request_watcher.go
@@ -102,8 +102,13 @@ func (c *Client) StartReviewRequestWatcher(ctx context.Context, authz ReviewRequ
 		c.logger.Warn("review-request watcher: could not set group-writable perms on request dir; agents may be unable to review",
 			slog.String("dir", reviewRequestDir()), slog.String("error", err.Error()))
 	}
+	// Capture the poll interval BEFORE spawning: the goroutine's first read of
+	// the package-level interval races with a test's fastTick cleanup restoring
+	// it (the race detector flagged exactly that on v4 CI). Reading it here is
+	// sequenced with the caller, and the loop only ever needed it once anyway.
+	interval := reviewRequestPollInterval
 	go func() {
-		t := time.NewTicker(reviewRequestPollInterval)
+		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
 			select {


### PR DESCRIPTION
Deflakes a DATA RACE that just started firing on v4 CI (`test (rest 1/3)`, e.g. run 32973174857 on PR #4787): the four write-request watchers create their tickers **inside** the spawned goroutine, so the goroutine's first read of the package-level poll-interval variable races with the watcher-loop tests' `fastTick` cleanup restoring it (tests landed in 170a8e0a; the race is real per the detector, even though it's test-orchestration-visible only).

Fix at the seam: capture the interval into a local **before** `go func()`. The read is now sequenced with the caller — happens-before the test returns and therefore before its cleanup write — and the loop only ever read the value once anyway. Zero behavior change; same pattern the test file itself documents for the dir hook.

Verified: `go test ./pkg/github -race` full package green, watcher tests green at `-race -count=5` (previously flaky under load).