### PR TITLE
✨ feat(tui): model picker overlay and apply (T17)

### DIFF
--- a/src/pkg/tui/app.go
+++ b/src/pkg/tui/app.go
@@ -135,7 +135,7 @@ const (
 // (m model, A acmm, …) documents keys whose tasks have not landed;
 // showing them now would advertise actions that silently do nothing. Each
 // action task appends its own binding when it wires the key.
-const footerText = "tab focus  p pause/resume  K kick  a attach  ? help  q quit"
+const footerText = "tab focus  p pause/resume  m model  K kick  a attach  ? help  q quit"
 
 // confirmState is the pause/resume dialog. It remains present while the HTTP
 // command is in flight so every other key stays behind the modal, and it also
@@ -167,6 +167,28 @@ type kickResultMsg struct {
 	agent  string
 	result client.KickResult
 	err    error
+}
+
+// modelListMsg is the asynchronous result of the model picker's catalogue
+// call. The pickerID it was issued for travels with it so a response for an
+// overlay the operator has already closed — or closed and reopened — cannot
+// populate the newer one with the older one's backend.
+type modelListMsg struct {
+	pickerID uint64
+	list     client.ModelList
+	err      error
+}
+
+// modelSetMsg is the asynchronous result of applying a model. Like
+// agentActionMsg it carries its own identity plus the target, because this
+// write RESTARTS the agent's session: a response matched to the wrong overlay
+// would report a restart that did not happen to that agent.
+type modelSetMsg struct {
+	pickerID uint64
+	agent    string
+	model    string
+	result   client.ModelSetResult
+	err      error
 }
 
 // model is the root bubbletea model.
@@ -207,6 +229,18 @@ type model struct {
 	// confirm is non-nil while a pause/resume dialog is open. Like help, it
 	// owns every key while visible; unlike help, only y, n and esc act on it.
 	confirm *confirmState
+
+	// picker is non-nil while the model picker overlay is open. Like confirm
+	// it owns every key while visible, so no key an operator presses inside it
+	// can reach quit, focus, pause, kick, attach or the ACMM binding.
+	picker *panes.ModelPicker
+
+	// pickerSeq identifies each opened overlay so a late catalogue or set
+	// response can be discarded if it belongs to a superseded one.
+	pickerSeq uint64
+
+	// pickerID is the sequence number of the currently open overlay.
+	pickerID uint64
 
 	// actionSeq identifies each confirmed HTTP call. Agent and verb alone are
 	// not enough: an operator can dismiss an in-flight request and open the
@@ -368,6 +402,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleAgentAction(msg)
 	case kickResultMsg:
 		return m.handleKickResult(msg)
+	case modelListMsg:
+		return m.handleModelList(msg)
+	case modelSetMsg:
+		return m.handleModelSet(msg)
 	case attachReadyMsg:
 		if msg.err != nil {
 			m.attachPending = false
@@ -388,6 +426,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		if m.confirm != nil {
 			return m.updateConfirm(msg)
+		}
+		// The model picker is modal for the same reason and is checked in the
+		// same place: every key it does not act on is SWALLOWED, so no key
+		// pressed while choosing a model can reach quit, focus, pause, kick,
+		// attach or the ACMM binding underneath it.
+		if m.picker != nil {
+			return m.updateModelPicker(msg)
 		}
 		// The help overlay is modal and dismisses on ANY key, so it is handled
 		// before the global bindings rather than as one of them. Order is the
@@ -431,6 +476,34 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.confirm = &confirmState{agent: name, pause: !paused}
 			return m, nil
+		case "m":
+			if m.focus != 0 {
+				return m, nil
+			}
+			agents, ok := m.panes[0].(panes.Agents)
+			if !ok {
+				return m, nil
+			}
+			name, display, backend, current, ok := agents.SelectedAgentDetail()
+			if !ok {
+				// No row selected yet — before the first successful fleet
+				// snapshot there is no agent to change, so `m` is a no-op
+				// rather than an overlay addressed at nothing.
+				return m, nil
+			}
+			if backend == "" {
+				// Models() requires a backend, and asking with an empty one
+				// would 404 on the routing table rather than on the backend.
+				// Say what is missing instead of showing a fetch error.
+				m.footerStatus = "Model picker unavailable: " + name + " has no configured backend"
+				return m, nil
+			}
+			m.pickerSeq++
+			m.pickerID = m.pickerSeq
+			picker := panes.NewModelPicker(name, display, backend, current)
+			m.picker = &picker
+			m.footerStatus = ""
+			return m, m.fetchModels(m.pickerID, backend)
 		case "K":
 			if m.focus != 0 || m.kickPending != "" {
 				return m, nil
@@ -543,11 +616,21 @@ func (m model) View() string {
 	if m.footerStatus != "" {
 		footerTextForFrame = m.footerStatus
 	}
-	footer := footerStyle.Width(m.width).MaxWidth(m.width).Render(footerTextForFrame)
+	// Clipped BEFORE the width is applied, then padded to it. Width() wraps
+	// rather than truncates, so a strip longer than the terminal — which the
+	// binding list became once `m model` was added, at 68 columns against a
+	// 60-column minimum — would silently become a SECOND footer line and push
+	// the frame one row past the terminal's height. MaxWidth() alone cannot
+	// undo that: by the time it runs the newline is already in the string.
+	footer := footerStyle.Width(m.width).Render(
+		lipgloss.NewStyle().Inline(true).MaxWidth(m.width).Render(footerTextForFrame))
 
 	frame := lipgloss.JoinVertical(lipgloss.Left, header, top, bottom, footer)
 	if m.confirm != nil {
 		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, m.confirmView())
+	}
+	if m.picker != nil {
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, m.picker.View(m.width))
 	}
 	if m.helpVisible {
 		// Place, not Join: the overlay sits ON the frame rather than taking
@@ -684,6 +767,116 @@ func (m model) handleKickResult(msg kickResultMsg) (tea.Model, tea.Cmd) {
 		m.footerStatus = fmt.Sprintf("Kick returned status %q for %s", msg.result.Status, agent)
 	}
 	return m, nil
+}
+
+// ── Model picker (T17) ───────────────────────────────────────────────────────
+
+// updateModelPicker consumes EVERY key while the overlay is open. Unknown keys
+// — including q, tab, p, K, a and A — deliberately do nothing rather than
+// leaking to the frame underneath, which is the whole point of the modal: an
+// operator scrolling a model list must not be able to quit the program or
+// pause an agent by pressing the wrong letter.
+func (m model) updateModelPicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		if m.picker.Pending() {
+			// A set request is already with the server and has already
+			// restarted (or is restarting) the session. Closing the overlay
+			// would not undo that, and it would hide the result, so the modal
+			// stays until the request answers.
+			return m, nil
+		}
+		m.picker = nil
+		return m, nil
+	case "j", "down":
+		next := m.picker.Move(1)
+		m.picker = &next
+		return m, nil
+	case "k", "up":
+		next := m.picker.Move(-1)
+		m.picker = &next
+		return m, nil
+	case "enter":
+		// Apply refuses while pending, which is what bounds this to exactly
+		// one session-restarting request no matter how many times enter is
+		// pressed before the first one answers.
+		next, chosen, ok := m.picker.Apply()
+		if !ok {
+			return m, nil
+		}
+		m.picker = &next
+		return m, m.setAgentModel(m.pickerID, next.Agent(), chosen)
+	default:
+		return m, nil
+	}
+}
+
+func (m model) fetchModels(pickerID uint64, backend string) tea.Cmd {
+	return func() tea.Msg {
+		list, err := m.api.Models(context.Background(), backend)
+		return modelListMsg{pickerID: pickerID, list: list, err: err}
+	}
+}
+
+func (m model) setAgentModel(pickerID uint64, agent, modelID string) tea.Cmd {
+	return func() tea.Msg {
+		result, err := m.api.SetAgentModel(context.Background(), agent, modelID)
+		return modelSetMsg{pickerID: pickerID, agent: agent, model: modelID, result: result, err: err}
+	}
+}
+
+func (m model) handleModelList(msg modelListMsg) (tea.Model, tea.Cmd) {
+	// A response for a closed or superseded overlay is dropped. It carries a
+	// catalogue for a backend the current overlay may not even be showing.
+	if m.picker == nil || m.pickerID != msg.pickerID {
+		return m, nil
+	}
+	var next panes.ModelPicker
+	if msg.err != nil {
+		next = m.picker.SetCatalogueError(msg.err)
+	} else {
+		next = m.picker.SetCatalogue(msg.list)
+	}
+	m.picker = &next
+	return m, nil
+}
+
+func (m model) handleModelSet(msg modelSetMsg) (tea.Model, tea.Cmd) {
+	matchesOpenModal := m.picker != nil && m.pickerID == msg.pickerID
+
+	if msg.err != nil {
+		if matchesOpenModal {
+			// The overlay stays open with the failure and retry/cancel
+			// guidance, and the Agents row is untouched: a failed write means
+			// the agent still has the model it had.
+			next := m.picker.SetApplyError(msg.err)
+			m.picker = &next
+		}
+		return m, nil
+	}
+
+	// The response is authoritative for what the agent now runs. Prefer it
+	// over the id that was requested so an alias the server canonicalized is
+	// shown as the server resolved it.
+	agent := msg.result.Agent
+	if agent == "" {
+		agent = msg.agent
+	}
+	applied := msg.result.Model
+	if applied == "" {
+		applied = msg.model
+	}
+	if agents, ok := m.panes[0].(panes.Agents); ok {
+		m.panes[0] = agents.SetAgentModel(agent, applied)
+	}
+	if matchesOpenModal {
+		m.picker = nil
+	}
+	m.footerStatus = fmt.Sprintf("%s now on %s (session restarted)", agent, applied)
+	// Reconcile: the write restarted the session, so the roster's live fields
+	// are stale by definition and the next frame should not wait a poll
+	// interval to say so.
+	return m, m.poll()
 }
 
 func (m model) confirmView() string {

--- a/src/pkg/tui/modelpicker_test.go
+++ b/src/pkg/tui/modelpicker_test.go
@@ -1,0 +1,601 @@
+package tui
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/kubestellar/hive/pkg/tui/client"
+	"github.com/kubestellar/hive/pkg/tui/panes"
+)
+
+var (
+	modelKey = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")}
+	enterKey = tea.KeyMsg{Type: tea.KeyEnter}
+	escKey   = tea.KeyMsg{Type: tea.KeyEsc}
+)
+
+// runCmd runs a command to completion and feeds its message back into the
+// model, which is what bubbletea's runtime does. Returning the model lets a
+// test drive open → fetch → respond without a program or a terminal.
+func runCmd(t *testing.T, m model, cmd tea.Cmd) model {
+	t.Helper()
+	if cmd == nil {
+		return m
+	}
+	msg := cmd()
+	if msg == nil {
+		return m
+	}
+	next, _ := m.Update(msg)
+	return next.(model)
+}
+
+func modelPickerModel(t *testing.T, agents ...client.Agent) model {
+	t.Helper()
+	if len(agents) == 0 {
+		agents = []client.Agent{{Name: "scanner", DisplayName: "Scanner", Enabled: true, Backend: "claude", Model: "claude-opus-4-5"}}
+	}
+	m := newModel()
+	m.width, m.height = 100, 30
+	next, _ := m.Update(panes.AgentsMsg{Agents: agents})
+	return next.(model)
+}
+
+// TestModelKeyOpensOnlyForASelectedAgentInTheFocusedPane. `m` addressed at a
+// pane that has no agent — or at a different pane entirely — must be a no-op
+// rather than an overlay pointed at nothing.
+func TestModelKeyOpensOnlyForASelectedAgentInTheFocusedPane(t *testing.T) {
+	t.Run("no fleet snapshot yet", func(t *testing.T) {
+		m := newModel()
+		m.width, m.height = 100, 30
+		next, cmd := m.Update(modelKey)
+		if next.(model).picker != nil {
+			t.Error("m opened a picker before any agent existed to change")
+		}
+		if cmd != nil {
+			t.Error("m issued a request with no agent selected")
+		}
+	})
+
+	t.Run("another pane focused", func(t *testing.T) {
+		m := modelPickerModel(t)
+		m.focus = 1
+		next, cmd := m.Update(modelKey)
+		if next.(model).picker != nil {
+			t.Error("m opened the picker while the Agents pane was not focused")
+		}
+		if cmd != nil {
+			t.Error("m issued a catalogue request from an unfocused Agents pane")
+		}
+	})
+
+	t.Run("agent with no backend", func(t *testing.T) {
+		// Models() requires a backend; asking with an empty one would 404 on
+		// the routing table and be reported as a broken catalogue instead of a
+		// missing configuration.
+		m := modelPickerModel(t, client.Agent{Name: "scanner", Enabled: true})
+		next, cmd := m.Update(modelKey)
+		got := next.(model)
+		if got.picker != nil {
+			t.Error("m opened a picker for an agent with no configured backend")
+		}
+		if cmd != nil {
+			t.Error("m issued a catalogue request with an empty backend")
+		}
+		if !strings.Contains(got.footerStatus, "no configured backend") {
+			t.Errorf("footer does not explain why nothing opened: %q", got.footerStatus)
+		}
+	})
+}
+
+// TestModelKeyRequestsTheSelectedAgentsBackend: the catalogue is
+// backend-qualified, so opening the overlay for the second row must ask about
+// THAT row's backend.
+func TestModelKeyRequestsTheSelectedAgentsBackend(t *testing.T) {
+	var requested atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"backend":"copilot","models":["gpt-5"]}`)
+	}))
+	t.Cleanup(server.Close)
+	pinDashboard(t, server.URL)
+
+	m := modelPickerModel(t,
+		client.Agent{Name: "scanner", Enabled: true, Backend: "claude", Model: "claude-opus-4-5"},
+		client.Agent{Name: "quality", Enabled: true, Backend: "copilot", Model: "gpt-5"},
+	)
+	m.api = client.New()
+	// Move the selection to the second row through the pane's own binding.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m = next.(model)
+
+	next, cmd := m.Update(modelKey)
+	m = next.(model)
+	if m.picker == nil {
+		t.Fatal("m did not open the picker for a selected agent")
+	}
+	if got := m.picker.Agent(); got != "quality" {
+		t.Errorf("picker agent = %q, want the selected row", got)
+	}
+	if got := m.picker.Backend(); got != "copilot" {
+		t.Errorf("picker backend = %q, want the selected agent's backend", got)
+	}
+	m = runCmd(t, m, cmd)
+	if got, _ := requested.Load().(string); got != "/api/inference/models/copilot" {
+		t.Errorf("catalogue request path = %q, want the selected agent's backend", got)
+	}
+	if m.picker == nil || m.picker.Loading() {
+		t.Error("the catalogue response did not reach the open overlay")
+	}
+}
+
+// TestModelPickerConsumesEveryGlobalBinding is the containment guarantee.
+// While the overlay is up, no key may reach quit, focus, pause, kick, attach
+// or the ACMM binding underneath it — an operator scrolling a model list must
+// not be able to quit the program or restart a different agent by typo.
+func TestModelPickerConsumesEveryGlobalBinding(t *testing.T) {
+	keys := []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("q")},
+		{Type: tea.KeyCtrlC},
+		{Type: tea.KeyTab},
+		{Type: tea.KeyShiftTab},
+		{Type: tea.KeyRunes, Runes: []rune("p")},
+		{Type: tea.KeyRunes, Runes: []rune("K")},
+		{Type: tea.KeyRunes, Runes: []rune("a")},
+		{Type: tea.KeyRunes, Runes: []rune("A")},
+		{Type: tea.KeyRunes, Runes: []rune("?")},
+		{Type: tea.KeyRunes, Runes: []rune("y")},
+		{Type: tea.KeyRunes, Runes: []rune("n")},
+	}
+	for _, key := range keys {
+		t.Run(key.String(), func(t *testing.T) {
+			m := modelPickerModel(t)
+			next, _ := m.Update(modelKey)
+			m = next.(model)
+			if m.picker == nil {
+				t.Fatal("the picker did not open")
+			}
+			openFocus := m.focus
+
+			next, cmd := m.Update(key)
+			got := next.(model)
+
+			if got.picker == nil {
+				t.Fatalf("%s closed the model picker; only esc may", key.String())
+			}
+			if cmd != nil {
+				t.Errorf("%s produced a command while the picker was modal", key.String())
+			}
+			if got.focus != openFocus {
+				t.Errorf("%s moved pane focus behind the modal", key.String())
+			}
+			if got.confirm != nil {
+				t.Errorf("%s opened the pause dialog behind the modal", key.String())
+			}
+			if got.helpVisible {
+				t.Errorf("%s opened help behind the modal", key.String())
+			}
+			if got.kickPending != "" {
+				t.Errorf("%s queued a kick behind the modal", key.String())
+			}
+			if got.attachPending {
+				t.Errorf("%s started an attach behind the modal", key.String())
+			}
+		})
+	}
+}
+
+// TestModelPickerEscClosesWithoutRequest.
+func TestModelPickerEscClosesWithoutRequest(t *testing.T) {
+	m := modelPickerModel(t)
+	next, _ := m.Update(modelKey)
+	m = next.(model)
+	next, cmd := m.Update(escKey)
+	if next.(model).picker != nil {
+		t.Error("esc did not close the picker")
+	}
+	if cmd != nil {
+		t.Error("esc issued a request")
+	}
+}
+
+// TestModelPickerEnterIssuesExactlyOneRequestWhilePending is the acceptance
+// criterion this whole modal exists to satisfy: POST /api/model restarts the
+// agent's session, so repeated enter presses before the first response must
+// not restart it repeatedly.
+func TestModelPickerEnterIssuesExactlyOneRequestWhilePending(t *testing.T) {
+	var sets atomic.Int64
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/inference/models/"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"backend":"claude","models":["claude-opus-4-5","claude-sonnet-4-5"]}`)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/model/"):
+			sets.Add(1)
+			// Block so the request is genuinely in flight while the extra
+			// enter presses are delivered.
+			<-release
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"status":"ok","agent":"scanner","model":"claude-sonnet-4-5"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+	pinDashboard(t, server.URL)
+
+	m := modelPickerModel(t)
+	m.api = client.New()
+	next, cmd := m.Update(modelKey)
+	m = runCmd(t, next.(model), cmd)
+	if m.picker == nil || m.picker.Loading() {
+		t.Fatal("the catalogue did not load")
+	}
+
+	// Select the second model, then press enter repeatedly.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m = next.(model)
+
+	next, applyCmd := m.Update(enterKey)
+	m = next.(model)
+	if applyCmd == nil {
+		t.Fatal("the first enter did not issue a model-set request")
+	}
+	if !m.picker.Pending() {
+		t.Fatal("the first enter did not put the overlay in a pending state")
+	}
+	// Issue the (blocking) request the way bubbletea would: on its own
+	// goroutine, so the model can keep processing keys while it is in flight.
+	done := make(chan tea.Msg, 1)
+	go func() { done <- applyCmd() }()
+
+	for i := 0; i < 5; i++ {
+		next, extra := m.Update(enterKey)
+		m = next.(model)
+		if extra != nil {
+			t.Fatalf("enter press %d issued a second model-set request while one was pending", i+2)
+		}
+		if m.picker == nil {
+			t.Fatalf("enter press %d closed the pending overlay", i+2)
+		}
+	}
+	// esc must not escape a pending request either: the restart is already
+	// under way and hiding it would leave the operator with no result.
+	next, escCmd := m.Update(escKey)
+	m = next.(model)
+	if m.picker == nil {
+		t.Error("esc closed the overlay while a session-restarting request was in flight")
+	}
+	if escCmd != nil {
+		t.Error("esc issued a command while pending")
+	}
+
+	release <- struct{}{}
+	select {
+	case msg := <-done:
+		next, _ := m.Update(msg)
+		m = next.(model)
+	case <-time.After(finalWait):
+		t.Fatal("the model-set request never answered")
+	}
+	if got := sets.Load(); got != 1 {
+		t.Fatalf("model-set requests = %d, want exactly 1 — the agent restarted %d times", got, got)
+	}
+	if m.picker != nil {
+		t.Error("a successful apply left the overlay open")
+	}
+}
+
+// TestModelPickerSuccessUpdatesTheRowImmediately: the fleet poll is on a five
+// second cadence, so a successful change that waited for it would leave the
+// old model on screen for seconds after the agent had already restarted onto
+// the new one.
+func TestModelPickerSuccessUpdatesTheRowImmediately(t *testing.T) {
+	m := modelPickerModel(t)
+	next, _ := m.Update(modelKey)
+	m = next.(model)
+	next, _ = m.Update(modelListMsg{
+		pickerID: m.pickerID,
+		list:     client.ModelList{Backend: "claude", Models: []client.ModelOption{"claude-opus-4-5", "claude-sonnet-4-5"}},
+	})
+	m = next.(model)
+
+	next, _ = m.Update(modelSetMsg{
+		pickerID: m.pickerID,
+		agent:    "scanner",
+		model:    "claude-sonnet-4-5",
+		result:   client.ModelSetResult{Status: "ok", Agent: "scanner", Model: "claude-sonnet-4-5"},
+	})
+	m = next.(model)
+
+	if m.picker != nil {
+		t.Error("a successful apply left the overlay open")
+	}
+	if !strings.Contains(m.View(), "claude-sonnet-4-5") {
+		t.Error("the Agents row still shows the previous model after a successful change")
+	}
+	if !strings.Contains(m.footerStatus, "session restarted") {
+		t.Errorf("the footer does not report the restart: %q", m.footerStatus)
+	}
+}
+
+// TestModelPickerAppliesTheServersModelNotTheRequestedOne: the response is
+// authoritative. A gateway that canonicalizes an alias must be reflected as it
+// resolved it, not as the operator typed it.
+func TestModelPickerAppliesTheServersModelNotTheRequestedOne(t *testing.T) {
+	m := modelPickerModel(t)
+	next, _ := m.Update(modelKey)
+	m = next.(model)
+	next, _ = m.Update(modelListMsg{pickerID: m.pickerID, list: client.ModelList{
+		Backend: "claude", Models: []client.ModelOption{"opus"},
+	}})
+	m = next.(model)
+	next, _ = m.Update(modelSetMsg{
+		pickerID: m.pickerID,
+		agent:    "scanner",
+		model:    "opus",
+		result:   client.ModelSetResult{Status: "ok", Agent: "scanner", Model: "claude-opus-4-5"},
+	})
+	m = next.(model)
+
+	agents := m.panes[0].(panes.Agents)
+	_, _, _, gotModel, ok := agents.SelectedAgentDetail()
+	if !ok || gotModel != "claude-opus-4-5" {
+		t.Errorf("row model = %q, want the server's canonical id", gotModel)
+	}
+}
+
+// TestModelPickerFailurePreservesTheRowAndOffersRetry covers the failure
+// classes the acceptance criteria names — 400 validation, 403, and a transport
+// error — at the app level: the overlay stays open, the row is untouched, and
+// the operator can retry or cancel.
+func TestModelPickerFailurePreservesTheRowAndOffersRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "400 validation",
+			err:  &client.APIError{StatusCode: http.StatusBadRequest, Method: http.MethodPost, Path: "/api/model/scanner/bogus", Body: "unsupported model"},
+			want: "unsupported model",
+		},
+		{
+			name: "403 forbidden",
+			err:  &client.APIError{StatusCode: http.StatusForbidden, Method: http.MethodPost, Path: "/api/model/scanner/claude-sonnet-4-5"},
+			want: "owner access required",
+		},
+		{
+			name: "transport error",
+			err:  fmt.Errorf("dial tcp: connection refused"),
+			want: "connection refused",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := modelPickerModel(t)
+			next, _ := m.Update(modelKey)
+			m = next.(model)
+			next, _ = m.Update(modelListMsg{pickerID: m.pickerID, list: client.ModelList{
+				Backend: "claude", Models: []client.ModelOption{"claude-opus-4-5", "claude-sonnet-4-5"},
+			}})
+			m = next.(model)
+			next, _ = m.Update(enterKey)
+			m = next.(model)
+
+			next, _ = m.Update(modelSetMsg{pickerID: m.pickerID, agent: "scanner", model: "claude-opus-4-5", err: tc.err})
+			m = next.(model)
+
+			if m.picker == nil {
+				t.Fatal("a failed apply closed the overlay, so the operator never sees why")
+			}
+			if m.picker.Pending() {
+				t.Error("a failed apply left the overlay pending, so retry is impossible")
+			}
+			flatView := strings.Join(strings.Fields(m.View()), " ")
+			if !strings.Contains(flatView, tc.want) {
+				t.Errorf("the overlay does not report %q:\n%s", tc.want, m.View())
+			}
+			// The row keeps the model the agent still actually runs.
+			agents := m.panes[0].(panes.Agents)
+			_, _, _, gotModel, _ := agents.SelectedAgentDetail()
+			if gotModel != "claude-opus-4-5" {
+				t.Errorf("a failed change rewrote the row to %q", gotModel)
+			}
+			// Retry is accepted exactly once.
+			next, retry := m.Update(enterKey)
+			m = next.(model)
+			if retry == nil {
+				t.Fatal("enter after a failure did not retry")
+			}
+			if _, again := m.Update(enterKey); again != nil {
+				t.Error("the retry is not single-shot")
+			}
+		})
+	}
+}
+
+// TestModelPickerCatalogueStatesReachTheOverlay walks the catalogue outcomes
+// through the app so the wiring — not only the pane — is covered for each.
+func TestModelPickerCatalogueStatesReachTheOverlay(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  func(id uint64) modelListMsg
+		want string
+		// selectable is whether enter should have anything to apply.
+		selectable bool
+	}{
+		{
+			name: "success",
+			msg: func(id uint64) modelListMsg {
+				return modelListMsg{pickerID: id, list: client.ModelList{Backend: "claude", Models: []client.ModelOption{"claude-opus-4-5"}}}
+			},
+			want:       "claude-opus-4-5",
+			selectable: true,
+		},
+		{
+			name: "empty successful catalogue",
+			msg: func(id uint64) modelListMsg {
+				return modelListMsg{pickerID: id, list: client.ModelList{Backend: "claude"}}
+			},
+			want: "no models reported",
+		},
+		{
+			name: "fallback",
+			msg: func(id uint64) modelListMsg {
+				return modelListMsg{pickerID: id, list: client.ModelList{Backend: "claude", Models: []client.ModelOption{"claude-opus-4-5"}, Fallback: true}}
+			},
+			want:       "Unverified",
+			selectable: true,
+		},
+		{
+			name: "partial",
+			msg: func(id uint64) modelListMsg {
+				return modelListMsg{pickerID: id, list: client.ModelList{Backend: "claude", Models: []client.ModelOption{"claude-opus-4-5"}, Partial: true}}
+			},
+			want:       "Incomplete",
+			selectable: true,
+		},
+		{
+			name: "404 is not an error",
+			msg: func(id uint64) modelListMsg {
+				return modelListMsg{pickerID: id, err: &client.APIError{StatusCode: http.StatusNotFound, Method: http.MethodGet, Path: "/api/inference/models/watsonx"}}
+			},
+			want: "no model catalogue for this backend",
+		},
+		{
+			name: "403",
+			msg: func(id uint64) modelListMsg {
+				return modelListMsg{pickerID: id, err: &client.APIError{StatusCode: http.StatusForbidden, Method: http.MethodGet, Path: "/api/inference/models/claude"}}
+			},
+			want: "owner access required",
+		},
+		{
+			name: "transport error",
+			msg: func(id uint64) modelListMsg {
+				return modelListMsg{pickerID: id, err: fmt.Errorf("dial tcp: connection refused")}
+			},
+			want: "Catalogue unavailable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := modelPickerModel(t)
+			next, _ := m.Update(modelKey)
+			m = next.(model)
+			if !m.picker.Loading() {
+				t.Fatal("the overlay did not open in a loading state")
+			}
+			if !strings.Contains(m.View(), "Loading models") {
+				t.Errorf("the loading state is not visible:\n%s", m.View())
+			}
+
+			next, _ = m.Update(tc.msg(m.pickerID))
+			m = next.(model)
+			if m.picker == nil {
+				t.Fatal("the catalogue response closed the overlay")
+			}
+			if m.picker.Loading() {
+				t.Error("the overlay is still loading after a response")
+			}
+			flatView := strings.Join(strings.Fields(m.View()), " ")
+			if !strings.Contains(flatView, tc.want) {
+				t.Errorf("the overlay does not show %q:\n%s", tc.want, m.View())
+			}
+			// The restart warning is guidance BEFORE the key press, so it is
+			// present in every state enter can be pressed from.
+			if !strings.Contains(flatView, "Applying restarts the agent's session.") {
+				t.Errorf("the overlay omits the restart warning:\n%s", m.View())
+			}
+
+			_, cmd := m.Update(enterKey)
+			if tc.selectable && cmd == nil {
+				t.Error("enter did not apply from a selectable catalogue")
+			}
+			if !tc.selectable && cmd != nil {
+				t.Error("enter issued a request with nothing selectable")
+			}
+		})
+	}
+}
+
+// TestModelPickerIgnoresResponsesForSupersededOverlays: an operator can close
+// an overlay and open another before the first request answers. A late
+// response must not populate — or close — the newer one.
+func TestModelPickerIgnoresResponsesForSupersededOverlays(t *testing.T) {
+	m := modelPickerModel(t)
+	next, _ := m.Update(modelKey)
+	m = next.(model)
+	stale := m.pickerID
+
+	next, _ = m.Update(escKey)
+	m = next.(model)
+	next, _ = m.Update(modelKey)
+	m = next.(model)
+	if m.pickerID == stale {
+		t.Fatal("reopening the overlay reused the previous request identity")
+	}
+
+	next, _ = m.Update(modelListMsg{pickerID: stale, list: client.ModelList{
+		Backend: "claude", Models: []client.ModelOption{"stale-model"},
+	}})
+	m = next.(model)
+	if !m.picker.Loading() {
+		t.Error("a superseded catalogue response populated the current overlay")
+	}
+	if strings.Contains(m.View(), "stale-model") {
+		t.Error("a superseded catalogue reached the screen")
+	}
+
+	next, _ = m.Update(modelSetMsg{pickerID: stale, agent: "scanner", model: "stale-model",
+		result: client.ModelSetResult{Status: "ok", Agent: "scanner", Model: "stale-model"}})
+	m = next.(model)
+	if m.picker == nil {
+		t.Error("a superseded apply response closed the current overlay")
+	}
+}
+
+// TestFooterAdvertisesModel is the honesty rule app.go's footerText documents:
+// a binding is listed only once pressing it does something. It is asserted
+// from the rendered frame rather than the constant, because the frame is what
+// the operator reads.
+func TestFooterAdvertisesModel(t *testing.T) {
+	m := modelPickerModel(t)
+	if !strings.Contains(m.View(), "m model") {
+		t.Errorf("the footer does not advertise the now-wired m binding:\n%s", m.View())
+	}
+}
+
+// TestFooterIsClippedNotWrappedAtTheMinimumWidth pins what adding `m model`
+// broke. The strip is now 68 columns against a 60-column minimum terminal, and
+// lipgloss's Width() WRAPS rather than truncates — so an over-long footer
+// became a second line and pushed the frame one row past the terminal's
+// height. Any future binding added to the strip will fail here rather than
+// silently corrupting the frame on a small terminal.
+func TestFooterIsClippedNotWrappedAtTheMinimumWidth(t *testing.T) {
+	if len(footerText) <= minWidth {
+		t.Skipf("footer is %d columns, still within the %d-column minimum; this test guards the case where it is not",
+			len(footerText), minWidth)
+	}
+	m := modelPickerModel(t)
+	m.width, m.height = minWidth, minHeight
+	view := m.View()
+	if got := lipgloss.Height(view); got != minHeight {
+		t.Errorf("frame at %dx%d renders %d lines, want exactly %d — the footer wrapped",
+			minWidth, minHeight, got, minHeight)
+	}
+	if got := lipgloss.Width(view); got != minWidth {
+		t.Errorf("frame width = %d, want %d", got, minWidth)
+	}
+}

