### PR TITLE
🐛 fix(notice): ignore the project's own module so go-licenses can run at all

### DIFF
--- a/src/scripts/generate-notice.sh
+++ b/src/scripts/generate-notice.sh
@@ -90,14 +90,21 @@ SAVE_DIR="${WORK_DIR}/licenses"
 echo "Walking the module graph and saving license files..." >&2
 (
   cd "${SRC_DIR}"
-  "${GO_LICENSES_BIN}" save ./... --save_path="${SAVE_DIR}" --force
+  # --ignore the project's own module: LICENSE lives at the REPO root while the
+  # Go module is src/, so go-licenses' upward search stops at src/ and reports
+  # "cannot find a known open source license" for every kubestellar/hive
+  # package, failing the whole run before any dependency is written. Hive's own
+  # code does not belong in a THIRD-PARTY notice regardless, so ignoring it is
+  # correct rather than a workaround for the path layout.
+  "${GO_LICENSES_BIN}" save ./... --save_path="${SAVE_DIR}" --force \
+    --ignore github.com/kubestellar/hive
 )
 
 echo "Classifying each module's license..." >&2
 REPORT_CSV="${WORK_DIR}/report.csv"
 (
   cd "${SRC_DIR}"
-  "${GO_LICENSES_BIN}" csv ./... > "${REPORT_CSV}"
+  "${GO_LICENSES_BIN}" csv ./... --ignore github.com/kubestellar/hive > "${REPORT_CSV}"
 )
 
 {


### PR DESCRIPTION
The `notice-drift` job from #5006 failed on its first real run against `v4` — but **not** from the placeholder drift it was built to detect. It failed *before generating anything*:

```
Failed to find license for github.com/kubestellar/hive/pkg/forge:
cannot find a known open source license for ".../hive/src/pkg/forge"
... and locates up until ".../hive/src"
```

Every error names a `github.com/kubestellar/hive/...` path — **the project's own packages, not a dependency.**

## Root cause: repo layout

`LICENSE` lives at the **repo root**; the Go module is **`src/`**. `go-licenses` searches upward from each package and stops at the module root, so it never sees `LICENSE`, reports every Hive package as unlicensed, and exits non-zero. No `NOTICE` is produced at all.

## Fix

Both invocations (`save` and `csv`) now pass `--ignore github.com/kubestellar/hive`.

This is the **correct** answer rather than a workaround: a *third-party* attribution file should not list the project's own code, so excluding it is what the file means.

The alternative — adding a duplicate `src/LICENSE` purely to satisfy the tool's search path — would create a second copy of the license to keep in sync for no benefit. This repo was already bitten today by a `LICENSE` that had drifted from canonical text (#4894, #4901); a deliberate second copy invites exactly that again.

## Why this is worth landing quickly

`notice-drift` currently fails on **every PR in the repo**, including contributors' work with no connection to it (#4979, #4981 are both green apart from this). A permanently-red check that nobody can fix trains people to read red as noise — which is worse than the missing NOTICE it was added to prevent.

After this merges, the job should produce real `go-licenses` output and fail with an *actionable* diff against the placeholder — which is the intended state, tracked in #5007.