### PR TITLE
🧪 test(cmd/hive): cover untested main.go helpers

### DIFF
--- a/src/cmd/hive/agent_activity_test.go
+++ b/src/cmd/hive/agent_activity_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/governor"
+)
+
+// activityTestConfig builds the minimal config agentActivityFor needs: one
+// enabled scanner agent scheduled on a kicking cadence in the "busy" mode.
+func activityTestConfig() *config.Config {
+	return &config.Config{
+		Agents: map[string]config.AgentConfig{
+			"scanner": {Backend: "claude", Enabled: true},
+		},
+		Governor: config.GovernorConfig{
+			Modes: map[string]config.ModeConfig{
+				"busy": {Cadences: map[string]config.Cadence{"scanner": "1h"}},
+			},
+		},
+	}
+}
+
+// agentActivityFor must carry the #4041 pause provenance (WHO/WHY/WHEN) to the
+// hub verbatim — dropping any of these is what turned a deliberate owner
+// quiesce into a multi-day incident investigation.
+func TestAgentActivityForRidesPauseProvenance(t *testing.T) {
+	cfg := activityTestConfig()
+	mgr := agent.NewManager(cfg.Agents, restoreTestLogger(), agent.ProjectContext{})
+	pausedAt := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	lastPane := time.Date(2026, 8, 20, 8, 55, 0, 0, time.UTC)
+	proc := &agent.AgentProcess{
+		Paused:         true,
+		PausedTrigger:  "dashboard-api",
+		PausedReason:   "manual pause",
+		PausedBy:       "owner",
+		PausedAt:       pausedAt,
+		NeedsLogin:     true,
+		QuotaExhausted: true,
+		LastPaneChange: lastPane,
+	}
+
+	act := agentActivityFor(mgr, cfg, governor.State{}, "busy", "scanner", proc, nil)
+
+	if !act.Paused || act.PausedTrigger != "dashboard-api" || act.PausedReason != "manual pause" ||
+		act.PausedBy != "owner" || !act.PausedAt.Equal(pausedAt) {
+		t.Errorf("pause provenance did not ride through verbatim: %+v", act)
+	}
+	if !act.NeedsLogin || !act.QuotaExhausted {
+		t.Error("NeedsLogin/QuotaExhausted flags were dropped")
+	}
+	if !act.LastActivityAt.Equal(lastPane) {
+		t.Errorf("LastActivityAt = %v, want the pane-change time %v", act.LastActivityAt, lastPane)
+	}
+	// StartedAt is nil on the process: the activity must report a ZERO time
+	// (hub reads it as "unknown"), never a fabricated timestamp.
+	if !act.StartedAt.IsZero() {
+		t.Errorf("StartedAt = %v for a never-started process, want zero", act.StartedAt)
+	}
+	// Backend rides along so the hub can interpret NeedsLogin.
+	if act.Backend != "claude" {
+		t.Errorf("Backend = %q, want %q", act.Backend, "claude")
+	}
+}
+
+// The EXPECTED leg: a cadence-scheduled agent in the current mode reports
+// ExpectedActive; the same agent flagged on-demand by an ACMM pack must NOT —
+// on-demand agents are never on a schedule, and reporting them as expected
+// would make every idle on-demand agent read as divergent fleet-side.
+func TestAgentActivityForExpectedActiveHonorsOnDemandPack(t *testing.T) {
+	cfg := activityTestConfig()
+	mgr := agent.NewManager(cfg.Agents, restoreTestLogger(), agent.ProjectContext{})
+	proc := &agent.AgentProcess{}
+
+	scheduled := agentActivityFor(mgr, cfg, governor.State{}, "busy", "scanner", proc, nil)
+	if !scheduled.ExpectedActive {
+		t.Error("cadence-scheduled agent in the current mode should report ExpectedActive")
+	}
+	if !scheduled.Enabled {
+		t.Error("enabled agent should report Enabled")
+	}
+
+	packOnDemand := agentActivityFor(mgr, cfg, governor.State{}, "busy", "scanner", proc,
+		map[string]bool{"scanner": true})
+	if packOnDemand.ExpectedActive {
+		t.Error("pack-on-demand agent must never report ExpectedActive")
+	}
+
+	otherMode := agentActivityFor(mgr, cfg, governor.State{}, "idle", "scanner", proc, nil)
+	if otherMode.ExpectedActive {
+		t.Error("agent with no cadence in the current mode must not report ExpectedActive")
+	}
+}
+
+// A nil config must leave the EXPECTED leg conservatively false rather than
+// panicking or guessing — the hub reads all-false as UNKNOWN, never as a
+// divergence verdict.
+func TestAgentActivityForNilConfig(t *testing.T) {
+	mgr := agent.NewManager(map[string]config.AgentConfig{}, restoreTestLogger(), agent.ProjectContext{})
+	act := agentActivityFor(mgr, nil, governor.State{}, "busy", "scanner", &agent.AgentProcess{}, nil)
+	if act.ExpectedActive || act.Enabled {
+		t.Errorf("nil config: ExpectedActive=%v Enabled=%v, want both false", act.ExpectedActive, act.Enabled)
+	}
+}
+
+// The ABLE leg: an agent the manager does not know must leave all three
+// capability bits false (hub-side UNKNOWN) and carry no backend — inventing
+// capabilities for an unknown agent would fabricate a divergence signal.
+func TestAgentActivityForUnknownAgentCapabilitiesStayFalse(t *testing.T) {
+	cfg := activityTestConfig()
+	mgr := agent.NewManager(cfg.Agents, restoreTestLogger(), agent.ProjectContext{})
+	act := agentActivityFor(mgr, cfg, governor.State{}, "busy", "ghost", &agent.AgentProcess{}, nil)
+	if act.CanOpenIssue || act.CanOpenPR || act.CanMerge {
+		t.Errorf("unknown agent capabilities = (%v, %v, %v), want all false (UNKNOWN)",
+			act.CanOpenIssue, act.CanOpenPR, act.CanMerge)
+	}
+	if act.Backend != "" {
+		t.Errorf("unknown agent Backend = %q, want empty", act.Backend)
+	}
+}