--- a/src/pkg/tui/panes/agents.go
+++ b/src/pkg/tui/panes/agents.go
@@ -75,6 +75,62 @@ func (p Agents) SelectedAgent() (name string, paused bool, ok bool) {
 	return agent.Name, !agent.Enabled, true
 }
 
+// SelectedAgentDetail returns the fields the model picker needs about the row
+// under the cursor: the canonical config-key name the /api/model write is
+// addressed to, the display label, the configured backend whose catalogue is
+// fetched, and the configured model to preselect.
+//
+// It is a second narrow accessor rather than a widening of SelectedAgent
+// because the two callers want different things and SelectedAgent's paused bit
+// is joined from supplemental status data that this caller has no use for.
+// Both exist so the app never reaches into pane internals for a row.
+//
+// Name is deliberately separate from Display: the write must address the agent
+// by its config key, and an agent whose displayName differs would be sent to a
+// path that does not exist if the label leaked into the request.
+func (p Agents) SelectedAgentDetail() (name, display, backend, model string, ok bool) {
+	if p.selected < 0 || p.selected >= len(p.agents) {
+		return "", "", "", "", false
+	}
+	agent := p.agents[p.selected]
+	display = agent.DisplayName
+	if display == "" {
+		display = agent.Name
+	}
+	return agent.Name, display, agent.Backend, agent.Model, true
+}
+
+// SetAgentModel applies the authoritative model returned by a successful model
+// change immediately, for the same reason SetAgentPaused does: the app also
+// refreshes the fleet afterwards, but reflecting the response here stops a
+// successful change from leaving the old model on screen while that refresh is
+// in flight, or if it fails.
+//
+// An unknown agent is ignored rather than inserted. A response naming an agent
+// that is not in the current roster is either stale or wrong, and inventing a
+// row from it would put an agent on screen that /api/agents does not list.
+func (p Agents) SetAgentModel(name, model string) Agents {
+	if model == "" {
+		// The write's authoritative response is the only source for this. An
+		// empty model would blank the column with no fact behind it.
+		return p
+	}
+	agents := append([]client.Agent(nil), p.agents...)
+	found := false
+	for i := range agents {
+		if agents[i].Name == name {
+			agents[i].Model = model
+			found = true
+			break
+		}
+	}
+	if !found {
+		return p
+	}
+	p.agents = agents
+	return p
+}
+
 // SetAgentPaused applies the authoritative state returned by a pause/resume
 // operation immediately. The app still refreshes the full fleet afterwards,
 // but reflecting the response here prevents a successful action from leaving

