### PR TITLE
test(watchdog): widen restart-settle wait budget to fix CI flake

### DIFF
--- a/src/pkg/watchdog/reconciler_test.go
+++ b/src/pkg/watchdog/reconciler_test.go
@@ -184,10 +184,10 @@ func (f *fakeFleet) waitRestart(t *testing.T, r *Reconciler) {
 	t.Helper()
 	select {
 	case <-f.restartDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(waitBudget):
 		t.Fatal("timed out waiting for a restart to complete")
 	}
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(waitBudget)
 	for time.Now().Before(deadline) {
 		r.mu.Lock()
 		rec, ok := r.agents[f.lastRestarted()]
@@ -1399,9 +1399,19 @@ func TestDefaultBackendProvider(t *testing.T) {
 	}
 }
 
+// waitBudget bounds how long the helpers below poll real wall-clock time for
+// a detached restart goroutine to settle. It is intentionally generous: the
+// condition each helper polls is a real, observed state transition
+// (restartInFlight clearing, restartCount advancing) rather than a fixed
+// sleep, so widening this budget only buys headroom against scheduler
+// contention on coverage-instrumented CI runners — it cannot mask a restart
+// that never happens, and it does not change what is being asserted (see
+// TestDeadSessionRestartsOncePerBackoffNotPerTick's exact-count check).
+const waitBudget = 20 * time.Second
+
 func waitFor(t *testing.T, cond func() bool, msg string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(waitBudget)
 	for time.Now().Before(deadline) {
 		if cond() {
 			return


### PR DESCRIPTION
## Root cause

`TestDeadSessionRestartsOncePerBackoffNotPerTick` drives 30 simulated
sweeps through a `fakeClock` seam (`clock.Advance(10s)` per iteration),
so the backoff-ladder math itself is already fully deterministic — the
reconciler never reads wall-clock time in this test.

What is NOT deterministic is how the test waits for each *detached*
restart goroutine (`Reconciler.restartDetached`, spawned via `go func()`)
to settle before the next `clock.Advance` call. Both `fakeFleet.waitRestart`
and the shared `waitFor` test helper bound their polling loops with a
fixed 5-second **real** wall-clock deadline. This test calls
`waitRestart` up to 3 times (once per ladder rung) plus a final `waitFor`,
so its cumulative real-time budget was tight. Under coverage
instrumentation, goroutine scheduling slows down, and on loaded CI
runners the last restart goroutine sometimes hadn't cleared
`restartInFlight` / posted to `restartDone` before the deadline expired,
producing the reported failure (and the telltale ~5.00s test duration —
one of the fixed 5s deadlines being hit).

## Why the fix is deterministic

The fix widens the shared real-time budget both helpers use (extracted
into one `waitBudget` constant, 5s → 20s) — it does **not** change what
either helper is polling for:

- `waitRestart` still blocks on the real `restartDone` channel, then
  polls the reconciler's own `restartInFlight` field under `r.mu`.
- `waitFor` still polls the caller-supplied condition function
  (`fleet.restartCount() >= wantRestarts`).

Both were already gating on **observed completion**, never on elapsed
time as a proxy for correctness — only the ceiling on how long the test
is willing to wait for that observation to become true has changed.
This can't mask a restart that never happens: the test's final
assertion is untouched and still requires the count to equal exactly 3,
not merely `>= 3`.

## Invariant preserved

The test still asserts the RFC #4665 invariant in full: exactly 3
restarts across 30 simulated sweeps (the backoff ladder), not one per
tick. Nothing about *what* is checked changed — only the real-time
patience the harness gives detached goroutines to settle under load.

A fully deterministic settle signal (e.g., a `sync.WaitGroup` in the
reconciler tracking in-flight detached restarts) would be preferable
long-term, but no such seam currently exists, and adding
production-only synchronization machinery purely for test observability
felt like more surface area than this flake warranted. Widening the
existing observed-completion polling budget is the minimal change that
fixes the actual problem (insufficient real-time headroom under CI
load), and it benefits all ~25 other call sites of `waitFor`/`waitRestart`
in this file, not just this one test.

Fixes #4872
