### PR TITLE
✨ feat: tui client estimated token cost (T28)

### DIFF
--- a/src/pkg/tui/client/cost.go
+++ b/src/pkg/tui/client/cost.go
@@ -1,0 +1,60 @@
+package client
+
+import "context"
+
+const costSourceEstimated = "estimated"
+
+// CostSummary is the estimated-cost portion of GET /api/cost.
+//
+// The dashboard response also carries native gateway balances, model and
+// session breakdowns, price-table metadata, and repository counts. The compact
+// TUI needs none of those: it joins this per-agent estimate to the token rows
+// and lets encoding/json discard the unrelated fields.
+//
+// TotalUSD is fully price-table-backed only when AllPriced reports true. The
+// server lists models without an exact price in UnpricedModels, so a caller must
+// not present a mixed summary's numeric total as an authoritative fleet cost.
+type CostSummary struct {
+	TotalUSD       float64          `json:"total_usd"`
+	ByAgent        []CostAgentEntry `json:"by_agent"`
+	UnpricedModels []string         `json:"unpriced_models"`
+}
+
+// AllPriced reports whether every model has an exact server-side price.
+func (s CostSummary) AllPriced() bool { return len(s.UnpricedModels) == 0 }
+
+// CostAgentEntry is one agent in the estimated-cost breakdown.
+//
+// USD is intentionally a float rather than a pointer because zero on the wire
+// can be either a genuine $0.00 estimate or an unpriced-model placeholder.
+// Source carries the distinction; callers must use Known rather than inferring
+// it from USD.
+type CostAgentEntry struct {
+	Name        string  `json:"name"`
+	USD         float64 `json:"usd"`
+	Source      string  `json:"source"`
+	Input       int64   `json:"input"`
+	Output      int64   `json:"output"`
+	CacheRead   int64   `json:"cache_read"`
+	CacheCreate int64   `json:"cache_create"`
+}
+
+// Known reports whether USD is backed by an exact server-side price. An
+// unpriced entry can carry USD 0 on the wire, but that zero is only a
+// placeholder and must not be mistaken for a free model.
+func (e CostAgentEntry) Known() bool { return e.Source == costSourceEstimated }
+
+type costResponse struct {
+	Estimated CostSummary `json:"estimated"`
+}
+
+// Costs returns the dashboard's estimated token-cost summary from GET
+// /api/cost. The dashboard remains the sole pricing authority; this client
+// decodes its estimate and does not calculate prices locally.
+func (c *Client) Costs(ctx context.Context) (CostSummary, error) {
+	var response costResponse
+	if err := c.getJSON(ctx, "/api/cost", &response); err != nil {
+		return CostSummary{}, err
+	}
+	return response.Estimated, nil
+}

--- a/src/pkg/tui/client/cost_test.go
+++ b/src/pkg/tui/client/cost_test.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCostsDecodesFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "cost.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod, gotAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		gotAuthorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "cost-token").Costs(context.Background())
+	if err != nil {
+		t.Fatalf("Costs() = %v, want nil", err)
+	}
+	if gotPath != "/api/cost" {
+		t.Errorf("path = %q, want /api/cost", gotPath)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotAuthorization != "Bearer cost-token" {
+		t.Errorf("Authorization = %q, want Bearer cost-token", gotAuthorization)
+	}
+
+	want := CostSummary{
+		TotalUSD: 7.375,
+		ByAgent: []CostAgentEntry{
+			{Name: "scanner", USD: 7.375, Source: "estimated", Input: 1_200_000, Output: 88_100, CacheRead: 450_000, CacheCreate: 10_000},
+			{Name: "quality", USD: 0, Source: "estimated", Input: 0, Output: 0, CacheRead: 0, CacheCreate: 0},
+			{Name: "reviewer", USD: 0, Source: "unpriced", Input: 96_700, Output: 12_400, CacheRead: 25_000, CacheCreate: 1_500},
+		},
+		UnpricedModels: []string{"private-model-v1"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Costs() =\n%+v\nwant\n%+v", got, want)
+	}
+
+	if !got.ByAgent[1].Known() {
+		t.Error("estimated $0.00 entry Known() = false, want true")
+	}
+	if got.ByAgent[2].Known() {
+		t.Error("unpriced $0.00 entry Known() = true, want false")
+	}
+	if got.AllPriced() {
+		t.Error("mixed priced/unpriced summary AllPriced() = true, want false")
+	}
+}
+
+func TestCostsEmptySummary(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"estimated":{"total_usd":0,"by_agent":[],"unpriced_models":[]}}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Costs(context.Background())
+	if err != nil {
+		t.Fatalf("Costs() = %v, want nil", err)
+	}
+	if got.TotalUSD != 0 || got.ByAgent == nil || len(got.ByAgent) != 0 || got.UnpricedModels == nil || len(got.UnpricedModels) != 0 {
+		t.Errorf("Costs() = %+v, want zero total and empty non-nil arrays", got)
+	}
+	if !got.AllPriced() {
+		t.Error("empty no-usage summary AllPriced() = false, want true")
+	}
+}
+
+func TestCostsMalformedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Costs(context.Background())
+	if err == nil {
+		t.Fatal("Costs() = nil error on a non-JSON 200, want a decode error")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("error = %v, want it to name the decode failure", err)
+	}
+	if !reflect.DeepEqual(got, CostSummary{}) {
+		t.Errorf("Costs() = %+v, want the zero value on error", got)
+	}
+}
+
+func TestCostsNonOKReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"cost estimate failed"}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").Costs(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Costs() error = %v (%T), want *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusInternalServerError)
+	}
+	if apiErr.Method != http.MethodGet {
+		t.Errorf("Method = %q, want GET", apiErr.Method)
+	}
+	if apiErr.Path != "/api/cost" {
+		t.Errorf("Path = %q, want /api/cost", apiErr.Path)
+	}
+	if !strings.Contains(apiErr.Body, "cost estimate failed") {
+		t.Errorf("Body = %q, want it to quote the dashboard's message", apiErr.Body)
+	}
+	if !reflect.DeepEqual(got, CostSummary{}) {
+		t.Errorf("Costs() = %+v, want the zero value on error", got)
+	}
+}

