### PR TITLE
🐛 fix(ci): retry the Quadlet gate's image pull instead of failing on a CDN blip

### DIFF
--- a/.github/workflows/quadlet-gate.yml
+++ b/.github/workflows/quadlet-gate.yml
@@ -97,10 +97,31 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # BOUNDED RETRY, NOT A SKIP PATH (#5273). The digest pin above fixed
+      # `manifest unknown` — a resolution failure, which no retry helps. This
+      # covers the other half: the TRANSFER dropping mid-layer. On 2026-08-31
+      # the pull died with `unexpected EOF` reading a blob from cdn01.quay.io
+      # and failed the whole gate for a PR that touches only Go code in
+      # pkg/dashboard; re-running the identical job passed. Three attempts
+      # with a short backoff, matching the transient-transport idiom in
+      # release.yml. Everything this gate refuses to do stays refused: a
+      # registry that is really unreachable still ends the job red on the last
+      # attempt, and there is still no `continue-on-error`, no `|| true`, and
+      # no path that reports green without the generator in hand.
       - name: Install the Quadlet generator
         run: |
           set -euo pipefail
-          podman pull -q "$PODMAN_IMAGE"
+          for attempt in 1 2 3; do
+            if podman pull -q "$PODMAN_IMAGE"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::could not pull ${PODMAN_IMAGE} after 3 attempts. The generator is not optional (#4211): failing rather than skipping the gate."
+              exit 1
+            fi
+            echo "podman pull failed (attempt ${attempt}/3) — retrying in 5s..."
+            sleep 5
+          done
           echo "pulled $PODMAN_IMAGE"
 
       # AC: the job fails if the generator is missing rather than passing


### PR DESCRIPTION
## Summary

- The Quadlet generator gate is a required CI job that validates Podman unit files by running the real `quadlet --dryrun` binary. The hosted runner's podman ships no such binary, so the job first pulls a pinned `quay.io/podman/stable` image to borrow one.
- That pull was a single unguarded attempt, so **any network blip mid-download failed the whole gate and turned a healthy PR red**. On 2026-08-31 it killed #5270 — a PR that changes only Go code under `pkg/dashboard` — with `unexpected EOF` while reading a blob from Quay's CDN. Re-running the identical job passed with no change to the branch.
- This PR retries the pull up to three times with a 5s backoff, matching the transient-transport idiom already used in `release.yml`.
- Blast radius: CI only, one workflow step. No product behavior, no change to what the gate accepts or rejects.

## Related issues

Fixes #5273

## Root cause

`quadlet-gate.yml` already survived one registry failure mode. Its comments record that pinning the image digest behind a *floating* tag broke the gate on every branch twice in four days (2026-08-21, 2026-08-24), because Quay re-pushes the tag and garbage-collects the previous index, which then 404s with `manifest unknown`. The fix was to pin the digest of a `-immutable` tag, and it works — the digest resolved fine in this failure.

What failed this time is the other half: not resolution, but **transfer**.

```
Error: unable to copy from source docker://quay.io/podman/stable@sha256:b017323…:
  copying system image from manifest list: writing blob:
  storing blob to file "/var/tmp/container_images_storage1461830012/5":
  happened during read: unexpected EOF
  (while reconnecting: Get "https://cdn01.quay.io/…": EOF)
##[error]Process completed with exit code 125
```

The connection dropped partway through a layer. No amount of pinning addresses that, and the step had nothing else to fall back on:

```yaml
- name: Install the Quadlet generator
  run: |
    set -euo pipefail
    podman pull -q "$PODMAN_IMAGE"
```

Evidence it was transient rather than systemic: one failure in the last 40 runs of this workflow; another branch passed the same gate against the same pinned digest ten minutes later; and `gh run rerun --failed` went green without touching the branch.

## Change

Three attempts, 5s apart, mirroring the bounded retry at `release.yml:482`.

**This is explicitly not a skip path.** The gate's whole design premise (`quadlet-gate.yml:12-18`, from #4211) is that podman can be present without its generator, and a job that skips when the generator is missing reports green while testing nothing — so it has no skip path at all. That stance is preserved exactly:

- A registry that is genuinely unreachable still fails the job, red, after the third attempt.
- No `continue-on-error`, no `|| true`, no conditional, no path that reports success without the generator in hand.
- The final failure is annotated with `::error::` naming why the generator is not optional, so the log says what happened rather than just exiting 125.
- Each retry prints which attempt failed, so a flaky-but-recovering pull stays visible in the log instead of being silently smoothed over.

Only a blip that a retry actually clears stops being fatal.

## Out of scope

The three other image pulls in CI (`pr-verifier.yml:27`, `docker.yml:268`, `release.yml:216`) all pull from `ghcr.io` — same-provider as the runner, and in `docker.yml`'s case an image the job itself just pushed. None has been observed failing this way, so they are left alone rather than hardened speculatively.

## Testing

- [x] Workflow YAML parses and the step round-trips (`yaml.safe_load`).
- [x] Retry logic exercised directly against a stubbed `podman`, all three paths: succeeds first try (one attempt, no retry noise, rc=0); fails twice then succeeds (two retry lines, rc=0 — the #5270 case); always fails (two retry lines, `::error::`, **rc=1** — the gate still goes red).
- [x] Other / not run: the gate itself runs on this PR, which exercises the changed step against the live registry.

## Contributor checklist

- [x] PR targets `v4` (current default branch; the template's `v2` note predates it).
- [x] Title uses the repo emoji convention, for example `📖 docs: ...`, `🐛 fix: ...`, or `✨ feature: ...`.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies are updated when behavior changes — the reasoning lives in the workflow's own comments, where the rest of this gate's design rationale is.
- [x] `CHANGELOG.md` has an entry for user-visible changes, or the change is not user-facing — **not user-facing**: CI reliability only, and `changelog-reminder.yml:65` already classifies `.github/` changes as non-code.
- [x] No secrets, credentials, or local runtime state are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JShrLsa7XNTsTDKmp3Z8E9

— hive: backend=claude model=claude-Fable-5
