### PR TITLE
🧪 test(agent): pin OPENAI_API_KEY/CODEX_API_KEY empty in TestAgentAuthState_CodexCredentials

### DIFF
--- a/src/pkg/agent/authprobe_test.go
+++ b/src/pkg/agent/authprobe_test.go
@@ -339,6 +339,11 @@ func TestAgentAuthState_CopilotCredentials(t *testing.T) {
 func TestAgentAuthState_CodexCredentials(t *testing.T) {
 	emptyCodexSharedPath(t)
 	t.Setenv("HOME", t.TempDir())
+	// codexEnvHasCredentials reads the developer's real shell: an
+	// OPENAI_API_KEY / CODEX_API_KEY exported locally made the "no
+	// credentials" arm pass as authenticated. Pin both empty first.
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("CODEX_API_KEY", "")
 	m := &Manager{}
 
 	if !BackendRequiresInteractiveAuth("codex") {


### PR DESCRIPTION
Fixes #4889

`codexEnvHasCredentials()` reads the real process env, so a developer with `OPENAI_API_KEY` exported saw the "codex without auth.json" arm report authenticated and the test fail on a clean tree. Clear both variables with `t.Setenv` before probing. Verified: passes with `OPENAI_API_KEY=x go test ./pkg/agent/ -run TestAgentAuthState_CodexCredentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SEx7DdWVED4txUw3ykY5D