### PR TITLE
🐛 fix(dashboard): contain Prompt Template tab scroll chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ### Fixed
 
+- Agent config **Prompt Template** tab scroll no longer chains into the
+  dashboard behind the modal ([#4850](https://github.com/kubestellar/hive/issues/4850)):
+  the tab wrapper is now its own contained scroller (`overflow-y:auto` +
+  `overscroll-behavior:contain`, with `min-height:0` so the flex child can
+  actually engage), and the same containment is applied to sibling tab panes
+  in the same dialog (Export YAML, Import paste, Prior Prompts shell) plus
+  the `.config-pre` / `.config-stats-list` CSS rules so they do not depend
+  solely on a multi-selector list that can be reorganized later. Nested
+  editor/preview/variable-picker containment from #2766 is unchanged.
 - The canonical `blocked` workflow overlay now stays out of the contributor
   queue: the actionable-work enumerator, ReadyQueue, live contributor
   assignment, and internal kick projection all withhold it. Work waiting on

--- a/src/pkg/dashboard/prompt_template_scroll_test.go
+++ b/src/pkg/dashboard/prompt_template_scroll_test.go
@@ -1,0 +1,115 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPromptTemplateTabScrollContainment pins #4850: the Prompt Template tab
+// scroll pane must contain overscroll so wheel/touch at its edge does not chain
+// into the dashboard behind the agent config modal. The editor/preview already
+// carried #2766 containment; the gap was the tab wrapper itself when
+// Import-from-repo expansion made the whole column taller than .config-body.
+func TestPromptTemplateTabScrollContainment(t *testing.T) {
+	html := indexHTML(t)
+
+	tabTag := `id="prompt-template-tab" style="`
+	idx := strings.Index(html, tabTag)
+	if idx < 0 {
+		t.Fatal(`index.html no longer renders #prompt-template-tab with an inline style — update this test alongside the markup (#4850)`)
+	}
+	styleEnd := strings.Index(html[idx+len(tabTag):], `"`)
+	if styleEnd < 0 {
+		t.Fatal("#prompt-template-tab inline style is unterminated")
+	}
+	style := html[idx+len(tabTag) : idx+len(tabTag)+styleEnd]
+	for _, want := range []string{
+		"overflow-y:auto",
+		"overscroll-behavior:contain",
+		"overscroll-behavior-y:contain",
+		"min-height:0",
+	} {
+		if !strings.Contains(style, want) {
+			t.Errorf("#prompt-template-tab inline style is missing %q — tab scroll chains to the dashboard (#4850); style: %s", want, style)
+		}
+	}
+
+	// Nested surfaces that operators actually wheel over must still contain.
+	for _, snippet := range []string{
+		"overscroll-behavior:contain;overscroll-behavior-y:contain\" placeholder=\"Enter your agent's kick template here.",
+		`class="config-pre config-pre-fill" style="display:none;flex:1;min-height:300px;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain"`,
+		`max-height:120px;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing Prompt Template nested containment %q (#4850)", snippet)
+		}
+	}
+}
+
+// TestAgentConfigSiblingTabScrollContainment audits sibling tab scroll panes in
+// the same agent config dialog (#4850): Export YAML, Import paste, and Prior
+// Prompts shell must carry the same overscroll containment convention.
+func TestAgentConfigSiblingTabScrollContainment(t *testing.T) {
+	html := indexHTML(t)
+
+	for _, tc := range []struct {
+		name    string
+		snippet string
+	}{
+		{
+			"export tab outer",
+			`flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">'
+        + '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Portable agent definition`,
+		},
+		{
+			"export yaml textarea",
+			`tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain">Loading...</textarea>`,
+		},
+		{
+			"import paste textarea",
+			`id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px;overscroll-behavior:contain;overscroll-behavior-y:contain"`,
+		},
+		{
+			"prior prompts shell outer",
+			"Prompts sent to this agent — fully expanded, all variables resolved and pipeline data injected. Newest first.",
+		},
+	} {
+		if !strings.Contains(html, tc.snippet) {
+			t.Errorf("index.html is missing sibling-tab scroll containment for %s (#4850): %q", tc.name, tc.snippet)
+		}
+	}
+	// Prior Prompts outer must carry the same tab-level containment as Prompt Template.
+	phMarker := "Prompts sent to this agent — fully expanded"
+	phIdx := strings.Index(html, phMarker)
+	if phIdx < 0 {
+		t.Fatal("prior prompts blurb missing")
+	}
+	// Walk back to the opening style= of the shell div (within ~400 chars).
+	start := phIdx - 400
+	if start < 0 {
+		start = 0
+	}
+	window := html[start:phIdx]
+	if !strings.Contains(window, "overscroll-behavior:contain") || !strings.Contains(window, "min-height:0") {
+		t.Error("Prior Prompts shell outer is missing overscroll containment / min-height:0 (#4850)")
+	}
+
+	// .config-pre and .config-stats-list own-rule containment (not only the
+	// multi-selector list) so regrouping selectors cannot drop them.
+	for _, rule := range []string{".config-pre {", ".config-stats-list {"} {
+		idx := strings.Index(html, rule)
+		if idx < 0 {
+			t.Errorf("index.html has no %q rule", rule)
+			continue
+		}
+		end := strings.Index(html[idx:], "}")
+		if end < 0 {
+			t.Errorf("%q rule is unterminated", rule)
+			continue
+		}
+		body := html[idx : idx+end]
+		if !strings.Contains(body, "overscroll-behavior") {
+			t.Errorf("%q rule is missing overscroll-behavior containment (#4850)", rule)
+		}
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -1789,7 +1789,14 @@
     /* compact stat-row inputs — size step re-declared after the input recipe */
     /* .btn-sm / .btn-danger / .btn-add — ghost/danger/secondary buttons (system recipe) */
     .btn-sm:disabled { opacity: 0.3; cursor: default; }
-    .config-stats-list { max-height: 400px; overflow-y: auto; padding-right: 12px; }
+    .config-stats-list {
+      max-height: 400px; overflow-y: auto; padding-right: 12px;
+      /* Inline with the scroller definition (#4850) — same belt-and-suspenders
+         as .config-pre so the Stats tab never depends solely on the shared
+         multi-selector containment rule. */
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
+    }
 
     .config-info {
       display: inline-flex; align-items: center; justify-content: center;
@@ -1844,6 +1851,10 @@
       border-radius: 6px; padding: 12px; font-size: 0.75rem;
       overflow-x: auto; white-space: pre-wrap; color: var(--muted);
       max-height: 300px; overflow-y: auto;
+      /* Own rule carries containment so a later regroup of the shared
+         modal-scroller selector list cannot re-open scroll chaining (#4850). */
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
     }
     .config-pre-fill {
       max-height: calc(85vh - 220px); min-height: 200px;
@@ -2895,7 +2906,7 @@
       <h2 class="config-title">ACMM Maturity Level <span id="acmm-dialog-current" style="font-size:0.72em;font-weight:400;color:var(--muted)"></span></h2>
       <button class="config-close" data-action="closeACMMDialog">&times;</button>
     </div>
-    <div class="config-body" style="padding:16px 24px;overflow-y:auto;max-height:calc(85vh - 120px)">
+    <div class="config-body" style="padding:16px 24px;overflow-y:auto;max-height:calc(85vh - 120px);overscroll-behavior:contain;overscroll-behavior-y:contain">
       <p style="font-size:0.82rem;color:var(--muted);margin:0 0 16px">
         Select your AI-native Continuous Maturity Model (ACMM) level. Each level provides a curated set of agents
         with increasing autonomy. Agents are additive — higher levels build on lower ones.
@@ -15911,7 +15922,7 @@ function burnAreaChart() {
         '</div>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Or paste agent definition</label>' +
-          '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
+          '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px;overscroll-behavior:contain;overscroll-behavior-y:contain" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
           '<div style="text-align:right;margin-top:6px"><button data-action="previewImportFromPaste" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Preview</button></div>' +
         '</div>' +
         '<div id="import-preview" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px;margin-top:16px">' +
@@ -18560,8 +18571,13 @@ function burnAreaChart() {
 
       const gen = (_configState.data && _configState.data.general) || {};
       const ps = gen.promptSource || {};
+      // Outer pane is its own contained scroller (#4850): when Import-from-repo
+      // is expanded the tab content exceeds .config-body, and without
+      // overscroll on this wrapper the wheel at the pane edge chains past the
+      // modal into the dashboard. min-height:0 lets the flex child shrink so
+      // overflow-y:auto actually engages inside the modal.
       return `
-        <div style="display:flex;flex-direction:column;height:100%">
+        <div id="prompt-template-tab" style="display:flex;flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">
         <div id="${srcId}" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:10px 14px;margin-bottom:10px;flex-shrink:0">
           <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Source files <span style="font-weight:400;color:var(--muted)">(edit these on your fork)</span></div>
         </div>
@@ -18749,13 +18765,15 @@ function burnAreaChart() {
           })
           .catch(function() {});
       }
-      return '<div style="display:flex;flex-direction:column;height:100%">'
+      // Sibling of Prompt Template (#4850): long export YAML scrolls the
+      // textarea; without containment the wheel chains out of the modal.
+      return '<div style="display:flex;flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">'
         + '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Portable agent definition in YAML format. Use this to share agents across hive instances.</p>'
         + '<div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">'
         + '<button data-action="copyExportYaml" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Copy to Clipboard</button>'
         + '<button data-action="downloadExportYaml" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
         + '</div>'
-        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--terminal-bg);color:var(--terminal-fg);border:1px solid var(--terminal-line);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
+        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--terminal-bg);color:var(--terminal-fg);border:1px solid var(--terminal-line);border-radius:6px;resize:vertical;white-space:pre;tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain">Loading...</textarea>'
         + '</div>';
     }
 
@@ -18885,7 +18903,10 @@ function burnAreaChart() {
       const opts = PROMPT_HISTORY_WINDOWS.map(function(w) {
         return '<option value="' + w.hours + '"' + (w.hours === selected ? ' selected' : '') + '>' + esc(w.label) + '</option>';
       }).join('');
-      return `<div style="display:flex;flex-direction:column;height:100%">
+      // Outer shell matches Prompt Template (#4850): min-height:0 so the list
+      // flex child can shrink and own the scroll, with tab-level containment
+      // if the header + list still overflow .config-body.
+      return `<div style="display:flex;flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Prompts sent to this agent — fully expanded, all variables resolved and pipeline data injected. Newest first.</p>
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-shrink:0">
           <label for="prompt-history-window" style="font-size:0.75rem;color:var(--muted)">Window</label>


### PR DESCRIPTION
## Summary

- Make the agent config **Prompt Template** tab wrapper (`#prompt-template-tab`) its own contained scroller (`overflow-y:auto`, `overscroll-behavior:contain` / `-y:contain`, `min-height:0`) so wheel/touch at the pane edge no longer chains into the dashboard behind the modal.
- Nested editor / preview / variable-picker containment from #2766 is unchanged.
- Audit sibling panes in the same dialog and apply the same convention: Export YAML (outer + textarea), Import paste textarea, Prior Prompts shell outer; also pin containment on the `.config-pre` and `.config-stats-list` CSS rules themselves (not only the multi-selector list).
- ACMM pack picker `config-body` gains inline containment for parity with the shared rule.

## Related issues

Fixes #4850

## Testing

- [x] Static pin checks (PowerShell string assertions matching the new Go tests) on `src/pkg/dashboard/static/index.html` — all pins passed
- [ ] `cd src && go test ./pkg/dashboard/ -run 'PromptTemplateTabScroll|AgentConfigSiblingTabScroll|ModalScrollContainment|PromptHistoryScroll'` — not run here: full package build fails on this Windows host (`syscall.Flock` undefined in `pkg/beads`); tests are pure HTML string pins and will run in Linux CI
- [ ] Other / not run (explain): no browser wheel repro in this environment; follows the #2766 / #4803 / #4805 containment pattern already proven in-repo

## Contributor checklist

- [x] PR targets `v4` unless a maintainer requested another branch.
- [x] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes.
- [x] `CHANGELOG.md` has an entry for user-visible changes (features, fixes, new env vars, behavior changes), or the change is not user-facing.
- [x] No secrets, credentials, or local runtime state are committed.