### PR TITLE
🐛 fix(dashboard): report the real HTTP failure when a kick response is not JSON

### DIFF
--- a/src/pkg/dashboard/kick_non_json_response_test.go
+++ b/src/pkg/dashboard/kick_non_json_response_test.go
@@ -1,0 +1,69 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests pin the structure of the kick error path in the embedded
+// static/index.html (#5301). The failure they guard against is not reachable
+// from a Go handler test: handleKick answers JSON on every path it controls,
+// so the HTML body that breaks the UI is always injected by an intermediary —
+// an auth proxy answering a session-expiry redirect, or an ingress answering a
+// 502/504. What these tests honestly guarantee is that the guard and both of
+// its call sites survive future edits to the file; the rendered toast text is
+// browser behavior and stays manual-verify.
+
+// TestPostJSONHelperGuardsNonJSONResponses asserts the shared helper exists and
+// still sniffs the content type before parsing. Losing the sniff regresses
+// #5301: res.json() throws on an HTML body and the caller reports the parser's
+// "Unexpected token '<'" instead of the actual HTTP failure.
+func TestPostJSONHelperGuardsNonJSONResponses(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"async function postJSON(url, opts)",
+		"const contentType = res.headers.get('content-type') || '';",
+		"if (!contentType.includes('application/json')) {",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — postJSON lost its non-JSON guard", snippet)
+		}
+	}
+}
+
+// TestPostJSONReportsStatusAndSessionExpiry asserts the two things the guard
+// must tell the operator apart: a 401/403 means sign in again, and any other
+// non-JSON answer must name its status. Collapsing them back into one generic
+// message is the exact ambiguity #5301 was filed about.
+func TestPostJSONReportsStatusAndSessionExpiry(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"res.status === 401 || res.status === 403",
+		"'session expired — reload and sign in again'",
+		"`server returned ${res.status} ${res.statusText || 'error'}`",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — the non-JSON path stopped reporting the real HTTP condition", snippet)
+		}
+	}
+}
+
+// TestKickCallSitesUsePostJSON asserts both kick paths route through the helper
+// rather than parsing the response themselves: the overview-card sender
+// (ocSendKick) and the agent-detail sender (kick). A site that regrows its own
+// res.json() is a site that regrows the misleading toast.
+func TestKickCallSitesUsePostJSON(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"const data = await postJSON('/api/kick/' + name, opts);",
+		"const data = await postJSON(`/api/kick/${agent}`, opts);",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q — a kick call site bypasses postJSON", snippet)
+		}
+	}
+	// No kick path may keep a raw fetch of the endpoint alongside the helper.
+	if strings.Contains(html, "await fetch('/api/kick/") || strings.Contains(html, "await fetch(`/api/kick/") {
+		t.Error("a kick call site still fetches /api/kick directly; it must go through postJSON")
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4552,8 +4552,7 @@
       const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
       if (prompt) opts.body = JSON.stringify({ prompt });
       try {
-        const res = await fetch('/api/kick/' + name, opts);
-        const data = await res.json();
+        const data = await postJSON('/api/kick/' + name, opts);
         if (!data.ok) { showToast('Kick failed: ' + (data.error || 'unknown'), 'error'); return; }
         showToast(prompt ? 'Sent to ' + name : 'Kicked ' + name, 'success');
         input.value = '';
@@ -14204,6 +14203,32 @@ function burnAreaChart() {
       }
     }
 
+    // postJSON POSTs to an API endpoint and returns its decoded JSON body.
+    //
+    // The endpoints we control always answer JSON, but an intermediary need
+    // not: an auth proxy can answer a session-expiry redirect, an ingress can
+    // answer a 502/504, and both bodies are HTML. Calling res.json() on those
+    // throws a parser error ("Unexpected token '<'"), and the caller's catch
+    // then reports the parser's complaint instead of the actual failure —
+    // hiding whether the fix is "sign in again" or "the spoke is unreachable".
+    //
+    // So sniff the content type first and, when it is not JSON, throw an Error
+    // whose message names the real HTTP condition. Callers keep their existing
+    // catch and now surface something an operator can act on.
+    async function postJSON(url, opts) {
+      const res = await fetch(url, opts);
+      const contentType = res.headers.get('content-type') || '';
+      if (!contentType.includes('application/json')) {
+        // 401/403 is the session-expiry case and has a specific remedy; every
+        // other non-JSON answer is reported by its status so a screenshot still
+        // carries the diagnosis.
+        throw new Error(res.status === 401 || res.status === 403
+          ? 'session expired — reload and sign in again'
+          : `server returned ${res.status} ${res.statusText || 'error'}`);
+      }
+      return await res.json();
+    }
+
     async function kick(agent) {
       const input = document.getElementById(`kick-prompt-${agent}`);
       const prompt = input ? input.value.trim() : '';
@@ -14215,8 +14240,7 @@ function burnAreaChart() {
       // request still surfaces feedback instead of silently doing nothing.
       const toast = showToast(`Kicking ${agent}...`, 'info', true);
       try {
-        const res = await fetch(`/api/kick/${agent}`, opts);
-        const data = await res.json();
+        const data = await postJSON(`/api/kick/${agent}`, opts);
         if (!data.ok) { dismissToast(toast, 'Kick failed: ' + (data.error || 'unknown'), 'error'); return; }
         dismissToast(toast, `Kicked ${agent}`, 'success');
         if (input) input.value = '';


### PR DESCRIPTION
## Problem

Kicking an agent from the dashboard could surface a JSON parser error instead of the real failure:

```
Kick failed: Unexpected token '<', "<html><bod"... is not valid JSON
```

Both kick call sites in `src/pkg/dashboard/static/index.html` called `res.json()` without first checking what came back. `handleKick` answers JSON on every path it controls, but an intermediary need not — an auth proxy answers a session-expiry redirect, an ingress answers a 502/504, and both bodies are HTML. `res.json()` throws on those, and the caller's `catch` reports the parser's complaint.

The result is actively misleading: a `401` after a session expires and a `504` from an unreachable spoke render identically, so the operator gets no signal about whether the fix is *sign in again* or *the spoke is unreachable*. It also hides the condition from anyone reading a screenshot.

## Fix

Adds a shared `postJSON(url, opts)` helper that sniffs the content type before parsing. On a non-JSON body it throws an `Error` naming the real HTTP condition — `401`/`403` as a session-expiry hint, anything else reported by its status — which the existing `catch` at each site then renders into the toast unchanged.

Both kick sites now route through it:

- `ocSendKick(name)` — the overview-card sender (was ~line 4555)
- `kick(agent)` — the agent-detail sender (was ~line 14219)

## Scope

Deliberately narrow: only the two kick call sites are converted. As the issue notes, the same unguarded `res.json()` shape appears elsewhere in this file and could adopt the helper in a follow-up sweep — `planIssue()` (`/api/plan/from-issue`) is the closest neighbour and the most obvious next candidate, since it has the identical `const data = await res.json(); if (!data.ok)` shape. Those are left alone here to keep the change reviewable.

## Testing

Added `src/pkg/dashboard/kick_non_json_response_test.go`, following the existing convention in this package for testing the embedded dashboard's JS (`agent_scroll_anchor_test.go`, `clickable_avatars_test.go`, and others assert against `indexHTML(t)`). Three tests pin the guard, the 401/403-vs-status split, and that both call sites route through `postJSON` — including a negative assertion that no kick path keeps a raw `fetch('/api/kick/...')` alongside the helper.

What those tests honestly guarantee is structural: the guard and its call sites survive future edits. The rendered toast text is browser behavior and is not executable from Go — and notably the failure itself is **not** reachable from a handler test at all, because the HTML body is always injected by an intermediary rather than by `/api/kick`. That is why the bug was invisible to the existing server-side kick tests, of which there are many. Runtime verification of the three scenarios in the issue (502 with HTML body, 401 with a login page, and a normal kick still succeeding and still reporting `{"ok":false}` as an error) is manual/CI; I did not run a local build or test as a gate.

Existing `/api/kick` tests all exercise the Go handler directly and are unaffected by this JS-only change.

Fixes #5301
