### PR TITLE
security: confine or honestly refuse every remaining backend on the contributor local path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ### Security
 
+- Contributor-local confinement now extends to every remaining backend, closing
+  the rest of the gap #5011 opened for claude/litellm only. `copilot` local
+  launches now use Copilot CLI's own OS-enforced `--sandbox` (Seatbelt on
+  macOS, bubblewrap on Linux — same class of boundary as Claude's), gated on
+  the installed CLI actually supporting the flag and falling back with a loud
+  warning (or `HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX=1`) if it does not.
+  `opencode` local launches gain a host-state command deny-list via its own
+  `permission.bash` config — the same command family the claude deny-list
+  covers, honestly documented as a floor and not a filesystem boundary, since
+  opencode has no OS sandbox of its own. `goose`, `agy`, `bob`, `pi`, and
+  `aider` have **no sandbox, filesystem allowlist, or command deny-list this
+  repo can wire at all** (verified against each CLI's own current
+  documentation) — `just contribute-hive <backend> local` for these five now
+  **refuses to launch** with a plain explanation of what's missing, unless the
+  operator sets that backend's own `HIVE_<BACKEND>_DANGEROUSLY_RUN_UNCONFINED=1`
+  escape hatch. The local-mode launch banner now distinguishes three postures
+  (sandboxed / denylisted-only / unconfined) instead of two, so it never calls
+  a command-deny floor a "confinement" it is not. Container mode remains the
+  backend-independent default for all of them. See
+  [docs/sandbox-isolation.md](src/docs/sandbox-isolation.md#per-backend-confinement-on-the-contributor-local-path)
+  for the full per-backend matrix
+  ([#4918](https://github.com/kubestellar/hive/issues/4918)).
+
 - Claude-family contributor agents are now write-confined even when explicitly
   launched in host-local mode. `just contribute-hive <claude|litellm> local`
   enables Claude Code's native OS sandbox, fails startup if that sandbox is

--- a/Justfile
+++ b/Justfile
@@ -808,49 +808,97 @@ contribute-hive backend="" mode="docker": check-version
       _local_truthy() {
         case "${1:-}" in 1|true|TRUE|yes|YES|on|ON) return 0 ;; *) return 1 ;; esac
       }
-      _LOCAL_WRITE_CONFINED=false
+      # Three postures, not two — an operator reading this banner needs to
+      # know which one they're actually getting:
+      #   sandboxed   — an OS-enforced filesystem boundary (claude/litellm's
+      #                 native sandbox, codex/copilot's own sandbox modes)
+      #   denylisted  — a command-name floor with NO filesystem boundary
+      #                 (opencode's permission.bash denials); real, but not a
+      #                 sandbox, and saying "confined" here would be exactly
+      #                 the overclaim #4918 is about
+      #   unconfined  — nothing at all unless the operator opted in
+      _LOCAL_POSTURE="unconfined"
       case "$BACKEND" in
         claude|litellm)
           if ! _local_truthy "${HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}"; then
-            _LOCAL_WRITE_CONFINED=true
+            _LOCAL_POSTURE="sandboxed"
           fi
           ;;
         codex)
           if ! _local_truthy "${HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX:-}"; then
-            _LOCAL_WRITE_CONFINED=true
+            _LOCAL_POSTURE="sandboxed"
+          fi
+          ;;
+        copilot)
+          if ! _local_truthy "${HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX:-}" \
+              && copilot --help 2>&1 | grep -qe '--sandbox'; then
+            _LOCAL_POSTURE="sandboxed"
+          fi
+          ;;
+        opencode)
+          if ! _local_truthy "${HIVE_OPENCODE_DANGEROUSLY_ALLOW_HOST_STATE:-}" \
+              && command -v jq >/dev/null 2>&1; then
+            _LOCAL_POSTURE="denylisted"
           fi
           ;;
       esac
-      if [[ "$_LOCAL_WRITE_CONFINED" == "true" ]]; then
-        echo "🔒 LOCAL MODE — workspace write confinement is enabled for ${BACKEND}."
-        echo ""
-        echo "    The CLI still runs as $(id -un) on this machine, but commands and"
-        echo "    file edits may write only under the agent state directory and"
-        echo "    ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
-        if [[ "$BACKEND" == "claude" || "$BACKEND" == "litellm" ]]; then
-          echo "    Claude's native sandbox is mandatory: startup fails rather than"
-          echo "    falling back unconfined when its OS sandbox is unavailable."
-        fi
-        echo ""
-        echo "    Container mode remains the stronger backend-independent boundary:"
-        echo "      just contribute-hive ${BACKEND}"
-        echo ""
-      else
-        echo "⚠️  LOCAL MODE — the agent is NOT confined to a workspace."
-        echo ""
-        echo "    The backend CLI runs as $(id -un) on this machine, with permission"
-        echo "    prompts bypassed. It can read and write anything your user can,"
-        echo "    including files outside ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
-        echo "    Assigned repos are third-party code and their test suites run for real."
-        echo ""
-        echo "    Still constrained: supported host-state commands are denied, and no"
-        echo "    agent receives a GitHub token or pushes directly."
-        echo "    NOT constrained: everything else your user can reach."
-        echo ""
-        echo "    For a confined agent, drop 'local' and use container mode:"
-        echo "      just contribute-hive ${BACKEND}"
-        echo ""
-      fi
+      case "$_LOCAL_POSTURE" in
+        sandboxed)
+          echo "🔒 LOCAL MODE — workspace write confinement is enabled for ${BACKEND}."
+          echo ""
+          echo "    The CLI still runs as $(id -un) on this machine, but commands and"
+          echo "    file edits may write only under the agent state directory and"
+          echo "    ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
+          if [[ "$BACKEND" == "claude" || "$BACKEND" == "litellm" ]]; then
+            echo "    Claude's native sandbox is mandatory: startup fails rather than"
+            echo "    falling back unconfined when its OS sandbox is unavailable."
+          elif [[ "$BACKEND" == "copilot" ]]; then
+            echo "    Copilot's own --sandbox flag (OS-enforced: Seatbelt on macOS,"
+            echo "    bubblewrap on Linux) provides the boundary."
+          fi
+          echo ""
+          echo "    Container mode remains the stronger backend-independent boundary:"
+          echo "      just contribute-hive ${BACKEND}"
+          echo ""
+          ;;
+        denylisted)
+          echo "🟡 LOCAL MODE — ${BACKEND} is NOT filesystem-confined, but named"
+          echo "    host-state commands are denied."
+          echo ""
+          echo "    opencode has no OS sandbox and no filesystem write-allowlist. The"
+          echo "    same command family the claude deny-list covers (sudo, pkexec,"
+          echo "    rpm-ostree, bootc, ...) is denied via opencode's own permission"
+          echo "    config, but this is a command-name floor, not a boundary: anything"
+          echo "    not on that list, and anything reached another way, is unconstrained."
+          echo ""
+          echo "    Container mode remains the stronger backend-independent boundary:"
+          echo "      just contribute-hive ${BACKEND}"
+          echo ""
+          ;;
+        *)
+          echo "⚠️  LOCAL MODE — the agent is NOT confined to a workspace."
+          echo ""
+          echo "    The backend CLI runs as $(id -un) on this machine, with permission"
+          echo "    prompts bypassed. It can read and write anything your user can,"
+          echo "    including files outside ${HIVE_WORKSPACE_DIR:-$HOME/workspace}."
+          echo "    Assigned repos are third-party code and their test suites run for real."
+          echo ""
+          if [[ "$BACKEND" == "claude" || "$BACKEND" == "litellm" || "$BACKEND" == "codex" || "$BACKEND" == "copilot" ]]; then
+            echo "    Still constrained: supported host-state commands are denied, and no"
+            echo "    agent receives a GitHub token or pushes directly."
+            echo "    NOT constrained: everything else your user can reach."
+          else
+            echo "    ${BACKEND} has no sandbox, filesystem allowlist, or command deny-list"
+            echo "    hive can wire on this path — nothing stands between the agent and"
+            echo "    anything your user can reach. No agent receives a GitHub token or"
+            echo "    pushes directly, but that is the only guardrail left."
+          fi
+          echo ""
+          echo "    For a confined agent, drop 'local' and use container mode:"
+          echo "      just contribute-hive ${BACKEND}"
+          echo ""
+          ;;
+      esac
       TMUX_SESSION="hive-${BACKEND}-$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' ')"
       SCRIPT_DIR="$(pwd)/bin"
       RELAY="${SCRIPT_DIR}/contributor-relay.sh"
