### PR TITLE
🐛 fix: hide observability agents below ACMM L5

### DIFF
--- a/src/docs/acmm-policy-matrix.md
+++ b/src/docs/acmm-policy-matrix.md
@@ -27,7 +27,7 @@ A single interactive advisor helps with repo setup and architecture decisions. G
 | guide | advisory | `guide-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L2 — Advisory (Instructed) (7 agents)
+### L2 — Advisory (Instructed) (5 agents)
 
 Agents observe and report findings as advisory beads on the dashboard and tracking issue. No GitHub issues or PRs created. Humans decide what to act on.
 
@@ -37,11 +37,9 @@ Agents observe and report findings as advisory beads on the dashboard and tracki
 | scanner | advisory | `scanner-advisory.md` |
 | quality | advisory | `quality-advisory.md` |
 | guide | advisory | `guide-advisory.md` |
-| telemetry (paused) | advisory | `telemetry-advisory.md` |
-| operations (paused) | advisory | `operations-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L3 — Quality-Gated (Measured) (8 agents)
+### L3 — Quality-Gated (Measured) (6 agents)
 
 Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI workflows. All other agents remain advisory. CI-maintainer joins to monitor build health. Key artifact: measurement infrastructure.
 
@@ -52,13 +50,11 @@ Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI w
 | ci-maintainer | advisory | `ci-maintainer-advisory.md` |
 | **quality** | **holdgated** | `quality-holdgated.md` |
 | guide | advisory | `guide-advisory.md` |
