### PR TITLE
test: assert CLI backend lists agree between shell and Go

### DIFF
--- a/src/pkg/config/backend_list_parity_test.go
+++ b/src/pkg/config/backend_list_parity_test.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// backendListsConfPath is the shell half of the CLI-backend list. config.go's
+// CLIBackends/InferenceBackends are the Go half, read by the config validator
+// and the hub-side launcher; config/backends.conf's KNOWN_BACKENDS is read by
+// the relay's tmux launch path (bin/agent-launch.sh, bin/hive.sh). A backend
+// added to one and not the other is accepted at config-set time and then
+// fails at kick time on whichever path was skipped — exactly the watsonx bug
+// TestValidateBackend_AcceptsWatsonx above exists to prevent, just for a
+// different pair of lists.
+const backendListsConfPath = "../../../config/backends.conf"
+
+// cliBackendListException documents one name that legitimately lives in only
+// one of KNOWN_BACKENDS (shell) or CLIBackends (Go), and why. This is NOT a
+// place to silence real drift: a name added here without the guard actually
+// having verified the asymmetry defeats the whole test. See REQUIREMENTS in
+// the PR that introduced this file for the bar a new entry must clear.
+type cliBackendListException struct {
+	name   string
+	reason string
+}
+
+// cliBackendExceptions is the complete, closed set of asymmetries between
+// KNOWN_BACKENDS and CLIBackends. Anything not listed here must appear in
+// both lists or the test fails.
+var cliBackendExceptions = []cliBackendListException{
+	{
+		name: "litellm",
+		reason: "shell-only. litellm is an inference gateway (it launches the " +
+			"claude binary pointed at a LiteLLM proxy via ANTHROPIC_BASE_URL), " +
+			"not an agentic CLI, so it belongs in InferenceBackends, not " +
+			"CLIBackends. It IS asserted against InferenceBackends below.",
+	},
+	{
+		name: "gemini",
+		reason: "Go-only. The relay never dispatches on the literal name " +
+			"\"gemini\" — detect_backend_from_model() in backends.conf routes " +
+			"gemini-* model names to the gemini case by PREFIX MATCH, not by a " +
+			"KNOWN_BACKENDS membership check, so gemini has no entry in " +
+			"KNOWN_BACKENDS, backend_binary, or backend_perm_flag to begin " +
+			"with. CLIBackends lists it because the hub-side config validator " +
+			"and launcher (which have no equivalent prefix-routing step) need " +
+			"it to accept `backend: gemini` for paid Gemini Code Assist " +
+			"licence holders (see the CLIBackends doc comment in config.go).",
+	},
+}
+
+// exceptedCLINames returns the set of names cliBackendExceptions permits to
+// live in only one list.
+func exceptedCLINames() map[string]bool {
+	out := make(map[string]bool, len(cliBackendExceptions))
+	for _, e := range cliBackendExceptions {
+		out[e.name] = true
+	}
+	return out
+}
+
+// shellKnownBackends sources config/backends.conf and returns KNOWN_BACKENDS
+// split on whitespace, mirroring how TestShellAndGoDenyListsAgree
+// (src/pkg/agent/host_state_deny_test.go) reads CLAUDE_HOST_DENY_TOOLS out of
+// the same file: shell out to bash, source the file, print the variable.
+func shellKnownBackends(t *testing.T) []string {
+	t.Helper()
+	if _, err := os.Stat(backendListsConfPath); err != nil {
+		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+	}
+	out, err := exec.Command("bash", "-c",
+		"source "+backendListsConfPath+" && printf '%s' \"$KNOWN_BACKENDS\"").Output()
+	if err != nil {
+		t.Fatalf("sourcing backends.conf: %v", err)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		t.Fatalf("KNOWN_BACKENDS came back empty from %s; sourcing likely failed silently", backendListsConfPath)
+	}
+	return fields
+}
+
+// TestShellAndGoCLIBackendListsAgree is the parity check REQUIREMENTS #1-#3
+// ask for: every CLI backend known to Go (CLIBackends) is known to the shell
+// (KNOWN_BACKENDS) and vice versa, except for the documented exceptions
+// above, and a mismatch names the specific backend and the specific list it
+// is missing from.
+//
+// This does go red if a backend is added to CLIBackends only: the reverse
+// direction below checks precisely that "every Go-known CLI name is in the
+// shell set or excepted", so a bare `append(CLIBackends, "newbackend")` with
+// no shell-side or exception-list change fails on the first `go test` run
+// touching this file.
+func TestShellAndGoCLIBackendListsAgree(t *testing.T) {
+	shellSet := make(map[string]bool)
+	for _, b := range shellKnownBackends(t) {
+		shellSet[b] = true
+	}
+	goSet := make(map[string]bool)
+	for _, b := range CLIBackends {
+		goSet[b] = true
+	}
+	excepted := exceptedCLINames()
+
+	var missing []string
+	for name := range shellSet {
+		if !goSet[name] && !excepted[name] {
+			missing = append(missing, "config/backends.conf KNOWN_BACKENDS has "+name+
+				" but config.CLIBackends does not, and it is not a declared exception")
+		}
+	}
+	for name := range goSet {
+		if !shellSet[name] && !excepted[name] {
+			missing = append(missing, "config.CLIBackends has "+name+
+				" but config/backends.conf KNOWN_BACKENDS does not, and it is not a declared exception")
+		}
+	}
+
+	// A declared exception that no longer describes a real asymmetry (the
+	// name is now in BOTH lists, or in NEITHER) is stale bookkeeping that
+	// would silently mask a future real removal on one side. Fail loudly
+	// rather than let it rot.
+	for name := range excepted {
+		inShell, inGo := shellSet[name], goSet[name]
+		if inShell && inGo {
+			missing = append(missing, "declared exception "+name+
+				" is now present in BOTH KNOWN_BACKENDS and CLIBackends; remove it from cliBackendExceptions")
+		}
+		if !inShell && !inGo {
+			missing = append(missing, "declared exception "+name+
+				" is present in NEITHER KNOWN_BACKENDS nor CLIBackends; remove it from cliBackendExceptions")
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("shell and Go CLI backend lists have drifted:\n  %s", strings.Join(missing, "\n  "))
+	}
+}
+
+// TestLiteLLMExceptionIsAnInferenceBackend pins the reason the litellm
+// exception is allowed to exist: it must actually be present in
+// InferenceBackends, not just absent from CLIBackends. If it were removed
+// from InferenceBackends too, litellm would be a name the shell accepts and
+// nothing in Go recognizes at all — silently unsupported rather than
+// deliberately routed elsewhere.
+func TestLiteLLMExceptionIsAnInferenceBackend(t *testing.T) {
+	if !IsInferenceBackend("litellm") {
+		t.Fatal(`litellm is excepted from CLIBackends parity on the theory that it belongs ` +
+			`in InferenceBackends instead, but IsInferenceBackend("litellm") = false. ` +
+			`Either restore it to InferenceBackends or drop the exception and treat this as real drift.`)
+	}
+}
+
+// TestGeminiExceptionRoutesByModelPrefix pins the reason the gemini exception
+// is allowed to exist: the shell config must still route gemini-* models to
+// the gemini backend by prefix match, even though gemini has no entry in
+// KNOWN_BACKENDS. If that routing were deleted, "gemini" would be a Go-only
+// name the shell has no path to at all.
+func TestGeminiExceptionRoutesByModelPrefix(t *testing.T) {
+	if _, err := os.Stat(backendListsConfPath); err != nil {
+		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+	}
+	out, err := exec.Command("bash", "-c",
+		"source "+backendListsConfPath+" && detect_backend_from_model gemini-2.5-pro").Output()
+	if err != nil {
+		t.Fatalf("sourcing backends.conf: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "gemini" {
+		t.Fatalf(`detect_backend_from_model("gemini-2.5-pro") = %q, want "gemini" — `+
+			`the gemini exception in cliBackendExceptions depends on this prefix routing existing`, got)
+	}
+}
+
+// TestBackendBinaryAndPermFlagCoverKnownBackends is REQUIREMENT #5: a name in
+// KNOWN_BACKENDS with no case in backend_binary/backend_perm_flag falls
+// through to that function's `*)` default, which is wrong for a supported
+// backend (backend_binary's default echoes the name back verbatim as if it
+// were also the binary name, which is only sometimes true, and
+// backend_perm_flag's default is an empty flag string, silently granting no
+// permissions). Every declared backend must hit an explicit case, not the
+// fallback.
+func TestBackendBinaryAndPermFlagCoverKnownBackends(t *testing.T) {
+	if _, err := os.Stat(backendListsConfPath); err != nil {
+		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+	}
+	for _, name := range shellKnownBackends(t) {
+		script := "source " + backendListsConfPath + " && " +
+			"grep -qE '^\\s*" + name + "\\)' <(sed -n '/^backend_binary\\(\\)/,/^}/p' " + backendListsConfPath + ")"
+		if err := exec.Command("bash", "-c", script).Run(); err != nil {
+			t.Errorf("backend_binary in %s has no explicit case for %q (falls through to the default)",
+				backendListsConfPath, name)
+		}
+		script = "source " + backendListsConfPath + " && " +
+			"grep -qE '^\\s*" + name + "\\)' <(sed -n '/^backend_perm_flag\\(\\)/,/^}/p' " + backendListsConfPath + ")"
+		if err := exec.Command("bash", "-c", script).Run(); err != nil {
+			t.Errorf("backend_perm_flag in %s has no explicit case for %q (falls through to the default)",
+				backendListsConfPath, name)
+		}
+	}
+}

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -4639,6 +4639,14 @@ func IsInferenceBackend(backend string) bool {
 // KNOWN_BACKENDS, so omitting it here reproduced exactly the accept-in-one-
 // place drift this list exists to prevent — except inverted: valid in the
 // shell config, rejected by the hub.
+//
+// TestShellAndGoCLIBackendListsAgree (backend_list_parity_test.go) asserts
+// this list against config/backends.conf's KNOWN_BACKENDS, with a closed,
+// commented set of exceptions (cliBackendExceptions in that file) for the two
+// names — litellm, gemini — that are known to belong on only one side. Adding
+// a backend here without also updating the shell side (or, if it genuinely
+// belongs on only one side, documenting why in cliBackendExceptions) fails
+// that test.
 var CLIBackends = []string{"claude", "copilot", "goose", "codex", "pi", "bob", "aider", "gemini", "agy"}
 
 // IsCLIBackend returns true if the backend launches an agentic CLI binary.


### PR DESCRIPTION
## What

STEP 1 of a two-step plan (see #4970): a parity guard asserting the CLI
backend lists declared in shell (`config/backends.conf`'s `KNOWN_BACKENDS`)
and Go (`src/pkg/config/config.go`'s `CLIBackends`) agree, with a closed,
commented set of exceptions for the two names that legitimately live on only
one side. This PR does **not** add the `opencode` backend — that is the
follow-up step, built on top of this guard.

Mirrors the house pattern for this exact class of problem:
`TestShellAndGoDenyListsAgree` (#4938,
`src/pkg/agent/host_state_deny_test.go`) sources `config/backends.conf` from
Go via `bash -c "source ... && printf ..."` and compares the shell value
against the Go constant. The new test does the same thing for
`KNOWN_BACKENDS` vs `CLIBackends`.

## What's new

`src/pkg/config/backend_list_parity_test.go`:

- **`TestShellAndGoCLIBackendListsAgree`** — sources `KNOWN_BACKENDS` out of
  `config/backends.conf` and diffs it against `config.CLIBackends` in both
  directions. A name present in one list and not the other (and not a
  declared exception) fails with a message naming the exact backend and the
  exact list it's missing from — not a generic "lists differ".
- **Exception bookkeeping is asserted closed**: a declared exception that
  becomes present in *both* lists, or in *neither*, also fails the test, so
  the exception list can't quietly rot into masking a future real removal.
- **`TestLiteLLMExceptionIsAnInferenceBackend`** / **`TestGeminiExceptionRoutesByModelPrefix`**
  — each exception is pinned to the specific mechanism that justifies it
  (see below), not just asserted by fiat.
- **`TestBackendBinaryAndPermFlagCoverKnownBackends`** — every name in
  `KNOWN_BACKENDS` must have an explicit `case` in both `backend_binary` and
  `backend_perm_flag`, not fall through to those functions' `*)` defaults. A
  backend with no binary/perm mapping is broken at launch time.

`src/pkg/config/config.go` — added a short pointer comment on `CLIBackends`
noting the guard exists and where the exceptions live. No behavior change.

## Declared exceptions (why each one is allowed to live on only one side)

| Name | Where | Reason |
|---|---|---|
| `litellm` | shell only (`KNOWN_BACKENDS`) | It's an inference gateway, not an agentic CLI — it launches the `claude` binary pointed at a LiteLLM proxy via `ANTHROPIC_BASE_URL`. It belongs in (and is already in) `InferenceBackends`, not `CLIBackends`. Pinned by `TestLiteLLMExceptionIsAnInferenceBackend`, which fails if `litellm` is ever also dropped from `InferenceBackends` — the failure mode that would leave it recognized nowhere in Go. |
| `gemini` | Go only (`CLIBackends`) | The shell path never dispatches on the literal name `gemini` — `detect_backend_from_model()` in `backends.conf` routes `gemini-*` model names to the `gemini` case by **prefix match**, not by `KNOWN_BACKENDS` membership, so `gemini` has no entry in `KNOWN_BACKENDS`, `backend_binary`, or `backend_perm_flag` to begin with. `CLIBackends` lists it because the hub-side config validator and launcher (which have no equivalent prefix-routing step) need it to accept `backend: gemini` for paid Gemini Code Assist licence holders. Pinned by `TestGeminiExceptionRoutesByModelPrefix`, which fails if that prefix routing is ever deleted — the failure mode that would leave `gemini` as a Go-only name the shell has no path to at all. |

Both exceptions were called out as already-verified-correct in the task spec;
this PR just makes them explicit, tested, and load-bearing instead of
implicit.

## Pre-existing drift found (reported, not silently excepted)

Went looking for drift beyond the two known exceptions before writing this,
per the instructions not to paper over anything found. One thing surfaced
that is **out of scope for this guard** (it isn't a `KNOWN_BACKENDS` vs
`CLIBackends` mismatch) but looks like real, separate drift worth a look:

- **`amazonq`** appears in three shell/JS "no `--model` flag" lists —
  `bin/agent-launch.sh:149`, `bin/contributor-agent.sh:521`,
  `bin/contributor-relay.sh:440` (`NO_MODEL_FLAG_BACKENDS`) — and in the
  dashboard's own `KNOWN_BACKENDS` JS array
  (`src/pkg/dashboard/static/index.html:7525`), but it is **not** in
  `config/backends.conf`'s shell `KNOWN_BACKENDS`, not in `backend_binary`,
  not in `backend_perm_flag`, and not in Go's `CLIBackends`. It has no
  dispatch path anywhere that would actually launch it. Either it's dead
  vestigial code from a removed backend, or a backend that was never fully
  wired up. Not touched here — flagging for a maintainer call.
- The dashboard's JS `KNOWN_BACKENDS` array
  (`src/pkg/dashboard/static/index.html:7525`) is a **third, independent**
  list (UI dropdown population) that also includes `openrouter` (a gateway
  *example* name, not a backend) and the `amazonq` name above, on top of the
  shell/Go names. It isn't sourced from either `config/backends.conf` or
  `config.go`, so it wasn't in scope for this Go-test guard (there's no
  practical way for a Go test to parse embedded `<script>` JS the way it can
  source a `.sh` file), but it's a third source of truth for the same
  concept with no guard on it at all. Flagging in case a follow-up wants to
  cover it too.

No other backend-name drift found beyond these.

## Verification

Per project policy, no local `go build`/`go test`/`go vet` was run — CI is
the gate. I did manually re-derive the shell-sourcing and `sed`/`grep`
extraction logic outside Go (same `bash -c` invocations the test issues) to
confirm the parity check passes cleanly against the current
`KNOWN_BACKENDS`/`CLIBackends` contents with exactly the two declared
exceptions, and that it flags a synthetic name added to only one side.

Refs #4970
