### PR TITLE
feat(turn): prototype durable re-entrant turns

### DIFF
--- a/src/docs/design/README.md
+++ b/src/docs/design/README.md
@@ -59,17 +59,14 @@ that status is the thing to check before treating a page as current behaviour:
   programmatic path that does work today.
 
 - [The agent turn model and where in-process state lives](agent-turn-model.md) —
-  **spike / investigation, informational.** Step 1 of RFC #4002 and the only
-  step taken: a cited map of how hive drives an agent turn today and which
-  per-agent state does not survive a process restart. No decision, no
-  prototype, no proposal. Its main finding is that there is no "turn" in the
-  code at all — a turn begins when hive types a prompt into a tmux pane and
-  ends when the pane matches an idle-prompt marker, so every progress signal
-  hive has (turn completion, liveness, stalls, auth failure) is screen-scraped
-  rendered terminal text. Read it before steps 2-4, particularly for the fork
-  it names: hive does not own the conversation format, so
-  "conversation-as-state" means either accepting backend-specific resume
-  envelopes or moving off opaque interactive CLIs.
+  **spike / investigation, steps 1 and 2 complete.** A cited map of how hive
+  drives an agent turn today and which state does not survive restart, plus an
+  isolated `pkg/turn` prototype: serialized conversation and operation state,
+  a re-entrant structured `Step`, atomic scrubbed persistence, and a replay
+  test that kills a contribute-shaped turn at every operation boundary. It is
+  not wired to the tmux loop or contributor relay, and takes no production
+  decision. Read it before steps 3-4, particularly for the unresolved fork:
+  backend-specific resume envelopes versus an API-shaped backend hive owns.
 
 - [Copilot per-repo cost capture at the MITM proxy](copilot-cost-capture.md) —
   **investigation, no decision taken.** Phase 4 of epic #4836, which asked

--- a/src/docs/design/agent-turn-model.md
+++ b/src/docs/design/agent-turn-model.md
@@ -1,13 +1,15 @@
 # The agent turn model and where in-process state lives (#4002)
 
-Status: **spike / investigation — informational, no decision taken.**
+Status: **spike / investigation — steps 1 and 2 complete, no production
+decision taken.**
 
-This is step 1 of the four steps proposed in RFC #4002 ("re-entrant
-conversation-as-state agent turn model"). It documents how hive drives an agent
-turn **today** and where per-agent state lives that would not survive a process
-restart. It prototypes nothing, proposes nothing, and takes no decision — steps
-2 (prototype), 3 (handoff path), and 4 (feasibility + migration cost) are
-untouched.
+Step 1 of RFC #4002 documented how hive drives an agent turn **today** and where
+per-agent state lives that would not survive a process restart. Step 2 now adds
+an isolated, contribute-shaped prototype in `pkg/turn`: a re-entrant `Step`
+function over a serialized conversation envelope, with journaled external
+effects and crash/reload tests. Nothing constructs it in the live tmux agent
+loop or contributor relay. Steps 3 (handoff path) and 4 (feasibility + migration
+cost) remain untouched.
 
 Every claim below carries a `file:line` citation against `origin/v4` at the time
 of writing. Line numbers drift; the function names are the durable handle. Where
@@ -414,6 +416,107 @@ A structured turn return value — the RFC's testability and subagent-sync
 benefits — is not a refactor of an existing structured signal. There is no
 structured signal. It would be a new capability, and it requires a channel to
 the backend that hive does not currently have.
