### PR TITLE
fix(hub): drain contributor WebSockets with 1012 on SIGTERM

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -1246,17 +1246,23 @@ func main() {
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	// preShutdownHook, when set, runs in the signal handler before the context
-	// is canceled. It is stored after the agent manager exists and archives
-	// every agent's in-flight kick log to /data so a pod roll or hive upgrade
-	// does not destroy the latest run's scrollback (#4296).
-	var preShutdownHook atomic.Pointer[func()]
+	// preShutdownHooks run in the signal handler before the context is canceled,
+	// in registration order, while every connection and tmux server is still
+	// live. Registrations happen later in startup, once the subsystems they
+	// touch exist.
+	//
+	// This was a single atomic.Pointer[func()] until kubestellar/hive#5390. A
+	// lone pointer makes registration DESTRUCTIVE: the second Store silently
+	// discards the first hook, and the loss is invisible — nothing fails, a
+	// shutdown side effect simply stops happening. That is precisely the trap
+	// the WebSocket drain walked into, since the slot was already held by
+	// #4296's kick-log archive. A slice makes adding a hook additive by
+	// construction, so the next one cannot repeat the mistake.
+	var preShutdownHooks shutdownHooks
 	go func() {
 		sig := <-sigCh
 		logger.Info("received signal, shutting down", "signal", sig)
-		if fn := preShutdownHook.Load(); fn != nil {
-			(*fn)()
-		}
+		preShutdownHooks.run()
 		cancel()
 	}()
 
@@ -1552,7 +1558,7 @@ func main() {
 	// SIGTERM (pod roll, hive upgrade) destroys every tmux server and with it
 	// the in-flight kick's scrollback; archive it to /data first (#4296).
 	archiveOnShutdown := func() { agentMgr.ArchiveAllKickLogs("shutdown") }
-	preShutdownHook.Store(&archiveOnShutdown)
+	preShutdownHooks.add("archive-kick-logs", archiveOnShutdown)
 	agentMgr.SetSandboxConfig(cfg.AgentSandbox)
 
 	// Say out loud when the sandbox opt-in is configured but inert. The gate is
@@ -1905,6 +1911,24 @@ func main() {
 	}
 
 	dashSrv := dashboard.NewServerWithAuth(cfg.Dashboard.Port, cfg.Dashboard.AuthToken, logger)
+	// SIGTERM (pod roll, hive self-upgrade) kills the process and every
+	// contributor WebSocket with it, and until #5390 it did so without a word:
+	// the peer saw a bare 1006, indistinguishable from a network fault, which is
+	// what made #5090 take days to diagnose. Send each contributor a 1012
+	// (CloseServiceRestart) first so the relay knows to reconnect immediately —
+	// into the replacement pod, which maxSurge=1/maxUnavailable=0 has already
+	// brought to readiness before this signal was delivered.
+	//
+	// Registered as its OWN hook rather than folded into archiveOnShutdown: the
+	// two are unrelated, and the drain must not be able to prevent the archive
+	// from running. addUrgent, not add, because it is the time-critical half —
+	// the sooner the frame is on the wire the sooner the relay reconnects,
+	// whereas the kick-log archive does PVC I/O on NFS and nobody is waiting on
+	// it. The hub is resolved lazily inside the closure because the contributor
+	// hub is not constructed until registerContributeRoutes runs, below.
+	preShutdownHooks.addUrgent("drain-contributor-websockets", func() {
+		dashSrv.DrainContributorsForShutdown()
+	})
 	var beadStores map[string]*beads.Store
 
 	// Wire ioscan input enforcement (opt-in via ioscan.enabled) to the dashboard

--- a/src/cmd/hive/shutdown_hooks.go
+++ b/src/cmd/hive/shutdown_hooks.go
@@ -1,0 +1,95 @@
+package main
+
+import "sync"
+
+// shutdownHooks is the ordered set of functions the signal handler runs before
+// the root context is canceled — while every WebSocket, tmux server and PVC
+// mount is still live.
+//
+// WHY A SLICE (kubestellar/hive#5390). This began as a single
+// atomic.Pointer[func()]. One pointer means one hook, and registration is
+// therefore DESTRUCTIVE: whoever calls Store second silently discards whatever
+// was there first. Nothing errors, no test fails, a shutdown side effect just
+// stops happening. #4296's kick-log archive already held the slot, so adding
+// the contributor-socket drain to it would have quietly deleted the archive on
+// every pod roll — invisible, and only discovered when someone went looking for
+// scrollback that was no longer being written. Appending cannot do that.
+//
+// Hooks run SERIALLY in registration order, on the signal goroutine, and each
+// is responsible for bounding its own work: this type imposes no timeout,
+// because a shared budget here would silently truncate a later hook when an
+// earlier one ran long. The whole sequence is racing
+// terminationGracePeriodSeconds (30s), so a hook that can block against a
+// remote peer must carry its own deadline — see wsDrainBudget.
+//
+// A panic in one hook must not cost the others theirs: the sequence is
+// best-effort cleanup on a process that is exiting regardless, so a hook that
+// blows up is contained and the rest still run.
+type shutdownHooks struct {
+	mu    sync.Mutex
+	hooks []namedShutdownHook
+}
+
+type namedShutdownHook struct {
+	name string
+	fn   func()
+}
+
+// add registers a hook to run at shutdown. The name is used only for panic
+// reporting. A nil fn is ignored so a caller need not guard an optional
+// subsystem at the registration site.
+func (s *shutdownHooks) add(name string, fn func()) {
+	if fn == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hooks = append(s.hooks, namedShutdownHook{name: name, fn: fn})
+}
+
+// addUrgent registers a hook to run BEFORE every hook registered so far.
+//
+// Registration order in main() is dictated by construction order — a hook
+// cannot be registered before the subsystem it touches exists — and that has
+// nothing to do with what should run first at shutdown. The contributor drain
+// is constructed late (the dashboard server comes ~350 lines after the agent
+// manager) but is the time-critical hook: it puts a Close frame on the wire
+// that a relay is waiting on, while the kick-log archive it would otherwise
+// queue behind does PVC I/O on NFS with nobody waiting. This lets a late
+// registration still take the front of the queue.
+func (s *shutdownHooks) addUrgent(name string, fn func()) {
+	if fn == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hooks = append([]namedShutdownHook{{name: name, fn: fn}}, s.hooks...)
+}
+
+// run executes every registered hook in registration order. It is safe to call
+// on a zero value and with no hooks registered.
+func (s *shutdownHooks) run() {
+	s.mu.Lock()
+	hooks := make([]namedShutdownHook, len(s.hooks))
+	copy(hooks, s.hooks)
+	s.mu.Unlock()
+
+	for _, h := range hooks {
+		runShutdownHook(h)
+	}
+}
+
+// runShutdownHook isolates one hook's panic so a later hook still runs.
+func runShutdownHook(h namedShutdownHook) {
+	defer func() {
+		_ = recover()
+	}()
+	h.fn()
+}
+
+// len reports how many hooks are registered. Test-facing.
+func (s *shutdownHooks) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.hooks)
+}

