### PR TITLE
📖 docs: correct stale v2 labels, retire legacy troubleshooting, document env-var upkeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Hive uses an **AI-native Capability Maturity Model** (ACMM) with six levels that
 | L5 | Semi-Autonomous (Semi-Automated) | 9 | All agents open hold-gated PRs. Humans batch-review and approve. |
 | L6 | Fully Autonomous | 10 | Agents open PRs and auto-merge on green CI. No hold label required. |
 
-Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). See `src/docs/acmm-policy-matrix.md` for the full matrix. Browse the [v2 docs index](src/docs/README.md) for operations, contributor relay, snapshots, health checks, and design guides.
+Each level defines per-agent **policy modes**: advisory (observe only), measured (file issues), holdgated (PRs with hold label), or full (auto-merge). See `src/docs/acmm-policy-matrix.md` for the full matrix. Browse the [documentation index](src/docs/README.md) for operations, contributor relay, snapshots, health checks, and design guides.
 
 Operational references from the repository root include [hub disaster recovery](docs/HUB_DISASTER_RECOVERY.md), [federation design](docs/federation-design.md), [outreach antispam policy](docs/outreach-antispam.md), [macOS deployment notes](docs/macos.md), and [backend setup](docs/backend-setup.md). Worked examples live under [examples/](examples/README.md), including [KubeStellar skill and campaign configs](examples/kubestellar/README.md), [SQLite state backend notes](examples/sqlite-state.md), and [ACMM runtime fragments](examples/acmm/README.md).
 
@@ -516,7 +516,7 @@ flowchart LR
 
 **See [src/docs/architecture.md](src/docs/architecture.md) for the full reference architecture** — process model, the governor loop, the deterministic pipeline, layered guardrails, ACMM, beads, hub & spoke, and an end-to-end walkthrough, with Mermaid diagrams throughout. Operator safety references include [trajectory review](src/docs/trajectory-review.md), [dashboard health checks](src/docs/health-checks.md), [sandbox guardrails](src/docs/sandbox-isolation.md), [manual provisioning](src/docs/manual-provisioning.md), [cross-cluster migration](src/docs/cross-cluster-migration.md), and [config layering](src/docs/config-layering.md). The dashboard API reference is published as [dashboard/openapi.json](dashboard/openapi.json).
 
-See also the [v2 docs index](src/docs/README.md), [public roadmap](src/docs/roadmap.md), and [landscape comparison](src/docs/landscape.md) for community-facing documentation and positioning.
+See also the [documentation index](src/docs/README.md), [public roadmap](src/docs/roadmap.md), and [landscape comparison](src/docs/landscape.md) for community-facing documentation and positioning.
 
 ## Contribute to a Hive
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,171 +1,24 @@
 # Troubleshooting
 
-> **Legacy v1/systemd documentation.** This page troubleshoots the original
-> supervisor/tmux/systemd deployment (`bin/supervisor.sh`, `systemctl`, and
-> `/etc/hive/agent.env`). For current containerized Go operations (branch `v4`; code under `src/`), use
-> [current troubleshooting](../src/docs/troubleshooting.md) and the
-> [`src/docs/README.md`](../src/docs/README.md) index.
+> **Retired.** This page documented the original supervisor/tmux/systemd
+> deployment (`bin/supervisor.sh`, `systemctl`, `/etc/hive/agent.env`), which is
+> no longer how Hive runs. None of it applies to the current containerized Go
+> deployment.
+>
+> **Current troubleshooting lives at
+> [`src/docs/troubleshooting.md`](../src/docs/troubleshooting.md)** — container
+> logs, config validation, agent sessions, dashboard auth, and GitHub
+> credential checks.
+>
+> See the [`src/docs/README.md`](../src/docs/README.md) index for the full
+> documentation set.
 
