### PR TITLE
🐛 fix(github): an agent-filed issue no longer authorizes an agent-filed PR (#5117)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1705,6 +1705,12 @@ func main() {
 		holdLabel := func(agentName string) bool {
 			return shouldHoldAgentPR(agentName, agentMgr.GetACMMLevel())
 		}
+		// #5117: tell the client which accounts are ours, so the
+		// self-authorization gate recognises an issue filed under
+		// project.ai_author's plain user account as hive-filed rather than
+		// mistaking it for a human's. The App bot is recognised without this;
+		// hiveIdentity() is the same resolver the duplicate-PR guard uses.
+		ghClient.SetHiveIdentity(hiveIdentity(cfg))
 		ghClient.StartPRRequestWatcher(ctx, agentMgr.AuthorizePROpen, holdLabel, nil)
 		// Issue relay: agents request issue creation and comments by dropping a
 		// file (hive-open-issue via the gh wrapper) instead of calling GitHub

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -166,6 +166,14 @@ type Client struct {
 	// issues:write) still surface within ~an hour instead of never. Guarded by
 	// advisoryMu.
 	advisoryDigestSkips map[string]int
+	// hiveIdentity records which accounts count as "this hive" for the
+	// self-authorization gate (pr_self_authorization.go, #5117). It is optional
+	// — the gate recognises the App bot without it — and exists so an issue
+	// filed under project.ai_author's plain user account is also recognised as
+	// ours rather than mistaken for a human's. Guarded because config reload
+	// re-installs it while the PR-request watcher goroutine may be reading it.
+	hiveIdentityMu sync.RWMutex
+	hiveIdentity   HiveIdentity
 }
 
 func (c *Client) SetCanaryScanner(enabled, failClosed bool, reg *ioscan.CanaryRegistry, onLeak func(ioscan.CanaryLeak)) {

--- a/src/pkg/github/pr_request_watcher.go
+++ b/src/pkg/github/pr_request_watcher.go
@@ -60,6 +60,12 @@ type PRResponse struct {
 	Number         int    `json:"number,omitempty"`
 	URL            string `json:"url,omitempty"`
 	AlreadyExisted bool   `json:"already_existed,omitempty"`
+	// SelfAuthorized reports that the PR was held because its only tracked
+	// rationale is an issue the hive filed and no human has acknowledged
+	// (#5117). The PR was still opened; it just cannot merge until someone
+	// signs off on the direction. Reported to the agent so it can go get that
+	// sign-off rather than reading the hold as an unexplained failure.
+	SelfAuthorized bool   `json:"self_authorized,omitempty"`
 	Error          string `json:"error,omitempty"`
 	At             string `json:"at"`
 }
@@ -297,7 +303,19 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 	// unreachable (it followed `exec hive-open-pr`), so those PRs were opened
 	// unlabeled and the gate was inert. AddLabels is additive + idempotent, so it
 	// is safe to (re)apply even when we reused an already-open PR.
-	if c.prHoldLabel != nil && c.prHoldLabel(req.Agent) {
+	//
+	// #5117 adds a second, level-independent reason to hold: the PR's only
+	// tracked rationale is an issue the hive filed that nobody has acknowledged.
+	// It is evaluated only when the level is NOT already holding — at a
+	// hold-gated level every PR already waits for the human checkpoint this gate
+	// exists to create, so asking GitHub about the issue would buy nothing.
+	holdByLevel := c.prHoldLabel != nil && c.prHoldLabel(req.Agent)
+	var selfAuth SelfAuthorization
+	if !holdByLevel {
+		selfAuth = c.EvaluateSelfAuthorization(ctx, req.Repo, title, body, req.IssueN)
+		resp.SelfAuthorized = selfAuth.Held
+	}
+	if holdByLevel || selfAuth.Held {
 		if lerr := c.AddLabels(ctx, req.Repo, res.Number, []string{"hold"}); lerr != nil {
 			// A missing hold label is a policy failure, not a cosmetic one. Keep
 			// the request queued: the next bounded retry deduplicates the existing
@@ -306,9 +324,26 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 				slog.String("repo", req.Repo), slog.Int("number", res.Number), slog.String("error", lerr.Error()))
 			c.failPRRequest(path, req, fmt.Errorf("PR #%d opened but required hold label could not be applied: %w", res.Number, lerr), nowFn)
 			return
+		} else if selfAuth.Held {
+			c.logger.Info("pr-request watcher: held PR — its only tracked rationale is an issue the hive filed and nobody acknowledged",
+				slog.String("repo", req.Repo), slog.Int("number", res.Number),
+				slog.String("rationale_repo", selfAuth.Repo), slog.Int("rationale_issue", selfAuth.Issue),
+				slog.String("reason", selfAuth.Reason), slog.String("agent", req.Agent))
 		} else {
 			c.logger.Info("pr-request watcher: applied hold label (hold-gated ACMM level)",
 				slog.String("repo", req.Repo), slog.Int("number", res.Number))
+		}
+	}
+
+	// Explain the hold on the PR itself, once, when we opened it. A "hold" with
+	// no stated cause reads as a malfunction, and the person who has to clear it
+	// needs to know what clears it. Best-effort: the label is the enforcement,
+	// the comment is the courtesy, and a failed courtesy must not fail the
+	// request and send it round the retry loop.
+	if selfAuth.Held && !res.AlreadyExisted {
+		if cerr := c.CreateIssueComment(ctx, req.Repo, res.Number, selfAuthorizationNotice(selfAuth)); cerr != nil {
+			c.logger.Warn("pr-request watcher: held PR but could not post the explanation",
+				slog.String("repo", req.Repo), slog.Int("number", res.Number), slog.String("error", cerr.Error()))
 		}
 	}
 
@@ -328,7 +363,8 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		"number", strconv.Itoa(res.Number),
 		"author", res.Author,
 		"url", res.URL,
-		"reused", strconv.FormatBool(res.AlreadyExisted))
+		"reused", strconv.FormatBool(res.AlreadyExisted),
+		"self_authorized", strconv.FormatBool(selfAuth.Held))
 	c.writePRResult(path, resp)
 	// Success (or reuse of an existing PR) — consume the request so it isn't
 	// reprocessed.

