### PR TITLE
fix(dashboard): cache /api/repo-cost on a ticker instead of per-request

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2106,6 +2106,17 @@ func main() {
 	activityCollector.EnablePersistence("/data/activity.json")
 	go activityCollector.Start(ctx)
 
+	// Per-repo cost collector: joins the same audited output events against
+	// the token collector's per-message usage timeline, on the same ticker
+	// interval as the activity collector above, and caches the result for
+	// /api/repo-cost. Before this (#4943), the interval join — including
+	// the same expensive audit read the activity collector does — ran on
+	// every 60s dashboard poll, per open browser tab, instead of once per
+	// collection interval.
+	repoCostCollector := dashboard.NewRepoCostCollector(dashSrv.GetAudit(), tokenCollector, "", logger)
+	repoCostCollector.EnablePersistence("/data/repo-cost.json")
+	go repoCostCollector.Start(ctx)
+
 	// Persistent hourly metrics behind the Operations + Leaderboard sparklines
 	// (queue depth, tasks/hour, fleet size, per-contributor completions). The
 	// store loads any prior 7-day history from the /data PVC on first use and the
@@ -2535,6 +2546,7 @@ func main() {
 		// 30-minute collect loop instead of issuing a second GitHub fetch.
 		FleetStats:            fleetStatsCollector,
 		Activity:              activityCollector,
+		RepoCost:              repoCostCollector,
 		BeadSynthesizer:       beadSynth,
 		BeadStores:            beadStores,
 		BeadStoreLoadFailures: beadStoreLoadFailures,

--- a/src/docs/api-reference.md
+++ b/src/docs/api-reference.md
@@ -155,6 +155,7 @@ Auth levels are derived from dashboard middleware (`isPublicPath`, dashboard tok
 | `GET` | `/api/tokens` | Dashboard auth/session | Tokens | `pkg/dashboard/api.go:82` |
 | `GET` | `/api/cost` | Dashboard auth/session | Cost | `pkg/dashboard/api.go:83` |
 | `GET` | `/api/repo-activity` | Dashboard auth/session | Per-repo audited activity | `pkg/dashboard/api.go` |
+| `GET` | `/api/repo-cost` | Dashboard auth/session | Per-repo estimated token cost (interval join, cached) | `pkg/dashboard/api.go` |
 | `GET` | `/api/cost/history` | Dashboard auth/session | Cost History | `pkg/dashboard/api.go:84` |
 | `GET` | `/api/trend/history` | Dashboard auth/session | Trend History | `pkg/dashboard/api.go:85` |
 | `GET` | `/api/timeseries` | Dashboard auth/session | Time Series | `pkg/dashboard/api.go:86` |

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -50,8 +50,13 @@ type Dependencies struct {
 	// already uses keeps the advisor read-only and adds zero GitHub traffic.
 	// Nil is safe: Snapshot() on a nil collector reports ready=false and the
 	// advisor leaves the signal at its conservative zero.
-	FleetStats      *FleetStatsCollector
-	Activity        *ActivityCollector
+	FleetStats *FleetStatsCollector
+	Activity   *ActivityCollector
+	// RepoCost caches the /api/repo-cost interval join on a ticker (see
+	// repo_cost_collector.go), mirroring Activity's caching of
+	// /api/repo-activity. Nil is safe: handleRepoCost falls back to computing
+	// inline (used by tests that construct a bare Dependencies).
+	RepoCost        *RepoCostCollector
 	BeadSynthesizer *knowledge.BeadSynthesizer
 	BeadStores      map[string]*beads.Store
 	// BeadStoreLoadFailures counts configured bead stores that failed to open at

--- a/src/pkg/dashboard/repo_cost.go
+++ b/src/pkg/dashboard/repo_cost.go
@@ -141,6 +141,16 @@ type repoCostResponse struct {
 	PriceTableDate string   `json:"price_table_date"`
 	Disclaimer     string   `json:"disclaimer"`
 	Limitations    []string `json:"limitations"`
+
+	// CollectedAt is when this snapshot was actually computed by
+	// RepoCostCollector (repo_cost_collector.go), NOT when this HTTP response
+	// was served — those now differ by up to repoCostCollectInterval because
+	// the endpoint serves a cached snapshot rather than recomputing per
+	// request (#4943). Zero when no collection has ever completed (Ready is
+	// then also false). A consumer diffing against time.Now() can detect a
+	// stalled collector — a stuck ticker goroutine — the same way a stale
+	// heartbeat is detected elsewhere in the dashboard.
+	CollectedAt time.Time `json:"collected_at,omitempty"`
 }
 
 // repoCostLimitations is surfaced in the payload so the UI renders the method's
@@ -261,6 +271,7 @@ func computeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 		Limitations:        repoCostLimitations(),
 		Unattributed:       repoCostEntry{Repo: repoCostBucketUnattributed, Source: "estimated"},
 		BackendUnsupported: repoCostEntry{Repo: repoCostBucketBackendUnsupported, Source: "estimated"},
+		CollectedAt:        now,
 	}
 	if summary == nil {
 		return resp
@@ -416,8 +427,41 @@ func attributeRepo(events []repoAuditEvent, tsMs, windowStartMs int64) (repoAudi
 	return events[i], true
 }
 
-// handleRepoCost serves GET /api/repo-cost.
+// handleRepoCost serves GET /api/repo-cost from the cached RepoCostCollector
+// snapshot (see repo_cost_collector.go) rather than recomputing the interval
+// join per request. The join reads every rotated/compressed audit backup
+// (up to 64MB decompressed each) and walks every retained Claude usage
+// event in the window — recomputing that on every 60s dashboard poll, per
+// open tab, was the defect fixed by #4943.
+//
+// When the collector has not produced a snapshot yet (fresh boot, before its
+// first ticker fire), this reports ready=false with an EMPTY by_repo/zero
+// totals and no CollectedAt — never a fabricated $0.00. A cost payload with
+// ready=true and an empty by_repo is indistinguishable from "this hive spent
+// nothing", which is exactly the misreporting the #4836 epic exists to
+// prevent, so the not-ready state must stay visibly different from that.
 func (s *Server) handleRepoCost(w http.ResponseWriter, r *http.Request) {
+	if s.deps != nil && s.deps.RepoCost != nil {
+		snap, ready := s.deps.RepoCost.Snapshot()
+		if !ready {
+			jsonResponse(w, repoCostResponse{
+				Phase:              "phase_3_interval_join",
+				ByRepo:             []repoCostEntry{},
+				PriceTableDate:     tokens.PriceTableDate(),
+				Disclaimer:         costEstimateDisclaimer,
+				Limitations:        repoCostLimitations(),
+				Unattributed:       repoCostEntry{Repo: repoCostBucketUnattributed, Source: "estimated"},
+				BackendUnsupported: repoCostEntry{Repo: repoCostBucketBackendUnsupported, Source: "estimated"},
+			})
+			return
+		}
+		jsonResponse(w, snap)
+		return
+	}
+
+	// No collector wired (e.g. a minimal test Server): fall back to computing
+	// inline so the endpoint still degrades to a correct answer rather than
+	// 503ing. Production always wires RepoCost (see cmd/hive/main.go).
 	now := time.Now()
 	var summary *tokens.AggregateSummary
 	if s.deps != nil && s.deps.Tokens != nil {

--- a/src/pkg/dashboard/repo_cost_collector.go
+++ b/src/pkg/dashboard/repo_cost_collector.go
@@ -1,0 +1,194 @@
+package dashboard
+
+// RepoCostCollector caches the /api/repo-cost interval join on a ticker,
+// exactly the way ActivityCollector (activity_collector.go) already caches
+// /api/repo-activity's read of the same audit files. Before this collector
+// existed, handleRepoCost ran the full join — including OutputActionsSince,
+// which globs the current audit file plus every rotated backup, decompressing
+// .gz ones up to 64MB each — on every request, and the dashboard polls that
+// endpoint every 60s per open tab (#4943).
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/tokens"
+)
+
+// repoCostCollectInterval mirrors activityCollectInterval on purpose: this
+// collector reads the SAME audit window as the activity collector (see
+// repoCostWindow = activityWindow) to feed the interval join, so there is no
+// reason for the two caches to go stale at different rates — a dashboard
+// comparing repo-activity counts against repo-cost dollars would otherwise be
+// looking at two different moments in time. If a reason to diverge ever shows
+// up (e.g. cost being materially more expensive to compute than activity),
+// change this constant alone; the join itself does not assume the value.
+var repoCostCollectInterval = activityCollectInterval
+
+// tokensSummaryReader is the subset of *tokens.Collector the collector needs,
+// so it can be faked in tests without a full token collector.
+type tokensSummaryReader interface {
+	Summary() *tokens.AggregateSummary
+}
+
+// RepoCostCollector recomputes the per-repo cost interval join on a ticker and
+// serves the last computed snapshot, instead of recomputing per HTTP request.
+// Mirrors ActivityCollector's lifecycle (EnablePersistence/Start/Snapshot).
+type RepoCostCollector struct {
+	mu     sync.Mutex
+	audit  auditReader
+	tokens tokensSummaryReader
+	// auditPath is where OutputActionsSince reads ("" -> the production audit
+	// log). Kept in sync with the activity collector's path so both caches
+	// read the identical file set — see auditPathForActivity.
+	auditPath   string
+	logger      *slog.Logger
+	nowFn       func() time.Time
+	persistPath string
+
+	snap        repoCostResponse
+	ready       bool
+	collectedAt time.Time
+}
+
+// persistedRepoCost is the on-disk sidecar shape, mirroring persistedActivity.
+type persistedRepoCost struct {
+	Snapshot    repoCostResponse `json:"snapshot"`
+	CollectedAt time.Time        `json:"collected_at"`
+}
+
+// NewRepoCostCollector builds a collector that joins audit output events
+// against the token collector's usage timeline. audit or tokens nil makes it
+// inert (Snapshot ready=false forever). auditPath is where OutputActionsSince
+// reads ("" -> the production audit log; pass the same path the activity
+// collector uses so both read one file set).
+func NewRepoCostCollector(audit auditReader, tok tokensSummaryReader, auditPath string, logger *slog.Logger) *RepoCostCollector {
+	return &RepoCostCollector{
+		audit:     audit,
+		tokens:    tok,
+		auditPath: auditPath,
+		logger:    logger,
+		nowFn:     time.Now,
+	}
+}
+
+// EnablePersistence mirrors each collect to path and restores whatever is
+// there now, so the first poll after a restart reports the last computed
+// snapshot (with its true CollectedAt, so staleness is still visible) rather
+// than losing it and going back through "not ready". Missing file = clean
+// first boot; corrupt = logged + ignored. Call once before Start.
+func (rc *RepoCostCollector) EnablePersistence(path string) {
+	if rc == nil {
+		return
+	}
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.persistPath = path
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) && rc.logger != nil {
+			rc.logger.Warn("repo-cost store unreadable — starting fresh", "path", path, "error", err)
+		}
+		return
+	}
+	var stored persistedRepoCost
+	if err := json.Unmarshal(data, &stored); err != nil {
+		if rc.logger != nil {
+			rc.logger.Warn("repo-cost store corrupt — starting fresh", "path", path, "error", err)
+		}
+		return
+	}
+	if stored.CollectedAt.IsZero() {
+		return
+	}
+	rc.snap = stored.Snapshot
+	rc.collectedAt = stored.CollectedAt
+	rc.ready = true
+}
+
+func (rc *RepoCostCollector) persistLocked() {
+	if rc.persistPath == "" {
+		return
+	}
+	data, err := json.Marshal(persistedRepoCost{Snapshot: rc.snap, CollectedAt: rc.collectedAt})
+	if err != nil {
+		return
+	}
+	tmp := rc.persistPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		if rc.logger != nil {
+			rc.logger.Warn("failed to write repo-cost store", "path", rc.persistPath, "error", err)
+		}
+		return
+	}
+	if err := os.Rename(tmp, rc.persistPath); err != nil && rc.logger != nil {
+		rc.logger.Warn("failed to replace repo-cost store", "path", rc.persistPath, "error", err)
+	}
+}
+
+// Start runs the collect loop until ctx is cancelled — once up front, then
+// every repoCostCollectInterval. Inert (returns) when there is no audit
+// reader or no token reader: the join needs both sides.
+func (rc *RepoCostCollector) Start(ctx context.Context) {
+	if rc == nil || rc.audit == nil || rc.tokens == nil {
+		return
+	}
+	rc.collect()
+	ticker := time.NewTicker(repoCostCollectInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rc.collect()
+		}
+	}
+}
+
+// collect runs the interval join over the current window and caches the
+// result. Identical inputs to what handleRepoCost used to compute inline —
+// same window, same audit path, same summary source — just on a ticker.
+func (rc *RepoCostCollector) collect() {
+	now := rc.nowFn()
+	summary := rc.tokens.Summary()
+	entries := rc.audit.OutputActionsSince(now.Add(-repoCostWindow), activityOutputActions, rc.auditPath)
+	resp := computeRepoCost(summary, entries, now)
+
+	rc.mu.Lock()
+	rc.snap = resp
+	rc.collectedAt = now
+	rc.ready = resp.Ready
+	rc.persistLocked()
+	rc.mu.Unlock()
+}
+
+// Snapshot returns the last computed response and whether a collect has ever
+// succeeded (i.e. produced a non-nil token summary; see computeRepoCost).
+// Ready=false must never be papered over with a zero-valued response by the
+// caller — a cost endpoint reporting $0.00 before its first collection is
+// indistinguishable from a hive that genuinely spent nothing, which is
+// exactly the misreporting #4836 exists to prevent.
+func (rc *RepoCostCollector) Snapshot() (repoCostResponse, bool) {
+	if rc == nil {
+		return repoCostResponse{}, false
+	}
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	return rc.snap, rc.ready
+}
+
+// CollectedAt returns when the cached snapshot was last computed (zero if
+// never).
+func (rc *RepoCostCollector) CollectedAt() time.Time {
+	if rc == nil {
+		return time.Time{}
+	}
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	return rc.collectedAt
+}

--- a/src/pkg/dashboard/repo_cost_collector_test.go
+++ b/src/pkg/dashboard/repo_cost_collector_test.go
@@ -1,0 +1,253 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/tokens"
+)
+
+// countingAuditReader wraps a real audit fixture and counts how many times
+// OutputActionsSince was called, so a test can assert the served endpoint did
+// NOT re-read the audit files on a second poll within the collect interval —
+// that is the actual defect #4943 fixes. A response-shape-only test would
+// still pass even if the cache were deleted, since handleRepoCost's fallback
+// path produces an identical-looking payload; only a call-count assertion
+// proves the cache is doing anything.
+type countingAuditReader struct {
+	inner auditReader
+	calls int32
+}
+
+func (c *countingAuditReader) OutputActionsSince(since time.Time, actions map[string]bool, filePath string) []AuditEntry {
+	atomic.AddInt32(&c.calls, 1)
+	return c.inner.OutputActionsSince(since, actions, filePath)
+}
+
+// fakeTokensSummary returns a fixed *tokens.AggregateSummary, so a test does
+// not need a real *tokens.Collector backed by session files on disk.
+type fakeTokensSummary struct {
+	summary *tokens.AggregateSummary
+}
+
+func (f *fakeTokensSummary) Summary() *tokens.AggregateSummary { return f.summary }
+
+// newRepoCostFixtureServer builds a Server wired with a RepoCostCollector
+// over a counting audit reader and a fixed token summary, with the collector
+// already run once (collect()) so Snapshot() is ready. Returns the server and
+// the counting reader so a test can assert on call counts.
+func newRepoCostFixtureServer(t *testing.T) (*Server, *countingAuditReader) {
+	t.Helper()
+	now := time.Now().UTC()
+	base := now.Add(-24 * time.Hour)
+
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		rcSession("s1", "scanner",
+			rcUsage(rcTime(base, 15), 200, 20), // between e@10 and e@20 -> repo-b
+		),
+	}}
+
+	inner := &fakeFixedAudit{entries: entries}
+	counting := &countingAuditReader{inner: inner}
+
+	rc := NewRepoCostCollector(counting, &fakeTokensSummary{summary: summary}, "", nil)
+	rc.nowFn = func() time.Time { return now }
+	rc.collect()
+
+	s := NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterAPI(&Dependencies{RepoCost: rc})
+	return s, counting
+}
+
+// fakeFixedAudit is an auditReader that always returns the same entries,
+// regardless of since/actions/filePath — good enough to drive the collector
+// in a test without a real audit file on disk.
+type fakeFixedAudit struct{ entries []AuditEntry }
+
+func (f *fakeFixedAudit) OutputActionsSince(_ time.Time, _ map[string]bool, _ string) []AuditEntry {
+	return f.entries
+}
+
+func getRepoCost(s *Server) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/repo-cost", nil)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHandleRepoCostServesCachedSnapshotWithoutReReading is the fix's core
+// assertion: two polls of /api/repo-cost within the collect interval must
+// read the audit files exactly ONCE total (from the single collect() the
+// fixture ran), not once per request. Before #4943 this would have been two
+// reads (and, in production, two full gunzip-and-join passes).
+func TestHandleRepoCostServesCachedSnapshotWithoutReReading(t *testing.T) {
+	s, counting := newRepoCostFixtureServer(t)
+
+	before := atomic.LoadInt32(&counting.calls)
+	if before != 1 {
+		t.Fatalf("collector's own collect() must have read the audit once, got %d calls", before)
+	}
+
+	rec1 := getRepoCost(s)
+	rec2 := getRepoCost(s)
+
+	if rec1.Code != http.StatusOK || rec2.Code != http.StatusOK {
+		t.Fatalf("status = %d, %d; want 200, 200", rec1.Code, rec2.Code)
+	}
+	after := atomic.LoadInt32(&counting.calls)
+	if after != before {
+		t.Fatalf("handleRepoCost must serve the cached snapshot, not re-read: calls went from %d to %d across 2 requests", before, after)
+	}
+
+	var body1, body2 repoCostResponse
+	if err := json.Unmarshal(rec1.Body.Bytes(), &body1); err != nil {
+		t.Fatalf("invalid JSON (req 1): %v", err)
+	}
+	if err := json.Unmarshal(rec2.Body.Bytes(), &body2); err != nil {
+		t.Fatalf("invalid JSON (req 2): %v", err)
+	}
+	if body1.CollectedAt.IsZero() || !body1.CollectedAt.Equal(body2.CollectedAt) {
+		t.Fatalf("both requests must report the SAME collection time, got %v and %v", body1.CollectedAt, body2.CollectedAt)
+	}
+	if !body1.Ready {
+		t.Fatalf("snapshot from a completed collect() must report ready=true")
+	}
+}
+
+// TestHandleRepoCostNotReadyBeforeFirstCollect pins the honesty requirement:
+// before any collection has completed, the endpoint must report ready=false
+// with an empty by_repo and no fabricated total — never a $0.00 that reads
+// identically to "this hive spent nothing".
+func TestHandleRepoCostNotReadyBeforeFirstCollect(t *testing.T) {
+	rc := NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	// Deliberately do NOT call collect(): simulates the window between
+	// process start and the collector's first ticker fire.
+
+	s := NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterAPI(&Dependencies{RepoCost: rc})
+
+	rec := getRepoCost(s)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	var body repoCostResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if body.Ready {
+		t.Fatalf("must report ready=false before the first collection, got ready=true: %+v", body)
+	}
+	if len(body.ByRepo) != 0 {
+		t.Fatalf("not-ready response must not fabricate by_repo entries, got %+v", body.ByRepo)
+	}
+	if body.TotalUSD != 0 || body.TotalTokens != 0 {
+		// These being the zero value here is fine — the point under test is
+		// Ready being false, which the caller MUST check before trusting any
+		// zero value as "nothing was spent" rather than "not measured yet".
+		t.Logf("zero totals reported alongside ready=false, as expected (caller must gate on Ready)")
+	}
+	if !body.CollectedAt.IsZero() {
+		t.Fatalf("not-ready response must not carry a CollectedAt, got %v", body.CollectedAt)
+	}
+}
+
+// TestRepoCostPartitionInvariantServedPath re-asserts the epic's hard
+// requirement — Σby_repo+unattributed+backend_unsupported == hive total — but
+// through the ACTUAL served path (RepoCostCollector.collect -> Snapshot ->
+// handleRepoCost -> HTTP JSON), not just the pure compute function. The
+// existing TestRepoCostPartitionInvariant in repo_cost_test.go only proves
+// computeRepoCost is correct; this proves the caching layer introduced by
+// #4943 does not lose or duplicate anything on the way to the wire.
+func TestRepoCostPartitionInvariantServedPath(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	base := now.Add(-24 * time.Hour)
+
+	summary := &tokens.AggregateSummary{Sessions: []tokens.SessionSummary{
+		rcSession("s1", "scanner",
+			rcUsage(rcTime(base, 5), 100, 10),
+			rcUsage(rcTime(base, 15), 200, 20),
+			rcUsage(rcTime(base, 25), 300, 30),
+		),
+		rcSession("s2", "lonely", rcUsage(rcTime(base, 15), 400, 40)),
+		{SessionID: "s3", Agent: "reviewer", Model: "gpt-5", Backend: tokens.BackendCopilot,
+			InputTokens: 500, OutputTokens: 50, TotalTokens: 550},
+	}}
+	var hiveTotal int64
+	for _, sess := range summary.Sessions {
+		hiveTotal += sess.TotalTokens
+	}
+
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+
+	rc := NewRepoCostCollector(&fakeFixedAudit{entries: entries}, &fakeTokensSummary{summary: summary}, "", nil)
+	rc.nowFn = func() time.Time { return now }
+	rc.collect()
+
+	s := NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.RegisterAPI(&Dependencies{RepoCost: rc})
+
+	rec := getRepoCost(s)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	var body repoCostResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !body.Ready {
+		t.Fatalf("expected ready=true, got %+v", body)
+	}
+
+	sum := body.Unattributed.Tokens + body.BackendUnsupported.Tokens
+	for _, e := range body.ByRepo {
+		sum += e.Tokens
+	}
+	if sum != hiveTotal {
+		t.Fatalf("served-path partition broken: Σby_repo+unattributed+backend_unsupported = %d, hive total = %d", sum, hiveTotal)
+	}
+	if body.TotalTokens != hiveTotal {
+		t.Fatalf("served TotalTokens = %d, want %d", body.TotalTokens, hiveTotal)
+	}
+}
+
+// TestRepoCostCollectorPersistsAcrossRestart mirrors ActivityCollector's
+// EnablePersistence contract: a fresh collector pointed at a prior snapshot
+// file must report ready=true immediately, with the ORIGINAL CollectedAt
+// preserved, before its own first ticker fire — so a restart does not present
+// a stale-but-labeled-fresh figure, and does not regress to not-ready either.
+func TestRepoCostCollectorPersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/repo-cost.json"
+
+	original := NewRepoCostCollector(&fakeFixedAudit{entries: []AuditEntry{
+		rcEvent(time.Now().Add(-time.Hour), "scanner", "org/repo-a"),
+	}}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	fixedNow := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Second)
+	original.nowFn = func() time.Time { return fixedNow }
+	original.EnablePersistence(path)
+	original.collect()
+
+	restarted := NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	restarted.EnablePersistence(path)
+
+	snap, ready := restarted.Snapshot()
+	if !ready {
+		t.Fatal("restored collector must report ready=true without waiting for its own first collect")
+	}
+	if !snap.CollectedAt.Equal(fixedNow) {
+		t.Fatalf("restored CollectedAt = %v, want %v (the ORIGINAL collection time, not now)", snap.CollectedAt, fixedNow)
+	}
+}


