### PR TITLE
fix(outreach): gate unsupported capability claims

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1695,13 +1695,15 @@ func main() {
 		// privilege. A denied request is quarantined, never opened.
 		// holdLabel (F6): at hold-gated ACMM levels (L3/L4/L5) every agent-opened
 		// PR must carry the "hold" label so the merge gate holds it for human
-		// approval. This is decided server-side from the authoritative hive level
+		// approval. Outreach content is public speech on the project's behalf, so
+		// it remains human-reviewed at L6 too. This is decided server-side from the
+		// authenticated agent identity and authoritative hive level
 		// (GetACMMLevel), NOT from a client flag — the gh-wrapper.sh tail that used
 		// to add the label was dead code after `exec hive-open-pr`. L1/L2 open no
-		// agent PRs (manual); L6 auto-merges on green (no hold).
-		holdLabel := func() bool {
-			l := agentMgr.GetACMMLevel()
-			return l >= acmmHoldGatedMinLevel && l <= acmmHoldGatedMaxLevel
+		// agent PRs (manual); non-outreach L6 PRs retain their existing automerge
+		// behavior.
+		holdLabel := func(agentName string) bool {
+			return shouldHoldAgentPR(agentName, agentMgr.GetACMMLevel())
 		}
 		ghClient.StartPRRequestWatcher(ctx, agentMgr.AuthorizePROpen, holdLabel, nil)
 		// Issue relay: agents request issue creation and comments by dropping a
@@ -7613,6 +7615,16 @@ const (
 	acmmHoldGatedMinLevel = 3
 	acmmHoldGatedMaxLevel = 5
 )
+
+// shouldHoldAgentPR keeps public outreach claims human-reviewed even at L6,
+// where ordinary agent PRs may auto-merge. The general ACMM hold gate remains
+// unchanged for all roles at L3-L5.
+func shouldHoldAgentPR(agentName string, level int) bool {
+	if strings.EqualFold(strings.TrimSpace(agentName), "outreach") {
+		return true
+	}
+	return level >= acmmHoldGatedMinLevel && level <= acmmHoldGatedMaxLevel
+}
 
 // mergeableJSONUnknown is the explicit wire value for "mergeability was never
 // determined". It is spelled out rather than left as "" so a consumer reading

--- a/src/cmd/hive/outreach_hold_test.go
+++ b/src/cmd/hive/outreach_hold_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestShouldHoldAgentPR(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent string
+		level int
+		want  bool
+	}{
+		{name: "outreach remains held at full autonomy", agent: "outreach", level: 6, want: true},
+		{name: "outreach identity is normalized", agent: " Outreach ", level: 6, want: true},
+		{name: "other agents remain autonomous at level 6", agent: "scanner", level: 6, want: false},
+		{name: "all agents are held at level 3", agent: "scanner", level: 3, want: true},
+		{name: "all agents are held at level 5", agent: "quality", level: 5, want: true},
+		{name: "manual level does not add a hold", agent: "scanner", level: 2, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldHoldAgentPR(tt.agent, tt.level); got != tt.want {
+				t.Fatalf("shouldHoldAgentPR(%q, %d) = %v, want %v", tt.agent, tt.level, got, tt.want)
+			}
+		})
+	}
+}

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -65,12 +65,14 @@ type Client struct {
 	// StartPRRequestWatcher.
 	prAuthz PRRequestAuthorizer
 	// prHoldLabel decides, at PR-creation time, whether a freshly-opened PR must
-	// carry the "hold" label (F6). It is consulted server-side from authoritative
-	// hive config (the ACMM level), NOT trusted from a client flag — the
+	// carry the "hold" label (F6). It receives the authoring agent so role-specific
+	// safety rules (for example, mandatory human review of outreach content) can
+	// be enforced alongside the authoritative ACMM level. It is consulted
+	// server-side, NOT trusted from a client flag — the
 	// gh-wrapper.sh tail that used to add the label is dead code (it sits after
 	// `exec hive-open-pr`). nil means "never hold" (backward-compatible no-op).
 	// Set by StartPRRequestWatcher.
-	prHoldLabel func() bool
+	prHoldLabel func(agent string) bool
 	// prOpenedHook, when set, is told about every NEW PR the request watcher
 	// opens (agent, repo, number, url) — the seam progress surfaces such as
 	// the Linear session emitter hook. atomic so SetPROpenedHook is safe

--- a/src/pkg/github/pr_request_outreach.go
+++ b/src/pkg/github/pr_request_outreach.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	outreachClaimEvidenceHeading = regexp.MustCompile(`(?im)^#{1,6}[ \t]+claim evidence[ \t]*\r?$`)
+	outreachRegulatoryTerm       = regexp.MustCompile(`(?i)\b(?:hipaa|gdpr|fedramp|fips(?:[- ]?\d+)?|soc[- ]?2|pci(?:[- ]?dss)?)\b`)
+)
+
+// validateOutreachPRRequest is the mechanical backstop for the outreach
+// policy's public-claims boundary. Prompt instructions remain responsible for
+// verifying capabilities against primary project evidence; this choke point
+// makes that verification visible to reviewers and prevents the highest-risk
+// regulatory language from becoming public in an agent-authored PR at all.
+//
+// A non-empty reason is a permanent policy rejection. An error is a transient
+// forge failure and should use the request watcher's normal bounded retry path.
+func (c *Client) validateOutreachPRRequest(ctx context.Context, req PRRequest) (reason string, err error) {
+	if !strings.EqualFold(strings.TrimSpace(req.Agent), "outreach") {
+		return "", nil
+	}
+	if c == nil || c.client == nil {
+		return "", ErrNoGitHubClient
+	}
+	if !outreachClaimEvidenceHeading.MatchString(req.Body) {
+		return "outreach PR body must include a Claim evidence section mapping public capability and roadmap claims to primary project sources", nil
+	}
+	if term := outreachRegulatoryTerm.FindString(req.Title + "\n" + req.Body); term != "" {
+		return fmt.Sprintf("outreach PR metadata contains regulatory term %q; regulatory and compliance language must be handled by a human", term), nil
+	}
+
+	owner, repo := c.requestRepo(req.Repo)
+	base := strings.TrimSpace(req.Base)
+	if base == "" {
+		base, err = c.DefaultBranch(ctx, owner, repo)
+		if err != nil {
+			return "", fmt.Errorf("resolving default branch for outreach claim validation: %w", err)
+		}
+	}
+
+	comparison, _, err := c.client.Repositories.CompareCommits(ctx, owner, repo, base, strings.TrimSpace(req.Head), nil)
+	if err != nil {
+		return "", fmt.Errorf("comparing outreach branch %s...%s for claim validation: %w", base, req.Head, err)
+	}
+	if comparison == nil {
+		return "", fmt.Errorf("comparing outreach branch %s...%s for claim validation: GitHub returned an empty comparison", base, req.Head)
+	}
+	// GitHub's compare response exposes at most 300 changed files. Refuse a
+	// boundary-sized response rather than silently approving uninspected files;
+	// outreach changes should be small enough for a human-readable review.
+	if len(comparison.Files) >= 300 {
+		return "outreach diff is too large to validate completely; split it into reviewable PRs", nil
+	}
+
+	for _, file := range comparison.Files {
+		if file == nil || file.GetAdditions() == 0 {
+			continue
+		}
+		patch := file.GetPatch()
+		if patch == "" {
+			return fmt.Sprintf("cannot inspect added text in %s; open this change manually for human review", file.GetFilename()), nil
+		}
+		for _, line := range strings.Split(patch, "\n") {
+			if !strings.HasPrefix(line, "+") {
+				continue
+			}
+			if term := outreachRegulatoryTerm.FindString(line[1:]); term != "" {
+				return fmt.Sprintf("outreach content adds regulatory term %q in %s; regulatory and compliance language must be handled by a human", term, file.GetFilename()), nil
+			}
+		}
+	}
+	return "", nil
+}
+
+func (c *Client) requestRepo(repo string) (string, string) {
+	owner := c.org
+	if parts := strings.SplitN(strings.TrimSpace(repo), "/", 2); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return owner, strings.TrimSpace(repo)
+}

