### PR TITLE
🐛 fix(hub): preserve forge kind in heartbeat API URLs

### DIFF
--- a/src/pkg/hub/forge_test.go
+++ b/src/pkg/hub/forge_test.go
@@ -143,7 +143,7 @@ func TestForgeSwitchSurvivesHeartbeat(t *testing.T) {
 // existing GHE push could never handle.
 //
 // Everywhere else an empty github_api_url means "leave the spoke alone", and
-// gheAPIURLForHost("github.com") is "" by definition — so a naive
+// forgeAPIURLForHost("", "github.com") is "" by definition — so a naive
 // implementation can move a hive TO enterprise but never back. The public
 // target is therefore delivered as an EXPLICIT api.github.com.
 func TestForgeSwitchBackToPublicIsDeliverable(t *testing.T) {
@@ -641,5 +641,69 @@ func TestPendingForgeAPIURLRespectsStoredKind(t *testing.T) {
 	})
 	if got := pendingForgeAPIURL(loadSaaSHive("pub"), ""); got != defaultPublicAPIURL {
 		t.Errorf("public hive: pendingForgeAPIURL = %q, want the explicit %q", got, defaultPublicAPIURL)
+	}
+}
+
+// TestProjectConfigAPIURLRespectsStoredKind is the steady-state regression for
+// #5346. pendingForgeAPIURL only governs an outstanding switch; after delivery,
+// projectConfigForHiveID derives the ordinary heartbeat value from the stored
+// forge and host on every beat. Dropping the kind there classified every
+// GitLab/Gitea host as GHE and permanently re-pushed /api/v3.
+func TestProjectConfigAPIURLRespectsStoredKind(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	nonGitHub := []struct {
+		id, forge, host, reportedAPIURL string
+	}{
+		{"steady-gl", string(ForgeGitLab), "gitlab.example.com", "https://gitlab.example.com/api/v4"},
+		{"steady-gt", string(ForgeGitea), "gitea.example.com", "https://gitea.example.com/api/v1"},
+	}
+	for _, tc := range nonGitHub {
+		t.Run(tc.forge, func(t *testing.T) {
+			h := &SaaSHive{
+				ID: tc.id, Status: "running", Org: "o", Repos: []string{"r"},
+				PrimaryRepo: "r", ACMMLevel: 2, ACMMDelivered: true,
+				Forge: tc.forge, GitHubHost: tc.host,
+			}
+			if err := saveSaaSHive(h); err != nil {
+				t.Fatalf("save hive: %v", err)
+			}
+
+			// Force a project push so the wire value is observable. A non-GitHub
+			// forge has no hub-side API URL; in particular it must not get GHE's
+			// /api/v3 suffix alongside the unrelated project reconciliation.
+			got := projectConfigForHiveID(tc.id, "old", []string{"r"}, "r", 2, "", tc.reportedAPIURL)
+			if got == nil {
+				t.Fatal("project mismatch should produce a project config")
+			}
+			if got.GitHubAPIURL != "" {
+				t.Fatalf("GitHubAPIURL = %q, want empty for %s", got.GitHubAPIURL, tc.forge)
+			}
+
+			// Once the project is delivered, the reported adapter URL must
+			// converge: the hub has no API URL to push and returns no config.
+			h.ClaimDelivered = true
+			if err := saveSaaSHive(h); err != nil {
+				t.Fatalf("save delivered hive: %v", err)
+			}
+			if got := projectConfigForHiveID(tc.id, "o", []string{"r"}, "r", 2, "", tc.reportedAPIURL); got != nil {
+				t.Fatalf("matching steady-state heartbeat pushed again: %+v", got)
+			}
+		})
+	}
+
+	// Records predating SaaSHive.Forge still use the original host inference.
+	// A legacy enterprise host must therefore continue to receive /api/v3.
+	if err := saveSaaSHive(&SaaSHive{
+		ID: "steady-ghe-legacy", Status: "running", Org: "o", Repos: []string{"r"},
+		PrimaryRepo: "r", ACMMLevel: 2, ClaimDelivered: true, ACMMDelivered: true,
+		GitHubHost: "github.ibm.com",
+	}); err != nil {
+		t.Fatalf("save legacy GHE hive: %v", err)
+	}
+	got := projectConfigForHiveID("steady-ghe-legacy", "o", []string{"r"}, "r", 2, "", defaultPublicAPIURL)
+	if got == nil || got.GitHubAPIURL != "https://github.ibm.com"+gheAPIPathSuffix {
+		t.Fatalf("legacy GHE project config = %+v, want unchanged /api/v3 delivery", got)
 	}
 }