--- a/src/cmd/hive/gateway_resolution_test.go
+++ b/src/cmd/hive/gateway_resolution_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// resolveWatsonxGateway must prefer the gateway BOTH named and kinded
+// "watsonx" (the built-in backend's canonical slot) over a merely
+// watsonx-kinded gateway with another name, fall back to kind-only when no
+// canonical slot exists, and return nil when no watsonx gateway is configured
+// — resolving the wrong gateway would route the built-in watsonx backend
+// through someone else's endpoint and key.
+func TestResolveWatsonxGateway(t *testing.T) {
+	canonical := config.GatewayConfig{Name: "watsonx", Kind: config.GatewayKindWatsonx, Endpoint: "https://canonical"}
+	kindOnly := config.GatewayConfig{Name: "ibm-granite", Kind: config.GatewayKindWatsonx, Endpoint: "https://kind-only"}
+	other := config.GatewayConfig{Name: "openrouter", Kind: "litellm", Endpoint: "https://other"}
+
+	cases := []struct {
+		name     string
+		gateways []config.GatewayConfig
+		want     string // expected Endpoint, "" for nil
+	}{
+		{"canonical preferred over kind-only", []config.GatewayConfig{other, kindOnly, canonical}, "https://canonical"},
+		{"kind-only fallback", []config.GatewayConfig{other, kindOnly}, "https://kind-only"},
+		{"no watsonx gateway", []config.GatewayConfig{other}, ""},
+		{"no gateways at all", nil, ""},
+		{"case-insensitive match", []config.GatewayConfig{{Name: "WatsonX", Kind: "WATSONX", Endpoint: "https://cased"}}, "https://cased"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Governor: config.GovernorConfig{Gateways: tc.gateways}}
+			got := resolveWatsonxGateway(cfg)
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("resolveWatsonxGateway = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.Endpoint != tc.want {
+				t.Fatalf("resolveWatsonxGateway endpoint = %v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// For every non-watsonx kind, resolveGatewayAuth must hand back the resolved
+// API key VERBATIM with no extra headers — only watsonx swaps the raw key for
+// an IAM bearer and adds the project header. A mutated key or a stray header
+// on a litellm/openrouter route would break auth at the upstream.
+func TestResolveGatewayAuthNonWatsonxPassesKeyVerbatim(t *testing.T) {
+	const keyEnv = "HIVE_TEST_GATEWAY_KEY"
+	t.Setenv(keyEnv, "sk-verbatim-key")
+	gw := &config.GatewayConfig{Name: "openrouter", Kind: "litellm", APIKeyEnv: keyEnv}
+
+	key, headers := resolveGatewayAuth(gw, "scanner", "openrouter", restoreTestLogger())
+
+	if key != "sk-verbatim-key" {
+		t.Errorf("key = %q, want the resolved key verbatim", key)
+	}
+	if headers != nil {
+		t.Errorf("extra headers = %v, want nil for a non-watsonx gateway", headers)
+	}
+}
+
+// A keyless non-watsonx gateway (some vLLM endpoints) resolves to an empty
+// key and still no headers — never a fabricated credential.
+func TestResolveGatewayAuthKeylessGateway(t *testing.T) {
+	gw := &config.GatewayConfig{Name: "local-vllm", Kind: "vllm"}
+	key, headers := resolveGatewayAuth(gw, "scanner", "local-vllm", restoreTestLogger())
+	if key != "" || headers != nil {
+		t.Errorf("keyless gateway auth = (%q, %v), want empty key and nil headers", key, headers)
+	}
+}
+
+// litellmLocalProxyURL is the forwarding contract between the Go inference
+// translator and the bundled litellm proxy: loopback-only (agents must never
+// reach it directly) on the dedicated local-proxy port.
+func TestLitellmLocalProxyURLIsLoopback(t *testing.T) {
+	url := litellmLocalProxyURL()
+	if !strings.HasPrefix(url, "http://127.0.0.1:") {
+		t.Errorf("litellmLocalProxyURL = %q, want a loopback http URL", url)
+	}
+	if url != "http://127.0.0.1:18445" {
+		t.Errorf("litellmLocalProxyURL = %q, want the pinned local-proxy port 18445 the translator forwards to", url)
+	}
+}

--- a/src/cmd/hive/hive_id_identity_test.go
+++ b/src/cmd/hive/hive_id_identity_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// An operator-provided HIVE_ID must win over anything on disk or any
+// generated name — it is the fleet-facing identity, and silently replacing it
+// would detach the spoke from its hub registration.
+func TestLoadOrGenerateHiveIDEnvWins(t *testing.T) {
+	t.Setenv("HIVE_ID", "hive-operator-chosen")
+	if got := loadOrGenerateHiveID(restoreTestLogger()); got != "hive-operator-chosen" {
+		t.Errorf("loadOrGenerateHiveID = %q, want the HIVE_ID env value", got)
+	}
+}
+
+// Without an env override the function must still return a usable identity:
+// non-empty and free of surrounding whitespace (the on-disk form carries a
+// trailing newline that must never leak into the ID itself).
+func TestLoadOrGenerateHiveIDAlwaysUsable(t *testing.T) {
+	t.Setenv("HIVE_ID", "")
+	got := loadOrGenerateHiveID(restoreTestLogger())
+	if got == "" {
+		t.Fatal("loadOrGenerateHiveID returned an empty identity")
+	}
+	if got != strings.TrimSpace(got) {
+		t.Errorf("loadOrGenerateHiveID = %q carries surrounding whitespace", got)
+	}
+}
+
+// randomName must always produce a well-formed Docker-style adjective-noun
+// name — it feeds the generated "hive-<name>" identity, which downstream
+// consumers treat as a single hostname-safe token.
+func TestRandomNameFormat(t *testing.T) {
+	wellFormed := regexp.MustCompile(`^[a-z]+-[a-z]+$`)
+	// A handful of draws exercises the random path; every draw must be valid.
+	const draws = 32
+	for i := 0; i < draws; i++ {
+		name := randomName()
+		if !wellFormed.MatchString(name) {
+			t.Fatalf("randomName() = %q, want lowercase adjective-noun", name)
+		}
+	}
+}

--- a/src/cmd/hive/hive_pr_observations_test.go
+++ b/src/cmd/hive/hive_pr_observations_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+func observationsTestConfig() *config.Config {
+	return &config.Config{
+		Project: config.ProjectConfig{Org: "kubestellar", AIAuthor: "hive-bee"},
+	}
+}
+
+// hivePRObservations feeds the escalation ledger, so its author filter is a
+// gate: a HUMAN-authored PR must never become an escalation observation — the
+// fix-loop reaper re-dispatching agents onto a human's in-progress branch is
+// exactly the interference the filter exists to prevent.
+func TestHivePRObservationsExcludesHumanAuthors(t *testing.T) {
+	cfg := observationsTestConfig()
+	actionable := &github.ActionableResult{PRs: github.PRResult{Items: []github.PullRequest{
+		{Repo: "hive", Number: 1, Author: "hive-bee", HeadSHA: "aaa"},
+		{Repo: "hive", Number: 2, Author: "human-dev", HeadSHA: "bbb"},
+		{Repo: "hive", Number: 3, Author: "dependabot[bot]", HeadSHA: "ccc"},
+	}}}
+
+	obs := hivePRObservations(cfg, actionable)
+
+	if len(obs) != 2 {
+		t.Fatalf("got %d observations, want 2 (agent + bot only)", len(obs))
+	}
+	for _, o := range obs {
+		if o.Number == 2 {
+			t.Errorf("human-authored PR #2 leaked into escalation observations: %+v", o)
+		}
+	}
+}
+
+// Observations must carry FULLY-QUALIFIED repos: the escalation store keys on
+// them, and a bare "hive" beside a "kubestellar/hive" for the same PR would
+// split its attempt count across two ledger entries and defeat the breaker.
+func TestHivePRObservationsQualifiesRepos(t *testing.T) {
+	cfg := observationsTestConfig()
+	actionable := &github.ActionableResult{PRs: github.PRResult{Items: []github.PullRequest{
+		{Repo: "hive", Number: 1, Author: "hive-bee"},
+		{Repo: "otherorg/console", Number: 2, Author: "hive-bee"},
+	}}}
+
+	obs := hivePRObservations(cfg, actionable)
+
+	if len(obs) != 2 {
+		t.Fatalf("got %d observations, want 2", len(obs))
+	}
+	if obs[0].Repo != "kubestellar/hive" {
+		t.Errorf("bare repo = %q, want qualified %q", obs[0].Repo, "kubestellar/hive")
+	}
+	if obs[1].Repo != "otherorg/console" {
+		t.Errorf("already-qualified repo rewritten to %q, want untouched %q", obs[1].Repo, "otherorg/console")
+	}
+}
+
+// Red must mean "a required check failed" — CIStatus "failure" WITHOUT a named
+// failing check must not read as red (HasFailingRequiredCheck's
+// belt-and-suspenders guard), and the CI failure excerpt must ride along as
+// the fix agent's evidence.
+func TestHivePRObservationsRedRequiresFailingCheck(t *testing.T) {
+	cfg := observationsTestConfig()
+	actionable := &github.ActionableResult{PRs: github.PRResult{Items: []github.PullRequest{
+		{Repo: "hive", Number: 1, Author: "hive-bee", HeadSHA: "aaa",
+			CIStatus: "failure", FailingChecks: []string{"build"}, CIFailureExcerpt: "compile error"},
+		{Repo: "hive", Number: 2, Author: "hive-bee", HeadSHA: "bbb", CIStatus: "failure"},
+		{Repo: "hive", Number: 3, Author: "hive-bee", HeadSHA: "ccc", CIStatus: "success"},
+	}}}
+
+	obs := hivePRObservations(cfg, actionable)
+
+	if len(obs) != 3 {
+		t.Fatalf("got %d observations, want 3", len(obs))
+	}
+	if !obs[0].Red || obs[0].Excerpt != "compile error" || obs[0].HeadSHA != "aaa" {
+		t.Errorf("red PR with failing check misprojected: %+v", obs[0])
+	}
+	if obs[1].Red {
+		t.Error("CIStatus failure without a named failing check must not read as red")
+	}
+	if obs[2].Red {
+		t.Error("green PR read as red")
+	}
+}
+
+// A nil enumeration yields nil — the eval cycle calls this before the first
+// successful GitHub pass.
+func TestHivePRObservationsNilActionable(t *testing.T) {
+	if obs := hivePRObservations(observationsTestConfig(), nil); obs != nil {
+		t.Errorf("hivePRObservations(nil) = %v, want nil", obs)
+	}
+}

--- a/src/cmd/hive/intent_advisory_record_test.go
+++ b/src/cmd/hive/intent_advisory_record_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/beads"
+	"github.com/kubestellar/hive/pkg/intent"
+)
+
+func newAdvisoryTestStore(t *testing.T) *beads.Store {
+	t.Helper()
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("beads.NewStore: %v", err)
+	}
+	return store
+}
+
+func misalignedVerdict() intent.AlignmentVerdict {
+	return intent.AlignmentVerdict{
+		Rationale: "diff exceeds linked issue scope",
+		DeterministicFindings: []intent.AlignmentFinding{
+			{Code: "unrelated-files", Status: intent.AlignmentStatusMisaligned,
+				Reason: "touches files outside the issue", Files: []string{"pkg/other/other.go"}},
+		},
+	}
+}
+
+// recordIntentAlignmentAdvisory must mint exactly ONE open advisory bead per
+// misaligned PR, carrying the alignment evidence in its notes — and a second
+// observation of the same PR must NOT mint a duplicate while the first is
+// still open, or every eval tick would pile advisories onto the same drift.
+func TestRecordIntentAlignmentAdvisoryCreatesAndDedupes(t *testing.T) {
+	store := newAdvisoryTestStore(t)
+	stores := map[string]*beads.Store{"intent": store}
+
+	recordIntentAlignmentAdvisory(stores, "kubestellar/hive", 42, misalignedVerdict(), restoreTestLogger())
+
+	all := store.List(beads.ListFilter{})
+	if len(all) != 1 {
+		t.Fatalf("got %d beads after first record, want 1", len(all))
+	}
+	b := all[0]
+	if b.Type != beads.TypeAdvisory {
+		t.Errorf("bead type = %q, want %q", b.Type, beads.TypeAdvisory)
+	}
+	if b.ExternalRef != "gh-kubestellar/hive#42" {
+		t.Errorf("external ref = %q, want %q", b.ExternalRef, "gh-kubestellar/hive#42")
+	}
+	if !strings.Contains(b.Notes, "diff exceeds linked issue scope") ||
+		!strings.Contains(b.Notes, "unrelated-files") {
+		t.Errorf("notes lack the alignment evidence: %q", b.Notes)
+	}
+
+	// Same PR again: the open advisory suppresses a duplicate.
+	recordIntentAlignmentAdvisory(stores, "kubestellar/hive", 42, misalignedVerdict(), restoreTestLogger())
+	if got := len(store.List(beads.ListFilter{})); got != 1 {
+		t.Errorf("got %d beads after re-record of the same PR, want 1 (no duplicate open advisory)", got)
+	}
+
+	// A DIFFERENT PR is a different drift and gets its own advisory.
+	recordIntentAlignmentAdvisory(stores, "kubestellar/hive", 43, misalignedVerdict(), restoreTestLogger())
+	if got := len(store.List(beads.ListFilter{})); got != 2 {
+		t.Errorf("got %d beads after recording a second PR, want 2", got)
+	}
+}
+
+// Store selection order: the dedicated "intent" store wins, then "quality",
+// then any non-nil store — and an all-nil or empty map is a silent no-op, so
+// a hive without bead stores can never crash the intent gate.
+func TestRecordIntentAlignmentAdvisoryStoreFallback(t *testing.T) {
+	intentStore := newAdvisoryTestStore(t)
+	qualityStore := newAdvisoryTestStore(t)
+
+	stores := map[string]*beads.Store{"intent": intentStore, "quality": qualityStore}
+	recordIntentAlignmentAdvisory(stores, "kubestellar/hive", 7, misalignedVerdict(), restoreTestLogger())
+	if len(intentStore.List(beads.ListFilter{})) != 1 || len(qualityStore.List(beads.ListFilter{})) != 0 {
+		t.Error("advisory not routed to the dedicated intent store")
+	}
+
+	fallback := map[string]*beads.Store{"intent": nil, "quality": qualityStore}
+	recordIntentAlignmentAdvisory(fallback, "kubestellar/hive", 8, misalignedVerdict(), restoreTestLogger())
+	if len(qualityStore.List(beads.ListFilter{})) != 1 {
+		t.Error("nil intent store did not fall back to the quality store")
+	}
+
+	// No usable store anywhere: must be a quiet no-op, not a panic.
+	recordIntentAlignmentAdvisory(map[string]*beads.Store{"x": nil}, "kubestellar/hive", 9, misalignedVerdict(), restoreTestLogger())
+	recordIntentAlignmentAdvisory(nil, "kubestellar/hive", 10, misalignedVerdict(), restoreTestLogger())
+}

--- a/src/cmd/hive/login_scan_gates_test.go
+++ b/src/cmd/hive/login_scan_gates_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+func loginScanConfig(patterns []string) *config.Config {
+	return &config.Config{
+		Governor: config.GovernorConfig{
+			Sensing: config.SensingConfig{LoginPatterns: patterns},
+		},
+	}
+}
+
+// The login detector must stand down COMPLETELY when it has no usable
+// patterns — no pane reads, no pauses, no notifications. Passing nil for the
+// manager, notifier and dashboard makes the invariant self-enforcing: any
+// scan activity past the gate would panic.
+func TestScanForLoginRequiredStandsDownWithoutUsablePatterns(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+	}{
+		{"no patterns configured", nil},
+		{"empty pattern list", []string{}},
+		{"only blank patterns", []string{"", "   "}},
+		{"only invalid regexes", []string{"(", "[unclosed"}},
+		{"blank and invalid mixed", []string{"", "("}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Must return without touching any of the nil collaborators.
+			scanForLoginRequired(context.Background(), loginScanConfig(tc.patterns),
+				nil, nil, nil, restoreTestLogger())
+		})
+	}
+}

