### PR TITLE
✨ feat(advisory): configurable advisory-issue update interval

### DIFF
--- a/src/cmd/hive/advisory_post_gate_test.go
+++ b/src/cmd/hive/advisory_post_gate_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// resetAdvisoryPostGate isolates each test from the package-level gate state.
+func resetAdvisoryPostGate() {
+	advisoryPostGate.mu.Lock()
+	defer advisoryPostGate.mu.Unlock()
+	advisoryPostGate.lastSuccess = map[string]time.Time{}
+	advisoryPostGate.clampLogged = false
+}
+
+// TestAdvisoryPostDue_UnsetIntervalPostsEveryCycle pins invariant 1 of #4820:
+// 0/unset update_interval_s is EXACTLY today's cadence — the gate is open on
+// every consecutive cycle, even immediately after a success.
+func TestAdvisoryPostDue_UnsetIntervalPostsEveryCycle(t *testing.T) {
+	resetAdvisoryPostGate()
+	now := time.Now()
+	cfg := config.AdvisoryConfig{} // update_interval_s absent
+	for i := 0; i < 3; i++ {
+		if !advisoryPostDue(cfg, "org/repo", now, slog.Default()) {
+			t.Fatalf("cycle %d: unset interval must post every cycle", i)
+		}
+		recordAdvisoryPostSuccess("org/repo", now)
+		now = now.Add(time.Second) // far shorter than any legal interval
+	}
+}
+
+// TestAdvisoryPostDue_ThrottlesUntilIntervalElapses pins the throttle: after a
+// successful post, the gate stays closed until the configured interval has
+// fully elapsed, then opens.
+func TestAdvisoryPostDue_ThrottlesUntilIntervalElapses(t *testing.T) {
+	resetAdvisoryPostGate()
+	now := time.Now()
+	cfg := config.AdvisoryConfig{UpdateIntervalS: 300}
+
+	if !advisoryPostDue(cfg, "org/repo", now, slog.Default()) {
+		t.Fatal("first post must never be delayed")
+	}
+	recordAdvisoryPostSuccess("org/repo", now)
+
+	if advisoryPostDue(cfg, "org/repo", now.Add(299*time.Second), slog.Default()) {
+		t.Fatal("gate must stay closed inside the configured interval")
+	}
+	if !advisoryPostDue(cfg, "org/repo", now.Add(300*time.Second), slog.Default()) {
+		t.Fatal("gate must open once the interval has elapsed")
+	}
+}
+
+// TestAdvisoryPostDue_FailedAttemptRetriesNextCycle pins the success-only
+// advance: the gate moves ONLY via recordAdvisoryPostSuccess, so a failed post
+// attempt is retried on the very next cycle instead of waiting out the
+// interval — error recovery (and the hub's staleness signal) stays as prompt
+// as before #4820.
+func TestAdvisoryPostDue_FailedAttemptRetriesNextCycle(t *testing.T) {
+	resetAdvisoryPostGate()
+	now := time.Now()
+	cfg := config.AdvisoryConfig{UpdateIntervalS: 3600}
+
+	if !advisoryPostDue(cfg, "org/repo", now, slog.Default()) {
+		t.Fatal("first attempt must be allowed")
+	}
+	// The attempt FAILED: no recordAdvisoryPostSuccess. The next cycle must be
+	// allowed to retry immediately.
+	if !advisoryPostDue(cfg, "org/repo", now.Add(time.Minute), slog.Default()) {
+		t.Fatal("a failed attempt must not consume the interval window")
+	}
+}
+
+// TestAdvisoryPostDue_PerRepoIsolation pins that the gate is keyed per repo: a
+// primary-repo change (the reinit path) starts with an open gate for the new
+// repo instead of inheriting the old repo's window.
+func TestAdvisoryPostDue_PerRepoIsolation(t *testing.T) {
+	resetAdvisoryPostGate()
+	now := time.Now()
+	cfg := config.AdvisoryConfig{UpdateIntervalS: 3600}
+	recordAdvisoryPostSuccess("org/old", now)
+
+	if advisoryPostDue(cfg, "org/old", now.Add(time.Minute), slog.Default()) {
+		t.Fatal("old repo's window must still be closed")
+	}
+	if !advisoryPostDue(cfg, "org/new", now.Add(time.Minute), slog.Default()) {
+		t.Fatal("a different repo must not inherit another repo's window")
+	}
+}
+
+// TestAdvisoryPostDue_ClampLogsOnce pins the clamp warning contract: an
+// out-of-band value is clamped at use time (here: below the minimum) and the
+// operator is told exactly once, not once per eval cycle.
+func TestAdvisoryPostDue_ClampLogsOnce(t *testing.T) {
+	resetAdvisoryPostGate()
+	now := time.Now()
+	cfg := config.AdvisoryConfig{UpdateIntervalS: 5} // below the 30s floor
+
+	if !advisoryPostDue(cfg, "org/repo", now, slog.Default()) {
+		t.Fatal("first post must be allowed")
+	}
+	recordAdvisoryPostSuccess("org/repo", now)
+	// Clamped to 30s, not the raw 5s: at +10s the gate must still be closed.
+	if advisoryPostDue(cfg, "org/repo", now.Add(10*time.Second), slog.Default()) {
+		t.Fatal("a 5s value must be clamped up to the 30s floor, not honored")
+	}
+	if !advisoryPostDue(cfg, "org/repo", now.Add(31*time.Second), slog.Default()) {
+		t.Fatal("gate must open after the clamped 30s interval")
+	}
+	advisoryPostGate.mu.Lock()
+	logged := advisoryPostGate.clampLogged
+	advisoryPostGate.mu.Unlock()
+	if !logged {
+		t.Fatal("clamped value must set the one-shot warning flag")
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -5418,6 +5418,54 @@ func shouldPostAdvisoryDigest(digest *advisory.Digest, ghClient *github.Client, 
 	return ghClient != nil && hasPinnedIssue
 }
 
+// advisoryPostGate tracks, per repo, when the digest was last SUCCESSFULLY
+// posted, so governor.advisory.update_interval_s (#4820) can throttle the
+// GitHub round-trip. Package-level because runEvalCycle carries no state of
+// its own, and mutex-guarded because startup/restart call sites exist besides
+// the ticker. clampLogged makes the "interval clamped" warning a one-shot
+// instead of a per-cycle drone.
+var advisoryPostGate = struct {
+	mu          sync.Mutex
+	lastSuccess map[string]time.Time
+	clampLogged bool
+}{lastSuccess: map[string]time.Time{}}
+
+// advisoryPostDue reports whether the update-interval gate is open for a post
+// attempt to repo, logging (once) if the configured value was clamped. An
+// interval of 0 (unset knob) means the gate is ALWAYS open — the digest posts
+// every eval cycle, exactly the pre-#4820 cadence — and a repo with no
+// successful post since process start is open too, so the first post is never
+// delayed. The gate advances only on SUCCESS (recordAdvisoryPostSuccess,
+// mirroring how the #4818 skip-guard records its hash): a failed attempt is
+// retried on the very next cycle instead of waiting out the interval, keeping
+// error recovery — and the hub's staleness signal — as prompt as today.
+func advisoryPostDue(advCfg config.AdvisoryConfig, repo string, now time.Time, logger *slog.Logger) bool {
+	interval := advCfg.UpdateInterval()
+	advisoryPostGate.mu.Lock()
+	defer advisoryPostGate.mu.Unlock()
+	if raw := advCfg.UpdateIntervalS; raw > 0 && time.Duration(raw)*time.Second != interval && !advisoryPostGate.clampLogged {
+		advisoryPostGate.clampLogged = true
+		logger.Warn("advisory update_interval_s outside allowed bounds — clamped",
+			"configured_s", raw, "effective_s", int(interval.Seconds()),
+			"min_s", config.MinAdvisoryUpdateIntervalS, "max_s", config.MaxAdvisoryUpdateIntervalS)
+	}
+	if interval <= 0 {
+		return true
+	}
+	last, ok := advisoryPostGate.lastSuccess[repo]
+	return !ok || now.Sub(last) >= interval
+}
+
+// recordAdvisoryPostSuccess advances the update-interval gate for repo after a
+// successful digest write. Skip-if-unchanged cycles count too: pkg/github
+// returns nil for them by design so freshness advances (#4818/#4821), and an
+// unchanged digest is exactly the case the throttle exists to quiet.
+func recordAdvisoryPostSuccess(repo string, now time.Time) {
+	advisoryPostGate.mu.Lock()
+	defer advisoryPostGate.mu.Unlock()
+	advisoryPostGate.lastSuccess[repo] = now
+}
+
 // advisoryIssueMissingError is the error recorded (and reported to the hub) when
 // a hive has findings to publish but no advisory issue to publish them to. It is
 // deliberately an ERROR rather than a silent skip: the hub's staleness gate
@@ -6083,7 +6131,20 @@ func runEvalCycle(
 		// freshness: otherwise the pinned comment and AdvisoryLastPostedAt
 		// freeze after the last finding disappears, and the hub reports a stale
 		// advisory loop even though the agents are running cleanly.
-		if shouldPostAdvisoryDigest(digest, ghClient, hasExistingPinnedIssueForEmptyDigest) {
+		//
+		// advisoryPostDue additionally paces the GitHub write to the
+		// operator's governor.advisory.update_interval_s (#4820); 0/unset
+		// keeps this exact per-cycle cadence. cfg is read live each cycle —
+		// the same pattern as the staleness/max-findings knobs above — so a
+		// dashboard edit applies from the next cycle without a restart. The
+		// digest itself and the dashboard state above still refresh every
+		// cycle; only the comment write is throttled. Note the #4821
+		// write-through counts consecutive unchanged post ATTEMPTS, so its
+		// forced full rewrite stretches with this interval (60 attempts ×
+		// interval) — acceptable, since it only heals out-of-band comment
+		// edits, and documented in the settings tooltip.
+		if shouldPostAdvisoryDigest(digest, ghClient, hasExistingPinnedIssueForEmptyDigest) &&
+			advisoryPostDue(advCfg, primaryRepo, time.Now(), logger) {
 			// Log severity breakdown and contributing agents
 			bySeverity := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
 			agentNames := make([]string, 0, len(digest.ByAgent))
@@ -6181,6 +6242,7 @@ func runEvalCycle(
 						// Record the fresh, successful digest post so the hub's
 						// advisory-staleness gate stays satisfied for this hive.
 						dashSrv.RecordAdvisoryPost(digest.TotalCount)
+						recordAdvisoryPostSuccess(primaryRepo, time.Now())
 						dashSrv.RecordAdvisoryOverflow(digest.OverflowCount)
 						// A successful write proves the app is installed AND has
 						// write access — clear BOTH the perm issue and the

--- a/src/docs/advisory.md
+++ b/src/docs/advisory.md
@@ -17,6 +17,7 @@ governor:
     show_all: false       # true = ignore max_findings
     staleness_days: 7
     pr_autoclose: true
+    update_interval_s: 0  # 0 = default (~60s cycle); 30–3600 to slow the refresh
 ```
 
 ## Keeping findings current
@@ -118,7 +119,11 @@ rendered ones used to.
 ## The digest stopped updating
 
 The digest is posted to one pinned issue per repo, titled **🐝 Hive Advisory
-Report**. Three things can stop it, and all three now surface rather than fail
+Report**. By default it refreshes every governor eval cycle (~60s); an operator
+can slow that deliberately (see below), which is a configured cadence, not a
+stall.
+
+Three things can stop it, and all three now surface rather than fail
 quietly:
 
 - **The pinned issue could not be resolved.** The hive ensures the issue at boot;
@@ -147,6 +152,33 @@ To check freshness: the hive's row on the hub shows the last successful post
 time and any error; on the spoke, `posted advisory digest` is logged at INFO on
 every successful update, and `advisory digest not posted` at WARN when there is
 nothing to post to.
+
+## How often the digest updates
+
+`governor.advisory.update_interval_s` — default `0`, meaning the digest is
+checked and refreshed every governor eval cycle (~60s), exactly the behavior
+before the knob existed. Set it between `30` and `3600` seconds to slow the
+refresh — useful to cut GitHub API writes, notification churn on watched
+repos, and audit-log noise. Also editable from **Governor Config → Advisory →
+When it updates**; dashboard edits apply live from the next cycle, no restart.
+
+Details worth knowing:
+
+- The throttle paces only the GitHub comment write. The digest itself, the
+  dashboard view, and the status broadcast still refresh every cycle.
+- The window advances only on a **successful** post, so a failed write is
+  retried on the very next cycle rather than waiting out the interval.
+- A brand-new finding on a quiet hive posts immediately; only subsequent
+  refreshes wait for the interval.
+- Byte-identical digests are skipped regardless of this setting, with a
+  periodic forced full rewrite to heal hand-edited comments; that forced
+  rewrite is counted in post attempts, so its spacing stretches proportionally
+  at longer intervals.
+- The maximum (1 hour) is deliberately capped under the hub's 90-minute
+  wedged-digest alarm, so a healthy slow cadence can never be flagged as a
+  stalled digest.
+- Values outside the band are rejected by the dashboard API and clamped (with
+  a one-time warning in the hive log) when hand-edited into `hive.yaml`.
 
 ## Related
 

--- a/src/pkg/config/advisory_config_test.go
+++ b/src/pkg/config/advisory_config_test.go
@@ -1,6 +1,12 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
 
 // TestAdvisoryConfigDefaults pins the shipped advisory behavior for a hive that
 // says nothing: a ten-finding digest, a week-long staleness window, and
@@ -56,5 +62,73 @@ func TestAdvisoryConfigDefaultsPreserveExplicitValues(t *testing.T) {
 	}
 	if a.PRAutoCloseEnabled() {
 		t.Error("PRAutoCloseEnabled() = true, want false when explicitly disabled")
+	}
+}
+
+// TestAdvisoryUpdateInterval pins update_interval_s resolution (#4820):
+// 0/absent/negative mean "post every eval cycle" — exactly the pre-#4820
+// behavior, so existing installs see no change — and set values clamp into
+// [MinAdvisoryUpdateIntervalS, MaxAdvisoryUpdateIntervalS] so a typo can
+// neither disable the throttle silently nor slow a hive past the hub's
+// wedged-digest threshold.
+func TestAdvisoryUpdateInterval(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  int
+		want time.Duration
+	}{
+		{"zero is unset — every cycle", 0, 0},
+		{"negative is unset, not clamped up", -5, 0},
+		{"below minimum clamps up", 10, MinAdvisoryUpdateIntervalS * time.Second},
+		{"minimum passes through", MinAdvisoryUpdateIntervalS, MinAdvisoryUpdateIntervalS * time.Second},
+		{"typical value passes through", 300, 300 * time.Second},
+		{"maximum passes through", MaxAdvisoryUpdateIntervalS, MaxAdvisoryUpdateIntervalS * time.Second},
+		{"above maximum clamps down", 86400, MaxAdvisoryUpdateIntervalS * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := AdvisoryConfig{UpdateIntervalS: tc.raw}
+			if got := a.UpdateInterval(); got != tc.want {
+				t.Fatalf("UpdateInterval(%d) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAdvisoryUpdateIntervalRoundTrip pins that hive.yaml stores the field as
+// written (no load-time rewrite): clamping happens at USE time via
+// UpdateInterval, so an operator's file round-trips byte-for-byte and applying
+// defaults never mutates the raw value.
+func TestAdvisoryUpdateIntervalRoundTrip(t *testing.T) {
+	cfg := &Config{}
+	cfg.Governor.Advisory.UpdateIntervalS = 300
+	cfg.applyDefaults()
+	if cfg.Governor.Advisory.UpdateIntervalS != 300 {
+		t.Fatalf("UpdateIntervalS = %d after defaults, want the configured 300", cfg.Governor.Advisory.UpdateIntervalS)
+	}
+
+	out, err := yaml.Marshal(cfg.Governor.Advisory)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "update_interval_s: 300") {
+		t.Fatalf("yaml round-trip lost update_interval_s: %s", out)
+	}
+	var back AdvisoryConfig
+	if err := yaml.Unmarshal(out, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.UpdateIntervalS != 300 {
+		t.Fatalf("round-tripped UpdateIntervalS = %d, want 300", back.UpdateIntervalS)
+	}
+
+	// Unset stays absent from the yaml entirely (omitempty), so untouched
+	// installs never see the key appear in their file.
+	out, err = yaml.Marshal(AdvisoryConfig{})
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	if strings.Contains(string(out), "update_interval_s") {
+		t.Fatalf("unset update_interval_s must be omitted from yaml, got: %s", out)
 	}
 }

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -1370,11 +1370,60 @@ type AdvisoryConfig struct {
 	// close enough to the finding's title. *bool so absent is distinct from an
 	// explicit false; default true.
 	PRAutoClose *bool `yaml:"pr_autoclose,omitempty" json:"pr_autoclose,omitempty"`
+	// UpdateIntervalS throttles how often, in seconds, the digest comment on
+	// the pinned advisory issue is refreshed (#4820). 0 (or absent) means
+	// UNSET and keeps today's behavior: a post attempt every governor eval
+	// cycle (~60s at the default cadence). Operators raise it to reduce
+	// GitHub API writes and notification churn on watched repos.
+	//
+	// The raw value is stored as written so hive.yaml round-trips byte-for-
+	// byte; consumers resolve it through UpdateInterval, which clamps into
+	// [MinAdvisoryUpdateIntervalS, MaxAdvisoryUpdateIntervalS]. The max
+	// exists for the hub's wedged-digest alarm: its staleness threshold
+	// (90 min) must stay comfortably above every healthy configured cadence
+	// so a user-lengthened interval never false-alarms as a wedge — pinned by
+	// TestAdvisoryStaleThresholdCoversMaxUpdateInterval in pkg/hub.
+	UpdateIntervalS int `yaml:"update_interval_s,omitempty" json:"update_interval_s,omitempty"`
 }
 
 // PRAutoCloseEnabled resolves AdvisoryConfig.PRAutoClose with its default (on).
 func (a AdvisoryConfig) PRAutoCloseEnabled() bool {
 	return a.PRAutoClose == nil || *a.PRAutoClose
+}
+
+// Bounds for AdvisoryConfig.UpdateIntervalS. Exported because the dashboard
+// PUT validates against them and pkg/hub pins the invariant that its
+// advisory-staleness threshold exceeds the maximum allowed posting cadence
+// (so a healthy slow digest never reads as wedged).
+const (
+	// MinAdvisoryUpdateIntervalS floors a configured interval at 30s: below
+	// the ~60s eval cycle the throttle is meaningless, and a typo like 3
+	// would silently disable the setting.
+	MinAdvisoryUpdateIntervalS = 30
+	// MaxAdvisoryUpdateIntervalS caps the interval at one hour. The hub flags
+	// a digest as wedged when its last successful post is older than 90
+	// minutes; capping the healthy cadence at 60 minutes keeps every allowed
+	// interval comfortably inside that threshold.
+	MaxAdvisoryUpdateIntervalS = 3600
+)
+
+// UpdateInterval resolves UpdateIntervalS to the effective posting throttle.
+// 0 means no throttle — post every eval cycle, exactly the pre-#4820 behavior
+// — and a set value is clamped into [MinAdvisoryUpdateIntervalS,
+// MaxAdvisoryUpdateIntervalS]. Negative values are treated as unset rather
+// than clamped up, so garbage cannot silently slow a hive down.
+func (a AdvisoryConfig) UpdateInterval() time.Duration {
+	if a.UpdateIntervalS <= 0 {
+		return 0
+	}
+	s := a.UpdateIntervalS
+	if s < MinAdvisoryUpdateIntervalS {
+		s = MinAdvisoryUpdateIntervalS
+	}
+	if s > MaxAdvisoryUpdateIntervalS {
+		s = MaxAdvisoryUpdateIntervalS
+	}
+	return time.Duration(s) * time.Second
 }
 
 // Default governor mode thresholds, in queue items (actionable issues + open

--- a/src/pkg/dashboard/api_governor_advisory_test.go
+++ b/src/pkg/dashboard/api_governor_advisory_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 type advisoryAPIResponse struct {
-	MaxFindings   int  `json:"max_findings"`
-	ShowAll       bool `json:"show_all"`
-	StalenessDays int  `json:"staleness_days"`
-	PRAutoClose   bool `json:"pr_autoclose"`
+	MaxFindings     int  `json:"max_findings"`
+	ShowAll         bool `json:"show_all"`
+	StalenessDays   int  `json:"staleness_days"`
+	PRAutoClose     bool `json:"pr_autoclose"`
+	UpdateIntervalS int  `json:"update_interval_s"`
 }
 
 func getAdvisorySettings(t *testing.T, s *Server) advisoryAPIResponse {
@@ -84,6 +85,9 @@ func TestGovAdvisory_Validation(t *testing.T) {
 		{"negative max findings", map[string]any{"max_findings": -1}},
 		{"zero staleness", map[string]any{"staleness_days": 0}},
 		{"negative staleness", map[string]any{"staleness_days": -7}},
+		{"negative update interval", map[string]any{"update_interval_s": -60}},
+		{"update interval below minimum", map[string]any{"update_interval_s": 5}},
+		{"update interval above maximum", map[string]any{"update_interval_s": 86400}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if rec := doPut(s, "/api/config/governor/advisory", tc.body); rec.Code != http.StatusBadRequest {
@@ -94,6 +98,44 @@ func TestGovAdvisory_Validation(t *testing.T) {
 
 	if rec := doPutRaw(s, "/api/config/governor/advisory", "not json"); rec.Code != http.StatusBadRequest {
 		t.Fatalf("bad body: expected 400, got %d", rec.Code)
+	}
+}
+
+// TestGovAdvisory_UpdateIntervalRoundTrip pins the #4820 knob's API contract:
+// unset reports 0 (the "default cadence" sentinel), an in-range PUT round-trips
+// verbatim, an explicit 0 resets to the default, and partial updates leave it
+// untouched.
+func TestGovAdvisory_UpdateIntervalRoundTrip(t *testing.T) {
+	s := govServer(t)
+
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != 0 {
+		t.Fatalf("untouched update_interval_s = %d, want the 0 default sentinel", got.UpdateIntervalS)
+	}
+
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"update_interval_s": 300}); rec.Code != http.StatusOK {
+		t.Fatalf("put update_interval_s: %d — %s", rec.Code, rec.Body.String())
+	}
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != 300 {
+		t.Fatalf("update_interval_s = %d, want the configured 300", got.UpdateIntervalS)
+	}
+	if s.deps.Config.Governor.Advisory.UpdateIntervalS != 300 {
+		t.Fatal("PUT did not store update_interval_s on the live config")
+	}
+
+	// A partial update of a sibling field leaves the interval alone.
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"max_findings": 7}); rec.Code != http.StatusOK {
+		t.Fatalf("partial put: %d", rec.Code)
+	}
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != 300 {
+		t.Fatalf("partial put changed update_interval_s to %d", got.UpdateIntervalS)
+	}
+
+	// Explicit 0 is the supported way back to the default cadence.
+	if rec := doPut(s, "/api/config/governor/advisory", map[string]any{"update_interval_s": 0}); rec.Code != http.StatusOK {
+		t.Fatalf("reset put: %d — %s", rec.Code, rec.Body.String())
+	}
+	if got := getAdvisorySettings(t, s); got.UpdateIntervalS != 0 {
+		t.Fatalf("update_interval_s = %d after reset, want 0", got.UpdateIntervalS)
 	}
 }
 

--- a/src/pkg/dashboard/api_governor_features.go
+++ b/src/pkg/dashboard/api_governor_features.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -247,10 +248,11 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var body struct {
-		MaxFindings   *int  `json:"max_findings"`
-		ShowAll       *bool `json:"show_all"`
-		StalenessDays *int  `json:"staleness_days"`
-		PRAutoClose   *bool `json:"pr_autoclose"`
+		MaxFindings     *int  `json:"max_findings"`
+		ShowAll         *bool `json:"show_all"`
+		StalenessDays   *int  `json:"staleness_days"`
+		PRAutoClose     *bool `json:"pr_autoclose"`
+		UpdateIntervalS *int  `json:"update_interval_s"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -264,6 +266,16 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 	}
 	if body.StalenessDays != nil && *body.StalenessDays < minAdvisoryStalenessDays {
 		jsonError(w, "staleness_days must be 1 or greater", http.StatusBadRequest)
+		return
+	}
+	// 0 is the explicit "default cadence" sentinel; anything else must land in
+	// the allowed band. Rejecting (rather than silently clamping) an
+	// out-of-range dashboard edit matches the max_findings/staleness_days
+	// contract above: the operator sees the rule instead of a mystery value.
+	if body.UpdateIntervalS != nil && *body.UpdateIntervalS != 0 &&
+		(*body.UpdateIntervalS < config.MinAdvisoryUpdateIntervalS || *body.UpdateIntervalS > config.MaxAdvisoryUpdateIntervalS) {
+		jsonError(w, fmt.Sprintf("update_interval_s must be 0 (default cadence) or between %d and %d seconds",
+			config.MinAdvisoryUpdateIntervalS, config.MaxAdvisoryUpdateIntervalS), http.StatusBadRequest)
 		return
 	}
 
@@ -282,6 +294,9 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 		v := *body.PRAutoClose
 		cfg.Governor.Advisory.PRAutoClose = &v
 	}
+	if body.UpdateIntervalS != nil {
+		cfg.Governor.Advisory.UpdateIntervalS = *body.UpdateIntervalS
+	}
 
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after advisory update", "error", err)
@@ -297,10 +312,11 @@ func (s *Server) handleGovernorAdvisoryPut(w http.ResponseWriter, r *http.Reques
 func advisorySectionResponse(cfg *config.Config) map[string]interface{} {
 	a := cfg.Governor.Advisory
 	return map[string]interface{}{
-		"max_findings":   a.MaxFindings,
-		"show_all":       a.ShowAll,
-		"staleness_days": a.StalenessDays,
-		"pr_autoclose":   a.PRAutoCloseEnabled(),
+		"max_findings":      a.MaxFindings,
+		"show_all":          a.ShowAll,
+		"staleness_days":    a.StalenessDays,
+		"pr_autoclose":      a.PRAutoCloseEnabled(),
+		"update_interval_s": a.UpdateIntervalS,
 	}
 }
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -20369,6 +20369,7 @@ function burnAreaChart() {
       a = a || {};
       const maxFindings = a.max_findings === undefined ? 10 : a.max_findings;
       const stalenessDays = a.staleness_days === undefined ? 7 : a.staleness_days;
+      const updateIntervalS = a.update_interval_s === undefined ? 0 : a.update_interval_s;
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Controls the advisory digest posted to your repo: how much of it is shown, and when findings nobody re-reports are retired.</p>
 
@@ -20381,6 +20382,14 @@ function burnAreaChart() {
           <div class="config-toggle" style="margin-top:10px">
             <div class="config-toggle-switch ${a.show_all ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="advisory" data-key="show_all"></div>
             <span class="config-toggle-label">Show all findings <span style="color:var(--muted);font-weight:400">— override the max and show everything</span></span>
+          </div>
+        </div>
+
+        <div style="margin:18px 0;padding-top:14px;border-top:1px solid var(--border)">
+          <div style="font-size:0.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px">When it updates</div>
+          <div class="config-field">
+            <label>Update interval (s) <span class="config-info">i<span class="config-tooltip">How often the digest comment on the pinned advisory issue is checked and refreshed. 0 = default (60s, every governor cycle). Longer values (30&ndash;3600s) reduce GitHub API writes and notification churn on watched repos; changes apply live from the next cycle. Unchanged digests are already skipped, and the periodic forced refresh that heals hand-edited comments stretches with this interval.</span></span></label>
+            <input type="number" min="0" max="3600" step="1" value="${updateIntervalS}" data-change-action="gh76">
           </div>
         </div>
 
@@ -22939,6 +22948,7 @@ function burnAreaChart() {
       gh58: function (event, A) { markDirty('features','otelHeaders',{});showToast('OTel headers will be cleared on Save','info'); },
       gh59: function (event, A) { markDirty('advisory','max_findings',Number(this.value)); },
       gh60: function (event, A) { markDirty('advisory','staleness_days',Number(this.value)); },
+      gh76: function (event, A) { markDirty('advisory','update_interval_s',Number(this.value)||0); },
       gh61: function (event, A) { markWorkSourceDirty('type',this.value);renderConfigTab('Work Source'); },
       gh62: function (event, A) { markWorkSourceDirty('github_projects.project_number',Number(this.value)||0); },
       gh63: function (event, A) { markWorkSourceDirty('github_projects.states',this.value.split(',').map(s=>s.trim()).filter(Boolean)); },

--- a/src/pkg/hub/advisory_staleness.go
+++ b/src/pkg/hub/advisory_staleness.go
@@ -9,11 +9,18 @@ import (
 // successful update before the hub flags it as stale. Advisory digests are
 // posted once per governor eval cycle; even a low-ACMM hive (which evaluates
 // infrequently by design — on the order of every ~10 min) posts far more often
-// than this. 90 minutes is therefore comfortably longer than any realistic
-// posting interval, so the pill only lights up on a digest path that has
-// GENUINELY wedged (a working App that has quietly stopped posting), never on a
-// hive that is merely slow. Kept a named constant with this reasoning so the
-// threshold is not a bare magic number.
+// than this. Operators may also slow the posting cadence deliberately via
+// governor.advisory.update_interval_s (#4820), whose maximum
+// (config.MaxAdvisoryUpdateIntervalS = 1h) is capped specifically to stay
+// under this threshold — the effective baseline is therefore always
+// max(configured interval, default cadence), with 30 minutes of slack on top
+// of the slowest legal cadence (pinned by
+// TestAdvisoryStaleThresholdCoversMaxUpdateInterval). 90 minutes is therefore
+// comfortably longer than any realistic or configurable posting interval, so
+// the pill only lights up on a digest path that has GENUINELY wedged (a
+// working App that has quietly stopped posting), never on a hive that is
+// merely slow. Kept a named constant with this reasoning so the threshold is
+// not a bare magic number.
 const advisoryStaleThreshold = 90 * time.Minute
 
 // appCanWriteForAdvisory reports whether a hive's GitHub App is in a state that

--- a/src/pkg/hub/advisory_staleness_test.go
+++ b/src/pkg/hub/advisory_staleness_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 // baseNow is a fixed reference time so age-based cases are deterministic.
@@ -33,6 +35,33 @@ func TestAdvisoryStale_FreshDigestNotStale(t *testing.T) {
 	e := advisoryModeEntry() // posted 5 min ago, well within threshold
 	if stale, reason := advisoryStale(e, advNow); stale {
 		t.Fatalf("a freshly-posted digest must not be stale, got reason %q", reason)
+	}
+}
+
+// TestAdvisoryStaleThresholdCoversMaxUpdateInterval pins the invariant that
+// makes governor.advisory.update_interval_s (#4820) safe: the hub's staleness
+// baseline is effectively max(configured interval, default cadence) because
+// the SLOWEST legal cadence stays at least 30 minutes under the alarm
+// threshold. If either side moves — the threshold shrinks or the config max
+// grows — a hive healthily posting at its configured maximum would false-alarm
+// as wedged, and this test fails first.
+func TestAdvisoryStaleThresholdCoversMaxUpdateInterval(t *testing.T) {
+	maxCadence := time.Duration(config.MaxAdvisoryUpdateIntervalS) * time.Second
+	if advisoryStaleThreshold < maxCadence+30*time.Minute {
+		t.Fatalf("advisoryStaleThreshold (%v) must exceed the max configurable advisory update interval (%v) by ≥30m of slack",
+			advisoryStaleThreshold, maxCadence)
+	}
+}
+
+// TestAdvisoryStale_HealthyLongCadenceNotWedged is the behavioral half of the
+// invariant above: a hive whose operator slowed the digest to the maximum
+// allowed hourly cadence, and which last posted a full such interval ago (plus
+// eval-cycle slack), must NOT light the wedged-digest pill.
+func TestAdvisoryStale_HealthyLongCadenceNotWedged(t *testing.T) {
+	e := advisoryModeEntry()
+	e.AdvisoryLastPostedAt = rfc3339Ago(time.Duration(config.MaxAdvisoryUpdateIntervalS)*time.Second + 5*time.Minute)
+	if stale, reason := advisoryStale(e, advNow); stale {
+		t.Fatalf("a healthy max-interval cadence must not read as wedged, got reason %q", reason)
 	}
 }
 


### PR DESCRIPTION
Fixes #4820

Adds `governor.advisory.update_interval_s`: a throttle on how often the pinned advisory-issue digest comment is refreshed, per the spec in #4820. Builds on the #4821 skip-if-unchanged guard.

## Design

- **0/unset = today's cadence exactly** (a post attempt every governor eval cycle, ~60s) — zero behavior change for existing installs; the raw value round-trips in hive.yaml untouched (`omitempty`, no load-time rewrite) and clamping happens at USE time into **[30s, 3600s]** with a one-shot log when a hand-edited value is clamped. The dashboard PUT instead *rejects* out-of-band values (matching the max_findings/staleness_days contract) so operators see the rule.
- **Only the GitHub write is paced.** The digest, dashboard state, and status broadcast still refresh every cycle. The gate advances on **success only**, per repo: failed posts retry the very next cycle (error recovery and the hub staleness signal stay as prompt as today), a primary-repo change starts open, the first post is never delayed, and quiet cycles don't consume the window — a brand-new finding still posts immediately.
- **Live re-read**: the posting loop reads `cfg.Governor.Advisory` each cycle (the existing pattern for the staleness/max-findings knobs — the PUT handler mutates the shared config in place), so dashboard edits apply from the next cycle without a restart. The tooltip says so.
- **Wedged-alarm invariant**: instead of plumbing the spoke's config to the hub, the interval max (1h) is deliberately capped under the hub's 90-minute staleness threshold — the alarm baseline is therefore always `max(configured, default)` with ≥30 minutes of slack over the slowest legal cadence. Pinned two ways in pkg/hub: `TestAdvisoryStaleThresholdCoversMaxUpdateInterval` (fails first if either side moves) and a behavioral healthy-max-cadence-not-wedged test.
- **#4821 write-through interaction**: the forced full rewrite counts consecutive unchanged post ATTEMPTS, so its spacing stretches with the interval (60 attempts × interval). Chose to **document** (code comment, UI tooltip, src/docs/advisory.md) rather than convert to a time bound: the write-through only heals out-of-band comment edits, and the existing pkg/github tests keep pinning the cycle-counted mechanism.

## UI

Settings → Advisory gains a **When it updates** group: number input "Update interval (s)" with tooltip (0 = default 60s; longer reduces API writes/notification churn; applies live), existing dirty-section pattern → `PUT /api/config/governor/advisory`, prefilled from the same `GET /api/config/governor` payload. check-inline-js CSP guard passes.

## Tests (all mutation-checked)

- config: parse/clamp/0→default table, yaml round-trip incl. omitempty (gut the unset sentinel → 3 fail)
- cmd/hive: gate throttle boundary, success-only advance (failed attempt retries next cycle), per-repo isolation, clamp-log-once (gate-always-open mutation → 3 fail)
- dashboard: API round-trip incl. explicit-0 reset + partial-update isolation, validation 400s (validation removed → 4 fail)
- hub: threshold-covers-max invariant + healthy-slow-cadence-not-wedged (threshold shrunk to 45m → 2 fail)

Note: the matrix lane had started an uncommitted sketch of this in a shared worktree; this implementation adopts its best idea (success-only, per-repo gate advance) — credit where due.