+
+---
+
+## 6. Step 2 prototype: a re-entrant contribute turn
+
+The additive prototype in [`pkg/turn`](../../pkg/turn/) takes the smallest
+headless slice that exercises the RFC's state claim without pretending the tmux
+path can provide a structured conversation. Its public transition is:
+
+```text
+Step(SessionEnvelope, optional initial TurnPlan)
+    -> (SessionEnvelope, TurnOutput, error)
+```
+
+It carries the operation-journal lesson previously exercised on the earlier
+`v5` line in [#4053](https://github.com/kubestellar/hive/pull/4053) onto current
+`v4`, and adds the real atomic file store plus fail-closed handling for effects
+that cannot be reconciled.
+
+The first invocation binds the ordered plan into the envelope. A later process
+receives only the serialized envelope and calls `Step` with no plan. The
+envelope carries the conversation, task and agent identity, bound operation
+plan, operation journal, status, and terminal contribute verdict. The return is
+structured (`status`, `done`, `verdict`, `rationale`, landed effects); no pane
+substring decides whether the turn finished.
+
+This is a prototype boundary, not a new production path. It does not call an
+LLM, replace a backend CLI, or run from `bin/contributor-relay.sh`. A headless
+backend adapter would produce the initial plan; the spike starts immediately
+after that model call, where re-entry meets external side effects and where a
+duplicate is more damaging than repeated inference.
+
+### 6.1 Durable operation protocol
+
+Each side-effectful operation has a stable key derived from:
+
+```text
+v1 + sha256(session | kind | repo | target | body)[:32]
+```
+
+The model's tool-call ID is recorded for traceability but excluded from the
+key, because a repeated inference can mint a new call ID for the same semantic
+effect. Keys are bound into the plan before persistence, so scrub-on-persist
+cannot change operation identity.
+
+An operation crosses two durable boundaries:
+
+1. Write `intended` to the envelope and commit it before the external write.
+2. Perform the write.
+3. Write `succeeded` or `failed` and commit again.
+
+On re-entry, `succeeded` short-circuits. `intended` is the ambiguous crash
+window: the write may have landed before the process died, so the runner asks a
+remote reconciler before proceeding. If no reconciler exists, it fails closed
+with `ErrAmbiguous`; it does not blindly replay. This is stricter than
+at-least-once delivery and deliberately trades manual recovery for never
+silently creating a duplicate PR or comment.
+
+`FileStore` makes those boundaries real rather than test-only: it serializes
+through the fleet's `logscrub` boundary, writes a mode-`0600` temporary file,
+syncs it, and atomically renames it over the prior envelope. The in-memory
+conversation is not redacted or mutated; only the artifact that can cross a
+process or spoke boundary is scrubbed.
+
+### 6.2 What the replay test establishes
+
+`TestStepReentersAtEveryPersistenceBoundary` drives a contribute-shaped turn
+(comment → push → PR create → label), kills it before every intent, settle, and
+terminal-envelope commit, discards all in-memory state, reloads only serialized
+JSON, and re-enters. Every case must produce:
+
+- exactly one call per external effect;
+- the same ordered effect summary and `shipped` verdict as an uninterrupted
+  control;
+- no ambiguous journal entries at completion.
+
+Separate tests prove that an ambiguous operation without reconciliation never
+replays, a known-not-landed operation does run, a failed operation can retry,
+semantic keys survive a freshly minted tool-call ID, and the persisted artifact
+contains no credential-shaped plaintext. `pkg/turn` remains above the
+repository's 90% package coverage floor under `go test -race`.
+
+### 6.3 What step 2 does not establish
+
+1. **Inference is outside the envelope transition.** A crash before the plan is
+   committed repeats inference and may produce a different plan. The prototype
+   protects landed effects, not token cost or plan determinism.
+2. **Reconciliation is effect-specific.** PR-by-head has a good remote
+   surrogate; pushes and high-traffic comments do not. Those effects stop as
+   ambiguous instead of claiming exactly-once semantics they cannot provide.
+3. **There is no concurrency claim.** The journal makes sequential re-entry
+   safe. It does not let two processes race one envelope. Step 3 must reuse the
+   contributor relay's existing offer→claim ownership rather than create a
+   fifth durable-state store or parallel claim system.
+4. **No backend conversation is captured.** The package proves the envelope
+   and side-effect protocol after a structured headless response. It does not
+   resolve §5.1's backend-native-resume versus API-shaped-backend fork.
+5. **The beads comparison is not measured.** A bead checkpoint can carry task
+   notes, but not this operation journal or a structured backend response today.
+   Step 4 still needs the proposed kill-at-50% comparison before recommending
+   the larger migration.
 
 ---
 

--- a/src/pkg/turn/envelope.go
+++ b/src/pkg/turn/envelope.go
@@ -1,0 +1,156 @@
+// Package turn prototypes a re-entrant, conversation-as-state agent turn.
+//
+// It is deliberately not wired into hive's tmux agent loop. The package is a
+// bounded spike for RFC #4002: all state needed to resume a contribute-shaped
+// turn is carried by SessionEnvelope, and Step returns a structured TurnOutput.
+package turn
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/logscrub"
+)
+
+const EnvelopeVersion = 1
+
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+type Message struct {
+	Role       Role              `json:"role"`
+	Content    string            `json:"content"`
+	Name       string            `json:"name,omitempty"`
+	ToolCallID string            `json:"tool_call_id,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+	Timestamp  time.Time         `json:"timestamp"`
+}
+
+type Status string
+
+const (
+	StatusActive    Status = "active"
+	StatusCompleted Status = "completed"
+	StatusFailed    Status = "failed"
+)
+
+type Verdict string
+
+const (
+	VerdictShipped      Verdict = "shipped"
+	VerdictNoWorkNeeded Verdict = "no_work_needed"
+	VerdictFailed       Verdict = "failed"
+)
+
+// TurnPlan is the ordered work for a single headless contribute turn. It lives
+// in the envelope rather than on a Runner so a fresh process does not need the
+// process that produced the plan in order to resume it.
+type TurnPlan struct {
+	Operations []PlannedOperation `json:"operations,omitempty"`
+	Verdict    Verdict            `json:"verdict"`
+	Rationale  string             `json:"rationale,omitempty"`
+}
+
+type PlannedOperation struct {
+	// IdempotencyKey is bound once, when the plan first enters the envelope.
+	// It remains stable even if scrub-on-persist redacts credential-shaped text
+	// from the operation body.
+	IdempotencyKey string   `json:"idempotency_key"`
+	Intent         OpIntent `json:"intent"`
+}
+
+// SessionEnvelope is the complete, serializable state of a prototype turn.
+// It can be discarded in memory after every Step and reconstructed from JSON.
+type SessionEnvelope struct {
+	Version   int       `json:"version"`
+	SessionID string    `json:"session_id"`
+	Agent     string    `json:"agent,omitempty"`
+	TaskRef   string    `json:"task_ref,omitempty"`
+	Status    Status    `json:"status"`
+	Messages  []Message `json:"messages,omitempty"`
+	Plan      *TurnPlan `json:"plan,omitempty"`
+	Journal   Journal   `json:"journal,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// TurnOutput is the structured return from one re-entrant Step invocation.
+type TurnOutput struct {
+	Status    Status         `json:"status"`
+	Done      bool           `json:"done"`
+	Verdict   Verdict        `json:"verdict,omitempty"`
+	Rationale string         `json:"rationale,omitempty"`
+	Effects   []JournalEntry `json:"effects,omitempty"`
+}
+
+func (e SessionEnvelope) Validate() error {
+	if e.Version != EnvelopeVersion {
+		return fmt.Errorf("turn: envelope version %d, want %d", e.Version, EnvelopeVersion)
+	}
+	if e.SessionID == "" {
+		return fmt.Errorf("turn: session ID is required")
+	}
+	return nil
+}
+
+func (e SessionEnvelope) Clone() SessionEnvelope {
+	data, _ := json.Marshal(e)
+	var out SessionEnvelope
+	_ = json.Unmarshal(data, &out)
+	return out
+}
+
+// ToJSON is the persistence boundary. The durable envelope may cross process
+// or spoke boundaries, so every content-bearing field is scrubbed here while
+// the in-memory envelope remains untouched.
+func (e SessionEnvelope) ToJSON() ([]byte, error) {
+	return json.Marshal(e.scrubbedForPersist())
+}
+
+func ParseEnvelope(data []byte) (SessionEnvelope, error) {
+	var env SessionEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return SessionEnvelope{}, fmt.Errorf("turn: parse envelope: %w", err)
+	}
+	if err := env.Validate(); err != nil {
+		return SessionEnvelope{}, err
+	}
+	return env, nil
+}
+
+func (e SessionEnvelope) scrubbedForPersist() SessionEnvelope {
+	out := e.Clone()
+	out.Agent = logscrub.ScrubString(out.Agent)
+	out.TaskRef = logscrub.ScrubString(out.TaskRef)
+	for i := range out.Messages {
+		out.Messages[i].Content = logscrub.ScrubString(out.Messages[i].Content)
+		out.Messages[i].Name = logscrub.ScrubString(out.Messages[i].Name)
+		for key, value := range out.Messages[i].Metadata {
+			out.Messages[i].Metadata[key] = logscrub.ScrubString(value)
+		}
+	}
+	if out.Plan != nil {
+		out.Plan.Rationale = logscrub.ScrubString(out.Plan.Rationale)
+		for i := range out.Plan.Operations {
+			op := &out.Plan.Operations[i].Intent
+			op.Repo = logscrub.ScrubString(op.Repo)
+			op.Target = logscrub.ScrubString(op.Target)
+			op.Body = logscrub.ScrubString(op.Body)
+		}
+	}
+	for i := range out.Journal.Entries {
+		entry := &out.Journal.Entries[i]
+		entry.Repo = logscrub.ScrubString(entry.Repo)
+		entry.Target = logscrub.ScrubString(entry.Target)
+		entry.ExternalRef = logscrub.ScrubString(entry.ExternalRef)
+		entry.Error = logscrub.ScrubString(entry.Error)
+	}
+	return out
+}

