### PR TITLE
docs(env-vars): correct the reference and add a drift guard

### DIFF
--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -34,6 +34,14 @@ This reference is compiled by hand from the Go source under `src/`, the deployme
 | `HIVE_FEDERATION_REGISTRY_PATH` | No | `/data/federation/registry.json` | Federation registry path override. |
 | `HIVE_WEBHOOK_SECRET` | No | none | HMAC secret for the spoke `/webhook` channel. |
 | `GITHUB_WEBHOOK_SECRET` | No | `/data/saas/webhook-secret.key` when present | Hub GitHub webhook HMAC secret. |
+| `HIVE_DASHBOARD_URL` | No | none | Base URL the `hive tui` client targets (`pkg/tui/client`). A bad value surfaces as a request error on the first call, not at startup. |
+| `HIVE_CONVERGENCE_MODE` | No | `convergence.mode` in `hive.yaml`, else `off` | Process-level override of the convergence mode (`off`, `shadow`, `enforce`) so an operator can flip shadow mode without editing `hive.yaml`. Any unrecognised value — a typo, or a mode this build does not know — resolves to `off`. |
+| `HIVE_WATCHDOG_PAUSE` | No | unset (not paused) | Fleet-wide watchdog kill switch (`1`, `true`, `yes`, `on`). Read at every config resolve, so it takes effect without a restart. It can only ever REDUCE authority: it never turns a watchdog on and never promotes observe to heal. |
+| `HIVE_DELEGATION_CHAIN_ENABLED` | No | disabled | Enables delegation chain minting (`1`, `true`, `yes`, `on` — same spelling as `HIVE_METRICS_ENABLED`). Read on each call rather than cached, so disabling it on a misbehaving spoke does not require a pod roll. |
+| `HIVE_ALLOW_PRIVATE_GIT_SOURCE` | No | `false` | Opt-in to knowledge Git sources whose host resolves to a private/internal address (self-hosted GitLab and similar). Off by default as SSRF protection. |
+| `HIVE_SHARED_AGENT_HOME` | No | per-agent HOME | Escape hatch (`1`) restoring the legacy shared-HOME layout for agents. |
+| `HIVE_WORKSPACE_CLEANUP_ENABLED` | No | enabled | Set `0` to opt out of automatic agent workspace cleanup. |
+| `HIVE_DOSSIER_CACHE_MAX_ENTRIES` | No | `512` | Caps each public dossier cache. Bounds username-spray memory while keeping normal contributor reuse hot. |
 
 ## Generating and rotating `HIVE_DASHBOARD_TOKEN`
 
