### PR TITLE
🌱 fix(github): skip byte-identical advisory digest rewrites, keep staleness + write-through honest

### DIFF
--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -140,6 +141,15 @@ const (
 	// one audit pulse per ~50 minutes, enough to show the loop is alive without
 	// flooding the dashboard audit log.
 	advisoryDigestAuditInterval = 50
+	// advisoryDigestWriteThroughInterval bounds how many consecutive
+	// unchanged-digest cycles may be skipped before a real write is forced
+	// (#4818). A skipped cycle proves a PRIOR successful write, not current
+	// write permission, so without a periodic write-through a 403 regression
+	// (App loses issues:write, repo dropped from the installation) would stay
+	// invisible for as long as the digest stayed quiet. At ~one cycle a minute
+	// this forces roughly one real write per hour — enough to keep the
+	// App-banner logic honest while still eliminating ~98% of the no-op edits.
+	advisoryDigestWriteThroughInterval = 60
 )
 
 // PostAdvisoryDigest updates the existing digest comment on the advisory issue,
@@ -160,6 +170,36 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	// mention and neither pass weakens the other.
 	digest = advisory.NeutralizeMentions(digest)
 	digest = truncateDigest(logscrub.ScrubString(digest))
+
+	// Skip-if-unchanged guard (#4818): the digest is re-rendered ~once a
+	// minute, and at steady state the body is byte-identical cycle after
+	// cycle — rewriting the pinned comment anyway burned ~1,440 no-op GitHub
+	// writes/day. Hash the FINAL body (post-scrub, post-truncation — exactly
+	// the bytes that would go over the wire) and skip the whole forge
+	// round-trip when it matches the last body this process successfully
+	// wrote. Returning nil is deliberate: an unchanged skip is a HEALTHY
+	// cycle, so the caller's success path still advances the
+	// advisory-staleness freshness record (RecordAdvisoryPost). Three cases
+	// always write: the first post after process start (no hash yet), a
+	// changed body, and the periodic write-through that re-proves write
+	// permission (see advisoryDigestWriteThroughInterval).
+	key := fmt.Sprintf("%s/%s#%d", owner, repoName, issueNum)
+	digestHash := fmt.Sprintf("%x", sha256.Sum256([]byte(digest)))
+	c.advisoryMu.Lock()
+	if c.advisoryDigestSkips == nil {
+		c.advisoryDigestSkips = make(map[string]int)
+	}
+	if c.advisoryDigestHashes[key] == digestHash &&
+		c.advisoryDigestSkips[key] < advisoryDigestWriteThroughInterval-1 {
+		c.advisoryDigestSkips[key]++
+		skips := c.advisoryDigestSkips[key]
+		c.advisoryMu.Unlock()
+		c.logger.Debug("advisory digest unchanged — skipping forge write",
+			slog.String("repo", repo), slog.Int("issue", issueNum),
+			slog.Int("consecutive_skips", skips))
+		return nil
+	}
+	c.advisoryMu.Unlock()
 
 	commentID, err := c.findDigestComment(ctx, owner, repoName, issueNum)
 	if err != nil {
@@ -193,7 +233,15 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	if c.advisoryDigestPosts == nil {
 		c.advisoryDigestPosts = make(map[string]int)
 	}
-	key := fmt.Sprintf("%s/%s#%d", owner, repoName, issueNum)
+	if c.advisoryDigestHashes == nil {
+		c.advisoryDigestHashes = make(map[string]string)
+	}
+	// Record the hash only after a SUCCESSFUL write (errors returned above),
+	// so a failed edit keeps being retried every cycle rather than skipped as
+	// "already posted". Reset the skip streak: the write-through clock starts
+	// over from any real write.
+	c.advisoryDigestHashes[key] = digestHash
+	c.advisoryDigestSkips[key] = 0
 	c.advisoryDigestPosts[key]++
 	count := c.advisoryDigestPosts[key]
 	c.advisoryMu.Unlock()

--- a/src/pkg/github/advisory_skip_test.go
+++ b/src/pkg/github/advisory_skip_test.go
@@ -1,0 +1,188 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Tests for the skip-if-unchanged guard on PostAdvisoryDigest (#4818): a
+// byte-identical digest must not be rewritten to the forge every ~60s, but
+// the guard must never mask a changed body, a failed write, or a permission
+// regression (periodic write-through).
+
+// digestCountingServer serves the advisory-digest comment endpoints and
+// counts every request class the guard is supposed to eliminate.
+type digestCountingServer struct {
+	*httptest.Server
+	listCalls  int // GET  /issues/N/comments (findDigestComment)
+	editCalls  int // PATCH /issues/comments/ID
+	editStatus int // response code for PATCH; 200 by default
+}
+
+func newDigestCountingServer(t *testing.T, org, repo string) *digestCountingServer {
+	t.Helper()
+	s := &digestCountingServer{editStatus: http.StatusOK}
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/10/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			s.listCalls++
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"id": 555, "body": advisoryDigestPrefix + " — old content"},
+			})
+		}
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/555", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			s.editCalls++
+			if s.editStatus != http.StatusOK {
+				w.WriteHeader(s.editStatus)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{"id": 555})
+		}
+	})
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestPostAdvisoryDigest_UnchangedSkipsForgeWrite(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	srv := newDigestCountingServer(t, org, repo)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	digest := advisoryDigestPrefix + "\nsteady-state content"
+	// First post after process start must always write.
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, digest); err != nil {
+		t.Fatalf("first post: %v", err)
+	}
+	if srv.editCalls != 1 {
+		t.Fatalf("first post: editCalls = %d, want 1", srv.editCalls)
+	}
+
+	// Byte-identical repeats: no edit AND no comment-list read — the whole
+	// forge round-trip is skipped. Must still return nil (a skipped cycle is
+	// a healthy cycle: the caller's success path advances RecordAdvisoryPost,
+	// the advisory-staleness freshness record — see cmd/hive/main.go).
+	for i := 0; i < 5; i++ {
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, digest); err != nil {
+			t.Fatalf("skipped cycle %d must return nil (staleness gate), got: %v", i, err)
+		}
+	}
+	if srv.editCalls != 1 {
+		t.Errorf("after 5 unchanged cycles: editCalls = %d, want 1 (no rewrites)", srv.editCalls)
+	}
+	if srv.listCalls != 1 {
+		t.Errorf("after 5 unchanged cycles: listCalls = %d, want 1 (skip avoids the read too)", srv.listCalls)
+	}
+}
+
+func TestPostAdvisoryDigest_ChangedBodyWritesExactlyOnce(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	srv := newDigestCountingServer(t, org, repo)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, advisoryDigestPrefix+"\nversion A"); err != nil {
+		t.Fatalf("post A: %v", err)
+	}
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, advisoryDigestPrefix+"\nversion B"); err != nil {
+		t.Fatalf("post B: %v", err)
+	}
+	if srv.editCalls != 2 {
+		t.Errorf("changed body: editCalls = %d, want 2 (exactly one edit per distinct body)", srv.editCalls)
+	}
+	// And the new body immediately becomes the skip baseline.
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, advisoryDigestPrefix+"\nversion B"); err != nil {
+		t.Fatalf("repeat B: %v", err)
+	}
+	if srv.editCalls != 2 {
+		t.Errorf("repeat of B: editCalls = %d, want 2 (unchanged repeat skipped)", srv.editCalls)
+	}
+}
+
+func TestPostAdvisoryDigest_WriteThroughFiresOnNthCycle(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	srv := newDigestCountingServer(t, org, repo)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	digest := advisoryDigestPrefix + "\nquiet hive"
+	// Cycle 1 writes; cycles 2..N-1 skip; cycle N (interval-th consecutive
+	// unchanged cycle) must write through so a 403/permission regression
+	// still surfaces within the interval.
+	total := advisoryDigestWriteThroughInterval + 1
+	for i := 0; i < total; i++ {
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, digest); err != nil {
+			t.Fatalf("cycle %d: %v", i+1, err)
+		}
+	}
+	if srv.editCalls != 2 {
+		t.Errorf("after %d unchanged cycles: editCalls = %d, want 2 (initial + one write-through)", total, srv.editCalls)
+	}
+	// The write-through resets the streak: the very next unchanged cycle
+	// skips again.
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, digest); err != nil {
+		t.Fatalf("post-write-through cycle: %v", err)
+	}
+	if srv.editCalls != 2 {
+		t.Errorf("cycle after write-through: editCalls = %d, want 2 (streak reset, skip resumes)", srv.editCalls)
+	}
+}
+
+func TestPostAdvisoryDigest_FailedWriteIsNotRecordedAsPosted(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	srv := newDigestCountingServer(t, org, repo)
+	srv.editStatus = http.StatusForbidden
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	digest := advisoryDigestPrefix + "\nnever landed"
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, digest); err == nil {
+		t.Fatal("expected error from 403 edit")
+	}
+	// The hash is recorded only on SUCCESS, so the retry must hit the forge
+	// again rather than skipping a body that never landed.
+	srv.editStatus = http.StatusOK
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, digest); err != nil {
+		t.Fatalf("retry after failure: %v", err)
+	}
+	if srv.editCalls != 2 {
+		t.Errorf("editCalls = %d, want 2 (failed write must be retried, not skipped)", srv.editCalls)
+	}
+}
+
+func TestPostAdvisoryDigest_SkipKeyedPerIssue(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	srv := newDigestCountingServer(t, org, repo)
+	// Second issue (#11) with its own comment endpoints.
+	var issue11Edits int
+	srv.Config.Handler.(*http.ServeMux).HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/11/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"id": 777, "body": advisoryDigestPrefix + " — old"},
+			})
+		}
+	})
+	srv.Config.Handler.(*http.ServeMux).HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/777", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			issue11Edits++
+			json.NewEncoder(w).Encode(map[string]any{"id": 777})
+		}
+	})
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	digest := advisoryDigestPrefix + "\nsame body, two issues"
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, digest); err != nil {
+		t.Fatalf("issue 10: %v", err)
+	}
+	// Same body, DIFFERENT issue: the hash is keyed per owner/repo#issue, so
+	// this must be a first-write for #11, not a skip inherited from #10.
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 11, digest); err != nil {
+		t.Fatalf("issue 11: %v", err)
+	}
+	if issue11Edits != 1 {
+		t.Errorf("issue 11 editCalls = %d, want 1 (hash must not be shared across issues)", issue11Edits)
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -135,6 +135,20 @@ type Client struct {
 	// advisoryMu.
 	advisoryMu          sync.Mutex
 	advisoryDigestPosts map[string]int
+	// advisoryDigestHashes holds, per "owner/repo#issue", the content hash of
+	// the last digest body SUCCESSFULLY written to the forge (#4818). When the
+	// next cycle renders a byte-identical body, PostAdvisoryDigest skips the
+	// EditComment call entirely — at steady state that saves ~1,440 no-op
+	// GitHub writes/day. Only successful writes record a hash, so a failed
+	// write keeps being retried. Guarded by advisoryMu.
+	advisoryDigestHashes map[string]string
+	// advisoryDigestSkips counts consecutive skipped-because-unchanged cycles
+	// per key since the last real write. Once it reaches
+	// advisoryDigestWriteThroughInterval-1 the next cycle writes through even
+	// if unchanged, so permission regressions (e.g. a 403 after the App loses
+	// issues:write) still surface within ~an hour instead of never. Guarded by
+	// advisoryMu.
+	advisoryDigestSkips map[string]int
 }
 
 func (c *Client) SetCanaryScanner(enabled, failClosed bool, reg *ioscan.CanaryRegistry, onLeak func(ioscan.CanaryLeak)) {


### PR DESCRIPTION
Fixes #4818.

`PostAdvisoryDigest` rewrote the pinned digest comment every ~60s even when byte-identical — ~1,440 no-op forge writes/day.

**Change** (src/pkg/github/advisory.go + client.go fields): hash the final body (post-scrub/post-truncation, exactly the wire bytes) per `owner/repo#issue` under `advisoryMu`; when unchanged, skip the entire forge round-trip (the `findDigestComment` list read too, not just the edit).

**Invariants from the issue, all pinned by tests** (counting fake server, `advisory_skip_test.go`):
- **Staleness gate intact**: a skipped cycle returns `nil` — the caller in `cmd/hive/main.go` treats it as success and still calls `RecordAdvisoryPost`/`RecordAdvisoryOverflow`, so `AdvisoryLastPostedAt` advances on quiet hives. No caller change needed.
- **First post after process start always writes** (no hash recorded yet).
- **Failed writes are never recorded** — hash is stored only after a successful edit, so a 403/500 keeps retrying every cycle.
- **Periodic write-through**: every 60th consecutive unchanged cycle (~hourly at 60s cadence) writes anyway, so permission regressions still surface and the App-banner clearing logic keys off a genuinely fresh write; streak resets after any real write.
- Hash keyed per issue — same body on a different issue is a first write.

**Mutation-checked**: disabling the write-through bound and removing hash-recording each fail the suite. `pkg/github` coverage 92.5% (floor 90), full package green.
