### PR TITLE
🐛 fix(contributor-relay): stop the agent and drop its token on every task exit

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1101,6 +1101,11 @@ function runHeadlessTask(task) {
       const noWork = prURL ? null : detectNoWorkVerdict(outTail);
       if (noWork) console.log(`Detected no_work_needed verdict for ${task.task_id}: ${noWork.reason || '(no reason)'}`);
       writeHeadlessStatus(HEADLESS_STATE_DONE, { task_id: task.task_id, task_gen: task.task_gen, result: 'completed', pr_url: prURL });
+      // #5353: the one-shot child has already exited (this callback is its
+      // exit), so there is no process to stop — but the task-scoped token it
+      // was given stays valid for the rest of wsTokenTTL. Drop it with the
+      // task, so a credential never outlives the assignment it belongs to.
+      stopAgentForTaskExit();
       send({ type: 'task_complete', seq: nextSeq(), task_id: task.task_id, task_gen: task.task_gen, result: 'completed', summary: 'Headless one-shot invocation exited 0', tmux_output: outTail, pr_url: prURL, verdict: noWork ? noWork.verdict : undefined, verdict_reason: noWork ? noWork.reason : undefined, ...effectiveSelectionFields() });
       currentTask = null;
       taskAssignedAt = 0;
@@ -1434,7 +1439,11 @@ function armCLIReadyWait() {
     pendingTask = null;
     if (currentTask) {
       // environment: the agent CLI never reached its prompt on this host.
-      failCurrentTask(`CLI never became ready: ${e.message}`, { skipReady: true, kind: 'environment' });
+      // skipCLI: this IS the relaunch path — armCLIReadyWait() re-arms itself
+      // below and the pane already has a launch in flight. Quitting and
+      // relaunching from here would nest a second launch inside the first
+      // (#5353). The credential is still dropped by failCurrentTask.
+      failCurrentTask(`CLI never became ready: ${e.message}`, { skipReady: true, skipCLI: true, kind: 'environment' });
     }
     // Keep waiting. The CLI may still come up (a slow login, an operator
     // attaching to clear a prompt we don't recognize), and when it does the
@@ -2309,6 +2318,86 @@ function relaunchCLI() {
   return launchCmd;
 }
 
+// dropTaskCredential removes the repo-scoped GitHub token this relay was given
+// for the task that is ending.
+//
+// The token lives in exactly one place — the 0600 GH_TOKEN_CACHE written by
+// injectGhToken — and it stays valid for the remainder of wsTokenTTL (~55min)
+// no matter what the relay reports. Leaving it on disk after the hub has
+// released the work means a turn that is still running can keep pushing and
+// opening PRs against an issue the hub has already offered to someone else.
+//
+// Kept separate from the stop so the ordering in stopAgentForTaskExit() is
+// visible at its single call site rather than buried in a compound helper.
+function dropTaskCredential() {
+  try { fs.unlinkSync(GH_TOKEN_CACHE); } catch (_) {}
+  tokenExpiresAt = null;
+}
+
+// stopAgentForTaskExit ends the AGENT, not just the bookkeeping, when a task
+// stops being ours (kubestellar/hive#5353 cause B).
+//
+// Reporting task_complete or task_failed tells the hub to revoke the lease,
+// book a cooldown and offer the issue to someone else. Before this existed,
+// only five of the relay's task-exit paths touched the pane, so the other
+// paths left the original agent running in the same pane, on the same context,
+// holding a live scoped token — and it would eventually open a PR against an
+// issue the hub had already reassigned. That is the duplicate-PR shape #2356
+// exists to prevent, produced from inside the contributor rather than outside
+// it, which is why the hub's cooldown accounting cannot see it.
+//
+// The sequence is the one the task_revoke handler already got right, and the
+// ORDER is load-bearing:
+//
+//  1. Unlink the credential FIRST, so a turn that survives the interrupt (or
+//     races it) cannot keep using it. Interrupting first leaves a window in
+//     which the agent is being killed but is still authorized.
+//  2. Two Ctrl-Cs via quitLiveCLI() — one only cancels a claude/codex/agy
+//     turn and leaves the CLI running, so the relaunch command that follows
+//     would be typed into the CLI as a chat message (#2203).
+//  3. Relaunch, which sets cliReady=false and re-arms armCLIReadyWait(), so
+//     the next task's prompt is queued until a clean prompt is confirmed.
+//
+// Re-entrancy: callers that have ALREADY stopped or relaunched the pane pass
+// { skipCLI: true } and get only step 1 — nesting a second quit/relaunch into
+// a relaunch already in flight is how double-launches happen. Headless mode
+// has no pane at all; there the in-flight one-shot child is killed instead,
+// matching what the revoke handler does.
+//
+// opts.reason names the exit in the relaunch log line, and opts.onRelaunchFailed
+// lets a caller with its own post-relaunch latch (the revoke handler's
+// readyAfterInteractiveRevoke) unwind it — the latch is only meaningful if a
+// relaunch actually happened.
+//
+// Best-effort by design, like quitLiveCLI(): every caller is already on an
+// exit path, and a relaunch that lands badly is recovered by the
+// armCLIReadyWait() contract.
+function stopAgentForTaskExit(opts) {
+  const skipCLI = !!(opts && opts.skipCLI);
+  const reason = (opts && opts.reason) || 'a task exit';
+  // Step 1, always — even when the pane is deliberately left alone. A task
+  // that is no longer ours must not keep its credential under any branch.
+  dropTaskCredential();
+  if (skipCLI) return;
+  if (CONTRIBUTOR_MODE === MODE_HEADLESS) {
+    if (headlessChild) {
+      try { headlessChild.kill('SIGKILL'); } catch (_) {}
+      headlessChild = null;
+      writeHeadlessStatus(HEADLESS_STATE_WAITING);
+    }
+    return;
+  }
+  cliReady = false;
+  quitLiveCLI();
+  try {
+    console.log(`Relaunching ${BACKEND} after ${reason}: ${relaunchCLI()}`);
+  } catch (e) {
+    cliReadyFailed = true;
+    if (opts && opts.onRelaunchFailed) opts.onRelaunchFailed();
+    console.error(`Failed to stop and relaunch ${BACKEND} after ${reason}: ${e.message}`);
+  }
+}
+
 // --- Pane stall backstop ------------------------------------------------
 //
 // A relay that BELIEVES it is working renews the hub's task lease on every
@@ -2510,13 +2599,25 @@ function restartBackoffMs(attempt) {
 //
 // It is advisory: the hub records and displays it and does not route, gate, or
 // change the work item's failure cooldown on it. Older hubs ignore the field.
+//
+// opts.skipCLI (kubestellar/hive#5353) says the CALLER has already dealt with
+// the pane — it quit and relaunched the CLI itself, or the CLI is already gone.
+// The credential is still dropped; only the quit/relaunch is skipped, so a
+// relaunch already in flight is not nested inside another one.
 function failCurrentTask(reason, opts) {
   if (!currentTask) return;
   const permanent = !!(opts && opts.permanent);
   const kind = (opts && opts.kind) || undefined;
   const taskId = currentTask.task_id;
   const taskGen = currentTask.task_gen;
+  // Captured BEFORE the agent is stopped: the pane text is the evidence the
+  // hub and the operator read to understand the failure, and quitLiveCLI()
+  // followed by a relaunch overwrites it with launch chrome.
   const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
+  // Cause B (#5353): the hub is about to release this issue and offer it to
+  // someone else. Stop the agent and drop its token FIRST, so the report and
+  // the reality agree at the instant the hub acts on it.
+  stopAgentForTaskExit({ skipCLI: !!(opts && opts.skipCLI) });
   console.error(`Task ${taskId} failed${permanent ? ' permanently' : ''}${kind ? ` [${kind}]` : ''}: ${reason}`);
   send({
     type: 'task_failed',
@@ -2820,9 +2921,14 @@ function progressTick() {
         // never wedge the whole contributor.
         givenUpTasks.set(key, Date.now());
         cliRestartCounts.delete(key);
+        // skipCLI: this branch's premise is that the CLI process is ALREADY
+        // gone (probeCLIPresence confirmed it), and the relaunch that follows
+        // is this path's own. There is no live turn to interrupt, so quitting
+        // here would only send Ctrl-Cs at a bare shell and then race the
+        // relaunch below. The token is dropped regardless (#5353).
         failCurrentTask(
           `CLI process exited ${MAX_TASK_CLI_RESTARTS} times for ${key} — giving up on this task (relay still accepting other work)`,
-          { permanent: true }
+          { permanent: true, skipCLI: true }
         );
         // Bring the CLI back so the next, different task can run.
         try { console.log(`CLI restarted: ${relaunchCLI()}`); } catch (e) { console.error('Failed to restart CLI:', e.message); }
@@ -2838,7 +2944,9 @@ function progressTick() {
         console.error('Failed to restart CLI:', e.message);
       }
       // environment: the agent CLI process died; nothing was judged about the work.
-      failCurrentTask('CLI process exited — restarted', { kind: 'environment' });
+      // skipCLI for the same reason as the give-up branch above — the process
+      // is gone and the relaunch just above is this path's own (#5353).
+      failCurrentTask('CLI process exited — restarted', { kind: 'environment', skipCLI: true });
       return;
     }
     // A pane sitting at a shell is never evidence that the AGENT finished: the
@@ -2884,11 +2992,31 @@ function progressTick() {
     // claim with "shipped" anyway).
     const noWork = prURL ? null : detectNoWorkVerdict(tmuxLines);
     if (noWork) console.log(`Detected no_work_needed verdict for ${currentTask.task_id}: ${noWork.reason || '(no reason)'}`);
+    // Cause B (#5353). "Idle" here is a verdict read off the pane's rendering
+    // chrome, and it is wrong often enough to have produced thirteen separate
+    // issues. When it is wrong, the agent is still mid-turn — and reporting
+    // task_complete makes the hub revoke the lease, book the cooldown, and
+    // offer the issue to somebody else while that turn keeps running in this
+    // pane on this token. Stopping the CLI and dropping the credential here
+    // makes the misread cost a retry instead of a duplicate PR.
+    //
+    // Note the ordering against `send` below: the agent is stopped BEFORE the
+    // hub is told, so at the instant the hub acts on the completion the claim
+    // is already true. tmuxLines was captured above, so the evidence the hub
+    // receives is still the agent's own output and not launch chrome.
+    //
+    // bob is exempt from the quit half: it is not a persistent REPL and has
+    // already exited at the end of its turn, so the pane is a bare shell and
+    // there is nothing to interrupt — sending Ctrl-C at that shell and then
+    // racing the bob-specific relaunch below is how a pane ends up with two
+    // launches in flight. Its credential is still dropped.
+    const bobAlreadyExited = BACKEND === 'bob' && !bobIsRunning();
+    stopAgentForTaskExit({ skipCLI: bobAlreadyExited });
     send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, task_gen: currentTask.task_gen, result: 'completed', summary: noWork ? 'Agent returned to idle (reported no_work_needed)' : 'Agent returned to idle', tmux_output: tmuxLines, pr_url: prURL, verdict: noWork ? noWork.verdict : undefined, verdict_reason: noWork ? noWork.reason : undefined });
     // bob exits after each turn, so the pane is now a bare shell. Bring it
     // back up before the next task, or the prompt would be typed into bash
     // ("-bash: <prompt>: command not found") and silently lost.
-    if (BACKEND === 'bob' && !bobIsRunning()) {
+    if (bobAlreadyExited) {
       try {
         // relaunchCLI() clears cliReady and re-arms the readiness callback,
         // which flushes any queued prompt once the CLI is confirmed up.
@@ -2977,12 +3105,11 @@ function progressTick() {
       // a live CLI that cancels the turn without exiting, and the launch command
       // is then typed into the CLI as a chat prompt — #2203 again, and worse here
       // because the "prompt" is a shell command an agent may simply run.
-      quitLiveCLI();
-      try {
-        console.log(`Relaunching ${BACKEND} after a confirmed pane stall: ${relaunchCLI()}`);
-      } catch (e) {
-        console.error('Failed to relaunch after a confirmed pane stall:', e.message);
-      }
+      //
+      // Now done by failCurrentTask via stopAgentForTaskExit (#5353), which
+      // adds the credential unlink ahead of the interrupt and captures the
+      // stalled pane as evidence BEFORE the relaunch overwrites it — this path
+      // previously reported the launch chrome as the failure's tmux_output.
       failCurrentTask(
         `no pane activity for ${Math.round(PANE_STALL_TIMEOUT_MS / 60000)}+ minutes, confirmed over ${PANE_STALL_CONFIRM_TICKS} checks — the agent CLI is not visibly working`,
         { kind: 'environment' }
@@ -3174,10 +3301,6 @@ function handleMessage(data, hub) {
         break;
       }
       console.log(`Task revoked: ${msg.task_id} — ${msg.reason}`);
-      // A task-issued GitHub token is stored only in this relay cache. Remove it
-      // before interrupting the CLI so a surviving turn cannot keep using it.
-      try { fs.unlinkSync(GH_TOKEN_CACHE); } catch (_) {}
-      tokenExpiresAt = null;
       currentTask = null;
       taskAssignedAt = 0;
       if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
@@ -3188,29 +3311,23 @@ function handleMessage(data, hub) {
       // re-arms it, which masked this; clearing it makes the lifecycle explicit
       // and matches every other task-exit path (#5321).
       if (taskTimeoutHandle) { clearTimeout(taskTimeoutHandle); taskTimeoutHandle = null; }
-      // Headless mode: kill the in-flight one-shot child so the revoked task's
-      // process does not keep running (and holding the credential) after the
-      // hub took the work back.
-      if (CONTRIBUTOR_MODE === MODE_HEADLESS && headlessChild) {
-        try { headlessChild.kill('SIGKILL'); } catch (_) {}
-        headlessChild = null;
-        writeHeadlessStatus(HEADLESS_STATE_WAITING);
-      }
+      // Stop the agent and drop its credential. This is the sequence
+      // stopAgentForTaskExit() was factored out of (#5353): the token is
+      // unlinked BEFORE the interrupt so a surviving turn cannot keep using
+      // it; two Ctrl-C events are required because one cancels a Claude/Codex/
+      // Pi turn but leaves the CLI alive; relaunchCLI gates ready on a clean
+      // prompt; and in headless mode the in-flight one-shot child is killed
+      // instead, so the revoked task's process does not keep running.
       if (CONTRIBUTOR_MODE !== MODE_HEADLESS) {
-        // Bind interruption to this relay's configured pane only. Two Ctrl-C
-        // events are required because one cancels a Claude/Codex/Pi turn but
-        // leaves the CLI alive; relaunchCLI gates ready on a clean prompt.
+        // Set before the stop: the relaunch's readiness callback consumes this
+        // latch to re-advertise availability, and it is only meaningful if a
+        // relaunch actually happened — hence the unwind on failure.
         readyAfterInteractiveRevoke = true;
-        cliReady = false;
-        quitLiveCLI();
-        try {
-          console.log(`Relaunching ${BACKEND} after task revoke: ${relaunchCLI()}`);
-        } catch (e) {
-          readyAfterInteractiveRevoke = false;
-          cliReadyFailed = true;
-          console.error(`Failed to stop and relaunch ${BACKEND} after revoke: ${e.message}`);
-        }
       }
+      stopAgentForTaskExit({
+        reason: 'task revoke',
+        onRelaunchFailed: () => { readyAfterInteractiveRevoke = false; },
+      });
       // Stay with the hub that just revoked — it's clearly alive and reachable.
       activeHubIndex = hubs.indexOf(hub);
       if (CONTRIBUTOR_MODE === MODE_HEADLESS) sendTo(hub, { type: 'ready', seq: nextSeq() });
@@ -3460,6 +3577,8 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     cliProcessLooksGone,
     paneForegroundCommand,
     quitLiveCLI,
+    stopAgentForTaskExit,
+    dropTaskCredential,
     CLI_GONE_CONFIRMATIONS,
     PANE_STALL_TIMEOUT_MS,
     // Backdate the stall clock so a test can cross the timeout without

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -4832,6 +4832,256 @@ test('#5321 a headless one-shot is no longer capped at the old 30-minute wall', 
 });
 
 // ---------------------------------------------------------------------------
+// kubestellar/hive#5353 cause B — ending a task must stop the agent.
+//
+// Reporting task_complete or task_failed tells the hub to revoke the lease,
+// book a cooldown and offer the issue to somebody else. Before this, only five
+// of the twelve task-exit paths touched the pane, so the other seven left the
+// original agent running in the same pane on the same context with a live
+// repo-scoped token — and it would go on to open a PR against work the hub had
+// already reassigned.
+//
+// Every assertion below is on OBSERVABLE state: the token file is gone, and
+// the pane received the two Ctrl-Cs that actually exit a CLI followed by a
+// relaunch. None of them assert that a particular function was called.
+// ---------------------------------------------------------------------------
+
+// An IDLE_COMPLETE pane for copilot/claude — the ready chrome the classifier
+// matches, with no "esc cancel" working marker.
+const IDLE_PANE = '/ commands for help\n';
+
+// Plant a task-scoped token exactly where injectGhToken puts it, so a test can
+// watch it survive or not survive a task exit.
+function plantTaskToken(relay) {
+  fs.mkdirSync(path.dirname(relay.GH_TOKEN_CACHE), { recursive: true });
+  fs.writeFileSync(relay.GH_TOKEN_CACHE, 'gho_task_scoped_token', { mode: 0o600 });
+  assert.ok(fs.existsSync(relay.GH_TOKEN_CACHE), 'test setup: token cache was not planted');
+}
+
+// The two Ctrl-Cs that exit a live CLI, followed by the launch command. One
+// Ctrl-C only cancels a claude/codex/agy turn and leaves the CLI running, so
+// "stopped" means at least two, and they must PRECEDE the relaunch or the
+// launch command is typed into the CLI as a chat message (#2203).
+function assertAgentStopped(sends, backend) {
+  const launchIdx = sends.findIndex(c => new RegExp(backend).test(c));
+  assert.ok(launchIdx >= 0, `expected a relaunch of ${backend}: ${JSON.stringify(sends)}`);
+  const ctrlCs = sends.slice(0, launchIdx).filter(c => /C-c\s*$/.test(c)).length;
+  assert.ok(ctrlCs >= 2,
+    `a live CLI needs two Ctrl-Cs before the relaunch; saw ${ctrlCs} in ${JSON.stringify(sends)}`);
+}
+
+test('#5353 a reported completion stops the agent and drops its token', () => {
+  // The headline case. The pane reads idle, the relay books a completion, the
+  // hub reassigns the issue — and the agent that "finished" must not still be
+  // sitting in the pane with a valid credential.
+  const relay = loadRelay({ backend: 'copilot', paneText: IDLE_PANE });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-complete');
+    plantTaskToken(relay);
+    const before = relay.__tmuxSends().length;
+    relay.__stallTick();
+
+    const completed = relay.__sent.filter(m => m.type === 'task_complete');
+    assert.strictEqual(completed.length, 1, 'setup: expected exactly one completion');
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE),
+      'a completed task left its repo-scoped GitHub token on disk, valid for the rest of wsTokenTTL');
+    assertAgentStopped(relay.__tmuxSends().slice(before), 'copilot');
+  } finally { teardown(relay); }
+});
+
+test('#5353 the completion report still carries the AGENT output, not the relaunch chrome', () => {
+  // Stopping the agent must not cost the evidence: tmux_output is captured
+  // before the quit, so the hub still sees the pane the verdict was read from
+  // (and detectPRURL still finds the PR the agent opened).
+  const relay = loadRelay({
+    backend: 'copilot',
+    paneText: 'Pull request opened: https://github.com/foo/bar/pull/909\n/ commands for help\n',
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-evidence');
+    relay.__stallTick();
+    const completed = relay.__sent.find(m => m.type === 'task_complete');
+    assert.ok(completed, 'expected a completion');
+    assert.strictEqual(completed.pr_url, 'https://github.com/foo/bar/pull/909',
+      'the PR the agent shipped must survive the stop');
+    assert.ok(completed.tmux_output.join('\n').includes('Pull request opened'),
+      `tmux_output must be the agent's pane, not launch chrome: ${JSON.stringify(completed.tmux_output)}`);
+  } finally { teardown(relay); }
+});
+
+test('#5353 a progress-lease expiry stops the agent and drops its token', () => {
+  // "No observed progress" is a verdict about a pane, not about a process. The
+  // CLI is still running and still authorized until something stops it.
+  const relay = loadRelay({ backend: 'agy', paneText: 'still chewing on it' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-lease');
+    plantTaskToken(relay);
+    const before = relay.__tmuxSends().length;
+    relay.__agePaneStallClock(relay.MAX_TASK_DURATION_MS + 1);
+    relay.onTaskProgressLeaseExpired();
+
+    const failedMsgs = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(failedMsgs.length, 1, `expected one failure: ${JSON.stringify(relay.__sent.map(m => m.type))}`);
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE),
+      'a lease-expired task left its GitHub token on disk');
+    assertAgentStopped(relay.__tmuxSends().slice(before), 'agy');
+  } finally { teardown(relay); }
+});
+
+test('#5353 the absolute deadline stops the agent and drops its token', () => {
+  const relay = loadRelay({ backend: 'agy', paneText: 'printing forever' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-deadline');
+    plantTaskToken(relay);
+    const before = relay.__tmuxSends().length;
+    relay.__ageTaskAssignedAt(relay.ABSOLUTE_TASK_DEADLINE_MS + 1);
+    relay.onTaskProgressLeaseExpired();
+
+    const failedMsgs = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(failedMsgs.length, 1);
+    assert.match(failedMsgs[0].reason, /absolute deadline/);
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE),
+      'a task killed at the absolute deadline left its GitHub token on disk');
+    assertAgentStopped(relay.__tmuxSends().slice(before), 'agy');
+  } finally { teardown(relay); }
+});
+
+test('#5353 a fatal API error stops the agent and drops its token', () => {
+  // An authorization refusal or exhausted quota ends the TASK. The CLI is
+  // still up, and on some backends will happily continue once the operator
+  // fixes the cause — on an issue the hub has already given to someone else.
+  const relay = loadRelay({
+    backend: 'claude',
+    paneText: 'API Error: 403 {"type":"error","error":{"type":"permission_error","message":"denied"}}\n',
+  });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-fatal');
+    plantTaskToken(relay);
+    const before = relay.__tmuxSends().length;
+    relay.__stallTick();
+
+    const failedMsgs = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.strictEqual(failedMsgs.length, 1, `expected a fatal-API failure: ${JSON.stringify(relay.__sent.map(m => m.type))}`);
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE),
+      'a fatally-failed task left its GitHub token on disk');
+    assertAgentStopped(relay.__tmuxSends().slice(before), 'claude');
+  } finally { teardown(relay); }
+});
+
+test('#5353 a task exit relaunches the CLI exactly once — no nested double launch', () => {
+  // quitLiveCLI + relaunch paths already existed; routing every exit through
+  // one helper must not stack a second launch on top of an in-flight one. The
+  // confirmed pane stall is the case that already stopped the CLI itself.
+  const relay = loadRelay({ backend: 'agy', paneText: 'a frozen pane, nothing happening' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-once');
+    plantTaskToken(relay);
+    const before = relay.__tmuxSends().length;
+    relay.__stallTick();
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();                                   // confirmation 1
+    relay.__agePaneStallClock(relay.PANE_STALL_TIMEOUT_MS + 1);
+    relay.__stallTick();                                   // confirmation 2 -> exit
+    const sends = relay.__tmuxSends().slice(before);
+    const launches = sends.filter(c => /agy --allow-all/.test(c)).length;
+    assert.strictEqual(launches, 1,
+      `exactly one relaunch per task exit; saw ${launches} in ${JSON.stringify(sends)}`);
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE), 'the stall path must also drop the token');
+  } finally { teardown(relay); }
+});
+
+test('#5353 a CLI that already died is not Ctrl-C\'d at a bare shell, but still loses its token', () => {
+  // The deliberate exception. This branch's premise is that the process is
+  // GONE and the pane is a shell; quitting there would only fire Ctrl-Cs at
+  // bash and race this path's own relaunch. The credential still goes.
+  const relay = loadRelay({ backend: 'copilot', procAlive: false });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-dead');
+    plantTaskToken(relay);
+    relay.__crashTick();   // reading 1 — not yet confirmed
+    const before = relay.__tmuxSends().length;
+    relay.__crashTick();   // reading 2 — confirmed death
+
+    const failedMsgs = relay.__sent.filter(m => m.type === 'task_failed');
+    assert.ok(failedMsgs.length >= 1, 'a dead CLI must still hand the task back');
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE),
+      'a task whose CLI died left its GitHub token on disk');
+    const launches = relay.__tmuxSends().slice(before).filter(c => /copilot --allow-all/.test(c)).length;
+    assert.strictEqual(launches, 1,
+      'the crash path owns its own single relaunch — the exit helper must not add another');
+  } finally { teardown(relay); }
+});
+
+test('#5353 a headless one-shot drops its token on completion as well as on revoke', () => {
+  // Headless already killed the child on revoke but kept the credential on a
+  // clean exit-0 completion, which is the same outlived-credential shape.
+  const relay = loadRelay({ backend: 'pi', mode: 'headless', model: 'openai/gpt-5', cliVersion: 'pi 0.73.1' });
+  try {
+    const task = { task_id: 'h-done', task_gen: 4, kind: 'issue', repo: 'x/y', number: 7, title: 'headless' };
+    relay.setCurrentTask(task);
+    plantTaskToken(relay);
+    relay.runHeadlessTask(task);
+    assert.ok(relay.__sent.some(m => m.type === 'task_complete'), 'setup: expected a headless completion');
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE),
+      'a completed headless task left its GitHub token on disk for the rest of wsTokenTTL');
+  } finally { teardown(relay); }
+});
+
+test('#5353 task_revoke keeps its exact behaviour after the refactor', () => {
+  // The path that was already correct is the one the helper was factored out
+  // of, so it is also the regression risk: the token must still go, the CLI
+  // must still be stopped and relaunched, and the revoke-specific readiness
+  // latch must still be armed so the relay re-advertises when it comes back.
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-revoke');
+    plantTaskToken(relay);
+    const before = relay.__tmuxSends().length;
+    relay.handleMessage(JSON.stringify({ type: 'task_revoke', task_id: 't-revoke', reason: 'operator stop' }));
+
+    assert.strictEqual(relay.getCurrentTask(), null, 'revoke must clear the active task');
+    assert.ok(!fs.existsSync(relay.GH_TOKEN_CACHE), 'revoke must still drop the token');
+    assert.strictEqual(relay.getCliReady(), false, 'revoke must clear the readiness latch');
+    assertAgentStopped(relay.__tmuxSends().slice(before), 'claude');
+  } finally { teardown(relay); }
+});
+
+test('#5353 declining an assignment touches neither the pane nor an unrelated token', () => {
+  // Three task_assign paths answer task_failed for work that was never
+  // started. There is no agent of ours to stop, and the running task's own
+  // credential must not be collateral damage — this is the exception the
+  // uniform treatment would have broken.
+  const relay = loadRelay({ backend: 'copilot', paneText: 'esc cancel\n' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-first', 1);
+    plantTaskToken(relay);
+    const before = relay.__tmuxSends().length;
+    relay.handleMessage(JSON.stringify({
+      type: 'task_assign', task_id: 't-second', kind: 'issue', repo: 'foo/bar', number: 2, title: 'second',
+    }));
+
+    const declined = relay.__sent.filter(m => m.type === 'task_failed' && m.task_id === 't-second');
+    assert.strictEqual(declined.length, 1, 'the second assignment must be declined');
+    assert.ok(fs.existsSync(relay.GH_TOKEN_CACHE),
+      'declining a NEW task must not delete the token of the task still being worked');
+    assert.strictEqual(relay.getCurrentTask().task_id, 't-first',
+      'declining must not disturb the active task');
+    const ctrlCs = relay.__tmuxSends().slice(before).filter(c => /C-c\s*$/.test(c)).length;
+    assert.strictEqual(ctrlCs, 0,
+      'declining an assignment must never interrupt the agent working the previous one');
+  } finally { teardown(relay); }
+});
+
+// ---------------------------------------------------------------------------
 
 let failed = 0;
 // RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.


### PR DESCRIPTION
Refs #5353 — **cause B only**. Cause A (completion inferred from tmux rendering chrome) is untouched and #5353 stays open.

## The problem

Ending a task did not stop the agent working it. Only five of the relay's task-exit paths touched the pane. The rest sent `task_complete` or `task_failed`, cleared `currentTask` and asked for more work — while the CLI kept running in the same pane, on the same context window, holding the repo-scoped GitHub token minted for the task it had just given up. The token stays valid for the remainder of `wsTokenTTL` (~55min) regardless of what the relay reported.

The hub then does exactly what it was told: revokes the lease, books a cooldown, selects a different issue, and assigns it. The original agent finishes and opens a PR against work already reassigned. That is the duplicate-PR shape #2356 exists to prevent, produced from *inside* the contributor — which is why the cooldown machinery guarding the outside cannot see it.

## The fix

`task_revoke` already had this right, including the ordering — it unlinks `GH_TOKEN_CACHE` **before** interrupting the CLI, per its own comment, "so a surviving turn cannot keep using it". That sequence is now `stopAgentForTaskExit()`, and every exit path routes through it:

1. drop the credential
2. two Ctrl-Cs (one only cancels a claude/codex/agy turn and leaves the CLI running — #2203)
3. relaunch, which clears `cliReady` and re-arms `armCLIReadyWait()`, so the next prompt is queued rather than typed into a pane mid-launch

## Exit-path table, verified against the code

| Path | Before | After |
|---|---|---|
| Pane reads `IDLE_COMPLETE` | No | **Stops + drops token** |
| Progress lease expired (30 min) | No | **Stops + drops token** |
| Absolute deadline (4 h) | No | **Stops + drops token** |
| Fatal API error (403 / quota) | No | **Stops + drops token** |
| API retry budget exhausted | No | **Stops + drops token** |
| Headless one-shot exit 0 | No | **Drops token** (child already exited) |
| Headless failure paths | No | **Drops token** |
| Confirmed pane stall (20 min) | Yes | Unchanged, via the helper (+ token now dropped first) |
| Hub `task_revoke` | Yes | Unchanged, refactored onto the helper |
| CLI process died — give-up | Yes | Token dropped; pane deliberately not re-quit |
| CLI process died — restart | Yes | Token dropped; pane deliberately not re-quit |
| `CLI never became ready` | relaunch | Token dropped; pane deliberately not re-quit |
| `bob` turn ended | Yes | Token dropped; pane deliberately not re-quit |
| Task arrives while busy | n/a | **Deliberately unchanged** |
| Previously given up on | n/a | **Deliberately unchanged** |
| Hub not the active polling slot | n/a | **Deliberately unchanged** |

### Deliberate exceptions, and why

**CLI-died (both branches), `CLI never became ready`, and `bob`** get `{ skipCLI: true }` — the credential still goes, the pane does not. In each of these the CLI process is already gone, or a relaunch is already in flight from that path's own code. Quitting again would fire Ctrl-Cs at a bare shell and race a launch that is already happening. That is the re-entrancy hazard, and it is handled by an explicit opt-out rather than by hoping call order works out.

**The three `task_assign` decline paths** are untouched entirely. They answer `task_failed` for work that was never started: there is no agent of theirs to stop, and dropping the token there would destroy the credential belonging to the task *still being worked*. A test pins this. (That these declines are booked as failures by the hub at all is finding 3 of #5353 and is hub-side work.)

## Incidental fix

The confirmed-stall path captured `tmux_output` **after** relaunching, so the hub received launch chrome instead of the stalled pane it was judging. Evidence is now captured before the stop on every path, and a test pins it.

## Scope

- No hub-side lease or cooldown accounting is changed — that is #5151's ground and it is held.
- No token material is printed, logged, or committed.
- Cause A is reported, not built.

## Tests

Ten new tests in `bin/contributor-relay.test.js`, asserting **observable** state — the token file is gone, the pane received two Ctrl-Cs and then exactly one relaunch — never that a function was called. **Seven fail against the unfixed relay**; the other three pin invariants the fix must not break (revoke unchanged, declines untouched, evidence preserved).

`240/240 passed` locally; CI is the gate.

> The Podman arm64 lane is red on `v4` for an unrelated reason (#5370).