### PR TITLE
🐛 fix(dashboard): correct openapi.json drift for /api/status, /api/tokens, /api/audit (#5077)

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -22,7 +22,12 @@ on:
   # so a red PR fails the check without also filing an issue.
   pull_request:
     branches: [v2, v4]
-    paths: ['src/**', '.github/workflows/v2-tests.yml']
+    # dashboard/openapi.json is in scope because the two guards that police it
+    # live under src/ (pkg/dashboard/openapi_route_parity_test.go and
+    # openapi_schema_parity_test.go) but the file they check does not. Without
+    # it a spec-only PR — the exact shape of the #5077 drift — would edit the
+    # published contract while running neither guard.
+    paths: ['src/**', 'dashboard/openapi.json', '.github/workflows/v2-tests.yml']
 
 permissions:
   contents: read

--- a/dashboard/openapi.json
+++ b/dashboard/openapi.json
@@ -103,7 +103,8 @@
                             "format": "date-time"
                           },
                           "user": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Actor identity. May be an opaque OIDC identity key rather than a human-readable name \u2014 see user_name."
                           },
                           "action": {
                             "type": "string"
@@ -113,8 +114,13 @@
                           },
                           "agent": {
                             "type": "string"
+                          },
+                          "user_name": {
+                            "type": "string",
+                            "description": "Hub-delivered display name, stamped at SERVE time only when `user` is an opaque OIDC identity key. The audit ring and the on-disk log keep the raw key, so history survives name changes. Absent when there is no display name to add."
                           }
-                        }
+                        },
+                        "description": "dashboard.AuditEntry (src/pkg/dashboard/audit.go)."
                       }
                     }
                   }
@@ -134,83 +140,367 @@
           "Status"
         ],
         "summary": "Overall hive status",
