### PR TITLE
🐛 fix(governor): conflicting PRs are not merge-eligible

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -8529,6 +8529,17 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 			continue
 		}
 
+		if pr.Mergeable == github.MergeableNo {
+			// A conflicting PR cannot merge no matter how green its checks
+			// are. Listing it as merge-eligible left the eligible count stuck
+			// at N forever while nothing could actually merge (console
+			// #23002/#23003, 2026-08-31: the only two build-gate-green PRs
+			// were DIRTY go.mod dependabot bumps). Conflicts are the
+			// rebase/needs-human path's job, not the sweep's — keep them out
+			// of the eligible bucket.
+			continue
+		}
+
 		dco := "unknown"
 		for _, l := range pr.Labels {
 			switch l {


### PR DESCRIPTION
Follow-up gap from #5019: `writeMergeEligible` classifies by check state only, so a PR whose required checks are green but which is CONFLICTING (`mergeable: no`) lands in `merge-eligible.json` — where the sweep can never merge it and agents are told it's ready. Observed on kubestellar/console (2026-08-31): the only two build-gate-green PRs were DIRTY dependabot go.mod bumps, so the soak read "eligible=2" indefinitely while nothing merged.

Exclude `mergeable=no` PRs from the eligible bucket — conflicts are the rebase/`needs-human` path's job. Mirrors the existing pending-band rule which already requires `MergeableYes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)