### PR TITLE
🧹 refactor: consolidate taskDescOf onto assignDesc

### DIFF
--- a/src/pkg/dashboard/contribute_release_visibility_test.go
+++ b/src/pkg/dashboard/contribute_release_visibility_test.go
@@ -24,15 +24,14 @@ import (
 // entries say "released", and the tests hold them to it.
 
 // TestTaskDescOfRendersGitHubWorkLikeItsPickup keeps the common case aligned: a
-// GitHub issue's release reads the same as the "picked up" entry it closes out,
-// because identityKey() spells a numbered item "repo#number" — exactly what the
-// pickup path formats by hand.
+// GitHub issue's release reads the same as the "picked up" entry it closes out.
 //
-// The two DO diverge for external work, and deliberately so. The pickup path
-// still formats with %d and therefore renders a Linear/Jira item as "repo#0";
-// this helper uses the canonical key instead. Matching that bug for symmetry
-// would be the wrong trade — the release entry is correct and the pickup entry
-// has a pre-existing gap worth fixing on its own.
+// HISTORY: when this test landed (#5097), the two DID diverge for external
+// work — the pickup path formatted with %d and rendered a Linear/Jira item as
+// "repo#0" while this helper used the canonical key, a divergence the test
+// comment flagged as a pre-existing gap worth its own fix. #5120 was that fix:
+// every feed entry now renders through assignDesc, and taskDescOf is a typed
+// wrapper over it, so the verbs can no longer disagree about the same item.
 func TestTaskDescOfRendersGitHubWorkLikeItsPickup(t *testing.T) {
 	task := &WSTaskAssign{
 		TaskID: "t-1",

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -921,11 +921,11 @@ func taskDescOf(task *WSTaskAssign) string {
 	if task == nil {
 		return ""
 	}
-	key := task.identityKey()
-	if key == "" {
-		return task.TaskID
-	}
-	return fmt.Sprintf("%s %s: %s", task.Kind, key, task.Title)
+	// Delegates to assignDesc (#5120), the one renderer every feed entry goes
+	// through — this typed wrapper exists so the release sites (#5097) keep
+	// their nil-tolerant one-argument call shape. Two copies of the format
+	// string would drift; one already almost did.
+	return assignDesc(task.Kind, task.identityKey(), task.Title, task.TaskID)
 }
 
 func (h *ContributeWSHub) addActivity(username, action, role, cli, model, effort, task string) {


### PR DESCRIPTION
## Summary

- #5108 and #5124 each introduced a helper that renders a work item for the
  activity feed — `taskDescOf` (release entries) and `assignDesc` (the other
  four verbs) — with the same format string, because each PR deliberately
  declined to rewrite the other while it was under review.
- The consolidation was pushed to #5124 before its merge, but **the merge raced
  the push**: tide merged the previously-reviewed head, so the merged tree
  carries both format-string copies. This PR is that orphaned commit,
  cherry-picked onto the merged `v4` — `taskDescOf` becomes a typed,
  nil-tolerant wrapper delegating to `assignDesc`.
- Behavior-identical: the two bodies produced the same string for every input,
  and both PRs' test suites pass unchanged. It also updates the release-test
  comment that documented the pickup path's `repo#0` divergence as a
  pre-existing gap — #5124 was the fix it anticipated, so the comment now
  records that as history instead of asserting a divergence that no longer
  exists.
- No behavior change; refactor + comment accuracy only. No CHANGELOG entry per
  the file's own rule ("do not include routine refactors").

## Testing

- [x] `cd src && go build ./...`
- [x] `cd src && go test ./...` — both PRs' suites pass unchanged
      (`TestTaskDescOf*`, `TestAssignDesc*`, `TestActivityFeed*`,
      `TestReleaseActivity*`); `gofmt`/`go vet` clean

## Related issues

Follow-up to #5108 and #5124 (both merged); no issue of its own.

## Contributor checklist

- [x] PR targets `v4` (the repository's default branch).
- [x] Title uses the repo emoji convention.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes — no
      behavior change.
- [x] `CHANGELOG.md` — routine refactor, excluded by the changelog's own rule.
- [x] No secrets, credentials, or local runtime state are committed.
