### PR TITLE
Remove half-wired amazonq backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ### Fixed
 
+- Removed the half-wired `amazonq` (Amazon Q Developer) backend from the operator-facing dashboard: the CLI backend picker's `KNOWN_BACKENDS` array and the "CLI Pin Value" tooltip both listed it as a selectable option, but it was never in either authoritative registry (`config/backends.conf`'s `KNOWN_BACKENDS`/`backend_binary`/`backend_perm_flag`, or `src/pkg/config/config.go`'s `CLIBackends`), so `validateBackendName` rejected it on launch — an accept-then-fail bug where the dashboard recommended a backend that could not start. Also dropped from the three shell/JS "no `--model` flag" lists in `bin/agent-launch.sh`, `bin/contributor-agent.sh`, and `bin/contributor-relay.sh` (the `goose`/`bob` handling in each is unaffected) and from `bin/contributor-relay.test.js`. Nobody had requested Amazon Q support; removal was cheaper than finishing the integration. Found by the backend-list parity guard added in [#4987](https://github.com/kubestellar/hive/pull/4987). The dashboard's JS `KNOWN_BACKENDS` array is still unguarded by that parity test — it cannot practically parse embedded JS — so this exact class of drift can recur there. ([#4988](https://github.com/kubestellar/hive/issues/4988))
+
 - An issue covered by an open PR that only *references* it (`Refs #N`, `Part of
   #N`) is no longer immediately re-offered to agents. Such weak claims — along
   with claims from externally-authored PRs — used to be ignored entirely on the

--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -144,9 +144,9 @@ else
   PERM_FLAG=$(backend_perm_flag "$BACKEND")
   MODEL_FLAG="--model"
 
-  # amazonq and goose don't support --model
+  # goose doesn't support --model
   case "$BACKEND" in
-    amazonq|goose) MODEL_FLAG="" ;;
+    goose) MODEL_FLAG="" ;;
   esac
 
   if [[ -z "$CMD" || -z "$PERM_FLAG" ]]; then

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -510,7 +510,7 @@ PERM_FLAG=$(backend_perm_flag "$AGENT_BACKEND")
 MODEL_FLAG=""
 if [[ -n "${AGENT_MODEL:-}" ]]; then
   case "$AGENT_BACKEND" in
-    # amazonq/goose take their model from config/env, not a --model flag.
+    # goose takes its model from config/env, not a --model flag.
     #
     # bob is excluded because --model is actively FATAL, not merely unused:
     # bob auto-selects its own model, and passing one leaves its model config
@@ -518,7 +518,7 @@ if [[ -n "${AGENT_MODEL:-}" ]]; then
     # "🛑 Cannot read properties of undefined (reading 'maxTokens')".
     # Verified against bobshell 1.0.6. PR #2249 removed it hub-side; this is
     # the same fix on the contributor-relay path.
-    amazonq|goose|bob) ;;
+    goose|bob) ;;
     *) MODEL_FLAG="--model $AGENT_MODEL" ;;
   esac
 fi

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -433,11 +433,11 @@ function warnOnProtocolDrift(hub, hubVersion) {
 }
 
 // Backends that must NOT be given --model, mirroring contributor-agent.sh.
-// amazonq/goose take their model from config/env. bob is excluded because
+// goose takes its model from config/env. bob is excluded because
 // --model is actively FATAL for it: bob auto-selects its own model and passing
 // one leaves its model config undefined, so every prompt dies with
 // "Cannot read properties of undefined (reading 'maxTokens')" (bobshell 1.0.6).
-const NO_MODEL_FLAG_BACKENDS = ['amazonq', 'goose', 'bob'];
+const NO_MODEL_FLAG_BACKENDS = ['goose', 'bob'];
 
 // agy (Google's Antigravity CLI) REQUIRES --effort whenever --model is given:
 // without it agy warns "--model <m> requires --effort (available: low, medium,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -751,13 +751,11 @@ test('agy headless argv carries the same --model/--effort pairing', () => {
   } finally { teardown(relay); }
 });
 
