### PR TITLE
🔒 fix(agent): deny host-state commands on the unconfined claude launch path

### DIFF
--- a/bin/contributor-agent.test.sh
+++ b/bin/contributor-agent.test.sh
@@ -445,4 +445,127 @@ if output="$(
   exit 1
 fi
 
-echo "contributor-agent codex contract tests passed"
+# ── claude host-state denials (#4918) ───────────────────────────────────
+#
+# The claude family runs permissions-bypassed on the operator's own host. #4918
+# is what that cost: an agent running an assigned repo's test suite issued
+# `rpm-ostree kargs --append-if-missing=...` against the operator's real
+# deployment, and was stopped only by lacking privilege. These cases pin the
+# denials that now sit on that path.
+
+claude_flags_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/workspace" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=claude \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+# The bypass flags stay — an unattended agent that stops to ask permission just
+# hangs — but the host-state denials ride alongside them.
+case "$claude_flags_output" in
+  *"backend_perm_flag=--dangerously-skip-permissions --permission-mode bypassPermissions --disallowed-tools "* ) ;;
+  *)
+    echo "expected claude to carry host-state denials by default; got:" >&2
+    echo "$claude_flags_output" >&2
+    exit 1
+    ;;
+esac
+# The command from the incident specifically.
+case "$claude_flags_output" in
+  *"Bash(rpm-ostree:*)"* ) ;;
+  *)
+    echo "expected claude denials to cover rpm-ostree, the command in #4918; got:" >&2
+    echo "$claude_flags_output" >&2
+    exit 1
+    ;;
+esac
+# rpm-ostree reached polkit without sudo, so escalation denials alone are not
+# the fix — but they must be there too, or `sudo rpm-ostree` walks around it.
+case "$claude_flags_output" in
+  *"Bash(sudo:*)"*"Bash(pkexec:*)"* ) ;;
+  *)
+    echo "expected claude denials to cover privilege escalation; got:" >&2
+    echo "$claude_flags_output" >&2
+    exit 1
+    ;;
+esac
+
+# THE WORD-SPLIT CONTRACT. agent-launch.sh does `read -r -a PERM_ARGS <<< "$PERM_FLAG"`,
+# so the pattern list must be ONE argv word. A space anywhere in it would arrive
+# as separate arguments and silently deny nothing — flag present, policy absent.
+claude_perm_line="$(printf '%s\n' "$claude_flags_output" | grep '^backend_perm_flag=' | head -1)"
+claude_perm_value="${claude_perm_line#backend_perm_flag=}"
+read -r -a claude_perm_args <<< "$claude_perm_value"
+if [[ "${#claude_perm_args[@]}" -ne 5 ]]; then
+  echo "expected claude perm flags to word-split into exactly 5 argv words; got ${#claude_perm_args[@]}:" >&2
+  printf '  [%s]\n' "${claude_perm_args[@]}" >&2
+  exit 1
+fi
+case "${claude_perm_args[4]}" in
+  *"Bash(rpm-ostree:*)"*"Bash(efibootmgr:*)"* ) ;;
+  *)
+    echo "expected the whole deny list to survive word-splitting as one argv word; got:" >&2
+    echo "  ${claude_perm_args[4]}" >&2
+    exit 1
+    ;;
+esac
+
+# litellm launches the claude binary, so it must be confined identically.
+# HIVE_LITELLM_ENDPOINT is required for this backend to resolve at all — without
+# it contributor-agent.sh errors out before it ever prints a flag string.
+litellm_flags_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_LITELLM_ENDPOINT="https://litellm.test:4000" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/workspace" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=litellm \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+case "$litellm_flags_output" in
+  *"Bash(rpm-ostree:*)"* ) ;;
+  *)
+    echo "expected litellm (which launches the claude binary) to carry the same denials; got:" >&2
+    echo "$litellm_flags_output" >&2
+    exit 1
+    ;;
+esac
+
+# The opt-out restores the pre-#4918 posture, and must drop the denials
+# entirely rather than leaving a dangling --disallowed-tools with no argument.
+claude_bypass_output="$(
+  env -i \
+    PATH="${PATH}" \
+    HOME="$HOME_DIR" \
+    HIVE_REGISTRATION_TOKEN="test-token" \
+    HIVE_ENTRYPOINT_HOOK_DIR="${WORK_DIR}/empty-entrypoint.d" \
+    HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1 \
+    HIVE_WORKSPACE_DIR="${WORK_DIR}/workspace" \
+    HIVE_CONTRIBUTOR_AGENT_TEST_RESOLVE_BACKEND=1 \
+    AGENT_BACKEND=claude \
+    bash "${ROOT_DIR}/bin/contributor-agent.sh"
+)"
+case "$claude_bypass_output" in
+  *"backend_perm_flag=--dangerously-skip-permissions --permission-mode bypassPermissions"* ) ;;
+  *)
+    echo "expected the claude opt-out to restore the plain bypass posture; got:" >&2
+    echo "$claude_bypass_output" >&2
+    exit 1
+    ;;
+esac
+case "$claude_bypass_output" in
+  *"--disallowed-tools"* )
+    echo "claude opt-out must drop --disallowed-tools entirely; got:" >&2
+    echo "$claude_bypass_output" >&2
+    exit 1
+    ;;
+esac
+
+echo "contributor-agent codex + claude contract tests passed"

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -40,10 +40,65 @@ backend_binary() {
   esac
 }
 
