### PR TITLE
✨ feat(tui): render events scrollback (T11)

### DIFF
--- a/src/pkg/tui/client/events.go
+++ b/src/pkg/tui/client/events.go
@@ -1,0 +1,43 @@
+package client
+
+import "context"
+
+// Event is one entry from the dashboard's poll-shaped activity feed,
+// GET /api/audit.
+//
+// WHY /api/audit, NOT /api/events. Despite this task's original wording,
+// dashboard/openapi.json and dashboard.Server.handleSSE agree that
+// GET /api/events is a long-lived text/event-stream of status snapshots. It
+// cannot be fetched with getJSON and does not return event rows. The web
+// dashboard's actual poll-shaped feed is GET /api/audit
+// (static/index.html:fetchAuditLog), which returns newest-first entries and is
+// the endpoint modeled here. Streaming /api/events remains T13a's concern.
+//
+// The first five fields mirror the published /api/audit schema. UserName is
+// also part of the live response: dashboard.AuditEntry and handleAuditLog add
+// it when an opaque OIDC user key has a display name. The OpenAPI schema has
+// not yet caught up with that optional field, but dropping it would expose an
+// opaque identity in the TUI where the web dashboard shows a person.
+type Event struct {
+	Timestamp string `json:"ts"`
+	User      string `json:"user"`
+	Action    string `json:"action"`
+	Detail    string `json:"detail,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	UserName  string `json:"user_name,omitempty"`
+}
+
+// Events returns up to 200 recent activity entries, newest first, from
+// GET /api/audit.
+//
+// The endpoint requires read-write or owner access. Insufficient access is
+// returned as the same typed APIError as every other non-2xx client response.
+func (c *Client) Events(ctx context.Context) ([]Event, error) {
+	var response struct {
+		Entries []Event `json:"entries"`
+	}
+	if err := c.getJSON(ctx, "/api/audit", &response); err != nil {
+		return nil, err
+	}
+	return response.Entries, nil
+}

--- a/src/pkg/tui/client/events_test.go
+++ b/src/pkg/tui/client/events_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestEventsDecodesFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "events.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	if err != nil {
+		t.Fatalf("Events() = %v, want nil", err)
+	}
+	if gotPath != "/api/audit" {
+		t.Errorf("path = %q, want /api/audit", gotPath)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+
+	want := []Event{
+		{
+			Timestamp: "2026-08-29T16:42:03Z",
+			User:      "oidc:00u1opaque",
+			UserName:  "Jane Doe",
+			Action:    "agent.kick",
+			Detail:    "reason=governor",
+			Agent:     "scanner",
+		},
+		{
+			Timestamp: "2026-08-29T16:41:20Z",
+			User:      "Danathar",
+			Action:    "agent.pause",
+			Agent:     "reviewer",
+		},
+		{
+			Timestamp: "2026-08-29T16:39:58Z",
+			User:      "system",
+			Action:    "governor.mode",
+			Detail:    "quiet -> busy",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Events() =\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+func TestEventsEmptyFeed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"entries":[]}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	if err != nil {
+		t.Fatalf("Events() = %v, want nil", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("Events() = %#v, want a non-nil empty slice", got)
+	}
+}
+
+func TestEventsMalformedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	if err == nil {
+		t.Fatal("Events() = nil error on a non-JSON 200, want a decode error")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("error = %v, want it to name the decode failure", err)
+	}
+	if got != nil {
+		t.Errorf("Events() = %+v, want nil on error", got)
+	}
+}
+
+func TestEventsNonOKReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"audit read failed"}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Events(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Events() error = %v (%T), want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusInternalServerError)
+	}
+	if apiErr.Path != "/api/audit" {
+		t.Errorf("Path = %q, want /api/audit", apiErr.Path)
+	}
+	if !strings.Contains(apiErr.Body, "audit read failed") {
+		t.Errorf("Body = %q, want it to quote the dashboard's message", apiErr.Body)
+	}
+	if got != nil {
+		t.Errorf("Events() = %+v, want nil on error", got)
+	}
+}

--- a/src/pkg/tui/client/testdata/events.json
+++ b/src/pkg/tui/client/testdata/events.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "ts": "2026-08-29T16:42:03Z",
+      "user": "oidc:00u1opaque",
+      "action": "agent.kick",
+      "detail": "reason=governor",
+      "agent": "scanner",
+      "user_name": "Jane Doe"
+    },
+    {
+      "ts": "2026-08-29T16:41:20Z",
+      "user": "Danathar",
+      "action": "agent.pause",
+      "agent": "reviewer"
+    },
+    {
+      "ts": "2026-08-29T16:39:58Z",
+      "user": "system",
+      "action": "governor.mode",
+      "detail": "quiet -> busy"
+    }
+  ]
+}

--- a/src/pkg/tui/panes/events.go
+++ b/src/pkg/tui/panes/events.go
@@ -1,13 +1,146 @@
 package panes
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"strings"
+	"time"
 
-// Events is the event-feed pane — the scrollback of kicks, PRs and state changes once T11
-// lands. Until then it is a stub that names itself and waits.
-type Events struct{ stub }
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
-// NewEvents returns the Events pane stub.
-func NewEvents() Events { return Events{stub{title: "EVENTS"}} }
+	"github.com/kubestellar/hive/pkg/tui/client"
+)
 
-// Update implements Pane. See stub.update for why a stub still returns itself.
-func (p Events) Update(msg tea.Msg) (Pane, tea.Cmd) { return p.update(msg, p) }
+// EventsMsg delivers a completed event-feed read to the Events pane.
+//
+// Events are newest first, matching client.Events and the dashboard's
+// /api/audit response. A message replaces the previous snapshot: polling owns
+// collection, while this pane owns only display and scroll position.
+type EventsMsg struct {
+	Events []client.Event
+}
+
+// Events is the event-feed pane: a newest-first scrollback of recent operator
+// and system activity.
+type Events struct {
+	stub
+	events []client.Event
+	loaded bool
+
+	// offset is the index of the first visible event. Zero follows the newest
+	// entry; positive values mean the operator has scrolled back toward older
+	// history.
+	offset int
+}
+
+// NewEvents returns the Events pane in its pre-data state.
+func NewEvents() Events { return Events{stub: stub{title: "EVENTS"}} }
+
+// Update implements Pane.
+func (p Events) Update(msg tea.Msg) (Pane, tea.Cmd) {
+	switch msg := msg.(type) {
+	case EventsMsg:
+		p.replace(msg.Events)
+		return p, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "j", "down":
+			if p.offset < len(p.events)-1 {
+				p.offset++
+			}
+			return p, nil
+		case "k", "up":
+			if p.offset > 0 {
+				p.offset--
+			}
+			return p, nil
+		}
+	}
+	return p.update(msg, p)
+}
+
+// replace installs a successful snapshot without taking ownership of the
+// message's backing array. When scrolled back, it keeps the event at the top
+// of the viewport anchored if that event is still present in the new snapshot;
+// when following the newest entry (offset zero), new data remains visible.
+func (p *Events) replace(events []client.Event) {
+	var anchor client.Event
+	haveAnchor := p.offset > 0 && p.offset < len(p.events)
+	if haveAnchor {
+		anchor = p.events[p.offset]
+	}
+
+	p.events = append([]client.Event(nil), events...)
+	p.loaded = true
+
+	if !haveAnchor {
+		p.offset = 0
+		return
+	}
+	for i, event := range p.events {
+		if event == anchor {
+			p.offset = i
+			return
+		}
+	}
+	p.offset = min(p.offset, max(0, len(p.events)-1))
+}
+
+// View implements Pane.
+func (p Events) View(width, height int) string {
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+	if !p.loaded {
+		return stubView(p.Title(), width, height)
+	}
+	if len(p.events) == 0 {
+		return contentView(p.Title(), "no events yet", width, height)
+	}
+
+	// Title + blank line consume two rows under the shared content contract.
+	visible := max(0, height-2)
+	end := min(len(p.events), p.offset+visible)
+	rows := make([]string, 0, end-p.offset)
+	rowStyle := lipgloss.NewStyle().Inline(true).MaxWidth(width)
+	for _, event := range p.events[p.offset:end] {
+		rows = append(rows, rowStyle.Render(eventRow(event)))
+	}
+	return contentView(p.Title(), strings.Join(rows, "\n"), width, height)
+}
+
+func eventRow(event client.Event) string {
+	return eventTime(event.Timestamp) + "  " + eventMessage(event)
+}
+
+func eventTime(timestamp string) string {
+	parsed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return "--:--:--"
+	}
+	return parsed.Format("15:04:05")
+}
+
+// eventMessage flattens the audit feed's structured fields into the sketch's
+// single message column without inventing action-specific prose. The action is
+// always first; the optional agent and detail follow it, and the actor is last
+// so narrow panes retain the most useful part of the event before clipping.
+func eventMessage(event client.Event) string {
+	message := event.Action
+	if message == "" {
+		message = "event"
+	}
+	if event.Agent != "" {
+		message += " " + event.Agent
+	}
+	if event.Detail != "" {
+		message += " — " + event.Detail
+	}
+	actor := event.UserName
+	if actor == "" {
+		actor = event.User
+	}
+	if actor != "" {
+		message += " (" + actor + ")"
+	}
+	return message
+}

--- a/src/pkg/tui/panes/events_golden_test.go
+++ b/src/pkg/tui/panes/events_golden_test.go
@@ -1,0 +1,32 @@
+package panes_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/tui/client"
+	"github.com/kubestellar/hive/pkg/tui/panes"
+)
+
+// TestEventsGolden pins the events pane's complete 48x12 render. The fixture
+// deliberately has more events than the ten body rows that fit, so the golden
+// also proves the initial viewport shows the newest events.
+func TestEventsGolden(t *testing.T) {
+	events := []client.Event{
+		{Timestamp: "2026-08-29T12:04:02Z", User: "governor", Action: "kick", Agent: "scanner", Detail: "reason=governor"},
+		{Timestamp: "2026-08-29T12:03:41Z", User: "Danathar", Action: "pr.open", Detail: "number=4919"},
+		{Timestamp: "2026-08-29T12:01:58Z", User: "system", Action: "state.change", Agent: "quality", Detail: "running -> idle"},
+		{Timestamp: "2026-08-29T11:58:20Z", User: "oidc:00u1opaque", UserName: "Jane Doe", Action: "pause", Agent: "reviewer"},
+		{Timestamp: "2026-08-29T11:57:03Z", User: "system", Action: "bead.close", Detail: "id=bd-1042"},
+		{Timestamp: "2026-08-29T11:55:44Z", User: "system", Action: "governor.mode", Detail: "quiet -> busy"},
+		{Timestamp: "2026-08-29T11:52:30Z", User: "operator", Action: "set_model", Agent: "quality", Detail: "model=gpt-5"},
+		{Timestamp: "2026-08-29T11:49:12Z", User: "system", Action: "agent.complete", Agent: "reviewer"},
+		{Timestamp: "2026-08-29T11:45:01Z", User: "operator", Action: "resume", Agent: "ux-discovery"},
+		{Timestamp: "2026-08-29T11:40:17Z", User: "system", Action: "queue.refresh", Detail: "actionable=7"},
+		{Timestamp: "2026-08-29T11:38:54Z", User: "operator", Action: "config.save", Detail: "file=hive.yaml"},
+		{Timestamp: "2026-08-29T11:32:09Z", User: "system", Action: "startup"},
+	}
+
+	pane, _ := panes.NewEvents().Update(panes.EventsMsg{Events: events})
+	requireGolden(t, []byte(pane.View(48, 12)), filepath.Join("testdata", "events.golden"))
+}

--- a/src/pkg/tui/panes/events_test.go
+++ b/src/pkg/tui/panes/events_test.go
@@ -1,0 +1,121 @@
+package panes
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/kubestellar/hive/pkg/tui/client"
+)
+
+func testEvent(second, action string) client.Event {
+	return client.Event{
+		Timestamp: "2026-08-29T12:04:" + second + "Z",
+		User:      "operator",
+		Action:    action,
+	}
+}
+
+func updateEvents(t *testing.T, pane Pane, msg tea.Msg) Events {
+	t.Helper()
+	next, cmd := pane.Update(msg)
+	if cmd != nil {
+		t.Fatal("Events.Update returned an unexpected command")
+	}
+	events, ok := next.(Events)
+	if !ok {
+		t.Fatalf("Events.Update returned %T, want Events", next)
+	}
+	return events
+}
+
+func TestEventsScrollMovementAndBounds(t *testing.T) {
+	events := []client.Event{
+		testEvent("04", "newest"),
+		testEvent("03", "middle"),
+		testEvent("02", "oldest"),
+	}
+	pane := updateEvents(t, NewEvents(), EventsMsg{Events: events})
+
+	if got := pane.View(48, 3); !strings.Contains(got, "newest") || strings.Contains(got, "middle") {
+		t.Fatalf("initial view does not start at newest event:\n%s", got)
+	}
+
+	pane = updateEvents(t, pane, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if got := pane.View(48, 3); !strings.Contains(got, "middle") || strings.Contains(got, "newest") {
+		t.Fatalf("j did not scroll toward older events:\n%s", got)
+	}
+
+	pane = updateEvents(t, pane, tea.KeyMsg{Type: tea.KeyDown})
+	pane = updateEvents(t, pane, tea.KeyMsg{Type: tea.KeyDown})
+	if pane.offset != 2 {
+		t.Fatalf("scroll past oldest offset = %d, want 2", pane.offset)
+	}
+
+	pane = updateEvents(t, pane, tea.KeyMsg{Type: tea.KeyUp})
+	pane = updateEvents(t, pane, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	pane = updateEvents(t, pane, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if pane.offset != 0 {
+		t.Fatalf("scroll past newest offset = %d, want 0", pane.offset)
+	}
+}
+
+func TestEventsReplacementPreservesScrollAnchor(t *testing.T) {
+	old := []client.Event{
+		testEvent("04", "newest"),
+		testEvent("03", "anchored"),
+		testEvent("02", "oldest"),
+	}
+	pane := updateEvents(t, NewEvents(), EventsMsg{Events: old})
+	pane = updateEvents(t, pane, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+
+	newest := testEvent("05", "new arrival")
+	pane = updateEvents(t, pane, EventsMsg{Events: append([]client.Event{newest}, old...)})
+	if pane.offset != 2 {
+		t.Fatalf("replacement offset = %d, want anchored event's new index 2", pane.offset)
+	}
+	if got := pane.View(48, 3); !strings.Contains(got, "anchored") || strings.Contains(got, "new arrival") {
+		t.Fatalf("replacement yanked scrolled view to newest event:\n%s", got)
+	}
+
+	following := updateEvents(t, NewEvents(), EventsMsg{Events: old})
+	following = updateEvents(t, following, EventsMsg{Events: append([]client.Event{newest}, old...)})
+	if following.offset != 0 || !strings.Contains(following.View(48, 3), "new arrival") {
+		t.Fatalf("replacement did not follow newest while at top:\n%s", following.View(48, 3))
+	}
+}
+
+func TestEventsLoadedEmptyAndInputOwnership(t *testing.T) {
+	pane := updateEvents(t, NewEvents(), EventsMsg{})
+	if got := pane.View(40, 6); !strings.Contains(got, "no events yet") || strings.Contains(got, placeholder) {
+		t.Fatalf("successful empty feed renders incorrectly:\n%s", got)
+	}
+
+	input := []client.Event{testEvent("04", "original")}
+	pane = updateEvents(t, pane, EventsMsg{Events: input})
+	input[0].Action = "mutated"
+	if got := pane.View(40, 6); !strings.Contains(got, "original") || strings.Contains(got, "mutated") {
+		t.Fatalf("pane retained ownership of caller's slice:\n%s", got)
+	}
+}
+
+func TestEventsRowsDoNotWrap(t *testing.T) {
+	pane := updateEvents(t, NewEvents(), EventsMsg{Events: []client.Event{{
+		Timestamp: "not-a-timestamp",
+		Action:    "a deliberately long event message that cannot fit",
+	}}})
+	view := pane.View(24, 5)
+	if lines := strings.Count(view, "\n") + 1; lines != 5 {
+		t.Fatalf("View rendered %d lines, want 5:\n%s", lines, view)
+	}
+	if width := visibleWidth(view); width != 24 {
+		t.Fatalf("View width = %d, want 24:\n%s", width, view)
+	}
+	if !strings.Contains(view, "--:--:--") {
+		t.Fatalf("invalid timestamp has no stable fallback:\n%s", view)
+	}
+	if strings.Contains(view, "cannot fit") {
+		t.Fatalf("long event wrapped instead of being clipped:\n%s", view)
+	}
+}

--- a/src/pkg/tui/panes/testdata/events.golden
+++ b/src/pkg/tui/panes/testdata/events.golden
@@ -1,0 +1,12 @@
+EVENTS                                          
+                                                
+12:04:02  kick scanner — reason=governor (govern
+12:03:41  pr.open — number=4919 (Danathar)      
+12:01:58  state.change quality — running -> idle
+11:58:20  pause reviewer (Jane Doe)             
+11:57:03  bead.close — id=bd-1042 (system)      
+11:55:44  governor.mode — quiet -> busy (system)
+11:52:30  set_model quality — model=gpt-5 (opera
+11:49:12  agent.complete reviewer (system)      
+11:45:01  resume ux-discovery (operator)        
+11:40:17  queue.refresh — actionable=7 (system) 


### PR DESCRIPTION
## Summary

- replace the EVENTS stub with a newest-first scrollback backed by `panes.EventsMsg`
- render clipped `HH:MM:SS  message` rows and support `j`/`k` plus arrow-key scrolling
- preserve the visible event across replacement updates while scrolled back
- add direct scroll behavior tests and the required 48x12 golden with overflow fixture data

## Testing

- `cd src && go build ./...`
- `cd src && go test ./pkg/tui/...`

## Dependency

This PR is stacked on #5144, which provides `client.Event` and the `/api/audit` client read required by #5060. The pane implementation is the top commit and will become the only remaining diff after #5144 merges.

Closes #5060

— hive: backend=codex