### PR TITLE
🐛 fix(release): earn `gate` as a commit status so v4 protection accepts it

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,6 +93,13 @@ jobs:
   # see the `env_lists` entry there and src/docs/release-line-guard.md.
   gate:
     runs-on: ubuntu-latest
+    # statuses: write is needed ONLY by the "Publish gate as a commit status"
+    # step below (#5356). Scoped to this job rather than raised on the whole
+    # workflow so the heavyweight build jobs keep the read-only contents /
+    # packages-write set they have today.
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       push: ${{ steps.decide.outputs.push }}
     steps:
@@ -124,6 +131,59 @@ jobs:
           esac
           echo "push=$push" >> "$GITHUB_OUTPUT"
           echo "Push to GHCR: $push (branch=$REF_NAME event=$EVENT)"
+
+      # #5356 (7th distinct release-workflow failure): v4 branch protection
+      # requires the context "gate". This job already produces a check-run by
+      # that name, and tagged-release.yml's SHA-keyed wait sees it conclude
+      # 'success' on the release commit — yet the merge API still answers
+      # `Required status check "gate" is expected.` for the full retry window.
+      #
+      # The reason is check-SUITE branch affinity. The release dance earns gate
+      # on a throwaway `release-gate/v<version>` branch (see the EXCEPTION
+      # comment above), so the check-run's parent suite carries
+      # head_branch: release-gate/v<version>, never v4. Measured on release PR
+      # #5355's head c4c5f3db: gate was a check-run with conclusion success,
+      # suite 90594836071, suite head_branch release-gate/v4.0.1 — and gate was
+      # ABSENT from that commit's statuses, which held only dco and tide.
+      # Protection evaluating a merge INTO v4 does not honour a check-run whose
+      # suite is bound to a different branch, so no change to how the merge is
+      # performed can fix it. Reproduced identically on PR #5357 (95fd0b5b).
+      #
+      # A commit STATUS has no check-suite and therefore no branch affinity, so
+      # it satisfies contexts: ["gate"] whichever branch or workflow produced
+      # it. dco and tide already prove statuses work on this repo. v4's
+      # protection pins the context to app_id 15368 (github-actions), which is
+      # the app a GITHUB_TOKEN status from Actions is attributed to, so this
+      # status is accepted for that pin.
+      #
+      # Deliberately ADDITIVE: the gate check-run stays exactly as it was,
+      # because tagged-release.yml's wait-for-gate step polls
+      # /commits/{sha}/check-runs for it. Removing or replacing the check-run
+      # would break that wait.
+      #
+      # `continue-on-error` so a statuses API hiccup cannot turn a green build
+      # red: the check-run remains the primary signal, and a missing status
+      # fails LOUDLY and safely later (the release merge simply defers) rather
+      # than silently landing an unbuilt commit.
+      - name: Publish gate as a commit status
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # For pull_request the run's github.sha is the ephemeral merge
+          # commit, which is NOT the SHA protection evaluates; the PR head is.
+          # For push / workflow_dispatch github.sha IS the commit under test.
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Posting 'gate' commit status on ${TARGET_SHA}..."
+          gh api -X POST "repos/${REPO}/statuses/${TARGET_SHA}" \
+            -f state=success \
+            -f context=gate \
+            -f target_url="${TARGET_URL}" \
+            -f description="gate passed" >/dev/null
+          echo "Posted 'gate' success status on ${TARGET_SHA}."
 
   build:
     needs: gate

--- a/src/scripts/test-release-push-retry.sh
+++ b/src/scripts/test-release-push-retry.sh
@@ -300,6 +300,60 @@ else:
 sys.exit(0 if ok else 1)
 PY
 
