### PR TITLE
🐛 fix(hub,dashboard): render human names for non-GitHub identities (IBMid/Google/Microsoft)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -4422,7 +4422,7 @@ func main() {
 				logger.Warn("branch switch via heartbeat failed", "tag", tag, "image", image, "error", err)
 				return
 			}
-		}), hub.AuthorizedUsersCallback(func(users []string) {
+		}), hub.AuthorizedUsersCallback(func(users []string, names map[string]string) {
 			// The hub delivered its authoritative access list. Reconcile our
 			// login allowlist so Manage Access grants take effect on this
 			// heartbeat-only spoke without any kubectl push. The dashboard reads
@@ -4433,6 +4433,11 @@ func main() {
 					"was", len(cfg.Dashboard.AuthorizedUsers), "now", len(users))
 				cfg.Dashboard.AuthorizedUsers = users
 			}
+			// AuthorizedUserNames is purely cosmetic (see its doc) — it never
+			// gates sign-in, so it's fine to just take whatever the hub sent
+			// (including nil, which means "no names known") without the
+			// same-value guard above.
+			cfg.Dashboard.AuthorizedUserNames = names
 		}), hub.ProjectConfigCallback(func(pc *hub.HeartbeatProjectConfig) {
 			// The hub assigned this (previously placeholder) hive a real project.
 			// Reconcile our running project config so agents work the claimed

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -3549,6 +3549,19 @@ type DashboardConfig struct {
 	// Populated on both hub-proxied hosted hives (for the Access view + hub
 	// Manage Access) and standalone direct-route spokes (for device-flow authz).
 	AuthorizedUsers []string `yaml:"authorized_users"`
+	// AuthorizedUserNames is an OPTIONAL, purely cosmetic map from an
+	// AuthorizedUsers entry's raw identity key (the same string before any
+	// ":role" suffix, e.g. "ibmid:5500087VJB" or a plain GitHub login) to a
+	// human-readable display name. It rides alongside AuthorizedUsers — never
+	// inside it — so the identity key used for allowlist matching and grants
+	// (AuthorizedRole, IsDirectRouteAuthzEnabled) is completely unaffected by
+	// this field's presence, absence, or content. Delivered by the hub in the
+	// same heartbeat beat as AuthorizedUsers (mirrors it 1:1) so the read-only
+	// Access tab can render "Jane Doe" instead of a raw IBMid/Google/Microsoft
+	// subject. A key with no entry here (or an empty value) simply has no known
+	// human name yet — the UI falls back to the raw key. omitempty/nil-safe:
+	// existing configs and hubs that never send this round-trip unchanged.
+	AuthorizedUserNames map[string]string `yaml:"authorized_user_names,omitempty"`
 	// HubProxied is true when this hive sits behind the hub's nginx auth-proxy,
 	// which authenticates every request and injects trusted X-Hive-User/X-Hive-Role
 	// headers (hub-reachable-cluster hosted hives). When true the hive TRUSTS those headers and

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -2954,9 +2954,20 @@ func (s *Server) handleAuthorizedUsersList(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	entries := s.deps.Config.Dashboard.AuthorizedUsers
+	// names is the purely cosmetic key→display-name companion delivered by the
+	// hub's heartbeat (AuthorizedUserNames). It is never consulted for
+	// authorization — only AuthorizedUsers (the raw key) is — so a nil/empty
+	// map here just means every row falls back to its raw key, exactly as
+	// before this field existed.
+	names := s.deps.Config.Dashboard.AuthorizedUserNames
 	type userView struct {
 		Username string `json:"username"`
 		Role     string `json:"role"`
+		// DisplayName is the human-readable name for Username, when the hub
+		// knows one (see AuthorizedUserNames). omitempty: absent means "no
+		// known name", and the UI must render Username (the raw identity key)
+		// instead — never blank, never "undefined".
+		DisplayName string `json:"display_name,omitempty"`
 	}
 	out := make([]userView, 0, len(entries))
 	for i, e := range entries {
@@ -2978,7 +2989,7 @@ func (s *Server) handleAuthorizedUsersList(w http.ResponseWriter, r *http.Reques
 				role = "read"
 			}
 		}
-		out = append(out, userView{Username: name, Role: role})
+		out = append(out, userView{Username: name, Role: role, DisplayName: strings.TrimSpace(names[name])})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Username < out[j].Username })
 	jsonResponse(w, map[string]any{

--- a/src/pkg/dashboard/clickable_avatars_test.go
+++ b/src/pkg/dashboard/clickable_avatars_test.go
@@ -30,7 +30,15 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 	}{
 		{"contributor cards", "const avatarHtml = linkedAvatar(c.github_username, CONTRIBUTOR_AVATAR_PX,"},
 		{"leaderboard rows", "? linkedAvatar(e.github_username, CONTRIBUTOR_AVATAR_PX, `@${e.github_username}`, e.avatar_url)"},
-		{"access tab allowlist", "linkedAvatar(u.username, ACCESS_LIST_AVATAR_PX,"},
+		// The access allowlist renders non-GitHub identities (ibmid:, google:,
+		// microsoft:) too, and those have no github.com profile — a linked
+		// avatar there produced a 404 that also pointed at whatever account
+		// occupies that URL shape. It now goes through accessRowAvatar, which
+		// DELEGATES to linkedAvatar for GitHub keys and renders an escaped
+		// initials tile otherwise. The guard's intent is unchanged: no site
+		// hand-rolls an <img>. TestAccessRowAvatarDelegates below pins the
+		// delegation so this indirection cannot become a bypass.
+		{"access tab allowlist", "accessRowAvatar(u.username, u.display_name || '', ACCESS_LIST_AVATAR_PX)"},
 		{"audit log actor", "? linkedAvatar(actor, AUDIT_AVATAR_PX, actor, '', 'margin-right:4px')"},
 	}
 	for _, tc := range cases {
@@ -39,6 +47,31 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 				t.Errorf("index.html is missing %q — did an avatar site stop using the shared helper?", tc.snippet)
 			}
 		})
+	}
+}
+
+// TestAccessRowAvatarDelegates pins that accessRowAvatar still routes GitHub
+// keys through the shared linkedAvatar helper, and escapes everything on the
+// non-GitHub path. Without this, swapping the access list off linkedAvatar
+// (see TestAvatarSitesUseSharedHelper) would be a way to bypass the shared
+// helper's anchor, onerror fallback and escaping rather than an indirection
+// through it.
+func TestAccessRowAvatarDelegates(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "function accessRowAvatar(key, displayName, px)") {
+		t.Fatal("accessRowAvatar is missing — the access list has no avatar helper")
+	}
+	// GitHub keys must still go through the shared helper, not a local <img>.
+	if !strings.Contains(html, "if (provider === 'github') return linkedAvatar(key, px, title, '', 'margin-right:6px');") {
+		t.Error("accessRowAvatar no longer delegates GitHub keys to linkedAvatar")
+	}
+	// A display name is attacker-influenced in a way an opaque subject is not,
+	// so both the tooltip and the initial must be escaped.
+	if !strings.Contains(html, `'<span title="' + esc(title) + '"`) {
+		t.Error("accessRowAvatar must escape its title — display names are user-controlled")
+	}
+	if !strings.Contains(html, `var initial = esc((displayName || key || '?')`) {
+		t.Error("accessRowAvatar must escape the initial it renders")
 	}
 }
 

