### PR TITLE
📖 docs: GitHub App Setup URL is browser-resolved and optional

### DIFF
--- a/src/docs/github-app-setup.md
+++ b/src/docs/github-app-setup.md
@@ -46,8 +46,17 @@ Recommended values:
 
 - **GitHub App name**: any unique operator-owned name.
 - **Homepage URL**: your project or Hive dashboard URL.
-- **Setup URL**: `https://<hive-host>/gh-setup`.
-- **Redirect on update**: enabled.
+- **Setup URL** (optional): `https://<hive-host>/gh-setup`. `<hive-host>` means
+  **the address you type into your browser to reach this hive** — not where the
+  hive process runs. GitHub redirects *your browser* here; it never fetches this
+  URL itself, and neither does the hive. See
+  [Choosing a Setup URL](#choosing-a-setup-url) before setting it, and leave it
+  blank if the hive is not reachable from the browser you administer it with —
+  Hive discovers `installation_id` on its own.
+- **Redirect on update**: enabled — but only alongside a Setup URL that is
+  actually reachable. It re-fires the redirect on every repository add or
+  removal, so an unreachable Setup URL produces a dead browser tab every time
+  you change the installation, not just once at install.
 - **Webhook**: inactive unless you separately configure webhook channels; the dashboard setup flow does not require webhooks.
 - **Device Flow**: enabled, so dashboard login can use the app's client ID.
 - **Visibility**: private for an organization-specific app; public only if you intentionally operate one app for many unrelated owners.
@@ -138,13 +147,63 @@ line above from its logs.
 ```yaml
 github:
   app_id: <app-id>
-  installation_id: <installation-id>  # optional when /gh-setup can complete it
+  installation_id: <installation-id>  # optional; auto-discovered (see below)
   app_slug: <app-slug>
   key_file: /secrets/gh-app-key.pem
   oauth_client_id: <client-id>
 ```
 
 For GitHub Enterprise, also set `api_url`/`base_url` or the supported `forge` value so install URLs and API calls target the same host.
+
+## Choosing a Setup URL
+
+The Setup URL is a **browser redirect target**, not a callback GitHub's servers
+make. After an install — and, with **Redirect on update** enabled, after every
+repository add or removal — GitHub sends whatever browser you were using to
+that address. So the only question that matters is:
+
+> Can the browser I administer this hive from open that URL?
+
+That is a property of how *you* reach the hive, not of where the hive runs:
+
+| How you reach the dashboard | Correct Setup URL |
+| --- | --- |
+| Desktop session on the hive machine | `http://localhost:3001/gh-setup` |
+| SSH tunnel (`ssh -L 3001:localhost:3001 you@hive`) | `http://localhost:3001/gh-setup` — the tunnel makes `localhost` genuinely the hive |
+| Another machine on the network | `http://<hive-lan-name-or-ip>:3001/gh-setup` |
+| Public hostname behind TLS | `https://<hive-host>/gh-setup` |
+| Not reachable from your browser at all | **leave it blank** — see below |
+
+`localhost` is the common trap. It is correct only for the first two rows, and
+it fails silently everywhere else: set it while sitting at the hive machine and
+it works, then administer the hive from a laptop and every install-update
+redirect lands on the laptop's own port 3001, which is nothing at all.
+
+### Headless, NATed, and remotely administered hives
+
+**The Setup URL is optional. A hive that is not reachable from anywhere should
+leave it blank and turn Redirect on update off.** Nothing is lost.
+
+The callback's only job is to save you from pasting an `installation_id`, and
+Hive already resolves that itself: it asks GitHub `GET /orgs/{org}/installation`
+authenticated with the **App JWT**, falling back to walking
+`GET /app/installations`. That runs when the hive starts, whenever App
+credentials are (re)loaded, and when you press **Re-check** on the dashboard's
+Forge App panel — adopting and persisting an unambiguous match, so it corrects a
+missing *or wrong* `installation_id` without any redirect. An ambiguous or
+absent result leaves your configuration untouched rather than guessing.
+
+Every one of those calls is **outbound, hive to GitHub**. A headless Fedora
+CoreOS host, a VM on a NAT network, or any server you only reach over SSH needs
+no inbound reachability for GitHub App authentication to work. The
+preconditions are the ones App auth already has: the private key mounted at
+`key_file`, and `project.org` set so Hive knows whose installation to look for.
+
+If you do leave a Setup URL configured that your browser cannot reach, the
+resulting dead redirect is cosmetic. Adding a repository modifies the existing
+installation rather than creating a new one, so the `installation_id` in that
+redirect is one the hive already holds — the failed page does not mean App
+authentication is broken.
 
 ## `/gh-setup` flow
 


### PR DESCRIPTION
## Summary

- A GitHub App's **Setup URL** is where GitHub sends the *operator's browser* after an install or an install update. Hive's setup guide listed it under "Recommended values" as `https://<hive-host>/gh-setup` with **Redirect on update** enabled, and said nothing more.
- `<hive-host>` reads as "wherever the hive runs", so an operator configuring it while sitting at the hive machine reasonably enters `http://localhost:3001/gh-setup`. That value works there and **fails from every other machine** — and on a headless host it can never work, because there is no browser on it. With Redirect on update also recommended, the dead redirect fires on **every repository add or removal**, which reads as broken App auth when nothing is wrong.
- It is also **optional**, which the docs never said. Hive resolves `installation_id` itself over outbound App-JWT calls, so a headless, NATed or SSH-only hive authenticates with no inbound reachability at all.
- **Blast radius: docs-only**, one file, no behavior change and no claim reversed — the existing text was accurate as far as it went.

Fixes #5232

## What was missing

Two facts an operator needs before setting this field, neither of which was written down:

1. **It is browser-resolved.** GitHub never fetches the URL, and neither does the hive — it hands your browser a redirect. So the correct value depends on how *you* reach the dashboard, not on where the hive process lives.
2. **It is optional.** `src/pkg/github/app_discovery.go` resolves the installation with an App-JWT call to `GET /orgs/{org}/installation`, falling back to walking `GET /app/installations`:

   > Both endpoints are authenticated with the App JWT, not an installation token, so this works even when the CONFIGURED `installation_id` is wrong — which is the whole point.

   `healGitHubAppInstallation` drives it at startup, when App credentials are (re)loaded, and from the dashboard's Re-check handler, persisting an unambiguous match and leaving config untouched when the result is ambiguous.

## Change

One file, `src/docs/github-app-setup.md`:

- **Recommended values** — Setup URL marked optional, with the rule stated inline and a pointer to the new section. Redirect on update gains the consequence: with an unreachable Setup URL it produces a dead browser tab on every installation change, not just at install.
- **New `## Choosing a Setup URL`** — the rule ("the address you type into your browser to reach this hive"), plus a table mapping each access pattern to its correct value. That includes the case worth calling out: under an SSH tunnel (`ssh -L 3001:localhost:3001 …`) `localhost` is *genuinely correct*, because the tunnel makes it the hive.
- **New `### Headless, NATed, and remotely administered hives`** — leave the field blank and turn Redirect on update off; nothing is lost. Explains auto-discovery, notes the preconditions are the ones App auth already has (key mounted, `project.org` set), and records that a dead redirect on a repo add is *cosmetic*, since that `installation_id` is one the hive already holds.
- **Install-and-configure snippet** — `# optional when /gh-setup can complete it` understated the case; now `# optional; auto-discovered (see below)`.

## Testing

Docs-only, so the verification was of the claims rather than of behavior:

- Auto-discovery endpoints and the "works even when the configured ID is wrong" property read directly from `src/pkg/github/app_discovery.go`.
- The three `healGitHubAppInstallation` call sites confirmed at `src/cmd/hive/main.go:779`, `:2800`, `:4491`. **Note:** that function's own comment mentions a "self-heal tick"; I could not find a periodic caller, so the doc claims only the three verified triggers rather than a timer. The argument does not depend on one. (I filed the issue with the looser wording and have since corrected it there too.)
- Preconditions (`key_file`, `project.org`) confirmed against the discovery and client-construction paths.
- The `#choosing-a-setup-url` anchor resolves to the new `## Choosing a Setup URL` heading; heading order checked for nesting.

## How this surfaced

An operator running a self-hosted Podman hive added a second repo from a different machine and was redirected to `http://localhost:3001/gh-setup`, then asked what would happen on a headless Fedora CoreOS host. The answer — nothing bad, and the Setup URL is unnecessary there — was not discoverable from the documentation.

---
— hive: backend=claude model=claude-Opus-5
