### PR TITLE
📝 docs: document the real CI test flags and the relay token lifecycle

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -73,6 +73,68 @@ go test ./pkg/...
 go test ./cmd/hive
 ```
 
+### The plain command above is weaker than the gate
+
+`go test ./...` is not what CI runs. Every shard in
+[`.github/workflows/v2-tests.yml`](../.github/workflows/v2-tests.yml) — the
+workflow that publishes the required `test` check — uses the same three flags:
+
+```bash
+cd src
+go test ./pkg/hub/... -short -race -count=1     # test (hub)
+go test ./pkg/agent   -short -race -count=1 -run '<1/5 slice>'
+go test $PKGS         -short -race -count=1     # test (rest i/3)
+```
+
+The workflow shards for wall-clock only: `pkg/hub` and `pkg/agent` get dedicated
+jobs, and everything else from `go list ./pkg/... ./cmd/...` is partitioned into
+balanced buckets. The union of the shards is the whole of `./pkg/...` and
+`./cmd/...`, so what changes between your loop and the gate is the *flags*, not
+the coverage. To reproduce the gate locally in one unsharded run:
+
+```bash
+cd src
+go test ./pkg/... ./cmd/... -short -race -count=1
+```
+
+What each flag changes:
+
+- **`-race`** is the one most likely to catch a bug you would otherwise ship. A
+  data race or a lock-ordering mistake usually passes a non-race run every time
+  and only surfaces under load in production. This repository has repeatedly
+  paid for that: see the `writeMu` / `WriteControl` reasoning in
+  [`src/pkg/dashboard/contribute_ws.go`](../src/pkg/dashboard/contribute_ws.go),
+  which exists because concurrent writers to a single WebSocket produced real
+  mutex re-entrancy deadlocks. If you run only one thing before pushing, run
+  the race build of the packages you touched.
+- **`-short`** sets `testing.Short()`, so any test guarded by
+  `if testing.Short() { t.Skip(...) }` does **not** run in CI. This cuts both
+  ways, and both directions bite. A slow test you write without a `Short` guard
+  runs on every shard and adds to the gate's wall clock. A test you write
+  *behind* a `Short` guard is never executed by the gate at all — a green
+  required check says nothing about it, exactly as a plain run says nothing
+  about the `integration` suite above. Guard slow *setup*, not the assertion
+  that proves your fix.
+- **`-count=1`** disables the test result cache. Without it, an unchanged
+  package reports its previous verdict instead of re-running, which is
+  precisely what you do not want when you are trying to reproduce a failure or
+  chase a flake.
+
+Two flags that appear in CI but are *not* part of the PR gate:
+
+- **`-timeout 600s`** is used only by the hourly coverage cron
+  ([`.github/workflows/coverage-hourly.yml`](../.github/workflows/coverage-hourly.yml)),
+  which runs the suite unsharded. The PR shards pass no `-timeout`, so they take
+  Go's default of 10 minutes per shard binary. The practical bound on a shard is
+  therefore the same 10 minutes, applied to a much smaller slice of the suite.
+- **`-coverprofile`** is added by each shard to feed a per-package coverage
+  report. Coverage is scored, but it is not the required merge gate; a failing
+  test is.
+
+Neither the PR gate nor the cron runs `./test/...`: both enumerate
+`./pkg/... ./cmd/...` explicitly, and the integration suite additionally needs
+the `integration` build tag and a live hive, as described above.
+
 ## Format and lint expectations
 
 Run `gofmt` on Go files you edit:

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -21,7 +21,7 @@ sequenceDiagram
 ```
 
 - The **work queue** is built from the hive's monitored repos: open, actionable issues that pass the admin's filters. The current depth is visible on the Hub tab and at `GET /api/contribute/status` (as `actionable_items`).