+# ── Host-state denials for the claude family ────────────────────────────
+#
+# The claude CLI runs with permissions fully bypassed, as the operator's own
+# user, directly on the operator's host: the tmux launch path has no container
+# and no workspace confinement. That is deliberate for the WORKSPACE — an
+# unattended agent that stops to ask permission just hangs, which is the failure
+# the codex block below also exists to avoid — but it left nothing at all
+# between an agent and the machine hive runs on.
+#
+# #4918 is what that costs. An agent doing correct work on an assigned
+# third-party repo ran that repo's own test suite; a latent defect in two of its
+# tests let a hook escape its stubs and call
+# `rpm-ostree kargs --append-if-missing=...` against the operator's REAL
+# deployment. Three polkit dialogs on the operator's desktop. Nothing was
+# written, and the only reason is that the process happened to lack privilege.
+#
+# NOTE WHAT WOULD NOT HAVE HELPED: rpm-ostree never invoked sudo. It asked
+# polkit directly. So denying escalation alone does not close this — the
+# host-state tools that reach polkit on their own have to be named.
+#
+# DENY, NOT ASK. These are --disallowed-tools entries, so a match is refused
+# outright and the agent moves on. A permission MODE change would instead make
+# the CLI prompt, and nobody is attached to an unattended pane to answer it.
+# Verified against Claude Code 2.1.231 that a deny still applies under
+# `--dangerously-skip-permissions --permission-mode bypassPermissions` (it does;
+# this is the same mechanism claudeGitHubWriteDenyFlags in
+# src/pkg/agent/manager.go already relies on) and that matching is
+# command-token-aware, so `su` does not also block `subl`.
+#
+# The list is deliberately minimal: privilege escalation, and the host
+# boot/deployment tools that need no escalation to do damage. It is NOT an
+# attempt to sandbox the host — that is the podman path (src/pkg/sandbox), and
+# #4918 tracks the separate question of why that path is double-gated off by
+# default. This is the floor, not the ceiling.
+#
+# ONE ARGV WORD, COMMA-SEPARATED. The caller word-splits this function's output
+# (agent-launch.sh: `read -r -a PERM_ARGS <<< "$PERM_FLAG"`), so the patterns
+# cannot be space-separated the way `claude --help` shows them — they would
+# arrive as separate argv words and silently deny nothing.
+CLAUDE_HOST_DENY_TOOLS='Bash(sudo:*),Bash(pkexec:*),Bash(doas:*),Bash(su:*),Bash(rpm-ostree:*),Bash(bootc:*),Bash(ostree:*),Bash(grubby:*),Bash(bootctl:*),Bash(efibootmgr:*)'
+
+# claude_family_perm_flag emits the permission flags for every backend that
+# launches the claude binary (claude, litellm).
+claude_family_perm_flag() {
+  local base="--dangerously-skip-permissions --permission-mode bypassPermissions"
+  # ESCAPE HATCH, named after the codex one so the two read alike. An operator
+  # who genuinely wants an agent to manage host state — the hive spoke upgrading
+  # its own host, say — sets this and gets the pre-#4918 posture back.
+  if is_truthy "${HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE:-}"; then
+    echo "$base"
+  else
+    echo "$base --disallowed-tools ${CLAUDE_HOST_DENY_TOOLS}"
+  fi
+}
+
 # ── Backend → permission flag ───────────────────────────────────────────
 backend_perm_flag() {
   case "$1" in
-    claude)  echo "--dangerously-skip-permissions --permission-mode bypassPermissions" ;;
+    claude)  claude_family_perm_flag ;;
     copilot) echo "--allow-all" ;;
     # bob (IBM bobshell). Mirrors the hub-side launcher (bobLaunchCmd in
     # src/pkg/agent/manager.go) so relay and pod agents behave identically:
