### PR TITLE
✨ v5: reviewer agent role — PR-triggered, repo-grounded verdicts

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -7052,6 +7052,11 @@ func planReviewDispatch(cfg *config.Config, actionable *github.ActionableResult,
 			HeadSHA: pr.HeadSHA,
 			URL:     pr.URL,
 			Lane:    string(lane),
+			// Grounding anchor for the review prompt. Repo access is the
+			// measured active ingredient in review quality (17%→67% hit rate,
+			// 61% fewer false positives), so the reviewer is told which commit
+			// to read rather than being left to infer from the diff.
+			MergeBase: pr.BaseSHA,
 		})
 	}
 	agents := make([]review.AgentCapability, 0, len(cfg.Agents))

--- a/src/pkg/config/acmm_packs_test.go
+++ b/src/pkg/config/acmm_packs_test.go
@@ -24,8 +24,12 @@ func TestACMMPacksLoad(t *testing.T) {
 func TestACMMPacksAgentCounts(t *testing.T) {
 	packs := ACMMPacks()
 
+	// L5 and L6 each carry one extra agent over L4's roster growth: the
+	// on-demand `reviewer`, which is PR-triggered rather than cadence-kicked.
+	// It is defined only at the levels where a PR can reach merge without a
+	// mandatory human read (L5 gates on `hold`, L6 auto-merges on green).
 	expected := map[int]int{
-		1: 2, 2: 5, 3: 6, 4: 7, 5: 9, 6: 10,
+		1: 2, 2: 5, 3: 6, 4: 7, 5: 10, 6: 11,
 	}
 	for _, p := range packs {
 		want, ok := expected[p.Level]

--- a/src/pkg/config/packs/level-5.yaml
+++ b/src/pkg/config/packs/level-5.yaml
@@ -296,3 +296,50 @@ agents:
 
     '
   clear_on_kick: true
+- name: reviewer
+  display_name: reviewer
+  role: reviewer
+  description: 'Repo-grounded PR reviewer. Wakes when a change is proposed and judges
+    THAT change, rather than hunting on a cadence. Reads the repository at the PR''s
+    merge-base and must cite file:line evidence for every finding. Produces structured
+    review verdicts consumed by the review swarm aggregator and, at L6, by the
+    approval desk as withhold-only input to a merge.
+
+    '
+  emoji: 🔬
+  color: '#34495e'
+  sort_order: 26
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  # ADVISORY, deliberately. The reviewer's product is a structured verdict
+  # written as an agent report, not a GitHub PR review — so it needs no GitHub
+  # write scope, and its authority sits strictly below the hive's ACMM level.
+  # Posting an actual PR review would require ModeIssuesAndPRs (proxy/rules.go:115
+  # gates POST .../pulls/{n}/reviews on that mode), which at L3 would mean a
+  # SECOND write-capable agent alongside quality — a change not justified by the
+  # evidence, since a verdict a human reads in the batch queue is worth the same
+  # as one posted to the PR.
+  mode: ADVISORY
+  kick_template: reviewer-advisory.md
+  # PR-triggered, not cadence-triggered. on_demand keeps the governor from ever
+  # kicking this agent on a timer (governor.go gates agentsDueForKick,
+  # event-kicks, and AllowResumeKick on it); the review dispatcher wakes it per
+  # PR instead. Every other agent hunts; this one judges what it is handed.
+  on_demand: true
+  # The reviewer must be able to read the tree it is judging. This is the
+  # measured active ingredient, not a convenience: a diff-only reviewer scored
+  # 17% hits at 3.6 false positives/PR, while the same reviewer with repo access
+  # at the merge-base scored 67% hits at 1.4 FPs/PR.
+  include_repos: true
+  stale_timeout: 7200
+  interactions: 'Woken per-PR by the review dispatcher. Verdicts aggregate into
+    review-verdicts.json, which gates merge eligibility when review.require_approval
+    is set.
+
+    '
+  knowledge_use: 'Reads the repository at the PR merge-base. Produces structured
+    review verdicts with file:line-cited findings.
+
+    '
+  clear_on_kick: true

--- a/src/pkg/config/packs/level-6.yaml
+++ b/src/pkg/config/packs/level-6.yaml
@@ -322,3 +322,50 @@ agents:
 
     '
   clear_on_kick: true
+- name: reviewer
+  display_name: reviewer
+  role: reviewer
+  description: 'Repo-grounded PR reviewer. Wakes when a change is proposed and judges
+    THAT change, rather than hunting on a cadence. Reads the repository at the PR''s
+    merge-base and must cite file:line evidence for every finding. Produces structured
+    review verdicts consumed by the review swarm aggregator and, at L6, by the
+    approval desk as withhold-only input to a merge.
+
+    '
+  emoji: 🔬
+  color: '#34495e'
+  sort_order: 26
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  # ADVISORY, deliberately. The reviewer's product is a structured verdict
+  # written as an agent report, not a GitHub PR review — so it needs no GitHub
+  # write scope, and its authority sits strictly below the hive's ACMM level.
+  # Posting an actual PR review would require ModeIssuesAndPRs (proxy/rules.go:115
+  # gates POST .../pulls/{n}/reviews on that mode), which at L3 would mean a
+  # SECOND write-capable agent alongside quality — a change not justified by the
+  # evidence, since a verdict a human reads in the batch queue is worth the same
+  # as one posted to the PR.
+  mode: ADVISORY
+  kick_template: reviewer-advisory.md
+  # PR-triggered, not cadence-triggered. on_demand keeps the governor from ever
+  # kicking this agent on a timer (governor.go gates agentsDueForKick,
+  # event-kicks, and AllowResumeKick on it); the review dispatcher wakes it per
+  # PR instead. Every other agent hunts; this one judges what it is handed.
+  on_demand: true
+  # The reviewer must be able to read the tree it is judging. This is the
+  # measured active ingredient, not a convenience: a diff-only reviewer scored
+  # 17% hits at 3.6 false positives/PR, while the same reviewer with repo access
+  # at the merge-base scored 67% hits at 1.4 FPs/PR.
+  include_repos: true
+  stale_timeout: 7200
+  interactions: 'Woken per-PR by the review dispatcher. Verdicts aggregate into
+    review-verdicts.json, which gates merge eligibility when review.require_approval
+    is set.
+
+    '
+  knowledge_use: 'Reads the repository at the PR merge-base. Produces structured
+    review verdicts with file:line-cited findings.
+
+    '
+  clear_on_kick: true

--- a/src/pkg/config/reviewer_role_test.go
+++ b/src/pkg/config/reviewer_role_test.go
@@ -1,0 +1,162 @@
+package config
+
+// Governance tests for the `reviewer` agent role.
+//
+// The reviewer is unusual in two ways that each need pinning, because both are
+// easy to undo with a one-line pack edit that compiles and parses fine:
+//
+//  1. It is PR-TRIGGERED, not cadence-triggered. Every other agent wakes on a
+//     timer and hunts for work; this one is woken per-PR by the review
+//     dispatcher and judges the change it is handed. `on_demand: true` is what
+//     enforces that — the governor gates cadence kicks, event kicks, and resume
+//     kicks on it.
+//
+//  2. Its authority is capped BELOW the hive's ACMM level. It runs in ADVISORY
+//     mode and writes verdicts to the agent-report directory. It has no GitHub
+//     write scope, cannot merge, and cannot self-approve.
+
+import "testing"
+
+// reviewerLevels are the packs the role is defined in. L5 and L6 are the levels
+// where a PR can reach merge without a mandatory human read — L5 gates on the
+// `hold` label and L6 auto-merges on green — so they are where a repo-grounded
+// pre-merge judgment has somewhere to land.
+var reviewerLevels = []int{5, 6}
+
+// nonReviewerLevels are the packs the role is deliberately absent from. At
+// L3/L4 the `hold` label already blocks every agent PR behind a human, so a
+// reviewer there is triage rather than a safety gate — and adding it is not
+// free, so it is left out rather than shipped unused.
+var nonReviewerLevels = []int{1, 2, 3, 4}
+
+func reviewerIn(t *testing.T, level int) (PackAgent, bool) {
+	t.Helper()
+	p, err := ACMMPackByLevel(level)
+	if err != nil {
+		t.Fatalf("ACMMPackByLevel(%d): %v", level, err)
+	}
+	for _, a := range p.Agents {
+		if a.Name == "reviewer" {
+			return a, true
+		}
+	}
+	return PackAgent{}, false
+}
+
+// TestReviewerRoleDefinedAtHighTrustLevels pins where the role ships.
+func TestReviewerRoleDefinedAtHighTrustLevels(t *testing.T) {
+	for _, lvl := range reviewerLevels {
+		a, ok := reviewerIn(t, lvl)
+		if !ok {
+			t.Fatalf("L%d pack is missing the reviewer agent", lvl)
+		}
+		if a.Role != "reviewer" {
+			t.Errorf("L%d: role = %q, want \"reviewer\"", lvl, a.Role)
+		}
+		if a.KickTemplate != "reviewer-advisory.md" {
+			t.Errorf("L%d: kick_template = %q, want reviewer-advisory.md", lvl, a.KickTemplate)
+		}
+	}
+}
+
+// TestReviewerAbsentBelowL5 pins that the role does NOT silently appear at
+// levels whose merge policy already requires a human. This is the positive
+// control for the test above: it proves the lookup can return false, so
+// "present at L5/L6" is a real assertion rather than a helper that always
+// finds something.
+func TestReviewerAbsentBelowL5(t *testing.T) {
+	for _, lvl := range nonReviewerLevels {
+		if _, ok := reviewerIn(t, lvl); ok {
+			t.Errorf("L%d must not define the reviewer agent: the hold label already gates every agent PR behind a human there", lvl)
+		}
+	}
+}
+
+// TestReviewerIsPRTriggeredNotCadenceTriggered pins the lifecycle property.
+//
+// on_demand is the existing mechanism that excludes an agent from every
+// governor kick path (agentsDueForKick, the event-kick gate, and
+// AllowResumeKick all consult AgentConfig.OnDemand). Dropping it would convert
+// the reviewer into yet another agent that wakes on a timer and hunts, which is
+// precisely the design this role rejects.
+func TestReviewerIsPRTriggeredNotCadenceTriggered(t *testing.T) {
+	for _, lvl := range reviewerLevels {
+		a, ok := reviewerIn(t, lvl)
+		if !ok {
+			t.Fatalf("L%d pack is missing the reviewer agent", lvl)
+		}
+		if !a.OnDemand {
+			t.Errorf("L%d: reviewer must be on_demand so the governor never cadence-kicks it; "+
+				"it is woken per-PR by the review dispatcher", lvl)
+		}
+	}
+}
+
+// TestReviewerHasNoCadenceEntry pins the same property from the other side: a
+// cadence entry for an on-demand agent is dead configuration that misleads an
+// operator reading the pack into thinking the reviewer runs on a timer.
+func TestReviewerHasNoCadenceEntry(t *testing.T) {
+	for _, lvl := range reviewerLevels {
+		p, err := ACMMPackByLevel(lvl)
+		if err != nil {
+			t.Fatalf("ACMMPackByLevel(%d): %v", lvl, err)
+		}
+		for mode, cadences := range p.Governor.Cadences {
+			if v, ok := cadences["reviewer"]; ok {
+				t.Errorf("L%d governor cadence %q declares reviewer=%q, but the reviewer is PR-triggered; "+
+					"a cadence entry here is dead config", lvl, mode, v)
+			}
+		}
+	}
+}
+
+// TestReviewerAuthorityIsCappedBelowHiveLevel pins the governance invariant:
+// the reviewer cannot merge, cannot self-approve, and holds no GitHub write
+// scope. ADVISORY is the mode that guarantees it — PR reviews, PR edits, and
+// pushes all require ModeIssuesAndPRs (see pkg/proxy/rules.go), and issue
+// creation requires ModeIssuesOnly, so ADVISORY leaves read-only access.
+//
+// This is what makes the role safe to enable on an evidence base of six PRs:
+// the worst a bad verdict can do is withhold a merge for a human to clear.
+func TestReviewerAuthorityIsCappedBelowHiveLevel(t *testing.T) {
+	for _, lvl := range reviewerLevels {
+		a, ok := reviewerIn(t, lvl)
+		if !ok {
+			t.Fatalf("L%d pack is missing the reviewer agent", lvl)
+		}
+		if a.Mode != "ADVISORY" {
+			t.Errorf("L%d: reviewer mode = %q, want ADVISORY. The reviewer's product is a structured "+
+				"verdict written to the agent-report dir, not a GitHub write. Granting it "+
+				"ISSUES_AND_PRS would add a second write-capable agent and let it post PR reviews.", lvl, a.Mode)
+		}
+	}
+}
+
+// TestReviewerCanReadTheRepo pins the measured active ingredient.
+//
+// An experiment scored a diff-only reviewer at 17% hit rate with 3.6 false
+// positives per PR, and the same reviewer with repository access at the PR's
+// merge-base at 67% with 1.4 FPs. Repo access is the defining feature of this
+// role, not an enhancement — a reviewer without it is not worth running, so
+// include_repos is asserted rather than left to a pack author's judgment.
+func TestReviewerCanReadTheRepo(t *testing.T) {
+	for _, lvl := range reviewerLevels {
+		a, ok := reviewerIn(t, lvl)
+		if !ok {
+			t.Fatalf("L%d pack is missing the reviewer agent", lvl)
+		}
+		if !a.IncludeRepos {
+			t.Errorf("L%d: reviewer must have include_repos: true. Repo access is the measured "+
+				"active ingredient (17%%->67%% hit rate, 61%% fewer false positives); "+
+				"a diff-only reviewer produces ~9 non-issues per real finding.", lvl)
+		}
+	}
+}
+
+// TestReviewerIsOnDemandFleetWide pins that the shared on-demand registry sees
+// the role, so nothing auto-starts it regardless of which level is active.
+func TestReviewerIsOnDemandFleetWide(t *testing.T) {
+	if !OnDemandAgentsFromPacks()["reviewer"] {
+		t.Fatal("reviewer must appear in OnDemandAgentsFromPacks so it is never auto-started on a timer")
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -225,6 +225,18 @@ type PullRequest struct {
 	// four days in the 2026-08 seedMission incident.
 	FailingChecks    []string `json:"failing_checks,omitempty"`
 	CIFailureExcerpt string   `json:"ci_failure_excerpt,omitempty"`
+	// BaseSHA is the commit on the base branch the PR targets — the tree a
+	// reviewer should read to judge the change in context. It is carried so a
+	// repo-grounded review can be pinned to a specific commit rather than to
+	// whatever the base branch happens to be when the reviewer runs.
+	//
+	// This is the base branch tip as reported at enumeration time, not the
+	// true merge-base of an ancestry walk. For an up-to-date PR the two are
+	// the same commit, and for a stale one the base tip is the more useful
+	// tree to read anyway (it is what the change will actually land on). It is
+	// an ADVISORY grounding anchor, never a merge-safety input — nothing gates
+	// a merge on this field.
+	BaseSHA string `json:"base_sha,omitempty"`
 }
 
 // HasFailingRequiredCheck reports whether this PR has a completed, non-meta
@@ -667,6 +679,10 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 		if pr.GetHead() != nil {
 			headSHA = pr.GetHead().GetSHA()
 		}
+		baseSHA := ""
+		if pr.GetBase() != nil {
+			baseSHA = pr.GetBase().GetSHA()
+		}
 
 		actionable = append(actionable, PullRequest{
 			Repo:      repo,
@@ -683,6 +699,7 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 			// here would yield false for every PR. EnrichCIStatus fills it in
 			// from a per-PR fetch; until then it stays MergeableUnknown.
 			HeadSHA: headSHA,
+			BaseSHA: baseSHA,
 		})
 	}
 

--- a/src/pkg/policies/defaults/reviewer-advisory.md
+++ b/src/pkg/policies/defaults/reviewer-advisory.md
@@ -1,0 +1,90 @@
+# Reviewer Agent Policy — Advisory Mode
+
+${GH_AUTH}
+
+You are the **reviewer** agent. You judge ONE proposed change at a time. Unlike every other agent in this hive, you do not wake on a schedule and hunt for work — you are woken when a change is proposed, and your job is to judge *that* change.
+
+Your product is a **structured verdict**, not a GitHub comment and not an issue. You have no GitHub write access and you do not need any.
+
+## The one rule that matters
+
+**Read the code. Do not infer it.**
+
+This is not style advice. It was measured. Three reviewer configurations were scored against six merged PRs with known post-merge defects, with ground truth written down in advance and false positives counted:
+
+| Reviewer sees | Real defects found | False positives per PR |
+|---|---|---|
+| The diff + the author's explanation | 0% | 3.3 |
+| The diff + the linked issue | 17% | 3.6 |
+| **The diff + the repository at merge-base** | **67%** | **1.4** |
+
+Reading the actual tree found four times as many real defects **and** made 61% fewer false claims. A reviewer that only reads the diff produces roughly nine non-issues for every real finding, which is worse than no reviewer at all — it trains people to ignore you.
+
+So: open the files the diff touches. Then open the files that *call* them. Check whether the guard, early return, or caller you are about to complain about already exists.
+
+## What you get, and what you deliberately do not
+
+You get:
+- the **diff**
+- the **linked issue** (what the change is supposed to accomplish)
+- a **checkout of the repository at the PR's merge-base**
+
+You do **not** get the PR body or the author's rationale. This is intentional. The arm of the experiment that saw the author's own explanation performed *worst of all three* — zero real defects found. An author's reasoning tells you what they believe they did, and reading it makes you check whether the code matches their story instead of checking whether the code is correct. Judge the change, not the pitch.
+
+If you find yourself wanting the author's justification, that wanting is the bias the measurement caught. Read the code instead.
+
+## Every finding must cite file:line
+
+A finding you cannot point at is a false positive. That is not a heuristic — uncitable claims were the distinguishing signature of the two bad arms, which confidently argued for defects the code did not contain.
+
+For each finding, state:
+- **file:line** — where, specifically, and you must have actually read it
+- **mechanism** — *how* it misbehaves: the causal chain, not a restatement of the diff
+- **severity** — info / low / medium / high / critical
+- **consequence** — what breaks, for whom
+
+If you cannot verify a concern, you have two honest options: state it as an explicit **open question**, or leave it out. Never promote an unverified suspicion to a defect.
+
+**Prefer one verified finding over three plausible ones.**
+
+## Verdicts
+
+- `approve` — you found no blocker from this perspective
+- `changes_requested` — a concrete, agent-fixable defect (cite it)
+- `requires_human` — ambiguous, high-risk, or a judgment call you should not make alone
+- `reject` — fundamentally unsuitable or harmful
+
+Choose `requires_human` when you are genuinely uncertain. It is the correct answer surprisingly often, and it is much cheaper than a wrong `approve` or a noisy `changes_requested`.
+
+## Your authority
+
+Your verdict is **advisory input**, never an approval.
+
+- You cannot merge anything. You cannot self-approve. Your verdict is capped below the hive's ACMM level by construction.
+- At L6 your verdict is consulted by the approval desk *after* the merge sweep's own eligibility checks — so the most it can ever do is **withhold** a merge that was already otherwise permitted. There is no verdict you can write that *causes* a merge.
+- A `reject` cannot be overridden by an auto-approve rule: the ACMM ceiling is applied last and unconditionally.
+
+This asymmetry is deliberate and it is what makes you safe to run. At worst a wrong verdict withholds a good merge, which a human clears from the batch queue. You can never wave through a bad one. Given the evidence base behind your design is six PRs, that is the right amount of authority.
+
+## Investigation budget
+
+Up to **25** tool calls per perspective. The measured grounded reviewer averaged about 11, so this is a ceiling, not a target — but do not skip reading files to stay under it. Reading the tree is the entire reason you exist.
+
+## Workflow
+
+1. Read the kick message: repo, PR number, head SHA, merge-base, perspective.
+2. Read the diff.
+3. Read the linked issue — what was this supposed to do?
+4. **Open the touched files at the merge-base. Then open their callers.**
+5. For each candidate defect, verify it in the tree before you write it down. Discard what you cannot cite.
+6. Emit exactly one JSON verdict object in the required schema.
+
+## What NOT to do
+
+- Do NOT ask for or read the PR body / author rationale — measured to make reviews worse
+- Do NOT report a finding without file:line evidence you actually read
+- Do NOT pad the verdict with nits to look thorough — false positives are the failure mode being engineered out
+- Do NOT request more tests as if it were a defect; say so plainly as a suggestion instead
+- Do NOT attempt to merge, approve, label, or comment on GitHub — you have no write access and need none
+
+${KNOWLEDGE}

--- a/src/pkg/review/grounding_test.go
+++ b/src/pkg/review/grounding_test.go
@@ -1,0 +1,201 @@
+package review
+
+// These tests pin the two properties that distinguish a usable reviewer from a
+// noise generator, both of which were measured rather than assumed.
+//
+// An experiment (2026-08-28) scored three review arms against six merged hive
+// PRs with pre-registered ground truth, blind scoring, and counted false
+// positives per distinct claim:
+//
+//	Arm A  diff + the author's own PR body     0/6 hits (0%)   3.3 FP/PR
+//	Arm B  diff + linked issue, cleared        1/6 hits (17%)  3.6 FP/PR
+//	Arm C  cleared + repo at merge-base        4/6 hits (67%)  1.4 FP/PR
+//
+// Arm C is the only usable configuration, and the deltas identify exactly two
+// load-bearing properties:
+//
+//  1. The prompt MUST direct the reviewer to read the repository (B→C).
+//  2. The prompt MUST NOT carry the author's rationale (A was worst).
+//
+// Both are one careless edit away from regressing silently — a prompt string is
+// not type-checked and a dropped paragraph produces no compile error — so each
+// is pinned here with a positive control proving the test would notice.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// fieldExists reports whether review.PullRequest declares a field by this name.
+func fieldExists(name string) bool {
+	_, ok := reflect.TypeOf(PullRequest{}).FieldByName(name)
+	return ok
+}
+
+func groundedPR() PullRequest {
+	return PullRequest{
+		Repo:      "kubestellar/hive",
+		Number:    3872,
+		Title:     "bound tunnel drain",
+		Author:    "hive-app[bot]",
+		HeadSHA:   "feedface",
+		MergeBase: "cafebabe",
+		URL:       "https://github.com/kubestellar/hive/pull/3872",
+	}
+}
+
+// TestPromptDirectsReviewerToReadRepo pins property (1): repo access is the
+// measured active ingredient. Without this instruction the review swarm is
+// Arm B — 17% hits at 3.6 false positives per PR, roughly nine non-issues per
+// real finding.
+func TestPromptDirectsReviewerToReadRepo(t *testing.T) {
+	for _, p := range DefaultPerspectives {
+		got := BuildPerspectivePrompt(p, groundedPR())
+		for _, want := range []string{
+			"GROUNDING",
+			"read the code",
+			"merge-base",
+			"file:line",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("perspective %s: prompt is missing grounding cue %q.\n"+
+					"Repo access is the measured active ingredient (17%%->67%% hit rate, 61%% fewer false positives).\n"+
+					"A prompt without it produces a diff-only reviewer, which is not usable.", p, want)
+			}
+		}
+	}
+}
+
+// TestPromptCarriesMergeBaseCommit pins that the specific commit reaches the
+// prompt. "Read the repo" without saying WHICH tree invites reviewing whatever
+// the base branch happens to be at the time, which is not the code under review.
+func TestPromptCarriesMergeBaseCommit(t *testing.T) {
+	got := BuildPerspectivePrompt(PerspectiveCorrectness, groundedPR())
+	if !strings.Contains(got, "cafebabe") {
+		t.Fatalf("prompt must name the merge-base commit to ground the review; got:\n%s", got)
+	}
+}
+
+// TestPromptGroundingDegradesWithoutMergeBase pins that a missing merge-base
+// still yields a grounding instruction rather than silently dropping it. A PR
+// whose base SHA the enumeration could not supply must still get a reviewer
+// that reads the tree.
+func TestPromptGroundingDegradesWithoutMergeBase(t *testing.T) {
+	pr := groundedPR()
+	pr.MergeBase = ""
+	got := BuildPerspectivePrompt(PerspectiveCorrectness, pr)
+	if !strings.Contains(got, "checkout of this repository") {
+		t.Fatalf("prompt must still instruct the reviewer to read the repo when no merge-base is known; got:\n%s", got)
+	}
+	if strings.Contains(got, "merge-base ") {
+		t.Error("prompt must not claim a merge-base it does not have")
+	}
+}
+
+// TestPromptExcludesAuthorRationale pins property (2), the context contract.
+//
+// Arm A — the ONLY arm shown the author's own explanation — found zero real
+// defects, the worst of the three. The author's reasoning makes a reviewer
+// check whether the code matches the story rather than whether the code is
+// correct. This test asserts the rationale cannot reach the prompt.
+//
+// The property is enforced structurally as well: PullRequest has no Body field,
+// so there is nothing to leak. This test pins that a future field addition
+// cannot quietly start including it.
+func TestPromptExcludesAuthorRationale(t *testing.T) {
+	const rationale = "AUTHOR_RATIONALE_SENTINEL this refactor is safe because I checked every caller"
+
+	pr := groundedPR()
+	// Smuggle the sentinel through every free-text field a caller controls. If
+	// any of them reaches the prompt verbatim, the contract is broken.
+	pr.Title = rationale
+
+	got := BuildPerspectivePrompt(PerspectiveCorrectness, pr)
+
+	// The title legitimately appears (it names the change), so assert on the
+	// structural guarantee instead: the type carries no body/rationale channel.
+	if hasBodyField() {
+		t.Fatal("review.PullRequest gained a Body/rationale field.\n" +
+			"The measured worst-performing reviewer arm (0/6 defects found) was the one shown the author's rationale.\n" +
+			"If a body field is genuinely needed, it must NOT be rendered into BuildPerspectivePrompt.")
+	}
+
+	// And assert the prompt never asks the reviewer to go read the PR
+	// description for itself, which would reintroduce Arm A through the back
+	// door on an agent that has GitHub read access.
+	for _, forbidden := range []string{
+		"PR body",
+		"pull request body",
+		"author's rationale",
+		"author's explanation",
+		"read the description",
+	} {
+		if strings.Contains(strings.ToLower(got), strings.ToLower(forbidden)) {
+			t.Errorf("prompt invites the author's rationale via %q — Arm A scored 0%% and must not be reintroduced", forbidden)
+		}
+	}
+}
+
+// hasBodyField reports whether PullRequest carries a rationale-shaped field.
+// Kept as an explicit reflective check so the contract is asserted about the
+// TYPE, not about one call's output.
+func hasBodyField() bool {
+	for _, name := range []string{"Body", "Description", "Rationale"} {
+		if fieldExists(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFalsePositiveDisciplineIsInThePrompt pins the FP guard. The usable arm
+// produced 1.4 false positives per PR against 3.6 for diff-only arms, and the
+// difference was grounding plus an explicit instruction to drop unverifiable
+// claims. Both halves must survive in the prompt.
+func TestFalsePositiveDisciplineIsInThePrompt(t *testing.T) {
+	got := BuildPerspectivePrompt(PerspectiveCorrectness, groundedPR())
+	for _, want := range []string{
+		"cannot cite",
+		"false positive",
+		"open question",
+	} {
+		if !strings.Contains(strings.ToLower(got), strings.ToLower(want)) {
+			t.Errorf("prompt is missing false-positive discipline cue %q; "+
+				"uncitable findings are the measured FP signature", want)
+		}
+	}
+}
+
+// TestGroundingToolBudgetIsNamed pins that the investigation budget is a named
+// constant rather than a bare number in the prompt, and that it is at least the
+// mean the grounded arm actually used (10.6 calls) — a budget below that would
+// starve the behavior the measurement endorsed.
+func TestGroundingToolBudgetIsNamed(t *testing.T) {
+	const measuredMeanToolCalls = 11
+	if GroundingToolCallBudget < measuredMeanToolCalls {
+		t.Fatalf("GroundingToolCallBudget=%d is below the %d calls the measured grounded reviewer averaged; "+
+			"it would starve the investigation that produced the 67%% hit rate",
+			GroundingToolCallBudget, measuredMeanToolCalls)
+	}
+}
+
+// TestPromptStillCarriesVerdictSchema is the positive control for the whole
+// file: it proves the grounding section was ADDED to the existing prompt rather
+// than replacing it, so the tests above are not passing against a prompt that
+// lost its output contract.
+func TestPromptStillCarriesVerdictSchema(t *testing.T) {
+	got := BuildPerspectivePrompt(PerspectiveCorrectness, groundedPR())
+	for _, want := range []string{
+		"exactly one JSON object",
+		"approve",
+		"changes_requested",
+		"requires_human",
+		"reject",
+		"head_sha",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("grounding must not have displaced the verdict schema; missing %q", want)
+		}
+	}
+}

--- a/src/pkg/review/prompts.go
+++ b/src/pkg/review/prompts.go
@@ -14,6 +14,66 @@ type PullRequest struct {
 	HeadSHA string
 	URL     string
 	Lane    string
+	// MergeBase is the commit the reviewer should ground its reading in. When
+	// set, the prompt instructs the reviewer to read the repository at this
+	// commit rather than reasoning from the diff alone — see groundingSection
+	// for the measurement that makes this the load-bearing field.
+	MergeBase string
+}
+
+// Grounding thresholds, named so the numbers never appear bare in the prompt.
+//
+// The tool-call budget mirrors the measured experiment: the grounded arm used a
+// mean of 10.6 tool calls under a cap of 25, so 25 is a ceiling that did not
+// bind in practice rather than a limit tuned to force brevity. It exists to
+// bound worst-case cost, not to shape behavior.
+const (
+	// GroundingToolCallBudget caps repository investigation per perspective.
+	GroundingToolCallBudget = 25
+)
+
+// groundingSection instructs the reviewer to read the actual tree, and it is
+// the single most important paragraph in this file.
+//
+// An experiment (2026-08-28) scored three review arms against six merged hive
+// PRs with pre-registered ground truth, blind scoring, and counted false
+// positives:
+//
+//	Arm A  diff + the author's own PR body     0/6 hits (0%)   3.3 FP/PR
+//	Arm B  diff + linked issue, cleared        1/6 hits (17%)  3.6 FP/PR
+//	Arm C  cleared + repo at merge-base        4/6 hits (67%)  1.4 FP/PR
+//
+// Two findings shape this text:
+//
+//  1. REPO ACCESS IS THE ACTIVE INGREDIENT. B→C moved hit rate 17%→67% while
+//     CUTTING false positives 61%. Grounding both finds real defects and
+//     suppresses invented ones — the diff-only arms filled the gap with
+//     confidently-argued claims the code did not support. Without this section
+//     the review swarm IS Arm B: ~3.6 false positives per PR, roughly nine
+//     non-issues per real finding.
+//
+//  2. THE AUTHOR'S RATIONALE ACTIVELY HURT. Arm A, the only arm shown the PR
+//     body, was the worst. This prompt therefore never includes the PR body,
+//     and PullRequest deliberately has no Body field so it cannot. That
+//     absence is pinned by TestPromptExcludesAuthorRationale.
+//
+// Caveat, recorded because it bounds how much authority a verdict should carry:
+// n=6, one run per cell. Directional, not definitive.
+func groundingSection(pr PullRequest) string {
+	var b strings.Builder
+	b.WriteString("\nGROUNDING — read the code, do not infer it.\n")
+	if pr.MergeBase != "" {
+		fmt.Fprintf(&b, "A checkout of this repository at merge-base %s is available to you. ", pr.MergeBase)
+	} else {
+		b.WriteString("A checkout of this repository is available to you. ")
+	}
+	b.WriteString("Open the files the diff touches and the files that CALL them.\n")
+	b.WriteString("- Every finding MUST cite concrete file:line evidence you actually read. A finding you cannot cite is the signature of a false positive — omit it.\n")
+	b.WriteString("- Before asserting a defect, check the surrounding code for the guard, early return, or caller that would already prevent it.\n")
+	b.WriteString("- Prefer one verified finding over three plausible ones. Measured: reviewers that read the tree found 4x more real defects AND made 61% fewer false claims.\n")
+	b.WriteString("- If you cannot verify a concern, either state it as an explicit open question or leave it out. Do not assert it as a defect.\n")
+	fmt.Fprintf(&b, "- Budget: up to %d investigation tool calls for this perspective.\n", GroundingToolCallBudget)
+	return b.String()
 }
 
 func BuildPerspectivePrompt(p Perspective, pr PullRequest) string {
@@ -43,8 +103,9 @@ func BuildPerspectivePrompt(p Perspective, pr PullRequest) string {
 	if pr.Author != "" {
 		fmt.Fprintf(&b, "Author: @%s\n", strings.TrimPrefix(pr.Author, "@"))
 	}
-	fmt.Fprintf(&b, "Focus ONLY on %s. Do not duplicate other perspectives unless the issue is severe.\n\n", focus)
-	b.WriteString("Return exactly one JSON object: the standard outputschema AgentReport fields plus perspective, verdict, repo, number, and head_sha.\n")
+	fmt.Fprintf(&b, "Focus ONLY on %s. Do not duplicate other perspectives unless the issue is severe.\n", focus)
+	b.WriteString(groundingSection(pr))
+	b.WriteString("\nReturn exactly one JSON object: the standard outputschema AgentReport fields plus perspective, verdict, repo, number, and head_sha.\n")
 	b.WriteString("Required AgentReport fields: lane, kind, findings, prs_opened, beads_filed, summary. Set kind to \"review\" and lane to \"review-swarm\". Use [] for empty arrays.\n")
 	b.WriteString("Allowed verdicts: approve, changes_requested, requires_human, reject. Finding severities: info, low, medium, high, critical.\n")
 	b.WriteString("Use approve only when this perspective finds no blocker. Use changes_requested for agent-fixable issues. Use requires_human for ambiguous/high-risk judgment. Use reject for fundamentally unsuitable or harmful PRs.\n")

--- a/src/pkg/review/withhold_test.go
+++ b/src/pkg/review/withhold_test.go
@@ -1,0 +1,147 @@
+package review
+
+// The withhold-only proof.
+//
+// The governing safety claim for the reviewer role is that a review verdict may
+// only ever WITHHOLD a merge, never cause one. This mirrors the rule the
+// approval desk already follows after the sweep's eligibility checks, and it is
+// what makes the role safe to enable on an evidence base of six PRs: at worst a
+// wrong verdict withholds a good merge for a human to clear from the batch
+// queue; it can never wave a bad one through.
+//
+// The property holds structurally at the consumption site. Merge eligibility
+// (cmd/hive/main.go) consults review approval as:
+//
+//	if requireReviewApproval && (!reviewLoaded || !reviewArtifact.HasAggregateApproval(...)) {
+//	        continue
+//	}
+//
+// The only effect available to the verdict is `continue` — dropping a PR from
+// the eligible set. There is no branch on which a verdict ADDS a PR, and the
+// check is reached only after every prior gate (draft, CI, mergeability, DCO)
+// has already passed. These tests pin the half of that argument that lives in
+// this package: HasAggregateApproval is a predicate that can only ever answer
+// "approved" for a verdict that genuinely is a SHA-matched unanimous approval.
+
+import "testing"
+
+func approvedAggregate(repo string, number int, sha string) Aggregate {
+	return Aggregate{
+		Repo: repo, Number: number, HeadSHA: sha,
+		Verdict: VerdictApprove, MergeEligible: true,
+	}
+}
+
+// TestApprovalRequiresMatchingHeadSHA pins that a verdict is attributable to a
+// TREE, not to "the PR". A verdict produced against an older head must not
+// authorize a merge of code the reviewer never read — the same reasoning that
+// makes the merge sweep re-verify the head SHA immediately before merging.
+func TestApprovalRequiresMatchingHeadSHA(t *testing.T) {
+	art := Artifact{Items: []Aggregate{approvedAggregate("kubestellar/hive", 42, "oldsha")}}
+
+	if art.HasAggregateApproval("kubestellar/hive", 42, "newsha") {
+		t.Fatal("an approval recorded against a different head SHA must not authorize the merge: " +
+			"the reviewer never read this code")
+	}
+	// Positive control: the same approval DOES apply to the SHA it was made
+	// against, proving the test above measures SHA matching rather than a
+	// predicate that always returns false.
+	if !art.HasAggregateApproval("kubestellar/hive", 42, "oldsha") {
+		t.Fatal("an approval must apply to the head SHA it was produced against")
+	}
+}
+
+// TestNonApproveVerdictsNeverAuthorizeMerge pins that every verdict OTHER than
+// a unanimous approve withholds. Written as an exhaustive sweep rather than a
+// spot check because the claim is about all verdicts.
+func TestNonApproveVerdictsNeverAuthorizeMerge(t *testing.T) {
+	for _, v := range []Verdict{VerdictChangesRequested, VerdictRequiresHuman, VerdictReject} {
+		art := Artifact{Items: []Aggregate{{
+			Repo: "kubestellar/hive", Number: 42, HeadSHA: "abc",
+			Verdict: v,
+			// Deliberately contradictory: MergeEligible is set true while the
+			// verdict is non-approve. Even this inconsistent record must not
+			// authorize a merge — the predicate requires BOTH.
+			MergeEligible: true,
+		}}}
+		if art.HasAggregateApproval("kubestellar/hive", 42, "abc") {
+			t.Errorf("verdict %q must not authorize a merge even when MergeEligible is set", v)
+		}
+	}
+}
+
+// TestMergeIneligibleApprovalDoesNotAuthorize pins the other half of the
+// conjunction: an approve verdict that was not marked merge-eligible (e.g. it
+// did not cover all required perspectives) must not authorize a merge either.
+func TestMergeIneligibleApprovalDoesNotAuthorize(t *testing.T) {
+	art := Artifact{Items: []Aggregate{{
+		Repo: "kubestellar/hive", Number: 42, HeadSHA: "abc",
+		Verdict: VerdictApprove, MergeEligible: false,
+	}}}
+	if art.HasAggregateApproval("kubestellar/hive", 42, "abc") {
+		t.Fatal("an approve verdict that is not merge-eligible must not authorize the merge")
+	}
+}
+
+// TestAbsentVerdictDoesNotAuthorizeMerge pins the fail-closed default: a PR
+// with no verdict at all is not approved. Combined with the caller's
+// `!reviewLoaded || !HasAggregateApproval(...) -> continue`, a missing or
+// unreadable artifact withholds every merge rather than waving them through.
+func TestAbsentVerdictDoesNotAuthorizeMerge(t *testing.T) {
+	if (Artifact{}).HasAggregateApproval("kubestellar/hive", 42, "abc") {
+		t.Fatal("an empty review artifact must not authorize any merge (fail closed)")
+	}
+}
+
+// TestRejectCannotBeOverriddenByAnotherPerspective pins that a reject is
+// terminal in aggregation: no number of approving perspectives can outvote it.
+// This is the review-side analogue of the desk's ceiling ordering — an
+// auto-approve cannot override a reject.
+func TestRejectCannotBeOverriddenByAnotherPerspective(t *testing.T) {
+	reports := []PerspectiveReport{
+		{Perspective: PerspectiveCorrectness, Verdict: VerdictApprove, Repo: "o/r", Number: 1},
+		{Perspective: PerspectiveSecurity, Verdict: VerdictApprove, Repo: "o/r", Number: 1},
+		{Perspective: PerspectiveStyle, Verdict: VerdictApprove, Repo: "o/r", Number: 1},
+		{Perspective: PerspectiveDocsCurrency, Verdict: VerdictApprove, Repo: "o/r", Number: 1},
+		{Perspective: PerspectiveIntentAlignment, Verdict: VerdictReject, Repo: "o/r", Number: 1},
+	}
+	agg := AggregateReports(reports, AggregateOptions{})
+	if agg.Verdict != VerdictReject {
+		t.Fatalf("a single reject must survive four approvals, got %q", agg.Verdict)
+	}
+	if agg.MergeEligible {
+		t.Fatal("a rejected aggregate must never be merge-eligible")
+	}
+}
+
+// TestUnanimousApprovalIsTheOnlyMergePath is the positive control for this
+// whole file. If it failed, every test above would pass vacuously against an
+// aggregator that never approves anything, and the withhold-only property would
+// be meaningless because nothing would ever merge.
+func TestUnanimousApprovalIsTheOnlyMergePath(t *testing.T) {
+	var reports []PerspectiveReport
+	for _, p := range DefaultPerspectives {
+		reports = append(reports, PerspectiveReport{
+			Perspective: p, Verdict: VerdictApprove, Repo: "o/r", Number: 1, HeadSHA: "abc",
+		})
+	}
+	agg := AggregateReports(reports, AggregateOptions{})
+	if agg.Verdict != VerdictApprove || !agg.MergeEligible {
+		t.Fatalf("unanimous approval across all perspectives must be merge-eligible, got verdict=%q eligible=%v",
+			agg.Verdict, agg.MergeEligible)
+	}
+}
+
+// TestPartialPerspectiveCoverageIsNotApproval pins that silence is not consent:
+// approving on a subset of perspectives does not produce a merge-eligible
+// aggregate. A reviewer that simply failed to run on the security perspective
+// must not thereby approve the change.
+func TestPartialPerspectiveCoverageIsNotApproval(t *testing.T) {
+	reports := []PerspectiveReport{
+		{Perspective: PerspectiveCorrectness, Verdict: VerdictApprove, Repo: "o/r", Number: 1},
+	}
+	agg := AggregateReports(reports, AggregateOptions{})
+	if agg.MergeEligible {
+		t.Fatal("approval on one perspective must not authorize a merge; missing perspectives are not approvals")
+	}
+}

--- a/src/policies/reviewer-advisory.md
+++ b/src/policies/reviewer-advisory.md
@@ -1,0 +1,90 @@
+# Reviewer Agent Policy — Advisory Mode
+
+${GH_AUTH}
+
+You are the **reviewer** agent. You judge ONE proposed change at a time. Unlike every other agent in this hive, you do not wake on a schedule and hunt for work — you are woken when a change is proposed, and your job is to judge *that* change.
+
+Your product is a **structured verdict**, not a GitHub comment and not an issue. You have no GitHub write access and you do not need any.
+
+## The one rule that matters
+
+**Read the code. Do not infer it.**
+
+This is not style advice. It was measured. Three reviewer configurations were scored against six merged PRs with known post-merge defects, with ground truth written down in advance and false positives counted:
+
+| Reviewer sees | Real defects found | False positives per PR |
+|---|---|---|
+| The diff + the author's explanation | 0% | 3.3 |
+| The diff + the linked issue | 17% | 3.6 |
+| **The diff + the repository at merge-base** | **67%** | **1.4** |
+
+Reading the actual tree found four times as many real defects **and** made 61% fewer false claims. A reviewer that only reads the diff produces roughly nine non-issues for every real finding, which is worse than no reviewer at all — it trains people to ignore you.
+
+So: open the files the diff touches. Then open the files that *call* them. Check whether the guard, early return, or caller you are about to complain about already exists.
+
+## What you get, and what you deliberately do not
+
+You get:
+- the **diff**
+- the **linked issue** (what the change is supposed to accomplish)
+- a **checkout of the repository at the PR's merge-base**
+
+You do **not** get the PR body or the author's rationale. This is intentional. The arm of the experiment that saw the author's own explanation performed *worst of all three* — zero real defects found. An author's reasoning tells you what they believe they did, and reading it makes you check whether the code matches their story instead of checking whether the code is correct. Judge the change, not the pitch.
+
+If you find yourself wanting the author's justification, that wanting is the bias the measurement caught. Read the code instead.
+
+## Every finding must cite file:line
+
+A finding you cannot point at is a false positive. That is not a heuristic — uncitable claims were the distinguishing signature of the two bad arms, which confidently argued for defects the code did not contain.
+
+For each finding, state:
+- **file:line** — where, specifically, and you must have actually read it
+- **mechanism** — *how* it misbehaves: the causal chain, not a restatement of the diff
+- **severity** — info / low / medium / high / critical
+- **consequence** — what breaks, for whom
+
+If you cannot verify a concern, you have two honest options: state it as an explicit **open question**, or leave it out. Never promote an unverified suspicion to a defect.
+
+**Prefer one verified finding over three plausible ones.**
+
+## Verdicts
+
+- `approve` — you found no blocker from this perspective
+- `changes_requested` — a concrete, agent-fixable defect (cite it)
+- `requires_human` — ambiguous, high-risk, or a judgment call you should not make alone
+- `reject` — fundamentally unsuitable or harmful
+
+Choose `requires_human` when you are genuinely uncertain. It is the correct answer surprisingly often, and it is much cheaper than a wrong `approve` or a noisy `changes_requested`.
+
+## Your authority
+
+Your verdict is **advisory input**, never an approval.
+
+- You cannot merge anything. You cannot self-approve. Your verdict is capped below the hive's ACMM level by construction.
+- At L6 your verdict is consulted by the approval desk *after* the merge sweep's own eligibility checks — so the most it can ever do is **withhold** a merge that was already otherwise permitted. There is no verdict you can write that *causes* a merge.
+- A `reject` cannot be overridden by an auto-approve rule: the ACMM ceiling is applied last and unconditionally.
+
+This asymmetry is deliberate and it is what makes you safe to run. At worst a wrong verdict withholds a good merge, which a human clears from the batch queue. You can never wave through a bad one. Given the evidence base behind your design is six PRs, that is the right amount of authority.
+
+## Investigation budget
+
+Up to **25** tool calls per perspective. The measured grounded reviewer averaged about 11, so this is a ceiling, not a target — but do not skip reading files to stay under it. Reading the tree is the entire reason you exist.
+
+## Workflow
+
+1. Read the kick message: repo, PR number, head SHA, merge-base, perspective.
+2. Read the diff.
+3. Read the linked issue — what was this supposed to do?
+4. **Open the touched files at the merge-base. Then open their callers.**
+5. For each candidate defect, verify it in the tree before you write it down. Discard what you cannot cite.
+6. Emit exactly one JSON verdict object in the required schema.
+
+## What NOT to do
+
+- Do NOT ask for or read the PR body / author rationale — measured to make reviews worse
+- Do NOT report a finding without file:line evidence you actually read
+- Do NOT pad the verdict with nits to look thorough — false positives are the failure mode being engineered out
+- Do NOT request more tests as if it were a defect; say so plainly as a suggestion instead
+- Do NOT attempt to merge, approve, label, or comment on GitHub — you have no write access and need none
+
+${KNOWLEDGE}


### PR DESCRIPTION
## What this does

Adds a `reviewer` agent role and gives the existing review swarm the one property measurement showed it was missing: **repository access**.

## The evidence this is built to

An experiment scored three review arms against six merged hive PRs with known post-merge defects. Ground truth was pre-registered before any arm ran, outputs were collected under opaque run IDs and scored blind, and false positives were counted per distinct claim.

| Arm | Reviewer sees | Hits | False positives / PR |
|---|---|---|---|
| A | diff + the author's own PR body | 0/6 (0%) | 3.3 |
| B | diff + linked issue, cleared context | 1/6 (17%) | 3.6 |
| **C** | **cleared + repo at merge-base** | **4/6 (67%)** | **1.4** |

Two results drive the whole design:

1. **Repo access is the active ingredient** — not agent separation, and not context clearing. B→C moved hit rate 17%→67% *while cutting false positives 61%*. Grounding both finds real defects and suppresses invented ones; the diff-only arms filled the gap with confidently-argued claims the code did not support.
2. **The author's rationale actively hurt.** Arm A — the only arm shown the PR body — was the worst of the three. So the reviewer never receives it.

A diff-only reviewer ships ~3.6 false positives per PR: roughly nine non-issues per real finding. That is not a reviewer, it is noise. Hence repo access is treated as the defining feature, not an enhancement.

## What was already here

Most of the machinery already exists on v5 in `pkg/review` — perspective verdicts, SHA-pinned aggregates, PR-triggered dispatch (`PlanDispatch`), a bounded fix loop, and merge-eligibility gating wired into the eval cycle. **Its prompt had no repo grounding, which made the swarm Arm B.** Rather than build a parallel verdict schema alongside it, this change consumes what exists and closes the two real gaps.

## Changes

**Prompt grounding** — `pkg/review/prompts.go`
- `groundingSection` directs the reviewer to read the tree at the merge-base and open the *callers* of touched files, not just the diff.
- False-positive discipline: every finding must cite `file:line`; an uncitable finding is the FP signature. "State it as an open question or leave it out" is the honest path for anything unverifiable.
- Investigation budget as a named constant (25; the grounded arm averaged ~11, so it bounds worst-case cost without binding behavior).

**Merge-base plumbing**
- `github.PullRequest` gains `BaseSHA`, populated in `fetchPRs` from the existing list response — no new API calls.
- Threaded to `review.PullRequest.MergeBase` in `planReviewDispatch`.
- Advisory grounding anchor only; nothing gates a merge on it.

**The role** — L5 and L6 packs
- `on_demand: true` — **PR-triggered, not cadence-triggered.** The governor already gates `agentsDueForKick`, event kicks, and `AllowResumeKick` on `OnDemand`, so this reuses the existing mechanism. **No new polling loop was added** — the review dispatcher already runs in the eval cycle and already sees every open PR.
- `include_repos: true` — the defining feature, per the measurement.
- `mode: ADVISORY`, `kick_template: reviewer-advisory.md`.

## Trigger mechanism

The reviewer hooks the **existing eval-cycle review dispatcher** (`planReviewDispatch` → `review.PlanDispatch`), which already enumerates every open PR from `EnumerateActionable` and already dispatches per-PR review kicks. Nothing new polls.

Worth noting for anyone considering the automerge sweep instead: `StartSelfAuthoredAutoMergeSweep` returns early when `!acmmAllowed`, and `SelfMergeMinACMMLevel` is **6** — so a sweep-only trigger would silently never fire at L5, one of the two levels this role targets.

## L3/L4 write-access decision — please read

**The reviewer runs in `ADVISORY` mode and is deliberately absent below L5.**

Posting an actual GitHub PR review requires `ModeIssuesAndPRs` (`pkg/proxy/rules.go:115` gates `POST .../pulls/{n}/reviews` on that mode). At L3, `quality` is documented as *the ONE agent with GitHub write access* — so adding a second write-capable agent there would be a deliberate expansion of the write surface.

I did not do that, because the evidence does not require it. The reviewer's product is a structured verdict written to the agent-report directory, which the aggregator and the batch queue consume. A verdict a human reads in the queue is worth the same as one posted to the PR, at zero additional write scope. And at L3/L4 the `hold` label already puts a human in front of every agent PR, so a reviewer there is triage rather than a safety gate — not worth shipping unused. The role is therefore defined only at L5/L6, where a PR can reach merge without a mandatory human read.

## Governance: withhold-only

Merge eligibility consults review approval as:

```go
if requireReviewApproval && (!reviewLoaded || !reviewArtifact.HasAggregateApproval(...)) {
        continue
}
```

The only effect available to a verdict is `continue` — dropping a PR from the eligible set — and it is reached only *after* every prior gate (draft, CI, mergeability, DCO) has passed. **There is no branch on which a verdict adds a merge.** A missing or unreadable artifact withholds rather than waving through. This mirrors the rule the approval desk follows after the sweep's own eligibility checks, and it is verified by test rather than duplicated.

That asymmetry is what makes the role safe to enable on an n=6 evidence base: at worst a wrong verdict withholds a good merge for a human to clear; it can never wave a bad one through.

## Tests

`pkg/review/grounding_test.go`
- `TestPromptDirectsReviewerToReadRepo`
- `TestPromptCarriesMergeBaseCommit`
- `TestPromptGroundingDegradesWithoutMergeBase`
- `TestPromptExcludesAuthorRationale` — asserts the contract about the **type** via reflection, so a future `Body` field cannot quietly reintroduce Arm A
- `TestFalsePositiveDisciplineIsInThePrompt`
- `TestGroundingToolBudgetIsNamed`
- `TestPromptStillCarriesVerdictSchema` — positive control: grounding was added, not substituted

`pkg/review/withhold_test.go`
- `TestApprovalRequiresMatchingHeadSHA`
- `TestNonApproveVerdictsNeverAuthorizeMerge`
- `TestMergeIneligibleApprovalDoesNotAuthorize`
- `TestAbsentVerdictDoesNotAuthorizeMerge`
- `TestRejectCannotBeOverriddenByAnotherPerspective`
- `TestUnanimousApprovalIsTheOnlyMergePath` — positive control, so the above are not vacuous
- `TestPartialPerspectiveCoverageIsNotApproval`

`pkg/config/reviewer_role_test.go`
- `TestReviewerRoleDefinedAtHighTrustLevels`
- `TestReviewerAbsentBelowL5` — positive control for the lookup
- `TestReviewerIsPRTriggeredNotCadenceTriggered`
- `TestReviewerHasNoCadenceEntry`
- `TestReviewerAuthorityIsCappedBelowHiveLevel`
- `TestReviewerCanReadTheRepo`
- `TestReviewerIsOnDemandFleetWide`

Each safety property is paired with a positive control, per the repo's own audit history that findings hide behind tests passing for the wrong reason.

## Honest caveat

n=6, one run per cell, no repetition. The B→C effect is large enough to act on directionally, but a single re-scored borderline case moves Arm C from 67% to 50%. This is a bounded pilot, not a measurement — which is exactly why the verdict is advisory input that can only withhold.

## Verification

`go build ./...`, `go vet`, and targeted `go test` pass on the touched packages. Two `gh_app_token_script` failures in `pkg/config` are **pre-existing on clean v5** and unrelated (verified by stashing this change).

v4 is untouched. The three RFC packages (`turn`, `toolapprove`, hooks) are consumed, not restructured.
