### PR TITLE
🐛 fix: constrain Copilot DCO workflow permissions

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11


### PR DESCRIPTION
## Summary
- add explicit least-privilege permissions to the Copilot DCO workflow caller
- grant only contents: read, statuses: write, and pull-requests: write for the reusable workflow actions

## Validation
- ruby YAML parse for .github/workflows/copilot-dco.yml
- git diff --check

Closes #4601