### PR TITLE
🐛 fix(github): make the request watchers joinable so cancelled loops cannot race test cleanup

### DIFF
--- a/src/pkg/github/issue_request_watcher.go
+++ b/src/pkg/github/issue_request_watcher.go
@@ -109,9 +109,16 @@ type issueRetryState struct {
 // dropped in IssueRequestDir. Same contract as StartPRRequestWatcher: returns
 // immediately, runs until ctx cancel, nil client is a no-op (requests
 // accumulate rather than silently dropping), nil authz fails closed.
-func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueRequestAuthorizer, nowFn func() time.Time) {
+//
+// The returned channel closes when the watcher goroutine has exited (or
+// immediately when it never starts), so callers — tests above all — can JOIN
+// the loop after cancelling instead of sleeping and hoping: an unjoined
+// watcher outliving its test races the test's global-seam restores.
+func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueRequestAuthorizer, nowFn func() time.Time) <-chan struct{} {
+	done := make(chan struct{})
 	if c == nil {
-		return
+		close(done)
+		return done
 	}
 	c.issueAuthz = authz
 	if nowFn == nil {
@@ -120,7 +127,8 @@ func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueReques
 	// Shared with PrepareRequestDirs, which creates this queue unconditionally
 	// at boot so findings can accumulate even before a watcher runs.
 	if !ensureRequestDir(c.logger, "issue", issueRequestDir()) {
-		return
+		close(done)
+		return done
 	}
 	// Capture the poll interval BEFORE spawning: the goroutine's first read of
 	// the package-level interval races with a test's fastTick cleanup restoring
@@ -128,6 +136,7 @@ func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueReques
 	// sequenced with the caller, and the loop only ever needed it once anyway.
 	interval := issueRequestPollInterval
 	go func() {
+		defer close(done)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
@@ -135,11 +144,19 @@ func (c *Client) StartIssueRequestWatcher(ctx context.Context, authz IssueReques
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				// A cancelled ctx can lose the select to an already-ready tick
+				// (select picks randomly among ready cases), letting the loop
+				// process one more scan after cancellation. Fail the tick
+				// closed so cancel means no further processing.
+				if ctx.Err() != nil {
+					return
+				}
 				c.processIssueRequests(ctx, nowFn)
 			}
 		}
 	}()
 	c.logger.Info("issue-request watcher started", slog.String("dir", issueRequestDir()))
+	return done
 }
 
 func (c *Client) processIssueRequests(ctx context.Context, nowFn func() time.Time) {

--- a/src/pkg/github/merge_request_watcher.go
+++ b/src/pkg/github/merge_request_watcher.go
@@ -144,9 +144,16 @@ func isRequiredCheckMergeBlocker(errMsg string) bool {
 // the per-agent ACMM merge-gate + forge-resistance AND the F4 target-binding
 // (pinned SHA + merge-eligible membership); a nil authz fails closed. nowFn is
 // injectable for tests; pass nil for time.Now.
-func (c *Client) StartMergeRequestWatcher(ctx context.Context, authz MergeRequestAuthorizer, nowFn func() time.Time) {
+//
+// The returned channel closes when the watcher goroutine has exited (or
+// immediately when it never starts), so callers — tests above all — can JOIN
+// the loop after cancelling instead of sleeping and hoping: an unjoined
+// watcher outliving its test races the test's global-seam restores.
+func (c *Client) StartMergeRequestWatcher(ctx context.Context, authz MergeRequestAuthorizer, nowFn func() time.Time) <-chan struct{} {
+	done := make(chan struct{})
 	if c == nil {
-		return
+		close(done)
+		return done
 	}
 	c.mergeAuthz = authz
 	if nowFn == nil {
@@ -155,7 +162,8 @@ func (c *Client) StartMergeRequestWatcher(ctx context.Context, authz MergeReques
 	if err := os.MkdirAll(mergeRequestDir(), 0o777); err != nil {
 		c.logger.Warn("merge-request watcher: cannot create request dir; disabled",
 			slog.String("dir", mergeRequestDir()), slog.String("error", err.Error()))
-		return
+		close(done)
+		return done
 	}
 	// Agents must be able to DROP request files here (hive-merge runs AS the
 	// agent). Force group-write + setgid so agent-written files inherit the node
@@ -171,6 +179,7 @@ func (c *Client) StartMergeRequestWatcher(ctx context.Context, authz MergeReques
 	// sequenced with the caller, and the loop only ever needed it once anyway.
 	interval := mergeRequestPollInterval
 	go func() {
+		defer close(done)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
@@ -178,11 +187,19 @@ func (c *Client) StartMergeRequestWatcher(ctx context.Context, authz MergeReques
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				// A cancelled ctx can lose the select to an already-ready tick
+				// (select picks randomly among ready cases), letting the loop
+				// process one more scan after cancellation. Fail the tick
+				// closed so cancel means no further processing.
+				if ctx.Err() != nil {
+					return
+				}
 				c.processMergeRequests(ctx, nowFn)
 			}
 		}
 	}()
 	c.logger.Info("merge-request watcher started", slog.String("dir", mergeRequestDir()))
+	return done
 }
 
 func (c *Client) processMergeRequests(ctx context.Context, nowFn func() time.Time) {

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -96,9 +96,16 @@ type PRRequestAuthorizer func(agent string, fileUID int) error
 // hold-gated PRs were being opened unlabeled. A nil holdLabel means "never hold".
 //
 // nowFn is injectable for tests; pass nil for time.Now.
-func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, holdLabel func() bool, nowFn func() time.Time) {
+//
+// The returned channel closes when the watcher goroutine has exited (or
+// immediately when it never starts), so callers — tests above all — can JOIN
+// the loop after cancelling instead of sleeping and hoping: an unjoined
+// watcher outliving its test races the test's global-seam restores.
+func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, holdLabel func() bool, nowFn func() time.Time) <-chan struct{} {
+	done := make(chan struct{})
 	if c == nil {
-		return
+		close(done)
+		return done
 	}
 	c.prAuthz = authz
 	c.prHoldLabel = holdLabel
@@ -108,7 +115,8 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 	// Shared with PrepareRequestDirs, which creates this queue unconditionally
 	// at boot so requests can accumulate even before a watcher runs.
 	if !ensureRequestDir(c.logger, "pr", prRequestDir()) {
-		return
+		close(done)
+		return done
 	}
 	// Capture the poll interval BEFORE spawning: the goroutine's first read of
 	// the package-level interval races with a test's fastTick cleanup restoring
@@ -116,6 +124,7 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 	// sequenced with the caller, and the loop only ever needed it once anyway.
 	interval := prRequestPollInterval
 	go func() {
+		defer close(done)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
@@ -123,11 +132,19 @@ func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAutho
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				// A cancelled ctx can lose the select to an already-ready tick
+				// (select picks randomly among ready cases), letting the loop
+				// process one more scan after cancellation. Fail the tick
+				// closed so cancel means no further processing.
+				if ctx.Err() != nil {
+					return
+				}
 				c.processPRRequests(ctx, nowFn)
 			}
 		}
 	}()
 	c.logger.Info("pr-request watcher started", slog.String("dir", prRequestDir()))
+	return done
 }
 
 // processPRRequests handles one scan of the request dir. Exported-in-spirit for

--- a/src/pkg/github/review_request_watcher.go
+++ b/src/pkg/github/review_request_watcher.go
@@ -82,9 +82,16 @@ func reviewEventToAPI(event string) (apiEvent, state string, ok bool) {
 // files dropped in ReviewRequestDir. Same contract as StartPRRequestWatcher:
 // returns immediately, runs until ctx cancel, nil client is a no-op (requests
 // accumulate rather than silently dropping), nil authz fails closed.
-func (c *Client) StartReviewRequestWatcher(ctx context.Context, authz ReviewRequestAuthorizer, nowFn func() time.Time) {
+//
+// The returned channel closes when the watcher goroutine has exited (or
+// immediately when it never starts), so callers — tests above all — can JOIN
+// the loop after cancelling instead of sleeping and hoping: an unjoined
+// watcher outliving its test races the test's global-seam restores.
+func (c *Client) StartReviewRequestWatcher(ctx context.Context, authz ReviewRequestAuthorizer, nowFn func() time.Time) <-chan struct{} {
+	done := make(chan struct{})
 	if c == nil {
-		return
+		close(done)
+		return done
 	}
 	c.reviewAuthz = authz
 	if nowFn == nil {
@@ -93,7 +100,8 @@ func (c *Client) StartReviewRequestWatcher(ctx context.Context, authz ReviewRequ
 	if err := os.MkdirAll(reviewRequestDir(), 0o777); err != nil {
 		c.logger.Warn("review-request watcher: cannot create request dir; disabled",
 			slog.String("dir", reviewRequestDir()), slog.String("error", err.Error()))
-		return
+		close(done)
+		return done
 	}
 	// Agents (UID >= 2001, shared node group) must be able to DROP request files;
 	// MkdirAll is umask-masked, so force group-write + setgid (same as the PR
@@ -108,6 +116,7 @@ func (c *Client) StartReviewRequestWatcher(ctx context.Context, authz ReviewRequ
 	// sequenced with the caller, and the loop only ever needed it once anyway.
 	interval := reviewRequestPollInterval
 	go func() {
+		defer close(done)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
@@ -115,11 +124,19 @@ func (c *Client) StartReviewRequestWatcher(ctx context.Context, authz ReviewRequ
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				// A cancelled ctx can lose the select to an already-ready tick
+				// (select picks randomly among ready cases), letting the loop
+				// process one more scan after cancellation. Fail the tick
+				// closed so cancel means no further processing.
+				if ctx.Err() != nil {
+					return
+				}
 				c.processReviewRequests(ctx, nowFn)
 			}
 		}
 	}()
 	c.logger.Info("review-request watcher started", slog.String("dir", reviewRequestDir()))
+	return done
 }
 
 func (c *Client) processReviewRequests(ctx context.Context, nowFn func() time.Time) {

--- a/src/pkg/github/watcher_loops_test.go
+++ b/src/pkg/github/watcher_loops_test.go
@@ -68,14 +68,18 @@ func reviewServer(t *testing.T, hits *atomic.Int64) *httptest.Server {
 // helpers: their restores would otherwise write the package globals while a
 // live watcher goroutine is still reading them on each tick, which the race
 // detector correctly flags — the test would be the data race, not the code.
-func drainAfter(t *testing.T, cancel context.CancelFunc) {
+// Joining via the done channel Start*Watcher now returns replaces the previous
+// fixed 750ms sleep, which was a guess that CI load (and -race slowdown) could
+// and did outlast.
+func drainAfter(t *testing.T, cancel context.CancelFunc, done <-chan struct{}) {
 	t.Helper()
 	t.Cleanup(func() {
 		cancel()
-		// Comfortably more than the 15ms test tick even under -race, which
-		// slows every scan down, so the loop has observed cancellation and
-		// returned before anything it reads is restored.
-		time.Sleep(750 * time.Millisecond)
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("watcher goroutine did not exit after context cancellation")
+		}
 	})
 }
 
@@ -148,8 +152,8 @@ func TestStartMergeRequestWatcher_DispatchesQueuedRequest(t *testing.T) {
 	fastTick(t, func(d time.Duration) { mergeRequestPollInterval = d }, mergeRequestPollInterval)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	drainAfter(t, cancel)
-	c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+	done := c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+	drainAfter(t, cancel, done)
 
 	if _, err := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 1, Agent: "a"}); err != nil {
 		t.Fatal(err)
@@ -168,11 +172,12 @@ func TestStartMergeRequestWatcher_StopsOnContextCancel(t *testing.T) {
 	fastTick(t, func(d time.Duration) { mergeRequestPollInterval = d }, mergeRequestPollInterval)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	drainAfter(t, cancel)
-	c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+	done := c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+	drainAfter(t, cancel, done)
 	cancel()
-	// Give the loop time to observe cancellation before queueing work.
-	time.Sleep(80 * time.Millisecond)
+	// Join the loop: after done closes, no scan can run, so the work queued
+	// below deterministically stays unprocessed.
+	<-done
 
 	if _, err := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 2, Agent: "a"}); err != nil {
 		t.Fatal(err)
@@ -200,8 +205,8 @@ func TestStartMergeRequestWatcher_SurvivesMalformedRequest(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	drainAfter(t, cancel)
-	c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+	done := c.StartMergeRequestWatcher(ctx, func(string, int, string, int, string) error { return nil }, nil)
+	drainAfter(t, cancel, done)
 
 	if _, err := WriteMergeRequest(dir, MergeRequest{Repo: "o/r", Number: 3, Agent: "a"}); err != nil {
 		t.Fatal(err)
@@ -222,8 +227,8 @@ func TestStartPRRequestWatcher_DispatchesQueuedRequest(t *testing.T) {
 	fastTick(t, func(d time.Duration) { prRequestPollInterval = d }, prRequestPollInterval)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	drainAfter(t, cancel)
-	c.StartPRRequestWatcher(ctx, func(string, int) error { return nil }, nil, nil)
+	done := c.StartPRRequestWatcher(ctx, func(string, int) error { return nil }, nil, nil)
+	drainAfter(t, cancel, done)
 
 	if _, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "f", Base: "main", Title: "t", Agent: "a"}); err != nil {
 		t.Fatal(err)
@@ -242,10 +247,10 @@ func TestStartPRRequestWatcher_StopsOnContextCancel(t *testing.T) {
 	fastTick(t, func(d time.Duration) { prRequestPollInterval = d }, prRequestPollInterval)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	drainAfter(t, cancel)
-	c.StartPRRequestWatcher(ctx, func(string, int) error { return nil }, nil, nil)
+	done := c.StartPRRequestWatcher(ctx, func(string, int) error { return nil }, nil, nil)
+	drainAfter(t, cancel, done)
 	cancel()
-	time.Sleep(80 * time.Millisecond)
+	<-done
 
 	if _, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "g", Base: "main", Title: "t", Agent: "a"}); err != nil {
 		t.Fatal(err)
@@ -268,8 +273,8 @@ func TestStartReviewRequestWatcher_DispatchesQueuedRequest(t *testing.T) {
 	fastTick(t, func(d time.Duration) { reviewRequestPollInterval = d }, reviewRequestPollInterval)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	drainAfter(t, cancel)
-	c.StartReviewRequestWatcher(ctx, func(string, int) error { return nil }, nil)
+	done := c.StartReviewRequestWatcher(ctx, func(string, int) error { return nil }, nil)
+	drainAfter(t, cancel, done)
 
 	if _, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 1, Event: "approve", Agent: "a"}); err != nil {
 		t.Fatal(err)
@@ -288,10 +293,10 @@ func TestStartReviewRequestWatcher_StopsOnContextCancel(t *testing.T) {
 	fastTick(t, func(d time.Duration) { reviewRequestPollInterval = d }, reviewRequestPollInterval)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	drainAfter(t, cancel)
-	c.StartReviewRequestWatcher(ctx, func(string, int) error { return nil }, nil)
+	done := c.StartReviewRequestWatcher(ctx, func(string, int) error { return nil }, nil)
+	drainAfter(t, cancel, done)
 	cancel()
-	time.Sleep(80 * time.Millisecond)
+	<-done
 
 	if _, err := WriteReviewRequest(dir, ReviewRequest{Repo: "o/r", Number: 2, Event: "approve", Agent: "a"}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The four `Start*RequestWatcher` functions gave callers no way to know their goroutine had exited (the test file's own comment notes this). The new `watcher_loops_test.go` cancel tests (from 170a8e0a) compensated with fixed sleeps (750ms drain / 80ms cancel), which CI load and `-race` outlast: leaked watcher goroutines keep reading package globals (poll intervals, request-dir overrides) while test cleanup restores them → data races and `test (rest 1/3)` shard failures currently hitting every open PR (e.g. #4789, #4790 runs 32973825186 / 32973826495).

Reproduced locally on clean v4: `go test ./pkg/github -run StopsOnContextCancel -count=40 -race` fails at the fastTick restore in watcher_loops_test.go.

Fix (same joinable-goroutine pattern as #4789):
- each `Start*Watcher` returns a `<-chan struct{}` done channel closed when its goroutine exits, immediately-closed on every early-return path (nil client, dir-setup failure)
- `ctx.Err()` guard after each tick so a cancelled watcher cannot take one more lap (select picks randomly among ready cases)
- tests join on `done` (10s budget) instead of sleeping

Production callers in `cmd/hive` ignore the return value — behavior unchanged. Verified: `-count=30 -race` on the watcher tests, full `./pkg/github` and `./cmd/hive` suites green.