### PR TITLE
🐛 fix: prevent PDF CMap import panics

### DIFF
--- a/src/pkg/knowledge/docparser.go
+++ b/src/pkg/knowledge/docparser.go
@@ -110,7 +110,13 @@ func parsePDF(data []byte) ([]DocChunk, string) {
 // extractPageText extracts readable text from a PDF page. Prefers the PDF's
 // own text stream (GetPlainText) which preserves correct character ordering.
 // Falls back to positioned-glyph reconstruction only when GetPlainText fails.
-func extractPageText(page pdf.Page) string {
+func extractPageText(page pdf.Page) (out string) {
+	defer func() {
+		if recover() != nil {
+			out = ""
+		}
+	}()
+
 	text, err := page.GetPlainText(nil)
 	if err == nil && strings.TrimSpace(text) != "" {
 		result := strings.ReplaceAll(text, "\r\n", "\n")

--- a/src/pkg/knowledge/docparser_pdf_malformed_test.go
+++ b/src/pkg/knowledge/docparser_pdf_malformed_test.go
@@ -1,0 +1,48 @@
+package knowledge
+
+import (
+	"fmt"
+	"testing"
+)
+
+func buildMalformedCMapPDF() []byte {
+	objects := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+		"<< /Length 37 >>\nstream\nBT /F1 12 Tf 72 720 Td (A) Tj ET\nendstream",
+		"<< /Type /Font /Subtype /Type0 /BaseFont /Bad /Encoding /Identity-H /ToUnicode 6 0 R /DescendantFonts [7 0 R] >>",
+		"<< /Length 9 >>\nstream\nendbfchar\nendstream",
+		"<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Bad /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>",
+	}
+	var buf []byte
+	buf = append(buf, []byte("%PDF-1.4\n")...)
+	offsets := make([]int, len(objects)+1)
+	for i, obj := range objects {
+		offsets[i+1] = len(buf)
+		buf = append(buf, []byte(fmt.Sprintf("%d 0 obj\n%s\nendobj\n", i+1, obj))...)
+	}
+	xref := len(buf)
+	buf = append(buf, []byte(fmt.Sprintf("xref\n0 %d\n0000000000 65535 f \n", len(objects)+1))...)
+	for i := 1; i <= len(objects); i++ {
+		buf = append(buf, []byte(fmt.Sprintf("%010d 00000 n \n", offsets[i]))...)
+	}
+	buf = append(buf, []byte(fmt.Sprintf("trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objects)+1, xref))...)
+	return buf
+}
+
+func TestParsePDFMalformedToUnicodeCMapDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parsePDF panicked on malformed ToUnicode CMap: %v", r)
+		}
+	}()
+
+	chunks, title := parsePDF(buildMalformedCMapPDF())
+	if len(chunks) != 0 {
+		t.Fatalf("malformed page should be skipped, got chunks: %+v", chunks)
+	}
+	if title != "" {
+		t.Fatalf("malformed page should not produce a title, got %q", title)
+	}
+}


### PR DESCRIPTION
Closes #4776.\n\nGuards PDF page text extraction so a malformed /ToUnicode CMap panic is treated as an empty page instead of crashing document import. Adds a minimal malformed-CMap PDF regression.\n\nValidation:\n- go test ./pkg/knowledge -count=1\n- go vet ./pkg/knowledge\n\nMutation spot-check: removing the recover guard made TestParsePDFMalformedToUnicodeCMapDoesNotPanic fail as expected.\n\nSigned-off-by: Copilot <223556219+Copilot@users.noreply.github.com>\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>