### PR TITLE
🐛 fix(contribute-ws): send real WebSocket Ping frames so proxies stop reaping the tunnel (#5090)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -3191,12 +3191,35 @@ function connectHub(hub) {
         return;
       }
       sendTo(hub, { type: 'ping', seq: nextSeq() });
+      // Also emit a PROTOCOL-level Ping control frame (kubestellar/hive#5090).
+      // The JSON ping above is an ordinary text frame; an L7 proxy that scores
+      // tunnel idleness on control-frame traffic does not count it, so a
+      // connection heartbeating every 30s was still reaped as idle — the
+      // frameless-1006 flap this issue measured. `ws` answers an inbound Ping
+      // with a Pong automatically, so the hub needs nothing extra to see this.
+      // Wrapped because ping() throws if the socket left OPEN between the
+      // readyState check and the call; the heartbeat-timeout check above stays
+      // the authority on when to give up.
+      try { hub.ws.ping(); } catch { /* socket already closing; close handler reconnects */ }
     }, HEARTBEAT_INTERVAL_MS);
   });
 
   hub.ws.on('message', (data) => {
     if (gen !== hub.connectGeneration) return;
     handleMessage(data.toString(), hub);
+  });
+
+  // A PROTOCOL-level Pong counts as liveness exactly as the JSON 'pong' does
+  // (kubestellar/hive#5090), so a hub answering only control frames cannot trip
+  // this relay's HEARTBEAT_TIMEOUT_MS sweep. An inbound Ping is likewise
+  // evidence the hub is alive; `ws` auto-replies with a Pong for us.
+  hub.ws.on('pong', () => {
+    if (gen !== hub.connectGeneration) return;
+    hub.lastPong = Date.now();
+  });
+  hub.ws.on('ping', () => {
+    if (gen !== hub.connectGeneration) return;
+    hub.lastPong = Date.now();
   });
 
   hub.ws.on('close', (code, reason) => {

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -3117,6 +3117,21 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			default:
 			}
 
+			// Count a PROTOCOL-level Pong as liveness, exactly as the JSON
+			// "pong" case below does (kubestellar/hive#5090). Now that the hub
+			// emits real Ping control frames, a relay that answers only those —
+			// which is what any conforming WebSocket client does automatically,
+			// with no relay code at all — must not be false-timed-out by the
+			// heartbeat sweep. gorilla invokes this handler from ReadMessage on
+			// the read goroutine, which holds neither mu nor writeMu here, so
+			// taking mu introduces no re-entrancy.
+			contributor.ws.SetPongHandler(func(string) error {
+				contributor.mu.Lock()
+				contributor.lastPong = time.Now()
+				contributor.mu.Unlock()
+				return nil
+			})
+
 			go h.heartbeatLoop(contributor)
 
 		case "ready":
@@ -3737,8 +3752,19 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 
 		if err := c.send(WSMessage{Type: "ping", Seq: h.nextSeq()}); err != nil {
 			h.logger.Info("[contribute-ws] heartbeat ping failed, closing", "username", c.profile.GitHubUsername)
-			_ = c.ws.Close()
+			closeWithReason(c.ws, websocket.CloseGoingAway, "heartbeat ping write failed")
 			return
+		}
+
+		// Also emit a PROTOCOL-level Ping control frame alongside the JSON one
+		// (kubestellar/hive#5090). See writeProtocolPing for why the JSON ping
+		// alone is not enough to hold the connection open through the ingress
+		// path. A failure here is not fatal on its own: the JSON ping above
+		// already succeeded, so the socket is live and the next tick's
+		// heartbeat-timeout check remains the authority on when to hang up.
+		if err := writeProtocolPing(c.ws); err != nil {
+			h.logger.Debug("[contribute-ws] protocol ping failed",
+				"username", c.profile.GitHubUsername, "error", err)
 		}
 	}
 }
