### PR TITLE
🐛 fix: pass the stored forge kind through pendingForgeAPIURL

### DIFF
--- a/src/pkg/hub/forge.go
+++ b/src/pkg/hub/forge.go
@@ -151,16 +151,15 @@ func parseForgeTarget(raw string) (ForgeTarget, error) {
 // anyone. It is a placeholder for a consumer that does not exist, not a value
 // something downstream fills in.
 //
-// It is also not delivered anywhere, and the reason is worth pinning down
-// because it is not obvious: the only path that would push it,
-// pendingForgeAPIURL, re-parses h.RequestedGitHubHost through parseForgeTarget
-// — the KIND-LESS variant, which cannot see that the hive is on GitLab/Gitea.
-// A well-formed non-github.com host there is therefore classified as GitHub
-// Enterprise and yields APIURL = "https://<host>/api/v3". So a GitLab hive does
-// not push an empty API URL; the delivery path would push a GHE /api/v3 URL for
-// a GitLab host. That value is meaningless to a spoke, which is another reason
-// this path is not deployment-ready — and a trap for anyone who wires it later
-// and assumes the kind survives the round trip through the stored host.
+// It is also not delivered anywhere. The only path that would push it,
+// pendingForgeAPIURL, passes h.Forge to THIS function rather than re-parsing
+// the stored host kind-lessly, so a gitlab/gitea hive resolves to this empty
+// APIURL and pendingForgeAPIURL pushes nothing at all. Before #5336 it called
+// the kind-less parseForgeTarget, which cannot see that the hive is on
+// GitLab/Gitea and classified every well-formed non-github.com host as GitHub
+// Enterprise — so a GitLab hive would have been sent
+// "https://<gitlab-host>/api/v3", a GHE path aimed at a GitLab instance. The
+// kind must survive the round trip through the stored host; it now does.
 //
 // Keep the empty APIURL: it is the correct hub-side value under the API-path
 // contract below, and pre-appending a suffix here would be the duplicate that
@@ -813,12 +812,27 @@ func pendingForgeAPIURL(h *SaaSHive, curAPIURL string) string {
 	if h == nil || h.ForgeDelivered || h.RequestedGitHubHost == "" {
 		return ""
 	}
-	target, err := parseForgeTarget(h.RequestedGitHubHost)
+	// Pass the STORED KIND through. A host alone cannot distinguish GitLab or
+	// Gitea from GitHub Enterprise, so the kind-less parseForgeTarget would
+	// classify every well-formed non-github.com host as GHE and hand a GitLab
+	// hive "https://<gitlab-host>/api/v3" — a GHE path aimed at a GitLab
+	// instance (#5336). h.Forge is written by handleForgeSwitch alongside
+	// RequestedGitHubHost and is the authoritative family for this record.
+	target, err := parseForgeTargetWithKind(h.Forge, h.RequestedGitHubHost)
 	if err != nil {
 		return "" // an unparseable stored target is never pushed
 	}
 	want := target.APIURL
 	if want == "" {
+		if !target.IsPublic() {
+			// A non-public target with no APIURL is a GitLab/Gitea hive. Its
+			// empty APIURL is the correct hub-side value under the API-path
+			// contract — the adapter appends /api/v4 or /api/v1 — so there is
+			// nothing to push. Falling through to defaultPublicAPIURL here
+			// would aim a GitLab spoke at api.github.com, which is the same
+			// class of wrong value this fix removes.
+			return ""
+		}
 		// Public github.com — send the explicit default, not "" (see above).
 		want = defaultPublicAPIURL
 	}

--- a/src/pkg/hub/forge_test.go
+++ b/src/pkg/hub/forge_test.go
@@ -566,3 +566,80 @@ func TestParseForgeTargetWithKind(t *testing.T) {
 		})
 	}
 }
