### PR TITLE
docs: document definition_source live-linking and AGENTS.md wiring status

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -53,7 +53,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 
 ## Configuration and agents
 
-- [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, and ACMM packs.
+- [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, ACMM packs, and live-linked `definition_source` (with its seed-only trust model).
 - [Advisory digest](advisory.md) — what the digest shows (`max_findings`, `show_all`) and how findings are retired (staleness auto-close, PR-linked auto-close).
 - [Advisory digest staleness](advisory-staleness.md) — when the hub raises the stale-advisory pill and alert, the gates that deliberately suppress it (undelivered App, App cannot write, all agents quiet), and the admin diagnostics that measure hidden staleness.
 - [Governor mode thresholds](https://github.com/kubestellar/hive/blob/v4/src/docs/governor-thresholds.md) — how idle/quiet/busy/surge thresholds scale with repo count, the `threshold_scaling` curves, and when explicit thresholds win.
@@ -62,6 +62,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [Portable AgentDefinition format](https://github.com/kubestellar/hive/blob/v4/src/AGENT-DEFINITION.md) — standalone YAML schema for importing/exporting agent definitions.
 - [Knowledge curator](https://github.com/kubestellar/hive/blob/v4/src/docs/knowledge-curator.md) — automatic fact extraction and promotion knobs, plus `knowledge.git_sources`: indexing a remote repo, layer semantics, private-repo auth (unsupported), and diagnosing a failed source.
 - [Skill registry](skills.md) — the `/data/skills/` file format and front-matter fields. **Loaded and counted on the dashboard, but not yet delivered to agents**: populating it changes no agent's behaviour today. Use the knowledge curator for knowledge that actually reaches agents.
+- [AGENTS.md repo instructions](agents-md.md) — the per-repo `AGENTS.md` file format Hive's parser (`pkg/agentsmd`) understands, including front-matter `skills:` and inline `## Skill:` sections. **Parsed and tested, but not wired into kicks**: the one call site's repo-root lookup unconditionally returns empty, so an `AGENTS.md` you add today has no effect on any agent's prompt.
 - [Agent peer-awareness logging (pluk)](https://github.com/kubestellar/hive/blob/v4/src/docs/agent-logging.md) — pluk log format, `hive-panes`, availability, and retention.
 - [Strategy Lab (Nous)](https://github.com/kubestellar/hive/blob/v4/src/docs/strategy-lab.md) — experiment lifecycle, dashboard/API configuration, fast-fail bounds, and the gate-decision flow. No `nous:` block in `hive.yaml`.
 - [GitHub App setup](https://github.com/kubestellar/hive/blob/v4/src/docs/github-app-setup.md) — the Forge App on GitHub and GitHub Enterprise: app creation, permissions, Setup URL, and `/gh-setup`.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -450,6 +450,107 @@ preselected as suggestions in the tab. They remain unsaved until an operator
 reviews them and clicks **Save**; after that, the persisted declaration governs
 future telemetry and operations work.
 
+## Live-linked agent definitions (`definition_source`)
+
+An agent can be linked to a whole portable `AgentDefinition` YAML file living in a GitHub repo, so an edit to that file propagates into the agent's config on the next reload or startup — no redeploy, no dashboard edit. This is the whole-agent analogue of `promptTemplate`/prompt-source live-linking (see [Policy and prompt templates](../policies/README.md)); both are implemented as graceful-fallback resolvers in `src/pkg/promptsrc` and `src/pkg/defsrc` respectively.
+
+```yaml
+agents:
+  scanner:
+    backend: copilot
+    model: claude-sonnet-4-6
+    definition_source:
+      type: github          # only "github" is supported; defaults to it when repo is set
+      owner: my-org
+      repo: agent-definitions
+      path: scanner.yaml
+      ref: main              # optional; branch/tag/SHA — omit for the default branch
+```
+
+`definition_source` is `DefinitionSourceConfig` (`src/pkg/config/config.go:469`), a field on `AgentConfig` (`config.go:908`). `owner`, `repo`, and `path` are required for the source to be considered set (`IsSet()`, `config.go:492`); `ref` is optional and falls back to the repo's default branch. `url` is a fifth, informational-only field the dashboard import UI uses to round-trip the pasted `github.com` blob URL — it plays no part in fetching.
+
+### What it does
+
+On startup and on every config reload, `defsrc.ApplyToConfig` (`src/pkg/defsrc/defsrc.go:416`) walks every agent that has `definition_source` set, fetches the file's content from GitHub, and merges the parsed `AgentDefinition`'s operator-safe fields over the agent's baked config in place. It is wired at two call sites in `src/cmd/hive/main.go`:
+
+- **Startup**, line 1294 — applied once before the first kick, so a repo edit made while the hive was down is already reflected.
+- **Config reload**, line 3009 — re-applied on every reload, before `initAgentConfigDrivenSystems`, so downstream systems see the merged config.
+
+Both call sites build the same `defsrc.Resolver` (`main.go:1287`), gated by `func(slug string) bool { return cfg.GitHubDefinitionAllowed(slug) }` (`main.go:1289`).
+
+### What fields the live definition can change
+
+`mergeAllowedFields` (`defsrc.go:170`) is an explicit **allow-list**, not a deny-list: only fields it names are copied from the fetched `AgentDefinition` onto the baked `AgentConfig`. A field not in this list — including any privilege- or security-relevant field added to `AgentConfig` later — is preserved from the baked config by construction; a new field is safe-by-default rather than accidentally live-sourced.
+
+| `AgentDefinition` field (YAML tag) | Applied to `AgentConfig` field |
+|---|---|
+| `metadata.displayName` | `DisplayName` |
+| `metadata.description` | `Description` |
+| `metadata.emoji` | `Emoji` |
+| `metadata.color` | `Color` |
+| `spec.backend` | `Backend` |
+| `spec.model` | `Model` |
+| `spec.role` | `Role` |
+| `spec.mode` | `Mode` |
+| `spec.sortOrder` | `SortOrder` |
+| `spec.beadRole` | `BeadRole` |
+| `spec.staleTimeout` | `StaleTimeout` |
+| `spec.restartStrategy` | `RestartStrategy` |
+| `spec.clearOnKick` | `ClearOnKick` |
+| `spec.includeRepos` | `IncludeRepos` |
+| `spec.laneKeywords` | `LaneKeywords` |
+| `spec.detectKeywords` | `DetectKeywords` |
+| `spec.aliases` | `Aliases` |
+| `spec.cadences` | `Cadences` |
+| `spec.promptTemplate` | `KickTemplate`/prompt template |
+| `spec.channels` | `Channels` |
+| `spec.tools` | `Tools` |
+| `spec.connections` | `Connections` |
+
+Two merge rules to know before you rely on this:
+
+- **A blank field never clears a baked value.** For most fields, an empty string or empty slice in the fetched definition is skipped, so a minimal definition can't silently wipe presentation you set elsewhere. `ClearOnKick` and `IncludeRepos` are the deliberate exceptions — their zero value (`false`) is a legitimate setting, so the definition's value is taken as authoritative whenever the source resolves live (`defsrc.go:212-216`).
+- **Everything else on the agent is preserved untouched**, explicitly including: `Enabled`/`Paused`/`Managed` (operator lifecycle state), `ID`, `BeadsDir`, `MetricsCollector`, `ACMMLevels`, `OnDemand`, `CavemanMode`, and — critically — the `definition_source`/`prompt_source` pointers themselves. A live definition cannot re-point the agent at a different repo (`ApplyToConfig` re-asserts this at `defsrc.go:437-440` even though the merge already excludes it). Nothing under the hive-level `variables.security` block is reachable either — it isn't part of `AgentConfig` at all.
+
+### The trust boundary: allowlisted repos are seed-only
+
+`definition_source` is gated by `Config.GitHubDefinitionAllowed(slug)` (`config.go:4162`), which simply delegates to `Config.GitHubPromptAllowed(slug)` (`config.go:4142`) — the **same** seed-only gate used by `prompt_source`. Fetching requires both:
+
+```yaml
+variables:
+  security:
+    allow_github_prompt: true              # default false (deny)
+    github_prompt_allowlist:
+      - my-org/agent-definitions           # exact "owner/repo" slugs only
+```
+
+This is the property operators most need to understand before enabling the feature: **`variables.security` is honored only from the trusted config seed.** `LoadWithDashboardOverlay` never merges the dashboard overlay's `Variables` block (`config.go:397-399`, `config.go:4157-4161`), so:
+
+- A dashboard save cannot turn `allow_github_prompt` on if the seed has it off.
+- A dashboard save cannot add a repo slug to `github_prompt_allowlist`.
+- A compromised or malicious dashboard overlay can neither widen the set of readable repos nor repoint an agent's `definition_source` at an arbitrary repo — only a seed edit (ConfigMap in Kubernetes, bind-mounted file in Docker/LXC) can do either.
+
+An empty allowlist denies every repo even with `allow_github_prompt: true` — the allowlist is required, not merely advisory.
+
+### Fetch failures never blank an agent
+
+`Resolve` (`defsrc.go:283`) never propagates an error to the caller: a reload must proceed even when GitHub is unreachable. On any failure it falls back, in order:
+
+1. **Denied** (not allowlisted) — logs a warning, keeps the baked config, `Source: "denied"`.
+2. **No fetcher** (token-mode boot without a GitHub App client) — uses the last-known-good cached document if one exists, else keeps baked, `Source: "no-client"`.
+3. **Fetch error** (timeout, network, 404, etc.) — falls back to the last-known-good cached document if one exists, else keeps baked, `Source: "error"`. Fetches are bounded to 8 seconds (`defaultFetchTimeout`, `defsrc.go:47`) so a hung GitHub call cannot stall a reload.
+4. **Malformed document** (bad YAML, wrong `kind`, missing `metadata.name`) — keeps baked, `Source: "error"`. A document is cached for fallback only after it parses cleanly (`defsrc.go:325-329`), so a later failure never falls back to a corrupt document.
+
+A fetched file is capped at 512 KiB (`maxDefinitionBytes`, `defsrc.go:43`); an oversized file is truncated (and likely then fails to parse) rather than consuming unbounded memory.
+
+### Validating a source before saving it
+
+`defsrc.FetchOnce` (`defsrc.go:372`) does a single gated fetch — bypassing the resolver's cache — and returns a parse error to the caller. This is what the dashboard's import/"keep linked" flow uses to surface a bad `owner`/`repo`/`path`/document to the operator at save time, rather than only discovering the problem silently on the next reload.
+
+### Format reference
+
+The fetched file must be a valid portable `AgentDefinition`: `kind: AgentDefinition` and a non-empty `metadata.name` are required (`ParseDefinition`, `defsrc.go:138`); everything else is optional. For the full schema and a worked example, see [`../AGENT-DEFINITION.md`](../AGENT-DEFINITION.md) and [`../examples/agents/customized-agent.yaml`](../examples/agents/customized-agent.yaml).
+
 ## Kick templates: what an agent is told to do
 
 `kick_template` names a Markdown file resolved from the hive's policies checkout (`/data/policies/examples/kubestellar/agents/`, or the directory your `policies:` config points at), falling back to the defaults embedded in the binary (`src/pkg/policies/defaults/`). It is the agent's **periodic work prompt**: on every kick, the template is loaded, variables like `${ISSUE_LIST}`, `${PR_LIST}`, `${AGENT_NAME}`, `${PROJECT_ORG}`, and `${KNOWLEDGE}` are substituted, and the result is dispatched to the agent's session.
@@ -512,6 +613,7 @@ Both polarities are enforced at **enumeration** — the point where GitHub issue
 - **[Documentation index](README.md)** — what hive is, setup, and the full topic-guide surface.
 - **[Architecture](architecture.md)** — process model, deterministic pipeline, governor loop, guardrails, and hub/spoke design.
 - **[Portable AgentDefinition format](../AGENT-DEFINITION.md)** — standalone YAML schema for agent imports, exports, and overlays.
+- **[AGENTS.md repo instructions](agents-md.md)** — the per-repo instruction file format Hive's parser understands. **Not wired into kicks today** — see the page for why.
 - **[Dashboard route and health checks](health-checks.md)** — listener probes and alert behavior for stuck sessions and restart loops.
 - **[Troubleshooting](troubleshooting.md)** — stuck sessions, login expiry, restart loops, and notification checks.
 - **[ACMM policy matrix](acmm-policy-matrix.md)** — the full per-level, per-agent policy table.

--- a/src/docs/agents-md.md
+++ b/src/docs/agents-md.md
@@ -1,0 +1,146 @@
+# AGENTS.md repo instructions
+
+> **⚠️ Parsed and tested, but NOT wired into kicks.** Hive ships a complete
+> `AGENTS.md` parser (`src/pkg/agentsmd`) and a call site that would prepend its
+> output to every kick prompt — but the call site is permanently disabled. The
+> single function that supplies it a repo checkout path,
+> `Scheduler.agentsRepoRoot()`, unconditionally returns `""`
+> (`src/pkg/scheduler/scheduler.go:1385-1390`), and `primeAgentsMd` treats an
+> empty root as "nothing to inject" (`scheduler.go:1394-1396`). **An `AGENTS.md`
+> file you add to a monitored repo today is never read by Hive and has no
+> effect on any agent's kick prompt.** This page documents the file format Hive
+> already understands, for when the wiring lands — not a feature you can rely
+> on to change agent behavior now.
+
+## Why it doesn't run today
+
+Hive agents work over the GitHub API — they do not keep a local git checkout of
+the repos they monitor. `agentsRepoRoot()` has no local path to hand back, so
+returning `""` is the deliberate, conservative choice rather than a bug. The
+comment on the function says so directly:
+
+> "Hive agents operate over GitHub rather than local clones, so this is
+> usually empty today; the hook exists so that when a checkout root becomes
+> available (e.g. a git source's `LocalDir`) the AGENTS.md convention is
+> honored without further wiring."
+
+The one call site, in `Scheduler.buildKickForAgent`-adjacent code, is guarded
+and additive — it only prepends when `primeAgentsMd` returns non-empty text —
+and carries an explicit `TODO(agentsmd)` marking the missing piece: threading a
+per-repo checkout root through, and preferring `agentsmd.ParseNearest` for
+closest-wins nested files once file-level targeting exists
+(`scheduler.go:242-248`).
+
+This is the same shape as two other recently-documented gaps in Hive:
+[`enqueue-approval`](https://github.com/kubestellar/hive/issues/4911) and the
+[skill registry](skills.md) (`pkg/skillreg`) — a complete, tested package that
+nothing in the runtime calls yet.
+
+## What Hive's parser supports (the format, once wired)
+
+`src/pkg/agentsmd` (`agentsmd.go:119`, `Parse`) reads a plain Markdown
+`AGENTS.md` file at a repo root, with two additive extensions on top of
+ordinary Markdown:
+
+### Optional YAML front-matter
+
+A block delimited by a line containing only `---` at the very top of the file,
+closed by a second `---` line. The only key Hive's parser reads is `skills:` —
+a list of skill names to request into the agent's context by default
+(`agentsmd.go:11-21`, struct `frontMatter` at `agentsmd.go:104`). Everything
+else in the block is ignored. Malformed front-matter is logged and skipped;
+the rest of the file (the body) is still used (`agentsmd.go:184-189`).
+
+```markdown
+---
+skills:
+  - go-testing
+  - pr-etiquette
+---
+
+# Repo conventions
+
+...
+```
+
+### Inline skill sections
+
+Any section whose heading is `## Skill: <name>` defines a reusable, named
+instruction snippet. The section body runs from that heading to the next
+`## ` heading, or end of file (`agentsmd.go:236-277`). Skills may also be
+defined as standalone files at `skills/<name>.md` relative to the repo root;
+when a standalone file and an inline section define the same name, **the
+inline section wins** (`agentsmd.go:202-207`).
+
+```markdown
+## Skill: go-testing
+
+Always run `go test ./...` before committing. Table-driven tests preferred.
+```
+
+### The body
+
+Whatever is left after front-matter and `## Skill:` sections are stripped out
+is the "body" — general instructions that would always apply
+(`agentsmd.go:30-31`, `agentsmd.go:198-200`).
+
+### Closest-wins nested `AGENTS.md`
+
+`ParseNearest(repoRoot, relPath, logger)` (`agentsmd.go:127`) walks from a
+target file's directory up to the repo root and uses the first `AGENTS.md` it
+finds; the root file is the required baseline nested files override for their
+own subtree. This exists in the package today but has no caller — the
+scheduler's `TODO(agentsmd)` names it as the intended future entry point once
+file-level targeting exists; the disabled call in `scheduler.go` currently
+only ever calls the flat `Parse`, and even that call never runs because its
+root argument is always `""`.
+
+### Rendered injection text (if it ran)
+
+`AgentsConfig.InjectionText(requestedSkills)` (`agentsmd.go:330`) is what would
+be prepended to a kick: a `# Repository Agent Instructions (AGENTS.md)`
+header, the body, and (if any skills resolve) a `## Requested Skills`
+subsection with each skill's text under a `### <name>` heading. It returns
+`""` — and therefore injects nothing — when both the body and the resolved
+skills are empty.
+
+## Parsing is tolerant, wiring is not the risk
+
+Everything about the *parser* is designed to fail safe: a missing file yields
+an empty, non-nil config (`agentsmd.go:171-174`); an unreadable file logs and
+returns empty (`agentsmd.go:175-178`); malformed front-matter logs and falls
+back to using the body alone. None of that tolerance is why the feature is
+inert today — the parser is simply never invoked, because `agentsRepoRoot()`
+never has anything to hand it.
+
+## Connection to the skill registry
+
+The `skills:` front-matter key names skills by the same kind of identifier the
+[skill registry](skills.md) (`/data/skills/`, `pkg/skillreg`) would resolve —
+but the two systems are **separately unwired** from each other and from the
+runtime:
+
+- `pkg/agentsmd` can resolve a skill name to text from an inline `## Skill:`
+  section or a `skills/<name>.md` file **in the same repo** — this is
+  self-contained and does not consult the registry at all.
+- The skill registry is a **different, hive-wide** store, loaded and counted
+  on the dashboard but — per its own page — not delivered into any agent's
+  context either.
+
+Neither pipeline reaches a live kick prompt today. Don't read the shared
+`skills:` vocabulary as evidence that authoring one wires up the other; they
+are independent, parallel gaps.
+
+## What to read next
+
+- **[Skill registry](skills.md)** — the sibling not-yet-wired feature: file
+  format, where it's loaded from, and what "loaded and counted" actually means
+  today.
+- **[Agent configuration](agent-configuration.md)** — the `definition_source`
+  and `channels`/`tools`/`connections` fields that *are* live.
+- **[ADR-0012: Skill registry](adr/0012-skill-registry.md)** — the design
+  rationale that also describes `AGENTS.md` inline snippets.
+- **[ClankeR contributor relay](contributor-relay.md)** — the per-backend
+  instruction file table (`AGENTS.md`, `CLAUDE.md`, `.goosehints`, etc.) for
+  CLI-side instruction conventions unrelated to this scheduler-side injection
+  gap.


### PR DESCRIPTION
## Summary

Two operator-documentation gaps, one live feature and one that is not.

### #4961 — `definition_source` (live, and now documented)

Adds a `definition_source` section to `src/docs/agent-configuration.md` covering:

- The field schema (`DefinitionSourceConfig`, `src/pkg/config/config.go:469`) and a worked YAML example.
- What it does and where it's wired: `defsrc.ApplyToConfig` called at startup (`src/cmd/hive/main.go:1294`) and on every config reload (`main.go:3009`).
- The exact operator-safe field allow-list `mergeAllowedFields` applies (`src/pkg/defsrc/defsrc.go:170`), as a table, plus the two fields (`clear_on_kick`, `include_repos`) whose zero value is meaningful and therefore always taken live.
- **The trust boundary operators most need**: `GitHubDefinitionAllowed` (`config.go:4162`) delegates to the same seed-only gate as `prompt_source` (`GitHubPromptAllowed`, `config.go:4142`). `variables.security` — the feature flag and repo allowlist — is never merged from the dashboard overlay (`LoadWithDashboardOverlay`, `config.go:397-399`), so a compromised overlay can neither enable the feature nor widen/repoint the allowlist.
- Graceful-fallback behavior on denied/unreachable/malformed sources (`Resolve`, `defsrc.go:283`), and the `FetchOnce` validation path used at import time (`defsrc.go:372`).

### #4962 — AGENTS.md injection (**not live** — issue's central claim was wrong)

The issue asserted "the feature is live" — that `scheduler.go` calls `agentsmd.Parse` and prepends AGENTS.md content on every kick. **That is incorrect.** Verified:

- The only call site, `s.primeAgentsMd(s.agentsRepoRoot())` (`src/pkg/scheduler/scheduler.go:247`), is guarded.
- `agentsRepoRoot()` (`scheduler.go:1385-1390`) **unconditionally returns `""`** — the whole body is `return ""`, with a comment stating this is intentionally conservative because hive agents work over the GitHub API rather than local clones.
- `primeAgentsMd` (`scheduler.go:1394`) returns `""` immediately whenever `repoRoot == ""` — which is always, today.

So an `AGENTS.md` a repo owner adds today is **never read and never injected**. The parser package (`src/pkg/agentsmd`) is complete and tested, but nothing in the runtime calls it with a real root.

Added `src/docs/agents-md.md` with the not-wired warning **at the top**, before any format reference, followed by the file-format documentation (front-matter `skills:`, inline `## Skill:` sections, closest-wins `ParseNearest`) for when the wiring lands. Cross-links `docs/skills.md` (the skill registry, merged in #4953) honestly — the two `skills:`-vocabulary systems are separately unwired from the runtime and from each other; the doc does not describe an end-to-end skills pipeline that does not exist.

### Index

`src/docs/README.md` entries updated for both pages; the AGENTS.md index line itself carries the not-wired caveat, matching how the skill-registry line already does, so a reader scanning the index doesn't need to open the page to learn the feature is inert.

## Verification

Every substantive claim in both docs cites a `file:line`. No Go/test/build changes — documentation only.

Fixes #4961
Fixes #4962