### PR TITLE
🐛 fix(contributor): link claude-code's native binary in the container image

### DIFF
--- a/src/Dockerfile.contributor
+++ b/src/Dockerfile.contributor
@@ -56,11 +56,30 @@ RUN mkdir -p /etc/apt/keyrings \
 # diff, mirroring the cleanup already done for the bobshell install below.
 ARG CLAUDE_CODE_VERSION=2.1.226
 ARG COPILOT_VERSION=1.0.59
+# --ignore-scripts (kept, deliberately: no arbitrary postinstall runs during
+# the build) skips claude-code's install.cjs, which is what LINKS the platform
+# native binary into the package's bin/. Without the link every invocation in
+# the container dies with:
+#
+#     Error: claude native binary not installed.
+#
+# i.e. the claude backend is unusable in container mode while local mode works
+# fine — observed live on a contributor's first `just contribute-hive claude`.
+# Run the vendor's own install step explicitly, exactly as src/Dockerfile
+# Layer 7 already does for the spoke image: still auditable (one named script,
+# not "whatever any dependency wants"), and it writes into the global package
+# dir, so the fix applies to every user rather than one $HOME. The path is
+# resolved via `npm root -g` because this image installs Node from NodeSource
+# debs, whose global root differs from the node base image src/Dockerfile uses.
+# `claude --version` makes the build itself fail loudly if the link is missing,
+# instead of every contributor task failing at runtime.
 RUN npm install -g --ignore-scripts --no-fund --no-audit \
     @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
     @github/copilot@${COPILOT_VERSION} \
     @openai/codex@0.146.0 \
-  && npm cache clean --force
+  && npm cache clean --force \
+  && node "$(npm root -g)/@anthropic-ai/claude-code/install.cjs" \
+  && claude --version
 
 # Install bobshell (IBM "bob"). Mirrors Layer 9 of src/Dockerfile so the
 # containerized contributor relay can actually run the bob backend — without

--- a/src/pkg/config/dockerfile_contributor_test.go
+++ b/src/pkg/config/dockerfile_contributor_test.go
@@ -27,3 +27,26 @@ func TestContributorDockerfileInstallsPiWithoutCurlPipeShell(t *testing.T) {
 		}
 	}
 }
+
+// The image installs claude-code with --ignore-scripts (deliberately — no
+// arbitrary postinstall runs during the build), but that also skips the
+// package's install.cjs, which links the platform-native binary into bin/.
+// Without an explicit postinstall + verification, `claude` in the container
+// dies with "claude native binary not installed" on every task while local
+// mode works fine. src/Dockerfile Layer 7 fixed this for the spoke image;
+// this pins the contributor image's copy of the same fix.
+func TestContributorDockerfileLinksClaudeNativeBinary(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "Dockerfile.contributor"))
+	if err != nil {
+		t.Fatalf("read Dockerfile.contributor: %v", err)
+	}
+	dockerfile := string(body)
+	for _, want := range []string{
+		`node "$(npm root -g)/@anthropic-ai/claude-code/install.cjs"`,
+		"claude --version",
+	} {
+		if !strings.Contains(dockerfile, want) {
+			t.Fatalf("Dockerfile.contributor missing %q — claude's native binary is not linked (or not verified) at build time, so container-mode claude fails at runtime with 'claude native binary not installed'", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **What broke.** Container-mode contributing with the claude backend (`just contribute-hive claude` — the default, recommended, sandboxed mode) fails on the very first launch: the pane shows `Error: claude native binary not installed.` and no task ever runs. Local mode works fine, which makes the failure look like a machine problem rather than what it is — an image build defect.
- **Why.** `Dockerfile.contributor` installs claude-code with `npm install -g --ignore-scripts`. That flag is deliberate (no arbitrary postinstall runs during the build), but it also skips claude-code's own `install.cjs`, which is what links the platform-native binary into the package's `bin/`. Newer claude-code versions require that link; without it the CLI refuses to start.
- **The fix, already proven elsewhere in this repo.** `src/Dockerfile` Layer 7 hit and fixed exactly this for the spoke image: keep `--ignore-scripts`, then run the one named vendor script explicitly — still auditable, applies to every user in the image rather than one `$HOME`. This ports that fix, with one adaptation: the path is resolved via `npm root -g`, because the contributor image installs Node from NodeSource debs whose global root differs from the node base image the spoke Dockerfile uses.
- **Build-time guard.** `claude --version` runs in the same layer, so if the link is ever missing again the **image build** fails loudly instead of every contributor's first task failing at runtime.
- **Blast radius.** Contributor image only. Copilot/codex in the same `npm install` line are unaffected (verified — both worked in the broken image; only claude needs the native-binary link).

## Reproduction and verification

Reproduced in a throwaway build on the image's exact base (`debian:bookworm-slim` + NodeSource Node 24, claude-code `2.1.226`):

```
STEP: npm install -g --ignore-scripts ... @anthropic-ai/claude-code@2.1.226
STEP: claude --version
  Error: claude native binary not installed.        ← the reported failure, byte-for-byte
STEP: node "$(npm root -g)/@anthropic-ai/claude-code/install.cjs" && claude --version
  FIX VERIFIED
```

Observed live first: a contributor's `just contribute-hive claude` (image `ghcr.io/kubestellar/hive-contributor:latest`) died with the identical error in the tmux pane.

Regression test: `TestContributorDockerfileLinksClaudeNativeBinary` in `src/pkg/config/dockerfile_contributor_test.go`, following the existing Dockerfile-pinning test in that file. Mutation-checked — reverting the Dockerfile change fails the test with a message naming the runtime consequence.

`go test ./pkg/config/ -run TestContributorDockerfile` — both tests pass.

## Note for deployment

The fix reaches contributors when CI rebuilds `hive-contributor:latest` from this. Until then, container-mode claude stays broken on the published image; local mode is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)