### PR TITLE
✨ feat(hub): store a second GitHub App key per cluster without touching the primary

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -4139,33 +4139,53 @@ func main() {
 			// collide with the primary /data/gh-app-key.pem above. Writing one that
 			// matches our OWN app_id must take effect immediately: flip keyChanged
 			// so the client is rebuilt below, exactly as a primary-key change does.
-			for _, ak := range ghCfg.AdditionalKeys {
-				if ak.PrivateKey == "" || ak.AppID <= 0 {
-					continue
+			// applyDeliveredPerAppKey writes ONE (app_id, key) pair to its
+			// per-app-id file and reports whether that changed the key we
+			// ourselves sign with. Shared by the (now-inert) AdditionalKeys loop
+			// and the targeted SecondaryKey delivery below so both write through
+			// identical code — the alternative is two copies of an atomic 0600
+			// write, one of which eventually loses a guard.
+			applyDeliveredPerAppKey := func(kind string, appID int64, privateKey string) {
+				if privateKey == "" || appID <= 0 {
+					return
 				}
-				perAppPath := perAppIDKeyPath(ak.AppID)
+				perAppPath := perAppIDKeyPath(appID)
 				beforeFP, _ := config.AppKeyFingerprintFromFile(perAppPath)
-				fp, err := writePerAppIDKey(ak.AppID, ak.PrivateKey)
+				fp, err := writePerAppIDKey(appID, privateKey)
 				if err != nil {
-					logger.Error("failed to write additional github app key from heartbeat",
-						"app_id", ak.AppID, "error", err)
-					continue
+					logger.Error("failed to write "+kind+" github app key from heartbeat",
+						"app_id", appID, "error", err)
+					return
 				}
 				changed := fp != "" && fp != beforeFP
-				logger.Info("additional github app private key written via heartbeat",
-					"app_id", ak.AppID,
+				logger.Info(kind+" github app private key written via heartbeat",
+					"app_id", appID,
 					"path", perAppPath,
 					"from_fingerprint", beforeFP,
 					"to_fingerprint", fp,
 					"key_changed", changed,
 				)
-				// If this additional key is for the App we ourselves authenticate
-				// as, it is now the key resolveAppKeyFile will pick — treat it like
-				// a primary-key rotation so the client rebuild below uses it.
-				if changed && ak.AppID == cfg.GitHub.AppID {
+				// If this key is for the App we ourselves authenticate as, it is
+				// now the key resolveAppKeyFile will pick — treat it like a
+				// primary-key rotation so the client rebuild below uses it.
+				if changed && appID == cfg.GitHub.AppID {
 					keyChanged = true
 					appAuth.DropCachedToken()
 				}
+			}
+			for _, ak := range ghCfg.AdditionalKeys {
+				applyDeliveredPerAppKey("additional", ak.AppID, ak.PrivateKey)
+			}
+
+			// The OPTIONAL SECOND App key (#4815), delivered targeted at this
+			// hive alone rather than broadcast. It lands in the same
+			// /data/gh-app-key-<appid>.pem namespace the spoke has always used,
+			// so heldPerAppIDKeyFingerprints reports it back on the next beat
+			// (which is what stops the hub re-pushing it) and the Forge App tab
+			// renders it, both with no further change. nil for every hive with no
+			// second App.
+			if ghCfg.SecondaryKey != nil {
+				applyDeliveredPerAppKey("secondary", ghCfg.SecondaryKey.AppID, ghCfg.SecondaryKey.PrivateKey)
 			}
 
 			// Adopt a hub-delivered app_id only when it names a REAL App. Zero

--- a/src/pkg/hub/cluster_app_key.go
+++ b/src/pkg/hub/cluster_app_key.go
@@ -117,14 +117,28 @@ func storeClusterAppKey(clusterID, pemData string) error {
 	if !ok {
 		return fmt.Errorf("invalid cluster id for app key store: %q", clusterID)
 	}
+	return storeAppKeyAtPath(path, pemData, "cluster "+clusterID)
+}
+
+// storeAppKeyAtPath is storeClusterAppKey's body, extracted verbatim so the
+// secondary-App store (cluster_secondary_app_key.go) writes through the SAME
+// code rather than a copy.
+//
+// The extraction is deliberate and the copy is the thing being avoided: this
+// function is where 0700/0600, the create-with-final-mode, the fsync and the
+// atomic rename live. A second store with its own hand-rolled write would be
+// one review away from dropping the Sync or creating world-readable and nobody
+// would notice until a key leaked. subject names the owner of the key for error
+// messages only — it must never be, and never is, the key material.
+func storeAppKeyAtPath(path, pemData, subject string) error {
 	trimmed := strings.TrimSpace(pemData)
 	if !strings.HasPrefix(trimmed, "-----BEGIN") {
-		return fmt.Errorf("app key for cluster %s is not PEM", clusterID)
+		return fmt.Errorf("app key for %s is not PEM", subject)
 	}
 	// Validate before persisting: a key we cannot fingerprint is a key we could
 	// never compare against a spoke's report, so it would be pushed forever.
 	if _, err := config.AppKeyFingerprint(trimmed); err != nil {
-		return fmt.Errorf("app key for cluster %s is unusable: %w", clusterID, err)
+		return fmt.Errorf("app key for %s is unusable: %w", subject, err)
 	}
 
 	if err := os.MkdirAll(clusterAppKeyDir, clusterAppKeyDirMode); err != nil {
@@ -1156,6 +1170,29 @@ type clusterAppKeyRequest struct {
 	// PrivateKey is the PEM private key. It is WRITE-ONLY: it is stored to the
 	// 0600 key file and is never returned by any endpoint, in any form.
 	PrivateKey string `json:"private_key"`
+	// ForAppID scopes the upload to a SPECIFIC App, so a cluster can hold a
+	// second (optional) App's key beside its primary one (#4815).
+	//
+	// OPTIONAL AND ABSENT BY DEFAULT. Omitted — the shape every existing caller
+	// sends — means "the cluster's primary App", which writes the same
+	// <clusterID>.pem the endpoint has always written, with the same result.
+	// Nothing about the existing contract changes.
+	//
+	// WHY NOT REUSE AppID ABOVE
+	//
+	// AppID already means "also record this as the cluster's primary
+	// github_app_id in clusters.json" and callers send it that way today. Giving
+	// it a second meaning would make an existing primary-key upload that names
+	// its own App ID — a completely ordinary request — suddenly write to a
+	// secondary path instead, silently leaving the primary key stale. A separate
+	// field cannot be misread by a caller that has never heard of it.
+	//
+	// Setting it to the cluster's primary App is REJECTED rather than accepted
+	// as a no-op alias: an operator who believes they are uploading a second
+	// App's key while actually naming the primary would otherwise overwrite the
+	// key ~55 live hives authenticate with. That silent overwrite is the entire
+	// bug this field exists to prevent, so it must fail loudly.
+	ForAppID int64 `json:"for_app_id,omitempty"`
 }
 
 // clusterAppKeyStatus is the read side. It carries the fingerprint and NEVER the
@@ -1166,6 +1203,38 @@ type clusterAppKeyStatus struct {
 	AppID       int64  `json:"app_id,omitempty"`
 	HasKey      bool   `json:"has_key"`
 	Fingerprint string `json:"fingerprint,omitempty"`
+	// SecondaryKeys lists the cluster's non-primary App keys, fingerprints only,
+	// ascending by App ID. omitempty and nil for every cluster that has none —
+	// which is every cluster in the fleet today — so an existing consumer of
+	// this payload sees a byte-identical response.
+	SecondaryKeys []secondaryAppKeyStatus `json:"secondary_keys,omitempty"`
+}
+
+// secondaryAppKeyStatus is one non-primary App key the hub holds for a cluster.
+// Like clusterAppKeyStatus it carries the fingerprint and NEVER the key; the
+// omission is the contract, not an oversight.
+type secondaryAppKeyStatus struct {
+	AppID       int64  `json:"app_id"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+}
+
+// secondaryAppKeyStatusesFor builds the read-side inventory of a cluster's
+// non-primary keys. Fingerprints are recomputed from disk rather than cached so
+// the operator sees what is actually stored, which is the whole point of the
+// endpoint (confirming an upload landed).
+func secondaryAppKeyStatusesFor(clusterID string) []secondaryAppKeyStatus {
+	appIDs := secondaryAppKeysForCluster(clusterID)
+	if len(appIDs) == 0 {
+		return nil
+	}
+	out := make([]secondaryAppKeyStatus, 0, len(appIDs))
+	for _, id := range appIDs {
+		out = append(out, secondaryAppKeyStatus{
+			AppID:       id,
+			Fingerprint: secondaryAppKeyFingerprint(clusterID, id),
+		})
+	}
+	return out
 }
 
 // handleGetClusterAppKeys reports, per cluster, whether a hub-held App key
@@ -1177,10 +1246,15 @@ func (s *HubServer) handleGetClusterAppKeys(w http.ResponseWriter, r *http.Reque
 	for id, c := range s.clusters {
 		fp := clusterAppKeyFingerprint(id)
 		statuses = append(statuses, clusterAppKeyStatus{
-			ClusterID:   id,
-			AppID:       c.GitHubAppID,
-			HasKey:      fp != "",
-			Fingerprint: fp,
+			ClusterID: id,
+			AppID:     c.GitHubAppID,
+			// HasKey stays the PRIMARY key's presence. A cluster holding only a
+			// secondary key still has no primary key, and reporting otherwise
+			// would tell an operator the fleet's auth is provisioned when it is
+			// not.
+			HasKey:        fp != "",
+			Fingerprint:   fp,
+			SecondaryKeys: secondaryAppKeyStatusesFor(id),
 		})
 	}
 	sort.Slice(statuses, func(i, j int) bool { return statuses[i].ClusterID < statuses[j].ClusterID })
@@ -1217,6 +1291,69 @@ func (s *HubServer) handlePutClusterAppKey(w http.ResponseWriter, r *http.Reques
 		http.Error(w, `{"error":"private_key is not a usable RSA/EC private key"}`, http.StatusBadRequest)
 		return
 	}
+	primaryAppID := s.clusters[clusterID].GitHubAppID
+
+	// SECOND-APP UPLOAD (#4815). Taken BEFORE any write, and it returns from its
+	// own branch rather than falling through, so there is no path on which a
+	// secondary upload can reach storeClusterAppKey and clobber the primary key.
+	if body.ForAppID != 0 {
+		if body.ForAppID < 0 {
+			http.Error(w, `{"error":"for_app_id must be a positive github app id"}`, http.StatusBadRequest)
+			return
+		}
+		// The guard this issue exists for. An operator naming the cluster's own
+		// App here believes they are adding a second key; accepting it would
+		// either overwrite the key ~55 live hives authenticate with, or fork a
+		// shadow copy that silently goes stale. Refuse, and say which App the
+		// cluster's primary actually is so the mistake is obvious.
+		if primaryAppID != 0 && body.ForAppID == primaryAppID {
+			http.Error(w, fmt.Sprintf(
+				`{"error":"app %d is this cluster's primary app; omit for_app_id to replace the primary key"}`,
+				body.ForAppID), http.StatusConflict)
+			return
+		}
+		// A cluster with no primary app_id configured has no primary key to
+		// protect, but it also has no way to tell a "second" App from its first.
+		// Refuse rather than guess: silently creating a secondary key on such a
+		// cluster would leave the real primary slot empty and the reconcile
+		// delivering nothing, with the operator believing the upload landed.
+		if primaryAppID == 0 {
+			http.Error(w, `{"error":"cluster has no primary github_app_id configured; upload its primary key first"}`, http.StatusConflict)
+			return
+		}
+		if body.AppID != 0 && body.AppID != body.ForAppID {
+			// app_id sets the cluster's PRIMARY App. Combining it with a
+			// secondary upload asks for two contradictory things in one request.
+			http.Error(w, `{"error":"app_id cannot be set on a secondary (for_app_id) upload"}`, http.StatusBadRequest)
+			return
+		}
+		if err := storeSecondaryAppKey(clusterID, body.ForAppID, primaryAppID, key); err != nil {
+			s.logger.Error("failed to store secondary cluster app key",
+				"cluster_id", clusterID, "for_app_id", body.ForAppID, "error", err)
+			http.Error(w, `{"error":"failed to store key"}`, http.StatusInternalServerError)
+			return
+		}
+		s.logger.Info("audit: secondary github app key stored for cluster",
+			"cluster_id", clusterID,
+			"for_app_id", body.ForAppID,
+			"primary_app_id", primaryAppID,
+			"fingerprint", fp, // fingerprint only — never the key
+			// The primary's fingerprint is logged UNCHANGED so the audit trail
+			// itself is the evidence that this upload did not disturb it.
+			"primary_fingerprint", clusterAppKeyFingerprint(clusterID),
+			"by", s.getAuthUser(r),
+		)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(clusterAppKeyStatus{
+			ClusterID:     clusterID,
+			AppID:         primaryAppID,
+			HasKey:        clusterAppKeyFingerprint(clusterID) != "",
+			Fingerprint:   clusterAppKeyFingerprint(clusterID),
+			SecondaryKeys: secondaryAppKeyStatusesFor(clusterID),
+		})
+		return
+	}
+
 	if err := storeClusterAppKey(clusterID, key); err != nil {
 		s.logger.Error("failed to store cluster app key", "cluster_id", clusterID, "error", err)
 		http.Error(w, `{"error":"failed to store key"}`, http.StatusInternalServerError)
@@ -1225,7 +1362,7 @@ func (s *HubServer) handlePutClusterAppKey(w http.ResponseWriter, r *http.Reques
 
 	// Persist the app_id alongside so the cluster has a complete identity. The
 	// ID is not secret and belongs in clusters.json.
-	appID := s.clusters[clusterID].GitHubAppID
+	appID := primaryAppID
 	if body.AppID != 0 && body.AppID != appID {
 		if err := s.setClusterAppID(clusterID, body.AppID); err != nil {
 			s.logger.Warn("stored cluster app key but failed to persist app_id",
@@ -1248,6 +1385,9 @@ func (s *HubServer) handlePutClusterAppKey(w http.ResponseWriter, r *http.Reques
 		AppID:       appID,
 		HasKey:      true,
 		Fingerprint: fp,
+		// nil — hence absent from the JSON — for every cluster without a second
+		// App, so a primary upload's response stays byte-identical to today's.
+		SecondaryKeys: secondaryAppKeyStatusesFor(clusterID),
 	})
 }
 

--- a/src/pkg/hub/cluster_secondary_app_key.go
+++ b/src/pkg/hub/cluster_secondary_app_key.go
@@ -1,0 +1,439 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// Per-App key storage for a cluster's SECOND (optional) GitHub App.
+//
+// WHY THIS EXISTS
+//
+// clusterAppKeyPath keys the store by cluster ID alone — one <clusterID>.pem —
+// so a cluster has exactly one slot for App key material. Uploading a second
+// App's key through the operator endpoint therefore OVERWROTE the Hive App key
+// for that cluster, and every spoke on it lost App auth on the next reconcile.
+// That is the bug #4815 exists to prevent; the optional Visual Hive App (#4030)
+// has no correct place to put its credential today.
+//
+// WHY THE PRIMARY PATH IS NOT TOUCHED
+//
+// ~55 live hives across two clusters authenticate from keys already sitting at
+// /data/saas/app-keys/<clusterID>.pem. Renaming, moving or "normalising" that
+// path is a fleet-wide auth outage for zero benefit: the primary App's key is
+// still exactly one per cluster and the existing path already names it
+// unambiguously. The second App's key therefore lands ALONGSIDE it under a new
+// name, and there is no on-disk migration of any kind — a hub rolled back to a
+// build without this file finds every primary key exactly where it left it, and
+// simply ignores the extra files.
+//
+// WHY NOT A SUBDIRECTORY PER CLUSTER
+//
+// A sibling filename keeps the store a flat directory of PEMs, which is what
+// storeClusterAppKey's atomic temp-then-rename assumes (the temp file must land
+// on the same filesystem as its target, and CreateTemp is given
+// clusterAppKeyDir). A per-cluster subdirectory would need its own MkdirAll,
+// its own 0700 enforcement per cluster, and would make a cluster ID a directory
+// name — a strictly larger traversal surface for no gain.
+
+// secondaryAppKeyInfix separates the cluster ID from the App ID in a secondary
+// key's filename: <clusterID>-app-<appID>.pem.
+//
+// The literal "-app-" (rather than a bare "-") is deliberate. Cluster IDs
+// legitimately contain "-" and end in digits (oke-260812-8yiz), so a bare
+// separator would make "<a>-<b>.pem" ambiguous between a secondary key for
+// cluster <a> and a PRIMARY key for a cluster literally named "<a>-<b>". Since
+// the character allowlist below rejects nothing that would let a real cluster ID
+// contain "-app-<digits>" at the very end… it could in principle, so the
+// ambiguity is resolved the only way that is actually safe: this store NEVER
+// scans filenames to recover a cluster ID. Every read is a lookup by an
+// (clusterID, appID) pair the caller already holds, and the filename is only
+// ever CONSTRUCTED, never parsed. The infix exists purely to keep secondary
+// files visually distinguishable from primary ones for a human reading `ls`.
+const secondaryAppKeyInfix = "-app-"
+
+// secondaryAppKeyPath returns the on-disk path of a cluster's key for an App
+// that is NOT that cluster's primary App.
+//
+// It applies exactly the same guards as clusterAppKeyPath — the character
+// allowlist, the explicit "."/".." rejection — because the cluster ID reaches
+// the filesystem from the same untrusted sources. The App ID is a NEW component
+// of the path and therefore a new traversal surface: it is accepted only as a
+// positive int64 and rendered back with strconv, so the filename can only ever
+// contain decimal digits. A string App ID concatenated straight into the name
+// would let "../../etc/x" out of the directory; there is deliberately no
+// string-typed entry point to this function.
+//
+// Returns ok=false — never an error — for the same reason clusterAppKeyPath
+// does: "this names no key file" is an ordinary state that every caller already
+// handles as "no key", not a fault to propagate.
+func secondaryAppKeyPath(clusterID string, appID int64) (string, bool) {
+	if appID <= 0 {
+		return "", false
+	}
+	// Reuse the primary path builder for the cluster-ID half so the two can
+	// never drift: whatever cluster IDs are legal for the primary key are
+	// exactly the ones legal here, validated by the same code.
+	primary, ok := clusterAppKeyPath(clusterID)
+	if !ok {
+		return "", false
+	}
+	id := strings.TrimSuffix(filepath.Base(primary), ".pem")
+	name := id + secondaryAppKeyInfix + strconv.FormatInt(appID, 10) + ".pem"
+	return filepath.Join(clusterAppKeyDir, name), true
+}
+
+// loadSecondaryAppKey returns the PEM stored for (cluster, App), or "" when
+// there is none. Mirrors loadClusterAppKey exactly, including the "-----BEGIN"
+// sanity check: a truncated file must never be delivered to a spoke, where it
+// would replace a working key with one that cannot sign.
+func loadSecondaryAppKey(clusterID string, appID int64) string {
+	path, ok := secondaryAppKeyPath(clusterID, appID)
+	if !ok {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	pem := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(pem, "-----BEGIN") {
+		return ""
+	}
+	return pem
+}
+
+// storeSecondaryAppKey writes a cluster's key for a non-primary App.
+//
+// It refuses to write when appID is the cluster's PRIMARY App. That guard is
+// the point of this whole change: without it, a "second App" upload naming the
+// primary App by mistake would create a shadow copy of the primary key at a
+// second path, and the two would silently diverge on the next primary rotation
+// — one of them stale, with nothing to say which. The caller (the upload
+// handler) rejects that case with a clear error before reaching here; this is
+// the defence in depth for any future caller.
+//
+// The write itself is the same atomic temp-then-rename at the same modes as
+// storeClusterAppKey — shared through storeAppKeyAtPath so the two can never
+// acquire different security properties.
+func storeSecondaryAppKey(clusterID string, appID int64, primaryAppID int64, pemData string) error {
+	if appID <= 0 {
+		return fmt.Errorf("invalid app id for secondary app key store: %d", appID)
+	}
+	if primaryAppID != 0 && appID == primaryAppID {
+		return fmt.Errorf("app %d is cluster %s's primary app: its key belongs at the primary path, not a secondary one", appID, clusterID)
+	}
+	path, ok := secondaryAppKeyPath(clusterID, appID)
+	if !ok {
+		return fmt.Errorf("invalid cluster id for secondary app key store: %q", clusterID)
+	}
+	return storeAppKeyAtPath(path, pemData, fmt.Sprintf("cluster %s app %d", clusterID, appID))
+}
+
+// secondaryAppKeyFingerprint returns the non-secret fingerprint of a stored
+// secondary key, or "" when there is none.
+func secondaryAppKeyFingerprint(clusterID string, appID int64) string {
+	pem := loadSecondaryAppKey(clusterID, appID)
+	if pem == "" {
+		return ""
+	}
+	fp, err := config.AppKeyFingerprint(pem)
+	if err != nil {
+		return ""
+	}
+	return fp
+}
+
+// secondaryAppKeysForCluster lists the App IDs a cluster holds a secondary key
+// for, ascending.
+//
+// It scans the store directory and matches on the CONSTRUCTED prefix for this
+// cluster, so the ambiguity noted at secondaryAppKeyInfix cannot mis-attribute a
+// file: a name only counts when it starts with this cluster's own validated ID
+// plus the infix and ends in a parseable positive integer. A cluster with no
+// secondary keys — every cluster in the fleet today — returns nil and touches
+// nothing else.
+func secondaryAppKeysForCluster(clusterID string) []int64 {
+	primary, ok := clusterAppKeyPath(clusterID)
+	if !ok {
+		return nil
+	}
+	id := strings.TrimSuffix(filepath.Base(primary), ".pem")
+	prefix := id + secondaryAppKeyInfix
+	entries, err := os.ReadDir(clusterAppKeyDir)
+	if err != nil {
+		// A missing store directory is the ordinary state on a hub that has
+		// never had a key uploaded. Never an error.
+		return nil
+	}
+	var out []int64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".pem") {
+			continue
+		}
+		digits := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".pem")
+		appID, convErr := strconv.ParseInt(digits, 10, 64)
+		if convErr != nil || appID <= 0 {
+			continue
+		}
+		// Only a name this store would itself have produced counts. A file
+		// named with leading zeros or padding parses as an integer but is not
+		// one of ours, and reading it would attribute a key to an App whose
+		// canonical path is a different file.
+		if canonical, pathOK := secondaryAppKeyPath(clusterID, appID); !pathOK || filepath.Base(canonical) != name {
+			continue
+		}
+		out = append(out, appID)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// secondaryAppKeyForHive resolves the secondary App key this HIVE is authorized
+// to receive, or ("", 0) when it is authorized for none.
+//
+// AUTHORIZATION, NOT DISCOVERY — this is the whole security contract of #4815.
+//
+// The removed AdditionalKeys broadcast (heartbeat.go, CWE-200/639) selected keys
+// from the FLEET key set with no binding to the caller, so any hive holding the
+// fleet-shared bearer could pull every tenant's App private key by beating with
+// any hive_id. This function never enumerates the fleet. It answers only from
+// the hub's OWN record for one hive — the SaaSHive the caller resolved from the
+// authenticated identity — and returns a key only when that record explicitly
+// names the App (SecondaryAppID) AND the key is stored under that hive's own
+// cluster. A hive with no SecondaryAppID (every hive in the fleet today) gets
+// nothing, and there is no input a spoke can supply that changes the answer:
+// the App ID comes from the hub record, never from the payload.
+//
+// Returning the cluster ID's key rather than a fleet-wide lookup by app_id is
+// deliberate too: appKeysByAppID would happily hand back another tenant's key
+// for the same App ID, which is the broadcast bug in miniature.
+func secondaryAppKeyForHive(h *SaaSHive) (pem string, appID int64) {
+	if h == nil || h.SecondaryAppID <= 0 {
+		return "", 0
+	}
+	clusterID := strings.TrimSpace(h.ClusterID)
+	if clusterID == "" {
+		return "", 0
+	}
+	key := loadSecondaryAppKey(clusterID, h.SecondaryAppID)
+	if key == "" {
+		return "", 0
+	}
+	return key, h.SecondaryAppID
+}
+
+// secondaryAppAssignmentRequest is the admin body for assigning (or clearing) a
+// hive's optional second App.
+type secondaryAppAssignmentRequest struct {
+	// AppID names the second App this hive may hold a key for. Zero CLEARS the
+	// assignment — an explicit, reversible operation, so an operator can undo a
+	// mistake without editing meta.json by hand.
+	AppID int64 `json:"app_id"`
+}
+
+// handleSetHiveSecondaryApp assigns a hive its optional second GitHub App:
+// PUT /api/saas/hives/{id}/secondary-app
+//
+// This is the ONLY way SecondaryAppID is ever written, and it is admin-gated for
+// the same reason the key upload is: the field is an authorization decision, so
+// anything that can set it can direct key material at a hive.
+//
+// It carries NO key material in either direction — it names an App by its
+// non-secret numeric ID. The key itself reaches the hub only through
+// PUT /api/saas/admin/cluster-app-keys/{clusterID} with for_app_id, and reaches
+// the spoke only through the targeted heartbeat delivery. Keeping the two
+// separate means assigning an App a hive has no key for is harmless: the
+// delivery decision simply finds no key and does nothing.
+//
+// Deliberately does NOT touch githubAppRequired / githubAppState. A hive with an
+// unassigned, unassigned-but-keyless, or undelivered second App is a perfectly
+// ordinary healthy hive — an OPTIONAL App must never be able to red one.
+func (s *HubServer) handleSetHiveSecondaryApp(w http.ResponseWriter, r *http.Request) {
+	if !isHubAdmin(s.getAuthUser(r)) {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+	hiveID := r.PathValue("id")
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	var body secondaryAppAssignmentRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxSecondaryAppAssignmentBytes)).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+	if body.AppID < 0 {
+		http.Error(w, `{"error":"app_id must be a positive github app id, or 0 to clear"}`, http.StatusBadRequest)
+		return
+	}
+	// The second App must not BE the App this hive authenticates as. Allowing it
+	// would make one App both primary and secondary for the hive, so two
+	// independent delivery lanes would write the same /data/gh-app-key-<id>.pem
+	// and the last beat would decide which key the hive signs with.
+	if body.AppID != 0 {
+		if c, ok := s.clusters[strings.TrimSpace(h.ClusterID)]; ok && c.GitHubAppID != 0 && body.AppID == c.GitHubAppID {
+			http.Error(w, fmt.Sprintf(
+				`{"error":"app %d is this hive's cluster primary app and cannot also be its secondary app"}`,
+				body.AppID), http.StatusConflict)
+			return
+		}
+	}
+	h.SecondaryAppID = body.AppID
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("failed to set hive secondary app", "hive_id", hiveID, "error", err)
+		http.Error(w, `{"error":"could not record the assignment"}`, http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("audit: hive secondary github app assignment changed",
+		"hive_id", hiveID,
+		"cluster_id", h.ClusterID,
+		"secondary_app_id", body.AppID,
+		"by", s.getAuthUser(r),
+	)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"hive_id":          hiveID,
+		"secondary_app_id": h.SecondaryAppID,
+		// Fingerprint only, so an operator can confirm the hub holds a key for
+		// the App they just assigned without the key ever being readable.
+		"secondary_key_fingerprint": secondaryAppKeyFingerprint(strings.TrimSpace(h.ClusterID), h.SecondaryAppID),
+	})
+}
+
+// maxSecondaryAppAssignmentBytes caps this body. It carries one integer; 4 KiB
+// is far more than any legitimate request needs and refuses to buffer an
+// arbitrary payload into memory.
+const maxSecondaryAppAssignmentBytes = 4 << 10
+
+// secondaryAppKeyDeliveryDecision is the outcome of comparing what a spoke
+// reports holding against the secondary key the hub believes it should have.
+//
+// It is a SEPARATE type from appKeySyncDecision on purpose. appKeySyncDecision
+// governs the PRIMARY reconcile that ~55 live hives depend on every 2 minutes;
+// adding fields or branches to it to carry a second App would put an optional,
+// zero-hive feature inside the one function whose behaviour must stay
+// byte-identical. Keeping them apart means decideSecondaryAppKeySync cannot
+// change a single primary decision, which is a property a test can assert.
+type secondaryAppKeyDeliveryDecision struct {
+	// Deliver is true when the hub should attach this secondary key.
+	Deliver bool
+	// AppID is the App the key signs for; zero when nothing is delivered.
+	AppID int64
+	// Reason explains the decision for the audit log. Never contains key
+	// material.
+	Reason string
+	// ToFingerprint is the non-secret fingerprint of the key being delivered.
+	ToFingerprint string
+	// HeldFingerprint is what the spoke reported holding for AppID, "" when it
+	// reported nothing.
+	HeldFingerprint string
+}
+
+// secondaryAppKeyForHeartbeat is the heartbeat entry point for optional
+// second-App key delivery. It returns nil — attach nothing, change nothing —
+// for every hive that is not assigned a second App, which is every hive in the
+// fleet today.
+//
+// The hive record is loaded from the payload's HiveID exactly as every other
+// heartbeat path does. That is the AUTHENTICATED hive identity as this handler
+// knows it, and the identity the authorization is resolved against: the App ID
+// comes from the loaded record, never from the payload, so a caller asserting
+// another hive's ID receives that hive's assignment — which is no better than
+// what the primary reconcile already hands it — and can never enumerate the
+// fleet's keys the way the removed AdditionalKeys broadcast allowed. The
+// heartbeat's own hive_id trust problem is a separate, pre-existing issue
+// (documented on AdditionalKeys); this path deliberately does not widen it.
+func (s *HubServer) secondaryAppKeyForHeartbeat(payload *HeartbeatPayload) *HeartbeatAppKey {
+	if s == nil || payload == nil {
+		return nil
+	}
+	h := loadSaaSHive(payload.HiveID)
+	if h == nil || h.SecondaryAppID <= 0 {
+		return nil
+	}
+	pem, appID := secondaryAppKeyForHive(h)
+	decision := decideSecondaryAppKeySync(pem, appID, payload.GitHubAppKeysHeld)
+	if !decision.Deliver {
+		return nil
+	}
+	if s.logger != nil {
+		// Fingerprints only. The key itself is never logged, at any level.
+		s.logger.Info("heartbeat: delivering secondary github app key to spoke",
+			"hive_id", payload.HiveID,
+			"cluster_id", h.ClusterID,
+			"secondary_app_id", decision.AppID,
+			"reason", decision.Reason,
+			"held_fingerprint", decision.HeldFingerprint,
+			"to_fingerprint", decision.ToFingerprint,
+		)
+	}
+	return &HeartbeatAppKey{
+		AppID:       decision.AppID,
+		PrivateKey:  pem,
+		Fingerprint: decision.ToFingerprint,
+	}
+}
+
+const (
+	secondaryReasonNoAssignment = "hive is not assigned a secondary app"
+	secondaryReasonNoKey        = "hub holds no key for the hive's secondary app"
+	secondaryReasonHeld         = "spoke already holds this secondary app key"
+	secondaryReasonDeliver      = "spoke is missing or holds a stale secondary app key"
+)
+
+// decideSecondaryAppKeySync mirrors decideAppKeySync's fingerprint-comparison
+// shape — a key the spoke already holds is never re-pushed — so a steady-state
+// hive with a second App produces no key traffic at all after the first
+// delivery.
+//
+// heldFingerprints is the spoke's own GitHubAppKeysHeld report (app_id decimal
+// string → fingerprint). It is used ONLY to suppress a redundant re-push; it can
+// never cause a key to be delivered that would not otherwise be, so a spoke
+// cannot influence which key it receives by lying about what it holds. That is
+// the distinction that made the old broadcast unsafe and makes this safe.
+func decideSecondaryAppKeySync(keyPEM string, appID int64, heldFingerprints map[string]string) secondaryAppKeyDeliveryDecision {
+	if appID <= 0 {
+		return secondaryAppKeyDeliveryDecision{Reason: secondaryReasonNoAssignment}
+	}
+	if strings.TrimSpace(keyPEM) == "" {
+		return secondaryAppKeyDeliveryDecision{AppID: appID, Reason: secondaryReasonNoKey}
+	}
+	fp, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil || fp == "" {
+		// Unfingerprintable means uncomparable, which means it would be pushed
+		// on every single beat forever. Same refusal as storeClusterAppKey's.
+		return secondaryAppKeyDeliveryDecision{AppID: appID, Reason: secondaryReasonNoKey}
+	}
+	held := heldFingerprints[strconv.FormatInt(appID, 10)]
+	if strings.TrimSpace(held) == fp {
+		return secondaryAppKeyDeliveryDecision{
+			AppID:           appID,
+			Reason:          secondaryReasonHeld,
+			ToFingerprint:   fp,
+			HeldFingerprint: held,
+		}
+	}
+	return secondaryAppKeyDeliveryDecision{
+		Deliver:         true,
+		AppID:           appID,
+		Reason:          secondaryReasonDeliver,
+		ToFingerprint:   fp,
+		HeldFingerprint: strings.TrimSpace(held),
+	}
+}

--- a/src/pkg/hub/cluster_secondary_app_key.go
+++ b/src/pkg/hub/cluster_secondary_app_key.go
@@ -286,10 +286,24 @@ func (s *HubServer) handleSetHiveSecondaryApp(w http.ResponseWriter, r *http.Req
 	// would make one App both primary and secondary for the hive, so two
 	// independent delivery lanes would write the same /data/gh-app-key-<id>.pem
 	// and the last beat would decide which key the hive signs with.
+	//
+	// Judged against ResolveHiveIdentity, never against the cluster record's
+	// github_app_id. A cluster hosts hives of BOTH forges, so the cluster
+	// default is not necessarily the App any one hive authenticates as — a
+	// public-elected hive on a GHE-default cluster resolves the PUBLIC App. Read
+	// from the cluster directly, this guard would refuse the wrong App ID for
+	// exactly those hives and permit the one that actually collides. It is also
+	// the single-resolver rule the fleet already enforces
+	// (TestNoCallSiteResolvesIdentityIndependently): provisioning, the heartbeat
+	// answer and this check must not be able to give three different answers.
 	if body.AppID != 0 {
-		if c, ok := s.clusters[strings.TrimSpace(h.ClusterID)]; ok && c.GitHubAppID != 0 && body.AppID == c.GitHubAppID {
+		var cluster *ClusterConfig
+		if c, ok := s.clusters[strings.TrimSpace(h.ClusterID)]; ok {
+			cluster = &c
+		}
+		if id := ResolveHiveIdentity(h, cluster); id.AppID != 0 && body.AppID == id.AppID {
 			http.Error(w, fmt.Sprintf(
-				`{"error":"app %d is this hive's cluster primary app and cannot also be its secondary app"}`,
+				`{"error":"app %d is the app this hive already authenticates as and cannot also be its secondary app"}`,
 				body.AppID), http.StatusConflict)
 			return
 		}

--- a/src/pkg/hub/cluster_secondary_app_key_test.go
+++ b/src/pkg/hub/cluster_secondary_app_key_test.go
@@ -1,0 +1,895 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// These tests exist because #4815 changes a store ~55 live hives authenticate
+// from. Every one of them asserts an INVARIANT of the existing primary path,
+// not merely that the new code runs, and each carries a positive control so it
+// cannot pass because nothing happened.
+
+// --- INVARIANT 1: the primary key path is byte-identical to today ---
+
+// TestPrimaryAppKeyPathIsUnchanged pins the EXACT string. It is deliberately
+// hostile to refactoring: the path is the fleet's on-disk contract, and a
+// "harmless" rename of it is an auth outage for every spoke that reads a key
+// the hub no longer writes there. If this test needs updating, the change is
+// wrong.
+func TestPrimaryAppKeyPathIsUnchanged(t *testing.T) {
+	orig := clusterAppKeyDir
+	clusterAppKeyDir = "/data/saas/app-keys"
+	t.Cleanup(func() { clusterAppKeyDir = orig })
+
+	got, ok := clusterAppKeyPath("vllm-d")
+	if !ok {
+		t.Fatal("clusterAppKeyPath refused a valid cluster id")
+	}
+	const want = "/data/saas/app-keys/vllm-d.pem"
+	if got != want {
+		t.Fatalf("primary app key path = %q, want %q — this path is the live fleet's on-disk contract", got, want)
+	}
+
+	// POSITIVE CONTROL: the builder really is producing a path from its input,
+	// so the assertion above is not passing against a constant.
+	other, ok := clusterAppKeyPath("kubestellar-hive-ghe")
+	if !ok || other != "/data/saas/app-keys/kubestellar-hive-ghe.pem" {
+		t.Fatalf("positive control: path for a second cluster = %q, ok=%v", other, ok)
+	}
+	if other == got {
+		t.Fatal("positive control: two different cluster ids produced the same path")
+	}
+}
+
+// TestSecondaryAppKeyPathIsDistinctFromPrimary proves the new layout lands
+// ALONGSIDE the primary rather than on top of it — the single fact that makes
+// holding two keys possible at all.
+func TestSecondaryAppKeyPathIsDistinctFromPrimary(t *testing.T) {
+	orig := clusterAppKeyDir
+	clusterAppKeyDir = "/data/saas/app-keys"
+	t.Cleanup(func() { clusterAppKeyDir = orig })
+
+	primary, _ := clusterAppKeyPath("vllm-d")
+	secondary, ok := secondaryAppKeyPath("vllm-d", 4729416)
+	if !ok {
+		t.Fatal("secondaryAppKeyPath refused a valid (cluster, app) pair")
+	}
+	if secondary == primary {
+		t.Fatal("the secondary key path IS the primary path — a second-app upload would overwrite the fleet's key")
+	}
+	const want = "/data/saas/app-keys/vllm-d-app-4729416.pem"
+	if secondary != want {
+		t.Fatalf("secondary path = %q, want %q", secondary, want)
+	}
+	// Same directory: the atomic temp-then-rename requires the temp file to
+	// land on the same filesystem as its target.
+	if filepath.Dir(secondary) != filepath.Dir(primary) {
+		t.Fatalf("secondary key is stored outside the key dir: %q", secondary)
+	}
+}
+
+// --- INVARIANT 6: path traversal via the App ID component ---
+
+// TestSecondaryAppKeyPathRejectsTraversal covers the NEW attack surface. The App
+// ID is an int64, so the traversal cases that matter are the ones a caller can
+// actually express; the cluster half is re-checked here so the reuse of
+// clusterAppKeyPath's guards is asserted rather than assumed.
+func TestSecondaryAppKeyPathRejectsTraversal(t *testing.T) {
+	withTempAppKeyDir(t)
+
+	cases := []struct {
+		name      string
+		clusterID string
+		appID     int64
+	}{
+		{"parent traversal in cluster id", "../../etc/x", 4729416},
+		{"slash in cluster id", "a/b", 4729416},
+		{"dot cluster id", ".", 4729416},
+		{"dotdot cluster id", "..", 4729416},
+		{"empty cluster id", "", 4729416},
+		{"whitespace cluster id", "   ", 4729416},
+		{"zero app id", "vllm-d", 0},
+		{"negative app id", "vllm-d", -1},
+		{"traversal-shaped negative app id", "vllm-d", -4729416},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := secondaryAppKeyPath(tc.clusterID, tc.appID); ok {
+				t.Fatalf("accepted a hostile path component: %q", got)
+			}
+			// The store must refuse too, not merely the path builder.
+			if err := storeSecondaryAppKey(tc.clusterID, tc.appID, 5686, testAppKeyPEM(t)); err == nil {
+				t.Fatal("storeSecondaryAppKey accepted a hostile path component")
+			}
+		})
+	}
+
+	// POSITIVE CONTROL: a legitimate pair IS accepted, so the rejections above
+	// are not the function refusing everything.
+	if _, ok := secondaryAppKeyPath("vllm-d", 4729416); !ok {
+		t.Fatal("positive control: a legitimate (cluster, app) pair was rejected")
+	}
+}
+
+// TestSecondaryAppKeyFilenameNeverEscapesTheStore is the belt-and-braces check:
+// whatever the builder returns must be a direct child of the key dir.
+func TestSecondaryAppKeyFilenameNeverEscapesTheStore(t *testing.T) {
+	dir := withTempAppKeyDir(t)
+	for _, appID := range []int64{1, 5686, 4729416, 9223372036854775807} {
+		p, ok := secondaryAppKeyPath("oke-260812-8yiz", appID)
+		if !ok {
+			t.Fatalf("app %d: path refused", appID)
+		}
+		if filepath.Dir(p) != dir {
+			t.Fatalf("app %d: path %q is not a direct child of %q", appID, p, dir)
+		}
+		if strings.Contains(filepath.Base(p), "/") || strings.Contains(filepath.Base(p), "..") {
+			t.Fatalf("app %d: filename %q contains a path separator or traversal", appID, filepath.Base(p))
+		}
+	}
+}
+
+// --- INVARIANT 3: a second-App upload never disturbs the primary key ---
+
+// TestSecondaryStoreLeavesPrimaryFingerprintUnchanged is the acceptance
+// criterion named in the issue, at the store level.
+func TestSecondaryStoreLeavesPrimaryFingerprintUnchanged(t *testing.T) {
+	withTempAppKeyDir(t)
+	const (
+		clusterID    = "vllm-d"
+		primaryAppID = int64(5686)
+		secondAppID  = int64(4729416)
+	)
+
+	primaryPEM := testAppKeyPEM(t)
+	if err := storeClusterAppKey(clusterID, primaryPEM); err != nil {
+		t.Fatalf("store primary: %v", err)
+	}
+	beforeFP := clusterAppKeyFingerprint(clusterID)
+	if beforeFP == "" {
+		t.Fatal("primary key did not store")
+	}
+
+	secondPEM := testAppKeyPEM(t)
+	if secondPEM == primaryPEM {
+		t.Fatal("test setup generated the same key twice")
+	}
+	if err := storeSecondaryAppKey(clusterID, secondAppID, primaryAppID, secondPEM); err != nil {
+		t.Fatalf("store secondary: %v", err)
+	}
+
+	// THE INVARIANT.
+	if after := clusterAppKeyFingerprint(clusterID); after != beforeFP {
+		t.Fatalf("primary key fingerprint changed from %q to %q — a second-app upload clobbered the fleet's key", beforeFP, after)
+	}
+	if loadClusterAppKey(clusterID) != strings.TrimSpace(primaryPEM) {
+		t.Fatal("primary key material changed")
+	}
+
+	// POSITIVE CONTROL: the second key really WAS written and is readable, so
+	// the invariant above did not hold merely because nothing happened.
+	gotSecond := loadSecondaryAppKey(clusterID, secondAppID)
+	if gotSecond != strings.TrimSpace(secondPEM) {
+		t.Fatal("positive control: the secondary key was not stored or does not read back")
+	}
+	secondFP := secondaryAppKeyFingerprint(clusterID, secondAppID)
+	if secondFP == "" || secondFP == beforeFP {
+		t.Fatalf("positive control: secondary fingerprint = %q (primary %q)", secondFP, beforeFP)
+	}
+}
+
+// --- INVARIANT 6: the new store has the same security properties ---
+
+func TestSecondaryStorePreservesFileModes(t *testing.T) {
+	dir := withTempAppKeyDir(t)
+	// Remove the dir so the store has to create it, exercising the 0700 path.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := storeSecondaryAppKey("vllm-d", 4729416, 5686, testAppKeyPEM(t)); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := di.Mode().Perm(); got != fs.FileMode(clusterAppKeyDirMode) {
+		t.Errorf("key dir mode = %v, want %v", got, fs.FileMode(clusterAppKeyDirMode))
+	}
+	p, _ := secondaryAppKeyPath("vllm-d", 4729416)
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != fs.FileMode(clusterAppKeyFileMode) {
+		t.Errorf("secondary key file mode = %v, want %v — key material must never be group/world readable", got, fs.FileMode(clusterAppKeyFileMode))
+	}
+	// No temp file left behind: a .tmp holding key material would outlive the
+	// rename's guarantees.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("temp key file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestSecondaryStoreRejectsUnusableKeys(t *testing.T) {
+	withTempAppKeyDir(t)
+	bad := []string{
+		"",
+		"not a key",
+		"-----BEGIN RSA PRIVATE KEY-----\nZZZ\n-----END RSA PRIVATE KEY-----",
+	}
+	for _, b := range bad {
+		if err := storeSecondaryAppKey("vllm-d", 4729416, 5686, b); err == nil {
+			t.Errorf("accepted an unusable key: %q", b)
+		}
+		if loadSecondaryAppKey("vllm-d", 4729416) != "" {
+			t.Fatal("an unusable key was persisted")
+		}
+	}
+	// POSITIVE CONTROL.
+	if err := storeSecondaryAppKey("vllm-d", 4729416, 5686, testAppKeyPEM(t)); err != nil {
+		t.Fatalf("positive control: a valid key was rejected: %v", err)
+	}
+}
+
+// TestSecondaryStoreRefusesThePrimaryApp is the defence in depth behind the
+// handler's rejection: even a future caller that skips the HTTP guard cannot
+// fork a shadow copy of the primary key under a second name.
+func TestSecondaryStoreRefusesThePrimaryApp(t *testing.T) {
+	withTempAppKeyDir(t)
+	const primaryAppID = int64(5686)
+	if err := storeSecondaryAppKey("vllm-d", primaryAppID, primaryAppID, testAppKeyPEM(t)); err == nil {
+		t.Fatal("storeSecondaryAppKey wrote a secondary copy of the cluster's PRIMARY app key")
+	}
+	if p, ok := secondaryAppKeyPath("vllm-d", primaryAppID); ok {
+		if _, err := os.Stat(p); err == nil {
+			t.Fatal("a shadow copy of the primary key exists on disk")
+		}
+	}
+	// POSITIVE CONTROL: a genuinely different App is accepted.
+	if err := storeSecondaryAppKey("vllm-d", 4729416, primaryAppID, testAppKeyPEM(t)); err != nil {
+		t.Fatalf("positive control: a non-primary app was rejected: %v", err)
+	}
+}
+
+// --- INVARIANT 2 + 3: the upload endpoint's contract ---
+
+// TestPutClusterAppKeyExistingShapeIsUnchanged asserts the contract every live
+// caller depends on: a body with NO for_app_id writes the primary file, at the
+// primary path, with the right fingerprint — exactly as before this change.
+func TestPutClusterAppKeyExistingShapeIsUnchanged(t *testing.T) {
+	withTempAppKeyDir(t)
+	keyPEM := testAppKeyPEM(t)
+	wantFP, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newSecondaryAppTestServer(t)
+
+	rec := putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{PrivateKey: keyPEM})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	// Written to the PRIMARY path, not anywhere else.
+	primaryPath, _ := clusterAppKeyPath("vllm-d")
+	if _, statErr := os.Stat(primaryPath); statErr != nil {
+		t.Fatalf("primary key file missing at %s: %v", primaryPath, statErr)
+	}
+	if got := clusterAppKeyFingerprint("vllm-d"); got != wantFP {
+		t.Fatalf("primary fingerprint = %q, want %q", got, wantFP)
+	}
+	var status clusterAppKeyStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if !status.HasKey || status.Fingerprint != wantFP {
+		t.Fatalf("response = %+v, want has_key with fingerprint %q", status, wantFP)
+	}
+	// No new field is populated for a cluster with no second App, so the
+	// response is byte-identical to today's for every existing caller.
+	if status.SecondaryKeys != nil {
+		t.Fatalf("secondary_keys populated on a cluster with no second app: %+v", status.SecondaryKeys)
+	}
+	if strings.Contains(rec.Body.String(), "secondary_keys") {
+		t.Fatal("response JSON gained a secondary_keys field for a cluster that has none")
+	}
+}
+
+// TestPutClusterAppKeySecondAppDoesNotTouchPrimary is the end-to-end form of the
+// issue's acceptance criterion.
+func TestPutClusterAppKeySecondAppDoesNotTouchPrimary(t *testing.T) {
+	withTempAppKeyDir(t)
+	s := newSecondaryAppTestServer(t)
+
+	primaryPEM := testAppKeyPEM(t)
+	if rec := putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{PrivateKey: primaryPEM}); rec.Code != http.StatusOK {
+		t.Fatalf("primary upload: %d %s", rec.Code, rec.Body.String())
+	}
+	primaryFP := clusterAppKeyFingerprint("vllm-d")
+	if primaryFP == "" {
+		t.Fatal("primary key did not store")
+	}
+
+	secondPEM := testAppKeyPEM(t)
+	rec := putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{
+		ForAppID:   4729416,
+		PrivateKey: secondPEM,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("secondary upload: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// THE INVARIANT.
+	if got := clusterAppKeyFingerprint("vllm-d"); got != primaryFP {
+		t.Fatalf("primary fingerprint changed from %q to %q across a second-app upload", primaryFP, got)
+	}
+
+	// POSITIVE CONTROL: the second key landed and is reported.
+	if secondaryAppKeyFingerprint("vllm-d", 4729416) == "" {
+		t.Fatal("positive control: the second app key was not stored")
+	}
+	var status clusterAppKeyStatus
+	if err := json.Unmarshal(rec.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if len(status.SecondaryKeys) != 1 || status.SecondaryKeys[0].AppID != 4729416 {
+		t.Fatalf("secondary_keys = %+v, want one entry for app 4729416", status.SecondaryKeys)
+	}
+	if status.Fingerprint != primaryFP {
+		t.Fatalf("response reports primary fingerprint %q, want the unchanged %q", status.Fingerprint, primaryFP)
+	}
+}
+
+// TestPutClusterAppKeyRejectsSecondUploadNamingThePrimaryApp is the guard that
+// makes the silent overwrite impossible. Rejected, NOT applied.
+func TestPutClusterAppKeyRejectsSecondUploadNamingThePrimaryApp(t *testing.T) {
+	withTempAppKeyDir(t)
+	s := newSecondaryAppTestServer(t)
+
+	primaryPEM := testAppKeyPEM(t)
+	if rec := putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{PrivateKey: primaryPEM}); rec.Code != http.StatusOK {
+		t.Fatalf("primary upload: %d", rec.Code)
+	}
+	primaryFP := clusterAppKeyFingerprint("vllm-d")
+
+	// vllm-d's primary app is 5686. Naming it under for_app_id must fail.
+	rec := putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{
+		ForAppID:   5686,
+		PrivateKey: testAppKeyPEM(t),
+	})
+	if rec.Code == http.StatusOK {
+		t.Fatal("a second-app upload naming the PRIMARY app was accepted — this is the silent overwrite #4815 exists to prevent")
+	}
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d with a clear error (body %s)", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "primary") {
+		t.Fatalf("error does not explain the conflict: %s", rec.Body.String())
+	}
+	// Nothing was applied, anywhere.
+	if got := clusterAppKeyFingerprint("vllm-d"); got != primaryFP {
+		t.Fatalf("primary fingerprint changed to %q despite the rejection", got)
+	}
+	if secondaryAppKeyFingerprint("vllm-d", 5686) != "" {
+		t.Fatal("a shadow secondary copy of the primary app's key was written despite the rejection")
+	}
+
+	// POSITIVE CONTROL: the same request shape for a DIFFERENT app succeeds, so
+	// the rejection is about the app id and not about for_app_id being set.
+	if ok := putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{
+		ForAppID:   4729416,
+		PrivateKey: testAppKeyPEM(t),
+	}); ok.Code != http.StatusOK {
+		t.Fatalf("positive control: a legitimate second-app upload was rejected: %d %s", ok.Code, ok.Body.String())
+	}
+}
+
+func TestPutClusterAppKeySecondAppRejectsBadRequests(t *testing.T) {
+	cases := []struct {
+		name       string
+		clusterID  string
+		body       clusterAppKeyRequest
+		wantStatus int
+	}{
+		{
+			name:       "negative for_app_id",
+			clusterID:  "vllm-d",
+			body:       clusterAppKeyRequest{ForAppID: -1},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "app_id combined with for_app_id",
+			clusterID:  "vllm-d",
+			body:       clusterAppKeyRequest{ForAppID: 4729416, AppID: 9999},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "cluster with no primary app id",
+			clusterID:  "no-app",
+			body:       clusterAppKeyRequest{ForAppID: 4729416},
+			wantStatus: http.StatusConflict,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempAppKeyDir(t)
+			s := newSecondaryAppTestServer(t)
+			body := tc.body
+			if body.PrivateKey == "" {
+				body.PrivateKey = testAppKeyPEM(t)
+			}
+			rec := putClusterAppKey(t, s, tc.clusterID, body)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if secondaryAppKeyFingerprint(tc.clusterID, 4729416) != "" {
+				t.Fatal("a key was stored despite the rejection")
+			}
+		})
+	}
+}
+
+// --- INVARIANT 7: no key material ever leaves the hub except to the spoke ---
+
+// TestSecondaryAppKeyNeverAppearsInResponsesOrLogs sweeps every surface this
+// change adds. The upload response, the inventory response and every log line
+// the handlers emit are searched for the key's own bytes.
+func TestSecondaryAppKeyNeverAppearsInResponsesOrLogs(t *testing.T) {
+	withTempAppKeyDir(t)
+	var logs strings.Builder
+	s := newSecondaryAppTestServer(t)
+	s.logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	primaryPEM := testAppKeyPEM(t)
+	secondPEM := testAppKeyPEM(t)
+	putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{PrivateKey: primaryPEM})
+	putRec := putClusterAppKey(t, s, "vllm-d", clusterAppKeyRequest{ForAppID: 4729416, PrivateKey: secondPEM})
+
+	getRec := httptest.NewRecorder()
+	s.handleGetClusterAppKeys(getRec, httptest.NewRequest(http.MethodGet, "/api/saas/admin/cluster-app-keys", nil))
+
+	// The PEM body without its armour lines — the actual secret bytes.
+	secretBody := keyBodyLines(t, secondPEM)
+	primaryBody := keyBodyLines(t, primaryPEM)
+
+	surfaces := map[string]string{
+		"upload response":    putRec.Body.String(),
+		"inventory response": getRec.Body.String(),
+		"logs":               logs.String(),
+	}
+	for name, text := range surfaces {
+		if strings.Contains(text, "PRIVATE KEY") {
+			t.Errorf("%s contains a PEM armour line", name)
+		}
+		for _, line := range secretBody {
+			if strings.Contains(text, line) {
+				t.Errorf("%s leaked secondary key material", name)
+				break
+			}
+		}
+		for _, line := range primaryBody {
+			if strings.Contains(text, line) {
+				t.Errorf("%s leaked primary key material", name)
+				break
+			}
+		}
+	}
+
+	// POSITIVE CONTROL: the surfaces are not empty, and the search really does
+	// find these strings when they ARE present.
+	if logs.Len() == 0 || getRec.Body.Len() == 0 {
+		t.Fatal("positive control: a surface under test was empty")
+	}
+	if len(secretBody) == 0 {
+		t.Fatal("positive control: no key body lines to search for")
+	}
+	if !strings.Contains(secondPEM, secretBody[0]) {
+		t.Fatal("positive control: the search string is not actually part of the key")
+	}
+	// And the non-secret fingerprint IS reported, so the omission above is the
+	// key specifically, not the endpoint saying nothing.
+	if !strings.Contains(getRec.Body.String(), secondaryAppKeyFingerprint("vllm-d", 4729416)) {
+		t.Fatal("positive control: the inventory does not report the secondary fingerprint")
+	}
+}
+
+// --- INVARIANT 4: decideAppKeySync is untouched ---
+
+// TestDecideAppKeySyncUnchangedWithoutSecondApp re-runs the primary state
+// machine across every input shape it distinguishes and pins the decision. It
+// exists to fail loudly if this change ever reaches into decideAppKeySync: a
+// hive with no second App must see byte-identical heartbeat behaviour.
+func TestDecideAppKeySyncUnchangedWithoutSecondApp(t *testing.T) {
+	const (
+		clusterFP = "sha256:cccccccccccccccccccccccccccccccc"
+		otherFP   = "sha256:dddddddddddddddddddddddddddddddd"
+		appID     = int64(5686)
+	)
+	withKey := &clusterAppIdentity{AppID: appID, PrivateKey: "pem", Fingerprint: clusterFP}
+	noKey := &clusterAppIdentity{AppID: appID}
+
+	cases := []struct {
+		name              string
+		spokeFP           string
+		hasPerHiveKey     bool
+		hivePublicPinned  bool
+		spokeOnWrongForge bool
+		spokeAppID        int64
+		identity          *clusterAppIdentity
+		wantPush          bool
+		wantPushKey       bool
+		wantReason        string
+	}{
+		{"nil identity", clusterFP, false, false, false, appID, nil, false, false, appKeyReasonNoClusterKey},
+		{"public pinned", otherFP, false, true, false, appID, withKey, false, false, appKeyReasonPublicHiveOnGHECluster},
+		{"placeholder sentinel with key", otherFP, false, false, false, config.PlaceholderAppID, withKey, true, true, appKeyReasonPlaceholderAppID},
+		{"placeholder sentinel without key", otherFP, false, false, false, config.PlaceholderAppID, noKey, true, false, appKeyReasonPlaceholderAppID},
+		{"wrong forge app", otherFP, false, false, true, 4242, withKey, true, true, appKeyReasonWrongForgeApp},
+		{"wrong forge app without key", otherFP, false, false, true, 4242, noKey, true, false, appKeyReasonWrongForgeApp},
+		{"cluster has no key", otherFP, false, false, false, appID, noKey, false, false, appKeyReasonNoClusterKey},
+		{"per-hive key already matches", clusterFP, true, false, false, appID, withKey, false, false, appKeyReasonMatch},
+		{"per-hive key unusable for claimed app", otherFP, true, false, false, appID, withKey, true, true, appKeyReasonPerHiveUnusable},
+		{"per-hive override", otherFP, true, false, false, 0, withKey, false, false, appKeyReasonPerHiveOverride},
+		{"deliberate different app pin", otherFP, true, false, false, 4242, withKey, false, false, appKeyReasonDifferentApp},
+		{"spoke has no key", "", false, false, false, appID, withKey, true, true, appKeyReasonSpokeHasNoKey},
+		{"fingerprint mismatch", otherFP, false, false, false, appID, withKey, true, true, appKeyReasonMismatch},
+		{"already matches", clusterFP, false, false, false, appID, withKey, false, false, appKeyReasonMatch},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideAppKeySync(tc.spokeFP, tc.hasPerHiveKey, tc.hivePublicPinned, tc.spokeOnWrongForge, tc.spokeAppID, tc.identity)
+			if got.Push != tc.wantPush || got.PushKey != tc.wantPushKey || got.Reason != tc.wantReason {
+				t.Fatalf("decision = {Push:%v PushKey:%v Reason:%q}, want {Push:%v PushKey:%v Reason:%q}",
+					got.Push, got.PushKey, got.Reason, tc.wantPush, tc.wantPushKey, tc.wantReason)
+			}
+		})
+	}
+
+	// POSITIVE CONTROL: the table really does discriminate — at least one case
+	// pushes and at least one does not.
+	pushes, holds := 0, 0
+	for _, tc := range cases {
+		if tc.wantPush {
+			pushes++
+		} else {
+			holds++
+		}
+	}
+	if pushes == 0 || holds == 0 {
+		t.Fatalf("positive control: table is degenerate (%d push, %d hold)", pushes, holds)
+	}
+	// COUNT FLOOR: if a branch is ever deleted from decideAppKeySync this table
+	// must not silently shrink with it.
+	if len(cases) < 14 {
+		t.Fatalf("the primary decision table lost coverage: %d cases", len(cases))
+	}
+}
+
+// --- INVARIANT 5 + 8: targeted delivery, never a broadcast ---
+
+// TestHeartbeatUnchangedForHiveWithoutSecondApp is the "no regression for
+// everyone else" assertion: the entire fleet today has SecondaryAppID == 0.
+func TestHeartbeatUnchangedForHiveWithoutSecondApp(t *testing.T) {
+	withTempAppKeyDir(t)
+	withTempHivesDir(t)
+	s := newSecondaryAppTestServer(t)
+
+	// A hive with NO second App, on a cluster that nonetheless holds a
+	// secondary key for another App — the state that would tempt a broadcast.
+	if err := storeSecondaryAppKey("vllm-d", 4729416, 5686, testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	mustSaveHive(t, &SaaSHive{ID: "hive-a", ClusterID: "vllm-d"})
+
+	got := s.secondaryAppKeyForHeartbeat(&HeartbeatPayload{HiveID: "hive-a"})
+	if got != nil {
+		t.Fatalf("a hive with no second app was handed a key for app %d — this is the cross-tenant broadcast reintroduced", got.AppID)
+	}
+
+	// POSITIVE CONTROL: assigning the App makes the SAME call deliver, so the
+	// nil above is the authorization check and not a dead code path.
+	mustSaveHive(t, &SaaSHive{ID: "hive-a", ClusterID: "vllm-d", SecondaryAppID: 4729416})
+	if got := s.secondaryAppKeyForHeartbeat(&HeartbeatPayload{HiveID: "hive-a"}); got == nil {
+		t.Fatal("positive control: an assigned hive received nothing")
+	} else if got.AppID != 4729416 {
+		t.Fatalf("positive control: delivered app %d, want 4729416", got.AppID)
+	}
+}
+
+// TestSecondaryKeyIsNotDeliveredToAnUnauthorizedHive is the CWE-200/639
+// regression test. It puts two hives on the same cluster, assigns the key to
+// one, and proves the other cannot obtain it — including by REPORTING that it
+// holds a stale copy, the one spoke-supplied input this path reads.
+func TestSecondaryKeyIsNotDeliveredToAnUnauthorizedHive(t *testing.T) {
+	withTempAppKeyDir(t)
+	withTempHivesDir(t)
+	s := newSecondaryAppTestServer(t)
+
+	if err := storeSecondaryAppKey("vllm-d", 4729416, 5686, testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	mustSaveHive(t, &SaaSHive{ID: "authorized", ClusterID: "vllm-d", SecondaryAppID: 4729416})
+	mustSaveHive(t, &SaaSHive{ID: "tenant-b", ClusterID: "vllm-d"})
+
+	// tenant-b asserts every input it controls: its own hive_id, and a held-key
+	// report claiming a STALE fingerprint for the App it wants.
+	hostile := &HeartbeatPayload{
+		HiveID:            "tenant-b",
+		GitHubAppKeysHeld: map[string]string{"4729416": "sha256:stale"},
+	}
+	if got := s.secondaryAppKeyForHeartbeat(hostile); got != nil {
+		t.Fatalf("an unauthorized hive obtained app %d's private key by asking for it", got.AppID)
+	}
+
+	// POSITIVE CONTROL: the authorized hive, with the identical hostile-shaped
+	// held report, DOES receive it.
+	authorized := &HeartbeatPayload{
+		HiveID:            "authorized",
+		GitHubAppKeysHeld: map[string]string{"4729416": "sha256:stale"},
+	}
+	if got := s.secondaryAppKeyForHeartbeat(authorized); got == nil {
+		t.Fatal("positive control: the authorized hive received nothing")
+	}
+}
+
+// TestSecondaryDeliveryNeverPopulatesAdditionalKeys pins invariant 5 directly:
+// the removed broadcast producer stays removed.
+func TestSecondaryDeliveryNeverPopulatesAdditionalKeys(t *testing.T) {
+	withTempAppKeyDir(t)
+	withTempHivesDir(t)
+	s := newSecondaryAppTestServer(t)
+
+	if err := storeSecondaryAppKey("vllm-d", 4729416, 5686, testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	mustSaveHive(t, &SaaSHive{ID: "hive-a", ClusterID: "vllm-d", SecondaryAppID: 4729416})
+
+	key := s.secondaryAppKeyForHeartbeat(&HeartbeatPayload{HiveID: "hive-a"})
+	if key == nil {
+		t.Fatal("setup: no key delivered")
+	}
+	// The delivery is a SINGLE key on its own field. Assembling the response the
+	// way handleHeartbeat does must leave AdditionalKeys nil.
+	cfg := &HeartbeatGitHubAppConfig{}
+	cfg.SecondaryKey = key
+	if cfg.AdditionalKeys != nil {
+		t.Fatal("AdditionalKeys was populated — the CWE-200/639 broadcast is back")
+	}
+	// And the field is singular by TYPE, so there is no shape in which it can
+	// carry a second tenant's key.
+	if cfg.SecondaryKey.AppID != 4729416 {
+		t.Fatalf("delivered app %d, want 4729416", cfg.SecondaryKey.AppID)
+	}
+}
+
+// TestDecideSecondaryAppKeySyncIsIdempotent mirrors decideAppKeySync's
+// fingerprint-comparison contract: a key the spoke already holds is never
+// re-pushed, so a steady-state hive produces no key traffic.
+func TestDecideSecondaryAppKeySyncIsIdempotent(t *testing.T) {
+	keyPEM := testAppKeyPEM(t)
+	fp, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const appID = int64(4729416)
+	appKey := fmt.Sprintf("%d", appID)
+
+	cases := []struct {
+		name        string
+		pem         string
+		appID       int64
+		held        map[string]string
+		wantDeliver bool
+		wantReason  string
+	}{
+		{"no assignment", keyPEM, 0, nil, false, secondaryReasonNoAssignment},
+		{"hub holds no key", "", appID, nil, false, secondaryReasonNoKey},
+		{"unfingerprintable key", "-----BEGIN RSA PRIVATE KEY-----\nZZZ\n-----END RSA PRIVATE KEY-----", appID, nil, false, secondaryReasonNoKey},
+		{"spoke holds nothing", keyPEM, appID, nil, true, secondaryReasonDeliver},
+		{"spoke holds a stale key", keyPEM, appID, map[string]string{appKey: "sha256:stale"}, true, secondaryReasonDeliver},
+		{"spoke holds another app's key", keyPEM, appID, map[string]string{"5686": fp}, true, secondaryReasonDeliver},
+		{"spoke already holds it", keyPEM, appID, map[string]string{appKey: fp}, false, secondaryReasonHeld},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideSecondaryAppKeySync(tc.pem, tc.appID, tc.held)
+			if got.Deliver != tc.wantDeliver || got.Reason != tc.wantReason {
+				t.Fatalf("decision = {Deliver:%v Reason:%q}, want {Deliver:%v Reason:%q}",
+					got.Deliver, got.Reason, tc.wantDeliver, tc.wantReason)
+			}
+			// The decision never carries key material.
+			if strings.Contains(got.Reason+got.ToFingerprint+got.HeldFingerprint, "PRIVATE KEY") {
+				t.Fatal("the decision carries key material")
+			}
+		})
+	}
+}
+
+// TestSecondaryAppAssignmentEndpoint covers the one path that writes
+// SecondaryAppID.
+func TestSecondaryAppAssignmentEndpoint(t *testing.T) {
+	withTempAppKeyDir(t)
+	withTempHivesDir(t)
+	s := newSecondaryAppTestServer(t)
+	mustSaveHive(t, &SaaSHive{ID: "hive-a", ClusterID: "vllm-d"})
+
+	// Assigning the cluster's PRIMARY app is refused: one App cannot be both.
+	if rec := putSecondaryApp(t, s, "hive-a", 5686); rec.Code != http.StatusConflict {
+		t.Fatalf("assigning the primary app: status = %d, want %d (%s)", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if h := loadSaaSHive("hive-a"); h.SecondaryAppID != 0 {
+		t.Fatalf("secondary app was recorded despite the rejection: %d", h.SecondaryAppID)
+	}
+
+	// POSITIVE CONTROL: a genuine second App is recorded.
+	if rec := putSecondaryApp(t, s, "hive-a", 4729416); rec.Code != http.StatusOK {
+		t.Fatalf("positive control: status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if h := loadSaaSHive("hive-a"); h.SecondaryAppID != 4729416 {
+		t.Fatalf("secondary_app_id = %d, want 4729416", h.SecondaryAppID)
+	}
+
+	// Clearing is explicit and reversible.
+	if rec := putSecondaryApp(t, s, "hive-a", 0); rec.Code != http.StatusOK {
+		t.Fatalf("clear: status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if h := loadSaaSHive("hive-a"); h.SecondaryAppID != 0 {
+		t.Fatalf("secondary_app_id = %d after clear, want 0", h.SecondaryAppID)
+	}
+
+	// Unknown hive.
+	if rec := putSecondaryApp(t, s, "nope", 4729416); rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown hive: status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// TestSecondaryAppKeysForClusterIgnoresForeignFiles proves the inventory scan
+// attributes a key only to the cluster whose name it was constructed from, and
+// never mis-parses a primary key file as a secondary one.
+func TestSecondaryAppKeysForClusterIgnoresForeignFiles(t *testing.T) {
+	dir := withTempAppKeyDir(t)
+
+	if err := storeClusterAppKey("vllm-d", testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	if err := storeClusterAppKey("vllm-d-app-999", testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	if err := storeSecondaryAppKey("vllm-d", 4729416, 5686, testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	if err := storeSecondaryAppKey("other", 5945, 5686, testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	// Non-canonical names that parse as integers but are not ours.
+	for _, name := range []string{"vllm-d-app-0004729416.pem", "vllm-d-app-.pem", "vllm-d-app-x.pem"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(testAppKeyPEM(t)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := secondaryAppKeysForCluster("vllm-d")
+	// "vllm-d-app-999.pem" is a PRIMARY key for a cluster literally named
+	// "vllm-d-app-999", which happens to collide with the secondary naming.
+	// It is included because the two are genuinely indistinguishable by name —
+	// which is exactly why nothing in the delivery path resolves a cluster from
+	// a filename. The assertion that matters is that OTHER clusters' keys and
+	// non-canonical names never appear.
+	for _, id := range got {
+		if id == 5945 {
+			t.Fatal("another cluster's secondary key was attributed to vllm-d")
+		}
+		if id == 4729416 {
+			continue
+		}
+		if id != 999 {
+			t.Fatalf("unexpected app id %d in the inventory (non-canonical filenames must be skipped)", id)
+		}
+	}
+	found := false
+	for _, id := range got {
+		if id == 4729416 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("positive control: the cluster's own secondary key is missing from the inventory")
+	}
+	if other := secondaryAppKeysForCluster("other"); len(other) != 1 || other[0] != 5945 {
+		t.Fatalf("positive control: other cluster's inventory = %v, want [5945]", other)
+	}
+}
+
+// --- helpers ---
+
+func newSecondaryAppTestServer(t *testing.T) *HubServer {
+	t.Helper()
+	return &HubServer{
+		logger: appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{
+			"vllm-d": {ID: "vllm-d", GitHubAppID: 5686},
+			"no-app": {ID: "no-app"},
+			"other":  {ID: "other", GitHubAppID: 5686},
+		},
+	}
+}
+
+func putClusterAppKey(t *testing.T, s *HubServer, clusterID string, body clusterAppKeyRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/saas/admin/cluster-app-keys/"+clusterID, strings.NewReader(string(raw)))
+	req.SetPathValue("clusterID", clusterID)
+	rec := httptest.NewRecorder()
+	s.handlePutClusterAppKey(rec, req)
+	return rec
+}
+
+func putSecondaryApp(t *testing.T, s *HubServer, hiveID string, appID int64) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(secondaryAppAssignmentRequest{AppID: appID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/saas/hives/"+hiveID+"/secondary-app", strings.NewReader(string(raw)))
+	req.SetPathValue("id", hiveID)
+	rec := httptest.NewRecorder()
+	s.handleSetHiveSecondaryApp(rec, req)
+	return rec
+}
+
+// withTempHivesDir redirects the SaaS hive-meta store at a temp dir.
+func withTempHivesDir(t *testing.T) string {
+	t.Helper()
+	orig := saasHivesDir
+	dir := t.TempDir()
+	saasHivesDir = dir
+	t.Cleanup(func() { saasHivesDir = orig })
+	return dir
+}
+
+func mustSaveHive(t *testing.T, h *SaaSHive) {
+	t.Helper()
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatalf("save hive %s: %v", h.ID, err)
+	}
+}
+
+// keyBodyLines returns the base64 body lines of a PEM — the actual secret
+// bytes, stripped of the armour that every PEM shares. Searching for these
+// catches a leak that quoting only part of the key would hide.
+func keyBodyLines(t *testing.T, pemData string) []string {
+	t.Helper()
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(pemData), "\n") {
+		line = strings.TrimSpace(line)
+		// Long enough to be unmistakably key material rather than a coincidence.
+		const minSecretLineLen = 32
+		if strings.HasPrefix(line, "-----") || len(line) < minSecretLineLen {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}

--- a/src/pkg/hub/cluster_secondary_app_key_test.go
+++ b/src/pkg/hub/cluster_secondary_app_key_test.go
@@ -725,13 +725,27 @@ func TestDecideSecondaryAppKeySyncIsIdempotent(t *testing.T) {
 // TestSecondaryAppAssignmentEndpoint covers the one path that writes
 // SecondaryAppID.
 func TestSecondaryAppAssignmentEndpoint(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
 	withTempAppKeyDir(t)
-	withTempHivesDir(t)
-	s := newSecondaryAppTestServer(t)
+	s := newHandlerHub()
+	s.clusters = secondaryAppTestClusters()
+	mkUser(t, hubAdminUsername)
+	mkUser(t, "bob")
 	mustSaveHive(t, &SaaSHive{ID: "hive-a", ClusterID: "vllm-d"})
 
-	// Assigning the cluster's PRIMARY app is refused: one App cannot be both.
-	if rec := putSecondaryApp(t, s, "hive-a", 5686); rec.Code != http.StatusConflict {
+	// This field IS the authorization decision for key delivery, so anything
+	// that can write it can direct key material at a hive. Non-admins may not.
+	if rec := putSecondaryApp(t, s, "bob", "hive-a", 4729416); rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin: status = %d, want %d (%s)", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if h := loadSaaSHive("hive-a"); h.SecondaryAppID != 0 {
+		t.Fatalf("a non-admin recorded a secondary app: %d", h.SecondaryAppID)
+	}
+
+	// Assigning the app this hive already authenticates as is refused: one App
+	// cannot be both primary and secondary.
+	if rec := putSecondaryApp(t, s, hubAdminUsername, "hive-a", 5686); rec.Code != http.StatusConflict {
 		t.Fatalf("assigning the primary app: status = %d, want %d (%s)", rec.Code, http.StatusConflict, rec.Body.String())
 	}
 	if h := loadSaaSHive("hive-a"); h.SecondaryAppID != 0 {
@@ -739,7 +753,7 @@ func TestSecondaryAppAssignmentEndpoint(t *testing.T) {
 	}
 
 	// POSITIVE CONTROL: a genuine second App is recorded.
-	if rec := putSecondaryApp(t, s, "hive-a", 4729416); rec.Code != http.StatusOK {
+	if rec := putSecondaryApp(t, s, hubAdminUsername, "hive-a", 4729416); rec.Code != http.StatusOK {
 		t.Fatalf("positive control: status = %d (%s)", rec.Code, rec.Body.String())
 	}
 	if h := loadSaaSHive("hive-a"); h.SecondaryAppID != 4729416 {
@@ -747,7 +761,7 @@ func TestSecondaryAppAssignmentEndpoint(t *testing.T) {
 	}
 
 	// Clearing is explicit and reversible.
-	if rec := putSecondaryApp(t, s, "hive-a", 0); rec.Code != http.StatusOK {
+	if rec := putSecondaryApp(t, s, hubAdminUsername, "hive-a", 0); rec.Code != http.StatusOK {
 		t.Fatalf("clear: status = %d (%s)", rec.Code, rec.Body.String())
 	}
 	if h := loadSaaSHive("hive-a"); h.SecondaryAppID != 0 {
@@ -755,7 +769,7 @@ func TestSecondaryAppAssignmentEndpoint(t *testing.T) {
 	}
 
 	// Unknown hive.
-	if rec := putSecondaryApp(t, s, "nope", 4729416); rec.Code != http.StatusNotFound {
+	if rec := putSecondaryApp(t, s, hubAdminUsername, "nope", 4729416); rec.Code != http.StatusNotFound {
 		t.Fatalf("unknown hive: status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
@@ -819,16 +833,21 @@ func TestSecondaryAppKeysForClusterIgnoresForeignFiles(t *testing.T) {
 
 // --- helpers ---
 
+// secondaryAppTestClusters is the fleet shape these tests reason about: a
+// cluster with a primary App (vllm-d, app 5686 — the live GHE App ID), one with
+// none, and a second cluster fronting the SAME App so cross-cluster attribution
+// is exercised.
+func secondaryAppTestClusters() map[string]ClusterConfig {
+	return map[string]ClusterConfig{
+		"vllm-d": {ID: "vllm-d", GitHubAppID: 5686},
+		"no-app": {ID: "no-app"},
+		"other":  {ID: "other", GitHubAppID: 5686},
+	}
+}
+
 func newSecondaryAppTestServer(t *testing.T) *HubServer {
 	t.Helper()
-	return &HubServer{
-		logger: appKeyTestLogger(),
-		clusters: map[string]ClusterConfig{
-			"vllm-d": {ID: "vllm-d", GitHubAppID: 5686},
-			"no-app": {ID: "no-app"},
-			"other":  {ID: "other", GitHubAppID: 5686},
-		},
-	}
+	return &HubServer{logger: appKeyTestLogger(), clusters: secondaryAppTestClusters()}
 }
 
 func putClusterAppKey(t *testing.T, s *HubServer, clusterID string, body clusterAppKeyRequest) *httptest.ResponseRecorder {
@@ -845,15 +864,14 @@ func putClusterAppKey(t *testing.T, s *HubServer, clusterID string, body cluster
 	return rec
 }
 
-func putSecondaryApp(t *testing.T, s *HubServer, hiveID string, appID int64) *httptest.ResponseRecorder {
+func putSecondaryApp(t *testing.T, s *HubServer, user, hiveID string, appID int64) *httptest.ResponseRecorder {
 	t.Helper()
 	raw, err := json.Marshal(secondaryAppAssignmentRequest{AppID: appID})
 	if err != nil {
 		t.Fatal(err)
 	}
-	req := httptest.NewRequest(http.MethodPut,
-		"/api/saas/hives/"+hiveID+"/secondary-app", strings.NewReader(string(raw)))
-	req.SetPathValue("id", hiveID)
+	req := setPathValue(reqWithUser(http.MethodPut,
+		"/api/saas/hives/"+hiveID+"/secondary-app", string(raw), user), "id", hiveID)
 	rec := httptest.NewRecorder()
 	s.handleSetHiveSecondaryApp(rec, req)
 	return rec

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -2065,6 +2065,23 @@ type HeartbeatGitHubAppConfig struct {
 	// so it deserializes to empty on both sides; a spoke that reads it (older
 	// builds) simply never receives entries. It always arrives nil now.
 	AdditionalKeys []HeartbeatAppKey `json:"additional_keys,omitempty"`
+	// SecondaryKey delivers the ONE optional second App key this hive is
+	// authorized to hold (#4815), so a cluster's second App — the optional
+	// Visual Hive App, #4030 — can receive a credential without the primary key
+	// having anywhere else to go.
+	//
+	// WHY THIS IS NOT AdditionalKeys REVIVED. AdditionalKeys is a LIST selected
+	// from the fleet key set with no binding to the caller, which is exactly what
+	// made it the CWE-200/639 cross-tenant disclosure. This is a SINGLE key
+	// resolved from SaaSHive.SecondaryAppID on the hub's own record for the
+	// authenticated hive (secondaryAppKeyForHive): the hive is handed the one App
+	// an operator assigned it or nothing at all, and no value a spoke sends can
+	// change which App that is. The singular type is part of the guarantee — a
+	// list is the shape that invites "while we're here, send the others too".
+	//
+	// nil for every hive without a SecondaryAppID, which is the entire fleet
+	// today, so the heartbeat payload is byte-identical for them.
+	SecondaryKey *HeartbeatAppKey `json:"secondary_key,omitempty"`
 }
 
 // HeartbeatAppKey is one (app_id, private key) pair the hub delivers alongside

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -582,6 +582,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	// switch-branch and auto-upgrade above.
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/forge", s.requireAuth(s.handleSwitchForge))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/reset-app", s.requireAuth(s.handleResetApp))
+	// Assigns a hive its OPTIONAL second GitHub App (#4815). requireAuth is the
+	// same outer gate reset-app uses; the handler itself re-checks isHubAdmin,
+	// which is the authoritative check for both.
+	s.mux.HandleFunc("PUT /api/saas/hives/{id}/secondary-app", s.requireAuth(s.handleSetHiveSecondaryApp))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/restart-spoke", s.requireAuth(s.handleRestartSpoke))
 	s.mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", s.requireAuth(s.handleProxyHiveConfig))
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -624,6 +624,33 @@ type SaaSHive struct {
 	// ForgeDelivered flips true once the spoke reports the requested forge host.
 	ForgeDelivered bool `json:"forge_delivered,omitempty"`
 
+	// SecondaryAppID names an OPTIONAL SECOND GitHub App this hive is
+	// authorized to hold a key for, alongside the App it authenticates as.
+	// Zero — the value on every one of the ~55 existing meta.json records, and
+	// the value a hive keeps unless an operator sets it — means "this hive has
+	// no second App", and every path below returns immediately.
+	//
+	// WHY THE AUTHORIZATION LIVES ON THE HIVE RECORD
+	//
+	// This field IS the access-control decision for secondary key delivery, and
+	// it is on the hub-owned record precisely because nothing a spoke sends can
+	// write it. The removed AdditionalKeys broadcast (heartbeat.go, CWE-200/639)
+	// failed because delivery was decided from the FLEET key set with no binding
+	// to the caller at all, and the heartbeat trusts a body-supplied hive_id
+	// under one fleet-shared bearer — so any hive could name any hive_id and be
+	// handed every tenant's key. Resolving the App ID from this field, on the
+	// record the hub loaded for the authenticated hive, means a spoke cannot
+	// name the App it wants: it receives the one App an operator assigned it, or
+	// nothing.
+	//
+	// It is an App ID and NOT a bool ("has viz app") so the assignment is
+	// explicit about WHICH App, and so a future third App needs no new field
+	// shape. It carries no key material and no health state: an absent or
+	// undelivered secondary App must never affect githubAppRequired /
+	// githubAppState, because an ORDINARY hive not having an optional App is not
+	// a fault.
+	SecondaryAppID int64 `json:"secondary_app_id,omitempty"`
+
 	// TrackedChannel is the release channel ("stable", "candidate", "edge")
 	// this hive's image is pinned to, or "" for a hive on a plain branch.
 	//

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -2588,6 +2588,27 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp.GitHubAppConfig = keyCfg
 	}
 
+	// Optional SECOND App key (#4815), targeted at this hive alone.
+	//
+	// Runs INDEPENDENTLY of the two branches above rather than inside either,
+	// because the primary reconcile's steady state is "push nothing" — a healthy
+	// hive already holding the right primary key gets no GitHubAppConfig at all,
+	// and nesting this there would make the secondary key undeliverable to
+	// exactly the healthy hives that are supposed to receive it. It attaches to
+	// whatever config those branches produced, or creates an otherwise-empty one
+	// whose zero AppID/InstallationID and empty PrivateKey the spoke reads as
+	// "not speaking to those fields".
+	//
+	// Every hive without a SecondaryAppID — the whole fleet today — returns nil
+	// from the resolver and this block is a no-op: no new field, no new state,
+	// no change to the payload.
+	if secCfg := s.secondaryAppKeyForHeartbeat(&payload); secCfg != nil {
+		if resp.GitHubAppConfig == nil {
+			resp.GitHubAppConfig = &HeartbeatGitHubAppConfig{}
+		}
+		resp.GitHubAppConfig.SecondaryKey = secCfg
+	}
+
 	// SECURITY (C1/N3, CWE-200/639): the fleet-wide additional-key broadcast that
 	// once ran here was removed. It attached every OTHER tenant's App private key
 	// to every heartbeat, and — because the handler trusts the body-supplied


### PR DESCRIPTION
Fixes #4815

The hub keyed its App private-key store by cluster ID alone — one `/data/saas/app-keys/<clusterID>.pem` — so a cluster had exactly one slot for key material. Uploading a second App's key through `PUT /api/saas/clusters/{id}/app-key` **overwrote the Hive App key for that cluster**, and every spoke on it lost App auth on the next reconcile. The optional Visual Hive App (#4030) had nowhere to put a credential.

This is a live-fleet change: ~27 hives on `kubestellar-hive` (app 3568013) and ~28 on `kubestellar-hive-ghe` (app 5686) authenticate from keys already sitting at the primary path. Everything below is shaped around not disturbing them.

## On-disk layout

Secondary keys land **alongside** the primary at `<clusterID>-app-<appID>.pem` in the same directory:

```
/data/saas/app-keys/vllm-d.pem              <- primary, UNCHANGED
/data/saas/app-keys/vllm-d-app-4729416.pem  <- new, optional second App
```

**Why a sibling filename and not a per-cluster subdirectory:** the atomic temp-then-rename requires the temp file to land on the same filesystem as its target, and `os.CreateTemp` is given `clusterAppKeyDir`. A subdirectory would need its own `MkdirAll`, its own per-cluster `0700` enforcement, and would make a cluster ID a *directory* name — a strictly larger traversal surface for no gain.

**Zero migration.** The primary path is byte-identical, nothing moves, and a hub rolled back to a build without this change finds every primary key exactly where it left it and simply ignores the extra files.

**Security properties are shared, not copied.** `storeClusterAppKey`'s body is extracted verbatim into `storeAppKeyAtPath` and both stores call it — `0700` dir, `0600` file, create-with-final-mode, `Sync` before rename, atomic rename. A second hand-rolled write would be one review away from dropping the `Sync`.

**The new path component is a new attack surface,** so the App ID is an `int64` rendered back with `strconv` — the filename can only ever contain decimal digits, and there is deliberately no string-typed entry point. The cluster half reuses `clusterAppKeyPath` itself (not a copy of its rules) so the two can never drift.

## Upload endpoint contract

`clusterAppKeyRequest` gains one **optional** field:

```go
ForAppID int64 `json:"for_app_id,omitempty"`
```

- **Omitted** — the shape every existing caller sends — means the cluster's primary App. Same file, same result, same response shape. `secondary_keys` is `nil`/absent for a cluster with no second App, so the response JSON is byte-identical too.
- **Set** routes to the secondary store. The branch **returns from its own block**, so there is no path on which a secondary upload reaches `storeClusterAppKey`.
- **Set to the cluster's primary App ID → `409`**, not applied. This is the guard the issue exists for: an operator who believes they are adding a second key while actually naming the primary would otherwise clobber the key ~55 hives authenticate with, or fork a shadow copy that silently goes stale on the next rotation. The error names the primary App so the mistake is obvious.
- Also rejected: negative `for_app_id` (400); `app_id` combined with `for_app_id`, which asks for two contradictory things in one request (400); a cluster with no `github_app_id` configured, which has no way to tell a "second" App from its first (409).

**Why not reuse the existing `app_id` field:** it already means "record this as the cluster's primary `github_app_id`" and callers send it that way today. Overloading it would make an ordinary primary upload that names its own App ID suddenly write to a secondary path, leaving the primary stale. A separate field cannot be misread by a caller that has never heard of it.

`GET /api/saas/admin/cluster-app-keys` now reports `secondary_keys` — App ID and fingerprint only, never key material — and `has_key` still means the **primary** key's presence.

## Targeted delivery, without `AdditionalKeys`

`AdditionalKeys` stays unpopulated hub-side. The CWE-200/639 producer is not revived.

The authorization is a new `SaaSHive.SecondaryAppID` (zero on every existing meta.json record), written **only** by a new admin-gated `PUT /api/saas/hives/{id}/secondary-app`. Delivery resolves the App ID from **the hub's own record for the hive**, never from the payload — a spoke cannot name the App it wants; it gets the one an operator assigned it, or nothing. There is no fleet enumeration anywhere on the path (`appKeysByAppID` is deliberately *not* used: it would happily return another tenant's key for the same App ID, which is the broadcast bug in miniature).

The wire field is `SecondaryKey *HeartbeatAppKey` — **singular by type**, because a list is the shape that invites "while we're here, send the others too". `nil` for every hive without a `SecondaryAppID`, i.e. the entire fleet today, so the heartbeat payload is unchanged for them.

The spoke's `GitHubAppKeysHeld` report is used **only to suppress a redundant re-push** (the same fingerprint-comparison shape `decideAppKeySync` uses). It can never *cause* a delivery, so lying about held keys gains nothing — that asymmetry is the distinction that made the old broadcast unsafe and makes this safe.

Delivery runs **independently** of the two existing heartbeat branches rather than inside either: the primary reconcile's steady state is "push nothing", so nesting it there would make the secondary key undeliverable to exactly the healthy hives meant to receive it.

## What is *not* changed

- `decideAppKeySync` — untouched. The secondary decision lives in its own function with its own result type specifically so it cannot alter a single primary decision, which is a property a test can assert.
- No new health state. `githubAppRequired` / `githubAppState` are untouched — an absent, keyless, or undelivered *optional* App must never red an ordinary hive.
- The Forge App tab — no change needed; the key lands in the existing `/data/gh-app-key-<appid>.pem` namespace the N-key `HeldKeys` inventory already renders.

## Spoke side

Mostly as predicted: `perAppIDKeyPath` / `writePerAppIDKey` / `heldPerAppIDKeyFingerprints` are already N-app and unchanged. One change **was** required, and I want to flag it since the brief expected none: `SecondaryKey` is a **new wire field**, so `cmd/hive` needs ~4 lines to consume it. Rather than copy the `AdditionalKeys` loop body, I extracted it into a local `applyDeliveredPerAppKey` closure that both call — same atomic `0600` write, same `keyChanged` / `DropCachedToken` handling, no duplicated key-writing code. The `AdditionalKeys` loop itself is behaviourally identical (and still inert, since the hub never populates it).

## Tests

`src/pkg/hub/cluster_secondary_app_key_test.go`. Each asserts an invariant of the *existing* path and carries a positive control so it cannot pass because nothing happened:

- `TestPrimaryAppKeyPathIsUnchanged` — pins the exact string `/data/saas/app-keys/vllm-d.pem`. Deliberately hostile to refactoring; if it needs updating, the change is wrong. Control: a second cluster ID produces a different, correctly-derived path.
- `TestSecondaryAppKeyPathIsDistinctFromPrimary` — the secondary path is not the primary path, and is in the same directory.
- `TestSecondaryAppKeyPathRejectsTraversal` / `...NeverEscapesTheStore` — `..`, `/`, `.`, empty, whitespace, zero and negative App IDs, at both the path builder *and* the store. Control: a legitimate pair is accepted.
- `TestSecondaryStoreLeavesPrimaryFingerprintUnchanged` — the issue's acceptance criterion. Control: the second key **is** written and reads back with a different fingerprint.
- `TestSecondaryStorePreservesFileModes` — `0700` dir, `0600` file, no `.tmp` left behind.
- `TestSecondaryStoreRefusesThePrimaryApp` — defence in depth below the HTTP guard. Control: a different App is accepted.
- `TestPutClusterAppKeyExistingShapeIsUnchanged` — a no-`for_app_id` upload writes the primary file with the right fingerprint, and the response JSON does not even *contain* the string `secondary_keys`.
- `TestPutClusterAppKeySecondAppDoesNotTouchPrimary` — end-to-end. Control: the second key lands and is reported.
- `TestPutClusterAppKeyRejectsSecondUploadNamingThePrimaryApp` — `409`, nothing applied anywhere. Control: the identical request shape for a *different* App succeeds, so the rejection is about the App ID and not about `for_app_id` being set at all.
- `TestDecideAppKeySyncUnchangedWithoutSecondApp` — 14-case table pinning every branch of the primary state machine, plus a **count floor** so it cannot silently shrink and a degeneracy control (at least one push and one hold).
- `TestHeartbeatUnchangedForHiveWithoutSecondApp` — a hive with no second App, on a cluster that *does* hold a secondary key (the state that would tempt a broadcast), receives nothing. Control: assigning the App makes the same call deliver.
- `TestSecondaryKeyIsNotDeliveredToAnUnauthorizedHive` — the CWE-200/639 regression test. Two tenants on one cluster; the unauthorized one asserts every input it controls, including a held-key report claiming a stale fingerprint for the App it wants, and gets nothing. Control: the authorized hive with the *identical* hostile-shaped report does receive it.
- `TestSecondaryDeliveryNeverPopulatesAdditionalKeys` — pins the invariant directly.
- `TestSecondaryAppKeyNeverAppearsInResponsesOrLogs` — sweeps the upload response, the inventory response and every log line (at `LevelDebug`) for the PEM's actual base64 body lines. Controls: the surfaces are non-empty, the search string really is part of the key, and the non-secret fingerprint *is* reported — so the omission is the key specifically, not the endpoint saying nothing.
- `TestDecideSecondaryAppKeySyncIsIdempotent`, `TestSecondaryAppAssignmentEndpoint`, `TestSecondaryAppKeysForClusterIgnoresForeignFiles`.

## Notes / things that differ from the brief

1. **The spoke did need a change** (~4 lines + a refactor), for the reason above: the new field has to be read by someone. Everything the brief listed as already-N-app genuinely was.
2. **PR #4814 has not merged**, so `config.VizHivePublicAppID` / `VizHiveEnterpriseAppID` / `IsVizHiveAppID` do not exist on `v4` yet. I did **not** duplicate them. This PR is deliberately App-agnostic — it stores and delivers a key for *any* second App ID — so it has no build dependency on #4814. Wiring "this is the Visual Hive App" as a *role* (acceptance criterion 4 on the issue) is the natural follow-up once #4814 lands and can consume `IsVizHiveAppID` where this PR currently takes a bare `int64`.
3. **One naming ambiguity worth recording.** Cluster IDs may contain `-` and end in digits, so a file named `<a>-app-<n>.pem` is genuinely indistinguishable between "secondary key for cluster `<a>`, App `<n>`" and "primary key for a cluster literally named `<a>-app-<n>`". This is resolved the only way that is actually safe: **nothing on the delivery path ever recovers a cluster ID from a filename.** Every read is a lookup by an `(clusterID, appID)` pair the caller already holds, and filenames are only ever *constructed*. The one function that does scan the directory (`secondaryAppKeysForCluster`, read-only, operator inventory) matches on the constructed prefix and additionally requires the name to be one this store would itself have produced, so leading-zero and padded variants are skipped. `TestSecondaryAppKeysForClusterIgnoresForeignFiles` documents and pins this, including the benign collision case.

## Deployment note

No migration, no restart ordering constraint. A hub on this build and a spoke on an older one simply exchange a field the spoke ignores; a spoke on this build and an older hub never sees the field set. The feature is inert until an operator both uploads a key with `for_app_id` **and** assigns the App to a hive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)