### PR TITLE
🐛 fix: carry duplicate dashboard deltas forward

### DIFF
--- a/src/pkg/dashboard/agent_config_single_save_test.go
+++ b/src/pkg/dashboard/agent_config_single_save_test.go
@@ -122,12 +122,14 @@ func TestModalScrollContainment(t *testing.T) {
 		`.config-body [style*="overflow-y: auto"],`,
 		// The Prompt Template tab body itself is a flex column that can host
 		// nested scrollers without passing wheel/touch chains to the page.
-		"height:100%;min-height:0;overscroll-behavior:contain;overscroll-behavior-y:contain",
+		`id="prompt-template-tab" style="display:flex;flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain`,
 		// Inline containment on the editor, preview, and variable picker, so
 		// the containment holds even if the element is restyled inline.
 		"resize:vertical;white-space:pre;tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain",
 		"display:none;flex:1;min-height:300px;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain",
 		"max-height:120px;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain",
+		`id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px;overscroll-behavior:contain;overscroll-behavior-y:contain`,
+		`tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain">Loading...</textarea>`,
 	} {
 		if !strings.Contains(html, snippet) {
 			t.Errorf("index.html is missing %q — modal scroll containment regressed (#2766)", snippet)
@@ -144,6 +146,19 @@ func TestModalScrollContainment(t *testing.T) {
 	}
 	if !strings.Contains(html[idx:idx+end], "overscroll-behavior: contain;") {
 		t.Error(".config-body rule is missing overscroll-behavior: contain — modal body scroll chains to the page")
+	}
+	for _, rule := range []string{".config-pre {", ".config-stats-list {"} {
+		idx := strings.Index(html, rule)
+		if idx < 0 {
+			t.Fatalf("index.html has no %s rule", rule)
+		}
+		end := strings.Index(html[idx:], "}")
+		if end < 0 {
+			t.Fatalf("%s rule is unterminated", rule)
+		}
+		if !strings.Contains(html[idx:idx+end], "overscroll-behavior: contain;") {
+			t.Errorf("%s rule is missing own-rule overscroll containment", rule)
+		}
 	}
 }
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -1791,7 +1791,11 @@
     /* compact stat-row inputs — size step re-declared after the input recipe */
     /* .btn-sm / .btn-danger / .btn-add — ghost/danger/secondary buttons (system recipe) */
     .btn-sm:disabled { opacity: 0.3; cursor: default; }
-    .config-stats-list { max-height: 400px; overflow-y: auto; padding-right: 12px; }
+    .config-stats-list {
+      max-height: 400px; overflow-y: auto; padding-right: 12px;
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
+    }
 
     .config-info {
       display: inline-flex; align-items: center; justify-content: center;
@@ -1846,6 +1850,8 @@
       border-radius: 6px; padding: 12px; font-size: 0.75rem;
       overflow-x: auto; white-space: pre-wrap; color: var(--muted);
       max-height: 300px; overflow-y: auto;
+      overscroll-behavior: contain;
+      overscroll-behavior-y: contain;
     }
     .config-pre-fill {
       max-height: calc(85vh - 220px); min-height: 200px;
@@ -15913,7 +15919,7 @@ function burnAreaChart() {
         '</div>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Or paste agent definition</label>' +
-          '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
+          '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px;overscroll-behavior:contain;overscroll-behavior-y:contain" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
           '<div style="text-align:right;margin-top:6px"><button data-action="previewImportFromPaste" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Preview</button></div>' +
         '</div>' +
         '<div id="import-preview" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px;margin-top:16px">' +
@@ -18563,7 +18569,7 @@ function burnAreaChart() {
       const gen = (_configState.data && _configState.data.general) || {};
       const ps = gen.promptSource || {};
       return `
-        <div style="display:flex;flex-direction:column;height:100%;min-height:0;overscroll-behavior:contain;overscroll-behavior-y:contain">
+        <div id="prompt-template-tab" style="display:flex;flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">
         <div id="${srcId}" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:10px 14px;margin-bottom:10px;flex-shrink:0">
           <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Source files <span style="font-weight:400;color:var(--muted)">(edit these on your fork)</span></div>
         </div>
@@ -18751,13 +18757,13 @@ function burnAreaChart() {
           })
           .catch(function() {});
       }
-      return '<div style="display:flex;flex-direction:column;height:100%">'
+      return '<div style="display:flex;flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">'
         + '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Portable agent definition in YAML format. Use this to share agents across hive instances.</p>'
         + '<div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">'
         + '<button data-action="copyExportYaml" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Copy to Clipboard</button>'
         + '<button data-action="downloadExportYaml" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
         + '</div>'
-        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--terminal-bg);color:var(--terminal-fg);border:1px solid var(--terminal-line);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
+        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--terminal-bg);color:var(--terminal-fg);border:1px solid var(--terminal-line);border-radius:6px;resize:vertical;white-space:pre;tab-size:2;overscroll-behavior:contain;overscroll-behavior-y:contain">Loading...</textarea>'
         + '</div>';
     }
 
@@ -18887,7 +18893,7 @@ function burnAreaChart() {
       const opts = PROMPT_HISTORY_WINDOWS.map(function(w) {
         return '<option value="' + w.hours + '"' + (w.hours === selected ? ' selected' : '') + '>' + esc(w.label) + '</option>';
       }).join('');
-      return `<div style="display:flex;flex-direction:column;height:100%;min-height:0;overscroll-behavior:contain;overscroll-behavior-y:contain">
+      return `<div style="display:flex;flex-direction:column;height:100%;min-height:0;overflow-y:auto;overscroll-behavior:contain;overscroll-behavior-y:contain">
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Prompts sent to this agent — fully expanded, all variables resolved and pipeline data injected. Newest first.</p>
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-shrink:0">
           <label for="prompt-history-window" style="font-size:0.75rem;color:var(--muted)">Window</label>

--- a/src/pkg/hub/agent_capability_test.go
+++ b/src/pkg/hub/agent_capability_test.go
@@ -450,8 +450,6 @@ func TestComputeAgentRosterMismatch_WarningReason(t *testing.T) {
 		{Name: "quality"},
 		{Name: "guide"},
 		{Name: "supervisor"},
-		{Name: "telemetry"},
-		{Name: "operations"},
 		{Name: "outreach"},
 	}
 	got := computeAgentRosterMismatch(2, agents)
@@ -473,11 +471,9 @@ func TestComputeAgentRosterMismatch_NoWarningForMatchingOrUnknown(t *testing.T) 
 	matching := []AgentSummary{
 		{Name: "brainstorm"},
 		{Name: "guide"},
-		{Name: "operations"},
 		{Name: "quality"},
 		{Name: "scanner"},
 		{Name: "supervisor"},
-		{Name: "telemetry"},
 	}
 	if got := computeAgentRosterMismatch(2, matching); got != nil {
 		t.Fatalf("matching roster got warning %+v", got)

--- a/src/pkg/hub/journey.go
+++ b/src/pkg/hub/journey.go
@@ -225,9 +225,9 @@ type acmmLevelInfo struct {
 // moving there entails. Kept in sync with src/pkg/config/packs/level-*.yaml.
 var acmmLevels = map[int]acmmLevelInfo{
 	1: {"Inception", "an interactive brainstorm agent turns ideas into structured facts and scaffolding, with every action human-approved"},
-	2: {"Advisory", "seven agents publish advisory findings, including opt-in telemetry and operations agents that start paused — still no GitHub writes"},
+	2: {"Advisory", "five agents publish advisory findings — still no GitHub writes"},
 	3: {"Quality-Gated", "the quality agent starts opening issues and hold-gated PRs about testing gaps, and ci-maintainer joins to watch build health — nothing merges without you"},
-	4: {"Security-Aware", "delivery agents file GitHub issues in their lanes and sec-check joins for vulnerabilities, while telemetry and operations remain advisory and paused"},
+	4: {"Security-Aware", "delivery agents file GitHub issues in their lanes and sec-check joins for vulnerabilities"},
 	5: {"Semi-Autonomous", "agents open hold-gated pull requests as well as issues; architect and strategist join, while telemetry and operations are available paused for deliberate opt-in"},
 	6: {"Fully Autonomous", "agents can auto-merge on green CI at the highest trust setting; outreach joins, while telemetry and operations remain paused until deliberately enabled"},
 }

--- a/src/pkg/hub/journey_test.go
+++ b/src/pkg/hub/journey_test.go
@@ -395,6 +395,18 @@ func TestACMMSuggestionIsLevelSpecific(t *testing.T) {
 	}
 }
 
+func TestACMMLevelCopyDoesNotAdvertiseOperabilityBelowL5(t *testing.T) {
+	for _, level := range []int{1, 2, 3, 4} {
+		info := acmmLevels[level]
+		lower := strings.ToLower(info.Summary)
+		for _, banned := range []string{"telemetry", "operations"} {
+			if strings.Contains(lower, banned) {
+				t.Errorf("L%d copy advertises %s below L5: %q", level, banned, info.Summary)
+			}
+		}
+	}
+}
+
 // TestMaxACMMLevelGetsNoNudge — a hive at the top has nowhere to graduate to.
 func TestMaxACMMLevelGetsNoNudge(t *testing.T) {
 	h := hive(stage3SuggestAfter*10, func(h *RegistryEntry) { h.ACMMLevel = maxACMMLevel })


### PR DESCRIPTION
## Summary
- add missed contained scrollers from duplicate PR #4851: Prompt Template root overflow, export/import panes, and config-pre/config-stats own-rule containment
- update hub ACMM journey copy/tests from duplicate PR #4852 so L1-L4 do not advertise telemetry/operations
- do not merge #4851/#4852; this extracts only the remaining deltas after #4855/#4856

Fixes #4849
Fixes #4850

## Validation
- cd src && go test ./pkg/dashboard ./pkg/hub -run 'TestModalScrollContainment|TestOverlayScrollContainmentAudit|TestPromptHistoryScrollContainment|TestComputeAgentRosterMismatch|TestACMMLevelCopyDoesNotAdvertiseOperabilityBelowL5|TestACMMSuggestionIsLevelSpecific' -count=1
- node .github/scripts/check-inline-js.js src/pkg/dashboard/static/index.html
- git diff --check
- npm build/lint: no package.json in repository