### PR TITLE
🧪 test(inference): extract and cover the litellm route resolution (#5460)

### DIFF
--- a/src/cmd/hive/litellm_route_resolution_test.go
+++ b/src/cmd/hive/litellm_route_resolution_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// resolveLiteLLMInferenceRoute is the route-install decision tree for the
+// built-in "litellm" backend. It shipped inline in main() with no coverage,
+// which is exactly how the #5393 outage happened: a hive configured ONLY
+// through the Model Gateways tab (explicit gateway named "litellm", legacy
+// governor.litellm block empty) resolved its key and CA bundle from that
+// gateway but its ENDPOINT from the empty legacy block, so no route was ever
+// installed and every agent call died "502 no inference route" while the
+// Gateways tab Test button passed. 231ca4b fixed it; this table pins the fix.
+//
+// The `gateway fallback` cases below FAIL against pre-231ca4b behavior (delete
+// the gateway-fallback block in resolveLiteLLMInferenceRoute and they go red
+// with ok=false), which is the point — a test that passes on both the fixed and
+// the broken code would guard nothing.
+func TestResolveLiteLLMInferenceRoute(t *testing.T) {
+	// The bundled local proxy's loopback URL is not a literal here: it must
+	// track litellmLocalProxyURL(), which owns the port.
+	localProxy := litellmLocalProxyURL()
+
+	cases := []struct {
+		name           string
+		litellm        config.LiteLLMConfig
+		gateways       []config.GatewayConfig
+		backend        string
+		requestedModel string
+
+		wantEndpoint string
+		wantModel    string
+		wantOK       bool
+	}{
+		{
+			// Classic hive: legacy block populated, no gateways. The legacy
+			// endpoint is used directly and its default_model fills in.
+			name:         "legacy endpoint used directly",
+			litellm:      config.LiteLLMConfig{Endpoint: "https://legacy.example", DefaultModel: "legacy-model"},
+			backend:      "litellm",
+			wantEndpoint: "https://legacy.example",
+			wantModel:    "legacy-model",
+			wantOK:       true,
+		},
+		{
+			// An agent that names a model keeps it; the legacy default_model
+			// is only a fallback, never an override.
+			name:           "requested model beats legacy default",
+			litellm:        config.LiteLLMConfig{Endpoint: "https://legacy.example", DefaultModel: "legacy-model"},
+			backend:        "litellm",
+			requestedModel: "asked-for-this",
+			wantEndpoint:   "https://legacy.example",
+			wantModel:      "asked-for-this",
+			wantOK:         true,
+		},
+		{
+			// local_proxy wins over BOTH the configured legacy endpoint and
+			// any gateway: the Go translator forwards to the bundled proxy on
+			// loopback. Losing this would silently send traffic upstream.
+			name: "local proxy overrides configured legacy endpoint",
+			litellm: config.LiteLLMConfig{
+				Endpoint: "https://legacy.example", DefaultModel: "legacy-model", LocalProxy: true,
+			},
+			gateways:     []config.GatewayConfig{{Name: "litellm", Endpoint: "https://gateway.example"}},
+			backend:      "litellm",
+			wantEndpoint: localProxy,
+			wantModel:    "legacy-model",
+			wantOK:       true,
+		},
+		{
+			name:         "local proxy with empty legacy block still routes",
+			litellm:      config.LiteLLMConfig{LocalProxy: true},
+			backend:      "litellm",
+			wantEndpoint: localProxy,
+			wantModel:    "",
+			wantOK:       true,
+		},
+		{
+			// THE #5393 CASE. Legacy block entirely empty, one explicit
+			// gateway named "litellm" from the Model Gateways tab. Pre-231ca4b
+			// this returned no endpoint and installed no route -> 502.
+			name:         "gateway fallback when legacy endpoint empty",
+			litellm:      config.LiteLLMConfig{},
+			gateways:     []config.GatewayConfig{{Name: "litellm", Kind: config.GatewayKindLiteLLM, Endpoint: "https://gateway.example", DefaultModel: "gateway-model"}},
+			backend:      "litellm",
+			wantEndpoint: "https://gateway.example",
+			wantModel:    "gateway-model",
+			wantOK:       true,
+		},
+		{
+			// The fallback must inherit the GATEWAY's default_model, not the
+			// (empty) legacy one — an empty model on the route is its own 4xx.
+			name:           "gateway fallback keeps an explicitly requested model",
+			litellm:        config.LiteLLMConfig{},
+			gateways:       []config.GatewayConfig{{Name: "litellm", Endpoint: "https://gateway.example", DefaultModel: "gateway-model"}},
+			backend:        "litellm",
+			requestedModel: "asked-for-this",
+			wantEndpoint:   "https://gateway.example",
+			wantModel:      "asked-for-this",
+			wantOK:         true,
+		},
+		{
+			// Gateway name match is case-insensitive (ResolveGateway uses
+			// EqualFold), so a tab-entered "LiteLLM" still backs the backend.
+			name:         "gateway fallback matches name case-insensitively",
+			litellm:      config.LiteLLMConfig{},
+			gateways:     []config.GatewayConfig{{Name: "LiteLLM", Endpoint: "https://cased.example", DefaultModel: "cased-model"}},
+			backend:      "litellm",
+			wantEndpoint: "https://cased.example",
+			wantModel:    "cased-model",
+			wantOK:       true,
+		},
+		{
+			// A gateway exists but carries no endpoint: there is nothing to
+			// fall back TO, so this must fail honestly rather than install a
+			// route with an empty endpoint.
+			name:         "gateway present but endpoint empty is not a route",
+			litellm:      config.LiteLLMConfig{},
+			gateways:     []config.GatewayConfig{{Name: "litellm", DefaultModel: "gateway-model"}},
+			backend:      "litellm",
+			wantEndpoint: "",
+			wantModel:    "",
+			wantOK:       false,
+		},
+		{
+			// A gateway list that does not name this backend must NOT be
+			// borrowed — routing litellm through someone else's endpoint and
+			// key is worse than no route.
+			name:         "unrelated gateway is not borrowed",
+			litellm:      config.LiteLLMConfig{},
+			gateways:     []config.GatewayConfig{{Name: "openrouter", Endpoint: "https://openrouter.example", DefaultModel: "or-model"}},
+			backend:      "litellm",
+			wantEndpoint: "",
+			wantModel:    "",
+			wantOK:       false,
+		},
+		{
+			// Nothing configured anywhere: the honest failure. ok=false tells
+			// main() to warn and install NO route. The contract is an explicit
+			// false, NOT a silently empty endpoint string.
+			name:         "nothing configured yields no route",
+			litellm:      config.LiteLLMConfig{},
+			backend:      "litellm",
+			wantEndpoint: "",
+			wantModel:    "",
+			wantOK:       false,
+		},
+		{
+			// On failure the requested model is handed back unchanged so the
+			// caller's warning names what the agent actually asked for.
+			name:           "no route preserves the requested model for the warning",
+			litellm:        config.LiteLLMConfig{},
+			backend:        "litellm",
+			requestedModel: "asked-for-this",
+			wantEndpoint:   "",
+			wantModel:      "asked-for-this",
+			wantOK:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// HIVE_LITELLM_ENDPOINT is consulted by ResolveEndpoint and would
+			// leak a real environment into these cases.
+			t.Setenv(config.LiteLLMEndpointEnv, "")
+
+			cfg := &config.Config{Governor: config.GovernorConfig{
+				LiteLLM:  tc.litellm,
+				Gateways: tc.gateways,
+			}}
+
+			endpoint, model, ok := resolveLiteLLMInferenceRoute(cfg, tc.backend, tc.requestedModel)
+
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (endpoint=%q model=%q)", ok, tc.wantOK, endpoint, model)
+			}
+			if endpoint != tc.wantEndpoint {
+				t.Errorf("endpoint = %q, want %q", endpoint, tc.wantEndpoint)
+			}
+			if model != tc.wantModel {
+				t.Errorf("model = %q, want %q", model, tc.wantModel)
+			}
+			// The 502 this path exists to prevent: ok must never be true with
+			// nothing to route to.
+			if ok && endpoint == "" {
+				t.Errorf("ok=true with an empty endpoint — that installs a dead route (502 no inference route)")
+			}
+		})
+	}
+}
+
+// The env var overrides the yaml endpoint, and local_proxy still beats it.
+// ResolveEndpoint owns this precedence; pinning it here keeps the route-level
+// tree honest about which source it consulted.
+func TestResolveLiteLLMInferenceRouteEnvEndpoint(t *testing.T) {
+	t.Setenv(config.LiteLLMEndpointEnv, "https://from-env.example")
+	cfg := &config.Config{Governor: config.GovernorConfig{
+		LiteLLM:  config.LiteLLMConfig{Endpoint: "https://from-yaml.example", DefaultModel: "legacy-model"},
+		Gateways: []config.GatewayConfig{{Name: "litellm", Endpoint: "https://gateway.example"}},
+	}}
+
+	endpoint, model, ok := resolveLiteLLMInferenceRoute(cfg, "litellm", "")
+	if !ok || endpoint != "https://from-env.example" || model != "legacy-model" {
+		t.Fatalf("env endpoint: got (%q, %q, %v), want (https://from-env.example, legacy-model, true)", endpoint, model, ok)
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3389,38 +3389,17 @@ func main() {
 					// pointer — the config watcher swaps its contents in
 					// place on reload.
 					lc := cfg.Governor.LiteLLM
-					endpoint := lc.ResolveEndpoint()
-					if lc.LocalProxy {
-						// Local fallback: the Go translator forwards to the
-						// bundled litellm proxy on loopback instead of the
-						// remote endpoint.
-						endpoint = litellmLocalProxyURL()
-					}
-					if endpoint == "" {
-						// A hive configured ONLY through the Model Gateways tab
-						// (an explicit gateway named "litellm") leaves the
-						// legacy governor.litellm block empty. The key and CA
-						// bundle below already resolve from that gateway — the
-						// endpoint must too, or NO route is ever installed and
-						// every agent call dies "502 no inference route" while
-						// the Gateways tab Test button (which uses the gateway)
-						// happily passes (ains-validation/pocketmini,
-						// 2026-08-31).
-						if gw := cfg.Governor.ResolveGateway(backend); gw != nil && gw.Endpoint != "" {
-							endpoint = gw.Endpoint
-							if model == "" {
-								model = gw.DefaultModel
-							}
-						}
-					}
-					if endpoint == "" {
+					// Endpoint/model resolution lives in a pure function so the
+					// decision tree (local proxy / legacy block / explicit-gateway
+					// fallback / no route at all) is unit-testable — it is not
+					// reachable from a test while inline in main(). See #5460.
+					endpoint, resolvedModel, ok := resolveLiteLLMInferenceRoute(cfg, backend, model)
+					if !ok {
 						logger.Warn("litellm backend selected but no endpoint configured",
 							"agent", agentName, "model", model)
 						return
 					}
-					if model == "" {
-						model = lc.DefaultModel
-					}
+					model = resolvedModel
 					// Key source must MATCH the entitlement/probe path (gateways.go,
 					// cost.go, openrouter.go), which resolve the key from the gateway
 					// via ResolveGateway(backend).ResolveAPIKey(). When an EXPLICIT
@@ -9093,6 +9072,57 @@ func runHub(logger *slog.Logger, configPath string) {
 		os.Exit(1)
 	}
 	logger.Info("hub server stopped")
+}
+
+// resolveLiteLLMInferenceRoute resolves the endpoint and model an agent's
+// inference route should use for the built-in "litellm" backend. It is the
+// whole route-install decision tree for that backend, lifted out of main() so
+// it can be unit-tested (#5460); main() calls it and keeps ownership of key,
+// CA bundle and logging.
+//
+// requestedModel is the model the agent asked for ("" when it named none). The
+// returned model is that request when non-empty, otherwise the default
+// inherited from whichever source supplied the endpoint.
+//
+// Resolution order — each step matches the behavior shipped in 231ca4b:
+//
+//  1. local_proxy: the Go translator forwards to the bundled litellm proxy on
+//     loopback, overriding any configured remote endpoint.
+//  2. the legacy governor.litellm block (HIVE_LITELLM_ENDPOINT or yaml), whose
+//     default_model supplies the model.
+//  3. the EXPLICIT gateway named by this backend. A hive configured only
+//     through the Model Gateways tab leaves the legacy block empty; the key
+//     and CA bundle already resolve from that gateway, so the endpoint must
+//     too, or NO route is installed and every agent call dies "502 no
+//     inference route" while the Gateways tab Test button happily passes
+//     (ains-validation/pocketmini, 2026-08-31 — #5393).
+//
+// ok is false when no source yields an endpoint: the caller must warn and
+// install NO route. It never invents an endpoint, and never returns a route
+// with an empty endpoint — a silently empty endpoint is the 502 this whole
+// path exists to prevent.
+func resolveLiteLLMInferenceRoute(cfg *config.Config, backend, requestedModel string) (endpoint, model string, ok bool) {
+	lc := cfg.Governor.LiteLLM
+	model = requestedModel
+	endpoint = lc.ResolveEndpoint()
+	if lc.LocalProxy {
+		endpoint = litellmLocalProxyURL()
+	}
+	if endpoint == "" {
+		if gw := cfg.Governor.ResolveGateway(backend); gw != nil && gw.Endpoint != "" {
+			endpoint = gw.Endpoint
+			if model == "" {
+				model = gw.DefaultModel
+			}
+		}
+	}
+	if endpoint == "" {
+		return "", requestedModel, false
+	}
+	if model == "" {
+		model = lc.DefaultModel
+	}
+	return endpoint, model, true
 }
 
 // resolveWatsonxGateway finds the gateway backing the built-in "watsonx" agent


### PR DESCRIPTION
Fixes #5460

## The gap

`231ca4b` (for #5393) fixed the *502 no inference route for agent* bug by falling back to the explicit gateway's `Endpoint`/`DefaultModel` when the legacy `governor.litellm` block is empty. The fix is correct. The problem is where it lives: inline in the ~3400-line `main()` of `src/cmd/hive/main.go`, with no test. A refactor of `main()` can delete it and nothing goes red, and the symptom it prevents only appears at runtime on a live hive — which is exactly how the original bug shipped (Gateways tab Test passed with 30 models listed while every agent call died 502; caught live on ains-validation/pocketmini, 2026-08-31).

## What changed

Lifted the endpoint/model decision tree for `backend == "litellm"` out of `main()` into a pure function next to `resolveWatsonxGateway`:

```go
func resolveLiteLLMInferenceRoute(cfg *config.Config, backend, requestedModel string) (endpoint, model string, ok bool)
```

Strictly behaviour-preserving. Same resolution order (`local_proxy` loopback > legacy `governor.litellm` block via `ResolveEndpoint` > explicit gateway named by the backend), same default-model inheritance, same warn-and-install-no-route on failure. `main()` keeps ownership of the API key, CA bundle and logging — none of that moved. `main()`'s call site shrank to a call plus the existing warn branch.

The one thing the extraction makes explicit rather than implicit: failure is `ok == false`, not an empty endpoint string. A caller can no longer install a route with an empty endpoint by accident, which is the 502 this whole path exists to prevent. That is a stronger type, not a behaviour change — the old code's `if endpoint == ""` guard did the same job positionally.

No `main()` restructuring beyond this one lift, and no new defaults or magic numbers: the test derives the loopback URL from `litellmLocalProxyURL()` rather than hardcoding the port.

## Demonstration that the test fails on the pre-fix code

The bar here is #5388's: a guard that cannot fail is worthless. So the tests were run against reverted behaviour, not just asserted to be meaningful.

Deleting the gateway-fallback block from `resolveLiteLLMInferenceRoute` restores exactly pre-`231ca4b` behaviour. Against that:

```
--- FAIL: TestResolveLiteLLMInferenceRoute
    --- FAIL: .../gateway_fallback_when_legacy_endpoint_empty
        ok = false, want true (endpoint="" model="")
    --- FAIL: .../gateway_fallback_keeps_an_explicitly_requested_model
        ok = false, want true (endpoint="" model="asked-for-this")
    --- FAIL: .../gateway_fallback_matches_name_case-insensitively
        ok = false, want true (endpoint="" model="")
FAIL
```

`ok = false, endpoint = ""` is precisely the live outage: no route installed, every agent call 502s. Restoring the block turns all cases green. Note that the other eight cases pass in **both** states — they pin the surrounding tree that the extraction had to preserve, while the three above discriminate the fix itself. A test that passed on both the fixed and the broken code would guard nothing, and that is what this issue is about.

## Coverage

Table-driven, 11 cases plus one for env-var precedence:

- legacy endpoint used directly, with and without an agent-requested model
- `local_proxy` overriding **both** a configured legacy endpoint and a gateway
- `local_proxy` with an entirely empty legacy block
- **the #5393 case**: legacy empty, explicit gateway named `litellm` — including `DefaultModel` inheritance and case-insensitive name matching
- gateway present but its endpoint empty — no route, not an empty-endpoint route
- an unrelated gateway (`openrouter`) that must **not** be borrowed for `litellm`
- nothing configured anywhere — the honest `ok=false`, and the requested model handed back unchanged so the caller's warning names what the agent actually asked for
- `HIVE_LITELLM_ENDPOINT` overriding the yaml endpoint

Each case clears `HIVE_LITELLM_ENDPOINT` via `t.Setenv` so a real environment cannot leak in.

## One judgement, not acted on

The fallback is the right behaviour here and should stay, but it is worth naming the shape of the hazard. A fallback that silently rescues a misconfiguration can hide the misconfiguration. In this specific case it does not: a hive configured only through the Model Gateways tab with an explicit gateway named `litellm` is a *legitimate, fully-specified* configuration, not a broken one — the legacy `governor.litellm` block being empty is the expected state for such a hive, and resolving the endpoint from the same gateway that already supplies the key and CA bundle makes the three agree instead of disagree. Falling back is restoring consistency, not papering over a gap.

The genuinely ambiguous case is a gateway named `litellm` that exists but carries **no** endpoint. Today that produces no route and a warning — pinned by the `gateway present but endpoint empty is not a route` case. Arguably that deserves to be louder than a `Warn` at route-install time, since the operator has clearly *intended* to configure a gateway and left it half-done; the current failure mode is a log line the operator will not see until agents start 502ing. Making that fail loudly at config-validation time is a behaviour change and a separate issue, so it is flagged here rather than done.

## Scope

Test-and-extraction only. No behaviour change, no `main()` restructuring beyond the single lift, no new configuration surface.