### PR TITLE
🐛 fix(scheduler): fix-before-new — route red PRs to their authoring agent with CI evidence

### DIFF
--- a/src/cmd/hive/audit_pr_agents_test.go
+++ b/src/cmd/hive/audit_pr_agents_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// auditPRAgents maps relay-opened PRs back to their authoring agent so the
+// scheduler's fix-before-new section can route each red PR to the agent that
+// created it (kubestellar/console 2026-08-26: ten red PRs, one commit each —
+// no agent ever saw its own reds).
+func TestAuditPRAgents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	now := time.Now().UTC()
+	recent := now.Format(time.RFC3339)
+	old := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+	lines := `{"ts":"` + recent + `","user":"app","action":"agent_pr_created","detail":"repo=kubestellar/console, number=22815, author=bot, reused=false","agent":"scanner"}
+{"ts":"` + recent + `","user":"app","action":"agent_pr_created","detail":"repo=console, number=7, author=bot","agent":"quality"}
+{"ts":"` + recent + `","user":"app","action":"agent_issue_created","detail":"repo=kubestellar/console, number=99","agent":"scanner"}
+{"ts":"` + old + `","user":"app","action":"agent_pr_created","detail":"repo=kubestellar/console, number=1, author=bot","agent":"scanner"}
+{"ts":"` + recent + `","user":"app","action":"agent_pr_created","detail":"repo=kubestellar/console, number=8","agent":""}
+`
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := auditPRAgents("kubestellar", now.Add(-auditPRAttributionWindow), path)
+
+	if got["kubestellar/console#22815"] != "scanner" {
+		t.Errorf("full-repo entry: got %q", got["kubestellar/console#22815"])
+	}
+	// Bare repo names are org-qualified so lookups by fullRepo hit.
+	if got["kubestellar/console#7"] != "quality" {
+		t.Errorf("bare-repo entry not org-qualified: got %q", got["kubestellar/console#7"])
+	}
+	// Non-PR actions, entries outside the window, and agent-less entries are
+	// all excluded.
+	if _, ok := got["kubestellar/console#99"]; ok {
+		t.Error("issue-created entry must not be mapped")
+	}
+	if _, ok := got["kubestellar/console#1"]; ok {
+		t.Error("entry outside the attribution window must not be mapped")
+	}
+	if _, ok := got["kubestellar/console#8"]; ok {
+		t.Error("agent-less entry must not be mapped")
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -7671,6 +7671,47 @@ func fullRepoName(repo, org string) string {
 	return org + "/" + repo
 }
 
+// auditPRAttributionWindow bounds how far back the audit trail is scanned to
+// map open PRs to the agent that opened them. Red PRs older than this fall
+// back to scanner ownership in the kick builders — acceptable: 14d exceeds any
+// PR the fleet should still be iterating on.
+const auditPRAttributionWindow = 14 * 24 * time.Hour
+
+// auditPRAgents maps "org/repo#number" → agent name from the audit trail's
+// agent_pr_created entries (attribution.go records one per relay-opened PR,
+// reuses included). Reading the on-disk log per eval tick keeps this
+// stateless; OutputActionsSince touches no receiver state, so a zero-value
+// AuditLog is safe here.
+func auditPRAgents(org string, since time.Time, auditPath string) map[string]string {
+	entries := (&dashboard.AuditLog{}).OutputActionsSince(since,
+		map[string]bool{github.AuditActionAgentPRCreated: true}, auditPath)
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if e.Agent == "" {
+			continue
+		}
+		var repo, number string
+		for _, part := range strings.Split(e.Detail, ",") {
+			if k, v, ok := strings.Cut(strings.TrimSpace(part), "="); ok {
+				switch k {
+				case "repo":
+					repo = v
+				case "number":
+					number = v
+				}
+			}
+		}
+		if repo == "" || number == "" {
+			continue
+		}
+		if !strings.Contains(repo, "/") && org != "" {
+			repo = org + "/" + repo
+		}
+		out[repo+"#"+number] = e.Agent
+	}
+	return out
+}
+
 func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, enforceIntent bool, intentVerdicts map[string]intent.Verdict, requireReviewApproval bool, logger *slog.Logger) {
 	holdSet := make(map[string]bool)
 	for _, h := range hold.Items {
@@ -7710,7 +7751,14 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		// builders list them separately and agents must NOT dispatch more
 		// fix work for them.
 		Escalated bool `json:"escalated,omitempty"`
+		// Agent is the hive agent whose relay request opened this PR (from the
+		// audit trail's agent_pr_created entries). The scheduler's
+		// fix-before-new section routes each red PR back to its author; empty
+		// means unattributed (kick builders default it to scanner).
+		Agent string `json:"agent,omitempty"`
 	}
+
+	prAgents := auditPRAgents(org, time.Now().Add(-auditPRAttributionWindow), "")
 
 	var eligible []eligiblePR
 	var failing []failingPR
@@ -7755,6 +7803,7 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 				FailingChecks: pr.FailingChecks,
 				Excerpt:       pr.CIFailureExcerpt,
 				Escalated:     escalatedPRs[escalation.Key(fullRepo, pr.Number)],
+				Agent:         prAgents[fmt.Sprintf("%s#%d", fullRepo, pr.Number)],
 			})
 			continue
 		}

