### PR TITLE
📖 scanner: mark agent env residual lane open

### DIFF
--- a/bin/agent-env-scrub.sh
+++ b/bin/agent-env-scrub.sh
@@ -30,11 +30,11 @@
 #   - git-credential-hive.sh reads the per-agent cache file directly; hive-merge
 #     and hive-open-pr likewise never rely on inherited token env.
 #
-# Residual (documented, closed elsewhere): a same-uid agent can still read a
-# backend CLI's /proc/<pid>/environ deliberately. That extraction lane — and
-# any smuggled credential — is closed at the transport by the MITM proxy's
-# Authorization strip/inject (#1861, PR #4032): the proxy, not the agent env,
-# decides what credential GitHub ever sees.
+# Residual (documented, OPEN today): a same-uid agent can still read a backend
+# CLI's /proc/<pid>/environ deliberately. Until the MITM proxy's Authorization
+# strip/inject lands (#1861, PR #4032), that extraction lane remains open: any
+# smuggled credential is still usable against GitHub. Once #1861/#4032 lands,
+# the proxy, not the agent env, will decide what credential GitHub ever sees.
 #
 # POSIX sh compatible (dash-safe): no bashisms, and `unset` of an absent
 # variable is not an error. Keep the variable list in sync with


### PR DESCRIPTION
Fixes #4845

## Summary
- Corrects bin/agent-env-scrub.sh so the same-uid /proc/<pid>/environ residual is documented as OPEN today.
- Keeps #1861 / PR #4032 as the planned transport-layer closure, but notes smuggled credentials remain usable against GitHub until that lands.
- Grepped for repeated false "closed at the transport" / strip-inject claims; no other locations required edits.

## Cause
Commit aa001459 documented the H3 residual as already closed by MITM proxy Authorization strip/inject, but PR #4032 is still open/parked and v4 only has an aspirational #1861 proxy comment.

## Test
- TMPDIR=$PWD/.scratch-tmp bash bin/test_agent_env_scrub.sh