### PR TITLE
🧪 test: cover knowledge document ingestion

### DIFF
--- a/src/pkg/knowledge/api.go
+++ b/src/pkg/knowledge/api.go
@@ -14,6 +14,11 @@ import (
 
 const localKnowledgeDir = "/data/knowledge"
 
+// knowledgeBaseDir is the root for imported document metadata and document
+// vaults. Production uses localKnowledgeDir; tests override it for hermetic
+// temp-dir-backed ingestion.
+var knowledgeBaseDir = localKnowledgeDir
+
 // vaultsBaseDir is where user-created knowledge channels (vaults) are stored on
 // the spoke's data volume, one directory per channel. It mirrors the location the
 // bead synthesizer uses for its own vault. A var (not const) only so purge/create
@@ -554,11 +559,11 @@ func (k *KnowledgeAPI) RemoveSubscription(url string) error {
 
 // VaultInfo describes a connected Obsidian/file-based vault for the dashboard.
 type VaultInfo struct {
-	Name       string         `json:"name"`
-	RootDir    string         `json:"root_dir"`
-	Pages      int            `json:"pages"`
-	LastIndexed time.Time     `json:"last_indexed"`
-	TagCounts  map[string]int `json:"tag_counts,omitempty"`
+	Name        string         `json:"name"`
+	RootDir     string         `json:"root_dir"`
+	Pages       int            `json:"pages"`
+	LastIndexed time.Time      `json:"last_indexed"`
+	TagCounts   map[string]int `json:"tag_counts,omitempty"`
 }
 
 // ConnectVault adds a file-based vault (Obsidian, MindStudio export, or any
@@ -851,7 +856,7 @@ func (k *KnowledgeAPI) ImportDocument(ctx context.Context, config DocSourceConfi
 	k.mu.Unlock()
 
 	vaultDir := k.docVaultDir()
-	ds := NewDocumentSource(config, localKnowledgeDir, vaultDir, k.graphStore, k.logger, k.context7APIKey)
+	ds := NewDocumentSource(config, knowledgeBaseDir, vaultDir, k.graphStore, k.logger, k.context7APIKey)
 	meta, err := ds.Import(ctx)
 	if err != nil {
 		return nil, err
@@ -942,7 +947,7 @@ func (k *KnowledgeAPI) SearchContext7Libraries(ctx context.Context, query string
 // reloadDocuments scans the documents directory for previously imported
 // documents and restores them into memory from their metadata.json files.
 func (k *KnowledgeAPI) reloadDocuments() {
-	docsDir := filepath.Join(localKnowledgeDir, docStorageDir)
+	docsDir := filepath.Join(knowledgeBaseDir, docStorageDir)
 	entries, err := os.ReadDir(docsDir)
 	if err != nil {
 		return
@@ -1065,7 +1070,7 @@ func (k *KnowledgeAPI) docVaultDir() string {
 			return v.rootDir
 		}
 	}
-	return filepath.Join(localKnowledgeDir, "documents-vault")
+	return filepath.Join(knowledgeBaseDir, "documents-vault")
 }
 
 // ObsidianSyncRequest is the payload from the Obsidian Post Webhook plugin.
@@ -1132,9 +1137,9 @@ func (r *ObsidianSyncRequest) Vault() string {
 
 // ObsidianSyncResult describes the outcome of an Obsidian sync operation.
 type ObsidianSyncResult struct {
-	Slug    string    `json:"slug"`
-	Action  string    `json:"action"` // "created" or "updated"
-	Fact    Fact      `json:"fact"`
+	Slug   string `json:"slug"`
+	Action string `json:"action"` // "created" or "updated"
+	Fact   Fact   `json:"fact"`
 }
 
 // defaultObsidianConfidence is used when frontmatter omits a confidence value.

--- a/src/pkg/knowledge/api_import_document_test.go
+++ b/src/pkg/knowledge/api_import_document_test.go
@@ -1,0 +1,130 @@
+package knowledge
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func withKnowledgeBaseDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	oldBase := knowledgeBaseDir
+	oldPrefixes := allowedFilePrefixes
+	knowledgeBaseDir = dir
+	allowedFilePrefixes = []string{dir + string(filepath.Separator)}
+	t.Cleanup(func() {
+		knowledgeBaseDir = oldBase
+		allowedFilePrefixes = oldPrefixes
+	})
+	return dir
+}
+
+func importDocTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestKnowledgeAPIImportDocumentFileIngestion(t *testing.T) {
+	base := withKnowledgeBaseDir(t)
+	source := filepath.Join(base, "uploads", "runbook.txt")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "Runbook Title\n\nThe system must retry failed jobs.\n\nOperators need clear rollback steps."
+	if err := os.WriteFile(source, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	api := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true}, importDocTestLogger())
+	meta, err := api.ImportDocument(context.Background(), DocSourceConfig{
+		Name:     "Runbook Import",
+		FilePath: source,
+		Layer:    LayerProject,
+	})
+	if err != nil {
+		t.Fatalf("ImportDocument: %v", err)
+	}
+	if meta.Slug != "runbook-import" {
+		t.Fatalf("slug = %q, want runbook-import", meta.Slug)
+	}
+	if meta.FactCount == 0 || len(meta.FactSlugs) != meta.FactCount {
+		t.Fatalf("expected imported facts, got meta %+v", meta)
+	}
+	if got := api.ListDocuments(); len(got) != 1 || got[0].Slug != meta.Slug {
+		t.Fatalf("ListDocuments = %+v, want imported metadata", got)
+	}
+	if got, err := api.GetDocument(meta.Slug); err != nil || got.FactCount != meta.FactCount {
+		t.Fatalf("GetDocument = %+v, %v; want fact count %d", got, err, meta.FactCount)
+	}
+
+	for _, slug := range meta.FactSlugs {
+		path := filepath.Join(base, "documents-vault", slug+".md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("expected fact %s written to vault: %v", slug, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("fact %s is empty", slug)
+		}
+	}
+
+	if _, err := api.ImportDocument(context.Background(), DocSourceConfig{Name: "Runbook Import", FilePath: source}); err == nil {
+		t.Fatal("duplicate import should be rejected")
+	}
+}
+
+func TestKnowledgeAPIReloadDocumentsSkipsCorruptMetadata(t *testing.T) {
+	base := withKnowledgeBaseDir(t)
+	source := filepath.Join(base, "uploads", "guide.txt")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("Guide Title\n\nA persistent fact from disk."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	api := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true}, importDocTestLogger())
+	if _, err := api.ImportDocument(context.Background(), DocSourceConfig{
+		Name:     "Reloaded Guide",
+		FilePath: source,
+	}); err != nil {
+		t.Fatalf("ImportDocument: %v", err)
+	}
+
+	badDir := filepath.Join(base, docStorageDir, "corrupt")
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, docMetadataFile), []byte("{not-json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true}, importDocTestLogger())
+	docs := reloaded.ListDocuments()
+	if len(docs) != 1 {
+		t.Fatalf("reloaded docs = %+v, want exactly the valid document", docs)
+	}
+	if docs[0].Slug != "reloaded-guide" {
+		t.Fatalf("reloaded slug = %q, want reloaded-guide", docs[0].Slug)
+	}
+}
+
+func TestKnowledgeAPIImportDocumentRejectsInvalidSources(t *testing.T) {
+	base := withKnowledgeBaseDir(t)
+	api := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true}, importDocTestLogger())
+
+	outside := filepath.Join(filepath.Dir(base), "outside.txt")
+	if err := os.WriteFile(outside, []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := api.ImportDocument(context.Background(), DocSourceConfig{Name: "Outside", FilePath: outside}); err == nil {
+		t.Fatal("outside file should be rejected")
+	}
+
+	if _, err := api.ImportDocument(context.Background(), DocSourceConfig{Name: "No Source"}); err == nil {
+		t.Fatal("missing url/file/context7 should be rejected")
+	}
+}


### PR DESCRIPTION
Closes #4755.\n\nAdds hermetic ImportDocument coverage using a temp knowledge-base root: real file ingestion, duplicate rejection, vault fact writes, reloadDocuments valid/corrupt metadata behavior, and invalid source errors.\n\nValidation:\n- go test ./pkg/knowledge -count=1\n- go vet ./pkg/knowledge\n\nMutation spot-check: disabling duplicate-import detection made TestKnowledgeAPIImportDocumentFileIngestion fail as expected.\n\nSigned-off-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>