### PR TITLE
✨ feat(advisory): configurable advisory-issue update interval (#4820)

### DIFF
--- a/src/cmd/hive/advisory_update_interval_test.go
+++ b/src/cmd/hive/advisory_update_interval_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// #4820: advisoryPostDue is the update-interval gate on the digest's GitHub
+// round-trip. These tests pin its three contracts: a zero interval means the
+// gate is always open (the pre-#4820 every-cycle cadence — invariant 1 of the
+// issue), the first post after process start is never delayed, and the window
+// is measured from the last SUCCESS so failures keep retrying every cycle.
+
+func TestAdvisoryPostDue_ZeroIntervalAlwaysOpen(t *testing.T) {
+	now := time.Now()
+	if !advisoryPostDue(0, now.Add(-time.Second), now) {
+		t.Error("interval 0 must open the gate every cycle — the default cadence")
+	}
+	if !advisoryPostDue(0, time.Time{}, now) {
+		t.Error("interval 0 with no prior post must open the gate")
+	}
+}
+
+func TestAdvisoryPostDue_FirstPostNeverDelayed(t *testing.T) {
+	if !advisoryPostDue(4*time.Hour, time.Time{}, time.Now()) {
+		t.Error("a zero lastSuccess (no post since process start) must open the gate regardless of interval")
+	}
+}
+
+func TestAdvisoryPostDue_WithinWindowDefers(t *testing.T) {
+	now := time.Now()
+	if advisoryPostDue(10*time.Minute, now.Add(-3*time.Minute), now) {
+		t.Error("3 minutes into a 10-minute window the gate must be closed")
+	}
+}
+
+func TestAdvisoryPostDue_PastWindowOpens(t *testing.T) {
+	now := time.Now()
+	if !advisoryPostDue(10*time.Minute, now.Add(-10*time.Minute), now) {
+		t.Error("exactly at the window boundary the gate must open")
+	}
+	if !advisoryPostDue(10*time.Minute, now.Add(-11*time.Minute), now) {
+		t.Error("past the window the gate must open")
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3632,6 +3632,17 @@ func main() {
 					_, overflow := dashSrv.AdvisoryCounts()
 					return overflow
 				}(),
+				// The spoke's EFFECTIVE advisory update interval (#4820), in
+				// seconds, so the hub can widen its staleness baseline for a
+				// hive whose operator deliberately slowed the digest cadence —
+				// a healthy 4-hour cadence must never trip the 90-minute
+				// default wedge alarm. 0 = unset (default cadence): the hub
+				// keeps its default threshold, which is also what it does for
+				// old spokes that never report the field.
+				AdvisoryUpdateIntervalS: func() int {
+					d, _ := cfg.Governor.Advisory.EffectiveUpdateInterval()
+					return int(d / time.Second)
+				}(),
 				// Inference-backend auth-failure signal (repeated 401s from a
 				// stale gateway key). Reported as its own field so the hub can
 				// raise a dedicated inference-auth alert whose ROOT cause an
@@ -5418,6 +5429,34 @@ func shouldPostAdvisoryDigest(digest *advisory.Digest, ghClient *github.Client, 
 	return ghClient != nil && hasPinnedIssue
 }
 
+// advisoryPostGate tracks, per repo, when the digest was last SUCCESSFULLY
+// posted, so governor.advisory.update_interval_s (#4820) can throttle the
+// GitHub round-trip. Package-level for the same reason as providerBudgetNotify
+// (runEvalCycle has no state of its own) and mutex-guarded for the same reason
+// too (startup/restart call sites besides the ticker). clampLogged makes the
+// "value below minimum, clamped" warning a one-shot instead of a per-cycle
+// drone.
+var advisoryPostGate = struct {
+	mu          sync.Mutex
+	lastSuccess map[string]time.Time
+	clampLogged bool
+}{lastSuccess: map[string]time.Time{}}
+
+// advisoryPostDue reports whether the update-interval gate is open for a post
+// attempt. interval 0 (unset knob) means the gate is ALWAYS open — the digest
+// posts every eval cycle, exactly the pre-#4820 cadence — and a zero
+// lastSuccess (no successful post since process start) opens it too, so the
+// first post is never delayed. The gate advances only on SUCCESS (mirroring
+// the #4818 skip-guard's hash recording): a failed attempt is retried on the
+// very next cycle instead of waiting out the configured interval, keeping
+// error recovery — and the hub's staleness signal — as prompt as today.
+func advisoryPostDue(interval time.Duration, lastSuccess, now time.Time) bool {
+	if interval <= 0 || lastSuccess.IsZero() {
+		return true
+	}
+	return now.Sub(lastSuccess) >= interval
+}
+
 // advisoryIssueMissingError is the error recorded (and reported to the hub) when
 // a hive has findings to publish but no advisory issue to publish them to. It is
 // deliberately an ERROR rather than a silent skip: the hub's staleness gate
@@ -6083,7 +6122,33 @@ func runEvalCycle(
 		// freshness: otherwise the pinned comment and AdvisoryLastPostedAt
 		// freeze after the last finding disappears, and the hub reports a stale
 		// advisory loop even though the agents are running cleanly.
-		if shouldPostAdvisoryDigest(digest, ghClient, hasExistingPinnedIssueForEmptyDigest) {
+		//
+		// The posting CADENCE is gated by governor.advisory.update_interval_s
+		// (#4820), re-read from live config every cycle like the other governor
+		// knobs, so a dashboard save takes effect without a restart. Unset/0
+		// leaves the gate always open — today's every-cycle behavior. Only the
+		// GitHub round-trip is throttled: the digest above is still built and
+		// handed to the dashboard every cycle, and the #4818 skip-if-unchanged
+		// guard still applies WITHIN each cycle the gate lets through (its
+		// forced write-through counts POST ATTEMPTS, so at a longer interval
+		// the ~hourly full rewrite stretches to 60 attempts × interval —
+		// acceptable, since the write-through only heals out-of-band comment
+		// edits). The gate advances only on SUCCESS, so quiet or failed cycles
+		// never delay the next attempt beyond today's cadence.
+		advisoryInterval, advisoryClamped := cfg.Governor.Advisory.EffectiveUpdateInterval()
+		advisoryPostGate.mu.Lock()
+		if advisoryClamped && !advisoryPostGate.clampLogged {
+			advisoryPostGate.clampLogged = true
+			logger.Warn("governor.advisory.update_interval_s below minimum — clamped",
+				"configured_s", cfg.Governor.Advisory.UpdateIntervalS,
+				"effective_s", int(advisoryInterval/time.Second))
+		}
+		advisoryLastPost := advisoryPostGate.lastSuccess[primaryRepo]
+		advisoryPostGate.mu.Unlock()
+		if !advisoryPostDue(advisoryInterval, advisoryLastPost, time.Now()) {
+			logger.Debug("advisory digest post deferred by update interval",
+				"repo", primaryRepo, "interval", advisoryInterval, "last_post", advisoryLastPost)
+		} else if shouldPostAdvisoryDigest(digest, ghClient, hasExistingPinnedIssueForEmptyDigest) {
 			// Log severity breakdown and contributing agents
 			bySeverity := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 			agentNames := make([]string, 0, len(digest.ByAgent))
@@ -6178,6 +6243,13 @@ func runEvalCycle(
 						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")
+						// Advance the update-interval gate (#4820) only on this
+						// verified success — a skipped-unchanged cycle (#4818)
+						// lands here too and counts, since it is equal proof of
+						// a prior successful write.
+						advisoryPostGate.mu.Lock()
+						advisoryPostGate.lastSuccess[primaryRepo] = time.Now()
+						advisoryPostGate.mu.Unlock()
 						// Record the fresh, successful digest post so the hub's
 						// advisory-staleness gate stays satisfied for this hive.
 						dashSrv.RecordAdvisoryPost(digest.TotalCount)

--- a/src/docs/advisory-staleness.md
+++ b/src/docs/advisory-staleness.md
@@ -10,6 +10,7 @@ never re-derives it.
 | Signal | Produced by | Notes |
 | --- | --- | --- |
 | `AdvisoryLastPostedAt` | spoke, `RecordAdvisoryPost` after a **successful** digest post | in spoke memory only; empty until the first success |
+| `AdvisoryUpdateIntervalS` | spoke, effective `governor.advisory.update_interval_s` (#4820) | widens the age threshold for an intentionally slow cadence; 0/absent (default cadence or an older spoke) keeps the default threshold |
 | `AdvisoryError` | spoke, `RecordAdvisoryError` on a failed post **attempt** | cleared by the next success |
 | `GitHubAppState` / `GitHubAppRequired` / `PendingGitHubAppInstall` | spoke App diagnosis | decides whether silence is expected |
 
@@ -31,9 +32,14 @@ never re-derives it.
    protocol fields, does *not* qualify, so the gate never silences a spoke the
    hub cannot read. A reported post **error** still flags regardless — a broken
    post path is broken whoever is paused.
-4. **Age** — with no error reported, a post time older than
-   `advisoryStaleThreshold` (90 min) is stale, but only when the App can write
-   at all (`appCanWriteForAdvisory`). Unparseable timestamps are unknown.
+4. **Age** — with no error reported, a post time older than the hive's
+   baseline is stale, but only when the App can write at all
+   (`appCanWriteForAdvisory`). The baseline is `advisoryStaleThreshold`
+   (90 min), widened to twice the spoke's reported
+   `governor.advisory.update_interval_s` when that is longer
+   (`advisoryStaleThresholdFor`) — one fully missed window plus jitter
+   headroom, so a deliberately slow healthy cadence never false-alarms.
+   Unparseable timestamps are unknown.
 
 ## Suppression matrix (#4167)
 

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -17,6 +17,7 @@ governor:
     show_all: false       # true = ignore max_findings
     staleness_days: 7
     pr_autoclose: true
+    update_interval_s: 0  # 0 = every governor cycle (the default)
 ```
 
 ## Keeping findings current
@@ -114,6 +115,29 @@ resolved) the ranking falls back to severity-then-recency and no path is
 checked. Path lookups are cached per commit and stop as soon as the cap is
 filled, so ranking the full finding set costs roughly what verifying only the
 rendered ones used to.
+
+## How often it updates
+
+By default the digest comment is checked and refreshed once per governor eval
+cycle (~60s), and since #4818 a byte-identical digest is skipped rather than
+rewritten. `governor.advisory.update_interval_s` additionally slows the
+*checking/posting cadence itself* — useful to cut GitHub API traffic,
+notification churn on watched repos, or audit-log noise.
+
+- `governor.advisory.update_interval_s` — default `0`, meaning "every eval
+  cycle": exactly the cadence every install had before the knob existed.
+  Values `1`–`29` are clamped up to `30` (logged once); there is no benefit to
+  a sub-30s cadence. The setting is re-read every cycle, so a dashboard save
+  applies live without a restart.
+- The window is measured from the last **successful** post, so a failed post is
+  retried on the very next cycle instead of waiting out the interval, and the
+  first post after process start is never delayed.
+- The dashboard's own advisory view is refreshed every cycle regardless — only
+  the GitHub comment write is paced.
+- The hub's stale-advisory alarm widens its baseline to
+  `max(90 minutes, 2 × update_interval_s)` for a hive reporting a configured
+  interval, so a deliberately slow but healthy cadence is never flagged as a
+  wedged digest.
 
 ## The digest stopped updating
 

--- a/src/pkg/config/advisory_update_interval_test.go
+++ b/src/pkg/config/advisory_update_interval_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// #4820: governor.advisory.update_interval_s throttles the advisory digest's
+// posting cadence. These tests pin the resolver contract — 0/unset means
+// "every eval cycle" (today's behavior, NOT a materialized 60), the floor
+// clamps up instead of erroring, and hive.yaml round-trips the field.
+
+// TestAdvisoryUpdateInterval_UnsetMeansDefaultCadence pins invariant 1 of the
+// issue: an untouched install resolves to a zero interval (gate always open),
+// and applyDefaults does NOT materialize a number into the field — "every
+// eval cycle" must keep tracking governor.eval_interval_s.
+func TestAdvisoryUpdateInterval_UnsetMeansDefaultCadence(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	if cfg.Governor.Advisory.UpdateIntervalS != 0 {
+		t.Errorf("applyDefaults materialized update_interval_s = %d, want 0 (unset)",
+			cfg.Governor.Advisory.UpdateIntervalS)
+	}
+	d, clamped := cfg.Governor.Advisory.EffectiveUpdateInterval()
+	if d != 0 || clamped {
+		t.Errorf("unset: EffectiveUpdateInterval() = (%v, %v), want (0, false)", d, clamped)
+	}
+}
+
+// TestAdvisoryUpdateInterval_ClampsToFloor pins the server-side clamp: a
+// configured sub-floor value (hand-edited hive.yaml included) resolves to the
+// 30s floor and reports that it was clamped, so the caller can log it once.
+func TestAdvisoryUpdateInterval_ClampsToFloor(t *testing.T) {
+	a := AdvisoryConfig{UpdateIntervalS: 10}
+	d, clamped := a.EffectiveUpdateInterval()
+	if d != MinAdvisoryUpdateIntervalS*time.Second {
+		t.Errorf("interval 10: EffectiveUpdateInterval() = %v, want %v", d, MinAdvisoryUpdateIntervalS*time.Second)
+	}
+	if !clamped {
+		t.Error("interval 10: clamped = false, want true")
+	}
+}
+
+// TestAdvisoryUpdateInterval_HonorsConfiguredValue pins the plain case: a
+// value at or above the floor is used as-is, unclamped.
+func TestAdvisoryUpdateInterval_HonorsConfiguredValue(t *testing.T) {
+	a := AdvisoryConfig{UpdateIntervalS: 300}
+	d, clamped := a.EffectiveUpdateInterval()
+	if d != 300*time.Second || clamped {
+		t.Errorf("interval 300: EffectiveUpdateInterval() = (%v, %v), want (5m0s, false)", d, clamped)
+	}
+}
+
+// TestAdvisoryUpdateInterval_YAMLRoundTrip pins the hive.yaml contract: the
+// field serializes under governor.advisory.update_interval_s, survives a
+// marshal/unmarshal cycle, and is OMITTED when unset so existing configs do
+// not grow a spurious key on the next save.
+func TestAdvisoryUpdateInterval_YAMLRoundTrip(t *testing.T) {
+	in := AdvisoryConfig{MaxFindings: 10, StalenessDays: 7, UpdateIntervalS: 300}
+	raw, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out AdvisoryConfig
+	if err := yaml.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.UpdateIntervalS != 300 {
+		t.Errorf("round-tripped update_interval_s = %d, want 300\nyaml:\n%s", out.UpdateIntervalS, raw)
+	}
+
+	unsetRaw, err := yaml.Marshal(AdvisoryConfig{MaxFindings: 10, StalenessDays: 7})
+	if err != nil {
+		t.Fatalf("marshal unset: %v", err)
+	}
+	if string(unsetRaw) != "" && yamlContainsKey(unsetRaw, "update_interval_s") {
+		t.Errorf("unset field must be omitted from yaml, got:\n%s", unsetRaw)
+	}
+}
+
+func yamlContainsKey(raw []byte, key string) bool {
+	var m map[string]any
+	if err := yaml.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
+}

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -1370,6 +1370,38 @@ type AdvisoryConfig struct {
 	// close enough to the finding's title. *bool so absent is distinct from an
 	// explicit false; default true.
 	PRAutoClose *bool `yaml:"pr_autoclose,omitempty" json:"pr_autoclose,omitempty"`
+	// UpdateIntervalS throttles how often the pinned advisory-issue digest
+	// comment is checked and refreshed, in seconds. 0 (or absent) means UNSET:
+	// the digest posts on every governor eval cycle, exactly the cadence every
+	// install had before this knob existed (#4820) — deliberately NOT
+	// materialized to a fixed number on load, because "every eval cycle"
+	// tracks governor.eval_interval_s, whatever that is set to. Values below
+	// MinAdvisoryUpdateIntervalS are clamped up at use time (hand-edited
+	// hive.yaml included), never rejected — see EffectiveUpdateInterval.
+	UpdateIntervalS int `yaml:"update_interval_s,omitempty" json:"update_interval_s,omitempty"`
+}
+
+// MinAdvisoryUpdateIntervalS is the floor for
+// governor.advisory.update_interval_s once it is set at all: a sub-30s cadence
+// only multiplies GitHub API writes — the opposite of what the knob is for —
+// so anything lower clamps up rather than erroring out a hand-edited
+// hive.yaml. Exported because the dashboard PUT handler normalizes writes to
+// the same floor.
+const MinAdvisoryUpdateIntervalS = 30
+
+// EffectiveUpdateInterval resolves UpdateIntervalS to the cadence the posting
+// loop actually honors. (0, false) when unset — the digest posts every
+// governor eval cycle, the pre-#4820 behavior — otherwise the configured
+// duration clamped to MinAdvisoryUpdateIntervalS, with clamped reporting
+// whether the floor was applied (the caller logs that once).
+func (a AdvisoryConfig) EffectiveUpdateInterval() (d time.Duration, clamped bool) {
+	if a.UpdateIntervalS <= 0 {
+		return 0, false
+	}
+	if a.UpdateIntervalS < MinAdvisoryUpdateIntervalS {
+		return MinAdvisoryUpdateIntervalS * time.Second, true
+	}
+	return time.Duration(a.UpdateIntervalS) * time.Second, false
 }
 
 // PRAutoCloseEnabled resolves AdvisoryConfig.PRAutoClose with its default (on).

--- a/src/pkg/dashboard/advisory_update_interval_ui_test.go
+++ b/src/pkg/dashboard/advisory_update_interval_ui_test.go
@@ -1,0 +1,29 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAdvisoryUpdateIntervalUIWiring pins the Advisory tab's "When it updates"
+// group (#4820) into the embedded page: the control exists, prefills from the
+// GET payload's update_interval_s, and marks its edit dirty under the
+// 'advisory' section via the CSP-safe data-action dispatch (markDirty with
+// declarative args — no inline handler, no bespoke ghNN closure to drift).
+func TestAdvisoryUpdateIntervalUIWiring(t *testing.T) {
+	raw, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	page := string(raw)
+	for _, want := range []string{
+		"When it updates",
+		"Update interval (s)",
+		`value="${a.update_interval_s || 0}"`,
+		`data-arg0="advisory" data-arg1="update_interval_s" data-arg-types="s,s,N"`,
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("Advisory tab missing update-interval wiring %q", want)
+		}
+	}
+}

--- a/src/pkg/dashboard/api_governor_advisory_test.go
+++ b/src/pkg/dashboard/api_governor_advisory_test.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 type advisoryAPIResponse struct {
-	MaxFindings   int  `json:"max_findings"`
-	ShowAll       bool `json:"show_all"`
-	StalenessDays int  `json:"staleness_days"`
-	PRAutoClose   bool `json:"pr_autoclose"`
+	MaxFindings     int  `json:"max_findings"`
+	ShowAll         bool `json:"show_all"`
+	StalenessDays   int  `json:"staleness_days"`
+	PRAutoClose     bool `json:"pr_autoclose"`
+	UpdateIntervalS int  `json:"update_interval_s"`
 }
 
 func getAdvisorySettings(t *testing.T, s *Server) advisoryAPIResponse {
@@ -84,6 +87,7 @@ func TestGovAdvisory_Validation(t *testing.T) {
 		{"negative max findings", map[string]any{"max_findings": -1}},
 		{"zero staleness", map[string]any{"staleness_days": 0}},
 		{"negative staleness", map[string]any{"staleness_days": -7}},
+		{"negative update interval", map[string]any{"update_interval_s": -60}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if rec := doPut(s, "/api/config/governor/advisory", tc.body); rec.Code != http.StatusBadRequest {
@@ -94,6 +98,51 @@ func TestGovAdvisory_Validation(t *testing.T) {
 
 	if rec := doPutRaw(s, "/api/config/governor/advisory", "not json"); rec.Code != http.StatusBadRequest {
 		t.Fatalf("bad body: expected 400, got %d", rec.Code)
+	}
+}
+
+// TestGovAdvisory_UpdateInterval pins the #4820 wiring end to end: the field
+// round-trips through PUT and GET, 0 means default (and is what an untouched
+// server reports), a sub-floor write is normalized up to the 30s floor so the
+// GET reports the cadence the hive actually runs, and an absent key leaves
+// the setting alone.
+func TestGovAdvisory_UpdateInterval(t *testing.T) {
+	s := govServer(t)
+
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != 0 {
+		t.Fatalf("untouched update_interval_s = %d, want 0 (default cadence)", got.UpdateIntervalS)
+	}
+
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"update_interval_s": 300}); rec.Code != http.StatusOK {
+		t.Fatalf("put update_interval_s: %d — %s", rec.Code, rec.Body.String())
+	}
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != 300 {
+		t.Fatalf("update_interval_s = %d, want 300", got.UpdateIntervalS)
+	}
+	if s.deps.Config.Governor.Advisory.UpdateIntervalS != 300 {
+		t.Fatal("PUT did not persist update_interval_s into config")
+	}
+
+	// A sub-floor value is clamped up at write time, never stored as typed.
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"update_interval_s": 10}); rec.Code != http.StatusOK {
+		t.Fatalf("put sub-floor interval: %d", rec.Code)
+	}
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != config.MinAdvisoryUpdateIntervalS {
+		t.Fatalf("sub-floor write stored %d, want the %d floor", got.UpdateIntervalS, config.MinAdvisoryUpdateIntervalS)
+	}
+
+	// Absent key = untouched; explicit 0 = back to default cadence.
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"max_findings": 5}); rec.Code != http.StatusOK {
+		t.Fatalf("unrelated put: %d", rec.Code)
+	}
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != config.MinAdvisoryUpdateIntervalS {
+		t.Fatalf("absent key changed update_interval_s to %d", got.UpdateIntervalS)
+	}
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"update_interval_s": 0}); rec.Code != http.StatusOK {
+		t.Fatalf("put zero interval: %d", rec.Code)
+	}
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != 0 {
+		t.Fatalf("explicit 0 stored as %d, want 0 (default cadence, gate always open)", got.UpdateIntervalS)
 	}
 }
 

--- a/src/pkg/dashboard/api_governor_features.go
+++ b/src/pkg/dashboard/api_governor_features.go
@@ -247,10 +247,11 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var body struct {
-		MaxFindings   *int  `json:"max_findings"`
-		ShowAll       *bool `json:"show_all"`
-		StalenessDays *int  `json:"staleness_days"`
-		PRAutoClose   *bool `json:"pr_autoclose"`
+		MaxFindings     *int  `json:"max_findings"`
+		ShowAll         *bool `json:"show_all"`
+		StalenessDays   *int  `json:"staleness_days"`
+		PRAutoClose     *bool `json:"pr_autoclose"`
+		UpdateIntervalS *int  `json:"update_interval_s"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -264,6 +265,10 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 	}
 	if body.StalenessDays != nil && *body.StalenessDays < minAdvisoryStalenessDays {
 		jsonError(w, "staleness_days must be 1 or greater", http.StatusBadRequest)
+		return
+	}
+	if body.UpdateIntervalS != nil && *body.UpdateIntervalS < 0 {
+		jsonError(w, "update_interval_s must be 0 (default) or greater", http.StatusBadRequest)
 		return
 	}
 
@@ -282,6 +287,17 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 		v := *body.PRAutoClose
 		cfg.Governor.Advisory.PRAutoClose = &v
 	}
+	if body.UpdateIntervalS != nil {
+		// Normalize the write to the same floor EffectiveUpdateInterval
+		// enforces at use time, so the value the GET reports back is the
+		// cadence the hive actually runs. 0 stays 0 — it means "default
+		// cadence" (every eval cycle), not "post continuously".
+		v := *body.UpdateIntervalS
+		if v > 0 && v < config.MinAdvisoryUpdateIntervalS {
+			v = config.MinAdvisoryUpdateIntervalS
+		}
+		cfg.Governor.Advisory.UpdateIntervalS = v
+	}
 
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after advisory update", "error", err)
@@ -297,10 +313,11 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 func advisorySectionResponse(cfg *config.Config) map[string]interface{} {
 	a := cfg.Governor.Advisory
 	return map[string]interface{}{
-		"max_findings":   a.MaxFindings,
-		"show_all":       a.ShowAll,
-		"staleness_days": a.StalenessDays,
-		"pr_autoclose":   a.PRAutoCloseEnabled(),
+		"max_findings":      a.MaxFindings,
+		"show_all":          a.ShowAll,
+		"staleness_days":    a.StalenessDays,
+		"pr_autoclose":      a.PRAutoCloseEnabled(),
+		"update_interval_s": a.UpdateIntervalS,
 	}
 }
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -20394,6 +20394,14 @@ function burnAreaChart() {
             <div class="config-toggle-switch ${a.pr_autoclose === false ? '' : 'on'}" data-action="toggleConfigSwitch" data-section="advisory" data-key="pr_autoclose"></div>
             <span class="config-toggle-label">Close findings fixed by a merged PR <span style="color:var(--muted);font-weight:400">— match merged PR titles against open findings</span></span>
           </div>
+        </div>
+
+        <div style="margin:18px 0;padding-top:14px;border-top:1px solid var(--border)">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">When it updates</div>
+          <div class="config-field">
+            <label>Update interval (s) <span class="config-info">i<span class="config-tooltip">How often the digest comment on the advisory issue is checked and refreshed, in seconds. 0 means the default: every governor cycle (~60s). Values below 30 are raised to 30. Longer intervals reduce GitHub API writes and notification churn on watched repos; unchanged digests are already skipped either way.</span></span></label>
+            <input type="number" min="0" step="1" value="${a.update_interval_s || 0}" placeholder="60" data-change-action="markDirty" data-arg0="advisory" data-arg1="update_interval_s" data-arg-types="s,s,N">
+          </div>
         </div>`;
     }
 

--- a/src/pkg/hub/advisory_diagnostics.go
+++ b/src/pkg/hub/advisory_diagnostics.go
@@ -111,7 +111,7 @@ func diagnoseAdvisory(e RegistryEntry, now time.Time) AdvisoryDiagnosis {
 	aged := false
 	if parseErr == nil {
 		d.AgeMinutes = int64(now.Sub(postedAt) / time.Minute)
-		aged = now.Sub(postedAt) > advisoryStaleThreshold
+		aged = now.Sub(postedAt) > advisoryStaleThresholdFor(e)
 	}
 
 	if stale, reason := advisoryStale(e, now); stale {

--- a/src/pkg/hub/advisory_interval_staleness_test.go
+++ b/src/pkg/hub/advisory_interval_staleness_test.go
@@ -1,0 +1,86 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// #4820 invariant 2: a hive whose operator deliberately slowed the advisory
+// cadence (governor.advisory.update_interval_s, reported over the heartbeat)
+// must not false-alarm as wedged. The staleness baseline becomes
+// max(advisoryStaleThreshold, 2× the reported interval); hives reporting no
+// interval keep the default threshold exactly as before.
+
+// TestAdvisoryStale_LongIntervalHealthyNotStale: a 2-hour cadence posting on
+// schedule ages past the 90-minute default between posts — the widened
+// baseline (4h) must keep it quiet.
+func TestAdvisoryStale_LongIntervalHealthyNotStale(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryUpdateIntervalS = 7200 // 2h configured cadence
+	e.AdvisoryLastPostedAt = rfc3339Ago(100 * time.Minute)
+
+	if stale, reason := advisoryStale(e, advNow); stale {
+		t.Fatalf("a healthy 2h cadence 100min after its last post must not be stale, got %q", reason)
+	}
+}
+
+// TestAdvisoryStale_LongIntervalGenuinelyWedgedStillFlags: the widened
+// baseline is 2× the interval, not infinity — a 2h-cadence hive silent for 5
+// hours HAS missed windows and must still alarm.
+func TestAdvisoryStale_LongIntervalGenuinelyWedgedStillFlags(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryUpdateIntervalS = 7200
+	e.AdvisoryLastPostedAt = rfc3339Ago(5 * time.Hour)
+
+	stale, reason := advisoryStale(e, advNow)
+	if !stale {
+		t.Fatal("a 2h-cadence hive silent for 5h must be flagged stale")
+	}
+	if !strings.Contains(reason, "has not updated since") {
+		t.Errorf("reason = %q, want the aged-digest cause", reason)
+	}
+}
+
+// TestAdvisoryStale_NoIntervalKeepsDefaultThreshold pins that nothing changes
+// for existing fleets: an entry reporting no interval (0 — unset knob, or an
+// old spoke) uses exactly advisoryStaleThreshold.
+func TestAdvisoryStale_NoIntervalKeepsDefaultThreshold(t *testing.T) {
+	if got := advisoryStaleThresholdFor(advisoryModeEntry()); got != advisoryStaleThreshold {
+		t.Errorf("no interval: threshold = %v, want default %v", got, advisoryStaleThreshold)
+	}
+
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(advisoryStaleThreshold + time.Minute)
+	if stale, _ := advisoryStale(e, advNow); !stale {
+		t.Error("default-cadence hive past the default threshold must still alarm — pre-#4820 behavior")
+	}
+}
+
+// TestAdvisoryStaleThresholdFor_ShortIntervalNeverShrinks: an interval shorter
+// than the default (e.g. the 30s floor) must not LOWER the baseline — the
+// widening is one-directional.
+func TestAdvisoryStaleThresholdFor_ShortIntervalNeverShrinks(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryUpdateIntervalS = 30
+	if got := advisoryStaleThresholdFor(e); got != advisoryStaleThreshold {
+		t.Errorf("30s interval: threshold = %v, want default %v (never below it)", got, advisoryStaleThreshold)
+	}
+}
+
+// TestAdvisoryDiagnostics_LongIntervalAgedUsesSameBaseline keeps the
+// diagnostics view consistent with the alarm: the same widened baseline
+// decides "aged", so the fleet report cannot disagree with the pill.
+func TestAdvisoryDiagnostics_LongIntervalAgedUsesSameBaseline(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryUpdateIntervalS = 7200
+	e.AdvisoryLastPostedAt = rfc3339Ago(100 * time.Minute)
+
+	d := diagnoseAdvisory(e, advNow)
+	if d.Class != advisoryClassFresh {
+		t.Errorf("healthy 2h-cadence hive diagnosed as %q, want %q", d.Class, advisoryClassFresh)
+	}
+	if d.HiddenStale {
+		t.Error("a within-baseline digest must not count as hidden-stale")
+	}
+}

--- a/src/pkg/hub/advisory_staleness.go
+++ b/src/pkg/hub/advisory_staleness.go
@@ -16,6 +16,24 @@ import (
 // threshold is not a bare magic number.
 const advisoryStaleThreshold = 90 * time.Minute
 
+// advisoryStaleThresholdFor is the staleness baseline for ONE hive:
+// max(advisoryStaleThreshold, 2× the spoke's reported update interval). Since
+// #4820 an operator can deliberately slow the digest cadence past the default
+// 90-minute threshold (e.g. a 4-hour interval), and the spoke reports the
+// effective interval over the heartbeat exactly so that healthy slowness is
+// never read as a wedge. Twice the interval, not the interval itself: a hive
+// posting exactly on schedule would otherwise brush the threshold every window
+// and flap the pill on any jitter — doubling means one FULLY missed window
+// plus the same again as headroom before the alarm fires. A zero/absent
+// interval (default cadence, or an old spoke) keeps the default threshold, so
+// nothing changes for existing fleets.
+func advisoryStaleThresholdFor(e RegistryEntry) time.Duration {
+	if iv := time.Duration(e.AdvisoryUpdateIntervalS) * time.Second; 2*iv > advisoryStaleThreshold {
+		return 2 * iv
+	}
+	return advisoryStaleThreshold
+}
+
 // appCanWriteForAdvisory reports whether a hive's GitHub App is in a state that
 // COULD post an advisory digest right now. It is the "app can write" gate on
 // the staleness alarm: a hive that legitimately cannot post — the App is not
@@ -214,7 +232,7 @@ func advisoryStale(e RegistryEntry, now time.Time) (stale bool, reason string) {
 	if err != nil {
 		return false, ""
 	}
-	if now.Sub(postedAt) > advisoryStaleThreshold {
+	if now.Sub(postedAt) > advisoryStaleThresholdFor(e) {
 		return true, "advisory digest has not updated since " + postedAt.UTC().Format(time.RFC3339)
 	}
 	return false, ""

--- a/src/pkg/hub/advisory_staleness_test.go
+++ b/src/pkg/hub/advisory_staleness_test.go
@@ -223,9 +223,10 @@ func TestAppCanWriteForAdvisory_EmptyStateIsWritable(t *testing.T) {
 func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
 	posted := advNow.Format(time.RFC3339)
 	in := HeartbeatPayload{
-		HiveID:               "hosted-adv",
-		AdvisoryLastPostedAt: posted,
-		AdvisoryError:        "rate limit",
+		HiveID:                  "hosted-adv",
+		AdvisoryLastPostedAt:    posted,
+		AdvisoryError:           "rate limit",
+		AdvisoryUpdateIntervalS: 300,
 	}
 	b, err := json.Marshal(in)
 	if err != nil {
@@ -241,6 +242,9 @@ func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
 	if out.AdvisoryError != "rate limit" {
 		t.Fatalf("advisory_error lost in round-trip: got %q", out.AdvisoryError)
 	}
+	if out.AdvisoryUpdateIntervalS != 300 {
+		t.Fatalf("advisory_update_interval_s lost in round-trip: got %d", out.AdvisoryUpdateIntervalS)
+	}
 
 	// Empty fields must be omitted so an old spoke's wire format is untouched.
 	empty, _ := json.Marshal(HeartbeatPayload{HiveID: "x"})
@@ -251,6 +255,9 @@ func TestHeartbeatPayload_CarriesAdvisoryFields(t *testing.T) {
 	}
 	if _, ok := m["advisory_error"]; ok {
 		t.Fatalf("advisory_error must be omitted when empty")
+	}
+	if _, ok := m["advisory_update_interval_s"]; ok {
+		t.Fatalf("advisory_update_interval_s must be omitted when zero — old spokes' wire format is untouched")
 	}
 }
 

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -626,6 +626,15 @@ type HeartbeatPayload struct {
 	// whole picture when it is deliberately only the top of it.
 	AdvisoryFindingCount  int `json:"advisory_finding_count,omitempty"`
 	AdvisoryOverflowCount int `json:"advisory_overflow_count,omitempty"`
+	// AdvisoryUpdateIntervalS is the spoke's EFFECTIVE
+	// governor.advisory.update_interval_s (#4820), in seconds — already
+	// clamped to its floor, so the hub can trust it as the real cadence. The
+	// hub widens its advisory-staleness baseline to cover it, so an operator
+	// who deliberately slowed the digest cadence is never false-alarmed as
+	// wedged. 0 means unset (default every-cycle cadence) — the same thing an
+	// old spoke that never reports the field looks like — and keeps the hub's
+	// default threshold.
+	AdvisoryUpdateIntervalS int `json:"advisory_update_interval_s,omitempty"`
 	// InferenceAuthError is the log-safe cause string set when this spoke's
 	// self-hosted inference backend (LiteLLM/vLLM/llm-d gateway) has rejected
 	// several CONSECUTIVE calls with 401 — a stale/invalid gateway key that

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -137,6 +137,12 @@ type RegistryEntry struct {
 	// it). My Hives renders the pair so a capped digest never reads as complete.
 	AdvisoryFindingCount  int `json:"advisoryFindingCount,omitempty"`
 	AdvisoryOverflowCount int `json:"advisoryOverflowCount,omitempty"`
+	// AdvisoryUpdateIntervalS is the spoke's effective advisory update
+	// interval in seconds (#4820), 0 when unset (default cadence) or the spoke
+	// is too old to report it. The staleness gate widens its baseline to
+	// max(advisoryStaleThreshold, 2× this) so a deliberately slowed but
+	// healthy cadence never reads as a wedge — see advisoryStaleThresholdFor.
+	AdvisoryUpdateIntervalS int `json:"advisoryUpdateIntervalS,omitempty"`
 	// InferenceAuthError is the log-safe cause set when the spoke's inference
 	// backend has rejected several consecutive calls with 401 (a stale gateway
 	// key). Empty = inference auth healthy / no inference backend / old spoke,
@@ -1687,7 +1693,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AdvisoryLastPostedAt:  sanitizeField(payload.AdvisoryLastPostedAt),
 		AdvisoryFindingCount:  payload.AdvisoryFindingCount,
 		AdvisoryOverflowCount: payload.AdvisoryOverflowCount,
-		AdvisoryError:         sanitizeProseField(payload.AdvisoryError),
+		// Clamped to a week: an absurd spoke-reported interval must not be
+		// able to disable the staleness alarm outright.
+		AdvisoryUpdateIntervalS: clampInt(payload.AdvisoryUpdateIntervalS, 0, 7*24*3600),
+		AdvisoryError:           sanitizeProseField(payload.AdvisoryError),
 		// Inference-backend auth-failure signal. Sanitized like every other
 		// spoke-reported string; empty is preserved as empty (no signal).
 		InferenceAuthError:   sanitizeField(payload.InferenceAuthError),


### PR DESCRIPTION
Fixes #4820

Companion to #4821 (the #4818 skip-if-unchanged guard, merged as 1c366e8d): that eliminated redundant *writes*; this makes the *checking/posting cadence itself* configurable.

## What

`governor.advisory.update_interval_s` (int seconds) in the existing `advisory` governor section, exposed in **Settings → Advisory** under a new **When it updates** group.

## Invariants (from the issue)

1. **Unset/0 → exactly today's cadence.** The field is not materialized on load ("every eval cycle" must keep tracking `governor.eval_interval_s`), and `advisoryPostDue(0, …)` is unconditionally open. Pinned by `TestAdvisoryUpdateInterval_UnsetMeansDefaultCadence`, `TestAdvisoryPostDue_ZeroIntervalAlwaysOpen`, `TestGovAdvisory_UpdateInterval`.
2. **Wedge alarm baselines on max(configured, default).** The spoke reports its *effective* interval over the heartbeat; the hub widens the staleness baseline to `max(90m, 2× interval)` in both `advisoryStale` and the diagnostics report (`advisoryStaleThresholdFor`). 2× = one fully missed window + jitter headroom, so an on-schedule slow cadence never brushes the threshold. Ingest clamps the reported value to a week so a rogue spoke can't disable the alarm; 0/absent (old spokes) keeps the default threshold — nothing changes for existing fleets. Pinned by `TestAdvisoryStale_LongIntervalHealthyNotStale` / `…GenuinelyWedgedStillFlags` / `…NoIntervalKeepsDefaultThreshold` / `…ShortIntervalNeverShrinks`.
3. **#4818 interaction.** Skip-if-unchanged still applies within each admitted cycle; the interval gate advances **only on a verified successful post** (mirroring the hash-recording rule), so failed posts retry every cycle, the first post after start is never delayed, and `RecordAdvisoryPost` semantics are unchanged. The digest is still built and handed to the dashboard every cycle — only the GitHub round-trip is paced. Note: the #4818 write-through counts post *attempts*, so at a longer interval the forced full rewrite stretches to 60 attempts × interval (documented; it only heals out-of-band comment edits).
4. **Server-side clamp ≥30s, logged once** — at use time via `EffectiveUpdateInterval` (covers hand-edited hive.yaml) *and* normalized at PUT so GET reports the cadence actually run; negative values are 400-rejected. Config is re-read live each cycle, so a dashboard save applies without restart (documented in advisory.md).
5. **hive.yaml round-trip** (`omitempty` pinned so untouched configs don't grow the key) + GET/PUT wiring tests; UI uses the existing `markDirty` dirty-section → `PUT /api/config/governor/advisory` pattern (`data-arg-types="s,s,N"`, no inline handlers).

## Verification

- Targeted + full suites green: config 93.6%, hub 88.7% (floor 87), dashboard 85.3% (floor 82); full `cmd/hive` green.
- Mutation checks: disabling the hub threshold widening → hub tests FAIL; forcing the gate always-open → `TestAdvisoryPostDue_WithinWindowDefers` FAILs.
- `check-inline-js` CSP guard passes on the index.html change.
- Docs: `src/docs/advisory.md` gains a "How often it updates" section.
