### PR TITLE
🔒 fix(contribute): sandbox Claude local mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ### Security
 
+- Claude-family contributor agents are now write-confined even when explicitly
+  launched in host-local mode. `just contribute-hive <claude|litellm> local`
+  enables Claude Code's native OS sandbox, fails startup if that sandbox is
+  unavailable, disables unsandboxed command retry, and grants writes only to
+  the agent state directory and `HIVE_WORKSPACE_DIR`. The old unconfined
+  posture now requires the explicit
+  `HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` escape hatch. This
+  closes the path on which a third-party repository's test suite reached an
+  operator's bootloader ([#4918](https://github.com/kubestellar/hive/issues/4918)).
+
 - `docs-index-reminder.yml` now pins `actions/checkout` to the same immutable commit SHA (`3d3c42e5…` / v7.0.1) every other workflow uses, instead of the mutable `@v4` tag it launched with — the sole mutable action reference in the repo. The workflow holds `pull-requests: write`, so a moved tag (or a compromise of the action's release process) could have run attacker-chosen code with a token able to post and edit PR comments, without any change landing in this repository. Its `permissions:` block was checked at the same time and is already least-privilege — `contents: read` plus the `pull-requests: write` the reminder comment needs — so only the pin changed ([#4642](https://github.com/kubestellar/hive/issues/4642)).
 - Agent traffic to `api.linear.app` is now gated. Hive could already read a Linear backlog, but that traffic tunnelled through the proxy untouched — `NeedsMITM` intercepted only `api.github.com` — so anything an agent sent to Linear left the hive ungated. That was harmless while the integration was read-only and stops being harmless the moment an agent can write, which is why this lands ahead of the rest of the Linear work rather than alongside it. Linear cannot be gated the way GitHub is: it serves its whole API from one `POST /graphql`, so reading an issue, commenting on it, relabelling it and acknowledging an agent session are the identical `(method, path)` the existing rule table keys on, and a rule for that tuple could only say "all of it" or "none of it". Enforcement is therefore by GraphQL operation — each mutation mapped to the tier its GitHub analogue already requires, so an agent's autonomy does not depend on which tracker its work came from. Acknowledging a Linear agent session is reachable at every tier, because Linear drops a session that is not acknowledged within ten seconds and an advisory agent must still be able to admit it received the work; commenting rides the `converse` capability exactly as it does on GitHub; editing an issue stays on the mode ladder and `converse` does not open it. The gate fails **closed**: an operation it does not recognise, a document it cannot parse, a body past the inspection limit, or a batch mixing a permitted mutation with a forbidden one is refused rather than forwarded — including at the highest tier, since an unclassifiable document is not a permissions question. Aliased mutations are resolved to the real field so a forbidden operation cannot wear a permitted one's name. Request bodies are never logged: they carry issue content and, in variables, potentially tokens, so only operation names and the decision are recorded. The hive's own control-plane calls are exempt, as they are for GitHub, so backlog enumeration is unaffected ([#4492](https://github.com/kubestellar/hive/issues/4492)).
 - The container image now ships exactly one setuid binary. The `su-exec` helper agents' UID switch runs through was hardened to `4750 root:hive-launch` so no agent UID could exec it — but that only ever covered the helper Hive builds. `node:26-slim` and the `passwd`/`util-linux` packages left eleven more behind (`chfn`, `chsh`, `gpasswd`, `mount`, `newgrp`, `passwd`, `su`, `umount` setuid-root; `chage`, `expiry`, `unix_chkpwd` setgid-shadow), every one world-executable and so reachable by exactly the agent UIDs the 4750 mode excludes. Nothing in Hive uses any of them. They could not be neutralised from the pod, either: `allowPrivilegeEscalation: false` sets `no_new_privs`, which would disable `su-exec` too and break agent launch, so a setuid-root exec from an agent UID landed in a bounding set still holding `SETUID`, `SETGID` and `DAC_OVERRIDE` — enough to read the MITM proxy's CA private key whatever mode the `0700` directory it was moved to in [#4341](https://github.com/kubestellar/hive/pull/4341) carries, and forge certificates for `api.github.com`. The build now strips every setuid/setgid bit but `su-exec`'s, after the last install layer, and **fails** if the resulting inventory is anything else — so a base-image bump or a new package cannot quietly reintroduce one. A new boot-level check builds the image both with and without the strip and requires the un-stripped build to show the eleven, then execs `su-exec` as `dev` to confirm the surviving bit still switches UID and as an agent UID to confirm it is still refused ([#3866](https://github.com/kubestellar/hive/issues/3866)).
@@ -122,16 +132,17 @@ Hive did not historically maintain a complete changelog. This file starts a prag
   the sandbox kick) outright, with the reason surfaced in the retry/quarantine
   log, because a wrong base is worse than a delayed PR
   ([#4928](https://github.com/kubestellar/hive/issues/4928)).
-- **`just contribute-hive <backend> local` now says that it runs the agent
-  unconfined on your machine**, and the docs no longer imply a workspace
-  boundary that only the opt-in Podman path provides
-  ([#4918](https://github.com/kubestellar/hive/issues/4918)). Container mode is
-  the default and is the confined one; local mode runs the backend CLI as your
-  own user with permission gating bypassed and nothing scoping its filesystem
-  access — which is how an agent running an assigned third-party repo's test
-  suite reached a contributor's bootloader. The launch banner now names what is
-  still constrained (the #4938 host-state denials; credentials and pushes on
-  every path) and what is not, and points at container mode as the remedy.
+- **`just contribute-hive <backend> local` now reports the backend's actual
+  confinement posture**, and the docs no longer imply a workspace boundary
+  that only the opt-in Podman path provides
+  ([#4918](https://github.com/kubestellar/hive/issues/4918)). Local mode had
+  run every backend CLI as the contributor's own user with permission gating
+  bypassed and nothing scoping filesystem access — which is how an assigned
+  third-party repo's test suite reached a contributor's bootloader. The launch
+  banner now reports Claude/LiteLLM and Codex write confinement, warns for
+  still-unconfined backends or explicit dangerous bypasses, names the controls
+  that still apply, and points at default container mode as the stronger
+  backend-independent remedy.
   `sandbox-isolation.md` gains a per-path table recording the finding that
   matters most here: **the `agent_sandbox` Podman path is hub-side only and
   does not exist on the contributor path at all**, so enabling it would not

--- a/Justfile
+++ b/Justfile
@@ -772,11 +772,13 @@ contribute-hive backend="" mode="docker": check-version
     if [[ "$_MODE" == "local" ]]; then
       # ── Local mode: tmux session + relay (same as container, but on host) ──
       #
-      # SAY WHAT THIS MODE COSTS (#4918). Local mode runs the backend CLI as
-      # THIS user, on THIS machine, with permission gating bypassed and nothing
-      # scoping its filesystem access to the workspace. Container mode — the
-      # DEFAULT, which is why the recipe's `mode` parameter defaults to
-      # "docker" — puts the same agent behind a container boundary instead.
+      # SAY WHAT THIS MODE COSTS (#4918). The backend CLI runs as THIS user on
+      # THIS machine. Claude-family agents now get Claude Code's native OS
+      # sandbox on this path, and Codex keeps its workspace-write sandbox.
+      # Backends without a sandbox (and either backend's explicit dangerous
+      # bypass) remain unconfined. Container mode — the DEFAULT, which is why
+      # the recipe's `mode` parameter defaults to "docker" — remains the
+      # backend-independent boundary.
       #
       # An operator picking `local` was previously told nothing about that
       # difference: the recipe's own usage line described it only as "native
@@ -789,27 +791,54 @@ contribute-hive backend="" mode="docker": check-version
       # privilege. No compromise was involved.
       #
       # The message names what IS still constrained, deliberately, so it reads
-      # as a boundary statement rather than an alarm: #4938's host-state
-      # denials apply here (backends.conf is sourced by this recipe below), and
-      # credentials/pushes are constrained on every path. Neither of those is
-      # filesystem confinement, and the agent_sandbox podman path is hub-side
-      # only — it does not exist on this path at all, so it is not offered as a
-      # remedy here. Container mode is the remedy on this path.
-      echo "⚠️  LOCAL MODE — the agent is NOT confined to a workspace."
-      echo ""
-      echo "    The backend CLI runs as $(id -un) on this machine, with permission"
-      echo "    prompts bypassed. It can read and write anything your user can,"
-      echo "    including files outside ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
-      echo "    Assigned repos are third-party code and their test suites run for real."
-      echo ""
-      echo "    Still constrained: privilege-escalation and host boot/deployment"
-      echo "    commands are denied (sudo, pkexec, rpm-ostree, bootc, grubby, ...),"
-      echo "    and no agent receives a GitHub token or pushes directly."
-      echo "    NOT constrained: everything else your user can reach."
-      echo ""
-      echo "    For a confined agent, drop 'local' and use container mode:"
-      echo "      just contribute-hive ${BACKEND}"
-      echo ""
+      # as a boundary statement rather than an alarm. The agent_sandbox Podman
+      # path is hub-side only; it does not exist on this contributor path.
+      _local_truthy() {
+        case "${1:-}" in 1|true|TRUE|yes|YES|on|ON) return 0 ;; *) return 1 ;; esac
+      }
+      _LOCAL_WRITE_CONFINED=false
+      case "$BACKEND" in
+        claude|litellm)
+          if ! _local_truthy "${HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}"; then
+            _LOCAL_WRITE_CONFINED=true
+          fi
+          ;;
+        codex)
+          if ! _local_truthy "${HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}"; then
+            _LOCAL_WRITE_CONFINED=true
+          fi
+          ;;
+      esac
+      if [[ "$_LOCAL_WRITE_CONFINED" == "true" ]]; then
+        echo "🔒 LOCAL MODE — workspace write confinement is enabled for ${BACKEND}."
+        echo ""
+        echo "    The CLI still runs as $(id -un) on this machine, but commands and"
+        echo "    file edits may write only under the agent state directory and"
+        echo "    ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
+        if [[ "$BACKEND" == "claude" || "$BACKEND" == "litellm" ]]; then
+          echo "    Claude's native sandbox is mandatory: startup fails rather than"
+          echo "    falling back unconfined when its OS sandbox is unavailable."
+        fi
+        echo ""
+        echo "    Container mode remains the stronger backend-independent boundary:"
+        echo "      just contribute-hive ${BACKEND}"
+        echo ""
+      else
+        echo "⚠️  LOCAL MODE — the agent is NOT confined to a workspace."
+        echo ""
+        echo "    The backend CLI runs as $(id -un) on this machine, with permission"
+        echo "    prompts bypassed. It can read and write anything your user can,"
+        echo "    including files outside ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
+        echo "    Assigned repos are third-party code and their test suites run for real."
+        echo ""
+        echo "    Still constrained: supported host-state commands are denied, and no"
+        echo "    agent receives a GitHub token or pushes directly."
+        echo "    NOT constrained: everything else your user can reach."
+        echo ""
+        echo "    For a confined agent, drop 'local' and use container mode:"
+        echo "      just contribute-hive ${BACKEND}"
+        echo ""
+      fi
       TMUX_SESSION="hive-${BACKEND}-$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' ')"
       SCRIPT_DIR="$(pwd)/bin"
       RELAY="${SCRIPT_DIR}/contributor-relay.sh"
@@ -868,11 +897,35 @@ contribute-hive backend="" mode="docker": check-version
       # are shell syntax and the pane dies with `syntax error near token '('`
       # before the CLI ever starts. backend_perm_flag stays raw for argv
       # consumers (agent-launch.sh); see backends.conf.
-      PERM_FLAG=$(backend_perm_flag_shell "$BACKEND" 2>/dev/null || echo "")
+      case "$BACKEND" in
+        claude|litellm)
+          PERM_FLAG=$(claude_family_local_perm_flag_shell)
+          ;;
+        *)
+          PERM_FLAG=$(backend_perm_flag_shell "$BACKEND" 2>/dev/null || echo "")
+          ;;
+      esac
 
       if ! command -v "$CMD" &>/dev/null; then
         echo "ERROR: ${BACKEND} CLI not found. Install it first."
         exit 1
+      fi
+
+      # Claude Code hard-fails internally when its native sandbox cannot start.
+      # Catch the ordinary Linux dependency failure before the relay connects,
+      # so an operator gets an actionable error instead of a dead CLI pane.
+      if [[ "$BACKEND" == "claude" || "$BACKEND" == "litellm" ]] \
+          && ! _local_truthy "${HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}" \
+          && [[ "$(uname -s)" == "Linux" ]]; then
+        for _SANDBOX_DEP in bwrap socat; do
+          if ! command -v "$_SANDBOX_DEP" >/dev/null 2>&1; then
+            echo "ERROR: Claude local confinement requires ${_SANDBOX_DEP}."
+            echo "       Install bubblewrap and socat, use container mode, or explicitly"
+            echo "       opt out only on an externally isolated/disposable host with:"
+            echo "       HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1"
+            exit 1
+          fi
+        done
       fi
 
       # LiteLLM: point Claude Code at the contributor's own proxy.

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -95,6 +95,59 @@ claude_family_perm_flag() {
   fi
 }
 
+# claude_family_local_perm_flag_shell emits the stricter posture used only by
+# `just contribute-hive <claude|litellm> local`. Unlike the hub/container paths,
+# local mode has no outer container boundary, so Claude Code's native sandbox
+# is the boundary. The compact settings JSON is a CLI argument (not a settings
+# file the agent can rewrite) and the whole argv is shell-escaped for the tmux
+# send-keys consumer.
+#
+# Network remains unrestricted for arbitrary third-party build/test suites;
+# filesystem writes remain limited to HIVE_AGENT_CWD (Claude's cwd) and the
+# exact workspace below. `dontAsk` makes any non-Bash tool request outside
+# those roots fail instead of hanging an unattended pane for approval.
+claude_family_local_perm_flag_shell() {
+  if is_truthy "${HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}"; then
+    backend_perm_flag_shell claude
+    return
+  fi
+  if [[ -z "${HIVE_WORKSPACE_DIR:-}" ]]; then
+    echo "ERROR: HIVE_WORKSPACE_DIR is required for the Claude local sandbox" >&2
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required to configure the Claude local sandbox" >&2
+    return 1
+  fi
+
+  local settings
+  settings="$(jq -cn --arg workspace "$HIVE_WORKSPACE_DIR" '{
+    sandbox: {
+      enabled: true,
+      failIfUnavailable: true,
+      autoAllowBashIfSandboxed: true,
+      allowUnsandboxedCommands: false,
+      filesystem: {allowWrite: [$workspace]},
+      network: {allowedDomains: ["*"]}
+    }
+  }')" || return
+
+  local -a args=(
+    --permission-mode dontAsk
+    --settings "$settings"
+    --add-dir "$HIVE_WORKSPACE_DIR"
+  )
+  if ! is_truthy "${HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE:-}"; then
+    args+=(--disallowed-tools "$CLAUDE_HOST_DENY_TOOLS")
+  fi
+
+  local word out=""
+  for word in "${args[@]}"; do
+    out+="$(printf '%q' "$word") "
+  done
+  printf '%s\n' "${out% }"
+}
+
 # ── Backend → permission flag ───────────────────────────────────────────
 backend_perm_flag() {
   case "$1" in

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -75,6 +75,8 @@ Important environment variables:
 | `CONTRIBUTOR_MODE` | `interactive` | `interactive` keeps a tmux/TTY session. `headless` is for one-shot/no-TTY task delivery. |
 | `HIVE_AGENT_SESSION` | `contributor` | tmux session name for interactive mode. |
 | `HIVE_CODEX_APPROVALS_REVIEWER` | `auto_review` | Codex reviewer for boundary requests. The default prevents Hive-delivered work from waiting on an interactive operator while retaining `workspace-write`; set `user` only for an intentionally attended contributor. Set it to the **empty string** to omit the `-c approvals_reviewer=` key entirely — the escape hatch if a Codex release rejects that config key at startup. Doing so keeps the sandbox posture; it is not the same as the dangerous bypass. |
+| `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE` | unset | Drops the defense-in-depth Claude command denylist. In local mode the native filesystem sandbox still applies, so this does not grant host writes. |
+| `HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX` | unset | Restores the pre-#4918 unconfined Claude/LiteLLM local posture. Use only on a disposable or externally sandboxed host. |
 
 ### Where each backend reads its instructions
 
@@ -113,25 +115,30 @@ this, omits `--add-dir`, and warns on stderr rather than corrupting the argv;
 the sandbox posture still applies, but the workspace is not granted. Move the
 workspace to a path without spaces.
 
-Claude-family host-state denials: `claude` and `litellm` run permissions-bypassed
-on the contributor's own machine, so hive denies privilege escalation
-(`sudo`, `pkexec`, `doas`, `su`) and host boot/deployment tools (`rpm-ostree`,
-`bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`) on that path — an agent
-running an assigned repo's test suite reached a contributor's bootloader
-otherwise (#4918). Repo work is unaffected. `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1`
-restores the old posture and is the claude analogue of the Codex bypass below;
-prefer leaving it unset.
+Claude-family local confinement: `claude` and `litellm` use Claude Code's
+native OS sandbox in host mode. Hive enables it through command-line settings,
+requires startup to fail when the sandbox is unavailable, disables unsandboxed
+command retry, and runs in `dontAsk` mode so a request outside the declared
+roots is denied instead of hanging an unattended pane. Bash subprocesses and
+file edits may write only to `HIVE_AGENT_CWD` and `HIVE_WORKSPACE_DIR`.
+Network domains are unrestricted because assigned third-party repositories
+must be able to fetch arbitrary test/build dependencies; this is write
+confinement, not a claim that the process can read or exfiltrate nothing.
 
-Container mode vs local mode is the confinement choice on this path. Those
-denials are a floor, not a boundary: they name commands, and an agent still runs
-unconfined against everything not on the list. `just contribute-hive` defaults to
-**container** mode, which puts the agent behind a container boundary;
-`just contribute-hive <backend> local` runs it as your own user on your own
-machine with permission gating bypassed and nothing scoping its filesystem access
-to the workspace. Local mode now says so at launch. Note that the `agent_sandbox`
-Podman path documented in [sandbox-isolation.md](sandbox-isolation.md) is
-**hub-side only** — nothing on the contributor path reads it — so container mode
-is the remedy here, not that setting.
+On Linux/WSL2 the native sandbox requires `bubblewrap` and `socat`; macOS uses
+Seatbelt. Missing dependencies are a hard launch failure, never a silent
+fallback. The existing privilege-escalation and boot/deployment command
+denials remain as defense in depth. `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1`
+drops only that command list; it does not cross the OS boundary. The distinct,
+loudly named `HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` restores
+the old unconfined local posture for an externally isolated/disposable host.
+
+`just contribute-hive` still defaults to **container** mode, the stronger
+backend-independent boundary. In local mode Claude/LiteLLM now use the native
+sandbox and Codex retains `workspace-write`; other backends remain unconfined
+and the launch banner says so. The `agent_sandbox` Podman path documented in
+[sandbox-isolation.md](sandbox-isolation.md) remains **hub-side only** — nothing
+on the contributor path reads it.
 
 Codex config-key compatibility: `approvals_reviewer` is passed with `-c`, so it
 depends on the installed Codex release accepting that key. If a version rejects

--- a/src/docs/design/agent-host-confinement.md
+++ b/src/docs/design/agent-host-confinement.md
@@ -1,9 +1,11 @@
-# Agent host confinement on the default (unconfined) launch path (#4918)
+# Agent host confinement on the default launch path (#4918)
 
-Status: **investigation — no decision taken.** Nothing here is implemented and
-nothing here is a commitment to implement. This page maps what #4918 reported,
-what #4938 already closed, what it deliberately left open, and the options for
-closing the rest — with costs — so the next decision is made on evidence.
+Status: **historical investigation; contributor-local Claude confinement is now
+implemented.** This page records the evidence and options as assessed before
+Claude Code's native sandbox was wired into `contribute-hive ... local`.
+Claude/LiteLLM local launches now use that OS-enforced sandbox with hard-fail
+startup and no unsandboxed retry; Codex retains `workspace-write`. The hub-side
+Podman default and local backends without a native sandbox remain open concerns.
 
 All citations are against `origin/v4` at `1b54c69e` unless noted.
 

--- a/src/docs/sandbox-isolation.md
+++ b/src/docs/sandbox-isolation.md
@@ -7,11 +7,11 @@ Hive agents are untrusted code executors: prompts, tool output, and cloned repos
 Two halves of that target hold differently, and the difference matters:
 
 - **Credentials and pushes are constrained on every path.** No agent receives a GitHub token or pushes directly; authorship goes through the App-gated `gh` wrapper and the push broker.
-- **Workspace confinement holds only on the sandbox path below.** "It can only modify its mounted workspace" is a property of the Podman sandbox, not of hive generally. On the default tmux path there is no container: the backend CLI runs as the operator's own user, on the operator's own host, with nothing scoping its filesystem access to the workspace.
+- **Workspace write confinement depends on the launch path and backend.** The Podman sandbox below is the hub-side boundary. Contributor container mode has its own container boundary. In contributor local mode, Claude/LiteLLM now require Claude Code's native OS sandbox and Codex retains its `workspace-write` sandbox; other backends still run as the operator's user without a filesystem boundary.
 
 **#4918 is what that costs in practice, and it did not require a compromise.** An agent doing correct work on an assigned third-party repo ran that repo's own test suite; a latent defect in two of its tests let a hook escape its stubs and issue `rpm-ostree kargs --append-if-missing=...` against the operator's real deployment. Nothing was written, and the only reason is that the process happened to lack privilege. Benign behaviour was a sufficient precondition, so this is a routine exposure rather than an exceptional one.
 
-The claude-family launch path now carries host-state denials for exactly this class — privilege escalation (`sudo`, `pkexec`, `doas`, `su`) and the boot/deployment tools that reach polkit without needing escalation of their own (`rpm-ostree`, `bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`), matching the workspace-write posture Codex has had since #3512. That is a floor, not a sandbox: it names commands rather than enforcing a boundary, and an agent still runs unconfined against everything not on the list.
+The claude-family launch path carries host-state denials for exactly this class — privilege escalation (`sudo`, `pkexec`, `doas`, `su`) and the boot/deployment tools that reach polkit without needing escalation of their own (`rpm-ostree`, `bootc`, `ostree`, `grubby`, `bootctl`, `efibootmgr`). Those denials remain only a command-list floor. On the contributor local path, Claude Code's native sandbox is now the OS-enforced write boundary around them.
 
 ## Which confinement is available depends on the path you are on
 
@@ -21,13 +21,13 @@ This is the part that is easy to get wrong, because the two paths have different
 |---|---|---|
 | Runs where | The hive spoke's own container | The contributor's machine |
 | Podman agent sandbox (`agent_sandbox`) | Available, opt-in — see below | **Does not exist on this path.** `SandboxEnabled` is read only by `pkg/agent`; nothing in `bin/contributor-relay.sh`, `bin/contributor-agent.sh` or the `Justfile` consults it |
-| The confinement lever | `agent_sandbox` + the per-agent opt-in | **Container mode vs local mode** — `just contribute-hive` defaults to container; `... local` is the unconfined one |
+| The confinement lever | `agent_sandbox` + the per-agent opt-in | Container mode (the default), or a backend-native sandbox in local mode. Claude/LiteLLM and Codex are write-confined locally; other backends are not |
 | Host-state denials (#4938) | Yes | Yes (`config/backends.conf`) |
 | Credentials / pushes | Constrained | Constrained |
 
-**The #4918 incident happened on the contributor relay's local mode**, so enabling `agent_sandbox` would not have prevented it. The remedy on that path is container mode, which `just contribute-hive` already uses by default and now warns about when it is not.
+**The #4918 incident happened on the contributor relay's local mode**, so enabling `agent_sandbox` would not have prevented it. Claude-family local launches now use Claude Code's native sandbox with hard-fail startup and unsandboxed retry disabled. Container mode remains the stronger backend-independent remedy and the `just contribute-hive` default.
 
-Operators running hive on a machine they care about should therefore: use container mode on the contributor path, and enable the sandbox below on the hub path.
+Operators running hive on a machine they care about should therefore prefer container mode on the contributor path, use only a locally sandboxed backend when local mode is necessary, and enable the sandbox below on the hub path.
 
 ## Current wiring
 

--- a/src/pkg/dashboard/contribute_local_mode_warning_test.go
+++ b/src/pkg/dashboard/contribute_local_mode_warning_test.go
@@ -1,15 +1,18 @@
 package dashboard
 
 import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 // #4918: `just contribute-hive <backend> local` runs the backend CLI as the
-// contributor's own user, on their own machine, with permission gating
-// bypassed and nothing scoping its filesystem access to the workspace. The
-// recipe previously described that mode only as "native mode" and said nothing
-// about the difference.
+// contributor's own user, on their own machine. Claude-family agents now use
+// Claude Code's native OS sandbox on that path, Codex retains its own sandbox,
+// and backends without a sandbox still warn plainly that they are unconfined.
 //
 // What the silence cost: an agent doing entirely correct work on an assigned
 // third-party repo ran that repo's own test suite; a latent defect in two of
@@ -18,8 +21,7 @@ import (
 // Nothing was written, and the only reason is that the process happened to lack
 // privilege. No compromise was involved.
 //
-// The remedy on this path is container mode, which is already the default. The
-// warning exists so the operator choosing `local` is choosing it knowingly.
+// Container mode remains the backend-independent remedy and the default.
 
 // contributeHiveLocalBranch returns the head of contribute-hive's local-mode
 // branch, up to the tmux session name it derives. Read from the Justfile rather
@@ -38,12 +40,19 @@ func contributeHiveLocalBranch(t *testing.T) string {
 	return src[start : start+end]
 }
 
-// TestLocalModeWarnsItIsUnconfined pins the warning itself.
-func TestLocalModeWarnsItIsUnconfined(t *testing.T) {
+// TestLocalModeDistinguishesConfinedAndUnconfinedBackends pins both messages.
+// A blanket warning would now lie about Claude and Codex; a blanket success
+// message would hide the unchanged exposure of the other backends.
+func TestLocalModeDistinguishesConfinedAndUnconfinedBackends(t *testing.T) {
 	block := contributeHiveLocalBranch(t)
 
-	if !strings.Contains(block, "LOCAL MODE") || !strings.Contains(block, "NOT confined") {
-		t.Error("contribute-hive local mode no longer states that the agent is unconfined (#4918)")
+	for _, want := range []string{
+		"claude|litellm", "codex)", "_LOCAL_WRITE_CONFINED=true",
+		"workspace write confinement is enabled", "NOT confined",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("local-mode posture branch does not contain %q", want)
+		}
 	}
 	// The warning has to name the way out, or it is an alarm rather than
 	// guidance. Container mode is the default and is the remedy on this path.
@@ -52,18 +61,113 @@ func TestLocalModeWarnsItIsUnconfined(t *testing.T) {
 	}
 }
 
-// TestLocalModeWarningIsHonestAboutWhatStillHolds. A warning that implies
-// NOTHING is constrained is its own kind of wrong: the #4938 host-state denials
-// do apply here (the recipe sources config/backends.conf), and credentials and
-// pushes are constrained on every path. Saying so is what makes the "not
-// constrained" half credible.
-func TestLocalModeWarningIsHonestAboutWhatStillHolds(t *testing.T) {
+// TestLocalModeMessagesAreHonestAboutWhatStillHolds pins the hard-fail promise
+// on the confined branch and the remaining controls on the fallback branch.
+func TestLocalModeMessagesAreHonestAboutWhatStillHolds(t *testing.T) {
 	block := contributeHiveLocalBranch(t)
 
-	for _, want := range []string{"Still constrained", "sudo", "rpm-ostree", "GitHub token"} {
+	for _, want := range []string{
+		"startup fails rather than", "falling back unconfined",
+		"Still constrained", "host-state commands", "GitHub token",
+	} {
 		if !strings.Contains(block, want) {
-			t.Errorf("the local-mode warning does not mention %q, so it overstates the exposure", want)
+			t.Errorf("the local-mode posture message does not mention %q", want)
 		}
+	}
+}
+
+func claudeLocalSandboxArgs(t *testing.T, extraEnv ...string) []string {
+	t.Helper()
+	workspace := filepath.Join(t.TempDir(), "workspace with spaces")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", "-c", `
+source ../../../config/backends.conf
+eval "set -- $(claude_family_local_perm_flag_shell)"
+printf '%s\0' "$@"
+`)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "HIVE_WORKSPACE_DIR=") || strings.HasPrefix(entry, "HIVE_CLAUDE_DANGEROUSLY_") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, entry)
+	}
+	cmd.Env = append(cmd.Env, append([]string{"HIVE_WORKSPACE_DIR=" + workspace}, extraEnv...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("resolve Claude local sandbox argv: %v", err)
+	}
+	parts := strings.Split(string(out), "\x00")
+	return parts[:len(parts)-1]
+}
+
+func argValue(args []string, key string) (string, bool) {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == key {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+// TestClaudeLocalSandboxIsMandatory asserts the three controls that turn the
+// native sandbox into a boundary instead of a best-effort hint.
+func TestClaudeLocalSandboxIsMandatory(t *testing.T) {
+	args := claudeLocalSandboxArgs(t)
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "dangerously-skip-permissions") {
+		t.Fatalf("default local Claude argv still bypasses permissions: %q", args)
+	}
+	if mode, ok := argValue(args, "--permission-mode"); !ok || mode != "dontAsk" {
+		t.Fatalf("permission mode = %q, %v; want dontAsk", mode, ok)
+	}
+	workspace, ok := argValue(args, "--add-dir")
+	if !ok || !strings.Contains(workspace, "workspace with spaces") {
+		t.Fatalf("workspace grant was lost or word-split: %q", args)
+	}
+
+	raw, ok := argValue(args, "--settings")
+	if !ok {
+		t.Fatalf("Claude local argv has no sandbox settings: %q", args)
+	}
+	var settings struct {
+		Sandbox struct {
+			Enabled                  bool `json:"enabled"`
+			FailIfUnavailable        bool `json:"failIfUnavailable"`
+			AllowUnsandboxedCommands bool `json:"allowUnsandboxedCommands"`
+			Filesystem               struct {
+				AllowWrite []string `json:"allowWrite"`
+			} `json:"filesystem"`
+		} `json:"sandbox"`
+	}
+	if err := json.Unmarshal([]byte(raw), &settings); err != nil {
+		t.Fatalf("settings argument is not JSON: %v\n%s", err, raw)
+	}
+	if !settings.Sandbox.Enabled || !settings.Sandbox.FailIfUnavailable || settings.Sandbox.AllowUnsandboxedCommands {
+		t.Fatalf("sandbox is not mandatory: %+v", settings.Sandbox)
+	}
+	if len(settings.Sandbox.Filesystem.AllowWrite) != 1 || settings.Sandbox.Filesystem.AllowWrite[0] != workspace {
+		t.Fatalf("sandbox write roots = %q, want only %q", settings.Sandbox.Filesystem.AllowWrite, workspace)
+	}
+}
+
+func TestClaudeLocalSandboxNeedsExplicitDangerousBypass(t *testing.T) {
+	args := claudeLocalSandboxArgs(t, "HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "dangerously-skip-permissions") || strings.Contains(joined, "--settings") {
+		t.Fatalf("explicit dangerous bypass did not restore the old posture: %q", args)
+	}
+}
+
+func TestClaudeHostStateOptOutDoesNotDisableLocalSandbox(t *testing.T) {
+	args := claudeLocalSandboxArgs(t, "HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE=1")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--settings") || strings.Contains(joined, "dangerously-skip-permissions") {
+		t.Fatalf("host-state opt-out crossed the filesystem boundary: %q", args)
+	}
+	if strings.Contains(joined, "Bash(rpm-ostree:*)") {
+		t.Fatalf("host-state opt-out did not remove the command list: %q", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

Close the actual host-write path from #4918 for the default contributor backend.

`just contribute-hive <claude|litellm> local` now uses Claude Code's native OS sandbox instead of `--dangerously-skip-permissions`:

- `sandbox.enabled: true` with `failIfUnavailable: true`
- `allowUnsandboxedCommands: false`, so a failed sandboxed command cannot retry on the host
- `dontAsk`, so non-Bash requests outside the granted roots fail instead of hanging an unattended pane
- writes granted only to Claude's agent-state cwd and the exact `HIVE_WORKSPACE_DIR`
- unrestricted network domains retained for arbitrary third-party build/test dependencies

The settings are passed as compact command-line JSON rather than a mutable settings file, and the generated argv safely preserves workspace paths containing whitespace. Linux local mode preflights `bwrap` and `socat` before connecting the relay. Missing or unusable sandbox support fails closed.

The existing host-state command denials remain defense in depth. Their old `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE` opt-out no longer crosses the OS boundary; restoring the pre-#4918 host posture requires the separate, explicit `HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` escape hatch.

The launch banner now reports the backend's real posture: Claude/LiteLLM native confinement, Codex's existing `workspace-write`, or an unconfined warning for other backends and explicit bypasses. Container mode remains the stronger backend-independent default.

Refs #4918

## Live boundary proof

Verified with the installed Claude Code 2.1.231 on Linux, using fresh sibling directories under `/tmp` and the exact argv this change generates:

```text
workspace/allowed: created
outside/blocked:   Read-only file system; not created
```

This exercises the real bubblewrap boundary, not a mock or a string assertion.

## Tests

- `bash bin/contributor-agent.test.sh`
- `go test ./pkg/dashboard` (full package)
- targeted local-confinement tests after rebasing onto current `v4`
- `bash -n config/backends.conf`
- `git diff --check upstream/v4...HEAD`

`go test ./pkg/config` still has its existing host-dependent `TestGateFailsClosedWithoutIP6Tables` failure without root/NET_ADMIN; the same failure was documented on #4991 and is unrelated to this change.

— hive: backend=codex