--- a/src/cmd/hive/shutdown_hooks_test.go
+++ b/src/cmd/hive/shutdown_hooks_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestShutdownHooksRunsBothArchiveAndDrain is the regression guard for the trap
+// kubestellar/hive#5390 walked into.
+//
+// The pre-shutdown slot used to be a single atomic.Pointer[func()]. Storing a
+// second hook SILENTLY discarded the first — no error, no failing test, a
+// shutdown side effect simply stopped happening. Since #4296's kick-log archive
+// already held that slot, adding the contributor drain to it would have deleted
+// the archive on every pod roll, invisibly.
+//
+// This asserts the OBSERVABLE consequence: after registering both, running the
+// sequence produces both effects.
+func TestShutdownHooksRunsBothArchiveAndDrain(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		archived bool
+		drained  bool
+	)
+
+	var hooks shutdownHooks
+	hooks.add("archive-kick-logs", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		archived = true
+	})
+	hooks.addUrgent("drain-contributor-websockets", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		drained = true
+	})
+
+	if got := hooks.count(); got != 2 {
+		t.Fatalf("registered hook count = %d, want 2 — a hook was overwritten "+
+			"rather than appended", got)
+	}
+
+	hooks.run()
+
+	mu.Lock()
+	if !archived {
+		t.Error("ArchiveAllKickLogs equivalent did NOT run — registering the " +
+			"WebSocket drain destroyed the #4296 kick-log archive")
+	}
+	if !drained {
+		t.Error("contributor drain did NOT run")
+	}
+	archived, drained = false, false
+	mu.Unlock()
+
+	// Same assertion with BOTH registered via add(), so the guard does not
+	// depend on addUrgent's prepend happening to survive a destructive add.
+	var plain shutdownHooks
+	plain.add("archive-kick-logs", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		archived = true
+	})
+	plain.add("drain-contributor-websockets", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		drained = true
+	})
+	if got := plain.count(); got != 2 {
+		t.Fatalf("add() is destructive: count = %d after two registrations, want 2", got)
+	}
+	plain.run()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !archived || !drained {
+		t.Errorf("add()-registered hooks did not both run (archived=%v drained=%v) — "+
+			"the second registration discarded the first", archived, drained)
+	}
+}
+
+// TestShutdownHooksAddUrgentRunsFirst pins the ordering the drain depends on.
+// The drain is registered later than the archive (the dashboard server is
+// constructed after the agent manager) but must run first: it puts a close
+// frame on a wire a relay is waiting on, while the archive does PVC I/O on NFS
+// that nobody is waiting on.
+func TestShutdownHooksAddUrgentRunsFirst(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		order []string
+	)
+	record := func(name string) func() {
+		return func() {
+			mu.Lock()
+			defer mu.Unlock()
+			order = append(order, name)
+		}
+	}
+
+	var hooks shutdownHooks
+	hooks.add("archive", record("archive"))
+	hooks.add("other", record("other"))
+	hooks.addUrgent("drain", record("drain"))
+
+	hooks.run()
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"drain", "archive", "other"}
+	if strings.Join(order, ",") != strings.Join(want, ",") {
+		t.Errorf("hook order = %v, want %v", order, want)
+	}
+}
+
+// TestShutdownHooksPanicDoesNotSkipRemaining pins that one failing hook cannot
+// cost the others theirs. A panic inside the drain must not prevent the
+// kick-log archive from running, and vice versa.
+func TestShutdownHooksPanicDoesNotSkipRemaining(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		ranAll []string
+	)
+
+	var hooks shutdownHooks
+	hooks.add("boom", func() { panic("hook exploded") })
+	hooks.add("archive", func() {
+		mu.Lock()
+		defer mu.Unlock()
+		ranAll = append(ranAll, "archive")
+	})
+
+	// Must not propagate the panic out of run().
+	hooks.run()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(ranAll) != 1 || ranAll[0] != "archive" {
+		t.Errorf("hooks after a panicking hook did not run: %v", ranAll)
+	}
+}
+
+// TestShutdownHooksZeroValueAndNilAreSafe covers the signal handler firing
+// before anything registered — a SIGTERM during early startup.
+func TestShutdownHooksZeroValueAndNilAreSafe(t *testing.T) {
+	var hooks shutdownHooks
+	hooks.run() // must not panic
+	hooks.add("nil-fn", nil)
+	hooks.addUrgent("nil-urgent", nil)
+	if got := hooks.count(); got != 0 {
+		t.Errorf("nil hooks were registered: count = %d, want 0", got)
+	}
+	hooks.run()
+}
+
+// TestMainRegistersBothPreShutdownHooks is a STRUCTURAL guard on the wiring in
+// main.go, which the unit tests above cannot reach: main() is a 2000-line
+// function that stands up the whole process and cannot be invoked from a test.
+//
+// It pins three things that a future edit could silently undo:
+//  1. both hooks are still registered,
+//  2. the mechanism is still additive (no atomic.Pointer Store on the slot),
+//  3. the drain still runs BEFORE cancel() in the signal handler, while the
+//     connections are still live.
+//
+// It is deliberately narrow — it does not attempt to verify runtime behaviour
+// from source text.
+func TestMainRegistersBothPreShutdownHooks(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	body := string(src)
+
+	for _, want := range []string{
+		`preShutdownHooks.add("archive-kick-logs"`,
+		`preShutdownHooks.addUrgent("drain-contributor-websockets"`,
+		`DrainContributorsForShutdown()`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("main.go no longer contains %q — a pre-shutdown hook was dropped", want)
+		}
+	}
+
+	// The destructive single-slot mechanism must not come back.
+	if regexp.MustCompile(`preShutdownHook\b.*\.Store\(`).MatchString(body) {
+		t.Error("main.go stores into a single-slot preShutdownHook again — that " +
+			"mechanism silently discards previously registered hooks (#5390)")
+	}
+
+	// Ordering: hooks must run before cancel() in the signal goroutine.
+	runIdx := strings.Index(body, "preShutdownHooks.run()")
+	if runIdx < 0 {
+		t.Fatal("signal handler no longer runs the pre-shutdown hooks")
+	}
+	cancelIdx := strings.Index(body[runIdx:], "cancel()")
+	if cancelIdx < 0 {
+		t.Fatal("could not locate cancel() after the hook run in the signal handler")
+	}
+	// Guard against the two being reordered: anything between them must be short.
+	if between := body[runIdx : runIdx+cancelIdx]; strings.Count(between, "\n") > 3 {
+		t.Errorf("cancel() is no longer immediately after preShutdownHooks.run(); "+
+			"the drain must run while connections are still live. Between them:\n%s", between)
+	}
+}

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -5580,3 +5580,101 @@ func closeWithReason(conn *websocket.Conn, code int, reason string) {
 	)
 	_ = conn.Close()
 }
