### PR TITLE
🔧 fix(ci): validate wiki links against the deployed flat layout, not the repo tree

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -20,6 +20,18 @@ name: Docs Link Check
 # It intentionally does NOT validate http(s)/mailto links (network-dependent,
 # and not what broke in #5206) and does not touch the sync manifest itself,
 # which lives in the separate kubestellar/docs repository.
+#
+# The job also guards a second, differently-shaped surface: the wiki vault at
+# src/deploy/data/wiki/. src/Dockerfile bakes that tree into the image and
+# src/deploy/entrypoint.sh seeds it with `cp -rn /opt/hive/seed-data/* /data/`,
+# so it is served FLAT from /data/wiki/ with nothing above it. A parent-
+# relative link there resolves for a reviewer browsing this repo and 404s for
+# the operator reading the deployed page — the repo view is the one that lies,
+# which is what makes the break invisible in review (#5309). The wiki step
+# therefore runs --vault-root, which treats the vault directory as the reader's
+# whole filesystem and rejects any escape regardless of what exists in this
+# checkout. Outbound wiki references belong in absolute blob/v4 URLs, which
+# resolve identically in both views (#5308).
 
 on:
   push:
@@ -27,14 +39,18 @@ on:
       - v4
     paths:
       - 'src/docs/**'
+      - 'src/deploy/data/wiki/**'
       - 'src/scripts/check-docs-links.py'
+      - 'src/scripts/test-check-docs-links.sh'
       - '.github/workflows/docs-link-check.yml'
   pull_request:
     branches:
       - v4
     paths:
       - 'src/docs/**'
+      - 'src/deploy/data/wiki/**'
       - 'src/scripts/check-docs-links.py'
+      - 'src/scripts/test-check-docs-links.sh'
       - '.github/workflows/docs-link-check.yml'
 
 permissions:
@@ -52,3 +68,12 @@ jobs:
 
       - name: Check src/docs/ relative links and anchors
         run: python3 src/scripts/check-docs-links.py src/docs
+
+      # The wiki vault is checked in --vault-root mode, which models the
+      # DEPLOYED layout rather than this checkout. See the header comment and
+      # check-docs-links.py's docstring: /data/wiki/ has nothing above it, so a
+      # parent-relative link is rejected here even when the target exists in
+      # the repo. Running the plain checker against this tree would pass
+      # exactly the links that are broken in production (#5309).
+      - name: Check wiki vault links against the deployed flat layout
+        run: python3 src/scripts/check-docs-links.py src/deploy/data/wiki --vault-root

--- a/src/scripts/check-docs-links.py
+++ b/src/scripts/check-docs-links.py
@@ -25,7 +25,28 @@ link-rewrite pass (Case 2) only rewrites such links to a GitHub blob URL; it
 does not verify the target exists. A stale escape link is a real 404 on the
 published site history/blob view.
 