--- a/src/pkg/turn/journal.go
+++ b/src/pkg/turn/journal.go
@@ -1,0 +1,147 @@
+package turn
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+type OpKind string
+
+const (
+	OpPRCreate OpKind = "pr_create"
+	OpPREdit   OpKind = "pr_edit"
+	OpComment  OpKind = "comment"
+	OpPush     OpKind = "push"
+	OpLabel    OpKind = "label"
+)
+
+type OpStatus string
+
+const (
+	// OpIntended is persisted before the effect. On recovery it means the
+	// effect may have landed and must be reconciled, never blindly replayed.
+	OpIntended  OpStatus = "intended"
+	OpSucceeded OpStatus = "succeeded"
+	OpFailed    OpStatus = "failed"
+)
+
+type OpIntent struct {
+	Kind       OpKind `json:"kind"`
+	Repo       string `json:"repo,omitempty"`
+	Target     string `json:"target,omitempty"`
+	Body       string `json:"body,omitempty"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+type JournalEntry struct {
+	IdempotencyKey string    `json:"idempotency_key"`
+	Kind           OpKind    `json:"kind"`
+	Status         OpStatus  `json:"status"`
+	Repo           string    `json:"repo,omitempty"`
+	Target         string    `json:"target,omitempty"`
+	ToolCallID     string    `json:"tool_call_id,omitempty"`
+	ExternalRef    string    `json:"external_ref,omitempty"`
+	Error          string    `json:"error,omitempty"`
+	Attempts       int       `json:"attempts"`
+	IntendedAt     time.Time `json:"intended_at"`
+	SettledAt      time.Time `json:"settled_at,omitempty"`
+}
+
+func (e JournalEntry) Done() bool      { return e.Status == OpSucceeded }
+func (e JournalEntry) Ambiguous() bool { return e.Status == OpIntended }
+
+const idempotencyKeyVersion = "v1"
+
+// DeriveIdempotencyKey is stable across processes and model retries. A model's
+// ToolCallID is deliberately excluded because inference can mint a new call ID
+// for the same semantic effect after re-entry.
+func DeriveIdempotencyKey(sessionID string, in OpIntent) string {
+	h := sha256.New()
+	for _, part := range []string{
+		idempotencyKeyVersion,
+		sessionID,
+		string(in.Kind),
+		in.Repo,
+		in.Target,
+		in.Body,
+	} {
+		_, _ = fmt.Fprintf(h, "%d:%s|", len(part), part)
+	}
+	return idempotencyKeyVersion + "-" + hex.EncodeToString(h.Sum(nil))[:32]
+}
+
+type Journal struct {
+	Entries []JournalEntry `json:"entries,omitempty"`
+}
+
+func (j *Journal) Lookup(key string) (JournalEntry, bool) {
+	for _, entry := range j.Entries {
+		if entry.IdempotencyKey == key {
+			return entry, true
+		}
+	}
+	return JournalEntry{}, false
+}
+
+func (j *Journal) recordIntent(key string, in OpIntent, now time.Time) JournalEntry {
+	for i := range j.Entries {
+		if j.Entries[i].IdempotencyKey != key {
+			continue
+		}
+		j.Entries[i].Status = OpIntended
+		j.Entries[i].Error = ""
+		j.Entries[i].SettledAt = time.Time{}
+		j.Entries[i].Attempts++
+		return j.Entries[i]
+	}
+	entry := JournalEntry{
+		IdempotencyKey: key,
+		Kind:           in.Kind,
+		Status:         OpIntended,
+		Repo:           in.Repo,
+		Target:         in.Target,
+		ToolCallID:     in.ToolCallID,
+		Attempts:       1,
+		IntendedAt:     now,
+	}
+	j.Entries = append(j.Entries, entry)
+	return entry
+}
+
+func (j *Journal) settle(key string, status OpStatus, externalRef, errText string, now time.Time) {
+	for i := range j.Entries {
+		if j.Entries[i].IdempotencyKey != key {
+			continue
+		}
+		j.Entries[i].Status = status
+		j.Entries[i].ExternalRef = externalRef
+		j.Entries[i].Error = errText
+		j.Entries[i].SettledAt = now
+		return
+	}
+}
+
+func (j *Journal) Ambiguous() []JournalEntry {
+	var entries []JournalEntry
+	for _, entry := range j.Entries {
+		if entry.Ambiguous() {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+func (j *Journal) Summary() string {
+	var lines []string
+	for _, entry := range j.Entries {
+		if entry.Done() {
+			lines = append(lines, fmt.Sprintf("%s %s/%s -> %s", entry.Kind, entry.Repo, entry.Target, entry.ExternalRef))
+		}
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}

--- a/src/pkg/turn/runner.go
+++ b/src/pkg/turn/runner.go
@@ -1,0 +1,179 @@
+package turn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+type EffectResult struct {
+	ExternalRef    string
+	Output         string
+	AlreadyExisted bool
+}
+
+type EffectSink interface {
+	Perform(context.Context, OpIntent) (EffectResult, error)
+}
+
+type Reconciler interface {
+	Reconcile(context.Context, OpIntent) (ref string, found bool, err error)
+}
+
+type Persister interface {
+	Persist(context.Context, SessionEnvelope) error
+}
+
+var ErrAmbiguous = errors.New("turn: effect outcome is ambiguous and no reconciler is available")
+
+// JournaledExecutor owns the intent-persist / effect / settle-persist protocol.
+type JournaledExecutor struct {
+	Sink       EffectSink
+	Reconciler Reconciler
+	Persister  Persister
+	Now        func() time.Time
+}
+
+func (x *JournaledExecutor) now() time.Time {
+	if x.Now != nil {
+		return x.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (x *JournaledExecutor) Do(ctx context.Context, env *SessionEnvelope, op PlannedOperation) (EffectResult, error) {
+	if env == nil {
+		return EffectResult{}, fmt.Errorf("turn: nil envelope")
+	}
+	if op.IdempotencyKey == "" {
+		return EffectResult{}, fmt.Errorf("turn: operation has no idempotency key")
+	}
+	if prior, ok := env.Journal.Lookup(op.IdempotencyKey); ok && prior.Done() {
+		return EffectResult{ExternalRef: prior.ExternalRef, AlreadyExisted: true}, nil
+	}
+	if prior, ok := env.Journal.Lookup(op.IdempotencyKey); ok && prior.Ambiguous() {
+		if x.Reconciler == nil {
+			return EffectResult{}, fmt.Errorf("%w: %s", ErrAmbiguous, op.IdempotencyKey)
+		}
+		ref, found, err := x.Reconciler.Reconcile(ctx, op.Intent)
+		if err != nil {
+			return EffectResult{}, fmt.Errorf("turn: reconcile %s: %w", op.IdempotencyKey, err)
+		}
+		if found {
+			env.Journal.settle(op.IdempotencyKey, OpSucceeded, ref, "", x.now())
+			if err := x.persist(ctx, *env); err != nil {
+				return EffectResult{}, err
+			}
+			return EffectResult{ExternalRef: ref, AlreadyExisted: true}, nil
+		}
+	}
+	if x.Sink == nil {
+		return EffectResult{}, fmt.Errorf("turn: no effect sink configured")
+	}
+	if x.Persister == nil {
+		return EffectResult{}, fmt.Errorf("turn: no persister configured")
+	}
+	env.Journal.recordIntent(op.IdempotencyKey, op.Intent, x.now())
+	if err := x.persist(ctx, *env); err != nil {
+		return EffectResult{}, err
+	}
+	result, err := x.Sink.Perform(ctx, op.Intent)
+	if err != nil {
+		env.Journal.settle(op.IdempotencyKey, OpFailed, "", err.Error(), x.now())
+		if persistErr := x.persist(ctx, *env); persistErr != nil {
+			return EffectResult{}, errors.Join(err, persistErr)
+		}
+		return EffectResult{}, err
+	}
+	env.Journal.settle(op.IdempotencyKey, OpSucceeded, result.ExternalRef, "", x.now())
+	if err := x.persist(ctx, *env); err != nil {
+		return EffectResult{}, err
+	}
+	return result, nil
+}
+
+func (x *JournaledExecutor) persist(ctx context.Context, env SessionEnvelope) error {
+	if x.Persister == nil {
+		return fmt.Errorf("turn: no persister configured")
+	}
+	env.UpdatedAt = x.now()
+	return x.Persister.Persist(ctx, env)
+}
+
+// Runner executes one contribute-shaped turn as a re-entrant function. The
+// first call binds input into the envelope. Later calls need only the envelope;
+// supplying a different plan is rejected instead of silently changing work.
+type Runner struct {
+	Executor *JournaledExecutor
+	Now      func() time.Time
+}
+
+func (r *Runner) now() time.Time {
+	if r.Now != nil {
+		return r.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (r *Runner) Step(ctx context.Context, env SessionEnvelope, input *TurnPlan) (SessionEnvelope, TurnOutput, error) {
+	outEnv := env.Clone()
+	if err := outEnv.Validate(); err != nil {
+		return outEnv, TurnOutput{}, err
+	}
+	if r.Executor == nil {
+		return outEnv, TurnOutput{}, fmt.Errorf("turn: no journaled executor configured")
+	}
+	if outEnv.CreatedAt.IsZero() {
+		outEnv.CreatedAt = r.now()
+	}
+	if outEnv.Plan == nil {
+		if input == nil {
+			return outEnv, TurnOutput{}, fmt.Errorf("turn: initial plan is required")
+		}
+		outEnv.Plan = bindPlan(outEnv.SessionID, input)
+	} else if input != nil && !reflect.DeepEqual(outEnv.Plan, bindPlan(outEnv.SessionID, input)) {
+		return outEnv, TurnOutput{}, fmt.Errorf("turn: input plan differs from persisted plan")
+	}
+	outEnv.Status = StatusActive
+	for _, operation := range outEnv.Plan.Operations {
+		if _, err := r.Executor.Do(ctx, &outEnv, operation); err != nil {
+			return outEnv, outputFor(outEnv), err
+		}
+	}
+	outEnv.Status = StatusCompleted
+	outEnv.UpdatedAt = r.now()
+	if err := r.Executor.persist(ctx, outEnv); err != nil {
+		return outEnv, outputFor(outEnv), err
+	}
+	return outEnv, outputFor(outEnv), nil
+}
+
+func bindPlan(sessionID string, input *TurnPlan) *TurnPlan {
+	bound := &TurnPlan{Verdict: input.Verdict, Rationale: input.Rationale}
+	bound.Operations = make([]PlannedOperation, len(input.Operations))
+	for i, operation := range input.Operations {
+		bound.Operations[i] = operation
+		// The caller does not choose operation identity. Binding always derives
+		// it from the session and semantic intent so a stale or model-supplied
+		// key cannot suppress unrelated work.
+		bound.Operations[i].IdempotencyKey = DeriveIdempotencyKey(sessionID, operation.Intent)
+	}
+	return bound
+}
+
+func outputFor(env SessionEnvelope) TurnOutput {
+	out := TurnOutput{Status: env.Status}
+	if env.Plan != nil {
+		out.Verdict = env.Plan.Verdict
+		out.Rationale = env.Plan.Rationale
+	}
+	for _, entry := range env.Journal.Entries {
+		if entry.Done() {
+			out.Effects = append(out.Effects, entry)
+		}
+	}
+	out.Done = env.Status == StatusCompleted
+	return out
+}

--- a/src/pkg/turn/runner_test.go
+++ b/src/pkg/turn/runner_test.go
@@ -1,0 +1,375 @@
+package turn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testToken = "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"
+
+type fakeRemote struct {
+	calls          map[string]int
+	refs           map[string]string
+	reconcileCalls int
+	fail           map[string]error
+}
+
+func newFakeRemote() *fakeRemote {
+	return &fakeRemote{
+		calls: make(map[string]int),
+		refs:  make(map[string]string),
+		fail:  make(map[string]error),
+	}
+}
+
+func effectID(in OpIntent) string {
+	return fmt.Sprintf("%s|%s|%s|%s", in.Kind, in.Repo, in.Target, in.Body)
+}
+
+func (f *fakeRemote) Perform(_ context.Context, in OpIntent) (EffectResult, error) {
+	id := effectID(in)
+	f.calls[id]++
+	if err := f.fail[id]; err != nil {
+		return EffectResult{}, err
+	}
+	ref := fmt.Sprintf("remote-%d", len(f.refs)+1)
+	f.refs[id] = ref
+	return EffectResult{ExternalRef: ref}, nil
+}
+
+func (f *fakeRemote) Reconcile(_ context.Context, in OpIntent) (string, bool, error) {
+	f.reconcileCalls++
+	ref, ok := f.refs[effectID(in)]
+	return ref, ok, nil
+}
+
+type killStore struct {
+	killAt   int
+	boundary int
+	saved    []byte
+}
+
+var errKilled = errors.New("test process killed")
+
+func (s *killStore) Persist(_ context.Context, env SessionEnvelope) error {
+	s.boundary++
+	if s.boundary == s.killAt {
+		return errKilled
+	}
+	data, err := env.ToJSON()
+	if err != nil {
+		return err
+	}
+	s.saved = data
+	return nil
+}
+
+func testEnvelope() SessionEnvelope {
+	return SessionEnvelope{
+		Version:   EnvelopeVersion,
+		SessionID: "session-4002",
+		Agent:     "contributor",
+		TaskRef:   "kubestellar/hive#4002",
+		Status:    StatusActive,
+		Messages: []Message{{
+			Role:      RoleUser,
+			Content:   "implement the re-entrant turn spike",
+			Timestamp: time.Unix(1, 0).UTC(),
+		}},
+	}
+}
+
+func testPlan() *TurnPlan {
+	return &TurnPlan{
+		Operations: []PlannedOperation{
+			{Intent: OpIntent{Kind: OpComment, Repo: "kubestellar/hive", Target: "4002", Body: "starting"}},
+			{Intent: OpIntent{Kind: OpPush, Repo: "kubestellar/hive", Target: "feat/4002", Body: "abc123"}},
+			{Intent: OpIntent{Kind: OpPRCreate, Repo: "kubestellar/hive", Target: "feat/4002", Body: "re-entrant turn spike"}},
+			{Intent: OpIntent{Kind: OpLabel, Repo: "kubestellar/hive", Target: "4002", Body: "needs-review"}},
+		},
+		Verdict:   VerdictShipped,
+		Rationale: "prototype completed",
+	}
+}
+
+func newRunner(remote *fakeRemote, store Persister) *Runner {
+	now := time.Unix(100, 0).UTC()
+	return &Runner{
+		Executor: &JournaledExecutor{
+			Sink:       remote,
+			Reconciler: remote,
+			Persister:  store,
+			Now:        func() time.Time { return now },
+		},
+		Now: func() time.Time { return now },
+	}
+}
+
+func TestStepReentersAtEveryPersistenceBoundary(t *testing.T) {
+	ctx := context.Background()
+	controlRemote := newFakeRemote()
+	controlStore := &killStore{}
+	controlEnv, controlOut, err := newRunner(controlRemote, controlStore).Step(ctx, testEnvelope(), testPlan())
+	if err != nil {
+		t.Fatalf("control Step: %v", err)
+	}
+	if !controlOut.Done || controlOut.Verdict != VerdictShipped || controlEnv.Status != StatusCompleted {
+		t.Fatalf("control output = %+v, status = %q", controlOut, controlEnv.Status)
+	}
+	if len(controlRemote.calls) != len(testPlan().Operations) {
+		t.Fatalf("control performed %d effects", len(controlRemote.calls))
+	}
+	wantSummary := controlEnv.Journal.Summary()
+
+	for boundary := 1; boundary <= controlStore.boundary; boundary++ {
+		t.Run(fmt.Sprintf("boundary_%02d", boundary), func(t *testing.T) {
+			remote := newFakeRemote()
+			store := &killStore{killAt: boundary}
+			runner := newRunner(remote, store)
+			_, _, err := runner.Step(ctx, testEnvelope(), testPlan())
+			if !errors.Is(err, errKilled) {
+				t.Fatalf("first Step error = %v, want process kill", err)
+			}
+
+			recovered := testEnvelope()
+			var input *TurnPlan = testPlan()
+			if store.saved != nil {
+				recovered, err = ParseEnvelope(store.saved)
+				if err != nil {
+					t.Fatalf("parse persisted envelope: %v", err)
+				}
+				input = nil // all resume state must come from the envelope
+			}
+			store.killAt = 0
+			gotEnv, gotOut, err := runner.Step(ctx, recovered, input)
+			if err != nil {
+				t.Fatalf("re-enter Step: %v", err)
+			}
+			if !gotOut.Done || gotOut.Verdict != controlOut.Verdict {
+				t.Errorf("output after re-entry = %+v", gotOut)
+			}
+			if got := gotEnv.Journal.Summary(); got != wantSummary {
+				t.Errorf("summary after re-entry:\n%s\nwant:\n%s", got, wantSummary)
+			}
+			if ambiguous := gotEnv.Journal.Ambiguous(); len(ambiguous) != 0 {
+				t.Errorf("ambiguous entries after re-entry: %+v", ambiguous)
+			}
+			for id, calls := range remote.calls {
+				if calls != 1 {
+					t.Errorf("effect %s performed %d times", id, calls)
+				}
+			}
+			if len(remote.calls) != len(testPlan().Operations) {
+				t.Errorf("performed %d distinct effects, want %d", len(remote.calls), len(testPlan().Operations))
+			}
+		})
+	}
+}
+
+func TestAmbiguousOperationFailsClosedWithoutReconciler(t *testing.T) {
+	env := testEnvelope()
+	plan := bindPlan(env.SessionID, testPlan())
+	op := plan.Operations[0]
+	env.Journal.recordIntent(op.IdempotencyKey, op.Intent, time.Now())
+	remote := newFakeRemote()
+	executor := &JournaledExecutor{Sink: remote, Persister: &killStore{}}
+
+	_, err := executor.Do(context.Background(), &env, op)
+	if !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("Do error = %v, want ErrAmbiguous", err)
+	}
+	if len(remote.calls) != 0 {
+		t.Fatal("ambiguous effect was replayed without reconciliation")
+	}
+}
+
+func TestReconcileNotFoundPerformsEffect(t *testing.T) {
+	env := testEnvelope()
+	op := bindPlan(env.SessionID, testPlan()).Operations[0]
+	env.Journal.recordIntent(op.IdempotencyKey, op.Intent, time.Now())
+	remote := newFakeRemote()
+	store := &killStore{}
+	executor := newRunner(remote, store).Executor
+
+	if _, err := executor.Do(context.Background(), &env, op); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if remote.reconcileCalls != 1 || remote.calls[effectID(op.Intent)] != 1 {
+		t.Fatalf("reconcile calls = %d, effect calls = %d", remote.reconcileCalls, remote.calls[effectID(op.Intent)])
+	}
+}
+
+func TestFailedEffectCanRetry(t *testing.T) {
+	env := testEnvelope()
+	op := bindPlan(env.SessionID, testPlan()).Operations[0]
+	remote := newFakeRemote()
+	remote.fail[effectID(op.Intent)] = errors.New("remote unavailable")
+	store := &killStore{}
+	executor := newRunner(remote, store).Executor
+
+	if _, err := executor.Do(context.Background(), &env, op); err == nil {
+		t.Fatal("first Do unexpectedly succeeded")
+	}
+	entry, _ := env.Journal.Lookup(op.IdempotencyKey)
+	if entry.Status != OpFailed {
+		t.Fatalf("entry status = %q", entry.Status)
+	}
+	delete(remote.fail, effectID(op.Intent))
+	if _, err := executor.Do(context.Background(), &env, op); err != nil {
+		t.Fatalf("retry Do: %v", err)
+	}
+	entry, _ = env.Journal.Lookup(op.IdempotencyKey)
+	if entry.Status != OpSucceeded || entry.Attempts != 2 {
+		t.Fatalf("entry after retry = %+v", entry)
+	}
+}
+
+func TestFileStoreRoundTripIsAtomicPrivateAndScrubbed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "turn.json")
+	store := FileStore{Path: path}
+	env := testEnvelope()
+	env.Messages[0].Content += " token=" + testToken
+	env.Messages[0].Metadata = map[string]string{"failure": "credential " + testToken}
+	env.Plan = bindPlan(env.SessionID, &TurnPlan{
+		Operations: []PlannedOperation{{Intent: OpIntent{Kind: OpPush, Repo: "kubestellar/hive", Target: "branch-" + testToken, Body: "push " + testToken}}},
+		Verdict:    VerdictShipped,
+		Rationale:  "used " + testToken,
+	})
+	env.Journal.Entries = []JournalEntry{{
+		IdempotencyKey: env.Plan.Operations[0].IdempotencyKey,
+		Kind:           OpPush,
+		Status:         OpFailed,
+		Error:          "remote rejected " + testToken,
+		ExternalRef:    "https://x-access-token:" + testToken + "@github.com/o/r",
+	}}
+
+	if err := store.Persist(context.Background(), env); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), testToken) || !strings.Contains(string(data), "[REDACTED]") {
+		t.Fatalf("persisted artifact was not scrubbed: %s", data)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %o, want 600", got)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".turn-envelope-*.tmp"))
+	if err != nil || len(matches) != 0 {
+		t.Errorf("temporary files after commit = %v, err = %v", matches, err)
+	}
+	restored, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if restored.Plan.Operations[0].IdempotencyKey != env.Plan.Operations[0].IdempotencyKey {
+		t.Fatal("scrubbing changed the bound idempotency key")
+	}
+	if strings.Contains(env.Messages[0].Content, "[REDACTED]") {
+		t.Fatal("persistence mutated the in-memory envelope")
+	}
+}
+
+func TestValidationAndConfigurationErrors(t *testing.T) {
+	ctx := context.Background()
+	if _, err := ParseEnvelope([]byte(`{"version":1}`)); err == nil {
+		t.Fatal("ParseEnvelope accepted an empty session ID")
+	}
+	if _, err := ParseEnvelope([]byte(`not-json`)); err == nil {
+		t.Fatal("ParseEnvelope accepted invalid JSON")
+	}
+	if err := (FileStore{}).Persist(ctx, testEnvelope()); err == nil {
+		t.Fatal("FileStore accepted an empty path")
+	}
+	if _, err := (FileStore{}).Load(); err == nil {
+		t.Fatal("FileStore Load accepted an empty path")
+	}
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := (FileStore{Path: "unused"}).Persist(cancelled, testEnvelope()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled Persist error = %v", err)
+	}
+
+	env := testEnvelope()
+	if _, _, err := (&Runner{}).Step(ctx, env, testPlan()); err == nil {
+		t.Fatal("Runner accepted no executor")
+	}
+	remote := newFakeRemote()
+	if _, _, err := newRunner(remote, &killStore{}).Step(ctx, env, nil); err == nil {
+		t.Fatal("Runner accepted no initial plan")
+	}
+	if _, _, err := (&Runner{Executor: &JournaledExecutor{}}).Step(ctx, env, &TurnPlan{Verdict: VerdictNoWorkNeeded}); err == nil {
+		t.Fatal("Runner accepted no persister for an empty plan")
+	}
+	bound := env.Clone()
+	bound.Plan = bindPlan(env.SessionID, testPlan())
+	different := testPlan()
+	different.Rationale = "changed"
+	if _, _, err := newRunner(remote, &killStore{}).Step(ctx, bound, different); err == nil {
+		t.Fatal("Runner accepted a changed persisted plan")
+	}
+
+	op := bindPlan(env.SessionID, testPlan()).Operations[0]
+	for name, executor := range map[string]*JournaledExecutor{
+		"nil envelope": {Sink: remote, Persister: &killStore{}},
+		"no sink":      {Persister: &killStore{}},
+		"no persister": {Sink: remote},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var target *SessionEnvelope
+			if name != "nil envelope" {
+				copy := env.Clone()
+				target = &copy
+			}
+			if _, err := executor.Do(ctx, target, op); err == nil {
+				t.Fatal("Do unexpectedly succeeded")
+			}
+		})
+	}
+	badOp := op
+	badOp.IdempotencyKey = ""
+	if _, err := newRunner(remote, &killStore{}).Executor.Do(ctx, &env, badOp); err == nil {
+		t.Fatal("Do accepted an unbound operation")
+	}
+}
+
+func TestIdempotencyKeySemanticIdentity(t *testing.T) {
+	base := OpIntent{Kind: OpComment, Repo: "kubestellar/hive", Target: "4002", Body: "hello", ToolCallID: "call-1"}
+	key := DeriveIdempotencyKey("session", base)
+	reentered := base
+	reentered.ToolCallID = "new-model-call"
+	if got := DeriveIdempotencyKey("session", reentered); got != key {
+		t.Fatal("tool call ID changed the semantic idempotency key")
+	}
+	variants := []OpIntent{
+		{Kind: OpLabel, Repo: base.Repo, Target: base.Target, Body: base.Body},
+		{Kind: base.Kind, Repo: "other/repo", Target: base.Target, Body: base.Body},
+		{Kind: base.Kind, Repo: base.Repo, Target: "4003", Body: base.Body},
+		{Kind: base.Kind, Repo: base.Repo, Target: base.Target, Body: "goodbye"},
+	}
+	for _, variant := range variants {
+		if DeriveIdempotencyKey("session", variant) == key {
+			t.Errorf("variant collided with base: %+v", variant)
+		}
+	}
+	if DeriveIdempotencyKey("other-session", base) == key {
+		t.Fatal("different sessions collided")
+	}
+	input := &TurnPlan{Operations: []PlannedOperation{{IdempotencyKey: "caller-chosen", Intent: base}}}
+	if got := bindPlan("session", input).Operations[0].IdempotencyKey; got != key {
+		t.Fatalf("bound key = %q, want derived key %q", got, key)
+	}
+}

--- a/src/pkg/turn/store.go
+++ b/src/pkg/turn/store.go
@@ -1,0 +1,77 @@
+package turn
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FileStore persists one envelope with an atomic temp-file + rename commit.
+// The containing directory must already exist; callers own its lifecycle and
+// access-control policy.
+type FileStore struct {
+	Path string
+}
+
+func (s FileStore) Persist(ctx context.Context, env SessionEnvelope) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.Path == "" {
+		return fmt.Errorf("turn: persistence path is required")
+	}
+	data, err := env.ToJSON()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(s.Path)
+	tmp, err := os.CreateTemp(dir, ".turn-envelope-*.tmp")
+	if err != nil {
+		return fmt.Errorf("turn: create temporary envelope: %w", err)
+	}
+	tmpPath := tmp.Name()
+	keep := false
+	defer func() {
+		_ = tmp.Close()
+		if !keep {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return fmt.Errorf("turn: protect temporary envelope: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("turn: write temporary envelope: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("turn: sync temporary envelope: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("turn: close temporary envelope: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.Path); err != nil {
+		return fmt.Errorf("turn: commit envelope: %w", err)
+	}
+	keep = true
+	directory, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("turn: open envelope directory: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("turn: sync envelope directory: %w", err)
+	}
+	return nil
+}
+
+func (s FileStore) Load() (SessionEnvelope, error) {
+	if s.Path == "" {
+		return SessionEnvelope{}, fmt.Errorf("turn: persistence path is required")
+	}
+	data, err := os.ReadFile(s.Path)
+	if err != nil {
+		return SessionEnvelope{}, fmt.Errorf("turn: read envelope: %w", err)
+	}
+	return ParseEnvelope(data)
+}


### PR DESCRIPTION
## Summary

Implements **step 2 of RFC #4002 on current `v4`**: an isolated, contribute-shaped re-entrant turn prototype whose conversation, ordered operation plan, effect journal, lifecycle status, and terminal verdict all live in one serializable `SessionEnvelope`.

The transition under test is deliberately plain:

```text
Step(SessionEnvelope, optional initial TurnPlan)
    -> (SessionEnvelope, TurnOutput, error)
```

The first process supplies a plan once. `Step` binds stable operation identities into the envelope before the first durable boundary. After that, a fresh process receives only the serialized envelope and calls `Step` with no plan; it skips effects known to have landed, reconciles effects whose outcome is ambiguous, and completes with the same structured verdict and effect summary as an uninterrupted run.

This carries the operation-journal lesson previously exercised on the earlier `v5` line in #4053 onto the active `v4` line, with two material additions:

1. **Persistence is real, not only an interface backed by a byte slice in tests.** `FileStore` performs a mode-`0600`, synced temp write, atomic rename, and parent-directory sync.
2. **Unreconcilable ambiguity fails closed.** If a process dies after an effect may have landed but before its outcome is durable, and no remote reconciliation query exists, re-entry returns `ErrAmbiguous` instead of replaying and risking a duplicate PR/comment/push.

Nothing in the live tmux agent loop or `bin/contributor-relay.sh` constructs this package. It remains the bounded spike requested by the issue. Step 3 (handoff through the existing claim machinery) and step 4 (feasibility/migration-cost report, including the beads-checkpoint comparison) remain open.

## Why this is the step-2 boundary

The merged step-1 inventory established that Hive does not currently own a structured conversation or a structured turn:

- hosted agents are opaque, long-lived backend CLIs under tmux;
- prompts enter through `tmux send-keys`;
- completion and liveness are inferred from rendered pane substrings;
- backend session formats are private and backend-specific;
- `/data/prompt-history.jsonl` contains prompts only, while kick logs contain rendered terminal text rather than role/message/tool structure.

So this PR does not pretend that the current pane-scraped path can be mechanically refactored into a re-entrant function. It prototypes the first honest boundary *after* a headless/structured backend response: the point where an ordered plan meets durable state and non-idempotent external writes. That is also the highest-risk boundary. Repeating inference wastes tokens; repeating “open PR” or “post comment” creates externally visible duplicate work.

The prototype is contribute-shaped because that plane already has the relevant vocabulary and failure history: task refs, `shipped`/`no_work_needed` completion verdicts, branch pushes, PR creation, comments, labels, and an existing offer→claim path that a future handoff must reuse.

## State envelope

`SessionEnvelope` is versioned and carries:

| Field | Why it must be durable |
| --- | --- |
| `session_id` | Stable scope for operation identity across processes/spokes. |
| `agent`, `task_ref` | The owner and work item a handoff receiver must validate. |
| `messages` | The structured conversation state; roles and tool correlation survive re-entry. |
| `plan` | The ordered operations and terminal verdict are state, not a suspended stack frame. |
| `journal` | Records whether each external effect is not started, possibly landed, failed, or definitely landed. |
| `status`, timestamps | Gives the caller a structured lifecycle/result rather than a pane-text inference. |

The plan is copied into the envelope on the initial call. Caller-provided idempotency keys are ignored and re-derived during binding, so a stale key—or a key emitted by a model—cannot suppress unrelated work. If a later caller supplies a plan that differs from the persisted plan, `Step` rejects it instead of silently changing the work during recovery.

The structured `TurnOutput` reports `status`, `done`, `verdict`, `rationale`, and every landed effect. A zero-operation `no_work_needed` plan is representable by the same return shape; no magic stdout line is needed inside the prototype.

## Operation identity

Each side-effectful operation receives a content-derived key:

```text
key = "v1-" + sha256(
    len(version) | version |
    len(session_id) | session_id |
    len(kind) | kind |
    len(repo) | repo |
    len(target) | target |
    len(body) | body
)[:32]
```

The fields are length-prefixed, so adjacent values cannot produce ambiguous concatenations (`("ab", "c")` cannot hash like `("a", "bc")`). The version prefix is an explicit migration escape hatch if the derivation changes later.

Two constraints pull in opposite directions:

- **Stable across re-entry:** the key must be recomputable in a different process from semantic state alone. That excludes timestamps, PIDs, random nonces, attempt counters, and process-local sequence numbers.
- **Distinct per logical effect:** two different comments on the same issue must not collide, because suppressing a legitimate second effect is a silent under-performance failure.

The model's `ToolCallID` is deliberately recorded but excluded from the key. A repeated inference can mint a fresh call ID for the same semantic effect; including it would make a retry look new and defeat replay protection.

Keys are bound before the first persistence call and stored beside the operation. That matters because the persisted artifact is scrubbed: credential-shaped text may be redacted from an operation body, but the already-bound identity must not change or re-entry would miss the journal entry and replay.

## Durable execution protocol

Every external write crosses two commits:

1. Derive/bind the semantic key.
2. If the journal already says `succeeded`, return the recorded external ref without touching the remote.
3. If the journal says `intended`, reconcile against the remote because the previous process may have died after the effect landed.
4. Otherwise record `intended` and **persist it before execution**.
5. Perform the external effect.
6. Record `succeeded` or `failed`, including the remote ref/error, and persist again.

The ordering is the guarantee. Performing first and recording intent afterward creates an unjournaled effect window where a fresh process has no evidence to query and replays blind.

The three journal states exist because two states are insufficient:

| Durable state | What re-entry knows | Action |
| --- | --- | --- |
| no entry | The effect was never admitted. | Persist intent, then perform. |
| `intended` | The effect may or may not have landed. | Reconcile; never guess. |
| `failed` | The prior attempt returned a known failure. | Persist a new intent attempt, then retry. |
| `succeeded` | The effect definitely landed or was reconciled. | Short-circuit with its external ref. |

### Why reconciliation is separate from the key

GitHub does not expose a general idempotency-key header for the writes involved here. Natural surrogates are remote queries after the fact: find an open PR by head branch, find a matching comment, or inspect a label set. Those queries are useful for resolving `intended`, but they are not stable offline identities; they cost a round trip, may be eventually consistent, and do not exist reliably for every effect.

Accordingly:

- the semantic hash is the local journal key;
- the remote query is the tie-breaker for the ambiguous state;
- absence of a reconciler returns `ErrAmbiguous` and performs **zero** remote writes.

This is intentionally conservative. For a push or a comment on a busy thread, manual recovery is preferable to claiming exactly-once semantics the remote cannot support.

## Persistence and secret boundary

The envelope is a secret-bearing artifact: conversation text, tool arguments, remote errors, authenticated URLs, branch names, and metadata can all contain credentials or sensitive repository content.

`FileStore` therefore treats serialization as the security boundary:

1. clone the in-memory envelope;
2. scrub every content-bearing field through Hive's existing `pkg/logscrub` implementation;
3. create a temp file in the destination directory;
4. force mode `0600`;
5. write and `fsync` the temp file;
6. atomically rename it over the previous envelope;
7. `fsync` the containing directory so the rename itself is durable.

The store does not create the directory. The eventual caller remains responsible for placing it under an existing state directory with the correct ownership and authorization policy.

The in-memory envelope is never scrubbed or mutated. The test asserts both halves: plaintext remains available to the active turn, while the durable artifact contains redaction markers and no plaintext credential. Bound idempotency keys survive unchanged so the scrub boundary cannot accidentally disable replay protection.

## Replay test: what it proves

`TestStepReentersAtEveryPersistenceBoundary` drives this ordered contribute turn:

```text
comment on issue
    → push branch
    → create PR
    → label issue
    → persist terminal shipped verdict
```

Four effects produce eight intent/settle commits; the terminal envelope is a ninth kill site. The test first runs an uninterrupted positive control and asserts that it genuinely performs all four effects without duplicates. It then kills the process **before each of the nine writes**, one boundary at a time.

| Kill boundary | Durable state after death | Recovery path |
| --- | --- | --- |
| intent write (odd effect boundary) | Prior effects only; current effect did not run. | Re-enter and perform normally. |
| settle write (even effect boundary) | Current effect landed remotely; journal still says `intended`. | Reconcile and adopt; do not replay. |
| terminal commit | All effects are settled; status may still be `active`. | Short-circuit every effect and persist the same terminal verdict. |

For every case, the simulated process loses all memory. Only serialized JSON crosses into recovery; when the first write itself is killed, recovery starts from the original task input because no envelope ever became durable.

Each case asserts:

- exactly one actual remote call per logical effect across both processes;
- the same sorted effect summary as the uninterrupted control;
- the same terminal `shipped` verdict;
- `StatusCompleted` and `Done=true`;
- no `intended` entry left ambiguous;
- no plaintext credential in the persisted envelope.

Supporting tests prevent the replay table from passing for the wrong reason:

- `TestAmbiguousOperationFailsClosedWithoutReconciler` proves ambiguity is not replayed when no query exists;
- `TestReconcileNotFoundPerformsEffect` proves the implementation does not “solve” ambiguity by skipping every intended operation;
- `TestFailedEffectCanRetry` proves a known failure is re-intended and increments its attempt count;
- `TestIdempotencyKeySemanticIdentity` proves reminted tool-call IDs remain stable while kind/repo/target/body/session changes produce different keys, and proves a caller cannot choose its own key;
- `TestFileStoreRoundTripIsAtomicPrivateAndScrubbed` checks round-trip parsing, mode `0600`, no temp-file residue, redaction, in-memory non-mutation, and key stability;
- `TestValidationAndConfigurationErrors` covers invalid envelopes and missing runner/sink/persister/path configuration, including the zero-operation path.

The new package is at **91.2% statement coverage** under the race detector, above the repository's 90% new-package floor.

## What this does not claim

This is deliberately explicit because a successful replay test can otherwise make a prototype sound more complete than it is.

1. **The model call is not journaled.** A crash before the plan enters the envelope repeats inference and can produce a different plan. The prototype protects landed effects, not token cost or plan determinism.
2. **There is no live backend adapter.** `pkg/turn` begins after a structured headless response. It does not parse a backend's private session files or convert tmux scrollback into a conversation.
3. **There is no cross-process lease.** The journal makes sequential re-entry safe, not concurrent execution safe. Two processes racing the same envelope can both observe the same state. Step 3 must reuse the contributor relay's existing atomic offer→claim ownership and completion verdicts rather than invent another queue or state store.
4. **Reconciliation quality is effect-specific.** PR-by-head is a strong surrogate. Pushes and comments can be ambiguous. The prototype fails closed where it cannot prove the outcome.
5. **Scrub-on-persist is not an authorization policy.** Redaction reduces credential exposure, but a handoff design still has to say which spoke/process may read an envelope and how that access is authenticated.
6. **The journal is unbounded.** No compaction/retention policy exists yet.
7. **The beads alternative is still unmeasured.** Current beads capture task lifecycle state, not structured model responses or pre-effect journals. Step 4 still needs the proposed realistic kill-at-50% comparison: resume from this envelope versus restart from aggressively checkpointed bead notes, measuring wall time, token cost, and duplicate effects.
8. **No production migration decision is taken.** The step-1 fork remains: use documented backend-native resume envelopes and accept backend-specific state, or move selected agents to an API-shaped backend Hive owns.

## Files and review map

- `src/pkg/turn/envelope.go` — versioned state envelope, structured verdict/output, deep clone, parse/validation, scrub-on-persist boundary.
- `src/pkg/turn/journal.go` — semantic operation identity and the `intended`/`failed`/`succeeded` journal.
- `src/pkg/turn/runner.go` — re-entrant `Step`, plan binding, effect execution protocol, reconciliation, fail-closed ambiguity.
- `src/pkg/turn/store.go` — private atomic file persistence with file and directory sync.
- `src/pkg/turn/runner_test.go` — nine-boundary replay matrix and positive/negative controls.
- `src/docs/design/agent-turn-model.md` — step-2 result, measured guarantee, and residual work.
- `src/docs/design/README.md` — design index status updated from “step 1 only” to “steps 1 and 2 complete.”

The highest-value review questions are:

1. Is fail-closed `ErrAmbiguous` the right default for effects without a reliable remote surrogate?
2. Is the semantic key scoped correctly, especially the deliberate exclusion of `ToolCallID`?
3. Is `TurnPlan` the right persisted boundary after structured inference, or should inference output itself be a separate journaled operation before step 3?
4. Does the envelope contain the minimum state needed for a later claim-owned handoff without becoming durable store number five?

## Verification

Local:

- `go test -race -cover ./pkg/turn` — pass, 91.2% statements
- `go vet ./pkg/turn` — pass
- `go build ./cmd/hive/` — pass
- `go vet ./...` — pass
- `git diff --check` — pass
- `go test ./pkg/...` with local socket/tmux/Podman access — the new `pkg/turn` and all other packages passed except existing privileged `pkg/config` test `TestGateFailsClosedWithoutIP6Tables`; this host has `ip6tables` installed without NET_ADMIN, so that fixture observed “permission denied” instead of its expected “binary missing” message

PR CI observed before handoff:

- DCO — pass
- PR content verifier — pass
- docs index and changelog reminders — pass
- `golangci-lint` — pass
- `gosec` — pass
- `govulncheck` — pass
- all five agent test shards completed at time of the latest check — pass
- general test shards and remaining deployment/build lanes were still completing when this body was updated

Refs #4002

— hive: backend=codex
