### PR TITLE
📖 docs(wiki): make getting-started an actual onboarding path

### DIFF
--- a/src/deploy/data/wiki/agents.md
+++ b/src/deploy/data/wiki/agents.md
@@ -69,7 +69,7 @@ There is no built-in `tester` agent. Test suites, coverage gates, and
 regression checks are the `quality` lane's work. An operator who wants a
 separate tester must define it as a custom agent with its own metadata and
 policy template — see
-[acmm-policy-matrix.md](../../../docs/acmm-policy-matrix.md).
+[acmm-policy-matrix.md](https://github.com/kubestellar/hive/blob/v4/src/docs/acmm-policy-matrix.md).
 
 ## Adding a New Agent
 

--- a/src/deploy/data/wiki/getting-started.md
+++ b/src/deploy/data/wiki/getting-started.md
@@ -9,6 +9,15 @@ Hive is an autonomous multi-agent system that manages software repositories
 using AI-powered agents. Each agent has a specific role and operates within
 governance boundaries set by the **Governor**.
 
+This page is the entry point. It gets a new operator from zero to a running
+hive, points contributors at the build/test path, and links the reference
+material for everything after that.
+
+> **Note on links.** This vault is copied to `/data/wiki/` when the container
+> starts, so it does not sit inside a checkout of the repository. Links out of
+> the vault are therefore absolute URLs to the `v4` branch on GitHub rather
+> than relative paths, which would not resolve at runtime.
+
 ## Core Concepts
 
 - **Governor** -- evaluates repository state (open issues, PRs, SLA breaches)
@@ -19,12 +28,128 @@ governance boundaries set by the **Governor**.
   agent was asked, what it did, and the outcome.
 - **Knowledge Layer** -- a wiki of facts (patterns, gotchas, regressions)
   extracted from merged PRs and fed back to agents as primer context.
+- **ACMM Level** -- six levels (L1-L6) that decide what agents are permitted to
+  do, from advisory-only observations up to opening and auto-merging pull
+  requests. You raise the level as you build trust in the output; the goal is
+  trust, not level.
 
-## Quick Links
+## Run a Hive (Docker Compose)
 
-- Dashboard: accessible on the configured port (default 3001)
-- Policies: stored in the `policies` repo path and hot-reloaded
-- Vaults: Obsidian-compatible markdown directories auto-indexed by Hive
+Docker Compose is the default standalone runtime. Podman is a parallel
+supported choice — see the
+[Podman quick start](https://github.com/kubestellar/hive/blob/v4/README.md#quick-start-podman).
+
+**Prerequisites**
+
+- Docker Engine 24+ with the Compose v2 plugin (`docker compose`, not the
+  legacy `docker-compose`)
+- Linux, macOS, or Windows (WSL2) on `amd64` or `arm64`
+- `git`, `openssl`, and a GitHub token (PAT or App) for the org the hive will
+  work on
+
+```bash
+git clone https://github.com/kubestellar/hive.git
+cd hive
+
+cp src/hive.yaml.example src/hive.yaml
+```
+
+Edit `src/hive.yaml` and set at least `project.org`, `project.repos`, and
+`project.ai_author` for the org and repositories the hive should manage.
+
+Now write the environment file. **It must be `src/.env`, not a `.env` at the
+repository root.** Because `-f src/docker-compose.yaml` makes `src/` the
+project directory, Compose reads `.env` from there — the same place the compose
+file's own `./hive.yaml` and `./secrets` mounts resolve against. A root `.env`
+is read by nothing, and since both paths are gitignored, neither git nor
+Compose warns you: the hive starts and then 401s on every GitHub call, which
+looks like a bad token rather than an unread file.
+
+```bash
+# Replace with your own token. Never commit this file.
+echo "HIVE_GITHUB_TOKEN=ghp_REPLACE_ME" > src/.env
+
+# REQUIRED. The dashboard's auth proxy enforces this token and refuses to
+# start without one, so the gateway on :3001 would proxy to a port nothing is
+# listening on.
+printf 'HIVE_DASHBOARD_TOKEN=%s\n' "$(openssl rand -hex 32)" >> src/.env
+
+docker compose -f src/docker-compose.yaml up -d
+```
+
+A classic PAT needs `repo` scope; see
+[github-app-setup.md](https://github.com/kubestellar/hive/blob/v4/src/docs/github-app-setup.md#personal-access-token-pat-scopes)
+for the App path and the full scope list.
+
+## Verify Your Hive Is Healthy
+
+The gateway publishes port 3001 whether or not the proxy behind it came up, so
+confirm the endpoint answers rather than assuming the port is enough:
+
+```bash
+curl -sf http://127.0.0.1:3001/api/health     # -> {"status":"ok"}
+```
+
+If that returns nothing, check the containers and their logs — the two
+services are named `hive` and `hive-gateway`:
+
+```bash
+docker compose -f src/docker-compose.yaml ps
+docker logs hive
+docker logs hive-gateway
+```
+
+A gateway that is up while `hive` is unhealthy is almost always the missing
+`HIVE_DASHBOARD_TOKEN` or a `.env` written to the wrong directory. For anything
+else, see
+[troubleshooting.md](https://github.com/kubestellar/hive/blob/v4/src/docs/troubleshooting.md).
+
+The dashboard is then at `http://localhost:3001`.
+
+## The Agents
+
+A hive deploys a roster of specialized agents, each with a distinct role:
+`scanner`, `quality`, `guide`, `brainstorm`, `ci-maintainer`, `architect`,
+`supervisor`, `outreach`, `sec-check`, and `strategist`. How many are active
+depends on your ACMM level, and what each one is permitted to do depends on its
+policy mode at that level.
+
+See [agents.md](agents.md) in this vault for what each agent does and how to
+add a custom one.
+
+## For Contributors
+
+If you are here to change Hive itself rather than run it:
+
+- [Getting started as a first-time contributor](https://github.com/kubestellar/hive/blob/v4/docs/getting-started-contributing.md)
+  -- the end-to-end path for a first PR.
+- [CONTRIBUTING.md](https://github.com/kubestellar/hive/blob/v4/CONTRIBUTING.md)
+  -- branches, DCO sign-off, and PR format.
+- [Local development](https://github.com/kubestellar/hive/blob/v4/docs/development.md)
+  -- Go version, `go build ./...`, `go test ./...`, and the helper recipes.
+
+Use `v4` as the PR base for ordinary Hive development. Most changes need no
+cluster: `cd src && go build ./...` is enough to iterate on Go code, and
+docs-only fixes need no toolchain at all.
+
+## Key References
+
+- [Reference architecture](https://github.com/kubestellar/hive/blob/v4/src/docs/architecture.md)
+  -- how the governor, agents, and dashboard fit together.
+- [ACMM policy matrix](https://github.com/kubestellar/hive/blob/v4/src/docs/acmm-policy-matrix.md)
+  -- the full per-level, per-agent permission table.
+- [Zero to automation](https://github.com/kubestellar/hive/blob/v4/src/docs/getting-started.md)
+  -- the narrative guide to climbing the ACMM levels.
+- [Agent configuration](https://github.com/kubestellar/hive/blob/v4/src/docs/agent-configuration.md)
+  -- every field of an `agents:` entry in `hive.yaml`.
+- [Environment variables](https://github.com/kubestellar/hive/blob/v4/src/docs/env-vars.md)
+  -- the compiled reference for `HIVE_*` and related variables.
+- [Operator reference](https://github.com/kubestellar/hive/blob/v4/src/docs/operator-reference.md)
+  -- runtime knobs, image provenance, and tags.
+- [hivectl](https://github.com/kubestellar/hive/blob/v4/src/docs/hivectl.md)
+  -- the non-interactive CLI client (`hivectl system health`, `system status`).
+- [Documentation index](https://github.com/kubestellar/hive/blob/v4/src/docs/README.md)
+  -- everything else: operations, snapshots, contributor relay, design notes.
 
 ## Editing This Wiki
 
@@ -34,3 +159,7 @@ This vault is an Obsidian-compatible directory of markdown files. You can:
 2. Open the vault in Obsidian and enable the **Obsidian Git** community plugin
 3. Push changes to the configured git remote -- Hive will pull them
    automatically every 60 seconds
+
+The files shipped in the image are starter knowledge, not fixed product
+documentation. Replace or extend them with the runbooks, gotchas, and policies
+that your agents should be primed with.


### PR DESCRIPTION
Fixes #5166

## What

`src/deploy/data/wiki/getting-started.md` is the first page a contributor or operator meets in the deployed Hive wiki. It was four paragraphs of definitions plus three placeholder "Quick Links" — no route to the real Quick Start, no way to check the hive is alive, no contributor path. Anyone landing there from the dashboard hit a dead end.

It is now a real onboarding page:

- **Run a Hive (Docker Compose)** — prerequisites, clone, `cp src/hive.yaml.example src/hive.yaml`, the `src/.env` write, and `up -d`.
- **Verify your hive is healthy** — `curl -sf http://127.0.0.1:3001/api/health`, plus the container/log commands and the two failure modes that actually cause a silent 401 or a dead proxy.
- **The agents** — the roster, linking to the sibling `agents.md` for detail.
- **For contributors** — `getting-started-contributing.md`, `CONTRIBUTING.md`, `docs/development.md`, and the `v4` base-branch rule.
- **Key references** — architecture, ACMM policy matrix, `src/docs/getting-started.md`, agent configuration, env vars, operator reference, hivectl, docs index.

## Stale thing found and fixed

`agents.md` linked `[acmm-policy-matrix.md](../../../docs/acmm-policy-matrix.md)`. That resolves inside a repo checkout, but it is **dead at runtime**: the Dockerfile copies `src/deploy/data/` to `/opt/hive/seed-data/`, and `src/deploy/entrypoint.sh` seeds the vault flat into `/data/wiki/` (`cp -rn /opt/hive/seed-data/* /data/`). Nothing above the vault directory exists at that point, so every `../../../` hop is broken for the operators actually reading this wiki.

Links leaving the vault now use absolute `blob/v4` URLs, and the new page carries a short note explaining why, so the next person editing the vault does not reintroduce relative paths. In-vault links (`getting-started.md` → `agents.md`) stay relative, which is correct — those files are siblings both in the repo and in `/data/wiki/`.

Note that `.github/workflows/docs-link-check.yml` only scans `src/docs`, so it would not have caught this and does not cover these files; the links below were checked by hand.

## Verified against the repo

Every command and path was checked against the tree rather than assumed:

- `cp src/hive.yaml.example src/hive.yaml` — `src/hive.yaml.example` exists.
- `src/.env`, not root `.env` — confirmed: `src/docker-compose.yaml` mounts `./hive.yaml` and `./secrets`, so `-f src/docker-compose.yaml` makes `src/` the project directory. Matches the README's own warning.
- `HIVE_DASHBOARD_TOKEN` required, generated with `openssl rand -hex 32` — confirmed. The compose healthcheck comment records the concrete regression: a missing token kept the proxy from binding 3001.
- `docker compose -f src/docker-compose.yaml up -d` — matches the README Quick Start.
- `curl -sf http://127.0.0.1:3001/api/health` — endpoint served at `src/pkg/dashboard/server.go:1352`; same URL used by both compose healthchecks and by `hivectl system health`.
- Container names `hive` and `hive-gateway` — from `container_name:` in `src/docker-compose.yaml`.
- Port 3001 published by the gateway; 3002 is the internal Go API.
- Agent roster — cross-checked against the `agents:` keys in `src/hive.yaml.example`; matches `agents.md`.
- ACMM L1–L6 summary — matches the README table and `src/docs/acmm-policy-matrix.md`.
- Go build/test commands and the `v4` base-branch rule — from `docs/development.md`.
- All 14 outbound links resolve to existing files, and both `#`-anchors (`README.md#quick-start-podman`, `github-app-setup.md#personal-access-token-pat-scopes`) match real headings.

Token values are placeholders (`ghp_REPLACE_ME`); the page tells the reader not to commit `src/.env`.

Docs-only change; CI is the gate.