### PR TITLE
✨ cost: surface audited repo activity attribution facts

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2499,6 +2499,7 @@ func main() {
 		// the heartbeat reads, so its merge-success signal reuses the existing
 		// 30-minute collect loop instead of issuing a second GitHub fetch.
 		FleetStats:            fleetStatsCollector,
+		Activity:              activityCollector,
 		BeadSynthesizer:       beadSynth,
 		BeadStores:            beadStores,
 		BeadStoreLoadFailures: beadStoreLoadFailures,
@@ -4876,15 +4877,31 @@ func buildRepoActivityWire(repos []dashboard.RepoActivity) []hub.RepoActivityWir
 	}
 	out := make([]hub.RepoActivityWire, 0, len(repos))
 	for _, r := range repos {
+		agents := make([]hub.AgentRepoActivityWire, 0, len(r.Agents))
+		for _, a := range r.Agents {
+			agents = append(agents, hub.AgentRepoActivityWire{
+				Agent:      a.Agent,
+				Issues:     stat(a.Issues),
+				PRs:        stat(a.PRs),
+				Comments:   stat(a.Comments),
+				Merges:     stat(a.Merges),
+				Claims:     stat(a.Claims),
+				Reviews:    stat(a.Reviews),
+				Advisory:   stat(a.Advisory),
+				Reconciled: stat(a.Reconciled),
+			})
+		}
 		out = append(out, hub.RepoActivityWire{
-			Repo:     r.Repo,
-			Issues:   stat(r.Issues),
-			PRs:      stat(r.PRs),
-			Comments: stat(r.Comments),
-			Merges:   stat(r.Merges),
-			Claims:   stat(r.Claims),
-			Reviews:  stat(r.Reviews),
-			Advisory: stat(r.Advisory),
+			Repo:       r.Repo,
+			Issues:     stat(r.Issues),
+			PRs:        stat(r.PRs),
+			Comments:   stat(r.Comments),
+			Merges:     stat(r.Merges),
+			Claims:     stat(r.Claims),
+			Reviews:    stat(r.Reviews),
+			Advisory:   stat(r.Advisory),
+			Reconciled: stat(r.Reconciled),
+			Agents:     agents,
 		})
 	}
 	return out

