### PR TITLE
🐛 close two path-filter exemptions and three shape-vs-property assertions (#5388)

### DIFF
--- a/.github/workflows/dashboard-lint.yml
+++ b/.github/workflows/dashboard-lint.yml
@@ -1,11 +1,23 @@
 name: Dashboard Lint
+
+# The checker itself is in scope, not just the files it checks (#5388).
+# The syntax-check job runs .github/scripts/check-inline-js.js, but the filter
+# named only 'dashboard/**' — so a change that broke the checker (or silently
+# stopped it detecting anything) ran no CI at all, and the next dashboard PR
+# would then pass against a checker nobody had exercised. The workflow file is
+# listed for the same reason: an edit to the `find` invocation here changes
+# what gets checked, and that edit must run the job it changes.
 on:
   push:
     paths:
       - 'dashboard/**'
+      - '.github/scripts/check-inline-js.js'
+      - '.github/workflows/dashboard-lint.yml'
   pull_request:
     paths:
       - 'dashboard/**'
+      - '.github/scripts/check-inline-js.js'
+      - '.github/workflows/dashboard-lint.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/go-security-analysis.yml
+++ b/.github/workflows/go-security-analysis.yml
@@ -36,13 +36,22 @@ name: Go Security Analysis
 # correct and complete attribution. See that job's own comment for the full
 # reasoning.
 
+# NOTICE is in the path filter because the notice-drift job below compares the
+# COMMITTED repo-root NOTICE byte-for-byte against a fresh regeneration
+# (`check-notice-drift.sh NOTICE /tmp/NOTICE.generated`). NOTICE does not live
+# under src/, so before #5388 a PR editing NOTICE alone — hand-correcting an
+# attribution, or reverting the autofix commit — changed the exact file this
+# gate polices while running neither that gate nor anything else. The drift
+# would surface only on the next unrelated src/ change, attributed to that PR.
+# Same shape as dashboard/openapi.json in v2-tests.yml: guarded by a job whose
+# filter excluded it.
 on:
   push:
     branches: [v2, v4]
-    paths: ['src/**', '.github/workflows/**', '.github/release-lines.yml']
+    paths: ['src/**', 'NOTICE', '.github/workflows/**', '.github/release-lines.yml']
   pull_request:
     branches: [v2, v4]
-    paths: ['src/**', '.github/workflows/**', '.github/release-lines.yml']
+    paths: ['src/**', 'NOTICE', '.github/workflows/**', '.github/release-lines.yml']
   schedule:
     # Weekly, so a newly-PUBLISHED advisory against unchanged code is still
     # found. A push-only trigger cannot catch that: the vulnerability appears

--- a/src/deploy/test_quadlet_config_contract.sh
+++ b/src/deploy/test_quadlet_config_contract.sh
@@ -327,7 +327,14 @@ fi
 
 # And the gateway must still carry the stop-direction half, or stopping hive
 # would leave an orphaned gateway serving 502s.
-if [[ -f "${ROOT}/${GATEWAY_UNIT}" ]]; then
+#
+# need_file, not a bare `[[ -f ]]`: GATEWAY_UNIT is not covered by need_file
+# anywhere else in this file (UNIT is, in sections 1-4), so a bare existence
+# test made this the one section that could vanish silently. Deleting
+# hive-gateway.container dropped the run from 14 assertions to 13 and still
+# exited 0 — the guard reported PASS for a repo with no gateway unit at all
+# (#5388). need_file turns that into a failure.
+if need_file "${GATEWAY_UNIT}"; then
   if grep -qE '^Requires=hive\.service[[:space:]]*$' "${ROOT}/${GATEWAY_UNIT}" \
      && grep -qE '^After=hive\.service[[:space:]]*$' "${ROOT}/${GATEWAY_UNIT}"; then
     ok

--- a/src/pkg/config/backend_validation_test.go
+++ b/src/pkg/config/backend_validation_test.go
@@ -17,6 +17,16 @@ func TestValidateBackend_AcceptsWatsonx(t *testing.T) {
 	}
 }
 
+// Ranging over SupportedBackends() alone is tautological (#5388):
+// SupportedBackends() is exactly CLIBackends ++ InferenceBackends, and
+// ValidateBackend returns nil early iff IsCLIBackend(b) || IsInferenceBackend(b).
+// Every element it yields satisfies that disjunction by construction, so the
+// gateway branch and the error-formatting branch below it are unreachable for
+// these inputs and no edit to either list can fail the loop.
+//
+// The loop is kept — it is cheap and it does pin the early-return path — but
+// the assertions that can actually fail are the ones after it: a rejection
+// that must happen, and the gateway acceptance path the loop never reaches.
 func TestValidateBackend_AcceptsAllSupported(t *testing.T) {
 	var g GovernorConfig
 	// Empty means "hive default" and must stay valid.
@@ -27,6 +37,13 @@ func TestValidateBackend_AcceptsAllSupported(t *testing.T) {
 		if err := g.ValidateBackend(b); err != nil {
 			t.Errorf("ValidateBackend(%q) = %v, want nil", b, err)
 		}
+	}
+
+	// A name in NEITHER list and matching no gateway must be rejected. Without
+	// this, a ValidateBackend rewritten to `return nil` unconditionally would
+	// pass every assertion above.
+	if err := g.ValidateBackend("definitely-not-a-backend"); err == nil {
+		t.Error("ValidateBackend(definitely-not-a-backend) = nil, want an error — validation accepts anything")
 	}
 }
 

