### PR TITLE
✨ feat: tui client token usage (T8)

### DIFF
--- a/src/pkg/tui/client/testdata/tokens.json
+++ b/src/pkg/tui/client/testdata/tokens.json
@@ -1,0 +1,113 @@
+{
+  "total_tokens": 1883700,
+  "total_input": 1296700,
+  "total_output": 100500,
+  "total_cache_read": 475000,
+  "total_cache_create": 11500,
+  "total_messages": 47,
+  "by_agent": {
+    "scanner": 1748100,
+    "reviewer": 135600
+  },
+  "by_model": {
+    "claude-opus-4-5": 1748100,
+    "claude-sonnet-4-5": 135600
+  },
+  "by_agent_detail": {
+    "scanner": {
+      "input": 1200000,
+      "output": 88100,
+      "cache_read": 450000,
+      "cache_create": 10000,
+      "messages": 42,
+      "sessions": 1
+    },
+    "reviewer": {
+      "input": 96700,
+      "output": 12400,
+      "cache_read": 25000,
+      "cache_create": 1500,
+      "messages": 5,
+      "sessions": 1
+    }
+  },
+  "by_model_detail": {
+    "claude-opus-4-5": {
+      "input": 1200000,
+      "output": 88100,
+      "cache_read": 450000,
+      "cache_create": 10000,
+      "messages": 42,
+      "sessions": 1
+    },
+    "claude-sonnet-4-5": {
+      "input": 96700,
+      "output": 12400,
+      "cache_read": 25000,
+      "cache_create": 1500,
+      "messages": 5,
+      "sessions": 1
+    }
+  },
+  "sessions": [
+    {
+      "session_id": "session-scanner-01",
+      "agent": "scanner",
+      "model": "claude-opus-4-5",
+      "input_tokens": 1200000,
+      "output_tokens": 88100,
+      "cache_read": 450000,
+      "cache_create": 10000,
+      "total_tokens": 1748100,
+      "messages": 42,
+      "first_active": 1788015600000,
+      "last_active": 1788016500000,
+      "backend": "claude",
+      "usage": [
+        {
+          "ts_ms": 1788015600000,
+          "model": "claude-opus-4-5",
+          "coalesced": 2,
+          "input": 700000,
+          "output": 50000,
+          "cache_read": 250000,
+          "cache_create": 6000
+        },
+        {
+          "ts_ms": 1788016500000,
+          "model": "claude-opus-4-5",
+          "input": 500000,
+          "output": 38100,
+          "cache_read": 200000,
+          "cache_create": 4000
+        }
+      ],
+      "usage_coalesced": 1
+    },
+    {
+      "session_id": "session-reviewer-01",
+      "agent": "reviewer",
+      "model": "claude-sonnet-4-5",
+      "input_tokens": 96700,
+      "output_tokens": 12400,
+      "cache_read": 25000,
+      "cache_create": 1500,
+      "total_tokens": 135600,
+      "messages": 5,
+      "first_active": 1788016200000,
+      "last_active": 1788016800000,
+      "backend": "claude",
+      "usage": [
+        {
+          "ts_ms": 1788016800000,
+          "model": "claude-sonnet-4-5",
+          "input": 96700,
+          "output": 12400,
+          "cache_read": 25000,
+          "cache_create": 1500
+        }
+      ]
+    }
+  ],
+  "session_count": 2
+}