--- a/src/pkg/tui/client/testdata/cost.json
+++ b/src/pkg/tui/client/testdata/cost.json
@@ -1,0 +1,76 @@
+{
+  "estimated": {
+    "total_usd": 7.375,
+    "by_model": [
+      {
+        "name": "claude-opus-4-5",
+        "usd": 7.375,
+        "source": "estimated",
+        "input": 1200000,
+        "output": 88100,
+        "cache_read": 450000,
+        "cache_create": 10000
+      },
+      {
+        "name": "private-model-v1",
+        "usd": 0,
+        "source": "unpriced",
+        "input": 96700,
+        "output": 12400,
+        "cache_read": 25000,
+        "cache_create": 1500
+      }
+    ],
+    "by_agent": [
+      {
+        "name": "scanner",
+        "usd": 7.375,
+        "source": "estimated",
+        "input": 1200000,
+        "output": 88100,
+        "cache_read": 450000,
+        "cache_create": 10000
+      },
+      {
+        "name": "quality",
+        "usd": 0,
+        "source": "estimated",
+        "input": 0,
+        "output": 0,
+        "cache_read": 0,
+        "cache_create": 0
+      },
+      {
+        "name": "reviewer",
+        "usd": 0,
+        "source": "unpriced",
+        "input": 96700,
+        "output": 12400,
+        "cache_read": 25000,
+        "cache_create": 1500
+      }
+    ],
+    "unpriced_models": ["private-model-v1"],
+    "by_session": [
+      {
+        "session_id": "session-scanner-01",
+        "agent": "scanner",
+        "model": "claude-opus-4-5",
+        "usd": 7.375,
+        "source": "estimated"
+      }
+    ]
+  },
+  "gateways": [
+    {
+      "name": "openrouter",
+      "kind": "openrouter",
+      "source": "native",
+      "spent_usd": 8.25
+    }
+  ],
+  "price_table_date": "2026-08-01",
+  "disclaimer": "Estimated from token counts; not a bill.",
+  "merged_prs": 123,
+  "closed_issues": 456
+}


### PR DESCRIPTION
## Problem

The TUI token client can read token counts from `GET /api/tokens`, but it has no client method for the dashboard's separate `GET /api/cost` estimate. That leaves the Tokens pane without a source for its documented `COST` column: every per-agent and fleet cost remains unknown even when the dashboard has calculated an estimate.

The cost wire format also uses the numeric value `0` for both a genuine `$0.00` estimate and an unpriced placeholder. Consumers therefore cannot infer whether a value is known from the number alone.

## Implementation

- Add `Client.Costs(ctx)` and a narrow response envelope that decodes only the `estimated` portion of `/api/cost` through the shared authenticated `getJSON` path.
- Add `CostSummary` for `total_usd`, `by_agent`, and `unpriced_models`, plus `CostAgentEntry` for the complete per-agent token and USD breakdown.
- Preserve the server's `source` value and expose `CostAgentEntry.Known()` so callers use the source tag rather than guessing from USD.
- Add `CostSummary.AllPriced()` so a summary containing models without exact server-side prices cannot be presented as an authoritative fleet total.
- Add a full-shaped fixture that includes ignored gateway, per-model, per-session, metadata, and repository-count siblings. This proves the TUI projection stays deliberately narrower than the dashboard payload.

The client does not calculate prices locally; the dashboard remains the sole pricing authority. `Known()` accepts only `source: "estimated"`, so an unknown or future source is handled conservatively.

## Regression coverage

`cost_test.go` verifies:

- the authenticated `GET /api/cost` request and full fixture decode, including every requested per-agent field and all unpriced-model names;
- a real `$0.00` value with `source: "estimated"` is known, while `$0.00` with `source: "unpriced"` is unknown;
- a mixed priced/unpriced summary reports `AllPriced() == false`;
- a zero-usage response preserves valid, non-nil empty arrays;
- malformed JSON returns a decode error and a zero summary;
- non-2xx responses retain the existing typed `*APIError` behavior, including method, path, status, and response body.

## Verification

From `src/`:

```text
go test ./pkg/tui/client -run 'TestCosts' -count=1
ok  github.com/kubestellar/hive/pkg/tui/client

go test ./pkg/tui/...
ok  github.com/kubestellar/hive/pkg/tui
ok  github.com/kubestellar/hive/pkg/tui/client
ok  github.com/kubestellar/hive/pkg/tui/panes
ok  github.com/kubestellar/hive/pkg/tui/theme

go build ./...
PASS
```

The commands used task-local `GOCACHE`, `GOTMPDIR`, and `CCACHE_DIR` paths because this execution environment mounts their defaults read-only; no source or test behavior was altered.

## Scope

This PR intentionally does not modify the Tokens pane, application refresh loop, native gateway balances, histories, session rows, repository counts, disclaimer, or price calculations. Rendering and joining cost rows to token rows remain T30 work.

Closes #5415

— hive: backend=codex
