### PR TITLE
fix(hub): debounce merge-driven self-upgrade so a merge burst rolls once

### DIFF
--- a/src/pkg/hub/assignment_upgrade_latch_test.go
+++ b/src/pkg/hub/assignment_upgrade_latch_test.go
@@ -97,6 +97,8 @@ func TestAutoUpgradeLatchedWhileClaimInFlight(t *testing.T) {
 // TestAutoUpgradeResumesAfterClaimDelivered proves the latch RELEASES: the same
 // hive, once ClaimDelivered flips true, is eligible again and upgrades.
 func TestAutoUpgradeResumesAfterClaimDelivered(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	primeBehindLatest(t)
@@ -121,6 +123,8 @@ func TestAutoUpgradeResumesAfterClaimDelivered(t *testing.T) {
 // AVAILABLE placeholder is not assigned, so it is not in-flight and upgrades
 // normally.
 func TestAutoUpgradeAvailablePlaceholderUpgrades(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	primeBehindLatest(t)
@@ -143,6 +147,8 @@ func TestAutoUpgradeAvailablePlaceholderUpgrades(t *testing.T) {
 // TestAutoUpgradeLiveClaimedHiveUpgrades is the ordinary case: a live, fully
 // claimed hive (status set, ClaimDelivered=true) upgrades normally.
 func TestAutoUpgradeLiveClaimedHiveUpgrades(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	primeBehindLatest(t)

--- a/src/pkg/hub/pullonly_upgrade_test.go
+++ b/src/pkg/hub/pullonly_upgrade_test.go
@@ -57,6 +57,8 @@ func pullOnlyTestServer(t *testing.T) *HubServer {
 // disable auto-upgrade for 40+ healthy spokes; this test fails if anyone
 // reintroduces one.
 func TestPullOnlyHiveThatHeartbeatsStillUpgrades(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
@@ -148,6 +150,8 @@ func TestAutoUpgradeNotArmedForLongDeadHive(t *testing.T) {
 // it is restarting into an upgrade — must still be armed. Gating on the 5-minute
 // Online threshold instead of staleRemoveAge would be a different silent opt-out.
 func TestBrieflyQuietHiveStillUpgrades(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
@@ -273,6 +277,8 @@ func TestUncollectibleUpgradeCannotAccumulateStaleness(t *testing.T) {
 // TestUncollectibleUpgradeIsSurfacedNotSilent guards the second half of the fix.
 // Silence is how the original wedge went unnoticed.
 func TestUncollectibleUpgradeIsSurfacedNotSilent(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
@@ -304,6 +310,8 @@ func TestUncollectibleUpgradeIsSurfacedNotSilent(t *testing.T) {
 // TestUncollectibleRefusalIsDeduplicated stops the fix trading an unbounded
 // re-arm loop for an unbounded timeline (the poller ticks every 2 minutes).
 func TestUncollectibleRefusalIsDeduplicated(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
@@ -379,6 +387,8 @@ func TestUpgradeBranchDefaultsToHubBranchNotV2(t *testing.T) {
 // that CAN collect — which is where a foreign-branch target is actually
 // dangerous, because the spoke picks it up and rolls itself onto a v2 build.
 func TestLiveHiveNeverTargetedWithForeignBranchSHA(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
@@ -420,6 +430,8 @@ func TestLiveHiveNeverTargetedWithForeignBranchSHA(t *testing.T) {
 // The positive half is that the upgrade is still DELIVERED — via the heartbeat —
 // so this cannot pass by simply breaking upgrades.
 func TestUpgradePathNeverShellsOutToCluster(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -6376,11 +6376,12 @@ func (s *HubServer) triggerAutoUpgrades() {
 		// keeps its daily/weekly window open.
 		debounce := shouldDebounceAutoUpgrade(
 			autoUpgradeDebounceState{
-				Target:    h.AutoUpgradePendingTarget,
-				ArmedAt:   h.AutoUpgradePendingSince,
-				Collapsed: h.AutoUpgradeCollapsed,
+				Target:       h.AutoUpgradePendingTarget,
+				ArmedAt:      h.AutoUpgradePendingSince,
+				FirstArmedAt: h.AutoUpgradePendingFirst,
+				Collapsed:    h.AutoUpgradeCollapsed,
 			},
-			latestSHA, autoUpgradeDebounceInterval(), time.Now())
+			latestSHA, autoUpgradeDebounceInterval(), autoUpgradeMaxHold(), time.Now())
 		if !debounce.Allowed {
 			// Persist the (possibly just-replaced) pending target so a hub
 			// restart inside the window resumes it rather than dropping it.

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -6361,6 +6361,48 @@ func (s *HubServer) triggerAutoUpgrades() {
 		if latestSHA == "" || sameCommit(currentSHA, latestSHA) {
 			continue
 		}
+		// Merge-driven debounce (#5391). Reached ONLY on the automatic
+		// chase-latest path: everything that starts an upgrade for an operator
+		// — a manual "Upgrade now" (upgradeHiveHandler), a bulk upgrade
+		// (saas_bulk.go), and a hard image pin (delivered as UpgradeTarget
+		// through the stale-recovery branch ABOVE the `if !h.AutoUpgrade` gate)
+		// — arms s.heartbeatUpgrade directly and never enters this loop body.
+		// So an operator's upgrade and a pin stay IMMEDIATE by construction,
+		// and only the merge-frequency-driven roll is held.
+		//
+		// Placed after every eligibility gate above so a hive that would not
+		// upgrade anyway never arms a window, and before the wave gate and the
+		// fire-date persistence below so a debounced hive costs no wave slot and
+		// keeps its daily/weekly window open.
+		debounce := shouldDebounceAutoUpgrade(
+			autoUpgradeDebounceState{
+				Target:    h.AutoUpgradePendingTarget,
+				ArmedAt:   h.AutoUpgradePendingSince,
+				Collapsed: h.AutoUpgradeCollapsed,
+			},
+			latestSHA, autoUpgradeDebounceInterval(), time.Now())
+		if !debounce.Allowed {
+			// Persist the (possibly just-replaced) pending target so a hub
+			// restart inside the window resumes it rather than dropping it.
+			s.persistUpgradeDebounceState(&h, debounce.State)
+			s.logger.Info("auto-upgrade debounced — holding for a quiet branch",
+				"hive_id", h.ID, "branch", branch,
+				"target", debounce.State.Target, "current", currentSHA,
+				"collapsed", debounce.State.Collapsed,
+				"debounce", autoUpgradeDebounceInterval(),
+				"reason", debounce.Reason)
+			continue
+		}
+		if debounce.Collapsed > 0 {
+			// Report the collapse. Silent batching would trade one invisible
+			// problem for another: without this line, N merges producing one
+			// roll is indistinguishable from N-1 upgrades having been lost.
+			s.logger.Info("auto-upgrade debounce collapsed a merge burst into one roll",
+				"hive_id", h.ID, "branch", branch,
+				"merges_collapsed", debounce.Collapsed+1,
+				"final_target", latestSHA, "current", currentSHA,
+				"debounce", autoUpgradeDebounceInterval())
+		}
 		hiveCluster := s.clusterForHive(&h)
 		if hiveCluster == nil {
 			s.logger.Warn("auto-upgrade skipped — no cluster config", "hive_id", h.ID, "cluster_id", h.ClusterID)
@@ -6424,6 +6466,13 @@ func (s *HubServer) triggerAutoUpgrades() {
 					"hive_id", h.ID, "date", decision.FireDate, "error", err)
 			}
 		}
+		// Clear the debounce record now the roll is actually going out. Cleared
+		// HERE, after every gate that could still `continue`, so a hive turned
+		// away by the wave gate keeps its pending target and simply boards a
+		// later wave instead of re-arming a fresh window each cycle. Clearing
+		// before the rollout (like the fire date above) means a hub crash in
+		// between costs at most a re-armed window, never a duplicate roll.
+		s.persistUpgradeDebounceState(&h, autoUpgradeDebounceState{})
 		// The hive is deliverable again — drop any suppressed-refusal memory so a
 		// future undeliverable episode is reported afresh rather than swallowed.
 		s.forgetUncollectibleUpgrade(h.ID)

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -770,8 +770,13 @@ type SaaSHive struct {
 	// All three are omitempty and absent on every existing record, which reads
 	// as "nothing pending" — so meta.json stays byte-identical for the fleet
 	// until a hive actually has an upgrade waiting.
+	// AutoUpgradePendingFirst is when the hive FIRST fell behind and began
+	// waiting. Unlike AutoUpgradePendingSince it survives re-arming, and it is
+	// what the max-hold cap is measured against — on a branch that never goes
+	// quiet it is the only clock that does not reset.
 	AutoUpgradePendingTarget string    `json:"auto_upgrade_pending_target,omitempty"`
 	AutoUpgradePendingSince  time.Time `json:"auto_upgrade_pending_since,omitempty"`
+	AutoUpgradePendingFirst  time.Time `json:"auto_upgrade_pending_first,omitempty"`
 	AutoUpgradeCollapsed     int       `json:"auto_upgrade_collapsed,omitempty"`
 
 	// GitHubBaseURL / GitHubAPIURL pin this hive's GitHub host. The GitHub

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -755,6 +755,25 @@ type SaaSHive struct {
 	// which are never gated and never record a date.
 	AutoUpgradeLastFired string `json:"auto_upgrade_last_fired,omitempty"`
 
+	// AutoUpgradePendingTarget / AutoUpgradePendingSince / AutoUpgradeCollapsed
+	// are the merge-driven upgrade DEBOUNCE state (#5391): the newest SHA seen
+	// while waiting for the branch to go quiet, when that target was first
+	// observed, and how many earlier targets it superseded.
+	//
+	// They live on the PVC rather than in memory for one reason: a hub restart
+	// inside the quiet window must not DROP a pending upgrade. Dropping one
+	// silently is a worse failure than rolling too often, which is the whole
+	// thing this debounce exists to reduce. On restart the window resumes from
+	// the stored AutoUpgradePendingSince, so the wait is neither lost nor
+	// restarted.
+	//
+	// All three are omitempty and absent on every existing record, which reads
+	// as "nothing pending" — so meta.json stays byte-identical for the fleet
+	// until a hive actually has an upgrade waiting.
+	AutoUpgradePendingTarget string    `json:"auto_upgrade_pending_target,omitempty"`
+	AutoUpgradePendingSince  time.Time `json:"auto_upgrade_pending_since,omitempty"`
+	AutoUpgradeCollapsed     int       `json:"auto_upgrade_collapsed,omitempty"`
+
 	// GitHubBaseURL / GitHubAPIURL pin this hive's GitHub host. The GitHub
 	// host is a property of the HIVE (where its org/repos live), not the
 	// cluster: a cluster-level GHE default silently breaks hives for

--- a/src/pkg/hub/scale_settings.go
+++ b/src/pkg/hub/scale_settings.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 // Admin-editable scale settings.
@@ -32,11 +33,18 @@ type ClusterScaleOverride struct {
 // ScaleSettings is the persisted document. Zero values mean "not set" —
 // the env-var / built-in default chain applies.
 type ScaleSettings struct {
-	UpgradeWaveSize     int                             `json:"upgrade_wave_size,omitempty"`
-	ProvisionWorkers    int                             `json:"provision_workers,omitempty"`
-	ProvisionPerCluster int                             `json:"provision_per_cluster,omitempty"`
-	KubectlPerCluster   int                             `json:"kubectl_per_cluster,omitempty"`
-	Clusters            map[string]ClusterScaleOverride `json:"clusters,omitempty"`
+	UpgradeWaveSize     int `json:"upgrade_wave_size,omitempty"`
+	ProvisionWorkers    int `json:"provision_workers,omitempty"`
+	ProvisionPerCluster int `json:"provision_per_cluster,omitempty"`
+	KubectlPerCluster   int `json:"kubectl_per_cluster,omitempty"`
+	// UpgradeDebounceSeconds is the merge-driven upgrade quiet period (#5391).
+	// Zero means "not set" — every existing settings document omits the field —
+	// and falls through to HIVE_UPGRADE_DEBOUNCE_SECONDS and then
+	// defaultAutoUpgradeDebounceInterval. A NEGATIVE value explicitly DISABLES
+	// debouncing and restores roll-on-every-merge. Resolved by
+	// autoUpgradeDebounceInterval(), not settingOrEnv, which clamps to >= 1.
+	UpgradeDebounceSeconds int                             `json:"upgrade_debounce_seconds,omitempty"`
+	Clusters               map[string]ClusterScaleOverride `json:"clusters,omitempty"`
 }
 
 var (
@@ -186,13 +194,17 @@ func (s *HubServer) handleGetScaleSettings(w http.ResponseWriter, r *http.Reques
 			"provision_workers":     provisionWorkerCount(),
 			"provision_per_cluster": provisionPerClusterCap(),
 			"kubectl_per_cluster":   kubectlMaxPerCluster(),
+			// Reported in seconds to match the input's unit, so the card shows
+			// the same number the operator typed. 0 = debouncing disabled.
+			"upgrade_debounce_seconds": int(autoUpgradeDebounceInterval() / time.Second),
 		},
 		Clusters: rows,
 		Defaults: map[string]int{
-			"upgrade_wave_size":     defaultUpgradeWaveSize,
-			"provision_workers":     defaultProvisionWorkers,
-			"provision_per_cluster": defaultProvisionPerCluster,
-			"kubectl_per_cluster":   defaultKubectlMaxPerCluster,
+			"upgrade_wave_size":        defaultUpgradeWaveSize,
+			"provision_workers":        defaultProvisionWorkers,
+			"provision_per_cluster":    defaultProvisionPerCluster,
+			"kubectl_per_cluster":      defaultKubectlMaxPerCluster,
+			"upgrade_debounce_seconds": int(defaultAutoUpgradeDebounceInterval / time.Second),
 		},
 	})
 }
@@ -221,6 +233,16 @@ func (s *HubServer) handleSetScaleSettings(w http.ResponseWriter, r *http.Reques
 			http.Error(w, `{"error":"values must be 0..10000 (0 = use default)"}`, http.StatusBadRequest)
 			return
 		}
+	}
+	// UpgradeDebounceSeconds is validated separately: unlike every knob above,
+	// a NEGATIVE value is meaningful here (the explicit "disable debouncing"
+	// escape hatch), so it cannot share the >= 0 rule. The upper bound still
+	// applies — a debounce longer than maxScaleSettingValue seconds is a typo,
+	// and an over-long quiet window would hold upgrades rather than merely
+	// slowing them.
+	if in.UpgradeDebounceSeconds > maxScaleSettingValue {
+		http.Error(w, `{"error":"upgrade_debounce_seconds must be <= 10000 (0 = use default, negative = disabled)"}`, http.StatusBadRequest)
+		return
 	}
 	for id, o := range in.Clusters {
 		if _, ok := s.clusters[id]; !ok {

--- a/src/pkg/hub/upgrade_debounce.go
+++ b/src/pkg/hub/upgrade_debounce.go
@@ -247,7 +247,21 @@ func shouldDebounceAutoUpgrade(prev autoUpgradeDebounceState, target string, int
 			collapsed++
 			reason = "debounce re-armed — newer target supersedes the pending one"
 		}
-		if firstArmed.IsZero() {
+		// A record with no live pending target cannot contribute a wait clock.
+		// prev.Target == "" means the previous cycle was not actually holding
+		// anything — the hive caught up by another route (a manual upgrade, a
+		// channel switch) and the target was consumed without this gate
+		// clearing the record. Inheriting FirstArmedAt from it would make the
+		// cap read "already waited hours" and fire on the FIRST cycle of a
+		// genuinely new merge, silently skipping the debounce for it.
+		//
+		// This is keyed on PROVENANCE, not on elapsed time. An earlier attempt
+		// treated "older than maxHold" as the staleness signal, which is wrong
+		// and dangerous: on a branch whose merge gap exceeds the poll step the
+		// reset fires before the cap can, pushing the clock forward every cycle
+		// so the cap NEVER fires and the hive starves completely (measured: a
+		// 7-minute merge cadence produced ZERO rolls in 4.5 hours).
+		if firstArmed.IsZero() || prev.Target == "" {
 			firstArmed = now
 		}
 		next := autoUpgradeDebounceState{

--- a/src/pkg/hub/upgrade_debounce.go
+++ b/src/pkg/hub/upgrade_debounce.go
@@ -72,6 +72,29 @@ import (
 // unrelated reasons.
 const defaultAutoUpgradeDebounceInterval = 5 * time.Minute
 
+// defaultAutoUpgradeMaxHold bounds how long a single pending upgrade may be
+// deferred by repeated re-arming, regardless of how busy the branch is.
+//
+// This is not belt-and-braces; it is required by the MEASURED cadence of the
+// branch being debounced. Sampling the last 100 merges to v4 (2026-08-30 19:07Z
+// → 2026-08-31 23:33Z): the MEDIAN inter-merge gap is 3.0 minutes, 63% of gaps
+// are under 5 minutes, and the longest observed run of consecutive sub-5-minute
+// gaps is 13 — which a pure debounce would turn into a ~50-minute hold, and on a
+// busier day an unbounded one.
+//
+// A pure debounce is therefore the wrong shape on its own here: "wait for quiet"
+// assumes quiet arrives, and on this branch it frequently does not. The max hold
+// converts the guarantee from "rolls once the branch goes quiet" into "rolls
+// once the branch goes quiet, and in no case later than this" — which is what
+// makes the change safe to run on a branch whose median gap is below the
+// debounce interval.
+//
+// 30 minutes is chosen to sit well above the interval (so it never pre-empts an
+// ordinary quiet-window roll) while still being far below the 5.5-hour window in
+// which the incident produced 11 rolls. Worst case the fleet now rolls about
+// twice an hour instead of every merge.
+const defaultAutoUpgradeMaxHold = 30 * time.Minute
+
 // autoUpgradeDebounceInterval resolves the live debounce interval. The
 // dashboard-saved Scale Controls value wins, then HIVE_UPGRADE_DEBOUNCE_SECONDS,
 // then the built-in default — the same precedence as upgradeWaveSize(), and read
@@ -106,6 +129,29 @@ func autoUpgradeDebounceInterval() time.Duration {
 	return time.Duration(secs) * time.Second
 }
 
+// autoUpgradeMaxHold resolves the live max-hold cap, overridable via
+// HIVE_UPGRADE_MAX_HOLD_SECONDS on the same conventions as the debounce
+// interval: 0 = use the default, negative = no cap at all.
+//
+// Disabling the cap is deliberately possible but is NOT recommended on a branch
+// whose median inter-merge gap is below the debounce interval — see
+// defaultAutoUpgradeMaxHold for the measurement.
+func autoUpgradeMaxHold() time.Duration {
+	secs := 0
+	if v := os.Getenv("HIVE_UPGRADE_MAX_HOLD_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			secs = n
+		}
+	}
+	if secs < 0 {
+		return 0 // cap explicitly disabled
+	}
+	if secs == 0 {
+		return defaultAutoUpgradeMaxHold
+	}
+	return time.Duration(secs) * time.Second
+}
+
 // autoUpgradeDebounceState is the per-hive pending-target record.
 //
 // It is persisted in the hive's own meta.json (see SaaSHive) rather than held in
@@ -123,6 +169,11 @@ type autoUpgradeDebounceState struct {
 	// that is what makes the window measure "the branch has been quiet",
 	// not "we have been waiting a while".
 	ArmedAt time.Time
+	// FirstArmedAt is when this hive FIRST fell behind and began waiting, and
+	// unlike ArmedAt it survives re-arming. It is what the max-hold cap is
+	// measured against: without it, a branch that never goes quiet would reset
+	// the only clock there was and defer the upgrade forever.
+	FirstArmedAt time.Time
 	// Collapsed counts how many distinct targets have superseded one another
 	// inside this window. It exists so the eventual roll can REPORT how many
 	// merges it absorbed. Silent batching would trade one invisible problem
@@ -152,7 +203,10 @@ type autoUpgradeDebounceDecision struct {
 //
 // prev is the hive's stored debounce state (zero value if none). target is the
 // SHA the hive would upgrade to on this cycle. interval is the quiet period; a
-// non-positive interval disables debouncing entirely. now is injected so the
+// non-positive interval disables debouncing entirely. maxHold caps the total
+// time a pending upgrade may be deferred by repeated re-arming, so a branch
+// that never goes quiet still converges; a non-positive maxHold disables the
+// cap. now is injected so the
 // behaviour is testable without touching the wall clock.
 //
 // The three cases:
@@ -168,7 +222,7 @@ type autoUpgradeDebounceDecision struct {
 // A hub restart inside the window is handled by prev being loaded from disk:
 // the SAME-TARGET case then sees the original ArmedAt and fires on schedule
 // rather than restarting the clock.
-func shouldDebounceAutoUpgrade(prev autoUpgradeDebounceState, target string, interval time.Duration, now time.Time) autoUpgradeDebounceDecision {
+func shouldDebounceAutoUpgrade(prev autoUpgradeDebounceState, target string, interval, maxHold time.Duration, now time.Time) autoUpgradeDebounceDecision {
 	if target == "" {
 		// Nothing to arm. Clear any pending record so a stale target cannot
 		// later fire against a branch that has since moved on.
@@ -187,19 +241,43 @@ func shouldDebounceAutoUpgrade(prev autoUpgradeDebounceState, target string, int
 	if prev.Target == "" || !sameCommit(prev.Target, target) {
 		collapsed := prev.Collapsed
 		reason := "debounce armed — waiting for the branch to go quiet"
+		firstArmed := prev.FirstArmedAt
 		if prev.Target != "" {
 			// A newer target REPLACED a pending one. This is the collapse.
 			collapsed++
 			reason = "debounce re-armed — newer target supersedes the pending one"
 		}
-		return autoUpgradeDebounceDecision{
-			State:  autoUpgradeDebounceState{Target: target, ArmedAt: now, Collapsed: collapsed},
-			Reason: reason,
+		if firstArmed.IsZero() {
+			firstArmed = now
 		}
+		next := autoUpgradeDebounceState{
+			Target: target, ArmedAt: now, FirstArmedAt: firstArmed, Collapsed: collapsed,
+		}
+		// Max-hold cap, checked on the RE-ARM path because that is the only
+		// path a never-quiet branch ever takes. Without this a branch whose
+		// median inter-merge gap is below the debounce interval — which v4's
+		// measurably is — would re-arm forever and never upgrade at all.
+		if maxHold > 0 && now.Sub(firstArmed) >= maxHold {
+			return autoUpgradeDebounceDecision{
+				Allowed:   true,
+				Collapsed: collapsed,
+				Reason:    "debounce max hold reached — rolling on a busy branch",
+			}
+		}
+		return autoUpgradeDebounceDecision{State: next, Reason: reason}
 	}
 
 	// Same target as the pending one: the branch has been quiet since ArmedAt.
 	if waited := now.Sub(prev.ArmedAt); waited < interval {
+		// The cap applies here too, so a hive cannot be held past it by any
+		// combination of quiet and busy cycles.
+		if maxHold > 0 && !prev.FirstArmedAt.IsZero() && now.Sub(prev.FirstArmedAt) >= maxHold {
+			return autoUpgradeDebounceDecision{
+				Allowed:   true,
+				Collapsed: prev.Collapsed,
+				Reason:    "debounce max hold reached — rolling before the window elapsed",
+			}
+		}
 		return autoUpgradeDebounceDecision{
 			State:  prev,
 			Reason: "debounce holding — branch not yet quiet",
@@ -229,6 +307,7 @@ func (s *HubServer) persistUpgradeDebounceState(h *SaaSHive, st autoUpgradeDebou
 	// state even if the disk write below fails.
 	h.AutoUpgradePendingTarget = st.Target
 	h.AutoUpgradePendingSince = st.ArmedAt
+	h.AutoUpgradePendingFirst = st.FirstArmedAt
 	h.AutoUpgradeCollapsed = st.Collapsed
 
 	// Re-read from disk rather than saving the loop's copy wholesale: that copy
@@ -241,6 +320,7 @@ func (s *HubServer) persistUpgradeDebounceState(h *SaaSHive, st autoUpgradeDebou
 	}
 	stored.AutoUpgradePendingTarget = st.Target
 	stored.AutoUpgradePendingSince = st.ArmedAt
+	stored.AutoUpgradePendingFirst = st.FirstArmedAt
 	stored.AutoUpgradeCollapsed = st.Collapsed
 	if err := saveSaaSHive(stored); err != nil {
 		s.logger.Warn("failed to persist auto-upgrade debounce state — a hub restart would re-arm the window",

--- a/src/pkg/hub/upgrade_debounce.go
+++ b/src/pkg/hub/upgrade_debounce.go
@@ -1,0 +1,249 @@
+package hub
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// Merge-driven upgrade debounce (#5391).
+//
+// THE DEFECT THIS FIXES
+//
+// Instant mode fires the moment a hive is seen behind latest. `latestSHA` is
+// re-resolved every latestSHAPollInterval, so on a busy branch the hive is seen
+// behind again a couple of minutes after it lands, and it rolls again. The rate
+// is therefore set by MERGE FREQUENCY, an input with nothing to do with how
+// urgently a spoke needs the image. Measured on
+// hive-hosted-hosted-available-oke-11-placeholder-r05x: ELEVEN ReplicaSets in
+// 5.5 hours, each stamped with a distinct upgrade-target-sha matching a v4
+// merge. Each roll kills every contributor WebSocket (#5090), spends ~2m05s
+// pulling a 4.05 GB image, and interrupts in-flight agent work.
+//
+// Every individual roll was correct. Only the rate was wrong.
+//
+// WHY DEBOUNCE RATHER THAN A MINIMUM INTERVAL OR A WINDOW
+//
+// A burst of merges wants to collapse to ONE roll at the NEWEST SHA — which is
+// also the SHA you actually want to be running. Debounce gives exactly that: a
+// newer target arriving inside the quiet window REPLACES the pending one
+// instead of queuing a second roll, and the roll fires once the branch has been
+// quiet for autoUpgradeDebounceInterval. A minimum-interval gate would also cut
+// the rate, but it rolls at whatever target happened to be armed when the timer
+// expired rather than converging on the newest; a scheduled window (the daily
+// and weekly modes below) is far too coarse for a hive that wants to track a
+// branch.
+//
+// RELATIONSHIP TO shouldAutoUpgradeNow
+//
+// This is deliberately the SAME SHAPE as the daily/weekly gate in
+// upgrade_schedule.go and reuses its decision type, so there is one vocabulary
+// for "may this hive fire now". It could not simply reuse
+// shouldAutoUpgradeNow's fired-date gate, because that gate answers "have we
+// already fired in this window" from a calendar day, and debounce must answer
+// "has the TARGET stopped moving" from a target plus a timestamp. The two
+// compose rather than compete: debounce gates instant mode only, and
+// shouldAutoUpgradeNow keeps gating daily and weekly, which are already far
+// coarser than any debounce interval and so have nothing to gain from one.
+//
+// It does inherit upgrade_schedule.go's most important rule directly. Missed
+// windows do NOT accumulate there, because "only ONE upgrade is ever owed" —
+// the gate is a state, not a queue. Debounce holds exactly the same line: at
+// most ONE target is ever pending, N merges inside a window collapse into one
+// roll, and the collapsed count is reported rather than silently discarded.
+
+// defaultAutoUpgradeDebounceInterval is how long a branch must be quiet before a
+// merge-driven upgrade is allowed to roll.
+//
+// Five minutes is chosen against the two costs it sits between. Below it is the
+// merge cadence being absorbed: the measured burst ran 11 merges in 5.5 hours,
+// with the tightest pair 16 minutes apart and several inside 25 — but the
+// expensive case is back-to-back merges (a PR train, a revert chasing a fix),
+// which land within a few minutes of each other and are precisely what must
+// collapse. Above it is the delay added to a QUIET branch, which is the only
+// case debounce makes worse: a single merge with nothing behind it now waits
+// this long before rolling. Five minutes is comfortably longer than a
+// back-to-back merge pair and comfortably shorter than the ~2m05s image pull
+// plus rollout it is protecting, so a lone merge still lands promptly while a
+// train collapses to one roll.
+//
+// It is deliberately NOT tied to latestSHAPollInterval (2m). Coupling them
+// would silently re-tune the debounce whenever the poll cadence changed for
+// unrelated reasons.
+const defaultAutoUpgradeDebounceInterval = 5 * time.Minute
+
+// autoUpgradeDebounceInterval resolves the live debounce interval. The
+// dashboard-saved Scale Controls value wins, then HIVE_UPGRADE_DEBOUNCE_SECONDS,
+// then the built-in default — the same precedence as upgradeWaveSize(), and read
+// on every trigger tick so a saved change takes effect without a hub restart.
+//
+// A NEGATIVE value at either layer DISABLES debounce and restores the historical
+// roll-on-every-merge behaviour. That escape hatch is deliberate: if debouncing
+// ever turns out to hide an upgrade, an operator can turn it off fleet-wide
+// without shipping a build. Zero is "not set" (the omitempty JSON default and an
+// unset env var), NOT "disabled" — otherwise every existing settings document,
+// which has no such field, would silently disable the feature.
+//
+// This deliberately does NOT use settingOrEnv/envInt. Both clamp to >= 1 and
+// fall through to the default on anything smaller, so routing through them would
+// make the documented "disable" value silently mean "use the default" — the
+// escape hatch would look configured and do nothing.
+func autoUpgradeDebounceInterval() time.Duration {
+	secs := getScaleSettings().UpgradeDebounceSeconds
+	if secs == 0 {
+		if v := os.Getenv("HIVE_UPGRADE_DEBOUNCE_SECONDS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				secs = n
+			}
+		}
+	}
+	if secs < 0 {
+		return 0 // explicitly disabled
+	}
+	if secs == 0 {
+		return defaultAutoUpgradeDebounceInterval
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// autoUpgradeDebounceState is the per-hive pending-target record.
+//
+// It is persisted in the hive's own meta.json (see SaaSHive) rather than held in
+// memory, because a hub restart inside the quiet window must not DROP the
+// pending upgrade. Losing an upgrade silently is a worse failure than rolling
+// too often — the whole point of this change is that the hive still converges on
+// latest, just less often. On restart the state is re-read and the window
+// resumes from the original ArmedAt, so a restart neither loses the target nor
+// extends the wait indefinitely.
+type autoUpgradeDebounceState struct {
+	// Target is the newest SHA seen for this hive's branch while waiting.
+	Target string
+	// ArmedAt is when the CURRENT pending target was first observed. It is
+	// deliberately reset each time a NEWER target replaces the pending one:
+	// that is what makes the window measure "the branch has been quiet",
+	// not "we have been waiting a while".
+	ArmedAt time.Time
+	// Collapsed counts how many distinct targets have superseded one another
+	// inside this window. It exists so the eventual roll can REPORT how many
+	// merges it absorbed. Silent batching would trade one invisible problem
+	// for another (see #5388 on guards that cannot report).
+	Collapsed int
+}
+
+// autoUpgradeDebounceDecision is the result of evaluating one hive's debounce
+// state for one poll cycle.
+type autoUpgradeDebounceDecision struct {
+	// Allowed reports whether the roll may proceed NOW.
+	Allowed bool
+	// State is the debounce state to persist for this hive. It is meaningful
+	// whether or not the roll is allowed: when held it carries the (possibly
+	// just-replaced) pending target, and when allowed it is the zero value,
+	// which clears the record.
+	State autoUpgradeDebounceState
+	// Collapsed is how many merges this roll absorbed beyond the first. Zero
+	// means the target never moved while waiting. Only meaningful when Allowed.
+	Collapsed int
+	// Reason is a short, log-friendly explanation. Always populated.
+	Reason string
+}
+
+// shouldDebounceAutoUpgrade decides whether a merge-driven upgrade to target may
+// roll now, or must wait for the branch to go quiet.
+//
+// prev is the hive's stored debounce state (zero value if none). target is the
+// SHA the hive would upgrade to on this cycle. interval is the quiet period; a
+// non-positive interval disables debouncing entirely. now is injected so the
+// behaviour is testable without touching the wall clock.
+//
+// The three cases:
+//
+//	NEW TARGET     — nothing pending, or a target NEWER than the pending one.
+//	                 Arm (or re-arm) the window and hold. Re-arming is what
+//	                 collapses a burst: the pending target is REPLACED, never
+//	                 queued, so N merges still produce exactly one roll.
+//	SAME TARGET    — the branch has not moved since we armed. Roll once the
+//	                 window has elapsed; keep holding until it has.
+//	NO TARGET      — nothing to do; clear any stale pending state.
+//
+// A hub restart inside the window is handled by prev being loaded from disk:
+// the SAME-TARGET case then sees the original ArmedAt and fires on schedule
+// rather than restarting the clock.
+func shouldDebounceAutoUpgrade(prev autoUpgradeDebounceState, target string, interval time.Duration, now time.Time) autoUpgradeDebounceDecision {
+	if target == "" {
+		// Nothing to arm. Clear any pending record so a stale target cannot
+		// later fire against a branch that has since moved on.
+		return autoUpgradeDebounceDecision{Reason: "no target"}
+	}
+	if interval <= 0 {
+		// Debounce disabled — historical behaviour, roll immediately.
+		return autoUpgradeDebounceDecision{Allowed: true, Reason: "debounce disabled"}
+	}
+
+	// A target that differs from the pending one supersedes it. sameCommit
+	// tolerates the short/full SHA length mismatch the rest of the upgrade path
+	// already handles, so a hub storing a 7-char SHA and a spoke reporting a
+	// longer one do not look like a fresh merge on every single cycle — which
+	// would re-arm the window forever and never roll at all.
+	if prev.Target == "" || !sameCommit(prev.Target, target) {
+		collapsed := prev.Collapsed
+		reason := "debounce armed — waiting for the branch to go quiet"
+		if prev.Target != "" {
+			// A newer target REPLACED a pending one. This is the collapse.
+			collapsed++
+			reason = "debounce re-armed — newer target supersedes the pending one"
+		}
+		return autoUpgradeDebounceDecision{
+			State:  autoUpgradeDebounceState{Target: target, ArmedAt: now, Collapsed: collapsed},
+			Reason: reason,
+		}
+	}
+
+	// Same target as the pending one: the branch has been quiet since ArmedAt.
+	if waited := now.Sub(prev.ArmedAt); waited < interval {
+		return autoUpgradeDebounceDecision{
+			State:  prev,
+			Reason: "debounce holding — branch not yet quiet",
+		}
+	}
+	// Window elapsed on a stable target. Roll, and clear the record.
+	return autoUpgradeDebounceDecision{
+		Allowed:   true,
+		Collapsed: prev.Collapsed,
+		Reason:    "debounce window elapsed — branch quiet",
+	}
+}
+
+// persistUpgradeDebounceState writes a hive's pending-target record to its
+// meta.json, and mirrors it onto the in-memory copy the caller is iterating so
+// the two cannot disagree within a cycle.
+//
+// The zero state CLEARS the record (all three fields are omitempty), which is
+// what the fire path wants. A save failure is logged but never fatal: the cost
+// of a lost write is a re-armed window — one extra quiet period before the roll
+// — which is strictly better than skipping the upgrade over a disk error.
+func (s *HubServer) persistUpgradeDebounceState(h *SaaSHive, st autoUpgradeDebounceState) {
+	if h == nil {
+		return
+	}
+	// Mutate the caller's copy first so the rest of THIS cycle sees the new
+	// state even if the disk write below fails.
+	h.AutoUpgradePendingTarget = st.Target
+	h.AutoUpgradePendingSince = st.ArmedAt
+	h.AutoUpgradeCollapsed = st.Collapsed
+
+	// Re-read from disk rather than saving the loop's copy wholesale: that copy
+	// is a snapshot taken at the top of the sweep, and writing it back would
+	// clobber any field another handler has changed since. Same pattern the
+	// fire-date persistence uses.
+	stored := loadSaaSHive(h.ID)
+	if stored == nil {
+		stored = h
+	}
+	stored.AutoUpgradePendingTarget = st.Target
+	stored.AutoUpgradePendingSince = st.ArmedAt
+	stored.AutoUpgradeCollapsed = st.Collapsed
+	if err := saveSaaSHive(stored); err != nil {
+		s.logger.Warn("failed to persist auto-upgrade debounce state — a hub restart would re-arm the window",
+			"hive_id", h.ID, "target", st.Target, "error", err)
+	}
+}

--- a/src/pkg/hub/upgrade_debounce_test.go
+++ b/src/pkg/hub/upgrade_debounce_test.go
@@ -163,6 +163,58 @@ func TestBusyBranchIsNotStarvedByDebounce(t *testing.T) {
 	}
 }
 
+// TestNoMergeCadenceStarvesTheHive sweeps a range of merge cadences and asserts
+// that NONE of them starve the hive.
+//
+// This exists because a plausible-looking staleness rule very nearly shipped
+// that did starve it. Keying "is this record stale" on ELAPSED TIME (older than
+// maxHold) rather than on provenance meant that on any branch whose merge gap
+// exceeded the poll step, the reset fired before the cap could, pushing the
+// wait clock forward every single cycle so the cap never fired at all —
+// measured at a 7-minute cadence: ZERO rolls in 4.5 hours, a total silent
+// stall. A single-cadence test missed it because the 2-minute case still
+// passed.
+//
+// Sweeping cadences is what catches that class of bug, so this test sweeps.
+func TestNoMergeCadenceStarvesTheHive(t *testing.T) {
+	base := time.Date(2026, 8, 31, 20, 0, 0, 0, time.UTC)
+	const maxHold = 30 * time.Minute
+
+	for _, step := range []time.Duration{
+		time.Minute, 2 * time.Minute, 3 * time.Minute, 4 * time.Minute,
+		7 * time.Minute, 11 * time.Minute, 13 * time.Minute,
+	} {
+		var obs []struct {
+			target string
+			at     time.Time
+		}
+		const n = 60
+		for i := 0; i < n; i++ {
+			obs = append(obs, struct {
+				target string
+				at     time.Time
+			}{fmt.Sprintf("sha%04d", i), base.Add(time.Duration(i) * step)})
+		}
+		span := time.Duration(n-1) * step
+
+		rolls := driveMerges(obs, testDebounce, maxHold)
+
+		if len(rolls) == 0 {
+			t.Errorf("merge cadence %v over %v STARVED the hive — zero rolls, it would never upgrade", step, span)
+			continue
+		}
+		// Upper bound: never worse than one roll per merge, and in practice far
+		// better. Expressed against the span so it holds for every cadence.
+		if maxExpected := int(span/maxHold) + 2; len(rolls) > maxExpected {
+			t.Errorf("cadence %v produced %d rolls over %v, want <= %d", step, len(rolls), span, maxExpected)
+		}
+		// It must also converge: the last roll cannot be the very first SHA.
+		if rolls[len(rolls)-1].target == "sha0000" {
+			t.Errorf("cadence %v: final roll is still the first SHA — not converging", step)
+		}
+	}
+}
+
 // TestQuietBranchStillUpgradesPromptly guards the cost of debouncing: a lone
 // merge with nothing behind it must still roll, one window later — not never,
 // and not only at some daily window.

--- a/src/pkg/hub/upgrade_debounce_test.go
+++ b/src/pkg/hub/upgrade_debounce_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -13,7 +14,12 @@ import (
 // SHA, a quiet branch must still upgrade, and the paths an operator drives must
 // not be delayed at all.
 
-const testDebounce = 5 * time.Minute
+const (
+	testDebounce = 5 * time.Minute
+	// Generous cap: the tests in this file that are about the QUIET-window
+	// behaviour must not trip the max hold. The cap has its own test.
+	testMaxHold = 4 * time.Hour
+)
 
 // disableUpgradeDebounceForTest turns the merge-driven debounce (#5391) off for
 // the duration of a test, restoring the historical roll-on-the-first-cycle
@@ -53,11 +59,11 @@ type roll struct {
 func driveMerges(observations []struct {
 	target string
 	at     time.Time
-}, interval time.Duration) []roll {
+}, interval, maxHold time.Duration) []roll {
 	var state autoUpgradeDebounceState
 	var rolls []roll
 	for _, o := range observations {
-		d := shouldDebounceAutoUpgrade(state, o.target, interval, o.at)
+		d := shouldDebounceAutoUpgrade(state, o.target, interval, maxHold, o.at)
 		if d.Allowed {
 			rolls = append(rolls, roll{target: o.target, collapsed: d.Collapsed})
 			state = autoUpgradeDebounceState{} // the fire path clears the record
@@ -93,7 +99,7 @@ func TestMergeBurstCollapsesToOneRollAtNewestSHA(t *testing.T) {
 		{"db613df", base.Add(14 * time.Minute)},
 	}
 
-	rolls := driveMerges(obs, testDebounce)
+	rolls := driveMerges(obs, testDebounce, testMaxHold)
 
 	if len(rolls) != 1 {
 		t.Fatalf("a burst of 5 merges must collapse into exactly ONE roll, got %d: %+v", len(rolls), rolls)
@@ -105,6 +111,55 @@ func TestMergeBurstCollapsesToOneRollAtNewestSHA(t *testing.T) {
 	// batching is explicitly rejected by #5391.
 	if rolls[0].collapsed != 4 {
 		t.Errorf("roll must report the 4 superseded targets it collapsed, reported %d", rolls[0].collapsed)
+	}
+}
+
+// TestBusyBranchIsNotStarvedByDebounce is the guard on the one real failure
+// mode of a pure debounce: a branch that NEVER goes quiet would re-arm the
+// window forever and the hive would never upgrade at all.
+//
+// This is not hypothetical for v4. Sampling the 100 merges from 2026-08-30
+// 19:07Z to 2026-08-31 23:33Z, the MEDIAN inter-merge gap is 3.0 minutes and
+// 63% of gaps are under 5 minutes — i.e. below the debounce interval. The
+// max-hold cap is what converts "rolls once the branch goes quiet" into "rolls
+// once the branch goes quiet, and in no case later than the cap".
+//
+// The test replays a relentless branch: a new merge every 2 minutes, never
+// pausing, for two hours.
+func TestBusyBranchIsNotStarvedByDebounce(t *testing.T) {
+	base := time.Date(2026, 8, 31, 20, 0, 0, 0, time.UTC)
+	const maxHold = 30 * time.Minute
+
+	var obs []struct {
+		target string
+		at     time.Time
+	}
+	for i := 0; i < 60; i++ { // 60 merges x 2m = 2 hours, never quiet
+		obs = append(obs, struct {
+			target string
+			at     time.Time
+		}{fmt.Sprintf("sha%04d", i), base.Add(time.Duration(i) * 2 * time.Minute)})
+	}
+
+	rolls := driveMerges(obs, testDebounce, maxHold)
+
+	if len(rolls) == 0 {
+		t.Fatal("a permanently busy branch was STARVED — the hive would never upgrade at all")
+	}
+	// Bounded above: roughly one roll per max-hold period across the 2h run,
+	// not one per merge. The old behaviour would have produced 60.
+	if len(rolls) > 6 {
+		t.Errorf("busy branch produced %d rolls in 2h; the cap should bound this near 2h/%v", len(rolls), maxHold)
+	}
+	// The cap must fire repeatedly across the run rather than once — otherwise
+	// the hive converges once and then starves again.
+	if len(rolls) < 2 {
+		t.Errorf("expected the cap to fire repeatedly across 2 hours, got %d roll(s)", len(rolls))
+	}
+	// Each roll must land on a target that was current at the time, and the
+	// LAST roll must be recent enough that the hive is not left far behind.
+	if rolls[len(rolls)-1].target == "sha0000" {
+		t.Error("the final roll landed on the very first SHA — the hive is not converging")
 	}
 }
 
@@ -123,7 +178,7 @@ func TestQuietBranchStillUpgradesPromptly(t *testing.T) {
 		{"abc1234", base.Add(6 * time.Minute)}, // window elapsed
 	}
 
-	rolls := driveMerges(obs, testDebounce)
+	rolls := driveMerges(obs, testDebounce, testMaxHold)
 
 	if len(rolls) != 1 {
 		t.Fatalf("a quiet branch must roll exactly once, got %d: %+v", len(rolls), rolls)
@@ -149,7 +204,7 @@ func TestDebounceDisabledRollsImmediately(t *testing.T) {
 		{"bcab144", base.Add(4 * time.Minute)},
 	}
 
-	rolls := driveMerges(obs, 0)
+	rolls := driveMerges(obs, 0, testMaxHold)
 
 	if len(rolls) != 3 {
 		t.Fatalf("with debounce disabled every merge must roll, want 3, got %d: %+v", len(rolls), rolls)
@@ -171,7 +226,7 @@ func TestPendingTargetSurvivesHubRestart(t *testing.T) {
 	base := time.Date(2026, 8, 31, 20, 45, 0, 0, time.UTC)
 
 	// Arm the window.
-	d := shouldDebounceAutoUpgrade(autoUpgradeDebounceState{}, "db613df", testDebounce, base)
+	d := shouldDebounceAutoUpgrade(autoUpgradeDebounceState{}, "db613df", testDebounce, testMaxHold, base)
 	if d.Allowed {
 		t.Fatal("a freshly observed target must be held, not rolled immediately")
 	}
@@ -194,13 +249,13 @@ func TestPendingTargetSurvivesHubRestart(t *testing.T) {
 	}
 
 	// Immediately after the restart the window has NOT elapsed — still held.
-	if got := shouldDebounceAutoUpgrade(recovered, "db613df", testDebounce, base.Add(time.Minute)); got.Allowed {
+	if got := shouldDebounceAutoUpgrade(recovered, "db613df", testDebounce, testMaxHold, base.Add(time.Minute)); got.Allowed {
 		t.Error("restart must not cause an early roll while the window is still open")
 	}
 
 	// Once the ORIGINAL window elapses the upgrade fires. If the restart had
 	// reset the clock this would still be holding.
-	after := shouldDebounceAutoUpgrade(recovered, "db613df", testDebounce, base.Add(testDebounce+time.Second))
+	after := shouldDebounceAutoUpgrade(recovered, "db613df", testDebounce, testMaxHold, base.Add(testDebounce+time.Second))
 	if !after.Allowed {
 		t.Fatal("pending upgrade was LOST across the restart — it must still roll")
 	}
@@ -218,7 +273,7 @@ func TestShortAndFullSHADoNotReArmForever(t *testing.T) {
 	armed := autoUpgradeDebounceState{Target: "db613df", ArmedAt: base}
 
 	// The same commit, reported at full length, must NOT look like a new merge.
-	d := shouldDebounceAutoUpgrade(armed, "db613df1c0ffee0123456789abcdef0123456789", testDebounce, base.Add(2*time.Minute))
+	d := shouldDebounceAutoUpgrade(armed, "db613df1c0ffee0123456789abcdef0123456789", testDebounce, testMaxHold, base.Add(2*time.Minute))
 	if d.Allowed {
 		t.Fatal("window should still be open at +2m")
 	}
@@ -230,7 +285,7 @@ func TestShortAndFullSHADoNotReArmForever(t *testing.T) {
 	}
 
 	// And it fires on schedule rather than being deferred forever.
-	if got := shouldDebounceAutoUpgrade(armed, "db613df1c0ffee0123456789abcdef0123456789", testDebounce, base.Add(6*time.Minute)); !got.Allowed {
+	if got := shouldDebounceAutoUpgrade(armed, "db613df1c0ffee0123456789abcdef0123456789", testDebounce, testMaxHold, base.Add(6*time.Minute)); !got.Allowed {
 		t.Error("upgrade must fire once the window elapses despite the SHA length mismatch")
 	}
 }
@@ -241,7 +296,7 @@ func TestEmptyTargetClearsPendingState(t *testing.T) {
 	base := time.Date(2026, 8, 31, 20, 45, 0, 0, time.UTC)
 	armed := autoUpgradeDebounceState{Target: "db613df", ArmedAt: base, Collapsed: 3}
 
-	d := shouldDebounceAutoUpgrade(armed, "", testDebounce, base.Add(time.Minute))
+	d := shouldDebounceAutoUpgrade(armed, "", testDebounce, testMaxHold, base.Add(time.Minute))
 	if d.Allowed {
 		t.Error("an empty target must never roll")
 	}

--- a/src/pkg/hub/upgrade_debounce_test.go
+++ b/src/pkg/hub/upgrade_debounce_test.go
@@ -1,0 +1,401 @@
+package hub
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The tests below assert the BEHAVIOUR #5391 asks for, not that a particular
+// function was called: a burst of merges must produce ONE roll at the NEWEST
+// SHA, a quiet branch must still upgrade, and the paths an operator drives must
+// not be delayed at all.
+
+const testDebounce = 5 * time.Minute
+
+// disableUpgradeDebounceForTest turns the merge-driven debounce (#5391) off for
+// the duration of a test, restoring the historical roll-on-the-first-cycle
+// behaviour.
+//
+// It exists for the same reason registryBehind() sets LastHeartbeat: a test
+// whose subject is ELIGIBILITY (the assignment latch, the wave bound, the
+// collectibility refusal) drives triggerAutoUpgrades() once and asserts an
+// upgrade was armed. Debounce is an unrelated gate for those tests — leaving it
+// on would make every one of them fail on timing and stop testing what it is
+// named for.
+//
+// Tests whose subject IS the debounce must NOT use this. They live in this file
+// and exercise shouldDebounceAutoUpgrade directly across a sequence of cycles.
+func disableUpgradeDebounceForTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("HIVE_UPGRADE_DEBOUNCE_SECONDS", "-1")
+	resetScaleSettingsForTest()
+	if got := autoUpgradeDebounceInterval(); got != 0 {
+		t.Fatalf("failed to disable debounce for this test: interval = %v", got)
+	}
+}
+
+// driveMerges replays a sequence of (target, time) observations through the
+// debounce gate exactly as triggerAutoUpgrades does — carrying the persisted
+// state forward across cycles — and returns every target that was actually
+// allowed to roll, plus the collapse count reported with each.
+//
+// This is the observable behaviour under test: the list of rolls a spoke would
+// actually perform. A test that asserted on internal state instead could pass
+// while the fleet still rolled eleven times.
+type roll struct {
+	target    string
+	collapsed int
+}
+
+func driveMerges(observations []struct {
+	target string
+	at     time.Time
+}, interval time.Duration) []roll {
+	var state autoUpgradeDebounceState
+	var rolls []roll
+	for _, o := range observations {
+		d := shouldDebounceAutoUpgrade(state, o.target, interval, o.at)
+		if d.Allowed {
+			rolls = append(rolls, roll{target: o.target, collapsed: d.Collapsed})
+			state = autoUpgradeDebounceState{} // the fire path clears the record
+			continue
+		}
+		state = d.State
+	}
+	return rolls
+}
+
+// TestMergeBurstCollapsesToOneRollAtNewestSHA is the core claim of #5391.
+//
+// It replays the measured incident: a run of merges landing inside the quiet
+// window, observed on the hub's 2-minute poll cadence. The fleet rolled once
+// per merge. It must now roll ONCE, and land on the LAST SHA, not the first.
+func TestMergeBurstCollapsesToOneRollAtNewestSHA(t *testing.T) {
+	base := time.Date(2026, 8, 31, 20, 45, 0, 0, time.UTC)
+	// Five merges, each seen on a later poll, all within the 5m window of the
+	// one before it — so the window keeps being re-armed and never elapses.
+	obs := []struct {
+		target string
+		at     time.Time
+	}{
+		{"e00214b", base},
+		{"d12ed62", base.Add(2 * time.Minute)},
+		{"bcab144", base.Add(4 * time.Minute)},
+		{"7d0afff", base.Add(6 * time.Minute)},
+		{"db613df", base.Add(8 * time.Minute)},
+		// Branch goes quiet: the newest target is re-observed on later polls
+		// until the window finally elapses.
+		{"db613df", base.Add(10 * time.Minute)},
+		{"db613df", base.Add(12 * time.Minute)},
+		{"db613df", base.Add(14 * time.Minute)},
+	}
+
+	rolls := driveMerges(obs, testDebounce)
+
+	if len(rolls) != 1 {
+		t.Fatalf("a burst of 5 merges must collapse into exactly ONE roll, got %d: %+v", len(rolls), rolls)
+	}
+	if rolls[0].target != "db613df" {
+		t.Errorf("the single roll must land on the NEWEST target db613df, got %q", rolls[0].target)
+	}
+	// The roll must be able to say how many merges it absorbed — silent
+	// batching is explicitly rejected by #5391.
+	if rolls[0].collapsed != 4 {
+		t.Errorf("roll must report the 4 superseded targets it collapsed, reported %d", rolls[0].collapsed)
+	}
+}
+
+// TestQuietBranchStillUpgradesPromptly guards the cost of debouncing: a lone
+// merge with nothing behind it must still roll, one window later — not never,
+// and not only at some daily window.
+func TestQuietBranchStillUpgradesPromptly(t *testing.T) {
+	base := time.Date(2026, 8, 31, 3, 0, 0, 0, time.UTC)
+	obs := []struct {
+		target string
+		at     time.Time
+	}{
+		{"abc1234", base},
+		{"abc1234", base.Add(2 * time.Minute)}, // still inside the window
+		{"abc1234", base.Add(4 * time.Minute)}, // still inside the window
+		{"abc1234", base.Add(6 * time.Minute)}, // window elapsed
+	}
+
+	rolls := driveMerges(obs, testDebounce)
+
+	if len(rolls) != 1 {
+		t.Fatalf("a quiet branch must roll exactly once, got %d: %+v", len(rolls), rolls)
+	}
+	if rolls[0].target != "abc1234" {
+		t.Errorf("roll target = %q, want abc1234", rolls[0].target)
+	}
+	if rolls[0].collapsed != 0 {
+		t.Errorf("a lone merge collapsed nothing, want 0, got %d", rolls[0].collapsed)
+	}
+}
+
+// TestDebounceDisabledRollsImmediately asserts the escape hatch restores the
+// historical behaviour exactly: every observed target rolls, with no wait.
+func TestDebounceDisabledRollsImmediately(t *testing.T) {
+	base := time.Date(2026, 8, 31, 20, 45, 0, 0, time.UTC)
+	obs := []struct {
+		target string
+		at     time.Time
+	}{
+		{"e00214b", base},
+		{"d12ed62", base.Add(2 * time.Minute)},
+		{"bcab144", base.Add(4 * time.Minute)},
+	}
+
+	rolls := driveMerges(obs, 0)
+
+	if len(rolls) != 3 {
+		t.Fatalf("with debounce disabled every merge must roll, want 3, got %d: %+v", len(rolls), rolls)
+	}
+	for i, want := range []string{"e00214b", "d12ed62", "bcab144"} {
+		if rolls[i].target != want {
+			t.Errorf("roll %d target = %q, want %q", i, rolls[i].target, want)
+		}
+	}
+}
+
+// TestPendingTargetSurvivesHubRestart asserts constraint 2: an upgrade pending
+// inside the quiet window must not be LOST when the hub restarts, and the wait
+// must resume from the original arming rather than starting over.
+//
+// The restart is modelled the way it actually happens: the in-memory state is
+// discarded and reconstructed from the fields persisted on the hive record.
+func TestPendingTargetSurvivesHubRestart(t *testing.T) {
+	base := time.Date(2026, 8, 31, 20, 45, 0, 0, time.UTC)
+
+	// Arm the window.
+	d := shouldDebounceAutoUpgrade(autoUpgradeDebounceState{}, "db613df", testDebounce, base)
+	if d.Allowed {
+		t.Fatal("a freshly observed target must be held, not rolled immediately")
+	}
+
+	// The hub persists the pending state and then restarts. Everything not on
+	// the hive record is gone; rebuild only from the persisted fields.
+	h := &SaaSHive{
+		ID:                       "hive-restart-test",
+		AutoUpgradePendingTarget: d.State.Target,
+		AutoUpgradePendingSince:  d.State.ArmedAt,
+		AutoUpgradeCollapsed:     d.State.Collapsed,
+	}
+	if h.AutoUpgradePendingTarget != "db613df" {
+		t.Fatalf("pending target was not persisted, got %q", h.AutoUpgradePendingTarget)
+	}
+	recovered := autoUpgradeDebounceState{
+		Target:    h.AutoUpgradePendingTarget,
+		ArmedAt:   h.AutoUpgradePendingSince,
+		Collapsed: h.AutoUpgradeCollapsed,
+	}
+
+	// Immediately after the restart the window has NOT elapsed — still held.
+	if got := shouldDebounceAutoUpgrade(recovered, "db613df", testDebounce, base.Add(time.Minute)); got.Allowed {
+		t.Error("restart must not cause an early roll while the window is still open")
+	}
+
+	// Once the ORIGINAL window elapses the upgrade fires. If the restart had
+	// reset the clock this would still be holding.
+	after := shouldDebounceAutoUpgrade(recovered, "db613df", testDebounce, base.Add(testDebounce+time.Second))
+	if !after.Allowed {
+		t.Fatal("pending upgrade was LOST across the restart — it must still roll")
+	}
+	if after.Reason == "" {
+		t.Error("decision must always carry a log-friendly reason")
+	}
+}
+
+// TestShortAndFullSHADoNotReArmForever guards a failure mode that would be
+// silent and total: if a stored short SHA and a reported longer SHA compared as
+// DIFFERENT, every cycle would re-arm the window and the hive would never
+// upgrade again. sameCommit tolerance is what prevents that.
+func TestShortAndFullSHADoNotReArmForever(t *testing.T) {
+	base := time.Date(2026, 8, 31, 20, 45, 0, 0, time.UTC)
+	armed := autoUpgradeDebounceState{Target: "db613df", ArmedAt: base}
+
+	// The same commit, reported at full length, must NOT look like a new merge.
+	d := shouldDebounceAutoUpgrade(armed, "db613df1c0ffee0123456789abcdef0123456789", testDebounce, base.Add(2*time.Minute))
+	if d.Allowed {
+		t.Fatal("window should still be open at +2m")
+	}
+	if d.State.Collapsed != 0 {
+		t.Errorf("a length-only SHA difference must not count as a collapsed merge, got %d", d.State.Collapsed)
+	}
+	if !d.State.ArmedAt.Equal(base) {
+		t.Error("a length-only SHA difference must not re-arm the window — the hive would never upgrade")
+	}
+
+	// And it fires on schedule rather than being deferred forever.
+	if got := shouldDebounceAutoUpgrade(armed, "db613df1c0ffee0123456789abcdef0123456789", testDebounce, base.Add(6*time.Minute)); !got.Allowed {
+		t.Error("upgrade must fire once the window elapses despite the SHA length mismatch")
+	}
+}
+
+// TestEmptyTargetClearsPendingState asserts a stale pending target cannot
+// survive to fire against a branch that has since moved on.
+func TestEmptyTargetClearsPendingState(t *testing.T) {
+	base := time.Date(2026, 8, 31, 20, 45, 0, 0, time.UTC)
+	armed := autoUpgradeDebounceState{Target: "db613df", ArmedAt: base, Collapsed: 3}
+
+	d := shouldDebounceAutoUpgrade(armed, "", testDebounce, base.Add(time.Minute))
+	if d.Allowed {
+		t.Error("an empty target must never roll")
+	}
+	if d.State.Target != "" {
+		t.Errorf("an empty target must clear the pending record, still holds %q", d.State.Target)
+	}
+}
+
+// TestManualAndPinnedUpgradesBypassDebounce asserts hard constraint 1 of
+// #5391: debounce is for the AUTOMATIC merge-driven path only. An operator
+// clicking "Upgrade now", a bulk upgrade, and a hard image pin must all still be
+// immediate.
+//
+// Those three paths arm s.heartbeatUpgrade DIRECTLY — upgradeHiveHandler and
+// saas_bulk.go write the map themselves, and a pin is delivered as
+// h.UpgradeTarget through the stale-recovery branch, which sits ABOVE the
+// `if !h.AutoUpgrade` gate and `continue`s. None of them reach the debounce
+// gate, so none of them can be delayed by it.
+//
+// What this test pins is the OTHER half of that argument: that the gate itself
+// is reached only when the hive is chasing latest automatically. It asserts on
+// the source of triggerAutoUpgrades because the ordering — pin/manual arming
+// happens before the auto gate — is precisely the property that keeps manual
+// upgrades immediate, and a refactor that moved the debounce call above the
+// AutoUpgrade gate would silently start delaying operator-driven upgrades while
+// every behavioural test above still passed.
+func TestManualAndPinnedUpgradesBypassDebounce(t *testing.T) {
+	src, err := os.ReadFile("saas.go")
+	if err != nil {
+		t.Fatalf("reading saas.go: %v", err)
+	}
+	body := string(src)
+
+	fn := strings.Index(body, "func (s *HubServer) triggerAutoUpgrades()")
+	if fn < 0 {
+		t.Fatal("triggerAutoUpgrades not found — this test must be re-pointed")
+	}
+	autoGate := strings.Index(body[fn:], "if !h.AutoUpgrade {")
+	if autoGate < 0 {
+		t.Fatal("the `if !h.AutoUpgrade` gate was not found inside triggerAutoUpgrades")
+	}
+	debounce := strings.Index(body[fn:], "shouldDebounceAutoUpgrade(")
+	if debounce < 0 {
+		t.Fatal("the debounce gate was not found inside triggerAutoUpgrades")
+	}
+
+	if debounce < autoGate {
+		t.Error("debounce is evaluated BEFORE the `if !h.AutoUpgrade` gate: " +
+			"manual, bulk and pinned upgrades would be delayed, violating #5391 constraint 1")
+	}
+}
+
+// TestTriggerAutoUpgradesHoldsThenRollsOnce is the end-to-end wiring test: it
+// drives the REAL triggerAutoUpgrades() sweep rather than the policy function,
+// and asserts the observable outcome a spoke would experience.
+//
+// Without it the policy could be perfect while the sweep ignored it — which is
+// exactly the defect #5391 describes, one layer up.
+func TestTriggerAutoUpgradesHoldsThenRollsOnce(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetCommitOrderState(t)
+	stubCommitCompare(func(base, head string, logger *slog.Logger) (string, error) {
+		return "behind", nil
+	})
+	// A short but non-zero window, so the test can step over it without sleeping.
+	t.Setenv("HIVE_UPGRADE_DEBOUNCE_SECONDS", "300")
+	resetScaleSettingsForTest()
+	setLatestSHAForBranchForTest(t, "v4", "merge111")
+
+	const id = "debounce-e2e"
+	saveSaaSHive(&SaaSHive{ID: id, Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "dc1"})
+	s := &HubServer{
+		logger:           slog.Default(),
+		hubSecret:        testHubSecret,
+		heartbeatUpgrade: make(map[string]string),
+		clusters:         map[string]ClusterConfig{"dc1": {ID: "dc1", InCluster: true}},
+	}
+	beat := time.Now().UTC().Format(time.RFC3339)
+	s.registry.Hives = []RegistryEntry{{ID: id, GitBranch: "v4", GitHash: "oldsha", LastHeartbeat: beat}}
+
+	armed := func() int {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return len(s.heartbeatUpgrade)
+	}
+
+	// Cycle 1: first sight of the merge. Must HOLD, not roll.
+	s.triggerAutoUpgrades()
+	if armed() != 0 {
+		t.Fatal("a freshly merged target rolled immediately — debounce is not wired into triggerAutoUpgrades")
+	}
+	// The pending target must be persisted, or a hub restart here loses it.
+	stored := loadSaaSHive(id)
+	if stored == nil || stored.AutoUpgradePendingTarget != "merge111" {
+		t.Fatalf("pending target was not persisted to the hive record, got %+v", stored)
+	}
+
+	// Cycle 2: a NEWER merge lands inside the window. Still no roll, and the
+	// pending target must be REPLACED rather than a second roll queued.
+	setLatestSHAForBranchForTest(t, "v4", "merge222")
+	s.triggerAutoUpgrades()
+	if armed() != 0 {
+		t.Fatal("a second merge inside the window rolled — the burst was not collapsed")
+	}
+	stored = loadSaaSHive(id)
+	if stored.AutoUpgradePendingTarget != "merge222" {
+		t.Errorf("pending target = %q, want the NEWER merge222", stored.AutoUpgradePendingTarget)
+	}
+	if stored.AutoUpgradeCollapsed != 1 {
+		t.Errorf("collapsed count = %d, want 1 superseded target", stored.AutoUpgradeCollapsed)
+	}
+
+	// The branch goes quiet. Backdate the arming to step past the window
+	// without sleeping, then sweep again: now it must roll, exactly once, on
+	// the NEWEST SHA.
+	stored.AutoUpgradePendingSince = time.Now().Add(-10 * time.Minute)
+	if err := saveSaaSHive(stored); err != nil {
+		t.Fatalf("saving backdated hive: %v", err)
+	}
+	s.triggerAutoUpgrades()
+	if armed() != 1 {
+		t.Fatalf("after the quiet window the upgrade must roll, armed %d", armed())
+	}
+	s.mu.RLock()
+	target := s.heartbeatUpgrade[id]
+	s.mu.RUnlock()
+	if target != "merge222" {
+		t.Errorf("rolled to %q, want the newest SHA merge222", target)
+	}
+	// And the debounce record must be cleared so the next merge starts fresh.
+	if after := loadSaaSHive(id); after.AutoUpgradePendingTarget != "" {
+		t.Errorf("debounce record not cleared after the roll, still %q", after.AutoUpgradePendingTarget)
+	}
+}
+
+// TestDebounceIntervalIsConfigurable asserts the interval is a named,
+// overridable knob rather than a magic number, and that the documented default
+// is what an unconfigured fleet gets.
+func TestDebounceIntervalIsConfigurable(t *testing.T) {
+	resetScaleSettingsForTest()
+	t.Setenv("HIVE_UPGRADE_DEBOUNCE_SECONDS", "")
+	if got := autoUpgradeDebounceInterval(); got != defaultAutoUpgradeDebounceInterval {
+		t.Errorf("unconfigured interval = %v, want the documented default %v", got, defaultAutoUpgradeDebounceInterval)
+	}
+
+	t.Setenv("HIVE_UPGRADE_DEBOUNCE_SECONDS", "90")
+	if got := autoUpgradeDebounceInterval(); got != 90*time.Second {
+		t.Errorf("env override = %v, want 90s", got)
+	}
+
+	// A negative value is the explicit "disable debouncing" escape hatch.
+	t.Setenv("HIVE_UPGRADE_DEBOUNCE_SECONDS", "-1")
+	if got := autoUpgradeDebounceInterval(); got != 0 {
+		t.Errorf("negative override must disable debounce (0), got %v", got)
+	}
+}

--- a/src/pkg/hub/upgrade_wave_test.go
+++ b/src/pkg/hub/upgrade_wave_test.go
@@ -12,6 +12,8 @@ import (
 // trigger cycle arms exactly waveSize upgrades; the rest board later waves as
 // in-flight upgrades clear.
 func TestTriggerAutoUpgradesWaveBound(t *testing.T) {
+	// Debounce is not this test's subject — see disableUpgradeDebounceForTest.
+	disableUpgradeDebounceForTest(t)
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	resetCommitOrderState(t)


### PR DESCRIPTION
## Problem

Every merge to `v4` triggered a self-upgrade roll on every hosted spoke. Measured on `hive-hosted-hosted-available-oke-11-placeholder-r05x`: **11 ReplicaSets in 5.5 hours**, each carrying a distinct `hive.kubestellar.io/upgrade-target-sha` matching a `v4` merge.

Each roll costs every contributor WebSocket (#5090), ~2m05s pulling a 4.05 GB image, interrupted in-flight agent work, and the release's cancelled docker builds (#5318/#5356).

Each individual roll was correct. The **rate** was the defect: instant mode fires as soon as a hive is seen behind latest, and `latestSHA` is re-resolved every `latestSHAPollInterval` (2m) — so the cadence was set by merge frequency, an input with nothing to do with how urgently a spoke needs the image.

## The change

Debounce the automatic chase-latest path. After a merge, wait a quiet interval before rolling; a newer target arriving inside the window **replaces** the pending one rather than queuing another roll. A burst collapses into **one** roll at the **newest** SHA.

The gate sits in `triggerAutoUpgrades()`, immediately after `latestSHA` is resolved — after every eligibility check that could already decline, and before the wave gate and fire-date persistence, so a debounced hive costs no wave slot and keeps its daily/weekly window open.

## Did it reuse `upgrade_schedule.go`'s policy?

**Partly, and deliberately so — the reasoning is reused, the fired-date mechanism could not be.**

`shouldAutoUpgradeNow`'s gate answers *"have we already fired in this window"* from a **calendar day**. Debounce must answer *"has the target stopped moving"* from a **target plus a timestamp**. A fired-date gate cannot express that: it has no notion of the target being superseded, which is the entire collapse mechanism.

So the two **compose** rather than compete. `shouldDebounceAutoUpgrade` gates **instant** mode only; `shouldAutoUpgradeNow` keeps gating daily and weekly, which are already far coarser than any debounce interval and have nothing to gain from one. The new code deliberately mirrors the existing shape — same decision-struct pattern, same injected `now` for testability, same "always populate a log-friendly Reason" rule — so there is one vocabulary for "may this hive fire now".

It inherits that file's most important rule directly. Missed windows do not accumulate there because *"only ONE upgrade is ever owed"* — the gate is a state, not a queue. Debounce holds the same line: at most one target is ever pending, N merges collapse into one roll, and the collapsed count is **reported** rather than silently discarded.

## Hard constraints

**1. Manual and pinned upgrades stay immediate.** By construction, not by a flag. Everything operator-driven arms `s.heartbeatUpgrade` directly and never enters this loop body:

- manual "Upgrade now" (`upgradeHiveHandler`) writes the map itself;
- bulk upgrade (`saas_bulk.go`) writes the map itself;
- a hard image pin is delivered as `h.UpgradeTarget` through the stale-recovery branch, which sits **above** the `if !h.AutoUpgrade` gate and `continue`s.

The debounce call is below that gate, so only the merge-frequency-driven roll is held. `TestManualAndPinnedUpgradesBypassDebounce` pins that ordering, because a refactor moving the gate upward would silently start delaying operator upgrades while every behavioural test still passed.

**2. No upgrade is lost.** The pending target, its arming time and the collapse count are persisted on the hive's own `meta.json` (all `omitempty`, absent on every existing record). A hub restart inside the window resumes from the stored `ArmedAt` — the wait is neither dropped nor restarted. The record is cleared only after every gate that could still `continue`, so a hive turned away by the wave gate keeps its pending target and boards a later wave.

**3. No magic numbers.** `defaultAutoUpgradeDebounceInterval` (5m, with the reasoning for that value documented against the costs on either side), overridable via Scale Controls (`upgrade_debounce_seconds`) or `HIVE_UPGRADE_DEBOUNCE_SECONDS`. A **negative** value disables debouncing and restores roll-on-every-merge — an escape hatch that needs no build. This deliberately does not route through `settingOrEnv`/`envInt`: both clamp to `>= 1`, which would have made the documented disable value silently mean "use the default". A test caught exactly that.

**4. The collapse is logged.** At INFO, with `merges_collapsed` and `final_target`, on the roll that absorbed them. Held cycles also log at INFO with the pending target and reason. Per #5388, a guard that cannot report is its own problem.

**5/6.** No deployment strategy, grace period or readiness probe changes. No hub-side lease/cooldown accounting touched — #5151 stays held.

## Tests

Behavioural, asserting the rolls a spoke would actually perform:

- a 5-merge burst produces **exactly one** roll, at the **newest** SHA, reporting 4 collapsed;
- a quiet branch still upgrades, one window later;
- debounce disabled rolls every merge, unchanged from today;
- a pending upgrade **survives a hub restart** and fires on the original schedule;
- a short/full SHA length mismatch does not re-arm forever (that failure would be silent and total — the hive would never upgrade again);
- an end-to-end test driving the real `triggerAutoUpgrades()` sweep: hold, replace-on-newer, then one roll at the newest SHA with the record cleared.

Ten existing tests drove `triggerAutoUpgrades()` once and asserted an upgrade was armed. Their subject is **eligibility** (assignment latch, wave bound, collectibility refusal), not timing, so they now disable debounce explicitly — the same way `registryBehind()` already sets `LastHeartbeat` to neutralise an unrelated gate.

## What I did NOT verify

Stated plainly:

- **Not tested against a real merge burst from CI.** Every result above is from unit and in-process tests with injected clocks. The 5-minute default is reasoned from the measured incident, not tuned against production.
- **Not deployed to a spoke.** No verification that the roll count actually drops on `hive-oke`.
- The **evidence caveat from #5391 stands**: the rollout timestamps and #5090's socket measurements come from overlapping but not identical windows. The correlation is strong (11 rolls, matching upgrade-target SHAs, an episodic shape tracking merges) but a rollout and a flap were never caught inside one window. The falsifier remains a reconnect with **no** corresponding rollout, which would mean a second cause is still hiding.
- I did not touch the spoke-side `UpgradeCallback` in `cmd/hive/main.go`. Debouncing there would have been per-spoke and could not collapse a burst as cleanly, since the spoke only learns of a target when the hub sends it.

## Interaction with #5390

Complementary and, as it turns out, **non-overlapping in files**. #5390 touches `cmd/hive/main.go`'s `preShutdownHook` (~L1249-1555) and `pkg/dashboard/contribute_ws.go`. This PR touches neither — it is confined to `pkg/hub/`. #5390 makes each roll legible and cheaper; this makes there be far fewer rolls. Neither substitutes for the other.

Fixes #5391
Refs #5090

---

## Update: a pure debounce was not safe on this branch

After the first commit I measured the branch this actually runs on, and it changed the design.

Sampling the last 100 merges to `v4` (2026-08-30 19:07Z → 2026-08-31 23:33Z):

| metric | value |
|---|---|
| median inter-merge gap | **3.0 min** |
| mean | 17.2 min |
| gaps under 5 min | **63%** (62/99) |
| longest run of consecutive sub-5m gaps | 13 |

The median gap is **below the debounce interval**. "Wait for quiet" assumes quiet arrives, and on `v4` it frequently does not. Replaying a relentless branch (a merge every 2 minutes for two hours) through the unbounded policy produces **zero rolls** — the hive would be starved and silently never upgrade. That would have traded the original defect for a worse one, and it is exactly the class of invisible failure #5391 and #5388 are about.

So the second commit adds a **max-hold cap**, measured from a `FirstArmedAt` that survives re-arming (`ArmedAt` deliberately resets on each newer target, so it cannot bound anything).

Same 2-hour relentless branch, measured:

| | rolls in 2h |
|---|---|
| today (one per merge) | 60 |
| debounce, no cap | **0 — starved** |
| debounce + 30m cap | **3** (each absorbing 15 merges, each on a newer SHA) |

Still a **20x reduction**, but with convergence **guaranteed** rather than assumed. The guarantee is now *"rolls once the branch goes quiet, and in no case later than the cap"*.

Default 30m, overridable via `HIVE_UPGRADE_MAX_HOLD_SECONDS` (0 = default, negative = no cap). `TestBusyBranchIsNotStarvedByDebounce` pins the property.

This is the part of the change I'd most want a reviewer's eyes on: the two constants (5m interval, 30m cap) are reasoned from the measurement above, but they have not been tuned against production.