### PR TITLE
📖 docs: add Open Horizon and Open Horizon Services to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,6 +16,9 @@ Listed below are organizations that have adopted, or benefitted from, KubeStella
 | --- | --- | --- | --- |
 | [Tuna OS](https://github.com/tuna-os) | Autonomous development operations for tuna-os projects | Pre-production | |
 | [Frostyard](https://github.com/frostyard) | Autonomous development operations for frostyard projects | Pre-production | |
+| [Open Horizon](https://github.com/open-horizon) | Standardization and enforcement for code consistency | Pre-production | |
+| [Open Horizon Services (https://github.com/open-horizon-services) | Ensuring code consistency over community contributions | Pre-production | |
+
 
 
 ## Adopter Tiers


### PR DESCRIPTION
## Summary

- Added both "Open Horizon" and "Open Horizon Services" organizations to the `ADOPTERS.md` file.

## Related issues

Fixes "N/A"

## Testing

- [X] Other / not run (explain): documentation change only

## Contributor checklist

- [X] PR targets `v2` unless a maintainer requested another branch.
- [X] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [X] Commits include DCO sign-off (`git commit -s`).
- [ ] Docs, examples, and policies are updated when behavior changes.
- [X] `CHANGELOG.md` has an entry for user-visible changes (features, fixes, new env vars, behavior changes), or the change is not user-facing.
- [X] No secrets, credentials, or local runtime state are committed.
