### PR TITLE
✨ feat: add opt-in telemetry and operations agents

### DIFF
--- a/src/docs/acmm-policy-matrix.md
+++ b/src/docs/acmm-policy-matrix.md
@@ -27,7 +27,7 @@ A single interactive advisor helps with repo setup and architecture decisions. G
 | guide | advisory | `guide-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L2 — Advisory (Instructed) (5 agents)
+### L2 — Advisory (Instructed) (7 agents)
 
 Agents observe and report findings as advisory beads on the dashboard and tracking issue. No GitHub issues or PRs created. Humans decide what to act on.
 
@@ -37,9 +37,11 @@ Agents observe and report findings as advisory beads on the dashboard and tracki
 | scanner | advisory | `scanner-advisory.md` |
 | quality | advisory | `quality-advisory.md` |
 | guide | advisory | `guide-advisory.md` |
+| telemetry (paused) | advisory | `telemetry-advisory.md` |
+| operations (paused) | advisory | `operations-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L3 — Quality-Gated (Measured) (6 agents)
+### L3 — Quality-Gated (Measured) (8 agents)
 
 Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI workflows. All other agents remain advisory. CI-maintainer joins to monitor build health. Key artifact: measurement infrastructure.
 
@@ -50,11 +52,13 @@ Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI w
 | ci-maintainer | advisory | `ci-maintainer-advisory.md` |
 | **quality** | **holdgated** | `quality-holdgated.md` |
 | guide | advisory | `guide-advisory.md` |
+| telemetry (paused) | advisory | `telemetry-advisory.md` |
+| operations (paused) | advisory | `operations-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L4 — Security-Aware (Adaptive) (7 agents)
+### L4 — Security-Aware (Adaptive) (9 agents)
 
-All agents open GitHub issues — bugs, docs gaps, CI problems, security vulnerabilities. Only Quality, sec-check, and ci-maintainer may open PRs. Security agent joins. Closed-loop feedback: agents act on their own findings.
+Delivery agents open GitHub issues — bugs, docs gaps, CI problems, security vulnerabilities. Telemetry and operations remain advisory and paused. Only Quality, sec-check, and ci-maintainer may open PRs. Security agent joins.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -64,9 +68,11 @@ All agents open GitHub issues — bugs, docs gaps, CI problems, security vulnera
 | **quality** | **holdgated** | `quality-holdgated.md` |
 | guide | measured | `guide-issues.md` |
 | **sec-check** | **holdgated** | `sec-check-holdgated.md` |
+| telemetry (paused) | advisory | `telemetry-advisory.md` |
+| operations (paused) | advisory | `operations-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L5 — Semi-Autonomous (Semi-Automated) (9 agents)
+### L5 — Semi-Autonomous (Semi-Automated) (11 agents)
 
 Agents open issues AND pull requests. All PRs get a hold label — humans batch-review and approve. Architect produces RFCs, strategist coordinates across agents. The system proposes; it does not merge autonomously.
 
@@ -80,11 +86,13 @@ Agents open issues AND pull requests. All PRs get a hold label — humans batch-
 | sec-check | holdgated | `sec-check-holdgated.md` |
 | architect | holdgated | `architect-holdgated.md` |
 | strategist | holdgated | `strategist-holdgated.md` |
+| telemetry (paused) | holdgated | `telemetry-holdgated.md` |
+| operations (paused) | holdgated | `operations-holdgated.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L6 — Fully Autonomous (10 agents)
+### L6 — Fully Autonomous (12 agents)
 
-Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outreach agent handles community engagement (highest trust — external-facing). Governor at fastest cadence.
+Existing autonomous lanes can open issues, create PRs, and auto-merge on green CI. No hold label. Outreach handles community engagement. Telemetry and operations remain paused and use `ISSUES_AND_PRS`, so they never merge their own PRs.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -97,6 +105,8 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 | architect | full | `architect-full.md` |
 | strategist | full | `strategist-full.md` |
 | outreach | full | `outreach-full.md` |
+| telemetry (paused) | full | `telemetry-full.md` |
+| operations (paused) | full | `operations-full.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
 ## Example config alignment
@@ -111,6 +121,7 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 4. **Mode escalation is per-agent.** At L4, some agents are measured (issues only) while others are holdgated (issues + PRs). The level defines the mix.
 5. **Knowledge priming works at all levels.** The `${KNOWLEDGE}` template variable injects relevant facts from git sources and wiki layers regardless of the agent's mode.
 6. **Brainstorm is always advisory.** It produces KB facts and beads, never GitHub issues or PRs. Its role evolves from inception (L1) to ongoing ideation (L2+), but its mode stays advisory at all levels.
+7. **Telemetry and operations are opt-in.** They are present from L2 onward but use a paused cadence in every governor mode. At L2–L4 they report findings only; at L5–L6 they may open issues and PRs but never merge.
 
 ## Changing a hive's ACMM level
 

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -22,7 +22,7 @@ That is a complete, valid agent. Defaults fill in the rest at load time:
 - `clear_on_kick: true` — the session context is cleared before each kick
 - `id` and `role` default to the agent's name (`scanner`)
 - `bead_role: worker`, `beads_dir: /data/beads/scanner`
-- Well-known names (`scanner`, `ci-maintainer`, `architect`, `supervisor`, `sec-check`, `quality`, `guide`, `strategist`, `outreach`) also get a default emoji, color, aliases, and lane keywords, so a bare `scanner:` entry already shows up in the dashboard as 🔍 with sensible triage keywords.
+- Well-known names (`scanner`, `ci-maintainer`, `architect`, `supervisor`, `sec-check`, `quality`, `guide`, `strategist`, `outreach`, `telemetry`, `operations`) also get a default emoji, color, aliases, and lane keywords, so a bare `scanner:` entry already shows up in the dashboard as 🔍 with sensible triage keywords.
 
 You almost never write a full roster by hand: applying an ACMM level (below) generates one for you, and the dashboard edits it live.
 
@@ -400,7 +400,7 @@ You don't have to design a roster. Hive ships six **ACMM packs** (`level-1.yaml`
 
 Applying a level **reconciles the whole roster**, not just the diff: missing agents are created (as overlay files in `/data/agent-configs/`), existing agents are merged — pack values fill blanks, but your explicit `backend:`, `model:`, and `enabled: false` always win — and the level's `kick_template` and `mode` are updated so the agent's *policy* matches the level. A failed agent doesn't abort the rest; the level is only recorded as cleanly applied when every agent reconciled.
 
-The L5 roster is the canonical worked example — nine agents, eight on the governor timer plus one on demand:
+The L5 roster is the canonical worked example — eleven agents, eight on the governor timer, two opt-in agents paused in every governor mode, plus one on demand:
 
 | Agent | | Mode | Cadence (all governor modes) |
 |---|---|---|---|
@@ -412,9 +412,13 @@ The L5 roster is the canonical worked example — nine agents, eight on the gove
 | sec-check 🛡 | CVEs, vulnerabilities | ISSUES_AND_PRS | 4h |
 | architect 🏗 | RFCs, refactors | ISSUES_AND_PRS | 4h |
 | strategist 🧠 | cross-agent coordination | ISSUES_AND_PRS | 4h |
+| telemetry 📡 | managed-project instrumentation | ISSUES_AND_PRS | paused |
+| operations 🚨 | managed-project operational practice | ISSUES_AND_PRS | paused |
 | brainstorm 💡 | ideation | ADVISORY | on demand |
 
 At L5, every agent PR gets a `hold` label automatically. The system proposes; it does not merge autonomously.