--- a/src/cmd/hive/wire_helpers_test.go
+++ b/src/cmd/hive/wire_helpers_test.go
@@ -23,14 +23,20 @@ func TestBuildRepoActivityWireMapsEveryStat(t *testing.T) {
 	at := func(i int) string { return fmt.Sprintf("2026-08-26T04:0%d:00Z", i) }
 	in := []dashboard.RepoActivity{
 		{
-			Repo:     "kubestellar/hive",
-			Issues:   dashboard.ActivityActionStat{Count: 1, NewestAt: at(0)},
-			PRs:      dashboard.ActivityActionStat{Count: 2, NewestAt: at(1)},
-			Comments: dashboard.ActivityActionStat{Count: 3, NewestAt: at(2)},
-			Merges:   dashboard.ActivityActionStat{Count: 4, NewestAt: at(3)},
-			Claims:   dashboard.ActivityActionStat{Count: 5, NewestAt: at(4)},
-			Reviews:  dashboard.ActivityActionStat{Count: 6, NewestAt: at(5)},
-			Advisory: dashboard.ActivityActionStat{Count: 7, NewestAt: at(6)},
+			Repo:       "kubestellar/hive",
+			Issues:     dashboard.ActivityActionStat{Count: 1, NewestAt: at(0)},
+			PRs:        dashboard.ActivityActionStat{Count: 2, NewestAt: at(1)},
+			Comments:   dashboard.ActivityActionStat{Count: 3, NewestAt: at(2)},
+			Merges:     dashboard.ActivityActionStat{Count: 4, NewestAt: at(3)},
+			Claims:     dashboard.ActivityActionStat{Count: 5, NewestAt: at(4)},
+			Reviews:    dashboard.ActivityActionStat{Count: 6, NewestAt: at(5)},
+			Advisory:   dashboard.ActivityActionStat{Count: 7, NewestAt: at(6)},
+			Reconciled: dashboard.ActivityActionStat{Count: 9, NewestAt: at(8)},
+			Agents: []dashboard.AgentRepoActivity{{
+				Agent:      "quality",
+				Issues:     dashboard.ActivityActionStat{Count: 8, NewestAt: at(7)},
+				Reconciled: dashboard.ActivityActionStat{Count: 10, NewestAt: at(9)},
+			}},
 		},
 		{Repo: "kubestellar/other"},
 	}
@@ -58,10 +64,14 @@ func TestBuildRepoActivityWireMapsEveryStat(t *testing.T) {
 		{"Claims", got.Claims.Count, 5, got.Claims.NewestAt, at(4)},
 		{"Reviews", got.Reviews.Count, 6, got.Reviews.NewestAt, at(5)},
 		{"Advisory", got.Advisory.Count, 7, got.Advisory.NewestAt, at(6)},
+		{"Reconciled", got.Reconciled.Count, 9, got.Reconciled.NewestAt, at(8)},
 	}
 	for _, c := range checks {
 		if c.count != c.wantCount {
 			t.Errorf("%s.Count = %d, want %d", c.name, c.count, c.wantCount)
+		}
+		if len(got.Agents) != 1 || got.Agents[0].Agent != "quality" || got.Agents[0].Issues.Count != 8 || got.Agents[0].Reconciled.Count != 10 {
+			t.Errorf("agent activity not mapped: %+v", got.Agents)
 		}
 		if c.newestAt != c.wantAt {
 			t.Errorf("%s.NewestAt = %q, want %q", c.name, c.newestAt, c.wantAt)

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -153,6 +153,7 @@ Auth levels are derived from dashboard middleware (`isPublicPath`, dashboard tok
 | `GET` | `/api/token-access` | Dashboard auth/session | Token Access | `pkg/dashboard/api.go:81` |
 | `GET` | `/api/tokens` | Dashboard auth/session | Tokens | `pkg/dashboard/api.go:82` |
 | `GET` | `/api/cost` | Dashboard auth/session | Cost | `pkg/dashboard/api.go:83` |
+| `GET` | `/api/repo-activity` | Dashboard auth/session | Per-repo audited activity | `pkg/dashboard/api.go` |
 | `GET` | `/api/cost/history` | Dashboard auth/session | Cost History | `pkg/dashboard/api.go:84` |
 | `GET` | `/api/trend/history` | Dashboard auth/session | Trend History | `pkg/dashboard/api.go:85` |
 | `GET` | `/api/timeseries` | Dashboard auth/session | Time Series | `pkg/dashboard/api.go:86` |

--- a/src/docs/token-tracking.md
+++ b/src/docs/token-tracking.md
@@ -29,6 +29,7 @@ The collector keeps the latest aggregate in memory and writes `/data/token-summa
 
 - `/api/status` includes token/cost fields used by the dashboard.
 - `/api/cost` returns estimated cost from token counts × the static price table plus native spend for gateways that report it (OpenRouter `/key`, LiteLLM `/key/info`). Estimated rows are labelled `estimated` or `unpriced`; native gateway rows are labelled `native`.
+- `/api/repo-activity` is phase 1 of per-repo cost attribution: it reports audited output counts per repo and per `(repo, agent)` from `repo=` audit entries, plus an explicit `unattributed` bucket for output events with no repo. It reports activity only, not dollars; cost must not be smeared across repos until timestamped token joins exist.
 - Cost estimates are not invoices. Subscription plans, self-hosted inference, negotiated rates, and provider billing semantics can differ from list prices.
 
 ## Hub rollups

--- a/src/pkg/dashboard/activity_collector.go
+++ b/src/pkg/dashboard/activity_collector.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"os"
 	"regexp"
+	"sort"
 	"sync"
 	"time"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
 )
 
 // activityCollectInterval is how often the spoke recomputes its per-repo output
@@ -30,13 +34,15 @@ const activityHealthWindowHours = 12
 // sync with pkg/github/attribution.go. Advisory is counted separately because it
 // is the L2 output signal.
 var activityOutputActions = map[string]bool{
-	"agent_issue_created":   true,
-	"agent_pr_created":      true,
-	"agent_comment_created": true,
-	"pr_merged":             true,
-	"agent_issue_claimed":   true,
-	"agent_pr_reviewed":     true,
-	"advisory_commented":    true,
+	ghpkg.AuditActionAgentIssueCreated:       true,
+	ghpkg.AuditActionAgentPRCreated:          true,
+	ghpkg.AuditActionAgentCommentCreated:     true,
+	ghpkg.AuditActionPRMerged:                true,
+	ghpkg.AuditActionIssueClaimed:            true,
+	ghpkg.AuditActionPRReviewed:              true,
+	ghpkg.AuditActionAdvisoryCommented:       true,
+	ghpkg.AuditActionHiveIssueCreated:        true,
+	ghpkg.AuditActionPRAttributionReconciled: true,
 }
 
 // ActivityActionStat is one action's count within the window plus the newest
@@ -49,22 +55,40 @@ type ActivityActionStat struct {
 
 // RepoActivity is per-repo output activity over the window.
 type RepoActivity struct {
-	Repo     string             `json:"repo"`
-	Issues   ActivityActionStat `json:"issues"`
-	PRs      ActivityActionStat `json:"prs"`
-	Comments ActivityActionStat `json:"comments"`
-	Merges   ActivityActionStat `json:"merges"`
-	Claims   ActivityActionStat `json:"claims"`
-	Reviews  ActivityActionStat `json:"reviews"`
-	Advisory ActivityActionStat `json:"advisory"`
+	Repo       string              `json:"repo"`
+	Issues     ActivityActionStat  `json:"issues"`
+	PRs        ActivityActionStat  `json:"prs"`
+	Comments   ActivityActionStat  `json:"comments"`
+	Merges     ActivityActionStat  `json:"merges"`
+	Claims     ActivityActionStat  `json:"claims"`
+	Reviews    ActivityActionStat  `json:"reviews"`
+	Advisory   ActivityActionStat  `json:"advisory"`
+	Reconciled ActivityActionStat  `json:"reconciled"`
+	Agents     []AgentRepoActivity `json:"agents,omitempty"`
+}
+
+// AgentRepoActivity is the same recorded-fact activity breakdown scoped to one
+// hive agent inside one repo. Agent is "unknown" only when an older/broken audit
+// line omitted both the typed Agent field and the detail's agent= pair.
+type AgentRepoActivity struct {
+	Agent      string             `json:"agent"`
+	Issues     ActivityActionStat `json:"issues"`
+	PRs        ActivityActionStat `json:"prs"`
+	Comments   ActivityActionStat `json:"comments"`
+	Merges     ActivityActionStat `json:"merges"`
+	Claims     ActivityActionStat `json:"claims"`
+	Reviews    ActivityActionStat `json:"reviews"`
+	Advisory   ActivityActionStat `json:"advisory"`
+	Reconciled ActivityActionStat `json:"reconciled"`
 }
 
 // ActivitySnapshot is the full per-hive activity summary the collector produces
 // and the heartbeat ships.
 type ActivitySnapshot struct {
-	Repos       []RepoActivity `json:"repos"`
-	WindowHours int            `json:"window_hours"`
-	CollectedAt time.Time      `json:"collected_at"`
+	Repos        []RepoActivity     `json:"repos"`
+	Unattributed ActivityActionStat `json:"unattributed"`
+	WindowHours  int                `json:"window_hours"`
+	CollectedAt  time.Time          `json:"collected_at"`
 }
 
 // auditReader is the subset of *AuditLog the collector needs, so it can be
@@ -181,6 +205,7 @@ func (ac *ActivityCollector) Start(ctx context.Context) {
 
 // repoRe extracts repo=<org/name> from an audit detail string ("k=v, k=v").
 var repoRe = regexp.MustCompile(`(?:^|[,\s])repo=([^,\s]+)`)
+var agentRe = regexp.MustCompile(`(?:^|[,\s])agent=([^,\s]+)`)
 
 // collect reads the window of output actions from the audit log and rebuilds the
 // per-repo summary.
@@ -190,16 +215,19 @@ func (ac *ActivityCollector) collect() {
 	entries := ac.audit.OutputActionsSince(since, activityOutputActions, ac.auditPath)
 
 	byRepo := map[string]*RepoActivity{}
+	byRepoAgent := map[string]map[string]*AgentRepoActivity{}
 	bump := func(stat *ActivityActionStat, ts string) {
 		stat.Count++
 		if ts > stat.NewestAt { // RFC3339 is lexically sortable
 			stat.NewestAt = ts
 		}
 	}
+	var unattributed ActivityActionStat
 	for _, e := range entries {
 		m := repoRe.FindStringSubmatch(e.Detail)
 		if m == nil {
-			continue // no repo → not attributable output (e.g. a lifecycle event)
+			bump(&unattributed, e.Timestamp)
+			continue
 		}
 		repo := m[1]
 		ra := byRepo[repo]
@@ -207,34 +235,72 @@ func (ac *ActivityCollector) collect() {
 			ra = &RepoActivity{Repo: repo}
 			byRepo[repo] = ra
 		}
+		agent := activityAgent(e)
+		agentMap := byRepoAgent[repo]
+		if agentMap == nil {
+			agentMap = map[string]*AgentRepoActivity{}
+			byRepoAgent[repo] = agentMap
+		}
+		aa := agentMap[agent]
+		if aa == nil {
+			aa = &AgentRepoActivity{Agent: agent}
+			agentMap[agent] = aa
+		}
 		switch e.Action {
-		case "agent_issue_created":
+		case ghpkg.AuditActionAgentIssueCreated, ghpkg.AuditActionHiveIssueCreated:
 			bump(&ra.Issues, e.Timestamp)
-		case "agent_pr_created":
+			bump(&aa.Issues, e.Timestamp)
+		case ghpkg.AuditActionAgentPRCreated:
 			bump(&ra.PRs, e.Timestamp)
-		case "agent_comment_created":
+			bump(&aa.PRs, e.Timestamp)
+		case ghpkg.AuditActionAgentCommentCreated:
 			bump(&ra.Comments, e.Timestamp)
-		case "pr_merged":
+			bump(&aa.Comments, e.Timestamp)
+		case ghpkg.AuditActionPRMerged:
 			bump(&ra.Merges, e.Timestamp)
-		case "agent_issue_claimed":
+			bump(&aa.Merges, e.Timestamp)
+		case ghpkg.AuditActionIssueClaimed:
 			bump(&ra.Claims, e.Timestamp)
-		case "agent_pr_reviewed":
+			bump(&aa.Claims, e.Timestamp)
+		case ghpkg.AuditActionPRReviewed:
 			bump(&ra.Reviews, e.Timestamp)
-		case "advisory_commented":
+			bump(&aa.Reviews, e.Timestamp)
+		case ghpkg.AuditActionAdvisoryCommented:
 			bump(&ra.Advisory, e.Timestamp)
+			bump(&aa.Advisory, e.Timestamp)
+		case ghpkg.AuditActionPRAttributionReconciled:
+			bump(&ra.Reconciled, e.Timestamp)
+			bump(&aa.Reconciled, e.Timestamp)
 		}
 	}
 	repos := make([]RepoActivity, 0, len(byRepo))
 	for _, ra := range byRepo {
+		agents := make([]AgentRepoActivity, 0, len(byRepoAgent[ra.Repo]))
+		for _, aa := range byRepoAgent[ra.Repo] {
+			agents = append(agents, *aa)
+		}
+		sort.Slice(agents, func(i, j int) bool { return agents[i].Agent < agents[j].Agent })
+		ra.Agents = agents
 		repos = append(repos, *ra)
 	}
+	sort.Slice(repos, func(i, j int) bool { return repos[i].Repo < repos[j].Repo })
 
 	ac.mu.Lock()
-	ac.snap = ActivitySnapshot{Repos: repos, WindowHours: activityHealthWindowHours, CollectedAt: now}
+	ac.snap = ActivitySnapshot{Repos: repos, Unattributed: unattributed, WindowHours: activityHealthWindowHours, CollectedAt: now}
 	ac.collectedAt = now
 	ac.ready = true
 	ac.persistLocked()
 	ac.mu.Unlock()
+}
+
+func activityAgent(e AuditEntry) string {
+	if e.Agent != "" {
+		return e.Agent
+	}
+	if m := agentRe.FindStringSubmatch(e.Detail); m != nil {
+		return m[1]
+	}
+	return "unknown"
 }
 
 // Snapshot returns the last computed summary and whether a collect has succeeded.
@@ -255,4 +321,28 @@ func (ac *ActivityCollector) CollectedAt() time.Time {
 	ac.mu.Lock()
 	defer ac.mu.Unlock()
 	return ac.collectedAt
+}
+
+type repoActivityResponse struct {
+	Ready       bool             `json:"ready"`
+	Phase       string           `json:"phase"`
+	Snapshot    ActivitySnapshot `json:"snapshot"`
+	Limitations []string         `json:"limitations"`
+}
+
+func (s *Server) handleRepoActivity(w http.ResponseWriter, r *http.Request) {
+	var snap ActivitySnapshot
+	ready := false
+	if s.deps != nil && s.deps.Activity != nil {
+		snap, ready = s.deps.Activity.Snapshot()
+	}
+	jsonResponse(w, repoActivityResponse{
+		Ready:    ready,
+		Phase:    "phase_1_activity_only",
+		Snapshot: snap,
+		Limitations: []string{
+			"Counts are recorded audit facts only; no token cost is attributed in this phase.",
+			"Entries without repo= are reported as unattributed and are never spread across repos.",
+		},
+	})
 }

--- a/src/pkg/dashboard/activity_collector_test.go
+++ b/src/pkg/dashboard/activity_collector_test.go
@@ -1,8 +1,11 @@
 package dashboard
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,6 +49,45 @@ func TestOutputActionsSince(t *testing.T) {
 	}
 }
 
+func TestOutputActionsSinceReadsRotatedCompressedBackups(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	current := writeAuditFixture(t, dir, []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=o/current, number=1"},
+	})
+	rotated := filepath.Join(dir, "audit-2026-08-26T12-00-00.000.jsonl.gz")
+	f, err := os.Create(rotated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(f)
+	if err := json.NewEncoder(gz).Encode(AuditEntry{
+		Timestamp: rfc3339(now.Add(-2 * time.Hour)),
+		Action:    "agent_issue_created",
+		Detail:    "repo=o/rotated, number=2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := (&AuditLog{}).OutputActionsSince(now.Add(-24*time.Hour), activityOutputActions, current)
+	if len(got) != 2 {
+		t.Fatalf("want current + rotated entries, got %d: %+v", len(got), got)
+	}
+	seen := map[string]bool{}
+	for _, e := range got {
+		seen[e.Detail] = true
+	}
+	if !seen["repo=o/current, number=1"] || !seen["repo=o/rotated, number=2"] {
+		t.Fatalf("rotated/current details missing: %+v", seen)
+	}
+}
+
 // collect groups by repo + action with counts and newest timestamps, across
 // multiple repos — the multi-repo case that broke the hand-scraped counts.
 func TestActivityCollector_CountsPerRepo(t *testing.T) {
@@ -53,12 +95,13 @@ func TestActivityCollector_CountsPerRepo(t *testing.T) {
 	dir := t.TempDir()
 	newest := now.Add(-10 * time.Minute)
 	p := writeAuditFixture(t, dir, []AuditEntry{
-		{Timestamp: rfc3339(now.Add(-2 * time.Hour)), Action: "agent_issue_created", Detail: "repo=z/ui, number=1"},
-		{Timestamp: rfc3339(newest), Action: "agent_issue_created", Detail: "repo=z/ui, number=2"},
-		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=z/api-server, number=9"},
-		{Timestamp: rfc3339(now.Add(-3 * time.Hour)), Action: "pr_merged", Detail: "repo=z/api-server, number=8"},
-		{Timestamp: rfc3339(now.Add(-4 * time.Hour)), Action: "agent_pr_reviewed", Detail: "repo=z/ui, number=5, state=approved"},
-		{Timestamp: rfc3339(now.Add(-5 * time.Hour)), Action: "agent_issue_claimed", Detail: "repo=z/ui-framework, number=3"},
+		{Timestamp: rfc3339(now.Add(-2 * time.Hour)), Action: "agent_issue_created", Detail: "repo=z/ui, number=1, agent=quality"},
+		{Timestamp: rfc3339(newest), Action: "agent_issue_created", Detail: "repo=z/ui, number=2", Agent: "docs"},
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=z/api-server, number=9", Agent: "quality"},
+		{Timestamp: rfc3339(now.Add(-3 * time.Hour)), Action: "pr_merged", Detail: "repo=z/api-server, number=8", Agent: "governor"},
+		{Timestamp: rfc3339(now.Add(-4 * time.Hour)), Action: "agent_pr_reviewed", Detail: "repo=z/ui, number=5, state=approved", Agent: "reviewer"},
+		{Timestamp: rfc3339(now.Add(-5 * time.Hour)), Action: "agent_issue_claimed", Detail: "repo=z/ui-framework, number=3", Agent: "quality"},
+		{Timestamp: rfc3339(now.Add(-6 * time.Hour)), Action: "pr_attribution_reconciled", Detail: "repo=z/ui, number=6", Agent: "governor"},
 	})
 	ac := NewActivityCollector(&AuditLog{}, p, nil)
 	ac.nowFn = func() time.Time { return now }
@@ -83,6 +126,16 @@ func TestActivityCollector_CountsPerRepo(t *testing.T) {
 	if byRepo["z/ui"].Reviews.Count != 1 {
 		t.Errorf("z/ui reviews = %d, want 1", byRepo["z/ui"].Reviews.Count)
 	}
+	if byRepo["z/ui"].Reconciled.Count != 1 {
+		t.Errorf("z/ui reconciled = %d, want 1", byRepo["z/ui"].Reconciled.Count)
+	}
+	uiAgents := map[string]AgentRepoActivity{}
+	for _, a := range byRepo["z/ui"].Agents {
+		uiAgents[a.Agent] = a
+	}
+	if uiAgents["quality"].Issues.Count != 1 || uiAgents["docs"].Issues.Count != 1 || uiAgents["reviewer"].Reviews.Count != 1 {
+		t.Errorf("z/ui per-agent counts = %+v, want quality/docs issues and reviewer review", uiAgents)
+	}
 	if byRepo["z/api-server"].PRs.Count != 1 || byRepo["z/api-server"].Merges.Count != 1 {
 		t.Errorf("z/api-server prs/merges = %d/%d, want 1/1", byRepo["z/api-server"].PRs.Count, byRepo["z/api-server"].Merges.Count)
 	}
@@ -94,7 +147,8 @@ func TestActivityCollector_CountsPerRepo(t *testing.T) {
 	}
 }
 
-// Entries with no repo= are skipped (not attributable output).
+// Entries with no repo= stay out of repo rows and are reported explicitly as
+// unattributed rather than smeared across known repos.
 func TestActivityCollector_SkipsNoRepo(t *testing.T) {
 	now := time.Now().UTC()
 	dir := t.TempDir()
@@ -107,6 +161,9 @@ func TestActivityCollector_SkipsNoRepo(t *testing.T) {
 	snap, _ := ac.Snapshot()
 	if len(snap.Repos) != 0 {
 		t.Errorf("entry without repo= must be skipped, got %+v", snap.Repos)
+	}
+	if snap.Unattributed.Count != 1 {
+		t.Errorf("unattributed count = %d, want 1", snap.Unattributed.Count)
 	}
 }
 
@@ -145,5 +202,41 @@ func TestActivityCollector_NilAuditInert(t *testing.T) {
 	ac.Start(ctx) // must return immediately
 	if _, ok := ac.Snapshot(); ok {
 		t.Error("nil-audit collector must not be ready")
+	}
+}
+
+func TestHandleRepoActivityReportsPhaseOneHonesty(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	p := writeAuditFixture(t, dir, []AuditEntry{{
+		Timestamp: rfc3339(now.Add(-1 * time.Hour)),
+		Action:    "agent_pr_created",
+		Detail:    "repo=o/r, number=1",
+		Agent:     "quality",
+	}})
+	ac := NewActivityCollector(&AuditLog{}, p, nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.collect()
+
+	s := NewServer(0, nil)
+	s.RegisterAPI(&Dependencies{Activity: ac})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/repo-activity", nil)
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp repoActivityResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Ready || resp.Phase != "phase_1_activity_only" {
+		t.Fatalf("ready/phase = %v/%q", resp.Ready, resp.Phase)
+	}
+	if len(resp.Snapshot.Repos) != 1 || len(resp.Snapshot.Repos[0].Agents) != 1 {
+		t.Fatalf("repo/agent activity missing: %+v", resp.Snapshot)
+	}
+	if len(resp.Limitations) == 0 {
+		t.Fatal("limitations must be explicit so activity is not mistaken for cost")
 	}
 }

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -93,6 +93,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/token-access", s.handleTokenAccess)
 	s.mux.HandleFunc("GET /api/tokens", s.handleTokens)
 	s.mux.HandleFunc("GET /api/cost", s.handleCost)
+	s.mux.HandleFunc("GET /api/repo-activity", s.handleRepoActivity)
 	s.mux.HandleFunc("GET /api/cost/history", s.handleCostHistory)
 	// #4298: "for every recent reset, how much of the budget had been used".
 	s.mux.HandleFunc("GET /api/budget/history", s.handleBudgetHistory)

--- a/src/pkg/dashboard/audit.go
+++ b/src/pkg/dashboard/audit.go
@@ -2,10 +2,15 @@ package dashboard
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -173,14 +178,12 @@ func (a *AuditLog) LastUserActions() map[string]string {
 
 // OutputActionsSince reads the on-disk audit log (auditLogPath) and returns
 // every entry whose Action is in `actions` and whose timestamp is at or after
-// `since`. It reads the FILE, not the in-memory ring, because the ring is capped
-// at auditRingCap (500) and reset on restart — the activity collector needs the
-// full window (e.g. 12h across every repo on a busy hive), which only the
-// lumberjack-rotated file holds. Malformed lines and unparseable timestamps are
-// skipped. Rotated/compressed backups are NOT read: the collector persists its
-// own running totals to a sidecar (see activity_collector.go), so the current
-// file is sufficient for the recent window and the sidecar covers history beyond
-// rotation. A missing file returns an empty slice (clean first-boot).
+// `since`. It reads the FILES, not the in-memory ring, because the ring is
+// capped at auditRingCap (500) and reset on restart — cost-attribution activity
+// needs the full audit window across busy hives. Lumberjack rotated backups
+// adjacent to filePath are included, including compressed ".gz" backups.
+// Malformed lines and unparseable timestamps are skipped. A missing current file
+// returns an empty slice (clean first-boot).
 //
 // filePath is a parameter (defaulting to auditLogPath when "") so tests can
 // point it at a fixture without touching /data.
@@ -188,30 +191,81 @@ func (a *AuditLog) OutputActionsSince(since time.Time, actions map[string]bool, 
 	if filePath == "" {
 		filePath = auditLogPath
 	}
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil
-	}
 	var out []AuditEntry
-	for _, line := range bytes.Split(data, []byte("\n")) {
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
+	for _, path := range auditLogFiles(filePath) {
+		data, err := readAuditLogFile(path)
+		if err != nil {
 			continue
 		}
-		var e AuditEntry
-		if json.Unmarshal(line, &e) != nil || e.Timestamp == "" {
-			continue
+		for _, line := range bytes.Split(data, []byte("\n")) {
+			line = bytes.TrimSpace(line)
+			if len(line) == 0 {
+				continue
+			}
+			var e AuditEntry
+			if json.Unmarshal(line, &e) != nil || e.Timestamp == "" {
+				continue
+			}
+			if len(actions) > 0 && !actions[e.Action] {
+				continue
+			}
+			t, perr := time.Parse(time.RFC3339, e.Timestamp)
+			if perr != nil || t.Before(since) {
+				continue
+			}
+			out = append(out, e)
 		}
-		if len(actions) > 0 && !actions[e.Action] {
-			continue
-		}
-		t, perr := time.Parse(time.RFC3339, e.Timestamp)
-		if perr != nil || t.Before(since) {
-			continue
-		}
-		out = append(out, e)
 	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Timestamp < out[j].Timestamp })
 	return out
+}
+
+func auditLogFiles(filePath string) []string {
+	dir := filepath.Dir(filePath)
+	base := filepath.Base(filePath)
+	ext := filepath.Ext(base)
+	prefix := strings.TrimSuffix(base, ext)
+	patterns := []string{
+		filePath,
+		filePath + ".*",
+		filepath.Join(dir, prefix+"-*"+ext),
+		filepath.Join(dir, prefix+"-*"+ext+".gz"),
+	}
+	seen := map[string]bool{}
+	files := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, p := range matches {
+			if seen[p] {
+				continue
+			}
+			seen[p] = true
+			files = append(files, p)
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
+func readAuditLogFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var r io.Reader = f
+	if strings.HasSuffix(path, ".gz") {
+		gz, err := gzip.NewReader(f)
+		if err != nil {
+			return nil, err
+		}
+		defer gz.Close()
+		r = gz
+	}
+	return io.ReadAll(r)
 }
 
 func (a *AuditLog) Recent(n int) []AuditEntry {

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -51,6 +51,7 @@ type Dependencies struct {
 	// Nil is safe: Snapshot() on a nil collector reports ready=false and the
 	// advisor leaves the signal at its conservative zero.
 	FleetStats      *FleetStatsCollector
+	Activity        *ActivityCollector
 	BeadSynthesizer *knowledge.BeadSynthesizer
 	BeadStores      map[string]*beads.Store
 	// BeadStoreLoadFailures counts configured bead stores that failed to open at

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -51,11 +51,11 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		entry     RegistryEntry
-		rollup    agentFleetRollup
-		app       GitHubAppHealth
-		queued    int
+		name       string
+		entry      RegistryEntry
+		rollup     agentFleetRollup
+		app        GitHubAppHealth
+		queued     int
 		wantState  string
 		wantKind   string
 		wantReason string // substring match, "" = don't check
@@ -421,6 +421,10 @@ func TestSanitizeRepoActivity(t *testing.T) {
 		Repo:   "org/name",
 		Issues: ActivityStatWire{Count: -5, NewestAt: "not-a-time"},
 		PRs:    ActivityStatWire{Count: 3, NewestAt: "2026-08-22T10:00:00Z"},
+		Agents: []AgentRepoActivityWire{{
+			Agent:  " quality ",
+			Merges: ActivityStatWire{Count: 2, NewestAt: "2026-08-22T11:00:00Z"},
+		}, {Agent: "   "}},
 	}}
 	got := sanitizeRepoActivity(in)
 	if len(got) != 1 {
@@ -431,5 +435,8 @@ func TestSanitizeRepoActivity(t *testing.T) {
 	}
 	if got[0].PRs.Count != 3 || got[0].PRs.NewestAt == "" {
 		t.Errorf("good PR stat mangled: %+v", got[0].PRs)
+	}
+	if len(got[0].Agents) != 1 || got[0].Agents[0].Agent != "quality" || got[0].Agents[0].Merges.Count != 2 {
+		t.Errorf("agent activity not sanitized: %+v", got[0].Agents)
 	}
 }

--- a/src/pkg/hub/repo_activity.go
+++ b/src/pkg/hub/repo_activity.go
@@ -43,20 +43,54 @@ func sanitizeRepoActivity(in []RepoActivityWire) []RepoActivityWire {
 		if repo == "" {
 			continue
 		}
+		agents := sanitizeAgentRepoActivity(r.Agents)
 		out = append(out, RepoActivityWire{
-			Repo:     repo,
-			Issues:   sanitizeStatWire(r.Issues),
-			PRs:      sanitizeStatWire(r.PRs),
-			Comments: sanitizeStatWire(r.Comments),
-			Merges:   sanitizeStatWire(r.Merges),
-			Claims:   sanitizeStatWire(r.Claims),
-			Reviews:  sanitizeStatWire(r.Reviews),
-			Advisory: sanitizeStatWire(r.Advisory),
+			Repo:       repo,
+			Issues:     sanitizeStatWire(r.Issues),
+			PRs:        sanitizeStatWire(r.PRs),
+			Comments:   sanitizeStatWire(r.Comments),
+			Merges:     sanitizeStatWire(r.Merges),
+			Claims:     sanitizeStatWire(r.Claims),
+			Reviews:    sanitizeStatWire(r.Reviews),
+			Advisory:   sanitizeStatWire(r.Advisory),
+			Reconciled: sanitizeStatWire(r.Reconciled),
+			Agents:     agents,
 		})
 	}
 	if len(out) == 0 {
 		// Every row was junk — treat as "no data" rather than an empty summary
 		// that would read as "reported zero output".
+		return nil
+	}
+	return out
+}
+
+func sanitizeAgentRepoActivity(in []AgentRepoActivityWire) []AgentRepoActivityWire {
+	if len(in) == 0 {
+		return nil
+	}
+	if len(in) > maxRepoActivityRepos {
+		in = in[:maxRepoActivityRepos]
+	}
+	out := make([]AgentRepoActivityWire, 0, len(in))
+	for _, a := range in {
+		agent := truncateReachRunes(sanitizeHeartbeatField(a.Agent), maxRepoNameRunes)
+		if agent == "" {
+			continue
+		}
+		out = append(out, AgentRepoActivityWire{
+			Agent:      agent,
+			Issues:     sanitizeStatWire(a.Issues),
+			PRs:        sanitizeStatWire(a.PRs),
+			Comments:   sanitizeStatWire(a.Comments),
+			Merges:     sanitizeStatWire(a.Merges),
+			Claims:     sanitizeStatWire(a.Claims),
+			Reviews:    sanitizeStatWire(a.Reviews),
+			Advisory:   sanitizeStatWire(a.Advisory),
+			Reconciled: sanitizeStatWire(a.Reconciled),
+		})
+	}
+	if len(out) == 0 {
 		return nil
 	}
 	return out
@@ -79,12 +113,26 @@ type ActivityStatWire struct {
 // RepoActivityWire is per-repo output activity over the collector's window.
 // Field set mirrors dashboard.RepoActivity.
 type RepoActivityWire struct {
-	Repo     string           `json:"repo"`
-	Issues   ActivityStatWire `json:"issues"`
-	PRs      ActivityStatWire `json:"prs"`
-	Comments ActivityStatWire `json:"comments"`
-	Merges   ActivityStatWire `json:"merges"`
-	Claims   ActivityStatWire `json:"claims"`
-	Reviews  ActivityStatWire `json:"reviews"`
-	Advisory ActivityStatWire `json:"advisory"`
+	Repo       string                  `json:"repo"`
+	Issues     ActivityStatWire        `json:"issues"`
+	PRs        ActivityStatWire        `json:"prs"`
+	Comments   ActivityStatWire        `json:"comments"`
+	Merges     ActivityStatWire        `json:"merges"`
+	Claims     ActivityStatWire        `json:"claims"`
+	Reviews    ActivityStatWire        `json:"reviews"`
+	Advisory   ActivityStatWire        `json:"advisory"`
+	Reconciled ActivityStatWire        `json:"reconciled"`
+	Agents     []AgentRepoActivityWire `json:"agents,omitempty"`
+}
+
+type AgentRepoActivityWire struct {
+	Agent      string           `json:"agent"`
+	Issues     ActivityStatWire `json:"issues"`
+	PRs        ActivityStatWire `json:"prs"`
+	Comments   ActivityStatWire `json:"comments"`
+	Merges     ActivityStatWire `json:"merges"`
+	Claims     ActivityStatWire `json:"claims"`
+	Reviews    ActivityStatWire `json:"reviews"`
+	Advisory   ActivityStatWire `json:"advisory"`
+	Reconciled ActivityStatWire `json:"reconciled"`
 }


### PR DESCRIPTION
Part of #4836

Implements Phase 1 only: per-repo activity from the audit log, with no token-cost attribution yet.

Scope delivered:
- Adds `/api/repo-activity` with phase/limitations so operators see recorded activity facts without mistaking them for spend.
- Counts audited output events per repo and per `(repo, agent)` from trusted hive audit entries (`repo=` plus typed audit agent / `agent=` fallback).
- Preserves honesty: output events without `repo=` are reported in an explicit `unattributed` bucket and are never spread across repos.
- Extends the audit reader to include lumberjack rotated backups, including compressed `.gz` files, so a busy hive does not silently truncate at the current 5 MB file.
- Carries per-agent repo activity through the existing spoke→hub heartbeat wire format.

Rejected routes intentionally not used: `HIVE_REPO`, removed `issueCosts`, agent cwd, agent-supplied session ids, session-discovery watcher, or mtime session selection.

Attribution-coverage honesty audit:
- Cost attributable in this PR: 0%. This is activity-only Phase 1; all token spend remains unlabeled by repo rather than guessed.
- Activity coverage is auditable from the returned snapshot: repo rows contain only `repo=` events; `snapshot.unattributed` contains count/recency for output events missing repo context.

Validation:
- `go test ./pkg/dashboard ./pkg/hub ./cmd/hive -short -race -count=1 -timeout 600s`
- `go build ./...`
- `go vet ./...`
- `go test -cover ./pkg/dashboard ./pkg/hub ./cmd/hive` (dashboard 85.2%, hub 88.7%; both above configured floors)
- `go test ./pkg/... ./cmd/... -short -count=1 -timeout 600s` (only local Darwin `cmd/bd TestResolveDirFallbackCwd` `/private/var` vs `/var` path canonicalization failure)
- Mutation checks: flipped rotated-backup assertion and per-agent join assertion; both failed as expected.
- No dashboard `index.html` touch; no v2 workflow rename; no new forbidden `podman system prune/reset` literals.

Remaining #4836 work:
- Phase 2: retain Claude per-message timestamped usage.
- Phase 3: Claude-only interval cost join with mandatory `unattributed` and `backend_unsupported` buckets.
- Phase 4: Copilot attribution through proxy-scoped per-request data, likely separate epic.
