### PR TITLE
✨ feat(tui): kick selected agent now

### DIFF
--- a/src/pkg/tui/actions_test.go
+++ b/src/pkg/tui/actions_test.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,7 +20,10 @@ import (
 	"github.com/kubestellar/hive/pkg/tui/panes"
 )
 
-var pauseKey = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")}
+var (
+	pauseKey = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")}
+	kickKey  = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("K")}
+)
 
 func modelWithAgent(paused bool) model {
 	m := newModel()
@@ -242,5 +247,184 @@ func TestPauseModalBoundsLongErrors(t *testing.T) {
 	}
 	if got := lipgloss.Height(view); got != minHeight {
 		t.Fatalf("modal error frame is %d rows high, want %d", got, minHeight)
+	}
+}
+
+// TestKickSelectedAgentThroughTeatest drives the complete T21 operator path:
+// the roster supplies the selection, uppercase K runs a Bubble Tea command,
+// and the dashboard receives exactly one bodyless kick request.
+func TestKickSelectedAgentThroughTeatest(t *testing.T) {
+	type observedRequest struct {
+		method string
+		path   string
+		body   []byte
+	}
+	request := make(chan observedRequest, 1)
+	var kickCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"name":"scanner","enabled":true,"backend":"claude","model":"claude-opus-4-5"}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/kick/scanner":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read kick body: %v", err)
+			}
+			kickCount.Add(1)
+			request <- observedRequest{method: r.Method, path: r.URL.Path, body: body}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"status":"queued","agent":"scanner"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	pinDashboard(t, server.URL)
+
+	tm := teatest.NewTestModel(t, newModel(), teatest.WithInitialTermSize(100, 30))
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "scanner")
+	}, teatest.WithDuration(finalWait))
+	tm.Send(kickKey)
+
+	select {
+	case got := <-request:
+		if got.method != http.MethodPost || got.path != "/api/kick/scanner" {
+			t.Errorf("kick request = %s %s, want POST /api/kick/scanner", got.method, got.path)
+		}
+		if len(got.body) != 0 {
+			t.Errorf("kick request body = %q, want no body", got.body)
+		}
+	case <-time.After(finalWait):
+		t.Fatal("uppercase K did not reach the dashboard")
+	}
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "kick queued for scanner")
+	}, teatest.WithDuration(finalWait))
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(finalWait))
+	if got := kickCount.Load(); got != 1 {
+		t.Errorf("kick request count = %d, want exactly 1", got)
+	}
+	if final := tm.FinalModel(t).(model); final.kickPending != "" {
+		t.Errorf("kick remained pending for %q after the response", final.kickPending)
+	}
+}
+
+func TestKickKeyRequiresFocusedSelectedAgent(t *testing.T) {
+	m := modelWithAgent(false)
+	m.focus = 1
+	next, cmd := m.Update(kickKey)
+	if cmd != nil || next.(model).kickPending != "" {
+		t.Fatal("K queued a kick while another pane was focused")
+	}
+
+	empty := newModel()
+	next, cmd = empty.Update(kickKey)
+	if cmd != nil || next.(model).kickPending != "" {
+		t.Fatal("K queued a kick before the roster supplied a selection")
+	}
+
+	loadedEmpty, _ := empty.Update(panes.AgentsMsg{Agents: []client.Agent{}})
+	next, cmd = loadedEmpty.(model).Update(kickKey)
+	if cmd != nil || next.(model).kickPending != "" {
+		t.Fatal("K queued a kick from a loaded but empty roster")
+	}
+}
+
+func TestLowercaseKRemainsAgentNavigation(t *testing.T) {
+	m := newModel()
+	next, _ := m.Update(panes.AgentsMsg{Agents: []client.Agent{
+		{Name: "scanner", Enabled: true},
+		{Name: "quality", Enabled: true},
+	}})
+	m = next.(model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m = next.(model)
+	name, _, _ := m.panes[0].(panes.Agents).SelectedAgent()
+	if name != "quality" {
+		t.Fatalf("j selected %q, want quality", name)
+	}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	got := next.(model)
+	name, _, _ = got.panes[0].(panes.Agents).SelectedAgent()
+	if name != "scanner" {
+		t.Errorf("lowercase k selected %q, want scanner", name)
+	}
+	if cmd != nil || got.kickPending != "" {
+		t.Fatal("lowercase k queued a kick instead of only navigating")
+	}
+}
+
+func TestRepeatedKickKeyWhilePendingQueuesOneCommand(t *testing.T) {
+	m := modelWithAgent(false)
+	next, first := m.Update(kickKey)
+	if first == nil {
+		t.Fatal("first K did not return a kick command")
+	}
+	pending := next.(model)
+	if pending.kickPending != "scanner" {
+		t.Fatalf("kick pending for %q, want scanner", pending.kickPending)
+	}
+
+	next, second := pending.Update(kickKey)
+	if second != nil {
+		t.Fatal("repeated K returned a second command while the first was pending")
+	}
+	if got := next.(model).kickPending; got != "scanner" {
+		t.Errorf("repeated K changed pending target to %q", got)
+	}
+}
+
+func TestKickResultStatusText(t *testing.T) {
+	apiFailure := &client.APIError{
+		StatusCode: http.StatusBadGateway,
+		Method:     http.MethodPost,
+		Path:       "/api/kick/scanner",
+		Body:       `{"error":"agent tmux session is unavailable"}`,
+	}
+	tests := []struct {
+		name   string
+		result client.KickResult
+		err    error
+		want   string
+	}{
+		{name: "queued", result: client.KickResult{Status: "queued", Agent: "scanner"}, want: "kick queued for scanner"},
+		{name: "in flight", result: client.KickResult{Status: "in-flight", Agent: "scanner"}, want: "kick already in flight for scanner (request deduplicated)"},
+		{name: "owner required", err: &client.APIError{StatusCode: http.StatusForbidden}, want: "Kick failed: owner access required"},
+		{name: "API failure", err: apiFailure, want: "agent tmux session is unavailable"},
+		{name: "transport failure", err: errors.New("dial tcp: connection refused"), want: "dial tcp: connection refused"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := modelWithAgent(false)
+			m.width, m.height = 100, 30
+			m.kickPending = "scanner"
+			next, cmd := m.Update(kickResultMsg{agent: "scanner", result: tc.result, err: tc.err})
+			got := next.(model)
+			if cmd != nil {
+				t.Fatal("kick result returned a command; status rendering must remain in the TUI")
+			}
+			if got.kickPending != "" {
+				t.Errorf("kick remained pending for %q", got.kickPending)
+			}
+			if !strings.Contains(got.footerStatus, tc.want) {
+				t.Errorf("kick status = %q, want it to contain %q", got.footerStatus, tc.want)
+			}
+			if !strings.Contains(got.View(), tc.want) {
+				t.Errorf("footer does not contain %q", tc.want)
+			}
+		})
+	}
+}
+
+func TestFooterAdvertisesKickBinding(t *testing.T) {
+	if !strings.Contains(footerText, "K kick") {
+		t.Errorf("footerText = %q, want it to advertise uppercase K kick", footerText)
 	}
 }

