### PR TITLE
🧹 lint: fix all 44 unused findings and enable unused in the gate

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -23,7 +23,7 @@ run:
 linters:
   default: none
   enable:
-    # STARTING SET — deliberately three linters, not six.
+    # THE ENABLED SET grows one linter at a time, never in batches.
     #
     # A first run with errcheck + staticcheck + unused enabled produced 859
     # findings (579 errcheck, 225 staticcheck, 44 unused, 11 ineffassign) on a
@@ -35,12 +35,20 @@ linters:
     # its own PR after its findings are fixed — that ratchet is tracked in the
     # ratchet issue #4903.
     #
-    # errcheck (579) is the most valuable remaining rung and the largest, and
-    # is worth splitting by package.
+    # errcheck is the most valuable remaining rung and the largest, and is worth
+    # splitting by package. Note its true size under this config: the 579 figure
+    # counts non-test files only, and `tests: true` above means the gate measures
+    # 3,139.
     - govet
     - misspell
     # RATCHET: ineffassign enabled after its 11 findings were fixed (#4903).
     - ineffassign
+    # RATCHET: unused enabled after its 44 findings were fixed (#4903). Most were
+    # constants and helpers superseded by a later refactor; a few were guards
+    # that had come loose from the code they were written to protect, and those
+    # were reconnected rather than deleted. One declaration is retained under an
+    # explained //nolint:unused — see pkg/hub/wrapkey_store.go.
+    - unused
 
   exclusions:
     generated: lax

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2812,7 +2812,7 @@ func main() {
 	// The loop therefore runs for the lifetime of the process (it does NOT
 	// return after the first success) and, whenever the banner is currently
 	// showing, re-runs the SAME read+write verification as the manual "Re-check"
-	// button (githubAppRecheckFn, which calls diagnoseGitHubAppWrite) and clears
+	// button (githubAppRecheckFn, which calls diagnoseGitHubApp) and clears
 	// the flag on success. When the banner is not showing there is nothing to do,
 	// so the tick is a cheap no-op that makes no GitHub API calls.
 	{
@@ -5175,14 +5175,8 @@ func (s labelPlanSink) QueuedPlan(epic *beads.Bead, paused bool) {
 	s.logger.Warn("plan-from-label: architect unavailable, plan queued", "epic", epic.ID, "ref", epic.ExternalRef)
 }
 
-// diagnoseGitHubAppWrite returns "" when the configured GitHub App
-// installation belongs to expectedOwner and grants issues:write. Otherwise it
-// returns a banner-ready diagnosis distinguishing the two write-failure causes
-// that produce identical 403s: an installation_id pointing at a different
-// org's installation, and a permission update the org owner hasn't approved
-// yet. A nil appAuth (token-authenticated hive) yields "" — nothing to check.
 // healGitHubAppInstallation self-heals a hive whose github.installation_id
-// points at the WRONG account — the failure mode diagnoseGitHubAppWrite
+// points at the WRONG account — the failure mode diagnoseGitHubApp
 // already detects and reports ("installation N belongs to 'X', not 'Y'"). It
 // asks pkg/github to rediscover the installation covering cfg.Project.Org via
 // the App JWT and, only on an unambiguous match, adopts it in place and
@@ -5248,13 +5242,6 @@ func diagnoseGitHubApp(ctx context.Context, appAuth *github.AppAuth, expectedOwn
 	}
 	d := appAuth.DiagnoseAppAuth(ctx, expectedOwner, spokeAppKeyPath, spokeProvisionedAppKeyPath)
 	return d.Message(), d.State
-}
-
-// diagnoseGitHubAppWrite is the string-only wrapper retained for callers that
-// only need banner copy.
-func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expectedOwner string) string {
-	msg, _ := diagnoseGitHubApp(ctx, appAuth, expectedOwner)
-	return msg
 }
 
 // maxTimelineEnumeratePerCycle bounds how many enumerated-issue events a single

--- a/src/pkg/agent/agent_bootstrap_test.go
+++ b/src/pkg/agent/agent_bootstrap_test.go
@@ -569,12 +569,3 @@ func TestRemoveAgentExisting(t *testing.T) {
 		t.Error("scanner should be removed")
 	}
 }
-
-func containsBoot2(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/src/pkg/agent/manager_coverage_test.go
+++ b/src/pkg/agent/manager_coverage_test.go
@@ -560,16 +560,3 @@ func TestBuildBootstrapPrompt_WithFile(t *testing.T) {
 		t.Error("boot prompt should be empty — agents get kicked by governor")
 	}
 }
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsHelper(s, sub))
-}
-
-func containsHelper(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}

--- a/src/pkg/agent/manager_test.go
+++ b/src/pkg/agent/manager_test.go
@@ -208,26 +208,6 @@ func makeAgentConfig(backend, model string) config.AgentConfig {
 	}
 }
 
