### PR TITLE
🐛 fix: contain prompt template scroll panes

### DIFF
--- a/src/pkg/dashboard/agent_config_single_save_test.go
+++ b/src/pkg/dashboard/agent_config_single_save_test.go
@@ -117,6 +117,12 @@ func TestModalScrollContainment(t *testing.T) {
 		// The CSS rule covering the template editor + preview.
 		"#prompt-template-editor,",
 		"#prompt-template-preview {",
+		// Attribute selectors harden sibling tab/modal inline scrollers.
+		`.config-body [style*="overflow-y:auto"],`,
+		`.config-body [style*="overflow-y: auto"],`,
+		// The Prompt Template tab body itself is a flex column that can host
+		// nested scrollers without passing wheel/touch chains to the page.
+		"height:100%;min-height:0;overscroll-behavior:contain;overscroll-behavior-y:contain",
 		// Inline containment on the editor, preview, and variable picker, so
 		// the containment holds even if the element is restyled inline.
 		"resize:vertical;white-space:pre;tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain",

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -1704,6 +1704,8 @@
     .config-overlay textarea,
     .config-overlay pre,
     .config-modal .config-pre,
+    .config-body [style*="overflow-y:auto"],
+    .config-body [style*="overflow-y: auto"],
     #prompt-template-editor,
     #prompt-template-preview {
       overscroll-behavior: contain;
@@ -18561,7 +18563,7 @@ function burnAreaChart() {
       const gen = (_configState.data && _configState.data.general) || {};
       const ps = gen.promptSource || {};
       return `
-        <div style="display:flex;flex-direction:column;height:100%">
+        <div style="display:flex;flex-direction:column;height:100%;min-height:0;overscroll-behavior:contain;overscroll-behavior-y:contain">
         <div id="${srcId}" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:10px 14px;margin-bottom:10px;flex-shrink:0">
           <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Source files <span style="font-weight:400;color:var(--muted)">(edit these on your fork)</span></div>
         </div>
@@ -18885,7 +18887,7 @@ function burnAreaChart() {
       const opts = PROMPT_HISTORY_WINDOWS.map(function(w) {
         return '<option value="' + w.hours + '"' + (w.hours === selected ? ' selected' : '') + '>' + esc(w.label) + '</option>';
       }).join('');
-      return `<div style="display:flex;flex-direction:column;height:100%">
+      return `<div style="display:flex;flex-direction:column;height:100%;min-height:0;overscroll-behavior:contain;overscroll-behavior-y:contain">
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Prompts sent to this agent — fully expanded, all variables resolved and pipeline data injected. Newest first.</p>
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-shrink:0">
           <label for="prompt-history-window" style="font-size:0.75rem;color:var(--muted)">Window</label>


### PR DESCRIPTION
## Summary
- contain overscroll on the Prompt Template tab flex root
- apply the same containment to Prompt History and config-body inline scroll panes
- extend regression coverage for modal scroll containment

Fixes #4850

## Validation
- go test ./pkg/dashboard -run 'TestModalScrollContainment|TestPromptHistoryScrollContainment|TestAgentConfigSingleSave|TestOverlay' -count=1\n- node .github/scripts/check-inline-js.js src/pkg/dashboard/static/index.html