### PR TITLE
🐛 ci(dd): stop triggering OpenSSF Scorecard on dd pushes

### DIFF
--- a/.github/release-lines.yml
+++ b/.github/release-lines.yml
@@ -64,7 +64,13 @@ pinned:
   # entry again, the exclusion has been lost upstream — restore it there; do
   # not merge the sync branch, and do not "fix" it by widening this entry.
   # See src/docs/release-line-guard.md, "The infra workflow sync".
-  scorecard.yml: [main, -v2]
+  # scorecard.yml also does not run on `dd`: the reusable scorecard action only
+  # supports the repository default branch, so a `dd` push trigger fails
+  # structurally on every push ("refs/heads/dd not supported with push event.
+  # Only the default branch v4 is supported.") — a guaranteed red check with no
+  # signal, seen on the #4839 sync merge. Excluded here so the gap is written
+  # down rather than a perpetual failure.
+  scorecard.yml: [main, -v2, -dd]
   suid-contract.yml: []
   v2-ci.yml: []
   v2-tests.yml: []

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,10 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
-    branches: [ "dd", "main", "v4" ]
+    # NOTE: the reusable scorecard action only supports the repository default
+    # branch (v4); running on dd pushes fails structurally with
+    # "refs/heads/dd not supported with push event".
+    branches: [ "main", "v4" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Every push to `dd` fails the OpenSSF Scorecard check structurally: the reusable scorecard action rejects non-default branches ("refs/heads/dd not supported with push event. Only the default branch v4 is supported."). Seen on the #4839 merge commit `d594ca05` — the only red check on an otherwise fully green dd HEAD.

Fix: remove `dd` from the push trigger list, matching v4's copy of scorecard.yml. Weekly cron + v4/main pushes still run the analysis; dd gains nothing from a run that cannot start.

Refs #4842.