### PR TITLE
🐛 fix(governor): the login detector must consult the credential, not just the pane (#5291)

### DIFF
--- a/src/cmd/hive/login_scan_decision_test.go
+++ b/src/cmd/hive/login_scan_decision_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// The shipping default patterns, resolved the way a real hive resolves them
+// (config.Load applies the defaults), so these tests exercise what actually
+// runs in production rather than a convenient stand-in that could drift from
+// it. defaultLoginPatterns is unexported, and loading is the supported way to
+// see the applied set.
+func defaultLoginRegexps(t *testing.T) []*regexp.Regexp {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hive.yaml")
+	minimal := "project:\n  name: login-scan-test\n  org: kubestellar\n" +
+		"github:\n  token: t-not-a-real-token\n" +
+		"agents:\n  supervisor:\n    backend: claude\n"
+	if err := os.WriteFile(path, []byte(minimal), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	patterns := cfg.Governor.Sensing.LoginPatterns
+	if len(patterns) == 0 {
+		t.Fatal("the default config carries no login patterns — this test would prove nothing")
+	}
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		re, err := regexp.Compile("(?i)" + p)
+		if err != nil {
+			t.Fatalf("default pattern %q does not compile: %v", p, err)
+		}
+		compiled = append(compiled, re)
+	}
+	return compiled
+}
+
+// loginResiduePane is the shape observed in kubestellar/hive#5291: the pane tail
+// still carries login-flow chrome minutes AFTER the operator's /login restored a
+// valid credential.
+var loginResiduePane = strings.Join([]string{
+	"╭──────────────────────────────────────────────╮",
+	"│  Please run /login to authenticate            │",
+	"╰──────────────────────────────────────────────╯",
+	"",
+	"Login successful. Press Enter to continue…",
+	"",
+	"❯ ",
+}, "\n")
+
+// TestLoginScanDecision_ValidCredentialNeverPauses is the issue's primary
+// acceptance criterion, and the regression for the reported incident: the same
+// pane text decides differently depending on whether the credential is good.
+func TestLoginScanDecision_ValidCredentialNeverPauses(t *testing.T) {
+	compiled := defaultLoginRegexps(t)
+
+	// Valid credential: never a pause, no matter how many cycles see it.
+	for _, sightings := range []int{1, 2, 3, 99} {
+		action, re := loginScanDecision("claude", loginResiduePane, compiled, true, sightings)
+		if action != loginScanDeferAuthenticated {
+			t.Fatalf("sightings=%d: got action %v, want defer-authenticated — a valid credential must never be paused", sightings, action)
+		}
+		if re == nil {
+			t.Fatal("the matched pattern must be reported so the log can explain the decision")
+		}
+	}
+
+	// Same text, credential NOT provable: still paused, exactly as today, once
+	// the sighting has persisted.
+	if action, _ := loginScanDecision("claude", loginResiduePane, compiled, false, loginPauseMinSightings); action != loginScanPause {
+		t.Fatalf("invalid credential + login prompt: got %v, want pause", action)
+	}
+}
+
+// TestLoginScanDecision_StreakDefersTheFirstSighting covers the secondary
+// hardening: one cycle is not evidence. The 3s pane poller already requires
+// three consecutive sightings for the far cheaper action of a restart.
+func TestLoginScanDecision_StreakDefersTheFirstSighting(t *testing.T) {
+	compiled := defaultLoginRegexps(t)
+	for s := 1; s < loginPauseMinSightings; s++ {
+		if action, _ := loginScanDecision("claude", loginResiduePane, compiled, false, s); action != loginScanDeferStreak {
+			t.Fatalf("sightings=%d: got %v, want defer-streak", s, action)
+		}
+	}
+	if action, _ := loginScanDecision("claude", loginResiduePane, compiled, false, loginPauseMinSightings); action != loginScanPause {
+		t.Fatalf("sightings=%d: got %v, want pause", loginPauseMinSightings, action)
+	}
+}
+
+// TestLoginScanDecision_UnrelatedPaneIsIgnored is the control: without it every
+// assertion above would also hold for a decision function that never matched.
+func TestLoginScanDecision_UnrelatedPaneIsIgnored(t *testing.T) {
+	compiled := defaultLoginRegexps(t)
+	working := strings.Join([]string{
+		"● Opened https://github.com/kubestellar/hive/pull/1234",
+		"",
+		"✻ Cogitated for 2m 10s",
+		"",
+		"❯ ",
+	}, "\n")
+	for _, credentialValid := range []bool{true, false} {
+		if action, re := loginScanDecision("claude", working, compiled, credentialValid, 99); action != loginScanIgnore || re != nil {
+			t.Fatalf("credentialValid=%v: got (%v,%v), want ignore/nil", credentialValid, action, re)
+		}
+	}
+}
+
+// TestLoginScanDecision_BlockingPromptStandsDown pins the pre-existing modal
+// stand-down through the extracted decision, so the refactor cannot drop it.
+// Pausing for a folder-trust modal cancels the watcher that would answer it.
+func TestLoginScanDecision_BlockingPromptStandsDown(t *testing.T) {
+	compiled := defaultLoginRegexps(t)
+	trustPane := strings.Join([]string{
+		"Do you trust the files in this folder?",
+		"Please run /login after continuing",
+		"❯ 1. Yes, proceed",
+		"  2. No, exit",
+	}, "\n")
+	if action, _ := loginScanDecision("copilot", trustPane, compiled, false, 99); action != loginScanIgnore {
+		t.Fatalf("a startup modal must not be treated as a login problem, got %v", action)
+	}
+}
+
+// --- the sighting tracker ---------------------------------------------------
+
+func TestLoginSightingTracker_AccumulatesAndResets(t *testing.T) {
+	tr := newLoginSightingTracker()
+
+	if got := tr.observe("supervisor", true); got != 1 {
+		t.Fatalf("first sighting = %d, want 1", got)
+	}
+	if got := tr.observe("supervisor", true); got != 2 {
+		t.Fatalf("second consecutive sighting = %d, want 2", got)
+	}
+	// A clean cycle breaks the streak — the whole point of "consecutive".
+	if got := tr.observe("supervisor", false); got != 0 {
+		t.Fatalf("clean cycle = %d, want 0", got)
+	}
+	if got := tr.observe("supervisor", true); got != 1 {
+		t.Fatalf("after a clean cycle the count must restart, got %d", got)
+	}
+	// Agents are counted independently.
+	if got := tr.observe("quality", true); got != 1 {
+		t.Fatalf("a second agent must have its own count, got %d", got)
+	}
+
+	tr.forget("supervisor")
+	if got := tr.observe("supervisor", true); got != 1 {
+		t.Fatalf("forget must clear the count, got %d", got)
+	}
+}
+
+// TestLoginSightingTracker_RetainDropsAbsentAgents keeps a long-lived process
+// from accumulating a map entry per agent that ever existed.
+func TestLoginSightingTracker_RetainDropsAbsentAgents(t *testing.T) {
+	tr := newLoginSightingTracker()
+	tr.observe("supervisor", true)
+	tr.observe("quality", true)
+
+	tr.retain(map[string]bool{"supervisor": true})
+	if len(tr.streak) != 1 {
+		t.Fatalf("retain left %d entries, want 1: %v", len(tr.streak), tr.streak)
+	}
+	if got := tr.observe("quality", true); got != 1 {
+		t.Fatalf("a dropped agent must start fresh, got %d", got)
+	}
+	if got := tr.observe("supervisor", true); got != 2 {
+		t.Fatalf("a retained agent must keep its count, got %d", got)
+	}
+}
+
+// TestLoginSightingTracker_NilFallsBackToSingleObservation pins what a missing
+// tracker means: the streak gate is disabled and the detector behaves as it did
+// before #5291. It must NOT mean "never pause".
+func TestLoginSightingTracker_NilFallsBackToSingleObservation(t *testing.T) {
+	var tr *loginSightingTracker
+	if got := tr.observe("supervisor", true); got < loginPauseMinSightings {
+		t.Fatalf("a nil tracker must not silently disable pausing, got %d", got)
+	}
+	if got := tr.observe("supervisor", false); got != 0 {
+		t.Fatalf("a clean pane must still read as no sighting, got %d", got)
+	}
+	// Must not panic.
+	tr.forget("supervisor")
+	tr.retain(map[string]bool{})
+}
+
+// TestLoginScanVerdict_NoMatchAlwaysIgnores pins the invariant the scan loop
+// relies on: a non-Ignore verdict implies a pattern was matched, so the logging
+// in each of the other branches can dereference it without a nil check.
+func TestLoginScanVerdict_NoMatchAlwaysIgnores(t *testing.T) {
+	for _, credentialValid := range []bool{true, false} {
+		for _, sightings := range []int{0, 1, loginPauseMinSightings, 99} {
+			if got := loginScanVerdict(false, credentialValid, sightings); got != loginScanIgnore {
+				t.Fatalf("no match (credentialValid=%v sightings=%d): got %v, want ignore",
+					credentialValid, sightings, got)
+			}
+		}
+	}
+}
+
+// TestLoginScanMatch_ReturnsThePatternItMatched keeps match and verdict honest
+// about each other: the loop advances the streak from this function's answer and
+// then logs the pattern it returned.
+func TestLoginScanMatch_ReturnsThePatternItMatched(t *testing.T) {
+	compiled := defaultLoginRegexps(t)
+	re := loginScanMatch("claude", loginResiduePane, compiled)
+	if re == nil {
+		t.Fatal("the residue pane carries a default login pattern and must match")
+	}
+	if !re.MatchString(loginResiduePane) {
+		t.Fatalf("returned pattern %q does not actually match the pane it was returned for", re.String())
+	}
+	if got := loginScanMatch("claude", "all quiet\n❯ ", compiled); got != nil {
+		t.Fatalf("a clean pane must match nothing, got %q", got.String())
+	}
+}

--- a/src/cmd/hive/login_scan_gates_test.go
+++ b/src/cmd/hive/login_scan_gates_test.go
@@ -35,7 +35,7 @@ func TestScanForLoginRequiredStandsDownWithoutUsablePatterns(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Must return without touching any of the nil collaborators.
 			scanForLoginRequired(context.Background(), loginScanConfig(tc.patterns),
-				nil, nil, nil, restoreTestLogger())
+				nil, nil, nil, restoreTestLogger(), nil)
 		})
 	}
 }