+# #5356: the required context "gate" must be earned as a commit STATUS, not
+# only as a check-run. The release dance earns it on a `release-gate/*` scratch
+# branch, so the check-run's parent check-suite is bound to that branch and
+# protection evaluating a merge into v4 ignores it — the merge API answers
+# `Required status check "gate" is expected.` while the SHA-keyed wait sees it
+# green. A status carries no suite and no branch affinity, so it is the only
+# form of `gate` that satisfies protection here. This pins both halves: the
+# status must be posted, AND the check-run must survive (tagged-release.yml's
+# wait-for-gate step polls /commits/{sha}/check-runs for it).
+echo "case: docker.yml publishes gate as a commit status (#5356)"
+python3 - "$repo_root/.github/workflows/docker.yml" <<'PY' && note_ok "gate status wiring intact" || fail=1
+import sys, yaml
+w = yaml.safe_load(open(sys.argv[1]))
+ok = True
+def bad(msg):
+    global ok; ok = False; print(f"  FAIL: {msg}")
+gate = (w.get("jobs") or {}).get("gate")
+if not gate:
+    bad("docker.yml has no `gate` job — it produces the ONLY context v4 protection requires")
+    sys.exit(1)
+steps = gate.get("steps") or []
+status_step = next((s for s in steps
+                    if "commit status" in (s.get("name") or "").lower()), None)
+if status_step is None:
+    bad("the gate job no longer posts `gate` as a commit status — a check-run alone is "
+        "bound to its check-suite's branch, so a release earned on release-gate/* can "
+        "never satisfy protection on v4 (#5356)")
+else:
+    run = status_step.get("run", "")
+    if "/statuses/" not in run:
+        bad("the gate status step no longer POSTs to the statuses API (#5356)")
+    if "context=gate" not in run:
+        bad("the gate status step no longer posts the context `gate` — protection matches "
+            "the context name exactly (#5356)")
+    if "state=success" not in run:
+        bad("the gate status step no longer posts state=success (#5356)")
+    # The pull_request run's github.sha is an ephemeral merge commit, not the
+    # SHA protection evaluates. Posting there would leave the head SHA bare.
+    if "pull_request.head.sha" not in yaml.dump(status_step):
+        bad("the gate status step does not target the PR HEAD sha — on pull_request, "
+            "github.sha is the ephemeral merge commit and protection evaluates the head (#5356)")
+# statuses: write must be granted somewhere that covers this job.
+perms = gate.get("permissions") or w.get("permissions") or {}
+if perms.get("statuses") != "write":
+    bad("the gate job lacks statuses: write — the commit status POST will 403 (#5356)")
+# Additive, not a replacement: the job must keep its `gate` name so the
+# check-run tagged-release.yml's SHA-keyed wait polls for still appears, and
+# so the required context resolves. A `name:` override would rename both.
+if gate.get("name") not in (None, "gate"):
+    bad("the gate job carries a display name that is not `gate` — that renames the "
+        "check-run tagged-release.yml waits on AND the required context (#5356)")
+sys.exit(0 if ok else 1)
+PY
+
 if [ "$fail" -ne 0 ]; then
   echo "FAILED"
   exit 1


### PR DESCRIPTION
Fixes #5356

## The failure

The release workflow now reaches the merge step and GitHub rejects it:

```json
{"message":"Required status check \"gate\" is expected.","status":"405"}
```

repeated for the full 120s retry window, then the job fails. This is the **seventh** distinct way `tagged-release.yml` has failed, and the last blocker on v4.0.1 — which has not cut since 2026-08-27.

## Root cause: check-suite branch affinity

`v4` protection requires `contexts: ["gate"]`, `strict: false`. `gate` is earned on a **scratch branch** by design — the workflow pushes the release commit to `release-gate/v4.0.1` so `docker.yml` runs and produces the `gate` check-run.

Verified independently on release PR #5355's head `c4c5f3db`:

| | |
|---|---|
| `gate` as a **check-run** | `success` |
| `gate` as a **status** | **ABSENT** (only `dco`, `tide` exist) |
| `check_suite.id` | `90594836071` |
| suite `head_branch` | **`release-gate/v4.0.1`** — the scratch branch, not `v4` |
| suite `head_sha` | `c4c5f3db` |