--- a/src/cmd/hive/nous_state_defaults_test.go
+++ b/src/cmd/hive/nous_state_defaults_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/dashboard"
+)
+
+// loadNousState builds the dashboard's nous panel state from optional on-disk
+// artifacts. Whatever is (or is not) on disk, the projected Status map must be
+// internally consistent: the legacy and new key spellings must agree, the
+// counts must match the loaded slices, and the phase must follow the ledger —
+// a Status map that disagrees with the state it summarizes renders a lying
+// panel.
+func TestLoadNousStateStatusConsistency(t *testing.T) {
+	state := loadNousState(restoreTestLogger())
+
+	if state.Mode != "observe" || state.Scope != "governor" {
+		t.Errorf("mode/scope = %q/%q, want observe/governor", state.Mode, state.Scope)
+	}
+
+	wantPhase := "collecting"
+	if len(state.Ledger) > 0 {
+		wantPhase = "observing"
+	}
+	if state.Phase != wantPhase {
+		t.Errorf("phase = %q with %d ledger iterations, want %q", state.Phase, len(state.Ledger), wantPhase)
+	}
+
+	// Legacy and new key spellings must never diverge.
+	if state.Status["snapshots"] != state.Status["snapshotCount"] {
+		t.Errorf("snapshots %v != snapshotCount %v", state.Status["snapshots"], state.Status["snapshotCount"])
+	}
+	if state.Status["principles"] != state.Status["principleCount"] {
+		t.Errorf("principles %v != principleCount %v", state.Status["principles"], state.Status["principleCount"])
+	}
+
+	// Counts must reflect the loaded state, not a stale or hardcoded value.
+	if got, ok := state.Status["iterations"].(int); !ok || got != len(state.Ledger) {
+		t.Errorf("iterations = %v, want %d", state.Status["iterations"], len(state.Ledger))
+	}
+	if got, ok := state.Status["principles"].(int); !ok || got != len(state.Principles) {
+		t.Errorf("principles = %v, want %d", state.Status["principles"], len(state.Principles))
+	}
+
+	// The Status map's own mode/scope/phase must mirror the struct fields.
+	if state.Status["mode"] != state.Mode || state.Status["scope"] != state.Scope || state.Status["phase"] != state.Phase {
+		t.Errorf("Status mode/scope/phase %v/%v/%v diverge from state %q/%q/%q",
+			state.Status["mode"], state.Status["scope"], state.Status["phase"], state.Mode, state.Scope, state.Phase)
+	}
+
+	// The baseline target rides from the dashboard package's single constant.
+	if state.Status["baseline_target"] != dashboard.NousBaselineTarget {
+		t.Errorf("baseline_target = %v, want %d", state.Status["baseline_target"], dashboard.NousBaselineTarget)
+	}
+}