@@ -131,7 +186,7 @@ backend_perm_flag() {
     pi)      echo "" ;;
     aider)   echo "--yes" ;;
     # Same flags as claude — litellm launches the claude binary
-    litellm) echo "--dangerously-skip-permissions --permission-mode bypassPermissions" ;;
+    litellm) claude_family_perm_flag ;;
     *)       echo "" ;;
   esac
 }

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -6,7 +6,7 @@ Hive validates backend names in `src/pkg/config` and launches CLIs in `src/pkg/a
 
 | Backend | Binary launched by the Go manager | Auth / setup | Notes |
 | --- | --- | --- | --- |
-| `claude` | `claude` | Install Claude Code and log in once. Hive launches with `--dangerously-skip-permissions`; inference routes add `--bare --settings`. | Advisory/issue modes add disallowed GitHub MCP tools. |
+| `claude` | `claude` | Install Claude Code and log in once. Hive launches with `--dangerously-skip-permissions`; inference routes add `--bare --settings`. | Advisory/issue modes add disallowed GitHub MCP tools. Every mode also denies host-state commands — privilege escalation (`sudo`/`pkexec`/`doas`/`su`) and boot/deployment tools (`rpm-ostree`/`bootc`/`ostree`/`grubby`/`bootctl`/`efibootmgr`) — because the tmux path runs unconfined on the operator's host (#4918). Set `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1` only when you intentionally want an agent to manage host state. |
 | `copilot` | `copilot` | Install GitHub Copilot CLI and authenticate with GitHub. Hive also probes Copilot model entitlements live. | Launched with `--no-auto-update --allow-all`; write tools are denied by mode when needed. |
 | `gemini` | `gemini` | Install Gemini CLI and configure its normal auth/API key. | Supported by the server-side manager; Hive launches `gemini` and passes `--model` when a model is configured. |
 | `goose` | `goose` | Install Block Goose and configure provider/model (`GOOSE_PROVIDER`, `GOOSE_MODEL`, or `goose configure`). | Hive launches `goose run -s` and appends `--model` when set. |

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -113,6 +113,15 @@ this, omits `--add-dir`, and warns on stderr rather than corrupting the argv;
 the sandbox posture still applies, but the workspace is not granted. Move the
 workspace to a path without spaces.
 
+Claude-family host-state denials: `claude` and `litellm` run permissions-bypassed
+on the contributor's own machine, so hive denies privilege escalation
+(`sudo`, `pkexec`, `doas`, `su`) and host boot/deployment tools (`rpm-ostree`,
+`bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`) on that path — an agent
+running an assigned repo's test suite reached a contributor's bootloader
+otherwise (#4918). Repo work is unaffected. `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1`
+restores the old posture and is the claude analogue of the Codex bypass below;
+prefer leaving it unset.
+
 Codex config-key compatibility: `approvals_reviewer` is passed with `-c`, so it
 depends on the installed Codex release accepting that key. If a version rejects
 it at startup, set `HIVE_CODEX_APPROVALS_REVIEWER=` (empty) to drop the key

--- a/src/docs/sandbox-isolation.md
+++ b/src/docs/sandbox-isolation.md
@@ -2,7 +2,16 @@
 
 ## Threat model
 
-Hive agents are untrusted code executors: prompts, tool output, and cloned repositories can all contain hostile instructions. The safe target is therefore **no credentials in the agent sandbox** and a network policy that is as close to default-deny as the configured inference runtime allows. If an agent is compromised, it can only modify its mounted workspace; it cannot receive GitHub tokens or push directly.
+Hive agents are untrusted code executors: prompts, tool output, and cloned repositories can all contain hostile instructions. The safe target is therefore **no credentials in the agent sandbox** and a network policy that is as close to default-deny as the configured inference runtime allows.
+
+Two halves of that target hold differently, and the difference matters:
+
+- **Credentials and pushes are constrained on every path.** No agent receives a GitHub token or pushes directly; authorship goes through the App-gated `gh` wrapper and the push broker.
+- **Workspace confinement holds only on the sandbox path below.** "It can only modify its mounted workspace" is a property of the Podman sandbox, not of hive generally. On the default tmux path there is no container: the backend CLI runs as the operator's own user, on the operator's own host, with nothing scoping its filesystem access to the workspace.
+
+**#4918 is what that costs in practice, and it did not require a compromise.** An agent doing correct work on an assigned third-party repo ran that repo's own test suite; a latent defect in two of its tests let a hook escape its stubs and issue `rpm-ostree kargs --append-if-missing=...` against the operator's real deployment. Nothing was written, and the only reason is that the process happened to lack privilege. Benign behaviour was a sufficient precondition, so this is a routine exposure rather than an exceptional one.
+
+The claude-family launch path now carries host-state denials for exactly this class — privilege escalation (`sudo`, `pkexec`, `doas`, `su`) and the boot/deployment tools that reach polkit without needing escalation of their own (`rpm-ostree`, `bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`), matching the workspace-write posture Codex has had since #3512. That is a floor, not a sandbox: it names commands rather than enforcing a boundary, and an agent still runs unconfined against everything not on the list. **Operators running hive on a machine they care about should enable the sandbox below.**
 
 ## Current wiring
 

--- a/src/pkg/agent/host_state_deny_test.go
+++ b/src/pkg/agent/host_state_deny_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// backendsConfPath is the shell half of this policy. Both launch paths must
+// deny the same commands; a test that only checked the Go side would let them
+// drift, and the drift is invisible until an agent on the other path reaches
+// something this one blocks.
+const backendsConfPath = "../../../config/backends.conf"
+
+// TestHostStateDenyBlocksTheReportedCommand pins the specific failure #4918
+// reported: `rpm-ostree kargs` against the operator's real deployment.
+func TestHostStateDenyBlocksTheReportedCommand(t *testing.T) {
+	flags := claudeHostStateDenyFlags()
+	if !strings.Contains(flags, "Bash(rpm-ostree:*)") {
+		t.Fatalf("host-state denials do not cover rpm-ostree, the command in #4918: %q", flags)
+	}
+	if !strings.HasPrefix(flags, " --disallowed-tools ") {
+		t.Fatalf("flags = %q, want a --disallowed-tools fragment", flags)
+	}
+}
+
+// TestHostStateDenyCoversEscalationAndBootState pins the two families the list
+// is built from. rpm-ostree asked polkit directly rather than shelling out to
+// sudo, so escalation alone would not have stopped #4918 — both halves have to
+// be present for the list to mean what its comment says.
+func TestHostStateDenyCoversEscalationAndBootState(t *testing.T) {
+	for _, want := range []string{
+		"Bash(sudo:*)", "Bash(pkexec:*)", "Bash(doas:*)", "Bash(su:*)",
+		"Bash(rpm-ostree:*)", "Bash(bootc:*)", "Bash(ostree:*)",
+		"Bash(grubby:*)", "Bash(bootctl:*)", "Bash(efibootmgr:*)",
+	} {
+		if !strings.Contains(claudeHostStateDenyTools, want) {
+			t.Errorf("host-state deny list is missing %s", want)
+		}
+	}
+}
+
+// TestHostStateDenyIsOneArgvWord guards the constraint that makes this work at
+// all. The shell path word-splits its flag string, so a space anywhere in the
+// pattern list would arrive as separate argv words and silently deny nothing —
+// the failure mode where the flag is present and the policy is absent.
+func TestHostStateDenyIsOneArgvWord(t *testing.T) {
+	if strings.ContainsAny(claudeHostStateDenyTools, " \t\n") {
+		t.Fatalf("deny list contains whitespace and would be word-split: %q", claudeHostStateDenyTools)
+	}
+}
+
+// TestHostStateDenyOptOut covers the escape hatch, including that it accepts
+// exactly the spellings the shell's is_truthy accepts.
+func TestHostStateDenyOptOut(t *testing.T) {
+	for _, on := range []string{"1", "true", "TRUE", "yes", "YES", "on", "ON"} {
+		t.Setenv(hostStateBypassEnv, on)
+		if got := claudeHostStateDenyFlags(); got != "" {
+			t.Errorf("%s=%q still emitted denials: %q", hostStateBypassEnv, on, got)
+		}
+	}
+	// Anything else keeps the denials. "false" and "0" matter most: an operator
+	// who writes them means "leave the protection on", and reading them as
+	// "set, therefore truthy" would invert the flag.
+	for _, off := range []string{"", "0", "false", "no", "off", "maybe"} {
+		t.Setenv(hostStateBypassEnv, off)
+		if got := claudeHostStateDenyFlags(); got == "" {
+			t.Errorf("%s=%q dropped the denials; only truthy values may", hostStateBypassEnv, off)
+		}
+	}
+}
+
+// TestGitHubWriteDenialsSurvive: the host-state denials are appended alongside
+// the GitHub MCP write denials, not in place of them.
+func TestGitHubWriteDenialsSurvive(t *testing.T) {
+	combined := claudeGitHubWriteDenyFlags + claudeHostStateDenyFlags()
+	if !strings.Contains(combined, "mcp__github__create_pull_request") {
+		t.Error("GitHub MCP write denials were lost")
+	}
+	if !strings.Contains(combined, "Bash(rpm-ostree:*)") {
+		t.Error("host-state denials were lost")
+	}
+}
+
+// TestShellAndGoDenyListsAgree is the parity check. config/backends.conf is the
+// relay path and this package is the pod path; an agent must be confined the
+// same way whichever launched it.
+func TestShellAndGoDenyListsAgree(t *testing.T) {
+	if _, err := os.Stat(backendsConfPath); err != nil {
+		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+	}
+	out, err := exec.Command("bash", "-c",
+		"source "+backendsConfPath+" && printf '%s' \"$CLAUDE_HOST_DENY_TOOLS\"").Output()
+	if err != nil {
+		t.Fatalf("sourcing backends.conf: %v", err)
+	}
+	if got := string(out); got != claudeHostStateDenyTools {
+		t.Fatalf("shell and Go deny lists have drifted:\n shell: %s\n    go: %s", got, claudeHostStateDenyTools)
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2564,7 +2564,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			// Deny ALL GitHub MCP write tools in EVERY mode: agents author via the
 			// App-gated gh wrapper, never as the user via the MCP. Mode governs the
 			// gh-wrapper/proxy layer only, not what the MCP may write.
-			launchCmd = base + claudeGitHubWriteDenyFlags
+			launchCmd = base + claudeGitHubWriteDenyFlags + claudeHostStateDenyFlags()
 		case "copilot":
 			// model arrives here already canonicalized by normalizeModelName
 			// (CanonicalizeCopilotModel: separator drift like claude-fable.5 is
@@ -7260,6 +7260,67 @@ const claudeGitHubWriteDenyFlags = " --disallowed-tools 'mcp__github__create_pul
 	" --disallowed-tools 'mcp__github__create_issue'" +
 	" --disallowed-tools 'mcp__github__update_issue'" +
 	" --disallowed-tools 'mcp__github__add_issue_comment'"
+
+// claudeHostStateDenyTools names the commands an agent editing a repo workspace
+// never needs and that reach the operator's own machine. It mirrors
+// CLAUDE_HOST_DENY_TOOLS in config/backends.conf so a pod agent and a relay
+// agent are confined identically — the same relay/pod parity bobLaunchCmd below
+// is written for.
+//
+// #4918: an agent doing correct work on an assigned third-party repo ran that
+// repo's test suite, a hook escaped its stubs, and `rpm-ostree kargs
+// --append-if-missing=...` was issued against the operator's real deployment.
+// It failed only because the process lacked privilege.
+//
+// rpm-ostree never invoked sudo — it asked polkit directly — so denying
+// escalation alone would not have stopped it. The host-state tools that reach
+// polkit on their own have to be named too.
+//
+// Comma-separated in ONE argv word: the shell path word-splits its flag string
+// (bin/agent-launch.sh), and keeping both paths on the identical spelling is
+// what makes them auditable as one policy.
+var claudeHostStateDenyTools = strings.Join([]string{
+	// Privilege escalation.
+	"Bash(sudo:*)", "Bash(pkexec:*)", "Bash(doas:*)", "Bash(su:*)",
+	// Host boot/deployment state — these need no escalation of their own.
+	"Bash(rpm-ostree:*)", "Bash(bootc:*)", "Bash(ostree:*)",
+	"Bash(grubby:*)", "Bash(bootctl:*)", "Bash(efibootmgr:*)",
+}, ",")
+
+// hostStateBypassEnv is the opt-out, named to match Codex's
+// HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX so the two read alike. An
+// operator who genuinely wants an agent to manage host state sets it and gets
+// the pre-#4918 posture back.
+const hostStateBypassEnv = "HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE"
+
+// claudeHostStateDenyFlags returns the --disallowed-tools fragment, or "" when
+// the operator has explicitly opted out.
+//
+// These are DENIALS, not a permission mode: a match is refused and the agent
+// carries on. Switching the mode instead would make the CLI prompt, and nobody
+// is attached to an unattended pane to answer it. Denials still apply under
+// --dangerously-skip-permissions, which is the same property
+// claudeGitHubWriteDenyFlags above already depends on.
+func claudeHostStateDenyFlags() string {
+	if hostStateBypassRequested(os.Getenv(hostStateBypassEnv)) {
+		return ""
+	}
+	return " --disallowed-tools '" + claudeHostStateDenyTools + "'"
+}
+
+// hostStateBypassRequested mirrors is_truthy() in config/backends.conf exactly.
+// The two launch paths must agree on what "on" means, or an operator who sets
+// the opt-out to "yes" gets a confined relay agent and an unconfined pod agent
+// from the same configuration — the worst outcome, because it looks like it
+// worked.
+func hostStateBypassRequested(value string) bool {
+	switch value {
+	case "1", "true", "TRUE", "yes", "YES", "on", "ON":
+		return true
+	default:
+		return false
+	}
+}
 
 // bobLaunchCmd builds bob's interactive launch command.
 //


