### PR TITLE
📖 docs: add KubeStellar Console as a Production adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -14,10 +14,11 @@ Listed below are organizations that have adopted, or benefitted from, KubeStella
 
 | Organization | Description | Maturity Level | Further Information |
 | --- | --- | --- | --- |
+| [KubeStellar Console](https://github.com/kubestellar/console) | Autonomous maintenance of the Console codebase — issue triage, fixes, review, and merge | Production | |
 | [Tuna OS](https://github.com/tuna-os) | Autonomous development operations for tuna-os projects | Pre-production | |
 | [Frostyard](https://github.com/frostyard) | Autonomous development operations for frostyard projects | Pre-production | |
 | [Open Horizon](https://github.com/open-horizon) | Standardization and enforcement for code consistency | Pre-production | |
-| [Open Horizon Services (https://github.com/open-horizon-services) | Ensuring code consistency over community contributions | Pre-production | |
+| [Open Horizon Services](https://github.com/open-horizon-services) | Ensuring code consistency over community contributions | Pre-production | |
 | [Danathar](https://github.com/Danathar) | Autonomous development operations for Danathar projects | Pre-production | |
 
 


### PR DESCRIPTION
Console is maintained by a hive today — triage, fixes, review, and merge run continuously against that repo.

**It is the first entry at the Production maturity level.** Every other adopter in the table is Pre-production, so this changes what the list demonstrates: not just interest, but a codebase actually being maintained this way in production.

## Also fixes a broken link in the same table

The Open Horizon Services row was missing the closing bracket on its markdown link:

```
| [Open Horizon Services (https://github.com/open-horizon-services) | ...
```

It rendered as literal text rather than a link. Fixed to `[Open Horizon Services](https://...)`.

Worth doing now rather than later: `ADOPTERS.md` is read directly during CNCF maturity review — the Incubation criteria ask for *"a publicly documented list of adopters, which may indicate their adoption level"* — so a visibly broken entry there costs more than in ordinary docs.

## Adopter count

Six entries, one Production. Note for the application: Incubation counts adopter **organizations**, and the `Danathar` row is an individual — the org count is five.