### PR TITLE
🐛 fix: base PRs on the repository's default branch, not a hardcoded "main"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@ Hive did not historically maintain a complete changelog. This file starts a prag
   documented `api_key: ${LINEAR_API_KEY}` form works from both `hive.yaml`
   and the dashboard.
 - Pull requests from forks can now satisfy `v4`'s required `gate` status context. `gate` is a job in `docker.yml`, which triggered on `push` only — and a fork PR's push event fires in the contributor's repo, not here, so `gate` never attached to the head SHA this repo evaluates and branch protection blocked the merge waiting for a check that could not arrive. Six fully green contributor PRs (#4930, #4932, #4934, #4935, #4936, #4937) were structurally unmergeable; `gate` was verified absent on every one of their head SHAs. It went unnoticed because `enforce_admins` is false, so maintainers' own merges silently bypassed the same missing check — the required context was in practice unenforced for maintainers and absolutely enforced for outside contributors. `docker.yml` now also triggers on `pull_request`, with every image-build job skipped for that event, so the context attaches to fork PRs at the cost of one ~5-second shell job and no image CI: the image is already built and smoke-tested on every PR by `v2-ci.yml` (`docker`, `build-and-test`, `overlayfs-exec-guard`). Push builds and GHCR publishing are unchanged — `gate` reports `push=false` for a PR event, so every `merge*` job stays skipped ([#4965](https://github.com/kubestellar/hive/issues/4965)).
+- PRs the hive opens are now based on the **target repository's default
+  branch** instead of a hardcoded `main`. Every PR the App filed on a repo
+  whose default branch is something else (e.g. `testing`) was opened against
+  `main`, so its diff carried the entire divergence between the two branches —
+  one reported PR showed 233 changed files and ~260k changed lines for a
+  one-file change, large enough that GitHub's diff API refused to serve it —
+  and merging it would have landed the change on the wrong branch. The base is
+  now resolved from the repo's own `default_branch` metadata (already covered
+  by the App's metadata:read permission, cached per repo), `hive-open-pr` no
+  longer pins `--base main` when the caller omits it, and sandbox kicks branch
+  from the default branch recorded in their own clone. An explicitly requested
+  base is still honored, and an unresolvable repo falls back to `main` rather
+  than failing the PR open. ([#4928](https://github.com/kubestellar/hive/issues/4928))
 
 - The canonical `blocked` workflow overlay now stays out of the contributor
   queue: the actionable-work enumerator, ReadyQueue, live contributor

--- a/bin/hive-open-pr.sh
+++ b/bin/hive-open-pr.sh
@@ -15,7 +15,13 @@
 # Usage (drop-in for the common gh pr create shape):
 #   hive-open-pr --repo <owner/repo> --head <branch> [--base <branch>] \
 #                --title "<title>" --body "<body>"
-#   # --head defaults to the current git branch; --base defaults to main.
+#   # --head defaults to the current git branch. --base is OPTIONAL and should
+#   # normally be omitted: an omitted base is left empty in the request so the
+#   # hive resolves the TARGET REPOSITORY's default branch when it opens the PR.
+#   # Do not pass --base main "to be safe" — that is exactly the bug that based
+#   # every PR on main in repos whose default branch is not main
+#   # (kubestellar/hive#4928). Pass --base only to target a non-default branch
+#   # deliberately (a release line, a stacked PR).
 #
 # On success it prints the request path and returns 0. The PR opens
 # asynchronously (within one watcher tick); poll the .result.json next to the
@@ -26,7 +32,7 @@ set -euo pipefail
 
 REQ_DIR="/var/run/hive-metrics/pr-requests"
 
-REPO=""; HEAD=""; BASE="main"; TITLE=""; BODY=""
+REPO=""; HEAD=""; BASE=""; TITLE=""; BODY=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --repo)  REPO="$2"; shift 2;;
@@ -91,5 +97,5 @@ else
     > "$REQ_FILE"
 fi
 
-echo "hive-open-pr: requested PR on $REPO ($HEAD -> $BASE) as the App bot"
+echo "hive-open-pr: requested PR on $REPO ($HEAD -> ${BASE:-<repo default branch>}) as the App bot"
 echo "hive-open-pr: request $REQ_FILE (the hive opens the PR within ~10s; result appears at ${REQ_FILE%.json}.result.json)"

--- a/src/pkg/agent/sandbox_executor.go
+++ b/src/pkg/agent/sandbox_executor.go
@@ -21,7 +21,11 @@ import (
 
 const (
 	DefaultSandboxKickTimeout = 45 * time.Minute
-	defaultSandboxBaseRef     = "main"
+	// fallbackSandboxBaseRef is used only when the cloned repository refuses to
+	// name its own default branch (see resolveBaseRef). It is a fallback, never
+	// the starting assumption — hardcoding it based every sandbox PR on main
+	// even in repos whose default branch is something else (kubestellar/hive#4928).
+	fallbackSandboxBaseRef    = "main"
 	defaultSandboxNetworkMode = sandbox.NetworkModeRestricted
 	sandboxPromptRelPath      = ".hive/kick-prompt.txt"
 	sandboxTranscriptRelPath  = ".hive/sandbox-transcript.log"
@@ -97,16 +101,16 @@ func (e *SandboxExecutor) Run(ctx context.Context, spec SandboxKickSpec) (Sandbo
 	if spec.Timeout <= 0 {
 		spec.Timeout = DefaultSandboxKickTimeout
 	}
-	if spec.BaseRef == "" {
-		spec.BaseRef = defaultSandboxBaseRef
-	}
 	if spec.NetworkMode == "" {
 		spec.NetworkMode = defaultSandboxNetworkMode
 	}
 	if spec.Branch == "" {
 		spec.Branch = e.branchName(spec.Agent)
 	}
-	workspace, baseSHA, err := e.prepareWorkspace(ctx, spec)
+	// prepareWorkspace resolves spec.BaseRef from the clone when the caller did
+	// not pin one, so the PR opened below is based on the repo's own default
+	// branch rather than an assumed "main".
+	workspace, baseSHA, err := e.prepareWorkspace(ctx, &spec)
 	if err != nil {
 		res.Error = err.Error()
 		return res, err
@@ -200,7 +204,11 @@ func (e *SandboxExecutor) Run(ctx context.Context, spec SandboxKickSpec) (Sandbo
 	return res, nil
 }
 
-func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec SandboxKickSpec) (string, string, error) {
+// prepareWorkspace clones the target repo and checks out the work branch off the
+// base ref. When spec.BaseRef is empty it is RESOLVED from the clone and written
+// back into spec, so the caller opens its PR against the same ref it branched
+// from.
+func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec *SandboxKickSpec) (string, string, error) {
 	if strings.TrimSpace(spec.Org) == "" || strings.TrimSpace(spec.Repo) == "" {
 		return "", "", errors.New("sandbox workspace prep requires org and repo")
 	}
@@ -221,6 +229,9 @@ func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec SandboxKick
 	if out, err := e.runner().Run(ctx, "", pushbroker.PushEnv(os.Environ()), "git", cloneArgs...); err != nil {
 		return "", "", fmt.Errorf("git clone: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+	if strings.TrimSpace(spec.BaseRef) == "" {
+		spec.BaseRef = e.resolveBaseRef(ctx, workspace)
+	}
 	fetchArgs := append(append([]string{}, authArgs...), "fetch", "origin", spec.BaseRef)
 	if out, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()), "git", fetchArgs...); err != nil {
 		return "", "", fmt.Errorf("git fetch %s: %w: %s", spec.BaseRef, err, strings.TrimSpace(string(out)))
@@ -233,6 +244,32 @@ func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec SandboxKick
 		return "", "", fmt.Errorf("git rev-parse HEAD: %w", err)
 	}
 	return workspace, strings.TrimSpace(string(base)), nil
+}
+
+// resolveBaseRef reports the default branch of the freshly cloned repo. `git
+// clone` records the remote's HEAD in refs/remotes/origin/HEAD, so the answer is
+// already on disk — no API call, no extra token scope. An unreadable or
+// unexpected answer falls back to fallbackSandboxBaseRef rather than failing the
+// kick.
+func (e *SandboxExecutor) resolveBaseRef(ctx context.Context, workspace string) string {
+	out, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()),
+		"git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	if err != nil {
+		if e.Logger != nil {
+			e.Logger.Warn("sandbox: default-branch lookup failed, using fallback base",
+				"workspace", workspace, "fallback", fallbackSandboxBaseRef, "error", err)
+		}
+		return fallbackSandboxBaseRef
+	}
+	ref := strings.TrimSpace(string(out))
+	// symbolic-ref --short renders it as "origin/<branch>".
+	if _, branch, found := strings.Cut(ref, "/"); found {
+		ref = branch
+	}
+	if ref == "" {
+		return fallbackSandboxBaseRef
+	}
+	return ref
 }
 
 func (e *SandboxExecutor) cloneAuthArgs(ctx context.Context, repo, dir string) ([]string, func(), error) {

--- a/src/pkg/agent/sandbox_executor_baseref_test.go
+++ b/src/pkg/agent/sandbox_executor_baseref_test.go
@@ -1,0 +1,148 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+// Regression coverage for kubestellar/hive#4928 on the sandbox path: the
+// executor branched from, and opened its PR against, a hardcoded "main"
+// regardless of what the target repository's default branch actually is. `git
+// clone` already records the remote's HEAD, so the right answer was on disk the
+// whole time.
+
+// baseRefRunner is a git stub that reports a configurable default branch for
+// refs/remotes/origin/HEAD and records the ref the executor fetched.
+type baseRefRunner struct {
+	mu sync.Mutex
+
+	symbolicRef    string // what `git symbolic-ref --short refs/remotes/origin/HEAD` prints
+	symbolicRefErr error  // when set, the lookup fails instead
+
+	fetchedRef      string
+	symbolicRefRuns int
+	revParses       int
+}
+
+func (r *baseRefRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	if name != "git" {
+		return nil, errors.New("unexpected command")
+	}
+	effective := stripGitConfigArgs(args)
+	joined := strings.Join(effective, " ")
+	switch {
+	case len(effective) >= 4 && effective[0] == "clone":
+		workspace := effective[len(effective)-1]
+		return nil, os.MkdirAll(filepath.Join(workspace, ".git"), 0o770)
+	case joined == "symbolic-ref --short refs/remotes/origin/HEAD":
+		r.mu.Lock()
+		r.symbolicRefRuns++
+		r.mu.Unlock()
+		if r.symbolicRefErr != nil {
+			return nil, r.symbolicRefErr
+		}
+		return []byte(r.symbolicRef + "\n"), nil
+	case strings.HasPrefix(joined, "fetch origin "):
+		r.mu.Lock()
+		r.fetchedRef = strings.TrimPrefix(joined, "fetch origin ")
+		r.mu.Unlock()
+		return []byte("ok\n"), nil
+	case joined == "rev-parse HEAD":
+		// First answer is the base the workspace was branched from; later ones
+		// are the agent's commit, so commitsSince sees real work to push.
+		r.mu.Lock()
+		r.revParses++
+		n := r.revParses
+		r.mu.Unlock()
+		if n > 1 {
+			return []byte("headsha\n"), nil
+		}
+		return []byte("basesha\n"), nil
+	case joined == "rev-list --count basesha..HEAD":
+		return []byte("1\n"), nil
+	case joined == "rev-parse --verify basesha":
+		return []byte("basesha\n"), nil
+	case joined == "diff --name-only basesha...HEAD":
+		return []byte("file.txt\n"), nil
+	case joined == "diff --no-ext-diff basesha...HEAD":
+		return []byte("diff --git a/file.txt b/file.txt\n"), nil
+	case strings.Contains(joined, "push ") && strings.Contains(joined, " origin HEAD:refs/heads/"):
+		return []byte("pushed\n"), nil
+	default:
+		return []byte(""), nil
+	}
+}
+
+// baseRefPRClient records the base the executor asked the hive to open against.
+type baseRefPRClient struct{ base string }
+
+func (p *baseRefPRClient) CreatePR(_ context.Context, _, _, base, _, _ string) (ghpkg.CreatePRResult, error) {
+	p.base = base
+	return ghpkg.CreatePRResult{Number: 1, URL: "https://example.test/pr/1"}, nil
+}
+
+func runSandboxForBaseRef(t *testing.T, runner *baseRefRunner, specBase string) *baseRefPRClient {
+	t.Helper()
+	pr := &baseRefPRClient{}
+	exec := &SandboxExecutor{
+		Runner:      runner,
+		Launcher:    sandboxFakeLauncher{},
+		PRClient:    pr,
+		PushEnabled: true,
+		Minter:      sandboxFakeMinter{},
+	}
+	if _, err := exec.Run(context.Background(), SandboxKickSpec{
+		Agent: "scanner", AgentConfig: configSnapshot{Backend: "claude"}, Message: "fix",
+		Org: "kubestellar", Repo: "hive", BaseRef: specBase,
+		WorkspaceDir: t.TempDir(), Image: "agent-image",
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return pr
+}
+
+func TestSandboxExecutorBranchesFromRepoDefaultBranch(t *testing.T) {
+	runner := &baseRefRunner{symbolicRef: "origin/testing"}
+	pr := runSandboxForBaseRef(t, runner, "")
+
+	if runner.fetchedRef != "testing" {
+		t.Fatalf("fetched %q, want testing — the clone's own default branch", runner.fetchedRef)
+	}
+	if pr.base != "testing" {
+		t.Fatalf("PR opened against %q, want testing", pr.base)
+	}
+}
+
+func TestSandboxExecutorFallsBackWhenDefaultBranchUnreadable(t *testing.T) {
+	runner := &baseRefRunner{symbolicRefErr: errors.New("no origin/HEAD")}
+	pr := runSandboxForBaseRef(t, runner, "")
+
+	if runner.fetchedRef != "main" {
+		t.Fatalf("fetched %q, want the main fallback", runner.fetchedRef)
+	}
+	if pr.base != "main" {
+		t.Fatalf("PR opened against %q, want the main fallback", pr.base)
+	}
+}
+
+func TestSandboxExecutorHonorsPinnedBaseRef(t *testing.T) {
+	runner := &baseRefRunner{symbolicRef: "origin/testing"}
+	pr := runSandboxForBaseRef(t, runner, "release-1.2")
+
+	if runner.fetchedRef != "release-1.2" {
+		t.Fatalf("fetched %q, want the pinned release-1.2", runner.fetchedRef)
+	}
+	if pr.base != "release-1.2" {
+		t.Fatalf("PR opened against %q, want release-1.2", pr.base)
+	}
+	if runner.symbolicRefRuns != 0 {
+		t.Fatalf("pinned base still ran %d default-branch lookups, want 0", runner.symbolicRefRuns)
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -149,6 +149,13 @@ type Client struct {
 	// issues:write) still surface within ~an hour instead of never. Guarded by
 	// advisoryMu.
 	advisoryDigestSkips map[string]int
+	// defaultBranches memoizes the resolved default branch per "owner/repo"
+	// (see defaultbranch.go). A repo's default branch changes about as often as
+	// the repo is renamed, so caching it keeps the "what is this repo's base?"
+	// lookup off the hot path of every PR open without risking a stale answer
+	// that matters. Guarded by defaultBranchMu.
+	defaultBranchMu sync.RWMutex
+	defaultBranches map[string]string
 }
 
 func (c *Client) SetCanaryScanner(enabled, failClosed bool, reg *ioscan.CanaryRegistry, onLeak func(ioscan.CanaryLeak)) {

--- a/src/pkg/github/defaultbranch.go
+++ b/src/pkg/github/defaultbranch.go
@@ -1,0 +1,81 @@
+package github
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+// FallbackDefaultBranch is what DefaultBranch reports when the repository's real
+// default branch cannot be resolved (no client, no credentials, or an API error).
+//
+// It is a LAST resort, not a starting assumption. Hive used to hardcode it as
+// THE base for every PR it opened, which silently mis-targeted every repository
+// whose default branch is not "main": the PR's diff then carries the entire
+// divergence between the two branches, and merging it lands the change on the
+// wrong branch (kubestellar/hive#4928).
+const FallbackDefaultBranch = "main"
+
+// DefaultBranch resolves the default branch of owner/repo from the repository's
+// own metadata (the `default_branch` REST field — the API behind
+// `gh repo view --json defaultBranchRef`), which the App's metadata:read
+// permission already covers.
+//
+// The result is cached for the life of the process: a repo's default branch
+// changes about as often as the repo is renamed, so caching keeps this off the
+// hot path of every PR open. Only successful lookups are cached — a transient
+// API error must not pin the repo to the fallback until the next restart.
+//
+// It never fails: an unresolvable repo falls back to FallbackDefaultBranch and
+// logs, because a base that is probably right beats refusing to open the PR at
+// all. Callers that need to distinguish "resolved" from "guessed" should call
+// GetRepo directly.
+func (c *Client) DefaultBranch(ctx context.Context, owner, repo string) string {
+	if c == nil || c.client == nil {
+		return FallbackDefaultBranch
+	}
+	owner, repo = strings.TrimSpace(owner), strings.TrimSpace(repo)
+	if owner == "" || repo == "" {
+		return FallbackDefaultBranch
+	}
+	key := owner + "/" + repo
+	if branch, ok := c.cachedDefaultBranch(key); ok {
+		return branch
+	}
+
+	r, _, err := c.client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Warn("DefaultBranch: lookup failed, falling back",
+				slog.String("repo", key),
+				slog.String("fallback", FallbackDefaultBranch),
+				slog.String("error", err.Error()))
+		}
+		return FallbackDefaultBranch
+	}
+	branch := strings.TrimSpace(r.GetDefaultBranch())
+	if branch == "" {
+		// A repo with no default_branch is not a thing GitHub returns for a
+		// live repo, but an empty string here would cache a base of "" and
+		// make every later PR open fail — treat it as unresolved.
+		return FallbackDefaultBranch
+	}
+	c.storeDefaultBranch(key, branch)
+	return branch
+}
+
+func (c *Client) cachedDefaultBranch(key string) (string, bool) {
+	c.defaultBranchMu.RLock()
+	defer c.defaultBranchMu.RUnlock()
+	branch, ok := c.defaultBranches[key]
+	return branch, ok
+}
+
+func (c *Client) storeDefaultBranch(key, branch string) {
+	c.defaultBranchMu.Lock()
+	defer c.defaultBranchMu.Unlock()
+	if c.defaultBranches == nil {
+		c.defaultBranches = map[string]string{}
+	}
+	c.defaultBranches[key] = branch
+}

--- a/src/pkg/github/defaultbranch_test.go
+++ b/src/pkg/github/defaultbranch_test.go
@@ -1,0 +1,106 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// repoMetadataServer serves GET /repos/{owner}/{repo} with the given
+// default_branch and counts how many times it was asked.
+func repoMetadataServer(t *testing.T, defaultBranch string, calls *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || !strings.HasSuffix(r.URL.Path, "/repos/org/repo") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		atomic.AddInt32(calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"name": "repo", "default_branch": defaultBranch})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDefaultBranch_ResolvesFromRepoMetadata(t *testing.T) {
+	var calls int32
+	srv := repoMetadataServer(t, "testing", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	if got := c.DefaultBranch(context.Background(), "org", "repo"); got != "testing" {
+		t.Fatalf("DefaultBranch = %q, want %q — the repo's own default branch, not an assumption", got, "testing")
+	}
+}
+
+func TestDefaultBranch_CachesResolvedBranch(t *testing.T) {
+	var calls int32
+	srv := repoMetadataServer(t, "develop", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	for i := 0; i < 3; i++ {
+		if got := c.DefaultBranch(context.Background(), "org", "repo"); got != "develop" {
+			t.Fatalf("lookup %d: DefaultBranch = %q, want develop", i, got)
+		}
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("repo metadata fetched %d times, want 1 — the resolved branch must be cached", n)
+	}
+}
+
+func TestDefaultBranch_FallsBackWhenLookupFails(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	if got := c.DefaultBranch(context.Background(), "org", "repo"); got != FallbackDefaultBranch {
+		t.Fatalf("DefaultBranch on API error = %q, want %q", got, FallbackDefaultBranch)
+	}
+	// A failed lookup must NOT be cached: a transient 5xx would otherwise pin
+	// this repo to the fallback base for the rest of the process.
+	_ = c.DefaultBranch(context.Background(), "org", "repo")
+	if n := atomic.LoadInt32(&calls); n != 2 {
+		t.Fatalf("repo metadata fetched %d times, want 2 — a failed lookup must not be cached", n)
+	}
+}
+
+func TestDefaultBranch_EmptyDefaultBranchFallsBack(t *testing.T) {
+	var calls int32
+	srv := repoMetadataServer(t, "", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	if got := c.DefaultBranch(context.Background(), "org", "repo"); got != FallbackDefaultBranch {
+		t.Fatalf("DefaultBranch with empty metadata = %q, want %q", got, FallbackDefaultBranch)
+	}
+}
+
+func TestDefaultBranch_NilAndEmptyInputs(t *testing.T) {
+	var nilClient *Client
+	if got := nilClient.DefaultBranch(context.Background(), "org", "repo"); got != FallbackDefaultBranch {
+		t.Fatalf("nil receiver: got %q, want %q", got, FallbackDefaultBranch)
+	}
+	if got := (&Client{}).DefaultBranch(context.Background(), "org", "repo"); got != FallbackDefaultBranch {
+		t.Fatalf("nil inner client: got %q, want %q", got, FallbackDefaultBranch)
+	}
+
+	var calls int32
+	srv := repoMetadataServer(t, "testing", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+	if got := c.DefaultBranch(context.Background(), "  ", "repo"); got != FallbackDefaultBranch {
+		t.Fatalf("blank owner: got %q, want %q", got, FallbackDefaultBranch)
+	}
+	if got := c.DefaultBranch(context.Background(), "org", ""); got != FallbackDefaultBranch {
+		t.Fatalf("blank repo: got %q, want %q", got, FallbackDefaultBranch)
+	}
+	if n := atomic.LoadInt32(&calls); n != 0 {
+		t.Fatalf("blank owner/repo issued %d API calls, want 0", n)
+	}
+}

--- a/src/pkg/github/hive_open_pr_script_test.go
+++ b/src/pkg/github/hive_open_pr_script_test.go
@@ -1,0 +1,111 @@
+package github
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// bin/hive-open-pr.sh is what agents run INSTEAD of `gh pr create`; it writes
+// the PRRequest this package's watcher consumes. It used to default BASE to
+// "main", which meant an agent that (correctly) said nothing about the base
+// still pinned every PR to "main" — so no amount of default-branch resolution
+// inside CreatePR could have helped: the request already carried the wrong
+// answer (kubestellar/hive#4928).
+//
+// These tests exercise the real script, following gh_app_token_script_test.go,
+// rather than a paraphrase of it.
+
+const hiveOpenPRScriptPath = "../../../bin/hive-open-pr.sh"
+
+// runHiveOpenPR executes the real script with its request dir redirected into a
+// temp root, and returns the single request it wrote.
+func runHiveOpenPR(t *testing.T, args ...string) PRRequest {
+	t.Helper()
+	src, err := os.ReadFile(hiveOpenPRScriptPath)
+	if err != nil {
+		t.Skipf("hive-open-pr.sh not readable from this package: %v", err)
+	}
+	for _, tool := range []string{"bash", "python3"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available: %v", tool, err)
+		}
+	}
+
+	root := t.TempDir()
+	reqDir := filepath.Join(root, "pr-requests")
+
+	// Point the hard-coded request dir at the temp root. If this literal ever
+	// stops matching, the test would silently write to the real /var/run path
+	// (or nowhere), so fail loudly instead.
+	text := string(src)
+	const reqDirLiteral = "/var/run/hive-metrics/pr-requests"
+	if !strings.Contains(text, reqDirLiteral) {
+		t.Fatalf("hive-open-pr.sh no longer references %s; this test would cover nothing", reqDirLiteral)
+	}
+	scriptPath := filepath.Join(root, "hive-open-pr.sh")
+	if err := os.WriteFile(scriptPath, []byte(strings.ReplaceAll(text, reqDirLiteral, reqDir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", append([]string{scriptPath}, args...)...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "HIVE_AGENT=scanner")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("hive-open-pr.sh %v: %v\n%s", args, err, out)
+	}
+
+	entries, err := filepath.Glob(filepath.Join(reqDir, "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("wrote %d request files, want 1: %v", len(entries), entries)
+	}
+	data, err := os.ReadFile(entries[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var req PRRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("request is not valid PRRequest JSON (%s): %v", data, err)
+	}
+	return req
+}
+
+func TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset(t *testing.T) {
+	req := runHiveOpenPR(t,
+		"--repo", "projectbluefin/dakota", "--head", "hive/fix-1",
+		"--title", "fix a thing", "--body", "body")
+
+	if req.Base != "" {
+		t.Fatalf("request pinned base %q; an omitted --base must stay empty so the hive "+
+			"resolves the repository's default branch", req.Base)
+	}
+	if req.Repo != "projectbluefin/dakota" || req.Head != "hive/fix-1" || req.Title != "fix a thing" {
+		t.Fatalf("request lost fields: %+v", req)
+	}
+}
+
+func TestHiveOpenPRScript_ExplicitBaseIsPreserved(t *testing.T) {
+	req := runHiveOpenPR(t,
+		"--repo", "projectbluefin/dakota", "--head", "hive/fix-1",
+		"--base", "release-1.2", "--title", "fix a thing", "--body", "body")
+
+	if req.Base != "release-1.2" {
+		t.Fatalf("request base = %q, want the explicitly requested release-1.2", req.Base)
+	}
+}
+
+func TestHiveOpenPRScript_ExplicitBaseEqualsFormIsPreserved(t *testing.T) {
+	req := runHiveOpenPR(t,
+		"--repo=projectbluefin/dakota", "--head=hive/fix-1",
+		"--base=release-1.2", "--title=fix a thing", "--body=body")
+
+	if req.Base != "release-1.2" {
+		t.Fatalf("request base = %q, want release-1.2", req.Base)
+	}
+}

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -37,8 +37,10 @@ func prRequestDir() string {
 var prRequestPollInterval = 10 * time.Second
 
 // PRRequest is the JSON an agent writes to PRRequestDir to ask the hive to open
-// a PR on its behalf. Repo may be "owner/repo" or a bare repo name; Base
-// defaults to "main".
+// a PR on its behalf. Repo may be "owner/repo" or a bare repo name. Base is
+// optional and normally omitted: an empty Base means "the target repository's
+// default branch", which CreatePR resolves from the repo's own metadata — set
+// it only to target a non-default branch on purpose (kubestellar/hive#4928).
 type PRRequest struct {
 	Repo   string `json:"repo"`
 	Head   string `json:"head"`

--- a/src/pkg/github/pullrequest.go
+++ b/src/pkg/github/pullrequest.go
@@ -32,7 +32,11 @@ type CreatePRResult struct {
 // `gh pr create` (which would attribute the PR to the Copilot login user).
 //
 // repo may be "owner/repo" or a bare repo name (owner defaults to the hive org).
-// head is the branch the agent pushed; base defaults to "main" when empty.
+// head is the branch the agent pushed; an empty base is RESOLVED from the target
+// repository's own default branch (see DefaultBranch) rather than assumed to be
+// "main" — a repo whose default is "testing" or "develop" would otherwise get
+// every PR based on the wrong branch, carrying the full divergence between the
+// two branches in its diff (kubestellar/hive#4928).
 //
 // It is idempotent: if an OPEN PR for head already exists, it returns that PR
 // with AlreadyExisted=true instead of erroring or opening a duplicate — this
@@ -50,7 +54,7 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 		return CreatePRResult{}, fmt.Errorf("CreatePR: head branch is required")
 	}
 	if base = strings.TrimSpace(base); base == "" {
-		base = "main"
+		base = c.DefaultBranch(ctx, owner, repo)
 	}
 	if strings.TrimSpace(title) == "" {
 		return CreatePRResult{}, fmt.Errorf("CreatePR: title is required")

--- a/src/pkg/github/pullrequest_base_test.go
+++ b/src/pkg/github/pullrequest_base_test.go
@@ -1,0 +1,136 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Regression tests for kubestellar/hive#4928: CreatePR hardcoded base="main"
+// when the caller did not pin one, so every PR the hive opened on a repository
+// whose default branch is not "main" was based on the wrong branch. The diff
+// then carried the whole divergence between the two branches (one reported PR
+// showed 233 files / ~260k lines for a one-file change), and merging it landed
+// the change on a branch nobody meant to touch.
+
+// prBaseCapture is a fake GitHub that answers the three calls CreatePR can make
+// — repo metadata, the dedupe lookup, and the create — and records the base the
+// create actually asked for.
+type prBaseCapture struct {
+	defaultBranch string
+	repoStatus    int // non-zero to fail the metadata lookup
+	repoCalls     int32
+	gotBase       string
+}
+
+func (p *prBaseCapture) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/org/repo"):
+			atomic.AddInt32(&p.repoCalls, 1)
+			if p.repoStatus != 0 {
+				w.WriteHeader(p.repoStatus)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "repo", "default_branch": p.defaultBranch})
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]any{}) // no existing PR for this head
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			p.gotBase = body["base"]
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number": 7, "html_url": "https://github.com/org/repo/pull/7",
+				"user": map[string]any{"login": "hive[bot]"},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestCreatePR_EmptyBaseTargetsRepoDefaultBranch(t *testing.T) {
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "org/repo", "feature", "", "title", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if res.Number != 7 {
+		t.Fatalf("Number = %d, want 7", res.Number)
+	}
+	if fake.gotBase != "testing" {
+		t.Fatalf("PR opened with base %q, want %q — the repository's default branch, not an assumed 'main'", fake.gotBase, "testing")
+	}
+}
+
+func TestCreatePR_WhitespaceBaseTargetsRepoDefaultBranch(t *testing.T) {
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	if _, err := c.CreatePR(context.Background(), "org/repo", "feature", "   ", "title", "body"); err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if fake.gotBase != "testing" {
+		t.Fatalf("PR opened with base %q, want %q", fake.gotBase, "testing")
+	}
+}
+
+func TestCreatePR_ExplicitBaseIsNotOverridden(t *testing.T) {
+	// A caller that deliberately targets a release line (or a stacked PR's
+	// parent) must keep that base, and must not pay for a metadata lookup.
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	if _, err := c.CreatePR(context.Background(), "org/repo", "feature", "release-1.2", "title", "body"); err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if fake.gotBase != "release-1.2" {
+		t.Fatalf("PR opened with base %q, want the explicitly requested release-1.2", fake.gotBase)
+	}
+	if n := atomic.LoadInt32(&fake.repoCalls); n != 0 {
+		t.Fatalf("explicit base still issued %d default-branch lookups, want 0", n)
+	}
+}
+
+func TestCreatePR_EmptyBaseFallsBackWhenLookupFails(t *testing.T) {
+	// Metadata unreachable: opening against the fallback still beats not
+	// opening the PR at all, so the failure must degrade rather than error.
+	fake := &prBaseCapture{repoStatus: http.StatusInternalServerError}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	if _, err := c.CreatePR(context.Background(), "org/repo", "feature", "", "title", "body"); err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if fake.gotBase != FallbackDefaultBranch {
+		t.Fatalf("PR opened with base %q, want fallback %q", fake.gotBase, FallbackDefaultBranch)
+	}
+}
+
+func TestCreatePR_DefaultBranchResolvedOncePerRepo(t *testing.T) {
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	for _, head := range []string{"feature-a", "feature-b", "feature-c"} {
+		if _, err := c.CreatePR(context.Background(), "org/repo", head, "", "title", "body"); err != nil {
+			t.Fatalf("CreatePR %s: %v", head, err)
+		}
+		if fake.gotBase != "testing" {
+			t.Fatalf("head %s opened with base %q, want testing", head, fake.gotBase)
+		}
+	}
+	if n := atomic.LoadInt32(&fake.repoCalls); n != 1 {
+		t.Fatalf("default branch resolved %d times across 3 PR opens, want 1", n)
+	}
+}


### PR DESCRIPTION
## Summary

- **What this touches.** Hive opens pull requests on other people's repositories on behalf of its agents. Every PR needs a *base* — the branch the change is proposed onto. Hive was not asking what that branch should be; it assumed `main`.
- **What went wrong.** On a repository whose default branch is not `main`, the PR got opened against a branch the work was never based on. On [projectbluefin/dakota](https://github.com/projectbluefin/dakota) (default: `testing`), a one-file change showed up as **233 changed files and ~260,000 changed lines** — the entire divergence between the two branches — large enough that GitHub's diff API refused to render it. Worse than the noise: a maintainer who did not notice the base would have merged the change onto the wrong branch.
- **The fix.** Ask the repository what its default branch actually is, in all three places that were assuming. A base the caller explicitly asked for is still honoured and never overridden; if the lookup fails, it falls back to `main` and logs a warning rather than refusing to open the PR.
- **Blast radius.** Changes the base branch of every PR hive opens from here on. Costs one extra GitHub API call per repository — cached, so not per PR — using a permission the App already holds. Already-open PRs are not retargeted.

## What this fixes

Every PR the hive opened was based on `main` whether or not that was the target repository's default branch. On [projectbluefin/dakota](https://github.com/projectbluefin/dakota), whose default is `testing`, that meant the PR's diff carried the entire divergence between the two branches — dakota#1411 showed 233 changed files and ~260k changed lines for a one-file change, large enough that GitHub's diff API refused to serve it — and a maintainer who missed the base would have merged the change onto the wrong branch.

The reporter's read was right: it is a hardcoded assumption, not an intermittent resolution failure.

## Why three changes and not one

The assumption lived in three places, and fixing only `CreatePR` would have accomplished nothing on the hosted path — `hive-open-pr` pinned `base: "main"` into the request file before `CreatePR` ever ran, so the wrong answer was already baked in.

| Where | Before | After |
| --- | --- | --- |
| `github.Client.CreatePR` | `base = "main"` when the caller passed none | resolves the repo's `default_branch` |
| `bin/hive-open-pr.sh` | `BASE="main"` — sent on every request, even when the agent said nothing | omitted `--base` stays empty, so the hive resolves it |
| `agent.SandboxExecutor` | cloned and PR'd against `defaultSandboxBaseRef = "main"` | reads the clone's own `refs/remotes/origin/HEAD` |

New `Client.DefaultBranch` reads the repository's own `default_branch` field — the REST API behind `gh repo view --json defaultBranchRef`, already covered by the App's metadata:read permission, exactly as the issue suggests. It is cached per repo, so this is one extra API call per repository rather than one per PR. Only *successful* lookups are cached: a transient 5xx must not pin a repo to the fallback for the life of the process.

The sandbox path needs the base *before* the PR — it branches from it — so it does not use the API at all. `git clone` already records the remote's HEAD in `refs/remotes/origin/HEAD`, so the answer is on disk: no API call, no extra token scope.

## Behavior preserved

- **An explicit base is never overridden.** Targeting a release line or stacking a PR still works, and issues no default-branch lookup.
- **Unresolvable repos degrade rather than fail.** If the metadata call errors or the clone has no `origin/HEAD`, the base falls back to `main` and logs a warning. A base that is probably right beats refusing to open the PR.

## Tests

Each of the three paths has a test that fails on the parent commit, verified by reverting each fix individually:

```
--- FAIL: TestCreatePR_EmptyBaseTargetsRepoDefaultBranch
    PR opened with base "main", want "testing" — the repository's default branch, not an assumed 'main'
--- FAIL: TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset
    request pinned base "main"; an omitted --base must stay empty so the hive resolves the repository's default branch
--- FAIL: TestSandboxExecutorBranchesFromRepoDefaultBranch
    fetched "main", want testing — the clone's own default branch
```

Alongside those: explicit-base-is-honored (and issues no lookup), fallback-on-API-error, the failed lookup not being cached, and one-lookup-per-repo across three PR opens. The `hive-open-pr.sh` test runs the **real script** with its request dir redirected into a temp root and parses the result back into `PRRequest`, following the precedent in `gh_app_token_script_test.go`; it fails loudly if the script stops referencing the request-dir literal it patches, so it can't silently cover nothing.

```
ok  github.com/kubestellar/hive/pkg/github  44.239s
ok  github.com/kubestellar/hive/pkg/agent   255.137s
```

`go build ./...`, `go vet ./pkg/github/... ./pkg/agent/...`, and `gofmt` are clean on the touched files. Two tests in `pkg/agent` (`TestSendKick_RestartsCrashedCLIThenDelivers`, `TestRestartThenSendKick_CleanSlateThenDelivers`) failed intermittently in this environment; I confirmed they fail the same way on the unmodified parent commit and pass on a rerun, so they are unrelated to this change.

## Note for the reporter

@ahmedadan — this does not retarget the seven PRs already open on dakota; those still need the manual retarget you have been doing. It changes what the App files from here on. You offered to test a fix from your side, which would be the real confirmation: after this lands, a fresh PR on dakota should come in with `baseRefName: testing` without anyone touching it.

Fixes #4928

— hive: backend=claude model=claude-fable-5