### PR DESCRIPTION
> [!NOTE]
> **This PR restores #4922, which was closed by accident.**
>
> The `Danathar/hive` fork was deleted and re-forked on 2026-08-28. Deleting a
> fork auto-closes every open PR submitted from it, so #4922 was swept up as a
> side effect of unrelated housekeeping. **It was not closed on the merits, and
> no review feedback prompted it.**
>
> #4922 cannot simply be reopened: a re-fork is a new repository, so the old PR
> still points at a deleted one (`head.repo` is `null`) and GitHub refuses the
> state change with *"the repository that submitted this pull request has been
> deleted"*. Reopening it is permanently impossible, hence a new number.
>
> The head commit is byte-identical to what #4922 carried (`0a5a6a3f`, recovered
> from `refs/pull/4922/head`), on the same branch and the same `v4` base. Nothing
> about the change itself has been revised.

---

## Summary

- **What happened.** An agent doing entirely correct work reached the operator's bootloader. It was assigned a third-party repo, cloned it, and ran that project's own test suite — an ordinary step for the task. A latent defect in two of those tests let a command escape its stubs, and `rpm-ostree kargs --append-if-missing=...` ran against the operator's **real OS deployment**, raising three authentication dialogs on their desktop. Nothing was written, and the only reason is that the process happened to lack privilege. No compromise was involved: legitimate repo, correct agent behaviour, command came from that project's own tests.
- **Why it was possible.** Hive's default agent backend launches with permission checks bypassed, as the operator's own user, on the operator's own host, with nothing scoping it to the workspace. The other backend, codex, has run confined since #3512; the default one never got the equivalent floor.
- **The fix.** A deny-list on that launch path covering two families — privilege escalation (`sudo`, `pkexec`, `doas`, `su`) and host boot/deployment state (`rpm-ostree`, `bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`). The second family is the one that matters and is easy to miss: **`rpm-ostree` never invoked `sudo`** — it asked polkit directly — so a list covering only escalation would not have stopped the reported incident at all.
- **Denials rather than a stricter permission mode**, because a stricter mode makes the CLI *prompt*, and nobody is attached to an unattended agent pane to answer it. A denial refuses the call outright and the agent moves on.
- **Blast radius.** Agents can no longer run those commands, on either launch path. Opt-out is `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1`. This is a **floor, not a sandbox** — it names commands, it does not enforce a boundary; the docs are corrected below where they overstated that. The broader sandbox-by-default question #4918 also raises is deliberately left for its own PR.