-        "description": "Returns the full hive status including governor state, agent details, repos, queue depth, and all metrics used by the dashboard.",
+        "description": "Returns the full hive status snapshot the dashboard renders from: governor state, agent runtime details, configured-agent inventory, repos, token rollups, health, budget and ACMM level. The response is dashboard.StatusPayload (src/pkg/dashboard/server.go). Before the first status build completes the handler returns {\"status\": \"initializing\"} instead. Only the fields TUI/API clients consume are enumerated below; StatusPayload carries more.",
         "responses": {
           "200": {
-            "description": "Current hive status",
+            "description": "Current hive status, or {\"status\": \"initializing\"} before the first status build.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "dashboard.StatusPayload.",
                   "properties": {
+                    "timestamp": {
+                      "type": "string"
+                    },
+                    "statusSeq": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "Monotonic publish sequence. Clients drop any payload whose seq is older than the last rendered one."
+                    },
+                    "statusInstance": {
+                      "type": "string",
+                      "description": "Identifies the server process that produced statusSeq; seqs restart at 1 on spoke restart, so a changed instance means reset the guard rather than drop."
+                    },
+                    "hiveId": {
+                      "type": "string"
+                    },
                     "governor": {
                       "type": "object",
+                      "description": "dashboard.FrontendGovernor (src/pkg/dashboard/server.go), built by buildGovernor (status_builder.go).",
                       "properties": {
+                        "active": {
+                          "type": "boolean",
+                          "description": "Hardcoded true whenever buildGovernor ran; false means the payload carried no governor section, not a stopped governor."
+                        },
                         "mode": {
                           "type": "string",
                           "enum": [
-                            "surge",
-                            "busy",
+                            "idle",
                             "quiet",
-                            "idle"
+                            "busy",
+                            "surge"
                           ],
-                          "description": "Current governor mode"
+                          "description": "Laddered governor mode, lowercased by buildGovernor."
                         },
-                        "queue": {
+                        "issues": {
                           "type": "integer",
-                          "description": "Actionable issue count"
+                          "description": "Actionable issue count the governor laddered on (governor.State.QueueIssues)."
                         },
-                        "budgetPct": {
-                          "type": "number",
-                          "description": "Token budget usage percentage"
+                        "prs": {
+                          "type": "integer",
+                          "description": "Actionable PR count the governor laddered on (governor.State.QueuePRs)."
+                        },
+                        "thresholds": {
+                          "type": "object",
+                          "description": "dashboard.FrontendThresholds: the EFFECTIVE ladder boundaries that produced mode, after per-repo scaling. Idle is absent by design \u2014 its threshold is always 0.",
+                          "properties": {
+                            "quiet": {
+                              "type": "integer"
+                            },
+                            "busy": {
+                              "type": "integer"
+                            },
+                            "surge": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "quiet",
+                            "busy",
+                            "surge"
+                          ]
+                        },
+                        "nextKick": {
+                          "type": "string",
+                          "description": "When the governor next evaluates, as a PRE-FORMATTED server-local display string (\"1/2 3:04 PM MST\"), NOT RFC 3339. Omitted when no evaluation interval is configured. The interval itself is only published by GET /api/config/governor as general_advanced.eval_interval_s."
                         }
-                      }
+                      },
+                      "required": [
+                        "active",
+                        "mode",
+                        "issues",
+                        "prs",
+                        "thresholds"
+                      ]
                     },
                     "agents": {
                       "type": "array",
                       "items": {
                         "type": "object",
+                        "description": "dashboard.FrontendAgent (src/pkg/dashboard/server.go). Only the commonly consumed fields are listed; the struct carries more.",
                         "properties": {
                           "name": {
                             "type": "string"
                           },
-                          "status": {
+                          "id": {
                             "type": "string"
                           },
-                          "model": {
+                          "displayName": {
                             "type": "string"
                           },
-                          "cli": {
+                          "role": {
+                            "type": "string"
+                          },
+                          "emoji": {
+                            "type": "string"
+                          },
+                          "session": {
+                            "type": "string",
+                            "description": "tmux session name."
+                          },
+                          "state": {
+                            "type": "string",
+                            "description": "Runtime state (e.g. \"running\", \"stopped\"). There is no `status` field on this object."
+                          },
+                          "busy": {
                             "type": "string"
                           },
                           "paused": {
                             "type": "boolean"
                           },
-                          "restarts": {
-                            "type": "integer"
+                          "pausedReason": {
+                            "type": "string"
+                          },
+                          "enabled": {
+                            "type": "boolean",
+                            "description": "Mirrors the CONFIG flag, not runtime state \u2014 the only thing distinguishing \"switched off on purpose\" from \"stopped because something broke\". Never omitted: false is meaningful."
+                          },
+                          "offByCadence": {
+                            "type": "boolean"
+                          },
+                          "needsLogin": {
+                            "type": "boolean"
+                          },
+                          "cli": {
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "string"
+                          },
+                          "cadence": {
+                            "type": "string"
+                          },
+                          "doing": {
+                            "type": "string"
                           },
                           "pinned": {
                             "type": "boolean"
+                          },
+                          "pinnedCli": {
+                            "type": "boolean"
+                          },
+                          "pinnedModel": {
+                            "type": "boolean"
+                          },
+                          "restarts": {
+                            "type": "integer"
+                          },
+                          "lastKick": {
+                            "type": "string",
+                            "description": "Pre-formatted server-local display string, not RFC 3339."
+                          },
+                          "nextKick": {
+                            "type": "string",
+                            "description": "Pre-formatted server-local display string, not RFC 3339."
+                          },
+                          "mode": {
+                            "type": "string"
+                          },
+                          "sandboxed": {
+                            "type": "boolean"
+                          },
+                          "onDemand": {
+                            "type": "boolean"
+                          },
+                          "proxyViolations": {
+                            "type": "integer"
+                          },
+                          "lastError": {
+                            "type": "string"
                           }
                         }
                       }
+                    },
+                    "configuredAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "dashboard.FrontendConfiguredAgent \u2014 secret-free config inventory covering agents with no runtime process (notably enabled: false)."
                     },
                     "repos": {
                       "type": "array",
                       "items": {
                         "type": "object",
+                        "description": "dashboard.FrontendRepo (src/pkg/dashboard/server.go).",
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Short repo name."
+                          },
+                          "full": {
+                            "type": "string",
+                            "description": "owner/name."
                           },
                           "issues": {
                             "type": "integer"
                           },
                           "prs": {
                             "type": "integer"
+                          },
+                          "actionableIssues": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            },
+                            "description": "Untyped in the Go source ([]any) \u2014 populated from forge issue records whose shape is not fixed by a Go struct."
+                          },
+                          "openPrs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            },
+                            "description": "Untyped in the Go source ([]any) \u2014 populated from forge PR records whose shape is not fixed by a Go struct."
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "full",
+                          "issues",
+                          "prs"
+                        ]
+                      }
+                    },
+                    "acmmLevel": {
+                      "type": "integer",
+                      "description": "Hive ACMM maturity level, 1-6. TOP-LEVEL, not nested under governor. 1 is also the fallback when nothing is configured \u2014 see acmmLevelConfigured to tell those apart."
+                    },
+                    "acmmLevelConfigured": {
+                      "type": "boolean",
+                      "description": "False means nobody chose a level and acmmLevel is the fallback."
+                    },
+                    "acmmPackAgents": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "tokens": {
+                      "type": "object",
+                      "description": "dashboard.FrontendTokens \u2014 the status-embedded token rollup (lookbackHours, sessions, totals, byAgent, byModel, byAgentModel). This is a DIFFERENT shape from GET /api/tokens, which returns tokens.AggregateSummary with snake_case keys."
+                    },
+                    "budget": {
+                      "type": "object",
+                      "description": "dashboard.FrontendBudget. Budget is top-level; there is no budgetPct under governor."
+                    },
+                    "beads": {
+                      "type": "object",
+                      "description": "dashboard.FrontendBeads: {workers, supervisor}."
+                    },
+                    "planning": {
+                      "type": "object",
+                      "description": "dashboard.FrontendPlanning."
+                    },
+                    "hold": {
+                      "type": "object",
+                      "description": "dashboard.FrontendHold."
+                    },
+                    "cadenceMatrix": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "dashboard.FrontendCadence entries."
+                    },
+                    "health": {
+                      "type": "object",
+                      "description": "Untyped in the Go source (map[string]any): repo-workflow health map."
+                    },
+                    "deepHealth": {
+                      "type": "object",
+                      "description": "Untyped in the Go source (map[string]any): the spoke's own deep health checks, the same ones reported hub-ward in the heartbeat."
+                    },
+                    "ghRateLimits": {
+                      "type": "object",
+                      "description": "Untyped in the Go source (map[string]any)."
+                    },
+                    "agentMetrics": {
+                      "type": "object",
+                      "description": "Untyped in the Go source (map[string]any)."
+                    },
+                    "issueToMerge": {
+                      "type": "object",
+                      "description": "Untyped in the Go source (map[string]any)."
+                    },
+                    "systemAlerts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "severity": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
                           }
                         }
                       }
