### PR TITLE
🐛 fix(release): remove the empty expression that broke workflow registration

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -652,8 +652,19 @@ jobs:
             # $GITHUB_REPOSITORY (runner-provided) rather than the
             # ${{ github.repository }} expression other steps use: this step's
             # script is extracted verbatim and run under plain bash by
-            # test-release-push-retry.sh, where an unexpanded ${{ }} is a bash
-            # bad-substitution. Same value, and it keeps the step testable.
+            # test-release-push-retry.sh, where an unexpanded workflow
+            # expression is a bash bad-substitution. Same value, and it keeps
+            # the step testable.
+            #
+            # Do NOT write an empty workflow-expression delimiter pair in this
+            # comment to illustrate the point. GitHub's workflow parser scans
+            # the entire `run:` string for expressions and does not honour
+            # shell comments, so an empty one is a hard parse error
+            # ("An expression was expected") that fails the WHOLE workflow at
+            # registration — not at runtime. That is #5339: the workflow
+            # silently fell back to being named by its path, its `on:` block
+            # was never read, and the workflow_run trigger stopped firing for
+            # four days while every run looked merely "failed".
             if out="$(gh api -X PUT "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/merge" \
                         -f merge_method=merge -f sha="${commit_sha}" 2>&1)"; then
               echo "$out"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -176,7 +176,13 @@ jobs:
       # it retags an existing digest, so a tip whose docker.yml run is still
       # running (or was cancelled) has nothing to retag. Stand down and let
       # the next tick take it — by then the build has settled either way.
+      #
+      # This stands down GREEN (an output the release job gates on), not by
+      # failing. A tip whose build is still in flight is the ordinary state of
+      # a busy branch, and an hourly job that paints the repo red for it would
+      # be training everyone to ignore exactly the signal #5318 added.
       - name: Require published images for the backstop's target
+        id: images
         if: github.event_name != 'workflow_run'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -188,12 +194,15 @@ jobs:
             --jq '[.workflow_runs[] | select(.event == "push")] | last | .conclusion // ""')"
           if [ "$conclusion" != "success" ]; then
             echo "::warning::Backstop standing down: docker.yml has no successful completed push run for v4 tip ${sha} (found '${conclusion:-none}'), so there is no published digest to retag. The next hourly tick will retry. If this persists, the images for v4's tip are not being built (#5318)."
-            exit 1
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "docker.yml succeeded on ${sha} — images are published, safe to retag."
+          echo "published=true" >> "$GITHUB_OUTPUT"
 
       - name: Derive whether this merge warrants a release
         id: derive
+        if: github.event_name == 'workflow_run' || steps.images.outputs.published == 'true'
         run: src/scripts/derive-release-version.sh
 
   # Cheap supersession check BEFORE the expensive release job (#5142): if v4

--- a/src/scripts/check-action-pins.sh
+++ b/src/scripts/check-action-pins.sh
@@ -49,6 +49,23 @@ if command -v gh >/dev/null 2>&1; then
   done || fail=1
 fi
 
+# An EMPTY workflow-expression delimiter pair anywhere in a workflow file is a
+# hard parse error in GitHub's workflow parser ("An expression was expected"),
+# and the parser scans `run:` blocks in full without honouring shell comments —
+# so one written inside a comment, purely to illustrate a point, still kills the
+# file. The failure mode is why this is worth a CI gate rather than a code
+# review note (#5339): GitHub does not reject the push or annotate the file. It
+# silently falls back to naming the workflow by its PATH, never reads its `on:`
+# block, and stops firing its triggers. release.yml sat like that for four days
+# with the entire tagged-release pipeline dead, while its only visible symptom
+# was job-less "failed" runs that looked like unrelated CI flake.
+empty_expr=$(grep -rnE '\$\{\{[[:space:]]*\}\}' "$DIR" 2>/dev/null || true)
+if [ -n "$empty_expr" ]; then
+  echo "EMPTY-EXPRESSION an empty \${{ }} is a workflow parse error, not a comment:"
+  echo "$empty_expr"
+  fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "action pin check FAILED"
   exit 1


### PR DESCRIPTION
## The actual root cause of #5339

#5347 renamed the workflow on the theory that GitHub's registration record was corrupt. **That theory was wrong**, and the rename disproved it: the freshly-created record (`346900866`) reproduced the identical symptom — path-named, job-less `push` runs — within minutes. A brand-new record cannot be stale.

Asking GitHub's parser directly gives the answer in one line:

```
$ gh workflow run tagged-release.yml --ref v4
HTTP 422: failed to parse workflow: (Line: 569, Col: 14): An expression was expected
```

Line 569 is the `push_v4` step's `run:` block. It contains an **empty workflow-expression delimiter pair** — an opening `${{` immediately followed by `}}` — inside a *shell comment*, written by #5334 to illustrate that an unexpanded expression is a bash bad-substitution:

```
# test-release-push-retry.sh, where an unexpanded ${{ }} is a bash
# bad-substitution.
```

GitHub's parser scans the entire `run:` string for expressions and **does not honour shell comments**, so the illustration is parsed as a real expression — an empty one, which is a hard error.

### Confirmed by construction

| | |
|---|---|
| occurrences before #5334 (`08505da`) | **0** |
| occurrences after #5334 (`22649407`) | **1** |
| registration broke at | **18:36:51** — the second `22649407` merged |

This also explains every observation that made the bug so confusing: the file is valid YAML, `name:` is on line 1, and no revision on any branch ever declared a `push:` trigger. The parse failure happens *after* YAML parsing, so `yaml.safe_load` succeeds while GitHub holds no definition at all.

### Why this needs a CI gate, not a review note

GitHub does not reject the push, fail a check, or annotate the file. It silently falls back to naming the workflow by its **path**, never reads its `on:` block, and stops firing its triggers. `release.yml` sat like that for four days with the entire tagged-release pipeline dead, while the only visible symptom was job-less "failed" runs that looked like unrelated CI flake.

`check-action-pins.sh` now fails on an empty expression in any workflow file. Verified it fires when one is reintroduced, rather than assuming it would.

### Verified live

Dispatching the fixed branch — the same call that returned 422 minutes earlier — now succeeds, and the run reports the **parsed** name:

```
run 33431628458   name=Tagged Release   completed/success
  decide: success    release: skipped    precheck: skipped
```

`name=Tagged Release` rather than the path is the exact signal #5339 asks for. The workflow record itself will flip once this reaches `v4`.

## Second commit: the backstop stands down green

That first live run also surfaced a flaw in #5347's own #5318 backstop: its published-images guard exited 1 when `v4`'s tip had no successful `docker.yml` run. That is the *ordinary* state of a busy branch — a build in flight, or cancelled by newer traffic — and an hourly job painting the repo red for the normal case would train everyone to ignore precisely the signal #5318 added. Worse, a red run is indistinguishable from the job-less failures of #5339.

It now emits `published=false` and exits 0, with the derive step gated on that output, so a stood-down backstop yields no `release=true` and the release job no-ops exactly as it does for an empty `Unreleased`. The `::warning::` still records the skipped opportunity. The run above is that path working.

## Preserved

Gate-wait, tag-already-exists refusal, `pushed=false` deferral and the `RELEASE_PUSH_GH006_WINDOW` seam untouched; `test-release-push-retry.sh` passes including its wiring case. No action pin changed.

Refs #5339
Refs #5318