--- a/src/cmd/hive/plan_from_label_wiring_test.go
+++ b/src/cmd/hive/plan_from_label_wiring_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/agent"
+	"github.com/kubestellar/hive/pkg/beads"
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/planning"
+)
+
+func newPlanTestStore(t *testing.T) *beads.Store {
+	t.Helper()
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("beads.NewStore: %v", err)
+	}
+	return store
+}
+
+func planLabeledIssue(number int, labels ...string) github.Issue {
+	return github.Issue{Repo: "kubestellar/hive", Number: number, Title: "build the thing", Labels: labels}
+}
+
+// Below the planning ACMM floor the `plan` label must mint NOTHING — the
+// architect that decomposes epics is not scheduled below L5, so an epic
+// minted here would sit in decompose_pending forever. The nil governor makes
+// the gate self-enforcing: any kick recorded past it would panic.
+func TestPlanFromLabeledIssuesGatedBelowPlanningLevel(t *testing.T) {
+	store := newPlanTestStore(t)
+	stores := map[string]*beads.Store{planning.ArchitectAgentName: store}
+	mgr := agent.NewManager(map[string]config.AgentConfig{}, restoreTestLogger(), agent.ProjectContext{})
+	actionable := &github.ActionableResult{Issues: github.IssueResult{Items: []github.Issue{
+		planLabeledIssue(1, "plan"),
+	}}}
+
+	planFromLabeledIssues(actionable, stores, mgr, nil, nil, restoreTestLogger(),
+		planning.PlanningMinACMMLevel-1)
+
+	if got := len(store.List(beads.ListFilter{})); got != 0 {
+		t.Errorf("minted %d epics below the planning ACMM floor, want 0", got)
+	}
+}
+
+// At the planning floor a plan-labeled issue mints an epic INTO THE
+// ARCHITECT'S STORE (never a sibling agent's), while unlabeled issues mint
+// nothing. With no architect agent registered the plan queues rather than
+// kicks — which the nil governor again enforces by construction.
+func TestPlanFromLabeledIssuesRoutesToArchitectStore(t *testing.T) {
+	architectStore := newPlanTestStore(t)
+	otherStore := newPlanTestStore(t)
+	stores := map[string]*beads.Store{
+		planning.ArchitectAgentName: architectStore,
+		"scanner":                   otherStore,
+	}
+	mgr := agent.NewManager(map[string]config.AgentConfig{}, restoreTestLogger(), agent.ProjectContext{})
+	actionable := &github.ActionableResult{Issues: github.IssueResult{Items: []github.Issue{
+		planLabeledIssue(1, "plan"),
+		planLabeledIssue(2, "kind/bug"),
+		planLabeledIssue(3),
+	}}}
+
+	planFromLabeledIssues(actionable, stores, mgr, nil, nil, restoreTestLogger(),
+		planning.PlanningMinACMMLevel)
+
+	if got := len(architectStore.List(beads.ListFilter{})); got != 1 {
+		t.Errorf("architect store holds %d beads, want 1 (only the plan-labeled issue mints)", got)
+	}
+	if got := len(otherStore.List(beads.ListFilter{})); got != 0 {
+		t.Errorf("sibling agent store holds %d beads, want 0", got)
+	}
+}
+
+// Nil enumeration and an empty store map are quiet no-ops — the eval cycle
+// runs this every tick, including before the first GitHub pass and on hives
+// with no bead stores at all.
+func TestPlanFromLabeledIssuesNilInputs(t *testing.T) {
+	mgr := agent.NewManager(map[string]config.AgentConfig{}, restoreTestLogger(), agent.ProjectContext{})
+	planFromLabeledIssues(nil, map[string]*beads.Store{}, mgr, nil, nil, restoreTestLogger(),
+		planning.PlanningMinACMMLevel)
+	planFromLabeledIssues(&github.ActionableResult{}, nil, mgr, nil, nil, restoreTestLogger(),
+		planning.PlanningMinACMMLevel)
+}

