### PR TITLE
🐛 fix(hub): L3-L5 verdict — held PRs awaiting review are amber, not 'no write' red

### DIFF
--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -252,7 +252,21 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 			return maxRFC3339(maxRFC3339(r.Issues.NewestAt, r.PRs.NewestAt),
 				maxRFC3339(r.Comments.NewestAt, r.Reviews.NewestAt))
 		})
-		return bandFreshness(v, last, ok, queuedWork, now, "write")
+		verdict := bandFreshness(v, last, ok, queuedWork, now, "write")
+		// A stale write stream is NOT an agent fault when the hive's output is
+		// parked on the HUMAN side of the gate: hold-labeled PRs awaiting
+		// review mean the agents produced, then correctly stood down to avoid
+		// duplicating in-flight work — the next move is the operator's.
+		// Without this, a saturated L3 hive reads "no write in Nd (M queued)",
+		// indistinguishable from a broken one (observed on flashsystems/ess
+		// 2026-08-31: 14 held PRs covering every queued item, quality agent
+		// explicitly declining new work, row solid red for 4 days). Amber, not
+		// green: the hive is healthy but a human action is pending.
+		if verdict.State == HealthStateRed && e.HoldTotal != nil && *e.HoldTotal > 0 {
+			verdict.State = HealthStateAmber
+			verdict.Reason = fmt.Sprintf("awaiting human review — %d held for approval", *e.HoldTotal)
+		}
+		return verdict
 	}
 }
 

--- a/src/pkg/hub/health_verdict_test.go
+++ b/src/pkg/hub/health_verdict_test.go
@@ -110,6 +110,27 @@ func TestHiveHealthFor_ACMMBands(t *testing.T) {
 			wantKind:  "creates",
 		},
 		{
+			// Saturated-on-human: the write stream is stale ONLY because the
+			// output is parked behind hold labels awaiting operator review —
+			// agents produced, then stood down to avoid duplicating held work
+			// (flashsystems/ess 2026-08-31: 14 held PRs covering all 28 queued
+			// items read as "no write in 4d" solid red). Amber + explicit
+			// reason, never red.
+			name: "L4 creates stale, work queued, but PRs HELD for review — amber",
+			entry: func() RegistryEntry {
+				e := withActivity(base(4), ractivity("o/r", oldTs, oldTs, "", ""))
+				held := 14
+				e.HoldTotal = &held
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     28,
+			wantState:  HealthStateAmber,
+			wantKind:   "creates",
+			wantReason: "awaiting human review — 14 held for approval",
+		},
+		{
 			name:      "L4 creates stale but queue EMPTY — green (idle, nothing to do)",
 			entry:     withActivity(base(4), ractivity("o/r", oldTs, oldTs, "", "")),
 			rollup:    okRollup(),


### PR DESCRIPTION
## Problem

flashsystems/ess (L3) showed **"no write in 4d (28 queued)"** solid red on /fleet while being completely healthy: its 14 hold-gated PRs covered every queued item, and its quality agent's turns explicitly stood down ("no new test PRs should be created — the 14 open PRs comprehensively cover all identified testing gaps... awaiting human review, not abandonment"). At L3, merging is the operator's job, so a saturated hive whose output is parked behind hold labels is indistinguishable from a dead one — the verdict sent the operator chasing a healthy hive.

## Fix

`HoldTotal` (issues+PRs parked behind hold labels awaiting a human) is already carried on the heartbeat and registry entry. In the L3–L5 creates band: when the write stream is stale-red but `HoldTotal > 0`, the verdict becomes **amber** with reason `awaiting human review — N held for approval`. Amber (not green) because the hive is healthy but a human action is pending; the dashboard already maps amber → warning.

L6 is deliberately unchanged — self-merging hives are judged on merges and hold-gating doesn't excuse a stalled merge stream there.

## Test

New table case: L4, stale creates, 28 queued, HoldTotal=14 → amber with the exact reason string (previously red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)