### PR DESCRIPTION
## Problem

`handleRepoCost` (`src/pkg/dashboard/repo_cost.go`) recomputed the full per-repo cost interval join from scratch on every `GET /api/repo-cost` request — including `OutputActionsSince`, which globs the current audit file plus all rotated backups (decompressing `.gz` ones, up to 64MB decompressed each), and a walk of every retained Claude usage event over the 14-day window. The dashboard polls this endpoint every 60s per open tab, so every open tab repeated that work every minute.

The phase-1 sibling (`activity_collector.go`, `/api/repo-activity`) already solved this exact problem: it reads the same files over the same window on a 5-minute ticker and serves from a cached snapshot. This PR applies the identical pattern to `/api/repo-cost`.

## What changed

- **New `RepoCostCollector`** (`src/pkg/dashboard/repo_cost_collector.go`), structured like `ActivityCollector`: runs the interval join (`computeRepoCost`) on a ticker, caches the result, supports `EnablePersistence` for restart continuity.
- **`handleRepoCost` now serves the cached snapshot** instead of recomputing per request. A fallback inline-compute path is kept for the case no collector is wired (bare test `Server`s), so the handler degrades gracefully rather than requiring the collector.
- **Wired into `cmd/hive/main.go`**: constructed and started right after the activity collector, persisted to `/data/repo-cost.json`, and added to `Dependencies.RepoCost`.
- **`docs/api-reference.md`**: added the missing `/api/repo-cost` row (added in #4884, never documented).

## Caching interval

Reuses `activityCollectInterval` (**5 minutes**), not a new constant. The cost join reads the identical audit window the activity collector already reads (`repoCostWindow = activityWindow`), so there's no reason for the two caches to drift out of sync — a dashboard comparing repo-activity counts against repo-cost dollars should be looking at the same moment in time. If a reason to diverge ever comes up, only `repoCostCollectInterval` needs to change; it's a separate `var`, documented in code.

## Not-ready state

Before the collector's first collection completes, `Snapshot()` returns `ready=false`. `handleRepoCost` then serves an explicit not-ready payload: **empty `by_repo`, zero totals, no `collected_at`** — never a fabricated `$0.00`. A `$0.00`/empty response with `ready=true` would be indistinguishable from "this hive spent nothing," which is exactly the misreporting the #4836 epic exists to prevent. A completed collection that happens to find zero spend still reports `ready=true` with real (zero) totals — a different, honest fact from "not measured yet."

The response also now carries `collected_at` (when the snapshot was actually computed), separate from when the HTTP response was served, so a stale snapshot — e.g. a stuck ticker goroutine — is visible to a consumer diffing against wall-clock time, rather than silently presented as current.

## Partition invariant

Still holds on the served path. The existing `TestRepoCostPartitionInvariant` continues to cover the pure `computeRepoCost` function. Added `TestRepoCostPartitionInvariantServedPath`, which asserts `Σ by_repo + unattributed + backend_unsupported == hive total` through the actual served path (collector → `Snapshot()` → `handleRepoCost` → HTTP JSON), proving the caching layer itself doesn't lose or duplicate tokens on the way to the wire.

## Test quality

`TestHandleRepoCostServesCachedSnapshotWithoutReReading` uses a call-counting `auditReader` wrapper to assert that two polls of `/api/repo-cost` within the collect interval read the audit files **exactly once total**, not once per request — the actual defect this PR fixes. A response-shape-only test would still pass even if the cache were deleted, since the handler's no-collector fallback path produces an identical-looking payload; only a call-count assertion proves the cache is doing anything.

Also added:
- `TestHandleRepoCostNotReadyBeforeFirstCollect` — pins the not-fabricated-zero requirement.
- `TestRepoCostCollectorPersistsAcrossRestart` — a restored collector reports `ready=true` with the *original* `CollectedAt` before its own first tick, mirroring `ActivityCollector`'s restart contract.

## Constraints followed

- No local build/test/lint run — CI is the gate.
- Signed commit (DCO), no Co-Authored-By.
- Not merging; not pushed to `v4`.

Fixes #4943
