### PR TITLE
🐛 fix: self-heal wrong-owner CODEX_HOME so codex agents don't wedge

### DIFF
--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -7281,8 +7281,14 @@ func (m *Manager) setupCodexHome(agent *AgentProcess) {
 	}
 	dir := codexHomePath(agent.Name)
 	agentUser := m.agentExecUserSpec(agent)
+	salvagedConfig := m.healCodexHomeOwnership(agent, dir, agentUser)
 	if err := exec.Command("su-exec", agentUser, "mkdir", "-p", dir).Run(); err != nil {
-		m.logger.Warn("failed to pre-create codex home", "agent", agent.Name, "dir", dir, "error", err)
+		m.logger.Error("failed to pre-create codex home; codex cannot start without it, and a later run may create it under the wrong identity", "agent", agent.Name, "dir", dir, "error", err)
+	}
+	if salvagedConfig != nil {
+		if err := writeFileAsUser(agentUser, filepath.Join(dir, "config.toml"), salvagedConfig); err != nil {
+			m.logger.Warn("failed to restore salvaged codex config", "agent", agent.Name, "dir", dir, "error", err)
+		}
 	}
 	// Bridge auth: symlink the per-agent auth.json to the shared login file so a
 	// single sign-in propagates to all agents. `ln -sfn` is idempotent and
@@ -7292,6 +7298,91 @@ func (m *Manager) setupCodexHome(agent *AgentProcess) {
 	if err := exec.Command("su-exec", agentUser, "ln", "-sfn", codexSharedAuthFile, authLink).Run(); err != nil {
 		m.logger.Warn("failed to link codex auth", "agent", agent.Name, "link", authLink, "error", err)
 	}
+}
+
+// healCodexHomeOwnership repairs a CODEX_HOME wedged by wrong-owner state.
+// /data is the persistent volume, so a stale owner survives every restart:
+// either the whole dir was created by a codex run under another identity
+// (e.g. after a failed pre-create), or a config.toml inside an agent-owned
+// dir was written as dev/root and the agent EACCESes on it at startup — the
+// same failure class cavemanNpmCachePath removes foreign-owned caches for.
+//
+// Hive never writes config.toml, so any content is operator-authored: the
+// heal salvages it when the manager can read it and returns the bytes for
+// setupCodexHome to write back as the agent after the re-mkdir. A dir that
+// cannot be rebuilt (root-owned, no write access) is left alone with an
+// Error log naming the owner and the manual fix.
+func (m *Manager) healCodexHomeOwnership(agent *AgentProcess, dir, agentUser string) []byte {
+	owner := fileOwnerUID(dir)
+	if owner < 0 {
+		return nil // absent (fresh mkdir will own it) or unstattable
+	}
+	if owner == agent.UID {
+		return m.healForeignCodexConfig(agent, dir, agentUser)
+	}
+	// Codex's app-server requires the current UID to own CODEX_HOME itself,
+	// so a foreign-owned dir can only be rebuilt, not patched around.
+	cfgPath := filepath.Join(dir, "config.toml")
+	salvaged, readErr := os.ReadFile(cfgPath)
+	if err := os.RemoveAll(dir); err != nil {
+		m.logger.Error("codex home is owned by the wrong UID and could not be rebuilt; codex will fail until it is chowned or removed manually", "agent", agent.Name, "dir", dir, "ownerUID", owner, "wantUID", agent.UID, "error", err)
+		return nil
+	}
+	m.logger.Warn("rebuilt codex home that was owned by the wrong UID", "agent", agent.Name, "dir", dir, "ownerUID", owner, "wantUID", agent.UID, "configSalvaged", readErr == nil)
+	if readErr != nil {
+		return nil
+	}
+	return salvaged
+}
+
+// healForeignCodexConfig handles the agent-owned-dir case: a config.toml
+// owned by another UID (written by a codex run as dev/root with CODEX_HOME
+// pointed at this agent's dir). The agent owns the dir, so it can unlink the
+// file even though it cannot read it; content is preserved when the manager
+// can read it.
+func (m *Manager) healForeignCodexConfig(agent *AgentProcess, dir, agentUser string) []byte {
+	cfgPath := filepath.Join(dir, "config.toml")
+	owner := fileOwnerUID(cfgPath)
+	if owner < 0 || owner == agent.UID {
+		return nil
+	}
+	salvaged, readErr := os.ReadFile(cfgPath)
+	if err := exec.Command("su-exec", agentUser, "rm", "-f", cfgPath).Run(); err != nil {
+		m.logger.Error("codex config.toml is owned by the wrong UID and could not be removed; codex will fail until it is chowned or removed manually", "agent", agent.Name, "path", cfgPath, "ownerUID", owner, "wantUID", agent.UID, "error", err)
+		return nil
+	}
+	m.logger.Warn("removed codex config.toml that was owned by the wrong UID", "agent", agent.Name, "path", cfgPath, "ownerUID", owner, "wantUID", agent.UID, "configSalvaged", readErr == nil)
+	if readErr != nil {
+		return nil
+	}
+	return salvaged
+}
+
+// fileOwnerUID returns the numeric owner of path, or -1 when it cannot be
+// determined (path absent, or a non-unix Stat result).
+func fileOwnerUID(path string) int {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return -1
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return -1
+	}
+	return int(st.Uid)
+}
+
+// writeFileAsUser writes content to path as userSpec via su-exec, for files
+// that must end up owned by the agent UID (the manager runs as dev and
+// cannot chown). The `sh -c 'cat > "$1"'` form keeps the path out of shell
+// parsing entirely.
+func writeFileAsUser(userSpec, path string, content []byte) error {
+	cmd := exec.Command("su-exec", userSpec, "sh", "-c", `cat > "$1"`, "sh", path)
+	cmd.Stdin = strings.NewReader(string(content))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return outputErr(fmt.Sprintf("writing %s as %s", path, userSpec), err, output)
+	}
+	return nil
 }
 
 // inferenceConfigMigrationVersion matches the Claude CLI internal config