--- a/src/pkg/tui/panes/agents_test.go
+++ b/src/pkg/tui/panes/agents_test.go
@@ -188,3 +188,79 @@ func TestAgentsViewFillsItsBoxExactly(t *testing.T) {
 		}
 	}
 }
+
+// TestSelectedAgentDetailReportsTheRowUnderTheCursor is the accessor the model
+// picker opens through. It exists so the app never reaches into pane internals
+// for a row, and it returns Name separately from Display because the write it
+// feeds addresses the agent by its CONFIG KEY.
+func TestSelectedAgentDetailReportsTheRowUnderTheCursor(t *testing.T) {
+	if _, _, _, _, ok := NewAgents().SelectedAgentDetail(); ok {
+		t.Error("a pre-poll pane offers a selected agent, so m would open on nothing")
+	}
+
+	loaded, _ := NewAgents().Update(AgentsMsg{Agents: []client.Agent{
+		{Name: "scanner", DisplayName: "Fleet Scanner", Backend: "claude", Model: "claude-opus-4-5", Enabled: true},
+		{Name: "quality", Backend: "copilot", Model: "gpt-5", Enabled: true},
+	}})
+	name, display, backend, model, ok := loaded.(Agents).SelectedAgentDetail()
+	if !ok {
+		t.Fatal("a loaded pane reports no selected agent")
+	}
+	if name != "scanner" || display != "Fleet Scanner" || backend != "claude" || model != "claude-opus-4-5" {
+		t.Errorf("SelectedAgentDetail() = (%q, %q, %q, %q), want the first row", name, display, backend, model)
+	}
+
+	moved, _ := loaded.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	name, display, backend, _, _ = moved.(Agents).SelectedAgentDetail()
+	if name != "quality" || backend != "copilot" {
+		t.Errorf("after j, SelectedAgentDetail() = (%q, %q), want the second row", name, backend)
+	}
+	// client.Agent marshals displayName with omitempty, so the pane falls back
+	// to Name exactly as the handler does.
+	if display != "quality" {
+		t.Errorf("display = %q, want a fallback to the agent's name", display)
+	}
+}
+
+// TestSetAgentModelAppliesTheAuthoritativeResponse: the write's response is
+// applied to the visible row immediately, so a successful change is not left
+// showing the old model for a poll interval.
+func TestSetAgentModelAppliesTheAuthoritativeResponse(t *testing.T) {
+	loaded, _ := NewAgents().Update(AgentsMsg{Agents: []client.Agent{agent("scanner")}})
+	p := loaded.(Agents)
+
+	updated := p.SetAgentModel("scanner", "claude-sonnet-4-5")
+	if _, _, _, model, _ := updated.SelectedAgentDetail(); model != "claude-sonnet-4-5" {
+		t.Errorf("row model = %q, want the applied model", model)
+	}
+	if !strings.Contains(updated.View(60, 10), "claude-sonnet") {
+		t.Errorf("the rendered row does not show the applied model:\n%s", updated.View(60, 10))
+	}
+	// The original value is untouched: Update's rule is that the input model
+	// is never mutated, and the roster is a slice shared by value.
+	if _, _, _, model, _ := p.SelectedAgentDetail(); model != "claude-opus-4-5" {
+		t.Errorf("SetAgentModel mutated the receiver's roster; model = %q", model)
+	}
+}
+
+// TestSetAgentModelIgnoresUnknownAgentsAndEmptyModels. A response naming an
+// agent the roster does not list is stale or wrong, and inventing a row from
+// it would show an agent /api/agents does not. An empty model would blank the
+// column with no fact behind it.
+func TestSetAgentModelIgnoresUnknownAgentsAndEmptyModels(t *testing.T) {
+	loaded, _ := NewAgents().Update(AgentsMsg{Agents: []client.Agent{agent("scanner")}})
+	p := loaded.(Agents)
+
+	for _, tc := range []struct{ name, model string }{
+		{"ghost", "claude-sonnet-4-5"},
+		{"scanner", ""},
+	} {
+		got := p.SetAgentModel(tc.name, tc.model)
+		if _, _, _, model, _ := got.SelectedAgentDetail(); model != "claude-opus-4-5" {
+			t.Errorf("SetAgentModel(%q, %q) changed the row to %q", tc.name, tc.model, model)
+		}
+		if view := got.View(60, 10); !strings.Contains(view, "claude-opus") {
+			t.Errorf("SetAgentModel(%q, %q) corrupted the row:\n%s", tc.name, tc.model, view)
+		}
+	}
+}

