### PR TITLE
🐛 fix(dashboard): let an opened Prior Prompt scroll instead of dead-latching or leaking to the page

### DIFF
--- a/src/pkg/dashboard/prompt_history_scroll_test.go
+++ b/src/pkg/dashboard/prompt_history_scroll_test.go
@@ -1,0 +1,67 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPromptHistoryScrollContainment pins the scroll geometry of the Prior
+// Prompts tab (#4801). An opened prompt body must be its own bounded scroller:
+// its inline overflow-x:auto forces a computed overflow-y of auto, making it a
+// scroll container, and the #2766 containment on `.config-overlay pre` makes
+// that container a scroll-chain boundary. Without a max-height the body can
+// never scroll, so wheel/touch over an opened prompt latched on it and went
+// nowhere — or, on short viewports, leaked to the dashboard behind the modal
+// instead of scrolling the prompt. Verified in headless Chromium: before the
+// fix 40 wheel ticks over the opened prompt left every scroller at 0 (1400x900)
+// or scrolled the page behind the modal (800x600); after, the prompt body
+// scrolls and the page stays put.
+func TestPromptHistoryScrollContainment(t *testing.T) {
+	html := indexHTML(t)
+
+	// The opened prompt body: bounded height, own vertical scroll, and
+	// overscroll containment inline (so it holds even if the shared
+	// `.config-overlay pre` rule is ever reorganized).
+	preStyle := `class="prompt-history-body" data-idx="' + i + '" style="`
+	idx := strings.Index(html, preStyle)
+	if idx < 0 {
+		t.Fatal("index.html no longer renders .prompt-history-body with an inline style — update this test alongside the markup")
+	}
+	styleEnd := strings.Index(html[idx+len(preStyle):], `"`)
+	if styleEnd < 0 {
+		t.Fatal(".prompt-history-body inline style is unterminated")
+	}
+	style := html[idx+len(preStyle) : idx+len(preStyle)+styleEnd]
+	for _, want := range []string{
+		"max-height:60vh",
+		"overflow-y:auto",
+		"overscroll-behavior:contain",
+		"overscroll-behavior-y:contain",
+	} {
+		if !strings.Contains(style, want) {
+			t.Errorf("prompt-history-body inline style is missing %q — an opened prior prompt cannot scroll (or chains to the dashboard) again (#4801); style: %s", want, style)
+		}
+	}
+
+	// The list around the entries scrolls too and must not chain past itself
+	// when it reaches an edge.
+	listTag := `id="prompt-history-list" class="config-pre-fill" style="`
+	idx = strings.Index(html, listTag)
+	if idx < 0 {
+		t.Fatal("index.html no longer renders #prompt-history-list with an inline style — update this test alongside the markup")
+	}
+	styleEnd = strings.Index(html[idx+len(listTag):], `"`)
+	if styleEnd < 0 {
+		t.Fatal("#prompt-history-list inline style is unterminated")
+	}
+	style = html[idx+len(listTag) : idx+len(listTag)+styleEnd]
+	for _, want := range []string{
+		"overflow-y:auto",
+		"overscroll-behavior:contain",
+		"overscroll-behavior-y:contain",
+	} {
+		if !strings.Contains(style, want) {
+			t.Errorf("#prompt-history-list inline style is missing %q — prompt-list scrolling chains to the dashboard behind the modal (#4801); style: %s", want, style)
+		}
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -18858,7 +18858,7 @@ function burnAreaChart() {
           <select id="prompt-history-window" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.75rem">${opts}</select>
           <span id="prompt-history-count" style="font-size:0.7rem;color:var(--muted)"></span>
         </div>
-        <div id="prompt-history-list" class="config-pre-fill" style="flex:1;min-height:200px;overflow-y:auto">
+        <div id="prompt-history-list" class="config-pre-fill" style="flex:1;min-height:200px;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">
           <div style="color:var(--muted);font-style:italic;padding:8px">Loading prompts…</div>
         </div>
         </div>`;
@@ -18952,7 +18952,14 @@ function burnAreaChart() {
             '<span style="padding:1px 6px;border-radius:4px;font-size:0.65rem;border:1px solid ' + color + ';color:' + color + ';white-space:nowrap">' + esc(trigger) + '</span>' +
             truncNote +
           '</button>' +
-          '<pre class="prompt-history-body" data-idx="' + i + '" style="display:none;margin:0;padding:10px 12px;background:var(--bg);border-top:1px solid var(--border);font-family:var(--font-mono);font-size:0.72rem;line-height:1.5;white-space:pre-wrap;overflow-x:auto;color:var(--text)">' +
+          // max-height + overflow-y make the opened body its own bounded
+          // scroller. Without a bound it is a scroll container (overflow-x
+          // forces computed overflow-y:auto) that can NEVER scroll, and the
+          // #2766 containment on `.config-overlay pre` turns it into a chain
+          // boundary: wheel/touch over the opened prompt latches there and
+          // goes nowhere — or, on short viewports, leaks to the dashboard
+          // behind the modal instead of scrolling the prompt (#4801).
+          '<pre class="prompt-history-body" data-idx="' + i + '" style="display:none;margin:0;padding:10px 12px;background:var(--bg);border-top:1px solid var(--border);font-family:var(--font-mono);font-size:0.72rem;line-height:1.5;white-space:pre-wrap;overflow-x:auto;max-height:60vh;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain;color:var(--text)">' +
             escPreserveNewlines((e && e.prompt) || '') +
           '</pre>' +
           '</div>';


### PR DESCRIPTION
Fixes #4801

## Bug

Opening a prior prompt in the **Prior Prompts** tab expands its content, but wheel/touch scrolling over it fails: nothing scrolls on tall viewports, and on short viewports the scroll leaks to the dashboard page behind the modal.

## Root cause

The expanded `<pre class="prompt-history-body">` has inline `overflow-x:auto`, which forces computed `overflow-y:auto` — a scroll container — but with no height bound it grows to full content height (13k+ px for a real prompt) and can never scroll. The #2766 containment rule `.config-overlay pre { overscroll-behavior:contain }` then makes that always-at-boundary scroller a scroll-chain boundary: the wheel latches on it and terminates, never reaching the scrollable `#prompt-history-list`.

## Fix

- `.prompt-history-body` becomes its own bounded scroller: `max-height:60vh; overflow-y:auto; overscroll-behavior:contain` — same pattern as `#prompt-template-preview`.
- `#prompt-history-list` gains the `overscroll-behavior:contain` it was missing versus every other scrollable modal surface (#2766).
- Body scroll-lock (`body.modal-open`) and the shared modal containment were checked and already cover this overlay — no shared-pattern change needed.

## Verification

Headless Chromium against the real rendered page (config dialog open, Prior Prompts tab mounted, 800-line prompt expanded, real `renderAgentPromptHistoryList` output):

| viewport | before (40×wheel over prompt) | after |
|---|---|---|
| 1400×900 | page 0, list 0, **pre 0** (dead) | **pre 13293**, page 0 |
| 800×600 | **page scrolled behind modal** | pre scrolls to max, page 0 |
| 800×600, 400×wheel (past end) | — | pre pinned at max, page 0, no leak |

- `check-inline-js.js` guard: pass
- `go test ./pkg/dashboard/`: green, coverage 84.7% (floor 82)
- New `TestPromptHistoryScrollContainment` pins both inline styles alongside the existing `TestModalScrollContainment` (#2766)
