### PR TITLE
🧹 lint: fix all 11 ineffassign findings and enable ineffassign in the gate

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -35,10 +35,12 @@ linters:
     # its own PR after its findings are fixed — that ratchet is tracked in the
     # ratchet issue #4903.
     #
-    # ineffassign (11) is the cheapest next rung; errcheck (579) is the most
-    # valuable and the largest, and is worth splitting by package.
+    # errcheck (579) is the most valuable remaining rung and the largest, and
+    # is worth splitting by package.
     - govet
     - misspell
+    # RATCHET: ineffassign enabled after its 11 findings were fixed (#4903).
+    - ineffassign
 
   exclusions:
     generated: lax

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2503,7 +2503,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		_ = m.verifyBobStateDirsWritable(agent.Name, bobSharedHome, m.workDir+"/"+agent.Name, agent.UID)
 	}
 
-	launchCmd := binary
+	var launchCmd string
 	model := agent.Config.Model
 	if agent.ModelOverride != "" {
 		model = agent.ModelOverride
@@ -3484,36 +3484,13 @@ var acmmLevelNames = map[int]string{
 }
 
 func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
-	// Look for policy files in priority order.
-	// For advisory agents (non-quality at L3+), prefer <agent>-advisory.md
-	// over <agent>.md so they get the correct advisory-only instructions.
-	policyDir := m.project.PolicyDir
-	if policyDir == "" {
-		policyDir = "/data/policies/agents"
-	}
-	policiesRoot := filepath.Dir(policyDir)
-	if policiesRoot == "." || policiesRoot == "" {
-		policiesRoot = "/data/policies"
-	}
-	mode := m.agentMode(agent)
-	suffix := mode.SuffixForLevel(m.project.ACMMLevel)
-
-	var paths []string
-	if agent.Config.KickTemplate != "" {
-		paths = append(paths, fmt.Sprintf("%s/%s", policyDir, agent.Config.KickTemplate))
-	}
-	paths = append(paths,
-		fmt.Sprintf("%s/%s%s.md", policyDir, agent.Name, suffix),
-		fmt.Sprintf("%s/%s.md", policyDir, agent.Name),
-		fmt.Sprintf("/data/agents/%s/CLAUDE.md", agent.Name),
-		filepath.Join(policiesRoot, "examples", "agents", agent.Name+suffix+".md"),
-		filepath.Join(policiesRoot, "examples", "agents", agent.Name+".md"),
-		fmt.Sprintf("/opt/hive/examples/agents/%s.md", agent.Name),
-	)
 	// No boot prompt — the governor's first eval cycle (10s after startup)
 	// kicks all due agents via BuildKickMessages with fully substituted
 	// templates. Sending a boot prompt here caused unsubstituted ${ISSUE_LIST}
-	// and other vars to reach the agent.
+	// and other vars to reach the agent. The policy-file path list this
+	// function used to assemble was dead code once the boot prompt was
+	// removed, so it is gone too.
+	_ = agent // signature kept for the call site; the arg is no longer read
 	return ""
 }
 

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -7903,11 +7903,6 @@ func (s *Server) buildAgentLeaderboardEntries() []LeaderboardEntry {
 		prsOpened, issuesFixed, totalFindings := s.countAgentActivity(name)
 		tasksCompleted := prsOpened + issuesFixed
 
-		displayName := proc.Config.DisplayName
-		if displayName == "" {
-			displayName = name
-		}
-
 		emoji := proc.Config.Emoji
 		if emoji == "" {
 			emoji = "\U0001F916"

--- a/src/pkg/hub/impersonation_test.go
+++ b/src/pkg/hub/impersonation_test.go
@@ -360,8 +360,8 @@ func TestImpersonationNoPrivilegeEscalation(t *testing.T) {
 	get2.AddCookie(testAuthCookie("bob"))
 	get2.AddCookie(impersonateCookie("bob", "alice", now))
 	eff, real, imp = s.resolveIdentity(get2)
-	if imp || eff != "bob" {
-		t.Errorf("non-admin self-minted grant honored: eff=%q imp=%v; want bob/false", eff, imp)
+	if imp || eff != "bob" || real != "bob" {
+		t.Errorf("non-admin self-minted grant honored: eff=%q real=%q imp=%v; want bob/bob/false", eff, real, imp)
 	}
 }
 

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2389,16 +2389,6 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 		}
 	}
 
-	aggCPUPct := 0
-	if aggCPUAlloc > 0 {
-		aggCPUPct = int(aggCPUUsed * percentMultiplier / aggCPUAlloc)
-	}
-	aggMemPct := 0
-	if aggMemAlloc > 0 {
-		aggMemPct = int(aggMemUsed * percentMultiplier / aggMemAlloc)
-	}
-	aggMemGB := int(aggMemAlloc / giToBytes)
-
 	// Include heartbeat-only clusters that are NOT in s.clusters but do have
 	// heartbeat-reported health data. This handles firewalled spokes whose
 	// cluster isn't in the hub's clusters.json.
@@ -2422,16 +2412,17 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 	}
 	s.heartbeatHealthMu.RUnlock()
 