Closes the gap #4918 reports, on the path people are actually on today.

## What happened, restated

An agent doing entirely correct work reached the operator's bootloader. It was assigned a third-party repo, cloned it, and ran that repo's own unit suite — an ordinary step for the task. A latent defect in two of those tests let a hook escape its stubs, so `rpm-ostree kargs --append-if-missing=usbcore.autosuspend=-1` ran against the operator's **real** deployment, raising three polkit dialogs on their desktop. Nothing was written, and the only reason is that the process happened to lack privilege.

No compromise was involved. The repo was legitimate, the agent behaved correctly, and the command came from that project's own test suite.

## The fix

The claude family (`claude`, `litellm`) launches permissions-bypassed, as the operator's user, on the operator's host, with nothing scoping it to the workspace. Hive already knows the right posture — codex has run `--sandbox workspace-write` by default since #3512, and the comment there is backend-agnostic:

> Hive-delivered work is unattended even in the tmux-backed mode: no operator is guaranteed to be watching the pane

This applies the equivalent floor to the default backend.

**Denials, not a permission mode.** Switching claude's mode would make the CLI *prompt*, and nobody is attached to an unattended pane to answer — the exact hang that codex comment warns about. `--disallowed-tools` refuses the call outright and the agent moves on, so the bypass flags stay and the denials ride alongside them.

