### PR TITLE
✨ feat(reviewer): escalated-PR adjudication lane (#5480)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -8506,6 +8506,11 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		// fix-before-new section routes each red PR back to its author; empty
 		// means unattributed (kick builders default it to scanner).
 		Agent string `json:"agent,omitempty"`
+		// Labels carries the PR's current labels into the kick builders. The
+		// reviewer lane (#5480) reads them to exclude PRs already carrying
+		// reviewer-passed — a PR that re-escalates after a reviewer pass
+		// belongs to a true human, never to another automated pass.
+		Labels []string `json:"labels,omitempty"`
 	}
 
 	prAgents := auditPRAgents(org, time.Now().Add(-auditPRAttributionWindow), "")
@@ -8570,6 +8575,7 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 					Excerpt:       pr.CIFailureExcerpt,
 					Escalated:     escalatedPRs[escalation.Key(fullRepo, pr.Number)],
 					Agent:         prAgents[fmt.Sprintf("%s#%d", fullRepo, pr.Number)],
+					Labels:        pr.Labels,
 				})
 				continue
 			}

--- a/src/pkg/escalation/escalation.go
+++ b/src/pkg/escalation/escalation.go
@@ -47,7 +47,23 @@ const RedPRStaleAfter = 10 * time.Minute
 // re-dispatched every tick forever. Distinct from DefaultThreshold, which
 // counts distinct red SHAs (real fix attempts); this counts re-nudges of an
 // unchanged red SHA.
-const MaxReEngagements = 3
+const MaxReEngagements = 6
+
+// MachineryVersion identifies the GENERATION of the fix-dispatch machinery.
+// Bump it when the kick/repair pipeline changes materially enough that
+// attempts burned under the previous generation are no longer predictive of
+// the next attempt's success. Entries whose recorded generation is older get
+// ONE fresh set of re-engagements (and are un-escalated) on their next
+// TryReEngage — without this, a PR escalated under machinery that could not
+// possibly have fixed it (pre-#4828 kicks carried no CI evidence, no branch
+// name, no push-to-branch instruction, and most "attempts" never produced a
+// single commit) stays human-parked forever even after the machinery is
+// repaired. Observed on kubestellar/console 2026-09-01: nine split PRs
+// escalated under generation-1 no-op attempts, permanently outside the loop.
+//
+// Generation 2: evidence-rich FIX-BEFORE-NEW kicks (#4828) + per-agent
+// attribution + AGENTS.md repair contracts.
+const MachineryVersion = 2
 
 // Entry is the persisted per-PR attempt record.
 type Entry struct {
@@ -76,6 +92,11 @@ type Entry struct {
 	// PR goes green. The re-engagement cap (MaxReEngagements) reads this so a
 	// permanently-red, never-moving PR is not nudged forever.
 	ReEngagements int `json:"re_engagements,omitempty"`
+
+	// Machinery is the MachineryVersion under which this entry's attempts
+	// were burned. Older-generation entries are granted amnesty (see
+	// MachineryVersion).
+	Machinery int `json:"machinery,omitempty"`
 }
 
 // Store is the on-PVC attempt ledger. All methods are safe for concurrent use.
@@ -149,8 +170,19 @@ func (s *Store) Sweep(obs []Observation, threshold int) map[string]Result {
 		}
 		e := s.entries[key]
 		if e == nil {
-			e = &Entry{}
+			e = &Entry{Machinery: MachineryVersion}
 			s.entries[key] = e
+		}
+		// Machinery amnesty (see MachineryVersion): attempts and escalations
+		// burned under an older fix-dispatch generation are wiped once, and
+		// the distinct-SHA ledger restarts, so the CURRENT machinery gets its
+		// own budget before a human is paged again. Without the RedSHAs reset
+		// the very next sweep would re-escalate on the old ledger.
+		if e.Machinery < MachineryVersion {
+			e.Machinery = MachineryVersion
+			e.ReEngagements = 0
+			e.Escalated = false
+			e.RedSHAs = nil
 		}
 		if o.HeadSHA != "" && !containsSHA(e.RedSHAs, o.HeadSHA) {
 			e.RedSHAs = append(e.RedSHAs, o.HeadSHA)
@@ -332,6 +364,16 @@ func (s *Store) TryReEngage(repo string, number int, headSHA string) bool {
 		e.CurRedSHA = headSHA
 		e.FirstRedAt = s.now()
 		e.ReEngagements = 0
+	}
+	// Machinery amnesty: attempts burned under an older fix-dispatch
+	// generation don't count against the current one. Grant one fresh set
+	// and pull the PR back out of the escalated (needs-human) state so the
+	// current machinery gets its own chance before a human is paged again.
+	if e.Machinery < MachineryVersion {
+		e.Machinery = MachineryVersion
+		e.ReEngagements = 0
+		e.Escalated = false
+		e.RedSHAs = nil
 	}
 	if e.ReEngagements >= MaxReEngagements {
 		return false

--- a/src/pkg/escalation/escalation_test.go
+++ b/src/pkg/escalation/escalation_test.go
@@ -228,3 +228,55 @@ func TestSweep_EscalatesWhenReEngagementBudgetExhaustedOnUnchangedSHA(t *testing
 		t.Fatalf("new SHA resets the budget; must not escalate yet: got %+v", got)
 	}
 }
+
+// Machinery amnesty: entries escalated under an older fix-dispatch generation
+// (pre-#4828 kicks carried no CI evidence and most attempts produced no
+// commit) get ONE fresh budget under the current generation — un-escalated,
+// counters cleared, distinct-SHA ledger restarted — instead of staying
+// human-parked forever. Entries already at the current generation keep their
+// state untouched.
+func TestSweep_MachineryAmnestyReleasesOldGenerationEscalations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "streaks.json")
+	s := Load(path)
+
+	// Simulate a generation-1 entry: escalated, budget exhausted, full ledger.
+	key := Key("org/repo", 9)
+	s.mu.Lock()
+	s.entries[key] = &Entry{
+		RedSHAs:       []string{"a", "b", "c"},
+		Escalated:     true,
+		CurRedSHA:     "c",
+		ReEngagements: MaxReEngagements,
+		Machinery:     1,
+	}
+	s.mu.Unlock()
+
+	// Next sweep under generation 2: amnesty fires — not escalated, ledger
+	// restarted at the observed SHA only, and it must NOT immediately
+	// re-escalate off the old ledger.
+	r := s.Sweep([]Observation{obs("org/repo", 9, "c", true)}, 3)
+	got := r[key]
+	if got.NewlyEscala {
+		t.Fatalf("amnestied entry must not re-escalate on the old ledger: %+v", got)
+	}
+	if got.Attempts != 1 {
+		t.Fatalf("ledger must restart: got %+v", got)
+	}
+	s.mu.Lock()
+	stillEscalated := s.entries[key].Escalated
+	s.mu.Unlock()
+	if stillEscalated {
+		t.Fatal("entry must be un-escalated after amnesty")
+	}
+	// Re-engagement budget is fresh.
+	if !s.TryReEngage("org/repo", 9, "c") {
+		t.Fatal("amnestied entry must have a fresh re-engagement budget")
+	}
+	// The amnesty fires ONCE: exhausting the fresh budget escalates again.
+	for i := 0; i < MaxReEngagements; i++ {
+		s.TryReEngage("org/repo", 9, "c")
+	}
+	if s.TryReEngage("org/repo", 9, "c") {
+		t.Fatal("cap must hold at the current generation — amnesty is one-shot")
+	}
+}