--- a/src/pkg/tui/client/tokens.go
+++ b/src/pkg/tui/client/tokens.go
@@ -1,0 +1,84 @@
+package client
+
+import "context"
+
+// TokenUsage is the response from GET /api/tokens.
+//
+// SOURCE OF TRUTH, AND A SPEC GAP. dashboard/openapi.json publishes the
+// operation but describes its 200 response only as an untyped object. These
+// fields are therefore transcribed from tokens.AggregateSummary and
+// tokens.AgentModelBucket (src/pkg/tokens/collector.go), which are returned
+// directly by dashboard.Server.handleTokens (src/pkg/dashboard/api.go). The
+// missing OpenAPI schema is tracked by kubestellar/hive#5077.
+//
+// Cost is deliberately absent. The endpoint returns token counts, not money;
+// cost is estimated separately by the dashboard's /api/cost endpoint. Adding a
+// cost field here would silently invent a wire contract that does not exist.
+//
+// Status is present only for the handler's {"status":"no_collector"}
+// response. When a collector exists, every other field mirrors
+// tokens.AggregateSummary field-for-field.
+type TokenUsage struct {
+	Status           string                  `json:"status,omitempty"`
+	TotalTokens      int64                   `json:"total_tokens"`
+	TotalInput       int64                   `json:"total_input"`
+	TotalOutput      int64                   `json:"total_output"`
+	TotalCacheRead   int64                   `json:"total_cache_read"`
+	TotalCacheCreate int64                   `json:"total_cache_create"`
+	TotalMessages    int                     `json:"total_messages"`
+	ByAgent          map[string]int64        `json:"by_agent"`
+	ByModel          map[string]int64        `json:"by_model"`
+	ByAgentDetail    map[string]*TokenBucket `json:"by_agent_detail"`
+	ByModelDetail    map[string]*TokenBucket `json:"by_model_detail"`
+	Sessions         []TokenSession          `json:"sessions"`
+	SessionCount     int                     `json:"session_count"`
+}
+
+// TokenBucket is one per-agent or per-model breakdown in TokenUsage.
+type TokenBucket struct {
+	Input       int64 `json:"input"`
+	Output      int64 `json:"output"`
+	CacheRead   int64 `json:"cache_read"`
+	CacheCreate int64 `json:"cache_create"`
+	Messages    int   `json:"messages"`
+	Sessions    int   `json:"sessions"`
+}
+
+// TokenSession mirrors tokens.SessionSummary, the entries in TokenUsage's
+// sessions array.
+type TokenSession struct {
+	SessionID      string            `json:"session_id"`
+	Agent          string            `json:"agent"`
+	Model          string            `json:"model"`
+	InputTokens    int64             `json:"input_tokens"`
+	OutputTokens   int64             `json:"output_tokens"`
+	CacheRead      int64             `json:"cache_read"`
+	CacheCreate    int64             `json:"cache_create"`
+	TotalTokens    int64             `json:"total_tokens"`
+	Messages       int               `json:"messages"`
+	FirstActive    int64             `json:"first_active,omitempty"`
+	LastActive     int64             `json:"last_active,omitempty"`
+	Backend        string            `json:"backend,omitempty"`
+	Usage          []TokenUsageEvent `json:"usage,omitempty"`
+	UsageCoalesced int               `json:"usage_coalesced,omitempty"`
+}
+
+// TokenUsageEvent is one timestamped token slice within a session.
+type TokenUsageEvent struct {
+	TimestampMs int64  `json:"ts_ms"`
+	Model       string `json:"model,omitempty"`
+	Coalesced   int    `json:"coalesced,omitempty"`
+	Input       int64  `json:"input"`
+	Output      int64  `json:"output"`
+	CacheRead   int64  `json:"cache_read"`
+	CacheCreate int64  `json:"cache_create"`
+}
+
+// Tokens returns the dashboard's token-usage summary from GET /api/tokens.
+func (c *Client) Tokens(ctx context.Context) (TokenUsage, error) {
+	var usage TokenUsage
+	if err := c.getJSON(ctx, "/api/tokens", &usage); err != nil {
+		return TokenUsage{}, err
+	}
+	return usage, nil
+}

