### PR TITLE
🐛 fix: repair renamed-agent CODEX_HOME by chowning in place, not os.RemoveAll

### DIFF
--- a/src/pkg/agent/codex_home_nfs_safety_test.go
+++ b/src/pkg/agent/codex_home_nfs_safety_test.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #5379 — NFS-safety structural pin
+// ---------------------------------------------------------------------------
+//
+// WHY THIS TEST IS STRUCTURAL RATHER THAN BEHAVIOURAL.
+//
+// The bug it guards is invisible to every filesystem CI can mount. The heal
+// used os.RemoveAll, which works perfectly on tmpfs, ext4, overlayfs and APFS
+// — so a behavioural unit test passed for months while the product stayed
+// broken. /data on hosted spokes is an NFSv3 PVC, and there os.RemoveAll
+// descends with openat-based directory file descriptors that fail
+// "openfdat ...: permission denied" even as root, leaving a renamed agent's
+// codex backend dead until someone shells into the pod.
+//
+// Reproducing that requires a real NFSv3 export, which this suite does not
+// have. Rather than write a test that merely proves the new code path runs
+// (the failure shape of #5360 and #5370), this pins the MECHANISM: the codex
+// home heal must reach the filesystem through an exec of chown/rm, never
+// through Go's own tree walkers. If a future refactor "simplifies" it back to
+// os.RemoveAll or filepath.WalkDir, this fails immediately and loudly instead
+// of shipping a silent regression that only hosted spokes discover.
+//
+// This test does not skip under any condition. See #5380.
+
+// codexHealMechanismFuncs are the declarations that perform, or decide on, the
+// filesystem repair of a wrong-owner CODEX_HOME.
+var codexHealMechanismFuncs = map[string]bool{
+	"healCodexHomeOwnership": true,
+	"chownCodexHomeToAgent":  true,
+	"chownTreeAsRoot":        true,
+	"removeTreeAsRoot":       true,
+	"healForeignCodexConfig": true,
+}
+
+// goTreeWalkers are Go stdlib calls that descend a directory tree using
+// openat-based directory file descriptors, which NFSv3 does not reliably
+// support. None of them may appear in the codex home heal.
+var goTreeWalkers = map[string]string{
+	"os.RemoveAll":     "descends with openat dirfds; fails on the NFSv3 /data PVC (#5379)",
+	"filepath.Walk":    "walks with openat dirfds; use an exec'd chown/rm instead (#5379)",
+	"filepath.WalkDir": "walks with openat dirfds; use an exec'd chown/rm instead (#5379)",
+	"os.ReadDir":       "opens a dirfd to enumerate; use an exec'd chown/rm instead (#5379)",
+	"ioutil.ReadDir":   "opens a dirfd to enumerate; use an exec'd chown/rm instead (#5379)",
+}
+
+// TestCodexHomeHealUsesNFSSafeMechanisms parses manager.go and asserts that no
+// function responsible for repairing a wrong-owner CODEX_HOME calls a Go
+// stdlib tree walker.
+func TestCodexHomeHealUsesNFSSafeMechanisms(t *testing.T) {
+	const src = "manager.go"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", src, err)
+	}
+
+	seen := map[string]bool{}
+	for _, decl := range file.Decls {
+		name, body := codexHealDeclBody(decl)
+		if body == nil || !codexHealMechanismFuncs[name] {
+			continue
+		}
+		seen[name] = true
+		ast.Inspect(body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			qualified, ok := qualifiedCallName(call.Fun)
+			if !ok {
+				return true
+			}
+			if why, banned := goTreeWalkers[qualified]; banned {
+				t.Errorf("%s calls %s at %s: %s\n"+
+					"The codex home heal must reach the filesystem via an exec'd "+
+					"chown/rm (su-exec), not a Go tree walk.",
+					name, qualified, fset.Position(call.Pos()), why)
+			}
+			return true
+		})
+	}
+
+	// Guard the guard: if a function is renamed away, this test would silently
+	// stop checking anything.
+	for name := range codexHealMechanismFuncs {
+		if !seen[name] {
+			t.Errorf("expected to find %s in %s — was it renamed? "+
+				"Update codexHealMechanismFuncs so this pin keeps covering the heal.", name, src)
+		}
+	}
+}
+
+// TestCodexHomeHealShellsOutToChownAndRm is the positive half of the pin: the
+// NFS-safe mechanisms must actually be exec'd, and the chown must use -h so it
+// re-owns the auth.json SYMLINK itself rather than following it into the
+// shared credential file.
+func TestCodexHomeHealShellsOutToChownAndRm(t *testing.T) {
+	const src = "manager.go"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", src, err)
+	}
+
+	var chownArgs, rmArgs []string
+	for _, decl := range file.Decls {
+		name, body := codexHealDeclBody(decl)
+		if body == nil {
+			continue
+		}
+		switch name {
+		case "chownTreeAsRoot":
+			chownArgs = execCommandStringArgs(body)
+		case "removeTreeAsRoot":
+			rmArgs = execCommandStringArgs(body)
+		}
+	}
+
+	if len(chownArgs) == 0 {
+		t.Fatal("chownTreeAsRoot must exec a command; found no exec.Command call")
+	}
+	if len(rmArgs) == 0 {
+		t.Fatal("removeTreeAsRoot must exec a command; found no exec.Command call")
+	}
+
+	joinedChown := strings.Join(chownArgs, " ")
+	if !strings.Contains(joinedChown, "su-exec") {
+		t.Errorf("chown must go through su-exec like the rest of setupCodexHome, got %q", joinedChown)
+	}
+	if !strings.Contains(joinedChown, "chown") {
+		t.Errorf("chownTreeAsRoot must exec chown, got %q", joinedChown)
+	}
+	// -h / --no-dereference: auth.json is a symlink to the SHARED credential
+	// file. Following it would rewrite ownership of every agent's login.
+	if !strings.Contains(joinedChown, "-Rh") && !strings.Contains(joinedChown, "--no-dereference") {
+		t.Errorf("chown must pass -h so it does not follow the shared auth.json symlink, got %q", joinedChown)
+	}
+	if !strings.Contains(joinedChown, "-R") {
+		t.Errorf("chown must be recursive to re-own the whole tree, got %q", joinedChown)
+	}
+
+	joinedRm := strings.Join(rmArgs, " ")
+	if !strings.Contains(joinedRm, "su-exec") {
+		t.Errorf("rm must go through su-exec like the rest of setupCodexHome, got %q", joinedRm)
+	}
+	if !strings.Contains(joinedRm, "rm") || !strings.Contains(joinedRm, "-rf") {
+		t.Errorf("removeTreeAsRoot must exec `rm -rf` (the mechanism verified on the affected NFS mount), got %q", joinedRm)
+	}
+}
+
+// codexHealDeclBody returns the name and body of a decl that is either a
+// func declaration or a `var name = func(...){...}` assignment.
+func codexHealDeclBody(decl ast.Decl) (string, ast.Node) {
+	switch d := decl.(type) {
+	case *ast.FuncDecl:
+		if d.Body == nil {
+			return "", nil
+		}
+		return d.Name.Name, d.Body
+	case *ast.GenDecl:
+		if d.Tok != token.VAR {
+			return "", nil
+		}
+		for _, spec := range d.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+				continue
+			}
+			lit, ok := vs.Values[0].(*ast.FuncLit)
+			if !ok {
+				continue
+			}
+			return vs.Names[0].Name, lit.Body
+		}
+	}
+	return "", nil
+}
+
+// qualifiedCallName renders a call target as "pkg.Func" for selector calls.
+func qualifiedCallName(fun ast.Expr) (string, bool) {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return ident.Name + "." + sel.Sel.Name, true
+}
+
+// execCommandStringArgs collects the string literal arguments of any
+// exec.Command call inside body.
+func execCommandStringArgs(body ast.Node) []string {
+	var args []string
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if name, ok := qualifiedCallName(call.Fun); !ok || name != "exec.Command" {
+			return true
+		}
+		for _, arg := range call.Args {
+			if lit, ok := arg.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				args = append(args, strings.Trim(lit.Value, `"`))
+			}
+		}
+		return true
+	})
+	return args
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -7420,11 +7420,21 @@ func (m *Manager) setupCodexHome(agent *AgentProcess) {
 // dir was written as dev/root and the agent EACCESes on it at startup — the
 // same failure class cavemanNpmCachePath removes foreign-owned caches for.
 //
+// The primary repair is an in-place `chown -R` to the agent UID (#5379): an
+// agent RENAME is the common trigger — the per-agent CODEX_HOME keeps the
+// PREVIOUS agent's owner — and a rename should not discard the lane's codex
+// state (cache/, .tmp/, history). Chowning also avoids walking the tree from
+// Go entirely, which matters because /data on hosted spokes is an NFSv3 PVC
+// where os.RemoveAll's openat-based descent fails with EACCES even as root.
+//
+// Only when the chown itself fails do we fall back to a rebuild, and that
+// rebuild shells out to `rm -rf` (via su-exec, the same idiom the rest of
+// setupCodexHome uses) rather than os.RemoveAll, for the same NFSv3 reason.
 // Hive never writes config.toml, so any content is operator-authored: the
-// heal salvages it when the manager can read it and returns the bytes for
-// setupCodexHome to write back as the agent after the re-mkdir. A dir that
-// cannot be rebuilt (root-owned, no write access) is left alone with an
-// Error log naming the owner and the manual fix.
+// rebuild path salvages it when the manager can read it and returns the bytes
+// for setupCodexHome to write back as the agent after the re-mkdir. A dir that
+// can be neither chowned nor removed is left alone with an Error log naming
+// the owner and the manual fix.
 func (m *Manager) healCodexHomeOwnership(agent *AgentProcess, dir, agentUser string) []byte {
 	owner := fileOwnerUID(dir)
 	if owner < 0 {
@@ -7434,10 +7444,20 @@ func (m *Manager) healCodexHomeOwnership(agent *AgentProcess, dir, agentUser str
 		return m.healForeignCodexConfig(agent, dir, agentUser)
 	}
 	// Codex's app-server requires the current UID to own CODEX_HOME itself,
-	// so a foreign-owned dir can only be rebuilt, not patched around.
+	// so a foreign-owned dir must be re-owned (preferred) or rebuilt.
+	chownErr := m.chownCodexHomeToAgent(agent, dir)
+	if chownErr == nil {
+		m.logger.Warn("re-owned codex home that was owned by the wrong UID (agent rename); codex state preserved", "agent", agent.Name, "dir", dir, "ownerUID", owner, "wantUID", agent.UID)
+		// healForeignCodexConfig is still the right follow-up: the recursive
+		// chown fixed every entry it could reach, but a config.toml that is a
+		// symlink or otherwise skipped stays foreign-owned, and that narrower
+		// heal removes it (salvaging content) so codex can read its config.
+		return m.healForeignCodexConfig(agent, dir, agentUser)
+	}
+	m.logger.Warn("could not chown codex home to the agent; falling back to rebuild", "agent", agent.Name, "dir", dir, "ownerUID", owner, "wantUID", agent.UID, "error", chownErr)
 	cfgPath := filepath.Join(dir, "config.toml")
 	salvaged, readErr := os.ReadFile(cfgPath)
-	if err := os.RemoveAll(dir); err != nil {
+	if err := removeTreeAsRoot(dir); err != nil {
 		m.logger.Error("codex home is owned by the wrong UID and could not be rebuilt; codex will fail until it is chowned or removed manually", "agent", agent.Name, "dir", dir, "ownerUID", owner, "wantUID", agent.UID, "error", err)
 		return nil
 	}
@@ -7446,6 +7466,56 @@ func (m *Manager) healCodexHomeOwnership(agent *AgentProcess, dir, agentUser str
 		return nil
 	}
 	return salvaged
+}
+
+// codexHomeChownUserSpec is the identity the recursive chown runs as. Only
+// root can give a directory away to another UID, and the manager runs as dev,
+// so this goes through the same SUID su-exec helper every other UID switch in
+// setupCodexHome uses (see the Dockerfile C6 note: su-exec is 4750
+// root:hive-launch, exec-able by dev but NOT by any agent UID).
+const codexHomeChownUserSpec = "root"
+
+// chownCodexHomeToAgent recursively gives CODEX_HOME to the agent UID.
+//
+// NFS SAFETY (#5379): this MUST shell out. /data on hosted spokes is NFSv3,
+// where Go's own tree walks (os.RemoveAll, filepath.WalkDir + os.Lchown) fail
+// mid-descent with "openfdat ...: permission denied" because openat-based
+// directory descriptors are not reliably supported there. `chown -R` in
+// coreutils does not use that access pattern and is verified working on the
+// affected mount. Do not "simplify" this back into a Go walk.
+//
+// -h chowns symlinks THEMSELVES rather than following them: auth.json is a
+// symlink into the SHARED credential file, which must keep its own ownership
+// and must never be rewritten through.
+func (m *Manager) chownCodexHomeToAgent(agent *AgentProcess, dir string) error {
+	return chownTreeAsRoot(dir, fmt.Sprintf("%d:%d", agent.UID, os.Getgid()))
+}
+
+// chownTreeAsRoot is a var, not a plain func, ONLY so tests can substitute a
+// harness that performs the same re-owning without the SUID helper (which
+// exists only inside the image). Production always uses the exec below.
+var chownTreeAsRoot = func(dir, spec string) error {
+	cmd := exec.Command("su-exec", codexHomeChownUserSpec, "chown", "-Rh", spec, dir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return outputErr(fmt.Sprintf("chown -Rh %s %s", spec, dir), err, output)
+	}
+	return nil
+}
+
+// removeTreeAsRoot deletes a tree the manager may not own.
+//
+// NFS SAFETY (#5379): os.RemoveAll CANNOT be used here. It descends with
+// openat-based directory file descriptors, which fail with EACCES on the
+// NFSv3-backed /data PVC even for root — the exact wedge that left a renamed
+// agent's codex backend dead for days. A shell `rm -rf` on the identical path
+// succeeds immediately. Keep this as an exec, not a Go walk.
+// It is a var for the same test-substitution reason as chownTreeAsRoot.
+var removeTreeAsRoot = func(dir string) error {
+	cmd := exec.Command("su-exec", codexHomeChownUserSpec, "rm", "-rf", dir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return outputErr(fmt.Sprintf("rm -rf %s", dir), err, output)
+	}
+	return nil
 }
 
 // healForeignCodexConfig handles the agent-owned-dir case: a config.toml

--- a/src/pkg/agent/manager3_coverage_test.go
+++ b/src/pkg/agent/manager3_coverage_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,13 +138,74 @@ func TestHealCodexHomeOwnership_AbsentDirNoOp(t *testing.T) {
 	}
 }
 
-// TestHealCodexHomeOwnership_ForeignDirRebuiltWithSalvage pins the wedge
-// this heal exists for: a CODEX_HOME owned by another identity survives on
-// /data across restarts and codex refuses to start. The heal must remove
-// the dir and hand back the operator-authored config.toml for the re-create
-// to restore. The test dir is owned by the test UID while the agent wants a
-// different UID, which is exactly the foreign-owner shape.
-func TestHealCodexHomeOwnership_ForeignDirRebuiltWithSalvage(t *testing.T) {
+// stubCodexHealMechanisms replaces the two root-privileged helpers for the
+// duration of a test. The real ones go through su-exec, which exists only
+// inside the hive image; substituting them lets the tests below exercise the
+// heal's DECISION logic (chown first, rebuild only on failure) on any host.
+// chownOK/removeOK select whether each mechanism succeeds. The returned
+// counters record how many times each was invoked.
+func stubCodexHealMechanisms(t *testing.T, chownOK, removeOK bool) (chownCalls, removeCalls *int) {
+	t.Helper()
+	origChown, origRemove := chownTreeAsRoot, removeTreeAsRoot
+	t.Cleanup(func() { chownTreeAsRoot, removeTreeAsRoot = origChown, origRemove })
+	chownCalls, removeCalls = new(int), new(int)
+	chownTreeAsRoot = func(dir, spec string) error {
+		*chownCalls++
+		if !chownOK {
+			return fmt.Errorf("stub: chown refused")
+		}
+		return nil // a real chown would re-own; ownership is not observable here
+	}
+	removeTreeAsRoot = func(dir string) error {
+		*removeCalls++
+		if !removeOK {
+			return fmt.Errorf("stub: rm refused")
+		}
+		return os.RemoveAll(dir) // local FS in tests; production shells out
+	}
+	return chownCalls, removeCalls
+}
+
+// TestHealCodexHomeOwnership_ForeignDirChownedNotRemoved is the #5379
+// regression test. A CODEX_HOME left owned by the PREVIOUS agent after a
+// rename must be re-owned IN PLACE — the lane's codex state (cache/, history)
+// must survive, and no removal may be attempted. Before the fix this path
+// called os.RemoveAll, which additionally cannot succeed on the NFSv3 /data
+// PVC at all.
+func TestHealCodexHomeOwnership_ForeignDirChownedNotRemoved(t *testing.T) {
+	chownCalls, removeCalls := stubCodexHealMechanisms(t, true, true)
+	m, agent := codexHealTestManager(t, os.Getuid()+12345)
+	dir := filepath.Join(t.TempDir(), "codex-cxa")
+	if err := os.MkdirAll(filepath.Join(dir, "cache"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const cfg = "model = \"gpt-5.1-codex\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.healCodexHomeOwnership(agent, dir, "hive-cxa"); got != nil {
+		t.Errorf("chown path preserves the dir, so nothing needs salvaging; got %q", got)
+	}
+	if *chownCalls != 1 {
+		t.Errorf("foreign-owned home must be chowned once, got %d calls", *chownCalls)
+	}
+	if *removeCalls != 0 {
+		t.Errorf("a successful chown must not fall back to removal, got %d calls", *removeCalls)
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "cache")); err != nil {
+		t.Errorf("codex state must survive the re-own, stat err=%v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "config.toml"))
+	if err != nil || string(content) != cfg {
+		t.Errorf("config.toml must survive the re-own in place, content=%q err=%v", content, err)
+	}
+}
+
+// TestHealCodexHomeOwnership_ChownFailureFallsBackToRebuild pins that the
+// rebuild is still reachable when the chown cannot run, and that it salvages
+// the operator-authored config.toml on the way out.
+func TestHealCodexHomeOwnership_ChownFailureFallsBackToRebuild(t *testing.T) {
+	chownCalls, removeCalls := stubCodexHealMechanisms(t, false, true)
 	m, agent := codexHealTestManager(t, os.Getuid()+12345)
 	dir := filepath.Join(t.TempDir(), "codex-cxa")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -157,8 +219,35 @@ func TestHealCodexHomeOwnership_ForeignDirRebuiltWithSalvage(t *testing.T) {
 	if string(got) != cfg {
 		t.Errorf("readable config.toml must be salvaged before the rebuild, got %q", got)
 	}
+	if *chownCalls != 1 || *removeCalls != 1 {
+		t.Errorf("expected one chown attempt then one removal, got chown=%d remove=%d", *chownCalls, *removeCalls)
+	}
 	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
-		t.Errorf("foreign-owned codex home must be removed, stat err=%v", err)
+		t.Errorf("fallback rebuild must remove the dir, stat err=%v", err)
+	}
+}
+
+// TestHealCodexHomeOwnership_BothMechanismsFailStaysLoud pins the constraint
+// that an unrepairable home keeps its loud ERROR and salvages nothing —
+// silence here would hide a dead agent.
+func TestHealCodexHomeOwnership_BothMechanismsFailStaysLoud(t *testing.T) {
+	chownCalls, removeCalls := stubCodexHealMechanisms(t, false, false)
+	m, agent := codexHealTestManager(t, os.Getuid()+12345)
+	dir := filepath.Join(t.TempDir(), "codex-cxa")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("x = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.healCodexHomeOwnership(agent, dir, "hive-cxa"); got != nil {
+		t.Errorf("an unrepairable home must salvage nothing, got %q", got)
+	}
+	if *chownCalls != 1 || *removeCalls != 1 {
+		t.Errorf("both mechanisms must be attempted, got chown=%d remove=%d", *chownCalls, *removeCalls)
+	}
+	if _, err := os.Lstat(dir); err != nil {
+		t.Errorf("an unrepairable home must be left alone for manual repair, stat err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`healCodexHomeOwnership` exists to repair a `CODEX_HOME` owned by the wrong UID. Its logic was correct; its **removal could not execute** on hosted spokes, so the agent it exists to rescue never started — dead for days on the reporting hive, retrying every ~40s:

```json
{"level":"ERROR","msg":"codex home is owned by the wrong UID and could not be rebuilt",
 "agent":"quality","dir":"/data/home/.codex-quality",
 "ownerUID":2006,"wantUID":2007,
 "error":"openfdat /data/home/.codex-quality/tmp/arg0: permission denied"}
```

`os.RemoveAll` walks a tree using **`openat`-based directory file descriptors** (the `openfdat` above). `/data` on hosted spokes is **NFSv3**, which does not reliably support that access pattern. This is **not** a permissions problem — on the affected spoke, as root against the offending `drwx------` dir: `ls` succeeded, `touch` inside it succeeded, and a shell `rm -rf` on the whole tree succeeded instantly. Only Go's `os.RemoveAll` failed.

The trigger is an **agent rename**: `.codex-quality` was owned by `hive-outreach` (2006) while the agent was `hive-quality` (2007). The per-agent `CODEX_HOME` kept the old owner.

## Fix — option 3 (chown in place)

The issue offered three options. This takes **option 3**, chowning the tree instead of removing it:

```go
su-exec root chown -Rh <uid>:<gid> <dir>
```

Reasoning: a rename should not discard the agent's codex state at all. Rebuilding salvages one file (`config.toml`) and destroys `cache/`, `.tmp/` and history. Chowning both preserves that state and **avoids the tree walk entirely**, which is the thing that breaks.

- `-R` re-owns the whole tree; `-h` chowns the **symlink itself** rather than following it — `auth.json` is a symlink into the shared credential file, which must keep its own ownership. Its contents are never read, copied, or logged.
- Runs via `su-exec`, the idiom the rest of `setupCodexHome` already uses (SUID `4750 root:hive-launch`, exec-able by `dev` but not by any agent UID). Only root can give a directory away to another UID.
- Per-agent UID isolation is preserved — the home ends up owned by **that** agent.
- Idempotent and cheap in the common case: the `owner == agent.UID` fast path is unchanged, so a correct home still costs one `Lstat`.
- Already-broken directories are repaired on the **first launch after upgrade**, which is exactly the affected population.

**Fallback retained.** When the chown cannot run, the rebuild still happens — but now via `su-exec root rm -rf` (option 1, the mechanism verified working on the affected mount) rather than `os.RemoveAll`. A home that can be neither chowned nor removed keeps its **loud ERROR** naming the owner and the manual fix; silence here would be worse than the bug.

### Does this subsume `healForeignCodexConfig`?

**No — they coexist, and that is deliberate.** It handles the narrower case where the *dir* is correctly owned but `config.toml` is foreign-owned; the recursive chown never reaches that case because it only runs when the *dir* owner is wrong. It is now also called **after** a successful chown: `chown -Rh` re-owns entries it can reach, but a `config.toml` that is itself a symlink is re-owned rather than followed, so it can stay foreign-owned. `healForeignCodexConfig` removes it (salvaging content) so codex can read its config.

## What the tests actually prove — and what they do not

**Read this section rather than assuming coverage.**

The bug is **invisible to every filesystem CI can mount**. `os.RemoveAll` works perfectly on tmpfs, ext4, overlayfs and APFS — a behavioural unit test passed for months while the product stayed broken on NFS. That is the failure shape of #5360 (asserting file *mode* rather than whether the reading user could open it) and #5370 (probing the published image rather than the PR build). I did not want to add a third.

So the primary test is a **structural pin** (`codex_home_nfs_safety_test.go`), which parses `manager.go` with `go/ast` and asserts that no function in the codex-home heal calls a Go stdlib tree walker (`os.RemoveAll`, `filepath.Walk`/`WalkDir`, `os.ReadDir`), and that the mechanisms *are* exec'd `su-exec chown -Rh` / `rm -rf`.

- **It genuinely fails on regression** — verified by reverting the call to `os.RemoveAll`, which produces: `healCodexHomeOwnership calls os.RemoveAll at manager.go:7460: descends with openat dirfds; fails on the NFSv3 /data PVC (#5379)`.
- It **guards the guard**: if a covered function is renamed away, the test fails rather than silently stopping checking.
- Per #5380, it **does not skip under any condition**.

Behavioural tests cover the decision logic — foreign dir is chowned and **not** removed with state surviving; chown failure falls back to rebuild with salvage; both failing stays loud and leaves the dir for manual repair. These substitute the two root-privileged helpers, since `su-exec` exists only inside the image.

### Remaining unverified

**The NFSv3 behaviour itself is not covered by any automated test in this PR, and cannot be without a real NFSv3 export in CI.** What is established: the operator confirmed on the affected spoke that shell `rm -rf` succeeds where `os.RemoveAll` fails, and that `chown` on that mount works. That `chown -Rh` specifically completes on a large NFSv3 codex home is inferred from `chown` not using the openat descent pattern — reasoned, not measured. The structural pin encodes that reasoning so it cannot be silently undone; it does not re-verify it.

Fixes #5379