### PR TITLE
🌱 test(agent): make the agy launch test hermetic so it stops zeroing pkg/agent coverage

### DIFF
--- a/src/pkg/agent/agy_launch_test.go
+++ b/src/pkg/agent/agy_launch_test.go
@@ -8,76 +8,60 @@ package agent
 //   - a configured model is passed as --model <m> --effort <agyDefaultEffort>,
 //     because agy silently IGNORES --model without --effort — dropping the
 //     effort flag would make the configured model a no-op while looking fine.
+//
+// This test used to launch a real tmux pane with an agy stub and poll
+// CaptureFullLog for ~35s waiting for the typed command to echo back. That is
+// environment- and timing-dependent: in CI the pane frequently never
+// materialized, the capture came back EMPTY, and the whole package failed —
+// which zeroed pkg/agent's coverage score and re-fired the coverage floor
+// issue even though no package had actually regressed (#5299).
+//
+// The flag contract lives in backendLaunchCmd, a pure function, so it is
+// asserted directly here. The assertions themselves are unchanged: same flags,
+// same model, same reason strings.
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/kubestellar/hive/pkg/config"
 )
 
-// installAgyStub writes an agy stub into the stub bin dir already on PATH
-// (TestMain does not pre-create one — agy postdates the original stub list).
-// It renders the ❯ ready marker so readiness gates resolve and no launch
-// goroutine outlives the test, then echoes stdin like the other stubs.
-func installAgyStub(t *testing.T) {
+// agyLaunchCmd builds the agy launch command the way Start does for an agent
+// with no ToolsConfig: normalize the configured model for the backend, then
+// hand it to backendLaunchCmd. Keeping the normalization step means the test
+// still covers the model plumbing, not just the fmt.Sprintf.
+func agyLaunchCmd(t *testing.T, model string) string {
 	t.Helper()
-	p := filepath.Join(stubBinDir, "agy")
-	script := "#!/bin/sh\nprintf '\\342\\235\\257 ready\\n'\nexec cat\n"
-	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
-		t.Fatalf("writing agy stub: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Remove(p) })
+	const backend = "agy"
+	isInference := IsInferenceBackend(backend)
+	return backendLaunchCmd("agy", normalizeModelNameForBackend(model, backend, isInference), backend, isInference)
 }
 
-// TestStart_AgyLaunchCommandLine launches a real agy-backed agent (stub
-// binary, real tmux) and asserts the command line actually typed into the
-// pane carries the #3910 flag contract. The pane is read via CaptureFullLog
-// so wrapped lines are joined before matching.
+// TestStart_AgyLaunchCommandLine asserts the command line agy is launched with
+// carries the #3910 flag contract.
 func TestStart_AgyLaunchCommandLine(t *testing.T) {
-	if !tmuxAvailable() {
-		t.Skip("tmux not available")
-	}
-	t.Setenv("HIVE_WORK_DIR", t.TempDir())
-	forceFastPaneShell(t)
-	installAgyStub(t)
-
 	// "gemini-pro" survives normalizeModelName unchanged (no trailing digit
 	// segment), so the assertion below sees the configured model verbatim.
-	m := NewManager(map[string]config.AgentConfig{
-		"worker": makeAgentConfig("agy", "gemini-pro"),
-	}, discardLogger(), ProjectContext{})
+	cmd := agyLaunchCmd(t, "gemini-pro")
 
-	if err := m.Start(t.Context(), "worker"); err != nil {
-		t.Fatalf("Start(agy): %v", err)
+	if !strings.Contains(cmd, "--dangerously-skip-permissions") {
+		t.Errorf("agy launched without --dangerously-skip-permissions — it will block on a per-tool approval prompt no one answers; cmd: %q", cmd)
 	}
-	defer cleanupAgent(t, m, "worker")
+	if !strings.Contains(cmd, "--model gemini-pro --effort "+agyDefaultEffort) {
+		t.Errorf("agy launched without '--model gemini-pro --effort %s' — agy silently ignores --model without --effort, so the configured model would never take effect; cmd: %q",
+			agyDefaultEffort, cmd)
+	}
+}
 
-	// The launch line is typed into the pane in chunks; poll the joined
-	// capture until the full command is visible.
-	deadline := time.Now().Add(30 * time.Second)
-	var pane string
-	for time.Now().Before(deadline) {
-		out, err := m.CaptureFullLog("worker")
-		if err == nil && strings.Contains(out, "--effort") {
-			pane = out
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	if pane == "" {
-		out, _ := m.CaptureFullLog("worker")
-		t.Fatalf("agy launch command never appeared in the pane; capture: %q", out)
-	}
+// TestAgyLaunchCommandLine_NoModel pins the other half of the contract: with no
+// model configured, agy still gets the bypass flag, and it must NOT be given a
+// bare --model/--effort pair built from an empty model.
+func TestAgyLaunchCommandLine_NoModel(t *testing.T) {
+	cmd := agyLaunchCmd(t, "")
 
-	if !strings.Contains(pane, "--dangerously-skip-permissions") {
-		t.Error("agy launched without --dangerously-skip-permissions — it will block on a per-tool approval prompt no one answers")
+	if !strings.Contains(cmd, "--dangerously-skip-permissions") {
+		t.Errorf("agy must get --dangerously-skip-permissions even with no model configured; cmd: %q", cmd)
 	}
-	if !strings.Contains(pane, "--model gemini-pro --effort "+agyDefaultEffort) {
-		t.Errorf("agy launched without '--model gemini-pro --effort %s' — agy silently ignores --model without --effort, so the configured model would never take effect; pane: %q",
-			agyDefaultEffort, pane)
+	if strings.Contains(cmd, "--model") || strings.Contains(cmd, "--effort") {
+		t.Errorf("agy with no configured model must not be passed --model/--effort; cmd: %q", cmd)
 	}
 }

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2560,81 +2560,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			m.logger.Warn("agent has both tools and mode set; tools takes precedence", "agent", agent.Name)
 		}
 	} else {
-		switch backend {
-		case "claude":
-			bareFlag := ""
-			if isInference {
-				bareFlag = fmt.Sprintf(" --bare --settings %s", claudeInferenceSettingsPath)
-			}
-			base := fmt.Sprintf("%s --model %s --dangerously-skip-permissions%s", binary, model, bareFlag)
-			// Deny ALL GitHub MCP write tools in EVERY mode: agents author via the
-			// App-gated gh wrapper, never as the user via the MCP. Mode governs the
-			// gh-wrapper/proxy layer only, not what the MCP may write.
-			launchCmd = base + claudeGitHubWriteDenyFlags + claudeHostStateDenyFlags()
-		case "copilot":
-			// model arrives here already canonicalized by normalizeModelName
-			// (CanonicalizeCopilotModel: separator drift like claude-fable.5 is
-			// normalized to the CLI-accepted claude-fable-5, #4262) and is then
-			// passed as-is to `copilot --model %s`. It may be a
-			// concrete id OR the auto-selection sentinel "auto" (copilotAutoModel
-			// in cli_models.go), which lets the Copilot CLI pick/adjust the model
-			// per task. Nothing here assumes a concrete id, so the sentinel flows
-			// through unchanged.
-			// PRIMARY defense against authoring as the login USER via the MCP:
-			// we do NOT pass --enable-all-github-mcp-tools. Copilot CLI's built-in
-			// GitHub MCP server is READ-ONLY BY DEFAULT (v0.0.350+), so the write
-			// tools (create_issue/create_pull_request/…) are never registered.
-			// READ tools (get_issue/list/search) stay available in that read-only
-			// default, so nothing here disables useful lookups. All GitHub writes
-			// must go through the App-gated gh wrapper / hive-open-pr.
-			// copilotGitHubWriteDenyFlags is applied as belt-and-suspenders (with
-			// the CORRECT `github-mcp-server(` server name) on top of the read-only
-			// default. This is identical across ModeIssuesAndPRs / ModeIssuesOnly /
-			// advisory — the mode never changes what the MCP can write (it never
-			// legitimately should), it only governs the separate, unchanged
-			// gh-wrapper/proxy layer that still reads Mode for the App-gated writes.
-			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all%s",
-				binary, model, copilotGitHubWriteDenyFlags)
-		case "gemini":
-			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
-		case "agy":
-			// Antigravity CLI (Google's Gemini CLI replacement). Needs
-			// --dangerously-skip-permissions or it blocks on a per-tool
-			// approval prompt that no one is attached to answer — the same
-			// contract as claude's bypass flag, and the value already used for
-			// agy in config/backends.conf.
-			//
-			// An unrecognised --model is NOT fatal here: agy warns
-			// ("model X is not recognized ... Using \"Gemini 3.6 Flash\"
-			// instead") and continues on its default, so a stale model carried
-			// over from another provider degrades to a warning rather than a
-			// dead agent.
-			//
-			// --effort is REQUIRED whenever --model is given. Without it agy
-			// warns "--model <m> requires --effort (available: low, medium,
-			// high)" and silently ignores the model, so the configured model
-			// would never actually take effect. "low" matches the effort agy
-			// itself falls back to, keeping behaviour unchanged while making
-			// the model selection real.
-			launchCmd = fmt.Sprintf("%s --dangerously-skip-permissions", binary)
-			if model != "" {
-				launchCmd = fmt.Sprintf("%s --model %s --effort %s", launchCmd, model, agyDefaultEffort)
-			}
-		case "pi":
-			// pi takes the model as a CLI flag, not a subcommand. Without
-			// this case the launch command never receives the configured
-			// model (previously it also hit the goose binary via the alias).
-			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
-		case "goose":
-			launchCmd = fmt.Sprintf("%s run -s", binary)
-			if model != "" {
-				launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
-			}
-		case bobBackend:
-			launchCmd = bobLaunchCmd(binary)
-		default:
-			launchCmd = binary
-		}
+		launchCmd = backendLaunchCmd(binary, model, backend, isInference)
 	}
 
 	if mcpFlags := connectionMCPFlags(agent.Config.Connections, backend); mcpFlags != "" {
@@ -9931,6 +9857,91 @@ func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConf
 		}
 		return cmd
 	}
+}
+
+// backendLaunchCmd builds the per-backend CLI command used when an agent has no
+// explicit ToolsConfig. It is the default-path counterpart to
+// toolRulesToLaunchCmd and is deliberately pure — no Manager, no tmux, no
+// process — so the flag contract each backend depends on can be asserted
+// directly in tests instead of by polling a live pane for typed output.
+func backendLaunchCmd(binary, model, backend string, isInference bool) string {
+	var launchCmd string
+	switch backend {
+	case "claude":
+		bareFlag := ""
+		if isInference {
+			bareFlag = fmt.Sprintf(" --bare --settings %s", claudeInferenceSettingsPath)
+		}
+		base := fmt.Sprintf("%s --model %s --dangerously-skip-permissions%s", binary, model, bareFlag)
+		// Deny ALL GitHub MCP write tools in EVERY mode: agents author via the
+		// App-gated gh wrapper, never as the user via the MCP. Mode governs the
+		// gh-wrapper/proxy layer only, not what the MCP may write.
+		launchCmd = base + claudeGitHubWriteDenyFlags + claudeHostStateDenyFlags()
+	case "copilot":
+		// model arrives here already canonicalized by normalizeModelName
+		// (CanonicalizeCopilotModel: separator drift like claude-fable.5 is
+		// normalized to the CLI-accepted claude-fable-5, #4262) and is then
+		// passed as-is to `copilot --model %s`. It may be a
+		// concrete id OR the auto-selection sentinel "auto" (copilotAutoModel
+		// in cli_models.go), which lets the Copilot CLI pick/adjust the model
+		// per task. Nothing here assumes a concrete id, so the sentinel flows
+		// through unchanged.
+		// PRIMARY defense against authoring as the login USER via the MCP:
+		// we do NOT pass --enable-all-github-mcp-tools. Copilot CLI's built-in
+		// GitHub MCP server is READ-ONLY BY DEFAULT (v0.0.350+), so the write
+		// tools (create_issue/create_pull_request/…) are never registered.
+		// READ tools (get_issue/list/search) stay available in that read-only
+		// default, so nothing here disables useful lookups. All GitHub writes
+		// must go through the App-gated gh wrapper / hive-open-pr.
+		// copilotGitHubWriteDenyFlags is applied as belt-and-suspenders (with
+		// the CORRECT `github-mcp-server(` server name) on top of the read-only
+		// default. This is identical across ModeIssuesAndPRs / ModeIssuesOnly /
+		// advisory — the mode never changes what the MCP can write (it never
+		// legitimately should), it only governs the separate, unchanged
+		// gh-wrapper/proxy layer that still reads Mode for the App-gated writes.
+		launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all%s",
+			binary, model, copilotGitHubWriteDenyFlags)
+	case "gemini":
+		launchCmd = fmt.Sprintf("%s --model %s", binary, model)
+	case "agy":
+		// Antigravity CLI (Google's Gemini CLI replacement). Needs
+		// --dangerously-skip-permissions or it blocks on a per-tool
+		// approval prompt that no one is attached to answer — the same
+		// contract as claude's bypass flag, and the value already used for
+		// agy in config/backends.conf.
+		//
+		// An unrecognised --model is NOT fatal here: agy warns
+		// ("model X is not recognized ... Using \"Gemini 3.6 Flash\"
+		// instead") and continues on its default, so a stale model carried
+		// over from another provider degrades to a warning rather than a
+		// dead agent.
+		//
+		// --effort is REQUIRED whenever --model is given. Without it agy
+		// warns "--model <m> requires --effort (available: low, medium,
+		// high)" and silently ignores the model, so the configured model
+		// would never actually take effect. "low" matches the effort agy
+		// itself falls back to, keeping behaviour unchanged while making
+		// the model selection real.
+		launchCmd = fmt.Sprintf("%s --dangerously-skip-permissions", binary)
+		if model != "" {
+			launchCmd = fmt.Sprintf("%s --model %s --effort %s", launchCmd, model, agyDefaultEffort)
+		}
+	case "pi":
+		// pi takes the model as a CLI flag, not a subcommand. Without
+		// this case the launch command never receives the configured
+		// model (previously it also hit the goose binary via the alias).
+		launchCmd = fmt.Sprintf("%s --model %s", binary, model)
+	case "goose":
+		launchCmd = fmt.Sprintf("%s run -s", binary)
+		if model != "" {
+			launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
+		}
+	case bobBackend:
+		launchCmd = bobLaunchCmd(binary)
+	default:
+		launchCmd = binary
+	}
+	return launchCmd
 }
 
 // connectionMCPFlags builds MCP-related launch flags from connection configs.


### PR DESCRIPTION
Fixes #5299

## This was a flaky test, not a coverage shortfall

The 87.6% total reported in the issue is an artifact. Exactly one package could not be scored:

```
agent: TESTS FAILING
```

caused by exactly one test:

```
--- FAIL: TestStart_AgyLaunchCommandLine (35.70s)
    agy_launch_test.go:73: agy launch command never appeared in the pane; capture: ""
```

`pkg/agent` is one of the larger packages in the tree, so when it scores nothing the aggregate drops below the floor and the issue re-fires. **No package is actually below its threshold.** Nothing in the product regressed.

Verified on current `v4` before changing anything: the test still exists at `src/pkg/agent/agy_launch_test.go` and still has the fragile shape described below.

## Why the test was the problem

It launched a real tmux pane with an `agy` stub binary and polled `CaptureFullLog` for ~30s waiting for the typed launch command to echo back. The failure captured an **empty string** — not wrong content, nothing at all. That is the pane never coming up in the runner, i.e. timing- and environment-dependent, not a defect in the launch path it covers.

## Option taken: 1 (hermetic), not a skip

The agy flag contract was built inline inside `Start`'s backend `switch`, so the only way to observe it was to launch an agent for real. This PR extracts that switch into a pure function, `backendLaunchCmd` — the default-path counterpart to the existing `toolRulesToLaunchCmd`, sitting right beside it — and asserts against it directly.

The extraction is **behavior-preserving**: every `case` (claude, copilot, gemini, agy, pi, goose, bob, default) is carried over verbatim, and `Start` now calls the function in place of the inlined block.

**The assertions are not weakened.** Same two checks, same flags, same expected model, same failure messages:

- `--dangerously-skip-permissions` is always passed
- a configured model is passed as `--model <m> --effort <agyDefaultEffort>`

The test still runs the configured model through `normalizeModelNameForBackend` exactly as `Start` does, so the model plumbing stays covered — only the tmux dependency is gone. Runtime drops from ~35s to ~0s.

I also **added** a case rather than removing one: `TestAgyLaunchCommandLine_NoModel` pins the other half of the contract — with no model configured agy must still get the bypass flag, and must not be handed a `--model`/`--effort` pair built from an empty string.

## Do other tests share this fragility?

I audited the package for the same pattern (launch a real agent, then poll its pane for typed output). **The agy test was the only instance**, so this is a one-off fix rather than a class fix.

For the record, the near misses that are fine as-is:

- `TestCaptureFullLog_CapturesPaneContent` uses a real pane, but injects a marker into a raw tmux session directly instead of waiting on an agent launch — no echo-timing dependency, and it is the test of `CaptureFullLog` itself.
- The deadline-poll loops in `sandbox_executor_test.go`, `authprobe_test.go`, and `kick_restart_recovery_test.go` poll **in-process manager state**, not pane text, so they do not depend on a pane materializing.

## Verification

`go vet ./pkg/agent/` is clean and `go test ./pkg/agent/` passes locally; the two tests in this file now run in 0.00s each. CI is the gate.