### PR TITLE
🐛 fix(ci): let fork PRs produce the required `gate` context (#4965)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,30 @@ on:
       - '**'
       - '!dependabot/**'
       - '!copilot/**'
+  # `gate` is the ONLY status context v4 branch protection requires, and a
+  # push-only workflow cannot produce it for a pull request from a FORK: the
+  # push event fires in the contributor's repo, not here, so `gate` never
+  # attaches to the head SHA this repo evaluates and protection blocks the
+  # merge waiting for a check that cannot arrive (#4965). Six green fork PRs
+  # were structurally unmergeable; maintainers never saw it because
+  # enforce_admins is false, so an admin merge silently bypasses the same
+  # missing check.
+  #
+  # This trigger exists to produce that one context. It deliberately runs
+  # NOTHING else on a pull request — every build job below is skipped for this
+  # event — so it adds no image CI. The heavyweight builds stay push-only,
+  # exactly as the comment above describes.
+  #
+  # No `paths:` or `branches:` filter, on purpose. A required context must
+  # attach to EVERY pull request; a filtered one silently never runs on the
+  # changes it does not match, and protection then waits forever. That is also
+  # why the already PR-triggered `build-and-test` is not a drop-in replacement
+  # for `gate` in the required list — v2-ci.yml path-filters it.
+  #
+  # Leaving the filter off also keeps this workflow's `unpinned: '**'` contract
+  # in .github/release-lines.yml intact: that guard requires every `branches:`
+  # filter here to stay a wildcard, so a fixed base-branch list would fail it.
+  pull_request:
   workflow_dispatch:
 
 # Serialize Docker builds per branch so concurrent merges don't race. Do NOT
@@ -72,6 +96,14 @@ jobs:
 
   build:
     needs: gate
+    # Skipped for `pull_request` (#4965): that trigger exists only so the
+    # required `gate` context attaches to a fork PR's head SHA. The image build
+    # stays push-only — and a PR is not left unbuilt by this, because
+    # v2-ci.yml already runs on pull_request and builds src/Dockerfile with a
+    # real `hive --version` smoke test (`docker`), plus `build-and-test`
+    # (go build + go vet) and `overlayfs-exec-guard`. Building here too would
+    # be a third image build of the same commit.
+    if: github.event_name != 'pull_request'
     strategy:
       matrix:
         include:
@@ -305,6 +337,8 @@ jobs:
 
   build-contributor:
     needs: gate
+    # Push-only, same as `build` above (#4965).
+    if: github.event_name != 'pull_request'
     strategy:
       matrix:
         include:
@@ -401,6 +435,8 @@ jobs:
 
   build-hub:
     needs: gate
+    # Push-only, same as `build` above (#4965).
+    if: github.event_name != 'pull_request'
     strategy:
       matrix:
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ### Fixed
 
+- Pull requests from forks can now satisfy `v4`'s required `gate` status context. `gate` is a job in `docker.yml`, which triggered on `push` only — and a fork PR's push event fires in the contributor's repo, not here, so `gate` never attached to the head SHA this repo evaluates and branch protection blocked the merge waiting for a check that could not arrive. Six fully green contributor PRs (#4930, #4932, #4934, #4935, #4936, #4937) were structurally unmergeable; `gate` was verified absent on every one of their head SHAs. It went unnoticed because `enforce_admins` is false, so maintainers' own merges silently bypassed the same missing check — the required context was in practice unenforced for maintainers and absolutely enforced for outside contributors. `docker.yml` now also triggers on `pull_request`, with every image-build job skipped for that event, so the context attaches to fork PRs at the cost of one ~5-second shell job and no image CI: the image is already built and smoke-tested on every PR by `v2-ci.yml` (`docker`, `build-and-test`, `overlayfs-exec-guard`). Push builds and GHCR publishing are unchanged — `gate` reports `push=false` for a PR event, so every `merge*` job stays skipped ([#4965](https://github.com/kubestellar/hive/issues/4965)).
+
 - The canonical `blocked` workflow overlay now stays out of the contributor
   queue: the actionable-work enumerator, ReadyQueue, live contributor
   assignment, and internal kick projection all withhold it. Work waiting on


### PR DESCRIPTION
## Summary

- **What this touches.** Before GitHub will let a PR merge into `v4`, branch protection requires one named check to report success. That check is called `gate`, and it is produced by the workflow that builds hive's container images.

- **The problem.** Anyone contributing from a fork — which is everyone without write access to the repo — gets a PR that is completely green and still cannot be merged, with nothing on the page saying why. Six contributor PRs are sitting in exactly that state right now (#4930, #4932, #4934, #4935, #4936, #4937): zero failing checks, DCO passing, and `gate` verified **absent** on every one of their head commits. Maintainers have not run into it because admin merges are allowed to bypass a missing required check, so the same gap silently resolves itself for them and only for them.

- **Why it happens.** The image workflow runs on `push` only. A fork PR's branch lives in the contributor's own copy of the repo, so the push event fires *there*, not here — the check is never attached to the commit this repository evaluates, and protection waits forever for something that cannot arrive.

- **The fix.** Run that workflow on pull requests too, but skip every image-build job when it is a pull request. That produces the one missing check and nothing else.

- **Blast radius.** Adds roughly five seconds of CI per PR and no image builds — the images are already built and smoke-tested on every PR by a different workflow. Nothing is published to the registry from a pull request. Workflow YAML only; no product code changes.

## Detail

`v4` protection requires exactly one status context, `gate`, which is a job in `.github/workflows/docker.yml`. That workflow triggered on `push` and `workflow_dispatch` only, so `gate` never attaches to a fork PR's head SHA and the merge blocks on a check that cannot arrive.

This adds a `pull_request` trigger and skips all three image-build jobs for that event.

### Why this shape rather than the issue's option 1 or 3

Two findings from checking option 1's cost, which the issue asked for:

1. **`gate` does not build or compile anything.** It is a ~20-line shell step with no `checkout` that decides the GHCR push policy, and it cannot fail. The heavyweight work was never what the required context asserted, so running only `gate` on a PR withholds nothing that was previously being proven.
2. **The image is already built on every PR.** `v2-ci.yml` runs on `pull_request`; its `docker` job runs `docker build -f src/Dockerfile` plus a real `hive --version` smoke test, alongside `build-and-test` (`go build` + `go vet`) and `overlayfs-exec-guard`. All three passed on all six PRs. Option 1 as written would have added a **third** image build of the same commit.

Option 3's "lightweight compile check that runs on `pull_request`" already exists as `build-and-test` — but it is **not** a drop-in replacement for `gate` in the required list, because `v2-ci.yml` path-filters it and a doc-only PR would then hang on a check that never runs.

Nothing reaches GHCR from a PR: `github.ref_name` is `<n>/merge`, not in `LONG_LIVED`, so `gate` outputs `push=false` and all three `merge*` jobs stay skipped by their existing `needs.gate.outputs.push == 'true'` guard.

Two shape decisions are load-bearing. The trigger carries no `paths:` or `branches:` filter, because a required context must attach to *every* PR — a filtered one silently never runs on the changes it does not match. Omitting `branches:` also keeps `docker.yml`'s `unpinned: '**'` contract in `.github/release-lines.yml` intact; I tried a fixed base-branch list first and that guard correctly failed it.

### Scope

**This makes the required check obtainable, not meaningful.** `gate` asserts nothing, on fork and same-repo PRs alike — it never did, which is the sharper version of the issue's own point that the protection "has been providing less assurance than it appears to."

The durable fix is the issue's **option 2**: point the required context at something that actually verifies the code. That is a branch-protection **settings** change — there is no Prow or branch-protection config in this repository, and `GET /branches/v4/protection` returns 404 without admin — so it cannot come from a PR. This removes the asymmetry meanwhile, holding contributors to the same standard maintainers already operate under rather than an impossible one. If you take option 2, this is 4 lines to revert.

Deliberately left to maintainers: handling `v2-ci.yml`'s path filters before promoting `build-and-test`/`docker` to required, and a guard asserting `docker.yml` keeps its `pull_request` trigger — without one this regresses silently, the "fails GREEN" pathology `release-lines.yml` was written for.

Merging this will not retroactively attach `gate` to the six. `pull_request` workflows are evaluated from the base+head merge ref, so each needs a new event — rebase, sync push, or close/reopen.

## Related issues

Refs #4965 — deliberately **not** `Fixes`, because two of the issue's concerns (a meaningful required context, and the settings change) are out of a PR's reach.

## Testing

- [ ] `cd src && go build ./...`
- [ ] `cd src && go test ./...`
- [x] Other / not run (explain):

No Go source changed — this is a workflow-YAML-only diff, so the Go build/test boxes are not applicable locally. What was run instead:

| Check | Result |
| --- | --- |
| `python3 -c "yaml.safe_load(...)"` on `docker.yml` | parses; job graph confirmed, all three build jobs carry `if: github.event_name != 'pull_request'` |
| `src/scripts/check-release-lines.sh` | **PASS** — `docker.yml:9 branches: wildcard kept (!copilot/**,!dependabot/**,**) — deliberately unpinned` |
| `src/scripts/test-release-lines-guard.sh` | **PASS** (the guard's own self-test) |
| `src/scripts/check-no-image-attestations.sh` | **PASS** — all four `build-push-action` steps still `provenance: false` / `sbom: false` (#3760) |

**This PR is itself a fork PR against `v4`, so it tests the fix on itself:**

| PR | `gate` | mergeStateStatus |
|---|---|---|
| #4930 | ABSENT | BLOCKED |
| #4932 | ABSENT | BLOCKED |
| #4934 | ABSENT | BLOCKED |
| #4935 | ABSENT | BLOCKED |
| #4936 | ABSENT | BLOCKED |
| #4937 | ABSENT | BLOCKED |
| **this PR** | **success** | **UNSTABLE** |

Its `docker.yml` run: `gate` success; `build`, `build-contributor`, `build-hub`, `merge`, `merge-hub`, `merge-contributor` all skipped. Full CI on this PR: 20 pass, 0 fail, 9 skipping, `tide` pending on `approved`/`lgtm` as expected.

## Contributor checklist

- [x] PR targets `v4`, per CONTRIBUTING.md ("Target `v4` for all code and documentation contributions"). Note this template's checklist still says `v2` — the two disagree, and I followed CONTRIBUTING.md.
- [x] Title uses the repo emoji convention (`🐛 fix(ci): ...`).
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies updated where behavior changes — the reasoning is documented inline in `docker.yml` at the trigger and at the first skipped job.
- [x] `CHANGELOG.md` has an entry under `Unreleased` → `Fixed`.
- [x] No secrets, credentials, or local runtime state are committed.

— hive: backend=claude model=claude-opus-5