-test('amazonq and goose are also excluded from --model', () => {
-  for (const backend of ['amazonq', 'goose']) {
-    const relay = loadRelay({ backend, model: 'some-model' });
-    try {
-      assert.ok(!/--model/.test(relay.buildLaunchCommand()), `${backend} should not get --model`);
-    } finally { teardown(relay); }
-  }
+test('goose is also excluded from --model', () => {
+  const relay = loadRelay({ backend: 'goose', model: 'some-model' });
+  try {
+    assert.ok(!/--model/.test(relay.buildLaunchCommand()), 'goose should not get --model');
+  } finally { teardown(relay); }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -7522,7 +7522,7 @@
     // 'openrouter' is a first-class inference method (an OpenAI-compatible gateway
     // preset), so it appears in every backend/method picker even before a matching
     // Model Gateway is configured — the user picks it, then funds/configures it.
-    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
+    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'goose', 'aider', 'vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
     const FREE_BACKENDS = ['copilot', 'goose'];
     const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm', 'openrouter', 'watsonx'];
     // Names of Model Gateways configured under Settings → Model Gateways
@@ -18128,7 +18128,7 @@ function burnAreaChart() {
           <span class="config-toggle-label">CLI Pinned <span class="config-info">i<span class="config-tooltip">When enabled, the agent is locked to the CLI backend specified in CLI Pin Value. The governor will not switch this agent to a different backend. Useful for agents that require a specific tool (e.g. copilot for free-tier work).</span></span></span>
         </div>
         <div class="config-field">
-          <label>CLI Pin Value <span class="config-info">i<span class="config-tooltip">Which CLI backend to pin this agent to when CLI Pinned is on. Options: claude, copilot, bob, gemini, codex, amazonq, goose, aider. copilot and goose are free backends (no token cost).</span></span></label>
+          <label>CLI Pin Value <span class="config-info">i<span class="config-tooltip">Which CLI backend to pin this agent to when CLI Pinned is on. Options: claude, copilot, bob, gemini, codex, goose, aider. copilot and goose are free backends (no token cost).</span></span></label>
           <select id="cfg-pin-value" data-prev="${esc(g.cliPinValue || '')}" data-change-action="onCliPinChange" data-arg-types="t">
             ${backendOptionList().map(b => `<option value="${b}" ${g.cliPinValue === b ? 'selected' : ''}>${backendLabel(b)}</option>`).join('')}
           </select>


### PR DESCRIPTION
## Problem

`amazonq` (Amazon Q Developer) was offered to operators in the dashboard as a selectable CLI backend but could not actually be launched — an accept-then-fail bug. It appeared in:

- `src/pkg/dashboard/static/index.html` — the JS `KNOWN_BACKENDS` array (backend picker)
- `src/pkg/dashboard/static/index.html` — the "CLI Pin Value" tooltip, naming it as a selectable option

...but was absent from both authoritative registries:

- `config/backends.conf` (`KNOWN_BACKENDS`, `backend_binary`, `backend_perm_flag`)
- `src/pkg/config/config.go` (`CLIBackends`, `InferenceBackends`)

So `validateBackendName` (`src/pkg/agent/manager.go:948`) rejected it at launch. Nobody has requested Amazon Q support, so the fix is removal rather than finishing the integration.

## Full reference sweep

Ran `git grep -in amazonq` across the whole tree. Found **more than the six files named in the issue**:

| File | Status |
|---|---|
| `src/pkg/dashboard/static/index.html:7525` (KNOWN_BACKENDS array) | **Fixed** |
| `src/pkg/dashboard/static/index.html:18131` (CLI Pin tooltip) | **Fixed** |
| `bin/agent-launch.sh:149` (`amazonq\|goose)` case) | **Fixed** |
| `bin/contributor-agent.sh:521` (`amazonq\|goose\|bob)` case — three names, not two) | **Fixed** |
| `bin/contributor-relay.sh:440` (`NO_MODEL_FLAG_BACKENDS` array, also had `bob`) | **Fixed** |
| `bin/contributor-relay.test.js:754` (assertion covering both amazonq and goose) | **Fixed**, narrowed to goose only |
| `dashboard/index.html:2820` (a *separate*, legacy `KNOWN_BACKENDS` array) | **Left as-is** — see below |
| `dashboard/server.js:85` (same legacy `KNOWN_BACKENDS` array) | **Left as-is** — see below |

The last two were not in the issue's list. They live in a top-level `dashboard/` directory that is distinct from `src/pkg/dashboard/`, and its own `dashboard/README.md` states explicitly: *"`server.js` and `index.html` are legacy Node dashboard assets from the pre-v2 dashboard path... useful historical/reference material, but v2 production does not start `dashboard/server.js`."* Since this is documented as unserved historical material rather than a live write path, I left it untouched rather than editing dead code as part of a bug fix — flagging it here in case a maintainer wants a follow-up cleanup issue.

After the fix, `git grep -in amazonq` returns only those two legacy-directory hits (plus nothing in CHANGELOG history, since this is a new entry).

## Files changed

- `src/pkg/dashboard/static/index.html` — removed `amazonq` from `KNOWN_BACKENDS` and from the CLI Pin Value tooltip prose (rewrote the option list so it reads naturally, no dangling comma).
- `bin/agent-launch.sh` — removed `amazonq` from the `amazonq|goose)` case branch; now `goose) MODEL_FLAG="" ;;`.
- `bin/contributor-agent.sh` — removed `amazonq` from the `amazonq|goose|bob)` case branch; now `goose|bob) ;;`.
- `bin/contributor-relay.sh` — removed `'amazonq'` from the `NO_MODEL_FLAG_BACKENDS` array; now `['goose', 'bob']`.
- `bin/contributor-relay.test.js` — removed the amazonq case from the shared assertion; kept a standalone goose-only test with the same assertion body.
- `CHANGELOG.md` — new entry under `### Fixed`.

**Not touched** (already correctly absent): `config/backends.conf`, `src/pkg/config/config.go`.

## goose (and bob) verified intact

Re-read every edited case branch in full after editing:

- `bin/agent-launch.sh`: `case "$BACKEND" in goose) MODEL_FLAG="" ;; esac` — goose still matches, comment updated to singular.
- `bin/contributor-agent.sh`: `case "$AGENT_BACKEND" in goose|bob) ;; *) MODEL_FLAG="--model $AGENT_MODEL" ;; esac` — both goose and bob still matched and no-op, comment explaining bob's FATAL `--model` behavior preserved verbatim.
- `bin/contributor-relay.sh`: `const NO_MODEL_FLAG_BACKENDS = ['goose', 'bob'];` — both still present, comment updated.
- `bin/contributor-relay.test.js`: goose-only test still asserts `!/--model/.test(...)` for goose.

`bash -n` passes on `bin/agent-launch.sh` and `bin/contributor-agent.sh`. `bin/contributor-relay.sh` is a `#!/usr/bin/env node` script despite its `.sh` extension (pre-existing — confirmed `bash -n` also fails identically on the unmodified file), so it was checked with `node --check` instead (passes). `node --check` also passes on `bin/contributor-relay.test.js`.

## Parity-guard status (per issue's ask)

`src/pkg/config/backend_list_parity_test.go` (from #4987) only sources `config/backends.conf`'s `KNOWN_BACKENDS` and compares it against Go's `CLIBackends` — it does not parse the dashboard's embedded JS. **The dashboard's `KNOWN_BACKENDS` JS array in `src/pkg/dashboard/static/index.html` remains unguarded**, exactly as the issue flagged. This exact class of drift (a name added to the JS array without also landing in `backends.conf`/`CLIBackends`) can recur. No changes were made to the parity test itself — no exceptions added or weakened.

Fixes #4988