**What is denied, and why those two families:**

| Family | Commands |
|---|---|
| Privilege escalation | `sudo`, `pkexec`, `doas`, `su` |
| Host boot/deployment state | `rpm-ostree`, `bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr` |

The second family is the one that matters and is easy to miss. **`rpm-ostree` never invoked `sudo` — it asked polkit directly**, so a list covering only escalation would not have stopped the reported incident at all.

The list is deliberately minimal, and it is a floor, not a sandbox: it names commands rather than enforcing a boundary. Package managers are left off because the ones needing root are already neutered by the `sudo` denial, and denying them outright would break legitimate agent work.

## Verified against the real CLI, not assumed

Claude Code 2.1.231, before writing any of it:

| Check | Result |
|---|---|
| Does a deny survive `--dangerously-skip-permissions --permission-mode bypassPermissions`? | **Yes** — denied; control run without the deny executes the same command |
| Is matching a raw prefix (would over-block)? | **No** — `Bash(ec:*)` does *not* block `echo`, so `Bash(su:*)` won't block `subl` |
| Do comma-separated patterns work in one argv word? | **Yes** — required, because the shell path word-splits its flag string |
| End-to-end with the argv this change produces | `rpm-ostree kargs` **denied**; `git --version` still runs |

The first row is worth noting beyond this PR: it also confirms the existing `claudeGitHubWriteDenyFlags` protection is not vacuous, which nothing had established.

