### PR TITLE
🐛 fix(release): re-earn gate after opening the release PR (#5356)

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -103,6 +103,24 @@ name: Tagged Release
 #     they now skip and the suite completes when `gate` does. If a job is ever
 #     added to docker.yml that runs on the scratch branch, it will re-block
 #     this merge in exactly the same invisible way.
+#   - OPENING THE RELEASE PR HIDES ITS OWN GREEN GATE (#5339 7th, #5356 8th).
+#     Opening the PR below fires every `pull_request`-triggered workflow on the
+#     SAME SHA. Those runs are created by GITHUB_TOKEN, so GitHub's recursion
+#     guard never starts their jobs: each fails in ~2s having scheduled ZERO
+#     jobs, leaving a check-SUITE with no check-RUNS in it. Protection resolves
+#     a required context against the most recent suite, so with an empty suite
+#     newest, `gate` reads as MISSING — `Required status check "gate" is
+#     expected` (405) for the whole retry window.
+#
+#     Note the green `gate` is NOT overwritten: a zero-job run publishes no
+#     check-runs, and the one `gate` check-run on the SHA stays `success`. It
+#     is simply not in the suite protection consults. #5358's job-level `if:`
+#     in docker.yml therefore fixed nothing (the runner never reaches a job),
+#     and no docker.yml-only change could — nine other workflows leave an
+#     identical empty suite in the same second. The step below instead
+#     RE-DISPATCHES docker.yml once the PR exists, making a green suite newest
+#     again. If a future change stops that re-dispatch, this failure returns
+#     looking exactly like a green gate that protection refuses to see.
 #
 # IDEMPOTENCY: this workflow's own release commit (moving Unreleased into a
 # dated section) is what empties Unreleased, which re-triggers docker.yml on
@@ -639,6 +657,105 @@ jobs:
             || { echo "::error::gh pr create failed: ${pr_url}" >&2; exit 1; }
           pr_number="$(grep -oE '[0-9]+$' <<<"$pr_url")"
           echo "Opened PR #${pr_number}: ${pr_url}"
+
+          # #5356 (8th recurrence): RE-EARN `gate` AFTER the PR exists.
+          #
+          # Opening the PR above fires every `pull_request`-triggered workflow
+          # in this repo on the SAME SHA. Those runs are created by this job's
+          # GITHUB_TOKEN, so GitHub's recursive-workflow guard never starts
+          # their jobs: each one completes as `failure` within ~2s having
+          # scheduled ZERO jobs, and therefore produces a check-SUITE that
+          # contains no check-RUNS at all. Measured on release PR #5361, head
+          # 4d6510fc: one green suite from the dispatch at 20:22:25Z with 10
+          # runs in it, then TEN empty failed github-actions suites at
+          # 20:22:42Z — docker.yml, changelog-reminder, docs-index-reminder,
+          # greetings, copilot-dco, copilot-automation, quadlet-gate and the
+          # three podman lanes.
+          #
+          # WHY THE EARLIER READING OF THIS BUG WAS WRONG, and why #5358 could
+          # not have fixed it. The failure was diagnosed as the empty run
+          # publishing a FAILED `gate` check-run that superseded the green one.
+          # It does not: a run with zero jobs publishes zero check-runs, and on
+          # 4d6510fc there is exactly ONE `gate` check-run and it is `success`.
+          # What protection actually reports is `Required status check "gate"
+          # is expected` — "expected", i.e. MISSING, not failed — because it
+          # resolves the required context against the most recent
+          # github-actions check-suite on the SHA, and the newest suite is an
+          # empty one that contains no `gate`. So the green `gate` is never
+          # overwritten; it is merely no longer the suite protection looks at.
+          #
+          # That is also why suppressing docker.yml alone cannot work, whether
+          # at the job layer or the trigger layer: NINE other workflows create
+          # an identical empty suite in the same second, and any one of them
+          # left newest reproduces the 405. #5358 added a job-level `if:` to
+          # docker.yml's `gate` job; a job-level condition is evaluated by the
+          # runner after the run exists, and these runs never schedule a job,
+          # so it is unreachable by construction. There is no trigger-layer fix
+          # either: `pull_request`'s `branches`/`branches-ignore` filter matches
+          # the PR's BASE ref (`v4`), never its head, and GitHub has no
+          # head-branch trigger filter — so `branches-ignore: [release-gate/**]`
+          # would exclude PRs INTO the scratch branch, not the release PR, while
+          # breaking the fork-PR contract (#4965) it is meant to preserve.
+          #
+          # The fix that matches the actual mechanism is to make a GREEN suite
+          # the newest one again, by dispatching docker.yml a second time now
+          # that the PR (and its burst of empty suites) exists. `gate` is a ~5s
+          # shell job and `release-gate/*` never pushes an image, so this is
+          # cheap and cannot publish anything. This does not weaken the gate:
+          # the merge below is still SHA-keyed and still rejected with 405 by
+          # the server if `gate` is genuinely unsatisfied.
+          #
+          # Settle first. The empty suites all land within ~2s of `gh pr
+          # create` returning; dispatching before they exist would put the
+          # green suite BACK underneath them and rebuild the same failure.
+          #
+          # RELEASE_REGATE_SETTLE / RELEASE_REGATE_WINDOW are test seams in the
+          # same spirit as RELEASE_PUSH_GH006_WINDOW (test-release-push-retry.sh
+          # sets them to 0 so the extracted step does not idle); production uses
+          # the defaults.
+          settle="${RELEASE_REGATE_SETTLE:-30}"
+          echo "Waiting ${settle}s for the PR-open workflow suites to land before re-earning gate (#5356)..."
+          [ "$settle" -gt 0 ] && sleep "$settle"
+
+          echo "Re-dispatching docker.yml on ${scratch} so a green 'gate' suite is the most recent on ${commit_sha} (#5356)..."
+          gh workflow run docker.yml --ref "${scratch}" \
+            || echo "::warning::re-dispatch of docker.yml failed; the merge retry below may exhaust its window (#5356)."
+
+          echo "Waiting for the re-dispatched 'gate' to conclude on ${commit_sha}..."
+          regate_deadline=$((SECONDS + ${RELEASE_REGATE_WINDOW:-600}))
+          regate=""
+          while [ "$SECONDS" -lt "$regate_deadline" ]; do
+            # Newest `gate` check-run by started_at — the one protection will
+            # resolve to once its suite is the most recent.
+            regate="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/check-runs" \
+              --jq '[.check_runs[] | select(.name == "gate")] | sort_by(.started_at) | last | (.conclusion // "pending")' 2>/dev/null || true)"
+            case "$regate" in
+              success|skipped|neutral)
+                echo "Re-earned gate concluded '${regate}' on ${commit_sha}."
+                break
+                ;;
+              failure|cancelled|timed_out|action_required|stale)
+                # A REAL red conclusion. Everything else — including an empty
+                # or unparseable response — is treated as "not known yet" and
+                # retried, never as a verdict: this step must not turn a
+                # transient API hiccup into a failed release.
+                echo "::error::re-dispatched gate concluded '${regate}' on ${commit_sha} — refusing to merge." >&2
+                exit 1
+                ;;
+              *) ;;
+            esac
+            [ "${RELEASE_REGATE_WINDOW:-600}" -gt 0 ] && sleep 10
+          done
+          case "$regate" in
+            success|skipped|neutral) ;;
+            *)
+              # NOT fatal. The merge below is SHA-keyed and the server enforces
+              # protection on it regardless, so an unconfirmed re-gate costs at
+              # worst the existing retry window — whereas failing here would
+              # abandon a release that may well be mergeable.
+              echo "::warning::could not confirm the re-dispatched gate on ${commit_sha} within the window; proceeding to the merge retry below, which enforces protection server-side regardless (#5356)."
+              ;;
+          esac
 
           # #5318/#5324 (5th recurrence): this loop called `gh pr merge`, which
           # refuses to act on a PR whose aggregate `mergeStateStatus` is