+                    },
+                    "inferenceBackends": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "inference": {
+                            "type": "boolean"
+                          },
+                          "models": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "models_fallback": {
+                            "type": "boolean",
+                            "description": "True when models is NOT an authoritative census (static aliases, partial sweep, or env list standing in). Consumers must not diff against a fallback list."
+                          }
+                        }
+                      }
+                    },
+                    "platform": {
+                      "type": "object",
+                      "description": "dashboard.FrontendPlatform: {forge, mint, skills}."
+                    },
+                    "security": {
+                      "type": "object",
+                      "description": "dashboard.FrontendSecurity."
+                    },
+                    "githubAppRequired": {
+                      "type": "boolean"
+                    },
+                    "githubAppInstallURL": {
+                      "type": "string"
+                    },
+                    "githubAppInstallMissing": {
+                      "type": "boolean",
+                      "description": "CONFIG TRUTH independent of any auth probe: a real App is named but installation_id is 0."
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "initializing"
+                      ],
+                      "description": "Present ONLY in the pre-first-build response, which is the bare object {\"status\": \"initializing\"} with no other field set."
                     }
                   }
                 }
@@ -567,15 +857,261 @@
           "Tokens"
         ],
         "summary": "Token usage by agent and model",
-        "description": "Returns token consumption data broken down by agent and model.",
+        "description": "Returns tokens.AggregateSummary (src/pkg/tokens/collector.go) as served by dashboard.Server.handleTokens (src/pkg/dashboard/api.go). Keys are snake_case and differ from the camelCase `tokens` block embedded in GET /api/status. NO COST FIELD is returned \u2014 this endpoint reports token counts only; cost must be estimated by the caller or read from a cost endpoint. The handler has two degenerate responses: {\"status\": \"no_collector\"} when no token collector is wired, and {\"total_tokens\": 0, \"sessions\": []} when the collector has no summary yet.",
         "responses": {
           "200": {
-            "description": "Token usage data",
+            "description": "Aggregate token usage, or one of the two degenerate shapes (no_collector / empty summary).",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "description": "Token usage keyed by agent name, with model-level breakdowns"
+                  "description": "tokens.AggregateSummary, or one of the two degenerate handler responses described above.",
+                  "properties": {
+                    "total_tokens": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "total_input": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "total_output": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "total_cache_read": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "total_cache_create": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "total_messages": {
+                      "type": "integer"
+                    },
+                    "by_agent": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "description": "Agent name to total token count."
+                    },
+                    "by_model": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "description": "Model id to total token count."
+                    },
+                    "by_agent_detail": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "description": "tokens.AgentModelBucket.",
+                        "properties": {
+                          "input": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "output": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "cache_read": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "cache_create": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "messages": {
+                            "type": "integer"
+                          },
+                          "sessions": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "input",
+                          "output",
+                          "cache_read",
+                          "cache_create",
+                          "messages",
+                          "sessions"
+                        ]
+                      },
+                      "description": "Agent name to its full breakdown."
+                    },
+                    "by_model_detail": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "description": "tokens.AgentModelBucket.",
+                        "properties": {
+                          "input": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "output": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "cache_read": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "cache_create": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "messages": {
+                            "type": "integer"
+                          },
+                          "sessions": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "input",
+                          "output",
+                          "cache_read",
+                          "cache_create",
+                          "messages",
+                          "sessions"
+                        ]
+                      },
+                      "description": "Model id to its full breakdown."
+                    },
+                    "sessions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "tokens.SessionSummary.",
+                        "properties": {
+                          "session_id": {
+                            "type": "string"
+                          },
+                          "agent": {
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "string"
+                          },
+                          "input_tokens": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "output_tokens": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "cache_read": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "cache_create": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "total_tokens": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "messages": {
+                            "type": "integer"
+                          },
+                          "first_active": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "Unix milliseconds of the earliest event seen; omitted when undeterminable."
+                          },
+                          "last_active": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "Unix milliseconds of the latest event seen; omitted when undeterminable."
+                          },
+                          "backend": {
+                            "type": "string",
+                            "description": "Tool that produced the session (\"claude\", \"copilot\", \"bob\", \"inference\"). Empty/absent means an older flat-format session of unknown provenance, which must be treated as NOT time-resolved."
+                          },
+                          "usage": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "tokens.UsageEvent \u2014 one timestamped slice of a session's usage timeline.",
+                              "properties": {
+                                "ts_ms": {
+                                  "type": "integer",
+                                  "format": "int64",
+                                  "description": "Unix milliseconds. 0 means the source line carried no parseable timestamp; consumers must treat 0 as unknown time rather than sorting it first."
+                                },
+                                "model": {
+                                  "type": "string"
+                                },
+                                "coalesced": {
+                                  "type": "integer",
+                                  "description": "How many raw per-message events this entry represents. Omitted/absent for an untouched event; >1 for a coalesced bucket."
+                                },
+                                "input": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "output": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "cache_read": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "cache_create": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              },
+                              "required": [
+                                "ts_ms",
+                                "input",
+                                "output",
+                                "cache_read",
+                                "cache_create"
+                              ]
+                            },
+                            "description": "Per-message usage timeline, populated only by scanners that can observe the grain (currently claude). ADDITIVE: when present its sums equal the summed session fields exactly \u2014 use either, never add both. Absent on sessions restored from the persisted snapshot, which strips timelines."
+                          },
+                          "usage_coalesced": {
+                            "type": "integer",
+                            "description": "How many raw events were folded to keep usage bounded. Absent/0 means full per-message fidelity."
+                          }
+                        },
+                        "required": [
+                          "session_id",
+                          "agent",
+                          "model",
+                          "input_tokens",
+                          "output_tokens",
+                          "cache_read",
+                          "cache_create",
+                          "total_tokens",
+                          "messages"
+                        ]
+                      }
+                    },
+                    "session_count": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "no_collector"
+                      ],
+                      "description": "Present ONLY in the degenerate no-collector response, which is the bare object {\"status\": \"no_collector\"} with no other field set."
+                    }
+                  }
                 }
               }
             }

