### PR TITLE
✨ feat(tui): API client core and the health check (#4907 T2)

### DIFF
--- a/src/pkg/tui/client/client.go
+++ b/src/pkg/tui/client/client.go
@@ -1,0 +1,182 @@
+// Package client is the TUI's HTTP client for the Hive dashboard API
+// (kubestellar/hive#4907).
+//
+// It is deliberately small: one transport, one auth header, one JSON decode
+// helper. Every later TUI task adds typed methods to this package rather than
+// its own HTTP handling, so there is exactly one place that knows how a request
+// to the dashboard is addressed and authenticated.
+//
+// WHY NOT REUSE pkg/hivectl's CLIENT. It was evaluated. It speaks to the same
+// API with the same token and would have brought its SSE reader along, but its
+// Do() returns `any` because it feeds the CLI's table/json/yaml printer — a TUI
+// decoding into typed structs would have to re-marshal that map on every poll —
+// and its constructor returns an error, which this package's New() cannot per
+// its contract. What it does have that is worth copying outright is the
+// transport lesson recorded at src/pkg/hivectl/client.go:69; see newTransport.
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is where the dashboard listens on a self-hosted hive: the
+	// Node auth proxy (src/proxy/server.js), not the Go API behind it on :3002.
+	// The proxy is where the token check and the SSE stream live, and it
+	// forwards /api/* to the Go API, so every endpoint the TUI needs is
+	// reachable here.
+	DefaultBaseURL = "http://localhost:3001"
+
+	// BaseURLEnv and TokenEnv are the two environment variables the TUI reads.
+	// TokenEnv is the same variable hivectl's --token-env defaults to, so an
+	// operator who has hivectl working has the TUI working.
+	BaseURLEnv = "HIVE_DASHBOARD_URL"
+	TokenEnv   = "HIVE_DASHBOARD_TOKEN"
+
+	// requestTimeout bounds a single dashboard request. The TUI repaints on a
+	// timer, so a request that outlives its frame is not worth waiting for —
+	// better to fail the pane and retry on the next tick than to stall the UI
+	// behind a hung socket.
+	requestTimeout = 5 * time.Second
+
+	// maxErrorBodyBytes caps how much of a failed response is read back into an
+	// APIError. Enough to carry the dashboard's `{"error":"..."}` payload, small
+	// enough that an HTML error page from a misconfigured reverse proxy cannot
+	// become a multi-megabyte string held in the model.
+	maxErrorBodyBytes = 4 << 10
+)
+
+// APIError is returned when the dashboard answers with a non-2xx status.
+//
+// It carries the status and the (truncated) body rather than collapsing to a
+// string so a pane can distinguish the cases that mean different things to an
+// operator: 401 is a missing or wrong HIVE_DASHBOARD_TOKEN, 404 is a dashboard
+// too old to serve the endpoint, 502 is the proxy up but the Go API behind it
+// down.
+type APIError struct {
+	StatusCode int
+	Path       string
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("GET %s: %s", e.Path, http.StatusText(e.StatusCode))
+	}
+	return fmt.Sprintf("GET %s: %s: %s", e.Path, http.StatusText(e.StatusCode), e.Body)
+}
+
+// Client talks to one dashboard.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// New builds a Client from the environment: base URL from HIVE_DASHBOARD_URL
+// (default DefaultBaseURL), token from HIVE_DASHBOARD_TOKEN.
+//
+// It cannot fail. A malformed HIVE_DASHBOARD_URL surfaces on the first request
+// as a request error rather than at construction, because the alternative — a
+// constructor that returns an error the TUI must render before it has a frame
+// to render into — buys nothing: the operator sees the same message either way,
+// one tick later.
+func New() *Client {
+	base := strings.TrimSpace(os.Getenv(BaseURLEnv))
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	return &Client{
+		// Trailing slash is trimmed so joining a leading-slash path cannot
+		// produce "//api/health", which some reverse proxies do not normalize.
+		baseURL: strings.TrimRight(base, "/"),
+		token:   strings.TrimSpace(os.Getenv(TokenEnv)),
+		http:    &http.Client{Timeout: requestTimeout, Transport: newTransport()},
+	}
+}
+
+// newTransport gives the client its OWN transport rather than letting a nil
+// Transport silently use http.DefaultTransport.
+//
+// This is copied deliberately from src/pkg/hivectl/client.go:69, which records
+// why: every parallel client test tears down its httptest.Server, and
+// Server.Close() calls CloseIdleConnections on http.DefaultTransport — racing
+// whichever other parallel test has a request in flight on a pooled connection.
+// Under a loaded CI runner that surfaces as a flaky "connection broken" from an
+// unrelated test. Clone() keeps DefaultTransport's dial/TLS/proxy defaults.
+func newTransport() http.RoundTripper {
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		return t.Clone()
+	}
+	return http.DefaultTransport
+}
+
+// Health reports whether the dashboard is up, returning nil on 2xx.
+//
+// /api/health is a PUBLIC path on the Go API (src/pkg/dashboard/server.go,
+// isPublicPath), so this succeeds without a token — which makes it the right
+// first call for the TUI: it separates "the dashboard is unreachable" from
+// "the dashboard is there and my token is wrong", and those are different
+// things to tell an operator.
+func (c *Client) Health(ctx context.Context) error {
+	return c.getJSON(ctx, "/api/health", nil)
+}
+
+// getJSON performs a GET and decodes the response body into v.
+//
+// It is the single request path for this package; later tasks add typed methods
+// that call it rather than building requests themselves. A nil v discards the
+// body, which is what a liveness check wants — Health cares about the status,
+// not the payload, and decoding a body it will not read would turn a healthy
+// dashboard serving an unexpected shape into a failure.
+func (c *Client) getJSON(ctx context.Context, path string, v any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("build request for %s: %w", path, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.token != "" {
+		// Authorization: Bearer is what the proxy's requireAuth verifies
+		// (src/proxy/server.js) and what hivectl already sends
+		// (src/pkg/hivectl/client.go). The published spec documents no security
+		// scheme at all, so this is read from the verifier, not from the spec —
+		// see kubestellar/hive#4912.
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// Read a bounded prefix so the error can quote the dashboard's own
+		// message; a body we cannot read is not worth failing differently for.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Path:       path,
+			Body:       strings.TrimSpace(string(body)),
+		}
+	}
+
+	if v == nil {
+		// Drain before the deferred Close so the connection returns to the pool
+		// instead of being torn down — this client polls the same few endpoints
+		// on a timer, so keeping the connection is the common case.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	return nil
+}

--- a/src/pkg/tui/client/client_test.go
+++ b/src/pkg/tui/client/client_test.go
@@ -1,0 +1,286 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestClient points a Client at a fixture server, bypassing New() so a test
+// never depends on the ambient environment.
+func newTestClient(t *testing.T, server *httptest.Server, token string) *Client {
+	t.Helper()
+	c := New()
+	c.baseURL = server.URL
+	c.token = token
+	return c
+}
+
+// TestHealthSendsExpectedRequest pins the three things about the request that a
+// server cares about: the path, the method, and the Authorization header.
+//
+// The header spelling is the load-bearing assertion. The published spec carries
+// no security scheme (#4912), so `Bearer` here is transcribed from the two
+// implementations that actually verify it — the proxy's requireAuth and
+// hivectl's client — and this test is what keeps it transcribed correctly.
+func TestHealthSendsExpectedRequest(t *testing.T) {
+	var gotPath, gotMethod, gotAuth, gotAccept string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		gotAuth, gotAccept = r.Header.Get("Authorization"), r.Header.Get("Accept")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := newTestClient(t, server, "s3cret").Health(context.Background()); err != nil {
+		t.Fatalf("Health() = %v, want nil", err)
+	}
+
+	if gotPath != "/api/health" {
+		t.Errorf("path = %q, want /api/health", gotPath)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotAuth != "Bearer s3cret" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer s3cret")
+	}
+	if gotAccept != "application/json" {
+		t.Errorf("Accept = %q, want application/json", gotAccept)
+	}
+}
+
+// TestHealthOmitsAuthorizationWithoutToken covers the unauthenticated path.
+//
+// /api/health is a public path on the Go API, so a tokenless health check must
+// work — it is how the TUI tells "dashboard unreachable" apart from "token
+// wrong". Sending an empty `Bearer ` would be worse than sending nothing: the
+// proxy's requireAuth matches `Bearer (.+)` and a bare prefix fails the regex,
+// turning a public endpoint into a 401.
+func TestHealthOmitsAuthorizationWithoutToken(t *testing.T) {
+	var hadAuth bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadAuth = r.Header["Authorization"]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	if err := newTestClient(t, server, "").Health(context.Background()); err != nil {
+		t.Fatalf("Health() = %v, want nil", err)
+	}
+	if hadAuth {
+		t.Error("Authorization header sent with an empty token; it must be omitted entirely")
+	}
+}
+
+// TestHealthNonOKReturnsAPIError checks the typed-error contract across the
+// statuses that mean different things to an operator.
+func TestHealthNonOKReturnsAPIError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code int
+		body string
+	}{
+		{name: "unauthorized", code: http.StatusUnauthorized, body: `{"error":"Unauthorized"}`},
+		{name: "not found", code: http.StatusNotFound, body: "not found"},
+		{name: "bad gateway", code: http.StatusBadGateway, body: `{"error":"Go API unavailable"}`},
+		{name: "empty body", code: http.StatusInternalServerError, body: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			err := newTestClient(t, server, "t").Health(context.Background())
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("Health() = %v (%T), want *APIError", err, err)
+			}
+			if apiErr.StatusCode != tc.code {
+				t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, tc.code)
+			}
+			if apiErr.Path != "/api/health" {
+				t.Errorf("Path = %q, want /api/health", apiErr.Path)
+			}
+			if apiErr.Body != tc.body {
+				t.Errorf("Body = %q, want %q", apiErr.Body, tc.body)
+			}
+			// The message must carry the status; a pane renders this string.
+			if !strings.Contains(apiErr.Error(), http.StatusText(tc.code)) {
+				t.Errorf("Error() = %q, does not name the status", apiErr.Error())
+			}
+		})
+	}
+}
+
+// TestHealthTruncatesHugeErrorBody guards the maxErrorBodyBytes cap. A
+// misconfigured reverse proxy answering with a large HTML page must not become
+// a multi-megabyte string held in the model.
+func TestHealthTruncatesHugeErrorBody(t *testing.T) {
+	huge := strings.Repeat("x", maxErrorBodyBytes*4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer server.Close()
+
+	err := newTestClient(t, server, "t").Health(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Health() = %v, want *APIError", err)
+	}
+	if len(apiErr.Body) > maxErrorBodyBytes {
+		t.Fatalf("Body is %d bytes, want at most %d", len(apiErr.Body), maxErrorBodyBytes)
+	}
+}
+
+// TestGetJSONDecodes covers the helper every later task builds on.
+func TestGetJSONDecodes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/status" {
+			t.Errorf("path = %q, want /api/status", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"mode":"BUSY","agents":4}`))
+	}))
+	defer server.Close()
+
+	var got struct {
+		Mode   string `json:"mode"`
+		Agents int    `json:"agents"`
+	}
+	if err := newTestClient(t, server, "t").getJSON(context.Background(), "/api/status", &got); err != nil {
+		t.Fatalf("getJSON() = %v, want nil", err)
+	}
+	if got.Mode != "BUSY" || got.Agents != 4 {
+		t.Fatalf("decoded %+v, want {BUSY 4}", got)
+	}
+}
+
+// TestGetJSONMalformedBody: a 200 carrying something that is not the expected
+// JSON is a decode error, not a silent zero value.
+func TestGetJSONMalformedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>`))
+	}))
+	defer server.Close()
+
+	var got struct{ Mode string }
+	err := newTestClient(t, server, "t").getJSON(context.Background(), "/api/status", &got)
+	if err == nil {
+		t.Fatal("getJSON() = nil on a non-JSON 200, want a decode error")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("error = %v, want it to name the decode failure", err)
+	}
+}
+
+// TestGetJSONTransportError: an unreachable dashboard is an error naming the
+// path, not a panic or a nil.
+func TestGetJSONTransportError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := server.URL
+	server.Close() // nothing is listening now
+
+	c := New()
+	c.baseURL = url
+	err := c.Health(context.Background())
+	if err == nil {
+		t.Fatal("Health() against a closed server = nil, want an error")
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		t.Fatalf("transport failure surfaced as *APIError (%v); it is not an API response", err)
+	}
+	if !strings.Contains(err.Error(), "/api/health") {
+		t.Fatalf("error = %v, want it to name the path", err)
+	}
+}
+
+// TestGetJSONHonoursContextCancellation: the TUI cancels in-flight requests
+// when a pane is torn down, and that must abort the request rather than block
+// until requestTimeout.
+func TestGetJSONHonoursContextCancellation(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := newTestClient(t, server, "t").Health(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Health() = %v, want context.Canceled", err)
+	}
+}
+
+// TestNewReadsEnvironment pins the two variable names and the default.
+func TestNewReadsEnvironment(t *testing.T) {
+	t.Setenv(BaseURLEnv, "https://hive.example.com:8443/")
+	t.Setenv(TokenEnv, "  tok  ")
+
+	c := New()
+	// The trailing slash is trimmed so path joining cannot produce "//api/...".
+	if c.baseURL != "https://hive.example.com:8443" {
+		t.Errorf("baseURL = %q, want the trailing slash trimmed", c.baseURL)
+	}
+	if c.token != "tok" {
+		t.Errorf("token = %q, want surrounding whitespace trimmed", c.token)
+	}
+	if c.http.Timeout != requestTimeout {
+		t.Errorf("timeout = %v, want %v", c.http.Timeout, requestTimeout)
+	}
+}
+
+// TestNewDefaultsBaseURL: an unset (or blank) HIVE_DASHBOARD_URL falls back to
+// the proxy's default port, not to an empty base that would make every request
+// a relative-URL error.
+func TestNewDefaultsBaseURL(t *testing.T) {
+	for _, value := range []string{"", "   "} {
+		t.Setenv(BaseURLEnv, value)
+		if got := New().baseURL; got != DefaultBaseURL {
+			t.Errorf("baseURL with %q = %q, want %q", value, got, DefaultBaseURL)
+		}
+	}
+}
+
+// TestNewUsesItsOwnTransport guards the reason newTransport exists: a nil
+// Transport silently shares http.DefaultTransport, whose connection pool other
+// packages' httptest teardowns call CloseIdleConnections on.
+func TestNewUsesItsOwnTransport(t *testing.T) {
+	c := New()
+	if c.http.Transport == nil {
+		t.Fatal("client has a nil Transport; it would share http.DefaultTransport")
+	}
+	if c.http.Transport == http.DefaultTransport {
+		t.Fatal("client shares http.DefaultTransport; it must own a clone")
+	}
+}
+
+// TestMalformedBaseURLFailsOnRequest pins the behaviour New()'s doc comment
+// promises: a bad HIVE_DASHBOARD_URL is not rejected at construction, it
+// surfaces on the first call. If that ever changes to a constructor error, this
+// test is the reminder that the doc comment changes with it.
+func TestMalformedBaseURLFailsOnRequest(t *testing.T) {
+	t.Setenv(BaseURLEnv, "http://a b c")
+
+	c := New()
+	if c == nil {
+		t.Fatal("New() = nil on a malformed base URL; it must not fail at construction")
+	}
+	err := c.Health(context.Background())
+	if err == nil {
+		t.Fatal("Health() = nil with a malformed base URL, want a request-build error")
+	}
+	if !strings.Contains(err.Error(), "/api/health") {
+		t.Fatalf("error = %v, want it to name the path", err)
+	}
+}


