### PR TITLE
🐛 fix(notice): regenerate after the otel 1.46.0 bumps

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2166,9 +2166,9 @@ Source:   https://github.com/open-telemetry/opentelemetry-go-instrumentation/blo
 -----------------------------------------------------------------------------
 
 Package:  go.opentelemetry.io/otel
-Version:  v1.45.0
+Version:  v1.46.0
 License:  Apache-2.0
-Source:   https://github.com/open-telemetry/opentelemetry-go/blob/v1.45.0/LICENSE
+Source:   https://github.com/open-telemetry/opentelemetry-go/blob/v1.46.0/LICENSE
 
                                  Apache License
                            Version 2.0, January 2004
@@ -2880,9 +2880,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -----------------------------------------------------------------------------
 
 Package:  go.opentelemetry.io/otel/metric
-Version:  v1.45.0
+Version:  v1.46.0
 License:  Apache-2.0
-Source:   https://github.com/open-telemetry/opentelemetry-go/blob/metric/v1.45.0/metric/LICENSE
+Source:   https://github.com/open-telemetry/opentelemetry-go/blob/metric/v1.46.0/metric/LICENSE
 
                                  Apache License
                            Version 2.0, January 2004
@@ -3118,9 +3118,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -----------------------------------------------------------------------------
 
 Package:  go.opentelemetry.io/otel/sdk
-Version:  v1.45.0
+Version:  v1.46.0
 License:  Apache-2.0
-Source:   https://github.com/open-telemetry/opentelemetry-go/blob/sdk/v1.45.0/sdk/LICENSE
+Source:   https://github.com/open-telemetry/opentelemetry-go/blob/sdk/v1.46.0/sdk/LICENSE
 
                                  Apache License
                            Version 2.0, January 2004
@@ -3356,9 +3356,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -----------------------------------------------------------------------------
 
 Package:  go.opentelemetry.io/otel/trace
-Version:  v1.45.0
+Version:  v1.46.0
 License:  Apache-2.0
-Source:   https://github.com/open-telemetry/opentelemetry-go/blob/trace/v1.45.0/trace/LICENSE
+Source:   https://github.com/open-telemetry/opentelemetry-go/blob/trace/v1.46.0/trace/LICENSE
 
                                  Apache License
                            Version 2.0, January 2004
@@ -3829,9 +3829,9 @@ THE SOFTWARE.
 -----------------------------------------------------------------------------
 
 Package:  go.yaml.in/yaml/v3
-Version:  v3.0.4
+Version:  v3.0.5
 License:  MIT
-Source:   https://github.com/yaml/go-yaml/blob/v3.0.4/LICENSE
+Source:   https://github.com/yaml/go-yaml/blob/v3.0.5/LICENSE
 
 
 This project is covered by two different licenses: MIT and Apache.
@@ -4698,7 +4698,7 @@ Source:   https://github.com/natefinch/lumberjack/blob/v2.2.1/LICENSE
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Nate Finch
+Copyright (c) 2014 Nate Finch 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What

`NOTICE` is stale on `v4` right now — `notice-drift` is failing on the branch itself, not only on the open dependency PRs.

The `go.opentelemetry.io/otel` and `otel/sdk` bumps to 1.46.0 merged without regenerating it. `NOTICE` is generated from the module graph, so any version bump makes it stale by construction.

## Verification

- **55 packages before and after** — no dependency added or removed
- Only `go.opentelemetry.io/otel*` version strings change, `v1.45.0` → `v1.46.0`
- Committed **verbatim** from `src/scripts/generate-notice.sh`; the drift check is byte-exact, so the output must not be reformatted or whitespace-stripped (#5064)

## Note for the remaining otel PRs

#5248 (`otlptracehttp`) and #5250 (`trace`) are still open and will each need the same regeneration after they merge — or, more simply, one regeneration once both have landed. Worth doing that as a single follow-up rather than per-PR, since each bump invalidates the previous PR's regenerated file.