### PR TITLE
✨ feature: add TUI agent model client operation

### DIFF
--- a/src/pkg/tui/client/models.go
+++ b/src/pkg/tui/client/models.go
@@ -20,6 +20,13 @@ import (
 // this drift; the T4/T6 precedent is to transcribe from the handler and cite it.
 type ModelOption string
 
+// ModelSetResult is the response from POST /api/model/{agent}/{model}.
+type ModelSetResult struct {
+	Status string `json:"status"`
+	Agent  string `json:"agent"`
+	Model  string `json:"model"`
+}
+
 // ModelList is the whole response from GET /api/inference/models/{backend}.
 //
 // The list-level flags are not decoration: a caller that keeps only Models is
@@ -106,4 +113,28 @@ func (c *Client) Models(ctx context.Context, backend string) (ModelList, error) 
 		return ModelList{}, err
 	}
 	return list, nil
+}
+
+// SetAgentModel persists a model override for one agent and restarts its
+// session so the selection takes effect immediately.
+//
+// Model ids are passed through unchanged. In particular, this client does not
+// canonicalize aliases or verify catalogue membership: the agent's effective
+// backend owns that validation and returns its authoritative reason in an
+// APIError when the model is unavailable.
+func (c *Client) SetAgentModel(ctx context.Context, agent, model string) (ModelSetResult, error) {
+	const prefix = "/api/model/"
+	if agent == "" {
+		return ModelSetResult{}, fmt.Errorf("POST %s: agent is required", prefix)
+	}
+	if model == "" {
+		return ModelSetResult{}, fmt.Errorf("POST %s: model is required", prefix)
+	}
+
+	var result ModelSetResult
+	path := prefix + url.PathEscape(agent) + "/" + url.PathEscape(model)
+	if err := c.postJSON(ctx, path, nil, &result); err != nil {
+		return ModelSetResult{}, err
+	}
+	return result, nil
 }

--- a/src/pkg/tui/client/models_test.go
+++ b/src/pkg/tui/client/models_test.go
@@ -278,3 +278,172 @@ func TestModelsMalformedBody(t *testing.T) {
 		t.Errorf("error = %q, does not name the decode failure", err)
 	}
 }