--- a/src/pkg/github/pr_request_outreach_test.go
+++ b/src/pkg/github/pr_request_outreach_test.go
@@ -1,0 +1,176 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func outreachValidationServer(t *testing.T, filename, patch string, additions int, created *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ahead",
+				"files": []map[string]any{{
+					"filename":  filename,
+					"status":    "modified",
+					"additions": additions,
+					"patch":     patch,
+				}},
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+			if created != nil {
+				*created++
+			}
+			_, _ = io.WriteString(w, `{"number":42,"html_url":"https://github.com/o/r/pull/42"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func outreachValidationClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	return NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestValidateOutreachPRRequestRequiresClaimEvidence(t *testing.T) {
+	srv := outreachValidationServer(t, "docs/guide.md", "@@ -0,0 +1 @@\n+Verified feature", 1, nil)
+	defer srv.Close()
+	c := outreachValidationClient(t, srv)
+
+	reason, err := c.validateOutreachPRRequest(context.Background(), PRRequest{
+		Repo: "o/r", Base: "main", Head: "outreach/guide", Agent: "outreach", Body: "## Summary\n\nA guide.",
+	})
+	if err != nil {
+		t.Fatalf("validateOutreachPRRequest: %v", err)
+	}
+	if !strings.Contains(reason, "must include a Claim evidence section") {
+		t.Fatalf("reason = %q, want missing-evidence rejection", reason)
+	}
+}
+
+func TestValidateOutreachPRRequestRejectsAddedRegulatoryTerms(t *testing.T) {
+	terms := []string{"HIPAA", "PCI DSS", "GDPR", "SOC 2", "FedRAMP", "FIPS-140"}
+	for _, term := range terms {
+		t.Run(term, func(t *testing.T) {
+			patch := "@@ -0,0 +1 @@\n+" + term + " ready"
+			srv := outreachValidationServer(t, "docs/guide.md", patch, 1, nil)
+			defer srv.Close()
+			c := outreachValidationClient(t, srv)
+
+			reason, err := c.validateOutreachPRRequest(context.Background(), PRRequest{
+				Repo: "o/r", Base: "main", Head: "outreach/guide", Agent: "outreach",
+				Body: "## Claim evidence\n\n- Feature: src/feature.go",
+			})
+			if err != nil {
+				t.Fatalf("validateOutreachPRRequest: %v", err)
+			}
+			if !strings.Contains(reason, "adds regulatory term") || !strings.Contains(reason, "docs/guide.md") {
+				t.Fatalf("reason = %q, want regulatory-term rejection", reason)
+			}
+		})
+	}
+}
+
+func TestValidateOutreachPRRequestRejectsRegulatoryPRMetadata(t *testing.T) {
+	srv := outreachValidationServer(t, "docs/guide.md", "@@ -0,0 +1 @@\n+Healthcare session guide", 1, nil)
+	defer srv.Close()
+	c := outreachValidationClient(t, srv)
+
+	reason, err := c.validateOutreachPRRequest(context.Background(), PRRequest{
+		Repo: "o/r", Base: "main", Head: "outreach/guide", Agent: "outreach",
+		Title: "docs: add HIPAA session guide",
+		Body:  "## Claim evidence\n\n- Session behavior: src/session.go",
+	})
+	if err != nil {
+		t.Fatalf("validateOutreachPRRequest: %v", err)
+	}
+	if !strings.Contains(reason, "PR metadata contains regulatory term") {
+		t.Fatalf("reason = %q, want regulatory-metadata rejection", reason)
+	}
+}
+
+func TestValidateOutreachPRRequestAllowsGroundedNonRegulatoryContent(t *testing.T) {
+	srv := outreachValidationServer(t, "docs/guide.md", "@@ -0,0 +1 @@\n+Feature X is implemented by src/feature.go", 1, nil)
+	defer srv.Close()
+	c := outreachValidationClient(t, srv)
+
+	reason, err := c.validateOutreachPRRequest(context.Background(), PRRequest{
+		Repo: "o/r", Base: "main", Head: "outreach/guide", Agent: " Outreach ",
+		Body: "## Claim Evidence\n\n- Feature X: src/feature.go",
+	})
+	if err != nil || reason != "" {
+		t.Fatalf("validation = reason %q, error %v; want allowed", reason, err)
+	}
+}
+
+func TestValidateOutreachPRRequestIgnoresOtherAgents(t *testing.T) {
+	c := &Client{}
+	reason, err := c.validateOutreachPRRequest(context.Background(), PRRequest{Agent: "scanner"})
+	if err != nil || reason != "" {
+		t.Fatalf("non-outreach validation = reason %q, error %v; want bypass", reason, err)
+	}
+}
+
+func TestValidateOutreachPRRequestFailsClosedWhenAddedPatchUnavailable(t *testing.T) {
+	srv := outreachValidationServer(t, "docs/large-guide.md", "", 12, nil)
+	defer srv.Close()
+	c := outreachValidationClient(t, srv)
+
+	reason, err := c.validateOutreachPRRequest(context.Background(), PRRequest{
+		Repo: "o/r", Base: "main", Head: "outreach/guide", Agent: "outreach",
+		Body: "## Claim evidence\n\n- Feature X: src/feature.go",
+	})
+	if err != nil {
+		t.Fatalf("validateOutreachPRRequest: %v", err)
+	}
+	if !strings.Contains(reason, "cannot inspect added text in docs/large-guide.md") {
+		t.Fatalf("reason = %q, want unavailable-patch rejection", reason)
+	}
+}
+
+func TestPRRequestWatcherRejectsOutreachRegulatoryClaimBeforeCreate(t *testing.T) {
+	created := 0
+	srv := outreachValidationServer(t, "docs/guide.md", "@@ -0,0 +1 @@\n+HIPAA compliant sessions", 1, &created)
+	defer srv.Close()
+	c := outreachValidationClient(t, srv)
+	c.prAuthz = func(string, int) error { return nil }
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Base: "main", Head: "outreach/guide", Title: "docs: add healthcare guide", Agent: "outreach",
+		Body: "## Claim evidence\n\n- Session behavior: src/session.go",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Fatalf("regulatory claim created %d PRs, want 0", created)
+	}
+	if _, err := os.Stat(reqPath + ".rejected"); err != nil {
+		t.Fatalf("rejected request was not quarantined: %v", err)
+	}
+	result, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(result), "regulatory term") {
+		t.Fatalf("result lacks actionable rejection: %s", result)
+	}
+}

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -93,11 +93,12 @@ type PRRequestAuthorizer func(agent string, fileUID int) error
 // watcher must never open a PR that hasn't been authorized against the same
 // policy as the direct `gh pr create` path.
 //
-// holdLabel (F6) decides server-side, from authoritative hive config (the ACMM
-// level), whether a freshly-opened PR must carry the "hold" label. It is applied
-// AFTER the PR is created, on the path that actually runs — unlike the
-// gh-wrapper.sh tail, which was dead code (it sat after `exec hive-open-pr`), so
-// hold-gated PRs were being opened unlabeled. A nil holdLabel means "never hold".
+// holdLabel (F6) decides server-side, from the authoring agent and authoritative
+// hive config (the ACMM level), whether a freshly-opened PR must carry the
+// "hold" label. It is applied AFTER the PR is created, on the path that
+// actually runs — unlike the gh-wrapper.sh tail, which was dead code (it sat
+// after `exec hive-open-pr`), so hold-gated PRs were being opened unlabeled. A
+// nil holdLabel means "never hold".
 //
 // nowFn is injectable for tests; pass nil for time.Now.
 //
@@ -121,7 +122,7 @@ func (c *Client) SetPROpenedHook(fn PROpenedHook) {
 	c.prOpenedHook.Store(&fn)
 }
 
-func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, holdLabel func() bool, nowFn func() time.Time) <-chan struct{} {
+func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, holdLabel func(agent string) bool, nowFn func() time.Time) <-chan struct{} {
 	done := make(chan struct{})
 	if c == nil {
 		close(done)
@@ -234,10 +235,23 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	title, body, err := c.validatePRRequestClaims(ctx, req)
 	if err != nil {
 		if reason, policy := prRequestPolicyReason(err); policy {
-			c.rejectPRRequest(path, req, reason, nowFn)
+			c.rejectPRRequest(path, req, "claim", reason, nowFn)
 			return
 		}
 		c.failPRRequest(path, req, err, nowFn)
+		return
+	}
+
+	// Public outreach prose speaks for the project, so it gets a second gate at
+	// the same choke point (#5115). The check above is about the request being
+	// accurate; this one is about the project being able to stand behind what
+	// the PR would publish — an unsupported capability claim with no evidence
+	// record, or regulatory language.
+	if reason, err := c.validateOutreachPRRequest(ctx, req); err != nil {
+		c.failPRRequest(path, req, err, nowFn)
+		return
+	} else if reason != "" {
+		c.rejectPRRequest(path, req, "outreach", reason, nowFn)
 		return
 	}
 
@@ -269,13 +283,15 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	// unreachable (it followed `exec hive-open-pr`), so those PRs were opened
 	// unlabeled and the gate was inert. AddLabels is additive + idempotent, so it
 	// is safe to (re)apply even when we reused an already-open PR.
-	if c.prHoldLabel != nil && c.prHoldLabel() {
+	if c.prHoldLabel != nil && c.prHoldLabel(req.Agent) {
 		if lerr := c.AddLabels(ctx, req.Repo, res.Number, []string{"hold"}); lerr != nil {
-			// A missing hold label at a hold-gated level is a policy failure, not a
-			// cosmetic one — surface it loudly so an operator notices, but the PR is
-			// already open so we do not fail the request.
+			// A missing hold label is a policy failure, not a cosmetic one. Keep
+			// the request queued: the next bounded retry deduplicates the existing
+			// PR and reapplies the label instead of silently declaring success.
 			c.logger.Warn("pr-request watcher: PR opened but failed to apply hold label (hold-gated level)",
 				slog.String("repo", req.Repo), slog.Int("number", res.Number), slog.String("error", lerr.Error()))
+			c.failPRRequest(path, req, fmt.Errorf("PR #%d opened but required hold label could not be applied: %w", res.Number, lerr), nowFn)
+			return
 		} else {
 			c.logger.Info("pr-request watcher: applied hold label (hold-gated ACMM level)",
 				slog.String("repo", req.Repo), slog.Int("number", res.Number))
@@ -328,14 +344,20 @@ func (c *Client) failPRRequest(path string, req PRRequest, err error, nowFn func
 		slog.String("repo", req.Repo), slog.String("head", req.Head), slog.String("error", err.Error()))
 }
 
-// rejectPRRequest records a claim-validation mismatch and quarantines it. A
+// rejectPRRequest records a permanent policy mismatch and quarantines it. A
 // changed request or branch is required to make it valid, so retrying the same
 // file would only consume API quota and hide the actionable feedback.
-func (c *Client) rejectPRRequest(path string, req PRRequest, reason string, nowFn func() time.Time) {
-	c.writePRResult(path, PRResponse{OK: false, Error: "PR claim rejected: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
+//
+// More than one gate shares this path, so gate names which one refused.
+// Without it a quarantined request says only that something was rejected, and
+// the gates have different remedies: correct the request, or change what the
+// branch would publish.
+func (c *Client) rejectPRRequest(path string, req PRRequest, gate, reason string, nowFn func() time.Time) {
+	c.writePRResult(path, PRResponse{OK: false, Error: "PR " + gate + " rejected: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
 	_ = os.Rename(path, path+".rejected")
 	c.prRetries.clear(path)
-	c.logger.Warn("pr-request watcher: REJECTED (claim mismatch)",
+	c.logger.Warn("pr-request watcher: REJECTED (policy)",
+		slog.String("gate", gate),
 		slog.String("agent", req.Agent), slog.String("repo", req.Repo),
 		slog.String("head", req.Head), slog.String("reason", reason))
 }

--- a/src/pkg/github/pr_request_watcher_test.go
+++ b/src/pkg/github/pr_request_watcher_test.go
@@ -230,12 +230,14 @@ func TestPRRequestWatcher_NilAuthzFailsClosed(t *testing.T) {
 func TestPRRequestWatcher_HoldLabelApplied(t *testing.T) {
 	cases := []struct {
 		name     string
-		holdFn   func() bool
+		agent    string
+		holdFn   func(string) bool
 		wantHold bool
 	}{
-		{"hold-gated level applies hold", func() bool { return true }, true},
-		{"non-hold-gated level applies nothing", func() bool { return false }, false},
-		{"nil decider applies nothing", nil, false},
+		{"hold-gated level applies hold", "scanner", func(string) bool { return true }, true},
+		{"non-hold-gated level applies nothing", "scanner", func(string) bool { return false }, false},
+		{"agent-specific decider applies hold", "publicist", func(agent string) bool { return agent == "publicist" }, true},
+		{"nil decider applies nothing", "scanner", nil, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -253,7 +255,7 @@ func TestPRRequestWatcher_HoldLabelApplied(t *testing.T) {
 			prRequestDirForTest = dir
 			defer func() { prRequestDirForTest = old }()
 
-			_, _ = WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/hold", Title: "gated PR", Agent: "scanner"})
+			_, _ = WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/hold", Title: "gated PR", Agent: tc.agent})
 			c.ProcessPRRequestsOnce(context.Background())
 
 			if created != 1 {
@@ -269,6 +271,70 @@ func TestPRRequestWatcher_HoldLabelApplied(t *testing.T) {
 				t.Errorf("hold label applied=%v, want %v (labels seen: %v)", gotHold, tc.wantHold, added)
 			}
 		})
+	}
+}
+
+func TestPRRequestWatcher_RetriesRequiredHoldLabelFailure(t *testing.T) {
+	created, labelAttempts := 0, 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/repos/o/r"):
+			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls"):
+			if created > 0 {
+				_, _ = io.WriteString(w, `[{"number":42,"html_url":"https://github.com/o/r/pull/42","head":{"ref":"scanner/hold"}}]`)
+			} else {
+				_, _ = io.WriteString(w, `[]`)
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+			created++
+			_, _ = io.WriteString(w, `{"number":42,"html_url":"https://github.com/o/r/pull/42"}`)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			labelAttempts++
+			if labelAttempts == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"message":"temporary label failure"}`)
+				return
+			}
+			_, _ = io.WriteString(w, `[]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.prAuthz = func(string, int) error { return nil }
+	c.prHoldLabel = func(string) bool { return true }
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "scanner/hold", Title: "gated PR", Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	c.processPRRequests(context.Background(), clock)
+	if _, err := os.Stat(reqPath); err != nil {
+		t.Fatalf("request must remain queued when required hold label fails: %v", err)
+	}
+	if created != 1 || labelAttempts != 1 {
+		t.Fatalf("first pass created=%d label attempts=%d, want 1/1", created, labelAttempts)
+	}
+
+	now = now.Add(requestRetryBase + time.Second)
+	c.processPRRequests(context.Background(), clock)
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Fatalf("request must be consumed after hold label retry succeeds: %v", err)
+	}
+	if created != 1 || labelAttempts != 2 {
+		t.Fatalf("retry created=%d label attempts=%d, want deduped 1/2", created, labelAttempts)
 	}
 }
 

--- a/src/pkg/github/request_watcher_start_test.go
+++ b/src/pkg/github/request_watcher_start_test.go
@@ -62,7 +62,7 @@ func TestPRRequestWatcher_StartWiresAuthzAndHold(t *testing.T) {
 	done := c.StartPRRequestWatcher(ctx, func(agent string, uid int) error {
 		authzCalled = true
 		return nil
-	}, func() bool { return true }, nil)
+	}, func(string) bool { return true }, nil)
 	drainAfter(t, cancel, done)
 
 	if st, err := os.Stat(dir); err != nil || !st.IsDir() {

--- a/src/pkg/policies/defaults/outreach-full.md
+++ b/src/pkg/policies/defaults/outreach-full.md
@@ -8,14 +8,17 @@ Your job is to drive community engagement, ecosystem partnerships, and contribut
 
 1. **Community outreach** — identify ecosystem partners, adoption opportunities, contributor onboarding gaps, and community health signals
 2. **Create GitHub issues for engagement opportunities** — conference proposals, ecosystem integrations, blog post ideas, outreach targets
-3. **Create PRs for outreach content** — blog posts, case studies, partner docs, ADOPTERS.md updates. No hold label required.
-4. **NEVER merge your own PRs** — open and push; a human or automerge agent merges
-5. **Write findings as beads** — use `bd create` for every finding
-6. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
-7. **Always sign commits** with DCO: `git commit -s`
-8. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `outreach`
-9. **Cross-check ADOPTERS.md before any cold outreach proposal** — never propose outreach to orgs already listed as adopters
-10. **Ask first, PR on request** — for external repos, propose the outreach in an issue first; only open external PRs when explicitly requested
+3. **Create human-reviewed PRs for outreach content** — blog posts, case studies, partner docs, ADOPTERS.md updates. Every outreach PR requires the `hold` label, including at ACMM L6; only a human may remove it and merge.
+4. **Ground every product capability claim before writing it** — verify the behavior against the current repository and released artifacts. In the PR body, cite the exact implementing file, test, release, or human-authored official documentation for each claim. A related filename or plausible platform default is not evidence that the product provides the behavior. If a claim cannot be verified, omit it and flag the question for a human.
+5. **NEVER make regulatory or compliance claims** — do not describe a project or product as compliant, certified, conformant, ready for, or satisfying HIPAA, PCI DSS, GDPR, SOC 2, FedRAMP, FIPS, or any other regulatory/certification regime. Software features are not proof of an organization's compliance posture. Refuse the claim and ask a human owner to handle any regulatory language.
+6. **NEVER invent roadmap commitments** — only discuss future versions, platforms, dates, or integrations when a human-authored issue, release plan, or official announcement already commits to them. Cite that source and preserve its uncertainty; otherwise omit the commitment and ask a human.
+7. **NEVER merge your own PRs** — open and push; a human reviews, removes `hold`, and merges
+8. **Write findings as beads** — use `bd create` for every finding
+9. **Respect hold labels** — never remove a `hold`, `on-hold`, or `do-not-merge` label and never merge work carrying one
+10. **Always sign commits** with DCO: `git commit -s`
+11. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `outreach`
+12. **Cross-check ADOPTERS.md before any cold outreach proposal** — never propose outreach to orgs already listed as adopters
+13. **Ask first, PR on request** — for external repos, propose the outreach in an issue first; only open external PRs when explicitly requested
 
 ## Opening Issues
 
@@ -45,19 +48,22 @@ gh issue create --repo "$HIVE_REPO" \
 ## Opening PRs
 
 1. Create a worktree: `git worktree add /tmp/outreach-<slug> -b outreach/<slug>`
-2. Write the content (blog post draft, case study, ADOPTERS.md entry, partner doc)
-3. Commit: `git commit -s -m "[outreach] content: <description>"`
-4. Push and open a PR — **NEVER merge it yourself**:
+2. Inventory every product, security, integration, compatibility, and roadmap claim the content will make
+3. Verify each claim against the current repository and released artifacts; record an exact citation for it and remove any claim you cannot prove
+4. Stop and ask a human if the content would make a regulatory/compliance claim or needs an unapproved roadmap commitment
+5. Write the content (blog post draft, case study, ADOPTERS.md entry, partner doc)
+6. Commit: `git commit -s -m "[outreach] content: <description>"`
+7. Push and open a PR with the `hold` label and the claim evidence — **NEVER remove the label or merge it yourself**:
 
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[outreach] content: <short description>" \
-  --body "## Outreach Content\n\n<what this adds and its purpose>\n\nRelated: #<issue-number>\n\n---\n*Filed by outreach agent (ACMM L6 — full mode)*" \
-  --label "community,outreach"
+  --body "## Outreach Content\n\n<what this adds and its purpose>\n\n## Claim evidence\n\n- <claim>: <exact implementing file, test, released artifact, or human-authored official source>\n\nRelated: #<issue-number>\n\n---\n*Filed by outreach agent (ACMM L6 — full mode)*" \
+  --label "community,outreach,hold"
 ```
 
 Outreach can PR: ADOPTERS.md, blog post drafts, case studies, partnership docs, contributor guides, event proposals.
-Outreach must NEVER: merge any PR, contact external parties directly, open PRs on external repos without explicit instruction.
+Outreach must NEVER: remove a hold label, merge any PR, make regulatory/compliance claims, invent roadmap commitments, contact external parties directly, or open PRs on external repos without explicit instruction.
 
 ## Writing Beads
 
@@ -76,6 +82,8 @@ Priority: 0 (critical retention/churn risk), 1 (high-leverage partnership), 2 (m
 4. Cross-check ADOPTERS.md before proposing any organization for outreach
 5. Identify high-leverage engagement opportunities
 6. Create a GitHub issue for each opportunity
-7. For opportunities with ready content, create a worktree and open a PR
-8. Create a bead for each finding
-9. Summarize outreach pipeline and community health in your response
+7. For opportunities with ready content, inventory and verify every capability and roadmap claim against primary project evidence
+8. Remove unsupported claims; escalate all regulatory/compliance language and unapproved roadmap commitments to a human
+9. Create a worktree and open a `hold`-labeled PR whose body maps each remaining claim to its evidence
+10. Create a bead for each finding
+11. Summarize outreach pipeline and community health in your response

--- a/src/pkg/policies/outreach_claims_test.go
+++ b/src/pkg/policies/outreach_claims_test.go
@@ -1,0 +1,51 @@
+package policies
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOutreachPolicyRequiresGroundedHumanReviewedClaims(t *testing.T) {
+	t.Parallel()
+
+	embedded, err := DefaultPolicies.ReadFile("defaults/outreach-full.md")
+	if err != nil {
+		t.Fatalf("read embedded outreach policy: %v", err)
+	}
+	source, err := os.ReadFile(filepath.Join("..", "..", "policies", "outreach-full.md"))
+	if err != nil {
+		t.Fatalf("read source outreach policy: %v", err)
+	}
+
+	required := []string{
+		"Every outreach PR requires the `hold` label, including at ACMM L6",
+		"Ground every product capability claim before writing it",
+		"cite the exact implementing file, test, release, or human-authored official documentation for each claim",
+		"If a claim cannot be verified, omit it and flag the question for a human",
+		"NEVER make regulatory or compliance claims",
+		"Software features are not proof of an organization's compliance posture",
+		"NEVER invent roadmap commitments",
+		"## Claim evidence",
+		"--label \"community,outreach,hold\"",
+	}
+	for _, policy := range []struct {
+		name string
+		body string
+	}{
+		{name: "embedded", body: string(embedded)},
+		{name: "source", body: string(source)},
+	} {
+		t.Run(policy.name, func(t *testing.T) {
+			for _, marker := range required {
+				if !strings.Contains(policy.body, marker) {
+					t.Errorf("outreach policy is missing safety requirement %q", marker)
+				}
+			}
+			if strings.Contains(policy.body, "No hold label required") {
+				t.Error("outreach policy still exempts public content from human review")
+			}
+		})
+	}
+}

--- a/src/policies/outreach-full.md
+++ b/src/policies/outreach-full.md
@@ -10,14 +10,17 @@ Your job is to drive community engagement, ecosystem partnerships, and contribut
 
 1. **Community outreach** — identify ecosystem partners, adoption opportunities, contributor onboarding gaps, and community health signals
 2. **Create GitHub issues for engagement opportunities** — conference proposals, ecosystem integrations, blog post ideas, outreach targets
-3. **Create PRs for outreach content** — blog posts, case studies, partner docs, ADOPTERS.md updates. No hold label required.
-4. **NEVER merge your own PRs** — open and push; a human or automerge agent merges
-5. **Write findings as beads** — use `bd create` for every finding
-6. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
-7. **Always sign commits** with DCO: `git commit -s`
-8. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `outreach`
-9. **Cross-check ADOPTERS.md before any cold outreach proposal** — never propose outreach to orgs already listed as adopters
-10. **Ask first, PR on request** — for external repos, propose the outreach in an issue first; only open external PRs when explicitly requested
+3. **Create human-reviewed PRs for outreach content** — blog posts, case studies, partner docs, ADOPTERS.md updates. Every outreach PR requires the `hold` label, including at ACMM L6; only a human may remove it and merge.
+4. **Ground every product capability claim before writing it** — verify the behavior against the current repository and released artifacts. In the PR body, cite the exact implementing file, test, release, or human-authored official documentation for each claim. A related filename or plausible platform default is not evidence that the product provides the behavior. If a claim cannot be verified, omit it and flag the question for a human.
+5. **NEVER make regulatory or compliance claims** — do not describe a project or product as compliant, certified, conformant, ready for, or satisfying HIPAA, PCI DSS, GDPR, SOC 2, FedRAMP, FIPS, or any other regulatory/certification regime. Software features are not proof of an organization's compliance posture. Refuse the claim and ask a human owner to handle any regulatory language.
+6. **NEVER invent roadmap commitments** — only discuss future versions, platforms, dates, or integrations when a human-authored issue, release plan, or official announcement already commits to them. Cite that source and preserve its uncertainty; otherwise omit the commitment and ask a human.
+7. **NEVER merge your own PRs** — open and push; a human reviews, removes `hold`, and merges
+8. **Write findings as beads** — use `bd create` for every finding
+9. **Respect hold labels** — never remove a `hold`, `on-hold`, or `do-not-merge` label and never merge work carrying one
+10. **Always sign commits** with DCO: `git commit -s`
+11. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `outreach`
+12. **Cross-check ADOPTERS.md before any cold outreach proposal** — never propose outreach to orgs already listed as adopters
+13. **Ask first, PR on request** — for external repos, propose the outreach in an issue first; only open external PRs when explicitly requested
 
 ## Opening Issues
 
@@ -47,19 +50,22 @@ gh issue create --repo "$HIVE_REPO" \
 ## Opening PRs
 
 1. Create a worktree: `git worktree add /tmp/outreach-<slug> -b outreach/<slug>`
-2. Write the content (blog post draft, case study, ADOPTERS.md entry, partner doc)
-3. Commit: `git commit -s -m "[outreach] content: <description>"`
-4. Push and open a PR — **NEVER merge it yourself**:
+2. Inventory every product, security, integration, compatibility, and roadmap claim the content will make
+3. Verify each claim against the current repository and released artifacts; record an exact citation for it and remove any claim you cannot prove
+4. Stop and ask a human if the content would make a regulatory/compliance claim or needs an unapproved roadmap commitment
+5. Write the content (blog post draft, case study, ADOPTERS.md entry, partner doc)
+6. Commit: `git commit -s -m "[outreach] content: <description>"`
+7. Push and open a PR with the `hold` label and the claim evidence — **NEVER remove the label or merge it yourself**:
 
 ```bash
 gh pr create --repo "$HIVE_REPO" \
   --title "[outreach] content: <short description>" \
-  --body "## Outreach Content\n\n<what this adds and its purpose>\n\nRelated: #<issue-number>\n\n---\n*Filed by outreach agent (ACMM L6 — full mode)*" \
-  --label "community,outreach"
+  --body "## Outreach Content\n\n<what this adds and its purpose>\n\n## Claim evidence\n\n- <claim>: <exact implementing file, test, released artifact, or human-authored official source>\n\nRelated: #<issue-number>\n\n---\n*Filed by outreach agent (ACMM L6 — full mode)*" \
+  --label "community,outreach,hold"
 ```
 
 Outreach can PR: ADOPTERS.md, blog post drafts, case studies, partnership docs, contributor guides, event proposals.
-Outreach must NEVER: merge any PR, contact external parties directly, open PRs on external repos without explicit instruction.
+Outreach must NEVER: remove a hold label, merge any PR, make regulatory/compliance claims, invent roadmap commitments, contact external parties directly, or open PRs on external repos without explicit instruction.
 
 ## Writing Beads
 
@@ -78,6 +84,8 @@ Priority: 0 (critical retention/churn risk), 1 (high-leverage partnership), 2 (m
 4. Cross-check ADOPTERS.md before proposing any organization for outreach
 5. Identify high-leverage engagement opportunities
 6. Create a GitHub issue for each opportunity
-7. For opportunities with ready content, create a worktree and open a PR
-8. Create a bead for each finding
-9. Summarize outreach pipeline and community health in your response
+7. For opportunities with ready content, inventory and verify every capability and roadmap claim against primary project evidence
+8. Remove unsupported claims; escalate all regulatory/compliance language and unapproved roadmap commitments to a human
+9. Create a worktree and open a `hold`-labeled PR whose body maps each remaining claim to its evidence
+10. Create a bead for each finding
+11. Summarize outreach pipeline and community health in your response


### PR DESCRIPTION
## Problem

The outreach agent could publish persuasive product and solution documentation containing capabilities the product does not provide. The reported incidents included a "HIPAA Session Compliance" page, security absolutes, automatic rollback behavior, zero-setup hardware claims, and roadmap commitments that were not grounded in shipped functionality or human-approved plans.

This was especially risky because the outreach policy explicitly said its content PRs needed no hold label. At ACMM L6, unsupported claims could therefore reach a public project site through the normal automerge path without human review.

## Root cause

Two policy layers were missing:

1. `outreach-full.md` optimized for engagement and instructed the agent to write content, but did not require each capability claim to be verified against the repository or a released artifact. It also did not prohibit regulatory/compliance assertions or invented roadmap commitments.
2. The server-side PR watcher only applied `hold` according to the global L3-L5 ACMM gate. It had no role-specific L6 exception for outreach, no requirement that outreach expose its claim evidence to reviewers, and no pre-publication rejection for regulatory language.

The result was a prompt that rewarded plausible solution-copy shape and a merge path that treated public claims like ordinary autonomous code changes.

## Implementation

### Ground outreach content in product evidence

Both the source policy (`src/policies/outreach-full.md`) and its embedded runtime default (`src/pkg/policies/defaults/outreach-full.md`) now require the outreach agent to:

- inventory every product, security, compatibility, integration, and roadmap claim before writing;
- verify each claim against an exact implementing file, test, released artifact, or human-authored official source;
- include a `Claim evidence` mapping in the PR body;
- omit unverifiable claims and escalate them to a human;
- refuse all regulatory/compliance posture claims, including HIPAA, PCI DSS, GDPR, SOC 2, FedRAMP, and FIPS language;
- avoid roadmap commitments unless an existing human-authored plan or announcement supports them; and
- open every outreach PR with `hold`, including at ACMM L6, without removing the label or merging the PR itself.

### Enforce the boundary at the PR-request choke point

`src/pkg/github/pr_request_outreach.go` validates authenticated outreach requests before `CreatePR` makes them public:

- the PR body must contain a `Claim evidence` section;
- regulatory terms in the title or body are rejected;
- the target branch is compared through GitHub and added lines are scanned for the same regulatory terms;
- a 300-file boundary response or an added text file whose patch cannot be inspected fails closed with an actionable reason;
- permanent content-policy failures are written to the result file and quarantined as `.rejected`;
- forge/default-branch/compare failures remain transient and use the existing bounded retry path.

The validator is deliberately scoped to the authenticated `outreach` role. Other agent roles keep their existing PR behavior, while a human can still author the regulatory language that the outreach policy tells the agent to escalate.

### Keep outreach human-reviewed at L6

The authoritative hold-label callback now receives the authenticated agent name. `shouldHoldAgentPR` preserves the existing behavior for every other role—held at L3-L5 and autonomous at L6—but always holds outreach PRs.

Required-label failures are no longer logged and treated as successful. The request remains queued under bounded backoff; its retry deduplicates the already-open PR and reapplies `hold`. This preserves the invariant that the watcher does not silently consume a request whose required review gate was not installed.

## Design decisions and boundaries

- The mechanical validator does not pretend that a filename citation proves a semantic capability. It makes evidence visible, rejects the highest-risk regulatory class, and relies on the mandatory human review gate for semantic review.
- The regulatory matcher covers the concrete regimes from the incident and scanner analysis. The policy prohibition intentionally remains broader than the matcher so renamed or less common certification regimes are still out of bounds for the agent.
- Regulatory scanning is limited to outreach rather than blanket-blocking all agent roles. This avoids preventing security and governance agents from accurately documenting the absence of a certification; outreach must hand such language to a human.
- The GitHub compare API is capped at 300 files and can omit patches for very large text changes. Those cases fail closed instead of silently approving an uninspected tail. Large outreach campaigns should be split into reviewable PRs or opened manually by a human.
- This change protects outreach PR creation. Outreach issue creation is governed by the strengthened policy but is not mechanically keyword-scanned in this patch.

## Regression coverage

- `TestOutreachPolicyRequiresGroundedHumanReviewedClaims` checks both policy copies for the evidence, compliance, roadmap, and mandatory-hold invariants and prevents the old exemption from returning.
- `TestShouldHoldAgentPR` proves outreach remains held at L6 while other L6 agents remain autonomous and the existing L3-L5 gate is unchanged.
- Outreach validator tests cover missing evidence, regulatory terms in every supported spelling, PR metadata, changed-file content, safe grounded content, non-outreach bypass, and fail-closed missing patches.
- `TestPRRequestWatcherRejectsOutreachRegulatoryClaimBeforeCreate` proves an invalid request is quarantined and no pull request is created.
- `TestPRRequestWatcher_RetriesRequiredHoldLabelFailure` proves a transient label failure retains the request, reuses the already-open PR, retries the label, and only then consumes the request.

## Verification

Passed:

```text
go test ./pkg/github ./pkg/policies ./cmd/hive
ok github.com/kubestellar/hive/pkg/github
ok github.com/kubestellar/hive/pkg/policies
ok github.com/kubestellar/hive/cmd/hive

go test ./pkg/github -run 'TestValidateOutreach|TestPRRequestWatcherRejectsOutreach|TestPRRequestWatcher_RetriesRequiredHold|TestPRRequestWatcher_HoldLabelApplied'
ok github.com/kubestellar/hive/pkg/github

git diff --check
```

The full `go test ./...` run compiled and passed the changed packages, but the repository-wide command was not green in this checkout for unrelated environment-specific tests:

- `pkg/agent` tmux tests failed because their generated Unix socket path exceeded the platform path limit (`File name too long` under this long worktree path).
- `pkg/config`'s IPv6 egress-gate test encountered the host `ip6tables` binary without the root/NET_ADMIN capability it expects, so its simulated "binary missing" assertion did not apply.

Neither failing package is changed by this PR. The affected package suites above pass independently.

Fixes #5115

— hive: backend=codex
