### PR TITLE
🐛 fix(dashboard): stop rendering ✓ and '? behind' together when the branch tip has no image

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -656,9 +656,15 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		stableShort := shortSHADashboard(stableV4)
 		resp["stableV4Hash"] = stableV4
 		resp["stableV4Short"] = stableShort
+		// Distinguish "the tip has no image yet" (a known state: nothing to
+		// upgrade to, compare never attempted) from "the compare failed"
+		// (genuinely unknown). Without this the frontend renders a yellow
+		// "? behind" next to the green ✓ whenever the tip is unbuilt (#4804).
+		stableImageReady := ghcrTagExistsCached(stableShort)
+		resp["stableV4ImageReady"] = stableImageReady
 		if sameCommitDashboard(versionHash, stableV4) {
 			resp["commitsBehind"] = 0
-		} else if ghcrTagExistsCached(stableShort) {
+		} else if stableImageReady {
 			if count, ok := s.commitsBehindStableTip(versionHash, stableV4); ok {
 				resp["commitsBehind"] = count
 			}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -15140,7 +15140,17 @@ function burnAreaChart() {
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         const commitsBehindText = v.commitsBehind != null && v.commitsBehind > 0
           ? ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Stable v4 tip: ${escapeHtml(v.stableV4Short || '?')}">${escapeHtml(String(v.commitsBehind))} behind</span>`
-          : (v.commitsBehind == null && v.stableV4Hash && String(v.short || '').toLowerCase() !== String(v.stableV4Short || '').toLowerCase() ? ` <span class="git-behind" title="Could not compare this commit with stable v4 tip ${escapeHtml(v.stableV4Short || '?')}">? behind</span>` : '');
+          : (v.commitsBehind == null && v.stableV4Hash && String(v.short || '').toLowerCase() !== String(v.stableV4Short || '').toLowerCase()
+            // commitsBehind is null for two unrelated reasons (#4804). If the
+            // stable tip has no published image, that is a KNOWN state — there
+            // is nothing to upgrade to and the compare was never attempted —
+            // so say that in muted text instead of a yellow "? behind" that
+            // contradicts the ✓. Only a genuine compare failure keeps the "?".
+            // Strict === false so older servers without the field keep "?".
+            ? (v.stableV4ImageReady === false
+              ? ` <span style="color:var(--muted)" title="Stable v4 tip ${escapeHtml(v.stableV4Short || '?')} has no published image yet — nothing to upgrade to">tip not built yet</span>`
+              : ` <span class="git-behind" title="Could not compare this commit with stable v4 tip ${escapeHtml(v.stableV4Short || '?')}">? behind</span>`)
+            : '');
         if (_upgradeInProgress && v.hash !== _upgradeTargetHash) {
           html += ` <span class="git-behind" title="Upgrading to ${escapeHtml(v.latestShort || '?')}">⬆ upgrading</span>`;
         } else if (_upgradeInProgress && v.hash === _upgradeTargetHash) {

--- a/src/pkg/dashboard/version_badge_unbuilt_tip_test.go
+++ b/src/pkg/dashboard/version_badge_unbuilt_tip_test.go
@@ -1,0 +1,37 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestVersionBadgeUnbuiltTipWording pins the #4804 frontend contract: when
+// commitsBehind is null because the stable v4 tip has no published image
+// (stableV4ImageReady === false), the badge must render a muted "tip not built
+// yet" note — never the yellow "? behind" that contradicts the green ✓. The
+// "?" wording is reserved for a genuine compare failure (image exists but
+// commitsBehind is still null), and older servers that do not send the field
+// keep the "?" via the strict === false comparison.
+func TestVersionBadgeUnbuiltTipWording(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		// The state discriminator, strict so an absent field keeps "?".
+		"v.stableV4ImageReady === false",
+		// The known-state arm: muted, no question mark, says why.
+		`has no published image yet — nothing to upgrade to">tip not built yet</span>`,
+		// The genuine-unknown arm survives for real compare failures.
+		`Could not compare this commit with stable v4 tip ${escapeHtml(v.stableV4Short || '?')}">? behind</span>`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — the badge again renders contradictory ✓ + ? behind for an unbuilt tip (#4804)", snippet)
+		}
+	}
+	if strings.Contains(html, `class="git-behind"`) && strings.Contains(html, `tip not built yet</span>`) {
+		// The muted arm must not reuse the yellow .git-behind styling.
+		idx := strings.Index(html, "tip not built yet</span>")
+		start := strings.LastIndex(html[:idx], "<span")
+		if start >= 0 && strings.Contains(html[start:idx], "git-behind") {
+			t.Error(`the "tip not built yet" note uses class="git-behind" — it must be muted, not warning-yellow (#4804)`)
+		}
+	}
+}

--- a/src/pkg/dashboard/version_behind_test.go
+++ b/src/pkg/dashboard/version_behind_test.go
@@ -68,3 +68,128 @@ func TestHandleVersionIncludesCommitsBehindAndCaches(t *testing.T) {
 		t.Fatalf("compare calls = %d, want 1 cached call", compareCalls)
 	}
 }
+
+// TestHandleVersionUnbuiltTipReportsImageNotReady pins the #4804 contract:
+// when the stable v4 tip has NO published GHCR image, the response must say so
+// explicitly (stableV4ImageReady=false) and must not attempt the compare, so
+// commitsBehind stays absent. Before the fix the frontend collapsed this known
+// state with a genuine compare failure and rendered a contradictory
+// "✓ ? behind" badge.
+func TestHandleVersionUnbuiltTipReportsImageNotReady(t *testing.T) {
+	origHash, origShort := versionHash, versionShort
+	versionHash, versionShort = "old11112222", "old1111"
+	t.Cleanup(func() { versionHash, versionShort = origHash, origShort })
+	// Tip image does NOT exist (cached negative so no network call is made).
+	ghcrCacheMu.Lock()
+	ghcrCacheResult["abc1234"] = false
+	ghcrCacheExpiry["abc1234"] = time.Now().Add(time.Hour)
+	ghcrCacheMu.Unlock()
+	t.Cleanup(func() {
+		ghcrCacheMu.Lock()
+		delete(ghcrCacheResult, "abc1234")
+		delete(ghcrCacheExpiry, "abc1234")
+		ghcrCacheMu.Unlock()
+	})
+
+	compareCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/kubestellar/hive/git/ref/heads/v4", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ref":    "refs/heads/v4",
+			"object": map[string]any{"sha": "abc1234567890abcdef1234567890abcdef123456"},
+		})
+	})
+	mux.HandleFunc("/repos/kubestellar/hive/commits/abc1234567890abcdef1234567890abcdef123456", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"commit": map[string]any{"message": "tip\nbody"}})
+	})
+	mux.HandleFunc("/repos/kubestellar/hive/compare/old1111...abc1234", func(w http.ResponseWriter, r *http.Request) {
+		compareCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"ahead_by": 5})
+	})
+	ghSrv := httptest.NewServer(mux)
+	defer ghSrv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewServer(0, logger)
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ghSrv.URL, "myorg", []string{"repo1"}, logger)
+	s.RegisterAPI(deps)
+
+	rec := doGet(s, "/api/version")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body["stableV4ImageReady"] != false {
+		t.Fatalf("stableV4ImageReady = %v, want false when the tip has no GHCR image", body["stableV4ImageReady"])
+	}
+	if got, present := body["commitsBehind"]; present {
+		t.Fatalf("commitsBehind = %v, want absent when the tip image is not built", got)
+	}
+	if body["behind"] != false {
+		t.Fatalf("behind = %v, want false when the tip image is not built", body["behind"])
+	}
+	if compareCalls != 0 {
+		t.Fatalf("compare calls = %d, want 0 (compare must not run for an unbuilt tip)", compareCalls)
+	}
+}
+
+// TestHandleVersionBuiltTipReportsImageReady pins the complementary #4804
+// contract: when the tip image exists, stableV4ImageReady is true and the
+// compare runs, so a null commitsBehind on the frontend then genuinely means
+// "the compare failed" and the "? behind" wording is accurate.
+func TestHandleVersionBuiltTipReportsImageReady(t *testing.T) {
+	origHash, origShort := versionHash, versionShort
+	versionHash, versionShort = "old11112222", "old1111"
+	t.Cleanup(func() { versionHash, versionShort = origHash, origShort })
+	ghcrCacheMu.Lock()
+	ghcrCacheResult["abc1234"] = true
+	ghcrCacheExpiry["abc1234"] = time.Now().Add(time.Hour)
+	ghcrCacheMu.Unlock()
+	t.Cleanup(func() {
+		ghcrCacheMu.Lock()
+		delete(ghcrCacheResult, "abc1234")
+		delete(ghcrCacheExpiry, "abc1234")
+		ghcrCacheMu.Unlock()
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/kubestellar/hive/git/ref/heads/v4", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ref":    "refs/heads/v4",
+			"object": map[string]any{"sha": "abc1234567890abcdef1234567890abcdef123456"},
+		})
+	})
+	mux.HandleFunc("/repos/kubestellar/hive/commits/abc1234567890abcdef1234567890abcdef123456", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"commit": map[string]any{"message": "tip\nbody"}})
+	})
+	mux.HandleFunc("/repos/kubestellar/hive/compare/old1111...abc1234", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ahead_by": 5})
+	})
+	ghSrv := httptest.NewServer(mux)
+	defer ghSrv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewServer(0, logger)
+	deps := testDeps(t)
+	deps.GHClient = ghpkg.NewClientForTest(ghSrv.URL, "myorg", []string{"repo1"}, logger)
+	s.RegisterAPI(deps)
+
+	rec := doGet(s, "/api/version")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body["stableV4ImageReady"] != true {
+		t.Fatalf("stableV4ImageReady = %v, want true when the tip image exists", body["stableV4ImageReady"])
+	}
+	if body["commitsBehind"] != float64(5) {
+		t.Fatalf("commitsBehind = %v, want 5", body["commitsBehind"])
+	}
+}


