### PR TITLE
✨ feat(acmm): attach level-up advice to status payload and thread a real GreenStreak

### DIFF
--- a/src/docs/acmm-advisor.md
+++ b/src/docs/acmm-advisor.md
@@ -12,7 +12,7 @@ The advisor evaluates a fixed set of six signals (`Signals` struct, `src/pkg/acm
 |---|---|
 | `CurrentLevel` | The ACMM level the hive is applying right now (1–6). |
 | `CoveragePct` | Current test-coverage percentage (0–100). |
-| `GreenStreak` | Count of consecutive green CI runs with no red. **Not yet measured — always zero.** See below. |
+| `GreenStreak` | Count of consecutive green CI runs with no red, measured from default-branch Actions history. See below. |
 | `MergeSuccessRate` | Fraction (0.0–1.0) of recent PRs that merged cleanly. |
 | `ActionableIssues` | Count of open actionable issues the hive has surfaced but not yet resolved. |
 | `HoldCount` | Count of open PRs still carrying a `hold` label awaiting human review. |
@@ -28,7 +28,7 @@ The dashboard assembles `Signals` for the running hive in `buildACMMStatusInputs
 - `MergeSuccessRate` is read from the fleet-stats collector's cached 90-day merged/rejected counts (`mergeSuccessRateFromFleetStats`, `src/pkg/dashboard/api_acmm_recommendation.go:135-141`) — no fresh GitHub call is made on the request path.
 - `ActionableIssues` and `HoldCount` come from the most recent published status snapshot (`status.Governor.Issues`, `status.Hold.Total`).
 - `CoveragePct` is read from `status.AgentMetrics["ci-maintainer"]["coverage"]`, the value the coverage badge collector populates (`coverageFromAgentMetrics`, `src/pkg/dashboard/api_acmm_recommendation.go:148-166`).
-- `GreenStreak` is **always zero** — the hive does not yet track a real green-CI streak as a first-class signal. The code comment is explicit that this must never be fabricated (`src/pkg/dashboard/api_acmm_recommendation.go:52-59`), and a zero streak only ever makes the advisor *more* conservative (it will never propose a raise on the strength of a made-up streak).
+- `GreenStreak` is the count of consecutive non-red completed runs on the primary repo's **default branch**, counting back from the most recent run (`Client.GreenCIStreak`, `src/pkg/github/health.go`). It is measured on the status-build path — the same pass that already fetches workflow health — and cached, so no fresh GitHub call is made on the request path. When no measurement has ever succeeded (no GitHub client, an Actions API failure, or a repo with **no CI history at all**) the signal stays at zero and reads as *unknown / not yet earned* rather than as a measured zero — a repo with no CI must never read as green. A failed refresh leaves the last real reading in place rather than clobbering it with an unknown.
 
 All of the above is nil-safe: a freshly-booted hive with no config, no status snapshot yet, or a nil fleet-stats collector collapses to conservative zero-value signals rather than panicking or fabricating data (comment at `src/pkg/dashboard/api_acmm_recommendation.go:41-45`, confirmed by `TestHandleACMMRecommendationEmpty` in `src/pkg/dashboard/api_acmm_recommendation_test.go`).
 
@@ -61,10 +61,10 @@ A recommendation (`Recommendation` struct, `src/pkg/acmmadvisor/acmmadvisor.go:1
 ## What this does NOT do
 
 - **It never changes the applied ACMM level.** The package comment states this explicitly: "This package is ADVISORY ONLY. It never changes the applied ACMM level... A human always approves the actual level change." (`src/pkg/acmmadvisor/acmmadvisor.go:12-17`). The only code path that changes a hive's level is `PUT /api/packs/level` → `handlePackSetLevel` → `ApplyPack`, documented in [ACMM policy matrix — Changing a hive's ACMM level](acmm-policy-matrix.md#changing-a-hives-acmm-level). Nothing in `pkg/acmmadvisor` or the `/api/acmm-recommendation` handler calls that path.
-- **It is a pure function with no I/O.** `Recommend` and `RecommendFromStatus` take already-collected signals and return a value; they do not read config, call GitHub, or touch the clock (`src/pkg/acmmadvisor/wire.go:1-12`).
-- **It is not currently rendered anywhere in the dashboard UI.** As of this writing there are no references to `acmm-recommendation` or the advisor under `src/dashboard`. The only way to obtain a recommendation today is to call the API endpoint directly (see below); there is no dashboard pill, tab, or card that displays it. A `TODO(acmm2-wiring)` comment in `src/pkg/acmmadvisor/wire.go` describes wiring `RecommendFromStatus` into the status payload as still-outstanding follow-up work — treat any documentation or issue text implying the dashboard already surfaces a recommendation pill as **not yet true**.
+- **It is a pure function with no I/O.** `Recommend` and `RecommendFromStatus` take already-collected signals and return a value; they do not read config, call GitHub, or touch the clock. Signal *collection* does talk to GitHub, but only on the status-build path, and its results are cached — neither the API endpoint nor the status payload triggers a GitHub call of its own.
+- **It never auto-applies a recommendation.** The recommendation now travels on the status payload as `acmmAdvice` (#5225) in addition to the API endpoint, but both are read-only advice. Nothing consumes them to change a level.
 - **Thresholds are not configurable.** All coverage/streak/rate/backlog numbers are Go constants in `pkg/acmmadvisor`; there is no `hive.yaml` field or environment variable to adjust them.
-- **`GreenStreak` is not measured yet, and its zero is deliberate rather than a bug.** The hive does not track a real green-CI streak, and the code refuses to fabricate one. Because a zero streak can only ever *withhold* a recommendation, the advisor stays conservative rather than proposing a raise on a fabricated signal — the safe direction to fail in. The practical effect is that any criterion gated on streak thresholds (L3 and above) will not pass until that wiring lands, so the advisor currently under-recommends rather than over-recommends.
+- **It does not measure streak quality, only streak length.** `GreenStreak` resets on **any** red, including a flake unrelated to code quality, and a repo that rarely commits can hold a stale streak indefinitely because the signal is count-based rather than time-based. The scan also reads at most one page of runs (`ciStreakRunsLimit`), so a very long streak is reported as "at least N" — the cap sits above every advisor threshold, so it can only ever under-report.
 
 ## The API endpoint
 
@@ -72,5 +72,5 @@ A recommendation (`Recommendation` struct, `src/pkg/acmmadvisor/acmmadvisor.go:1
 
 ## Open questions
 
-- The exact date/PR that will wire `RecommendFromStatus` into the dashboard status payload and UI is not yet known — `src/pkg/acmmadvisor/wire.go` marks it `TODO(acmm2-wiring)` with no linked issue found in this repo at the time of writing.
-- Whether `GreenStreak` will be sourced from CI history or another signal once implemented is left open by the `TODO(acmm-signals)` comment in `src/pkg/dashboard/api_acmm_recommendation.go:58-59`.
+- Whether the streak should become time-based ("days since last red") rather than count-based is unresolved. A count-based streak lets a quiet repo hold a stale value; a time-based one would change the meaning of the existing `greenStreakL3..L6` thresholds, so it is deliberately not attempted here.
+- Whether a "green" streak should require the run to have actually executed gates is unresolved: `skipped` runs are currently transparent to the streak (matching `ciPassRate`), so a repo whose workflows are entirely skipped on the default branch could accumulate a streak without any gate ever running.

--- a/src/pkg/acmmadvisor/wire.go
+++ b/src/pkg/acmmadvisor/wire.go
@@ -6,16 +6,18 @@ package acmmadvisor
 // signals and returns a recommendation. It does NOT read the config, apply a
 // level, or perform any I/O.
 //
-// TODO(acmm2-wiring): wire RecommendFromStatus into pkg/dashboard's
-// status_builder.go — populate a StatusPayload.ACMMAdvice field from the same
-// inputs the dashboard already gathers:
-//   - CurrentLevel: dashboard.detectACMMLevel(cfg)
-//   - CoveragePct:  MetricsCollector coverage ("coverage" key, collectCoverage)
-//   - GreenStreak / MergeSuccessRate: from issue-to-merge / CI metrics
-//   - ActionableIssues: len(actionable) already passed to buildRepos/buildHold
-//   - HoldCount: buildHold(actionable) count
-//   - HasQualityAgent: presence of an active "quality" agent in the pack
-// The dashboard must render Recommendation.Met/Unmet as a checklist and must
+// Wiring status: RecommendFromStatus is wired into pkg/dashboard on two
+// surfaces that share ONE signal-collection path (buildACMMStatusInputs) so
+// they cannot drift — the GET /api/acmm-recommendation endpoint (#5225) and
+// the StatusPayload.ACMMAdvice field attached on the status-build path.
+// Every input is now sourced from real data: CurrentLevel from
+// detectACMMLevel, CoveragePct from the ci-maintainer coverage metric,
+// ActionableIssues/HoldCount from the live status snapshot, HasQualityAgent
+// from the active pack, MergeSuccessRate from the fleet-stats collector
+// (#3972), and GreenStreak from default-branch Actions history (#5226).
+// Signals that cannot be measured stay at zero rather than being fabricated.
+//
+// The dashboard renders Recommendation.Met/Unmet as a checklist and must
 // NEVER auto-apply the target level — a human approves via handlePackSetLevel.
 
 // StatusInputs is the forge-neutral bundle a status builder assembles from

--- a/src/pkg/dashboard/api_acmm_recommendation.go
+++ b/src/pkg/dashboard/api_acmm_recommendation.go
@@ -49,14 +49,14 @@ func (s *Server) buildACMMStatusInputs() acmmadvisor.StatusInputs {
 		// A hive with no explicit level detects as MinLevel (L1); see
 		// detectACMMLevel. Zero-value fallbacks keep this at a safe default.
 		CurrentLevel: acmmadvisor.MinLevel,
-		// GreenStreak is intentionally left at zero: the hive does not yet
-		// track a real green-CI streak as a first-class signal, and the
-		// advisor must never fabricate one. It therefore reads as "unknown /
-		// not yet earned", which only ever makes the advisor MORE conservative
-		// (it will not propose a raise on the strength of a made-up streak).
-		// When the signal becomes available, populate it here.
-		// TODO(acmm-signals): thread a real GreenStreak from CI history once
-		// tracked.
+		// GreenStreak IS real as of #5226: it is populated below from the
+		// green-CI streak the status-build path measures against the primary
+		// repo's default-branch Actions history. Until a measurement has
+		// actually succeeded it STAYS at zero — "unknown / not yet earned"
+		// rather than a fabricated number — which only ever makes the advisor
+		// MORE conservative. A repo with no CI at all reads as unknown, never
+		// as green. See Client.GreenCIStreak for what it measures and its
+		// known weaknesses (flake-sensitive, stale on quiet repos, capped).
 		//
 		// MergeSuccessRate IS real as of #3972: it is populated below from the
 		// fleet-stats collector's cached 90-day merged/rejected counts. See
@@ -86,6 +86,16 @@ func (s *Server) buildACMMStatusInputs() acmmadvisor.StatusInputs {
 		if rate, measured := mergeSuccessRateFromFleetStats(s.deps.FleetStats); measured {
 			in.MergeSuccessRate = rate
 		}
+	}
+
+	// Real green-CI streak (#5226), read from the cache the status-build path
+	// refreshes on the same pass it already fetches workflow health — no fresh
+	// GitHub call on this advisory request. When no measurement has ever
+	// succeeded (no GitHub client, API failure, or a repo with no CI history
+	// on its default branch) the signal STAYS at zero rather than reporting an
+	// unmeasured zero as a measured one.
+	if streak, measured := greenCIStreakSnapshot(); measured {
+		in.GreenStreak = streak
 	}
 
 	// Live queue/coverage signals come from the most recent status snapshot the

--- a/src/pkg/dashboard/api_acmm_recommendation_test.go
+++ b/src/pkg/dashboard/api_acmm_recommendation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/acmmadvisor"
@@ -99,6 +100,7 @@ func TestHandleACMMRecommendationWithSignals(t *testing.T) {
 // TestBuildACMMStatusInputs_ReadsLiveSignals unit-tests the signal mapping in
 // isolation, including the coverage extraction and nil-safety.
 func TestBuildACMMStatusInputs_ReadsLiveSignals(t *testing.T) {
+	resetGreenStreakCache(t)
 	s := newTestServer()
 	lvl := 3
 	s.deps = &Dependencies{
@@ -134,11 +136,128 @@ func TestBuildACMMStatusInputs_ReadsLiveSignals(t *testing.T) {
 	if in.CoveragePct != 88 {
 		t.Fatalf("CoveragePct = %v, want 88", in.CoveragePct)
 	}
-	// GreenStreak is still untracked and must remain zero (never fabricated).
+	// GreenStreak must read zero here: no streak has ever been measured in this
+	// test (the cache is cleared above), so the signal is unknown, not a
+	// measured zero, and must never be fabricated (#5226).
 	// MergeSuccessRate must also read zero here: no fleet-stats collector is
 	// wired into deps, so the signal is unknown, not measured (#3972).
 	if in.GreenStreak != 0 || in.MergeSuccessRate != 0 {
 		t.Fatalf("GreenStreak/MergeSuccessRate should be 0, got %d / %v", in.GreenStreak, in.MergeSuccessRate)
+	}
+}
+
+// resetGreenStreakCache clears the package-level green-CI streak cache and
+// restores it when the test ends, so streak-sensitive tests do not leak state
+// into each other.
+func resetGreenStreakCache(t *testing.T) {
+	t.Helper()
+	cachedGreenStreakMu.Lock()
+	prevStreak, prevOK := cachedGreenStreak, cachedGreenStreakOK
+	cachedGreenStreak, cachedGreenStreakOK = 0, false
+	cachedGreenStreakMu.Unlock()
+	t.Cleanup(func() {
+		cachedGreenStreakMu.Lock()
+		cachedGreenStreak, cachedGreenStreakOK = prevStreak, prevOK
+		cachedGreenStreakMu.Unlock()
+	})
+}
+
+// TestBuildACMMStatusInputs_GreenStreak verifies the #5226 wiring: when the
+// status-build path has measured a real green-CI streak, that REAL VALUE
+// reaches the advisor input — it is no longer the hardcoded zero this code
+// carried before. The unmeasured case must stay at the conservative zero so an
+// absent measurement is never reported as a measured streak.
+func TestBuildACMMStatusInputs_GreenStreak(t *testing.T) {
+	cases := []struct {
+		name     string
+		streak   int
+		measured bool
+		want     int
+	}{
+		{
+			// The load-bearing case: a measured streak of 7 must arrive as 7.
+			// Against the pre-#5226 code this fails (it would read 0), which is
+			// what makes this an assertion of substance rather than shape.
+			name: "measured streak flows through",
+			// A value above greenStreakL4 (5) and below greenStreakL6 (12), so
+			// it is unmistakably a real reading rather than a boundary artifact.
+			streak: 7, measured: true, want: 7,
+		},
+		{
+			// A measured zero is legitimate: CI ran and the latest run is red.
+			name:   "measured zero (latest run red) is honest",
+			streak: 0, measured: true, want: 0,
+		},
+		{
+			// Never measured: must NOT be reported as a streak.
+			name:   "unmeasured stays conservative",
+			streak: 99, measured: false, want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGreenStreakCache(t)
+			if tc.measured {
+				cachedGreenStreakMu.Lock()
+				cachedGreenStreak, cachedGreenStreakOK = tc.streak, true
+				cachedGreenStreakMu.Unlock()
+			}
+			s := newTestServer()
+			lvl := 3
+			s.deps = &Dependencies{Config: &config.Config{ACMMLevel: &lvl}}
+			s.UpdateStatus(minimalPayload())
+
+			if got := s.buildACMMStatusInputs().GreenStreak; got != tc.want {
+				t.Fatalf("GreenStreak = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStatusPayloadCarriesACMMAdvice verifies the #5225 wiring end-to-end: the
+// status payload must carry a recommendation whose CONTENT reflects the live
+// signals, not merely a non-nil struct. A hive at L3 with a measured green
+// streak, quality agent and coverage must produce advice that evaluates the
+// L3→L4 criteria and names the real streak value in its checklist.
+func TestStatusPayloadCarriesACMMAdvice(t *testing.T) {
+	resetGreenStreakCache(t)
+	cachedGreenStreakMu.Lock()
+	cachedGreenStreak, cachedGreenStreakOK = 7, true
+	cachedGreenStreakMu.Unlock()
+
+	s := newTestServer()
+	lvl := 3
+	s.deps = &Dependencies{
+		Config: &config.Config{
+			ACMMLevel: &lvl,
+			Agents:    map[string]config.AgentConfig{qualityAgentName: {}},
+		},
+	}
+	s.UpdateStatus(minimalPayload())
+
+	in := s.buildACMMStatusInputs()
+	if in.GreenStreak != 7 {
+		t.Fatalf("advisor input GreenStreak = %d, want the measured 7", in.GreenStreak)
+	}
+	rec := acmmadvisor.RecommendFromStatus(in)
+	if rec.CurrentLevel != 3 {
+		t.Fatalf("recommendation CurrentLevel = %d, want 3", rec.CurrentLevel)
+	}
+	// The streak criterion must appear as MET: 7 clears the L4 floor of 5.
+	// This asserts the real value drove a real verdict — a payload carrying a
+	// permanently-zero streak would land this criterion in Unmet instead.
+	var found bool
+	for _, c := range rec.Met {
+		if strings.Contains(c.Name, "Green-CI streak") {
+			found = true
+		}
+	}
+	if !found {
+		var unmet []string
+		for _, c := range rec.Unmet {
+			unmet = append(unmet, c.Name)
+		}
+		t.Fatalf("Green-CI streak should be MET with a measured streak of 7; unmet = %v", unmet)
 	}
 }
 

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/acmmadvisor"
 	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/github"
@@ -320,23 +321,29 @@ type StatusPayload struct {
 	// from the shallow /api/health liveness signal or the repo-workflow
 	// Health map above, so the pill can never show "Health OK" while the
 	// spoke's own agents are down (#2465).
-	DeepHealth          map[string]any         `json:"deepHealth,omitempty"`
-	Budget              FrontendBudget         `json:"budget"`
-	CadenceMatrix       []FrontendCadence      `json:"cadenceMatrix"`
-	GHRateLimits        map[string]any         `json:"ghRateLimits"`
-	AgentMetrics        map[string]any         `json:"agentMetrics"`
-	Hold                FrontendHold           `json:"hold"`
-	IssueToMerge        map[string]any         `json:"issueToMerge"`
-	ACMMLevel           int                    `json:"acmmLevel"`
-	ACMMLevelConfigured bool                   `json:"acmmLevelConfigured"`
-	ACMMPackAgents      []string               `json:"acmmPackAgents"`
-	AdvisoryDigest      any                    `json:"advisoryDigest,omitempty"`
-	ContributorPool     *ContributorPoolStatus `json:"contributorPool,omitempty"`
-	SystemResources     *SystemResources       `json:"systemResources,omitempty"`
-	GitHubAppRequired   bool                   `json:"githubAppRequired,omitempty"`
-	GitHubAppInstallURL string                 `json:"githubAppInstallURL,omitempty"`
-	GitHubAppPermIssue  string                 `json:"githubAppPermIssue,omitempty"`
-	GitHubAppState      string                 `json:"githubAppState,omitempty"`
+	DeepHealth          map[string]any    `json:"deepHealth,omitempty"`
+	Budget              FrontendBudget    `json:"budget"`
+	CadenceMatrix       []FrontendCadence `json:"cadenceMatrix"`
+	GHRateLimits        map[string]any    `json:"ghRateLimits"`
+	AgentMetrics        map[string]any    `json:"agentMetrics"`
+	Hold                FrontendHold      `json:"hold"`
+	IssueToMerge        map[string]any    `json:"issueToMerge"`
+	ACMMLevel           int               `json:"acmmLevel"`
+	ACMMLevelConfigured bool              `json:"acmmLevelConfigured"`
+	ACMMPackAgents      []string          `json:"acmmPackAgents"`
+	// ACMMAdvice is the advisory level-up recommendation (#5225), derived from
+	// the same live signals the /api/acmm-recommendation endpoint serves so the
+	// two surfaces can never drift. It is ADVISORY ONLY: nothing acts on it
+	// automatically — a human approves a level change via handlePackSetLevel.
+	// Omitted when it could not be computed (e.g. no config yet).
+	ACMMAdvice          *acmmadvisor.Recommendation `json:"acmmAdvice,omitempty"`
+	AdvisoryDigest      any                         `json:"advisoryDigest,omitempty"`
+	ContributorPool     *ContributorPoolStatus      `json:"contributorPool,omitempty"`
+	SystemResources     *SystemResources            `json:"systemResources,omitempty"`
+	GitHubAppRequired   bool                        `json:"githubAppRequired,omitempty"`
+	GitHubAppInstallURL string                      `json:"githubAppInstallURL,omitempty"`
+	GitHubAppPermIssue  string                      `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState      string                      `json:"githubAppState,omitempty"`
 	// GitHubAppInstallMissing is CONFIG TRUTH, independent of any auth probe
 	// or classification: a real App is named (app_id set, not the placeholder)
 	// but installation_id is 0. That state alone means every token is a
@@ -1664,6 +1671,15 @@ func (s *Server) UpdateStatusIfFresh(status *StatusPayload, buildEpoch uint64) b
 	}
 
 	status.InferenceBackends = s.buildInferenceBackends()
+
+	// Attach the advisory ACMM level-up recommendation (#5225) from the SAME
+	// signal-collection path the /api/acmm-recommendation endpoint uses, so the
+	// endpoint and the status payload cannot report different advice. Pure
+	// computation over already-collected signals — no I/O on this hot path.
+	// ADVISORY ONLY: this must never auto-apply a level.
+	if advice := acmmadvisor.RecommendFromStatus(s.buildACMMStatusInputs()); advice.CurrentLevel > 0 {
+		status.ACMMAdvice = &advice
+	}
 
 	// Deep checks travel inside the status payload so every dashboard surface
 	// (header pill included) renders the same truth the heartbeat sends the

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -114,6 +114,16 @@ var (
 	cachedHealth   map[string]any
 	cachedHealthMu sync.RWMutex
 
+	// cachedGreenStreak carries the real green-CI streak (#5226) computed on
+	// the status-build path, where a GitHub client and context already exist.
+	// The ACMM advisor endpoint reads this cache rather than calling GitHub
+	// itself, so an advisory HTTP request never triggers an Actions API call.
+	// cachedGreenStreakOK stays false until a collect has actually succeeded,
+	// which is what keeps "not measured yet" distinct from a measured zero.
+	cachedGreenStreak   int
+	cachedGreenStreakOK bool
+	cachedGreenStreakMu sync.RWMutex
+
 	proxyViolationsMu sync.RWMutex
 	proxyViolationsFn func() map[string]int
 
@@ -1382,7 +1392,29 @@ func buildHealth(ghClient *github.Client, ctx context.Context) map[string]any {
 	cachedHealth = health
 	cachedHealthMu.Unlock()
 
+	// Refresh the green-CI streak on the same pass that already talks to
+	// GitHub for workflow health (#5226). A failed or unmeasurable read leaves
+	// the previous cached value untouched rather than clobbering a real streak
+	// with an unknown — a transient API error must not make the advisor
+	// suddenly withdraw a recommendation it had legitimately earned.
+	if streak, measured := ghClient.GreenCIStreak(ctx); measured {
+		cachedGreenStreakMu.Lock()
+		cachedGreenStreak = streak
+		cachedGreenStreakOK = true
+		cachedGreenStreakMu.Unlock()
+	}
+
 	return copyHealthMap(health)
+}
+
+// greenCIStreakSnapshot returns the last successfully measured green-CI streak
+// and whether one has ever been measured. measured=false means "unknown", and
+// the ACMM advisor leaves its GreenStreak signal at the conservative zero
+// rather than treating the absence of data as a measured zero.
+func greenCIStreakSnapshot() (streak int, measured bool) {
+	cachedGreenStreakMu.RLock()
+	defer cachedGreenStreakMu.RUnlock()
+	return cachedGreenStreak, cachedGreenStreakOK
 }
 
 func buildBudget(gov *governor.Governor, tokenCollector *tokens.Collector) FrontendBudget {

--- a/src/pkg/github/health.go
+++ b/src/pkg/github/health.go
@@ -15,6 +15,24 @@ const (
 	pctMultiplier        = 100
 )
 
+// ciStreakRunsLimit is how many completed default-branch runs the green-streak
+// scan reads. It is deliberately larger than ciRunsLimit (which powers the
+// pass-rate percentage over a short recent window): the ACMM advisor's highest
+// streak threshold is 12 consecutive green runs, so a 10-run page could never
+// satisfy it and the criterion would be unreachable no matter how green the
+// repo actually is. One page of this size covers every threshold with headroom
+// while remaining a single API request.
+const ciStreakRunsLimit = 30
+
+// ciConclusionSuccess / ciConclusionSkipped are the run conclusions that count
+// as "not red" for streak purposes. A skipped run means no gate ran, so it
+// neither proves nor breaks greenness — it is transparent to the streak, the
+// same treatment ciPassRate already gives it.
+const (
+	ciConclusionSuccess = "success"
+	ciConclusionSkipped = "skipped"
+)
+
 func (c *Client) FetchWorkflowHealth(ctx context.Context) map[string]any {
 	primaryRepo := c.primaryRepo()
 
@@ -25,11 +43,11 @@ func (c *Client) FetchWorkflowHealth(ctx context.Context) map[string]any {
 	health["helm"] = c.helmCheck(ctx, primaryRepo)
 
 	nightlyWorkflows := map[string]string{
-		"nightly":            "Nightly Test Suite",
-		"nightlyCompliance":  "Nightly Compliance & Perf",
-		"nightlyDashboard":   "Nightly Dashboard Health",
-		"nightlyGhaw":        "Nightly gh-aw Version Check",
-		"nightlyPlaywright":  "Playwright Cross-Browser (Nightly)",
+		"nightly":           "Nightly Test Suite",
+		"nightlyCompliance": "Nightly Compliance & Perf",
+		"nightlyDashboard":  "Nightly Dashboard Health",
+		"nightlyGhaw":       "Nightly gh-aw Version Check",
+		"nightlyPlaywright": "Playwright Cross-Browser (Nightly)",
 	}
 	for key, wfName := range nightlyWorkflows {
 		health[key] = c.checkWorkflow(ctx, primaryRepo, wfName)
@@ -76,6 +94,69 @@ func (c *Client) ciPassRate(ctx context.Context, repo string) int {
 		return healthStatusFailure
 	}
 	return passed * pctMultiplier / total
+}
+
+// GreenCIStreak returns the number of consecutive green CI runs on the primary
+// repo's default branch, counting back from the most recent completed run, and
+// whether the streak could be measured at all.
+//
+// measured=false means "unknown" and MUST be treated as such by callers — it is
+// returned when there is no GitHub client, when the Actions API call fails, and
+// when the repo reports no completed runs at all. That last case is the
+// important one: a repo with no CI configured must read as unknown, never as a
+// green streak, or the advisor would reward a repo for having no gates to fail.
+// Callers leave the advisor signal at its conservative zero when measured is
+// false rather than fabricating a number.
+//
+// What it measures, honestly: consecutive non-red completed runs on the default
+// branch, over at most ciStreakRunsLimit runs. Its known weaknesses, stated in
+// the same spirit as mergeSuccessRateFromFleetStats:
+//   - the streak resets on ANY red, including a flake unrelated to code quality;
+//   - it measures nothing about repos whose CI does not run on the default
+//     branch (they read as unknown, which is the safe direction);
+//   - a repo that rarely commits can hold a stale streak indefinitely, because
+//     the signal is count-based rather than time-based;
+//   - it is capped at ciStreakRunsLimit, so it reports "at least N" rather than
+//     a true unbounded streak. The cap sits above every advisor threshold, so
+//     the cap can only ever under-report, never over-report.
+func (c *Client) GreenCIStreak(ctx context.Context) (streak int, measured bool) {
+	if c == nil || c.client == nil {
+		return 0, false
+	}
+	repo := c.primaryRepo()
+	branch, err := c.DefaultBranch(ctx, c.org, repo)
+	if err != nil || branch == "" {
+		return 0, false
+	}
+	opts := &gh.ListWorkflowRunsOptions{
+		Status:      "completed",
+		Branch:      branch,
+		ListOptions: gh.ListOptions{PerPage: ciStreakRunsLimit},
+	}
+	runs, _, err := c.client.Actions.ListRepositoryWorkflowRuns(ctx, c.org, repo, opts)
+	if err != nil || runs == nil {
+		return 0, false
+	}
+	// No completed runs at all: the repo has no CI history on its default
+	// branch. Unknown, explicitly NOT a zero-length green streak.
+	if len(runs.WorkflowRuns) == 0 {
+		return 0, false
+	}
+	// ListRepositoryWorkflowRuns returns runs newest-first, so counting from
+	// the head of the slice walks backwards in time from the latest run. Stop
+	// at the first red — that is where the streak ended.
+	for _, run := range runs.WorkflowRuns {
+		if run == nil {
+			continue
+		}
+		switch run.GetConclusion() {
+		case ciConclusionSuccess, ciConclusionSkipped:
+			streak++
+		default:
+			return streak, true
+		}
+	}
+	return streak, true
 }
 
 func (c *Client) checkWorkflow(ctx context.Context, repo, workflowName string) int {
@@ -274,8 +355,8 @@ func (c *Client) deployChecks(ctx context.Context, repo string, health map[strin
 	})
 
 	deployJobs := map[string]string{
-		"deploy_vllm_d":    "deploy-vllm-d",
-		"deploy_pok_prod":  "deploy-pok-prod",
+		"deploy_vllm_d":   "deploy-vllm-d",
+		"deploy_pok_prod": "deploy-pok-prod",
 	}
 
 	for key := range deployJobs {

--- a/src/pkg/github/health_test.go
+++ b/src/pkg/github/health_test.go
@@ -1490,3 +1490,130 @@ func TestCheckWorkflow_APIError(t *testing.T) {
 		t.Errorf("expected not-found, got %d", result)
 	}
 }
+
+// --------------------------------------------------------------------------
+// GreenCIStreak (#5226)
+// --------------------------------------------------------------------------
+
+// greenStreakServer stands up a mock exposing the repo metadata (for the
+// default-branch lookup) and the completed-runs listing GreenCIStreak reads.
+func greenStreakServer(t *testing.T, conclusions []string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo1", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"default_branch": "main"})
+	})
+	mux.HandleFunc("/repos/org/repo1/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+		// The streak must be scoped to the default branch, not the whole repo:
+		// counting PR-branch runs would let unmerged work inflate the streak.
+		if got := r.URL.Query().Get("branch"); got != "main" {
+			t.Errorf("branch filter = %q, want \"main\"", got)
+		}
+		runs := make([]map[string]any, 0, len(conclusions))
+		for i, c := range conclusions {
+			runs = append(runs, map[string]any{"id": i + 1, "conclusion": c, "status": "completed"})
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count":   len(runs),
+			"workflow_runs": runs,
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestGreenCIStreak(t *testing.T) {
+	cases := []struct {
+		name         string
+		conclusions  []string
+		wantStreak   int
+		wantMeasured bool
+	}{
+		{
+			// Runs are newest-first, so the streak counts from the head and
+			// stops at the first red: 3 green then a failure = 3.
+			name:        "counts consecutive green from newest, stops at first red",
+			conclusions: []string{"success", "success", "success", "failure", "success"},
+			wantStreak:  3, wantMeasured: true,
+		},
+		{
+			// Latest run red: a real, measured zero. Distinct from unknown.
+			name:        "latest run red is a measured zero",
+			conclusions: []string{"failure", "success", "success"},
+			wantStreak:  0, wantMeasured: true,
+		},
+		{
+			// Skipped means no gate ran: transparent, neither breaks nor is
+			// counted against the streak (same treatment ciPassRate gives it).
+			name:        "skipped runs count as not-red",
+			conclusions: []string{"success", "skipped", "success", "failure"},
+			wantStreak:  3, wantMeasured: true,
+		},
+		{
+			// A repo with NO CI history must read as unknown, never as green —
+			// otherwise the advisor rewards having no gates to fail.
+			name:        "no completed runs reads as unknown, not green",
+			conclusions: nil,
+			wantStreak:  0, wantMeasured: false,
+		},
+		{
+			// Non-success, non-skipped conclusions (cancelled, timed_out) end
+			// the streak: they are not evidence CI held.
+			name:        "cancelled ends the streak",
+			conclusions: []string{"success", "cancelled", "success"},
+			wantStreak:  1, wantMeasured: true,
+		},
+		{
+			// All green: the streak is the full page.
+			name:        "all green counts every run",
+			conclusions: []string{"success", "success", "success", "success"},
+			wantStreak:  4, wantMeasured: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := greenStreakServer(t, tc.conclusions)
+			defer server.Close()
+
+			c := newTestClient(t, server, "org", []string{"repo1"})
+			streak, measured := c.GreenCIStreak(context.Background())
+			if measured != tc.wantMeasured {
+				t.Fatalf("measured = %v, want %v", measured, tc.wantMeasured)
+			}
+			if streak != tc.wantStreak {
+				t.Fatalf("streak = %d, want %d", streak, tc.wantStreak)
+			}
+		})
+	}
+}
+
+// TestGreenCIStreak_APIError verifies an Actions failure reads as unknown
+// rather than as a zero streak, so a transient outage cannot be mistaken for
+// a repo whose CI just went red.
+func TestGreenCIStreak_APIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/org/repo1", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"default_branch": "main"})
+	})
+	mux.HandleFunc("/repos/org/repo1/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, "org", []string{"repo1"})
+	streak, measured := c.GreenCIStreak(context.Background())
+	if measured {
+		t.Fatalf("measured = true on API error, want false (unknown)")
+	}
+	if streak != 0 {
+		t.Fatalf("streak = %d on API error, want 0", streak)
+	}
+}
+
+// TestGreenCIStreak_NilClient verifies nil-safety: no client means unknown.
+func TestGreenCIStreak_NilClient(t *testing.T) {
+	var c *Client
+	if streak, measured := c.GreenCIStreak(context.Background()); measured || streak != 0 {
+		t.Fatalf("nil client: got (%d, %v), want (0, false)", streak, measured)
+	}
+}


### PR DESCRIPTION
Fixes #5225
Fixes #5226

## Why one PR

These are two halves of one feature. #5225 exposes the advisor's recommendation on the status payload; `GreenStreak` is one of the signals that recommendation **consumes**, and nothing populated it. Shipping #5225 alone would expose a payload carrying a permanently-zero field — plumbing that looks wired but reports nothing.

## #5225 — recommendation on the status payload

Adds `StatusPayload.ACMMAdvice`, populated from `buildACMMStatusInputs` — the **same** signal-collection path `GET /api/acmm-recommendation` already uses, so the endpoint and the payload cannot drift (the design decision the issue called out).

Stays **advisory only**: nothing consumes it to change a level. `handlePackSetLevel` remains the only apply path.

## #5226 — a real GreenStreak

Adds `Client.GreenCIStreak`: consecutive non-red completed runs on the primary repo's **default branch**, newest-first, stopping at the first red. This is the issue's recommended Option 1.

**No new API caller.** It reuses the `ListRepositoryWorkflowRuns` listing `health.go`'s `ciPassRate` already calls, plus the already-cached `DefaultBranch` lookup. The streak is refreshed on the status-build pass that *already* talks to GitHub for workflow health, and cached — so no advisory HTTP request ever triggers a GitHub call.

### Honest-signal handling

Follows the `mergeSuccessRateFromFleetStats` (#3972) model:

- **unknown ≠ zero.** No GitHub client, an API failure, or a repo with **no CI history at all** read as *unmeasured*; the advisor leaves the signal at its conservative zero rather than reporting a fabricated or vacuous value. Per the issue: a repo with no CI must never read as green.
- **A failed refresh leaves the last real reading intact** rather than clobbering an earned streak with an unknown.
- **`ciStreakRunsLimit` = 30**, deliberately above the highest advisor threshold (`greenStreakL6` = 12). The existing `ciRunsLimit` of 10 would have made the L6 criterion *unreachable no matter how green the repo was*. The cap can only ever under-report.

Documented weaknesses (in the code and in `src/docs/acmm-advisor.md`): flake-sensitive, stale on quiet repos, capped, and `skipped` runs are transparent to the streak.

## Tests assert substance, not shape

The streak tests verify a measured `7` **actually reaches the advisor input and flips the L4 streak criterion to MET** — both fail against the pre-fix hardcoded zero (verified by reverting the wiring locally). Also covered: red-first (a legitimate *measured* zero), skipped-as-transparent, cancelled-ends-streak, no-CI-history, API error, and nil client.

## Also

Removes the now-stale `TODO(acmm2-wiring)` and `TODO(acmm-signals)` comments, and corrects `src/docs/acmm-advisor.md`, which claimed `GreenStreak` is "always zero" and that the advisor "is not currently rendered anywhere".

## Note for reviewers

The Podman arm64 lane is red on `v4` for an unrelated reason (#5370 — it probes the last published image, not the PR build).