+
+// wsDrainReason is the close reason every contributor socket receives when the
+// hub process is shutting down. It is a fixed string rather than a formatted
+// one so a relay may match on it verbatim.
+const wsDrainReason = "hub restarting for upgrade"
+
+// wsDrainBudget bounds the ENTIRE shutdown drain, not one socket.
+//
+// closeWithReason writes a Close frame with a wsCloseFrameDeadline (1s) write
+// deadline, so a peer that has stopped reading can stall a single close for up
+// to a second. Against the maxWSConnections cap of 50 a serial drain is a 50s
+// worst case — longer than terminationGracePeriodSeconds (30s), which would
+// mean the drain itself delays the exit past the point where SIGKILL lands and
+// the archive hook that follows it never runs. The budget makes that
+// impossible: whatever has not been closed when it expires is abandoned, and
+// the sockets left behind are exactly as dead as they are today.
+const wsDrainBudget = 2 * time.Second
+
+// DrainForShutdown tells every registered contributor WHY the socket is about
+// to die (kubestellar/hive#5390).
+//
+// THE DEFECT: the hub process is killed on every upgrade roll — measured at 11
+// ReplicaSets in 5.5 hours on one hosted spoke, one per merge to v4 — and it
+// has no shutdown handling for contributor WebSockets at all. The sockets die
+// with the process at SIGKILL, so the peer observes a bare 1006 with no reason,
+// byte-for-byte identical to a yanked cable. #5107 made DELIBERATE closes
+// legible; process death was not one of them, which is why the hub provably
+// sends Close frames and yet every flap observed in #5090 was frameless.
+//
+// CloseServiceRestart (1012) is defined as "the server is restarting" and
+// carries the client expectation of reconnecting, which is exactly true here:
+// the deployment is maxSurge=1/maxUnavailable=0, so the replacement pod has
+// already passed its readiness probe by the time the old one gets SIGTERM.
+//
+// This does NOT stop the flap — the pod still rolls, the socket still dies.
+// What changes is that the relay learns immediately and reconnects into an
+// already-serving hub, instead of discovering the corpse by read error or
+// missed pong seconds later.
+//
+// Locking follows cleanupLoop exactly: snapshot the sockets under h.mu, then
+// close OUTSIDE it. Closing under the lock would hold the hub-wide mutex for up
+// to wsCloseFrameDeadline per wedged peer, serially. Connections are NOT
+// deleted from the map — the process is about to exit, and leaving the
+// bookkeeping untouched keeps this off the lease/cooldown accounting held under
+// #5151.
+//
+// Returns the number of sockets a Close frame was attempted on, for the
+// shutdown log line.
+func (h *ContributeWSHub) DrainForShutdown() int {
+	if h == nil {
+		return 0
+	}
+
+	var conns []*websocket.Conn
+	h.mu.RLock()
+	for _, c := range h.connections {
+		// Nil-guard mirrors cleanupLoop: a registered connection may carry no live
+		// socket (test-injected in-flight entry, or one torn down elsewhere).
+		if c != nil && c.ws != nil {
+			conns = append(conns, c.ws)
+		}
+	}
+	h.mu.RUnlock()
+
+	if len(conns) == 0 {
+		return 0
+	}
+
+	// Fire-and-forget. A WebSocket Close is not a handshake we need to complete
+	// server-side, and waiting for acknowledgements would put a peer's silence on
+	// the shutdown path's critical section.
+	deadline := time.Now().Add(wsDrainBudget)
+	drained := 0
+	for _, ws := range conns {
+		if !time.Now().Before(deadline) {
+			break
+		}
+		closeWithReason(ws, websocket.CloseServiceRestart, wsDrainReason)
+		drained++
+	}
+
+	if h.logger != nil {
+		h.logger.Info("[contribute-ws] drained contributor sockets for shutdown",
+			"drained", drained, "registered", len(conns))
+	}
+	return drained
+}
+
+// DrainContributorsForShutdown is the Server-level entry point for the
+// pre-shutdown drain. It exists so cmd/hive can reach the contributor hub
+// without the hub itself being exported plumbing, and is a no-op on a Server
+// whose contribute routes were never registered.
+func (s *Server) DrainContributorsForShutdown() int {
+	if s == nil || s.contributeHub == nil {
+		return 0
+	}
+	return s.contributeHub.DrainForShutdown()
+}

