### PR TITLE
🧪 ci: trigger v2 test guards on guarded files (#5388)

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -22,12 +22,20 @@ on:
   # so a red PR fails the check without also filing an issue.
   pull_request:
     branches: [v2, v4]
-    # dashboard/openapi.json is in scope because the two guards that police it
-    # live under src/ (pkg/dashboard/openapi_route_parity_test.go and
-    # openapi_schema_parity_test.go) but the file they check does not. Without
-    # it a spec-only PR — the exact shape of the #5077 drift — would edit the
-    # published contract while running neither guard.
-    paths: ['src/**', 'dashboard/openapi.json', '.github/workflows/v2-tests.yml']
+    # Several package tests police shipped files outside src/: contributor
+    # scripts under bin/, the shared shell backend config, and Justfile recipes.
+    # Those files must trigger the tests that guard them; otherwise a change to
+    # the guarded side of a parity assertion skips the assertion entirely.
+    # dashboard/openapi.json is the same class: its route/schema guards live in
+    # src/pkg/dashboard, but the published contract does not. The contract test
+    # in pkg/github/ci_trigger_contract_test.go pins this complete relationship.
+    paths:
+      - 'src/**'
+      - 'bin/**'
+      - 'config/**'
+      - 'Justfile'
+      - 'dashboard/openapi.json'
+      - '.github/workflows/v2-tests.yml'
 
 permissions:
   contents: read

--- a/src/pkg/github/ci_trigger_contract_test.go
+++ b/src/pkg/github/ci_trigger_contract_test.go
@@ -1,0 +1,112 @@
+package github
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const v2TestsWorkflowPath = "../../../.github/workflows/v2-tests.yml"
+
+type workflowPathTriggers struct {
+	On struct {
+		PullRequest struct {
+			Paths []string `yaml:"paths"`
+		} `yaml:"pull_request"`
+	} `yaml:"on"`
+}
+
+// githubPathPatternMatches implements the subset of GitHub's path-filter glob
+// syntax used by v2-tests.yml. path.Match handles exact paths and single-level
+// globs; the explicit /** case gives directory patterns their recursive GitHub
+// meaning instead of Go's slash-stopping meaning.
+func githubPathPatternMatches(pattern, changed string) bool {
+	pattern = strings.TrimPrefix(pattern, "./")
+	changed = strings.TrimPrefix(changed, "./")
+	if prefix, ok := strings.CutSuffix(pattern, "/**"); ok {
+		return changed == prefix || strings.HasPrefix(changed, prefix+"/")
+	}
+	matched, err := path.Match(pattern, changed)
+	return err == nil && matched
+}
+
+func anyPathTriggerMatches(patterns []string, changed string) bool {
+	matched := false
+	for _, pattern := range patterns {
+		exclude := strings.HasPrefix(pattern, "!")
+		pattern = strings.TrimPrefix(pattern, "!")
+		if githubPathPatternMatches(pattern, changed) {
+			// GitHub evaluates path patterns in order: a later negative match
+			// excludes a path, and a later positive match can include it again.
+			matched = !exclude
+		}
+	}
+	return matched
+}
+
+func v2TestsPullRequestPaths(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(v2TestsWorkflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", v2TestsWorkflowPath, err)
+	}
+	var workflow workflowPathTriggers
+	if err := yaml.Unmarshal(raw, &workflow); err != nil {
+		t.Fatalf("parse %s: %v", v2TestsWorkflowPath, err)
+	}
+	paths := workflow.On.PullRequest.Paths
+	if len(paths) == 0 {
+		t.Fatalf("%s has no pull_request path filters; workflow parsing or trigger wiring drifted", v2TestsWorkflowPath)
+	}
+	return paths
+}
+
+// TestV2TestsTriggersForExternalPackageTestInputs closes the #5388 path-filter
+// exemption class. These are real repository files read by tests under
+// src/pkg/..., not illustrative filenames. A PR changing only one of them must
+// start v2-tests, or the relevant assertion is structurally unable to fail.
+func TestV2TestsTriggersForExternalPackageTestInputs(t *testing.T) {
+	paths := v2TestsPullRequestPaths(t)
+	externalInputs := []struct {
+		property string
+		changed  string
+	}{
+		{"agent launch stderr scrubbing", "bin/agent-launch.sh"},
+		{"container pane working directory", "bin/contributor-agent.sh"},
+		{"relay protocol compatibility", "bin/contributor-relay.sh"},
+		{"scoped GitHub App token isolation", "bin/gh-app-token.sh"},
+		{"pull request default-branch handling", "bin/hive-open-pr.sh"},
+		{"fresh-install release branch", "bin/hive-setup.sh"},
+		{"prerequisite install release branch", "bin/hive-prereq-check.sh"},
+		{"shell and Go backend parity", "config/backends.conf"},
+		{"contributor recipe behavior", "Justfile"},
+		{"OpenAPI route and schema parity", "dashboard/openapi.json"},
+		{"this trigger contract", ".github/workflows/v2-tests.yml"},
+	}
+	for _, input := range externalInputs {
+		t.Run(input.property, func(t *testing.T) {
+			if !anyPathTriggerMatches(paths, input.changed) {
+				t.Errorf("a PR changing only %s does not trigger v2-tests; the %s guard cannot fail", input.changed, input.property)
+			}
+		})
+	}
+}
+
+// TestV2TestsPathMatcherReproducesThePre5388Gap is the failure-direction
+// control: the matcher must reject the exact external inputs that the old
+// filter omitted. Without this control, an accidentally always-true matcher
+// could make the contract above green without proving any trigger property.
+func TestV2TestsPathMatcherReproducesThePre5388Gap(t *testing.T) {
+	oldPaths := []string{"src/**", "dashboard/openapi.json", ".github/workflows/v2-tests.yml"}
+	for _, changed := range []string{"bin/contributor-relay.sh", "config/backends.conf", "Justfile"} {
+		if anyPathTriggerMatches(oldPaths, changed) {
+			t.Errorf("pre-#5388 filters unexpectedly match %s; negative control no longer reproduces the exemption", changed)
+		}
+	}
+	if anyPathTriggerMatches([]string{"bin/**", "!bin/contributor-relay.sh"}, "bin/contributor-relay.sh") {
+		t.Error("a later negative pattern must exclude an earlier positive match")
+	}
+}


### PR DESCRIPTION
Addresses #5388

## Problem

The `v2 Tests` workflow is the PR gate that executes `go test ./pkg/...`, but its pull-request path filter only covered `src/**`, `dashboard/openapi.json`, and the workflow itself. A deliberate sweep of package tests found more guards whose inputs live outside `src/`:

- `bin/agent-launch.sh`, `bin/contributor-agent.sh`, and `bin/contributor-relay.sh` are read by stderr-scrubbing, pane-working-directory, and relay-protocol tests;
- `bin/gh-app-token.sh` and `bin/hive-open-pr.sh` are executed by credential-isolation and PR-request tests;
- `bin/hive-setup.sh` and `bin/hive-prereq-check.sh` are inspected by the fresh-install branch guard;
- `config/backends.conf` is sourced by the shell/Go backend and host-state deny-list parity tests;
- `Justfile` is inspected by contributor-recipe behavior tests.

A PR changing only one of those shipped files did not start `v2 Tests`. The relevant assertion could therefore be correct, present, and permanently green while the guarded side regressed—the same path-exemption failure described in #5388 for `dashboard/openapi.json`.

## Root cause

The workflow filter followed the location of the Go tests (`src/**`) rather than the complete set of files whose properties those tests assert. `v2-ci.yml` does run for `bin/**`, but it builds and vets without running the package unit suite, so that separate workflow did not close the gap. `config/backends.conf` and `Justfile` were outside the package-test trigger as well.

## Implementation

- `.github/workflows/v2-tests.yml` now includes `bin/**`, `config/**`, and `Justfile` in the PR path filter. The existing `src/**`, OpenAPI contract, and workflow-self entries remain intact.
- `src/pkg/github/ci_trigger_contract_test.go` parses the real workflow and evaluates whether every current repository-external package-test input would cause `v2 Tests` to run.
- The matcher checks the effective changed-file property rather than requiring a particular YAML shape. It accepts exact entries or broader equivalent globs, implements the recursive `/**` form used here, and honors GitHub's ordered negative-pattern behavior.

The directory filters are intentionally broader than today's exact filename list. Multiple packages already consume several `bin/` files, and an exact allow-list would recreate the same maintenance trap when the next script-backed package test is added. The additional CI cost is limited to PRs that change shipped contributor scripts/configuration or the root `Justfile`—the inputs whose package guards need a chance to fail.

## Regression evidence

`TestV2TestsTriggersForExternalPackageTestInputs` covers eleven external inputs/properties, including the workflow itself. `TestV2TestsPathMatcherReproducesThePre5388Gap` carries the old filter as a failure-direction control and confirms it does **not** match representative `bin/`, `config/`, or `Justfile` changes; it also proves a later negative glob excludes an earlier positive match.

The failure direction was also demonstrated against the real workflow during development. Temporarily removing the three new trigger entries made the contract exit 1 with nine named failures, including:

```text
a PR changing only bin/contributor-relay.sh does not trigger v2-tests; the relay protocol compatibility guard cannot fail
a PR changing only config/backends.conf does not trigger v2-tests; the shell and Go backend parity guard cannot fail
a PR changing only Justfile does not trigger v2-tests; the contributor recipe behavior guard cannot fail
```

Restoring the entries returned the same test to green, and the committed tree is clean.

## Verification

- `go test ./pkg/github -run '^TestV2Tests' -count=1` — PASS
- targeted existing guards across `./pkg/agent ./pkg/config ./pkg/dashboard ./pkg/github` with `-short -count=1` — PASS
- `go test ./pkg/github -short -count=1` — PASS (full package, 44.758s)
- `go vet ./pkg/github` — PASS
- `bash src/scripts/check-release-lines.sh` — PASS; every pinned workflow still covers `v2,v4`
- `git diff --check` — PASS

The first sandboxed cross-package attempt could not download missing declared Go modules, and the first full-package attempt could not bind the loopback sockets used by `httptest`; rerunning with the required network/loopback access passed as recorded above. These were environment restrictions, not test failures in the change.

## Scope

This PR closes the concrete path-filter exemptions found in the requested sweep and prevents their current form from returning. It does not change runtime behavior, make unrelated conditional test skips fatal, or claim that every shape-oriented assertion in the repository has been converted in one change. No changelog entry is included because this is CI and regression-test wiring, not a user-visible product change.

— hive: backend=codex