--- a/src/cmd/hive/quota_exhausted_agents_test.go
+++ b/src/cmd/hive/quota_exhausted_agents_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/hub"
+)
+
+// quotaExhaustedAgentCount must count ONLY running, unpaused agents whose
+// pane showed quota exhaustion — the summary-side twin of
+// quotaExhaustedProcessCount. A paused or stopped agent out of quota is not an
+// actionable heartbeat signal, and the state match must be case-insensitive
+// because summaries carry whatever casing the producer used.
+func TestQuotaExhaustedAgentCount(t *testing.T) {
+	agents := []hub.AgentSummary{
+		{Name: "counted", State: "running", QuotaExhausted: true},
+		{Name: "mixed-case", State: "Running", QuotaExhausted: true},
+		{Name: "paused-flag", State: "running", QuotaExhausted: true, Paused: true},
+		{Name: "paused-state", State: "paused", QuotaExhausted: true},
+		{Name: "stopped", State: "stopped", QuotaExhausted: true},
+		{Name: "has-quota", State: "running", QuotaExhausted: false},
+	}
+	if got := quotaExhaustedAgentCount(agents); got != 2 {
+		t.Errorf("quotaExhaustedAgentCount = %d, want 2 (only running+unpaused out-of-quota agents)", got)
+	}
+}
+
+// A nil or empty summary slice must count zero — the heartbeat builder calls
+// this before any agent has reported.
+func TestQuotaExhaustedAgentCountEmpty(t *testing.T) {
+	if got := quotaExhaustedAgentCount(nil); got != 0 {
+		t.Errorf("quotaExhaustedAgentCount(nil) = %d, want 0", got)
+	}
+	if got := quotaExhaustedAgentCount([]hub.AgentSummary{}); got != 0 {
+		t.Errorf("quotaExhaustedAgentCount(empty) = %d, want 0", got)
+	}
+}

