### PR TITLE
✨ tui T4: client — list agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 - Interactive contributor relays now revoke task-scoped GitHub credentials, double-interrupt only their configured tmux pane, and relaunch a clean backend before advertising `ready` after a task revoke ([#5041](https://github.com/kubestellar/hive/issues/5041)). A failed relaunch remains unavailable instead of overlapping another assignment.
 
 ### Added
+- `hive tui`'s API client gains `Client.Agents(ctx)`, decoding `GET /api/agents` into a new `client.Agent` type (`name`, `id`, `displayName`, `enabled`, `managed`, `backend`, `model`) — the TUI's agent-list read path (T4 of [#4907](https://github.com/kubestellar/hive/issues/4907), [#5053](https://github.com/kubestellar/hive/issues/5053)). The design doc's contract gap this task was filed against ([#4912](https://github.com/kubestellar/hive/issues/4912)) is closed: [#5023](https://github.com/kubestellar/hive/pull/5023) added `/api/agents` to `dashboard/openapi.json`, and its shape matches the `handleAgentsList` handler field-for-field, so no fields were invented or guessed from the live response.
+
 - `kilo` (`Kilo-Org/kilocode`) as a headless contributor-relay backend ([#5038](https://github.com/kubestellar/hive/issues/5038)). It uses Kilo's distinct `kilo run` surface with `--auto` and optional `--model provider/model`; credentials/config flow only through `KILO_AUTH_CONTENT`, `KILO_CONFIG_CONTENT`, `KILO_API_KEY`, and optional `KILO_ORG_ID`, never a whole Kilo config mount. Kilo is headless-only and remains outside the Kubernetes allowlist pending independent credential and confinement verification.
 
 

--- a/src/pkg/tui/client/agents.go
+++ b/src/pkg/tui/client/agents.go
@@ -1,0 +1,62 @@
+package client
+
+import "context"
+
+// Agent is one entry from GET /api/agents.
+//
+// Fields are transcribed from the dashboard handler, pkg/dashboard/api_agents.go
+// (handleAgentsList / agentListEntry), which the published spec now matches
+// exactly (kubestellar/hive#5023 widened dashboard/openapi.json from 32
+// documented operations to 255 paths, and /api/agents is one of them — the
+// design doc's §2.1 gap this task was filed against is now closed). Both
+// sources agree field-for-field; nothing here is invented or guessed from the
+// live response.
+//
+// Two things the design doc's contract table implied this struct might need —
+// a "last activity" timestamp and a running/paused/idle status string — are
+// NOT part of this payload. handleAgentsList only ever sets Name, ID,
+// DisplayName, Enabled, Managed, Backend and Model; activity and live state
+// live elsewhere (e.g. /api/status), not here. A future task that needs those
+// fields renders from a different endpoint rather than this struct growing
+// fields the server never sends.
+type Agent struct {
+	// Name is the agent's config key — what hivectl and the dashboard use to
+	// address it in every other endpoint (/api/pause/{name}, /api/kick/{name},
+	// /api/config/agent/{name}, ...).
+	Name string `json:"name"`
+
+	// ID is the agent's stable identifier, distinct from Name (agentListEntry.ID
+	// is populated from cfg.ID, not derived from the map key).
+	ID string `json:"id"`
+
+	// DisplayName is the human-facing label. The handler falls back to Name
+	// when the config has none, but still marshals it with `omitempty` — so an
+	// agent whose config carries no display name at all can (in principle)
+	// arrive as an empty string on the wire; callers should fall back to Name
+	// exactly as the handler does when this is empty.
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Enabled reports whether the agent is turned on in config.
+	Enabled bool `json:"enabled"`
+
+	// Managed is true for CRUD-created agents, false for base/pack-defined
+	// agents — the latter cannot be deleted (see handleAgentDelete).
+	Managed bool `json:"managed"`
+
+	// Backend is the agent's configured backend, e.g. "claude", "copilot",
+	// "codex".
+	Backend string `json:"backend"`
+
+	// Model is the agent's configured model.
+	Model string `json:"model"`
+}
+
+// Agents lists every configured agent (managed and pack-defined) with its
+// core identity and current backend/model, from GET /api/agents.
+func (c *Client) Agents(ctx context.Context) ([]Agent, error) {
+	var agents []Agent
+	if err := c.getJSON(ctx, "/api/agents", &agents); err != nil {
+		return nil, err
+	}
+	return agents, nil
+}

--- a/src/pkg/tui/client/agents_test.go
+++ b/src/pkg/tui/client/agents_test.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAgentsDecodesFixture decodes the full testdata/agents.json fixture and
+// asserts every field on every entry, including the zero-value cases: an
+// agent whose config has no display name (handler falls back to Name but
+// still marshals `omitempty`, so the wire can legitimately omit it) and an
+// agent that is disabled.
+func TestAgentsDecodesFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "agents.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Agents(context.Background())
+	if err != nil {
+		t.Fatalf("Agents() = %v, want nil", err)
+	}
+
+	if gotPath != "/api/agents" {
+		t.Errorf("path = %q, want /api/agents", gotPath)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+
+	want := []Agent{
+		{
+			Name:        "scanner",
+			ID:          "agt_scanner01",
+			DisplayName: "Scanner",
+			Enabled:     true,
+			Managed:     false,
+			Backend:     "claude",
+			Model:       "claude-opus-4-5",
+		},
+		{
+			Name:        "quality",
+			ID:          "agt_quality01",
+			DisplayName: "", // omitted on the wire; handler's Name fallback is a caller concern, not a decode concern
+			Enabled:     true,
+			Managed:     true,
+			Backend:     "copilot",
+			Model:       "gpt-5",
+		},
+		{
+			Name:        "reviewer",
+			ID:          "agt_reviewer01",
+			DisplayName: "Reviewer",
+			Enabled:     false,
+			Managed:     false,
+			Backend:     "claude",
+			Model:       "claude-sonnet-4-5",
+		},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d agents, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("agent[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestAgentsEmptyList covers the zero-agents case: a valid empty JSON array,
+// not a nil/error.
+func TestAgentsEmptyList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Agents(context.Background())
+	if err != nil {
+		t.Fatalf("Agents() = %v, want nil", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Agents() = %+v, want empty", got)
+	}
+}
+
+// TestAgentsMalformedBody: a 200 carrying something that is not a JSON array
+// of agents is a decode error, not a silent empty/zero result.
+func TestAgentsMalformedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Agents(context.Background())
+	if err == nil {
+		t.Fatal("Agents() = nil error on a non-JSON 200, want a decode error")
+	}
+	if got != nil {
+		t.Errorf("Agents() = %+v, want nil on error", got)
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("error = %v, want it to name the decode failure", err)
+	}
+}
+
+// TestAgentsNonOKReturnsAPIError checks the typed-error contract on a failed
+// request, matching TestHealthNonOKReturnsAPIError's coverage for this
+// endpoint.
+func TestAgentsNonOKReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal"}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Agents(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Agents() error = %v (%T), want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusInternalServerError)
+	}
+	if apiErr.Path != "/api/agents" {
+		t.Errorf("Path = %q, want /api/agents", apiErr.Path)
+	}
+	if got != nil {
+		t.Errorf("Agents() = %+v, want nil on error", got)
+	}
+}

--- a/src/pkg/tui/client/testdata/agents.json
+++ b/src/pkg/tui/client/testdata/agents.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "scanner",
+    "id": "agt_scanner01",
+    "displayName": "Scanner",
+    "enabled": true,
+    "managed": false,
+    "backend": "claude",
+    "model": "claude-opus-4-5"
+  },
+  {
+    "name": "quality",
+    "id": "agt_quality01",
+    "enabled": true,
+    "managed": true,
+    "backend": "copilot",
+    "model": "gpt-5"
+  },
+  {
+    "name": "reviewer",
+    "id": "agt_reviewer01",
+    "displayName": "Reviewer",
+    "enabled": false,
+    "managed": false,
+    "backend": "claude",
+    "model": "claude-sonnet-4-5"
+  }
+]


### PR DESCRIPTION
Fixes #5053

Part of #4907 (TUI epic). Depends on T2 (#4917, merged as #4937).

## What

- `client.Agent` struct + `Client.Agents(ctx)` in `src/pkg/tui/client/agents.go`, decoding `GET /api/agents` via the existing `getJSON` helper.
- Table-driven tests in `agents_test.go` against a `testdata/agents.json` fixture: full decode, empty list, malformed JSON, non-200 (`*APIError`).
- `CHANGELOG.md` entry under `### Added`.

## The issue's premise is stale (in this PR's favor)

The issue and the design doc (`src/docs/design/tui.md` §2.1) say `/api/agents` is missing from `dashboard/openapi.json` and to derive the shape from `hivectl agent list` / the handler. **That's no longer true.** #5023 landed since and widened the spec from 32 documented operations to 255 paths — `/api/agents` is now published with both `get` and `post`.

So this PR takes the spec as primary and cross-checks it against the handler:

- **Spec** (`dashboard/openapi.json`, `paths./api/agents.get`): `name`, `id`, `displayName`, `enabled`, `managed` (bool, "true for CRUD-created agents; false for base/pack-defined"), `backend`, `model`.
- **Handler** (`pkg/dashboard/api_agents.go`, `handleAgentsList` / `agentListEntry`): the exact same seven fields, same names, same types, `displayName` marshaled with `omitempty`.

**No disagreement found** — spec and handler match field-for-field. `Agent`'s json tags mirror both exactly.

Two fields the issue text speculated about ("last activity", "whatever status field the response exposes") are **not** in either source — `handleAgentsList` never sets them, so they're not on `Agent`. Nothing invented.

## Verify

```
cd src && go build ./... && go test ./pkg/tui/...
```

`TestOpenAPISpecCoversEveryRegisteredRoute` (`pkg/dashboard/openapi_route_parity_test.go`, added by #5023) is untouched and still green — no routes changed here.