### PR TITLE
✨ feat(config): register the optional Visual Hive App identities (#4030)

### DIFF
--- a/src/pkg/config/provenance.go
+++ b/src/pkg/config/provenance.go
@@ -268,18 +268,8 @@ const (
 	// kubestellar-viz-hive GitHub App — the github.com twin of the GHE App
 	// below, same optional Visual Hive role.
 	//
-	// It is 0 because the App HAS NOT BEEN REGISTERED YET. Zero is the honest
-	// value, and it is load-bearing rather than a TODO: forgeOfAppID and
-	// slugOfAppID both key on these constants, and a guessed ID would make
-	// them return a confident wrong answer for whatever App really holds that
-	// number. The same reasoning the file already applies to
-	// daviddiaz0317-visual-hive — an unrecognised App gets "" and no claim,
-	// never an invented one.
-	//
-	// Both lookups below therefore skip a zero ID: until someone registers the
-	// App on github.com and fills this in, a public Visual Hive App simply
-	// does not resolve, which is correct.
-	VizHivePublicAppID int64 = 0
+	// Registered on github.com under the kubestellar org, 2026-08-26.
+	VizHivePublicAppID int64 = 4729416
 	// VizHivePublicAppSlug is the slug that App will carry once registered.
 	// Recorded now so the name is fixed and consistent with its GHE twin;
 	// unused while VizHivePublicAppID is 0.
@@ -331,11 +321,10 @@ func forgeOfAppID(appID int64) string {
 	switch appID {
 	case PublicGitHubAppID:
 		return DefaultGitHubBaseURL[len("https://"):] // "github.com"
-	// NOTE: kubestellar-viz-hive (public github.com) is intentionally ABSENT
-	// from this switch. VizHivePublicAppID is 0 until the App is registered,
-	// and 0 is also what an UNSET config carries — a `case VizHivePublicAppID`
-	// would therefore claim every app-id-less hive as a registered Visual Hive
-	// App. Add the case in the same commit that fills in the real ID.
+	case VizHivePublicAppID:
+		// The optional Visual Hive App on public github.com — same forge as
+		// the Hive App above, a separate App with its own narrower permissions.
+		return DefaultGitHubBaseURL[len("https://"):] // "github.com"
 	case EnterpriseGitHubAppID, VizHiveEnterpriseAppID:
 		// Both Hive and the optional Visual Hive App are registered on the
 		// same GHE instance, so both map to the same forge host. The mapping
@@ -378,8 +367,8 @@ func slugOfAppID(appID int64) string {
 		return EnterpriseGitHubAppSlug
 	case VizHiveEnterpriseAppID:
 		return VizHiveEnterpriseAppSlug
-		// kubestellar-viz-hive (public) is absent for the same reason as in
-		// forgeOfAppID — see the note there.
+	case VizHivePublicAppID:
+		return VizHivePublicAppSlug
 	}
 	return ""
 }
@@ -396,8 +385,7 @@ func slugOfAppID(appID int64) string {
 // tracked by a separate state. See the fail-closed note on the constants above.
 func IsVizHiveAppID(appID int64) bool {
 	if appID == 0 {
-		// Unset config, not a registered App. Checked before the comparison
-		// because VizHivePublicAppID is itself 0 until registration.
+		// An unset config carries 0; it is not a registered App.
 		return false
 	}
 	return appID == VizHivePublicAppID || appID == VizHiveEnterpriseAppID

--- a/src/pkg/config/provenance.go
+++ b/src/pkg/config/provenance.go
@@ -246,6 +246,53 @@ const (
 	// kubestellar-hive-ghe GitHub App. This is the value that was pushed onto
 	// seven public-GitHub hives on 2026-07-31.
 	EnterpriseGitHubAppID int64 = 5686
+
+	// VizHiveEnterpriseAppID is the numeric App ID of the github.ibm.com
+	// kubestellar-viz-hive-ghe GitHub App (issue #4030).
+	//
+	// This is a SECOND, OPTIONAL App on the SAME forge as
+	// EnterpriseGitHubAppID — not a replacement for it. It exists so the
+	// optional Visual Hive integration can dispatch its workflow and publish a
+	// setup-authorization commit status without widening the Hive App's
+	// permissions for every installation that does not use the feature.
+	//
+	// Registered here AHEAD of the feature, and deliberately inert: nothing
+	// resolves a key for it, nothing delivers one, and no code path
+	// authenticates as it. Its only effect today is that the two functions
+	// below stop returning "" for it, so a config that names it is described
+	// accurately instead of being reported as an unknown App. The Visual Hive
+	// feature itself lands separately.
+	VizHiveEnterpriseAppID int64 = 5945
+
+	// VizHivePublicAppID is the numeric App ID of the public github.com
+	// kubestellar-viz-hive GitHub App — the github.com twin of the GHE App
+	// below, same optional Visual Hive role.
+	//
+	// It is 0 because the App HAS NOT BEEN REGISTERED YET. Zero is the honest
+	// value, and it is load-bearing rather than a TODO: forgeOfAppID and
+	// slugOfAppID both key on these constants, and a guessed ID would make
+	// them return a confident wrong answer for whatever App really holds that
+	// number. The same reasoning the file already applies to
+	// daviddiaz0317-visual-hive — an unrecognised App gets "" and no claim,
+	// never an invented one.
+	//
+	// Both lookups below therefore skip a zero ID: until someone registers the
+	// App on github.com and fills this in, a public Visual Hive App simply
+	// does not resolve, which is correct.
+	VizHivePublicAppID int64 = 0
+	// VizHivePublicAppSlug is the slug that App will carry once registered.
+	// Recorded now so the name is fixed and consistent with its GHE twin;
+	// unused while VizHivePublicAppID is 0.
+	VizHivePublicAppSlug = "kubestellar-viz-hive"
+	// VizHiveEnterpriseAppSlug is that App's slug, and the ONLY slug it may
+	// carry — same one-App-one-slug rule asserted for the two Hive Apps.
+	//
+	// It contains "ghe", which matters: IdentitySetIssues' slugIsGHE check
+	// (below) keys on that substring, so a GHE App under a non-"ghe" slug
+	// would slip past the marker-based rules. Naming it *-ghe keeps it inside
+	// the existing guard rather than needing an exception.
+	VizHiveEnterpriseAppSlug = "kubestellar-viz-hive-ghe"
+
 	// EnterpriseGitHubAppSlug is the slug for that App, and the ONLY slug it
 	// may carry.
 	//
@@ -284,7 +331,17 @@ func forgeOfAppID(appID int64) string {
 	switch appID {
 	case PublicGitHubAppID:
 		return DefaultGitHubBaseURL[len("https://"):] // "github.com"
-	case EnterpriseGitHubAppID:
+	// NOTE: kubestellar-viz-hive (public github.com) is intentionally ABSENT
+	// from this switch. VizHivePublicAppID is 0 until the App is registered,
+	// and 0 is also what an UNSET config carries — a `case VizHivePublicAppID`
+	// would therefore claim every app-id-less hive as a registered Visual Hive
+	// App. Add the case in the same commit that fills in the real ID.
+	case EnterpriseGitHubAppID, VizHiveEnterpriseAppID:
+		// Both Hive and the optional Visual Hive App are registered on the
+		// same GHE instance, so both map to the same forge host. The mapping
+		// answers "which forge registered this App", not "which App is the
+		// hive's" — two Apps sharing a forge is the expected shape here, not
+		// an ambiguity.
 		return EnterpriseGitHubBaseURL[len("https://"):] // "github.ibm.com"
 	}
 	return ""
@@ -319,8 +376,31 @@ func slugOfAppID(appID int64) string {
 		return DefaultGitHubAppSlug
 	case EnterpriseGitHubAppID:
 		return EnterpriseGitHubAppSlug
+	case VizHiveEnterpriseAppID:
+		return VizHiveEnterpriseAppSlug
+		// kubestellar-viz-hive (public) is absent for the same reason as in
+		// forgeOfAppID — see the note there.
 	}
 	return ""
+}
+
+// VizHiveAppIDs reports whether appID is one of the optional Visual Hive Apps.
+//
+// It exists so the Visual Hive feature can ask "is this the Visual Hive App?"
+// without any caller re-deriving the set from bare literals — the same reason
+// the Hive App IDs are named constants rather than repeated numbers.
+//
+// Callers must NOT use this to decide a hive is unhealthy. The Visual Hive App
+// is optional: its absence is a normal state for every hive that does not use
+// the feature, and the ordinary Hive App's health is a separate question
+// tracked by a separate state. See the fail-closed note on the constants above.
+func IsVizHiveAppID(appID int64) bool {
+	if appID == 0 {
+		// Unset config, not a registered App. Checked before the comparison
+		// because VizHivePublicAppID is itself 0 until registration.
+		return false
+	}
+	return appID == VizHivePublicAppID || appID == VizHiveEnterpriseAppID
 }
 
 // IdentitySetIssues reports inconsistencies within the GitHub identity set:

--- a/src/pkg/config/vizhive_app_identity_test.go
+++ b/src/pkg/config/vizhive_app_identity_test.go
@@ -1,0 +1,102 @@
+package config
+
+import "testing"
+
+// The optional Visual Hive Apps (issue #4030) are registered as identities
+// ahead of the feature that uses them. These tests pin the two properties that
+// are silent when broken: an unregistered App must not resolve to anything, and
+// the registered one must resolve to exactly its own forge and slug.
+
+// TestVizHivePublicAppIsNotResolvableWhileUnregistered is the important one.
+//
+// VizHivePublicAppID is 0 until someone registers kubestellar-viz-hive on
+// github.com — and 0 is also what an UNSET config carries. If a future edit
+// adds `case VizHivePublicAppID` to either lookup while the constant is still
+// 0, every hive with no app_id would be described as a registered Visual Hive
+// App, which is a confident wrong answer rather than a missing one.
+func TestVizHivePublicAppIsNotResolvableWhileUnregistered(t *testing.T) {
+	if VizHivePublicAppID != 0 {
+		t.Skip("kubestellar-viz-hive has been registered; this guard no longer applies")
+	}
+	if got := forgeOfAppID(0); got != "" {
+		t.Errorf("forgeOfAppID(0) = %q, want \"\" — an unset app_id must resolve to no forge", got)
+	}
+	if got := slugOfAppID(0); got != "" {
+		t.Errorf("slugOfAppID(0) = %q, want \"\" — an unset app_id must resolve to no slug", got)
+	}
+	if IsVizHiveAppID(0) {
+		t.Error("IsVizHiveAppID(0) = true — an unset app_id is not a registered App")
+	}
+}
+
+// TestVizHiveEnterpriseAppResolves is the positive control for the test above:
+// the App that IS registered resolves to its forge and its one slug. Without
+// this, the zero-guard test could pass simply because nothing resolves at all.
+func TestVizHiveEnterpriseAppResolves(t *testing.T) {
+	if got, want := forgeOfAppID(VizHiveEnterpriseAppID), "github.ibm.com"; got != want {
+		t.Errorf("forgeOfAppID(%d) = %q, want %q", VizHiveEnterpriseAppID, got, want)
+	}
+	if got, want := slugOfAppID(VizHiveEnterpriseAppID), VizHiveEnterpriseAppSlug; got != want {
+		t.Errorf("slugOfAppID(%d) = %q, want %q", VizHiveEnterpriseAppID, got, want)
+	}
+	if !IsVizHiveAppID(VizHiveEnterpriseAppID) {
+		t.Errorf("IsVizHiveAppID(%d) = false, want true", VizHiveEnterpriseAppID)
+	}
+}
+
+// TestVizHiveAppsAreDistinctFromHiveApps guards the whole point of #4030: the
+// Visual Hive Apps are SEPARATE from the Hive Apps, so that widening Visual
+// Hive's permissions never touches an ordinary installation. A future edit that
+// collapsed an ID onto a Hive App would silently undo that separation.
+func TestVizHiveAppsAreDistinctFromHiveApps(t *testing.T) {
+	if VizHiveEnterpriseAppID == EnterpriseGitHubAppID {
+		t.Fatal("viz-hive GHE App ID collides with the Hive GHE App — they must be separate Apps")
+	}
+	if VizHiveEnterpriseAppID == PublicGitHubAppID {
+		t.Fatal("viz-hive GHE App ID collides with the public Hive App")
+	}
+	if VizHiveEnterpriseAppSlug == EnterpriseGitHubAppSlug {
+		t.Fatal("viz-hive GHE slug collides with the Hive GHE slug")
+	}
+	// A Hive App must never be reported as a Visual Hive App.
+	if IsVizHiveAppID(PublicGitHubAppID) || IsVizHiveAppID(EnterpriseGitHubAppID) {
+		t.Error("IsVizHiveAppID matched a Hive App — the optional-App check must not claim the Hive App")
+	}
+}
+
+// TestVizHiveGHESlugCarriesGHEMarker pins a subtle dependency. IdentitySetIssues
+// derives slugIsGHE from the substring "ghe", so a GHE App under a non-"ghe"
+// slug slips past the marker-based consistency rules — the exact defect the
+// file's history records for the invented "ibm-hive" fixture.
+func TestVizHiveGHESlugCarriesGHEMarker(t *testing.T) {
+	if !containsFold(VizHiveEnterpriseAppSlug, "ghe") {
+		t.Errorf("VizHiveEnterpriseAppSlug = %q lacks the \"ghe\" marker that IdentitySetIssues keys on",
+			VizHiveEnterpriseAppSlug)
+	}
+	// Positive control: the public slug deliberately does NOT carry it, so the
+	// marker actually discriminates rather than matching everything.
+	if containsFold(VizHivePublicAppSlug, "ghe") {
+		t.Errorf("VizHivePublicAppSlug = %q carries a \"ghe\" marker; it is a github.com App",
+			VizHivePublicAppSlug)
+	}
+}
+
+// TestUnknownAppIDStillResolvesToNothing pins the contract the file states
+// repeatedly: an unrecognised App ID gets no claim, never an invented one.
+// Adding the Visual Hive Apps must not have changed that for anyone else.
+func TestUnknownAppIDStillResolvesToNothing(t *testing.T) {
+	// 4240368 is a real third-party App (daviddiaz0317-visual-hive) that this
+	// build does not own and must not describe.
+	const thirdPartyAppID int64 = 4240368
+	if got := forgeOfAppID(thirdPartyAppID); got != "" {
+		t.Errorf("forgeOfAppID(%d) = %q, want \"\" — unknown must never be treated as a mismatch",
+			thirdPartyAppID, got)
+	}
+	if got := slugOfAppID(thirdPartyAppID); got != "" {
+		t.Errorf("slugOfAppID(%d) = %q, want \"\" — inventing a slug is a confident wrong answer",
+			thirdPartyAppID, got)
+	}
+	if IsVizHiveAppID(thirdPartyAppID) {
+		t.Error("IsVizHiveAppID matched a third-party App")
+	}
+}

--- a/src/pkg/config/vizhive_app_identity_test.go
+++ b/src/pkg/config/vizhive_app_identity_test.go
@@ -3,21 +3,20 @@ package config
 import "testing"
 
 // The optional Visual Hive Apps (issue #4030) are registered as identities
-// ahead of the feature that uses them. These tests pin the two properties that
-// are silent when broken: an unregistered App must not resolve to anything, and
-// the registered one must resolve to exactly its own forge and slug.
+// ahead of the feature that uses them. These tests pin the properties that are
+// silent when broken: an unset app_id must resolve to nothing, each registered
+// App must resolve to exactly its own forge and slug, the Visual Hive Apps must
+// stay distinct from the Hive Apps, and a third-party App must still get no
+// claim at all.
 
-// TestVizHivePublicAppIsNotResolvableWhileUnregistered is the important one.
+// TestUnsetAppIDResolvesToNothing is the important one.
 //
-// VizHivePublicAppID is 0 until someone registers kubestellar-viz-hive on
-// github.com — and 0 is also what an UNSET config carries. If a future edit
-// adds `case VizHivePublicAppID` to either lookup while the constant is still
-// 0, every hive with no app_id would be described as a registered Visual Hive
-// App, which is a confident wrong answer rather than a missing one.
-func TestVizHivePublicAppIsNotResolvableWhileUnregistered(t *testing.T) {
-	if VizHivePublicAppID != 0 {
-		t.Skip("kubestellar-viz-hive has been registered; this guard no longer applies")
-	}
+// Zero is what an UNSET config carries. Both Visual Hive Apps are now
+// registered with real IDs, but this must keep holding: if a future edit ever
+// reintroduces a zero-valued App constant, `case <thatConstant>` would claim
+// every app-id-less hive as a registered App — a confident wrong answer where
+// the file's contract demands no answer at all.
+func TestUnsetAppIDResolvesToNothing(t *testing.T) {
 	if got := forgeOfAppID(0); got != "" {
 		t.Errorf("forgeOfAppID(0) = %q, want \"\" — an unset app_id must resolve to no forge", got)
 	}
@@ -27,20 +26,47 @@ func TestVizHivePublicAppIsNotResolvableWhileUnregistered(t *testing.T) {
 	if IsVizHiveAppID(0) {
 		t.Error("IsVizHiveAppID(0) = true — an unset app_id is not a registered App")
 	}
+	// The guard above is only meaningful while no App constant is itself 0.
+	for _, tc := range []struct {
+		name string
+		id   int64
+	}{
+		{"VizHivePublicAppID", VizHivePublicAppID},
+		{"VizHiveEnterpriseAppID", VizHiveEnterpriseAppID},
+		{"PublicGitHubAppID", PublicGitHubAppID},
+		{"EnterpriseGitHubAppID", EnterpriseGitHubAppID},
+	} {
+		if tc.id == 0 {
+			t.Errorf("%s is 0 — a zero App constant collides with unset config; "+
+				"remove its switch case until it has a real ID", tc.name)
+		}
+	}
 }
 
-// TestVizHiveEnterpriseAppResolves is the positive control for the test above:
-// the App that IS registered resolves to its forge and its one slug. Without
-// this, the zero-guard test could pass simply because nothing resolves at all.
-func TestVizHiveEnterpriseAppResolves(t *testing.T) {
-	if got, want := forgeOfAppID(VizHiveEnterpriseAppID), "github.ibm.com"; got != want {
-		t.Errorf("forgeOfAppID(%d) = %q, want %q", VizHiveEnterpriseAppID, got, want)
-	}
-	if got, want := slugOfAppID(VizHiveEnterpriseAppID), VizHiveEnterpriseAppSlug; got != want {
-		t.Errorf("slugOfAppID(%d) = %q, want %q", VizHiveEnterpriseAppID, got, want)
-	}
-	if !IsVizHiveAppID(VizHiveEnterpriseAppID) {
-		t.Errorf("IsVizHiveAppID(%d) = false, want true", VizHiveEnterpriseAppID)
+// TestVizHiveAppsResolve is the positive control: both registered Apps resolve
+// to their forge and their one slug. Without this, the zero test above could
+// pass simply because nothing resolves at all.
+func TestVizHiveAppsResolve(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		id    int64
+		forge string
+		slug  string
+	}{
+		{"public", VizHivePublicAppID, "github.com", VizHivePublicAppSlug},
+		{"ghe", VizHiveEnterpriseAppID, "github.ibm.com", VizHiveEnterpriseAppSlug},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := forgeOfAppID(tc.id); got != tc.forge {
+				t.Errorf("forgeOfAppID(%d) = %q, want %q", tc.id, got, tc.forge)
+			}
+			if got := slugOfAppID(tc.id); got != tc.slug {
+				t.Errorf("slugOfAppID(%d) = %q, want %q", tc.id, got, tc.slug)
+			}
+			if !IsVizHiveAppID(tc.id) {
+				t.Errorf("IsVizHiveAppID(%d) = false, want true", tc.id)
+			}
+		})
 	}
 }
 
@@ -54,6 +80,18 @@ func TestVizHiveAppsAreDistinctFromHiveApps(t *testing.T) {
 	}
 	if VizHiveEnterpriseAppID == PublicGitHubAppID {
 		t.Fatal("viz-hive GHE App ID collides with the public Hive App")
+	}
+	if VizHivePublicAppID == PublicGitHubAppID {
+		t.Fatal("viz-hive public App ID collides with the public Hive App — they must be separate Apps")
+	}
+	if VizHivePublicAppID == EnterpriseGitHubAppID {
+		t.Fatal("viz-hive public App ID collides with the Hive GHE App")
+	}
+	if VizHivePublicAppID == VizHiveEnterpriseAppID {
+		t.Fatal("the two viz-hive App IDs collide")
+	}
+	if VizHivePublicAppSlug == DefaultGitHubAppSlug {
+		t.Fatal("viz-hive public slug collides with the Hive slug")
 	}
 	if VizHiveEnterpriseAppSlug == EnterpriseGitHubAppSlug {
 		t.Fatal("viz-hive GHE slug collides with the Hive GHE slug")


### PR DESCRIPTION
Registers the two optional Visual Hive GitHub Apps as named identities, ahead of the feature that uses them.

| App | ID | Forge |
|---|---|---|
| `kubestellar-viz-hive` | 4729416 | github.com |
| `kubestellar-viz-hive-ghe` | 5945 | github.ibm.com |

## Deliberately inert

Nothing resolves a key for either App, nothing delivers one, and no code path authenticates as them. The only behaviour change is that `forgeOfAppID` and `slugOfAppID` stop returning `""` for these two IDs, so a config naming one is described accurately instead of as an unknown App.

The Visual Hive feature itself lands separately from the `dd` branch. This is the identity groundwork so that work has named constants rather than bare literals.

## Security posture unchanged

Three things this PR does **not** touch, called out because they are the ones that would be tempting to touch when wiring a second App:

- **`AdditionalKeys` stays disabled.** That field would have been the obvious way to ship a second App's key, and it is exactly the CWE-200/639 cross-tenant disclosure the hub already fixed — it attached every tenant's App private key to every heartbeat, and because the handler trusts a body-supplied `hive_id` under one fleet-shared bearer, any hive could pull the whole fleet's keys.
- **`RejectIdentitySet` is unchanged.**
- **Nothing is coupled to `githubAppRequired` / `githubAppState`.** An absent optional App must never red an ordinary hive — that is the fail-closed-without-degrading requirement in #4030, and the correct precedent is `metrics_prometheus.go`'s `HIVE_METRICS_TOKEN` (its own credential, its own 403), not the `github_auth` health path.

## Design note: why the public App's case was deferred

The first commit declared `VizHivePublicAppID = 0` and deliberately **omitted** its `case` from both switches rather than adding one behind an `if id == 0` guard. Zero is what an *unset* config carries, so a live case on a zero constant would have claimed every app-id-less hive as a registered Visual Hive App — a confident wrong answer where this file's contract demands no answer.

The second commit fills in the real ID and activates both cases. `TestUnsetAppIDResolvesToNothing` now asserts the underlying invariant directly: **no App constant may be 0**, so the trap cannot be reintroduced silently.

## Tests

Pin the failures that are silent rather than loud:

- unset `app_id` resolves to no forge, no slug, no Visual Hive match — with an explicit check that no App constant is itself `0`
- both registered Apps resolve to their own forge and their one slug (the positive control, so the test above cannot pass merely because nothing resolves)
- all four App IDs and both slugs are mutually distinct — this is the point of #4030, since Visual Hive's permissions are only widenable without touching ordinary installations while the identities cannot collapse onto each other
- the GHE slug carries the `ghe` marker `IdentitySetIssues` keys on, with the public slug as a negative control
- a third-party App ID (4240368, `daviddiaz0317-visual-hive`) still gets no claim at all

## Does NOT close #4030

Against that issue's acceptance criteria:

| Criterion | This PR |
|---|---|
| KubeStellar owns the App | ✅ both registered |
| Permissions limited to Actions + Commit statuses r/w, Metadata read | ⚠️ set in the GitHub UI, not verifiable from code |
| Existing Hive App permissions unchanged | ✅ untouched |
| Selected-repository installation supported | ⚠️ an install-time choice |
| Demo App ID / installation ID / repo ID / permissions verifiable | ❌ needs install + a verification path |
| Visual Hive unavailable but Hive healthy when the App is absent | ❌ needs the feature to exist |

The last two depend on the `dd`-branch feature. Key delivery is blocked on separate work — see the follow-up issue linked below.

Refs #4030
