### PR TITLE
📖 docs(beads): document bd decompose

### DIFF
--- a/src/docs/beads-cli.md
+++ b/src/docs/beads-cli.md
@@ -17,6 +17,35 @@
 | `bd remember "fact"` | Quick-add an advisory bead authored by `system`. |
 | `bd init` | No-op compatibility command; opening the store creates it. |
 | `bd dolt push` | No-op compatibility command; bead data is already persisted on disk. |
+| `bd decompose <epic-id> [--plan <file>] [--actor <lane>] [--auto-approve] [--print-prompt]` | Decompose an epic bead into a DAG of child task beads. See below. |
+
+## Decomposing an epic
+
+`bd decompose` turns one epic bead into a graph of child task beads, wiring
+their dependencies so `bd ready` only offers a child once its predecessors
+close.
+
+```bash
+bd decompose <epic-id> --plan plan.txt
+cat plan.txt | bd decompose <epic-id>          # or read the plan from stdin
+```
+
+| Flag | Effect |
+|---|---|
+| `--plan <file>` | File holding the planner's task list. Defaults to stdin. |
+| `--actor <lane>` | Override the child beads' actor/lane. Defaults to `classifier`/`architect`. |
+| `--auto-approve` | Approve the plan immediately — children are claimable at once, with no review gate. |
+| `--print-prompt` | Print the architect decomposition prompt for this epic and exit without writing anything. |
+
+**This does not run an agent.** The task breakdown is read from `--plan` or
+stdin, so the trigger stays manual and the planning package carries no
+agent/tmux dependency. Wiring the architect lane's live output in place of the
+file/stdin source is later-phase work — see `cmdDecompose` in
+`src/cmd/bd/decompose.go`.
+
+Without `--auto-approve` the children land behind a review gate, so use
+`--print-prompt` first when you want to see what an epic would expand into
+before committing anything to the ledger.
 
 Examples:
 


### PR DESCRIPTION
Fixes #5174

## What

`src/docs/beads-cli.md` (46 lines) had **zero** mentions of `decompose`, despite it being a real, dispatched, tested subcommand:

- `src/cmd/bd/decompose.go` — the implementation
- `src/cmd/bd/decompose_test.go` — its tests
- `src/cmd/bd/main.go:72` — `case "decompose": cmdDecompose(...)`
- `bd --help` already lists it

So the CLI advertised a command its own reference doc omitted.

## What was added

A table row plus a short section covering the four flags — each verified against the `flag.NewFlagSet` definitions in the source, not inferred from the issue:

| Flag | Effect |
|---|---|
| `--plan <file>` | Planner's task list; defaults to stdin |
| `--actor <lane>` | Override child actor/lane; defaults to `classifier`/`architect` |
| `--auto-approve` | Children claimable immediately, no review gate |
| `--print-prompt` | Print the architect prompt and exit |

## The caveat worth documenting

The source's own doc comment says it plainly:

> Phase 1 does **NOT** launch a live agent: the planner's task breakdown is read from a file (`--plan`) or stdin.

Without that, `bd decompose` reads like it will plan an epic for you — when it expects you to supply the plan. That is the detail an operator most needs from a reference page.

Docs only.