### PR TITLE
✨ feat(contributor): remind an unattended agent to proceed on its own (#5281)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -205,6 +205,18 @@ const TRANSIENT_API_ERROR_NUDGE_MESSAGE = 'try again';
 const TRANSIENT_API_ERROR_MAX_NUDGES = 3;
 const TRANSIENT_API_ERROR_NUDGE_COOLDOWN_MS = 90000;
 
+// What the relay types at an unattended pane that stopped to ask a question
+// (kubestellar/hive#5281). The task prompts already tell agents to decide for
+// themselves — an agent that stops to ask is one that forgot, and a human
+// watching would type exactly this line. When nobody is watching, nobody does.
+//
+// Letters, spaces and one comma, by construction: tmuxSendNudge interpolates
+// this into a single-quoted `tmux send-keys -l '...'`, so a quote or a shell
+// metacharacter here would be a command-injection shaped bug rather than a
+// typo. There is a test pinning that.
+const AUTONOMY_NUDGE_MESSAGE =
+  'no human is available to answer, so proceed autonomously with your best judgment';
+
 // Cap on captured child output kept in memory / sent to the hub, so a chatty
 // CLI cannot grow the buffer without bound. The tail is what matters for an
 // audit trail, mirroring TMUX_TAIL_LINES on the interactive path.
@@ -1679,9 +1691,49 @@ function recentPaneLines(text, limit = 12) {
     .slice(-limit);
 }
 
-function paneLooksBlockedOnHuman(text) {
+// Why a blocked pane is blocked (kubestellar/hive#5281). BLOCKED_ON_HUMAN
+// conflates two populations, and only one of them can be helped without a
+// person:
+//
+//   question       — a plain "?", a y/N, an elicitation form. The agent forgot
+//                    its standing instruction to decide for itself, and a
+//                    one-line reminder is usually all it takes.
+//   menu           — a numbered menu. Deliberately NOT nudge-eligible: a menu
+//                    TUI may read typed text as a selection filter rather than
+//                    as chat input, so covering it properly needs Escape
+//                    handling this does not attempt.
+//   human-required — login, credential entry, trust/consent, permission. Only
+//                    a person can answer these, and typing at them is actively
+//                    harmful.
+const BLOCKED_REASON_QUESTION = 'question';
+const BLOCKED_REASON_MENU = 'menu';
+const BLOCKED_REASON_HUMAN_REQUIRED = 'human-required';
+
+// The confirmation half of the old blockingPatterns list: prompts an agent
+// working autonomously is entitled to answer for itself.
+const QUESTION_BLOCKING_PATTERNS = [
+  /\[[Yy]\/[Nn]\]|\([Yy]\/[Nn]\)|\b[Yy]es\/[Nn]o\b/,
+  /\b(?:continue|proceed|confirm|approve|allow|deny|accept|reject|choose|select)\b.*\?/i,
+  /\bPress Enter to continue\b/i,
+  /\bEnter to confirm\b/i,
+];
+
+// The other half: prompts where a person is the only possible answer. Kept as
+// its own list because it is a veto, not a detector — see
+// classifyBlockedOnHumanReason.
+const HUMAN_REQUIRED_BLOCKING_PATTERNS = [
+  /\b(?:approval|consent|trust this folder|Do you trust|Confirm folder trust)\b/i,
+  /\bpermission\b.*\b(?:allow|approve|confirm|continue|proceed)\b/i,
+  /\b(?:allow|approve|confirm|continue|proceed)\b.*\bpermission\b/i,
+  /\b(?:Allow|Approve|Run|Execute)\b.*\b(?:command|tool|edit|file|operation)\b/i,
+  /\b(?:Paste|Enter).*(?:API key|token|code|password)\b/i,
+];
+
+// classifyBlockedOnHumanReason returns one of the BLOCKED_REASON_* constants,
+// or null when the pane is not blocked at all.
+function classifyBlockedOnHumanReason(text) {
   const lines = recentPaneLines(text);
-  if (lines.length === 0) return false;
+  if (lines.length === 0) return null;
   const recent = lines.join('\n');
   const last = lines[lines.length - 1];
   const beforePrompt = [...lines].reverse().find(line =>
@@ -1722,21 +1774,36 @@ function paneLooksBlockedOnHuman(text) {
     /\bElicitation request timed out\b/i.test(recent) ||
     /\bTimeout waiting for user response\b/i.test(recent);
   const hasElicitationForm = (hasInputRequestLeadIn && hasFormStructure) || hasElicitationMarker;
-  const blockingPatterns = [
-    // Confirmation prompts and TUI continuation screens.
-    /\[[Yy]\/[Nn]\]|\([Yy]\/[Nn]\)|\b[Yy]es\/[Nn]o\b/,
-    /\b(?:continue|proceed|confirm|approve|allow|deny|accept|reject|choose|select)\b.*\?/i,
-    /\bPress Enter to continue\b/i,
-    /\bEnter to confirm\b/i,
-    // Permission/auth/onboarding prompts seen from Claude/Copilot/Goose/Bob.
-    /\b(?:approval|consent|trust this folder|Do you trust|Confirm folder trust)\b/i,
-    /\bpermission\b.*\b(?:allow|approve|confirm|continue|proceed)\b/i,
-    /\b(?:allow|approve|confirm|continue|proceed)\b.*\bpermission\b/i,
-    /\b(?:Allow|Approve|Run|Execute)\b.*\b(?:command|tool|edit|file|operation)\b/i,
-    /\b(?:Paste|Enter).*(?:API key|token|code|password)\b/i,
-  ];
+  const blockingPatterns = [...QUESTION_BLOCKING_PATTERNS, ...HUMAN_REQUIRED_BLOCKING_PATTERNS];
 
-  return hasQuestion || hasNumberedMenu || hasElicitationForm || blockingPatterns.some(re => re.test(beforePrompt));
+  const blocked = hasQuestion || hasNumberedMenu || hasElicitationForm ||
+    blockingPatterns.some(re => re.test(beforePrompt));
+  if (!blocked) return null;
+
+  // Human-required WINS over every other signal, and is asked of the whole
+  // recent window rather than just the line above the prompt (#5281). A trust
+  // dialog or a credential request often renders its heading a few lines up
+  // while the cursor line is a bare "Do you want to proceed?" — classifying
+  // that as an ordinary question is exactly the mistake that would type an
+  // autonomy reminder into a /login flow or submit it as a password.
+  //
+  // Widening the window can only move a pane from question to human-required,
+  // never make an unblocked pane blocked: `blocked` above is computed exactly
+  // as it always was. When in doubt, human-required — waiting costs 30 minutes,
+  // a wrong nudge costs a credential prompt answered with prose.
+  if (HUMAN_REQUIRED_BLOCKING_PATTERNS.some(re => re.test(recent))) {
+    return BLOCKED_REASON_HUMAN_REQUIRED;
+  }
+  if (hasNumberedMenu) return BLOCKED_REASON_MENU;
+  return BLOCKED_REASON_QUESTION;
+}
+
+// paneLooksBlockedOnHuman is the original boolean, now derived from the
+// classifier so there is exactly one definition of "blocked". Its answer is
+// unchanged: classifyBlockedOnHumanReason returns non-null for precisely the
+// panes this used to return true for.
+function paneLooksBlockedOnHuman(text) {
+  return classifyBlockedOnHumanReason(text) !== null;
 }
 
 // paneTail returns the last n lines of a pane capture. Pure, so the detectors
@@ -2266,6 +2333,17 @@ function resetTransientNudgeState() {
   lastTransientNudgeAt = 0;
 }
 
+// Autonomy-nudge state (kubestellar/hive#5281), scoped to the CURRENT task.
+// Budget of exactly one: a question the agent re-asks AFTER being told to
+// proceed autonomously is a question it genuinely cannot answer itself, and
+// re-nudging it would loop until the max-duration ceiling. Once spent, the pane
+// reports blocked_on_human exactly as it does today.
+let autonomyNudgeSent = false;
+
+function resetAutonomyNudgeState() {
+  autonomyNudgeSent = false;
+}
+
 function resetPaneStallClock() {
   lastPaneFingerprint = null;
   lastPaneChangeAt = Date.now();
@@ -2417,6 +2495,8 @@ function startProgressReporting() {
   // Likewise the retry budget: a previous task that exhausted its API-error
   // retries must not deny this one its own (#5094).
   resetTransientNudgeState();
+  // And the one-shot autonomy reminder (#5281), for the same reason.
+  resetAutonomyNudgeState();
 
   taskTimeoutHandle = setTimeout(() => {
     if (currentTask) {
@@ -2514,6 +2594,75 @@ function handleTransientAPIError(tmuxLines) {
       `(${transientNudgeCount}/${TRANSIENT_API_ERROR_MAX_NUDGES})`,
     ...progressModelFields(),
   });
+}
+
+// paneHasPresentHuman is the one place this file asks "is a person there?".
+//
+// It exists as a named seam because #5281 and #5094 must answer it the SAME
+// way: a guard that diverges between two nudges is how you get a pane that is
+// safe from one watchdog and not the other.
+//
+// Today it is the bare attached check — a client is connected. #5277 is
+// replacing that with a recency test on tmux's `client_activity`, because a
+// dashboard terminal tab left open is a connected client and not a person.
+// When that lands this body becomes `return tmuxSessionHumanPresence().active;`
+// and both callers inherit it; that one line is the whole follow-up.
+function paneHasPresentHuman() {
+  return tmuxSessionHasAttachedClient();
+}
+
+// maybeSendAutonomyNudge types a one-shot reminder at an unattended pane that
+// stopped to ask a question it was already instructed to answer for itself
+// (kubestellar/hive#5281), and reports whether it did.
+//
+// Detection without recovery is what this fixes. The relay already SEES the
+// question and raises `attention`, but an attention flag only helps someone who
+// is watching something, and a contributor run by a user who never attaches to
+// tmux is a supported way to run one. For that user every question the agent
+// asks costs 20-30 minutes and a failed task.
+//
+// Four things must all hold, and each one is a separate way to get this wrong:
+//
+//  1. The pane is blocked on a QUESTION, not on something only a person can
+//     answer. See classifyBlockedOnHumanReason.
+//  2. It is not a login/401 pane. Belt to the classifier's braces: a /login
+//     flow is reached by a different route through checkTmuxPaneState (#4400),
+//     so excluding it here makes "never nudge a login" true by construction
+//     rather than true by coincidence.
+//  3. Nobody is at the pane.
+//  4. The one-shot budget is unspent.
+function maybeSendAutonomyNudge(tmuxLines) {
+  if (!currentTask) return false;
+  if (autonomyNudgeSent) return false;
+
+  const pane = tmuxLines.join('\n');
+  if (paneShowsLoginRequiredError(pane)) return false;
+  if (classifyBlockedOnHumanReason(pane) !== BLOCKED_REASON_QUESTION) return false;
+  if (paneHasPresentHuman()) return false;
+
+  // Spend the budget BEFORE typing. A send that throws has still disturbed the
+  // pane, and retrying it on the next tick is the loop this budget exists to
+  // prevent.
+  autonomyNudgeSent = true;
+  console.warn(`Task ${currentTask.task_id} is blocked on a question with nobody attached to ` +
+    `${TMUX_SESSION} — reminding it to proceed autonomously (once per task)`);
+  try {
+    tmuxSendNudge(AUTONOMY_NUDGE_MESSAGE);
+  } catch (e) {
+    console.error('Failed to send the autonomy reminder:', e.message);
+    return false;
+  }
+  send({
+    type: 'task_progress',
+    seq: nextSeq(),
+    task_id: currentTask.task_id,
+    task_gen: currentTask.task_gen,
+    status: 'working',
+    summary: 'Agent asked a question with no human attached; reminded it to proceed autonomously',
+    tmux_output: tmuxLines,
+    ...progressModelFields(),
+  });
+  return true;
 }
 
 function progressTick() {
@@ -2640,6 +2789,11 @@ function progressTick() {
       send({ type: 'ready', seq: nextSeq() });
     }
   } else if (paneState === PANE_STATE_BLOCKED_ON_HUMAN) {
+    // #5281: before reporting a blocked pane to a human who may not be there,
+    // see whether this is a question the agent was already told to answer
+    // itself. At most once per task; everything below is unchanged and is what
+    // runs on every later tick.
+    if (maybeSendAutonomyNudge(tmuxLines)) return;
     console.warn(`Task ${currentTask.task_id} is blocked waiting for human input`);
     send({
       type: 'task_progress',
@@ -3109,6 +3263,13 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     paneShowsLoginRequiredError,
     handleTransientAPIError,
     resetTransientNudgeState,
+    classifyBlockedOnHumanReason,
+    BLOCKED_REASON_QUESTION,
+    BLOCKED_REASON_MENU,
+    BLOCKED_REASON_HUMAN_REQUIRED,
+    maybeSendAutonomyNudge,
+    resetAutonomyNudgeState,
+    AUTONOMY_NUDGE_MESSAGE,
     tmuxSessionHasAttachedClient,
     tmuxSessionHumanPresence,
     HUMAN_PRESENCE_IDLE_MS,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -36,8 +36,19 @@ function loadRelay({ backend = 'copilot', backendBinary = null, backendPerm = '-
   // Guard against a runaway loop in the code under test eating all memory.
   const MAX_RECORDED_COMMANDS = 10000;
 
+  // #5281: lets a test model a tmux send that fails, so the one-shot budget's
+  // behaviour on a throwing send is pinned rather than assumed.
+  let failNextLiteralSend = false;
+
   const fakeExecSync = (cmd) => {
     if (commands.length < MAX_RECORDED_COMMANDS) commands.push(cmd);
+    // Recorded BEFORE throwing: a test needs to see that the send was
+    // ATTEMPTED, which is the difference between "spent the budget" and
+    // "retried every tick".
+    if (failNextLiteralSend && /send-keys\b.*\s-l\s/.test(cmd)) {
+      failNextLiteralSend = false;
+      throw new Error('tmux: server exited unexpectedly');
+    }
     // backendBinary lets a test model backends.conf mapping a backend NAME to a
     // different BINARY (litellm → claude); it defaults to the identity mapping
     // every other backend has.
@@ -185,6 +196,7 @@ function loadRelay({ backend = 'copilot', backendBinary = null, backendPerm = '-
   const ws = new stubs.ws();
   relay.setWs(ws);
   relay.__commands = commands;
+  relay.__failNextNudge = () => { failNextLiteralSend = true; };
   relay.__sent = sent;
   relay.__tmpDir = tmpDir;
   relay.__execFileCalls = execFileCalls;
@@ -1573,6 +1585,11 @@ test('blocked interactive panes report attention instead of task_complete', () =
   try {
     relay.setCliReady(true);
     assignTask(relay, 'ct-blocked');
+    // #5281: an unattended question now gets ONE autonomy reminder first. The
+    // guarantee this test exists for is unchanged and asserted below -- never a
+    // completion, task stays active -- but it is now the SECOND tick that
+    // reports it, once the one-shot budget is spent.
+    relay.__crashTick();
     relay.__crashTick();
 
     assert.ok(!relay.__sent.some(m => m.type === 'task_complete'),
@@ -1593,6 +1610,10 @@ test('goose elicitation form is reported as blocked, never as task_complete (#28
   try {
     relay.setCliReady(true);
     assignTask(relay, 'ct-elicit');
+    // #5281: one autonomy reminder first (a form is a question), then today's
+    // report from the second tick on. The never-a-completion guarantee below is
+    // what this test is for and is unchanged.
+    relay.__crashTick();
     relay.__crashTick();
 
     assert.ok(!relay.__sent.some(m => m.type === 'task_complete'),
@@ -1601,6 +1622,273 @@ test('goose elicitation form is reported as blocked, never as task_complete (#28
     assert.ok(progress, `expected blocked_on_human progress, got: ${JSON.stringify(relay.__sent)}`);
     assert.strictEqual(progress.attention, true, 'blocked status must request human attention');
     assert.ok(relay.getCurrentTask(), 'the task must remain active while the form is unanswered');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
+// kubestellar/hive#5281 — an unattended agent that stops to ask a question gets
+// one reminder to proceed on its own.
+//
+// Detection without recovery was the gap: the relay already SAW the question
+// and raised `attention`, but an attention flag only helps someone watching,
+// and a contributor run by a user who never attaches to tmux is a supported way
+// to run one. For that user every question cost 20-30 minutes and a failed
+// task, even though the task prompt had already told the agent to decide for
+// itself.
+//
+// The dangerous half is telling a question apart from a prompt only a person
+// can answer. Typing "proceed autonomously" into a /login flow, or submitting
+// it as a password, is worse than waiting — so those panes are vetoed, and the
+// veto is asked of the whole recent window rather than just the cursor line.
+// ---------------------------------------------------------------------------
+
+const QUESTION_PANE = 'Should I open a pull request for this change?\n> \n';
+
+function nudges(relay, from = 0) {
+  return relay.__tmuxSends().slice(from).filter(c => c.includes(relay.AUTONOMY_NUDGE_MESSAGE));
+}
+
+test('#5281 an unattended question gets exactly one autonomy reminder', () => {
+  const relay = loadRelay({ backend: 'goose', cliStates: [QUESTION_PANE, QUESTION_PANE], attachedClients: false });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-question');
+    const before = relay.__tmuxSends().length;
+
+    relay.__crashTick();
+    assert.strictEqual(nudges(relay, before).length, 1, 'the first tick reminds it to proceed');
+    assert.strictEqual(relay.__sent.filter(m => m.status === 'blocked_on_human').length, 0,
+      'nobody is attached to be blocked on, so the first tick does not raise attention');
+
+    relay.__crashTick();
+    assert.strictEqual(nudges(relay, before).length, 1,
+      'a question re-asked after the reminder is one the agent cannot answer — do not loop');
+    const blocked = relay.__sent.filter(m => m.status === 'blocked_on_human');
+    assert.strictEqual(blocked.length, 1, 'from the second tick on, behaviour is exactly today\'s');
+    assert.strictEqual(blocked[0].attention, true);
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_complete').length, 0,
+      'a blocked pane must never be booked as a completion, nudged or not');
+    assert.ok(relay.getCurrentTask(), 'the task stays active');
+  } finally { teardown(relay); }
+});
+
+test('#5281 the budget is per task, not per process', () => {
+  // Driven through the REAL lifecycle — ask, finish, get assigned again —
+  // rather than by calling the reset directly, so that a change which dropped
+  // resetAutonomyNudgeState() from the task-start path would fail here.
+  const DONE_PANE = [
+    '● Done — opened https://github.com/kubestellar/hive/pull/9999',
+    '',
+    '✻ Cogitated for 3m 30s',
+    '',
+    '❯ ',
+    '  ⏵⏵ auto mode on (shift+tab to cycle)',
+  ].join('\n');
+  let pane = QUESTION_PANE;
+  const relay = loadRelay({ backend: 'claude', paneText: () => pane, attachedClients: false });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-first');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    relay.__crashTick();
+    assert.strictEqual(nudges(relay, before).length, 1, 'one reminder for the first task');
+
+    pane = DONE_PANE;
+    relay.__crashTick();
+    assert.ok(!relay.getCurrentTask(), 'the first task should have completed');
+
+    // A fresh task must get its own reminder — a previous task's spent budget
+    // denying this one is the same bug #5094 fixed for the retry budget.
+    pane = QUESTION_PANE;
+    assignTask(relay, 't-second');
+    const mid = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.strictEqual(nudges(relay, mid).length, 1, 'the next task gets its own one-shot');
+  } finally { teardown(relay); }
+});
+
+test('#5281 an attached pane is never nudged', () => {
+  const relay = loadRelay({ backend: 'goose', cliStates: [QUESTION_PANE, QUESTION_PANE], attachedClients: true });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-attached-question');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.strictEqual(nudges(relay, before).length, 0,
+      'someone is there to answer — do not type over them');
+    const blocked = relay.__sent.filter(m => m.status === 'blocked_on_human');
+    assert.strictEqual(blocked.length, 1, 'and the attention report is unchanged');
+    assert.strictEqual(blocked[0].attention, true);
+  } finally { teardown(relay); }
+});
+
+test('#5281 a login pane is never nudged, even when it is phrased as a question', () => {
+  // #4400: only a human can log in, so typing the reminder here would put the
+  // literal string into a /login flow.
+  //
+  // The second case is the one that makes the explicit login veto load-bearing
+  // rather than decorative. A bare 401 pane is already not a question, so the
+  // reason classifier alone would refuse it; a 401 whose next line ASKS
+  // something classifies as a perfectly ordinary question, and only the
+  // paneShowsLoginRequiredError check stops it being nudged.
+  const cases = {
+    'bare 401': '● Please run /login · API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth token has expired"}}\n\n❯ \n',
+    '401 phrased as a question': [
+      '● Please run /login · API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth token has expired"}}',
+      'Would you like to log in now?',
+      '❯ ',
+    ].join('\n'),
+  };
+  for (const [name, loginPane] of Object.entries(cases)) {
+    const relay = loadRelay({ backend: 'claude', paneText: loginPane, attachedClients: false });
+    try {
+      assert.strictEqual(relay.classifyTmuxPane(loginPane), relay.PANE_STATE_BLOCKED_ON_HUMAN, name);
+      relay.setCliReady(true);
+      assignTask(relay, `t-login-${name.replace(/\W+/g, '-')}`);
+      const before = relay.__tmuxSends().length;
+      relay.__crashTick();
+      assert.strictEqual(nudges(relay, before).length, 0, `${name} must never be nudged`);
+      assert.strictEqual(relay.__sent.filter(m => m.status === 'blocked_on_human').length, 1, name);
+    } finally { teardown(relay); }
+  }
+});
+
+test('#5281 human-required prompts are never nudged', () => {
+  // Each of these is a pane where typing prose is actively harmful: it would be
+  // submitted as a credential, or would answer a trust/permission decision the
+  // agent is not entitled to make.
+  const panes = {
+    'credential entry': 'Paste your API key to continue:\n> \n',
+    'folder trust': 'Do you trust this folder?\n> \n',
+    'permission prompt': 'Allow Claude to run this command?\n> \n',
+    'consent': 'This action requires your approval before continuing.\n> \n',
+  };
+  for (const [name, pane] of Object.entries(panes)) {
+    const relay = loadRelay({ backend: 'goose', cliStates: [pane, pane], attachedClients: false });
+    try {
+      assert.strictEqual(relay.classifyBlockedOnHumanReason(pane), relay.BLOCKED_REASON_HUMAN_REQUIRED,
+        `${name} must classify as human-required`);
+      relay.setCliReady(true);
+      assignTask(relay, `t-${name.replace(/\s+/g, '-')}`);
+      const before = relay.__tmuxSends().length;
+      relay.__crashTick();
+      assert.strictEqual(nudges(relay, before).length, 0, `${name} must never be nudged`);
+      assert.strictEqual(relay.__sent.filter(m => m.status === 'blocked_on_human').length, 1,
+        `${name} must still report blocked_on_human`);
+    } finally { teardown(relay); }
+  }
+});
+
+test('#5281 the human-required veto beats a trailing question mark anywhere in the window', () => {
+  // The precedence rule, and the reason the veto reads the whole recent window:
+  // a trust dialog renders its heading a few lines up while the cursor line is
+  // an innocent-looking question. Classifying on the cursor line alone would
+  // nudge it.
+  const pane = [
+    'Confirm folder trust',
+    'This folder has not been opened before.',
+    '',
+    'Do you want to proceed?',
+    '> ',
+  ].join('\n');
+  const relay = loadRelay({ backend: 'goose', cliStates: [pane, pane], attachedClients: false });
+  try {
+    assert.strictEqual(relay.classifyBlockedOnHumanReason(pane), relay.BLOCKED_REASON_HUMAN_REQUIRED,
+      'when in doubt, human-required — waiting is cheaper than a wrong answer');
+    relay.setCliReady(true);
+    assignTask(relay, 't-trust-question');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.strictEqual(nudges(relay, before).length, 0);
+  } finally { teardown(relay); }
+});
+
+test('#5281 a numbered menu is left in today\'s behaviour, deliberately', () => {
+  // Pinned rather than implemented: a menu TUI may read typed text as a
+  // selection filter rather than as chat input, so nudging one needs Escape
+  // handling this version does not attempt. If that changes, this test is the
+  // thing that should be rewritten, not deleted.
+  // Worded to match the shipping hasNumberedMenu detector: a choose/select
+  // lead-in, a menu-shaped line above the prompt, and two or more numbered
+  // options.
+  const menuPane = [
+    'Please choose how to continue:',
+    '',
+    '❯ 1. Rebase onto main',
+    '  2. Merge main in',
+    '  3. Leave it alone',
+    '',
+    '> ',
+  ].join('\n');
+  const relay = loadRelay({ backend: 'goose', cliStates: [menuPane, menuPane], attachedClients: false });
+  try {
+    assert.strictEqual(relay.classifyBlockedOnHumanReason(menuPane), relay.BLOCKED_REASON_MENU);
+    relay.setCliReady(true);
+    assignTask(relay, 't-menu');
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();
+    assert.strictEqual(nudges(relay, before).length, 0, 'menus are out of scope for the nudge');
+    assert.strictEqual(relay.__sent.filter(m => m.status === 'blocked_on_human').length, 1,
+      'and they keep reporting exactly as they do today');
+  } finally { teardown(relay); }
+});
+
+test('#5281 an elicitation form and a y/N both count as questions', () => {
+  const cases = {
+    'elicitation form': 'Extension needs some information to proceed:\n\n  Project name: my-service\n  Region:       us-east-1\n\n> Enter to send\n',
+    'y/N confirmation': 'Overwrite the existing branch? [y/N]\n> \n',
+  };
+  for (const [name, pane] of Object.entries(cases)) {
+    const relay = loadRelay({ backend: 'goose', cliStates: [pane, pane], attachedClients: false });
+    try {
+      assert.strictEqual(relay.classifyBlockedOnHumanReason(pane), relay.BLOCKED_REASON_QUESTION, name);
+      relay.setCliReady(true);
+      assignTask(relay, `t-${name.replace(/\W+/g, '-')}`);
+      const before = relay.__tmuxSends().length;
+      relay.__crashTick();
+      assert.strictEqual(nudges(relay, before).length, 1, `${name} should be nudged`);
+    } finally { teardown(relay); }
+  }
+});
+
+test('#5281 an unblocked pane classifies as no reason at all', () => {
+  const relay = loadRelay({ backend: 'goose' });
+  try {
+    assert.strictEqual(relay.classifyBlockedOnHumanReason('Done — opened a PR.\n> \n'), null);
+    assert.strictEqual(relay.classifyBlockedOnHumanReason(''), null);
+  } finally { teardown(relay); }
+});
+
+test('#5281 the reminder carries no shell metacharacters', () => {
+  // tmuxSendNudge interpolates this into a single-quoted `send-keys -l '...'`.
+  // A quote or a metacharacter here would be a command-injection shaped bug,
+  // not a typo, so the constraint is pinned rather than trusted.
+  const relay = loadRelay({ backend: 'goose' });
+  try {
+    assert.match(relay.AUTONOMY_NUDGE_MESSAGE, /^[A-Za-z0-9 ,.]+$/,
+      `the nudge text must stay trivially quotable, got: ${relay.AUTONOMY_NUDGE_MESSAGE}`);
+  } finally { teardown(relay); }
+});
+
+test('#5281 a failed send still spends the budget', () => {
+  // A send that throws has already disturbed the pane. Retrying it every tick
+  // is the loop the one-shot budget exists to prevent.
+  const relay = loadRelay({ backend: 'goose', cliStates: [QUESTION_PANE, QUESTION_PANE], attachedClients: false });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-send-fails');
+    const origWarn = console.error;
+    console.error = () => {};
+    try {
+      relay.__failNextNudge();
+      relay.__crashTick();
+      relay.__crashTick();
+    } finally { console.error = origWarn; }
+    assert.strictEqual(nudges(relay).length, 1,
+      'the send was attempted exactly once and not retried on the next tick');
+    assert.strictEqual(relay.__sent.filter(m => m.status === 'blocked_on_human').length, 2,
+      'both ticks fell through to today\'s report');
   } finally { teardown(relay); }
 });
 


### PR DESCRIPTION
## Summary

When a contributor pauses to ask a question — "which approach?", a y/N, an elicitation form — the relay detects it, reports `blocked_on_human` with `attention`, and stops. **That is detection without recovery.** An attention flag only helps someone who is watching something, and a contributor run by a user who never attaches to tmux is a supported way to run one. For that user every question costs 20–30 minutes and a failed task — even though the task prompt already told the agent to decide for itself.

An agent that stops to ask is an agent that forgot its standing instructions, and a one-line reminder is usually all it takes. A human types exactly that today. Now the relay can, when no human is there to.

## What is and is not nudgeable

The dangerous half is telling a question apart from a prompt only a person can answer. `BLOCKED_ON_HUMAN` conflated the two and the handler received only the state, not the reason — so `classifyBlockedOnHumanReason` now returns:

| Reason | Nudged? | Why |
|---|---|---|
| `question` — plain `?`, y/N, elicitation form | **yes** | the agent forgot it was told to decide |
| `menu` — numbered menu | no, pinned by test | a menu TUI may read typed text as a *selection filter*, not chat input; covering it needs Escape handling this doesn't attempt |
| `human-required` — login, credential, trust/consent, permission | **never** | typing prose here submits it as a password, or answers a trust decision the agent isn't entitled to make |

`paneLooksBlockedOnHuman` is now *derived* from the classifier, so there's exactly one definition of "blocked" and its answer is unchanged.

**Human-required is a veto, not a detector**, and it reads the whole recent window rather than only the line above the cursor. A trust dialog renders its heading a few lines up while the cursor line is an innocent `Do you want to proceed?` — classifying on the cursor line alone would nudge it. Widening the window can only move a pane from *question* to *human-required*, never make an unblocked pane blocked, because `blocked` is still computed exactly as before. When in doubt, human-required: waiting costs 30 minutes, a wrong nudge costs a credential prompt answered with prose.

## Bounds

One shot per task, reset at task start beside the #5094 retry budget. A question re-asked *after* being told to proceed autonomously is one the agent genuinely cannot answer, and re-nudging would loop to the max-duration ceiling.

The budget is spent **before** the send — a send that throws has already disturbed the pane, and retrying every tick is the loop the budget exists to prevent. Once spent, every later tick is byte-for-byte today's behaviour: `blocked_on_human`, `attention`, stall backstop, max duration.

Uses `tmuxSendNudge`, not `tmuxSendKeys`, for the #5094 reason — the task-prompt path carries `/clear` and restart machinery that would destroy the context being rescued. The message is letters, spaces and one comma by construction, since it's interpolated into a single-quoted `send-keys`; a metacharacter there is a command-injection shaped bug, not a typo, so there's a test pinning it.

**One honest cost:** typing into the pane resets the stall fingerprint, so a nudged task can spend up to one extra stall window before the backstop fires. That's inherent to typing, shared with the existing retry nudge, and `MAX_TASK_DURATION_MS` still bounds it.

## Relationship to #5277 — please read

Constraint 2 asks that the presence check be factored so both nudges share it. **`paneHasPresentHuman()` is that seam.**

On this branch it is the bare attached check, which is what `v4` has. [#5287](https://github.com/kubestellar/hive/pull/5287) (open) replaces that with a recency test on tmux's `client_activity`, because a dashboard tab left open is a connected client and not a person. When it lands, this body becomes `return tmuxSessionHumanPresence().active;` — **that one line is the whole follow-up**, and both nudges inherit it.

Deliberately **not** stacked on that branch: this is independently mergeable, touches no line #5287 touches (so no conflict either merge order), and the issue's own AC says *"per the #5277-style presence test, once available"*. The cost is that until both land, a left-open dashboard tab suppresses this nudge too. Stating that plainly rather than hiding it — if you'd prefer this stacked instead, say so and I'll rebase.

## Verification

`211/211` relay tests. Mutation-checked **nine ways**:

| Mutant | Caught by |
|---|---|
| feature removed | 4 tests incl. both existing blocked-pane tests |
| one-shot budget removed | `exactly one autonomy reminder`, `failed send`, + both existing |
| presence guard removed | `an attached pane is never nudged` |
| login veto removed | `a login pane is never nudged…` |
| human-required veto removed | `human-required prompts are never nudged` |
| veto narrowed to the cursor line | `the veto beats a trailing question mark anywhere in the window` |
| menus made nudge-eligible | `a numbered menu is left in today's behaviour` |
| per-task reset removed | `the budget is per task, not per process` |
| budget spent after the send | `a failed send still spends the budget` |

**The login-veto mutant initially survived.** A bare 401 pane is already not a question, so the classifier alone refused it and the explicit check was decorative. The test now *also* covers a 401 whose next line asks `Would you like to log in now?` — which classifies as an ordinary question and is caught **only** by that veto. That is precisely the case the issue warned about: typing the reminder into a `/login` flow.

`the budget is per task` drives the **real** lifecycle — ask, finish, get reassigned — rather than calling the reset directly, so dropping `resetAutonomyNudgeState()` from the task-start path fails it.

### Two existing tests changed meaning

`blocked interactive panes report attention…` and `goose elicitation form is reported as blocked…` were unattended question panes, which is exactly what this feature changes. They now tick twice — still asserting **never a completion** and **task stays active**, which is what they exist for — and additionally pin that the report arrives once the one-shot is spent. Updated, not weakened.

**Pre-existing test-environment note:** `a relaunch cds somewhere resolvable before starting the CLI` fails when `HIVE_AGENT_CWD` is set in the runner's environment (it asserts behaviour for that var being *unset*). Unrelated and untouched; all counts above are under `env -u HIVE_AGENT_CWD`.

## Acceptance criteria

- [x] Unattended question / y-N / elicitation form → reminded once; a turn that resumes is classified normally from there
- [x] Login, credential-entry, trust/consent and 401 panes are never nudged, even unattended
- [x] Attached pane never nudged; `blocked_on_human` + `attention` unchanged there
- [x] At most once per task; after it, behaviour is today's
- [x] A nudged task that still ends blocked is reported blocked/failed as today — never a completion
- [x] Tests cover question → one nudge; second question same task → no second nudge; login/credential → no nudge; attached → no nudge; numbered menu → pinned explicitly

Fixes #5281.

— hive: backend=claude model=claude-opus-5
