### PR TITLE
🐛 fix(config): make the entrypoint's read-only config redirect reach the binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,29 @@ Hive did not historically maintain a complete changelog. This file starts a prag
   documented `api_key: ${LINEAR_API_KEY}` form works from both `hive.yaml`
   and the dashboard.
 - Pull requests from forks can now satisfy `v4`'s required `gate` status context. `gate` is a job in `docker.yml`, which triggered on `push` only — and a fork PR's push event fires in the contributor's repo, not here, so `gate` never attached to the head SHA this repo evaluates and branch protection blocked the merge waiting for a check that could not arrive. Six fully green contributor PRs (#4930, #4932, #4934, #4935, #4936, #4937) were structurally unmergeable; `gate` was verified absent on every one of their head SHAs. It went unnoticed because `enforce_admins` is false, so maintainers' own merges silently bypassed the same missing check — the required context was in practice unenforced for maintainers and absolutely enforced for outside contributors. `docker.yml` now also triggers on `pull_request`, with every image-build job skipped for that event, so the context attaches to fork PRs at the cost of one ~5-second shell job and no image CI: the image is already built and smoke-tested on every PR by `v2-ci.yml` (`docker`, `build-and-test`, `overlayfs-exec-guard`). Push builds and GHCR publishing are unchanged — `gate` reports `push=false` for a PR event, so every `merge*` job stays skipped ([#4965](https://github.com/kubestellar/hive/issues/4965)).
+- A dashboard-set **ACMM level (and every other saved config field) no longer
+  reverts on restart** on hives whose config path is read-only — the ordinary
+  shape of a bind-mounted `hive.yaml` under Docker/podman
+  ([#4973](https://github.com/kubestellar/hive/issues/4973)). When it cannot
+  write the config path, `entrypoint.sh` falls back to reading
+  `/data/hive.yaml.runtime` directly and signals that by exporting
+  `HIVE_CONFIG`. That export was inert: the binary reads `HIVE_CONFIG` only to
+  choose the *default* of `--config`, and the image's own
+  `CMD ["--config", "/etc/hive/hive.yaml"]` passes the flag explicitly, which
+  outranks any default. So the hive booted from the stale, unwritable file the
+  entrypoint had just decided not to use — and because `Config.Save()` writes
+  `/data/hive.yaml.runtime` unconditionally, the next save of any kind (a
+  dashboard edit, a heartbeat-delivered config) wrote that stale config back
+  over the operator's real persisted state, making the loss durable rather
+  than momentary. Reported as an L4 level returning to L3 after every restart,
+  with `/data` fully intact. The entrypoint now appends `--config
+  "$HIVE_CONFIG"` to the launch argv so its redirect actually reaches the
+  process (`flag.Parse` keeps the last occurrence), and the boot log warns at
+  `WARN` if the loaded config path ever disagrees with `HIVE_CONFIG` again —
+  the discrepancy was previously invisible, because
+  `/api/config/provenance` reads `HIVE_CONFIG` directly and so reported the
+  file the entrypoint chose while the process ran on the one it did not. Hives
+  whose config path is writable are unaffected: nothing is appended there.
 
 - The canonical `blocked` workflow overlay now stays out of the contributor
   queue: the actionable-work enumerator, ReadyQueue, live contributor

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1139,6 +1139,36 @@ func main() {
 		}
 	}
 
+	// HIVE_CONFIG names a DIFFERENT file from the one we actually loaded.
+	//
+	// This is only ever the entrypoint's read-only escape hatch failing to
+	// land. When the config path cannot be written, entrypoint.sh exports
+	// HIVE_CONFIG=/data/hive.yaml.runtime and logs "config path is read-only —
+	// using ... directly"; HIVE_CONFIG is read above only as the DEFAULT of
+	// -config, and the image's CMD passes that flag explicitly
+	// (Dockerfile: CMD ["--config", "/etc/hive/hive.yaml"]), so the explicit
+	// value won and the redirect did nothing.
+	//
+	// That is #4973, and it is silently destructive rather than merely wrong:
+	// the stale file loads, then Config.Save() writes the whole in-memory
+	// config back over /data/hive.yaml.runtime, destroying the state the
+	// operator had persisted there. An ACMM level set from the dashboard came
+	// back at its provisioned value after a restart, twice, with /data intact.
+	//
+	// entrypoint.sh now appends `--config "$HIVE_CONFIG"` to the argv so the
+	// last-occurrence-wins rule in flag.Parse carries the redirect, which means
+	// this branch should be unreachable. It is kept — at WARN, naming both
+	// paths — because the failure it reports is invisible from every other
+	// vantage point: /api/config/provenance reads HIVE_CONFIG directly, so it
+	// reports the file the entrypoint chose while the process runs on the one
+	// it did not, and the two disagree with no way to tell from the outside.
+	if envCfg := os.Getenv("HIVE_CONFIG"); envCfg != "" && envCfg != *configPath {
+		logger.Warn("config path disagreement: HIVE_CONFIG names a different file than the one loaded — an explicit -config (the image CMD) outranked the entrypoint's redirect; persisted state in HIVE_CONFIG may be overwritten by the next save",
+			"hive_config_env", envCfg,
+			"loaded_config", *configPath,
+		)
+	}
+
 	logger.Info("hive starting",
 		"org", cfg.Project.Org,
 		"repos", cfg.Project.Repos,

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -1339,6 +1339,48 @@ elif [ -f /data/proxy-ca.pem ]; then
   echo "[entrypoint] WARN: no system CA bundle at $SYSTEM_CA_BUNDLE; SSL_CERT_FILE=/data/proxy-ca.pem (proxy CA only)"
 fi
 
+# ── Config-path argv reconciliation (#4973) ───────────────────────────
+# Both config branches above have a read-only escape hatch: when the config
+# path cannot be written they `export HIVE_CONFIG=<runtime config>` and log
+# "config path is read-only — using ... directly". That export was INERT.
+#
+# main.go reads HIVE_CONFIG only to pick the DEFAULT of its -config flag:
+#
+#   defaultConfig := "/etc/hive/hive.yaml"
+#   if envCfg := os.Getenv("HIVE_CONFIG"); envCfg != "" { defaultConfig = envCfg }
+#   configPath := flag.String("config", defaultConfig, ...)
+#
+# and the image's own CMD passes the flag EXPLICITLY
+# (Dockerfile: CMD ["--config", "/etc/hive/hive.yaml"]), which outranks any
+# default. So on every hive whose config path is read-only — a bind-mounted
+# hive.yaml under docker/podman is the common case — the binary loaded the
+# stale read-only file while the entrypoint believed it had redirected it.
+#
+# The damage is not confined to that boot. Config.Save() writes
+# /data/hive.yaml.runtime unconditionally, so the first save of any kind
+# (dashboard edit, heartbeat-delivered config) wrote the STALE config back
+# over the runtime file that held the operator's real state. Observed as an
+# ACMM level set from the dashboard reverting on the next restart, twice, with
+# /data fully intact (#4973).
+#
+# main.go cannot fix this on its own: an explicit --config coming from the
+# image's CMD is indistinguishable from one an operator typed. The entrypoint
+# is the component that knows the config path is stale, so it has to say so in
+# the argv it actually launches with.
+#
+# APPENDED, not substituted: Go's flag package processes occurrences in order
+# and keeps the last, so `--config <stale> ... --config $HIVE_CONFIG` resolves
+# to HIVE_CONFIG without this script having to parse and rewrite the CMD.
+#
+# When HIVE_CONFIG is unset (the ordinary case, where the cp above succeeded
+# and the config path IS current) nothing is appended and the CMD applies
+# unchanged. When an operator sets HIVE_CONFIG themselves, this makes the
+# binary honour it — which is what the variable already means everywhere else
+# in this script (HIVE_CONFIG_PATH is derived from it at the top).
+if [ -n "${HIVE_CONFIG:-}" ]; then
+  set -- "$@" --config "$HIVE_CONFIG"
+  echo "[entrypoint] Config path pinned for the Go binary: --config $HIVE_CONFIG"
+fi
 echo "[entrypoint] Starting Go binary on :${HIVE_API_PORT} (uid=$(id -u))"
 hive "$@" &
 HIVE_PID=$!

--- a/src/docs/config-layering.md
+++ b/src/docs/config-layering.md
@@ -104,8 +104,10 @@ that does restore from it first; that variant is not what new hives get.
 
 **On Docker/LXC it is a live boot input, and the source of truth.** There is no
 ConfigMap and no overlay in that mode, so the entrypoint restores this file over
-the config path on every boot (or points `HIVE_CONFIG` straight at it when the
-config path is read-only). It is also the only reason a dashboard save survives
+the config path on every boot (or points `HIVE_CONFIG` straight at it, and
+pins the same path into the launch argv as `--config`, when the config path is
+read-only — the argv half is required, because the image's `CMD` passes an
+explicit `--config` that would otherwise outrank the variable, [#4973](https://github.com/kubestellar/hive/issues/4973)). It is also the only reason a dashboard save survives
 a container recreation: `Config.saveDashboardOverlay` deliberately early-returns
 outside Kubernetes because this file already plays that role.
 

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -6,7 +6,7 @@ This reference is compiled by hand from the Go source under `src/`, the deployme
 
 | Variable | Required | Default | Purpose |
 |---|---:|---|---|
-| `HIVE_CONFIG` | No | `/etc/hive/hive.yaml` | Default config path used before the `--config` flag is parsed. The dashboard also uses it when reporting config provenance. |
+| `HIVE_CONFIG` | No | `/etc/hive/hive.yaml` | Default config path used before the `--config` flag is parsed; an explicit `--config` outranks it, so `entrypoint.sh` also appends `--config "$HIVE_CONFIG"` to the launch argv when it is set ([#4973](https://github.com/kubestellar/hive/issues/4973)). The dashboard also uses it when reporting config provenance — which is why the two must not disagree. |
 | `HIVE_MODE` | No | spoke/dashboard mode | Set to `hub` to run the hub server instead of the spoke dashboard. |
 | `HIVE_HUB_PORT` | No | `3001` | Hub listen port when `HIVE_MODE=hub`. |
 | `HIVE_SINGLETON_LOCK` | No | `/var/run/hive-metrics/hive.singleton.lock` when available, otherwise OS temp dir | Overrides the process singleton lock path. Set exactly `off` only for local development where duplicate processes are intentional. |

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -182,7 +182,7 @@ installation instead of broadening the PAT.
 | Name | Source | Purpose |
 |---|---|---|
 | `--config` | flag | Path to `hive.yaml`; default `/etc/hive/hive.yaml` unless `HIVE_CONFIG` is set. |
-| `HIVE_CONFIG` | env | Overrides the default config path before `--config` is parsed. |
+| `HIVE_CONFIG` | env | Sets the **default** of `--config`. An explicit `--config` outranks it — and the image ships one (`CMD ["--config", "/etc/hive/hive.yaml"]`), so `entrypoint.sh` appends `--config "$HIVE_CONFIG"` to the launch argv when the variable is set. Without that append the variable is inert in the container ([#4973](https://github.com/kubestellar/hive/issues/4973)). |
 | `HIVE_MODE=hub` | env | Starts the hub server instead of a spoke dashboard. |
 | `HIVE_HUB_PORT` | env | Hub listen port in hub mode; default `3001`. |
 | `HIVE_SINGLETON_LOCK` | env | Internal/escape hatch for the process singleton lock path; value `off` disables the guard. |

--- a/src/pkg/config/entrypoint_boot_test.go
+++ b/src/pkg/config/entrypoint_boot_test.go
@@ -20,6 +20,15 @@ const entrypointPath = "../../deploy/entrypoint.sh"
 // executes the real branching logic, not a paraphrase of it.
 func runBootPrelude(t *testing.T, env map[string]string, files map[string]string) string {
 	t.Helper()
+	return runBootPreludeRO(t, env, files, nil)
+}
+
+// runBootPreludeRO is runBootPrelude with a set of files made read-only after
+// they are written, so a test can exercise the branches that fire when the
+// config path cannot be written — a bind-mounted hive.yaml under docker/podman
+// is the ordinary way that happens.
+func runBootPreludeRO(t *testing.T, env map[string]string, files map[string]string, readOnly []string) string {
+	t.Helper()
 	src, err := os.ReadFile(entrypointPath)
 	if err != nil {
 		t.Skipf("entrypoint.sh not readable from this package: %v", err)
@@ -44,6 +53,20 @@ func runBootPrelude(t *testing.T, env map[string]string, files map[string]string
 	body := text[:end]
 	body = strings.ReplaceAll(body, `"/data/`, `"`+root+`/data/`)
 	body = strings.ReplaceAll(body, `/etc/hive/hive.yaml`, root+"/etc/hive/hive.yaml")
+
+	for _, rel := range readOnly {
+		p := filepath.Join(root, rel)
+		if err := os.Chmod(p, 0o444); err != nil {
+			t.Fatal(err)
+		}
+		// The parent directory must be read-only too, or `cp` simply unlinks
+		// and recreates the file rather than failing — which is precisely the
+		// distinction the read-only branch turns on.
+		if err := os.Chmod(filepath.Dir(p), 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(filepath.Dir(p), 0o755) })
+	}
 
 	cmd := exec.Command("bash", "-c", body)
 	cmd.Env = append(os.Environ(), "HIVE_CONFIG="+root+"/etc/hive/hive.yaml")
@@ -109,5 +132,166 @@ func TestK8sNoConfigAtAllFailsLoudly(t *testing.T) {
 		map[string]string{})
 	if !strings.Contains(out, "ERROR: no runtime config") {
 		t.Fatalf("missing config did not fail loudly:\n%s", out)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// #4973 — the entrypoint's read-only redirect must reach the Go binary
+// ─────────────────────────────────────────────────────────────────────────
+
+// requireUnprivileged skips a test that depends on file permissions actually
+// denying a write. Root bypasses the mode bits, so the read-only branch under
+// test would never be taken and the assertion would be vacuous rather than
+// wrong — say so instead of passing for the wrong reason.
+func requireUnprivileged(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode bits do not deny writes, so the read-only branch cannot be exercised")
+	}
+}
+
+// TestDockerReadOnlyConfigPathRedirectsToRuntimeConfig is the PRECONDITION of
+// #4973: on a non-Kubernetes hive whose config path is read-only, the
+// entrypoint must fall back to reading the PVC runtime config directly, and it
+// signals that by exporting HIVE_CONFIG.
+//
+// The config path keeps its stale contents in this branch — that is the whole
+// point, it could not be written — so everything downstream depends on the
+// export being honoured.
+func TestDockerReadOnlyConfigPathRedirectsToRuntimeConfig(t *testing.T) {
+	requireUnprivileged(t)
+	out := runBootPreludeRO(t,
+		map[string]string{"KUBERNETES_SERVICE_HOST": ""},
+		map[string]string{
+			"data/hive.yaml.runtime": "acmm_level: 4\n",
+			"etc/hive/hive.yaml":     "acmm_level: 3\n", // stale, and unwritable
+		},
+		[]string{"etc/hive/hive.yaml"})
+
+	if !strings.Contains(out, "Config path is read-only") {
+		t.Fatalf("read-only config path did not take the redirect branch:\n%s", out)
+	}
+	if !strings.Contains(out, "hive.yaml.runtime") {
+		t.Fatalf("the redirect did not name the runtime config:\n%s", out)
+	}
+}
+
+// launchArgvAfterReconciliation runs ONLY the argv-reconciliation block that
+// precedes the `hive "$@" &` launch, with argv preset to the image's default
+// CMD, and returns the argv the binary would actually receive.
+//
+// Extracted from the real script by marker, like runBootPrelude, so the test
+// covers the shipped line rather than a paraphrase of it.
+func launchArgvAfterReconciliation(t *testing.T, hiveConfigEnv string) []string {
+	t.Helper()
+	src, err := os.ReadFile(entrypointPath)
+	if err != nil {
+		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+	}
+	text := string(src)
+
+	const startMarker = "# ── Config-path argv reconciliation (#4973)"
+	const endMarker = `echo "[entrypoint] Starting Go binary`
+	start := strings.Index(text, startMarker)
+	if start < 0 {
+		t.Fatal("entrypoint.sh no longer contains the config-path argv reconciliation block; the #4973 redirect is inert again")
+	}
+	end := strings.Index(text[start:], endMarker)
+	if end < 0 {
+		t.Fatal("could not find the Go binary launch after the reconciliation block; the markers moved and this test would silently cover nothing")
+	}
+	block := text[start : start+end]
+
+	// The image's CMD, verbatim from src/Dockerfile.
+	script := `set -- "--config" "/etc/hive/hive.yaml"` + "\n" + block + "\n" + `printf '%s\n' "$@"`
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "HIVE_CONFIG="+hiveConfigEnv)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("running the reconciliation block: %v", err)
+	}
+	var argv []string
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if strings.HasPrefix(line, "[entrypoint]") {
+			continue // the block's own log line
+		}
+		argv = append(argv, line)
+	}
+	return argv
+}
+
+// TestRedirectedConfigPathReachesTheBinaryArgv is the #4973 regression.
+//
+// The entrypoint exported HIVE_CONFIG and stopped there. main.go reads that
+// variable only to choose the DEFAULT of -config, and the image's CMD passes
+// -config EXPLICITLY, so the explicit value won: the hive loaded the stale
+// read-only file the entrypoint had just decided not to use. Config.Save()
+// then wrote that stale config back over /data/hive.yaml.runtime, so an ACMM
+// level set from the dashboard reverted on the next restart and stayed
+// reverted.
+//
+// The last occurrence of a repeated flag wins in flag.Parse, so appending the
+// redirect is what makes it effective.
+func TestRedirectedConfigPathReachesTheBinaryArgv(t *testing.T) {
+	argv := launchArgvAfterReconciliation(t, "/data/hive.yaml.runtime")
+
+	if len(argv) < 2 {
+		t.Fatalf("argv = %q, want the CMD plus an appended --config", argv)
+	}
+	gotFlag, gotValue := argv[len(argv)-2], argv[len(argv)-1]
+	if gotFlag != "--config" || gotValue != "/data/hive.yaml.runtime" {
+		t.Errorf("argv = %q; the LAST --config must be the entrypoint's redirect (/data/hive.yaml.runtime), or flag.Parse keeps the stale CMD value", argv)
+	}
+}
+
+// TestUnsetHiveConfigLeavesArgvAlone: when the config path was writable the
+// entrypoint copies the runtime config over it and exports nothing, so the
+// image CMD must apply unchanged. This is the ordinary boot, and the fix must
+// not perturb it.
+func TestUnsetHiveConfigLeavesArgvAlone(t *testing.T) {
+	argv := launchArgvAfterReconciliation(t, "")
+
+	want := []string{"--config", "/etc/hive/hive.yaml"}
+	if len(argv) != len(want) || argv[0] != want[0] || argv[1] != want[1] {
+		t.Errorf("argv = %q, want the untouched CMD %q", argv, want)
+	}
+}
+
+// TestLaunchUsesTheReconciledArgv guards the other half of the fix: rewriting
+// "$@" only helps if the launch still passes "$@". A launch rebuilt from
+// explicit arguments would silently drop the redirect and restore #4973 with
+// every test above still green.
+func TestLaunchUsesTheReconciledArgv(t *testing.T) {
+	src, err := os.ReadFile(entrypointPath)
+	if err != nil {
+		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+	}
+	if !strings.Contains(string(src), `hive "$@" &`) {
+		t.Error(`entrypoint.sh no longer launches the binary as 'hive "$@" &'; the argv reconciliation above it can no longer reach the process`)
+	}
+}
+
+// TestDockerfileCMDAndEntrypointAgreeOnConfigPath pins the COUPLING that broke.
+//
+// The bug was not in either file alone: the Dockerfile passing -config
+// explicitly is fine, and the entrypoint exporting HIVE_CONFIG is fine. It is
+// the combination that made the export inert. So if the image ever again ships
+// an explicit -config in its CMD, the entrypoint must still carry the
+// reconciliation that outranks it.
+func TestDockerfileCMDAndEntrypointAgreeOnConfigPath(t *testing.T) {
+	dockerfile, err := os.ReadFile("../../Dockerfile")
+	if err != nil {
+		t.Skipf("Dockerfile not readable from this package: %v", err)
+	}
+	if !strings.Contains(string(dockerfile), `CMD ["--config"`) {
+		t.Skip("the image CMD no longer passes -config explicitly; the coupling this guards is gone")
+	}
+	entry, err := os.ReadFile(entrypointPath)
+	if err != nil {
+		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+	}
+	if !strings.Contains(string(entry), `set -- "$@" --config "$HIVE_CONFIG"`) {
+		t.Error("the image CMD passes -config explicitly but entrypoint.sh no longer appends its own; HIVE_CONFIG is inert again (#4973)")
 	}
 }


### PR DESCRIPTION
## Summary

If your hive's `hive.yaml` is mounted read-only — the normal thing under Docker/podman — then **every config change you made from the dashboard was being thrown away on restart**, and then permanently destroyed.

The chain is short:

1. The entrypoint notices it can't write `/etc/hive/hive.yaml`, so it decides to read your real config from `/data/hive.yaml.runtime` instead. It announces this by setting `HIVE_CONFIG`.
2. **The binary never saw that.** It only uses `HIVE_CONFIG` to pick a *default*, and the container image already passes `--config /etc/hive/hive.yaml` explicitly. An explicit flag beats a default, so the hive booted from the stale file the entrypoint had just rejected.
3. The next save of any kind then wrote that stale config *back over* `/data/hive.yaml.runtime` — so the good state wasn't just ignored, it was overwritten.

That's why the reporter saw an ACMM level go L4 → L3 on every restart with `/data` completely intact (#4973).

**The fix:** the entrypoint now also appends `--config "$HIVE_CONFIG"` to the command line it launches, so its decision actually reaches the process. If your config path *is* writable, nothing changes at all.

Fixes #4973.

---

## Root cause

`src/cmd/hive/main.go`:

```go
defaultConfig := "/etc/hive/hive.yaml"
if envCfg := os.Getenv("HIVE_CONFIG"); envCfg != "" {
    defaultConfig = envCfg
}
configPath := flag.String("config", defaultConfig, "path to hive.yaml config file")
```

`src/Dockerfile`:

```dockerfile
CMD ["--config", "/etc/hive/hive.yaml"]
```

`HIVE_CONFIG` only moves the **default**. The CMD supplies the flag **explicitly**, which outranks it. So both read-only escape hatches in `entrypoint.sh` — the Docker one at `:282` and the identical K8s one at `:111` — were writing a log line and changing nothing:

```sh
export HIVE_CONFIG="$HIVE_CONFIG_SOURCE"
echo "[entrypoint] Config path is read-only — using $HIVE_CONFIG_SOURCE directly"
```

Neither file is wrong by itself. It is the **pairing** that is broken, which is why it survived review of each.

### Why the loss became permanent

`Config.Save()` writes `RuntimeConfigFile` unconditionally (`config.go:5142`). So after booting on the stale config, the first save of any kind — a dashboard edit, a heartbeat-delivered config — serialised the stale in-memory config over `/data/hive.yaml.runtime`. That is what turns "wrong for one boot" into "your L4 is gone".

### Why it was invisible from outside

`/api/config/provenance` reads `os.Getenv("HIVE_CONFIG")` directly for `seed_path`. It therefore reported `/data/hive.yaml.runtime` — the file the *entrypoint* chose — while the process was running on `/etc/hive/hive.yaml`. This exactly matches the reporter's observation that the middle row of their table looked correct: the dashboard save really did land in the file provenance was reading, it just wasn't the file the hive would boot from. It also explains why the three candidate causes in the issue couldn't be told apart from the boot log — the log line that ran (`Config path is read-only — using ... directly`) was truthful about the *decision* and silent about the decision having no effect.

## Verification

Measured against the real `entrypoint.sh` and a stub binary with `main.go`'s exact flag-resolution logic, with a read-only config path holding `acmm_level: 3` and a runtime config holding `acmm_level: 4`:

| | entrypoint log | config the binary resolved | level loaded |
|---|---|---|---|
| before | `Config path is read-only — using .../hive.yaml.runtime directly` | `/etc/hive/hive.yaml` | **3** ❌ |
| after | same, plus `Config path pinned for the Go binary: --config .../hive.yaml.runtime` | `/data/hive.yaml.runtime` | **4** ✅ |

Also confirmed directly that Go's `flag` package keeps the **last** occurrence of a repeated flag, which is what makes appending sufficient:

```
HIVE_CONFIG=/data/hive.yaml.runtime  --config /etc/hive/hive.yaml                                 -> /etc/hive/hive.yaml
HIVE_CONFIG=/data/hive.yaml.runtime  --config /etc/hive/hive.yaml --config /data/hive.yaml.runtime -> /data/hive.yaml.runtime
```

Test suite: `pkg/config` and `cmd/hive` pass. `pkg/config` has one pre-existing failure on this machine, `TestGateFailsClosedWithoutIP6Tables`, which needs `NET_ADMIN`; it fails identically on a clean checkout of `v4`.

## Changes

- **`src/deploy/entrypoint.sh`** — the fix. Appends `--config "$HIVE_CONFIG"` to the launch argv when the variable is set. Appended rather than substituted so `flag.Parse`'s last-wins rule carries it, without this script having to parse and rewrite the CMD. When `HIVE_CONFIG` is unset — every hive whose config path is writable — nothing is appended and behaviour is byte-identical.
- **`src/cmd/hive/main.go`** — `WARN` when the loaded config path disagrees with `HIVE_CONFIG`. Should now be unreachable; kept because this exact discrepancy was undetectable from any external vantage point.
- **`src/pkg/config/entrypoint_boot_test.go`** — five tests. They extract the real launch block from `entrypoint.sh` by marker (the existing `runBootPrelude` idiom) rather than paraphrasing it, and fail loudly if the marker moves. Verified to fail without the entrypoint change.
- Docs (`config-layering.md`, `env-vars.md`, `operator-reference.md`) and a `CHANGELOG.md` entry under `Unreleased → Fixed`.

## Scope note

The issue also flags `api_packs.go:535`, where a failed `saveConfig()` is logged but the handler still returns `200`. That's a fair criticism and I'd support fixing it — but it needs a decision this PR shouldn't make silently: at that point the in-memory level and every agent's `Mode` have already been mutated, so returning `500` means either rolling those back or returning an error alongside completed side effects. It's a behavioural change to the API contract, independent of this root cause, and better reviewed on its own. Deliberately left out rather than forgotten.

Note also that this bug was *not* the cause of the misleading provenance output described in #4971 — that's a separate defect in `Layer.Path()`/`Writer()` and is still open.

— hive: backend=claude model=claude-opus-5
