### PR TITLE
📖 docs(bin): index the 9 missing regression test scripts

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -98,6 +98,15 @@ Most production scripts are installed under `/usr/local/bin` by `bin/hive-deploy
 | `contributor-agent.test.sh` | Contributor-agent regression for knowledge export handling. |
 | `contributor-relay.test.js` | Contributor relay task/restart/headless behavior; loads `contributor-relay.sh` as JavaScript with stubs. |
 | `gh-wrapper.test.sh` | `gh-wrapper.sh` author-gate and restriction regressions using a mock `gh` binary. |
+| `test_agent_env_scrub.sh` | `agent-env-scrub.sh` (#4045): backend CLIs must not re-export live GitHub credentials into the tool shells they spawn. Behavioural plus source assertions. |
+| `test_gh_auth_native_no_cat.sh` | The N14 (#3842) fix: a native/systemd-install agent kicked via `kick-agents.sh` — no Go AgentManager, no per-agent `HIVE_AGENT_TOKEN_CACHE` — still authenticates without leaking the token through `cat`. |
+| `test_gh_wrapper_gates.sh` | `gh-wrapper.sh`'s enforcement gates. |
+| `test_git_credential_hive.sh` | `git-credential-hive.sh` behaviour. |
+| `test_hive_open_issue.sh` | `hive-open-issue.sh`, the agent issue-creation chokepoint. See [`src/docs/hive-open-issue.md`](../src/docs/hive-open-issue.md). |
+| `test_hive_review.sh` | `hive-review.sh`, the agent PR-review chokepoint. |
+| `test_hive_podman_setup.sh` | Contract tests for `hive-podman-setup.sh` (#4470). |
+| `test_hive_podman_update.sh` | Contract tests for `hive-podman-update.sh` (#4378). |
+| `test_hive_podman_lifecycle_probe.sh` | Contract tests for `hive-podman-lifecycle-probe.sh` (#4377). |
 | `test_hive_baseline_check.sh` | Shared-CI classifier regressions for red default branches, exact-name sibling thresholds, reruns, pending checks, and fail-closed API errors. |
 | `test_bin_suites_wired.sh` | Fails when a test suite in this directory is not run by any workflow, Justfile target, or hook (#4363). |
 | `test_hive_standalone_runtime.sh` | `hive-standalone-runtime.sh` engine selection: Docker default, explicit Podman, and no silent fallback. |


### PR DESCRIPTION
Fixes #5253

## What

`bin/README.md`'s regression tests table listed 9 of the 18 test scripts in `bin/`. All nine missing ones are wired into `.github/workflows/v2-ci.yml`:

`test_agent_env_scrub.sh`, `test_gh_auth_native_no_cat.sh`, `test_gh_wrapper_gates.sh`, `test_git_credential_hive.sh`, `test_hive_open_issue.sh`, `test_hive_review.sh`, `test_hive_podman_setup.sh`, `test_hive_podman_update.sh`, `test_hive_podman_lifecycle_probe.sh`

Each entry is written from the script's own header comment.

## This gap is one I created

#5239 stated that "every non-test file in `bin/` now appears in the index," and I verified it with:

```sh
ls bin/ | grep -vE "^test_|\.test\.js$|^README"
```

That claim was true and useless. The loop filtered out `test_*` files, so it could never inspect the one table that exists specifically for them — a check scoped to exclude the thing being asked about will always pass.

Re-verified this time **without** the exclusion: every file in `bin/` now appears in `bin/README.md`.

## Two worth finding from the index

`test_hive_open_issue.sh` and `test_hive_review.sh` guard the agent chokepoints that route issue creation and PR review through the App bot — the same family as `hive-merge.sh` and `hive-open-pr.sh`, whose docs landed in #5240.

Docs only, 9 lines.