--- a/src/pkg/scheduler/red_pr_fix_first_test.go
+++ b/src/pkg/scheduler/red_pr_fix_first_test.go
@@ -1,0 +1,118 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+const redPRFixture = `{"generated_at":"2026-08-26T00:00:00Z","ci_failing":[
+  {"number":22815,"repo":"test-org/console","title":"[Refactor] split tests","agent":"scanner",
+   "failing_checks":["build-gate","Test (chromium, shard 1)"],
+   "excerpt":"src/hooks/__tests__/a.test.tsx:1:8 — 'React' is defined but never used."},
+  {"number":7,"repo":"test-org/console","title":"quality PR","agent":"quality","failing_checks":["go test"]},
+  {"number":8,"repo":"test-org/console","title":"unattributed PR","failing_checks":["build-gate"]},
+  {"number":9,"repo":"test-org/console","title":"escalated PR","agent":"scanner","escalated":true}
+]}`
+
+// The fix-before-new section routes each red PR to its authoring agent, with
+// the failing checks and CI evidence inline, and the push-to-same-branch
+// instruction. Escalated (needs-human) PRs never appear.
+func TestFormatRedPRFixData_PerAgentRouting(t *testing.T) {
+	scanner := formatRedPRFixData([]byte(redPRFixture), "scanner")
+	for _, want := range []string{
+		"FIX-BEFORE-NEW",
+		"#22815 test-org/console",
+		"build-gate, Test (chromium, shard 1)",
+		"'React' is defined but never used",
+		"#8 test-org/console", // unattributed defaults to scanner
+		"gh pr checkout",
+		"Do NOT open a replacement PR",
+	} {
+		if !strings.Contains(scanner, want) {
+			t.Errorf("scanner section missing %q:\n%s", want, scanner)
+		}
+	}
+	if strings.Contains(scanner, "#7 ") {
+		t.Error("quality's PR must not appear in scanner's section")
+	}
+	if strings.Contains(scanner, "#9 ") {
+		t.Error("escalated PR must never appear in an agent's fix list")
+	}
+
+	quality := formatRedPRFixData([]byte(redPRFixture), "quality")
+	if !strings.Contains(quality, "#7 ") || strings.Contains(quality, "#22815") {
+		t.Errorf("quality section wrong:\n%s", quality)
+	}
+
+	if got := formatRedPRFixData([]byte(redPRFixture), "outreach"); got != "" {
+		t.Errorf("agent with no red PRs must get an empty section, got:\n%s", got)
+	}
+	if got := formatRedPRFixData([]byte("not json"), "scanner"); got != "" {
+		t.Errorf("malformed file must yield empty section, got:\n%s", got)
+	}
+}
+
+// Long evidence excerpts are truncated and a large backlog is capped with a
+// summary line instead of flooding the kick.
+func TestFormatRedPRFixData_Bounds(t *testing.T) {
+	long := strings.Repeat("x", 2*redPRFixExcerptRunes)
+	var rows []string
+	for i := 0; i < redPRFixMaxDetailed+3; i++ {
+		rows = append(rows, `{"number":`+string(rune('1'+i))+`00,"repo":"o/r","title":"t","agent":"scanner","excerpt":"`+long+`"}`)
+	}
+	data := `{"ci_failing":[` + strings.Join(rows, ",") + `]}`
+	out := formatRedPRFixData([]byte(data), "scanner")
+	if !strings.Contains(out, "… and 3 more") {
+		t.Errorf("expected cap summary line, got:\n%s", out)
+	}
+	if strings.Contains(out, long) {
+		t.Error("excerpt must be truncated")
+	}
+}
+
+// addRedPRFixFirst injects the section right below the kick header for
+// PR-capable agents on every resolution path, and stays out of advisory
+// agents' kicks entirely.
+func TestAddRedPRFixFirst_Injection(t *testing.T) {
+	dir := t.TempDir()
+	orig := ciFailingPath
+	ciFailingPath = filepath.Join(dir, "ci-failing.json")
+	t.Cleanup(func() { ciFailingPath = orig })
+	if err := os.WriteFile(ciFailingPath, []byte(redPRFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: "test-org", Repos: []string{"test-org/console"}},
+		Agents: map[string]config.AgentConfig{
+			"scanner":  {Mode: "ISSUES_AND_PRS"},
+			"advisor":  {Mode: "ADVISORY"},
+			"outreach": {Mode: "ISSUES_AND_PRS"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := New(cfg, logger)
+
+	msg := s.addRedPRFixFirst("scanner", "[agent:scanner]\nWORK LIST\n")
+	if !strings.Contains(msg, "FIX-BEFORE-NEW") {
+		t.Fatalf("scanner kick missing fix-before-new section:\n%s", msg)
+	}
+	if !strings.HasPrefix(msg, "[agent:scanner]\n\n## 🔴 FIX-BEFORE-NEW") {
+		t.Errorf("section must land directly below the kick header:\n%s", msg[:min(len(msg), 120)])
+	}
+
+	if got := s.addRedPRFixFirst("advisor", "[agent:advisor]\nADVISORY\n"); strings.Contains(got, "FIX-BEFORE-NEW") {
+		t.Error("advisory agent must not receive the section")
+	}
+	if got := s.addRedPRFixFirst("outreach", "[agent:outreach]\nWORK\n"); strings.Contains(got, "FIX-BEFORE-NEW") {
+		t.Error("agent with no red PRs must not receive the section")
+	}
+	if got := s.addRedPRFixFirst("scanner", ""); got != "" {
+		t.Error("empty (fail-closed) message must stay empty")
+	}
+}

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -592,6 +592,14 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	// operator overrides vulnerable indefinitely (kubestellar/hive#4744).
 	defer func() {
 		message = s.addHeldPRCoordination(agentName, actionable, message)
+		// Fix-before-new: an agent with red PRs of its own must see them —
+		// with the CI evidence — ahead of any new work. Injected at the same
+		// post-resolution seam as the held-PR preflight so no template path
+		// can omit it (kubestellar/hive#4744): observed live on
+		// kubestellar/console (2026-08-26), ten red split-PRs each had exactly
+		// one commit — kicks kept spawning NEW PRs while the reaper's
+		// re-engagements aged every red SHA to its cap unfixed.
+		message = s.addRedPRFixFirst(agentName, message)
 	}()
 
 	baseName := s.cfg.BaseAgentName(agentName)
@@ -747,6 +755,127 @@ func (s *Scheduler) isHoldGatedPRAgent(agentName string) bool {
 	return mode == "ISSUES_AND_PRS" || mode == "ISSUES_PRS_MERGE"
 }
 
+// isPRCapableAgent reports whether the agent's effective mode lets it push
+// branches / open PRs at all. Advisory-only agents can never repair a red PR,
+// so the fix-before-new section would be noise for them.
+func (s *Scheduler) isPRCapableAgent(agentName string) bool {
+	if s.cfg == nil {
+		return false
+	}
+	agentCfg, ok := s.cfg.Agents[agentName]
+	if !ok {
+		agentCfg, ok = s.cfg.Agents[s.cfg.BaseAgentName(agentName)]
+	}
+	if !ok {
+		return false
+	}
+	mode := agentCfg.Mode
+	if agentCfg.Tools != nil {
+		if effective := agentCfg.Tools.EffectiveMode(); effective != "" {
+			mode = effective
+		}
+	}
+	return mode == "ISSUES_AND_PRS" || mode == "ISSUES_PRS_MERGE"
+}
+
+// redPRFixMaxDetailed bounds how many red PRs get a full evidence entry in one
+// kick; the rest are summarized so a pathological backlog cannot flood the
+// prompt. redPRFixExcerptRunes bounds the per-PR CI evidence excerpt.
+const (
+	redPRFixMaxDetailed  = 5
+	redPRFixExcerptRunes = 400
+)
+
+// addRedPRFixFirst prepends a fix-before-new section listing the agent's OWN
+// red-CI PRs, with the failing checks and the raw CI evidence, right below the
+// kick header. It reads ci-failing.json (written by writeMergeEligible each
+// eval tick), which attributes each PR to the agent whose relay request opened
+// it. Unattributed rows default to scanner — the fleet's primary PR creator.
+// Escalated (needs-human) PRs are never listed: they belong to a human.
+func (s *Scheduler) addRedPRFixFirst(agentName string, message string) string {
+	if message == "" || !s.isPRCapableAgent(agentName) {
+		return message
+	}
+	data, err := os.ReadFile(ciFailingPath)
+	if err != nil {
+		return message
+	}
+	section := formatRedPRFixData(data, s.cfg.BaseAgentName(agentName))
+	if section == "" {
+		return message
+	}
+	// Insert directly after the "[agent:x]" header line when present, so the
+	// section is the first thing the agent reads; otherwise prefix.
+	if idx := strings.Index(message, "\n"); idx >= 0 && strings.HasPrefix(message, "[agent:") {
+		return message[:idx+1] + section + message[idx+1:]
+	}
+	return section + message
+}
+
+// formatRedPRFixData renders the fix-before-new section for one agent from
+// raw ci-failing.json bytes. Empty result means the agent has no open,
+// non-escalated red PRs.
+func formatRedPRFixData(data []byte, agent string) string {
+	type ciFailingRow struct {
+		Number        int      `json:"number"`
+		Repo          string   `json:"repo"`
+		Title         string   `json:"title"`
+		Agent         string   `json:"agent"`
+		FailingChecks []string `json:"failing_checks"`
+		Excerpt       string   `json:"excerpt"`
+		Escalated     bool     `json:"escalated"`
+	}
+	var payload struct {
+		Items []ciFailingRow `json:"ci_failing"`
+	}
+	if json.Unmarshal(data, &payload) != nil {
+		return ""
+	}
+	var mine []ciFailingRow
+	for _, pr := range payload.Items {
+		if pr.Escalated {
+			continue // needs-human: hands off for agents
+		}
+		owner := pr.Agent
+		if owner == "" {
+			owner = "scanner"
+		}
+		if owner != agent {
+			continue
+		}
+		mine = append(mine, pr)
+	}
+	if len(mine) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("\n## 🔴 FIX-BEFORE-NEW — your open PRs with failing CI (%d)\n\n", len(mine)))
+	b.WriteString("These PRs are YOURS and they are red. Repairing them comes BEFORE claiming\n")
+	b.WriteString("new issues or opening ANY new PR. For each one:\n")
+	b.WriteString("  gh pr checkout <number> → fix using the evidence below → commit -s → git push\n")
+	b.WriteString("Push to the SAME branch. Do NOT open a replacement PR. Do NOT leave these\n")
+	b.WriteString("for a later cycle — every kick will re-list them until they are green.\n\n")
+	for i, pr := range mine {
+		if i >= redPRFixMaxDetailed {
+			b.WriteString(fmt.Sprintf("  … and %d more (full list: %s)\n", len(mine)-i, ciFailingPath))
+			break
+		}
+		b.WriteString(fmt.Sprintf("  #%d %s — %s\n", pr.Number, pr.Repo, pr.Title))
+		if len(pr.FailingChecks) > 0 {
+			b.WriteString(fmt.Sprintf("    failing: %s\n", strings.Join(pr.FailingChecks, ", ")))
+		}
+		if excerpt := strings.TrimSpace(pr.Excerpt); excerpt != "" {
+			if runes := []rune(excerpt); len(runes) > redPRFixExcerptRunes {
+				excerpt = string(runes[:redPRFixExcerptRunes]) + "…"
+			}
+			b.WriteString("    evidence: " + strings.ReplaceAll(excerpt, "\n", "\n              ") + "\n")
+		}
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
 func (s *Scheduler) formatHeldPRClaimsWithPolicy(actionable *github.ActionableResult) (string, bool) {
 	if actionable == nil {
 		return "  (none)", false
@@ -900,8 +1029,8 @@ func (s *Scheduler) buildSupervisorMessage(actionable *github.ActionableResult) 
 	return b.String()
 }
 
-const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
-const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
+var mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
+var ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
 
 func (s *Scheduler) buildMergeEligibleList() string {
 	data, err := os.ReadFile(mergeEligiblePath)


### PR DESCRIPTION
## Problem

Agents never repair their own red PRs. The reaper re-dispatches stuck red PRs (capped, then `needs-human`) and they sit in `ci-failing.json`, but no kick ever shows an agent **its own** failing PRs with the actual CI evidence — so kicks keep spawning NEW PRs while every red SHA ages to its re-engagement cap unfixed. Observed live on kubestellar/console (2026-08-26): ten red refactor-split PRs, each with exactly one commit, re-engaged ~80×/20m with zero follow-up pushes.

## Fix (two halves, one loop)

**Attribution (hub work-list):** `writeMergeEligible` now maps each red PR back to the agent whose relay request opened it, from the audit trail's `agent_pr_created` entries (14-day window, bare repo names org-qualified), and writes it as `ci_failing[].agent`.

**Fix-before-new kick section (scheduler):** every PR-capable agent's kick gets a `## 🔴 FIX-BEFORE-NEW` section injected directly below the header, listing that agent's own red PRs with:
- failing check names,
- the CI failure excerpt (already carried in `ci-failing.json`, previously dropped at format time),
- the explicit repair contract: `gh pr checkout <N>` → fix → `commit -s` → push to the **same** branch; never open a replacement PR.

Injection happens at the same post-resolution seam as the held-PR preflight, so config kick templates, repo-sourced prompts, and hardcoded fallbacks all receive it (the #4744 lesson). Escalated (`needs-human`) PRs are never listed — they belong to a human. Unattributed rows default to scanner, the fleet's primary PR creator. Advisory-only agents are excluded. Detail is bounded (5 PRs detailed, 400-rune excerpts) so a backlog can't flood the prompt.

## Tests

- `TestFormatRedPRFixData_PerAgentRouting` — per-agent filtering, scanner default, escalated exclusion, evidence + instruction presence, malformed-file safety
- `TestFormatRedPRFixData_Bounds` — excerpt truncation + backlog cap
- `TestAddRedPRFixFirst_Injection` — lands below the kick header, skips advisory agents and agents with no reds, preserves fail-closed empty kicks
- `TestAuditPRAgents` — audit parsing: window, org-qualification, non-PR actions and agent-less rows excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)