### PR TITLE
🐛 fail-soft flexTime parsing so one bad bead cannot poison a whole store

### DIFF
--- a/src/pkg/beads/beads.go
+++ b/src/pkg/beads/beads.go
@@ -58,6 +58,16 @@ var flexTimeFormats = []string{
 	"2006-01-02T15:04-07:00",
 	"2006-01-02T15:04:05",
 	"2006-01-02",
+	// Agents write beads through the bd CLI but occasionally hand-edit or
+	// template a human-format timestamp (observed live on torch-spyre:
+	// "2026-07-23 16:04 EDT"). Accept the common space-separated shapes so a
+	// well-meaning-but-wrong value still parses. time.Parse resolves a bare
+	// zone abbreviation to offset 0 when it isn't the local zone — hours-level
+	// imprecision, which beats the alternative below.
+	"2006-01-02 15:04:05 MST",
+	"2006-01-02 15:04 MST",
+	"2006-01-02 15:04:05",
+	"2006-01-02 15:04",
 }
 
 func (ft *flexTime) UnmarshalJSON(b []byte) error {
@@ -74,7 +84,18 @@ func (ft *flexTime) UnmarshalJSON(b []byte) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("parsing time %q: no matching format", s)
+	// FAIL-SOFT, deliberately. This unmarshals inside the store-wide
+	// json.Unmarshal of beads.json, so returning an error here poisons the
+	// ENTIRE agent ledger over one malformed field: the store is dropped from
+	// beadStores, the hive runs on a partial ledger for the life of the
+	// process, and the hub raises "N bead store(s) failed to load at startup"
+	// (observed live: torch-spyre ran degraded for a month over a single
+	// hand-written timestamp). A zero time is strictly less wrong — the bead
+	// stays visible with unknown age, and zero-CreatedAt beads simply sort
+	// oldest. Callers that must distinguish "absent" from "unparseable" can't
+	// anyway: both arrive as the zero value, same as the "" case above.
+	ft.Time = time.Time{}
+	return nil
 }
 
 func (ft flexTime) MarshalJSON() ([]byte, error) {

--- a/src/pkg/beads/beads_extra_coverage_test.go
+++ b/src/pkg/beads/beads_extra_coverage_test.go
@@ -94,10 +94,18 @@ func TestFlexTimeUnmarshalNotString(t *testing.T) {
 }
 
 func TestFlexTimeUnmarshalInvalid(t *testing.T) {
+	// An unparseable date string FAIL-SOFTS to the zero time instead of
+	// erroring: this unmarshal runs inside the store-wide json.Unmarshal of
+	// beads.json, so a hard error here poisoned an entire agent ledger over
+	// one malformed field (torch-spyre ran on a partial ledger for a month
+	// over a single hand-written "2026-07-23 16:04 EDT"). See
+	// flextime_failsoft_test.go for the full contract.
 	var ft flexTime
-	err := json.Unmarshal([]byte(`"not-a-date"`), &ft)
-	if err == nil {
-		t.Error("expected error for invalid date")
+	if err := json.Unmarshal([]byte(`"not-a-date"`), &ft); err != nil {
+		t.Errorf("invalid date must fail-soft, not error: %v", err)
+	}
+	if !ft.IsZero() {
+		t.Errorf("invalid date must land on the zero time, got %v", ft.Time)
 	}
 }
 

--- a/src/pkg/beads/flextime_failsoft_test.go
+++ b/src/pkg/beads/flextime_failsoft_test.go
@@ -1,0 +1,112 @@
+package beads
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Regression: one malformed timestamp used to poison an ENTIRE agent ledger.
+// flexTime.UnmarshalJSON returned an error for any format it didn't know, that
+// error surfaced through the store-wide json.Unmarshal of beads.json, and
+// NewStore failed — the store was dropped from beadStores, the hive ran on a
+// partial ledger for the life of the process, and the hub raised "N bead
+// store(s) failed to load at startup". Observed live on torch-spyre: a single
+// hand-written `"created_at": "2026-07-23 16:04 EDT"` in one supervisor bead
+// kept the whole store unloadable for a month.
+//
+// The fix is two-layered and both layers are pinned here: the common
+// space-separated human formats now PARSE, and anything still unknown
+// fail-softs to the zero time instead of erroring — so no future creative
+// timestamp can take out a ledger again.
+func TestFlexTimeAcceptsHumanFormats(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantYear int
+	}{
+		// The exact live torch-spyre value. Go resolves the bare "EDT"
+		// abbreviation to offset 0 when it is not the local zone — hours-level
+		// imprecision is accepted; losing the store is not.
+		{`"2026-07-23 16:04 EDT"`, 2026},
+		{`"2026-07-23 16:04:05 EDT"`, 2026},
+		{`"2026-07-23 16:04:05"`, 2026},
+		{`"2026-07-23 16:04"`, 2026},
+	}
+	for _, c := range cases {
+		var ft flexTime
+		if err := json.Unmarshal([]byte(c.in), &ft); err != nil {
+			t.Fatalf("flexTime rejected %s: %v", c.in, err)
+		}
+		if ft.Year() != c.wantYear {
+			t.Fatalf("flexTime parsed %s to %v (want year %d)", c.in, ft.Time, c.wantYear)
+		}
+	}
+}
+
+func TestFlexTimeFailSoftOnGarbage(t *testing.T) {
+	var ft flexTime
+	if err := json.Unmarshal([]byte(`"three days after the equinox"`), &ft); err != nil {
+		t.Fatalf("an unparseable timestamp must fail-soft, not error: %v", err)
+	}
+	if !ft.IsZero() {
+		t.Fatalf("an unparseable timestamp must land on the zero time, got %v", ft.Time)
+	}
+	// Non-string JSON is still a hard error: that is file corruption, not a
+	// creative timestamp, and the caller should see it.
+	if err := json.Unmarshal([]byte(`42`), &ft); err == nil {
+		t.Fatal("a non-string timestamp value must still be a hard error")
+	}
+}
+
+// The store-level consequence: a beads.json carrying the exact live torch-spyre
+// bead must LOAD, keeping every other bead readable.
+func TestStoreLoadsDespiteMalformedBeadTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	raw := `[
+	  {
+	    "id": "sup-sweep-bad",
+	    "title": "sweep with hand-written timestamp",
+	    "type": "task",
+	    "status": "open",
+	    "priority": 2,
+	    "actor": "supervisor",
+	    "created_at": "2026-07-23 16:04 EDT",
+	    "updated_at": "2026-07-23 16:04 EDT"
+	  },
+	  {
+	    "id": "sup-good",
+	    "title": "healthy bead",
+	    "type": "task",
+	    "status": "open",
+	    "priority": 2,
+	    "actor": "supervisor",
+	    "created_at": "2026-07-23T16:04:00Z",
+	    "updated_at": "2026-07-23T16:04:00Z"
+	  }
+	]`
+	if err := os.WriteFile(filepath.Join(dir, "beads.json"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("store failed to load over one malformed timestamp — the exact regression: %v", err)
+	}
+	all := store.List(ListFilter{})
+	if len(all) != 2 {
+		t.Fatalf("want both beads readable, got %d", len(all))
+	}
+	good, err := store.Get("sup-good")
+	if err != nil || good.CreatedAt.IsZero() {
+		t.Fatalf("healthy bead must keep its timestamp: %v / %v", err, good)
+	}
+	bad, err := store.Get("sup-sweep-bad")
+	if err != nil {
+		t.Fatalf("malformed-timestamp bead must still be readable: %v", err)
+	}
+	if bad.CreatedAt.Year() != 2026 {
+		t.Fatalf("the EDT shape now parses; want year 2026, got %v", bad.CreatedAt.Time)
+	}
+	_ = time.Now() // keep time import for future edits
+}


### PR DESCRIPTION
## Problem
One malformed timestamp in one bead (`"created_at": "2026-07-23 16:04 EDT"` on torch-spyre's supervisor store) made the store-wide `json.Unmarshal` of beads.json fail. The store was dropped from `beadStores` at startup, the hive ran on a **partial bead ledger for ~a month**, and the hub pill showed *"2 bead store(s) failed to load at startup"*.

## Fix (two layers, both pinned by tests)
1. `flexTimeFormats` now includes the common space-separated human shapes: `2006-01-02 15:04[:05][ MST]`.
2. Anything still unparseable **fail-softs to the zero time** instead of erroring — an empty string already yielded zero time, so callers can't distinguish, and no future creative timestamp can take out an entire ledger.

Non-string JSON values remain a hard error (that's file corruption, not a timestamp variant).

## Tests
- `TestFlexTimeAcceptsHumanFormats` — exact live torch-spyre value parses
- `TestFlexTimeFailSoftOnGarbage` — garbage → zero time, non-string → still error
- `TestStoreLoadsDespiteMalformedBeadTimestamp` — store loads with every bead readable
- Updated `TestFlexTimeUnmarshalInvalid` which pinned the old poison behavior

Live data on torch-spyre already repaired separately; this prevents recurrence fleet-wide.