### PR TITLE
🐛 fix(hub): label the Manage Access expiry field and say when a grant is permanent

### DIFF
--- a/src/pkg/hub/access_expiry_test.go
+++ b/src/pkg/hub/access_expiry_test.go
@@ -263,3 +263,38 @@ func TestAccessListIncludesExpiry(t *testing.T) {
 		t.Errorf("ExpiresAt = %q, want %q", access[0].ExpiresAt, future)
 	}
 }
+
+// TestAccessExpiryFieldIsLabelled pins the VISIBLE label on the Manage Access
+// expiry controls.
+//
+// An empty <input type="date"> is not blank on screen: browsers render their
+// own mm/dd/yyyy placeholder, which reads as a date that has already been
+// chosen. Without a label beside it, an operator cannot tell that the box is an
+// expiry, which direction it acts in, or that leaving it alone is a valid
+// answer meaning "permanent". A title tooltip does not cover this — it is
+// invisible until hover and unavailable on touch.
+//
+// The field is and must stay OPTIONAL: nothing pre-fills it, and addAccess
+// sends whatever is there, so empty means permanent.
+func TestAccessExpiryFieldIsLabelled(t *testing.T) {
+	// The Add User control carries a visible label naming the field and saying
+	// an empty value is allowed.
+	if !strings.Contains(dashboardHTML, `<label for="access-expiry"`) {
+		t.Error("the Add User expiry input has no visible <label> — a bare date box does not say it is an expiry")
+	}
+	if !strings.Contains(dashboardHTML, "Expires <span style=\"opacity:0.75\">(optional)</span>") {
+		t.Error(`the Add User expiry label must say "Expires (optional)": the name gives the field meaning, "(optional)" says an empty field is a valid answer`)
+	}
+
+	// Per-user rows: a grant with no expiry must SAY it is permanent rather
+	// than leaving the reader to infer it from a box that looks filled in.
+	if !strings.Contains(dashboardHTML, `Expires: <span style="color:var(--text)">Never</span>`) {
+		t.Error(`a grant with no expiry must render "Expires: Never" — otherwise a permanent grant is indistinguishable from one expiring today`)
+	}
+
+	// The input must not gain a default. A pre-filled expiry would silently
+	// convert every new grant into a temporary one.
+	if strings.Contains(dashboardHTML, `id="access-expiry" type="date" value=`) {
+		t.Error("the expiry input must not carry a default value — empty means permanent, and a default would make every new grant expire")
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -20945,8 +20945,19 @@ const dashboardHTML = `<!DOCTYPE html>
             <option value="merger" title="Everything Read-Write grants, plus approve and queue other contributors' work for auto-merge.">Merger</option>
             <option value="owner" title="Full control: manage access, settings and budget for this hive.">Owner</option>
           </select>
-          <input id="access-expiry" type="date" title="Optional expiry — leave empty for permanent access. Access is revoked automatically after this date (UTC)."
-            style="flex:0 0 auto;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+          <!-- The date input is OPTIONAL and empty means permanent. It needs a
+               visible label because an empty type="date" renders as today's
+               date in the browser's own placeholder styling, which reads as a
+               value that has already been chosen rather than an empty field.
+               The label says which direction the date acts in; "(optional)"
+               says an empty field is a valid answer. A title tooltip alone is
+               not enough — it is invisible until hover and unavailable on
+               touch. -->
+          <label for="access-expiry" style="display:flex;flex-direction:column;gap:2px;flex:0 0 auto;font-size:0.7rem;color:var(--muted)">
+            <span>Expires <span style="opacity:0.75">(optional)</span></span>
+            <input id="access-expiry" type="date" title="Optional expiry — leave empty for permanent access. Access is revoked automatically after this date (UTC)."
+              style="padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+          </label>
           <button onclick="addAccess()" class="btn-primary" style="flex:0 0 auto;padding:8px 16px;font-size:0.8rem">Add</button>
         </div>
         <div id="access-role-hint" style="margin-top:6px;font-size:0.72rem;color:var(--muted);line-height:1.4"></div>
@@ -21458,11 +21469,22 @@ const dashboardHTML = `<!DOCTYPE html>
           // last valid day when set, and empty means permanent. Changing it
           // extends (or clears) the expiry; the last owner cannot be expired
           // for the same reason they cannot be removed or demoted.
+          // A bare date box next to a grant does not say which direction the
+          // date acts in, and an EMPTY type="date" still renders as today in
+          // the browser's placeholder — so a permanent grant looks like one
+          // expiring today. The prefix names the field, and when no expiry is
+          // set it reads "Never" so the permanent case states itself instead
+          // of being inferred from an apparently-filled box.
+          var expiryLabel = u.expires_at ?
+            '<span style="font-size:0.6rem;color:var(--muted)">Expires</span>' :
+            '<span style="font-size:0.6rem;color:var(--muted)" title="No expiry set — this grant is permanent until removed.">Expires: <span style="color:var(--text)">Never</span></span>';
           var expiryControl = isLastOwner ? '' :
+            '<span style="display:inline-flex;align-items:center;gap:4px">' + expiryLabel +
             '<input type="date" class="access-expiry-input" value="' + esc(expiryToDateInput(u.expires_at)) + '"' +
             ' onchange="changeAccessExpiry(\'' + esc(u.username) + '\', \'' + esc(u.role) + '\', this.value)"' +
             ' title="Optional expiry — empty means permanent. Access is revoked automatically after this date (UTC)."' +
-            ' style="font-size:0.65rem;padding:2px 4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:' + (u.expires_at ? 'var(--amber)' : 'var(--muted)') + '">';
+            ' style="font-size:0.65rem;padding:2px 4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:' + (u.expires_at ? 'var(--amber)' : 'var(--muted)') + '">' +
+            '</span>';
           return '<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:8px;padding:8px 0;border-bottom:1px solid var(--border)">' +
             '<div style="display:flex;align-items:center;gap:4px;flex:1 1 240px;min-width:0">' + checkbox + avatar + providerIconHTML(identityProviderFromKey(u.username)) + '<span style="font-size:0.85rem;word-break:break-word">' + esc(u.username) + '</span>' +
             /* Empty placeholder the async GitHub profile lookup fills in


### PR DESCRIPTION
Reported from the hub UI: *"there is nothing indicating that the date field is an expiration."*

The **Manage Access** dialog put a bare date box between the role dropdown and the **Add** button, with no label. The same box appears again on every per-user row.

## Why an unlabelled date input is worse than an unlabelled text input

An empty `<input type="date">` is **not blank on screen**. The browser renders its own `mm/dd/yyyy` placeholder in the current locale, so the field looks like a date that has already been chosen. That produces two distinct misreadings:

1. **In Add User** — the operator cannot tell the box is an expiry, which direction it acts in, or that leaving it alone is a valid answer.
2. **On per-user rows** — a *permanent* grant was visually indistinguishable from one *expiring today*. Both render the same apparently-filled box.

Both inputs already carried a `title` tooltip saying the field is optional, but a tooltip is invisible until hover and unavailable on touch, so it does not do a label's job.

## The change

- **Add User** gains a visible **"Expires (optional)"** label. The name gives the field meaning; `(optional)` states that an empty field is a valid answer rather than something the operator still owes.
- **Per-user rows** gain an `Expires` prefix, and a grant with no expiry now reads **"Expires: Never"** — the permanent case states itself instead of being inferred from a box that looks filled in.

## On the "should be optional by default" half of the report

**It already is, and this PR keeps it that way.** Nothing pre-fills either input — the date visible in the report was the browser's placeholder, not a value. `addAccess` sends whatever is in the box and empty means permanent (`parseAccessExpiry` / `handleAccessAdd`, #4150).

So this is presentation-only: no behaviour change, no API change, no change to what gets sent.

The test includes a **negative assertion** that the input never gains a `value=` default, because that is the failure mode this report would otherwise invite — a pre-filled expiry would silently turn every new grant into a temporary one, and the resulting revocations would look like a backend bug rather than a UI default.

## Scope

Hub UI markup plus one test. `isLastOwner` still suppresses the control entirely — the last owner cannot be expired, for the same reason they cannot be removed or demoted.