### PR TITLE
🐛 fix(escalation): machinery-generation amnesty + larger re-engagement budget

### DIFF
--- a/src/pkg/escalation/escalation.go
+++ b/src/pkg/escalation/escalation.go
@@ -47,7 +47,23 @@ const RedPRStaleAfter = 10 * time.Minute
 // re-dispatched every tick forever. Distinct from DefaultThreshold, which
 // counts distinct red SHAs (real fix attempts); this counts re-nudges of an
 // unchanged red SHA.
-const MaxReEngagements = 3
+const MaxReEngagements = 6
+
+// MachineryVersion identifies the GENERATION of the fix-dispatch machinery.
+// Bump it when the kick/repair pipeline changes materially enough that
+// attempts burned under the previous generation are no longer predictive of
+// the next attempt's success. Entries whose recorded generation is older get
+// ONE fresh set of re-engagements (and are un-escalated) on their next
+// TryReEngage — without this, a PR escalated under machinery that could not
+// possibly have fixed it (pre-#4828 kicks carried no CI evidence, no branch
+// name, no push-to-branch instruction, and most "attempts" never produced a
+// single commit) stays human-parked forever even after the machinery is
+// repaired. Observed on kubestellar/console 2026-09-01: nine split PRs
+// escalated under generation-1 no-op attempts, permanently outside the loop.
+//
+// Generation 2: evidence-rich FIX-BEFORE-NEW kicks (#4828) + per-agent
+// attribution + AGENTS.md repair contracts.
+const MachineryVersion = 2
 
 // Entry is the persisted per-PR attempt record.
 type Entry struct {
@@ -76,6 +92,10 @@ type Entry struct {
 	// PR goes green. The re-engagement cap (MaxReEngagements) reads this so a
 	// permanently-red, never-moving PR is not nudged forever.
 	ReEngagements int `json:"re_engagements,omitempty"`
+	// Machinery is the MachineryVersion under which this entry's attempts
+	// were burned. Older-generation entries are granted amnesty (see
+	// MachineryVersion).
+	Machinery int `json:"machinery,omitempty"`
 }
 
 // Store is the on-PVC attempt ledger. All methods are safe for concurrent use.
@@ -149,8 +169,19 @@ func (s *Store) Sweep(obs []Observation, threshold int) map[string]Result {
 		}
 		e := s.entries[key]
 		if e == nil {
-			e = &Entry{}
+			e = &Entry{Machinery: MachineryVersion}
 			s.entries[key] = e
+		}
+		// Machinery amnesty (see MachineryVersion): attempts and escalations
+		// burned under an older fix-dispatch generation are wiped once, and
+		// the distinct-SHA ledger restarts, so the CURRENT machinery gets its
+		// own budget before a human is paged again. Without the RedSHAs reset
+		// the very next sweep would re-escalate on the old ledger.
+		if e.Machinery < MachineryVersion {
+			e.Machinery = MachineryVersion
+			e.ReEngagements = 0
+			e.Escalated = false
+			e.RedSHAs = nil
 		}
 		if o.HeadSHA != "" && !containsSHA(e.RedSHAs, o.HeadSHA) {
 			e.RedSHAs = append(e.RedSHAs, o.HeadSHA)
@@ -332,6 +363,16 @@ func (s *Store) TryReEngage(repo string, number int, headSHA string) bool {
 		e.CurRedSHA = headSHA
 		e.FirstRedAt = s.now()
 		e.ReEngagements = 0
+	}
+	// Machinery amnesty: attempts burned under an older fix-dispatch
+	// generation don't count against the current one. Grant one fresh set
+	// and pull the PR back out of the escalated (needs-human) state so the
+	// current machinery gets its own chance before a human is paged again.
+	if e.Machinery < MachineryVersion {
+		e.Machinery = MachineryVersion
+		e.ReEngagements = 0
+		e.Escalated = false
+		e.RedSHAs = nil
 	}
 	if e.ReEngagements >= MaxReEngagements {
 		return false

--- a/src/pkg/escalation/escalation_test.go
+++ b/src/pkg/escalation/escalation_test.go
@@ -228,3 +228,55 @@ func TestSweep_EscalatesWhenReEngagementBudgetExhaustedOnUnchangedSHA(t *testing
 		t.Fatalf("new SHA resets the budget; must not escalate yet: got %+v", got)
 	}
 }
+
+// Machinery amnesty: entries escalated under an older fix-dispatch generation
+// (pre-#4828 kicks carried no CI evidence and most attempts produced no
+// commit) get ONE fresh budget under the current generation — un-escalated,
+// counters cleared, distinct-SHA ledger restarted — instead of staying
+// human-parked forever. Entries already at the current generation keep their
+// state untouched.
+func TestSweep_MachineryAmnestyReleasesOldGenerationEscalations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "streaks.json")
+	s := Load(path)
+
+	// Simulate a generation-1 entry: escalated, budget exhausted, full ledger.
+	key := Key("org/repo", 9)
+	s.mu.Lock()
+	s.entries[key] = &Entry{
+		RedSHAs:       []string{"a", "b", "c"},
+		Escalated:     true,
+		CurRedSHA:     "c",
+		ReEngagements: MaxReEngagements,
+		Machinery:     1,
+	}
+	s.mu.Unlock()
+
+	// Next sweep under generation 2: amnesty fires — not escalated, ledger
+	// restarted at the observed SHA only, and it must NOT immediately
+	// re-escalate off the old ledger.
+	r := s.Sweep([]Observation{obs("org/repo", 9, "c", true)}, 3)
+	got := r[key]
+	if got.NewlyEscala {
+		t.Fatalf("amnestied entry must not re-escalate on the old ledger: %+v", got)
+	}
+	if got.Attempts != 1 {
+		t.Fatalf("ledger must restart: got %+v", got)
+	}
+	s.mu.Lock()
+	stillEscalated := s.entries[key].Escalated
+	s.mu.Unlock()
+	if stillEscalated {
+		t.Fatal("entry must be un-escalated after amnesty")
+	}
+	// Re-engagement budget is fresh.
+	if !s.TryReEngage("org/repo", 9, "c") {
+		t.Fatal("amnestied entry must have a fresh re-engagement budget")
+	}
+	// The amnesty fires ONCE: exhausting the fresh budget escalates again.
+	for i := 0; i < MaxReEngagements; i++ {
+		s.TryReEngage("org/repo", 9, "c")
+	}
+	if s.TryReEngage("org/repo", 9, "c") {
+		t.Fatal("cap must hold at the current generation — amnesty is one-shot")
+	}
+}