-	// Recompute aggregates after including heartbeat-only clusters.
-	aggCPUPct = 0
+	// Compute aggregates only after heartbeat-only clusters are included; an
+	// earlier pre-inclusion computation was dead (always overwritten here).
+	aggCPUPct := 0
 	if aggCPUAlloc > 0 {
 		aggCPUPct = int(aggCPUUsed * percentMultiplier / aggCPUAlloc)
 	}
-	aggMemPct = 0
+	aggMemPct := 0
 	if aggMemAlloc > 0 {
 		aggMemPct = int(aggMemUsed * percentMultiplier / aggMemAlloc)
 	}
-	aggMemGB = int(aggMemAlloc / giToBytes)
+	aggMemGB := int(aggMemAlloc / giToBytes)
 
 	// Sort clusters by ID for deterministic output.
 	sort.Slice(perCluster, func(i, j int) bool {
@@ -4159,7 +4150,9 @@ func (s *HubServer) handleOpenHive(w http.ResponseWriter, r *http.Request) {
 	// Access gate: only the owner, an authorized user, or the hub admin may open
 	// the spoke. The role we pass is advisory — the spoke re-checks its own
 	// allowlist and uses that role authoritatively.
-	role := saasRoleRead
+	// Every branch below either assigns role or rejects the request, so no
+	// initializer is needed (and ineffassign flags one as dead).
+	var role string
 	if isHubAdmin(username) {
 		role = saasRoleOwner
 	} else {

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -2517,7 +2517,6 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			s.mu.Unlock()
 			s.logger.Info("heartbeat: spoke branch switch complete",
 				"hive_id", payload.HiveID, "branch", payload.GitBranch)
-			switchTag = ""
 		} else if spokeUpgradesPausedNow {
 			// Kill switch: keep the armed tag but do not put it on the wire.
 			s.logger.Debug("heartbeat: switch instruction withheld — spoke upgrades are paused",

--- a/src/pkg/hubbackup/backup_test.go
+++ b/src/pkg/hubbackup/backup_test.go
@@ -1,16 +1,16 @@
 package hubbackup
 
 import (
-	"syscall"
-	"encoding/json"
-	"compress/gzip"
-	"bytes"
 	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/config"
@@ -266,7 +266,7 @@ func TestBuildIncludesSpokesAndSecrets(t *testing.T) {
 
 	spokes := fakeSpokes{spokes: []SpokeConfig{
 		{ID: "hosted-x", Files: map[string][]byte{
-			"hive.yaml.runtime":       []byte("project:\n  org: acme\n"),
+			"hive.yaml.runtime":   []byte("project:\n  org: acme\n"),
 			"hive-id":             []byte("hosted-x"),
 			"gh-app-key-5686.pem": []byte("-----BEGIN RSA PRIVATE KEY-----\n"),
 		}},
@@ -324,7 +324,7 @@ func TestExtractRestoresContent(t *testing.T) {
 	spokes := fakeSpokes{spokes: []SpokeConfig{
 		{ID: "hosted-x", Files: map[string][]byte{
 			"hive.yaml.runtime": spokeYAML,
-			"hive-id":       []byte("hosted-x"),
+			"hive-id":           []byte("hosted-x"),
 		}},
 	}}
 	sealed, _, err := Build(key, spokes, nil, quietLogger())
@@ -445,9 +445,7 @@ func TestKubectlArgsForRemoteCluster(t *testing.T) {
 }
 
 func TestStripSecretNoise(t *testing.T) {
-	raw := []byte(`{"kind":"Secret","metadata":{"name":"x","uid":"u1',","resourceVersion":"9","creationTimestamp":"t"},"data":{"a":"b"}}`)
-	// Use a well-formed input.
-	raw = []byte(`{"kind":"Secret","metadata":{"name":"x","uid":"u1","resourceVersion":"9","creationTimestamp":"t"},"data":{"a":"b"}}`)
+	raw := []byte(`{"kind":"Secret","metadata":{"name":"x","uid":"u1","resourceVersion":"9","creationTimestamp":"t"},"data":{"a":"b"}}`)
 	out, err := stripSecretNoise(raw)
 	if err != nil {
 		t.Fatal(err)

--- a/src/pkg/resolve/registry_test.go
+++ b/src/pkg/resolve/registry_test.go
@@ -140,11 +140,10 @@ func TestRuntimeContext_Hit(t *testing.T) {
 func TestBuild_UnknownType_Skipped(t *testing.T) {
 	specs := []VarSpec{{Name: "V", Type: "nonexistent", Scope: ScopeConfig}}
 	reg := Build(specs, Policy{}, nil)
-	// Unknown type is skipped — variable left literal.
-	got := reg.Expand(context.Background(), "${V}", ScopeConfig, nil)
-	// Since no env var V is set, bare env fallback also fails → literal.
+	// Unknown type is skipped — variable left literal. With no env var V
+	// set, the bare env fallback also fails → literal survives.
 	os.Unsetenv("V")
-	got = reg.Expand(context.Background(), "${V}", ScopeConfig, nil)
+	got := reg.Expand(context.Background(), "${V}", ScopeConfig, nil)
 	if got != "${V}" {
 		t.Errorf("unknown type should leave literal, got %q", got)
 	}


### PR DESCRIPTION
Rung 1 of the static-analysis ratchet. Fixes every finding `ineffassign` reports on v4, then enables the linter in `src/.golangci.yml` in the same PR so the class cannot regress. One linter per PR, per the ratchet procedure.

Part of #4903

## The 11 findings and how each was resolved

| Site | Resolution |
|---|---|
| `pkg/agent/manager.go:2506` `launchCmd := binary` | Initial value is overwritten on every backend branch before use → `var launchCmd string`. |
| `pkg/agent/manager.go:3505` `paths = append(...)` | The whole path-list assembly in `buildBootstrapPrompt` was dead: the function deliberately returns `""` (boot prompts were removed in favor of governor kicks) and never read `paths`. Removed the dead assembly, kept the explanatory comment and the call-site-compatible signature. |
| `pkg/dashboard/api_contribute.go:7908` `displayName` | Computed but never used — `LeaderboardEntry` has no display-name field and deliberately uses the agent name. Dead code removed. |
| `pkg/hub/impersonation_test.go:362` `real` | Second `resolveIdentity` assertion ignored the returned `real` identity. Strengthened the test to assert `real == "bob"` as well — the assertion is now stronger, not weaker. |
| `pkg/hub/saas.go:2394/2398/2400` agg aggregates | Aggregates were computed once BEFORE heartbeat-only clusters were merged in and then unconditionally recomputed after. The pre-inclusion computation was fully dead; removed it and made the post-inclusion computation the declaration. No behavior change — only the second computation was ever read. |
| `pkg/hub/saas.go:4162` `role := saasRoleRead` | Every branch either assigns `role` or rejects the request with 403/409, so the initializer was dead → `var role string` with a comment. |
| `pkg/hub/server.go:2520` `switchTag = ""` | Local cleared after the switch-complete log, but `switchTag` is never read again in the function. Dead store removed; the authoritative clear is the `delete(s.heartbeatSwitchTag, ...)` just above it. |
| `pkg/hubbackup/backup_test.go:448` `raw` | First assignment (a malformed-JSON literal with a stray `',`) was immediately overwritten by the "well-formed input" line — leftover from an earlier edit. Removed. |
| `pkg/resolve/registry_test.go:144` `got` | `Expand` was called twice with the first result discarded; only the post-`Unsetenv` call is asserted. Removed the redundant first call. |

None of the findings concealed a live bug: each was either a dead store, dead code, or (in the two tests) an unasserted value — and the impersonation test now asserts it.

## Gate change

`src/.golangci.yml`: `ineffassign` added to the enabled set; header comments updated to reflect the rung landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fp3vjF34D23HauvZeicDa