### PR TITLE
🐛 fix: clarify byte-exact NOTICE drift failures

### DIFF
--- a/.github/workflows/go-security-analysis.yml
+++ b/.github/workflows/go-security-analysis.yml
@@ -185,6 +185,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Exercise NOTICE drift diagnostics
+        run: src/scripts/test-check-notice-drift.sh
+
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
@@ -194,10 +197,4 @@ jobs:
         run: src/scripts/generate-notice.sh /tmp/NOTICE.generated
 
       - name: Fail if the committed NOTICE is stale
-        run: |
-          set -euo pipefail
-          if ! diff -u NOTICE /tmp/NOTICE.generated; then
-            echo "::error::NOTICE is out of date with src/go.mod / src/go.sum. Run 'src/scripts/generate-notice.sh' locally (requires a Go toolchain) and commit the regenerated NOTICE." >&2
-            exit 1
-          fi
-          echo "NOTICE matches the current module graph."
+        run: src/scripts/check-notice-drift.sh NOTICE /tmp/NOTICE.generated

--- a/src/scripts/check-notice-drift.sh
+++ b/src/scripts/check-notice-drift.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# check-notice-drift.sh — compare the committed NOTICE with fresh output and
+# explain the repository's byte-exact commit contract when they differ.
+#
+# Usage: src/scripts/check-notice-drift.sh [committed-notice] [generated-notice]
+set -euo pipefail
+
+COMMITTED_NOTICE="${1:-NOTICE}"
+GENERATED_NOTICE="${2:-/tmp/NOTICE.generated}"
+
+if ! diff -u -- "${COMMITTED_NOTICE}" "${GENERATED_NOTICE}"; then
+  echo "::error::NOTICE is out of date with src/go.mod / src/go.sum. Run 'src/scripts/generate-notice.sh' locally (requires a Go toolchain). The comparison is byte-for-byte and whitespace-significant; commit the regenerated NOTICE verbatim without reformatting it." >&2
+  exit 1
+fi
+
+echo "NOTICE matches the current module graph."

--- a/src/scripts/test-check-notice-drift.sh
+++ b/src/scripts/test-check-notice-drift.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regression coverage for the notice-drift failure contract (#5064).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="${SCRIPT_DIR}/check-notice-drift.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+COMMITTED="${TMP}/NOTICE.committed"
+GENERATED="${TMP}/NOTICE.generated"
+
+printf 'license text\n' > "${COMMITTED}"
+cp "${COMMITTED}" "${GENERATED}"
+output="$("${CHECKER}" "${COMMITTED}" "${GENERATED}" 2>&1)"
+grep -qF 'NOTICE matches the current module graph.' <<< "${output}"
+
+# Whitespace-only drift is still real drift: NOTICE is compared byte-for-byte.
+printf 'license text \n' > "${GENERATED}"
+if output="$("${CHECKER}" "${COMMITTED}" "${GENERATED}" 2>&1)"; then
+  echo "whitespace-only NOTICE drift passed unexpectedly" >&2
+  exit 1
+fi
+
+for required in \
+  'src/scripts/generate-notice.sh' \
+  'byte-for-byte' \
+  'whitespace-significant' \
+  'commit the regenerated NOTICE verbatim'; do
+  if ! grep -qF -- "${required}" <<< "${output}"; then
+    echo "notice-drift diagnostic omitted '${required}'" >&2
+    echo "output: ${output}" >&2
+    exit 1
+  fi
+done
+
+echo "notice-drift checker tests: PASS"


### PR DESCRIPTION
## Summary

- keep NOTICE drift detection byte-exact while moving the comparison into a focused helper
- warn explicitly that whitespace is significant and the generated NOTICE must be committed verbatim
- exercise both the matching and whitespace-only drift paths in CI

Fixes #5064

## Testing

- `bash -n src/scripts/check-notice-drift.sh src/scripts/test-check-notice-drift.sh`
- `shellcheck src/scripts/check-notice-drift.sh src/scripts/test-check-notice-drift.sh`
- `src/scripts/test-check-notice-drift.sh`
- `src/scripts/check-notice-drift.sh NOTICE NOTICE`
- parsed `.github/workflows/go-security-analysis.yml` with PyYAML
- `git diff --check upstream/v4...HEAD`

## Changelog

Not added: this changes a CI-only failure diagnostic and its regression coverage, not shipped Hive behavior.

— hive: backend=codex
