### PR TITLE
fix(ui): contain scrolling across overlay surfaces

### DIFF
--- a/src/pkg/dashboard/agent_config_single_save_test.go
+++ b/src/pkg/dashboard/agent_config_single_save_test.go
@@ -139,6 +139,34 @@ func TestModalScrollContainment(t *testing.T) {
 	if !strings.Contains(html[idx:idx+end], "overscroll-behavior: contain;") {
 		t.Error(".config-body rule is missing overscroll-behavior: contain — modal body scroll chains to the page")
 	}
+	// Other bounded overlay surfaces must not hand their wheel delta to the
+	// dashboard when they reach an edge (#4805).
+	for _, selector := range []string{
+		".oc-sidebar {",
+		".gh-setup-modal {",
+		".acmm-dialog {",
+		".config-stats-list {",
+		".hive-chat-panel {",
+		".hive-chat-messages {",
+		".hive-chat-input {",
+		".chat-raw-details pre {",
+		".nous-config-body,",
+		".welcome-body {",
+		".gh-auth-overlay, .cred-dialog-overlay, .config-overlay, .hive-dialog-overlay, .nous-config-overlay, .acmm-dialog-overlay {",
+	} {
+		idx := strings.Index(html, selector)
+		if idx < 0 {
+			t.Errorf("index.html has no %s rule", selector)
+			continue
+		}
+		end := strings.Index(html[idx:], "}")
+		if end < 0 || !strings.Contains(html[idx:idx+end], "overscroll-behavior: contain;") {
+			t.Errorf("%s rule is missing overscroll containment (#4805)", selector)
+		}
+	}
+	if !strings.Contains(html, `.nous-config-body [style*="overflow-y:auto"],`) {
+		t.Error("KB inline scrollers are missing containment coverage (#4805)")
+	}
 }
 
 // TestModalBodyScrollLockReused asserts the pre-existing single body scroll-lock
