### PR TITLE
🌱 chore: restore canonical Apache-2.0 text and document OWNERS roles

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -137,8 +137,8 @@
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -158,22 +158,47 @@
       incidental, or consequential damages of any character arising as a
       result of this License or out of the use or inability to use the
       Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer or file corruption, or any and all other
-      commercial damages or losses), even if such Contributor has been
-      advised of the possibility of such damages.
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Support. While redistributing the Work or
-      Derivative Works thereof, You may choose to offer, and charge a
-      fee for, acceptance of support, warranty, indemnity, or other
-      liability obligations and/or rights consistent with this License.
-      However, in accepting such obligations, You may act only on Your
-      own behalf and on Your sole responsibility, not on behalf of any
-      other Contributor, and only if You agree to indemnify, defend,
-      and hold each Contributor harmless for any liability incurred by,
-      or claims asserted against, such Contributor by reason of your
-      accepting any such warranty or support.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
    Copyright 2026 The KubeStellar Authors
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,27 @@
+# Hive maintainers and reviewers.
+#
+# This file is the machine-readable form of the Maintainer Committee recorded in
+# GOVERNANCE-HIVE.md upstream:
+# https://github.com/kubestellar/kubestellar/blob/main/GOVERNANCE-HIVE.md#current-maintainers
+#
+# The two files MUST agree. A change here without the matching upstream change
+# (or vice versa) is a governance drift bug, not a housekeeping detail — CNCF
+# maturity review checks that code ownership matches documented governance
+# roles.
+#
+# Roles:
+#   approvers — may approve and merge. Members of the Maintainer Committee.
+#   reviewers — may review and LGTM; approval still requires an approver.
+#               This is the Contributor Ladder rung below maintainer and is the
+#               normal path onto the committee.
+#
+# Adding or removing anyone here follows the maintainer lifecycle in
+# GOVERNANCE-HIVE.md: nomination by an existing maintainer, lazy consensus of
+# the committee, and a PR against BOTH this file and the upstream table.
+# Affiliation changes must be reflected within 30 days.
+
 approvers:
   - clubanderson
+
 reviewers:
   - clubanderson


### PR DESCRIPTION
Two CNCF-maturity blockers, one of which is a genuine legal-correctness bug rather than a metadata quirk.

## LICENSE was a modified copy of Apache-2.0

GitHub reported **no license** for this repo (`licenseInfo: null`) despite a `LICENSE` file being present. The cause is that the text had been altered, so Licensee could not match it to Apache-2.0. The differences are substantive wording, not whitespace:

| Section | Shipped text | Canonical |
|---|---|---|
| §4(d) | "except as required for describing the origin of the Work" | "except as required for **reasonable and customary use in** describing the origin of the Work" |
| §8 | "computer or file corruption" | "computer **failure or malfunction**" |
| §9 | reflowed | — |

**A project cannot ship an altered copy of the license it claims to be under** — the grant is only Apache-2.0 if the terms are Apache-2.0. This is worth fixing on its own merits, independent of any CNCF process.

Replaced with the verbatim text from `apache.org`, with the project's copyright appendix kept below `END OF TERMS AND CONDITIONS` where it belongs and where it does not affect detection. The TERMS body now matches canonical byte-for-byte.

## OWNERS had no documentation

CNCF maturity review checks that "code and doc ownership in GitHub and elsewhere matches documented governance roles." The file listed two names and nothing else — a reader could not tell what an approver may do that a reviewer may not, or how someone joins.

It now records what each role grants, that this file is the machine-readable form of the Maintainer Committee in the upstream [`GOVERNANCE-HIVE.md`](https://github.com/kubestellar/kubestellar/blob/main/GOVERNANCE-HIVE.md#current-maintainers), that the two **must** agree, and that adds/removes follow the documented maintainer lifecycle with affiliation updates inside 30 days.

**Membership is unchanged** and still matches upstream exactly. This PR does not add or remove anyone.

## Scope

Two files, no code. Nothing here changes behaviour.