### PR TITLE
🐛 fix(dashboard): say a disabled agent is disabled, not down

### DIFF
--- a/src/pkg/dashboard/dashboard_handlers_extra_test.go
+++ b/src/pkg/dashboard/dashboard_handlers_extra_test.go
@@ -31,7 +31,14 @@ func newFullServer(t *testing.T) *Server {
 		},
 		Data: config.DataConfig{AgentsDir: t.TempDir()},
 		Agents: map[string]config.AgentConfig{
-			"scanner": {ID: "scan-001", Role: "scanner", Backend: "claude", Model: "sonnet", DisplayName: "Scanner"},
+			// Enabled must be set explicitly. This literal skips
+			// ApplyAgentDefaults, which is what gives a real config
+			// `enabled: true` unless the operator wrote `enabled: false`
+			// (config/agent_overlay.go). Leaving it at the zero value
+			// described a state production cannot produce — an agent in the
+			// runtime roster that is switched OFF — and the health checks now
+			// read that as a deliberate off-state rather than a down agent.
+			"scanner": {ID: "scan-001", Role: "scanner", Backend: "claude", Model: "sonnet", DisplayName: "Scanner", Enabled: true},
 		},
 		GitHub:     config.GitHubConfig{Token: "ghp_test123456789"},
 		SourcePath: t.TempDir() + "/hive.yaml",