--- a/src/pkg/github/pr_self_authorization.go
+++ b/src/pkg/github/pr_self_authorization.go
@@ -1,0 +1,281 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// Self-authorization gate (kubestellar/hive#5117).
+//
+// Every fix-capable policy teaches the same loop: find a problem, file an
+// issue, open a PR citing it. Nothing in that loop distinguishes "an issue a
+// human filed" from "an issue I filed sixty seconds ago", so the
+// tracked-rationale precondition is satisfiable by the agent alone. In
+// tuna-os/tunaos-packages, issue #581 proposed a decomposition and PR #583
+// implemented phase 1 of it, introducing a module-sourcing pattern with no
+// precedent in the repository. Both were hive-filed; no human agreed to the
+// direction in between. The code was fine — that is what makes it a governance
+// bug rather than a code bug.
+//
+// This gate does not block the work. It applies the "hold" label the merge gate
+// already keys on, so the PR is filed and visible but cannot merge until a
+// person looks at it. Blocking creation instead would throw away a finished,
+// often-correct change to make a point about process.
+//
+// WHAT COUNTS AS EVIDENCE
+//
+// The gate fires on POSITIVE evidence only: it must actually read an issue,
+// find a non-human author, and find no human acknowledgement. An issue it
+// cannot read at all decides nothing — a network error must not manufacture a
+// hold on an unrelated PR, because a label people learn to strip on sight stops
+// gating anything. The one asymmetry is deliberate: once the author is known to
+// be non-human, a FAILED acknowledgement lookup holds, because at that point
+// self-authorship is established and only the excuse is missing.
+
+// HumanAckLabel is the label a human applies to an agent-filed issue to say
+// "yes, take this direction". It is one of several acknowledgements the gate
+// accepts (see issueHasHumanAcknowledgement) and exists for the case where a
+// maintainer wants to approve without writing a comment.
+const HumanAckLabel = "approved-direction"
+
+// selfAuthCommentPageSize bounds the acknowledgement scan. The first page is
+// enough: the gate needs to know whether ANY human has engaged, and a human who
+// engaged only after 100 bot comments is not the acknowledgement this is
+// looking for.
+const selfAuthCommentPageSize = 100
+
+// SetHiveIdentity records which accounts count as "this hive", so the
+// self-authorization gate can recognise an issue the hive filed under a plain
+// user account (project.ai_author) as well as under the App bot. It is
+// optional: with no identity configured the gate still recognises bot-authored
+// issues by login suffix and account type, which is what the App-authored
+// incident case looks like.
+func (c *Client) SetHiveIdentity(id HiveIdentity) {
+	if c == nil {
+		return
+	}
+	c.hiveIdentityMu.Lock()
+	defer c.hiveIdentityMu.Unlock()
+	c.hiveIdentity = id
+}
+
+func (c *Client) getHiveIdentity() HiveIdentity {
+	c.hiveIdentityMu.RLock()
+	defer c.hiveIdentityMu.RUnlock()
+	return c.hiveIdentity
+}
+
+// isHumanAuthor reports whether a GitHub account is a person other than this
+// hive. It is the single definition the whole gate turns on, so the three ways
+// an account can fail to be one live here rather than being re-derived per call
+// site: it is empty, it is a bot, or it is one of our own accounts.
+//
+// The "[bot]" login suffix is checked as well as the account type because the
+// type is absent from some abbreviated API payloads, and a login ending in
+// "[bot]" is never a person — GitHub reserves the suffix.
+func (c *Client) isHumanAuthor(user *gh.User) bool {
+	login := strings.TrimSpace(user.GetLogin())
+	if login == "" {
+		return false
+	}
+	if strings.EqualFold(user.GetType(), "Bot") || strings.HasSuffix(login, "[bot]") {
+		return false
+	}
+	if c != nil && strings.EqualFold(login, c.appBotLogin) && c.appBotLogin != "" {
+		return false
+	}
+	if c != nil && c.getHiveIdentity().Matches(login) {
+		return false
+	}
+	return true
+}
+
+// isKnownNonHumanAuthor is isHumanAuthor's positive counterpart, and the two are
+// deliberately NOT complements: both are false when the account is unknown.
+//
+// An abbreviated or partial API payload can carry no login at all, and "we could
+// not tell" must not read as "a bot filed it" — that is how a gate starts firing
+// on issues real people opened. The tri-state is the whole point, so the gate
+// asks this question rather than negating the other one.
+func (c *Client) isKnownNonHumanAuthor(user *gh.User) bool {
+	if strings.TrimSpace(user.GetLogin()) == "" {
+		return false
+	}
+	return !c.isHumanAuthor(user)
+}
+
+// SelfAuthorization is the gate's finding for one PR request.
+type SelfAuthorization struct {
+	// Held is true when the PR must carry "hold" regardless of ACMM level.
+	Held bool
+	// Issue is the agent-filed issue that decided it, for the log and the
+	// explanatory comment. Zero when Held is false.
+	Issue int
+	// Repo is that issue's repository ("owner/repo").
+	Repo string
+	// Reason is a short human-readable explanation, used verbatim in the audit
+	// entry and the log.
+	Reason string
+}
+
+// rationaleIssues collects the issues a PR request offers as its rationale:
+// everything the title and body claim to close or reference, plus the request's
+// own IssueN list. Both parsers are reused as-is rather than re-implemented, so
+// the gate reads exactly the references the claim ledger already understands.
+func rationaleIssues(repo, title, body string, declared []int) []ClaimedRef {
+	text := title + "\n" + body
+	refs := ParseClaimedIssues(text, repo)
+	seen := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		seen[fmt.Sprintf("%s#%d", ref.Repo, ref.Issue)] = true
+	}
+	add := func(candidates []ClaimedRef) {
+		for _, ref := range candidates {
+			key := fmt.Sprintf("%s#%d", ref.Repo, ref.Issue)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			refs = append(refs, ref)
+		}
+	}
+	add(ParseReferencedIssues(text, repo))
+	for _, n := range declared {
+		if n > 0 {
+			add([]ClaimedRef{{Repo: repo, Issue: n}})
+		}
+	}
+	return refs
+}
+
+// EvaluateSelfAuthorization decides whether a PR request's rationale rests
+// entirely on issues the hive filed and no human has acknowledged.
+//
+// A PR that cites NOTHING is not this bug and is left alone: "no tracked
+// rationale at all" is a different problem with a different answer, and
+// widening the gate to cover it would hold most of the fleet's routine work.
+func (c *Client) EvaluateSelfAuthorization(ctx context.Context, repo, title, body string, declared []int) SelfAuthorization {
+	if c == nil || c.client == nil {
+		return SelfAuthorization{}
+	}
+	refs := rationaleIssues(repo, title, body, declared)
+	if len(refs) == 0 {
+		return SelfAuthorization{}
+	}
+
+	var firstSelfFiled *SelfAuthorization
+	for _, ref := range refs {
+		owner, name := splitRepoRef(ref.Repo, c.org)
+		if owner == "" || name == "" {
+			continue
+		}
+		issue, _, err := c.client.Issues.Get(ctx, owner, name, ref.Issue)
+		if err != nil {
+			// No evidence either way. Deliberately not a hold: see the file
+			// comment — a hold nobody can explain is a hold people learn to
+			// strip.
+			c.logger.Warn("self-authorization gate: could not read a cited issue, it decides nothing",
+				"repo", ref.Repo, "issue", ref.Issue, "error", err.Error())
+			continue
+		}
+		if c.isHumanAuthor(issue.GetUser()) {
+			// A person proposed this. That is the precondition working.
+			return SelfAuthorization{}
+		}
+		if !c.isKnownNonHumanAuthor(issue.GetUser()) {
+			// Neither provably a person nor provably one of ours. No evidence,
+			// so no hold — same rule as an issue we could not read at all.
+			c.logger.Warn("self-authorization gate: cited issue has no identifiable author, it decides nothing",
+				"repo", ref.Repo, "issue", ref.Issue)
+			continue
+		}
+		acknowledged, ackErr := c.issueHasHumanAcknowledgement(ctx, owner, name, issue)
+		if acknowledged {
+			return SelfAuthorization{}
+		}
+		if firstSelfFiled != nil {
+			continue
+		}
+		reason := fmt.Sprintf("issue %s#%d was filed by %s and no human has acknowledged it",
+			ref.Repo, ref.Issue, issue.GetUser().GetLogin())
+		if ackErr != nil {
+			// Authorship is established; only the acknowledgement lookup
+			// failed. Holding is the safe half of the asymmetry.
+			reason = fmt.Sprintf("issue %s#%d was filed by %s and its acknowledgements could not be read (%v)",
+				ref.Repo, ref.Issue, issue.GetUser().GetLogin(), ackErr)
+		}
+		firstSelfFiled = &SelfAuthorization{Held: true, Issue: ref.Issue, Repo: ref.Repo, Reason: reason}
+	}
+	if firstSelfFiled == nil {
+		return SelfAuthorization{}
+	}
+	return *firstSelfFiled
+}
+
+// issueHasHumanAcknowledgement reports whether any person has signalled assent
+// on an agent-filed issue. Four signals count, in ascending cost:
+//
+//  1. the approval label, for a maintainer who wants to approve without prose;
+//  2. a human assignee, which is how a maintainer says "yes, and I own it";
+//  3. a human comment;
+//  4. nothing — which is the incident.
+//
+// The error is returned rather than swallowed because the caller treats "no
+// acknowledgement found" and "could not look" differently.
+func (c *Client) issueHasHumanAcknowledgement(ctx context.Context, owner, repo string, issue *gh.Issue) (bool, error) {
+	for _, label := range issue.Labels {
+		if strings.EqualFold(label.GetName(), HumanAckLabel) {
+			return true, nil
+		}
+	}
+	for _, assignee := range issue.Assignees {
+		if c.isHumanAuthor(assignee) {
+			return true, nil
+		}
+	}
+	if issue.GetComments() == 0 {
+		// The issue payload already told us there are none; skip the call.
+		return false, nil
+	}
+	comments, _, err := c.client.Issues.ListComments(ctx, owner, repo, issue.GetNumber(), &gh.IssueListCommentsOptions{
+		ListOptions: gh.ListOptions{PerPage: selfAuthCommentPageSize},
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, comment := range comments {
+		if c.isHumanAuthor(comment.GetUser()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// splitRepoRef normalises "owner/repo" or a bare repo name into its two halves,
+// defaulting the owner to the hive's org the way CreatePR does.
+func splitRepoRef(repo, defaultOwner string) (string, string) {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return "", ""
+	}
+	if owner, name, ok := strings.Cut(repo, "/"); ok {
+		return strings.TrimSpace(owner), strings.TrimSpace(name)
+	}
+	return strings.TrimSpace(defaultOwner), repo
+}
+
+// selfAuthorizationNotice is the comment left on a held PR. A "hold" label with
+// no explanation reads as a malfunction, and the person who has to clear it
+// needs to know what would clear it.
+func selfAuthorizationNotice(finding SelfAuthorization) string {
+	return fmt.Sprintf(`> [!IMPORTANT]
+> **Held for human sign-off on the direction, not on the code.**
+>
+> This PR's only tracked rationale is %s#%d, which the hive filed itself — %s. An agent-filed issue does not, on its own, establish that anyone agreed to the direction (kubestellar/hive#5117).
+>
+> The change may well be right; nothing here is a review of it. To release the hold, acknowledge the direction on that issue — comment on it, assign yourself, or add the `+"`%s`"+` label — and remove the `+"`hold`"+` label here.`,
+		finding.Repo, finding.Issue, finding.Reason, HumanAckLabel)
+}

--- a/src/pkg/github/pr_self_authorization_test.go
+++ b/src/pkg/github/pr_self_authorization_test.go
@@ -1,0 +1,433 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// selfAuthIssue is one issue the fake forge serves.
+type selfAuthIssue struct {
+	Author     string
+	AuthorType string // "Bot" for App/bot accounts; "" means User
+	Labels     []string
+	Assignees  []string
+	Comments   []selfAuthComment
+	Status     int // non-zero to fail the GET
+	FailList   bool
+}
+
+type selfAuthComment struct {
+	Author     string
+	AuthorType string
+}
+
+// selfAuthServer fakes the endpoints the gate reads, plus enough of the PR path
+// that the watcher end-to-end tests can run through it.
+type selfAuthServer struct {
+	issues map[int]*selfAuthIssue
+
+	mu            sync.Mutex
+	labelsApplied []string
+	comments      []string
+	listCalls     int
+}
+
+func (s *selfAuthServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(p, "/repos/o/r"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"name":"r","default_branch":"main"}`)
+
+		case r.Method == "GET" && strings.Contains(p, "/issues/") && strings.HasSuffix(p, "/comments"):
+			s.mu.Lock()
+			s.listCalls++
+			s.mu.Unlock()
+			num := issueNumFromPath(p, "/comments")
+			issue := s.issues[num]
+			if issue == nil || issue.FailList {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			out := make([]map[string]any, 0, len(issue.Comments))
+			for _, c := range issue.Comments {
+				out = append(out, map[string]any{"user": userJSON(c.Author, c.AuthorType)})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(out)
+
+		case r.Method == "GET" && strings.Contains(p, "/issues/"):
+			num := issueNumFromPath(p, "")
+			issue := s.issues[num]
+			if issue == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if issue.Status != 0 {
+				w.WriteHeader(issue.Status)
+				return
+			}
+			labels := make([]map[string]any, 0, len(issue.Labels))
+			for _, l := range issue.Labels {
+				labels = append(labels, map[string]any{"name": l})
+			}
+			assignees := make([]map[string]any, 0, len(issue.Assignees))
+			for _, a := range issue.Assignees {
+				assignees = append(assignees, userJSON(a, ""))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":    num,
+				"user":      userJSON(issue.Author, issue.AuthorType),
+				"labels":    labels,
+				"assignees": assignees,
+				"comments":  len(issue.Comments),
+			})
+
+		case r.Method == "POST" && strings.HasSuffix(p, "/labels"):
+			body, _ := io.ReadAll(r.Body)
+			var labels []string
+			_ = json.Unmarshal(body, &labels)
+			s.mu.Lock()
+			s.labelsApplied = append(s.labelsApplied, labels...)
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+
+		case r.Method == "POST" && strings.HasSuffix(p, "/comments"):
+			body, _ := io.ReadAll(r.Body)
+			var c map[string]any
+			_ = json.Unmarshal(body, &c)
+			s.mu.Lock()
+			s.comments = append(s.comments, fmt.Sprint(c["body"]))
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":1}`)
+
+		// #5114's content-metadata gate compares the branch before creating.
+		// An empty file list is a branch with nothing objectionable in it.
+		case r.Method == "GET" && strings.Contains(p, "/compare/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"files":[]}`)
+
+		case r.Method == "GET" && strings.HasSuffix(p, "/pulls"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[]`)
+
+		case r.Method == "POST" && strings.HasSuffix(p, "/pulls"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":583,"html_url":"https://github.com/o/r/pull/583"}`)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func userJSON(login, kind string) map[string]any {
+	u := map[string]any{"login": login}
+	if kind != "" {
+		u["type"] = kind
+	}
+	return u
+}
+
+func issueNumFromPath(path, suffix string) int {
+	p := strings.TrimSuffix(path, suffix)
+	idx := strings.LastIndex(p, "/")
+	if idx < 0 {
+		return 0
+	}
+	var n int
+	_, _ = fmt.Sscanf(p[idx+1:], "%d", &n)
+	return n
+}
+
+func (s *selfAuthServer) applied() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.labelsApplied...)
+}
+
+func (s *selfAuthServer) postedComments() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.comments...)
+}
+
+// TestEvaluateSelfAuthorization is the decision table. The incident is the
+// "bot-filed, untouched" row; every other row exists so the gate cannot pass it
+// by holding everything.
+func TestEvaluateSelfAuthorization(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+
+	cases := []struct {
+		name      string
+		issue     *selfAuthIssue // nil means the issue does not exist
+		body      string
+		declared  []int
+		wantHeld  bool
+		wantWhyIn string
+	}{{
+		name:     "the incident: hive filed it, nobody touched it",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot"},
+		body:     "Implements phase 1 of #581.\n\nCloses #581",
+		wantHeld: true, wantWhyIn: "no human has acknowledged it",
+	}, {
+		name:     "a person filed the issue",
+		issue:    &selfAuthIssue{Author: "hanthor"},
+		body:     "Closes #581",
+		wantHeld: false,
+	}, {
+		name:     "hive filed it but a person commented",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot", Comments: []selfAuthComment{{Author: "hanthor"}}},
+		body:     "Closes #581",
+		wantHeld: false,
+	}, {
+		name: "hive filed it and only bots commented",
+		issue: &selfAuthIssue{Author: botLogin, AuthorType: "Bot", Comments: []selfAuthComment{
+			{Author: "kubestellar-hive[bot]", AuthorType: "Bot"}, {Author: "dependabot[bot]", AuthorType: "Bot"},
+		}},
+		body:     "Closes #581",
+		wantHeld: true,
+	}, {
+		name:     "hive filed it but a person approved the direction by label",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot", Labels: []string{"bug", HumanAckLabel}},
+		body:     "Closes #581",
+		wantHeld: false,
+	}, {
+		name:     "hive filed it but a person assigned themselves",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot", Assignees: []string{"clubanderson"}},
+		body:     "Closes #581",
+		wantHeld: false,
+	}, {
+		name:     "hive filed it and only a bot is assigned",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot", Assignees: []string{"kubestellar-hive[bot]"}},
+		body:     "Closes #581",
+		wantHeld: true,
+	}, {
+		name:     "a non-closing reference is rationale too",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot"},
+		body:     "Part of #581 — extracts the first module.",
+		wantHeld: true,
+	}, {
+		name:     "the request's declared issue list counts",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot"},
+		body:     "No references in the prose at all.",
+		declared: []int{581},
+		wantHeld: true,
+	}, {
+		name:     "no rationale cited at all is a different problem",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot"},
+		body:     "Just a change, no issue reference.",
+		wantHeld: false,
+	}, {
+		name:     "an unreadable issue decides nothing",
+		issue:    &selfAuthIssue{Author: botLogin, AuthorType: "Bot", Status: http.StatusInternalServerError},
+		body:     "Closes #581",
+		wantHeld: false,
+	}, {
+		name:     "an issue with no identifiable author decides nothing",
+		issue:    &selfAuthIssue{Author: ""},
+		body:     "Closes #581",
+		wantHeld: false,
+	}, {
+		name: "authorship known, acknowledgements unreadable: hold",
+		issue: &selfAuthIssue{Author: botLogin, AuthorType: "Bot", FailList: true,
+			Comments: []selfAuthComment{{Author: "hanthor"}}},
+		body:     "Closes #581",
+		wantHeld: true, wantWhyIn: "could not be read",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &selfAuthServer{issues: map[int]*selfAuthIssue{}}
+			if tc.issue != nil {
+				srv.issues[581] = tc.issue
+			}
+			c := NewClientForTest(srv.start(t).URL, "o", nil, prTestLogger())
+			c.SetAppBotLogin(botLogin)
+
+			got := c.EvaluateSelfAuthorization(context.Background(), "o/r", "some title", tc.body, tc.declared)
+			if got.Held != tc.wantHeld {
+				t.Fatalf("Held = %v, want %v (reason %q)", got.Held, tc.wantHeld, got.Reason)
+			}
+			if tc.wantHeld {
+				if got.Issue != 581 || got.Repo != "o/r" {
+					t.Errorf("finding named %s#%d, want o/r#581", got.Repo, got.Issue)
+				}
+				if tc.wantWhyIn != "" && !strings.Contains(got.Reason, tc.wantWhyIn) {
+					t.Errorf("Reason = %q, want it to contain %q", got.Reason, tc.wantWhyIn)
+				}
+			}
+		})
+	}
+}
+
+// TestEvaluateSelfAuthorization_OneHumanRationaleIsEnough pins the multi-issue
+// rule. A PR citing both a hive-filed issue and a human-filed one HAS a human
+// rationale; requiring every citation to be human-blessed would hold work that
+// a person did ask for.
+func TestEvaluateSelfAuthorization_OneHumanRationaleIsEnough(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{
+		581: {Author: botLogin, AuthorType: "Bot"},
+		590: {Author: "hanthor"},
+	}}
+	c := NewClientForTest(srv.start(t).URL, "o", nil, prTestLogger())
+	c.SetAppBotLogin(botLogin)
+
+	got := c.EvaluateSelfAuthorization(context.Background(), "o/r", "t", "Closes #581\nCloses #590", nil)
+	if got.Held {
+		t.Fatalf("Held = true (%s); a human-filed citation authorizes the PR", got.Reason)
+	}
+}
+
+// TestEvaluateSelfAuthorization_RecognisesTheAIAuthorAccount covers the hive
+// that files issues under a plain user account (project.ai_author) rather than
+// the App bot: that login has no "[bot]" suffix and no Bot type, so only the
+// configured identity can tell it apart from a maintainer.
+func TestEvaluateSelfAuthorization_RecognisesTheAIAuthorAccount(t *testing.T) {
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: "hive-worker"}}}
+	c := NewClientForTest(srv.start(t).URL, "o", nil, prTestLogger())
+
+	if got := c.EvaluateSelfAuthorization(context.Background(), "o/r", "t", "Closes #581", nil); got.Held {
+		t.Fatalf("Held before identity was configured; a plain login must read as human until told otherwise")
+	}
+
+	c.SetHiveIdentity(HiveIdentity{AIAuthor: "hive-worker"})
+	if got := c.EvaluateSelfAuthorization(context.Background(), "o/r", "t", "Closes #581", nil); !got.Held {
+		t.Fatal("Held = false after the identity named hive-worker as ours")
+	}
+}
+
+// TestPRRequestWatcher_HoldsSelfAuthorizedPR is the end-to-end shape: the PR is
+// still opened (the work is not thrown away), it carries "hold", and it carries
+// a comment saying what would clear it.
+func TestPRRequestWatcher_HoldsSelfAuthorizedPR(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: botLogin, AuthorType: "Bot"}}}
+	c := testClient(t, srv.start(t).URL)
+	c.SetAppBotLogin(botLogin)
+	// No hold-gated level: at L6 this gate is the only thing standing between a
+	// self-proposed direction and a merged one.
+	c.prHoldLabel = func(agent string) bool { return false }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	reqPath, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "decompose-phase-1", Base: "main",
+		Title: "phase 1 of the decomposition", Body: "Closes #581", Agent: "quality",
+	})
+	if err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if applied := srv.applied(); len(applied) != 1 || applied[0] != "hold" {
+		t.Fatalf("labels applied = %v, want [hold]", applied)
+	}
+	comments := srv.postedComments()
+	if len(comments) != 1 {
+		t.Fatalf("posted %d comments, want 1 explaining the hold", len(comments))
+	}
+	for _, want := range []string{"#581", HumanAckLabel, "5117"} {
+		if !strings.Contains(comments[0], want) {
+			t.Errorf("hold explanation does not mention %q:\n%s", want, comments[0])
+		}
+	}
+
+	resultPath := strings.TrimSuffix(reqPath, ".json") + ".result.json"
+	raw, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("reading result: %v", err)
+	}
+	var resp PRResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decoding result: %v", err)
+	}
+	if !resp.OK || resp.Number != 583 {
+		t.Fatalf("result = %+v, want the PR to have been opened", resp)
+	}
+	if !resp.SelfAuthorized {
+		t.Error("self_authorized = false in the result; the agent cannot tell why its PR is held")
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Error("request file survived; the PR was opened, so the request is settled")
+	}
+}
+
+// TestPRRequestWatcher_DoesNotHoldHumanBackedPR is the control. Without it the
+// test above would also pass if the watcher simply held everything.
+func TestPRRequestWatcher_DoesNotHoldHumanBackedPR(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: "hanthor"}}}
+	c := testClient(t, srv.start(t).URL)
+	c.SetAppBotLogin(botLogin)
+	c.prHoldLabel = func(agent string) bool { return false }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	if _, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "fix", Base: "main", Title: "fix", Body: "Closes #581", Agent: "quality",
+	}); err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if applied := srv.applied(); len(applied) != 0 {
+		t.Fatalf("labels applied = %v, want none — a human filed the issue", applied)
+	}
+	if comments := srv.postedComments(); len(comments) != 0 {
+		t.Fatalf("posted %d comments, want none", len(comments))
+	}
+}
+
+// TestPRRequestWatcher_HoldGatedLevelSkipsTheLookup pins the short-circuit. At a
+// hold-gated level the PR is held anyway, so spending API calls to discover a
+// second reason to hold it buys nothing.
+func TestPRRequestWatcher_HoldGatedLevelSkipsTheLookup(t *testing.T) {
+	const botLogin = "kubestellar-hive[bot]"
+	srv := &selfAuthServer{issues: map[int]*selfAuthIssue{581: {Author: botLogin, AuthorType: "Bot",
+		Comments: []selfAuthComment{{Author: "someone"}}}}}
+	c := testClient(t, srv.start(t).URL)
+	c.SetAppBotLogin(botLogin)
+	c.prHoldLabel = func(agent string) bool { return true }
+
+	dir := t.TempDir()
+	prRequestDirForTest = dir
+	t.Cleanup(func() { prRequestDirForTest = "" })
+
+	if _, err := WritePRRequest(dir, PRRequest{
+		Repo: "o/r", Head: "fix", Base: "main", Title: "fix", Body: "Closes #581", Agent: "quality",
+	}); err != nil {
+		t.Fatalf("WritePRRequest: %v", err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if applied := srv.applied(); len(applied) != 1 || applied[0] != "hold" {
+		t.Fatalf("labels applied = %v, want [hold] from the level alone", applied)
+	}
+	srv.mu.Lock()
+	listCalls := srv.listCalls
+	srv.mu.Unlock()
+	if listCalls != 0 {
+		t.Errorf("gate made %d comment lookups at a hold-gated level, want 0", listCalls)
+	}
+}


### PR DESCRIPTION
## Summary

Every fix-capable policy teaches the same loop: find a problem, file an issue, open a PR citing it. Nothing in that loop distinguishes *"an issue a human filed"* from *"an issue I filed sixty seconds ago"* — so the tracked-rationale precondition is **satisfiable by the agent alone**.

In tuna-os/tunaos-packages, issue #581 proposed a decomposition and PR #583 implemented phase 1 of it, introducing a module-sourcing pattern with no precedent in the repository. Both were hive-filed; no human agreed to the direction in between. The code was fine — that is exactly what makes it a governance bug rather than a code bug.

This implements the issue's Expected Behavior at the choke point every agent PR flows through:

> An agent-filed issue should not satisfy the "there is a tracked rationale" precondition for an agent-filed PR.

When a request's only tracked rationale is a hive-filed issue nobody has acknowledged, the PR gets the `hold` label the merge gate already keys on.

## It does not block the work

The change is usually finished and often correct. Discarding it to make a point about process would trade one governance failure for a worse one. The PR is filed and visible — it just cannot merge until a person looks at it.

A held PR also gets **one comment saying what would clear it**. A `hold` with no stated cause reads as a malfunction to whoever has to clear it. That comment is best-effort: the label is the enforcement, and a failed courtesy must not send the request round the retry loop.

## What counts as acknowledgement

Four signals, in ascending cost — **any one** releases the gate:

| Signal | Reads as |
|---|---|
| human author on the issue | a person proposed this; the precondition is working |
| `approved-direction` label | a maintainer approving without writing prose |
| human assignee | "yes, and I own it" |
| human comment | ordinary engagement |

Only bots on all four is the incident. Multiple citations are **OR-ed, not AND-ed**: a PR citing both a hive-filed issue and a human-filed one *has* a human rationale, and requiring every citation to be human-blessed would hold work someone did ask for.

## Evidence, not suspicion

The gate fires on **positive evidence only**. It must actually read an issue, find a non-human author, and find no acknowledgement. An issue it cannot read — and an issue whose author it cannot *identify* — decides nothing. A hold nobody can explain is a hold people learn to strip on sight, and a gate everyone strips gates nothing.

That is why `isHumanAuthor` and `isKnownNonHumanAuthor` are deliberately **not** complements: both are false for an unknown account. Writing it as a simple negation is precisely the bug the **existing** watcher suite caught during development — a partial API payload with no login read as "a bot filed it" and held an unrelated PR. The tri-state is load-bearing, and there is a test pinning it.

One asymmetry is intentional: once authorship is established as non-human, a **failed acknowledgement lookup holds**. At that point self-authorship is a fact and only the excuse is missing.

## Cost

Nothing is looked up unless the PR cites an issue, and nothing is looked up at a hold-gated level — there every PR already waits for the human checkpoint this gate exists to create. So it costs 1–2 API calls per PR open, at L6, on PRs that cite an issue. That is also where it matters: L6 is the incident's setting.

A PR citing **no** issue at all is left alone. "No tracked rationale" is a different problem with a different answer, and widening the gate to cover it would hold most of the fleet's routine work.

## Verification

Mutation-checked **eight ways**; each mutant fails a test that names the property it broke:

| Mutant | Test that catches it |
|---|---|
| gate never fires | 6 subtests + `RecognisesTheAIAuthorAccount` |
| human comments no longer acknowledge | `hive filed it but a person commented` |
| approval label ignored | `…approved the direction by label` |
| human assignee ignored | `…assigned themselves` |
| unknown author treated as a bot | `an issue with no identifiable author decides nothing` |
| unreadable issue holds | `an unreadable issue decides nothing` |
| hold-gated short-circuit removed | `HoldGatedLevelSkipsTheLookup` |
| explanation comment not posted | `HoldsSelfAuthorizedPR` |

`DoesNotHoldHumanBackedPR` is the control — without it the suite would also pass if the watcher simply held everything.

- `go build ./...` — clean
- `go vet ./pkg/github/... ./cmd/hive/...` — clean
- `go test ./pkg/github/` — passes (full package, not just the new tests)

## Scope note

The **policy-text** half of the analysis on the issue is deliberately not here: telling agents up front to seek acknowledgement, and the "pattern with no precedent in the repo" heuristic — which the analysis itself notes is not mechanically checkable. It spans **73 files** across `policies/` and `pkg/policies/defaults/`, which have already drifted apart from each other, and that churn would bury the mechanism it accompanies. The gate enforces the requirement whether or not an agent reads the policy, so the two are separable and the policy edit is a maintainer call about which of those two trees is authoritative.

Fixes #5117.

— hive: backend=claude model=claude-opus-5
