### PR TITLE
🔧 fix(ci): stop the NOTICE gate from blocking every Dependabot gomod PR

### DIFF
--- a/.github/workflows/go-security-analysis.yml
+++ b/.github/workflows/go-security-analysis.yml
@@ -188,6 +188,13 @@ jobs:
       - name: Exercise NOTICE drift diagnostics
         run: src/scripts/test-check-notice-drift.sh
 
+      # The autofix workflow commits a generated NOTICE unattended, so the
+      # guard that decides whether a generated file is fit to commit needs its
+      # own regression coverage here — notice-autofix.yml runs on
+      # workflow_run and cannot gate a PR itself.
+      - name: Exercise generated-NOTICE validation
+        run: src/scripts/test-validate-generated-notice.sh
+
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
@@ -195,6 +202,39 @@ jobs:
 
       - name: Regenerate NOTICE from the current module graph
         run: src/scripts/generate-notice.sh /tmp/NOTICE.generated
+
+      # Publish the regenerated file BEFORE the gate runs, so it is uploaded
+      # on the failing path too — that is the only path where anyone needs it.
+      # notice-autofix.yml consumes this artifact via workflow_run to commit
+      # the regeneration back onto a Dependabot branch (#5256). Uploading here
+      # rather than regenerating in the autofix workflow is deliberate: this
+      # job already runs the generator with a read-only token and no secrets,
+      # so the privileged workflow never has to execute PR-head code.
+      - name: Publish the regenerated NOTICE for the autofix workflow
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: notice-generated
+          path: /tmp/NOTICE.generated
+          retention-days: 1
+          if-no-files-found: error
+
+      # The PR number travels with the artifact because workflow_run does not
+      # expose it: the triggering run's event payload is not forwarded, and
+      # resolving head SHA back to a PR is an extra API round trip that can
+      # match the wrong PR when several share a head.
+      - name: Record the PR number for the autofix workflow
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > /tmp/pr-number.txt
+
+      - name: Publish the PR number for the autofix workflow
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: notice-pr-number
+          path: /tmp/pr-number.txt
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Fail if the committed NOTICE is stale
         run: src/scripts/check-notice-drift.sh NOTICE /tmp/NOTICE.generated

