### PR TITLE
📖 docs: show the OpenSSF Best Practices passing badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Hive
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14261/badge)](https://www.bestpractices.dev/projects/14261)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
 AI agent orchestration for open source projects. A single Go binary enumerates GitHub issues and PRs, classifies them by complexity, and dispatches work to AI agents (Claude, Copilot, Gemini, Goose) on adaptive cadences governed by queue depth.
 
 Hive separates decisions into two layers: a **deterministic pipeline** of shell scripts handles filtering, classification, merge-gating, and enforcement before any LLM sees the work. Agents only handle judgment calls — reading code, reasoning about fixes, writing PRs.


### PR DESCRIPTION
Hive earned the **OpenSSF Best Practices passing badge** ([project 14261](https://www.bestpractices.dev/projects/14261)) at **100%** — 55 criteria Met, 11 N/A, 1 Unmet.

## What this adds

Two badges at the top of the README:

- **OpenSSF Best Practices** — links to the badge entry
- **Apache-2.0 license** — links to `LICENSE`

## Why a live badge rather than a static image

The OpenSSF badge is served from the badge site and re-renders on every page load. If the project's answers ever stop holding, the README stops asserting a pass on its own. A hardcoded "passing" image would keep claiming a badge the project had lost — the live image is the version that can't quietly become a lie.

## On the license badge

GitHub only began detecting Apache-2.0 again after #4894 and #4901. The file had shipped with **altered wording** in §4(d) and §8, and then briefly with a **duplicated appendix**; both blocked classification. Surfacing it in the README while that fix is fresh makes the license visible to anyone evaluating the project.

## Honest notes on the badge state

- The one **Unmet** criterion is `dynamic_analysis_enable_assertions`.
- `static_analysis` and `static_analysis_common_vulnerabilities` are answered **Met with the qualification stated in the justification**: `golangci-lint` and `govulncheck` block, while `gosec` currently reports without blocking pending the backlog drain tracked in #4903. The justification text on the badge site says so rather than implying a fully blocking gate.

Related: #4902 (added the analysis tooling), #4903 (ratchet), #4894 / #4901 (license)