### PR DESCRIPTION
T2 of the #4907 TUI epic: the one place that knows how a request to the dashboard is addressed and authenticated. `Client`, `New()`, `Health()`, and the shared `getJSON()` helper the pane-client tasks (T4/T6/T8/T10) build on.

Stdlib only — `go.mod` and `go.sum` are untouched.

## The auth header, and why it isn't a guess

The issue says to send the token "the same way the web dashboard does per `dashboard/openapi.json` security scheme (**check the spec; do not guess the header**)".

Checked. **The spec has no security scheme.** It has no `components` block at all — the whole document is `openapi`, `info`, `servers`, `tags`, `paths` — so there is no `securitySchemes`, no top-level `security`, and no per-operation `security` to read. `/api/health` isn't in it either.

```
$ python3 -c "import json;d=json.load(open('dashboard/openapi.json'));print(list(d.keys()), d.get('security'), d.get('components'))"
['openapi', 'info', 'servers', 'tags', 'paths'] None None
```

So rather than guess, the header is transcribed from the two things that actually *verify* it, which agree:

- **`src/proxy/server.js` `requireAuth()`** matches `/^Bearer\s+(.+)$/i` against `req.headers.authorization` and timing-safe compares against `HIVE_DASHBOARD_TOKEN`.
- **`src/pkg/hivectl/client.go`** sets `Authorization: Bearer <token>` from the same environment variable.

