### PR TITLE
🐛 fix(contribute-ws): the heartbeat ping failure is a symptom, and absorb reconnect churn

### DIFF
--- a/src/pkg/dashboard/contribute_reconnect_flap_test.go
+++ b/src/pkg/dashboard/contribute_reconnect_flap_test.go
@@ -1,0 +1,280 @@
+package dashboard
+
+import (
+	"testing"
+	"time"
+)
+
+// The tests in this file cover the two halves of the contributor-flap work:
+// kubestellar/hive#5151 (a ~1s reconnect must not be booked as a full departure
+// plus arrival) and kubestellar/hive#5090 (the heartbeat loop must not report a
+// ping failure on a socket somebody else already tore down).
+
+// flapRows drives the exact three-row sequence one flap writes:
+// "released: connection lost" -> "left" -> "joined".
+func flapRows(hub *ContributeWSHub, user, task string) {
+	hub.addActivity(user, "released: connection lost", "contributor", "claude", "m", "", task)
+	hub.addActivity(user, "left", "contributor", "claude", "m", "", "")
+	hub.addActivity(user, "joined", "contributor", "claude", "m", "", "")
+}
+
+func actions(entries []ActivityEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Action
+	}
+	return out
+}
+
+// TestReconnectFlap_CollapsesToSingleJoined is the core #5151 assertion: a flap
+// leaves ONE row, not three, and the surviving row is the "joined" that proves the
+// contributor is present. The prior "picked up" — the row an operator actually
+// wants and that this churn was evicting — must survive untouched.
+func TestReconnectFlap_CollapsesToSingleJoined(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.addActivity("alice", "picked up", "contributor", "claude", "m", "", "myorg/repo#7")
+	flapRows(hub, "alice", "myorg/repo#7")
+
+	got := actions(hub.RecentActivity())
+	want := []string{"picked up", "joined"}
+	if len(got) != len(want) {
+		t.Fatalf("flap should collapse to %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("activity = %v, want %v", got, want)
+		}
+	}
+
+	if n := hub.AbsorbedReconnects(); n != 1 {
+		t.Fatalf("absorbed reconnect counter = %d, want 1 — the flap must stay countable", n)
+	}
+}
+
+// TestReconnectFlap_ManyFlapsDoNotEvictTheFeed pins the concrete harm #5151
+// reports: at three rows per flap against maxActivityEntries (50), a flapping
+// contributor churns the whole retained feed in under 20 minutes, evicting every
+// real row. Twenty flaps must not evict the surrounding history.
+func TestReconnectFlap_ManyFlapsDoNotEvictTheFeed(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.addActivity("alice", "picked up", "contributor", "claude", "m", "", "myorg/repo#7")
+	for i := 0; i < 20; i++ {
+		flapRows(hub, "alice", "myorg/repo#7")
+	}
+
+	got := hub.RecentActivity()
+	if len(got) > 3 {
+		t.Fatalf("20 flaps should not fill the feed, got %d rows: %v", len(got), actions(got))
+	}
+	if got[0].Action != "picked up" {
+		t.Fatalf("the real 'picked up' row was evicted by flap churn: %v", actions(got))
+	}
+	if n := hub.AbsorbedReconnects(); n != 20 {
+		t.Fatalf("absorbed reconnect counter = %d, want 20", n)
+	}
+}
+
+// TestGenuineDeparture_KeepsEveryRow is the falling-through case #5151 requires:
+// "a grace period that swallows a genuine departure would be worse than the
+// churn". With no reconnect, all rows stand exactly as they do today.
+func TestGenuineDeparture_KeepsEveryRow(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.addActivity("alice", "released: connection lost", "contributor", "claude", "m", "", "myorg/repo#7")
+	hub.addActivity("alice", "left", "contributor", "claude", "m", "", "")
+
+	got := actions(hub.RecentActivity())
+	if len(got) != 2 || got[0] != "released: connection lost" || got[1] != "left" {
+		t.Fatalf("a departure with no reconnect must keep every row, got %v", got)
+	}
+	if n := hub.AbsorbedReconnects(); n != 0 {
+		t.Fatalf("nothing was absorbed, counter = %d, want 0", n)
+	}
+}
+
+// TestReconnectFlap_DoesNotCollapseAcrossUsers guards the narrowness of the walk
+// back: bob's departure must not be retracted by alice arriving.
+func TestReconnectFlap_DoesNotCollapseAcrossUsers(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.addActivity("bob", "left", "contributor", "claude", "m", "", "")
+	hub.addActivity("alice", "joined", "contributor", "claude", "m", "", "")
+
+	got := actions(hub.RecentActivity())
+	if len(got) != 2 || got[0] != "left" {
+		t.Fatalf("another user's 'left' must not be absorbed, got %v", got)
+	}
+	if hub.RecentActivity()[0].Username != "bob" {
+		t.Fatalf("bob's departure row was retracted by alice's arrival")
+	}
+}
+
+// TestReconnectFlap_StaleLeftIsNotAbsorbed checks the window bound: a "left" from
+// outside reconnectFlapWindow is a real departure, and a later arrival is a real
+// arrival. Both rows stand.
+func TestReconnectFlap_StaleLeftIsNotAbsorbed(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.addActivity("alice", "left", "contributor", "claude", "m", "", "")
+
+	// Backdate the departure past the window.
+	hub.activityMu.Lock()
+	hub.activity[0].Timestamp = time.Now().Add(-2 * reconnectFlapWindow).UTC().Format(time.RFC3339)
+	hub.activityMu.Unlock()
+
+	hub.addActivity("alice", "joined", "contributor", "claude", "m", "", "")
+
+	got := actions(hub.RecentActivity())
+	if len(got) != 2 || got[0] != "left" || got[1] != "joined" {
+		t.Fatalf("a departure older than the flap window must not be absorbed, got %v", got)
+	}
+}
+
+// TestReconnectFlap_BareReleasedRowSurvives ensures a "released: connection lost"
+// is only ever retracted as part of a left+joined round trip. On its own it
+// describes WORK, not presence, and a subsequent join must not erase it.
+func TestReconnectFlap_BareReleasedRowSurvives(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.addActivity("alice", "released: connection lost", "contributor", "claude", "m", "", "myorg/repo#7")
+	hub.addActivity("alice", "joined", "contributor", "claude", "m", "", "")
+
+	got := actions(hub.RecentActivity())
+	if len(got) != 2 || got[0] != "released: connection lost" {
+		t.Fatalf("a released row with no 'left' must survive, got %v", got)
+	}
+}
+
+// TestReconnectFlap_PreservesDuplicatePRGuarantee is the #2356 invariant #5151
+// explicitly asks to be pinned by a test.
+//
+// The duplicate-PR guarantee lives in the release cooldown, NOT in the activity
+// feed. The failure mode this guards against is a "fix" that defers or suppresses
+// bookReleaseCooldown behind a grace timer, which would reopen the window in which
+// selectTask can hand the same issue to a second session while the original relay
+// is still working it. The feed collapse must be provably orthogonal: after a full
+// flap has been absorbed down to one row, the issue must STILL be in failure
+// cooldown.
+func TestReconnectFlap_PreservesDuplicatePRGuarantee(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	// A disconnect books the #2356 hedge on the in-flight issue...
+	hub.bookReleaseCooldown("myorg/repo", 7)
+	// ...and writes the three feed rows, which the reconnect then absorbs.
+	flapRows(hub, "alice", "myorg/repo#7")
+
+	if len(hub.RecentActivity()) != 1 {
+		t.Fatalf("precondition: the flap should have been absorbed, got %v",
+			actions(hub.RecentActivity()))
+	}
+	if !hub.isTaskInFailureCooldown("myorg/repo", 7) {
+		t.Fatal("#2356 REGRESSION: absorbing the feed rows must not withdraw the " +
+			"release cooldown — the duplicate-PR window would be reopened")
+	}
+}
+
+// TestReleaseCooldown_WithdrawnOnlyByLeaseBoundResume documents the one sanctioned
+// way the #2356 hedge is withdrawn (#5322): the original owner re-entering
+// activeIssues via a lease-bound resume, which is the STRONGER guard the cooldown
+// was standing in for. Absorbing feed rows is not that, and must not imitate it.
+func TestReleaseCooldown_WithdrawnOnlyByLeaseBoundResume(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	hub.bookReleaseCooldown("myorg/repo", 7)
+	if !hub.isTaskInFailureCooldown("myorg/repo", 7) {
+		t.Fatal("precondition: cooldown should be booked")
+	}
+
+	// The resume path's withdrawal.
+	hub.clearReleaseCooldown("myorg/repo", 7)
+	if hub.isTaskInFailureCooldown("myorg/repo", 7) {
+		t.Fatal("a lease-bound resume should withdraw the speculative hedge")
+	}
+
+	// And it stays narrow: a cooldown carrying a real consecutive-failure count is
+	// a genuine failure record and must NOT be launderable by a resume.
+	hub.recordTaskFailure("myorg/repo", 8, false)
+	hub.completedMu.Lock()
+	hub.consecutiveFailures["myorg/repo#8"] = 2
+	hub.completedMu.Unlock()
+
+	hub.clearReleaseCooldown("myorg/repo", 8)
+	if !hub.isTaskInFailureCooldown("myorg/repo", 8) {
+		t.Fatal("a real failure record must not be withdrawn by a resume")
+	}
+}
+
+// TestHeartbeatLoop_SilentOnDeregisteredConnection is the #5090 assertion.
+//
+// The "heartbeat ping failed, closing" line fired ~29-30s after EVERY new
+// connection because the heartbeat tick is a fixed offset from registration: the
+// read loop's disconnect defer had already deleted the connection and closed the
+// socket, and this loop — which has no done channel — slept out its interval and
+// then wrote to a corpse. The resulting log line read as a cause and was a
+// lagging indicator by up to a full heartbeat interval, which is what sent #5090's
+// diagnosis toward a per-direction proxy idle timer.
+//
+// connectionRegistered is the guard. Asserting it directly is what matters: a
+// connection that is not in h.connections must be reported as gone, so the loop
+// returns before it can write and mislabel.
+func TestHeartbeatLoop_SilentOnDeregisteredConnection(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	c := &ContributorConnection{profile: &ContributorProfile{GitHubUsername: "alice"}}
+
+	if hub.connectionRegistered(c) {
+		t.Fatal("an unregistered connection must not be reported as registered")
+	}
+
+	hub.mu.Lock()
+	hub.connections["conn-1"] = c
+	hub.mu.Unlock()
+	if !hub.connectionRegistered(c) {
+		t.Fatal("a registered connection must be reported as registered")
+	}
+
+	// What the disconnect defer does on the read goroutine.
+	hub.mu.Lock()
+	delete(hub.connections, "conn-1")
+	hub.mu.Unlock()
+	if hub.connectionRegistered(c) {
+		t.Fatal("after deregistration the heartbeat loop must stop rather than " +
+			"write to a torn-down socket and log a misleading ping failure")
+	}
+
+	// Identity is by pointer, not by username: a reconnect registering a NEW
+	// connection for the same contributor must not keep the OLD loop alive.
+	replacement := &ContributorConnection{profile: &ContributorProfile{GitHubUsername: "alice"}}
+	hub.mu.Lock()
+	hub.connections["conn-2"] = replacement
+	hub.mu.Unlock()
+	if hub.connectionRegistered(c) {
+		t.Fatal("the superseded connection must not be kept alive by its replacement")
+	}
+	if !hub.connectionRegistered(replacement) {
+		t.Fatal("the replacement connection should be registered")
+	}
+}
+
+// TestWriteDeadline_IsBoundedAndUnderHeartbeatInterval pins the relationship the
+// #5090 write-deadline fix depends on. A write must not still be parked when the
+// next heartbeat tick arrives (which would stack ticker goroutines on writeMu),
+// and it must be comfortably longer than the control-frame deadline so an
+// ordinarily slow client is never mistaken for a wedged one.
+func TestWriteDeadline_IsBoundedAndUnderHeartbeatInterval(t *testing.T) {
+	if wsWriteDeadline <= 0 {
+		t.Fatal("an unbounded write deadline is the defect: WriteJSON on a " +
+			"half-open socket blocks indefinitely while holding writeMu")
+	}
+	if wsWriteDeadline >= wsHeartbeatInterval {
+		t.Fatalf("wsWriteDeadline (%v) must be shorter than wsHeartbeatInterval (%v) "+
+			"so a wedged write cannot outlive the tick that started it",
+			wsWriteDeadline, wsHeartbeatInterval)
+	}
+	if wsWriteDeadline <= wsProtocolPingDeadline {
+		t.Fatalf("wsWriteDeadline (%v) should exceed wsProtocolPingDeadline (%v)",
+			wsWriteDeadline, wsProtocolPingDeadline)
+	}
+}

