### PR TITLE
🐛 fix(agent): remove unsafe ACMM level suffix helper

### DIFF
--- a/src/pkg/agent/manager_coverage2_test.go
+++ b/src/pkg/agent/manager_coverage2_test.go
@@ -1333,7 +1333,7 @@ func TestDefaultAgentMode_AllLevels(t *testing.T) {
 	}
 }
 
-// SuffixForLevel, AgentMode booleans, and ParseAgentMode are tested in mode_test.go
+// AgentMode booleans and ParseAgentMode are tested in mode_test.go.
 
 // ---------------------------------------------------------------------------
 // ClearAllModeOverrides — verify modes cleared

--- a/src/pkg/agent/mode.go
+++ b/src/pkg/agent/mode.go
@@ -6,7 +6,7 @@ type AgentMode int
 const (
 	ModeAdvisory       AgentMode = iota // Advisory beads only, governor posts digests
 	ModeIssuesOnly                      // Open issues, no PRs
-	ModeIssuesAndPRs                    // Issues + PRs (hold-labeled at L5)
+	ModeIssuesAndPRs                    // Issues + PRs, without merge authority
 	ModeIssuesPRsMerge                  // Issues + PRs + auto-merge on green CI
 )
 
@@ -52,18 +52,6 @@ func (m AgentMode) Suffix() string {
 		return modeSuffixes[m]
 	}
 	return "-advisory"
-}
-
-// SuffixForLevel returns the policy file suffix adjusted for ACMM level.
-// ISSUES_AND_PRS uses "-holdgated" only at L5 (hold-labeled PRs) and "-full" at all other levels.
-func (m AgentMode) SuffixForLevel(level int) string {
-	if m == ModeIssuesAndPRs {
-		if level == 5 {
-			return "-holdgated"
-		}
-		return "-full"
-	}
-	return m.Suffix()
 }
 
 func (m AgentMode) CanCreateIssues() bool { return m >= ModeIssuesOnly }

--- a/src/pkg/agent/mode_test.go
+++ b/src/pkg/agent/mode_test.go
@@ -55,27 +55,6 @@ func TestAgentModeSuffix(t *testing.T) {
 	}
 }
 