--- a/src/scripts/test-release-push-retry.sh
+++ b/src/scripts/test-release-push-retry.sh
@@ -155,6 +155,7 @@ run_step() {
   : > "$st/out"
   RPR_SCENARIO="$1" RPR_TAG_SCENARIO="${2:-ok}" RPR_STATE="$st" \
     RELEASE_PUSH_GH006_WINDOW="${3:-120}" \
+    RELEASE_REGATE_SETTLE=0 RELEASE_REGATE_WINDOW=0 \
     VERSION="4.0.1" SHA="deadbeefcafe" GITHUB_OUTPUT="$st/gh_output" \
     GITHUB_REPOSITORY="kubestellar/hive" \
     PATH="$tmp/bin:$PATH" bash "$tmp/push_v4.sh" > "$st/out" 2>&1
@@ -332,6 +333,18 @@ else:
         bad("push_v4 regressed to `gh pr merge`, which refuses any PR whose AGGREGATE "
             "mergeStateStatus is BLOCKED — a pending non-required `tide` status alone is "
             "enough to block every release forever (#5318/#5324)")
+    # #5356: the re-dispatch must happen AFTER `gh pr create`, or the green
+    # suite goes back underneath the empty ones the PR-open burst creates and
+    # the 405 returns. Order is the whole point, so assert it, not mere
+    # presence.
+    if "gh workflow run docker.yml" not in code:
+        bad("push_v4 no longer re-dispatches docker.yml after opening the release PR — "
+            "the PR-open burst leaves an EMPTY check-suite newest on the head SHA and "
+            "protection reports `gate` as missing, blocking every release (#5356)")
+    elif code.index("gh workflow run docker.yml") < code.index("gh pr create"):
+        bad("push_v4 re-dispatches docker.yml BEFORE opening the release PR — the "
+            "PR-open burst then leaves an empty check-suite newest again and the "
+            "merge is refused exactly as in #5356. Re-dispatch after `gh pr create`.")
 sys.exit(0 if ok else 1)
 PY
 


### PR DESCRIPTION
## What breaks

The release workflow reaches its merge step and is rejected:

```
{"message":"Required status check \"gate\" is expected.","status":"405"}
```

v4.0.1 has not cut since 2026-08-27.

## The mechanism — and a correction to the recorded diagnosis

Opening the release PR fires **every** `pull_request`-triggered workflow on the same SHA. Those runs are created by `GITHUB_TOKEN`, so GitHub's recursion guard never starts their jobs: each concludes `failure` in ~2s having scheduled **zero jobs**, leaving a check-**suite** that contains no check-**runs**. Branch protection resolves a required context against the most recent check-suite, so with an empty suite newest, `gate` reads as **missing**.

Note the error says `is expected` — missing — not "failed". That is the tell.

**This is not supersession.** A zero-job run publishes no check-runs at all. On release PR #5361's head `4d6510fc` there is exactly **one** `gate` check-run and it is `success` — nothing overwrote it. Measured on that SHA:

```
20:22:25Z  suite 90601686745  success  runs=10   <-- the green gate
20:22:42Z  suite 90601762369  failure  runs=0    docker.yml
20:22:42Z  suite 90601762476  failure  runs=0    changelog-reminder.yml
20:22:42Z  suite 90601762541  failure  runs=0    podman-arm64-lane.yml
20:22:42Z  suite 90601762656  failure  runs=0    docs-index-reminder.yml
20:22:42Z  suite 90601762685  failure  runs=0    podman-rootless-lane.yml
20:22:42Z  suite 90601762695  failure  runs=0    quadlet-gate.yml
20:22:42Z  suite 90601762699  failure  runs=0    podman-rootful-lane.yml
20:22:43Z  suite 90601764053  failure  runs=0    greetings.yml
20:22:43Z  suite 90601764248  failure  runs=0    copilot-dco.yml
20:22:43Z  suite 90601764285  failure  runs=0    copilot-automation.yml
```

## Why the previous fix could not work, and why the obvious next one cannot either

**#5358's job-level `if:`** is evaluated by the runner *after* the run exists. These runs never schedule a job, so it is unreachable by construction.

**A docker.yml-only change of any kind** cannot work: nine other workflows leave an identical empty suite in the same second, and any one left newest reproduces the 405.

**A trigger-layer filter is not available.** `pull_request`'s `branches`/`branches-ignore` matches the PR's **base** ref (`v4`), never its head, and GitHub has no head-branch trigger filter ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpull_requestpull_request_targetbranchesbranches-ignore)). So `branches-ignore: ['release-gate/**']` would exclude PRs *into* the scratch branch — not the release PR — while breaking the fork-PR contract (#4965) that trigger exists to serve.

## The fix

After opening the PR, let the burst settle, then **re-dispatch `docker.yml`** so a green suite is the most recent one again. `gate` is a ~5s shell job and `release-gate/*` never pushes an image, so this is cheap and publishes nothing.

The gate is not weakened: the merge stays SHA-keyed and the server still rejects a genuinely unsatisfied required context with 405.

This also removes the race noted on the issue — it does not depend on the two original runs ordering correctly, because it adds a third, later, green one.

## Robustness

An unconfirmed or unparseable re-gate is a **warning, not a failure**, so a transient API hiccup cannot abandon a mergeable release; only a real red conclusion (`failure`/`cancelled`/`timed_out`/`action_required`/`stale`) aborts. Timings sit behind `RELEASE_REGATE_SETTLE` / `RELEASE_REGATE_WINDOW` seams, matching the existing `RELEASE_PUSH_GH006_WINDOW` pattern.

## Release-lines pin contract

Untouched and still green. No trigger filter was added, so docker.yml keeps its `unpinned: '**'` contract; `check-release-lines.sh` and `test-release-lines-guard.sh` both pass.

## #5358's dead guard

Kept, comment corrected. A `release-gate/*` head is never a real code review, so skipping the build is still the right behaviour — but the comment no longer claims to fix this, and now records why it cannot. `test-release-push-retry.sh` drops the assertion that pinned that guard as the remedy and instead asserts the re-dispatch happens **after** `gh pr create` (before it, the green suite lands back underneath the empty ones and the 405 returns).

## Preserved

Gate-wait SHA-keyed lookup, tag-already-exists refusal, `pushed=false` deferral, `RELEASE_PUSH_GH006_WINDOW`, the backstop's published-images guard, and the fork-PR contract.

## Verified

`check-release-lines.sh` PASS; `test-release-lines-guard.sh` PASS; `test-release-push-retry.sh` PASS; both workflows parse; no empty `${​{ }}` anywhere.

## Unproven

**This cannot be proven until a release actually cuts.** The mechanism and the ten empty suites are measured from real API data, but the fix itself is verified only against the local test harness and static guards. Specifically unproven: that 30s is always enough for the PR-open burst to land (if a suite arrives *after* the re-dispatch, the 405 returns — the merge retry window is the backstop, not a guarantee), and that no other actor creates a newer empty suite between the re-gate and the merge.

Fixes #5356