### PR TITLE
🐛 watchdog: fix failing tests blocking the coverage gate

### DIFF
--- a/src/pkg/watchdog/reconciler_test.go
+++ b/src/pkg/watchdog/reconciler_test.go
@@ -547,6 +547,8 @@ func TestWedgedRestartNeverBlocksTickAndNeverStacks(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Tick blocked on a wedged restart — the control-plane guard failed")
 	}
+	waitFor(t, func() bool { return fleet.restartCount() == 1 },
+		"initial wedged restart was never invoked")
 
 	// Past the hard timeout the wedge is alerted; no restart stacks on it.
 	clock.Advance(s.RestartTimeout + time.Second)
@@ -1106,6 +1108,9 @@ func TestDeadSessionRestartsOncePerBackoffNotPerTick(t *testing.T) {
 	)
 	for i := 0; i < sweeps; i++ {
 		r.Tick(context.Background())
+		if restartInFlight(r, "a1") {
+			fleet.waitRestart(t, r)
+		}
 		clock.Advance(sweepGap)
 	}
 	// Detached restarts settle asynchronously, so wait for the ladder's count
@@ -1392,4 +1397,11 @@ func waitFor(t *testing.T, cond func() bool, msg string) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal(msg)
+}
+
+func restartInFlight(r *Reconciler, name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rec, ok := r.agents[name]
+	return ok && rec.restartInFlight
 }


### PR DESCRIPTION
Fixes #4829

Root cause: offending commit 03a2221559d798f434a18dbe5ae19c301204da39 (#4675) introduced the self-healing watchdog and its tests. Two tests sampled detached restart side effects before the restart goroutine was guaranteed to start or settle under the fake clock, so v4 could report `watchdog: TESTS FAILING` before the coverage floor was evaluated.

Fix: keep the behavioral assertions intact, but make the harness wait for the wedged restart invocation and settle non-wedged restarts between synthetic sweeps. Watchdog coverage remains 97.6%, above the 90% floor.

Validation:
- go test ./pkg/watchdog -short -race -count=1 -cover
- go test ./pkg/agent -short -count=1 -run 'Watchdog|CredentialWatchdog|WatchdogFleet'\n- go build ./...\n- go vet ./...\n- attempted workflow coverage command: go test ./pkg/... ./cmd/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s (watchdog passed at 97.6%; local Darwin-only cmd/bd cwd path expectation and cmd/hivectl covdata failure prevented a full local gate result)