+
+// TestSetAgentModelDecodesFixture covers the complete write contract: both
+// inputs are escaped as individual path segments, the operation is a bodiless
+// authenticated POST, and every published response field is decoded.
+func TestSetAgentModelDecodesFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "model-set.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod, gotAuth, gotContentType string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.EscapedPath(), r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "tok").SetAgentModel(
+		context.Background(), "review/team", "meta/llama-3.1",
+	)
+	if err != nil {
+		t.Fatalf("SetAgentModel() = %v, want nil", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/model/review%2Fteam/meta%2Fllama-3.1" {
+		t.Errorf("escaped path = %q, want /api/model/review%%2Fteam/meta%%2Fllama-3.1", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer tok")
+	}
+	if len(gotBody) != 0 {
+		t.Errorf("request body = %q, want empty", gotBody)
+	}
+	if gotContentType != "" {
+		t.Errorf("Content-Type = %q, want unset for a bodiless POST", gotContentType)
+	}
+
+	want := ModelSetResult{
+		Status: "model_set",
+		Agent:  "review/team",
+		Model:  "meta/llama-3.1",
+	}
+	if got != want {
+		t.Errorf("SetAgentModel() = %+v, want %+v", got, want)
+	}
+}
+
+// TestSetAgentModelRequiresPathParameters verifies caller mistakes fail before
+// a round trip instead of producing a misleading route-level 404.
+func TestSetAgentModelRequiresPathParameters(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	cases := []struct {
+		name  string
+		agent string
+		model string
+		want  string
+	}{
+		{name: "empty agent", model: "gpt-5", want: "agent is required"},
+		{name: "empty model", agent: "scanner", want: "model is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := newTestClient(t, server, "tok").SetAgentModel(context.Background(), tc.agent, tc.model)
+			if err == nil {
+				t.Fatal("error = nil, want a local validation error")
+			}
+			if got != (ModelSetResult{}) {
+				t.Errorf("result = %+v, want zero value", got)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+	if called {
+		t.Error("an empty path parameter reached the server; both must fail locally")
+	}
+}
+
+// TestSetAgentModelNonOKReturnsAPIError proves the client preserves the
+// backend's model-validation explanation and still handles server failures
+// through the shared typed error path.
+func TestSetAgentModelNonOKReturnsAPIError(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		body string
+	}{
+		{
+			name: "model not available",
+			code: http.StatusBadRequest,
+			body: `{"ok":false,"error":"model meta/llama-3.1 is not available for backend codex"}`,
+		},
+		{name: "server error", code: http.StatusInternalServerError, body: `{"ok":false,"error":"boom"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.code)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer server.Close()
+
+			got, err := newTestClient(t, server, "tok").SetAgentModel(context.Background(), "scanner", "meta/llama-3.1")
+			if err == nil {
+				t.Fatalf("SetAgentModel() error = nil, want *APIError for %d", tc.code)
+			}
+			if got != (ModelSetResult{}) {
+				t.Errorf("result = %+v, want zero value", got)
+			}
+
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("error = %v (%T), want *APIError", err, err)
+			}
+			if apiErr.StatusCode != tc.code {
+				t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, tc.code)
+			}
+			if apiErr.Method != http.MethodPost {
+				t.Errorf("Method = %q, want POST", apiErr.Method)
+			}
+			if apiErr.Path != "/api/model/scanner/meta%2Fllama-3.1" {
+				t.Errorf("Path = %q, want escaped model path", apiErr.Path)
+			}
+			if apiErr.Body != tc.body {
+				t.Errorf("Body = %q, want %q", apiErr.Body, tc.body)
+			}
+		})
+	}
+}
+
+// TestSetAgentModelMalformedBody distinguishes a malformed success response
+// from a dashboard status error.
+func TestSetAgentModelMalformedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `not-json`)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "tok").SetAgentModel(context.Background(), "scanner", "gpt-5")
+	if err == nil {
+		t.Fatal("SetAgentModel() error = nil, want a decode error")
+	}
+	if got != (ModelSetResult{}) {
+		t.Errorf("result = %+v, want zero value", got)
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		t.Errorf("decode failure surfaced as *APIError (%v); the response was a 2xx", err)
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("error = %q, does not name the decode failure", err)
+	}
+}

--- a/src/pkg/tui/client/testdata/model-set.json
+++ b/src/pkg/tui/client/testdata/model-set.json
@@ -1,0 +1,6 @@
+{
+  "ok": true,
+  "status": "model_set",
+  "agent": "review/team",
+  "model": "meta/llama-3.1"
+}


### PR DESCRIPTION
## Summary

- add the typed `ModelSetResult` response and `Client.SetAgentModel` operation for `POST /api/model/{agent}/{model}`;
- keep model application behind the TUI client boundary, including dashboard authentication and typed API failures;
- cover escaped path segments, bodiless POST semantics, local argument validation, server failures, and malformed success payloads.

## Problem and user impact

The TUI model catalogue client can list the models available to an agent's backend, but it has no typed operation for applying a selection. The follow-up picker therefore cannot change an agent's model without either issuing raw dashboard HTTP from UI code or silently expanding its scope into client plumbing.

That missing boundary also matters for correctness: model IDs may contain `/`, model validity depends on the agent's effective backend, and the dashboard returns the authoritative validation explanation. Reimplementing any of those details in a picker would make the UI responsible for route construction and backend policy that belong elsewhere.

## Root cause

`pkg/tui/client/models.go` only represented the read-side catalogue endpoint. Although the dashboard already publishes and implements `POST /api/model/{agent}/{model}`, the TUI client had no corresponding response type or method. As a result, there was no reusable path that could apply a model while inheriting the client's bearer-token handling, timeout behavior, 2xx decoding, and `*APIError` handling.

## Implementation

- `src/pkg/tui/client/models.go`
  - adds the published `ModelSetResult` response shape;
  - adds `SetAgentModel(ctx, agent, model)`;
  - rejects an empty agent or model before creating a request;
  - escapes the agent and model independently with `url.PathEscape` so each remains one route segment;
  - calls `postJSON` with a nil body, preserving the endpoint's path-only request contract and all shared transport behavior.
- `src/pkg/tui/client/models_test.go`
  - exercises the operation through the existing `httptest` client pattern;
  - asserts POST, the exact escaped path, bearer authentication, an empty body, and no body content type;
  - covers local validation, dashboard 400/500 responses, and malformed 2xx JSON.
- `src/pkg/tui/client/testdata/model-set.json`
  - records the real `model_set` success envelope used by the handler.

## Design decisions and invariants

- Agent and model are escaped separately, rather than escaping a combined path. This preserves a model such as `meta/llama-3.1` as one `{model}` value instead of retargeting the request to additional path segments.
- The request deliberately has no JSON body because both inputs are defined as path parameters. Reusing `postJSON` with `nil` also avoids inventing a content type for an absent payload.
- The client does not normalize aliases or validate catalogue membership. The dashboard validates against the agent's effective backend, including backend-specific alias rules, and its 400 response remains available to the picker as an `*APIError`.
- `ModelSetResult` contains exactly the published `status`, `agent`, and `model` fields. The handler's additional `ok` envelope field is intentionally ignored by Go's JSON decoder.

## Regression coverage

- `TestSetAgentModelDecodesFixture` proves both parameters are escaped as single segments, the request is an authenticated bodiless POST, and all result fields decode.
- `TestSetAgentModelRequiresPathParameters` proves an empty agent and an empty model each fail locally without a round trip.
- `TestSetAgentModelNonOKReturnsAPIError` proves a 400 preserves the dashboard's model-unavailable explanation and a 500 uses the same typed error path, including method, escaped path, status, and body.
- `TestSetAgentModelMalformedBody` proves invalid JSON on a successful status is reported as a decode failure rather than an `*APIError`.

## Verification

The runner's default `/tmp` was at its per-user quota, so the equivalent issue-required commands were run with task-local Go temporary/cache directories:

```text
cd src && env TMPDIR=/var/home/dbaggett/workspace/.tmp-hive-5413 GOCACHE=/var/home/dbaggett/workspace/.gocache-hive-5413 CCACHE_DIR=/var/home/dbaggett/workspace/.ccache-hive-5413 go build ./...
PASS

cd src && env TMPDIR=/var/home/dbaggett/workspace/.tmp-hive-5413 GOCACHE=/var/home/dbaggett/workspace/.gocache-hive-5413 CCACHE_DIR=/var/home/dbaggett/workspace/.ccache-hive-5413 go test ./pkg/tui/...
PASS: github.com/kubestellar/hive/pkg/tui
PASS: github.com/kubestellar/hive/pkg/tui/client
PASS: github.com/kubestellar/hive/pkg/tui/panes
PASS: github.com/kubestellar/hive/pkg/tui/theme
```

## Scope

This PR does not change `app.go`, any pane, picker rendering or keyboard behavior, the Agents row, dashboard handlers, OpenAPI, backend switching, or free-form model entry. The operation is client plumbing for the separately scoped picker work. No changelog entry is included because this method is not yet exposed through user-facing TUI behavior.

Fixes #5413

— hive: backend=codex
