### PR TITLE
✨ feat(tui): add kick-agent client operation

### DIFF
--- a/src/pkg/tui/client/actions.go
+++ b/src/pkg/tui/client/actions.go
@@ -56,6 +56,24 @@ type AgentActionResult struct {
 	State string `json:"state"`
 }
 
+// KickResult is the response from POST /api/kick/{agent}.
+//
+// It mirrors dashboard/openapi.json exactly. Unlike AgentActionResult, the
+// kick response has no blanket success flag or resulting lifecycle state: a
+// 200 is represented by status "kicked" and the resolved agent name.
+type KickResult struct {
+	Status string `json:"status"`
+	Agent  string `json:"agent"`
+}
+
+// kickRequest is the prompt-bearing form of the optional kick request body.
+// The published operation also accepts a legacy message field when prompt is
+// empty, but callers of KickAgent supply a prompt, so sending message here
+// would duplicate the same value in a lower-precedence field.
+type kickRequest struct {
+	Prompt string `json:"prompt"`
+}
+
 // Paused reports whether the agent is paused after the call, per State.
 //
 // State is a string on the wire because that is what the spec and handler
@@ -87,6 +105,31 @@ func (c *Client) PauseAgent(ctx context.Context, agent string) (AgentActionResul
 // owner-only.
 func (c *Client) ResumeAgent(ctx context.Context, agent string) (AgentActionResult, error) {
 	return c.agentAction(ctx, "/api/resume/", agent)
+}
+
+// KickAgent sends a prompt to one running agent via POST /api/kick/{agent}.
+//
+// An empty prompt deliberately sends no request body. That reaches the
+// server's auto-generated-message path, which builds a kick from the agent's
+// last actionable item. A non-empty prompt is sent in the preferred prompt
+// field; the server enforces the operation's 10000-character limit.
+func (c *Client) KickAgent(ctx context.Context, agent, prompt string) (KickResult, error) {
+	const prefix = "/api/kick/"
+	if agent == "" {
+		return KickResult{}, fmt.Errorf("POST %s: agent name is required", prefix)
+	}
+
+	var body any
+	if prompt != "" {
+		body = kickRequest{Prompt: prompt}
+	}
+
+	var result KickResult
+	path := prefix + url.PathEscape(agent)
+	if err := c.postJSON(ctx, path, body, &result); err != nil {
+		return KickResult{}, err
+	}
+	return result, nil
 }
 
 // agentAction is the shared body of PauseAgent and ResumeAgent, which differ

--- a/src/pkg/tui/client/actions_test.go
+++ b/src/pkg/tui/client/actions_test.go
@@ -327,3 +327,138 @@ func TestAgentActionDecodeErrorIsNotAPIError(t *testing.T) {
 		t.Errorf("error = %q, does not name the decode failure", err)
 	}
 }
+
+// TestKickAgentDecodesFixtureAndSendsPrompt pins the response schema and the
+// prompt-bearing request form published for POST /api/kick/{agent}.
+func TestKickAgentDecodesFixtureAndSendsPrompt(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "kick.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod, gotAuth, gotContentType string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "tok").KickAgent(context.Background(), "scanner", "review issue 5217")
+	if err != nil {
+		t.Fatalf("KickAgent() = %v, want nil", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/kick/scanner" {
+		t.Errorf("path = %q, want /api/kick/scanner", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer tok")
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if want := `{"prompt":"review issue 5217"}`; string(gotBody) != want {
+		t.Errorf("request body = %q, want %q", gotBody, want)
+	}
+	if want := (KickResult{Status: "kicked", Agent: "scanner"}); got != want {
+		t.Errorf("KickAgent() = %+v, want %+v", got, want)
+	}
+}
+
+// TestKickAgentWithoutPromptSendsNoBody protects the server's automatic-kick
+// path. Sending an empty prompt object would be observably different from the
+// operation's optional request body and would mask regressions in postJSON.
+func TestKickAgentWithoutPromptSendsNoBody(t *testing.T) {
+	var gotBody []byte
+	var gotContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotContentType = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"kicked","agent":"quality"}`)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "tok").KickAgent(context.Background(), "quality", "")
+	if err != nil {
+		t.Fatalf("KickAgent() = %v, want nil", err)
+	}
+	if len(gotBody) != 0 {
+		t.Errorf("request body = %q, want empty for an automatic kick", gotBody)
+	}
+	if gotContentType != "" {
+		t.Errorf("Content-Type = %q, want unset for a bodiless POST", gotContentType)
+	}
+	if want := (KickResult{Status: "kicked", Agent: "quality"}); got != want {
+		t.Errorf("KickAgent() = %+v, want %+v", got, want)
+	}
+}
+
+// TestKickAgentEscapesAndRequiresAgentName keeps the agent argument inside its
+// one path segment and rejects an empty path parameter before any request.
+func TestKickAgentEscapesAndRequiresAgentName(t *testing.T) {
+	var gotRawPath string
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		gotRawPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":"kicked","agent":"a/b"}`)
+	}))
+	defer server.Close()
+	c := newTestClient(t, server, "tok")
+
+	if _, err := c.KickAgent(context.Background(), "a/b", "go"); err != nil {
+		t.Fatalf("KickAgent() = %v, want nil", err)
+	}
+	if gotRawPath != "/api/kick/a%2Fb" {
+		t.Errorf("escaped path = %q, want /api/kick/a%%2Fb", gotRawPath)
+	}
+	if _, err := c.KickAgent(context.Background(), "", "go"); err == nil {
+		t.Fatal("KickAgent() error = nil, want a rejection of the empty agent name")
+	} else if !strings.Contains(err.Error(), "agent name is required") {
+		t.Errorf("error = %q, does not name the problem", err)
+	}
+	if calls != 1 {
+		t.Errorf("server calls = %d, want 1; empty agent must fail locally", calls)
+	}
+}
+
+// TestKickAgentServerErrorReturnsAPIError covers the task's required error
+// path and ensures failed kicks retain their POST method and escaped path.
+func TestKickAgentServerErrorReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":"boom"}`)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "tok").KickAgent(context.Background(), "scanner", "go")
+	if err == nil {
+		t.Fatal("KickAgent() error = nil, want *APIError")
+	}
+	if got != (KickResult{}) {
+		t.Errorf("result = %+v, want the zero value on error", got)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v (%T), want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want 500", apiErr.StatusCode)
+	}
+	if apiErr.Method != http.MethodPost {
+		t.Errorf("Method = %q, want POST", apiErr.Method)
+	}
+	if apiErr.Path != "/api/kick/scanner" {
+		t.Errorf("Path = %q, want /api/kick/scanner", apiErr.Path)
+	}
+}