--- a/src/pkg/dashboard/contribute_ws_shutdown_drain_test.go
+++ b/src/pkg/dashboard/contribute_ws_shutdown_drain_test.go
@@ -1,0 +1,356 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// These tests assert OBSERVABLE behaviour: that a real Close frame with code
+// 1012 and the reason string actually arrives on a real socket. They do not
+// assert that a function was called (kubestellar/hive#5388 — four "guard fails
+// green" incidents in one week came from exactly that shortcut).
+//
+// WHAT THEY CANNOT COVER, stated plainly: none of this exercises a real pod
+// roll. There is no kubelet here, no SIGTERM delivery, no
+// terminationGracePeriodSeconds, and no rolling-update surge. The drain is
+// invoked directly. That the hook is WIRED to SIGTERM in cmd/hive is covered
+// separately and structurally in shutdown_hooks_test.go; that a real roll
+// produces a 1012 at the relay can only be confirmed by observing a live
+// upgrade on a hosted spoke.
+
+// drainTestPeer is one end-to-end contributor socket: a real HTTP server that
+// upgrades, the server-side *websocket.Conn the hub would hold, and the client
+// side the "relay" reads close frames from.
+type drainTestPeer struct {
+	server   *httptest.Server
+	clientWS *websocket.Conn
+	serverWS *websocket.Conn
+}
+
+func (p *drainTestPeer) Close() {
+	if p.clientWS != nil {
+		_ = p.clientWS.Close()
+	}
+	if p.serverWS != nil {
+		_ = p.serverWS.Close()
+	}
+	if p.server != nil {
+		p.server.Close()
+	}
+}
+
+// newDrainTestPeer stands up a genuine WebSocket pair. Nothing is mocked: the
+// close frame under test travels over a real TCP connection.
+func newDrainTestPeer(t *testing.T) *drainTestPeer {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(*http.Request) bool { return true },
+	}
+
+	var (
+		mu       sync.Mutex
+		serverWS *websocket.Conn
+		ready    = make(chan struct{})
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		mu.Lock()
+		serverWS = conn
+		mu.Unlock()
+		close(ready)
+		// Hold the handler open; the hub owns this conn for the rest of the test.
+		<-r.Context().Done()
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial: %v", err)
+	}
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		_ = client.Close()
+		srv.Close()
+		t.Fatal("server side of the websocket never became ready")
+	}
+
+	mu.Lock()
+	sws := serverWS
+	mu.Unlock()
+
+	peer := &drainTestPeer{server: srv, clientWS: client, serverWS: sws}
+	t.Cleanup(peer.Close)
+	return peer
+}
+
+// observedClose is what the client end actually saw.
+type observedClose struct {
+	code   int
+	reason string
+	err    error
+}
+
+// awaitClose reads on the client socket until the peer closes it, and reports
+// the close code and reason the CLIENT observed — which is the only thing the
+// relay ever gets to see.
+func awaitClose(ws *websocket.Conn, within time.Duration) observedClose {
+	_ = ws.SetReadDeadline(time.Now().Add(within))
+	for {
+		if _, _, err := ws.ReadMessage(); err != nil {
+			if ce, ok := err.(*websocket.CloseError); ok {
+				return observedClose{code: ce.Code, reason: ce.Text}
+			}
+			return observedClose{code: -1, err: err}
+		}
+	}
+}
+
+func drainTestHub(conns map[string]*ContributorConnection) *ContributeWSHub {
+	return &ContributeWSHub{
+		connections: conns,
+		logger:      slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestDrainForShutdownWritesServiceRestartCloseFrame is the core assertion: a
+// real relay on the other end of a real socket receives close code 1012 with
+// the upgrade reason, not a bare 1006.
+func TestDrainForShutdownWritesServiceRestartCloseFrame(t *testing.T) {
+	peer := newDrainTestPeer(t)
+
+	hub := drainTestHub(map[string]*ContributorConnection{
+		"conn-1": {ws: peer.serverWS, profile: &ContributorProfile{GitHubUsername: "alice"}},
+	})
+
+	if n := hub.DrainForShutdown(); n != 1 {
+		t.Fatalf("DrainForShutdown() = %d, want 1", n)
+	}
+
+	got := awaitClose(peer.clientWS, 5*time.Second)
+	if got.err != nil {
+		t.Fatalf("client did not observe a websocket close frame: %v", got.err)
+	}
+	if got.code != websocket.CloseServiceRestart {
+		t.Errorf("close code = %d, want %d (CloseServiceRestart/1012)", got.code, websocket.CloseServiceRestart)
+	}
+	if got.code == websocket.CloseAbnormalClosure {
+		t.Error("client saw 1006 — the frameless close this issue exists to eliminate")
+	}
+	if got.reason != wsDrainReason {
+		t.Errorf("close reason = %q, want %q", got.reason, wsDrainReason)
+	}
+}
+
+// TestDrainForShutdownClosesEveryConnection pins that the drain walks the WHOLE
+// map — a drain that closed only the first socket would still pass a
+// single-connection test.
+func TestDrainForShutdownClosesEveryConnection(t *testing.T) {
+	const peerCount = 3
+
+	peers := make([]*drainTestPeer, 0, peerCount)
+	conns := make(map[string]*ContributorConnection, peerCount)
+	for i := 0; i < peerCount; i++ {
+		p := newDrainTestPeer(t)
+		peers = append(peers, p)
+		conns[string(rune('a'+i))] = &ContributorConnection{
+			ws:      p.serverWS,
+			profile: &ContributorProfile{GitHubUsername: "user" + string(rune('a'+i))},
+		}
+	}
+
+	hub := drainTestHub(conns)
+	if n := hub.DrainForShutdown(); n != peerCount {
+		t.Fatalf("DrainForShutdown() = %d, want %d", n, peerCount)
+	}
+
+	for i, p := range peers {
+		got := awaitClose(p.clientWS, 5*time.Second)
+		if got.err != nil {
+			t.Errorf("peer %d observed no close frame: %v", i, got.err)
+			continue
+		}
+		if got.code != websocket.CloseServiceRestart || got.reason != wsDrainReason {
+			t.Errorf("peer %d: close = (%d, %q), want (%d, %q)",
+				i, got.code, got.reason, websocket.CloseServiceRestart, wsDrainReason)
+		}
+	}
+}
+
+// TestDrainForShutdownIsBounded pins the design constraint that the drain
+// cannot stall shutdown. It does NOT assert a precise duration — that would be
+// a flaky wall-clock test — it asserts the budget is enforced as an upper
+// bound with generous headroom for CI.
+func TestDrainForShutdownIsBounded(t *testing.T) {
+	// Sockets whose peer has vanished: the close-frame write can block against
+	// wsCloseFrameDeadline, which is the stall this budget exists to bound.
+	conns := make(map[string]*ContributorConnection, maxWSConnections)
+	for i := 0; i < maxWSConnections; i++ {
+		p := newDrainTestPeer(t)
+		// Kill the client end without a handshake so the server-side write has no
+		// reader.
+		_ = p.clientWS.UnderlyingConn().Close()
+		conns[string(rune('A'+i%26))+string(rune('a'+i/26))] = &ContributorConnection{ws: p.serverWS}
+	}
+
+	hub := drainTestHub(conns)
+
+	start := time.Now()
+	hub.DrainForShutdown()
+	elapsed := time.Since(start)
+
+	// The budget is 2s. Allow one in-flight close to overrun by a full
+	// wsCloseFrameDeadline past the deadline check, plus CI slack.
+	limit := wsDrainBudget + wsCloseFrameDeadline + 3*time.Second
+	if elapsed > limit {
+		t.Errorf("drain of %d dead sockets took %v, want <= %v — an unbounded drain "+
+			"can outlive terminationGracePeriodSeconds and get SIGKILLed mid-shutdown",
+			maxWSConnections, elapsed, limit)
+	}
+}
+
+// TestDrainForShutdownDoesNotTearDownOtherInstancesConnections is the SURGE
+// case (kubestellar/hive#5322).
+//
+// The deployment is maxSurge=1/maxUnavailable=0, so the replacement pod is
+// Ready and serving BEFORE the old pod receives SIGTERM. A relay can therefore
+// already have reconnected to the NEW hub when the OLD one drains. The old
+// hub's drain must touch only the sockets in its own connection map: the new
+// hub's connection is a different process, a different map, and a different TCP
+// socket, and must survive intact.
+//
+// Modelled here as two hub values with disjoint maps, which is exactly the
+// relationship two hub processes have.
+func TestDrainForShutdownDoesNotTearDownOtherInstancesConnections(t *testing.T) {
+	oldPeer := newDrainTestPeer(t)
+	newPeer := newDrainTestPeer(t)
+
+	oldHub := drainTestHub(map[string]*ContributorConnection{
+		"conn-old": {ws: oldPeer.serverWS, profile: &ContributorProfile{GitHubUsername: "alice"}},
+	})
+	newHub := drainTestHub(map[string]*ContributorConnection{
+		"conn-new": {ws: newPeer.serverWS, profile: &ContributorProfile{GitHubUsername: "alice"}},
+	})
+
+	// The OLD pod gets SIGTERM and drains.
+	if n := oldHub.DrainForShutdown(); n != 1 {
+		t.Fatalf("old hub drained %d connections, want 1", n)
+	}
+
+	// The old socket is closed with 1012 — expected and correct.
+	if got := awaitClose(oldPeer.clientWS, 5*time.Second); got.code != websocket.CloseServiceRestart {
+		t.Errorf("old socket close code = %d, want %d", got.code, websocket.CloseServiceRestart)
+	}
+
+	// The connection on the NEW hub must be untouched and still carrying traffic.
+	if newHub.ActiveCount() != 1 {
+		t.Errorf("new hub ActiveCount() = %d, want 1 — the old pod's drain "+
+			"must not deregister the replacement's contributors", newHub.ActiveCount())
+	}
+
+	// Prove liveness rather than merely absence-of-close: write and read a real
+	// message across the new socket AFTER the old hub drained.
+	if err := newPeer.serverWS.WriteMessage(websocket.TextMessage, []byte("still-alive")); err != nil {
+		t.Fatalf("new hub's socket was broken by the old pod's drain: %v", err)
+	}
+	_ = newPeer.clientWS.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, payload, err := newPeer.clientWS.ReadMessage()
+	if err != nil {
+		t.Fatalf("new hub's relay could not read after the old pod drained: %v", err)
+	}
+	if string(payload) != "still-alive" {
+		t.Errorf("payload = %q, want %q", payload, "still-alive")
+	}
+}
+
+// TestDrainForShutdownHandlesEmptyAndNilSafely covers the shapes the shutdown
+// path can legitimately hit: no contributors connected at all, an entry with no
+// live socket (mirrors cleanupLoop's nil-guard), and a nil hub — the last being
+// what a Server whose contribute routes were never registered hands back.
+func TestDrainForShutdownHandlesEmptyAndNilSafely(t *testing.T) {
+	if n := drainTestHub(map[string]*ContributorConnection{}).DrainForShutdown(); n != 0 {
+		t.Errorf("empty hub drained %d, want 0", n)
+	}
+
+	wsLess := drainTestHub(map[string]*ContributorConnection{
+		"no-socket": {profile: &ContributorProfile{GitHubUsername: "ghost"}},
+		"nil-entry": nil,
+	})
+	if n := wsLess.DrainForShutdown(); n != 0 {
+		t.Errorf("hub of socketless entries drained %d, want 0", n)
+	}
+
+	var nilHub *ContributeWSHub
+	if n := nilHub.DrainForShutdown(); n != 0 {
+		t.Errorf("nil hub drained %d, want 0", n)
+	}
+
+	var nilSrv *Server
+	if n := nilSrv.DrainContributorsForShutdown(); n != 0 {
+		t.Errorf("nil server drained %d, want 0", n)
+	}
+
+	srvNoHub := &Server{}
+	if n := srvNoHub.DrainContributorsForShutdown(); n != 0 {
+		t.Errorf("server without a contribute hub drained %d, want 0", n)
+	}
+}
+
+// TestDrainForShutdownDoesNotHoldHubLockDuringClose pins the locking shape the
+// implementation inherited from cleanupLoop: sockets are snapshotted under
+// h.mu and closed OUTSIDE it. Holding the hub-wide lock across a close frame
+// that can block for wsCloseFrameDeadline per wedged peer would stall every
+// other hub operation for up to maxWSConnections seconds.
+//
+// Asserted behaviourally: while the drain is running against a dead peer,
+// another goroutine must still be able to acquire the hub lock.
+func TestDrainForShutdownDoesNotHoldHubLockDuringClose(t *testing.T) {
+	conns := make(map[string]*ContributorConnection, 4)
+	for i := 0; i < 4; i++ {
+		p := newDrainTestPeer(t)
+		_ = p.clientWS.UnderlyingConn().Close()
+		conns[string(rune('a'+i))] = &ContributorConnection{ws: p.serverWS}
+	}
+	hub := drainTestHub(conns)
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		// Give the drain a moment to be mid-close, then contend for the lock.
+		time.Sleep(50 * time.Millisecond)
+		hub.mu.Lock()
+		hub.mu.Unlock() //nolint:staticcheck // acquiring the lock is the assertion
+		close(lockAcquired)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		hub.DrainForShutdown()
+		close(done)
+	}()
+
+	select {
+	case <-lockAcquired:
+	case <-time.After(wsDrainBudget + 5*time.Second):
+		t.Fatal("could not acquire h.mu while a drain was in progress — the drain " +
+			"is closing sockets under the hub lock")
+	}
+	<-done
+}


### PR DESCRIPTION
## What

The hub had no shutdown handling for contributor WebSockets. On SIGTERM — which happens on **every** upgrade roll — the sockets died with the process at SIGKILL, so the relay saw a bare **1006**, byte-for-byte identical to a yanked network cable.

This registers a pre-shutdown hook that walks the contributor connection map and sends:

```go
closeWithReason(ws, websocket.CloseServiceRestart, "hub restarting for upgrade")
```

`CloseServiceRestart` is **1012** — "the server is restarting", clients expected to reconnect.

This resolves the contradiction that ran through #5090's whole thread: the hub provably sends Close frames (#5107), yet every observed flap was frameless. Process death was never a deliberate close.

## What this does and does NOT fix

**It does not stop the flapping.** The pod still rolls — that is #5391 — and the socket still dies. No hub-side change can keep a socket alive across a process that is being deliberately killed.

**What changes:**

1. **Every future flap becomes self-describing.** The relay logs "hub restarting for upgrade" instead of an uninterpretable 1006, and can distinguish "hub is rolling, reconnect now" from a real network fault. This diagnosis took multiple days; with a 1012 it would have been a five-minute job.
2. **It shortens the outage.** Today the relay discovers the dead connection by *timeout* — a read error or missed pong, seconds later. With a 1012 it learns immediately and reconnects into the replacement pod, which `maxSurge=1/maxUnavailable=0` has already brought to readiness before this signal was delivered.

`Fixes #5390`. `Refs #5090` — #5090's flapping is **not** resolved by this.

## The composition trap

The pre-shutdown slot was a single `atomic.Pointer[func()]`, **already occupied** by #4296's kick-log archive (`main.go:1555`). A `Store` of a drain hook would have SILENTLY DESTROYED kick-log archiving on shutdown — no error, no failing test, a shutdown side effect simply stops happening, discovered only when someone goes looking for scrollback that is no longer being written.

**Chosen: convert the mechanism to an ordered slice** (`shutdownHooks`), rather than chaining the two closures.

Chaining fixes this instance; a slice fixes the *class*. Registration becomes additive by construction, so the next person to add a shutdown hook cannot repeat the mistake — which matters because the trap is invisible by nature. It also let each hook keep its own failure isolation: a panic in one no longer costs the others theirs.

Two ordering details:

- The drain registers via `addUrgent` (prepend), not `add`. Registration order in `main()` is dictated by *construction* order — the dashboard server is built ~350 lines after the agent manager — which has nothing to do with what should run first at shutdown. The drain is the time-critical half: it puts a frame on a wire a relay is waiting on, while the archive does PVC I/O on NFS that nobody is waiting on.
- The hook still runs **before** `cancel()`, so connections are live when it fires. Not moved.

## Bounding the drain

- **No close acknowledgements.** WebSocket close is fire-and-forget server-side.
- **Whole drain capped at 2s** (`wsDrainBudget`), not per socket. `closeWithReason` writes with a 1s deadline, so against the 50-connection cap a serial drain of wedged peers is a 50s worst case — longer than `terminationGracePeriodSeconds: 30`. That would mean the drain itself delays the exit past SIGKILL and **the archive hook that follows it never runs**. Whatever is not closed when the budget expires is abandoned; those sockets are exactly as dead as they are today.
- **Snapshot under `h.mu`, close outside it** — follows `cleanupLoop` exactly. Closing under the hub-wide lock would stall every other hub operation for up to `wsCloseFrameDeadline` per wedged peer, serially.
- **`WriteControl`, no `writeMu`.** Verified rather than assumed: `closeWithReason` already calls `conn.WriteControl` directly and takes no lock, matching `writeProtocolPing`. Taking `writeMu` here would nest under callers that already hold it — the re-entrancy shape this repo has deadlocked on.

Cost is one `WriteControl` per connection: single-digit milliseconds against a 30s grace period, on rollouts that already spend 2m05s pulling a 4.05 GB image.

## Testing

Per #5388 (four "guard fails green" incidents this week), these assert **observable behaviour** on real sockets — a genuine `httptest` server, a real dial, a real close frame read off the wire — not that a function was called.

`pkg/dashboard/contribute_ws_shutdown_drain_test.go`:
- a real relay observes close code **1012** and the exact reason string, with an explicit assertion it is not 1006
- every connection in the map is closed, not just the first
- the drain is bounded against 50 dead peers
- **surge case (#5322)**: two hubs with disjoint maps; the old pod drains, and the new hub's connection must survive — asserted by writing and reading a real message across it *after* the drain, not merely by absence of a close
- empty map, socketless entries, nil connection, nil hub, hub-less server
- `h.mu` remains acquirable by another goroutine while a drain is in flight

`cmd/hive/shutdown_hooks_test.go`:
- **both** the archive and the drain run — asserted twice, once via `add`+`addUrgent` and once with both via `add`, so the guard does not depend on the prepend happening to survive a destructive registration
- `addUrgent` ordering; panic isolation; zero-value and nil safety
- a structural guard that `main.go` still registers both, that a single-slot `Store` cannot come back, and that `cancel()` still immediately follows the hook run

**Mutation-verified** — each guard was confirmed to actually fail when the behaviour is broken:

| Mutation | Result |
|---|---|
| `closeWithReason(...)` → bare `ws.Close()` | 3 tests FAIL |
| drain only the first socket | `ClosesEveryConnection` FAILs |
| `add` appends → `add` overwrites (the #5390 trap) | `RunsBothArchiveAndDrain` FAILs on the count |

Clean under `-race`. Full `./cmd/hive` suite passes.

### What remains unverified

**This cannot be verified against a real pod roll from CI, and is not.** There is no kubelet in these tests, no SIGTERM delivery, no `terminationGracePeriodSeconds`, and no rolling-update surge — the drain is invoked directly. That the hook is wired to SIGTERM is covered structurally, since `main()` is a 2000-line function that cannot be invoked from a test. That a real roll produces a 1012 at the relay can only be confirmed by observing a live upgrade on a hosted spoke.

The surge test models two hub *processes* as two hub values with disjoint maps, which is the relationship they have with respect to this code path, but it is a model and not a real two-pod rollout.

## Not touched

- Hub-side lease/cooldown accounting — #5151 stays held.
- Deployment strategy, grace period, readiness probe.

## Related

- #5090 — the flap this explains; ingress exonerated there
- #5107 — added `closeWithReason`
- #5322 — the bare `joined` with no `left`, same surge/roll interaction
- #5391 — the roll cadence itself