--- a/src/pkg/tui/panes/help.go
+++ b/src/pkg/tui/panes/help.go
@@ -45,7 +45,7 @@ func HelpBindings() []Binding {
 		{Keys: "q / ctrl+c", Action: "Quit", Scope: "global", Available: true},
 		{Keys: "j / k, ↓ / ↑", Action: "Move the selection within the focused pane", Scope: "Agents / Events panes", Available: true},
 		{Keys: "p", Action: "Pause or resume the selected agent", Scope: "Agents pane", Available: true},
-		{Keys: "m", Action: "Open the model picker for the selected agent", Scope: "Agents pane"},
+		{Keys: "m", Action: "Open the model picker for the selected agent", Scope: "Agents pane", Available: true},
 		{Keys: "K", Action: "Kick the selected agent now", Scope: "Agents pane", Available: true},
 		{Keys: "A", Action: "Open the ACMM level overlay", Scope: "global"},
 		{Keys: "a", Action: "Attach to the selected agent's tmux session", Scope: "Agents pane (local)", Available: true},

--- a/src/pkg/tui/panes/help_golden_test.go
+++ b/src/pkg/tui/panes/help_golden_test.go
@@ -104,6 +104,7 @@ func TestHelpMarksOnlyWiredBindingsAvailable(t *testing.T) {
 		"q / ctrl+c":      true, // T1
 		"j / k, ↓ / ↑":    true, // T5 and T11
 		"p":               true, // T15
+		"m":               true, // T17
 		"K":               true, // T21
 		"a":               true, // T22
 	}

--- a/src/pkg/tui/panes/modelpicker.go
+++ b/src/pkg/tui/panes/modelpicker.go
@@ -1,0 +1,430 @@
+package panes
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/kubestellar/hive/pkg/tui/client"
+	"github.com/kubestellar/hive/pkg/tui/theme"
+)
+
+// ModelPicker is the `m` overlay's whole state: which agent is being changed,
+// what the catalogue call returned, where the cursor is, and whether a set
+// request is in flight.
+//
+// It is a VALUE type with value receivers like every other pane, but unlike
+// the four grid panes it is not a Pane: it is never a cell, it is an overlay
+// the app raises over the grid. It therefore takes its keys from the app's
+// modal branch (app.go's updateModelPicker) rather than from the pane routing
+// seam, which is what makes "every key is consumed while open" a property of
+// one switch statement instead of a rule four panes have to remember.
+//
+// The catalogue this renders is QUALIFIED data (see client.ModelList). The
+// picker's job is to show the qualification, not to launder it: a fallback
+// list is a set of unverified guesses, a partial list is a floor, and neither
+// licenses the operator — or this code — to conclude that a model missing from
+// the list is unsupported (#4438).
+type ModelPicker struct {
+	// agent is the canonical config-key name the set request is addressed to,
+	// not the display name. It is what /api/model/{agent}/{model} expects.
+	agent string
+	// display is the label shown to the operator, which may be the display
+	// name. Kept separate so the request can never accidentally use it.
+	display string
+	// backend is the agent's configured backend, the required path parameter
+	// of GET /api/inference/models/{backend}.
+	backend string
+	// current is the agent's configured model at the moment the overlay
+	// opened, used for preselection and for the "unchanged" hint.
+	current string
+
+	// loading is true between opening and the catalogue call returning. It is
+	// distinct from "loaded an empty list": an operator must be able to tell a
+	// request still in flight from a backend that reported nothing.
+	loading bool
+	// loaded is true once a catalogue call has returned successfully, whether
+	// or not it carried any models.
+	loaded bool
+	// list is the last successful catalogue, including its qualification flags.
+	list client.ModelList
+	// listErr describes a catalogue call that failed in a way the operator has
+	// to be told about. A 404 is NOT one of those: see SetCatalogueError.
+	listErr string
+	// unavailable is the 404 case — a backend with no configured discovery
+	// endpoint. That is an ordinary state of a working hive, so it renders as
+	// "no catalogue" rather than as an error with retry guidance.
+	unavailable bool
+
+	// selected indexes list.Models.
+	selected int
+
+	// pending is true from the moment enter is accepted until the set request
+	// answers. It is the whole reason a second enter cannot restart the agent
+	// a second time, so the applying branch checks it before doing anything.
+	pending bool
+	// pendingModel is the id the in-flight request is setting, so the overlay
+	// can name it while working and so a late response for a superseded target
+	// can be recognised.
+	pendingModel string
+	// applyErr is a failed set request rendered as UI. The overlay stays open
+	// with retry/cancel guidance rather than the failure ending the program.
+	applyErr string
+}
+
+// NewModelPicker returns the overlay in its loading state for one agent.
+//
+// It is constructed already loading because the app opens it and issues the
+// catalogue call in the same Update: there is no frame in which the overlay is
+// open but nothing has been asked for, so there is no state for one.
+func NewModelPicker(agent, display, backend, current string) ModelPicker {
+	if display == "" {
+		display = agent
+	}
+	return ModelPicker{
+		agent:   agent,
+		display: display,
+		backend: backend,
+		current: current,
+		loading: true,
+	}
+}
+
+// Agent returns the canonical agent name the overlay is acting on.
+func (p ModelPicker) Agent() string { return p.agent }
+
+// Backend returns the backend whose catalogue the overlay requested.
+func (p ModelPicker) Backend() string { return p.backend }
+
+// Pending reports whether a set request is in flight. The app checks this
+// before accepting enter, which is what bounds the overlay to exactly one
+// session-restarting request at a time.
+func (p ModelPicker) Pending() bool { return p.pending }
+
+// Loading reports whether the catalogue call is still outstanding.
+func (p ModelPicker) Loading() bool { return p.loading }
+
+// Selected returns the model id under the cursor. ok is false whenever there
+// is nothing selectable — still loading, a failed or unavailable catalogue, or
+// a successful but empty one — so the app makes enter a no-op rather than
+// sending an empty model id the client would reject anyway.
+func (p ModelPicker) Selected() (string, bool) {
+	if p.loading || !p.loaded {
+		return "", false
+	}
+	if p.selected < 0 || p.selected >= len(p.list.Models) {
+		return "", false
+	}
+	return string(p.list.Models[p.selected]), true
+}
+
+// SetCatalogue records a successful catalogue response and preselects the
+// agent's current model when the list contains it.
+//
+// Preselection is a convenience, not an assertion: when the current model is
+// absent the cursor starts at the top and the overlay says the current model
+// is not listed, because on a fallback or partial list that absence is not
+// evidence the backend lacks it.
+func (p ModelPicker) SetCatalogue(list client.ModelList) ModelPicker {
+	p.loading = false
+	p.loaded = true
+	p.unavailable = false
+	p.listErr = ""
+	p.list = list
+	p.selected = 0
+	for i, m := range list.Models {
+		if string(m) == p.current && p.current != "" {
+			p.selected = i
+			break
+		}
+	}
+	return p
+}
+
+// SetCatalogueError records a failed catalogue call.
+//
+// A 404 is deliberately not an error here. GET /api/inference/models/{backend}
+// answers 404 for a backend with no configured discovery endpoint — watsonx or
+// litellm before a gateway is set up — which is an ordinary configuration, not
+// a broken hive. Rendering it with retry guidance would send an operator
+// looking for a fault that does not exist, so it becomes the
+// unavailable-catalogue state instead.
+func (p ModelPicker) SetCatalogueError(err error) ModelPicker {
+	p.loading = false
+	p.loaded = false
+	p.list = client.ModelList{}
+	p.selected = 0
+	if isNotFound(err) {
+		p.unavailable = true
+		p.listErr = ""
+		return p
+	}
+	p.unavailable = false
+	if client.IsForbidden(err) {
+		p.listErr = "Catalogue unavailable: owner access required"
+	} else {
+		p.listErr = fmt.Sprintf("Catalogue unavailable: %v", err)
+	}
+	return p
+}
+
+// isNotFound reports whether err is an APIError carrying 404.
+//
+// Written here rather than added to the client package because T17 is a UI
+// task and the issue puts client changes out of scope; client.IsForbidden is
+// the precedent for the shape, and errors.As over the exported APIError is the
+// documented way to ask.
+func isNotFound(err error) bool {
+	var apiErr *client.APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+// Apply marks a set request as started for the model under the cursor.
+//
+// It refuses when one is already pending, which is the guard the acceptance
+// criteria names: applying restarts the agent's session, so a second enter
+// arriving before the first answers must not restart it twice. ok reports
+// whether the caller should actually issue the request.
+func (p ModelPicker) Apply() (ModelPicker, string, bool) {
+	if p.pending {
+		return p, "", false
+	}
+	model, ok := p.Selected()
+	if !ok {
+		return p, "", false
+	}
+	p.pending = true
+	p.pendingModel = model
+	p.applyErr = ""
+	return p, model, true
+}
+
+// SetApplyError records a failed set request and clears the pending state so
+// the operator can retry or cancel.
+func (p ModelPicker) SetApplyError(err error) ModelPicker {
+	p.pending = false
+	if client.IsForbidden(err) {
+		p.applyErr = "Model change failed: owner access required"
+	} else {
+		p.applyErr = fmt.Sprintf("Model change failed: %v", err)
+	}
+	return p
+}
+
+// Move steps the cursor by delta and clamps at the list's edges, so holding a
+// direction key parks at an end rather than wrapping past it.
+func (p ModelPicker) Move(delta int) ModelPicker {
+	if len(p.list.Models) == 0 {
+		p.selected = 0
+		return p
+	}
+	next := p.selected + delta
+	if next < 0 {
+		next = 0
+	}
+	if next >= len(p.list.Models) {
+		next = len(p.list.Models) - 1
+	}
+	p.selected = next
+	return p
+}
+
+var (
+	modelPickerBoxStyle = lipgloss.NewStyle().
+				Border(lipgloss.ThickBorder()).
+				BorderForeground(theme.BorderFocus).
+				Padding(0, 1)
+	modelPickerTitleStyle  = lipgloss.NewStyle().Bold(true)
+	modelPickerErrorStyle  = lipgloss.NewStyle().Bold(true)
+	modelPickerNoteStyle   = lipgloss.NewStyle().Faint(true)
+	modelPickerCursorStyle = lipgloss.NewStyle().Bold(true)
+)
+
+// modelPickerRestartWarning is the one sentence the overlay may not omit.
+// POST /api/model/{agent}/{model} restarts the agent's session, which can
+// interrupt work in progress; an operator choosing from a list must be told
+// that before they press enter, not after.
+const modelPickerRestartWarning = "Applying restarts the agent's session."
+
+// The qualification labels. Each names what the flag actually means about the
+// list rather than grading it, because "unverified" and "incomplete" are
+// instructions to the reader about what a model's ABSENCE proves — namely
+// nothing.
+const (
+	modelPickerFallbackNote = "Unverified: discovery found nothing, so these are common aliases. " +
+		"A model missing here may still work."
+	modelPickerPartialNote = "Incomplete: only some endpoints answered. " +
+		"A model missing here may still be served by one that did not."
+	modelPickerEntitledNote = "Narrowed to the models this key is entitled to use"
+	modelPickerEmptyNote    = "no models reported"
+	modelPickerNoCatalogue  = "no model catalogue for this backend"
+)
+
+// modelPickerVisibleRows bounds the list so a backend advertising hundreds of
+// ids cannot grow the overlay past the terminal. The window scrolls with the
+// cursor; the count line above it says how much is off screen.
+const modelPickerVisibleRows = 8
+
+// View renders the overlay's box, sized to its own content. Placing it over
+// the frame is the app's job, matching the split pane.go draws between a
+// pane's content and the chrome around it.
+func (p ModelPicker) View(width int) string {
+	var body strings.Builder
+	body.WriteString(modelPickerTitleStyle.Render("Model for " + p.display))
+	body.WriteString("\n")
+	body.WriteString(modelPickerNoteStyle.Render(p.subtitle()))
+	body.WriteString("\n\n")
+	body.WriteString(p.bodyText())
+	body.WriteString("\n\n")
+	body.WriteString(modelPickerNoteStyle.Render(modelPickerRestartWarning))
+	body.WriteString("\n")
+	body.WriteString(modelPickerNoteStyle.Render(p.footer()))
+
+	// Matches confirmView's sizing so the two modals sit in the same place at
+	// the same widths; the extra columns give long model ids room to breathe.
+	contentWidth := min(60, max(1, width-6))
+	return modelPickerBoxStyle.Width(contentWidth).Render(body.String())
+}
+
+func (p ModelPicker) subtitle() string {
+	backend := p.backend
+	if backend == "" {
+		backend = "—"
+	}
+	current := p.current
+	if current == "" {
+		current = "—"
+	}
+	return fmt.Sprintf("backend %s   current %s", backend, current)
+}
+
+func (p ModelPicker) bodyText() string {
+	switch {
+	case p.applyErr != "":
+		// The failure is what the operator must read first, but the list stays
+		// under it: retry means "press enter on the same row", so hiding the
+		// row would make the guidance meaningless.
+		return modelPickerErrorStyle.Render(p.applyErr) + "\n\n" + p.listBody()
+	case p.pending:
+		return fmt.Sprintf("Applying %s… restarting the agent's session.", p.pendingModel)
+	default:
+		return p.listBody()
+	}
+}
+
+func (p ModelPicker) listBody() string {
+	switch {
+	case p.loading:
+		return "Loading models…"
+	case p.unavailable:
+		// Not an error: the backend simply has no discovery endpoint
+		// configured, so there is nothing to enumerate.
+		return modelPickerNoCatalogue + "\n" +
+			"This backend has no discovery endpoint configured."
+	case p.listErr != "":
+		return modelPickerErrorStyle.Render(p.listErr)
+	case !p.loaded:
+		return "Loading models…"
+	case len(p.list.Models) == 0:
+		// An empty SUCCESSFUL catalogue. Saying so explicitly is the
+		// difference between "the backend told us it has nothing" and a box
+		// that merely looks broken.
+		return modelPickerEmptyNote
+	}
+
+	var out strings.Builder
+	for _, note := range p.qualifications() {
+		out.WriteString(modelPickerNoteStyle.Render(note) + "\n")
+	}
+	if len(p.qualifications()) > 0 {
+		out.WriteString("\n")
+	}
+
+	start, end := p.window()
+	for i := start; i < end; i++ {
+		id := string(p.list.Models[i])
+		cursor := "  "
+		if i == p.selected {
+			cursor = modelPickerCursorStyle.Render("▸ ")
+		}
+		mark := ""
+		if id == p.current && p.current != "" {
+			mark = "  (current)"
+		}
+		out.WriteString(cursor + id + mark + "\n")
+	}
+	out.WriteString(modelPickerNoteStyle.Render(fmt.Sprintf("%d of %d", p.selected+1, len(p.list.Models))))
+	if p.current != "" && !p.currentListed() {
+		// Absence is not evidence, so this states the fact and not a verdict.
+		out.WriteString("\n" + modelPickerNoteStyle.Render(
+			"Current model "+p.current+" is not in this list."))
+	}
+	return out.String()
+}
+
+// qualifications returns the flag notes that apply to the loaded catalogue, in
+// the order they most change how the list should be read.
+func (p ModelPicker) qualifications() []string {
+	var notes []string
+	if p.list.Fallback {
+		notes = append(notes, modelPickerFallbackNote)
+	}
+	if p.list.Partial {
+		notes = append(notes, modelPickerPartialNote)
+	}
+	if p.list.Entitled {
+		note := modelPickerEntitledNote
+		if p.list.EntitledSource != "" {
+			note += " (" + p.list.EntitledSource + ")"
+		}
+		notes = append(notes, note)
+	}
+	return notes
+}
+
+func (p ModelPicker) currentListed() bool {
+	for _, m := range p.list.Models {
+		if string(m) == p.current {
+			return true
+		}
+	}
+	return false
+}
+
+// window returns the slice of model indices to draw, scrolled to keep the
+// cursor visible.
+func (p ModelPicker) window() (int, int) {
+	n := len(p.list.Models)
+	if n <= modelPickerVisibleRows {
+		return 0, n
+	}
+	start := p.selected - modelPickerVisibleRows/2
+	if start < 0 {
+		start = 0
+	}
+	if start+modelPickerVisibleRows > n {
+		start = n - modelPickerVisibleRows
+	}
+	return start, start + modelPickerVisibleRows
+}
+
+func (p ModelPicker) footer() string {
+	switch {
+	case p.pending:
+		// No cancel offered while pending on purpose: the request is already
+		// with the server and closing the overlay would not un-restart the
+		// session.
+		return "working…"
+	case p.applyErr != "":
+		return "enter retry  esc cancel"
+	case p.loading:
+		return "esc cancel"
+	case p.loaded && len(p.list.Models) > 0:
+		return "j/k move  enter apply  esc cancel"
+	default:
+		return "esc close"
+	}
+}

--- a/src/pkg/tui/panes/modelpicker_golden_test.go
+++ b/src/pkg/tui/panes/modelpicker_golden_test.go
@@ -1,0 +1,51 @@
+package panes_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/kubestellar/hive/pkg/tui"
+	"github.com/kubestellar/hive/pkg/tui/client"
+	"github.com/kubestellar/hive/pkg/tui/panes"
+)
+
+// TestModelPickerGolden pins the complete overlay frame at a fixed terminal
+// size, in the state an operator first sees it: opened over a real fleet row,
+// with the catalogue call still in flight.
+//
+// The LOADING state is what is pinned rather than a populated list, and that
+// is deliberate. A populated frame would need a dashboard to answer, which
+// would make the golden depend on whether something is listening on this
+// machine — the same reason TestHelpOverlayGolden does not call Init. Driving
+// Update and View directly renders the frame with no renderer, no goroutines
+// and no network, so the file pins the frame rather than a transcript of a
+// race. The list, qualification and failure states are asserted by
+// modelpicker_test.go against the pane directly.
+//
+// Regenerate after a DELIBERATE change with:
+//
+//	cd src && go test ./pkg/tui/panes/... -update
+//
+// and read the regenerated file in the diff.
+func TestModelPickerGolden(t *testing.T) {
+	m := tui.New()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m, _ = m.Update(panes.AgentsMsg{Agents: []client.Agent{
+		{Name: "scanner", DisplayName: "Scanner", Enabled: true, Backend: "claude", Model: "claude-opus-4-5"},
+	}})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")})
+
+	view := m.View()
+	// The overlay must not grow the frame: one that did would scroll the
+	// operator's screen the moment it opened.
+	if got := lipgloss.Width(view); got != 100 {
+		t.Errorf("frame width = %d, want 100", got)
+	}
+	if got := lipgloss.Height(view); got != 30 {
+		t.Errorf("frame height = %d, want 30", got)
+	}
+	requireGolden(t, []byte(view), filepath.Join("testdata", "modelpicker.golden"))
+}

