### PR TITLE
📖 docs(development): document NOTICE regeneration

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -88,6 +88,40 @@ cd src
 go vet ./...
 ```
 
+
+## If CI says "NOTICE is out of date"
+
+`NOTICE` lists every Go module compiled into the shipped binaries. It is
+**generated**, not hand-edited, so any change to `src/go.mod` or `src/go.sum`
+— including a Dependabot version bump — makes it stale and fails the
+`notice-drift` job ("NOTICE matches the module graph") in
+`.github/workflows/go-security-analysis.yml`.
+
+Regenerate and commit it:
+
+```bash
+bash src/scripts/generate-notice.sh   # writes NOTICE at the repo root
+```
+
+Three things that will otherwise cost you a CI round trip:
+
+- **Commit the output verbatim.** The check is byte-exact. Do not reformat it,
+  do not strip trailing whitespace — several dependency licences contain
+  trailing spaces on their own lines, and removing them produces a permanent
+  diff against what CI generates.
+- **The generator needs the module's Go toolchain.** `src/go.mod` pins a
+  specific version; running under an older `go` makes `go-licenses` fail to
+  resolve stdlib packages and abort before writing anything. Set
+  `GOTOOLCHAIN` to the pinned version if your default `go` is older.
+- **A red `notice-drift` is not always yours.** Because `NOTICE` lives on the
+  branch, a dependency bump merged without regenerating it leaves `v4` itself
+  stale — and then *every* open PR inherits the failure, including docs-only
+  ones. Check whether `v4` is clean before assuming your change caused it.
+
+A `FORBIDDEN` result is a different problem: the module graph contains a
+licence the project cannot ship (this is how an AGPL-3.0 dependency was caught
+in #5016). That needs the dependency removed or replaced, not a regeneration.
+
 There is no public `just lint` recipe in the current root `Justfile`; use `go vet ./...` for the repository's documented local lint-equivalent check, plus `gofmt`, `go build`, and targeted `go test` for the files you change.
 
 ## Running Hive locally


### PR DESCRIPTION
Fixes #5283

## What

A contributor whose PR fails `notice-drift` ("NOTICE matches the module graph") had nowhere to look:

| File | mentions `generate-notice` |
|---|---|
| `CONTRIBUTING.md` | **0** |
| `docs/development.md` | **0** |
| `src/docs/releases.md` | 1 — but that is a maintainer doc |

Adds a section to `docs/development.md` under format/lint expectations.

## The three traps, all hit today

- **Commit the output verbatim.** The check is byte-exact, and several dependency licences carry trailing whitespace on their own lines. I filed #5064 claiming the generator emitted whitespace CI strips — the truth was the **inverse**, and the `sed` normalisation I proposed would have guaranteed a permanent diff.
- **The generator needs the module's pinned Go toolchain.** Under an older `go`, `go-licenses` fails to resolve stdlib packages and aborts before writing anything — so it looks like the script is broken rather than the toolchain being wrong.
- **A red `notice-drift` is not always yours.** `NOTICE` lives on the branch, so a dependency bump merged without regenerating leaves `v4` itself stale and *every* open PR inherits the failure — including docs-only ones. That happened this morning after the otel bumps (#5275 fixed it).

Also distinguishes a **`FORBIDDEN`** result from ordinary drift: that means the module graph contains a licence the project cannot ship — how the AGPL-3.0 dependency was caught in #5016 — and needs the dependency removed, not a regeneration.

## Verification

Ran the documented command on current `v4`: exits 0 and produces no diff. Also corrected the invocation — the script resolves its own paths from `BASH_SOURCE`, so it does not need to be run from `src/`.

Docs only.