@@ -55,5 +55,5 @@ func TestScanForLoginRequiredMixedValidityPatternsReachesScanLoop(t *testing.T) 
 	// never executes. This still proves the function gets PAST the early
 	// "no usable patterns" return (which the panic-on-touch test above
 	// verifies happens for an all-invalid list) to the scan loop itself.
-	scanForLoginRequired(context.Background(), cfg, mgr, nil, nil, restoreTestLogger())
+	scanForLoginRequired(context.Background(), cfg, mgr, nil, nil, restoreTestLogger(), newLoginSightingTracker())
 }

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6259,7 +6259,7 @@ func runEvalCycle(
 	}
 
 	// Scan agent panes for login-required patterns and pause + notify if detected
-	scanForLoginRequired(ctx, cfg, agentMgr, notifier, dashSrv, logger)
+	scanForLoginRequired(ctx, cfg, agentMgr, notifier, dashSrv, logger, loginSightings)
 
 	// Epoch captured before reading agent/governor state so a mutation that
 	// lands mid-build (restart-count/budget reset) drops this snapshot instead
@@ -6702,6 +6702,173 @@ func loginCommandForBackend(backend string) string {
 	}
 }
 
+// loginScanAction is what the detector should do about one agent this cycle.
+type loginScanAction int
+
+const (
+	// loginScanIgnore: nothing that looks like a login problem, or a startup
+	// modal is on screen. Any sighting streak is cleared.
+	loginScanIgnore loginScanAction = iota
+	// loginScanDeferAuthenticated: the pane matched, but the backend credential
+	// is demonstrably valid, so this is residue or a stuck CLI — the manager's
+	// token-restart heal's case, not an operator's (kubestellar/hive#5291).
+	loginScanDeferAuthenticated
+	// loginScanDeferStreak: the pane matched and the credential is not provably
+	// good, but this is the first consecutive cycle to see it.
+	loginScanDeferStreak
+	// loginScanPause: pause the agent and page the operator.
+	loginScanPause
+)
+
+// loginPauseMinSightings is how many CONSECUTIVE governor cycles must see a
+// login pattern before the detector pauses (kubestellar/hive#5291).
+//
+// The manager's own pane poller learned this at its ~3s cadence, where a single
+// sighting restarted healthy agents; it now requires loginStreakRestartMin = 3.
+// The detector had no equivalent, and a pause is far more expensive than a
+// restart — it is sticky, it needs a human to undo, and it cancels the agent
+// context that hosts the heal. Two is deliberate rather than three: a governor
+// cycle is minutes, not seconds, so each extra cycle is real delay for a
+// genuine logout, and the credential gate above already covers the case this
+// backstops. It matters most for backends with no credential file this process
+// can check, where it is the only new protection.
+const loginPauseMinSightings = 2
+
+// loginSightingTracker counts CONSECUTIVE cycles in which each agent's pane
+// matched a login pattern. A clean cycle resets the count to zero, so a match
+// has to persist to accumulate — a single flicker never reaches the threshold.
+type loginSightingTracker struct {
+	mu     sync.Mutex
+	streak map[string]int
+}
+
+func newLoginSightingTracker() *loginSightingTracker {
+	return &loginSightingTracker{streak: map[string]int{}}
+}
+
+// loginSightings is the detector's process-scoped state. The governor cycle is
+// a function rather than an object, so the consecutive-sighting counts have to
+// outlive a single call; tests build their own tracker and pass it explicitly.
+var loginSightings = newLoginSightingTracker()
+
+// observe records this cycle's reading for one agent and returns the resulting
+// consecutive-sighting count (1 on the first sighting).
+func (t *loginSightingTracker) observe(agent string, matched bool) int {
+	if t != nil {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+	}
+	if t == nil {
+		// No tracker wired: behave as if every sighting is its own streak, which
+		// is exactly the pre-#5291 single-observation behaviour.
+		if matched {
+			return loginPauseMinSightings
+		}
+		return 0
+	}
+	if !matched {
+		delete(t.streak, agent)
+		return 0
+	}
+	t.streak[agent]++
+	return t.streak[agent]
+}
+
+// forget drops an agent's streak — on pause (it stops being scanned) and for
+// agents that are no longer present, so the map cannot grow without bound
+// across a long-lived process.
+func (t *loginSightingTracker) forget(agent string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.streak, agent)
+}
+
+// retain drops every agent not in the given set.
+func (t *loginSightingTracker) retain(present map[string]bool) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for name := range t.streak {
+		if !present[name] {
+			delete(t.streak, name)
+		}
+	}
+}
+
+// loginScanDecision is the detector's whole judgement about one agent, as a
+// pure function of what was observed. It exists apart from scanForLoginRequired
+// so the decision can be tested against real pane text without a tmux session,
+// a manager, or a governor cycle.
+//
+// sightings is the consecutive-cycle count INCLUDING this one.
+//
+// The credential gate is the fix for kubestellar/hive#5291: the detector used
+// to pause on pane text alone, and the pane during and just after an
+// interactive /login necessarily contains login-screen chrome — so it fired on
+// the evidence the operator's own fix had just produced, seven minutes after
+// the credential was already valid. Worse, Pause() cancels the agent context
+// and tears down the poller that hosts the token-restart heal (#4606), which is
+// the mechanism built for exactly "login prompt on screen, credential valid".
+// Pausing first therefore disabled the machinery that would have fixed the pane
+// it misread.
+//
+// Text matching cannot be narrowed out of this: two earlier fixes tried
+// (tail-only matching, then a tighter copilot pattern) and this incident is the
+// third false positive. The pane legitimately contains login text at the moment
+// the credential is freshest, so the credential has to be consulted.
+func loginScanDecision(
+	backend, paneText string,
+	compiled []*regexp.Regexp,
+	credentialValid bool,
+	sightings int,
+) (loginScanAction, *regexp.Regexp) {
+	matched := loginScanMatch(backend, paneText, compiled)
+	return loginScanVerdict(matched != nil, credentialValid, sightings), matched
+}
+
+// loginScanMatch reports which login pattern this pane trips, or nil for none.
+// Separate from the verdict so the scan loop can match ONCE and use the answer
+// both to advance the sighting streak and to decide.
+func loginScanMatch(backend, paneText string, compiled []*regexp.Regexp) *regexp.Regexp {
+	// Stand down while a startup-blocking modal (folder trust, codex update, …)
+	// is on screen: that is not a login problem, and pausing the agent for it
+	// cancels the trust-prompt watcher that would answer it — the deadlock that
+	// kept copilot agents "sitting at login prompt" through every operator
+	// re-login (kubestellar/hive, 2026-08-22). The watcher answers the modal
+	// within seconds; if a REAL login prompt follows, the next detector tick
+	// sees it on a clean pane.
+	if agent.PaneShowsBlockingPrompt(backend, paneText) {
+		return nil
+	}
+	for _, re := range compiled {
+		if re.MatchString(paneText) {
+			return re
+		}
+	}
+	return nil
+}
+
+// loginScanVerdict turns "what the pane showed" into "what to do". It returns
+// loginScanIgnore whenever matched is false, which is what lets the scan loop
+// rely on a non-Ignore verdict implying a non-nil pattern to log.
+func loginScanVerdict(matched, credentialValid bool, sightings int) loginScanAction {
+	if !matched {
+		return loginScanIgnore
+	}
+	if credentialValid {
+		return loginScanDeferAuthenticated
+	}
+	if sightings < loginPauseMinSightings {
+		return loginScanDeferStreak
+	}
+	return loginScanPause
+}
+
 // scanForLoginRequired checks each running agent's tmux pane output for login-required
 // patterns. When a match is found, the agent is paused and a notification is sent.
 func scanForLoginRequired(
@@ -6711,6 +6878,7 @@ func scanForLoginRequired(
 	notifier *notify.Notifier,
 	dashSrv *dashboard.Server,
 	logger *slog.Logger,
+	sightings *loginSightingTracker,
 ) {
 	patterns := cfg.Governor.Sensing.LoginPatterns
 	if len(patterns) == 0 {
@@ -6743,10 +6911,12 @@ func scanForLoginRequired(
 	// Same discipline as the poller's tail-only match (#4577).
 	const paneLines = 12
 	statuses := agentMgr.AllStatuses()
+	scanned := make(map[string]bool, len(statuses))
 	for name, proc := range statuses {
 		if proc.State != "running" {
 			continue
 		}
+		scanned[name] = true
 
 		output, err := agentMgr.GetOutput(name, paneLines)
 		if err != nil || len(output) == 0 {
@@ -6754,62 +6924,78 @@ func scanForLoginRequired(
 		}
 
 		joined := strings.Join(output, "\n")
+		backend := cfg.Agents[name].Backend
 
-		// Stand down while a startup-blocking modal (folder trust, codex
-		// update, …) is on screen: that is not a login problem, and pausing
-		// the agent for it cancels the trust-prompt watcher that would answer
-		// it — the deadlock that kept copilot agents "sitting at login prompt"
-		// through every operator re-login (kubestellar/hive, 2026-08-22). The
-		// watcher answers the modal within seconds; if a REAL login prompt
-		// follows, the next detector tick sees it on a clean pane.
-		if agent.PaneShowsBlockingPrompt(cfg.Agents[name].Backend, joined) {
+		// #5291: ask the CREDENTIAL, not just the pane. A valid credential plus
+		// a login prompt is the token-restart heal's case; only an invalid one
+		// needs a human.
+		credentialValid := agentMgr.AgentHasValidCredential(name)
+
+		// Match once. The streak has to reflect what the pane SHOWED, including
+		// on the cycles where a gate below declines to act on it, so the
+		// sighting is recorded before the verdict is taken.
+		re := loginScanMatch(backend, joined, compiled)
+		streak := sightings.observe(name, re != nil)
+
+		switch loginScanVerdict(re != nil, credentialValid, streak) {
+		case loginScanIgnore:
 			continue
-		}
+		case loginScanDeferAuthenticated:
+			// Logged at Info, not Warn: this is the detector working correctly,
+			// and it is the line that explains an agent staying up with login
+			// text on its pane.
+			logger.Info("login pattern matched but the backend credential is valid — leaving it to the token-restart heal",
+				"agent", name, "backend", backend, "pattern", re.String())
+			continue
+		case loginScanDeferStreak:
+			logger.Info("login pattern matched but not yet on enough consecutive cycles — deferring",
+				"agent", name, "backend", backend, "pattern", re.String(),
+				"sightings", streak, "required", loginPauseMinSightings)
+			continue
+		case loginScanPause:
+			logger.Warn("login required detected",
+				"agent", name,
+				"pattern", re.String(),
+				"sightings", streak,
+			)
+			sightings.forget(name)
 
-		for _, re := range compiled {
-			if re.MatchString(joined) {
-				logger.Warn("login required detected",
-					"agent", name,
-					"pattern", re.String(),
-				)
-
-				// Attempt a per-agent token re-cache BEFORE pausing. On an
-				// App-authenticated hive the likeliest cause of a "gh auth
-				// login" prompt is an expired scoped-token cache (#4072);
-				// re-minting it now means the operator's Resume immediately
-				// works instead of 401ing straight back into this pause.
-				// Best-effort: hives without App auth (or agents without a
-				// dedicated UID) simply skip it.
-				if refreshErr := agentMgr.RefreshAgentTokenFor(ctx, name); refreshErr == nil {
-					logger.Info("re-cached per-agent scoped token before login-detector pause", "agent", name)
-				}
-
-				// Pause the agent instead of restarting
-				if pauseErr := agentMgr.Pause(name, "login-detector", "login required detected"); pauseErr != nil {
-					logger.Warn("failed to pause agent after login detection",
-						"agent", name, "error", pauseErr)
-				} else {
-					dashSrv.AuditLog("system", "pause", "trigger=login-detector", name)
-				}
-
-				// Determine the login instruction based on the agent's backend
-				backend := cfg.Agents[name].Backend
-				loginCmd := loginCommandForBackend(backend)
-
-				notifier.Send(
-					fmt.Sprintf("\U0001F511 Login required: %s", name),
-					fmt.Sprintf(
-						"Agent '%s' needs authentication. Open the agent's terminal "+
-							"(tmux attach -t hive-%s) and run the login command for the CLI (%s). %s",
-						name, name, backend, loginCmd,
-					),
-					notify.PriorityHigh,
-				)
-
-				break // one match per agent is enough
+			// Attempt a per-agent token re-cache BEFORE pausing. On an
+			// App-authenticated hive the likeliest cause of a "gh auth
+			// login" prompt is an expired scoped-token cache (#4072);
+			// re-minting it now means the operator's Resume immediately
+			// works instead of 401ing straight back into this pause.
+			// Best-effort: hives without App auth (or agents without a
+			// dedicated UID) simply skip it.
+			if refreshErr := agentMgr.RefreshAgentTokenFor(ctx, name); refreshErr == nil {
+				logger.Info("re-cached per-agent scoped token before login-detector pause", "agent", name)
 			}
+
+			// Pause the agent instead of restarting
+			if pauseErr := agentMgr.Pause(name, "login-detector", "login required detected"); pauseErr != nil {
+				logger.Warn("failed to pause agent after login detection",
+					"agent", name, "error", pauseErr)
+			} else {
+				dashSrv.AuditLog("system", "pause", "trigger=login-detector", name)
+			}
+
+			// Determine the login instruction based on the agent's backend
+			loginCmd := loginCommandForBackend(backend)
+
+			notifier.Send(
+				fmt.Sprintf("\U0001F511 Login required: %s", name),
+				fmt.Sprintf(
+					"Agent '%s' needs authentication. Open the agent's terminal "+
+						"(tmux attach -t hive-%s) and run the login command for the CLI (%s). %s",
+					name, name, backend, loginCmd,
+				),
+				notify.PriorityHigh,
+			)
 		}
 	}
+	// Agents that vanished (removed from config, stopped) must not keep a
+	// streak alive in the map for the life of the process.
+	sightings.retain(scanned)
 }
 
 func convertKnowledgeLayers(cfgLayers []config.KnowledgeLayer) []knowledge.LayerConfig {

--- a/src/pkg/agent/authprobe.go
+++ b/src/pkg/agent/authprobe.go
@@ -287,13 +287,14 @@ func (m *Manager) AgentAuthState(agentName string, uid int, backend string, runn
 		return false, false
 	}
 
-	// (4) FILE PROBE, agent-own home first, shared legacy path second.
+	// (4) FILE PROBE, agent-own home first, shared legacy path second. The
+	// POSITIVE half lives in credentialFileProves so the login detector can ask
+	// the same question without inheriting rules 1-3 (#5291).
+	proven := m.credentialFileProves(agentName, uid, backend)
 	switch backend {
 	case "claude":
-		for _, p := range agentClaudeCredentialPaths(agentName, uid, backend) {
-			if claude.HasValidToken(p) {
-				return true, true
-			}
+		if proven {
+			return true, true
 		}
 		// A found+valid token is positive proof (above). Its ABSENCE, however, is
 		// NOT proof of "needs login" for Claude: unlike copilot/codex, Claude can
@@ -310,29 +311,13 @@ func (m *Manager) AgentAuthState(agentName string, uid int, backend string, runn
 		// pane-scan needsLogin signal at (3), which outranks this.
 		return false, false
 	case "copilot":
-		m.mu.RLock()
-		tok := m.copilotAuthToken
-		m.mu.RUnlock()
-		if tok != "" {
+		if proven {
 			return true, true
-		}
-		if _, err := os.Stat(copilotUserTokenProbePath); err == nil {
-			return true, true
-		}
-		for _, p := range agentCopilotConfigPaths(agentName, uid, backend) {
-			if copilotCredentialFileHasTokens(p) {
-				return true, true
-			}
 		}
 		return false, true
 	case "codex":
-		if codexEnvHasCredentials() {
+		if proven {
 			return true, true
-		}
-		for _, p := range agentCodexAuthPaths(agentName, uid, backend) {
-			if codexAuthFileHasCredentials(p) {
-				return true, true
-			}
 		}
 		return false, true
 	default:
@@ -359,4 +344,94 @@ func (m *Manager) AgentAuthAvailable(agentName string) (available, known bool) {
 	needsLogin := proc.NeedsLogin
 	proc.paneMu.RUnlock()
 	return m.AgentAuthState(agentName, proc.UID, backend, proc.State == StateRunning, needsLogin)
+}
+
+// credentialFileProves answers ONLY the positive half of the file probe: is
+// there, right now, on-disk (or in-process) evidence that this agent's backend
+// is authenticated?
+//
+// It is deliberately one-directional. `false` means "no proof", NOT "logged
+// out" — Claude in particular can be authenticated with no credentials file
+// this process can read (a live in-memory session, a per-UID HOME, a keychain),
+// which is why AgentAuthState reports UNKNOWN rather than needs-login when this
+// comes back false for claude.
+//
+// Split out of AgentAuthState for kubestellar/hive#5291. The login detector
+// needs this question and must NOT get AgentAuthState's answer, whose
+// precedence rules are built for a dashboard badge: rule 2 short-circuits to
+// "unknown" for any RUNNING agent (the detector only ever scans running
+// agents), and rule 3 lets the pane's own login text outrank the credential
+// file (which is precisely the evidence the detector must not trust on its
+// own). Sharing the code rather than copying it keeps the two answers from
+// drifting the way #4699 describes.
+func (m *Manager) credentialFileProves(agentName string, uid int, backend string) bool {
+	switch backend {
+	case "claude":
+		for _, p := range agentClaudeCredentialPaths(agentName, uid, backend) {
+			if claude.HasValidToken(p) {
+				return true
+			}
+		}
+	case "copilot":
+		if m != nil {
+			m.mu.RLock()
+			tok := m.copilotAuthToken
+			m.mu.RUnlock()
+			if tok != "" {
+				return true
+			}
+		}
+		if _, err := os.Stat(copilotUserTokenProbePath); err == nil {
+			return true
+		}
+		for _, p := range agentCopilotConfigPaths(agentName, uid, backend) {
+			if copilotCredentialFileHasTokens(p) {
+				return true
+			}
+		}
+	case "codex":
+		if codexEnvHasCredentials() {
+			return true
+		}
+		for _, p := range agentCodexAuthPaths(agentName, uid, backend) {
+			if codexAuthFileHasCredentials(p) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AgentHasValidCredential reports whether this agent's backend is DEMONSTRABLY
+// authenticated right now (kubestellar/hive#5291).
+//
+// Positive evidence only, and that asymmetry is the whole point. The login
+// detector uses it to decide when NOT to pause: proof of a working credential
+// means a login prompt on screen is residue or a stuck CLI, which is the
+// token-restart heal's job, not an operator's. Anything less than proof —
+// including "we cannot check this backend at all" — returns false and leaves
+// the detector's existing behaviour untouched.
+//
+// One honest limitation: only claude's credential carries an expiry this can
+// verify (claude.HasValidToken). Copilot and codex are checked for the PRESENCE
+// of tokens, so a stale-but-present copilot token reads as valid here. That is
+// the same trade the manager's own token-restart heal already makes in
+// configHasTokens(), and it fails in the safe direction for this caller: the
+// heal restarts the CLI, which is a recovery attempt, rather than the detector
+// pausing the agent, which is not.
+func (m *Manager) AgentHasValidCredential(agentName string) bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	proc := m.agents[agentName]
+	m.mu.RUnlock()
+	if proc == nil {
+		return false
+	}
+	backend := proc.Config.Backend
+	if proc.BackendOverride != "" {
+		backend = proc.BackendOverride
+	}
+	return m.credentialFileProves(agentName, proc.UID, backend)
 }

--- a/src/pkg/agent/authprobe_credential_gate_test.go
+++ b/src/pkg/agent/authprobe_credential_gate_test.go
@@ -1,0 +1,198 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// writeExpiredClaudeCreds writes a credentials.json whose OAuth token expired
+// in the past — the shape the login detector MUST still pause on.
+func writeExpiredClaudeCreds(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := map[string]any{
+		"claudeAiOauth": map[string]any{
+			"accessToken": "stale-token",
+			"expiresAt":   time.Now().Add(-1 * time.Hour).UnixMilli(),
+		},
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestCredentialFileProves_ClaudeExpiryIsHonoured is the core of the #5291 gate:
+// the detector may only skip a pause on PROOF of a working credential, and for
+// claude that means an unexpired token — the one backend where expiry is
+// actually knowable from the file.
+func TestCredentialFileProves_ClaudeExpiryIsHonoured(t *testing.T) {
+	emptySharedPaths(t)
+	m := &Manager{}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cred := filepath.Join(home, ".claude", ".credentials.json")
+
+	if m.credentialFileProves("supervisor", 0, "claude") {
+		t.Fatal("no credential file anywhere must not read as proof")
+	}
+
+	writeExpiredClaudeCreds(t, cred)
+	if m.credentialFileProves("supervisor", 0, "claude") {
+		t.Fatal("an EXPIRED token must not read as proof — that agent genuinely needs a login")
+	}
+
+	writeClaudeCreds(t, cred)
+	if !m.credentialFileProves("supervisor", 0, "claude") {
+		t.Fatal("a fresh token is exactly the proof the detector must stand down for")
+	}
+}
+
+// TestCredentialFileProves_SharedPathCountsForTheAgent reproduces the incident's
+// own shape: the operator's /login refreshed the SHARED credential, and the
+// agent whose pane still showed login chrome must be recognised as
+// authenticated through that shared file.
+func TestCredentialFileProves_SharedPathCountsForTheAgent(t *testing.T) {
+	emptySharedPaths(t)
+	m := &Manager{}
+	t.Setenv("HOME", t.TempDir()) // the agent's own home is empty
+
+	if m.credentialFileProves("supervisor", 0, "claude") {
+		t.Fatal("precondition: nothing should be proven yet")
+	}
+	writeClaudeCreds(t, sharedClaudeCredentialPath)
+	if !m.credentialFileProves("supervisor", 0, "claude") {
+		t.Fatal("the shared credential the operator just refreshed must count for the agent")
+	}
+}
+
+// TestCredentialFileProves_UncheckableBackendsStayUnproven pins the deliberate
+// limit: a backend with no credential file this process can read yields no
+// proof, so the detector keeps its existing behaviour for it rather than
+// silently never pausing.
+func TestCredentialFileProves_UncheckableBackendsStayUnproven(t *testing.T) {
+	emptySharedPaths(t)
+	emptyCodexSharedPath(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	m := &Manager{}
+
+	for _, backend := range append([]string{"gemini", "bob", "agy", ""}, config.InferenceBackends...) {
+		if m.credentialFileProves("supervisor", 0, backend) {
+			t.Errorf("backend %q has no checkable credential file — it must not claim proof", backend)
+		}
+	}
+}
+
+// TestCredentialFileProves_CopilotAndCodexPresence documents the honest
+// asymmetry: these two are checked for the PRESENCE of tokens, not for expiry,
+// which is the same trade configHasTokens() already makes for the heal.
+func TestCredentialFileProves_CopilotAndCodexPresence(t *testing.T) {
+	emptySharedPaths(t)
+	emptyCodexSharedPath(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	m := &Manager{}
+
+	if m.credentialFileProves("supervisor", 0, "copilot") {
+		t.Fatal("precondition: no copilot tokens yet")
+	}
+	if err := os.MkdirAll(filepath.Dir(sharedCopilotConfigPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(sharedCopilotConfigPath,
+		[]byte(`{"copilotTokens":{"github.com":"tok"}}`), 0o600); err != nil {
+		t.Fatalf("write copilot config: %v", err)
+	}
+	if !m.credentialFileProves("supervisor", 0, "copilot") {
+		t.Fatal("a copilot config carrying tokens must read as proof")
+	}
+
+	if m.credentialFileProves("supervisor", 0, "codex") {
+		t.Fatal("precondition: no codex auth yet")
+	}
+	writeCodexAuth(t, codexSharedAuthFile, `{"tokens":{"access_token":"tok"}}`)
+	if !m.credentialFileProves("supervisor", 0, "codex") {
+		t.Fatal("a codex auth.json carrying tokens must read as proof")
+	}
+}
+
+// TestAgentHasValidCredential_ResolvesBackendAndNilSafety covers the public
+// entry point the detector calls: it must resolve the agent's own backend
+// (including a runtime override) and must never panic on an unknown agent or a
+// nil manager.
+func TestAgentHasValidCredential_ResolvesBackendAndNilSafety(t *testing.T) {
+	emptySharedPaths(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeClaudeCreds(t, filepath.Join(home, ".claude", ".credentials.json"))
+
+	var nilMgr *Manager
+	if nilMgr.AgentHasValidCredential("supervisor") {
+		t.Fatal("a nil manager cannot prove anything")
+	}
+
+	m := &Manager{agents: map[string]*AgentProcess{}}
+	if m.AgentHasValidCredential("supervisor") {
+		t.Fatal("an agent the manager does not know cannot be proven authenticated")
+	}
+
+	m.agents["supervisor"] = &AgentProcess{Config: config.AgentConfig{Backend: "claude"}}
+	if !m.AgentHasValidCredential("supervisor") {
+		t.Fatal("a claude agent with a fresh token must be proven authenticated")
+	}
+
+	// A runtime backend override must be what gets probed — otherwise an agent
+	// switched to gemini would keep answering from claude's credential.
+	m.agents["supervisor"].BackendOverride = "gemini"
+	if m.AgentHasValidCredential("supervisor") {
+		t.Fatal("the override backend must be probed, not the configured one")
+	}
+}
+
+// TestAgentAuthState_UnchangedByTheCredentialExtraction is the refactor guard:
+// AgentAuthState's answers must not have moved when its positive file probe was
+// split out for the detector to share.
+func TestAgentAuthState_UnchangedByTheCredentialExtraction(t *testing.T) {
+	emptySharedPaths(t)
+	emptyCodexSharedPath(t)
+	t.Setenv("CODEX_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	m := &Manager{}
+
+	// claude, nothing on disk: UNKNOWN (absence is not proof of logged-out).
+	if avail, known := m.AgentAuthState("a", 0, "claude", false, false); avail || known {
+		t.Fatalf("claude with no file: got (%v,%v), want (false,false)", avail, known)
+	}
+	// copilot, nothing on disk: KNOWN needs-login.
+	if avail, known := m.AgentAuthState("a", 0, "copilot", false, false); avail || !known {
+		t.Fatalf("copilot with no file: got (%v,%v), want (false,true)", avail, known)
+	}
+	// codex, nothing on disk: KNOWN needs-login.
+	if avail, known := m.AgentAuthState("a", 0, "codex", false, false); avail || !known {
+		t.Fatalf("codex with no file: got (%v,%v), want (false,true)", avail, known)
+	}
+	// claude with a fresh token: authenticated and known.
+	writeClaudeCreds(t, filepath.Join(home, ".claude", ".credentials.json"))
+	if avail, known := m.AgentAuthState("a", 0, "claude", false, false); !avail || !known {
+		t.Fatalf("claude with a fresh token: got (%v,%v), want (true,true)", avail, known)
+	}
+	// The pane's own login signal still outranks the file (rule 3).
+	if avail, known := m.AgentAuthState("a", 0, "claude", false, true); avail || !known {
+		t.Fatalf("needsLogin must still win: got (%v,%v), want (false,true)", avail, known)
+	}
+}


### PR DESCRIPTION
## Summary

Observed live: the login detector paused an agent **seven minutes after** the operator's `/login` had already restored a valid shared credential, because the pane tail still carried login-flow chrome. The pause is sticky — there is no auto-resume — so the agent sat orange in the dashboard while its terminal was healthy, until a human noticed.

**The cosmetic half is the smaller half.** `Pause()` cancels the agent context, which tears down `pollTmuxOutputForAgent` — the loop hosting the #4606 token-triggered restart heal, the mechanism built for exactly *"login prompt on screen while the shared credential is valid"*. So the false positive didn't merely misreport: by pausing first it **disabled the purpose-built recovery for the pane it had misread**.

## Why not narrow the patterns again

That's been tried twice:

| | false positive | fix |
|---|---|---|
| 2026-08-22 | work output quoting `gh auth login` deep in scrollback paused a working agent | tail-only matching |
| earlier | over-broad `copilot auth` flapped a logged-in quality agent to `restart_count 83` | tightened to `copilot auth login` |

This is the third class, and it's the one text matching **cannot** reach: the pane legitimately contains login text at the moment the credential is freshest, because an interactive `/login` is what puts it there. The credential has to be consulted.

## The gate

`scanForLoginRequired` now skips the pause when the agent's backend is **demonstrably** authenticated — mirroring the gate the heal already applies via `configHasTokens()`. That restores the division of labour the fleet was already half-built for:

- **valid credential + login prompt** → the token-restart heal's case (its documented design case: *"an operator authenticates in one agent's terminal and the others need a nudge"*)
- **invalid credential + login prompt** → pause and page the operator, the only case a human is actually needed

Today the detector raced the heal and, by pausing first, won destructively.

The probe is **positive-evidence only**, and that asymmetry is the whole design. Anything short of proof — including *"this backend has no credential file we can read"* — leaves existing behaviour untouched. The change can only ever suppress a pause it can justify, never invent one.

It is **split out of `AgentAuthState`, not copied**, because that function answers a *dashboard badge* question whose precedence rules are wrong here: rule 2 short-circuits to "unknown" for any **running** agent (the detector only ever scans running agents), and rule 3 lets the pane's own login text outrank the credential file — precisely the evidence the detector must not trust on its own. Sharing the positive probe keeps the two answers from drifting the way #4699 describes.

**One honest limitation, stated in the code:** only claude's credential carries an expiry this can verify. Copilot and codex are checked for the *presence* of tokens, so a stale-but-present copilot token reads as valid. That's the same trade `configHasTokens()` already makes, and it fails in the safe direction here — the heal restarts the CLI, which is a recovery attempt, where the detector would have paused, which is not.

## The streak

The issue's secondary hardening: a pattern must persist across **two consecutive** governor cycles before pausing. The manager's own pane poller learned this at its ~3s cadence, where single sightings restarted healthy agents, and now requires three; the detector had no equivalent while taking a far more expensive action.

Two rather than three because a governor cycle is *minutes* — each extra cycle is real delay for a genuine logout — and the credential gate already covers the case this backstops. It matters most for backends with no checkable credential, where it is the only new protection.

A nil tracker deliberately falls back to **single-observation** behaviour rather than never-pause: a wiring mistake must not silently disable the detector. There's a test for that.

## Shape

The per-agent judgement is extracted into pure `loginScanMatch` / `loginScanVerdict`, so it can be tested against real pane text without a tmux session, a manager, or a governor cycle — the scan loop keeps only the fetch-and-act wiring. Matching runs once and feeds both the streak and the verdict.

## Verification

Tests use the **shipping** default pattern set, resolved through `config.Load` the way a real hive resolves it, so they cannot drift from what production runs. The regression test is the incident's own shape: login-residue pane + valid credential → no pause; same pane text + expired/missing credential → pause.

Mutation-checked **nine ways**; each mutant fails a test that names the property it broke:

| Mutant | Caught by |
|---|---|
| credential gate removed (**reproduces the incident**) | `ValidCredentialNeverPauses` |
| streak gate removed | `StreakDefersTheFirstSighting` |
| modal stand-down dropped | `BlockingPromptStandsDown` |
| streak never resets on a clean cycle | `AccumulatesAndResets` |
| nil tracker disables pausing | `NilFallsBackToSingleObservation` |
| `retain` leaks entries | `RetainDropsAbsentAgents` |
| claude expiry ignored (presence only) | `ClaudeExpiryIsHonoured` |
| backend override ignored | `ResolvesBackendAndNilSafety` |
| uncheckable backend claims proof | 6 tests incl. `UncheckableBackendsStayUnproven` |

`UnrelatedPaneIsIgnored` is the control — without it the suite would also pass for a decision function that never matched. `AgentAuthState_UnchangedByTheCredentialExtraction` is the refactor guard.

- `go build ./...`, `go vet ./cmd/hive/... ./pkg/agent/...` — clean
- `go test ./cmd/hive/` — passes
- `pkg/agent` has **35 pre-existing failures** in a sandbox that cannot launch tmux or write `/data`. I diffed the failure sets before and after this change: byte-identical apart from timing digits, so this adds none. Worth a real CI run to confirm.

## Acceptance criteria

- [x] An agent whose credential is currently valid is never paused, regardless of pane text
- [x] An agent with an invalid/expired credential and a genuine login prompt is still paused and notified exactly as today
- [x] A stuck login pane with a valid credential is left to the token-restart heal, which is no longer torn down by a detector pause
- [x] Regression test in the incident's shape (valid → no pause; missing/expired → pause)
- [x] Streak adopted, with a test that a single-cycle sighting does not pause

## Not addressed

The **optional auto-resume** for pauses that were correct when taken. With this gate the stranded-pause window is much smaller, but a pause taken against a genuinely expired credential still needs a human to clear it after the operator logs back in. Out of the stated acceptance criteria, and it wants its own decision about who is allowed to un-pause.

Fixes #5291.

— hive: backend=claude model=claude-opus-5