--- a/src/pkg/tui/panes/modelpicker_test.go
+++ b/src/pkg/tui/panes/modelpicker_test.go
@@ -1,0 +1,428 @@
+package panes
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/tui/client"
+)
+
+const pickerWidth = 70
+
+// flat collapses the rendered box to a single space-separated line.
+//
+// The overlay WRAPS long prose to its width, so a phrase an assertion cares
+// about ("connection refused", "entitled to use") legitimately spans two
+// rows with the border glyphs and padding in between. Asserting on the raw
+// frame would make these tests fail whenever the box width changed, which
+// says nothing about whether the operator was told the right thing. The
+// golden file is what pins the exact layout; these assert the CONTENT.
+func flat(view string) string {
+	return strings.Join(strings.Fields(strings.NewReplacer("┃", " ", "┏", " ", "┓", " ", "┗", " ", "┛", " ", "━", " ").Replace(view)), " ")
+}
+
+func newPicker() ModelPicker {
+	return NewModelPicker("scanner", "Scanner", "claude", "claude-opus-4-5")
+}
+
+func catalogue(models ...string) client.ModelList {
+	list := client.ModelList{Backend: "claude"}
+	for _, m := range models {
+		list.Models = append(list.Models, client.ModelOption(m))
+	}
+	return list
+}
+
+// TestModelPickerLoadingState: the overlay opens already asking, and says so.
+// A blank box while a request is in flight is indistinguishable from a backend
+// that answered with nothing, which is exactly the confusion the empty-state
+// wording exists to prevent.
+func TestModelPickerLoadingState(t *testing.T) {
+	p := newPicker()
+	if !p.Loading() {
+		t.Fatal("a freshly opened picker is not loading; the catalogue call is issued with it")
+	}
+	if _, ok := p.Selected(); ok {
+		t.Error("a loading picker offers a selection, so enter would apply a model nobody chose")
+	}
+	view := p.View(pickerWidth)
+	if !strings.Contains(view, "Loading models") {
+		t.Errorf("loading view does not say it is loading:\n%s", view)
+	}
+	if !strings.Contains(view, modelPickerRestartWarning) {
+		t.Errorf("loading view omits the restart warning:\n%s", view)
+	}
+}
+
+// TestModelPickerEmptySuccessfulCatalogue is the state the acceptance criteria
+// singles out: a call that SUCCEEDED and returned no models must say "no
+// models reported" rather than render an empty box that reads as broken.
+func TestModelPickerEmptySuccessfulCatalogue(t *testing.T) {
+	p := newPicker().SetCatalogue(client.ModelList{Backend: "claude"})
+	if p.Loading() {
+		t.Error("picker still reports loading after a successful response")
+	}
+	view := p.View(pickerWidth)
+	if !strings.Contains(view, modelPickerEmptyNote) {
+		t.Errorf("empty successful catalogue does not say so:\n%s", view)
+	}
+	if strings.Contains(view, "Loading models") {
+		t.Errorf("empty successful catalogue still claims to be loading:\n%s", view)
+	}
+	if _, ok := p.Selected(); ok {
+		t.Error("an empty catalogue offers a selection")
+	}
+}
+
+// TestModelPickerFallbackIsLabelledUnverified: client.ModelList.Fallback means
+// discovery found nothing and the server substituted static aliases. Rendering
+// those as a discovered catalogue would offer models the gateway may not serve
+// — and would imply that a model's absence proves something.
+func TestModelPickerFallbackIsLabelledUnverified(t *testing.T) {
+	list := catalogue("claude-opus-4-5", "claude-sonnet-4-5")
+	list.Fallback = true
+	view := newPicker().SetCatalogue(list).View(pickerWidth)
+
+	if !strings.Contains(view, "Unverified") {
+		t.Errorf("fallback catalogue is not labelled unverified:\n%s", view)
+	}
+	if !strings.Contains(view, "may still work") {
+		t.Errorf("fallback catalogue does not say absence is not proof:\n%s", view)
+	}
+	if list.Authoritative() {
+		t.Fatal("client says a fallback list is authoritative; this test's premise is wrong")
+	}
+}
+
+// TestModelPickerPartialIsLabelledIncomplete: Partial means only some
+// endpoints answered, so every id present was really discovered but a model's
+// ABSENCE proves nothing (#4438).
+func TestModelPickerPartialIsLabelledIncomplete(t *testing.T) {
+	list := catalogue("gpt-5", "gpt-5-mini")
+	list.Partial = true
+	view := newPicker().SetCatalogue(list).View(pickerWidth)
+
+	if !strings.Contains(view, "Incomplete") {
+		t.Errorf("partial catalogue is not labelled incomplete:\n%s", view)
+	}
+	if !strings.Contains(view, "may still be served") {
+		t.Errorf("partial catalogue does not say absence is not proof:\n%s", view)
+	}
+}
+
+// TestModelPickerEntitledIsLabelled: an entitlement-narrowed list is neither
+// wrong nor complete — it is what THIS key may use, and the source of that
+// knowledge is worth naming.
+func TestModelPickerEntitledIsLabelled(t *testing.T) {
+	list := catalogue("gpt-5")
+	list.Entitled = true
+	list.EntitledSource = "key-info"
+	view := newPicker().SetCatalogue(list).View(pickerWidth)
+
+	if !strings.Contains(flat(view), "entitled to use") {
+		t.Errorf("entitlement-narrowed catalogue is not labelled:\n%s", view)
+	}
+	// The source is asserted with the wrap collapsed AND the hyphen break
+	// healed: the box is a fixed 60 columns, so "key-info" lands across a line
+	// boundary. What matters is that the source is named at all — where it
+	// wraps is the golden file's business.
+	if !strings.Contains(strings.ReplaceAll(flat(view), "- ", "-"), "key-info") {
+		t.Errorf("entitlement source is not named:\n%s", view)
+	}
+}
+
+// TestModelPickerSuccessfulCatalogueCarriesNoFalseQualification: the flags are
+// only shown when set. A clean discovery labelled "unverified" would be as
+// wrong as a fallback list presented as discovered.
+func TestModelPickerSuccessfulCatalogueCarriesNoFalseQualification(t *testing.T) {
+	view := newPicker().SetCatalogue(catalogue("claude-opus-4-5", "claude-sonnet-4-5")).View(pickerWidth)
+	for _, unwanted := range []string{"Unverified", "Incomplete", "entitled", modelPickerEmptyNote} {
+		if strings.Contains(view, unwanted) {
+			t.Errorf("a full discovery is labelled %q:\n%s", unwanted, view)
+		}
+	}
+}
+
+// TestModelPickerPreselectsCurrentModel. Preselection is the difference
+// between "change this" and "pick from scratch"; getting it wrong is how an
+// operator restarts an agent onto a neighbouring model by pressing enter.
+func TestModelPickerPreselectsCurrentModel(t *testing.T) {
+	p := NewModelPicker("scanner", "Scanner", "claude", "claude-sonnet-4-5").
+		SetCatalogue(catalogue("claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"))
+	got, ok := p.Selected()
+	if !ok || got != "claude-sonnet-4-5" {
+		t.Fatalf("Selected() = (%q, %v), want the current model preselected", got, ok)
+	}
+	if !strings.Contains(p.View(pickerWidth), "(current)") {
+		t.Error("the preselected row is not marked as the current model")
+	}
+}
+
+// TestModelPickerAbsentCurrentModelIsStatedNotJudged: when the current model
+// is missing from the list, the overlay reports the fact and starts at the top
+// — it does not conclude the model is unsupported, because on a fallback or
+// partial list that conclusion is unfounded.
+func TestModelPickerAbsentCurrentModelIsStatedNotJudged(t *testing.T) {
+	p := NewModelPicker("scanner", "Scanner", "claude", "claude-opus-4-6").
+		SetCatalogue(catalogue("claude-opus-4-5", "claude-sonnet-4-5"))
+	got, ok := p.Selected()
+	if !ok || got != "claude-opus-4-5" {
+		t.Fatalf("Selected() = (%q, %v), want the first row when the current model is absent", got, ok)
+	}
+	view := p.View(pickerWidth)
+	if !strings.Contains(view, "not in this list") {
+		t.Errorf("absent current model is not reported:\n%s", view)
+	}
+	for _, verdict := range []string{"unsupported", "unavailable model", "invalid"} {
+		if strings.Contains(strings.ToLower(view), verdict) {
+			t.Errorf("absence is rendered as a verdict (%q):\n%s", verdict, view)
+		}
+	}
+}
+
+// TestModelPickerNavigationClamps. Holding a direction key must park at an
+// end, not wrap: wrapping past the bottom onto the top is how a fast operator
+// applies the wrong model.
+func TestModelPickerNavigationClamps(t *testing.T) {
+	p := NewModelPicker("scanner", "Scanner", "claude", "").
+		SetCatalogue(catalogue("a", "b", "c"))
+
+	if got, _ := p.Selected(); got != "a" {
+		t.Fatalf("initial selection = %q, want the first row", got)
+	}
+	p = p.Move(1)
+	if got, _ := p.Selected(); got != "b" {
+		t.Errorf("after Move(1) selection = %q, want b", got)
+	}
+	p = p.Move(1).Move(1).Move(1)
+	if got, _ := p.Selected(); got != "c" {
+		t.Errorf("moving past the end selection = %q, want it clamped at c", got)
+	}
+	p = p.Move(-1).Move(-1).Move(-1).Move(-1)
+	if got, _ := p.Selected(); got != "a" {
+		t.Errorf("moving past the start selection = %q, want it clamped at a", got)
+	}
+}
+
+// TestModelPickerNavigationOnEmptyCatalogueIsSafe: an empty list has nothing
+// to move within, and moving must not produce an index that Selected() then
+// reads out of range.
+func TestModelPickerNavigationOnEmptyCatalogueIsSafe(t *testing.T) {
+	p := newPicker().SetCatalogue(client.ModelList{Backend: "claude"}).Move(1).Move(-1).Move(5)
+	if _, ok := p.Selected(); ok {
+		t.Error("moving within an empty catalogue produced a selection")
+	}
+}
+
+// TestModelPickerScrollsWithoutGrowing: a backend advertising many ids must
+// not grow the overlay past a window, and the cursor must stay inside it.
+func TestModelPickerScrollsWithoutGrowing(t *testing.T) {
+	var ids []string
+	for i := 0; i < modelPickerVisibleRows*3; i++ {
+		ids = append(ids, fmt.Sprintf("model-%02d", i))
+	}
+	p := NewModelPicker("scanner", "Scanner", "claude", "").SetCatalogue(catalogue(ids...))
+	for i := 0; i < len(ids)-1; i++ {
+		p = p.Move(1)
+	}
+	view := p.View(pickerWidth)
+	if !strings.Contains(view, ids[len(ids)-1]) {
+		t.Errorf("the selected row scrolled out of the visible window:\n%s", view)
+	}
+	if strings.Contains(view, ids[0]) {
+		t.Errorf("the list is not clipped; the first row is still drawn:\n%s", view)
+	}
+	if !strings.Contains(view, fmt.Sprintf("%d of %d", len(ids), len(ids))) {
+		t.Errorf("the clipped list does not report the full count:\n%s", view)
+	}
+}
+
+// TestModelPickerNotFoundIsNotAnError. GET /api/inference/models/{backend}
+// answers 404 for a backend with no configured discovery endpoint. That is an
+// ordinary configuration, so rendering it with retry guidance would send an
+// operator hunting for a fault that does not exist.
+func TestModelPickerNotFoundIsNotAnError(t *testing.T) {
+	err := &client.APIError{StatusCode: http.StatusNotFound, Method: http.MethodGet, Path: "/api/inference/models/watsonx"}
+	view := newPicker().SetCatalogueError(err).View(pickerWidth)
+
+	if !strings.Contains(view, modelPickerNoCatalogue) {
+		t.Errorf("a 404 does not render as an unavailable catalogue:\n%s", view)
+	}
+	for _, wrong := range []string{"failed", "Not Found", "retry"} {
+		if strings.Contains(view, wrong) {
+			t.Errorf("a 404 is rendered as an error (%q):\n%s", wrong, view)
+		}
+	}
+}
+
+// TestModelPickerForbiddenCatalogue: 403 is the one failure worth wording
+// differently — the request worked, the role does not permit it, and retrying
+// will never help.
+func TestModelPickerForbiddenCatalogue(t *testing.T) {
+	err := &client.APIError{StatusCode: http.StatusForbidden, Method: http.MethodGet, Path: "/api/inference/models/claude"}
+	view := newPicker().SetCatalogueError(err).View(pickerWidth)
+	if !strings.Contains(view, "owner access required") {
+		t.Errorf("a 403 catalogue failure does not name the cause:\n%s", view)
+	}
+}
+
+// TestModelPickerTransportErrorIsShown: a dial failure has no status to
+// classify, so it is reported verbatim rather than silently leaving a loading
+// spinner up forever.
+func TestModelPickerTransportErrorIsShown(t *testing.T) {
+	p := newPicker().SetCatalogueError(errors.New("dial tcp 127.0.0.1:8080: connection refused"))
+	if p.Loading() {
+		t.Error("a failed catalogue call leaves the overlay loading forever")
+	}
+	view := p.View(pickerWidth)
+	if !strings.Contains(flat(view), "Catalogue unavailable") || !strings.Contains(flat(view), "connection refused") {
+		t.Errorf("transport error is not surfaced:\n%s", view)
+	}
+	if _, ok := p.Selected(); ok {
+		t.Error("a failed catalogue offers a selection")
+	}
+}
+
+// TestModelPickerApplyIsSingleShotWhilePending is the acceptance criterion
+// that matters most: applying RESTARTS the agent's session, so a second enter
+// arriving before the first response must not restart it again.
+func TestModelPickerApplyIsSingleShotWhilePending(t *testing.T) {
+	p := newPicker().SetCatalogue(catalogue("claude-opus-4-5", "claude-sonnet-4-5"))
+
+	p, chosen, ok := p.Apply()
+	if !ok || chosen != "claude-opus-4-5" {
+		t.Fatalf("first Apply() = (%q, %v), want the selected model", chosen, ok)
+	}
+	if !p.Pending() {
+		t.Fatal("Apply() did not enter the pending state, so nothing blocks a second request")
+	}
+	for i := 0; i < 5; i++ {
+		var again bool
+		p, _, again = p.Apply()
+		if again {
+			t.Fatalf("Apply() was accepted again while pending (attempt %d) — the agent would restart twice", i+2)
+		}
+	}
+}
+
+// TestModelPickerPendingViewSaysTheSessionRestarts.
+func TestModelPickerPendingViewSaysTheSessionRestarts(t *testing.T) {
+	p, _, _ := newPicker().SetCatalogue(catalogue("claude-opus-4-5")).Apply()
+	view := p.View(pickerWidth)
+	if !strings.Contains(view, "claude-opus-4-5") {
+		t.Errorf("the pending view does not name the model being applied:\n%s", view)
+	}
+	if !strings.Contains(strings.ToLower(view), "restart") {
+		t.Errorf("the pending view does not say the session restarts:\n%s", view)
+	}
+}
+
+// TestModelPickerRestartWarningIsAlwaysShown: it is guidance BEFORE the key
+// press, so it must be present in every state an operator can press enter
+// from, not only once the request is under way.
+func TestModelPickerRestartWarningIsAlwaysShown(t *testing.T) {
+	states := map[string]ModelPicker{
+		"loading":     newPicker(),
+		"empty":       newPicker().SetCatalogue(client.ModelList{}),
+		"loaded":      newPicker().SetCatalogue(catalogue("claude-opus-4-5")),
+		"unavailable": newPicker().SetCatalogueError(&client.APIError{StatusCode: http.StatusNotFound}),
+		"failed":      newPicker().SetCatalogueError(errors.New("boom")),
+	}
+	for name, p := range states {
+		if !strings.Contains(p.View(pickerWidth), modelPickerRestartWarning) {
+			t.Errorf("%s state omits the restart warning", name)
+		}
+	}
+}
+
+// TestModelPickerApplyFailureKeepsTheListAndOffersRetry. A validation 400 is
+// the backend's authoritative refusal of a model id — including an id that was
+// in a fallback list. The overlay reports it and stays open on the same row so
+// "retry" means something.
+func TestModelPickerApplyFailureKeepsTheListAndOffersRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "400 validation",
+			err:  &client.APIError{StatusCode: http.StatusBadRequest, Method: http.MethodPost, Path: "/api/model/scanner/bogus", Body: "unsupported model for backend claude"},
+			want: "unsupported model for backend claude",
+		},
+		{
+			name: "403 forbidden",
+			err:  &client.APIError{StatusCode: http.StatusForbidden, Method: http.MethodPost, Path: "/api/model/scanner/claude-opus-4-5"},
+			want: "owner access required",
+		},
+		{
+			name: "transport error",
+			err:  errors.New("dial tcp 127.0.0.1:8080: connection refused"),
+			want: "connection refused",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, _, _ := newPicker().SetCatalogue(catalogue("claude-opus-4-5", "claude-sonnet-4-5")).Apply()
+			p = p.SetApplyError(tc.err)
+
+			if p.Pending() {
+				t.Fatal("a failed apply left the overlay pending, so retry is impossible")
+			}
+			view := p.View(pickerWidth)
+			if !strings.Contains(flat(view), tc.want) {
+				t.Errorf("failure view does not carry %q:\n%s", tc.want, view)
+			}
+			if !strings.Contains(view, "retry") || !strings.Contains(view, "cancel") {
+				t.Errorf("failure view does not offer retry/cancel:\n%s", view)
+			}
+			// The list stays under the error: retry means "press enter on the
+			// same row", which is meaningless if the row is gone.
+			if !strings.Contains(view, "claude-opus-4-5") {
+				t.Errorf("failure view dropped the model list:\n%s", view)
+			}
+			if _, ok := p.Selected(); !ok {
+				t.Error("failure cleared the selection, so retry has no target")
+			}
+		})
+	}
+}
+
+// TestModelPickerRetryAfterFailureIsAcceptedOnce: the single-shot guard must
+// RELEASE on failure, otherwise "retry" is advertised and does nothing.
+func TestModelPickerRetryAfterFailureIsAcceptedOnce(t *testing.T) {
+	p, _, _ := newPicker().SetCatalogue(catalogue("claude-opus-4-5")).Apply()
+	p = p.SetApplyError(errors.New("boom"))
+
+	p, chosen, ok := p.Apply()
+	if !ok || chosen != "claude-opus-4-5" {
+		t.Fatalf("retry Apply() = (%q, %v), want the same model accepted once", chosen, ok)
+	}
+	if _, _, again := p.Apply(); again {
+		t.Error("a retried apply is not single-shot")
+	}
+}
+
+// TestModelPickerAddressesTheConfigKeyNotTheDisplayName: /api/model/{agent}
+// takes the config key. A display name leaking into the request would target a
+// path that does not exist.
+func TestModelPickerAddressesTheConfigKeyNotTheDisplayName(t *testing.T) {
+	p := NewModelPicker("scanner", "Fleet Scanner", "claude", "")
+	if p.Agent() != "scanner" {
+		t.Errorf("Agent() = %q, want the config key", p.Agent())
+	}
+	if !strings.Contains(p.View(pickerWidth), "Fleet Scanner") {
+		t.Error("the overlay does not show the display name to the operator")
+	}
+}
+
+// TestModelPickerFallsBackToNameWhenDisplayNameIsEmpty. client.Agent marshals
+// displayName with omitempty, so an agent can arrive without one.
+func TestModelPickerFallsBackToNameWhenDisplayNameIsEmpty(t *testing.T) {
+	if !strings.Contains(NewModelPicker("scanner", "", "claude", "").View(pickerWidth), "scanner") {
+		t.Error("an agent with no display name is not labelled at all")
+	}
+}

