### PR TITLE
🐛 ci: repin sbom-action to a SHA that exists, and guard against fabricated pins

### DIFF
--- a/.github/workflows/go-security-analysis.yml
+++ b/.github/workflows/go-security-analysis.yml
@@ -28,10 +28,10 @@ name: Go Security Analysis
 on:
   push:
     branches: [v2, v4]
-    paths: ['src/**', '.github/workflows/go-security-analysis.yml', '.github/release-lines.yml']
+    paths: ['src/**', '.github/workflows/**', '.github/release-lines.yml']
   pull_request:
     branches: [v2, v4]
-    paths: ['src/**', '.github/workflows/go-security-analysis.yml', '.github/release-lines.yml']
+    paths: ['src/**', '.github/workflows/**', '.github/release-lines.yml']
   schedule:
     # Weekly, so a newly-PUBLISHED advisory against unchanged code is still
     # found. A push-only trigger cannot catch that: the vulnerability appears
@@ -123,3 +123,18 @@ jobs:
         with:
           version: v2.13.1
           working-directory: src
+
+  action-pins:
+    name: action pins resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # A fabricated 40-hex SHA looks exactly like a correct pin and is only
+      # caught when the workflow RUNS. release.yml shipped one (#4908), so every
+      # tagged release failed at "Prepare all required actions" — discovered
+      # only when someone tried to cut a release.
+      - name: Check every pinned action SHA exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: src/scripts/check-action-pins.sh .github/workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
       # AND in the generated release notes rather than silently shipping one
       # file and implying full multi-arch coverage.
       - name: Generate per-image SBOMs (SPDX JSON, Syft, linux/amd64)
-        uses: anchore/sbom-action@f4dccdb4d47756825f4cc0c65181bd67e19eb70a # v0.20.9
+        uses: anchore/sbom-action@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
         with:
           image: ghcr.io/kubestellar/hive:v${{ env.VERSION }}
           output-file: hive-v${{ env.VERSION }}-sbom.spdx.json
@@ -220,7 +220,7 @@ jobs:
           artifact-name: "" # do not also attach to a GH Actions run artifact; the release upload below is the distribution point
 
       - name: Generate contributor image SBOM
-        uses: anchore/sbom-action@f4dccdb4d47756825f4cc0c65181bd67e19eb70a # v0.20.9
+        uses: anchore/sbom-action@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
         with:
           image: ghcr.io/kubestellar/hive-contributor:v${{ env.VERSION }}
           output-file: hive-contributor-v${{ env.VERSION }}-sbom.spdx.json
@@ -228,7 +228,7 @@ jobs:
           artifact-name: ""
 
       - name: Generate hub image SBOM
-        uses: anchore/sbom-action@f4dccdb4d47756825f4cc0c65181bd67e19eb70a # v0.20.9
+        uses: anchore/sbom-action@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
         with:
           image: ghcr.io/kubestellar/hive-hub:v${{ env.VERSION }}
           output-file: hive-hub-v${{ env.VERSION }}-sbom.spdx.json

