### PR TITLE
🐛 fix(test): remove duplicate TestConfiguredDossierCacheMaxEntries

### DIFF
--- a/src/pkg/dashboard/role_convergence_replan_coverage_test.go
+++ b/src/pkg/dashboard/role_convergence_replan_coverage_test.go
@@ -77,31 +77,6 @@ func TestRequestRoleAllowsOwner_EmptyRoleDeniedWithDirectRouteAuthz(t *testing.T
 
 // ── configuredDossierCacheMaxEntries (dossier.go) ───────────────────────────
 
-func TestConfiguredDossierCacheMaxEntries(t *testing.T) {
-	cases := []struct {
-		name string
-		env  string
-		want int
-	}{
-		{"unset", "", dossierCacheMaxEntriesDefault},
-		{"valid", "64", 64},
-		{"whitespace-padded valid", "  128  ", 128},
-		{"non-numeric", "lots", dossierCacheMaxEntriesDefault},
-		{"zero", "0", dossierCacheMaxEntriesDefault},
-		{"negative", "-3", dossierCacheMaxEntriesDefault},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(dossierCacheMaxEntriesEnv, tc.env)
-			if got := configuredDossierCacheMaxEntries(); got != tc.want {
-				t.Fatalf("env %q: got %d, want %d", tc.env, got, tc.want)
-			}
-		})
-	}
-}
-
-// ── handleConvergenceConfigGet (api_config_convergence.go) ──────────────────
-
 func convergenceGetReq(owner bool) *http.Request {
 	r := httptest.NewRequest(http.MethodGet, "/api/config/convergence", nil)
 	if owner {


### PR DESCRIPTION
## v4 does not compile

`pkg/dashboard` fails to build on `v4`:

```
pkg/dashboard/viewer_identity_coverage_test.go:287:6: TestConfiguredDossierCacheMaxEntries redeclared in this block
	pkg/dashboard/role_convergence_replan_coverage_test.go:80:6: other declaration
```

**Every open PR touching `pkg/dashboard` is red for this**, not for anything in its own diff — #5276 and #5248 among them.

## How it happened

Two `[quality]` coverage PRs added the same test independently:

- `0b1b9cc6` — cover `pkg/dashboard` viewer-identity resolver
- `295849fe` — cover `pkg/dashboard` `requestRoleAllowsOwner`

Each was green on its own base. The collision only exists once **both** are on `v4`, so neither PR's CI could have caught it — a merge-order hazard rather than a mistake in either change.

## Fix

Removes the later copy. Both were table-driven over the same function with six equivalent cases, so no coverage is lost.

Verified: package builds, and the surviving test passes.