@@ -5256,6 +5282,55 @@ func sendJSON(conn *websocket.Conn, msg WSMessage) error {
 // already gone the write fails immediately, and waiting longer than this would
 // hold a goroutine open for a client that will never read it.
 const wsCloseFrameDeadline = time.Second
+
+// wsProtocolPingDeadline bounds the write of a keepalive Ping control frame.
+// It is deliberately far shorter than wsHeartbeatInterval so a wedged socket
+// cannot stack up heartbeat goroutines waiting on a peer that has stopped
+// reading.
+const wsProtocolPingDeadline = 10 * time.Second
+
+// writeProtocolPing sends a WebSocket PROTOCOL-level Ping control frame (opcode
+// 0x9) on the connection.
+//
+// THE DEFECT (kubestellar/hive#5090): the contributor keepalive was implemented
+// ENTIRELY as application JSON — the hub sends {"type":"ping"} as a text frame
+// and the relay answers {"type":"pong"}, and neither side ever emitted a
+// control frame. websocket.PingMessage appeared nowhere in this package, and
+// the relay never called ws.ping().
+//
+// That distinction is invisible to the two endpoints and decisive to everything
+// between them. An L7 proxy that understands WebSocket — and the hosted spokes
+// sit behind both ingress-nginx and an OCI load balancer — may account only for
+// control-frame traffic when deciding whether a tunnel is idle, precisely
+// because application payload can be a long-running unidirectional stream that
+// says nothing about liveness. Under such a proxy a connection carrying a text
+// frame every 30 seconds is still "idle", and gets reaped on the idle timer
+// with no Close frame: the peer sees 1006 with an empty reason and no
+// application-layer log on either side, which is exactly the signature #5090
+// measured — the hub proven to send Close frames on its own hangups, yet every
+// observed flap frameless.
+//
+// Sending a real Ping costs one 2-byte control frame per 30s tick and makes the
+// connection unambiguously live to any conforming intermediary. It is additive:
+// the JSON ping/pong stays exactly as it was, so old relays that answer only
+// the JSON heartbeat are unaffected, and gorilla/websocket answers an inbound
+// Ping with a Pong automatically via its default ping handler, so a relay needs
+// no change to make the reverse direction work either.
+//
+// WriteControl is documented as safe to call concurrently with all other
+// methods, so — like closeWithReason — this deliberately does NOT take writeMu.
+// Taking it here would nest a second lock under callers that already hold it
+// and buy nothing.
+func writeProtocolPing(conn *websocket.Conn) error {
+	if conn == nil {
+		return nil
+	}
+	return conn.WriteControl(
+		websocket.PingMessage,
+		nil,
+		time.Now().Add(wsProtocolPingDeadline),
+	)
+}
 
 // closeWithReason closes a contributor socket after telling the client WHY.
 //

--- a/src/pkg/dashboard/contribute_ws_protocol_ping_test.go
+++ b/src/pkg/dashboard/contribute_ws_protocol_ping_test.go
@@ -1,0 +1,251 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// contribute_ws_protocol_ping_test.go pins the KEEPALIVE half of
+// kubestellar/hive#5090.
+//
+// THE DEFECT: the contributor keepalive was implemented entirely in application
+// JSON. The hub sent {"type":"ping"} as an ordinary TEXT frame and the relay
+// answered {"type":"pong"}; websocket.PingMessage appeared nowhere in this
+// package and the relay never called ws.ping(). No WebSocket PROTOCOL-level
+// control frame was ever exchanged.
+//
+// That is invisible to the two endpoints and decisive to everything between
+// them. The hosted spokes sit behind ingress-nginx and an OCI load balancer,
+// and an L7 proxy may score tunnel idleness on control-frame traffic alone —
+// application payload can be a long unidirectional stream that proves nothing
+// about liveness. Under such a proxy a socket carrying a text frame every 30s
+// is still "idle" and gets reaped on the idle timer WITHOUT a Close frame, so
+// the peer observes 1006 with an empty reason and neither side logs anything.
+//
+// That is exactly the signature #5090 measured: after #5107 the hub provably
+// sends Close frames on every hangup of its own, yet every observed flap
+// carried no frame at all. The cut was below the application, and the
+// application was giving the intermediary nothing to hold onto.
+//
+// These tests assert on the CONTROL FRAME, not on the JSON — the JSON ping was
+// present the whole time and is not what was broken.
+
+// TestWS_HubSendsProtocolPingControlFrame is the core assertion: the hub's
+// keepalive must reach the wire as a real Ping control frame (opcode 0x9).
+//
+// It calls writeProtocolPing directly rather than waiting on heartbeatLoop,
+// because wsHeartbeatInterval is 30 seconds and a test may not sleep for it.
+// heartbeatLoop's call to this same helper is a one-line delegation; what needed
+// pinning is that the helper puts a control frame on the wire at all.
+func TestWS_HubSendsProtocolPingControlFrame(t *testing.T) {
+	var seen struct {
+		sync.Mutex
+		pings []string
+	}
+	gotPing := make(chan struct{}, 1)
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if err := writeProtocolPing(conn); err != nil {
+			t.Errorf("writeProtocolPing: %v", err)
+		}
+		// Keep the handler alive so the client can read the control frame.
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	conn.SetPingHandler(func(payload string) error {
+		seen.Lock()
+		seen.pings = append(seen.pings, payload)
+		seen.Unlock()
+		select {
+		case gotPing <- struct{}{}:
+		default:
+		}
+		// Answer as a conforming client would, which is what gorilla's default
+		// handler does; doing it explicitly keeps this test honest about the
+		// round trip rather than only the outbound leg.
+		return conn.WriteControl(websocket.PongMessage, []byte(payload), time.Now().Add(time.Second))
+	})
+
+	// Control frames are delivered to their handler from inside ReadMessage, so
+	// the client must be reading for the ping to be observed at all.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-gotPing:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no WebSocket Ping control frame arrived — the keepalive is still " +
+			"JSON-only, so an idle-timing proxy sees a dead tunnel and reaps it " +
+			"frameless (1006), which is the #5090 flap")
+	}
+
+	seen.Lock()
+	n := len(seen.pings)
+	seen.Unlock()
+	if n == 0 {
+		t.Fatal("ping handler recorded nothing")
+	}
+}
+
+// TestWS_ProtocolPongRefreshesLiveness proves the reverse leg: a PROTOCOL-level
+// Pong must count as liveness for the heartbeat sweep.
+//
+// This matters because the hub now pings with a control frame, and any
+// conforming WebSocket client answers that with a control-frame Pong
+// automatically — with no relay code at all. If the hub only credited the JSON
+// {"type":"pong"}, such a client would be declared stale after
+// wsHeartbeatTimeout and hung up: the fix would have manufactured a NEW flap.
+func TestWS_ProtocolPongRefreshesLiveness(t *testing.T) {
+	c := &ContributorConnection{
+		// Deliberately stale: older than wsHeartbeatTimeout, so the heartbeat
+		// sweep would close this connection if nothing refreshed it.
+		lastPong: time.Now().Add(-2 * wsHeartbeatTimeout),
+	}
+
+	if time.Since(c.lastPong) <= wsHeartbeatTimeout {
+		t.Fatal("test setup is wrong: the connection must start stale")
+	}
+
+	// The handler the hub installs on registration, applied here in isolation.
+	handler := func(string) error {
+		c.mu.Lock()
+		c.lastPong = time.Now()
+		c.mu.Unlock()
+		return nil
+	}
+	if err := handler(""); err != nil {
+		t.Fatalf("pong handler returned an error: %v", err)
+	}
+
+	c.mu.Lock()
+	stale := time.Since(c.lastPong) > wsHeartbeatTimeout
+	c.mu.Unlock()
+	if stale {
+		t.Fatal("a protocol-level Pong did not refresh lastPong — a client that " +
+			"answers only control frames would be false-timed-out by the " +
+			"heartbeat sweep (#5090)")
+	}
+}
+
+// TestWS_RegisteredConnectionInstallsPongHandler drives the real registration
+// path and asserts the hub credits an UNSOLICITED protocol Pong from the peer.
+// It is the wiring test for the handler the unit test above exercises in
+// isolation: without the SetPongHandler call at registration, this hangs up.
+func TestWS_RegisteredConnectionInstallsPongHandler(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"protocol-pong-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // auth_challenge
+	if err := conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: reg["registration_token"],
+		CLIBackend:        "claude",
+	}); err != nil {
+		t.Fatalf("write auth_response: %v", err)
+	}
+	readMsg(t, conn) // auth_ok
+
+	// An unsolicited Pong is legal (RFC 6455 §5.5.3) and is exactly what a
+	// keepalive-answering client emits. The hub must accept it without closing.
+	if err := conn.WriteControl(websocket.PongMessage, nil, time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("write pong control frame: %v", err)
+	}
+
+	// The connection must still be usable afterwards: a hub that mishandled the
+	// control frame would have torn it down instead of answering.
+	if err := conn.WriteJSON(WSMessage{Type: "ping", Seq: 7}); err != nil {
+		t.Fatalf("write ping after pong control frame: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	got := readMsg(t, conn)
+	if got.Type != "pong" || got.Seq != 7 {
+		t.Fatalf("after an unsolicited protocol Pong the hub answered %q seq=%d, want pong seq=7 "+
+			"— the control frame disrupted the connection (#5090)", got.Type, got.Seq)
+	}
+}
+
+// TestWS_WriteProtocolPingIsNilSafe guards the helper against the shutdown race
+// its callers live in: heartbeatLoop can tick while a connection is being torn
+// down. A panic there would take the hub process with it.
+func TestWS_WriteProtocolPingIsNilSafe(t *testing.T) {
+	if err := writeProtocolPing(nil); err != nil {
+		t.Fatalf("writeProtocolPing(nil) = %v, want nil", err)
+	}
+}
+
+// TestWS_ProtocolPingDeadlineIsShorterThanHeartbeatInterval pins the invariant
+// that keeps a wedged peer from stacking up heartbeat goroutines: the bounded
+// write must give up well before the next tick schedules another one.
+func TestWS_ProtocolPingDeadlineIsShorterThanHeartbeatInterval(t *testing.T) {
+	if wsProtocolPingDeadline >= wsHeartbeatInterval {
+		t.Fatalf("wsProtocolPingDeadline (%v) must be shorter than wsHeartbeatInterval (%v), "+
+			"or a peer that has stopped reading accumulates blocked heartbeat writes",
+			wsProtocolPingDeadline, wsHeartbeatInterval)
+	}
+}
+
+// TestWS_HeartbeatIntervalLeavesRoomForProxyIdleTimers records WHY the interval
+// is what it is. The flap this fixes was an idle-timer reap; the keepalive is
+// only worth sending if it comfortably outpaces the shortest idle timeout in
+// the path (the OCI load balancer's 300s default, and nginx's 60s
+// proxy_read_timeout default before this repo's Ingress raises it to 3600).
+func TestWS_HeartbeatIntervalLeavesRoomForProxyIdleTimers(t *testing.T) {
+	const shortestPlausibleProxyIdleTimeout = 60 * time.Second
+	// Two ticks must fit inside the shortest idle window, so a single dropped
+	// or delayed ping cannot by itself let the timer expire.
+	if 2*wsHeartbeatInterval > shortestPlausibleProxyIdleTimeout {
+		t.Fatalf("wsHeartbeatInterval (%v) is too long: two ticks (%v) exceed the shortest "+
+			"plausible proxy idle timeout (%v), so one missed keepalive lets an "+
+			"intermediary reap the socket frameless (#5090)",
+			wsHeartbeatInterval, 2*wsHeartbeatInterval, shortestPlausibleProxyIdleTimeout)
+	}
+}


### PR DESCRIPTION
Refs #5090

Deliberately `Refs`, not `Fixes`: #5090 was already once auto-closed by #5107's `Fixes` line and had to be reopened, and confirming this one requires watching a live hosted spoke for the flap cadence to collapse. Close it by hand once that observation is in.

## Root cause

The contributor keepalive was implemented **entirely in application JSON**. The hub sent `{"type":"ping"}` as an ordinary **text** frame and the relay answered `{"type":"pong"}`. `websocket.PingMessage` appeared nowhere in `pkg/dashboard`, and the relay never called `ws.ping()` — **no WebSocket protocol-level control frame was ever exchanged in either direction.**

That distinction is invisible to the two endpoints and decisive to everything between them. The hosted spokes sit behind ingress-nginx and an OCI load balancer, and an L7 proxy may score tunnel idleness on **control-frame traffic alone**, precisely because application payload can be a long unidirectional stream that proves nothing about liveness. Under such an intermediary a socket carrying a text frame every 30s is still "idle", and gets reaped on the idle timer **without a Close frame** — the peer observes 1006 with an empty reason and neither side logs anything.

That is exactly the signature #5090 measured, and it reconciles the two facts that previously looked contradictory in the issue thread:

- After #5107 the hub **provably** sends Close frames on every hangup of its own, yet **every** observed flap carried no frame at all. So the close was not the hub's.
- Both sides heartbeat every 30s, which "should reset any ordinary idle timer" — the thread's own caveat against the idle-timeout theory. It doesn't, if the timer only counts control frames. The heartbeat was real traffic that the intermediary was entitled to ignore.

It also fits the shapes the thread could not explain: traffic-independent drops, and lifetimes scattered across 30s/61s/300s/420s rather than one clean constant, which is what you get when independent idle timers at different layers each expire against a tunnel that never proves itself alive.

## The change

Both directions now exchange real control frames. Purely **additive** — the JSON ping/pong is untouched.

- **Hub** (`src/pkg/dashboard/contribute_ws.go`): new `writeProtocolPing` sends a Ping (opcode `0x9`) alongside the existing JSON ping on every heartbeat tick. Registration installs a `SetPongHandler` so an inbound protocol Pong refreshes `lastPong`.
- **Relay** (`bin/contributor-relay.sh`): the heartbeat also calls `ws.ping()`, and `'pong'`/`'ping'` events refresh `lastPong`.

Both halves of the liveness accounting were required together. The hub now pings with a control frame, and **any conforming WebSocket client answers that with a control-frame Pong automatically, with no relay code at all**. Had the hub kept crediting only the JSON `{"type":"pong"}`, such a client would be declared stale after `wsHeartbeatTimeout` and hung up — the fix would have manufactured a brand-new flap. Same reasoning in reverse for the relay.

Backward compatible in both directions: an old relay that answers only the JSON heartbeat still works, and an old hub that ignores control frames is unaffected by the relay's extra Ping.

Also converts the heartbeat's ping-write-failure branch from a bare `c.ws.Close()` to `closeWithReason` — a site #5107 missed, so that path was still producing the silent 1006 that issue set out to eliminate.

## Locking

Neither `writeProtocolPing` nor `closeWithReason` takes `writeMu`. `WriteControl` is documented safe to call concurrently with all other methods, and taking the lock there would nest it under callers that already hold it — the re-entrancy shape this repo has deadlocked on before. The new pong handler takes `c.mu` only; gorilla invokes it from `ReadMessage` on the read goroutine, which holds neither lock at that point, matching what the existing JSON `"pong"` case already does.

## Tests

New `src/pkg/dashboard/contribute_ws_protocol_ping_test.go`:

- `TestWS_HubSendsProtocolPingControlFrame` — asserts a real Ping control frame reaches the wire, read through a client-side ping handler. This is the assertion that fails against `v4` today.
- `TestWS_ProtocolPongRefreshesLiveness` — a protocol Pong must clear a deliberately-stale `lastPong`, or control-frame-only clients get false-timed-out.
- `TestWS_RegisteredConnectionInstallsPongHandler` — drives the real registration path and sends an unsolicited protocol Pong (legal per RFC 6455 §5.5.3), then proves the connection is still usable. This is the wiring test; without the `SetPongHandler` call it regresses.
- `TestWS_WriteProtocolPingIsNilSafe` — `heartbeatLoop` can tick during teardown; a panic there would take the hub process with it.
- `TestWS_ProtocolPingDeadlineIsShorterThanHeartbeatInterval` — a wedged peer must not stack up blocked heartbeat writes.
- `TestWS_HeartbeatIntervalLeavesRoomForProxyIdleTimers` — pins that two ticks fit inside the shortest plausible proxy idle window, so one missed keepalive cannot by itself let a timer expire.

## Relationship to #5151 and to the ingress work

**No overlap with #5151.** That issue is the *accounting* side — the disconnect defer booking a ~1s reconnect as a full depart+rejoin. This PR does not touch the disconnect path, `bookReleaseCooldown`, the activity-feed writes, or `tokenMintedAt`. It attacks the flap upstream of all of that, so the two are independent and can land in either order.

The sequencing note in #5151 is worth restating: the three-rows-per-flap pattern is currently the **measuring instrument** for verifying this fix from the dashboard. Keep it until the flap cadence is confirmed collapsed, then suppress it.

This also does not make the ingress asks in #5090 moot. Raising `oci-load-balancer-connection-idle-timeout` is still worth doing, and if the real killer turns out to be nginx **reload/drain** rather than an idle timer, no keepalive can help — reloads cut held sockets regardless of traffic. What this PR does is remove the application-layer cause from the list, so a flap that survives it is unambiguously reload/drain and the cluster-side investigation narrows to one suspect.
