### PR TITLE
🐛 Name the real cause on /fleet: all-paused, login-blocked, and partially-dead hives

### DIFF
--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -393,6 +393,14 @@ type agentFleetRollup struct {
 	Expected int `json:"expected"`
 	Running  int `json:"running"`
 	Able     int `json:"able"`
+	// Paused is how many expected-active agents are deliberately quiet because
+	// the operator paused them. Live all-paused hives (aslom/hive-agent,
+	// castrojo/endusers, hashicorp/dev-portal, inference-sim/sim2real, and
+	// peers) reported Expected>0, Running=0, Problems=0 and therefore fell
+	// into the false "no agents running" outage leg. Pause is an operator
+	// choice, not a dead session; count it separately so hive health can say
+	// "all agents paused" instead of inventing a crash.
+	Paused   int `json:"paused,omitempty"`
 	Stuck    int `json:"stuck"`
 	Impotent int `json:"impotent"`
 	// Problems is how many agents the governor expects on that cannot deliver
@@ -595,6 +603,9 @@ func rollupAgents(agents []AgentSummary, blockers hiveBlockers, queuedWork int, 
 		if a.ExpectedActive {
 			r.Expected++
 		}
+		if a.ExpectedActive && (a.Paused || strings.EqualFold(a.State, agentStatePaused)) {
+			r.Paused++
+		}
 		if v.RunState == runWorking {
 			r.Running++
 		}
@@ -618,6 +629,18 @@ func rollupAgents(agents []AgentSummary, blockers hiveBlockers, queuedWork int, 
 				r.QuotaExhausted++
 			case runDead, runSessionGone:
 				r.DeadOrGone++
+			case runWorking:
+				if v.BlockedReason == "sitting at login prompt" {
+					// Login prompts are actionable the moment the ABLE leg sees
+					// NeedsLogin on an interactive backend, even while the ACTUAL
+					// leg is still inside its 20-minute grace and therefore says
+					// runWorking. Live "placeholder/" and available-akswec2 pool
+					// hives hit this shape: Problems>0 but LoginStuck stayed zero,
+					// so /fleet hid the cause behind "N agent(s) blocked". Bucket
+					// by the blocked reason as a fallback so the hive chip tells
+					// the operator to re-login.
+					r.LoginStuck++
+				}
 			}
 		}
 	}

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -314,6 +314,27 @@ func TestRollup_LoginStuckCount(t *testing.T) {
 	}
 }
 
+func TestRollup_LoginPromptWithinGraceStillBucketsHiveCause(t *testing.T) {
+	now := time.Now()
+	guide := modernWorking(now)
+	guide.Name, guide.Backend = "guide", "copilot"
+	guide.NeedsLogin = true
+	guide.StartedAt = now.Add(-(inactiveAgentStartupGrace + 2*time.Minute)).UTC().Format(time.RFC3339)
+
+	v := deriveAgentVerdict(guide, hiveBlockers{}, 17, now)
+	if v.RunState != runWorking {
+		t.Fatalf("login prompt inside 20m grace should still be runWorking, got %+v", v)
+	}
+	if !v.Problem || v.BlockedReason != "sitting at login prompt" {
+		t.Fatalf("ABLE leg must mark the login prompt as the problem cause, got %+v", v)
+	}
+
+	r := rollupAgents([]AgentSummary{guide}, hiveBlockers{}, 17, now)
+	if r.Problems != 1 || r.LoginStuck != 1 {
+		t.Fatalf("login-in-grace pool-hive shape must bucket as login-stuck cause, got %+v", r)
+	}
+}
+
 // TestParseAgentTime_CompactWireFormat pins the colonless timestamp variant
 // spokes emit live ("2026-08-22T024118Z"). RFC3339-only parsing returned !ok
 // for every such value, which silently disabled the needs-login grace and the