--- a/src/pkg/dashboard/contribute_reconnect_flap_test.go
+++ b/src/pkg/dashboard/contribute_reconnect_flap_test.go
@@ -64,15 +64,42 @@ func TestReconnectFlap_ManyFlapsDoNotEvictTheFeed(t *testing.T) {
 		flapRows(hub, "alice", "myorg/repo#7")
 	}
 
-	got := hub.RecentActivity()
-	if len(got) > 3 {
-		t.Fatalf("20 flaps should not fill the feed, got %d rows: %v", len(got), actions(got))
+	// A contributor that never actually left should occupy exactly one presence
+	// row, however many times it bounced — not one row per flap, which would be
+	// the same eviction only quieter.
+	got := actions(hub.RecentActivity())
+	want := []string{"picked up", "joined"}
+	if len(got) != len(want) {
+		t.Fatalf("20 flaps should collapse to %v, got %d rows: %v", want, len(got), got)
 	}
-	if got[0].Action != "picked up" {
-		t.Fatalf("the real 'picked up' row was evicted by flap churn: %v", actions(got))
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("activity = %v, want %v", got, want)
+		}
 	}
 	if n := hub.AbsorbedReconnects(); n != 20 {
-		t.Fatalf("absorbed reconnect counter = %d, want 20", n)
+		t.Fatalf("absorbed reconnect counter = %d, want 20 — every flap must stay countable", n)
+	}
+}
+
+// TestReconnectFlap_DoesNotConsumeUnrelatedJoined guards the third row of the
+// walk. The superseded "joined" is consumed ONLY after a "left" above it has been
+// seen; a "joined" that no departure followed is a live presence and must stand.
+func TestReconnectFlap_DoesNotConsumeUnrelatedJoined(t *testing.T) {
+	hub, _ := covK2Hub(t)
+
+	// Two arrivals with no departure between them: nothing to absorb. (The
+	// consecutive-action debounce is dodged by using a different user in between.)
+	hub.addActivity("alice", "joined", "contributor", "claude", "m", "", "")
+	hub.addActivity("bob", "picked up", "contributor", "claude", "m", "", "t")
+	hub.addActivity("alice", "joined", "contributor", "claude", "m", "", "")
+
+	got := actions(hub.RecentActivity())
+	if len(got) != 3 {
+		t.Fatalf("a 'joined' with no 'left' after it must not be consumed, got %v", got)
+	}
+	if n := hub.AbsorbedReconnects(); n != 0 {
+		t.Fatalf("nothing was absorbed, counter = %d, want 0", n)
 	}
 }
 

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -183,6 +183,24 @@ type ContributorConnection struct {
 func (c *ContributorConnection) send(msg WSMessage) error {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
+	// Bound the write (kubestellar/hive#5090). WriteJSON on a gorilla connection
+	// with no write deadline blocks INDEFINITELY once the peer's receive window
+	// closes — a half-open socket (an L7 proxy that dropped the tunnel without
+	// telling either endpoint) accepts no bytes and sends no RST, so the write
+	// neither completes nor fails. Every caller of send holds writeMu for the
+	// duration, so one wedged peer would park the heartbeat ticker, the read
+	// loop's replies, and the operator revoke/yank/reassign paths for that
+	// connection behind a lock nothing can break.
+	//
+	// wsWriteDeadline turns that unbounded park into a bounded failure the
+	// existing error paths already handle: the heartbeat's write-failure branch
+	// closes the socket with a reason, and a reply failure surfaces to its
+	// caller. The deadline is per-write and generous enough that an ordinary
+	// slow-but-live client is never cut — it exists to bound the pathological
+	// case, not to police latency.
+	if err := c.ws.SetWriteDeadline(time.Now().Add(wsWriteDeadline)); err != nil {
+		return err
+	}
 	return c.ws.WriteJSON(msg)
 }
 
@@ -432,11 +450,15 @@ type ContributeWSHub struct {
 	// mu-guarded to match taskGen's reasoning above: it is touched from the
 	// upgrade path and from deferred cleanup, and must never contend with or
 	// re-enter h.mu.
-	pendingConns   atomic.Int64
-	activityMu     sync.RWMutex
-	activity       []ActivityEntry
-	server         *Server
-	completedTasks map[string]time.Time
+	pendingConns atomic.Int64
+	activityMu   sync.RWMutex
+	activity     []ActivityEntry
+	// absorbedReconnects counts flaps collapsed by absorbReconnectFlapLocked
+	// (kubestellar/hive#5151), so a contributor bouncing stays countable after its
+	// feed rows stop being written. Guarded by activityMu alongside activity itself.
+	absorbedReconnects int
+	server             *Server
+	completedTasks     map[string]time.Time
 	// completedTaskCooldown holds a per-task override for how long, from the
 	// completion time in completedTasks, the issue stays in cooldown. It is
 	// populated by markTaskCompleted based on whether a PR was reported. When a
@@ -954,6 +976,31 @@ func (h *ContributeWSHub) addActivity(username, action, role, cli, model, effort
 			}
 		}
 	}