-func waitForState(t *testing.T, m *Manager, name string, want ...ProcessState) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		ap, _ := m.GetStatus(name)
-		for _, w := range want {
-			if ap.State == w {
-				return
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	ap, _ := m.GetStatus(name)
-	wantStrs := make([]string, len(want))
-	for i, w := range want {
-		wantStrs[i] = string(w)
-	}
-	t.Errorf("timed out waiting for %q state: got %q", strings.Join(wantStrs, "|"), ap.State)
-}
-
 // ---------------------------------------------------------------------------
 // NewManager
 // ---------------------------------------------------------------------------

--- a/src/pkg/agent/tmux_coverage_test.go
+++ b/src/pkg/agent/tmux_coverage_test.go
@@ -158,18 +158,6 @@ func requirePaneShows(t *testing.T, session, text string) {
 	}
 }
 
-// paneInjectLines renders each string on its own pane line.
-func paneInjectLines(t *testing.T, session string, lines ...string) {
-	t.Helper()
-	for _, ln := range lines {
-		if err := testTmuxCommand("send-keys", "-t", session, "-l", ": "+ln).Run(); err != nil {
-			t.Fatalf("send-keys: %v", err)
-		}
-		_ = testTmuxCommand("send-keys", "-t", session, "Enter").Run()
-	}
-	time.Sleep(500 * time.Millisecond)
-}
-
 // ---------------------------------------------------------------------------
 // Start / launchInTmux — full launch path with real tmux + stub binary
 // ---------------------------------------------------------------------------

--- a/src/pkg/apiproxy/proxy.go
+++ b/src/pkg/apiproxy/proxy.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -55,7 +54,6 @@ type Proxy struct {
 	// never an implicit credential for anyone who can reach the listener. It
 	// is required: when empty every request is refused with 503.
 	clientAuthToken string
-	mu              sync.RWMutex
 }
 
 func New(upstreamURL string, handler EventHandler, apiKey, clientAuthToken string) (*Proxy, error) {

--- a/src/pkg/celtrigger/celtrigger.go
+++ b/src/pkg/celtrigger/celtrigger.go
@@ -43,10 +43,6 @@ const (
 	KindCommentCreated = "comment.created"
 )
 
-// defaultPriority is applied to rules that declare no explicit priority. Higher
-// priority sorts first in Match results.
-const defaultPriority = 0
-
 // maxEvalCost bounds CEL runtime work per rule evaluation. The budget is high
 // enough for realistic operator rules that combine field checks, string
 // predicates, and modest label scans, while still stopping pathological nested
@@ -107,7 +103,8 @@ type Rule struct {
 	Expr string
 	// Agent names the agent to trigger when Expr matches.
 	Agent string
-	// Priority orders matched rules; higher sorts first. Defaults to defaultPriority.
+	// Priority orders matched rules; higher sorts first. A rule that declares
+	// no priority gets the zero value, so declared order decides ties.
 	Priority int
 }
 

--- a/src/pkg/dashboard/api_agents.go
+++ b/src/pkg/dashboard/api_agents.go
@@ -582,25 +582,6 @@ func isGistImportHost(host string) bool {
 	return host == "gist.github.com" || host == "gist.githubusercontent.com"
 }
 
-func importFetchURL(rawURL string) string {
-	u, err := url.Parse(strings.TrimSpace(rawURL))
-	if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
-		return rawURL
-	}
-	m := githubBlobURLPattern.FindStringSubmatch(u.Path)
-	if m == nil {
-		return rawURL
-	}
-	raw := url.URL{
-		Scheme:   "https",
-		Host:     "raw.githubusercontent.com",
-		Path:     "/" + strings.Join([]string{m[1], m[2], m[3], m[4]}, "/"),
-		RawQuery: u.RawQuery,
-		Fragment: u.Fragment,
-	}
-	return raw.String()
-}
-
 // definitionSourceFromURL parses a GitHub blob or raw file URL into a
 // DefinitionSourceConfig (owner/repo/path/ref). It is used when an operator
 // imports an agent with "keep linked" checked, so the pasted human-facing URL

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -255,14 +255,6 @@ type ContributorRateLimits struct {
 	MaxPerDay     int `json:"max_tasks_per_day"`
 }
 
-type ContributorPool struct {
-	Active     int `json:"active"`
-	Registered int `json:"registered"`
-	mu         sync.RWMutex
-}
-
-var contributorPool = &ContributorPool{}
-
 type ContributorPoolStatus struct {
 	Active     int            `json:"active"`
 	Registered int            `json:"registered"`

--- a/src/pkg/dashboard/api_leaderboard_style.go
+++ b/src/pkg/dashboard/api_leaderboard_style.go
@@ -894,14 +894,8 @@ func (s *Server) handleLeaderboardStyle(w http.ResponseWriter, r *http.Request) 
 	s.handleStyle(w, r)
 }
 