--- a/src/pkg/tui/client/tokens_test.go
+++ b/src/pkg/tui/client/tokens_test.go
@@ -1,0 +1,170 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTokensDecodesFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "tokens.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Tokens(context.Background())
+	if err != nil {
+		t.Fatalf("Tokens() = %v, want nil", err)
+	}
+	if gotPath != "/api/tokens" {
+		t.Errorf("path = %q, want /api/tokens", gotPath)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+
+	want := TokenUsage{
+		TotalTokens:      1_883_700,
+		TotalInput:       1_296_700,
+		TotalOutput:      100_500,
+		TotalCacheRead:   475_000,
+		TotalCacheCreate: 11_500,
+		TotalMessages:    47,
+		ByAgent: map[string]int64{
+			"scanner":  1_748_100,
+			"reviewer": 135_600,
+		},
+		ByModel: map[string]int64{
+			"claude-opus-4-5":   1_748_100,
+			"claude-sonnet-4-5": 135_600,
+		},
+		ByAgentDetail: map[string]*TokenBucket{
+			"scanner":  {Input: 1_200_000, Output: 88_100, CacheRead: 450_000, CacheCreate: 10_000, Messages: 42, Sessions: 1},
+			"reviewer": {Input: 96_700, Output: 12_400, CacheRead: 25_000, CacheCreate: 1_500, Messages: 5, Sessions: 1},
+		},
+		ByModelDetail: map[string]*TokenBucket{
+			"claude-opus-4-5":   {Input: 1_200_000, Output: 88_100, CacheRead: 450_000, CacheCreate: 10_000, Messages: 42, Sessions: 1},
+			"claude-sonnet-4-5": {Input: 96_700, Output: 12_400, CacheRead: 25_000, CacheCreate: 1_500, Messages: 5, Sessions: 1},
+		},
+		Sessions: []TokenSession{
+			{
+				SessionID: "session-scanner-01", Agent: "scanner", Model: "claude-opus-4-5",
+				InputTokens: 1_200_000, OutputTokens: 88_100, CacheRead: 450_000,
+				CacheCreate: 10_000, TotalTokens: 1_748_100, Messages: 42,
+				FirstActive: 1_788_015_600_000, LastActive: 1_788_016_500_000, Backend: "claude",
+				Usage: []TokenUsageEvent{
+					{TimestampMs: 1_788_015_600_000, Model: "claude-opus-4-5", Coalesced: 2, Input: 700_000, Output: 50_000, CacheRead: 250_000, CacheCreate: 6_000},
+					{TimestampMs: 1_788_016_500_000, Model: "claude-opus-4-5", Input: 500_000, Output: 38_100, CacheRead: 200_000, CacheCreate: 4_000},
+				},
+				UsageCoalesced: 1,
+			},
+			{
+				SessionID: "session-reviewer-01", Agent: "reviewer", Model: "claude-sonnet-4-5",
+				InputTokens: 96_700, OutputTokens: 12_400, CacheRead: 25_000,
+				CacheCreate: 1_500, TotalTokens: 135_600, Messages: 5,
+				FirstActive: 1_788_016_200_000, LastActive: 1_788_016_800_000, Backend: "claude",
+				Usage: []TokenUsageEvent{
+					{TimestampMs: 1_788_016_800_000, Model: "claude-sonnet-4-5", Input: 96_700, Output: 12_400, CacheRead: 25_000, CacheCreate: 1_500},
+				},
+			},
+		},
+		SessionCount: 2,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Tokens() =\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+func TestTokensNoCollector(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"no_collector"}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Tokens(context.Background())
+	if err != nil {
+		t.Fatalf("Tokens() = %v, want nil", err)
+	}
+	if got.Status != "no_collector" {
+		t.Errorf("Status = %q, want no_collector", got.Status)
+	}
+	if got.TotalTokens != 0 || len(got.Sessions) != 0 {
+		t.Errorf("Tokens() = %+v, want no-collector status and zero usage", got)
+	}
+}
+
+func TestTokensEmptySummary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total_tokens":0,"sessions":[]}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Tokens(context.Background())
+	if err != nil {
+		t.Fatalf("Tokens() = %v, want nil", err)
+	}
+	if got.Status != "" || got.TotalTokens != 0 || got.Sessions == nil || len(got.Sessions) != 0 {
+		t.Errorf("Tokens() = %+v, want an empty non-nil sessions slice and zero totals", got)
+	}
+}
+
+func TestTokensMalformedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Tokens(context.Background())
+	if err == nil {
+		t.Fatal("Tokens() = nil error on a non-JSON 200, want a decode error")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("error = %v, want it to name the decode failure", err)
+	}
+	if !reflect.DeepEqual(got, TokenUsage{}) {
+		t.Errorf("Tokens() = %+v, want the zero value on error", got)
+	}
+}
+
+func TestTokensNonOKReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"token collection failed"}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Tokens(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Tokens() error = %v (%T), want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusInternalServerError)
+	}
+	if apiErr.Path != "/api/tokens" {
+		t.Errorf("Path = %q, want /api/tokens", apiErr.Path)
+	}
+	if !strings.Contains(apiErr.Body, "token collection failed") {
+		t.Errorf("Body = %q, want it to quote the dashboard's message", apiErr.Body)
+	}
+	if !reflect.DeepEqual(got, TokenUsage{}) {
+		t.Errorf("Tokens() = %+v, want the zero value on error", got)
+	}
+}


### PR DESCRIPTION
Part of #4907. Closes #5057.

## Summary

- add a typed `GET /api/tokens` client covering totals, agent/model breakdowns, sessions, and usage events
- preserve the handler's `no_collector` and empty-summary response shapes without inventing the absent cost field
- document the untyped OpenAPI response gap tracked in #5077
- add a complete schema-shaped fixture plus success, degenerate-response, malformed-body, and HTTP 500 tests

## Testing

- `cd src && go build ./...`
- `cd src && go test ./pkg/tui/...`

— hive: backend=codex
