### PR TITLE
🐛 fix(ci): classify docs-link-check.yml in the release-lines manifest

### DIFF
--- a/.github/release-lines.yml
+++ b/.github/release-lines.yml
@@ -46,6 +46,11 @@ pinned:
   # release lines and nothing else: a feature branch gets the same gate through
   # `pull_request`, and running it on every pushed branch would burn runner
   # minutes re-scanning code that has not reached a release line.
+  # Added with the docs link checker (#5278), after the v2 line was sunset
+  # (#5030-era). It gates src/docs/ links on v4 only; v2 is excluded rather
+  # than back-filled, because the workflow never ran there and adding it
+  # would gate a line no longer taking doc changes.
+  docs-link-check.yml: [-v2]
   go-security-analysis.yml: []
   podman-arm64-lane.yml: []
   podman-contract.yml: []


### PR DESCRIPTION
## `release-lines-in-sync` fails on `v4` itself

Every open PR inherits it. Running the guard against a clean `v4` checkout:

```
FAIL: docs-link-check.yml:26 branches: workflow has a branch filter (v4)
      but is not classified in .github/release-lines.yml
RESULT: FAIL — hand-written branch lists are out of sync
```

#5278 added `.github/workflows/docs-link-check.yml` with `branches: [v4]` on both `push` and `pull_request` and did not classify it in the manifest. The guard exists precisely to catch a workflow whose branch list drifts from the declared release lines — a workflow that silently stops running reports green forever (#4339) — so it correctly refused one it had never been told about.

## Why `[-v2]` and not `[]`

The plain `[]` form means "covers every declared release line", which makes the guard demand a `v2` trigger:

```
FAIL: has [v4], expected [v2,v4] — missing: v2
```

The link checker was added after `v2` was sunset and has never run there. Back-filling it would gate a line no longer taking doc changes. `-v2` is an explicit exclusion, the same form `scorecard.yml: [main, -v2]` already uses.

Guard now passes:

> RESULT: PASS — every pinned workflow and hand-written list covers the declared release lines.

## Third branch-wide break today

After the duplicate test (#5279) and the `NOTICE` trailing space (#5294). In each case PRs were red for a condition on `v4`, not anything in their own diff — worth noting as a pattern, since diagnosing from the failing PR rather than the branch sends you the wrong way every time.