### PR TITLE
🐛 fix(github): stop filing a PR whose content an open PR already carries (#5111)

### DIFF
--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -174,6 +174,14 @@ type Client struct {
 	// re-installs it while the PR-request watcher goroutine may be reading it.
 	hiveIdentityMu sync.RWMutex
 	hiveIdentity   HiveIdentity
+	// commitTrees memoizes "owner/repo@commitSHA" -> tree SHA for the
+	// duplicate-payload guard (pr_duplicate_tree.go, #5111). A commit's tree
+	// can never change, so unlike defaultBranches this cache has no staleness
+	// window at all; it exists purely so re-inspecting the same open PRs on
+	// every PR creation does not re-pay a lookup per candidate. Guarded by
+	// commitTreeMu.
+	commitTreeMu sync.RWMutex
+	commitTrees  map[string]string
 }
 
 func (c *Client) SetCanaryScanner(enabled, failClosed bool, reg *ioscan.CanaryRegistry, onLeak func(ioscan.CanaryLeak)) {

--- a/src/pkg/github/pr_duplicate_tree.go
+++ b/src/pkg/github/pr_duplicate_tree.go
@@ -1,0 +1,175 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// Content-identity duplicate guard (kubestellar/hive#5111).
+//
+// CreatePR has always been idempotent for the SAME head branch: re-requesting a
+// PR for a branch that already has one returns the existing PR instead of
+// opening a second. That covers a retried request; it cannot see the incident
+// class this file exists for — an agent copying one change forward onto a NEW
+// branch and filing it again. tuna-os/tromso collected five such PRs (#170,
+// #212, #225, #241, #244) sharing the same blobs, two of them (#241, #212)
+// carrying an identical tree, so `git diff` between their tips was empty.
+//
+// The discriminator is the commit's TREE SHA. Two commits with the same tree
+// have byte-identical content, so two open PRs on the same base whose head
+// commits share a tree propose exactly the same change — whatever their branch
+// names, commit messages, or authorship. That is an equality test, not a
+// heuristic: it cannot fire on two changes that merely look alike, which is why
+// it is safe to act on automatically. The near-duplicate class in the same
+// issue (same topic, different bytes) is deliberately NOT addressed here; it
+// has no exact test and belongs in policy text, not in a gate that silently
+// swallows work.
+//
+// Comparing only against PRs with the SAME base matters. An identical tree on a
+// different base is a different diff, so it is not a duplicate.
+
+// maxDuplicateTreeCandidates bounds how many open PRs one guard pass inspects.
+// Each uncached candidate costs a commit lookup, and PR creation must not turn
+// into an unbounded fan-out on a repository with hundreds of open PRs — the
+// same secondary-rate-limit exposure that made the request watcher adopt
+// backoff. Reaching the cap is logged rather than passed over in silence: a
+// truncated pass can miss a duplicate, and an operator reading "no duplicate
+// found" deserves to know the search was partial.
+const maxDuplicateTreeCandidates = 50
+
+// findOpenPRWithIdenticalTree returns an open PR against base whose head commit
+// points at the same tree as head's tip, or nil when there is none.
+//
+// Errors are for the CALLER to decide about. This returns them rather than
+// swallowing them because a dedupe lookup that failed is not the same fact as a
+// dedupe lookup that found nothing, and CreatePR deliberately treats the former
+// as "proceed and open the PR" — refusing to publish work because an auxiliary
+// read failed would be a worse bug than the duplicate it is guarding.
+func (c *Client) findOpenPRWithIdenticalTree(ctx context.Context, owner, repo, head, base string) (*gh.PullRequest, error) {
+	if c == nil || c.client == nil {
+		return nil, ErrNoGitHubClient
+	}
+	headSHA, err := c.LatestCommitHash(ctx, owner, repo, head)
+	if err != nil {
+		return nil, err
+	}
+	headTree, err := c.commitTreeSHA(ctx, owner, repo, headSHA)
+	if err != nil {
+		return nil, err
+	}
+	if headTree == "" {
+		return nil, fmt.Errorf("duplicate-tree guard: commit %s carries no tree SHA", headSHA)
+	}
+
+	prs, _, err := c.client.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
+		State:       "open",
+		Base:        base,
+		ListOptions: gh.ListOptions{PerPage: 100},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	inspected := 0
+	for _, pr := range prs {
+		if pr == nil {
+			continue
+		}
+		candidateSHA := strings.TrimSpace(pr.GetHead().GetSHA())
+		if candidateSHA == "" {
+			continue
+		}
+		// The same commit is trivially the same tree, and costs no lookup to
+		// recognise. This also covers the branch-renamed-but-not-rebuilt case.
+		if candidateSHA == headSHA {
+			return pr, nil
+		}
+		if inspected >= maxDuplicateTreeCandidates {
+			c.logger.Info("duplicate-tree guard: candidate cap reached, remaining open PRs not inspected",
+				slog.String("repo", owner+"/"+repo), slog.String("base", base),
+				slog.Int("inspected", inspected), slog.Int("open_prs", len(prs)))
+			break
+		}
+		inspected++
+		candidateTree, terr := c.commitTreeSHA(ctx, owner, repo, candidateSHA)
+		if terr != nil {
+			// One unreadable candidate must not blind the guard to the rest.
+			// A PR whose head commit was force-pushed away between the list and
+			// the lookup is the ordinary cause, and it is not a duplicate of
+			// anything by then.
+			c.logger.Warn("duplicate-tree guard: could not read a candidate's tree, skipping it",
+				slog.String("repo", owner+"/"+repo), slog.Int("number", pr.GetNumber()),
+				slog.String("error", terr.Error()))
+			continue
+		}
+		if candidateTree == headTree {
+			return pr, nil
+		}
+	}
+	return nil, nil
+}
+
+// commitTreeSHA resolves a commit SHA to the SHA of the tree it points at.
+//
+// The mapping is immutable — a commit's tree can never change — so the result
+// is cached for the life of the process without any staleness risk. That
+// matters more than it looks: the open PRs on a repository are re-inspected on
+// every PR creation, so without the cache the guard's cost would grow with the
+// product of open PRs and PRs opened, and with it the steady-state cost is one
+// lookup for the new head alone.
+func (c *Client) commitTreeSHA(ctx context.Context, owner, repo, sha string) (string, error) {
+	if c == nil || c.client == nil {
+		return "", ErrNoGitHubClient
+	}
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return "", fmt.Errorf("commitTreeSHA: a commit SHA is required")
+	}
+	key := owner + "/" + repo + "@" + sha
+	if tree, ok := c.cachedCommitTree(key); ok {
+		return tree, nil
+	}
+	commit, _, err := c.client.Git.GetCommit(ctx, owner, repo, sha)
+	if err != nil {
+		return "", fmt.Errorf("fetching commit %s/%s@%s: %w", owner, repo, sha, err)
+	}
+	tree := strings.TrimSpace(commit.GetTree().GetSHA())
+	if tree == "" {
+		// Do not cache an empty answer: it would make a one-off malformed
+		// response permanent for the life of the process.
+		return "", nil
+	}
+	c.storeCommitTree(key, tree)
+	return tree, nil
+}
+
+func (c *Client) cachedCommitTree(key string) (string, bool) {
+	c.commitTreeMu.RLock()
+	defer c.commitTreeMu.RUnlock()
+	tree, ok := c.commitTrees[key]
+	return tree, ok
+}
+
+// maxCommitTreeCacheEntries bounds the commit->tree cache. The mapping is
+// immutable so nothing here goes stale; the bound exists only so a long-lived
+// process working many repositories cannot grow the map without limit. At the
+// bound the cache is dropped whole rather than evicted entry by entry — this is
+// a cost optimisation, not a correctness mechanism, so the simplest possible
+// reclaim is the right one and a rebuilt cache costs only lookups.
+const maxCommitTreeCacheEntries = 4096
+
+func (c *Client) storeCommitTree(key, tree string) {
+	c.commitTreeMu.Lock()
+	defer c.commitTreeMu.Unlock()
+	if c.commitTrees == nil {
+		c.commitTrees = map[string]string{}
+	}
+	if len(c.commitTrees) >= maxCommitTreeCacheEntries {
+		c.commitTrees = map[string]string{}
+	}
+	c.commitTrees[key] = tree
+}

--- a/src/pkg/github/pr_duplicate_tree_test.go
+++ b/src/pkg/github/pr_duplicate_tree_test.go
@@ -1,0 +1,580 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// dupTreeServer fakes the four endpoints the content-identity guard touches.
+//
+//	branches: branch name        -> head commit SHA
+//	trees:    commit SHA         -> tree SHA
+//	openPRs:  base branch        -> open PRs on that base
+//
+// It counts POST /pulls (created) and GET /git/commits/* (commitCalls) so a test
+// can assert both the OUTCOME (no duplicate PR) and the COST (the cache works).
+type dupTreeServer struct {
+	branches map[string]string
+	trees    map[string]string
+	openPRs  map[string][]dupTreePR
+
+	mu          sync.Mutex
+	created     int
+	commitCalls int
+	labels      int
+	listedBases []string
+	// failRef, failList and failCommit make the corresponding endpoint 500, so
+	// the fail-open behaviour can be exercised one dependency at a time.
+	failRef, failList, failCommit bool
+}
+
+type dupTreePR struct {
+	Number  int
+	HeadRef string
+	HeadSHA string
+}
+
+func (d *dupTreeServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(path, "/repos/o/r"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
+
+		case r.Method == "GET" && strings.Contains(path, "/git/ref/heads/"):
+			if d.failRef {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			branch := path[strings.Index(path, "/git/ref/heads/")+len("/git/ref/heads/"):]
+			sha, ok := d.branches[branch]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"ref":"refs/heads/%s","object":{"sha":%q}}`, branch, sha)
+
+		case r.Method == "GET" && strings.Contains(path, "/git/commits/"):
+			d.mu.Lock()
+			d.commitCalls++
+			d.mu.Unlock()
+			if d.failCommit {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			sha := path[strings.Index(path, "/git/commits/")+len("/git/commits/"):]
+			tree, ok := d.trees[sha]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"sha":%q,"tree":{"sha":%q}}`, sha, tree)
+
+		case r.Method == "GET" && strings.Contains(path, "/compare/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"files":[]}`)
+
+		case r.Method == "GET" && strings.HasSuffix(path, "/pulls"):
+			if d.failList {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			// The head-branch dedupe query is a different question from the
+			// guard's base query; only the latter carries no head filter.
+			if head := r.URL.Query().Get("head"); head != "" {
+				_, _ = io.WriteString(w, `[]`)
+				return
+			}
+			base := r.URL.Query().Get("base")
+			d.mu.Lock()
+			d.listedBases = append(d.listedBases, base)
+			d.mu.Unlock()
+			out := make([]map[string]any, 0, len(d.openPRs[base]))
+			for _, pr := range d.openPRs[base] {
+				out = append(out, map[string]any{
+					"number":   pr.Number,
+					"html_url": fmt.Sprintf("https://github.com/o/r/pull/%d", pr.Number),
+					"head":     map[string]any{"ref": pr.HeadRef, "sha": pr.HeadSHA},
+					"user":     map[string]any{"login": "kubestellar-hive[bot]"},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(out)
+
+		// #5117's self-authorisation gate reads the cited issue. Counted (and
+		// then 404'd, as an unconfigured issue) so a test can assert the
+		// duplicate path never asks.
+		case r.Method == "GET" && strings.Contains(path, "/issues/") && strings.HasSuffix(path, "/comments"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+
+		case r.Method == "GET" && strings.Contains(path, "/issues/"):
+			// Hive-filed and untouched by any human — the shape that makes
+			// #5117's gate return Held. If the duplicate path ever consults it,
+			// the test's SelfAuthorized assertion fails rather than passing by
+			// accident.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":581,"user":{"login":"kubestellar-hive[bot]","type":"Bot"},"labels":[],"assignees":[],"comments":0}`)
+
+		case r.Method == "POST" && strings.HasSuffix(path, "/labels"):
+			d.mu.Lock()
+			d.labels++
+			d.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+
+		case r.Method == "POST" && strings.HasSuffix(path, "/pulls"):
+			d.mu.Lock()
+			d.created++
+			d.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":99,"html_url":"https://github.com/o/r/pull/99"}`)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (d *dupTreeServer) counts() (created, commitCalls int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.created, d.commitCalls
+}
+
+func (d *dupTreeServer) labelCalls() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.labels
+}
+
+// readPRResult decodes the .result.json the watcher writes next to a consumed
+// request — the artifact the requesting agent actually reads.
+func readPRResult(t *testing.T, reqPath string) PRResponse {
+	t.Helper()
+	raw, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatalf("reading PR result: %v", err)
+	}
+	var resp PRResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decoding PR result: %v", err)
+	}
+	return resp
+}
+
+// TestCreatePR_ReusesOpenPRWithIdenticalTree is the incident from
+// kubestellar/hive#5111: a change copied forward onto a NEW branch, whose tree
+// is identical to an open PR's. `git diff` between the tips is empty, so the
+// second PR proposes nothing. The head-branch dedupe cannot see it — the
+// branches differ — so before this guard a duplicate PR was opened.
+func TestCreatePR_ReusesOpenPRWithIdenticalTree(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"autotune-again": "cafe1111"},
+		trees: map[string]string{
+			"cafe1111": "eb0b85ab", // the new branch
+			"beef2222": "eb0b85ab", // the open PR's head — SAME tree
+		},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 212, HeadRef: "autotune", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "o/r", "autotune-again", "main", "autotune, again", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if created, _ := d.counts(); created != 0 {
+		t.Fatalf("opened %d PRs, want 0 — an identical tree is a no-op, not a contribution", created)
+	}
+	if res.Number != 212 {
+		t.Errorf("Number = %d, want the existing PR 212", res.Number)
+	}
+	if !res.AlreadyExisted {
+		t.Error("AlreadyExisted = false, want true — the caller must not treat this as a fresh PR")
+	}
+	if !res.DuplicateTree {
+		t.Error("DuplicateTree = false, want true — the reuse was decided by content, not by head branch")
+	}
+	if res.URL != "https://github.com/o/r/pull/212" {
+		t.Errorf("URL = %q, want the existing PR's URL", res.URL)
+	}
+}
+
+// TestCreatePR_OpensWhenTreesDiffer is the control. Without it the test above
+// would also pass if the guard simply refused everything.
+func TestCreatePR_OpensWhenTreesDiffer(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"real-work": "cafe1111"},
+		trees: map[string]string{
+			"cafe1111": "aaaaaaaa",
+			"beef2222": "bbbbbbbb",
+		},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 212, HeadRef: "other", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "o/r", "real-work", "main", "real work", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if created, _ := d.counts(); created != 1 {
+		t.Fatalf("opened %d PRs, want 1 — a genuinely different tree must still be filed", created)
+	}
+	if res.DuplicateTree || res.AlreadyExisted {
+		t.Errorf("DuplicateTree=%v AlreadyExisted=%v, want both false", res.DuplicateTree, res.AlreadyExisted)
+	}
+	if res.Number != 99 {
+		t.Errorf("Number = %d, want the newly created 99", res.Number)
+	}
+}
+
+// TestCreatePR_DuplicateTreeOnlyComparesTheSameBase pins the correctness
+// boundary. An identical tree on a DIFFERENT base is a different diff, so it is
+// not a duplicate. The guard must scope its query by base rather than scanning
+// every open PR.
+func TestCreatePR_DuplicateTreeOnlyComparesTheSameBase(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"feature": "cafe1111"},
+		trees: map[string]string{
+			"cafe1111": "eb0b85ab",
+			"beef2222": "eb0b85ab", // same tree, but the PR targets "release"
+		},
+		openPRs: map[string][]dupTreePR{
+			"release": {{Number: 7, HeadRef: "other", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "o/r", "feature", "main", "feature", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if created, _ := d.counts(); created != 1 {
+		t.Fatalf("opened %d PRs, want 1 — the identical tree targets another base", created)
+	}
+	if res.DuplicateTree {
+		t.Error("DuplicateTree = true; an identical tree on a different base is a different change")
+	}
+	d.mu.Lock()
+	bases := append([]string(nil), d.listedBases...)
+	d.mu.Unlock()
+	if len(bases) != 1 || bases[0] != "main" {
+		t.Errorf("guard listed bases %v, want exactly [main] — an unscoped scan would compare unrelated diffs", bases)
+	}
+}
+
+// TestCreatePR_DuplicateTreeMatchesIdenticalHeadSHA covers the branch-renamed
+// case: the very same commit filed under a new branch name. It must be caught
+// without paying a commit lookup for the candidate.
+func TestCreatePR_DuplicateTreeMatchesIdenticalHeadSHA(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"renamed": "cafe1111"},
+		trees:    map[string]string{"cafe1111": "eb0b85ab"},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 241, HeadRef: "original", HeadSHA: "cafe1111"}},
+		},
+	}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "o/r", "renamed", "main", "renamed", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	created, commitCalls := d.counts()
+	if created != 0 || res.Number != 241 || !res.DuplicateTree {
+		t.Fatalf("created=%d number=%d duplicate=%v, want 0/241/true", created, res.Number, res.DuplicateTree)
+	}
+	// One lookup for our own head; the candidate is recognised by SHA alone.
+	if commitCalls != 1 {
+		t.Errorf("commit lookups = %d, want 1 — an equal head SHA needs no tree fetch", commitCalls)
+	}
+}
+
+// TestCreatePR_DuplicateTreeFailsOpen is the property that keeps this guard from
+// becoming a new way to LOSE work. Every dependency it reads is auxiliary: if
+// any of them fails, the PR must still be opened. A guard that blocked
+// publication on a failed read would be a worse bug than the duplicate it
+// prevents.
+func TestCreatePR_DuplicateTreeFailsOpen(t *testing.T) {
+	// Each case makes one dependency fail while leaving a real duplicate in
+	// place, so a guard that somehow still fired would be visible as created=0.
+	cases := map[string]func(d *dupTreeServer){
+		"ref lookup fails":    func(d *dupTreeServer) { d.failRef = true },
+		"open-PR list fails":  func(d *dupTreeServer) { d.failList = true },
+		"commit lookup fails": func(d *dupTreeServer) { d.failCommit = true },
+		"head branch missing": func(d *dupTreeServer) { d.branches = map[string]string{} },
+	}
+	for name, breakIt := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := &dupTreeServer{
+				branches: map[string]string{"dup": "cafe1111"},
+				trees:    map[string]string{"cafe1111": "eb0b85ab", "beef2222": "eb0b85ab"},
+				openPRs: map[string][]dupTreePR{
+					"main": {{Number: 212, HeadRef: "other", HeadSHA: "beef2222"}},
+				},
+			}
+			breakIt(d)
+			srv := d.start(t)
+			c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+			res, err := c.CreatePR(context.Background(), "o/r", "dup", "main", "dup", "body")
+			if err != nil {
+				t.Fatalf("CreatePR returned an error instead of opening the PR: %v", err)
+			}
+			if created, _ := d.counts(); created != 1 {
+				t.Fatalf("opened %d PRs, want 1 — a failed auxiliary read must never withhold the PR", created)
+			}
+			if res.DuplicateTree {
+				t.Error("DuplicateTree = true after a failed lookup; the guard must not claim a finding it could not make")
+			}
+		})
+	}
+}
+
+// TestCommitTreeSHA_CachesImmutableMapping pins the cache. A commit's tree can
+// never change, so a second resolution must cost no request — without this the
+// guard would re-fetch every open PR's tree on every PR creation.
+func TestCommitTreeSHA_CachesImmutableMapping(t *testing.T) {
+	d := &dupTreeServer{trees: map[string]string{"cafe1111": "eb0b85ab"}}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	for i := range 3 {
+		tree, err := c.commitTreeSHA(context.Background(), "o", "r", "cafe1111")
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if tree != "eb0b85ab" {
+			t.Fatalf("call %d: tree = %q, want eb0b85ab", i, tree)
+		}
+	}
+	if _, commitCalls := d.counts(); commitCalls != 1 {
+		t.Errorf("commit lookups = %d across 3 resolutions, want 1", commitCalls)
+	}
+}
+
+// TestFindOpenPRWithIdenticalTree_CapsCandidates pins the bound. The duplicate
+// sits past the cap on purpose: the guard is allowed to miss it, but it must
+// stop looking rather than fan out over an unbounded number of open PRs.
+func TestFindOpenPRWithIdenticalTree_CapsCandidates(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"dup": "cafe1111"},
+		trees:    map[string]string{"cafe1111": "eb0b85ab"},
+	}
+	var prs []dupTreePR
+	for i := range maxDuplicateTreeCandidates + 10 {
+		sha := fmt.Sprintf("sha%04d", i)
+		d.trees[sha] = fmt.Sprintf("tree%04d", i) // distinct: nothing matches
+		prs = append(prs, dupTreePR{Number: i + 1, HeadRef: fmt.Sprintf("b%d", i), HeadSHA: sha})
+	}
+	d.openPRs = map[string][]dupTreePR{"main": prs}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	found, err := c.findOpenPRWithIdenticalTree(context.Background(), "o", "r", "dup", "main")
+	if err != nil {
+		t.Fatalf("findOpenPRWithIdenticalTree: %v", err)
+	}
+	if found != nil {
+		t.Fatalf("found PR #%d, want none — no candidate shares the tree", found.GetNumber())
+	}
+	// One lookup for our head plus at most the cap for candidates.
+	if _, commitCalls := d.counts(); commitCalls > maxDuplicateTreeCandidates+1 {
+		t.Errorf("commit lookups = %d, want at most %d — the candidate cap is not holding",
+			commitCalls, maxDuplicateTreeCandidates+1)
+	}
+}
+
+// TestCreatePR_DuplicateTreeHandlesSlashedBranchNames guards a footgun rather
+// than a hypothetical: nearly every hive branch name contains a slash
+// ("fix/5111-..."), and the guard resolves it through a ref lookup whose URL
+// has to survive the embedded path separator.
+func TestCreatePR_DuplicateTreeHandlesSlashedBranchNames(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"fix/5111-duplicate-payloads": "cafe1111"},
+		trees:    map[string]string{"cafe1111": "eb0b85ab", "beef2222": "eb0b85ab"},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 212, HeadRef: "fix/5111-earlier", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := NewClientForTest(srv.URL, "o", nil, prTestLogger())
+
+	res, err := c.CreatePR(context.Background(), "o/r", "fix/5111-duplicate-payloads", "main", "dup", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if created, _ := d.counts(); created != 0 || !res.DuplicateTree {
+		t.Fatalf("created=%d duplicate=%v, want 0/true — a slashed branch name must resolve", created, res.DuplicateTree)
+	}
+}
+
+// TestPRRequestWatcher_DuplicateTreeDoesNotLabelTheOtherPR pins a side effect
+// the guard must NOT have. On the duplicate path the watcher is pointing at a
+// PR this request did not open — possibly a human's. Applying the hold label
+// there would block a merge that has nothing to do with this agent.
+func TestPRRequestWatcher_DuplicateTreeDoesNotLabelTheOtherPR(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"copy-forward": "cafe1111"},
+		trees:    map[string]string{"cafe1111": "eb0b85ab", "beef2222": "eb0b85ab"},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 212, HeadRef: "someone-elses-branch", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := testClient(t, srv.URL)
+	c.prHoldLabel = func(agent string) bool { return true }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	// Body cites an issue ON PURPOSE: without a citation #5117's gate returns
+	// before touching GitHub, and the "no issue lookups" assertion below would
+	// hold no matter what the precedence did.
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "copy-forward", Base: "main", Title: "copy forward",
+		Body: "Closes #581", Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	// Prove the request actually reached the duplicate verdict FIRST. Without
+	// this, a request that failed earlier — a mock endpoint the production path
+	// grew and this fake never learned — would also apply no labels, and the
+	// assertion below would pass for entirely the wrong reason. It did exactly
+	// that when #5198's content-metadata gate landed.
+	resp := readPRResult(t, reqPath)
+	if !resp.OK || !resp.DuplicateTree || resp.Number != 212 {
+		t.Fatalf("result = %+v, want the duplicate verdict against PR 212", resp)
+	}
+
+	if labeled := d.labelCalls(); labeled != 0 {
+		t.Fatalf("applied labels %d times to PR #212, want 0 — that PR is not this request's to gate", labeled)
+	}
+}
+
+// TestPRRequestWatcher_DuplicateTreeIsNotSelfAuthorizationJudged pins the
+// #5111 x #5117 precedence.
+//
+// The two guards answer different questions. #5117 asks "may this agent's
+// change proceed to merge?", a property of the PR THIS REQUEST CREATED. A
+// duplicate request created nothing — it is pointing at a PR that already
+// existed, possibly a human's — so there is nothing of its own to judge, and a
+// hold computed here could only land on somebody else's PR.
+//
+// Deliberately at a NON-hold-gated level: at a hold-gated one #5117 is already
+// short-circuited by the level, so the test would pass without the precedence
+// existing at all.
+func TestPRRequestWatcher_DuplicateTreeIsNotSelfAuthorizationJudged(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"copy-forward": "cafe1111"},
+		trees:    map[string]string{"cafe1111": "eb0b85ab", "beef2222": "eb0b85ab"},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 212, HeadRef: "someone-elses-branch", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := testClient(t, srv.URL)
+	c.SetAppBotLogin("kubestellar-hive[bot]")
+	c.prHoldLabel = func(agent string) bool { return false }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	// #581 is served as hive-filed and unacknowledged — exactly the shape that
+	// makes #5117 return Held. If the duplicate path consulted it, this test
+	// fails.
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "copy-forward", Base: "main", Title: "copy forward",
+		Body: "Closes #581", Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	resp := readPRResult(t, reqPath)
+	if !resp.OK || !resp.DuplicateTree || resp.Number != 212 {
+		t.Fatalf("result = %+v, want the duplicate verdict against PR 212", resp)
+	}
+	if resp.SelfAuthorized {
+		t.Error("a duplicate request opened no PR of its own; there is nothing of its to have authorised")
+	}
+	if labeled := d.labelCalls(); labeled != 0 {
+		t.Errorf("applied labels %d times, want 0 — PR 212 is not this request's to gate", labeled)
+	}
+}
+
+// TestPRRequestWatcher_ReportsDuplicateTreeAndConsumesRequest is the end-to-end
+// shape an agent actually sees: the request is consumed (not retried forever),
+// and the result file says the content is already proposed as #212 rather than
+// implying a new PR was opened.
+func TestPRRequestWatcher_ReportsDuplicateTreeAndConsumesRequest(t *testing.T) {
+	d := &dupTreeServer{
+		branches: map[string]string{"copy-forward": "cafe1111"},
+		trees:    map[string]string{"cafe1111": "eb0b85ab", "beef2222": "eb0b85ab"},
+		openPRs: map[string][]dupTreePR{
+			"main": {{Number: 212, HeadRef: "original", HeadSHA: "beef2222"}},
+		},
+	}
+	srv := d.start(t)
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "copy-forward", Base: "main", Title: "copy forward", Agent: "scanner",
+	})
+	if err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created, _ := d.counts(); created != 0 {
+		t.Fatalf("opened %d PRs, want 0", created)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Error("request file survived; a duplicate is a settled outcome, not something to retry")
+	}
+	resultPath := strings.TrimSuffix(reqPath, ".json") + ".result.json"
+	raw, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", filepath.Base(resultPath), err)
+	}
+	var resp PRResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decoding result: %v", err)
+	}
+	if !resp.OK || resp.Number != 212 || !resp.AlreadyExisted || !resp.DuplicateTree {
+		t.Fatalf("result = %+v, want ok/212/already_existed/duplicate_tree", resp)
+	}
+}

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -60,11 +60,22 @@ type PRResponse struct {
 	Number         int    `json:"number,omitempty"`
 	URL            string `json:"url,omitempty"`
 	AlreadyExisted bool   `json:"already_existed,omitempty"`
+	// DuplicateTree says the returned PR was reused because it already carries
+	// this request's exact content, not because it shares the head branch
+	// (#5111). It is the difference between "your retry landed on the PR you
+	// already opened" and "this change is already proposed as #N" — the second
+	// is the one an agent must act on, by commenting on that PR rather than
+	// filing again, so it is reported rather than folded into AlreadyExisted.
+	DuplicateTree bool `json:"duplicate_tree,omitempty"`
 	// SelfAuthorized reports that the PR was held because its only tracked
 	// rationale is an issue the hive filed and no human has acknowledged
 	// (#5117). The PR was still opened; it just cannot merge until someone
 	// signs off on the direction. Reported to the agent so it can go get that
 	// sign-off rather than reading the hold as an unexplained failure.
+	//
+	// Never set together with DuplicateTree: see the precedence note in
+	// handleOnePRRequest. A duplicate request opened no PR, so there is nothing
+	// of this request's to have authorised.
 	SelfAuthorized bool   `json:"self_authorized,omitempty"`
 	Error          string `json:"error,omitempty"`
 	At             string `json:"at"`
@@ -295,6 +306,7 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	resp.Number = res.Number
 	resp.URL = res.URL
 	resp.AlreadyExisted = res.AlreadyExisted
+	resp.DuplicateTree = res.DuplicateTree
 
 	// F6: apply the ACMM "hold" label server-side, from authoritative config, on
 	// the path that actually runs. At hold-gated levels (L3/L4/L5) every
@@ -309,13 +321,27 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	// It is evaluated only when the level is NOT already holding — at a
 	// hold-gated level every PR already waits for the human checkpoint this gate
 	// exists to create, so asking GitHub about the issue would buy nothing.
+	//
+	// PRECEDENCE, #5111 over #5117 (and over the level gate). The other two ask
+	// "may this agent's change proceed to merge?", which is a property of the PR
+	// THIS REQUEST CREATED. DuplicateTree says this request created nothing: res
+	// names a PR that already existed, and it may belong to another agent or to
+	// a human. Labelling or commenting there acts on somebody else's PR, and a
+	// "hold" stamped on it blocks a merge that has nothing to do with this
+	// request. So the duplicate path takes neither hold reason.
+	//
+	// No governance is skipped by that ordering. The PR being pointed at went
+	// through the self-authorisation gate when IT was opened through this same
+	// path; and where it is a human's PR, hive has no standing to gate it at
+	// all. Evaluating the gate here would additionally spend GitHub calls to
+	// compute a hold that must not be applied.
 	holdByLevel := c.prHoldLabel != nil && c.prHoldLabel(req.Agent)
 	var selfAuth SelfAuthorization
-	if !holdByLevel {
+	if !res.DuplicateTree && !holdByLevel {
 		selfAuth = c.EvaluateSelfAuthorization(ctx, req.Repo, title, body, req.IssueN)
 		resp.SelfAuthorized = selfAuth.Held
 	}
-	if holdByLevel || selfAuth.Held {
+	if !res.DuplicateTree && (holdByLevel || selfAuth.Held) {
 		if lerr := c.AddLabels(ctx, req.Repo, res.Number, []string{"hold"}); lerr != nil {
 			// A missing hold label is a policy failure, not a cosmetic one. Keep
 			// the request queued: the next bounded retry deduplicates the existing
@@ -364,15 +390,26 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		"author", res.Author,
 		"url", res.URL,
 		"reused", strconv.FormatBool(res.AlreadyExisted),
-		"self_authorized", strconv.FormatBool(selfAuth.Held))
+		"self_authorized", strconv.FormatBool(selfAuth.Held),
+		"duplicate_tree", strconv.FormatBool(res.DuplicateTree))
 	c.writePRResult(path, resp)
 	// Success (or reuse of an existing PR) — consume the request so it isn't
 	// reprocessed.
 	_ = os.Remove(path)
 	c.prRetries.clear(path)
+	if res.DuplicateTree {
+		// Logged on its own line, not folded into the line below: this is the
+		// outcome the issue asked to be able to count ("a queue that looks like
+		// five problems when it is one"), and it should be findable without
+		// parsing a boolean out of a success message.
+		c.logger.Info("pr-request watcher: request carried content an open PR already proposes; reused it instead of opening a duplicate",
+			slog.String("repo", req.Repo), slog.String("head", req.Head),
+			slog.Int("number", res.Number), slog.String("agent", req.Agent))
+	}
 	c.logger.Info("pr-request watcher: PR opened by App bot",
 		slog.String("repo", req.Repo), slog.String("head", req.Head),
 		slog.Int("number", res.Number), slog.Bool("reused", res.AlreadyExisted),
+		slog.Bool("duplicate_tree", res.DuplicateTree),
 		slog.String("agent", req.Agent))
 }
 

--- a/src/pkg/github/pullrequest.go
+++ b/src/pkg/github/pullrequest.go
@@ -19,9 +19,18 @@ type CreatePRResult struct {
 	// the App bot the hive relayed as (e.g. "kubestellar-hive[bot]"). Taken from
 	// the API response, not assumed, so the audit log records the true author.
 	Author string
-	// AlreadyExisted is true when an open PR for this head branch was already
-	// present, so we returned it instead of opening a duplicate.
+	// AlreadyExisted is true when an open PR already covers this request, so we
+	// returned it instead of opening a duplicate. Two different findings set it:
+	// an open PR for the same HEAD BRANCH, and (see DuplicateTree) an open PR
+	// carrying the same CONTENT from a different branch.
 	AlreadyExisted bool
+	// DuplicateTree narrows AlreadyExisted to the content case (#5111): the
+	// reuse was decided because an open PR on the same base has an identical
+	// tree SHA, not because the head branch matched. Callers that report the
+	// outcome keep the two apart because they mean different things to whoever
+	// reads the result — "your retry was absorbed" versus "this change is
+	// already proposed as #N, go comment on it".
+	DuplicateTree bool
 }
 
 // CreatePR opens a pull request on behalf of THIS hive's GitHub App — so the PR
@@ -48,6 +57,11 @@ type CreatePRResult struct {
 // It is idempotent: if an OPEN PR for head already exists, it returns that PR
 // with AlreadyExisted=true instead of erroring or opening a duplicate — this
 // makes the file-watcher safe to retry a request that partially succeeded.
+//
+// It also refuses to file the same CONTENT twice (kubestellar/hive#5111): if an
+// open PR on the same base already carries an identical tree SHA, that PR is
+// returned with AlreadyExisted and DuplicateTree set. Same-branch idempotency
+// cannot see this case, because the duplicate arrives on a fresh branch.
 func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body string) (CreatePRResult, error) {
 	if c == nil || c.client == nil {
 		return CreatePRResult{}, ErrNoGitHubClient
@@ -89,6 +103,31 @@ func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body str
 		c.logger.Info("CreatePR: open PR already exists for head, reusing",
 			slog.String("repo", repo), slog.String("head", head), slog.Int("number", existing.GetNumber()))
 		return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), Author: existing.GetUser().GetLogin(), AlreadyExisted: true}, nil
+	}
+
+	// Content identity (#5111): the check above only recognises a duplicate that
+	// reuses the SAME branch. Agents also copy a change forward onto a NEW branch
+	// and file it again — five such PRs on tuna-os/tromso, two with identical
+	// trees, so `git diff` between their tips was empty. Compare the tree SHA
+	// against the open PRs on this same base and reuse the match instead.
+	//
+	// A failed lookup proceeds to create. Refusing to publish work because an
+	// auxiliary read failed would be a worse bug than the duplicate: the guard
+	// is here to stop redundant PRs, not to become a new way to lose one.
+	if existing, err := c.findOpenPRWithIdenticalTree(ctx, owner, repo, head, base); err != nil {
+		c.logger.Warn("CreatePR: duplicate-tree lookup failed, proceeding to create",
+			slog.String("repo", repo), slog.String("head", head), slog.String("error", err.Error()))
+	} else if existing != nil {
+		c.logger.Info("CreatePR: an open PR already carries this exact tree, reusing it instead of opening a duplicate",
+			slog.String("repo", repo), slog.String("head", head),
+			slog.String("base", base), slog.Int("number", existing.GetNumber()))
+		return CreatePRResult{
+			Number:         existing.GetNumber(),
+			URL:            existing.GetHTMLURL(),
+			Author:         existing.GetUser().GetLogin(),
+			AlreadyExisted: true,
+			DuplicateTree:  true,
+		}, nil
 	}
 
 	pr, _, err := c.client.PullRequests.Create(ctx, owner, repo, &gh.NewPullRequest{


### PR DESCRIPTION
## Summary

`CreatePR` has always been idempotent for the same **head branch**: re-requesting a PR for a branch that already has one returns the existing PR. That covers a *retried request*. It cannot see the incident in #5111, where an agent copies a change forward onto a **new** branch and files it again — tuna-os/tromso collected five such PRs (#170, #212, #225, #241, #244) sharing the same blobs, two of them (#241, #212) with an identical tree, so `git diff` between their tips was empty.

The issue's Expected Behavior is exactly one sentence, and this implements it:

> Before opening a PR, diff the intended tree against open PRs on the same repo. An empty diff against an existing PR is a no-op, not a new contribution.

## The discriminator

The commit's **tree SHA**. Two commits with the same tree have byte-identical content, so two open PRs *on the same base* whose head commits share a tree propose exactly the same change — whatever their branch names, commit messages, or authorship.

That is an **equality test, not a similarity heuristic**, which is what makes it safe to act on automatically: it cannot fire on two changes that merely look alike.

`CreatePR` consults it after the existing head-branch check and returns the matching PR with `AlreadyExisted` and a new `DuplicateTree` flag set. The request is then consumed rather than retried, and the agent's `.result.json` points at the PR that already proposes its change. This sits at the choke point every agent PR flows through, so it covers the request watcher and the sandbox executor alike (the proxy hard-denies direct `POST /pulls`).

## Three deliberate properties, each pinned by a test

| Property | Why |
|---|---|
| **Same base only** | An identical tree on a *different* base is a different diff. The open-PR query is scoped by base rather than scanning everything open. |
| **Fails OPEN** | Every read the guard makes is auxiliary — ref lookup, PR list, commit lookup — and a failure proceeds to create. A guard that withheld a PR because a lookup failed would be a worse bug than the duplicate it prevents. |
| **Bounded cost** | Candidates are capped, reaching the cap is *logged* rather than passed over in silence, and commit→tree is memoized. That mapping is immutable, so the cache has no staleness window; without it the guard would re-fetch every open PR's tree on every creation — the secondary-rate-limit exposure the watcher already had to adopt backoff for. |

## One side effect suppressed on purpose

The watcher no longer applies the ACMM `hold` label on the duplicate path. There it is pointing at a PR **this request did not open**, and which may not even be the hive's — an agent can duplicate a human's content, and stamping `hold` on a stranger's PR would block their merge. When the duplicate is the agent's own earlier PR, that PR already got its label when it was opened through this same path.

## Verification

Tests are **mutation-checked six ways**; each mutant fails a test that names the property it broke:

| Mutant | Test that catches it |
|---|---|
| guard removed entirely | `ReusesOpenPRWithIdenticalTree`, `MatchesIdenticalHeadSHA`, `HandlesSlashedBranchNames`, both watcher tests |
| base scoping dropped | `DuplicateTreeOnlyComparesTheSameBase` |
| candidate cap removed | `FindOpenPRWithIdenticalTree_CapsCandidates` |
| fail-**closed** instead of fail-open | `DuplicateTreeFailsOpen` (all 4 subcases) |
| tree cache disabled | `CommitTreeSHA_CachesImmutableMapping` |
| hold label re-enabled on duplicate path | `DuplicateTreeDoesNotLabelTheOtherPR` |

`TestCreatePR_OpensWhenTreesDiffer` is the control — without it the suite would also pass if the guard simply refused everything. `HandlesSlashedBranchNames` guards a real footgun rather than a hypothetical: nearly every hive branch name contains a slash, and the guard resolves it through a ref lookup whose URL has to survive the separator.

- `go build ./...` — clean
- `go vet ./pkg/github/...` — clean
- `go test ./pkg/github/` — passes (full package, not just the new tests)

## Scope note

This addresses the **byte-identical** class the issue's Expected Behavior names. The **near-duplicate** class also listed there (tuna-os/docs #315↔#340 and friends: same topic, different bytes) is deliberately left alone. It has no exact test, so the analysis on the issue correctly puts it in policy text — but the policy packs currently instruct the *opposite* ("never run `gh pr list` unprompted"), and the packs are duplicated across ~40 hand-maintained files in `policies/` and `pkg/policies/defaults/`. Reconciling those is a maintainer decision, not a drive-by edit.

Fixes #5111.

— hive: backend=claude model=claude-opus-5
