### PR TITLE
docs: add agent sandbox confinement section to getting-started guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ## Unreleased
 
+### Changed
+
+- `src/docs/getting-started.md`, the primary operator onboarding doc, now includes a "Where agents actually run" section ahead of L3, covering the host-tmux default, the per-backend confinement matrix from [#5024](https://github.com/kubestellar/hive/pull/5024), the `HIVE_<BACKEND>_DANGEROUSLY_RUN_UNCONFINED` escape hatches, and the hub-side `agent_sandbox` two-gate requirement — with a link to [sandbox-isolation.md](src/docs/sandbox-isolation.md) for the full picture. Previously the guide had zero mentions of sandboxing, confinement, or the security implications of running agents unconfined on a host ([#5028](https://github.com/kubestellar/hive/issues/5028)).
+
 ### Added
 
 - `opencode` (`anomalyco/opencode`) as a contributor-relay CLI backend ([#4970](https://github.com/kubestellar/hive/issues/4970)). It joins `KNOWN_BACKENDS`/`config.CLIBackends` and dispatches through headless one-shot mode (`opencode run "<prompt>" --model provider/model --auto`, `CONTRIBUTOR_MODE=headless`) rather than the interactive tmux keystroke path, since `opencode run` is the CLI's natural non-interactive entry point. opencode is provider-agnostic (75+ providers) and unconfined (no OS sandbox of its own, like goose/pi/bob); `--auto` is its unattended auto-approve flag. It is not yet in `just contribute-k8s`'s headless-pod allowlist pending verification that `opencode auth login`'s credential (`~/.local/share/opencode/auth.json`) supports unattended use in a fresh pod. Relay-only: this does not add hub-side pod-launcher support beyond what the shell/Go backend-list parity guard ([#4987](https://github.com/kubestellar/hive/pull/4987)) already requires.

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -219,6 +219,26 @@ New users often expect PRs at L2 (they don't happen) or are surprised when they 
 
 > 💡 **Tip: customize before you escalate.** Before moving from L3 to L4, take 30 minutes to edit each agent's policy template. Add your coding conventions, your preferred test framework, your off-limits directories. Agents follow instructions literally — the more specific you are, the better the output.
 
+### 🔒 Where agents actually run (read this before L3)
+
+By L3, agents are writing code and running commands on your behalf — so it's worth knowing exactly where that happens. On the contributor path (`just contribute-hive <backend>`), agents run in a **tmux session on the host** by default: the backend CLI runs as your own user, with permission prompts bypassed, and nothing containing it to the assigned workspace unless the backend provides its own confinement.
+
+**Confinement is not the same for every backend.** As of this writing:
+
+| Backend | Confined? |
+|---|---|
+| `claude` / `litellm` | Yes — Claude Code's native OS sandbox |
+| `codex` | Yes — its own `workspace-write` sandbox |
+| `copilot` | Yes — Copilot CLI's own `--sandbox`, checked at launch |
+| `opencode` | Partial — a command deny-list only, **not** a filesystem sandbox |
+| `goose`, `agy`, `bob`, `pi`, `aider` | No — these backends have no confinement mechanism at all. Local mode **refuses to launch** for them unless you explicitly set that backend's own `HIVE_<BACKEND>_DANGEROUSLY_RUN_UNCONFINED=1` |
+
+If you see one of those `_DANGEROUSLY_RUN_UNCONFINED` variables mentioned in setup instructions, it means exactly what it says: that backend has no sandbox, and setting the variable is you accepting that the agent runs with full access to your machine. Prefer container mode (drop `local` from the command) or a confined/denylisted backend if you're running hive on a machine you care about.
+
+This matters beyond backend choice, too: the hub-side Podman sandbox (`agent_sandbox`) is a separate, opt-in mechanism, and enabling it requires setting **both** the global `agent_sandbox.enabled` flag **and** a per-agent `sandbox.enabled` flag — the dashboard's Security tab only writes the global one, so turning that toggle on by itself does not sandbox any agent.
+
+See [sandbox-isolation.md](sandbox-isolation.md) for the full threat model, the complete per-backend matrix, and the hub-side sandbox setup.
+
 ## L4 — Issues and Security
 
 **The level:** You're trusting agents to *file issues on their own* and trusting sec-check to propose security fixes — still all hold-labeled.


### PR DESCRIPTION
## Summary

`src/docs/getting-started.md`, the primary operator onboarding doc, had zero mentions of agent sandbox isolation, confinement, or the security implications of running agents unconfined on a host (`grep -ci sandbox\|confin\|isolation` = 0). This is the documentation counterpart to #4918, the incident where an unconfined agent reached a contributor's host bootloader.

## What changed

Adds a new "🔒 Where agents actually run (read this before L3)" section, placed immediately after L3 (Build Your Safety Net) and before L4 — the point where agents move from suggesting to writing code and opening PRs, matching the issue's own recommendation for placement.

The section covers:

1. Agents run in tmux sessions **on the host** by default on the contributor path (`just contribute-hive <backend>`).
2. A per-backend confinement table, matching the merged state of #5024 exactly:

| Backend | Confined? |
|---|---|
| `claude` / `litellm` | Yes — Claude Code's native OS sandbox |
| `codex` | Yes — its own `workspace-write` sandbox |
| `copilot` | Yes — Copilot CLI's own `--sandbox`, checked at launch |
| `opencode` | Partial — a command deny-list only, **not** a filesystem sandbox |
| `goose`, `agy`, `bob`, `pi`, `aider` | No confinement mechanism at all — local mode refuses to launch without an explicit per-backend `HIVE_<BACKEND>_DANGEROUSLY_RUN_UNCONFINED=1` |

3. What the `HIVE_<BACKEND>_DANGEROUSLY_RUN_UNCONFINED` escape hatches mean, and a nudge toward container mode / confined backends on a machine you care about.
4. The hub-side `agent_sandbox` two-gate requirement — global `agent_sandbox.enabled` **and** per-agent `sandbox.enabled`, and that the dashboard's Security tab only writes the global flag. This is verified directly against `AgentConfig.SandboxEnabled` in `src/pkg/config/config.go`, not assumed from the issue text.
5. A link to `sandbox-isolation.md` for the full threat model and per-backend matrix — this section is a path to that doc, not a duplicate of it.

A `### Changed` entry is added to `CHANGELOG.md` (existing `### Added` entries above it are left untouched).

## Verification

- Confirmed the per-backend matrix against #5024's merged diff (PR body table + the actual `sandbox-isolation.md` diff hunk it shipped), not the issue's summary.
- Confirmed the "two gates" claim by reading `AgentConfig.SandboxEnabled` and the adjacent `AgentSandboxGateWarnings` doc comment in `src/pkg/config/config.go` — both gates (`agent_sandbox.enabled` global + per-agent `sandbox.enabled`) are required, and the doc comment independently confirms the dashboard Security tab writes only the global flag.
- Docs-only change — no code, config, or CI touched.

Fixes #5028

🐝