@@ -110,6 +118,11 @@ new value at the same time.
 | `HIVE_PROXY_ADVISORY_OK` | No | `false` | Allows the spoke to start when the forced-proxy egress redirect cannot be installed (no `CAP_NET_ADMIN`/iptables). Enforcement becomes advisory-only — agents can bypass the proxy. Also gates whether the Go proxy trusts a self-asserted `Proxy-Authorization` header as agent identity when its UID map is unavailable (N7, #3841) — off by default, an unidentified caller is treated as `ADVISORY` (writes blocked) rather than whatever name it claims. See [security-model.md](security-model.md#forced-proxy-egress-and-cap_net_admin). |
 | `HIVE_TMUX_HISTORY_LIMIT` | No | `50000` | tmux scrollback depth applied when an agent session is created (positive integer; the authoritative knob for terminal scrollback and full-log capture). |
 | `HIVE_TTYD_HISTORY_LIMIT` | No | `50000` | Defense-in-depth history-limit raise applied at browser attach time; only affects panes created after attach. |
+| `HIVE_TMUX_PANE_WIDTH` | No | `200` | Column count agent tmux sessions are created with. A detached tmux session defaults to 80 columns because no attached client supplies a size. |
+| `HIVE_KICK_LOG_DIR` | No | `/data/logs/kicks` | Root directory per-kick log archives are written under. On the persistent volume so archives survive restarts, pod rolls, and image upgrades. |
+| `HIVE_KICK_LOG_RETENTION` | No | `10` | Archived kick logs kept per agent. `0` disables archiving entirely. |
+| `HIVE_KICK_LOG_MAX_BYTES` | No | `67108864` (64 MiB) | Per-agent total size cap across archived kick logs. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | none | OTLP trace exporter endpoint. Tracing stays disabled while unset. |
 | `HIVE_WIKI_GIT_URL` | No | none | Optional wiki vault URL cloned into `/data/vaults/hive-wiki` on first boot. |
 
 ## Inference, CLI backends, and agents
@@ -137,6 +150,13 @@ new value at the same time.
 | `HIVE_EXPLAIN_MODE` | No | `off` | **Fallback** for the hive-wide default agent explain mode (`off`, `brief`, `full`) — see [agent-configuration.md](agent-configuration.md#explain-mode-debugging-agent-behaviour). `governor.explain_mode` in `hive.yaml` (Settings → Governor → General in the dashboard) takes precedence; this variable applies only when that is unset. Either way it applies only to agents that leave `explain_mode` unset; an agent with an explicit value, including `off`, keeps it. Hive also injects the *resolved* mode into every agent process under this same name. An unrecognized value resolves to `off`. |
 | `BD_DIR` | No | current directory | `bd` beads CLI data directory. |
 | `BD_DASHBOARD_URL` | No | none | Dashboard URL used by `bd kb` integration. |
+| `OPENAI_API_KEY` | No | none | OpenAI-compatible API key consulted by backend/model resolution. |
+| `CODEX_API_KEY` | No | none | API key consulted for the Codex CLI backend. |
+| `HIVE_AGENT_TOKEN_REFRESH_INTERVAL` | No | `40m` | Go duration overriding the per-agent token refresh interval. Invalid or non-positive values fall back to the default. |
+| `HIVE_CREDENTIAL_WATCHDOG_INTERVAL` | No | `5m` | Go duration overriding how often the credential watchdog verifies each in-use backend credential file. `0` does NOT disable the watchdog — disabling is intentionally not offered. |
+| `HIVE_COPILOT_SESSION_REFRESH_INTERVAL` | No | `10m` | Go duration overriding the Copilot session refresh interval. |
+| `HIVE_COPILOT_SESSION_REFRESH_START_DELAY` | No | `30s` | Go duration overriding the delay before the first Copilot session refresh. |
+| `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE` | No | unset | Bypasses the Claude host-state isolation guard. As the name says, unsafe outside local development. |
 | `HIVE_CONN_<NAME>_URL` | No | generated from agent connection config | Agent API connection URI variable when a connection omits `env_name`; `<NAME>` is the uppercased connection name with `-` replaced by `_`. |
 | Custom connection auth env vars | No | none | If an agent API connection uses `auth.type: env`, Hive reads `auth.env_var` and injects that exact variable into the agent. |
 
@@ -181,6 +201,36 @@ Inside an **agent** session (set by the hive, never by the operator): ISSUES_ONL
 | `OCI_AVAILABILITY_DOMAIN` | Required for OCI FSS provisioning | none | OCI availability domain. |
 | `OCI_MOUNT_TARGET_ID` | Required for OCI FSS provisioning | none | OCI mount target OCID. |
 | `OCI_EXPORT_SET_ID` | Required for OCI FSS provisioning | none | OCI export set OCID. |
+| `HIVE_HUB_ADMIN_USERNAME` | No | none | Single hub admin username. Consulted alongside `HIVE_HUB_ADMINS`. |
+| `HIVE_HUB_ADMINS` | No | none | Comma-separated hub admin usernames. |
+| `HIVE_HUB_GITHUB_TOKEN` | No | none | Hub-side GitHub token used by the dibs public-repo check. |
+| `HIVE_REACH_REPO_DIR` | No | none (GitHub compare API) | Local clone the reach ancestry check resolves against via `git merge-base --is-ancestor`. The hub image ships no clone, so the compare-API adapter is the default. |
+| `HIVE_REACH_NEVER_RAN_DAYS` | No | `3` | Never-ran grace period in days (integer, > 0). Absent or invalid values fall back to the default. |
+| `HIVE_PROVISION_WORKERS` | No | saved scale setting, else built-in default | Provision queue worker count. The saved dashboard scale setting takes precedence over this variable. |
+| `HIVE_PROVISION_PER_CLUSTER` | No | saved scale setting, else built-in default | Maximum concurrent provisions per cluster. |
+| `HIVE_KUBECTL_MAX_PER_CLUSTER` | No | saved scale setting, else built-in default | Maximum concurrent `kubectl` executions per cluster. |
+| `HIVE_UPGRADE_WAVE_SIZE` | No | saved scale setting, else built-in default | Number of spokes upgraded per wave. |
+| `HIVE_UPGRADE_DEBOUNCE_SECONDS` | No | built-in default | Debounce window before an upgrade wave starts. |
+| `HIVE_UPGRADE_MAX_HOLD_SECONDS` | No | built-in default | Maximum time an upgrade may be held before proceeding. |
+
+### Spoke-side derived keys
+
+A hub-hosted spoke is provisioned with only the derived sub-keys it needs and
+never receives the master `HIVE_HUB_SECRET`. When one of these is unset, the
+spoke derives the same domain-separated sub-key from `HIVE_HUB_SECRET`, so a
+spoke still rolling on an older Deployment keeps working. Both sources yield the
+identical key, so hub verification succeeds either way; a lookup fails closed
+only when neither is configured.
+
+| Variable | Required | Default | Purpose |
+|---|---:|---|---|
+| `HIVE_HEARTBEAT_KEY` | No | derived from `HIVE_HUB_SECRET` | Spoke heartbeat signing sub-key. |
+| `HIVE_SESSION_KEY` | No | derived from `HIVE_HUB_SECRET` | Spoke session-cookie signing sub-key. |
+| `HIVE_INVITE_KEY` | No | derived from `HIVE_HUB_SECRET` | Per-hive contributor-invite signing key. Symmetric: the spoke both mints and verifies invite tokens with it. |
+| `HIVE_TERMINAL_KEY` | No | self-derived per-hive from `HIVE_HUB_SECRET` + `HIVE_ID` | Per-hive terminal-assertion signing key. It never falls back to a fleet-uniform key. |
+| `HIVE_SSO_PUBLIC_KEY` | No | none | Ed25519 **public** key a spoke verifies hub-minted SSO handoff tokens with. Holding only the public key, a spoke can verify but cannot mint. |
+| `HIVE_SSO_PUBLIC_KEY_PREV` | No | none | Previous SSO public key, accepted during rotation so a spoke bridges a hub key change. |
+| `HIVE_SSO_KEY` | No | none | Legacy symmetric SSO key, still read for one release so spokes on a pre-cutover Deployment keep working. |
 
 ### Hub login providers
 

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -319,6 +319,19 @@ The code is authoritative and this table is hand-maintained, so it drifts unless
 PRs update it. **If your change adds, renames, or removes an environment
 variable lookup, update this file in the same PR.**
 
+A CI guard (`TestEnvVarsDocDocumentsOnlyRealVariables`, in
+`src/pkg/config/env_vars_doc_parity_test.go`) enforces **one** direction of
+this: every variable given a table row here must actually appear in the
+implementation, so the reference cannot document something nothing reads. It is
+one-directional on purpose — env var names reach `os.Getenv` through package
+constants, config-resolved struct fields, injected `getenv` parameters, and
+local wrapper helpers, so no static check can enumerate the full set of
+variables the code reads.
+
+**The converse is therefore not enforced: adding a lookup without adding a row
+here will not fail CI.** Keeping this file complete remains a human
+responsibility, which is what the rest of this section is for.
+
 What counts as a change that needs an entry:
 
 - A new `os.Getenv` or `os.LookupEnv` call in `src/` — most live in

--- a/src/pkg/config/env_vars_doc_parity_test.go
+++ b/src/pkg/config/env_vars_doc_parity_test.go
@@ -1,0 +1,230 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// envVarsDocPath is the hand-maintained environment variable reference this
+// guard polices. It lives under src/, which matters: v2-tests.yml gates PRs on
+// `paths: ['src/**', ...]`, so both this test and the file it checks are inside
+// the filter. The #5077 post-mortem (#5388) found two guards that could never
+// run because the artifact they checked sat outside their workflow's path
+// filter — dashboard/openapi.json and the repo-root NOTICE. This one does not
+// have that hole, and an env-vars.md-only PR does run this test.
+const envVarsDocPath = "../../docs/env-vars.md"
+
+// envVarsDocScanRoots are the trees searched for evidence that a documented
+// variable is real. Env vars in this repo are consumed from Go, from the
+// deployment/entrypoint shell, from the Justfile, and from config templates, so
+// all of them count as an implementation. Paths are relative to this package
+// (src/pkg/config).
+var envVarsDocScanRoots = []string{
+	"../..", // the whole src/ tree: Go, src/deploy/entrypoint.sh, manifests
+	"../../../bin",
+	"../../../config",
+	"../../../Justfile",
+	"../../../install.sh",
+	"../../../uninstall.sh",
+}
+
+// TestEnvVarsDocDocumentsOnlyRealVariables is the #5407 guard.
+//
+// src/docs/env-vars.md is a hand-compiled reference whose own header says "the
+// code is authoritative". Nothing kept it honest. That is the same shape of
+// artifact as dashboard/openapi.json before #5077: a published reference
+// consumers are told to trust, with no mechanical tie to the thing it
+// describes. In #5077 the spec had drifted into documenting fields the server
+// never sent, and three downstream client tasks carried the acceptance
+// criterion "mirror the spec, do not invent fields" — mirroring the drift would
+// have produced a wrong client.
+//
+// DIRECTION, and why this one.
+//
+// This guard is deliberately one-directional: it forbids the reference from
+// documenting a variable that nothing reads. It does NOT require the converse
+// (every variable read anywhere is documented). That choice is forced by what
+// the source actually looks like, not by convenience:
+//
+//  1. Env var names reach os.Getenv through at least four indirections that no
+//     static extractor here can follow — package constants (EnvBucket,
+//     envOCICompartmentID), struct fields resolved from config at runtime
+//     (gw.APIKeyEnv, c.APIKeyEnv), injected getenv func(string) string
+//     parameters (src/cmd/apiproxy/main.go), and local helpers that wrap the
+//     lookup (getEnvOrDefault in src/pkg/hub/oci_fss.go). An AST pass over
+//     call sites resolves ~105 names; grepping every ALLCAPS string literal in
+//     src/ yields ~311 candidates, most of which are not env vars at all.
+//     There is no rule separating the two sets that does not itself need
+//     hand-maintenance — which is the very failure mode being fixed.
+//  2. So a "must be documented" guard would open red against a set of names it
+//     cannot enumerate correctly, and would demand a large permanent exception
+//     list of things that merely LOOK like env vars. Per #5384's reasoning, a
+//     guard that cannot be made green gets skipped or deleted, and then it
+//     protects nothing.
+//
+// The direction kept is the one that is both decidable and the one that
+// actually bit in #5077: a reference entry that corresponds to nothing real.
+// Deciding it needs only "does this exact name appear anywhere in the
+// implementation?", which is exact, cheap, and has no false positives that
+// require excusing.
+//
+// The uncovered direction — a newly added env var silently going undocumented —
+// is left to the "Keeping this reference current" section of env-vars.md and to
+// review. This is a real, acknowledged gap, not an oversight.
+func TestEnvVarsDocDocumentsOnlyRealVariables(t *testing.T) {
+	documented, proposed := documentedEnvVars(t)
+	if len(documented) == 0 {
+		t.Fatalf("%s yielded no documented variable rows; the table format changed and this "+
+			"guard is no longer reading it — fix the parser, do not delete the test",
+			envVarsDocPath)
+	}
+
+	corpus := envVarNameCorpus(t)
+	if len(corpus) == 0 {
+		t.Fatalf("scanned %v and found no identifier tokens at all; the scan roots are wrong "+
+			"and this guard would vacuously pass", envVarsDocScanRoots)
+	}
+
+	var problems []string
+	for _, name := range documented {
+		if corpus[name] {
+			continue
+		}
+		if _, ok := proposed[name]; ok {
+			// A row explicitly marked "proposed"/"not implemented" is an
+			// honest reservation of a name, not a claim that the code reads
+			// it. Documenting a name as unimplemented is the opposite of the
+			// #5077 defect, so it is allowed — but only when the row says so
+			// in the Required column, which is why this is derived from the
+			// table rather than from a hand-kept list that could go stale.
+			continue
+		}
+		problems = append(problems, name+" is documented in "+envVarsDocPath+
+			" but the name appears nowhere in the implementation "+
+			"(no Go source, entrypoint/helper shell, Justfile, or config template reads it) — "+
+			"remove the row, correct a typo in the name, or, if the variable is planned but "+
+			"not yet wired, mark its Required column \"proposed\" the way the Credly rows do")
+	}
+
+	// A row marked "proposed" that the code now DOES read is stale bookkeeping
+	// pointing operators at a variable the reference still calls unimplemented.
+	// Failing on it mirrors how openapi_route_parity_test.go fails on stale
+	// exceptions rather than letting them rot into cover for real drift.
+	for name := range proposed {
+		if corpus[name] {
+			problems = append(problems, name+" is marked \"proposed\"/not-implemented in "+
+				envVarsDocPath+" but the implementation now references it — the feature shipped; "+
+				"move the row into the section for the component that reads it and give it a "+
+				"real Required/Default")
+		}
+	}
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("%s has drifted from the implementation (%d documented, %d marked proposed, "+
+			"%d problem(s)):\n  %s",
+			envVarsDocPath, len(documented), len(proposed), len(problems),
+			strings.Join(problems, "\n  "))
+	}
+}
+
+// envVarDocRowPattern matches a markdown table row whose first cell is a
+// backticked ALLCAPS identifier — the shape every variable row in env-vars.md
+// uses. Prose mentions of a variable elsewhere in the file are deliberately not
+// matched: only a table row is a claim that the variable exists.
+var envVarDocRowPattern = regexp.MustCompile("^\\|\\s*`([A-Z][A-Z0-9_]{2,})`\\s*\\|(.*)$")
+
+// proposedMarker identifies the Required-column text env-vars.md uses for a
+// name that is reserved but not yet implemented.
+const proposedMarker = "proposed"
+
+// documentedEnvVars returns every variable named in a table row of
+// env-vars.md, plus the subset whose Required column marks them as proposed
+// (mapped to the raw Required cell, for failure messages).
+func documentedEnvVars(t *testing.T) (all []string, proposed map[string]string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(envVarsDocPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", envVarsDocPath, err)
+	}
+	proposed = map[string]string{}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		m := envVarDocRowPattern.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		name := m[1]
+		if !seen[name] {
+			seen[name] = true
+			all = append(all, name)
+		}
+		// m[2] is the remainder of the row; its first cell is Required.
+		required, _, _ := strings.Cut(m[2], "|")
+		if strings.Contains(strings.ToLower(required), proposedMarker) {
+			proposed[name] = strings.TrimSpace(required)
+		}
+	}
+	sort.Strings(all)
+	return all, proposed
+}
+
+// envVarNameCorpus returns the set of ALLCAPS identifier tokens appearing
+// anywhere in the implementation trees. Membership is the test's definition of
+// "this variable is real": it is intentionally permissive, because a false
+// "real" only weakens the guard for one name, while a false "fictional" would
+// fail a PR over a lookup this scanner could not follow. Markdown is excluded
+// so documentation cannot vouch for itself.
+func envVarNameCorpus(t *testing.T) map[string]bool {
+	t.Helper()
+
+	tokenPattern := regexp.MustCompile(`[A-Z][A-Z0-9_]{2,}`)
+	corpus := map[string]bool{}
+	for _, root := range envVarsDocScanRoots {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				// A missing optional root (e.g. a trimmed checkout) must not
+				// silently shrink the corpus into false failures.
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			if info.IsDir() {
+				if info.Name() == ".git" || info.Name() == "node_modules" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.EqualFold(filepath.Ext(path), ".md") {
+				return nil
+			}
+			if info.Size() > maxEnvCorpusFileBytes {
+				return nil
+			}
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return nil
+			}
+			for _, tok := range tokenPattern.FindAllString(string(data), -1) {
+				corpus[tok] = true
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("scanning %s for env var references: %v", root, err)
+		}
+	}
+	return corpus
+}
+
+// maxEnvCorpusFileBytes skips vendored blobs and build artifacts that would
+// slow the scan without containing env var lookups. It is generous enough to
+// cover every hand-written source file in the repo, including
+// src/cmd/hive/main.go.
+const maxEnvCorpusFileBytes = 4 << 20 // 4 MiB


