### PR TITLE
📖 docs(readme): drop stale v2 labels from hub deploy and config sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Teardown: `bin/hive-podman-teardown.sh`.
 
 The [Hive Hub](https://hive.kubestellar.io) provides hosted hives with OAuth-protected dashboards, a public registry, and cross-hive leaderboards. No cluster required.
 
-If you need to run your own private hub instead, see the v2
+If you need to run your own private hub instead, see the
 [self-hosted hub deployment guide](src/docs/hub-deployment.md).
 
 ### Self-Hosted Deployment
@@ -412,7 +412,7 @@ kubectl apply -f src/deploy/k8s/service.yaml
 
 ## Configuration
 
-All v2 runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [src/hive.yaml.example](src/hive.yaml.example) for the full reference, [src/docs/env-vars.md](src/docs/env-vars.md) for the centralized environment variable reference, [src/docs/agent-configuration.md](src/docs/agent-configuration.md) for agent configuration, [src/AGENT-DEFINITION.md](src/AGENT-DEFINITION.md) for the portable agent YAML format, [src/docs/supervisor.md](src/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration, and [src/docs/migration-v2-v4.md](src/docs/migration-v2-v4.md) for upgrading a v2 deployment to v4.
+All runtime config lives in a single `hive.yaml`. Environment variables are interpolated with `${VAR}` syntax. See [src/hive.yaml.example](src/hive.yaml.example) for the full reference, [src/docs/env-vars.md](src/docs/env-vars.md) for the centralized environment variable reference, [src/docs/agent-configuration.md](src/docs/agent-configuration.md) for agent configuration, [src/AGENT-DEFINITION.md](src/AGENT-DEFINITION.md) for the portable agent YAML format, [src/docs/supervisor.md](src/docs/supervisor.md) for the supervisor agent, [docs/backend-setup.md](docs/backend-setup.md) for CLI backends, [docs/inference-backends.md](docs/inference-backends.md) for model gateways, [docs/migration-v1-v2.md](docs/migration-v1-v2.md) for v1→v2 migration, and [src/docs/migration-v2-v4.md](src/docs/migration-v2-v4.md) for upgrading a v2 deployment to v4.
 
 The top-level deterministic shell pipeline uses a separate project file,
 `config/hive-project.yaml.example`; see [config/README.md](config/README.md)


### PR DESCRIPTION
Fixes #5027

## What

Removes two stale `v2` labels from `README.md`:

| Line | Before | After |
|---|---|---|
| 262 | "see the **v2** self-hosted hub deployment guide" | "see the self-hosted hub deployment guide" |
| 415 | "All **v2** runtime config lives in a single `hive.yaml`" | "All runtime config lives in a single `hive.yaml`" |

## Why

Both are holdovers from before the v2→v4 migration.

`src/docs/hub-deployment.md` is **version-agnostic** — it mentions neither `v2` nor `v4`. So the label is not merely outdated, it is actively misleading: an operator evaluating a self-hosted hub reads "v2", assumes the guide is retired, and goes looking for a v4-specific one that does not exist. This is a high-visibility line in the main README.

The config-section instance at line 415 is the same defect. #5027 reported only the hub-deployment line; both are fixed here.

## Deliberately unchanged

- Line 28 — **Compose v2** (third-party version)
- Line 82 — **cgroup v2** (third-party version)
- Line 415's `migration-v1-v2.md` / `migration-v2-v4.md` links, which correctly name the versions they migrate between

Docs only.