### PR TITLE
🔒 fix(contribute): warn that local mode is unconfined, and stop the sandbox toggle failing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,32 @@ Hive did not historically maintain a complete changelog. This file starts a prag
   the sandbox kick) outright, with the reason surfaced in the retry/quarantine
   log, because a wrong base is worse than a delayed PR
   ([#4928](https://github.com/kubestellar/hive/issues/4928)).
+- **`just contribute-hive <backend> local` now says that it runs the agent
+  unconfined on your machine**, and the docs no longer imply a workspace
+  boundary that only the opt-in Podman path provides
+  ([#4918](https://github.com/kubestellar/hive/issues/4918)). Container mode is
+  the default and is the confined one; local mode runs the backend CLI as your
+  own user with permission gating bypassed and nothing scoping its filesystem
+  access — which is how an agent running an assigned third-party repo's test
+  suite reached a contributor's bootloader. The launch banner now names what is
+  still constrained (the #4938 host-state denials; credentials and pushes on
+  every path) and what is not, and points at container mode as the remedy.
+  `sandbox-isolation.md` gains a per-path table recording the finding that
+  matters most here: **the `agent_sandbox` Podman path is hub-side only and
+  does not exist on the contributor path at all**, so enabling it would not
+  have prevented the reported incident.
+- **A globally-enabled agent sandbox that sandboxes nothing is no longer
+  silent.** `agent_sandbox.enabled` is only half the gate — each agent also
+  needs `sandbox: {enabled: true}` — and the dashboard's Security tab writes
+  only the global half, so an owner could turn the sandbox on, be told the
+  setting was updated, and have every agent keep running unconfined. Hive now
+  logs an `agent sandbox posture` warning at boot **and on every config
+  reload** (the moment the toggle is flipped) naming which agents are still
+  unconfined, and separately warns when an opted-in agent resolves no sandbox
+  image — sandboxed kicks have no tmux fallback and fail outright. Behaviour is
+  unchanged: the second gate is load-bearing and collapsing it would convert
+  working agents into permanently failing ones, so that remains a separate,
+  measurement-first decision.
 
 - Pull requests from forks can now satisfy `v4`'s required `gate` status context. `gate` is a job in `docker.yml`, which triggered on `push` only — and a fork PR's push event fires in the contributor's repo, not here, so `gate` never attached to the head SHA this repo evaluates and branch protection blocked the merge waiting for a check that could not arrive. Six fully green contributor PRs (#4930, #4932, #4934, #4935, #4936, #4937) were structurally unmergeable; `gate` was verified absent on every one of their head SHAs. It went unnoticed because `enforce_admins` is false, so maintainers' own merges silently bypassed the same missing check — the required context was in practice unenforced for maintainers and absolutely enforced for outside contributors. `docker.yml` now also triggers on `pull_request`, with every image-build job skipped for that event, so the context attaches to fork PRs at the cost of one ~5-second shell job and no image CI: the image is already built and smoke-tested on every PR by `v2-ci.yml` (`docker`, `build-and-test`, `overlayfs-exec-guard`). Push builds and GHCR publishing are unchanged — `gate` reports `push=false` for a PR event, so every `merge*` job stays skipped ([#4965](https://github.com/kubestellar/hive/issues/4965)).
 

--- a/Justfile
+++ b/Justfile
@@ -720,7 +720,11 @@ contribute-move backend="claude": check-version (contribute-check-backend backen
 # Start contributing — containerized (default; docker or podman) or local mode
 # Usage: just contribute-hive              (container, default CLI from setup)
 #        just contribute-hive copilot      (container, copilot backend)
-#        just contribute-hive claude local  (native mode, claude)
+#        just contribute-hive claude local  (UNCONFINED, on your host — see #4918)
+#
+# Container mode is the default and is the confined one. Local mode runs the
+# backend CLI as your own user on your own machine with permission gating
+# bypassed and no workspace confinement; the recipe warns about that at launch.
 # Runtime: auto-detects docker then podman (discovery order, not posture —
 # see src/docs/podman-rootless-ci.md); force with HIVE_CONTAINER_RUNTIME=podman
 contribute-hive backend="" mode="docker": check-version
@@ -767,6 +771,45 @@ contribute-hive backend="" mode="docker": check-version
 
     if [[ "$_MODE" == "local" ]]; then
       # ── Local mode: tmux session + relay (same as container, but on host) ──
+      #
+      # SAY WHAT THIS MODE COSTS (#4918). Local mode runs the backend CLI as
+      # THIS user, on THIS machine, with permission gating bypassed and nothing
+      # scoping its filesystem access to the workspace. Container mode — the
+      # DEFAULT, which is why the recipe's `mode` parameter defaults to
+      # "docker" — puts the same agent behind a container boundary instead.
+      #
+      # An operator picking `local` was previously told nothing about that
+      # difference: the recipe's own usage line described it only as "native
+      # mode". #4918 is what the silence cost. An agent doing entirely correct
+      # work on an assigned third-party repo ran that repo's own test suite; a
+      # latent defect in two of its tests let a hook escape its stubs and call
+      # `rpm-ostree kargs --append-if-missing=...` against the operator's REAL
+      # deployment, raising three polkit dialogs on their desktop. Nothing was
+      # written, and the only reason is that the process happened to lack
+      # privilege. No compromise was involved.
+      #
+      # The message names what IS still constrained, deliberately, so it reads
+      # as a boundary statement rather than an alarm: #4938's host-state
+      # denials apply here (backends.conf is sourced by this recipe below), and
+      # credentials/pushes are constrained on every path. Neither of those is
+      # filesystem confinement, and the agent_sandbox podman path is hub-side
+      # only — it does not exist on this path at all, so it is not offered as a
+      # remedy here. Container mode is the remedy on this path.
+      echo "⚠️  LOCAL MODE — the agent is NOT confined to a workspace."
+      echo ""
+      echo "    The backend CLI runs as $(id -un) on this machine, with permission"
+      echo "    prompts bypassed. It can read and write anything your user can,"
+      echo "    including files outside ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
+      echo "    Assigned repos are third-party code and their test suites run for real."
+      echo ""
+      echo "    Still constrained: privilege-escalation and host boot/deployment"
+      echo "    commands are denied (sudo, pkexec, rpm-ostree, bootc, grubby, ...),"
+      echo "    and no agent receives a GitHub token or pushes directly."
+      echo "    NOT constrained: everything else your user can reach."
+      echo ""
+      echo "    For a confined agent, drop 'local' and use container mode:"
+      echo "      just contribute-hive ${BACKEND}"
+      echo ""
       TMUX_SESSION="hive-${BACKEND}-$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' ')"
       SCRIPT_DIR="$(pwd)/bin"
       RELAY="${SCRIPT_DIR}/contributor-relay.sh"

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1519,6 +1519,19 @@ func main() {
 	archiveOnShutdown := func() { agentMgr.ArchiveAllKickLogs("shutdown") }
 	preShutdownHook.Store(&archiveOnShutdown)
 	agentMgr.SetSandboxConfig(cfg.AgentSandbox)
+
+	// Say out loud when the sandbox opt-in is configured but inert. The gate is
+	// two-part (global agent_sandbox.enabled AND a per-agent sandbox.enabled),
+	// and the dashboard's Security tab writes only the global half — so an
+	// owner can turn the sandbox on, be told the setting was updated, and still
+	// have every agent running unconfined on the operator's own host.
+	//
+	// That silence is the part of #4918 that is safe to fix here. The gate
+	// itself is load-bearing: a sandboxed agent runs a different execution
+	// model and startSandboxKickLocked has no tmux fallback, so collapsing it
+	// would convert working agents into permanently failing ones. Telling an
+	// operator who believes they are covered that they are not costs nothing.
+	logAgentSandboxPosture(logger, cfg)
 	// Treat any configured gateway name as an inference-routable backend so an
 	// agent with backend: <gateway> routes through it. Resolution is live
 	// (reads cfg on each call) so gateways added from the Model Gateways tab
@@ -3002,6 +3015,11 @@ func main() {
 		// threshold — re-sync it alongside the repo list above.
 		gov.SetRepoCount(cfg.Project.RepoCount())
 		agentMgr.SetSandboxConfig(cfg.AgentSandbox)
+		// Re-run the posture check on reload, not only at boot: flipping the
+		// Security tab's sandbox toggle writes the config and lands here, which
+		// is the exact moment an operator forms the belief that they are now
+		// sandboxed. See logAgentSandboxPosture.
+		logAgentSandboxPosture(logger, cfg)
 
 		// Hot-reload the state-triggered hooks (RFC #4001). Recompiles only
 		// when the `hooks:` list actually changed, and swaps the registry in
@@ -8612,6 +8630,18 @@ func parseColorInt(color string) int {
 	var result int
 	fmt.Sscanf(color, "%x", &result)
 	return result
+}
+
+// logAgentSandboxPosture emits the sandbox gate diagnostics from
+// config.AgentSandboxGateWarnings at WARN.
+//
+// Split out so boot and the config-watcher reload report identically — an
+// operator who flips the Security tab's sandbox toggle never restarts, so a
+// boot-only check would never reach the person who most needs it.
+func logAgentSandboxPosture(logger *slog.Logger, cfg *config.Config) {
+	for _, warning := range config.AgentSandboxGateWarnings(cfg) {
+		logger.Warn("agent sandbox posture", "warning", warning)
+	}
 }
 
 func runHub(logger *slog.Logger, configPath string) {

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -122,6 +122,17 @@ otherwise (#4918). Repo work is unaffected. `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_
 restores the old posture and is the claude analogue of the Codex bypass below;
 prefer leaving it unset.
 
+Container mode vs local mode is the confinement choice on this path. Those
+denials are a floor, not a boundary: they name commands, and an agent still runs
+unconfined against everything not on the list. `just contribute-hive` defaults to
+**container** mode, which puts the agent behind a container boundary;
+`just contribute-hive <backend> local` runs it as your own user on your own
+machine with permission gating bypassed and nothing scoping its filesystem access
+to the workspace. Local mode now says so at launch. Note that the `agent_sandbox`
+Podman path documented in [sandbox-isolation.md](sandbox-isolation.md) is
+**hub-side only** — nothing on the contributor path reads it — so container mode
+is the remedy here, not that setting.
+
 Codex config-key compatibility: `approvals_reviewer` is passed with `-c`, so it
 depends on the installed Codex release accepting that key. If a version rejects
 it at startup, set `HIVE_CODEX_APPROVALS_REVIEWER=` (empty) to drop the key

--- a/src/docs/sandbox-isolation.md
+++ b/src/docs/sandbox-isolation.md
@@ -11,11 +11,27 @@ Two halves of that target hold differently, and the difference matters:
 
 **#4918 is what that costs in practice, and it did not require a compromise.** An agent doing correct work on an assigned third-party repo ran that repo's own test suite; a latent defect in two of its tests let a hook escape its stubs and issue `rpm-ostree kargs --append-if-missing=...` against the operator's real deployment. Nothing was written, and the only reason is that the process happened to lack privilege. Benign behaviour was a sufficient precondition, so this is a routine exposure rather than an exceptional one.
 
-The claude-family launch path now carries host-state denials for exactly this class — privilege escalation (`sudo`, `pkexec`, `doas`, `su`) and the boot/deployment tools that reach polkit without needing escalation of their own (`rpm-ostree`, `bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`), matching the workspace-write posture Codex has had since #3512. That is a floor, not a sandbox: it names commands rather than enforcing a boundary, and an agent still runs unconfined against everything not on the list. **Operators running hive on a machine they care about should enable the sandbox below.**
+The claude-family launch path now carries host-state denials for exactly this class — privilege escalation (`sudo`, `pkexec`, `doas`, `su`) and the boot/deployment tools that reach polkit without needing escalation of their own (`rpm-ostree`, `bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`), matching the workspace-write posture Codex has had since #3512. That is a floor, not a sandbox: it names commands rather than enforcing a boundary, and an agent still runs unconfined against everything not on the list.
+
+## Which confinement is available depends on the path you are on
+
+This is the part that is easy to get wrong, because the two paths have different levers and only one of them has the Podman sandbox at all.
+
+| | Hub / pod agents (`pkg/agent`) | Contributor relay (`just contribute-hive`) |
+|---|---|---|
+| Runs where | The hive spoke's own container | The contributor's machine |
+| Podman agent sandbox (`agent_sandbox`) | Available, opt-in — see below | **Does not exist on this path.** `SandboxEnabled` is read only by `pkg/agent`; nothing in `bin/contributor-relay.sh`, `bin/contributor-agent.sh` or the `Justfile` consults it |
+| The confinement lever | `agent_sandbox` + the per-agent opt-in | **Container mode vs local mode** — `just contribute-hive` defaults to container; `... local` is the unconfined one |
+| Host-state denials (#4938) | Yes | Yes (`config/backends.conf`) |
+| Credentials / pushes | Constrained | Constrained |
+
+**The #4918 incident happened on the contributor relay's local mode**, so enabling `agent_sandbox` would not have prevented it. The remedy on that path is container mode, which `just contribute-hive` already uses by default and now warns about when it is not.
+
+Operators running hive on a machine they care about should therefore: use container mode on the contributor path, and enable the sandbox below on the hub path.
 
 ## Current wiring
 
-Sandbox execution is opt-in and the tmux path remains unchanged for all agents unless both gates are set:
+Sandbox execution is opt-in and the tmux path remains unchanged for all agents unless **both** gates are set — the global one and a per-agent one:
 
 ```yaml
 agent_sandbox:
@@ -30,6 +46,10 @@ agents:
     sandbox:
       enabled: true
 ```
+
+**Both gates are required, and the global one alone does nothing.** `agent_sandbox.enabled: true` with no per-agent `sandbox.enabled: true` sandboxes zero agents. That matters more than it reads, because the dashboard's Security tab writes *only* the global flag and is the only sandbox control the UI offers: an owner can turn "agent sandbox" on, be told the setting was updated, and have every agent keep running unconfined. Hive now logs a `agent sandbox posture` warning at boot and on every config reload when the sandbox is enabled globally but some or all agents are not opted in (`config.AgentSandboxGateWarnings`).
+
+The second gate is deliberate rather than an oversight, and it is not safe to simply collapse. A sandboxed agent runs a different execution model — no tmux CLI at all, and every kick is a Podman run against the primary repo — and `startSandboxKickLocked` has **no fallback to the tmux path**: an agent opted in without a resolvable image fails every kick outright rather than degrading. Making the global flag sufficient would therefore convert working agents into permanently failing ones on any hive that set it without an image. Changing that default is a fleet-affecting decision that wants measurement, not a code-reading; the warning above is the part that is safe today.
 
 For sandboxed agents, a kick now follows this path:
 

--- a/src/pkg/config/agent_sandbox_gate_test.go
+++ b/src/pkg/config/agent_sandbox_gate_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// The sandbox opt-in is two-gated: agent_sandbox.enabled AND a per-agent
+// sandbox.enabled. The dashboard's Security tab writes only the first, and it
+// is the only sandbox control the UI offers — so an owner can turn "agent
+// sandbox" on, be told the setting was updated, and have every agent keep
+// running unconfined on the operator's host.
+//
+// #4918 is what that silence costs: an agent doing correct work on an assigned
+// third-party repo ran that repo's test suite, a hook escaped its stubs, and
+// `rpm-ostree kargs` reached the operator's real deployment. An operator who
+// had flipped the toggle would reasonably have believed they were covered.
+//
+// These tests pin the diagnostic, not a behaviour change. Collapsing the gate
+// itself is deliberately NOT done — see AgentSandboxGateWarnings.
+
+func gateCfg(t *testing.T, globalEnabled bool, globalImage string, agents map[string]AgentConfig) *Config {
+	t.Helper()
+	return &Config{
+		AgentSandbox: AgentSandboxConfig{Enabled: globalEnabled, Image: globalImage},
+		Agents:       agents,
+	}
+}
+
+// TestSandboxOffGloballyIsNotAWarning: the documented default posture is the
+// sandbox being off. Warning about it on every hive would be noise that trains
+// operators to ignore the line that matters.
+func TestSandboxOffGloballyIsNotAWarning(t *testing.T) {
+	cfg := gateCfg(t, false, "", map[string]AgentConfig{"scanner": {}})
+	if got := AgentSandboxGateWarnings(cfg); len(got) != 0 {
+		t.Errorf("AgentSandboxGateWarnings = %q, want none when the sandbox is off globally", got)
+	}
+}
+
+// TestGlobalGateAloneIsReportedInert is the #4918 case: the exact state the
+// dashboard toggle produces on a hive with no per-agent sandbox blocks.
+func TestGlobalGateAloneIsReportedInert(t *testing.T) {
+	cfg := gateCfg(t, true, "ghcr.io/example/agent:latest", map[string]AgentConfig{
+		"scanner": {},
+		"quality": {},
+	})
+	got := AgentSandboxGateWarnings(cfg)
+	if len(got) != 1 {
+		t.Fatalf("AgentSandboxGateWarnings = %q, want exactly one warning", got)
+	}
+	for _, want := range []string{"NO agent is opted in", "inert", "unconfined", "#4918"} {
+		if !strings.Contains(got[0], want) {
+			t.Errorf("warning %q does not mention %q", got[0], want)
+		}
+	}
+	// The remedy has to be in the message. A warning that names a problem and
+	// not the key that fixes it sends the operator back to the source.
+	if !strings.Contains(got[0], "sandbox: {enabled: true}") {
+		t.Errorf("warning %q does not name the per-agent key that fixes it", got[0])
+	}
+}
+
+// TestFullyOptedInIsSilent: a correctly configured hive must produce no
+// warnings at all, or the diagnostic is noise.
+func TestFullyOptedInIsSilent(t *testing.T) {
+	cfg := gateCfg(t, true, "ghcr.io/example/agent:latest", map[string]AgentConfig{
+		"scanner": {Sandbox: &AgentSandboxOverride{Enabled: boolPtr(true)}},
+	})
+	if got := AgentSandboxGateWarnings(cfg); len(got) != 0 {
+		t.Errorf("AgentSandboxGateWarnings = %q, want none for a fully opted-in hive", got)
+	}
+}
+
+// TestPartialOptInNamesTheUnconfinedRemainder. A hive that sandboxed one agent
+// and forgot the others is the state most likely to be mistaken for "we are
+// sandboxed" — the Security tab reports the global flag as on either way.
+func TestPartialOptInNamesTheUnconfinedRemainder(t *testing.T) {
+	cfg := gateCfg(t, true, "ghcr.io/example/agent:latest", map[string]AgentConfig{
+		"scanner": {Sandbox: &AgentSandboxOverride{Enabled: boolPtr(true)}},
+		"quality": {},
+		"planner": {},
+	})
+	got := AgentSandboxGateWarnings(cfg)
+	if len(got) != 1 {
+		t.Fatalf("AgentSandboxGateWarnings = %q, want exactly one warning", got)
+	}
+	for _, want := range []string{"only 1 of 3", "scanner", "unconfined"} {
+		if !strings.Contains(got[0], want) {
+			t.Errorf("warning %q does not mention %q", got[0], want)
+		}
+	}
+}
+
+// TestOptedInWithoutAnImageIsReported. startSandboxKickLocked refuses a kick
+// when no image resolves, and there is NO fallback to the tmux path — so this
+// misconfiguration does not degrade, it fails every kick. That is also the
+// reason the second gate cannot simply be collapsed, so it is worth its own
+// line rather than being folded into the inert-gate message.
+func TestOptedInWithoutAnImageIsReported(t *testing.T) {
+	cfg := gateCfg(t, true, "", map[string]AgentConfig{
+		"scanner": {Sandbox: &AgentSandboxOverride{Enabled: boolPtr(true)}},
+	})
+	got := AgentSandboxGateWarnings(cfg)
+	if len(got) != 1 {
+		t.Fatalf("AgentSandboxGateWarnings = %q, want exactly one warning", got)
+	}
+	for _, want := range []string{"scanner", "no sandbox image", "no tmux fallback"} {
+		if !strings.Contains(got[0], want) {
+			t.Errorf("warning %q does not mention %q", got[0], want)
+		}
+	}
+}
+
+// TestPerAgentImageSatisfiesTheImageCheck: the per-agent override is a real
+// source of the image, so an agent carrying its own must not be reported.
+func TestPerAgentImageSatisfiesTheImageCheck(t *testing.T) {
+	cfg := gateCfg(t, true, "", map[string]AgentConfig{
+		"scanner": {Sandbox: &AgentSandboxOverride{
+			Enabled: boolPtr(true),
+			Image:   "ghcr.io/example/scanner:latest",
+		}},
+	})
+	if got := AgentSandboxGateWarnings(cfg); len(got) != 0 {
+		t.Errorf("AgentSandboxGateWarnings = %q, want none when the agent carries its own image", got)
+	}
+}
+
+// TestExplicitPerAgentFalseStillCountsAsUnconfined. `sandbox: {enabled: false}`
+// is a deliberate opt-out, but the agent is still running unconfined, so the
+// count the operator is shown must include it.
+func TestExplicitPerAgentFalseStillCountsAsUnconfined(t *testing.T) {
+	cfg := gateCfg(t, true, "ghcr.io/example/agent:latest", map[string]AgentConfig{
+		"scanner": {Sandbox: &AgentSandboxOverride{Enabled: boolPtr(true)}},
+		"quality": {Sandbox: &AgentSandboxOverride{Enabled: boolPtr(false)}},
+	})
+	got := AgentSandboxGateWarnings(cfg)
+	if len(got) != 1 || !strings.Contains(got[0], "only 1 of 2") {
+		t.Errorf("AgentSandboxGateWarnings = %q, want it to count the opted-out agent as unconfined", got)
+	}
+}
+
+// TestNilConfigIsSafe: the diagnostic runs on the boot path and on every config
+// reload; it must never be the thing that panics there.
+func TestNilConfigIsSafe(t *testing.T) {
+	if got := AgentSandboxGateWarnings(nil); len(got) != 0 {
+		t.Errorf("AgentSandboxGateWarnings(nil) = %q, want none", got)
+	}
+}

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -1034,6 +1034,73 @@ func (a *AgentConfig) SandboxEnabled(global AgentSandboxConfig) bool {
 	return *a.Sandbox.Enabled
 }
 
+// AgentSandboxGateWarnings reports the sandbox misconfigurations that the
+// two-gate opt-in otherwise makes SILENT. Empty means nothing to say.
+//
+// SandboxEnabled (above) requires BOTH agent_sandbox.enabled AND a per-agent
+// sandbox.enabled: true. That second gate is deliberate — a sandboxed agent
+// runs a completely different execution model (no tmux CLI at all; every kick
+// is a podman run against the primary repo), and startSandboxKickLocked in
+// pkg/agent has NO fallback to tmux: an agent flipped on without a resolvable
+// image fails every kick outright. So the gate is not something to quietly
+// collapse.
+//
+// What it must not do is stay invisible. The dashboard's Security tab writes
+// only the GLOBAL flag (handleGovernorSecurity), and it is the only sandbox
+// control the UI offers — so an owner can turn "agent sandbox" on, be told the
+// setting was updated, and have every agent keep running unconfined. The
+// response's own sandboxedAgents field stays 0 and nothing explains why.
+//
+// #4918 is what that silence costs. An agent doing correct work on an assigned
+// third-party repo ran that repo's test suite, a hook escaped its stubs, and
+// `rpm-ostree kargs` reached the operator's real deployment. An operator who
+// had flipped the sandbox toggle on would reasonably believe they were covered.
+//
+// These are WARNINGS, not validation errors: every state described here is a
+// legal config, and refusing to boot on it would turn a diagnostic into an
+// outage.
+func AgentSandboxGateWarnings(cfg *Config) []string {
+	if cfg == nil || !cfg.AgentSandbox.Enabled {
+		// The sandbox is off globally. That is the documented default and the
+		// posture the docs describe; it is not a misconfiguration.
+		return nil
+	}
+
+	var optedIn, noImage []string
+	for name, a := range cfg.Agents {
+		if !a.SandboxEnabled(cfg.AgentSandbox) {
+			continue
+		}
+		optedIn = append(optedIn, name)
+		if strings.TrimSpace(a.SandboxImage(cfg.AgentSandbox)) == "" {
+			noImage = append(noImage, name)
+		}
+	}
+	sort.Strings(optedIn)
+	sort.Strings(noImage)
+
+	var out []string
+	if len(optedIn) == 0 {
+		out = append(out, fmt.Sprintf(
+			"agent_sandbox.enabled is true but NO agent is opted in, so the sandbox is inert and all %d agent(s) still run unconfined on the tmux path — "+
+				"the per-agent gate is separate: set `sandbox: {enabled: true}` on each agent that should be sandboxed (#4918)",
+			len(cfg.Agents)))
+		return out
+	}
+	if len(noImage) > 0 {
+		out = append(out, fmt.Sprintf(
+			"agent(s) %s are sandbox-opted-in but resolve no sandbox image; sandboxed kicks have no tmux fallback and will fail outright — "+
+				"set agent_sandbox.image (or the per-agent sandbox.image)",
+			strings.Join(noImage, ", ")))
+	}
+	if len(optedIn) < len(cfg.Agents) {
+		out = append(out, fmt.Sprintf(
+			"agent_sandbox.enabled is true but only %d of %d agent(s) are opted in (%s); the rest still run unconfined on the tmux path (#4918)",
+			len(optedIn), len(cfg.Agents), strings.Join(optedIn, ", ")))
+	}
+	return out
+}
+
 // SandboxImage returns the per-agent image override, then the global default.
 func (a *AgentConfig) SandboxImage(global AgentSandboxConfig) string {
 	if a != nil && a.Sandbox != nil && a.Sandbox.Image != "" {

--- a/src/pkg/dashboard/contribute_local_mode_warning_test.go
+++ b/src/pkg/dashboard/contribute_local_mode_warning_test.go
@@ -1,0 +1,77 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// #4918: `just contribute-hive <backend> local` runs the backend CLI as the
+// contributor's own user, on their own machine, with permission gating
+// bypassed and nothing scoping its filesystem access to the workspace. The
+// recipe previously described that mode only as "native mode" and said nothing
+// about the difference.
+//
+// What the silence cost: an agent doing entirely correct work on an assigned
+// third-party repo ran that repo's own test suite; a latent defect in two of
+// its tests let a hook escape its stubs and call `rpm-ostree kargs` against the
+// operator's REAL deployment, raising three polkit dialogs on their desktop.
+// Nothing was written, and the only reason is that the process happened to lack
+// privilege. No compromise was involved.
+//
+// The remedy on this path is container mode, which is already the default. The
+// warning exists so the operator choosing `local` is choosing it knowingly.
+
+// contributeHiveLocalBranch returns the head of contribute-hive's local-mode
+// branch, up to the tmux session name it derives. Read from the Justfile rather
+// than restated, so the warning cannot be dropped quietly.
+func contributeHiveLocalBranch(t *testing.T) string {
+	t.Helper()
+	src := justfileSource(t)
+	start := strings.Index(src, `if [[ "$_MODE" == "local" ]]; then`)
+	if start < 0 {
+		t.Fatal("contribute-hive local-mode branch not found in the Justfile")
+	}
+	end := strings.Index(src[start:], "TMUX_SESSION=")
+	if end < 0 {
+		t.Fatal("end of the local-mode preamble not found in the Justfile")
+	}
+	return src[start : start+end]
+}
+
+// TestLocalModeWarnsItIsUnconfined pins the warning itself.
+func TestLocalModeWarnsItIsUnconfined(t *testing.T) {
+	block := contributeHiveLocalBranch(t)
+
+	if !strings.Contains(block, "LOCAL MODE") || !strings.Contains(block, "NOT confined") {
+		t.Error("contribute-hive local mode no longer states that the agent is unconfined (#4918)")
+	}
+	// The warning has to name the way out, or it is an alarm rather than
+	// guidance. Container mode is the default and is the remedy on this path.
+	if !strings.Contains(block, "just contribute-hive ${BACKEND}") {
+		t.Error("the local-mode warning does not point at container mode as the confined alternative")
+	}
+}
+
+// TestLocalModeWarningIsHonestAboutWhatStillHolds. A warning that implies
+// NOTHING is constrained is its own kind of wrong: the #4938 host-state denials
+// do apply here (the recipe sources config/backends.conf), and credentials and
+// pushes are constrained on every path. Saying so is what makes the "not
+// constrained" half credible.
+func TestLocalModeWarningIsHonestAboutWhatStillHolds(t *testing.T) {
+	block := contributeHiveLocalBranch(t)
+
+	for _, want := range []string{"Still constrained", "sudo", "rpm-ostree", "GitHub token"} {
+		if !strings.Contains(block, want) {
+			t.Errorf("the local-mode warning does not mention %q, so it overstates the exposure", want)
+		}
+	}
+}
+
+// TestContainerModeRemainsTheDefault. The whole remedy above is "drop the word
+// local", which only works while container mode is what you get by default.
+func TestContainerModeRemainsTheDefault(t *testing.T) {
+	src := justfileSource(t)
+	if !strings.Contains(src, `contribute-hive backend="" mode="docker":`) {
+		t.Error("contribute-hive no longer defaults to container mode; the #4918 warning's advice is stale")
+	}
+}


### PR DESCRIPTION
## Summary

Two small changes that tell operators the truth about how confined their agents actually are.

1. **`just contribute-hive <backend> local` now warns that it is unconfined.** That mode runs the backend CLI as your own user, on your own machine, with permission prompts bypassed and nothing keeping it inside the workspace. The recipe previously described it only as "native mode". Container mode — already the default — is the confined one, and the warning points there.

2. **A sandbox toggle that sandboxes nothing is no longer silent.** `agent_sandbox.enabled` is only *half* the gate; each agent also needs `sandbox: {enabled: true}`. The dashboard's Security tab writes only the global half and is the only sandbox control the UI offers — so an owner could flip "agent sandbox" on, be told it was updated, and have every agent keep running unconfined. Hive now warns at boot **and on every config reload**, naming the agents still exposed.

Nothing about how agents run changes. This is the next safe increment after #4938; it is deliberately **not** the sandbox-by-default change, and there is a measured reason below.

Refs #4918.

---

## The finding that reframes the issue

#4918's root-cause section blames the double-gated Podman sandbox. **That sandbox does not exist on the path where the incident happened.**

`SandboxEnabled` is read only by `pkg/agent` — the hub-side pod agents. Nothing in `bin/contributor-relay.sh`, `bin/contributor-agent.sh` or the `Justfile` consults it:

```console
$ grep -rn "sandbox" bin/contributor-relay.sh bin/contributor-agent.sh | grep -v codex
$ grep -n "agent_sandbox" Justfile
$    # (both empty)
```

And the reporter's own evidence points at the contributor path: tmux session `hive-claude-bc59` in a `tmux-spawn-*` scope under the user slice is exactly what the Justfile's local-mode branch creates (`TMUX_SESSION="hive-${BACKEND}-$(head -c 2 /dev/urandom ...)"`).

**So enabling `agent_sandbox` would not have prevented the reported incident.** The lever on that path is container mode vs local mode — and container mode is already the default (`contribute-hive backend="" mode="docker"`). What was missing was anything saying so.

`sandbox-isolation.md` now carries a per-path table, and drops its "operators should enable the sandbox below" line, which was wrong advice for the contributor path.

## Why the gate is not collapsed

Making `agent_sandbox.enabled: true` sufficient on its own looks like the obvious fix. It is not safe, and I want the reason on the record rather than in a commit message:

A sandboxed agent runs a **different execution model** — no tmux CLI at all; every kick is a podman run against the primary repo. And `startSandboxKickLocked` (`src/pkg/agent/manager.go`) has **no fallback to tmux**:

```go
if strings.TrimSpace(m.sandboxConfig.Image) == "" && strings.TrimSpace(agent.Config.SandboxImage(m.sandboxConfig)) == "" {
    return fmt.Errorf("agent %s sandbox image is not configured", agent.Name)
}
repo := m.project.PrimaryRepo()
if repo == "" {
    return fmt.Errorf("agent %s sandbox execution requires a primary repo", agent.Name)
}
```

On any hive that set the global flag without a configured image, collapsing the gate would convert working agents into **permanently failing** ones. That is a fleet-affecting posture change that deserves measurement and a maintainer decision, not a code-reading — so it stays open. The warning is the part that is safe today, and a second warning names the no-image case for the same reason.

Worth noting for whoever picks up option 2: the strong form in #4918 ("require the podman path when the assigned repo is not the primary repo") is not expressible against the current executor, which clones `m.project.PrimaryRepo()` by construction.

## What the warnings look like

```
⚠️  LOCAL MODE — the agent is NOT confined to a workspace.

    The backend CLI runs as dbaggett on this machine, with permission
    prompts bypassed. It can read and write anything your user can,
    including files outside /home/op/workspace.
    Assigned repos are third-party code and their test suites run for real.

    Still constrained: privilege-escalation and host boot/deployment
    commands are denied (sudo, pkexec, rpm-ostree, bootc, grubby, ...),
    and no agent receives a GitHub token or pushes directly.
    NOT constrained: everything else your user can reach.

    For a confined agent, drop 'local' and use container mode:
      just contribute-hive claude
```

Naming what *still* holds is deliberate. A warning implying nothing is constrained is its own kind of wrong, and gets ignored.

```
WARN agent sandbox posture: agent_sandbox.enabled is true but NO agent is opted in, so the
  sandbox is inert and all 3 agent(s) still run unconfined on the tmux path — the per-agent
  gate is separate: set `sandbox: {enabled: true}` on each agent that should be sandboxed (#4918)

WARN agent sandbox posture: agent_sandbox.enabled is true but only 1 of 2 agent(s) are opted
  in (scanner); the rest still run unconfined on the tmux path (#4918)

WARN agent sandbox posture: agent(s) scanner are sandbox-opted-in but resolve no sandbox
  image; sandboxed kicks have no tmux fallback and will fail outright — set
  agent_sandbox.image (or the per-agent sandbox.image)
```

The reload hook matters more than the boot one: flipping the Security tab toggle writes the config and never restarts the process, so a boot-only check would never reach the person who most needs it.

## Tests

Pinned in both directions, because a diagnostic that cries wolf is worse than none:

- sandbox off globally is **not** a warning (that is the documented default; warning on every hive would train operators to ignore the line that matters)
- a fully opted-in hive is **silent**
- the inert and partial cases name the agents still unconfined, and the message must carry the key that fixes it
- an explicit per-agent `false` still counts as unconfined — it is a deliberate opt-out, but the agent is still exposed and the count an operator sees must say so
- the Justfile warning is read from the file rather than restated, including an assertion that **container mode is still the default**, since the advice goes stale the moment that changes

`pkg/config`, `pkg/dashboard` and `cmd/hive` pass. `pkg/config` has one pre-existing failure on this machine, `TestGateFailsClosedWithoutIP6Tables`, which needs `NET_ADMIN`; it fails identically on a clean checkout of `v4`.

## Still open on #4918

Option 1 (a real filesystem boundary on the default path, beyond #4938's command deny-list) and option 2 (changing the sandbox default) are both untouched here. The issue should stay open for them.

— hive: backend=claude model=claude-opus-5