--- a/dashboard/openapi.json
+++ b/dashboard/openapi.json
@@ -653,7 +653,7 @@
           "History"
         ],
         "summary": "Sparkline history",
-        "description": "Returns ~120 downsampled status snapshots from the in-memory 12-hour rolling window (5s intervals). Used for sparkline charts.",
+        "description": "Returns the governor's evaluation history (governor.EvalSnapshot entries) for sparkline charts. When /data/sparkline-history.json exists its seeded entries are prepended to the live in-memory history.",
         "responses": {
           "200": {
             "description": "Array of status snapshots",
@@ -663,21 +663,110 @@
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "description": "governor.EvalSnapshot (src/pkg/governor/governor.go).",
                     "properties": {
                       "t": {
                         "type": "integer",
-                        "description": "Unix timestamp (ms)"
+                        "format": "int64",
+                        "description": "Unix timestamp (ms)."
                       },
                       "govMode": {
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                          "idle",
+                          "quiet",
+                          "busy",
+                          "surge"
+                        ],
+                        "description": "Governor mode at this evaluation."
                       },
-                      "queue": {
+                      "govIssues": {
+                        "type": "integer",
+                        "description": "Actionable issue count. There is no single `queue` field."
+                      },
+                      "govPrs": {
+                        "type": "integer",
+                        "description": "Actionable PR count."
+                      },
+                      "govTotal": {
+                        "type": "integer",
+                        "description": "Combined queue depth the governor laddered on."
+                      },
+                      "govHold": {
+                        "type": "integer",
+                        "description": "Items held back from the queue."
+                      },
+                      "govActive": {
+                        "type": "integer",
+                        "description": "Items actively being worked."
+                      },
+                      "sla_violations": {
                         "type": "integer"
                       },
-                      "budgetPct": {
-                        "type": "number"
+                      "agents_kicked": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Agents the governor kicked at this evaluation."
+                      },
+                      "actionableCount": {
+                        "type": "integer"
+                      },
+                      "openPrCount": {
+                        "type": "integer"
+                      },
+                      "mergeableCount": {
+                        "type": "integer"
+                      },
+                      "beadsWorkers": {
+                        "type": "integer"
+                      },
+                      "beadsSupervisor": {
+                        "type": "integer"
+                      },
+                      "repos": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "description": "governor.RepoSnapshot.",
+                          "properties": {
+                            "issues": {
+                              "type": "integer"
+                            },
+                            "prs": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "issues",
+                            "prs"
+                          ]
+                        },
+                        "description": "Per-repo queue split, keyed by owner/name."
+                      },
+                      "agentStats": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object"
+                        },
+                        "description": "Untyped in the Go source (map[string]map[string]any): per-agent stat bag whose inner keys are not fixed by a Go struct."
                       }
-                    }
+                    },
+                    "required": [
+                      "t",
+                      "govMode",
+                      "govIssues",
+                      "govPrs",
+                      "govTotal",
+                      "govHold",
+                      "govActive",
+                      "actionableCount",
+                      "openPrCount",
+                      "mergeableCount",
+                      "beadsWorkers",
+                      "beadsSupervisor"
+                    ]
                   }
                 }
               }
@@ -692,7 +781,7 @@
           "History"
         ],
         "summary": "Persistent trend data",
-        "description": "Returns downsampled persistent history for the given range. Used for trend sparklines and governor mode distribution.",
+        "description": "Returns the governor's evaluation history (governor.EvalSnapshot entries) filtered to a time window. `range=day|week` or `hours=N` selects the window; hours is clamped to 720 (30 days) and defaults to 24.",
         "parameters": [
           {
             "name": "range",
@@ -701,12 +790,21 @@
               "type": "string",
               "enum": [
                 "day",
-                "week",
-                "month"
-              ],
-              "default": "week"
+                "week"
+              ]
             },
