### PR TITLE
🐛 Fix dead-agent hub verdict wording

### DIFF
--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -124,17 +124,11 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 				// actionable cause (operator re-login) instead of the generic
 				// count — the EPM/alchemy at-a-glance case.
 				v.Reason = fmt.Sprintf("%d agent(s) stuck at login — re-login needed", rollup.LoginStuck)
-			case rollup.DeadOrGone == rollup.Problems && rollup.Running == 0:
-				// Nothing alive at all: keep the familiar wording so a fully
-				// down hive reads the same as before the cause split.
-				v.Reason = "no agents running"
 			case rollup.DeadOrGone == rollup.Problems:
-				// Katamari/ibm-aiops-orchestrator live shape: guide+supervisor
-				// were failed/dead while quality+scanner still ran. The old
-				// Running==0 guard meant the cause fell through to generic
-				// "2 agent(s) blocked", hiding the restart remedy. When every
-				// problem is dead/gone, name that cause even if other agents in
-				// the hive are still healthy.
+				// Katamari/ibm-aiops-orchestrator live shapes: failed/dead agents
+				// need a restart whether the outage is partial or every expected
+				// agent is down. Name that cause instead of the generic "blocked"
+				// or "no agents running" wording.
 				v.Reason = fmt.Sprintf("%d agent(s) down — restart needed", rollup.DeadOrGone)
 			case rollup.IdleWithWork == rollup.Problems:
 				// Sessions are alive but every scheduled agent is sitting past

--- a/src/pkg/hub/health_verdict_reasons_test.go
+++ b/src/pkg/hub/health_verdict_reasons_test.go
@@ -148,13 +148,14 @@ func TestHiveHealthForReasons(t *testing.T) {
 		},
 		{
 			// Every problem is a dead/vanished session and nothing is alive:
-			// the familiar full-outage wording is preserved by the cause split.
-			name:   "L3 all problems dead — keeps no-agents-running wording",
+			// still name the restart remedy instead of falling through to the
+			// generic full-outage wording.
+			name:   "L3 all problems dead — names restart cause",
 			entry:  base(3),
-			rollup: agentFleetRollup{Expected: 2, Running: 0, Known: 2, Problems: 2, DeadOrGone: 2},
+			rollup: agentFleetRollup{Expected: 4, Running: 0, Known: 4, Problems: 4, DeadOrGone: 4},
 			app:    okApp(), queued: 3,
 			wantState:  HealthStateRed,
-			wantReason: "no agents running",
+			wantReason: "4 agent(s) down — restart needed",
 		},
 		{
 			// Katamari/ibm-aiops-orchestrator live shape: guide+supervisor are
@@ -334,6 +335,15 @@ func TestHiveHealth_LiveFleetCauseShapes(t *testing.T) {
 			agents:     []AgentSummary{dead("guide"), dead("supervisor"), working("quality"), working("scanner")},
 			wantState:  HealthStateRed,
 			wantReason: "2 agent(s) down — restart needed",
+		},
+		{
+			// Katamari/ibm-aiops-orchestrator can also have all four expected bob
+			// agents failed. That should keep the actionable restart cause instead
+			// of saying only that no agents are running.
+			name:       "all expected agents dead",
+			agents:     []AgentSummary{dead("guide"), dead("quality"), dead("scanner"), dead("supervisor")},
+			wantState:  HealthStateRed,
+			wantReason: "4 agent(s) down — restart needed",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- Report the specific "N agent(s) down — restart needed" cause whenever every problem agent is dead or gone, even when zero agents are running.
- Extend live-shape regression coverage for the katamari/ibm-aiops-orchestrator case where all four expected bob agents failed.

## Live example
katamari/ibm-aiops-orchestrator had 4 expected bob agents all failed, but the hub chip said "no agents running", hiding the actionable restart cause.

## Validation
- `cd /Users/andan02/wt-dead-chip/src && go test ./pkg/hub/... -count=1`
- `cd /Users/andan02/wt-dead-chip/src && go vet ./pkg/hub/...`