### PR DESCRIPTION
Fixes #5407

## The problem

`src/docs/env-vars.md` opens by saying it is compiled **by hand** and that "the code is authoritative". Nothing kept it honest.

That is the same shape of artifact as `dashboard/openapi.json` before #5077: a published reference consumers are told to trust, with no mechanical tie to the thing it describes. In #5077 the spec had drifted into documenting fields the server never sent, and three TUI client tasks carried the acceptance criterion "mirror the spec, do not invent fields" — mirroring it would have produced a wrong client.

## Measured drift

The issue guessed at the numbers; these are measured against the implementation.

| Direction | Count |
|---|---|
| Read in Go but **not documented** | **36** |
| Documented but **read nowhere** (true fiction) | **0** |

All 36 are now documented, with defaults and semantics read from their declaration sites rather than guessed (e.g. `HIVE_KICK_LOG_MAX_BYTES` = 64 MiB, `HIVE_REACH_NEVER_RAN_DAYS` = 3, `HIVE_CREDENTIAL_WATCHDOG_INTERVAL` = 5m). The spoke-side derived keys (`HIVE_HEARTBEAT_KEY`, `HIVE_TERMINAL_KEY`, `HIVE_SSO_PUBLIC_KEY`, …) got their own subsection, because the "unset means derive from `HIVE_HUB_SECRET`" rule is the load-bearing part.

