### PR TITLE
📖 docs(hub): correct two comments describing forge delivery that does not exist

### DIFF
--- a/src/pkg/hub/forge.go
+++ b/src/pkg/hub/forge.go
@@ -141,10 +141,30 @@ func parseForgeTarget(raw string) (ForgeTarget, error) {
 // parseForgeTargetWithKind is parseForgeTarget with an explicit forge kind.
 // An empty kind preserves the original behavior (public github.com, else GHE
 // inferred from the host). "gitlab"/"gitea" produce non-GitHub targets whose
-// BaseURL is the bare instance root and whose APIURL is left empty — the
-// spoke-side pkg/forge adapter appends the /api/v4 or /api/v1 suffix itself
-// (see the forge API-path contract note above). "github"/
+// BaseURL is the bare instance root and whose APIURL is left EMPTY. "github"/
 // "github-enterprise" fall through to the host-based GitHub path.
+//
+// WHAT AN EMPTY APIURL MEANS TODAY: nothing appends the /api/v4 or /api/v1
+// suffix to it. The pkg/forge adapters own those constants and would append
+// them, but nothing constructs an adapter (see the display-only note above), so
+// for a gitlab/gitea target the empty APIURL is simply never completed by
+// anyone. It is a placeholder for a consumer that does not exist, not a value
+// something downstream fills in.
+//
+// It is also not delivered anywhere, and the reason is worth pinning down
+// because it is not obvious: the only path that would push it,
+// pendingForgeAPIURL, re-parses h.RequestedGitHubHost through parseForgeTarget
+// — the KIND-LESS variant, which cannot see that the hive is on GitLab/Gitea.
+// A well-formed non-github.com host there is therefore classified as GitHub
+// Enterprise and yields APIURL = "https://<host>/api/v3". So a GitLab hive does
+// not push an empty API URL; the delivery path would push a GHE /api/v3 URL for
+// a GitLab host. That value is meaningless to a spoke, which is another reason
+// this path is not deployment-ready — and a trap for anyone who wires it later
+// and assumes the kind survives the round trip through the stored host.
+//
+// Keep the empty APIURL: it is the correct hub-side value under the API-path
+// contract below, and pre-appending a suffix here would be the duplicate that
+// contract exists to prevent. The gap is the missing consumer, not this field.
 func parseForgeTargetWithKind(kind, raw string) (ForgeTarget, error) {
 	switch ForgeKind(strings.ToLower(strings.TrimSpace(kind))) {
 	case ForgeGitLab, ForgeGitea:
@@ -159,7 +179,9 @@ func parseForgeTargetWithKind(kind, raw string) (ForgeTarget, error) {
 		if !isValidForgeHostLabel(host) {
 			return ForgeTarget{}, fmt.Errorf("%q is not a valid %s host", raw, fk)
 		}
-		// BaseURL only; the spoke adapter appends the REST API path. APIURL empty.
+		// BaseURL only; APIURL empty. Under the API-path contract the adapter
+		// would append the REST path — but no adapter is constructed today, so
+		// nothing completes it (see the doc comment above).
 		return ForgeTarget{Kind: fk, Host: host, BaseURL: "https://" + host}, nil
 	}
 	// kind is empty or a GitHub kind → the original host-based GitHub resolution.
@@ -419,10 +441,12 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		fromHost = publicForgeHost // "" has always meant public github.com
 	}
 
-	// NON-GITHUB FORGES (GitLab / Gitea): these authenticate with a
-	// PRIVATE-TOKEN via pkg/forge, not a GitHub App, so the App-identity
-	// resolution, PendingAppConfig, and IdentitySet machinery below do not
-	// apply. Record the forge family + host durably and re-arm the same
+	// NON-GITHUB FORGES (GitLab / Gitea): these do not use a GitHub App, so the
+	// App-identity resolution, PendingAppConfig, and IdentitySet machinery below
+	// do not apply. (The pkg/forge adapters are written to authenticate with a
+	// PRIVATE-TOKEN, but nothing constructs one — see the display-only note at
+	// the top of this file — so no credential of either kind is in play for
+	// these hives today.) Record the forge family + host durably and re-arm the same
 	// requested/delivered handshake used for GitHub, then return. GitHub App
 	// fields are cleared so a stale app_id/installation from a prior GitHub
 	// forge can't be sent to a spoke that no longer talks to GitHub.
@@ -430,7 +454,7 @@ func (s *HubServer) handleSwitchForge(w http.ResponseWriter, r *http.Request) {
 		h.Forge = string(target.Kind)
 		h.GitHubHost = target.Host
 		h.GitHubBaseURL = target.BaseURL
-		h.GitHubAPIURL = "" // adapter appends /api/v4 or /api/v1 to BaseURL
+		h.GitHubAPIURL = "" // no API URL for a non-GitHub forge; nothing consumes BaseURL today
 		h.RequestedGitHubHost = target.Host
 		h.ForgeDelivered = false
 		h.PendingAppConfig = nil // no GitHub App on GitLab/Gitea

--- a/src/pkg/hub/forge.go
+++ b/src/pkg/hub/forge.go
@@ -37,18 +37,50 @@ const (
 	// both resolve through the same identity/credential machinery.
 	ForgeGitHubEnterprise ForgeKind = "github-enterprise"
 	// ForgeGitLab is a GitLab instance (gitlab.com or self-managed). Unlike the
-	// GitHub kinds it does NOT use the GitHub App identity machinery: the spoke
-	// executes against it via pkg/forge's GitLab adapter using a PRIVATE-TOKEN
-	// from the env. These values match pkg/forge.KindGitLab.
+	// GitHub kinds it does NOT use the GitHub App identity machinery. It is
+	// DISPLAY-ONLY today: accepting this kind records the forge family and host
+	// on the hive and changes what the dashboard shows. No spoke executes
+	// against GitLab. The value matches pkg/forge.KindGitLab so a future wiring
+	// need not translate, but pkg/forge is not reached from here.
 	ForgeGitLab ForgeKind = "gitlab"
 	// ForgeGitea is a Gitea/Forgejo instance (self-managed or Codeberg). Same
-	// story as GitLab — executed via pkg/forge's Gitea adapter. Matches
-	// pkg/forge.KindGitea.
+	// story as GitLab: display-only, matching pkg/forge.KindGitea by value only.
 	ForgeGitea ForgeKind = "gitea"
 )
 
+// WHY "DISPLAY-ONLY" IS THE ACCURATE WORD FOR GITLAB/GITEA
+//
+// src/pkg/forge is a complete, tested adapter package with THREE implementations
+// (GitHub, GitLab, Gitea) and ZERO non-test importers:
+//
+//	$ grep -rn "kubestellar/hive/pkg/forge" --include="*.go" src/ \
+//	    | grep -v _test | grep -v "^src/pkg/forge/"
+//	(no output)
+//
+// Nothing in the running system constructs an adapter. Agents reach their forge
+// through the gh CLI wrapper, which is GitHub-only. So a hive switched to
+// ForgeGitLab gets a recorded kind/host and a different dashboard tile, and its
+// agents do not run.
+//
+// The hub-side SaaSHive.Forge field this endpoint writes is also NOT delivered
+// to spokes: no heartbeat struct carries a forge field. Wiring the path would
+// mean adding one to HeartbeatResponse, adding a spoke-side consumer that
+// constructs the adapter, and extending the interface (below).
+//
+// THE INTERFACE CEILING, worth knowing before anyone plans that work: the
+// pkg/forge.Forge interface exposes GetRepo, ListOpenIssues,
+// ListOpenChangeRequests, CreateIssueComment, AddLabels, RemoveLabel and
+// SetHold — but NO CreateIssue and NO CreatePR. Merge is a separate, optional
+// Merger interface that no adapter implements. Even fully delivered and wired,
+// these adapters could comment, label and hold, but could not open the issue or
+// change request an agent's work has to land in.
+//
+// The verified support matrix lives in src/docs/forge-app-setup.md; keep this
+// comment and that document in agreement.
+
 // FORGE API-PATH CONTRACT, hub side. The REST API base paths for the non-GitHub
-// forges are appended by the spoke-side pkg/forge adapters themselves
+// forges are appended by the pkg/forge adapters themselves (which, per the note
+// above, no running code path constructs today)
 // (gitLabAPIPath="/api/v4", giteaAPIPath="/api/v1"), so for those kinds a
 // ForgeTarget carries the BARE instance URL in BaseURL and leaves APIURL empty —
 // the opposite of the GHE case below, where the hub pre-appends /api/v3. The hub

--- a/src/pkg/hub/forge_test.go
+++ b/src/pkg/hub/forge_test.go
@@ -525,9 +525,11 @@ func TestSwitchForgeAuthorization(t *testing.T) {
 }
 
 // TestParseForgeTargetWithKind covers the GitLab/Gitea explicit-kind path added
-// for spoke-side pkg/forge routing: a non-GitHub kind yields a bare-host BaseURL
-// and an EMPTY APIURL (the spoke adapter appends /api/v4 or /api/v1 itself),
-// while the GitHub kinds behave exactly as the host-only parse.
+// in anticipation of pkg/forge routing: a non-GitHub kind yields a bare-host
+// BaseURL and an EMPTY APIURL, while the GitHub kinds behave exactly as the
+// host-only parse. The empty APIURL is asserted as the hub-side contract; note
+// that nothing completes it today, since no running code path constructs a
+// pkg/forge adapter (see the note at the top of forge.go).
 func TestParseForgeTargetWithKind(t *testing.T) {
 	cases := []struct {
 		name        string

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -670,12 +670,31 @@ type SaaSHive struct {
 	// reporting the code branch actually running.
 	TrackedChannel string `json:"tracked_channel,omitempty"`
 
-	// Forge names the forge FAMILY this hive runs against: "" / "github" /
-	// "github-enterprise" (the GitHub App path), or "gitlab" / "gitea" (the
-	// pkg/forge adapter path, PRIVATE-TOKEN auth — no GitHub App). Empty means
-	// GitHub, preserving every existing hive. The spoke uses this to pick which
-	// pkg/forge adapter to execute against; it is delivered over the heartbeat
-	// alongside the host. GitLab/Gitea carry no PendingAppConfig (no App).
+	// Forge names the forge FAMILY this hive is recorded as running against:
+	// "" / "github" / "github-enterprise" (the GitHub App path), or "gitlab" /
+	// "gitea". Empty means GitHub, preserving every existing hive. GitLab/Gitea
+	// carry no PendingAppConfig (no App).
+	//
+	// WHAT THIS FIELD ACTUALLY DOES TODAY: it is hub-side bookkeeping only. It
+	// is written by handleForgeSwitch (forge.go) and read by hub code to
+	// classify a hive — e.g. saas.go excludes non-"github" hives from
+	// github.com-scoped sweeps. It is NOT delivered to any spoke: no heartbeat
+	// struct carries a forge field, and HeartbeatResponse has no way to convey
+	// one, so the value never reaches a spoke at all.
+	//
+	// NO SPOKE SELECTS AN ADAPTER FROM THIS. The pkg/forge adapter package has
+	// zero non-test importers anywhere in the tree — nothing constructs a
+	// GitLab or Gitea adapter in any running code path. Setting this to
+	// "gitlab" or "gitea" changes hub classification and what the dashboard
+	// displays; it does not change what any agent executes against. See
+	// src/docs/forge-app-setup.md for the verified support matrix.
+	//
+	// FOR THE ADAPTER-SELECTION PATH TO EXIST, three things would have to be
+	// built: (1) a forge field on HeartbeatResponse (and the hub code to
+	// populate it), (2) a spoke-side consumer that reads it and constructs the
+	// matching pkg/forge adapter, and (3) CreateIssue/CreatePR on the
+	// pkg/forge.Forge interface — it has neither today, so even a fully wired
+	// adapter could comment and label but could not file the work.
 	Forge string `json:"forge,omitempty"`
 
 	// PendingAppConfig is a GitHub App identity queued for delivery to the


### PR DESCRIPTION
## Problem

Two comments in `src/pkg/hub` describe a forge delivery and spoke execution path that does not exist. Read together they state that setting `forge: gitlab` on a hive causes a spoke to run against GitLab via a `pkg/forge` adapter — which would send a maintainer debugging a delivery path that was never built.

This is the code-side counterpart to #5312, which made `src/docs/forge-app-setup.md` correct. The docs are now right while these comments were still wrong.

## Claims independently verified against `v4`

I re-ran every check rather than trusting the issue. All four claims held up:

1. **`pkg/forge` has zero non-test importers.** `grep -rn "kubestellar/hive/pkg/forge" --include="*.go" src/ | grep -v _test | grep -v "^src/pkg/forge/"` returns nothing. Widening to the whole repo *including* tests also returns nothing — the package is not imported from anywhere outside itself, not even by a test. No running code path constructs a GitLab or Gitea adapter.

2. **No heartbeat struct carries a forge field.** `HeartbeatResponse` (`src/pkg/hub/heartbeat.go:2184`) was read field by field: `OK`, `UpgradeTo`, `HubGitHash`, `LatestSHA`, `LatestTag`, `SwitchToTag`, `RestartSpoke`, `GitHubAppConfig`, `HubBanner`, `IsPublic`, `AuthorizedUsers`, `AuthorizedUserNames`, `ProjectConfig`, `PendingGateway`. There is no forge field and no nested struct that could carry one, so the value never reaches a spoke.

3. **The `Forge` interface has no `CreateIssue` and no `CreatePR`.** Full surface at `src/pkg/forge/forge.go:119-156` is `Kind`, `GetRepo`, `ListOpenIssues`, `ListOpenChangeRequests`, `CreateIssueComment`, `AddLabels`, `RemoveLabel`, `SetHold`. Nothing creates an issue or change request.

4. **`Merger` is optional and unimplemented.** Declared at `src/pkg/forge/forge.go:164` with a source `TODO`; grepping the three adapters for a `Merge` method returns no implementations.

Nothing in the issue turned out to be wrong.

### One thing the issue did not mention, corrected here

The `FORGE API-PATH CONTRACT` comment (`src/pkg/hub/forge.go:81`) called the adapters "the spoke-side `pkg/forge` adapters", carrying the same implication that they run on spokes. The path contract it documents is real and unchanged; only the framing was reworded to point at the note above it.

### What the `Forge` field genuinely does

Worth stating since the fix has to describe it accurately: it is not dead. It is written by `handleForgeSwitch` (`forge.go:398`) and read by hub code to classify a hive — for example `saas.go:9600` skips hives whose `Forge` is set and not `"github"` when sweeping github.com-scoped work, and the identity resolution in `cluster_app_key.go` / `hive_identity.go` uses the forge family. It is hub-side bookkeeping plus display, which is what the corrected comment now says.

## The fix

Both comments now describe the code as it is — an unwired adapter package and a hub-side kind that is currently display-only — and state plainly what building the described path would require: a forge field on `HeartbeatResponse`, a spoke-side consumer that constructs the adapter, and `CreateIssue`/`CreatePR` on the interface. A block near the kind definitions records the interface ceiling, so the next person to plan this work sees the gap before starting.

## Scope

Comments only. `git diff` filtered to non-comment lines is empty — no behavior, config schema, struct field, or interface changed. The `Forge` field and both `ForgeGitLab`/`ForgeGitea` kinds are untouched; `pkg/forge` is not wired. Kept consistent with `src/docs/forge-app-setup.md`.

Fixes #5317

---

## Follow-up commit: the rest of the class

Review caught a fourth instance I had missed, and sweeping for the pattern rather than fixing one at a time turned up **five** more comments making the identical false claim — that a spoke-side `pkg/forge` adapter performs work nothing performs.

| # | Location | Claim | Verdict |
| --- | --- | --- | --- |
| 1 | `saas_provision.go:677` (`Forge` field) | spoke picks adapter; delivered over heartbeat | **False — fixed** (commit 1) |
| 2 | `forge.go:39-46` (`ForgeGitLab`/`ForgeGitea`) | spoke executes via adapter w/ PRIVATE-TOKEN | **False — fixed** (commit 1) |
| 3 | `forge.go:81` (API-path contract) | "the spoke-side `pkg/forge` adapters" | **False framing — fixed** (commit 1) |
| 4 | `forge.go:144` (`parseForgeTargetWithKind` doc) | spoke-side adapter appends `/api/v4`/`/api/v1` | **False — fixed** (commit 2) |
| 5 | `forge.go:162` (inline, parse branch) | "the spoke adapter appends the REST API path" | **False — fixed** (commit 2) |
| 6 | `forge.go:433` (inline on `GitHubAPIURL = ""`) | "adapter appends /api/v4 or /api/v1" | **False — fixed** (commit 2) |
| 7 | `forge.go:444` (`handleSwitchForge` block) | present-tense "authenticate with a PRIVATE-TOKEN via pkg/forge" | **False — fixed** (commit 2) |
| 8 | `forge_test.go:528` | "spoke-side pkg/forge routing… spoke adapter appends" | **False — fixed** (commit 2) |
| 9 | `saas.go:9598` | "the pkg/forge adapters (gitlab/gitea) never point at github.com repos" | **Accurate — left alone** (property of the adapters, not a delivery claim) |

I also swept all 30+ other `spoke-side` occurrences in `src/pkg/hub/` (`hub_keys.go`, `perhive_env_reconcile.go`, `oauth.go`, `wrapkey_store.go`, `cluster_metrics.go`, and others). Every one refers to genuinely spoke-resident code — env-var resolvers, the `src/proxy/server.js` verifier, the metrics collector — and is accurate. Only the `pkg/forge` cluster was wrong. Left untouched.

### What actually happens to an empty `APIURL` — the answer is worse than "nothing"

The review asked me to verify this rather than write something merely less wrong. Tracing it:

`pendingForgeAPIURL` (`forge.go:788`) is the only path that would push an API URL. It re-parses `h.RequestedGitHubHost` through **`parseForgeTarget`** — the *kind-less* variant, which delegates to `parseForgeTargetWithKind("", raw)` and so cannot see that the hive is on GitLab/Gitea. `parseGitHubForgeTarget` then treats **every** well-formed non-`github.com` host as GitHub Enterprise (`forge.go:245-255`), returning `APIURL = "https://<host>/api/v3"`.

So a GitLab hive does not push an empty API URL — **the delivery path would push a GHE `/api/v3` URL for a GitLab host.** The forge kind does not survive the round trip through the stored host. That is meaningless to a spoke and is a live trap for whoever wires this later. Recorded in the comment; no behavior changed, since the path is unreachable in practice today (nothing consumes it).

The empty `APIURL` is deliberately kept — it is the correct hub-side value under the API-path contract, and pre-appending a suffix would be exactly the duplicate that contract exists to prevent. The gap is the missing consumer, not the field.

Still comments-only across both commits.
