### PR TITLE
🐛 bound rotation probe Wait so a grandchild pipe cannot wedge the governor

### DIFF
--- a/src/pkg/rotation/rotation.go
+++ b/src/pkg/rotation/rotation.go
@@ -29,6 +29,18 @@ import (
 // probeTimeout bounds each CLI/HTTP headroom probe.
 const probeTimeout = 10 * time.Second
 
+// probeWaitDelay bounds how long exec.Cmd.Wait may block on the probe's I/O
+// pipes after the child is killed or the context expires. CLI probes spawn
+// processes (codex app-server, claude) that fork grandchildren which inherit
+// the stdout/stderr pipe write ends; killing the direct child then leaves the
+// pipe open, exec's copier goroutine never sees EOF, and a bare Wait blocks
+// FOREVER. Observed live on weavster: the watchdog's codex auth probe wedged
+// the main governor goroutine for 2.5h (no evals, no advisory digest — the
+// hub flagged the digest stale). WaitDelay is the stdlib's remedy: after the
+// delay Wait force-closes the pipes and returns ErrWaitDelay instead of
+// hanging.
+const probeWaitDelay = 5 * time.Second
+
 // pollInterval is how often the Manager re-probes provider headroom.
 const pollInterval = 5 * time.Minute
 
@@ -91,7 +103,11 @@ type Prober interface {
 func runCLI(ctx context.Context, name string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	cmd := exec.CommandContext(ctx, name, args...)
+	// See probeWaitDelay: without this a grandchild holding the output pipe
+	// makes CombinedOutput block past the context timeout, indefinitely.
+	cmd.WaitDelay = probeWaitDelay
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("%s probe failed: %w", name, err)
 	}
@@ -266,6 +282,11 @@ func (p CodexProber) Probe(ctx context.Context) Headroom {
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout+5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "codex", "app-server")
+	// See probeWaitDelay: codex app-server forks helpers that inherit the
+	// stdout pipe, so the deferred Kill+Wait below blocked forever without
+	// this — wedging the caller (the watchdog tick on the main governor
+	// goroutine) and with it every eval and advisory-digest post.
+	cmd.WaitDelay = probeWaitDelay
 	// The hive main process runs with HOME=/home/dev, but codex auth state
 	// lives in the shared CLI home on the PVC (/data/home/.codex — the HOME
 	// the manager gives agent sessions). Point the app-server there when it

--- a/src/pkg/rotation/rotation_waitdelay_test.go
+++ b/src/pkg/rotation/rotation_waitdelay_test.go
@@ -1,0 +1,52 @@
+package rotation
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// Regression: a probe child that forks a GRANDCHILD inheriting its output pipe
+// used to hang exec.Cmd.Wait forever — killing the direct child does not close
+// the pipe's write end held by the grandchild, so the copier goroutine exec
+// creates for an io.Writer Stdout/Stderr (CodexProber sets Stderr = io.Discard;
+// runCLI's CombinedOutput wires both) never sees EOF and Wait blocks on it.
+// Observed live on weavster: the watchdog's codex auth probe
+// (CodexProber.Probe's deferred Kill+Wait) wedged the main governor goroutine
+// for 2.5 hours, stopping every eval and advisory-digest post until the hub
+// flagged the digest stale.
+//
+// probeWaitDelay is the fix: exec.Cmd.WaitDelay force-closes the pipes after
+// the delay and Wait returns instead of hanging. This test builds the same
+// shape — sh forks a sleeping grandchild sharing the pipes, the direct child
+// exits — and asserts Wait returns promptly. Without WaitDelay it blocks until
+// the grandchild's sleep finishes (60s), far past the assertion's deadline
+// (verified by running this exact shape without WaitDelay: it hangs).
+func TestProbeWaitDelayUnblocksGrandchildPipeHang(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+	// Grandchild inherits stdout/stderr and sleeps well past every bound
+	// involved; the direct child exits immediately — the exact weavster shape.
+	cmd := exec.CommandContext(ctx, "sh", "-c", "sleep 60 & exit 0")
+	cmd.WaitDelay = probeWaitDelay
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		// ErrWaitDelay (pipes force-closed) or nil are both fine — the point
+		// is that Wait RETURNED.
+		t.Logf("Wait returned: %v", err)
+	case <-time.After(probeWaitDelay + probeTimeout):
+		t.Fatal("cmd.Wait still blocked after WaitDelay — grandchild pipe hang regressed")
+	}
+}


### PR DESCRIPTION
## Problem

weavster-dev/weavster showed **stale advisory** on the fleet ("advisory digest has not updated since 2026-08-27T12:52:23Z"). Root cause was far worse than a digest issue: the spoke's **entire main governor loop had been wedged for 2.5 hours** — no evals, no digest builds, no advisory posts.

A SIGQUIT goroutine dump showed goroutine 1 blocked **146 minutes** in:

```
watchdog.(*Reconciler).Tick → reconcileAuth → rotation.CodexProber.Probe → exec.(*Cmd).Wait
```

`CodexProber.Probe` launches `codex app-server`, kills it in a defer, then calls `cmd.Wait()`. codex forks helpers that inherit the stdout/stderr pipe write ends — killing the direct child does not close them, the copier goroutine exec creates for `Stderr = io.Discard` never sees EOF, and `Wait` blocks **forever**. The watchdog tick runs on the main goroutine, so the whole hive wedges. `runCLI`'s `CombinedOutput` has the same exposure.

## Fix

Set `cmd.WaitDelay = probeWaitDelay` (5s) on both exec sites in `pkg/rotation/rotation.go`. `WaitDelay` is the stdlib remedy: after the delay, `Wait` force-closes the pipes and returns `ErrWaitDelay` instead of hanging.

## Test

`TestProbeWaitDelayUnblocksGrandchildPipeHang` reproduces the exact shape (`sh -c 'sleep 60 & exit 0'` with `io.Discard` writers — verified to hang indefinitely without `WaitDelay`) and asserts `Wait` returns promptly:

```
Wait returned: exec: WaitDelay expired before I/O complete
--- PASS: TestProbeWaitDelayUnblocksGrandchildPipeHang (5.02s)
```

`go vet` + full `pkg/rotation` and `pkg/watchdog` suites pass. Weavster itself was unwedged by a pod restart and is posting digests again.