### PR TITLE
🧹 lint: fix all 44 unused findings and enable unused in the gate

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -23,7 +23,7 @@ run:
 linters:
   default: none
   enable:
-    # STARTING SET — deliberately three linters, not six.
+    # THE ENABLED SET grows one linter at a time, never in batches.
     #
     # A first run with errcheck + staticcheck + unused enabled produced 859
     # findings (579 errcheck, 225 staticcheck, 44 unused, 11 ineffassign) on a
@@ -35,12 +35,18 @@ linters:
     # its own PR after its findings are fixed — that ratchet is tracked in the
     # ratchet issue #4903.
     #
-    # errcheck (579) is the most valuable remaining rung and the largest, and
-    # is worth splitting by package.
+    # Remaining backlog: staticcheck (225), errcheck (579). errcheck is the
+    # most valuable remaining rung and the largest, and is worth splitting by
+    # package.
     - govet
     - misspell
     # RATCHET: ineffassign enabled after its 11 findings were fixed (#4903).
     - ineffassign
+    # RATCHET: unused enabled after its 44 findings were fixed (#4903). Most
+    # were dead constants, aliases, and test helpers superseded by refactors
+    # that moved on without deleting them. One declaration is retained under an
+    # explained //nolint:unused — see pkg/hub/wrapkey_store.go.
+    - unused
 
   exclusions:
     generated: lax

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2812,7 +2812,7 @@ func main() {
 	// The loop therefore runs for the lifetime of the process (it does NOT
 	// return after the first success) and, whenever the banner is currently
 	// showing, re-runs the SAME read+write verification as the manual "Re-check"
-	// button (githubAppRecheckFn, which calls diagnoseGitHubAppWrite) and clears
+	// button (githubAppRecheckFn, which calls diagnoseGitHubApp) and clears
 	// the flag on success. When the banner is not showing there is nothing to do,
 	// so the tick is a cheap no-op that makes no GitHub API calls.
 	{
@@ -5175,14 +5175,8 @@ func (s labelPlanSink) QueuedPlan(epic *beads.Bead, paused bool) {
 	s.logger.Warn("plan-from-label: architect unavailable, plan queued", "epic", epic.ID, "ref", epic.ExternalRef)
 }
 
-// diagnoseGitHubAppWrite returns "" when the configured GitHub App
-// installation belongs to expectedOwner and grants issues:write. Otherwise it
-// returns a banner-ready diagnosis distinguishing the two write-failure causes
-// that produce identical 403s: an installation_id pointing at a different
-// org's installation, and a permission update the org owner hasn't approved
-// yet. A nil appAuth (token-authenticated hive) yields "" — nothing to check.
 // healGitHubAppInstallation self-heals a hive whose github.installation_id
-// points at the WRONG account — the failure mode diagnoseGitHubAppWrite
+// points at the WRONG account — the failure mode diagnoseGitHubApp
 // already detects and reports ("installation N belongs to 'X', not 'Y'"). It
 // asks pkg/github to rediscover the installation covering cfg.Project.Org via
 // the App JWT and, only on an unambiguous match, adopts it in place and
@@ -5256,13 +5250,6 @@ func diagnoseGitHubAppFull(ctx context.Context, appAuth *github.AppAuth, expecte
 		return github.AppAuthDiagnosis{State: github.AppStateOK, ExpectedAccount: expectedOwner}
 	}
 	return appAuth.DiagnoseAppAuth(ctx, expectedOwner, spokeAppKeyPath, spokeProvisionedAppKeyPath)
-}
-
-// diagnoseGitHubAppWrite is the string-only wrapper retained for callers that
-// only need banner copy.
-func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expectedOwner string) string {
-	msg, _ := diagnoseGitHubApp(ctx, appAuth, expectedOwner)
-	return msg
 }
 
 // maxTimelineEnumeratePerCycle bounds how many enumerated-issue events a single

--- a/src/pkg/agent/agent_bootstrap_test.go
+++ b/src/pkg/agent/agent_bootstrap_test.go
@@ -569,12 +569,3 @@ func TestRemoveAgentExisting(t *testing.T) {
 		t.Error("scanner should be removed")
 	}
 }
-
-func containsBoot2(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/src/pkg/agent/manager_coverage_test.go
+++ b/src/pkg/agent/manager_coverage_test.go
@@ -560,16 +560,3 @@ func TestBuildBootstrapPrompt_WithFile(t *testing.T) {
 		t.Error("boot prompt should be empty — agents get kicked by governor")
 	}
 }
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsHelper(s, sub))
-}
-
-func containsHelper(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}

