### PR TITLE
🐛 Reap orphaned Terminating spoke pods (#5328)

### DIFF
--- a/src/pkg/hub/orphaned_pod_reaper.go
+++ b/src/pkg/hub/orphaned_pod_reaper.go
@@ -1,0 +1,430 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// Orphaned Terminating-pod reaper (issue #5328).
+//
+// THE CONDITION. A hosted spoke pod acquires a deletionTimestamp and then never
+// goes away. A live sweep of one cluster found 27 such pods across 15 hive
+// namespaces, the oldest stuck for three weeks; a sixteenth namespace held 5
+// more, for 32 cleared by hand. Every one carried the SAME signature:
+//
+//   - deletionTimestamp set — the API server recorded the delete;
+//   - finalizers: [] — nothing was legitimately holding the object;
+//   - status.phase != "Running" — the pod was not serving;
+//   - the namespace still had exactly 1 healthy Running pod, so the live spoke
+//     was unaffected in every case.
+//
+// That is the fingerprint of a node disappearing without draining. The API
+// server records the deletion and waits for the kubelet to confirm it; the
+// kubelet is gone, so confirmation never arrives, and because no finalizer and
+// no controller owns the remaining work the object persists forever. The
+// distribution — 15 namespaces with 1-4 orphans each rather than one bad
+// namespace with 27 — argues for a recurring cluster-level event (spot
+// reclaim, autoscaler scale-down, or a node lifecycle event) rather than a
+// single misbehaving spoke.
+//
+// WHY A REAPER IS THE RIGHT FIX EVEN THOUGH IT TREATS THE SYMPTOM. Finding and
+// fixing whatever removes nodes ungracefully is issue #5328 item 1 and is NOT
+// this lane. But ungraceful node loss can always recur — it is a property of
+// the infrastructure, not a bug that stays fixed — so a reaper remains useful
+// after the root cause lands. What makes the accumulation expensive is not any
+// single orphan but that NOTHING sweeps them: the condition is self-
+// perpetuating, so the count only ever grows between manual interventions, and
+// it grew for three weeks with no alert.
+//
+// IMPACT. Orphans hold their scheduler slot until forcibly removed, and
+// anything counting pods per namespace sees phantom replicas — a namespace
+// showing 4 pods when 1 is live misreports fleet capacity and makes "is this
+// spoke healthy" unanswerable from the dashboard.
+//
+// THE PREDICATE IS DELIBERATELY NARROW AND MUST NOT BE LOOSENED. See
+// podIsOrphanedTerminating for the rule and the reasoning behind each clause.
+// It is the exact predicate used for the manual remediation, verified against
+// all 32 pods with zero collateral damage.
+//
+// WHY THE HUB CAN DO THIS WITHOUT NEW CREDENTIALS — AND THE ONE RBAC CAVEAT.
+//
+// This lane adds NO new credential, kubeconfig or client of any kind. It rides
+// the existing kubectlForCluster path, which for a remote spoke cluster
+// authenticates with the per-cluster kubeconfig the hub ALREADY holds — the
+// same credential provisioning uses to issue strictly BROADER destructive
+// operations against these clusters today: cleanupHiveResources runs
+// `kubectl delete namespace` and `kubectl delete pv` (saas_provision.go ~2429,
+// ~2441). Deleting one already-deleted pod inside one hive-hosted namespace is
+// a strict NARROWING of blast radius relative to that.
+//
+// This is consistent with pullonly_upgrade.go's push-path retirement note,
+// which retires the UPGRADE push path specifically and states plainly that the
+// hub's kubeconfigs are NOT yet droppable, because provisioning (namespace,
+// Deployment and RBAC creation on spoke clusters) is inherently a hub-side
+// write. The reaper is that same class of hub-side write and rides that same
+// existing grant. It does not extend the ordering constraint recorded there: if
+// those kubeconfigs are ever dropped or downgraded to read-only, this sweep
+// degrades exactly like the provisioning path and must move spoke-side with it.
+//
+// THE CAVEAT, STATED PLAINLY BECAUSE IT IS THE DRIFT CLASS THAT NOTE WARNS
+// ABOUT. No manifest in this repo grants `pods` at all for the hub — the only
+// in-repo pods rules belong to the separate hive-hub-backup ServiceAccount
+// (deploy/k8s/backup-cronjob.yaml: pods get,list and pods/exec create, with NO
+// delete). The hub nonetheless already runs `kubectl get pods
+// --all-namespaces` (saas.go ~2627) successfully in production, so pod READ is
+// present out-of-band on the live clusters. Pod DELETE is the same story: it
+// comes from the kubeconfig's identity, not from anything this repo asserts.
+//
+// The consequence is bounded and non-silent BY CONSTRUCTION. If the credential
+// lacks delete, `kubectl delete pod` fails, the failure is counted in
+// deleteFailures and logged at Warn per pod, and the sweep retries next
+// interval. It cannot fail closed-and-quiet, which is the specific failure mode
+// the pullonly note calls worse than failing loudly. What this lane does NOT do
+// is paper over that by minting a new grant: adding a cluster-wide pods-delete
+// ClusterRole to close a gap the hub already operates through would broaden the
+// blast radius on every cluster to fix a reporting problem on one.
+//
+// SCOPE OF THE VERBS USED: `get pods -n <hive-hosted-ns>` and
+// `delete pod <name> -n <hive-hosted-ns>`. Both are namespace-scoped. Nothing
+// here lists or deletes cluster-wide.
+//
+// PULL-ONLY CLUSTERS ARE SKIPPED, NOT FAILED. A cluster the hub cannot reach
+// with kubectl is left alone via KubectlReachable, the same guard every other
+// hub-side kubectl caller uses. Its orphans are not reaped from here; that is a
+// known and accepted gap, and the sweep counters make it visible rather than
+// silent.
+
+const (
+	// orphanedPodReapInterval throttles the sweep. Orphan production is a rare
+	// cluster-level event, not a hot path — the measured accumulation was ~32
+	// pods over three weeks — so a generous interval keeps this off the
+	// per-tick critical path. The SHA poller ticks every 2 min; this sweep runs
+	// at most once per this window. Matches netAdminReconcileInterval, the
+	// sibling remediation sweep it is modelled on.
+	orphanedPodReapInterval = 15 * time.Minute
+
+	// orphanedPodMinAge is how long a pod must have carried its
+	// deletionTimestamp before the reaper will touch it.
+	//
+	// A normal pod termination completes in SECONDS: the kubelet stops the
+	// containers, honours terminationGracePeriodSeconds (30s by default), and
+	// confirms. An hour is therefore ~120x the normal graceful path and orders
+	// of magnitude beyond any legitimate slow shutdown, while being three weeks
+	// short of the observed accumulation. The margin is deliberate: this bound
+	// exists so a pod that is merely mid-shutdown — including one with a long
+	// custom grace period — is never mistaken for an orphan. Being late costs
+	// one extra sweep interval; being early force-deletes a pod that was about
+	// to finish on its own.
+	orphanedPodMinAge = time.Hour
+
+	// orphanedPodKubectlTimeout bounds each per-namespace kubectl get/delete so
+	// one unreachable cluster cannot stall the whole sweep. Mirrors
+	// netAdminKubectlTimeout.
+	orphanedPodKubectlTimeout = 30 * time.Second
+
+	// orphanedPodMaxDeletesPerCycle caps how many pods one sweep will delete.
+	//
+	// A correct sweep on the measured fleet deletes ~32 pods ONCE and then
+	// nothing. A sweep trying to delete hundreds means either the predicate has
+	// been loosened by mistake or the cluster is in an unexpected state, and in
+	// both cases stopping to be noticed beats grinding through. The remainder
+	// is picked up next interval, so the cap delays cleanup rather than
+	// abandoning it — orphans are inert, and the condition took three weeks to
+	// matter.
+	orphanedPodMaxDeletesPerCycle = 50
+)
+
+// orphanedPodCandidate is the subset of pod metadata the predicate needs. It
+// exists so the decision is made over PLAIN DATA rather than over kubectl
+// output, which is what makes the rule unit-testable in isolation.
+type orphanedPodCandidate struct {
+	Namespace         string
+	Name              string
+	DeletionTimestamp time.Time
+	Finalizers        []string
+	Phase             string
+}
+
+// podPhaseRunning is the pod phase that must never be force-deleted, spelled
+// once so the predicate and its tests cannot disagree on the literal.
+const podPhaseRunning = "Running"
+
+// podIsOrphanedTerminating reports whether a pod matches the orphaned-
+// Terminating signature and may be force-deleted.
+//
+// THE RULE — all four clauses must hold:
+//
+//	deletionTimestamp != null &&
+//	  finalizers == [] &&
+//	  phase != "Running" &&
+//	  age(deletionTimestamp) > orphanedPodMinAge
+//
+// This is the predicate that cleared 32 pods by hand with zero collateral
+// damage. Each clause is load-bearing and NONE may be relaxed:
+//
+//   - deletionTimestamp != null. Without it the pod was never asked to go away
+//     and deleting it would be destroying a live workload, not cleaning up
+//     after one. This clause is what makes the whole operation a completion of
+//     an already-issued delete rather than a new delete.
+//
+//   - finalizers == []. A finalizer is an explicit statement that some
+//     controller has unfinished work — volume detach, network cleanup,
+//     external deregistration. Force-deleting past one strands exactly the
+//     resource the finalizer existed to reclaim, and the damage is silent and
+//     usually unrecoverable. Every one of the 32 observed orphans had an EMPTY
+//     finalizer list, which is precisely why they were safe and precisely why
+//     nothing was ever going to clean them up. A pod with finalizers is stuck
+//     for a DIFFERENT reason and is out of scope for this lane.
+//
+//   - phase != "Running". A Running pod carrying a deletionTimestamp is a pod
+//     mid-shutdown that is still serving traffic. It is the normal, healthy
+//     path and it resolves on its own. Reaping it would be an outage caused by
+//     the cleanup tool. Note every namespace in the measured incident kept
+//     exactly one Running pod — that pod is the live spoke, and this clause is
+//     what guarantees the reaper cannot touch it.
+//
+//   - age > orphanedPodMinAge. Termination normally completes in seconds, so
+//     any pod inside the window is presumed to be shutting down correctly. See
+//     orphanedPodMinAge.
+//
+// now is passed in rather than read from the clock so age is testable.
+func podIsOrphanedTerminating(p orphanedPodCandidate, now time.Time, minAge time.Duration) bool {
+	// Not deleted at all — a live pod. Never touch it.
+	if p.DeletionTimestamp.IsZero() {
+		return false
+	}
+	// Something owns unfinished work here. Out of scope, and unsafe.
+	if len(p.Finalizers) > 0 {
+		return false
+	}
+	// Still serving. Shutting down normally, or genuinely live.
+	if strings.TrimSpace(p.Phase) == podPhaseRunning {
+		return false
+	}
+	// Inside the grace window — presumed to be terminating correctly.
+	return now.Sub(p.DeletionTimestamp) > minAge
+}
+
+// podListItem mirrors the fields of `kubectl get pods -o json` that the
+// predicate consumes.
+type podListItem struct {
+	Metadata struct {
+		Name              string   `json:"name"`
+		Namespace         string   `json:"namespace"`
+		DeletionTimestamp string   `json:"deletionTimestamp"`
+		Finalizers        []string `json:"finalizers"`
+	} `json:"metadata"`
+	Status struct {
+		Phase string `json:"phase"`
+	} `json:"status"`
+}
+
+// parseOrphanCandidates turns the stdout of `kubectl get pods -n <ns> -o json`
+// into candidates. Pure and fully testable: no kubectl, no cluster.
+//
+// A pod whose deletionTimestamp is absent or unparseable yields a ZERO
+// DeletionTimestamp, which the predicate rejects. That is the safe direction —
+// an unreadable timestamp can never be read as "old enough to delete".
+func parseOrphanCandidates(raw []byte) ([]orphanedPodCandidate, error) {
+	var list struct {
+		Items []podListItem `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, err
+	}
+	out := make([]orphanedPodCandidate, 0, len(list.Items))
+	for _, it := range list.Items {
+		c := orphanedPodCandidate{
+			Namespace:  it.Metadata.Namespace,
+			Name:       it.Metadata.Name,
+			Finalizers: it.Metadata.Finalizers,
+			Phase:      it.Status.Phase,
+		}
+		if ts := strings.TrimSpace(it.Metadata.DeletionTimestamp); ts != "" {
+			if parsed, err := time.Parse(time.RFC3339, ts); err == nil {
+				c.DeletionTimestamp = parsed
+			}
+			// On a parse error the zero value stands and the predicate skips
+			// the pod. Deliberate: never guess an age.
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// selectOrphanedPods applies the predicate across a parsed pod list. Split out
+// from the sweep so the selection step is testable as a unit.
+func selectOrphanedPods(candidates []orphanedPodCandidate, now time.Time, minAge time.Duration) []orphanedPodCandidate {
+	var orphans []orphanedPodCandidate
+	for _, c := range candidates {
+		if podIsOrphanedTerminating(c, now, minAge) {
+			orphans = append(orphans, c)
+		}
+	}
+	return orphans
+}
+
+// reapOrphanedPodsIfDue runs the sweep only if orphanedPodReapInterval has
+// elapsed. Safe to call from the poller loop every tick. Same shape and same
+// guarding mutex as reconcileNetAdminIfDue — poller-loop-only state.
+func (s *HubServer) reapOrphanedPodsIfDue() {
+	s.clusterUnreachableMu.Lock()
+	due := s.lastOrphanedPodReap.IsZero() ||
+		time.Since(s.lastOrphanedPodReap) >= orphanedPodReapInterval
+	if due {
+		s.lastOrphanedPodReap = time.Now()
+	}
+	s.clusterUnreachableMu.Unlock()
+	if !due {
+		return
+	}
+	s.reapOrphanedPods()
+}
+
+// reapOrphanedPods sweeps every hub-managed hosted hive namespace and force-
+// deletes pods matching podIsOrphanedTerminating.
+//
+// SCOPED TO HIVE NAMESPACES ONLY. Every kubectl call is `-n <hive-hosted-ID>`,
+// derived from the registry — the sweep never lists or deletes cluster-wide and
+// cannot reach a namespace the hub did not provision. There is no all-
+// namespaces path in this file by construction.
+//
+// Idempotent and non-fatal: a namespace with no orphans is a no-op, and any
+// kubectl error is logged and retried next sweep.
+func (s *HubServer) reapOrphanedPods() {
+	hives := listSaaSHives()
+	now := time.Now()
+
+	// Sweep accounting. A reaper that silently deletes nothing is
+	// indistinguishable from a clean fleet, and a reaper that silently deletes
+	// a lot is the failure mode worth catching early. Both are recorded and
+	// logged, so "the sweep ran and found nothing" and "the sweep never
+	// selected anybody" are different, readable outcomes. Trading one invisible
+	// problem for another is the thing this lane exists to avoid.
+	namespacesScanned := 0
+	namespacesSkippedUnreachable := 0
+	orphansFound := 0
+	orphansDeleted := 0
+	deleteFailures := 0
+	capped := false
+
+	for _, h := range hives {
+		if orphansDeleted >= orphanedPodMaxDeletesPerCycle {
+			capped = true
+			break
+		}
+
+		cluster := s.clusterForHive(&h)
+		if cluster == nil {
+			continue
+		}
+		// A pull-only cluster is reached only by answering its outbound
+		// heartbeat; the hub has no kubectl path into it. Skip rather than
+		// burn a timeout, and count it so the gap is visible.
+		if !cluster.KubectlReachable() {
+			namespacesSkippedUnreachable++
+			continue
+		}
+		// Skip clusters the hub just failed to dial, the same suppression the
+		// upgrade and NET_ADMIN paths use, so one down cluster does not cost a
+		// timeout per hive every sweep. Recovers on the next sweep after TTL.
+		if s.clusterRecentlyUnreachable(cluster.ID) {
+			namespacesSkippedUnreachable++
+			continue
+		}
+
+		// Canonical derivation — the hub never enumerates namespaces, it
+		// derives each one from the registry. This is what confines the sweep
+		// to hive-managed namespaces.
+		ns := hostedNamespaceForHive(&h)
+		if ns == "" {
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), orphanedPodKubectlTimeout)
+		out, err := kubectlForClusterContext(ctx, cluster, "get", "pods", "-n", ns, "-o", "json").Output()
+		cancel()
+		if err != nil {
+			// Namespace missing, cluster unreachable, or a transient kubectl
+			// error — all non-fatal. Debug, and the next sweep retries.
+			s.logger.Debug("orphaned-pod reap: could not list pods",
+				"hive_id", h.ID, "cluster", cluster.ID, "namespace", ns, "error", err)
+			continue
+		}
+		s.markClusterReachable(cluster.ID)
+		namespacesScanned++
+
+		candidates, perr := parseOrphanCandidates(out)
+		if perr != nil {
+			s.logger.Warn("orphaned-pod reap: could not parse pod list",
+				"hive_id", h.ID, "cluster", cluster.ID, "namespace", ns, "error", perr)
+			continue
+		}
+
+		for _, orphan := range selectOrphanedPods(candidates, now, orphanedPodMinAge) {
+			orphansFound++
+			if orphansDeleted >= orphanedPodMaxDeletesPerCycle {
+				capped = true
+				break
+			}
+
+			age := now.Sub(orphan.DeletionTimestamp)
+
+			dctx, dcancel := context.WithTimeout(context.Background(), orphanedPodKubectlTimeout)
+			dout, derr := kubectlForClusterContext(dctx, cluster, "delete", "pod", orphan.Name,
+				"-n", ns, "--force", "--grace-period=0", "--ignore-not-found").CombinedOutput()
+			dcancel()
+			if derr != nil {
+				deleteFailures++
+				s.logger.Warn("orphaned-pod reap: force-delete failed — will retry next sweep",
+					"hive_id", h.ID, "cluster", cluster.ID, "namespace", ns,
+					"pod", orphan.Name, "age", age.String(),
+					"output", strings.TrimSpace(string(dout)), "error", derr)
+				continue
+			}
+			orphansDeleted++
+			// Every deletion is logged at INFO with namespace, name and age.
+			// Silent reaping would trade one invisible problem for another:
+			// the whole cost of this incident was that nothing was watching.
+			s.logger.Info("reaped orphaned terminating pod",
+				"namespace", ns, "pod", orphan.Name, "age", age.String(),
+				"hive_id", h.ID, "cluster", cluster.ID)
+		}
+	}
+
+	// Per-sweep summary. Logged at INFO only when the sweep actually did
+	// something, so a healthy fleet stays quiet and a reaping sweep is
+	// countable in the logs without reconstructing it from per-pod lines.
+	if orphansFound > 0 || deleteFailures > 0 {
+		s.logger.Info("orphaned-pod reap sweep complete",
+			"namespaces_scanned", namespacesScanned,
+			"orphans_found", orphansFound,
+			"orphans_deleted", orphansDeleted,
+			"delete_failures", deleteFailures,
+			"namespaces_skipped_unreachable", namespacesSkippedUnreachable,
+			"capped", capped)
+	} else {
+		s.logger.Debug("orphaned-pod reap sweep complete — no orphans",
+			"namespaces_scanned", namespacesScanned,
+			"namespaces_skipped_unreachable", namespacesSkippedUnreachable)
+	}
+
+	// Hitting the cap means either the predicate is wrong or the cluster is in
+	// an unexpected state. Both deserve to be loud.
+	if capped {
+		s.logger.Warn("orphaned-pod reap hit the per-cycle delete cap — remainder deferred to next sweep",
+			"cap", orphanedPodMaxDeletesPerCycle, "orphans_deleted", orphansDeleted)
+	}
+
+	// The registry is never legitimately empty on a hub that hosts spokes. A
+	// sweep that scanned nothing while hives exist is a bug signal, not a quiet
+	// no-op — the same failure mode that made the NET_ADMIN lane dead code for
+	// its entire production life.
+	if namespacesScanned == 0 && len(hives) > 0 {
+		s.logger.Warn("orphaned-pod reap scanned NO namespaces — sweep is a no-op, orphaned pods will not be reaped",
+			"hives_in_registry", len(hives),
+			"namespaces_skipped_unreachable", namespacesSkippedUnreachable)
+	}
+}

--- a/src/pkg/hub/orphaned_pod_reaper_test.go
+++ b/src/pkg/hub/orphaned_pod_reaper_test.go
@@ -1,0 +1,325 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+// fixedReapNow is the clock every case in this file is evaluated against, so
+// ages are exact rather than relative to a running wall clock.
+var fixedReapNow = time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+
+// reapAgo builds a deletionTimestamp d before fixedReapNow.
+func reapAgo(d time.Duration) time.Time { return fixedReapNow.Add(-d) }
+
+// TestPodIsOrphanedTerminating pins the exact predicate that cleared 32 pods by
+// hand with zero collateral damage (#5328):
+//
+//	deletionTimestamp != null && finalizers == [] && phase != "Running" &&
+//	  age(deletionTimestamp) > threshold
+//
+// The NEGATIVE cases are the point of this test. Each of them is a pod that a
+// looser predicate would delete and that must survive: loosening any one clause
+// converts a cleanup tool into an outage, and this table is what makes that
+// regression fail CI instead of production.
+func TestPodIsOrphanedTerminating(t *testing.T) {
+	cases := []struct {
+		name string
+		pod  orphanedPodCandidate
+		want bool
+		why  string
+	}{
+		// --- The signature that must be reaped. ---
+		{
+			name: "orphan: deleted, no finalizers, Failed, three weeks old",
+			pod: orphanedPodCandidate{
+				Namespace:         "hive-hosted-abc",
+				Name:              "hive-1",
+				DeletionTimestamp: reapAgo(21 * 24 * time.Hour),
+				Finalizers:        nil,
+				Phase:             "Failed",
+			},
+			want: true,
+			why:  "the exact measured signature — the oldest of the 27 orphans",
+		},
+		{
+			name: "orphan: Succeeded phase, empty (non-nil) finalizer slice",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(2 * time.Hour),
+				Finalizers:        []string{},
+				Phase:             "Succeeded",
+			},
+			want: true,
+			why:  "finalizers: [] is the observed shape; empty slice == nil here",
+		},
+		{
+			name: "orphan: Pending, just past the threshold",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(orphanedPodMinAge + time.Minute),
+				Phase:             "Pending",
+			},
+			want: true,
+			why:  "strictly greater than the threshold is enough",
+		},
+		{
+			name: "orphan: Unknown phase — the classic lost-kubelet phase",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(6 * time.Hour),
+				Phase:             "Unknown",
+			},
+			want: true,
+			why:  "Unknown is precisely what a vanished node leaves behind",
+		},
+
+		// --- NEGATIVE: has finalizers. Never delete. ---
+		{
+			name: "skipped: has a finalizer, otherwise a perfect match",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(21 * 24 * time.Hour),
+				Finalizers:        []string{"kubernetes.io/pv-protection"},
+				Phase:             "Failed",
+			},
+			want: false,
+			why:  "a finalizer means a controller has unfinished work; forcing past it strands the resource silently",
+		},
+		{
+			name: "skipped: multiple finalizers",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(30 * 24 * time.Hour),
+				Finalizers:        []string{"foo.io/cleanup", "bar.io/dereg"},
+				Phase:             "Unknown",
+			},
+			want: false,
+			why:  "age never overrides a finalizer, no matter how old",
+		},
+		{
+			name: "skipped: finalizer on an otherwise ancient Succeeded pod",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(365 * 24 * time.Hour),
+				Finalizers:        []string{"example.com/f"},
+				Phase:             "Succeeded",
+			},
+			want: false,
+			why:  "the finalizer clause is absolute",
+		},
+
+		// --- NEGATIVE: Running. Never delete. ---
+		{
+			name: "skipped: Running with a deletionTimestamp (normal shutdown)",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(2 * time.Hour),
+				Phase:             podPhaseRunning,
+			},
+			want: false,
+			why:  "a Running pod mid-shutdown is still serving; reaping it is an outage caused by the cleanup tool",
+		},
+		{
+			name: "skipped: Running and very old — this is the live spoke",
+			pod: orphanedPodCandidate{
+				Namespace:         "hive-hosted-abc",
+				Name:              "hive-live",
+				DeletionTimestamp: reapAgo(21 * 24 * time.Hour),
+				Phase:             podPhaseRunning,
+			},
+			want: false,
+			why:  "every measured namespace kept exactly 1 Running pod; this clause is what guarantees it is untouchable",
+		},
+		{
+			name: "skipped: Running with surrounding whitespace",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(5 * time.Hour),
+				Phase:             "  Running  ",
+			},
+			want: false,
+			why:  "phase is trimmed before comparison so whitespace cannot smuggle a live pod past the guard",
+		},
+
+		// --- NEGATIVE: too young. Never delete yet. ---
+		{
+			name: "skipped: deleted seconds ago — normal termination in progress",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(5 * time.Second),
+				Phase:             "Failed",
+			},
+			want: false,
+			why:  "normal termination completes in seconds; this pod is shutting down correctly",
+		},
+		{
+			name: "skipped: deleted 59 minutes ago — inside the window",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(59 * time.Minute),
+				Phase:             "Unknown",
+			},
+			want: false,
+			why:  "under the threshold, so presumed healthy",
+		},
+		{
+			name: "skipped: exactly at the threshold (boundary is exclusive)",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: reapAgo(orphanedPodMinAge),
+				Phase:             "Failed",
+			},
+			want: false,
+			why:  "the rule is strictly greater-than; being one sweep late is cheaper than being early",
+		},
+
+		// --- NEGATIVE: never deleted at all. ---
+		{
+			name: "skipped: no deletionTimestamp — a live pod",
+			pod: orphanedPodCandidate{
+				Phase: "Failed",
+			},
+			want: false,
+			why:  "without a deletionTimestamp this would be a NEW delete, not the completion of an issued one",
+		},
+		{
+			name: "skipped: no deletionTimestamp and not Running",
+			pod: orphanedPodCandidate{
+				Phase: "Pending",
+			},
+			want: false,
+			why:  "a Pending pod nobody asked to delete is just scheduling",
+		},
+
+		// --- Guard against a future clock skew / negative age. ---
+		{
+			name: "skipped: deletionTimestamp in the future (clock skew)",
+			pod: orphanedPodCandidate{
+				DeletionTimestamp: fixedReapNow.Add(time.Hour),
+				Phase:             "Failed",
+			},
+			want: false,
+			why:  "a negative age can never exceed the threshold",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := podIsOrphanedTerminating(tc.pod, fixedReapNow, orphanedPodMinAge)
+			if got != tc.want {
+				t.Fatalf("podIsOrphanedTerminating = %v, want %v\nreason: %s", got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestOrphanedPodMinAgeIsGenerous pins the threshold's intent. A normal
+// termination is seconds; if someone ever shrinks this to minutes the predicate
+// starts racing legitimate shutdowns.
+func TestOrphanedPodMinAgeIsGenerous(t *testing.T) {
+	if orphanedPodMinAge < time.Hour {
+		t.Fatalf("orphanedPodMinAge = %v, want >= 1h — a shorter window races normal termination "+
+			"(default grace period is 30s, and slow shutdowns are legitimate)", orphanedPodMinAge)
+	}
+}
+
+// TestParseOrphanCandidates covers the kubectl-JSON decode, including the
+// timestamp cases that must fail SAFE.
+func TestParseOrphanCandidates(t *testing.T) {
+	raw := []byte(`{"items":[
+      {"metadata":{"name":"orphan","namespace":"hive-hosted-a","deletionTimestamp":"2026-08-10T00:00:00Z","finalizers":[]},
+       "status":{"phase":"Failed"}},
+      {"metadata":{"name":"live","namespace":"hive-hosted-a"},
+       "status":{"phase":"Running"}},
+      {"metadata":{"name":"held","namespace":"hive-hosted-a","deletionTimestamp":"2026-08-10T00:00:00Z","finalizers":["x.io/f"]},
+       "status":{"phase":"Failed"}},
+      {"metadata":{"name":"badstamp","namespace":"hive-hosted-a","deletionTimestamp":"not-a-timestamp"},
+       "status":{"phase":"Failed"}}
+    ]}`)
+
+	got, err := parseOrphanCandidates(raw)
+	if err != nil {
+		t.Fatalf("parseOrphanCandidates returned error: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("parsed %d candidates, want 4", len(got))
+	}
+
+	byName := map[string]orphanedPodCandidate{}
+	for _, c := range got {
+		byName[c.Name] = c
+	}
+
+	if byName["orphan"].DeletionTimestamp.IsZero() {
+		t.Error("orphan: deletionTimestamp should have parsed")
+	}
+	if byName["orphan"].Phase != "Failed" || byName["orphan"].Namespace != "hive-hosted-a" {
+		t.Errorf("orphan: unexpected fields %+v", byName["orphan"])
+	}
+	if !byName["live"].DeletionTimestamp.IsZero() {
+		t.Error("live: absent deletionTimestamp must stay zero")
+	}
+	if len(byName["held"].Finalizers) != 1 {
+		t.Errorf("held: finalizers not carried through: %+v", byName["held"].Finalizers)
+	}
+	// The safety-critical case: an unparseable timestamp must yield the zero
+	// value, which the predicate rejects. Never guess an age.
+	if !byName["badstamp"].DeletionTimestamp.IsZero() {
+		t.Error("badstamp: unparseable deletionTimestamp must leave the zero value so the pod is SKIPPED")
+	}
+	if podIsOrphanedTerminating(byName["badstamp"], fixedReapNow, orphanedPodMinAge) {
+		t.Error("badstamp: a pod with an unreadable timestamp must never be reaped")
+	}
+}
+
+func TestParseOrphanCandidatesRejectsGarbage(t *testing.T) {
+	if _, err := parseOrphanCandidates([]byte("not json")); err == nil {
+		t.Fatal("expected an error on non-JSON input")
+	}
+}
+
+func TestParseOrphanCandidatesEmptyList(t *testing.T) {
+	got, err := parseOrphanCandidates([]byte(`{"items":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d candidates from an empty list, want 0", len(got))
+	}
+}
+
+// TestSelectOrphanedPods reproduces the measured incident shape end to end over
+// the pure path: one namespace holding the live Running spoke plus several
+// orphans, with a finalizer-held pod and a young pod mixed in. Only the true
+// orphans may be selected.
+func TestSelectOrphanedPods(t *testing.T) {
+	candidates := []orphanedPodCandidate{
+		{Name: "live", Phase: podPhaseRunning, DeletionTimestamp: reapAgo(21 * 24 * time.Hour)},
+		{Name: "orphan-old", Phase: "Failed", DeletionTimestamp: reapAgo(21 * 24 * time.Hour)},
+		{Name: "orphan-mid", Phase: "Unknown", DeletionTimestamp: reapAgo(3 * time.Hour)},
+		{Name: "held", Phase: "Failed", DeletionTimestamp: reapAgo(9 * time.Hour), Finalizers: []string{"x.io/f"}},
+		{Name: "young", Phase: "Failed", DeletionTimestamp: reapAgo(time.Minute)},
+		{Name: "not-deleted", Phase: "Failed"},
+	}
+
+	got := selectOrphanedPods(candidates, fixedReapNow, orphanedPodMinAge)
+	if len(got) != 2 {
+		t.Fatalf("selected %d pods, want 2: %+v", len(got), got)
+	}
+	selected := map[string]bool{}
+	for _, c := range got {
+		selected[c.Name] = true
+	}
+	for _, want := range []string{"orphan-old", "orphan-mid"} {
+		if !selected[want] {
+			t.Errorf("expected %q to be selected", want)
+		}
+	}
+	// The live spoke surviving is the single most important assertion here.
+	for _, mustSurvive := range []string{"live", "held", "young", "not-deleted"} {
+		if selected[mustSurvive] {
+			t.Errorf("%q must NOT be selected — the predicate has been loosened", mustSurvive)
+		}
+	}
+}
+
+// TestSelectOrphanedPodsNoneWhenHealthy pins the common steady state: a
+// namespace with only a live pod yields nothing, so a healthy fleet is a no-op.
+func TestSelectOrphanedPodsNoneWhenHealthy(t *testing.T) {
+	got := selectOrphanedPods([]orphanedPodCandidate{
+		{Name: "live", Phase: podPhaseRunning},
+	}, fixedReapNow, orphanedPodMinAge)
+	if len(got) != 0 {
+		t.Fatalf("selected %d pods from a healthy namespace, want 0", len(got))
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -5884,6 +5884,14 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// rate-limited to perHiveEnvMaxPatchesPerCycle patches per cycle, because
 	// each patch rolls that hive's pod. See perhive_env_reconcile.go.
 	s.reconcilePerHiveEnvIfDue()
+	// Force-delete hive-namespace pods stuck in Terminating past
+	// orphanedPodMinAge with no finalizers and a non-Running phase — the
+	// residue of nodes disappearing without draining (#5328). Throttled
+	// internally to orphanedPodReapInterval and capped per cycle; nothing else
+	// ever removes these, so without this they accumulate indefinitely (32
+	// measured across 16 namespaces, oldest three weeks). See
+	// orphaned_pod_reaper.go.
+	s.reapOrphanedPodsIfDue()
 	// Drop master generations whose verify window has closed, and warn when one
 	// is closing while spokes still carry it. Throttled internally to
 	// generationRetireInterval. This lane PERSISTS the drop and ALERTS; it is
@@ -5930,6 +5938,7 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		s.sweepStuckAssignmentsIfDue()
 		s.reconcileNetAdminIfDue()
 		s.reconcilePerHiveEnvIfDue()
+		s.reapOrphanedPodsIfDue()
 		s.retireExpiredGenerationsIfDue()
 		s.sweepExpiredAccessIfDue()
 		s.replenishPoolsIfDue()

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -1012,6 +1012,11 @@ type HubServer struct {
 	// Same rationale and same guarding mutex as lastNetAdminReconcile above:
 	// both are poller-loop-only state.
 	lastPerHiveEnvReconcile time.Time
+	// lastOrphanedPodReap throttles the orphaned Terminating-pod reaper
+	// (orphaned_pod_reaper.go), which force-deletes hive-namespace pods left
+	// behind when a node disappears without draining (#5328). Same rationale
+	// and same guarding mutex as the two above: poller-loop-only state.
+	lastOrphanedPodReap time.Time
 	// lastGenerationRetire throttles the expired-master-generation retirement
 	// sweep (hub_generations_retire.go). Same rationale and same guarding mutex
 	// as the two above: poller-loop-only state.


### PR DESCRIPTION
## Problem

Hosted spoke pods stuck in `Terminating` are never reaped. A sweep of one cluster found **27 orphans across 15 hive namespaces**, oldest stuck three weeks; a sixteenth namespace held 5 more, for **32 cleared by hand**.

Every one shared the same signature: `deletionTimestamp` set, `finalizers: []`, `status.phase != "Running"` — and each namespace still had exactly **1 healthy Running pod**, so the live spoke was never affected. That is the fingerprint of a node disappearing without draining: the API server records the delete, the kubelet never confirms it, and because no finalizer and no controller owns the remaining work the object persists forever.

The distribution — 15 namespaces with 1–4 orphans each rather than one bad namespace with 27 — argues for a recurring cluster-level event, not a single misbehaving spoke.

Orphans hold their scheduler slot and inflate per-namespace pod counts, so fleet capacity is misreported. It accumulated for three weeks with no alert, because nothing sweeps it.

## What this PR does

Adds a throttled hub-side sweep that force-deletes hive-namespace pods matching **exactly** the predicate used for the manual remediation:

```
deletionTimestamp != null && finalizers == [] && phase != "Running" && age(deletionTimestamp) > 1h
```

That predicate was verified against all 32 pods with zero collateral damage, and it is deliberately narrow. Each clause is load-bearing:

- **`finalizers == []`** — a finalizer means some controller has unfinished work. Forcing past one strands exactly the resource it existed to reclaim, silently. A pod with finalizers is stuck for a different reason and is out of scope.
- **`phase != "Running"`** — a Running pod with a `deletionTimestamp` is mid-shutdown and still serving. This clause is what guarantees the one live spoke per namespace can never be touched.
- **age > threshold** — normal termination completes in seconds, so anything inside the window is presumed to be shutting down correctly.

## Design decisions

**Where it lives.** `src/pkg/hub/orphaned_pod_reaper.go`, wired as a `reapOrphanedPodsIfDue()` lane on the existing SHA poller next to `reconcileNetAdminIfDue` and `reconcilePerHiveEnvIfDue`, using the same `clusterUnreachableMu`-guarded `lastOrphanedPodReap` throttle. No new goroutine, no new scheduler.

**No new credentials, and the RBAC caveat stated plainly.** This adds no credential, client or kubeconfig. It rides `kubectlForCluster`, which already issues the strictly *broader* `kubectl delete namespace` and `delete pv` against these clusters during provisioning — deleting one already-deleted pod in one namespace is a narrowing of blast radius.

Consistent with the push-path retirement note in `pullonly_upgrade.go`: that note retires the *upgrade* push path specifically and states the hub's kubeconfigs are **not** droppable because provisioning is inherently a hub-side write. This is that same class of write on that same grant, and it does not extend the ordering constraint recorded there.

The honest caveat: **no manifest in this repo grants `pods` for the hub at all** — the only in-repo pods rules belong to the separate `hive-hub-backup` SA (`get,list` + `pods/exec`, no delete). The hub already runs `kubectl get pods --all-namespaces` successfully in production, so pod read exists out-of-band; pod delete comes from the kubeconfig identity the same way. That is called out in the file comment as exactly the drift class the pullonly note warns about. **The consequence is bounded and non-silent by construction**: if the credential lacks delete, the delete fails, is counted in `deleteFailures`, logs at Warn per pod, and retries next sweep. I deliberately did **not** mint a new cluster-wide pods-delete ClusterRole to close a gap the hub already operates through.

**Scoped to hive namespaces only.** Every call is `-n <hive-hosted-id>`, derived from the registry via `hostedNamespaceForHive`. There is no all-namespaces path in the file by construction. Pull-only clusters (`KubectlReachable`) and recently-unreachable clusters are skipped and counted, not failed.

**Named constants, no magic numbers:** `orphanedPodReapInterval` (15m), `orphanedPodMinAge` (1h — ~120x the 30s default grace period), `orphanedPodKubectlTimeout` (30s), `orphanedPodMaxDeletesPerCycle` (50), `podPhaseRunning`.

**Nothing is silent.** Every deletion logs at INFO with namespace, pod and age. Each sweep logs a counted summary (`orphans_found` / `orphans_deleted` / `delete_failures` / `namespaces_skipped_unreachable`). A sweep that scans **no** namespaces while hives exist warns loudly — that is the exact failure mode that made the NET_ADMIN lane dead code for its entire production life. Hitting the per-cycle cap also warns, since mass selection means either the predicate broke or the cluster is in an unexpected state.

## Tests

The predicate is split into pure functions (`podIsOrphanedTerminating`, `parseOrphanCandidates`, `selectOrphanedPods`) so it is testable without kubectl or a cluster. The **negative** cases are the point:

- has finalizers (one, several, and on a year-old pod) → skipped
- `Running`, including a 3-week-old Running pod and one with padded whitespace → skipped
- too young (5s, 59m) and exactly at the threshold, since the bound is exclusive → skipped
- no `deletionTimestamp` at all → skipped
- future timestamp / clock skew → skipped
- unparseable `deletionTimestamp` → fails **safe** to skipped rather than guessing an age

Plus an end-to-end selection test reproducing the measured namespace shape — live spoke + orphans + a finalizer-held pod + a young pod — asserting the live spoke survives, and a guard pinning `orphanedPodMinAge >= 1h` so nobody shrinks it into racing legitimate shutdowns.

## Scope

This is **item 2** of the issue. Root-causing what removes nodes without draining (item 1) and surfacing stuck-pod counts in fleet health (item 3) are separate — hence `Refs`, not `Fixes`. Item 2 is independently useful even after item 1 lands, since ungraceful node loss is a property of the infrastructure and can always recur.

Refs #5328
