### PR TITLE
🔒 fix(entrypoint): harden runtime config recreated by cp at boot (#5331)

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -70,6 +70,24 @@ for _cfg in "$HIVE_CONFIG_RUNTIME" "$HIVE_CONFIG_RUNTIME_LEGACY" /data/hive.yaml
 done
 unset _cfg
 
+# hive_harden_runtime_config tightens $1 to 0600 after any cp that (re)creates
+# a PVC config copy.
+#
+# The boot-time chmod loop above only covers files that already existed when
+# this script started. Every `cp` below that writes $HIVE_CONFIG_RUNTIME
+# creates the destination anew, and cp gives a newly created destination the
+# SOURCE's mode — the ConfigMap seed and the bind-mounted hive.yaml are both
+# 0644 — so the runtime copy is re-widened to 0644 on every boot, after the
+# loop above has already run. Without this the 0600 fix only holds from the
+# first Config.Save() onward, and a hive that boots and never saves stays
+# world-readable indefinitely.
+#
+# Best-effort for the same reason as the loop above: a read-only or
+# foreign-owned PVC must not abort boot.
+hive_harden_runtime_config() {
+  [ -f "$1" ] && chmod 600 "$1" 2>/dev/null || true
+}
+
 # hive_runtime_config_read echoes the path to read the persisted runtime
 # config from: the new name when it is present and non-empty, else the
 # legacy name when that is, else empty. Read-only — it never creates,
@@ -264,6 +282,7 @@ PYEOF
     # Write the (merged) config as the disaster-recovery snapshot. Always
     # under the new name; the legacy file is left untouched on the PVC.
     cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_RUNTIME" 2>/dev/null || true
+    hive_harden_runtime_config "$HIVE_CONFIG_RUNTIME"
     echo "[entrypoint] K8s mode — ConfigMap is the seed, runtime config written to $HIVE_CONFIG_RUNTIME"
   else
     # Neither source exists: no runtime config on the PVC (checked first,
@@ -287,6 +306,7 @@ else
   if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ -z "$HIVE_CONFIG_SOURCE" ]; then
     # First boot: config exists but no PVC runtime config yet — seed it
     cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_RUNTIME"
+    hive_harden_runtime_config "$HIVE_CONFIG_RUNTIME"
     echo "[entrypoint] First boot — config seeded to PVC: $HIVE_CONFIG_RUNTIME"
   elif [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ -n "$HIVE_CONFIG_SOURCE" ]; then
     # The PVC runtime config is the source of truth (updated by Save()).
@@ -303,6 +323,7 @@ else
     # as the untouched fallback until Save() takes over writing the new one.
     if [ "$HIVE_CONFIG_SOURCE" = "$HIVE_CONFIG_RUNTIME_LEGACY" ]; then
       if cp "$HIVE_CONFIG_RUNTIME_LEGACY" "$HIVE_CONFIG_RUNTIME" 2>/dev/null; then
+        hive_harden_runtime_config "$HIVE_CONFIG_RUNTIME"
         echo "[entrypoint] Migration — seeded $HIVE_CONFIG_RUNTIME from legacy $HIVE_CONFIG_RUNTIME_LEGACY (legacy left in place)"
       fi
     fi