--- a/src/pkg/hub/ghe_forge_map_shape_test.go
+++ b/src/pkg/hub/ghe_forge_map_shape_test.go
@@ -143,8 +143,8 @@ func TestBackfillGitHubHostForgeMapShape(t *testing.T) {
 		t.Errorf("public pin backfill = %q, want empty — an explicit public pin must stay public", got)
 	}
 	// And the backfilled host must actually drive a GHE API URL on the heartbeat.
-	if got := gheAPIURLForHost(backfillGitHubHostFromCluster(&SaaSHive{}, cluster)); got != identGHEAPIURL {
-		t.Errorf("gheAPIURLForHost = %q, want %q", got, identGHEAPIURL)
+	if got := forgeAPIURLForHost("", backfillGitHubHostFromCluster(&SaaSHive{}, cluster)); got != identGHEAPIURL {
+		t.Errorf("forgeAPIURLForHost = %q, want %q", got, identGHEAPIURL)
 	}
 }
 

--- a/src/pkg/hub/github_host_assignment_test.go
+++ b/src/pkg/hub/github_host_assignment_test.go
@@ -110,7 +110,7 @@ func TestAssignmentGitHubHostPrecedence(t *testing.T) {
 				t.Errorf("GitHubHost = %q, want %q", h.GitHubHost, tc.wantHost)
 			}
 			// The host only matters because of what it makes the heartbeat push.
-			if got := gheAPIURLForHost(h.GitHubHost); got != tc.wantAPIURL {
+			if got := forgeAPIURLForHost("", h.GitHubHost); got != tc.wantAPIURL {
 				t.Errorf("pushed github_api_url = %q, want %q", got, tc.wantAPIURL)
 			}
 		})

