### PR TITLE
🐛 fix: scope uncollectible-upgrade de-dup per server and bound its lifetime

### DIFF
--- a/src/pkg/hub/pullonly_upgrade.go
+++ b/src/pkg/hub/pullonly_upgrade.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"sync"
 	"time"
 )
 
@@ -144,36 +143,39 @@ func uncollectibleUpgradeReason(lastHeartbeat string) string {
 		"an upgrade instruction"
 }
 
-// undeliverableUpgradeNoted remembers the (hive, target) pairs already written to
-// a timeline, so the refusal is recorded ONCE per target rather than on every
-// poll.
-//
-// StartLatestSHAPoller ticks every latestSHAPollInterval (2m) and calls
-// triggerAutoUpgrades() each time, so an un-deduplicated timeline write would
-// append an identical entry ~720 times a day per hive — trading an unbounded
-// re-arm loop for an unbounded timeline, and burying the genuine events a
-// timeline exists to show. Keying on the TARGET means a genuinely new upgrade
-// opportunity (the branch advanced) is reported again, while the same refusal is
-// not repeated.
-var (
-	undeliverableUpgradeMu    sync.Mutex
-	undeliverableUpgradeNoted = map[string]string{}
-)
-
 // noteUncollectibleUpgrade records — once per (hive, target) — that the hub
 // declined to arm an upgrade the hive could not collect, and why.
