### PR TITLE
🐛 fix(tokens): assign session timestamps so LastActive is not permanently 0

### DIFF
--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -21,6 +21,11 @@ type SessionEntry struct {
 	OutputTokens  int64  `json:"output_tokens,omitempty"`
 	Message       string `json:"message,omitempty"`
 	Role          string `json:"role,omitempty"`
+	// Timestamp is the per-entry event time as an ISO 8601 / RFC 3339 string
+	// (the same wire format the Claude and Copilot session files use). It is
+	// optional; entries without one simply don't contribute to the session's
+	// FirstActive/LastActive bracket.
+	Timestamp string `json:"timestamp,omitempty"`
 	// Agent, when set, pins the session to a specific agent instead of
 	// relying on keyword detection from the first user message. Inference
 	// (bare-mode) agents set this so the translator-written usage records
@@ -352,11 +357,25 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 
 	firstUserMsg := ""
 	explicitAgent := ""
-	var lastTimestamp int64
+	// FirstActive/LastActive are the min/max parseable entry timestamps, not
+	// the first/last line seen: flat-format files are append-mostly but not
+	// guaranteed ordered (atomic rewrites and merged records can interleave),
+	// so line position is not a reliable recency signal. Unparseable or absent
+	// timestamps contribute nothing, leaving 0 when no entry carries one.
+	var firstTimestamp, lastTimestamp int64
 	for scanner.Scan() {
 		var entry SessionEntry
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
 			continue
+		}
+
+		if ts := parseTimestampToUnixMilli(entry.Timestamp); ts > 0 {
+			if ts > lastTimestamp {
+				lastTimestamp = ts
+			}
+			if firstTimestamp == 0 || ts < firstTimestamp {
+				firstTimestamp = ts
+			}
 		}
 
 		if entry.Agent != "" && explicitAgent == "" {
@@ -382,6 +401,7 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 	}
 
 	summary.TotalTokens = summary.InputTokens + summary.OutputTokens + summary.CacheRead + summary.CacheCreate
+	summary.FirstActive = firstTimestamp
 	summary.LastActive = lastTimestamp
 
 	if explicitAgent != "" {

--- a/src/pkg/tokens/collector_test.go
+++ b/src/pkg/tokens/collector_test.go
@@ -721,3 +721,68 @@ func TestCollectFromDir_ByAgentAndByModelSums(t *testing.T) {
 		t.Errorf("TotalTokens = %d, want 220", agg.TotalTokens)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// parseSessionFile timestamps → FirstActive/LastActive (#4835)
+// ---------------------------------------------------------------------------
+
+func TestParseSessionFile_LastActiveFromMaxTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	// Deliberately out of order: the newest event is NOT the last line. The
+	// bracket must come from min/max timestamps, not line position.
+	content := strings.Join([]string{
+		`{"role":"user","message":"hi","timestamp":"2026-08-26T10:00:00Z"}`,
+		`{"role":"assistant","model":"gpt-4","input_tokens":10,"output_tokens":5,"timestamp":"2026-08-26T12:00:00Z"}`,
+		`{"role":"assistant","input_tokens":1,"output_tokens":1,"timestamp":"2026-08-26T11:00:00Z"}`,
+	}, "\n") + "\n"
+	path := writeFile(t, dir, "sess-ts.jsonl", content)
+
+	sum, err := parseSessionFile(path, nil)
+	if err != nil {
+		t.Fatalf("parseSessionFile: %v", err)
+	}
+	wantLast := parseTimestampToUnixMilli("2026-08-26T12:00:00Z")
+	wantFirst := parseTimestampToUnixMilli("2026-08-26T10:00:00Z")
+	if sum.LastActive != wantLast {
+		t.Errorf("LastActive = %d, want %d (max timestamp, not last line)", sum.LastActive, wantLast)
+	}
+	if sum.FirstActive != wantFirst {
+		t.Errorf("FirstActive = %d, want %d (min timestamp)", sum.FirstActive, wantFirst)
+	}
+}
+
+func TestParseSessionFile_TimestampsAbsentOrUnparseable(t *testing.T) {
+	dir := t.TempDir()
+	content := strings.Join([]string{
+		`{"role":"user","message":"hi"}`,
+		`{"role":"assistant","model":"m","input_tokens":10,"output_tokens":5,"timestamp":"not-a-time"}`,
+		`{"role":"assistant","input_tokens":1,"output_tokens":1,"timestamp":""}`,
+	}, "\n") + "\n"
+	path := writeFile(t, dir, "sess-nots.jsonl", content)
+
+	sum, err := parseSessionFile(path, nil)
+	if err != nil {
+		t.Fatalf("parseSessionFile: %v", err)
+	}
+	if sum.LastActive != 0 || sum.FirstActive != 0 {
+		t.Errorf("First/LastActive = %d/%d, want 0/0 when no entry has a parseable timestamp", sum.FirstActive, sum.LastActive)
+	}
+}
+
+func TestParseSessionFile_SingleTimestampBracketsBothEnds(t *testing.T) {
+	dir := t.TempDir()
+	content := strings.Join([]string{
+		`{"role":"user","message":"hi"}`,
+		`{"role":"assistant","model":"m","input_tokens":10,"output_tokens":5,"timestamp":"2026-08-26T09:30:00Z"}`,
+	}, "\n") + "\n"
+	path := writeFile(t, dir, "sess-onets.jsonl", content)
+
+	sum, err := parseSessionFile(path, nil)
+	if err != nil {
+		t.Fatalf("parseSessionFile: %v", err)
+	}
+	want := parseTimestampToUnixMilli("2026-08-26T09:30:00Z")
+	if sum.FirstActive != want || sum.LastActive != want {
+		t.Errorf("First/LastActive = %d/%d, want both %d", sum.FirstActive, sum.LastActive, want)
+	}
+}

--- a/src/pkg/tokens/inference_sink.go
+++ b/src/pkg/tokens/inference_sink.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 // inferenceSessionFilePrefix is prepended to per-agent inference usage files
@@ -33,6 +34,8 @@ const inferenceFilePerm = 0o644
 type InferenceSink struct {
 	dir    string
 	logger *slog.Logger
+	// now is a clock seam for tests; production uses time.Now.
+	now func() time.Time
 
 	mu     sync.Mutex
 	totals map[string]*inferenceAgentTotals
@@ -42,6 +45,12 @@ type inferenceAgentTotals struct {
 	Model        string
 	InputTokens  int64
 	OutputTokens int64
+	// FirstSeen/LastSeen bracket the agent's recorded activity as RFC 3339
+	// strings, written into the usage file's entry timestamps so the
+	// Collector's FirstActive/LastActive come out nonzero for inference
+	// sessions. FirstSeen survives restarts via restoreFromDisk.
+	FirstSeen string
+	LastSeen  string
 }
 
 // NewInferenceSink returns a sink that writes per-agent usage files into dir.
@@ -58,6 +67,7 @@ func NewInferenceSink(dir string, logger *slog.Logger) *InferenceSink {
 	s := &InferenceSink{
 		dir:    dir,
 		logger: logger,
+		now:    time.Now,
 		totals: make(map[string]*inferenceAgentTotals),
 	}
 	s.restoreFromDisk()
@@ -111,6 +121,14 @@ func (s *InferenceSink) parseAgentFile(path string) *inferenceAgentTotals {
 		if e.Model != "" {
 			t.Model = e.Model
 		}
+		if ms := parseTimestampToUnixMilli(e.Timestamp); ms > 0 {
+			if t.FirstSeen == "" || ms < parseTimestampToUnixMilli(t.FirstSeen) {
+				t.FirstSeen = e.Timestamp
+			}
+			if t.LastSeen == "" || ms > parseTimestampToUnixMilli(t.LastSeen) {
+				t.LastSeen = e.Timestamp
+			}
+		}
 		if e.InputTokens > 0 || e.OutputTokens > 0 {
 			t.InputTokens += e.InputTokens
 			t.OutputTokens += e.OutputTokens
@@ -145,6 +163,15 @@ func (s *InferenceSink) Record(agent, model string, inputTokens, outputTokens in
 	if model != "" {
 		t.Model = model
 	}
+	nowFn := s.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	stamp := nowFn().UTC().Format(time.RFC3339)
+	if t.FirstSeen == "" {
+		t.FirstSeen = stamp
+	}
+	t.LastSeen = stamp
 	if inputTokens > 0 {
 		t.InputTokens += inputTokens
 	}
@@ -171,13 +198,14 @@ func (s *InferenceSink) writeAgentFile(agent string, t *inferenceAgentTotals) er
 	}
 
 	entries := []SessionEntry{
-		{Role: "user", Agent: agent, Message: agent, Model: t.Model},
+		{Role: "user", Agent: agent, Message: agent, Model: t.Model, Timestamp: t.FirstSeen},
 		{
 			Role:         "assistant",
 			Agent:        agent,
 			Model:        t.Model,
 			InputTokens:  t.InputTokens,
 			OutputTokens: t.OutputTokens,
+			Timestamp:    t.LastSeen,
 		},
 	}
 

--- a/src/pkg/tokens/inference_sink_test.go
+++ b/src/pkg/tokens/inference_sink_test.go
@@ -3,6 +3,7 @@ package tokens
 import (
 	"log/slog"
 	"testing"
+	"time"
 )
 
 // TestInferenceSinkRecordsIntoCollectableFile verifies that usage recorded by
@@ -134,5 +135,68 @@ func TestParseSessionFileExplicitAgent(t *testing.T) {
 	}
 	if got := agg.ByAgent["kellyaa"]; got != 15 {
 		t.Fatalf("ByAgent[kellyaa] = %d, want 15 (explicit agent should win)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp stamping → nonzero First/LastActive for inference sessions (#4835)
+// ---------------------------------------------------------------------------
+
+func TestInferenceSinkStampsTimestampsForLastActive(t *testing.T) {
+	dir := t.TempDir()
+	sink := NewInferenceSink(dir, nil)
+
+	t0 := time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC)
+	current := t0
+	sink.now = func() time.Time { return current }
+
+	sink.Record("llm-worker", "llama-3", 100, 40)
+	current = t0.Add(45 * time.Minute)
+	sink.Record("llm-worker", "llama-3", 50, 20)
+
+	agg, err := CollectFromDir(dir, nil)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+	if len(agg.Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(agg.Sessions))
+	}
+	sess := agg.Sessions[0]
+	if sess.FirstActive != t0.UnixMilli() {
+		t.Errorf("FirstActive = %d, want first Record time %d", sess.FirstActive, t0.UnixMilli())
+	}
+	if sess.LastActive != t0.Add(45*time.Minute).UnixMilli() {
+		t.Errorf("LastActive = %d, want latest Record time %d", sess.LastActive, t0.Add(45*time.Minute).UnixMilli())
+	}
+}
+
+func TestInferenceSinkFirstSeenSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	t0 := time.Date(2026, 8, 26, 8, 0, 0, 0, time.UTC)
+
+	sink := NewInferenceSink(dir, nil)
+	sink.now = func() time.Time { return t0 }
+	sink.Record("llm-worker", "llama-3", 10, 5)
+
+	// Restart: a fresh sink restores FirstSeen from disk, so a later Record
+	// moves only LastSeen forward.
+	sink2 := NewInferenceSink(dir, nil)
+	t1 := t0.Add(2 * time.Hour)
+	sink2.now = func() time.Time { return t1 }
+	sink2.Record("llm-worker", "llama-3", 1, 1)
+
+	agg, err := CollectFromDir(dir, nil)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+	if len(agg.Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(agg.Sessions))
+	}
+	sess := agg.Sessions[0]
+	if sess.FirstActive != t0.UnixMilli() {
+		t.Errorf("FirstActive = %d, want pre-restart first Record %d", sess.FirstActive, t0.UnixMilli())
+	}
+	if sess.LastActive != t1.UnixMilli() {
+		t.Errorf("LastActive = %d, want post-restart Record %d", sess.LastActive, t1.UnixMilli())
 	}
 }


### PR DESCRIPTION
Fixes #4835 — follow-up to the #4838 review, where this bug was scoped out of the stub removal as live retained code.

## Bug
`parseSessionFile` declared `lastTimestamp`, never assigned it in the scan loop, and unconditionally wrote it back — every flat-format session reported `LastActive: 0` (epoch). Real consumers starve on that: the dashboard cost session list renders epoch for Started/LastActive, and `resolveAgentModels` (status_builder) can't pick an agent's most-recent session model.

## Fix
- `SessionEntry` gains an optional RFC 3339 `timestamp` field (the same wire format the Claude/Copilot session files use), per the issue's own remediation note.
- The loop tracks **min/max parseable timestamps** → `FirstActive`/`LastActive`. **Ordering decision: max timestamp seen, not last line** — flat files are append-mostly but not guaranteed ordered (atomic rewrites, merged records), so line position is not a recency signal. Documented in-code. Absent/unparseable timestamps contribute nothing, preserving the documented 0-when-unknown contract.
- `InferenceSink` — the in-repo flat-format producer, which writes no timestamps and would otherwise keep yielding 0 forever — now stamps its entries (first Record time / latest Record time) via an injectable clock seam; `FirstSeen` survives restarts through `restoreFromDisk`.

## Consumer verification
- **copilot live-capture gate** (`copilot_scanner.go:108`): unaffected — it reads `LastActive` from `parseCopilotSessionFile`, a separate parser over a separate directory with its own (correct) timestamp tracking. This change cannot flip that gate; no staleness threshold exists on the generic path to trip.
- **resolveAgentModels** (status_builder): pure max-pick — nonzero LastActive strictly improves the pick; ties/zeroes behave as before.
- **cost.go session list**: display pass-through; sort key is `Started` which now also populates.

## Tests
Out-of-order fixture pins max-not-last-line; min pins FirstActive; absent/unparseable → 0; single timestamp brackets both ends; sink stamping with fake clock; FirstSeen restart survival. **Mutation-checked (4 flips)**: dropped assignment, min-instead-of-max, last-line-instead-of-max, unstamped sink — each goes red. pkg/tokens coverage 92.6%; pkg/dashboard suite green.