-Usage: src/scripts/check-docs-links.py [docs-dir]  (default: src/docs)
+VAULT MODE (--vault-root): the wiki vault under src/deploy/data/wiki/ is NOT
+read from a repo checkout by its real audience. src/Dockerfile bakes
+`COPY src/deploy/data/ /opt/hive/seed-data/` and src/deploy/entrypoint.sh
+seeds it with `cp -rn /opt/hive/seed-data/* /data/`, so the vault lands at
+/data/wiki/ with NOTHING above it. A parent-relative link such as
+`../../../docs/acmm-policy-matrix.md` therefore resolves fine for a reviewer
+browsing this repo on GitHub and is a dead link for the operator reading the
+same page in a running hive — the audiences see different results from
+identical source, and the repo view is the one that lies.
+
+A plain relative-link check run from a checkout would call that link VALID,
+because the target genuinely exists at that path in the repo. So --vault-root
+does not model the source layout: it models the DEPLOYED layout. Every
+relative link is resolved against the vault root as its containment boundary,
+and any target that escapes it is rejected outright regardless of whether the
+file exists in the repo. In-vault links (siblings, subdirectories) are still
+resolved and anchor-checked exactly as in src/docs/ mode. Outbound references
+from the wiki must use absolute https://github.com/kubestellar/hive/blob/v4/
+URLs, which work identically in the repo view and the deployed vault (#5308).
+
+Usage: src/scripts/check-docs-links.py [docs-dir] [--vault-root]
+       (default docs-dir: src/docs)
 Exit 0 with a per-file summary; exit 1 and print every broken link if any.
 """
 from __future__ import annotations
@@ -105,7 +126,19 @@ def extract_links(text: str) -> list[str]:
     return links
 
 
-def check_file(path: Path, repo_root: Path, heading_cache: dict[Path, set[str]]) -> list[str]:
+def check_file(
+    path: Path,
+    repo_root: Path,
+    heading_cache: dict[Path, set[str]],
+    vault_root: Path | None = None,
+) -> list[str]:
+    """Check one Markdown file.
+
+    repo_root is the containment boundary in normal (src/docs/) mode.
+    When vault_root is set, the boundary tightens to the vault directory,
+    because that directory is the whole filesystem the deployed reader has:
+    nothing above /data/wiki/ is reachable at runtime.
+    """
     problems = []
     text = path.read_text(encoding="utf-8", errors="replace")
     own_slugs = heading_cache.setdefault(path, heading_slugs(text))
@@ -125,11 +158,29 @@ def check_file(path: Path, repo_root: Path, heading_cache: dict[Path, set[str]])
 
         # Relative file link, resolved against this file's directory.
         resolved = (path.parent / path_part).resolve()
-        try:
-            resolved.relative_to(repo_root)
-        except ValueError:
-            problems.append(f"{path}: link '{raw}' escapes the repository")
-            continue
+
+        if vault_root is not None:
+            # Deployed-layout rule. The vault is seeded flat at /data/wiki/,
+            # so a target outside it cannot resolve for the operator no matter
+            # what exists in the repo checkout. Reject before any exists()
+            # test — the on-disk file is exactly the false reassurance that
+            # made this class of break invisible in review (#5309).
+            try:
+                resolved.relative_to(vault_root)
+            except ValueError:
+                problems.append(
+                    f"{path}: link '{raw}' escapes the wiki vault root; the vault is "
+                    f"seeded flat at /data/wiki/, so this cannot resolve in a running "
+                    f"hive even though the target exists in the repo. Use an absolute "
+                    f"https://github.com/kubestellar/hive/blob/v4/... URL instead."
+                )
+                continue
+        else:
+            try:
+                resolved.relative_to(repo_root)
+            except ValueError:
+                problems.append(f"{path}: link '{raw}' escapes the repository")
+                continue
 
         if not resolved.exists():
             problems.append(f"{path}: broken link '{raw}' -> {resolved.relative_to(repo_root)} does not exist")
@@ -150,12 +201,27 @@ def check_file(path: Path, repo_root: Path, heading_cache: dict[Path, set[str]])
 
 
 def main() -> int:
-    docs_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("src/docs")
+    args = sys.argv[1:]
+    vault_mode = "--vault-root" in args
+    positional = [a for a in args if not a.startswith("--")]
+    unknown = [a for a in args if a.startswith("--") and a != "--vault-root"]
+    if unknown or len(positional) > 1:
+        print(
+            "usage: check-docs-links.py [docs-dir] [--vault-root]",
+            file=sys.stderr,
+        )
+        return 2
+
+    docs_dir = Path(positional[0]) if positional else Path("src/docs")
     if not docs_dir.is_dir():
         print(f"no such directory: {docs_dir}", file=sys.stderr)
         return 1
 
     repo_root = Path.cwd().resolve()
+    # In vault mode the checked directory IS the reader's root: it is seeded to
+    # /data/wiki/ with nothing above it, so it doubles as the containment
+    # boundary that models the deployed layout.
+    vault_root = docs_dir.resolve() if vault_mode else None
     md_files = sorted(docs_dir.rglob("*.md"))
     if not md_files:
         print(f"no Markdown files found under {docs_dir}")
@@ -164,9 +230,10 @@ def main() -> int:
     heading_cache: dict[Path, set[str]] = {}
     all_problems: list[str] = []
     for f in md_files:
-        all_problems.extend(check_file(f, repo_root, heading_cache))
+        all_problems.extend(check_file(f, repo_root, heading_cache, vault_root))
 
-    print(f"checked {len(md_files)} files under {docs_dir}")
+    mode = " (deployed flat-vault layout)" if vault_mode else ""
+    print(f"checked {len(md_files)} files under {docs_dir}{mode}")
     if all_problems:
         print(f"\n{len(all_problems)} broken link(s):\n")
         for p in all_problems:

--- a/src/scripts/test-check-docs-links.sh
+++ b/src/scripts/test-check-docs-links.sh
@@ -161,6 +161,83 @@ else
 fi
 rm -f /tmp/out.$$
 
+# --- Case 8: --vault-root rejects a parent escape EVEN THOUGH the target
+# exists on disk (the #5309 bug: the repo view lies about the deployed vault) --
+vault="$tmp/vault"
+mkdir -p "$vault/docs" "$vault/wiki"
+cat > "$vault/docs/policy.md" <<'EOF'
+# Policy
+
+This file really does exist in the repo checkout.
+EOF
+cat > "$vault/wiki/agents.md" <<'EOF'
+# Agents
+
+See [policy](../docs/policy.md).
+EOF
+# Sanity: without --vault-root the very same link is considered valid, which
+# is precisely why pointing the plain checker at the wiki would not fix #5309.
+if (cd "$vault" && python3 "$checker" wiki) >/tmp/out.$$ 2>&1; then
+  note_ok "source-layout mode still accepts an existing ../ target (baseline)"
+else
+  note_fail "baseline source-layout run should pass, got:"; cat /tmp/out.$$
+fi
+rm -f /tmp/out.$$
+if (cd "$vault" && python3 "$checker" wiki --vault-root) >/tmp/out.$$ 2>&1; then
+  note_fail "--vault-root should reject '../docs/policy.md' despite it existing"
+else
+  grep -q "escapes the wiki vault root" /tmp/out.$$ \
+    && note_ok "--vault-root rejects a parent escape whose target exists on disk" \
+    || { note_fail "expected vault-escape message in output:"; cat /tmp/out.$$; }
+fi
+rm -f /tmp/out.$$
+
+# --- Case 9: in-vault links keep working under --vault-root ---------------
+invault="$tmp/invault/wiki"
+mkdir -p "$invault/sub"
+cat > "$invault/agents.md" <<'EOF'
+# Agents
+
+Sibling: [getting started](getting-started.md#first-run).
+Subdir: [deep](sub/deep.md).
+Absolute outbound: [policy](https://github.com/kubestellar/hive/blob/v4/src/docs/policy.md).
+EOF
+cat > "$invault/getting-started.md" <<'EOF'
+# Getting started
+
+## First run
+
+Text.
+EOF
+cat > "$invault/sub/deep.md" <<'EOF'
+# Deep
+
+Back up within the vault: [agents](../agents.md).
+EOF
+if (cd "$tmp/invault" && python3 "$checker" wiki --vault-root) >/tmp/out.$$ 2>&1; then
+  note_ok "in-vault siblings, subdirs, in-vault '../' and blob/v4 URLs all pass"
+else
+  note_fail "in-vault links should pass under --vault-root, got:"; cat /tmp/out.$$
+fi
+rm -f /tmp/out.$$
+
+# --- Case 10: a broken in-vault link is still caught under --vault-root ---
+vbroken="$tmp/vbroken/wiki"
+mkdir -p "$vbroken"
+cat > "$vbroken/a.md" <<'EOF'
+# A
+
+See [gone](nowhere.md).
+EOF
+if (cd "$tmp/vbroken" && python3 "$checker" wiki --vault-root) >/tmp/out.$$ 2>&1; then
+  note_fail "missing in-vault target should still fail under --vault-root"
+else
+  grep -q "nowhere.md does not exist" /tmp/out.$$ \
+    && note_ok "ordinary broken-link checking still applies under --vault-root" \
+    || { note_fail "expected 'does not exist' in output:"; cat /tmp/out.$$; }
+fi
+rm -f /tmp/out.$$
+
 if [ "$fail" -ne 0 ]; then
   echo "test-check-docs-links FAILED"
   exit 1


### PR DESCRIPTION
Fixes #5309

## Problem

The docs link checker never inspected the wiki vault, so a link that is dead for every operator reading the deployed wiki passed CI. `src/deploy/data/wiki/` sat outside both the workflow's `paths` filters and the checked directory, so a wiki-only change did not even trigger the workflow.

## Why a plain relative-link check would not have fixed this

This is the load-bearing part of the issue, so it is worth being explicit.

The vault is seeded **flat**. `src/Dockerfile:439` bakes the tree into the image:

    COPY src/deploy/data/ /opt/hive/seed-data/

and `src/deploy/entrypoint.sh:448` seeds it:

    cp -rn /opt/hive/seed-data/* /data/ 2>/dev/null || true

So the vault lands at `/data/wiki/` with **nothing above it**. A link like `../../../docs/acmm-policy-matrix.md` resolves fine for a reviewer browsing this repo on GitHub and is a dead link for the operator reading the same page in a running hive.

Simply pointing the existing checker at `src/deploy/data/wiki` would have called that link **VALID**, because the file genuinely exists at that path in a repo checkout. It would have passed exactly the links that are broken in production. Verified on this branch — re-adding the escape link that #5308 removed:

    $ python3 src/scripts/check-docs-links.py src/deploy/data/wiki
    checked 2 files under src/deploy/data/wiki
    all relative links and anchors resolve          # <- wrong, and green

    $ python3 src/scripts/check-docs-links.py src/deploy/data/wiki --vault-root
    1 broken link(s):
      src/deploy/data/wiki/agents.md: link '../../../docs/acmm-policy-matrix.md'
      escapes the wiki vault root; the vault is seeded flat at /data/wiki/, so this
      cannot resolve in a running hive even though the target exists in the repo.

## How the check models the deployed layout

New `--vault-root` mode changes *what the checker treats as the reader's filesystem*. In normal mode the containment boundary is the repo root. Under `--vault-root` the boundary tightens to the checked directory itself, because that directory **is** the whole filesystem the deployed reader has — `/data/wiki/` with nothing above it.

Concretely, the escape test moves **before** the `exists()` test. Existence on disk is precisely the false reassurance that made this class of break invisible in review, so in vault mode a target that escapes the vault is rejected outright, regardless of whether the repo happens to contain it. The rule is about reachability in the deployed artifact, not about the source tree.

What still behaves exactly as before, inside the vault:

- sibling links (`agents.md` -> `getting-started.md`) resolve and are anchor-checked normally
- subdirectory links resolve
- a `../` that stays **inside** the vault is fine — the rule is containment, not a textual `../` ban
- missing in-vault targets and stale heading anchors still fail
- absolute `https://github.com/kubestellar/hive/blob/v4/...` URLs pass as external, the convention #5308 established for outbound references

## Changes

- `src/scripts/check-docs-links.py` — add `--vault-root`; docstring explains the repo-vs-artifact split and why the source layout is the wrong model.
- `.github/workflows/docs-link-check.yml` — add `src/deploy/data/wiki/**` to **both** `paths` filters (push and pull_request), plus `src/scripts/test-check-docs-links.sh`; add a step running the checker in vault mode. No new action reference, so the existing pin is untouched.
- `src/scripts/test-check-docs-links.sh` — four new cases (8-10), including a **baseline** case asserting that source-layout mode still accepts an existing `../` target. That case is deliberate: it pins the exact difference between the two modes, so a future refactor that quietly makes vault mode behave like source mode fails the suite.

## Verification

All 11 self-test cases pass. `src/docs/` checking is unchanged — still 126 files, still green. The wiki tree is clean today (#5308 fixed the one live occurrence); no wiki content is modified by this PR, which is only the guard against recurrence.

Against the issue's stated criteria: a wiki file containing `](../anything)` fails; a bare-filename sibling link passes; an absolute `blob/v4` link passes; and editing only a wiki file now triggers the workflow.
