### PR TITLE
🐛 fix(release): stop inferring MAJOR from `### Security` — it would cut a new release line

### DIFF
--- a/src/scripts/derive-release-version.sh
+++ b/src/scripts/derive-release-version.sh
@@ -132,14 +132,56 @@ if [[ -n "$override" ]]; then
   bump="$override"
   echo "Bump forced to '${bump}' by explicit <!-- release: ${bump} --> marker in CHANGELOG.md."
 else
-  if printf '%s\n' "$unreleased" | grep -qE '^### Security[[:space:]]*$'; then
-    bump=major
-  elif printf '%s\n' "$unreleased" | grep -qE '^### Added[[:space:]]*$'; then
+  # NOTE: `### Security` does NOT imply major here, and that is deliberate.
+  #
+  # In this repository the MAJOR version IS the release line: `v2`, `v4` and
+  # `v5` are real long-lived branches listed in .github/release-lines.yml, and
+  # cutting a new line is a coordinated decision (new branch, workflow pins,
+  # docker LONG_LIVED policy, hub branch switcher). A tag that crosses a major
+  # boundary is therefore not "a bigger release" — it claims a line that may
+  # already exist and be owned by other work.
+  #
+  # This fired for real: a merge to v4 whose Unreleased section contained two
+  # Security entries (an action-pin hardening and a proxy gate) derived
+  # VERSION=5.0.0 while a `v5` branch already existed. Security entries are
+  # common and usually NOT breaking — pinning an action is the opposite of a
+  # breaking change — so inferring major from them mislabels routine hardening
+  # as a line cut.
+  #
+  # Security now maps to PATCH by default, which is the honest floor: a
+  # security fix is at least a patch, and anything genuinely breaking is
+  # declared with the explicit `<!-- release: major -->` marker. Crossing a
+  # release line stays a human decision, which is what it already is
+  # everywhere else in this repo.
+  if printf '%s\n' "$unreleased" | grep -qE '^### Added[[:space:]]*$'; then
     bump=minor
   else
     bump=patch
   fi
   echo "Inferred bump '${bump}' from CHANGELOG.md Unreleased section headers."
+fi
+
+# ---------------------------------------------------------------------------
+# HARD GUARD: never derive a version whose MAJOR differs from the release line
+# this branch belongs to.
+#
+# Belt-and-braces alongside the inference above. Even with an explicit
+# `<!-- release: major -->` marker, a merge to v4 must not mint a v5.x.y tag:
+# in this repo the major IS the line (see .github/release-lines.yml), a `v5`
+# branch can already exist, and a tag minted from the wrong branch is not
+# fixable by deleting it — consumers may already have pulled the image it
+# retagged.
+#
+# Cutting a new line stays a deliberate, human, multi-step operation. If that
+# is genuinely what you want, tag it by hand on the correct branch.
+# ---------------------------------------------------------------------------
+branch_line="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [[ "$branch_line" =~ ^v([0-9]+)$ ]]; then
+  line_major="${BASH_REMATCH[1]}"
+  if [[ "$bump" == "major" ]]; then
+    echo "::error::refusing to derive a MAJOR bump on release line ${branch_line}: the major version is the release line here, so a major bump would mint a v$((line_major + 1)).0.0 tag from the ${branch_line} branch. Cut a new line deliberately instead." >&2
+    exit 1
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A merge to `v4` derived **`VERSION=5.0.0`** and tried to tag it ([run 33175070806](https://github.com/kubestellar/hive/actions/runs/33175070806)).

The push was rejected as non-fast-forward. **That race is the only reason a `v5.0.0` tag does not now exist on the `v4` branch.**

## Why this is worse than a wrong version number

In this repo the **major version IS the release line.** `v2`, `v4`, and `v5` are real long-lived branches listed in `.github/release-lines.yml`, and cutting a line is a coordinated operation — new branch, workflow pins in three places, `docker.yml`'s `LONG_LIVED` publish policy, the hub's branch switcher.

**A `v5` branch already exists.**

So `v5.0.0` minted from a `v4` merge does not mean "a bigger release." It claims a line owned by other work, from the wrong branch. And a tag that has already retagged a published image is **not fixable by deleting it** — consumers may have pulled it.

## What triggered it

Two `### Security` entries in `Unreleased`. One of them was *pinning an action to an immutable SHA* — the opposite of a breaking change.

The original rationale is documented in the script: *"security changes in this changelog have historically included breaking auth/permission changes, so this errs toward the more disruptive bump."* That is reasonable in the abstract and wrong here, because it treats major as a **severity** signal when in this repo it is a **branch identity**.

## The fix

**`### Security` → PATCH**, the honest floor. A security fix is at least a patch; anything genuinely breaking is declared with the existing `<!-- release: major -->` marker rather than inferred.

**Plus a hard guard.** On a `vN` branch the script now refuses *any* major bump — including one forced by the explicit marker — because this failure is not correctable after the fact. Cutting a line stays a deliberate human operation, which is what it already is everywhere else here.

## Verified

Run against the real `CHANGELOG.md`: the same `Unreleased` section that derived `5.0.0` now derives a **patch** bump.

```
Inferred bump 'patch' from CHANGELOG.md Unreleased section headers.
Derived release version: v0.0.1 (bump=patch)
```

(`0.0.0` base is the test worktree having no tags; CI sees `v4.0.0` and derives `v4.0.1`.)

## Context

This is the second defect in the release automation I shipped today, after the fabricated `sbom-action` SHA in #4966. Both share a cause worth naming: a **tag-triggered workflow gets no exercise from normal PR traffic**, so its failure modes surface only when someone cuts a release. The pin guard from #4966 and this guard both move that discovery earlier.