### PR TITLE
fix: base PRs on the repository's default branch, not a hardcoded main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,23 @@ Hive did not historically maintain a complete changelog. This file starts a prag
   so the overlay stays secret-free. The
   documented `api_key: ${LINEAR_API_KEY}` form works from both `hive.yaml`
   and the dashboard.
+- PRs the hive opens are now based on the **target repository's default
+  branch** instead of a hardcoded `main`. Every PR the App filed on a repo
+  whose default branch is something else (e.g. `testing`) was opened against
+  `main`, so its diff carried the entire divergence between the two branches —
+  one reported PR showed 233 changed files and ~260k changed lines for a
+  one-file change, large enough that GitHub's diff API refused to serve it —
+  and merging it would have landed the change on the wrong branch. The base is
+  now resolved from the repo's own `default_branch` metadata (already covered
+  by the App's metadata:read permission, cached per repo), `hive-open-pr` no
+  longer pins `--base main` when the caller omits it, and sandbox kicks branch
+  from the default branch recorded in their own clone. An explicitly requested
+  base is still honored. Unlike an earlier draft of this fix, an unresolvable
+  repo does **not** fall back to guessing `main` — it fails the PR request (or
+  the sandbox kick) outright, with the reason surfaced in the retry/quarantine
+  log, because a wrong base is worse than a delayed PR
+  ([#4928](https://github.com/kubestellar/hive/issues/4928)).
+
 - Pull requests from forks can now satisfy `v4`'s required `gate` status context. `gate` is a job in `docker.yml`, which triggered on `push` only — and a fork PR's push event fires in the contributor's repo, not here, so `gate` never attached to the head SHA this repo evaluates and branch protection blocked the merge waiting for a check that could not arrive. Six fully green contributor PRs (#4930, #4932, #4934, #4935, #4936, #4937) were structurally unmergeable; `gate` was verified absent on every one of their head SHAs. It went unnoticed because `enforce_admins` is false, so maintainers' own merges silently bypassed the same missing check — the required context was in practice unenforced for maintainers and absolutely enforced for outside contributors. `docker.yml` now also triggers on `pull_request`, with every image-build job skipped for that event, so the context attaches to fork PRs at the cost of one ~5-second shell job and no image CI: the image is already built and smoke-tested on every PR by `v2-ci.yml` (`docker`, `build-and-test`, `overlayfs-exec-guard`). Push builds and GHCR publishing are unchanged — `gate` reports `push=false` for a PR event, so every `merge*` job stays skipped ([#4965](https://github.com/kubestellar/hive/issues/4965)).
 
 - The canonical `blocked` workflow overlay now stays out of the contributor

--- a/bin/hive-open-pr.sh
+++ b/bin/hive-open-pr.sh
@@ -15,7 +15,13 @@
 # Usage (drop-in for the common gh pr create shape):
 #   hive-open-pr --repo <owner/repo> --head <branch> [--base <branch>] \
 #                --title "<title>" --body "<body>"
-#   # --head defaults to the current git branch; --base defaults to main.
+#   # --head defaults to the current git branch. --base is OPTIONAL and should
+#   # normally be omitted: an omitted base is left empty in the request so the
+#   # hive resolves the TARGET REPOSITORY's default branch when it opens the PR.
+#   # Do not pass --base main "to be safe" — that is exactly the bug that based
+#   # every PR on main in repos whose default branch is not main
+#   # (kubestellar/hive#4928). Pass --base only to target a non-default branch
+#   # deliberately (a release line, a stacked PR).
 #
 # On success it prints the request path and returns 0. The PR opens
 # asynchronously (within one watcher tick); poll the .result.json next to the
@@ -26,7 +32,7 @@ set -euo pipefail
 
 REQ_DIR="/var/run/hive-metrics/pr-requests"
 
-REPO=""; HEAD=""; BASE="main"; TITLE=""; BODY=""
+REPO=""; HEAD=""; BASE=""; TITLE=""; BODY=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --repo)  REPO="$2"; shift 2;;
@@ -91,5 +97,5 @@ else
     > "$REQ_FILE"
 fi
 
-echo "hive-open-pr: requested PR on $REPO ($HEAD -> $BASE) as the App bot"
+echo "hive-open-pr: requested PR on $REPO ($HEAD -> ${BASE:-<repo default branch>}) as the App bot"
 echo "hive-open-pr: request $REQ_FILE (the hive opens the PR within ~10s; result appears at ${REQ_FILE%.json}.result.json)"

--- a/src/pkg/agent/sandbox_executor.go
+++ b/src/pkg/agent/sandbox_executor.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	DefaultSandboxKickTimeout = 45 * time.Minute
-	defaultSandboxBaseRef     = "main"
 	defaultSandboxNetworkMode = sandbox.NetworkModeRestricted
 	sandboxPromptRelPath      = ".hive/kick-prompt.txt"
 	sandboxTranscriptRelPath  = ".hive/sandbox-transcript.log"
@@ -97,16 +96,19 @@ func (e *SandboxExecutor) Run(ctx context.Context, spec SandboxKickSpec) (Sandbo
 	if spec.Timeout <= 0 {
 		spec.Timeout = DefaultSandboxKickTimeout
 	}
-	if spec.BaseRef == "" {
-		spec.BaseRef = defaultSandboxBaseRef
-	}
 	if spec.NetworkMode == "" {
 		spec.NetworkMode = defaultSandboxNetworkMode
 	}
 	if spec.Branch == "" {
 		spec.Branch = e.branchName(spec.Agent)
 	}
-	workspace, baseSHA, err := e.prepareWorkspace(ctx, spec)
+	// prepareWorkspace resolves spec.BaseRef from the clone's own
+	// refs/remotes/origin/HEAD when the caller did not pin one, so the PR
+	// opened below is based on the repo's own default branch rather than an
+	// assumed "main" (kubestellar/hive#4928). It fails the kick outright when
+	// the base cannot be determined and none was pinned — a wrong base is
+	// worse than a failed kick.
+	workspace, baseSHA, err := e.prepareWorkspace(ctx, &spec)
 	if err != nil {
 		res.Error = err.Error()
 		return res, err
@@ -200,7 +202,14 @@ func (e *SandboxExecutor) Run(ctx context.Context, spec SandboxKickSpec) (Sandbo
 	return res, nil
 }
 
-func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec SandboxKickSpec) (string, string, error) {
+// prepareWorkspace clones the target repo and checks out the work branch off
+// the base ref. When spec.BaseRef is empty it is RESOLVED from the clone's own
+// refs/remotes/origin/HEAD and written back into spec, so the caller opens its
+// PR against the same ref it branched from (kubestellar/hive#4928). If that
+// resolution fails, prepareWorkspace fails the kick rather than silently
+// falling back to "main" — a wrong base is worse than a failed kick, and the
+// error surfaces through res.Error into the kick result the operator sees.
+func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec *SandboxKickSpec) (string, string, error) {
 	if strings.TrimSpace(spec.Org) == "" || strings.TrimSpace(spec.Repo) == "" {
 		return "", "", errors.New("sandbox workspace prep requires org and repo")
 	}
@@ -221,6 +230,13 @@ func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec SandboxKick
 	if out, err := e.runner().Run(ctx, "", pushbroker.PushEnv(os.Environ()), "git", cloneArgs...); err != nil {
 		return "", "", fmt.Errorf("git clone: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+	if strings.TrimSpace(spec.BaseRef) == "" {
+		ref, err := e.resolveBaseRef(ctx, workspace)
+		if err != nil {
+			return "", "", fmt.Errorf("sandbox workspace prep: could not resolve %s/%s's default branch and no explicit base ref was given (refusing to guess %q): %w", spec.Org, spec.Repo, FallbackSandboxBaseRef, err)
+		}
+		spec.BaseRef = ref
+	}
 	fetchArgs := append(append([]string{}, authArgs...), "fetch", "origin", spec.BaseRef)
 	if out, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()), "git", fetchArgs...); err != nil {
 		return "", "", fmt.Errorf("git fetch %s: %w: %s", spec.BaseRef, err, strings.TrimSpace(string(out)))
@@ -233,6 +249,34 @@ func (e *SandboxExecutor) prepareWorkspace(ctx context.Context, spec SandboxKick
 		return "", "", fmt.Errorf("git rev-parse HEAD: %w", err)
 	}
 	return workspace, strings.TrimSpace(string(base)), nil
+}
+
+// FallbackSandboxBaseRef names the branch resolveBaseRef would have used had
+// it not been made an error instead (kubestellar/hive#4928) — kept as a named
+// constant purely so the "refusing to guess" error message above never has a
+// bare string literal to drift out of sync with intent.
+const FallbackSandboxBaseRef = "main"
+
+// resolveBaseRef reports the default branch of the freshly cloned repo. `git
+// clone` records the remote's HEAD in refs/remotes/origin/HEAD, so the answer
+// is already on disk — no API call, no extra token scope. An unreadable or
+// empty answer is returned as an error so the caller can fail the kick rather
+// than silently branching off an assumed "main" (kubestellar/hive#4928).
+func (e *SandboxExecutor) resolveBaseRef(ctx context.Context, workspace string) (string, error) {
+	out, err := e.runner().Run(ctx, workspace, pushbroker.PushEnv(os.Environ()),
+		"git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", fmt.Errorf("reading refs/remotes/origin/HEAD: %w", err)
+	}
+	ref := strings.TrimSpace(string(out))
+	// symbolic-ref --short renders it as "origin/<branch>".
+	if _, branch, found := strings.Cut(ref, "/"); found {
+		ref = branch
+	}
+	if ref == "" {
+		return "", errors.New("refs/remotes/origin/HEAD resolved to an empty branch name")
+	}
+	return ref, nil
 }
 
 func (e *SandboxExecutor) cloneAuthArgs(ctx context.Context, repo, dir string) ([]string, func(), error) {

--- a/src/pkg/agent/sandbox_executor_baseref_test.go
+++ b/src/pkg/agent/sandbox_executor_baseref_test.go
@@ -1,0 +1,167 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	ghpkg "github.com/kubestellar/hive/pkg/github"
+)
+
+// Regression coverage for kubestellar/hive#4928 on the sandbox path: the
+// executor branched from, and opened its PR against, a hardcoded "main"
+// regardless of what the target repository's default branch actually is. `git
+// clone` already records the remote's HEAD, so the right answer was on disk the
+// whole time.
+
+// baseRefRunner is a git stub that reports a configurable default branch for
+// refs/remotes/origin/HEAD and records the ref the executor fetched.
+type baseRefRunner struct {
+	mu sync.Mutex
+
+	symbolicRef    string // what `git symbolic-ref --short refs/remotes/origin/HEAD` prints
+	symbolicRefErr error  // when set, the lookup fails instead
+
+	fetchedRef      string
+	symbolicRefRuns int
+	revParses       int
+}
+
+func (r *baseRefRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
+	if name != "git" {
+		return nil, errors.New("unexpected command")
+	}
+	effective := stripGitConfigArgs(args)
+	joined := strings.Join(effective, " ")
+	switch {
+	case len(effective) >= 4 && effective[0] == "clone":
+		workspace := effective[len(effective)-1]
+		return nil, os.MkdirAll(filepath.Join(workspace, ".git"), 0o770)
+	case joined == "symbolic-ref --short refs/remotes/origin/HEAD":
+		r.mu.Lock()
+		r.symbolicRefRuns++
+		r.mu.Unlock()
+		if r.symbolicRefErr != nil {
+			return nil, r.symbolicRefErr
+		}
+		return []byte(r.symbolicRef + "\n"), nil
+	case strings.HasPrefix(joined, "fetch origin "):
+		r.mu.Lock()
+		r.fetchedRef = strings.TrimPrefix(joined, "fetch origin ")
+		r.mu.Unlock()
+		return []byte("ok\n"), nil
+	case joined == "rev-parse HEAD":
+		// First answer is the base the workspace was branched from; later ones
+		// are the agent's commit, so commitsSince sees real work to push.
+		r.mu.Lock()
+		r.revParses++
+		n := r.revParses
+		r.mu.Unlock()
+		if n > 1 {
+			return []byte("headsha\n"), nil
+		}
+		return []byte("basesha\n"), nil
+	case joined == "rev-list --count basesha..HEAD":
+		return []byte("1\n"), nil
+	case joined == "rev-parse --verify basesha":
+		return []byte("basesha\n"), nil
+	case joined == "diff --name-only basesha...HEAD":
+		return []byte("file.txt\n"), nil
+	case joined == "diff --no-ext-diff basesha...HEAD":
+		return []byte("diff --git a/file.txt b/file.txt\n"), nil
+	case strings.Contains(joined, "push ") && strings.Contains(joined, " origin HEAD:refs/heads/"):
+		return []byte("pushed\n"), nil
+	default:
+		return []byte(""), nil
+	}
+}
+
+// baseRefPRClient records the base the executor asked the hive to open against.
+type baseRefPRClient struct{ base string }
+
+func (p *baseRefPRClient) CreatePR(_ context.Context, _, _, base, _, _ string) (ghpkg.CreatePRResult, error) {
+	p.base = base
+	return ghpkg.CreatePRResult{Number: 1, URL: "https://example.test/pr/1"}, nil
+}
+
+func runSandboxForBaseRef(t *testing.T, runner *baseRefRunner, specBase string) (*baseRefPRClient, SandboxKickResult, error) {
+	t.Helper()
+	pr := &baseRefPRClient{}
+	exec := &SandboxExecutor{
+		Runner:      runner,
+		Launcher:    sandboxFakeLauncher{},
+		PRClient:    pr,
+		PushEnabled: true,
+		Minter:      sandboxFakeMinter{},
+		Logger:      discardLogger(),
+	}
+	res, err := exec.Run(context.Background(), SandboxKickSpec{
+		Agent: "scanner", AgentConfig: configSnapshot{Backend: "claude"}, Message: "fix",
+		Org: "kubestellar", Repo: "hive", BaseRef: specBase,
+		WorkspaceDir: t.TempDir(), Image: "agent-image",
+	})
+	return pr, res, err
+}
+
+// TestSandboxExecutorBranchesFromRepoDefaultBranch asserts the invariant this
+// bug broke: a repository whose default branch is NOT "main" gets its PR based
+// on that branch. A test that only exercised a "main" default would pass even
+// with the old hardcoded behavior — this one fails if resolveBaseRef (or its
+// call site) is deleted.
+func TestSandboxExecutorBranchesFromRepoDefaultBranch(t *testing.T) {
+	runner := &baseRefRunner{symbolicRef: "origin/testing"}
+	pr, _, err := runSandboxForBaseRef(t, runner, "")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if runner.fetchedRef != "testing" {
+		t.Fatalf("fetched %q, want testing — the clone's own default branch", runner.fetchedRef)
+	}
+	if pr.base != "testing" {
+		t.Fatalf("PR opened against %q, want testing", pr.base)
+	}
+}
+
+// TestSandboxExecutorFailsKickWhenDefaultBranchUnreadable asserts requirement
+// 2: an unresolvable default branch must fail the kick rather than silently
+// substitute "main" — a wrong base is worse than a failed kick.
+func TestSandboxExecutorFailsKickWhenDefaultBranchUnreadable(t *testing.T) {
+	runner := &baseRefRunner{symbolicRefErr: errors.New("no origin/HEAD")}
+	_, res, err := runSandboxForBaseRef(t, runner, "")
+
+	if err == nil {
+		t.Fatal("expected the kick to fail when the default branch cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "could not resolve") {
+		t.Fatalf("error = %v, want it to explain the unresolved default branch", err)
+	}
+	if res.Error == "" {
+		t.Error("res.Error must carry the failure (the dashboard renders this field)")
+	}
+	if runner.fetchedRef != "" {
+		t.Fatalf("fetched %q, want no fetch at all — the kick must fail before guessing a base", runner.fetchedRef)
+	}
+}
+
+func TestSandboxExecutorHonorsPinnedBaseRef(t *testing.T) {
+	runner := &baseRefRunner{symbolicRef: "origin/testing"}
+	pr, _, err := runSandboxForBaseRef(t, runner, "release-1.2")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if runner.fetchedRef != "release-1.2" {
+		t.Fatalf("fetched %q, want the pinned release-1.2", runner.fetchedRef)
+	}
+	if pr.base != "release-1.2" {
+		t.Fatalf("PR opened against %q, want release-1.2", pr.base)
+	}
+	if runner.symbolicRefRuns != 0 {
+		t.Fatalf("pinned base still ran %d default-branch lookups, want 0", runner.symbolicRefRuns)
+	}
+}

--- a/src/pkg/agent/sandbox_executor_test.go
+++ b/src/pkg/agent/sandbox_executor_test.go
@@ -24,6 +24,11 @@ type sandboxFakeRunner struct {
 	commits  int
 	cloneDir string
 	revParse int
+	// defaultBranch is what `git symbolic-ref --short refs/remotes/origin/HEAD`
+	// reports for the clone; tests that don't care about default-branch
+	// resolution leave it at the zero value, which resolves to "main" below so
+	// existing fetch/checkout expectations keep working unchanged.
+	defaultBranch string
 }
 
 func (r *sandboxFakeRunner) Run(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
@@ -43,6 +48,12 @@ func (r *sandboxFakeRunner) Run(ctx context.Context, dir string, env []string, n
 			return nil, err
 		}
 		return nil, os.WriteFile(filepath.Join(workspace, ".git", "config"), []byte("[remote]\nurl = "+effective[len(effective)-2]+"\n"), 0o660)
+	case joined == "symbolic-ref --short refs/remotes/origin/HEAD":
+		branch := r.defaultBranch
+		if branch == "" {
+			branch = "main"
+		}
+		return []byte("origin/" + branch + "\n"), nil
 	case joined == "fetch origin main", strings.HasPrefix(joined, "checkout -B "):
 		return []byte("ok\n"), nil
 	case joined == "rev-parse HEAD":

--- a/src/pkg/github/attribution_test.go
+++ b/src/pkg/github/attribution_test.go
@@ -148,6 +148,11 @@ func attribPRMock(t *testing.T, postedBody *string) *httptest.Server {
 	var mu sync.Mutex
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/o/r"):
+			// DefaultBranch: the requests these tests write omit Base, so
+			// CreatePR resolves it here (kubestellar/hive#4928).
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			_, _ = io.WriteString(w, `[]`)
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -93,6 +93,15 @@ type Client struct {
 	// Zero values are ready to use.
 	prRetries     retryTracker
 	reviewRetries retryTracker
+	// defaultBranchMu guards defaultBranches, which memoizes the resolved
+	// default branch per "owner/repo" (see defaultbranch.go). A repo's default
+	// branch changes about as often as the repo is renamed, so caching it keeps
+	// the "what is this repo's base?" lookup off the hot path of every PR open
+	// without risking a stale answer that matters. Only successful lookups are
+	// cached — a transient API error must not pin a repo to the fallback for
+	// the life of the process.
+	defaultBranchMu sync.RWMutex
+	defaultBranches map[string]string
 	// mergerAuthz gates the label-queued auto-merge sweep on WHO queued the
 	// merge: it reports whether a login holds at least config.RoleMerger (audit
 	// F3). nil fails closed — SweepQueuedAutoMerges merges nothing. Guarded

--- a/src/pkg/github/defaultbranch.go
+++ b/src/pkg/github/defaultbranch.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FallbackDefaultBranch names the branch CreatePR would fall back to if it
+// chose to guess instead of failing (see CreatePR's doc): it does not, by
+// default, but the constant is kept so error messages that explain the
+// refusal never carry a bare string literal.
+//
+// It is a LAST resort, not a starting assumption. Hive used to hardcode it as
+// THE base for every PR it opened, which silently mis-targeted every
+// repository whose default branch is not "main": the PR's diff then carried
+// the entire divergence between the two branches, and merging it landed the
+// change on the wrong branch (kubestellar/hive#4928).
+const FallbackDefaultBranch = "main"
+
+// DefaultBranch resolves the default branch of owner/repo from the
+// repository's own metadata (the `default_branch` REST field — the API
+// behind `gh repo view --json defaultBranchRef`), which the App's
+// metadata:read permission already covers.
+//
+// The result is cached for the life of the process: a repo's default branch
+// changes about as often as the repo is renamed, so caching keeps this off
+// the hot path of every PR open. Only successful lookups are cached — a
+// transient API error must not pin the repo to a wrong answer until the next
+// restart.
+//
+// Unlike the original #4930 draft, this does NOT silently substitute
+// FallbackDefaultBranch on error: a lookup failure is returned to the caller
+// so it can choose to fail the PR request rather than open it against a base
+// nobody confirmed is right (kubestellar/hive#4928 requirement: a wrong base
+// is worse than a delayed PR). Callers that have no explicit base and cannot
+// tolerate a failed request may still choose to fall back to
+// FallbackDefaultBranch themselves, logging that decision.
+func (c *Client) DefaultBranch(ctx context.Context, owner, repo string) (string, error) {
+	if c == nil || c.client == nil {
+		return "", ErrNoGitHubClient
+	}
+	owner, repo = strings.TrimSpace(owner), strings.TrimSpace(repo)
+	if owner == "" || repo == "" {
+		return "", errors.New("DefaultBranch: owner and repo are required")
+	}
+	key := owner + "/" + repo
+	if branch, ok := c.cachedDefaultBranch(key); ok {
+		return branch, nil
+	}
+
+	r, _, err := c.client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return "", fmt.Errorf("resolving default branch for %s: %w", key, err)
+	}
+	branch := strings.TrimSpace(r.GetDefaultBranch())
+	if branch == "" {
+		// A repo with no default_branch is not a thing GitHub returns for a
+		// live repo, but an empty string here would cache a base of "" and
+		// make every later PR open fail — treat it as unresolved and do not
+		// cache it.
+		return "", fmt.Errorf("resolving default branch for %s: repository metadata reported an empty default branch", key)
+	}
+	c.storeDefaultBranch(key, branch)
+	return branch, nil
+}
+
+func (c *Client) cachedDefaultBranch(key string) (string, bool) {
+	c.defaultBranchMu.RLock()
+	defer c.defaultBranchMu.RUnlock()
+	branch, ok := c.defaultBranches[key]
+	return branch, ok
+}
+
+func (c *Client) storeDefaultBranch(key, branch string) {
+	c.defaultBranchMu.Lock()
+	defer c.defaultBranchMu.Unlock()
+	if c.defaultBranches == nil {
+		c.defaultBranches = map[string]string{}
+	}
+	c.defaultBranches[key] = branch
+}

--- a/src/pkg/github/defaultbranch_test.go
+++ b/src/pkg/github/defaultbranch_test.go
@@ -1,0 +1,120 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// repoMetadataServer serves GET /repos/{owner}/{repo} with the given
+// default_branch and counts how many times it was asked.
+func repoMetadataServer(t *testing.T, defaultBranch string, calls *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || !strings.HasSuffix(r.URL.Path, "/repos/org/repo") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		atomic.AddInt32(calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"name": "repo", "default_branch": defaultBranch})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestDefaultBranch_ResolvesFromRepoMetadata asserts the invariant this bug
+// broke: a repository whose default branch is NOT "main" resolves to that
+// branch, not to an assumption. A test using a repo whose default is "main"
+// would pass even with the old hardcoded behavior.
+func TestDefaultBranch_ResolvesFromRepoMetadata(t *testing.T) {
+	var calls int32
+	srv := repoMetadataServer(t, "testing", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	got, err := c.DefaultBranch(context.Background(), "org", "repo")
+	if err != nil {
+		t.Fatalf("DefaultBranch: %v", err)
+	}
+	if got != "testing" {
+		t.Fatalf("DefaultBranch = %q, want %q — the repo's own default branch, not an assumption", got, "testing")
+	}
+}
+
+func TestDefaultBranch_CachesResolvedBranch(t *testing.T) {
+	var calls int32
+	srv := repoMetadataServer(t, "develop", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	for i := 0; i < 3; i++ {
+		got, err := c.DefaultBranch(context.Background(), "org", "repo")
+		if err != nil {
+			t.Fatalf("lookup %d: DefaultBranch: %v", i, err)
+		}
+		if got != "develop" {
+			t.Fatalf("lookup %d: DefaultBranch = %q, want develop", i, got)
+		}
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("repo metadata fetched %d times, want 1 — the resolved branch must be cached", n)
+	}
+}
+
+func TestDefaultBranch_ErrorsWhenLookupFails(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	if _, err := c.DefaultBranch(context.Background(), "org", "repo"); err == nil {
+		t.Fatal("DefaultBranch on API error = nil error, want a returned error (the caller decides fallback vs failure)")
+	}
+	// A failed lookup must NOT be cached: a transient 5xx would otherwise pin
+	// this repo to a wrong answer for the rest of the process.
+	if _, err := c.DefaultBranch(context.Background(), "org", "repo"); err == nil {
+		t.Fatal("second lookup after a failure unexpectedly succeeded")
+	}
+	if n := atomic.LoadInt32(&calls); n != 2 {
+		t.Fatalf("repo metadata fetched %d times, want 2 — a failed lookup must not be cached", n)
+	}
+}
+
+func TestDefaultBranch_EmptyDefaultBranchErrors(t *testing.T) {
+	var calls int32
+	srv := repoMetadataServer(t, "", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+
+	if _, err := c.DefaultBranch(context.Background(), "org", "repo"); err == nil {
+		t.Fatal("DefaultBranch with empty metadata = nil error, want an error rather than caching an empty base")
+	}
+}
+
+func TestDefaultBranch_NilAndEmptyInputs(t *testing.T) {
+	var nilClient *Client
+	if _, err := nilClient.DefaultBranch(context.Background(), "org", "repo"); err == nil {
+		t.Fatal("nil receiver: want an error, not a silent fallback")
+	}
+	if _, err := (&Client{}).DefaultBranch(context.Background(), "org", "repo"); err == nil {
+		t.Fatal("nil inner client: want an error, not a silent fallback")
+	}
+
+	var calls int32
+	srv := repoMetadataServer(t, "testing", &calls)
+	c := NewClientForTest(srv.URL, "org", nil, prTestLogger())
+	if _, err := c.DefaultBranch(context.Background(), "  ", "repo"); err == nil {
+		t.Fatal("blank owner: want an error")
+	}
+	if _, err := c.DefaultBranch(context.Background(), "org", ""); err == nil {
+		t.Fatal("blank repo: want an error")
+	}
+	if n := atomic.LoadInt32(&calls); n != 0 {
+		t.Fatalf("blank owner/repo issued %d API calls, want 0", n)
+	}
+}

--- a/src/pkg/github/hive_open_pr_script_test.go
+++ b/src/pkg/github/hive_open_pr_script_test.go
@@ -1,0 +1,115 @@
+package github
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// bin/hive-open-pr.sh is what agents run INSTEAD of `gh pr create`; it writes
+// the PRRequest this package's watcher consumes. It used to default BASE to
+// "main", which meant an agent that (correctly) said nothing about the base
+// still pinned every PR to "main" — so no amount of default-branch resolution
+// inside CreatePR could have helped: the request already carried the wrong
+// answer (kubestellar/hive#4928).
+//
+// These tests exercise the real script, following gh_app_token_script_test.go,
+// rather than a paraphrase of it.
+
+const hiveOpenPRScriptPath = "../../../bin/hive-open-pr.sh"
+
+// runHiveOpenPR executes the real script with its request dir redirected into a
+// temp root, and returns the single request it wrote.
+func runHiveOpenPR(t *testing.T, args ...string) PRRequest {
+	t.Helper()
+	src, err := os.ReadFile(hiveOpenPRScriptPath)
+	if err != nil {
+		t.Skipf("hive-open-pr.sh not readable from this package: %v", err)
+	}
+	for _, tool := range []string{"bash", "python3"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available: %v", tool, err)
+		}
+	}
+
+	root := t.TempDir()
+	reqDir := filepath.Join(root, "pr-requests")
+
+	// Point the hard-coded request dir at the temp root. If this literal ever
+	// stops matching, the test would silently write to the real /var/run path
+	// (or nowhere), so fail loudly instead.
+	text := string(src)
+	const reqDirLiteral = "/var/run/hive-metrics/pr-requests"
+	if !strings.Contains(text, reqDirLiteral) {
+		t.Fatalf("hive-open-pr.sh no longer references %s; this test would cover nothing", reqDirLiteral)
+	}
+	scriptPath := filepath.Join(root, "hive-open-pr.sh")
+	if err := os.WriteFile(scriptPath, []byte(strings.ReplaceAll(text, reqDirLiteral, reqDir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", append([]string{scriptPath}, args...)...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "HIVE_AGENT=scanner")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("hive-open-pr.sh %v: %v\n%s", args, err, out)
+	}
+
+	entries, err := filepath.Glob(filepath.Join(reqDir, "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("wrote %d request files, want 1: %v", len(entries), entries)
+	}
+	data, err := os.ReadFile(entries[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var req PRRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("request is not valid PRRequest JSON (%s): %v", data, err)
+	}
+	return req
+}
+
+// TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset asserts the invariant this
+// bug broke: an agent that says nothing about --base must not have the script
+// silently pin "main" into the request. A test that only checked "the request
+// has SOME base" would pass even with the old BASE="main" default.
+func TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset(t *testing.T) {
+	req := runHiveOpenPR(t,
+		"--repo", "projectbluefin/dakota", "--head", "hive/fix-1",
+		"--title", "fix a thing", "--body", "body")
+
+	if req.Base != "" {
+		t.Fatalf("request pinned base %q; an omitted --base must stay empty so the hive "+
+			"resolves the repository's default branch", req.Base)
+	}
+	if req.Repo != "projectbluefin/dakota" || req.Head != "hive/fix-1" || req.Title != "fix a thing" {
+		t.Fatalf("request lost fields: %+v", req)
+	}
+}
+
+func TestHiveOpenPRScript_ExplicitBaseIsPreserved(t *testing.T) {
+	req := runHiveOpenPR(t,
+		"--repo", "projectbluefin/dakota", "--head", "hive/fix-1",
+		"--base", "release-1.2", "--title", "fix a thing", "--body", "body")
+
+	if req.Base != "release-1.2" {
+		t.Fatalf("request base = %q, want the explicitly requested release-1.2", req.Base)
+	}
+}
+
+func TestHiveOpenPRScript_ExplicitBaseEqualsFormIsPreserved(t *testing.T) {
+	req := runHiveOpenPR(t,
+		"--repo=projectbluefin/dakota", "--head=hive/fix-1",
+		"--base=release-1.2", "--title=fix a thing", "--body=body")
+
+	if req.Base != "release-1.2" {
+		t.Fatalf("request base = %q, want release-1.2", req.Base)
+	}
+}

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -37,8 +37,12 @@ func prRequestDir() string {
 var prRequestPollInterval = 10 * time.Second
 
 // PRRequest is the JSON an agent writes to PRRequestDir to ask the hive to open
-// a PR on its behalf. Repo may be "owner/repo" or a bare repo name; Base
-// defaults to "main".
+// a PR on its behalf. Repo may be "owner/repo" or a bare repo name. Base is
+// optional and normally omitted: an empty Base means "resolve the target
+// repository's default branch" (CreatePR does this from the repo's own
+// metadata, and FAILS THE REQUEST rather than guessing "main" if it can't) —
+// set it only to target a non-default branch on purpose
+// (kubestellar/hive#4928).
 type PRRequest struct {
 	Repo   string `json:"repo"`
 	Head   string `json:"head"`

--- a/src/pkg/github/pr_request_watcher_test.go
+++ b/src/pkg/github/pr_request_watcher_test.go
@@ -28,6 +28,13 @@ func newPRMockServerLabels(t *testing.T, existingHead string, created *int, adde
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/o/r"):
+			// DefaultBranch: every request in this file omits Base, so CreatePR
+			// resolves it here. "main" keeps existing assertions in this file
+			// (which expect base "main") unchanged; the non-"main" regression
+			// coverage for kubestellar/hive#4928 lives in pullrequest_base_test.go.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			// dedupe list — return one PR only when the requested head matches.
 			head := r.URL.Query().Get("head") // "owner:branch"
@@ -268,6 +275,9 @@ func newPRFailingMockServer(t *testing.T, created *int, fails *int) *httptest.Se
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/o/r"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			_, _ = io.WriteString(w, `[]`)
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):

--- a/src/pkg/github/pullrequest.go
+++ b/src/pkg/github/pullrequest.go
@@ -32,7 +32,18 @@ type CreatePRResult struct {
 // `gh pr create` (which would attribute the PR to the Copilot login user).
 //
 // repo may be "owner/repo" or a bare repo name (owner defaults to the hive org).
-// head is the branch the agent pushed; base defaults to "main" when empty.
+// head is the branch the agent pushed; an empty base is RESOLVED from the
+// target repository's own default branch (see DefaultBranch) rather than
+// assumed to be "main" — a repo whose default is "testing" or "develop" would
+// otherwise get every PR based on the wrong branch, carrying the full
+// divergence between the two branches in its diff (kubestellar/hive#4928).
+//
+// A base the caller explicitly passed is always honored as-is and never
+// second-guessed against the resolved default. When no base is given and the
+// resolution fails, CreatePR returns an error rather than silently falling
+// back to "main" — a wrong base is worse than a delayed PR, and the caller
+// (the pr-request watcher) already surfaces a returned error into the audit
+// log and the request's .result.json, and retries with backoff.
 //
 // It is idempotent: if an OPEN PR for head already exists, it returns that PR
 // with AlreadyExisted=true instead of erroring or opening a duplicate — this
@@ -50,7 +61,11 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 		return CreatePRResult{}, fmt.Errorf("CreatePR: head branch is required")
 	}
 	if base = strings.TrimSpace(base); base == "" {
-		base = "main"
+		resolved, err := c.DefaultBranch(ctx, owner, repo)
+		if err != nil {
+			return CreatePRResult{}, fmt.Errorf("CreatePR %s/%s: could not resolve the repository's default branch and no explicit base was given (refusing to guess \"%s\"): %w", owner, repo, FallbackDefaultBranch, err)
+		}
+		base = resolved
 	}
 	if strings.TrimSpace(title) == "" {
 		return CreatePRResult{}, fmt.Errorf("CreatePR: title is required")

--- a/src/pkg/github/pullrequest_base_test.go
+++ b/src/pkg/github/pullrequest_base_test.go
@@ -1,0 +1,150 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Regression tests for kubestellar/hive#4928: CreatePR hardcoded base="main"
+// when the caller did not pin one, so every PR the hive opened on a repository
+// whose default branch is not "main" was based on the wrong branch. The diff
+// then carried the whole divergence between the two branches (one reported PR
+// showed 233 files / ~260k lines for a one-file change), and merging it landed
+// the change on a branch nobody meant to touch.
+
+// prBaseCapture is a fake GitHub that answers the three calls CreatePR can make
+// — repo metadata, the dedupe lookup, and the create — and records the base the
+// create actually asked for.
+type prBaseCapture struct {
+	defaultBranch string
+	repoStatus    int // non-zero to fail the metadata lookup
+	repoCalls     int32
+	gotBase       string
+	createCalled  bool
+}
+
+func (p *prBaseCapture) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/org/repo"):
+			atomic.AddInt32(&p.repoCalls, 1)
+			if p.repoStatus != 0 {
+				w.WriteHeader(p.repoStatus)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "repo", "default_branch": p.defaultBranch})
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]any{}) // no existing PR for this head
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			p.createCalled = true
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			p.gotBase = body["base"]
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number": 7, "html_url": "https://github.com/org/repo/pull/7",
+				"user": map[string]any{"login": "hive[bot]"},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestCreatePR_EmptyBaseTargetsRepoDefaultBranch asserts the invariant this
+// bug broke: a repository whose default branch is NOT "main" gets its PR based
+// on that branch. Using a repo whose default is "main" would pass unchanged
+// even with the old hardcoded behavior — this fixture deliberately picks
+// "testing" so the test fails if the resolution call is deleted.
+func TestCreatePR_EmptyBaseTargetsRepoDefaultBranch(t *testing.T) {
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "org/repo", "feature", "", "title", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if res.Number != 7 {
+		t.Fatalf("Number = %d, want 7", res.Number)
+	}
+	if fake.gotBase != "testing" {
+		t.Fatalf("PR opened with base %q, want %q — the repository's default branch, not an assumed 'main'", fake.gotBase, "testing")
+	}
+}
+
+func TestCreatePR_WhitespaceBaseTargetsRepoDefaultBranch(t *testing.T) {
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	if _, err := c.CreatePR(context.Background(), "org/repo", "feature", "   ", "title", "body"); err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if fake.gotBase != "testing" {
+		t.Fatalf("PR opened with base %q, want %q", fake.gotBase, "testing")
+	}
+}
+
+func TestCreatePR_ExplicitBaseIsNotOverridden(t *testing.T) {
+	// A caller that deliberately targets a release line (or a stacked PR's
+	// parent) must keep that base, and must not pay for a metadata lookup.
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	if _, err := c.CreatePR(context.Background(), "org/repo", "feature", "release-1.2", "title", "body"); err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if fake.gotBase != "release-1.2" {
+		t.Fatalf("PR opened with base %q, want the explicitly requested release-1.2", fake.gotBase)
+	}
+	if n := atomic.LoadInt32(&fake.repoCalls); n != 0 {
+		t.Fatalf("explicit base still issued %d default-branch lookups, want 0", n)
+	}
+}
+
+// TestCreatePR_EmptyBaseFailsWhenLookupFails asserts requirement 2: when no
+// base was given and the default branch cannot be resolved, CreatePR must fail
+// the request rather than silently opening the PR against "main" — a wrong
+// base is worse than a failed PR-open, and the caller (the pr-request watcher)
+// already retries failed requests with backoff and surfaces the error.
+func TestCreatePR_EmptyBaseFailsWhenLookupFails(t *testing.T) {
+	fake := &prBaseCapture{repoStatus: http.StatusInternalServerError}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	_, err := c.CreatePR(context.Background(), "org/repo", "feature", "", "title", "body")
+	if err == nil {
+		t.Fatal("CreatePR with an unresolvable default branch and no explicit base = nil error, want a failure")
+	}
+	if !strings.Contains(err.Error(), "could not resolve") {
+		t.Fatalf("error = %v, want it to explain the unresolved default branch", err)
+	}
+	if fake.createCalled {
+		t.Fatal("no PR should have been opened when the base could not be resolved")
+	}
+}
+
+func TestCreatePR_DefaultBranchResolvedOncePerRepo(t *testing.T) {
+	fake := &prBaseCapture{defaultBranch: "testing"}
+	c := NewClientForTest(fake.server(t).URL, "org", nil, prTestLogger())
+
+	for _, head := range []string{"feature-a", "feature-b", "feature-c"} {
+		if _, err := c.CreatePR(context.Background(), "org/repo", head, "", "title", "body"); err != nil {
+			t.Fatalf("CreatePR %s: %v", head, err)
+		}
+		if fake.gotBase != "testing" {
+			t.Fatalf("head %s opened with base %q, want testing", head, fake.gotBase)
+		}
+	}
+	if n := atomic.LoadInt32(&fake.repoCalls); n != 1 {
+		t.Fatalf("default branch resolved %d times across 3 PR opens, want 1", n)
+	}
+}

--- a/src/pkg/github/pullrequest_test.go
+++ b/src/pkg/github/pullrequest_test.go
@@ -81,6 +81,10 @@ func TestCreatePR_WhitespaceOnlyTitle(t *testing.T) {
 func TestCreatePR_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		// DefaultBranch: GET /repos/org/repo
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/org/repo"):
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"name": "repo", "default_branch": "main"})
 		// findOpenPRForHead: GET /repos/org/repo/pulls?head=org:feature&state=open
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			w.Header().Set("Content-Type", "application/json")
@@ -123,10 +127,19 @@ func TestCreatePR_Success(t *testing.T) {
 	}
 }
 
-func TestCreatePR_DefaultBaseToMain(t *testing.T) {
+// TestCreatePR_EmptyBaseResolvesRepoDefault replaces the old
+// TestCreatePR_DefaultBaseToMain: an empty base is no longer assumed to be
+// "main", it is resolved from the repository's own default_branch metadata.
+// This fixture's default happens to be "main" (the resolution path is what is
+// under test here); kubestellar/hive#4928's actual regression coverage —
+// a non-"main" default reaching the PR — lives in pullrequest_base_test.go.
+func TestCreatePR_EmptyBaseResolvesRepoDefault(t *testing.T) {
 	var receivedBase string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/org/repo"):
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"name": "repo", "default_branch": "main"})
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode([]any{})


### PR DESCRIPTION
## Summary

Hive opened every PR against a hardcoded `main`, never asking the target repository what its actual default branch is. On [projectbluefin/dakota](https://github.com/projectbluefin/dakota) (default: `testing`), that meant every PR the App filed carried the entire divergence between `main` and `testing` in its diff — one PR showed 233 changed files and ~260k changed lines for a one-file change, large enough that GitHub's diff API refused to serve it — and a maintainer who missed the base would have merged onto the wrong branch.

## Credit where it's due

**This is not original work.** Danathar filed [#4930](https://github.com/kubestellar/hive/pull/4930) with the correct diagnosis and a complete fix days ago. That PR is now `DIRTY` — unresolvable merge conflicts against a `v4` that has moved substantially since — through no fault of the fix itself; it's churn on this fast-moving branch, not a flaw in the approach. This PR re-applies Danathar's design against current `v4` rather than reinventing it.

**Carried forward from #4930, materially unchanged:**
- The core insight: fix the base in *three* places, not one — `CreatePR` alone accomplishes nothing while `hive-open-pr.sh` still pins `--base main` into the request file before `CreatePR` ever sees it.
- `Client.DefaultBranch` — a new `pkg/github/defaultbranch.go` that resolves and caches a repo's `default_branch` from its own metadata (the API behind `gh repo view --json defaultBranchRef`), covered by the App's existing `metadata:read` permission. Only successful lookups are cached, so a transient 5xx doesn't pin a repo to a wrong answer for the life of the process.
- `hive-open-pr.sh`: `BASE="main"` → `BASE=""`, with the same "do not pass --base main to be safe" warning in the usage comment.
- The sandbox path (`sandbox_executor.go`) resolving the base from the clone's own `refs/remotes/origin/HEAD` — `git clone` already records it, so no extra API call or token scope is needed there.
- An explicit `--base`/base argument always wins and is never second-guessed, at every layer.
- The test structure and the discipline behind it: `hive_open_pr_script_test.go` runs the **real script**, following the `gh_app_token_script_test.go` precedent, rather than testing a paraphrase of it; the default-branch regression tests deliberately use a repo whose default is `testing`, not `main`, so they fail if the resolution code is deleted.

**Changed from #4930, and why:**
- **Failure mode.** #4930 fell back to `main` and logged a warning when the default branch couldn't be resolved (API error, or an unreadable `origin/HEAD` in the sandbox clone). Per this issue's explicit requirement, that's still the exact bug in miniature: a lookup failure would silently produce a base nobody confirmed is right. This PR instead **fails the PR request** (`CreatePR` returns an error; the pr-request watcher's existing retry/quarantine path surfaces it into `.result.json` and the log) **or fails the sandbox kick outright** rather than guessing. `main` stays defined as `FallbackDefaultBranch` / `FallbackSandboxBaseRef` purely so the "refusing to guess" error messages have a named constant instead of a bare string literal — it is never silently used.
- `DefaultBranch` therefore returns `(string, error)` rather than always succeeding with a guaranteed answer, since callers now need to distinguish "resolved" from "give up".
- Re-pointed at current `v4`: the request/PR-request watcher, `pullrequest.go`, and `sandbox_executor.go` have all moved since #4930 was written, so this is a re-application against the present code rather than a rebase.

## What changed

- **`src/pkg/github/defaultbranch.go`** (new) — `Client.DefaultBranch(ctx, owner, repo) (string, error)`, cached per `owner/repo`, only successful lookups cached.
- **`src/pkg/github/pullrequest.go`** — `CreatePR` resolves an empty base through `DefaultBranch`; on resolution failure it returns an error explaining the refusal rather than opening against `main`. An explicit base is untouched and issues no lookup.
- **`src/pkg/github/pr_request_watcher.go`** — doc-only: clarifies that an empty `Base` in a `PRRequest` means "resolve it", and that resolution failure fails the request (the watcher's existing retry-with-backoff + `.failed` quarantine + logging already handles a `CreatePR` error correctly; no watcher logic needed to change).
- **`src/pkg/github/client.go`** — adds the `defaultBranchMu`/`defaultBranches` cache fields to `Client`.
- **`bin/hive-open-pr.sh`** — `BASE` no longer defaults to `"main"`; an omitted `--base` stays empty in the request file.
- **`src/pkg/agent/sandbox_executor.go`** — `prepareWorkspace` resolves an empty `spec.BaseRef` from the clone's `refs/remotes/origin/HEAD` (`resolveBaseRef`); an unresolvable ref fails the kick instead of silently branching off `main`.
- Tests: `defaultbranch_test.go`, `pullrequest_base_test.go`, `hive_open_pr_script_test.go`, `sandbox_executor_baseref_test.go` (new), plus fixes to existing tests (`pullrequest_test.go`, `pr_request_watcher_test.go`, `attribution_test.go`, `sandbox_executor_test.go`) whose fake GitHub servers/runners needed a `default_branch`/`origin/HEAD` response now that an empty base triggers real resolution instead of an assumption.

## Test quality

Per `CONTRIBUTING.md`'s bar — would a test fail if the code it covers were deleted — the regression tests deliberately exercise a repository whose default branch is **not** `main`:

- `TestCreatePR_EmptyBaseTargetsRepoDefaultBranch` / `TestCreatePR_DefaultBranchResolvedOncePerRepo` — fixture default branch is `testing`.
- `TestDefaultBranch_ResolvesFromRepoMetadata` — same.
- `TestSandboxExecutorBranchesFromRepoDefaultBranch` — clone's `origin/HEAD` reports `testing`; asserts both the `git fetch` target and the PR base end up as `testing`, not `main`.
- `TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset` — asserts the *request file* has no base at all when `--base` is omitted, not merely that "some" base is present (the old bug would have passed a weaker assertion).
- New failure-path tests (`TestCreatePR_EmptyBaseFailsWhenLookupFails`, `TestSandboxExecutorFailsKickWhenDefaultBranchUnreadable`, `TestDefaultBranch_ErrorsWhenLookupFails`) assert the request/kick is refused, not silently based on `main`.

Explicit-base-is-honored, cache-hit-count, and empty-metadata-still-errors cases are covered alongside.

## Both PR-open paths covered

- `bin/hive-open-pr.sh` → `PRRequest` (consumed by `pr_request_watcher.go`) → `CreatePR`: fixed by no longer pre-poisoning the request with `--base main`, and by `CreatePR` resolving the empty base.
- Direct `sandbox_executor.go` → `CreatePR` path (sandboxed kicks): fixed independently via `resolveBaseRef` reading the clone's own `origin/HEAD`, since that base is needed *before* the PR — the sandbox branches off it.

Fixes #4928