--- a/src/pkg/scheduler/reviewer_lane.go
+++ b/src/pkg/scheduler/reviewer_lane.go
@@ -1,0 +1,242 @@
+// Reviewer lane (#5480): an explicitly-configured agent role with the
+// authority to adjudicate ESCALATED (needs-human) hive-authored PRs.
+//
+// Escalation is a one-way door to a human queue with no assigned worker: when
+// a PR exhausts its fix budget it gets `needs-human` and every automated path
+// stands down — by design. Nothing owned that queue (kubestellar/console,
+// 2026-09-01: nine escalated PRs sat invisible for a week until an ad-hoc
+// operator-authorized review fleet cleared all nine in ~1 hour, every fix
+// mechanical from CI evidence). The reviewer lane is that missing worker:
+// off by default (an operator must add an agent with `role: reviewer`),
+// hard-gated to ACMM level >= reviewerLaneMinACMMLevel, and bounded to
+// reviewerMaxPRsPerKick adjudications per kick.
+//
+// This is distinct from the pack-defined on-demand "reviewer" agent
+// (reviewer-advisory.md), which is PR-triggered pre-merge verdict voting on
+// HEALTHY PRs in ADVISORY mode. The lane here is cadence-kicked, targets only
+// escalated red PRs, and requires push capability — an operator enables it by
+// adding a cadence agent (any name) with `role: reviewer`.
+package scheduler
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+const (
+	// RoleReviewer is the AgentConfig.Role value that routes an agent into
+	// the escalated-PR adjudication lane. Config loading defaults Role to the
+	// agent's name, so an agent literally named "reviewer" (with no template
+	// shadowing it) also lands here.
+	RoleReviewer = "reviewer"
+
+	// reviewerLaneMinACMMLevel is the HARD gate: the reviewer work list and
+	// adjudication contract render only when the hive runs at this ACMM level
+	// or above. Below it the kick states the lane is dormant and the agent
+	// stands down — an operator adding a reviewer-role agent to an L3 hive
+	// must not silently acquire an agent that un-escalates human queues.
+	reviewerLaneMinACMMLevel = 5
+
+	// reviewerCloseACMMLevel is the level at or above which the reviewer may
+	// actually CLOSE a PR after posting a recommend-close comment. Below it,
+	// closing stays operator-only and the comment is the entire verdict.
+	reviewerCloseACMMLevel = 6
+
+	// reviewerMaxPRsPerKick caps how many escalated PRs one kick may
+	// adjudicate, oldest first. The cap is enforced structurally: the work
+	// list itself never contains more rows than this.
+	reviewerMaxPRsPerKick = 3
+
+	// ReviewerPassedLabel marks a PR the reviewer lane has already repaired or
+	// de-escalated once. A PR that RE-escalates after carrying this label
+	// belongs to a true human: the work-list builder excludes labeled rows, so
+	// there is no reviewer<->escalation ping-pong. The machinery-generation
+	// amnesty (#5471) plus one reviewer pass then human is the full ladder.
+	ReviewerPassedLabel = "reviewer-passed"
+)
+
+// agentRole resolves the effective role for an agent name: the configured
+// AgentConfig.Role when set, else the base agent name (config loading applies
+// the same default, but a directly-constructed Config in tests may not have).
+func (s *Scheduler) agentRole(agentName string) string {
+	baseName := s.cfg.BaseAgentName(agentName)
+	agentCfg, ok := s.cfg.Agents[agentName]
+	if !ok {
+		agentCfg, ok = s.cfg.Agents[baseName]
+	}
+	if ok && agentCfg.Role != "" {
+		return agentCfg.Role
+	}
+	return baseName
+}
+
+// buildReviewerMessage is the hardcoded-fallback kick for reviewer-role
+// agents, mirroring buildQualityMessage's structure. It renders the escalated
+// hive-authored PR work list (from ci-failing.json) and the adjudication
+// contract — or a dormant notice when the hive's ACMM level is below the gate.
+func (s *Scheduler) buildReviewerMessage(agentName string, actionable *github.ActionableResult) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("[agent:%s]\n", agentName))
+	b.WriteString("REVIEWER — adjudicate escalated (needs-human) hive-authored PRs.\n\n")
+
+	level := 0
+	if s.cfg.ACMMLevel != nil {
+		level = *s.cfg.ACMMLevel
+	}
+	if level < reviewerLaneMinACMMLevel {
+		b.WriteString(fmt.Sprintf(
+			"⛔ REVIEWER LANE DORMANT: this hive runs at ACMM level %d; the escalated-PR\n"+
+				"adjudication lane requires level %d or above. The needs-human queue belongs\n"+
+				"entirely to human operators at this level. Do NOT touch, comment on, relabel,\n"+
+				"rebase, or close any PR. Stand down this kick.\n",
+			level, reviewerLaneMinACMMLevel))
+		return b.String()
+	}
+
+	workList := s.buildReviewerWorkList()
+	if workList == "" {
+		b.WriteString("ESCALATED PRs AWAITING ADJUDICATION: (none)\n")
+		b.WriteString("Nothing to adjudicate — stand down this kick. Do NOT go hunting for other work.\n")
+		return b.String()
+	}
+
+	b.WriteString(s.ghAuthInstructions())
+	b.WriteString(fmt.Sprintf("ESCALATED PRs AWAITING ADJUDICATION (max %d per kick, oldest first):\n", reviewerMaxPRsPerKick))
+	b.WriteString(workList)
+
+	b.WriteString("\nADJUDICATION CONTRACT — for EACH PR above, deliver EXACTLY ONE verdict:\n")
+	b.WriteString("  1. REPAIR — the change is still wanted and can be made lossless:\n")
+	b.WriteString("     a. Verify still-wanted: the problem it solves still exists on the base branch\n")
+	b.WriteString("        and no merged PR supersedes it.\n")
+	b.WriteString("     b. Verify lossless vs main: compare the PR's diff and its TEST COUNT against\n")
+	b.WriteString("        the base branch (diff/test-count parity). A branch that drops code or tests\n")
+	b.WriteString("        present on main is lossy — do NOT repair it; use RECOMMEND-CLOSE instead.\n")
+	b.WriteString("     c. Fix on the SAME branch, working from the CI evidence above:\n")
+	b.WriteString("        gh pr checkout <number> → fix → commit -s → git push\n")
+	b.WriteString("        Do NOT open a replacement PR.\n")
+	b.WriteString(fmt.Sprintf("     d. Then return it to the automated lane and mark your pass:\n"+
+		"        gh pr edit <number> --remove-label needs-human --add-label %s\n", ReviewerPassedLabel))
+	b.WriteString("  2. DE-ESCALATE — the failure was environmental (base-branch regression since\n")
+	b.WriteString("     fixed, infra flake): rebase the branch on its base, push, then\n")
+	b.WriteString(fmt.Sprintf("        gh pr edit <number> --remove-label needs-human --add-label %s\n", ReviewerPassedLabel))
+	b.WriteString("  3. RECOMMEND-CLOSE — duplicate, superseded, or irreparably lossy: post exactly\n")
+	b.WriteString("     ONE comment:\n")
+	b.WriteString("        gh pr comment <number> --body \"[reviewer] recommend close: <rationale>\"\n")
+	if level >= reviewerCloseACMMLevel {
+		b.WriteString(fmt.Sprintf("     At this hive's ACMM level (%d) you MAY then close the PR yourself\n", level))
+		b.WriteString("     (gh pr close <number>) after posting the comment.\n")
+	} else {
+		b.WriteString(fmt.Sprintf("     ⛔ NEVER close the PR yourself: closing is operator-only below ACMM level %d.\n", reviewerCloseACMMLevel))
+		b.WriteString("     The comment is your entire verdict; leave needs-human in place.\n")
+	}
+
+	b.WriteString("\nINVARIANTS:\n")
+	b.WriteString(fmt.Sprintf("  ⛔ Adjudicate AT MOST %d PRs this kick, oldest first — the list above is\n", reviewerMaxPRsPerKick))
+	b.WriteString("     already capped and ordered; work it top to bottom.\n")
+	b.WriteString("  ⛔ NEVER touch a human-authored PR. The work list contains ONLY hive-authored\n")
+	b.WriteString("     PRs; if you nonetheless encounter a PR not authored by this hive's bot\n")
+	b.WriteString("     identity, skip it — it is not yours to adjudicate.\n")
+	b.WriteString(fmt.Sprintf("  ⛔ NEVER adjudicate a PR whose ledger shows a prior reviewer pass (the\n"+
+		"     `%s` label). Such PRs are excluded from your list; a PR that\n"+
+		"     re-escalates after your pass belongs to a true human. That is why you add\n"+
+		"     the label on every repair/de-escalate.\n", ReviewerPassedLabel))
+	b.WriteString("  ⛔ NEVER run gh pr list / gh search — the work list above is your ONLY source.\n")
+
+	return b.String()
+}
+
+// buildReviewerWorkList renders the escalated-PR work list from
+// ci-failing.json ("" when the file is missing or holds no adjudicable rows).
+func (s *Scheduler) buildReviewerWorkList() string {
+	data, err := os.ReadFile(ciFailingPath)
+	if err != nil {
+		return ""
+	}
+	return formatReviewerWorkList(data)
+}
+
+// formatReviewerWorkList renders the reviewer work list from raw
+// ci-failing.json bytes. Rows are ESCALATED hive-authored PRs only —
+// writeMergeEligible builds the file exclusively from the hive's own PR
+// enumeration with per-agent attribution, so every row is hive work; rows
+// whose Labels carry ReviewerPassedLabel are excluded (one reviewer pass per
+// PR, ever). Output is capped at reviewerMaxPRsPerKick rows, oldest first
+// (ascending PR number per repo — the enumeration carries no creation time,
+// and numbers are monotonic per repo).
+func formatReviewerWorkList(data []byte) string {
+	type ciFailingRow struct {
+		Number        int      `json:"number"`
+		Repo          string   `json:"repo"`
+		Title         string   `json:"title"`
+		Agent         string   `json:"agent"`
+		Labels        []string `json:"labels"`
+		FailingChecks []string `json:"failing_checks"`
+		Excerpt       string   `json:"excerpt"`
+		Escalated     bool     `json:"escalated"`
+	}
+	var payload struct {
+		Items []ciFailingRow `json:"ci_failing"`
+	}
+	if json.Unmarshal(data, &payload) != nil {
+		return ""
+	}
+	var rows []ciFailingRow
+	for _, pr := range payload.Items {
+		if !pr.Escalated {
+			continue // still in the automated fix lane — not the reviewer's
+		}
+		passed := false
+		for _, l := range pr.Labels {
+			if l == ReviewerPassedLabel {
+				passed = true
+				break
+			}
+		}
+		if passed {
+			continue // one reviewer pass per PR: a re-escalation is a human's
+		}
+		rows = append(rows, pr)
+	}
+	if len(rows) == 0 {
+		return ""
+	}
+	// Oldest first: PR numbers are monotonic per repo, the only age signal
+	// these rows carry.
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Repo != rows[j].Repo {
+			return rows[i].Repo < rows[j].Repo
+		}
+		return rows[i].Number < rows[j].Number
+	})
+
+	var b strings.Builder
+	for i, pr := range rows {
+		if i >= reviewerMaxPRsPerKick {
+			b.WriteString(fmt.Sprintf("  … %d more escalated PRs held for later kicks (cap: %d per kick)\n",
+				len(rows)-i, reviewerMaxPRsPerKick))
+			break
+		}
+		author := pr.Agent
+		if author == "" {
+			author = "scanner"
+		}
+		b.WriteString(fmt.Sprintf("  %s#%d — %s\n", pr.Repo, pr.Number, pr.Title))
+		b.WriteString(fmt.Sprintf("    original author agent: %s\n", author))
+		b.WriteString(fmt.Sprintf("    checkout: gh pr checkout %d --repo %s\n", pr.Number, pr.Repo))
+		if len(pr.FailingChecks) > 0 {
+			b.WriteString(fmt.Sprintf("    failing: %s\n", strings.Join(pr.FailingChecks, ", ")))
+		}
+		if excerpt := strings.TrimSpace(pr.Excerpt); excerpt != "" {
+			if runes := []rune(excerpt); len(runes) > redPRFixExcerptRunes {
+				excerpt = string(runes[:redPRFixExcerptRunes]) + "…"
+			}
+			b.WriteString("    evidence: " + strings.ReplaceAll(excerpt, "\n", "\n              ") + "\n")
+		}
+	}
+	return b.String()
+}

