### PR TITLE
🐛 fix(ci): v5 branch owns the edge release channel

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -339,7 +339,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/kubestellar/hive /tmp/digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 false
+            v5 false edge
 
   build-contributor:
     needs: gate
@@ -437,7 +437,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/kubestellar/hive-contributor /tmp/contrib-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 true
+            v5 true edge
 
   build-hub:
     needs: gate
@@ -544,4 +544,4 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/kubestellar/hive-hub /tmp/hub-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 true
+            v5 true edge

--- a/src/scripts/publish-image-tags.sh
+++ b/src/scripts/publish-image-tags.sh
@@ -7,8 +7,8 @@
 # newer run that finished first.
 set -euo pipefail
 
-if [[ $# -ne 7 ]]; then
-  echo "usage: $0 IMAGE DIGEST_DIR BRANCH GIT_SHA RUN_NUMBER RELEASE_BRANCH INCLUDE_LATEST" >&2
+if [[ $# -lt 7 || $# -gt 8 ]]; then
+  echo "usage: $0 IMAGE DIGEST_DIR BRANCH GIT_SHA RUN_NUMBER RELEASE_BRANCH INCLUDE_LATEST [CHANNELS]" >&2
   exit 2
 fi
 
@@ -19,6 +19,11 @@ git_sha=$4
 run_number=$5
 release_branch=$6
 include_latest=$7
+# CHANNELS: comma-separated release-channel tags this branch's builds own.
+# Channel ownership is per-branch: v4 owns stable+candidate, the v5 line owns
+# edge — without the split, every v4 merge silently re-pointed edge back onto
+# v4 minutes after any deliberate promotion of edge to v5.
+channels=${8:-stable,candidate,edge}
 run_label=io.kubestellar.hive.github-actions-run-number
 
 if [[ ! $run_number =~ ^[0-9]+$ ]]; then
@@ -43,8 +48,11 @@ moving_refs=("$image:${branch_tag}-latest")
 if [[ $include_latest == true ]]; then
   moving_refs+=("$image:latest")
 fi
-if [[ $branch == "$release_branch" ]]; then
-  moving_refs+=("$image:stable" "$image:candidate" "$image:edge")
+if [[ $branch == "$release_branch" && -n $channels ]]; then
+  IFS=, read -ra channel_tags <<<"$channels"
+  for ch in "${channel_tags[@]}"; do
+    [[ -n $ch ]] && moving_refs+=("$image:$ch")
+  done
 fi
 
 inspect_status=


### PR DESCRIPTION
Companion to #5021 (v4 stops re-pointing edge). This side:

- Ports the `CHANNELS` argument to v5's copy of `publish-image-tags.sh`.
- v5 `docker.yml`: all three publish calls pass `v5 ... edge` — v5 merges now move `hive:edge` (and the contributor/hub images' edge tags) to the v5 build.

With both sides landed, edge tracks v5 durably; the manual digest promotion done today stops being reverted. Operator-requested: edge channel → v5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)