### PR TITLE
🐛 fix(hub): scope the undeliverable-upgrade memory to its server and stop it leaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ### Fixed
 
+- The hub's "upgrade not armed" de-duplication memory is now **per hub server**
+  and no longer leaks entries for hives that no longer exist
+  ([#4995](https://github.com/kubestellar/hive/issues/4995)). It was a
+  package-level global keyed on hive ID alone, so two hub instances in one
+  process — or two servers managing same-named hives, the normal case for
+  fixtures — clobbered each other, and one server's arming could suppress a
+  refusal notice the other should have emitted. That timeline entry is the only
+  operator-visible signal distinguishing "deliberately not upgraded" from
+  "silently broken", so suppressing it across a server boundary defeated the
+  feature. Entries also grew without bound: the sole removal path was a
+  successful arming, and a hive deleted or deprovisioned while uncollectible is
+  by definition never armed — which is precisely the unassigned-placeholder
+  population this code exists for. Entries are now reconciled against the live
+  hive set on the auto-upgrade sweep that already lists it. No behaviour change
+  for a single running hub beyond the leak being fixed.
+
 - Removed the half-wired `amazonq` (Amazon Q Developer) backend from the operator-facing dashboard: the CLI backend picker's `KNOWN_BACKENDS` array and the "CLI Pin Value" tooltip both listed it as a selectable option, but it was never in either authoritative registry (`config/backends.conf`'s `KNOWN_BACKENDS`/`backend_binary`/`backend_perm_flag`, or `src/pkg/config/config.go`'s `CLIBackends`), so `validateBackendName` rejected it on launch — an accept-then-fail bug where the dashboard recommended a backend that could not start. Also dropped from the three shell/JS "no `--model` flag" lists in `bin/agent-launch.sh`, `bin/contributor-agent.sh`, and `bin/contributor-relay.sh` (the `goose`/`bob` handling in each is unaffected) and from `bin/contributor-relay.test.js`. Nobody had requested Amazon Q support; removal was cheaper than finishing the integration. Found by the backend-list parity guard added in [#4987](https://github.com/kubestellar/hive/pull/4987). The dashboard's JS `KNOWN_BACKENDS` array is still unguarded by that parity test — it cannot practically parse embedded JS — so this exact class of drift can recur there. ([#4988](https://github.com/kubestellar/hive/issues/4988))
 
 - An issue covered by an open PR that only *references* it (`Refs #N`, `Part of

--- a/src/pkg/hub/pullonly_upgrade.go
+++ b/src/pkg/hub/pullonly_upgrade.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"sync"
 	"time"
 )
 
@@ -144,9 +143,10 @@ func uncollectibleUpgradeReason(lastHeartbeat string) string {
 		"an upgrade instruction"
 }
 
-// undeliverableUpgradeNoted remembers the (hive, target) pairs already written to
-// a timeline, so the refusal is recorded ONCE per target rather than on every
-// poll.
+// The de-duplication memory for the "upgrade not armed" timeline entry lives on
+// HubServer as undeliverableUpgradeNoted (see server.go). It remembers the
+// (hive, target) pairs already written, so the refusal is recorded ONCE per
+// target rather than on every poll.
 //
 // StartLatestSHAPoller ticks every latestSHAPollInterval (2m) and calls
 // triggerAutoUpgrades() each time, so an un-deduplicated timeline write would
@@ -155,10 +155,20 @@ func uncollectibleUpgradeReason(lastHeartbeat string) string {
 // timeline exists to show. Keying on the TARGET means a genuinely new upgrade
 // opportunity (the branch advanced) is reported again, while the same refusal is
 // not repeated.
-var (
-	undeliverableUpgradeMu    sync.Mutex
-	undeliverableUpgradeNoted = map[string]string{}
-)
+//
+// It was a package-level global until #4995. Two problems, both real:
+//
+//  1. SHARED ACROSS SERVERS. Every hub in a process wrote to one map, keyed on
+//     hive ID alone. Two servers managing same-named hives clobbered each
+//     other, so one server's arming could suppress a refusal the other should
+//     have reported — silencing the one operator-visible signal this file
+//     exists to produce.
+//  2. UNBOUNDED. The comment above claims the map is bounded because it is
+//     keyed on target, but the only removal path was "the hive was successfully
+//     armed". A hive deleted or deprovisioned while uncollectible is never
+//     armed — and an unassigned placeholder that never heartbeats is exactly
+//     the population this file is about — so its entry was retained for the
+//     lifetime of the process. pruneUncollectibleUpgrades below closes that.
 
 // noteUncollectibleUpgrade records — once per (hive, target) — that the hub
 // declined to arm an upgrade the hive could not collect, and why.
@@ -167,13 +177,16 @@ var (
 // original wedge went unnoticed: a hive with auto_upgrade=true that never
 // upgrades is indistinguishable from one already at latest.
 func (s *HubServer) noteUncollectibleUpgrade(hiveID, target, reason string) {
-	undeliverableUpgradeMu.Lock()
-	if prev, ok := undeliverableUpgradeNoted[hiveID]; ok && prev == target {
-		undeliverableUpgradeMu.Unlock()
+	s.undeliverableUpgradeMu.Lock()
+	if prev, ok := s.undeliverableUpgradeNoted[hiveID]; ok && prev == target {
+		s.undeliverableUpgradeMu.Unlock()
 		return
 	}
-	undeliverableUpgradeNoted[hiveID] = target
-	undeliverableUpgradeMu.Unlock()
+	if s.undeliverableUpgradeNoted == nil {
+		s.undeliverableUpgradeNoted = map[string]string{}
+	}
+	s.undeliverableUpgradeNoted[hiveID] = target
+	s.undeliverableUpgradeMu.Unlock()
 
 	s.recordTimeline(hiveID, TimelineUpgradeStale,
 		"auto-upgrade to "+orDash(target)+" not armed — "+reason, "auto-upgrade")
@@ -183,10 +196,49 @@ func (s *HubServer) noteUncollectibleUpgrade(hiveID, target, reason string) {
 // if it later becomes uncollectible again the refusal is reported afresh rather
 // than suppressed by a stale entry. Called when a hive is successfully armed —
 // i.e. the condition has genuinely cleared.
-func forgetUncollectibleUpgrade(hiveID string) {
-	undeliverableUpgradeMu.Lock()
-	delete(undeliverableUpgradeNoted, hiveID)
-	undeliverableUpgradeMu.Unlock()
+func (s *HubServer) forgetUncollectibleUpgrade(hiveID string) {
+	s.undeliverableUpgradeMu.Lock()
+	delete(s.undeliverableUpgradeNoted, hiveID)
+	s.undeliverableUpgradeMu.Unlock()
+}
+
+// pruneUncollectibleUpgrades drops memory for hives that no longer exist, given
+// the live hive set the caller is already iterating.
+//
+// This is the entry lifecycle the map never had. Arming is the only other
+// removal path, and a hive deleted or deprovisioned while uncollectible is by
+// definition never armed, so without this the entry outlives the hive for the
+// process's lifetime and the set of dead placeholders grows monotonically.
+//
+// A SWEEP RATHER THAN A REMOVAL HOOK, deliberately. removeHiveRecord() — the
+// deletion path — is a bare function with no server receiver, so it cannot
+// reach a per-server map without threading a HubServer through it, and it is
+// not the only way a hive leaves the set (deprovision, a record failing to load,
+// an operator clearing the directory). Reconciling against the live set on a
+// sweep the caller already performs covers every disappearance for free and is
+// self-healing after a missed event, which a hook is not.
+//
+// EMPTY IS NOT AUTHORITATIVE. listSaaSHives() returns nil both when there are no
+// hives and when its ReadDir fails (saas_provision.go), and those are
+// indistinguishable to a caller. Pruning on an empty list would let one
+// transient read error wipe the memory and re-emit every suppressed refusal on
+// the next tick — the duplicate-timeline flood this map exists to prevent. So an
+// empty set prunes nothing; the next successful sweep does the work.
+func (s *HubServer) pruneUncollectibleUpgrades(live []SaaSHive) {
+	if len(live) == 0 {
+		return
+	}
+	alive := make(map[string]bool, len(live))
+	for i := range live {
+		alive[live[i].ID] = true
+	}
+	s.undeliverableUpgradeMu.Lock()
+	defer s.undeliverableUpgradeMu.Unlock()
+	for id := range s.undeliverableUpgradeNoted {
+		if !alive[id] {
+			delete(s.undeliverableUpgradeNoted, id)
+		}
+	}
 }
 
 // upgradeBranchOrDefault resolves the branch whose latest SHA should be used as

--- a/src/pkg/hub/pullonly_upgrade_scope_test.go
+++ b/src/pkg/hub/pullonly_upgrade_scope_test.go
@@ -1,0 +1,238 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// #4995 — the undeliverable-upgrade de-duplication memory used to be a
+// package-level global shared by every HubServer in the process.
+//
+// Two defects came out of that, and these tests pin both:
+//
+//  1. Cross-instance clobbering. Keying was on hive ID alone, so two servers
+//     managing same-named hives (the normal case for fixtures) overwrote each
+//     other, and one server's memory could suppress a refusal the other should
+//     have reported. The timeline entry is the whole operator-visible point of
+//     pullonly_upgrade.go, so that is a silenced signal, not a tidiness issue.
+//
+//  2. Unbounded growth. The only removal path was "the hive was successfully
+//     armed". A hive deleted while uncollectible is never armed — and an
+//     unassigned placeholder that never heartbeats is exactly the population
+//     this file is about — so entries outlived their hives forever.
+//
+// The strongest evidence for (1) was in the test file itself: 12 tests opened
+// by calling forgetUncollectibleUpgrade(...) to scrub state a freshly built
+// server should never have inherited. Those calls are gone as of this change,
+// and that deletion is itself part of the regression coverage — if the memory
+// ever becomes shared again, the existing tests start failing in combination.
+
+// countStaleTimelineEntries reports how many "upgrade not armed" entries a
+// server recorded for a hive.
+func countStaleTimelineEntries(s *HubServer, hiveID string) int {
+	n := 0
+	for _, e := range s.timeline.recent(hiveID, 100) {
+		if e.Kind == TimelineUpgradeStale {
+			n++
+		}
+	}
+	return n
+}
+
+// uncollectibleHive registers a hive that can never collect an upgrade: auto
+// upgrade on, behind the branch SHA, and no heartbeat ever. That is the exact
+// shape pullonly_upgrade.go exists for.
+func uncollectibleHive(s *HubServer, id string) {
+	saveSaaSHive(&SaaSHive{
+		ID: id, Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{{ID: id, GitBranch: "v4", GitHash: "old1234"}}
+}
+
+// TestUndeliverableMemoryIsNotSharedBetweenServers is the headline regression.
+//
+// Both servers manage a hive with the SAME id — which is what fixtures and a
+// two-hub process both do. Under the package global, the first server's entry
+// suppressed the second server's timeline write entirely, so an operator
+// looking at the second hub saw silence where a refusal belonged.
+func TestUndeliverableMemoryIsNotSharedBetweenServers(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const hiveID = "shared-id"
+
+	first := pullOnlyTestServer(t)
+	uncollectibleHive(first, hiveID)
+	first.triggerAutoUpgrades()
+	if got := countStaleTimelineEntries(first, hiveID); got != 1 {
+		t.Fatalf("first server recorded %d refusal entries, want 1", got)
+	}
+
+	// A SECOND, independent server, same hive id. It has recorded nothing yet,
+	// so it must report the refusal itself.
+	second := pullOnlyTestServer(t)
+	uncollectibleHive(second, hiveID)
+	second.triggerAutoUpgrades()
+
+	if got := countStaleTimelineEntries(second, hiveID); got != 1 {
+		t.Errorf("second server recorded %d refusal entries, want 1 — "+
+			"the first server's de-duplication memory suppressed a refusal it does not own (#4995)", got)
+	}
+	// And the first server must not have gained an entry from the second's work.
+	if got := countStaleTimelineEntries(first, hiveID); got != 1 {
+		t.Errorf("first server now has %d refusal entries, want 1 — the two servers are sharing state", got)
+	}
+}
+
+// TestUndeliverableMemoryStartsEmptyOnAFreshServer states the property the 12
+// deleted forgetUncollectibleUpgrade(...) prologue calls were compensating for.
+// A server built now must inherit nothing from a server built earlier, without
+// the test having to scrub anything.
+func TestUndeliverableMemoryStartsEmptyOnAFreshServer(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const hiveID = "fresh-id"
+
+	older := pullOnlyTestServer(t)
+	uncollectibleHive(older, hiveID)
+	older.triggerAutoUpgrades()
+
+	fresh := pullOnlyTestServer(t)
+	fresh.undeliverableUpgradeMu.Lock()
+	n := len(fresh.undeliverableUpgradeNoted)
+	fresh.undeliverableUpgradeMu.Unlock()
+	if n != 0 {
+		t.Errorf("a freshly built server already remembers %d undeliverable hive(s); "+
+			"it must start empty so tests need no scrubbing prologue (#4995)", n)
+	}
+}
+
+// TestUndeliverableMemoryIsDroppedWhenTheHiveIsGone covers the leak.
+//
+// A hive that is deleted while uncollectible is never armed, so arming — the
+// only removal path before this change — never fires for it. Without the sweep
+// prune, its entry is retained for the process lifetime and the set of dead
+// placeholders grows monotonically, contradicting the "bounded" claim in the
+// map's own doc comment.
+func TestUndeliverableMemoryIsDroppedWhenTheHiveIsGone(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	uncollectibleHive(s, "doomed")
+	s.triggerAutoUpgrades()
+
+	s.undeliverableUpgradeMu.Lock()
+	_, noted := s.undeliverableUpgradeNoted["doomed"]
+	s.undeliverableUpgradeMu.Unlock()
+	if !noted {
+		t.Fatal("precondition failed: the uncollectible hive was never noted")
+	}
+
+	// The hive goes away, and a LIVE hive remains so the sweep sees a non-empty
+	// set (an empty one is deliberately not authoritative — see
+	// pruneUncollectibleUpgrades).
+	removeHiveRecord("doomed", s.logger)
+	saveSaaSHive(&SaaSHive{
+		ID: "survivor", Owner: "alice", AutoUpgrade: true,
+		Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{{
+		ID: "survivor", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
+	}}
+
+	s.triggerAutoUpgrades()
+
+	s.undeliverableUpgradeMu.Lock()
+	_, stillNoted := s.undeliverableUpgradeNoted["doomed"]
+	s.undeliverableUpgradeMu.Unlock()
+	if stillNoted {
+		t.Error("memory for a hive that no longer exists survived the sweep — " +
+			"deleted-while-uncollectible hives are never armed, so this entry leaks forever (#4995)")
+	}
+}
+
+// TestPruneKeepsEntriesForLiveHives is the control for the test above. A prune
+// that simply cleared the map would pass it while destroying the whole point of
+// the memory, re-emitting every suppressed refusal on the next 2-minute tick.
+func TestPruneKeepsEntriesForLiveHives(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	uncollectibleHive(s, "still-here")
+	s.triggerAutoUpgrades()
+	if got := countStaleTimelineEntries(s, "still-here"); got != 1 {
+		t.Fatalf("precondition: recorded %d entries, want 1", got)
+	}
+
+	// A second sweep with the hive still present must neither prune its entry
+	// nor write a duplicate.
+	s.triggerAutoUpgrades()
+
+	s.undeliverableUpgradeMu.Lock()
+	_, kept := s.undeliverableUpgradeNoted["still-here"]
+	s.undeliverableUpgradeMu.Unlock()
+	if !kept {
+		t.Error("the prune dropped a LIVE hive's entry")
+	}
+	if got := countStaleTimelineEntries(s, "still-here"); got != 1 {
+		t.Errorf("recorded %d refusal entries after two sweeps, want 1 — "+
+			"de-duplication broke, which is the ~720-entries-a-day flood this map prevents", got)
+	}
+}
+
+// TestPruneIgnoresAnEmptyHiveSet pins the read-failure guard. listSaaSHives()
+// returns nil both when there are no hives and when its ReadDir fails, and the
+// caller cannot tell those apart. Pruning on empty would let one transient error
+// wipe the memory and re-emit every suppressed refusal.
+func TestPruneIgnoresAnEmptyHiveSet(t *testing.T) {
+	s := pullOnlyTestServer(t)
+	s.undeliverableUpgradeNoted = map[string]string{"keep-me": "abc1234"}
+
+	s.pruneUncollectibleUpgrades(nil)
+
+	if _, ok := s.undeliverableUpgradeNoted["keep-me"]; !ok {
+		t.Error("an empty hive list pruned the memory; a transient ReadDir failure " +
+			"is indistinguishable from 'no hives' and must not wipe state (#4995)")
+	}
+}
+
+// TestForgetIsScopedToItsOwnServer pins the method conversion. As a bare
+// function taking only a hive ID, forgetUncollectibleUpgrade had no server to
+// scope to and cleared the memory for every hub in the process.
+func TestForgetIsScopedToItsOwnServer(t *testing.T) {
+	a := pullOnlyTestServer(t)
+	b := pullOnlyTestServer(t)
+	a.undeliverableUpgradeNoted = map[string]string{"h": "sha-a"}
+	b.undeliverableUpgradeNoted = map[string]string{"h": "sha-b"}
+
+	a.forgetUncollectibleUpgrade("h")
+
+	if _, ok := a.undeliverableUpgradeNoted["h"]; ok {
+		t.Error("forget did not clear its own server's entry")
+	}
+	if _, ok := b.undeliverableUpgradeNoted["h"]; !ok {
+		t.Error("forget on one server cleared another server's entry (#4995)")
+	}
+}
+
+// TestNoteOnBareServerLiteralDoesNotPanic. Bare &HubServer{} literals are the
+// norm in this package's tests and run no constructor, so the map is nil on
+// first write. A nil map read is fine in Go; a write panics.
+func TestNoteOnBareServerLiteralDoesNotPanic(t *testing.T) {
+	s := &HubServer{timeline: newTimelineStore()}
+	s.noteUncollectibleUpgrade("bare", "abc1234", "never heartbeated")
+
+	if got := countStaleTimelineEntries(s, "bare"); got != 1 {
+		t.Errorf("recorded %d entries on a bare server literal, want 1", got)
+	}
+	// Second call with the same target must still de-duplicate.
+	s.noteUncollectibleUpgrade("bare", "abc1234", "never heartbeated")
+	if got := countStaleTimelineEntries(s, "bare"); got != 1 {
+		t.Errorf("recorded %d entries after a repeat, want 1", got)
+	}
+}

--- a/src/pkg/hub/pullonly_upgrade_test.go
+++ b/src/pkg/hub/pullonly_upgrade_test.go
@@ -60,7 +60,6 @@ func TestPullOnlyHiveThatHeartbeatsStillUpgrades(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("pull-live")
 	saveSaaSHive(&SaaSHive{
 		ID: "pull-live", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -96,7 +95,6 @@ func TestAutoUpgradeNotArmedForNeverHeartbeatedHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -125,7 +123,6 @@ func TestAutoUpgradeNotArmedForLongDeadHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("dead-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "dead-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "hive-oke",
@@ -151,7 +148,6 @@ func TestBrieflyQuietHiveStillUpgrades(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("quiet-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "quiet-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -179,7 +175,6 @@ func TestStaleUpgradeNotReArmedForUncollectibleHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-2")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-2", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -214,7 +209,6 @@ func TestStaleUpgradeStillRecoveredForLiveHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ok-2")
 	saveSaaSHive(&SaaSHive{
 		ID: "ok-2", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -245,7 +239,6 @@ func TestUncollectibleUpgradeCannotAccumulateStaleness(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-3")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-3", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -276,7 +269,6 @@ func TestUncollectibleUpgradeIsSurfacedNotSilent(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-4")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-4", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -307,7 +299,6 @@ func TestUncollectibleRefusalIsDeduplicated(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-5")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-5", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -382,7 +373,6 @@ func TestLiveHiveNeverTargetedWithForeignBranchSHA(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("live-nobranch")
 	latestSHAMu.Lock()
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "0b78dc0"}
 	latestSHAMu.Unlock()
@@ -423,7 +413,6 @@ func TestUpgradePathNeverShellsOutToCluster(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("nopush")
 	// A REACHABLE remote cluster: under the old push model this is exactly the
 	// case that would have shelled out to kubectl.
 	s.clusters["remote"] = ClusterConfig{
@@ -529,7 +518,6 @@ func TestAutoUpgradeToggleWorksUnderPull(t *testing.T) {
 
 	// And the setting must actually take effect on the next poll — on a
 	// pull-only cluster, which is the case that matters.
-	forgetUncollectibleUpgrade("toggle-1")
 	s.triggerAutoUpgrades()
 	if !s.registry.Hives[0].Upgrading {
 		t.Error("after enabling auto-upgrade, a live hive must be armed on the next cycle")

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -5937,6 +5937,10 @@ func (s *HubServer) triggerAutoUpgrades() {
 		return
 	}
 	hives := listSaaSHives()
+	// Reconcile the undeliverable-upgrade memory against the live set while we
+	// have it. Arming is the only other removal path, and a hive deleted while
+	// uncollectible is never armed — see pruneUncollectibleUpgrades (#4995).
+	s.pruneUncollectibleUpgrades(hives)
 	// Upgrade waves: bound how many hives may be UPGRADING per cluster at
 	// once. A merge used to roll every behind hive simultaneously — observed
 	// live as a fleet-wide restart inside minutes, an image-pull + PVC IO
@@ -6276,7 +6280,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 		}
 		// The hive is deliverable again — drop any suppressed-refusal memory so a
 		// future undeliverable episode is reported afresh rather than swallowed.
-		forgetUncollectibleUpgrade(h.ID)
+		s.forgetUncollectibleUpgrade(h.ID)
 		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID, "mode", normalizeAutoUpgradeMode(h.AutoUpgradeMode))
 		s.recordTimeline(h.ID, TimelineUpgradeStarted,
 			fmt.Sprintf("auto-upgrade triggered on %s: %s → %s", branch, orDash(currentSHA), latestSHA), "auto-upgrade")

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -975,6 +975,29 @@ type HubServer struct {
 	// target SHA, proving the upgrade completed.
 	heartbeatUpgrade map[string]string
 
+	// undeliverableUpgradeNoted de-duplicates the "upgrade not armed" timeline
+	// entry per (hive, target) — see noteUncollectibleUpgrade in
+	// pullonly_upgrade.go for why that entry exists and why it must not repeat
+	// every 2-minute poll.
+	//
+	// PER-SERVER, not package-global (#4995). As a global it was shared by every
+	// hub in a process: two servers managing same-named hives — the normal case
+	// for fixtures — clobbered each other's memory, and one server's arming
+	// could suppress a refusal the other should have reported. The timeline
+	// entry is the whole operator-visible point of that file ("Silence is how
+	// the original wedge went unnoticed"), so suppressing it across a server
+	// boundary defeats the feature rather than merely being untidy.
+	//
+	// GUARDED BY undeliverableUpgradeMu, which is separate from s.mu on purpose:
+	// noteUncollectibleUpgrade calls recordTimeline immediately after releasing
+	// it, and recordTimeline is not safe to call under the registry lock.
+	//
+	// Lazily created on first write. Bare &HubServer{} literals are common in
+	// this package's tests and never run a constructor, so a nil map here must
+	// be a working empty map rather than a panic.
+	undeliverableUpgradeMu    sync.Mutex
+	undeliverableUpgradeNoted map[string]string
+
 	// clusterUnreachableUntil suppresses kubectl against clusters the hub has
 	// just proven it cannot route to (firewalled GPU clusters like the heartbeat-only cluster).
 	// Without this, triggerAutoUpgrades() paid a full dial timeout PER HIVE PER


### PR DESCRIPTION
## Summary

`undeliverableUpgradeNoted` — the memory that stops the hub writing an identical "upgrade not armed" timeline entry every 2 minutes — was a package-level global instead of a field on `HubServer`. This moves it onto the server, makes `forgetUncollectibleUpgrade` a method, and gives entries a lifecycle so they stop outliving their hives.

Two things were wrong, and the first is worse than it looks:

1. **Shared across servers.** Every hub in a process wrote to one map, keyed on hive ID alone. Two servers managing same-named hives clobbered each other, so one server's arming could suppress a refusal the *other* should have reported. That timeline entry is the entire operator-visible point of `pullonly_upgrade.go` — whose own comment says *"Silence is how the original wedge went unnoticed"* — so a suppressed entry puts an operator back in exactly the state the file exists to prevent.
2. **Unbounded.** The only removal path was "the hive was successfully armed." A hive deleted or deprovisioned while uncollectible is *by definition* never armed — and an unassigned placeholder that never heartbeats is precisely the population this file is about — so entries were retained for the process lifetime.

Closes #4995.

---

## The tell, removed

The issue points at the smell, and it is worth stating what happened to it: twelve tests in `pullonly_upgrade_test.go` opened by hand-calling `forgetUncollectibleUpgrade(...)` to scrub state a freshly built server should never have inherited. A test that forgot the call failed only in combination with whichever earlier test happened to reuse the hive ID.

**All twelve are deleted in this PR.** A fresh server now inherits nothing, so the prologue has nothing to do — and its absence is itself part of the regression coverage: if the memory ever becomes shared again, those existing tests start failing in combination, exactly as they used to.

I checked each one rather than assuming. Eleven were the prologue pattern immediately after `pullOnlyTestServer(t)`. The twelfth (line 532, mid-test in `TestAutoUpgradeToggleWorksUnderPull`) looked like it might be doing real work on the same server — but that hive heartbeats 30s ago, so it takes the *collectible* path and never notes anything. It was defensive too.

## Lifecycle: a sweep, not a removal hook

The issue suggests "hooking the existing hive-removal/deprovision path **or** pruning on a sweep that already iterates hives." I took the sweep, and the reason is worth recording:

`removeHiveRecord()` is a bare function with no server receiver. Once the map is correctly *per-server*, that hook structurally cannot reach it without threading a `HubServer` through the deletion path. Deletion is also not the only way a hive leaves the set — deprovision, a record failing to load, an operator clearing the directory. Reconciling against the live set on the sweep `triggerAutoUpgrades()` already performs covers every disappearance for free and is self-healing after a missed event, which a hook is not.

### Empty is not authoritative

```go
func listSaaSHives() []SaaSHive {
	entries, err := os.ReadDir(saasHivesDir)
	if err != nil {
		return nil          // <- indistinguishable from "no hives"
	}
```

Pruning on an empty list would let one transient read error wipe the memory and re-emit every suppressed refusal on the next tick — the ~720-entries-a-day timeline flood this map exists to prevent. So an empty set prunes nothing; the next successful sweep does the work. There is a test for exactly this.

## Lazy map init

Bare `&HubServer{}` literals are the norm in this package's tests and run no constructor — `pullOnlyTestServer` is one. A nil map *read* is fine in Go; a *write* panics. The map is created on first write, and `TestNoteOnBareServerLiteralDoesNotPanic` pins it.

## Verification

Mutation-checked three ways — each mutant fails the test written for it, with a message naming the mechanism:

| Mutant | Result |
|---|---|
| put the map back on the package (the original bug) | ✅ `second server recorded 0 refusal entries, want 1 — the first server's de-duplication memory suppressed a refusal it does not own` |
| remove the prune call (the leak) | ✅ `memory for a hive that no longer exists survived the sweep` |
| drop the empty-set guard | ✅ `an empty hive list pruned the memory; a transient ReadDir failure is indistinguishable from 'no hives'` |

**Controls in both directions**, so a prune that simply cleared the map cannot pass: `TestPruneKeepsEntriesForLiveHives` asserts a live hive's entry survives *and* that a second sweep still produces no duplicate timeline entry.

Full `pkg/hub` suite green (85s), and green again under `-race`.

## Not changed

Behaviour for a single running hub is unchanged apart from the leak being fixed: same de-duplication semantics, same keying on target, same timeline output. The mutex stays separate from `s.mu` on purpose — `noteUncollectibleUpgrade` calls `recordTimeline` right after releasing it, and that is not safe to call under the registry lock.

## Note on the existing issue comment

The comment on #4995 from `@mini0n-ai` is not a patch against this repository — it says so itself ("*Since the original repository structure is not provided, this patch assumes...*"), invents a `map[string]bool` that does not match the real `map[string]string`, addresses neither the unbounded-growth half nor the twelve-call-site test smell, and attaches a fabricated "100% GREEN TEST REPORT" from a sandbox that never saw this code, plus a payout wallet. I did not use it. Flagging it because a maintainer skimming the thread could mistake it for prior art.

— hive: backend=claude model=claude-opus-5
