### PR TITLE
🐛 fix(contributor): decide pane presence by client activity, not by connection (#5277)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1808,20 +1808,81 @@ function paneShowsLoginRequiredError(text) {
   });
 }
 
-// tmuxSessionHasAttachedClient reports whether a human is currently attached to
-// the agent's tmux session. The hub-side nudge declines in exactly this case
-// (manager.go, tmuxSessionHasAttachedClientForAgent) so a watchdog never types
-// over someone who is sitting in the pane; the relay honors the same rule.
-// Failure to ask is treated as "attached", i.e. the cautious answer: it
-// withholds typing rather than risking it.
-function tmuxSessionHasAttachedClient() {
+// How long an attached tmux client must have been silent before the relay
+// stops treating it as a person who owns the pane (kubestellar/hive#5277).
+//
+// The guard this feeds exists so a watchdog never types over someone
+// mid-keystroke, and that is worth keeping. But "a client is connected" is not
+// "a human is here": a dashboard terminal tab left open an hour ago
+// (bin/ttyd-tmux.sh attaches one, and the dashboard's browser terminal proxies
+// to it) was indistinguishable from someone actively typing, and it disabled
+// API-error auto-retry for the whole 30-minute task ceiling.
+//
+// Five minutes, and the two bounds are asymmetric. Below ~2 minutes the
+// threshold is not observable at all: the only caller runs on the
+// PROGRESS_REPORT_INTERVAL_MS tick, 120s apart. Above it, every extra minute is
+// a minute of a stranded task, and the cost of being wrong in that direction is
+// mild — "try again" typed at a prompt nobody is typing at is visible and
+// harmless, while the cost of being wrong in the other direction is the bug
+// this fixes. Long enough to cover reading a diff; far short of the 30-minute
+// strand it replaces.
+const HUMAN_PRESENCE_IDLE_MS = Number(process.env.HIVE_HUMAN_PRESENCE_IDLE_MS) || 5 * 60 * 1000;
+
+// tmuxSessionHumanPresence reports whether a human is at the agent's tmux
+// session, and how confident that answer is.
+//
+//   attached — some client is connected at all.
+//   active   — some client has typed within HUMAN_PRESENCE_IDLE_MS. This, not
+//               `attached`, is the question a watchdog must ask before typing.
+//   idleMs   — how long the most recently active client has been quiet, or
+//               null when tmux did not say.
+//
+// `client_activity` is tmux's per-client timestamp of last input, in epoch
+// seconds — the signal that distinguishes an abandoned tab from a person.
+//
+// EVERY uncertain answer resolves to active:true, because the failure this
+// guard prevents (typing over someone mid-keystroke) is worse than the failure
+// it causes (a retry deferred one tick). tmux erroring, tmux returning
+// unparseable activity values, and a clock skewed into the future all take that
+// branch. Only a client that positively reports itself quiet for long enough
+// releases the pane.
+function tmuxSessionHumanPresence() {
   try {
-    const out = execSync(`tmux list-clients -t ${TMUX_SESSION} 2>/dev/null || true`,
+    const out = execSync(
+      `tmux list-clients -t ${TMUX_SESSION} -F '#{client_activity}' 2>/dev/null || true`,
       { encoding: 'utf8', timeout: 15000 });
-    return String(out).trim().length > 0;
+    const text = String(out).trim();
+    if (!text) return { attached: false, active: false, idleMs: null };
+
+    let newestSec = null;
+    for (const line of text.split('\n')) {
+      const seconds = Number(String(line).trim());
+      if (!Number.isFinite(seconds) || seconds <= 0) continue;
+      if (newestSec === null || seconds > newestSec) newestSec = seconds;
+    }
+    if (newestSec === null) {
+      // Attached, but tmux told us nothing usable about when — an old tmux
+      // whose client_activity is not an epoch integer, say. Presence unknown,
+      // so presence assumed.
+      return { attached: true, active: true, idleMs: null };
+    }
+
+    // A negative age means the client's clock is ahead of ours; clamping to
+    // zero makes that read as "just now", which is the cautious direction.
+    const idleMs = Math.max(0, Date.now() - newestSec * 1000);
+    return { attached: true, active: idleMs < HUMAN_PRESENCE_IDLE_MS, idleMs };
   } catch (_) {
-    return true;
+    return { attached: true, active: true, idleMs: null };
   }
+}
+
+// tmuxSessionHasAttachedClient reports only whether a client is CONNECTED. It
+// deliberately says nothing about whether a person is there — see
+// tmuxSessionHumanPresence for the question callers actually want. Kept because
+// "is anything attached at all" is still a real question, and because failing
+// closed on a tmux error is the same rule at both layers.
+function tmuxSessionHasAttachedClient() {
+  return tmuxSessionHumanPresence().attached;
 }
 
 // tmuxSendNudge types a short literal message and submits it.
@@ -2391,21 +2452,32 @@ function handleTransientAPIError(tmuxLines) {
     tmux_output: tmuxLines,
   };
 
-  // A human attached to the pane owns it. The hub-side nudge declines in
-  // exactly this case so a watchdog never types over someone; the honest
-  // fallback is to say the agent needs attention, which is true, rather than to
-  // stay silent and let the stall backstop eventually fail the task.
-  if (tmuxSessionHasAttachedClient()) {
+  // A human AT the pane owns it, and a watchdog must never type over someone
+  // mid-keystroke. But presence is a recency question, not a connection one
+  // (#5277): a dashboard terminal tab left open is a connected client and not a
+  // person, and treating the two alike disabled recovery entirely for as long
+  // as the tab lived. An attached-but-quiet client falls through to the retry
+  // below; only a recently active one still takes this branch.
+  const presence = tmuxSessionHumanPresence();
+  if (presence.active) {
+    const since = presence.idleMs === null
+      ? 'activity unknown'
+      : `last input ${Math.round(presence.idleMs / 1000)}s ago`;
     console.warn(`Task ${currentTask.task_id} stopped on a retryable API error; ` +
-      `a client is attached to ${TMUX_SESSION}, so not typing a retry`);
+      `someone is active on ${TMUX_SESSION} (${since}), so not typing a retry`);
     send({
       ...progressBase,
       status: 'blocked_on_human',
       attention: true,
-      summary: 'Agent stopped on a retryable API error; a human is attached to the pane',
+      summary: 'Agent stopped on a retryable API error; a human is active in the pane',
       ...progressModelFields(),
     });
     return;
+  }
+  if (presence.attached) {
+    console.warn(`Task ${currentTask.task_id} stopped on a retryable API error; ` +
+      `a client is attached to ${TMUX_SESSION} but has been idle ` +
+      `${Math.round(presence.idleMs / 1000)}s, so proceeding with the retry`);
   }
 
   // Bounded: a persistent upstream failure ends as an honest environment
@@ -3038,6 +3110,8 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     handleTransientAPIError,
     resetTransientNudgeState,
     tmuxSessionHasAttachedClient,
+    tmuxSessionHumanPresence,
+    HUMAN_PRESENCE_IDLE_MS,
     TRANSIENT_API_ERROR_MAX_NUDGES,
     TRANSIENT_API_ERROR_NUDGE_MESSAGE,
     getTransientNudgeCount: () => transientNudgeCount,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -26,7 +26,7 @@ const RELAY_PATH = path.join(__dirname, 'contributor-relay.sh');
 // bash and no WebSocket are ever touched.
 // ---------------------------------------------------------------------------
 
-function loadRelay({ backend = 'copilot', backendBinary = null, backendPerm = '--allow-all', model = '', reasoningEffort = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, paneText = null, env = null, cliVersion = null, attachedClients = false } = {}) {
+function loadRelay({ backend = 'copilot', backendBinary = null, backendPerm = '--allow-all', model = '', reasoningEffort = '', cliStates = ['ready'], procAlive = true, mode = 'interactive', execFileResult = null, statusFile = null, paneText = null, env = null, cliVersion = null, attachedClients = false, attachedIdleMs = 0, clientActivityRaw = null, listClientsThrows = false } = {}) {
   const commands = [];
   const sent = [];
   // Records every execFile (headless one-shot) invocation: { bin, args, opts }.
@@ -61,7 +61,16 @@ function loadRelay({ backend = 'copilot', backendBinary = null, backendPerm = '-
     if (/list-clients/.test(cmd)) {
       // #5094: the relay asks whether a human is attached before it types a
       // retry into the pane. An empty answer means nobody is watching.
-      return attachedClients ? '/dev/pts/3: 0 [200x50 xterm-256color] (utf8)\n' : '';
+      //
+      // #5277: the question is now "has anyone typed recently", asked as
+      // `-F '#{client_activity}'`, so the stub answers in tmux's own currency —
+      // epoch SECONDS of last input. attachedIdleMs defaults to 0, i.e. a
+      // client that just typed, which is what every pre-#5277 test meant by
+      // `attachedClients: true`.
+      if (listClientsThrows) throw new Error('tmux: no server running');
+      if (!attachedClients) return '';
+      if (clientActivityRaw !== null) return clientActivityRaw;
+      return `${Math.floor((Date.now() - attachedIdleMs) / 1000)}\n`;
     }
     if (/display-message/.test(cmd)) {
       // The relay asks the PANE what it is running (pane_current_command).
@@ -3933,6 +3942,201 @@ test('#5094 with a human attached the relay asks for attention instead of typing
     assert.strictEqual(blocked.length, 1, 'the human should be told the agent needs them');
     assert.strictEqual(blocked[0].attention, true);
     assert.strictEqual(relay.__sent.filter(m => m.type === 'task_complete').length, 0);
+  } finally { teardown(relay); }
+});
+
+
+// ---------------------------------------------------------------------------
+// kubestellar/hive#5277 — "a client is attached" is not "a human is here".
+//
+// The #5094 guard above is right to refuse to type over someone, but it tested
+// connection rather than presence. bin/ttyd-tmux.sh attaches a client with
+// `tmux attach-session`, and the dashboard's browser terminal proxies to it, so
+// a tab someone opened an hour ago and walked away from was indistinguishable
+// from a person mid-keystroke — and disabled API-error auto-retry for the whole
+// 30-minute task ceiling. Observed live: a contributor hit a connection-lost
+// error, no `try again` was ever typed, and a human hand-typed the recovery.
+//
+// The fix is a recency test on tmux's own `client_activity`. Everything the
+// guard used to protect is still protected; only the abandoned tab changes.
+// ---------------------------------------------------------------------------
+
+test('#5277 a dashboard tab left open no longer disables auto-retry', () => {
+  // The incident, exactly: attached the whole time, idle the whole time.
+  const relay = loadRelay({
+    backend: 'claude', paneText: CLAUDE_API_ERROR_PANE,
+    attachedClients: true, attachedIdleMs: 60 * 60 * 1000,
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-idle-tab');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.ok(relay.__tmuxSends().slice(before).some(c => c.includes(relay.TRANSIENT_API_ERROR_NUDGE_MESSAGE)),
+      'an hour-idle client is a left-open tab, not a person — the retry must be typed');
+    assert.strictEqual(relay.__sent.filter(m => m.status === 'blocked_on_human').length, 0,
+      'nobody is there to be blocked on');
+    assert.strictEqual(relay.getTransientNudgeCount(), 1);
+  } finally { teardown(relay); }
+});
+
+test('#5277 a client that typed a moment ago still owns the pane', () => {
+  // The control. Without it the fix could pass by simply never checking.
+  const relay = loadRelay({
+    backend: 'claude', paneText: CLAUDE_API_ERROR_PANE,
+    attachedClients: true, attachedIdleMs: 30 * 1000,
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-active');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.ok(!relay.__tmuxSends().slice(before).some(c => c.includes(relay.TRANSIENT_API_ERROR_NUDGE_MESSAGE)),
+      'someone who typed 30 seconds ago is still someone');
+    const blocked = relay.__sent.filter(m => m.status === 'blocked_on_human');
+    assert.strictEqual(blocked.length, 1, 'and they should be told the agent needs them');
+    assert.strictEqual(blocked[0].attention, true);
+  } finally { teardown(relay); }
+});
+
+test('#5277 presence is decided by the idle threshold, not by the connection', () => {
+  // Both sides of the boundary, read straight off the helper. The 5s margins
+  // clear the stub's whole-second quantisation.
+  const idle = (ms) => {
+    const relay = loadRelay({ backend: 'claude', attachedClients: true, attachedIdleMs: ms });
+    try { return relay.tmuxSessionHumanPresence(); } finally { teardown(relay); }
+  };
+  const threshold = loadRelay({ backend: 'claude' }).HUMAN_PRESENCE_IDLE_MS;
+
+  const justActive = idle(threshold - 5000);
+  assert.strictEqual(justActive.attached, true);
+  assert.strictEqual(justActive.active, true, 'just inside the threshold is still a person');
+
+  const justIdle = idle(threshold + 5000);
+  assert.strictEqual(justIdle.attached, true, 'the client is still connected');
+  assert.strictEqual(justIdle.active, false, 'but it is no longer evidence of a person');
+  assert.ok(justIdle.idleMs >= threshold, `idleMs ${justIdle.idleMs} should report the real age`);
+});
+
+test('#5277 the query asks tmux for client_activity, not just for a client list', () => {
+  // The whole fix rests on tmux being ASKED for the timestamp. A refactor that
+  // dropped the -F would leave every other test passing — the stub would answer
+  // with epoch seconds regardless — while the real tmux returned a pts line and
+  // silently restored the bug as "activity unknown, assume present".
+  const relay = loadRelay({ backend: 'claude', attachedClients: true });
+  try {
+    relay.tmuxSessionHumanPresence();
+    const query = relay.__commands.filter(c => /list-clients/.test(c)).pop();
+    assert.ok(query, 'the presence check must actually ask tmux');
+    assert.ok(query.includes('client_activity'),
+      `presence must be asked as a recency question, got: ${query}`);
+  } finally { teardown(relay); }
+});
+
+test('#5277 nobody attached reports neither attached nor active', () => {
+  const relay = loadRelay({ backend: 'claude', attachedClients: false });
+  try {
+    assert.deepStrictEqual(relay.tmuxSessionHumanPresence(), { attached: false, active: false, idleMs: null });
+  } finally { teardown(relay); }
+});
+
+test('#5277 a tmux failure still counts as someone present', () => {
+  // Fail closed, unchanged: not being able to ask must never license typing.
+  const relay = loadRelay({
+    backend: 'claude', paneText: CLAUDE_API_ERROR_PANE, listClientsThrows: true,
+  });
+  try {
+    assert.deepStrictEqual(relay.tmuxSessionHumanPresence(), { attached: true, active: true, idleMs: null });
+    relay.setCliReady(true);
+    assignTask(relay, 't-tmux-broken');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.ok(!relay.__tmuxSends().slice(before).some(c => c.includes(relay.TRANSIENT_API_ERROR_NUDGE_MESSAGE)),
+      'a tmux hiccup must not be read as an empty room');
+    assert.strictEqual(relay.__sent.filter(m => m.status === 'blocked_on_human').length, 1);
+  } finally { teardown(relay); }
+});
+
+test('#5277 an activity value tmux did not give us counts as someone present', () => {
+  // An older tmux whose client_activity is not an epoch integer: attached is
+  // known, recency is not, so recency is assumed.
+  const relay = loadRelay({
+    backend: 'claude', paneText: CLAUDE_API_ERROR_PANE, attachedClients: true,
+    clientActivityRaw: '/dev/pts/3: 0 [200x50 xterm-256color] (utf8)\n',
+  });
+  try {
+    const presence = relay.tmuxSessionHumanPresence();
+    assert.strictEqual(presence.attached, true);
+    assert.strictEqual(presence.active, true);
+    assert.strictEqual(presence.idleMs, null, 'an unknown age must read as unknown, not as zero');
+    relay.setCliReady(true);
+    assignTask(relay, 't-unparseable');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.ok(!relay.__tmuxSends().slice(before).some(c => c.includes(relay.TRANSIENT_API_ERROR_NUDGE_MESSAGE)));
+  } finally { teardown(relay); }
+});
+
+test('#5277 a client clock ahead of ours counts as someone present', () => {
+  // A future timestamp clamps to "just now" rather than wrapping to a huge
+  // idle age, which would hand the pane away on a clock skew.
+  const relay = loadRelay({ backend: 'claude', attachedClients: true, attachedIdleMs: -10 * 60 * 1000 });
+  try {
+    const presence = relay.tmuxSessionHumanPresence();
+    assert.strictEqual(presence.active, true, 'skew must not read as an abandoned tab');
+    assert.strictEqual(presence.idleMs, 0);
+  } finally { teardown(relay); }
+});
+
+test('#5277 the newest client decides — one active client protects the pane', () => {
+  // Two clients: a stale dashboard tab and a person who just typed. The person
+  // wins, so the tab cannot drag presence down to "nobody home".
+  const stale = Math.floor((Date.now() - 60 * 60 * 1000) / 1000);
+  const fresh = Math.floor(Date.now() / 1000);
+  const relay = loadRelay({
+    backend: 'claude', attachedClients: true,
+    clientActivityRaw: `${stale}\n${fresh}\n`,
+  });
+  try {
+    assert.strictEqual(relay.tmuxSessionHumanPresence().active, true);
+  } finally { teardown(relay); }
+});
+
+test('#5277 a suppressed nudge still consumes no retry budget', () => {
+  const relay = loadRelay({
+    backend: 'claude', paneText: CLAUDE_API_ERROR_PANE,
+    attachedClients: true, attachedIdleMs: 10 * 1000,
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-budget');
+    for (let i = 0; i < 5; i++) {
+      relay.__clearTransientNudgeCooldown();
+      relay.__crashTick();
+    }
+    assert.strictEqual(relay.getTransientNudgeCount(), 0,
+      'refusing to type must not spend a retry the agent never got');
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_failed').length, 0,
+      'and it must not exhaust the budget into a failure either');
+  } finally { teardown(relay); }
+});
+
+test('#5277 the idle-client retry is still bounded and still fails honestly', () => {
+  const relay = loadRelay({
+    backend: 'claude', paneText: CLAUDE_API_ERROR_PANE,
+    attachedClients: true, attachedIdleMs: 45 * 60 * 1000,
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-idle-bounded');
+    for (let i = 0; i <= relay.TRANSIENT_API_ERROR_MAX_NUDGES; i++) {
+      relay.__clearTransientNudgeCooldown();
+      relay.__crashTick();
+    }
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_complete').length, 0);
+    const failures = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(failures.length, 1, 'an exhausted budget hands the task back exactly once');
+    assert.strictEqual(failures[0].failure_kind, 'environment');
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
## Summary

When a contributor's turn dies on a transient API error, the relay is meant to type `try again` and recover the task — up to three retries (#5094/#5121). That recovery was silently disabled for as long as **anything** was attached to the agent's tmux session, including a dashboard terminal tab someone left open. `bin/ttyd-tmux.sh` attaches a client with `tmux attach-session`, and the dashboard's browser terminal proxies to it, so an open tab suppressed every retry with no indication anywhere that it had.

Nothing else rescued the task. The three retries were never spent — `transientNudgeCount` only increments *past* the attached check — and a pane parked in the API-error state never reaches the stall backstop, so every tick re-classified the same unchanged text and re-sent `blocked_on_human`. The only thing that ended it was `MAX_TASK_DURATION_MS` at 30 minutes.

## The guard stays; the definition changes

Typing over someone mid-keystroke can interleave with their input or submit a half-typed line, and #5094 was right to refuse it. What was wrong is the definition: `tmux list-clients` being non-empty means a client is **connected**, not that a human is **present**.

tmux already exposes the missing signal. `client_activity` is a per-client timestamp of last input, so the guard becomes a recency test:

- `tmuxSessionHumanPresence()` returns `{attached, active, idleMs}`
- `handleTransientAPIError` suppresses the nudge on **`active`**, not on `attached`

Someone who typed thirty seconds ago is protected exactly as before. A tab abandoned an hour ago stops blocking recovery.

## The threshold

`HUMAN_PRESENCE_IDLE_MS` = 5 minutes, overridable via `HIVE_HUMAN_PRESENCE_IDLE_MS` (following the `HIVE_PANE_STALL_TIMEOUT_MS` precedent). The bounds are asymmetric on purpose:

- **Below ~2 minutes** the threshold isn't observable at all — the only caller runs on the `PROGRESS_REPORT_INTERVAL_MS` tick, 120s apart.
- **Above it**, every extra minute is a minute of a stranded task. Being wrong in that direction is mild: `try again` typed at a prompt nobody is typing at is visible and harmless. Being wrong the other way is a 30-minute strand.

## Every uncertain answer still means "someone is present"

The existing fail-closed rule, made explicit and extended to the new failure modes:

| Case | Verdict |
|---|---|
| `tmux` errors | present (unchanged) |
| activity is not an epoch integer (older tmux) | present, `idleMs: null` |
| client clock ahead of ours | present — clamped to "just now" |
| several clients | the **newest** decides, so a stale tab can't drag presence down while a person types |

Only a client that *positively* reports itself quiet for long enough releases the pane. Without the skew clamp a future timestamp would read as an enormous idle age and hand the pane away on a clock difference.

Retry budget and cooldown semantics are unchanged, and **a suppressed nudge still consumes no budget** — there's a test for it, because that's the property letting the guard defer indefinitely without ever failing the task.

`tmuxSessionHasAttachedClient()` stays as a thin wrapper, still meaning exactly what its name says.

## Verification

`211/211` relay tests pass. Mutation-checked **seven ways**; each mutant fails a test that names the property it broke:

| Mutant | Test that catches it |
|---|---|
| revert to the presence test (**reproduces the original bug**) | `a dashboard tab left open no longer disables auto-retry` |
| tmux errors stop failing closed | `a tmux failure still counts as someone present` |
| unparseable activity stops failing closed | `an activity value tmux did not give us…` |
| clock-skew clamp removed | `a client clock ahead of ours counts as someone present` |
| oldest client wins instead of newest | `the newest client decides` |
| suppressed nudge spends budget | `a suppressed nudge still consumes no retry budget` |
| `-F` dropped from the tmux query | `the query asks tmux for client_activity` |

That last one matters more than it looks: without it, a refactor that stopped *asking* tmux for `client_activity` would leave every other test green — the stub answers with epoch seconds regardless — while real tmux returned a pts line and silently restored the bug as "activity unknown, assume present".

`a client that typed a moment ago still owns the pane` is the control; without it the fix could pass by simply never checking.

The harness now answers `list-clients` in tmux's own currency, and `attachedClients: true` defaults to idle 0 — so every pre-existing test keeps the exact meaning it had: *a client that just typed*.

**Pre-existing test-environment note:** `a relaunch cds somewhere resolvable before starting the CLI` fails when `HIVE_AGENT_CWD` is set in the runner's environment — it asserts behaviour for that var being *unset*. Confirmed pre-existing by stashing this change (`199/200` before, `200/200` with `env -u HIVE_AGENT_CWD`). Not touched here.

## Acceptance criteria

- [x] Idle attached client → retried automatically, including the dashboard-tab case
- [x] Recently-active client → no nudge, `blocked_on_human` with `attention`, unchanged
- [x] `tmux list-clients` failure → still counts as present (fails closed)
- [x] Retry budget and cooldown otherwise unchanged; a suppressed nudge consumes no budget
- [x] Tests cover all four, and the existing #5094/#5121 unattached paths still pass

## Deliberately not in scope

- **The hub-side twin.** `m.tmuxSessionHasAttachedClientForAgent` (`src/pkg/agent/manager.go:4132`) tests `session_attached` and has the same connection-vs-presence flaw on the hosted-agent nudge path. Different subsystem, own tests, and the incident here is relay-side — widening this into the hosted fleet's watchdog is a maintainer's call.
- **The `MAX_TASK_DURATION_MS` failure kind.** The issue notes that path records an infrastructure stall as a plain task failure rather than an `environment` one. It isn't a one-liner: that timeout fires for *every* task over 30 minutes, and a genuinely slow task is not an environment failure, so it needs to know *why* it timed out. Left alone.
- **The inert cooldown.** `TRANSIENT_API_ERROR_NUDGE_COOLDOWN_MS` = 90s never defers anything because ticks are 120s apart. Unchanged, as the issue flags — worth knowing before anyone drops the tick interval below 90s, which would make it load-bearing for the first time.

Fixes #5277.

— hive: backend=claude model=claude-fable-5