+	// #5151: absorb a fast reconnect instead of booking it as a departure plus an
+	// arrival. A flap emits "released: connection lost" -> "left" -> "joined"; the
+	// debounce above never fires on it because consecutive entries never repeat an
+	// action. At three rows per flap against maxActivityEntries (50), one flapping
+	// contributor evicts the entire retained feed in under 20 minutes, which is what
+	// #5090 measured as 19 joined / 19 left filling 38 of 50 slots.
+	//
+	// Retracting the trailing flap rows on the "joined" that closes the round trip is
+	// what makes this correct rather than merely quieter: the pair is only collapsed
+	// once the reconnect has PROVEN the contributor came back, so a genuine departure
+	// — where no "joined" ever arrives — keeps every row exactly as today. That is the
+	// property #5151 asks for ("expiry must fall through to exactly today's
+	// behavior"), and it needs no timer, no deferred work, and no grace period during
+	// which the hub is holding a decision it has not made.
+	//
+	// It touches ONLY the feed. The #2356 duplicate-PR guarantee is untouched and is
+	// not this function's to weaken: the release cooldown is still booked eagerly by
+	// the disconnect defer, and is withdrawn only by the lease-bound resume in
+	// task_progress via clearReleaseCooldown (#5322) — which withdraws it because the
+	// original owner has re-entered activeIssues, the stronger guard the cooldown was
+	// standing in for. No window is ever open in which the issue is both out of
+	// activeIssues and out of cooldown.
+	if action == "joined" {
+		h.absorbReconnectFlapLocked(username)
+	}
 	entry := ActivityEntry{
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Username:  username,
@@ -978,6 +1025,92 @@ func (h *ContributeWSHub) addActivity(username, action, role, cli, model, effort
 	// center). Done AFTER releasing activityMu, and the fan-out itself is a
 	// non-blocking send, so a subscribed browser can never stall the WS path.
 	h.broadcastActivity(entry)
+}
+
+// reconnectFlapWindow is how recently a "left" must have been written for the
+// following "joined" to count as the same contributor bouncing rather than a
+// genuine departure followed later by a fresh arrival.
+//
+// It is sized against the relay's reconnect backoff, not against human behaviour:
+// BASE_RECONNECT_DELAY_MS is 1s and MAX_RECONNECT_DELAY_MS is 60s, so a relay that
+// is coming back does so inside a minute. Matching activityDebounceSecs keeps one
+// notion of "the same session, still" in this file rather than two that can drift.
+const reconnectFlapWindow = activityDebounceSecs * time.Second
+
+// absorbReconnectFlapLocked retracts the trailing "left" — and the
+// "released: connection lost" that may immediately precede it — written for this
+// user by a disconnect that a reconnect has now undone (kubestellar/hive#5151).
+//
+// Called from addActivity with activityMu already held, immediately before a
+// "joined" is appended. It walks back over at most the two rows one flap can
+// write, requires them to belong to THIS user and to be inside
+// reconnectFlapWindow, and stops at anything else. It therefore cannot reach past
+// a flap into unrelated history, cannot collapse two different users' rows
+// together, and cannot touch a "picked up" or "completed" — the rows an operator
+// actually wants and that this churn was evicting.
+//
+// A departure with no reconnect behind it is never reached at all: this runs only
+// on "joined". A departure whose reconnect arrives later than the window keeps its
+// rows, because at that distance it is no longer a flap.
+//
+// The flap stays COUNTABLE. #5151 is explicit that absorbing must not become
+// silence — the hub-side "[contribute-ws] disconnected" log line and the relay's
+// describeWsClose output are untouched and unconditional (they are the #5107
+// instrumentation and the real diagnostic surface), and absorbedReconnects
+// increments here so "this contributor flapped N times" stays answerable more
+// cheaply than by counting feed rows, which is what the issue asked for.
+func (h *ContributeWSHub) absorbReconnectFlapLocked(username string) {
+	if username == "" {
+		return
+	}
+	end := len(h.activity)
+	i := end
+	sawLeft := false
+	// At most two rows: the "left", then optionally the "released: connection lost"
+	// that preceded it. Bounded explicitly rather than by a general scan so this can
+	// never chew through the feed.
+	for i > 0 && end-i < 2 {
+		e := h.activity[i-1]
+		if e.Username != username {
+			break
+		}
+		t, err := time.Parse(time.RFC3339, e.Timestamp)
+		if err != nil || time.Since(t) >= reconnectFlapWindow {
+			break
+		}
+		if e.Action == "left" && !sawLeft {
+			sawLeft = true
+			i--
+			continue
+		}
+		if sawLeft && e.Action == "released: connection lost" {
+			i--
+			continue
+		}
+		break
+	}
+	// Only collapse when a "left" was actually found. Without it there is no
+	// departure to undo, and a bare "released: connection lost" must survive — it
+	// describes work, not presence.
+	if !sawLeft {
+		return
+	}
+	h.activity = h.activity[:i]
+	h.absorbedReconnects++
+}
+
+// AbsorbedReconnects returns how many contributor reconnects have been absorbed
+// into the activity feed rather than booked as a departure plus an arrival
+// (kubestellar/hive#5151). It is the cheap, non-evicting answer to "is a
+// contributor flapping, and how much", which before this was answerable only by
+// counting the feed rows the flapping was simultaneously evicting.
+func (h *ContributeWSHub) AbsorbedReconnects() int {
+	if h == nil {
+		return 0
+	}
+	h.activityMu.RLock()
+	defer h.activityMu.RUnlock()
+	return h.absorbedReconnects
 }
 
 func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
@@ -3878,6 +4011,35 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 	defer ticker.Stop()
 
 	for range ticker.C {
+		// Stop as soon as this socket has been deregistered (kubestellar/hive#5090).
+		//
+		// The disconnect defer in HandleWS runs on the READ goroutine the moment
+		// ReadMessage errors: it deletes the connID from h.connections and closes
+		// the socket. This loop learns none of that — it has no done channel and no
+		// reference to the read side — so it slept out the remainder of its 30s tick
+		// and then wrote a ping to an already-closed connection. That write of
+		// course failed, and the failure branch logged
+		//
+		//     [contribute-ws] heartbeat ping failed, closing
+		//
+		// which reads as a diagnosis of why the connection died and is nothing of
+		// the sort: the connection was already dead and buried, by up to a full
+		// heartbeat interval. That line is what #5090 spent an investigation
+		// chasing. Because the tick is a fixed offset from REGISTRATION, it landed
+		// ~29-30s after every "new connection" regardless of what actually killed
+		// the socket, which is precisely why the flap looked like a clean 30s idle
+		// timer and sent the diagnosis toward per-direction proxy timeouts.
+		//
+		// Checking registration here makes the loop exit silently on a socket
+		// somebody else already tore down, so the "heartbeat ping failed" line is
+		// emitted ONLY when the heartbeat write is genuinely the first thing to
+		// notice the socket is bad. It also stops the goroutine leaking for up to
+		// one interval per disconnect, which on a flapping session is a goroutine
+		// per flap.
+		if !h.connectionRegistered(c) {
+			return
+		}
+
 		c.mu.Lock()
 		lastPong := c.lastPong
 		c.mu.Unlock()
@@ -3967,6 +4129,36 @@ func (h *ContributeWSHub) taskHeldByAnotherConnection(candidate *ContributorConn
 			h.canonicalRepoKey(conn.currentTask.Repo) == canonicalRepo
 		conn.mu.Unlock()
 		if held {
+			return true
+		}
+	}
+	return false
+}
+
+// connectionRegistered reports whether this exact connection object is still in
+// the hub's live connection map (kubestellar/hive#5090).
+//
+// h.connections is keyed by a random per-socket connID that the heartbeat loop
+// never sees, so the lookup is by VALUE: scan for the pointer. The map is capped
+// at maxWSConnections (50), so this is a bounded scan once per 30s tick per
+// connection — negligible next to the network write it guards.
+//
+// Pointer identity is the right test rather than any field comparison: it is
+// exactly "is the object I was started for still the registered one", which is
+// false both when the socket was deregistered by its disconnect defer and when a
+// reconnect replaced it under a new connID. Both mean this loop has no further
+// work to do.
+//
+// Takes only h.mu.RLock and no connection-level lock, so it cannot participate in
+// any lock ordering — callers may hold c.mu or c.writeMu or neither.
+func (h *ContributeWSHub) connectionRegistered(c *ContributorConnection) bool {
+	if h == nil || c == nil {
+		return false
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, conn := range h.connections {
+		if conn == c {
 			return true
 		}
 	}
@@ -5503,6 +5695,22 @@ const wsCloseFrameDeadline = time.Second
 // cannot stack up heartbeat goroutines waiting on a peer that has stopped
 // reading.
 const wsProtocolPingDeadline = 10 * time.Second
+
+// wsWriteDeadline bounds every application JSON write to a live contributor
+// connection (kubestellar/hive#5090).
+//
+// gorilla/websocket applies no write deadline by default, so WriteJSON against a
+// peer that has stopped reading blocks until the OS gives up on the socket —
+// which, on a half-open TCP connection with no RST, can be many minutes of
+// retransmission backoff. Because send() holds writeMu across the write, that
+// stall is not confined to the writing goroutine: it blocks every other writer
+// on the same connection.
+//
+// It is deliberately shorter than wsHeartbeatInterval so a write cannot still be
+// parked when the next heartbeat tick arrives (which would stack ticker
+// goroutines on writeMu), and comfortably longer than wsProtocolPingDeadline so
+// an ordinary slow client is never mistaken for a wedged one.
+const wsWriteDeadline = 15 * time.Second
 
 // writeProtocolPing sends a WebSocket PROTOCOL-level Ping control frame (opcode
 // 0x9) on the connection.

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -1066,10 +1066,22 @@ func (h *ContributeWSHub) absorbReconnectFlapLocked(username string) {
 	end := len(h.activity)
 	i := end
 	sawLeft := false
-	// At most two rows: the "left", then optionally the "released: connection lost"
-	// that preceded it. Bounded explicitly rather than by a general scan so this can
-	// never chew through the feed.
-	for i > 0 && end-i < 2 {
+	// At most three rows, which is everything one flap cycle can leave behind:
+	// the "left", the "released: connection lost" that may precede it, and the
+	// "joined" written by the PREVIOUS absorbed flap.
+	//
+	// That third row is what makes repeated flapping actually collapse. Each
+	// absorbed flap leaves its own "joined" as the new trailing row, so on the next
+	// flap the walk would stop at it and the feed would still grow by one row per
+	// flap — 20 flaps leaving 20 "joined" rows, which is the same eviction #5151
+	// reports, only quieter. Consuming the superseded "joined" makes a contributor
+	// that flaps N times in a row occupy ONE row rather than N: the arrival that is
+	// still true is the one about to be appended, and the earlier ones describe a
+	// presence that never lapsed.
+	//
+	// Bounded explicitly rather than by a general scan so this can never chew
+	// through the feed.
+	for i > 0 && end-i < 3 {
 		e := h.activity[i-1]
 		if e.Username != username {
 			break
@@ -1084,6 +1096,13 @@ func (h *ContributeWSHub) absorbReconnectFlapLocked(username string) {
 			continue
 		}
 		if sawLeft && e.Action == "released: connection lost" {
+			i--
+			continue
+		}
+		// Only reachable once the left (and any released) above it have been
+		// consumed, so this can only ever be the arrival that opened the session
+		// this flap just closed — never an unrelated join.
+		if sawLeft && e.Action == "joined" {
 			i--
 			continue
 		}


### PR DESCRIPTION
## The headline: `heartbeat ping failed, closing` is a **lagging indicator**, not a cause

#5090 has been chasing this line:

```
09:37:48  [contribute-ws] new connection      id=5b4e6771cb201bff
09:38:00  [contribute-ws] disconnected        username=<contributor>
09:38:30  [contribute-ws] heartbeat ping failed, closing
```

The disconnect **precedes** the ping failure by 30 seconds, and that ordering is structural rather than coincidental.

`heartbeatLoop` has no done channel and no reference to the read side. When `ReadMessage` errors, the disconnect defer runs **on the read goroutine**: it deletes the connID from `h.connections` and calls `conn.Close()`. The heartbeat goroutine learns none of that — it sleeps out the remainder of its 30s tick, writes a ping to an already-closed socket, fails, and logs a line that reads like a diagnosis of why the connection died.

Because the tick is a fixed offset from **registration**, that line lands the same distance after every `new connection` regardless of what actually killed the socket. The arithmetic in #5090's own evidence:

| new connection | ping failed | delta |
|---|---|---|
| 12:30:11 | 12:30:40 | 29s |
| 12:30:42 | 12:31:11 | 29s |
| 12:46:43 | 12:47:12 | 29s |
| 12:47:14 | 12:47:43 | 29s |

Four for four at 29s — 30s minus the ~1s auth handshake before `go h.heartbeatLoop(contributor)`. A causal event does not land on a fixed offset from *establishment*; a scheduled tick does.

**This is why the flap looked like a clean 30s idle timer**, and it is what pointed the investigation at per-direction proxy idle timeouts. The measurement was reading the hub's own ticker.

Note the one row that breaks the pattern and confirms the reading: `11:34:40 -> 11:34:44` is **4s**, not 29s. That is the case where the heartbeat write genuinely *was* the first thing to notice a bad socket — which is what the line should always have meant.

## What this PR changes

**#5090 (`Refs`, not `Fixes` — see below)**

- `heartbeatLoop` returns when its connection is no longer registered, so the ping-failure line is emitted **only** when the heartbeat write is genuinely first to notice. The 29s phantom stops. This also stops leaking a goroutine for up to one heartbeat interval per disconnect — one per flap on a flapping session.
- `send()` sets a write deadline. gorilla applies none by default, so `WriteJSON` against a half-open socket (a proxy that dropped the tunnel without an RST) blocks until the OS abandons retransmission — **while holding `writeMu`**, which parks the heartbeat ticker, the read loop's replies, and the operator revoke/yank/reassign paths for that connection behind a lock nothing can break. Answers question 2 from the investigation: yes, it matters, and yes, it should.

On question 3 — the JSON ping is still needed. It carries `Seq` and is what pre-#5310 relays answer; removing it would false-time-out older clients. Both fire, and that is correct. The JSON ping's *failure branch* was the noisy part, and that is what is fixed here.

**#5151 (`Fixes`)**

A ~1s reconnect no longer churns three feed rows. The `left` (and the `released: connection lost` immediately preceding it) is retracted on the `joined` that closes the round trip.

This is approach (a) without its hazard: the collapse happens only once the reconnect has **proven** the contributor returned, so there is no timer, no grace period, and no interval during which the hub is holding a decision it has not made. A genuine departure — where no `joined` ever arrives — keeps every row exactly as today.

## How the #2356 guarantee is protected

The duplicate-PR guarantee lives in the **release cooldown**, not in the activity feed, and this PR does not touch it. `bookReleaseCooldown` still fires eagerly in the disconnect defer. It is withdrawn only by the lease-bound resume in `task_progress` via `clearReleaseCooldown` (#5322) — and that is safe for the reason #5322 records: the thing that clears the hedge is the original owner **re-entering `activeIssues`**, which is the stronger guard the cooldown was standing in for. There is never a window in which the issue is both out of `activeIssues` and out of cooldown.

`TestReconnectFlap_PreservesDuplicatePRGuarantee` pins this directly: after a full flap has been absorbed to one row, the issue must still be in failure cooldown. `TestReleaseCooldown_WithdrawnOnlyByLeaseBoundResume` additionally pins that a cooldown carrying a real consecutive-failure count cannot be laundered by a resume.

Costs 1 (cooldown) and 5 (`tokenMintedAt`) from #5151's list turn out to be **already handled** by #5322's resume path, which re-mints via `resumeTaskToken` and withdraws the cooldown. What remained was the feed churn, which is what this addresses.

## Observability preserved

#5151 is explicit that absorbing must not become silence:

- The hub-side `[contribute-ws] disconnected` line and the relay's `describeWsClose` output are **untouched and unconditional** — the #5107 instrumentation and the real diagnostic surface.
- `absorbedReconnects` / `AbsorbedReconnects()` makes "this contributor flapped N times" answerable **more cheaply than counting feed rows**, which is what the issue asked for, and without the counting instrument destroying the feed it is counted from.

## What remains unverified — the ingress is NOT cleared

**This does not close #5090.** It removes a false signal and a real lock hazard; it does not prove what cuts the socket ~12s after connect.

What is now known: the 30s figure was an artifact of the hub's own ticker, so **the residual cause should no longer be assumed to be a 30s-periodic timer**. The real disconnects are at 12s and at other intervals, and the previously-observed "burst then calm" shape stands.

Still open, and still infrastructure:

- `service.beta.kubernetes.io/oci-load-balancer-connection-idle-timeout` remains absent — the OCI LB is on its 300s default.
- An nginx **config reload** cuts held WebSockets without restarting the controller pod. The 54-day controller uptime rules out **restarts only**; it does not clear reloads, and it does not clear the OCI LB in front.

The falsifier from #5090 stands unchanged: reconnects inside a single pod's lifetime are real and are not rollouts. What this PR fixes is that the log line everyone was reading as the cause was the hub reporting on a corpse.

Fixes #5151
Refs #5090