--- a/src/pkg/agent/manager_test.go
+++ b/src/pkg/agent/manager_test.go
@@ -208,26 +208,6 @@ func makeAgentConfig(backend, model string) config.AgentConfig {
 	}
 }
 
-func waitForState(t *testing.T, m *Manager, name string, want ...ProcessState) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		ap, _ := m.GetStatus(name)
-		for _, w := range want {
-			if ap.State == w {
-				return
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	ap, _ := m.GetStatus(name)
-	wantStrs := make([]string, len(want))
-	for i, w := range want {
-		wantStrs[i] = string(w)
-	}
-	t.Errorf("timed out waiting for %q state: got %q", strings.Join(wantStrs, "|"), ap.State)
-}
-
 // ---------------------------------------------------------------------------
 // NewManager
 // ---------------------------------------------------------------------------

--- a/src/pkg/agent/tmux_coverage_test.go
+++ b/src/pkg/agent/tmux_coverage_test.go
@@ -158,18 +158,6 @@ func requirePaneShows(t *testing.T, session, text string) {
 	}
 }
 
-// paneInjectLines renders each string on its own pane line.
-func paneInjectLines(t *testing.T, session string, lines ...string) {
-	t.Helper()
-	for _, ln := range lines {
-		if err := testTmuxCommand("send-keys", "-t", session, "-l", ": "+ln).Run(); err != nil {
-			t.Fatalf("send-keys: %v", err)
-		}
-		_ = testTmuxCommand("send-keys", "-t", session, "Enter").Run()
-	}
-	time.Sleep(500 * time.Millisecond)
-}
-
 // ---------------------------------------------------------------------------
 // Start / launchInTmux — full launch path with real tmux + stub binary
 // ---------------------------------------------------------------------------

--- a/src/pkg/apiproxy/proxy.go
+++ b/src/pkg/apiproxy/proxy.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -55,7 +54,6 @@ type Proxy struct {
 	// never an implicit credential for anyone who can reach the listener. It
 	// is required: when empty every request is refused with 503.
 	clientAuthToken string
-	mu              sync.RWMutex
 }
 
 func New(upstreamURL string, handler EventHandler, apiKey, clientAuthToken string) (*Proxy, error) {

--- a/src/pkg/celtrigger/celtrigger.go
+++ b/src/pkg/celtrigger/celtrigger.go
@@ -43,10 +43,6 @@ const (
 	KindCommentCreated = "comment.created"
 )
 
-// defaultPriority is applied to rules that declare no explicit priority. Higher
-// priority sorts first in Match results.
-const defaultPriority = 0
-
 // maxEvalCost bounds CEL runtime work per rule evaluation. The budget is high
 // enough for realistic operator rules that combine field checks, string
 // predicates, and modest label scans, while still stopping pathological nested
@@ -107,7 +103,8 @@ type Rule struct {
 	Expr string
 	// Agent names the agent to trigger when Expr matches.
 	Agent string
-	// Priority orders matched rules; higher sorts first. Defaults to defaultPriority.
+	// Priority orders matched rules; higher sorts first. A rule that declares
+	// no priority gets the zero value, so declared order decides ties.
 	Priority int
 }
 

--- a/src/pkg/dashboard/api_agents.go
+++ b/src/pkg/dashboard/api_agents.go
@@ -582,25 +582,6 @@ func isGistImportHost(host string) bool {
 	return host == "gist.github.com" || host == "gist.githubusercontent.com"
 }
 
-func importFetchURL(rawURL string) string {
-	u, err := url.Parse(strings.TrimSpace(rawURL))
-	if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
-		return rawURL
-	}
-	m := githubBlobURLPattern.FindStringSubmatch(u.Path)
-	if m == nil {
-		return rawURL
-	}
-	raw := url.URL{
-		Scheme:   "https",
-		Host:     "raw.githubusercontent.com",
-		Path:     "/" + strings.Join([]string{m[1], m[2], m[3], m[4]}, "/"),
-		RawQuery: u.RawQuery,
-		Fragment: u.Fragment,
-	}
-	return raw.String()
-}
-
 // definitionSourceFromURL parses a GitHub blob or raw file URL into a
 // DefinitionSourceConfig (owner/repo/path/ref). It is used when an operator
 // imports an agent with "keep linked" checked, so the pasted human-facing URL

--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -255,14 +255,6 @@ type ContributorRateLimits struct {
 	MaxPerDay     int `json:"max_tasks_per_day"`
 }
 
