### PR TITLE
📖 docs(tui): record the design for `hive tui` (#4907 T0)

### DIFF
--- a/src/docs/design/README.md
+++ b/src/docs/design/README.md
@@ -85,6 +85,16 @@ that status is the thing to check before treating a page as current behaviour:
   with its timestamp would move Copilot from "structurally impossible" to
   phase 3's existing join, in `pkg/tokens` only and off the request path.
 
+- [`hive tui` — a terminal dashboard for Hive](tui.md) — **design only.** The
+  accepted plan for the k9s-style terminal client tracked in #4907: scope,
+  the fixed architecture decisions, the default 2x2 pane layout, the keybinding
+  table, and the golden-file testing convention. Read it before picking up any
+  #4907 sub-issue, for two corrections it carries that the sub-issue bodies do
+  not: their `v2/...` paths are pre-#3996 spellings and map to `src/pkg/tui/...`,
+  and `dashboard/openapi.json` — which the epic names as the contract for every
+  client task — publishes 32 of the dashboard's 298 routes and **no write
+  operations at all**, so the four action tasks have no spec to build against.
+
 ## Adding a document here
 
 Add the page, then add a line above saying what a reader gets from it **and its

--- a/src/docs/design/tui.md
+++ b/src/docs/design/tui.md
@@ -1,0 +1,298 @@
+# `hive tui` — a terminal dashboard for Hive (#4907)
+
+Status: **design only.** Nothing described here is shipped. The scaffold is
+proposed in [#4916](https://github.com/kubestellar/hive/issues/4916) (PR #4919,
+open); every pane, every client call, and every action below is a separate
+unmerged task in the [#4907](https://github.com/kubestellar/hive/issues/4907)
+task graph. Read this as intent, not as behaviour.
+
+Two things in the epic's drafted text do not match this repository, and both
+are corrected here with the evidence: the `v2/` path prefix
+([Paths](#paths-the-epics-v2-prefix-predates-3996)) and the assumption that
+`dashboard/openapi.json` is a usable contract for the action tasks
+([Contract status](#contract-status-the-spec-covers-11-of-the-api-and-no-writes)).
+Citations are against `origin/v4` at `45a13d5`.
+
+---
+
+## 1. Scope
+
+Add a full-screen terminal UI to Hive that covers the day-to-day operator loop
+currently served by the web dashboard: watch the agent fleet, watch the
+governor, watch token spend, and take the common actions (pause/resume an agent,
+switch a model, apply an ACMM level, kick an agent now). Functional model is
+**k9s** — interactive, action-capable, keyboard-driven; visual inspiration is
+**btop** — dense live panes. This is **not a second implementation of Hive
+logic**: it is a second *client* of the existing dashboard API, consuming the
+same endpoints, the same auth token, and the same SSE stream as the web
+dashboard. Hive operators are terminal people by construction — agents live in
+tmux, the relay is a CLI, self-hosters are SSH'd into a box — so exposing :3001
+or tunnelling it just to check governor mode is friction the web UI imposes. A
+second API consumer also hardens the contract: anything the TUI cannot do
+through the published spec is a gap worth an issue anyway, which is exactly what
+[section 2.1](#contract-status-the-spec-covers-11-of-the-api-and-no-writes)
+turned out to be.
+
+**Non-goals for v1**, quoted from the epic:
+
+- Hub-hosted hives / OAuth login flows. v1 targets self-hosted hives with the
+  dashboard token. Hub auth is a follow-up epic.
+- Remote terminal embedding via the ttyd WebSocket. v1 offers local tmux attach
+  only (T22). Remote attach is a follow-up epic.
+- Pixel parity with the web dashboard. Feature parity for the operator loop,
+  not visual parity.
+
+---
+
+## 2. Fixed architecture decisions
+
+Quoted verbatim from #4907. These are settled; sub-issues should not relitigate
+them.
+
+> - **Language/framework:** Go, `charmbracelet/bubbletea` + `bubbles` +
+>   `lipgloss`. Stays in-family with the existing Go module, and teatest
+>   gives us golden-file testing that runs in plain CI with no TTY.
+> - **Delivery:** a subcommand of the existing binary (`hive tui`) if the
+>   CLI entrypoint has subcommand structure; otherwise a sibling
+>   `cmd/hive-tui` main in the same module. Task T1 resolves which.
+> - **Data source:** the Node proxy on `:3001` (auth + SSE live there),
+>   not the internal Go API on `:3002`. Base URL from `HIVE_DASHBOARD_URL`
+>   (default `http://localhost:3001`), token from `HIVE_DASHBOARD_TOKEN`.
+> - **Contract:** `dashboard/openapi.json` is the source of truth for every
+>   client task. If an operation the dashboard visibly performs is missing
+>   from the spec, the sub-issue's deliverable converts to filing a scoped
+>   follow-up issue describing the gap. That is a valid completion.
+> - **Testing:** every task is verifiable with `go build ./...` and
+>   `go test ./...` alone. No task requires a running Hive stack, Docker,
+>   or network access. Client code tests against `httptest` fixture
+>   servers; rendering tests use teatest golden files.
+
+Everything below this line is **not** part of the quoted decisions. It is what
+those decisions resolve to against this repository.
+
+### Delivery: `hivectl tui`
+
+T1 resolves the open question in the Delivery decision. Of the two candidate
+entrypoints in the module, only one has subcommand structure:
+
+- **`hive` (`src/cmd/hive`) is the spoke daemon, not a CLI.** It parses a single
+  `-config` flag, takes a process-wide singleton flock whose purpose is to
+  refuse a second `hive` process (`src/cmd/hive/main.go`, `singletonLockEnv`),
+  then runs the agent manager, dashboard and heartbeat for the container's
+  lifetime. There is no subcommand dispatch to hang `tui` off.
+- **`hivectl` (`src/cmd/hivectl` + `src/pkg/hivectl/commands`) is the
+  operator-facing cobra CLI**, and it already carries the plumbing the Data
+  source decision specifies: its persistent `--server` defaults to
+  `http://127.0.0.1:3001` and `--token-env` defaults to `HIVE_DASHBOARD_TOKEN`
+  (`src/pkg/hivectl/commands/root.go`).
+
+So the command is **`hivectl tui`**. Note the one deviation this forces from the
+Data source decision as written: the base URL comes from `--server`, whose
+default is `http://127.0.0.1:3001` rather than the epic's
+`HIVE_DASHBOARD_URL` / `http://localhost:3001`. Reusing hivectl's existing flag
+is worth more than a second, differently-spelled way to say the same thing; a
+task that wants `HIVE_DASHBOARD_URL` honoured should add it as the flag's
+default source rather than as a parallel path.
+
+### Paths: the epic's `v2/` prefix predates #3996
+
+The epic and its sub-issues specify `v2/internal/tui/...` and `v2/docs/tui.md`.
+**There is no `v2/` directory in this repository and no module at the repo
+root.** The Go module is `src/` (`github.com/kubestellar/hive`), which is where
+`go build ./...` and every CI test shard run from
+(`.github/workflows/v2-tests.yml`, `working-directory: src`). A tree at the repo
+root would sit outside the module and never be compiled or tested at all.
+
+The prefix is not a typo — it is a stale spelling. **#3996 renamed the `v2/`
+source tree to `src/`**, recorded in `src/pkg/reach/mapping.go:36-37`:
+
+> `#3996 renamed the v2/ source tree to src/, but a merged PR's file list is`
+> `immutable history: PRs merged before the rename report v2/... paths from`
+> `the forge API forever`
+
+Within `src/`, code goes under `pkg/` rather than `internal/`: every non-`main`
+package in this module already lives there and the tree contains no `internal/`
+directory, so `internal/tui` would introduce a second layout convention for one
+package. The mapping for the whole epic:
+
+| Epic spelling | This repository |
+|---|---|
+| `v2/internal/tui/app.go` | `src/pkg/tui/app.go` |
+| `v2/internal/tui/client/` (T2, T4, T6, T8, T10, T13a) | `src/pkg/tui/client/` |
+| `v2/internal/tui/panes/` (T3, T5, T7, T9, T11, T17, T19, T23) | `src/pkg/tui/panes/` |
+| `v2/internal/tui/panes/testdata/` (golden files) | `src/pkg/tui/panes/testdata/` |
+| `v2/docs/tui.md` (T0) | `src/docs/design/tui.md` — this page |
+| `v2/docs/README.md` (T26) | `src/docs/design/README.md` |
+
+Verification for every code task is `go test ./pkg/tui/...`, run from `src/`.
+
+### Contract status: the spec covers 11% of the API, and no writes
+
+The Contract decision names `dashboard/openapi.json` as the source of truth and
+tells a sub-issue what to do when an operation is missing from it. That clause
+is going to fire far more often than the epic assumes, so the size of the gap is
+recorded here once rather than rediscovered by each task.
+
+Measured at `45a13d5`:
+
+| | Published in `dashboard/openapi.json` | Registered by the dashboard |
+|---|---:|---:|
+| Distinct `/api` routes | 32 | 298 |
+| `GET` | 32 | 137 |
+| `POST` | **0** | 83 |
+| `PUT` | **0** | 64 |
+| `DELETE` | **0** | 14 |
+
+The spec is **GET-only**. It documents no write operation of any kind, which
+means **every Phase 2 action task in the epic — T14 pause/resume, T17 apply
+model, T19 apply ACMM, T20 kick now — has no contract to build against.** Each
+of those endpoints exists and is exercised today by `hivectl`; none is in the
+spec:
+
+| Task | Endpoint `hivectl` uses today | In spec |
+|---|---|---|
+| T14 pause/resume | `POST /api/pause/{name}`, `POST /api/resume/{name}` (`commands/agent.go:39`) | no |
+| T17 apply model | `PUT /api/config/agent/{name}/models` (`commands/agent.go:262`) | no |
+| T19 apply ACMM | `GET /api/acmm/evaluation`, `POST /api/acmm/issue` (`dashboard/api.go:228-229`) | no |
+| T20 kick now | `POST /api/kick/{name}` (`commands/agent.go:158`) | no |
+
+Two **read** tasks are affected too, and one of them is named after the gap:
+
+- **T2 (#4917) is "API client core + `/api/health`" — `/api/health` is not in
+  the spec.** It is a real endpoint (`hivectl system health` calls it,
+  `commands/system.go`), just an undocumented one.
+- **T4 needs the agent list. `/api/agents` is not in the spec** either, though
+  `hivectl agent list` calls it (`commands/agent.go:24`). The spec has
+  `/api/status` and `/api/config/agent/{name}`, but no list operation.
+
+Of the four pane endpoints, only three are published: `/api/status`,
+`/api/config/governor`, `/api/tokens` and `/api/events` are all in the spec;
+`/api/agents` is not.
+
+**What this means for sub-issues.** The epic's own escape hatch applies and
+should be used deliberately rather than as a surprise: a task whose endpoint is
+absent should file the scoped spec-gap issue *and* build against the endpoint
+`hivectl` already calls, citing this table — not stall. The alternative reading,
+that a missing spec entry blocks the task, would block six of them at once and
+leave the TUI read-only. Widening `dashboard/openapi.json` to cover the write
+surface is worth its own issue; it is not something any single pane task should
+absorb.
+
+---
+
+## 3. Default layout
+
+Header bar, a 2×2 pane grid, and a footer keybinding strip. The sketch is the
+target for T3 (grid) and T5/T7/T9/T11 (pane contents); it is not a golden file.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ hive: acme-prod            governor: ●BUSY            ws: connected  12:04:31 │
+├───────────────────────────────────────┬──────────────────────────────────────┤
+│ AGENTS                            [1] │ GOVERNOR                         [2] │
+│  NAME          STATE     BACKEND      │  mode          BUSY                  │
+│ ▸scanner       running   claude       │  queue depth   7 actionable          │
+│  quality       running   copilot      │  next eval     in 3m12s              │
+│  reviewer      paused    claude       │  eval interval 5m                    │
+│  ux-discovery  idle      codex        │  budget        41% of daily          │
+│                                       │  acmm level    L4                    │
+├───────────────────────────────────────┼──────────────────────────────────────┤
+│ TOKENS                            [3] │ EVENTS                           [4] │
+│  AGENT         IN       OUT    COST   │  12:04:02  kick scanner (governor)   │
+│  scanner       1.2M     88.1k  $4.10  │  12:03:41  pr #4919 opened           │
+│  quality       410.3k   31.0k  $1.32  │  12:01:58  quality → idle            │
+│  reviewer      96.7k    12.4k  $0.38  │  11:58:20  reviewer paused (operator)│
+│  ─────────────────────────────────    │  11:57:03  bead bd-1042 closed       │
+│  total         1.7M     131.5k $5.80  │  11:55:44  governor QUIET → BUSY     │
+├───────────────────────────────────────┴──────────────────────────────────────┤
+│ tab focus  j/k move  p pause  m model  K kick  A acmm  a attach  ? help  q quit│
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Notes the sketch encodes, for the tasks that implement it:
+
+- **Header** carries hive name, a governor mode badge, and connection state.
+  Connection state is its own field because the SSE stream can drop while the
+  process stays up (T13b); a TUI that silently shows stale numbers is worse than
+  one that says it is disconnected.
+- **Focus** is shown two ways — the `[n]` pane index and the `▸` row cursor —
+  because only one pane has focus but every pane keeps its own selection.
+- **Numbers are illustrative.** No pane task should treat these as expected
+  output; the golden files in each pane's `testdata/` are the assertion.
+- T24 owns the below-minimum-size path: at small terminals the grid is not
+  shrunk, it is replaced by a single message.
+
+---
+
+## 4. Keybindings
+
+| Key | Action | Scope | Task |
+|---|---|---|---|
+| `tab` / `shift+tab` | Cycle pane focus forward / backward | global | T3 |
+| `j` / `k`, `↓` / `↑` | Move the selection within the focused pane | focused pane | T3, T11 |
+| `p` | Pause or resume the selected agent | Agents pane | T15 |
+| `m` | Open the model picker for the selected agent | Agents pane | T17 |
+| `K` | Kick the selected agent now | Agents pane | T21 |
+| `A` | Open the ACMM level overlay | global | T19 |
+| `a` | Attach to the selected agent's tmux session (**local only**) | Agents pane | T22 |
+| `?` | Toggle the help overlay | global | T23 |
+| `q` / `ctrl+c` | Quit | global | T1 |
+
+Conventions these bindings assume:
+
+- **Case is meaningful.** `K` kicks and `A` opens ACMM, while `k` moves the
+  cursor up and `a` attaches. The destructive-ish member of each pair is the
+  shifted one, deliberately: `k` is pressed constantly during navigation and
+  must never be one missed shift away from an action.
+- **Actions apply to the selection in the focused pane**, never to a global
+  "current agent". A key that acts on an agent while the Agents pane is not
+  focused should be a no-op, not a guess.
+- **Confirmation is per-risk, not uniform.** T15 specifies a confirm modal for
+  pause/resume and T19 specifies *typed* confirmation for an ACMM change,
+  because an ACMM level applies fleet-wide and is not obviously reversible from
+  the same screen.
+- `q` quits from the top level only once overlays exist; an open overlay should
+  consume it (T23).
+
+---
+
+## 5. Testing convention
+
+Every task is verifiable with `go build ./...` and `go test ./...` alone — no
+running Hive, no Docker, no network.
+
+- **Client code** (`src/pkg/tui/client/`) tests against `httptest` fixture
+  servers. Fixtures are captured response bodies, not live calls.
+- **Rendering** (`src/pkg/tui/panes/`) uses teatest golden files under
+  `src/pkg/tui/panes/testdata/`, regenerated with:
+
+  ```
+  cd src && go test ./pkg/tui/panes/... -update
+  ```
+
+  `-update` is registered by `github.com/charmbracelet/x/exp/golden`
+  (`golden.go:15`), which `teatest.RequireEqualOutput` calls; it is not a flag
+  this repository defines. Regenerated files must be reviewed in the diff like
+  any other change — a golden file updated without reading it asserts nothing.
+- **Behaviour that is not layout** — key handling, quit, focus movement — should
+  be asserted directly rather than through a golden file, so that a deliberate
+  layout change does not force an unrelated behavioural test to be regenerated.
+  The scaffold's `TestAppQuits` is the pattern: it drives the model through
+  teatest so the assertion covers `tea.Quit` actually reaching the program, not
+  merely being returned.
+- **Golden files are terminal output.** They contain escape sequences and are
+  width-sensitive, so every golden test must pin its size with
+  `teatest.WithInitialTermSize`; a test that inherits a default size will
+  produce a diff on someone else's machine.
+
+---
+
+## Related
+
+- [#4907](https://github.com/kubestellar/hive/issues/4907) — the tracker, task
+  table, and filing protocol.
+- [`hivectl`](../hivectl.md) — the non-interactive client for the same API, and
+  the command this TUI is a subcommand of.
+- [`api-reference.md`](../api-reference.md) — the dashboard API as documented
+  for humans; see [section 2.1](#contract-status-the-spec-covers-11-of-the-api-and-no-writes)
+  for how much of it `dashboard/openapi.json` actually publishes.


### PR DESCRIPTION
T0 of the #4907 TUI epic: the design record every later sub-issue reads before picking up work.

All five sections the issue asks for, in order — scope, the verbatim architecture decisions, the ASCII layout sketch, the keybinding table, the testing convention — plus two corrections that the sub-issue bodies do not carry and that change what several of them can do.

## The `v2/` paths are a pre-#3996 spelling

The epic specifies `v2/internal/tui/...` and `v2/docs/tui.md`. There is no `v2/` directory and no module at the repo root — the module is `src/`, which is where `go build` and every CI shard run from (`v2-tests.yml`, `working-directory: src`), so a tree at the repo root would never be compiled or tested at all.

It is not a typo. **#3996 renamed the `v2/` source tree to `src/`**, and `src/pkg/reach/mapping.go:36-37` both records it and still compensates for it:

> `#3996 renamed the v2/ source tree to src/, but a merged PR's file list is immutable history: PRs merged before the rename report v2/... paths from the forge API forever`

The doc carries the full mapping table so T2 through T27 do not each rediscover it.

## `dashboard/openapi.json` publishes no writes at all

This is the finding worth a maintainer's attention. The epic names the spec as the source of truth for every client task, with an escape hatch when an operation is missing. Measured at `45a13d5`, that hatch is going to fire constantly:

| | Published in `dashboard/openapi.json` | Registered by the dashboard |
|---|---:|---:|
| Distinct `/api` routes | 32 | 298 |
| `GET` | 32 | 137 |
| `POST` | **0** | 83 |
| `PUT` | **0** | 64 |
| `DELETE` | **0** | 14 |

The spec is GET-only. **All four Phase 2 action tasks have no contract to build against** — T14 pause/resume, T17 apply model, T19 apply ACMM, T20 kick now. Every one of those endpoints exists and is exercised by `hivectl` today; none is published.

Two read tasks are hit too, and one is named after the gap: **T2 (#4917) is "API client core + `/api/health`", and `/api/health` is not in the spec.** Neither is `/api/agents`, which T4 needs and `hivectl agent list` already calls.

The doc cites the live endpoint for each, so those tasks can file the scoped spec-gap issue *and* still ship. The alternative reading — that a missing spec entry blocks the task — would block six of them at once and leave the TUI read-only. Widening the spec to cover the write surface is worth its own issue; it is not something a single pane task should absorb.

## Also recorded

The Delivery decision resolves to **`hivectl tui`** (T1, #4919): `hive` is the spoke daemon with no subcommand dispatch, while `hivectl` is the cobra CLI that already defaults `--server` to the `:3001` proxy and `--token-env` to `HIVE_DASHBOARD_TOKEN`. The doc also flags the one deviation that forces — the epic names `HIVE_DASHBOARD_URL` and hivectl spells the same thing `--server`.

## Two deliberate deviations from the issue text

**Location is `src/docs/design/tui.md`, not `v2/docs/tui.md`** — per the path correction above. `src/docs/design/` is this repo's home for "longer-form design records … the reference record for a decision", which is what T0 describes, and its status taxonomy gives the page the **design only** header it needs while nothing is shipped.

**One line added to `src/docs/design/README.md`, which the issue said not to do.** The issue says not to touch any docs index because T26 owns that. That file is the *directory's own* index, not the top-level one T26 names (`README.md`, `v2/docs/README.md`), and its own "Adding a document here" section makes the entry part of the procedure:

> Add the page, then add a line above saying what a reader gets from it **and its status**.
>
> Pages in this directory are reached through this index rather than through `src/docs/README.md` directly…

Following the letter of the issue would land a page nothing links to — the exact failure the docs-index-reminder workflow exists to catch. If you'd rather T26 own it, it is one bullet to drop.

## Verification

Doc-only. `go build ./...` still passes, every relative link resolves, and each numeric claim was measured against `origin/v4` at `45a13d5` rather than estimated:

- 32 spec paths / GET-only: parsed from `dashboard/openapi.json`
- 298 registered routes: `HandleFunc` registrations across `src/pkg/dashboard`, excluding `_test.go`
- endpoint citations: `commands/agent.go:24,39,158,262`, `commands/system.go`, `dashboard/api.go:228-229`
- the `-update` flag: `x/exp/golden/golden.go:15`, not something this repo defines

Part of #4907. Closes #4915

— hive: backend=claude model=claude-opus-5
