### PR TITLE
fix(contributor): allow Claude local file tools

### DIFF
--- a/config/backends.conf
+++ b/config/backends.conf
@@ -124,6 +124,12 @@ claude_family_local_perm_flag_shell() {
 
   local settings
   settings="$(jq -cn --arg workspace "$HIVE_WORKSPACE_DIR" '{
+    permissions: {
+      allow: [
+        "Edit(" + $workspace + "/**)",
+        "Write(" + $workspace + "/**)"
+      ]
+    },
     sandbox: {
       enabled: true,
       failIfUnavailable: true,

--- a/src/pkg/dashboard/contribute_local_mode_warning_test.go
+++ b/src/pkg/dashboard/contribute_local_mode_warning_test.go
@@ -137,6 +137,9 @@ func TestClaudeLocalSandboxIsMandatory(t *testing.T) {
 		t.Fatalf("Claude local argv has no sandbox settings: %q", args)
 	}
 	var settings struct {
+		Permissions struct {
+			Allow []string `json:"allow"`
+		} `json:"permissions"`
 		Sandbox struct {
 			Enabled                  bool `json:"enabled"`
 			FailIfUnavailable        bool `json:"failIfUnavailable"`
@@ -154,6 +157,15 @@ func TestClaudeLocalSandboxIsMandatory(t *testing.T) {
 	}
 	if len(settings.Sandbox.Filesystem.AllowWrite) != 1 || settings.Sandbox.Filesystem.AllowWrite[0] != workspace {
 		t.Fatalf("sandbox write roots = %q, want only %q", settings.Sandbox.Filesystem.AllowWrite, workspace)
+	}
+	wantPermissions := []string{"Edit(" + workspace + "/**)", "Write(" + workspace + "/**)"}
+	if len(settings.Permissions.Allow) != len(wantPermissions) {
+		t.Fatalf("tool write permissions = %q, want %q", settings.Permissions.Allow, wantPermissions)
+	}
+	for i, want := range wantPermissions {
+		if settings.Permissions.Allow[i] != want {
+			t.Fatalf("tool write permissions = %q, want %q", settings.Permissions.Allow, wantPermissions)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- explicitly allow Claude's `Edit` and `Write` tools within `HIVE_WORKSPACE_DIR`
- retain `dontAsk`, the mandatory native sandbox, and existing host-state denials
- verify the emitted permission rules preserve exact workspace path scoping

## Testing

- `bash -n config/backends.conf`
- `go test ./pkg/dashboard -run 'TestClaude(LocalSandboxIsMandatory|LocalSandboxNeedsExplicitDangerousBypass|HostStateOptOutDoesNotDisableLocalSandbox)$' -count=1`
- `go test ./pkg/dashboard -count=1`

Fixes #5147

— hive: backend=codex
