### PR TITLE
🐛 Signal failed token re-mints to the relay and read token_expires_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ## Unreleased
 
+### Fixed
+
+- A contributor token re-mint that fails is no longer invisible to the relay, and the `token_expires_at` the hub already sends is finally read ([#5447](https://github.com/kubestellar/hive/issues/5447)). Refresh itself was working and is unchanged — the 50-minute re-mint against a 55-minute TTL still re-arms each cycle, so a 4-hour task never loses push access. What was missing was what happens when a mint *fails*: the hub logged a warning and told the relay nothing, so the first observable symptom was a push that started failing roughly an hour into a long task, surfaced to the agent as a generic authentication error. The hub now sends a `token_refresh_failed` message — a reason string, never token material — from both the heartbeat and the task-resume paths, advertised in the `auth_ok` capability set, and the relay logs it against the task it belongs to. Separately, the relay now compares `token_expires_at` against the clock on each progress tick and warns when the credential is within five minutes of expiry or already past it, more pointedly when a failed renewal was also reported. Both halves are advisory by design: nothing is revoked, no task is failed, and **no push is refused** — `token_expires_at` is the hub's wall clock read on the relay's, so refusing work on a few minutes of clock skew would be worse than the current behavior. GitHub's answer to the actual call remains the authority; these changes only ensure that when it does fail, the cause is already named in the log. A relay that ignores the new message behaves exactly as before.
+
 ## 2026-09-01 (v4.0.1)
 
 ### Added

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -341,6 +341,80 @@ let seq = 0;
 let currentTask = null;
 let progressInterval = null;
 let tokenExpiresAt = null;
+// tokenRefreshFailedAt records when the hub last told us a mid-task re-mint
+// FAILED (a token_refresh_failed, kubestellar/hive#5447). Null means "no known
+// refresh problem"; a successful token_refresh clears it, because a fresh
+// credential resolves the condition. It exists so the expiry warning below can
+// distinguish "the hub is quiet and our clock may simply be off" from "the hub
+// told us it could not renew this credential", which is the difference between a
+// guess and a diagnosis.
+let tokenRefreshFailedAt = null;
+
+// TOKEN_EXPIRY_WARN_MS is how far ahead of expiry the relay starts warning. It
+// is one full progress interval plus a margin, so a task that is about to lose
+// push access says so at least one tick BEFORE the first push can fail, rather
+// than reporting it afterwards.
+const TOKEN_EXPIRY_WARN_MS = 5 * 60 * 1000;
+// TOKEN_EXPIRY_WARN_INTERVAL_MS throttles the warning so a long task past expiry
+// logs periodically instead of on every single progress tick.
+const TOKEN_EXPIRY_WARN_INTERVAL_MS = 10 * 60 * 1000;
+let lastTokenExpiryWarnAt = 0;
+
+// tokenLifetimeStatus turns the hub-supplied token_expires_at into the relay's
+// own read of its credential: how long is left, whether we are inside the warning
+// window, and whether the hub has reported a failed renewal.
+//
+// It is PURE and clock-injectable so the expiry logic can be tested without
+// waiting an hour, and it deliberately reports rather than decides — see
+// warnOnTokenExpiry() for why this only ever warns.
+function tokenLifetimeStatus(now = Date.now()) {
+  if (!tokenExpiresAt) {
+    return { known: false, expired: false, expiring: false, remainingMs: null, refreshFailed: tokenRefreshFailedAt !== null };
+  }
+  const remainingMs = tokenExpiresAt - now;
+  return {
+    known: true,
+    expired: remainingMs <= 0,
+    expiring: remainingMs <= TOKEN_EXPIRY_WARN_MS,
+    remainingMs,
+    refreshFailed: tokenRefreshFailedAt !== null,
+  };
+}
+
+function formatDuration(ms) {
+  const abs = Math.abs(ms);
+  const mins = Math.floor(abs / 60000);
+  const secs = Math.floor((abs % 60000) / 1000);
+  return mins > 0 ? `${mins}m${secs}s` : `${secs}s`;
+}
+
+// warnOnTokenExpiry logs — and ONLY logs — when the task's credential is at or
+// past its advertised expiry (kubestellar/hive#5447).
+//
+// It does NOT refuse the push, and that is deliberate. The relay's clock and the
+// hub's are independent; tokenExpiresAt is the HUB's wall-clock stamp read on the
+// relay's, so a machine with a few minutes of skew would refuse work on a
+// perfectly valid credential. Refusing on a bad clock is strictly worse than
+// today's behaviour, where the token simply works. The authority on whether a
+// token is good remains GitHub's answer to the actual call; this turns the
+// resulting failure from an unexplained auth error into a named, already-logged
+// condition — which is the whole point of the issue.
+//
+// Throttled, and never touches the token itself.
+function warnOnTokenExpiry(now = Date.now()) {
+  const status = tokenLifetimeStatus(now);
+  if (!status.known || !status.expiring) return null;
+  if (now - lastTokenExpiryWarnAt < TOKEN_EXPIRY_WARN_INTERVAL_MS) return null;
+  lastTokenExpiryWarnAt = now;
+  const cause = status.refreshFailed
+    ? ' — the hub reported that it could not renew this credential, so pushes may fail with a generic auth error'
+    : '';
+  const msg = status.expired
+    ? `GitHub token expired ${formatDuration(status.remainingMs)} ago${cause}`
+    : `GitHub token expires in ${formatDuration(status.remainingMs)}${cause}`;
+  console.warn(msg);
+  return msg;
+}
 
 function nextSeq() { return ++seq; }
 
@@ -2383,6 +2457,11 @@ function relaunchCLI() {
 function dropTaskCredential() {
   try { fs.unlinkSync(GH_TOKEN_CACHE); } catch (_) {}
   tokenExpiresAt = null;
+  // The credential this failure was ABOUT is gone, so the condition dies with
+  // it — otherwise a stale "refresh failed" would colour the next task's
+  // warnings (#5447).
+  tokenRefreshFailedAt = null;
+  lastTokenExpiryWarnAt = 0;
 }
 
 // stopAgentForTaskExit ends the AGENT, not just the bookkeeping, when a task
@@ -3011,6 +3090,13 @@ function maybeSendAutonomyNudge(tmuxLines) {
 function progressTick() {
   lastProgressTick = Date.now();
   if (!currentTask) return;
+
+  // Surface the credential's remaining lifetime BEFORE the grace-period return
+  // and before any of the pane judging below, so a token that is about to lapse
+  // is reported on its own schedule rather than only on ticks that happen to get
+  // as far as a progress report (#5447). Warn-only — see warnOnTokenExpiry.
+  warnOnTokenExpiry();
+
   if (Date.now() - taskAssignedAt < TASK_GRACE_PERIOD_MS) return;
 
   // #4117: re-detect the running model each tick so a mid-session model switch
@@ -3435,6 +3521,9 @@ function handleMessage(data, hub) {
       if (msg.github_token) {
         injectGhToken(msg.github_token);
         tokenExpiresAt = msg.token_expires_at ? new Date(msg.token_expires_at).getTime() : null;
+        // Fresh task, fresh credential: no inherited refresh failure (#5447).
+        tokenRefreshFailedAt = null;
+        lastTokenExpiryWarnAt = 0;
       }
       // TASK_FILE is observability/debug state with no reader that needs the
       // credential; the live token's one legitimate on-disk home is the 0600
@@ -3468,9 +3557,36 @@ function handleMessage(data, hub) {
       if (msg.github_token) {
         injectGhToken(msg.github_token);
         tokenExpiresAt = msg.token_expires_at ? new Date(msg.token_expires_at).getTime() : null;
+        // A delivered credential resolves any earlier renewal failure, and
+        // re-arms the expiry warning for the new token's own window (#5447).
+        tokenRefreshFailedAt = null;
+        lastTokenExpiryWarnAt = 0;
         console.log('GitHub token refreshed');
       }
       break;
+
+    // token_refresh_failed (kubestellar/hive#5447): the hub could not re-mint
+    // this task's credential. The token we hold is still the OLD one and stays
+    // installed — the hub retries on its next heartbeat — so there is nothing to
+    // drop and nothing to fail here. Recording it is the entire point: without
+    // it, the first evidence of a stale credential is a push failing about an
+    // hour into a long task, surfaced to the agent as a generic auth error
+    // (#5343's misleading-symptom class).
+    case 'token_refresh_failed': {
+      if (!currentTask || currentTaskHub() !== hub) {
+        console.log(`Ignoring token_refresh_failed from ${hub.url} — it does not own the active task`);
+        break;
+      }
+      tokenRefreshFailedAt = Date.now();
+      const status = tokenLifetimeStatus();
+      const remaining = status.known
+        ? (status.expired
+          ? `the current token expired ${formatDuration(status.remainingMs)} ago`
+          : `the current token expires in ${formatDuration(status.remainingMs)}`)
+        : 'the current token has no known expiry';
+      console.error(`GitHub token refresh FAILED for ${taskKey(currentTask)}: ${msg.reason || 'no reason given'} — ${remaining}. Pushes may fail with a generic auth error until the hub renews it.`);
+      break;
+    }
 
     case 'task_revoke':
       if (!currentTask) {
@@ -3699,6 +3815,9 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     handleMessage,
     injectGhToken,
     GH_TOKEN_CACHE,
+    tokenLifetimeStatus,
+    warnOnTokenExpiry,
+    TOKEN_EXPIRY_WARN_MS,
     tmuxSendKeys,
     flushPendingTask,
     relaunchCLI,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -5513,6 +5513,171 @@ test('#5376 recordChromeIdleTick fires only after the full consecutive window', 
 });
 
 // ---------------------------------------------------------------------------
+// kubestellar/hive#5447 — a failed re-mint must be visible to the relay, and
+// token_expires_at must actually be read.
+//
+// Both halves were plumbing that carried no effect: maybeRefreshToken() logged
+// hub-side and told the relay nothing, so a stale credential first showed up as
+// a push failing about an hour into a long task; and tokenExpiresAt was
+// assigned in two places and never compared against anything.
+//
+// These assert OBSERVABLE behaviour (#5388): that a simulated mint failure
+// produces relay-visible output naming the condition, and that the expiry check
+// actually fires on a stale token rather than merely being reachable.
+// ---------------------------------------------------------------------------
+
+// Drives a token_refresh carrying an expiry, so a test starts from a relay that
+// genuinely holds a credential with a known lifetime.
+function refreshToken(relay, expiresInMs) {
+  relay.handleMessage(JSON.stringify({
+    type: 'token_refresh',
+    github_token: 'ghs_fake_test_token',
+    token_expires_at: new Date(Date.now() + expiresInMs).toISOString(),
+  }));
+}
+
+test('#5447 a hub-reported refresh failure is logged against the task, not swallowed', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  const origError = console.error;
+  const errors = [];
+  console.error = (...args) => { errors.push(args.join(' ')); };
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-refresh-fail');
+    refreshToken(relay, 55 * 60 * 1000);
+    relay.handleMessage(JSON.stringify({
+      type: 'token_refresh_failed',
+      reason: 'mint failed, will retry on the next heartbeat',
+    }));
+    // The whole point of the issue: the relay must name the CREDENTIAL as the
+    // problem. Before this change nothing was emitted at all — the message type
+    // fell through handleMessage's switch unhandled.
+    const named = errors.find(e => e.includes('token refresh FAILED'));
+    assert.ok(named, 'a failed re-mint produced no relay-visible signal');
+    assert.ok(named.includes('foo/bar#421'), 'the failure was not logged against the task it belongs to');
+    assert.ok(named.includes('mint failed'), 'the hub-supplied reason did not reach the log');
+  } finally {
+    console.error = origError;
+    teardown(relay);
+  }
+});
+
+test('#5447 a refresh failure for a task we do not own is ignored', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    relay.setCliReady(true);
+    // No active task: the message must not be recorded against nothing.
+    relay.handleMessage(JSON.stringify({ type: 'token_refresh_failed', reason: 'mint failed' }));
+    assert.strictEqual(relay.tokenLifetimeStatus().refreshFailed, false,
+      'a refresh failure with no active task was recorded anyway');
+  } finally { teardown(relay); }
+});
+
+test('#5447 a later successful refresh clears the failure condition', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-refresh-recover');
+    refreshToken(relay, 55 * 60 * 1000);
+    relay.handleMessage(JSON.stringify({ type: 'token_refresh_failed', reason: 'mint failed' }));
+    assert.strictEqual(relay.tokenLifetimeStatus().refreshFailed, true,
+      'the failure was not recorded in the first place');
+    refreshToken(relay, 55 * 60 * 1000);
+    assert.strictEqual(relay.tokenLifetimeStatus().refreshFailed, false,
+      'a delivered credential must resolve the earlier renewal failure');
+  } finally { teardown(relay); }
+});
+
+test('#5447 tokenExpiresAt is actually read — a stale token warns', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  const origWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => { warnings.push(args.join(' ')); };
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-expiry');
+    // A credential that lapsed ten minutes ago. Before this change the relay
+    // held this number and never compared it to anything.
+    refreshToken(relay, -10 * 60 * 1000);
+    const msg = relay.warnOnTokenExpiry();
+    assert.ok(msg, 'an expired token produced no warning — token_expires_at is still unread');
+    assert.ok(/expired/.test(msg), `expected an expiry warning, got: ${msg}`);
+    assert.ok(warnings.some(w => /expired/.test(w)), 'the expiry warning never reached the log');
+    const status = relay.tokenLifetimeStatus();
+    assert.strictEqual(status.expired, true);
+    assert.strictEqual(status.known, true);
+  } finally {
+    console.warn = origWarn;
+    teardown(relay);
+  }
+});
+
+test('#5447 a healthy token neither warns nor reports expiry', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-healthy');
+    refreshToken(relay, 50 * 60 * 1000);
+    assert.strictEqual(relay.warnOnTokenExpiry(), null,
+      'a token with 50 minutes left must not warn — that would be noise on every task');
+    const status = relay.tokenLifetimeStatus();
+    assert.strictEqual(status.expired, false);
+    assert.strictEqual(status.expiring, false);
+  } finally { teardown(relay); }
+});
+
+test('#5447 the warning fires inside the window, before the first push can fail', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-window');
+    // Still valid, but inside the warning window: the operator should hear
+    // about it BEFORE the credential lapses, not afterwards.
+    refreshToken(relay, Math.floor(relay.TOKEN_EXPIRY_WARN_MS / 2));
+    const status = relay.tokenLifetimeStatus();
+    assert.strictEqual(status.expired, false, 'this token has not expired yet');
+    assert.strictEqual(status.expiring, true, 'a token inside the warning window must be flagged as expiring');
+    const msg = relay.warnOnTokenExpiry();
+    assert.ok(msg && /expires in/.test(msg), `expected a pre-expiry warning, got: ${msg}`);
+  } finally { teardown(relay); }
+});
+
+test('#5447 the expiry warning is throttled, not emitted every tick', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-throttle');
+    refreshToken(relay, -10 * 60 * 1000);
+    assert.ok(relay.warnOnTokenExpiry(), 'the first warning must fire');
+    assert.strictEqual(relay.warnOnTokenExpiry(), null,
+      'a second immediate warning would spam the log on every progress tick');
+  } finally { teardown(relay); }
+});
+
+test('#5447 an expired token still does NOT refuse the work (clock skew)', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  const origWarn = console.warn;
+  console.warn = () => {};
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-no-refusal');
+    refreshToken(relay, -60 * 60 * 1000);
+    relay.handleMessage(JSON.stringify({ type: 'token_refresh_failed', reason: 'mint failed' }));
+    relay.progressTick();
+    // Deliberate: tokenExpiresAt is the HUB's wall clock read on OURS, so a
+    // skewed machine would abandon work on a perfectly good credential.
+    // Warning is the ceiling here; failing the task is not.
+    assert.ok(!relay.__sent.some(m => m.type === 'task_failed'),
+      'an expired-looking token must not fail the task — clock skew would destroy live work');
+    assert.strictEqual(relay.getCurrentTask() ? relay.getCurrentTask().task_id : null, 't-no-refusal',
+      'the task must still be held');
+  } finally {
+    console.warn = origWarn;
+    teardown(relay);
+  }
+});
+
+// ---------------------------------------------------------------------------
 
 let failed = 0;
 // RELAY_TEST_ONLY=<substring> runs a single test, for debugging in isolation.

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -468,21 +468,32 @@ Two things follow from refresh being driven by the hub's heartbeat:
   re-arms the cycle — without that step the resumed session's mint time would
   stay zero and refresh would never fire again for the life of the connection
   ([#2610](https://github.com/kubestellar/hive/issues/2610)).
-- **A failed re-mint is not fatal and is not announced.** If the mint errors, or
-  the hive has no App auth to mint from, the hub logs it and leaves the relay's
-  existing token in place, retrying on the next heartbeat. The relay is told
-  nothing. So the observable failure mode is not a "token expired" message: it
-  is a push or `gh` call that starts returning an authentication error partway
-  through a long task, with the previous 55 minutes having worked normally.
+- **A failed re-mint is not fatal, but it is announced.** If the mint errors the
+  hub logs it, leaves the relay's existing token in place, and retries on the
+  next heartbeat — and it now also sends the relay a `token_refresh_failed`
+  carrying a reason and no token material, so the relay logs the condition
+  against the task it belongs to
+  ([#5447](https://github.com/kubestellar/hive/issues/5447)). Both the heartbeat
+  and the resume path do this, and the hub advertises `token_refresh_failed` in
+  its `auth_ok` capability set. The message is advisory: nothing is revoked, no
+  task is failed, and a relay that ignores it behaves exactly as before. The
+  no-App-auth case is still silent — it is a deployment posture, not a failure.
 
-**Expiry is advertised but not enforced by the relay.** Each `token_refresh`
-carries a `token_expires_at` timestamp, and the relay records it — but it never
-checks it. Nothing in the relay warns as expiry approaches, refuses to start a
-push against a stale token, or asks the hub for a new one. The relay finds out
-that a token has died the same way it finds out about any other GitHub error:
-the command fails. If you see an authentication failure on a task that has been
-running for around an hour, a re-mint that quietly failed on the hub side is the
-first thing to check, and the hub's log is the only place that records it.
+**Expiry is now read, and warned on — but never enforced.** Each `token_refresh`
+carries a `token_expires_at` timestamp. The relay records it and, on each
+progress tick, compares it against the clock: it warns once the credential is
+within five minutes of expiry or already past it, and says so more pointedly
+when the hub has separately reported a failed renewal. The warning is throttled
+to once every ten minutes so a long task does not spam its log.
+
+It stops at warning deliberately. `token_expires_at` is the *hub's* wall clock
+read on the *relay's*, so a machine with a few minutes of skew would refuse work
+on a perfectly valid credential — strictly worse than today, where the token
+simply works. GitHub's answer to the actual call remains the authority on
+whether a token is good; the warning exists so that when the call does fail, the
+cause is already named in the log rather than surfacing as a generic
+authentication error. If you see an authentication failure on a task that has
+been running for around an hour, look for these two lines first.
 
 **Removal.** The token is unlinked on **every** task-exit path, before the agent
 is interrupted, so a turn that survives the stop cannot keep pushing against an

--- a/src/pkg/dashboard/contribute_protocol.go
+++ b/src/pkg/dashboard/contribute_protocol.go
@@ -79,6 +79,16 @@ const (
 	// offer-pool suppression instead of the short idle cooldown loop. Purely
 	// additive: a relay that never sends the field behaves exactly as before.
 	capCompletionVerdict = "completion_verdict"
+	// capTokenRefreshFailed: when a mid-task re-mint FAILS, the hub tells the
+	// relay so with a token_refresh_failed message instead of only logging it
+	// hub-side (#5447). Without it the relay's first evidence that its
+	// credential went stale is a push that starts failing roughly an hour into
+	// a long task, reported to the agent as a generic auth error — the
+	// misleading-symptom class of #5343. Purely additive and advisory: the
+	// existing token stays in place and the hub keeps retrying on the next
+	// heartbeat exactly as before, so a relay that ignores the message behaves
+	// precisely as it does today.
+	capTokenRefreshFailed = "token_refresh_failed"
 )
 
 // serverCapabilities returns the capability set this hub advertises on auth_ok.
@@ -93,6 +103,7 @@ func serverCapabilities() []string {
 		capCredentialAfterAccept,
 		capAgentRoleClaim,
 		capCompletionVerdict,
+		capTokenRefreshFailed,
 	}
 }
 

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -3925,6 +3925,7 @@ func (h *ContributeWSHub) maybeRefreshToken(c *ContributorConnection) {
 	if err != nil {
 		h.logger.Warn("[contribute-ws] token refresh: mint failed, will retry next heartbeat",
 			"username", c.profile.GitHubUsername, "tier", tier, "error", err)
+		h.sendTokenRefreshFailed(c, "mint failed, will retry on the next heartbeat")
 		return
 	}
 	if tok == "" {
@@ -4053,6 +4054,7 @@ func (h *ContributeWSHub) resumeTaskToken(c *ContributorConnection, lease *taskL
 	if err != nil {
 		h.logger.Warn("[contribute-ws] resume token refresh: mint failed, refresh will re-arm on next resume/heartbeat",
 			"username", c.profile.GitHubUsername, "tier", tier, "error", err)
+		h.sendTokenRefreshFailed(c, "mint failed on task resume, refresh will re-arm on the next resume or heartbeat")
 		return
 	}
 	if tok == "" {
@@ -4086,6 +4088,47 @@ func tokenRefreshDue(c *ContributorConnection, now time.Time) (tier, repo string
 	}
 	repo = c.currentTask.Repo
 	return tier, repo, true
+}
+
+// sendTokenRefreshFailed tells the relay that a mid-task re-mint FAILED, so the
+// credential it is holding is the OLD one and will expire at the token_expires_at
+// it was last given (#5447).
+//
+// Before this, a failed mint was recorded only in the hub's log. The relay's first
+// evidence was a push that started failing roughly an hour into a long task, which
+// the agent saw as a generic auth error — the same misleading-symptom class as
+// #5343, where a credential problem was reported as "the branch doesn't exist on
+// the remote".
+//
+// It deliberately carries NO token material: only a type and a human-readable
+// reason. The reason is a fixed, caller-supplied string, never the mint error
+// itself, because that error can quote GitHub App responses and we do not want
+// hub-internal auth detail crossing to a contributor-controlled process.
+//
+// Advisory only, and it changes NOTHING about the refresh contract: the old token
+// stays installed, tokenMintedAt is untouched (so tokenRefreshDue keeps firing),
+// and the next heartbeat retries exactly as before. A send failure is swallowed —
+// this is a notification about a degraded credential, and failing the refresh path
+// because the notification could not be delivered would turn a warning into an
+// outage. The heartbeat's own ping remains the authority on whether the socket is
+// alive.
+//
+// Concurrency: goes through c.send, which takes writeMu, and takes no other lock.
+// Both callers (maybeRefreshToken, resumeTaskToken) hold neither c.mu nor c.writeMu
+// at the call site — tokenRefreshDue releases c.mu before returning — so there is
+// no re-entrancy here.
+func (h *ContributeWSHub) sendTokenRefreshFailed(c *ContributorConnection, reason string) {
+	if c == nil {
+		return
+	}
+	if err := c.send(WSMessage{
+		Type:   "token_refresh_failed",
+		Seq:    h.nextSeq(),
+		Reason: reason,
+	}); err != nil {
+		h.logger.Debug("[contribute-ws] token refresh: could not notify relay of mint failure",
+			"username", c.profile.GitHubUsername, "error", err)
+	}
 }
 
 // sendTokenRefresh writes a token_refresh message carrying the new token and its

--- a/src/pkg/dashboard/contribute_ws_maybe_refresh_test.go
+++ b/src/pkg/dashboard/contribute_ws_maybe_refresh_test.go
@@ -88,10 +88,16 @@ func TestMaybeRefreshToken_NotDueIsANoOp(t *testing.T) {
 }
 
 // TestMaybeRefreshToken_MintFailureRetriesNextHeartbeat: when the mint fails
-// (#2436-style App API error) nothing may be sent — the relay keeps its
+// (#2436-style App API error) NO CREDENTIAL may be sent — the relay keeps its
 // existing token — and tokenMintedAt must NOT advance, so tokenRefreshDue still
 // reports due on the next heartbeat and the refresh is retried rather than
 // abandoned for the life of the task.
+//
+// As of #5447 this path DOES write one frame: an advisory token_refresh_failed
+// carrying no token material (asserted below and, for its content, in
+// TestMaybeRefreshToken_MintFailureNotifiesRelay). The connection therefore now
+// needs a real socket rather than the nil-ws tripwire the other no-send cases
+// still use; the retry policy this test guards is unchanged.
 func TestMaybeRefreshToken_MintFailureRetriesNextHeartbeat(t *testing.T) {
 	hub := &ContributeWSHub{logger: slog.Default()}
 	s := NewServer(0, slog.Default())
@@ -99,9 +105,27 @@ func TestMaybeRefreshToken_MintFailureRetriesNextHeartbeat(t *testing.T) {
 	hub.server = s
 
 	minted := time.Now().Add(-wsTokenRefreshPeriod - time.Minute)
-	conn := refreshConn(nil, minted) // nil ws: a send attempt would panic
+	server, client := wsPair(t)
+	conn := refreshConn(server, minted)
 
 	hub.maybeRefreshToken(conn)
+
+	// Whatever is written on a failed mint, it must never be a credential.
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("read after failed mint: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if wire["type"] != "token_refresh_failed" {
+		t.Fatalf("type = %v, want token_refresh_failed", wire["type"])
+	}
+	if _, ok := wire["github_token"]; ok {
+		t.Fatalf("a failed mint must never put token material on the wire: %s", data)
+	}
 
 	conn.mu.Lock()
 	got := conn.tokenMintedAt
@@ -212,4 +236,105 @@ func TestMaybeRefreshToken_SendFailureKeepsRetryArmed(t *testing.T) {
 	if _, _, due := tokenRefreshDue(conn, time.Now()); !due {
 		t.Fatalf("after a failed send, refresh must still be due on the next heartbeat")
 	}
+}
+
+// TestMaybeRefreshToken_MintFailureNotifiesRelay is the hub half of #5447.
+//
+// Before it, a failed re-mint was recorded ONLY in the hub's log. The relay was
+// told nothing, so its first evidence that the credential it holds had gone
+// stale was a push failing roughly an hour into a long task, which the agent
+// reported as a generic auth error — the misleading-symptom class of #5343.
+//
+// This asserts the OBSERVABLE consequence (#5388): a real frame, of a named
+// type, carrying a reason and no token material. Asserting only that the hub
+// "handles" a mint failure would pass against the old silent code.
+func TestMaybeRefreshToken_MintFailureNotifiesRelay(t *testing.T) {
+	hub := &ContributeWSHub{logger: slog.Default()}
+	s := NewServer(0, slog.Default())
+	s.deps = &Dependencies{GHAppAuth: newFailingAppAuth(t)}
+	hub.server = s
+
+	server, client := wsPair(t)
+	conn := refreshConn(server, time.Now().Add(-wsTokenRefreshPeriod-time.Minute))
+
+	hub.maybeRefreshToken(conn)
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("the relay was never told the re-mint failed: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if wire["type"] != "token_refresh_failed" {
+		t.Fatalf("type = %v, want token_refresh_failed", wire["type"])
+	}
+	reason, _ := wire["reason"].(string)
+	if reason == "" {
+		t.Fatalf("token_refresh_failed carried no reason: %s", data)
+	}
+	// The reason is a fixed, caller-supplied string. The mint error itself can
+	// quote GitHub App responses, and that must not cross to a
+	// contributor-controlled process.
+	if strings.Contains(strings.ToLower(reason), "ghs_") || strings.Contains(reason, "token ") {
+		t.Fatalf("reason looks like it leaked auth detail: %q", reason)
+	}
+	if _, ok := wire["github_token"]; ok {
+		t.Fatalf("token material on a failure notice: %s", data)
+	}
+}
+
+// TestResumeTaskToken_MintFailureNotifiesRelay: the reconnect path must be as
+// loud as the heartbeat one. A resume whose mint fails leaves the relay holding
+// a credential minted before the disconnect, with refresh un-armed — exactly the
+// state in which a later push fails for no visible reason (#5447).
+func TestResumeTaskToken_MintFailureNotifiesRelay(t *testing.T) {
+	hub := &ContributeWSHub{logger: slog.Default()}
+	s := NewServer(0, slog.Default())
+	s.deps = &Dependencies{GHAppAuth: newFailingAppAuth(t)}
+	hub.server = s
+
+	server, client := wsPair(t)
+	conn := refreshConn(server, time.Time{})
+
+	hub.resumeTaskToken(conn, &taskLease{taskID: "t-resume", repo: "o/r", number: 7, tier: "contributor", gen: 1})
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, data, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("a failed resume mint told the relay nothing: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if wire["type"] != "token_refresh_failed" {
+		t.Fatalf("type = %v, want token_refresh_failed", wire["type"])
+	}
+	if _, ok := wire["github_token"]; ok {
+		t.Fatalf("token material on a failure notice: %s", data)
+	}
+
+	// The lenient retry policy is unchanged: a failed resume mint must leave
+	// tokenMintedAt zero so a later resume or heartbeat can still arm refresh.
+	conn.mu.Lock()
+	minted := conn.tokenMintedAt
+	conn.mu.Unlock()
+	if !minted.IsZero() {
+		t.Fatalf("tokenMintedAt = %s, want zero after a failed resume mint", minted)
+	}
+}
+
+// TestServerCapabilitiesAdvertisesTokenRefreshFailed: the notice is only useful
+// if a client can learn the hub sends it without probing (#2567's contract).
+func TestServerCapabilitiesAdvertisesTokenRefreshFailed(t *testing.T) {
+	caps := serverCapabilities()
+	for _, c := range caps {
+		if c == capTokenRefreshFailed {
+			return
+		}
+	}
+	t.Fatalf("serverCapabilities() = %v, missing %q", caps, capTokenRefreshFailed)
 }


### PR DESCRIPTION
Fixes #5447

## What was wrong

**Refresh itself works and is untouched.** `wsTokenRefreshPeriod` (50m) re-mints five minutes before the 55m `wsTokenTTL` and re-arms each cycle; `resumeTaskToken()` re-mints on reconnect. A 4-hour task is refreshed ~4 times and never loses push access. No cadence or TTL constant is changed by this PR.

The two failure modes *around* refresh were both silent.

### 1. A failed re-mint was invisible to the relay

`maybeRefreshToken()` logged a warning hub-side, left the old token in place, and retried on the next heartbeat — telling the relay nothing. The observable symptom was a push that started failing roughly an hour into a long task, with the hub log as the only record, and the agent seeing a generic auth failure. Same misleading-symptom class as #5343.

### 2. `token_expires_at` was computed and then ignored

`tokenExpiresAt` appeared exactly four times in `bin/contributor-relay.sh` — declared, cleared, assigned twice — and was never compared against anything. The hub already pays for the field on the wire; the relay dropped it. Same shape as #5430 and #5228.

## What this does

### Priority 1 — the relay is told

A new **`token_refresh_failed`** message, sent from **both** mint-failure paths (`maybeRefreshToken` and `resumeTaskToken`), and advertised as a server capability (`capTokenRefreshFailed`) so a client can learn about it without probing.

- Carries a **fixed, caller-supplied reason string** — never the mint error itself, which can quote GitHub App API responses, and never any token material. Asserted by test.
- **Advisory only.** The old token stays installed, `tokenMintedAt` is untouched so `tokenRefreshDue` keeps firing, and the next heartbeat retries exactly as before. A relay that ignores the message behaves precisely as it does today.
- **Send failures are swallowed.** This is a notification about a degraded credential; failing the refresh path because the notification could not be delivered would turn a warning into an outage. The heartbeat's own ping remains the authority on socket liveness.
- The no-App-auth case (`tok == ""`) stays silent — that is a deployment posture, not a failure.

Relay side: the handler records the condition and logs it **against the task**, including the current token's remaining lifetime.

### Priority 2 — `tokenExpiresAt` earns its place

`tokenLifetimeStatus()` (pure, clock-injectable) turns the hub's timestamp into remaining lifetime, expired/expiring flags, and whether a renewal failure was reported. `warnOnTokenExpiry()` is called from `progressTick` and warns once the credential is within five minutes of expiry or already past it — more pointedly when the hub also reported a failed renewal. Throttled to once per ten minutes so a long task does not spam its log.

**Warning only — no refusal.** This is the judgement call the issue asked for. `token_expires_at` is the *hub's* wall clock read on the *relay's*, so refusing a push on a few minutes of skew would abandon work on a perfectly valid credential — strictly worse than today, where the token simply works. GitHub's answer to the real call remains the authority on whether a token is good; this only ensures that when the call fails, the cause is already named in the log. A test pins the no-refusal behaviour so a later change cannot quietly tighten it into a task failure.

## Credential lifecycle (#5373)

The failure flag is cleared wherever the credential it describes is replaced or dropped: `task_assign` with a token, a successful `token_refresh`, and `dropTaskCredential()`. Nothing is dropped on the three `task_assign` decline paths — per #5373 that would destroy the credential of the task still being worked.

## Concurrency

`sendTokenRefreshFailed` goes through `c.send` (which takes `writeMu`) and takes no other lock. Both callers hold neither `c.mu` nor `c.writeMu` at the call site — `tokenRefreshDue` releases `c.mu` before returning — so there is no re-entrancy. `writeProtocolPing`/`closeWithReason` are untouched.

## Tests — demonstrated failing without the change

Per #5388, these assert **observable behaviour**, not reachability.

**Go** (`src/pkg/dashboard/contribute_ws_maybe_refresh_test.go`) — reverting only `contribute_ws.go`:

```
--- FAIL: TestMaybeRefreshToken_MintFailureRetriesNextHeartbeat
    read after failed mint: i/o timeout
--- FAIL: TestMaybeRefreshToken_MintFailureNotifiesRelay
    the relay was never told the re-mint failed: i/o timeout
--- FAIL: TestResumeTaskToken_MintFailureNotifiesRelay
    a failed resume mint told the relay nothing: i/o timeout
```

They read the actual frame off a real socket pair, so the timeout *is* the old silence. With the change, the full `pkg/dashboard` package passes (`ok ... 70.9s`), and `gofmt`/`go vet` are clean.

**Relay** (`bin/contributor-relay.test.js`) — reverting only `contributor-relay.sh`:

```
FAIL #5447 a hub-reported refresh failure is logged against the task, not swallowed
     a failed re-mint produced no relay-visible signal
FAIL #5447 a refresh failure for a task we do not own is ignored
FAIL #5447 a later successful refresh clears the failure condition
FAIL #5447 tokenExpiresAt is actually read — a stale token warns
     relay.warnOnTokenExpiry is not a function
FAIL #5447 a healthy token neither warns nor reports expiry
FAIL #5447 the warning fires inside the window, before the first push can fail
FAIL #5447 the expiry warning is throttled, not emitted every tick
257/264 passed
```

With the change: **264/264 passed**. The eighth new test (the clock-skew no-refusal guard) passes both ways by design — it pins behaviour this PR deliberately *preserves*.

The pre-existing `TestMaybeRefreshToken_MintFailureRetriesNextHeartbeat` moved off its `nil`-ws tripwire, since that path now legitimately writes one non-credential frame; it still asserts the retry policy, and additionally asserts no `github_token` on the wire.

## Docs

`src/docs/contributor-relay.md` stated "a failed re-mint is not fatal **and is not announced**" and "expiry is advertised but **not enforced** by the relay" — both now stale. Rewritten, including why the expiry check stops at warning. `check-docs-links.py` passes (126 files).

## Not verified

- Only exercised against the test harness — **not** run on a live hive with a genuinely failing GitHub App mint. The mint failure is simulated via `newFailingAppAuth`.
- The relay warning is wired to `progressTick`, so a task whose progress reporting is not running (e.g. before `startProgressReporting`) will not warn; the `token_refresh_failed` log is unconditional and covers that window.
- No operator-facing surface (dashboard/status JSON) shows the condition — it is log-only, as the issue scoped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)