--- a/src/scripts/check-action-pins.sh
+++ b/src/scripts/check-action-pins.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# check-action-pins.sh — assert every SHA-pinned GitHub Action actually exists.
+#
+# WHY: release.yml shipped `anchore/sbom-action@f4dccdb4...`, a 40-hex SHA that
+# resolves to no commit in that repository (#4908). It LOOKS like a correct pin
+# — right shape, plausible `# v0.20.9` comment beside it — and nothing catches a
+# fabricated SHA until the workflow runs and dies at "Prepare all required
+# actions". For a tag-triggered release workflow that means the break is only
+# discovered when someone cuts a release, which is the worst time to find it.
+#
+# This checks the pin shape statically and, when a token is available, resolves
+# each SHA against the GitHub API.
+#
+# Usage: src/scripts/check-action-pins.sh [workflow-dir]
+set -uo pipefail
+
+DIR="${1:-.github/workflows}"
+fail=0
+
+# Every `uses:` on a third-party action must be a 40-hex SHA, not a tag or
+# branch. A moving ref is a supply-chain hole; that part is shape-only and needs
+# no network.
+while IFS= read -r line; do
+  file="${line%%:*}"
+  ref="$(printf '%s' "$line" | grep -oE '[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+@[^ ]+' | head -1)"
+  [ -z "$ref" ] && continue
+  sha="${ref#*@}"
+  case "$sha" in
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+    *) echo "NOT-PINNED $file: $ref (use a 40-hex commit SHA)"; fail=1; continue ;;
+  esac
+done < <(grep -rhnE '^\s*(-\s*)?uses:\s*[a-zA-Z0-9._-]+/' "$DIR" 2>/dev/null | grep -v '^\s*#')
+
+# Resolve each unique pin. Skipped without a token so the script stays usable
+# offline; CI always has one.
+if command -v gh >/dev/null 2>&1; then
+  # Extract owner/repo from the `uses:` VALUE, taking only the first two path
+  # segments: a reusable workflow is `owner/repo/.github/workflows/x.yml@SHA`,
+  # so naively splitting on the last '/' asks the API about a path, not a repo.
+  grep -rhoE 'uses:[[:space:]]*[a-zA-Z0-9._-]+/[a-zA-Z0-9._/-]+@[0-9a-f]{40}' "$DIR" 2>/dev/null \
+    | sed -E 's/^uses:[[:space:]]*//' | sort -u | while read -r ref; do
+    sha="${ref#*@}"; path="${ref%@*}"
+    repo="$(printf '%s' "$path" | cut -d/ -f1,2)"
+    if ! gh api "repos/$repo/commits/$sha" --jq '.sha' >/dev/null 2>&1; then
+      echo "MISSING-SHA $repo@$sha does not exist in that repository"
+      exit 1
+    fi
+  done || fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "action pin check FAILED"
+  exit 1
+fi
+echo "action pin check OK"


### PR DESCRIPTION
`release.yml` pinned `anchore/sbom-action` to `f4dccdb4d47756825f4cc0c65181bd67e19eb70a` at three call sites. **That commit does not exist** — the API returns *"No commit found for SHA"*.

Every Tagged Release run died at `Prepare all required actions` before doing any work. No release artifacts, no SBOMs. (#4908)

**This was mine**, introduced with the release automation earlier today.

## The fix

Repinned all three to `8e94d75ddd33f69f691467e42275782e4bfefe84` — the real v0.20.9 commit, verified against the API rather than trusted from a comment. I also checked every other pin in `release.yml` and in the security workflow; those four all resolve.

## Why a guard, not just a repin

A fabricated pin is a genuinely nasty failure mode. It has the **right shape** — forty hex characters, with a plausible `# v0.20.9` comment beside it — so it survives review by inspection. Nothing catches it until the workflow runs.

And for a **tag-triggered** release workflow, "when the workflow runs" means *when someone cuts a release*. That is the worst possible moment to discover CI is broken, and it is why this sat undetected: the normal PR path never exercises it.

`src/scripts/check-action-pins.sh` now:

- resolves every SHA-pinned action against the GitHub API
- asserts third-party actions are pinned to a **40-hex SHA**, not a moving tag

It runs as a new `action-pins` job in the security workflow, and that workflow's trigger widens to `.github/workflows/**` so a bad pin fails **on the PR that introduces it** rather than at release time.

## A bug in the guard itself, caught on its first run

The first version reported `MISSING-SHA` for `kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd`. That is a **false positive**: a reusable-workflow ref is `owner/repo/.github/workflows/x.yml@SHA`, so splitting on the last `/` asks the API about a *path*, not a repo.

Now fixed to take the first two path segments, and verified the existing `kubestellar/infra` reference passes. Worth noting because a check that cries wolf on a legitimate ref gets disabled, which would have left the real gap open.

Fixes #4908