### PR TITLE
🐛 fix(github): record pr_merged audit on automerge-sweep merges

### DIFF
--- a/src/pkg/github/automerge_sweep.go
+++ b/src/pkg/github/automerge_sweep.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -562,6 +563,16 @@ func (c *Client) trySweepSelfAuthoredPR(ctx context.Context, displayRepo, owner,
 	if !mergeResult.GetMerged() {
 		return AutoMergeSweepEvent{}, "merge-not-applied", nil
 	}
+	// Audit the merge like MergePR does (pullrequest.go): the activity
+	// collector counts pr_merged entries from this trail, and the /fleet L6
+	// health verdict is judged on them. When the fleet's merges moved to this
+	// sweep, the unaudited path made merging hives read as "no merge in Nd"
+	// red on /fleet (observed live on kubestellar/console, 2026-08-26).
+	c.recordCreationAudit(AuditActionPRMerged, InvocationMeta{Agent: AttributionAgentGovernor},
+		"repo", owner+"/"+repo,
+		"number", strconv.Itoa(number),
+		"method", "squash",
+		"sha", mergeResult.GetSHA())
 	event := AutoMergeSweepEvent{
 		Repo:     displayRepo,
 		Number:   number,
@@ -691,6 +702,13 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 	if !mergeResult.GetMerged() {
 		return AutoMergeSweepEvent{}, "merge-not-applied", nil
 	}
+	// Same audit obligation as the self-authored path above: pr_merged on
+	// the trail is what makes this merge count as hive output.
+	c.recordCreationAudit(AuditActionPRMerged, InvocationMeta{Agent: AttributionAgentGovernor},
+		"repo", owner+"/"+repo,
+		"number", strconv.Itoa(number),
+		"method", "squash",
+		"sha", mergeResult.GetSHA())
 	event := AutoMergeSweepEvent{
 		Repo:     displayRepo,
 		Number:   number,

--- a/src/pkg/github/automerge_sweep_test.go
+++ b/src/pkg/github/automerge_sweep_test.go
@@ -1412,3 +1412,55 @@ func shaNumber(t *testing.T, path string) int {
 	t.Fatalf("sha number not found in %q", path)
 	return 0
 }
+
+// A sweep merge must land on the attribution audit trail as pr_merged — the
+// activity collector counts that trail and the /fleet L6 health verdict is
+// judged on merges. The sweep paths skipping this audit made merging hives
+// read as "no merge in Nd" red (kubestellar/console, 2026-08-26).
+func TestSweepQueuedAutoMergesRecordsPRMergedAuditTrail(t *testing.T) {
+	var merged []int
+	api := newAutoMergeSweepAPI(t, AutoMergeQueuedLabel, []sweepPR{{
+		number:          7,
+		author:          "alice",
+		queuedBy:        "bob",
+		label:           true,
+		mergeableState:  "clean",
+		statusState:     "success",
+		checkStatus:     "completed",
+		checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	type auditRec struct{ action, detail, agent string }
+	var trail []auditRec
+	c.SetAttributionHooks(AttributionHooks{
+		Audit: func(action, detail, agent string) {
+			trail = append(trail, auditRec{action, detail, agent})
+		},
+	})
+
+	if _, err := c.SweepQueuedAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != nil {
+		t.Fatalf("SweepQueuedAutoMerges returned error: %v", err)
+	}
+	if len(merged) != 1 {
+		t.Fatalf("expected one merge, got %v", merged)
+	}
+	var got *auditRec
+	for i := range trail {
+		if trail[i].action == AuditActionPRMerged {
+			got = &trail[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("no %s entry on the attribution trail; trail=%#v", AuditActionPRMerged, trail)
+	}
+	if got.agent != AttributionAgentGovernor {
+		t.Errorf("pr_merged agent = %q, want %q", got.agent, AttributionAgentGovernor)
+	}
+	for _, want := range []string{"number=7", "method=squash"} {
+		if !strings.Contains(got.detail, want) {
+			t.Errorf("pr_merged detail missing %q: %q", want, got.detail)
+		}
+	}
+}

--- a/src/pkg/github/automerge_sweep_test.go
+++ b/src/pkg/github/automerge_sweep_test.go
@@ -1464,3 +1464,48 @@ func TestSweepQueuedAutoMergesRecordsPRMergedAuditTrail(t *testing.T) {
 		}
 	}
 }
+
+// The self-authored sweep path has the same audit obligation as the queued
+// one: without a pr_merged trail entry its merges are invisible to the
+// activity collector and the merge-judged /fleet verdict.
+func TestSweepSelfAuthoredAutoMergesRecordsPRMergedAuditTrail(t *testing.T) {
+	var merged []int
+	api := newSelfAuthoredAutoMergeAPI(t, []selfAuthoredPR{{
+		number: 11, author: testHiveAppBotLogin, mergeableState: "clean",
+		statusState: "success", checkStatus: "completed", checkConclusion: "success",
+	}}, &merged)
+	defer api.Close()
+
+	c := newAutoMergeSweepClient(api.URL)
+	type auditRec struct{ action, detail, agent string }
+	var trail []auditRec
+	c.SetAttributionHooks(AttributionHooks{
+		Audit: func(action, detail, agent string) {
+			trail = append(trail, auditRec{action, detail, agent})
+		},
+	})
+
+	if _, err := c.SweepSelfAuthoredAutoMerges(context.Background(), AutoMergeSweepOptions{}); err != nil {
+		t.Fatalf("SweepSelfAuthoredAutoMerges returned error: %v", err)
+	}
+	if len(merged) != 1 {
+		t.Fatalf("expected one merge, got %v", merged)
+	}
+	var got *auditRec
+	for i := range trail {
+		if trail[i].action == AuditActionPRMerged {
+			got = &trail[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("no %s entry on the attribution trail; trail=%#v", AuditActionPRMerged, trail)
+	}
+	if got.agent != AttributionAgentGovernor {
+		t.Errorf("pr_merged agent = %q, want %q", got.agent, AttributionAgentGovernor)
+	}
+	for _, want := range []string{"number=11", "method=squash"} {
+		if !strings.Contains(got.detail, want) {
+			t.Errorf("pr_merged detail missing %q: %q", want, got.detail)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The /fleet page shows kubestellar/console red: **"no merge in 3d (47 queued) · judged on merges · last output 3d ago"** and the repo drill-down says "merged 2 (13d ago)" — while the App bot actually merged six console PRs in the last 24h (e.g. #22811 at 13:14Z today, merged_by `kubestellar-hive[bot]`).

Root cause: both automerge-sweep merge sites (`trySweepSelfAuthoredPR` and the label-queued path in `automerge_sweep.go`) call `PullRequests.Merge` directly and never record the `pr_merged` attribution audit — unlike `MergePR` (pullrequest.go), which audits unconditionally. When the fleet's merges moved to the sweep (~13d ago on the console spoke, matching the last trail entry), the audit trail went silent on merges. The activity collector counts that trail, and the L6 health verdict is judged on merges, so a daily-merging hive reads as red.

## Fix

Record `pr_merged` at both sweep merge sites with the same governor attribution and detail shape as `MergePR` (`repo=owner/repo, number=, method=squash, sha=`).

## Test

`TestSweepQueuedAutoMergesRecordsPRMergedAuditTrail` — drives the existing sweep mock API and asserts the attribution trail receives a `pr_merged` entry with governor agent and correct detail on a successful sweep merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)