--- a/src/pkg/config/litellm_test.go
+++ b/src/pkg/config/litellm_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -115,12 +116,38 @@ governor:
 // config.IsInferenceBackend — canonical list
 // ---------------------------------------------------------------------------
 
+// The want-set is written out literally rather than ranged over from
+// InferenceBackends. Ranging over the very slice IsInferenceBackend linearly
+// scans is tautological: every element is a member by construction, so the
+// scan always hits on that element and NO edit to the list can fail the test.
+// Verified (#5388) by replacing the list with
+// []string{"vllm", "totally-bogus-backend"} — dropping litellm and watsonx and
+// inventing a backend that does not exist — and watching the loop still pass.
+// An independent literal is what makes a wrong list a red test.
+//
+// Adding a real inference backend means adding it in BOTH places, which is the
+// point: the second edit is a deliberate confirmation, not a formality.
 func TestIsInferenceBackend_Config(t *testing.T) {
-	for _, b := range InferenceBackends {
+	want := []string{"vllm", "llm-d", "litellm", "watsonx"}
+
+	for _, b := range want {
 		if !IsInferenceBackend(b) {
 			t.Errorf("IsInferenceBackend(%q) = false, want true", b)
 		}
 	}
+
+	// The converse: nothing may quietly JOIN the canonical list either. Without
+	// this, adding a backend to InferenceBackends alone still passes.
+	if len(InferenceBackends) != len(want) {
+		t.Errorf("InferenceBackends = %v (%d entries), want %v (%d). A backend was added or removed without updating this test's want-set.",
+			InferenceBackends, len(InferenceBackends), want, len(want))
+	}
+	for _, b := range InferenceBackends {
+		if !slices.Contains(want, b) {
+			t.Errorf("InferenceBackends contains %q, which this test does not expect. Add it to want above if it is genuinely an inference backend.", b)
+		}
+	}
+
 	if IsInferenceBackend("claude") {
 		t.Error("IsInferenceBackend(claude) = true, want false")
 	}

--- a/src/pkg/hub/server_handlers_coverage_test.go
+++ b/src/pkg/hub/server_handlers_coverage_test.go
@@ -337,9 +337,23 @@ func TestHandleStats_EmptyRegistry(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
+	// Presence AND value. The registry is empty, so the expected answer for
+	// every counter is 0 — asserting only that the key exists (#5388) let any
+	// count through, including garbage, in the one test whose name states what
+	// the numbers have to be.
 	for _, key := range []string{"hives", "online", "agents", "contributors", "issues", "prs"} {
-		if _, ok := resp[key]; !ok {
+		v, ok := resp[key]
+		if !ok {
 			t.Errorf("response missing key %q", key)
+			continue
+		}
+		n, isNum := v.(float64)
+		if !isNum {
+			t.Errorf("%s = %v (%T), want a JSON number", key, v, v)
+			continue
+		}
+		if n != 0 {
+			t.Errorf("%s = %v, want 0 — the registry is empty", key, n)
 		}
 	}
 }


### PR DESCRIPTION
## What this does

Two follow-ups from #5388: a path-filter exemption sweep, and a shape-vs-property audit. Every change here is demonstrated against the bug it exists to catch, per the standard #5383 and #5384 set. No existing assertion is weakened — every change strictly ADDS a failure mode. No lane is made a required status check.

## 1. Path-filter exemptions (sweep complete)

Enumerated every `paths:` filter in `.github/workflows/*.yml` and compared it against what each workflow's jobs actually read. Nine workflows have filters; two had a real exemption.

**Fixed — `go-security-analysis.yml`.** The `notice-drift` job ends with `check-notice-drift.sh NOTICE /tmp/NOTICE.generated`, a byte-for-byte comparison of the COMMITTED repo-root `NOTICE` against a fresh regeneration. `NOTICE` is not under `src/`, and the filter was `['src/**', '.github/workflows/**', '.github/release-lines.yml']`. A PR editing `NOTICE` alone changed the exact file this gate polices while running neither that gate nor anything else. Not hypothetical: `notice-autofix.yml` commits a generated NOTICE unattended, and a human correcting or reverting that commit touches `NOTICE` and nothing else. The drift would then surface on the next unrelated `src/` change, blamed on that PR.

**Fixed — `dashboard-lint.yml`.** The `syntax-check` job runs `.github/scripts/check-inline-js.js`, but the filter named only `dashboard/**`. A change breaking the checker — or silently stopping it detecting anything — ran no CI, and the next dashboard PR would pass against a checker nobody had exercised. The workflow file is added for the same reason: the `find` invocation decides what gets checked.

Demonstrated:

```
changed=NOTICE                              before=SKIPPED  after=RUNS
changed=.github/scripts/check-inline-js.js  before=SKIPPED  after=RUNS
```

Confirmed live on this branch: **Dashboard Lint ran and passed on commit `f3a357c`, which touches zero `dashboard/` files.** Under the old filter that run would not exist. And the NOTICE gate has real teeth once it runs — appending `" [hand-edited]"` to a single `License:` line makes `check-notice-drift.sh` emit a diff and fail.

**Checked and clean:** `v2-ci.yml` (quadlet/compose/standalone contract tests all resolve under `src/` or `docs/`, both in the filter), `v2-tests.yml` (`dashboard/openapi.json` already added), `suid-contract.yml` (all derived inputs listed, incl. `saas_provision.go`), `image-attestation-guard.yml`, `release-line-guard.yml`, `podman-contract.yml`, `docs-link-check.yml`. The four podman/quadlet lanes have no path filter at all, so no exemption is possible.

**Reported, not changed — judgement calls:**
- **`docs/` at repo root is never link-checked.** `docs-link-check.yml` covers `src/docs/` and the wiki only. This is a coverage gap rather than a filter exemption, and widening it would newly gate ~20 files that have never been checked — likely red on arrival. Worth its own issue.
- **`docs-link-check.yml` excludes v2 deliberately**, documented in `release-lines.yml`. Left alone.

## 2. Shape-vs-property audit

Two sweeps (shell guards, Go tests). Fixed the clear, small ones; the rest are prioritised below for follow-up issues.

### Fixed

**`test_quadlet_config_contract.sh` reported PASS with no gateway unit at all.** The file defines `need_file()`, which FAILS when an asserted-about file is missing. Sections 1–4 use it for `hive.container`. Section 10 — `hive-gateway.container`'s `Requires=`/`After=hive.service`, the stop-direction half of the dependency — used a bare `[[ -f ]]` with no else, and `GATEWAY_UNIT` is passed to `need_file` nowhere else. So it was the one section that could evaporate silently:

```
clean tree                                    PASS: 14 assertions   exit 0
rm src/deploy/quadlet/hive-gateway.container
  before this PR                              PASS: 13 assertions   exit 0   <-- green
  after  this PR                              FAIL: expected file is missing, exit 1
file restored                                 PASS: 14 assertions   exit 0
```

The pre-fix line is the bug: a repo shipping no gateway unit, with the guard policing that unit reporting PASS. The count dropped 14→13 and nothing compares it to an expected total.

**`TestIsInferenceBackend_Config` was tautological.** It ranged over the very slice the function linearly scans, so every element was a member by construction and NO edit to the list could fail it. Replacing the list with `[]string{"vllm", "totally-bogus-backend"}` — dropping `litellm` and `watsonx`, inventing a backend that does not exist — **passed**. It now asserts an independent literal want-set plus a length check, and the same mutation produces five failures. (`KNOWN_BACKENDS` in `config/backends.conf` was considered as the external source but covers CLI backends only; `vllm`/`watsonx` are absent.)

**`TestHandleStats_EmptyRegistry` never asserted the registry was empty.** Presence-only loop over six counters, in the test whose name states the expected answer is 0. Making `handleStats` report `"agents": 42` left it green; it now fails, and type-checks each value is a JSON number.

**`TestValidateBackend_AcceptsAllSupported`** — same tautological shape (`SupportedBackends()` is exactly the union `ValidateBackend` early-returns nil on). Added a rejection assertion. Being straight about value: a sibling test already caught the `return nil` rewrite, so this is defence-in-depth; the tautology comment is the substantive part, stopping the loop being read as coverage it does not provide.

### Prioritised — recommend follow-up issues

**P1 — `api_routes_coverage_test.go` (591 lines, 30 × `Code != 200`).** Lines 25–35 assert `/api/trends` returns 200 across `?range=day`, `?range=week`, `?hours=48`, `?hours=99999` while never decoding a body — a handler ignoring the range parameter entirely passes all five. LARGE: deciding correct per-endpoint payloads is design work.

**P1 — self-disarming skips whose skip condition IS the guarded coupling.** Highest: `pkg/dashboard/f16_owner_gate_test.go:94-96` skips if `handleGovernorSecurity` no longer contains `AgentSandboxEnabled` — renaming the toggle silently retires the owner-gate assertion on a security surface. Also `pkg/hub/error_pages_backend_test.go:187-189` (its own comment asks this "be revisited rather than silently kept green"), `pkg/config/entrypoint_boot_test.go:370-372`, `pkg/dashboard/backend_picker_parity_test.go:194` (evaporates on a tooltip copy edit), `pkg/worksource/github_issues_test.go:79-83`. Each is a one-line `Skip`→`Fatal`, but it changes CI outcomes and may turn lanes red immediately — **explicitly deferred as adjacent to item 3 of #5388, which is out of scope here pending a maintainer decision.**

**P2 — `check-podman-contract.sh` greps the whole 2000-line Justfile unscoped** (`:Z`, `--userns=keep-id`). The property is that the podman branch of `contribute-hive` applies them; the assertion is that the string appears anywhere. Green today for the right reason, but would stay green if the flag moved to a comment or dead branch. `test_attach_hint_runtime.sh:48` already has the correct pattern (extract the block with `awk`, assert within it). SMALL, but it changes a guard I could not demonstrate failing without a live podman run, so reported rather than rushed.

**P2 — `test_watchtower_socket_contract.sh:229-244` asserts the risk is DOCUMENTED, not true** — `grep -qF "host root"` matches any sentence containing those words, including one denying the risk. The same file's lines 200–214 already assert the real property structurally.

**P2 — mode-only permission assertions (~40 sites)** comparing against the same constant production chmods with, so they cannot catch a wrong CHOICE of mode: `pkg/agent/seams_coverage_test.go:201-203`, `bob_settings_test.go:187,232` (its comment states the real property — "must stay group-writable or the next agent's own startup write fails" — never exercised), `mint_token_cache_test.go:68-69`. Done right already in `pluk_publisher_test.go:136-143`. Constant→literal is SMALL; exercising a real group write is LARGE.

**P3 — presence-only assertions:** `pkg/hub/openrouter_coverage_test.go:183-185`, `pkg/dashboard/contribute_metrics_test.go:211-225` (doc comment claims it "pins the on-disk JSON keys" but pins presence only, with correct values seeded and unasserted), `contribute_metrics_endpoint_test.go:31-40`.

**P3 — `probe_boot_transaction_coupling.sh:104`** exits **0** on missing podman where its four siblings use `fail_prereq` → exit 78. Reported, not changed: it is wired into no workflow and `src/deploy/README.md` documents "skips cleanly" as intended. Convention call for a maintainer.

### Verified clean — deliberately untouched

`openapi_schema_parity_test.go` and `openapi_route_parity_test.go` (the #5077/#5384 fixes — AST-parses real registrations, both directions, fails on stale exceptions), `backend_list_parity_test.go`, `check-notice-drift.sh`, `check-no-image-attestations.sh` (refuses to pass on zero steps — the anti-vacuity pattern others should copy), `test_supply_chain_pins.sh`, `test_ambient_cap_runtime.sh` (boots containers, reads `CapAmb`, includes a negative control), `test_attach_hint_runtime.sh`, `cmd/hive/identity_guard_test.go`. `check-suid-contract.sh`'s static greps look like the antipattern but are a deliberate fast-fail layer over `test_image_suid_inventory.sh`, which boots the image and reads the inventory back.

## Not swept

1450 test files, prioritised by filename and targeted greps per antipattern class. `pkg/proxy`, `pkg/governor`, `pkg/hubbackup`, `pkg/tui`, `pkg/discord` not exhaustively read. The 213 `len(x) == 0` and 291 source-text `strings.Contains` sites were sampled, not triaged — the Contains-on-production-source family is itself a shape-vs-property class deserving its own sweep.

## Verification

- `check-release-lines.sh`: **PASS** — both touched workflows are pinned in `.github/release-lines.yml`.
- Both workflows parse (Dashboard Lint and Release Line Guard both completed on this branch; no 422).
- Grepped for empty `${{` `}}` across `.github/` per #5339 — none.
- Action pins untouched; neighbour style preserved.
- `gofmt` clean on all touched Go files.
- Pre-existing unrelated failure `TestEntrypointHardensRuntimeConfigItRecreates` (the #5380 container-lane family) reproduces on pristine `origin/v4` and is untouched.

## Coordination

No overlap with the concurrent agents: this PR touches two workflow YAMLs, one shell guard, and three Go test files. #5390/#5394 is in `src/cmd/hive/` and `src/pkg/dashboard/contribute_ws.go`; #5391 and #5328 are elsewhere in `src/pkg/`. Confirmed disjoint against #5394's file list.

Item 3 of #5388 (making `skip` fatal generally) is out of scope; candidates are listed under P1 above.

Refs #5388