--- a/src/pkg/tui/panes/testdata/grid.golden
+++ b/src/pkg/tui/panes/testdata/grid.golden
@@ -27,4 +27,4 @@
 │                                                ││                                                │
 │                                                ││                                                │
 └────────────────────────────────────────────────┘└────────────────────────────────────────────────┘
-tab focus  p pause/resume  K kick  a attach  ? help  q quit                                         [2K[?2004l[?25h[?1002l[?1003l[?1006l
+tab focus  p pause/resume  m model  K kick  a attach  ? help  q quit                                [2K[?2004l[?25h[?1002l[?1003l[?1006l

--- a/src/pkg/tui/panes/testdata/help.golden
+++ b/src/pkg/tui/panes/testdata/help.golden
@@ -12,11 +12,11 @@
       ┃ q / ctrl+c       Quit                                          global                ┃      
       ┃ j / k, ↓ / ↑     Move the selection within the focused pane    Agents / Events panes ┃      
       ┃ p                Pause or resume the selected agent            Agents pane           ┃      
+      ┃ m                Open the model picker for the selected agent  Agents pane           ┃      
       ┃ K                Kick the selected agent now                   Agents pane           ┃      
       ┃ a                Attach to the selected agent's tmux session   Agents pane (local)   ┃      
       ┃                                                                                      ┃      
       ┃ Not wired up yet — listed because the design reserves them                           ┃      
-      ┃ m                Open the model picker for the selected agent  Agents pane           ┃      
       ┃ A                Open the ACMM level overlay                   global                ┃      
       ┃                                                                                      ┃      
       ┃ press any key to dismiss                                                             ┃      

--- a/src/pkg/tui/panes/testdata/modelpicker.golden
+++ b/src/pkg/tui/panes/testdata/modelpicker.golden
@@ -1,0 +1,30 @@
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                   
+                   ┃ Model for Scanner                                          ┃                   
+                   ┃ backend claude   current claude-opus-4-5                   ┃                   
+                   ┃                                                            ┃                   
+                   ┃ Loading models…                                            ┃                   
+                   ┃                                                            ┃                   
+                   ┃ Applying restarts the agent's session.                     ┃                   
+                   ┃ esc cancel                                                 ┃                   
+                   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛                   
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    


### PR DESCRIPTION
Fixes #5416

Part of #4907. Depends on T15 (#5216), T16 (#5135), T16b (#5413) and T21 (#5414), all merged.

## What this adds

With the Agents pane focused, `m` opens a modal for the selected agent, fetches that agent's backend catalogue via `Models(ctx, backend)`, and applies a chosen model via T16b's `SetAgentModel`.

- `src/pkg/tui/panes/modelpicker.go` (new) — the overlay's state and rendering. Not a `Pane`: it is never a grid cell, so it takes its keys from the app's modal branch rather than the pane routing seam.
- `src/pkg/tui/panes/agents.go` — two narrow accessors, `SelectedAgentDetail()` and `SetAgentModel()`, so the app never reaches into pane internals for a row.
- `src/pkg/tui/app.go` — `m` handler, `modelListMsg`/`modelSetMsg`, modal key routing, overlay placement, footer.
- `src/pkg/tui/panes/help.go` — `m` flipped to `Available`.

## Discovery is qualified data, and stays that way

`client.ModelList`'s flags are rendered as qualifications, not laundered into an authoritative catalogue:

| State | Rendering |
|---|---|
| `Fallback` | "Unverified: discovery found nothing… A model missing here **may still work**." |
| `Partial` | "Incomplete: only some endpoints answered… **may still be served** by one that did not." (#4438) |
| `Entitled` | "Narrowed to the models this key is entitled to use", with `EntitledSource` named |
| Empty but successful | explicit `no models reported`, not an empty box |
| 404 | `no model catalogue for this backend` — an ordinary state for a backend with no discovery endpoint, **not** an error, and no retry guidance |
| Current model absent from list | stated as a fact; `TestModelPickerAbsentCurrentModelIsStatedNotJudged` asserts the words "unsupported"/"invalid" never appear |

## Applying restarts the session

The overlay carries `Applying restarts the agent's session.` in **every** state enter can be pressed from — not only once the request is under way.

State stays modal/pending until the request returns. `Apply()` refuses while pending and `esc` refuses to close a pending overlay (the restart is already with the server; hiding it would just lose the result). `TestModelPickerEnterIssuesExactlyOneRequestWhilePending` blocks the handler, delivers five further Enter presses plus an `esc`, and asserts **exactly one** POST reached the dashboard.

Success closes, updates the row from the authoritative response (preferring the server's canonical id over the requested one) and polls. Failure keeps the overlay open on the same row with retry/cancel and leaves the row untouched.

## Incidental fix

Adding `m model` took the footer to 68 columns against the 60-column minimum terminal. `lipgloss` `Width()` **wraps** rather than truncates, so the strip became a second line and pushed the frame one row past the terminal height — `TestResizeRendersGridOrMessageBySize` caught it. The footer is now clipped before being padded, with `TestFooterIsClippedNotWrappedAtTheMinimumWidth` guarding it for the next binding that gets added.

## Testing notes

```bash
cd src
go build ./...
go test ./pkg/tui/...
go test -race ./pkg/tui/...
```

Covered states: loading, empty-successful, fallback, partial, entitled, full success, 400 validation, 403, transport error, and 404-is-not-an-error — each at both the pane level (`panes/modelpicker_test.go`) and through the app's wiring (`tui/modelpicker_test.go`).

Also covered:

- **Modal containment** — `TestModelPickerConsumesEveryGlobalBinding` drives `q`, `ctrl+c`, `tab`, `shift+tab`, `p`, `K`, `a`, `A`, `?`, `y`, `n` into the open overlay and asserts none of them quit, moved focus, opened help or the pause dialog, queued a kick, or started an attach.
- **Navigation and preselection** — clamping at both ends, preselection of the current model, safe movement in an empty catalogue, and window scrolling that keeps the cursor visible without growing the box.
- **Opening rules** — no-op before the first fleet snapshot, no-op when another pane is focused, and a footer explanation (rather than a misleading fetch error) for an agent with no configured backend.
- **Late/superseded responses** — a catalogue or set response for a closed-and-reopened overlay is dropped rather than populating or closing the newer one.
- **Golden** — `panes/testdata/modelpicker.golden` pins the full 100x30 frame in the loading state, driven through `Update`/`View` with no `Init`, so it cannot depend on whether a dashboard happens to be listening. `grid.golden` and `help.golden` were regenerated for the footer and the `m` availability flip; both diffs are one line and reviewed.

Local runs are for iteration only — CI is the gate.

## Notes for review

- `isNotFound` is a small local helper in `modelpicker.go` rather than a `client.IsNotFound` addition, because the issue puts client changes out of scope. It mirrors `client.IsForbidden`'s shape over the exported `APIError`. Promoting it to the client package would be reasonable follow-up if another caller wants it.
- The issue text says the overlay should "trigger reconciliation" on success; implemented as `m.poll()`, matching what the pause/resume path already does.
- `src/pkg/tui/poll.go` and `poll_test.go` are deliberately untouched (owned by concurrent #5418).