### PR TITLE
🐛 fix(governor): PRs red only on non-required checks are merge-eligible

### DIFF
--- a/src/cmd/hive/audit_pr_agents_test.go
+++ b/src/cmd/hive/audit_pr_agents_test.go
@@ -48,3 +48,18 @@ func TestAuditPRAgents(t *testing.T) {
 		t.Error("agent-less entry must not be mapped")
 	}
 }
+
+// Non-required-only red PRs (perma-red Playwright shards on a dependabot
+// bump) must not be classed as failing when a required-check set is declared.
+func TestAnyRequiredCheckFailing(t *testing.T) {
+	req := map[string]bool{"build-gate": true, "go test ./...": true}
+	if anyRequiredCheckFailing([]string{"Test (chromium, shard 1)", "coverage"}, req) {
+		t.Error("optional-only failures must not count as required-failing")
+	}
+	if !anyRequiredCheckFailing([]string{"Test (chromium, shard 1)", "build-gate"}, req) {
+		t.Error("a failing required check must count")
+	}
+	if anyRequiredCheckFailing(nil, req) || anyRequiredCheckFailing([]string{"x"}, nil) {
+		t.Error("empty inputs must be false")
+	}
+}

--- a/src/cmd/hive/intent_alignment_gate_test.go
+++ b/src/cmd/hive/intent_alignment_gate_test.go
@@ -34,7 +34,7 @@ func TestWriteMergeEligibleExcludesMisalignedWhenIntentEnforced(t *testing.T) {
 			Alignment:  &intent.AlignmentVerdict{Status: intent.AlignmentStatusMisaligned, Rationale: "docs intent touched proxy"},
 		},
 	}
-	writeMergeEligible(actionable, github.HoldResult{}, "kubestellar", nil, true, verdicts, false, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	writeMergeEligible(actionable, github.HoldResult{}, "kubestellar", nil, true, verdicts, false, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	raw, err := os.ReadFile(mergeEligiblePath)
 	if err != nil {

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -5902,7 +5902,8 @@ func runEvalCycle(
 
 	intentVerdicts := writeIntentVerdicts(ctx, cfg, ghClient, actionable, beadStores, logger)
 	refreshReviewVerdicts(cfg, logger)
-	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, cfg.Intent.Enforce, intentVerdicts, cfg.Review.RequireApproval, logger)
+	requiredCheckSet, _ := cfg.AutoMerge.RequiredCheckSet()
+	writeMergeEligible(actionable, actionable.Hold, cfg.Project.Org, escalatedPRs, cfg.Intent.Enforce, intentVerdicts, cfg.Review.RequireApproval, requiredCheckSet, logger)
 
 	// Stuck-PR reaper (backstop): re-dispatch a fix for any hive-authored PR
 	// that is red on a required check AND stale (its red head SHA unchanged past
@@ -8164,7 +8165,18 @@ func auditPRAgents(org string, since time.Time, auditPath string) map[string]str
 	return out
 }
 
-func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, enforceIntent bool, intentVerdicts map[string]intent.Verdict, requireReviewApproval bool, logger *slog.Logger) {
+// anyRequiredCheckFailing reports whether any of a PR's failing check names
+// is in the operator-declared required set.
+func anyRequiredCheckFailing(failing []string, required map[string]bool) bool {
+	for _, name := range failing {
+		if required[name] {
+			return true
+		}
+	}
+	return false
+}
+
+func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, escalatedPRs map[string]bool, enforceIntent bool, intentVerdicts map[string]intent.Verdict, requireReviewApproval bool, requiredChecks map[string]bool, logger *slog.Logger) {
 	holdSet := make(map[string]bool)
 	for _, h := range hold.Items {
 		key := fmt.Sprintf("%s/%d", h.Repo, h.Number)
@@ -8246,18 +8258,35 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		}
 
 		if pr.CIStatus == "failure" {
-			failing = append(failing, failingPR{
-				Number:        pr.Number,
-				Repo:          fullRepo,
-				Title:         pr.Title,
-				Author:        pr.Author,
-				HeadSHA:       pr.HeadSHA,
-				FailingChecks: pr.FailingChecks,
-				Excerpt:       pr.CIFailureExcerpt,
-				Escalated:     escalatedPRs[escalation.Key(fullRepo, pr.Number)],
-				Agent:         prAgents[fmt.Sprintf("%s#%d", fullRepo, pr.Number)],
-			})
-			continue
+			// A PR red ONLY on non-required checks (perma-red Playwright
+			// shards, coverage) that GitHub itself reports mergeable is NOT a
+			// failing PR — it is merge-eligible, mirroring the
+			// pending-but-mergeable rule below. Without this, every dependabot
+			// PR on a repo with permanently-red optional checks classified as
+			// "failure", landed in ci-failing.json where no sweep or agent
+			// would ever merge it, and accumulated indefinitely (observed on
+			// kubestellar/console 2026-08-28: 16 dependabot PRs, oldest 11
+			// days). Gated on an operator-declared required-check set: with no
+			// set configured we cannot distinguish required from optional and
+			// keep the old fail-closed behavior. The merge step re-enforces
+			// branch protection, so this cannot merge anything GitHub blocks.
+			onlyOptionalRed := len(requiredChecks) > 0 &&
+				!anyRequiredCheckFailing(pr.FailingChecks, requiredChecks) &&
+				pr.Mergeable == github.MergeableYes
+			if !onlyOptionalRed {
+				failing = append(failing, failingPR{
+					Number:        pr.Number,
+					Repo:          fullRepo,
+					Title:         pr.Title,
+					Author:        pr.Author,
+					HeadSHA:       pr.HeadSHA,
+					FailingChecks: pr.FailingChecks,
+					Excerpt:       pr.CIFailureExcerpt,
+					Escalated:     escalatedPRs[escalation.Key(fullRepo, pr.Number)],
+					Agent:         prAgents[fmt.Sprintf("%s#%d", fullRepo, pr.Number)],
+				})
+				continue
+			}
 		}
 
 		// A PR whose CI is still "pending" is nonetheless merge-eligible when


### PR DESCRIPTION
## Problem

16 dependabot PRs sat unmerged on kubestellar/console (oldest 11 days). Cause: every console PR carries permanently-red optional checks (Playwright chromium shards), so `writeMergeEligible` classified them all `CIStatus=failure` → `ci-failing.json` — where no automerge sweep (they're neither App-authored nor queue-labeled) and no agent (kicks say merge GREEN PRs) would ever touch them. `merge-eligible.json` was literally null.

## Fix

Mirror the existing pending-but-mergeable rule: when the operator has declared `auto_merge.required_checks`, a PR whose failing checks are **all non-required** and which GitHub reports mergeable (`mergeStateStatus=unstable` ⇒ every required check passed) is **merge-eligible**, not failing. With no declared set we can't tell required from optional, so the old fail-closed behavior is kept. The merge step still re-enforces branch protection, so nothing GitHub blocks can merge.

Also keeps these PRs out of `ci-failing.json`, so they no longer pollute the FIX-BEFORE-NEW kick section (#4828) as phantom scanner reds.

Note for operators: this activates only where `auto_merge.required_checks` is configured — console needs that set in its config for the dependabot backlog to start draining.

## Test

`TestAnyRequiredCheckFailing` — optional-only failures don't count, required failures do, empty inputs safe. Existing `intent_alignment_gate_test` updated for the new parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)