### PR TITLE
🐛 fix: gate every upgrade re-arm site on collectibility

### DIFF
--- a/src/pkg/hub/final2_coverage_test.go
+++ b/src/pkg/hub/final2_coverage_test.go
@@ -51,6 +51,9 @@ func TestTriggerAutoUpgradesRemoteNotStale(t *testing.T) {
 	s.registry.Hives = []RegistryEntry{{
 		ID: "h1", GitBranch: "v2", GitHash: "old", Upgrading: true,
 		UpgradeTarget: "keepTarget", UpgradeStartedAt: time.Now(),
+		// Heartbeating, so the upgrade is collectible and delivery is re-armed
+		// (uncollectible hives are covered in rearm_collectible_test.go).
+		LastHeartbeat: rfc3339At(time.Now().Add(-time.Minute)),
 	}}
 	s.triggerAutoUpgrades()
 	s.mu.RLock()

--- a/src/pkg/hub/rearm_collectible_test.go
+++ b/src/pkg/hub/rearm_collectible_test.go
@@ -1,0 +1,211 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// #3839 gated upgrade delivery on collectibility, but applied the gate only in
+// the isStale branch of triggerAutoUpgrades(). Three other sites armed
+// heartbeatUpgrade with no such check, so an uncollectible upgrade was re-armed
+// faster than abandonment could retire it and the wedge merely raced the
+// timeout. These tests pin the gate at every arming site.
+//
+// Every rejection test below is PAIRED with a positive control asserting that a
+// hive which CAN collect is still armed by the same path. Over-blocking here
+// would strand legitimate upgrades — a silent permanent opt-out, which the
+// pull-only design notes call out as worse than the wedge itself.
+
+// armedHive builds a registry entry latched mid-upgrade with a fresh (non-stale)
+// clock, so triggerAutoUpgrades() takes the NOT-stale branch.
+func armedHive(id, lastHeartbeat string) RegistryEntry {
+	return RegistryEntry{
+		ID: id, GitBranch: "v4", GitHash: "old1234",
+		Upgrading: true, UpgradeTarget: "7cd059b",
+		UpgradeStartedAt: time.Now(),
+		LastHeartbeat:    lastHeartbeat,
+	}
+}
+
+// TestNonStaleRearmSkipsUncollectibleHive is the regression for
+// saas.go's not-stale branch. The hive is latched Upgrading with a FRESH clock,
+// so abandonment (which only runs when isStale) cannot help: this is the branch
+// that re-populated the map every 2-minute poll forever.
+func TestNonStaleRearmSkipsUncollectibleHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUncollectibleUpgrade("never-beat")
+	saveSaaSHive(&SaaSHive{
+		ID: "never-beat", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	// Never heartbeated: LastHeartbeat empty. Cannot collect, ever.
+	s.registry.Hives = []RegistryEntry{armedHive("never-beat", "")}
+
+	for cycle := 1; cycle <= 5; cycle++ {
+		s.triggerAutoUpgrades()
+		if got := s.heartbeatUpgrade["never-beat"]; got != "" {
+			t.Fatalf("cycle %d: non-stale branch re-armed heartbeatUpgrade to %q for a hive "+
+				"that has never heartbeated — this is the loop that defeats #3839's gate", cycle, got)
+		}
+	}
+}
+
+// TestNonStaleRearmStillArmsCollectibleHive is the positive control for the
+// test above: a mid-upgrade hive that is heartbeating MUST keep its instruction
+// re-armed across hub restarts, which is the entire reason that branch exists.
+func TestNonStaleRearmStillArmsCollectibleHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUncollectibleUpgrade("beating")
+	saveSaaSHive(&SaaSHive{
+		ID: "beating", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{armedHive("beating", rfc3339At(time.Now().Add(-2*time.Minute)))}
+	// Simulate the hub restart this branch is meant to repair.
+	delete(s.heartbeatUpgrade, "beating")
+
+	s.triggerAutoUpgrades()
+
+	if got := s.heartbeatUpgrade["beating"]; got != "7cd059b" {
+		t.Fatalf("heartbeatUpgrade[beating] = %q, want 7cd059b — a heartbeating hive "+
+			"mid-upgrade must still have its instruction re-armed; over-blocking here "+
+			"strands legitimate upgrades", got)
+	}
+}
+
+// TestNonStaleRearmArmsSpokeQuietBecauseItIsRestarting guards the subtle case
+// the predicate was deliberately bounded on staleRemoveAge (24h) rather than
+// maxHeartbeatAge (5m) to protect: a spoke that is quiet precisely BECAUSE it is
+// restarting into the upgrade just armed for it.
+func TestNonStaleRearmArmsSpokeQuietBecauseItIsRestarting(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUncollectibleUpgrade("restarting")
+	saveSaaSHive(&SaaSHive{
+		ID: "restarting", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	// 30 minutes silent — well past the Online pill's 5m, nowhere near eviction.
+	s.registry.Hives = []RegistryEntry{armedHive("restarting", rfc3339At(time.Now().Add(-30*time.Minute)))}
+	delete(s.heartbeatUpgrade, "restarting")
+
+	s.triggerAutoUpgrades()
+
+	if got := s.heartbeatUpgrade["restarting"]; got != "7cd059b" {
+		t.Fatalf("heartbeatUpgrade[restarting] = %q, want 7cd059b — a spoke mid-restart "+
+			"is still collectible; gating on maxHeartbeatAge would self-defeatingly "+
+			"disarm the upgrade that caused the silence", got)
+	}
+}
+
+// TestRecoverArmedUpgradesSkipsUncollectible is the regression for startup
+// recovery. The registry latch is DURABLE, so without a gate here a hub restart
+// resurrects an upgrade that was abandoned in memory.
+func TestRecoverArmedUpgradesSkipsUncollectible(t *testing.T) {
+	s := pullOnlyTestServer(t)
+	s.registry.Hives = []RegistryEntry{
+		armedHive("ghost", ""),
+		armedHive("live", rfc3339At(time.Now().Add(-time.Minute))),
+	}
+
+	s.recoverArmedUpgrades()
+
+	if got := s.heartbeatUpgrade["ghost"]; got != "" {
+		t.Errorf("startup recovery re-armed %q for a never-heartbeated hive — a hub roll "+
+			"resurrects the abandoned wedge", got)
+	}
+	// Positive control in the same run: recovery must still work for a hive
+	// that can collect, or a restart silently drops every in-flight upgrade.
+	if got := s.heartbeatUpgrade["live"]; got != "7cd059b" {
+		t.Errorf("heartbeatUpgrade[live] = %q, want 7cd059b — startup recovery must still "+
+			"restore instructions for collectible hives", got)
+	}
+}
+
+// TestRecoverArmedUpgradesSkipsLongSilentHive pins the far edge of the
+// predicate: a hive silent past staleRemoveAge is being evicted anyway.
+func TestRecoverArmedUpgradesSkipsLongSilentHive(t *testing.T) {
+	s := pullOnlyTestServer(t)
+	s.registry.Hives = []RegistryEntry{
+		armedHive("gone", rfc3339At(time.Now().Add(-staleRemoveAge-time.Hour))),
+	}
+
+	s.recoverArmedUpgrades()
+
+	if got := s.heartbeatUpgrade["gone"]; got != "" {
+		t.Errorf("startup recovery re-armed %q for a hive silent past staleRemoveAge", got)
+	}
+}
+
+// TestUncollectibleUpgradeSurvivesRestartCycle replays the wedge shape from the
+// original incident: a never-heartbeated placeholder latched Upgrading, driven
+// through repeated poll cycles AND a hub restart. Before the fix the hive stayed
+// armed indefinitely, with UpgradeStartedAt preserved by beginUpgrade() so the
+// elapsed clock only ever grew (measured live past 146 minutes).
+func TestUncollectibleUpgradeSurvivesRestartCycle(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	forgetUncollectibleUpgrade("wedge-1")
+	saveSaaSHive(&SaaSHive{
+		ID: "wedge-1", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{armedHive("wedge-1", "")}
+
+	for cycle := 1; cycle <= 10; cycle++ {
+		s.triggerAutoUpgrades()
+		// Interleave the hub roll that orphans upgrades in the real incident.
+		if cycle%3 == 0 {
+			s.recoverArmedUpgrades()
+		}
+		if got := s.heartbeatUpgrade["wedge-1"]; got != "" {
+			t.Fatalf("cycle %d: hive is armed with %q despite never having heartbeated — "+
+				"the wedge is still reachable", cycle, got)
+		}
+	}
+}
+
+// TestOrphanSweepDoesNotRearmUncollectible covers the third arming site.
+// This sweep is where an uncollectible hive would otherwise spin forever:
+// evaluateOrphanedUpgrade() bails on an unparseable/absent LastHeartbeat, so the
+// retry budget that is meant to retire the upgrade is never spent.
+func TestOrphanSweepDoesNotRearmUncollectible(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	// Old enough for evaluateOrphanedUpgrade() to consider the attempt orphaned,
+	// and — for the ghost — past silentUpgradeDeadline so the silence itself is
+	// the evidence (it has no heartbeat to prove anything with).
+	started := time.Now().Add(-silentUpgradeDeadline - time.Minute)
+
+	ghost := armedHive("sweep-ghost", "")
+	ghost.UpgradeStartedAt = started
+
+	// A genuinely orphaned BUT collectible hive: it has heartbeated since the
+	// instruction (so it is alive and can collect) yet is still reporting the
+	// OLD SHA, so the upgrade did not converge and delivery must be re-armed.
+	live := armedHive("sweep-live", rfc3339At(time.Now().Add(-time.Minute)))
+	live.UpgradeStartedAt = started
+	s.registry.Hives = []RegistryEntry{ghost, live}
+
+	s.sweepOrphanedUpgrades()
+
+	if got := s.heartbeatUpgrade["sweep-ghost"]; got != "" {
+		t.Errorf("orphan sweep re-armed %q for a never-heartbeated hive", got)
+	}
+	if got := s.heartbeatUpgrade["sweep-live"]; got != "7cd059b" {
+		t.Errorf("heartbeatUpgrade[sweep-live] = %q, want 7cd059b — the sweep must still "+
+			"keep instructions alive for hives that can collect them", got)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -6168,6 +6168,22 @@ func (s *HubServer) triggerAutoUpgrades() {
 
 			// Not stale — keep the original target so the hive can satisfy it.
 			// Re-populate the heartbeatUpgrade map in case the hub restarted.
+			//
+			// SAME COLLECTIBILITY GATE AS THE STALE BRANCH ABOVE. Arming is
+			// arming: re-populating the map for a hive that cannot collect
+			// reproduces the wedge the stale branch just abandoned, only
+			// sooner. Because this branch runs on EVERY poll while the hive is
+			// latched, it re-arms roughly every 2 minutes, whereas abandonment
+			// waits out staleUpgradeTimeout — so without this check the fix
+			// merely races the timeout and the uncollectible hive stays armed.
+			// The predicate is upgradeCollectible(), reused rather than
+			// restated, so there is one definition of "can collect".
+			if upgradeTarget != "" && !upgradeCollectible(lastHeartbeat, time.Now()) {
+				s.logger.Debug("not re-arming in-progress upgrade — hive cannot collect it",
+					"hive", h.ID, "target", upgradeTarget,
+					"last_heartbeat", orDash(lastHeartbeat))
+				continue
+			}
 			hiveCluster := s.clusterForHive(&h)
 			if hiveCluster != nil && !hiveCluster.InCluster {
 				if upgradeTarget != "" {

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -3762,6 +3762,7 @@ func (s *HubServer) recoverArmedUpgrades() {
 	type armed struct{ id, target string }
 	var recovered []armed
 	stamped := 0
+	skippedUncollectible := 0
 	s.mu.Lock()
 	if s.heartbeatUpgrade == nil {
 		s.heartbeatUpgrade = make(map[string]string)
@@ -3793,6 +3794,17 @@ func (s *HubServer) recoverArmedUpgrades() {
 		if h.UpgradeFailed {
 			continue
 		}
+		// Do not re-arm an instruction this hive cannot collect. Startup
+		// recovery reads the DURABLE registry latch, so an uncollectible
+		// upgrade abandoned in memory by triggerAutoUpgrades() would be
+		// resurrected by the next hub restart if the latch had not yet been
+		// persisted — restoring the wedge across exactly the event (a hub
+		// roll) that this function exists to survive. Same predicate as every
+		// other arming site.
+		if !upgradeCollectible(h.LastHeartbeat, time.Now()) {
+			skippedUncollectible++
+			continue
+		}
 		s.heartbeatUpgrade[h.ID] = h.UpgradeTarget
 		recovered = append(recovered, armed{id: h.ID, target: h.UpgradeTarget})
 	}
@@ -3802,6 +3814,10 @@ func (s *HubServer) recoverArmedUpgrades() {
 		// before saveLoop starts is not lost) — otherwise a crash-looping hub
 		// would re-stamp them to now on every restart.
 		s.requestSave()
+	}
+	if skippedUncollectible > 0 {
+		s.logger.Info("skipped recovering armed upgrades for hives that cannot collect them",
+			"count", skippedUncollectible)
 	}
 	for _, a := range recovered {
 		s.logger.Info("recovered armed upgrade from registry after restart",

--- a/src/pkg/hub/stale_upgrade.go
+++ b/src/pkg/hub/stale_upgrade.go
@@ -406,7 +406,14 @@ func (s *HubServer) sweepOrphanedUpgrades() {
 		// silently stop receiving the upgrade. Re-arming the existing target
 		// keeps the instruction alive; it is idempotent, and the heartbeat path
 		// clears it as soon as the spoke reports the target SHA.
-		if h.UpgradeTarget != "" {
+		//
+		// Bounded by collectibility, like every other arming site: a hive that
+		// cannot collect gains nothing from a re-arm here, and re-arming it
+		// each sweep is one of the loops that kept the measured wedge alive.
+		// This sweep is also where such a hive would otherwise spin forever —
+		// evaluateOrphanedUpgrade() bails on an unparseable LastHeartbeat, so
+		// the retry budget above is never spent and cannot retire it.
+		if h.UpgradeTarget != "" && upgradeCollectible(h.LastHeartbeat, now) {
 			s.heartbeatUpgrade[h.ID] = h.UpgradeTarget
 		}
 	}

--- a/src/pkg/hub/upgrade_pause_test.go
+++ b/src/pkg/hub/upgrade_pause_test.go
@@ -101,6 +101,8 @@ func TestSpokePauseBlocksTriggerAutoUpgradesReArm(t *testing.T) {
 	s.registry.Hives = []RegistryEntry{{
 		ID: "h1", GitBranch: "v2", GitHash: "old", Upgrading: true,
 		UpgradeTarget: "keepTarget", UpgradeStartedAt: time.Now(),
+		// Collectible, so the resumed positive control genuinely re-arms.
+		LastHeartbeat: rfc3339At(time.Now().Add(-time.Minute)),
 	}}
 
 	pauseSpokes(t, s, true)

--- a/src/pkg/hub/upgrade_recovery_test.go
+++ b/src/pkg/hub/upgrade_recovery_test.go
@@ -26,16 +26,21 @@ import (
 // only for it.
 func TestRecoverArmedUpgradesRebuildsHeartbeatMap(t *testing.T) {
 	s := &HubServer{logger: slog.Default()}
+	// These entries carry a recent LastHeartbeat because recovery only re-arms
+	// hives that can COLLECT the instruction (upgradeCollectible); a real
+	// latched hive always has one. The uncollectible case is covered in
+	// rearm_collectible_test.go.
+	beat := rfc3339At(time.Now().Add(-time.Minute))
 	s.registry.Hives = []RegistryEntry{
 		// The incident shape: durably latched Upgrading with a target, armed by
 		// handleUpgradeHive before the hub restarted.
-		{ID: "latched", Upgrading: true, UpgradeTarget: "fc32ae4"},
+		{ID: "latched", Upgrading: true, UpgradeTarget: "fc32ae4", LastHeartbeat: beat},
 		// Not upgrading — a leftover target alone must not arm delivery.
-		{ID: "idle", Upgrading: false, UpgradeTarget: "deadbee"},
+		{ID: "idle", Upgrading: false, UpgradeTarget: "deadbee", LastHeartbeat: beat},
 		// Latched but with no target — nothing a heartbeat could deliver.
-		{ID: "no-target", Upgrading: true},
+		{ID: "no-target", Upgrading: true, LastHeartbeat: beat},
 		// Terminal failure recorded by the orphan sweep — must stay terminal.
-		{ID: "failed", Upgrading: true, UpgradeTarget: "fc32ae4", UpgradeFailed: true},
+		{ID: "failed", Upgrading: true, UpgradeTarget: "fc32ae4", UpgradeFailed: true, LastHeartbeat: beat},
 	}
 
 	// heartbeatUpgrade is deliberately left nil: at this point in NewHubServer
@@ -68,7 +73,8 @@ func TestNewHubServerRecoversArmedUpgradesFromDisk(t *testing.T) {
 	defer func() { registryPath = oldRegistry }()
 
 	reg := Registry{Hives: []RegistryEntry{
-		{ID: "latched-disk", Upgrading: true, UpgradeTarget: "fc32ae4"},
+		{ID: "latched-disk", Upgrading: true, UpgradeTarget: "fc32ae4",
+			LastHeartbeat: rfc3339At(time.Now().Add(-time.Minute))},
 	}}
 	data, err := json.Marshal(reg)
 	if err != nil {
@@ -251,6 +257,7 @@ func TestTriggerAutoUpgradesNotStaleManualRepopulates(t *testing.T) {
 	s.registry.Hives = []RegistryEntry{{
 		ID: "manual-2", GitBranch: "v2", GitHash: "old1234", Upgrading: true,
 		UpgradeTarget: "keepTarget", UpgradeStartedAt: time.Now(),
+		LastHeartbeat: rfc3339At(time.Now().Add(-time.Minute)),
 	}}
 
 	s.triggerAutoUpgrades()
@@ -273,14 +280,17 @@ func TestTriggerAutoUpgradesNotStaleManualRepopulates(t *testing.T) {
 func TestRecoverArmedUpgradesStampsZeroClockPreservesLiveClock(t *testing.T) {
 	persisted := time.Now().Add(-42 * time.Minute)
 	s := &HubServer{logger: slog.Default()}
+	// Recent heartbeats: clock stamping is what this test is about, and re-arming
+	// is gated on collectibility (see rearm_collectible_test.go).
+	beat := rfc3339At(time.Now().Add(-time.Minute))
 	s.registry.Hives = []RegistryEntry{
 		// Rehydrated from disk with its real clock — must survive untouched.
-		{ID: "with-clock", Upgrading: true, UpgradeTarget: "fc32ae4", UpgradeStartedAt: persisted},
+		{ID: "with-clock", Upgrading: true, UpgradeTarget: "fc32ae4", UpgradeStartedAt: persisted, LastHeartbeat: beat},
 		// Latched with a lost/never-set clock — must be stamped now.
-		{ID: "zero-clock", Upgrading: true, UpgradeTarget: "fc32ae4"},
+		{ID: "zero-clock", Upgrading: true, UpgradeTarget: "fc32ae4", LastHeartbeat: beat},
 		// Spoke-reported upgrading (no target): nothing to arm, but the badge
 		// still renders, so it must get a clock too.
-		{ID: "spoke-reported", Upgrading: true},
+		{ID: "spoke-reported", Upgrading: true, LastHeartbeat: beat},
 		// Not upgrading — must keep a zero clock.
 		{ID: "idle"},
 	}


### PR DESCRIPTION
## Problem

#3839 gated upgrade delivery so an upgrade a hive can never **collect** is abandoned rather than re-armed forever. The gate is applied at one of the four sites that arm `heartbeatUpgrade`. The other three re-arm with no collectibility check, so the wedge #3839 documents is still reachable — it now races the staleness timeout instead of being prevented.

Delivery is pull: the hub records a target and the spoke collects it on its own outbound heartbeat. A hive that has never heartbeated (an unassigned placeholder) can never collect.

## Fix

Each ungated site now reuses `upgradeCollectible()` — #3839's own predicate — rather than restating it, so there is one definition of "can collect" and not four that drift:

| Site | Was gated on | Why it mattered |
|---|---|---|
| `saas.go` not-stale branch | cluster topology only | runs every 2-minute poll while latched, so it re-armed far faster than the 10m stale branch could retire; `beginUpgrade()` preserves the original clock on a same-target re-arm, so elapsed only grew |
| `server.go` `recoverArmedUpgrades()` | `UpgradeTarget != ""`, `!UpgradeFailed` | reads the **durable** registry latch, so a hub roll resurrected anything abandoned in memory |
| `stale_upgrade.go` `sweepOrphanedUpgrades()` | retry budget only | where an uncollectible hive spins forever: `evaluateOrphanedUpgrade()` bails on an absent `LastHeartbeat`, so the budget is never spent |

The third site was not in the issue report; it was found while confirming the other two.

## Not over-blocking

Over-blocking here is a silent permanent opt-out — worse than the wedge, per this file's own design notes. Every rejection test is paired with a positive control:

- a heartbeating hive mid-upgrade is still re-armed by the non-stale branch;
- startup recovery still restores collectible hives (asserted in the same run as the rejection);
- the orphan sweep still keeps delivery alive for a live-but-un-converged hive;
- **a spoke silent for 30 minutes because it is restarting into the upgrade just armed for it is still collectible** — this is exactly why the predicate bounds on `staleRemoveAge` (24h) rather than `maxHeartbeatAge` (5m), and gating on the latter would self-defeatingly disarm the upgrade that caused the silence.

## Verification

Neuter-tested, per the Audit 6 doctrine that a rejection test is worthless without a control that genuinely exercises the path:

1. **Planted bug** — made `upgradeCollectible()` return `true` for a never-heartbeated hive. All four rejection tests went RED; all three positive controls stayed green.
2. **Per-site isolation** — reverted each gate individually and confirmed only that site's own test fails, so no test is passing on another site's coverage:
   - revert `saas.go` → `TestNonStaleRearmSkipsUncollectibleHive` + the restart-cycle replay fail
   - revert `server.go` → `TestRecoverArmedUpgradesSkipsUncollectible` + the restart-cycle replay fail
   - revert `stale_upgrade.go` → `TestOrphanSweepDoesNotRearmUncollectible` fails

`TestUncollectibleUpgradeSurvivesRestartCycle` replays the original incident shape — a never-heartbeated placeholder driven through 10 poll cycles with hub rolls interleaved.

Full `go test ./pkg/hub/` green (175s); `go vet` and `gofmt` clean.

## Note on existing tests

Six existing tests carried fixtures with no `LastHeartbeat`. That omission was incidental to their subjects (commit-order, spoke pause, disk recovery, clock stamping) — a real latched hive always has one, since `LastHeartbeat` is populated from the heartbeat that also drives the upgrade. They now set a recent heartbeat so they keep testing what they were written to test. No assertion was weakened or removed; the pause test's positive control in particular is preserved and still meaningful.

Fixes #4994