@@ -356,6 +377,9 @@ func TestRollup_Counts(t *testing.T) {
 	if r.Able != 1 {
 		t.Errorf("able = %d, want 1", r.Able)
 	}
+	if r.Paused != 1 {
+		t.Errorf("paused = %d, want 1 (expected-active paused agent)", r.Paused)
+	}
 	// stuck: loginStuck (running+login) and down (dead). paused is not stuck.
 	if r.Stuck != 2 {
 		t.Errorf("stuck = %d, want 2 (login-stuck + down)", r.Stuck)
@@ -363,6 +387,26 @@ func TestRollup_Counts(t *testing.T) {
 	// impotent: only loginStuck (running but blocked). down is not running.
 	if r.Impotent != 1 {
 		t.Errorf("impotent = %d, want 1 (login-stuck)", r.Impotent)
+	}
+}
+
+func TestRollup_AllExpectedAgentsPaused(t *testing.T) {
+	now := time.Now()
+	agent := func(name string) AgentSummary {
+		a := modernWorking(now)
+		a.Name = name
+		a.State = agentStatePaused
+		a.Paused = true
+		return a
+	}
+
+	r := rollupAgents([]AgentSummary{
+		agent("quality"),
+		agent("scanner"),
+		agent("supervisor"),
+	}, hiveBlockers{}, 11, now)
+	if r.Expected != 3 || r.Paused != 3 || r.Running != 0 || r.Problems != 0 {
+		t.Fatalf("all-paused live shape should be expected+paused, not dead/problematic: %+v", r)
 	}
 }
 

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	HealthStateGreen   = "green"
+	HealthStateAmber   = "amber"
 	HealthStateRed     = "red"
 	HealthStateUnknown = "unknown"
 )
@@ -45,7 +46,7 @@ const (
 
 // HealthVerdict is the at-a-glance answer for one hive, surfaced on MyHiveEntry.
 type HealthVerdict struct {
-	State string `json:"state"` // green | red | unknown
+	State string `json:"state"` // green | amber | red | unknown
 	// Reason is a short human phrase for the WHY chip ("last output 3h ago",
 	// "GitHub App broken", "no agents running", "queue empty — idle").
 	Reason string `json:"reason"`
@@ -127,6 +128,14 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 				// Nothing alive at all: keep the familiar wording so a fully
 				// down hive reads the same as before the cause split.
 				v.Reason = "no agents running"
+			case rollup.DeadOrGone == rollup.Problems:
+				// Katamari/ibm-aiops-orchestrator live shape: guide+supervisor
+				// were failed/dead while quality+scanner still ran. The old
+				// Running==0 guard meant the cause fell through to generic
+				// "2 agent(s) blocked", hiding the restart remedy. When every
+				// problem is dead/gone, name that cause even if other agents in
+				// the hive are still healthy.
+				v.Reason = fmt.Sprintf("%d agent(s) down — restart needed", rollup.DeadOrGone)
 			case rollup.IdleWithWork == rollup.Problems:
 				// Sessions are alive but every scheduled agent is sitting past
 				// the idle threshold while work is queued. "no agents running"
@@ -139,6 +148,19 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 			return v
 		}
 		if rollup.Expected > 0 && rollup.Running == 0 {
+			if rollup.Paused == rollup.Expected {
+				// Live all-paused hives (aslom/hive-agent, castrojo/endusers,
+				// hashicorp/dev-portal, inference-sim/sim2real, singhar/go-ci,
+				// torch-spyre/spyre-inference, TradingAsBuddies/falcon-core,
+				// zacburns/mlz-manager, llm-d/llm-d-workload-variant-autoscaler)
+				// are ExpectedActive because work is queued, but every agent is
+				// intentionally paused. That is operator choice, not a red outage;
+				// still, queued work will not move until somebody resumes them, so
+				// amber is more honest than the green "off by schedule" verdict.
+				v.State = HealthStateAmber
+				v.Reason = "all agents paused — resume to produce output"
+				return v
+			}
 			v.State = HealthStateRed
 			v.Reason = "no agents running"
 			return v

--- a/src/pkg/hub/health_verdict_reasons_test.go
+++ b/src/pkg/hub/health_verdict_reasons_test.go
@@ -157,6 +157,33 @@ func TestHiveHealthForReasons(t *testing.T) {
 			wantReason: "no agents running",
 		},
 		{
+			// Katamari/ibm-aiops-orchestrator live shape: guide+supervisor are
+			// down, but quality+scanner still run. The hive is not fully out, so
+			// preserve the real cause instead of falling through to the generic
+			// "2 agent(s) blocked".
+			name:   "L3 all problems dead while other agents run — names restart cause",
+			entry:  base(3),
+			rollup: agentFleetRollup{Expected: 4, Running: 2, Known: 4, Problems: 2, DeadOrGone: 2},
+			app:    okApp(), queued: 3,
+			wantState:  HealthStateRed,
+			wantReason: "2 agent(s) down — restart needed",
+		},
+		{
+			// Live all-paused hives (aslom/hive-agent, castrojo/endusers,
+			// hashicorp/dev-portal, inference-sim/sim2real, singhar/go-ci,
+			// torch-spyre/spyre-inference, TradingAsBuddies/falcon-core,
+			// zacburns/mlz-manager, llm-d/llm-d-workload-variant-autoscaler):
+			// ExpectedActive remains true while the operator deliberately pauses
+			// every agent. That is not "no agents running" red; queued work will
+			// wait until a resume, so show an amber action chip.
+			name:   "L3 all expected agents paused — amber resume reason",
+			entry:  base(3),
+			rollup: agentFleetRollup{Expected: 3, Running: 0, Known: 3, Paused: 3},
+			app:    okApp(), queued: 11,
+			wantState:  HealthStateAmber,
+			wantReason: "all agents paused — resume to produce output",
+		},
+		{
 			name:      "L4 recent create — reason humanizes the age",
 			entry:     withActivity(writer(base(4)), ractivity("o/r", rfc(now.Add(-3*time.Hour)), "", "", "")),
 			rollup:    okRollup(),
@@ -245,6 +272,81 @@ func TestHiveHealth_L2FreshAdvisoryIgnoresWriteIncapableIdleAgents(t *testing.T)
 	v := hiveHealthFor(e, rollup, okApp(), 9, now)
 	if v.State != HealthStateGreen || !strings.Contains(v.Reason, "advisory 4m ago") {
 		t.Fatalf("fresh L2 advisory should stay healthy, got state=%s reason=%q", v.State, v.Reason)
+	}
+}
+
+func TestHiveHealth_LiveFleetCauseShapes(t *testing.T) {
+	now := time.Date(2026, 8, 26, 15, 28, 0, 0, time.UTC)
+	base := RegistryEntry{Online: true, ACMMLevel: 3}
+	working := func(name string) AgentSummary {
+		a := modernWorking(now)
+		a.Name = name
+		return a
+	}
+	paused := func(name string) AgentSummary {
+		a := working(name)
+		a.State = agentStatePaused
+		a.Paused = true
+		return a
+	}
+	dead := func(name string) AgentSummary {
+		a := working(name)
+		a.State = "failed"
+		return a
+	}
+	loginInGrace := func(name string) AgentSummary {
+		a := working(name)
+		a.Backend = "copilot"
+		a.NeedsLogin = true
+		a.StartedAt = now.Add(-(inactiveAgentStartupGrace + 2*time.Minute)).UTC().Format(time.RFC3339)
+		return a
+	}
+
+	tests := []struct {
+		name       string
+		agents     []AgentSummary
+		wantState  string
+		wantReason string
+	}{
+		{
+			// The all-paused hives seen live (for example aslom/hive-agent and
+			// castrojo/endusers) have queued work and ExpectedActive agents, but
+			// every expected agent is deliberately paused by the operator.
+			name:       "all agents paused",
+			agents:     []AgentSummary{paused("quality"), paused("scanner"), paused("supervisor")},
+			wantState:  HealthStateAmber,
+			wantReason: "all agents paused — resume to produce output",
+		},
+		{
+			// The placeholder/available-akswec2 pool shape is inside the 20m
+			// login grace, so RunState is still working; the ABLE leg already
+			// knows the cause is a login prompt and the hive chip must say that.
+			name:       "login prompt inside grace",
+			agents:     []AgentSummary{loginInGrace("guide"), loginInGrace("quality"), loginInGrace("scanner"), loginInGrace("supervisor")},
+			wantState:  HealthStateRed,
+			wantReason: "4 agent(s) stuck at login — re-login needed",
+		},
+		{
+			// Katamari/ibm-aiops-orchestrator had guide+supervisor down while
+			// quality+scanner still ran; this is a partial outage, not a generic
+			// blocked count.
+			name:       "dead agents while others run",
+			agents:     []AgentSummary{dead("guide"), dead("supervisor"), working("quality"), working("scanner")},
+			wantState:  HealthStateRed,
+			wantReason: "2 agent(s) down — restart needed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := base
+			e.Agents = tc.agents
+			rollup := rollupAgents(tc.agents, hiveBlockers{}, 9, now)
+			v := hiveHealthFor(e, rollup, okApp(), 9, now)
+			if v.State != tc.wantState || v.Reason != tc.wantReason {
+				t.Fatalf("verdict = (%s, %q), want (%s, %q); rollup=%+v",
+					v.State, v.Reason, tc.wantState, tc.wantReason, rollup)
+			}
+		})
 	}
 }
 

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -156,6 +156,7 @@
   /* Health dot (left of hive name) — reflects PROBLEMS, not online/offline. */
   .hdot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 8px; vertical-align: middle; }
   .hdot.problem { background: var(--red); box-shadow: 0 0 0 3px rgba(229,72,77,.18); }
+  .hdot.warning { background: var(--amber); box-shadow: 0 0 0 3px rgba(224,168,0,.14); }
   .hdot.ok { background: var(--green); }
   .hdot.unknown { background: var(--gray); }
   .hdot.offline { background: transparent; border: 1px solid var(--gray); }
@@ -290,7 +291,7 @@
 </header>
 <div class="wrap">
   <div class="legend">
-    <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting) · <span class="hdot parked"></span> parked (all agents quiet by design — hive not in use)</span>
+    <span><span class="hdot problem"></span> problem (needs attention) · <span class="hdot warning"></span> warning (operator action) · <span class="hdot ok"></span> ok · <span class="hdot unknown"></span> unknown (not yet reporting) · <span class="hdot parked"></span> parked (all agents quiet by design — hive not in use)</span>
     <span><b>advisory output:</b> <span class="advisory-activity fresh"><span class="light"></span>fresh</span> · <span class="advisory-activity aging"><span class="light"></span>aging</span> · <span class="advisory-activity stale"><span class="light"></span>stale</span> · <span class="advisory-activity unknown"><span class="light"></span>n/a</span></span>
     <span><b>budget:</b> <span class="budget-health ok"><span class="light"></span>ok</span> · <span class="budget-health warning"><span class="light"></span>warning</span> · <span class="budget-health critical"><span class="light"></span>critical</span> · <span class="budget-health exhausted"><span class="light"></span>exhausted</span> · <span class="budget-health unknown"><span class="light"></span>n/a</span></span>
     <span><b>gh app:</b> <span class="github-app-health ok"><span class="light"></span>ok</span> · <span class="github-app-health degraded"><span class="light"></span>stale</span> · <span class="github-app-health broken"><span class="light"></span>broken</span> · <span class="github-app-health unknown"><span class="light"></span>n/a</span></span>