## Both launch paths, held together by a test

`config/backends.conf` covers the relay; `src/pkg/agent/manager.go` covers pod agents. Same list, and the same truthiness rule for the opt-out — an operator who writes `yes` must not get a confined agent on one path and an unconfined one on the other, which is the worst outcome because it looks like it worked. `TestShellAndGoDenyListsAgree` sources the shell file and compares, so the two cannot drift.

Escape hatch: `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1`, named after the codex one so they read alike.

## Docs

`sandbox-isolation.md` stated *"if an agent is compromised, it can only modify its mounted workspace"* as an unconditional property. It is not one — it holds on the opt-in Podman path, not the default. The threat model now separates the half that holds everywhere (credentials, pushes) from the half that does not, and says so with the incident. `backend-setup.md` and `contributor-relay.md` document the new denials and the opt-out next to their codex equivalents.

## Tests

Shell suite pins the default posture, the `rpm-ostree` entry, the escalation entries, litellm parity, the opt-out dropping the flag *entirely* (not leaving a dangling `--disallowed-tools`), and the word-split contract — exactly 5 argv words with the list intact in the 5th. Go tests pin the same list, every truthy spelling of the opt-out, that GitHub MCP denials survive alongside, and shell/Go parity.

Mutation-checked:

| Mutation | Caught by |
|---|---|
| drop `rpm-ostree` from the list | shell suite + `TestShellAndGoDenyListsAgree` |
| introduce a space (breaks word-splitting) | shell suite (6 argv words) + parity test |
| stop emitting denials entirely | shell suite |

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint` with the repo config (0 issues), the full `pkg/agent` suite (255s, pass), `bash bin/contributor-agent.test.sh` (pass), `bin/test_bin_suites_wired.sh` (18 suites, 0 orphaned). `gosec` on `pkg/agent` is 60 findings before and 60 after — no new ones. Shellcheck's two findings on `backends.conf` (SC2148, SC2034) are pre-existing.

## Not fixed here, deliberately

#4918 also asks whether the Podman sandbox should stop being double-gated off by default — both `agent_sandbox.enabled` and a per-agent `sandbox.enabled` must currently be set. That is an OS-level posture change with real blast radius for existing fleets: flipping it would sandbox agents on hosts that may not have podman or the image. It deserves its own PR and its own argument, so **please leave #4918 open for it** — this PR is the floor for the path people are on today, not the ceiling the issue asks for.

Refs #4918

— hive: backend=claude model=claude-opus-5


