### PR TITLE
🐛 fix(inference): litellm route falls back to the explicit gateway endpoint

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3373,6 +3373,23 @@ func main() {
 						endpoint = litellmLocalProxyURL()
 					}
 					if endpoint == "" {
+						// A hive configured ONLY through the Model Gateways tab
+						// (an explicit gateway named "litellm") leaves the
+						// legacy governor.litellm block empty. The key and CA
+						// bundle below already resolve from that gateway — the
+						// endpoint must too, or NO route is ever installed and
+						// every agent call dies "502 no inference route" while
+						// the Gateways tab Test button (which uses the gateway)
+						// happily passes (ains-validation/pocketmini,
+						// 2026-08-31).
+						if gw := cfg.Governor.ResolveGateway(backend); gw != nil && gw.Endpoint != "" {
+							endpoint = gw.Endpoint
+							if model == "" {
+								model = gw.DefaultModel
+							}
+						}
+					}
+					if endpoint == "" {
 						logger.Warn("litellm backend selected but no endpoint configured",
 							"agent", agentName, "model", model)
 						return


### PR DESCRIPTION
## Problem (user-reported: 'Test pass, it loads all the models' but agents get 502)

A hive whose LiteLLM is configured ONLY via the **Model Gateways tab** (an explicit `gateways:` entry named `litellm`, endpoint+key set) never gets inference routes installed: the `backend == "litellm"` branch resolves the API key (`ResolveLiteLLMInferenceKey`) and CA bundle from that gateway, but the **endpoint** from the legacy `governor.litellm` block — which is empty in this shape. Result: `litellm backend selected but no endpoint configured` → early return → `p.inference.Get(agent)` is nil → every agent request answers **502 "no inference route for agent"** and dashboard kicks fail with "Unexpected token '<'" (HTML error page). Meanwhile the Gateways tab **Test** button uses the gateway directly and happily lists 30 models — maximally confusing.

Observed live on ains-validation/pocketmini (vllmd-260731-fbo1), 2026-08-31; reported in Slack by the hive's user.

## Fix

When the legacy endpoint resolves empty, fall back to `ResolveGateway(backend).Endpoint` (and its `DefaultModel` when no model was given) — exactly mirroring the existing key/CA-bundle resolution. LocalProxy override order unchanged; no-gateway hives keep legacy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)