### PR TITLE
📖 docs(wiki): add the missing quality, guide, and brainstorm agents

### DIFF
--- a/src/deploy/data/wiki/agents.md
+++ b/src/deploy/data/wiki/agents.md
@@ -14,6 +14,22 @@ repository queue depth.
 The first-responder agent. Scans open issues and PRs for actionable items,
 triages new issues, and handles quick fixes. Runs frequently in all modes.
 
+## Quality
+
+Owns test suites, coverage gates, and regression checks. Typically the first
+agent an operator grants write access to when moving to L3.
+
+## Guide
+
+Audits documentation, onboarding material, and contributor experience,
+identifying gaps that make the project harder to pick up.
+
+## Brainstorm
+
+Idea incubation. **Advisory only** — it files beads, never GitHub issues or
+pull requests, at every level. Commonly left paused until an operator wants
+its output.
+
 ## CI Maintainer
 
 Monitors CI pipelines, fixes flaky tests, updates workflows, and ensures


### PR DESCRIPTION
Fixes #5180

## The missing-agents half is correct — fixed here

`src/deploy/data/wiki/agents.md` documented **7** agents; `src/hive.yaml.example` configures **10**.

| Agent | `hive.yaml.example` | wiki (before) |
|---|:--:|:--:|
| quality | ✓ | ✗ |
| guide | ✓ | ✗ |
| brainstorm | ✓ | ✗ |

`quality` matters most — it is the first agent most operators grant write access to at L3, and it is where test coverage actually lives. `guide` is the agent that authors these wiki audits.

Descriptions come from each agent's own policy fragment in `src/pkg/policies/defaults/`, not invented. `brainstorm` is documented as **advisory-only — beads, never issues or PRs** — because its fragment states that as a hard constraint at every level.

One verification note: `brainstorm` is **not** in `applyKnownAgentDefaults`, so a `config.go` grep makes it look nonexistent. It is registered through the ACMM packs instead (4 occurrences in each of `level-3` through `level-6`) and ships a policy fragment. Confirmed before documenting.

After this change the wiki and `hive.yaml.example` agree on all 10 configured agents.

## The model-slug half is not a bug

The issue also reports `claude-opus-4.6` (dots) in the "Adding a New Agent" example as wrong. It is correct as written, and changing it would break the example.

Slug notation is **backend-specific**, per `config/backends.conf` lines 7-8:

```
#   claude  → hyphens in version: claude-haiku-4-5, claude-opus-4-6
#   copilot → dots in version:    claude-haiku-4.5, claude-opus-4.6
```

That example's `launch_cmd` is `/usr/bin/copilot`, so dots are right. Both forms are handled deliberately in code — `config/backends.conf:518` matches `claude-opus-4-6*|claude-opus-4.6*` in one case arm, and `src/pkg/dashboard/cli_models.go` carries both.

This was previously reported as #5163 and closed with the same evidence. Left unchanged here.

Docs only.