--- a/src/pkg/agent/manager3_coverage_test.go
+++ b/src/pkg/agent/manager3_coverage_test.go
@@ -113,6 +113,90 @@ func TestSetupCodexHome_NonRootRunsSuExec(t *testing.T) {
 	m.setupCodexHome(agent) // must not panic even when su-exec is missing
 }
 
+// codexHealTestManager returns a manager and a codex agent with the given UID.
+func codexHealTestManager(t *testing.T, uid int) (*Manager, *AgentProcess) {
+	t.Helper()
+	m := NewManager(map[string]config.AgentConfig{"cxa": {Backend: "codex"}}, discardLogger(), ProjectContext{})
+	m.mu.Lock()
+	agent := m.agents["cxa"]
+	agent.UID = uid
+	m.mu.Unlock()
+	return m, agent
+}
+
+// TestHealCodexHomeOwnership_AbsentDirNoOp pins that a fresh spoke (no
+// CODEX_HOME yet) is untouched: the following mkdir owns the create path.
+func TestHealCodexHomeOwnership_AbsentDirNoOp(t *testing.T) {
+	m, agent := codexHealTestManager(t, 2001)
+	dir := filepath.Join(t.TempDir(), "codex-cxa")
+	if got := m.healCodexHomeOwnership(agent, dir, "hive-cxa"); got != nil {
+		t.Errorf("absent dir must salvage nothing, got %q", got)
+	}
+	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+		t.Errorf("absent dir must not be created by the heal, stat err=%v", err)
+	}
+}
+
+// TestHealCodexHomeOwnership_ForeignDirRebuiltWithSalvage pins the wedge
+// this heal exists for: a CODEX_HOME owned by another identity survives on
+// /data across restarts and codex refuses to start. The heal must remove
+// the dir and hand back the operator-authored config.toml for the re-create
+// to restore. The test dir is owned by the test UID while the agent wants a
+// different UID, which is exactly the foreign-owner shape.
+func TestHealCodexHomeOwnership_ForeignDirRebuiltWithSalvage(t *testing.T) {
+	m, agent := codexHealTestManager(t, os.Getuid()+12345)
+	dir := filepath.Join(t.TempDir(), "codex-cxa")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const cfg = "model = \"gpt-5.1-codex\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := m.healCodexHomeOwnership(agent, dir, "hive-cxa")
+	if string(got) != cfg {
+		t.Errorf("readable config.toml must be salvaged before the rebuild, got %q", got)
+	}
+	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+		t.Errorf("foreign-owned codex home must be removed, stat err=%v", err)
+	}
+}
+
+// TestHealCodexHomeOwnership_AgentOwnedDirKept pins the invariant that a
+// correctly-owned CODEX_HOME (and its config.toml) is never touched.
+func TestHealCodexHomeOwnership_AgentOwnedDirKept(t *testing.T) {
+	m, agent := codexHealTestManager(t, os.Getuid())
+	dir := filepath.Join(t.TempDir(), "codex-cxa")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "config.toml")
+	const cfg = "model = \"gpt-5.1-codex\"\n"
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.healCodexHomeOwnership(agent, dir, "hive-cxa"); got != nil {
+		t.Errorf("agent-owned home must salvage nothing, got %q", got)
+	}
+	content, err := os.ReadFile(cfgPath)
+	if err != nil || string(content) != cfg {
+		t.Errorf("agent-owned config.toml must be untouched, content=%q err=%v", content, err)
+	}
+}
+
+func TestFileOwnerUID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := fileOwnerUID(path); got != os.Getuid() {
+		t.Errorf("fileOwnerUID = %d, want %d", got, os.Getuid())
+	}
+	if got := fileOwnerUID(filepath.Join(t.TempDir(), "absent")); got != -1 {
+		t.Errorf("fileOwnerUID(absent) = %d, want -1", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CheckAndRestartCrashedAgents
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A quality agent's codex CLI wedges at startup with a permission error on `$CODEX_HOME/config.toml`. `/data` is the persistent volume, so a `CODEX_HOME` (or a `config.toml` inside it) left owned by dev/root — created by a codex run under another identity, or after a silently-warned failed pre-create — survives every restart and blocks the agent until fixed by hand.

## Fix

`setupCodexHome` now heals ownership before the pre-create, mirroring the existing `cavemanNpmCachePath` foreign-owner removal pattern:

- A foreign-owned dir is rebuilt (codex's app-server requires the agent UID to own the dir itself).
- A foreign-owned `config.toml` inside an agent-owned dir is unlinked as the agent (the agent owns the dir, so it can unlink a file it cannot read).
- In both cases, readable operator-authored `config.toml` content is salvaged and written back as the agent after the re-mkdir — hive never writes that file, so its content is always operator-authored.
- Unhealable state (root-owned, unremovable) and a failed pre-create now log at **Error** with the owning UID and the manual fix, instead of the silent Warn that let the wrong-identity dir get created in the first place.

Unit tests cover the absent-dir no-op, the foreign-dir rebuild with config salvage, the agent-owned untouched invariant, and `fileOwnerUID`.

Fixes #4886