-| telemetry (paused) | advisory | `telemetry-advisory.md` |
-| operations (paused) | advisory | `operations-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L4 — Security-Aware (Adaptive) (9 agents)
+### L4 — Security-Aware (Adaptive) (7 agents)
 
-Delivery agents open GitHub issues — bugs, docs gaps, CI problems, security vulnerabilities. Telemetry and operations remain advisory and paused. Only Quality, sec-check, and ci-maintainer may open PRs. Security agent joins.
+Delivery agents open GitHub issues — bugs, docs gaps, CI problems, security vulnerabilities. Only Quality, sec-check, and ci-maintainer may open PRs. Security agent joins.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -68,8 +64,6 @@ Delivery agents open GitHub issues — bugs, docs gaps, CI problems, security vu
 | **quality** | **holdgated** | `quality-holdgated.md` |
 | guide | measured | `guide-issues.md` |
 | **sec-check** | **holdgated** | `sec-check-holdgated.md` |
-| telemetry (paused) | advisory | `telemetry-advisory.md` |
-| operations (paused) | advisory | `operations-advisory.md` |
 | brainstorm | advisory | `brainstorm-advisory.md` |
 
 ### L5 — Semi-Autonomous (Semi-Automated) (11 agents)
@@ -121,7 +115,7 @@ Existing autonomous lanes can open issues, create PRs, and auto-merge on green C
 4. **Mode escalation is per-agent.** At L4, some agents are measured (issues only) while others are holdgated (issues + PRs). The level defines the mix.
 5. **Knowledge priming works at all levels.** The `${KNOWLEDGE}` template variable injects relevant facts from git sources and wiki layers regardless of the agent's mode.
 6. **Brainstorm is always advisory.** It produces KB facts and beads, never GitHub issues or PRs. Its role evolves from inception (L1) to ongoing ideation (L2+), but its mode stays advisory at all levels.
-7. **Telemetry and operations are opt-in.** They are present from L2 onward but use a paused cadence in every governor mode. At L2–L4 they report findings only; at L5–L6 they may open issues and PRs but never merge.
+7. **Telemetry and operations are L5/L6-only opt-in agents.** Below L5 they are absent from the pack roster and dashboard, do not spawn panes, and cannot be kicked. At L5–L6 they use a paused cadence in every governor mode until an operator opts in; they may open issues and PRs but never merge.
 
 ## Changing a hive's ACMM level
 

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -418,7 +418,7 @@ The L5 roster is the canonical worked example — eleven agents, eight on the go
 
 At L5, every agent PR gets a `hold` label automatically. The system proposes; it does not merge autonomously.
 
-Telemetry and operations stay paused until an operator deliberately opts in. Their lane keywords are disjoint: telemetry owns instrumentation and observability terms, while operations owns health, SLO, runbook, incident, rollback, and alerting terms.
+Telemetry and operations are L5/L6-only agents. They stay absent below L5 and remain paused at L5/L6 until an operator deliberately opts in. Their lane keywords are disjoint: telemetry owns instrumentation and observability terms, while operations owns health, SLO, runbook, incident, rollback, and alerting terms.
 
 Configure that opt-in under **Settings → Project Observability**. This tab is
 for the managed project's target stack; the **Features** tab separately controls

--- a/src/pkg/agent/acmm_gate.go
+++ b/src/pkg/agent/acmm_gate.go
@@ -1,0 +1,14 @@
+package agent
+
+const operabilityAgentMinACMMLevel = 5
+
+// AgentAvailableAtACMMLevel is the hard ACMM roster gate for agents whose
+// existence is level-scoped, not just whose GitHub write authority is scoped.
+func AgentAvailableAtACMMLevel(name string, level int) bool {
+	switch name {
+	case "telemetry", "operations":
+		return level >= operabilityAgentMinACMMLevel
+	default:
+		return true
+	}
+}

--- a/src/pkg/agent/agent_unit_test.go
+++ b/src/pkg/agent/agent_unit_test.go
@@ -24,6 +24,76 @@ func TestSetAndGetACMMLevel(t *testing.T) {
 	}
 }
 
+func TestOperabilityAgentsRequireACMML5(t *testing.T) {
+	for _, name := range []string{"telemetry", "operations"} {
+		for level := 0; level < operabilityAgentMinACMMLevel; level++ {
+			if AgentAvailableAtACMMLevel(name, level) {
+				t.Fatalf("%s should be unavailable at L%d", name, level)
+			}
+		}
+		if !AgentAvailableAtACMMLevel(name, 5) || !AgentAvailableAtACMMLevel(name, 6) {
+			t.Fatalf("%s should be available at L5/L6", name)
+		}
+	}
+	if !AgentAvailableAtACMMLevel("scanner", 1) {
+		t.Fatal("non-operability agents must not be affected by the L5 gate")
+	}
+}
+
+func TestManagerDoesNotInstantiateOperabilityAgentsBelowL5(t *testing.T) {
+	cfgs := map[string]config.AgentConfig{
+		"scanner":    {Backend: "copilot"},
+		"telemetry":  {Backend: "copilot"},
+		"operations": {Backend: "copilot"},
+	}
+	m := NewManager(cfgs, slog.Default(), ProjectContext{ACMMLevel: 3})
+
+	if _, ok := m.agents["telemetry"]; ok {
+		t.Fatal("telemetry should not be instantiated below L5")
+	}
+	if _, ok := m.agents["operations"]; ok {
+		t.Fatal("operations should not be instantiated below L5")
+	}
+	if _, ok := m.agents["scanner"]; !ok {
+		t.Fatal("scanner should still be instantiated below L5")
+	}
+
+	m.AddAgent("telemetry", config.AgentConfig{Backend: "copilot"})
+	if _, ok := m.agents["telemetry"]; ok {
+		t.Fatal("AddAgent should respect the L5 operability gate")
+	}
+
+	m.SetACMMLevel(5)
+	m.AddAgent("telemetry", config.AgentConfig{Backend: "copilot"})
+	if _, ok := m.agents["telemetry"]; !ok {
+		t.Fatal("telemetry should be addable at L5")
+	}
+
+	m.SetACMMLevel(4)
+	if _, ok := m.agents["telemetry"]; ok {
+		t.Fatal("downgrading below L5 should remove instantiated telemetry")
+	}
+}
+
+func TestReconcileAgentsTreatsOperabilityAgentsAsAbsentBelowL5(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"scanner":   {Backend: "copilot"},
+		"telemetry": {Backend: "copilot"},
+	}, slog.Default(), ProjectContext{ACMMLevel: 5})
+
+	if _, ok := m.agents["telemetry"]; !ok {
+		t.Fatal("telemetry should start present at L5")
+	}
+	m.SetACMMLevel(3)
+	m.ReconcileAgents(map[string]config.AgentConfig{
+		"scanner":   {Backend: "copilot"},
+		"telemetry": {Backend: "copilot"},
+	})
+	if _, ok := m.agents["telemetry"]; ok {
+		t.Fatal("reconcile below L5 should retire stale telemetry even if config still lists it")
+	}
+}
+
 func TestResolveAgentByName(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {ID: "scan-001", Backend: "claude"},

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1437,6 +1437,7 @@ func (m *Manager) SetACMMLevel(level int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.project.ACMMLevel = level
+	m.removeAgentsBelowACMMGateLocked(level)
 }
 
 func (m *Manager) GetACMMLevel() int {
@@ -1488,6 +1489,10 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 	}
 
 	for name, cfg := range agents {
+		if !AgentAvailableAtACMMLevel(name, project.ACMMLevel) {
+			logger.Info("agent below ACMM gate; not instantiating", "agent", name, "level", project.ACMMLevel)
+			continue
+		}
 		agentID := cfg.ID
 		if agentID == "" {
 			agentID = name
@@ -1584,6 +1589,10 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	if !ok {
 		m.mu.Unlock()
 		return fmt.Errorf("agent %s not found", name)
+	}
+	if !AgentAvailableAtACMMLevel(name, m.project.ACMMLevel) {
+		m.mu.Unlock()
+		return fmt.Errorf("agent %s is not available below ACMM L5", name)
 	}
 
 	if agent.State == StateRunning {
@@ -4055,6 +4064,11 @@ func (m *Manager) AddAgent(name string, cfg config.AgentConfig) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if !AgentAvailableAtACMMLevel(name, m.project.ACMMLevel) {
+		m.logger.Info("agent below ACMM gate; not adding", "agent", name, "level", m.project.ACMMLevel)
+		return
+	}
+
 	if _, exists := m.agents[name]; exists {
 		return
 	}
@@ -4092,6 +4106,21 @@ func (m *Manager) AddAgent(name string, cfg config.AgentConfig) {
 	))
 }
 
+func (m *Manager) removeAgentsBelowACMMGateLocked(level int) {
+	for name, existing := range m.agents {
+		if AgentAvailableAtACMMLevel(name, level) {
+			continue
+		}
+		if existing.cancel != nil {
+			existing.cancel()
+		}
+		_ = m.tmuxCmd(existing, "kill-session", "-t", existing.tmuxSession).Run()
+		delete(m.idToName, existing.ID)
+		delete(m.agents, name)
+		m.logger.Info("audit: agent removed by ACMM gate", "name", name, "id", existing.ID, "level", level, "session", existing.tmuxSession)
+	}
+}
+
 // UpdateConfig updates the stored config for a running agent process so that
 // status builders (which read from AgentProcess.Config) reflect changes made
 // via the config dialog (which writes to the global Config.Agents map).
@@ -4115,8 +4144,13 @@ func (m *Manager) ReconcileAgents(configs map[string]config.AgentConfig) []strin
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var added []string
+	allowedConfigs := make(map[string]config.AgentConfig, len(configs))
 
 	for name, cfg := range configs {
+		if !AgentAvailableAtACMMLevel(name, m.project.ACMMLevel) {
+			continue
+		}
+		allowedConfigs[name] = cfg
 		if existing, ok := m.agents[name]; ok {
 			delete(m.idToName, existing.ID)
 			existing.Config = cfg
@@ -4158,7 +4192,7 @@ func (m *Manager) ReconcileAgents(configs map[string]config.AgentConfig) []strin
 	}
 
 	for name, existing := range m.agents {
-		if _, ok := configs[name]; ok {
+		if _, ok := allowedConfigs[name]; ok {
 			continue
 		}
 		if existing.cancel != nil {

--- a/src/pkg/classify/classifier.go
+++ b/src/pkg/classify/classifier.go
@@ -120,8 +120,6 @@ var defaultLanes = []LaneConfig{
 	{Name: "ci-maintainer", Keywords: []string{"workflow-failure", "ci-failure", "nightly", "coverage", "regression", "ga4", "analytics"}},
 	{Name: "outreach", Keywords: []string{"adopters", "outreach", "community", "engagement"}},
 	{Name: "quality", Keywords: []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"}},
-	{Name: "telemetry", Keywords: []string{"observability", "opentelemetry", "prometheus", "grafana", "tracing", "metrics", "structured-logging", "servicemonitor", "podmonitor"}},
-	{Name: "operations", Keywords: []string{"healthz", "readyz", "readiness", "slo-", "sli-", "service-level-objective", "service-level-indicator", "error-budget", "runbook", "incident-response", "rollback", "alerting"}},
 }
 
 var lanesMu sync.RWMutex

--- a/src/pkg/classify/classifier_test.go
+++ b/src/pkg/classify/classifier_test.go
@@ -210,6 +210,11 @@ func TestClassify_OutreachLane(t *testing.T) {
 }
 
 func TestClassify_OperabilityLanes(t *testing.T) {
+	SetLanes([]LaneConfig{
+		{Name: "telemetry", Keywords: []string{"observability", "opentelemetry", "prometheus", "grafana", "tracing", "metrics", "structured-logging", "servicemonitor", "podmonitor"}},
+		{Name: "operations", Keywords: []string{"healthz", "readyz", "readiness", "slo-", "sli-", "service-level-objective", "service-level-indicator", "error-budget", "runbook", "incident-response", "rollback", "alerting"}},
+	})
+	defer SetLanes(nil)
 	tests := []struct {
 		title string
 		want  Lane
@@ -228,6 +233,18 @@ func TestClassify_OperabilityLanes(t *testing.T) {
 				t.Errorf("lane = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClassify_DefaultLanesExcludeOperabilityAgents(t *testing.T) {
+	SetLanes(nil)
+	for _, title := range []string{
+		"Add an OpenTelemetry collector configuration",
+		"Create a readiness runbook and rollback procedure",
+	} {
+		if got := Classify(makeIssue(title)).Lane; got != Lane("scanner") {
+			t.Fatalf("default lane for %q = %q, want scanner", title, got)
+		}
 	}
 }
 

--- a/src/pkg/config/acmm_packs_test.go
+++ b/src/pkg/config/acmm_packs_test.go
@@ -25,7 +25,7 @@ func TestACMMPacksAgentCounts(t *testing.T) {
 	packs := ACMMPacks()
 
 	expected := map[int]int{
-		1: 2, 2: 7, 3: 8, 4: 9, 5: 11, 6: 12,
+		1: 2, 2: 5, 3: 6, 4: 7, 5: 11, 6: 12,
 	}
 	for _, p := range packs {
 		want, ok := expected[p.Level]
@@ -38,8 +38,8 @@ func TestACMMPacksAgentCounts(t *testing.T) {
 	}
 }
 
-func TestOperabilityAgentsArePausedInEveryGovernorMode(t *testing.T) {
-	for level := 2; level <= 6; level++ {
+func TestOperabilityAgentsArePausedInEveryGovernorModeAtEligibleLevels(t *testing.T) {
+	for level := 5; level <= 6; level++ {
 		pack, err := ACMMPackByLevel(level)
 		if err != nil {
 			t.Fatalf("load L%d pack: %v", level, err)

--- a/src/pkg/config/packs/level-2.yaml
+++ b/src/pkg/config/packs/level-2.yaml
@@ -1,8 +1,7 @@
 level: 2
 name: Advisory
 description: >
-  One-way feedback (formerly "Instructed"). Seven agents, including opt-in telemetry and operations,
-  produce advisory beads — findings visible on the dashboard and in a tracking
+  One-way feedback (formerly "Instructed"). Five agents produce advisory beads — findings visible on the dashboard and in a tracking
   issue. No GitHub issues or PRs created. Agents observe and report; humans
   decide what to act on.
 governor:
@@ -15,29 +14,21 @@ governor:
       guide: 4h
       scanner: 4h
       quality: 6h
-      telemetry: paused
-      operations: paused
     busy:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
-      telemetry: paused
-      operations: paused
     quiet:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
-      telemetry: paused
-      operations: paused
     idle:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
-      telemetry: paused
-      operations: paused
 agents:
   - name: supervisor
     display_name: Supervisor
@@ -147,37 +138,3 @@ agents:
       Heavy consumer of community wiki patterns. Produces ideation facts
       (feature proposals, architecture decisions, strategic direction) into
       the project KB layer.
-  - name: telemetry
-    display_name: telemetry
-    role: telemetry
-    description: Audits managed-project instrumentation and observability backends; reports findings only.
-    emoji: "📡"
-    color: "#00a8cc"
-    sort_order: 65
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ADVISORY
-    kick_template: telemetry-advisory.md
-    include_repos: true
-    stale_timeout: 28800
-    lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
-    interactions: Reports instrumentation and telemetry gaps without changing repositories.
-    knowledge_use: Reads project stack and observability conventions from the knowledge base.
-  - name: operations
-    display_name: operations
-    role: operations
-    description: Audits managed-project health checks, SLOs, runbooks, alerts, and rollback practice; reports findings only.
-    emoji: "🚨"
-    color: "#d35400"
-    sort_order: 66
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ADVISORY
-    kick_template: operations-advisory.md
-    include_repos: true
-    stale_timeout: 28800
-    lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
-    interactions: Reports operational-practice gaps without changing repositories.
-    knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-3.yaml
+++ b/src/pkg/config/packs/level-3.yaml
@@ -23,32 +23,24 @@ governor:
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
-      telemetry: paused
-      operations: paused
       guide: 4h
     busy:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
-      telemetry: paused
-      operations: paused
       guide: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
-      telemetry: paused
-      operations: paused
       guide: 4h
     idle:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
-      telemetry: paused
-      operations: paused
       guide: 4h
 agents:
 - name: supervisor
@@ -206,37 +198,3 @@ agents:
 
     '
   clear_on_kick: true
-- name: telemetry
-  display_name: telemetry
-  role: telemetry
-  description: Audits managed-project instrumentation and observability backends; reports findings only.
-  emoji: 📡
-  color: '#00a8cc'
-  sort_order: 65
-  backend: copilot
-  model: claude-sonnet-4-6
-  bead_role: worker
-  mode: ADVISORY
-  kick_template: telemetry-advisory.md
-  include_repos: true
-  stale_timeout: 28800
-  lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
-  interactions: Reports instrumentation and telemetry gaps without changing repositories.
-  knowledge_use: Reads project stack and observability conventions from the knowledge base.
-- name: operations
-  display_name: operations
-  role: operations
-  description: Audits managed-project health checks, SLOs, runbooks, alerts, and rollback practice; reports findings only.
-  emoji: 🚨
-  color: '#d35400'
-  sort_order: 66
-  backend: copilot
-  model: claude-sonnet-4-6
-  bead_role: worker
-  mode: ADVISORY
-  kick_template: operations-advisory.md
-  include_repos: true
-  stale_timeout: 28800
-  lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
-  interactions: Reports operational-practice gaps without changing repositories.
-  knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/config/packs/level-4.yaml
+++ b/src/pkg/config/packs/level-4.yaml
@@ -3,7 +3,7 @@ name: Security-Aware
 description: 'Closed-loop feedback (formerly ''Adaptive''). Existing delivery agents open GitHub issues — not just quality.
   Scanner files bug reports, guide files documentation gaps, ci-maintainer files workflow
   issues, sec-check files vulnerabilities. No PRs yet — issues only. Adds security
-  agent (+sec-check). Nine agents total, including opt-in telemetry and operations.
+  agent (+sec-check). Seven agents total.
 
   '
 governor:
@@ -29,8 +29,6 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
-      telemetry: paused
-      operations: paused
     busy:
       supervisor: 5m
       scanner: 4h
@@ -38,8 +36,6 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
-      telemetry: paused
-      operations: paused
     quiet:
       supervisor: 5m
       scanner: 4h
@@ -47,8 +43,6 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
-      telemetry: paused
-      operations: paused
     idle:
       supervisor: 5m
       scanner: 4h
@@ -56,8 +50,6 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
-      telemetry: paused
-      operations: paused
 agents:
 - name: supervisor
   display_name: Supervisor
@@ -248,37 +240,3 @@ agents:
 
     '
   clear_on_kick: true
-- name: telemetry
-  display_name: telemetry
-  role: telemetry
-  description: Audits managed-project instrumentation and observability backends; reports findings only.
-  emoji: 📡
-  color: '#00a8cc'
-  sort_order: 65
-  backend: copilot
-  model: claude-sonnet-4-6
-  bead_role: worker
-  mode: ADVISORY
-  kick_template: telemetry-advisory.md
-  include_repos: true
-  stale_timeout: 28800
-  lane_keywords: [observability, opentelemetry, prometheus, grafana, tracing, metrics, structured-logging, servicemonitor, podmonitor]
-  interactions: Reports instrumentation and telemetry gaps without changing repositories.
-  knowledge_use: Reads project stack and observability conventions from the knowledge base.
-- name: operations
-  display_name: operations
-  role: operations
-  description: Audits managed-project health checks, SLOs, runbooks, alerts, and rollback practice; reports findings only.
-  emoji: 🚨
-  color: '#d35400'
-  sort_order: 66
-  backend: copilot
-  model: claude-sonnet-4-6
-  bead_role: worker
-  mode: ADVISORY
-  kick_template: operations-advisory.md
-  include_repos: true
-  stale_timeout: 28800
-  lane_keywords: [healthz, readyz, readiness, slo-, sli-, service-level-objective, service-level-indicator, error-budget, runbook, incident-response, rollback, alerting]
-  interactions: Reports operational-practice gaps without changing repositories.
-  knowledge_use: Reads reliability goals and operational conventions from the knowledge base.

--- a/src/pkg/dashboard/acmm_roster_reconcile_test.go
+++ b/src/pkg/dashboard/acmm_roster_reconcile_test.go
@@ -117,6 +117,30 @@ func TestApplyPackReconcilesOrphanAgent(t *testing.T) {
 	}
 }
 
+func TestApplyPackRestartsEligibleOperabilityAgentsAfterDowngrade(t *testing.T) {
+	srv := newFullServer(t)
+	if _, err := srv.ApplyPack(5); err != nil {
+		t.Fatalf("ApplyPack(5): %v", err)
+	}
+	if _, err := srv.deps.AgentMgr.GetStatus("telemetry"); err != nil {
+		t.Fatalf("telemetry should be instantiated at L5: %v", err)
+	}
+
+	if _, err := srv.ApplyPack(3); err != nil {
+		t.Fatalf("ApplyPack(3): %v", err)
+	}
+	if _, err := srv.deps.AgentMgr.GetStatus("telemetry"); err == nil {
+		t.Fatal("telemetry should be retired below L5")
+	}
+
+	if _, err := srv.ApplyPack(5); err != nil {
+		t.Fatalf("ApplyPack(5) after downgrade: %v", err)
+	}
+	if _, err := srv.deps.AgentMgr.GetStatus("telemetry"); err != nil {
+		t.Fatalf("stale telemetry config should be re-instantiated at L5: %v", err)
+	}
+}
+
 // TestSetLevelFailsWhenRosterReconcileFails locks in the fix for the decoupling
 // bug: PUT /api/packs/level must NOT report success when the roster could not
 // be reconciled to the requested level. Previously it wrote acmm_level, then

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -1300,13 +1300,74 @@ func (s *Server) handleLifecycleTimeline(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	dto := s.LifecycleTimeline().Snapshot(limit, window)
+	store := s.LifecycleTimeline()
+	dto := store.Snapshot(limit, window)
+	if level := s.lifecycleACMMLevel(); level > 0 {
+		dto.Events = filterTimelineEventsByACMMLevel(dto.Events, level)
+		dto.Fleet = fleetHealthForTimelineEvents(store.Recent(0), window, level)
+	}
 	// Defensive nil-guard: Snapshot already guarantees a non-nil slice, but
 	// keep the endpoint's array-always contract explicit.
 	if dto.Events == nil {
 		dto.Events = []timeline.Event{}
 	}
 	jsonResponse(w, dto)
+}
+
+func (s *Server) lifecycleACMMLevel() int {
+	if s == nil || s.deps == nil || s.deps.Config == nil {
+		return 0
+	}
+	return detectACMMLevel(s.deps.Config)
+}
+
+func filterTimelineEventsByACMMLevel(events []timeline.Event, level int) []timeline.Event {
+	filtered := make([]timeline.Event, 0, len(events))
+	for _, event := range events {
+		if agent.AgentAvailableAtACMMLevel(event.Agent, level) {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+func fleetHealthForTimelineEvents(events []timeline.Event, window time.Duration, level int) timeline.FleetHealth {
+	if window <= 0 {
+		window = timeline.DefaultFleetWindow
+	}
+	fh := timeline.FleetHealth{WindowMs: window.Milliseconds()}
+	cutoff := time.Now().Add(-window).UnixMilli()
+	merged := map[string]bool{}
+	blocked := map[string]bool{}
+	active := map[string]bool{}
+	for _, event := range events {
+		if event.At < cutoff || !agent.AgentAvailableAtACMMLevel(event.Agent, level) {
+			continue
+		}
+		fh.Events++
+		if event.IssueRef == "" {
+			continue
+		}
+		switch event.Kind {
+		case timeline.KindMerged:
+			merged[event.IssueRef] = true
+		case timeline.KindBlocked:
+			blocked[event.IssueRef] = true
+		default:
+			active[event.IssueRef] = true
+		}
+	}
+	for ref := range merged {
+		fh.Merged++
+		delete(active, ref)
+		delete(blocked, ref)
+	}
+	for ref := range blocked {
+		fh.Blocked++
+		delete(active, ref)
+	}
+	fh.InFlight = len(active)
+	return fh
 }
 
 func (s *Server) handleWidget(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/dashboard/api_lifecycle_timeline_test.go
+++ b/src/pkg/dashboard/api_lifecycle_timeline_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/timeline"
 )
 
@@ -77,6 +78,32 @@ func TestHandleLifecycleTimelineWithEvents(t *testing.T) {
 	}
 	if dto.Fleet.InFlight != 1 {
 		t.Fatalf("Fleet.InFlight = %d, want 1 (issue #2)", dto.Fleet.InFlight)
+	}
+}
+
+func TestHandleLifecycleTimelineFiltersOperabilityAgentsBelowL5(t *testing.T) {
+	resetLifecycleStore()
+	s := newTestServer()
+	level := 3
+	s.deps = &Dependencies{Config: &config.Config{ACMMLevel: &level}}
+	store := s.LifecycleTimeline()
+	store.Record(timeline.Event{IssueRef: "org/repo#1", Kind: timeline.KindKicked, Agent: "telemetry"})
+	store.Record(timeline.Event{IssueRef: "org/repo#2", Kind: timeline.KindKicked, Agent: "operations"})
+	store.Record(timeline.Event{IssueRef: "org/repo#3", Kind: timeline.KindKicked, Agent: "scanner"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/lifecycle-timeline", nil)
+	rr := httptest.NewRecorder()
+	s.handleLifecycleTimeline(rr, req)
+
+	var dto timeline.TimelineDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(dto.Events) != 1 || dto.Events[0].Agent != "scanner" {
+		t.Fatalf("events = %+v, want only scanner event", dto.Events)
+	}
+	if dto.Fleet.Events != 1 || dto.Fleet.InFlight != 1 {
+		t.Fatalf("fleet = %+v, want one in-flight scanner event", dto.Fleet)
 	}
 }
 

--- a/src/pkg/dashboard/api_packs.go
+++ b/src/pkg/dashboard/api_packs.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/hooks"
 )
@@ -116,6 +117,8 @@ func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, err
 	if agentsDir == "" {
 		return nil, fmt.Errorf("agents_dir not configured")
 	}
+	s.deps.AgentMgr.SetACMMLevel(level)
+	removedByGate := s.removeAgentsUnavailableAtLevel(level, agentsDir)
 
 	var created []string
 	var skipped []string
@@ -218,6 +221,15 @@ func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, err
 			} else {
 				skipped = append(skipped, pa.Name)
 			}
+			if _, err := s.deps.AgentMgr.GetStatus(pa.Name); err != nil {
+				s.deps.AgentMgr.AddAgent(pa.Name, existing)
+				if !pa.OnDemand && existing.Enabled {
+					if err := s.deps.AgentMgr.Start(s.deps.Ctx, pa.Name); err != nil {
+						s.logger.Warn("failed to start reconciled agent", "agent", pa.Name, "error", err)
+					}
+				}
+				created = append(created, pa.Name)
+			}
 			continue
 		}
 
@@ -283,7 +295,7 @@ func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, err
 	// path, switching between levels whose packs differ only in cadences (no new
 	// agent) kept the previous level's cadences — including a stale SURGE=pause —
 	// so the hive stopped kicking agents after a level switch.
-	isFirstApplyOrExpansion := len(created) > 0 || forceGovernor
+	isFirstApplyOrExpansion := len(created) > 0 || len(removedByGate) > 0 || forceGovernor
 	governorChanges := &GovernorChanges{}
 
 	if pack.Governor.EvalIntervalS > 0 && isFirstApplyOrExpansion {
@@ -357,7 +369,7 @@ func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, err
 		}
 	}
 
-	if len(created) > 0 {
+	if len(created) > 0 || len(removedByGate) > 0 {
 		s.reInitSubsystems()
 	}
 
@@ -382,7 +394,7 @@ func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, err
 	// field report, so also list WHICH agents were tombstoned (deleted by the operator
 	// and NOT re-created) vs skipped (already present) — a grep by agent name against
 	// this single line answers "did the pack try to re-add the agent I removed?".
-	s.logger.Info("ACMM pack applied", "hive_id", s.deps.Config.HiveID, "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned), "tombstoned_agents", tombstoned, "skipped_agents", skipped)
+	s.logger.Info("ACMM pack applied", "hive_id", s.deps.Config.HiveID, "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned), "gate_removed", len(removedByGate), "tombstoned_agents", tombstoned, "skipped_agents", skipped)
 	if len(tombstoned) > 0 {
 		// Say it plainly in the log too: an operator reading "this level has 6
 		// agents but I see 4" needs the reason, not a silent gap.
@@ -410,6 +422,33 @@ func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, err
 		return result, fmt.Errorf("failed to persist %d pack agent(s): %s", len(createErrs), strings.Join(createErrs, "; "))
 	}
 	return result, nil
+}
+
+func (s *Server) removeAgentsUnavailableAtLevel(level int, agentsDir string) []string {
+	var removed []string
+	for name := range s.deps.Config.Agents {
+		if agent.AgentAvailableAtACMMLevel(name, level) {
+			continue
+		}
+		delete(s.deps.Config.Agents, name)
+		if agentsDir != "" {
+			if err := config.RemoveAgentFile(agentsDir, name); err != nil {
+				s.logger.Warn("failed to remove below-level agent overlay", "agent", name, "level", level, "error", err)
+			}
+		}
+		if s.deps.AgentMgr != nil {
+			s.deps.AgentMgr.RemoveAgent(name)
+		}
+		for modeName, mode := range s.deps.Config.Governor.Modes {
+			if mode.Cadences != nil {
+				delete(mode.Cadences, name)
+				s.deps.Config.Governor.Modes[modeName] = mode
+			}
+		}
+		removed = append(removed, name)
+	}
+	sort.Strings(removed)
+	return removed
 }
 
 func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -295,6 +295,9 @@ func buildConfiguredAgents(cfg *config.Config) []FrontendConfiguredAgent {
 
 	agents := make([]FrontendConfiguredAgent, 0, len(names))
 	for _, name := range names {
+		if !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+			continue
+		}
 		agentCfg := cfg.Agents[name]
 		// Same resolution buildAgents uses: explicit per-agent Mode wins,
 		// otherwise the ACMM level default for this agent.
@@ -1426,8 +1429,18 @@ func buildBudget(gov *governor.Governor, tokenCollector *tokens.Collector) Front
 }
 
 func buildCadenceMatrix(cfg *config.Config, agentStatuses map[string]*agent.AgentProcess) []FrontendCadence {
+	if cfg == nil {
+		return nil
+	}
+	acmmLevel := 0
+	if cfg.ACMMLevel != nil {
+		acmmLevel = *cfg.ACMMLevel
+	}
 	sortedNames := make([]string, 0, len(cfg.Agents))
 	for name := range cfg.Agents {
+		if !agent.AgentAvailableAtACMMLevel(name, acmmLevel) {
+			continue
+		}
 		sortedNames = append(sortedNames, name)
 	}
 	sort.Strings(sortedNames)

--- a/src/pkg/dashboard/status_builder_test.go
+++ b/src/pkg/dashboard/status_builder_test.go
@@ -45,6 +45,79 @@ func TestParseCadenceDuration(t *testing.T) {
 	}
 }
 
+func TestOperabilityAgentsHiddenFromDashboardBelowL5(t *testing.T) {
+	level := 3
+	cfg := &config.Config{
+		ACMMLevel: &level,
+		Agents: map[string]config.AgentConfig{
+			"scanner":    {Backend: "copilot", Enabled: true},
+			"telemetry":  {Backend: "copilot", Enabled: true},
+			"operations": {Backend: "copilot", Enabled: true},
+		},
+		Governor: config.GovernorConfig{Modes: map[string]config.ModeConfig{
+			"idle": {
+				Cadences: map[string]config.Cadence{
+					"scanner":    "4h",
+					"telemetry":  "4h",
+					"operations": "4h",
+				},
+			},
+		}},
+	}
+	statuses := map[string]*agent.AgentProcess{
+		"scanner":    {Name: "scanner", Config: cfg.Agents["scanner"]},
+		"telemetry":  {Name: "telemetry", Config: cfg.Agents["telemetry"]},
+		"operations": {Name: "operations", Config: cfg.Agents["operations"]},
+	}
+
+	if got := agentNamesFromConfigured(buildConfiguredAgents(cfg)); containsAny(got, "telemetry", "operations") {
+		t.Fatalf("configured agents below L5 = %v, want no telemetry/operations", got)
+	}
+	if got := agentNamesFromFrontend(buildAgents(statuses, cfg, governor.State{Mode: governor.ModeIdle})); containsAny(got, "telemetry", "operations") {
+		t.Fatalf("frontend agents below L5 = %v, want no telemetry/operations", got)
+	}
+	if got := agentNamesFromCadence(buildCadenceMatrix(cfg, statuses)); containsAny(got, "telemetry", "operations") {
+		t.Fatalf("cadence matrix below L5 = %v, want no telemetry/operations", got)
+	}
+}
+
+func agentNamesFromConfigured(in []FrontendConfiguredAgent) []string {
+	out := make([]string, 0, len(in))
+	for _, a := range in {
+		out = append(out, a.Name)
+	}
+	return out
+}
+
+func agentNamesFromFrontend(in []FrontendAgent) []string {
+	out := make([]string, 0, len(in))
+	for _, a := range in {
+		out = append(out, a.Name)
+	}
+	return out
+}
+
+func agentNamesFromCadence(in []FrontendCadence) []string {
+	out := make([]string, 0, len(in))
+	for _, a := range in {
+		out = append(out, a.Agent)
+	}
+	return out
+}
+
+func containsAny(names []string, needles ...string) bool {
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		seen[name] = true
+	}
+	for _, needle := range needles {
+		if seen[needle] {
+			return true
+		}
+	}
+	return false
+}
+
 func TestComputeNextKick(t *testing.T) {
 	// off cadence
 	result := computeNextKick(nil, "off")

--- a/src/pkg/hub/agent_capability.go
+++ b/src/pkg/hub/agent_capability.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/config"
 )
 
@@ -544,6 +545,9 @@ func computeAgentRosterMismatch(level int, agents []AgentSummary) *agentRosterMi
 	for _, a := range agents {
 		name := strings.TrimSpace(a.Name)
 		if name == "" {
+			continue
+		}
+		if !agent.AgentAvailableAtACMMLevel(name, level) {
 			continue
 		}
 		actual[name] = struct{}{}


### PR DESCRIPTION
## Summary
- remove telemetry/operations from ACMM L2-L4 packs and docs
- hard-gate telemetry/operations manager processes, dashboard rosters, cadence matrix, lifecycle timeline, hub roster mismatch, and default classifier lanes below L5
- clean stale below-level agent config while preserving L5/L6 paused-by-default behavior

Fixes #4849

## Validation
- go test ./pkg/hub -run 'TestComputeAgentRosterMismatch' -count=1\n- go test ./pkg/agent ./pkg/config ./pkg/dashboard ./pkg/classify -run 'Test(Operability|ACMMPacks|ApplyPack|SetLevel|OperabilityAgentsHidden|Classify|HandleLifecycleTimeline)' -count=1\n- mutation check: killed mutant changing L5 gate to L4\n- mutation check: killed mutant allowing telemetry/operations below L5