### PR TITLE
📖 docs(tui): document hivectl tui, refresh the stale contract-status table

### DIFF
--- a/src/docs/design/tui.md
+++ b/src/docs/design/tui.md
@@ -126,48 +126,47 @@ package. The mapping for the whole epic:
 
 Verification for every code task is `go test ./pkg/tui/...`, run from `src/`.
 
-### Contract status: the spec covers 11% of the API, and no writes
+### Contract status: the spec now covers writes, with four gaps
 
 The Contract decision names `dashboard/openapi.json` as the source of truth and
-tells a sub-issue what to do when an operation is missing from it. That clause
-is going to fire far more often than the epic assumes, so the size of the gap is
-recorded here once rather than rediscovered by each task.
+tells a sub-issue what to do when an operation is missing from it. This section
+records how large that gap actually is.
 
-Measured at `45a13d5`:
+**Originally measured at `45a13d5`, the spec was GET-only: 32 routes, zero
+writes.** [#5023](https://github.com/kubestellar/hive/pull/5023) closed most of
+that — it found the 32-vs-298 comparison had been made against
+`dashboard/server.js`, a legacy Node prototype that `dashboard/README.md`
+states v2 production never starts, and re-measured against the live Go server.
 
-| | Published in `dashboard/openapi.json` | Registered by the dashboard |
-|---|---:|---:|
-| Distinct `/api` routes | 32 | 298 |
-| `GET` | 32 | 137 |
-| `POST` | **0** | 83 |
-| `PUT` | **0** | 64 |
-| `DELETE` | **0** | 14 |
+Current state:
 
-The spec is **GET-only**. It documents no write operation of any kind, which
-means **every Phase 2 action task in the epic — T14 pause/resume, T17 apply
-model, T19 apply ACMM, T20 kick now — has no contract to build against.** Each
-of those endpoints exists and is exercised today by `hivectl`; none is in the
-spec:
+| Method | Published in `dashboard/openapi.json` |
+|---|---:|
+| Distinct `/api` paths | 255 |
+| `GET` | 131 |
+| `POST` | 83 |
+| `PUT` | 64 |
+| `DELETE` | 14 |
 
-| Task | Endpoint `hivectl` uses today | In spec |
-|---|---|---|
-| T14 pause/resume | `POST /api/pause/{name}`, `POST /api/resume/{name}` (`commands/agent.go:39`) | no |
-| T17 apply model | `PUT /api/config/agent/{name}/models` (`commands/agent.go:262`) | no |
-| T19 apply ACMM | `GET /api/acmm/evaluation`, `POST /api/acmm/issue` (`dashboard/api.go:228-229`) | no |
-| T20 kick now | `POST /api/kick/{name}` (`commands/agent.go:158`) | no |
+The Phase 2 action tasks now have a contract to build against, and the two read
+tasks that were blocked are unblocked: **`/api/agents` is in the spec** (`get`,
+`post`), as is `/api/acmm/evaluation` and `/api/events`.
 
-Two **read** tasks are affected too, and one of them is named after the gap:
+The Phase 2 action endpoints are all published — note the path parameter is
+`{agent}`, not `{name}`: `POST /api/pause/{agent}`, `POST /api/resume/{agent}`,
+`POST /api/kick/{agent}`, plus `/api/agents/{name}/kicks`.
 
-- **T2 (#4917) is "API client core + `/api/health`" — `/api/health` is not in
-  the spec.** It is a real endpoint (`hivectl system health` calls it,
-  `commands/system.go`), just an undocumented one.
-- **T4 needs the agent list. `/api/agents` is not in the spec** either, though
-  `hivectl agent list` calls it (`commands/agent.go:24`). The spec has
-  `/api/status` and `/api/config/agent/{name}`, but no list operation.
+**One endpoint remains unpublished by design.** `GET /api/health` (used by
+`hivectl system health`, `commands/system.go`) sits in the parity test's
+documented exception set as "not part of the client data contract", alongside
+`/api/health/deep`, `/api/livez`, `/api/docs`, `/api/contribute/ws`,
+`/api/terminal/assertion/renew` and the legacy `/api/v1/` catch-all. T2 should
+treat it as a deliberate exception rather than a gap to fill.
 
-Of the four pane endpoints, only three are published: `/api/status`,
-`/api/config/governor`, `/api/tokens` and `/api/events` are all in the spec;
-`/api/agents` is not.
+`TestOpenAPISpecCoversEveryRegisteredRoute`
+(`src/pkg/dashboard/openapi_route_parity_test.go`, added by #5023) now fails if
+a registered route and the spec diverge in either direction, so this section
+should not go stale again silently.
 
 **What this means for sub-issues.** The epic's own escape hatch applies and
 should be used deliberately rather than as a surprise: a task whose endpoint is

--- a/src/docs/hivectl.md
+++ b/src/docs/hivectl.md
@@ -137,6 +137,38 @@ hivectl observe timeline
 hivectl observe trends --range week        # or --hours 12 (1-720); not both
 ```
 
+### tui — live terminal dashboard
+
+```bash
+hivectl tui
+```
+
+Opens a full-screen, keyboard-driven view of the fleet over the same dashboard
+API the non-interactive subcommands use, so it honours the same `--hive` /
+endpoint configuration. Requires a real terminal; press `q` or `ctrl+c` to
+exit.
+
+**Under active construction.** Four panes sit in a 2×2 grid, and only half are
+wired to live data today:
+
+| Pane | State |
+|---|---|
+| Agents | live — polls `GET /api/agents` |
+| Tokens | live — per-agent rows and fleet total |
+| Governor | stub — renders its title, pending T7 |
+| Events | stub — renders its title, pending T11 |
+
+`tab` moves focus between panes; `q` or `ctrl+c` exits. Those are the only keys
+bound: no help overlay, no pause/resume, no resize handling yet.
+
+Note the command's own `--help` text describes an event feed — that is the
+end-state design, not what ships today.
+
+Track progress under the `hive tui` epic
+([#4907](https://github.com/kubestellar/hive/issues/4907)); the open `tui T*`
+issues list what is still missing. Prefer the web dashboard or the
+non-interactive subcommands above for anything you need today.
+
 ### enroll — spoke-based lite repo enrollment
 
 ```bash


### PR DESCRIPTION
Fixes #5191
Fixes #5192

## #5191 — `hivectl tui` was undocumented

`src/pkg/hivectl/commands/tui.go` is a real, registered, tested subcommand. `src/docs/hivectl.md` never mentioned it across 161 lines.

Documented with **what ships today**, not the end-state design:

| Pane | State |
|---|---|
| Agents | live — polls `GET /api/agents` |
| Tokens | live — per-agent rows and fleet total |
| Governor | stub — pending T7 |
| Events | stub — pending T11 |

`tab` moves focus, `q`/`ctrl+c` exits; no help overlay, pause/resume, or resize handling yet. Ten `tui T*` issues remain open under #4907.

The command's own `--help` promises an event feed. That pane is `type Events struct{ stub }`. The doc notes the discrepancy rather than repeating the promise.

## #5192 — contract-status section was stale

`src/docs/design/tui.md` claimed the spec covers **"11% of the API, and no writes"** — 32 routes, zero POST/PUT/DELETE — and listed T14/T17/T19/T20 as having no contract to build against.

[#5023](https://github.com/kubestellar/hive/pull/5023) changed that:

| | Then (`45a13d5`) | Now |
|---|---:|---:|
| Paths | 32 | **255** |
| POST | 0 | **83** |
| PUT | 0 | **64** |
| DELETE | 0 | **14** |

`/api/agents`, `/api/acmm/evaluation` and `/api/events` are all published, so the blocked read tasks are unblocked.

## A near-miss worth recording

While correcting it I almost introduced a fresh error. `/api/pause`, `/api/resume` and `/api/kick` appeared absent — because I searched for `{name}` when the spec uses **`{agent}`**. They are published.

Only `GET /api/health` is genuinely unpublished, and deliberately: it sits in `TestOpenAPISpecCoversEveryRegisteredRoute`'s documented exception set as "not part of the client data contract". T2 should treat it as an exception, not a gap.

Docs only.