### PR TITLE
feat: configure advisory digest update interval

### DIFF
--- a/src/cmd/hive/advisory_wedge_test.go
+++ b/src/cmd/hive/advisory_wedge_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubestellar/hive/pkg/advisory"
 	"github.com/kubestellar/hive/pkg/beads"
@@ -88,6 +89,32 @@ func TestEmptyAdvisoryDigestPostsOnlyToExistingIssue(t *testing.T) {
 	}
 	if !shouldPostAdvisoryDigest(withResolved, nil, false) {
 		t.Fatal("recently resolved findings must still flow to the missing-issue error path")
+	}
+}
+
+func TestAdvisoryPostScheduleLiveInterval(t *testing.T) {
+	schedule := &advisoryPostSchedule{}
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	advisoryCfg := config.AdvisoryConfig{}
+
+	if !schedule.due("org/repo", advisoryCfg.AdvisoryUpdateInterval(), now) {
+		t.Fatal("first advisory cycle must be due")
+	}
+	if schedule.due("org/repo", advisoryCfg.AdvisoryUpdateInterval(), now.Add(59*time.Second)) {
+		t.Fatal("unset interval must preserve the 60-second default")
+	}
+	if !schedule.due("org/repo", advisoryCfg.AdvisoryUpdateInterval(), now.Add(60*time.Second)) {
+		t.Fatal("default interval should be due at 60 seconds")
+	}
+
+	// The interval is read from config on each eval: extending it live must
+	// delay the next post relative to the most recent attempt.
+	advisoryCfg.UpdateIntervalS = 300
+	if schedule.due("org/repo", advisoryCfg.AdvisoryUpdateInterval(), now.Add(299*time.Second)) {
+		t.Fatal("live 300-second interval should suppress an early post")
+	}
+	if !schedule.due("org/repo", advisoryCfg.AdvisoryUpdateInterval(), now.Add(360*time.Second)) {
+		t.Fatal("live 300-second interval should allow the next due post")
 	}
 }
 

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2443,6 +2443,7 @@ func main() {
 			"providers", len(cfg.Governor.Rotation.Providers))
 	}
 
+	advisorySchedule := &advisoryPostSchedule{}
 	dashSrv.RegisterAPI(&dashboard.Dependencies{
 		Config:           cfg,
 		AgentMgr:         agentMgr,
@@ -2482,7 +2483,7 @@ func main() {
 			initAgentConfigDrivenSystems(cfg)
 		},
 		EnumerateFunc: func() {
-			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
+			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, advisorySchedule, nil, logger)
 		},
 		AdvisoryResetFunc: func(newPrimaryRepo string) {
 			logger.Info("advisory reset: primary repo changed, creating new advisory issue", "repo", newPrimaryRepo)
@@ -3617,6 +3618,7 @@ func main() {
 					}
 					return postedAt.UTC().Format(time.RFC3339)
 				}(),
+				AdvisoryUpdateIntervalS: int(cfg.Governor.Advisory.AdvisoryUpdateInterval() / time.Second),
 				AdvisoryError: func() string {
 					_, _, errMsg := dashSrv.AdvisoryState()
 					return errMsg
@@ -4660,7 +4662,7 @@ func main() {
 	// interval. A hive with no persisted state (fresh install) has no LastKick
 	// entries, and every cadenced agent is still kicked here, unchanged.
 	logger.Info("startup honors persisted cadence state — first eval kicks only agents whose cadence has elapsed")
-	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
+	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, advisorySchedule, nil, logger)
 	runRotationCheck(ctx, cfg, rotationMgr, gov, agentMgr, logger)
 	runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
@@ -4702,7 +4704,7 @@ func main() {
 					}
 				}
 			}
-			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, restarted, logger)
+			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, advisorySchedule, restarted, logger)
 			runRotationCheck(ctx, cfg, rotationMgr, gov, agentMgr, logger)
 			runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 			// Trajectory review runs after the eval cycle (so kicks/intents are
@@ -5418,6 +5420,31 @@ func shouldPostAdvisoryDigest(digest *advisory.Digest, ghClient *github.Client, 
 	return ghClient != nil && hasPinnedIssue
 }
 
