### PR TITLE
fix: skip unchanged advisory digest edits

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6177,13 +6177,16 @@ func runEvalCycle(
 							}
 						}
 					} else {
-						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")
-						// Record the fresh, successful digest post so the hub's
-						// advisory-staleness gate stays satisfied for this hive.
+						logger.Info("advisory digest cycle succeeded", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")
+						// Record the fresh, successful digest cycle so the hub's
+						// advisory-staleness gate stays satisfied for this hive. A
+						// byte-identical body may have skipped the forge mutation;
+						// PostAdvisoryDigest returns nil for that healthy case and
+						// periodically writes through to re-check permission.
 						dashSrv.RecordAdvisoryPost(digest.TotalCount)
 						dashSrv.RecordAdvisoryOverflow(digest.OverflowCount)
-						// A successful write proves the app is installed AND has
-						// write access — clear BOTH the perm issue and the
+						// A successful cycle is backed by a prior or current App
+						// write, so clear BOTH the perm issue and the
 						// app-required banner flag. Previously only the perm
 						// issue was cleared, so githubAppRequired (set true at
 						// startup or on an early transient failure) stuck on

--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -134,16 +135,17 @@ const (
 	advisoryDigestPrefix    = "## 🐝 Advisory Digest"
 	githubCommentCharLimit  = 65536
 	truncationFooterPadding = 200
-	// advisoryDigestAuditInterval is how often (in digest posts) an
-	// advisory_commented audit entry is emitted, in addition to the very first
-	// post. The digest is refreshed ~once a minute; a value of 50 yields roughly
-	// one audit pulse per ~50 minutes, enough to show the loop is alive without
-	// flooding the dashboard audit log.
+	// advisoryDigestAuditInterval is both the unchanged-body write-through
+	// interval and the cadence for advisory_commented audit entries. The digest
+	// is refreshed ~once a minute; a value of 50 yields roughly one real write
+	// and audit pulse per ~50 minutes. The write-through ensures permission
+	// regressions still surface while suppressing redundant forge mutations.
 	advisoryDigestAuditInterval = 50
 )
 
 // PostAdvisoryDigest updates the existing digest comment on the advisory issue,
-// or creates one if none exists. This prevents duplicate comments on each eval cycle.
+// or creates one if none exists. An unchanged body returns nil without a forge
+// mutation, except for periodic write-through cycles that verify write access.
 func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum int, digest string) error {
 	if c == nil {
 		return ErrNoGitHubClient
@@ -160,6 +162,29 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	// mention and neither pass weakens the other.
 	digest = advisory.NeutralizeMentions(digest)
 	digest = truncateDigest(logscrub.ScrubString(digest))
+	key := fmt.Sprintf("%s/%s#%d", owner, repoName, issueNum)
+	digestHash := sha256.Sum256([]byte(digest))
+
+	// A body known to match the last successful write needs no forge mutation.
+	// Treat the skip as a successful cycle (nil return), so the caller refreshes
+	// AdvisoryLastPostedAt and clears stale App-required state just as it does
+	// after a write. Every interval-th cycle deliberately writes through to
+	// detect permission regressions. The first call after process start always
+	// writes because the hash cache is empty.
+	c.advisoryMu.Lock()
+	previousHash, known := c.advisoryDigestHashes[key]
+	count := c.advisoryDigestCycles[key]
+	unchanged := known && previousHash == digestHash
+	writeThrough := (count+1)%advisoryDigestAuditInterval == 0
+	if unchanged && !writeThrough {
+		if c.advisoryDigestCycles == nil {
+			c.advisoryDigestCycles = make(map[string]int)
+		}
+		c.advisoryDigestCycles[key] = count + 1
+		c.advisoryMu.Unlock()
+		return nil
+	}
+	c.advisoryMu.Unlock()
 
 	commentID, err := c.findDigestComment(ctx, owner, repoName, issueNum)
 	if err != nil {
@@ -185,17 +210,20 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 		author = comment.GetUser().GetLogin()
 	}
 
-	// Audit the FIRST post and every advisoryDigestAuditInterval-th one, not the
-	// ~once-a-minute refreshes in between: auditing every update would flood the
-	// audit log (1000s/day) and evict the discrete create→merge events. A
-	// periodic pulse still proves the advisory loop is alive on the dashboard.
+	// Audit the FIRST write and every advisoryDigestAuditInterval-th cycle, which
+	// is also a real write-through. Auditing every ~once-a-minute cycle would
+	// flood the audit log (1000s/day) and evict the discrete create→merge events.
+	// A periodic pulse still proves the advisory loop is alive on the dashboard.
 	c.advisoryMu.Lock()
-	if c.advisoryDigestPosts == nil {
-		c.advisoryDigestPosts = make(map[string]int)
+	if c.advisoryDigestCycles == nil {
+		c.advisoryDigestCycles = make(map[string]int)
 	}
-	key := fmt.Sprintf("%s/%s#%d", owner, repoName, issueNum)
-	c.advisoryDigestPosts[key]++
-	count := c.advisoryDigestPosts[key]
+	if c.advisoryDigestHashes == nil {
+		c.advisoryDigestHashes = make(map[string][32]byte)
+	}
+	c.advisoryDigestCycles[key]++
+	c.advisoryDigestHashes[key] = digestHash
+	count = c.advisoryDigestCycles[key]
 	c.advisoryMu.Unlock()
 
 	if count == 1 || count%advisoryDigestAuditInterval == 0 {

--- a/src/pkg/github/advisory_test.go
+++ b/src/pkg/github/advisory_test.go
@@ -542,6 +542,96 @@ func TestPostAdvisoryDigest_UpdateExisting(t *testing.T) {
 	}
 }
 
+func TestPostAdvisoryDigest_SkipsUnchangedBody(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var listCalls, editCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/10/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		listCalls++
+		json.NewEncoder(w).Encode([]map[string]any{{"id": 555, "body": advisoryDigestPrefix + " — old"}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/555", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		editCalls++
+		json.NewEncoder(w).Encode(map[string]any{"id": 555})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	body := advisoryDigestPrefix + " — stable"
+	for cycle := 1; cycle <= 3; cycle++ {
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, body); err != nil {
+			t.Fatalf("cycle %d: PostAdvisoryDigest: %v", cycle, err)
+		}
+		if editCalls != 1 {
+			t.Fatalf("cycle %d: edit calls = %d, want 1", cycle, editCalls)
+		}
+	}
+	if listCalls != 1 {
+		t.Fatalf("comment-list calls = %d, want 1", listCalls)
+	}
+}
+
+func TestPostAdvisoryDigest_ChangedBodyWritesOnce(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var editCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/10/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{{"id": 555, "body": advisoryDigestPrefix + " — old"}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/555", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		editCalls++
+		json.NewEncoder(w).Encode(map[string]any{"id": 555})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	for _, body := range []string{advisoryDigestPrefix + " — first", advisoryDigestPrefix + " — changed"} {
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, body); err != nil {
+			t.Fatalf("PostAdvisoryDigest: %v", err)
+		}
+	}
+	if editCalls != 2 {
+		t.Fatalf("edit calls = %d, want 2 (one initial and one changed-body edit)", editCalls)
+	}
+}
+
+func TestPostAdvisoryDigest_PeriodicWriteThroughDetectsPermissionRegression(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	var editCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/10/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{{"id": 555, "body": advisoryDigestPrefix + " — old"}})
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/555", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		editCalls++
+		if editCalls == 2 {
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration"})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": 555})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	body := advisoryDigestPrefix + " — stable"
+	for cycle := 1; cycle <= advisoryDigestAuditInterval; cycle++ {
+		err := c.PostAdvisoryDigest(context.Background(), repo, 10, body)
+		if cycle < advisoryDigestAuditInterval && err != nil {
+			t.Fatalf("cycle %d: PostAdvisoryDigest: %v", cycle, err)
+		}
+		if cycle == advisoryDigestAuditInterval && err == nil {
+			t.Fatal("periodic write-through error = nil, want permission regression surfaced")
+		}
+	}
+	if editCalls != 2 {
+		t.Fatalf("edit calls = %d, want 2 (initial plus failed periodic write-through)", editCalls)
+	}
+}
+
 func TestPostAdvisoryDigest_UpdateError(t *testing.T) {
 	org, repo := "testorg", "testrepo"
 	mux := http.NewServeMux()

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -127,14 +127,14 @@ type Client struct {
 	// the PR-request watcher goroutine may already be reading them.
 	attribMu    sync.RWMutex
 	attribution AttributionHooks
-	// advisoryDigestPosts counts how many times the advisory digest has been
-	// (re)posted per "owner/repo#issue" since this process started. The digest
-	// is refreshed ~once a minute, so PostAdvisoryDigest audits only the 1st
-	// post and every advisoryDigestAuditInterval-th one — a periodic pulse that
-	// proves the loop is alive without flooding the audit log. Guarded by
-	// advisoryMu.
-	advisoryMu          sync.Mutex
-	advisoryDigestPosts map[string]int
+	// advisoryDigestCycles counts successful digest cycles and
+	// advisoryDigestHashes remembers the body from the last successful write,
+	// both per "owner/repo#issue". Identical bodies skip the forge mutation,
+	// except for a periodic write-through that re-proves issues:write access.
+	// Guarded by advisoryMu.
+	advisoryMu           sync.Mutex
+	advisoryDigestCycles map[string]int
+	advisoryDigestHashes map[string][32]byte
 }
 
 func (c *Client) SetCanaryScanner(enabled, failClosed bool, reg *ioscan.CanaryRegistry, onLeak func(ioscan.CanaryLeak)) {


### PR DESCRIPTION
## Summary

- cache the scrubbed and truncated advisory digest hash after successful writes
- skip byte-identical comment edits while treating the cycle as healthy for staleness and App-banner state
- force every 50th cycle through GitHub so permission regressions remain detectable
- cover repeated unchanged cycles, changed bodies, and a periodic 403 write-through

Fixes #4818

## Testing

- `go test ./pkg/github`
- `go test ./cmd/hive -run 'Test(EmptyAdvisory|MissingAdvisory)'`

— hive: backend=codex
