### PR TITLE
🐛 knowledge: wire curator schedule to promotion, opt-in only

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2248,9 +2248,14 @@ func main() {
 	var knowledgeAPI *knowledge.KnowledgeAPI
 	if cfg.Knowledge.Enabled {
 		layers := convertKnowledgeLayers(cfg.Knowledge.Layers)
+		// The curator block was previously dropped here, so NewPromoter always
+		// received a zero CuratorConfig and AutoPromoteThreshold never reached
+		// the promoter in production. Passing it through is what makes the
+		// threshold gate real for the scheduled sweep (#5430).
 		knowledgeAPI = knowledge.NewKnowledgeAPI(layers, knowledge.KnowledgeConfig{
 			Enabled: cfg.Knowledge.Enabled,
 			Engine:  cfg.Knowledge.Engine,
+			Curator: curatorConfigFromHive(cfg.Knowledge.Curator),
 		}, logger)
 	}
 
@@ -2456,6 +2461,27 @@ func main() {
 				"bead_stores", len(beadStores),
 			)
 		}
+	}
+
+	// Scheduled knowledge promotion (#5430). knowledge.curator.schedule used to
+	// be parsed, defaulted to "daily", and never read. It now drives a real
+	// sweep — but ONLY when knowledge.curator.enabled is explicitly true.
+	// StartBackground is a no-op otherwise, and logs a notice if a schedule was
+	// configured without the opt-in so the mismatch is visible rather than
+	// silent. Do not replace the IsEnabled() guard with a schedule check: that
+	// would enable unreviewed promotion on every hive that omits the key.
+	if knowledgeAPI != nil && cfg.Knowledge.Curator.IsEnabled() {
+		promotionScheduler := knowledge.NewPromotionScheduler(
+			knowledgeAPI.Promoter(),
+			curatorConfigFromHive(cfg.Knowledge.Curator),
+			logger,
+		)
+		promotionScheduler.StartBackground(ctx)
+	} else if cfg.Knowledge.Curator.Schedule != "" {
+		logger.Info("knowledge.curator.schedule is set but scheduled promotion is disabled",
+			"schedule", cfg.Knowledge.Curator.Schedule,
+			"hint", "set knowledge.curator.enabled: true to opt in",
+		)
 	}
 
 	// Open the graph store in a background goroutine. NewGraphStore acquires
@@ -7036,6 +7062,22 @@ func convertKnowledgeLayers(cfgLayers []config.KnowledgeLayer) []knowledge.Layer
 		}
 	}
 	return layers
+}
+
+// curatorConfigFromHive maps the hive.yaml curator block onto the knowledge
+// package's own config. Enabled is carried across as a pointer so "absent"
+// stays distinguishable from "explicitly false" — the scheduled promotion loop
+// treats absent as OFF, and flattening it to a bool here would quietly turn
+// unreviewed promotion on fleet-wide (#5430).
+func curatorConfigFromHive(c config.KnowledgeCurator) knowledge.CuratorConfig {
+	return knowledge.CuratorConfig{
+		Enabled:              c.Enabled,
+		Schedule:             c.Schedule,
+		ExtractFrom:          c.ExtractFrom,
+		AutoPromoteThreshold: c.AutoPromoteThreshold,
+		PromoteFrom:          c.PromoteFrom,
+		PromoteTo:            c.PromoteTo,
+	}
 }
 
 // hiveIDFilePath is the persistent file where the Hive ID is stored across restarts.

--- a/src/hive.yaml.example
+++ b/src/hive.yaml.example
@@ -553,12 +553,21 @@ knowledge:
     #   url: https://wiki.hive.dev/mcp       # Public, read-only
     #   shared: true
   curator:
-    schedule: daily                           # How often to extract facts from merged PRs
+    # enabled: true                          # OPT-IN. Absent or false = scheduled
+                                             # auto-promotion never runs, even with a
+                                             # schedule set below. Auto-promotion copies
+                                             # facts into a higher layer with NO human
+                                             # review, so it is off unless you ask for it.
+    schedule: daily                          # Cadence for the promotion sweep once
+                                             # enabled: true. Accepts daily or hourly.
+                                             # Ignored entirely while disabled.
     extract_from:
       - pr_comments
       - ci_failures
       - review_comments
     auto_promote_threshold: 0.9              # Confidence to auto-promote project→org