--- a/src/pkg/dashboard/disabled_agent_no_session_test.go
+++ b/src/pkg/dashboard/disabled_agent_no_session_test.go
@@ -1,0 +1,167 @@
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/governor"
+)
+
+// A disabled agent still has a RUNTIME entry: ApplyPack adds every agent in the
+// ACMM level's pack to the manager and gates only the Start on enabled
+// (api_packs.go). Everything below covers what that costs when nothing carries
+// the enabled flag forward — a card that offers a terminal and a full log for an
+// agent that has never had a tmux session, and two health checks that score a
+// deliberately switched-off agent as a failure.
+//
+// Observed live on hive-wild-mole (ACMM L3): guide, brainstorm and ci-maintainer
+// sat at state=stopped, restarts=0, and /api/agents/guide/log answered
+// "capturing pane for guide: exit status 1" while the card still linked to both.
+
+func TestBuildAgentsCarriesEnabledFlag(t *testing.T) {
+	statuses := map[string]*agent.AgentProcess{
+		"scanner": {
+			Name:         "scanner",
+			Config:       config.AgentConfig{Backend: "claude", Enabled: true},
+			State:        agent.StateRunning,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+		"guide": {
+			Name:         "guide",
+			Config:       config.AgentConfig{Backend: "copilot", Enabled: false},
+			State:        agent.StateStopped,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+	}
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{
+		"scanner": {Backend: "claude", Enabled: true, SortOrder: 10},
+		"guide":   {Backend: "copilot", Enabled: false, SortOrder: 20},
+	}}
+
+	byName := map[string]FrontendAgent{}
+	for _, a := range buildAgents(statuses, cfg, governor.State{Mode: governor.ModeIdle}) {
+		byName[a.Name] = a
+	}
+
+	if !byName["scanner"].Enabled {
+		t.Error("scanner.Enabled = false, want true")
+	}
+	if byName["guide"].Enabled {
+		t.Error("guide.Enabled = true, want false — a disabled agent must be distinguishable from a crashed one")
+	}
+	// State alone cannot carry this: a stopped-because-disabled agent and a
+	// stopped-because-it-died agent are the same string here, which is why the
+	// flag has to travel separately.
+	if byName["guide"].State != string(agent.StateStopped) {
+		t.Fatalf("guide.State = %q, want stopped (precondition)", byName["guide"].State)
+	}
+}
+
+func TestBuildAgentsPrefersLiveConfigForEnabled(t *testing.T) {
+	// proc.Config is the manager's COPY, refreshed only on UpdateConfig or a
+	// reconcile. An operator who just disabled the agent from the config dialog
+	// has written cfg.Agents and nothing else, so the live config must win.
+	statuses := map[string]*agent.AgentProcess{
+		"guide": {
+			Name:         "guide",
+			Config:       config.AgentConfig{Backend: "copilot", Enabled: true},
+			State:        agent.StateStopped,
+			OutputBuffer: agent.NewRingBuffer(10),
+		},
+	}
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{
+		"guide": {Backend: "copilot", Enabled: false},
+	}}
+
+	agents := buildAgents(statuses, cfg, governor.State{Mode: governor.ModeIdle})
+	if len(agents) != 1 {
+		t.Fatalf("agents = %d, want 1", len(agents))
+	}
+	if agents[0].Enabled {
+		t.Error("Enabled = true, want false — the stale process copy outranked the live config")
+	}
+}
+
+func TestAgentDisabledInConfigFallsBackToProcessCopy(t *testing.T) {
+	proc := &agent.AgentProcess{Name: "guide", Config: config.AgentConfig{Enabled: false}}
+
+	// Absent from the live config (an agent that exists only in the roster):
+	// the process copy is all there is.
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{}}
+	if !agentDisabledInConfig(cfg, "guide", proc) {
+		t.Error("want disabled when the live config has no entry and the process copy says disabled")
+	}
+	// Present and enabled: the live config wins over the process copy.
+	cfg.Agents["guide"] = config.AgentConfig{Enabled: true}
+	if agentDisabledInConfig(cfg, "guide", proc) {
+		t.Error("want enabled — the live config entry must outrank the process copy")
+	}
+	// Nothing to read at all is not a claim that the agent is off.
+	if agentDisabledInConfig(nil, "guide", nil) {
+		t.Error("want false with no config and no process — absence is not evidence of disabled")
+	}
+}
+
+func TestHealthDeepSkipsDisabledAgentInsteadOfFailing(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Agents["guide"] = config.AgentConfig{Backend: "copilot", Enabled: false}
+	deps.AgentMgr.AddAgent("guide", deps.Config.Agents["guide"])
+
+	rec := doGet(s, "/api/health/deep")
+	if rec.Code != http.StatusOK && rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("health deep: unexpected %d", rec.Code)
+	}
+	checks, ok := decodeJSON(t, rec)["checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("no checks in body: %s", rec.Body.String())
+	}
+	agents, ok := checks["agents"].(map[string]any)
+	if !ok {
+		t.Fatalf("no agents check in body: %s", rec.Body.String())
+	}
+	guide, ok := agents["guide"].(map[string]any)
+	if !ok {
+		t.Fatalf("guide missing from agent checks: %#v", agents)
+	}
+	// "skip" is the verdict the paused branch already uses for a deliberate
+	// off-state. "fail" here is a health failure the operator can never clear
+	// without turning on an agent they chose to turn off.
+	if guide["status"] != "skip" {
+		t.Errorf("guide status = %#v, want skip", guide["status"])
+	}
+	if guide["disabled"] != true {
+		t.Errorf("guide disabled = %#v, want true", guide["disabled"])
+	}
+}
+
+func TestDisabledAgentSessionActionsAreInert(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		// The flag has to reach the browser before anything can act on it.
+		`function agentIsDisabled(a) {`,
+		// state is checked too: an agent disabled while still up keeps its
+		// session until the next reconcile, and its terminal still works.
+		`return agentIsDisabled(a) && a.state !== 'running';`,
+		// Both dead-end actions routed through the same gate, on both the
+		// agent card and the operations-center detail panel.
+		`${sessionChip(a, '▶ terminal',`,
+		`${sessionChip(a, '📄 full log',`,
+		`${sessionChip(a, '⬇ log',`,
+		// The card says WHY it is grey rather than leaving "stopped" to be
+		// read as a crash.
+		`<span class="status-badge disabled"`,
+		`.status-badge.disabled { --pill-c: var(--muted); }`,
+		`.terminal-link.inert {`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html missing wiring: %s", snippet)
+		}
+	}
+	// The inert chip must not be a link — that is the whole point.
+	if strings.Contains(html, `class="terminal-link inert" href`) {
+		t.Error("inert chip rendered as a link")
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -492,6 +492,21 @@ type FrontendAgent struct {
 	// verdict means the agent was NOT paused, and a reader must not conclude
 	// otherwise.
 	WatchdogMode string `json:"watchdogMode,omitempty"`
+	// Enabled mirrors the CONFIG flag, not a runtime state, and is the only
+	// thing that distinguishes "switched off on purpose" from "stopped because
+	// something broke" — State reads "stopped" for both.
+	//
+	// A disabled agent reaches this payload at all because ApplyPack adds every
+	// pack agent to the runtime roster and gates only the Start on Enabled
+	// (api_packs.go), which is deliberate: the card is how an operator turns
+	// the agent on. But without this field the card cannot say so, and it
+	// offers a terminal and a full log for an agent that has never had a tmux
+	// session — a dead end that reports "no tmux socket found for session
+	// hive-<name>".
+	//
+	// NOT omitempty: false is the meaningful value here, and omitempty would
+	// erase exactly the case this exists to report.
+	Enabled bool `json:"enabled"`
 }
 
 // FrontendConfiguredAgent is the secret-free config inventory used by the
@@ -2212,6 +2227,16 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 					ac["status"] = "warn"
 					ac["detail"] = "refused kick: " + proc.KickRefusalReason
 				}
