### PR TITLE
🔒 fix(entrypoint): write PVC runtime config 0600 at boot, including the copies cp recreates (#5331)

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -61,6 +61,32 @@ HIVE_CONFIG_PATH="${HIVE_CONFIG:-/etc/hive/hive.yaml}"
 HIVE_CONFIG_RUNTIME="/data/hive.yaml.runtime"
 HIVE_CONFIG_RUNTIME_LEGACY="/data/hive.yaml.bak"
 
+# hive_harden_runtime_config tightens $1 to 0600.
+#
+# The PVC config copies carry dashboard.auth_token (and github.token in PAT
+# mode) and /data is world-traversable, so a 0644 copy hands the dashboard
+# owner credential to every unprivileged agent uid on the host (#5331).
+#
+# This is called in two places, and both are needed:
+#
+#   1. Once at boot over the copies that ALREADY exist, so hives deployed
+#      before the 0600 fix are remediated rather than waiting for a save.
+#   2. After every `cp` below that (re)creates $HIVE_CONFIG_RUNTIME. cp gives
+#      a newly created destination the SOURCE's mode, and both sources (the
+#      ConfigMap seed, the bind-mounted hive.yaml) are 0644 — so without this
+#      the file is re-widened to 0644 on every boot, undoing (1) on the very
+#      same boot and leaving a hive that never saves world-readable forever.
+#
+# Best-effort: on a read-only or foreign-owned PVC this must not abort boot.
+hive_harden_runtime_config() {
+  [ -f "$1" ] && chmod 600 "$1" 2>/dev/null || true
+}
+
+for _cfg in "$HIVE_CONFIG_RUNTIME" "$HIVE_CONFIG_RUNTIME_LEGACY" /data/hive.yaml.dashboard; do
+  hive_harden_runtime_config "$_cfg"
+done
+unset _cfg
+
 # hive_runtime_config_read echoes the path to read the persisted runtime
 # config from: the new name when it is present and non-empty, else the
 # legacy name when that is, else empty. Read-only — it never creates,
@@ -255,6 +281,7 @@ PYEOF
     # Write the (merged) config as the disaster-recovery snapshot. Always
     # under the new name; the legacy file is left untouched on the PVC.
     cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_RUNTIME" 2>/dev/null || true
+    hive_harden_runtime_config "$HIVE_CONFIG_RUNTIME"
     echo "[entrypoint] K8s mode — ConfigMap is the seed, runtime config written to $HIVE_CONFIG_RUNTIME"
   else
     # Neither source exists: no runtime config on the PVC (checked first,
@@ -278,6 +305,7 @@ else
   if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ -z "$HIVE_CONFIG_SOURCE" ]; then
     # First boot: config exists but no PVC runtime config yet — seed it
     cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_RUNTIME"
+    hive_harden_runtime_config "$HIVE_CONFIG_RUNTIME"
     echo "[entrypoint] First boot — config seeded to PVC: $HIVE_CONFIG_RUNTIME"
   elif [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ -n "$HIVE_CONFIG_SOURCE" ]; then
     # The PVC runtime config is the source of truth (updated by Save()).
@@ -294,6 +322,7 @@ else
     # as the untouched fallback until Save() takes over writing the new one.
     if [ "$HIVE_CONFIG_SOURCE" = "$HIVE_CONFIG_RUNTIME_LEGACY" ]; then
       if cp "$HIVE_CONFIG_RUNTIME_LEGACY" "$HIVE_CONFIG_RUNTIME" 2>/dev/null; then
+        hive_harden_runtime_config "$HIVE_CONFIG_RUNTIME"
         echo "[entrypoint] Migration — seeded $HIVE_CONFIG_RUNTIME from legacy $HIVE_CONFIG_RUNTIME_LEGACY (legacy left in place)"
       fi
     fi