+// advisoryPostSchedule gates only the forge-facing digest refresh. The eval
+// loop still ingests findings and refreshes dashboard state on every tick. Its
+// interval is supplied on every call, so a live config edit takes effect on the
+// next eval without restarting the hive.
+type advisoryPostSchedule struct {
+	mu          sync.Mutex
+	lastAttempt map[string]time.Time
+}
+
+func (s *advisoryPostSchedule) due(repo string, interval time.Duration, now time.Time) bool {
+	if s == nil {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if last := s.lastAttempt[repo]; !last.IsZero() && now.Before(last.Add(interval)) {
+		return false
+	}
+	if s.lastAttempt == nil {
+		s.lastAttempt = make(map[string]time.Time)
+	}
+	s.lastAttempt[repo] = now
+	return true
+}
+
 // advisoryIssueMissingError is the error recorded (and reported to the hub) when
 // a hive has findings to publish but no advisory issue to publish them to. It is
 // deliberately an ERROR rather than a silent skip: the hub's staleness gate
@@ -5453,6 +5480,7 @@ func runEvalCycle(
 	lastActionable *atomic.Pointer[github.ActionableResult],
 	advisoryStore *advisory.Store,
 	advisoryIssues map[string]int,
+	advisorySchedule *advisoryPostSchedule,
 	restartedAgents []string,
 	logger *slog.Logger,
 ) {
@@ -6083,7 +6111,8 @@ func runEvalCycle(
 		// freshness: otherwise the pinned comment and AdvisoryLastPostedAt
 		// freeze after the last finding disappears, and the hub reports a stale
 		// advisory loop even though the agents are running cleanly.
-		if shouldPostAdvisoryDigest(digest, ghClient, hasExistingPinnedIssueForEmptyDigest) {
+		if shouldPostAdvisoryDigest(digest, ghClient, hasExistingPinnedIssueForEmptyDigest) &&
+			advisorySchedule.due(primaryRepo, advCfg.AdvisoryUpdateInterval(), time.Now()) {
 			// Log severity breakdown and contributing agents
 			bySeverity := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 			agentNames := make([]string, 0, len(digest.ByAgent))

--- a/src/docs/advisory-staleness.md
+++ b/src/docs/advisory-staleness.md
@@ -10,6 +10,7 @@ never re-derives it.
 | Signal | Produced by | Notes |
 | --- | --- | --- |
 | `AdvisoryLastPostedAt` | spoke, `RecordAdvisoryPost` after a **successful** digest post | in spoke memory only; empty until the first success |
+| `AdvisoryUpdateIntervalS` | spoke, effective digest update cadence | expands the age threshold for an intentionally slow cadence; absent on older spokes means the 60s default |
 | `AdvisoryError` | spoke, `RecordAdvisoryError` on a failed post **attempt** | cleared by the next success |
 | `GitHubAppState` / `GitHubAppRequired` / `PendingGitHubAppInstall` | spoke App diagnosis | decides whether silence is expected |
 
@@ -31,9 +32,11 @@ never re-derives it.
    protocol fields, does *not* qualify, so the gate never silences a spoke the
    hub cannot read. A reported post **error** still flags regardless — a broken
    post path is broken whoever is paused.
-4. **Age** — with no error reported, a post time older than
-   `advisoryStaleThreshold` (90 min) is stale, but only when the App can write
-   at all (`appCanWriteForAdvisory`). Unparseable timestamps are unknown.
+4. **Age** — with no error reported, the threshold is the historical 90 minutes
+   or two update intervals, whichever is longer. The interval baseline is
+   `max(configured interval, 60s)`, so deliberately slow healthy cadences do not
+   false-alarm. The post is stale only when the App can write at all
+   (`appCanWriteForAdvisory`). Unparseable timestamps are unknown.
 
 ## Suppression matrix (#4167)
 

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -1,10 +1,10 @@
 # Advisory digest
 
 Advisory agents (scanner, ci-maintainer, reviewer, and friends) file their
-findings as **advisory beads**. Once per governor eval cycle the hive rolls the
-open advisory beads of every agent into a single **advisory digest** and posts it
-as a pinned comment on the advisory issue of the primary repo, rewriting the same
-comment each cycle so a repo owner has exactly one place to look.
+findings as **advisory beads**. The hive rolls the open advisory beads of every
+agent into a single **advisory digest** and posts it as a pinned comment on the
+advisory issue of the primary repo, updating the same comment so a repo owner has
+exactly one place to look.
 
 Everything on this page lives under `governor.advisory` in `hive.yaml`, and every
 setting is also editable from **Governor Config → Advisory** in the dashboard
@@ -16,8 +16,17 @@ governor:
     max_findings: 10
     show_all: false       # true = ignore max_findings
     staleness_days: 7
+    update_interval_s: 0  # 0 = historical 60-second default
     pr_autoclose: true
 ```
+
+`governor.advisory.update_interval_s` controls how often the forge-facing
+digest refresh is attempted. Zero or an omitted field preserves the 60-second
+default; positive values below 30 seconds are clamped to 30 with one process
+warning. Changes made in the dashboard are read live on the next governor eval
+cycle, without a restart. The eval cycle still ingests findings and refreshes
+dashboard state normally, and the byte-identical-content guard still skips an
+unnecessary forge write when a refresh is due.
 
 ## Keeping findings current
 

--- a/src/pkg/config/advisory_config_test.go
+++ b/src/pkg/config/advisory_config_test.go
@@ -1,6 +1,11 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
 
 // TestAdvisoryConfigDefaults pins the shipped advisory behavior for a hive that
 // says nothing: a ten-finding digest, a week-long staleness window, and
@@ -25,6 +30,12 @@ func TestAdvisoryConfigDefaults(t *testing.T) {
 	if a.ShowAll {
 		t.Error("ShowAll = true, want false — the cap is the default, opting out of it is not")
 	}
+	if a.UpdateIntervalS != 0 {
+		t.Errorf("UpdateIntervalS = %d, want 0 to preserve the unset sentinel", a.UpdateIntervalS)
+	}
+	if got := a.AdvisoryUpdateInterval(); got != 60*time.Second {
+		t.Errorf("AdvisoryUpdateInterval() = %v, want 60s", got)
+	}
 }
 
 // TestAdvisoryConfigDefaultsPreserveExplicitValues confirms defaulting never
@@ -34,10 +45,11 @@ func TestAdvisoryConfigDefaultsPreserveExplicitValues(t *testing.T) {
 	off := false
 	cfg := &Config{}
 	cfg.Governor.Advisory = AdvisoryConfig{
-		MaxFindings:   25,
-		ShowAll:       true,
-		StalenessDays: 3,
-		PRAutoClose:   &off,
+		MaxFindings:     25,
+		ShowAll:         true,
+		StalenessDays:   3,
+		UpdateIntervalS: 300,
+		PRAutoClose:     &off,
 	}
 	cfg.applyDefaults()
 
@@ -51,10 +63,39 @@ func TestAdvisoryConfigDefaultsPreserveExplicitValues(t *testing.T) {
 	if a.StalenessDays != 3 {
 		t.Errorf("StalenessDays = %d, want the configured 3", a.StalenessDays)
 	}
+	if got := a.AdvisoryUpdateInterval(); got != 300*time.Second {
+		t.Errorf("AdvisoryUpdateInterval() = %v, want 300s", got)
+	}
 	if a.PRAutoClose == nil || *a.PRAutoClose {
 		t.Errorf("PRAutoClose = %v, want the configured false", a.PRAutoClose)
 	}
 	if a.PRAutoCloseEnabled() {
 		t.Error("PRAutoCloseEnabled() = true, want false when explicitly disabled")
+	}
+}
+
+func TestAdvisoryUpdateIntervalClamp(t *testing.T) {
+	cfg := &Config{Governor: GovernorConfig{Advisory: AdvisoryConfig{UpdateIntervalS: 1}}}
+	cfg.applyDefaults()
+	if cfg.Governor.Advisory.UpdateIntervalS != AdvisoryUpdateIntervalMinS {
+		t.Fatalf("UpdateIntervalS = %d, want clamp to %d", cfg.Governor.Advisory.UpdateIntervalS, AdvisoryUpdateIntervalMinS)
+	}
+	if got := cfg.Governor.Advisory.AdvisoryUpdateInterval(); got != 30*time.Second {
+		t.Fatalf("AdvisoryUpdateInterval() = %v, want 30s", got)
+	}
+}
+
+func TestAdvisoryUpdateIntervalYAMLRoundTrip(t *testing.T) {
+	in := Config{Governor: GovernorConfig{Advisory: AdvisoryConfig{UpdateIntervalS: 900}}}
+	raw, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	var out Config
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if got := out.Governor.Advisory.UpdateIntervalS; got != 900 {
+		t.Fatalf("round-trip update_interval_s = %d, want 900", got)
 	}
 }

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -32,6 +32,8 @@ import (
 // only the last 1-2 on the PVC. Serializing every Save() closes the race.
 var saveMu sync.Mutex
 
+var advisoryUpdateIntervalClampWarning sync.Once
+
 type Config struct {
 	Project       ProjectConfig          `yaml:"project"`
 	Policies      PoliciesConfig         `yaml:"policies"`
@@ -1366,6 +1368,10 @@ type AdvisoryConfig struct {
 	// re-reported before the hive auto-closes it. Default
 	// defaultAdvisoryStalenessDays.
 	StalenessDays int `yaml:"staleness_days" json:"staleness_days"`
+	// UpdateIntervalS controls how often the pinned advisory digest is checked
+	// and refreshed. Zero/unset preserves the historical 60-second default;
+	// positive values below AdvisoryUpdateIntervalMinS are clamped on load.
+	UpdateIntervalS int `yaml:"update_interval_s,omitempty" json:"update_interval_s,omitempty"`
 	// PRAutoClose retires an advisory finding when a merged PR's title is
 	// close enough to the finding's title. *bool so absent is distinct from an
 	// explicit false; default true.
@@ -1375,6 +1381,31 @@ type AdvisoryConfig struct {
 // PRAutoCloseEnabled resolves AdvisoryConfig.PRAutoClose with its default (on).
 func (a AdvisoryConfig) PRAutoCloseEnabled() bool {
 	return a.PRAutoClose == nil || *a.PRAutoClose
+}
+
+// AdvisoryUpdateInterval resolves the configured digest refresh cadence.
+// Config is live-read by the eval loop, so dashboard changes apply without a
+// restart. The defensive clamp also covers configs constructed directly in
+// tests or by callers that have not run applyDefaults.
+func (a AdvisoryConfig) AdvisoryUpdateInterval() time.Duration {
+	seconds := ClampAdvisoryUpdateIntervalS(a.UpdateIntervalS)
+	if seconds == 0 {
+		seconds = AdvisoryUpdateIntervalDefaultS
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// ClampAdvisoryUpdateIntervalS preserves zero as the default sentinel and
+// clamps all other too-small values. The warning is process-wide so config
+// load, live dashboard updates, and defensive resolution cannot spam logs.
+func ClampAdvisoryUpdateIntervalS(seconds int) int {
+	if seconds != 0 && seconds < AdvisoryUpdateIntervalMinS {
+		advisoryUpdateIntervalClampWarning.Do(func() {
+			log.Printf("[config] warning: governor.advisory.update_interval_s=%d is below the %ds minimum; clamped to %d", seconds, AdvisoryUpdateIntervalMinS, AdvisoryUpdateIntervalMinS)
+		})
+		return AdvisoryUpdateIntervalMinS
+	}
+	return seconds
 }
 
 // Default governor mode thresholds, in queue items (actionable issues + open
@@ -4015,6 +4046,11 @@ const (
 	// without being re-reported. Advisory agents re-scan far more often than
 	// weekly, so a finding untouched for a week is one no agent still sees.
 	defaultAdvisoryStalenessDays = 7
+	// AdvisoryUpdateIntervalDefaultS preserves the historical digest cadence
+	// for existing configs. AdvisoryUpdateIntervalMinS prevents a typo from
+	// creating a tight GitHub API loop.
+	AdvisoryUpdateIntervalDefaultS = 60
+	AdvisoryUpdateIntervalMinS     = 30
 )
 
 func (c *Config) applyDefaults() {
@@ -4259,6 +4295,7 @@ func (c *Config) applyDefaults() {
 	if c.Governor.Advisory.StalenessDays == 0 {
 		c.Governor.Advisory.StalenessDays = defaultAdvisoryStalenessDays
 	}
+	c.Governor.Advisory.UpdateIntervalS = ClampAdvisoryUpdateIntervalS(c.Governor.Advisory.UpdateIntervalS)
 	if c.Governor.Advisory.PRAutoClose == nil {
 		on := true
 		c.Governor.Advisory.PRAutoClose = &on

--- a/src/pkg/dashboard/advisory_update_interval_ui_test.go
+++ b/src/pkg/dashboard/advisory_update_interval_ui_test.go
@@ -1,0 +1,25 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAdvisoryUpdateIntervalUIWiring(t *testing.T) {
+	raw, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	page := string(raw)
+	for _, want := range []string{
+		"When it updates",
+		"Update interval (s)",
+		"a.update_interval_s === undefined ? 0 : a.update_interval_s",
+		`data-change-action="gh75"`,
+		"markDirty('advisory','update_interval_s',Number(this.value)||0)",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("Advisory tab missing update-interval wiring %q", want)
+		}
+	}
+}

--- a/src/pkg/dashboard/api_governor_advisory_test.go
+++ b/src/pkg/dashboard/api_governor_advisory_test.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 type advisoryAPIResponse struct {
-	MaxFindings   int  `json:"max_findings"`
-	ShowAll       bool `json:"show_all"`
-	StalenessDays int  `json:"staleness_days"`
-	PRAutoClose   bool `json:"pr_autoclose"`
+	MaxFindings    int  `json:"max_findings"`
+	ShowAll        bool `json:"show_all"`
+	StalenessDays  int  `json:"staleness_days"`
+	UpdateInterval int  `json:"update_interval_s"`
+	PRAutoClose    bool `json:"pr_autoclose"`
 }
 
 func getAdvisorySettings(t *testing.T, s *Server) advisoryAPIResponse {
@@ -44,14 +47,14 @@ func TestGovAdvisory_GetPutRoundTrip(t *testing.T) {
 	s := govServer(t)
 
 	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{
-		"max_findings": 25, "show_all": true, "staleness_days": 3, "pr_autoclose": false,
+		"max_findings": 25, "show_all": true, "staleness_days": 3, "update_interval_s": 300, "pr_autoclose": false,
 	}); rec.Code != http.StatusOK {
 		t.Fatalf("put advisory settings: %d — %s", rec.Code, rec.Body.String())
 	}
 
 	got := getAdvisorySettings(t, s)
-	if got.MaxFindings != 25 || !got.ShowAll || got.StalenessDays != 3 || got.PRAutoClose {
-		t.Fatalf("settings = %+v, want {25 true 3 false}", got)
+	if got.MaxFindings != 25 || !got.ShowAll || got.StalenessDays != 3 || got.UpdateInterval != 300 || got.PRAutoClose {
+		t.Fatalf("settings = %+v, want update interval 300", got)
 	}
 	if s.deps.Config.Governor.Advisory.PRAutoCloseEnabled() {
 		t.Error("pr_autoclose: false must be stored as an explicit false pointer")
@@ -65,7 +68,7 @@ func TestGovAdvisory_GetPutRoundTrip(t *testing.T) {
 	if got.MaxFindings != 5 {
 		t.Errorf("MaxFindings = %d, want the updated 5", got.MaxFindings)
 	}
-	if !got.ShowAll || got.StalenessDays != 3 || got.PRAutoClose {
+	if !got.ShowAll || got.StalenessDays != 3 || got.UpdateInterval != 300 || got.PRAutoClose {
 		t.Errorf("partial put changed untouched fields: %+v", got)
 	}
 }
@@ -84,6 +87,7 @@ func TestGovAdvisory_Validation(t *testing.T) {
 		{"negative max findings", map[string]any{"max_findings": -1}},
 		{"zero staleness", map[string]any{"staleness_days": 0}},
 		{"negative staleness", map[string]any{"staleness_days": -7}},
+		{"negative update interval", map[string]any{"update_interval_s": -1}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if rec := doPut(s, "/api/config/governor/advisory", tc.body); rec.Code != http.StatusBadRequest {
@@ -94,6 +98,24 @@ func TestGovAdvisory_Validation(t *testing.T) {
 
 	if rec := doPutRaw(s, "/api/config/governor/advisory", "not json"); rec.Code != http.StatusBadRequest {
 		t.Fatalf("bad body: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestGovAdvisory_UpdateIntervalZeroAndClamp(t *testing.T) {
+	s := govServer(t)
+
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"update_interval_s": 0}); rec.Code != http.StatusOK {
+		t.Fatalf("put default interval: %d — %s", rec.Code, rec.Body.String())
+	}
+	if got := getAdvisorySettings(t, s).UpdateInterval; got != 0 {
+		t.Fatalf("default sentinel = %d, want 0", got)
+	}
+
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"update_interval_s": 5}); rec.Code != http.StatusOK {
+		t.Fatalf("put clamped interval: %d — %s", rec.Code, rec.Body.String())
+	}
+	if got := getAdvisorySettings(t, s).UpdateInterval; got != config.AdvisoryUpdateIntervalMinS {
+		t.Fatalf("clamped interval = %d, want %d", got, config.AdvisoryUpdateIntervalMinS)
 	}
 }
 

--- a/src/pkg/dashboard/api_governor_features.go
+++ b/src/pkg/dashboard/api_governor_features.go
@@ -247,10 +247,11 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var body struct {
-		MaxFindings   *int  `json:"max_findings"`
-		ShowAll       *bool `json:"show_all"`
-		StalenessDays *int  `json:"staleness_days"`
-		PRAutoClose   *bool `json:"pr_autoclose"`
+		MaxFindings    *int  `json:"max_findings"`
+		ShowAll        *bool `json:"show_all"`
+		StalenessDays  *int  `json:"staleness_days"`
+		UpdateInterval *int  `json:"update_interval_s"`
+		PRAutoClose    *bool `json:"pr_autoclose"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -266,6 +267,10 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 		jsonError(w, "staleness_days must be 1 or greater", http.StatusBadRequest)
 		return
 	}
+	if body.UpdateInterval != nil && *body.UpdateInterval < 0 {
+		jsonError(w, "update_interval_s must be 0 or greater", http.StatusBadRequest)
+		return
+	}
 
 	// --- apply ---
 	cfg := s.deps.Config
@@ -277,6 +282,9 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 	}
 	if body.StalenessDays != nil {
 		cfg.Governor.Advisory.StalenessDays = *body.StalenessDays
+	}
+	if body.UpdateInterval != nil {
+		cfg.Governor.Advisory.UpdateIntervalS = config.ClampAdvisoryUpdateIntervalS(*body.UpdateInterval)
 	}
 	if body.PRAutoClose != nil {
 		v := *body.PRAutoClose
@@ -297,10 +305,11 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 func advisorySectionResponse(cfg *config.Config) map[string]interface{} {
 	a := cfg.Governor.Advisory
 	return map[string]interface{}{
-		"max_findings":   a.MaxFindings,
-		"show_all":       a.ShowAll,
-		"staleness_days": a.StalenessDays,
-		"pr_autoclose":   a.PRAutoCloseEnabled(),
+		"max_findings":      a.MaxFindings,
+		"show_all":          a.ShowAll,
+		"staleness_days":    a.StalenessDays,
+		"update_interval_s": a.UpdateIntervalS,
+		"pr_autoclose":      a.PRAutoCloseEnabled(),
 	}
 }
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -20369,6 +20369,7 @@ function burnAreaChart() {
       a = a || {};
       const maxFindings = a.max_findings === undefined ? 10 : a.max_findings;
       const stalenessDays = a.staleness_days === undefined ? 7 : a.staleness_days;
+      const updateInterval = a.update_interval_s === undefined ? 0 : a.update_interval_s;
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Controls the advisory digest posted to your repo: how much of it is shown, and when findings nobody re-reports are retired.</p>
 
@@ -20381,6 +20382,14 @@ function burnAreaChart() {
           <div class="config-toggle" style="margin-top:10px">
             <div class="config-toggle-switch ${a.show_all ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="advisory" data-key="show_all"></div>
             <span class="config-toggle-label">Show all findings <span style="color:var(--muted);font-weight:400">— override the max and show everything</span></span>
+          </div>
+        </div>
+
+        <div style="margin:18px 0;padding-top:14px;border-top:1px solid var(--border)">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">When it updates</div>
+          <div class="config-field">
+            <label>Update interval (s) <span class="config-info">i<span class="config-tooltip">How often the digest comment is checked and refreshed. 0 means the default (60 seconds). Longer values reduce API writes and notification churn; the effective cadence is also bounded by the governor eval interval.</span></span></label>
+            <input type="number" min="0" step="1" value="${updateInterval}" placeholder="60" data-change-action="gh75">
           </div>
         </div>
 
@@ -22879,6 +22888,7 @@ function burnAreaChart() {
       gh72: function (event, A) { markDirty('auto-merge','required_checks',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
       gh73: function (event, A) { markDirty('review','max_parallel_reviews',Number(this.value)||0); },
       gh74: function (event, A) { markDirty('review','reviewer_agents',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },
+      gh75: function (event, A) { markDirty('advisory','update_interval_s',Number(this.value)||0); },
       gh0: function (event, A) { document.getElementById('gh-setup-overlay').style.display='none'; },
       gh1: function (event, A) { openConfigDialog('governor',null,'Repos'); },
       gh2: function (event, A) { acmmSelectRepo(null); },

--- a/src/pkg/hub/advisory_diagnostics.go
+++ b/src/pkg/hub/advisory_diagnostics.go
@@ -111,7 +111,7 @@ func diagnoseAdvisory(e RegistryEntry, now time.Time) AdvisoryDiagnosis {
 	aged := false
 	if parseErr == nil {
 		d.AgeMinutes = int64(now.Sub(postedAt) / time.Minute)
-		aged = now.Sub(postedAt) > advisoryStaleThreshold
+		aged = now.Sub(postedAt) > advisoryStaleThresholdFor(e)
 	}
 
 	if stale, reason := advisoryStale(e, now); stale {

--- a/src/pkg/hub/advisory_staleness.go
+++ b/src/pkg/hub/advisory_staleness.go
@@ -5,16 +5,28 @@ import (
 	"time"
 )
 
-// advisoryStaleThreshold is how long a hive's advisory digest may go without a
-// successful update before the hub flags it as stale. Advisory digests are
-// posted once per governor eval cycle; even a low-ACMM hive (which evaluates
-// infrequently by design — on the order of every ~10 min) posts far more often
-// than this. 90 minutes is therefore comfortably longer than any realistic
-// posting interval, so the pill only lights up on a digest path that has
-// GENUINELY wedged (a working App that has quietly stopped posting), never on a
-// hive that is merely slow. Kept a named constant with this reasoning so the
-// threshold is not a bare magic number.
+// advisoryStaleThreshold is the historical minimum age before the hub flags a
+// digest as stale. advisoryStaleThresholdFor expands it when the spoke reports
+// a deliberately slower configured update interval, so existing/default hives
+// retain the exact 90-minute behavior while slow healthy hives do not alarm.
 const advisoryStaleThreshold = 90 * time.Minute
+
+const advisoryDefaultUpdateInterval = 60 * time.Second
+
+// advisoryStaleThresholdFor preserves the historical 90-minute threshold for
+// old/default spokes and expands it for intentionally slower digest cadences.
+// Two configured intervals allow normal scheduling jitter and one delayed
+// cycle before declaring the path wedged.
+func advisoryStaleThresholdFor(e RegistryEntry) time.Duration {
+	baseline := advisoryDefaultUpdateInterval
+	if configured := time.Duration(e.AdvisoryUpdateIntervalS) * time.Second; configured > baseline {
+		baseline = configured
+	}
+	if intervalThreshold := 2 * baseline; intervalThreshold > advisoryStaleThreshold {
+		return intervalThreshold
+	}
+	return advisoryStaleThreshold
+}
 
 // appCanWriteForAdvisory reports whether a hive's GitHub App is in a state that
 // COULD post an advisory digest right now. It is the "app can write" gate on
@@ -214,7 +226,7 @@ func advisoryStale(e RegistryEntry, now time.Time) (stale bool, reason string) {
 	if err != nil {
 		return false, ""
 	}
-	if now.Sub(postedAt) > advisoryStaleThreshold {
+	if now.Sub(postedAt) > advisoryStaleThresholdFor(e) {
 		return true, "advisory digest has not updated since " + postedAt.UTC().Format(time.RFC3339)
 	}
 	return false, ""

--- a/src/pkg/hub/advisory_staleness_test.go
+++ b/src/pkg/hub/advisory_staleness_test.go
@@ -36,6 +36,21 @@ func TestAdvisoryStale_FreshDigestNotStale(t *testing.T) {
 	}
 }
 
+func TestAdvisoryStale_LongConfiguredIntervalRemainsHealthy(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryUpdateIntervalS = int((2 * time.Hour) / time.Second)
+	e.AdvisoryLastPostedAt = rfc3339Ago(3 * time.Hour)
+
+	if stale, reason := advisoryStale(e, advNow); stale {
+		t.Fatalf("three-hour-old post on a two-hour cadence must remain healthy: %s", reason)
+	}
+
+	e.AdvisoryLastPostedAt = rfc3339Ago(5 * time.Hour)
+	if stale, _ := advisoryStale(e, advNow); !stale {
+		t.Fatal("post older than two configured intervals must be stale")
+	}
+}
+
 func TestAdvisoryStale_PastThresholdIsStale(t *testing.T) {
 	e := advisoryModeEntry()
 	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Minute)
@@ -223,9 +238,10 @@ func TestAppCanWriteForAdvisory_EmptyStateIsWritable(t *testing.T) {
 func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
 	posted := advNow.Format(time.RFC3339)
 	in := HeartbeatPayload{
-		HiveID:               "hosted-adv",
-		AdvisoryLastPostedAt: posted,
-		AdvisoryError:        "rate limit",
+		HiveID:                  "hosted-adv",
+		AdvisoryLastPostedAt:    posted,
+		AdvisoryUpdateIntervalS: 300,
+		AdvisoryError:           "rate limit",
 	}
 	b, err := json.Marshal(in)
 	if err != nil {
@@ -240,6 +256,9 @@ func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
 	}
 	if out.AdvisoryError != "rate limit" {
 		t.Fatalf("advisory_error lost in round-trip: got %q", out.AdvisoryError)
+	}
+	if out.AdvisoryUpdateIntervalS != 300 {
+		t.Fatalf("advisory_update_interval_s lost in round-trip: got %d", out.AdvisoryUpdateIntervalS)
 	}
 
 	// Empty fields must be omitted so an old spoke's wire format is untouched.

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -613,6 +613,10 @@ type HeartbeatPayload struct {
 	// same rule the codebase already applies to StartedAt/GitHubAPIURL. Only a
 	// hive that HAS posted at least once, and then stopped, can trip staleness.
 	AdvisoryLastPostedAt string `json:"advisory_last_posted_at,omitempty"`
+	// AdvisoryUpdateIntervalS is the spoke's effective configured digest
+	// cadence. The hub uses it to avoid flagging a deliberately slow healthy
+	// digest as stale. Zero from an older spoke means the historical 60s default.
+	AdvisoryUpdateIntervalS int `json:"advisory_update_interval_s,omitempty"`
 	// AdvisoryError is the log-safe error string from the spoke's most recent
 	// FAILED advisory-post attempt (403 issues:write, rate limit, auth failure),
 	// or empty when the last attempt succeeded. It is the same string the spoke

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -127,6 +127,10 @@ type RegistryEntry struct {
 	// "stale advisory" pill (advisoryStaleSummary) when this ages past
 	// advisoryStaleThreshold on a hive whose App can write.
 	AdvisoryLastPostedAt string `json:"advisoryLastPostedAt,omitempty"`
+	// AdvisoryUpdateIntervalS is the spoke's effective advisory digest cadence.
+	// It expands the stale threshold for operators who intentionally post less
+	// often. Zero from an old spoke resolves to the historical 60s default.
+	AdvisoryUpdateIntervalS int `json:"advisoryUpdateIntervalS,omitempty"`
 	// AdvisoryError is the log-safe error from the spoke's most recent failed
 	// advisory-post attempt ("" on success). When set on an app-can-write hive
 	// it trips the stale pill directly, carrying the specific cause.
@@ -1684,10 +1688,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// esc() double-escaped it into "&amp;amp;" artifacts. An empty
 		// AdvisoryLastPostedAt is preserved as empty so the render/gate reads
 		// it as UNKNOWN rather than stale.
-		AdvisoryLastPostedAt:  sanitizeField(payload.AdvisoryLastPostedAt),
-		AdvisoryFindingCount:  payload.AdvisoryFindingCount,
-		AdvisoryOverflowCount: payload.AdvisoryOverflowCount,
-		AdvisoryError:         sanitizeProseField(payload.AdvisoryError),
+		AdvisoryLastPostedAt:    sanitizeField(payload.AdvisoryLastPostedAt),
+		AdvisoryUpdateIntervalS: clampInt(payload.AdvisoryUpdateIntervalS, 0, 31_536_000),
+		AdvisoryFindingCount:    payload.AdvisoryFindingCount,
+		AdvisoryOverflowCount:   payload.AdvisoryOverflowCount,
+		AdvisoryError:           sanitizeProseField(payload.AdvisoryError),
 		// Inference-backend auth-failure signal. Sanitized like every other
 		// spoke-reported string; empty is preserved as empty (no signal).
 		InferenceAuthError:   sanitizeField(payload.InferenceAuthError),


### PR DESCRIPTION
Closes #4820

## Summary

- add `governor.advisory.update_interval_s`, preserving the existing 60-second behavior when unset or zero and clamping positive values below 30 seconds
- expose the setting in Governor Config → Advisory and apply live changes on the next eval cycle without restarting
- gate only forge-facing digest refresh attempts, leaving finding ingestion and dashboard state updates on their existing cadence
- propagate the effective interval to the hub and expand wedge-detection thresholds for intentionally slow healthy cadences
- document the interaction with the byte-identical digest guard from #4818

## Testing

- `go test ./cmd/hive ./pkg/dashboard ./pkg/hub`
- `go test ./pkg/config -run 'TestAdvisory'`
- `node .github/scripts/check-inline-js.js src/pkg/dashboard/static/index.html`

— hive: backend=codex
