### PR TITLE
🐛 fix(dashboard): report the count window separately from the freshness window

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3546,9 +3546,11 @@ func main() {
 			var repoActivity []hub.RepoActivityWire
 			repoActivityCollectedAt := ""
 			repoActivityWindowHours := 0
+			repoActivityCountWindowHours := 0
 			if asnap, ok := activityCollector.Snapshot(); ok {
 				repoActivity = buildRepoActivityWire(asnap.Repos)
 				repoActivityWindowHours = asnap.WindowHours
+				repoActivityCountWindowHours = asnap.CountWindowHours
 				if t := activityCollector.CollectedAt(); !t.IsZero() {
 					repoActivityCollectedAt = t.UTC().Format(time.RFC3339)
 				}
@@ -3870,13 +3872,14 @@ func main() {
 					}
 					return hub.CollectClusterHealth(logger)
 				}(),
-				PRsMerged90d:            prsMerged,
-				PRsRejected90d:          prsRejected,
-				CVEsClosed:              cvesClosed,
-				FleetStatsCollectedAt:   fleetStatsCollectedAt,
-				RepoActivity:            repoActivity,
-				RepoActivityCollectedAt: repoActivityCollectedAt,
-				RepoActivityWindowHours: repoActivityWindowHours,
+				PRsMerged90d:                 prsMerged,
+				PRsRejected90d:               prsRejected,
+				CVEsClosed:                   cvesClosed,
+				FleetStatsCollectedAt:        fleetStatsCollectedAt,
+				RepoActivity:                 repoActivity,
+				RepoActivityCollectedAt:      repoActivityCollectedAt,
+				RepoActivityWindowHours:      repoActivityWindowHours,
+				RepoActivityCountWindowHours: repoActivityCountWindowHours,
 				// Report WHICH App key we hold, never the key. The hub compares
 				// this against its per-cluster key and pushes a correction only
 				// on a mismatch, so a spoke already holding the right key costs

--- a/src/pkg/dashboard/activity_collector.go
+++ b/src/pkg/dashboard/activity_collector.go
@@ -28,6 +28,11 @@ const activityWindow = 14 * 24 * time.Hour
 
 // activityHealthWindowHours is advertised to the hub as the intended freshness
 // window (the hub still computes recency from NewestAt).
+//
+// This is NOT the window Count is accumulated over — that is activityWindow
+// (14d). The snapshot reports both: window_hours (this constant, freshness)
+// and count_window_hours (activityWindow). They are 28x apart, so a consumer
+// that divides Count by window_hours to get a rate overstates activity by 28x.
 const activityHealthWindowHours = 12
 
 // Audit action names the collector counts as OUTPUT to a work source. Kept in
@@ -87,8 +92,17 @@ type AgentRepoActivity struct {
 type ActivitySnapshot struct {
 	Repos        []RepoActivity     `json:"repos"`
 	Unattributed ActivityActionStat `json:"unattributed"`
-	WindowHours  int                `json:"window_hours"`
-	CollectedAt  time.Time          `json:"collected_at"`
+	// WindowHours is the FRESHNESS window the hub's health verdict uses. It is
+	// deliberately NOT the window Count was accumulated over — see
+	// CountWindowHours. Kept under its original name because the hub registry
+	// and heartbeat already carry this field with this meaning.
+	WindowHours int `json:"window_hours"`
+	// CountWindowHours is the lookback the per-repo Count values were actually
+	// accumulated over (activityWindow). A consumer deriving a RATE must divide
+	// by this, not by WindowHours: they differ by 28x, so using the freshness
+	// window would overstate activity by that factor.
+	CountWindowHours int       `json:"count_window_hours"`
+	CollectedAt      time.Time `json:"collected_at"`
 }
 
 // auditReader is the subset of *AuditLog the collector needs, so it can be
@@ -286,7 +300,7 @@ func (ac *ActivityCollector) collect() {
 	sort.Slice(repos, func(i, j int) bool { return repos[i].Repo < repos[j].Repo })
 
 	ac.mu.Lock()
-	ac.snap = ActivitySnapshot{Repos: repos, Unattributed: unattributed, WindowHours: activityHealthWindowHours, CollectedAt: now}
+	ac.snap = ActivitySnapshot{Repos: repos, Unattributed: unattributed, WindowHours: activityHealthWindowHours, CountWindowHours: int(activityWindow / time.Hour), CollectedAt: now}
 	ac.collectedAt = now
 	ac.ready = true
 	ac.persistLocked()
@@ -343,6 +357,8 @@ func (s *Server) handleRepoActivity(w http.ResponseWriter, r *http.Request) {
 		Limitations: []string{
 			"Counts are recorded audit facts only; no token cost is attributed in this phase.",
 			"Entries without repo= are reported as unattributed and are never spread across repos.",
+			"window_hours is the freshness window used by the hub health verdict; per-repo counts are accumulated over count_window_hours. Divide by count_window_hours for a rate — window_hours would overstate it by 28x.",
+			"Counts are bounded by audit-log retention: rotated and compressed backups are read, but only MaxBackups of them are kept, so a busy hive's effective lookback can be shorter than count_window_hours.",
 		},
 	})
 }

--- a/src/pkg/dashboard/activity_collector_test.go
+++ b/src/pkg/dashboard/activity_collector_test.go
@@ -244,3 +244,48 @@ func TestHandleRepoActivityReportsPhaseOneHonesty(t *testing.T) {
 		t.Fatal("limitations must be explicit so activity is not mistaken for cost")
 	}
 }
