### PR TITLE
fix(dashboard): add Podman path to hive onboarding

### DIFF
--- a/src/pkg/dashboard/api_contribute.go
+++ b/src/pkg/dashboard/api_contribute.go
@@ -7735,8 +7735,8 @@ func (s *Server) handleHivesOnboard(w http.ResponseWriter, r *http.Request) {
 		"next_steps": []string{
 			"1. Install the Hive GitHub App on your org",
 			"2. Note the App ID and Installation ID",
-			"3. Save the private key as /etc/hive/gh-app-key.pem",
-			"4. Deploy with: docker compose up -d",
+			"3. Save the private key in the deployment's secrets directory (for example, /etc/hive/secrets/gh-app-key.pem, or ~/.config/hive/secrets/gh-app-key.pem for rootless Podman)",
+			"4. Deploy: Docker — docker compose up -d; Podman — install the Quadlet units from src/deploy/quadlet/ per src/docs/podman-standalone-quadlet.md, then start hive-gateway.service with systemctl (systemctl --user for rootless)",
 			"5. Register: POST /api/hives/register",
 		},
 	})

--- a/src/pkg/dashboard/api_contribute_test.go
+++ b/src/pkg/dashboard/api_contribute_test.go
@@ -1209,9 +1209,24 @@ func TestHivesOnboard(t *testing.T) {
 	var resp struct {
 		NextSteps []string `json:"next_steps"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &resp)
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
 	if len(resp.NextSteps) < 3 {
-		t.Errorf("expected >=3 steps, got %d", len(resp.NextSteps))
+		t.Fatalf("expected >=3 steps, got %d", len(resp.NextSteps))
+	}
+
+	steps := strings.Join(resp.NextSteps, "\n")
+	for _, want := range []string{
+		"docker compose up -d",
+		"Quadlet",
+		"systemctl --user",
+		"src/docs/podman-standalone-quadlet.md",
+		"~/.config/hive/secrets/gh-app-key.pem",
+	} {
+		if !strings.Contains(steps, want) {
+			t.Errorf("onboarding steps do not mention %q: %q", want, steps)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`POST /api/hives/onboard` returned a five-step setup checklist whose deployment step only said `docker compose up -d`. Podman-only operators therefore received a command they could not run, even though Hive ships and documents a supported Quadlet deployment. The neighboring private-key step also named only a rootful `/etc/hive/` layout and did not tell rootless Podman operators about their `~/.config/hive/` configuration tree.

The handler encoded these assumptions as static response strings, and `TestHivesOnboard` only checked the number of returned steps. It could not detect either runtime-specific instruction regressing.

## Implementation

- Preserve the existing Docker Compose command in the deployment step.
- Add an explicit Podman branch that points operators to the shipped files under `src/deploy/quadlet/`, the standalone Quadlet guide, and the systemd lifecycle used by rootless installs.
- Direct operators to start `hive-gateway.service`, matching the documented Quadlet dependency chain in which the gateway pulls the Hive service, network, and volume up in order.
- Expand the private-key step with the rootless Podman host path under `~/.config/hive/secrets/` while retaining a rootful `/etc/hive/secrets/` example.
- Strengthen `TestHivesOnboard` to fail on malformed JSON and assert that the response continues to name Docker Compose, Quadlet, the rootless `systemctl --user` path, the canonical Podman guide, and the rootless key location.

## Design notes

This deliberately does not recommend bare `podman compose`. Hive's Podman lifecycle decision and shipped deployment use Quadlet, avoiding compose-provider ambiguity and preserving systemd-managed readiness. The response names both supported deployment choices because the onboarding endpoint does not receive or infer the operator's container runtime.

No API schema, routing, runtime behavior, Quadlet units, or Docker Compose files change; this is limited to correcting the onboarding guidance and pinning it with regression coverage.

## Verification

- `env GOCACHE=/tmp/hive-5229-go-cache CCACHE_DIR=/tmp/hive-5229-ccache go test ./pkg/dashboard -run '^TestHivesOnboard$' -count=1` — PASS
- `env GOCACHE=/tmp/hive-5229-go-cache CCACHE_DIR=/tmp/hive-5229-ccache go test ./pkg/dashboard -count=1` — PASS (`48.931s`)
- `git diff --check` — PASS

The full package test initially could not bind an `httptest` loopback socket under the restricted sandbox; rerunning the unchanged command with local ephemeral socket access passed. There are no repository test failures associated with this change.

Fixes #5229

— hive: backend=codex
