### PR TITLE
📝 Correct orphaned-pod reaper root-cause note with measured evidence

### DIFF
--- a/src/pkg/hub/orphaned_pod_reaper.go
+++ b/src/pkg/hub/orphaned_pod_reaper.go
@@ -20,23 +20,42 @@ import (
 //   - the namespace still had exactly 1 healthy Running pod, so the live spoke
 //     was unaffected in every case.
 //
-// That is the fingerprint of a node disappearing without draining. The API
-// server records the deletion and waits for the kubelet to confirm it; the
-// kubelet is gone, so confirmation never arrives, and because no finalizer and
-// no controller owns the remaining work the object persists forever. The
-// distribution — 15 namespaces with 1-4 orphans each rather than one bad
-// namespace with 27 — argues for a recurring cluster-level event (spot
-// reclaim, autoscaler scale-down, or a node lifecycle event) rather than a
-// single misbehaving spoke.
+// The ORIGINAL reading of that signature was "a node disappeared without
+// draining": the API server records the deletion and waits for the kubelet to
+// confirm it, the kubelet is gone, so confirmation never arrives, and with no
+// finalizer and no owning controller the object persists forever. That reading
+// was inferred from absent spec fields rather than measured, and MEASUREMENT
+// HAS SINCE DISPROVEN IT. Recorded here because the wrong cause is the kind of
+// thing that gets re-derived from the same signature by the next reader:
 //
-// WHY A REAPER IS THE RIGHT FIX EVEN THOUGH IT TREATS THE SYMPTOM. Finding and
-// fixing whatever removes nodes ungracefully is issue #5328 item 1 and is NOT
-// this lane. But ungraceful node loss can always recur — it is a property of
-// the infrastructure, not a bug that stays fixed — so a reaper remains useful
-// after the root cause lands. What makes the accumulation expensive is not any
-// single orphan but that NOTHING sweeps them: the condition is self-
-// perpetuating, so the count only ever grows between manual interventions, and
-// it grew for three weeks with no alert.
+//   - No node was lost in the orphan window. Every node on the affected
+//     cluster has been continuously Running with no Machine ever deleted, and
+//     the newest node predates the oldest orphan by weeks. There is no
+//     autoscaler and no spot/preemptible capacity in play.
+//   - Orphan onsets arrive in tight BATCHES — several within the same second,
+//     repeatedly, across ten separate days. Node loss would tie a batch to one
+//     node; these batches span namespaces spread over many nodes.
+//   - The largest batches land inside the hive AUTO-UPGRADE window (see
+//     autoUpgradeDailyHour in upgrade_schedule.go), and per-namespace
+//     ReplicaSet history shows one new ReplicaSet per namespace per day at
+//     that same moment.
+//
+// The actual mechanism is ORDINARY ROLLING REDEPLOY, not node loss. The daily
+// auto-upgrade re-applies each hosted spoke Deployment; the RollingUpdate
+// replaces the pod; and occasionally the outgoing pod's delete is never
+// confirmed, leaving exactly this signature. That is why the orphans recur on
+// a healthy, static cluster, and why they concentrate in the namespaces that
+// get redeployed most often.
+//
+// WHY A REAPER REMAINS THE RIGHT FIX. The trigger is a routine, deliberate,
+// recurring operation that the fleet depends on — not an infrastructure fault
+// to be engineered away. Slowing or suppressing redeploys to avoid a rare
+// unconfirmed delete would trade a cosmetic accounting problem for a real loss
+// of upgrade cadence. What makes the accumulation expensive is not any single
+// orphan but that NOTHING sweeps them: the condition is self-perpetuating, so
+// the count only ever grows between manual interventions, and it grew for
+// three weeks with no alert. A sweep is the proportionate response, and it
+// stays correct regardless of which delete goes unconfirmed or why.
 //
 // IMPACT. Orphans hold their scheduler slot until forcibly removed, and
 // anything counting pods per namespace sees phantom replicas — a namespace


### PR DESCRIPTION
## What

Doc-only correction to `src/pkg/hub/orphaned_pod_reaper.go`. The reaper's header explained the orphan signature as **"a node disappearing without draining"**, naming spot reclaim, autoscaler scale-down, or a node lifecycle event as the likely trigger. That explanation was inferred from *absent spec fields* rather than measured. Measurement against the affected cluster disproves it.

## The measurement

Item 1 of #5328 asked for the root cause, and named the concrete test: correlate node deletion timestamps against orphan `deletionTimestamp`s. Done, and the node-loss hypothesis fails on three independent counts.

**No node was lost in the orphan window.** Every node on the affected cluster has been continuously `Running`, with no `Machine` ever carrying a `deletionTimestamp`. The newest node predates the oldest orphan by weeks, node `Ready` conditions show no flap during the window, and the cluster runs no autoscaler and no spot/preemptible capacity. There is simply no node-loss event to correlate against.

**Orphan onsets arrive in tight batches that span many nodes.** Onsets cluster several-within-the-same-second — nine namespaces at `22:18:42`–`22:18:50`, three at `01:51:13`–`01:51:15` — repeated across ten separate days. Ungraceful node loss ties a batch to *one* node. These batches span namespaces spread across many different nodes, which is a per-namespace signature, not a per-node one.

**The batches land in the auto-upgrade window.** The largest batches fall at `17:02`–`17:03` UTC, which is `autoUpgradeDailyHour` (1pm ET) from `upgrade_schedule.go`. Per-namespace ReplicaSet history shows exactly one new ReplicaSet per namespace per day at that same moment.

## The actual mechanism

Ordinary rolling redeploy. The daily auto-upgrade re-applies each hosted spoke Deployment, the `RollingUpdate` (`maxSurge: 1`, `maxUnavailable: 0`, `replicas: 1`) replaces the pod, and occasionally the outgoing pod's delete is never confirmed — leaving `deletionTimestamp` set, `finalizers: []`, `phase != Running`. That is the observed signature exactly.

This explains what node loss could not: why orphans recur on a completely healthy, static cluster, and why they concentrate in the most frequently redeployed namespaces.

## What is deliberately NOT changed

The trigger is a routine, deliberate operation the fleet depends on, not an infrastructure fault to engineer away. **No production pod scheduling is touched** — no PodDisruptionBudget, no `safe-to-evict` annotation, no `tolerationSeconds` change:

- A **shorter `tolerationSeconds`** would make orphans appear *faster*, not fewer. It targets a node-loss path that measurement shows is not active here.
- **`safe-to-evict: false`** changes autoscaler behaviour fleet-wide, and the affected cluster runs no autoscaler at all. It would be a fleet-wide change addressing nothing measured.
- A **PDB on a `replicas: 1` Deployment** can block legitimate drains outright, converting a cosmetic accounting problem into a real operational hazard.

Slowing or suppressing redeploys to avoid a rare unconfirmed delete would trade a cosmetic accounting problem for a real loss of upgrade cadence. The sweep from #5345 is the proportionate response, and it stays correct regardless of which delete goes unconfirmed or why.

The reaper predicate is **unchanged and unloosened**. No behaviour change, no new credentials, no widening of the hub's blast radius.

## Why this is worth a commit

The wrong cause is exactly the kind of thing that gets re-derived from the same signature by the next reader — and would send them looking for a node-lifecycle bug that does not exist. The corrected note records both the disproof and the real mechanism at the place the next reader will look.

Marked `Refs` rather than `Fixes`: this establishes the root cause and closes item 1's investigation, but ships no behavioural change. Retaining `#5328` for the maintainer's call on closure.

Refs #5328