--- a/src/cmd/hive/repo_name_resolution_test.go
+++ b/src/cmd/hive/repo_name_resolution_test.go
@@ -1,0 +1,76 @@
+package main
+
+import "testing"
+
+// bareRepoName must strip everything up to the last slash and pass a bare
+// name through untouched — the audit-trail attribution map keys off the bare
+// form, so a fully-qualified and a bare spelling of the same repo must
+// collapse to the same key.
+func TestBareRepoName(t *testing.T) {
+	cases := []struct {
+		name string
+		repo string
+		want string
+	}{
+		{"qualified", "kubestellar/hive", "hive"},
+		{"bare passthrough", "hive", "hive"},
+		{"nested path keeps last segment", "ghe.example.com/org/hive", "hive"},
+		{"trailing slash yields empty", "kubestellar/", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bareRepoName(tc.repo); got != tc.want {
+				t.Errorf("bareRepoName(%q) = %q, want %q", tc.repo, got, tc.want)
+			}
+		})
+	}
+}
+
+// fullRepoName must qualify a bare repo with the org, and must NEVER rewrite
+// a repo that already names an owner — re-qualifying "otherorg/repo" with the
+// project org would silently point maintainer-approval and merge checks at
+// the wrong repository.
+func TestFullRepoName(t *testing.T) {
+	cases := []struct {
+		name string
+		repo string
+		org  string
+		want string
+	}{
+		{"bare gets org", "hive", "kubestellar", "kubestellar/hive"},
+		{"qualified untouched", "kubestellar/hive", "kubestellar", "kubestellar/hive"},
+		{"foreign owner untouched", "otherorg/hive", "kubestellar", "otherorg/hive"},
+		{"empty org leaves bare", "hive", "", "hive"},
+		{"empty repo stays empty", "", "kubestellar", "kubestellar/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fullRepoName(tc.repo, tc.org); got != tc.want {
+				t.Errorf("fullRepoName(%q, %q) = %q, want %q", tc.repo, tc.org, got, tc.want)
+			}
+		})
+	}
+}
+
+// describeKeySource is banner copy for the App-key resolution trail: an empty
+// or whitespace-only source must render as the explicit "(unset)" marker so an
+// operator can tell "not configured" from a path that merely failed to load.
+func TestDescribeKeySource(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "(unset)"},
+		{"whitespace only", "   \t", "(unset)"},
+		{"path passthrough", "/data/github-app.pem", "/data/github-app.pem"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeKeySource(tc.in); got != tc.want {
+				t.Errorf("describeKeySource(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/cmd/hive/review_dispatch_gates_test.go
+++ b/src/cmd/hive/review_dispatch_gates_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/review"
+)
+
+func emptyDispatchPlan(p review.DispatchPlan) bool {
+	return len(p.ReviewKicks) == 0 && len(p.FixKicks) == 0 && p.State.GeneratedAt.IsZero()
+}
+
+// planReviewDispatch is the review-swarm entry gate: unless BOTH
+// review.require_approval and review.fan_out are enabled, it must plan
+// nothing at all — a kick escaping this gate would dispatch reviewer agents
+// on a hive whose operator never opted into the review swarm.
+func TestPlanReviewDispatchRequiresBothToggles(t *testing.T) {
+	actionable := &github.ActionableResult{PRs: github.PRResult{Items: []github.PullRequest{
+		{Repo: "hive", Number: 1, Title: "feat: thing", Author: "hive-bee", HeadSHA: "aaa"},
+	}}}
+	cases := []struct {
+		name            string
+		requireApproval bool
+		fanOut          bool
+	}{
+		{"neither toggle", false, false},
+		{"fan_out without require_approval", false, true},
+		{"require_approval without fan_out", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Review: config.ReviewConfig{RequireApproval: tc.requireApproval, FanOut: tc.fanOut},
+			}
+			plan := planReviewDispatch(cfg, actionable, nil, restoreTestLogger())
+			if !emptyDispatchPlan(plan) {
+				t.Errorf("plan = %+v, want empty (gate must hold with require_approval=%v fan_out=%v)",
+					plan, tc.requireApproval, tc.fanOut)
+			}
+		})
+	}
+}
+
+// A nil config or nil enumeration must yield an empty plan, never a panic —
+// the eval cycle calls this before the first successful GitHub pass.
+func TestPlanReviewDispatchNilInputs(t *testing.T) {
+	if plan := planReviewDispatch(nil, &github.ActionableResult{}, nil, restoreTestLogger()); !emptyDispatchPlan(plan) {
+		t.Errorf("nil config produced a non-empty plan: %+v", plan)
+	}
+	cfg := &config.Config{Review: config.ReviewConfig{RequireApproval: true, FanOut: true}}
+	if plan := planReviewDispatch(cfg, nil, nil, restoreTestLogger()); !emptyDispatchPlan(plan) {
+		t.Errorf("nil actionable produced a non-empty plan: %+v", plan)
+	}
+}

