### PR TITLE
📖 docs(development): document how to run the inception integration suite

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -46,7 +46,24 @@ cd src
 go test ./...
 ```
 
-The `src/test/` package contains integration/regression coverage and may exercise local ports, temporary state, and helper processes. If a local environment dependency prevents a full run, include the failing package and error summary in the PR and still run the narrower package tests affected by your change.
+The `src/test/` package holds the inception e2e/regression suite. Those tests
+talk to a **live hive over the network** and sit behind the `integration` build
+tag, so the command above compiles the package but runs none of them — a plain
+`go test ./...` will never exercise this suite, and a green run says nothing
+about it. To actually run it:
+
+```bash
+cd src
+HIVE_URL=http://<host>:<port> HIVE_TOKEN=<token> go test -tags integration ./test/...
+```
+
+The suite skips itself (exit 0) when `HIVE_URL` is unset or the endpoint does
+not answer a fast TCP dial, so a passing run without those variables means
+"skipped", not "verified". Run it when you touch inception code; the normal
+`go test ./pkg/...` loop is enough otherwise. See `src/test/doc.go` for the
+package's own description.
+
+If a local environment dependency prevents a full run, include the failing package and error summary in the PR and still run the narrower package tests affected by your change.
 
 Useful narrower loops:
 


### PR DESCRIPTION
Fixes #5029

## What

`docs/development.md` described `src/test/` as integration coverage that "may exercise local ports, temporary state, and helper processes." That is vague enough to imply the documented `go test ./...` covers it.

**It does not.** The suite sits behind `//go:build integration`, so that command compiles the package and runs nothing.

## Why it matters

The failure mode is silent success. `go test ./...` goes green having executed none of these tests. And even with the tag set, the suite skips itself (exit 0) when `HIVE_URL` is unset or the endpoint does not answer a fast TCP dial — so a contributor touching inception code can believe they verified their change when they ran nothing.

## One correction to the issue

#5029 says these tests "have no documentation." That is not quite right — `src/test/doc.go` already documents the build tag, env vars, invocation, and skip behavior accurately.

The real gap is **discoverability**: neither `docs/development.md` nor `docs/getting-started-contributing.md` mentions `-tags integration`, so a contributor reading the contributor docs never learns `doc.go` exists. This PR closes that path rather than duplicating what is already written.

## Verified against source

- `//go:build integration` — present in `src/test/inception_e2e_test.go`
- `HIVE_URL`, `HIVE_TOKEN` — the only `HIVE_*` variables the suite reads

Docs only.