### PR TITLE
🐛 fix(hub): stop showing "queued for auto-upgrade" on hives the hub refused

### DIFF
--- a/src/pkg/hub/auto_upgrade_blocked_test.go
+++ b/src/pkg/hub/auto_upgrade_blocked_test.go
@@ -1,0 +1,100 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The fleet row used to render "Queued for auto-upgrade · 1pm ET" from
+// autoUpgradeMode alone. Nothing in that expression consulted eligibility, so a
+// hive the hub had permanently REFUSED — upgradeCollectible() false, recorded on
+// the timeline by noteUncollectibleUpgrade() — kept advertising a queued upgrade
+// that would never fire. These tests pin the read-side decision that replaces
+// the client's re-derivation.
+
+// TestAutoUpgradeBlockedMatchesTriggerGate is THE regression: the read-side
+// answer must agree with the gate triggerAutoUpgrades() actually applies. If
+// these two ever disagree, the badge is lying again — which is the whole bug.
+func TestAutoUpgradeBlockedMatchesTriggerGate(t *testing.T) {
+	now := time.Now()
+
+	cases := []struct {
+		name          string
+		lastHeartbeat string
+	}{
+		{"never heartbeated", ""},
+		{"unparseable timestamp", "not-a-timestamp"},
+		{"beating just now", now.Format(time.RFC3339)},
+		{"one hour late", now.Add(-time.Hour).Format(time.RFC3339)},
+		{"inside staleRemoveAge", now.Add(-(staleRemoveAge - time.Hour)).Format(time.RFC3339)},
+		{"past staleRemoveAge", now.Add(-(staleRemoveAge + time.Hour)).Format(time.RFC3339)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			collectible := upgradeCollectible(tc.lastHeartbeat, now)
+			blocked, _ := autoUpgradeBlocked(true, tc.lastHeartbeat, now)
+			if blocked == collectible {
+				t.Errorf("autoUpgradeBlocked = %v but upgradeCollectible = %v; the badge "+
+					"must report exactly what triggerAutoUpgrades() will do",
+					blocked, collectible)
+			}
+		})
+	}
+}
+
+// TestAutoUpgradeBlockedRequiresAutoUpgrade pins the gating. A manual hive is
+// not "blocked" — it never asked the hub to upgrade it — and must not carry the
+// badge no matter how long it has been silent.
+func TestAutoUpgradeBlockedRequiresAutoUpgrade(t *testing.T) {
+	now := time.Now()
+	dead := now.Add(-(staleRemoveAge + time.Hour)).Format(time.RFC3339)
+
+	if blocked, _ := autoUpgradeBlocked(false, dead, now); blocked {
+		t.Error("a manual (auto-upgrade OFF) hive must never report blocked — it is " +
+			"manual, not refused")
+	}
+	if blocked, _ := autoUpgradeBlocked(false, "", now); blocked {
+		t.Error("a manual hive that never heartbeated must never report blocked")
+	}
+	// Sanity: the same silent hive WITH auto-upgrade on is blocked, so the test
+	// above is proving the gate and not merely a dead predicate.
+	if blocked, _ := autoUpgradeBlocked(true, dead, now); !blocked {
+		t.Error("auto-upgrade ON plus an uncollectible hive must report blocked")
+	}
+}
+
+// TestAutoUpgradeBlockedReasonIsOperatorSafe pins the tooltip contract. The
+// reason string is rendered into the fleet row, so it must be non-empty (an
+// empty tooltip explains nothing) and must not leak credentials or kubeconfig
+// paths — the property uncollectibleUpgradeReason() documents.
+func TestAutoUpgradeBlockedReasonIsOperatorSafe(t *testing.T) {
+	now := time.Now()
+
+	for _, hb := range []string{"", now.Add(-(staleRemoveAge + time.Hour)).Format(time.RFC3339)} {
+		blocked, reason := autoUpgradeBlocked(true, hb, now)
+		if !blocked {
+			t.Fatalf("last_heartbeat %q should be blocked", hb)
+		}
+		if strings.TrimSpace(reason) == "" {
+			t.Errorf("blocked hive (last_heartbeat %q) has an empty reason; the badge "+
+				"tooltip would explain nothing", hb)
+		}
+		if reason != uncollectibleUpgradeReason(hb) {
+			t.Errorf("reason = %q, want the SAME string noteUncollectibleUpgrade() "+
+				"writes to the timeline — the two surfaces must not diverge", reason)
+		}
+		for _, leak := range []string{"kubeconfig", "token", "secret", "password", "/root/", ".kube"} {
+			if strings.Contains(strings.ToLower(reason), leak) {
+				t.Errorf("reason %q contains %q; this string is rendered in an "+
+					"operator-facing tooltip", reason, leak)
+			}
+		}
+	}
+
+	// A collectible hive carries no reason at all.
+	if _, reason := autoUpgradeBlocked(true, now.Format(time.RFC3339), now); reason != "" {
+		t.Errorf("healthy hive reason = %q, want empty", reason)
+	}
+}

