### PR TITLE
fix(github): keep agent metadata out of publishable content

### DIFF
--- a/src/pkg/github/attribution_test.go
+++ b/src/pkg/github/attribution_test.go
@@ -153,6 +153,9 @@ func attribPRMock(t *testing.T, postedBody *string) *httptest.Server {
 			// CreatePR resolves it here (kubestellar/hive#4928).
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/compare/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"files":[]}`)
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			_, _ = io.WriteString(w, `[]`)
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/issues/"):

--- a/src/pkg/github/pr_request_content.go
+++ b/src/pkg/github/pr_request_content.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const githubCompareFileLimit = 300
+
+var compareHunkRE = regexp.MustCompile(`^@@ -(?:\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
+
+// prContentMetadataError is a permanent policy mismatch: changing the request
+// metadata cannot make the candidate branch safe, but changing the branch can.
+// Forge/API errors remain ordinary errors so the watcher retries them.
+type prContentMetadataError struct {
+	file string
+	line int
+	kind string
+}
+
+func (e *prContentMetadataError) Error() string {
+	return fmt.Sprintf("internal %s metadata in %s:%d; attribution and run metadata belong in the PR body or commit trailer, not committed files", e.kind, e.file, e.line)
+}
+
+func prContentMetadataReason(err error) (string, bool) {
+	var metadataErr *prContentMetadataError
+	if !errors.As(err, &metadataErr) {
+		return "", false
+	}
+	return metadataErr.Error(), true
+}
+
+// validatePRRequestContent checks only lines added by the candidate branch.
+// Existing repository prose and deleted metadata do not block a cleanup PR.
+func (c *Client) validatePRRequestContent(ctx context.Context, req PRRequest) error {
+	if c == nil || c.client == nil {
+		return ErrNoGitHubClient
+	}
+
+	owner, repo := c.splitRepo(strings.TrimSpace(req.Repo))
+	base := strings.TrimSpace(req.Base)
+	if base == "" {
+		resolved, err := c.DefaultBranch(ctx, owner, repo)
+		if err != nil {
+			return fmt.Errorf("validating PR content metadata: %w", err)
+		}
+		base = resolved
+	}
+	head := strings.TrimSpace(req.Head)
+	comparison, _, err := c.client.Repositories.CompareCommits(ctx, owner, repo, base, head, nil)
+	if err != nil {
+		return fmt.Errorf("validating PR content metadata in %s/%s diff %s...%s: %w", owner, repo, base, head, err)
+	}
+	if comparison == nil {
+		return fmt.Errorf("validating PR content metadata in %s/%s diff %s...%s: GitHub returned an empty comparison", owner, repo, base, head)
+	}
+	// GitHub exposes changed files only on the first compare page and caps that
+	// list at 300. Do not claim a clean scan when later files may be invisible.
+	if len(comparison.Files) >= githubCompareFileLimit {
+		return fmt.Errorf("validating PR content metadata in %s/%s diff %s...%s: comparison reached GitHub's %d-file scan limit", owner, repo, base, head, githubCompareFileLimit)
+	}
+	for _, file := range comparison.Files {
+		if file == nil || file.GetPatch() == "" {
+			continue
+		}
+		line, kind, found := addedInternalMetadata(file.GetPatch())
+		if found {
+			return &prContentMetadataError{file: file.GetFilename(), line: line, kind: kind}
+		}
+	}
+	return nil
+}
+
+// addedInternalMetadata scans a unified patch and returns the new-file line of
+// the first leaked attribution marker. Marker strings are assembled from
+// fragments so this detector's own source is not itself a match.
+func addedInternalMetadata(patch string) (line int, kind string, found bool) {
+	filedPrefix := strings.ToLower("Filed" + " by ")
+	hivePrefix := strings.ToLower("hive" + ":")
+	newLine := 0
+	inHunk := false
+
+	scanner := bufio.NewScanner(strings.NewReader(patch))
+	for scanner.Scan() {
+		text := scanner.Text()
+		if match := compareHunkRE.FindStringSubmatch(text); match != nil {
+			newLine, _ = strconv.Atoi(match[1])
+			inHunk = true
+			continue
+		}
+		if !inHunk || text == "" {
+			continue
+		}
+		switch text[0] {
+		case '+':
+			if strings.HasPrefix(text, "+++") {
+				continue
+			}
+			added := strings.TrimSpace(text[1:])
+			lower := strings.ToLower(added)
+			if filed := strings.Index(lower, filedPrefix); filed >= 0 &&
+				strings.Contains(lower[filed+len(filedPrefix):], " agent (acmm") {
+				return newLine, "agent attribution", true
+			}
+			trimmed := strings.TrimSpace(strings.TrimLeft(added, "—-"))
+			if strings.HasPrefix(strings.ToLower(trimmed), hivePrefix) {
+				return newLine, "hive run", true
+			}
+			newLine++
+		case '-':
+			// Removed lines do not exist in the candidate tree.
+		case ' ':
+			newLine++
+		case '\\':
+			// "No newline at end of file" marker.
+		}
+	}
+	return 0, "", false
+}

--- a/src/pkg/github/pr_request_content_test.go
+++ b/src/pkg/github/pr_request_content_test.go
@@ -1,0 +1,135 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAddedInternalMetadata(t *testing.T) {
+	filed := "*" + "Filed" + " by outreach agent (ACMM L6 — full mode)*"
+	hive := "— " + "hive" + ": agent=outreach backend=agy"
+	tests := []struct {
+		name     string
+		patch    string
+		wantLine int
+		wantKind string
+	}{
+		{
+			name:     "agent attribution added",
+			patch:    "@@ -8,2 +8,3 @@\n context\n+" + filed + "\n context\n",
+			wantLine: 9,
+			wantKind: "agent attribution",
+		},
+		{
+			name:     "hive run trailer added",
+			patch:    "@@ -0,0 +1,2 @@\n+# Page\n+" + hive + "\n",
+			wantLine: 2,
+			wantKind: "hive run",
+		},
+		{
+			name:  "removed attribution allowed",
+			patch: "@@ -1,2 +1 @@\n-" + filed + "\n clean\n",
+		},
+		{
+			name:  "context attribution allowed",
+			patch: "@@ -1,2 +1,3 @@\n " + filed + "\n+real content\n context\n",
+		},
+		{
+			name:  "ordinary authorship prose allowed",
+			patch: "@@ -1 +1 @@\n+Filed by the release engineering team.\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			line, kind, found := addedInternalMetadata(tc.patch)
+			if tc.wantKind == "" {
+				if found {
+					t.Fatalf("unexpected match at line %d (%s)", line, kind)
+				}
+				return
+			}
+			if !found || line != tc.wantLine || kind != tc.wantKind {
+				t.Fatalf("got (%d, %q, %v), want (%d, %q, true)", line, kind, found, tc.wantLine, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestPRRequestWatcherRejectsInternalMetadata(t *testing.T) {
+	created := 0
+	filed := "*" + "Filed" + " by outreach agent (ACMM L6 — full mode)*"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r":
+			_, _ = io.WriteString(w, `{"default_branch":"docs"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/compare/docs...outreach/page":
+			_ = json.NewEncoder(w).Encode(map[string]any{"files": []map[string]string{{
+				"filename": "docs/page.md",
+				"patch":    "@@ -1 +1,3 @@\n # Page\n+copy\n+" + filed,
+			}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/o/r/pulls":
+			created++
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.prAuthz = func(string, int) error { return nil }
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "outreach/page", Title: "docs: add page", Agent: "outreach",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Fatalf("unsafe content must not create a PR; got %d creates", created)
+	}
+	if _, err := os.Stat(reqPath + ".rejected"); err != nil {
+		t.Fatalf("unsafe request was not quarantined as .rejected: %v", err)
+	}
+	result, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"docs/page.md:3", "PR body or commit trailer"} {
+		if !strings.Contains(string(result), want) {
+			t.Errorf("result %q does not contain %q", result, want)
+		}
+	}
+}
+
+func TestValidatePRRequestContentUsesExplicitBase(t *testing.T) {
+	var comparePath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		comparePath = r.URL.Path
+		_, _ = io.WriteString(w, `{"files":[]}`)
+	}))
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.Default())
+
+	err := c.validatePRRequestContent(context.Background(), PRRequest{Repo: "o/r", Base: "release", Head: "fix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comparePath != "/repos/o/r/compare/release...fix" {
+		t.Fatalf("compare path = %q", comparePath)
+	}
+}

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -242,6 +242,20 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		return
 	}
 
+	// Scan the candidate diff at the same choke point (#5114). The gate above
+	// checks what the request SAYS; this one checks what the branch would
+	// PUBLISH — agent and run metadata committed into files, which no change to
+	// the request can make safe. Both run because a request can be honest about
+	// a branch that is still unpublishable.
+	if err := c.validatePRRequestContent(ctx, req); err != nil {
+		if reason, policy := prContentMetadataReason(err); policy {
+			c.rejectPRRequest(path, req, "content", reason, nowFn)
+			return
+		}
+		c.failPRRequest(path, req, err, nowFn)
+		return
+	}
+
 	// Public outreach prose speaks for the project, so it gets a second gate at
 	// the same choke point (#5115). The check above is about the request being
 	// accurate; this one is about the project being able to stand behind what

--- a/src/pkg/github/pr_request_watcher_test.go
+++ b/src/pkg/github/pr_request_watcher_test.go
@@ -35,6 +35,9 @@ func newPRMockServerLabels(t *testing.T, existingHead string, created *int, adde
 			// coverage for kubestellar/hive#4928 lives in pullrequest_base_test.go.
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/compare/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"files":[]}`)
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			// dedupe list — return one PR only when the requested head matches.
 			head := r.URL.Query().Get("head") // "owner:branch"
@@ -281,6 +284,10 @@ func TestPRRequestWatcher_RetriesRequiredHoldLabelFailure(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/repos/o/r"):
 			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
+		// The content gate compares base...head before the PR is opened; this
+		// test is about the hold label, so the diff is empty and clean.
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			_, _ = io.WriteString(w, `{"files":[]}`)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls"):
 			if created > 0 {
 				_, _ = io.WriteString(w, `[{"number":42,"html_url":"https://github.com/o/r/pull/42","head":{"ref":"scanner/hold"}}]`)
@@ -347,6 +354,9 @@ func newPRFailingMockServer(t *testing.T, created *int, fails *int) *httptest.Se
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/repos/o/r"):
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/compare/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"files":[]}`)
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
 			_, _ = io.WriteString(w, `[]`)
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):

--- a/src/pkg/github/watcher_loops_test.go
+++ b/src/pkg/github/watcher_loops_test.go
@@ -39,6 +39,10 @@ func countingServer(t *testing.T, hits *atomic.Int64, match func(*http.Request) 
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/compare/") {
+			_, _ = io.WriteString(w, `{"files":[]}`)
+			return
+		}
 		_, _ = io.WriteString(w, `[]`)
 	}))
 }

--- a/src/pkg/policies/content_boundary_test.go
+++ b/src/pkg/policies/content_boundary_test.go
@@ -1,0 +1,58 @@
+package policies
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPRCapablePoliciesProtectPublishableContent(t *testing.T) {
+	policyNames := []string{
+		"architect-full.md",
+		"architect-holdgated.md",
+		"ci-maintainer-full.md",
+		"ci-maintainer-holdgated.md",
+		"guide-full.md",
+		"guide-holdgated.md",
+		"operations-full.md",
+		"operations-holdgated.md",
+		"outreach-full.md",
+		"quality-full.md",
+		"quality-holdgated.md",
+		"scanner-automerge.md",
+		"scanner-full.md",
+		"scanner-holdgated.md",
+		"sec-check-full.md",
+		"sec-check-holdgated.md",
+		"strategist-full.md",
+		"strategist-holdgated.md",
+		"telemetry-full.md",
+		"telemetry-holdgated.md",
+	}
+	markers := []string{
+		"Attribution belongs ONLY in the issue or PR body and the DCO commit trailer.",
+		"NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.",
+	}
+
+	for _, name := range policyNames {
+		t.Run(name, func(t *testing.T) {
+			embedded, err := DefaultPolicies.ReadFile("defaults/" + name)
+			if err != nil {
+				t.Fatalf("read embedded policy: %v", err)
+			}
+			source, err := os.ReadFile(filepath.Join("..", "..", "policies", name))
+			if err != nil {
+				t.Fatalf("read source policy: %v", err)
+			}
+			for _, marker := range markers {
+				if !strings.Contains(string(embedded), marker) {
+					t.Errorf("embedded policy is missing publishable-content guard %q", marker)
+				}
+				if !strings.Contains(string(source), marker) {
+					t.Errorf("source policy is missing publishable-content guard %q", marker)
+				}
+			}
+		})
+	}
+}

--- a/src/pkg/policies/defaults/architect-full.md
+++ b/src/pkg/policies/defaults/architect-full.md
@@ -90,3 +90,7 @@ ${PR_LIST}
 8. Summarize architectural health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/architect-holdgated.md
+++ b/src/pkg/policies/defaults/architect-holdgated.md
@@ -89,3 +89,7 @@ ${PR_LIST}
 8. Summarize architectural health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/ci-maintainer-full.md
+++ b/src/pkg/policies/defaults/ci-maintainer-full.md
@@ -77,3 +77,7 @@ Priority: 0 (CI broken/blocking), 1 (persistent failure/coverage drop), 2 (flaky
 6. For problems with a clear fix, create a worktree and open a PR
 7. Create a bead for each finding
 8. Summarize CI health in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/ci-maintainer-holdgated.md
+++ b/src/pkg/policies/defaults/ci-maintainer-holdgated.md
@@ -89,3 +89,7 @@ Priority: 0 (CI broken/blocking), 1 (persistent failure/coverage drop), 2 (flaky
 6. For problems with a clear fix, create a worktree and open a hold-gated PR
 7. Create a bead for each finding
 8. Summarize CI health in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/guide-full.md
+++ b/src/pkg/policies/defaults/guide-full.md
@@ -66,3 +66,7 @@ bd create --title "<specific documentation gap title>" \
 5. For gaps with a clear fix, create a worktree and open a PR
 6. Create a bead for each finding
 7. Summarize findings in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/guide-holdgated.md
+++ b/src/pkg/policies/defaults/guide-holdgated.md
@@ -67,3 +67,7 @@ bd create --title "<specific documentation gap title>" \
 5. For gaps with a clear fix, create a worktree and open a hold-gated PR
 6. Create a bead for each finding
 7. Summarize findings in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/operations-full.md
+++ b/src/pkg/policies/defaults/operations-full.md
@@ -17,3 +17,7 @@ Operations must never: merge a PR; modify work labeled `hold`, `on-hold`, or `do
 `$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
 
 Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. Sign every commit with `git commit -s` and open, but never merge, PRs. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/operations-holdgated.md
+++ b/src/pkg/policies/defaults/operations-holdgated.md
@@ -17,3 +17,7 @@ Operations must never: merge a PR; remove `hold`, `on-hold`, or `do-not-merge` l
 `$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
 
 Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. For a safe improvement, create a branch, sign commits with `git commit -s`, and open a PR labeled `hold`; never merge it. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/outreach-full.md
+++ b/src/pkg/policies/defaults/outreach-full.md
@@ -87,3 +87,7 @@ Priority: 0 (critical retention/churn risk), 1 (high-leverage partnership), 2 (m
 9. Create a worktree and open a `hold`-labeled PR whose body maps each remaining claim to its evidence
 10. Create a bead for each finding
 11. Summarize outreach pipeline and community health in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/quality-full.md
+++ b/src/pkg/policies/defaults/quality-full.md
@@ -126,3 +126,7 @@ ${PR_LIST}
 7. Summarize findings in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/quality-holdgated.md
+++ b/src/pkg/policies/defaults/quality-holdgated.md
@@ -172,3 +172,7 @@ ${PR_LIST}
 - Do NOT create PRs for production code changes — testing only
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/scanner-automerge.md
+++ b/src/pkg/policies/defaults/scanner-automerge.md
@@ -208,3 +208,7 @@ ${KNOWLEDGE}
 Items marked **ESCALATED** in your kick (or PRs carrying the `needs-human` label) have failed CI across multiple distinct fix attempts and the hub has escalated them to a human with the raw failure evidence. Do NOT open new fix PRs, push commits, or retrigger CI for them. They re-enter your lane only when a human removes the `needs-human` label.
 
 For **CI-FAILING** items, your kick includes `ERROR:` lines extracted from the failing check-run annotations — that is the actual failure. Start your diagnosis from those lines; do not guess from the check name alone.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/scanner-full.md
+++ b/src/pkg/policies/defaults/scanner-full.md
@@ -97,3 +97,7 @@ For PRs in the PR_LIST that have merge conflicts:
 8. Summarize completed work
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/scanner-holdgated.md
+++ b/src/pkg/policies/defaults/scanner-holdgated.md
@@ -87,3 +87,7 @@ ${PR_LIST}
 7. Summarize completed work
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/sec-check-full.md
+++ b/src/pkg/policies/defaults/sec-check-full.md
@@ -75,3 +75,7 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 6. For findings with a clear safe fix, create a worktree and open a PR
 7. Create a bead for each finding
 8. Summarize security posture in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/sec-check-holdgated.md
+++ b/src/pkg/policies/defaults/sec-check-holdgated.md
@@ -84,3 +84,7 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 7. For findings with a clear safe fix, create a worktree and open a hold-gated PR
 8. Create a bead for each finding
 9. Summarize security posture in your response, naming which repo you covered
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/strategist-full.md
+++ b/src/pkg/policies/defaults/strategist-full.md
@@ -77,3 +77,7 @@ Priority: 0 (critical adoption blocker), 1 (high-impact opportunity), 2 (medium 
 6. For findings that need a planning document, create a worktree and open a PR
 7. Create a bead for each finding
 8. Summarize strategic health in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/strategist-holdgated.md
+++ b/src/pkg/policies/defaults/strategist-holdgated.md
@@ -76,3 +76,7 @@ Priority: 0 (critical adoption blocker), 1 (high-impact opportunity), 2 (medium 
 6. For findings that need a planning document, create a worktree and open a hold-gated PR
 7. Create a bead for each finding
 8. Summarize strategic health in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/telemetry-full.md
+++ b/src/pkg/policies/defaults/telemetry-full.md
@@ -17,3 +17,7 @@ Telemetry must never: commit credentials, literal collector endpoints, API keys,
 `$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
 
 Detect the existing stack first; without an explicitly configured backend, audit and file recommendations only. Close only stale `telemetry` beads. Sign every commit with `git commit -s`. Return `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/pkg/policies/defaults/telemetry-holdgated.md
+++ b/src/pkg/policies/defaults/telemetry-holdgated.md
@@ -21,3 +21,7 @@ Telemetry must never: commit credentials, literal collector endpoints, API keys,
 3. File confirmed findings with a `[telemetry]` title and create a telemetry-owned bead.
 4. For a safe, bounded improvement, create a branch, commit with `git commit -s`, push, and open a PR labeled `hold`. Never merge it.
 5. Return an AgentReport. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/architect-full.md
+++ b/src/policies/architect-full.md
@@ -90,3 +90,7 @@ ${PR_LIST}
 8. Summarize architectural health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/architect-holdgated.md
+++ b/src/policies/architect-holdgated.md
@@ -89,3 +89,7 @@ ${PR_LIST}
 8. Summarize architectural health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/ci-maintainer-full.md
+++ b/src/policies/ci-maintainer-full.md
@@ -81,3 +81,7 @@ Priority: 0 (CI broken/blocking), 1 (persistent failure/coverage drop), 2 (flaky
 8. Summarize CI health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/ci-maintainer-holdgated.md
+++ b/src/policies/ci-maintainer-holdgated.md
@@ -93,3 +93,7 @@ Priority: 0 (CI broken/blocking), 1 (persistent failure/coverage drop), 2 (flaky
 8. Summarize CI health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/guide-full.md
+++ b/src/policies/guide-full.md
@@ -70,3 +70,7 @@ bd create --title "<specific documentation gap title>" \
 7. Summarize findings in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/guide-holdgated.md
+++ b/src/policies/guide-holdgated.md
@@ -71,3 +71,7 @@ bd create --title "<specific documentation gap title>" \
 7. Summarize findings in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/operations-full.md
+++ b/src/policies/operations-full.md
@@ -17,3 +17,7 @@ Operations must never: merge a PR; modify work labeled `hold`, `on-hold`, or `do
 `$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
 
 Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. Sign every commit with `git commit -s` and open, but never merge, PRs. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/operations-holdgated.md
+++ b/src/policies/operations-holdgated.md
@@ -17,3 +17,7 @@ Operations must never: merge a PR; remove `hold`, `on-hold`, or `do-not-merge` l
 `$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
 
 Re-verify and close only stale beads whose actor is `operations`. File confirmed findings with an `[operations]` title. For a safe improvement, create a branch, sign commits with `git commit -s`, and open a PR labeled `hold`; never merge it. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/outreach-full.md
+++ b/src/policies/outreach-full.md
@@ -89,3 +89,7 @@ Priority: 0 (critical retention/churn risk), 1 (high-leverage partnership), 2 (m
 9. Create a worktree and open a `hold`-labeled PR whose body maps each remaining claim to its evidence
 10. Create a bead for each finding
 11. Summarize outreach pipeline and community health in your response
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/quality-full.md
+++ b/src/policies/quality-full.md
@@ -126,3 +126,7 @@ ${PR_LIST}
 7. Summarize findings in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/quality-holdgated.md
+++ b/src/policies/quality-holdgated.md
@@ -172,3 +172,7 @@ ${PR_LIST}
 - Do NOT create PRs for production code changes — testing only
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/scanner-automerge.md
+++ b/src/policies/scanner-automerge.md
@@ -195,3 +195,7 @@ ${PR_LIST}
 ⛔ NEVER run `gh issue list`, `gh pr list`, or `gh search issues`.
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/scanner-full.md
+++ b/src/policies/scanner-full.md
@@ -97,3 +97,7 @@ For PRs in the PR_LIST that have merge conflicts:
 8. Summarize completed work
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/scanner-holdgated.md
+++ b/src/policies/scanner-holdgated.md
@@ -88,3 +88,7 @@ ${PR_LIST}
 7. Summarize completed work
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/sec-check-full.md
+++ b/src/policies/sec-check-full.md
@@ -79,3 +79,7 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 8. Summarize security posture in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/sec-check-holdgated.md
+++ b/src/policies/sec-check-holdgated.md
@@ -88,3 +88,7 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 9. Summarize security posture in your response, naming which repo you covered
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/strategist-full.md
+++ b/src/policies/strategist-full.md
@@ -81,3 +81,7 @@ Priority: 0 (critical adoption blocker), 1 (high-impact opportunity), 2 (medium 
 8. Summarize strategic health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/strategist-holdgated.md
+++ b/src/policies/strategist-holdgated.md
@@ -80,3 +80,7 @@ Priority: 0 (critical adoption blocker), 1 (high-impact opportunity), 2 (medium 
 8. Summarize strategic health in your response
 
 ${KNOWLEDGE}
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/telemetry-full.md
+++ b/src/policies/telemetry-full.md
@@ -17,3 +17,7 @@ Telemetry must never: commit credentials, literal collector endpoints, API keys,
 `$HIVE_REPOS` lists every authorized repository. No secondary worktree is provisioned: rotate to the least recently covered repository, clone it when needed, and use `gh ... --repo "<org>/<target-repo>"` explicitly for every issue and PR action.
 
 Detect the existing stack first; without an explicitly configured backend, audit and file recommendations only. Close only stale `telemetry` beads. Sign every commit with `git commit -s`. Return `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.

--- a/src/policies/telemetry-holdgated.md
+++ b/src/policies/telemetry-holdgated.md
@@ -21,3 +21,7 @@ Telemetry must never: commit credentials, literal collector endpoints, API keys,
 3. File confirmed findings with a `[telemetry]` title and create a telemetry-owned bead.
 4. For a safe, bounded improvement, create a branch, commit with `git commit -s`, push, and open a PR labeled `hold`. Never merge it.
 5. Return an AgentReport. Use `kind: "instrument"` when files were produced and list each in `artifacts` with `repo`, `path`, and `description`.
+
+## Publishable Content Boundary
+
+Attribution belongs ONLY in the issue or PR body and the DCO commit trailer. NEVER write `Filed by`, ACMM levels, agent names, or hive run metadata inside any committed file.


### PR DESCRIPTION
## Summary

Agent policy templates showed attribution trailers in issue and PR bodies but never stated that those trailers must stay out of repository content. The PR request watcher also passed a pushed branch to `CreatePR` without checking whether the branch itself contained Hive's internal attribution.

This PR adds both layers of protection:

- every shipped PR-capable policy and its embedded default now says attribution and run metadata belong only in issue/PR bodies or commit trailers, never committed files
- the server-side PR request choke point scans added compare-diff lines before opening a PR
- added `Filed by ... agent (ACMM ...)` attribution and `— hive: ...` run trailers permanently reject the request
- the rejection result names the offending file and new-file line, while deleted or pre-existing markers remain allowed so cleanup PRs can land
- GitHub/default-branch/compare failures remain transient and use the watcher's existing bounded retry path
- compare results at GitHub's 300-file visibility limit fail closed rather than claiming an incomplete scan is clean

Fixes #5114.

## Reported incident

The regression test submits the incident shape through `ProcessPRRequestsOnce`: a Markdown page with a trailing outreach attribution. It verifies that no `POST /pulls` occurs, the request is quarantined as `.rejected`, and the result points to the exact Markdown file and line.

The patch scanner looks only at added lines. A branch that removes leaked metadata is therefore accepted, and unchanged historical content does not block unrelated work.

## Policy coverage

The boundary is present in all 20 PR-capable full, hold-gated, and automerge templates, including outreach, guide, architect, scanner, quality, CI, security, strategy, telemetry, and operations roles. A policy invariant test checks both the human-editable source templates and the embedded defaults.

## Validation

Passed:

- `go test ./pkg/github`
- `go test ./pkg/policies`
- `go vet ./pkg/github ./pkg/policies`
- `git diff --check`

`go test ./...` also passed both changed packages. The repository-wide run could not complete in this checkout because unrelated packages exhausted the temporary disk quota while linking; host-sensitive `pkg/agent` and `pkg/config` tests also hit the existing overlong tmux socket path and unavailable `NET_ADMIN` environment limitations.

## Contributor checklist

- [x] Targets `v4`
- [x] Ready for review, not draft
- [x] Commit carries a DCO sign-off matching the author email
- [x] Regression test covers the reported publishable-content leak
- [x] No credentials or generated runtime artifacts committed

— hive: backend=codex
