### PR TITLE
fix(config): poll for reloaded org instead of reload counter in flaky watcher test

### DIFF
--- a/src/pkg/config/watcher_test.go
+++ b/src/pkg/config/watcher_test.go
@@ -43,23 +43,34 @@ func TestWatcher_ReloadsOnChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for debounce + reload
-	const waitForReload = 2 * time.Second
+	// Wait for the debounced reload to deliver the *new* content.
+	//
+	// Poll on the observable outcome (lastOrg) rather than on reloadCount.
+	// The callback increments reloadCount before it stores lastOrg, so a
+	// loop that exits on reloadCount > 0 can observe the counter in the
+	// window between those two statements and then read a still-unset
+	// lastOrg — yielding org == "" and a spurious failure. That window is
+	// tiny locally but is readily hit under -race on a loaded CI runner.
+	const waitForReload = 10 * time.Second
+	const pollInterval = 10 * time.Millisecond
 	deadline := time.Now().Add(waitForReload)
+	var org string
 	for time.Now().Before(deadline) {
-		if reloadCount.Load() > 0 {
+		if v, ok := lastOrg.Load().(string); ok && v == "updated-org" {
+			org = v
 			break
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(pollInterval)
 	}
 
 	if reloadCount.Load() == 0 {
 		t.Fatal("expected at least one reload after file change")
 	}
 
-	org, ok := lastOrg.Load().(string)
-	if !ok || org != "updated-org" {
-		t.Errorf("expected org = %q after reload, got %q", "updated-org", org)
+	if org != "updated-org" {
+		last, _ := lastOrg.Load().(string)
+		t.Errorf("expected org = %q after reload, got %q (reloads=%d)",
+			"updated-org", last, reloadCount.Load())
 	}
 }
 


### PR DESCRIPTION
Fixes #5448

## Root cause — a race in the test, not in the watcher

`TestWatcher_ReloadsOnChange` failed the required **v2 Tests** gate on PRs that do not touch `pkg/config` (#5440, run 33488167240, job `test (rest 2/3)`):

```
watcher_test.go:62: expected org = "updated-org" after reload, got ""
```

The `onChange` callback increments the counter **before** it stores the value:

```go
reloadCount.Add(1)
lastOrg.Store(cfg.Project.Org)
```

while the wait loop exited as soon as `reloadCount > 0` and then immediately read `lastOrg`. If the poll observes the counter in the window between those two statements, `lastOrg` is still unset, the type assertion `lastOrg.Load().(string)` returns `ok=false` with the zero value, and the test reports `got ""`.

The 50ms poll interval usually hides the window; a scheduler stall under `-race` on a loaded runner lands the observation inside it.

## This is not the originally suspected cause

The issue proposed a partial read of a non-atomic `os.WriteFile`. That mechanism cannot produce this failure — every truncation of the config is rejected before `onChange` runs:

| written content | `LoadWithDashboardOverlay` result |
|---|---|
| empty | error: `project.org is required` |
| first 1/2 | error: `yaml: unmarshal errors` |
| first 1/4 | error: `could not find expected ':'` |
| valid YAML, no org | error: `project.org is required` |

A failed load returns early and never invokes `onChange`, so no empty org can ever be stored. The observed `""` is the **never-stored** case, which is why the fix targets the observation order rather than write atomicity.

## Fix

Poll for the **observable outcome** (`lastOrg == "updated-org"`) instead of the reload counter, with a generous deadline and a tighter poll interval.

The assertion is **not weakened**: the test still requires `reloadCount > 0` and still requires the reloaded config to carry exactly `updated-org`. A watcher that failed to reload, or reloaded stale content, still fails — now by timing out rather than by reading a half-published result. The failure message also reports the reload count for easier diagnosis.

## Verification (all `-short -race`)

Reproduced deterministically by injecting a stall between the increment and the store, modelling a scheduler preemption:

| scenario | before | after |
|---|---|---|
| 120ms stall injected | **10/10 FAIL** (identical message) | **0/25 fail** |
| 3s stall injected (extreme) | — | **0/10 fail** |
| real test, `-count=200` | — | **0/200 fail** |
| all `TestWatcher_*`, `-count=100` under 12-way CPU saturation | — | **0 fail** |

The pre-fix run reproduces the exact CI message and line, and the fix survives a 3s stall — far beyond any plausible CI delay, so this is not merely a retuned timeout.

## Notes

- Test-only change; `watcher.go` is untouched. The watcher itself is correct — no product race was found.
- `TestEntrypointHardensRuntimeConfig` fails locally on macOS both with and without this change (pre-existing `chown`/file-mode limitation, #5360/#5331); unrelated and out of scope. The rest of `pkg/config` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)