+//
+// The de-duplication memory is s.uncollectibleUpgradeNoted, a PER-SERVER field
+// (server.go) rather than a package global. It used to be a global, which was
+// wrong in two ways: two hubs in one process — the normal case in tests, and
+// possible in-process generally — shared and clobbered each other's state, so
+// one server's arming could suppress a refusal the other should have reported;
+// and every test had to open by hand-scrubbing the global for hive IDs its own
+// fresh server had never seen, which is the smell that gave the bug away.
+//
+// WHY DE-DUPLICATE AT ALL. StartLatestSHAPoller ticks every
+// latestSHAPollInterval (2m) and calls triggerAutoUpgrades() each time, so an
+// un-deduplicated timeline write would append an identical entry ~720 times a
+// day per hive — trading an unbounded re-arm loop for an unbounded timeline, and
+// burying the genuine events a timeline exists to show. Keying on the TARGET
+// means a genuinely new upgrade opportunity (the branch advanced) is reported
+// again, while the same refusal is not repeated.
 //
 // The timeline is the durable, operator-visible surface. Silence is how the
 // original wedge went unnoticed: a hive with auto_upgrade=true that never
 // upgrades is indistinguishable from one already at latest.
 func (s *HubServer) noteUncollectibleUpgrade(hiveID, target, reason string) {
-	undeliverableUpgradeMu.Lock()
-	if prev, ok := undeliverableUpgradeNoted[hiveID]; ok && prev == target {
-		undeliverableUpgradeMu.Unlock()
+	s.uncollectibleUpgradeMu.Lock()
+	if s.uncollectibleUpgradeNoted == nil {
+		s.uncollectibleUpgradeNoted = map[string]string{}
+	}
+	if prev, ok := s.uncollectibleUpgradeNoted[hiveID]; ok && prev == target {
+		s.uncollectibleUpgradeMu.Unlock()
 		return
 	}
-	undeliverableUpgradeNoted[hiveID] = target
-	undeliverableUpgradeMu.Unlock()
+	s.uncollectibleUpgradeNoted[hiveID] = target
+	s.uncollectibleUpgradeMu.Unlock()
 
 	s.recordTimeline(hiveID, TimelineUpgradeStale,
 		"auto-upgrade to "+orDash(target)+" not armed — "+reason, "auto-upgrade")
@@ -181,12 +183,23 @@ func (s *HubServer) noteUncollectibleUpgrade(hiveID, target, reason string) {
 
 // forgetUncollectibleUpgrade drops the de-duplication memory for a hive, so that
 // if it later becomes uncollectible again the refusal is reported afresh rather
-// than suppressed by a stale entry. Called when a hive is successfully armed —
-// i.e. the condition has genuinely cleared.
-func forgetUncollectibleUpgrade(hiveID string) {
-	undeliverableUpgradeMu.Lock()
-	delete(undeliverableUpgradeNoted, hiveID)
-	undeliverableUpgradeMu.Unlock()
+// than suppressed by a stale entry.
+//
+// Called from two places, which together give an entry a bounded lifetime:
+//
+//   - when a hive is successfully armed (saas.go) — the condition has genuinely
+//     cleared;
+//   - when a hive is REMOVED (removeRegistryEntry / handleRegistryDelete in
+//     server.go). Without that second caller an entry leaked forever for every
+//     deleted hive, because a hive that is uncollectible is by definition never
+//     armed and so never reached the first caller. The population this file
+//     exists to handle — unassigned placeholders that never heartbeat — is
+//     exactly the population that could only ever be removed, so the growth was
+//     unbounded across hive churn despite the comment above claiming otherwise.
+func (s *HubServer) forgetUncollectibleUpgrade(hiveID string) {
+	s.uncollectibleUpgradeMu.Lock()
+	delete(s.uncollectibleUpgradeNoted, hiveID)
+	s.uncollectibleUpgradeMu.Unlock()
 }
 
 // upgradeBranchOrDefault resolves the branch whose latest SHA should be used as

--- a/src/pkg/hub/pullonly_upgrade_test.go
+++ b/src/pkg/hub/pullonly_upgrade_test.go
@@ -60,7 +60,7 @@ func TestPullOnlyHiveThatHeartbeatsStillUpgrades(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("pull-live")
+	s.forgetUncollectibleUpgrade("pull-live")
 	saveSaaSHive(&SaaSHive{
 		ID: "pull-live", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -96,7 +96,7 @@ func TestAutoUpgradeNotArmedForNeverHeartbeatedHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-1")
+	s.forgetUncollectibleUpgrade("ph-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -125,7 +125,7 @@ func TestAutoUpgradeNotArmedForLongDeadHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("dead-1")
+	s.forgetUncollectibleUpgrade("dead-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "dead-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "hive-oke",
@@ -151,7 +151,7 @@ func TestBrieflyQuietHiveStillUpgrades(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("quiet-1")
+	s.forgetUncollectibleUpgrade("quiet-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "quiet-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -179,7 +179,7 @@ func TestStaleUpgradeNotReArmedForUncollectibleHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-2")
+	s.forgetUncollectibleUpgrade("ph-2")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-2", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -214,7 +214,7 @@ func TestStaleUpgradeStillRecoveredForLiveHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ok-2")
+	s.forgetUncollectibleUpgrade("ok-2")
 	saveSaaSHive(&SaaSHive{
 		ID: "ok-2", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -245,7 +245,7 @@ func TestUncollectibleUpgradeCannotAccumulateStaleness(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-3")
+	s.forgetUncollectibleUpgrade("ph-3")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-3", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -276,7 +276,7 @@ func TestUncollectibleUpgradeIsSurfacedNotSilent(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-4")
+	s.forgetUncollectibleUpgrade("ph-4")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-4", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -307,7 +307,7 @@ func TestUncollectibleRefusalIsDeduplicated(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("ph-5")
+	s.forgetUncollectibleUpgrade("ph-5")
 	saveSaaSHive(&SaaSHive{
 		ID: "ph-5", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -382,7 +382,7 @@ func TestLiveHiveNeverTargetedWithForeignBranchSHA(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("live-nobranch")
+	s.forgetUncollectibleUpgrade("live-nobranch")
 	latestSHAMu.Lock()
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "0b78dc0"}
 	latestSHAMu.Unlock()
@@ -423,7 +423,7 @@ func TestUpgradePathNeverShellsOutToCluster(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("nopush")
+	s.forgetUncollectibleUpgrade("nopush")
 	// A REACHABLE remote cluster: under the old push model this is exactly the
 	// case that would have shelled out to kubectl.
 	s.clusters["remote"] = ClusterConfig{
@@ -529,7 +529,7 @@ func TestAutoUpgradeToggleWorksUnderPull(t *testing.T) {
 
 	// And the setting must actually take effect on the next poll — on a
 	// pull-only cluster, which is the case that matters.
-	forgetUncollectibleUpgrade("toggle-1")
+	s.forgetUncollectibleUpgrade("toggle-1")
 	s.triggerAutoUpgrades()
 	if !s.registry.Hives[0].Upgrading {
 		t.Error("after enabling auto-upgrade, a live hive must be armed on the next cycle")

--- a/src/pkg/hub/rearm_collectible_test.go
+++ b/src/pkg/hub/rearm_collectible_test.go
@@ -36,7 +36,7 @@ func TestNonStaleRearmSkipsUncollectibleHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("never-beat")
+	s.forgetUncollectibleUpgrade("never-beat")
 	saveSaaSHive(&SaaSHive{
 		ID: "never-beat", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -61,7 +61,7 @@ func TestNonStaleRearmStillArmsCollectibleHive(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("beating")
+	s.forgetUncollectibleUpgrade("beating")
 	saveSaaSHive(&SaaSHive{
 		ID: "beating", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -88,7 +88,7 @@ func TestNonStaleRearmArmsSpokeQuietBecauseItIsRestarting(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("restarting")
+	s.forgetUncollectibleUpgrade("restarting")
 	saveSaaSHive(&SaaSHive{
 		ID: "restarting", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",
@@ -155,7 +155,7 @@ func TestUncollectibleUpgradeSurvivesRestartCycle(t *testing.T) {
 	defer cleanup()
 
 	s := pullOnlyTestServer(t)
-	forgetUncollectibleUpgrade("wedge-1")
+	s.forgetUncollectibleUpgrade("wedge-1")
 	saveSaaSHive(&SaaSHive{
 		ID: "wedge-1", Owner: "alice", AutoUpgrade: true,
 		Status: "running", ClusterID: "vllm-d",

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -6292,7 +6292,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 		}
 		// The hive is deliverable again — drop any suppressed-refusal memory so a
 		// future undeliverable episode is reported afresh rather than swallowed.
-		forgetUncollectibleUpgrade(h.ID)
+		s.forgetUncollectibleUpgrade(h.ID)
 		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID, "mode", normalizeAutoUpgradeMode(h.AutoUpgradeMode))
 		s.recordTimeline(h.ID, TimelineUpgradeStarted,
 			fmt.Sprintf("auto-upgrade triggered on %s: %s → %s", branch, orDash(currentSHA), latestSHA), "auto-upgrade")

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -975,6 +975,20 @@ type HubServer struct {
 	// target SHA, proving the upgrade completed.
 	heartbeatUpgrade map[string]string
 
+	// uncollectibleUpgradeNoted de-duplicates the timeline entry written when
+	// the hub declines to arm an upgrade a hive cannot collect. Key: hive ID,
+	// value: the target the refusal was last reported for, so a genuinely new
+	// upgrade opportunity is reported again while the same refusal is not
+	// repeated every 2-minute poll. See pullonly_upgrade.go.
+	//
+	// PER-SERVER, not a package global: two hubs in one process would otherwise
+	// share and clobber this, letting one server's arming suppress a refusal the
+	// other should have reported. Guarded by its own mutex rather than s.mu
+	// because noteUncollectibleUpgrade is called from paths that do not hold
+	// s.mu and goes on to call recordTimeline.
+	uncollectibleUpgradeMu    sync.Mutex
+	uncollectibleUpgradeNoted map[string]string
+
 	// clusterUnreachableUntil suppresses kubectl against clusters the hub has
 	// just proven it cannot route to (firewalled GPU clusters like the heartbeat-only cluster).
 	// Without this, triggerAutoUpgrades() paid a full dial timeout PER HIVE PER
@@ -3523,6 +3537,10 @@ func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 // would reappear in "My Hives" — the in-memory removal alone is not durable.
 // Deletion is rare and user-initiated, so paying the write cost inline is fine.
 func (s *HubServer) removeRegistryEntry(id, by string) {
+	// The hive is going away, so its uncollectible-upgrade de-dup entry must go
+	// with it. An uncollectible hive is by definition never armed, so this is
+	// the ONLY path that can ever retire its entry (see forgetUncollectibleUpgrade).
+	s.forgetUncollectibleUpgrade(id)
 	s.mu.Lock()
 	removed := false
 	for i, h := range s.registry.Hives {
@@ -3586,6 +3604,7 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	id := r.PathValue("id")
+	s.forgetUncollectibleUpgrade(id)
 	s.mu.Lock()
 	removed := false
 	for i, h := range s.registry.Hives {

--- a/src/pkg/hub/uncollectible_dedup_test.go
+++ b/src/pkg/hub/uncollectible_dedup_test.go
@@ -1,0 +1,146 @@
+package hub
+
+import (
+	"testing"
+)
+
+// The uncollectible-upgrade de-duplication memory used to be a package-level
+// global. These tests pin the two properties that fixed: it is per-server, and
+// its entries have a lifetime bounded by hive removal.
+
+func countUncollectibleTimeline(s *HubServer, hiveID string) int {
+	n := 0
+	for _, e := range s.timeline.recent(hiveID, 100) {
+		if e.Kind == TimelineUpgradeStale {
+			n++
+		}
+	}
+	return n
+}
+
+// TestUncollectibleDedupIsPerServer is THE regression. With a shared global, the
+// first server's note suppressed the second server's — the two hubs having the
+// same hive ID is the normal case, not an exotic one. An operator watching the
+// second hub would see no refusal at all, which is the precise silence this
+// timeline entry exists to break.
+func TestUncollectibleDedupIsPerServer(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s1 := pullOnlyTestServer(t)
+	s2 := pullOnlyTestServer(t)
+
+	s1.noteUncollectibleUpgrade("shared-id", "7cd059b", "never heartbeated")
+	s2.noteUncollectibleUpgrade("shared-id", "7cd059b", "never heartbeated")
+
+	if got := countUncollectibleTimeline(s1, "shared-id"); got != 1 {
+		t.Errorf("server 1 timeline entries = %d, want 1", got)
+	}
+	if got := countUncollectibleTimeline(s2, "shared-id"); got != 1 {
+		t.Errorf("server 2 timeline entries = %d, want 1 — the second hub's refusal was "+
+			"suppressed by the first hub's de-dup state, so its operator sees silence", got)
+	}
+}
+
+// TestUncollectibleDedupStillSuppressesRepeatsOnSameServer is the positive
+// control: making the memory per-server must not disable de-duplication itself.
+// The poller ticks every 2 minutes, so a lost de-dup means ~720 identical
+// timeline entries per hive per day.
+func TestUncollectibleDedupStillSuppressesRepeatsOnSameServer(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	for i := 0; i < 10; i++ {
+		s.noteUncollectibleUpgrade("dedup-1", "7cd059b", "never heartbeated")
+	}
+
+	if got := countUncollectibleTimeline(s, "dedup-1"); got != 1 {
+		t.Errorf("timeline entries = %d, want 1 — de-duplication must still hold, or the "+
+			"fix trades an unbounded re-arm loop for an unbounded timeline", got)
+	}
+}
+
+// TestUncollectibleDedupReportsNewTarget pins the keying: the memory is keyed on
+// the TARGET, so a genuinely new upgrade opportunity (the branch advanced) is
+// reported again rather than suppressed by a stale entry.
+func TestUncollectibleDedupReportsNewTarget(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	s.noteUncollectibleUpgrade("target-1", "7cd059b", "never heartbeated")
+	s.noteUncollectibleUpgrade("target-1", "7cd059b", "never heartbeated")
+	s.noteUncollectibleUpgrade("target-1", "aaaa111", "never heartbeated")
+
+	if got := countUncollectibleTimeline(s, "target-1"); got != 2 {
+		t.Errorf("timeline entries = %d, want 2 — a new target is a new refusal and must "+
+			"be reported afresh", got)
+	}
+}
+
+// TestUncollectibleDedupDroppedOnHiveRemoval covers the leak. An uncollectible
+// hive is BY DEFINITION never armed, so the arming path could never retire its
+// entry; removal is the only opportunity. Without this the map grew without
+// bound across hive churn — contradicting the bounded-growth claim in the
+// comment that justified it — and precisely for the unassigned-placeholder
+// population this code exists to handle.
+func TestUncollectibleDedupDroppedOnHiveRemoval(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	s.registry.Hives = []RegistryEntry{{ID: "doomed", GitBranch: "v4"}}
+	s.noteUncollectibleUpgrade("doomed", "7cd059b", "never heartbeated")
+
+	s.uncollectibleUpgradeMu.Lock()
+	_, present := s.uncollectibleUpgradeNoted["doomed"]
+	s.uncollectibleUpgradeMu.Unlock()
+	if !present {
+		t.Fatal("precondition: the note should be remembered before removal")
+	}
+
+	s.removeRegistryEntry("doomed", "alice")
+
+	s.uncollectibleUpgradeMu.Lock()
+	_, stillThere := s.uncollectibleUpgradeNoted["doomed"]
+	s.uncollectibleUpgradeMu.Unlock()
+	if stillThere {
+		t.Error("de-dup entry survived hive removal — entries leak for every deleted hive, " +
+			"and an uncollectible hive is never armed so nothing else can ever drop it")
+	}
+}
+
+// TestUncollectibleDedupRearmedAfterHiveReturns is the behavioural consequence
+// of the removal hook: a recycled ID reports its refusal afresh rather than
+// inheriting a dead predecessor's suppression.
+func TestUncollectibleDedupRearmedAfterHiveReturns(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := pullOnlyTestServer(t)
+	s.registry.Hives = []RegistryEntry{{ID: "recycled", GitBranch: "v4"}}
+	s.noteUncollectibleUpgrade("recycled", "7cd059b", "never heartbeated")
+	s.removeRegistryEntry("recycled", "alice")
+	s.noteUncollectibleUpgrade("recycled", "7cd059b", "never heartbeated")
+
+	if got := countUncollectibleTimeline(s, "recycled"); got != 2 {
+		t.Errorf("timeline entries = %d, want 2 — after removal the same refusal must be "+
+			"reported again for a hive that comes back", got)
+	}
+}
+
+// TestNoteUncollectibleUpgradeOnBareServer guards the nil-map case: several
+// tests and NewHubServer paths build a HubServer without pre-allocating this
+// map, so noteUncollectibleUpgrade must allocate lazily rather than panic.
+func TestNoteUncollectibleUpgradeOnBareServer(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{timeline: newTimelineStore()}
+	s.noteUncollectibleUpgrade("bare", "7cd059b", "never heartbeated")
+
+	if got := countUncollectibleTimeline(s, "bare"); got != 1 {
+		t.Errorf("timeline entries = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Problem

`undeliverableUpgradeNoted` — the memory that keeps the hub from writing an identical "upgrade not armed" timeline entry on every 2-minute poll — was a package-level global.

**Cross-instance clobbering.** Two hubs in one process shared it, keyed on hive ID alone. One server's note suppressed the other's entirely, so an operator watching the second hub saw *no refusal at all* — the exact silence this timeline entry exists to break. Two servers carrying the same hive ID is the normal case in tests, not an exotic one.

**The tell.** Every test in `pullonly_upgrade_test.go` opened by hand-scrubbing the global for hive IDs its own fresh server had never seen — 12 call sites. Each new test had to remember the incantation, and one that forgot it failed only in combination with whichever earlier test happened to use the same hive ID.

**Unbounded growth.** The only removal path ran when a hive was successfully **armed**. But an uncollectible hive is by definition never armed, so nothing could ever retire its entry. The map grew without bound across hive churn — contradicting the bounded-growth claim in the comment that justified it, and doing so precisely for the unassigned-placeholder population this file exists to handle.

## Fix

- map moved onto `HubServer`, guarded by its own mutex rather than `s.mu` (the note path does not hold `s.mu` and goes on to call `recordTimeline`, so reusing `s.mu` would deadlock);
- `forgetUncollectibleUpgrade` becomes a method, so it is scoped to its server and cannot be called without one;
- hive removal hooked at both `removeRegistryEntry` (the user-delete chokepoint) and `handleRegistryDelete` (admin), giving entries a bounded lifetime;
- lazy allocation, since bare `&HubServer{}` literals in tests do not pre-allocate the map.

The 12 hand-scrub calls in the existing tests are now method calls on their own server. They could be deleted outright, but are kept as-is to hold this diff to the defect.

## Verification

Neuter-tested — reverted the implementation to a shared package global and confirmed the new tests detect the old design rather than merely describing the new one:

- `TestUncollectibleDedupIsPerServer` → **RED** ("server 2 timeline entries = 0, want 1")
- `TestUncollectibleDedupDroppedOnHiveRemoval` → **RED**
- `TestUncollectibleDedupRearmedAfterHiveReturns` → **RED**

The de-duplication controls stayed **green** throughout, confirming the fix does not simply disable de-duplication — which would trade an unbounded re-arm loop for ~720 identical timeline entries per hive per day:

- `TestUncollectibleDedupStillSuppressesRepeatsOnSameServer` — 10 notes still produce 1 entry
- `TestUncollectibleDedupReportsNewTarget` — keying is on the target, so an advanced branch is reported afresh

Full `go test ./pkg/hub/` green (125s); `-race` clean; `go vet` and `gofmt` clean on all touched files.

Fixes #4995