-
-## The `/loop` prompt never fires — the agent just sits at the prompt
-
-Cause: the supervisor's `AGENT_READY_MARKER` doesn't appear in the agent's TUI, so the supervisor gives up before sending `AGENT_LOOP_PROMPT`.
-
-Fix: attach to the session, look at the footer the agent shows when it's accepting input (for Claude Code v2.x it's "bypass permissions on"), and put that string in `AGENT_READY_MARKER` in `/etc/hive/agent.env`. Then:
-
-```sh
-sudo systemctl stop hive
-sudo -u "$AGENT_USER" tmux kill-session -t "$AGENT_SESSION_NAME"
-sudo systemctl start hive
-```
-
-## A permission prompt blocks every `/loop` iteration
-
-Cause: the agent is hitting an interactive prompt that needs a human to dismiss. For Claude Code writing to `memory/` triggers a "sensitive file" prompt even under `--dangerously-skip-permissions`.
-
-Fix: find the unique text of the "accept" option (e.g. `Yes, and always allow access to`) and put it in `AGENT_AUTO_APPROVE_PHRASE`. The supervisor will auto-send `Down Enter` the next time that phrase appears in the pane.
-
-If your agent needs multiple different approvals, extend `approve_prompt_if_present()` in `bin/supervisor.sh` to loop over a list of phrases.
-
-## `systemctl restart hive` didn't pick up my new `AGENT_LOOP_PROMPT`
-
-This is a footgun and it's worth repeating: **plain `systemctl restart` doesn't cause a session respawn.** tmux sessions survive supervisor exit, so when the new supervisor starts and sees a "healthy" old session with an "alive" agent, it does nothing. The old session is still running the old prompt.
-
-For a full reset you need:
+The v1 content that used to live here was removed because it was full-text
+searchable and surfaced ahead of the current guide, sending operators to
+`systemctl` steps that no longer exist. Recover it from git history if you are
+maintaining a v1 deployment:
 
 ```sh
-sudo systemctl stop hive
-sudo -u "$AGENT_USER" tmux kill-session -t "$AGENT_SESSION_NAME"
-sudo systemctl start hive
-```
-
-Now the new supervisor finds no session, creates one, and sends the current `AGENT_LOOP_PROMPT`.
-
-## ntfy push never arrives
-
-Run in order:
-
-```sh
-# 1. Manual test — does ntfy work at all?
-curl -d "test" "$NTFY_SERVER/$NTFY_TOPIC"
-
-# 2. Is the healthcheck env correct?
-systemctl cat hive-healthcheck.service
-# Look for EnvironmentFile=/etc/hive/agent.env
-
-# 3. Run the healthcheck by hand to see any errors:
-sudo -u "$AGENT_USER" env $(cat /etc/hive/agent.env | xargs) /usr/local/bin/agent-healthcheck.sh
-
-# 4. Is the log actually stale?
-stat "$AGENT_LOG_FILE"
-```
-
-If step 1 works but the healthcheck doesn't push, the most common cause is `NTFY_TOPIC` being blank or misspelled in the env file.
-
-## Supervisor keeps respawning even though the agent looks healthy
-
-Check the `agent_alive()` heuristic in `bin/supervisor.sh`. It considers the agent dead if no non-shell process is running under the pane PID. If your launch command has an extra shell wrapper, the supervisor may mistake the wrapper for "dead." Remove the wrapper, or edit the heuristic.
-
-## Agent writes the heartbeat but scans are obviously broken
-
-The healthcheck only knows about file mtime. If the agent's iteration code is silently noop-ing but still remembers to append to the log, the healthcheck is happy. Two defensive patterns:
-
-1. **Put counts in the log.** If `Issues triaged: 0` for 8 firings in a row, something's wrong. You'll see it in `tail -f $AGENT_LOG_FILE`.
-2. **Add your own smoke-check** as a second systemd timer that hits an external endpoint (GitHub API, your app) and cross-checks the agent's reported state.
-
-## Where do I see what the agent is doing right now?
-
-```sh
-sudo -u "$AGENT_USER" tmux attach -t "$AGENT_SESSION_NAME"
-# Ctrl+B, D to detach — session keeps running.
-
-# Or just peek without attaching:
-sudo -u "$AGENT_USER" tmux capture-pane -t "$AGENT_SESSION_NAME" -p -S -50
-```
-
-## Switching Claude Code models via tmux
-
-The `/model` slash command inside Claude Code has a picker with only three choices: **Default** (Opus 4.7), **Sonnet** (Sonnet 4.6), and **Haiku** (Haiku 4.5). There is no picker entry for Opus 4.6.
-
-To select a model not shown in the picker, pass the **full model slug** to `/model`:
-
-```
-/model claude-opus-4-6
-```
-
-### Known model slugs
-
-| Alias in picker | Full slug | Notes |
-|----------------|-----------|-------|
-| Default (Opus 4.7) | `claude-opus-4-7` | Latest, highest capability |
-| — | `claude-opus-4-6` | Not in picker — must use full slug |
-| Sonnet | `claude-sonnet-4-6` | Best for everyday tasks |
-| Haiku | `claude-haiku-4-5` | Fastest |
-
-### What does NOT work
-
-| Command | Result |
-|---------|--------|
-| `/model opus 4` | `Model 'opus 4' not found` |
-| `/model claude-opus-4` | `Model 'claude-opus-4' not found` |
-| `/model --model claude-opus-4-6` | `Model '--model claude-opus-4-6' not found` (treats flag as model name) |
-| `/fast` | Toggles "Fast mode" billing tier for Opus 4.6 — does NOT switch the model itself |
-
-### Sending via tmux (supervisor)
-
-When switching an agent's model via `tmux send-keys`, the full sequence is:
-
-```sh
-tmux send-keys -t <session> '/model claude-opus-4-6'
-tmux send-keys -t <session> Enter
-```
-
-Confirm by reading the pane — the footer should show `Opus 4.6`:
-
-```sh
-tmux capture-pane -t <session> -p | grep -i opus
-```
-
-### Confirming with `claude -p`
-
-To verify a slug works before sending it to an agent session:
-
-```sh
-claude -p --model claude-opus-4-6 "say hello"
-```
-
-If the slug is valid, you'll get a response. If not, you'll get an error.
-
-## CI check rules for merging PRs
-
-All agents that merge PRs (scanner, reviewer, supervisor) MUST follow these rules:
-
-### Non-negotiable
-
-1. **ALL required CI checks must show SUCCESS before merging.** Run `gh pr checks <number> --required` and verify every line says `pass`. If any check is `pending` or `fail`, WAIT.
-2. **The ONLY exception is `tide`.** Prow's merge queue (`tide`) stays pending forever without `lgtm`/`approved` labels. If `tide` is the only non-passing check, treat CI as green and merge.
-3. **Never batch-merge.** After merging one PR, wait for the next PR's CI to re-run against the updated base. PRs green before a merge may conflict after.
-4. **Merge sequence:** merge one → wait for next PR's CI to re-trigger and pass → merge next.
-
-### Why `tide` is safe to ignore
-
-`tide` is Prow's automatic merge controller. It requires `lgtm` + `approved` labels to queue a PR. Since AI-authored PRs use a normal `--squash` merge (Prow is not involved, and `--admin` is never used), `tide` will never transition to `success`. It is not a CI quality gate — it is a merge queue status indicator.
-
-### Checking CI status
-
-```sh
-# Check all checks (filter out tide)
-gh pr checks <number> --required 2>&1 | grep -v tide
-
-# Quick pass/fail summary
-gh pr checks <number> --required 2>&1 | grep -v tide | grep -E "fail|pending"
-# If no output → safe to merge
-```
-
-## Clean reinstall
-
-```sh
-sudo ./uninstall.sh
-# (optionally remove /etc/hive/agent.env and the heartbeat log dir)
-sudo ./install.sh
+git log --all --oneline -- docs/troubleshooting.md
+git show <commit>:docs/troubleshooting.md
 ```