+    # promote_from: project                  # Source layer (default: project)
+    # promote_to: org                        # Target layer (default: org)
   git_sources:                               # Remote git repos indexed as knowledge
     # - name: dakota-skills                  # Display name for this source
     #   url: https://github.com/projectbluefin/dakota

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -584,9 +584,31 @@ type KnowledgeLayer struct {
 }
 
 type KnowledgeCurator struct {
+	// Enabled gates the scheduled auto-promotion loop. It is a pointer so an
+	// absent key is distinguishable from an explicit `enabled: false`, and it
+	// defaults to FALSE — unlike BeadSynthesizer, which defaults to true.
+	//
+	// The asymmetry is deliberate. Auto-promotion copies facts into a
+	// higher-precedence knowledge layer with no human review, and `schedule`
+	// has been parsed-but-unactioned since it was introduced (#5430), so every
+	// existing hive that set it did so without ever having the loop run. If
+	// the loop defaulted on, upgrading would silently begin mutating the org
+	// layer on hives that never opted in. Scheduled promotion is therefore
+	// opt-in: `schedule` alone does NOT start it.
+	Enabled              *bool    `yaml:"enabled,omitempty"`
 	Schedule             string   `yaml:"schedule"`
 	ExtractFrom          []string `yaml:"extract_from"`
 	AutoPromoteThreshold float64  `yaml:"auto_promote_threshold"`
+	// PromoteFrom / PromoteTo name the source and target layers for the
+	// scheduled promotion sweep. Empty values fall back to project→org.
+	PromoteFrom string `yaml:"promote_from,omitempty"`
+	PromoteTo   string `yaml:"promote_to,omitempty"`
+}
+
+// IsEnabled reports whether scheduled auto-promotion is active. Absent (nil)
+// means DISABLED — see the Enabled field comment for why this defaults false.
+func (k KnowledgeCurator) IsEnabled() bool {
+	return k.Enabled != nil && *k.Enabled
 }
 
 type KnowledgePrimer struct {
@@ -4677,7 +4699,13 @@ func (c *Config) applyDefaults() {
 		if len(c.Knowledge.Primer.Priority) == 0 {
 			c.Knowledge.Primer.Priority = []string{"regression", "gotcha", "test_scaffold", "pattern", "decision"}
 		}
-		if c.Knowledge.Curator.Schedule == "" {
+		// Schedule is only defaulted when the curator has been explicitly
+		// enabled. Defaulting it unconditionally (the pre-#5430 behaviour) was
+		// harmless while nothing read the field, but now that it drives a
+		// promotion loop a blanket default would hand every hive a cadence it
+		// never asked for. The Enabled gate is the real guard; leaving Schedule
+		// empty on disabled hives keeps the config honest about what will run.
+		if c.Knowledge.Curator.IsEnabled() && c.Knowledge.Curator.Schedule == "" {
 			c.Knowledge.Curator.Schedule = defaultCuratorSchedule
 		}
 		if c.Knowledge.Curator.AutoPromoteThreshold == 0 {

--- a/src/pkg/config/config_test.go
+++ b/src/pkg/config/config_test.go
@@ -936,9 +936,20 @@ func TestApplyDefaults_KnowledgeDefaults(t *testing.T) {
 	if len(cfg.Knowledge.Primer.Priority) == 0 {
 		t.Error("expected default priority")
 	}
-	if cfg.Knowledge.Curator.Schedule != defaultCuratorSchedule {
-		t.Errorf("schedule = %q", cfg.Knowledge.Curator.Schedule)
+	// Curator schedule is deliberately NOT defaulted here. Since #5430 wired
+	// the schedule to a real promotion loop, stamping "daily" onto a hive that
+	// never set knowledge.curator.enabled would advertise a cadence that (a)
+	// will not run, and (b) must not run — auto-promotion writes into a higher
+	// knowledge layer without review. The default applies only once opted in;
+	// see TestCuratorEnabledGetsScheduleDefault in curator_optin_test.go.
+	if cfg.Knowledge.Curator.IsEnabled() {
+		t.Error("curator must default to disabled")
 	}
+	if cfg.Knowledge.Curator.Schedule != "" {
+		t.Errorf("schedule = %q, want empty on a hive that did not opt in", cfg.Knowledge.Curator.Schedule)
+	}
+	// The threshold is still defaulted unconditionally: it is a ceiling on what
+	// may ever be promoted, so a value is useful even when nothing is running.
 	if cfg.Knowledge.Curator.AutoPromoteThreshold != defaultPromoteThreshold {
 		t.Errorf("threshold = %f", cfg.Knowledge.Curator.AutoPromoteThreshold)
 	}

--- a/src/pkg/config/curator_optin_test.go
+++ b/src/pkg/config/curator_optin_test.go
@@ -1,0 +1,79 @@
+package config
+
+import "testing"
+
+// TestCuratorDisabledByDefault pins the opt-in contract for #5430 at the config
+// layer: a knowledge block that says nothing about the curator must report
+// disabled, so the promotion scheduler never starts on an existing hive that is
+// merely upgraded.
+func TestCuratorDisabledByDefault(t *testing.T) {
+	cfg := &Config{}
+	cfg.Knowledge.Enabled = true
+	cfg.applyDefaults()
+
+	if cfg.Knowledge.Curator.IsEnabled() {
+		t.Fatal("curator must be disabled when knowledge.curator.enabled is absent")
+	}
+	// The pre-#5430 code stamped "daily" here unconditionally. Leaving it empty
+	// on a disabled hive keeps the effective config honest about what runs.
+	if cfg.Knowledge.Curator.Schedule != "" {
+		t.Errorf("schedule defaulted to %q on a hive that never opted in; want empty",
+			cfg.Knowledge.Curator.Schedule)
+	}
+}
+
+// TestCuratorExplicitFalseStaysDisabled covers the third state the pointer
+// makes representable — set, and set to off.
+func TestCuratorExplicitFalseStaysDisabled(t *testing.T) {
+	off := false
+	cfg := &Config{}
+	cfg.Knowledge.Enabled = true
+	cfg.Knowledge.Curator.Enabled = &off
+	cfg.Knowledge.Curator.Schedule = "hourly"
+	cfg.applyDefaults()
+
+	if cfg.Knowledge.Curator.IsEnabled() {
+		t.Error("enabled:false must stay disabled")
+	}
+	// An explicitly configured schedule is preserved verbatim; it simply is not
+	// acted on while disabled.
+	if cfg.Knowledge.Curator.Schedule != "hourly" {
+		t.Errorf("schedule = %q, want it preserved as \"hourly\"", cfg.Knowledge.Curator.Schedule)
+	}
+}
+
+// TestCuratorEnabledGetsScheduleDefault shows the default cadence is still
+// applied — but only once an operator has opted in.
+func TestCuratorEnabledGetsScheduleDefault(t *testing.T) {
+	on := true
+	cfg := &Config{}
+	cfg.Knowledge.Enabled = true
+	cfg.Knowledge.Curator.Enabled = &on
+	cfg.applyDefaults()
+
+	if !cfg.Knowledge.Curator.IsEnabled() {
+		t.Fatal("enabled:true must report enabled")
+	}
+	if cfg.Knowledge.Curator.Schedule != defaultCuratorSchedule {
+		t.Errorf("schedule = %q, want %q", cfg.Knowledge.Curator.Schedule, defaultCuratorSchedule)
+	}
+	if cfg.Knowledge.Curator.AutoPromoteThreshold != defaultPromoteThreshold {
+		t.Errorf("threshold = %v, want %v",
+			cfg.Knowledge.Curator.AutoPromoteThreshold, defaultPromoteThreshold)
+	}
+}
+
+// TestCuratorEnabledPreservesExplicitSchedule ensures the default never
+// overwrites an operator's choice.
+func TestCuratorEnabledPreservesExplicitSchedule(t *testing.T) {
+	on := true
+	cfg := &Config{}
+	cfg.Knowledge.Enabled = true
+	cfg.Knowledge.Curator.Enabled = &on
+	cfg.Knowledge.Curator.Schedule = "hourly"
+	cfg.applyDefaults()
+
+	if cfg.Knowledge.Curator.Schedule != "hourly" {
+		t.Errorf("schedule = %q, want \"hourly\"", cfg.Knowledge.Curator.Schedule)
+	}
+}

--- a/src/pkg/knowledge/api.go
+++ b/src/pkg/knowledge/api.go
@@ -361,6 +361,12 @@ func (k *KnowledgeAPI) DeleteFact(ctx context.Context, layer LayerType, slug str
 	return nil
 }
 
+// Promoter exposes the layer promoter so the scheduled promotion loop can be
+// built over the same clients the dashboard's manual promote path uses.
+func (k *KnowledgeAPI) Promoter() *Promoter {
+	return k.promoter
+}
+
 // PromoteFact promotes a fact from one layer to another (upward only).
 func (k *KnowledgeAPI) PromoteFact(ctx context.Context, req PromoteRequest) PromoteResult {
 	return k.promoter.Promote(ctx, req)

--- a/src/pkg/knowledge/curator_schedule.go
+++ b/src/pkg/knowledge/curator_schedule.go
@@ -1,0 +1,203 @@
+package knowledge
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Layer defaults for the scheduled promotion sweep. project→org is the
+// promotion documented in hive.yaml.example ("Confidence to auto-promote
+// project→org") and is the only pair the shipped example config implies.
+const (
+	defaultPromoteFromLayer = LayerProject
+	defaultPromoteToLayer   = LayerOrg
+)
+
+// PromotionScheduler drives Promoter.AutoPromoteCandidates on the cadence set
+// by knowledge.curator.schedule.
+//
+// It exists because that schedule field was parsed, defaulted and never read
+// (#5430). Wiring it naively would have been a behaviour change for every
+// existing deployment, since applyDefaults stamped "daily" onto any hive that
+// omitted the key — so the scheduler is gated on CuratorConfig.IsEnabled(),
+// which is false unless an operator writes `enabled: true`. A configured
+// schedule on a hive that never opted in still does nothing, by design.
+//
+// The scheduler adds no promotion semantics: it decides WHEN to sweep and
+// logs WHAT was swept. Which facts qualify remains entirely
+// AutoPromoteCandidates' business, including the AutoPromoteThreshold gate.
+type PromotionScheduler struct {
+	promoter *Promoter
+	config   CuratorConfig
+	logger   *slog.Logger
+
+	from LayerType
+	to   LayerType
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	running bool
+}
+
+// NewPromotionScheduler builds a scheduler over an existing promoter. It never
+// starts anything on its own — callers must invoke Start/StartBackground, and
+// those are no-ops unless the config opts in.
+func NewPromotionScheduler(promoter *Promoter, config CuratorConfig, logger *slog.Logger) *PromotionScheduler {
+	from := LayerType(config.PromoteFrom)
+	if from == "" {
+		from = defaultPromoteFromLayer
+	}
+	to := LayerType(config.PromoteTo)
+	if to == "" {
+		to = defaultPromoteToLayer
+	}
+	return &PromotionScheduler{
+		promoter: promoter,
+		config:   config,
+		logger:   logger,
+		from:     from,
+		to:       to,
+	}
+}
+
+// Interval returns the tick period for the configured schedule. It reuses
+// ParseSynthSchedule rather than introducing a second parser: the curator's
+// documented vocabulary is "daily" (defaultCuratorSchedule) and the
+// synthesizer's parser already maps daily/hourly onto named hour constants, so
+// the two agree with no new values needed.
+func (s *PromotionScheduler) Interval() time.Duration {
+	return ParseSynthSchedule(s.config.Schedule)
+}
+
+// Start runs the promotion loop until ctx is cancelled. If the curator is not
+// explicitly enabled it returns immediately, having done no work and started
+// no ticker — the disabled path costs nothing per tick because there is no
+// tick.
+func (s *PromotionScheduler) Start(ctx context.Context) {
+	if !s.config.IsEnabled() {
+		// Only worth a line when an operator set a cadence that will not run;
+		// silence would reproduce exactly the confusion #5430 describes.
+		if s.config.Schedule != "" && s.logger != nil {
+			s.logger.Info("scheduled knowledge promotion is disabled; configured schedule will not run",
+				"schedule", s.config.Schedule,
+				"hint", "set knowledge.curator.enabled: true to opt in",
+			)
+		}
+		return
+	}
+	if s.promoter == nil {
+		return
+	}
+
+	interval := s.Interval()
+	s.logger.Info("scheduled knowledge promotion started",
+		"schedule", s.config.Schedule,
+		"interval", interval,
+		"from", s.from,
+		"to", s.to,
+		"threshold", s.config.AutoPromoteThreshold,
+	)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	s.RunOnce(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.RunOnce(ctx)
+		}
+	}
+}
+
+// RunOnce performs a single promotion sweep. It is exported so the dashboard
+// and tests can trigger a sweep without waiting out an interval; it still
+// honours the enable gate, so it cannot be used to bypass opt-in.
+func (s *PromotionScheduler) RunOnce(ctx context.Context) {
+	if !s.config.IsEnabled() || s.promoter == nil {
+		return
+	}
+
+	candidates, err := s.promoter.AutoPromoteCandidates(ctx, s.from, s.to)
+	if err != nil {
+		s.logger.Warn("scheduled promotion: listing candidates failed",
+			"from", s.from, "to", s.to, "error", err)
+		return
+	}
+	if len(candidates) == 0 {
+		return
+	}
+
+	var promoted, failed int
+	for _, req := range candidates {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		result := s.promoter.Promote(ctx, req)
+		if result.Success {
+			promoted++
+			// Per-fact INFO: a background job that writes into a knowledge
+			// layer must name what it wrote and where it came from, or an
+			// operator has no way to audit or undo it.
+			s.logger.Info("scheduled promotion: fact promoted",
+				"slug", req.Slug, "from", req.FromLayer, "to", req.ToLayer, "reason", req.Reason)
+			continue
+		}
+		failed++
+		s.logger.Warn("scheduled promotion: fact promotion failed",
+			"slug", req.Slug, "from", req.FromLayer, "to", req.ToLayer, "error", result.Error)
+	}
+
+	s.logger.Info("scheduled promotion sweep complete",
+		"from", s.from, "to", s.to,
+		"candidates", len(candidates), "promoted", promoted, "failed", failed,
+		"threshold", s.config.AutoPromoteThreshold,
+	)
+}
+
+// StartBackground launches the loop in a goroutine, tracking it so it can be
+// stopped and restarted. It is a no-op when the curator is not enabled.
+func (s *PromotionScheduler) StartBackground(parent context.Context) {
+	if !s.config.IsEnabled() {
+		s.Start(parent) // emits the disabled-with-schedule notice, returns
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.running {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	s.cancel = cancel
+	s.running = true
+	go func() {
+		s.Start(ctx)
+		s.mu.Lock()
+		s.running = false
+		s.mu.Unlock()
+	}()
+}
+
+// Stop cancels the background loop.
+func (s *PromotionScheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+}
+
+// IsRunning reports whether the background loop is active.
+func (s *PromotionScheduler) IsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
+}

--- a/src/pkg/knowledge/curator_schedule_test.go
+++ b/src/pkg/knowledge/curator_schedule_test.go
@@ -1,0 +1,312 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// promoteProbe stands in for a pair of wiki layers and records what was
+// actually written to the TARGET layer. Tests assert on ingests observed here
+// rather than on scheduler flags, so a scheduler that "runs" but promotes
+// nothing cannot pass, and neither can one that is wired but never ticks.
+type promoteProbe struct {
+	mu       sync.Mutex
+	ingests  [][]ExtractedFact
+	listHits int
+
+	source *httptest.Server
+	target *httptest.Server
+}
+
+func (p *promoteProbe) close() {
+	p.source.Close()
+	p.target.Close()
+}
+
+func (p *promoteProbe) ingestCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.ingests)
+}
+
+func (p *promoteProbe) listCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.listHits
+}
+
+// newPromoteProbe serves one page at the given confidence/status from the
+// source layer and accepts ingests at the target layer.
+func newPromoteProbe(slug string, confidence float64, status string) *promoteProbe {
+	p := &promoteProbe{}
+
+	p.source = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// ListPages GETs /api/pages exactly; ReadPage GETs /api/pages/<slug>.
+		// Match the list path exactly so the read is not swallowed by a prefix.
+		if r.URL.Path == "/api/pages" {
+			p.mu.Lock()
+			p.listHits++
+			p.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(searchResponse{
+				Results: []searchResult{{
+					Slug:       slug,
+					Title:      "scheduled promotion probe",
+					Type:       "gotcha",
+					Status:     status,
+					Confidence: confidence,
+				}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(pageResponse{
+			Slug:       slug,
+			Title:      "scheduled promotion probe",
+			Body:       "probe body",
+			Type:       "gotcha",
+			Status:     status,
+			Confidence: confidence,
+		})
+	}))
+
+	p.target = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var facts []ExtractedFact
+		_ = json.Unmarshal(body, &facts)
+		p.mu.Lock()
+		p.ingests = append(p.ingests, facts)
+		p.mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	return p
+}
+
+func (p *promoteProbe) promoter(cfg CuratorConfig) *Promoter {
+	return NewPromoter([]LayerConfig{
+		{Type: LayerProject, URL: p.source.URL},
+		{Type: LayerOrg, URL: p.target.URL},
+	}, cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func schedTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestScheduledPromotionDisabledByDefaultDoesNotRun is THE guard test for
+// #5430. An unconfigured hive — one that never set knowledge.curator.enabled —
+// must perform no promotion at all, even though applyDefaults historically
+// stamped schedule: daily onto it.
+//
+// This test fails if the opt-in guard is removed: deleting the
+// `if !s.config.IsEnabled()` early return from Start/RunOnce makes RunOnce
+// list candidates and ingest the 0.95-confidence page, so both ingestCount and
+// listCount become non-zero and both assertions below fail.
+func TestScheduledPromotionDisabledByDefaultDoesNotRun(t *testing.T) {
+	probe := newPromoteProbe("guard-fact", 0.95, "verified")
+	defer probe.close()
+
+	// Exactly what a hive that never opted in looks like: a schedule present
+	// (the historical default) but no Enabled key.
+	cfg := CuratorConfig{Schedule: "daily", AutoPromoteThreshold: 0.9}
+	if cfg.IsEnabled() {
+		t.Fatal("CuratorConfig with no Enabled key must report disabled")
+	}
+
+	s := NewPromotionScheduler(probe.promoter(cfg), cfg, schedTestLogger())
+
+	// Start must return immediately rather than blocking on a ticker.
+	done := make(chan struct{})
+	go func() {
+		s.Start(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start blocked on a disabled curator: the opt-in guard is not short-circuiting")
+	}
+
+	// And a direct sweep must also refuse.
+	s.RunOnce(context.Background())
+
+	if got := probe.ingestCount(); got != 0 {
+		t.Errorf("disabled curator promoted %d fact batches; want 0 — unconfigured hives must never auto-promote", got)
+	}
+	if got := probe.listCount(); got != 0 {
+		t.Errorf("disabled curator made %d candidate-list calls; want 0 — the disabled path must cost nothing", got)
+	}
+	if s.IsRunning() {
+		t.Error("disabled curator reports a running loop")
+	}
+}
+
+// TestScheduledPromotionExplicitFalseDoesNotRun covers the third state the
+// pointer makes expressible: explicitly opted out.
+func TestScheduledPromotionExplicitFalseDoesNotRun(t *testing.T) {
+	probe := newPromoteProbe("guard-fact", 0.99, "verified")
+	defer probe.close()
+
+	cfg := CuratorConfig{Enabled: boolPtr(false), Schedule: "hourly", AutoPromoteThreshold: 0.5}
+	s := NewPromotionScheduler(probe.promoter(cfg), cfg, schedTestLogger())
+	s.RunOnce(context.Background())
+
+	if got := probe.ingestCount(); got != 0 {
+		t.Errorf("enabled:false promoted %d batches; want 0", got)
+	}
+}
+
+// TestScheduledPromotionEnabledPromotes proves the wiring actually works —
+// that a hive which opts in gets facts promoted into the target layer.
+func TestScheduledPromotionEnabledPromotes(t *testing.T) {
+	probe := newPromoteProbe("wired-fact", 0.95, "verified")
+	defer probe.close()
+
+	cfg := CuratorConfig{Enabled: boolPtr(true), Schedule: "daily", AutoPromoteThreshold: 0.9}
+	s := NewPromotionScheduler(probe.promoter(cfg), cfg, schedTestLogger())
+	s.RunOnce(context.Background())
+
+	if got := probe.ingestCount(); got != 1 {
+		t.Fatalf("enabled curator ingested %d batches; want 1", got)
+	}
+	probe.mu.Lock()
+	facts := probe.ingests[0]
+	probe.mu.Unlock()
+	if len(facts) != 1 {
+		t.Fatalf("ingested %d facts; want 1", len(facts))
+	}
+	if facts[0].Title != "scheduled promotion probe" {
+		t.Errorf("promoted the wrong fact: title = %q", facts[0].Title)
+	}
+}
+
+// TestScheduledPromotionRespectsThreshold proves the scheduler did not bypass
+// the existing AutoPromoteThreshold gate: same opted-in config, a fact below
+// the bar, and nothing may be written.
+func TestScheduledPromotionRespectsThreshold(t *testing.T) {
+	probe := newPromoteProbe("low-confidence-fact", 0.42, "verified")
+	defer probe.close()
+
+	cfg := CuratorConfig{Enabled: boolPtr(true), Schedule: "daily", AutoPromoteThreshold: 0.9}
+	s := NewPromotionScheduler(probe.promoter(cfg), cfg, schedTestLogger())
+	s.RunOnce(context.Background())
+
+	if got := probe.listCount(); got == 0 {
+		t.Fatal("enabled curator never listed candidates; the test is not exercising the gate")
+	}
+	if got := probe.ingestCount(); got != 0 {
+		t.Errorf("promoted %d batches for a 0.42-confidence fact under a 0.90 threshold; want 0", got)
+	}
+}
+
+// TestScheduledPromotionUnverifiedNotPromoted pins the other half of the
+// existing gate: confidence alone is not sufficient, status must be verified.
+func TestScheduledPromotionUnverifiedNotPromoted(t *testing.T) {
+	probe := newPromoteProbe("draft-fact", 0.99, "draft")
+	defer probe.close()
+
+	cfg := CuratorConfig{Enabled: boolPtr(true), Schedule: "daily", AutoPromoteThreshold: 0.9}
+	s := NewPromotionScheduler(probe.promoter(cfg), cfg, schedTestLogger())
+	s.RunOnce(context.Background())
+
+	if got := probe.ingestCount(); got != 0 {
+		t.Errorf("promoted %d batches for an unverified fact; want 0", got)
+	}
+}
+
+// TestScheduledPromotionIntervalMatchesSchedule asserts the configured cadence
+// maps to the expected period — a "daily" hive must not tick hourly.
+func TestScheduledPromotionIntervalMatchesSchedule(t *testing.T) {
+	tests := []struct {
+		schedule string
+		want     time.Duration
+	}{
+		{"daily", time.Duration(beadSynthDailyScheduleHours) * time.Hour},
+		{"hourly", time.Duration(beadSynthDefaultScheduleHours) * time.Hour},
+		{"", time.Duration(beadSynthDefaultScheduleHours) * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.schedule, func(t *testing.T) {
+			cfg := CuratorConfig{Enabled: boolPtr(true), Schedule: tt.schedule}
+			s := NewPromotionScheduler(nil, cfg, schedTestLogger())
+			if got := s.Interval(); got != tt.want {
+				t.Errorf("Interval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestScheduledPromotionTicksOnInterval proves a configured schedule produces
+// repeated runs rather than a single startup sweep. It drives RunOnce through
+// a short ticker instead of waiting an hour, then checks the sweep count grew.
+func TestScheduledPromotionTicksOnInterval(t *testing.T) {
+	probe := newPromoteProbe("tick-fact", 0.95, "verified")
+	defer probe.close()
+
+	cfg := CuratorConfig{Enabled: boolPtr(true), Schedule: "daily", AutoPromoteThreshold: 0.9}
+	s := NewPromotionScheduler(probe.promoter(cfg), cfg, schedTestLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const sweeps = 3
+	for i := 0; i < sweeps; i++ {
+		s.RunOnce(ctx)
+	}
+	if got := probe.ingestCount(); got != sweeps {
+		t.Errorf("after %d sweeps saw %d ingests; want %d — repeated ticks must each promote", sweeps, got, sweeps)
+	}
+}
+
+// TestScheduledPromotionDefaultLayers pins the project→org default that
+// hive.yaml.example documents.
+func TestScheduledPromotionDefaultLayers(t *testing.T) {
+	s := NewPromotionScheduler(nil, CuratorConfig{Enabled: boolPtr(true)}, schedTestLogger())
+	if s.from != LayerProject || s.to != LayerOrg {
+		t.Errorf("default layers = %s→%s, want %s→%s", s.from, s.to, LayerProject, LayerOrg)
+	}
+
+	custom := NewPromotionScheduler(nil, CuratorConfig{
+		Enabled: boolPtr(true), PromoteFrom: string(LayerPersonal), PromoteTo: string(LayerProject),
+	}, schedTestLogger())
+	if custom.from != LayerPersonal || custom.to != LayerProject {
+		t.Errorf("configured layers = %s→%s, want %s→%s", custom.from, custom.to, LayerPersonal, LayerProject)
+	}
+}
+
+// TestScheduledPromotionStopHalts covers lifecycle: an opted-in background
+// loop must be stoppable.
+func TestScheduledPromotionStopHalts(t *testing.T) {
+	probe := newPromoteProbe("lifecycle-fact", 0.95, "verified")
+	defer probe.close()
+
+	cfg := CuratorConfig{Enabled: boolPtr(true), Schedule: "daily", AutoPromoteThreshold: 0.9}
+	s := NewPromotionScheduler(probe.promoter(cfg), cfg, schedTestLogger())
+
+	s.StartBackground(context.Background())
+	deadline := time.Now().Add(2 * time.Second)
+	for !s.IsRunning() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !s.IsRunning() {
+		t.Fatal("StartBackground did not start an opted-in loop")
+	}
+
+	s.Stop()
+	deadline = time.Now().Add(2 * time.Second)
+	for s.IsRunning() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if s.IsRunning() {
+		t.Error("Stop did not halt the loop")
+	}
+}

--- a/src/pkg/knowledge/types.go
+++ b/src/pkg/knowledge/types.go
@@ -112,9 +112,23 @@ func (b BeadSynthesizerConfig) IsEnabled() bool {
 
 // CuratorConfig controls automated knowledge extraction from merged PRs.
 type CuratorConfig struct {
-	Schedule              string   `yaml:"schedule"                json:"schedule"`
-	ExtractFrom           []string `yaml:"extract_from"            json:"extract_from"`
-	AutoPromoteThreshold  float64  `yaml:"auto_promote_threshold"  json:"auto_promote_threshold"`
+	// Enabled gates the scheduled auto-promotion loop and defaults to FALSE
+	// when absent — see config.KnowledgeCurator.Enabled for the reasoning.
+	// Scheduled promotion writes into a higher layer without human review, so
+	// it must be opted into explicitly; a bare `schedule` does not start it.
+	Enabled              *bool    `yaml:"enabled,omitempty"       json:"enabled"`
+	Schedule             string   `yaml:"schedule"                json:"schedule"`
+	ExtractFrom          []string `yaml:"extract_from"            json:"extract_from"`
+	AutoPromoteThreshold float64  `yaml:"auto_promote_threshold"  json:"auto_promote_threshold"`
+	PromoteFrom          string   `yaml:"promote_from,omitempty"  json:"promote_from,omitempty"`
+	PromoteTo            string   `yaml:"promote_to,omitempty"    json:"promote_to,omitempty"`
+}
+
+// IsEnabled reports whether scheduled auto-promotion is active. Absent (nil)
+// means DISABLED. This is the single guard the promotion scheduler consults;
+// removing it turns scheduled, unreviewed layer mutation on fleet-wide.
+func (c CuratorConfig) IsEnabled() bool {
+	return c.Enabled != nil && *c.Enabled
 }
 
 // PrimerConfig controls how facts are selected and injected into agent kicks.
@@ -304,19 +318,19 @@ type Question struct {
 
 // InceptionState tracks the progress of a Level 1 ideation workflow.
 type InceptionState struct {
-	Phase          InceptionPhase    `json:"phase"`
-	Mode           InceptionMode     `json:"mode"`
-	IdeaText       string            `json:"idea_text"`
-	IdeaSlug       string            `json:"idea_slug"`
-	RepoURL        string            `json:"repo_url,omitempty"`
-	Questions      []Question        `json:"questions"`
-	Answers        map[string]string `json:"answers"`
-	FactSlugs      []string          `json:"fact_slugs"`
-	StartedAt      time.Time         `json:"started_at"`
-	PhaseChangedAt *time.Time        `json:"phase_changed_at,omitempty"`
-	WikiName       string            `json:"wiki_name,omitempty"`
-	AutoFactCount     int            `json:"auto_fact_count,omitempty"`
-	AutoQuestionCount int            `json:"auto_question_count,omitempty"`
+	Phase             InceptionPhase    `json:"phase"`
+	Mode              InceptionMode     `json:"mode"`
+	IdeaText          string            `json:"idea_text"`
+	IdeaSlug          string            `json:"idea_slug"`
+	RepoURL           string            `json:"repo_url,omitempty"`
+	Questions         []Question        `json:"questions"`
+	Answers           map[string]string `json:"answers"`
+	FactSlugs         []string          `json:"fact_slugs"`
+	StartedAt         time.Time         `json:"started_at"`
+	PhaseChangedAt    *time.Time        `json:"phase_changed_at,omitempty"`
+	WikiName          string            `json:"wiki_name,omitempty"`
+	AutoFactCount     int               `json:"auto_fact_count,omitempty"`
+	AutoQuestionCount int               `json:"auto_question_count,omitempty"`
 }
 
 // ScaffoldFile is a single generated file in the scaffold output.


### PR DESCRIPTION
Fixes #5430

## The bug

`knowledge.curator.schedule` is parsed, defaulted to `"daily"`, and never read. Its only mention in the tree assigns the default:

```go
// src/pkg/config/config.go:4680-4681
if c.Knowledge.Curator.Schedule == "" {
    c.Knowledge.Curator.Schedule = defaultCuratorSchedule
}
```

An operator who sets it reasonably concludes curation is running. Nothing tells them otherwise. Confirmed exactly as described in the issue — the `.Schedule` reads that do exist (`bead_synthesizer.go:90`, `main.go:2434`) belong to `BeadSynthesizer`, not `Curator`.

Maintainer picked Option 1 (wire it). This does that.

## Why a naive wiring would have been unsafe

`defaultCuratorSchedule = "daily"` was applied to **every** hive whose config omits the field. Wiring the schedule as-is would have started scheduled auto-promotion **fleet-wide, on hives that never opted in** — and auto-promotion copies facts into a higher-precedence knowledge layer **with no human review**. Enabling that on upgrade is not acceptable, so the whole feature is gated.

## How it is opt-in

**`CuratorConfig` had no enable flag** — checked before adding one; only `Schedule`, `ExtractFrom`, `AutoPromoteThreshold` existed.

**The config layer *can* distinguish defaulted from explicit, via a pointer.** `BeadSynthesizerConfig` already uses `Enabled *bool` for exactly this, so the mechanism is established rather than invented here. I added the same shape to `KnowledgeCurator` and `CuratorConfig` — with the **opposite default**:

| | absent | `false` | `true` |
|---|---|---|---|
| `BeadSynthesizer.Enabled` | **on** | off | on |
| `Curator.Enabled` (new) | **off** | off | on |

The asymmetry is deliberate and commented at both definitions: synthesis writes into a dedicated vault, promotion writes into a shared higher layer without review. Absent must mean off for the second.

I chose an explicit `enabled` over inferring intent from "was the schedule explicitly set". Inference would have worked mechanically — the pointer trick generalises — but it makes a destructive capability turn on as a side effect of setting a cadence, and the shipped `hive.yaml.example` has carried `schedule: daily` for a long time, so plenty of hives have an "explicit" schedule they never thought of as consent.

**Defaulting also stops for the disabled case.** `applyDefaults` no longer stamps `"daily"` onto a hive that did not opt in, so the effective config stops advertising a cadence that will not run — this is the honest-fix element the issue asked about, applied to the default rather than to the field. `AutoPromoteThreshold` is still defaulted unconditionally: it is a ceiling on what may ever be promoted, so a value is useful even while idle.

## What was added

`PromotionScheduler` (`src/pkg/knowledge/curator_schedule.go`) drives `Promoter.AutoPromoteCandidates` on the configured cadence, following the `BeadSynthesizer` lifecycle pattern (`Start` / `StartBackground` / `Stop` / `IsRunning`).

- **Reused `ParseSynthSchedule`** rather than writing a second parser. The curator's documented vocabulary is `daily` — the exact value of `defaultCuratorSchedule` — and that parser already switches `daily`/`hourly` over named hour constants. No new values were needed, so extending it was not warranted.
- **Cheap when disabled**: the guard returns before any ticker is created, so there is no tick to cost anything, and no HTTP call is made.
- **Logs what it does**: every promoted fact logs at INFO with slug and both layers, plus a per-sweep summary (candidates/promoted/failed/threshold). Silent background mutation is the failure mode this avoids.
- **A schedule set without the opt-in logs a notice** naming the key to set — the original bug's silence, fixed even for operators who do not want the feature.

## Adjacent gap found while wiring

`cfg.Knowledge.Curator` was **never copied into `knowledge.KnowledgeConfig` at any production call site** (`Curator:` appears in zero non-test files). `NewPromoter` therefore always received a zero `CuratorConfig`, so `AutoPromoteThreshold` never reached the promoter outside tests, and `AutoPromoteCandidates` had no production caller at all. The issue notes `CuratorConfig` "is NOT dead" because `api.go:74` passes it along — true, but what it passes was always the zero value. It is now populated, which is what makes the threshold gate real rather than nominal.

## Promotion semantics unchanged

`Promote` and `AutoPromoteCandidates` are not modified. The scheduler decides *when* to sweep and logs *what* it wrote; which facts qualify stays entirely with `AutoPromoteCandidates`, threshold and `status == "verified"` gates included. No hub lease or cooldown accounting is touched (#5151 stays held).

## Testing

Tests assert observable behaviour against fake wiki layers, counting **real ingests and real list calls**, not scheduler flags — a scheduler that "runs" but promotes nothing cannot pass, and neither can one that is wired but never sweeps.

- `TestScheduledPromotionDisabledByDefaultDoesNotRun` — the one that matters. An unconfigured hive makes **zero** candidate-list calls and **zero** ingests, and `Start` returns instead of blocking on a ticker.
- `TestScheduledPromotionExplicitFalseDoesNotRun` — `enabled: false` likewise.
- `TestScheduledPromotionEnabledPromotes` — opting in actually promotes, and promotes the right fact.
- `TestScheduledPromotionRespectsThreshold` — a 0.42-confidence fact under a 0.90 threshold is listed but never ingested.
- `TestScheduledPromotionUnverifiedNotPromoted` — 0.99 confidence but `status: draft` is not promoted.
- Interval mapping, default `project→org` layers, repeated sweeps, and `Stop` lifecycle.
- Config layer: absent / `false` / `true` / explicit-schedule-preserved.

**Mutation-verified, per the #5388 concern about guards that cannot fail.** Deleting the `if !s.config.IsEnabled()` early returns from `Start` and `RunOnce` and re-running produces:

```
--- FAIL: TestScheduledPromotionDisabledByDefaultDoesNotRun (2.00s)
    Start blocked on a disabled curator: the opt-in guard is not short-circuiting
--- FAIL: TestScheduledPromotionExplicitFalseDoesNotRun (0.00s)
    enabled:false promoted 1 batches; want 0
```

The second line is the real point: without the guard, a hive that opted out performs an actual unreviewed ingest. The guard was restored and the suite re-run green.

`pkg/knowledge` passes clean, including under `-race`. `pkg/config` has one failure, `TestEntrypointHardensRuntimeConfigItRecreates`, which **reproduces identically on a clean `v4` checkout** — a chown/permissions test that is environment-dependent on macOS, unrelated to this change.

## Not verified

- No live hive was exercised; behaviour is verified by unit tests against fake wiki layers, not against a real llm-wiki endpoint.
- `TestApplyDefaults_KnowledgeDefaults` was updated, since it asserted the old unconditional `"daily"` default. That is an intentional behaviour change, commented in place.
- The dashboard has no curator enable/disable control — the flag is config-only for now. Adding a toggle (as `BeadSynthesizer` has) would be a reasonable follow-up.
- `ExtractFrom` remains unread by this change; only the scheduling half of the block is wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)