Hence `Authorization: Bearer $HIVE_DASHBOARD_TOKEN` — and **omitted entirely** when no token is set, because a bare `Bearer ` fails that regex and would turn a public endpoint into a 401. Both behaviours are pinned by tests.

## No duplicate spec-gap issue

The issue's note says filing a scoped spec-gap issue completes this task. **#4912 is already open and already reports exactly this**, down to recommending "the `HIVE_DASHBOARD_TOKEN` security scheme". Filing a second would be noise, and stopping at a filing would leave T4/T6/T8/T10 blocked behind a client that can be written correctly *today* from the verifier.

I've posted corrections to #4912's route inventory there as a comment rather than duplicating them here — briefly: it measured `dashboard/server.js`, but the container entrypoint starts `src/proxy/server.js`, which proxies `/api/*` to the Go API, so the real undocumented surface is larger than 69 routes.

## Where `/api/health` actually lives

It is a **Go dashboard** route (`src/pkg/dashboard/server.go`) on the `isPublicPath` list. It is reachable at the epic's `:3001` base URL because `src/proxy/server.js` proxies `/api/*` to the Go API on `:3002` — confirmed independently by `src/pkg/hub/heartbeat.go`, which probes `http://localhost:3001/api/health`, and by the compose healthcheck.

That public status is load-bearing for the TUI, and is why `Health()` works without a token: a tokenless health check is what separates *"the dashboard is unreachable"* from *"the dashboard is there and my token is wrong"*, and those are different things to tell an operator.