**On the "fiction" count being zero.** A first pass flagged 17 documented-but-unread names. Every one was a false positive, and checking them is what determined the guard's direction: `PROXY_AUTH_TOKEN` is read through an injected `getenv func(string) string` parameter, `OCI_COMPARTMENT_ID` through a local `getEnvOrDefault` wrapper, `HIVE_LLMD_API_KEY` through a config-resolved struct field, and others are shell/Justfile reads. The 3 Credly rows are explicitly marked "proposed — not implemented", which is honest reservation, not drift. The document was in much better shape than the issue assumed.

## The guard, and which direction it enforces

`TestEnvVarsDocDocumentsOnlyRealVariables` in `src/pkg/config/env_vars_doc_parity_test.go`.

It enforces: **every variable documented in a table row must appear somewhere in the implementation.** It forbids documenting fiction.

It deliberately does **not** enforce the converse ("every var read is documented"), and the reason is the finding above, not convenience. Env var names reach `os.Getenv` through at least four indirections no static pass here can follow — package constants, config-resolved struct fields, injected `getenv` parameters, and local wrapper helpers. An AST pass over call sites resolves ~105 names; grepping every ALLCAPS literal in `src/` yields ~311 candidates, most not env vars at all. There is no rule separating those sets that does not itself need hand-maintenance — the very failure mode being fixed. That guard would open red against a set it cannot enumerate and would need a large permanent exception list. Per #5384's reasoning, a guard that cannot be made green gets skipped or deleted, and then it protects nothing.