+			} else if agentDisabledInConfig(s.deps.Config, name, proc) {
+				// Switched off in config, so nothing ever starts it and it has
+				// no session — the same DELIBERATE non-running state the paused
+				// branch above already scores as "skip". Scoring it "fail"
+				// meant every hive that turns an agent off reports a permanent
+				// health failure it can never clear, and (via healthSummaryFor)
+				// raises a standing hub alert for an agent nobody wants running.
+				ac["disabled"] = true
+				ac["status"] = "skip"
+				ac["detail"] = "disabled in config — not started"
 			} else {
 				ac["status"] = "fail"
 				failCount++
@@ -2924,6 +2949,7 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		const staleOutputThreshold = 30 * time.Minute
 		running := 0
 		paused := 0
+		disabled := 0
 		stalled := 0
 		unsubstituted := 0
 		down := 0
@@ -2972,6 +2998,15 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 					}
 				}
 			} else if !grace {
+				// Disabled in config is a deliberate off-state, not a fault:
+				// nothing starts the agent, so "down" would be a permanent
+				// false alarm on any hive that switched an agent off. Counted
+				// separately (like paused) so the detail line still says the
+				// agent is not running, without failing the check.
+				if agentDisabledInConfig(s.deps.Config, name, proc) {
+					disabled++
+					continue
+				}
 				// A non-running agent whose CLI has no credentials is not
 				// crashed — it is waiting for a human to click Login on the
 				// agent panel. Bucket it separately so the operator reads an
@@ -2995,6 +3030,9 @@ func (s *Server) healthSummaryFor(status *StatusPayload, ready bool) map[string]
 		detail := fmt.Sprintf("%d running", running)
 		if paused > 0 {
 			detail += fmt.Sprintf(", %d paused", paused)
+		}
+		if disabled > 0 {
+			detail += fmt.Sprintf(", %d disabled", disabled)
 		}
 		if down > 0 {
 			detail += fmt.Sprintf(", %d down: %s", down, strings.Join(downNames, ", "))

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -980,6 +980,7 @@
     .status-badge.needs-context { --pill-c: var(--yellow); }
     .status-badge.done-concerns { --pill-c: var(--orange); }
     .status-badge.done { --pill-c: var(--green); }
+    .status-badge.disabled { --pill-c: var(--muted); }
     .agent-card.status-blocked { border-left-color: var(--red) !important; }
     .agent-card.status-needs-context { border-left-color: var(--yellow) !important; }
     @keyframes pulse-amber {
@@ -2321,6 +2322,11 @@
     /* status-flavored one-offs on the shared base (semantic colors kept) */
     .terminal-link { border-color: var(--cyan); color: var(--cyan); text-decoration: none; display: inline-block; }
     .terminal-link:hover { background: var(--cyan); border-color: var(--cyan); color: var(--bg); }
+    /* Inert chip: an action that exists on the card but cannot work for this
+       agent (see sessionChip). Keeps the chip's shape so the row does not
+       reflow, drops the affordance so it does not read as clickable. */
+    .terminal-link.inert { border-color: var(--muted); color: var(--muted); opacity: 0.55; cursor: not-allowed; }
+    .terminal-link.inert:hover { background: none; border-color: var(--muted); color: var(--muted); }
     .restart-btn { border-color: var(--yellow); color: var(--yellow); display: inline-block; }
     .restart-btn:hover { background: var(--yellow); border-color: var(--yellow); color: var(--bg); }
     .layout-toggle.active { border-color: var(--amber); color: var(--amber); }
@@ -4310,7 +4316,10 @@
       const dotTitle = isOff ? OFF_HEALTHY_TITLE : '';
 
       detail.className = 'oc-agent-detail active state-' + dotCls;
-      const stateLabel = needsLoginDown ? 'needs login' : isStopped ? 'down' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
+      /* 'disabled' outranks 'down': both reach here with state!=='running',
+         but a switched-off agent is not a fault, and labelling it "down" sent
+         operators looking for a crash that never happened. */
+      const stateLabel = agentSessionUnavailable(a) ? 'disabled' : needsLoginDown ? 'needs login' : isStopped ? 'down' : isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : isRunning ? 'working' : 'idle';
 
       const kickId = `oc-kick-${a.name}`;
       const prevInput = document.getElementById(kickId);
@@ -4456,9 +4465,9 @@
             : !dashboardRoleAtLeast(window._hiveRole || 'read', 'owner')
             ? ''
             : `<button class="btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="${isPaused}" title="${isPaused ? 'Resume this agent — it will start running on its configured cadence' : isOff ? 'Start this agent — it is currently off in this governor mode' : 'Pause this agent — stops governor from kicking it until resumed'}">${isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause'}</button>`}
-          <a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>
-          <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>
-          <a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>
+          ${sessionChip(a, '▶ terminal', `<a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>`)}
+          ${sessionChip(a, '📄 full log', `<a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>`)}
+          ${sessionChip(a, '⬇ log', `<a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>`)}
           <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Browse archived logs of this agent's previous kicks — history survives restarts and hive upgrades">🕘 past kicks</a>
           <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill this agent's tmux session — supervisor will respawn it with fresh context">↻ restart</button>
           <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" style="font-size:1rem;opacity:0.7" title="Open configuration dialog for this agent (cadences, model, pipeline, hooks, etc.)">⚙️</button>
@@ -5996,6 +6005,34 @@
       }
       return false;
     }