--- a/src/pkg/tui/client/testdata/kick.json
+++ b/src/pkg/tui/client/testdata/kick.json
@@ -1,0 +1,1 @@
+{"status":"kicked","agent":"scanner"}


### PR DESCRIPTION
## Summary

Add the typed TUI client operation for sending an immediate kick to an agent, completing T20 of the `hivectl tui` work tracked by #4907.

The dashboard already publishes and serves `POST /api/kick/{agent}`, but `pkg/tui/client` only exposed the T14 pause/resume writes. Without this method, the later T21 keybinding cannot invoke the existing kick workflow through the TUI's typed, authenticated HTTP client.

Closes #5217.

## What changed

### Typed kick operation

`src/pkg/tui/client/actions.go` now defines `KickResult` with exactly the response fields published by `dashboard/openapi.json`:

- `status`, normally `"kicked"` on success;
- `agent`, the server-resolved agent name.

`Client.KickAgent(ctx, agent, prompt)` sends a POST to `/api/kick/{agent}` through the existing `postJSON` helper and decodes that response. Agent names use `url.PathEscape`, matching the pause/resume action invariant that one agent argument remains one path segment. An empty agent name fails locally with a caller-oriented error instead of issuing a request to an unmatched route.

### Optional request-body semantics

A non-empty prompt is encoded only as the spec's preferred field:

```json
{"prompt":"review issue 5217"}
```

The client does not duplicate the value into the lower-precedence `message` compatibility field. Prompt length remains server-enforced, preserving the thin-client shape of the existing action methods and returning the dashboard's structured 400 as `*APIError`.

When `prompt` is empty, `KickAgent` passes a nil body to `postJSON`. This produces a genuinely bodiless POST with no `Content-Type`, rather than `null` or `{"prompt":""}`, and keeps the server's auto-generated message path directly reachable from the TUI.

### Fixture and regression coverage

`src/pkg/tui/client/testdata/kick.json` is a captured response-shaped fixture containing only the two fields in the published schema. The new tests verify:

- every fixture field decodes into `KickResult`;
- method, path, bearer authentication, content type, and exact prompt JSON;
- an empty prompt sends zero body bytes and no JSON content type;
- agent names containing `/` remain inside one escaped path segment;
- an empty agent name is rejected without a network call;
- a 500 returns the zero result plus the client's typed `*APIError`, retaining the POST method and request path.

## Verification

Run from `src/`:

```text
go test ./pkg/tui/client -run 'TestKickAgent' -count=1
ok github.com/kubestellar/hive/pkg/tui/client 0.006s

go test ./pkg/tui/... -count=1
ok github.com/kubestellar/hive/pkg/tui 0.564s
ok github.com/kubestellar/hive/pkg/tui/client 0.048s
ok github.com/kubestellar/hive/pkg/tui/panes 0.010s
ok github.com/kubestellar/hive/pkg/tui/theme 0.002s

go build ./...
go vet ./pkg/tui/...
git diff --check
```

The test commands were run with writable temporary Go/ccache directories because the execution environment's default cache is read-only. The `httptest`-based client tests also required loopback socket access; all passed once run with that access.

## Scope

This PR adds only the TUI client primitive. It does not add the T21 `K` keybinding or confirmation UX, change server-side kick generation or prompt limits, expose kick history, or alter pause/resume behavior.

— hive: backend=codex