### PR DESCRIPTION
## Problem

Escalation is a one-way door keyed to attempt counts — but the attempts that burn the cap are only as good as the dispatch machinery of their era. Nine kubestellar/console PRs escalated to `needs-human` after 3 attempts under generation-1 kicks (no CI evidence, no branch name, no push-to-branch instruction — every escalated PR shows exactly ONE commit, i.e. the attempts were no-ops). When #4828 fixed the machinery, nothing re-armed them: they were grandfathered outside the automated loop forever, the fix-before-new section skips escalated PRs by design, and the queue stopped draining.

## Fix

- **`MachineryVersion` (now 2)**: entries whose attempts were burned under an older generation get one fresh budget on their next sweep/re-engage — un-escalated, `ReEngagements` cleared, distinct-SHA ledger restarted (without the ledger reset the very next sweep would re-escalate off the old SHAs). One-shot per generation bump; within a generation the loop-breaker is unchanged. Bump the const whenever the kick/repair pipeline changes materially enough that prior failures aren't predictive.
- **`MaxReEngagements` 3→6**: with evidence-rich FIX-BEFORE-NEW kicks, per-attempt success odds are materially higher, so the breaker can afford more patience before paging a human.

Deploying this un-parks the current escalated set automatically on the next eval sweep.

## Test

`TestSweep_MachineryAmnestyReleasesOldGenerationEscalations` — old-generation escalated entry: amnesty un-escalates, restarts the ledger, doesn't re-escalate off old SHAs, grants a fresh TryReEngage budget, and the amnesty is one-shot (fresh budget exhaustion escalates again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)