-// Back-compatible leaderboard names kept for the PR #2834 tests and callers.
+// Back-compatible leaderboard name kept for the PR #2834 tests and callers.
 type leaderboardCustomStyleSource = customStyleSource
-type leaderboardCustomStyleCacheEntry = customStyleCacheEntry
-
-const (
-	leaderboardCustomStyleMaxBytes   = customStyleMaxBytes
-	leaderboardCustomStyleDefaultRef = customStyleDefaultRef
-)
 
 func validateLeaderboardCustomStyleSource(src string) (leaderboardCustomStyleSource, error) {
 	return validateCustomStyleSource(src)

--- a/src/pkg/dashboard/contribute_admission_deps.go
+++ b/src/pkg/dashboard/contribute_admission_deps.go
@@ -136,10 +136,6 @@ func (r beadRecord) generation() string {
 	return r.updatedAt.UTC().Format(time.RFC3339Nano)
 }
 
-// beadLedgerPartialReason is the DegradedReason reported when the ledger
-// snapshot could not cover every configured store.
-const beadLedgerPartialReason = "BeadLedgerPartial"
-
 // contributorAdmissionSweep carries the observation state shared by every
 // candidate in ONE ReadyQueue / selectTask pass. Building it once per sweep
 // keeps the shared admission contract cheap enough to sit in the assignment

--- a/src/pkg/dashboard/contribute_agent_roles.go
+++ b/src/pkg/dashboard/contribute_agent_roles.go
@@ -108,13 +108,6 @@ func (h *ContributeWSHub) roleKickPrompt(role string) string {
 	return h.server.deps.Scheduler.BuildAgentMessageFromLastActionable(role)
 }
 
-// buildRoleTaskPrompt is the GitHub-shaped entry point retained for existing
-// callers; buildRoleTaskPromptForRef is the identity-aware one
-// (kubestellar/hive#4245).
-func buildRoleTaskPrompt(repoFull string, number int, title, role, agentPrompt string) string {
-	return buildRoleTaskPromptForRef(worksource.Ref{Repo: repoFull, Number: number}, title, role, agentPrompt)
-}
-
 // buildRoleTaskPromptForRef wraps the source-aware assignment prompt in the
 // role framing. Only the base prompt carries work identity, so the role text
 // itself is unchanged for every source.

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -356,20 +356,6 @@ func (t *WSTaskAssign) identityKey() string {
 	return worksource.Ref{Repo: t.Repo, Number: t.Number}.Key()
 }
 
-// ref reconstructs the assigned item's source-aware reference.
-func (t *WSTaskAssign) ref() worksource.Ref {
-	if t == nil {
-		return worksource.Ref{}
-	}
-	return worksource.Ref{
-		SourceType: t.SourceType,
-		Repo:       t.Repo,
-		ExternalID: t.ExternalID,
-		Number:     t.Number,
-		URL:        t.URL,
-	}
-}
-
 const maxActivityEntries = 50
 
 type ActivityEntry struct {

--- a/src/pkg/dashboard/gateways.go
+++ b/src/pkg/dashboard/gateways.go
@@ -70,17 +70,6 @@ func gatewayProbeAuth(kind, key, projectID string) (bearer string, headers map[s
 }
 
 const (
-	// openRouterBaseURL is the OpenAI-compatible base URL for OpenRouter. Used
-	// as the preset endpoint when the UI picks the OpenRouter gateway kind.
-	openRouterBaseURL = "https://openrouter.ai/api/v1"
-
-	// watsonxBaseURLTemplate / watsonxDefaultRegion alias the canonical values
-	// in pkg/watsonx. They are NOT redefined here: the agent launch path needs
-	// the same template, and two copies is exactly how the gateway half and the
-	// agent half of watsonx support were able to disagree.
-	watsonxBaseURLTemplate = watsonx.BaseURLTemplate
-	watsonxDefaultRegion   = watsonx.DefaultRegion
-
 	// gatewaySecretFileMode / gatewaySecretDirMode keep gateway key files
 	// owner-only, matching the LiteLLM key store (litellmKeyFileMode).
 	gatewaySecretFileMode = 0o600

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -38,12 +38,19 @@ var skillsConventionalDir = dataVolumePath + "/skills"
 const defaultLookbackHours = 24
 
 // Cadence sentinel values: a per-mode cadence set to one of these means the
-// governor will not kick the agent on a timer in that mode. Kept as named
-// constants so the offByCadence detection and computeNextKick agree on the
-// exact spellings the config layer emits.
+// governor will not kick the agent on a timer in that mode. Named constants so
+// the two next-kick computations below agree on the exact spellings the config
+// layer emits, rather than each carrying its own literal list — the drift these
+// were introduced to prevent, and which had already started before they were
+// wired in.
+//
+// config.Cadence.IsPaused() remains the authority for the interval-mode
+// judgment (it also accepts "paused" and "0"); these are the string-cadence
+// spellings the dashboard's own formatting paths compare against.
 const (
-	cadencePause = "pause"
-	cadenceOff   = "off"
+	cadencePause    = "pause"
+	cadenceOff      = "off"
+	cadenceOnDemand = "on demand"
 )
 
 // SetProxyViolationsProvider registers a function that returns per-agent
@@ -941,7 +948,7 @@ func formatHumanTime(t time.Time) string {
 }
 
 func computeNextKick(lastKick *time.Time, cadence string) string {
-	if cadence == "" || cadence == "off" || cadence == "pause" || cadence == "on demand" {
+	if cadence == "" || cadence == cadenceOff || cadence == cadencePause || cadence == cadenceOnDemand {
 		return ""
 	}
 	base := time.Now()
@@ -973,7 +980,7 @@ func computeNextKickFromCadence(lastKick *time.Time, cadence config.Cadence) str
 
 func parseCadenceDuration(cadence string) time.Duration {
 	cadence = strings.TrimSpace(cadence)
-	if cadence == "" || cadence == "off" || cadence == "pause" || cadence == "on demand" {
+	if cadence == "" || cadence == cadenceOff || cadence == cadencePause || cadence == cadenceOnDemand {
 		return 0
 	}
 	d, err := time.ParseDuration(cadence)

--- a/src/pkg/discord/bot_test.go
+++ b/src/pkg/discord/bot_test.go
@@ -665,15 +665,6 @@ func TestRouteMessage_EnqueueDoesNotPanic(t *testing.T) {
 // SendMessage – error branches
 // ──────────────────────────────────────────────────────────────────────────────
 
-// errTransport is an http.RoundTripper that always returns the given error.
-// It is used to exercise error paths that cannot be reached through a normal
-// test server (e.g. http.NewRequest failures triggered by an invalid URL).
-type errTransport struct{ err error }
-
-func (e *errTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
-	return nil, e.err
-}
-
 // TestSendMessage_NewRequestError covers the http.NewRequest error branch in
 // SendMessage by using a channelID containing a null byte, which makes the
 // constructed URL invalid.

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -397,8 +397,6 @@ var PermanentExemptLabels = []string{"do-not-merge"}
 // exists so a nil or unconfigured client still has a sane value.
 const AutoMergeQueuedLabel = config.DefaultAutoMergeLabel
 
-var exemptFiles = []string{"ADOPTERS.md", "ADOPTERS.MD"}
-
 const slaThresholdMinutes = 30
 
 // NewClient creates a GitHub API client. If apiURL is non-empty and differs
@@ -1424,8 +1422,6 @@ func (c *Client) SearchOutreachPRCount(ctx context.Context, author, org, project
 	}
 	return result.GetTotal(), nil
 }
-
-const perPage = 100
 
 var shaPattern = regexp.MustCompile(`[0-9a-f]{7,40}\b`)
 

--- a/src/pkg/github/client_test.go
+++ b/src/pkg/github/client_test.go
@@ -63,8 +63,6 @@ type wireIssue struct {
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 }
 
-func boolPtr(b bool) *bool { return &b }
-
 func mustMarshal(t *testing.T, v any) []byte {
 	t.Helper()
 	b, err := json.Marshal(v)

--- a/src/pkg/hub/forge.go
+++ b/src/pkg/hub/forge.go
@@ -47,16 +47,13 @@ const (
 	ForgeGitea ForgeKind = "gitea"
 )
 
-// gitLabAPIPathSuffix / giteaAPIPathSuffix are the REST API base paths for the
-// non-GitHub forges. The spoke-side pkg/forge adapters append these to the
-// instance root themselves (gitLabAPIPath="/api/v4", giteaAPIPath="/api/v1"), so
-// for these kinds a ForgeTarget carries the BARE instance URL in BaseURL and
-// leaves APIURL empty — the opposite of the GHE case, where the hub pre-appends
-// /api/v3. Kept here as documentation of that contract.
-const (
-	gitLabAPIPathSuffix = "/api/v4"
-	giteaAPIPathSuffix  = "/api/v1"
-)
+// FORGE API-PATH CONTRACT, hub side. The REST API base paths for the non-GitHub
+// forges are appended by the spoke-side pkg/forge adapters themselves
+// (gitLabAPIPath="/api/v4", giteaAPIPath="/api/v1"), so for those kinds a
+// ForgeTarget carries the BARE instance URL in BaseURL and leaves APIURL empty —
+// the opposite of the GHE case below, where the hub pre-appends /api/v3. The hub
+// must not duplicate the GitLab/Gitea suffixes: a second copy here is how the two
+// halves would get a chance to disagree.
 
 // publicForgeHost is the canonical host of public GitHub. A hive on this host
 // carries GitHubHost == "github.com" (or "", historically) and an empty
@@ -412,10 +409,10 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		s.logger.Info("forge switch queued (non-GitHub)",
 			"hive_id", id, "kind", target.Kind, "host", target.Host)
 		json.NewEncoder(w).Encode(map[string]any{
-			"ok":    true,
-			"kind":  string(target.Kind),
-			"host":  target.Host,
-			"note":  fmt.Sprintf("hive %s will switch to %s (%s) on its next heartbeat. Ensure the spoke has a %s access token in its environment.", id, target.Host, target.Kind, defaultTokenEnvForKind(target.Kind)),
+			"ok":   true,
+			"kind": string(target.Kind),
+			"host": target.Host,
+			"note": fmt.Sprintf("hive %s will switch to %s (%s) on its next heartbeat. Ensure the spoke has a %s access token in its environment.", id, target.Host, target.Kind, defaultTokenEnvForKind(target.Kind)),
 		})
 		return
 	}

--- a/src/pkg/hub/hub_generations_store.go
+++ b/src/pkg/hub/hub_generations_store.go
@@ -477,17 +477,6 @@ func (s *HubServer) currentGenerations() *generationSet {
 	return s.keyGenerations
 }
 
-// setGenerations installs a new set and records when it happened.
-func (s *HubServer) setGenerations(gs *generationSet, rotatedAt time.Time) {
-	if s == nil || gs == nil {
-		return
-	}
-	s.keyGenerationsMu.Lock()
-	defer s.keyGenerationsMu.Unlock()
-	s.keyGenerations = gs
-	s.lastKeyRotation = rotatedAt
-}
-
 // lastRotationAt reports when the current generation was minted, or the zero
 // time on a hub that has never rotated.
 func (s *HubServer) lastRotationAt() time.Time {

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2074,18 +2074,14 @@ func (s *HubServer) handleListClusters(w http.ResponseWriter, r *http.Request) {
 
 const clusterHealthCacheTTL = 30 * time.Second
 
-// clusterHealthCPUWarnPct is the CPU usage percentage threshold for warning state.
-const clusterHealthCPUWarnPct = 60
-
-// clusterHealthCPUDangerPct is the CPU usage percentage threshold for danger state.
-const clusterHealthCPUDangerPct = 80
-
-// clusterHealthMemWarnPct is the memory usage percentage threshold for warning state.
-const clusterHealthMemWarnPct = 60
-
-// clusterHealthMemDangerPct is the memory usage percentage threshold for danger state.
-const clusterHealthMemDangerPct = 80
-
+// CPU and memory bar thresholds are NOT declared here. The hub serves the
+// cluster-health panel raw percentages and the panel colours them with its own
+// CLUSTER_CPU_WARN_PCT / CLUSTER_CPU_DANGER_PCT / CLUSTER_MEM_* constants, so a
+// Go-side copy would be a second set of numbers that nothing reads and nobody
+// updates together. The disk thresholds below are different: they are anchored
+// to kubelet behaviour rather than taste and are pinned by a test, so they have
+// a reason to exist on this side.
+//
 // Disk thresholds are anchored to kubelet's own behaviour rather than to
 // round numbers, so a coloured bar means something concrete is about to
 // happen on the node:
@@ -2107,17 +2103,8 @@ const clusterHealthDiskWarnPct = 85
 // hard eviction threshold fires (nodefs.available<10%).
 const clusterHealthDiskDangerPct = 90
 
-// kubectlTopTimeoutSec is the timeout for kubectl top nodes commands.
-const kubectlTopTimeoutSec = 10
-
-// kubectlGetTimeoutSec is the timeout for kubectl get nodes commands.
-const kubectlGetTimeoutSec = 10
-
 // millicoresPerCore converts cores to millicores.
 const millicoresPerCore = 1000
-
-// mbPerGB converts megabytes to gigabytes.
-const mbPerGB = 1024
 
 // kiToBytes converts Ki units to bytes.
 const kiToBytes = 1024
@@ -2163,15 +2150,6 @@ type ClusterHealthNode struct {
 // hiveHostedNamespacePrefix is the namespace prefix used for SaaS-provisioned
 // hives; pods in these namespaces identify hives running on a node.
 const hiveHostedNamespacePrefix = "hive-hosted-"
-
-// hostedAvailableIDPrefix is the ID prefix a pre-provisioned pool slot carries
-// while it is unclaimed inventory (e.g. "hosted-available-oke-01-placeholder-bb95").
-// It is the RegistryEntry-side marker for an available placeholder: unlike
-// MyHiveEntry, RegistryEntry has no ProvStatus field, so the ID prefix (paired
-// with the "available-" org prefix, placeholderOrgPrefix) is the reliable signal
-// that a slot is idle inventory rather than a claimed hive. A claimed hive keeps
-// neither marker.
-const hostedAvailableIDPrefix = "hosted-available-"
 
 type ClusterHealthSummary struct {
 	TotalNodes    int `json:"total_nodes"`
@@ -4375,7 +4353,9 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 		return fmt.Errorf("hub image %s:%s not published yet", ghcrRepoHub, sha)
 	}
 	image := fmt.Sprintf("ghcr.io/%s:%s", ghcrRepoHub, sha)
-	cmd := kubectlForCluster(s.hubCluster(), "set", "image",
+	ctx, cancel := context.WithTimeout(context.Background(), upgradeKubectlTimeout)
+	defer cancel()
+	cmd := kubectlForClusterContext(ctx, s.hubCluster(), "set", "image",
 		"deployment/"+hubDeploymentName, hubContainerName+"="+image, "-n", hubNamespace)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("kubectl set image failed: %s", strings.TrimSpace(string(out)))
@@ -4764,8 +4744,10 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	}
 	// "*=" updates every container including init containers (copy-config,
 	// init-permissions) — pinning only "hive" left inits on the old branch tag.
-	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
+	setCtx, cancelSet := context.WithTimeout(context.Background(), upgradeKubectlTimeout)
+	cmd := kubectlForClusterContext(setCtx, cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
 	out, err := cmd.CombinedOutput()
+	cancelSet()
 	if err != nil {
 		// The hub can't reach this hive's cluster over kubectl (e.g. the heartbeat-only cluster
 		// from the hub-reachable-cluster hub). Fall back to the heartbeat path: record the
@@ -4790,8 +4772,10 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Restart the deployment to pull the new image
-	restartCmd := kubectlForCluster(cluster, "rollout", "restart", "deployment/hive", "-n", ns)
+	restartCtx, cancelRestart := context.WithTimeout(context.Background(), upgradeKubectlTimeout)
+	restartCmd := kubectlForClusterContext(restartCtx, cluster, "rollout", "restart", "deployment/hive", "-n", ns)
 	restartOut, restartErr := restartCmd.CombinedOutput()
+	cancelRestart()
 	if restartErr != nil {
 		s.logger.Warn("rollout restart after branch switch failed", "hive", id, "output", string(restartOut))
 	}
@@ -5132,8 +5116,11 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			hiveCluster := s.clusterForHive(h)
 			if hiveCluster != nil {
 				ns := "hive-hosted-" + id
-				cmd := kubectlForCluster(hiveCluster, "rollout", "restart", "deployment/hive", "-n", ns)
-				if out, err := cmd.CombinedOutput(); err != nil {
+				trigCtx, cancelTrig := context.WithTimeout(context.Background(), upgradeKubectlTimeout)
+				cmd := kubectlForClusterContext(trigCtx, hiveCluster, "rollout", "restart", "deployment/hive", "-n", ns)
+				out, err := cmd.CombinedOutput()
+				cancelTrig()
+				if err != nil {
 					s.logger.Warn("auto-upgrade initial trigger failed (will retry via heartbeat)", "hive", id, "cluster", hiveCluster.ID, "output", string(out))
 				}
 			}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -880,8 +880,11 @@ type HubServer struct {
 	//
 	// GUARDED BY keyGenerationsMu. The admin rotate endpoint replaces this
 	// pointer while heartbeat and cookie verifiers are concurrently reading it,
-	// so every access goes through currentGenerations() / setGenerations()
-	// rather than touching the field. The field itself is only ever REPLACED,
+	// so every read goes through currentGenerations() rather than touching the
+	// field, and every write holds keyGenerationsMu across the whole
+	// evaluate-persist-install sequence (rotateMasterSecret,
+	// retireExpiredGenerations) so a concurrent rotation cannot be silently
+	// discarded by the other's persist. The field itself is only ever REPLACED,
 	// never mutated in place — generationSet.rotate is pure and returns a new
 	// set — so a reader that grabbed the old pointer keeps a consistent,
 	// immutable snapshot and simply verifies against the pre-rotation set for

--- a/src/pkg/hub/wrapkey_store.go
+++ b/src/pkg/hub/wrapkey_store.go
@@ -32,6 +32,16 @@ import (
 // the PVC. A var rather than a const so tests can redirect it and exercise the
 // real resolution order — the reason given at src/cmd/hive/main.go:95-97.
 // Production never reassigns it.
+//
+// NOT YET READ BY ANY CALLER, deliberately kept. Every function in this file
+// takes the path as an argument and the spoke-side lifecycle has no production
+// entry point yet, so this declaration is the only record of where the key is
+// supposed to land once it does. Deleting it to satisfy the linter would delete
+// the answer, not the dead code — the first caller would then have to re-derive
+// a path for private key material, which is exactly the kind of decision that
+// should not be made twice.
+//
+//nolint:unused // staged lifecycle: documented production location, no caller yet
 var spokeWrapKeyPath = "/data/hive-wrap-key"
 
 // spokeWrapKeyFileMode is rw------- , identical to spokeAppKeyFileMode and for

--- a/src/pkg/proxy/proxy_coverage2_test.go
+++ b/src/pkg/proxy/proxy_coverage2_test.go
@@ -726,20 +726,6 @@ func TestStartInferenceTranslator_HandlerBranches(t *testing.T) {
 	}
 }
 
-func waitForServer(t *testing.T, base string) {
-	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", strings.TrimPrefix(base, "http://"), 200*time.Millisecond)
-		if err == nil {
-			conn.Close()
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("translator server did not come up at %s", base)
-}
-
 // ---------- handleInferenceRequest / handleAnthropicReroute over MITM ----------
 
 // mitmDialClient builds an HTTP client that CONNECTs through the proxy and does

--- a/src/pkg/proxy/proxy_deep6_test.go
+++ b/src/pkg/proxy/proxy_deep6_test.go
@@ -2,8 +2,6 @@ package proxy
 
 import (
 	"bufio"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
@@ -197,13 +195,6 @@ func TestHandleConnectDirectUpstreamDialFail(t *testing.T) {
 	if !strings.Contains(statusLine, "502") {
 		t.Fatalf("expected 502 on upstream dial failure, got %q", statusLine)
 	}
-}
-
-func newCertPool(p *GitHubProxy) *x509.CertPool {
-	pool := x509.NewCertPool()
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: p.caX509.Raw})
-	pool.AppendCertsFromPEM(caPEM)
-	return pool
 }
 
 // ---------- identifyAgentFromReq: UID lookup succeeds ----------

--- a/src/pkg/tokens/collector_test.go
+++ b/src/pkg/tokens/collector_test.go
@@ -8,22 +8,6 @@ import (
 	"testing"
 )
 
-// jsonlLine builds a minimal JSONL line for session entries used in tests.
-func jsonlLine(fields map[string]interface{}) string {
-	parts := []string{}
-	for k, v := range fields {
-		switch val := v.(type) {
-		case string:
-			parts = append(parts, fmt.Sprintf("%q:%q", k, val))
-		case int:
-			parts = append(parts, fmt.Sprintf("%q:%d", k, val))
-		case int64:
-			parts = append(parts, fmt.Sprintf("%q:%d", k, val))
-		}
-	}
-	return "{" + strings.Join(parts, ",") + "}"
-}
-
 // writeFile writes content to a file in dir with the given name.
 func writeFile(t *testing.T, dir, name, content string) string {
 	t.Helper()

--- a/src/pkg/worksource/linear.go
+++ b/src/pkg/worksource/linear.go
@@ -28,9 +28,6 @@ import (
 // defaultLinearBaseURL is Linear's single GraphQL endpoint.
 const defaultLinearBaseURL = "https://api.linear.app/graphql"
 
-// linearPageSize is the number of issues requested per GraphQL page.
-const linearPageSize = 100
-
 // defaultLinearStates is used when a team's States list is empty.
 var defaultLinearStates = []string{"Todo", "In Progress", "Backlog"}
 
@@ -86,6 +83,10 @@ func NewLinearSource(cfg LinearConfig, httpClient *http.Client) *LinearSource {
 // SourceType implements WorkSource.
 func (s *LinearSource) SourceType() string { return "linear" }
 
+// linearIssuesQuery pages at `first: 100`, Linear's maximum page size. The page
+// size is part of the query document rather than a separate constant so it
+// cannot be changed in one place and left unchanged in the document that
+// actually runs.
 const linearIssuesQuery = `query($teamKey: String!, $states: [String!], $cursor: String) {
   issues(
     filter: {


### PR DESCRIPTION
Second rung of the golangci ratchet in #4903, after `ineffassign` in #4906. One linter, its findings, and its config change — nothing else, per the issue's one-linter-per-PR procedure.

`golangci-lint v2.13.1` with the repo config and `unused` enabled: **44 findings → 0**. `unused` is now enabled in `src/.golangci.yml`.

## The findings needed judgment, not a delete pass

The issue calls this rung "dead code, including possibly-dead security guards", and that turned out to be the whole story. Three findings were guards that had come loose from the code they were written to protect — deleting those would have removed the protection and called it cleanup.

### Fixed by wiring up

**`upgradeKubectlTimeout` (`pkg/hub/saas.go`)** — this one is a live defect, not tidiness. The constant documents the bound on "a single auto-upgrade kubectl call", and `bulkRequestBudget` is *sized off it*:

> Worst case per hive is upgradeKubectlTimeout (15s); with the concurrency above, 100 hives need ~100/4*15s = 375s, so this leaves headroom without being unbounded.

Nothing applied it. All four upgrade-delivery kubectl calls — the hub's own `set image`, the branch switch's `set image` and `rollout restart`, and the initial trigger fired when auto-upgrade is switched on — went through `kubectlForCluster`, which builds an `exec.Command` with no context at all. So the per-hive bound was whatever kubectl decided, and `bulkRequestBudget`'s arithmetic rested on a number no code enforced. They now run through `kubectlForClusterContext` under `upgradeKubectlTimeout`, each call with its own bound rather than sharing one.

**`cadencePause` / `cadenceOff` (`pkg/dashboard/status_builder.go`)** — the constants say why they exist:

> Kept as named constants so the offByCadence detection and computeNextKick agree on the exact spellings the config layer emits.

`computeNextKick` and `parseCadenceDuration` both still compared bare literals — the drift the constants were introduced to prevent, already underway. Wired in, plus `cadenceOnDemand` for the third spelling both were comparing.

### Kept, with the reason stated

**`spokeWrapKeyPath` (`pkg/hub/wrapkey_store.go`)** is the documented PVC location of the spoke's X25519 private wrapping key. Every function in that file takes the path as an argument and the lifecycle has no production entry point yet, so this declaration is the only record of where that key material is supposed to land. It carries a `//nolint:unused` with the reason spelled out — the same discipline the issue asks of `#nosec`: an annotation with no stated reason is indistinguishable from hiding something.

This is the one finding in the 44 where "not wired up yet" is the honest answer, and it seemed worth flagging rather than burying.

### Deleted

The remaining 40 were superseded by a later refactor and had no reader. Two are worth calling out because their comments had gone stale in a way that mattered:

- **`hostedAvailableIDPrefix` (`pkg/hub/saas.go`)** claimed the ID prefix is "the reliable signal that a slot is idle inventory". `isAvailableRegistryEntry` records the opposite, with numbers: consulting it counted every claimed placeholder as still available, **38 reported vs 17 true**. An unused constant advertising a known-wrong signal is an invitation back into that bug.
- **`beadLedgerPartialReason` (`pkg/dashboard`)** named "the DegradedReason reported when the ledger snapshot could not cover every configured store" — but the final #3904 policy deliberately never reports a partial ledger as degraded (`observeCandidateDependencies` documents why at length). It described behaviour that does not exist.

Also removed: `diagnoseGitHubAppWrite` (wrapper whose callers all moved to `diagnoseGitHubApp`); `setGenerations` (every writer of `keyGenerations` already holds `keyGenerationsMu` across a wider critical section, so calling it would self-deadlock); the CPU/memory health thresholds duplicated in Go beside the panel's own `CLUSTER_CPU_*_PCT`; `kubectlTop/GetTimeoutSec`, superseded by the per-cluster `clusterHealthQueryTimeoutFor`; `mbPerGB`; `Proxy.mu` (every field set once in `New`); `ContributorPool` and its RWMutex, which guarded two counters nothing ever wrote; `perPage`, shadowed at its one apparent use by a function-local const of the same name; and nine dead test helpers.

Where a declaration was explicitly documentation rather than code — the GitLab/Gitea API path suffixes ("Kept here as documentation of that contract"), `linearPageSize`, `defaultPriority` — the prose stays and the constant goes. A constant nothing reads is not how to keep a contract. Three comments that named a deleted symbol were updated to name the live one.

## Verification

- `golangci-lint run` with the repo config (`unused` enabled): **0 issues**
- `go build ./...`, `go vet ./...`: clean
- `go test` for every touched package: pass — `pkg/dashboard`, `pkg/hub`, `pkg/proxy`, `cmd/hive`, `pkg/apiproxy`, `pkg/celtrigger`, `pkg/github`, `pkg/tokens`, `pkg/worksource`, `pkg/discord`
- One pre-existing failure: `pkg/agent`'s `TestSendKick_RestartsCrashedCLIThenDelivers` fails identically on the unmodified base (`git stash` + rerun) — it needs a real agent CLI in the environment.

## One note for the errcheck rung

The scanner comment on #4903 is right that the issue's 579 figure counts non-test files only, while the gate runs with `tests: true` and therefore measures **3,139**. I've recorded that in the `.golangci.yml` comment so the next person sizing that rung reads the number the gate will actually enforce. The choice between "fix all 3,139" and "enable errcheck with a test exclusion" is a maintainer decision and is left open here.

Remaining rungs after this: `staticcheck` (212 at `45a13d5`), `errcheck`, then dropping `continue-on-error` from gosec.

Refs: #4903

— hive: backend=claude model=claude-opus-5