--- a/src/README.md
+++ b/src/README.md
@@ -288,7 +288,7 @@ Configure via the dashboard (Strategy Lab panel, ACMM level 4+) or the `/api/nou
 
 ## Further reading
 
-- [v2 docs index](docs/README.md) — all operator, contributor, and design docs.
+- [documentation index](docs/README.md) — all operator, contributor, and design docs.
 - [Cross-cluster migration](docs/cross-cluster-migration.md) — move a hive between clusters.
 - [Manual provisioning](docs/manual-provisioning.md) — hosted/spoke provisioning and hub access.
 - [Config layering](docs/config-layering.md) — ConfigMap vs PVC overlay precedence.
@@ -347,7 +347,7 @@ The `deploy/` directory contains pre-built configurations for common deployment 
 ## Additional references
 
 - [Operator reference](docs/operator-reference.md) — config blocks, server flags/env, GitHub token scopes.
-- [Troubleshooting](docs/troubleshooting.md) — v2 container logs, config validation, agent sessions, dashboard auth, and GitHub credential checks.
+- [Troubleshooting](docs/troubleshooting.md) — container logs, config validation, agent sessions, dashboard auth, and GitHub credential checks.
 - [Config layering](docs/config-layering.md) — effective config provenance and precedence.
 - [Dashboard API reference](docs/api-reference.md) — generated route index.
 - [apiproxy](docs/apiproxy.md) — model API proxy purpose and deployment notes.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -513,7 +513,7 @@ Both polarities are enforced at **enumeration** — the point where GitHub issue
 - **[Architecture](architecture.md)** — process model, deterministic pipeline, governor loop, guardrails, and hub/spoke design.
 - **[Portable AgentDefinition format](../AGENT-DEFINITION.md)** — standalone YAML schema for agent imports, exports, and overlays.
 - **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.
-- **[Troubleshooting](../../docs/troubleshooting.md)** — stuck sessions, login expiry, restart loops, and notification checks.
+- **[Troubleshooting](troubleshooting.md)** — stuck sessions, login expiry, restart loops, and notification checks.
 - **[ACMM policy matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.
 - **[Config layering](config-layering.md)** — precedence for seed, dashboard overlay, agent overlays, and runtime snapshots.
 - **[Cross-cluster migration](cross-cluster-migration.md)** — the manual procedure for moving a hive (and its PVC state) between clusters.

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -242,6 +242,32 @@ With two or more providers configured, `/login` renders a provider picker; with 
 | `SLACK_WEBHOOK` | No | none | Slack incoming webhook for top-level script notifications. |
 | `DISCORD_WEBHOOK` | No | none | Discord webhook for top-level script notifications. |
 
+## Keeping this reference current
+
+The code is authoritative and this table is hand-maintained, so it drifts unless
+PRs update it. **If your change adds, renames, or removes an environment
+variable lookup, update this file in the same PR.**
+
+What counts as a change that needs an entry:
+
+- A new `os.Getenv` or `os.LookupEnv` call in `src/` — most live in
+  `src/pkg/hub`, `src/pkg/dashboard`, `src/pkg/agent`, and `src/pkg/config`.
+- A new variable referenced from a deployment manifest under `src/deploy/`, or
+  from a top-level helper script in `bin/`.
+- A change to an existing variable's default, or to whether it is required.
+
+What each column means:
+
+| Column | What to write |
+|---|---|
+| Variable | The exact name, in backticks. |
+| Required | `No` for anything with a working default. Spell out the condition when it is conditional (see `HIVE_GITHUB_TOKEN`). |
+| Default | The literal fallback value, or `none`. If the fallback is a lookup chain, describe the order — precedence is the part operators get wrong. |
+| Purpose | What it controls and which component reads it. Link to a deeper section when the variable has real setup steps. |
+
+Add the row to the section matching the component that reads the variable, and
+run the searches below to confirm nothing else was missed.
+
 ## Verification commands
 
 The table above was cross-checked with these mechanical searches from the repository root:


### PR DESCRIPTION
Three guide-agent docs findings, verified against `v4` before filing this PR.

## #4841 — stale "v2" labels on current docs

`README.md` linked `src/docs/README.md` as the **"v2 docs index"** in two places. That file opens by stating the `v2` branch was retired in August 2026 — it *is* the current index. The label told readers the current documentation was deprecated.

**The same bug appears twice more in `src/README.md`, which the issue did not cite:**

| File | Line | Was |
|---|---|---|
| `README.md` | 491 | `[v2 docs index]` |
| `README.md` | 519 | `[v2 docs index]` |
| `src/README.md` | 291 | `[v2 docs index]` |
| `src/README.md` | 350 | Troubleshooting — "**v2 container logs**, config validation…" |

All four corrected. A repo-wide sweep confirms no stale label remains (migration guides, which legitimately reference v2, are untouched).

## #4843 — legacy troubleshooting still full-text searchable

`docs/troubleshooting.md` carried 171 lines of v1 supervisor/tmux/systemd content (`AGENT_READY_MARKER`, `/etc/hive/agent.env`, `systemctl restart hive`) behind a redirect header. The header does not help anyone arriving from GitHub search — they land mid-document on `systemctl` steps that no longer exist.

Reduced to a redirect stub. The content stays recoverable from git history, and the stub says how.

**The issue's alternative — deleting the file — would have broken a live link.** `src/docs/agent-configuration.md:516` pointed at the legacy path and described it as current ("stuck sessions, login expiry, restart loops"). That link now targets `src/docs/troubleshooting.md`. Verified no other inbound reference to the legacy path remains.

## #4844 — env-var reference upkeep (scope corrected)

The issue asks for guidance on which files to grep. **`env-vars.md` already ends with a `## Verification commands` section carrying exactly those searches** (`os.(Getenv|LookupEnv)` across `src`, plus manifest and script sweeps), so that part of the premise does not hold.

The real gap is contributor-facing: nothing told a PR author the file was their responsibility, or what belongs in each column. Added a `## Keeping this reference current` section covering:

- the same-PR expectation for any added/renamed/removed lookup
- what triggers an entry (new `os.Getenv`/`os.LookupEnv` in `src/`, a `src/deploy/` manifest reference, a `bin/` script reference, or a change to a default or required-ness)
- per-column guidance — notably that `Default` should describe the *order* when the fallback is a lookup chain, since precedence is what operators get wrong

It references the existing searches rather than duplicating them.

## Scope

Docs only. No Go, no manifests, no behavior change.

Fixes #4841
Fixes #4843
Fixes #4844