The direction kept is decidable with no false positives needing excuse, and it is the one that actually bit in #5077.

**The uncovered direction — a new env var silently going undocumented — remains uncovered.** It is left to the "Keeping this reference current" section and to review. Stating that plainly rather than implying full coverage.

## Exceptions

No hand-maintained exception list. Rows marked `proposed` in the Required column are excused, and that is read from the table itself, so it cannot go stale independently of the doc.

Staleness fails in the other direction too: a row marked "proposed" that the code **now reads** fails the test as stale bookkeeping, mirroring how `openapi_route_parity_test.go` fails on stale exceptions instead of letting them rot into cover for real drift.

## Demonstrated failing (#5388's bar)

Not asserted — run.

**1. Documenting fiction** — added `HIVE_TOTALLY_INVENTED_KNOB` as a normal row:
```
--- FAIL: TestEnvVarsDocDocumentsOnlyRealVariables
    HIVE_TOTALLY_INVENTED_KNOB is documented in ../../docs/env-vars.md but the name
    appears nowhere in the implementation ... remove the row, correct a typo in the
    name, or, if the variable is planned but not yet wired, mark its Required column
    "proposed" the way the Credly rows do
```

**2. Stale "proposed" marker** — marked the genuinely-read `HIVE_WORK_DIR` as proposed:
```
--- FAIL: TestEnvVarsDocDocumentsOnlyRealVariables
    HIVE_WORK_DIR is marked "proposed"/not-implemented ... but the implementation now
    references it — the feature shipped; move the row into the section for the
    component that reads it
```