--- a/src/cmd/hive/watchdog_auth_probes_test.go
+++ b/src/cmd/hive/watchdog_auth_probes_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// watchdogAuthProbes adapts the rotation package's provider probers (#4608)
+// for the watchdog. Every provider the rotation subsystem can probe must be
+// represented exactly once, keyed by the prober's own Provider() name — a
+// missing key silently exempts that provider's credentials from watchdog
+// verification, and a wrong key orphans the probe.
+func TestWatchdogAuthProbesCoversAllProviders(t *testing.T) {
+	probes := watchdogAuthProbes(&config.Config{})
+
+	wantProviders := []string{"anthropic", "openai", "google", "deepseek"}
+	if len(probes) != len(wantProviders) {
+		t.Fatalf("got %d probes, want %d (%v)", len(probes), len(wantProviders), wantProviders)
+	}
+	for _, provider := range wantProviders {
+		if _, ok := probes[provider]; !ok {
+			t.Errorf("provider %q has no watchdog auth probe — its credentials would go unverified", provider)
+		}
+	}
+}


### PR DESCRIPTION
Test-only PR addressing the largest absolute test gap from the quality report: src/cmd/hive/main.go at 16.9%% statement coverage over 4046 statements.

Adds 12 new focused test files in package main, following the existing per-topic test-file idiom. No non-test file is touched.

