### PR TITLE
✨ feat: tui client events feed (T10)

### DIFF
--- a/src/pkg/tui/client/events.go
+++ b/src/pkg/tui/client/events.go
@@ -1,0 +1,43 @@
+package client
+
+import "context"
+
+// Event is one entry from the dashboard's poll-shaped activity feed,
+// GET /api/audit.
+//
+// WHY /api/audit, NOT /api/events. Despite this task's original wording,
+// dashboard/openapi.json and dashboard.Server.handleSSE agree that
+// GET /api/events is a long-lived text/event-stream of status snapshots. It
+// cannot be fetched with getJSON and does not return event rows. The web
+// dashboard's actual poll-shaped feed is GET /api/audit
+// (static/index.html:fetchAuditLog), which returns newest-first entries and is
+// the endpoint modeled here. Streaming /api/events remains T13a's concern.
+//
+// The first five fields mirror the published /api/audit schema. UserName is
+// also part of the live response: dashboard.AuditEntry and handleAuditLog add
+// it when an opaque OIDC user key has a display name. The OpenAPI schema has
+// not yet caught up with that optional field, but dropping it would expose an
+// opaque identity in the TUI where the web dashboard shows a person.
+type Event struct {
+	Timestamp string `json:"ts"`
+	User      string `json:"user"`
+	Action    string `json:"action"`
+	Detail    string `json:"detail,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	UserName  string `json:"user_name,omitempty"`
+}
+
+// Events returns up to 200 recent activity entries, newest first, from
+// GET /api/audit.
+//
+// The endpoint requires read-write or owner access. Insufficient access is
+// returned as the same typed APIError as every other non-2xx client response.
+func (c *Client) Events(ctx context.Context) ([]Event, error) {
+	var response struct {
+		Entries []Event `json:"entries"`
+	}
+	if err := c.getJSON(ctx, "/api/audit", &response); err != nil {
+		return nil, err
+	}
+	return response.Entries, nil
+}

--- a/src/pkg/tui/client/events_test.go
+++ b/src/pkg/tui/client/events_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestEventsDecodesFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "events.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	if err != nil {
+		t.Fatalf("Events() = %v, want nil", err)
+	}
+	if gotPath != "/api/audit" {
+		t.Errorf("path = %q, want /api/audit", gotPath)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+
+	want := []Event{
+		{
+			Timestamp: "2026-08-29T16:42:03Z",
+			User:      "oidc:00u1opaque",
+			UserName:  "Jane Doe",
+			Action:    "agent.kick",
+			Detail:    "reason=governor",
+			Agent:     "scanner",
+		},
+		{
+			Timestamp: "2026-08-29T16:41:20Z",
+			User:      "Danathar",
+			Action:    "agent.pause",
+			Agent:     "reviewer",
+		},
+		{
+			Timestamp: "2026-08-29T16:39:58Z",
+			User:      "system",
+			Action:    "governor.mode",
+			Detail:    "quiet -> busy",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Events() =\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+func TestEventsEmptyFeed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"entries":[]}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	if err != nil {
+		t.Fatalf("Events() = %v, want nil", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("Events() = %#v, want a non-nil empty slice", got)
+	}
+}
+
+func TestEventsMalformedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	if err == nil {
+		t.Fatal("Events() = nil error on a non-JSON 200, want a decode error")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("error = %v, want it to name the decode failure", err)
+	}
+	if got != nil {
+		t.Errorf("Events() = %+v, want nil on error", got)
+	}
+}
+
+func TestEventsNonOKReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"audit read failed"}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Events() error = %v (%T), want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusInternalServerError)
+	}
+	if apiErr.Path != "/api/audit" {
+		t.Errorf("Path = %q, want /api/audit", apiErr.Path)
+	}
+	if !strings.Contains(apiErr.Body, "audit read failed") {
+		t.Errorf("Body = %q, want it to quote the dashboard's message", apiErr.Body)
+	}
+	if got != nil {
+		t.Errorf("Events() = %+v, want nil on error", got)
+	}
+}

--- a/src/pkg/tui/client/testdata/events.json
+++ b/src/pkg/tui/client/testdata/events.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "ts": "2026-08-29T16:42:03Z",
+      "user": "oidc:00u1opaque",
+      "action": "agent.kick",
+      "detail": "reason=governor",
+      "agent": "scanner",
+      "user_name": "Jane Doe"
+    },
+    {
+      "ts": "2026-08-29T16:41:20Z",
+      "user": "Danathar",
+      "action": "agent.pause",
+      "agent": "reviewer"
+    },
+    {
+      "ts": "2026-08-29T16:39:58Z",
+      "user": "system",
+      "action": "governor.mode",
+      "detail": "quiet -> busy"
+    }
+  ]
+}


### PR DESCRIPTION
Part of #4907. Closes #5059.

## Summary

- add `Client.Events` and a typed `Event` model for the dashboard's poll-shaped activity feed
- target `GET /api/audit`, because the issue's original `/api/events` endpoint is a long-lived SSE status stream and cannot be decoded with `getJSON`
- preserve all live audit fields, including the optional server-resolved `user_name`
- add fixture-based decoding plus empty-feed, malformed-body, and HTTP 500 tests

This follows the preferred resolution in the issue's scanner analysis and leaves `/api/events` streaming to T13a (#5062).

## Testing

- `cd src && go build ./...`
- `cd src && go test ./pkg/tui/...`

— hive: backend=codex