**3. Anti-vacuity** — the #5388 failure mode itself. Stripped the backticks from every row so the parser matched nothing:
```
--- FAIL: TestEnvVarsDocDocumentsOnlyRealVariables
    ../../docs/env-vars.md yielded no documented variable rows; the table format
    changed and this guard is no longer reading it — fix the parser, do not delete
    the test
```
It fails rather than silently passing on zero rows. The same check covers an empty scan corpus.

All three reverted; the suite is green on the committed tree.

## Path-filter check (the trap from #5388)

Verified, not assumed. `v2-tests.yml` filters `paths: ['src/**', 'dashboard/openapi.json', '.github/workflows/v2-tests.yml']` and triggers on `pull_request` against `[v2, v4]`.

- the test — `src/pkg/config/env_vars_doc_parity_test.go` — is under `src/**` ✅
- the file it checks — `src/docs/env-vars.md` — is under `src/**` ✅

So a docs-only PR editing `env-vars.md` does run this guard. That is exactly what `dashboard/openapi.json` and the repo-root `NOTICE` got wrong. **No workflow changes were needed**, so there is no new `${{ }}` parsing risk (#5339) and no `.github/release-lines.yml` pinning to update.

## Contributor-facing note

`env-vars.md`'s "Keeping this reference current" section now states that the guard exists, which direction it enforces, and — explicitly — that **adding a lookup without a row here will not fail CI**. A contributor should not infer from a green build that this file is complete.

## What remains unverified

- **The undocumented direction is not guarded.** Stated above; the largest residual gap.
- **The corpus check is substring-free but name-level**: a name appearing only in a comment counts as "real". Deliberately permissive — a false "real" weakens the guard for one name, whereas a false "fictional" would fail a PR over a lookup the scanner cannot follow.
- `src/pkg/config` has a **pre-existing** unrelated failure, `TestEntrypointHardensRuntimeConfigItRecreates` (0644 vs 0600, a local umask artifact). Confirmed identical on clean `origin/v4` with my changes stashed. CI is the gate.
- The 36 new rows' defaults were read from declaration sites; I did not exercise each variable at runtime.