## Areas covered and invariants asserted

- **agent_activity_test.go** — agentActivityFor: #4041 pause provenance (WHO/WHY/WHEN) rides to the hub verbatim; on-demand agents (own flag or ACMM pack) never report ExpectedActive; an unknown agent reports all-false capabilities (hub-side UNKNOWN, never a fabricated divergence verdict); nil config leaves the EXPECTED leg conservatively false.
- **hive_pr_observations_test.go** — hivePRObservations: human-authored PRs never become escalation observations (the reaper must not re-dispatch onto a human branch); repos are fully qualified so the escalation ledger never splits attempt counts; red strictly requires a named failing required check (CIStatus alone is not enough); failure excerpts ride as fix evidence.
- **quota_exhausted_agents_test.go** — quotaExhaustedAgentCount counts only running, unpaused, out-of-quota agents; case-insensitive state match; nil/empty safe.
- **watchdog_auth_probes_test.go** — every rotation provider (anthropic, openai, google, deepseek) gets exactly one watchdog auth probe; a missing key would silently exempt that provider from credential verification.
- **gateway_resolution_test.go** — resolveWatsonxGateway prefers the canonical name+kind slot over kind-only, falls back correctly, case-insensitive; resolveGatewayAuth hands non-watsonx keys back VERBATIM with no extra headers (keyless gateways never fabricate a credential); litellm local-proxy URL stays loopback on the pinned port.
- **review_dispatch_gates_test.go** — planReviewDispatch plans NOTHING unless require_approval AND fan_out are both enabled; nil config/enumeration yield an empty plan.
- **intent_advisory_record_test.go** — recordIntentAlignmentAdvisory mints exactly one open advisory bead per misaligned PR with the evidence in notes, dedupes re-observations while open, honors the intent→quality→any store fallback, and no-ops (never panics) with no usable store.
- **plan_from_label_wiring_test.go** — the plan label mints nothing below the planning ACMM floor (an epic nothing decomposes must never exist); at the floor, epics route only to the architect store; the nil governor makes any stray kick panic, so the deny path is asserted by construction.
- **login_scan_gates_test.go** — the login detector stands down completely on empty/blank/invalid pattern sets: nil manager/notifier/dashboard collaborators enforce that no pane read, pause, or notification can escape the gate.
- **nous_state_defaults_test.go** — loadNousState status-map internal consistency: legacy and new key spellings agree, counts match loaded state, phase follows the ledger.
- **hive_id_identity_test.go** — operator HIVE_ID always wins; the identity is always non-empty and whitespace-free; randomName is always a well-formed lowercase adjective-noun token.
- **repo_name_resolution_test.go** — fullRepoName never rewrites a foreign owner (merge/approval checks must never be pointed at the wrong repo); bareRepoName collapses qualified and bare spellings to one attribution key; describeKeySource renders the explicit (unset) marker.

Fixes #4900