### PR TITLE
✨ tui T13b: wire SSE into the app, keep the poll as fallback

### DIFF
--- a/src/pkg/tui/app.go
+++ b/src/pkg/tui/app.go
@@ -23,10 +23,19 @@
 // design doc's note on the sketch (src/docs/design/tui.md §3).
 // T25 (#5139): every color the frame draws comes from theme.go, as a
 // light/dark pair. No call site names a color of its own.
+//
+// T13b (#5215): the frame is PUSHED to. The TUI subscribes to the dashboard's
+// SSE stream (T13a) at startup and translates each event into the same pane
+// messages the poll produces, so a pane moves the moment the server publishes
+// rather than on the next tick. The poll does not go away — it becomes the
+// fallback and the reconciler: healthy stream, 60s reconcile; dropped stream,
+// back to the 5s poll and a header that says so. See the SSE section at the
+// bottom of this file.
 package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -92,21 +101,35 @@ var (
 	confirmErrorStyle = lipgloss.NewStyle().Bold(true)
 )
 
-// headerText still carries placeholders after T12, and each one is a fact
-// about what is not fetched yet rather than an oversight:
+// headerFormat is the header bar, with the SSE connection state as its only
+// live field after T13b. The other two still carry placeholders, and each one
+// is a fact about what is not fetched yet rather than an oversight:
 //
 //   - `hive:` — the hive's name is on GET /api/status (StatusPayload.HiveID),
 //     which no merged client method reads. T6's /api/status client decodes the
 //     governor slice; until a client call exposes the id, inventing one here
 //     would be a guess rendered as a fact.
 //   - `governor:` — same endpoint, T6/T7's to fill.
-//   - `ws:` — SSE connection state, and the TUI opens no stream yet. T13b owns
-//     this field and it stays literally true until then: not connected.
 //
 // A dash is "not known", which is true; any value polled data does not support
-// would be false. T12 populates none of them because nothing it polls carries
-// them — /api/agents is the only merged read, and it carries none of the three.
-const headerText = "hive: —   governor: —   ws: not connected"
+// would be false.
+const headerFormat = "hive: —   governor: —   ws: %s"
+
+// The two `ws:` values, and why there are only two.
+//
+// "connected" means an event has been RECEIVED on the stream, not that a
+// socket was opened: client.StreamEvents hands back its channels before the
+// request is even dialled, so a successful connect is not observable through
+// its contract — the first event is. Everything else is "not connected", and
+// that deliberately covers three situations the operator does not need told
+// apart: before the first event, while a reconnect is backing off, and after a
+// drop. All three mean the same thing about what is on screen — the numbers
+// are coming from the 5s poll, not from the stream — which is the only
+// distinction the header exists to draw.
+const (
+	wsConnected    = "connected"
+	wsNotConnected = "not connected"
+)
 
 // footerText lists only the bindings that EXIST. The sketch's full strip
 // (p pause, m model, K kick, …) documents keys whose tasks have not landed;
@@ -200,6 +223,43 @@ type model struct {
 	// stream is connected the poll becomes a fallback and should slow down,
 	// not keep hammering an endpoint the stream has already superseded.
 	interval time.Duration
+
+	// tickGen retires superseded poll chains. Changing interval only affects
+	// the NEXT re-arm, so switching cadence means arming a fresh chain while
+	// the old one is still pending; bumping this makes the pending tick a
+	// no-op instead of a second, permanent loop. See tickMsg in poll.go.
+	tickGen uint64
+
+	// agents is the last fleet roster a poll returned.
+	//
+	// The stream carries live per-agent state but not the /api/agents contract
+	// panes.Agents draws its rows from, so an SSE update joins its states onto
+	// this list rather than rebuilding the roster from a second source that
+	// would disagree with the polled one about who is in the fleet. This is
+	// the join panes.AgentsMsg.States was defined for.
+	agents []client.Agent
+
+	// sse is the live stream, or nil while there is none. It is a pointer
+	// because it owns a cancel func and two channels — things a value-typed
+	// model copies by reference on purpose, so cancelling reaches the one
+	// goroutine that exists rather than a copy of it.
+	sse *sseStream
+
+	// sseGen identifies the current stream attempt. Every SSE message carries
+	// the generation it was produced for, so a late event or error from a
+	// stream that has already been replaced is dropped instead of degrading
+	// (or resurrecting) the connection state of its successor.
+	sseGen uint64
+
+	// sseConnected is whether an event has arrived on the current stream. It
+	// is the header's `ws:` field and the reason the poll is stretched; see
+	// wsConnected for why receipt, not dial, is the signal.
+	sseConnected bool
+
+	// sseBackoff is the delay before the NEXT reconnect attempt, zero before
+	// the first failure. It doubles per consecutive failure and is reset by
+	// any received event.
+	sseBackoff time.Duration
 }
 
 // newModel returns the root model in its initial state. Unexported because the
