### PR TITLE
🐛 fix(notice): strip the one trailing space CI's generator does not emit

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4698,7 +4698,7 @@ Source:   https://github.com/natefinch/lumberjack/blob/v2.2.1/LICENSE
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Nate Finch 
+Copyright (c) 2014 Nate Finch
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Every open PR is red on `notice-drift`, and the whole diff is one space

Including PRs that touch **no Go code at all** — #5274 changes a single workflow YAML file and cannot affect the module graph.

CI's diff:

```
-Copyright (c) 2014 Nate Finch·
+Copyright (c) 2014 Nate Finch
```

`v4`'s committed `NOTICE` carries a trailing space on line 4701. CI's generator does not produce it.

## The generator is not byte-reproducible across environments

I regenerated `NOTICE` locally from clean `v4` with the pinned toolchain: my run **emits** the trailing space, CI's **does not**. So the committed file always matches whoever regenerated it last and fails for everyone else — and because the check is byte-exact, one space fails the whole gate.

## This is #5064, and my correction to it was wrong

I filed #5064 reporting exactly this. Then I hit a diff I read backwards, concluded CI *added* the whitespace rather than stripping it, and posted a correction saying the generator was fine and the real gap was only a missing warning against post-processing.

The first report was right. Today's recurrence — on a PR that changes one YAML file — proves it: nothing about #5274 could produce a NOTICE diff, so the disagreement is environmental.

## This PR

Strips the single trailing space so `v4` matches CI's output, unblocking every open PR. It does not fix the underlying non-reproducibility — #5064 should be reopened for that, and the durable fix is likely normalising trailing whitespace **inside** the generator so both environments agree by construction.