### PR TITLE
fix(config): provenance layer identity is environment-aware; #4973 diagnosed, not fixed

### DIFF
--- a/src/pkg/config/layers.go
+++ b/src/pkg/config/layers.go
@@ -125,9 +125,19 @@ func (l Layer) String() string {
 // Path returns where an operator must write to change a field won by this
 // layer. This is the answer to the question that took four attempts during the
 // GitHub Enterprise incident.
+//
+// LayerSeed is environment-aware, gated on the same IsKubernetesPod() the
+// layering itself already uses (see config.go). In Kubernetes the seed really
+// is the ConfigMap. Outside Kubernetes there is no ConfigMap at all — the seed
+// is RuntimeConfigFile, a plain file on the PVC that Save() rewrites on every
+// dashboard save (see saveLocked, config.go:5141) — so naming the ConfigMap
+// there points an operator at a layer that does not exist (#4971).
 func (l Layer) Path() string {
 	switch l {
 	case LayerSeed:
+		if !IsKubernetesPod() {
+			return RuntimeConfigFile
+		}
 		return "ConfigMap hive-config (key hive.yaml)"
 	case LayerDashboardOverlay:
 		return DashboardOverlayFile
@@ -144,14 +154,24 @@ func (l Layer) Path() string {
 // the provenance API so an operator can see not just which layer won but
 // whether editing it is even possible.
 //
-// The ConfigMap's answer — "nobody" — is the single most useful fact this
-// package exposes. Nothing in the system writes it: the hub only reads it, and
-// the spoke's RBAC omits configmaps entirely. An operator who edits it and
-// restarts will observe no change, which is exactly what happened four times
-// in a row during the GHE incident.
+// In Kubernetes, the ConfigMap's answer — "nobody" — is the single most
+// useful fact this package exposes. Nothing in the system writes it: the hub
+// only reads it, and the spoke's RBAC omits configmaps entirely. An operator
+// who edits it and restarts will observe no change, which is exactly what
+// happened four times in a row during the GHE incident.
+//
+// Outside Kubernetes there is no ConfigMap and no RBAC to omit — LayerSeed is
+// RuntimeConfigFile, which the spoke rewrites on every save (saveLocked,
+// config.go:5141) and the entrypoint restores over the boot config on every
+// restart (entrypoint.sh:267-311, Docker/LXC branch). Reporting "nobody" there
+// is the same misdirection in the opposite direction: it hides the one file
+// that actually decides the value (#4971).
 func (l Layer) Writer() string {
 	switch l {
 	case LayerSeed:
+		if !IsKubernetesPod() {
+			return "spoke (Config.Save)"
+		}
 		return "nobody (hub has read-only access; spoke RBAC omits configmaps)"
 	case LayerDashboardOverlay:
 		return "spoke (Config.Save) and hub (via heartbeat delivery)"
@@ -165,7 +185,16 @@ func (l Layer) Writer() string {
 }
 
 // Writable reports whether any running component can write this layer.
-func (l Layer) Writable() bool { return l != LayerSeed && l != LayerUnset }
+//
+// Outside Kubernetes LayerSeed is RuntimeConfigFile, which the spoke writes
+// directly (see Writer), so it is writable there even though the same layer
+// is genuinely unwritable ("nobody") in Kubernetes (#4971).
+func (l Layer) Writable() bool {
+	if l == LayerSeed {
+		return !IsKubernetesPod()
+	}
+	return l != LayerUnset
+}
 
 // seedKeys carries key-presence facts that survive only in raw YAML, so the
 // merge can be exactly faithful to the heredoc. See MergeLayersYAML.

--- a/src/pkg/config/layers_test.go
+++ b/src/pkg/config/layers_test.go
@@ -236,18 +236,54 @@ func TestIsPublicExplicitFalseInSeedStillWins(t *testing.T) {
 // ─────────────────────────────────────────────────────────────────────────
 
 func TestSeedIsWritableByNobody(t *testing.T) {
-	// The single most useful fact this package exposes. The hub has only a
-	// "get" against configmaps and the spoke's RBAC omits them entirely, so
-	// editing the ConfigMap and restarting changes nothing — which is what
-	// happened four times during the GHE incident.
+	// The single most useful fact this package exposes IN KUBERNETES. The hub
+	// has only a "get" against configmaps and the spoke's RBAC omits them
+	// entirely, so editing the ConfigMap and restarting changes nothing — which
+	// is what happened four times during the GHE incident.
+	//
+	// Explicitly forces Kubernetes mode: without this, the test's answer
+	// depended on whether the test host looked like a pod, which is exactly
+	// the gap #4971 shipped through (see
+	// TestSeedIsWritableOutsideKubernetes for the other branch, and
+	// TestProvenanceReportsSeedWritableOutsideKubernetes in pkg/dashboard for
+	// the end-to-end regression test).
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1") // IsKubernetesPod() → true
 	if LayerSeed.Writable() {
 		t.Error("LayerSeed.Writable() = true, want false")
 	}
 	if w := LayerSeed.Writer(); !strings.Contains(w, "nobody") {
 		t.Errorf("LayerSeed.Writer() = %q, want it to say nobody", w)
 	}
+	if p := LayerSeed.Path(); !strings.Contains(p, "ConfigMap") {
+		t.Errorf("LayerSeed.Path() = %q, want it to name the ConfigMap", p)
+	}
 	if !LayerDashboardOverlay.Writable() {
 		t.Error("LayerDashboardOverlay.Writable() = false, want true")
+	}
+}
+
+// TestSeedIsWritableOutsideKubernetes is the #4971 regression test at the
+// Layer-metadata level (see TestProvenanceReportsSeedWritableOutsideKubernetes
+// in pkg/dashboard for the end-to-end HTTP version). Outside Kubernetes there
+// is no ConfigMap and no RBAC to omit: LayerSeed is RuntimeConfigFile, a plain
+// file the spoke rewrites on every save (saveLocked, config.go:5141). Reporting
+// writable=false / writer=nobody / path=ConfigMap there sends an operator
+// looking for something that does not exist while hiding the file that
+// actually decides the value.
+func TestSeedIsWritableOutsideKubernetes(t *testing.T) {
+	// No KUBERNETES_SERVICE_HOST and (on any normal test host) no
+	// serviceaccount token — IsKubernetesPod() reads false.
+	if !LayerSeed.Writable() {
+		t.Error("LayerSeed.Writable() = false outside Kubernetes, want true — RuntimeConfigFile is writable by the spoke")
+	}
+	if w := LayerSeed.Writer(); strings.Contains(w, "nobody") {
+		t.Errorf("LayerSeed.Writer() = %q, want it to name the spoke, not nobody (there is no RBAC to omit outside Kubernetes)", w)
+	}
+	if p := LayerSeed.Path(); strings.Contains(p, "ConfigMap") {
+		t.Errorf("LayerSeed.Path() = %q, want the real runtime file, not a ConfigMap that does not exist on this hive", p)
+	}
+	if p := LayerSeed.Path(); p != RuntimeConfigFile {
+		t.Errorf("LayerSeed.Path() = %q, want RuntimeConfigFile (%q)", p, RuntimeConfigFile)
 	}
 }
 

--- a/src/pkg/dashboard/api_provenance_test.go
+++ b/src/pkg/dashboard/api_provenance_test.go
@@ -102,8 +102,15 @@ func TestProvenanceAnswersTheGHEQuestion(t *testing.T) {
 }
 
 // TestProvenanceReportsSeedUnwritable pins the single most valuable line in
-// the report: nothing can write the ConfigMap.
+// the report: in Kubernetes, nothing can write the ConfigMap.
+//
+// Explicitly forces Kubernetes mode (#4971): this test previously ran
+// whatever IsKubernetesPod() detected on the test host — normally not a pod —
+// so it was silently exercising the non-Kubernetes branch and would not have
+// caught #4971's regression to the wrong environment's answer. See
+// TestProvenanceReportsSeedWritableOutsideKubernetes for the other branch.
 func TestProvenanceReportsSeedUnwritable(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1") // IsKubernetesPod() → true
 	writeProvenanceFixture(t,
 		"project:\n  org: acme\nagents:\n  scanner: {}\nhub:\n  is_public: true\n",
 		"project:\n  org: acme\nagents:\n  scanner: {}\n")
@@ -124,6 +131,65 @@ func TestProvenanceReportsSeedUnwritable(t *testing.T) {
 	}
 	if !strings.Contains(seedLayer.Writer, "nobody") {
 		t.Errorf("configmap-seed writer = %q, want it to say nobody", seedLayer.Writer)
+	}
+	if !strings.Contains(seedLayer.Path, "ConfigMap") {
+		t.Errorf("configmap-seed path = %q, want it to name the ConfigMap", seedLayer.Path)
+	}
+}
+
+// TestProvenanceReportsSeedWritableOutsideKubernetes is the #4971 regression
+// test: on a non-Kubernetes hive (Docker/podman/LXC) there is no ConfigMap and
+// no RBAC to omit — LayerSeed is RuntimeConfigFile, a plain file the spoke
+// rewrites on every save (saveLocked, config.go:5141) and the entrypoint
+// restores over the boot config on every restart (entrypoint.sh:267-311). The
+// report must say so: writable=true, writer names the spoke, and the path
+// names the real file — never the ConfigMap, which does not exist here.
+func TestProvenanceReportsSeedWritableOutsideKubernetes(t *testing.T) {
+	// No KUBERNETES_SERVICE_HOST set and no serviceaccount token on this host
+	// — IsKubernetesPod() reads false, matching a real Docker/podman hive.
+	writeProvenanceFixture(t,
+		"project:\n  org: acme\nagents:\n  scanner: {}\nhub:\n  is_public: true\nacmm_level: 4\n",
+		"project:\n  org: acme\nagents:\n  scanner: {}\n")
+
+	_, body := getProvenance(t, "owner")
+
+	var seedLayer *layerInfo
+	for i := range body.Layers {
+		if body.Layers[i].Name == "configmap-seed" {
+			seedLayer = &body.Layers[i]
+		}
+	}
+	if seedLayer == nil {
+		t.Fatal("layer legend omits configmap-seed")
+	}
+	if !seedLayer.Writable {
+		t.Error("configmap-seed reported writable=false outside Kubernetes, want true — RuntimeConfigFile is writable by the spoke")
+	}
+	if strings.Contains(seedLayer.Writer, "nobody") {
+		t.Errorf("configmap-seed writer = %q, want it to name the spoke, not nobody (there is no RBAC to omit outside Kubernetes)", seedLayer.Writer)
+	}
+	if strings.Contains(seedLayer.Path, "ConfigMap") {
+		t.Errorf("configmap-seed path = %q, want the real runtime file, not a ConfigMap that does not exist on this hive", seedLayer.Path)
+	}
+	if !strings.Contains(seedLayer.Path, "hive.yaml.runtime") {
+		t.Errorf("configmap-seed path = %q, want it to name RuntimeConfigFile (hive.yaml.runtime)", seedLayer.Path)
+	}
+
+	// acmm_level in the fixture is set only in the seed (no overlay override),
+	// so it is won by LayerSeed — the field-level report must carry the same
+	// writable/writer/path facts as the layer legend above.
+	acmm, ok := fieldByName(body.Fields, "acmm_level")
+	if !ok {
+		t.Fatal("acmm_level missing from fields")
+	}
+	if acmm.Layer != "configmap-seed" {
+		t.Fatalf("acmm_level layer = %q, want configmap-seed (test setup assumption)", acmm.Layer)
+	}
+	if !acmm.Writable {
+		t.Error("acmm_level reported writable=false outside Kubernetes, want true")
+	}
+	if strings.Contains(acmm.Writer, "nobody") {
+		t.Errorf("acmm_level writer = %q, want it to name the spoke, not nobody", acmm.Writer)
 	}
 }
 


### PR DESCRIPTION
## Summary

Investigates both config-layer bugs Danathar filed with reproduction evidence. #4971 is fixed. #4973 is diagnosed but **not fixed** — the mechanism the issue describes could not be reproduced from the code, and CONTRIBUTING.md's bar ("a wrong fix is worse than none" for a silent-revert bug) means I'm not guessing at one.

They do **not** share a root cause. #4971 is a pure reporting bug in `Layer.Path()`/`Writer()`/`Writable()` — it changes no config value. #4973 is a real persisted-value change across a boot, and every code path that could cause it reads correctly on inspection.

## #4971 — provenance reports a Kubernetes layer on non-Kubernetes hives

**Root cause:** `Layer.Path()`, `Layer.Writer()` and `Layer.Writable()` in `src/pkg/config/layers.go` (pre-fix lines 128–168) were hardcoded `switch` statements with no environment awareness — exactly as the issue's evidence names. `LayerSeed` always rendered as `"ConfigMap hive-config (key hive.yaml)"` / `"nobody (hub has read-only access; spoke RBAC omits configmaps)"` / `writable: false`, regardless of `IsKubernetesPod()` (`src/pkg/config/config.go:5227`), which the *layering* logic (`MergeLayers`, same file) already consults but the *metadata* methods did not.

Outside Kubernetes, `LayerSeed` is actually `RuntimeConfigFile` (`/data/hive.yaml.runtime`, `config.go:5193`) — a plain file the spoke rewrites unconditionally on every `Config.Save()` (`saveLocked`, `config.go:5141-5155`) and the entrypoint restores over the boot config path on every restart (`entrypoint.sh:267-311`, the Docker/LXC branch). It is genuinely writable by the spoke; reporting it as a nonexistent, unwritable ConfigMap is the exact misdirection the package exists to prevent, pointed the wrong way.

**Fix:** gate all three methods on `IsKubernetesPod()` for `LayerSeed`, reporting `RuntimeConfigFile` / `"spoke (Config.Save)"` / `writable: true` outside Kubernetes. `Layer.String()` is untouched — it's the documented stable identifier in the provenance contract, per the issue's own note.

**Test-quality note:** the existing K8s-shape tests (`TestSeedIsWritableByNobody` in `layers_test.go`, `TestProvenanceReportsSeedUnwritable` in `api_provenance_test.go`) never pinned `KUBERNETES_SERVICE_HOST` — they passed only because the CI/dev host they ran on doesn't look like a pod, so `IsKubernetesPod()` happened to read `false` and the test's assertions happened to still hold before this fix by coincidence of what the old hardcoded switch always returned. That's the same blind spot the issue calls out ("current tests appear to cover the Kubernetes shape only"). Both now explicitly `t.Setenv("KUBERNETES_SERVICE_HOST", ...)`, and I added `TestSeedIsWritableOutsideKubernetes` and `TestProvenanceReportsSeedWritableOutsideKubernetes` as the non-Kubernetes counterparts — the latter is an end-to-end HTTP-handler test that asserts the exact `writable`/`writer`/`path` triple an operator would see, for both the layer legend and a real field (`acmm_level`) won by the seed.

## #4973 — ACMM level reverts across a restart

**Not fixed. Diagnosed as far as static reading permits; every mechanism traced reads correctly.**

I traced the full write→persist→boot→resolve chain the reporter's evidence points at:

- **Write path** (`src/pkg/dashboard/api_packs.go` `applyPack`): sets `s.deps.Config.ACMMLevel = &level`, calls `s.saveConfig()` → `Config.Save()` → `saveLocked()`, which writes both `c.SourcePath` **and** `RuntimeConfigFile` unconditionally (`config.go:5141-5155`), matching the reporter's own confirmation that provenance read back `4` before the restart.
- **Boot restore** (`entrypoint.sh:267-311`, Docker/LXC branch): `hive_runtime_config_read()` prefers `hive.yaml.runtime` over the legacy `.bak` name, copies it over `HIVE_CONFIG_PATH` (or exports `HIVE_CONFIG` to point at it directly if the mount is read-only), and distinguishes first-boot / steady-state / wiped-to-zero / missing cases correctly. The reporter's evidence (kick history intact, not first boot) rules out the first-boot branch (candidate 2) and a wiped volume.
- **Go boot-time precedence** (`src/cmd/hive/main.go:2888-2925`): explicitly comments "config file authoritative on restarts; HIVE_LEVEL env var is only a fallback", and the code matches — `cfg.ACMMLevel` (from the file) is checked *before* `saved.ACMMLevel` (from `/data/hive-state.json`) or `HIVE_LEVEL`. `HIVE_LEVEL` cannot override a present file value (rules out candidate: env re-applied every boot).
- **`ApplyPack` at startup** (`applyPack`, `api_packs.go`): re-derives `level` from the same precedence chain and re-saves it — it does not reset the level to anything else (rules out candidate 3, an ApplyPack reset, as the mechanism — though see the note below).
- **State snapshot aging** (`src/pkg/snapshot/state.go` `LoadState`): treats state older than 7 days as absent, which would push boot into the "first boot" `HIVE_LEVEL`-only branch — but the reporter's restart was the same day, well under that window, so this doesn't apply here either.

Every one of these reads correctly in isolation. That means if `acmm_level: 4` really was in `/data/hive.yaml.runtime` at the moment of restart, `cfg.ACMMLevel` should load as `4` and nothing downstream should touch it. Since the reporter observed `3` after restart, either:

1. The file the entrypoint actually restored over `HIVE_CONFIG_PATH` did **not** contain `4` — despite `saveLocked` having written it — which would mean something *else* rewrote `/data/hive.yaml.runtime` (or the legacy `.bak`) back to `3` between the dashboard save and the restart, independent of a normal boot; or
2. The entrypoint took a different branch than the Docker/LXC one I traced (unlikely given the reporter confirmed `IsKubernetesPod()` is false and cited `entrypoint.sh:267`); or
3. Candidate 1 from the issue — `hive_runtime_config_read` resolving the legacy `.bak` file, which still held `3` — if this hive's `.bak` predates the `.runtime` rename and somehow raced with or superseded the `.runtime` write. The read function prefers `.runtime` when non-empty, so this requires `.runtime` to have been briefly empty/missing at exactly the read instant, which I cannot confirm or rule out without the container's log.

None of these is something I can confirm by reading source. Per CONTRIBUTING.md and the task's explicit guidance, I'm not shipping a guess for a silent-persistence bug — a wrong fix here would make the next reproduction harder to interpret, not easier.

### What evidence would resolve it

The reporter already identified the right artifact and the exact grep. Restated for whoever picks this up:

```bash
podman logs <hive-container> 2>&1 | grep -E "^\[entrypoint\].*(config|runtime|First boot|PVC runtime|Migration)"
```

Specifically need, from the boot that reverted the level:
- Which of the four Docker-branch log lines fired (`entrypoint.sh:281`, `287`, `290`, `297`, `303`) — this alone distinguishes "restored from `.runtime`" vs "restored from legacy `.bak`" vs "first boot: seeded" vs "recovered from empty".
- The content of `/data/hive.yaml.runtime` and `/data/hive.yaml.bak` (if present) on the affected hive, specifically each file's `acmm_level` — to see directly whether `.runtime` ever actually held `3` after the dashboard save, or whether `.bak` is the one holding `3` and got picked up.
- Timestamps (mtime) on both files relative to the dashboard save and the restart, to catch a race.

If `.runtime` is confirmed to hold `4` at restart time and the log shows the `.runtime`-restore branch fired, the bug is downstream of the entrypoint (something in the Go process rewriting the level after boot) and this diagnosis is wrong in a way worth knowing. If `.runtime` holds `3` (or is missing) at restart time, the bug is upstream of what this PR traced (something rewrites `.runtime` after the save but before the restart), and the fix would need to find that write — none of the writers I found are candidates for it.

## Testing

`TestSeedIsWritableByNobody` / `TestSeedIsWritableOutsideKubernetes` (`src/pkg/config/layers_test.go`) and `TestProvenanceReportsSeedUnwritable` / `TestProvenanceReportsSeedWritableOutsideKubernetes` (`src/pkg/dashboard/api_provenance_test.go`) assert the `writable`/`writer`/`path` triple in both environments, at both the `Layer` unit level and the full `/api/config/provenance` HTTP response — they fail if the environment-gating regresses in either direction.

No test for #4973 since no fix is shipped for it.

Fixes #4971
Refs #4973

---

Do not merge — awaiting review per project policy on human-filed issues.
