### PR TITLE
🐛 test: make the sandbox owner-gate and /api/trends guards able to fail (#5388 P1)

### DIFF
--- a/src/pkg/dashboard/api_routes_coverage_test.go
+++ b/src/pkg/dashboard/api_routes_coverage_test.go
@@ -1,9 +1,13 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sort"
 	"testing"
+	"time"
 )
 
 // covG2ServeRaw sends a request with a raw (possibly malformed) JSON body and a
@@ -32,6 +36,100 @@ func TestCovG2_HistoryTrendsTimeline(t *testing.T) {
 	}
 	if rec := doGet(s, "/api/timeline"); rec.Code != http.StatusOK {
 		t.Errorf("timeline status = %d", rec.Code)
+	}
+}
+
+// TestCovG2_TrendsHonoursRangeAndHours is the #5388 fix for the loop above.
+//
+// The loop passes five query variants to /api/trends and asserts only that each
+// returns 200. It never decodes a body, so it asserts the shape of the response
+// (a status code) rather than the property the parameters are supposed to have
+// (selecting a time window). Demonstrated: replacing the whole range/hours
+// switch in handleTrends with a hardcoded `hours := hoursPerDay` — a handler
+// that ignores its parameters completely — left the loop green, and in fact left
+// EVERY test in package dashboard green.
+//
+// This test seeds token-sparkline entries at known ages and asserts each
+// parameter selects a provably different subset. Ages are chosen so every
+// documented branch of the switch separates from its neighbours:
+//
+//	range=day / no param → 24h  → picks up 1h, 12h
+//	hours=48             → 48h  → additionally 30h
+//	range=week           → 168h → additionally 100h
+//	hours=99999          → clamped to maxTrendHours (720h/30d), so 800h stays
+//	                       excluded — that clamp is the reason 99999 is in the
+//	                       original list, and it was never actually checked.
+func TestCovG2_TrendsHonoursRangeAndHours(t *testing.T) {
+	s, _ := apiServer(t)
+
+	now := time.Now()
+	// ageHours → the entry's token count, used as an identifying marker.
+	ages := []int{1, 12, 30, 100, 800}
+	entries := make([]TokenSparklineEntry, 0, len(ages))
+	for _, age := range ages {
+		entries = append(entries, TokenSparklineEntry{
+			Timestamp: now.Add(-time.Duration(age)*time.Hour - time.Minute).UnixMilli(),
+			Input:     int64(age),
+		})
+	}
+	s.SeedTokenSparklineHistory(entries)
+
+	// Guard against the seam itself silently doing nothing: if seeding stops
+	// working, every expectation below collapses to "0 == 0" and this test
+	// would pass while checking nothing (#5388 anti-vacuity, per #5409).
+	if got := len(s.TokenSparklineHistory()); got != len(ages) {
+		t.Fatalf("seed did not take: history has %d entries, want %d — "+
+			"the assertions below would be vacuous", got, len(ages))
+	}
+
+	// wantAges is the set of seeded entries each query must return, keyed by the
+	// marker written into Input above.
+	for _, tc := range []struct {
+		query    string
+		wantAges []int
+	}{
+		{"", []int{1, 12}},
+		{"?range=day", []int{1, 12}},
+		{"?hours=48", []int{1, 12, 30}},
+		{"?range=week", []int{1, 12, 30, 100}},
+		{"?hours=99999", []int{1, 12, 30, 100}}, // clamped to 720h, so 800 excluded
+	} {
+		rec := doGet(s, "/api/trends"+tc.query)
+		if rec.Code != http.StatusOK {
+			t.Errorf("trends%s status = %d", tc.query, rec.Code)
+			continue
+		}
+
+		var body struct {
+			TokenHistory []TokenSparklineEntry `json:"tokenHistory"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Errorf("trends%s: decode: %v", tc.query, err)
+			continue
+		}
+
+		got := make([]int, 0, len(body.TokenHistory))
+		for _, e := range body.TokenHistory {
+			got = append(got, int(e.Input))
+		}
+		sort.Ints(got)
+
+		want := append([]int(nil), tc.wantAges...)
+		sort.Ints(want)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("trends%s returned entries aged %v, want %v — "+
+				"the time-window parameter is not being honoured", tc.query, got, want)
+		}
+	}
+
+	// The five variants must not all mean the same thing, or the table above
+	// could be satisfied by a handler with a single fixed window.
+	dayRec := doGet(s, "/api/trends?range=day")
+	weekRec := doGet(s, "/api/trends?range=week")
+	if dayRec.Body.String() == weekRec.Body.String() {
+		t.Error("range=day and range=week returned identical bodies — " +
+			"handleTrends is ignoring the range parameter")
 	}
 }
 
@@ -306,13 +404,29 @@ func TestCovG2_BudgetIgnore(t *testing.T) {
 	if rec := doGet(s, "/api/budget-ignore"); rec.Code != http.StatusOK {
 		t.Errorf("budget-ignore get = %d", rec.Code)
 	}
-	// Bool form.
+	// Bool form. #5388: assert the write actually took, not just that the
+	// handler returned 200 — a no-op handler satisfies the status alone.
 	if rec := doPost(s, "/api/budget-ignore", map[string]any{"ignored": true}); rec.Code != http.StatusOK {
 		t.Errorf("budget-ignore bool = %d", rec.Code)
+	} else if got := decodeJSON(t, rec)["ignored"]; got != true {
+		t.Errorf("budget-ignore bool: response ignored = %v, want true — the global bypass was not applied", got)
+	}
+	if got := decodeJSON(t, doGet(s, "/api/budget-ignore"))["ignored"]; got != true {
+		t.Errorf("budget-ignore: re-read ignored = %v, want true — the bool form did not persist", got)
+	}
+	// Setting it back to false must also take, or the field is simply stuck on.
+	if rec := doPost(s, "/api/budget-ignore", map[string]any{"ignored": false}); rec.Code != http.StatusOK {
+		t.Errorf("budget-ignore bool false = %d", rec.Code)
+	}
+	if got := decodeJSON(t, doGet(s, "/api/budget-ignore"))["ignored"]; got != false {
+		t.Errorf("budget-ignore: re-read ignored = %v, want false — the toggle is stuck on", got)
 	}
 	// List form.
 	if rec := doPost(s, "/api/budget-ignore", map[string]any{"ignored": []string{"scanner"}}); rec.Code != http.StatusOK {
 		t.Errorf("budget-ignore list = %d", rec.Code)
+	}
+	if got := decodeJSON(t, doGet(s, "/api/budget-ignore"))["agents"]; !reflect.DeepEqual(got, []any{"scanner"}) {
+		t.Errorf("budget-ignore: re-read agents = %v, want [scanner] — the per-agent exemption list did not persist", got)
 	}
 	// Bad body → 400.
 	if rec := covG2ServeRaw(s, http.MethodPost, "/api/budget-ignore", `{bad`); rec.Code != http.StatusBadRequest {
@@ -416,18 +530,26 @@ func TestCovG2_KnowledgeCluster(t *testing.T) {
 }
 
 func TestCovG2_KnowledgeToggle(t *testing.T) {
-	s, _ := apiServer(t)
+	s, deps := apiServer(t)
 
 	// Bad body → 400.
 	if rec := covG2ServeRaw(s, http.MethodPut, "/api/knowledge/enabled", `{bad`); rec.Code != http.StatusBadRequest {
 		t.Errorf("knowledge toggle bad body = %d, want 400", rec.Code)
 	}
-	// Enable then disable.
+	// Enable then disable. #5388: a handler that parsed the body and did
+	// nothing with it passed the status-only form of this test in both
+	// directions; assert the config field the toggle exists to write.
 	if rec := doPut(s, "/api/knowledge/enabled", map[string]bool{"enabled": true}); rec.Code != http.StatusOK {
 		t.Errorf("knowledge toggle enable = %d", rec.Code)
 	}
+	if !deps.Config.Knowledge.Enabled {
+		t.Error("knowledge toggle enable returned 200 but Config.Knowledge.Enabled is false — the toggle did not take")
+	}
 	if rec := doPut(s, "/api/knowledge/enabled", map[string]bool{"enabled": false}); rec.Code != http.StatusOK {
 		t.Errorf("knowledge toggle disable = %d", rec.Code)
+	}
+	if deps.Config.Knowledge.Enabled {
+		t.Error("knowledge toggle disable returned 200 but Config.Knowledge.Enabled is still true — the toggle is stuck on")
 	}
 }
 
@@ -511,18 +633,27 @@ func TestCovG2_Documents(t *testing.T) {
 // ---------- Bead synthesizer ----------
 
 func TestCovG2_BeadSynth(t *testing.T) {
-	s, _ := apiServer(t)
+	s, deps := apiServer(t)
 	if rec := doGet(s, "/api/knowledge/bead-synthesizer"); rec.Code != http.StatusOK {
 		t.Errorf("bead-synth status = %d", rec.Code)
 	}
 	if rec := covG2ServeRaw(s, http.MethodPut, "/api/knowledge/bead-synthesizer/enabled", `{bad`); rec.Code != http.StatusBadRequest {
 		t.Errorf("bead-synth bad body = %d, want 400", rec.Code)
 	}
+	// #5388: assert the toggle writes the config field it exists to write.
+	// IsEnabled() is the accessor the rest of the codebase reads, so assert
+	// through it rather than the raw pointer.
 	if rec := doPut(s, "/api/knowledge/bead-synthesizer/enabled", map[string]bool{"enabled": true}); rec.Code != http.StatusOK {
 		t.Errorf("bead-synth enable = %d", rec.Code)
 	}
+	if !deps.Config.Knowledge.BeadSynthesizer.IsEnabled() {
+		t.Error("bead-synth enable returned 200 but BeadSynthesizer.IsEnabled() is false — the toggle did not take")
+	}
 	if rec := doPut(s, "/api/knowledge/bead-synthesizer/enabled", map[string]bool{"enabled": false}); rec.Code != http.StatusOK {
 		t.Errorf("bead-synth disable = %d", rec.Code)
+	}
+	if deps.Config.Knowledge.BeadSynthesizer.IsEnabled() {
+		t.Error("bead-synth disable returned 200 but BeadSynthesizer.IsEnabled() is still true — the toggle is stuck on")
 	}
 }
 

--- a/src/pkg/dashboard/f16_owner_gate_test.go
+++ b/src/pkg/dashboard/f16_owner_gate_test.go
@@ -90,11 +90,45 @@ func TestF16PrivilegedHandlersAreOwnerGated(t *testing.T) {
 // explicitly, so the reason this fix exists survives even if someone prunes the
 // table above. handleGovernorSecurity is the only handler that writes
 // cfg.AgentSandbox.Enabled from request input.
+//
+// #5388 item 2: this test previously anchored on the Go identifier
+// "AgentSandboxEnabled" and SKIPPED when it was absent. That made the skip
+// condition identical to the coupling being guarded, so the guard retired
+// itself on the one edit most likely to disturb it. Demonstrated: renaming the
+// struct field to SandboxOn — leaving the JSON tag, the config write and the
+// whole wire contract untouched, so the toggle is still fully reachable —
+// turned this from an owner-gate security assertion into a silent SKIP, and
+// nothing else in the file re-asserts that THIS surface writes the sandbox
+// toggle. The sibling table test still catches an outright gate removal, but it
+// does not know the sandbox toggle exists, so after a rename the highest-impact
+// item is guarded only generically and this test never speaks again.
+//
+// The fix anchors on the two things that are the actual contract rather than a
+// private naming choice: the JSON wire field the browser sends, and the config
+// field the handler writes. Both must change for the toggle to genuinely move,
+// and if they do, this test FAILS and names itself rather than skipping.
 func TestF16AgentSandboxToggleIsOwnerOnly(t *testing.T) {
 	body := f16HandlerBody(t, f16ReadSource(t, "api_governor_security.go"), "handleGovernorSecurity")
-	if !strings.Contains(body, "AgentSandboxEnabled") {
-		t.Skip("handleGovernorSecurity no longer accepts agentSandboxEnabled; the sandbox toggle moved — re-point this test")
+
+	// The wire field and the config write, not the Go identifier that carries
+	// them between the two. A rename of the local struct field changes neither.
+	const wireField = `json:"agentSandboxEnabled"`
+	const configWrite = "cfg.AgentSandbox.Enabled ="
+
+	hasWire := strings.Contains(body, wireField)
+	hasWrite := strings.Contains(body, configWrite)
+
+	// If the toggle really did move, that is a deliberate change to a security
+	// surface and must be re-pointed by a human — so fail loudly. It is never
+	// correct for this assertion to go quiet on its own.
+	if !hasWire || !hasWrite {
+		t.Fatalf("handleGovernorSecurity no longer both accepts %s (found=%v) and writes %s (found=%v) — "+
+			"the agent-sandbox toggle moved. Re-point this test at whichever handler now writes "+
+			"cfg.AgentSandbox.Enabled and confirm THAT handler is owner-gated. Do not delete this case: "+
+			"it is the only assertion that names the sandbox toggle specifically (audit F16, #5388)",
+			wireField, hasWire, configWrite, hasWrite)
 	}
+
 	if !strings.Contains(body, "requireOwnerRole(w, r)") {
 		t.Error("handleGovernorSecurity accepts agentSandboxEnabled but is not owner-gated — " +
 			"a read-write member can disable the agent sandbox (audit F16)")


### PR DESCRIPTION
## What this does

Takes the **P1 items** from #5398's prioritised backlog. Both are now fixed, each demonstrated failing against the specific bug it exists to catch and then restored to green, per the #5383 / #5384 / #5409 standard.

**No production code is changed** — the diff is two test files. Every bug below was injected temporarily to prove a guard can fail, then reverted; `git diff` against `src/pkg/dashboard/api.go` and `api_governor_security.go` is empty. **No existing assertion is weakened**: every status assertion in the original loops is still there, and each change strictly ADDS a failure mode.

---

## P1 item 2 — the self-disarming owner-gate skip (prioritised, as instructed)

`f16_owner_gate_test.go:94` skipped when `handleGovernorSecurity` no longer contained the identifier `AgentSandboxEnabled`. The skip condition *was* the coupling being guarded, so the guard retired itself on the one edit most likely to disturb it — and it guards a security surface: whether a read-write member can turn off the agent sandbox.

**The demonstration sharpened the finding.** Removing the owner gate outright is already caught by two sibling tests (`TestF16PrivilegedHandlersAreOwnerGated`, `TestF16OwnerGateCountFloor`), so the hole is narrower than "renaming retires a security assertion" and worth stating precisely:

| mutation | before | after |
|---|---|---|
| clean tree | PASS | PASS |
| rename field to `SandboxOn` only — JSON tag, config write and wire contract all intact, toggle still fully reachable | **SKIP** (retired for good) | PASS (correct: the toggle did not move, so the gate assertion stays live) |
| same rename **+ owner gate removed** | **SKIP — reported PASS** | **FAIL** — `handleGovernorSecurity accepts agentSandboxEnabled but is not owner-gated` |
| toggle genuinely removed from the handler | SKIP | **FAIL**, naming itself and asking to be re-pointed |

Row 3 is the bug. A rename is a routine, innocuous-looking edit; it permanently silenced the only assertion that names the sandbox toggle specifically, leaving that surface guarded only by a generic table test that does not know the toggle exists. Row 4 is the anti-vacuity case per #5409 — a genuine move now fails loudly instead of going quiet, because a security surface moving is a human decision, not something a test should absorb silently.

The fix anchors on the JSON wire field the browser sends and the config field the handler writes — the actual contract — rather than a private Go identifier that carries the value between them.

---

## P1 item 1 — `api_routes_coverage_test.go` (scoped, as instructed)

Explicitly LARGE (~30 `Code != 200` sites, 591 lines). Per the scope guidance I fixed the **named concrete example** plus a **small obvious subset**, and report the rest below rather than sweeping.

### `/api/trends` — the named example

The loop passed five query variants and asserted only the status, never decoding a body.

**Demonstrated the defect first.** Replacing the entire `range`/`hours` switch in `handleTrends` with a hardcoded `hours := hoursPerDay` — a handler that ignores its parameters completely — left the loop green, and left **every test in package dashboard green** (`ok ... 75.5s`). That is the whole defect class in one line: nothing in 1450 test files noticed.

The new `TestCovG2_TrendsHonoursRangeAndHours` seeds token-sparkline entries at known ages (1h, 12h, 30h, 100h, 800h) via the existing `SeedTokenSparklineHistory` seam and asserts each parameter selects a *provably different* subset:

```
""            → 24h   → {1,12}
?range=day    → 24h   → {1,12}
?hours=48     → 48h   → {1,12,30}
?range=week   → 168h  → {1,12,30,100}
?hours=99999  → clamped to maxTrendHours (720h) → {1,12,30,100}, 800 excluded
```

Failing runs — two independent bugs, both of which return 200 for all five variants:

```
BUG A: handler ignores range+hours
  FAIL trends?hours=48    aged [1 12] want [1 12 30]
  FAIL trends?range=week  aged [1 12] want [1 12 30 100]
  FAIL trends?hours=99999 aged [1 12] want [1 12 30 100]
  FAIL range=day and range=week returned identical bodies

BUG B: only the maxTrendHours clamp removed  (subtler; all five still 200)
  FAIL trends?hours=99999 aged [1 12 30 100 800] want [1 12 30 100]
```

Bug B is worth calling out: `?hours=99999` was clearly put in the original list *to* exercise the 30-day clamp, but a status-only assertion could never check it. It does now.

Includes an anti-vacuity guard: if `SeedTokenSparklineHistory` ever stops taking, every expectation would collapse to `0 == 0` and the test would pass having checked nothing — so it `t.Fatal`s on a short seed. Plus a day-vs-week body inequality check, so the table cannot be satisfied by a handler with one fixed window.

### Three round-trip toggles — the obvious subset

`knowledge/enabled`, `knowledge/bead-synthesizer/enabled` and `budget-ignore` each set a value and never read it back, so a handler that parses the body and discards it passed in **both** directions. These are the cases where the correct assertion is unambiguous (the state each toggle exists to write is directly observable), so I took them and left the judgement calls alone.

Injected no-op writes into all three handlers, each still returning 200:

```
BUG C/D/E — with the PRE-PR test file:  ok      (all three green)
            with this PR's test file:   FAIL
  budget-ignore bool: response ignored = false, want true — the global bypass was not applied
  budget-ignore: re-read ignored = false, want true — the bool form did not persist
  knowledge toggle enable returned 200 but Config.Knowledge.Enabled is false — the toggle did not take
  bead-synth disable returned 200 but IsEnabled() is still true — the toggle is stuck on
```

The pre-PR/post-PR pair on the identical injected bug is the before/after: the old assertions report `ok`, the new ones fail.

---

## Remaining P1 backlog — reported, not changed

`src/pkg/dashboard/api_routes_coverage_test.go`, ~26 status-only sites left. Triaged into what is mechanical and what is design work:

**Mechanical — response body has an obvious invariant:**
- `:143` `/api/token-access` — asserts 200 only; should assert the payload shape and, given #3936 owner-gating, that a **non-owner** request does not receive gh-command lines. The security half of this endpoint is untested here.
- `:189,199,213` `/api/gh-user-auth/status` — three branches (logged-out, session, header) all assert 200 and nothing distinguishes them; a handler returning the same body for all three passes. Should assert the logged-out branch reports logged-out.
- `:227` `/api/gh-user-auth/logout` — never asserts the session was actually cleared.
- `:370` `/api/config/agent/scanner/export` — `buildExportYAML` output never parsed; should assert it is valid YAML naming the agent.
- `:467` `/api/inference/models/vllm` — comment says "fetch fails → static fallback" but nothing asserts the fallback list is returned.
- `:504,507,512,515` knowledge search/project/git_source — `?q=foo` and `?tag=bar` never assert the filter was applied (same shape as the `/api/trends` bug).

**Design work — correct payload is a judgement call:**
- `:29,37` `/api/history`, `/api/timeline` — need a decision on the minimum documented payload.
- `:311,336` governor agent add/remove — should re-read the agent list to confirm membership changed.
- `:449` `TestCovG2_SimpleGets` — six endpoints in one loop (`/api/gh-auth`, `/api/model-advisor`, `/api/tokens`, `/api/config/backends`, `/api/cost`, `/api/cost/history`); each needs its own invariant, and `/api/config/backends` likely wants a parity assertion against `config.CLIBackends` rather than a bespoke literal.
- `:280` asserts `200 || 400`, which is nearly unfalsifiable and should be pinned to one.

**Other self-disarming skips from #5398's P1 list** — left alone deliberately. #5398 flagged these as adjacent to item 3 of #5388 (whether `skip` should ever be silent in CI), which is a maintainer policy decision, and unlike the owner-gate case none guards a security surface:
- `pkg/hub/error_pages_backend_test.go:187` — its own comment asks to "be revisited rather than silently kept green".
- `pkg/config/entrypoint_boot_test.go:370` — skips if `entrypoint.sh` is unreadable from the package.
- `pkg/dashboard/backend_picker_parity_test.go:194` — evaporates on a tooltip copy edit.
- `pkg/worksource/github_issues_test.go:79` — skip is inside the assertion path.

I took the owner-gate one because it is the security case and because it could be fixed without a policy call: it now fails rather than skips only when the guarded thing genuinely moved, which is a re-point request, not a CI policy change. Converting the other four is a one-line `Skip`→`Fatal` each but may turn lanes red immediately, so it stays a maintainer call.

---

## Verification

- Full `go test ./pkg/dashboard/` green with production code restored: `ok ... 54.9s`.
- Production files confirmed byte-identical to `origin/v4` after every demonstration (`git diff --stat` empty on `api.go` and `api_governor_security.go`).
- `gofmt` clean on both touched files. The other `gofmt -l` hits in `pkg/dashboard/` are pre-existing on `origin/v4` and untouched.
- No workflow files touched, so no `.github/release-lines.yml` pinning implications and no parse risk. Grepped the diff for empty `${{ }}` per #5339 — none; no `${{` appears in it at all.
- No test deleted, no assertion weakened, no lane made a required status check.

## Coordination

Touches only `src/pkg/dashboard/f16_owner_gate_test.go` and `src/pkg/dashboard/api_routes_coverage_test.go`. Disjoint from #5463 (docs/policies) and #5464 (`pkg/config` watcher flake). No overlap with the #5090 verification, which is observation-only.

Refs #5388