+
+Telemetry and operations stay paused until an operator deliberately opts in. Their lane keywords are disjoint: telemetry owns instrumentation and observability terms, while operations owns health, SLO, runbook, incident, rollback, and alerting terms.
 
 ## Kick templates: what an agent is told to do
 

--- a/src/pkg/classify/classifier.go
+++ b/src/pkg/classify/classifier.go
@@ -121,7 +121,7 @@ var defaultLanes = []LaneConfig{
 	{Name: "outreach", Keywords: []string{"adopters", "outreach", "community", "engagement"}},
 	{Name: "quality", Keywords: []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"}},
 	{Name: "telemetry", Keywords: []string{"observability", "opentelemetry", "prometheus", "grafana", "tracing", "metrics", "structured-logging", "servicemonitor", "podmonitor"}},
-	{Name: "operations", Keywords: []string{"healthz", "readyz", "readiness", "slo", "sli", "runbook", "incident-response", "rollback", "alerting"}},
+	{Name: "operations", Keywords: []string{"healthz", "readyz", "readiness", "slo-", "sli-", "service-level-objective", "service-level-indicator", "error-budget", "runbook", "incident-response", "rollback", "alerting"}},
 }
 
 var lanesMu sync.RWMutex

--- a/src/pkg/classify/classifier.go
+++ b/src/pkg/classify/classifier.go
@@ -120,6 +120,8 @@ var defaultLanes = []LaneConfig{
 	{Name: "ci-maintainer", Keywords: []string{"workflow-failure", "ci-failure", "nightly", "coverage", "regression", "ga4", "analytics"}},
 	{Name: "outreach", Keywords: []string{"adopters", "outreach", "community", "engagement"}},
 	{Name: "quality", Keywords: []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"}},
+	{Name: "telemetry", Keywords: []string{"observability", "opentelemetry", "prometheus", "grafana", "tracing", "metrics", "structured-logging", "servicemonitor", "podmonitor"}},
+	{Name: "operations", Keywords: []string{"healthz", "readyz", "readiness", "slo", "sli", "runbook", "incident-response", "rollback", "alerting"}},
 }
 
 var lanesMu sync.RWMutex

--- a/src/pkg/classify/classifier_test.go
+++ b/src/pkg/classify/classifier_test.go
@@ -209,6 +209,23 @@ func TestClassify_OutreachLane(t *testing.T) {
 	}
 }
 
+func TestClassify_OperabilityLanes(t *testing.T) {
+	tests := []struct {
+		title string
+		want  Lane
+	}{
+		{"Add an OpenTelemetry collector configuration", Lane("telemetry")},
+		{"Create a readiness runbook and rollback procedure", Lane("operations")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			if got := Classify(makeIssue(tt.title)).Lane; got != tt.want {
+				t.Errorf("lane = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClassify_TitlePrefixRoutesToLane(t *testing.T) {
 	cases := []struct {
 		title    string
@@ -286,8 +303,8 @@ func TestClassify_ArchitectBeatsReviewer(t *testing.T) {
 
 func TestClassify_ClusterKeyExtraction(t *testing.T) {
 	cases := []struct {
-		title      string
-		wantKey    string
+		title   string
+		wantKey string
 	}{
 		{"Dashboard loading spinner is broken", "dashboard"},
 		{"Card border radius too large", "card"},

--- a/src/pkg/classify/classifier_test.go
+++ b/src/pkg/classify/classifier_test.go
@@ -216,6 +216,11 @@ func TestClassify_OperabilityLanes(t *testing.T) {
 	}{
 		{"Add an OpenTelemetry collector configuration", Lane("telemetry")},
 		{"Create a readiness runbook and rollback procedure", Lane("operations")},
+		{"Define an SLO for API availability", Lane("scanner")},
+		{"Add a service-level-objective for API availability", Lane("operations")},
+		{"Fix the slow login redirect", Lane("scanner")},
+		{"Fix the sliding window rate limiter", Lane("scanner")},
+		{"Fix an array slice panic", Lane("scanner")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {

--- a/src/pkg/config/acmm_packs_test.go
+++ b/src/pkg/config/acmm_packs_test.go
@@ -25,7 +25,7 @@ func TestACMMPacksAgentCounts(t *testing.T) {
 	packs := ACMMPacks()
 
 	expected := map[int]int{
-		1: 2, 2: 5, 3: 6, 4: 7, 5: 9, 6: 10,
+		1: 2, 2: 7, 3: 8, 4: 9, 5: 11, 6: 12,
 	}
 	for _, p := range packs {
 		want, ok := expected[p.Level]
@@ -34,6 +34,36 @@ func TestACMMPacksAgentCounts(t *testing.T) {
 		}
 		if len(p.Agents) != want {
 			t.Errorf("L%d (%s): expected %d agents, got %d", p.Level, p.Name, want, len(p.Agents))
+		}
+	}
+}
+
+func TestOperabilityAgentsArePausedInEveryGovernorMode(t *testing.T) {
+	for level := 2; level <= 6; level++ {
+		pack, err := ACMMPackByLevel(level)
+		if err != nil {
+			t.Fatalf("load L%d pack: %v", level, err)
+		}
+		for _, mode := range []string{"surge", "busy", "quiet", "idle"} {
+			for _, agent := range []string{"telemetry", "operations"} {
+				cadence := NewIntervalCadence(pack.Governor.Cadences[mode][agent])
+				if !cadence.IsPaused() {
+					t.Errorf("L%d %s %s cadence = %q, want paused", level, mode, agent, cadence)
+				}
+			}
+		}
+	}
+}
+
+func TestOperabilityAgentDefaults(t *testing.T) {
+	for _, name := range []string{"telemetry", "operations"} {
+		agent := AgentConfig{}
+		applyKnownAgentDefaults(name, &agent)
+		if agent.Emoji == "" || agent.Color == "" || len(agent.Aliases) == 0 || len(agent.LaneKeywords) == 0 || len(agent.DetectKeywords) == 0 {
+			t.Errorf("%s defaults incomplete: %#v", name, agent)
+		}
+		if agent.BeadRole != "worker" || agent.IncludeRepos == nil || !*agent.IncludeRepos {
+			t.Errorf("%s defaults = bead_role %q, include_repos %v", name, agent.BeadRole, agent.IncludeRepos)
 		}
 	}
 }

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -4358,7 +4358,7 @@ func applyKnownAgentDefaults(name string, agent *AgentConfig) {
 		},
 		"operations": {
 			Emoji: "🚨", Color: "#d35400", Aliases: []string{"op"},
-			LaneKeywords:   []string{"healthz", "readyz", "readiness", "slo", "sli", "runbook", "incident-response", "rollback", "alerting"},
+			LaneKeywords:   []string{"healthz", "readyz", "readiness", "slo-", "sli-", "service-level-objective", "service-level-indicator", "error-budget", "runbook", "incident-response", "rollback", "alerting"},
 			DetectKeywords: []string{"operations", "operability", "healthz", "runbook"},
 			BeadRole:       "worker", SortOrder: 66, IncludeRepos: true,
 		},

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -4350,6 +4350,18 @@ func applyKnownAgentDefaults(name string, agent *AgentConfig) {
 			DetectKeywords: []string{"security", "sec-check", "vulnerability"},
 			BeadRole:       "worker", SortOrder: 60, IncludeRepos: true,
 		},
+		"telemetry": {
+			Emoji: "📡", Color: "#00a8cc", Aliases: []string{"tm"},
+			LaneKeywords:   []string{"observability", "opentelemetry", "prometheus", "grafana", "tracing", "metrics", "structured-logging", "servicemonitor", "podmonitor"},
+			DetectKeywords: []string{"telemetry", "observability", "opentelemetry", "prometheus"},
+			BeadRole:       "worker", SortOrder: 65, IncludeRepos: true,
+		},
+		"operations": {
+			Emoji: "🚨", Color: "#d35400", Aliases: []string{"op"},
+			LaneKeywords:   []string{"healthz", "readyz", "readiness", "slo", "sli", "runbook", "incident-response", "rollback", "alerting"},
+			DetectKeywords: []string{"operations", "operability", "healthz", "runbook"},
+			BeadRole:       "worker", SortOrder: 66, IncludeRepos: true,
+		},
 		"quality": {
 			Emoji: "🧪", Color: "#3498db", Aliases: []string{"te", "qa"},
 			LaneKeywords:   []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"},

--- a/src/pkg/config/packs/level-2.yaml
+++ b/src/pkg/config/packs/level-2.yaml
@@ -178,6 +178,6 @@ agents:
     kick_template: operations-advisory.md
     include_repos: true
     stale_timeout: 28800
-    lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+    lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
     interactions: Reports operational-practice gaps without changing repositories.
     knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-2.yaml
+++ b/src/pkg/config/packs/level-2.yaml
@@ -1,7 +1,7 @@
 level: 2
 name: Advisory
 description: >
-  One-way feedback (formerly "Instructed"). Five agents (supervisor, scanner, quality, guide, brainstorm)
+  One-way feedback (formerly "Instructed"). Seven agents, including opt-in telemetry and operations,
   produce advisory beads — findings visible on the dashboard and in a tracking
   issue. No GitHub issues or PRs created. Agents observe and report; humans
   decide what to act on.
@@ -15,21 +15,29 @@ governor:
       guide: 4h
       scanner: 4h
       quality: 6h
+      telemetry: paused
+      operations: paused
     busy:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
+      telemetry: paused
+      operations: paused
     quiet:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
+      telemetry: paused
+      operations: paused
     idle:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
+      telemetry: paused
+      operations: paused
 agents:
   - name: supervisor
     display_name: Supervisor
@@ -139,3 +147,37 @@ agents:
       Heavy consumer of community wiki patterns. Produces ideation facts
       (feature proposals, architecture decisions, strategic direction) into
       the project KB layer.
+  - name: telemetry
+    display_name: telemetry
+    role: telemetry
+    description: Audits managed-project instrumentation and observability backends; reports findings only.
+    emoji: "📡"
+    color: "#00a8cc"
+    sort_order: 65
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    mode: ADVISORY
+    kick_template: telemetry-advisory.md
+    include_repos: true
+    stale_timeout: 28800
+    lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
+    interactions: Reports instrumentation and telemetry gaps without changing repositories.
+    knowledge_use: Reads project stack and observability conventions from the knowledge base.
+  - name: operations
+    display_name: operations
+    role: operations
+    description: Audits managed-project health checks, SLOs, runbooks, alerts, and rollback practice; reports findings only.
+    emoji: "🚨"
+    color: "#d35400"
+    sort_order: 66
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    mode: ADVISORY
+    kick_template: operations-advisory.md
+    include_repos: true
+    stale_timeout: 28800
+    lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+    interactions: Reports operational-practice gaps without changing repositories.
+    knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-3.yaml
+++ b/src/pkg/config/packs/level-3.yaml
@@ -237,6 +237,6 @@ agents:
   kick_template: operations-advisory.md
   include_repos: true
   stale_timeout: 28800
-  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
   interactions: Reports operational-practice gaps without changing repositories.
   knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-3.yaml
+++ b/src/pkg/config/packs/level-3.yaml
@@ -23,24 +23,32 @@ governor:
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
+      telemetry: paused
+      operations: paused
       guide: 4h
     busy:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
+      telemetry: paused
+      operations: paused
       guide: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
+      telemetry: paused
+      operations: paused
       guide: 4h
     idle:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
+      telemetry: paused
+      operations: paused
       guide: 4h
 agents:
 - name: supervisor
@@ -198,3 +206,37 @@ agents:
 
     '
   clear_on_kick: true
+- name: telemetry
+  display_name: telemetry
+  role: telemetry
+  description: Audits managed-project instrumentation and observability backends; reports findings only.
+  emoji: 📡
+  color: '#00a8cc'
+  sort_order: 65
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: telemetry-advisory.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
+  interactions: Reports instrumentation and telemetry gaps without changing repositories.
+  knowledge_use: Reads project stack and observability conventions from the knowledge base.
+- name: operations
+  display_name: operations
+  role: operations
+  description: Audits managed-project health checks, SLOs, runbooks, alerts, and rollback practice; reports findings only.
+  emoji: 🚨
+  color: '#d35400'
+  sort_order: 66
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: operations-advisory.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  interactions: Reports operational-practice gaps without changing repositories.
+  knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-4.yaml
+++ b/src/pkg/config/packs/level-4.yaml
@@ -1,9 +1,9 @@
 level: 4
 name: Security-Aware
-description: 'Closed-loop feedback (formerly ''Adaptive''). All agents open GitHub issues — not just quality.
+description: 'Closed-loop feedback (formerly ''Adaptive''). Existing delivery agents open GitHub issues — not just quality.
   Scanner files bug reports, guide files documentation gaps, ci-maintainer files workflow
   issues, sec-check files vulnerabilities. No PRs yet — issues only. Adds security
-  agent (+sec-check). Six agents total.
+  agent (+sec-check). Nine agents total, including opt-in telemetry and operations.
 
   '
 governor:
@@ -29,6 +29,8 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
+      telemetry: paused
+      operations: paused
     busy:
       supervisor: 5m
       scanner: 4h
@@ -36,6 +38,8 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
+      telemetry: paused
+      operations: paused
     quiet:
       supervisor: 5m
       scanner: 4h
@@ -43,6 +47,8 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
+      telemetry: paused
+      operations: paused
     idle:
       supervisor: 5m
       scanner: 4h
@@ -50,6 +56,8 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
+      telemetry: paused
+      operations: paused
 agents:
 - name: supervisor
   display_name: Supervisor
@@ -240,3 +248,37 @@ agents:
 
     '
   clear_on_kick: true
+- name: telemetry
+  display_name: telemetry
+  role: telemetry
+  description: Audits managed-project instrumentation and observability backends; reports findings only.
+  emoji: 📡
+  color: '#00a8cc'
+  sort_order: 65
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: telemetry-advisory.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
+  interactions: Reports instrumentation and telemetry gaps without changing repositories.
+  knowledge_use: Reads project stack and observability conventions from the knowledge base.
+- name: operations
+  display_name: operations
+  role: operations
+  description: Audits managed-project health checks, SLOs, runbooks, alerts, and rollback practice; reports findings only.
+  emoji: 🚨
+  color: '#d35400'
+  sort_order: 66
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: operations-advisory.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  interactions: Reports operational-practice gaps without changing repositories.
+  knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-4.yaml
+++ b/src/pkg/config/packs/level-4.yaml
@@ -279,6 +279,6 @@ agents:
   kick_template: operations-advisory.md
   include_repos: true
   stale_timeout: 28800
-  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
   interactions: Reports operational-practice gaps without changing repositories.
   knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-5.yaml
+++ b/src/pkg/config/packs/level-5.yaml
@@ -335,6 +335,6 @@ agents:
   kick_template: operations-holdgated.md
   include_repos: true
   stale_timeout: 28800
-  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
   interactions: Opens issues and hold-gated PRs for operational-practice improvements.
   knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-5.yaml
+++ b/src/pkg/config/packs/level-5.yaml
@@ -3,7 +3,7 @@ name: Semi-Autonomous
 description: 'Multi-loop feedback (formerly ''Semi-Automated''). Agents open issues AND pull requests. All agent
   PRs get a ''hold'' label automatically — humans batch-review and approve. Adds architect
   (+architect) for RFCs and strategist (+strategist) for cross-agent coordination.
-  Eight agents total. The system proposes; it does not merge autonomously.
+  Eleven agents total, including opt-in telemetry and operations. The system proposes; it does not merge autonomously.
 
   '
 governor:
@@ -30,6 +30,8 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      telemetry: paused
+      operations: paused
     busy:
       supervisor: 5m
       scanner: 4h
@@ -39,6 +41,8 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      telemetry: paused
+      operations: paused
     quiet:
       supervisor: 5m
       scanner: 4h
@@ -48,6 +52,8 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      telemetry: paused
+      operations: paused
     idle:
       supervisor: 5m
       scanner: 4h
@@ -57,6 +63,8 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      telemetry: paused
+      operations: paused
 agents:
 - name: supervisor
   display_name: Supervisor
@@ -296,3 +304,37 @@ agents:
 
     '
   clear_on_kick: true
+- name: telemetry
+  display_name: telemetry
+  role: telemetry
+  description: Adds vendor-neutral instrumentation and configured observability backend artifacts to managed projects.
+  emoji: 📡
+  color: '#00a8cc'
+  sort_order: 65
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: telemetry-holdgated.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
+  interactions: Opens issues and hold-gated PRs for bounded, explicitly configured telemetry improvements.
+  knowledge_use: Reads project stack and selected observability backends from the knowledge base.
+- name: operations
+  display_name: operations
+  role: operations
+  description: Adds health checks, SLOs, runbooks, alerts, and release or rollback safeguards to managed projects.
+  emoji: 🚨
+  color: '#d35400'
+  sort_order: 66
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: operations-holdgated.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  interactions: Opens issues and hold-gated PRs for operational-practice improvements.
+  knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-6.yaml
+++ b/src/pkg/config/packs/level-6.yaml
@@ -361,6 +361,6 @@ agents:
   kick_template: operations-full.md
   include_repos: true
   stale_timeout: 28800
-  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
   interactions: Opens issues and PRs for operational-practice improvements; never merges its own PRs.
   knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-6.yaml
+++ b/src/pkg/config/packs/level-6.yaml
@@ -2,7 +2,7 @@ level: 6
 name: Fully Autonomous
 description: 'Multi-loop with external orchestration. Agents open issues, create PRs,
   and auto-merge on green CI. No hold label. Adds outreach agent (+outreach) for community
-  engagement and external-facing actions. Nine agents total. Highest trust — governor
+  engagement and external-facing actions. Twelve agents total, including opt-in telemetry and operations. Highest trust — governor
   at fastest cadence.
 
   '
@@ -30,6 +30,8 @@ governor:
       outreach: 30m
       sec-check: 15m
       strategist: 30m
+      telemetry: paused
+      operations: paused
     busy:
       supervisor: 2m
       scanner: 10m
@@ -39,6 +41,8 @@ governor:
       outreach: 1h
       sec-check: 30m
       strategist: 1h
+      telemetry: paused
+      operations: paused
     quiet:
       supervisor: 3m
       scanner: 20m
@@ -48,6 +52,8 @@ governor:
       outreach: 2h
       sec-check: 1h
       strategist: 2h
+      telemetry: paused
+      operations: paused
     idle:
       supervisor: 5m
       scanner: 30m
@@ -57,6 +63,8 @@ governor:
       outreach: 4h
       sec-check: 2h
       strategist: 4h
+      telemetry: paused
+      operations: paused
 agents:
 - name: supervisor
   display_name: Supervisor
@@ -322,3 +330,37 @@ agents:
 
     '
   clear_on_kick: true
+- name: telemetry
+  display_name: telemetry
+  role: telemetry
+  description: Adds vendor-neutral instrumentation and configured observability backend artifacts to managed projects.
+  emoji: 📡
+  color: '#00a8cc'
+  sort_order: 65
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: telemetry-full.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
+  interactions: Opens issues and PRs for bounded, explicitly configured telemetry improvements; never merges its own PRs.
+  knowledge_use: Reads project stack and selected observability backends from the knowledge base.
+- name: operations
+  display_name: operations
+  role: operations
+  description: Adds health checks, SLOs, runbooks, alerts, and release or rollback safeguards to managed projects.
+  emoji: 🚨
+  color: '#d35400'
+  sort_order: 66
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: operations-full.md
+  include_repos: true
+  stale_timeout: 28800
+  lane_keywords: [healthz, readyz, readiness, slo, sli, runbook, incident-response, rollback, alerting]
+  interactions: Opens issues and PRs for operational-practice improvements; never merges its own PRs.
+  knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/dashboard/validation.go
+++ b/src/pkg/dashboard/validation.go
@@ -77,6 +77,8 @@ var knownRoles = map[string]bool{
 	"quality":       true,
 	"ci-maintainer": true,
 	"sec-check":     true,
+	"telemetry":     true,
+	"operations":    true,
 	"architect":     true,
 	"strategist":    true,
 	"outreach":      true,

--- a/src/pkg/dashboard/validation_test.go
+++ b/src/pkg/dashboard/validation_test.go
@@ -135,6 +135,16 @@ func TestValidateAgentGeneralInput(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid telemetry role",
+			body:    map[string]interface{}{"role": "telemetry"},
+			wantErr: false,
+		},
+		{
+			name:    "valid operations role",
+			body:    map[string]interface{}{"role": "operations"},
+			wantErr: false,
+		},
+		{
 			name:    "negative sortOrder",
 			body:    map[string]interface{}{"sortOrder": float64(-1)},
 			wantErr: true,
@@ -306,10 +316,10 @@ func TestValidateGovernorThresholds(t *testing.T) {
 
 func TestValidateGovernorHealth(t *testing.T) {
 	tests := []struct {
-		name               string
+		name                string
 		healthcheckInterval int
-		restartCooldown    int
-		wantErr            bool
+		restartCooldown     int
+		wantErr             bool
 	}{
 		{"valid", 120, 30, false},
 		{"zero values", 0, 0, false},

--- a/src/pkg/discord/bot.go
+++ b/src/pkg/discord/bot.go
@@ -48,6 +48,7 @@ var aliases = map[string]string{
 	"sc": "scanner", "ar": "architect", "ou": "outreach",
 	"su": "supervisor", "ci": "ci-maintainer", "se": "sec-check",
 	"sg": "strategist", "te": "quality", "qa": "quality",
+	"tm": "telemetry", "op": "operations",
 }
 
 func SetAgentIdentities(identities map[string]AgentIdentity) {

--- a/src/pkg/discord/bot_coverage_test.go
+++ b/src/pkg/discord/bot_coverage_test.go
@@ -61,6 +61,8 @@ func TestResolveAlias_KnownAliases(t *testing.T) {
 		{"se", "sec-check"},
 		{"sg", "strategist"},
 		{"te", "quality"},
+		{"tm", "telemetry"},
+		{"op", "operations"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -84,7 +86,7 @@ func TestResolveAlias_NotAnAlias(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGetIdentity_KnownAgents(t *testing.T) {
-	known := []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "strategist", "quality", "governor", "pipeline"}
+	known := []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "strategist", "quality", "telemetry", "operations", "governor", "pipeline"}
 	for _, name := range known {
 		id := getIdentity(name)
 		if id.Emoji == "" {

--- a/src/pkg/governor/governor.go
+++ b/src/pkg/governor/governor.go
@@ -809,6 +809,7 @@ func (g *Governor) validateAgentReportIfPresent(agentName string) (AgentReportRe
 			"findings", len(report.Findings),
 			"prs_opened", len(report.PRsOpened),
 			"beads_filed", len(report.BeadsFiled),
+			"artifacts", len(report.Artifacts),
 		)
 	}
 	return record, true

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -406,6 +406,8 @@ func TestComputeAgentRosterMismatch_WarningReason(t *testing.T) {
 		{Name: "quality"},
 		{Name: "guide"},
 		{Name: "supervisor"},
+		{Name: "telemetry"},
+		{Name: "operations"},
 		{Name: "outreach"},
 	}
 	got := computeAgentRosterMismatch(2, agents)
@@ -427,9 +429,11 @@ func TestComputeAgentRosterMismatch_NoWarningForMatchingOrUnknown(t *testing.T) 
 	matching := []AgentSummary{
 		{Name: "brainstorm"},
 		{Name: "guide"},
+		{Name: "operations"},
 		{Name: "quality"},
 		{Name: "scanner"},
 		{Name: "supervisor"},
+		{Name: "telemetry"},
 	}
 	if got := computeAgentRosterMismatch(2, matching); got != nil {
 		t.Fatalf("matching roster got warning %+v", got)

--- a/src/pkg/hub/journey.go
+++ b/src/pkg/hub/journey.go
@@ -225,11 +225,11 @@ type acmmLevelInfo struct {
 // moving there entails. Kept in sync with src/pkg/config/packs/level-*.yaml.
 var acmmLevels = map[int]acmmLevelInfo{
 	1: {"Inception", "an interactive brainstorm agent turns ideas into structured facts and scaffolding, with every action human-approved"},
-	2: {"Advisory", "five agents (supervisor, scanner, quality, guide, brainstorm) publish advisory findings to your dashboard and a tracking issue — still no GitHub writes"},
+	2: {"Advisory", "seven agents publish advisory findings, including opt-in telemetry and operations agents that start paused — still no GitHub writes"},
 	3: {"Quality-Gated", "the quality agent starts opening issues and hold-gated PRs about testing gaps, and ci-maintainer joins to watch build health — nothing merges without you"},
-	4: {"Security-Aware", "every agent files GitHub issues in its lane (bugs, docs gaps, workflow breakage) and a sec-check agent joins for vulnerabilities — issues only, still no PRs"},
-	5: {"Semi-Autonomous", "agents open pull requests as well as issues, all carrying a 'hold' label for you to batch-review, and architect plus strategist join — the system proposes, you dispose"},
-	6: {"Fully Autonomous", "agents open issues, raise PRs, and auto-merge them on green CI with no hold label, plus an outreach agent for community work — the highest trust setting"},
+	4: {"Security-Aware", "delivery agents file GitHub issues in their lanes and sec-check joins for vulnerabilities, while telemetry and operations remain advisory and paused"},
+	5: {"Semi-Autonomous", "agents open hold-gated pull requests as well as issues; architect and strategist join, while telemetry and operations are available paused for deliberate opt-in"},
+	6: {"Fully Autonomous", "agents can auto-merge on green CI at the highest trust setting; outreach joins, while telemetry and operations remain paused until deliberately enabled"},
 }
 
 // maxACMMLevel is the top of the 6-level model. A hive here has nowhere to

--- a/src/pkg/outputschema/outputschema.go
+++ b/src/pkg/outputschema/outputschema.go
@@ -150,7 +150,7 @@ func validateReport(report AgentReport) []Violation {
 	violations = append(violations, requireBounded("lane", report.Lane, MaxLaneLength)...)
 	violations = append(violations, requireBounded("kind", string(report.Kind), MaxKindLength)...)
 	if report.Kind != "" && !validKind(report.Kind) {
-		violations = append(violations, Violation{Field: "kind", Message: "must be one of findings, fix, review, advisory, summary"})
+		violations = append(violations, Violation{Field: "kind", Message: "must be one of findings, fix, review, advisory, summary, instrument"})
 	}
 	if report.Findings == nil {
 		violations = append(violations, Violation{Field: "findings", Message: "is required; use [] when there are no findings"})

--- a/src/pkg/outputschema/outputschema.go
+++ b/src/pkg/outputschema/outputschema.go
@@ -18,27 +18,30 @@ const (
 	AgentReportFilePrefix = "agent-report-"
 	AgentReportFileSuffix = ".json"
 
-	MaxLaneLength        = 64
-	MaxKindLength        = 64
-	MaxSummaryLength     = 2000
-	MaxFindings          = 100
-	MaxPRsOpened         = 50
-	MaxBeadsFiled        = 50
-	MaxTitleLength       = 200
-	MaxFindingBodyLength = 2000
-	MaxRepoLength        = 200
-	MaxURLLength         = 500
-	MaxBeadIDLength      = 120
+	MaxLaneLength         = 64
+	MaxKindLength         = 64
+	MaxSummaryLength      = 2000
+	MaxFindings           = 100
+	MaxPRsOpened          = 50
+	MaxBeadsFiled         = 50
+	MaxArtifacts          = 100
+	MaxTitleLength        = 200
+	MaxFindingBodyLength  = 2000
+	MaxRepoLength         = 200
+	MaxURLLength          = 500
+	MaxBeadIDLength       = 120
+	MaxArtifactPathLength = 500
 )
 
 type ReportKind string
 
 const (
-	KindFindings ReportKind = "findings"
-	KindFix      ReportKind = "fix"
-	KindReview   ReportKind = "review"
-	KindAdvisory ReportKind = "advisory"
-	KindSummary  ReportKind = "summary"
+	KindFindings   ReportKind = "findings"
+	KindFix        ReportKind = "fix"
+	KindReview     ReportKind = "review"
+	KindAdvisory   ReportKind = "advisory"
+	KindSummary    ReportKind = "summary"
+	KindInstrument ReportKind = "instrument"
 )
 
 type Severity string
@@ -66,7 +69,17 @@ type AgentReport struct {
 	Findings   []Finding   `json:"findings"`
 	PRsOpened  []PROpened  `json:"prs_opened"`
 	BeadsFiled []BeadFiled `json:"beads_filed"`
+	Artifacts  []Artifact  `json:"artifacts,omitempty"`
 	Summary    string      `json:"summary"`
+}
+
+// Artifact records a repository file produced or materially updated by an agent.
+// It lets artifact-producing lanes report their primary output independently of
+// the pull request that happens to carry it.
+type Artifact struct {
+	Repo        string `json:"repo"`
+	Path        string `json:"path"`
+	Description string `json:"description"`
 }
 
 type Finding struct {
@@ -154,6 +167,9 @@ func validateReport(report AgentReport) []Violation {
 	} else if len(report.BeadsFiled) > MaxBeadsFiled {
 		violations = append(violations, Violation{Field: "beads_filed", Message: fmt.Sprintf("must contain at most %d items", MaxBeadsFiled)})
 	}
+	if len(report.Artifacts) > MaxArtifacts {
+		violations = append(violations, Violation{Field: "artifacts", Message: fmt.Sprintf("must contain at most %d items", MaxArtifacts)})
+	}
 	violations = append(violations, requireBounded("summary", report.Summary, MaxSummaryLength)...)
 
 	for i, finding := range report.Findings {
@@ -187,6 +203,12 @@ func validateReport(report AgentReport) []Violation {
 		violations = append(violations, requireBounded(prefix+".title", bead.Title, MaxTitleLength)...)
 		violations = append(violations, optionalBounded(prefix+".url", bead.URL, MaxURLLength)...)
 	}
+	for i, artifact := range report.Artifacts {
+		prefix := fmt.Sprintf("artifacts[%d]", i)
+		violations = append(violations, requireBounded(prefix+".repo", artifact.Repo, MaxRepoLength)...)
+		violations = append(violations, requireBounded(prefix+".path", artifact.Path, MaxArtifactPathLength)...)
+		violations = append(violations, requireBounded(prefix+".description", artifact.Description, MaxFindingBodyLength)...)
+	}
 	return violations
 }
 
@@ -194,7 +216,7 @@ func CorrectivePrompt(err error) string {
 	if err == nil {
 		return ""
 	}
-	return fmt.Sprintf("Your previous structured agent report was invalid and could not be consumed by Hive. Return exactly one JSON object matching the AgentReport contract: required fields lane, kind, findings, prs_opened, beads_filed, summary. Use [] for empty arrays. Allowed kind values: findings, fix, review, advisory, summary. Fix these validation errors: %s. Hive will retry validation at most %d times.", err.Error(), MaxValidationRetries)
+	return fmt.Sprintf("Your previous structured agent report was invalid and could not be consumed by Hive. Return exactly one JSON object matching the AgentReport contract: required fields lane, kind, findings, prs_opened, beads_filed, summary; artifacts is optional. Use [] for empty arrays. Allowed kind values: findings, fix, review, advisory, summary, instrument. Fix these validation errors: %s. Hive will retry validation at most %d times.", err.Error(), MaxValidationRetries)
 }
 
 func AgentReportPath(agentName string) string {
@@ -237,7 +259,7 @@ func optionalBounded(field, value string, max int) []Violation {
 
 func validKind(kind ReportKind) bool {
 	switch kind {
-	case KindFindings, KindFix, KindReview, KindAdvisory, KindSummary:
+	case KindFindings, KindFix, KindReview, KindAdvisory, KindSummary, KindInstrument:
 		return true
 	default:
 		return false

--- a/src/pkg/outputschema/outputschema_test.go
+++ b/src/pkg/outputschema/outputschema_test.go
@@ -13,6 +13,7 @@ func TestValidate(t *testing.T) {
 		"findings":[{"title":"racy write","severity":"high","summary":"shared map is written without a lock","file":"pkg/x.go","line":42}],
 		"prs_opened":[{"repo":"kubestellar/hive","number":2806,"title":"structured reports","url":"https://github.com/kubestellar/hive/pull/1"}],
 		"beads_filed":[{"id":"bead-1","type":"task","title":"follow-up"}],
+		"artifacts":[{"repo":"kubestellar/hive","path":"grafana/dashboards/api.json","description":"API service dashboard"}],
 		"summary":"one finding, one PR, one bead"
 	}`
 
@@ -29,6 +30,15 @@ func TestValidate(t *testing.T) {
 		{
 			name: "valid empty arrays",
 			raw:  `{"lane":"fixer","kind":"fix","findings":[],"prs_opened":[],"beads_filed":[],"summary":"nothing to report"}`,
+		},
+		{
+			name: "valid instrument report",
+			raw:  `{"lane":"telemetry","kind":"instrument","findings":[],"prs_opened":[],"beads_filed":[],"artifacts":[{"repo":"kubestellar/hive","path":"deploy/servicemonitor.yaml","description":"Prometheus scrape target"}],"summary":"added monitoring"}`,
+		},
+		{
+			name:    "invalid artifact",
+			raw:     `{"lane":"telemetry","kind":"instrument","findings":[],"prs_opened":[],"beads_filed":[],"artifacts":[{"repo":"","path":"","description":""}],"summary":"bad artifact"}`,
+			wantErr: []string{"artifacts[0].repo", "artifacts[0].path", "artifacts[0].description"},
 		},
 		{
 			name:    "missing required arrays",
@@ -92,6 +102,7 @@ func TestCorrectivePrompt(t *testing.T) {
 	for _, want := range []string{
 		"structured agent report was invalid",
 		"lane, kind, findings, prs_opened, beads_filed, summary",
+		"instrument",
 		"kind: must be one of findings, fix",
 		"3 times",
 	} {

--- a/src/pkg/outputschema/outputschema_test.go
+++ b/src/pkg/outputschema/outputschema_test.go
@@ -48,7 +48,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "bad enum values",
 			raw:     `{"lane":"scanner","kind":"other","findings":[{"title":"x","severity":"severe","summary":"y"}],"prs_opened":[],"beads_filed":[{"id":"b","type":"unknown","title":"t"}],"summary":"bad enums"}`,
-			wantErr: []string{"kind", "findings[0].severity", "beads_filed[0].type"},
+			wantErr: []string{"kind: must be one of findings, fix, review, advisory, summary, instrument", "findings[0].severity", "beads_filed[0].type"},
 		},
 		{
 			name:    "bounded lengths",

--- a/src/pkg/policies/defaults/operations-advisory.md
+++ b/src/pkg/policies/defaults/operations-advisory.md
@@ -1,0 +1,16 @@
+# Operations Agent Policy — Advisory Mode (ACMM L2–L4)
+
+You are the **operations** agent. Audit the operational readiness of managed projects and report findings; do not create GitHub issues, branches, commits, or pull requests.
+
+## Scope
+
+- Inspect health and readiness endpoints, SLO/SLI definitions, user-impact alert rules, runbooks, incident/postmortem templates, release procedures, and rollback paths.
+- Verify probes check every dependency required to serve their claimed readiness state.
+- Flag alerts without runbook links, machine-state alerts without user impact, undocumented rollback, and SLOs without measurable indicators.
+- Never weaken an alert or SLO to make reported health look better.
+
+## Repository coverage
+
+`$HIVE_REPOS` is the authorized comma-separated repository list. Your workdir is at most a checkout of the primary repository; no additional worktree is provisioned. Rotate to the least recently audited repository, clone it yourself when needed, and pass `--repo "<org>/<repo>"` to every read-only `gh` command.
+
+Write each confirmed finding as an advisory bead owned by `operations`. Return an AgentReport with `kind: "findings"`.

--- a/src/pkg/policies/defaults/operations-full.md
+++ b/src/pkg/policies/defaults/operations-full.md
@@ -1,0 +1,15 @@
+# Operations Agent Policy — Full Mode (ACMM L6)
+
+You are the **operations** agent in **ISSUES_AND_PRS** mode. Audit operational readiness, file confirmed findings, and implement bounded improvements in pull requests. Never merge your own PRs.
+
+## Allowed work
+
+Operations can PR: health and readiness handlers, SLO/SLI definitions, user-impact alert rules with runbook links, `runbooks/*.md`, incident and postmortem templates, and release/rollback documentation or safeguards.
+
+Operations must never: merge a PR; modify work labeled `hold`, `on-hold`, or `do-not-merge`; weaken an existing alert or SLO to improve reported health; or add a probe that reports healthy without checking a dependency required to serve traffic.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. Sign every commit with `git commit -s` and open, but never merge, PRs. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.

--- a/src/pkg/policies/defaults/operations-holdgated.md
+++ b/src/pkg/policies/defaults/operations-holdgated.md
@@ -1,0 +1,15 @@
+# Operations Agent Policy — Hold-Gated Mode (ACMM L5)
+
+You are the **operations** agent in **ISSUES_AND_PRS** mode. Audit operational readiness, file confirmed findings, and implement bounded improvements in hold-gated pull requests. Never merge or remove a hold label.
+
+## Allowed work
+
+Operations can PR: health and readiness handlers, SLO/SLI definitions, user-impact alert rules with runbook links, `runbooks/*.md`, incident and postmortem templates, and release/rollback documentation or safeguards.
+
+Operations must never: merge a PR; remove `hold`, `on-hold`, or `do-not-merge` labels; weaken an existing alert or SLO to improve reported health; or add a probe that reports healthy without checking a dependency required to serve traffic.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. For a safe improvement, create a branch, sign commits with `git commit -s`, and open a PR labeled `hold`; never merge it. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.

--- a/src/pkg/policies/defaults/telemetry-advisory.md
+++ b/src/pkg/policies/defaults/telemetry-advisory.md
@@ -1,0 +1,16 @@
+# Telemetry Agent Policy — Advisory Mode (ACMM L2–L4)
+
+You are the **telemetry** agent. Audit the observability of managed projects and report findings; do not create GitHub issues, branches, commits, or pull requests.
+
+## Scope
+
+- Inspect tracing, metrics, structured logging, scrape targets, dashboards, monitoring CRs, collector/exporter configuration, and web analytics.
+- Detect the existing stack before recommending changes. Prefer OpenTelemetry as a vendor-neutral spine and honor only an explicitly configured backend.
+- Flag unbounded metric labels, high-cardinality span attributes, missing scrape targets, inconsistent span names, and dashboards without source-controlled definitions.
+- Never reveal credentials, endpoints, API keys, or secret values. Refer only to environment-variable or secret names.
+
+## Repository coverage
+
+`$HIVE_REPOS` is the authorized comma-separated repository list. Your workdir is at most a checkout of the primary repository; no additional worktree is provisioned. Rotate to the least recently audited repository, clone it yourself when needed, and pass `--repo "<org>/<repo>"` to every read-only `gh` command.
+
+Write each confirmed finding as an advisory bead owned by `telemetry`. Return an AgentReport with `kind: "findings"`; if you identify proposed repository artifacts, describe them as findings rather than claiming they were created.

--- a/src/pkg/policies/defaults/telemetry-full.md
+++ b/src/pkg/policies/defaults/telemetry-full.md
@@ -1,0 +1,15 @@
+# Telemetry Agent Policy — Full Mode (ACMM L6)
+
+You are the **telemetry** agent in **ISSUES_AND_PRS** mode. Audit observability, file confirmed findings, and implement bounded improvements in pull requests. Never merge your own PRs.
+
+## Allowed work
+
+Telemetry can PR: OpenTelemetry SDK wiring and request-path spans, bounded metrics and `/metrics` endpoints, structured logging, dashboard JSON, alert-rule YAML, ServiceMonitor/PodMonitor resources, collector/exporter configuration, dashboard-lint CI, and GA4 wiring for an identified web property.
+
+Telemetry must never: commit credentials, literal collector endpoints, API keys, or secret values; add an exporter that sends data off-box without an explicitly configured backend; introduce unbounded labels or span attributes; merge a PR; or modify work labeled `hold`, `on-hold`, or `do-not-merge`.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+Detect the existing stack first; without an explicitly configured backend, audit and file recommendations only. Close only stale `telemetry` beads. Sign every commit with `git commit -s`. Return `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.

--- a/src/pkg/policies/defaults/telemetry-holdgated.md
+++ b/src/pkg/policies/defaults/telemetry-holdgated.md
@@ -1,0 +1,19 @@
+# Telemetry Agent Policy — Hold-Gated Mode (ACMM L5)
+
+You are the **telemetry** agent in **ISSUES_AND_PRS** mode. Audit observability, file confirmed findings, and implement bounded improvements in hold-gated pull requests. Never merge or remove a hold label.
+
+## Allowed work
+
+Telemetry can PR: OpenTelemetry SDK wiring and request-path spans, bounded metrics and `/metrics` endpoints, structured logging, dashboard JSON, alert-rule YAML, ServiceMonitor/PodMonitor resources, collector/exporter configuration, dashboard-lint CI, and GA4 wiring for an identified web property.
+
+Telemetry must never: commit credentials, literal collector endpoints, API keys, or secret values; add an exporter that sends data off-box without an explicitly configured backend; introduce unbounded labels or span attributes; merge a PR; or remove `hold`, `on-hold`, or `do-not-merge` labels.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+1. Detect the project's existing telemetry stack. If no backend has been explicitly configured, audit and file recommendations only.
+2. Re-verify and close only stale beads whose actor is `telemetry`.
+3. File confirmed findings with a `[telemetry]` title and create a telemetry-owned bead.
+4. For a safe, bounded improvement, create a branch, commit with `git commit -s`, push, and open a PR labeled `hold`. Never merge it.
+5. Return an AgentReport. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.

--- a/src/policies/operations-advisory.md
+++ b/src/policies/operations-advisory.md
@@ -1,0 +1,16 @@
+# Operations Agent Policy — Advisory Mode (ACMM L2–L4)
+
+You are the **operations** agent. Audit the operational readiness of managed projects and report findings; do not create GitHub issues, branches, commits, or pull requests.
+
+## Scope
+
+- Inspect health and readiness endpoints, SLO/SLI definitions, user-impact alert rules, runbooks, incident/postmortem templates, release procedures, and rollback paths.
+- Verify probes check every dependency required to serve their claimed readiness state.
+- Flag alerts without runbook links, machine-state alerts without user impact, undocumented rollback, and SLOs without measurable indicators.
+- Never weaken an alert or SLO to make reported health look better.
+
+## Repository coverage
+
+`$HIVE_REPOS` is the authorized comma-separated repository list. Your workdir is at most a checkout of the primary repository; no additional worktree is provisioned. Rotate to the least recently audited repository, clone it yourself when needed, and pass `--repo "<org>/<repo>"` to every read-only `gh` command.
+
+Write each confirmed finding as an advisory bead owned by `operations`. Return an AgentReport with `kind: "findings"`.

--- a/src/policies/operations-full.md
+++ b/src/policies/operations-full.md
@@ -1,0 +1,15 @@
+# Operations Agent Policy — Full Mode (ACMM L6)
+
+You are the **operations** agent in **ISSUES_AND_PRS** mode. Audit operational readiness, file confirmed findings, and implement bounded improvements in pull requests. Never merge your own PRs.
+
+## Allowed work
+
+Operations can PR: health and readiness handlers, SLO/SLI definitions, user-impact alert rules with runbook links, `runbooks/*.md`, incident and postmortem templates, and release/rollback documentation or safeguards.
+
+Operations must never: merge a PR; modify work labeled `hold`, `on-hold`, or `do-not-merge`; weaken an existing alert or SLO to improve reported health; or add a probe that reports healthy without checking a dependency required to serve traffic.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. Sign every commit with `git commit -s` and open, but never merge, PRs. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.

--- a/src/policies/operations-holdgated.md
+++ b/src/policies/operations-holdgated.md
@@ -1,0 +1,15 @@
+# Operations Agent Policy — Hold-Gated Mode (ACMM L5)
+
+You are the **operations** agent in **ISSUES_AND_PRS** mode. Audit operational readiness, file confirmed findings, and implement bounded improvements in hold-gated pull requests. Never merge or remove a hold label.
+
+## Allowed work
+
+Operations can PR: health and readiness handlers, SLO/SLI definitions, user-impact alert rules with runbook links, `runbooks/*.md`, incident and postmortem templates, and release/rollback documentation or safeguards.
+
+Operations must never: merge a PR; remove `hold`, `on-hold`, or `do-not-merge` labels; weaken an existing alert or SLO to improve reported health; or add a probe that reports healthy without checking a dependency required to serve traffic.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. For a safe improvement, create a branch, sign commits with `git commit -s`, and open a PR labeled `hold`; never merge it. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.

--- a/src/policies/telemetry-advisory.md
+++ b/src/policies/telemetry-advisory.md
@@ -1,0 +1,16 @@
+# Telemetry Agent Policy — Advisory Mode (ACMM L2–L4)
+
+You are the **telemetry** agent. Audit the observability of managed projects and report findings; do not create GitHub issues, branches, commits, or pull requests.
+
+## Scope
+
+- Inspect tracing, metrics, structured logging, scrape targets, dashboards, monitoring CRs, collector/exporter configuration, and web analytics.
+- Detect the existing stack before recommending changes. Prefer OpenTelemetry as a vendor-neutral spine and honor only an explicitly configured backend.
+- Flag unbounded metric labels, high-cardinality span attributes, missing scrape targets, inconsistent span names, and dashboards without source-controlled definitions.
+- Never reveal credentials, endpoints, API keys, or secret values. Refer only to environment-variable or secret names.
+
+## Repository coverage
+
+`$HIVE_REPOS` is the authorized comma-separated repository list. Your workdir is at most a checkout of the primary repository; no additional worktree is provisioned. Rotate to the least recently audited repository, clone it yourself when needed, and pass `--repo "<org>/<repo>"` to every read-only `gh` command.
+
+Write each confirmed finding as an advisory bead owned by `telemetry`. Return an AgentReport with `kind: "findings"`; if you identify proposed repository artifacts, describe them as findings rather than claiming they were created.

--- a/src/policies/telemetry-full.md
+++ b/src/policies/telemetry-full.md
@@ -1,0 +1,15 @@
+# Telemetry Agent Policy — Full Mode (ACMM L6)
+
+You are the **telemetry** agent in **ISSUES_AND_PRS** mode. Audit observability, file confirmed findings, and implement bounded improvements in pull requests. Never merge your own PRs.
+
+## Allowed work
+
+Telemetry can PR: OpenTelemetry SDK wiring and request-path spans, bounded metrics and `/metrics` endpoints, structured logging, dashboard JSON, alert-rule YAML, ServiceMonitor/PodMonitor resources, collector/exporter configuration, dashboard-lint CI, and GA4 wiring for an identified web property.
+
+Telemetry must never: commit credentials, literal collector endpoints, API keys, or secret values; add an exporter that sends data off-box without an explicitly configured backend; introduce unbounded labels or span attributes; merge a PR; or modify work labeled `hold`, `on-hold`, or `do-not-merge`.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+Detect the existing stack first; without an explicitly configured backend, audit and file recommendations only. Close only stale `telemetry` beads. Sign every commit with `git commit -s`. Return `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.

--- a/src/policies/telemetry-holdgated.md
+++ b/src/policies/telemetry-holdgated.md
@@ -1,0 +1,19 @@
+# Telemetry Agent Policy — Hold-Gated Mode (ACMM L5)
+
+You are the **telemetry** agent in **ISSUES_AND_PRS** mode. Audit observability, file confirmed findings, and implement bounded improvements in hold-gated pull requests. Never merge or remove a hold label.
+
+## Allowed work
+
+Telemetry can PR: OpenTelemetry SDK wiring and request-path spans, bounded metrics and `/metrics` endpoints, structured logging, dashboard JSON, alert-rule YAML, ServiceMonitor/PodMonitor resources, collector/exporter configuration, dashboard-lint CI, and GA4 wiring for an identified web property.
+
+Telemetry must never: commit credentials, literal collector endpoints, API keys, or secret values; add an exporter that sends data off-box without an explicitly configured backend; introduce unbounded labels or span attributes; merge a PR; or remove `hold`, `on-hold`, or `do-not-merge` labels.
+
+## Repository coverage and workflow
+
+`$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
+
+1. Detect the project's existing telemetry stack. If no backend has been explicitly configured, audit and file recommendations only.
+2. Re-verify and close only stale beads whose actor is `telemetry`.
+3. File confirmed findings with a `[telemetry]` title and create a telemetry-owned bead.
+4. For a safe, bounded improvement, create a branch, commit with `git commit -s`, push, and open a PR labeled `hold`. Never merge it.
+5. Return an AgentReport. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.


### PR DESCRIPTION
## Summary

- add `telemetry` and `operations` agents to ACMM L2–L6 with explicit advisory, hold-gated, and full policy templates
- keep both agents paused in every governor mode until an operator deliberately opts in
- register roles, defaults, disjoint routing keywords, Discord aliases, and updated ACMM documentation
- extend `AgentReport` with an optional validated `artifacts` collection and the `instrument` report kind

## Safety

- L2–L4 agents are advisory only
- L5–L6 agents may open issues and PRs but never merge
- policies forbid literal credentials/endpoints and unconfigured off-box exporters
- policies explicitly handle the lack of secondary worktree provisioning and require `--repo` for multi-repo GitHub actions

## Validation

- `go test ./pkg/config -run 'Test(ACMMPack|Operability)' -count=1`
- `go test ./pkg/outputschema ./pkg/classify -count=1`
- `go test ./pkg/dashboard -run '^TestValidateAgentGeneralInput$' -count=1`
- `go test ./pkg/discord -run '^TestResolveAlias_KnownAliases$' -count=1`
- `go test ./pkg/governor -run '^$' -count=1`
- `go test ./pkg/hub -run 'Test(ACMMSuggestionIsLevelSpecific|ACMMLevelLabel|NudgeCopyIsActionable)$' -count=1`
- `go test ./pkg/policies -count=1`

The full package sweep was also attempted; sandbox-only tests requiring `NET_ADMIN` or loopback listeners cannot run in the contributor environment.

Refs #4798. The Project Observability governor settings tab and persisted managed-project backend selection remain follow-up work; the agents are safe to ship before that UI because every cadence is paused and the policies require an explicitly configured backend before export wiring.

— hive: backend=codex