-type ContributorPool struct {
-	Active     int `json:"active"`
-	Registered int `json:"registered"`
-	mu         sync.RWMutex
-}
-
-var contributorPool = &ContributorPool{}
-
 type ContributorPoolStatus struct {
 	Active     int            `json:"active"`
 	Registered int            `json:"registered"`

--- a/src/pkg/dashboard/api_leaderboard_style.go
+++ b/src/pkg/dashboard/api_leaderboard_style.go
@@ -894,14 +894,8 @@ func (s *Server) handleLeaderboardStyle(w http.ResponseWriter, r *http.Request) 
 	s.handleStyle(w, r)
 }
 
-// Back-compatible leaderboard names kept for the PR #2834 tests and callers.
+// Back-compatible leaderboard name kept for the PR #2834 tests and callers.
 type leaderboardCustomStyleSource = customStyleSource
-type leaderboardCustomStyleCacheEntry = customStyleCacheEntry
-
-const (
-	leaderboardCustomStyleMaxBytes   = customStyleMaxBytes
-	leaderboardCustomStyleDefaultRef = customStyleDefaultRef
-)
 
 func validateLeaderboardCustomStyleSource(src string) (leaderboardCustomStyleSource, error) {
 	return validateCustomStyleSource(src)

--- a/src/pkg/dashboard/contribute_admission_deps.go
+++ b/src/pkg/dashboard/contribute_admission_deps.go
@@ -136,10 +136,6 @@ func (r beadRecord) generation() string {
 	return r.updatedAt.UTC().Format(time.RFC3339Nano)
 }
 
-// beadLedgerPartialReason is the DegradedReason reported when the ledger
-// snapshot could not cover every configured store.
-const beadLedgerPartialReason = "BeadLedgerPartial"
-
 // contributorAdmissionSweep carries the observation state shared by every
 // candidate in ONE ReadyQueue / selectTask pass. Building it once per sweep
 // keeps the shared admission contract cheap enough to sit in the assignment

--- a/src/pkg/dashboard/contribute_agent_roles.go
+++ b/src/pkg/dashboard/contribute_agent_roles.go
@@ -108,13 +108,6 @@ func (h *ContributeWSHub) roleKickPrompt(role string) string {
 	return h.server.deps.Scheduler.BuildAgentMessageFromLastActionable(role)
 }
 
-// buildRoleTaskPrompt is the GitHub-shaped entry point retained for existing
-// callers; buildRoleTaskPromptForRef is the identity-aware one
-// (kubestellar/hive#4245).
-func buildRoleTaskPrompt(repoFull string, number int, title, role, agentPrompt string) string {
-	return buildRoleTaskPromptForRef(worksource.Ref{Repo: repoFull, Number: number}, title, role, agentPrompt)
-}
-
 // buildRoleTaskPromptForRef wraps the source-aware assignment prompt in the
 // role framing. Only the base prompt carries work identity, so the role text
 // itself is unchanged for every source.

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -356,20 +356,6 @@ func (t *WSTaskAssign) identityKey() string {
 	return worksource.Ref{Repo: t.Repo, Number: t.Number}.Key()
 }
 
-// ref reconstructs the assigned item's source-aware reference.
-func (t *WSTaskAssign) ref() worksource.Ref {
-	if t == nil {
-		return worksource.Ref{}
-	}
-	return worksource.Ref{
-		SourceType: t.SourceType,
-		Repo:       t.Repo,
-		ExternalID: t.ExternalID,
-		Number:     t.Number,
-		URL:        t.URL,
-	}
-}
-
 const maxActivityEntries = 50
 
 type ActivityEntry struct {

--- a/src/pkg/dashboard/gateways.go
+++ b/src/pkg/dashboard/gateways.go
@@ -70,17 +70,6 @@ func gatewayProbeAuth(kind, key, projectID string) (bearer string, headers map[s
 }
 
 const (
-	// openRouterBaseURL is the OpenAI-compatible base URL for OpenRouter. Used
-	// as the preset endpoint when the UI picks the OpenRouter gateway kind.
-	openRouterBaseURL = "https://openrouter.ai/api/v1"
-
-	// watsonxBaseURLTemplate / watsonxDefaultRegion alias the canonical values
-	// in pkg/watsonx. They are NOT redefined here: the agent launch path needs
-	// the same template, and two copies is exactly how the gateway half and the
-	// agent half of watsonx support were able to disagree.
-	watsonxBaseURLTemplate = watsonx.BaseURLTemplate
-	watsonxDefaultRegion   = watsonx.DefaultRegion
-
 	// gatewaySecretFileMode / gatewaySecretDirMode keep gateway key files
 	// owner-only, matching the LiteLLM key store (litellmKeyFileMode).
 	gatewaySecretFileMode = 0o600

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -38,12 +38,19 @@ var skillsConventionalDir = dataVolumePath + "/skills"
 const defaultLookbackHours = 24
 
 // Cadence sentinel values: a per-mode cadence set to one of these means the
-// governor will not kick the agent on a timer in that mode. Kept as named
-// constants so the offByCadence detection and computeNextKick agree on the
-// exact spellings the config layer emits.
+// governor will not kick the agent on a timer in that mode. Named constants so
+// the two next-kick computations below agree on the exact spellings the config
+// layer emits, rather than each carrying its own literal list — the drift these
+// were introduced to prevent, and which had already started before they were
+// wired in.
+//
+// config.Cadence.IsPaused() remains the authority for the interval-mode
+// judgment (it also accepts "paused" and "0"); these are the string-cadence
+// spellings the dashboard's own formatting paths compare against.
 const (
-	cadencePause = "pause"
-	cadenceOff   = "off"
+	cadencePause    = "pause"
+	cadenceOff      = "off"
+	cadenceOnDemand = "on demand"
 )
 
 // SetProxyViolationsProvider registers a function that returns per-agent
@@ -941,7 +948,7 @@ func formatHumanTime(t time.Time) string {
 }
 
 func computeNextKick(lastKick *time.Time, cadence string) string {
-	if cadence == "" || cadence == "off" || cadence == "pause" || cadence == "on demand" {
+	if cadence == "" || cadence == cadenceOff || cadence == cadencePause || cadence == cadenceOnDemand {
 		return ""
 	}
 	base := time.Now()
@@ -973,7 +980,7 @@ func computeNextKickFromCadence(lastKick *time.Time, cadence config.Cadence) str
 
 func parseCadenceDuration(cadence string) time.Duration {
 	cadence = strings.TrimSpace(cadence)
-	if cadence == "" || cadence == "off" || cadence == "pause" || cadence == "on demand" {
+	if cadence == "" || cadence == cadenceOff || cadence == cadencePause || cadence == cadenceOnDemand {
 		return 0
 	}
 	d, err := time.ParseDuration(cadence)

--- a/src/pkg/discord/bot_test.go
+++ b/src/pkg/discord/bot_test.go
@@ -665,15 +665,6 @@ func TestRouteMessage_EnqueueDoesNotPanic(t *testing.T) {
 // SendMessage – error branches
 // ──────────────────────────────────────────────────────────────────────────────
 
-// errTransport is an http.RoundTripper that always returns the given error.
-// It is used to exercise error paths that cannot be reached through a normal
-// test server (e.g. http.NewRequest failures triggered by an invalid URL).
-type errTransport struct{ err error }
-
-func (e *errTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
-	return nil, e.err
-}
-
 // TestSendMessage_NewRequestError covers the http.NewRequest error branch in
 // SendMessage by using a channelID containing a null byte, which makes the
 // constructed URL invalid.

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -397,8 +397,6 @@ var PermanentExemptLabels = []string{"do-not-merge"}
 // exists so a nil or unconfigured client still has a sane value.
 const AutoMergeQueuedLabel = config.DefaultAutoMergeLabel
 
-var exemptFiles = []string{"ADOPTERS.md", "ADOPTERS.MD"}
-
 const slaThresholdMinutes = 30
 
 // NewClient creates a GitHub API client. If apiURL is non-empty and differs
@@ -1424,8 +1422,6 @@ func (c *Client) SearchOutreachPRCount(ctx context.Context, author, org, project
 	}
 	return result.GetTotal(), nil
 }
-
-const perPage = 100
 
 var shaPattern = regexp.MustCompile(`[0-9a-f]{7,40}\b`)
 

--- a/src/pkg/github/client_test.go
+++ b/src/pkg/github/client_test.go
@@ -63,8 +63,6 @@ type wireIssue struct {
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 }
 
-func boolPtr(b bool) *bool { return &b }
-
 func mustMarshal(t *testing.T, v any) []byte {
 	t.Helper()
 	b, err := json.Marshal(v)

--- a/src/pkg/hub/forge.go
+++ b/src/pkg/hub/forge.go
@@ -47,16 +47,13 @@ const (
 	ForgeGitea ForgeKind = "gitea"
 )
 
-// gitLabAPIPathSuffix / giteaAPIPathSuffix are the REST API base paths for the
-// non-GitHub forges. The spoke-side pkg/forge adapters append these to the
-// instance root themselves (gitLabAPIPath="/api/v4", giteaAPIPath="/api/v1"), so
-// for these kinds a ForgeTarget carries the BARE instance URL in BaseURL and
-// leaves APIURL empty — the opposite of the GHE case, where the hub pre-appends
-// /api/v3. Kept here as documentation of that contract.
-const (
-	gitLabAPIPathSuffix = "/api/v4"
-	giteaAPIPathSuffix  = "/api/v1"
-)
+// FORGE API-PATH CONTRACT, hub side. The REST API base paths for the non-GitHub
+// forges are appended by the spoke-side pkg/forge adapters themselves
+// (gitLabAPIPath="/api/v4", giteaAPIPath="/api/v1"), so for those kinds a
+// ForgeTarget carries the BARE instance URL in BaseURL and leaves APIURL empty —
+// the opposite of the GHE case below, where the hub pre-appends /api/v3. The hub
+// must not duplicate the GitLab/Gitea suffixes: a second copy here is how the two
+// halves would get a chance to disagree.
 
 // publicForgeHost is the canonical host of public GitHub. A hive on this host
 // carries GitHubHost == "github.com" (or "", historically) and an empty
@@ -114,7 +111,7 @@ func parseForgeTarget(raw string) (ForgeTarget, error) {
 // inferred from the host). "gitlab"/"gitea" produce non-GitHub targets whose
 // BaseURL is the bare instance root and whose APIURL is left empty — the
 // spoke-side pkg/forge adapter appends the /api/v4 or /api/v1 suffix itself
-// (see the gitLabAPIPathSuffix/giteaAPIPathSuffix note). "github"/
+// (see the forge API-path contract note above). "github"/
 // "github-enterprise" fall through to the host-based GitHub path.
 func parseForgeTargetWithKind(kind, raw string) (ForgeTarget, error) {
 	switch ForgeKind(strings.ToLower(strings.TrimSpace(kind))) {
@@ -412,10 +409,10 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		s.logger.Info("forge switch queued (non-GitHub)",
 			"hive_id", id, "kind", target.Kind, "host", target.Host)
 		json.NewEncoder(w).Encode(map[string]any{
-			"ok":    true,
-			"kind":  string(target.Kind),
-			"host":  target.Host,
-			"note":  fmt.Sprintf("hive %s will switch to %s (%s) on its next heartbeat. Ensure the spoke has a %s access token in its environment.", id, target.Host, target.Kind, defaultTokenEnvForKind(target.Kind)),
+			"ok":   true,
+			"kind": string(target.Kind),
+			"host": target.Host,
+			"note": fmt.Sprintf("hive %s will switch to %s (%s) on its next heartbeat. Ensure the spoke has a %s access token in its environment.", id, target.Host, target.Kind, defaultTokenEnvForKind(target.Kind)),
 		})
 		return
 	}

--- a/src/pkg/hub/hub_generations_store.go
+++ b/src/pkg/hub/hub_generations_store.go
@@ -477,17 +477,6 @@ func (s *HubServer) currentGenerations() *generationSet {
 	return s.keyGenerations
 }
 
-// setGenerations installs a new set and records when it happened.
-func (s *HubServer) setGenerations(gs *generationSet, rotatedAt time.Time) {
-	if s == nil || gs == nil {
-		return
-	}
-	s.keyGenerationsMu.Lock()
-	defer s.keyGenerationsMu.Unlock()
-	s.keyGenerations = gs
-	s.lastKeyRotation = rotatedAt
-}
-
 // lastRotationAt reports when the current generation was minted, or the zero
 // time on a hub that has never rotated.
 func (s *HubServer) lastRotationAt() time.Time {

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2074,18 +2074,14 @@ func (s *HubServer) handleListClusters(w http.ResponseWriter, r *http.Request) {
 
 const clusterHealthCacheTTL = 30 * time.Second
 
-// clusterHealthCPUWarnPct is the CPU usage percentage threshold for warning state.
-const clusterHealthCPUWarnPct = 60
-
-// clusterHealthCPUDangerPct is the CPU usage percentage threshold for danger state.
-const clusterHealthCPUDangerPct = 80
-
-// clusterHealthMemWarnPct is the memory usage percentage threshold for warning state.
-const clusterHealthMemWarnPct = 60
-
-// clusterHealthMemDangerPct is the memory usage percentage threshold for danger state.
-const clusterHealthMemDangerPct = 80
-
+// CPU and memory bar thresholds are NOT declared here. The hub serves the
+// cluster-health panel raw percentages and the panel colours them with its own
+// CLUSTER_CPU_WARN_PCT / CLUSTER_CPU_DANGER_PCT / CLUSTER_MEM_* constants, so a
+// Go-side copy would be a second set of numbers that nothing reads and nobody
+// updates together. The disk thresholds below are different: they are anchored
+// to kubelet behaviour rather than taste and are pinned by a test, so they have
+// a reason to exist on this side.
+//
 // Disk thresholds are anchored to kubelet's own behaviour rather than to
 // round numbers, so a coloured bar means something concrete is about to
 // happen on the node:
@@ -2107,17 +2103,8 @@ const clusterHealthDiskWarnPct = 85
 // hard eviction threshold fires (nodefs.available<10%).
 const clusterHealthDiskDangerPct = 90
 
-// kubectlTopTimeoutSec is the timeout for kubectl top nodes commands.
-const kubectlTopTimeoutSec = 10
-
-// kubectlGetTimeoutSec is the timeout for kubectl get nodes commands.
-const kubectlGetTimeoutSec = 10
-
 // millicoresPerCore converts cores to millicores.
 const millicoresPerCore = 1000
-
-// mbPerGB converts megabytes to gigabytes.
-const mbPerGB = 1024
 
 // kiToBytes converts Ki units to bytes.
 const kiToBytes = 1024
@@ -2163,15 +2150,6 @@ type ClusterHealthNode struct {
 // hiveHostedNamespacePrefix is the namespace prefix used for SaaS-provisioned
 // hives; pods in these namespaces identify hives running on a node.
 const hiveHostedNamespacePrefix = "hive-hosted-"
-
-// hostedAvailableIDPrefix is the ID prefix a pre-provisioned pool slot carries
-// while it is unclaimed inventory (e.g. "hosted-available-oke-01-placeholder-bb95").
-// It is the RegistryEntry-side marker for an available placeholder: unlike
-// MyHiveEntry, RegistryEntry has no ProvStatus field, so the ID prefix (paired
-// with the "available-" org prefix, placeholderOrgPrefix) is the reliable signal
-// that a slot is idle inventory rather than a claimed hive. A claimed hive keeps
-// neither marker.
-const hostedAvailableIDPrefix = "hosted-available-"
 
 type ClusterHealthSummary struct {
 	TotalNodes    int `json:"total_nodes"`

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -174,6 +174,14 @@ const hubUpgradeDebounce = 4 * time.Minute
 // paying that per hive serialized the upgrade loop and starved the hub's own
 // upgrade check that runs after it. The heartbeat fallback is the real delivery
 // path for unreachable clusters, so failing fast costs nothing.
+//
+// Retained under nolint despite having no current caller: three other files
+// cite it BY NAME as the basis for their own timeouts
+// (hosted_namespace_identity.go, netadmin_reconcile.go, saas_bulk.go). Deleting
+// it to satisfy the linter would orphan those comments and lose the recorded
+// reasoning for the 15s figure, which is the thing worth keeping.
+//
+//nolint:unused // referenced by name from three sibling timeout comments
 const upgradeKubectlTimeout = 15 * time.Second
 
 // clusterUnreachableTTL is how long the hub skips kubectl for a cluster after a

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -880,8 +880,9 @@ type HubServer struct {
 	//
 	// GUARDED BY keyGenerationsMu. The admin rotate endpoint replaces this
 	// pointer while heartbeat and cookie verifiers are concurrently reading it,
-	// so every access goes through currentGenerations() / setGenerations()
-	// rather than touching the field. The field itself is only ever REPLACED,
+	// so every read goes through currentGenerations() rather than touching the
+	// field, and every write holds keyGenerationsMu for the duration of its
+	// evaluate-persist-install sequence. The field itself is only ever REPLACED,
 	// never mutated in place — generationSet.rotate is pure and returns a new
 	// set — so a reader that grabbed the old pointer keeps a consistent,
 	// immutable snapshot and simply verifies against the pre-rotation set for

--- a/src/pkg/hub/wrapkey_store.go
+++ b/src/pkg/hub/wrapkey_store.go
@@ -32,6 +32,16 @@ import (
 // the PVC. A var rather than a const so tests can redirect it and exercise the
 // real resolution order — the reason given at src/cmd/hive/main.go:95-97.
 // Production never reassigns it.
+//
+// NOT YET READ BY ANY CALLER, deliberately kept. Every function in this file
+// takes the path as an argument and the spoke-side lifecycle has no production
+// entry point yet, so this declaration is the only record of where the key is
+// supposed to land once it does. Deleting it to satisfy the linter would delete
+// the answer, not the dead code — the first caller would then have to re-derive
+// a path for private key material, which is exactly the kind of decision that
+// should not be made twice.
+//
+//nolint:unused // staged lifecycle: documented production location, no caller yet (#4903)
 var spokeWrapKeyPath = "/data/hive-wrap-key"
 
 // spokeWrapKeyFileMode is rw------- , identical to spokeAppKeyFileMode and for

--- a/src/pkg/proxy/proxy_coverage2_test.go
+++ b/src/pkg/proxy/proxy_coverage2_test.go
@@ -726,20 +726,6 @@ func TestStartInferenceTranslator_HandlerBranches(t *testing.T) {
 	}
 }
 
-func waitForServer(t *testing.T, base string) {
-	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", strings.TrimPrefix(base, "http://"), 200*time.Millisecond)
-		if err == nil {
-			conn.Close()
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("translator server did not come up at %s", base)
-}
-
 // ---------- handleInferenceRequest / handleAnthropicReroute over MITM ----------
 
 // mitmDialClient builds an HTTP client that CONNECTs through the proxy and does

--- a/src/pkg/proxy/proxy_deep6_test.go
+++ b/src/pkg/proxy/proxy_deep6_test.go
@@ -2,8 +2,6 @@ package proxy
 
 import (
 	"bufio"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
@@ -197,13 +195,6 @@ func TestHandleConnectDirectUpstreamDialFail(t *testing.T) {
 	if !strings.Contains(statusLine, "502") {
 		t.Fatalf("expected 502 on upstream dial failure, got %q", statusLine)
 	}
-}
-
-func newCertPool(p *GitHubProxy) *x509.CertPool {
-	pool := x509.NewCertPool()
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: p.caX509.Raw})
-	pool.AppendCertsFromPEM(caPEM)
-	return pool
 }
 
 // ---------- identifyAgentFromReq: UID lookup succeeds ----------

--- a/src/pkg/tokens/collector_test.go
+++ b/src/pkg/tokens/collector_test.go
@@ -8,22 +8,6 @@ import (
 	"testing"
 )
 
-// jsonlLine builds a minimal JSONL line for session entries used in tests.
-func jsonlLine(fields map[string]interface{}) string {
-	parts := []string{}
-	for k, v := range fields {
-		switch val := v.(type) {
-		case string:
-			parts = append(parts, fmt.Sprintf("%q:%q", k, val))
-		case int:
-			parts = append(parts, fmt.Sprintf("%q:%d", k, val))
-		case int64:
-			parts = append(parts, fmt.Sprintf("%q:%d", k, val))
-		}
-	}
-	return "{" + strings.Join(parts, ",") + "}"
-}
-
 // writeFile writes content to a file in dir with the given name.
 func writeFile(t *testing.T, dir, name, content string) string {
 	t.Helper()

--- a/src/pkg/worksource/linear.go
+++ b/src/pkg/worksource/linear.go
@@ -28,9 +28,6 @@ import (
 // defaultLinearBaseURL is Linear's single GraphQL endpoint.
 const defaultLinearBaseURL = "https://api.linear.app/graphql"
 
-// linearPageSize is the number of issues requested per GraphQL page.
-const linearPageSize = 100
-
 // defaultLinearStates is used when a team's States list is empty.
 var defaultLinearStates = []string{"Todo", "In Progress", "Backlog"}
 
@@ -86,6 +83,10 @@ func NewLinearSource(cfg LinearConfig, httpClient *http.Client) *LinearSource {
 // SourceType implements WorkSource.
 func (s *LinearSource) SourceType() string { return "linear" }
 
+// linearIssuesQuery pages at `first: 100`, Linear's maximum page size. The page
+// size is part of the query document rather than a separate constant so it
+// cannot be changed in one place and left unchanged in the document that
+// actually runs.
 const linearIssuesQuery = `query($teamKey: String!, $states: [String!], $cursor: String) {
   issues(
     filter: {


### PR DESCRIPTION
## What

Advances the golangci-lint ratchet tracked in #4903: fixes all 44 `unused` (staticcheck U1000) findings from the first lint run and adds `unused` to the enforced linter set in `src/.golangci.yml`.

This is the third rung after #4902 (gate created) and #4906 (`ineffassign`, 11 findings). Remaining after this: `staticcheck` (225), then `errcheck` (579, split by package) — each gets its own PR per the issue's one-linter-per-PR procedure.

## Credit

Contributor **Danathar** did this rung first in #4934 and correctly identified this same finding set, but that PR became unmergeable (`DIRTY`) through unrelated churn on `v4` after it was opened. Its diff was used as the map of where every finding lives. Every single site was independently re-verified against current `v4` HEAD before being carried forward — grepping the whole repo to confirm each symbol is still genuinely unreferenced, since several of the touched files had changed since #4934 was opened.

A few things #4934 also touched were deliberately **not** carried forward here as out of scope for a dead-code-only rung:
- Converting `kubectlForCluster` call sites in `pkg/hub/saas.go` to a timeout-context variant (`kubectlForClusterContext` / `upgradeKubectlTimeout`) — a behavior-adjacent refactor, not dead-code removal.
- A doc-comment fix unrelated to any `unused` finding (`githubAppRecheckFn` → `diagnoseGitHubApp` rename in a `cmd/hive/main.go` comment) — carried forward here anyway since it was directly adjacent to the `diagnoseGitHubAppWrite` deletion and left stale otherwise.

## Fixed (43 findings, deleted)

Mostly dead constants, type aliases, and test helpers left behind by refactors that moved on without deleting them:

- `cmd/hive/main.go`: `diagnoseGitHubAppWrite` — superseded wrapper, no callers.
- `pkg/agent`: unused test string-matching helpers (`containsBoot2`, `contains`/`containsHelper`, `waitForState`, `paneInjectLines`).
- `pkg/apiproxy/proxy.go`: unused `mu sync.RWMutex` field on `Proxy` (never locked/unlocked anywhere).
- `pkg/celtrigger/celtrigger.go`: unused `defaultPriority` const (doc comment referencing it corrected to describe the zero-value behavior directly).
- `pkg/dashboard`: `importFetchURL`, `ContributorPool` type + `contributorPool` var, `leaderboardCustomStyleCacheEntry`/`leaderboardCustomStyleMaxBytes`/`leaderboardCustomStyleDefaultRef` aliases, `beadLedgerPartialReason` (its test uses the raw string literal, not the const), `buildRoleTaskPrompt` (stale "retained for existing callers" claim — there were none), `WSTaskAssign.ref()` (superseded by `identityKey()`), `openRouterBaseURL`/`watsonxBaseURLTemplate`/`watsonxDefaultRegion` gateway aliases.
- `pkg/discord`, `pkg/github`, `pkg/proxy`, `pkg/tokens`: unused test-only helpers/types (`errTransport`, `boolPtr` in `client_test.go` — a different local `boolPtr` closure in `mergeable_test.go` is what's actually used — `waitForServer`, `newCertPool`, `jsonlLine`).
- `pkg/github/client.go`: unused `exemptFiles` var (no reader anywhere) and a duplicate package-level `perPage` const shadowed by an identically-named function-local const that's the one actually used.
- `pkg/hub`: unused forge API-path suffix consts `gitLabAPIPathSuffix`/`giteaAPIPathSuffix` (converted to a plain doc comment — the values are correct but nothing reads the constants, the spoke-side adapters own the real ones), `setGenerations` (every writer already goes directly through the field under `keyGenerationsMu`; the stale comment claiming otherwise on `HubServer.keyGenerations` is corrected), unused `clusterHealthCPUWarnPct`/`clusterHealthCPUDangerPct`/`clusterHealthMemWarnPct`/`clusterHealthMemDangerPct`/`kubectlTopTimeoutSec`/`kubectlGetTimeoutSec`/`mbPerGB` consts, `hostedAvailableIDPrefix` (its own doc comment's stated purpose — ID-prefix matching — is superseded by the org-prefix (`placeholderOrgPrefix`) matching the code actually uses; `server.go` explicitly documents the ID prefix as "deliberately NOT consulted").
- `pkg/worksource/linear.go`: unused `linearPageSize` const — the page size it claimed to name is hardcoded as `first: 100` directly in the GraphQL query document; moved the explanation there instead, where the number that actually runs lives.

Also fixed in `pkg/dashboard/status_builder.go`: `computeNextKick` and `parseCadenceDuration` were comparing against raw string literals (`"off"`, `"pause"`, `"on demand"`) instead of the `cadencePause`/`cadenceOff` constants already declared for exactly that purpose — which is why those two constants showed up as unused. Added the missing `cadenceOnDemand` const and wired all three comparison sites through the named constants. Same string comparisons, no behavior change.

## Annotated, not deleted (1 finding)

- `pkg/hub/wrapkey_store.go`: `spokeWrapKeyPath` is a documented, deliberately-unwired seam for the spoke-side wrap-key lifecycle (generate/persist/load/rotate), which has no production entry point yet — every function in the file takes the path as an argument rather than reading the var directly. Deleting it would delete the only record of where the key is supposed to live once a caller exists, not remove dead code. Kept under an explained `//nolint:unused` naming this issue.

## Behavior

Dead-code removal only. No production logic changes — the two comparison-site fixes in `status_builder.go` are string-equality checks that now go through named constants holding the identical string values, and the `forge.go`/`server.go`/`hub_generations_store.go` comment corrections describe existing behavior more accurately, they don't change it.

Refs #4903