-- The **relay** authenticates with a registration token, receives one task at a time, drives the local CLI inside a tmux session, injects a short-lived GitHub token for the PR, and reports the result. It heartbeats every 30 s and reconnects with exponential backoff; a task is abandoned if the relay observes no forward progress for 30 minutes, or if it crosses an absolute 4-hour backstop.
+- The **relay** authenticates with a registration token, receives one task at a time, drives the local CLI inside a tmux session, injects a short-lived GitHub token for the PR, and reports the result. It heartbeats every 30 s and reconnects with exponential backoff; a task is abandoned if the relay observes no forward progress for 30 minutes, or if it crosses an absolute 4-hour backstop. The GitHub token is valid for 55 minutes and is re-minted by the hub before it expires, so a task may outlive any single token ([below](#the-github-token-outlives-the-task-because-the-hub-re-mints-it)).
 - Every contributor has a **trust tier** with per-tier rate limits. See [Contributor trust tiers and delegated agent roles](contributor-trust-and-roles.md).
 
 ## Basic setup
@@ -423,6 +423,66 @@ This aligns the relay with the hub, which has been progress-driven since [#4260]
 Crossing either ceiling is reported with `failure_kind: environment`. It is a statement about this runtime — the relay could not see the work finish — not a judgement that the agent failed its task. The old path passed no options at all, so an infrastructure ceiling was recorded as a plain task failure.
 
 The hang case these ceilings nominally guard is covered better and sooner by the pane-stall detector above: 20 minutes of byte-identical output, confirmed over `PANE_STALL_CONFIRM_TICKS` ticks. The headless path has no pane to scrape and therefore no progress signal, so its one-shot child is bounded by the absolute backstop directly (`HIVE_HEADLESS_TASK_TIMEOUT_MS`).
+
+### The GitHub token outlives the task, because the hub re-mints it
+
+The scoped GitHub token the relay pushes with is valid for **55 minutes**
+(`wsTokenTTL`), which is shorter than the 4-hour absolute backstop above. A task
+is therefore allowed to run for longer than any single token lives. That gap is
+covered, not ignored: the hub re-mints ahead of expiry, so a task running to the
+backstop is expected to use several tokens in succession.
+
+**Minting.** The token is minted per task and scoped to that task's repository
+and the contributor's trust tier. It is delivered *after* the task's acceptance
+decision, on the `token_refresh` wire shape rather than inside `task_assign`
+itself — under the default auto-accept this is immediate, and under the opt-in
+explicit-acceptance mode it waits for the human. The relay's handler writes it
+to a single `0600` file (`GH_TOKEN_CACHE`, overridable with
+`HIVE_GH_TOKEN_CACHE`); that file is the only place the token lives.
+
+**Refresh.** On every heartbeat the hub checks whether the active task's token
+was minted at least **50 minutes** ago (`wsTokenRefreshPeriod`) and, if so,
+re-mints and pushes a fresh `token_refresh`. The relay overwrites the cache file
+in place. The five-minute gap before the 55-minute expiry absorbs clock skew and
+any `gh` command already in flight, so push access does not lapse between the
+old token dying and the new one landing. Refresh is unconditional on task
+duration: it re-arms each time it fires, so a task at the 4-hour backstop has
+been refreshed roughly four times.
+
+Two things follow from refresh being driven by the hub's heartbeat:
+
+- **It requires a live socket and an active task.** A task with no assignment,
+  or a connection whose socket has dropped, is not refreshed. A reconnect that
+  re-adopts a task through the server-issued lease re-mints immediately and
+  re-arms the cycle — without that step the resumed session's mint time would
+  stay zero and refresh would never fire again for the life of the connection
+  ([#2610](https://github.com/kubestellar/hive/issues/2610)).
+- **A failed re-mint is not fatal and is not announced.** If the mint errors, or
+  the hive has no App auth to mint from, the hub logs it and leaves the relay's
+  existing token in place, retrying on the next heartbeat. The relay is told
+  nothing. So the observable failure mode is not a "token expired" message: it
+  is a push or `gh` call that starts returning an authentication error partway
+  through a long task, with the previous 55 minutes having worked normally.
+
+**Expiry is advertised but not enforced by the relay.** Each `token_refresh`
+carries a `token_expires_at` timestamp, and the relay records it — but it never
+checks it. Nothing in the relay warns as expiry approaches, refuses to start a
+push against a stale token, or asks the hub for a new one. The relay finds out
+that a token has died the same way it finds out about any other GitHub error:
+the command fails. If you see an authentication failure on a task that has been
+running for around an hour, a re-mint that quietly failed on the hub side is the
+first thing to check, and the hub's log is the only place that records it.
+
+**Removal.** The token is unlinked on **every** task-exit path, before the agent
+is interrupted, so a turn that survives the stop cannot keep pushing against an
+issue the hub has already offered to someone else
+([#5353](https://github.com/kubestellar/hive/issues/5353),
+[#5373](https://github.com/kubestellar/hive/issues/5373)). It is deliberately
+*not* dropped when the relay declines an offered task: a decline is not an exit,
+and dropping the credential there would destroy the token belonging to the task
+still being worked. Unlinking the file does not revoke the token — it stays
+valid at GitHub for the remainder of its 55 minutes — so removal bounds *this
+relay's* use of it, not the credential's lifetime.
 
 ## Troubleshooting: the backend dies seconds after every task
 


### PR DESCRIPTION
Two documentation-only gaps in adjacent developer docs. Both were verified against the code on current `v4`, and in both cases the filed issue's framing turned out to be partly wrong — the docs here follow the code.

Fixes #5442
Fixes #5443

## `docs/development.md` — the documented test command is weaker than the gate

The file documented `go test ./...` and never mentioned a flag. The required `test` check runs three shard shapes, all with the identical flags:

```
go test ./pkg/hub/... -short -race -count=1     # test (hub)
go test ./pkg/agent   -short -race -count=1 -run '<1/5 slice>'
go test $PKGS         -short -race -count=1     # test (rest i/3)
```

Sharding is for wall clock only — the union of the shards is all of `./pkg/...` and `./cmd/...`, so what differs between the local loop and the gate is the flags, not the coverage.

The new section explains each flag, and gives the unsharded one-liner that reproduces the gate. `-race` gets the emphasis: it is the flag most likely to catch a bug that would otherwise ship, and this repo has paid for that more than once — the `writeMu` / `WriteControl` reasoning in `contribute_ws.go` exists because concurrent writers to one WebSocket produced real mutex re-entrancy deadlocks.

The `-short` explanation deliberately covers both directions. The issue only noted that an unguarded slow test costs CI time; the sharper hazard is the reverse — a test written *behind* a `testing.Short()` guard is never run by the gate at all, so a green required check says nothing about it. That mirrors the register the file already uses for the `integration` suite.

**Corrections to #5442's framing:**

- `-timeout 600s` is **not** part of the PR gate. Only the hourly coverage cron passes it. The PR shards pass no `-timeout` and take Go's 10-minute default per shard binary. The issue attributed the flag to the gate.
- The issue said CI runs `go test ./pkg/... ./cmd/... -short -race -count=1` as one command. That is the cron's shape; the gate is sharded into hub / agent×5 / rest×3.
- The issue's claim that `./test/...` "is excluded from CI because it needs a live hive" is right on the outcome but the doc already covered the `integration` tag and `HIVE_URL`. The new text just adds that neither the gate nor the cron enumerates it.

## `src/docs/contributor-relay.md` — the token lifecycle was undocumented

The doc described a 4-hour absolute backstop and a 30-minute no-progress lease but said nothing about the GitHub token, leaving an apparent contradiction: the token is valid **55 minutes** (`wsTokenTTL`) and the task may run **4 hours**.

**The gap is covered, and the issue's premise that it might not be is wrong.** The hub re-mints on the heartbeat once the active task's token is `wsTokenRefreshPeriod` (50 min) old and pushes a fresh `token_refresh`; the 5-minute margin absorbs clock skew and in-flight `gh` commands. Refresh re-arms each time it fires, so a task reaching the backstop has been refreshed roughly four times. A long-running task does **not** silently lose push access.

The new section documents minting (per task, repo- and tier-scoped, delivered on the `token_refresh` shape after the acceptance decision, into a single `0600` `GH_TOKEN_CACHE`), refresh and its two preconditions (live socket, active task; a reconnect re-mints via the server lease to re-arm the cycle, per #2610), and removal.

Removal reflects the last day's changes: #5373's `stopAgentForTaskExit()` drops the credential on **every** task-exit path before interrupting the agent, and deliberately does **not** drop it on the `task_assign` decline paths, where dropping would destroy the credential of the task still being worked. The doc also notes that unlinking the file does not revoke the token at GitHub — it bounds this relay's use of it, not the credential's lifetime.

Two limits are documented plainly rather than assumed away, since both are real and neither is a doc-fixable bug on its own:

- A failed re-mint is logged hub-side, leaves the old token in place, and retries next heartbeat — **the relay is never told**. So the observable symptom is a push that starts failing partway through a long task, not a "token expired" message. The hub log is the only record.
- `token_expires_at` is recorded by the relay (`bin/contributor-relay.sh`) but **never read**. Nothing warns near expiry or refuses a push against a stale token.

These are not filed as separate bugs: with refresh working, they are only reachable when a mint fails, and the honest documentation of the symptom is the useful artifact. Happy to file if a maintainer disagrees.

## Notes

- Docs-only. No code, no behaviour change.
- All four new relative links verified to resolve; `src/scripts/check-docs-links.py src/docs` passes (126 files). Note `docs/` at repo root is not covered by that checker, so its two workflow links and one source link were checked by hand.
- No cluster names, hostnames, or credentials; token values are described, never shown.