### PR TITLE
🐛 fix: remove the duplicated LICENSE appendix blocking license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,20 +186,6 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
    Copyright 2026 The KubeStellar Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Follow-up to #4894, which fixed the right problem but left a new one.

#4894 correctly restored the canonical Apache-2.0 TERMS body — the shipped text had genuinely altered wording in §4(d) and §8. But it then appended the project's copyright block *after* the canonical text, not realising **canonical already ends with that same APPENDIX boilerplate**, carrying a `Copyright [yyyy] [name of copyright owner]` placeholder.

The result carried the boilerplate **twice** and ran **215 lines against canonical's 202**, so Licensee still could not classify it. `gh repo view --json licenseInfo` continued to return `none` after the merge, which is how this surfaced.

The appendix is meant to be **filled in, not duplicated**.

## After this change

`LICENSE` differs from `apache.org/licenses/LICENSE-2.0.txt` by **exactly one line** — the copyright placeholder replaced with `Copyright 2026 The KubeStellar Authors` — which is precisely the substitution the license's own instructions call for.

Verified:
- boilerplate block appears exactly once (was twice)
- `diff` against canonical reports only the copyright line
- 201 lines, matching canonical

## Why it matters

An undetected license is a CNCF Incubation blocker and, more practically, makes the repo appear unlicensed to anyone evaluating it — GitHub shows no license in the sidebar and the API reports none.