--- a/src/pkg/config/entrypoint_boot_test.go
+++ b/src/pkg/config/entrypoint_boot_test.go
@@ -29,6 +29,15 @@ func runBootPrelude(t *testing.T, env map[string]string, files map[string]string
 // is the ordinary way that happens.
 func runBootPreludeRO(t *testing.T, env map[string]string, files map[string]string, readOnly []string) string {
 	t.Helper()
+	out, _ := runBootPreludeRoot(t, env, files, readOnly)
+	return out
+}
+
+// runBootPreludeRoot is runBootPreludeRO that also returns the temp root, so a
+// test can inspect the FILES the prelude left behind (permissions, contents)
+// and not just what it logged.
+func runBootPreludeRoot(t *testing.T, env map[string]string, files map[string]string, readOnly []string) (string, string) {
+	t.Helper()
 	src, err := os.ReadFile(entrypointPath)
 	if err != nil {
 		t.Skipf("entrypoint.sh not readable from this package: %v", err)
@@ -40,6 +49,14 @@ func runBootPreludeRO(t *testing.T, env map[string]string, files map[string]stri
 		t.Fatal("could not find the end of the config branch in entrypoint.sh; the marker moved and this test would silently cover nothing")
 	}
 	root := t.TempDir()
+	// /data always exists on a real hive (it is the PVC mount point), so
+	// create it even when a case seeds no files into it. Otherwise the
+	// entrypoint's `cp ... /data/hive.yaml.runtime` fails on the missing
+	// directory and a permissions assertion would pass/fail for the wrong
+	// reason.
+	if err := os.MkdirAll(filepath.Join(root, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	for rel, content := range files {
 		p := filepath.Join(root, rel)
 		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
@@ -81,7 +98,67 @@ func runBootPreludeRO(t *testing.T, env map[string]string, files map[string]stri
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 	out, _ := cmd.CombinedOutput()
-	return string(out)
+	return string(out), root
+}
+
+// TestEntrypointHardensRuntimeConfigItRecreates is the regression guard for
+// #5331: every `cp` that (re)creates /data/hive.yaml.runtime must leave it
+// 0600.
+//
+// The boot-time chmod loop only covers files that already exist when the
+// script starts. These three branches CREATE the runtime copy from a 0644
+// source (the ConfigMap seed or the bind-mounted hive.yaml), and cp gives a
+// newly created destination the source's mode — so without the explicit
+// hardening the file is re-widened to 0644 on every boot, after the loop has
+// already run. The runtime config carries dashboard.auth_token, and /data is
+// world-traversable, so 0644 hands the dashboard owner credential to every
+// unprivileged agent uid on the host.
+//
+// The harness writes its seed files 0644, which is exactly the production
+// mode, so this test fails against the unhardened script.
+func TestEntrypointHardensRuntimeConfigItRecreates(t *testing.T) {
+	cases := []struct {
+		name  string
+		env   map[string]string
+		files map[string]string
+	}{
+		{
+			// K8s first boot: seeded from the 0644 ConfigMap seed.
+			name: "k8s seeds runtime from ConfigMap",
+			env:  map[string]string{"KUBERNETES_SERVICE_HOST": "10.0.0.1"},
+			files: map[string]string{
+				"etc/hive/hive.yaml": "acmm_level: 3\n",
+			},
+		},
+		{
+			// Docker first boot: seeded from the 0644 bind-mounted config.
+			name:  "docker first boot seeds runtime",
+			env:   map[string]string{},
+			files: map[string]string{"etc/hive/hive.yaml": "acmm_level: 3\n"},
+		},
+		{
+			// Docker migration: the new name is created from legacy .bak.
+			name: "docker migration seeds runtime from legacy bak",
+			env:  map[string]string{},
+			files: map[string]string{
+				"etc/hive/hive.yaml": "acmm_level: 3\n",
+				"data/hive.yaml.bak": "acmm_level: 5\n",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, root := runBootPreludeRoot(t, tc.env, tc.files, nil)
+			p := filepath.Join(root, "data/hive.yaml.runtime")
+			info, err := os.Stat(p)
+			if err != nil {
+				t.Fatalf("the prelude did not create the runtime config (%v); this branch no longer covers what the test claims:\n%s", err, out)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("runtime config is %04o, want 0600 — it carries dashboard.auth_token and /data is world-traversable (#5331):\n%s", got, out)
+			}
+		})
+	}
 }
 
 // TestK8sBootsFromRuntimeConfigNotTheSeed pins the phase-2 precedence: the PVC


### PR DESCRIPTION
## Scope — this is the remainder of #5331, not a competing fix

**PR #5335 covers the rest and is correct on its merits.** This PR is stacked
on top of it (base = `sec-check/5331-runtime-config-perms`) so the diff here is
only the one commit. It retargets to `v4` automatically when #5335 merges.

What #5335 already handles, and I am deliberately not touching:
- `saveLocked` — `RuntimeConfigFile` written `0o600` (both the initial write and
  the remove-and-retry), plus explicit `os.Chmod` for the pre-existing-inode case
- `saveDashboardOverlay` — `overlayFileMode` `0o600` and `f.Chmod` on a leftover `.tmp`
- `entrypoint.sh` — boot-time `chmod 600` loop over pre-existing
  `hive.yaml.runtime` / `.bak` / `.dashboard`

Those Go paths create the files `0600` **from the start** (`os.WriteFile` /
`OpenFile` apply the mode at create), so there is no world-readable window in
the write path. I reviewed for that specifically.

## The gap that remains

#5335's chmod loop runs at the **top** of `entrypoint.sh`, before the config
branch. Three `cp` calls further down **recreate** `$HIVE_CONFIG_RUNTIME`:

| line | branch |
|---|---|
| `cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_RUNTIME"` | K8s — ConfigMap is the seed |
| `cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_RUNTIME"` | Docker first boot |
| `cp "$HIVE_CONFIG_RUNTIME_LEGACY" "$HIVE_CONFIG_RUNTIME"` | legacy `.bak` migration |

`cp` gives a **newly created** destination the **source's** mode. Both sources
(the ConfigMap seed, the bind-mounted `hive.yaml`) are `0644`, so the runtime
copy is re-widened to `0644` on every boot — *after* the hardening loop has
already run.

Net effect without this patch: the `0600` fix only holds from the first
`Config.Save()` onward. A hive that boots and never saves stays world-readable
indefinitely. The runtime config carries `dashboard.auth_token`, and `/data` is
world-traversable, so that is the dashboard owner credential readable by every
unprivileged agent uid — the exact exposure #5331 reports.

## Change

- `hive_harden_runtime_config()` called after each of the three `cp` calls.
  Best-effort (`2>/dev/null || true`), matching the existing loop's contract: a
  read-only or foreign-owned PVC must not abort boot.
- Nothing group-writable is tightened. `/data/home/.codex` and the other
  intentionally shared paths are untouched.

## Remediation for already-deployed hives

This *is* the remediation for the recreate path. #5335 tightens copies that
already exist at boot; this keeps them tightened through the `cp` that would
otherwise undo it on the same boot. Together they converge every existing hive
to `0600` on its next restart, without waiting for a config save.

## Test

`TestEntrypointHardensRuntimeConfigItRecreates` — table-driven over all three
branches, asserting `Mode().Perm() == 0600`. Verified it **fails at `0644`**
against the unhardened script (the harness seeds files `0644`, the production
mode), so it is a real regression guard rather than a tautology. Existing
entrypoint boot tests still pass; the harness gained a `/data` mkdir so the
assertion turns on the mode and not a missing directory.

No token or key material appears in the diff, the test fixtures, or the logs.

Fixes #5331