+
+// TestPendingForgeAPIURLRespectsStoredKind is the regression test for #5336.
+//
+// pendingForgeAPIURL used to re-parse the stored host with the KIND-LESS
+// parseForgeTarget. A host alone cannot distinguish GitLab or Gitea from GitHub
+// Enterprise, so every well-formed non-github.com host was classified as GHE and
+// a GitLab hive got "https://<gitlab-host>/api/v3" — a GHE API path aimed at a
+// GitLab instance. The failure is silent: a plausible-looking wrong URL, not an
+// error, which is exactly why it needs a test.
+//
+// The CORRECT outcome for gitlab/gitea is that NOTHING is pushed. Their
+// ForgeTarget.APIURL is deliberately empty under the API-path contract — the
+// pkg/forge adapter appends /api/v4 or /api/v1, so the hub must not pre-append a
+// suffix — and an empty API URL is not a value the hub has anything to say
+// about. Asserting merely "not /api/v3" would pass if the public api.github.com
+// default leaked through instead, so the assertion is on emptiness.
+func TestPendingForgeAPIURLRespectsStoredKind(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	nonGitHub := []struct {
+		id, forge, host string
+	}{
+		{"gl", string(ForgeGitLab), "gitlab.example.com"},
+		{"gl-saas", string(ForgeGitLab), "gitlab.com"},
+		{"gt", string(ForgeGitea), "gitea.example.com"},
+		{"gt-codeberg", string(ForgeGitea), "codeberg.org"},
+	}
+	for _, tc := range nonGitHub {
+		t.Run(tc.forge+"/"+tc.host, func(t *testing.T) {
+			saveSaaSHive(&SaaSHive{
+				ID: tc.id, Status: "running", Org: "o", Repos: []string{"r"},
+				PrimaryRepo: "r", ACMMLevel: 2,
+				Forge: tc.forge, GitHubHost: tc.host,
+				RequestedGitHubHost: tc.host,
+			})
+			got := pendingForgeAPIURL(loadSaaSHive(tc.id), "")
+			if strings.Contains(got, gheAPIPathSuffix) {
+				t.Fatalf("a %s hive was handed the GitHub Enterprise API path %q — the stored kind was dropped (#5336)", tc.forge, got)
+			}
+			if got != "" {
+				t.Fatalf("pendingForgeAPIURL = %q, want %q: a %s target has no hub-side API URL, and pushing anything here (including the public default) aims the spoke at the wrong host", got, "", tc.forge)
+			}
+		})
+	}
+
+	// The GitHub paths must be untouched by passing the kind through: an
+	// enterprise hive still gets its /api/v3, and a switch to public github.com
+	// still gets the EXPLICIT default rather than "" (which the spoke ignores).
+	saveSaaSHive(&SaaSHive{
+		ID: "ghe", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 2,
+		Forge: string(ForgeGitHubEnterprise), GitHubHost: "github.ibm.com",
+		RequestedGitHubHost: "github.ibm.com",
+	})
+	if got, want := pendingForgeAPIURL(loadSaaSHive("ghe"), ""), "https://github.ibm.com"+gheAPIPathSuffix; got != want {
+		t.Errorf("enterprise hive: pendingForgeAPIURL = %q, want %q", got, want)
+	}
+	// An enterprise hive whose Forge field was never written (every record
+	// predating the field) must still resolve through the host, unchanged.
+	saveSaaSHive(&SaaSHive{
+		ID: "ghe-legacy", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 2,
+		GitHubHost: "github.ibm.com", RequestedGitHubHost: "github.ibm.com",
+	})
+	if got, want := pendingForgeAPIURL(loadSaaSHive("ghe-legacy"), ""), "https://github.ibm.com"+gheAPIPathSuffix; got != want {
+		t.Errorf("legacy enterprise hive with no stored kind: pendingForgeAPIURL = %q, want %q", got, want)
+	}
+	saveSaaSHive(&SaaSHive{
+		ID: "pub", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 2,
+		Forge: string(ForgeGitHub), RequestedGitHubHost: "github.com",
+	})
+	if got := pendingForgeAPIURL(loadSaaSHive("pub"), ""); got != defaultPublicAPIURL {
+		t.Errorf("public hive: pendingForgeAPIURL = %q, want the explicit %q", got, defaultPublicAPIURL)
+	}
+}


### PR DESCRIPTION
Fixes #5336

## Problem

`pendingForgeAPIURL` (`src/pkg/hub/forge.go`) is the only code that would push an API URL to a spoke, and it re-parsed the stored host with the **kind-less** `parseForgeTarget`. A host alone cannot distinguish GitLab or Gitea from GitHub Enterprise, so `parseGitHubForgeTarget`'s terminal return classified every well-formed non-`github.com` host as GHE:

    return ForgeTarget{Kind: ForgeGitHubEnterprise, ..., APIURL: "https://" + host + gheAPIPathSuffix}, nil