+    /* A DISABLED agent (enabled:false) is never started, so it has no tmux
+       session and no pane to capture. Its ▶ terminal dead-ends on
+       "no tmux socket found for session hive-<name>" and its 📄 full log on
+       "capturing pane for <name>: exit status 1".
+
+       It has a card at all because ApplyPack adds every agent in the ACMM
+       level's pack to the runtime roster and gates only the Start on enabled
+       (pkg/dashboard/api_packs.go) — deliberate, since the card is how an
+       operator turns the agent on. So the card must SAY it is off rather than
+       offer session actions that cannot work.
+
+       state is checked first on purpose: an agent disabled while it is still
+       up keeps running until the next reconcile and genuinely does have a
+       session until then. */
+    function agentIsDisabled(a) {
+      return !!a && a.enabled === false;
+    }
+    function agentSessionUnavailable(a) {
+      return agentIsDisabled(a) && a.state !== 'running';
+    }
+    /* Returns linkHtml unchanged for any agent that can have a session, and an
+       inert chip carrying the reason for one that cannot. */
+    function sessionChip(a, label, linkHtml) {
+      if (!agentSessionUnavailable(a)) return linkHtml;
+      const who = esc(a.displayName || a.name);
+      return `<span class="terminal-link inert" title="${who} is disabled in config and has never started, so there is no session or log to open. Enable it with \u2699\uFE0F first.">${label}</span>`;
+    }
+
     async function openTerminal(agentName, href) {
       const url = href || terminalUrl(agentName);
       const tab = window.open('about:blank', '_blank');
@@ -6123,9 +6160,13 @@
         const compactCls = isAgentCompact(a.name) ? ' compact' : '';
         const replicaBadge = (a.replicaBase && a.replicaIndex > 1) ? ` <span class="status-badge" title="Replica ${a.replicaIndex} of ${a.replicaCount} for ${esc(a.replicaBase)}">${esc(a.replicaBase)} · replica ${a.replicaIndex} of ${a.replicaCount}</span>` : '';
         const configTarget = a.replicaBase || a.name;
+        /* Says why the card is grey. Without it the only visible difference
+           between "switched off" and "crashed" is the absence of a session,
+           which is exactly what the reader cannot see from here. */
+        const disabledBadge = agentIsDisabled(a) ? ` <span class="status-badge disabled" title="Disabled in config — the governor never starts this agent. Configure it with the gear to enable.">disabled</span>` : '';
         return `<div class="agent-card ${cls}${compactCls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${replicaBadge} ${toggleBtn} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> <a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open tmux session">▶ terminal</a> <a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a> <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Archived logs of previous kicks — survives restarts and upgrades">🕘 past kicks</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotState}"${isOff ? ` title="${esc(OFF_HEALTHY_TITLE)}"` : ''}></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}${needsLogin ? ' <span title="CLI needs login">\uD83D\uDD11</span>' : ''}${a.sandboxed ? ' <span class="status-badge done" title="Sandboxed runner active">sandboxed</span>' : ''}${disabledBadge}${replicaBadge} ${toggleBtn} <button class="compact-toggle" data-action="toggleAgentCompact" data-arg0="${esc(a.name)}" data-stop="1" title="Toggle compact/expanded view for this agent card">${isAgentCompact(a.name) ? '&#9655; expand' : '&#9661; compact'}</button> ${sessionChip(a, '▶ terminal', `<a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open tmux session">▶ terminal</a>`)} ${sessionChip(a, '📄 full log', `<a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Full log of the latest run as selectable, searchable text">📄 full log</a>`)} <a href="${kickHistoryUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" title="Archived logs of previous kicks — survives restarts and upgrades">🕘 past kicks</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(configTarget)}" title="Configure ${esc(a.replicaBase ? (a.replicaBase + ' (base for ' + a.name + ')') : (a.displayName || a.name))}">⚙️</button></div>
           <div class="agent-state ${isOnDemand ? 'on-demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : a.busy}${pauseInfoIcon(a)}${(() => {
             if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
             if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -272,6 +272,32 @@ func BuildFrontendStatus(
 	return payload
 }
 
+// agentDisabledInConfig reports whether an agent is switched OFF in config —
+// `enabled: false` — as opposed to merely not running right now.
+//
+// The distinction matters because a disabled agent is never started, so it has
+// no tmux session and no captured pane, yet it still appears in the runtime
+// roster: ApplyPack adds every agent in the ACMM level's pack to the manager
+// and gates only the Start on Enabled (api_packs.go). That is deliberate — the
+// runtime card is how an operator turns the agent back on — but it means every
+// consumer reading "not running" has to ask WHY before calling it a fault.
+//
+// The live config wins; proc.Config is the manager's copy and only refreshes
+// on UpdateConfig/reconcile. Callers must check "running" FIRST: an agent
+// disabled while it is still up keeps running until the next reconcile, and it
+// genuinely does have a session until then.
+func agentDisabledInConfig(cfg *config.Config, name string, proc *agent.AgentProcess) bool {
+	if cfg != nil {
+		if liveCfg, ok := cfg.Agents[name]; ok {
+			return !liveCfg.Enabled
+		}
+	}
+	if proc != nil {
+		return !proc.Config.Enabled
+	}
+	return false
+}
+
 func buildConfiguredAgents(cfg *config.Config) []FrontendConfiguredAgent {
 	if cfg == nil {
 		return []FrontendConfiguredAgent{}
@@ -570,6 +596,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			Color:         agentCfg.Color,
 			BeadRole:      agentCfg.GetBeadRole(),
 			Managed:       agentCfg.Managed,
+			Enabled:       !agentDisabledInConfig(cfg, name, proc),
 			ReplicaBase:   agentCfg.ReplicaOf,
 			ReplicaIndex:  agentCfg.ReplicaIndex,
 			ReplicaCount:  agentCfg.ReplicaCount,


### PR DESCRIPTION
## The report

An operator clicked **▶ terminal** on the `guide` agent and got:

```
error: no tmux socket found for session 'hive-guide'
```

That is the same message #4593 produced, which points diagnosis at ttyd's
`--url-arg`. It is a different fault. #4593 named the *fallback* session for
every agent, because the plumbing was broken fleet-wide — that repeated
`'supervisor'` is the tell. This one names the agent that was clicked,
because the plumbing is fine and the session genuinely does not exist.

## What is actually wrong

A disabled agent keeps a full runtime card, including `▶ terminal` and
`📄 full log`. Neither can work: nothing ever starts the agent, so it has no
tmux session and no pane to capture.

Observed on a live L3 hive — `guide`, `brainstorm` and `ci-maintainer` all at
`state=stopped`, `restarts=0`, never launched, while their cards advertised
both actions:

```
$ curl -s localhost:3001/api/agents/guide/log
capturing pane for guide: exit status 1
```

Disabled agents reach the runtime roster because `ApplyPack` adds every agent
in the ACMM level's pack and gates only the `Start` on `Enabled`
(`api_packs.go:225-231`). That is deliberate — the card is how an operator
turns the agent on — but nothing carried the flag forward, so no consumer
could tell "switched off on purpose" from "stopped because it broke".
`FrontendAgent` had no `enabled` field at all, and `State` reads `stopped`
for both.

The same blind spot reached health. Both checks scored a deliberately
switched-off agent as broken, so any hive that turns an agent off reports a
failure it can never clear — and raises a standing hub alert for an agent
nobody wants running:

```
"guide": { "state": "stopped", "status": "fail" }
```

## The change

- `FrontendAgent.Enabled`, from the live config (`proc.Config` is the
  manager's copy and only refreshes on `UpdateConfig`/reconcile). Not
  `omitempty` — `false` is the value this exists to report.
- The card shows a `disabled` badge, and the session-backed actions render
  inert with the reason instead of linking into a dead end. `past kicks` is
  left alone: it serves a real page for an agent that never ran.
- Deep health scores `skip` instead of `fail`, and `healthSummaryFor` counts
  disabled separately instead of `down` — the same treatment `paused` already
  gets two branches up.

Every check reads "running" before "disabled": an agent disabled while it is
still up keeps running until the next reconcile and genuinely does have a
session until then.

## Not in scope

`AddAgent` running regardless of `Enabled` is the root of the roster entry,
but leaving it is what gives an operator a card to enable the agent from.
With this change that card is honest rather than misleading, and touching it
would pull in the enable flow (`disabled_agent_enable_test.go`) for no gain.

`↻ restart` on a disabled agent is the remaining odd action on that card —
worth a follow-up, not bundled here.

## Testing

`disabled_agent_no_session_test.go` covers the flag reaching the payload, the
live-config-wins precedence, deep health returning `skip`, and the frontend
wiring. Verified failing without the fix. Full `pkg/dashboard` and `pkg/hub`
suites pass.

`newFullServer`'s fixture had to set `Enabled` explicitly: the literal skips
`ApplyAgentDefaults`, which is what gives a real config `enabled: true` unless
the operator wrote `enabled: false`, so the zero value described a state
production cannot produce — an agent in the runtime roster that is switched
off — and the health checks now correctly read that as deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)