### PR TITLE
🌱 fix(dashboard): salvage KB inline-scroller containment and the whole-file lock pin from #4809

### DIFF
--- a/src/pkg/dashboard/overlay_scroll_audit_test.go
+++ b/src/pkg/dashboard/overlay_scroll_audit_test.go
@@ -35,6 +35,8 @@ func TestOverlayScrollContainmentAudit(t *testing.T) {
 		".nous-config-dialog > .nous-config-body,",
 		".nous-config-overlay textarea,",
 		".nous-config-overlay pre,",
+		".nous-config-body [style*=\"overflow-y:auto\"],",
+		".nous-config-body [style*=\"overflow-y: auto\"],",
 		".welcome-body,",
 		".config-stats-list {",
 	}
@@ -86,15 +88,10 @@ func TestModalScrollLockObservesLateOverlays(t *testing.T) {
 			t.Errorf("index.html is missing %q — late-created overlays escape the shared body scroll-lock (#4805)", snippet)
 		}
 	}
-	// The acmm dialog must rely on the shared lock, not a second bespoke
-	// body.style.overflow mechanism that fights the class-based lock.
-	idx := strings.Index(html, "function acmmShowDialog(")
-	end := strings.Index(html, "function acmmCloseDialog(")
-	if idx < 0 || end < 0 || end < idx {
-		t.Fatal("cannot locate acmmShowDialog/acmmCloseDialog in index.html")
-	}
-	closeEnd := end + strings.Index(html[end:], "\n    }")
-	if strings.Contains(html[idx:closeEnd], "document.body.style.overflow") {
-		t.Error("acmm dialog manages body.style.overflow itself — a second scroll-lock mechanism alongside installModalScrollLock (#4805)")
+	// No dialog anywhere in the SPA may run a bespoke body.style.overflow
+	// lock alongside the shared class-based lock (salvaged from #4809's
+	// stronger whole-file pin; the acmm dialog was the last holdout).
+	if strings.Contains(html, "document.body.style.overflow") {
+		t.Error("a dialog manages body.style.overflow itself — a second scroll-lock mechanism alongside installModalScrollLock (#4805)")
 	}
 }

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -1730,6 +1730,8 @@
     .nous-config-dialog > .nous-config-body,
     .nous-config-overlay textarea,
     .nous-config-overlay pre,
+    .nous-config-body [style*="overflow-y:auto"],
+    .nous-config-body [style*="overflow-y: auto"],
     .welcome-body,
     .config-stats-list {
       overscroll-behavior: contain;


### PR DESCRIPTION
Follow-up to #4810 / #4805. Dedupe disposition for the #4809 collision: #4810 merged first; this salvages the two pieces where #4809 was stronger — first-hop `overscroll-behavior` containment on the KB modal's inline scrollers (`#kb-subs-content`, `#kb-ctx7-results`, matched via `.nous-config-body [style*="overflow-y:auto"]`), and widening the bespoke-lock absence pin from the acmm region to the whole SPA (no `body.style.overflow` writes anywhere). Credit: @Danathar (#4809).

Tests: full pin-test set + #4803's green; check-inline-js passes.