--- a/.github/workflows/notice-autofix.yml
+++ b/.github/workflows/notice-autofix.yml
@@ -1,0 +1,137 @@
+# NOTICE Autofix — commit the regenerated NOTICE back onto Dependabot's own
+# Go-module bump branches.
+#
+# WHY THIS WORKFLOW EXISTS (#5256)
+#
+# The "NOTICE matches the module graph" gate (go-security-analysis.yml, job
+# notice-drift) compares the committed NOTICE byte-for-byte against a fresh
+# regeneration from src/go.mod + src/go.sum. That comparison is correct and
+# worth keeping — it is what surfaced an AGPL-3.0 dependency entering this
+# Apache-2.0 project (#5016). But it fails on EVERY Dependabot gomod PR by
+# construction: a version bump changes the module graph, so the committed
+# NOTICE necessarily no longer matches, and Dependabot cannot regenerate it
+# (that needs a Go toolchain and the pinned go-licenses). Result: 100% of
+# gomod bumps arrive permanently red and each one needs a human to check out
+# the branch, run the generator, and push.
+#
+# This workflow closes that loop. It does NOT weaken the gate: the gate still
+# runs, still compares byte-for-byte, and still fails when NOTICE is stale.
+# What changes is that for a Dependabot branch the staleness is repaired
+# automatically, so the next run of the gate passes on a correct NOTICE
+# rather than a human doing the same mechanical regeneration by hand.
+#
+# WHY workflow_run AND NOT pull_request_target
+#
+# The obvious implementation is a pull_request_target job that checks out the
+# PR head and runs src/scripts/generate-notice.sh with a contents:write token.
+# That is unsafe even when gated to Dependabot: generate-notice.sh resolves
+# and downloads the module graph described by the PR's own go.mod/go.sum, so
+# it executes tooling against attacker-influenceable inputs while holding a
+# token that can write to the repository. `go install`, module resolution and
+# go-licenses all run arbitrary upstream code paths.
+#
+# workflow_run splits the privilege from the untrusted work:
+#
+#   * go-security-analysis.yml's notice-drift job runs on `pull_request` —
+#     read-only token, no secrets — and uploads its already-generated
+#     /tmp/NOTICE.generated as an artifact. It was going to generate that
+#     file anyway; it now publishes it.
+#   * this workflow runs on `workflow_run`, so it executes the version of
+#     itself committed on the DEFAULT branch, never the PR's version. It
+#     downloads the artifact and commits it. It never checks out or runs any
+#     code from the PR head.
+#
+# The artifact is data, not code, and it is validated below before use.
+#
+# WHY THE VALIDATION STEP IS NOT OPTIONAL
+#
+# Committing a generated file from an artifact means the artifact's content
+# becomes the repository's attribution record. Three things are checked
+# before anything is committed, and any failure aborts loudly rather than
+# committing a degraded NOTICE:
+#
+#   1. The file must carry the generator's real header — a truncated or
+#      empty artifact must never overwrite a good NOTICE.
+#   2. No trailing-whitespace lines (#5064). The generator normalizes these,
+#      but committing an unnormalized file would guarantee a permanent diff
+#      against every future regeneration.
+#   3. No unverified/missing license text, and no FORBIDDEN license class.
+#      A copyleft dependency entering the tree must still stop the pipeline
+#      and reach a human — auto-committing a NOTICE that records an AGPL
+#      dependency would launder a license problem into a green check.
+#
+# KNOWN LIMITATION
+#
+# A push made with GITHUB_TOKEN does not trigger new workflow runs, so the
+# autofix commit does not itself re-run notice-drift. The branch is correct
+# from that moment on and the gate passes on the next run (Dependabot's next
+# rebase, a maintainer re-run, or any later push). The value delivered is
+# that no human has to regenerate the file. If Dependabot force-pushes a
+# rebase the autofix commit is dropped and this workflow simply runs again.
+
+name: NOTICE Autofix
+
+on:
+  workflow_run:
+    workflows: ['Go Security Analysis']
+    types: [completed]
+
+# contents:write is the only privilege needed and the only one granted.
+permissions:
+  contents: write
+
+concurrency:
+  group: notice-autofix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  regenerate-notice:
+    name: Commit regenerated NOTICE for Dependabot
+    runs-on: ubuntu-latest
+    # Gate on the triggering run: a Dependabot-authored PR from a branch in
+    # this repository. Dependabot never opens PRs from forks, so requiring
+    # head_repository == repository closes the fork vector completely.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+    steps:
+      # Check out the DEFAULT branch state of the PR's branch — i.e. the
+      # Dependabot branch itself, which contains only manifest/lockfile
+      # changes. Nothing from it is executed; it is the commit target.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Download the regenerated NOTICE
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: notice-generated
+          path: /tmp/notice-artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate the regenerated NOTICE before trusting it
+        run: src/scripts/validate-generated-notice.sh /tmp/notice-artifact/NOTICE.generated
+
+      - name: Commit and push if NOTICE changed
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          cp -- /tmp/notice-artifact/NOTICE.generated NOTICE
+          if git diff --quiet -- NOTICE; then
+            echo "NOTICE already matches the module graph — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- NOTICE
+          # -s because this repository requires DCO sign-off on every commit.
+          git commit -s -m "chore: regenerate NOTICE for dependency bump
+
+          Regenerated by .github/workflows/notice-autofix.yml from the module
+          graph in this branch's src/go.mod and src/go.sum. See #5256."
+          git push origin "HEAD:${HEAD_BRANCH}"

