### PR TITLE
[quality] deflake TestDeliverStartupKick_Delivered: gate readiness clock on actual pane render

### DIFF
--- a/src/pkg/agent/branches_coverage_test.go
+++ b/src/pkg/agent/branches_coverage_test.go
@@ -73,6 +73,13 @@ func TestDeliverStartupKick_Delivered(t *testing.T) {
 	agent.State = StateRunning
 	agent.launchGen = 3
 	paneInject(t, session, "goose is ready")
+	// Don't start deliverStartupKick's readiness clock until tmux has actually
+	// painted the marker: on a loaded runner the render can outlast
+	// paneInject's fixed sleep AND the TestMain-shrunk cliReadyTimeout,
+	// dropping the kick and flaking this test for reasons unrelated to the
+	// delivery path under test. Same pattern as
+	// TestDeliverStartupKick_BobReceivesKick (#4871).
+	requirePaneShows(t, session, "goose is ready")
 	m.deliverStartupKick(agent, "bootstrap prompt", 3)
 	if agent.LastKick == nil {
 		t.Error("startup kick should be delivered on matching generation")


### PR DESCRIPTION
## Root cause

Same root cause as #4871, on the sibling test that PR didn't touch.

`TestDeliverStartupKick_Delivered` (`src/pkg/agent/branches_coverage_test.go`) calls `paneInject(t, session, "goose is ready")`, which types the marker into the tmux pane and sleeps a fixed 400ms, then immediately calls `m.deliverStartupKick(...)`. Inside `deliverStartupKick`, readiness is polled via `waitForCLIReadyForAgent`, bounded by the TestMain-shrunk `cliReadyTimeout`. Under full-suite load (shared tmux server contention, ~282s for `pkg/agent` alone per the issue), tmux can take longer than 400ms to actually paint the marker, so the readiness clock starts before the pane has rendered it. `waitForCLIReadyForAgent` then times out, the kick is (correctly) dropped, and `agent.LastKick` stays nil — failing an assertion unrelated to the delivery logic under test.

## Fix

Gate the readiness clock on the actual pane render instead of the fixed sleep, using the `requirePaneShows` helper already added in #4871 (`tmux_coverage_test.go`), which polls `capture-pane` until the marker is visible (15s test-only deadline). This mirrors exactly the pattern #4871 used to deflake the sibling test `TestDeliverStartupKick_BobReceivesKick`. No production timeouts or delivery-path assertions change — the test still asserts `agent.LastKick` is set on a matching launch generation.

Fixes #4865