### PR TITLE
fix(github): validate PR titles and closing references

### DIFF
--- a/src/pkg/github/attribution_test.go
+++ b/src/pkg/github/attribution_test.go
@@ -155,6 +155,9 @@ func attribPRMock(t *testing.T, postedBody *string) *httptest.Server {
 			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/issues/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":9,"title":"ordinary issue","body":"implement the requested change","state":"open"}`)
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			raw, _ := io.ReadAll(r.Body)
 			var np map[string]any

--- a/src/pkg/github/pr_request_claims.go
+++ b/src/pkg/github/pr_request_claims.go
@@ -1,0 +1,212 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// prRequestPolicyError is a permanent mismatch between a PR's claim and its
+// diff. It is distinct from forge/API errors, which the watcher should retry.
+type prRequestPolicyError struct {
+	reason string
+}
+
+func (e *prRequestPolicyError) Error() string { return e.reason }
+
+func prRequestPolicyReason(err error) (string, bool) {
+	var policyErr *prRequestPolicyError
+	if !errors.As(err, &policyErr) {
+		return "", false
+	}
+	return policyErr.reason, true
+}
+
+type titleArtifactRule struct {
+	name       string
+	titleMatch *regexp.Regexp
+	fileMatch  func(string) bool
+}
+
+var titleArtifactRules = []titleArtifactRule{
+	{name: "workflow", titleMatch: regexp.MustCompile(`(?i)\bworkflows?\b`), fileMatch: isWorkflowFile},
+	{name: "test", titleMatch: regexp.MustCompile(`(?i)\btests?\b`), fileMatch: isTestFile},
+	{name: "migration", titleMatch: regexp.MustCompile(`(?i)\bmigrations?\b`), fileMatch: isMigrationFile},
+}
+
+var uncheckedTaskItemRE = regexp.MustCompile(`(?m)^\s*[-*+]\s*\[\s\]`)
+
+// validatePRRequestClaims checks objective artifact claims against the compare
+// file list and downgrades unsafe closing references on structurally incomplete
+// issues. It returns the title/body to send to GitHub.
+func (c *Client) validatePRRequestClaims(ctx context.Context, req PRRequest) (string, string, error) {
+	if c == nil || c.client == nil {
+		return "", "", ErrNoGitHubClient
+	}
+
+	owner, repo := c.prRequestRepo(req.Repo)
+	defaultRepo := owner + "/" + repo
+	title, body := req.Title, req.Body
+
+	var claimedArtifacts []titleArtifactRule
+	for _, rule := range titleArtifactRules {
+		if rule.titleMatch.MatchString(title) {
+			claimedArtifacts = append(claimedArtifacts, rule)
+		}
+	}
+	if len(claimedArtifacts) > 0 {
+		base := strings.TrimSpace(req.Base)
+		if base == "" {
+			resolved, err := c.DefaultBranch(ctx, owner, repo)
+			if err != nil {
+				return "", "", fmt.Errorf("validating PR title artifacts: %w", err)
+			}
+			base = resolved
+		}
+		comparison, _, err := c.client.Repositories.CompareCommits(ctx, owner, repo, base, strings.TrimSpace(req.Head), nil)
+		if err != nil {
+			return "", "", fmt.Errorf("validating PR title against %s/%s diff %s...%s: %w", owner, repo, base, req.Head, err)
+		}
+		if comparison == nil {
+			return "", "", fmt.Errorf("validating PR title against %s/%s diff %s...%s: GitHub returned an empty comparison", owner, repo, base, req.Head)
+		}
+		for _, rule := range claimedArtifacts {
+			matched := false
+			for _, file := range comparison.Files {
+				if file != nil && rule.fileMatch(file.GetFilename()) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return "", "", &prRequestPolicyError{reason: fmt.Sprintf("title claims %s but diff contains no %s file", rule.name, rule.name)}
+			}
+		}
+	}
+
+	refs := ParseClaimedIssues(title+"\n"+body, defaultRepo)
+	if len(refs) == 0 {
+		return title, body, nil
+	}
+
+	downgrade := make(map[string]string)
+	for _, ref := range refs {
+		refOwner, refRepo := c.prRequestRepo(ref.Repo)
+		issue, _, err := c.client.Issues.Get(ctx, refOwner, refRepo, ref.Issue)
+		if err != nil {
+			return "", "", fmt.Errorf("validating closing reference %s#%d: %w", ref.Repo, ref.Issue, err)
+		}
+		if reason := incompleteIssueReason(issue); reason != "" {
+			key := claimKey(strings.ToLower(refOwner+"/"+refRepo), ref.Issue)
+			downgrade[key] = reason
+			c.logger.Warn("pr-request watcher: downgraded closing reference to Refs",
+				slog.String("repo", refOwner+"/"+refRepo), slog.Int("issue", ref.Issue),
+				slog.String("reason", reason), slog.String("head", req.Head))
+		}
+	}
+	if len(downgrade) == 0 {
+		return title, body, nil
+	}
+	return downgradeClosingReferences(title, defaultRepo, downgrade), downgradeClosingReferences(body, defaultRepo, downgrade), nil
+}
+
+func (c *Client) prRequestRepo(repo string) (string, string) {
+	owner := c.org
+	if parts := strings.SplitN(strings.TrimSpace(repo), "/", 2); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return owner, strings.TrimSpace(repo)
+}
+
+func incompleteIssueReason(issue *gh.Issue) string {
+	if issue == nil {
+		return "issue metadata is empty"
+	}
+	labels := make([]string, 0, len(issue.Labels))
+	for _, label := range issue.Labels {
+		name := label.GetName()
+		labels = append(labels, name)
+		if strings.EqualFold(name, "epic") || strings.EqualFold(name, "tracker") || strings.EqualFold(name, "meta-tracker") {
+			return "issue is labeled as a tracker or epic"
+		}
+	}
+	title := strings.ToLower(strings.TrimSpace(issue.GetTitle()))
+	if strings.HasPrefix(title, "[epic]") || strings.HasPrefix(title, "[tracker]") {
+		return "issue title marks it as a tracker or epic"
+	}
+	if IsTrackerIssue(issue.GetTitle(), labels, issue.GetBody()) {
+		return "issue is a tracker"
+	}
+	if uncheckedTaskItemRE.MatchString(issue.GetBody()) {
+		return "issue has unchecked task items"
+	}
+	return ""
+}
+
+func downgradeClosingReferences(text, defaultRepo string, downgrade map[string]string) string {
+	if text == "" {
+		return text
+	}
+	return claimRefPattern.ReplaceAllStringFunc(text, func(match string) string {
+		parts := claimRefPattern.FindStringSubmatch(match)
+		if len(parts) < 4 {
+			return match
+		}
+		issue, err := strconv.Atoi(parts[3])
+		if err != nil {
+			return match
+		}
+		repo := parts[2]
+		if repo == "" {
+			repo = defaultRepo
+		}
+		if _, ok := downgrade[claimKey(strings.ToLower(repo), issue)]; !ok {
+			return match
+		}
+		return "Refs" + match[len(parts[1]):]
+	})
+}
+
+func isWorkflowFile(filename string) bool {
+	filename = strings.ToLower(strings.TrimPrefix(path.Clean(filename), "./"))
+	if !strings.HasPrefix(filename, ".github/workflows/") {
+		return false
+	}
+	ext := path.Ext(filename)
+	return ext == ".yml" || ext == ".yaml"
+}
+
+func isTestFile(filename string) bool {
+	filename = strings.ToLower(strings.TrimPrefix(path.Clean(filename), "./"))
+	base := path.Base(filename)
+	ext := path.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	if strings.HasSuffix(stem, "_test") || strings.HasSuffix(stem, "_spec") ||
+		strings.HasPrefix(base, "test_") || strings.HasPrefix(base, "test-") ||
+		strings.Contains(base, ".test.") || strings.Contains(base, ".spec.") || ext == ".bats" {
+		return true
+	}
+	for _, segment := range strings.Split(filename, "/") {
+		if segment == "test" || segment == "tests" || segment == "spec" || segment == "specs" || segment == "__tests__" {
+			return true
+		}
+	}
+	return false
+}
+
+func isMigrationFile(filename string) bool {
+	filename = strings.ToLower(strings.TrimPrefix(path.Clean(filename), "./"))
+	for _, segment := range strings.Split(filename, "/") {
+		if segment == "migration" || segment == "migrations" || segment == "migrate" {
+			return true
+		}
+	}
+	return false
+}

--- a/src/pkg/github/pr_request_claims_test.go
+++ b/src/pkg/github/pr_request_claims_test.go
@@ -1,0 +1,171 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func claimValidationServer(t *testing.T, files []string, issue map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			changed := make([]map[string]string, 0, len(files))
+			for _, file := range files {
+				changed = append(changed, map[string]string{"filename": file, "status": "modified"})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ahead", "files": changed})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/"):
+			_ = json.NewEncoder(w).Encode(issue)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func claimValidationClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	return NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestValidatePRRequestClaims_ArtifactTitleMatchesDiff(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		file  string
+	}{
+		{"workflow", "ci: add upstream sync workflow", ".github/workflows/sync.yml"},
+		{"test", "test: cover retry behavior", "src/retry_test.go"},
+		{"cross-language test", "test: cover sync helper", "build-aux/sync_test.py"},
+		{"migration", "db: add user migration", "db/migrations/001_users.sql"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := claimValidationServer(t, []string{tt.file}, nil)
+			defer srv.Close()
+			c := claimValidationClient(t, srv)
+			gotTitle, _, err := c.validatePRRequestClaims(context.Background(), PRRequest{
+				Repo: "o/r", Base: "main", Head: "agent/change", Title: tt.title,
+			})
+			if err != nil {
+				t.Fatalf("validatePRRequestClaims: %v", err)
+			}
+			if gotTitle != tt.title {
+				t.Fatalf("title = %q, want %q", gotTitle, tt.title)
+			}
+		})
+	}
+}
+
+func TestValidatePRRequestClaims_RejectsMissingClaimedArtifact(t *testing.T) {
+	srv := claimValidationServer(t, []string{"docs/UPSTREAM.md", "build-aux/sync-upstream.sh"}, nil)
+	defer srv.Close()
+	c := claimValidationClient(t, srv)
+
+	_, _, err := c.validatePRRequestClaims(context.Background(), PRRequest{
+		Repo: "o/r", Base: "main", Head: "agent/change", Title: "ci: add upstream sync workflow",
+	})
+	reason, ok := prRequestPolicyReason(err)
+	if !ok || reason != "title claims workflow but diff contains no workflow file" {
+		t.Fatalf("error = %v (%q, policy=%v)", err, reason, ok)
+	}
+}
+
+func TestPRRequestWatcher_QuarantinesArtifactClaimMismatch(t *testing.T) {
+	created := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			_, _ = io.WriteString(w, `{"status":"ahead","files":[{"filename":"docs/UPSTREAM.md"}]}`)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+			created++
+			_, _ = io.WriteString(w, `{"number":42}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := claimValidationClient(t, srv)
+	c.prAuthz = func(string, int) error { return nil }
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Base: "main", Head: "agent/change", Title: "ci: add upstream sync workflow", Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Fatalf("mismatched title created %d PRs, want 0", created)
+	}
+	if _, err := os.Stat(reqPath + ".rejected"); err != nil {
+		t.Fatalf("rejected request was not quarantined: %v", err)
+	}
+	result, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(result), "title claims workflow but diff contains no workflow file") {
+		t.Fatalf("result lacks actionable mismatch: %s", result)
+	}
+}
+
+func TestValidatePRRequestClaims_DowngradesIncompleteIssues(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue map[string]any
+	}{
+		{"unchecked task", map[string]any{"number": 60, "title": "work", "body": "- [x] first\n- [ ] remaining", "state": "open"}},
+		{"epic label", map[string]any{"number": 60, "title": "work", "body": "several phases", "state": "open", "labels": []map[string]string{{"name": "epic"}}}},
+		{"tracker title", map[string]any{"number": 60, "title": "[Tracker] program", "body": "children", "state": "open"}},
+		{"epic title", map[string]any{"number": 60, "title": "[EPIC] program", "body": "children", "state": "open"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := claimValidationServer(t, nil, tt.issue)
+			defer srv.Close()
+			c := claimValidationClient(t, srv)
+			title, body, err := c.validatePRRequestClaims(context.Background(), PRRequest{
+				Repo: "o/r", Head: "agent/change", Title: "Fixes #60: partial work", Body: "Closes: #60\n\nDetails",
+			})
+			if err != nil {
+				t.Fatalf("validatePRRequestClaims: %v", err)
+			}
+			if title != "Refs #60: partial work" || body != "Refs: #60\n\nDetails" {
+				t.Fatalf("downgraded title/body = %q / %q", title, body)
+			}
+		})
+	}
+}
+
+func TestValidatePRRequestClaims_LeavesCompleteIssueClosingReference(t *testing.T) {
+	issue := map[string]any{"number": 7, "title": "focused bug", "body": "One concrete acceptance criterion", "state": "open"}
+	srv := claimValidationServer(t, nil, issue)
+	defer srv.Close()
+	c := claimValidationClient(t, srv)
+
+	title, body, err := c.validatePRRequestClaims(context.Background(), PRRequest{
+		Repo: "o/r", Head: "agent/change", Title: "fix: focused bug", Body: "Fixes #7",
+	})
+	if err != nil {
+		t.Fatalf("validatePRRequestClaims: %v", err)
+	}
+	if title != "fix: focused bug" || body != "Fixes #7" {
+		t.Fatalf("title/body changed: %q / %q", title, body)
+	}
+}

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -228,39 +228,33 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		return
 	}
 
+	// Validate claims while the request is still at the server-side choke point.
+	// Agents cannot bypass this by invoking a different CLI: direct POST /pulls
+	// is denied by the proxy, and every supported path arrives here.
+	title, body, err := c.validatePRRequestClaims(ctx, req)
+	if err != nil {
+		if reason, policy := prRequestPolicyReason(err); policy {
+			c.rejectPRRequest(path, req, reason, nowFn)
+			return
+		}
+		c.failPRRequest(path, req, err, nowFn)
+		return
+	}
+
 	// Invocation-attribution trail (attribution.go): resolve what the hive
 	// invoked for this agent, append the visible trailer to the PR body when
 	// the toggle is on, and — below, on success — record the audit entry
 	// unconditionally. This choke point covers every agent regardless of CLI,
 	// because the proxy hard-denies direct POST /pulls.
 	meta := c.attributionMeta(req.Agent)
-	body := req.Body
 	if c.attributionTrailerOn() {
 		body = AppendTrailer(body, meta)
 	}
 
-	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, body)
+	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, title, body)
 	resp := PRResponse{At: nowFn().UTC().Format(time.RFC3339)}
 	if err != nil {
-		// Leave the request in place so a later tick retries (transient API
-		// errors, main not yet pushed, etc.) — but with exponential backoff, and
-		// quarantine once the give-up horizon passes. Retrying every tick
-		// forever let ~10 poisoned requests generate thousands of junk create
-		// calls an hour, tripping the org-wide secondary rate limit
-		// (request_retry.go).
-		resp.OK = false
-		resp.Error = err.Error()
-		c.writePRResult(path, resp)
-		if c.prRetries.noteFailure(path, nowFn()) {
-			_ = os.Rename(path, path+".failed")
-			c.prRetries.clear(path)
-			c.logger.Error("pr-request watcher: request exceeded retry horizon, quarantined",
-				slog.String("path", path), slog.String("repo", req.Repo),
-				slog.String("head", req.Head), slog.String("error", err.Error()))
-			return
-		}
-		c.logger.Warn("pr-request watcher: open failed, will retry with backoff",
-			slog.String("repo", req.Repo), slog.String("head", req.Head), slog.String("error", err.Error()))
+		c.failPRRequest(path, req, err, nowFn)
 		return
 	}
 	resp.OK = true
@@ -314,6 +308,36 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		slog.String("repo", req.Repo), slog.String("head", req.Head),
 		slog.Int("number", res.Number), slog.Bool("reused", res.AlreadyExisted),
 		slog.String("agent", req.Agent))
+}
+
+// failPRRequest records a transient validation or PR-creation failure. The
+// request remains queued and is retried with the same bounded backoff used for
+// all other forge failures.
+func (c *Client) failPRRequest(path string, req PRRequest, err error, nowFn func() time.Time) {
+	resp := PRResponse{OK: false, Error: err.Error(), At: nowFn().UTC().Format(time.RFC3339)}
+	c.writePRResult(path, resp)
+	if c.prRetries.noteFailure(path, nowFn()) {
+		_ = os.Rename(path, path+".failed")
+		c.prRetries.clear(path)
+		c.logger.Error("pr-request watcher: request exceeded retry horizon, quarantined",
+			slog.String("path", path), slog.String("repo", req.Repo),
+			slog.String("head", req.Head), slog.String("error", err.Error()))
+		return
+	}
+	c.logger.Warn("pr-request watcher: request failed, will retry with backoff",
+		slog.String("repo", req.Repo), slog.String("head", req.Head), slog.String("error", err.Error()))
+}
+
+// rejectPRRequest records a claim-validation mismatch and quarantines it. A
+// changed request or branch is required to make it valid, so retrying the same
+// file would only consume API quota and hide the actionable feedback.
+func (c *Client) rejectPRRequest(path string, req PRRequest, reason string, nowFn func() time.Time) {
+	c.writePRResult(path, PRResponse{OK: false, Error: "PR claim rejected: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
+	_ = os.Rename(path, path+".rejected")
+	c.prRetries.clear(path)
+	c.logger.Warn("pr-request watcher: REJECTED (claim mismatch)",
+		slog.String("agent", req.Agent), slog.String("repo", req.Repo),
+		slog.String("head", req.Head), slog.String("reason", reason))
 }
 
 // denyPRRequest records an authorization failure and quarantines the request

--- a/src/pkg/github/pr_request_watcher_test.go
+++ b/src/pkg/github/pr_request_watcher_test.go
@@ -44,6 +44,9 @@ func newPRMockServerLabels(t *testing.T, existingHead string, created *int, adde
 				return
 			}
 			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/issues/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":1,"title":"ordinary issue","body":"implement the requested change","state":"open"}`)
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			if created != nil {
 				*created++


### PR DESCRIPTION
## Summary

The PR request watcher was checking who may open a PR, but not whether the PR's claims matched the branch it was about to publish. It passed the request's title and body straight to `CreatePR`, so an agent could call a manual script a "workflow" without changing a workflow file, or attach `Fixes #N` to a tracker that the branch only partly addressed. Once merged, GitHub would trust the closing keyword and close the issue anyway.

This PR adds claim validation at that server-side choke point, after authorization and before PR creation:

- artifact words in the title (`workflow`, `test`, `migration`, including plurals) are checked against the compare diff
- a missing claimed artifact permanently rejects and quarantines the request with an actionable `.result.json` error
- closing references targeting structurally incomplete work are rewritten to `Refs` before the PR is opened
- GitHub lookup failures remain transient and use the watcher's existing bounded retry/backoff path

Fixes #5112.

## The reported incident now fails before PR creation

The incident title was `ci: add upstream sync workflow`, but its diff contained only `docs/UPSTREAM.md`, `build-aux/sync-upstream.sh`, and a README edit. The new end-to-end regression submits that same shape through `ProcessPRRequestsOnce` and asserts all three externally visible outcomes:

1. no `POST /pulls` occurs
2. the request is quarantined as `.rejected`
3. the result explains `title claims workflow but diff contains no workflow file`

This check lives in the watcher rather than in agent instructions. Direct `POST /pulls` is already denied by the proxy, so every supported agent PR path reaches the same validation point regardless of CLI or backend.

## Artifact claim contract

The title match is case-insensitive and word-bounded, so `workflow`/`workflows`, `test`/`tests`, and `migration`/`migrations` are claims while unrelated words containing those strings are not.

Each claim has an objective changed-path requirement:

| title claim | accepted changed paths |
|---|---|
| workflow | `.github/workflows/*.yml` or `.github/workflows/*.yaml` |
| test | conventional `test`/`tests`/`spec` directories and common cross-language names such as `*_test.*`, `*_spec.*`, `test_*`, `*.test.*`, `*.spec.*`, and `*.bats` |
| migration | a path containing a `migration`, `migrations`, or `migrate` directory segment |

If a title claims more than one artifact type, the diff must contain each one. The compare request is made only when the title contains one of these claims, avoiding a new API call for ordinary titles. When the request omits `base`, validation resolves the repository's real default branch through the same cached metadata path `CreatePR` uses; it does not guess `main`.

## Closing-reference handling

The watcher scans both title and body using Hive's existing parser for GitHub's `close`, `fix`, and `resolve` keyword families. It then reads each referenced issue and downgrades the matching keyword to `Refs` when the issue carries strong structural evidence that one branch must not auto-close it:

- `epic`, `tracker`, or `meta-tracker` label
- `[Epic]` or `[Tracker]` title marker
- Hive's existing tracker detector (including a multi-issue task list)
- any unchecked Markdown task item

The rewrite is targeted per issue and preserves the rest of the reference, including same-repository and `owner/repo#N` forms. A PR can therefore retain a valid `Fixes #7` while an incomplete `Closes #8` in the same request becomes `Refs #8`.

This is deliberately conservative. Code cannot prove from filenames alone that an arbitrary implementation semantically completes an ordinary focused issue. Rejecting every uncertain closing reference would create false positives; trusting known trackers and unfinished task lists would recreate the reported auto-close risk. The implementation rewrites only where the issue itself provides objective incompleteness evidence and leaves focused issues unchanged.

## Failure and retry behavior

Claim mismatches and forge failures are different classes:

- **permanent mismatch:** a title names an artifact absent from the diff; write the actionable result, rename the request to `.rejected`, clear retry state, and stop
- **transient evidence failure:** compare/default-branch/issue lookup fails; keep the request queued and apply the existing exponential backoff and give-up horizon
- **valid request:** pass the validated title/body to the existing attribution and `CreatePR` path unchanged

The old PR-creation failure block is factored into `failPRRequest`, so validation lookups and PR creation share exactly the same retry/quarantine behavior rather than growing a second retry policy.

## Testing

`pr_request_claims_test.go` covers:

- workflow, test, cross-language test, and migration claims with matching files
- the real incident shape with no workflow file
- end-to-end rejection, no PR creation, `.rejected` quarantine, and actionable result text
- closing-reference downgrades for unchecked tasks, epic/tracker labels, and epic/tracker title markers
- rewrites in both PR title and body
- preservation of `Fixes` for a focused issue without structural incompleteness

Existing watcher and attribution mocks now serve focused issue metadata, confirming the new validation step does not disturb PR creation, deduplication, trailers, audits, hold labels, or retry behavior.

Commands run successfully:

- `go build ./...`
- `go test ./pkg/github`
- `go vet ./pkg/github`
- `git diff --check`

I also ran `go test ./...`. The changed `pkg/github` package and the rest of the ordinary suite passed; host-sensitive tests in `pkg/agent` and `pkg/config` failed because this checkout's generated tmux socket exceeded the Unix socket path limit and the host `ip6tables` binary lacked `NET_ADMIN`. Neither failing package is changed by this PR.

## Scope

This PR validates agent-filed PR requests at creation time. It does not edit existing PRs, infer semantic completeness for unstructured issue prose, or change GitHub's merge-time closing behavior. The compare result is intentionally local to this guard; it can be shared with a future duplicate-tree gate without changing this contract.

## Contributor checklist

- [x] Targets `v4`
- [x] Ready for review, not draft
- [x] Commit carries a DCO sign-off matching the author email
- [x] Regression test reproduces the reported no-workflow diff
- [x] No credentials, runtime state, or generated test artifacts committed

— hive: backend=codex