A hive whose forge kind is `gitlab` therefore resolved to `https://<gitlab-host>/api/v3` — a GitHub Enterprise API path aimed at a GitLab instance. It fails in the worst direction: a plausible-looking wrong value rather than an error.

## Fix

Pass the stored kind through:

    target, err := parseForgeTargetWithKind(h.Forge, h.RequestedGitHubHost)

`h.Forge` is written by `handleForgeSwitch` alongside `RequestedGitHubHost` and is already read elsewhere for identity and app-key resolution, so it is available and authoritative at this call site.

One consequence needed handling. A gitlab/gitea target's `APIURL` is deliberately **empty** under the forge API-path contract — the adapter appends `/api/v4` or `/api/v1`, so the hub must not pre-append a suffix. But the existing empty-`APIURL` branch means "public github.com, send the explicit default", so with the kind now passed through, a GitLab hive would have fallen out of `/api/v3` and into `https://api.github.com`, which is the same class of wrong value. The branch is now guarded on `target.IsPublic()`: a non-public target with an empty `APIURL` pushes nothing, which is correct — the hub has nothing to say about a value the adapter owns.

The emptiness itself is left exactly as-is. No suffix is pre-appended anywhere.

## Tests

`TestPendingForgeAPIURLRespectsStoredKind` asserts that gitlab and gitea hives (self-managed and SaaS hosts) never yield an `/api/v3` URL from this path, and — since asserting merely "not `/api/v3`" would pass if the public default leaked through instead — that they yield nothing at all. It also locks the GitHub paths as unchanged: enterprise still gets its `/api/v3`, a **legacy record with no stored `Forge` field** still resolves through the host, and a switch to public github.com still gets the explicit `api.github.com` default rather than the `""` the spoke ignores.

The failure this fixes is silent, so without the test a regression would be invisible.

## Other kind-less call sites

None. After this change `parseForgeTarget` has **zero** non-test callers — `handleForgeSwitch` already used `parseForgeTargetWithKind(body.Kind, body.Host)`, and this was the one site that forgot. The kind-less wrapper is retained for the existing tests and for callers who genuinely have only a host.

## Notes

- Comment consistency with #5329: the `parseForgeTargetWithKind` doc comment described this exact kind-less round trip as current behavior. It is updated to record the bug as fixed and to keep the reason the empty `APIURL` is correct.
- Scope: no change to `pkg/forge`, the `Forge` interface, the config schema, or any struct field. `pkg/forge` still has zero non-test importers, so this path remains unreachable in practice — the fix removes a latent trap for whoever wires the forge path later.

## Follow-up found while fixing this (NOT fixed here)

There is a second occurrence of the same bug class on the **steady-state** push, which this PR deliberately leaves alone because the fix is not equally clear.

`gheAPIURLForHost(host)` (`src/pkg/hub/server.go`) unconditionally returns `https://<host>/api/v3` for any non-`github.com` host — the same host-cannot-imply-kind assumption, but in a helper that takes **only a host** and has no kind parameter. `projectConfigForHiveID` calls it at two places in `src/pkg/hub/saas.go` (the `wantAPIURL`/`needGHEAPIPush` gate, and the `GitHubAPIURL` fallback inside the pushed struct), both on `h.GitHubHost`.

`handleForgeSwitch` sets `h.GitHubHost = target.Host` for a GitLab/Gitea hive, so `gheAPIURLForHost("gitlab.example.com")` returns `https://gitlab.example.com/api/v3` (verified locally). This matters because it is **not** gated by the forge handshake: `pendingForgeAPIURL` stops once `ForgeDelivered` latches, and the code then falls back to exactly this host-derived value — so the GHE suffix would reappear permanently for a GitLab hive. The comment at that fallback ("which by then derives from the SAME host, so the two agree and nothing flaps") is true for GitHub hives but does not hold once the kind differs.

It is out of scope here for two reasons: fixing it means threading a kind through a helper used at six call sites (a signature change touching lite enrollment and two provisioning paths), and it is unreachable today for the same reason as the bug in this PR — `pkg/forge` has zero non-test importers, and `handleForgeSwitch` clears `GitHubAPIURL` for non-GitHub forges. Worth its own issue.