Branch-protection evaluation for a merge **into `v4`** does not honour a check-run whose suite is bound to a different branch. So the workflow's own SHA-keyed gate-wait correctly sees `gate: success` on the commit, and moments later the merge API calls `gate` "expected" on that same commit. Reproduced deterministically across two independent runs (#5355 `c4c5f3db`, #5357 `95fd0b5b`).

**No change to how the merge is performed can fix this.** The fix has to change how `gate` is *earned*.

## The fix

`docker.yml`'s `gate` job now **also** posts `gate` as a commit status:

```
POST /repos/{owner}/{repo}/statuses/{sha}   context=gate  state=success
```

A commit status has no check-suite and therefore no branch affinity, so it satisfies `contexts: ["gate"]` regardless of which branch or workflow produced it. `dco` and `tide` already exist as statuses on these commits, so this path is demonstrably available on this repo.

One detail worth flagging, since it is what makes this work rather than merely look like it should: protection pins the context to **`app_id: 15368`**, which is `github-actions`. A status posted with the workflow's `GITHUB_TOKEN` is attributed to exactly that app, so it satisfies the pin. A status from a PAT or a different App would **not** have.

### Additive by design

The existing `gate` **check-run is untouched**. `tagged-release.yml`'s gate-wait step polls `/commits/{sha}/check-runs` for `gate`, and that keeps working unchanged. `tagged-release.yml` is not modified at all in this PR.

### New permission — yes, one

`statuses: write`, granted at **job level on `gate` only** (`contents: read` + `statuses: write`), not raised workflow-wide. The heavyweight build jobs keep the existing `contents: read` / `packages: write` set.

### PR-head SHA, not `github.sha`

On `pull_request`, `github.sha` is the ephemeral merge commit, which is **not** the SHA protection evaluates. The step targets `github.event.pull_request.head.sha || github.sha`, so it is correct on both `pull_request` and `push`/`workflow_dispatch`.

### `continue-on-error`

A statuses API hiccup cannot turn a green build red. The check-run remains the primary build signal, and a missing status fails **loudly and safely** — the release merge simply defers rather than silently landing an unbuilt commit.

## What would prove this works

**Honest scope: I cannot fully prove this without a release actually cutting.** What I can and did verify:

- ✅ The suite-binding diagnosis, re-derived independently from the API (table above) — not taken on trust.
- ✅ `app_id 15368 == github-actions`, confirming a `GITHUB_TOKEN` status satisfies the pin. This was the one step that could have silently invalidated the whole approach.
- ✅ `docker.yml` parses; no empty `${{ }}` anywhere (the #5339/#5354 failure mode).
- ✅ `check-action-pins.sh`, `check-release-lines.sh`, `check-no-image-attestations.sh`, `test-release-push-retry.sh` all pass.
- ✅ The new regression pin genuinely fails when the status step is deleted (verified by deleting it), so it is not a vacuous pass.

**The decisive evidence, available on this very PR:** once `docker.yml` runs here, this PR's head SHA should carry `gate` as **both** a check-run and a **status**. Check with:

```
gh api repos/kubestellar/hive/commits/<head-sha>/status --jq '.statuses[].context'
```

If `gate` appears in that list alongside `dco` and `tide`, the mechanism works. That is a direct observation, and it is the thing that was missing before.

**What remains genuinely unproven:** that branch protection then *accepts* that status for a merge into `v4`. That is standard, documented GitHub behaviour for context matching, and the `app_id` check above removes the one plausible way it could fail — but it is inference, not observation, until a release actually cuts. The next `v4.0.1` attempt is the real test.

## Preserved, not weakened

- gate-wait step's SHA-keyed check-runs lookup
- tag-already-exists refusal
- `pushed=false` deferral output gating the GitHub-Release step
- `RELEASE_PUSH_GH006_WINDOW` test seam
- backstop's published-images guard (stands down **green**, deliberately)

All of the above live in `tagged-release.yml`, which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)