### PR TITLE
📝 docs: operator diagnostics for unpublished agent work and relay redaction scope

### DIFF
--- a/src/docs/hive-open-pr.md
+++ b/src/docs/hive-open-pr.md
@@ -63,6 +63,99 @@ comment on it will fail.
 To confirm, poll the `.result.json` written next to the request file, or simply
 look for the PR.
 
+## Diagnosing a PR request that never opens
+
+When the PR does not appear, the request file's `.result.json` is the record of
+why. It sits next to the request in `/var/run/hive-metrics/pr-requests`, named
+`<request>.result.json`, and on failure carries `"ok": false` with an `error`
+string.
+
+The request file itself is also renamed once it stops being retried, and the
+suffix tells you which kind of failure it was:
+
+| Suffix | Meaning | Retried? |
+| --- | --- | --- |
+| *(none)* | still queued | yes, with backoff |
+| `.failed` | transient failure that never recovered within the give-up horizon | no longer |
+| `.rejected` | a policy gate refused the content — the request or branch must change | no |
+| `.denied` | authorization refused (ACMM write-gate, forge-resistance) | no |
+
+A transient failure backs off exponentially from 30s to a 15-minute ceiling and
+is quarantined as `.failed` only after **24 hours** without success. So a
+freshly failing request is normal-looking for a while: read `.result.json`
+rather than waiting for a rename.
+
+### The 404 that means "your push failed"
+
+Every gate on the PR-open path begins by comparing `base...head`. If the
+agent's branch was never pushed, GitHub answers 404 — and the message used to
+read as though the *branch* were the problem, which sends an operator to
+investigate branch creation. That is the wrong place: the branch is missing
+because the **push** failed.
+
+The watcher now investigates a 404 before reporting it ([#5343](https://github.com/kubestellar/hive/issues/5343),
+fixed in [#5352](https://github.com/kubestellar/hive/pull/5352)). It probes the
+**repository** first, then the **head ref**, and reports one of three distinct
+outcomes. Only a definitive 404 is investigated — a 403, a rate limit, or a 5xx
+keeps its own identity so the existing retry and rate-limit handling still
+recognise it.
+
+**1. The App cannot see the repository.** The repo probe 404s:
+
+> cannot open a PR on `<owner>/<repo>`: this hive's GitHub App cannot see that repository (404). Check that the App is installed on it and that the installation grants contents+pull_requests access — this is NOT a problem with branch `<branch>`
+
+The branch is not implicated at all. Fix the App installation — see
+[GitHub App setup](github-app-setup.md).
+
+**2. The repository is visible but the head ref is genuinely absent.** This is
+the push-authentication case, and the error says so:
+
+> branch `<branch>` was never pushed to `<owner>/<repo>` — the commits exist only in the agent's working copy. This is almost always a PUSH AUTHENTICATION failure, not a branch-creation problem
+
+It names the two causes to check, in order:
+
+1. **The git credential helper is not reachable from the agent's UID.**
+   `su -s /bin/sh hive-<agent> -c 'git config --get-regexp credential'` must
+   list `/usr/local/bin/git-credential-hive.sh`. It is wired system-wide in
+   `/etc/gitconfig` precisely because agents do not share the dev user's
+   `$HOME`.
+2. **The agent's scoped token file is absent or unreadable by that UID.** The
+   path is in `$HIVE_AGENT_TOKEN_CACHE`. Check readability only — never print
+   its contents.
+
+This stays a **retryable** error rather than a policy rejection: once the agent
+pushes the branch, the same request becomes valid and succeeds on retry. That
+is exactly what the bounded retry is for, so fix the credential problem and let
+the queued request land — you do not need to re-issue it.
+
+**3. The head ref exists, so the 404 was about something else.** Usually the
+base:
+
+> GitHub returned 404 although branch `<branch>` exists — check that the base branch `<base>` exists on the remote
+
+Note the watcher deliberately does **not** try to read the agent's git state or
+test the credential helper itself: it runs in the hive process, not in the
+agent's UID, so any such check would answer a different question than the one
+that failed. It names the causes; you verify them from the agent's UID.
+
+### The log line to grep for
+
+Case 2 is also logged at ERROR on its own line, because it is work an agent
+already completed and cannot publish — and it is invisible in the fleet view,
+since the agent's session ended healthy:
+
+```sh
+kubectl -n hive logs deploy/hive | grep 'pr-request watcher'
+```
+
+Look for `head branch is not on the remote — the agent's push did not
+authenticate`, which carries `repo`, `head`, `agent`, and the full `diagnosis`.
+
+For the broader symptom — an agent that completed a session with no branch and
+no PR, and how to tell a credential-helper failure from a mid-task token
+refresh failure — see
+[Troubleshooting: an agent session completes but no branch or PR appears](troubleshooting.md#an-agent-session-completes-but-no-branch-or-pr-appears).
+
 ## Where things live
 
 | Path | What |

--- a/src/docs/security.md
+++ b/src/docs/security.md
@@ -47,7 +47,7 @@ The relay applies `redactTokens()` to agent output before it leaves the host: to
 | PEM private-key blocks | yes | **no** |
 | Backend provider credentials | no | Pi backend only |
 
-Two further differences worth knowing:
+Three further differences worth knowing:
 
 - **Minimum match length.** The Go patterns require 10 or more characters after the prefix; the relay requires 36 or more. A short or truncated token-shaped string is redacted by Go and passed through by the relay. The relay's bound is deliberately `{36,}` rather than `{36}` so a *longer* token is not redacted only in its first 36 characters, leaking its tail ([#4267](https://github.com/kubestellar/hive/issues/4267)).
 - **Character class.** Go accepts `[A-Za-z0-9_]` after every prefix. The relay accepts only `[A-Za-z0-9]` for the `gh*_` prefixes (underscores allowed for `github_pat_` alone).

--- a/src/docs/security.md
+++ b/src/docs/security.md
@@ -4,6 +4,8 @@
 
 Hive wraps its structured `slog` handler with `pkg/logscrub`. The wrapper redacts recognized token-like strings before log records reach the underlying handler.
 
+**This covers the Go process only.** The contributor relay is a separate Node process and does not use `pkg/logscrub` at all — it carries its own, independently written redaction. The two are described separately below, because they do not cover the same things. See [Two redaction layers, not one](#two-redaction-layers-not-one).
+
 ## What is scrubbed
 
 The current redaction pattern replaces matches with `[REDACTED]` in:
@@ -15,16 +17,52 @@ The current redaction pattern replaces matches with `[REDACTED]` in:
 
 Recognized patterns are:
 
-- GitHub token prefixes `ghs_`, `ghp_`, `gho_`, and `github_pat_` followed by at least ten token characters.
+- GitHub token prefixes `ghs_`, `ghp_`, `gho_`, `ghu_`, `ghr_`, and `github_pat_` followed by at least ten token characters.
 - JWT-like strings beginning with `eyJ` and containing three base64url segments.
+- Hive canary values (`HIVE-CANARY-` followed by 48 hex characters).
+- AWS access key IDs (`AKIA`/`ASIA` followed by 16 uppercase alphanumerics).
+- `Bearer` authorization values of 16 characters or more.
+- PEM private-key blocks — RSA, EC, OpenSSH, DSA, encrypted, and PGP private-key blocks — redacted whole, including multi-line bodies.
+
+The GitHub and JWT shapes live in the exported `logscrub.TokenPattern`, which other packages (for example `pkg/ioscan`) reuse rather than duplicating; keep that the single source of truth.
 
 The cost endpoint also redacts the configured gateway API key from native-cost probe errors before returning the error text.
+
+## Two redaction layers, not one
+
+`pkg/logscrub` protects the **Go process**. The contributor relay (`bin/contributor-relay.sh`) is a **separate Node process** that never loads it, and redacts on its own with a `redactTokens()` function. Both exist and both work — but they are separate implementations with separate pattern lists, and reading only the section above would leave you assuming a coverage the relay does not have.
+
+The relay applies `redactTokens()` to agent output before it leaves the host: to the captured tmux tail, and to the combined stdout/stderr tail of a headless task. See [Contributor relay](contributor-relay.md).
+
+### Where they differ
+
+| Shape | `pkg/logscrub` (Go) | relay `redactTokens()` (Node) |
+| --- | :---: | :---: |
+| `ghs_` `ghp_` `gho_` `ghu_` `ghr_` | yes | yes |
+| `github_pat_` | yes | yes |
+| JWTs (`eyJ…` triples) | yes | **no** |
+| `HIVE-CANARY-…` | yes | **no** |
+| AWS `AKIA`/`ASIA` keys | yes | **no** |
+| `Bearer <value>` | yes | **no** |
+| PEM private-key blocks | yes | **no** |
+| Backend provider credentials | no | Pi backend only |
+
+Two further differences worth knowing:
+
+- **Minimum match length.** The Go patterns require 10 or more characters after the prefix; the relay requires 36 or more. A short or truncated token-shaped string is redacted by Go and passed through by the relay. The relay's bound is deliberately `{36,}` rather than `{36}` so a *longer* token is not redacted only in its first 36 characters, leaking its tail ([#4267](https://github.com/kubestellar/hive/issues/4267)).
+- **Character class.** Go accepts `[A-Za-z0-9_]` after every prefix. The relay accepts only `[A-Za-z0-9]` for the `gh*_` prefixes (underscores allowed for `github_pat_` alone).
+- **Placeholder text.** Go writes `[REDACTED]`; the relay writes `<prefix>_***REDACTED***`, keeping the prefix visible. Alerting that greps for one will not match the other.
+
+When the relay's backend is Pi, `redactTokens()` additionally strips the configured provider credential values by literal substring match — a mechanism neither layer applies to GitHub tokens.
+
+**The practical reading:** GitHub token material is covered on both paths. Everything else in the Go list — JWTs, canaries, AWS keys, `Bearer` headers, private keys — is redacted in the hive's own logs and **not** in relay-forwarded agent output. If an agent's terminal prints a JWT or a private key, the relay will forward it.
 
 ## Limits
 
 - Scrubbing is pattern-based, not a general secret scanner. A secret with another shape can still appear if code logs it directly.
 - Non-string slog values are passed through unchanged unless they are inside a group containing string attributes.
-- Redaction happens in the Hive logging path. Data written by external tools, agent CLIs, terminal transcripts, or third-party proxies is not automatically covered unless it flows through Hive's scrubbed logger.
+- `pkg/logscrub` redaction happens in the Hive logging path. Data written by external tools, agent CLIs, or third-party proxies is not automatically covered unless it flows through Hive's scrubbed logger. Agent terminal output forwarded by the contributor relay is a partial exception — it is redacted, but by the relay's own narrower pattern list, not by `pkg/logscrub`.
+- The two layers can drift. They are separate implementations with no shared source of truth, so a pattern added to one does not appear in the other; the table above is accurate as of writing and worth re-checking against both implementations before relying on it.
 - False positives are replaced with `[REDACTED]`; there is no runtime allow-list or custom pattern configuration today.
 
 ## Operator checks

--- a/src/docs/troubleshooting.md
+++ b/src/docs/troubleshooting.md
@@ -129,6 +129,90 @@ Liveness is judged by the governor's in-process health check, so an agent that k
 1. **Read the work counts, not just liveness.** If an agent reports "Issues triaged: 0" cycle after cycle in the logs, that is the signal — `kubectl -n hive logs deploy/hive | grep <agent>` or attach to the session.
 2. **Cross-check an external surface.** Confirm the effect the agent is supposed to produce (a GitHub API query for the PRs/issues it claims to have handled) rather than trusting its self-reported state.
 
+## An agent session completes but no branch or PR appears
+
+The agent ran, the session ended cleanly, the fleet view shows it healthy — and there is no PR and no branch on the remote. Often the agent's own summary says so plainly, in words like "branch committed locally but push failed due to git authentication issue."
+
+This is not the agent deciding no work was needed. The work was done; it could not be published. The fleet view cannot tell you which, because from the governor's point of view the session *is* healthy — the agent hit an auth error, correctly refused to manipulate git credentials, and wrote an honest summary. See [kubestellar/hive#5343](https://github.com/kubestellar/hive/issues/5343).
+
+There are two distinct causes with the same symptom, and they are distinguishable.
+
+### First: confirm the work exists and is unpublished
+
+```sh
+# Does the branch exist on the remote at all?
+gh api "repos/<owner>/<repo>/git/ref/heads/<branch>" 2>&1 | head -3
+
+# Did the agent commit it locally? (per-agent HOME, not the dev user's)
+ls -d /data/home/agents/<agent>/* 2>/dev/null
+```
+
+A 404 from the first command plus commits in the agent's working copy is this scenario. If the branch *is* on the remote, the problem is downstream — go to [`hive-open-pr`](hive-open-pr.md#diagnosing-a-pr-request-that-never-opens) instead.
+
+### Cause 1 — the credential helper is not reachable from the agent's UID
+
+The helper is invoked per-UID, and agents do **not** share the dev user's `$HOME`: each per-agent UID runs with its own `$HOME` under `/data/home/agents/<name>`, which has no `.gitconfig`. `git config --global` writes to the *caller's* `$HOME`, so wiring the helper that way makes it invisible to every agent. The helper is therefore wired **system-wide in `/etc/gitconfig`**, written from the entrypoint's root phase — see [#5343](https://github.com/kubestellar/hive/issues/5343) for the original defect and [#5352](https://github.com/kubestellar/hive/pull/5352) for the fix.
+
+Check the layer that actually matters, from a process with no per-user config — this is the same probe the entrypoint runs at boot:
+
+```sh
+# Inside the hive container. Empty output = the helper is invisible to agents.
+HOME=/nonexistent XDG_CONFIG_HOME=/nonexistent \
+  git config --get-regexp '^credential\.' | grep git-credential-hive.sh
+
+# Or ask as the agent UID directly:
+su -s /bin/sh hive-<agent> -c 'git config --get-regexp credential'
+
+# The file that supplies it — must exist and be world-readable (0644).
+ls -l /etc/gitconfig
+```
+
+Each should list `/usr/local/bin/git-credential-hive.sh`. The boot log records the same verdict, so you can also just read it back:
+
+```sh
+kubectl -n hive logs deploy/hive | grep 'git credential helper'
+```
+
+- `git credential helper VERIFIED reachable without a per-user .gitconfig` — this cause is ruled out. Go to cause 2.
+- `WARN: git credential helper is NOT reachable ...` — this is your cause. Every agent on this hive will commit branches it cannot push. Restart the hive so the entrypoint's root phase rewrites `/etc/gitconfig`; if that phase never ran (a boot that could not become root), only the dev user's global config exists and no agent will ever push.
+
+Also confirm the agent's own scoped token is present and readable by its UID — the helper needs it:
+
+```sh
+su -s /bin/sh hive-<agent> -c 'test -r "$HIVE_AGENT_TOKEN_CACHE" && echo readable || echo MISSING'
+```
+
+Never print the file's contents.
+
+### Cause 2 — the credential went stale mid-task (silent refresh failure)
+
+Contributor-relay tasks are pushed with a scoped token the hub re-mints periodically, a few minutes before its TTL expires. When a re-mint **fails**, the hub logs a warning and keeps the old token; the relay is told nothing. See [kubestellar/hive#5447](https://github.com/kubestellar/hive/issues/5447).
+
+The signature is different from cause 1, and it is a timing signature:
+
+| | Cause 1 (helper unreachable) | Cause 2 (refresh failed) |
+| --- | --- | --- |
+| Which agents | **all** agents on the hive | usually one long-running task |
+| When the push fails | the **first** push of any task | roughly an hour in, after earlier pushes in the *same* task succeeded |
+| Boot-log probe | `WARN: ... NOT reachable` | `VERIFIED reachable` |
+| Where it is recorded | entrypoint boot log | hub log only — nothing agent-side |
+
+So: **a task whose earlier pushes worked and whose later ones did not is cause 2, not cause 1.** Confirm from the hub log:
+
+```sh
+kubectl -n hive logs deploy/hive | grep -iE 'token.*(refresh|mint)'
+```
+
+A short task that never pushes successfully at all is cause 1.
+
+### If neither fits
+
+Read what the PR-request watcher itself concluded. It probes the repository and then the head ref before blaming a push, and writes its verdict to the request's result file — the shapes and where to find them are in [`hive-open-pr`](hive-open-pr.md#diagnosing-a-pr-request-that-never-opens).
+
+```sh
+kubectl -n hive logs deploy/hive | grep 'pr-request watcher'
+```
+
 ## An agent says "Please run /login" but logging in changes nothing
 
 Check whether the same line carries **`API Error: 403`**. If it does, the agent is


### PR DESCRIPTION
Fixes #5468
Fixes #5469
Fixes #5470

Three adjacent documentation gaps in `src/docs/`, all operator-facing, all docs-only.

## `troubleshooting.md` — "An agent session completes but no branch or PR appears" (#5468)

The doc had nothing for this: zero mentions of "completes work", "no PR", "push failed", or "credential helper". An operator whose agent finishes a task and produces no PR had nothing to consult — and the symptom is indistinguishable from an agent that decided no work was needed, because the fleet view is *correct*: the agent hit an auth error, refused to manipulate git credentials, wrote an honest summary, and ended healthy.

Two causes produce the identical symptom, and the new section is built around telling them apart rather than listing possibilities:

| | Cause 1 — helper unreachable (#5343/#5352) | Cause 2 — silent refresh failure (#5447) |
| --- | --- | --- |
| Which agents | **all** agents on the hive | usually one long-running task |
| When the push fails | the **first** push of any task | ~an hour in, after earlier pushes in the *same* task worked |
| Boot-log probe | `WARN: … NOT reachable` | `VERIFIED reachable` |
| Recorded where | entrypoint boot log | hub log only — nothing agent-side |

The entrypoint already runs the exact probe that settles it (`HOME=/nonexistent … git config --get-regexp '^credential\.'`) and logs a `VERIFIED` / `WARN` verdict at boot, so the section leads with reading that back — one grep, and cause 1 is confirmed or eliminated.

## `hive-open-pr.md` — "Diagnosing a PR request that never opens" (#5469)

The doc matched credential/token/auth six times, but every hit was about **authorship** (App bot vs the agent's CLI login). There was no credential-*failure* diagnostic, and the "It is asynchronous, by design" section said to poll `.result.json` without saying what a failure looks like in it.

Now documented from `src/pkg/github/pr_request_missing_head.go` and `pr_request_watcher.go`:

- the `.result.json` failure shape, and the `.failed` / `.rejected` / `.denied` quarantine suffixes with which are retried
- the retry policy that makes a freshly-failing request look normal for a while — 30s exponential to a 15m ceiling, quarantined only after **24h**
- the three outcomes a 404 on `base...head` now resolves to: **repo invisible to the App** (branch not implicated), **head ref genuinely unpushed** (reported as a push-authentication failure with the two credential causes to check in order), and **head exists so the 404 was about the base**
- that case 2 is **retryable, not a rejection** — fix the credential and the already-queued request lands on retry; no need to re-issue
- the ERROR log line to grep, and why the watcher deliberately does *not* probe the agent's git state itself (it runs in the hive process, not the agent's UID, so it would be answering a different question than the one that failed)

## `security.md` — logscrub scope corrected (#5470)

The page said Hive wraps `slog` with `pkg/logscrub` and stopped there. True for the Go process — but the contributor relay is a **separate Node process** that never loads it (`grep logscrub bin/` returns nothing) and redacts independently via its own `redactTokens()`. A reader reasonably concluded relay logs were covered by `pkg/logscrub`. They are covered by something else, with its own pattern list and its own gaps.

Both layers are now described, with an explicit divergence table.

### Two corrections to the issue's premise

**The documented pattern list was stale.** It named four GitHub prefixes. `pkg/logscrub` actually also covers `ghu_`, `ghr_`, `HIVE-CANARY-…`, AWS `AKIA`/`ASIA` key IDs, `Bearer` values, and PEM private-key blocks (RSA/EC/OpenSSH/DSA/encrypted/PGP).

**The relay is the narrower layer, not the broader one.** #5470 argued the relay covers *more* (five prefixes vs four) and that the Limits note was therefore misleading in the relay's favour. With the real Go list in hand it goes the other way: both cover the same six GitHub prefixes, and the relay covers **nothing else** — no JWTs, no canaries, no AWS keys, no `Bearer`, no private keys. It also requires 36+ trailing characters where Go requires 10+, so short or truncated token-shaped strings pass the relay and are caught by Go.

So the fix is the opposite of the one requested: rather than reassuring operators that the relay has them covered, the page now states plainly that **GitHub token material is covered on both paths and everything else in the Go list is not covered in relay-forwarded agent output**. If an agent's terminal prints a JWT or a private key, the relay forwards it.

Also noted: the placeholders differ (`[REDACTED]` vs `<prefix>_***REDACTED***`), so alerting that greps for one will not match the other — and the two lists can drift, since they share no source of truth.

## Notes

- Docs-only. No code, no shared files — no overlap with the concurrent work on `contribute_ws.go` / relay (#5090/#5151), relay token lifecycle (#5447), or the hub reaper (#5328). The #5447 reference here is descriptive only.
- All claims read off the implementations rather than the issue text; the divergence table was built by comparing `src/pkg/logscrub/handler.go` against `redactTokens()` in `bin/contributor-relay.sh` directly.
- No token values, real or redacted-from-logs — placeholders only. No internal hostnames.
- All cross-links are `src/docs/*.md` relative paths (the link-checked tree) with anchors verified against the headings they target.