### PR TITLE
✨ feat(tui): client — hive display identity

### DIFF
--- a/src/pkg/tui/client/hive.go
+++ b/src/pkg/tui/client/hive.go
@@ -1,0 +1,22 @@
+package client
+
+import "context"
+
+// hiveIDResponse is the intentionally narrow wire shape returned by
+// GET /api/hive-id. Hive identity is independent from the much larger status
+// payload, so callers should not need to fetch or model unrelated fields.
+type hiveIDResponse struct {
+	ID string `json:"id"`
+}
+
+// HiveID returns the hive's configured display identity.
+//
+// An empty identity is valid and is returned unchanged. The TUI owns how that
+// state is rendered; the client only preserves the dashboard response.
+func (c *Client) HiveID(ctx context.Context) (string, error) {
+	var response hiveIDResponse
+	if err := c.getJSON(ctx, "/api/hive-id", &response); err != nil {
+		return "", err
+	}
+	return response.ID, nil
+}

--- a/src/pkg/tui/client/hive_test.go
+++ b/src/pkg/tui/client/hive_test.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHiveIDDecodesFixtureAndSendsExpectedRequest(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "hive.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var gotPath, gotMethod, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "dashboard-secret").HiveID(context.Background())
+	if err != nil {
+		t.Fatalf("HiveID() = %v, want nil", err)
+	}
+	if got != "production-east" {
+		t.Errorf("HiveID() = %q, want production-east", got)
+	}
+	if gotPath != "/api/hive-id" {
+		t.Errorf("path = %q, want /api/hive-id", gotPath)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotAuth != "Bearer dashboard-secret" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer dashboard-secret")
+	}
+}
+
+func TestHiveIDPreservesEmptyIdentity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":""}`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").HiveID(context.Background())
+	if err != nil {
+		t.Fatalf("HiveID() = %v, want nil", err)
+	}
+	if got != "" {
+		t.Errorf("HiveID() = %q, want empty", got)
+	}
+}
+
+func TestHiveIDMalformedBodyReturnsDecodeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html>not json</html>`))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").HiveID(context.Background())
+	if err == nil {
+		t.Fatal("HiveID() = nil error on a non-JSON 200, want a decode error")
+	}
+	if got != "" {
+		t.Errorf("HiveID() = %q, want empty on error", got)
+	}
+	if !strings.Contains(err.Error(), "decode /api/hive-id") {
+		t.Fatalf("error = %v, want it to name the endpoint decode failure", err)
+	}
+}
+
+func TestHiveIDNonOKReturnsBoundedAPIError(t *testing.T) {
+	body := strings.Repeat("x", maxErrorBodyBytes*2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	got, err := newTestClient(t, server, "t").HiveID(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("HiveID() error = %v (%T), want *APIError", err, err)
+	}
+	if got != "" {
+		t.Errorf("HiveID() = %q, want empty on error", got)
+	}
+	if apiErr.Method != http.MethodGet {
+		t.Errorf("Method = %q, want GET", apiErr.Method)
+	}
+	if apiErr.Path != "/api/hive-id" {
+		t.Errorf("Path = %q, want /api/hive-id", apiErr.Path)
+	}
+	if apiErr.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusBadGateway)
+	}
+	if apiErr.Body != body[:maxErrorBodyBytes] {
+		t.Errorf("Body length = %d, want bounded prefix of %d bytes", len(apiErr.Body), maxErrorBodyBytes)
+	}
+}

--- a/src/pkg/tui/client/testdata/hive.json
+++ b/src/pkg/tui/client/testdata/hive.json
@@ -1,0 +1,1 @@
+{"id":"production-east"}


### PR DESCRIPTION
## Summary

Adds the typed TUI client operation that fetches the hive's configured display identity:

```go
func (c *Client) HiveID(ctx context.Context) (string, error)
```

`HiveID` reads `GET /api/hive-id` through the existing shared `getJSON` path and returns the response's `id` unchanged. This supplies the client half needed for the live `hive:` header field without coupling identity to the much larger governor/status payload.

Fixes #5412. Part of #4907.

## Problem and root cause

The TUI header currently has no client operation for its hive display identity, so the rendering work owned by T29 can only show the placeholder `hive: —`. The dashboard already exposes the configured value through the dedicated, documented `GET /api/hive-id` endpoint.

Reusing `GET /api/status` would be the wrong boundary: the governor client intentionally projects only governor and ACMM fields from that large payload, while hive identity is an independent concern with its own API operation. Adding the field there would both couple unrelated refresh data and leave `/api/hive-id` unused.

## Implementation

- Added `src/pkg/tui/client/hive.go` with a private `hiveIDResponse` wire type containing only the documented `id` field.
- Added `Client.HiveID`, which delegates to `c.getJSON(ctx, "/api/hive-id", &response)` and returns `response.ID` exactly as received.
- Added `src/pkg/tui/client/testdata/hive.json` as the populated response fixture.
- Added focused regression coverage in `hive_test.go` for the endpoint's success and failure contracts.

Using `getJSON` is load-bearing: it preserves the existing base-URL joining, `Authorization: Bearer <dashboard token>` behavior, five-second client timeout, context cancellation, bounded error-body reads, and typed `*APIError` semantics. The method performs no trimming or validation. In particular, `{"id":""}` is a successful configured state and returns `"", nil`; presentation of that state belongs to T29.

## Regression coverage

The new tests prove that:

- a populated fixture returns `production-east` and sends `GET /api/hive-id` with the configured dashboard token;
- an empty `id` is returned unchanged without an error;
- malformed JSON on a 200 response produces a decode error naming `/api/hive-id`, rather than silently becoming an empty successful identity;
- a non-2xx response remains a `*client.APIError` carrying `GET`, `/api/hive-id`, the status, and exactly the bounded prefix of an oversized response body.

## Verification

Run from `src/` (the task-local cache variables work around this hosted workspace's read-only default Go/ccache directories):

- `env TMPDIR=/var/home/dbaggett/workspace/.hive-5412-tmp GOCACHE=/var/home/dbaggett/workspace/.hive-5412-go-cache CCACHE_DIR=/var/home/dbaggett/workspace/.hive-5412-ccache go test ./pkg/tui/client` — PASS
- `env TMPDIR=/var/home/dbaggett/workspace/.hive-5412-tmp GOCACHE=/var/home/dbaggett/workspace/.hive-5412-go-cache CCACHE_DIR=/var/home/dbaggett/workspace/.hive-5412-ccache go test ./pkg/tui/...` — PASS (`pkg/tui`, `pkg/tui/client`, `pkg/tui/panes`, and `pkg/tui/theme`)
- `env TMPDIR=/var/home/dbaggett/workspace/.hive-5412-tmp GOCACHE=/var/home/dbaggett/workspace/.hive-5412-go-cache CCACHE_DIR=/var/home/dbaggett/workspace/.hive-5412-ccache go build ./...` — PASS
- `git diff --cached --check` — PASS

The initial sandboxed test attempts did not execute the suite because the harness's default Go cache and ccache directories were read-only and loopback listeners were prohibited. The commands above use writable task-local caches, and the `httptest` suites were rerun with loopback permission; there are no code or test failures to report.

## Scope

This PR intentionally does not modify `app.go`, header rendering, panes, refresh orchestration, hive-ID setting/validation, dashboard API handlers, or OpenAPI. Those are either already implemented server-side or owned by T29 and later UI work. No changelog entry is included because this client-only operation is not user-visible until that rendering work consumes it.

The branch targets `v4`, contains one DCO-signed commit, and adds no credentials or runtime state.

— hive: backend=codex
