### PR TITLE
🐛 fix(entrypoint): chown the runtime config to dev so hive can read it (#5360)

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -61,32 +61,71 @@ HIVE_CONFIG_PATH="${HIVE_CONFIG:-/etc/hive/hive.yaml}"
 HIVE_CONFIG_RUNTIME="/data/hive.yaml.runtime"
 HIVE_CONFIG_RUNTIME_LEGACY="/data/hive.yaml.bak"
 
-# These PVC config copies can carry dashboard.auth_token (and github.token in
-# PAT mode). Files written before the 0600 fix (#5331) are world-readable, and
-# /data is world-traversable, so tighten pre-existing copies at boot.
-# Best-effort: on a read-only or foreign-owned PVC this must not abort boot.
-for _cfg in "$HIVE_CONFIG_RUNTIME" "$HIVE_CONFIG_RUNTIME_LEGACY" /data/hive.yaml.dashboard; do
-  [ -f "$_cfg" ] && chmod 600 "$_cfg" 2>/dev/null || true
-done
-unset _cfg
+# The uid/gid the hive process actually runs as after the privilege drop
+# further down (setpriv/gosu to dev). 0600 is an OWNER-only mode, so every
+# hardened config copy has to be owned by THIS user or the owner of the file
+# is not the reader of the file — see hive_harden_runtime_config.
+HIVE_RUNTIME_USER="dev"
+HIVE_RUNTIME_GROUP="node"
 
-# hive_harden_runtime_config tightens $1 to 0600 after any cp that (re)creates
-# a PVC config copy.
+# hive_harden_runtime_config makes $1 readable by the user that reads it, and
+# by nobody else: chown to dev:node, then chmod 0600.
 #
-# The boot-time chmod loop above only covers files that already existed when
-# this script started. Every `cp` below that writes $HIVE_CONFIG_RUNTIME
+# BOTH halves are load-bearing, and #5360 is what happens with only one.
+#
+# The mode half (#5342/#5331): every `cp` below that writes a PVC config copy
 # creates the destination anew, and cp gives a newly created destination the
 # SOURCE's mode — the ConfigMap seed and the bind-mounted hive.yaml are both
-# 0644 — so the runtime copy is re-widened to 0644 on every boot, after the
-# loop above has already run. Without this the 0600 fix only holds from the
-# first Config.Save() onward, and a hive that boots and never saves stays
-# world-readable indefinitely.
+# 0644 — so the copy is re-widened to 0644 on every boot. Without the chmod
+# the 0600 fix only holds from the first Config.Save() onward, and a hive that
+# boots and never saves stays world-readable indefinitely. These files carry
+# dashboard.auth_token (and github.token in PAT mode) and /data is
+# world-traversable, so that is the dashboard owner credential readable by
+# every unprivileged agent uid.
 #
-# Best-effort for the same reason as the loop above: a read-only or
-# foreign-owned PVC must not abort boot.
+# The ownership half (#5360): those same `cp` calls run in the ROOT phase, so
+# the destination is created root:root. chmod 600 on a root:root file grants
+# access to root ALONE — and the hive process drops to dev (uid 1001) before
+# it ever opens the config, so it reads back `permission denied` and startup
+# aborts. The `chown -R dev:node /data` in the root-only block does NOT cover
+# this: it is guarded by `[ "$DATA_OWNER" != "1001" ]` and src/Dockerfile
+# already ships /data owned by dev:node, so on a fresh anonymous volume the
+# guard is false and the recursive chown never runs at all. It is also far
+# BELOW these call sites, so even when it does run it cannot help a file the
+# config branch has not created yet.
+#
+# Do the chown FIRST and the chmod second. The reverse order leaves a window
+# in which the file is 0644 and root-owned; chown does not clear the mode, so
+# chown-then-chmod is never wider than 0600 for longer than the chown itself.
+#
+# Best-effort throughout: a read-only or foreign-owned PVC, or a container
+# without CAP_CHOWN, must not abort boot. When the chown cannot be performed
+# the chmod is deliberately skipped rather than applied to a file we do not
+# own — locking a root-owned file to 0600 is precisely the #5360 failure, and
+# a readable-but-wider file that boots beats a hardened one that cannot.
 hive_harden_runtime_config() {
-  [ -f "$1" ] && chmod 600 "$1" 2>/dev/null || true
+  [ -f "$1" ] || return 0
+  # Already owned by the runtime user (the steady state after Config.Save(),
+  # and every non-root boot) — just tighten the mode.
+  if [ "$(stat -c '%u' "$1" 2>/dev/null || echo)" = "1001" ]; then
+    chmod 600 "$1" 2>/dev/null || true
+    return 0
+  fi
+  if chown "$HIVE_RUNTIME_USER:$HIVE_RUNTIME_GROUP" "$1" 2>/dev/null; then
+    chmod 600 "$1" 2>/dev/null || true
+  else
+    echo "[entrypoint] WARN: cannot chown $1 to $HIVE_RUNTIME_USER:$HIVE_RUNTIME_GROUP — leaving its mode alone so the runtime user can still read it (0600 on a foreign-owned file is #5360). Is CAP_CHOWN in the pod's capabilities.add?"
+  fi
 }
+
+# Tighten pre-existing PVC config copies at boot. Files written before the
+# 0600 fix (#5331) are world-readable. Routed through the helper above so
+# these get the same chown-then-chmod treatment as the ones the `cp` calls
+# recreate — a pre-existing root-owned copy is just as unreadable to dev.
+for _cfg in "$HIVE_CONFIG_RUNTIME" "$HIVE_CONFIG_RUNTIME_LEGACY" /data/hive.yaml.dashboard; do
+  hive_harden_runtime_config "$_cfg"
+done
+unset _cfg
 
 # hive_runtime_config_read echoes the path to read the persisted runtime
 # config from: the new name when it is present and non-empty, else the

--- a/src/deploy/test_entrypoint_runtime_config.sh
+++ b/src/deploy/test_entrypoint_runtime_config.sh
@@ -114,6 +114,120 @@ check "both PVC writes target the new name" "2" "$writes_new"
 writes_legacy="$(grep -c 'cp "\$HIVE_CONFIG_PATH" "\$HIVE_CONFIG_RUNTIME_LEGACY"' "$ENTRYPOINT" || true)"
 check "no PVC write targets the legacy name" "0" "$writes_legacy"
 
+# ── #5360: hardening must leave the file READABLE BY THE READING USER ──
+#
+# The regression this closes: #5342 asserted only that the mode was 0600 and
+# passed while the product was broken. 0600 is OWNER-only, the `cp` calls that
+# create the file run as root, and the hive process drops to dev (uid 1001)
+# before it opens the config — so a root:root 0600 file is mode-correct and
+# unreadable, and startup died with `permission denied` on the arm64 lane.
+#
+# So the assertion is not "mode is 0600". It is "the mode is 0600 AND uid 1001
+# can actually open it" — the property the product needs, checked by really
+# opening the file as that uid rather than by inspecting metadata.
+
+echo
+echo "=== #5360: hardened config is readable by the runtime user ==="
+
+# Every site that creates or hardens a PVC config copy must route through the
+# helper, so a new `cp` cannot reintroduce the bug by hardening inline.
+inline_chmod="$(grep -cE '^[[:space:]]*chmod 600 "\$(HIVE_CONFIG_RUNTIME|_cfg)' "$ENTRYPOINT" || true)"
+check "no site chmods a PVC config copy outside the helper" "0" "$inline_chmod"
+
+# The helper must chown, not merely chmod. A helper that only chmods is
+# exactly the #5360 shape.
+HARDEN="$(sed -n '/^hive_harden_runtime_config() {/,/^}/p' "$ENTRYPOINT")"
+if [ -z "$HARDEN" ]; then
+  echo "  FAIL: could not extract hive_harden_runtime_config from $ENTRYPOINT"
+  FAIL=$((FAIL + 1))
+elif ! printf '%s' "$HARDEN" | grep -q 'chown'; then
+  echo "  FAIL: hive_harden_runtime_config does not chown — 0600 on a root-owned"
+  echo "        file is unreadable to the dev uid that reads it (#5360)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: hive_harden_runtime_config chowns as well as chmods"
+  PASS=$((PASS + 1))
+fi
+
+# The behavioural test. Requires root (to own a file as root and then drop to
+# another uid) and a uid-1001 account. CI's arm64/container lanes have both;
+# a developer laptop generally has neither, so skip loudly rather than fake a
+# pass — a silent skip here is how the original gap shipped.
+RUNTIME_UID=1001
+if [ "$(id -u)" != "0" ]; then
+  echo "  SKIP: not root — cannot exercise the root-creates/dev-reads path"
+  echo "        (this is the case CI must run; see #5360)"
+elif ! id -u dev >/dev/null 2>&1; then
+  echo "  SKIP: no 'dev' account on this host — cannot exercise the drop"
+else
+  tmpd="$(mktemp -d)"
+  trap 'rm -rf "$tmpd"' EXIT
+  # /data is world-traversable in the image; mirror that so the only thing
+  # under test is the file's own mode and ownership.
+  chmod 755 "$tmpd"
+
+  target="$tmpd/hive.yaml.runtime"
+  # Reproduce the failing shape exactly: root creates the file 0644 (the mode
+  # `cp` inherits from the 0644 ConfigMap seed / bind-mounted hive.yaml).
+  printf 'dashboard:\n  auth_token: probe-not-a-real-token\n' > "$target"
+  chown root:root "$target"
+  chmod 644 "$target"
+
+  HIVE_RUNTIME_USER="dev"
+  HIVE_RUNTIME_GROUP="node"
+  export HIVE_RUNTIME_USER HIVE_RUNTIME_GROUP
+  # shellcheck disable=SC1090
+  eval "$HARDEN"
+  hive_harden_runtime_config "$target" >/dev/null
+
+  mode="$(stat -c '%a' "$target" 2>/dev/null)"
+  owner="$(stat -c '%u' "$target" 2>/dev/null)"
+
+  # 1. Still owner-only. The security fix must not be weakened to buy back
+  #    readability — the file holds dashboard.auth_token (#5331).
+  check "hardened config is still mode 0600" "600" "$mode"
+
+  # 2. Owned by the uid that reads it. This is the half #5342 was missing.
+  check "hardened config is owned by the runtime uid" "$RUNTIME_UID" "$owner"
+
+  # 3. THE ASSERTION THAT MATTERS: really open it as that uid. Mode and owner
+  #    are metadata; this is the syscall the hive binary makes at startup,
+  #    and it is what returned EACCES in #5360.
+  if su -s /bin/sh dev -c "cat '$target' >/dev/null 2>&1"; then
+    echo "  PASS: the runtime user can actually read the hardened config"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: the runtime user CANNOT read the hardened config"
+    echo "        this is #5360 — hive aborts with 'permission denied' at startup"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # 4. And nobody else can. Confirms we bought readability with ownership,
+  #    not by widening the mode. 'nobody' exists on every image variant here.
+  if id -u nobody >/dev/null 2>&1; then
+    if su -s /bin/sh nobody -c "cat '$target' >/dev/null 2>&1"; then
+      echo "  FAIL: an unrelated uid can read the hardened config"
+      echo "        the token in this file must not be world-readable (#5331)"
+      FAIL=$((FAIL + 1))
+    else
+      echo "  PASS: an unrelated uid cannot read the hardened config"
+      PASS=$((PASS + 1))
+    fi
+  fi
+
+  # 5. A file already owned by the runtime user still gets tightened. This is
+  #    the steady state after Config.Save() and every non-root boot.
+  printf 'dashboard:\n  auth_token: probe-not-a-real-token\n' > "$target"
+  chown dev:node "$target"
+  chmod 644 "$target"
+  hive_harden_runtime_config "$target" >/dev/null
+  check "already dev-owned config is still tightened to 0600" \
+    "600" "$(stat -c '%a' "$target" 2>/dev/null)"
+
+  rm -rf "$tmpd"
+  trap - EXIT
+fi
+
 echo
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## The bug

Hive fails to start, deterministically, on the Podman arm64 lane:

```json
{"level":"ERROR","msg":"failed to load config",
 "error":"reading config /data/hive.yaml.runtime: open /data/hive.yaml.runtime: permission denied"}
```

Regression window is #5342 (`fe853992`, 19:33), confirming the analysis in the issue. #5352 is not involved.

## Mechanism

`hive_harden_runtime_config()` did `chmod 600` with no `chown`. Its three call sites sit at entrypoint.sh:426/450/467 — inside the config branch, which runs **as root**, before the privilege drop. `cp` creates the destination anew, so the file lands **root:root 0600**. The process then drops to `dev` (uid 1001) at ~line 1300 via setpriv/gosu and cannot open its own config. `0600` grants access to the owner alone, and the owner is not the reader.

## Why `chown -R dev:node /data` did not cover this

Two independent reasons — this was the part worth pinning down:

```sh
DATA_OWNER=$(stat -c '%u' /data 2>/dev/null || echo "0")
if [ "$DATA_OWNER" != "1001" ]; then
  chown -R dev:node /data 2>/dev/null || true
fi
```

1. **The guard is false, so it never runs.** `src/Dockerfile:562` already does `chown -R dev:node /data` at build time. Podman creates the arm64 probe's `/data` as an anonymous volume seeded from the image, so `/data` is *already* uid 1001 at boot, `DATA_OWNER == 1001`, and the recursive chown is skipped entirely. It is not failing silently — it is not executing.
2. **It is in the wrong place anyway.** It sits ~60 lines *below* the config branch, so even when it does run it cannot help a file that branch has not created yet.

Note that the guard is a **latent hole beyond this file**: it exists for a good reason (recursive chown over an NFS PVC is a multi-minute stall), but its effect is that on any already-dev-owned `/data`, *anything* root creates keeps root ownership indefinitely. Any future root-phase write under `/data` inherits this bug. Not fixed here — flagging it as worth its own issue.

## Why only arm64 caught it

`podman-arm64-lane.yml` is the only lane that actually boots hive and waits for `GET /api/health`. The rootful and rootless lanes run `probe_podman_rootful_netadmin.sh` / the rootless equivalent, which probe NET_ADMIN capability behaviour and never assert startup. So the other two lanes were never able to see this, and they are unaffected by the change.

## The fix — shape 1 (chown, keep 0600)

Chose chown-to-`dev:node` over `0640`+group because nothing other than the hive process reads this file; `0640` would widen access to every member of `node` for no benefit. The mode stays `0600`, so **#5331/#5342 are not weakened** — the file still holds `dashboard.auth_token` and is still owner-only.

- `chown` first, `chmod` second: the reverse order leaves a window at 0644, and chown does not clear the mode.
- Applied at **all four sites** by routing the boot-time chmod loop through the same helper, so a pre-existing root-owned copy is repaired too and no path can diverge.
- **Fails open, not shut:** if the chown cannot be performed (no `CAP_CHOWN`, foreign-owned PVC) the chmod is deliberately skipped and a WARN is printed rather than locking a file we do not own to 0600 — that exact combination is this bug. A readable-but-wider file that boots beats a hardened one that cannot.

## Tests — closing the gap that let this ship

`test_entrypoint_runtime_config.sh` asserted the **mode** and therefore passed while the product was broken. It now asserts the property the product actually needs:

- root creates the file 0644 (the mode `cp` inherits), helper runs, then **`su dev -c cat`** — a real `open()` as uid 1001, the same syscall that returned EACCES.
- an unrelated uid (`nobody`) still **cannot** read it — proves readability was bought with ownership, not by widening the mode.
- the helper chowns, and no site chmods a config copy outside the helper.
- the already-dev-owned steady state is still tightened to 0600.

The behavioural cases need root plus a uid-1001 account; they **skip loudly** where those are absent rather than faking a pass, since a silent skip is how the original gap shipped.

## What I verified, and what I did not

**Verified:** the mechanism, by reading the code paths end to end — the ownership guard, the call-site ordering relative to the privilege drop, and the image's build-time `/data` chown that makes the guard false. Shell syntax (`bash -n`). The test suite passes (11/11, root-only cases skipped). The chown-fails fallback leaves the mode at 0644 rather than 0600, confirmed directly.

**NOT verified: the arm64 lane has not gone green with this change yet.** That is the only check that can actually confirm the fix, and it runs on this PR. I could not reproduce locally — the rootful/rootless lanes cannot exercise startup, and the local container VM is broken on this machine, so a green local run would have proven nothing regardless. **Do not merge on my say-so; merge on the arm64 lane going green.** Also unverified locally: the root-only test cases, which run for the first time in CI.

## Secondary: the iptables warnings

```
iptables ... Could not fetch rule set generation id: Permission denied (you must be root)
```

**Separate from this bug, and not a symptom of it.** I initially guessed they were downstream of the config failure; the CI log on this PR disproves that — they are emitted *before* the config error, so they cannot be caused by it:

```
[entrypoint] ERROR: iptables chain creation failed after 5 attempts: ...
{"level":"ERROR","msg":"failed to load config", ... permission denied}
```

The "0 occurrences on green, 5 on red" comparison in the issue does not hold up either: the probe only prints `Starting|WARN: proxy egress` milestones on a successful run and dumps the full log on failure, so the green run's silence is log filtering, not absence. These warnings are most likely present on green runs too — rootless Podman simply cannot manage nf_tables — and are non-fatal by design (5 retries, then continue). They are unrelated to the config read and are not fixed here. Worth a separate issue to either grant the capability or stop retrying five times for something that cannot succeed in this lane.

Fixes #5360