--- a/src/pkg/hub/pullonly_upgrade.go
+++ b/src/pkg/hub/pullonly_upgrade.go
@@ -143,6 +143,35 @@ func uncollectibleUpgradeReason(lastHeartbeat string) string {
 		"an upgrade instruction"
 }
 
+// autoUpgradeBlocked reports whether the fleet row should say the hub has
+// REFUSED this hive's auto-upgrade, and why.
+//
+// It is the read-side twin of the upgradeCollectible() gate in
+// triggerAutoUpgrades(): same predicate, same reason string, so the badge and
+// the hub's actual behaviour cannot drift. Exposed on MyHiveEntry as
+// AutoUpgradeBlocked/AutoUpgradeBlockedReason precisely so the dashboard never
+// re-implements this in JavaScript — it previously derived "Queued for
+// auto-upgrade · 1pm ET" from autoUpgradeMode alone, which consults nothing
+// about eligibility and so kept promising an upgrade the hub had permanently
+// declined.
+//
+// autoUpgrade gates the whole thing: a hive that never asked for auto-upgrades
+// is manual, not blocked, and must not carry the badge.
+//
+// This covers ONLY the refusal. The other gates in triggerAutoUpgrades() —
+// claim in flight, wave cap, provisioning, the daily schedule — are transient
+// and clear without intervention, so "queued" eventually comes true for them.
+// Uncollectible is the one that never does.
+func autoUpgradeBlocked(autoUpgrade bool, lastHeartbeat string, now time.Time) (bool, string) {
+	if !autoUpgrade {
+		return false, ""
+	}
+	if upgradeCollectible(lastHeartbeat, now) {
+		return false, ""
+	}
+	return true, uncollectibleUpgradeReason(lastHeartbeat)
+}
+
 // noteUncollectibleUpgrade records — once per (hive, target) — that the hub
 // declined to arm an upgrade the hive could not collect, and why.
 //

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3101,6 +3101,32 @@ type MyHiveEntry struct {
 	AdvisoryStale       bool   `json:"advisoryStale,omitempty"`
 	AdvisoryStaleReason string `json:"advisoryStaleReason,omitempty"`
 
+	// AutoUpgradeBlocked is true when this hive has auto-upgrade ON but the hub
+	// will REFUSE to arm it: upgradeCollectible() is false, so the spoke cannot
+	// pull the instruction off its own heartbeat and triggerAutoUpgrades()
+	// declines every cycle. AutoUpgradeBlockedReason is the operator-facing
+	// cause from uncollectibleUpgradeReason() — the SAME string
+	// noteUncollectibleUpgrade() writes to the timeline, and documented there as
+	// free of credentials and kubeconfig paths, so it is safe as a tooltip.
+	//
+	// WHY THIS IS COMPUTED ON READ RATHER THAN RE-DERIVED IN JAVASCRIPT. The
+	// fleet row used to render "Queued for auto-upgrade · 1pm ET" from
+	// autoUpgradeMode alone, which consults nothing about eligibility. A hive
+	// the hub had permanently refused therefore advertised a queued upgrade
+	// while the timeline recorded the refusal — two surfaces, opposite stories,
+	// and no way to tell "waiting for the window" from "will never fire". The
+	// browser must not re-implement the predicate or its staleRemoveAge bound;
+	// sending the evaluated decision is what keeps badge and hub in agreement.
+	//
+	// DELIBERATELY ONLY THE REFUSED GATE. The other gates in
+	// triggerAutoUpgrades() (claim in flight, wave full, provisioning, the
+	// schedule itself) are TRANSIENT — they clear on their own, so a badge
+	// saying "queued" is eventually true. Uncollectible is the one state that
+	// never resolves without operator action, which is why it is the one worth
+	// naming distinctly.
+	AutoUpgradeBlocked       bool   `json:"autoUpgradeBlocked,omitempty"`
+	AutoUpgradeBlockedReason string `json:"autoUpgradeBlockedReason,omitempty"`
+
 	// The inference-backend auth-failure signal (InferenceAuthError) is NOT
 	// re-declared here: MyHiveEntry embeds RegistryEntry, which already carries
 	// the spoke-reported InferenceAuthError verbatim, so the promoted field is
@@ -3607,6 +3633,17 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		if stale, reason := advisoryStale(result[i].RegistryEntry, journeyNow); stale {
 			result[i].AdvisoryStale = true
 			result[i].AdvisoryStaleReason = reason
+		}
+
+		// Auto-upgrade REFUSAL, computed on read for the same reason: the
+		// predicate and its staleRemoveAge bound live ONLY in Go, so the fleet
+		// badge cannot drift from what triggerAutoUpgrades() will actually do.
+		// Gated on AutoUpgrade because the state only means anything for a hive
+		// that has asked for auto-upgrades in the first place — a manual hive is
+		// not "blocked", it is simply manual.
+		if blocked, reason := autoUpgradeBlocked(result[i].AutoUpgrade, result[i].LastHeartbeat, journeyNow); blocked {
+			result[i].AutoUpgradeBlocked = true
+			result[i].AutoUpgradeBlockedReason = reason
 		}
 
 		// Running-but-inactive agents, computed on read for the same reason:
@@ -16406,6 +16443,21 @@ const dashboardHTML = `<!DOCTYPE html>
             var queuedTitle = queuedDaily
               ? 'Auto-upgrade will apply ' + branchLatest + ' (' + versionLabel(versionSel) + ') at the next 1pm ET window' + buildingHint
               : 'Auto-upgrade will apply ' + branchLatest + ' (' + versionLabel(versionSel) + ') shortly' + buildingHint;
+            /* REFUSED, not queued. autoUpgradeBlocked is the hub's own evaluated
+               decision (upgradeCollectible false), sent by the fleet API rather
+               than re-derived here — the badge must never claim an upgrade is
+               coming for a hive triggerAutoUpgrades() declines every cycle and
+               will keep declining until an operator intervenes. The mode-derived
+               label above says nothing about eligibility, which is exactly how a
+               hive sat 89 commits behind still advertising "· 1pm ET".
+               "Upgrade now" stays beside it: the manual path is pushed through a
+               different route and remains the operator's escape hatch. */
+            if (h.autoUpgradeBlocked) {
+              queuedLabel = 'Auto-upgrade blocked';
+              queuedTitle = 'The hub will not arm an auto-upgrade for this hive: ' +
+                (h.autoUpgradeBlockedReason || 'it cannot collect the upgrade instruction') +
+                '. It will not resolve on its own.' + buildingHint;
+            }
             /* escAttr, not esc, for the title: esc() leaves quotes intact and a
                branch name or commit subject carrying one would break out of the
                attribute. jsArg supplies its own quotes for the handler args. */


### PR DESCRIPTION
## Problem

The fleet row rendered **"Queued for auto-upgrade · 1pm ET"** from `h.autoUpgradeMode` alone:

```js
var queuedDaily = h.autoUpgradeMode === AUTO_UPGRADE_DAILY;
var queuedLabel = queuedDaily ? 'Queued for auto-upgrade · 1pm ET' : 'Queued for auto-upgrade';
```

Nothing in that expression consults whether the hive is actually eligible. The sharpest case is `upgradeCollectible` failing: the hub deliberately did **not** arm, recorded the refusal on the timeline via `noteUncollectibleUpgrade`, and will keep declining every cycle — while the row went on advertising a queued upgrade at a specific time. Two surfaces, opposite stories, and no way to tell *waiting for the window* from *refused, and will never fire on its own*.

## Which of the three states this implements

Deliberately **only the refused case**, plus the unchanged eligible case:

| State | Badge | Status |
|---|---|---|
| eligible + waiting | `Queued for auto-upgrade · 1pm ET` | unchanged |
| **refused (`upgradeCollectible` false)** | **`Auto-upgrade blocked`**, reason as tooltip | **implemented** |
| held transiently (wave full / claim in flight / provisioning) | — | **not implemented** |

The `Auto-upgrade deferred` state is not included, and that is a scope decision rather than an oversight. Those gates are *transient*: the wave cap frees on the next cycle, `assignmentInFlight` releases the moment `ClaimDelivered` flips (and `sweepStuckAssignments` bounds it either way), and `provisioning` resolves. For all of them "queued" eventually comes true, so the badge is imprecise but not false. Uncollectible is the only gate that never resolves without operator action — the state the issue calls out as "worth it on its own" — and plumbing the transient decisions would mean evaluating the wave cap and cluster assignment per row on every fleet read, which is materially more invasive for a strictly smaller payoff.

## Approach

Investigated what the hives API already returns first. There was no existing decision field, but `MyHiveEntry` already carries `LastHeartbeat` (promoted from the embedded `RegistryEntry`) and there is an established pattern for exactly this shape — `AdvisoryStale` / `AdvisoryStaleReason`, computed on read in `handleMyHives` specifically so the browser never re-derives a Go threshold. This follows it:

- **`MyHiveEntry.AutoUpgradeBlocked` / `AutoUpgradeBlockedReason`** (`saas.go`) — the hub's evaluated decision, not a client re-derivation. Deliberately not computed in JS: the browser would have to re-implement the predicate *and* its `staleRemoveAge` bound, which is the drift that caused the bug.
- **`autoUpgradeBlocked()`** (`pullonly_upgrade.go`) — the read-side twin of the gate in `triggerAutoUpgrades`, calling the same `upgradeCollectible` predicate and returning the same `uncollectibleUpgradeReason` string the timeline records. Gated on `AutoUpgrade`, because a manual hive is not blocked, it is manual.
- **Badge** — `Auto-upgrade blocked` with the reason as tooltip, stating explicitly that it will not resolve on its own. `Upgrade now` stays beside it; the manual path is routed differently and remains the escape hatch.

The reason string is safe for display: `uncollectibleUpgradeReason` is already operator-facing and documented as free of credentials and kubeconfig paths, and it is the same text already written to the timeline.

## Escaping

The tooltip goes through the pre-existing `escAttr(queuedTitle)` call, not `esc` — the reason string interpolates an arbitrary RFC3339 timestamp, and `esc()` leaves quotes intact, which would break out of the attribute. The new code only reassigns `queuedTitle`/`queuedLabel` ahead of the existing escaping, so both stay on their correct escaper. Matches surrounding `var` style.

## Tests

`src/pkg/hub/auto_upgrade_blocked_test.go`:

- `TestAutoUpgradeBlockedMatchesTriggerGate` — the regression. Across never-heartbeated, unparseable, fresh, and past-`staleRemoveAge` timestamps, the read-side answer must be the exact inverse of `upgradeCollectible`. If badge and hub ever disagree, the bug is back.
- `TestAutoUpgradeBlockedRequiresAutoUpgrade` — a manual hive never carries the badge, with a positive control so it is not passing against a dead predicate.
- `TestAutoUpgradeBlockedReasonIsOperatorSafe` — the tooltip is non-empty, is byte-identical to what `noteUncollectibleUpgrade` writes to the timeline, and leaks no credential/kubeconfig terms.

## Note on #5304

This does not touch the related `Upgrade now` behaviour — that button still arms uncollectible upgrades that auto-upgrade refuses. Left for #5304 as filed. One visible consequence: a blocked hive now shows `Auto-upgrade blocked` next to a live `Upgrade now`, which is accurate about both today (the hub will not arm it; you still can) but reads a little oddly until #5304 lands.

Fixes #5305