--- a/src/pkg/dashboard/identity_display_test.go
+++ b/src/pkg/dashboard/identity_display_test.go
@@ -1,0 +1,130 @@
+package dashboard
+
+// Tests for the OIDC identity DISPLAY fix on the spoke: Settings → Security →
+// Access must show a human name for non-GitHub identities (IBMid, Google,
+// Microsoft) when the hub has resolved one, and must always keep the raw
+// identity key discoverable and fall back to it cleanly when no name is
+// known. This is presentation only — AuthorizedUsers (the allowlist/auth-key
+// list AuthorizedRole matches against) is never touched by any of this.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestAuthorizedUsersListCarriesDisplayName asserts handleAuthorizedUsersList
+// attaches display_name from Dashboard.AuthorizedUserNames when the hub sent
+// one for that raw key, and omits it (never emits an empty/undefined name)
+// for a key the hub has no name for.
+func TestAuthorizedUsersListCarriesDisplayName(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Dashboard.AuthorizedUsers = []string{
+		"owner1:owner",
+		"ibmid:5500087VJB:read",
+		"google:NONAMECLAIM:read",
+	}
+	deps.Config.Dashboard.AuthorizedUserNames = map[string]string{
+		"ibmid:5500087VJB": "Jane Doe",
+		// Deliberately no entry for owner1 or the google key: both must fall
+		// back to their raw key rather than rendering blank.
+	}
+
+	rec := doGet(s, "/api/config/authorized-users")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var body struct {
+		Users []struct {
+			Username    string `json:"username"`
+			Role        string `json:"role"`
+			DisplayName string `json:"display_name"`
+		} `json:"users"`
+		Enforced bool `json:"enforced"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	byUsername := map[string]string{}
+	for _, u := range body.Users {
+		byUsername[u.Username] = u.DisplayName
+		// The identity key itself must be the untouched raw allowlist entry —
+		// this endpoint must never rewrite Username to the friendly name.
+	}
+
+	if got := byUsername["ibmid:5500087VJB"]; got != "Jane Doe" {
+		t.Errorf(`ibmid user display_name = %q, want "Jane Doe"`, got)
+	}
+	if got, ok := byUsername["owner1"]; ok && got != "" {
+		t.Errorf("owner1 (no known name) display_name = %q, want empty/absent", got)
+	}
+	if got, ok := byUsername["google:NONAMECLAIM"]; ok && got != "" {
+		t.Errorf("google user with no known name display_name = %q, want empty/absent", got)
+	}
+	if _, ok := byUsername["ibmid:5500087VJB"]; !ok {
+		t.Fatal("ibmid user missing from the authorized-users response entirely")
+	}
+}
+
+// TestAuthorizedUsersListNilNamesMapFallsBackCleanly asserts a hub that has
+// never sent AuthorizedUserNames (nil map, e.g. an older hub or one with no
+// SaaS record for this hive) still renders every row from its raw key — the
+// pre-existing behavior — rather than erroring or producing empty rows.
+func TestAuthorizedUsersListNilNamesMapFallsBackCleanly(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Dashboard.AuthorizedUsers = []string{"owner1:owner", "microsoft:AAAABBBB:read"}
+	deps.Config.Dashboard.AuthorizedUserNames = nil
+
+	rec := doGet(s, "/api/config/authorized-users")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var body struct {
+		Users []struct {
+			Username    string `json:"username"`
+			DisplayName string `json:"display_name"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(body.Users) != 2 {
+		t.Fatalf("users = %d, want 2", len(body.Users))
+	}
+	for _, u := range body.Users {
+		if u.DisplayName != "" {
+			t.Errorf("%s: display_name = %q, want empty (no names map delivered)", u.Username, u.DisplayName)
+		}
+		if u.Username == "" {
+			t.Error("a row lost its raw identity key")
+		}
+	}
+}
+
+// TestAccessRowRenderingUsesDisplayNameAndKeepsRawKeyDiscoverable pins the
+// Access tab's row markup: it must prefer display_name over the raw key,
+// classify the provider icon without assuming github, avoid linking a
+// non-GitHub key to a bogus github.com profile, and always keep the raw key
+// reachable (a title attribute and, when a friendly name is shown, a muted
+// secondary line) — never an empty/blank row.
+func TestAccessRowRenderingUsesDisplayNameAndKeepsRawKeyDiscoverable(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"var hasName = !!(u.display_name && u.display_name !== u.username);",
+		"var primary = hasName ? u.display_name : u.username;",
+		"function identityKeyProvider(key)",
+		"function accessRowAvatar(key, displayName, px)",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("Access tab row rendering missing expected snippet: %q", snippet)
+		}
+	}
+	// A non-GitHub identity must not get the plain linkedAvatar (which always
+	// points at github.com/<key>.png — wrong host for an ibmid/google/ms
+	// subject and a dead link).
+	if !strings.Contains(html, "if (provider === 'github') return linkedAvatar(key, px, title, '', 'margin-right:6px');") {
+		t.Error("accessRowAvatar must special-case github vs non-github rather than always linking to a github.com profile")
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -12086,6 +12086,39 @@ function burnAreaChart() {
       return avatarProfileLink(username, label, avatarImg(src, px, extraStyle));
     }
 
+    /* identityKeyProvider classifies a raw identity key by its prefix —
+       "google:…" → google, "ibmid:…" → ibmid, "microsoft:…"/"ms:…" →
+       microsoft, anything with no "provider:" prefix (a plain GitHub login,
+       or legacy "github:<login>") → github. Mirrors the hub dashboard's
+       identityProviderFromKey (pkg/hub/saas.go) so the two badges classify a
+       given key identically; kept as a separate copy because this file and
+       the hub dashboard are different bundles with no shared JS module. */
+    function identityKeyProvider(key) {
+      key = String(key || '');
+      if (key.indexOf('github.com/') === 0 || key.indexOf('github:') === 0) return 'github';
+      var m = key.match(/^([a-z][a-z0-9_-]*):/);
+      if (!m) return 'github';
+      return m[1] === 'ms' ? 'microsoft' : m[1];
+    }
+
+    /* accessRowAvatar renders the avatar for one authorized-users row. A
+       GitHub identity keeps the existing linked github.com avatar + profile
+       link. A non-GitHub identity (ibmid/google/microsoft) has no github.com
+       profile to link to — linking one anyway 404s and points at someone
+       else's account by coincidence of URL-shape — so it gets a plain,
+       unlinked initials tile instead. displayName (may be '') seeds the
+       initial; the raw key is the tooltip either way. */
+    function accessRowAvatar(key, displayName, px) {
+      var provider = identityKeyProvider(key);
+      var title = String(key || '') + (displayName ? ' (' + displayName : '') + (displayName ? ')' : '');
+      if (provider === 'github') return linkedAvatar(key, px, title, '', 'margin-right:6px');
+      var initial = esc((displayName || key || '?').trim().charAt(0).toUpperCase() || '?');
+      return '<span title="' + esc(title) + '" style="display:inline-flex;align-items:center;justify-content:center;' +
+        'width:' + px + 'px;height:' + px + 'px;border-radius:50%;margin-right:6px;flex:none;' +
+        'background:var(--line);color:var(--muted);font-size:' + Math.max(10, Math.round(px * 0.5)) + 'px;font-weight:600">' +
+        initial + '</span>';
+    }
+
     /* Rendered avatar sizes, in CSS pixels. The contributor cards and the
        leaderboard rows share a size because they are the same kind of roster;
        the Security tab's Access subsection allowlist is a denser config list. */
@@ -16319,10 +16352,22 @@ function burnAreaChart() {
         }
         listEl.innerHTML = users.map(function(u) {
           var roleCls = u.role === 'owner' ? 'role-owner' : u.role === 'merger' ? 'role-merger' : u.role === 'read-write' ? 'role-read-write' : 'role-read';
+          // u.username is the raw identity key (the actual auth key / allowlist
+          // match — NEVER altered here). u.display_name is an OPTIONAL cosmetic
+          // name the hub resolved (see AuthorizedUserNames); absent for a user
+          // who hasn't completed a login yet, or whose provider returned no
+          // name claim, in which case the raw key is shown exactly as before.
+          var hasName = !!(u.display_name && u.display_name !== u.username);
+          var primary = hasName ? u.display_name : u.username;
+          // The raw key stays reachable even when a friendly name is shown:
+          // the avatar title carries it always, and a muted secondary line
+          // shows it beside the name for support/debugging.
+          var secondary = hasName
+            ? '<span style="display:block;font-size:0.68rem;color:var(--muted);word-break:break-word" title="Auth key">' + esc(u.username) + '</span>'
+            : '';
           return '<div class="config-list-item" style="align-items:center;gap:8px">' +
-            linkedAvatar(u.username, ACCESS_LIST_AVATAR_PX,
-              String(u.username || '') + (u.role ? ' — ' + u.role : ''), '', '') +
-            '<span style="flex:1;font-size:0.85rem">' + esc(u.username) + '</span>' +
+            accessRowAvatar(u.username, u.display_name || '', ACCESS_LIST_AVATAR_PX) +
+            '<span style="flex:1;min-width:0;font-size:0.85rem" title="' + esc(u.username) + '">' + esc(primary) + secondary + '</span>' +
             '<span class="role-badge ' + roleCls + '" style="font-size:0.7rem">' + esc(u.role) + '</span>' +
             '</div>';
         }).join('');

--- a/src/pkg/hub/access_hover_test.go
+++ b/src/pkg/hub/access_hover_test.go
@@ -18,11 +18,16 @@ func TestAccessForHive(t *testing.T) {
 
 	// includeNotes is irrelevant here (no user carries notes); false keeps the
 	// entries at their zero contact fields so the equality check below is exact.
+	// DisplayLabel/Provider are always populated now (#identity-display-names):
+	// none of these fixture users carry a DisplayName/Email/FullName/linked
+	// GitHub login, so DisplayLabel falls all the way back to the raw
+	// Username (provisionRequestUserIdentity's documented behavior) and
+	// Provider is "github" (a bare login with no provider prefix).
 	got := accessForHive("h1", users, false)
 	want := []HiveAccessEntry{
-		{Username: "owner1", Role: "owner"},
-		{Username: "adam", Role: "read-write"},
-		{Username: "zoe", Role: "read"},
+		{Username: "owner1", Role: "owner", DisplayLabel: "owner1", Provider: "github"},
+		{Username: "adam", Role: "read-write", DisplayLabel: "adam", Provider: "github"},
+		{Username: "zoe", Role: "read", DisplayLabel: "zoe", Provider: "github"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("accessForHive returned %d entries, want %d: %+v", len(got), len(want), got)

--- a/src/pkg/hub/clickable_avatars_test.go
+++ b/src/pkg/hub/clickable_avatars_test.go
@@ -20,7 +20,12 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 		name    string
 		snippet string
 	}{
-		{"inline per-hive faces", "return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX,"},
+		// GitHub keys still route through the shared helper; a non-GitHub key
+		// (ibmid/google/microsoft) has no github.com profile, so linkedAvatar
+		// would build a 404'ing image AND link to whatever account happens to
+		// occupy that URL shape. The guard's intent — no site hand-rolls an
+		// <img> — is unchanged; userAvatar is the other shared helper.
+		{"inline per-hive faces", "? linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a), extraStyle)"},
 		{"status-dot hover panel rows", "linkedAvatar(a.username, PANEL_ACCESS_AVATAR_PX,"},
 		{"per-hive pending request rows", "var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');"},
 		{"past requests table", "provisionRequesterAvatar(pr, PANEL_ACCESS_AVATAR_PX, 'margin-right:6px')"},
@@ -31,7 +36,7 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 		{"admin users table (github path)", "? linkedAvatar(u.github_username, TABLE_AVATAR_PX,"},
 		{"admin users table (oidc path)", ": userAvatar(u, TABLE_AVATAR_PX, 'margin-right:6px');"},
 		{"access modal pending requests", "var avatar = linkedAvatar(r.username, LIST_AVATAR_PX, r.username, 'margin-right:6px');"},
-		{"access modal access list", "var avatar = linkedAvatar(u.username, LIST_AVATAR_PX,"},
+		{"access modal access list", "? linkedAvatar(u.github_username, TABLE_AVATAR_PX,"},
 		{"nav bar viewer avatar", "avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,"},
 	}
 	for _, tc := range cases {

--- a/src/pkg/hub/grantable_users_test.go
+++ b/src/pkg/hub/grantable_users_test.go
@@ -382,7 +382,7 @@ func TestManageAccessProviderIcons(t *testing.T) {
 		`PROVIDER_ICON_SVG[provider] || '👤'`,
 		`(PROVIDER_EMOJI[provider] || '👤')`,
 		// Icons applied in both the existing rows and the Add User picker.
-		`providerIconHTML(identityProviderFromKey(u.username))`,
+		`providerIconHTML(provider)`,
 		`providerOptionEmoji(e.provider || identityProviderFromKey(e.id))`,
 	} {
 		if !strings.Contains(dashboardHTML, want) {

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -1062,7 +1062,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		// A non-nil slice (even empty) is an authoritative replacement of the
 		// spoke's allowlist; nil means the hub sent nothing, leave it alone.
 		if resp.AuthorizedUsers != nil && onAuthorizedUsers != nil {
-			onAuthorizedUsers(resp.AuthorizedUsers)
+			onAuthorizedUsers(resp.AuthorizedUsers, resp.AuthorizedUserNames)
 		}
 		// A non-nil ProjectConfig means the hub wants the spoke to adopt a newly
 		// claimed project (placeholder assignment); nil means leave it alone.
@@ -2213,6 +2213,18 @@ type HeartbeatResponse struct {
 	// changes propagate automatically. nil means "hub sent nothing" (leave the
 	// spoke's list unchanged); a non-nil (possibly empty) slice replaces it.
 	AuthorizedUsers []string `json:"authorized_users,omitempty"`
+	// AuthorizedUserNames is a PURELY COSMETIC companion to AuthorizedUsers: a
+	// map from each entry's raw identity key (never the "username:role" wire
+	// form — just the key before the ":role" suffix) to a human display name,
+	// so the spoke's read-only Access tab can show "Jane Doe" instead of a raw
+	// "ibmid:5500087VJB"/"google:1078…"/"microsoft:AAAA…" subject. It carries
+	// NO authority — the spoke's allowlist match (AuthorizedRole) reads only
+	// AuthorizedUsers/the key, and this map is never consulted for sign-in.
+	// Sent whenever AuthorizedUsers is (nil means "leave the spoke's copy
+	// unchanged", mirroring AuthorizedUsers' own nil semantics); a key absent
+	// here, or mapped to "", simply has no known name yet and the spoke falls
+	// back to the raw key.
+	AuthorizedUserNames map[string]string `json:"authorized_user_names,omitempty"`
 	// ProjectConfig is the claimed project's real org/repos/ACMM. The hub sets
 	// it (mirroring AuthorizedUsers) when a placeholder hive has been assigned
 	// to a user and the spoke is still reporting its old (placeholder) project.
@@ -2252,7 +2264,7 @@ type SwitchBranchCallback func(tag string)
 // access list ("username:role" entries) so the spoke can reconcile its
 // device-flow login allowlist with Manage Access grants. Used for
 // heartbeat-only clusters where the hub cannot push config over kubectl.
-type AuthorizedUsersCallback func(users []string)
+type AuthorizedUsersCallback func(users []string, names map[string]string)
 
 // GitHubAppConfigCallback is called when the hub delivers GitHub App config
 // via the heartbeat response (app ID, installation ID, private key).

--- a/src/pkg/hub/heartbeat_reconnect_upgrade_coverage_test.go
+++ b/src/pkg/hub/heartbeat_reconnect_upgrade_coverage_test.go
@@ -98,7 +98,7 @@ func TestStartHeartbeatProcessesFullResponse(t *testing.T) {
 		gotVisibility = &p
 		mu.Unlock()
 	})
-	onUsers := AuthorizedUsersCallback(func(u []string) {
+	onUsers := AuthorizedUsersCallback(func(u []string, names map[string]string) {
 		mu.Lock()
 		gotUsers = u
 		mu.Unlock()

--- a/src/pkg/hub/hive_access_avatars_test.go
+++ b/src/pkg/hub/hive_access_avatars_test.go
@@ -85,7 +85,7 @@ func TestInlineAccessAvatarEscaping(t *testing.T) {
 		{"anchor title uses escAttr", `'title="' + escAttr(title) + '" aria-label="' + escAttr(label || uname) + '" '`},
 		// The inline face still carries the role in its tooltip, now built by the
 		// shared accessAvatarTitle helper (username — role, plus contact metadata).
-		{"inline face labels username and role via title helper", `return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a),`},
+		{"inline face labels username and role via title helper", `? linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a), extraStyle)`},
 		{"access title helper carries username and role", `var lines = [uname + (role ? ' — ' + role : '')];`},
 		{"overflow chip title uses escAttr", `'<span title="' + escAttr(hiddenNames.join(', ')) + '" '`},
 		{"aria-label uses escAttr", `'<span class="hive-access-faces" aria-label="' + escAttr(label) + '" '`},
@@ -197,6 +197,30 @@ func TestHiveTableColumnCountUnchanged(t *testing.T) {
 	} {
 		if !strings.Contains(dashboardHTML, snippet) {
 			t.Errorf("dashboardHTML is missing %q — did the hive table gain or lose a column?", snippet)
+		}
+	}
+}
+
+// TestNonGitHubAvatarsNeverLinkToGitHub pins the reason the avatar sites stopped
+// calling linkedAvatar unconditionally (see TestAvatarSitesUseSharedHelper).
+//
+// A key like "ibmid:5500087VJB" is not a github.com login. Building an avatar
+// URL from it yields a 404 AND a profile link to whatever account happens to
+// occupy that URL shape — attributing a stranger's face and identity to an
+// internal user. Each site now branches on provider: GitHub keys keep the
+// linked github.com avatar, everything else renders the provider-stored avatar
+// or initials derived from the DISPLAY LABEL, never from the opaque subject.
+func TestNonGitHubAvatarsNeverLinkToGitHub(t *testing.T) {
+	for _, snippet := range []string{
+		// Inline per-hive faces branch before linking.
+		"var provider = a.provider || identityProviderFromKey(uname);",
+		// The non-GitHub arm seeds initials from the display label, not the key.
+		"userAvatar({display_name: a.display_label, avatar_url: a.avatar_url, github_username: uname},",
+		// The admin table makes the same distinction.
+		"var isGitHubUser = String(u.provider || 'github').toLowerCase() === 'github';",
+	} {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("dashboardHTML is missing %q — a non-GitHub identity may be linking to github.com", snippet)
 		}
 	}
 }

--- a/src/pkg/hub/identity_display_test.go
+++ b/src/pkg/hub/identity_display_test.go
@@ -1,0 +1,256 @@
+package hub
+
+// Tests for the OIDC identity DISPLAY fix: non-GitHub users (IBMid, Google,
+// Microsoft) rendering as their human name instead of a raw opaque provider
+// subject ("ibmid:5500087VJB", "google:1078…", "microsoft:AAAA…") wherever
+// access identities are listed.
+//
+// This is presentation only — the identity KEY (SaaSUser.GitHubUsername, the
+// value used for allowlist matching, RejectIdentitySet, and grants) is never
+// touched by anything here. Every case below asserts DisplayLabel/the wire
+// map is derived FROM the raw key, never that the raw key itself changed.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAccessForHiveDisplayLabelPrecedence pins the precedence
+// provisionRequestUserIdentity already documents, reused verbatim by
+// accessForHive: linked GitHub login → recognizable GitHub login → email →
+// DisplayName → FullName → raw key. accessForHive must not invent a second,
+// competing resolver.
+func TestAccessForHiveDisplayLabelPrecedence(t *testing.T) {
+	cases := []struct {
+		name     string
+		user     SaaSUser
+		wantName string
+		wantProv string
+	}{
+		{
+			name: "github user with no extra claims falls back to the login itself",
+			user: SaaSUser{
+				GitHubUsername: "clubanderson",
+				Hives:          map[string]string{"h1": "owner"},
+			},
+			wantName: "clubanderson",
+			wantProv: "github",
+		},
+		{
+			name: "ibmid user with an OIDC display name shows the name",
+			user: SaaSUser{
+				GitHubUsername: "ibmid:5500087VJB",
+				Provider:       "ibmid",
+				DisplayName:    "Jane Doe",
+				Hives:          map[string]string{"h1": "read"},
+			},
+			wantName: "Jane Doe",
+			wantProv: "ibmid",
+		},
+		{
+			name: "google user with an OIDC display name shows the name",
+			user: SaaSUser{
+				GitHubUsername: "google:107812345678901234567",
+				Provider:       "google",
+				DisplayName:    "Priya Patel",
+				Hives:          map[string]string{"h1": "read"},
+			},
+			wantName: "Priya Patel",
+			wantProv: "google",
+		},
+		{
+			name: "microsoft user with an OIDC display name shows the name",
+			user: SaaSUser{
+				GitHubUsername: "microsoft:AAAABBBBCCCCDDDD",
+				Provider:       "microsoft",
+				DisplayName:    "Sam Lee",
+				Hives:          map[string]string{"h1": "read"},
+			},
+			wantName: "Sam Lee",
+			wantProv: "microsoft",
+		},
+		{
+			name: "no display name but email claim falls back to email",
+			user: SaaSUser{
+				GitHubUsername: "ibmid:6600099XYZ",
+				Provider:       "ibmid",
+				Email:          "kim@example.com",
+				Hives:          map[string]string{"h1": "read"},
+			},
+			wantName: "kim@example.com",
+			wantProv: "ibmid",
+		},
+		{
+			name: "no display name but admin-entered full name falls back to it",
+			user: SaaSUser{
+				GitHubUsername: "google:99988877766655544433",
+				Provider:       "google",
+				FullName:       "Operator Entered Name",
+				Hives:          map[string]string{"h1": "read"},
+			},
+			wantName: "Operator Entered Name",
+			wantProv: "google",
+		},
+		{
+			name: "linked github login wins over everything for a non-github primary",
+			user: SaaSUser{
+				GitHubUsername:    "ibmid:7700011AAA",
+				Provider:          "ibmid",
+				DisplayName:       "Should Not Win",
+				LinkedGitHubLogin: "realghlogin",
+				Hives:             map[string]string{"h1": "read"},
+			},
+			wantName: "realghlogin",
+			wantProv: "ibmid",
+		},
+		{
+			// CRITICAL: no human name is known anywhere — never logged in, or the
+			// provider returned no name claim. The row MUST still render the raw
+			// key, never blank/undefined.
+			name: "no name anywhere falls back cleanly to the raw key",
+			user: SaaSUser{
+				GitHubUsername: "microsoft:NONAMECLAIM0000",
+				Provider:       "microsoft",
+				Hives:          map[string]string{"h1": "read"},
+			},
+			wantName: "microsoft:NONAMECLAIM0000",
+			wantProv: "microsoft",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			access := accessForHive("h1", []SaaSUser{c.user}, false)
+			if len(access) != 1 {
+				t.Fatalf("access rows = %d, want 1", len(access))
+			}
+			row := access[0]
+			// The identity KEY must never change — this is display only.
+			if row.Username != c.user.GitHubUsername {
+				t.Fatalf("Username = %q, want unchanged raw key %q", row.Username, c.user.GitHubUsername)
+			}
+			if row.DisplayLabel != c.wantName {
+				t.Errorf("DisplayLabel = %q, want %q", row.DisplayLabel, c.wantName)
+			}
+			if row.Provider != c.wantProv {
+				t.Errorf("Provider = %q, want %q", row.Provider, c.wantProv)
+			}
+		})
+	}
+}
+
+// TestAuthorizedUserNamesOmitsRawKeyFallback asserts the heartbeat's cosmetic
+// name map only carries an entry when a friendlier name than the raw key was
+// actually found — a key with nothing better maps to nothing, so the spoke's
+// own "no entry means show the raw key" fallback kicks in uniformly instead
+// of the hub sending a redundant self-referential mapping.
+func TestAuthorizedUserNamesOmitsRawKeyFallback(t *testing.T) {
+	withTempSaaSDirs(t)
+	putHiveOwnedBy(t, "h1", "owner1")
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "owner1",
+		Hives:          map[string]string{"h1": "owner"},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser owner1: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "ibmid:5500087VJB",
+		Provider:       "ibmid",
+		DisplayName:    "Jane Doe",
+		Hives:          map[string]string{"h1": "read"},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser ibmid user: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{
+		GitHubUsername: "google:NONAMECLAIM",
+		Provider:       "google",
+		Hives:          map[string]string{"h1": "read"},
+	}); err != nil {
+		t.Fatalf("saveSaaSUser google user: %v", err)
+	}
+
+	users, names := authorizedUsersAndNamesForHiveID("h1")
+
+	foundOwner, foundJane, foundGoogle := false, false, false
+	for _, e := range users {
+		switch {
+		case strings.HasPrefix(e, "owner1:"):
+			foundOwner = true
+		case strings.HasPrefix(e, "ibmid:5500087VJB:"):
+			foundJane = true
+		case strings.HasPrefix(e, "google:NONAMECLAIM:"):
+			foundGoogle = true
+		}
+	}
+	if !foundOwner || !foundJane || !foundGoogle {
+		t.Fatalf("authorized users list missing expected entries: %v", users)
+	}
+
+	if got := names["ibmid:5500087VJB"]; got != "Jane Doe" {
+		t.Errorf(`names["ibmid:5500087VJB"] = %q, want "Jane Doe"`, got)
+	}
+	if _, ok := names["google:NONAMECLAIM"]; ok {
+		t.Errorf("names has an entry for a key with no known human name; want it absent so the spoke falls back to the raw key")
+	}
+	// A GitHub owner with no display/full name/email is also "native" — no
+	// entry expected, same reasoning.
+	if _, ok := names["owner1"]; ok {
+		t.Errorf("names has a self-referential entry for a plain GitHub login with no extra claims")
+	}
+}
+
+// TestAuthorizedUsersAndNamesNoSaaSRecord pins the nil contract: a hive with
+// no SaaS record gets nil for both return values, so a non-hosted spoke's own
+// locally configured allowlist (and its own AuthorizedUserNames, if any) is
+// left completely untouched.
+func TestAuthorizedUsersAndNamesNoSaaSRecord(t *testing.T) {
+	withTempSaaSDirs(t)
+	users, names := authorizedUsersAndNamesForHiveID("no-such-hive")
+	if users != nil {
+		t.Errorf("users = %v, want nil", users)
+	}
+	if names != nil {
+		t.Errorf("names = %v, want nil", names)
+	}
+}
+
+// TestManageAccessRowsRenderFriendlyNameAndKeepRawKeyDiscoverable pins the
+// Manage Access modal's row markup: it must read the server-resolved
+// display_label/provider fields (not re-derive a name from the raw key
+// client-side), and the raw key must stay reachable (title attribute + a
+// muted secondary line) even when a friendly name is shown.
+func TestManageAccessRowsRenderFriendlyNameAndKeepRawKeyDiscoverable(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "var hasFriendlyName = !!(u.display_label && u.display_label !== u.username)") {
+		t.Error("Manage Access rows must resolve friendliness from the server-provided display_label, not re-derive one client-side")
+	}
+	if !strings.Contains(dashboardHTML, `title="Auth key">' + esc(u.username) + '</span>'`) {
+		t.Error("the raw auth key must stay visible as a muted secondary line when a friendly name is shown")
+	}
+	if !strings.Contains(dashboardHTML, "var primaryLabel = hasFriendlyName ? u.display_label : u.username;") {
+		t.Error("a row with no known friendly name must still render the raw key, never blank/undefined")
+	}
+	// The provider icon must come from the server's classification when
+	// present, falling back to the existing prefix-based classifier — never
+	// hard-coded to "github".
+	if !strings.Contains(dashboardHTML, "var provider = u.provider || identityProviderFromKey(u.username);") {
+		t.Error("Manage Access rows must classify the provider icon from u.provider (falling back to identityProviderFromKey), not assume github")
+	}
+}
+
+// TestInlineAccessAvatarHandlesNonGitHubIdentity pins the third surface: the
+// "My Hives" co-member face avatars (hiveAccessAvatars / inlineAccessAvatar).
+// A non-GitHub key must not get the plain linkedAvatar, which always builds a
+// github.com/<key>.png URL — wrong host for an ibmid/google/microsoft
+// subject, so it 404s and (worse) links to whatever github.com account
+// happens to sit at that URL-shaped path.
+func TestInlineAccessAvatarHandlesNonGitHubIdentity(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "var provider = a.provider || identityProviderFromKey(uname);") {
+		t.Error("inlineAccessAvatar must classify the provider from a.provider (falling back to identityProviderFromKey)")
+	}
+	if !strings.Contains(dashboardHTML, "provider === 'github'\n        ? linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a), extraStyle)") {
+		t.Error("inlineAccessAvatar must only use the GitHub-profile-linked avatar for provider === 'github'")
+	}
+	if !strings.Contains(dashboardHTML, "if (label && label !== uname) lines.splice(0, 0, label);") {
+		t.Error("accessAvatarTitle must show the resolved friendly name ahead of the raw key when one is known")
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -6642,15 +6642,39 @@ func (s *HubServer) handleLatestSHA(w http.ResponseWriter, r *http.Request) {
 // non-hosted spoke's own allowlist is left untouched. The owner is always
 // included as owner even if no explicit access record names them.
 func authorizedUsersForHiveID(hiveID string) []string {
+	users, _ := authorizedUsersAndNamesForHiveID(hiveID)
+	return users
+}
+
+// authorizedUsersAndNamesForHiveID does the shared work behind
+// authorizedUsersForHiveID and the heartbeat handler's AuthorizedUserNames
+// delivery: one roster scan producing both the authoritative "username:role"
+// allowlist and its cosmetic display-name companion, so the two can never
+// drift out of sync with each other (different key sets, different order) by
+// construction.
+//
+// The name map only gets an entry when provisionRequestUserIdentity resolves
+// to something FRIENDLIER than the raw key itself (source != "native") — an
+// entry with no known human name is simply absent, and the spoke's own
+// rendering falls back to the raw key exactly as it does today for a key with
+// no map entry at all.
+func authorizedUsersAndNamesForHiveID(hiveID string) ([]string, map[string]string) {
 	h := loadSaaSHive(hiveID)
 	if h == nil {
-		return nil
+		return nil, nil
 	}
 	out := make([]string, 0, 4)
+	names := make(map[string]string, 4)
 	seen := map[string]bool{}
+	addName := func(key string, u *SaaSUser) {
+		if id, source := provisionRequestUserIdentity(key, u, ""); source != "native" && id != key {
+			names[key] = id
+		}
+	}
 	if h.Owner != "" {
 		out = append(out, h.Owner+":owner")
 		seen[strings.ToLower(h.Owner)] = true
+		addName(h.Owner, loadSaaSUser(h.Owner))
 	}
 	for _, u := range listAllSaaSUsers() {
 		role, ok := u.Hives[hiveID]
@@ -6662,8 +6686,13 @@ func authorizedUsersForHiveID(hiveID string) []string {
 		}
 		out = append(out, u.GitHubUsername+":"+role)
 		seen[strings.ToLower(u.GitHubUsername)] = true
+		uu := u
+		addName(u.GitHubUsername, &uu)
 	}
-	return out
+	if len(names) == 0 {
+		return out, nil
+	}
+	return out, names
 }
 
 // HiveAccessEntry is one user's access to a hive.
@@ -6684,6 +6713,23 @@ type HiveAccessEntry struct {
 	FullName string `json:"full_name,omitempty"`
 	SlackID  string `json:"slack_id,omitempty"`
 	Notes    string `json:"notes,omitempty"`
+	// DisplayLabel is the human-facing name for this row, resolved with the
+	// SAME precedence provisionRequestUserIdentity uses everywhere else
+	// (linked GitHub login → recognizable GitHub login → email → DisplayName
+	// → FullName → raw key) — never a second, competing resolver. Username
+	// above stays the raw identity key throughout (the auth key / allowlist
+	// match, completely unchanged); DisplayLabel is presentation only. Always
+	// non-empty: it falls all the way back to Username, so the UI never has
+	// to special-case "no name known" beyond comparing the two strings.
+	DisplayLabel string `json:"display_label,omitempty"`
+	// Provider is the identity provider ("github"/"google"/"ibmid"/"microsoft"/…)
+	// so the row can show the right provider mark without re-deriving it from
+	// Username client-side. See grantableUserProvider.
+	Provider string `json:"provider,omitempty"`
+	// AvatarURL is the provider-stored avatar (Google/Microsoft picture claim)
+	// for a non-GitHub user; empty for a GitHub user, who keeps the derived
+	// github.com/<login>.png the UI already builds from Username.
+	AvatarURL string `json:"avatar_url,omitempty"`
 	// Engagement stats copied from the user's record so a co-member's My-Hives
 	// avatar hover can show the same logins / time-in-hive the admin Users card
 	// shows. Like Notes these are stats ABOUT a person, so they ride ONLY for a
@@ -6744,12 +6790,17 @@ func accessForHive(hiveID string, users []SaaSUser, includeAdminOnly bool) []Hiv
 	access := make([]HiveAccessEntry, 0)
 	for _, u := range users {
 		if role, ok := u.Hives[hiveID]; ok {
+			uu := u
+			label, _ := provisionRequestUserIdentity(u.GitHubUsername, &uu, "")
 			entry := HiveAccessEntry{
-				Username:  u.GitHubUsername,
-				Role:      role,
-				ExpiresAt: u.HiveExpiry[hiveID],
-				FullName:  u.FullName,
-				SlackID:   u.SlackID,
+				Username:     u.GitHubUsername,
+				Role:         role,
+				ExpiresAt:    u.HiveExpiry[hiveID],
+				FullName:     u.FullName,
+				SlackID:      u.SlackID,
+				DisplayLabel: label,
+				Provider:     grantableUserProvider(&uu),
+				AvatarURL:    u.AvatarURL,
 				// Coarse last-active rides for every viewer of the row (see the
 				// field doc) — only the granular stats below stay admin-only.
 				LastActive: latestUserActivity(&u),
@@ -11280,7 +11331,15 @@ const dashboardHTML = `<!DOCTYPE html>
     function accessAvatarTitle(a) {
       var uname = String(a.username || '');
       var role = String(a.role || '');
+      // display_label is resolved hub-side (accessForHive) with the same
+      // precedence used everywhere else a friendly name is shown, and always
+      // falls back to the raw key — so it's only worth a separate first line
+      // when it's actually friendlier than uname itself. The raw key rides
+      // on every title regardless (first line), same as before this field
+      // existed.
+      var label = String(a.display_label || '');
       var lines = [uname + (role ? ' — ' + role : '')];
+      if (label && label !== uname) lines.splice(0, 0, label);
       // ("Logged into their hive now" is appended generically in avatarProfileLink
       // for EVERY avatar surface, so it is not added here — doing both would
       // double the line.)
@@ -11308,8 +11367,22 @@ const dashboardHTML = `<!DOCTYPE html>
     function inlineAccessAvatar(a) {
       var uname = String(a.username || '');
       var role = String(a.role || '');
-      return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a),
-        'border:1px solid ' + accessRoleColor(role) + ';background:var(--surface);flex:0 0 auto');
+      var provider = a.provider || identityProviderFromKey(uname);
+      var extraStyle = 'border:1px solid ' + accessRoleColor(role) + ';background:var(--surface);flex:0 0 auto';
+      // A non-GitHub key (ibmid/google/microsoft) has no github.com profile to
+      // link to — linkedAvatar would build a 404'ing image and a link to
+      // someone else's account by coincidence of URL-shape. userAvatar uses
+      // the provider-stored avatar_url when present, else initials derived
+      // from the real display label (never from the opaque provider:sub key).
+      var avatar = provider === 'github'
+        ? linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a), extraStyle)
+        : userAvatar({display_name: a.display_label, avatar_url: a.avatar_url, github_username: uname},
+            INLINE_ACCESS_AVATAR_PX, extraStyle);
+      if (provider === 'github') return avatar;
+      // userAvatar returns a bare <img> with no title/tooltip and no profile
+      // link (there is none to link to) — wrap it so the same rich tooltip
+      // accessAvatarTitle gives GitHub faces is not lost for everyone else.
+      return '<span title="' + escAttr(accessAvatarTitle(a)) + '" style="display:inline-block;line-height:0">' + avatar + '</span>';
     }
 
     /* Inline summary of the OTHER users on this hive, or '' when there are
@@ -21438,8 +21511,19 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         var ownerCount = users.filter(function(u) { return u.role === 'owner'; }).length;
         var rows = users.map(function(u) {
-          var avatar = linkedAvatar(u.username, LIST_AVATAR_PX,
-            String(u.username || '') + (u.role ? ' — ' + u.role : ''), 'margin-right:6px');
+          // u.username is the raw identity key — the actual auth key and
+          // allowlist match — and is NEVER altered for display. u.display_label
+          // is resolved hub-side (accessForHive → provisionRequestUserIdentity,
+          // the SAME precedence used everywhere else a friendly name is shown)
+          // and always falls back to u.username, so hasFriendlyName is exactly
+          // "the hub found something better than the raw key".
+          var provider = u.provider || identityProviderFromKey(u.username);
+          var hasFriendlyName = !!(u.display_label && u.display_label !== u.username);
+          var avatar = provider === 'github'
+            ? linkedAvatar(u.username, LIST_AVATAR_PX,
+                String(u.username || '') + (u.role ? ' — ' + u.role : ''), 'margin-right:6px')
+            : userAvatar({display_name: u.display_label, avatar_url: u.avatar_url, github_username: u.username},
+                LIST_AVATAR_PX, 'margin-right:6px');
           // The last owner can be neither removed nor demoted — doing so would
           // orphan the hive with no one able to manage access.
           var isLastOwner = (u.role === 'owner' && ownerCount <= 1);
@@ -21502,12 +21586,27 @@ const dashboardHTML = `<!DOCTYPE html>
               ' style="font-size:0.65rem;padding:2px 4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--amber)">'
               : '<span style="font-size:0.6rem;color:var(--text)">Never</span>') +
             '</span>';
-          return '<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:8px;padding:8px 0;border-bottom:1px solid var(--border)">' +
-            '<div style="display:flex;align-items:center;gap:4px;flex:1 1 240px;min-width:0">' + checkbox + avatar + providerIconHTML(identityProviderFromKey(u.username)) + '<span style="font-size:0.85rem;word-break:break-word">' + esc(u.username) + '</span>' +
+          // Primary label: the resolved friendly name when the hub found one,
+          // else the raw key exactly as before. The raw key is NEVER hidden —
+          // it rides as a muted secondary line (and the avatar's title) any
+          // time a friendly name is shown, so support/debugging always has it
+          // one glance away. A GitHub user whose label is still the bare
+          // login keeps the existing async profile-name enrichment
+          // (.gh-display-name / enrichGhDisplayNames, #4145).
+          var primaryLabel = hasFriendlyName ? u.display_label : u.username;
+          var rawKeyLine = hasFriendlyName
+            ? '<span style="display:block;font-size:0.7rem;color:var(--muted);word-break:break-word" title="Auth key">' + esc(u.username) + '</span>'
+            : '';
+          var ghEnrichPlaceholder = (provider === 'github' && !hasFriendlyName)
             /* Empty placeholder the async GitHub profile lookup fills in
                (#4145): display name lands beside the username when it arrives,
                and stays empty on any failure — the login always renders first. */
-            '<span class="gh-display-name" data-gh-login="' + escAttr(u.username) + '" style="margin-left:6px;font-size:0.75rem;color:var(--muted)"></span></div>' +
+            ? '<span class="gh-display-name" data-gh-login="' + escAttr(u.username) + '" style="margin-left:6px;font-size:0.75rem;color:var(--muted)"></span>'
+            : '';
+          return '<div style="display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:8px;padding:8px 0;border-bottom:1px solid var(--border)">' +
+            '<div style="display:flex;align-items:center;gap:4px;flex:1 1 240px;min-width:0">' + checkbox + avatar + providerIconHTML(provider) +
+            '<span style="font-size:0.85rem;word-break:break-word;min-width:0" title="' + escAttr(u.username) + '">' + esc(primaryLabel) + rawKeyLine + '</span>' +
+            ghEnrichPlaceholder + '</div>' +
             '<div style="display:flex;align-items:center;justify-content:flex-end;flex-wrap:wrap;gap:8px;flex:1 1 300px;min-width:0">' +
             lastActive +
             roleControl +

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -2347,8 +2347,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// (which authorize their own logins) stay in sync with Manage Access grants.
 	// Only for hives the hub actually has a SaaS record for; a bare non-SaaS
 	// spoke gets nothing and keeps its own configured allowlist.
-	if authUsers := authorizedUsersForHiveID(payload.HiveID); authUsers != nil {
+	if authUsers, authNames := authorizedUsersAndNamesForHiveID(payload.HiveID); authUsers != nil {
 		resp.AuthorizedUsers = authUsers
+		resp.AuthorizedUserNames = authNames
 	}
 
 	// Deliver the claimed project's real org/repos/ACMM so a spoke that was


### PR DESCRIPTION
## Problem

In the hub's **Manage Access** modal, in the "My Hives" co-member face avatars, and in the spoke dashboard's **Settings → Security → Access** list, a GitHub user renders as `clubanderson` with an avatar — but an IBMid, Google, or Microsoft user renders as their raw opaque provider subject: `ibmid:5500087VJB`, `google:1078...`, `microsoft:AAAA...`.

The provider-asserted name/email/avatar were already captured and persisted on login (`SaaSUser.DisplayName`/`Email`/`AvatarURL`, `oidc_provider.go`), and a canonical precedence resolver already existed (`provisionRequestUserIdentity`) — they just weren't wired into these three render sites.

## Fix

Reuses `provisionRequestUserIdentity`'s existing, documented precedence everywhere an access identity renders — no second resolver invented:

**linked GitHub/GHE login → recognizable GitHub login → email → OIDC `DisplayName` → admin-entered `FullName` → raw key**

### Surfaces changed

1. **Hub Manage Access modal rows** (`src/pkg/hub/saas.go`, `loadAccessList`) — shows the resolved name + correct provider icon; the raw key rides as a muted secondary line and a `title` tooltip whenever a friendlier name is shown. A GitHub user with no extra claims keeps the existing async GitHub-profile-name enrichment unchanged.
2. **Hub "My Hives" co-member face avatars** (`src/pkg/hub/saas.go`, `inlineAccessAvatar` / `accessAvatarTitle`) — same precedence; a non-GitHub identity no longer gets `linkedAvatar` pointed at a bogus, 404'ing `github.com/<raw-key>.png`. This is a third surface found during the sweep, beyond the two named in the issue.
3. **Spoke dashboard Settings → Security → Access list** (`src/pkg/dashboard/static/index.html` `loadAuthorizedUsers`, `src/pkg/dashboard/api.go` `handleAuthorizedUsersList`) — the spoke's `AuthorizedUsers` allowlist is just `"key:role"` strings with no name data. The hub now delivers a **purely cosmetic** `key → display name` map (`AuthorizedUserNames`) alongside the existing `AuthorizedUsers` list in the heartbeat response, so the read-only Access tab can show a name without the allowlist itself ever carrying one.

### Identity key: unchanged

- `HiveAccessEntry.Username`, `AuthorizedUsers` entries, and the heartbeat allowlist string format are **byte-identical** to before.
- `AuthorizedUserNames` is strictly additive, `omitempty`, nil-safe for older hubs/spokes, and **never consulted for authorization** — `AuthorizedRole`/`IsDirectRouteAuthzEnabled`/allowlist matching read only the raw key, exactly as before.
- Email is never used as an identity key anywhere in this change (per `oidc_provider.go`'s "display only, never the key" rule) — only ever as a display fallback.

### Fallback

A user with no known human name (never logged in, or the provider returned no name claim) still renders the raw key — never blank, never "undefined". This is asserted directly in tests (`no name anywhere falls back cleanly to the raw key`, `TestAuthorizedUsersListNilNamesMapFallsBackCleanly`).

### Before / after

**Hub Manage Access / My Hives faces:**
```
Before: ibmid:5500087VJB                    [read]
After:  🔷 Jane Doe                          [read]
        ibmid:5500087VJB  (muted, title="Auth key")
```

**Spoke Settings → Security → Access:**
```
Before: ibmid:5500087VJB                    read
After:  Jane Doe                            read
        ibmid:5500087VJB  (muted secondary line)
```

## Tests

- `src/pkg/hub/identity_display_test.go` — precedence table (GitHub/IBMid/Google/Microsoft, email fallback, FullName fallback, linked-GitHub-wins, and the raw-key fallback case), `AuthorizedUserNames` map omits self-referential/no-name entries, nil-contract for a hive with no SaaS record, and markup pins for all three render sites.
- `src/pkg/dashboard/identity_display_test.go` — `handleAuthorizedUsersList` attaches `display_name` from the hub-delivered map and falls back cleanly when nil/absent; markup pins for the Access tab row rendering.
- `src/pkg/hub/access_hover_test.go` — updated the pre-existing `TestAccessForHive` exact-struct comparison to include the now-always-populated `DisplayLabel`/`Provider` fields (both fall back to the raw login/`"github"` for the fixture's plain GitHub users, so behavior for GitHub users is unchanged).

## Wire/protocol changes

- `HiveAccessEntry` (hub API): + `DisplayLabel`, `Provider`, `AvatarURL` (all `omitempty`).
- `DashboardConfig` (spoke config): + `AuthorizedUserNames map[string]string` (`omitempty`).
- `HeartbeatResponse`: + `AuthorizedUserNames map[string]string` (`omitempty`), delivered in the same beat as `AuthorizedUsers`.
- `hub.AuthorizedUsersCallback` signature grew a second `names map[string]string` parameter (internal Go callback type, not wire-facing); the one production call site (`src/cmd/hive/main.go`) and the one test call site were updated.

Not touched: `RejectIdentitySet`, allowlist matching, `AuthorizedRole`, session/cookie identity handling, or anything under `oidc_provider.go`'s claim capture (already correct per the issue's own investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
