### PR TITLE
📖 docs: name Podman in the non-Kubernetes config branch

### DIFF
--- a/docs/HUB_DISASTER_RECOVERY.md
+++ b/docs/HUB_DISASTER_RECOVERY.md
@@ -67,9 +67,11 @@ Note it only *reports* the runtime config. It never restores from it.
 > `hive.yaml.bak` and boots normally from it. Backups capture **both** names, so
 > restore whichever the archive contains — under the new name.
 >
-> On Docker/LXC this file is not a snapshot at all but the boot-time source of
-> truth, since there is no ConfigMap and no overlay there. See
-> `src/docs/config-layering.md`.
+> Outside Kubernetes — Docker, Podman, LXC, or a bare host binary; the branch is
+> chosen by the absence of a Kubernetes pod, not by the runtime — this file is not
+> a snapshot at all but the boot-time source of truth, since there is no ConfigMap
+> and no overlay there. Restoring such a hive means restoring the data volume that
+> holds it, not the seed. See `src/docs/config-layering.md`.
 
 **How to tell which variant a hive runs** — this is the only way to know:
 

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -31,7 +31,7 @@ You almost never write a full roster by hand: applying an ACMM level (below) gen
 Hive's config is layered, and the layering is the point: **a file's location says who owns the setting.**
 
 ```
-/etc/hive/hive.yaml            ← ConfigMap seed (Kubernetes) or bind mount (Docker/LXC).
+/etc/hive/hive.yaml            ← ConfigMap seed (Kubernetes) or bind mount (Docker, Podman, LXC).
 │                                 The operator/platform layer. Re-seeded on every pod
 │                                 boot; authoritative for acmm_level and hub.is_public.
 ├── /data/hive.yaml.dashboard  ← Dashboard overlay on the PVC. Every save from the
@@ -43,7 +43,7 @@ Hive's config is layered, and the layering is the point: **a file's location say
 │                                 Merged over the agents: map at load time.
 ├── /data/hive.yaml.runtime    ← Persisted runtime config (was hive.yaml.bak). Never
 │                                 edit. On K8s a post-merge snapshot the entrypoint
-│                                 restores from if the seed is lost; on Docker/LXC the
+│                                 restores from if the seed is lost; outside Kubernetes the
 │                                 boot-time source of truth. The legacy name is still
 │                                 read as a fallback during the migration.
 ├── /data/secrets/             ← Secret VALUES written by the dashboard (writable PVC).
@@ -536,7 +536,7 @@ This is the property operators most need to understand before enabling the featu
 
 - A dashboard save cannot turn `allow_github_prompt` on if the seed has it off.
 - A dashboard save cannot add a repo slug to `github_prompt_allowlist`.
-- A compromised or malicious dashboard overlay can neither widen the set of readable repos nor repoint an agent's `definition_source` at an arbitrary repo — only a seed edit (ConfigMap in Kubernetes, bind-mounted file in Docker/LXC) can do either.
+- A compromised or malicious dashboard overlay can neither widen the set of readable repos nor repoint an agent's `definition_source` at an arbitrary repo — only a seed edit (ConfigMap in Kubernetes, bind-mounted file under Docker, Podman or LXC) can do either.
 
 An empty allowlist denies every repo even with `allow_github_prompt: true` — the allowlist is required, not merely advisory.
 

--- a/src/docs/config-layering.md
+++ b/src/docs/config-layering.md
@@ -91,7 +91,7 @@ rational response to having one road, not duplicated effort.
 > and only ever *adds*, so a deleted agent reappears on the next config reload.
 > Tracked in #2361.
 
-## `hive.yaml.runtime` — a snapshot on Kubernetes, an input on Docker/LXC
+## `hive.yaml.runtime` — a snapshot on Kubernetes, an input everywhere else
 
 This file was called `hive.yaml.bak` until the rename. The old name implied
 "the restorable backup", which is true of only half its behaviour, and the
@@ -102,7 +102,7 @@ and *reads* it only when the ConfigMap is missing or empty — the disaster
 fallback. A minority of older hives run a `copy-config` init container variant
 that does restore from it first; that variant is not what new hives get.
 
-**On Docker/LXC it is a live boot input, and the source of truth.** There is no
+**Outside Kubernetes it is a live boot input, and the source of truth.** There is no
 ConfigMap and no overlay in that mode, so the entrypoint restores this file over
 the config path on every boot (or points `HIVE_CONFIG` straight at it, and
 pins the same path into the launch argv as `--config`, when the config path is
@@ -113,19 +113,73 @@ outside Kubernetes because this file already plays that role.
 
 > An earlier version of this section was headed "`hive.yaml.bak` is a backup,
 > not an input" and mentioned Docker only in passing. That was wrong for every
-> Docker/LXC hive, where the file is precisely an input.
+> non-Kubernetes hive, where the file is precisely an input.
+
+### Which mode am I in?
+
+There is no Docker-specific or Podman-specific code path. The entrypoint and
+`config.IsKubernetesPod()` both ask one question — *is this a Kubernetes pod?*
+— and everything that is not one takes the same branch:
+
+```sh
+# src/deploy/entrypoint.sh
+if [ -n "${KUBERNETES_SERVICE_HOST:-}" ] || [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+  IS_KUBERNETES=true
+```
+
+So **Docker, Podman (rootful or rootless) and LXC all behave identically here**,
+as does any other container runtime and a bare binary on a host. This document
+says "outside Kubernetes" rather than naming runtimes, because naming a subset
+of them is how a Podman operator concludes the section is about someone else's
+deployment ([#5220](https://github.com/kubestellar/hive/issues/5220)).
+
+Ask the running hive which file actually decides a field:
+
+```bash
+# Same endpoint as above; use whichever port this hive serves the dashboard on
+# (3002 direct, or 3001 when an nginx gateway fronts it).
+curl -s localhost:3002/api/config/provenance | jq '.fields[] | select(.field=="acmm_level")'
+```
+
+```jsonc
+{
+  "field": "acmm_level",
+  "layer": "configmap-seed",        // the layer's stable contract name…
+  "path": "/data/hive.yaml.runtime", // …but outside Kubernetes this is the real file (#4971)
+  "writer": "spoke (Config.Save)",
+  "writable": true,
+  "value": "4"
+}
+```
+
+Note the `layer` name stays `configmap-seed` on a host that has no ConfigMap:
+the layer identity is a stable part of the provenance contract, while `path`
+and `writer` are the environment-aware fields that tell you where to write.
+Trust `path`, not the layer name.
+
+Two consequences worth stating outright for a non-Kubernetes hive:
+
+- **The bind-mounted seed at `/etc/hive/hive.yaml` goes stale and stays stale.**
+  A dashboard change to `acmm_level` is written to `/data/hive.yaml.runtime`;
+  nothing writes it back to the seed. Reading the seed to find out what level a
+  hive is running will mislead you. This is by design (issue #1856 — letting
+  the seed win reverted a hive to its provisioned level on every restart), not
+  drift to be repaired.
+- **`/data` is the only copy of the live config.** Losing that volume reverts
+  the hive to whatever the seed was provisioned with, silently downgrading
+  every hold-gated agent. Back up the volume, not just the seed file.
 
 ### Migration
 
 The rename is **copy-forward, never destructive**. Writers emit
 `/data/hive.yaml.runtime`; readers prefer it and fall back to
 `/data/hive.yaml.bak` when it is absent. Nothing renames or deletes the legacy
-file on a PVC — on Docker/LXC it is the single copy of the live config, so
+file on a PVC — outside Kubernetes it is the single copy of the live config, so
 mutating it at boot could lose owner customisations with no warning.
 
 A hive booting new code with only the legacy file present therefore boots
 normally from that file, and gains the new name on the next config save (on
-Docker/LXC, the entrypoint also copies it forward immediately). Backups capture
+non-Kubernetes, the entrypoint also copies it forward immediately). Backups capture
 both names for the same reason. The legacy fallback can be removed one release
 after every live hive has written the new name.
 


### PR DESCRIPTION
## Summary

- Hive has two configuration modes. Inside Kubernetes the ConfigMap seed matters and `/data/hive.yaml.runtime` is a snapshot written after the merge; outside Kubernetes there is no ConfigMap and no dashboard overlay, and that runtime file *is* the live source of truth the hive boots from.
- The docs describing the second mode called it **"Docker/LXC"**, and the word "podman" appeared in **none** of them — but the code never asks which runtime is in use. `entrypoint.sh` and `config.IsKubernetesPod()` both branch on *is this a Kubernetes pod*, so Docker, Podman, LXC and a bare host binary behave identically. A self-hosted Podman operator searching the docs for their runtime found nothing, and the one section that answers their question read as though it were about someone else's deployment.
- This renames the branch to "outside Kubernetes" where the text means the branch, names Podman where it enumerates runtimes, and adds a "Which mode am I in?" section to `config-layering.md` with the detection rule and the provenance query that answers it.
- **Blast radius: docs-only, no behavior change.** No existing claim changes — the text was accurate, just addressed to a subset of its readers.

Fixes #5220

## Why this surfaced

A self-hosted rootless-Podman hive, ACMM level moved from 3 to 4 in the dashboard. Reading the seed afterwards to confirm the level:

```console
$ grep acmm_level /home/hive/.config/hive/hive.yaml
acmm_level: 3          # stale, and it stays stale forever
```

The hive is really at 4 — the deciding value lives in the runtime file, and the process is launched with two `--config` flags where the second wins:

```console
$ ps -o args= -p <hive-pid>
hive --config /etc/hive/hive.yaml --config /data/hive.yaml.runtime
```

All of that is correct and deliberate (#1856: letting the seed win reverted a hive to its provisioned level on every restart), and `config-layering.md` already explained it. The gap was purely discoverability: nothing connected "Docker/LXC" to a Podman host.

## Change

**Wording**, across `src/docs/config-layering.md`, `src/docs/agent-configuration.md` and `docs/HUB_DISASTER_RECOVERY.md`: `Docker/LXC` → `outside Kubernetes` where it names the branch, and `Docker, Podman, LXC` where it enumerates runtimes.

**New section**, `config-layering.md` → *Which mode am I in?* — "outside Kubernetes" is only actionable if a reader can tell which side they are on. It quotes the detection from `entrypoint.sh` and `IsKubernetesPod()`, and shows the per-field provenance query. It also records two things an operator otherwise learns the hard way:

- **Trust `path`, not the layer name.** The provenance report still labels the layer `configmap-seed` on a host that has no ConfigMap. That name is a deliberately stable part of the `/api/config/provenance` contract, while `path` and `writer` are the environment-aware fields corrected in #4971. A reader who trusts the layer name over `path` lands back in exactly the confusion #4971 set out to fix.
- **`/data` is the only copy of the live config.** Losing that volume reverts the hive to whatever the seed was provisioned with — silently downgrading every hold-gated agent to advisory. Back up the volume, not the seed file.

## Testing

- `src/scripts/check-podman-contract.sh` passes (unrelated to these files, run because it is the repo's existing Podman guard).
- Verified no `Docker/LXC` occurrences remain in the three files, and that `podman` is now greppable in each.
- Detection rule quoted verbatim against `src/deploy/entrypoint.sh:76-79` and `src/pkg/config/config.go:5425`; provenance behavior checked against a live self-hosted Podman hive, whose report shows `layer: configmap-seed` with `path: /data/hive.yaml.runtime` and `writable: true`.
- The `localhost:3002` port in the new example matches the existing example at the top of the same document; a note names 3001 for gateway-fronted hives.

---
— hive: backend=claude model=claude-Opus-5