--- a/src/pkg/config/entrypoint_boot_test.go
+++ b/src/pkg/config/entrypoint_boot_test.go
@@ -29,6 +29,15 @@ func runBootPrelude(t *testing.T, env map[string]string, files map[string]string
 // is the ordinary way that happens.
 func runBootPreludeRO(t *testing.T, env map[string]string, files map[string]string, readOnly []string) string {
 	t.Helper()
+	out, _ := runBootPreludeRoot(t, env, files, readOnly)
+	return out
+}
+
+// runBootPreludeRoot is runBootPreludeRO that also returns the temp root, so a
+// test can inspect the FILES the prelude left behind (permissions, contents)
+// and not just what it logged.
+func runBootPreludeRoot(t *testing.T, env map[string]string, files map[string]string, readOnly []string) (string, string) {
+	t.Helper()
 	src, err := os.ReadFile(entrypointPath)
 	if err != nil {
 		t.Skipf("entrypoint.sh not readable from this package: %v", err)
@@ -40,6 +49,14 @@ func runBootPreludeRO(t *testing.T, env map[string]string, files map[string]stri
 		t.Fatal("could not find the end of the config branch in entrypoint.sh; the marker moved and this test would silently cover nothing")
 	}
 	root := t.TempDir()
+	// /data always exists on a real hive (it is the PVC mount point), so
+	// create it even when a case seeds no files into it. Otherwise the
+	// entrypoint's `cp ... /data/hive.yaml.runtime` fails on the missing
+	// directory and a permissions assertion would pass/fail for the wrong
+	// reason.
+	if err := os.MkdirAll(filepath.Join(root, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	for rel, content := range files {
 		p := filepath.Join(root, rel)
 		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
@@ -81,7 +98,67 @@ func runBootPreludeRO(t *testing.T, env map[string]string, files map[string]stri
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 	out, _ := cmd.CombinedOutput()
-	return string(out)
+	return string(out), root
+}
+
+// TestEntrypointHardensRuntimeConfigItRecreates is the regression guard for
+// #5331: every `cp` that (re)creates /data/hive.yaml.runtime must leave it
+// 0600.
+//
+// The boot-time chmod loop only covers files that already exist when the
+// script starts. These three branches CREATE the runtime copy from a 0644
+// source (the ConfigMap seed or the bind-mounted hive.yaml), and cp gives a
+// newly created destination the source's mode — so without the explicit
+// hardening the file is re-widened to 0644 on every boot, after the loop has
+// already run. The runtime config carries dashboard.auth_token, and /data is
+// world-traversable, so 0644 hands the dashboard owner credential to every
+// unprivileged agent uid on the host.
+//
+// The harness writes its seed files 0644, which is exactly the production
+// mode, so this test fails against the unhardened script.
+func TestEntrypointHardensRuntimeConfigItRecreates(t *testing.T) {
+	cases := []struct {
+		name  string
+		env   map[string]string
+		files map[string]string
+	}{
+		{
+			// K8s first boot: seeded from the 0644 ConfigMap seed.
+			name: "k8s seeds runtime from ConfigMap",
+			env:  map[string]string{"KUBERNETES_SERVICE_HOST": "10.0.0.1"},
+			files: map[string]string{
+				"etc/hive/hive.yaml": "acmm_level: 3\n",
+			},
+		},
+		{
+			// Docker first boot: seeded from the 0644 bind-mounted config.
+			name:  "docker first boot seeds runtime",
+			env:   map[string]string{},
+			files: map[string]string{"etc/hive/hive.yaml": "acmm_level: 3\n"},
+		},
+		{
+			// Docker migration: the new name is created from legacy .bak.
+			name: "docker migration seeds runtime from legacy bak",
+			env:  map[string]string{},
+			files: map[string]string{
+				"etc/hive/hive.yaml": "acmm_level: 3\n",
+				"data/hive.yaml.bak": "acmm_level: 5\n",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, root := runBootPreludeRoot(t, tc.env, tc.files, nil)
+			p := filepath.Join(root, "data/hive.yaml.runtime")
+			info, err := os.Stat(p)
+			if err != nil {
+				t.Fatalf("the prelude did not create the runtime config (%v); this branch no longer covers what the test claims:\n%s", err, out)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("runtime config is %04o, want 0600 — it carries dashboard.auth_token and /data is world-traversable (#5331):\n%s", got, out)
+			}
+		})
+	}
 }
 
 // TestK8sBootsFromRuntimeConfigNotTheSeed pins the phase-2 precedence: the PVC


### PR DESCRIPTION
## Overlap with #5335 — please read first

#5335 is open and fixes the **Go write paths** for the same issue, and its
approach is sound: `saveLocked` writes `RuntimeConfigFile` `0o600` on both the
initial write and the remove-and-retry, `saveDashboardOverlay` uses
`overlayFileMode = 0o600` plus `f.Chmod` on a leftover `.tmp`. Those create the
files `0600` **from the start** (`os.WriteFile`/`OpenFile` apply the mode at
create time), so there is no world-readable window. **This PR does not touch
`config.go` at all** — that half is #5335's and I've left it alone.

The two PRs overlap on one thing only: both add a boot-time `chmod` loop to
`entrypoint.sh`. Whichever lands second will need a trivial conflict resolution
there. I based this on `v4` rather than stacking on #5335 because the repo's
`branches: [v2, v4]` workflow filters skip the Go test suite for any other
base — the new regression test would never have run in CI, which is not an
acceptable way to land a security fix.

## The part #5335 does not cover

A boot-time `chmod` alone is **silently reverted later in the same script**.
Three `cp` calls in the config branch *recreate* `$HIVE_CONFIG_RUNTIME`:

| branch | source |
|---|---|
| K8s — ConfigMap is the seed | `$HIVE_CONFIG_PATH` (0644) |
| Docker first boot | `$HIVE_CONFIG_PATH` (0644) |
| legacy `.bak` migration | `$HIVE_CONFIG_RUNTIME_LEGACY` (0644) |

`cp` gives a **newly created** destination the **source's** mode. Both sources
are 0644, so the runtime copy is re-widened to 0644 on every boot — after the
hardening loop at the top has already run.

Consequence: with the write-path fix alone, 0600 only holds from the first
`Config.Save()` onward. **A hive that boots and never saves stays
world-readable indefinitely.** The runtime config carries
`dashboard.auth_token`, and `/data` is world-traversable, so that is the
dashboard owner credential readable by every unprivileged agent uid — the exact
exposure #5331 reports.

## Change

`hive_harden_runtime_config`, called in two places, both required:

1. **Once at boot** over `hive.yaml.runtime` / `.bak` / `.dashboard` that
   already exist — remediation for hives deployed before this fix, so they are
   tightened on their next restart rather than waiting for a save.
2. **After each of the three `cp` calls**, so (1) is not undone on the same boot.

Best-effort (`2>/dev/null || true`) throughout, matching the surrounding
convention: a read-only or foreign-owned PVC must not abort boot. No
intentionally group-shared path (`/data/home/.codex` and friends) is touched —
I checked the surrounding comments before tightening anything.

## Remediation for already-deployed hives

Point 1 above. Every existing hive converges to 0600 on its next restart,
without needing a config save first.

## Test

`TestEntrypointHardensRuntimeConfigItRecreates` — table-driven over all three
recreate branches, asserting `Mode().Perm() == 0600`. Verified it **fails at
`0644`** against the unhardened script (the harness seeds files 0644, the
production mode), so it is a real regression guard and not a tautology.
Existing entrypoint boot tests still pass; the harness gained a `/data` mkdir
so the assertion turns on the mode rather than a missing directory.

No token or key material appears in the diff, the fixtures, or the logs.

## Still open after this

Item 3 of the issue's recommendation — folding `dashboard.auth_token` out of
`redactedForPersist()` — is addressed by neither PR. Worth tracking separately:
defense-in-depth on top of 0600 is a different change with a real regression
surface, since the token has to survive a restart.

Fixes #5331