### PR TITLE
📖 governance: add James Reilly and Doug Baggett as Hive maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -20,8 +20,19 @@
 # the committee, and a PR against BOTH this file and the upstream table.
 # Affiliation changes must be reflected within 30 days.
 
+# Maintainer roster. Affiliation is recorded because CNCF maturity review asks
+# for it; "independent" is a legitimate entry and is not a lesser status.
+#
+#   clubanderson  Andy Anderson    IBM
+#   hanthor       James Reilly     Universal Blue
+#   Danathar      Doug Baggett     independent
+
 approvers:
   - clubanderson
+  - hanthor
+  - Danathar
 
 reviewers:
   - clubanderson
+  - hanthor
+  - Danathar


### PR DESCRIPTION
Both accepted a maintainer invitation.

| GitHub | Name | Affiliation |
|---|---|---|
| [@hanthor](https://github.com/hanthor) | James Reilly | Universal Blue |
| [@Danathar](https://github.com/Danathar) | Doug Baggett | independent |

## This is half of a paired change

The companion PR updates the **Current Maintainers** table in [`GOVERNANCE-HIVE.md`](https://github.com/kubestellar/kubestellar/blob/main/GOVERNANCE-HIVE.md#current-maintainers) upstream. **They must land together.** This file's own header says a change to one without the other is governance drift — and "code and doc ownership matches documented governance roles" is a thing CNCF maturity review checks explicitly.

## Contribution basis

**Danathar** (~180 commits) authored the fix for the fork `gate` bug that made *every* outside contributor PR structurally unmergeable (#4968), the restart-cost instrumentation (#4989), and the host-state command denylist that followed his own incident report (#4938). He also caught a framing error of mine on #4988 and backed the correction with the commit that proved it.

**hanthor** has contributed steadily across the relay and packaging surface.

## Approvers, not reviewers-first

Both are added as **approvers and reviewers** rather than starting at the reviewer rung. In this file approvers may merge. Both have been reviewing and landing substantive changes already, so reviewer-only would describe *less* authority than they have been exercising — the roster should reflect practice, not lag it.

## Affiliation

Now recorded per maintainer, which the file asked for and did not have for **anyone**, including the existing maintainer. Doug is independent; that is a real entry and carries no lesser standing.

## Why this matters beyond the roster

CNCF Incubation requires a **demonstrated** maintainer lifecycle — an actual add with outcomes, not just a documented process. This is that demonstration, and it closes the single-maintainer gap flagged in the security self-assessment as the largest institutional risk.