### PR TITLE
🐛 fix(test): pin codex env keys empty in TestAgentAuthState_CodexCredentials

### DIFF
--- a/src/pkg/agent/authprobe_test.go
+++ b/src/pkg/agent/authprobe_test.go
@@ -339,6 +339,11 @@ func TestAgentAuthState_CopilotCredentials(t *testing.T) {
 func TestAgentAuthState_CodexCredentials(t *testing.T) {
 	emptyCodexSharedPath(t)
 	t.Setenv("HOME", t.TempDir())
+	// codexEnvHasCredentials reads the real process environment, so a key
+	// exported in the developer's shell would make every arm look
+	// authenticated (#4889). Pin both empty; later arms set what they need.
+	t.Setenv("CODEX_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
 	m := &Manager{}
 
 	if !BackendRequiresInteractiveAuth("codex") {


### PR DESCRIPTION
## Problem

`TestAgentAuthState_CodexCredentials` fails on a clean tree whenever the developer's shell exports `OPENAI_API_KEY` or `CODEX_API_KEY`: `codexEnvHasCredentials()` reads the real process environment, so the 'without auth.json' arm sees the leaked key and reports authenticated. CI is green only because the runner has neither variable.

## Fix

Pin both variables empty with `t.Setenv` at the top of the test, alongside the existing `HOME` override. `t.Setenv` restores the developer's values on test exit. The later `CODEX_API_KEY` arm still sets what it needs, and this is the only codex arm in the file that expects unauthenticated.

Fixes #4889