### PR TITLE
feat(hub): surface stuck-pod count in fleet health + root-cause finding (#5328 items 1 & 3)

### DIFF
--- a/src/pkg/hub/orphaned_pod_visibility.go
+++ b/src/pkg/hub/orphaned_pod_visibility.go
@@ -1,0 +1,163 @@
+package hub
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Orphaned Terminating-pod VISIBILITY (issue #5328, item 3).
+//
+// WHY THIS EXISTS SEPARATELY FROM THE REAPER. orphaned_pod_reaper.go removes
+// orphaned pods. This file REPORTS them. Those are deliberately different
+// lanes, because a reaper alone trades one invisible problem for another:
+//
+// The measured incident was 27 orphaned pods across 15 hive namespaces
+// accumulating for THREE WEEKS with nothing reporting it. The reaper now
+// clears them. But orphan PRODUCTION — a node disappearing without draining —
+// is issue #5328 item 1 and is NOT fixed by the reaper. If the reaper quietly
+// deletes 30 pods every sweep forever, the fleet looks healthy and the
+// underlying node-lifecycle fault stays invisible exactly as it did for those
+// three weeks. A count on the fleet-health surface is what makes a SPIKE in
+// orphan volume legible as the upstream signal it is.
+//
+// WHY IT IS COUNTED HERE AND NOT DERIVED FROM THE REAPER'S DELETIONS. Counting
+// what the reaper deleted would report only what the hub could reach and had
+// permission to remove — a cluster whose credential lacks pod-delete, or a pod
+// inside the orphanedPodMinAge window, would silently read as zero. Counting
+// the LIVE state instead means the number is what is actually stuck right now,
+// independent of whether anything succeeded in cleaning it up. That is the
+// property the fleet-health surface needs.
+//
+// THE PREDICATE IS NOT RESTATED. Selection goes through
+// podIsOrphanedTerminating from orphaned_pod_reaper.go — the exact function the
+// reaper uses, unmodified. There is deliberately no second copy of the rule to
+// drift out of agreement with the first: if the predicate is ever changed, the
+// count and the reaping change together or not at all.
+//
+// READ-ONLY. This lane issues `kubectl get pods` and NOTHING else. It adds no
+// credential, no verb and no cluster-write of any kind beyond the read the
+// cluster-health collector already performs on this same path (saas.go runs
+// `get pods --all-namespaces` there today). The hub's blast radius is
+// unchanged.
+//
+// SCOPED TO HIVE NAMESPACES. Only namespaces carrying hiveHostedNamespacePrefix
+// are counted. A stuck pod in kube-system is somebody else's problem and
+// reporting it here would be noise the fleet view cannot act on.
+
+// orphanedPodStuckReportLimit caps how many per-namespace entries the report
+// carries.
+//
+// The count itself is always exact and fleet-wide — the cap applies ONLY to the
+// per-namespace breakdown that accompanies it. The breakdown exists so an
+// operator can see WHERE orphans are concentrated; past a couple of dozen
+// namespaces that list has stopped being diagnostic and started being a wall of
+// text, and the total plus the worst offenders already says everything the
+// operator needs to act on. The measured incident spanned 15 namespaces, so
+// this is comfortably above the shape the signal was designed around.
+const orphanedPodStuckReportLimit = 25
+
+// OrphanedNamespaceCount is one namespace's stuck-pod count.
+type OrphanedNamespaceCount struct {
+	Namespace string `json:"namespace"`
+	Count     int    `json:"count"`
+}
+
+// StuckPodReport is the per-cluster orphaned-pod signal surfaced in fleet
+// health.
+//
+// Total is the authoritative number and is exact. Namespaces is the
+// (possibly truncated, see orphanedPodStuckReportLimit) breakdown, ordered
+// worst-first so the head of the list is the useful part when it is cut.
+// NamespacesAffected is the exact count of distinct namespaces holding at
+// least one orphan, so a truncated breakdown never understates the spread.
+type StuckPodReport struct {
+	Total              int                      `json:"total"`
+	NamespacesAffected int                      `json:"namespaces_affected"`
+	Namespaces         []OrphanedNamespaceCount `json:"namespaces,omitempty"`
+	// Truncated marks that Namespaces holds fewer entries than
+	// NamespacesAffected, so a reader can tell a short list from a complete
+	// one rather than silently believing it saw everything.
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// summarizeStuckPods builds the report from already-parsed candidates.
+//
+// PURE. No kubectl, no cluster, no clock of its own — now is passed in. This is
+// what makes the count testable against real predicate matches rather than
+// against the mere existence of a field.
+//
+// Namespaces not carrying hiveHostedNamespacePrefix are skipped before the
+// predicate ever runs, so the report cannot include pods this fleet does not
+// own.
+func summarizeStuckPods(candidates []orphanedPodCandidate, now time.Time, minAge time.Duration) StuckPodReport {
+	perNS := make(map[string]int)
+	total := 0
+	for _, c := range candidates {
+		if !strings.HasPrefix(c.Namespace, hiveHostedNamespacePrefix) {
+			continue
+		}
+		// The reaper's predicate, called not copied.
+		if !podIsOrphanedTerminating(c, now, minAge) {
+			continue
+		}
+		perNS[c.Namespace]++
+		total++
+	}
+
+	rep := StuckPodReport{
+		Total:              total,
+		NamespacesAffected: len(perNS),
+	}
+	if total == 0 {
+		return rep
+	}
+
+	rep.Namespaces = make([]OrphanedNamespaceCount, 0, len(perNS))
+	for ns, n := range perNS {
+		rep.Namespaces = append(rep.Namespaces, OrphanedNamespaceCount{Namespace: ns, Count: n})
+	}
+	// Worst-first, then by name so equal counts have a stable, reproducible
+	// order rather than Go's randomized map iteration. Determinism matters:
+	// this list is truncated, and a nondeterministic order would change WHICH
+	// namespaces survive the cut between two reads of the same cluster state.
+	sort.Slice(rep.Namespaces, func(i, j int) bool {
+		if rep.Namespaces[i].Count != rep.Namespaces[j].Count {
+			return rep.Namespaces[i].Count > rep.Namespaces[j].Count
+		}
+		return rep.Namespaces[i].Namespace < rep.Namespaces[j].Namespace
+	})
+	if len(rep.Namespaces) > orphanedPodStuckReportLimit {
+		rep.Namespaces = rep.Namespaces[:orphanedPodStuckReportLimit]
+		rep.Truncated = true
+	}
+	return rep
+}
+
+// collectStuckPods lists pods across the cluster and summarizes the orphans.
+//
+// READ-ONLY and best-effort: on any error it returns nil, and the caller omits
+// the signal entirely rather than reporting a false zero. That distinction is
+// the whole point — "no orphans" and "could not tell" must not render alike,
+// which is the same rule the disk fields on this surface already follow.
+//
+// The list is NOT field-selector-filtered to a phase. The existing pod query in
+// buildSingleClusterHealth uses --field-selector=status.phase=Running, which by
+// construction can never see an orphan (the predicate requires phase !=
+// Running) — so this needs its own, separate listing. It is scoped to the
+// hive-hosted namespaces at summarize time.
+func collectStuckPods(ctx context.Context, cluster *ClusterConfig, timeout time.Duration, now time.Time) *StuckPodReport {
+	out, err := kubectlForClusterContext(ctx, cluster,
+		"--request-timeout", timeout.String(),
+		"get", "pods", "--all-namespaces", "-o", "json").Output()
+	if err != nil {
+		return nil
+	}
+	candidates, perr := parseOrphanCandidates(out)
+	if perr != nil {
+		return nil
+	}
+	rep := summarizeStuckPods(candidates, now, orphanedPodMinAge)
+	return &rep
+}

--- a/src/pkg/hub/orphaned_pod_visibility_test.go
+++ b/src/pkg/hub/orphaned_pod_visibility_test.go
@@ -1,0 +1,348 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedVisNow is the clock every case here is evaluated against, so ages are
+// exact rather than relative to a running wall clock.
+var fixedVisNow = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+func visAgo(d time.Duration) time.Time { return fixedVisNow.Add(-d) }
+
+// TestSummarizeStuckPodsCountsRealPredicateMatches is the load-bearing test for
+// #5328 item 3.
+//
+// Per #5388, a guard that asserts a FIELD EXISTS is a guard that fails green.
+// This test therefore never checks "is StuckPods non-nil" — it builds a pod
+// population whose orphan count is known by construction, and asserts the
+// reported number equals that count and no other. The population deliberately
+// mixes in every pod shape that a LOOSER predicate would wrongly count:
+// a Running pod carrying a deletionTimestamp (the live spoke), a pod held by a
+// finalizer, a pod inside the age window, a pod never asked to terminate, and
+// an orphan in a NON-hive namespace. If the count ever picks any of those up,
+// the number moves and this fails.
+func TestSummarizeStuckPodsCountsRealPredicateMatches(t *testing.T) {
+	nsA := hiveHostedNamespacePrefix + "alpha"
+	nsB := hiveHostedNamespacePrefix + "bravo"
+
+	candidates := []orphanedPodCandidate{
+		// --- nsA: 3 genuine orphans -------------------------------------
+		{Namespace: nsA, Name: "orphan-a1", DeletionTimestamp: visAgo(72 * time.Hour), Phase: "Failed"},
+		{Namespace: nsA, Name: "orphan-a2", DeletionTimestamp: visAgo(3 * time.Hour), Phase: "Succeeded"},
+		{Namespace: nsA, Name: "orphan-a3", DeletionTimestamp: visAgo(21 * 24 * time.Hour), Phase: "Pending"},
+
+		// --- nsA: pods that MUST NOT be counted -------------------------
+		// The live spoke: Running with a deletionTimestamp. Counting this
+		// would report a healthy namespace as broken.
+		{Namespace: nsA, Name: "live-spoke", DeletionTimestamp: visAgo(48 * time.Hour), Phase: podPhaseRunning},
+		// A finalizer means a controller has unfinished work — different
+		// problem, out of scope.
+		{Namespace: nsA, Name: "finalizer-held", DeletionTimestamp: visAgo(48 * time.Hour),
+			Finalizers: []string{"kubernetes.io/pv-protection"}, Phase: "Failed"},
+		// Inside the grace window: terminating correctly right now.
+		{Namespace: nsA, Name: "young-terminating", DeletionTimestamp: visAgo(2 * time.Minute), Phase: "Failed"},
+		// Never asked to go away at all.
+		{Namespace: nsA, Name: "healthy", Phase: podPhaseRunning},
+
+		// --- nsB: 1 genuine orphan --------------------------------------
+		{Namespace: nsB, Name: "orphan-b1", DeletionTimestamp: visAgo(9 * time.Hour), Phase: "Failed"},
+		{Namespace: nsB, Name: "live-spoke", Phase: podPhaseRunning},
+
+		// --- a NON-hive namespace: matches the predicate but is not ours --
+		// kube-system's stuck pods are somebody else's problem; counting
+		// them would make the fleet signal unactionable.
+		{Namespace: "kube-system", Name: "not-ours", DeletionTimestamp: visAgo(96 * time.Hour), Phase: "Failed"},
+	}
+
+	got := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+
+	const wantTotal = 4          // 3 in nsA + 1 in nsB, and nothing else
+	const wantNamespacesAffected = 2
+
+	if got.Total != wantTotal {
+		t.Errorf("Total = %d, want %d — the count must equal the number of real predicate matches, not the number of pods", got.Total, wantTotal)
+	}
+	if got.NamespacesAffected != wantNamespacesAffected {
+		t.Errorf("NamespacesAffected = %d, want %d", got.NamespacesAffected, wantNamespacesAffected)
+	}
+	if got.Truncated {
+		t.Errorf("Truncated = true, want false — only 2 namespaces, far below the limit of %d", orphanedPodStuckReportLimit)
+	}
+
+	// Per-namespace breakdown must carry the real per-namespace numbers, and
+	// must be ordered worst-first.
+	want := []OrphanedNamespaceCount{
+		{Namespace: nsA, Count: 3},
+		{Namespace: nsB, Count: 1},
+	}
+	if len(got.Namespaces) != len(want) {
+		t.Fatalf("Namespaces has %d entries, want %d: %+v", len(got.Namespaces), len(want), got.Namespaces)
+	}
+	for i := range want {
+		if got.Namespaces[i] != want[i] {
+			t.Errorf("Namespaces[%d] = %+v, want %+v (expect worst-first ordering)", i, got.Namespaces[i], want[i])
+		}
+	}
+
+	// The per-namespace counts must sum to the total; a breakdown that
+	// disagrees with its own headline is worse than no breakdown.
+	sum := 0
+	for _, n := range got.Namespaces {
+		sum += n.Count
+	}
+	if sum != got.Total {
+		t.Errorf("per-namespace counts sum to %d but Total is %d", sum, got.Total)
+	}
+}
+
+// TestSummarizeStuckPodsCleanFleetIsZeroNotUnknown pins the steady state. A
+// cluster with only live spokes must report a real, present zero — that is what
+// distinguishes "we looked and it is clean" from "we could not tell", which is
+// the distinction whose absence let this incident run for three weeks.
+func TestSummarizeStuckPodsCleanFleetIsZeroNotUnknown(t *testing.T) {
+	candidates := []orphanedPodCandidate{
+		{Namespace: hiveHostedNamespacePrefix + "alpha", Name: "spoke", Phase: podPhaseRunning},
+		{Namespace: hiveHostedNamespacePrefix + "bravo", Name: "spoke", Phase: podPhaseRunning},
+		// Mid-shutdown, correctly: still Running with a fresh timestamp.
+		{Namespace: hiveHostedNamespacePrefix + "bravo", Name: "rolling", DeletionTimestamp: visAgo(5 * time.Second), Phase: podPhaseRunning},
+	}
+	got := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+	if got.Total != 0 {
+		t.Errorf("Total = %d, want 0 on a clean fleet", got.Total)
+	}
+	if got.NamespacesAffected != 0 {
+		t.Errorf("NamespacesAffected = %d, want 0", got.NamespacesAffected)
+	}
+	if len(got.Namespaces) != 0 {
+		t.Errorf("Namespaces = %+v, want empty", got.Namespaces)
+	}
+}
+
+// TestSummarizeStuckPodsReproducesMeasuredIncident replays the actual shape from
+// the incident: 27 orphans spread across 15 hive namespaces, each namespace
+// still holding exactly one healthy Running spoke. This is the number the fleet
+// surface would have shown had it existed, and it is the regression that proves
+// the signal reports reality rather than a placeholder.
+func TestSummarizeStuckPodsReproducesMeasuredIncident(t *testing.T) {
+	// 15 namespaces holding 27 orphans total: 12 namespaces with 2, 3 with 1.
+	perNS := []int{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1}
+	wantTotal := 0
+	var candidates []orphanedPodCandidate
+	for i, n := range perNS {
+		ns := fmt.Sprintf("%sspoke%02d", hiveHostedNamespacePrefix, i)
+		// Every namespace keeps exactly one healthy Running pod — the live
+		// spoke, which must never be counted.
+		candidates = append(candidates, orphanedPodCandidate{Namespace: ns, Name: "live", Phase: podPhaseRunning})
+		for j := 0; j < n; j++ {
+			candidates = append(candidates, orphanedPodCandidate{
+				Namespace:         ns,
+				Name:              fmt.Sprintf("orphan-%d", j),
+				DeletionTimestamp: visAgo(time.Duration(3+i) * 24 * time.Hour),
+				Phase:             "Failed",
+			})
+		}
+		wantTotal += n
+	}
+	if wantTotal != 27 {
+		t.Fatalf("test fixture builds %d orphans, expected the measured 27", wantTotal)
+	}
+
+	got := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+	if got.Total != 27 {
+		t.Errorf("Total = %d, want 27 (the measured incident)", got.Total)
+	}
+	if got.NamespacesAffected != 15 {
+		t.Errorf("NamespacesAffected = %d, want 15 (the measured incident)", got.NamespacesAffected)
+	}
+	// 15 affected namespaces sits under the breakdown cap, so the operator
+	// sees the full spread rather than a truncated one.
+	if got.Truncated {
+		t.Errorf("Truncated = true, but the measured incident's 15 namespaces fit under the cap of %d", orphanedPodStuckReportLimit)
+	}
+	if len(got.Namespaces) != 15 {
+		t.Errorf("Namespaces has %d entries, want all 15", len(got.Namespaces))
+	}
+}
+
+// TestSummarizeStuckPodsTruncatesButKeepsTotalExact pins that the cap applies
+// ONLY to the breakdown. The headline number and the affected-namespace count
+// must stay exact, otherwise a large incident would be reported as smaller than
+// it is — the precise way a safety signal fails green.
+func TestSummarizeStuckPodsTruncatesButKeepsTotalExact(t *testing.T) {
+	const namespaces = orphanedPodStuckReportLimit + 10
+	var candidates []orphanedPodCandidate
+	for i := 0; i < namespaces; i++ {
+		candidates = append(candidates, orphanedPodCandidate{
+			Namespace:         fmt.Sprintf("%sspoke%03d", hiveHostedNamespacePrefix, i),
+			Name:              "orphan",
+			DeletionTimestamp: visAgo(48 * time.Hour),
+			Phase:             "Failed",
+		})
+	}
+
+	got := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+	if got.Total != namespaces {
+		t.Errorf("Total = %d, want %d — truncation must never shrink the headline count", got.Total, namespaces)
+	}
+	if got.NamespacesAffected != namespaces {
+		t.Errorf("NamespacesAffected = %d, want %d — truncation must never shrink the spread", got.NamespacesAffected, namespaces)
+	}
+	if len(got.Namespaces) != orphanedPodStuckReportLimit {
+		t.Errorf("Namespaces has %d entries, want the cap %d", len(got.Namespaces), orphanedPodStuckReportLimit)
+	}
+	if !got.Truncated {
+		t.Error("Truncated = false, want true — a short list must announce itself as short")
+	}
+}
+
+// TestSummarizeStuckPodsOrderingIsDeterministic guards the truncation cut. Go
+// map iteration is randomized, so without an explicit tiebreak the SAME cluster
+// state could yield different surviving namespaces on two consecutive reads.
+func TestSummarizeStuckPodsOrderingIsDeterministic(t *testing.T) {
+	var candidates []orphanedPodCandidate
+	for i := 0; i < orphanedPodStuckReportLimit+5; i++ {
+		candidates = append(candidates, orphanedPodCandidate{
+			Namespace:         fmt.Sprintf("%sspoke%03d", hiveHostedNamespacePrefix, i),
+			Name:              "orphan",
+			DeletionTimestamp: visAgo(48 * time.Hour),
+			Phase:             "Failed",
+		})
+	}
+	first := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+	for i := 0; i < 20; i++ {
+		again := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+		if len(again.Namespaces) != len(first.Namespaces) {
+			t.Fatalf("run %d returned %d entries, first returned %d", i, len(again.Namespaces), len(first.Namespaces))
+		}
+		for j := range first.Namespaces {
+			if again.Namespaces[j] != first.Namespaces[j] {
+				t.Fatalf("run %d entry %d = %+v, first run had %+v — ordering must be deterministic or truncation is nondeterministic",
+					i, j, again.Namespaces[j], first.Namespaces[j])
+			}
+		}
+	}
+}
+
+// TestSummarizeStuckPodsAgreesWithReaperSelection is the anti-drift guard. The
+// count and the reaper MUST be the same predicate; this asserts they select the
+// identical set over one population, so a future change to
+// podIsOrphanedTerminating can never move one without the other.
+func TestSummarizeStuckPodsAgreesWithReaperSelection(t *testing.T) {
+	ns := hiveHostedNamespacePrefix + "alpha"
+	candidates := []orphanedPodCandidate{
+		{Namespace: ns, Name: "orphan-1", DeletionTimestamp: visAgo(30 * time.Hour), Phase: "Failed"},
+		{Namespace: ns, Name: "orphan-2", DeletionTimestamp: visAgo(90 * time.Minute), Phase: "Succeeded"},
+		{Namespace: ns, Name: "live", DeletionTimestamp: visAgo(30 * time.Hour), Phase: podPhaseRunning},
+		{Namespace: ns, Name: "held", DeletionTimestamp: visAgo(30 * time.Hour), Finalizers: []string{"x"}, Phase: "Failed"},
+		{Namespace: ns, Name: "young", DeletionTimestamp: visAgo(time.Minute), Phase: "Failed"},
+	}
+
+	reaperWould := selectOrphanedPods(candidates, fixedVisNow, orphanedPodMinAge)
+	counted := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+
+	if counted.Total != len(reaperWould) {
+		t.Errorf("count reports %d stuck pods but the reaper would select %d — the two must use the ONE predicate",
+			counted.Total, len(reaperWould))
+	}
+}
+
+// TestSummarizeStuckPodsIgnoresNonHiveNamespaces pins the scope clause on its
+// own, so a namespace-prefix regression cannot hide behind other assertions.
+func TestSummarizeStuckPodsIgnoresNonHiveNamespaces(t *testing.T) {
+	// Every one of these matches the predicate perfectly; none of them is ours.
+	candidates := []orphanedPodCandidate{
+		{Namespace: "kube-system", Name: "a", DeletionTimestamp: visAgo(48 * time.Hour), Phase: "Failed"},
+		{Namespace: "default", Name: "b", DeletionTimestamp: visAgo(48 * time.Hour), Phase: "Failed"},
+		{Namespace: "hive-hosted", Name: "c", DeletionTimestamp: visAgo(48 * time.Hour), Phase: "Failed"}, // no trailing dash: not the prefix
+	}
+	got := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+	if got.Total != 0 {
+		t.Errorf("Total = %d, want 0 — only %q namespaces are in scope", got.Total, hiveHostedNamespacePrefix)
+	}
+}
+
+// TestStuckPodsFlowsFromKubectlJSONToCount covers the real ingest path end to
+// end over the pure functions: raw `kubectl get pods -o json` bytes in, a
+// correct count out. Parsing is shared with the reaper (parseOrphanCandidates),
+// so this also pins that the timestamp decode feeding the COUNT fails safe.
+func TestStuckPodsFlowsFromKubectlJSONToCount(t *testing.T) {
+	ns := hiveHostedNamespacePrefix + "alpha"
+	old := visAgo(50 * time.Hour).Format(time.RFC3339)
+	fresh := visAgo(10 * time.Second).Format(time.RFC3339)
+
+	raw := fmt.Sprintf(`{"items":[
+	  {"metadata":{"name":"orphan","namespace":%q,"deletionTimestamp":%q,"finalizers":[]},"status":{"phase":"Failed"}},
+	  {"metadata":{"name":"live","namespace":%q},"status":{"phase":"Running"}},
+	  {"metadata":{"name":"held","namespace":%q,"deletionTimestamp":%q,"finalizers":["a/b"]},"status":{"phase":"Failed"}},
+	  {"metadata":{"name":"young","namespace":%q,"deletionTimestamp":%q},"status":{"phase":"Failed"}},
+	  {"metadata":{"name":"unparseable","namespace":%q,"deletionTimestamp":"not-a-time"},"status":{"phase":"Failed"}},
+	  {"metadata":{"name":"elsewhere","namespace":"kube-system","deletionTimestamp":%q},"status":{"phase":"Failed"}}
+	]}`, ns, old, ns, ns, old, ns, fresh, ns, old)
+
+	// Sanity: the fixture must be valid JSON, or this test proves nothing.
+	if !json.Valid([]byte(raw)) {
+		t.Fatal("test fixture is not valid JSON")
+	}
+
+	candidates, err := parseOrphanCandidates([]byte(raw))
+	if err != nil {
+		t.Fatalf("parseOrphanCandidates: %v", err)
+	}
+	got := summarizeStuckPods(candidates, fixedVisNow, orphanedPodMinAge)
+
+	// Exactly ONE pod qualifies: "orphan". Every other row is a documented
+	// exclusion, including the unparseable timestamp which must fail SAFE
+	// (never counted) rather than be guessed at.
+	if got.Total != 1 {
+		t.Errorf("Total = %d, want 1 (only \"orphan\" qualifies): %+v", got.Total, got.Namespaces)
+	}
+	if got.NamespacesAffected != 1 {
+		t.Errorf("NamespacesAffected = %d, want 1", got.NamespacesAffected)
+	}
+	if len(got.Namespaces) == 1 && got.Namespaces[0].Namespace != ns {
+		t.Errorf("reported namespace %q, want %q", got.Namespaces[0].Namespace, ns)
+	}
+}
+
+// TestStuckPodReportSerializesUnknownDistinctFromZero pins the wire contract
+// that makes the signal trustworthy. A nil report must vanish from the JSON so
+// the UI renders UNKNOWN; a present zero must serialize as an explicit total so
+// the UI can say "checked, clean". If these two ever look alike on the wire,
+// the surface reproduces the exact blindness this issue is about.
+func TestStuckPodReportSerializesUnknownDistinctFromZero(t *testing.T) {
+	unknown, err := json.Marshal(PerClusterHealth{ID: "c1"})
+	if err != nil {
+		t.Fatalf("marshal unknown: %v", err)
+	}
+	if strings.Contains(string(unknown), "stuck_pods") {
+		t.Errorf("a nil StuckPods must be OMITTED so the UI shows unknown, got: %s", unknown)
+	}
+
+	clean, err := json.Marshal(PerClusterHealth{ID: "c1", StuckPods: &StuckPodReport{}})
+	if err != nil {
+		t.Fatalf("marshal clean: %v", err)
+	}
+	if !strings.Contains(string(clean), `"stuck_pods"`) {
+		t.Errorf("a present zero report must SERIALIZE so the UI can distinguish clean from unknown, got: %s", clean)
+	}
+	if !strings.Contains(string(clean), `"total":0`) {
+		t.Errorf("a clean report must carry an explicit total:0, got: %s", clean)
+	}
+}
+
+// TestStuckPodReportLimitIsAboveMeasuredIncident pins the cap's intent: the
+// breakdown must not truncate at the scale the signal was designed around, or
+// operators would routinely see a partial list for the very shape of incident
+// this exists to report.
+func TestStuckPodReportLimitIsAboveMeasuredIncident(t *testing.T) {
+	const measuredNamespaces = 15
+	if orphanedPodStuckReportLimit < measuredNamespaces {
+		t.Errorf("orphanedPodStuckReportLimit = %d, must be at least the measured incident's %d namespaces",
+			orphanedPodStuckReportLimit, measuredNamespaces)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -2202,6 +2202,14 @@ type PerClusterHealth struct {
 	DataSource string               `json:"data_source,omitempty"` // "heartbeat" when data comes from spoke heartbeat instead of kubectl
 	DataStale  bool                 `json:"data_stale,omitempty"`  // true when heartbeat data is older than heartbeatHealthStaleness
 	DataAge    string               `json:"data_age,omitempty"`    // human-readable age or collection timestamp
+	// StuckPods reports hive-namespace pods stuck Terminating — the residue of
+	// nodes disappearing without draining (#5328 item 3). Nil means the hub
+	// could not determine it (unreachable cluster, pull-only pool, failed
+	// listing); a non-nil report with Total 0 means it looked and the cluster
+	// is clean. Those must not render alike: 27 orphans accumulated for three
+	// weeks precisely because nothing distinguished "none" from "nobody
+	// checked". See orphaned_pod_visibility.go.
+	StuckPods *StuckPodReport `json:"stuck_pods,omitempty"`
 }
 
 type ClusterHealthResponse struct {
@@ -2742,6 +2750,28 @@ func buildSingleClusterHealth(cluster *ClusterConfig, hiveCount int, logger *slo
 		result.GPUSummary = &GPUSummary{
 			TotalGPUs:       totalGPUCapacity,
 			AllocatableGPUs: totalGPUAllocatable,
+		}
+	}
+
+	// Orphaned Terminating-pod count (#5328 item 3). READ-ONLY: one extra
+	// `kubectl get pods` on a path that already lists pods. It needs its own
+	// listing because the query above is field-selected to phase=Running and
+	// therefore cannot see an orphan by construction.
+	//
+	// Best-effort: nil on failure, so a cluster the hub could not interrogate
+	// reports UNKNOWN rather than a reassuring zero.
+	if stuck := collectStuckPods(ctx, cluster, timeout, time.Now()); stuck != nil {
+		result.StuckPods = stuck
+		// Log when the fleet is actually accumulating orphans. The reaper
+		// clears them, so a persistently non-zero count here means orphans are
+		// being PRODUCED faster than they age past orphanedPodMinAge — which is
+		// the upstream node-lifecycle fault (#5328 item 1), not a reaper
+		// problem. Silence on zero keeps a healthy fleet quiet.
+		if stuck.Total > 0 && logger != nil {
+			logger.Warn("cluster has hive pods stuck terminating — check for ungraceful node loss",
+				"cluster", cluster.ID,
+				"stuck_pods", stuck.Total,
+				"namespaces_affected", stuck.NamespacesAffected)
 		}
 	}
 
@@ -18590,6 +18620,24 @@ const dashboardHTML = `<!DOCTYPE html>
               var capRemaining = cs.hive_capacity_remaining;
               capacityLine = ' · <span title="Estimated headroom: per-hive CPU/memory request footprint bin-packed into free (allocatable minus requested) capacity on Ready, schedulable nodes only">room for ~' + capRemaining + ' more hive' + (capRemaining === 1 ? '' : 's') + '</span>';
             }
+            // Stuck (orphaned Terminating) hive pods — the residue of nodes
+            // disappearing without draining (#5328). ABSENT means the hub could
+            // not determine it and nothing is claimed; a present zero is
+            // deliberately silent so a healthy fleet stays quiet. Only a real
+            // non-zero count renders, because the whole cost of this incident
+            // was that 27 orphans across 15 namespaces accumulated for three
+            // weeks with nothing reporting them.
+            var stuckLine = '';
+            if (c.stuck_pods && c.stuck_pods.total > 0) {
+              var sp = c.stuck_pods;
+              var nsList = (sp.namespaces || []).map(function(x) { return x.namespace + ' (' + x.count + ')'; }).join(', ');
+              if (sp.truncated) { nsList += ', …'; }
+              var stuckTitle = 'Hive pods stuck Terminating past the reaper threshold: deletionTimestamp set, no finalizers, not Running. ' +
+                'Signature of a node removed without draining. Affected namespaces: ' + nsList;
+              stuckLine = ' · <span style="color:var(--red)" title="' + esc(stuckTitle) + '">' +
+                sp.total + ' stuck pod' + (sp.total === 1 ? '' : 's') +
+                ' in ' + sp.namespaces_affected + ' ns</span>';
+            }
             var errorLine = c.error ? '<div style="margin:8px 0;padding:6px 10px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.3);border-radius:6px;font-size:0.75rem;color:var(--red)">' + esc(c.error) + '</div>' : '';
             var headerHtml = '<div style="display:flex;align-items:center;gap:8px;margin:16px 0 8px">' +
               clusterBadge(c.id, c.name) +
@@ -18599,7 +18647,7 @@ const dashboardHTML = `<!DOCTYPE html>
               '<span style="color:' + cCpuColor + '">' + (cs.total_cpu_percent || 0) + '% cpu</span> · ' +
               '<span style="color:' + cMemColor + '">' + (cs.total_mem_percent || 0) + '% mem</span> · ' +
               cDiskSegment +
-              (c.hive_count || 0) + ' hives' + capacityLine + gpuLine +
+              (c.hive_count || 0) + ' hives' + capacityLine + gpuLine + stuckLine +
               '</span></div>';
             var nodesHtml = (c.nodes || []).length > 0
               ? '<div style="display:grid;grid-template-columns:repeat(2,1fr);gap:12px">' + (c.nodes || []).map(renderNodeCard).join('') + '</div>'


### PR DESCRIPTION
Addresses the two remaining items of #5328. Item 2 (the reaper) shipped in #5345 and is **not** touched here — the predicate is called, never restated or loosened.

## Item 3 — surface it (SHIPPED)

**Where:** `PerClusterHealth.StuckPods` (`saas.go`), populated in `buildSingleClusterHealth`, served on `GET /api/saas/cluster-health`, rendered on the per-cluster header line of the cluster-health section. New logic lives in `pkg/hub/orphaned_pod_visibility.go` rather than in `saas.go` to keep the diff off lines other lanes are editing.

**Why a count is needed even though the reaper now runs.** Orphan *production* — a node disappearing without draining — is item 1 and is unfixed. If the reaper silently deletes pods every sweep forever, the fleet looks healthy while the upstream fault stays exactly as invisible as it was for the three weeks 27 orphans accumulated across 15 namespaces. A spike in stuck-pod volume is the signal that something upstream is wrong.

Design decisions worth review:

- **The predicate is called, not copied.** Selection goes through `podIsOrphanedTerminating` unmodified. There is deliberately no second copy of the rule to drift out of agreement with the first.
- **Counts live state, not reaper deletions.** Counting what the reaper deleted would report only what the hub could reach *and* had permission to remove — a cluster whose credential lacks pod-delete would silently read zero. The number is what is stuck right now, independent of cleanup success.
- **Unknown is distinct from clean.** `nil` (field omitted) when the hub could not determine it; a present `total: 0` means it looked and the cluster is clean. Those two rendering alike is precisely the blindness this issue is about. Same rule the disk fields on this surface already follow.
- **Read-only, no new blast radius.** One `kubectl get pods` on a path that already lists pods. No new credential, no new verb. It needs its own listing because the existing query is `--field-selector=status.phase=Running` and therefore cannot see an orphan by construction.
- **Scoped** to `hive-hosted-*`; a stuck pod in `kube-system` is not this fleet's problem.
- Breakdown cap is a named constant (`orphanedPodStuckReportLimit = 25`, above the measured 15). The **total and affected-namespace count stay exact** when the breakdown truncates — a cap that shrank the headline would be the exact way a safety signal fails green.

### Testing

Per #5388, no test here asserts that a field exists. Each builds a population whose orphan count is known by construction and asserts the reported number equals that and no other:

- replays the measured incident (27 orphans / 15 namespaces, each namespace keeping its one healthy `Running` spoke) and asserts 27 and 15;
- pins that the live `Running` spoke, a finalizer-held pod, a pod inside the age window, a never-deleted pod, and an orphan in a non-hive namespace are **never** counted;
- asserts the count equals `selectOrphanedPods` over the same population, so the count and the reaping cannot diverge;
- pins deterministic ordering (Go map iteration is randomized, so without a tiebreak the same cluster state could truncate to a different set on two reads);
- pins the wire contract that omitted != `total: 0`.

**Verified by mutation, not just by passing:** removing the finalizer guard from the predicate, or breaking the namespace scope clause, turns these tests red. They fail for the right reason.

## Item 1 — root cause (INVESTIGATED; not fixable from this repo)

**Conclusion: this is a cluster-lifecycle/configuration problem, not hive code.** Evidence:

1. **The repo contains zero node-pool or IaC definitions.** No `.tf`/`.tfvars`, no Pulumi, Ansible, CloudFormation or Helm chart anywhere. No `MachineSet`, `MachineAutoscaler`, `nodepool`, `preemptible`, `spot`, or `capacity_reservation`. Everything infra-shaped is the hub's *own* workload (`src/deploy/k8s/`) plus kustomize overlays that patch RBAC/SCC/Route/storageclass only. The OKE and OpenShift clusters are provisioned entirely out-of-band, so there is nothing here to inspect or change.
2. **No cluster-autoscaler config, no PodDisruptionBudget, no `safe-to-evict` annotation exists in the repo at all.** A repo-wide grep for `tolerations|tolerationSeconds|terminationGracePeriodSeconds|priorityClassName|PodDisruptionBudget|safe-to-evict` returns exactly one hit, and it is a *comment* in the reaper.
3. **The mechanism is consistent with the default eviction path.** The hosted spoke Deployment template (`saas_provision.go` ~2881+) is `replicas: 1` and sets **no** tolerations, so each pod inherits the DefaultTolerationSeconds admission plugin's **300s** `node.kubernetes.io/unreachable:NoExecute` toleration. After 5 minutes of an unreachable node the controller issues the delete; the kubelet is gone and never confirms it; with no finalizer and no owning controller the object persists forever. That matches the observed signature exactly — `finalizers: []`, non-`Running`, one healthy pod surviving per namespace.
4. **No node-lifecycle-aware code exists hub-side.** There is no `client-go` dependency at all; all Kubernetes access shells out to `kubectl`. The hub reads node `Ready`/`NotReady` for capacity dashboards but never reacts to it — no watcher, no informer, no taint inspection, no drain/cordon logic.

**Where item 1 belongs:** the OKE / OpenShift cluster configuration, not this repo. Confirming *which* of spot/preemptible reclaim vs. autoscaler scale-down vs. an OKE node-lifecycle event is responsible requires querying the live clusters — correlating node deletion timestamps against the orphans' `deletionTimestamp` values and checking the node pools for preemptible capacity. The repo cannot answer it.

**In-repo mitigations that would reduce blast radius** (deliberately NOT done here — each changes production pod scheduling behaviour fleet-wide and deserves its own issue and its own review, not a quiet ride-along on a reporting PR): adding a PodDisruptionBudget and `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to the spoke template, and shortening the default 300s unreachable/not-ready `tolerationSeconds`.

## What remains unverified

- The count is verified against real predicate matches in unit tests and by mutation, but has **not** been observed against a live cluster carrying real orphans — the fleet was cleared by hand and the reaper now keeps it clear. First real read will be the first production confirmation.
- The 300s-toleration mechanism in (3) is strongly consistent with the evidence but is **inferred** from the absent spec fields; it is not proven against node-deletion timelines on the live clusters. That correlation is the next concrete step for item 1.
- Pull-only clusters report `nil` (unknown), not zero — the hub has no kubectl path into them. Their orphans remain uncounted and unreaped, the same known gap the reaper already has.

Item 1 is not fixed, so this is `Refs`, not `Fixes`.

Refs #5328