-func TestSuffixForLevel(t *testing.T) {
-	tests := []struct {
-		mode  AgentMode
-		level int
-		want  string
-	}{
-		{ModeIssuesAndPRs, 3, "-full"},
-		{ModeIssuesAndPRs, 4, "-full"},
-		{ModeIssuesAndPRs, 5, "-holdgated"},
-		{ModeIssuesAndPRs, 6, "-full"},
-		{ModeAdvisory, 3, "-advisory"},
-		{ModeIssuesOnly, 4, "-issues"},
-		{ModeIssuesPRsMerge, 6, "-automerge"},
-	}
-	for _, tt := range tests {
-		if got := tt.mode.SuffixForLevel(tt.level); got != tt.want {
-			t.Errorf("AgentMode(%d).SuffixForLevel(%d) = %q, want %q", tt.mode, tt.level, got, tt.want)
-		}
-	}
-}
-
 func TestAgentModeCapabilities(t *testing.T) {
 	tests := []struct {
 		mode      AgentMode


### PR DESCRIPTION
## Summary

- remove the unused `AgentMode.SuffixForLevel` helper whose L3/L4 mapping would fail open from `-holdgated` to `-full`
- remove the unit test that enshrined that unsafe mapping as expected behavior
- correct the adjacent `ModeIssuesAndPRs` comment so it describes the mode's intrinsic no-merge authority instead of incorrectly tying hold labels to L5
- leave the shipped ACMM packs—the sole runtime source of template selection—unchanged

## Problem and risk

Hive's level packs explicitly select each agent's policy template. At L3, L4, and L5, every `ISSUES_AND_PRS` entry uses a `-holdgated.md` template; at L6 those entries use `-full.md`. This is the security-relevant boundary that keeps PR-opening agents below L6 behind human review.

`AgentMode.SuffixForLevel` duplicated that decision but returned `-holdgated` only for exactly L5 and `-full` at every other level. A future caller at L3 or L4 would therefore silently remove the hold label and grant more PR authority at a lower trust level. `TestSuffixForLevel` asserted those incorrect L3/L4 results, so CI would have approved that regression.

There is no current incident or runtime behavior change: the helper has had no production caller since it was introduced in `d4b3f0b7` for #613. The risk was latent but fail-open, made more likely by an exported-looking method, a confident doc comment, and a green test all presenting the wrong mapping as supported API.

## Root cause

The original mode architecture introduced a level-aware policy-suffix helper even though runtime configuration never derived templates from it. `src/pkg/config/packs/level-*.yaml` names every `kick_template` explicitly, so the helper became an unmaintained second source of truth. Later pack evolution established hold-gating below L6, while the dead helper and its isolated self-test remained frozen on the original L5-only assumption.

The adjacent `ModeIssuesAndPRs` constant comment carried the same stale assumption—“hold-labeled at L5”—even though the mode represents capability, while the selected pack template determines hold-gating.

## Implementation

### Remove the duplicate policy API

`src/pkg/agent/mode.go` no longer exposes `SuffixForLevel`. There is now no code path that can appear to derive a policy suffix from an ACMM level while disagreeing with the packs.

`AgentMode.Suffix` remains unchanged. It is the mode-to-default-suffix mapping and conservatively maps `ModeIssuesAndPRs` to `-holdgated`; this issue is specifically about the unused level override that replaced that safe default with `-full` at L3/L4.

### Remove the misleading test signal

`src/pkg/agent/mode_test.go` drops `TestSuffixForLevel` in full. Flipping two expected strings would make the helper locally correct today but would preserve an unused second implementation that can drift again without any connection to the packs.

`src/pkg/agent/manager_coverage2_test.go` updates its test-ownership comment so it no longer claims that the removed helper is covered elsewhere.

### Clarify the mode invariant

The `ModeIssuesAndPRs` declaration now says “Issues + PRs, without merge authority.” That is intrinsic to `AgentMode` (`CanCreatePRs` is true and `CanMerge` is false) at every level. Hold-gating remains a property of the pack-selected policy template.

## Design decision: deletion instead of correcting the branch

The issue allowed either changing `level == 5` to `level <= 5` or deleting the method, and preferred deletion. This PR takes the deletion path because:

- repository-wide search finds zero production callers;
- every runtime template is already selected explicitly by the embedded level packs;
- a pack-consistency test for an unused helper would add parsing/coupling solely to preserve dead API;
- deleting the helper makes disagreement impossible, while correcting it would only make two sources agree at this point in time;
- no production behavior, persisted data, configuration schema, or documented operator API depends on the method.

## Regression evidence

The issue's pack probe reports:

```text
level-3: quality-holdgated.md
level-4: ci-maintainer-holdgated.md, quality-holdgated.md, sec-check-holdgated.md
level-5: all nine ISSUES_AND_PRS entries use -holdgated.md
level-6: all nine ISSUES_AND_PRS entries use -full.md
```

After this change, `rg -n 'SuffixForLevel' src --glob '*.go'` returns no matches. This is the regression guarantee chosen here: the unsafe duplicate API and the test signal that advertised it are absent, while the existing `DefaultAgentMode`, capability, suffix, and full agent-package suites continue to pass.

No replacement unit test is added for deleted behavior. The authoritative packs are unchanged, already load through the config test suite, and are verified directly above; inventing a new helper solely to test its agreement would recreate the source-of-truth problem this fix removes.

## Verification

- `cd src && env GOCACHE=/tmp/hive-5219-go-cache CCACHE_DIR=/tmp/hive-5219-ccache go build ./...` — PASS
- `cd src && env GOCACHE=/tmp/hive-5219-go-cache CCACHE_DIR=/tmp/hive-5219-ccache go test ./pkg/agent -run '^(TestAgentMode|TestParseAgentMode|TestDefaultAgentMode)' -count=1` — PASS
- `cd /tmp/hv5219/src && env GOCACHE=/tmp/hive-5219-go-cache CCACHE_DIR=/tmp/hive-5219-ccache go test ./pkg/agent -count=1` — PASS (`253.580s`)
- `cd src && env GOCACHE=/tmp/hive-5219-go-cache CCACHE_DIR=/tmp/hive-5219-ccache go vet ./pkg/agent` — PASS
- issue-provided `awk` probe over `src/pkg/config/packs/level-{3,4,5,6}.yaml` — PASS; confirms hold-gated L3–L5 and full L6 templates
- `rg -n 'SuffixForLevel' src --glob '*.go'` — no matches
- `git diff --check` — PASS

The full agent suite creates real hermetic tmux Unix sockets. From the normal deep worktree it first failed before relevant assertions because tmux's socket path exceeded the platform limit (`File name too long`); from a short worktree inside the restricted sandbox it reached the same tests but socket creation was denied (`Operation not permitted`). The reported passing run used the exact committed tree in a temporary short detached worktree with local Unix-socket access. The worktree was removed afterward. These environment-specific failures are unrelated to this diff.

The explicit cache variables only redirect Go and ccache writes from the read-only host cache in this development environment.

## Scope

This PR removes a latent fail-open trap; it does not change the shipped level packs, current agent modes, token tiers, PR labeling, merge authority, runtime config reconciliation, or the documented ACMM policy matrix. Because no user-visible runtime behavior changes, no changelog entry is warranted under the repository's changelog policy.

## Related issues

Fixes #5219

## Contributor checklist

- [x] Targets `v4`, the repository's current development branch (the template's `v2` wording predates the source-tree rename).
- [x] Title follows the repository emoji convention.
- [x] The commit includes a DCO sign-off matching the commit author email.
- [x] No changelog entry is needed because the removed helper had no runtime caller or user-visible behavior.
- [x] No secrets, credentials, or local runtime state are committed.

— hive: backend=codex
