### PR TITLE
📖 docs: index the agent watchdog; record proposed Credly vars as not implemented

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -19,6 +19,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Cross-cluster migration](https://github.com/kubestellar/hive/blob/v4/src/docs/cross-cluster-migration.md) — the manual procedure for moving a hive between clusters.
 - [v2 → v4 migration](migration-v2-v4.md) — upgrading a v2 deployment: the config is compatible unmodified, and what actually changes is the image tag, the published `7681` port, and the Compose/Kubernetes security settings.
 - [Dashboard route and health checks](https://github.com/kubestellar/hive/blob/v4/src/docs/health-checks.md) — `dashboard-route-rbac.yaml`, `route_exists`, listener probes, and alert behavior.
+- [Agent self-healing watchdog](agent-watchdog.md) — liveness and readiness reconciliation for launched agents: liveness classification, restart backoff, crash-loop escalation, the auth probe that refuses to restart into dead credentials, and the `conditions` array on `/api/agents`. Ships in `mode: observe`, which audits the restarts it would have made without making them.
 - [Network and port requirements](https://github.com/kubestellar/hive/blob/v4/src/docs/network-requirements.md) — inbound ports, proxy paths, egress, and firewall guidance.
 - [TLS, HTTPS, and certificates](https://github.com/kubestellar/hive/blob/v4/src/docs/tls-setup.md) — termination patterns and certificate ownership.
 - [Security notes](https://github.com/kubestellar/hive/blob/v4/src/docs/security.md) — log scrubbing and secret redaction guarantees/limits.

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -242,6 +242,24 @@ With two or more providers configured, `/login` renders a provider picker; with 
 | `SLACK_WEBHOOK` | No | none | Slack incoming webhook for top-level script notifications. |
 | `DISCORD_WEBHOOK` | No | none | Discord webhook for top-level script notifications. |
 
+## Credly badge integration (proposed — not implemented)
+
+> **No code reads these variables.** The Credly integration is a design
+> ([Credly badges](credly-badges.md)); Hive ships only the contributor-card
+> placeholder and the milestone mapping. There are no live Credly API calls,
+> credentials, or badge issuance. Setting these today has **no effect**.
+
+They are listed here so the central reference does not appear to contradict
+`credly-badges.md`, and so the names are reserved. Treat the table as a design
+record until the feature ships — at which point these rows move into the
+sections above and gain real defaults.
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_CREDLY_ORG_ID` | n/a — proposed | none | Credly issuing organization id. |
+| `HIVE_CREDLY_API_TOKEN` | n/a — proposed | none | Credly Issuer API token. A live issuing credential when the feature ships: supply it by environment or secret reference only, never in `hive.yaml` and never committed. Until then, unset leaves the card in placeholder mode. |
+| `HIVE_CREDLY_TEMPLATES` | n/a — proposed | none | JSON map of milestone id → Credly badge template id. |
+
 ## Keeping this reference current
 
 The code is authoritative and this table is hand-maintained, so it drifts unless
@@ -267,6 +285,13 @@ What each column means:
 
 Add the row to the section matching the component that reads the variable, and
 run the searches below to confirm nothing else was missed.
+
+One exception to "the code is authoritative": a **proposed** variable that no
+code reads yet may be listed, but only in a section explicitly marked as such
+(see [Credly badge integration](#credly-badge-integration-proposed--not-implemented)).
+The marking is the whole point — an operator must never set a variable from this
+file and have it silently do nothing. When the feature ships, move those rows
+into the section for the component that reads them.
 
 ## Verification commands
 


### PR DESCRIPTION
Two guide-agent docs findings, verified against `v4`.

## #4858 — watchdog doc not reachable by navigation

`src/docs/agent-watchdog.md` exists but was absent from `src/docs/README.md`. An operator troubleshooting a crash-looping or stuck agent had no path to it.

Added to **Operations**, beside `health-checks.md` where the runtime-health topics cluster. The entry notes the watchdog ships in `mode: observe` — it audits the restarts it *would* have made without making them. That is the first thing an operator needs to know, otherwise the absence of restarts reads as the watchdog being broken.

## #4859 — Credly vars: recommendation corrected

The issue asks for `HIVE_CREDLY_ORG_ID`, `HIVE_CREDLY_API_TOKEN`, and `HIVE_CREDLY_TEMPLATES` in the central reference. **They have no implementation.**

A repo-wide grep finds no `HIVE_CREDLY_*` lookup anywhere outside `credly-badges.md`. That document's own first line is *"integration design (planned, not yet built)"*, and it states no live Credly API calls, credentials, or badge issuance exist.

`env-vars.md` opens with **"The code is authoritative"**. Adding three unread variables as ordinary table rows would tell an operator to set an API token that nothing consumes — worse than the omission the issue reports, particularly for a credential.

Added instead as a section marked **"proposed — not implemented"**, leading with *"No code reads these variables"* and stating plainly that setting them today has no effect. This reserves the names and removes the apparent contradiction with `credly-badges.md` without implying the feature is live. The source calls them *"proposed"* rather than *"planned"*, so that wording carries over.

There is precedent for documenting variables the Go runtime does not read — the legacy helper-script section — and it works because it is explicitly labeled. Same principle here.

### Consistency fix

The `Keeping this reference current` section added in #4846 tells contributors this file tracks real `os.Getenv`/`os.LookupEnv` calls, which the new section would contradict. It now carries the single exception and requires the explicit marking, so a future contributor does not either delete the Credly section as spurious or add unmarked speculative rows next to it.

## Scope

Docs only. No Go, no manifests, no behavior change.

Fixes #4858
Fixes #4859