### PR TITLE
🐛 fix(hub): refuse manual upgrades a spoke cannot collect

### DIFF
--- a/src/pkg/hub/cluster_health_coverage_test.go
+++ b/src/pkg/hub/cluster_health_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // ============================================================
@@ -110,7 +111,13 @@ func TestHandleUpgradeHiveSuccess(t *testing.T) {
 		logger:    slog.Default(),
 		clusters:  map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}},
 	}
-	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
+	// LastHeartbeat: the manual path refuses a hive that cannot COLLECT the
+	// upgrade (pull-only delivery, see pullonly_upgrade.go), so a success-path
+	// test needs a hive that is heartbeating.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitBranch: "v2",
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
+	}}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "h1")

--- a/src/pkg/hub/pullonly_upgrade_test.go
+++ b/src/pkg/hub/pullonly_upgrade_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -533,5 +534,251 @@ func TestAutoUpgradeToggleWorksUnderPull(t *testing.T) {
 	s.triggerAutoUpgrades()
 	if !s.registry.Hives[0].Upgrading {
 		t.Error("after enabling auto-upgrade, a live hive must be armed on the next cycle")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MANUAL "Upgrade now" — the same collectibility gate as the automatic path.
+//
+// These are the manual-path halves of the pairs above. The bug they pin (#5304)
+// is an ASYMMETRY, not a missing feature: triggerAutoUpgrades() already refused
+// to arm a hive that cannot COLLECT an upgrade, while handleUpgradeHive — the
+// button — armed unconditionally. That made the click strictly worse than the
+// auto path it diverged from. The auto path refuses and records the refusal on
+// the timeline, so an operator can find out why; the click returned
+// {"status":"upgrading"} and a success toast for a target that could never be
+// collected, then latched Upgrading=true for the stale sweep to re-arm every
+// staleUpgradeTimeout forever.
+//
+// The asymmetry is also actively misleading: the same spoke auto-upgrade had
+// declined would happily accept a manual click, so the button LOOKED like it
+// worked around the problem when it had only hidden it.
+//
+// The positive control (healthy hive → 200) is what stops a regression that
+// simply refuses every manual upgrade from passing this file.
+// ---------------------------------------------------------------------------
+
+// manualUpgradeReq builds the authenticated manual-upgrade request the button
+// sends, with the hive id bound the way the mux would bind it.
+func manualUpgradeReq(hiveID, user string) *http.Request {
+	return setPathValue(reqWithUser(http.MethodPost, "/api/saas/hives/"+hiveID+"/upgrade", "", user), "id", hiveID)
+}
+
+func TestManualUpgradeRefusesUncollectibleHive(t *testing.T) {
+	cases := []struct {
+		name string
+		// lastHeartbeat is RegistryEntry.LastHeartbeat — the ONLY record that
+		// carries it. SaaSHive has no such field, so this is also the source the
+		// automatic path reads.
+		lastHeartbeat func() string
+		// wantReason is a fragment the operator-facing refusal must contain.
+		wantReason string
+	}{
+		{
+			// The measured wedge population: unassigned placeholders that have
+			// never checked in. Under pull delivery nothing will EVER collect.
+			name:          "never heartbeated",
+			lastHeartbeat: func() string { return "" },
+			wantReason:    "never heartbeated",
+		},
+		{
+			// Silent past staleRemoveAge is the same bound the registry already
+			// uses to call a hive gone for good. Deliberately NOT
+			// maxHeartbeatAge — a spoke one beat late must still be upgradable.
+			name:          "silent beyond staleRemoveAge",
+			lastHeartbeat: func() string { return rfc3339At(time.Now().Add(-staleRemoveAge - time.Hour)) },
+			wantReason:    "beyond the point where it is considered present",
+		},
+		{
+			// An unreadable timestamp is treated as uncollectible: we must not
+			// arm on evidence we cannot read (the rule evaluateOrphanedUpgrade
+			// applies).
+			name:          "unparseable heartbeat",
+			lastHeartbeat: func() string { return "not-a-timestamp" },
+			wantReason:    "cannot collect",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+			mkUser(t, "alice")
+
+			s := pullOnlyTestServer(t)
+			s.forgetUncollectibleUpgrade("manual-dead")
+			saveSaaSHive(&SaaSHive{
+				ID: "manual-dead", Owner: "alice", Status: "running", ClusterID: "vllm-d",
+			})
+			s.registry.Hives = []RegistryEntry{{
+				ID: "manual-dead", GitBranch: "v4", GitHash: "old1234",
+				LastHeartbeat: tc.lastHeartbeat(),
+			}}
+
+			rec := httptest.NewRecorder()
+			s.handleUpgradeHive(rec, manualUpgradeReq("manual-dead", "alice"))
+
+			// 409, matching the pause-switch refusal shape in the same handler.
+			if rec.Code != http.StatusConflict {
+				t.Fatalf("status = %d, want 409 — the manual button must refuse an upgrade "+
+					"this hive can never collect, exactly as auto-upgrade does (body=%s)",
+					rec.Code, rec.Body.String())
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+
+			var body map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("refusal body is not JSON: %v (%s)", err, rec.Body.String())
+			}
+			// The operator must be told WHY. A bare 409 reproduces the original
+			// complaint in a new shape: the click stops working with no reason.
+			if !strings.Contains(body["error"], tc.wantReason) {
+				t.Errorf("refusal reason %q does not contain %q", body["error"], tc.wantReason)
+			}
+			// The reason is returned over the wire, so it must stay free of
+			// anything that is not the operator's business.
+			for _, leak := range []string{"kubeconfig", "/root/", "token", "secret"} {
+				if strings.Contains(strings.ToLower(body["error"]), leak) {
+					t.Errorf("refusal body leaks %q: %s", leak, body["error"])
+				}
+			}
+
+			// THE LATCH IS THE BUG. Arming set Upgrading=true against a target
+			// nothing would collect, and the stale sweep then re-armed it every
+			// staleUpgradeTimeout while beginUpgrade preserved the original start
+			// clock — so the elapsed only ever grew. Refusing must leave no latch.
+			s.mu.RLock()
+			h := s.registry.Hives[0]
+			s.mu.RUnlock()
+			if h.Upgrading {
+				t.Error("refused upgrade still latched Upgrading=true — this is the wedge: " +
+					"the stale sweep re-arms it forever and the orphan sweep's retry budget " +
+					"cannot break the loop, because a hive that never heartbeated fails " +
+					"evaluateOrphanedUpgrade()'s liveness test")
+			}
+			if h.UpgradeTarget != "" {
+				t.Errorf("refused upgrade recorded a target %q", h.UpgradeTarget)
+			}
+			if got, ok := s.heartbeatUpgrade["manual-dead"]; ok {
+				t.Errorf("refused upgrade still armed the heartbeat with %q", got)
+			}
+
+			// Refused LOUDLY. The auto path records its refusal on the timeline;
+			// the manual path recording nothing is what let this hide as success.
+			var found bool
+			for _, e := range s.timeline.recent("manual-dead", 100) {
+				if e.Kind == TimelineUpgradeStale {
+					found = true
+				}
+			}
+			if !found {
+				t.Error("the manual refusal left NO timeline record — the operator has no " +
+					"durable way to learn why the click did nothing")
+			}
+		})
+	}
+}
+
+// TestManualUpgradeHealthyHiveStillArms is the positive control for the gate
+// above: without it, a change that refused EVERY manual upgrade would pass.
+// A heartbeating spoke must arm exactly as before — including on a pull-only
+// cluster, since the hub's inability to kubectl in is irrelevant to a pull
+// delivery.
+func TestManualUpgradeHealthyHiveStillArms(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+
+	s := pullOnlyTestServer(t)
+	s.forgetUncollectibleUpgrade("manual-live")
+	saveSaaSHive(&SaaSHive{
+		ID: "manual-live", Owner: "alice", Status: "running", ClusterID: "vllm-d",
+	})
+	s.registry.Hives = []RegistryEntry{{
+		ID: "manual-live", GitBranch: "v4", GitHash: "old1234",
+		LastHeartbeat: rfc3339At(time.Now().Add(-30 * time.Second)),
+	}}
+
+	rec := httptest.NewRecorder()
+	s.handleUpgradeHive(rec, manualUpgradeReq("manual-live", "alice"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — a heartbeating spoke must still upgrade on "+
+			"click, on ANY cluster (body=%s)", rec.Code, rec.Body.String())
+	}
+	// The exact success shape the dashboard parses; "heartbeat" is what makes
+	// the UI say "queued" rather than implying an immediate pod roll.
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"status":"upgrading","mode":"heartbeat"}` {
+		t.Errorf("success body = %s, want {\"status\":\"upgrading\",\"mode\":\"heartbeat\"}", got)
+	}
+
+	s.mu.RLock()
+	h := s.registry.Hives[0]
+	s.mu.RUnlock()
+	if !h.Upgrading || h.UpgradeTarget != "7cd059b" {
+		t.Errorf("healthy hive was not armed: Upgrading=%v target=%q", h.Upgrading, h.UpgradeTarget)
+	}
+	// Delivery is pull: this map entry is the whole mechanism — the spoke reads
+	// it off its next heartbeat response and patches its own Deployment.
+	if got := s.heartbeatUpgrade["manual-live"]; got != "7cd059b" {
+		t.Errorf("heartbeat not armed for delivery: got %q, want 7cd059b", got)
+	}
+}
+
+// TestManualUpgradeRefusalDoesNotSuppressLaterRefusal pins the de-duplication
+// contract across the two paths. noteUncollectibleUpgrade dedupes per
+// (hive, target) using per-server memory; a successful arm must CLEAR that
+// memory, as the auto path already does on its own successful arm. Otherwise a
+// hive that is refused, recovers, is armed, and later goes silent again has its
+// second — genuine — refusal swallowed for the same target, putting the
+// operator back in the silence this fix exists to remove.
+func TestManualUpgradeRefusalDoesNotSuppressLaterRefusal(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+
+	s := pullOnlyTestServer(t)
+	s.forgetUncollectibleUpgrade("manual-flap")
+	saveSaaSHive(&SaaSHive{
+		ID: "manual-flap", Owner: "alice", Status: "running", ClusterID: "vllm-d",
+	})
+
+	// 1. Dead → refused, and recorded.
+	s.registry.Hives = []RegistryEntry{{ID: "manual-flap", GitBranch: "v4", GitHash: "old1234"}}
+	rec := httptest.NewRecorder()
+	s.handleUpgradeHive(rec, manualUpgradeReq("manual-flap", "alice"))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("first click status = %d, want 409", rec.Code)
+	}
+
+	// 2. Recovers and is armed. This must clear the de-dup memory.
+	s.mu.Lock()
+	s.registry.Hives[0].LastHeartbeat = rfc3339At(time.Now())
+	s.mu.Unlock()
+	rec = httptest.NewRecorder()
+	s.handleUpgradeHive(rec, manualUpgradeReq("manual-flap", "alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("recovered click status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	// 3. Goes silent again, same target. The refusal must be reported AFRESH.
+	s.mu.Lock()
+	s.registry.Hives[0].LastHeartbeat = ""
+	s.registry.Hives[0].Upgrading = false
+	s.registry.Hives[0].UpgradeTarget = ""
+	s.mu.Unlock()
+	delete(s.heartbeatUpgrade, "manual-flap")
+
+	before := len(s.timeline.recent("manual-flap", 100))
+	rec = httptest.NewRecorder()
+	s.handleUpgradeHive(rec, manualUpgradeReq("manual-flap", "alice"))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("second refusal status = %d, want 409", rec.Code)
+	}
+	if after := len(s.timeline.recent("manual-flap", 100)); after <= before {
+		t.Error("the second, genuine refusal was suppressed by stale de-duplication memory " +
+			"from the first — a successful arm must forget it, as the auto path does")
 	}
 }

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -4617,12 +4617,59 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	// the wedge this PR fixes. The hive is latched Upgrading with a target the
 	// moment the request returns, which is what the dashboard renders.
 
+	// Do not ARM an upgrade this hive cannot COLLECT — the same predicate
+	// triggerAutoUpgrades() applies, for the same reason. Delivery is PULL on
+	// BOTH paths: the hub only records a target and arms the heartbeat, and the
+	// spoke patches its own Deployment when it next beats. A hive that never
+	// heartbeats (or is silent past staleRemoveAge) therefore never collects
+	// the instruction, while Upgrading=true latches on the hub and the
+	// stale-upgrade sweep re-arms it every staleUpgradeTimeout — an unbounded
+	// loop the orphan sweep's retry budget cannot break, because such a hive
+	// fails evaluateOrphanedUpgrade()'s liveness test. See pullonly_upgrade.go.
+	//
+	// Without this, the manual button was strictly WORSE than the auto path it
+	// diverged from: auto-upgrade refuses and records the refusal on the
+	// timeline, whereas the click reported {"status":"upgrading"} and a success
+	// toast for an upgrade that could never land. Worse, the asymmetry read as
+	// a workaround — the same spoke auto-upgrade had declined would accept a
+	// manual click, appearing to fix the problem while only hiding it.
+	//
+	// lastHeartbeat comes from the REGISTRY entry, which is the only record
+	// that carries it; SaaSHive (the loadSaaSHive record `h` above) has no such
+	// field. This is the identical source triggerAutoUpgrades() reads.
+	//
+	// Refused with 409, matching the pause-switch refusal above. The reason is
+	// operator-facing by construction and documented to carry no kubeconfig
+	// paths or credentials, so it is safe in the body.
 	s.mu.Lock()
-	var latestSHA string
+	var latestSHA, lastHeartbeat string
+	var found bool
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
+			found = true
+			lastHeartbeat = s.registry.Hives[i].LastHeartbeat
 			branch := s.upgradeBranchOrDefault(s.registry.Hives[i].GitBranch)
 			latestSHA = getLatestSHAForBranch(branch)
+			break
+		}
+	}
+	// A hive with no registry entry has never checked in at all, so it is
+	// uncollectible for exactly the reason the empty-heartbeat case is.
+	if !found || !upgradeCollectible(lastHeartbeat, time.Now()) {
+		s.mu.Unlock()
+		reason := uncollectibleUpgradeReason(lastHeartbeat)
+		s.logger.Warn("manual upgrade not armed — hive cannot collect the instruction",
+			"hive_id", id, "by", username, "cluster", cluster.ID,
+			"would_have_targeted", latestSHA, "last_heartbeat", orDash(lastHeartbeat),
+			"reason", reason)
+		s.noteUncollectibleUpgrade(id, latestSHA, reason)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": reason})
+		return
+	}
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == id {
 			s.beginUpgrade(i, latestSHA)
 			break
 		}
@@ -4651,6 +4698,11 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	// collected by the spoke on its next beat. The UI uses this to say "queued"
 	// rather than implying an immediate roll.
 	const mode = "heartbeat"
+	// Armed successfully, so the uncollectible condition has genuinely cleared:
+	// drop the de-duplication memory (as the auto path does on its own successful
+	// arm) so a LATER refusal for this same target is reported afresh rather than
+	// suppressed by a stale entry.
+	s.forgetUncollectibleUpgrade(id)
 	s.logger.Info("audit: hosted hive upgrade requested",
 		"hive_id", id, "by", username, "cluster", cluster.ID, "mode", mode)
 	s.recordTimeline(id, TimelineUpgradeStarted, "upgrade requested from the hub dashboard ("+mode+")", username)

--- a/src/pkg/hub/saas_edge_coverage_test.go
+++ b/src/pkg/hub/saas_edge_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // ============================================================
@@ -49,7 +50,11 @@ func TestHandleUpgradeHiveRegistryUpdate(t *testing.T) {
 
 	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
 	// A matching registry entry so the post-upgrade registry-update loop runs.
-	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitBranch: "v2",
+		// Heartbeating, so the collectibility gate does not refuse the arm.
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
+	}}
 	resetSHACaches(t)
 	latestSHAMu.Lock()
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "latest7"}

--- a/src/pkg/hub/saas_handlers_coverage_test.go
+++ b/src/pkg/hub/saas_handlers_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ============================================================
@@ -286,6 +287,13 @@ func TestHandleUpgradeHiveKubectlFails(t *testing.T) {
 	// failure alone no longer fails the request: with a known target it arms
 	// the heartbeat fallback instead (TestHandleUpgradeHiveUnreachableCluster*).
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
+	// The hive must be heartbeating, otherwise the collectibility gate refuses
+	// with 409 BEFORE the no-build-target check this case is about. The branch
+	// deliberately has no known SHA, which is what produces the 502.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", GitBranch: "branch-with-no-build",
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
+	}}
 	rec = httptest.NewRecorder()
 	req = setPathValue(reqWithUser(http.MethodPost, "/up", "", "alice"), "id", "h1")
 	s.handleUpgradeHive(rec, req)

--- a/src/pkg/hub/spoke_upgrade_auth_test.go
+++ b/src/pkg/hub/spoke_upgrade_auth_test.go
@@ -26,6 +26,9 @@ func TestSpokeUpgradeProofAllowsOwnerWithoutHubCookie(t *testing.T) {
 		Owner:     user,
 		ClusterID: "hive-oke",
 		GitBranch: branch,
+		// Heartbeating: the manual upgrade path refuses a hive that cannot
+		// COLLECT the instruction (pull-only delivery, see pullonly_upgrade.go).
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
 	}}
 	s.spokeProxyAuthCache = map[string]spokeProxyAuthEntry{
 		hiveID: {token: token, expires: time.Now().Add(time.Hour)},
@@ -125,7 +128,8 @@ func TestSpokeUpgradeMiddlewareStillAcceptsHubSession(t *testing.T) {
 
 	s := newHandlerHub()
 	s.hubGitBranch = branch
-	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: user, ClusterID: "hive-oke", GitBranch: branch}}
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: user, ClusterID: "hive-oke", GitBranch: branch,
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: user, ClusterID: "hive-oke"}); err != nil {
 		t.Fatalf("save hive: %v", err)
 	}
@@ -261,7 +265,8 @@ func TestSpokeUpgradeProofWithoutUserIdentityAttributesToOwner(t *testing.T) {
 
 	s := newHandlerHub()
 	s.hubGitBranch = branch
-	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "hive-oke", GitBranch: branch}}
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "hive-oke", GitBranch: branch,
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	s.spokeProxyAuthCache = map[string]spokeProxyAuthEntry{
 		hiveID: {token: token, expires: time.Now().Add(time.Hour)},
 	}

--- a/src/pkg/hub/spoke_upgrade_stored_proof_test.go
+++ b/src/pkg/hub/spoke_upgrade_stored_proof_test.go
@@ -69,7 +69,7 @@ func TestSpokeUpgradeProofStoredRecordNoClusterAccess(t *testing.T) {
 	s.hubGitBranch = branch
 	// ClusterID the hub has no config (and so no kubeconfig) for: every
 	// kubectl lane is structurally unavailable.
-	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", GitBranch: branch}}
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", GitBranch: branch, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	if err := saveSaaSHive(&SaaSHive{
 		ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only",
 		Org: "org", PrimaryRepo: "repo",
@@ -110,7 +110,7 @@ func TestSpokeUpgradeProofClusterReadFallbackBackfillsRecord(t *testing.T) {
 
 	s := newHandlerHub()
 	s.hubGitBranch = branch
-	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "hive-oke", GitBranch: branch}}
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "hive-oke", GitBranch: branch, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	s.spokeProxyAuthCache = map[string]spokeProxyAuthEntry{
 		hiveID: {token: token, expires: time.Now().Add(time.Hour)},
 	}
@@ -148,7 +148,7 @@ func TestSpokeUpgradeProofBothLanesUnavailableIsHonest(t *testing.T) {
 	)
 
 	s := newHandlerHub()
-	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only"}}
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only"}); err != nil {
 		t.Fatalf("save hive: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestSpokeUpgradeProofMismatchAgainstStoredRecord(t *testing.T) {
 	)
 
 	s := newHandlerHub()
-	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only"}}
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	if err := saveSaaSHive(&SaaSHive{
 		ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only",
 		DashboardTokenHash: HashDashboardToken("the-real-token"),
@@ -259,7 +259,7 @@ func TestHeartbeatAdoptedHashVerifiesUpgradeProof(t *testing.T) {
 	)
 
 	hb := newHeartbeatHub()
-	hb.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", GitBranch: branch}}
+	hb.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", GitBranch: branch, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", Org: "org", PrimaryRepo: "repo"}); err != nil {
 		t.Fatalf("save hive: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestHeartbeatAdoptedHashVerifiesUpgradeProof(t *testing.T) {
 
 	s := newHandlerHub()
 	s.hubGitBranch = branch
-	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", GitBranch: branch}}
+	s.registry.Hives = []RegistryEntry{{ID: hiveID, Owner: owner, ClusterID: "fmaas-pull-only", GitBranch: branch, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	seedUpgradeTarget(t, branch, "89abcdef")
 
 	rec = httptest.NewRecorder()

--- a/src/pkg/hub/upgrade_fallback_test.go
+++ b/src/pkg/hub/upgrade_fallback_test.go
@@ -47,7 +47,10 @@ func TestHandleUpgradeHiveUnreachableClusterArmsHeartbeatFallback(t *testing.T) 
 		// kubectl entirely and reports non-delivery.
 		clusterUnreachableUntil: map[string]time.Time{"vllm-d": time.Now().Add(time.Hour)},
 	}
-	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
+	// Heartbeating: the manual upgrade path refuses a hive that cannot COLLECT
+	// the instruction (pull-only delivery, see pullonly_upgrade.go). That gate is
+	// independent of what this test is about.
+	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2", LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	seedLatestSHA(t, "v2", "abc1234")
 
 	rec := httptest.NewRecorder()
@@ -95,7 +98,10 @@ func TestHandleUpgradeHiveUnreachableClusterWithoutTargetFails(t *testing.T) {
 		clusterUnreachableUntil: map[string]time.Time{"vllm-d": time.Now().Add(time.Hour)},
 	}
 	// The registry names a branch with NO cached SHA: no target can exist.
-	s.registry.Hives = []RegistryEntry{{ID: "h2", GitBranch: "branch-with-no-builds"}}
+	// Heartbeating: the manual upgrade path refuses a hive that cannot COLLECT
+	// the instruction (pull-only delivery, see pullonly_upgrade.go). That gate is
+	// independent of what this test is about.
+	s.registry.Hives = []RegistryEntry{{ID: "h2", GitBranch: "branch-with-no-builds", LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "h2")

--- a/src/pkg/hub/upgrade_pause_test.go
+++ b/src/pkg/hub/upgrade_pause_test.go
@@ -426,7 +426,12 @@ func TestSpokePauseRefusesManualUpgradeHive(t *testing.T) {
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
 	s := newHandlerHub()
 	s.clusters = map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}
-	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2", GitHash: "old"}}
+	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2", GitHash: "old",
+		// Heartbeating, so the ONLY thing that can refuse the resumed control
+		// below is the pause switch — which is what this test is about. The
+		// manual path independently refuses a hive that cannot COLLECT an
+		// upgrade (pull-only delivery, see pullonly_upgrade.go).
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339)}}
 	resetSHACaches(t)
 	latestSHAMu.Lock()
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newsha7"}

--- a/src/pkg/hub/upgrade_schedule_test.go
+++ b/src/pkg/hub/upgrade_schedule_test.go
@@ -460,6 +460,14 @@ func TestManualUpgradeUnaffectedByMode(t *testing.T) {
 		AutoUpgradeMode: AutoUpgradeModeDaily,
 	})
 	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
+	// This hive must be COLLECTIBLE, so that the only candidate reason for a
+	// refusal below is the schedule — which is what this test is about. The
+	// manual path refuses a hive that cannot collect an upgrade (it is pull-only
+	// delivery; see pullonly_upgrade.go), and that gate is deliberately
+	// independent of AutoUpgradeMode.
+	s.registry.Hives = []RegistryEntry{{
+		ID: "h1", LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
+	}}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPost, "/upgrade", `{}`, "alice"), "id", "h1")


### PR DESCRIPTION
## Problem

The manual **Upgrade now** button armed an upgrade without checking whether the spoke could actually collect it. Auto-upgrade already performs that check; the manual path did not.

Delivery is **pull** on both paths: the hub only records a target and arms the heartbeat, and the spoke patches its own Deployment when it next beats. A hive that has never heartbeated — or is silent past `staleRemoveAge` — never collects the instruction, while `Upgrading=true` latches on the hub. The stale-upgrade sweep then re-arms it every `staleUpgradeTimeout`, `beginUpgrade` preserves the original start clock, and the elapsed grows without bound. The orphan sweep's retry budget cannot break the loop, because such a hive fails `evaluateOrphanedUpgrade()`'s liveness test.

This made the click **strictly worse** than the auto path it diverged from. Auto-upgrade refuses and records the refusal on the timeline, so an operator can find out why; the manual click reported `{"status":"upgrading"}` and a success toast for a target that could never land. The asymmetry also read as a workaround — the same spoke auto-upgrade had declined would accept a manual click, appearing to fix the problem while only hiding it.

## Fix

`handleUpgradeHive` now applies the **same** `upgradeCollectible()` predicate before `beginUpgrade`, reusing the existing helpers in `pullonly_upgrade.go` rather than restating the logic. On refusal it calls `noteUncollectibleUpgrade` (so the refusal reaches the timeline, as the auto path's does) and returns **409** with `uncollectibleUpgradeReason` in a JSON body — matching the pause-switch refusal shape a few lines above. That reason is operator-facing by construction and documented to carry no kubeconfig paths or credentials, so it is safe over the wire.

## Two details worth review attention

**1. `lastHeartbeat` comes from the registry, not the hive record.** The issue's proposed snippet used `h.LastHeartbeat`, but `SaaSHive` (the `loadSaaSHive` record) has no such field — that would not compile. The value is read from `RegistryEntry.LastHeartbeat`, which is the only record carrying it and the identical source `triggerAutoUpgrades()` reads. A hive with no registry entry at all is treated as uncollectible for the same reason the empty-heartbeat case is.

**2. A successful manual arm now calls `forgetUncollectibleUpgrade`,** mirroring the auto path. Without it, a hive that is refused, recovers, is armed, and later goes silent again would have its second — genuine — refusal swallowed by stale per-`(hive, target)` de-duplication memory, putting the operator back in the silence this fix exists to remove. Covered by a dedicated regression test.

## Tests

Table-driven coverage in `pullonly_upgrade_test.go`:

- never-heartbeated → 409
- silent beyond `staleRemoveAge` → 409
- unparseable timestamp → 409 (must not arm on evidence we cannot read)

Each asserts no `Upgrading` latch, no `UpgradeTarget`, no `heartbeatUpgrade` entry, a timeline record explaining the refusal, and no credential-shaped strings in the response body.

Plus the **positive control** — a heartbeating spoke on a *pull-only* cluster still arms and returns the unchanged `{"status":"upgrading","mode":"heartbeat"}`. Without it, a regression that simply refused every manual upgrade would pass the file.

Existing manual-upgrade fixtures across seven test files gained a `LastHeartbeat`: they asserted success (or a 502) against registry entries that had never heartbeated, which is incidental to what each of those tests is actually about. `TestManualUpgradeUnaffectedByMode` in particular now documents that the collectibility gate is deliberately independent of `AutoUpgradeMode`.

Fixes #5304