### PR TITLE
✨ feat: per-repo cost attribution — phases 2 and 3 (#4836)

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -94,6 +94,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/tokens", s.handleTokens)
 	s.mux.HandleFunc("GET /api/cost", s.handleCost)
 	s.mux.HandleFunc("GET /api/repo-activity", s.handleRepoActivity)
+	s.mux.HandleFunc("GET /api/repo-cost", s.handleRepoCost)
 	s.mux.HandleFunc("GET /api/cost/history", s.handleCostHistory)
 	// #4298: "for every recent reset, how much of the budget had been used".
 	s.mux.HandleFunc("GET /api/budget/history", s.handleBudgetHistory)

--- a/src/pkg/dashboard/repo_cost.go
+++ b/src/pkg/dashboard/repo_cost.go
@@ -1,0 +1,427 @@
+package dashboard
+
+// Per-repo estimated cost attribution — phase 3 of #4836.
+//
+// WHAT THIS DOES
+//
+// Hive knows two things separately and has never joined them:
+//
+//   - WHEN tokens were spent, and by which agent (pkg/tokens — since #4836
+//     phase 2 the Claude scanner retains a timestamped per-message usage
+//     timeline instead of only a session total)
+//   - WHEN an agent produced output against a named repo (the audit log's
+//     `repo=` pairs, summarized per repo by the activity collector in phase 1)
+//
+// The join is an INTERVAL join on time, per agent. Order one agent's audited
+// repo events by timestamp. Between two consecutive events, every usage event
+// that falls inside is attributed to the repo named by the CLOSING event — the
+// reasoning being that work done immediately before filing on a repo was work
+// done FOR that repo.
+//
+// WHAT THIS IS NOT
+//
+// It is not a bill, and it is not measured. It is an inference from timing, and
+// its failure mode is specific and known: an agent that investigates repo A,
+// finds nothing worth filing, then files on repo B bills ALL of A's
+// investigation to B. Nothing in the data distinguishes those two cases. This is
+// documented in the API `limitations` array, not just here, because an operator
+// reading a per-repo dollar figure must be able to see it.
+//
+// TWO BUCKETS ARE MANDATORY AND ARE NEVER NORMALIZED AWAY:
+//
+//   - `unattributed` — tokens before an agent's first `repo=` event, tokens
+//     after its last one, tokens from agents with no repo events at all, and
+//     tokens whose timestamp could not be determined. The LEADING interval is
+//     never given to the first repo seen: there is no closing event for it, and
+//     inventing one is how a per-repo cost number becomes plausibly wrong.
+//   - `backend_unsupported` — every non-Claude backend's tokens. Copilot accrues
+//     all usage in one lump at session.shutdown and bob parses no per-message
+//     timestamps, so neither has an intra-session time distribution to join
+//     against. Their spend is REAL and is reported here in full; it is simply
+//     not placeable against a repo.
+//
+// The invariant `Σ by_repo + unattributed + backend_unsupported == hive total`
+// holds by construction and is asserted by test. Any token the hive counted
+// lands in exactly one bucket.
+//
+// DOUBLE-COUNTING: this reads the token collector's already-merged
+// AggregateSummary, which is the same figure /api/cost reports. It does NOT
+// re-read scanner sources, so the copilot scanner's live-capture zero-out
+// (which avoids double-counting sessions the MITM sink already recorded) is
+// respected rather than bypassed.
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/tokens"
+)
+
+// repoCostWindow is the lookback for BOTH sides of the join. It matches the
+// activity collector's activityWindow so the audit events and the usage events
+// cover the same span — joining a 14d event stream against a 30d usage stream
+// would silently push 16 days of real spend into `unattributed`.
+const repoCostWindow = activityWindow
+
+// repoCostBucketUnattributed and repoCostBucketBackendUnsupported are the two
+// mandatory buckets. They are exported in the payload under fixed keys because
+// a UI must be able to render them without inferring their meaning, and they
+// are always present even when zero.
+const (
+	repoCostBucketUnattributed       = "unattributed"
+	repoCostBucketBackendUnsupported = "backend_unsupported"
+)
+
+// repoCostEntry is one repo's attributed estimated cost. USD is a POINTER so a
+// repo with no attributable cost renders as "—" and never as "$0.00": those are
+// different facts and conflating them is how an operator concludes a repo was
+// cheap when it was merely unobserved.
+type repoCostEntry struct {
+	Repo string   `json:"repo"`
+	USD  *float64 `json:"usd"`
+	// Source is "estimated" when every model contributing to this repo had an
+	// exact list price, and "estimated_tier" when any contributor fell back to
+	// FallbackPrice's coarse tier guess. It is NEVER "actual": nothing here is
+	// a billed figure.
+	Source      string `json:"source"`
+	Input       int64  `json:"input"`
+	Output      int64  `json:"output"`
+	CacheRead   int64  `json:"cache_read"`
+	CacheCreate int64  `json:"cache_create"`
+	Tokens      int64  `json:"tokens"`
+	// Events is how many audited repo= events closed an interval for this repo.
+	Events int `json:"events"`
+	// Agents lists the agents that contributed, sorted, so an operator can see
+	// which sandbox drove the cost.
+	Agents []string `json:"agents,omitempty"`
+}
+
+// repoCostResponse is the GET /api/repo-cost payload.
+type repoCostResponse struct {
+	Ready bool   `json:"ready"`
+	Phase string `json:"phase"`
+	// ByRepo excludes the two mandatory buckets, which are reported separately
+	// so no consumer can accidentally sum them into a "per-repo" total or
+	// normalize them away as rounding.
+	ByRepo             []repoCostEntry `json:"by_repo"`
+	Unattributed       repoCostEntry   `json:"unattributed"`
+	BackendUnsupported repoCostEntry   `json:"backend_unsupported"`
+
+	// TotalUSD is the sum of every bucket below — the hive-wide estimated total
+	// this response partitions. Pricing is linear in token counts, so it tracks
+	// /api/cost's figure; it can differ marginally because /api/cost merges
+	// model ids by normalized spelling before pricing while this prices each
+	// usage event at its own recorded model id. TOKEN totals are exact either
+	// way, which is why the partition invariant is asserted on tokens.
+	TotalUSD float64 `json:"total_usd"`
+	// AttributedTokens / TotalTokens give the attribution RATE directly, so the
+	// UI need not derive it and cannot derive it differently.
+	AttributedTokens int64 `json:"attributed_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+
+	// WindowHours is the lookback the join actually used. It travels WITH the
+	// numbers because audit retention is size-triggered (5MB x 3 backups), so
+	// the effective lookback varies per hive and is SHORTEST on the busiest
+	// ones — exactly where per-repo cost matters most. A per-repo figure whose
+	// window is unknown is not comparable across the fleet.
+	WindowHours int `json:"window_hours"`
+	// OldestEventAt is the earliest audited repo= event the join could see,
+	// which is the real lower bound on the window when rotation has already
+	// discarded older entries. Empty when there were no events.
+	OldestEventAt string `json:"oldest_event_at,omitempty"`
+
+	PriceTableDate string   `json:"price_table_date"`
+	Disclaimer     string   `json:"disclaimer"`
+	Limitations    []string `json:"limitations"`
+}
+
+// repoCostLimitations is surfaced in the payload so the UI renders the method's
+// caveats alongside the numbers rather than burying them in code comments.
+func repoCostLimitations() []string {
+	return []string{
+		"Claude sessions only. Copilot records all token usage in a single lump at session shutdown and bob parses no per-message timestamps, so neither can be placed in time. Their spend is real and is reported in full under backend_unsupported — it is not missing, it is not attributable.",
+		"Attribution is inferred from TIMING, not measured. Tokens spent between two audited repo= events are billed to the repo named by the later event.",
+		"KNOWN BIAS: an agent that investigates repo A, finds nothing to file, then files on repo B bills ALL of A's investigation to B. This is the method's failure mode, not a rounding error — treat a repo's figure as an upper bound when neighbouring repos show activity but little cost.",
+		"Tokens before an agent's first repo= event, after its last, or from agents with no repo events at all are reported as unattributed and are NEVER spread across repos.",
+		"A repo with no attributable cost reports null, not zero. Null means unobserved; it does not mean free.",
+		"Bounded by audit-log retention, which is size-triggered (5MB x 3 backups) rather than age-based. The effective lookback therefore varies per hive and is shortest on the busiest ones. Compare oldest_event_at against window_hours before comparing figures across hives.",
+		"Estimated from token counts x published list prices, never a billed figure. Models absent from the price table are priced from a coarse tier guess and marked source=estimated_tier.",
+	}
+}
+
+// repoUsagePoint is one attributable slice of spend: tokens at a time, owned by
+// an agent, priced by a model.
+type repoUsagePoint struct {
+	tsMs  int64
+	agent string
+	model string
+	usage tokens.UsageEvent
+}
+
+// repoCostAccumulator sums tokens and dollars into one bucket.
+type repoCostAccumulator struct {
+	usd                                   float64
+	input, output, cacheRead, cacheCreate int64
+	events                                int
+	agents                                map[string]bool
+	// anyTier records that at least one contributing model was priced from the
+	// coarse tier fallback rather than an exact list price.
+	anyTier bool
+	// touched distinguishes "no cost attributed" from "zero cost attributed",
+	// which is what lets USD stay nil and the UI render an honest "—".
+	touched bool
+}
+
+func (a *repoCostAccumulator) add(p repoUsagePoint) {
+	usd, exact := tokens.EstimateCostUSD(p.model, p.usage.Input, p.usage.Output, p.usage.CacheRead, p.usage.CacheCreate)
+	a.usd += usd
+	if !exact {
+		a.anyTier = true
+	}
+	a.input += p.usage.Input
+	a.output += p.usage.Output
+	a.cacheRead += p.usage.CacheRead
+	a.cacheCreate += p.usage.CacheCreate
+	if p.agent != "" {
+		if a.agents == nil {
+			a.agents = map[string]bool{}
+		}
+		a.agents[p.agent] = true
+	}
+	a.touched = true
+}
+
+func (a *repoCostAccumulator) entry(name string) repoCostEntry {
+	e := repoCostEntry{
+		Repo:        name,
+		Input:       a.input,
+		Output:      a.output,
+		CacheRead:   a.cacheRead,
+		CacheCreate: a.cacheCreate,
+		Tokens:      a.input + a.output + a.cacheRead + a.cacheCreate,
+		Events:      a.events,
+		Source:      "estimated",
+	}
+	if a.anyTier {
+		e.Source = "estimated_tier"
+	}
+	// nil != zero: only a bucket that actually received usage gets a dollar
+	// figure. An untouched bucket renders "—".
+	if a.touched {
+		usd := a.usd
+		e.USD = &usd
+	}
+	for agent := range a.agents {
+		e.Agents = append(e.Agents, agent)
+	}
+	sort.Strings(e.Agents)
+	return e
+}
+
+// repoAuditEvent is one audited repo= output event, already time-resolved.
+type repoAuditEvent struct {
+	tsMs int64
+	repo string
+}
+
+// computeRepoCost performs the interval join. It is a pure function of its
+// inputs — no clock, no I/O — so the invariant test can drive it directly.
+//
+// summary is the hive's merged token summary (the same one /api/cost prices).
+// entries are audited output actions carrying repo= over the window.
+func computeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now time.Time) repoCostResponse {
+	resp := repoCostResponse{
+		Phase:              "phase_3_interval_join",
+		ByRepo:             []repoCostEntry{},
+		WindowHours:        int(repoCostWindow / time.Hour),
+		PriceTableDate:     tokens.PriceTableDate(),
+		Disclaimer:         costEstimateDisclaimer,
+		Limitations:        repoCostLimitations(),
+		Unattributed:       repoCostEntry{Repo: repoCostBucketUnattributed, Source: "estimated"},
+		BackendUnsupported: repoCostEntry{Repo: repoCostBucketBackendUnsupported, Source: "estimated"},
+	}
+	if summary == nil {
+		return resp
+	}
+	resp.Ready = true
+
+	// --- Side A: audited repo events, grouped per agent and time-ordered ---
+	byAgentEvents := map[string][]repoAuditEvent{}
+	var oldest string
+	for _, e := range entries {
+		m := repoRe.FindStringSubmatch(e.Detail)
+		if m == nil {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, e.Timestamp)
+		if err != nil {
+			continue
+		}
+		agent := activityAgent(e)
+		byAgentEvents[agent] = append(byAgentEvents[agent], repoAuditEvent{tsMs: t.UnixMilli(), repo: m[1]})
+		if oldest == "" || e.Timestamp < oldest {
+			oldest = e.Timestamp
+		}
+	}
+	for agent := range byAgentEvents {
+		ev := byAgentEvents[agent]
+		sort.Slice(ev, func(i, j int) bool { return ev[i].tsMs < ev[j].tsMs })
+		byAgentEvents[agent] = ev
+	}
+	resp.OldestEventAt = oldest
+
+	// --- Side B: usage points, split by whether they are placeable in time ---
+	windowStartMs := now.Add(-repoCostWindow).UnixMilli()
+	byRepo := map[string]*repoCostAccumulator{}
+	unattributed := &repoCostAccumulator{}
+	backendUnsupported := &repoCostAccumulator{}
+
+	for i := range summary.Sessions {
+		sess := &summary.Sessions[i]
+
+		// Any backend that cannot produce a per-message timeline contributes
+		// its FULL session total to backend_unsupported. This is the branch
+		// that keeps the invariant honest: those tokens are counted, just not
+		// placed. A Claude session that somehow carries no timeline (an older
+		// persisted snapshot from before phase 2, say) lands here too — the
+		// tokens are real and must not vanish.
+		if sess.Backend != tokens.BackendClaude || len(sess.Usage) == 0 {
+			backendUnsupported.add(repoUsagePoint{
+				agent: sess.Agent,
+				model: sess.Model,
+				usage: tokens.UsageEvent{
+					Input:       sess.InputTokens,
+					Output:      sess.OutputTokens,
+					CacheRead:   sess.CacheRead,
+					CacheCreate: sess.CacheCreate,
+				},
+			})
+			continue
+		}
+
+		// A Claude session's retained timeline sums to its session total
+		// exactly (pkg/tokens asserts this), so iterating the timeline
+		// accounts for the whole session and never double-counts it against
+		// the summed fields.
+		events := byAgentEvents[sess.Agent]
+		for _, u := range sess.Usage {
+			model := u.Model
+			if model == "" {
+				model = sess.Model
+			}
+			p := repoUsagePoint{tsMs: u.TimestampMs, agent: sess.Agent, model: model, usage: u}
+
+			repo, ok := attributeRepo(events, u.TimestampMs, windowStartMs)
+			if !ok {
+				unattributed.add(p)
+				continue
+			}
+			acc := byRepo[repo]
+			if acc == nil {
+				acc = &repoCostAccumulator{}
+				byRepo[repo] = acc
+			}
+			acc.add(p)
+		}
+	}
+
+	// Count how many audited events actually closed an interval for each repo,
+	// so the UI can show the evidence behind a figure.
+	for _, ev := range byAgentEvents {
+		for _, e := range ev {
+			if acc := byRepo[e.repo]; acc != nil {
+				acc.events++
+			}
+		}
+	}
+
+	for repo, acc := range byRepo {
+		entry := acc.entry(repo)
+		resp.ByRepo = append(resp.ByRepo, entry)
+		resp.AttributedTokens += entry.Tokens
+		resp.TotalUSD += acc.usd
+	}
+	sort.Slice(resp.ByRepo, func(i, j int) bool {
+		a, b := resp.ByRepo[i], resp.ByRepo[j]
+		if a.Tokens != b.Tokens {
+			return a.Tokens > b.Tokens
+		}
+		return a.Repo < b.Repo
+	})
+
+	resp.Unattributed = unattributed.entry(repoCostBucketUnattributed)
+	resp.BackendUnsupported = backendUnsupported.entry(repoCostBucketBackendUnsupported)
+	resp.TotalUSD += unattributed.usd + backendUnsupported.usd
+	resp.TotalTokens = resp.AttributedTokens + resp.Unattributed.Tokens + resp.BackendUnsupported.Tokens
+
+	return resp
+}
+
+// attributeRepo finds the repo that owns the usage at tsMs: the first audited
+// event at or after tsMs, whose repo is the CLOSING event of the interval the
+// usage falls in.
+//
+// It returns ok=false — sending the tokens to `unattributed` — in every case
+// where honest attribution is impossible:
+//
+//   - tsMs == 0: the usage carries no parseable timestamp, so it cannot be
+//     placed in any interval.
+//   - tsMs is before the window: the audit events that would have closed its
+//     interval have already rotated out of the log. Attributing it to the
+//     oldest surviving event would silently bill an unknown span to whichever
+//     repo happened to survive rotation.
+//   - no event at or after tsMs: the interval has no closing event (the agent
+//     spent tokens and has not yet filed anything). Assigning it to the
+//     PRECEDING event would be attributing work to a repo the agent had
+//     already finished with.
+//
+// The leading interval is handled by the same rule rather than by a special
+// case: usage before an agent's first event DOES find a closing event, so it
+// would be billed to the first repo. That is exactly the behaviour #4836
+// forbids, so it is excluded explicitly below.
+func attributeRepo(events []repoAuditEvent, tsMs, windowStartMs int64) (string, bool) {
+	if tsMs == 0 || len(events) == 0 {
+		return "", false
+	}
+	if tsMs < windowStartMs {
+		return "", false
+	}
+	// Never attribute the leading interval: usage that precedes an agent's
+	// FIRST audited event has no opening event, so the span it belongs to is
+	// unbounded and may predate the log entirely.
+	if tsMs <= events[0].tsMs {
+		return "", false
+	}
+	// First event at or after tsMs closes the interval.
+	i := sort.Search(len(events), func(i int) bool { return events[i].tsMs >= tsMs })
+	if i >= len(events) {
+		// Trailing usage with nothing filed after it.
+		return "", false
+	}
+	return events[i].repo, true
+}
+
+// handleRepoCost serves GET /api/repo-cost.
+func (s *Server) handleRepoCost(w http.ResponseWriter, r *http.Request) {
+	now := time.Now()
+	var summary *tokens.AggregateSummary
+	if s.deps != nil && s.deps.Tokens != nil {
+		summary = s.deps.Tokens.Summary()
+	}
+	var entries []AuditEntry
+	if s.audit != nil {
+		entries = s.audit.OutputActionsSince(now.Add(-repoCostWindow), activityOutputActions, s.auditPathForActivity())
+	}
+	jsonResponse(w, computeRepoCost(summary, entries, now))
+}
+
+// auditPathForActivity returns the audit file path the activity collector was
+// configured with, so the cost join reads exactly the same log. "" means the
+// production default (see OutputActionsSince).
+func (s *Server) auditPathForActivity() string {
+	if s.deps != nil && s.deps.Activity != nil {
+		return s.deps.Activity.auditPath
+	}
+	return ""
+}

--- a/src/pkg/dashboard/repo_cost.go
+++ b/src/pkg/dashboard/repo_cost.go
@@ -53,6 +53,7 @@ package dashboard
 import (
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/kubestellar/hive/pkg/tokens"
@@ -90,7 +91,13 @@ type repoCostEntry struct {
 	CacheRead   int64  `json:"cache_read"`
 	CacheCreate int64  `json:"cache_create"`
 	Tokens      int64  `json:"tokens"`
-	// Events is how many audited repo= events closed an interval for this repo.
+	// Events is how many DISTINCT audited repo= events actually closed an
+	// interval that carried usage for this repo — the evidence behind the
+	// figure. It deliberately does NOT count every audited event mentioning
+	// the repo: an agent's first event closes nothing (the leading interval is
+	// never attributed), and events that closed only empty intervals are not
+	// evidence of spend. Counting those would overstate the support for a
+	// dollar figure.
 	Events int `json:"events"`
 	// Agents lists the agents that contributed, sorted, so an operator can see
 	// which sandbox drove the cost.
@@ -163,14 +170,28 @@ type repoUsagePoint struct {
 type repoCostAccumulator struct {
 	usd                                   float64
 	input, output, cacheRead, cacheCreate int64
-	events                                int
 	agents                                map[string]bool
 	// anyTier records that at least one contributing model was priced from the
 	// coarse tier fallback rather than an exact list price.
 	anyTier bool
+	// closers holds each distinct audited event that closed a non-empty
+	// interval for this repo, keyed agent+timestamp so two agents filing at
+	// the same instant are two pieces of evidence, not one. Events counts real
+	// evidence rather than every event that merely names the repo.
+	closers map[string]bool
 	// touched distinguishes "no cost attributed" from "zero cost attributed",
 	// which is what lets USD stay nil and the UI render an honest "—".
 	touched bool
+}
+
+// noteCloser records that a specific audited event closed a non-empty interval
+// for this bucket. Called only from the attributed path — the two mandatory
+// buckets have no closing events by definition.
+func (a *repoCostAccumulator) noteCloser(agent string, tsMs int64) {
+	if a.closers == nil {
+		a.closers = map[string]bool{}
+	}
+	a.closers[agent+"@"+strconv.FormatInt(tsMs, 10)] = true
 }
 
 func (a *repoCostAccumulator) add(p repoUsagePoint) {
@@ -200,7 +221,7 @@ func (a *repoCostAccumulator) entry(name string) repoCostEntry {
 		CacheRead:   a.cacheRead,
 		CacheCreate: a.cacheCreate,
 		Tokens:      a.input + a.output + a.cacheRead + a.cacheCreate,
-		Events:      a.events,
+		Events:      len(a.closers),
 		Source:      "estimated",
 	}
 	if a.anyTier {
@@ -312,27 +333,20 @@ func computeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 			}
 			p := repoUsagePoint{tsMs: u.TimestampMs, agent: sess.Agent, model: model, usage: u}
 
-			repo, ok := attributeRepo(events, u.TimestampMs, windowStartMs)
+			closer, ok := attributeRepo(events, u.TimestampMs, windowStartMs)
 			if !ok {
 				unattributed.add(p)
 				continue
 			}
-			acc := byRepo[repo]
+			acc := byRepo[closer.repo]
 			if acc == nil {
 				acc = &repoCostAccumulator{}
-				byRepo[repo] = acc
+				byRepo[closer.repo] = acc
 			}
 			acc.add(p)
-		}
-	}
-
-	// Count how many audited events actually closed an interval for each repo,
-	// so the UI can show the evidence behind a figure.
-	for _, ev := range byAgentEvents {
-		for _, e := range ev {
-			if acc := byRepo[e.repo]; acc != nil {
-				acc.events++
-			}
+			// Only an event that closed an interval carrying real usage counts
+			// as evidence behind this repo's figure.
+			acc.noteCloser(sess.Agent, closer.tsMs)
 		}
 	}
 
@@ -380,26 +394,26 @@ func computeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 // case: usage before an agent's first event DOES find a closing event, so it
 // would be billed to the first repo. That is exactly the behaviour #4836
 // forbids, so it is excluded explicitly below.
-func attributeRepo(events []repoAuditEvent, tsMs, windowStartMs int64) (string, bool) {
+func attributeRepo(events []repoAuditEvent, tsMs, windowStartMs int64) (repoAuditEvent, bool) {
 	if tsMs == 0 || len(events) == 0 {
-		return "", false
+		return repoAuditEvent{}, false
 	}
 	if tsMs < windowStartMs {
-		return "", false
+		return repoAuditEvent{}, false
 	}
 	// Never attribute the leading interval: usage that precedes an agent's
 	// FIRST audited event has no opening event, so the span it belongs to is
 	// unbounded and may predate the log entirely.
 	if tsMs <= events[0].tsMs {
-		return "", false
+		return repoAuditEvent{}, false
 	}
 	// First event at or after tsMs closes the interval.
 	i := sort.Search(len(events), func(i int) bool { return events[i].tsMs >= tsMs })
 	if i >= len(events) {
 		// Trailing usage with nothing filed after it.
-		return "", false
+		return repoAuditEvent{}, false
 	}
-	return events[i].repo, true
+	return events[i], true
 }
 
 // handleRepoCost serves GET /api/repo-cost.

--- a/src/pkg/dashboard/repo_cost_test.go
+++ b/src/pkg/dashboard/repo_cost_test.go
@@ -1,0 +1,269 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/tokens"
+)
+
+func rcTime(base time.Time, min int) time.Time { return base.Add(time.Duration(min) * time.Minute) }
+
+func rcEvent(ts time.Time, agent, repo string) AuditEntry {
+	return AuditEntry{
+		Timestamp: ts.UTC().Format(time.RFC3339),
+		Action:    ghpkg.AuditActionAgentPRCreated,
+		Agent:     agent,
+		Detail:    "agent=" + agent + ", repo=" + repo + ", number=1",
+	}
+}
+
+func rcUsage(ts time.Time, in, out int64) tokens.UsageEvent {
+	return tokens.UsageEvent{TimestampMs: ts.UnixMilli(), Model: "claude-opus-4-1", Coalesced: 1, Input: in, Output: out}
+}
+
+// rcSession builds a Claude session whose summed fields agree with its timeline,
+// exactly as the phase-2 scanner produces.
+func rcSession(id, agent string, usage ...tokens.UsageEvent) tokens.SessionSummary {
+	s := tokens.SessionSummary{SessionID: id, Agent: agent, Model: "claude-opus-4-1", Backend: tokens.BackendClaude, Usage: usage}
+	for _, u := range usage {
+		s.InputTokens += u.Input
+		s.OutputTokens += u.Output
+		s.CacheRead += u.CacheRead
+		s.CacheCreate += u.CacheCreate
+	}
+	s.TotalTokens = s.InputTokens + s.OutputTokens + s.CacheRead + s.CacheCreate
+	return s
+}
+
+func findRepo(t *testing.T, resp repoCostResponse, repo string) repoCostEntry {
+	t.Helper()
+	for _, e := range resp.ByRepo {
+		if e.Repo == repo {
+			return e
+		}
+	}
+	t.Fatalf("repo %q not in by_repo: %+v", repo, resp.ByRepo)
+	return repoCostEntry{}
+}
+
+// TestRepoCostPartitionInvariant is the epic's hard requirement #1, written as
+// an actual test: every token the hive counted lands in exactly one bucket, and
+// the three buckets sum to the hive total. This is the assertion that makes the
+// per-repo number trustworthy — without it a repo figure could silently be a
+// fraction of reality.
+func TestRepoCostPartitionInvariant(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	base := now.Add(-24 * time.Hour)
+
+	summary := &tokens.AggregateSummary{
+		Sessions: []tokens.SessionSummary{
+			// Attributable: usage between two repo events.
+			rcSession("s1", "scanner",
+				rcUsage(rcTime(base, 5), 100, 10),  // leading -> unattributed
+				rcUsage(rcTime(base, 15), 200, 20), // between e@10 and e@20 -> repo-b
+				rcUsage(rcTime(base, 25), 300, 30), // trailing, no closer -> unattributed
+			),
+			// Agent with no repo events at all -> entirely unattributed.
+			rcSession("s2", "lonely", rcUsage(rcTime(base, 15), 400, 40)),
+			// Non-Claude backend -> backend_unsupported, in full.
+			{SessionID: "s3", Agent: "reviewer", Model: "gpt-5", Backend: tokens.BackendCopilot,
+				InputTokens: 500, OutputTokens: 50, TotalTokens: 550},
+			// Claude session with NO timeline (e.g. a pre-phase-2 persisted
+			// snapshot) must not vanish.
+			{SessionID: "s4", Agent: "scanner", Model: "claude-opus-4-1", Backend: tokens.BackendClaude,
+				InputTokens: 600, OutputTokens: 60, TotalTokens: 660},
+		},
+	}
+	var hiveTotal int64
+	for _, s := range summary.Sessions {
+		hiveTotal += s.TotalTokens
+	}
+
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+
+	resp := computeRepoCost(summary, entries, now)
+
+	sum := resp.Unattributed.Tokens + resp.BackendUnsupported.Tokens
+	for _, e := range resp.ByRepo {
+		sum += e.Tokens
+	}
+	if sum != hiveTotal {
+		t.Fatalf("partition broken: Σby_repo+unattributed+backend_unsupported = %d, hive total = %d", sum, hiveTotal)
+	}
+	if resp.TotalTokens != hiveTotal {
+		t.Fatalf("TotalTokens = %d, want %d", resp.TotalTokens, hiveTotal)
+	}
+	if resp.AttributedTokens+resp.Unattributed.Tokens+resp.BackendUnsupported.Tokens != hiveTotal {
+		t.Fatalf("AttributedTokens does not complete the partition")
+	}
+}
+
+// TestRepoCostAttributesToClosingEvent pins the join rule: usage between two
+// events belongs to the LATER (closing) one.
+func TestRepoCostAttributesToClosingEvent(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	base := now.Add(-24 * time.Hour)
+
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		rcSession("s1", "scanner", rcUsage(rcTime(base, 15), 1000, 100)),
+	}}
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+
+	resp := computeRepoCost(summary, entries, now)
+	b := findRepo(t, resp, "org/repo-b")
+	if b.Tokens != 1100 {
+		t.Fatalf("closing repo tokens = %d, want 1100", b.Tokens)
+	}
+	for _, e := range resp.ByRepo {
+		if e.Repo == "org/repo-a" && e.Tokens > 0 {
+			t.Fatalf("tokens billed to the OPENING event's repo: %+v", e)
+		}
+	}
+}
+
+// TestRepoCostNeverAttributesLeadingInterval is the epic's explicit "never
+// attribute the leading interval to the first repo seen".
+func TestRepoCostNeverAttributesLeadingInterval(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	base := now.Add(-24 * time.Hour)
+
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		rcSession("s1", "scanner", rcUsage(rcTime(base, 5), 999, 1)),
+	}}
+	entries := []AuditEntry{rcEvent(rcTime(base, 10), "scanner", "org/repo-a")}
+
+	resp := computeRepoCost(summary, entries, now)
+	if len(resp.ByRepo) != 0 {
+		t.Fatalf("leading interval was attributed: %+v", resp.ByRepo)
+	}
+	if resp.Unattributed.Tokens != 1000 {
+		t.Fatalf("unattributed = %d, want 1000", resp.Unattributed.Tokens)
+	}
+}
+
+// TestRepoCostBackendUnsupportedCarriesNonClaude asserts non-Claude spend is
+// reported in FULL rather than dropped — it is real money, just unplaceable.
+func TestRepoCostBackendUnsupportedCarriesNonClaude(t *testing.T) {
+	now := time.Now().UTC()
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		{SessionID: "c1", Agent: "a", Model: "gpt-5", Backend: tokens.BackendCopilot, InputTokens: 100, OutputTokens: 10, TotalTokens: 110},
+		{SessionID: "b1", Agent: "a", Model: "bob", Backend: tokens.BackendBob, InputTokens: 200, OutputTokens: 20, TotalTokens: 220},
+	}}
+	resp := computeRepoCost(summary, nil, now)
+	if resp.BackendUnsupported.Tokens != 330 {
+		t.Fatalf("backend_unsupported tokens = %d, want 330", resp.BackendUnsupported.Tokens)
+	}
+	if resp.BackendUnsupported.USD == nil || *resp.BackendUnsupported.USD <= 0 {
+		t.Fatal("backend_unsupported must carry a real dollar figure, not nil/zero")
+	}
+}
+
+// TestRepoCostNilNotZero: hard requirement #3. An untouched bucket reports null
+// so the UI renders "—", never "$0.00".
+func TestRepoCostNilNotZero(t *testing.T) {
+	resp := computeRepoCost(&tokens.AggregateSummary{}, nil, time.Now())
+	if resp.Unattributed.USD != nil {
+		t.Fatalf("unattributed USD = %v, want nil (no cost attributed != $0.00)", *resp.Unattributed.USD)
+	}
+	if resp.BackendUnsupported.USD != nil {
+		t.Fatalf("backend_unsupported USD = %v, want nil", *resp.BackendUnsupported.USD)
+	}
+	// The mandatory buckets must still be PRESENT even when empty.
+	if resp.Unattributed.Repo != repoCostBucketUnattributed || resp.BackendUnsupported.Repo != repoCostBucketBackendUnsupported {
+		t.Fatalf("mandatory buckets missing: %+v %+v", resp.Unattributed, resp.BackendUnsupported)
+	}
+}
+
+// TestRepoCostUnknownTimestampIsUnattributed: a usage event that carries no
+// parseable timestamp cannot be placed and must not be guessed into a repo.
+func TestRepoCostUnknownTimestampIsUnattributed(t *testing.T) {
+	now := time.Now().UTC()
+	base := now.Add(-24 * time.Hour)
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		rcSession("s1", "scanner",
+			tokens.UsageEvent{TimestampMs: 0, Coalesced: 1, Input: 500},
+			rcUsage(rcTime(base, 15), 100, 0),
+		),
+	}}
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+	resp := computeRepoCost(summary, entries, now)
+	if resp.Unattributed.Tokens != 500 {
+		t.Fatalf("unattributed = %d, want 500 (the zero-timestamp event)", resp.Unattributed.Tokens)
+	}
+	if findRepo(t, resp, "org/repo-b").Tokens != 100 {
+		t.Fatal("timestamped event should still attribute")
+	}
+}
+
+// TestRepoCostPerAgentIsolation: one agent's repo events must never attribute
+// another agent's tokens.
+func TestRepoCostPerAgentIsolation(t *testing.T) {
+	now := time.Now().UTC()
+	base := now.Add(-24 * time.Hour)
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		rcSession("s1", "other", rcUsage(rcTime(base, 15), 700, 0)),
+	}}
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+	resp := computeRepoCost(summary, entries, now)
+	if len(resp.ByRepo) != 0 {
+		t.Fatalf("another agent's events attributed these tokens: %+v", resp.ByRepo)
+	}
+	if resp.Unattributed.Tokens != 700 {
+		t.Fatalf("unattributed = %d, want 700", resp.Unattributed.Tokens)
+	}
+}
+
+// TestRepoCostReportsWindow: hard requirement #6 — the window travels with the
+// number, and the oldest observable event bounds it.
+func TestRepoCostReportsWindow(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	base := now.Add(-24 * time.Hour)
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+	}
+	resp := computeRepoCost(&tokens.AggregateSummary{}, entries, now)
+	if resp.WindowHours != int(repoCostWindow/time.Hour) {
+		t.Fatalf("WindowHours = %d", resp.WindowHours)
+	}
+	if resp.OldestEventAt != rcTime(base, 10).UTC().Format(time.RFC3339) {
+		t.Fatalf("OldestEventAt = %q, want the earliest event", resp.OldestEventAt)
+	}
+	if len(resp.Limitations) == 0 {
+		t.Fatal("limitations must ship with the numbers")
+	}
+}
+
+// TestRepoCostTierPricingIsTagged: hard requirement #4 — a model priced from the
+// coarse tier fallback must not be presented with the same confidence as an
+// exact list price.
+func TestRepoCostTierPricingIsTagged(t *testing.T) {
+	now := time.Now().UTC()
+	base := now.Add(-24 * time.Hour)
+	u := tokens.UsageEvent{TimestampMs: rcTime(base, 15).UnixMilli(), Model: "totally-made-up-model-xyz", Coalesced: 1, Input: 1000}
+	s := rcSession("s1", "scanner", u)
+	s.Model = "totally-made-up-model-xyz"
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{s}}
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+	resp := computeRepoCost(summary, entries, now)
+	if got := findRepo(t, resp, "org/repo-b").Source; got != "estimated_tier" {
+		t.Fatalf("Source = %q, want estimated_tier for an unpriced model", got)
+	}
+}

--- a/src/pkg/dashboard/repo_cost_test.go
+++ b/src/pkg/dashboard/repo_cost_test.go
@@ -248,6 +248,36 @@ func TestRepoCostReportsWindow(t *testing.T) {
 	}
 }
 
+// TestRepoCostEventsCountOnlyRealClosers asserts that `events` is evidence, not
+// decoration: it counts the DISTINCT audited events that actually closed an
+// interval carrying usage. An agent's first event closes nothing (the leading
+// interval is never attributed) and events closing empty intervals are not
+// evidence of spend — counting either would overstate the support behind a
+// dollar figure.
+func TestRepoCostEventsCountOnlyRealClosers(t *testing.T) {
+	now := time.Now().UTC()
+	base := now.Add(-24 * time.Hour)
+
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		// Only ONE usage event, closing at the event at +20.
+		rcSession("s1", "scanner", rcUsage(rcTime(base, 15), 100, 0)),
+	}}
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"), // first event: closes nothing
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-a"), // closes the interval with usage
+		rcEvent(rcTime(base, 30), "scanner", "org/repo-a"), // closes an EMPTY interval
+	}
+
+	resp := computeRepoCost(summary, entries, now)
+	a := findRepo(t, resp, "org/repo-a")
+	if a.Events != 1 {
+		t.Fatalf("Events = %d, want 1 (only the event that closed a non-empty interval)", a.Events)
+	}
+	if a.Tokens != 100 {
+		t.Fatalf("Tokens = %d, want 100", a.Tokens)
+	}
+}
+
 // TestRepoCostTierPricingIsTagged: hard requirement #4 — a model priced from the
 // coarse tier fallback must not be presented with the same confidence as an
 // exact list price.

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -8559,8 +8559,10 @@ function burnAreaChart() {
     // CSS-only via max-height), so a collapsed subsection keeps receiving fresh
     // data and shows current numbers the moment it is re-expanded. Defaults on
     // first visit: "cost per session" collapsed, "usage by sandbox" expanded.
+    // "cost by repo" starts collapsed because it is an INFERRED attribution
+    // whose caveats need reading before its numbers are acted on (#4836).
     const COST_SUB_LS_PREFIX = 'hive-cost-sub-';
-    const COST_SUB_DEFAULT_COLLAPSED = { session: true, sandbox: false };
+    const COST_SUB_DEFAULT_COLLAPSED = { session: true, sandbox: false, repo: true };
     function isCostSubCollapsed(key) {
       const v = localStorage.getItem(COST_SUB_LS_PREFIX + key);
       if (v === null) return !!COST_SUB_DEFAULT_COLLAPSED[key];
@@ -8857,6 +8859,16 @@ function burnAreaChart() {
         </div>
       </div>`;
 
+      // ── Estimated cost by repo (#4836 phase 3) ──
+      // An INFERRED attribution, not a measurement: tokens spent between two
+      // audited repo= events are billed to the repo named by the later event.
+      // Two buckets are mandatory and are rendered as real rows, never folded
+      // into the repos or hidden: `unattributed` (spend that cannot honestly be
+      // placed) and `backend_unsupported` (Copilot/bob — real spend with no
+      // intra-session timing to join against). A repo with no attributable cost
+      // shows "—", never "$0.00": those are different facts.
+      const repoTable = costRepoTableHtml(lastRepoCost);
+
       el.innerHTML = `<div class="cost-panel">
         <div class="cost-title cost-toggle" role="button" tabindex="0" aria-expanded="true" aria-controls="cost-panel-body" data-action="toggleCostPanel" data-keydown-action="costHeaderKey" data-arg-types="e" data-keys="*" title="Collapse / expand the cost panel">
           <span class="cost-chevron" aria-hidden="true">▼</span>
@@ -8878,6 +8890,7 @@ function burnAreaChart() {
             <tbody>${modelRows || '<tr><td colspan="5" style="color:var(--muted)">no usage yet</td></tr>'}</tbody>
           </table>
           ${sandboxTable}
+          ${repoTable}
           ${sessionTable}
           ${unpricedNote}
           ${costTokenBudgetHtml()}
@@ -8888,9 +8901,82 @@ function burnAreaChart() {
       applyCostSubCollapse();
     }
 
+    // ── Per-repo estimated cost (#4836 phase 3) ──
+    // Held outside renderCost so a transient /api/repo-cost failure leaves the
+    // last good table in place rather than blanking the section.
+    let lastRepoCost = null;
+
+    // Render a single row of the by-repo table. usd is a POINTER server-side:
+    // null means "no attributable cost", which is NOT $0.00 — a repo can be
+    // busy and still show — when its spend could not be placed in time. Render
+    // the two states differently or the operator will read absence as free.
+    function costRepoRowHtml(r, opts) {
+      const o = opts || {};
+      const usd = (r.usd === null || r.usd === undefined)
+        ? `<span class="cagents-zero" title="No cost could be attributed to this row. This is NOT $0.00 — it means unobserved, not free.">—</span>`
+        : (r.source === 'estimated_tier'
+            ? `<span title="tier estimate — at least one contributing model has no exact list price">~${fmtUSD(r.usd)}</span>`
+            : fmtUSD(r.usd));
+      const label = o.label
+        ? `<span title="${esc(o.title || '')}" style="color:var(--muted)">${esc(o.label)}</span>`
+        : esc(r.repo || 'unknown');
+      const agents = (r.agents || []).length
+        ? `<span class="cagents-badge" title="${esc((r.agents || []).join(', '))}">${(r.agents || []).length}</span>`
+        : `<span class="cagents-zero">—</span>`;
+      return `<tr${o.muted ? ' style="opacity:.85"' : ''}>
+        <td class="cmodel">${label}</td>
+        <td class="cnum" style="text-align:center">${agents}</td>
+        <td class="cnum">${fmtTokens(r.tokens)}</td>
+        <td class="cnum">${usd}</td>
+      </tr>`;
+    }
+
+    function costRepoTableHtml(rc) {
+      if (!rc || !rc.ready) return '';
+      const repos = rc.by_repo || [];
+      const rows = repos.map(r => costRepoRowHtml(r)).join('');
+      // The two mandatory buckets ALWAYS render, even at zero, so the table can
+      // never be mistaken for a complete picture of where the money went.
+      const unattr = costRepoRowHtml(rc.unattributed || { repo: 'unattributed', usd: null }, {
+        muted: true, label: 'unattributed',
+        title: "Tokens spent before an agent's first repo event, after its last, or by agents with no repo events at all. Never spread across repos."
+      });
+      const unsup = costRepoRowHtml(rc.backend_unsupported || { repo: 'backend_unsupported', usd: null }, {
+        muted: true, label: 'backend unsupported',
+        title: 'Copilot and bob record no per-message timing, so their spend cannot be placed against a repo. This spend is REAL — it is not missing, it is not attributable.'
+      });
+      const total = Number(rc.total_tokens) || 0;
+      const rate = total > 0 ? Math.round((Number(rc.attributed_tokens) || 0) / total * 100) : null;
+      const windowTxt = rc.window_hours
+        ? `${Math.round(rc.window_hours / 24)}d window`
+        : 'window unknown';
+      const oldest = rc.oldest_event_at
+        ? ` · oldest audited event ${esc(String(rc.oldest_event_at).slice(0, 10))}`
+        : '';
+      return `<div class="cost-subsection" data-cost-sub="repo">
+        <div class="cost-subtable-title cost-sub-toggle" role="button" tabindex="0" aria-expanded="false" aria-controls="cost-sub-repo-body" data-action="costSubToggle" data-keydown-action="costSubToggle" data-arg-types="e,s" data-arg1="repo" data-keys="*" title="Estimated cost attributed to each repo by joining audited repo events against per-message token timing. Inferred, not measured. Click to collapse / expand."><span class="cost-chevron" aria-hidden="true">▼</span>cost by repo <span class="cost-badge est">inferred</span></div>
+        <div class="cost-sub-body" id="cost-sub-repo-body">
+        <div class="cost-subtitle">Claude sessions only. Cost is attributed by TIMING: tokens spent between two audited repo events are billed to the repo named by the later event. ${rate === null ? '' : `<strong>${rate}%</strong> of tokens attributable`} · ${windowTxt}${oldest}.</div>
+        <div class="cost-disclaimer" style="margin:4px 0 8px">Known bias — an agent that investigates repo A, finds nothing to file, then files on repo B bills <em>all</em> of A's investigation to B. That is this method's failure mode, not a rounding error: treat a repo's figure as an upper bound when a neighbouring repo shows activity but little cost. A row showing "—" means unobserved, not free. Not a bill.</div>
+        <table class="cost-table">
+          <thead><tr><th>repo</th><th style="text-align:center">sandboxes</th><th style="text-align:right">tokens</th><th style="text-align:right">est. $</th></tr></thead>
+          <tbody>${rows || '<tr><td colspan="4" style="color:var(--muted)">no attributable repo cost yet</td></tr>'}${unattr}${unsup}</tbody>
+        </table>
+        </div>
+      </div>`;
+    }
+
+    async function fetchRepoCost() {
+      try {
+        const r = await fetch('/api/repo-cost');
+        if (!r.ok) return;
+        lastRepoCost = await r.json();
+      } catch (e) { /* transient — keep the last good attribution */ }
+    }
+
     async function fetchCost() {
       try {
-        const [resp] = await Promise.all([fetch('/api/cost'), fetchCostHistory()]);
+        const [resp] = await Promise.all([fetch('/api/cost'), fetchCostHistory(), fetchRepoCost()]);
         if (!resp.ok) return;
         const cost = await resp.json();
         renderCost(cost);

--- a/src/pkg/tokens/bob_scanner.go
+++ b/src/pkg/tokens/bob_scanner.go
@@ -228,7 +228,12 @@ func scanBobSessions(bobHomeDir string, logger *slog.Logger) (*AggregateSummary,
 			sessionID = extractBobSessionID(path)
 		}
 		agg.Sessions = append(agg.Sessions, SessionSummary{
-			SessionID:    sessionID,
+			SessionID: sessionID,
+			// No per-message timestamps are parsed here (and estimate-fallback
+			// sessions carry no explicit usage at all), so bob tokens cannot be
+			// placed on a timeline — repo attribution reports them as
+			// backend_unsupported rather than guessing.
+			Backend:      BackendBob,
 			Agent:        agentName,
 			Model:        model,
 			InputTokens:  inputTokens,

--- a/src/pkg/tokens/claude_scanner.go
+++ b/src/pkg/tokens/claude_scanner.go
@@ -40,9 +40,9 @@ type claudeMessagePayload struct {
 
 // claudeUsagePayload is the token usage block inside a Claude Code assistant message.
 type claudeUsagePayload struct {
-	InputTokens             int64 `json:"input_tokens"`
-	OutputTokens            int64 `json:"output_tokens"`
-	CacheReadInputTokens    int64 `json:"cache_read_input_tokens"`
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
 	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
 }
 

--- a/src/pkg/tokens/claude_scanner.go
+++ b/src/pkg/tokens/claude_scanner.go
@@ -158,6 +158,7 @@ func parseClaudeSessionFile(path string, agentDetector func(string) string) (*Se
 	summary := &SessionSummary{
 		SessionID: sessionID,
 		Agent:     "unknown",
+		Backend:   BackendClaude,
 	}
 
 	scanner := bufio.NewScanner(f)
@@ -166,6 +167,10 @@ func parseClaudeSessionFile(path string, agentDetector func(string) string) (*Se
 	firstHumanMsg := ""
 	var firstTimestamp int64
 	var lastTimestamp int64
+	// timeline retains the per-message usage grain that the loop below would
+	// otherwise sum away. It is additive — the summed fields are still the
+	// authoritative totals — and bounded by coalescing, not truncation.
+	var timeline usageTimeline
 
 	for scanner.Scan() {
 		var raw claudeRawEntry
@@ -176,6 +181,7 @@ func parseClaudeSessionFile(path string, agentDetector func(string) string) (*Se
 		switch raw.Type {
 		case "assistant":
 			// Parse nested message payload for model and usage
+			entryTS := parseTimestampToUnixMilli(raw.Timestamp)
 			var msg claudeMessagePayload
 			if len(raw.Message) > 0 {
 				if err := json.Unmarshal(raw.Message, &msg); err == nil {
@@ -186,10 +192,21 @@ func parseClaudeSessionFile(path string, agentDetector func(string) string) (*Se
 					summary.OutputTokens += msg.Usage.OutputTokens
 					summary.CacheRead += msg.Usage.CacheReadInputTokens
 					summary.CacheCreate += msg.Usage.CacheCreationInputTokens
+					// Retain the same numbers at their own timestamp. This is
+					// the ONLY place the per-message time distribution exists;
+					// everything downstream is summed.
+					timeline.add(UsageEvent{
+						TimestampMs: entryTS,
+						Model:       msg.Model,
+						Input:       msg.Usage.InputTokens,
+						Output:      msg.Usage.OutputTokens,
+						CacheRead:   msg.Usage.CacheReadInputTokens,
+						CacheCreate: msg.Usage.CacheCreationInputTokens,
+					})
 				}
 			}
 			summary.Messages++
-			lastTimestamp = parseTimestampToUnixMilli(raw.Timestamp)
+			lastTimestamp = entryTS
 			if firstTimestamp == 0 {
 				firstTimestamp = lastTimestamp
 			}
@@ -225,6 +242,19 @@ func parseClaudeSessionFile(path string, agentDetector func(string) string) (*Se
 				if raw.Model != "" && summary.Model == "" {
 					summary.Model = raw.Model
 				}
+				// Flat-format entries carry a timestamp only when the writer
+				// supplied one; parseTimestampToUnixMilli yields 0 otherwise.
+				// A zero stamp is retained deliberately (the tokens are real)
+				// but marks the event as unplaceable in time, so an interval
+				// join must send it to `unattributed` rather than guessing.
+				timeline.add(UsageEvent{
+					TimestampMs: parseTimestampToUnixMilli(raw.Timestamp),
+					Model:       raw.Model,
+					Input:       raw.InputTokens,
+					Output:      raw.OutputTokens,
+					CacheRead:   raw.CacheRead,
+					CacheCreate: raw.CacheCreate,
+				})
 			}
 			if raw.Role == "user" || raw.Role == "assistant" {
 				summary.Messages++
@@ -248,6 +278,7 @@ func parseClaudeSessionFile(path string, agentDetector func(string) string) (*Se
 	summary.TotalTokens = summary.InputTokens + summary.OutputTokens + summary.CacheRead + summary.CacheCreate
 	summary.FirstActive = firstTimestamp
 	summary.LastActive = lastTimestamp
+	summary.Usage, summary.UsageCoalesced = timeline.finish()
 
 	if agentDetector != nil && firstHumanMsg != "" {
 		summary.Agent = agentDetector(firstHumanMsg)

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -104,6 +104,39 @@ type SessionSummary struct {
 	UsageCoalesced int `json:"usage_coalesced,omitempty"`
 }
 
+// stripUsageTimelines returns a shallow copy of agg whose sessions carry no
+// Usage timeline, for persistence only.
+//
+// The timeline is a LIVE-ONLY structure. It is rebuilt from the source session
+// JSONL on every scan, so persisting it buys nothing on restart — but it would
+// cost a great deal: up to maxUsageEventsPerSession events per Claude session
+// at ~60-90 bytes of JSON each, re-marshalled and rewritten to
+// /data/token-summary.json every scanInterval. On a hive with many sessions
+// that turns a modest snapshot into a multi-megabyte write every 30 seconds,
+// for data that is discarded and recomputed at the next scan anyway.
+//
+// UsageCoalesced is likewise dropped: it describes a timeline that is not
+// present, and keeping it would imply a fidelity claim about nothing.
+//
+// The summed token fields are untouched, so a restored snapshot is exactly as
+// complete as it was before the timeline existed. A restored session therefore
+// has Backend set but Usage empty, which the repo-cost join treats as
+// not-time-resolved and reports under backend_unsupported rather than
+// silently dropping or misattributing its tokens.
+func stripUsageTimelines(agg *AggregateSummary) *AggregateSummary {
+	if agg == nil {
+		return nil
+	}
+	out := *agg
+	out.Sessions = make([]SessionSummary, len(agg.Sessions))
+	copy(out.Sessions, agg.Sessions)
+	for i := range out.Sessions {
+		out.Sessions[i].Usage = nil
+		out.Sessions[i].UsageCoalesced = 0
+	}
+	return &out
+}
+
 // UsageTotal sums the retained usage timeline. It exists so tests and consumers
 // can assert the timeline reconciles against TotalTokens without duplicating the
 // summation. Returns 0 for a session with no timeline.
@@ -511,7 +544,7 @@ func (c *Collector) saveSnapshot(agg *AggregateSummary) {
 	if c.persistPath == "" || agg == nil {
 		return
 	}
-	data, err := json.Marshal(agg)
+	data, err := json.Marshal(stripUsageTimelines(agg))
 	if err != nil {
 		c.logger.Warn("failed to marshal token snapshot", "error", err)
 		return

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -33,6 +33,36 @@ type SessionEntry struct {
 	Agent string `json:"agent,omitempty"`
 }
 
+// UsageEvent is one timestamped slice of token usage inside a session — the
+// per-assistant-message grain that the Claude session files record and that
+// every scanner previously summed away. Retaining it is what makes intra-session
+// analysis possible: burn-rate curves over the life of a run, and (see
+// pkg/dashboard/repo_cost.go) attributing a session's cost to the repos an agent
+// actually touched while it was spending.
+//
+// TimestampMs is unix-milliseconds. An event whose source line carried no
+// parseable timestamp is still emitted with TimestampMs 0 so its tokens are
+// never lost; consumers that need ordering must treat 0 as "unknown time" and
+// refuse to place it in an interval rather than sorting it to the front.
+type UsageEvent struct {
+	TimestampMs int64 `json:"ts_ms"`
+	Model       string `json:"model,omitempty"`
+	// Coalesced counts how many raw per-message events this entry represents.
+	// It is 1 for an untouched event and >1 for a bucket produced by
+	// coalescing (see maxUsageEventsPerSession). It is never 0 for a real event.
+	Coalesced   int   `json:"coalesced,omitempty"`
+	Input       int64 `json:"input"`
+	Output      int64 `json:"output"`
+	CacheRead   int64 `json:"cache_read"`
+	CacheCreate int64 `json:"cache_create"`
+}
+
+// Total is the sum of the four token counts, matching how SessionSummary
+// computes TotalTokens.
+func (u UsageEvent) Total() int64 {
+	return u.Input + u.Output + u.CacheRead + u.CacheCreate
+}
+
 type SessionSummary struct {
 	SessionID    string `json:"session_id"`
 	Agent        string `json:"agent"`
@@ -48,6 +78,41 @@ type SessionSummary struct {
 	// (0 when the scanner could not determine them).
 	FirstActive int64 `json:"first_active,omitempty"`
 	LastActive  int64 `json:"last_active,omitempty"`
+
+	// Backend names the tool that produced this session ("claude", "copilot",
+	// "bob", "inference", ""). Consumers use it to tell which sessions carry a
+	// usable Usage timeline; "" means an older/flat-format session of unknown
+	// provenance and must be treated as NOT time-resolved.
+	Backend string `json:"backend,omitempty"`
+
+	// Usage is the time-ordered per-message usage timeline, populated only by
+	// scanners that can observe the grain (currently Claude — see
+	// BackendClaude). It is ADDITIVE: the summed fields above remain the
+	// authoritative session totals and are unchanged by its presence. When
+	// non-empty its token sums equal the summed fields exactly, so a consumer
+	// may use either but must never add both.
+	//
+	// Bounded by maxUsageEventsPerSession via coalescing, never truncation:
+	// tokens are preserved even when individual message boundaries are not.
+	Usage []UsageEvent `json:"usage,omitempty"`
+
+	// UsageCoalesced is how many raw per-message events were folded into
+	// coarser buckets to keep Usage within maxUsageEventsPerSession. 0 means
+	// the timeline is at full per-message fidelity. It is reported rather than
+	// hidden because a silently-degraded timeline would make an interval join
+	// look more precise than it is.
+	UsageCoalesced int `json:"usage_coalesced,omitempty"`
+}
+
+// UsageTotal sums the retained usage timeline. It exists so tests and consumers
+// can assert the timeline reconciles against TotalTokens without duplicating the
+// summation. Returns 0 for a session with no timeline.
+func (s *SessionSummary) UsageTotal() int64 {
+	var t int64
+	for _, u := range s.Usage {
+		t += u.Total()
+	}
+	return t
 }
 
 // AgentModelBucket holds per-agent or per-model token breakdown.

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -45,7 +45,7 @@ type SessionEntry struct {
 // never lost; consumers that need ordering must treat 0 as "unknown time" and
 // refuse to place it in an interval rather than sorting it to the front.
 type UsageEvent struct {
-	TimestampMs int64 `json:"ts_ms"`
+	TimestampMs int64  `json:"ts_ms"`
 	Model       string `json:"model,omitempty"`
 	// Coalesced counts how many raw per-message events this entry represents.
 	// It is 1 for an untouched event and >1 for a bucket produced by

--- a/src/pkg/tokens/copilot_scanner.go
+++ b/src/pkg/tokens/copilot_scanner.go
@@ -166,6 +166,10 @@ func parseCopilotSessionFile(path string) (*SessionSummary, error) {
 	summary := &SessionSummary{
 		Agent: "unknown",
 		Model: "unknown",
+		// All token usage lands in one lump at session.shutdown, so there is no
+		// intra-session time distribution to recover. Repo attribution reports
+		// copilot tokens as backend_unsupported.
+		Backend: BackendCopilot,
 	}
 
 	scanner := bufio.NewScanner(f)

--- a/src/pkg/tokens/usage_timeline.go
+++ b/src/pkg/tokens/usage_timeline.go
@@ -1,0 +1,127 @@
+package tokens
+
+import "sort"
+
+// Backend identifiers carried on SessionSummary.Backend. They name the tool that
+// produced a session, which is what decides whether that session's tokens can be
+// placed on a timeline at all.
+const (
+	// BackendClaude is the Claude Code CLI. Its session JSONL records
+	// per-assistant-message usage WITH a per-entry timestamp, so it is the only
+	// backend that currently yields a UsageEvent timeline.
+	BackendClaude = "claude"
+	// BackendCopilot is the Copilot CLI. Its events.jsonl accrues all token
+	// usage in a single lump at session.shutdown, so no intra-session time
+	// distribution exists to recover. Interval attribution is structurally
+	// impossible for it without proxy-side capture.
+	BackendCopilot = "copilot"
+	// BackendBob is the bobshell backend. Its messages carry per-message usage
+	// but the parser does not currently read per-message timestamps, and
+	// sessions without explicit usage fall back to character estimates.
+	BackendBob = "bob"
+	// BackendInference is the MITM/inference sink path (bare-mode agents).
+	BackendInference = "inference"
+)
+
+// maxUsageEventsPerSession bounds the retained per-message timeline for one
+// session. A long agent run can emit many thousands of assistant messages, and
+// the summary is persisted to /data/token-summary.json and shipped in API
+// payloads, so an unbounded timeline is a real memory and payload hazard.
+//
+// The bound is enforced by COALESCING adjacent events into coarser time
+// buckets, never by dropping them: total tokens are preserved exactly, only
+// message-level resolution degrades. SessionSummary.UsageCoalesced reports how
+// many raw events were folded so a consumer can see the timeline is coarse
+// rather than assuming full fidelity. 2000 events keeps a worst-case session
+// timeline near ~100KB while giving an interval join far finer grain than the
+// minutes-to-hours spacing of audit events it is joined against.
+const maxUsageEventsPerSession = 2000
+
+// usageTimeline accumulates per-message usage during a scan and enforces the
+// per-session bound by coalescing. Zero value is ready to use.
+type usageTimeline struct {
+	events    []UsageEvent
+	coalesced int
+}
+
+// add records one per-message usage event. Events with no tokens at all are
+// dropped — they carry no cost and would only dilute the timeline — but every
+// event with any token count is retained, including ones with an unknown
+// (zero) timestamp.
+func (t *usageTimeline) add(e UsageEvent) {
+	if e.Total() == 0 {
+		return
+	}
+	if e.Coalesced == 0 {
+		e.Coalesced = 1
+	}
+	t.events = append(t.events, e)
+	if len(t.events) > maxUsageEventsPerSession*2 {
+		t.compact()
+	}
+}
+
+// compact halves the timeline by merging adjacent pairs of events. The merged
+// event keeps the EARLIER timestamp and the model of the larger contributor, so
+// an interval join places the merged tokens no later than the earliest message
+// they came from. Token counts are summed, never discarded.
+func (t *usageTimeline) compact() {
+	t.sortEvents()
+	merged := make([]UsageEvent, 0, len(t.events)/2+1)
+	for i := 0; i < len(t.events); i += 2 {
+		a := t.events[i]
+		if i+1 >= len(t.events) {
+			merged = append(merged, a)
+			break
+		}
+		b := t.events[i+1]
+		// The earlier timestamp wins; a zero (unknown) timestamp must not
+		// win, since it would claim the merged tokens happened at the epoch.
+		ts := a.TimestampMs
+		if ts == 0 || (b.TimestampMs != 0 && b.TimestampMs < ts) {
+			ts = b.TimestampMs
+		}
+		model := a.Model
+		if b.Total() > a.Total() && b.Model != "" {
+			model = b.Model
+		}
+		t.coalesced += a.Coalesced + b.Coalesced - 1
+		merged = append(merged, UsageEvent{
+			TimestampMs: ts,
+			Model:       model,
+			Coalesced:   a.Coalesced + b.Coalesced,
+			Input:       a.Input + b.Input,
+			Output:      a.Output + b.Output,
+			CacheRead:   a.CacheRead + b.CacheRead,
+			CacheCreate: a.CacheCreate + b.CacheCreate,
+		})
+	}
+	t.events = merged
+}
+
+// sortEvents orders the timeline by timestamp ascending. Events with an unknown
+// (zero) timestamp sort LAST, not first: sorting them to the front would make
+// them look like the session's opening messages and hand their tokens to
+// whatever interval starts the session.
+func (t *usageTimeline) sortEvents() {
+	sort.SliceStable(t.events, func(i, j int) bool {
+		a, b := t.events[i].TimestampMs, t.events[j].TimestampMs
+		if a == 0 || b == 0 {
+			return b == 0 && a != 0
+		}
+		return a < b
+	})
+}
+
+// finish returns the bounded, time-ordered timeline and the number of raw
+// events that were coalesced into it.
+func (t *usageTimeline) finish() ([]UsageEvent, int) {
+	for len(t.events) > maxUsageEventsPerSession {
+		t.compact()
+	}
+	t.sortEvents()
+	if len(t.events) == 0 {
+		return nil, 0
+	}
+	return t.events, t.coalesced
+}

--- a/src/pkg/tokens/usage_timeline_test.go
+++ b/src/pkg/tokens/usage_timeline_test.go
@@ -131,6 +131,35 @@ func TestUsageTimelineUnknownTimestampsSortLast(t *testing.T) {
 	}
 }
 
+// TestSnapshotOmitsUsageTimeline pins that the live-only timeline never reaches
+// the persisted snapshot. It is recomputed from the source JSONL on every scan,
+// so persisting it buys nothing — but it would rewrite megabytes to
+// /data/token-summary.json every scan interval. The summed totals must survive
+// untouched, and the in-memory aggregate must NOT be mutated by saving.
+func TestSnapshotOmitsUsageTimeline(t *testing.T) {
+	agg := &AggregateSummary{
+		TotalTokens: 300,
+		Sessions: []SessionSummary{{
+			SessionID: "s1", Backend: BackendClaude,
+			InputTokens: 200, OutputTokens: 100, TotalTokens: 300,
+			Usage:          []UsageEvent{{TimestampMs: 1000, Coalesced: 2, Input: 200, Output: 100}},
+			UsageCoalesced: 1,
+		}},
+	}
+
+	stripped := stripUsageTimelines(agg)
+	if len(stripped.Sessions[0].Usage) != 0 || stripped.Sessions[0].UsageCoalesced != 0 {
+		t.Fatalf("timeline reached the snapshot: %+v", stripped.Sessions[0])
+	}
+	if stripped.Sessions[0].TotalTokens != 300 || stripped.TotalTokens != 300 {
+		t.Fatalf("stripping changed the totals: %+v", stripped.Sessions[0])
+	}
+	// The live aggregate must be unaffected — the join still needs its timeline.
+	if len(agg.Sessions[0].Usage) != 1 {
+		t.Fatal("stripUsageTimelines mutated the live aggregate")
+	}
+}
+
 // TestUsageTimelineDropsZeroTokenEvents keeps the timeline free of no-cost
 // entries, which would only dilute it.
 func TestUsageTimelineDropsZeroTokenEvents(t *testing.T) {

--- a/src/pkg/tokens/usage_timeline_test.go
+++ b/src/pkg/tokens/usage_timeline_test.go
@@ -1,0 +1,143 @@
+package tokens
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeClaudeSession writes a JSONL session file and returns its path.
+func writeClaudeSession(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	projDir := filepath.Join(dir, "proj")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	p := filepath.Join(projDir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// TestClaudeUsageTimelineRetainsPerMessageGrain is the core Phase 2 assertion:
+// the scanner keeps a per-message, timestamped usage entry AND the pre-existing
+// summed totals, and the two reconcile exactly.
+func TestClaudeUsageTimelineRetainsPerMessageGrain(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"type":"assistant","timestamp":"2026-08-01T10:00:00Z","message":{"model":"claude-opus-4-1","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":20,"cache_creation_input_tokens":10}}}
+{"type":"assistant","timestamp":"2026-08-01T11:00:00Z","message":{"model":"claude-opus-4-1","usage":{"input_tokens":200,"output_tokens":75,"cache_read_input_tokens":0,"cache_creation_input_tokens":5}}}
+{"type":"human","timestamp":"2026-08-01T10:30:00Z","message":{"text":"go"}}
+`
+	path := writeClaudeSession(t, dir, "s1.jsonl", body)
+
+	sum, err := parseClaudeSessionFile(path, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// Summed fields must be untouched by Phase 2.
+	if sum.InputTokens != 300 || sum.OutputTokens != 125 || sum.CacheRead != 20 || sum.CacheCreate != 15 {
+		t.Fatalf("summed fields changed: %+v", sum)
+	}
+	if sum.TotalTokens != 460 {
+		t.Fatalf("TotalTokens = %d, want 460", sum.TotalTokens)
+	}
+	if sum.Backend != BackendClaude {
+		t.Fatalf("Backend = %q, want %q", sum.Backend, BackendClaude)
+	}
+
+	// Timeline must exist at per-message grain and reconcile with the totals.
+	if len(sum.Usage) != 2 {
+		t.Fatalf("len(Usage) = %d, want 2: %+v", len(sum.Usage), sum.Usage)
+	}
+	if got := sum.UsageTotal(); got != sum.TotalTokens {
+		t.Fatalf("UsageTotal() = %d, want TotalTokens %d", got, sum.TotalTokens)
+	}
+	if sum.UsageCoalesced != 0 {
+		t.Fatalf("UsageCoalesced = %d, want 0 (no coalescing needed)", sum.UsageCoalesced)
+	}
+
+	// Ordered ascending by time, with the real per-message split preserved.
+	if sum.Usage[0].TimestampMs >= sum.Usage[1].TimestampMs {
+		t.Fatalf("timeline not time-ordered: %+v", sum.Usage)
+	}
+	if sum.Usage[0].Input != 100 || sum.Usage[1].Input != 200 {
+		t.Fatalf("per-message split lost: %+v", sum.Usage)
+	}
+	if sum.Usage[0].Model != "claude-opus-4-1" {
+		t.Fatalf("model not carried: %+v", sum.Usage[0])
+	}
+}
+
+// TestClaudeUsageTimelineCoalescesRatherThanTruncates asserts the memory bound
+// preserves tokens. A session far over the cap must still reconcile exactly
+// against TotalTokens, and must report that it was coalesced — silent
+// truncation of a cost timeline is forbidden.
+func TestClaudeUsageTimelineCoalescesRatherThanTruncates(t *testing.T) {
+	dir := t.TempDir()
+	const n = maxUsageEventsPerSession*2 + 500
+	body := ""
+	for i := 0; i < n; i++ {
+		body += fmt.Sprintf(
+			`{"type":"assistant","timestamp":"2026-08-01T%02d:%02d:%02dZ","message":{"model":"m","usage":{"input_tokens":1,"output_tokens":1}}}`+"\n",
+			i/3600%24, i/60%60, i%60)
+	}
+	path := writeClaudeSession(t, dir, "big.jsonl", body)
+
+	sum, err := parseClaudeSessionFile(path, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if sum.TotalTokens != int64(n*2) {
+		t.Fatalf("TotalTokens = %d, want %d", sum.TotalTokens, n*2)
+	}
+	if len(sum.Usage) > maxUsageEventsPerSession {
+		t.Fatalf("timeline unbounded: %d events > cap %d", len(sum.Usage), maxUsageEventsPerSession)
+	}
+	// The whole point: no tokens lost to the bound.
+	if got := sum.UsageTotal(); got != sum.TotalTokens {
+		t.Fatalf("coalescing lost tokens: UsageTotal %d != TotalTokens %d", got, sum.TotalTokens)
+	}
+	if sum.UsageCoalesced == 0 {
+		t.Fatal("UsageCoalesced = 0 — degraded timeline must be reported, not hidden")
+	}
+	// Coalesced counts must add up to the number of real events.
+	var raw int
+	for _, u := range sum.Usage {
+		raw += u.Coalesced
+	}
+	if raw != n {
+		t.Fatalf("sum of Coalesced = %d, want %d raw events", raw, n)
+	}
+}
+
+// TestUsageTimelineUnknownTimestampsSortLast pins the ordering rule that keeps
+// unplaceable tokens out of a repo's interval: a zero timestamp must never sort
+// to the front where it would look like the session's opening message.
+func TestUsageTimelineUnknownTimestampsSortLast(t *testing.T) {
+	var tl usageTimeline
+	tl.add(UsageEvent{TimestampMs: 0, Input: 5})
+	tl.add(UsageEvent{TimestampMs: 2000, Input: 5})
+	tl.add(UsageEvent{TimestampMs: 1000, Input: 5})
+	events, _ := tl.finish()
+	if len(events) != 3 {
+		t.Fatalf("len = %d, want 3", len(events))
+	}
+	if events[0].TimestampMs != 1000 || events[1].TimestampMs != 2000 || events[2].TimestampMs != 0 {
+		t.Fatalf("bad order: %+v", events)
+	}
+}
+
+// TestUsageTimelineDropsZeroTokenEvents keeps the timeline free of no-cost
+// entries, which would only dilute it.
+func TestUsageTimelineDropsZeroTokenEvents(t *testing.T) {
+	var tl usageTimeline
+	tl.add(UsageEvent{TimestampMs: 1000})
+	events, coalesced := tl.finish()
+	if len(events) != 0 || coalesced != 0 {
+		t.Fatalf("zero-token event retained: %+v", events)
+	}
+}


### PR DESCRIPTION
Implements phases 2 and 3 of the per-repo cost attribution epic. Phase 1 (per-repo audited event counts) shipped in #4854. Phase 4 (proxy-side Copilot capture) is **not** in this PR.

`Refs #4836`

## Phase 2 — retain timestamped per-message usage (`pkg/tokens`)

`parseClaudeSessionFile` already parsed per-assistant-message `message.usage` **and** `raw.Timestamp`, then summed them into session totals and threw the time distribution away. Once summed it cannot be recovered from any other source.

It now retains that grain as `SessionSummary.Usage`, a time-ordered `[]UsageEvent` carrying the four token counts plus model per message. The change is **strictly additive** — the existing summed fields are untouched and remain authoritative, so every current consumer (`/api/cost`, `/api/tokens`, the Prometheus exporter) is unaffected. Where a timeline exists its sums equal the summed fields exactly, asserted by test.

Standalone value beyond phase 3: intra-session burn-rate curves.

The timeline is **live-only**: it is stripped before `saveSnapshot` writes `/data/token-summary.json`. It is rebuilt from the source JSONL on every scan, so persisting it would buy nothing while rewriting megabytes every 30s. A restored snapshot keeps its summed totals unchanged; its sessions come back with `Backend` set but no timeline, which the phase-3 join already treats as not-time-resolved — so those tokens land in `backend_unsupported` and the partition invariant holds across a restart.

Memory is bounded by **coalescing, never truncation**. Above 2000 events per session, adjacent events merge into coarser buckets — tokens are summed so nothing is lost, only message-level resolution degrades — and `UsageCoalesced` reports how many raw events were folded, so a consumer can see the timeline is coarse rather than assuming full fidelity. Silent truncation of a cost timeline is the exact failure this epic exists to prevent.

Two ordering rules matter downstream and are pinned by tests: an event with an unparseable (zero) timestamp is **retained** (the tokens are real) but sorts **last**, never masquerading as a session's opening message; and a merged bucket takes the **earlier** of its two timestamps, so coalescing can only move tokens earlier, never later, in a subsequent join.

## Phase 3 — the interval join (`GET /api/repo-cost`)

Per agent, order its audited `repo=` events by time. Tokens spent between two consecutive events are attributed to the repo named by the **closing** event.

### What is and is NOT attributable

**Claude sessions only.** This is the headline limitation, not a footnote.

- **Copilot** accrues all token usage in a single lump at `session.shutdown`. There is no intra-session time distribution to join against — this is structural, not a gap in the implementation.
- **bob** parses no per-message timestamps, and its estimate-fallback sessions carry no explicit usage at all.

Their spend is **real and reported in full** under `backend_unsupported`. It is not missing; it is not attributable. Making it attributable is phase 4.

### The two mandatory buckets

Both are always present in the payload and always render as real rows in the UI, even at zero, so the table can never be mistaken for a complete account of where the money went.

| bucket | contains |
|---|---|
| `unattributed` | tokens before an agent's first `repo=` event, after its last, from agents with no repo events at all, with an unparseable timestamp, or falling before the retained audit window |
| `backend_unsupported` | every non-Claude backend's tokens (Copilot, bob), plus any Claude session carrying no timeline (e.g. a pre-phase-2 persisted snapshot) |

Each repo row also carries `events`: the count of **distinct audited events that actually closed an interval carrying usage**. It deliberately excludes an agent's first event (which closes nothing) and events closing empty intervals — counting either would make the evidence behind a dollar figure look stronger than it is.

The **leading interval is never given to the first repo seen**. It has no opening event, so its span is unbounded and may predate the log entirely; inventing a closing event for it is precisely how a per-repo cost number becomes plausibly wrong.

### The epic's must-not list, as tests

- `Σ by_repo + unattributed + backend_unsupported == hive total` — `TestRepoCostPartitionInvariant`. Every token the hive counted lands in exactly one bucket.
- **No double-counting across the scanner/sink boundary.** This reads the token collector's already-merged `AggregateSummary` — the same figure `/api/cost` prices — and never re-reads scanner sources, so `copilot_scanner.go`'s live-capture zero-out is respected rather than bypassed.
- **nil is not zero.** `usd` is a pointer. A repo with no attributable cost reports `null` and renders `—`. `$0.00` would assert the repo was free; `null` says it was unobserved.
- **No implied exactness for unpriced models.** Any repo with a `FallbackPrice` contributor is tagged `source: "estimated_tier"`, and those models still contribute to totals as they do today.
- **No implied billed spend.** Carries the existing `estimated` naming and the "Not a bill" disclaimer.
- **The window ships with the number** — `window_hours` plus `oldest_event_at`. Audit retention is size-triggered (5MB × 3 backups), so the effective lookback varies per hive and is *shortest on the busiest ones*, exactly where per-repo cost matters most. A figure whose window is unknown is not comparable across the fleet.

### Known bias — documented in the UI, not just in code

An agent that investigates repo A, finds nothing worth filing, then files on repo B bills **all** of A's investigation to B. Nothing in the data distinguishes that from genuine B work.

This is rendered in the cost panel itself alongside the numbers, and repeated in the API's `limitations` array — an operator reading a dollar figure has to be able to see the method's failure mode. The panel defaults to collapsed because the caveats need reading before the numbers are acted on.

## Expected attribution rate

Governed by three multiplicative factors, so the honest expectation is **modest**:

1. **Backend mix.** Only Claude spend is eligible at all. A hive running mostly Copilot agents will see most of its dollars in `backend_unsupported` — correctly.
2. **Event density.** Only tokens strictly *between* two of an agent's `repo=` events attribute. Long stretches of investigation that never close in a filed artifact land in `unattributed` by design.
3. **Audit retention.** Usage older than the surviving audit window cannot be joined and goes to `unattributed` rather than being billed to whichever event happened to survive rotation.

The endpoint reports `attributed_tokens` / `total_tokens` so the real rate is measured per hive rather than assumed — and a low rate is a correct, visible result, not a bug.

## Not shipped here

- **Phase 4 / Copilot attribution** — requires proxy-side per-completion capture; out of scope by the epic's own phasing.
- **Bob timestamp parsing** — the scanner comment notes it is a one-field parser change, but it also needs the estimate-fallback sessions excluded from any join, so it is left for a follow-up rather than bundled in.
- Hub-side rollup of per-repo cost across the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