### PR DESCRIPTION
Fixes #4804

## Root cause (as Danathar diagnosed — confirmed exact)

`commitsBehind` is `null` for two unrelated reasons and the badge collapsed them:

| cause | meaning |
|---|---|
| stable v4 tip has no GHCR image (`ghcrTagExistsCached(stableShort)` false, compare never attempted) | **known** state: nothing to upgrade to |
| `CompareAheadBy` failed | genuinely unknown |

With an unbuilt tip, `behind` is (correctly) `false` → the frontend emits the green ✓, then `if (!v.behind) html += commitsBehindText` appends the yellow `? behind` — a contradiction.

## Fix (server + frontend, per the issue's suggestion)

- `api.go`: `resp["stableV4ImageReady"] = ghcrTagExistsCached(stableShort)` (computed once, reused for the compare gate).
- `index.html` null arm of `commitsBehindText`:
  - `stableV4ImageReady === false` → muted `tip not built yet` note ("has no published image yet — nothing to upgrade to") that agrees with the ✓;
  - otherwise (field true or absent on older servers, via strict `=== false`) → `? behind` survives, now accurately meaning "the compare really failed".

## Tests

- `TestHandleVersionUnbuiltTipReportsImageNotReady`: field `false`, `commitsBehind` absent, `behind` false, **zero** compare calls.
- `TestHandleVersionBuiltTipReportsImageReady`: field `true`, compare runs, `commitsBehind` = 5.
- `TestVersionBadgeUnbuiltTipWording`: pins the discriminator, both wordings, and that the muted note does not reuse the warning-yellow `.git-behind` class.

## Verification

- `check-inline-js.js` guard: pass
- `go vet` + full `./pkg/dashboard/`: green, coverage 84.8% (floor 82)

The `docker.yml` stale-skip observation (immutable per-SHA tag skipped alongside the moving tags) is left for its own issue as the reporter offered — this PR is only the badge.