## Carried over: the transport lesson

A nil `Transport` silently shares `http.DefaultTransport`, whose idle pool **every** parallel `httptest` teardown calls `CloseIdleConnections` on. `src/pkg/hivectl/client.go:69` records that this already produced a flaky "connection broken" from an unrelated test in this repo. This client clones its own transport, and a test asserts it rather than trusting the comment.

## Reuse was considered

`pkg/hivectl`'s client speaks the same API with the same token and would have brought its SSE reader along. It isn't wrapped because its `Do()` returns `any` — it feeds the CLI's table/json/yaml printer, so a TUI decoding into typed structs would re-marshal that map on every poll — and its constructor returns an error, which this task's `New() *Client` contract cannot. The reasoning is in the package doc so the next reader doesn't have to redo it. (Its `StreamSSE` is still worth a look for T13a.)

## Tests

httptest fixtures assert path, method, `Authorization` and `Accept`; the tokenless path; `APIError` across 401/404/502/500-with-empty-body; the error-body cap; and `getJSON`'s decode, malformed-body, transport-error and context-cancellation paths, plus both environment variables and the default.

Every load-bearing assertion is mutation-checked:

| Mutation | Test that catches it |
|---|---|
| `Bearer` → `Token` | `TestHealthSendsExpectedRequest` |
| send `Authorization` with an empty token | `TestHealthOmitsAuthorizationWithoutToken` |
| drop the trailing-slash trim | `TestNewReadsEnvironment` |
| share `http.DefaultTransport` | `TestNewUsesItsOwnTransport` |
| unbound the error body | `TestHealthTruncatesHugeErrorBody` |

## Verification

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint` with the repo config — 0 issues; also 0 `unused` findings in the new package, since #4914 will make that linter blocking
- `gosec` on `pkg/tui` — 0 issues
- every test binary in the module compiles
- **`pkg/tui/client` is at 96.9%**, against the gate's 90% floor (that gate caught #4919 on its first push, so it is checked up front here)

One honest gap: **`govulncheck` could not be run locally** — v1.1.4 crashes in the `x/tools` SSA builder on the Go 1.27 toolchain on this machine. CI runs it on Go 1.25. Since this branch adds no dependencies, its vulnerability surface is identical to `v4`.

## Out of scope

Any endpoint other than health, SSE, retries/backoff — per the issue.

Part of #4907. Closes #4917

Independent of #4919 (T1) and #4920 (T0): new package, no shared files, no `go.mod` change — it can merge in any order. The path is `src/pkg/tui/client/` per the mapping in #4920, since the epic's `v2/` prefix is a pre-#3996 spelling.

— hive: backend=claude model=claude-opus-5
