### PR TITLE
fix(dashboard): vet model auto-heal targets instead of pinning available[0]

### DIFF
--- a/src/pkg/dashboard/model_heal_target_test.go
+++ b/src/pkg/dashboard/model_heal_target_test.go
@@ -1,0 +1,120 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// Model auto-heal picks the model it will PIN an agent to. Before #5338 it
+// took available[0] — the first entry of whatever catalog discovery returned —
+// on the unstated assumption that catalog membership proves the backend's CLI
+// can run the model. It does not.
+//
+// For claude the catalog comes from api.anthropic.com/v1/models, which
+// enumerates what the ACCOUNT may call over the HTTP API. That is a superset of
+// what the bundled `claude` CLI can drive, and it is ordered newest-first, so a
+// model the CLI lists but cannot build a request for lands exactly in the slot
+// auto-heal assigned from. The reporting hive had its only write-capable agent
+// pinned that way; every model call died inside the CLI's request builder, the
+// agent produced nothing for days, and each boot re-applied the same model.
+//
+// These tests pin the guard at the selection point.
+
+// TestHealTargetIsVettedNotFirstAvailable is the core assertion: the heal
+// target must come from healTargetFor, never straight from available[0].
+func TestHealTargetIsVettedNotFirstAvailable(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "const first = healTargetFor(backend, available);") {
+		t.Error("auto-heal no longer routes its heal target through healTargetFor — it would pin agents to available[0], a model the backend's CLI may advertise but cannot run (#5338)")
+	}
+	if strings.Contains(html, "const first = available[0];") {
+		t.Error("auto-heal still assigns available[0] directly as the heal target (#5338)")
+	}
+}
+
+// TestClaudeHealTargetsArePreferredAliases pins WHICH targets are vetted for
+// claude. The bare aliases resolve through the claude CLI's own current-model
+// mapping, so the CLI can only ever land on something it can actually drive —
+// unlike a concrete dated id lifted from the API catalog.
+func TestClaudeHealTargetsArePreferredAliases(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "const MODEL_HEAL_PREFERRED_TARGETS = {") {
+		t.Fatal("MODEL_HEAL_PREFERRED_TARGETS is gone — auto-heal has no vetted target set (#5338)")
+	}
+	if !strings.Contains(html, "claude: ['sonnet', 'opus', 'haiku'],") {
+		t.Error("claude's vetted heal targets are not the bare CLI aliases — a concrete catalog id can be advertised by the CLI yet fail on every call (#5338)")
+	}
+}
+
+// TestVettedHealTargetsAreAlwaysServed is the cross-file invariant that makes
+// the claude targets usable: the aliases must be in every served claude list,
+// live-discovered or static fallback, or healTargetFor would find no target and
+// permanently suppress claude heals.
+func TestVettedHealTargetsAreAlwaysServed(t *testing.T) {
+	for _, alias := range []string{"opus", "sonnet", "haiku"} {
+		if !contains(claudeAlwaysIncludeModels, alias) {
+			t.Errorf("claudeAlwaysIncludeModels is missing %q, a vetted heal target — auto-heal for claude would never find a target and stop healing entirely (#5338)", alias)
+		}
+	}
+}
+
+// TestNoHealTargetSuppressesTheSwitch covers the fail-safe. When no vetted
+// target is available the heal must be SKIPPED, not fired with an empty model:
+// leaving a model that is merely missing from one catalog sample is strictly
+// better than pinning an agent to one its CLI cannot run.
+func TestNoHealTargetSuppressesTheSwitch(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "if (!first) {") {
+		t.Error("auto-heal does not bail out when healTargetFor finds no vetted target — it would call switchModel with an empty model (#5338)")
+	}
+	// The bail-out must precede _confirmAbsent, or a heal that cannot fire
+	// still burns the once-per-disappearance guard and the absence clock,
+	// silently disqualifying the later heal that COULD have succeeded.
+	bail := strings.Index(html, "no vetted heal target is available — keeping selection")
+	confirm := strings.Index(html, "if (!_confirmAbsent(key, a.model)) return;")
+	if bail < 0 || confirm < 0 {
+		t.Fatal("could not locate the auto-heal bail-out and confirmation guards (#5338)")
+	}
+	if bail > confirm {
+		t.Error("the no-target bail-out runs AFTER _confirmAbsent — a suppressed heal would consume the absence clock and the once-per-disappearance guard (#5338)")
+	}
+}
+
+// TestHealTargetFallbackKeepsOtherBackendsUnchanged pins the blast radius.
+// Backends with no entry in MODEL_HEAL_PREFERRED_TARGETS must keep the previous
+// first-available behavior — this change narrows claude's target selection, it
+// does not re-tune heal targets fleet-wide.
+func TestHealTargetFallbackKeepsOtherBackendsUnchanged(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "if (!preferred) return available[0] || '';") {
+		t.Error("healTargetFor no longer falls back to available[0] for unlisted backends — this change must not alter heal behavior for backends it did not vet (#5338)")
+	}
+}
+
+// TestAutoHealStillExemptsAutoSentinels guards the load-bearing exemption this
+// change sits next to. copilot's and bob's `auto` are never concrete ids and
+// never in a catalog, so healing them would rewrite a valid selection — and for
+// bob specifically, any concrete id makes every prompt die with "Cannot read
+// properties of undefined (reading 'maxTokens')".
+func TestAutoHealStillExemptsAutoSentinels(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, "if (isAutoModelSentinel(backend, a.model)) return;") {
+		t.Error("auto-heal lost its AUTO_MODEL_SENTINELS exemption — it would rewrite copilot/bob 'auto' to a concrete discovered id (bob crashes on any concrete model)")
+	}
+	if !strings.Contains(html, "const AUTO_MODEL_SENTINELS = { copilot: ['auto'], bob: ['auto'] };") {
+		t.Error("AUTO_MODEL_SENTINELS no longer exempts both copilot and bob")
+	}
+}
+
+// TestBobStaysSingleOptionAndModelless re-pins bob's contract from the model
+// layer this change touches: exactly one offered value, and no --model on the
+// launch path at all.
+func TestBobStaysSingleOptionAndModelless(t *testing.T) {
+	if len(bobStaticModels) != 1 || bobStaticModels[0] != bobAutoModel {
+		t.Errorf("bobStaticModels = %v, want exactly [%q] — offering bob a concrete model breaks every prompt", bobStaticModels, bobAutoModel)
+	}
+	html := indexHTML(t)
+	if !strings.Contains(html, "const SINGLE_OPTION_BACKENDS = ['bob'];") {
+		t.Error("bob is no longer a single-option backend — the dropdown could offer a model bob cannot honor")
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -8045,12 +8045,55 @@
     // when the model is observed available again.
     const _modelHealFired = {};
 
+    // Auto-heal HEAL TARGETS, per backend. Appearing in a discovery catalog is
+    // NOT proof the backend's CLI can run a model, and auto-heal pins an agent
+    // to its target for real work — so the target is drawn from a known-good
+    // set rather than from `available[0]` (#5338).
+    //
+    // The claude catalog is the strict case that motivated this: it is
+    // discovered from api.anthropic.com/v1/models, which enumerates what the
+    // ACCOUNT may call over the HTTP API — a superset of what the bundled
+    // `claude` CLI can drive. A model the CLI advertises but whose adapter
+    // cannot build a request still lists cleanly, and because /v1/models is
+    // newest-first, that model lands at available[0] — exactly the slot the
+    // old code auto-assigned. On the reporting hive that pinned the only
+    // write-capable agent to a model whose every call died in the CLI's
+    // request builder, and re-applied it at each boot, defeating config-file
+    // remediation.
+    //
+    // The bare aliases are the safe targets: `claude --model opus|sonnet|haiku`
+    // resolves through the CLI's OWN current-model mapping, so the CLI can only
+    // ever select something it can actually drive. They are also in
+    // claudeAlwaysIncludeModels (cli_models.go), so they are present in every
+    // served claude list — live-discovered or static fallback.
+    //
+    // Backends absent from this map keep the previous first-available
+    // behavior: this narrows the blast radius to the backend the failure was
+    // reported against rather than re-tuning heal targets fleet-wide.
+    const MODEL_HEAL_PREFERRED_TARGETS = {
+      claude: ['sonnet', 'opus', 'haiku'],
+    };
+
+    // healTargetFor picks the model auto-heal should switch an agent TO.
+    // Returns '' when no vetted target is available, which SUPPRESSES the heal
+    // — leaving a model that is merely absent from one catalog beats pinning
+    // the agent to one its CLI cannot run.
+    function healTargetFor(backend, available) {
+      const preferred = MODEL_HEAL_PREFERRED_TARGETS[backend];
+      if (!preferred) return available[0] || '';
+      for (const want of preferred) {
+        const hit = available.find(v => _modelIdMatches(v, want));
+        if (hit) return hit;
+      }
+      return '';
+    }
+
     function reconcileModelsAfterDiscovery(backend, models, fallback) {
       // Guard: only act on a genuinely successful discovery. Never switch
       // based on unverified static aliases or an empty list.
       if (fallback || !models || !models.length) return;
       const available = models.map(m => m.value);
-      const first = available[0];
+      const first = healTargetFor(backend, available);
       const isAvailable = (m) => available.some(v => _modelIdMatches(v, m));
       const now = Date.now();
 
@@ -8087,6 +8130,14 @@
         if (isAutoModelSentinel(backend, a.model)) return; // auto-select value — never a concrete id, never healed
         const key = `${backend}|${a.name}`;
         if (isAvailable(a.model)) { _markAvailable(key, a.model); return; } // still valid — leave untouched (idempotent)
+        // No vetted heal target for this backend — keep the current model.
+        // Checked BEFORE _confirmAbsent so the absence clock and the
+        // once-per-disappearance guard are not consumed by a heal that cannot
+        // fire; a target appearing later still gets its chance (#5338).
+        if (!first) {
+          console.warn(`model ${a.model} missing from ${backend} discovery but no vetted heal target is available — keeping selection`);
+          return;
+        }
         if (!_confirmAbsent(key, a.model)) return; // unconfirmed or already healed — no switch
         const label = a.displayName || a.name;
         const pinNote = (a.pinnedModel || a.pinnedBoth) ? ' (was pinned — model gone from provider)' : '';
@@ -8104,7 +8155,7 @@
         const defKey = `${backend}|__defaultModel__`;
         if (saved && isAvailable(saved)) {
           _markAvailable(defKey, saved);
-        } else if (saved && _confirmAbsent(defKey, saved)) {
+        } else if (saved && first && _confirmAbsent(defKey, saved)) {
           _configState.data.litellm.defaultModel = first;
           fetch('/api/config/governor/litellm', {
             method: 'PUT',


### PR DESCRIPTION
## Root cause

Model auto-heal (`reconcileModelsAfterDiscovery`) chose the model it pins an agent to as `available[0]` — the first entry of whatever catalog discovery returned. That encodes an assumption that never held: **appearing in a discovery catalog is not proof the backend's CLI can run the model.**

For `claude` the catalog comes from `api.anthropic.com/v1/models`, which enumerates what the **account** may call over the **HTTP API**. That is a superset of what the bundled `claude` CLI can actually drive, and `parseClaudeModelsResponse` passes every id through unfiltered while `dedupeModels` preserves API order — which is newest-first. So a model the CLI advertises but whose adapter cannot build a request lands *exactly* in the slot auto-heal assigned from.

On the reporting hive that pinned the only write-capable agent to such a model. Every model call died inside the CLI's request builder, the agent produced zero output for 4+ days while `/fleet` showed it green, and each boot re-applied the same model — defeating config-file remediation.

Notably there is **no Go-side model auto-assignment at all**; `switchModel(a.name, first)` in the dashboard is the single site where a model is automatically resolved to a concrete id, so this is the one place the guard belongs.

## Fix

Draw the heal target from a vetted per-backend set (`MODEL_HEAL_PREFERRED_TARGETS`) via a new `healTargetFor`, rather than from `available[0]`.

For claude the vetted targets are the bare aliases `sonnet`/`opus`/`haiku`. These resolve through the **CLI's own** current-model mapping, so the CLI can only ever land on something it can actually drive. `claudeAlwaysIncludeModels` already guarantees they are present in every served claude list — live-discovered or static fallback — so the target set can never come up empty in practice.

When no vetted target is available the heal is **suppressed** rather than fired with an empty model: keeping a model that is merely missing from one catalog sample is strictly better than pinning an agent to one its CLI cannot run. The bail-out runs *before* `_confirmAbsent`, so a heal that cannot fire does not consume the absence clock or the once-per-disappearance guard — a target appearing later still gets its chance.

Backends with no entry in the map keep the previous first-available behavior, so the blast radius stays on the backend the failure was reported against rather than re-tuning heal targets fleet-wide.

## Invariants preserved

- `AUTO_MODEL_SENTINELS` exemption is **untouched** — copilot/bob `auto` is still never healed to a concrete id.
- `SINGLE_OPTION_BACKENDS` / bob still offers exactly one value, and **no `--model` is passed to bob on any path**.
- Both are now re-pinned by tests so a future change cannot silently drop them.

## Tests

New `src/pkg/dashboard/model_heal_target_test.go`, following the existing `indexHTML(t)` substring-assertion convention used by `model_removal_toast_test.go`:

- heal target routes through `healTargetFor`, never `available[0]` directly
- claude's vetted targets are the bare CLI aliases
- those aliases are in `claudeAlwaysIncludeModels` (cross-file invariant — without it claude heals would be suppressed forever)
- no-target case suppresses the switch, and does so *before* `_confirmAbsent`
- unlisted backends keep first-available behavior
- the `AUTO_MODEL_SENTINELS` exemption and bob's single-option/model-less contract still hold

Verified the core test fails against the pre-fix line and passes after; full `pkg/dashboard` suite is green.

## Scope note

The issue also proposed CLI error-streak tracking (`.bob-errors`) and a `/fleet` "agent model failing" chip. Those are separate detection/observability features and are deliberately not in this PR, which fixes the assignment bug itself.

Fixes #5338