@@ -233,8 +293,13 @@ func New() tea.Model {
 // fetch is what keeps startup honest — without it every pane would show
 // "waiting for data" for a full interval while a perfectly reachable dashboard
 // sat there answering, and an operator would read that as the TUI being broken.
+//
+// The SSE subscription starts here too, and starts ALONGSIDE the poll rather
+// than instead of it: the stream's first event may be seconds away (or never
+// arrive, on a dashboard that is down), and the first frame must not wait on
+// it. The poll stretches only once the stream has proved itself.
 func (m model) Init() tea.Cmd {
-	cmds := []tea.Cmd{m.poll(), m.scheduleTick()}
+	cmds := []tea.Cmd{m.poll(), m.scheduleTick(), m.connectSSE()}
 	for _, p := range m.panes {
 		if c := p.Init(); c != nil {
 			cmds = append(cmds, c)
@@ -250,6 +315,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
 	case tickMsg:
+		if msg.gen != m.tickGen {
+			// A tick from a chain the cadence change retired. Dropping it
+			// without re-arming is what ends that chain; see tickMsg.
+			return m, nil
+		}
 		// Re-arm BEFORE the fetches are issued, not after they resolve: the
 		// loop's cadence must not depend on how long a fetch takes, and a
 		// dashboard that never answers must not be able to stop the clock.
@@ -260,6 +330,26 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the panes never see the error, so they never have to decide whether
 		// to clear their data, and the previous frame simply persists.
 		return m, nil
+	case sseOpenMsg:
+		return m.handleSSEOpen(msg)
+	case sseEventMsg:
+		return m.handleSSEEvent(msg)
+	case sseDroppedMsg:
+		return m.handleSSEDropped(msg)
+	case sseReconnectMsg:
+		if msg.gen != m.sseGen {
+			return m, nil
+		}
+		return m, m.connectSSE()
+	case panes.AgentsMsg:
+		// Remember the roster on its way to the pane. A poll-sourced snapshot
+		// carries the fleet; an SSE-sourced one carries the same slice back
+		// with live states joined onto it, so re-caching is a no-op there.
+		if msg.Agents != nil {
+			m.agents = msg.Agents
+		}
+		next, cmd := m.broadcast(msg)
+		return next, cmd
 	case agentActionMsg:
 		return m.handleAgentAction(msg)
 	case attachReadyMsg:
@@ -302,7 +392,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.helpVisible = true
 			return m, nil
 		case "q", "ctrl+c":
-			return m, tea.Quit
+			return m.stopSSE(), tea.Quit
 		case "tab":
 			m.focus = (m.focus + 1) % paneCount
 			return m, nil
@@ -350,6 +440,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	// Non-key messages go to every pane: a poll result or SSE event (T12,
 	// T13b) is not addressed to whichever pane happens to be focused.
+	next, cmd := m.broadcast(msg)
+	return next, cmd
+}
+
+// broadcast delivers one message to every pane and returns the updated model
+// with their commands batched.
+//
+// It returns the concrete model rather than tea.Model so the SSE path can
+// deliver SEVERAL messages out of one event — an agents snapshot and a
+// governor snapshot from the same status payload — by threading the result of
+// one broadcast into the next, instead of discarding the panes each one
+// updated.
+func (m model) broadcast(msg tea.Msg) (model, tea.Cmd) {
 	var cmds []tea.Cmd
 	for i, p := range m.panes {
 		next, c := p.Update(msg)
@@ -404,7 +507,7 @@ func (m model) View() string {
 	bottom := lipgloss.JoinHorizontal(lipgloss.Top,
 		cell(2, leftW, botH), cell(3, rightW, botH))
 
-	header := headerStyle.Width(m.width).Render(headerText)
+	header := headerStyle.Width(m.width).Render(m.headerText())
 	footerTextForFrame := footerText
 	if m.footerErr != "" {
 		footerTextForFrame = m.footerErr
@@ -534,6 +637,15 @@ func (m model) confirmView() string {
 	return confirmBoxStyle.Width(contentWidth).Render(body)
 }
 
+// headerText renders the header bar for this model's connection state.
+func (m model) headerText() string {
+	ws := wsNotConnected
+	if m.sseConnected {
+		ws = wsConnected
+	}
+	return fmt.Sprintf(headerFormat, ws)
+}
+
 // tooSmallView renders the below-minimum frame: the message alone, centred in
 // the terminal, and nothing else.
 //
@@ -550,6 +662,384 @@ func (m model) tooSmallView() string {
 		Render(tooSmallText)
 	placed := lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, msg)
 	return lipgloss.NewStyle().MaxWidth(m.width).MaxHeight(m.height).Render(placed)
+}
+
+// ── SSE (T13b) ───────────────────────────────────────────────────────────────
+
+// sseReconcileInterval is the poll cadence while the stream is healthy.
+//
+// The poll is not switched off when the stream connects; it is demoted to a
+// RECONCILER, and two things make that worth a request a minute. The stream
+// carries live state but not the /api/agents roster panes.Agents draws its
+// rows from, so something still has to notice an agent being added or removed.
+// And a stream that is up is not proof the frame is current: a dropped event,
+// or a server that stopped publishing while holding the connection open, looks
+// exactly like a quiet hive. 60s is twelve times the push cadence — slow
+// enough that the stream is plainly doing the work, often enough that a
+// silently stale frame cannot outlive a minute.
+const sseReconcileInterval = 60 * time.Second
+
+// The reconnect backoff. It starts at a second so a momentary blip costs
+// almost nothing, and stops doubling at 30s so a dashboard that is down for an
+// hour is still retried steadily rather than at an interval that has grown
+// past usefulness. The fallback poll runs at pollInterval throughout, so the
+// backoff never decides how fresh the frame is — only how soon push resumes.
+const (
+	sseBackoffMin = 1 * time.Second
+	sseBackoffMax = 30 * time.Second
+)
+
+// errSSEClosed is a stream that ended without an error of its own: the server
+// closed cleanly. For the frame it means what an error means — nothing is
+// being pushed any more — so it travels the same path rather than being a
+// second, silent case.
+var errSSEClosed = errors.New("sse stream closed")
+
+// sseStream is one live subscription: the channels client.StreamEvents
+// returned, the cancel that ends the request behind them, and the generation
+// they belong to.
+type sseStream struct {
+	events <-chan client.SSEEvent
+	errs   <-chan error
+	cancel context.CancelFunc
+	gen    uint64
+}
+
+// The SSE messages, each carrying the generation of the stream that produced
+// it.
+//
+// GENERATIONS ARE THE WHOLE CONCURRENCY STORY. A dropped stream is replaced
+// while its Cmds may still be in flight: without the guard, a late error from
+// the connection we already gave up on would degrade the fresh one, a late
+// event would report it healthy, and a backoff timer from an abandoned attempt
+// would open a second stream nobody re-arms a reader for. Every handler
+// therefore compares against model.sseGen first and drops anything older.
+type (
+	// sseOpenMsg hands a newly subscribed stream back to the model.
+	// Subscribing happens in a Cmd rather than in Update because it starts a
+	// goroutine and creates a cancel func, and Update stays pure.
+	sseOpenMsg struct {
+		gen    uint64
+		stream *sseStream
+	}
+
+	// sseEventMsg is one completely framed event off the stream.
+	sseEventMsg struct {
+		gen   uint64
+		event client.SSEEvent
+	}
+
+	// sseDroppedMsg is the stream ending, by error or by clean close.
+	sseDroppedMsg struct {
+		gen uint64
+		err error
+	}
+
+	// sseReconnectMsg is the backoff timer firing.
+	sseReconnectMsg struct {
+		gen uint64
+	}
+)
+
+// connectSSE subscribes to the dashboard's event stream.
+//
+// The context is deliberately not derived from anything request-scoped: this
+// stream lives until it drops or the program exits. Its cancel travels on the
+// returned stream so the model can end the request on a drop, on a reconnect,
+// and on quit.
+func (m model) connectSSE() tea.Cmd {
+	api, gen := m.api, m.sseGen
+	return func() tea.Msg {
+		ctx, cancel := context.WithCancel(context.Background())
+		events, errs := api.StreamEvents(ctx)
+		return sseOpenMsg{gen: gen, stream: &sseStream{
+			events: events,
+			errs:   errs,
+			cancel: cancel,
+			gen:    gen,
+		}}
+	}
+}
+
+// waitSSE is ONE receive from the stream; Update re-arms it for the next.
+//
+// That is the bubbletea channel pump: a Cmd runs on its own goroutine and ends
+// by producing a message, so a long-lived channel is drained one Cmd per value
+// rather than by a loop, which would have no way to deliver what it read.
+func waitSSE(s *sseStream) tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case event, ok := <-s.events:
+			if !ok {
+				return sseDroppedMsg{gen: s.gen, err: s.terminalErr()}
+			}
+			return sseEventMsg{gen: s.gen, event: event}
+		case err, ok := <-s.errs:
+			if !ok {
+				return sseDroppedMsg{gen: s.gen, err: errSSEClosed}
+			}
+			return sseDroppedMsg{gen: s.gen, err: err}
+		}
+	}
+}
+
+// terminalErr takes the stream's failure without blocking, falling back to
+// errSSEClosed when it simply ended.
+//
+// It exists because the select above can observe either channel first. The
+// producer buffers its error and only then closes both (errs first, events
+// second, its defers running in reverse), so a closed events channel means any
+// error is already sitting in errs — and receiving from a closed buffered
+// channel still yields what it holds. Reporting a bare close without looking
+// would throw away the one description of what went wrong.
+func (s *sseStream) terminalErr() error {
+	select {
+	case err, ok := <-s.errs:
+		if ok && err != nil {
+			return err
+		}
+	default:
+	}
+	return errSSEClosed
+}
+
+// cancelSSE ends the current stream's request, if there is one.
+func (m model) cancelSSE() {
+	if m.sse != nil {
+		m.sse.cancel()
+	}
+}
+
+// stopSSE ends the stream for good, on the way out of the program.
+//
+// Cancelling is what stops the goroutine StreamEvents owns: it is blocked on a
+// read that nothing else can end, which is harmless for `hivectl tui` — the
+// process is exiting — and is a leak per program under teatest, where the test
+// binary outlives everything it drives.
+//
+// Retiring the generation is the other half, and it is not bookkeeping. The
+// cancellation closes the stream's channels, so the pump produces one last
+// drop; without the bump that drop is indistinguishable from a real one and
+// the model would degrade the header and schedule a reconnect while the
+// program is already quitting.
+func (m model) stopSSE() model {
+	m.cancelSSE()
+	m.sse = nil
+	m.sseGen++
+	return m
+}
+
+func (m model) handleSSEOpen(msg sseOpenMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.sseGen {
+		// A subscription abandoned before it reported back. Cancelling here is
+		// what stops it holding a request open with nobody reading it.
+		msg.stream.cancel()
+		return m, nil
+	}
+	m.sse = msg.stream
+	return m, waitSSE(msg.stream)
+}
+
+func (m model) handleSSEEvent(msg sseEventMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.sseGen || m.sse == nil {
+		return m, nil
+	}
+	// A received event is the only proof the stream is up (see wsConnected),
+	// so it is what resets the backoff and stretches the poll. No new tick
+	// chain is armed for the stretch: the pending tick re-arms itself from
+	// m.interval, so the new cadence takes effect within one pollInterval
+	// without a second chain ever existing.
+	m.sseConnected = true
+	m.sseBackoff = 0
+	m.interval = sseReconcileInterval
+
+	cmds := []tea.Cmd{waitSSE(m.sse)}
+	for _, paneMsg := range m.paneMsgs(msg.event) {
+		var cmd tea.Cmd
+		m, cmd = m.broadcast(paneMsg)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m model) handleSSEDropped(msg sseDroppedMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.sseGen {
+		return m, nil
+	}
+	m.cancelSSE()
+	m.sse = nil
+	m.sseConnected = false
+
+	if m.sseBackoff == 0 {
+		m.sseBackoff = sseBackoffMin
+	} else {
+		m.sseBackoff = min(2*m.sseBackoff, sseBackoffMax)
+	}
+	m.sseGen++
+	gen, delay := m.sseGen, m.sseBackoff
+	cmds := []tea.Cmd{tea.Tick(delay, func(time.Time) tea.Msg {
+		return sseReconnectMsg{gen: gen}
+	})}
+
+	// Only the first drop after a healthy stream restores the poll, because it
+	// is the only one with a stretched cadence to undo. Retiring the 60s chain
+	// and arming a 5s one on EVERY failed reconnect as well would issue a
+	// fetch per backoff step — which is how a dashboard that is down ends up
+	// receiving more requests than one that is up.
+	if m.interval != pollInterval {
+		m.interval = pollInterval
+		m.tickGen++
+		// Fetch now as well as re-arming: the pending tick belonged to the 60s
+		// chain this retires, so without an immediate poll the fallback's
+		// first data would be a whole pollInterval away — spent showing a
+		// frame the stream has already stopped updating.
+		cmds = append(cmds, m.scheduleTick(), m.poll())
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// sseStatusAgent is the subset of the dashboard's status agent entry that this
+// frame renders. Fields are transcribed from dashboard.FrontendAgent
+// (src/pkg/dashboard/server.go), which is what both the full status payload
+// and the lighter `agent-status` payload carry under `agents`.
+//
+// It is deliberately narrow. The wire object has some sixty fields; decoding
+// the four that decide a status glyph keeps this file from becoming a second,
+// drifting copy of the dashboard's model — the same reason client.Agent
+// documents itself as exactly the /api/agents contract and nothing more.
+type sseStatusAgent struct {
+	Name      string `json:"name"`
+	Enabled   bool   `json:"enabled"`
+	Paused    bool   `json:"paused"`
+	State     string `json:"state"`
+	LastError string `json:"lastError,omitempty"`
+}
+
+// sseAgentStateRunning is the one agent.ProcessState value that means the
+// process is up ("running"; the only other is "stopped").
+const sseAgentStateRunning = "running"
+
+// sseStatusPayload is the envelope both stream event types share. The full
+// status payload has a great deal more in it, and the JSON decoder discards
+// every key not named here without retaining it.
+type sseStatusPayload struct {
+	Timestamp string           `json:"timestamp"`
+	Agents    []sseStatusAgent `json:"agents"`
+}
+
+// paneMsgs translates one stream event into the pane messages it supports.
+//
+// The panes are not taught about SSE: an event becomes the SAME message type
+// the poll delivers, so a pane cannot tell (and never has to handle) where its
+// snapshot came from. That is what makes the stream a source rather than a
+// second rendering path.
+//
+// Two event types arrive on this stream (see client/sse.go):
+//
+//   - `agent-status`, the dashboard's fast agent-only push, carries agents
+//     alone — so it produces an agents delivery and nothing else.
+//   - the default message event, the full status snapshot, carries the
+//     governor slice as well; client.GovernorStatus decodes directly from that
+//     document, which is why the governor delivery costs one more Decode of
+//     the same bytes rather than a second endpoint.
+//
+// WHAT IS DELIBERATELY NOT FILLED IN. GovernorMsg.EvalInterval is left zero:
+// it is configuration from /api/config/governor, not live state, and this task
+// adds no fetches. The pane already renders an unknown interval as a dash, so
+// the result is an honest partial frame instead of no governor frame at all —
+// nothing else feeds that pane today. AgentState.LastActivity is left zero for
+// the same kind of reason: the payload's per-agent timestamp (`lastKick`) is a
+// pre-formatted server-local display string, so a real instant cannot be
+// recovered from it, and panes.Agents renders zero as "—".
+func (m model) paneMsgs(event client.SSEEvent) []tea.Msg {
+	var payload sseStatusPayload
+	if err := event.Decode(&payload); err != nil {
+		// A frame we cannot read is dropped exactly as a failed fetch is: the
+		// panes keep what they were last told rather than being handed a zero
+		// value they could not tell from an empty hive.
+		return nil
+	}
+
+	var msgs []tea.Msg
+	// The roster comes from the poll, the states from the stream. Before the
+	// first poll returns there is no roster to join onto, and sending the
+	// states alone would blank the pane — so this waits, which costs at most
+	// the one in-flight fetch Init issued.
+	if states := sseAgentStates(payload.Agents); states != nil && len(m.agents) > 0 {
+		msgs = append(msgs, panes.AgentsMsg{
+			Agents:     m.agents,
+			States:     states,
+			ObservedAt: sseObservedAt(payload.Timestamp),
+		})
+	}
+
+	if event.Type != client.SSEEventTypeAgentStatus {
+		var status client.GovernorStatus
+		// Active is the payload's own "this document has a governor section"
+		// bit — buildGovernor hardcodes it true — so this both skips a
+		// governor-less snapshot and avoids overwriting a good frame with an
+		// all-dashes one.
+		if err := event.Decode(&status); err == nil && status.Active {
+			msgs = append(msgs, panes.GovernorMsg{Status: status})
+		}
+	}
+	return msgs
+}
+
+// sseAgentStates keys the live states by agent name, the key panes.AgentsMsg
+// joins on. It returns nil for a payload with nothing usable, which is the
+// signal to leave the pane's existing states alone rather than clear them.
+func sseAgentStates(agents []sseStatusAgent) map[string]panes.AgentState {
+	if len(agents) == 0 {
+		return nil
+	}
+	states := make(map[string]panes.AgentState, len(agents))
+	for _, agent := range agents {
+		if agent.Name == "" {
+			continue
+		}
+		states[agent.Name] = panes.AgentState{Status: agent.status()}
+	}
+	if len(states) == 0 {
+		return nil
+	}
+	return states
+}
+
+// status maps the wire's several state fields onto the pane's three.
+//
+// The order is the priority order an operator reads them in: a recorded error
+// is the thing to say about an agent even while it is nominally running, and a
+// paused agent is paused whatever its process is doing. A stopped-but-not
+// -errored agent lands on paused, which is also what the poll-only path shows
+// for a disabled one (panes.Agents.agentLine) — the pane has no fourth status
+// and adding one is a pane change, which this task does not make.
+func (a sseStatusAgent) status() panes.AgentStatus {
+	switch {
+	case a.LastError != "":
+		return panes.AgentStatusError
+	case a.Paused || !a.Enabled:
+		return panes.AgentStatusPaused
+	case a.State == sseAgentStateRunning:
+		return panes.AgentStatusRunning
+	default:
+		return panes.AgentStatusPaused
+	}
+}
+
+// sseObservedAt reads the payload's own publish time, which is RFC 3339 (
+// BuildFrontendStatus formats it with time.RFC3339). Using the server's
+// timestamp rather than the receiving clock is what keeps the relative
+// activity labels honest about the snapshot they describe; an unreadable one
+// returns zero, which panes.Agents substitutes its own clock for.
+func sseObservedAt(timestamp string) time.Time {
+	observed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return time.Time{}
+	}
+	return observed
 }
 
 // Run starts the TUI on this process's own terminal and blocks until the

--- a/src/pkg/tui/app_test.go
+++ b/src/pkg/tui/app_test.go
@@ -169,7 +169,7 @@ func TestViewFillsTerminalExactly(t *testing.T) {
 			t.Fatalf("line %d is %d cells wide, want <= %d:\n%q", i, lw, w, line)
 		}
 	}
-	for _, want := range []string{headerText, footerText} {
+	for _, want := range []string{m.(model).headerText(), footerText} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("sized View() missing %q", want)
 		}

--- a/src/pkg/tui/poll.go
+++ b/src/pkg/tui/poll.go
@@ -23,13 +23,30 @@ import (
 //
 // T13b replaces this loop with the SSE stream and keeps it as the fallback;
 // having picked the stream's own cadence means that switch changes where the
-// data comes from without changing how often the frame moves.
+// data comes from without changing how often the frame moves. It is also the
+// cadence the fallback returns to: while the stream is up the loop stretches to
+// sseReconcileInterval (app.go), and a dropped stream puts it back here.
 const pollInterval = 5 * time.Second
 
-// tickMsg is the poll heartbeat. Its time value is not read today — the tick
-// is a "go fetch now" signal, not a clock — but tea.Tick supplies it and
-// dropping it would mean wrapping the callback for nothing.
-type tickMsg time.Time
+// tickMsg is the poll heartbeat. It carries no time: the tick is a "go fetch
+// now" signal, not a clock, and nothing reads when it fired. tea.Tick supplies
+// the instant to the callback, which discards it — T13b made this a struct for
+// the generation below, and a field kept only because the callback is handed
+// one would be a value no reader could rely on.
+//
+// GEN IS WHAT KEEPS THE LOOP SINGLE. tea.Tick fires once and the loop stays
+// alive by re-arming from the handler, so "arm the new cadence" and "the old
+// cadence is still armed" are the same instant: T13b changes the cadence when
+// the SSE stream connects or drops, and arming a replacement chain without
+// retiring the old one would leave two live chains ticking forever — one
+// cadence change doubling the fetch rate for the rest of the process's life.
+// Each chain therefore carries the model's tick generation, and a tick whose
+// generation no longer matches is dropped instead of re-armed. That is what
+// ends the superseded chain at its next fire rather than running it alongside
+// the new one.
+type tickMsg struct {
+	gen uint64
+}
 
 // fetchErrMsg reports that one poll failed.
 //
@@ -68,7 +85,10 @@ func (e fetchErrMsg) Error() string {
 // queue up a backlog of pending fetches that all land at once when it
 // recovers.
 func (m model) scheduleTick() tea.Cmd {
-	return tea.Tick(m.interval, func(t time.Time) tea.Msg { return tickMsg(t) })
+	gen := m.tickGen
+	return tea.Tick(m.interval, func(time.Time) tea.Msg {
+		return tickMsg{gen: gen}
+	})
 }
 
 // poll issues every fetch the client can currently make, as one batch.

--- a/src/pkg/tui/poll_test.go
+++ b/src/pkg/tui/poll_test.go
@@ -106,7 +106,7 @@ func drain(cmd tea.Cmd) []tea.Msg {
 // "does not sleep real intervals", and it is also what makes these assertions
 // deterministic rather than timing-dependent.
 func runTick(m model) []tea.Msg {
-	_, cmd := m.Update(tickMsg(time.Time{}))
+	_, cmd := m.Update(tickMsg{})
 	return drain(cmd)
 }
 
@@ -142,6 +142,12 @@ func findFetchErr(msgs []tea.Msg) *fetchErrMsg {
 // agentsServer serves the fixture, or a 500 once fail is set. The counter lets
 // a test assert that a second tick really issued a second request rather than
 // replaying a cached result.
+//
+// It counts /api/agents ONLY. Since T13b the model also subscribes to
+// /api/events at startup, and that request lands on this handler too — so a
+// counter that counted every path would make "the poll fetched twice" and "the
+// poll fetched once and the stream connected" indistinguishable, and would
+// depend on when an asynchronous stream goroutine happened to dial.
 type agentsServer struct {
 	*httptest.Server
 	fail     atomic.Bool
@@ -152,14 +158,14 @@ func newAgentsServer(t *testing.T) *agentsServer {
 	t.Helper()
 	s := &agentsServer{}
 	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		s.requests.Add(1)
 		if s.fail.Load() {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"error":"internal"}`))
-			return
-		}
-		if r.URL.Path != "/api/agents" {
-			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -226,7 +232,7 @@ func TestTickFetchesAndRearms(t *testing.T) {
 	server := newAgentsServer(t)
 	m := pollTestModel(t, server.URL)
 
-	next, cmd := m.Update(tickMsg(time.Time{}))
+	next, cmd := m.Update(tickMsg{})
 	if cmd == nil {
 		t.Fatal("a tick produced no command at all")
 	}

--- a/src/pkg/tui/sse_test.go
+++ b/src/pkg/tui/sse_test.go
@@ -1,0 +1,637 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+
+	"github.com/kubestellar/hive/pkg/tui/client"
+	"github.com/kubestellar/hive/pkg/tui/panes"
+)
+
+// statusFixture is one full status snapshot as the dashboard publishes it on
+// the stream's default (unnamed) event — a trimmed dashboard.StatusPayload
+// carrying only the keys this frame reads.
+//
+// The three agents are the three in agentsFixture, and each is arranged to
+// contradict what /api/agents alone would show, because that is the only way a
+// test can tell a stream-fed frame from a polled one:
+//
+//   - scanner is enabled in config but PAUSED live (poll alone: running)
+//   - quality is enabled and running (poll alone: running — the control)
+//   - reviewer is disabled and carries a lastError (poll alone: paused)
+const statusFixture = `{
+  "timestamp": "2026-08-30T12:00:00Z",
+  "agents": [
+    {"name": "scanner", "enabled": true, "paused": true, "state": "running"},
+    {"name": "quality", "enabled": true, "paused": false, "state": "running"},
+    {"name": "reviewer", "enabled": false, "paused": false, "state": "stopped",
+     "lastError": "backend auth failed"}
+  ],
+  "governor": {
+    "active": true, "mode": "busy", "issues": 7, "prs": 2,
+    "thresholds": {"quiet": 1, "busy": 5, "surge": 20},
+    "nextKick": "8/30 12:05 PM UTC"
+  },
+  "acmmLevel": 4,
+  "acmmLevelConfigured": true
+}`
+
+// agentStatusFixture is the lighter `agent-status` push: agents and the
+// governor MODE, but no governor object.
+const agentStatusFixture = `{
+  "timestamp": "2026-08-30T12:00:01Z",
+  "agents": [
+    {"name": "scanner", "enabled": true, "paused": true, "state": "running"}
+  ],
+  "govMode": "busy"
+}`
+
+// sseEvent frames a fixture as the client would hand it to the app.
+func sseEvent(eventType client.SSEEventType, data string) client.SSEEvent {
+	return client.SSEEvent{Type: eventType, Data: json.RawMessage(data)}
+}
+
+// streamServer serves the poll's /api/agents alongside a live /api/events
+// stream that republishes one frame on a heartbeat.
+//
+// It republishes rather than sending once because the startup poll and the
+// stream race by construction: per-agent states are joined onto the polled
+// roster, so a stream frame that arrives before the fetch resolves carries
+// states with nothing to join them to. The real dashboard republishes every
+// REFRESH_MS for the same reason a browser refreshing mid-connect still ends
+// up correct; a single-shot test server would make this test depend on which
+// of two concurrent startup commands happened to finish first.
+type streamServer struct {
+	*httptest.Server
+}
+
+func newStreamServer(t *testing.T, frame string) *streamServer {
+	t.Helper()
+	s := &streamServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/agents":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(agentsFixture))
+		case "/api/events":
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher.Flush()
+
+			ticker := time.NewTicker(20 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				// One data: line per source line, which is how SSE carries a
+				// multi-line payload — and what lets the fixture above stay
+				// readable instead of being one enormous line.
+				for _, line := range strings.Split(frame, "\n") {
+					if _, err := fmt.Fprintf(w, "data: %s\n", line); err != nil {
+						return
+					}
+				}
+				if _, err := fmt.Fprint(w, "\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+
+				select {
+				case <-ticker.C:
+				case <-r.Context().Done():
+					return
+				}
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// drainUntil runs cmd's leaves CONCURRENTLY — as bubbletea does — and returns
+// the messages collected once want is satisfied, or everything that arrived
+// within d.
+//
+// The sequential drain() in poll_test.go cannot be used on the fallback path:
+// that batch contains the re-armed five-second tick, and running it in line
+// would make the test sit out a real poll interval to learn something the
+// model state already says. Concurrency is not a shortcut here — batched
+// commands have no ordering guarantee under bubbletea, so nothing may depend
+// on it.
+func drainUntil(cmd tea.Cmd, d time.Duration, want func([]tea.Msg) bool) []tea.Msg {
+	// Buffered so a command still running when this returns — the five-second
+	// tick, every time — can finish into the channel rather than blocking on a
+	// send nobody will receive.
+	out := make(chan tea.Msg, 16)
+	var run func(tea.Cmd)
+	run = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		go func() {
+			// A batch is only discoverable by running it, and a batch of
+			// timers must therefore be expanded on its own goroutine: doing it
+			// in line would mean waiting out every timer just to learn what
+			// the batch contained.
+			msg := c()
+			if batch, ok := msg.(tea.BatchMsg); ok {
+				for _, sub := range batch {
+					run(sub)
+				}
+				return
+			}
+			out <- msg
+		}()
+	}
+	run(cmd)
+
+	deadline := time.After(d)
+	var msgs []tea.Msg
+	for {
+		select {
+		case msg := <-out:
+			msgs = append(msgs, msg)
+			if want != nil && want(msgs) {
+				return msgs
+			}
+		case <-deadline:
+			return msgs
+		}
+	}
+}
+
+func hasMsg[T tea.Msg](msgs []tea.Msg) bool {
+	for _, msg := range msgs {
+		if _, ok := msg.(T); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// connectedModel is a model in the state a healthy stream leaves behind: an
+// open subscription, the header reporting connected, and the poll stretched to
+// the reconcile cadence.
+func connectedModel(t *testing.T, url string) model {
+	t.Helper()
+	pinDashboard(t, url)
+	m := newModel()
+	m.sse = &sseStream{
+		events: make(chan client.SSEEvent),
+		errs:   make(chan error),
+		cancel: func() {},
+		gen:    m.sseGen,
+	}
+	m.sseConnected = true
+	m.interval = sseReconcileInterval
+	return m
+}
+
+// TestSSEEventUpdatesAPaneWithoutATick is the AC's first case, driven through
+// the real program.
+//
+// The model's poll interval is set to an hour, so no tick can fire inside the
+// test: everything on screen beyond the single startup fetch arrived because
+// the stream pushed it. Each assertion is something polling cannot produce —
+// /api/agents carries no live state at all, and nothing polled feeds the
+// governor pane today.
+func TestSSEEventUpdatesAPaneWithoutATick(t *testing.T) {
+	server := newStreamServer(t, statusFixture)
+	pinDashboard(t, server.URL)
+
+	m := newModel()
+	m.interval = time.Hour
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(100, 30))
+	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
+		out := string(b)
+		return strings.Contains(out, "ws: "+wsConnected) && // header went live
+			strings.Contains(out, "BUSY") && // governor pane, SSE-only
+			strings.Contains(out, "×") // reviewer's error glyph
+	}, teatest.WithDuration(finalWait))
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(finalWait))
+
+	final, ok := tm.FinalModel(t).(model)
+	if !ok {
+		t.Fatalf("final model has unexpected type %T", tm.FinalModel(t))
+	}
+	if !final.sseConnected {
+		t.Error("a stream that delivered events left the header disconnected")
+	}
+	if final.interval != sseReconcileInterval {
+		t.Errorf("interval = %v after a healthy stream, want the reconcile cadence %v",
+			final.interval, sseReconcileInterval)
+	}
+}
+
+// TestSSEDropFallsBackToPolling is the AC's second case: the stream ends and
+// the frame goes back to being poll-driven, at the poll's own cadence, saying
+// so in the header.
+//
+// The assertions are on the model rather than on a rendered frame for the
+// cadence, because "polling every five seconds" is not observable in a test
+// that must not take five seconds — but the header and the immediate refetch
+// are, and both are checked.
+func TestSSEDropFallsBackToPolling(t *testing.T) {
+	server := newAgentsServer(t)
+	m := connectedModel(t, server.URL)
+
+	next, cmd := m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+	got, ok := next.(model)
+	if !ok {
+		t.Fatalf("a dropped stream returned %T, want the root model", next)
+	}
+
+	if got.interval != pollInterval {
+		t.Errorf("interval = %v after a drop, want the fallback cadence %v", got.interval, pollInterval)
+	}
+	if got.sseConnected {
+		t.Error("a dropped stream still reports connected")
+	}
+	if got.sse != nil {
+		t.Error("a dropped stream was not released")
+	}
+	if got.tickGen == m.tickGen {
+		t.Error("the stretched tick chain was not retired; the 60s chain would keep ticking alongside the 5s one")
+	}
+	if got.sseGen == m.sseGen {
+		t.Error("the stream generation did not advance; a straggler from the dead stream could still be believed")
+	}
+	if got.sseBackoff != sseBackoffMin {
+		t.Errorf("sseBackoff = %v after the first drop, want %v", got.sseBackoff, sseBackoffMin)
+	}
+
+	sized, _ := got.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	if view := sized.(model).View(); !strings.Contains(view, "ws: "+wsNotConnected) {
+		t.Errorf("the header does not report the degraded connection:\n%s", view)
+	}
+
+	// The fallback must fetch NOW, not at the end of the interval it just
+	// restored, and it must schedule the reconnect.
+	msgs := drainUntil(cmd, finalWait, func(msgs []tea.Msg) bool {
+		return findAgentsMsg(msgs) != nil && hasMsg[sseReconnectMsg](msgs)
+	})
+	if findAgentsMsg(msgs) == nil {
+		t.Error("the drop issued no immediate poll; the frame would sit stale for a whole interval")
+	}
+	if !hasMsg[sseReconnectMsg](msgs) {
+		t.Error("the drop scheduled no reconnect; the stream would never come back")
+	}
+	for _, msg := range msgs {
+		if reconnect, isReconnect := msg.(sseReconnectMsg); isReconnect && reconnect.gen != got.sseGen {
+			t.Errorf("reconnect carries generation %d, want the new %d", reconnect.gen, got.sseGen)
+		}
+	}
+}
+
+// TestRepeatedDropsDoNotRestartTheFallback pins the other half of the fallback
+// rule. Only the first drop has a stretched cadence to undo; doing the work
+// again on every failed reconnect would arm a tick chain and issue a fetch per
+// backoff step, so a dashboard that is DOWN would receive more requests than
+// one that is up.
+func TestRepeatedDropsDoNotRestartTheFallback(t *testing.T) {
+	m := connectedModel(t, closedDashboard)
+
+	first, _ := m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+	degraded := first.(model)
+
+	second, cmd := degraded.Update(sseDroppedMsg{gen: degraded.sseGen, err: errSSEClosed})
+	again := second.(model)
+
+	if again.tickGen != degraded.tickGen {
+		t.Error("a repeated drop armed a second tick chain")
+	}
+	if again.interval != pollInterval {
+		t.Errorf("interval = %v after a repeated drop, want %v", again.interval, pollInterval)
+	}
+	msgs := drainUntil(cmd, finalWait, func(msgs []tea.Msg) bool { return hasMsg[sseReconnectMsg](msgs) })
+	if findAgentsMsg(msgs) != nil {
+		t.Error("a repeated drop issued another poll; the 5s loop is already doing that")
+	}
+	if !hasMsg[sseReconnectMsg](msgs) {
+		t.Error("a repeated drop stopped retrying the stream")
+	}
+}
+
+// TestSSEEventStretchesThePollWithoutASecondChain pins both halves of the
+// healthy-stream case: the poll slows to the reconcile cadence, and it does so
+// WITHOUT arming a new chain — the pending tick re-arms itself from the field,
+// and a second chain would double the fetch rate for the rest of the session.
+func TestSSEEventStretchesThePollWithoutASecondChain(t *testing.T) {
+	m := connectedModel(t, closedDashboard)
+	m.sseConnected = false
+	m.interval = pollInterval
+	m.sseBackoff = sseBackoffMax
+
+	next, cmd := m.Update(sseEventMsg{
+		gen:   m.sseGen,
+		event: sseEvent(client.SSEEventTypeMessage, statusFixture),
+	})
+	got := next.(model)
+
+	if got.interval != sseReconcileInterval {
+		t.Errorf("interval = %v while the stream is healthy, want %v", got.interval, sseReconcileInterval)
+	}
+	if got.tickGen != m.tickGen {
+		t.Error("stretching the poll armed a second tick chain")
+	}
+	if !got.sseConnected {
+		t.Error("a received event did not mark the stream connected")
+	}
+	if got.sseBackoff != 0 {
+		t.Errorf("sseBackoff = %v after a received event, want it reset", got.sseBackoff)
+	}
+	if got.headerText() != fmt.Sprintf(headerFormat, wsConnected) {
+		t.Errorf("header = %q, want it to report a live stream", got.headerText())
+	}
+	// The pump must re-arm, or the stream delivers exactly one event and then
+	// looks healthy forever while nothing more arrives.
+	if cmd == nil {
+		t.Error("a received event did not re-arm the reader")
+	}
+}
+
+// TestSSEBackoffDoublesAndCaps pins the reconnect schedule. Without the cap a
+// long outage pushes the retry interval past any useful value; without the
+// doubling a dashboard that is down is retried once a second forever.
+func TestSSEBackoffDoublesAndCaps(t *testing.T) {
+	m := connectedModel(t, closedDashboard)
+
+	want := []time.Duration{
+		1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
+		16 * time.Second, 30 * time.Second, 30 * time.Second,
+	}
+	for i, wantDelay := range want {
+		next, _ := m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+		m = next.(model)
+		if m.sseBackoff != wantDelay {
+			t.Fatalf("drop %d: sseBackoff = %v, want %v", i+1, m.sseBackoff, wantDelay)
+		}
+	}
+}
+
+// TestStaleSSEMessagesAreIgnored pins the generation guard, one message type
+// at a time. Each of these is a straggler from a stream that has already been
+// replaced, and each would corrupt the successor's state in its own way.
+func TestStaleSSEMessagesAreIgnored(t *testing.T) {
+	pinDashboard(t, closedDashboard)
+
+	t.Run("event", func(t *testing.T) {
+		m := newModel()
+		m.sseGen = 3
+
+		next, cmd := m.Update(sseEventMsg{
+			gen:   2,
+			event: sseEvent(client.SSEEventTypeMessage, statusFixture),
+		})
+		got := next.(model)
+		if cmd != nil {
+			t.Error("a stale event produced a command")
+		}
+		if got.sseConnected {
+			t.Error("a stale event reported the replacement stream healthy")
+		}
+		if got.interval != pollInterval {
+			t.Errorf("interval = %v, want the fallback cadence untouched by a stale event", got.interval)
+		}
+	})
+
+	t.Run("drop", func(t *testing.T) {
+		m := connectedModel(t, closedDashboard)
+		m.sseGen = 3
+
+		next, cmd := m.Update(sseDroppedMsg{gen: 1, err: errSSEClosed})
+		got := next.(model)
+		if cmd != nil {
+			t.Error("a stale drop produced a command")
+		}
+		if !got.sseConnected || got.interval != sseReconcileInterval {
+			t.Error("a stale drop degraded a healthy stream")
+		}
+	})
+
+	t.Run("reconnect", func(t *testing.T) {
+		m := newModel()
+		m.sseGen = 3
+
+		if _, cmd := m.Update(sseReconnectMsg{gen: 1}); cmd != nil {
+			t.Error("an abandoned backoff timer opened a second stream")
+		}
+	})
+
+	t.Run("open", func(t *testing.T) {
+		m := newModel()
+		m.sseGen = 2
+
+		ctx, cancel := context.WithCancel(context.Background())
+		next, cmd := m.Update(sseOpenMsg{gen: 1, stream: &sseStream{cancel: cancel, gen: 1}})
+		if cmd != nil {
+			t.Error("a stale subscription was read from")
+		}
+		if next.(model).sse != nil {
+			t.Error("a stale subscription was adopted")
+		}
+		select {
+		case <-ctx.Done():
+		default:
+			t.Error("an abandoned subscription was left holding its request open")
+		}
+	})
+}
+
+// TestStaleTickDoesNotRearm pins the mechanism the fallback relies on: the
+// retired chain ends at its next fire instead of running forever beside the
+// new one.
+func TestStaleTickDoesNotRearm(t *testing.T) {
+	m := pollTestModel(t, closedDashboard)
+	m.tickGen = 1
+
+	next, cmd := m.Update(tickMsg{})
+	if cmd != nil {
+		t.Error("a tick from a retired chain re-armed itself")
+	}
+	if next.(model).tickGen != 1 {
+		t.Error("a stale tick changed the tick generation")
+	}
+}
+
+// TestScheduleTickStampsTheCurrentGeneration is the other half of that
+// mechanism: a chain armed after a cadence change must carry the new
+// generation, or the guard above would drop the live chain instead of the dead
+// one and the poll would stop entirely.
+func TestScheduleTickStampsTheCurrentGeneration(t *testing.T) {
+	m := pollTestModel(t, closedDashboard)
+	m.tickGen = 7
+
+	msgs := drain(m.scheduleTick())
+	if len(msgs) != 1 {
+		t.Fatalf("scheduleTick produced %d messages, want 1", len(msgs))
+	}
+	tick, ok := msgs[0].(tickMsg)
+	if !ok {
+		t.Fatalf("scheduleTick produced %T, want a tickMsg", msgs[0])
+	}
+	if tick.gen != 7 {
+		t.Errorf("tick carries generation %d, want the model's 7", tick.gen)
+	}
+}
+
+// TestPaneMsgsTranslateStatusEvents pins the translation itself: which pane
+// messages each event type produces, and what the wire's several state fields
+// map onto.
+func TestPaneMsgsTranslateStatusEvents(t *testing.T) {
+	pinDashboard(t, closedDashboard)
+	m := newModel()
+	m.agents = []client.Agent{{Name: "scanner"}, {Name: "quality"}, {Name: "reviewer"}}
+
+	t.Run("full status", func(t *testing.T) {
+		msgs := m.paneMsgs(sseEvent(client.SSEEventTypeMessage, statusFixture))
+
+		agents := findAgentsMsg(msgs)
+		if agents == nil {
+			t.Fatal("a full status event delivered no agents snapshot")
+		}
+		if len(agents.Agents) != len(m.agents) {
+			t.Errorf("delivered %d agents, want the polled roster's %d", len(agents.Agents), len(m.agents))
+		}
+		want := map[string]panes.AgentStatus{
+			"scanner":  panes.AgentStatusPaused,  // enabled but paused live
+			"quality":  panes.AgentStatusRunning, // the control
+			"reviewer": panes.AgentStatusError,   // lastError beats disabled
+		}
+		for name, wantStatus := range want {
+			if got := agents.States[name].Status; got != wantStatus {
+				t.Errorf("%s status = %q, want %q", name, got, wantStatus)
+			}
+		}
+		if got, wantAt := agents.ObservedAt, time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC); !got.Equal(wantAt) {
+			t.Errorf("ObservedAt = %v, want the payload's own publish time %v", got, wantAt)
+		}
+
+		governor := findGovernorMsg(msgs)
+		if governor == nil {
+			t.Fatal("a full status event delivered no governor snapshot")
+		}
+		if governor.Status.Mode != "busy" || governor.Status.QueueDepth() != 9 {
+			t.Errorf("governor = %+v, want mode busy and queue depth 9", governor.Status)
+		}
+		if governor.Status.ACMMLevel != 4 || !governor.Status.ACMMLevelConfigured {
+			t.Errorf("governor ACMM = %d (configured %v), want a configured L4",
+				governor.Status.ACMMLevel, governor.Status.ACMMLevelConfigured)
+		}
+	})
+
+	t.Run("agent-status carries no governor", func(t *testing.T) {
+		msgs := m.paneMsgs(sseEvent(client.SSEEventTypeAgentStatus, agentStatusFixture))
+
+		if findAgentsMsg(msgs) == nil {
+			t.Fatal("an agent-status event delivered no agents snapshot")
+		}
+		if governor := findGovernorMsg(msgs); governor != nil {
+			t.Errorf("an agent-status event produced a governor snapshot (%+v); it carries no governor object "+
+				"and would blank the pane", governor.Status)
+		}
+	})
+
+	t.Run("no governor object", func(t *testing.T) {
+		// A message event whose payload has no governor section. Active is the
+		// payload's own marker for one (buildGovernor hardcodes it true), so
+		// this must not overwrite a good frame with an all-dashes one.
+		msgs := m.paneMsgs(sseEvent(client.SSEEventTypeMessage, `{"timestamp":"2026-08-30T12:00:00Z"}`))
+		if findGovernorMsg(msgs) != nil {
+			t.Error("a governor-less payload still produced a governor snapshot")
+		}
+	})
+
+	t.Run("before the first poll", func(t *testing.T) {
+		// No roster to join onto yet. Sending states alone would blank the
+		// fleet pane, which is worse than the one fetch's wait.
+		empty := newModel()
+		msgs := empty.paneMsgs(sseEvent(client.SSEEventTypeMessage, statusFixture))
+		if findAgentsMsg(msgs) != nil {
+			t.Error("an event delivered an agents snapshot with no roster to join onto")
+		}
+		if findGovernorMsg(msgs) == nil {
+			t.Error("the governor snapshot was withheld along with it; it needs no roster")
+		}
+	})
+
+	t.Run("undecodable payload", func(t *testing.T) {
+		// Valid JSON, wrong shape. Like a failed fetch, it must reach no pane:
+		// the panes keep what they were last told rather than being handed a
+		// zero value they cannot tell from an empty hive.
+		if msgs := m.paneMsgs(sseEvent(client.SSEEventTypeMessage, `{"agents":"not a list"}`)); msgs != nil {
+			t.Errorf("an undecodable event produced %d pane messages, want none", len(msgs))
+		}
+	})
+}
+
+// TestStreamErrorSurvivesTheRaceForIt pins terminalErr. The producer closes
+// both channels after buffering its failure, so the pump can observe the
+// closed events channel first — and reporting a bare close then would throw
+// away the only description of what went wrong.
+func TestStreamErrorSurvivesTheRaceForIt(t *testing.T) {
+	events := make(chan client.SSEEvent)
+	errs := make(chan error, 1)
+	wantErr := fmt.Errorf("GET /api/events: connection refused")
+	errs <- wantErr
+	close(errs)
+	close(events)
+
+	stream := &sseStream{events: events, errs: errs, cancel: func() {}}
+	msg, ok := waitSSE(stream)().(sseDroppedMsg)
+	if !ok {
+		t.Fatalf("a closed stream produced %T, want a drop", waitSSE(stream)())
+	}
+	if msg.err == nil {
+		t.Fatal("a failed stream reported no error at all")
+	}
+	if msg.err != wantErr && msg.err != errSSEClosed {
+		t.Fatalf("drop error = %v, want the stream's own error or the clean-close sentinel", msg.err)
+	}
+}
+
+// TestCleanStreamCloseIsADrop pins that a server closing tidily is still the
+// end of push: the frame must fall back rather than sit forever waiting for
+// events on a stream nobody is sending on.
+func TestCleanStreamCloseIsADrop(t *testing.T) {
+	events := make(chan client.SSEEvent)
+	errs := make(chan error, 1)
+	close(errs)
+	close(events)
+
+	msg, ok := waitSSE(&sseStream{events: events, errs: errs, cancel: func() {}})().(sseDroppedMsg)
+	if !ok {
+		t.Fatal("a cleanly closed stream did not produce a drop")
+	}
+	if msg.err != errSSEClosed {
+		t.Errorf("drop error = %v, want %v", msg.err, errSSEClosed)
+	}
+}
+
+// findGovernorMsg returns the delivered governor snapshot, or nil if none was
+// produced.
+func findGovernorMsg(msgs []tea.Msg) *panes.GovernorMsg {
+	for _, msg := range msgs {
+		if g, ok := msg.(panes.GovernorMsg); ok {
+			return &g
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

The TUI currently learns everything by asking: a timer fires every 5 seconds and
it re-fetches. This PR makes the dashboard **tell** it instead. The TUI now
opens the dashboard's live event stream when it starts, and updates a pane the
moment the server publishes something, rather than waiting for the next timer.

Polling doesn't go away — it becomes the safety net. While the stream is
working, the timer slows to once a minute (enough to notice an agent being
added or removed, cheap enough to be free). If the stream drops, the TUI goes
straight back to polling every 5 seconds, immediately refetches so the screen
isn't stale while it recovers, says `ws: not connected` in the header, and
retries the stream on a backoff that starts at a second and tops out at 30.

Nothing about how the panes draw changed, and no new endpoints were added.

Closes #5215.

---

## What's in it

**Subscribe (`app.go`).** `Init` starts the stream alongside the existing
startup fetch rather than instead of it — the first event might be seconds
away, or never come, and the first frame must not wait on it. Reading the
stream is the standard bubbletea channel pump: one `tea.Cmd` per receive,
re-armed from `Update`.

**Translate.** An event becomes the *same* message type the poll delivers, so
no pane can tell (or has to handle) where its snapshot came from:

| stream event | delivers |
|---|---|
| default `message` (full status snapshot) | `panes.GovernorMsg` + `panes.AgentsMsg` |
| `agent-status` (the lighter agent-only push) | `panes.AgentsMsg` |

Live per-agent state is **joined onto the polled roster**, which is what
`panes.AgentsMsg.States` was defined for. The stream carries live state but not
the `/api/agents` contract the fleet pane's rows are built from, so rebuilding
the roster from the status payload would create a second source that could
disagree with the polled one about who is even in the fleet. This is also why
the 60s reconcile poll still earns its keep.

Two fields are deliberately left unset, and both are documented at the call
site: `GovernorMsg.EvalInterval` (configuration from `/api/config/governor`, and
this task adds no fetches — the pane renders an unknown interval as a dash) and
`AgentState.LastActivity` (the payload's per-agent timestamp is a pre-formatted
server-local display string, so no real instant can be recovered from it).

**Header.** `ws:` is live now, with exactly two values. `connected` means an
event has been *received* — a successful dial is not observable through
`client.StreamEvents`, which hands back its channels before the request is even
made. Everything else is `not connected`: before the first event, during
backoff, and after a drop. Those three are not worth distinguishing to an
operator, because they all mean the same thing about what is on screen — it is
coming from the poll, not the stream.

**Generations.** Every SSE message carries the generation of the stream that
produced it, and every handler drops anything older. A dropped stream is
replaced while its commands may still be in flight, so without the guard a late
error from a connection we already gave up on would degrade its replacement, a
late event would report it healthy, and an abandoned backoff timer would open a
second stream nobody reads.

## The one change outside `app.go`

`poll.go`'s `tickMsg` gained a generation field (and lost its unread time
value). Changing the cadence means arming a new `tea.Tick` chain while the old
one is still pending — `tea.Tick` fires once, and the loop is kept alive by
re-arming from the handler. Without a generation, a single connect/drop cycle
would leave **two** chains ticking forever, permanently doubling the fetch rate.
With it, the retired chain ends at its next fire. `TestStaleTickDoesNotRearm`
and `TestScheduleTickStampsTheCurrentGeneration` pin both halves.

## Tests

`src/pkg/tui/sse_test.go`, plus the `tickMsg` call-site updates in
`poll_test.go`:

- **`TestSSEEventUpdatesAPaneWithoutATick`** — the AC's first case, through
  teatest against a real SSE server. The model's poll interval is set to an
  *hour*, so no tick can fire during the test: everything on screen beyond the
  single startup fetch got there because the stream pushed it. Each assertion is
  something polling cannot produce — `/api/agents` carries no live state at all,
  and nothing polled feeds the governor pane today.
- **`TestSSEDropFallsBackToPolling`** — the AC's second case: cadence back to
  5s, header degraded, an immediate refetch, a reconnect scheduled on the new
  generation, and the stretched tick chain retired.
- **`TestRepeatedDropsDoNotRestartTheFallback`** — only the *first* drop
  restores the poll. Doing it on every failed reconnect would issue a fetch per
  backoff step, so a dashboard that is down would receive more requests than one
  that is up.
- Plus: the backoff schedule and its cap, the generation guard for each message
  type, the clean-close and error-race paths of the stream reader, and a table
  covering the translation (including the cases that must produce *nothing* —
  an `agent-status` event has no governor object, and an event arriving before
  the first poll has no roster to join onto).

Verified with `go build ./...` and `go test ./src/pkg/tui/...`, and the tui
suite also passes under `-race -count=2`.

— hive: backend=claude model=claude-opus-5