--- a/src/pkg/tui/app.go
+++ b/src/pkg/tui/app.go
@@ -132,10 +132,10 @@ const (
 )
 
 // footerText lists only the bindings that EXIST. The sketch's full strip
-// (p pause, m model, K kick, …) documents keys whose tasks have not landed;
+// (m model, A acmm, …) documents keys whose tasks have not landed;
 // showing them now would advertise actions that silently do nothing. Each
 // action task appends its own binding when it wires the key.
-const footerText = "tab focus  p pause/resume  a attach  ? help  q quit"
+const footerText = "tab focus  p pause/resume  K kick  a attach  ? help  q quit"
 
 // confirmState is the pause/resume dialog. It remains present while the HTTP
 // command is in flight so every other key stays behind the modal, and it also
@@ -158,6 +158,15 @@ type agentActionMsg struct {
 	pause    bool
 	result   client.AgentActionResult
 	err      error
+}
+
+// kickResultMsg is the asynchronous result of asking the dashboard to queue a
+// kick. The target travels with the result because an empty Agent in a malformed
+// success response must not erase the operator's target from the status text.
+type kickResultMsg struct {
+	agent  string
+	result client.KickResult
+	err    error
 }
 
 // model is the root bubbletea model.
@@ -210,10 +219,15 @@ type model struct {
 	// completes.
 	attachPending bool
 
-	// footerErr is an attach failure rendered in place of the normal binding
-	// strip. tmux is a local optional dependency, so a missing binary or session
-	// is UI state rather than a reason to terminate the whole TUI.
-	footerErr string
+	// kickPending is the selected agent whose kick request is currently in
+	// flight. Only one local request is allowed at a time, so repeated K presses
+	// cannot enqueue duplicate commands before the dashboard answers.
+	kickPending string
+
+	// footerStatus is the latest action result rendered in place of the normal
+	// binding strip. Whichever asynchronous action answers last is the status
+	// the operator sees. Kick success describes only queueing or deduplication.
+	footerStatus string
 
 	// interval is this model's poll cadence, defaulting to pollInterval.
 	//
@@ -352,10 +366,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return next, cmd
 	case agentActionMsg:
 		return m.handleAgentAction(msg)
+	case kickResultMsg:
+		return m.handleKickResult(msg)
 	case attachReadyMsg:
 		if msg.err != nil {
 			m.attachPending = false
-			m.footerErr = "Attach failed: " + msg.err.Error()
+			m.footerStatus = "Attach failed: " + msg.err.Error()
 			return m, nil
 		}
 		return m, tea.ExecProcess(msg.cmd, func(err error) tea.Msg {
@@ -364,9 +380,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case attachDoneMsg:
 		m.attachPending = false
 		if msg.err != nil {
-			m.footerErr = "Attach failed: " + msg.err.Error()
+			m.footerStatus = "Attach failed: " + msg.err.Error()
 		} else {
-			m.footerErr = ""
+			m.footerStatus = ""
 		}
 		return m, m.poll()
 	case tea.KeyMsg:
@@ -415,6 +431,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.confirm = &confirmState{agent: name, pause: !paused}
 			return m, nil
+		case "K":
+			if m.focus != 0 || m.kickPending != "" {
+				return m, nil
+			}
+			agents, ok := m.panes[0].(panes.Agents)
+			if !ok {
+				return m, nil
+			}
+			name, _, ok := agents.SelectedAgent()
+			if !ok {
+				return m, nil
+			}
+			m.kickPending = name
+			m.footerStatus = ""
+			return m, m.kickAgent(name)
 		case "a":
 			if m.focus != 0 || m.attachPending {
 				return m, nil
@@ -428,7 +459,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.attachPending = true
-			m.footerErr = ""
+			m.footerStatus = ""
 			return m, prepareAttach(name)
 		}
 		// Any other key belongs to the focused pane. The T3 stubs ignore
@@ -509,8 +540,8 @@ func (m model) View() string {
 
 	header := headerStyle.Width(m.width).Render(m.headerText())
 	footerTextForFrame := footerText
-	if m.footerErr != "" {
-		footerTextForFrame = m.footerErr
+	if m.footerStatus != "" {
+		footerTextForFrame = m.footerStatus
 	}
 	footer := footerStyle.Width(m.width).MaxWidth(m.width).Render(footerTextForFrame)
 
@@ -613,6 +644,46 @@ func (m model) handleAgentAction(msg agentActionMsg) (tea.Model, tea.Cmd) {
 		m.confirm = nil
 	}
 	return m, m.poll()
+}
+
+func (m model) kickAgent(agent string) tea.Cmd {
+	return func() tea.Msg {
+		result, err := m.api.KickAgent(context.Background(), agent, "")
+		return kickResultMsg{agent: agent, result: result, err: err}
+	}
+}
+
+func (m model) handleKickResult(msg kickResultMsg) (tea.Model, tea.Cmd) {
+	// A result for anything other than the one local request still pending is
+	// stale. Ignoring it prevents an old response from clearing or rewriting a
+	// newer action if messages are replayed by an embedding program.
+	if m.kickPending != msg.agent {
+		return m, nil
+	}
+	m.kickPending = ""
+
+	if msg.err != nil {
+		if client.IsForbidden(msg.err) {
+			m.footerStatus = "Kick failed: owner access required"
+		} else {
+			m.footerStatus = fmt.Sprintf("Kick failed: %v", msg.err)
+		}
+		return m, nil
+	}
+
+	agent := msg.result.Agent
+	if agent == "" {
+		agent = msg.agent
+	}
+	switch msg.result.Status {
+	case "queued":
+		m.footerStatus = "kick queued for " + agent
+	case "in-flight":
+		m.footerStatus = "kick already in flight for " + agent + " (request deduplicated)"
+	default:
+		m.footerStatus = fmt.Sprintf("Kick returned status %q for %s", msg.result.Status, agent)
+	}
+	return m, nil
 }
 
 func (m model) confirmView() string {

--- a/src/pkg/tui/attach_test.go
+++ b/src/pkg/tui/attach_test.go
@@ -79,8 +79,8 @@ exit 99`)
 		t.Fatal("attach remained pending after the preflight failed")
 	}
 	for _, want := range []string{"Attach failed:", "hive-scanner", "can't find session"} {
-		if !strings.Contains(failed.footerErr, want) {
-			t.Errorf("footer error %q does not contain %q", failed.footerErr, want)
+		if !strings.Contains(failed.footerStatus, want) {
+			t.Errorf("footer error %q does not contain %q", failed.footerStatus, want)
 		}
 		if !strings.Contains(failed.View(), want) {
 			t.Errorf("rendered footer does not contain %q", want)

--- a/src/pkg/tui/panes/help.go
+++ b/src/pkg/tui/panes/help.go
@@ -19,7 +19,7 @@ type Binding struct {
 	Scope string
 	// Available reports whether pressing Keys does something TODAY.
 	//
-	// The design doc's §4 table is a ROADMAP: most of its rows belong to tasks
+	// The design doc's §4 table is a ROADMAP: some of its rows belong to tasks
 	// that have not landed. app.go's footerText already refuses to advertise
 	// those ("showing them now would advertise actions that silently do
 	// nothing"), and the same rule matters more here, because help is exactly
@@ -43,10 +43,10 @@ func HelpBindings() []Binding {
 		{Keys: "tab / shift+tab", Action: "Cycle pane focus forward / backward", Scope: "global", Available: true},
 		{Keys: "?", Action: "Toggle this help overlay", Scope: "global", Available: true},
 		{Keys: "q / ctrl+c", Action: "Quit", Scope: "global", Available: true},
-		{Keys: "j / k, ↓ / ↑", Action: "Move the selection within the focused pane", Scope: "focused pane"},
+		{Keys: "j / k, ↓ / ↑", Action: "Move the selection within the focused pane", Scope: "Agents / Events panes", Available: true},
 		{Keys: "p", Action: "Pause or resume the selected agent", Scope: "Agents pane", Available: true},
 		{Keys: "m", Action: "Open the model picker for the selected agent", Scope: "Agents pane"},
-		{Keys: "K", Action: "Kick the selected agent now", Scope: "Agents pane"},
+		{Keys: "K", Action: "Kick the selected agent now", Scope: "Agents pane", Available: true},
 		{Keys: "A", Action: "Open the ACMM level overlay", Scope: "global"},
 		{Keys: "a", Action: "Attach to the selected agent's tmux session", Scope: "Agents pane (local)", Available: true},
 	}

--- a/src/pkg/tui/panes/help_golden_test.go
+++ b/src/pkg/tui/panes/help_golden_test.go
@@ -102,7 +102,9 @@ func TestHelpMarksOnlyWiredBindingsAvailable(t *testing.T) {
 		"tab / shift+tab": true, // T3
 		"?":               true, // T23, this task
 		"q / ctrl+c":      true, // T1
+		"j / k, ↓ / ↑":    true, // T5 and T11
 		"p":               true, // T15
+		"K":               true, // T21
 		"a":               true, // T22
 	}
 	for _, b := range panes.HelpBindings() {

--- a/src/pkg/tui/panes/testdata/grid.golden
+++ b/src/pkg/tui/panes/testdata/grid.golden
@@ -27,4 +27,4 @@
 │                                                ││                                                │
 │                                                ││                                                │
 └────────────────────────────────────────────────┘└────────────────────────────────────────────────┘
-tab focus  p pause/resume  a attach  ? help  q quit                                                 [2K[?2004l[?25h[?1002l[?1003l[?1006l
+tab focus  p pause/resume  K kick  a attach  ? help  q quit                                         [2K[?2004l[?25h[?1002l[?1003l[?1006l

--- a/src/pkg/tui/panes/testdata/help.golden
+++ b/src/pkg/tui/panes/testdata/help.golden
@@ -4,23 +4,23 @@
                                                                                                     
                                                                                                     
                                                                                                     
-       ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓       
-       ┃ Keybindings                                                                        ┃       
-       ┃                                                                                    ┃       
-       ┃ tab / shift+tab  Cycle pane focus forward / backward           global              ┃       
-       ┃ ?                Toggle this help overlay                      global              ┃       
-       ┃ q / ctrl+c       Quit                                          global              ┃       
-       ┃ p                Pause or resume the selected agent            Agents pane         ┃       
-       ┃ a                Attach to the selected agent's tmux session   Agents pane (local) ┃       
-       ┃                                                                                    ┃       
-       ┃ Not wired up yet — listed because the design reserves them                         ┃       
-       ┃ j / k, ↓ / ↑     Move the selection within the focused pane    focused pane        ┃       
-       ┃ m                Open the model picker for the selected agent  Agents pane         ┃       
-       ┃ K                Kick the selected agent now                   Agents pane         ┃       
-       ┃ A                Open the ACMM level overlay                   global              ┃       
-       ┃                                                                                    ┃       
-       ┃ press any key to dismiss                                                           ┃       
-       ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛       
+      ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓      
+      ┃ Keybindings                                                                          ┃      
+      ┃                                                                                      ┃      
+      ┃ tab / shift+tab  Cycle pane focus forward / backward           global                ┃      
+      ┃ ?                Toggle this help overlay                      global                ┃      
+      ┃ q / ctrl+c       Quit                                          global                ┃      
+      ┃ j / k, ↓ / ↑     Move the selection within the focused pane    Agents / Events panes ┃      
+      ┃ p                Pause or resume the selected agent            Agents pane           ┃      
+      ┃ K                Kick the selected agent now                   Agents pane           ┃      
+      ┃ a                Attach to the selected agent's tmux session   Agents pane (local)   ┃      
+      ┃                                                                                      ┃      
+      ┃ Not wired up yet — listed because the design reserves them                           ┃      
+      ┃ m                Open the model picker for the selected agent  Agents pane           ┃      
+      ┃ A                Open the ACMM level overlay                   global                ┃      
+      ┃                                                                                      ┃      
+      ┃ press any key to dismiss                                                             ┃      
+      ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛      
                                                                                                     
                                                                                                     
                                                                                                     


### PR DESCRIPTION
## Problem

The TUI already exposes the selected agent and the dashboard client already supports the asynchronous kick endpoint, but the reserved uppercase `K` binding was not connected to either one. Pressing it in the Agents pane fell through to pane-level key handling and did nothing, forcing operators out of the full-screen workflow to queue immediate work.

This also left the UI without a truthful way to distinguish a newly queued kick from a request deduplicated into an existing delivery. Treating either response as delivered would be wrong because the POST contract only reports queue admission; delivery is tracked separately.

## Root cause

`pkg/tui/app.go` had no root-model state or message type for kicks. Unlike navigation keys, an agent action needs the app to resolve the focused pane's selection, run HTTP outside `Update`, suppress duplicate local commands while that request is pending, and retain its result as renderable status. The help table correctly marked `K` unavailable, but it also still marked the already-live Agents/Events navigation bindings unavailable and scoped them too broadly.

## Implementation

- Handle uppercase `K` only when the Agents pane is focused, a selected agent exists, and no local kick request is pending.
- Return a Bubble Tea command that calls `KickAgent(context.Background(), agent, "")`; the empty prompt intentionally sends no body and selects the server-generated work-message path.
- Track the pending target in the value model so repeated `K` presses cannot enqueue duplicate local requests before the first response arrives. Stale result messages cannot clear or overwrite a different pending target.
- Render the asynchronous contract in the existing footer/status area:
  - `queued` becomes `kick queued for <agent>`;
  - `in-flight` explicitly says an existing delivery is in flight and the request was deduplicated;
  - HTTP 403 becomes `Kick failed: owner access required`;
  - other API and transport errors retain the client's actionable error text.
- Rename the shared footer override to `footerStatus`, since it now carries both attach outcomes and kick outcomes rather than attach errors alone.
- Advertise `K kick` in the footer and mark `K` live in `HelpBindings`. Move `j / k, ↓ / ↑` into the live section and scope it to the Agents and Events panes, matching the behavior that already shipped.
- Regenerate the grid and help goldens to pin the updated footer, availability split, and navigation scope.

The fixed v1 interaction deliberately remains a single shifted keypress. There is no confirmation modal: uppercase `K` is the specified safety affordance, and adding another interaction would diverge from the settled TUI design.

## Regression coverage

- A teatest + `httptest` flow loads and selects `scanner`, presses uppercase `K`, observes exactly one `POST /api/kick/scanner`, proves the request body is empty, and waits for the queued footer text.
- Focus and selection tests prove `K` is inert outside the Agents pane, before a roster is loaded, and for a loaded-but-empty roster.
- A navigation test proves lowercase `k` only moves the Agents selection and never creates a kick command.
- A pending-state test proves a repeated uppercase `K` does not enqueue a second Bubble Tea command.
- Result-table tests cover queued, in-flight/deduplicated, owner-only 403, generic API, and transport failures, and prove each result remains in the TUI rather than returning an exit command.
- Footer/help assertions and updated goldens prove only live bindings are advertised and Agents/Events navigation is no longer mislabeled unavailable.

## Verification

The host's `/tmp` quota was exhausted, so only Go's temporary/cache locations were redirected to a writable workspace directory; the build and tests themselves ran normally.

```text
cd src
env TMPDIR=/var/home/dbaggett/workspace/.hive-5414-cache/tmp GOCACHE=/var/home/dbaggett/workspace/.hive-5414-cache/go CCACHE_DIR=/var/home/dbaggett/workspace/.hive-5414-cache/ccache go build ./...
# PASS

env TMPDIR=/var/home/dbaggett/workspace/.hive-5414-cache/tmp GOCACHE=/var/home/dbaggett/workspace/.hive-5414-cache/go CCACHE_DIR=/var/home/dbaggett/workspace/.hive-5414-cache/ccache go test ./pkg/tui/... -count=1
# PASS: pkg/tui, pkg/tui/client, pkg/tui/panes, pkg/tui/theme
```

## Scope

This does not add custom prompts, kick history or delivery-status UI, change the kick client or Agents pane rendering, alter server-side deduplication, or introduce a confirmation modal. Pause/resume, attach, model selection, ACMM, and tmux behavior remain otherwise unchanged.

Fixes #5414

— hive: backend=codex