--- a/src/scripts/test-validate-generated-notice.sh
+++ b/src/scripts/test-validate-generated-notice.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Regression coverage for the autofix validation contract (#5256).
+#
+# Each case asserts the INVARIANT, not just an exit code: a validator that
+# accepted everything would still pass an exit-status-only test on the happy
+# path, so every rejection case also asserts the specific diagnostic that
+# names WHY the file was refused.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate-generated-notice.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# A minimal but structurally complete generated NOTICE.
+write_good_notice() {
+  cat > "$1" <<'EOF'
+Hive — Third-Party Notices
+===========================
+
+-----------------------------------------------------------------------------
+
+Package:  github.com/example/one
+Version:  v1.0.0
+License:  Apache-2.0
+Source:   https://example.invalid/one/LICENSE
+
+Licensed under the Apache License, Version 2.0.
+
+-----------------------------------------------------------------------------
+
+EOF
+}
+
+GOOD="${TMP}/NOTICE.good"
+write_good_notice "${GOOD}"
+
+# --- happy path --------------------------------------------------------------
+output="$("${VALIDATOR}" "${GOOD}" 2>&1)"
+grep -qF 'Generated NOTICE validated' <<< "${output}"
+grep -qF '1 dependency entries' <<< "${output}"
+
+# --- empty / missing ---------------------------------------------------------
+: > "${TMP}/NOTICE.empty"
+if output="$("${VALIDATOR}" "${TMP}/NOTICE.empty" 2>&1)"; then
+  echo "FAIL: empty NOTICE accepted" >&2; exit 1
+fi
+grep -qF 'missing or empty' <<< "${output}"
+
+if output="$("${VALIDATOR}" "${TMP}/does-not-exist" 2>&1)"; then
+  echo "FAIL: nonexistent NOTICE accepted" >&2; exit 1
+fi
+
+# --- truncated (no header) ---------------------------------------------------
+grep -v 'Third-Party Notices' "${GOOD}" > "${TMP}/NOTICE.noheader"
+if output="$("${VALIDATOR}" "${TMP}/NOTICE.noheader" 2>&1)"; then
+  echo "FAIL: headerless NOTICE accepted" >&2; exit 1
+fi
+grep -qF 'looks truncated' <<< "${output}"
+
+# --- header but zero dependency entries --------------------------------------
+printf 'Hive — Third-Party Notices\n===========================\n\n' > "${TMP}/NOTICE.noentries"
+if output="$("${VALIDATOR}" "${TMP}/NOTICE.noentries" 2>&1)"; then
+  echo "FAIL: NOTICE with no dependency entries accepted" >&2; exit 1
+fi
+grep -qF 'no dependency entries' <<< "${output}"
+
+# --- trailing whitespace (#5064) ---------------------------------------------
+write_good_notice "${TMP}/NOTICE.trailing"
+printf 'some license line with a trailing space \n' >> "${TMP}/NOTICE.trailing"
+if output="$("${VALIDATOR}" "${TMP}/NOTICE.trailing" 2>&1)"; then
+  echo "FAIL: trailing-whitespace NOTICE accepted" >&2; exit 1
+fi
+grep -qF 'trailing whitespace' <<< "${output}"
+grep -qF '#5064' <<< "${output}"
+
+# --- unverified attribution --------------------------------------------------
+write_good_notice "${TMP}/NOTICE.unverified"
+cat >> "${TMP}/NOTICE.unverified" <<'EOF'
+Package:  github.com/example/two
+Version:  v2.0.0
+License:  MIT
+Source:   https://example.invalid/two
+
+    (license text not found by go-licenses; verify manually)
+
+-----------------------------------------------------------------------------
+
+EOF
+if output="$("${VALIDATOR}" "${TMP}/NOTICE.unverified" 2>&1)"; then
+  echo "FAIL: NOTICE with unverified license text accepted" >&2; exit 1
+fi
+grep -qF 'Attribution is incomplete' <<< "${output}"
+
+# --- unknown license identifier ----------------------------------------------
+write_good_notice "${TMP}/NOTICE.unknown"
+printf 'Package:  github.com/example/three\nVersion:  v3.0.0\nLicense:  Unknown\nSource:   https://example.invalid/three\n\ntext\n' >> "${TMP}/NOTICE.unknown"
+if output="$("${VALIDATOR}" "${TMP}/NOTICE.unknown" 2>&1)"; then
+  echo "FAIL: NOTICE with Unknown license accepted" >&2; exit 1
+fi
+grep -qF 'unknown or empty license identifier' <<< "${output}"
+
+# --- FORBIDDEN licenses must fail loudly -------------------------------------
+# This is the invariant that matters most: the autofix must never launder a
+# copyleft dependency into a green check (#5016 caught AGPL-3.0 go-docx).
+for spdx in AGPL-3.0 AGPL-3.0-or-later GPL-2.0 GPL-3.0-only SSPL-1.0 BUSL-1.1 EUPL-1.2 OSL-3.0 CC-BY-NC-4.0; do
+  f="${TMP}/NOTICE.forbidden"
+  write_good_notice "${f}"
+  printf 'Package:  github.com/example/bad\nVersion:  v1.0.0\nLicense:  %s\nSource:   https://example.invalid/bad\n\ntext\n' "${spdx}" >> "${f}"
+  if output="$("${VALIDATOR}" "${f}" 2>&1)"; then
+    echo "FAIL: forbidden license ${spdx} accepted" >&2; exit 1
+  fi
+  grep -qF 'FORBIDDEN' <<< "${output}" || {
+    echo "FAIL: ${spdx} rejected without naming it FORBIDDEN" >&2; exit 1; }
+  grep -qF "${spdx}" <<< "${output}" || {
+    echo "FAIL: diagnostic for ${spdx} did not name the offending license" >&2; exit 1; }
+done
+
+# --- permissive licenses must NOT be misclassified as forbidden --------------
+# Guards against an over-broad pattern: LGPL and MPL are not on the forbidden
+# list, and no permissive identifier may be caught by the copyleft regex.
+for spdx in MIT Apache-2.0 BSD-3-Clause BSD-2-Clause ISC MPL-2.0 LGPL-3.0 Unlicense Zlib; do
+  f="${TMP}/NOTICE.ok"
+  write_good_notice "${f}"
+  printf 'Package:  github.com/example/fine\nVersion:  v1.0.0\nLicense:  %s\nSource:   https://example.invalid/fine\n\ntext\n' "${spdx}" >> "${f}"
+  if ! output="$("${VALIDATOR}" "${f}" 2>&1)"; then
+    echo "FAIL: permissive license ${spdx} rejected: ${output}" >&2; exit 1
+  fi
+done
+
+# --- license BODY text naming a copyleft licence must not false-positive -----
+# Many permissive license texts mention "GNU General Public License" in prose;
+# only the anchored "License:  " field may trigger the policy check.
+f="${TMP}/NOTICE.prose"
+write_good_notice "${f}"
+cat >> "${f}" <<'EOF'
+Package:  github.com/example/prose
+Version:  v1.0.0
+License:  MIT
+Source:   https://example.invalid/prose
+
+This library is not licensed under the AGPL-3.0 or GPL-3.0; see LICENSE.
+
+-----------------------------------------------------------------------------
+
+EOF
+if ! output="$("${VALIDATOR}" "${f}" 2>&1)"; then
+  echo "FAIL: prose mentioning AGPL-3.0 triggered a false positive: ${output}" >&2; exit 1
+fi
+
+echo "validate-generated-notice tests: PASS"

--- a/src/scripts/validate-generated-notice.sh
+++ b/src/scripts/validate-generated-notice.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# validate-generated-notice.sh — assert that a generated NOTICE is fit to be
+# committed automatically.
+#
+# WHY THIS EXISTS (#5256)
+#
+# .github/workflows/notice-autofix.yml commits a regenerated NOTICE onto
+# Dependabot branches without a human reading it first. That is only safe if
+# something refuses the file when it is degraded or when it records a license
+# this project cannot ship. This script is that something.
+#
+# It deliberately does NOT compare against the committed NOTICE — drift is
+# check-notice-drift.sh's job, and drift is the expected state here (a
+# dependency bump changed the graph). This script asks a different question:
+# "is the freshly generated file itself trustworthy enough to commit
+# unattended?"
+#
+# Usage: src/scripts/validate-generated-notice.sh <generated-notice>
+set -euo pipefail
+
+GENERATED_NOTICE="${1:?usage: validate-generated-notice.sh <generated-notice>}"
+
+if [[ ! -s "${GENERATED_NOTICE}" ]]; then
+  echo "::error::${GENERATED_NOTICE} is missing or empty; refusing to overwrite NOTICE." >&2
+  exit 1
+fi
+
+fail=0
+
+# 1. STRUCTURAL INTEGRITY -----------------------------------------------------
+# A truncated artifact (interrupted upload, partial generator run) must never
+# replace a good NOTICE. The generator's header and at least one rendered
+# dependency entry are the cheapest proof the file is whole.
+if ! grep -qF 'Hive — Third-Party Notices' -- "${GENERATED_NOTICE}"; then
+  echo "::error::${GENERATED_NOTICE} does not carry the generator's header; it looks truncated or hand-made. Refusing to commit it." >&2
+  fail=1
+fi
+
+entry_count="$(grep -c '^Package:  ' -- "${GENERATED_NOTICE}" || true)"
+if (( entry_count == 0 )); then
+  echo "::error::${GENERATED_NOTICE} contains no dependency entries; a NOTICE with zero third-party packages is a generator failure, not a real module graph. Refusing to commit it." >&2
+  fail=1
+fi
+
+# 2. BYTE-REPRODUCIBILITY (#5064) --------------------------------------------
+# The drift gate is byte-for-byte and whitespace-significant. generate-notice.sh
+# strips end-of-line whitespace from upstream license texts precisely so local
+# and CI output agree. If a trailing-space line survives into the artifact, the
+# generator's normalization has regressed, and committing the file would bake a
+# permanent phantom diff into the repository.
+trailing="$(grep -c '[[:space:]]$' -- "${GENERATED_NOTICE}" || true)"
+if (( trailing > 0 )); then
+  echo "::error::${GENERATED_NOTICE} has ${trailing} line(s) with trailing whitespace. generate-notice.sh is supposed to normalize these (#5064); committing this file would guarantee permanent NOTICE drift. Refusing to commit it." >&2
+  fail=1
+fi
+
+# 3. ATTRIBUTION COMPLETENESS -------------------------------------------------
+# The generator emits this marker when go-licenses could not locate a
+# dependency's license file. That is a genuine gap in attribution and needs a
+# human, not an automatic commit that makes it look resolved.
+if grep -qF 'license text not found by go-licenses' -- "${GENERATED_NOTICE}"; then
+  echo "::error::${GENERATED_NOTICE} contains dependencies whose license text go-licenses could not find. Attribution is incomplete; a human must resolve this rather than auto-committing. Offending entries:" >&2
+  grep -B 5 -F 'license text not found by go-licenses' -- "${GENERATED_NOTICE}" | grep '^Package:  ' >&2 || true
+  fail=1
+fi
+
+# An empty alternation branch ("(a|b|)") is a GNU-grep extension that other
+# POSIX greps reject outright, so the "no identifier at all" case is spelled as
+# its own alternative rather than an empty branch.
+UNKNOWN_SPDX_PATTERN='^License:  ([Uu]nknown|UNKNOWN|none|NONE)?[[:space:]]*$'
+
+if grep -qE "${UNKNOWN_SPDX_PATTERN}" -- "${GENERATED_NOTICE}"; then
+  echo "::error::${GENERATED_NOTICE} contains entries with an unknown or empty license identifier. Refusing to commit an unverified attribution record." >&2
+  grep -nE "${UNKNOWN_SPDX_PATTERN}" -- "${GENERATED_NOTICE}" >&2 || true
+  fail=1
+fi
+
+# 4. LICENSE POLICY -----------------------------------------------------------
+# Hive ships under Apache-2.0. A strong-copyleft dependency entering the module
+# graph is exactly the event the notice-drift gate exists to surface — it is how
+# the AGPL-3.0 go-docx dependency was caught (#5016). Auto-committing a NOTICE
+# that records such a dependency would turn that red signal green and launder a
+# real license problem into a routine bot commit. This check fails LOUDLY and
+# stops the autofix; the human path (read the finding, drop or replace the
+# dependency) is unchanged.
+#
+# Matched on the SPDX identifiers go-licenses emits, anchored to the generator's
+# "License:  " field so license BODY text mentioning a licence name cannot
+# trigger a false positive.
+FORBIDDEN_SPDX_PATTERN='^License:  (AGPL-[0-9.]+(-only|-or-later)?|GPL-[0-9.]+(-only|-or-later)?|SSPL-[0-9.]+|OSL-[0-9.]+|CC-BY-NC[-.A-Za-z0-9]*|BUSL-[0-9.]+|EUPL-[0-9.]+)([[:space:]]|$)'
+
+if grep -qE "${FORBIDDEN_SPDX_PATTERN}" -- "${GENERATED_NOTICE}"; then
+  echo "::error::${GENERATED_NOTICE} records a dependency under a license that is FORBIDDEN in this Apache-2.0 project. Refusing to auto-commit. A human must remove or replace the dependency. Offending entries:" >&2
+  grep -nE "${FORBIDDEN_SPDX_PATTERN}" -- "${GENERATED_NOTICE}" >&2 || true
+  fail=1
+fi
+
+if (( fail != 0 )); then
+  exit 1
+fi
+
+echo "Generated NOTICE validated: ${entry_count} dependency entries, no trailing whitespace, no unverified attribution, no forbidden licenses."


### PR DESCRIPTION
## Problem

The `notice-drift` job ("NOTICE matches the module graph") compares the committed `NOTICE` **byte-for-byte** against a fresh regeneration from `src/go.mod` + `src/go.sum`.

Every Dependabot Go-module bump changes the module graph, so the committed `NOTICE` necessarily no longer matches — and Dependabot **cannot** regenerate it, because that needs a Go toolchain and the pinned `go-licenses`. The result is structural: **100% of gomod bumps arrive permanently red**, and each one needs a human to check out the branch, run `src/scripts/generate-notice.sh`, and push before it can merge.

## Approach chosen: auto-regenerate, via `workflow_run` (option 1)

Of the three directions on the table, this is the only one that keeps the gate meaningful *and* stops the blocking. Option 2 (make the gate advisory for Dependabot) lets a stale `NOTICE` merge — and a stale `NOTICE` is exactly the false completeness claim the job exists to prevent. Option 3 is already done: the generator normalizes trailing whitespace today, and `v4`'s `NOTICE` has zero trailing-space lines, so determinism is not what is breaking these PRs. A version bump genuinely *does* change the graph; no amount of determinism makes that diff zero.

### Why `workflow_run` and not `pull_request_target`

The obvious implementation — and the one drafted in the issue thread — is a `pull_request_target` job that checks out the PR head and runs `generate-notice.sh` with a `contents: write` token. **That is unsafe even when gated to Dependabot.** `generate-notice.sh` resolves and downloads the module graph described by the PR's own `go.mod`/`go.sum`; `go install`, module resolution, and `go-licenses` all execute upstream code paths against attacker-influenceable inputs, while holding a token that can write to the repository.

This PR splits the privilege from the untrusted work:

- `notice-drift` runs on `pull_request` (read-only token, no secrets) and uploads the `NOTICE` **it already generates** as an artifact. Upload happens *before* the gate step, so it is published on the failing path too — the only path where anyone needs it.
- `notice-autofix.yml` runs on `workflow_run`, so it executes the version of itself on the default branch, never the PR's version. It downloads the artifact and commits it. **It never checks out or executes any code from the PR head.**

The artifact is data, not code — and it is validated before use.

### The validation guard is the load-bearing part

Committing a generated file unattended means the artifact's content *becomes* the repository's attribution record. New `src/scripts/validate-generated-notice.sh` refuses to commit when the file is:

1. **truncated / empty / headerless**, or has zero dependency entries
2. carrying **trailing-whitespace lines** (would bake permanent phantom drift into the repo)
3. missing license text (`license text not found by go-licenses`) or carrying an **unknown/empty** SPDX identifier
4. recording a **FORBIDDEN** license: `AGPL` / `GPL` / `SSPL` / `BUSL` / `EUPL` / `OSL` / `CC-BY-NC`

Any failure aborts loudly instead of committing. **License enforcement is not weakened** — the gate still runs, still compares byte-for-byte, and a copyleft dependency entering the tree now fails in *two* places instead of one. Auto-committing a `NOTICE` that records an AGPL dependency would have laundered a real license problem into a routine green bot commit; #5016 (AGPL-3.0 `go-docx`) is why that path is explicitly closed.

## Relationship to #5064

This **helps but does not close** #5064.

`generate-notice.sh` already carries the `sed 's/[[:space:]]\+$//'` normalization, and `v4`'s committed `NOTICE` has **0** trailing-space lines and **0** unverified entries today (verified against all 55 entries). So the fix #5064 asked for has effectively landed in the generator.

What this PR adds is **enforcement** of that property: check 2 above turns "the generator is supposed to normalize" into "a regression in that normalization stops the pipeline." I have **not** verified byte-reproducibility across environments, which is #5064's actual acceptance criterion, so I am deliberately not claiming to close it.

Per @clubanderson's caveat on that issue: this PR commits the generator's output **verbatim**. No reformatting, no post-hoc `sed` on the committed file. The validator only *rejects*, it never rewrites.

## Tradeoff, stated honestly

A push made with `GITHUB_TOKEN` does not trigger new workflow runs, so the autofix commit **does not itself re-run `notice-drift`**. The branch is correct from that moment on and the gate passes on the next run — Dependabot's next rebase, a maintainer re-run, or any later push. The value delivered is that **no human has to regenerate the file**; a re-run click is not the same cost as a local checkout plus Go toolchain plus regeneration. If Dependabot force-pushes a rebase, the autofix commit is dropped and the workflow simply runs again on the new head.

Using a PAT or App token instead would make the re-run automatic, but that trades a scoped `GITHUB_TOKEN` for a long-lived credential with write access — not worth it for one click.

## Testing

New `src/scripts/test-validate-generated-notice.sh` (wired into `notice-drift`, following the existing `test-check-notice-drift.sh` pattern) asserts the **invariant**, not just exit codes — every rejection case also asserts the specific diagnostic naming *why* the file was refused. Covers: happy path, empty, missing, truncated, zero-entry, trailing whitespace, unverified text, unknown identifier, 9 forbidden licenses, 9 permissive licenses that must **not** be misclassified (incl. `LGPL-3.0` and `MPL-2.0`), and license *body* prose mentioning AGPL/GPL that must not false-positive.

Validator runs clean against the real committed `NOTICE` (55 entries). Both new scripts are `shellcheck`-clean and committed `100755`. All action references are SHA-pinned, copied from existing neighbors; `check-action-pins.sh` passes.

Fixes #5256