@@ -715,9 +716,9 @@ function deltaHTML(a) {
   if (a.quietByDesign) return '<span class="delta quiet">quiet</span>';
   return "";
 }
-// hiveHealth returns "problem" | "ok" | "unknown" | "offline" | "parked" for
+// hiveHealth returns "problem" | "warning" | "ok" | "unknown" | "offline" | "parked" for
 // the left dot. The backend now sends an ACMM-banded output verdict
-// (h.healthVerdict = {state:green|red|unknown, reason, outputKind, lastOutputAt,
+// (h.healthVerdict = {state:green|amber|red|unknown, reason, outputKind, lastOutputAt,
 // queuedWork}) that answers the core question — "does this hive have recent
 // output back to its work source, for the level it is AT?" — with the level
 // banding, precondition gates and queue-gate already applied. We prefer it, but
@@ -736,6 +737,7 @@ function hiveHealth(h) {
   var v = h.healthVerdict;
   if (v && v.state) {
     if (v.state === "red") return "problem";
+    if (v.state === "amber") return "warning";
     if (v.state === "green") return "ok";
     return "unknown"; // v.state === "unknown"
   }
@@ -759,7 +761,7 @@ function whyChipHTML(h, health) {
   if (health === "parked" || health === "offline") return "";
   var v = h.healthVerdict;
   if (!v || !v.reason) return "";
-  var cls = v.state === "red" ? "why-chip bad" : (v.state === "unknown" ? "why-chip unknown" : "why-chip");
+  var cls = v.state === "red" ? "why-chip bad" : (v.state === "amber" ? "why-chip warn" : (v.state === "unknown" ? "why-chip unknown" : "why-chip"));
   return '<span class="' + cls + '" title="' + esc(v.outputKind ? "output judged on: " + v.outputKind : "hive-health") + '">' + esc(v.reason) + '</span>';
 }
 function rosterMismatchChipHTML(h) {
@@ -812,11 +814,14 @@ function renderHives(hives) {
   tb.innerHTML = "";
   hives = hives || [];
 
-  // Rank: problems first, then unknown, then ok; stable within a rank by name.
-  var rank = { problem: 0, unknown: 1, offline: 2, parked: 3, ok: 4 };
+  // Rank: problems first, then amber operator-action warnings, then unknown,
+  // then ok; stable within a rank by name.
+  var rank = { problem: 0, warning: 1, unknown: 2, offline: 3, parked: 4, ok: 5 };
   var rows = hives.map(function (h) { return { h: h, health: hiveHealth(h) }; });
   rows.sort(function (a, b) {
-    var d = (rank[a.health] || 9) - (rank[b.health] || 9);
+    var ar = Object.prototype.hasOwnProperty.call(rank, a.health) ? rank[a.health] : 9;
+    var br = Object.prototype.hasOwnProperty.call(rank, b.health) ? rank[b.health] : 9;
+    var d = ar - br;
     if (d) return d;
     return String(a.h.name || a.h.id).localeCompare(String(b.h.name || b.h.id));
   });


### PR DESCRIPTION
## Summary

Fixes two hive-level verdict gaps on /fleet so the hive reason chip names the operator-actionable cause instead of falling through to misleading generic text.

## Gap 1: all agents paused

Live examples observed today include aslom/hive-agent, castrojo/endusers, hashicorp/dev-portal, inference-sim/sim2real, singhar/go-ci, torch-spyre/spyre-inference, TradingAsBuddies/falcon-core, zacburns/mlz-manager, and llm-d/llm-d-workload-variant-autoscaler.

These hives have ExpectedActive agents and queued work, but every expected agent is deliberately paused. The old rollup produced Expected>0, Running=0, Problems=0, causing hiveHealthFor to report red "no agents running". This PR adds an expected-active Paused count and returns an amber verdict: "all agents paused — resume to produce output".

## Gap 2: blocked/down causes hidden

### Login prompt inside grace

Live shapes include placeholder/, available-akswec2-260810-* pool hives, and jeejz/incubator-kie-drools. deriveAgentVerdict already knows the agent is blocked by "sitting at login prompt", but RunState stays working during the 20-minute login grace. The rollup now buckets those problem agents into LoginStuck via BlockedReason fallback, so the hive reads: "N agent(s) stuck at login — re-login needed".

### Dead agents while others still run

Live shape: katamari/ibm-aiops-orchestrator had guide+supervisor failed/down while quality+scanner still ran. When every problem is dead/gone but Running>0, the verdict now says "N agent(s) down — restart needed". Fully down hives still keep the existing "no agents running" wording.

## Tests

- gofmt
- cd src && go test -count=1 ./pkg/hub/