@@ -153,9 +181,13 @@ func TestModalBodyScrollLockReused(t *testing.T) {
 		"body.modal-open { overflow: hidden; }",
 		// The config overlay is one of the observed overlays.
 		"var OVERLAY_SELECTOR = '.config-overlay,",
+		"function observeOverlays() {",
 	} {
 		if !strings.Contains(html, snippet) {
 			t.Errorf("index.html is missing %q — the shared modal body scroll lock regressed", snippet)
 		}
+	}
+	if strings.Contains(html, "document.body.style.overflow") {
+		t.Error("a modal still manages body.style.overflow directly instead of using the shared modal-open lock")
 	}
 }

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -138,6 +138,8 @@
       background: var(--bg-soft); border-right: 1px solid var(--line);
       display: flex; flex-direction: column; padding: 0;
       z-index: 100; overflow-y: auto;
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
     }
     .oc-sidebar-resize {
       position: fixed; top: 0; bottom: 0; width: 5px;
@@ -944,7 +946,7 @@
     .gh-auth-modal .gh-verify-link:hover { background: color-mix(in srgb, var(--green) 85%, #fff); }
     .gh-auth-modal .gh-poll-status { color: var(--muted); font-size: 0.8rem; margin-top: 12px; }
     .gh-auth-modal .gh-cancel { margin-top: 12px; } /* ghost button (system recipe) */
-    .gh-setup-modal { padding: 32px; max-width: 560px; width: 92%; text-align: left; max-height: 85vh; overflow-y: auto; } /* modal panel recipe */
+    .gh-setup-modal { padding: 32px; max-width: 560px; width: 92%; text-align: left; max-height: 85vh; overflow-y: auto; overscroll-behavior: contain; overscroll-behavior-y: contain; } /* modal panel recipe */
     .claude-auth-btn { background: #d97706; color: #fff; border: none; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
     .claude-auth-btn:hover { background: #f59e0b; }
     .claude-auth-status { font-size: 0.8rem; color: var(--muted); }
@@ -1647,7 +1649,7 @@
     @keyframes config-fade-in { from { opacity: 0; } to { opacity: 1; } }
     .hive-dialog-overlay { z-index: 20000; }
     .acmm-dialog-overlay { z-index: 10000; } /* JS toggles inline display flex/none */
-    .acmm-dialog { padding: 20px; max-width: 600px; width: 92%; max-height: 80vh; overflow-y: auto; }
+    .acmm-dialog { padding: 20px; max-width: 600px; width: 92%; max-height: 80vh; overflow-y: auto; overscroll-behavior: contain; overscroll-behavior-y: contain; }
     .hive-dialog { width: 460px; max-width: 92vw; padding: 24px; } /* modal panel recipe */
     .hive-dialog-title { font-size: var(--fs-lg); font-weight: 700; color: var(--text); margin-bottom: 12px; }
     .hive-dialog-body { font-size: 0.9rem; color: var(--muted); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
@@ -1763,7 +1765,7 @@
     /* compact stat-row inputs — size step re-declared after the input recipe */
     /* .btn-sm / .btn-danger / .btn-add — ghost/danger/secondary buttons (system recipe) */
     .btn-sm:disabled { opacity: 0.3; cursor: default; }
-    .config-stats-list { max-height: 400px; overflow-y: auto; padding-right: 12px; }
+    .config-stats-list { max-height: 400px; overflow-y: auto; padding-right: 12px; overscroll-behavior: contain; overscroll-behavior-y: contain; }
 
     .config-info {
       display: inline-flex; align-items: center; justify-content: center;
@@ -1901,6 +1903,8 @@
       background: var(--bg); border: 1px solid var(--border);
       box-shadow: 0 8px 32px rgba(0,0,0,0.5);
       display: none; flex-direction: column; overflow: hidden;
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
     }
     .hive-chat-resize {
       height: 6px; cursor: ns-resize; background: transparent;
@@ -1920,6 +1924,8 @@
       flex: 1; overflow-y: auto; padding: 12px 14px;
       display: flex; flex-direction: column; gap: 10px;
       min-height: 100px;
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
     }
     .chat-msg {
       max-width: 88%; padding: 8px 12px; border-radius: 10px;
@@ -1934,7 +1940,7 @@
       border-top: 1px solid var(--border); background: var(--surface);
     }
     /* .hive-chat-input — shared input recipe (end of style block) */
-    .hive-chat-input { flex: 1; resize: none; min-height: 36px; max-height: 80px; }
+    .hive-chat-input { flex: 1; resize: none; min-height: 36px; max-height: 80px; overscroll-behavior: contain; overscroll-behavior-y: contain; }
     .hive-chat-send {
       background: var(--purple); color: var(--bg); border: none; border-radius: 8px;
       padding: 0 14px; cursor: pointer; font-size: 0.8rem; font-weight: 600;
@@ -1946,7 +1952,7 @@
     .chat-sources span { background: rgba(255,255,255,0.06); padding: 1px 5px; border-radius: 3px; margin-right: 3px; }
     .chat-raw-details { margin-top: 6px; font-size: 0.7rem; }
     .chat-raw-details summary { cursor: pointer; color: var(--muted); font-size: 0.65rem; }
-    .chat-raw-details pre { white-space: pre-wrap; word-break: break-all; font-size: 0.65rem; color: var(--muted); margin-top: 4px; max-height: 200px; overflow-y: auto; }
+    .chat-raw-details pre { white-space: pre-wrap; word-break: break-all; font-size: 0.65rem; color: var(--muted); margin-top: 4px; max-height: 200px; overflow-y: auto; overscroll-behavior: contain; overscroll-behavior-y: contain; }
     @media (max-width: 500px) {
       .hive-chat-panel { width: calc(100vw - 32px); right: 16px; bottom: 72px; }
       /* Phone: the fixed FAB used to sit on top of in-flow controls at the
@@ -2003,6 +2009,14 @@
     .nous-config-dialog { width: 900px; max-width: 95vw; max-height: 85vh; display: flex; flex-direction: column; padding: 0; }
     .nous-config-dialog > h2 { flex-shrink: 0; padding: 24px 24px 0; }
     .nous-config-dialog > .nous-config-body { flex: 1; overflow-y: auto; padding: 16px 24px; }
+    .nous-config-body,
+    .nous-config-body textarea,
+    .nous-config-body pre,
+    .nous-config-body [style*="overflow-y:auto"],
+    .nous-config-body [style*="overflow-y: auto"] {
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
+    }
     .nous-config-dialog > .nous-config-footer { flex-shrink: 0; padding: 12px 24px; border-top: 1px solid var(--border); }
     .nous-config-dialog h2 { font-size: var(--fs-lg); margin: 0 0 16px 0; display: flex; align-items: center; gap: 8px; }
     .nous-config-section { margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
@@ -2345,6 +2359,8 @@
       -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
       display: flex; align-items: center; justify-content: center;
       animation: config-fade-in 0.15s ease-out;
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
     }
     /* Glass panel — hub recipe linear-gradient(#17212deb,#0c1219eb) +
        border #ffffff1a, expressed in tokens so the light-mode remap
@@ -2513,7 +2529,7 @@
        button recipes (.config-overlay/.config-modal/.hive-dialog-btn);
        only the checklist internals are defined here. Tokens only. */
     .welcome-modal { max-width: 680px; width: 92%; max-height: 86vh; display: flex; flex-direction: column; }
-    .welcome-body { padding: 4px 24px 16px; overflow-y: auto; }
+    .welcome-body { padding: 4px 24px 16px; overflow-y: auto; overscroll-behavior: contain; overscroll-behavior-y: contain; }
     .welcome-progress { font-size: 0.72em; font-weight: 400; color: var(--muted); margin-left: 8px; white-space: nowrap; }
     .welcome-intro { font-size: var(--fs-base); color: var(--text); margin: 12px 0 16px; line-height: 1.55; }
     .welcome-step { border: 1px solid var(--line); border-radius: var(--radius); margin-bottom: 8px; background: color-mix(in srgb, var(--panel-strong) 40%, transparent); }
@@ -3882,11 +3898,19 @@
         return false;
       }
       function sync() { document.body.classList.toggle('modal-open', anyOverlayOpen()); }
-      var obs = new MutationObserver(sync);
-      function start() {
+      var obs = new MutationObserver(function() {
+        // Re-observing is harmless and subscribes overlays appended after
+        // startup (KB/ACMM) before their next display toggle.
+        observeOverlays();
+        sync();
+      });
+      function observeOverlays() {
         document.querySelectorAll(OVERLAY_SELECTOR).forEach(function(el) {
           obs.observe(el, { attributes: true, attributeFilter: ['class', 'style'] });
         });
+      }
+      function start() {
+        observeOverlays();
         // Catch overlays created later (e.g. acmm dialog appended on first open).
         obs.observe(document.body, { childList: true, subtree: false });
         sync();
@@ -14959,7 +14983,6 @@ function burnAreaChart() {
         document.body.appendChild(overlay);
       }
       overlay.style.display = 'flex';
-      document.body.style.overflow = 'hidden';
       overlay.innerHTML = '<div class="acmm-dialog">' +
         '<div class="row-between" style="margin-bottom:12px">' +
         '<h3 style="margin:0;font-size:1rem;font-weight:700;color:var(--text)">' + title + '</h3>' +
@@ -14970,7 +14993,6 @@ function burnAreaChart() {
     function acmmCloseDialog() {
       const overlay = document.getElementById('acmm-dialog-overlay');
       if (overlay) overlay.style.display = 'none';
-      document.body.style.overflow = '';
     }
 
     function acmmSelectRepo(repoName) {

--- a/src/pkg/hub/contribute_modal_scroll_test.go
+++ b/src/pkg/hub/contribute_modal_scroll_test.go
@@ -1,0 +1,35 @@
+package hub
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestContributeModalScrollContainment(t *testing.T) {
+	b, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("read static/index.html: %v", err)
+	}
+	html := string(b)
+	for _, snippet := range []string{
+		"body.modal-open { overflow: hidden; }",
+		"document.body.classList.add('modal-open');",
+		"function closeContributeInfo() {",
+		"document.body.classList.remove('modal-open');",
+		`id="contrib-modal-panel"`,
+		`onclick="closeContributeInfo()"`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("static/index.html is missing %q — contribute modal scroll containment regressed", snippet)
+		}
+	}
+	idx := strings.Index(html, "#contrib-modal-panel {")
+	if idx < 0 {
+		t.Fatal("static/index.html has no #contrib-modal-panel CSS rule")
+	}
+	end := strings.Index(html[idx:], "}")
+	if end < 0 || !strings.Contains(html[idx:idx+end], "overscroll-behavior: contain;") {
+		t.Error("#contrib-modal-panel rule is missing overscroll containment")
+	}
+}

--- a/src/pkg/hub/static/index.html
+++ b/src/pkg/hub/static/index.html
@@ -39,6 +39,12 @@
       color: var(--text);
       margin: 0;
     }
+    body.modal-open { overflow: hidden; }
+    #contrib-modal,
+    #contrib-modal-panel {
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
+    }
     a { color: inherit; text-decoration: none; }
 
     /* ── Header ── */
@@ -1638,6 +1644,7 @@
     async function openContributeInfo(name, id) {
       _contribHiveId = id;
       document.getElementById('contrib-modal').style.display = 'flex';
+      document.body.classList.add('modal-open');
       document.getElementById('contrib-hive-name').textContent = name;
       document.getElementById('contrib-hive-id').textContent = id;
       var area = document.getElementById('contrib-access-area');
@@ -1663,6 +1670,11 @@
 
       area.innerHTML = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">Request access to view the hive dashboard, agents, and config.</p>' +
         '<button onclick="requestAccessFromModal()" id="contrib-req-btn" style="padding:8px 16px;background:var(--blue);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:0.85rem">Request Access</button>';
+    }
+
+    function closeContributeInfo() {
+      document.getElementById('contrib-modal').style.display = 'none';
+      document.body.classList.remove('modal-open');
     }
 
     async function requestAccessFromModal() {
@@ -1758,13 +1770,13 @@
   </script>
 
   <div id="contrib-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:100;align-items:center;justify-content:center">
-    <div style="background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:32px;max-width:540px;width:90%;max-height:80vh;overflow-y:auto">
+    <div id="contrib-modal-panel" style="background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:32px;max-width:540px;width:90%;max-height:80vh;overflow-y:auto">
       <h2 style="font-size:1.3rem;margin-bottom:4px;color:var(--amber)">Contribute to <span id="contrib-hive-name"></span></h2>
       <p style="font-size:0.8rem;color:var(--muted);margin-bottom:16px">Hive ID: <code id="contrib-hive-id" style="font-size:0.75rem;background:#080b0f85;border:1px solid var(--line);padding:2px 6px;border-radius:4px"></code></p>
       <p style="color:var(--muted);font-size:0.9rem;line-height:1.6;margin-bottom:20px">Help this project by contributing to open issues and PRs. Login with GitHub to request access &mdash; the hive owner will be notified and can approve your request.</p>
       <div id="contrib-access-area"></div>
       <div style="display:flex;justify-content:flex-end;margin-top:12px">
-        <button onclick="document.getElementById('contrib-modal').style.display='none'" style="padding:8px 20px;background:var(--bg);border:1px solid var(--line);border-radius:6px;color:var(--muted);cursor:pointer">Close</button>
+        <button onclick="closeContributeInfo()" style="padding:8px 20px;background:var(--bg);border:1px solid var(--line);border-radius:6px;color:var(--muted);cursor:pointer">Close</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #4805.

## Summary

- contain wheel/touch scroll chaining across chat, sidebar, GitHub, ACMM, Nous/KB, welcome, stats, and dialog overlay surfaces
- teach the shared modal scroll-lock observer to subscribe to dynamically appended KB/ACMM overlays, preventing both stuck locks and unlocked reopens
- remove ACMM's competing inline body overflow management and add a shared lock to the hub contribute modal
- extend dashboard and hub static-HTML regression coverage for each affected surface

## Testing

- `go test ./pkg/dashboard ./pkg/hub -run 'TestModalScrollContainment|TestModalBodyScrollLockReused|TestContributeModalScrollContainment' -count=1`
- `go test ./pkg/dashboard ./pkg/hub -count=1`

— hive: backend=codex
