### PR TITLE
📖 docs(wiki): remove the phantom Tester agent, point at quality instead

### DIFF
--- a/src/deploy/data/wiki/agents.md
+++ b/src/deploy/data/wiki/agents.md
@@ -42,15 +42,18 @@ communications. Activated during idle periods.
 Security-focused agent. Reviews code for vulnerabilities, checks
 dependencies, and audits access patterns. Runs frequently across all modes.
 
-## Tester
-
-Writes and maintains test suites. Activated when coverage gaps or test
-failures are detected.
-
 ## Strategist
 
 Long-horizon planning agent. Analyzes trends, proposes roadmap items, and
 evaluates technical debt. Only activated in idle mode.
+
+## A note on testing
+
+There is no built-in `tester` agent. Test suites, coverage gates, and
+regression checks are the `quality` lane's work. An operator who wants a
+separate tester must define it as a custom agent with its own metadata and
+policy template — see
+[acmm-policy-matrix.md](../../../docs/acmm-policy-matrix.md).
 
 ## Adding a New Agent
 


### PR DESCRIPTION
Fixes #5164

## What

`src/deploy/data/wiki/agents.md` documented a **Tester** agent alongside the real built-ins. There is no such agent.

## Evidence

I cross-checked every agent the wiki documents against its actual registration in `applyKnownAgentDefaults` (`src/pkg/config/config.go`):

| Wiki agent | Occurrences in `config.go` |
|---|---:|
| supervisor | 5 |
| outreach | 4 |
| scanner | 3 |
| architect, ci-maintainer, sec-check, strategist | 2 each |
| **tester** | **0** |

Also **0** occurrences across `src/pkg/config/packs/level-{1..6}.yaml`.

`tester` is the only wiki entry with nothing behind it.

## The wiki contradicted a doc already in the tree

`src/docs/acmm-policy-matrix.md` states plainly:

> There is no built-in `tester` lane in the ACMM packs, known-agent defaults, or shipped policy templates; operators who want a separate tester must define it as a custom agent with explicit metadata and a policy template.

## Impact

An operator following the wiki would configure an agent that never activates — and would not learn that the **`quality`** lane already owns test suites, coverage gates, and regression checks.

## Change

Removes the section and replaces it with a short "A note on testing" entry stating that `quality` does this work and linking the authoritative matrix. Verified the relative link resolves to `src/docs/acmm-policy-matrix.md`.

Docs only.