@@ -912,6 +960,24 @@ contribute-hive backend="" mode="docker": check-version
       case "$BACKEND" in
         claude|litellm)
           PERM_FLAG=$(claude_family_local_perm_flag_shell)
+          ;;
+        copilot)
+          PERM_FLAG=$(copilot_local_perm_flag_shell)
+          ;;
+        opencode)
+          PERM_FLAG=$(opencode_local_perm_flag_shell)
+          ;;
+        codex)
+          PERM_FLAG=$(backend_perm_flag_shell "$BACKEND" 2>/dev/null || echo "")
+          ;;
+        goose|agy|bob|pi|aider)
+          # No sandbox, filesystem allowlist, or command deny-list exists for
+          # any of these five (see the "no confinement mechanism at all"
+          # block in backends.conf) — refuse to launch unconfined by
+          # default rather than silently grant full host access (#4918).
+          if ! PERM_FLAG=$(unconfined_local_perm_flag_shell "$BACKEND"); then
+            exit 1
+          fi
           ;;
         *)
           PERM_FLAG=$(backend_perm_flag_shell "$BACKEND" 2>/dev/null || echo "")

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -149,6 +149,167 @@ claude_family_local_perm_flag_shell() {
   printf '%s\n' "${out% }"
 }
 
+# copilot_local_perm_flag_shell emits the stricter posture used only by
+# `just contribute-hive copilot local`. Copilot CLI has its own OS-enforced
+# sandbox (MXC: Seatbelt on macOS, bubblewrap on Linux — same underlying
+# bubblewrap dependency the Claude local sandbox above already requires),
+# turned on with the `--sandbox` flag introduced in copilot-cli 1.0.60 and
+# usable in the headless `-p` mode contributor-relay.sh already launches
+# Copilot with (`copilot: { flag: '-p' }` in bin/contributor-relay.sh).
+# `--no-sandbox` is also a real flag, so a stale/older `copilot` binary
+# silently ignoring `--sandbox` is not something to assume — this function
+# verifies the installed CLI actually understands the flag before relying on
+# it, and fails closed (falls through to the deny-list-only unconfined path
+# below, loudly) rather than claim a boundary an old binary does not have.
+#
+# --add-dir grants exactly HIVE_WORKSPACE_DIR, same as the Claude/Codex
+# grants above, so build/test tooling can still reach the assigned repo.
+# Copilot's sandbox does not have a documented filesystem-allowlist flag of
+# its own the way Claude's --settings JSON does — --sandbox plus --add-dir is
+# the full extent of what the CLI exposes.
+copilot_local_perm_flag_shell() {
+  if is_truthy "${HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX:-}"; then
+    backend_perm_flag_shell copilot
+    return
+  fi
+  if ! copilot --help 2>&1 | grep -qe '--sandbox'; then
+    echo "WARNING: installed copilot CLI has no --sandbox flag (needs copilot-cli >= 1.0.60)." >&2
+    echo "         Falling back UNCONFINED — set HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX=1 to" >&2
+    echo "         silence this warning, or upgrade copilot-cli to get local confinement." >&2
+    backend_perm_flag_shell copilot
+    return
+  fi
+  local -a args=(--sandbox --allow-all-tools)
+  if [[ -n "${HIVE_WORKSPACE_DIR:-}" ]]; then
+    args+=(--add-dir "$HIVE_WORKSPACE_DIR")
+  fi
+
+  local word out=""
+  for word in "${args[@]}"; do
+    out+="$(printf '%q' "$word") "
+  done
+  printf '%s\n' "${out% }"
+}
+
+# opencode_local_perm_flag_shell narrows opencode's local posture with the
+# SAME host-state command family the claude deny-list covers, via opencode's
+# own `permission.bash` pattern-match config (https://opencode.ai/docs/permissions/).
+#
+# THIS IS A FLOOR, NOT A SANDBOX — same honest limitation as
+# CLAUDE_HOST_DENY_TOOLS above and the same as #4938's original claude
+# denylist: opencode has no OS-enforced filesystem boundary of its own
+# (confirmed against the current opencode CLI/docs: no bwrap/seatbelt
+# integration, no workspace-write mode). "deny" rules are documented to stay
+# enforced even under --auto ("auto mode only changes requests that would
+# otherwise ask for approval"), so this is a real narrowing, not a no-op —
+# but it is a command-name denylist like Claude's, not a filesystem
+# boundary like Claude's or Copilot's --sandbox.
+#
+# OPENCODE_PERMISSION carries inline JSON (documented opencode env var) so no
+# on-disk config file is mutated. Explicit deny wins because opencode
+# evaluates patterns in order with "last matching rule wins", and this key is
+# assembled with catch-all "allow" first, "*" host-state denials last.
+OPENCODE_HOST_DENY_PATTERNS='sudo *:pkexec *:doas *:su *:rpm-ostree *:bootc *:ostree *:grubby *:bootctl *:efibootmgr *'
+
+opencode_local_perm_flag_shell() {
+  if is_truthy "${HIVE_OPENCODE_DANGEROUSLY_ALLOW_HOST_STATE:-}"; then
+    backend_perm_flag_shell opencode
+    return
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "WARNING: jq not found; opencode local mode cannot apply host-state denials." >&2
+    echo "         Falling back UNCONFINED for host-state commands. Install jq, or set" >&2
+    echo "         HIVE_OPENCODE_DANGEROUSLY_ALLOW_HOST_STATE=1 to silence this warning." >&2
+    backend_perm_flag_shell opencode
+    return
+  fi
+
+  local bash_json
+  bash_json="$(
+    IFS=':'; set -- $OPENCODE_HOST_DENY_PATTERNS
+    jq -cn --args '{"*": "allow"} + (($ARGS.positional) | map({(.): "deny"}) | add)' -- "$@"
+  )" || return
+  local perm_json
+  perm_json="$(jq -cn --argjson bash "$bash_json" '{bash: $bash}')" || return
+
+  # opencode reads OPENCODE_PERMISSION as inline JSON (no config file
+  # mutation, no risk of an agent rewriting a persisted settings file).
+  local -a args=(--auto)
+  local word out
+  out="OPENCODE_PERMISSION=$(printf '%q' "$perm_json") "
+  for word in "${args[@]}"; do
+    out+="$(printf '%q' "$word") "
+  done
+  printf '%s\n' "${out% }"
+}
+
+# ── Backends with no confinement mechanism at all ───────────────────────
+#
+# goose, agy, bob, pi, and aider expose no OS-level sandbox, no filesystem
+# write-allowlist, and no bash-command deny mechanism analogous to
+# opencode's `permission.bash` — verified against each CLI's own current
+# documentation, not assumed:
+#   - goose: GOOSE_MODE (auto/approve/chat/smart_approve) governs interactive
+#     APPROVAL only; none of the four modes confines writes to a directory,
+#     and only `auto` is usable unattended.
+#   - agy (Google Antigravity CLI): execution modes (default/accept-edits/
+#     plan) govern approval only, same as goose; --dangerously-skip-permissions
+#     is already what hive passes and there is no lesser mode that still
+#     confines the filesystem.
+#   - bob (IBM bobshell): no sandbox, approval mode, or path-restriction
+#     mechanism documented anywhere in bob's own docs.
+#   - pi (@earendil-works/pi-coding-agent): ships with no sandbox by default;
+#     directory confinement exists only via a third-party extension
+#     (pi-permission-modes) hive does not install or depend on.
+#   - aider: has no sandbox of any kind; runs directly against the
+#     filesystem with no Docker/OS isolation option.
+#
+# An HONEST "unconfined, opt in to proceed" is the documented contract here
+# (#4918's own ask: never claim confinement a backend does not have). Local
+# mode for these backends REFUSES to launch without the explicit per-backend
+# escape hatch below, matching the HIVE_CLAUDE_DANGEROUSLY_* / codex naming
+# convention. Container mode remains the confined default for all of them.
+unconfined_local_backend_env_var() {
+  case "$1" in
+    goose) echo "HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED" ;;
+    agy)   echo "HIVE_AGY_DANGEROUSLY_RUN_UNCONFINED" ;;
+    bob)   echo "HIVE_BOB_DANGEROUSLY_RUN_UNCONFINED" ;;
+    pi)    echo "HIVE_PI_DANGEROUSLY_RUN_UNCONFINED" ;;
+    aider) echo "HIVE_AIDER_DANGEROUSLY_RUN_UNCONFINED" ;;
+    *)     echo "" ;;
+  esac
+}
+
+# unconfined_local_perm_flag_shell is the local-mode entry point for the five
+# backends above. It refuses to emit a launch line at all unless the
+# operator has set that backend's own escape-hatch env var — there is no
+# confinement to fall back to, so silence is not an option (#4918's
+# lesson: an unconfined default that says nothing is exactly the failure
+# mode this whole change exists to close).
+unconfined_local_perm_flag_shell() {
+  local backend="$1" var
+  var="$(unconfined_local_backend_env_var "$backend")"
+  if [[ -z "$var" ]]; then
+    # Not one of the five — caller error, not an operator-facing case.
+    backend_perm_flag_shell "$backend"
+    return
+  fi
+  if ! is_truthy "${!var:-}"; then
+    echo "ERROR: ${backend} has no sandbox, no filesystem write-allowlist, and no" >&2
+    echo "       command deny-list hive can wire on the local launch path (verified" >&2
+    echo "       against ${backend}'s own current docs — this is not a placeholder)." >&2
+    echo "       It would run as \$(id -un) on this machine with nothing standing" >&2
+    echo "       between the agent and everything your user can reach." >&2
+    echo "" >&2
+    echo "       Refusing to launch. Either:" >&2
+    echo "         - use container mode instead:  just contribute-hive ${backend}" >&2
+    echo "         - or explicitly accept the unconfined risk on this host:" >&2
+    echo "             ${var}=1" >&2
+    return 1
+  fi
+  backend_perm_flag_shell "$backend"
+}
+
 # ── Backend → permission flag ───────────────────────────────────────────
 backend_perm_flag() {
   case "$1" in

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -77,6 +77,13 @@ Important environment variables:
 | `HIVE_CODEX_APPROVALS_REVIEWER` | `auto_review` | Codex reviewer for boundary requests. The default prevents Hive-delivered work from waiting on an interactive operator while retaining `workspace-write`; set `user` only for an intentionally attended contributor. Set it to the **empty string** to omit the `-c approvals_reviewer=` key entirely — the escape hatch if a Codex release rejects that config key at startup. Doing so keeps the sandbox posture; it is not the same as the dangerous bypass. |
 | `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE` | unset | Drops the defense-in-depth Claude command denylist. In local mode the native filesystem sandbox still applies, so this does not grant host writes. |
 | `HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX` | unset | Restores the pre-#4918 unconfined Claude/LiteLLM local posture. Use only on a disposable or externally sandboxed host. |
+| `HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX` | unset | Restores the unconfined Copilot local posture. Also the automatic fallback (with a warning) when the installed `copilot` CLI predates `--sandbox` (copilot-cli < 1.0.60). |
+| `HIVE_OPENCODE_DANGEROUSLY_ALLOW_HOST_STATE` | unset | Drops opencode's host-state command deny-list (`permission.bash`). opencode has no filesystem sandbox to fall back to either way — this only removes the command-name floor. |
+| `HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED` | unset | **Required** for `just contribute-hive goose local` to launch at all. goose has no sandbox, filesystem allowlist, or command deny-list hive can wire; local mode refuses to launch without this. |
+| `HIVE_AGY_DANGEROUSLY_RUN_UNCONFINED` | unset | **Required** for `just contribute-hive agy local` to launch at all. Same reasoning as goose above — agy's execution modes govern approval only, not filesystem confinement. |
+| `HIVE_BOB_DANGEROUSLY_RUN_UNCONFINED` | unset | **Required** for `just contribute-hive bob local` to launch at all. Bob Shell documents no sandbox or path-restriction mechanism of any kind. |
+| `HIVE_PI_DANGEROUSLY_RUN_UNCONFINED` | unset | **Required** for `just contribute-hive pi local` to launch at all. pi ships with no sandbox by default; directory confinement exists only via a third-party extension hive does not depend on. |
+| `HIVE_AIDER_DANGEROUSLY_RUN_UNCONFINED` | unset | **Required** for `just contribute-hive aider local` to launch at all. aider has no sandbox or OS isolation option of any kind. |
 
 ### Where each backend reads its instructions
 
@@ -135,11 +142,19 @@ loudly named `HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` restores
 the old unconfined local posture for an externally isolated/disposable host.
 
 `just contribute-hive` still defaults to **container** mode, the stronger
-backend-independent boundary. In local mode Claude/LiteLLM now use the native
-sandbox and Codex retains `workspace-write`; other backends remain unconfined
-and the launch banner says so. The `agent_sandbox` Podman path documented in
-[sandbox-isolation.md](sandbox-isolation.md) remains **hub-side only** — nothing
-on the contributor path reads it.
+backend-independent boundary. In local mode: Claude/LiteLLM and Codex use
+their own OS-enforced sandboxes; Copilot now uses its own `--sandbox` (also
+OS-enforced — Seatbelt/bubblewrap/ProcessContainer depending on platform),
+gated on the installed CLI actually supporting the flag; opencode gets a
+command-name deny-list via its own `permission.bash` config (a floor, not a
+filesystem boundary — opencode has no OS sandbox); goose, agy, bob, pi, and
+aider have no confinement mechanism this repo can wire at all, and local mode
+for them **refuses to launch** unless the operator sets that backend's own
+`HIVE_<BACKEND>_DANGEROUSLY_RUN_UNCONFINED=1`. See
+[sandbox-isolation.md](sandbox-isolation.md)'s per-backend confinement matrix
+for the authoritative, up-to-date state. The `agent_sandbox` Podman path
+documented there remains **hub-side only** — nothing on the contributor path
+reads it.
 
 Codex config-key compatibility: `approvals_reviewer` is passed with `-c`, so it
 depends on the installed Codex release accepting that key. If a version rejects

--- a/src/docs/design/agent-host-confinement.md
+++ b/src/docs/design/agent-host-confinement.md
@@ -1,11 +1,22 @@
 # Agent host confinement on the default launch path (#4918)
 
-Status: **historical investigation; contributor-local Claude confinement is now
-implemented.** This page records the evidence and options as assessed before
-Claude Code's native sandbox was wired into `contribute-hive ... local`.
-Claude/LiteLLM local launches now use that OS-enforced sandbox with hard-fail
-startup and no unsandboxed retry; Codex retains `workspace-write`. The hub-side
-Podman default and local backends without a native sandbox remain open concerns.
+Status: **historical investigation; contributor-local confinement is now
+implemented for every backend that has a real mechanism, and the rest refuse
+to launch unconfined.** This page records the evidence and options as
+assessed before that work landed (#5011, then this follow-up). Claude/LiteLLM
+and Codex local launches use their own OS-enforced sandboxes with hard-fail
+startup and no unsandboxed retry; Copilot local launches now use Copilot
+CLI's own `--sandbox` (OS-enforced, same underlying technology class); opencode
+gets a command-name deny-list (a floor, not a boundary — it has no OS sandbox);
+goose, agy, bob, pi, and aider have **no confinement mechanism this repo can
+wire at all**, verified against each CLI's own current docs, and local mode
+for them now refuses to launch without an explicit per-backend operator
+opt-in rather than launching silently unconfined. See
+`src/docs/sandbox-isolation.md`'s per-backend confinement matrix for the
+current, authoritative state — the analysis below is left as the historical
+record of how each decision was reached, not a live status report. The
+hub-side Podman sandbox's double gate (`agent_sandbox.enabled` +
+per-agent `sandbox.enabled`) remains an open concern, unchanged by this pass.
 
 All citations are against `origin/v4` at `1b54c69e` unless noted.
 
@@ -331,6 +342,13 @@ estimated from reading the code, not measured.
   default.
 
 ## Recommendation
+
+> **Update:** this recommendation is about the hub-side Podman sandbox
+> (`agent_sandbox`), which is a separate axis from the contributor-local
+> per-backend work this page's status line now describes — that work closed
+> the specific incident path (`contribute-hive ... local`) without touching
+> the Podman double-gate discussed here. The recommendation below is
+> unimplemented and still stands as an open item.
 
 **This investigation's single strongest recommendation: single-gate or
 default-on the existing Podman sandbox for `contribute-hive` (both

--- a/src/docs/sandbox-isolation.md
+++ b/src/docs/sandbox-isolation.md
@@ -7,7 +7,7 @@ Hive agents are untrusted code executors: prompts, tool output, and cloned repos
 Two halves of that target hold differently, and the difference matters:
 
 - **Credentials and pushes are constrained on every path.** No agent receives a GitHub token or pushes directly; authorship goes through the App-gated `gh` wrapper and the push broker.
-- **Workspace write confinement depends on the launch path and backend.** The Podman sandbox below is the hub-side boundary. Contributor container mode has its own container boundary. In contributor local mode, Claude/LiteLLM now require Claude Code's native OS sandbox and Codex retains its `workspace-write` sandbox; other backends still run as the operator's user without a filesystem boundary.
+- **Workspace write confinement depends on the launch path and backend.** The Podman sandbox below is the hub-side boundary. Contributor container mode has its own container boundary. In contributor local mode: claude/litellm and codex have OS-enforced sandboxes; copilot has its own OS-enforced sandbox, wired the same way, gated on the installed CLI actually supporting it; opencode has no sandbox but does get a command-name deny-list (a floor, not a boundary); goose, agy, bob, pi, and aider have **no confinement mechanism this repo can wire at all** and refuse to launch in local mode unless the operator explicitly opts in per backend. See the [per-backend matrix](#per-backend-confinement-on-the-contributor-local-path) below.
 
 **#4918 is what that costs in practice, and it did not require a compromise.** An agent doing correct work on an assigned third-party repo ran that repo's own test suite; a latent defect in two of its tests let a hook escape its stubs and issue `rpm-ostree kargs --append-if-missing=...` against the operator's real deployment. Nothing was written, and the only reason is that the process happened to lack privilege. Benign behaviour was a sufficient precondition, so this is a routine exposure rather than an exceptional one.
 
@@ -21,13 +21,31 @@ This is the part that is easy to get wrong, because the two paths have different
 |---|---|---|
 | Runs where | The hive spoke's own container | The contributor's machine |
 | Podman agent sandbox (`agent_sandbox`) | Available, opt-in — see below | **Does not exist on this path.** `SandboxEnabled` is read only by `pkg/agent`; nothing in `bin/contributor-relay.sh`, `bin/contributor-agent.sh` or the `Justfile` consults it |
-| The confinement lever | `agent_sandbox` + the per-agent opt-in | Container mode (the default), or a backend-native sandbox in local mode. Claude/LiteLLM and Codex are write-confined locally; other backends are not |
+| The confinement lever | `agent_sandbox` + the per-agent opt-in | Container mode (the default), or a backend-native sandbox in local mode — see the matrix below, coverage varies by backend |
 | Host-state denials (#4938) | Yes | Yes (`config/backends.conf`) |
 | Credentials / pushes | Constrained | Constrained |
 
-**The #4918 incident happened on the contributor relay's local mode**, so enabling `agent_sandbox` would not have prevented it. Claude-family local launches now use Claude Code's native sandbox with hard-fail startup and unsandboxed retry disabled. Container mode remains the stronger backend-independent remedy and the `just contribute-hive` default.
+**The #4918 incident happened on the contributor relay's local mode**, so enabling `agent_sandbox` would not have prevented it. Claude-family local launches now use Claude Code's native sandbox with hard-fail startup and unsandboxed retry disabled; codex keeps its `workspace-write` sandbox; copilot local launches now use Copilot CLI's own OS-enforced sandbox. Container mode remains the stronger backend-independent remedy and the `just contribute-hive` default.
 
-Operators running hive on a machine they care about should therefore prefer container mode on the contributor path, use only a locally sandboxed backend when local mode is necessary, and enable the sandbox below on the hub path.
+Operators running hive on a machine they care about should therefore prefer container mode on the contributor path, use only a locally sandboxed (or, for opencode, at least denylisted) backend when local mode is necessary, and enable the sandbox below on the hub path.
+
+### Per-backend confinement on the contributor local path
+
+This table is the ground truth for `just contribute-hive <backend> local` — the only mode where "the operator's host" means a real desktop with no container boundary. Verified against each backend's own current CLI documentation, not assumed; see `config/backends.conf` for the implementation and `src/pkg/dashboard/contribute_local_mode_backend_matrix_test.go` for the tests that pin it.
+
+| Backend | Mechanism | What it actually bounds | Escape hatch (unconfined opt-in) |
+|---|---|---|---|
+| `claude` / `litellm` | Claude Code's native OS sandbox (`--settings` sandbox JSON; Seatbelt on macOS, bubblewrap on Linux) | Filesystem writes confined to the agent cwd and `HIVE_WORKSPACE_DIR`; `failIfUnavailable: true`, no unsandboxed fallback | `HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` |
+| `codex` | Codex's own `--sandbox workspace-write` | Filesystem writes confined to the workspace root(s) codex is given | `HIVE_CODEX_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX=1` |
+| `copilot` | Copilot CLI's own `--sandbox` flag (MXC: Seatbelt on macOS, bubblewrap on Linux, ProcessContainer on Windows Insiders) | Filesystem/network/process access of the commands and tools Copilot runs, restricted by the OS-level backend; `--add-dir` grants the exact workspace | `HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX=1`, or automatic fallback with a loud warning if the installed CLI predates `--sandbox` (copilot-cli < 1.0.60) |
+| `opencode` | opencode's own `permission.bash` deny rules (inline via `OPENCODE_PERMISSION`), denying the same host-state command family the claude deny-list covers | **Not a filesystem boundary.** A command-name floor only — anything not on the list, or reached another way, is unconstrained. Deny rules are documented to hold even under `--auto`. | `HIVE_OPENCODE_DANGEROUSLY_ALLOW_HOST_STATE=1` |
+| `goose` | **None.** `GOOSE_MODE` (`auto`/`approve`/`chat`/`smart_approve`) governs interactive approval only; no mode confines writes to a directory, and only `auto` is usable unattended. | Nothing — local mode refuses to launch without explicit opt-in | `HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED=1` |
+| `agy` | **None.** Antigravity CLI's execution modes (`default`/`accept-edits`/`plan`) govern approval only, same shape as goose; `--dangerously-skip-permissions` is what hive already passes and there is no lesser mode that confines the filesystem. | Nothing — local mode refuses to launch without explicit opt-in | `HIVE_AGY_DANGEROUSLY_RUN_UNCONFINED=1` |
+| `bob` | **None.** No sandbox, approval mode, or path-restriction mechanism documented anywhere in Bob Shell's own docs. | Nothing — local mode refuses to launch without explicit opt-in | `HIVE_BOB_DANGEROUSLY_RUN_UNCONFINED=1` |
+| `pi` | **None.** `@earendil-works/pi-coding-agent` ships with no sandbox by default; directory confinement exists only via a third-party extension (`pi-permission-modes`) hive does not install or depend on. | Nothing — local mode refuses to launch without explicit opt-in | `HIVE_PI_DANGEROUSLY_RUN_UNCONFINED=1` |
+| `aider` | **None.** No Docker/OS isolation option of any kind. | Nothing — local mode refuses to launch without explicit opt-in | `HIVE_AIDER_DANGEROUSLY_RUN_UNCONFINED=1` |
+
+The five backends with no mechanism (goose, agy, bob, pi, aider) are a hard stop, by design: `just contribute-hive <backend> local` prints an honest refusal and a non-zero exit rather than a silent unconfined launch, unless the operator sets that backend's own escape-hatch env var. This is deliberately not a blanket `HIVE_DANGEROUSLY_RUN_UNCONFINED` — a single shared flag would let opting into one unconfined backend silently opt into all five.
 
 ## Current wiring
 

--- a/src/pkg/dashboard/contribute_local_mode_backend_matrix_test.go
+++ b/src/pkg/dashboard/contribute_local_mode_backend_matrix_test.go
@@ -1,0 +1,339 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #4918 remaining-backend confinement. #5011 closed the gap for claude and
+// litellm only, via Claude Code's native sandbox. This file pins the rest of
+// the backend matrix:
+//
+//   - copilot: has its own OS-enforced sandbox (--sandbox, MXC: Seatbelt on
+//     macOS, bubblewrap on Linux). Wired the same way the claude sandbox is —
+//     gated on the installed CLI actually supporting the flag, with an
+//     explicit dangerous-bypass escape hatch.
+//   - opencode: has NO OS sandbox, but does have a real command-deny
+//     mechanism (permission.bash pattern config) that survives --auto. Wired
+//     as a floor, matching the claude host-state deny-list precedent — and
+//     the local-mode banner must never call this "confined", only
+//     "denylisted", because it is not a filesystem boundary.
+//   - goose, agy, bob, pi, aider: verified against each CLI's own current
+//     docs to have no sandbox, no filesystem allowlist, and no deny
+//     mechanism at all. Local mode for these MUST refuse to launch without
+//     an explicit per-backend HIVE_<BACKEND>_DANGEROUSLY_RUN_UNCONFINED=1 —
+//     an honest refusal, not a silent unconfined launch.
+//
+// backendsConfSource/runBackendsConf below shell out to bash the same way
+// contribute_local_mode_warning_test.go's claudeLocalSandboxArgs does.
+
+func backendsConfSource(t *testing.T) string {
+	t.Helper()
+	return fileSource(t, "config/backends.conf")
+}
+
+// runBackendsConfFunc sources backends.conf, calls fn with args, and returns
+// (stdout, exit code). A non-zero exit is a real failure mode here (the
+// unconfined-backend refusal), not a test-harness error, so callers assert
+// on it rather than treating it as fatal.
+func runBackendsConfFunc(t *testing.T, fn string, args []string, extraEnv ...string) (string, int) {
+	t.Helper()
+	script := "source ../../../config/backends.conf\n" + fn
+	for _, a := range args {
+		script += " " + a
+	}
+	script += "\n"
+	cmd := exec.Command("bash", "-c", script)
+	for _, entry := range os.Environ() {
+		skip := false
+		for _, prefix := range []string{
+			"HIVE_WORKSPACE_DIR=", "HIVE_COPILOT_DANGEROUSLY_",
+			"HIVE_OPENCODE_DANGEROUSLY_", "HIVE_GOOSE_DANGEROUSLY_",
+			"HIVE_AGY_DANGEROUSLY_", "HIVE_BOB_DANGEROUSLY_",
+			"HIVE_PI_DANGEROUSLY_", "HIVE_AIDER_DANGEROUSLY_",
+		} {
+			if strings.HasPrefix(entry, prefix) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			exitCode = ee.ExitCode()
+		} else {
+			t.Fatalf("running %s: %v\n%s", fn, err, out)
+		}
+	}
+	return string(out), exitCode
+}
+
+// ── The five backends with no confinement mechanism at all ─────────────
+
+func TestUnconfinedBackendsRefuseToLaunchByDefault(t *testing.T) {
+	for _, tc := range []struct {
+		backend string
+		envVar  string
+	}{
+		{"goose", "HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED"},
+		{"agy", "HIVE_AGY_DANGEROUSLY_RUN_UNCONFINED"},
+		{"bob", "HIVE_BOB_DANGEROUSLY_RUN_UNCONFINED"},
+		{"pi", "HIVE_PI_DANGEROUSLY_RUN_UNCONFINED"},
+		{"aider", "HIVE_AIDER_DANGEROUSLY_RUN_UNCONFINED"},
+	} {
+		t.Run(tc.backend, func(t *testing.T) {
+			out, code := runBackendsConfFunc(t, "unconfined_local_perm_flag_shell", []string{tc.backend})
+			if code == 0 {
+				t.Fatalf("%s local launch did not refuse without %s; output: %q", tc.backend, tc.envVar, out)
+			}
+			if !strings.Contains(out, "Refusing to launch") {
+				t.Errorf("%s refusal message does not say it refused to launch: %q", tc.backend, out)
+			}
+			if !strings.Contains(out, tc.envVar) {
+				t.Errorf("%s refusal message does not name its own escape hatch %s: %q", tc.backend, tc.envVar, out)
+			}
+			if !strings.Contains(out, "no sandbox") {
+				t.Errorf("%s refusal message does not say honestly that there is no sandbox: %q", tc.backend, out)
+			}
+		})
+	}
+}
+
+func TestUnconfinedBackendsLaunchWithExplicitOptIn(t *testing.T) {
+	for _, tc := range []struct {
+		backend string
+		envVar  string
+	}{
+		{"goose", "HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED"},
+		{"agy", "HIVE_AGY_DANGEROUSLY_RUN_UNCONFINED"},
+		{"bob", "HIVE_BOB_DANGEROUSLY_RUN_UNCONFINED"},
+		{"pi", "HIVE_PI_DANGEROUSLY_RUN_UNCONFINED"},
+		{"aider", "HIVE_AIDER_DANGEROUSLY_RUN_UNCONFINED"},
+	} {
+		t.Run(tc.backend, func(t *testing.T) {
+			_, code := runBackendsConfFunc(t, "unconfined_local_perm_flag_shell", []string{tc.backend}, tc.envVar+"=1")
+			if code != 0 {
+				t.Fatalf("%s local launch still refused with %s=1 set", tc.backend, tc.envVar)
+			}
+		})
+	}
+}
+
+// TestEveryUnconfinedBackendHasItsOwnEscapeHatch guards against a copy-paste
+// slip where two backends share one env var name — that would let opting
+// into one silently opt into another with no confinement either.
+func TestEveryUnconfinedBackendHasItsOwnEscapeHatch(t *testing.T) {
+	seen := map[string]string{}
+	for _, tc := range []struct{ backend, envVar string }{
+		{"goose", "HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED"},
+		{"agy", "HIVE_AGY_DANGEROUSLY_RUN_UNCONFINED"},
+		{"bob", "HIVE_BOB_DANGEROUSLY_RUN_UNCONFINED"},
+		{"pi", "HIVE_PI_DANGEROUSLY_RUN_UNCONFINED"},
+		{"aider", "HIVE_AIDER_DANGEROUSLY_RUN_UNCONFINED"},
+	} {
+		if prior, ok := seen[tc.envVar]; ok {
+			t.Fatalf("escape hatch %s is claimed by both %s and %s", tc.envVar, prior, tc.backend)
+		}
+		seen[tc.envVar] = tc.backend
+	}
+}
+
+// ── copilot: real OS-enforced sandbox, gated on CLI support ────────────
+
+func TestCopilotLocalSandboxWiredWhenCLISupportsIt(t *testing.T) {
+	fakeBin := t.TempDir()
+	writeFakeCopilot(t, fakeBin, "--sandbox is a real flag\n--add-dir <path>\n")
+
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, code := runBackendsConfFunc(t, "copilot_local_perm_flag_shell", nil,
+		"PATH="+fakeBin+":"+os.Getenv("PATH"), "HIVE_WORKSPACE_DIR="+workspace)
+	if code != 0 {
+		t.Fatalf("copilot local sandbox wiring failed: %q", out)
+	}
+	if !strings.Contains(out, "--sandbox") {
+		t.Fatalf("copilot local argv missing --sandbox: %q", out)
+	}
+	if strings.Contains(out, "WARNING") {
+		t.Fatalf("unexpected fallback warning with a CLI that supports --sandbox: %q", out)
+	}
+}
+
+func TestCopilotLocalSandboxFallsBackWhenCLILacksFlag(t *testing.T) {
+	fakeBin := t.TempDir()
+	writeFakeCopilot(t, fakeBin, "an old copilot CLI with no sandbox support\n")
+
+	out, code := runBackendsConfFunc(t, "copilot_local_perm_flag_shell", nil,
+		"PATH="+fakeBin+":"+os.Getenv("PATH"))
+	if code != 0 {
+		t.Fatalf("copilot fallback path should not itself fail: %q", out)
+	}
+	if !strings.Contains(out, "WARNING") || !strings.Contains(out, "--sandbox") {
+		t.Fatalf("old-CLI fallback did not warn honestly about the missing flag: %q", out)
+	}
+	// The warning text itself names the missing --sandbox flag, so check the
+	// EMITTED ARGV (the last line) rather than the whole output for the flag.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	argvLine := lines[len(lines)-1]
+	if strings.Contains(argvLine, "--sandbox") {
+		t.Fatalf("fallback argv must not claim --sandbox when the installed CLI does not support it: %q", argvLine)
+	}
+	if !strings.Contains(argvLine, "--allow-all") {
+		t.Fatalf("fallback argv should be the plain unconfined copilot posture: %q", argvLine)
+	}
+}
+
+func TestCopilotLocalSandboxExplicitBypassSkipsTheCLIProbe(t *testing.T) {
+	fakeBin := t.TempDir()
+	writeFakeCopilot(t, fakeBin, "an old copilot CLI with no sandbox support\n")
+
+	out, code := runBackendsConfFunc(t, "copilot_local_perm_flag_shell", nil,
+		"PATH="+fakeBin+":"+os.Getenv("PATH"), "HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX=1")
+	if code != 0 {
+		t.Fatalf("explicit bypass should not fail: %q", out)
+	}
+	if strings.Contains(out, "WARNING") {
+		t.Fatalf("explicit bypass should not also print the unsolicited warning: %q", out)
+	}
+}
+
+func writeFakeCopilot(t *testing.T, dir, helpOutput string) {
+	t.Helper()
+	path := filepath.Join(dir, "copilot")
+	script := "#!/usr/bin/env bash\nif [[ \"$1\" == \"--help\" ]]; then cat <<'EOF'\n" + helpOutput + "EOF\nexit 0\nfi\nexit 0\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ── opencode: command deny-list, not a sandbox ──────────────────────────
+
+func TestOpencodeLocalModeDeniesHostStateCommands(t *testing.T) {
+	out, code := runBackendsConfFunc(t, "opencode_local_perm_flag_shell", nil)
+	if code != 0 {
+		t.Fatalf("opencode local deny-list wiring failed: %q", out)
+	}
+	if !strings.Contains(out, "OPENCODE_PERMISSION=") {
+		t.Fatalf("opencode argv missing OPENCODE_PERMISSION: %q", out)
+	}
+	if !strings.Contains(out, "--auto") {
+		t.Fatalf("opencode argv missing --auto: %q", out)
+	}
+
+	// Unquote the shell-escaped output the same way the real consumers do
+	// (tmux send-keys / heredoc re-parse): `eval "set -- $out"`. Written to a
+	// script file, rather than interpolated into a -c string, so the JSON's
+	// own quoting cannot collide with Go's command-string construction.
+	script := filepath.Join(t.TempDir(), "unquote.sh")
+	if err := os.WriteFile(script, []byte("out='"+strings.ReplaceAll(out, "'", `'\''`)+"'\neval \"set -- $out\"\nprintf '%s\\0' \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unquoteCmd := exec.Command("bash", script)
+	raw, err := unquoteCmd.Output()
+	if err != nil {
+		t.Fatalf("unquote opencode local argv: %v", err)
+	}
+	words := strings.Split(string(raw), "\x00")
+	words = words[:len(words)-1]
+	var permJSON string
+	for _, w := range words {
+		if strings.HasPrefix(w, "OPENCODE_PERMISSION=") {
+			permJSON = strings.TrimPrefix(w, "OPENCODE_PERMISSION=")
+		}
+	}
+	if permJSON == "" {
+		t.Fatalf("OPENCODE_PERMISSION assignment not found among unquoted words: %q", words)
+	}
+	// Confirm it actually denies the same host-state family the claude list
+	// covers, and does not deny everything (which would just be a
+	// differently-shaped unconfined refusal).
+	var perm struct {
+		Bash map[string]string `json:"bash"`
+	}
+	if err := json.Unmarshal([]byte(permJSON), &perm); err != nil {
+		t.Fatalf("OPENCODE_PERMISSION is not valid JSON: %v\n%s", err, permJSON)
+	}
+	if perm.Bash["*"] != "allow" {
+		t.Errorf(`expected catch-all "*" to be "allow" (deny-list, not allow-list), got %q`, perm.Bash["*"])
+	}
+	for _, pattern := range []string{"sudo *", "pkexec *", "rpm-ostree *", "bootc *"} {
+		if perm.Bash[pattern] != "deny" {
+			t.Errorf("expected opencode permission.bash to deny %q, got %q", pattern, perm.Bash[pattern])
+		}
+	}
+}
+
+func TestOpencodeHostStateOptOutDropsTheDenyList(t *testing.T) {
+	out, code := runBackendsConfFunc(t, "opencode_local_perm_flag_shell", nil,
+		"HIVE_OPENCODE_DANGEROUSLY_ALLOW_HOST_STATE=1")
+	if code != 0 {
+		t.Fatalf("opencode opt-out should not fail: %q", out)
+	}
+	if strings.Contains(out, "OPENCODE_PERMISSION=") {
+		t.Fatalf("explicit host-state opt-out should drop the deny-list entirely: %q", out)
+	}
+}
+
+// TestLocalModeBannerNeverCallsOpencodeConfined pins the honesty requirement
+// directly: the banner text must distinguish opencode's command-deny floor
+// from an actual sandbox, using the same distinct-message contract
+// TestLocalModeDistinguishesConfinedAndUnconfinedBackends already pins for
+// claude/codex.
+func TestLocalModeBannerNeverCallsOpencodeConfined(t *testing.T) {
+	block := contributeHiveLocalBranch(t)
+	for _, want := range []string{
+		`_LOCAL_POSTURE="denylisted"`,
+		"opencode has no OS sandbox and no filesystem write-allowlist",
+		"not a boundary",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("local-mode posture branch does not contain %q", want)
+		}
+	}
+}
+
+// TestLocalModeBannerNamesCopilotSandbox pins that copilot gets the
+// "sandboxed" banner branch, backed by its own --sandbox flag, not lumped in
+// with the generic unconfined warning.
+func TestLocalModeBannerNamesCopilotSandbox(t *testing.T) {
+	block := contributeHiveLocalBranch(t)
+	for _, want := range []string{
+		"copilot)",
+		"HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX",
+		"Seatbelt on macOS",
+		"bubblewrap on Linux",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("local-mode posture branch does not contain %q", want)
+		}
+	}
+}
+
+// TestBackendsConfDocumentsWhyFiveBackendsHaveNoWiring guards the honesty
+// requirement at the source: the "no confinement mechanism at all" block
+// must exist and must not silently shrink to fewer than the five backends
+// it names today.
+func TestBackendsConfDocumentsWhyFiveBackendsHaveNoWiring(t *testing.T) {
+	src := backendsConfSource(t)
+	for _, want := range []string{
+		"goose, agy, bob, pi, and aider expose no OS-level sandbox",
+		"unconfined_local_backend_env_var",
+		"unconfined_local_perm_flag_shell",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("config/backends.conf no longer documents %q", want)
+		}
+	}
+}

--- a/src/pkg/dashboard/contribute_local_mode_warning_test.go
+++ b/src/pkg/dashboard/contribute_local_mode_warning_test.go
@@ -10,9 +10,14 @@ import (
 )
 
 // #4918: `just contribute-hive <backend> local` runs the backend CLI as the
-// contributor's own user, on their own machine. Claude-family agents now use
-// Claude Code's native OS sandbox on that path, Codex retains its own sandbox,
-// and backends without a sandbox still warn plainly that they are unconfined.
+// contributor's own user, on their own machine. Claude/litellm, codex, and
+// copilot now use a native OS-enforced sandbox on that path; opencode gets a
+// command-name deny-list (a floor, not a boundary) via its own permission
+// config; goose, agy, bob, pi, and aider have no confinement mechanism this
+// repo can wire at all and REFUSE to launch locally without an explicit
+// per-backend opt-in env var. See contribute_local_mode_backend_matrix_test.go
+// for the tests covering the five refuse-to-launch backends, copilot's
+// sandbox gating, and opencode's deny-list.
 //
 // What the silence cost: an agent doing entirely correct work on an assigned
 // third-party repo ran that repo's own test suite; a latent defect in two of
@@ -47,7 +52,7 @@ func TestLocalModeDistinguishesConfinedAndUnconfinedBackends(t *testing.T) {
 	block := contributeHiveLocalBranch(t)
 
 	for _, want := range []string{
-		"claude|litellm", "codex)", "_LOCAL_WRITE_CONFINED=true",
+		"claude|litellm", "codex)", `_LOCAL_POSTURE="sandboxed"`,
 		"workspace write confinement is enabled", "NOT confined",
 	} {
 		if !strings.Contains(block, want) {


### PR DESCRIPTION
## Summary

Advances #4918. #5011 closed the host-confinement gap for `claude`/`litellm` only, via Claude Code's native OS sandbox. This closes it for the rest of the backend matrix on `just contribute-hive <backend> local` — the path where the original incident happened (a contributor's real desktop, no container boundary).

## Per-backend outcome

| Backend | Mechanism | Verified how |
|---|---|---|
| `claude` / `litellm` | Claude Code native sandbox (unchanged, from #5011) | pre-existing tests |
| `codex` | `workspace-write` sandbox (unchanged) | pre-existing tests |
| `copilot` | **New.** Copilot CLI's own `--sandbox` (OS-enforced: Seatbelt/bubblewrap/ProcessContainer) | `copilot --help` grep-probed at launch to confirm the installed CLI actually supports the flag (copilot-cli >= 1.0.60, confirmed via changelog); falls back with a loud warning, or `HIVE_COPILOT_DANGEROUSLY_BYPASS_SANDBOX=1`, if not. New Go tests exercise both branches against a fake `copilot` binary. |
| `opencode` | **New.** Host-state command deny-list via opencode's real `permission.bash` config, delivered as inline `OPENCODE_PERMISSION` JSON | Confirmed against opencode's own docs that explicit `deny` rules hold under `--auto`. New tests unquote the generated argv and assert the deny/allow JSON shape. **Honestly labeled a floor, not a sandbox** — opencode has no OS-level filesystem boundary of its own. |
| `goose` | **None available.** `GOOSE_MODE` (auto/approve/chat/smart_approve) governs interactive approval only; no mode confines filesystem writes | Local mode now **refuses to launch** without `HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED=1` |
| `agy` | **None available.** Execution modes (default/accept-edits/plan) govern approval only, same shape as goose | Refuses without `HIVE_AGY_DANGEROUSLY_RUN_UNCONFINED=1` |
| `bob` | **None available.** No sandbox/approval/path-restriction mechanism documented anywhere in Bob Shell's docs | Refuses without `HIVE_BOB_DANGEROUSLY_RUN_UNCONFINED=1` |
| `pi` | **None available.** Ships with no sandbox by default; confinement exists only via a third-party extension hive doesn't depend on | Refuses without `HIVE_PI_DANGEROUSLY_RUN_UNCONFINED=1` |
| `aider` | **None available.** No Docker/OS isolation option of any kind | Refuses without `HIVE_AIDER_DANGEROUSLY_RUN_UNCONFINED=1` |

Each of the five refusal backends has its own escape-hatch env var (never a shared flag), so opting one in can never silently opt another in — pinned by `TestEveryUnconfinedBackendHasItsOwnEscapeHatch`.

## What this does NOT claim

`goose`, `agy`, `bob`, `pi`, and `aider` remain genuinely unconfined if an operator sets their escape hatch — that is by design, not an oversight. This PR does not add a sandbox that doesn't exist; it makes the absence loud and requires explicit consent instead of a silent unconfined launch, per the issue's own preference ("an honest 'this backend is unconfined, set X=true to proceed anyway' is far better than a sandbox flag that silently does nothing").

`opencode`'s deny-list is real (verified against its docs to survive `--auto`) but is explicitly documented, in code comments, the CHANGELOG, and both design docs, as a command-name floor rather than a filesystem boundary — the same honesty distinction #4938's original claude deny-list already established.

## Where the existing docs overclaimed before this change

`src/docs/sandbox-isolation.md` and `src/docs/design/agent-host-confinement.md` both described a two-way split ("Claude/LiteLLM and Codex are write-confined locally; other backends are not") that collapsed six very different postures (real sandbox, deny-list-only, and five backends with literally nothing) into one undifferentiated "not confined" bucket. Both docs are updated with a full per-backend matrix; `agent-host-confinement.md`'s stale status line and now-partially-stale hub-Podman recommendation are annotated rather than deleted, preserving it as the historical investigation record it says it is.

## Verification

- `bash bin/contributor-agent.test.sh` — passes (unchanged suite)
- `bash -n config/backends.conf`, `just --list` (Justfile parses)
- `go build ./...`, `go vet ./pkg/dashboard/... ./pkg/config/...`, `gofmt -l` on touched files — clean
- `go test ./pkg/dashboard/... ./pkg/config/...` — passes, including:
  - the existing `TestShellAndGoCLIBackendListsAgree` / `TestBackendBinaryAndPermFlagCoverKnownBackends` parity guards (untouched, still green — `opencode` still in both `KNOWN_BACKENDS` and `CLIBackends`)
  - new `contribute_local_mode_backend_matrix_test.go`: refusal behavior for all five unconfined backends (default-refuses, opt-in launches, distinct env vars), copilot sandbox gating (wired when CLI supports `--sandbox`, warns and falls back when it doesn't, explicit bypass skips the probe), opencode's deny-list JSON shape, and banner-text assertions that opencode is never called "confined"
- Live end-to-end run: `just contribute-hive goose local` refuses with the documented message and exit 1; `HIVE_GOOSE_DANGEROUSLY_RUN_UNCONFINED=1 just contribute-hive goose local` proceeds past that point
- `git diff --check` — no whitespace issues
- Manually confirmed `src/pkg/agent/manager.go`, `host_state_deny_test.go`, and `backend_list_parity_test.go` are untouched by this diff

`### Security` entry added to `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)