+
+// TestActivitySnapshotWindowsAreDistinct pins the two windows apart. window_hours
+// is the hub's FRESHNESS window; count_window_hours is the lookback Count was
+// accumulated over. #4860: the snapshot advertised only the 12h freshness value
+// while counting over 14d, so any consumer deriving a rate overstated activity
+// by 28x. Re-coupling them (or dropping count_window_hours) must fail here
+// rather than silently reappear as a wrong number on a cost row later.
+func TestActivitySnapshotWindowsAreDistinct(t *testing.T) {
+	now := time.Now().UTC()
+	dir := t.TempDir()
+	p := writeAuditFixture(t, dir, []AuditEntry{{
+		Timestamp: rfc3339(now.Add(-1 * time.Hour)),
+		Action:    "agent_pr_created",
+		Detail:    "repo=o/r, number=1",
+		Agent:     "quality",
+	}})
+	ac := NewActivityCollector(&AuditLog{}, p, nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.collect()
+
+	snap, ready := ac.Snapshot()
+	if !ready {
+		t.Fatal("snapshot not ready")
+	}
+	if snap.WindowHours != activityHealthWindowHours {
+		t.Errorf("WindowHours = %d, want %d (the freshness window)",
+			snap.WindowHours, activityHealthWindowHours)
+	}
+	wantCount := int(activityWindow / time.Hour)
+	if snap.CountWindowHours != wantCount {
+		t.Errorf("CountWindowHours = %d, want %d (the accumulation window)",
+			snap.CountWindowHours, wantCount)
+	}
+	// The bug was reporting one value for both. If a future edit makes them
+	// equal, the 28x rate error is back and this is the signal.
+	if snap.CountWindowHours == snap.WindowHours {
+		t.Fatalf("count and freshness windows must stay distinct; both = %d", snap.WindowHours)
+	}
+	// The count window must cover the freshness window, or a "fresh" event
+	// could fall outside the counted range.
+	if snap.CountWindowHours < snap.WindowHours {
+		t.Fatalf("CountWindowHours (%d) must be >= WindowHours (%d)",
+			snap.CountWindowHours, snap.WindowHours)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -739,6 +739,11 @@ type HeartbeatPayload struct {
 	RepoActivity            []RepoActivityWire `json:"repo_activity,omitempty"`
 	RepoActivityCollectedAt string             `json:"repo_activity_collected_at,omitempty"`
 	RepoActivityWindowHours int                `json:"repo_activity_window_hours,omitempty"`
+	// RepoActivityCountWindowHours is the lookback the per-repo counts were
+	// accumulated over. RepoActivityWindowHours above is the FRESHNESS window
+	// the health verdict uses; the two differ by 28x, so a rate computed
+	// against the freshness window overstates activity (#4860).
+	RepoActivityCountWindowHours int `json:"repo_activity_count_window_hours,omitempty"`
 
 	// --- Quadrant signals -------------------------------------------------
 	// Cheap, already-computed spoke metrics forwarded so the hub can score the

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -325,9 +325,10 @@ type RegistryEntry struct {
 	// the last real summary. RepoActivityCollectedAt / RepoActivityWindowHours
 	// travel with it so the hub can age the summary and know the intended
 	// freshness window (see health_verdict.go).
-	RepoActivity            []RepoActivityWire `json:"repoActivity,omitempty"`
-	RepoActivityCollectedAt time.Time          `json:"repoActivityCollectedAt,omitempty"`
-	RepoActivityWindowHours int                `json:"repoActivityWindowHours,omitempty"`
+	RepoActivity                 []RepoActivityWire `json:"repoActivity,omitempty"`
+	RepoActivityCollectedAt      time.Time          `json:"repoActivityCollectedAt,omitempty"`
+	RepoActivityWindowHours      int                `json:"repoActivityWindowHours,omitempty"`
+	RepoActivityCountWindowHours int                `json:"repoActivityCountWindowHours,omitempty"`
 
 	// Quadrant signals reported by the spoke (nil = not reported). These back
 	// the per-hive quadrant score; see quadrant.go for how each is used and
@@ -1849,9 +1850,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		// Per-repo output activity (hive-health): sanitized/clamped, never the
 		// raw payload. The collected-at + window travel with it so the verdict
 		// can age the summary.
-		RepoActivity:            sanitizeRepoActivity(payload.RepoActivity),
-		RepoActivityCollectedAt: parseHeartbeatTime(payload.RepoActivityCollectedAt),
-		RepoActivityWindowHours: clampInt(payload.RepoActivityWindowHours, 0, repoActivityMaxWindowHours),
+		RepoActivity:                 sanitizeRepoActivity(payload.RepoActivity),
+		RepoActivityCollectedAt:      parseHeartbeatTime(payload.RepoActivityCollectedAt),
+		RepoActivityWindowHours:      clampInt(payload.RepoActivityWindowHours, 0, repoActivityMaxWindowHours),
+		RepoActivityCountWindowHours: clampInt(payload.RepoActivityCountWindowHours, 0, repoActivityMaxWindowHours),
 	}
 
 	// Fleet error-rate history (#3995, phase 2c): fold this beat's rolling
@@ -2072,6 +2074,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				entry.RepoActivity = h.RepoActivity
 				entry.RepoActivityCollectedAt = h.RepoActivityCollectedAt
 				entry.RepoActivityWindowHours = h.RepoActivityWindowHours
+				entry.RepoActivityCountWindowHours = h.RepoActivityCountWindowHours
 			}
 			// Advisory post time survives a spoke restart — see
 			// carryAdvisoryPostTime for why that is the difference between a


### PR DESCRIPTION
`GET /api/repo-activity` advertised `window_hours: 12` while the per-repo counts were accumulated over **14 days**:

| | Value | Source |
|---|---|---|
| Counts accumulated over | `activityWindow` = 336h | `activity_collector.go:214` |
| Window advertised | `activityHealthWindowHours` = 12 | `activity_collector.go:289` |

Any consumer treating `Count` as "output within `window_hours`" — an events-per-hour rate, most obviously — **overstates activity by 28×**.

## Both values are legitimate; reporting one for both questions was the bug

The wide accumulation window is deliberate and documented: the hub computes freshness itself from `NewestAt`, and a slightly-late collect must not drop a just-inside-12h event. So this adds `count_window_hours` **alongside** `window_hours` rather than redefining either.

The hub's health verdict already recomputes recency from `NewestAt` and owns its own 12h constant (`health_verdict.go:33-35`), so it was never misled and its semantics are untouched. No clamp change was needed — `sanitizeRepoActivity` already tolerates 720h.

## What's included

- `CountWindowHours` on `ActivitySnapshot`, populated from `activityWindow`
- Carried through the heartbeat (`repo_activity_count_window_hours`) and the hub registry, so hub-side consumers get the same disambiguation
- Stated in the endpoint's own `limitations` strings — a caller reading the JSON shouldn't have to find this commit
- A test pinning the two apart: **equal values fail**, and a count window *narrower* than the freshness window fails, since that would let a "fresh" event fall outside the counted range

## Why this is worth fixing now rather than later

Phase 1 of the per-repo cost epic (#4836) produces these counts, and Phase 3 attaches spend to them. At that point a 28× mislabel stops being a wrong dashboard number and becomes **a wrong budget figure**. It also directly contradicted that epic's own stated rule that the attribution window must be reported alongside the number.

## One correction to the reported scope

While adding a retention caveat I initially wrote that the audit log's rotated backups are not read. That is **no longer true** — `OutputActionsSince` reads rotated and compressed `.gz` backups (with a gzip-bomb cap, hardened in #4863). The limitation now states the accurate constraint: backups *are* read, but only `MaxBackups` are kept, so a busy hive's effective lookback can still be shorter than the nominal count window.

Fixes #4860