### PR TITLE
🐛 fix(ci): per-branch channel ownership — v4 stops re-pointing edge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -333,7 +333,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/kubestellar/hive /tmp/digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 false
+            v4 false stable,candidate
 
   build-contributor:
     needs: gate
@@ -431,7 +431,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/kubestellar/hive-contributor /tmp/contrib-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 true
+            v4 true stable,candidate
 
   build-hub:
     needs: gate
@@ -538,4 +538,4 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/kubestellar/hive-hub /tmp/hub-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 true
+            v4 true stable,candidate

--- a/src/scripts/publish-image-tags.sh
+++ b/src/scripts/publish-image-tags.sh
@@ -7,8 +7,8 @@
 # newer run that finished first.
 set -euo pipefail
 
-if [[ $# -ne 7 ]]; then
-  echo "usage: $0 IMAGE DIGEST_DIR BRANCH GIT_SHA RUN_NUMBER RELEASE_BRANCH INCLUDE_LATEST" >&2
+if [[ $# -lt 7 || $# -gt 8 ]]; then
+  echo "usage: $0 IMAGE DIGEST_DIR BRANCH GIT_SHA RUN_NUMBER RELEASE_BRANCH INCLUDE_LATEST [CHANNELS]" >&2
   exit 2
 fi
 
@@ -19,6 +19,12 @@ git_sha=$4
 run_number=$5
 release_branch=$6
 include_latest=$7
+# CHANNELS: comma-separated release-channel tags this branch's builds own
+# (default preserves the historical behavior). Channel ownership is
+# per-branch: v4 owns stable+candidate, the v5 line owns edge — without the
+# split, every v4 merge silently re-pointed edge back onto v4 minutes after
+# any deliberate promotion of edge to v5.
+channels=${8:-stable,candidate,edge}
 run_label=io.kubestellar.hive.github-actions-run-number
 
 if [[ ! $run_number =~ ^[0-9]+$ ]]; then
@@ -43,8 +49,11 @@ moving_refs=("$image:${branch_tag}-latest")
 if [[ $include_latest == true ]]; then
   moving_refs+=("$image:latest")
 fi
-if [[ $branch == "$release_branch" ]]; then
-  moving_refs+=("$image:stable" "$image:candidate" "$image:edge")
+if [[ $branch == "$release_branch" && -n $channels ]]; then
+  IFS=, read -ra channel_tags <<<"$channels"
+  for ch in "${channel_tags[@]}"; do
+    [[ -n $ch ]] && moving_refs+=("$image:$ch")
+  done
 fi
 
 inspect_status=


### PR DESCRIPTION
The operator promoted the `edge` channel to the v5 build (digest now matches `v5-latest`), but `publish-image-tags.sh` re-pushes stable+candidate+edge on EVERY v4 merge — the promotion would be silently reverted by the next build.

- `publish-image-tags.sh`: optional 8th arg `CHANNELS` (comma list) controlling which release-channel tags this branch's builds own; default unchanged (`stable,candidate,edge`) for back-compat.
- v4 `docker.yml`: all three publish calls now pass `stable,candidate` — v4 no longer touches `edge`.
- Companion change on the v5 branch gives its workflow `edge` ownership.

`bash -n` clean; behavior verified by reading the moving_refs construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)