### PR TITLE
🔒 fix(agent): reap the processes an agent spawns, not just its CLI

### DIFF
--- a/src/pkg/agent/helpers_coverage_test.go
+++ b/src/pkg/agent/helpers_coverage_test.go
@@ -10,8 +10,8 @@ import (
 
 // ---------------------------------------------------------------------------
 // reapAgentCLI / killAgentProcesses — /proc-based; on non-Linux /proc is
-// absent so these exercise the ReadDir-error branch. containsCLIMarker and
-// environHasMarker are pure and always testable.
+// absent so these exercise the ReadDir-error branch. reapExcluded,
+// reapSkipPID and environHasMarker are pure and always testable.
 // ---------------------------------------------------------------------------
 
 func TestReapAgentCLI_NoProc(t *testing.T) {

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -9194,36 +9194,74 @@ func (m *Manager) RestartThenSendKick(ctx context.Context, name, message string)
 	return m.SendKick(name, message)
 }
 
-// cliProcessMarkers are substrings that identify a CLI process in its
-// /proc/<pid>/cmdline. The Claude CLI (and inference backends, which also use
-// it) runs as `claude` (often re-exec'd via node); copilot/gemini/goose/bob run
-// under their own names. Matching cmdline substrings catches the CLI regardless
-// of the interpreter the process reports as its comm name.
-var cliProcessMarkers = []string{
-	"claude",
-	"copilot",
-	"gemini",
-	"goose",
-	"bob",
-}
+// reapExclusions are cmdline substrings that must NEVER be SIGKILLed by the
+// marker sweep, even when the process carries this agent's HIVE_AGENT.
+//
+// Only tmux is listed, and it is defensive rather than observed: hive starts
+// the tmux server itself with exec.Command, which inherits hive's own
+// environment and therefore has no HIVE_AGENT — so it should never match. But
+// the server owns every pane for the agent (and, on a shared socket, for other
+// agents), so a single mis-match would take the fleet's panes down with it.
+// That asymmetry is worth one string compare.
+//
+// Matched as a SUBSTRING, deliberately: the exclusion should fire on
+// "/usr/bin/tmux" and "tmux -S /tmp/... attach" alike. It therefore also spares
+// an agent process that merely mentions tmux in its arguments. That is a
+// false NEGATIVE — one leaked process not reaped — which is the direction an
+// exclusion list should fail in.
+var reapExclusions = []string{"tmux"}
 
-// reapAgentCLI finds and SIGKILLs every CLI process belonging to the given
-// agent, matched by the HIVE_AGENT=<name> marker in /proc/<pid>/environ. This
-// marker is inlined into every launch command (buildEnvPrefix) and set on the
-// tmux session (ensureTmuxSession), so it uniquely identifies an agent's CLI
-// processes — unlike UID matching, which cannot distinguish agents that share
-// the dev UID (UID isolation disabled). Returns the number of processes killed.
+// procRoot is the /proc mount the reaper scans. A var (not const) so tests can
+// point it at a fake proc tree on non-Linux hosts; production value is "/proc"
+// and nothing on the launch path mutates it.
+var procRoot = "/proc"
+
+// reapKill is the kill syscall the marker sweep uses. A var (not a direct
+// syscall.Kill call) for the same reason procRoot is: it is the only way a test
+// can assert what the sweep DECIDED to signal, as opposed to what it managed to
+// signal. Those differ exactly where it matters — an unprivileged test cannot
+// kill PID 1, so a count-based assertion passes whether or not the guard that
+// skips init is present. Production never reassigns it.
+var reapKill = syscall.Kill
+
+// reapAgentCLI finds and SIGKILLs every process belonging to the given agent,
+// matched by the HIVE_AGENT=<name> marker in /proc/<pid>/environ. Returns the
+// number of processes killed.
 //
 // This is the single-CLI guarantee: before every (re)launch, any pre-existing
 // or leaked CLI for the agent is terminated, so an agent can never accumulate
 // concurrent claude processes on different models. tmux kill-session alone is
 // insufficient — a detached node/claude child can survive the session's SIGHUP
 // and keep hitting the gateway (403-flooding the pane on a stale model).
-// procRoot is the /proc mount the reaper scans. A var (not const) so tests can
-// point it at a fake proc tree on non-Linux hosts; production value is "/proc"
-// and nothing on the launch path mutates it.
-var procRoot = "/proc"
-
+//
+// #4924: IT ALSO REAPS THE CLI'S CHILDREN, and that is the point of the marker
+// being the only predicate. This used to require the cmdline to name a backend
+// binary (claude/copilot/gemini/goose/bob), which meant a process the agent
+// spawned — a poll loop, a dev server, a `sleep` — passed the env check and
+// failed the cmdline one, so it was skipped and outlived every task. Nothing
+// else collected it: killAgentProcesses does sweep non-CLI helpers, but it is
+// gated on agent.UID > 0 and so never runs on the contributor/workstation path
+// where UID isolation is off. That is precisely the deployment where a leaked
+// poller burns an operator's own rate limit indefinitely.
+//
+// WHY THE MARKER ALONE IS SAFE ENOUGH TO KILL ON. HIVE_AGENT reaches a process
+// two ways, and both mean "hive started this for this agent":
+//
+//   - inlined into the typed launch command (buildEnvPrefix), so the CLI and
+//     everything it forks inherit it;
+//   - set on the tmux session by ensureTmuxSession, AFTER it has created the
+//     session — so shells started in that session later inherit it.
+//
+// environHasMarker compares whole NUL-separated entries, so "scanner" cannot
+// match "scanner-2". The pane's own bash is NOT affected: ensureTmuxSession
+// creates the session (and therefore that shell) BEFORE it runs the
+// set-environment loop, so the shell never carries the marker — the same
+// ordering RelaunchBobAgentsAwaitingKey depends on and verified live.
+//
+// The one behaviour change worth stating plainly: a shell an operator opens
+// inside this agent's tmux session after launch DOES carry the marker and is
+// now reaped. That is judged acceptable because every caller is tearing the
+// agent down at that moment anyway (pre-launch, restart, stop).
 func (m *Manager) reapAgentCLI(agent *AgentProcess) int {
 	procPath := procRoot
 	marker := "HIVE_AGENT=" + agent.Name
@@ -9243,7 +9281,7 @@ func (m *Manager) reapAgentCLI(agent *AgentProcess) int {
 		if err != nil {
 			continue
 		}
-		if pid == os.Getpid() {
+		if reapSkipPID(pid, os.Getpid()) {
 			continue
 		}
 
@@ -9253,7 +9291,7 @@ func (m *Manager) reapAgentCLI(agent *AgentProcess) int {
 			continue
 		}
 		cmdline := strings.ReplaceAll(string(cmdlineRaw), "\x00", " ")
-		if !containsCLIMarker(cmdline) {
+		if reapExcluded(cmdline) {
 			continue
 		}
 
@@ -9267,7 +9305,7 @@ func (m *Manager) reapAgentCLI(agent *AgentProcess) int {
 			continue
 		}
 
-		if err := syscall.Kill(pid, syscall.SIGKILL); err == nil {
+		if err := reapKill(pid, syscall.SIGKILL); err == nil {
 			killed++
 			m.logger.Info("reaped agent CLI process",
 				"agent", agent.Name, "pid", pid, "cmdline", truncateStr(cmdline, 120))
@@ -9279,9 +9317,25 @@ func (m *Manager) reapAgentCLI(agent *AgentProcess) int {
 	return killed
 }
 
-// containsCLIMarker reports whether a /proc cmdline names a known CLI binary.
-func containsCLIMarker(cmdline string) bool {
-	for _, marker := range cliProcessMarkers {
+// reapSkipPID reports pids the sweep must never signal, whatever their markers
+// say. Split out from the loop so the guard is directly testable: PID 1 cannot
+// be killed by an unprivileged test process anyway, so a test that only checked
+// the reaped COUNT would pass with or without this guard and prove nothing.
+func reapSkipPID(pid, self int) bool {
+	// Never signal ourselves.
+	if pid == self {
+		return true
+	}
+	// PID 1 can never be an agent process, and SIGKILLing it takes down the
+	// container (or the workstation's init). Guard explicitly rather than
+	// relying on init never carrying the marker.
+	return pid == 1
+}
+
+// reapExcluded reports whether a /proc cmdline names something the marker
+// sweep must leave alone.
+func reapExcluded(cmdline string) bool {
+	for _, marker := range reapExclusions {
 		if strings.Contains(cmdline, marker) {
 			return true
 		}

--- a/src/pkg/agent/proc_coverage_test.go
+++ b/src/pkg/agent/proc_coverage_test.go
@@ -54,8 +54,17 @@ func TestReapAgentCLI_FakeProc(t *testing.T) {
 	// A non-matching entry (different agent) that must be skipped.
 	writeProcEntry(t, root, pid+100000, "node\x00claude",
 		"HIVE_AGENT=other\x00", os.Getuid())
-	// A non-CLI entry that must be skipped by the cmdline marker check.
-	writeProcEntry(t, root, pid+200000, "/bin/bash\x00-l",
+	// #4924: a non-CLI process carrying THIS agent's marker — a child the agent
+	// spawned. It used to be skipped by the cmdline allowlist; it must now be
+	// reaped. A REAL child, because a fake pid makes syscall.Kill fail and the
+	// counter would not move whether the predicate matched or not — the test
+	// would pass either way and prove nothing.
+	child2 := exec.Command("sleep", "30")
+	if err := child2.Start(); err != nil {
+		t.Skipf("cannot start child: %v", err)
+	}
+	defer func() { _ = child2.Process.Kill(); _, _ = child2.Process.Wait() }()
+	writeProcEntry(t, root, child2.Process.Pid, "/bin/bash\x00-c\x00until gh pr checks; do sleep 60; done",
 		"HIVE_AGENT=scanner\x00", os.Getuid())
 	// A non-numeric dir entry (ignored).
 	os.MkdirAll(filepath.Join(root, "not-a-pid"), 0o755)
@@ -66,16 +75,19 @@ func TestReapAgentCLI_FakeProc(t *testing.T) {
 	m.mu.RUnlock()
 
 	killed := m.reapAgentCLI(agent)
-	if killed != 1 {
-		t.Errorf("expected 1 reaped process, got %d", killed)
+	if killed != 2 {
+		t.Errorf("expected 2 reaped processes (the CLI and its spawned child), got %d", killed)
 	}
 }
 
 func TestReapAgentCLI_FakeProcNoMatch(t *testing.T) {
 	root := t.TempDir()
 	withFakeProc(t, root)
-	// Only non-matching entries.
-	writeProcEntry(t, root, 424242, "/bin/bash", "HIVE_AGENT=scanner\x00", os.Getuid())
+	// Only entries for a DIFFERENT agent. Since #4924 the cmdline no longer
+	// narrows anything, so the agent marker is the whole test: "/bin/bash" with
+	// HIVE_AGENT=scanner would now be reaped, and this case has to key off the
+	// name mismatch instead to still mean something.
+	writeProcEntry(t, root, 424242, "/bin/bash", "HIVE_AGENT=other\x00", os.Getuid())
 	m := NewManager(map[string]config.AgentConfig{"scanner": {Backend: "claude"}}, discardLogger(), ProjectContext{})
 	m.mu.RLock()
 	agent := m.agents["scanner"]

--- a/src/pkg/agent/reap_children_test.go
+++ b/src/pkg/agent/reap_children_test.go
@@ -1,0 +1,240 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// startSleeper launches a real child and registers its cleanup. Real processes
+// matter here: with a fake pid syscall.Kill fails, the counter never moves, and
+// a test asserting "0 reaped" passes whether the predicate matched or not.
+func startSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	c := exec.Command("sleep", "30")
+	if err := c.Start(); err != nil {
+		t.Skipf("cannot start child: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Process.Kill(); _, _ = c.Process.Wait() })
+	return c
+}
+
+// assertKilled confirms the sweep actually delivered SIGKILL.
+//
+// A signal-0 liveness probe is NOT sufficient here and reports the opposite of
+// the truth: SIGKILL leaves a child of this test process as a ZOMBIE until it
+// is waited on, and signal 0 succeeds against a zombie. Waiting and reading the
+// exit status is what distinguishes "killed" from "still running".
+func assertKilled(t *testing.T, name string, c *exec.Cmd) {
+	t.Helper()
+	_ = c.Wait()
+	ws, ok := c.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok {
+		t.Fatalf("%s: cannot read wait status", name)
+	}
+	if !ws.Signaled() || ws.Signal() != syscall.SIGKILL {
+		t.Errorf("%s survived the sweep (exit state %v)", name, c.ProcessState)
+	}
+}
+
+// assertRunning confirms a process was left alone. It has not been signalled,
+// so it cannot be a zombie and signal 0 is a truthful probe.
+func assertRunning(t *testing.T, name string, c *exec.Cmd) {
+	t.Helper()
+	if err := syscall.Kill(c.Process.Pid, 0); err != nil {
+		t.Errorf("%s was killed by the marker sweep: %v", name, err)
+	}
+}
+
+func reaperFor(t *testing.T) (*Manager, *AgentProcess) {
+	t.Helper()
+	m := NewManager(map[string]config.AgentConfig{"scanner": {Backend: "claude"}}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["scanner"]
+	m.mu.RUnlock()
+	return m, agent
+}
+
+// TestReapsAgentSpawnedChild is the #4924 regression.
+//
+// A poll loop the agent spawned carries HIVE_AGENT by inheritance but is not
+// named after a backend binary. Under the old cmdline allowlist it survived
+// every task; on the workstation path nothing else collected it, because
+// killAgentProcesses is gated on UID isolation being on.
+func TestReapsAgentSpawnedChild(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("the reaper reads /proc; Linux only (GOOS=%s)", runtime.GOOS)
+	}
+	root := t.TempDir()
+	withFakeProc(t, root)
+
+	child := startSleeper(t)
+	writeProcEntry(t, root, child.Process.Pid,
+		"/bin/bash\x00-c\x00until gh pr checks 4914; do sleep 60; done",
+		"PATH=/bin\x00HIVE_AGENT=scanner\x00", os.Getuid())
+
+	m, agent := reaperFor(t)
+	if killed := m.reapAgentCLI(agent); killed != 1 {
+		t.Fatalf("reaped %d, want 1 — an agent-spawned child must not outlive its agent", killed)
+	}
+	assertKilled(t, "spawned poll loop", child)
+}
+
+// TestReapSkipsTmux: tmux owns every pane for the agent, and on a shared socket
+// for other agents too. Even carrying the marker it must never be signalled.
+func TestReapSkipsTmux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("the reaper reads /proc; Linux only (GOOS=%s)", runtime.GOOS)
+	}
+	root := t.TempDir()
+	withFakeProc(t, root)
+
+	tmux := startSleeper(t)
+	writeProcEntry(t, root, tmux.Process.Pid, "tmux\x00new-session\x00-d\x00-s\x00hive-scanner",
+		"HIVE_AGENT=scanner\x00", os.Getuid())
+
+	m, agent := reaperFor(t)
+	if killed := m.reapAgentCLI(agent); killed != 0 {
+		t.Fatalf("reaped %d, want 0 — killing tmux takes every pane down with it", killed)
+	}
+	assertRunning(t, "tmux", tmux)
+}
+
+// TestReapSkipsOtherAgent: the marker is compared as a whole NUL-separated
+// entry, so one agent's sweep can never reach another's processes — including
+// the prefix case, where "scanner" must not match "scanner-2".
+func TestReapSkipsOtherAgent(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("the reaper reads /proc; Linux only (GOOS=%s)", runtime.GOOS)
+	}
+	root := t.TempDir()
+	withFakeProc(t, root)
+
+	other := startSleeper(t)
+	prefix := startSleeper(t)
+	writeProcEntry(t, root, other.Process.Pid, "sleep\x0030", "HIVE_AGENT=quality\x00", os.Getuid())
+	writeProcEntry(t, root, prefix.Process.Pid, "sleep\x0030", "HIVE_AGENT=scanner-2\x00", os.Getuid())
+
+	m, agent := reaperFor(t)
+	if killed := m.reapAgentCLI(agent); killed != 0 {
+		t.Fatalf("reaped %d, want 0", killed)
+	}
+	assertRunning(t, "another agent's process", other)
+	assertRunning(t, "scanner-2 (prefix collision)", prefix)
+}
+
+// TestReapSkipPID asserts the guard DIRECTLY rather than through the reaped
+// count.
+//
+// Going through the count would be vacuous: an unprivileged test process cannot
+// kill real PID 1, so syscall.Kill fails, the counter stays 0, and the test
+// passes whether or not the guard exists. Verified by mutation — deleting the
+// guard left a count-based test green.
+func TestReapSkipPID(t *testing.T) {
+	const self = 4242
+	cases := []struct {
+		name string
+		pid  int
+		want bool
+	}{
+		{name: "init is never signalled", pid: 1, want: true},
+		{name: "hive never signals itself", pid: self, want: true},
+		{name: "an ordinary agent pid is fair game", pid: 9001, want: false},
+	}
+	for _, c := range cases {
+		if got := reapSkipPID(c.pid, self); got != c.want {
+			t.Errorf("%s: reapSkipPID(%d, %d) = %v, want %v", c.name, c.pid, self, got, c.want)
+		}
+	}
+}
+
+// TestReapNeverSignalsPIDOne records every pid the sweep tries to kill, rather
+// than counting the ones it succeeded in killing.
+//
+// That distinction is the whole test. An unprivileged process cannot kill real
+// PID 1, so syscall.Kill fails and the reaped count stays 0 whether the guard
+// exists or not — verified by mutation: removing the guard from the loop left a
+// count-based version of this test green. Recording the ATTEMPT is what makes
+// "hive never signals init" an assertion instead of an accident.
+func TestReapNeverSignalsPIDOne(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("the reaper reads /proc; Linux only (GOOS=%s)", runtime.GOOS)
+	}
+	root := t.TempDir()
+	withFakeProc(t, root)
+	// init, wearing the agent's marker — the worst case the guard exists for.
+	writeProcEntry(t, root, 1, "/sbin/init", "HIVE_AGENT=scanner\x00", 0)
+	// A normal agent process, so the sweep is not trivially a no-op.
+	writeProcEntry(t, root, 9001, "sleep\x0060", "HIVE_AGENT=scanner\x00", os.Getuid())
+
+	var attempted []int
+	orig := reapKill
+	reapKill = func(pid int, sig syscall.Signal) error {
+		attempted = append(attempted, pid)
+		return nil
+	}
+	t.Cleanup(func() { reapKill = orig })
+
+	m, agent := reaperFor(t)
+	m.reapAgentCLI(agent)
+
+	for _, pid := range attempted {
+		if pid == 1 {
+			t.Fatal("the sweep signalled PID 1 — that takes down init")
+		}
+	}
+	if len(attempted) == 0 {
+		t.Fatal("the sweep signalled nothing; the fixture is not exercising the kill path")
+	}
+}
+
+// TestReapSkipsUnmarkedProcess: the agent's own pane bash is created before the
+// session env is set, so it never carries the marker and must be left alone —
+// the ordering RelaunchBobAgentsAwaitingKey depends on.
+func TestReapSkipsUnmarkedProcess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("the reaper reads /proc; Linux only (GOOS=%s)", runtime.GOOS)
+	}
+	root := t.TempDir()
+	withFakeProc(t, root)
+
+	shell := startSleeper(t)
+	writeProcEntry(t, root, shell.Process.Pid, "/bin/bash", "PATH=/bin\x00TERM=xterm\x00", os.Getuid())
+
+	m, agent := reaperFor(t)
+	if killed := m.reapAgentCLI(agent); killed != 0 {
+		t.Fatalf("reaped %d, want 0", killed)
+	}
+	assertRunning(t, "the pane's unmarked bash", shell)
+}
+
+// TestReapCountsCLIAndChildrenTogether: the mixed case an operator actually
+// has — a CLI plus two things it spawned, all reaped in one pass.
+func TestReapCountsCLIAndChildrenTogether(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("the reaper reads /proc; Linux only (GOOS=%s)", runtime.GOOS)
+	}
+	root := t.TempDir()
+	withFakeProc(t, root)
+
+	cli := startSleeper(t)
+	poller := startSleeper(t)
+	server := startSleeper(t)
+	writeProcEntry(t, root, cli.Process.Pid, "node\x00claude\x00--model\x00opus", "HIVE_AGENT=scanner\x00", os.Getuid())
+	writeProcEntry(t, root, poller.Process.Pid, "sleep\x0060", "HIVE_AGENT=scanner\x00", os.Getuid())
+	writeProcEntry(t, root, server.Process.Pid, "node\x00server.js", "HIVE_AGENT=scanner\x00", os.Getuid())
+	os.MkdirAll(filepath.Join(root, "not-a-pid"), 0o755)
+
+	m, agent := reaperFor(t)
+	if killed := m.reapAgentCLI(agent); killed != 3 {
+		t.Fatalf("reaped %d, want 3 (CLI + poller + server)", killed)
+	}
+	assertKilled(t, "cli", cli)
+	assertKilled(t, "poller", poller)
+	assertKilled(t, "server", server)
+}

--- a/src/pkg/agent/reaper_test.go
+++ b/src/pkg/agent/reaper_test.go
@@ -10,24 +10,39 @@ import (
 	"github.com/kubestellar/hive/pkg/config"
 )
 
-func TestContainsCLIMarker(t *testing.T) {
+// TestReapExcluded pins the sweep's ONLY cmdline predicate.
+//
+// This replaces TestContainsCLIMarker, which asserted the inverse: that the
+// sweep matched only backend binaries. That allowlist is what let an agent's
+// spawned children survive every task (#4924) — a poll loop carries the agent's
+// HIVE_AGENT but is not named "claude", so it was skipped. The marker is the
+// authority now, and the only question a cmdline answers is whether the process
+// is tmux, which must never be signalled.
+func TestReapExcluded(t *testing.T) {
 	cases := []struct {
 		cmdline string
 		want    bool
 	}{
-		{"claude --model claude-opus-4.7 --dangerously-skip-permissions", true},
-		{"node /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js", true},
-		{"copilot --model gpt-5 --allow-all", true},
-		{"gemini --model gemini-2.5-pro", true},
-		{"goose run -s", true},
-		{"bob", true},
+		// tmux owns the panes; killing it takes them all down.
+		{"tmux new-session -d -s hive-scanner", true},
+		{"/usr/bin/tmux -S /tmp/tmux-2007/hive-scanner attach", true},
+
+		// Backend CLIs — reaped, as before.
+		{"claude --model claude-opus-4.7 --dangerously-skip-permissions", false},
+		{"node /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js", false},
+		{"copilot --model gpt-5 --allow-all", false},
+		{"bob", false},
+
+		// The #4924 cases: agent-spawned children that the old allowlist skipped.
+		{"/bin/bash -c until gh pr checks 4914; do sleep 60; done", false},
+		{"sleep 60", false},
+		{"node server.js", false},
 		{"/bin/bash -l", false},
-		{"tmux new-session -d -s hive-scanner", false},
 		{"", false},
 	}
 	for _, c := range cases {
-		if got := containsCLIMarker(c.cmdline); got != c.want {
-			t.Errorf("containsCLIMarker(%q) = %v, want %v", c.cmdline, got, c.want)
+		if got := reapExcluded(c.cmdline); got != c.want {
+			t.Errorf("reapExcluded(%q) = %v, want %v", c.cmdline, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Requesting an LLM review pass from a maintainer before merge.** This changes the predicate on a `SIGKILL` loop that runs against `/proc` on an operator's own machine. I have reasoned about the blast radius carefully and mutation-tested every guard (below), but the cost of being wrong here is high and asymmetric, so a second automated review on validation and safety is worth the cycles. `/code-review ultra` or your usual pass — whatever you run, please run it against this one before merging.

Fixes #4924.

## Root cause

`reapAgentCLI` required **two** predicates, not one:

```go
if !containsCLIMarker(cmdline) { continue }              // cmdline names a backend binary
if !environHasMarker(string(environRaw), marker) { continue }  // HIVE_AGENT=<name>
```

with `cliProcessMarkers = {"claude", "copilot", "gemini", "goose", "bob"}`.

A child the agent spawned inherits `HIVE_AGENT` and passes the second check, but its cmdline reads `bash` or `sleep`, so it fails the first and is skipped. It then outlives every task.

Hive already knew about this gap — `killAgentProcesses` exists to *"sweep any non-CLI helper processes"*, per its own call-site comment. But it matches by owner UID and is gated on `agent.UID > 0`, floor-guarded at 2001 so a `uid == 0` sweep as root cannot SIGKILL every root process. On a workstation there is no per-agent UID, so it never runs:

| Deployment | `agent.UID` | Sweeps that run | Spawned children collected? |
|---|---|---|---|
| Containerized spoke | ≥ 2001 | both | yes |
| `contribute-hive` on a workstation | 0 | `reapAgentCLI` only | **no** |

## The fix

Make the env marker the sole predicate; replace the CLI allowlist with a narrow exclusion list.

### Why the marker alone is safe to kill on — the part to review

`HIVE_AGENT` reaches a process exactly two ways, and both mean *"hive started this, for this agent"*:

1. inlined into the typed launch command (`buildEnvPrefix`), so the CLI and everything it forks inherit it;
2. set on the tmux session by `ensureTmuxSession`.

**The ordering inside `ensureTmuxSession` is load-bearing, and I verified it rather than assuming it:** the session — and therefore the pane's own bash — is created at lines 2057-2069, *before* the `set-environment` loop at 2096. So that shell never carries the marker and is never reaped. `RelaunchBobAgentsAwaitingKey` depends on the same ordering and records a live confirmation of it (`BOBSHELL_API_KEY present in the tmux session env, absent from every bob /proc/<pid>/environ`).

`environHasMarker` already compares whole NUL-separated entries, so `scanner` cannot reach `scanner-2`.

Two guards, explicit rather than assumed:

- **tmux is excluded** even carrying the marker. It should never match (hive starts the server with `exec.Command`, inheriting hive's own env), but it owns every pane, so one mis-match takes the fleet's panes down. Substring-matched deliberately — it over-excludes, which is the direction an exclusion list should fail in.
- **PID 1 is never signalled**, split into `reapSkipPID` so the guard is directly testable.

### One behaviour change, stated plainly

A shell an operator opens inside the agent's tmux session **after** launch does carry the marker and is now reaped. Judged acceptable because every caller — pre-launch, restart, stop — is tearing that agent down at that moment anyway. Flagging it explicitly because it is the one case where this is not a strict improvement.

## Two tests that were vacuous

The existing fake-proc cases asserted the old behaviour using pids that **do not exist**, so `syscall.Kill` failed and the counter never moved — they passed whether the predicate matched or not. They now use real child processes. Two further traps found while writing the new ones:

- **SIGKILL leaves a child of the test process as a zombie** until it is waited on, and signal 0 succeeds against a zombie — so a liveness probe reports the *opposite* of the truth. `assertKilled` waits and reads the exit status instead.
- **An unprivileged test cannot kill real PID 1**, so a count-based assertion passes with or without the guard. Confirmed by mutation: deleting the guard left that test green. `reapKill` is now a test seam (like the existing `procRoot`) so the test asserts what the sweep *decided* to signal rather than what it *managed* to.

## Mutation matrix

Every guard is proven to be load-bearing:

| Mutation | Caught by |
|---|---|
| PID-1 guard removed from the predicate | `TestReapSkipPID`, `TestReapNeverSignalsPIDOne` |
| guard no longer called in the loop | `TestReapNeverSignalsPIDOne` |
| tmux exclusion emptied | `TestReapSkipsTmux`, `TestReapExcluded` |
| exclusion inverted | `TestReapAgentCLI_FakeProc`, `TestReapsAgentSpawnedChild` |
| agent-marker check dropped | reap suite |
| marker loosened to a prefix | `TestReapAgentCLI_FakeProc`, `TestReapsAgentSpawnedChild` |

## Also fixed while here

`reapAgentCLI`'s doc comment was separated from the function by the `procRoot` declaration, so it documented nothing. The vars now sit above it.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint` with the repo config — 0 issues; also 0 `unused` findings in the touched files, since #4914 will make that linter blocking
- `gosec` on `pkg/agent` — **60 findings before and after**, no new ones
- every test binary in the module compiles
- full `pkg/agent` suite under CI flags (`-short -race`) — passes, **91.4%** coverage against the package's recorded floor of **89**

## Not covered here

The second half of #4924 — reaping on *task completion* rather than only on launch/restart/stop — is untouched. Every `reapAgentCLI` call site is still a teardown, so a process leaked at the end of a task survives until the next kick. That is a scheduling change rather than a predicate change and wants its own PR; **please leave #4924 open for it.**

— hive: backend=claude model=claude-opus-5