-            "description": "Time range to query"
+            "description": "Window preset. \"day\" is 24h, \"week\" is 168h. Any other value (including an absent one) falls through to `hours`, defaulting to 24h. Takes precedence over `hours`."
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 720,
+              "default": 24
+            },
+            "description": "Window length in hours, used only when `range` is not \"day\" or \"week\". Values above 720 (30 days) are clamped; values at or below 0 become 24."
           }
         ],
         "responses": {
@@ -718,21 +816,110 @@
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "description": "governor.EvalSnapshot (src/pkg/governor/governor.go).",
                     "properties": {
                       "t": {
                         "type": "integer",
-                        "description": "Unix timestamp (ms)"
+                        "format": "int64",
+                        "description": "Unix timestamp (ms)."
                       },
                       "govMode": {
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                          "idle",
+                          "quiet",
+                          "busy",
+                          "surge"
+                        ],
+                        "description": "Governor mode at this evaluation."
                       },
-                      "queue": {
+                      "govIssues": {
+                        "type": "integer",
+                        "description": "Actionable issue count. There is no single `queue` field."
+                      },
+                      "govPrs": {
+                        "type": "integer",
+                        "description": "Actionable PR count."
+                      },
+                      "govTotal": {
+                        "type": "integer",
+                        "description": "Combined queue depth the governor laddered on."
+                      },
+                      "govHold": {
+                        "type": "integer",
+                        "description": "Items held back from the queue."
+                      },
+                      "govActive": {
+                        "type": "integer",
+                        "description": "Items actively being worked."
+                      },
+                      "sla_violations": {
                         "type": "integer"
                       },
-                      "budgetPct": {
-                        "type": "number"
+                      "agents_kicked": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Agents the governor kicked at this evaluation."
+                      },
+                      "actionableCount": {
+                        "type": "integer"
+                      },
+                      "openPrCount": {
+                        "type": "integer"
+                      },
+                      "mergeableCount": {
+                        "type": "integer"
+                      },
+                      "beadsWorkers": {
+                        "type": "integer"
+                      },
+                      "beadsSupervisor": {
+                        "type": "integer"
+                      },
+                      "repos": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "description": "governor.RepoSnapshot.",
+                          "properties": {
+                            "issues": {
+                              "type": "integer"
+                            },
+                            "prs": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "issues",
+                            "prs"
+                          ]
+                        },
+                        "description": "Per-repo queue split, keyed by owner/name."
+                      },
+                      "agentStats": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object"
+                        },
+                        "description": "Untyped in the Go source (map[string]map[string]any): per-agent stat bag whose inner keys are not fixed by a Go struct."
                       }
-                    }
+                    },
+                    "required": [
+                      "t",
+                      "govMode",
+                      "govIssues",
+                      "govPrs",
+                      "govTotal",
+                      "govHold",
+                      "govActive",
+                      "actionableCount",
+                      "openPrCount",
+                      "mergeableCount",
+                      "beadsWorkers",
+                      "beadsSupervisor"
+                    ]
                   }
                 }
               }

