### PR TITLE
🐛 fix(ci): bump infra scorecard pin so the action image pulls from ghcr.io

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@dd836e89cb97c6e433067497ebcb355a01741aad # kubestellar/infra main as of 2026-09-01


### PR DESCRIPTION
OpenSSF Scorecard has failed **53 of 60 runs since 2026-08-31**.

## The cause is not in this repo

`.github/workflows/scorecard.yml` is 17 lines and contains **no `scorecard-action` reference at all** — it only calls infra's reusable workflow. That workflow pinned `ossf/scorecard-action` at `62b2cac`, which is exactly tag **v2.4.0** — the last release whose `action.yaml` points at `gcr.io`:

| Release | Image |
|---|---|
| v2.4.0 | `docker://gcr.io/openssf/scorecard-action:v2.4.0` |
| v2.4.1+ | `docker://ghcr.io/ossf/scorecard-action:v2.4.1` |

OpenSSF has let the backing GCP project lapse, so the pull fails with `denied: Consumer 'projects/367732848534' is invalid`. Terminal, not transient — waiting it out was never an option.

## Fix

kubestellar/infra#147 moved that pin to v2.4.4. This PR bumps our reusable-workflow SHA `1a04a3fd` → `dd836e89` to pick it up. Consumers pin by SHA, so the infra merge does **not** propagate on its own — this second step is required.

## Verified end-to-end, not just merged

infra dogfoods its own reusable workflow, and its **Scorecard run on `dd836e89` passed**. That proves the `ghcr.io` image actually pulls, rather than only proving the pin text changed.

Also verified while preparing the infra fix:
- both SHAs dereferenced **through their annotated tag objects** — the tag refs point at tag objects, not commits, so comparing ref SHAs directly would have been misleading
- the registry change was read from **each release's `action.yaml`**, not from release notes
- `inputs` diff v2.4.0..v2.4.4 is **purely additive** (one optional `file_mode` with a default); the three inputs the workflow passes are unchanged, so no wiring changes

## Scope

One line. No permissions, workflow logic, or Scorecard configuration changes.

Worth noting for expectations: Scorecard is **not a required check** on `v4` (protection requires only `gate`), so this was never blocking merges — the cost was CI noise and lost supply-chain signal.

Fixes #5477