--- a/src/pkg/hub/github_host_backfill_test.go
+++ b/src/pkg/hub/github_host_backfill_test.go
@@ -289,11 +289,11 @@ func TestBackfilledHostProducesGHEAPIURL(t *testing.T) {
 	host := backfillGitHubHostFromCluster(&SaaSHive{}, &ClusterConfig{
 		GitHubBaseURL: "https://github.ibm.com",
 	})
-	if got := gheAPIURLForHost(host); got != "https://github.ibm.com/api/v3" {
-		t.Errorf("gheAPIURLForHost(%q) = %q, want https://github.ibm.com/api/v3", host, got)
+	if got := forgeAPIURLForHost("", host); got != "https://github.ibm.com/api/v3" {
+		t.Errorf("forgeAPIURLForHost(%q) = %q, want https://github.ibm.com/api/v3", host, got)
 	}
 	// And a public hive must still push nothing.
-	if got := gheAPIURLForHost(backfillGitHubHostFromCluster(&SaaSHive{}, &ClusterConfig{})); got != "" {
+	if got := forgeAPIURLForHost("", backfillGitHubHostFromCluster(&SaaSHive{}, &ClusterConfig{})); got != "" {
 		t.Errorf("public hive pushed API URL %q, want empty", got)
 	}
 }

--- a/src/pkg/hub/lite_enrollment.go
+++ b/src/pkg/hub/lite_enrollment.go
@@ -334,7 +334,7 @@ func (s *HubServer) requestHostedLiteSpoke(username, owner, repo, host string, i
 	if host != "" && host != publicGitHubHost {
 		h.GitHubHost = host
 		h.GitHubBaseURL = "https://" + host
-		h.GitHubAPIURL = gheAPIURLForHost(host)
+		h.GitHubAPIURL = forgeAPIURLForHost("", host)
 	}
 	if err := saveSaaSHive(h); err != nil {
 		return nil, fmt.Errorf("save hosted lite spoke metadata: %w", err)

--- a/src/pkg/hub/request_forge_required_test.go
+++ b/src/pkg/hub/request_forge_required_test.go
@@ -254,10 +254,10 @@ func TestRequestForgeSurvivesToApprovedHive(t *testing.T) {
 
 	// And the host must actually change downstream behavior — that is the whole
 	// reason it has to be captured.
-	if api := gheAPIURLForHost(h.GitHubHost); api == "" {
+	if api := forgeAPIURLForHost("", h.GitHubHost); api == "" {
 		t.Errorf("a GHE host must yield a GHE API URL, got empty for %q", h.GitHubHost)
 	}
-	if gheAPIURLForHost("") != "" {
+	if forgeAPIURLForHost("", "") != "" {
 		t.Error("an empty host must yield no GHE API URL (public github.com default)")
 	}
 }

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3913,7 +3913,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	if host, org, reposFromOrg := normalizeProjectRef(req.Org); org != "" && (host != "" || len(reposFromOrg) > 0) {
 		if host != "" {
 			req.GitHubBaseURL = "https://" + host
-			req.GitHubAPIURL = gheAPIURLForHost(host)
+			req.GitHubAPIURL = forgeAPIURLForHost("", host)
 		}
 		req.Org = org
 		if len(reposFromOrg) > 0 {
@@ -3929,7 +3929,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 		host, org, reposFromShifted := normalizeProjectRef(req.Org + "/" + originalFirstRepo)
 		if host != "" && org != "" && strings.Contains(req.Org, ".") {
 			req.GitHubBaseURL = "https://" + host
-			req.GitHubAPIURL = gheAPIURLForHost(host)
+			req.GitHubAPIURL = forgeAPIURLForHost("", host)
 			req.Org = org
 			repos := replaceFirstCSV(req.Repos, strings.Join(reposFromShifted, "/"))
 			req.Repos = repos
@@ -8341,7 +8341,7 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		// An explicit "public" choice means public github.com. Record it as a
-		// blank host so gheAPIURLForHost pushes nothing and the spoke keeps its
+		// blank host so forgeAPIURLForHost pushes nothing and the spoke keeps its
 		// own api.github.com default — and so the cluster backfill below, which
 		// only ever fills a blank, does not silently re-GHE it.
 		if strings.EqualFold(host, githubHostPublic) {
@@ -8891,7 +8891,7 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	// Deliberately conservative: an empty curAPIURL means the spoke is too old
 	// to report its API URL, which is UNKNOWN, not a mismatch — pushing on it
 	// would re-send on every beat with no read-back to ever stop it.
-	wantAPIURL := gheAPIURLForHost(h.GitHubHost)
+	wantAPIURL := forgeAPIURLForHost(h.Forge, h.GitHubHost)
 	// The api_url is the field where unknown-vs-mismatch actually bites: a spoke
 	// too old to report it sends "", which is NOT "I am on api.github.com". The
 	// observedKnown argument carries that distinction explicitly instead of
@@ -8962,7 +8962,7 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 			if forgeAPIURL != "" {
 				return forgeAPIURL
 			}
-			return gheAPIURLForHost(h.GitHubHost)
+			return forgeAPIURLForHost(h.Forge, h.GitHubHost)
 		}(),
 		// AIAuthor is deliberately left empty here. Provisioning state never
 		// knows the agents' GitHub account — the spoke owns it — and the spoke
@@ -9152,7 +9152,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// right GitHub API. Never blank an existing value with an empty one.
 	//
 	// "public" is an explicit choice of public github.com on a cluster whose
-	// defaults point at GHE. Record it as a blank host (so gheAPIURLForHost
+	// defaults point at GHE. Record it as a blank host (so forgeAPIURLForHost
 	// pushes nothing and the spoke keeps api.github.com) PLUS the
 	// GitHubBaseURL sentinel, which is what makes effectiveGitHubBaseURL
 	// resolve to "" and therefore makes the cluster backfill below decline to
@@ -9171,7 +9171,7 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// the placeholder carries one. Placeholders provisioned BEFORE their
 	// cluster gained github_base_url/github_api_url have GitHubHost == "", and
 	// nothing else ever fills it in: projectConfigForHiveID pushes
-	// gheAPIURLForHost(h.GitHubHost), which is empty for those hives, so the
+	// forgeAPIURLForHost(h.Forge, h.GitHubHost), which is empty for those hives, so the
 	// spoke keeps api.github.com and the public app_id even though the cluster
 	// is a GHE cluster (observed on the heartbeat-only cluster: hosted-available-vllmd-01 has
 	// base_url: "" / api_url: "" against a github.ibm.com cluster). The hive's

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -903,7 +903,7 @@ func resolveProvisionAppID(reqAppID string, h *SaaSHive, cluster *ClusterConfig)
 // A hive's GitHubHost is otherwise only ever set from an explicitly pasted
 // org URL at assign time. Placeholders provisioned BEFORE their cluster gained
 // github_base_url/github_api_url therefore keep GitHubHost == "" forever, and
-// projectConfigForHiveID pushes gheAPIURLForHost("") == "" on every heartbeat
+// projectConfigForHiveID pushes forgeAPIURLForHost("", "") == "" on every heartbeat
 // — which the spoke reads as "leave mine alone". The result is a hive on a GHE
 // cluster still pointing at api.github.com with the public app_id (observed on
 // the heartbeat-only cluster: a hosted-available hive in org "katamari" has base_url: "",

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -4287,15 +4287,25 @@ func sanitizeRepoEntry(s string) string {
 	return strings.Join(parts, "/")
 }
 
-// gheAPIURLForHost turns a GitHub host into the API base URL the spoke should
-// use. GitHub Enterprise serves its v3 API at https://<host>/api/v3 — the
-// working reference is hosted-open-source-osscar, which runs against
-// github.ibm.com with exactly that value.
+// forgeAPIURLForHost turns a forge kind and host into the API base URL the
+// spoke should use. GitHub Enterprise serves its v3 API at
+// https://<host>/api/v3 — the working reference is hosted-open-source-osscar,
+// which runs against github.ibm.com with exactly that value.
+//
+// GitLab and Gitea deliberately return an empty URL. Their adapters own the
+// /api/v4 and /api/v1 suffixes respectively, so adding either suffix here would
+// duplicate the API-path contract. More importantly, treating either host as
+// GitHub Enterprise would aim the spoke at a nonexistent /api/v3 endpoint.
 //
 // Public github.com (and an empty host) return "", meaning "leave the spoke's
 // github.api_url alone" — its own default is already https://api.github.com,
-// and pushing a value here would overwrite a hand-tuned config.
-func gheAPIURLForHost(host string) string {
+// and pushing a value here would overwrite a hand-tuned config. An empty or
+// legacy kind retains the original host-based GitHub/GHE inference.
+func forgeAPIURLForHost(kind, host string) string {
+	switch ForgeKind(strings.ToLower(strings.TrimSpace(kind))) {
+	case ForgeGitLab, ForgeGitea:
+		return ""
+	}
 	host = strings.TrimSpace(strings.ToLower(host))
 	if host == "" || host == "github.com" || host == "api.github.com" {
 		return ""

--- a/src/pkg/hub/server_csv_sanitize_test.go
+++ b/src/pkg/hub/server_csv_sanitize_test.go
@@ -227,20 +227,22 @@ func TestIsAvailableRegistryEntry(t *testing.T) {
 	}
 }
 
-func TestGheAPIURLForHost(t *testing.T) {
+func TestForgeAPIURLForHost(t *testing.T) {
 	cases := []struct {
-		in, want string
+		kind, host, want string
 	}{
-		{"", ""},
-		{"github.com", ""},
-		{"GITHUB.COM", ""},
-		{"api.github.com", ""},
-		{"github.ibm.com", "https://github.ibm.com/api/v3"},
-		{"  GitHub.Enterprise.org  ", "https://github.enterprise.org/api/v3"},
+		{"", "", ""},
+		{"", "github.com", ""},
+		{"", "GITHUB.COM", ""},
+		{"", "api.github.com", ""},
+		{"", "github.ibm.com", "https://github.ibm.com/api/v3"},
+		{string(ForgeGitHubEnterprise), "  GitHub.Enterprise.org  ", "https://github.enterprise.org/api/v3"},
+		{string(ForgeGitLab), "gitlab.example.com", ""},
+		{string(ForgeGitea), "gitea.example.com", ""},
 	}
 	for _, tc := range cases {
-		if got := gheAPIURLForHost(tc.in); got != tc.want {
-			t.Errorf("gheAPIURLForHost(%q) = %q, want %q", tc.in, got, tc.want)
+		if got := forgeAPIURLForHost(tc.kind, tc.host); got != tc.want {
+			t.Errorf("forgeAPIURLForHost(%q, %q) = %q, want %q", tc.kind, tc.host, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`gheAPIURLForHost` inferred GitHub Enterprise from every non-`github.com` host and appended `/api/v3` without considering the hive's stored forge kind. The pending-switch handshake was corrected in #5341, but the steady-state heartbeat path still recomputed the URL from `GitHubHost` alone. A GitLab or Gitea hive would therefore receive a GitHub Enterprise URL on every heartbeat, and reconciliation could never converge on the adapter-owned API URL.

## Root cause

The helper accepted only a host. A hostname is insufficient to distinguish GitHub Enterprise from GitLab or Gitea, because all three can use an arbitrary well-formed non-public hostname. `projectConfigForHiveID` had the authoritative `SaaSHive.Forge` value available but discarded it in both the drift check and the emitted heartbeat payload.

## Implementation

- Replace `gheAPIURLForHost(host)` with `forgeAPIURLForHost(kind, host)`.
- Return an empty hub-side API URL for stored `gitlab` and `gitea` kinds.
- Pass `h.Forge` through both steady-state derivations in `projectConfigForHiveID`: the `needsPush` comparison and the final `HeartbeatProjectConfig` value.
- Preserve the original host-based GitHub/GHE inference for legacy records and create/lite enrollment paths that have no stored kind by passing an empty kind explicitly.
- Update existing helper callers and tests to make the fallback choice visible.

The empty non-GitHub URL is intentional. The GitLab and Gitea adapters own `/api/v4` and `/api/v1`; pre-appending either suffix in the hub would duplicate that API-path contract. This change also leaves `pendingForgeAPIURL` as the higher-priority value while a forge switch is outstanding.

## Regression coverage

`TestProjectConfigAPIURLRespectsStoredKind` exercises the steady-state path that #5341 did not cover. For both GitLab and Gitea it proves that:

- an unrelated project reconciliation carries an empty `GitHubAPIURL`, never `/api/v3`; and
- after the project is delivered, a heartbeat reporting the adapter URL produces no repeated push.

The same test verifies that a legacy enterprise record with no `Forge` field still receives the existing `/api/v3` URL. `TestForgeAPIURLForHost` additionally pins public GitHub, explicit GHE, GitLab, Gitea, case normalization, and empty-kind fallback behavior.

## Verification

From `src/`:

```text
env GOCACHE=/var/tmp/hive-5346-go-cache GOMODCACHE=/var/tmp/hive-5346-go-mod-cache GOTMPDIR=/var/tmp/hive-5346-go-build CCACHE_DIR=/var/tmp/hive-5346-ccache go test ./pkg/hub -run 'Test(ForgeAPIURLForHost|ProjectConfigAPIURLRespectsStoredKind|PendingForgeAPIURLRespectsStoredKind)$' -count=1
ok github.com/kubestellar/hive/pkg/hub 0.013s

env GOCACHE=/var/tmp/hive-5346-go-cache GOMODCACHE=/var/tmp/hive-5346-go-mod-cache GOTMPDIR=/var/tmp/hive-5346-go-build CCACHE_DIR=/var/tmp/hive-5346-ccache go test ./pkg/hub -count=1
ok github.com/kubestellar/hive/pkg/hub 89.989s
```

`git diff --check origin/v4...HEAD` is clean.

## Scope

This fixes URL derivation and heartbeat convergence only. It does not wire the currently display-only GitLab/Gitea forge selection into the spoke, construct adapters, or move their API path suffixes into the hub.

Fixes #5346

— hive: backend=claude model=codex-sol-5.6-high