--- a/src/pkg/dashboard/openapi_schema_parity_test.go
+++ b/src/pkg/dashboard/openapi_schema_parity_test.go
@@ -1,0 +1,246 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/tokens"
+)
+
+// TestOpenAPISchemaFieldsExistOnGoTypes is the #5077 guard.
+//
+// TestOpenAPISpecCoversEveryRegisteredRoute (openapi_route_parity_test.go)
+// proves every registered route is DOCUMENTED. It says nothing about whether
+// what the documentation claims is TRUE. That blind spot is exactly how #5077
+// happened: /api/status's governor object was published as
+// {mode, queue, budgetPct} while the server has always sent
+// dashboard.FrontendGovernor {active, mode, issues, prs, thresholds, nextKick}.
+// Both `queue` and `budgetPct` were pure invention, the route guard was green
+// throughout, and three TUI client tasks carried an acceptance criterion
+// ("mirror the spec, do not invent fields") that mirroring the spec could not
+// satisfy.
+//
+// This guard closes the direction that actually bit: a spec property that
+// corresponds to NO field on the Go type the handler marshals. It is
+// deliberately one-directional. Requiring the converse — every Go field
+// documented — would fail immediately and permanently on StatusPayload, which
+// carries far more fields than any client consumes and which this spec has
+// never attempted to enumerate exhaustively. A guard that cannot be made green
+// gets deleted or blanket-skipped, and then it protects nothing; a guard that
+// only forbids INVENTION is one that can hold.
+//
+// Nested objects are checked recursively wherever the spec descends into
+// `properties`, so FrontendThresholds and tokens.SessionSummary are covered
+// through their parents. A spec object that stops at `type: object` with no
+// properties (the honest way to say "untyped map[string]any") is skipped, as
+// there is nothing to verify.
+func TestOpenAPISchemaFieldsExistOnGoTypes(t *testing.T) {
+	// Each case pins one documented response schema to the Go value the
+	// handler actually passes to jsonResponse. Adding an endpoint here is the
+	// cheapest possible way to extend this guard's reach.
+	cases := []struct {
+		name string
+		path string
+		// goType is the type the handler marshals for the 200 response.
+		goType reflect.Type
+		// degenerate lists spec properties that belong to an alternative
+		// response shape the handler emits instead of goType (never alongside
+		// it), so they legitimately have no field on goType. Each entry must
+		// name the handler branch that produces it.
+		degenerate map[string]string
+	}{
+		{
+			name:   "GET /api/status",
+			path:   "/api/status",
+			goType: reflect.TypeOf(StatusPayload{}),
+			degenerate: map[string]string{
+				"status": "handleStatus returns the bare object {\"status\":\"initializing\"} " +
+					"before the first status build completes, instead of a StatusPayload.",
+			},
+		},
+		{
+			name:   "GET /api/tokens",
+			path:   "/api/tokens",
+			goType: reflect.TypeOf(tokens.AggregateSummary{}),
+			degenerate: map[string]string{
+				"status": "handleTokens returns the bare object {\"status\":\"no_collector\"} " +
+					"when no token collector is wired, instead of an AggregateSummary.",
+			},
+		},
+		{
+			name:   "GET /api/audit entries[]",
+			path:   "/api/audit",
+			goType: reflect.TypeOf(AuditEntry{}),
+		},
+	}
+
+	raw, err := os.ReadFile(openAPISpecPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", openAPISpecPath, err)
+	}
+	var doc struct {
+		Paths map[string]map[string]struct {
+			Responses map[string]struct {
+				Content map[string]struct {
+					Schema map[string]any `json:"schema"`
+				} `json:"content"`
+			} `json:"responses"`
+		} `json:"paths"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parsing %s: %v", openAPISpecPath, err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op, ok := doc.Paths[tc.path]["get"]
+			if !ok {
+				t.Fatalf("%s documents no GET %s; this guard's case list has gone stale",
+					openAPISpecPath, tc.path)
+			}
+			schema := op.Responses["200"].Content["application/json"].Schema
+			if len(schema) == 0 {
+				t.Fatalf("GET %s has no application/json 200 schema to check", tc.path)
+			}
+			// /api/audit's rows are the thing typed by AuditEntry; descend to
+			// them rather than checking the {entries: [...]} envelope, which
+			// has no Go struct of its own (handleAuditLog builds it inline).
+			if tc.path == "/api/audit" {
+				entries, ok := schema["properties"].(map[string]any)["entries"].(map[string]any)
+				if !ok {
+					t.Fatalf("GET /api/audit 200 schema has no `entries` property")
+				}
+				schema, ok = entries["items"].(map[string]any)
+				if !ok {
+					t.Fatalf("GET /api/audit `entries` has no `items` schema")
+				}
+			}
+
+			var problems []string
+			checkSchemaAgainstType(t, schema, tc.goType, tc.path, tc.degenerate, &problems)
+			if len(problems) > 0 {
+				sort.Strings(problems)
+				t.Fatalf("%s documents field(s) that do not exist on the Go type the handler "+
+					"marshals — the #5077 defect class (%d problem(s)):\n  %s",
+					openAPISpecPath, len(problems), strings.Join(problems, "\n  "))
+			}
+		})
+	}
+}
+
+// checkSchemaAgainstType walks a spec object schema alongside the Go type it
+// claims to describe, recording every documented property with no
+// corresponding JSON-marshalled field. where is a human-readable breadcrumb
+// used only in failure messages.
+func checkSchemaAgainstType(t *testing.T, schema map[string]any, goType reflect.Type,
+	where string, degenerate map[string]string, problems *[]string) {
+	t.Helper()
+
+	for goType.Kind() == reflect.Pointer {
+		goType = goType.Elem()
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		// An object documented without properties is the honest way to
+		// describe a map[string]any / genuinely dynamic payload. Nothing to
+		// verify, and demanding properties here would push authors toward
+		// inventing a shape — the very thing this guard exists to prevent.
+		return
+	}
+	if goType.Kind() != reflect.Struct {
+		// e.g. the spec descends into an object where Go has map[string]any.
+		// The keys are data, not fields; not checkable.
+		return
+	}
+
+	fields := jsonFieldsOfStruct(goType)
+	for name, sub := range props {
+		field, known := fields[name]
+		if !known {
+			if _, excused := degenerate[name]; excused {
+				continue
+			}
+			*problems = append(*problems, where+"."+name+" is documented but "+
+				goType.String()+" marshals no such key — remove it, correct the name, or "+
+				"(if it belongs to an alternative response shape the handler emits) declare "+
+				"it in the case's degenerate map with the handler branch that produces it")
+			continue
+		}
+		subSchema, ok := sub.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Descend through arrays to the item schema so []SessionSummary and
+		// friends are checked against their element type.
+		fieldType := field
+		itemSchema := subSchema
+		for itemSchema["type"] == "array" {
+			next, ok := itemSchema["items"].(map[string]any)
+			if !ok {
+				break
+			}
+			itemSchema = next
+			for fieldType.Kind() == reflect.Pointer {
+				fieldType = fieldType.Elem()
+			}
+			if fieldType.Kind() != reflect.Slice && fieldType.Kind() != reflect.Array {
+				break
+			}
+			fieldType = fieldType.Elem()
+		}
+		// additionalProperties describes a map's VALUE type; descend into it
+		// so by_agent_detail's bucket schema is checked against
+		// tokens.AgentModelBucket.
+		if ap, ok := itemSchema["additionalProperties"].(map[string]any); ok {
+			ft := fieldType
+			for ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Map {
+				checkSchemaAgainstType(t, ap, ft.Elem(), where+"."+name+"[*]", nil, problems)
+			}
+			continue
+		}
+		checkSchemaAgainstType(t, itemSchema, fieldType, where+"."+name, nil, problems)
+	}
+}
+
+// jsonFieldsOfStruct maps the JSON key each exported field of goType marshals
+// to, to that field's type — resolving embedded structs the same way
+// encoding/json promotes them.
+func jsonFieldsOfStruct(goType reflect.Type) map[string]reflect.Type {
+	out := make(map[string]reflect.Type)
+	for i := 0; i < goType.NumField(); i++ {
+		f := goType.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if f.Anonymous && name == "" {
+			// Embedded without a tag: encoding/json promotes its fields.
+			et := f.Type
+			for et.Kind() == reflect.Pointer {
+				et = et.Elem()
+			}
+			if et.Kind() == reflect.Struct {
+				for k, v := range jsonFieldsOfStruct(et) {
+					out[k] = v
+				}
+			}
+			continue
+		}
+		if !f.IsExported() {
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+		out[name] = f.Type
+	}
+	return out
+}

--- a/src/pkg/dashboard/openapi_schema_parity_test.go
+++ b/src/pkg/dashboard/openapi_schema_parity_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubestellar/hive/pkg/governor"
 	"github.com/kubestellar/hive/pkg/tokens"
 )
 
@@ -76,6 +77,20 @@ func TestOpenAPISchemaFieldsExistOnGoTypes(t *testing.T) {
 			path:   "/api/audit",
 			goType: reflect.TypeOf(AuditEntry{}),
 		},
+		// /api/history and /api/trends both serve Governor.EvalHistory(), so
+		// both are arrays of the same element type. They carried the identical
+		// invented queue/budgetPct pair that #5077 reported under
+		// /api/status.governor.
+		{
+			name:   "GET /api/history",
+			path:   "/api/history",
+			goType: reflect.TypeOf([]governor.EvalSnapshot{}),
+		},
+		{
+			name:   "GET /api/trends",
+			path:   "/api/trends",
+			goType: reflect.TypeOf([]governor.EvalSnapshot{}),
+		},
 	}
 
 	raw, err := os.ReadFile(openAPISpecPath)
@@ -140,6 +155,12 @@ func checkSchemaAgainstType(t *testing.T, schema map[string]any, goType reflect.
 	where string, degenerate map[string]string, problems *[]string) {
 	t.Helper()
 
+	// Unwrap array schemas to their item schema, stepping the Go type down to
+	// its element in lockstep. Applies at the top level too, so an endpoint
+	// whose whole 200 response is an array (e.g. /api/history) is checked
+	// against its element type without a special case in the table.
+	schema, goType = unwrapArrays(schema, goType)
+
 	for goType.Kind() == reflect.Pointer {
 		goType = goType.Elem()
 	}
@@ -176,22 +197,7 @@ func checkSchemaAgainstType(t *testing.T, schema map[string]any, goType reflect.
 		}
 		// Descend through arrays to the item schema so []SessionSummary and
 		// friends are checked against their element type.
-		fieldType := field
-		itemSchema := subSchema
-		for itemSchema["type"] == "array" {
-			next, ok := itemSchema["items"].(map[string]any)
-			if !ok {
-				break
-			}
-			itemSchema = next
-			for fieldType.Kind() == reflect.Pointer {
-				fieldType = fieldType.Elem()
-			}
-			if fieldType.Kind() != reflect.Slice && fieldType.Kind() != reflect.Array {
-				break
-			}
-			fieldType = fieldType.Elem()
-		}
+		itemSchema, fieldType := unwrapArrays(subSchema, field)
 		// additionalProperties describes a map's VALUE type; descend into it
 		// so by_agent_detail's bucket schema is checked against
 		// tokens.AgentModelBucket.
@@ -207,6 +213,28 @@ func checkSchemaAgainstType(t *testing.T, schema map[string]any, goType reflect.
 		}
 		checkSchemaAgainstType(t, itemSchema, fieldType, where+"."+name, nil, problems)
 	}
+}
+
+// unwrapArrays steps a schema and its Go type down through matched array/slice
+// levels together, returning the innermost pair. It stops as soon as either
+// side stops being an array, so a mismatch is simply left unchecked rather
+// than reported as a phantom field problem.
+func unwrapArrays(schema map[string]any, goType reflect.Type) (map[string]any, reflect.Type) {
+	for schema["type"] == "array" {
+		next, ok := schema["items"].(map[string]any)
+		if !ok {
+			break
+		}
+		t := goType
+		for t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+		if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
+			break
+		}
+		schema, goType = next, t.Elem()
+	}
+	return schema, goType
 }
 
 // jsonFieldsOfStruct maps the JSON key each exported field of goType marshals


### PR DESCRIPTION
Fixes #5077

## What was wrong

`dashboard/openapi.json` published response shapes the server has never sent. Every field in this PR is transcribed from the Go type the handler actually marshals on current `v4` — nothing is invented, and genuinely dynamic payloads are documented as untyped rather than given a guessed shape.

**1. `/api/status` governor schema (defect 1).** Spec said `governor: {mode, queue, budgetPct}`. The server sends `dashboard.FrontendGovernor` (`src/pkg/dashboard/server.go`, built by `buildGovernor` in `status_builder.go`):

```
{active, mode, issues, prs, thresholds{quiet,busy,surge}, nextKick}
```

There is no `queue` — queue depth arrives split as `issues`/`prs`. There is no `budgetPct` — budget is a separate top-level object. A client that mirrored the spec decoded zeroes forever.

While in there, three further `/api/status` inaccuracies, same defect class and same evidence standard:
- `agents[].status` does not exist. `FrontendAgent` marshals `state`.
- `acmmLevel` is **top-level** on `StatusPayload`, not nested under `governor`.
- `nextKick` / `lastKick` are pre-formatted **server-local display strings** (`"1/2 3:04 PM MST"`), not RFC 3339 — a consumer cannot parse them back into an instant. The evaluation interval is only published by `GET /api/config/governor` as `general_advanced.eval_interval_s`.

Also added the `statusSeq`/`statusInstance` ordering-guard fields and the pre-first-build `{"status": "initializing"}` response, which `handleStatus` returns instead of a `StatusPayload`.

**2. `/api/tokens` was untyped (defect 2).** The 200 response was `{"type": "object", "description": "..."}` with no properties, so the "match the spec schema exactly" criterion was unsatisfiable — there was no schema to match. Now documents the real `tokens.AggregateSummary` (`src/pkg/tokens/collector.go`), returned directly by `handleTokens`, down through `SessionSummary`, `AgentModelBucket` and the `UsageEvent` timeline. Recorded explicitly:
- keys are **snake_case** and differ from the camelCase `tokens` block embedded in `/api/status` (`FrontendTokens`) — two different shapes for related data, easy to conflate;
- there is **no cost field**; the endpoint reports token counts only;
- the handler's two degenerate responses (`{"status":"no_collector"}` and `{"total_tokens":0,"sessions":[]}`).

**3. `/api/events` (defect 3) — no change, and that is the finding.** The spec already correctly describes it as `text/event-stream`. The mischaracterization was in the *task text* of #5059, not in the spec, so there is nothing here to fix.

**Bonus, found while verifying the clients:** `/api/audit` entries carry `user_name` (`dashboard.AuditEntry`), stamped at serve time when `user` is an opaque OIDC identity key. It was undocumented. Dropping it would expose an opaque identity where the web dashboard shows a person.

## The shipped TUI clients are correct — they did not mirror the bad spec

The original issue framed this as blocking #5055/#5057/#5059. Those are all closed and shipped, so I checked whether they had encoded the wrong shapes. **They had not.** Each client transcribed from the Go types instead and documented the spec gap in-code, citing this issue:

- `src/pkg/tui/client/governor.go` — `GovernorState` mirrors `FrontendGovernor` field-for-field, with a `SOURCE OF TRUTH, AND A SPEC GAP` comment stating the spec's `{mode, queue, budgetPct}` is wrong and referencing #5077.
- `src/pkg/tui/client/tokens.go` — `TokenUsage` mirrors `AggregateSummary`, notes the untyped spec entry, and explicitly declines to invent a cost field.
- `src/pkg/tui/client/events.go` — targets `GET /api/audit`, not `/api/events`, and explains why. It is also where the undocumented `user_name` was already noticed.

So no client bug to report. This PR makes the published spec agree with what those clients (correctly) built against, which retires the in-code caveats' underlying cause.

## Drift guard

The existing `TestOpenAPISpecCoversEveryRegisteredRoute` proves every route is **documented** but never checks whether the documentation is **true** — which is exactly how this drift survived. That is the same "guard fails green" shape as #5360/#5370/#5380.

Second commit adds `TestOpenAPISchemaFieldsExistOnGoTypes`: every property a documented response schema declares must correspond to a JSON key the Go type the handler marshals actually emits. Nested objects, array item schemas, and map value schemas (`additionalProperties`) are walked recursively, so `SessionSummary` and `AgentModelBucket` are covered through their parents.

It is **deliberately one-directional**. Requiring the converse — every Go field documented — would fail immediately and permanently on `StatusPayload`, which carries far more fields than any client consumes and which this spec has never tried to enumerate exhaustively. A guard that cannot be made green gets deleted or blanket-skipped, and then it protects nothing. Forbidding *invention* is the half that both bites and holds.

**Verified it actually fails.** Reintroducing the original defect — restoring `queue`/`budgetPct` under `governor`, plus a nested `cost_usd` on a session object — fails with each offending path named:

```
/api/status.governor.queue is documented but dashboard.FrontendGovernor marshals no such key
/api/status.governor.budgetPct is documented but dashboard.FrontendGovernor marshals no such key
/api/tokens.sessions.cost_usd is documented but tokens.SessionSummary marshals no such key
```

Covers `/api/status`, `/api/tokens` and `/api/audit`; extending it to another endpoint is one entry in the case table.

## The guard immediately found the same bug on two more endpoints

Adding the schema check and pointing it at the rest of the spec found the identical invented pair on `/api/history` and `/api/trends`. Both serve `Governor.EvalHistory()` — arrays of `governor.EvalSnapshot` — and both documented items as `{t, govMode, queue, budgetPct}`. `EvalSnapshot` has neither: queue depth is published split as `govIssues`/`govPrs` with a `govTotal` alongside, and there is no budget figure at all.

Same invented pair, same wrong assumption, three endpoints. That is the argument for the guard rather than a one-off correction — the third commit fixes these and adds both to the case table, verified failing by reintroducing `queue` on each.

Also corrected `/api/trends`' `range` parameter, wrong in a way a client would act on: the enum advertised `month` and defaulted to `week`, but `handleTrends` only special-cases `day` and `week` — `month` falls through to the default branch and silently yields 24h, not 30 days. Documented the real behaviour plus the previously undocumented `hours` parameter and its 720-hour clamp.

## Notes for reviewers

- An object documented as `type: object` with no `properties` is the honest way to describe a `map[string]any` (`health`, `deepHealth`, `ghRateLimits`, `agentMetrics`, `issueToMerge`, and `FrontendRepo`'s `[]any` lists). The guard skips those rather than pushing an author toward inventing a shape — the very thing it exists to prevent.
- No server behaviour changed. The server is ground truth throughout; only the spec moved.
- The wave-4 `/api/inference/models/{backend}` instance reported in the issue comments was already fixed by #5153 (merged), so it is not re-touched here.
- Fourth commit closes a related hole: both guards live under `src/`, but `dashboard/openapi.json` does not, and `v2-tests.yml`'s `pull_request` trigger filters on `src/**`. A spec-only PR therefore ran neither guard — openapi.json being the one file where a wrong edit is invisible to every other check. It is now in that path filter.

