### PR TITLE
📖 docs: add Danathar to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -18,6 +18,7 @@ Listed below are organizations that have adopted, or benefitted from, KubeStella
 | [Frostyard](https://github.com/frostyard) | Autonomous development operations for frostyard projects | Pre-production | |
 | [Open Horizon](https://github.com/open-horizon) | Standardization and enforcement for code consistency | Pre-production | |
 | [Open Horizon Services (https://github.com/open-horizon-services) | Ensuring code consistency over community contributions | Pre-production | |
+| [Danathar](https://github.com/Danathar) | Autonomous development operations for Danathar projects | Pre-production | |
 
 
 


### PR DESCRIPTION
## Summary

Adds `Danathar` to the Adopters List in `ADOPTERS.md`, following the schema documented in the file's own "How to Add Yourself" section:

`| Organization | Description | Maturity Level | Further Information |`

The description and maturity level match the existing entries.

## Change

One row appended to the Adopters List table:

| Organization | Description | Maturity Level | Further Information |
| --- | --- | --- | --- |
| [Danathar](https://github.com/Danathar) | Autonomous development operations for Danathar projects | Pre-production | |

Existing adopter entries are preserved, per the maintainer note in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)