--- a/src/pkg/scheduler/reviewer_lane_test.go
+++ b/src/pkg/scheduler/reviewer_lane_test.go
@@ -1,0 +1,227 @@
+package scheduler
+
+// Tests for the reviewer lane (#5480): the escalated-PR adjudication kick.
+//
+// The lane's safety properties are all here: escalated-only rows, the
+// one-pass-ever exclusion (reviewer-passed), the per-kick cap with oldest
+// first ordering, the hard ACMM gate, and the adjudication contract itself
+// (REPAIR / DE-ESCALATE / RECOMMEND-CLOSE with the close authority split at
+// L6). Each is a one-line edit away from an agent that closes human queues,
+// so each is pinned.
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+)
+
+const reviewerFixture = `{"generated_at":"2026-09-01T00:00:00Z","ci_failing":[
+  {"number":22815,"repo":"test-org/console","title":"red but NOT escalated","agent":"scanner",
+   "failing_checks":["build-gate"],"excerpt":"still in the automated lane"},
+  {"number":9,"repo":"test-org/console","title":"escalated split PR","agent":"scanner","escalated":true,
+   "failing_checks":["build-gate","Test (chromium, shard 1)"],
+   "excerpt":"ReferenceError: seedMission is not defined"},
+  {"number":41,"repo":"test-org/console","title":"escalated, already adjudicated","agent":"quality","escalated":true,
+   "labels":["needs-human","reviewer-passed"],"failing_checks":["go test"]},
+  {"number":3,"repo":"test-org/console","title":"oldest escalated","escalated":true,
+   "labels":["needs-human"],"failing_checks":["lint"]}
+]}`
+
+// Only rows with escalated=true appear; red-but-still-automated PRs stay in
+// the fix lane, and rows carrying reviewer-passed are excluded forever.
+func TestFormatReviewerWorkList_EscalatedOnlyAndReviewerPassedExcluded(t *testing.T) {
+	out := formatReviewerWorkList([]byte(reviewerFixture))
+	for _, want := range []string{
+		"test-org/console#9",
+		"test-org/console#3",
+		"gh pr checkout 9 --repo test-org/console",
+		"build-gate, Test (chromium, shard 1)",
+		"ReferenceError: seedMission is not defined",
+		"original author agent: scanner",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("work list missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "#22815") {
+		t.Error("non-escalated red PR must stay in the automated fix lane, not the reviewer's list")
+	}
+	if strings.Contains(out, "#41") {
+		t.Error("reviewer-passed PR must be excluded: one reviewer pass per PR, ever")
+	}
+	// Unattributed rows surface as scanner, the fleet's primary PR creator.
+	if !strings.Contains(out, "original author agent: scanner") {
+		t.Errorf("unattributed escalated row must default its author agent to scanner:\n%s", out)
+	}
+	// Oldest first: #3 precedes #9.
+	if strings.Index(out, "#3 ") > strings.Index(out, "#9 ") {
+		t.Errorf("work list must be oldest first (ascending PR number):\n%s", out)
+	}
+
+	if got := formatReviewerWorkList([]byte(`{"ci_failing":[{"number":1,"repo":"o/r","title":"red"}]}`)); got != "" {
+		t.Errorf("no escalated rows must yield an empty list, got:\n%s", got)
+	}
+	if got := formatReviewerWorkList([]byte("not json")); got != "" {
+		t.Errorf("malformed file must yield an empty list, got:\n%s", got)
+	}
+}
+
+// The work list is structurally capped at reviewerMaxPRsPerKick rows, oldest
+// first, with the remainder summarized rather than listed.
+func TestFormatReviewerWorkList_CapOldestFirst(t *testing.T) {
+	var rows []string
+	for _, n := range []int{50, 10, 40, 20, 30} { // deliberately out of order
+		rows = append(rows, fmt.Sprintf(`{"number":%d,"repo":"o/r","title":"t%d","agent":"scanner","escalated":true}`, n, n))
+	}
+	data := `{"ci_failing":[` + strings.Join(rows, ",") + `]}`
+	out := formatReviewerWorkList([]byte(data))
+
+	for _, want := range []string{"o/r#10", "o/r#20", "o/r#30"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("capped list missing oldest row %q:\n%s", want, out)
+		}
+	}
+	for _, banned := range []string{"o/r#40", "o/r#50"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("row %q exceeds the per-kick cap of %d:\n%s", banned, reviewerMaxPRsPerKick, out)
+		}
+	}
+	if !strings.Contains(out, fmt.Sprintf("… %d more escalated PRs", 2)) {
+		t.Errorf("expected cap summary line for the 2 held-back rows:\n%s", out)
+	}
+	if strings.Index(out, "#10") > strings.Index(out, "#20") || strings.Index(out, "#20") > strings.Index(out, "#30") {
+		t.Errorf("rows must render oldest first:\n%s", out)
+	}
+}
+
+func reviewerTestScheduler(t *testing.T, acmmLevel int, fixture string) *Scheduler {
+	t.Helper()
+	dir := t.TempDir()
+	orig := ciFailingPath
+	ciFailingPath = filepath.Join(dir, "ci-failing.json")
+	t.Cleanup(func() { ciFailingPath = orig })
+	if fixture != "" {
+		if err := os.WriteFile(ciFailingPath, []byte(fixture), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: "test-org", Repos: []string{"test-org/console"}},
+		Agents: map[string]config.AgentConfig{
+			// An operator-added adjudicator: name is NOT "reviewer"; the ROLE
+			// is what routes it into the lane.
+			"adjudicator": {Role: "reviewer", Mode: "ISSUES_AND_PRS"},
+			"scanner":     {Mode: "ISSUES_AND_PRS"},
+		},
+	}
+	if acmmLevel > 0 {
+		cfg.ACMMLevel = &acmmLevel
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(cfg, logger)
+}
+
+// Below ACMM L5 the kick renders only the dormant notice — no work list, no
+// contract — regardless of how deep the escalated queue is. This is the hard
+// gate: an operator adding a reviewer-role agent to a low-trust hive must not
+// acquire an agent that un-escalates human queues.
+func TestBuildReviewerMessage_ACMMGateDormantBelowL5(t *testing.T) {
+	for _, level := range []int{0, 1, 2, 3, 4} {
+		s := reviewerTestScheduler(t, level, reviewerFixture)
+		msg := s.buildReviewerMessage("adjudicator", &github.ActionableResult{})
+		if !strings.Contains(msg, "REVIEWER LANE DORMANT") {
+			t.Errorf("L%d: kick must say the lane is dormant:\n%s", level, msg)
+		}
+		if !strings.Contains(msg, "Stand down") {
+			t.Errorf("L%d: dormant kick must order a stand-down:\n%s", level, msg)
+		}
+		for _, banned := range []string{"#9", "#3", "ADJUDICATION CONTRACT", "REPAIR", "gh pr checkout"} {
+			if strings.Contains(msg, banned) {
+				t.Errorf("L%d: dormant kick must not render %q:\n%s", level, banned, msg)
+			}
+		}
+	}
+}
+
+// At L5+ the kick carries the work list and the full adjudication contract:
+// the three exclusive verdicts, the same-branch repair rule, label mechanics,
+// the cap, and the human-authored-PR and reviewer-passed invariants. Below L6
+// closing is forbidden.
+func TestBuildReviewerMessage_ContractAtL5(t *testing.T) {
+	s := reviewerTestScheduler(t, 5, reviewerFixture)
+	msg := s.buildReviewerMessage("adjudicator", &github.ActionableResult{})
+	for _, want := range []string{
+		"[agent:adjudicator]",
+		"test-org/console#9",
+		"REPAIR",
+		"DE-ESCALATE",
+		"RECOMMEND-CLOSE",
+		"EXACTLY ONE verdict",
+		"diff/test-count parity",
+		"SAME branch",
+		"Do NOT open a replacement PR",
+		"--remove-label needs-human",
+		"--add-label " + ReviewerPassedLabel,
+		"[reviewer] recommend close:",
+		"NEVER close the PR yourself",
+		fmt.Sprintf("AT MOST %d PRs this kick", reviewerMaxPRsPerKick),
+		"NEVER touch a human-authored PR",
+		"prior reviewer pass",
+		"NEVER run gh pr list",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("L5 reviewer kick missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "MAY then close") {
+		t.Error("closing must not be offered below L6")
+	}
+}
+
+// At L6, and only at L6+, the kick grants close authority after the
+// recommend-close comment.
+func TestBuildReviewerMessage_CloseAllowedAtL6(t *testing.T) {
+	s := reviewerTestScheduler(t, 6, reviewerFixture)
+	msg := s.buildReviewerMessage("adjudicator", &github.ActionableResult{})
+	if !strings.Contains(msg, "MAY then close the PR yourself") {
+		t.Errorf("L6 kick must grant close authority:\n%s", msg)
+	}
+	if strings.Contains(msg, "NEVER close the PR yourself") {
+		t.Errorf("L6 kick must not simultaneously forbid closing:\n%s", msg)
+	}
+}
+
+// An empty escalated queue produces a stand-down kick, not a hunt.
+func TestBuildReviewerMessage_EmptyQueueStandsDown(t *testing.T) {
+	s := reviewerTestScheduler(t, 5, `{"ci_failing":[{"number":1,"repo":"o/r","title":"red, not escalated"}]}`)
+	msg := s.buildReviewerMessage("adjudicator", &github.ActionableResult{})
+	if !strings.Contains(msg, "(none)") || !strings.Contains(msg, "stand down") {
+		t.Errorf("empty queue must render (none) + stand down:\n%s", msg)
+	}
+	if strings.Contains(msg, "ADJUDICATION CONTRACT") {
+		t.Errorf("no contract without work:\n%s", msg)
+	}
+}
+
+// BuildAgentMessage routes by ROLE, not name: an operator-added agent with
+// role: reviewer receives the adjudication kick through the normal resolution
+// chain's hardcoded fallback, so it participates in ordinary cadence kicks
+// like every other role.
+func TestBuildAgentMessage_RoutesReviewerRole(t *testing.T) {
+	s := reviewerTestScheduler(t, 5, reviewerFixture)
+	msg := s.BuildAgentMessage("adjudicator", nil, &github.ActionableResult{})
+	if !strings.Contains(msg, "[agent:adjudicator]") || !strings.Contains(msg, "ADJUDICATION CONTRACT") {
+		t.Errorf("role: reviewer agent must receive the adjudication kick:\n%s", msg)
+	}
+	// A role-less agent must not be captured by the reviewer routing.
+	scanner := s.BuildAgentMessage("scanner", nil, &github.ActionableResult{})
+	if strings.Contains(scanner, "ADJUDICATION CONTRACT") {
+		t.Errorf("scanner must not receive the reviewer kick:\n%s", scanner)
+	}
+}

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -700,6 +700,14 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 
 	// 3. Legacy hardcoded fallback (removed in Phase 4 when all agents use templates)
 	s.logger.Info("no prompt template found, using hardcoded kick", "agent", agentName)
+	// Role-based routing (#5480): an operator-added agent with `role: reviewer`
+	// gets the escalated-PR adjudication kick regardless of its name. Checked
+	// before the name switch because the lane is enabled by ROLE — the agent
+	// may be named anything. (The pack-defined on-demand "reviewer" agent
+	// never reaches this fallback: its kick_template resolves above.)
+	if s.agentRole(agentName) == RoleReviewer {
+		return s.buildReviewerMessage(agentName, actionable)
+	}
 	switch baseName {
 	case "scanner":
 		return s.buildScannerMessage(issues, actionable)


### PR DESCRIPTION
Refs #5480

## What this is

The **reviewer lane**: an explicitly-configured agent role with bounded authority to adjudicate escalated (`needs-human`) hive-authored PRs. Escalation is a one-way door to a human queue with no assigned worker; this is the missing worker the RFC describes (and #4828 / #5471 / #5479 expose).

## Design

**Role, not name.** The lane is enabled by adding an agent with `role: reviewer` (any name) to the config. Routing happens in `BuildAgentMessage`'s hardcoded-fallback seam, *by role*, before the name switch — so:
- Nothing ships enabled: no pack or default materializes a cadence reviewer-role agent. An operator must add one.
- The pack-defined on-demand pre-merge `reviewer` (ADVISORY, `reviewer-advisory.md`, PR-triggered verdict voting) is untouched — its kick resolves via `kick_template` well before this fallback, and `OnDemandAgentsFromPacks` keeps anything *named* `reviewer` off the cadence. A cadence-kicked adjudicator should therefore use a different name (e.g. `adjudicator`) with `role: reviewer`; it then participates in normal `agents_due` cadence kicks like every other role.
- `pkg/classify` is untouched: the role receives lane-filtered issues via the existing `filterByLane` path, compatible with any operator-configured lane keywords.

**Hard ACMM gate.** The work list + adjudication contract render only at ACMM level ≥ 5 (`reviewerLaneMinACMMLevel`). Below that the kick states the lane is dormant and orders a stand-down — an operator adding a reviewer-role agent to an L3 hive does not silently acquire an agent that drains human queues.

**Work list** (`formatReviewerWorkList`, reading `/var/run/hive-metrics/ci-failing.json`):
- `escalated=true` rows ONLY — red-but-still-automated PRs stay in the FIX-BEFORE-NEW lane.
- Rows whose `labels` contain `reviewer-passed` are excluded — see ping-pong prevention below.
- Structurally capped at 3 rows per kick (`reviewerMaxPRsPerKick`), oldest first (ascending PR number per repo — the only age signal the rows carry), remainder summarized.
- Each row: repo, number, branchless checkout instruction (`gh pr checkout N --repo <repo>`), failing check names, CI evidence excerpt (bounded by `redPRFixExcerptRunes`), and the original author agent (unattributed defaults to `scanner`, matching `formatRedPRFixData`).

**Adjudication contract** (`buildReviewerMessage`, mirroring `buildQualityMessage`'s structure): per PR **exactly one** of
1. **REPAIR** — verify still-wanted + lossless vs main (diff/test-count parity; lossy → recommend-close instead); fix on the SAME branch from the CI evidence; push; `gh pr edit N --remove-label needs-human --add-label reviewer-passed`.
2. **DE-ESCALATE** — environmental failure since fixed: rebase, push, remove label, add `reviewer-passed`.
3. **RECOMMEND-CLOSE** — exactly one comment `[reviewer] recommend close: <rationale>`. Closing is forbidden below L6 (`reviewerCloseACMMLevel`); at L6 the kick grants close-after-comment.

**Guardrails stated as invariants in the kick:** 3-PR cap oldest-first; never touch human-authored PRs (the list contains only hive-authored rows — writeMergeEligible builds it from the hive's own enumeration with per-agent attribution — but the invariant is stated anyway); never adjudicate a PR with a prior reviewer pass; never rebuild the work list with `gh pr list`/`gh search`.

**Ping-pong prevention.** The reviewer labels every repair/de-escalate `reviewer-passed`; the work-list builder excludes labeled rows. A PR that re-escalates after a reviewer pass therefore lands with a true human. To support this, `writeMergeEligible` now threads each PR's `labels` into the `ci_failing` rows.

**Escalation amnesty port (#5471).** v5's `pkg/escalation` lacked the v4 machinery-generation amnesty, which the RFC names as one rung of the full ladder (amnesty → one reviewer pass → human). Ported verbatim: `MachineryVersion` (generation 2), per-entry `Machinery` field, one-shot amnesty in `Sweep` and `TryReEngage` (un-escalate, clear counters, restart the distinct-SHA ledger), and the 6-attempt re-engagement budget (`MaxReEngagements` 3 → 6).

## Files changed
- `src/pkg/scheduler/reviewer_lane.go` (new) — role constant, gates, work-list builder, kick builder
- `src/pkg/scheduler/reviewer_lane_test.go` (new)
- `src/pkg/scheduler/scheduler.go` — role-based routing in the hardcoded fallback
- `src/cmd/hive/main.go` — `Labels` threaded into `ci_failing` rows
- `src/pkg/escalation/escalation.go` + test — #5471 amnesty port

## Tests
`go test ./pkg/scheduler/ ./pkg/escalation/ ./cmd/hive/` all pass locally; `gofmt` clean on touched files; `go vet` clean.
- `TestFormatReviewerWorkList_EscalatedOnlyAndReviewerPassedExcluded`
- `TestFormatReviewerWorkList_CapOldestFirst`
- `TestBuildReviewerMessage_ACMMGateDormantBelowL5`
- `TestBuildReviewerMessage_ContractAtL5`
- `TestBuildReviewerMessage_CloseAllowedAtL6`
- `TestBuildReviewerMessage_EmptyQueueStandsDown`
- `TestBuildAgentMessage_RoutesReviewerRole`
- `TestSweep_MachineryAmnestyReleasesOldGenerationEscalations`

## Deferred
- **Audit events** (`agent_pr_reviewed` / close-recommend on the attribution trail + advisory digest): the relay watchers already audit the writes the reviewer performs (label edits, comments, pushes) generically; a dedicated adjudication event type is follow-up work.
- **Reviewer's notes attached on post-pass re-escalation**: the pass is currently visible via the `reviewer-passed` label and the PR's commit/comment history; a structured hand-off note is follow-up.
- **True creation-time ordering** of the work list (rows carry no timestamps; PR number is the proxy).
- **Kick template** (`reviewer-lane.md` embedded default) — the hardcoded builder is the fallback per the existing Phase-4 plan; operators can already override via `kick_template`/prompt editor.
