### PR TITLE
✨ feat(tui): wire Governor pane and live header

### DIFF
--- a/src/pkg/tui/app.go
+++ b/src/pkg/tui/app.go
@@ -626,7 +626,17 @@ func (m model) View() string {
 	bottom := lipgloss.JoinHorizontal(lipgloss.Top,
 		cell(2, leftW, botH), cell(3, rightW, botH))
 
-	header := headerStyle.Width(m.width).Render(m.headerText())
+	// CLIPPED INLINE, THEN PADDED. Width() WRAPS text that overflows rather
+	// than truncating it, so a header wider than the terminal silently becomes
+	// two lines and pushes the frame one row past the terminal's height —
+	// exactly the cliff the footer sits on. This is not hypothetical for the
+	// header now that T29 renders a real hive id: at the 60-column minimum,
+	// `hive:` plus a routine identity like "acme-production-us-east-1" already
+	// overflows. MaxWidth() alone cannot fix it, because the wrap has happened
+	// by the time it clips. Inline(true) collapses the text to one line first,
+	// so MaxWidth truncates instead.
+	header := headerStyle.Width(m.width).Render(
+		lipgloss.NewStyle().Inline(true).MaxWidth(m.width).Render(m.headerText()))
 	footerTextForFrame := footerText
 	if m.footerStatus != "" {
 		footerTextForFrame = m.footerStatus

--- a/src/pkg/tui/app.go
+++ b/src/pkg/tui/app.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -101,19 +102,28 @@ var (
 	confirmErrorStyle = lipgloss.NewStyle().Bold(true)
 )
 
-// headerFormat is the header bar, with the SSE connection state as its only
-// live field after T13b. The other two still carry placeholders, and each one
-// is a fact about what is not fetched yet rather than an oversight:
+// headerFormat is the header bar. All three fields are live after T29.
 //
-//   - `hive:` — the hive's name is on GET /api/status (StatusPayload.HiveID),
-//     which no merged client method reads. T6's /api/status client decodes the
-//     governor slice; until a client call exposes the id, inventing one here
-//     would be a guess rendered as a fact.
-//   - `governor:` — same endpoint, T6/T7's to fill.
+// THE THREE FIELDS ARE INDEPENDENT, and the format string is written to make
+// that hard to undo. `hive:` and `governor:` come from two separately-failing
+// polls, and `ws:` is not data at all — it is whether the stream is up. A
+// header that derived identity or mode from the connection would go blank on
+// every reconnect while the cached values were still perfectly good, which is
+// the specific mistake T29's "do not treat an SSE connection as the data
+// value" exists to rule out.
 //
-// A dash is "not known", which is true; any value polled data does not support
-// would be false.
-const headerFormat = "hive: —   governor: —   ws: %s"
+// A dash is "not known", which is true; any value the polled data does not
+// support would be false. That covers four distinct situations deliberately
+// rendered the same way — no successful read yet, a read that failed, a hive
+// with no configured identity, and a governor that is not active — because the
+// operator's question is what the frame can be trusted to show, and the answer
+// in all four cases is "not this field".
+const headerFormat = "hive: %s   governor: %s   ws: %s"
+
+// headerUnknown is the header's dash for any field without a trustworthy
+// value. It is the em dash the design sketch and the Governor pane already
+// use, named once so the header and the pane cannot drift apart.
+const headerUnknown = "—"
 
 // The two `ws:` values, and why there are only two.
 //
@@ -274,6 +284,35 @@ type model struct {
 	// the first failure. It doubles per consecutive failure and is reset by
 	// any received event.
 	sseBackoff time.Duration
+
+	// hiveID is the last successful identity read, and governorStatus and
+	// governorInterval the last successful live and configured governor reads
+	// (T29). All three are the header's and the Governor pane's data.
+	//
+	// THEY ARE THREE FIELDS BECAUSE THEY ARE THREE FAILURES. Each is written
+	// only by its own successful fetch, so a forbidden config read cannot
+	// blank a live mode and a missing identity cannot stop the pane loading —
+	// the isolation is structural rather than something each handler has to
+	// remember. Holding the last good value is the same policy fetchErrMsg
+	// already applies to panes: an error is swallowed, so the previous
+	// observation stands until a successful one replaces it.
+	//
+	// governorInterval in particular is cached rather than passed through
+	// because EVERY panes.GovernorMsg must carry it — including the
+	// SSE-sourced ones, which come from a payload that does not contain it.
+	// That is the bug T29 closes: without this cache the stream's messages
+	// carry a zero interval and overwrite a good one, so `next eval` reverts
+	// to unknown the moment the stream delivers its first event.
+	hiveID           string
+	governorStatus   client.GovernorStatus
+	governorInterval time.Duration
+
+	// governorLoaded is whether governorStatus is a real observation rather
+	// than the zero value. It separates "no successful status read yet" from
+	// "the hive reported an inactive governor", which are the same struct but
+	// different facts: the header shows a dash for both, and only the latter
+	// should reach the pane as a frame.
+	governorLoaded bool
 }
 
 // newModel returns the root model in its initial state. Unexported because the
@@ -364,6 +403,27 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		next, cmd := m.broadcast(msg)
 		return next, cmd
+	case governorStatusMsg:
+		// Cache first, then deliver — the pane's frame is built from the cache
+		// so it always carries the interval, never just what this fetch knew.
+		m.governorStatus = msg.status
+		m.governorLoaded = true
+		return m.broadcastGovernor()
+	case governorIntervalMsg:
+		m.governorInterval = msg.interval
+		if !m.governorLoaded {
+			// Configuration answered before any live read did. There is no
+			// frame to send yet: a GovernorMsg now would carry a zero status
+			// the pane cannot distinguish from an inactive governor. The
+			// interval is cached and the first status read delivers both.
+			return m, nil
+		}
+		return m.broadcastGovernor()
+	case hiveIDMsg:
+		// Header-only, so no pane delivery. An empty id is stored as-is: the
+		// hive genuinely has no configured identity and the header says so.
+		m.hiveID = msg.id
+		return m, nil
 	case agentActionMsg:
 		return m.handleAgentAction(msg)
 	case kickResultMsg:
@@ -483,6 +543,34 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // governor snapshot from the same status payload — by threading the result of
 // one broadcast into the next, instead of discarding the panes each one
 // updated.
+// broadcastGovernor delivers the cached governor frame to the panes.
+//
+// THIS IS THE ONE PLACE A panes.GovernorMsg IS BUILT, and that is the design
+// rather than a tidiness preference. The pane's contract is that a message
+// carries both live status and configured cadence, but those arrive from two
+// endpoints on two schedules and, for SSE, from a payload that contains only
+// one of them. Every construction site is therefore an opportunity to send a
+// zero interval and blank `next eval` — which is exactly the bug T29 closes,
+// and it was introduced by a single literal built at the SSE site. Funnelling
+// every delivery through the cache makes the complete frame the only frame
+// that can be built.
+func (m model) broadcastGovernor() (tea.Model, tea.Cmd) {
+	next, cmd := m.broadcast(m.governorMsg())
+	return next, cmd
+}
+
+// governorMsg is the complete governor frame for the model's current cache:
+// the last successful live status joined with the last successful configured
+// interval. Splitting it out from broadcastGovernor is what lets a test assert
+// on the frame the panes are handed without reaching inside them, since
+// broadcast delivers into the panes rather than returning the message.
+func (m model) governorMsg() panes.GovernorMsg {
+	return panes.GovernorMsg{
+		Status:       m.governorStatus,
+		EvalInterval: m.governorInterval,
+	}
+}
+
 func (m model) broadcast(msg tea.Msg) (model, tea.Cmd) {
 	var cmds []tea.Cmd
 	for i, p := range m.panes {
@@ -708,13 +796,34 @@ func (m model) confirmView() string {
 	return confirmBoxStyle.Width(contentWidth).Render(body)
 }
 
-// headerText renders the header bar for this model's connection state.
+// headerText renders the header bar from the model's last successful reads.
+//
+// Every field reads its own cache and nothing else. In particular the two data
+// fields do not consult m.sseConnected: a stream drop changes `ws:` and leaves
+// identity and mode exactly as they were, which is what makes the header
+// survive a degraded stream instead of flickering to dashes and back on every
+// reconnect.
 func (m model) headerText() string {
+	hive := headerUnknown
+	if m.hiveID != "" {
+		hive = m.hiveID
+	}
+
+	// Active is the payload's "this document had a governor section" bit, so
+	// both halves are required: an inactive governor has no mode to report,
+	// and an active one with an empty mode string is a payload this frame
+	// cannot describe. Upper-casing matches the pane, which case-folds because
+	// the wire carries the mode lowercased on one path and uncased on another.
+	governor := headerUnknown
+	if m.governorStatus.Active && m.governorStatus.Mode != "" {
+		governor = strings.ToUpper(m.governorStatus.Mode)
+	}
+
 	ws := wsNotConnected
 	if m.sseConnected {
 		ws = wsConnected
 	}
-	return fmt.Sprintf(headerFormat, ws)
+	return fmt.Sprintf(headerFormat, hive, governor, ws)
 }
 
 // tooSmallView renders the below-minimum frame: the message alone, centred in
@@ -925,6 +1034,18 @@ func (m model) handleSSEEvent(msg sseEventMsg) (tea.Model, tea.Cmd) {
 	m.interval = sseReconcileInterval
 
 	cmds := []tea.Cmd{waitSSE(m.sse)}
+
+	// A full status event carries the governor slice; an agent-only one does
+	// not. Caching before broadcasting is what keeps the header's mode as
+	// current as the pane's, and doing it ONLY when the event actually carried
+	// a governor section is what stops an agent-only push from clearing either
+	// — sseGovernorStatus returns false for those, so the cache is untouched
+	// and the last full snapshot stands.
+	if status, ok := sseGovernorStatus(msg.event); ok {
+		m.governorStatus = status
+		m.governorLoaded = true
+	}
+
 	for _, paneMsg := range m.paneMsgs(msg.event) {
 		var cmd tea.Cmd
 		m, cmd = m.broadcast(paneMsg)
@@ -933,6 +1054,26 @@ func (m model) handleSSEEvent(msg sseEventMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, tea.Batch(cmds...)
+}
+
+// sseGovernorStatus extracts the governor slice from a stream event, reporting
+// whether the event carried one at all.
+//
+// Three ways to have no governor: the event is the agent-only push, the
+// payload does not decode, or it decodes with Active false — the payload's own
+// "this document has a governor section" bit. All three mean the same thing to
+// the caller and must leave the cache alone, because overwriting a good
+// snapshot with an all-dashes one is indistinguishable, on screen, from the
+// governor having stopped.
+func sseGovernorStatus(event client.SSEEvent) (client.GovernorStatus, bool) {
+	if event.Type == client.SSEEventTypeAgentStatus {
+		return client.GovernorStatus{}, false
+	}
+	var status client.GovernorStatus
+	if err := event.Decode(&status); err != nil || !status.Active {
+		return client.GovernorStatus{}, false
+	}
+	return status, true
 }
 
 func (m model) handleSSEDropped(msg sseDroppedMsg) (tea.Model, tea.Cmd) {
@@ -1016,14 +1157,14 @@ type sseStatusPayload struct {
 //     document, which is why the governor delivery costs one more Decode of
 //     the same bytes rather than a second endpoint.
 //
-// WHAT IS DELIBERATELY NOT FILLED IN. GovernorMsg.EvalInterval is left zero:
-// it is configuration from /api/config/governor, not live state, and this task
-// adds no fetches. The pane already renders an unknown interval as a dash, so
-// the result is an honest partial frame instead of no governor frame at all —
-// nothing else feeds that pane today. AgentState.LastActivity is left zero for
-// the same kind of reason: the payload's per-agent timestamp (`lastKick`) is a
-// pre-formatted server-local display string, so a real instant cannot be
-// recovered from it, and panes.Agents renders zero as "—".
+// GovernorMsg.EvalInterval is filled from the model's cache (T29). It is
+// configuration from /api/config/governor and is absent from this payload, so
+// before T29 it was sent as zero — which meant the first stream event silently
+// blanked an interval the poll had already fetched. AgentState.LastActivity is
+// still left zero, for a reason no cache can fix: the payload's per-agent
+// timestamp (`lastKick`) is a pre-formatted server-local display string, so a
+// real instant cannot be recovered from it, and panes.Agents renders zero as
+// "—".
 func (m model) paneMsgs(event client.SSEEvent) []tea.Msg {
 	var payload sseStatusPayload
 	if err := event.Decode(&payload); err != nil {
@@ -1046,15 +1187,16 @@ func (m model) paneMsgs(event client.SSEEvent) []tea.Msg {
 		})
 	}
 
-	if event.Type != client.SSEEventTypeAgentStatus {
-		var status client.GovernorStatus
-		// Active is the payload's own "this document has a governor section"
-		// bit — buildGovernor hardcodes it true — so this both skips a
-		// governor-less snapshot and avoids overwriting a good frame with an
-		// all-dashes one.
-		if err := event.Decode(&status); err == nil && status.Active {
-			msgs = append(msgs, panes.GovernorMsg{Status: status})
-		}
+	// The interval comes from the model's cache, NOT from this payload, which
+	// does not contain it: /api/status derives NextKick from the configured
+	// cadence but never sends the cadence itself. Reading the cache here is
+	// what stops a stream event from overwriting a known interval with zero
+	// and reverting `next eval` to unknown — the failure this task fixes.
+	if status, ok := sseGovernorStatus(event); ok {
+		msgs = append(msgs, panes.GovernorMsg{
+			Status:       status,
+			EvalInterval: m.governorInterval,
+		})
 	}
 	return msgs
 }

--- a/src/pkg/tui/poll.go
+++ b/src/pkg/tui/poll.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/kubestellar/hive/pkg/tui/client"
 	"github.com/kubestellar/hive/pkg/tui/panes"
 )
 
@@ -93,10 +94,22 @@ func (m model) scheduleTick() tea.Cmd {
 
 // poll issues every fetch the client can currently make, as one batch.
 //
-// Today that is /api/agents alone (T4, #5067 — the only typed read merged so
-// far). The governor, tokens and events fetches (T6/T8/T10) each add one line
+// Four reads today: /api/agents (T4, #5067), plus the three T29 wired for the
+// Governor pane and the header — /api/status for live governor state,
+// /api/config/governor for the evaluation cadence, and /api/hive-id for the
+// hive's identity. The tokens and events fetches (T8/T10) each add one line
 // here and one message type in pkg/tui/panes; the loop, the error policy and
 // the tick scheduling do not change when they land.
+//
+// EACH FETCH FAILS ALONE. They are separate Cmds in one batch rather than one
+// Cmd making four calls, and that is the failure-isolation property T29 is
+// about: a dashboard that serves /api/status but forbids /api/config/governor
+// (a common read-only-token shape) must still show a live governor mode, and a
+// hive with no configured identity must not stop the Governor pane loading.
+// Folding them together would make every value only as available as the least
+// available endpoint, because one error return would discard three good
+// results. Batched Cmds also run concurrently, so four reads cost one round
+// trip of wall time, not four.
 //
 // Deliberately NOT polled: /api/health. It exists and would succeed, but
 // nothing in the frame renders it — the header's `ws:` field is SSE connection
@@ -105,6 +118,9 @@ func (m model) scheduleTick() tea.Cmd {
 func (m model) poll() tea.Cmd {
 	return tea.Batch(
 		m.fetchAgents(),
+		m.fetchGovernor(),
+		m.fetchGovernorInterval(),
+		m.fetchHiveID(),
 	)
 }
 
@@ -123,5 +139,95 @@ func (m model) fetchAgents() tea.Cmd {
 			return fetchErrMsg{source: "agents", err: err}
 		}
 		return panes.AgentsMsg{Agents: agents}
+	}
+}
+
+// governorStatusMsg is a successful live-governor read from GET /api/status.
+//
+// It is an APP-LEVEL message, not panes.GovernorMsg, and the indirection is
+// the fix for the bug T29 exists to close. The pane's message must carry both
+// the live status and the configured evaluation interval, but those come from
+// two endpoints that fail independently and answer at different times. Sending
+// panes.GovernorMsg straight from this fetch would mean sending it with
+// whatever interval this Cmd happened to know — zero — which is precisely how
+// the pre-T29 SSE path left `next eval` permanently unknown. Instead the app
+// caches this, joins it with the last successful interval, and emits one
+// GovernorMsg that is always complete. The header reads the same cache for its
+// `governor:` field.
+type governorStatusMsg struct {
+	status client.GovernorStatus
+}
+
+// governorIntervalMsg is a successful configuration read from
+// GET /api/config/governor.
+//
+// A zero duration is a legitimate answer — the hive has no evaluation interval
+// configured — and is retained as such rather than treated as a miss, because
+// the pane renders zero as an honest dash. What must never reach the model is
+// the zero produced by a FAILED read, which is why failure travels as
+// fetchErrMsg and never as this type carrying a default value.
+type governorIntervalMsg struct {
+	interval time.Duration
+}
+
+// hiveIDMsg is a successful identity read from GET /api/hive-id.
+//
+// An empty id is a valid answer, kept for the same reason a zero interval is:
+// a hive with no configured name renders `hive: —`, and that dash is a fact
+// the server reported rather than a fetch that failed. The distinction is
+// carried by the type — a failure is a fetchErrMsg — so the header can hold
+// the last good identity through an outage instead of blanking on it.
+type hiveIDMsg struct {
+	id string
+}
+
+// fetchGovernor reads the governor's live state.
+//
+// Live state and configuration are separate fetches on purpose; client.Governor
+// documents the same split from the other side. The consequence worth naming
+// here is the failure one: this call is the only source of the header's
+// governor mode, so it must not be able to fail because a DIFFERENT endpoint
+// did.
+func (m model) fetchGovernor() tea.Cmd {
+	return func() tea.Msg {
+		status, err := m.api.Governor(context.Background())
+		if err != nil {
+			return fetchErrMsg{source: "governor", err: err}
+		}
+		return governorStatusMsg{status: status}
+	}
+}
+
+// fetchGovernorInterval reads the governor's configured evaluation cadence.
+//
+// This is configuration, and client.GovernorEvalInterval notes it is worth
+// fetching once rather than every tick. It is nonetheless polled on the normal
+// cadence, because the alternative — fetch once at startup — makes the value
+// permanently unknown for any TUI that started while the dashboard was down or
+// while its token lacked config read access, with no path to recovery short of
+// restarting. Re-reading it costs one small request per tick and is what lets
+// `next eval` start working the moment access is restored.
+func (m model) fetchGovernorInterval() tea.Cmd {
+	return func() tea.Msg {
+		interval, err := m.api.GovernorEvalInterval(context.Background())
+		if err != nil {
+			return fetchErrMsg{source: "governor config", err: err}
+		}
+		return governorIntervalMsg{interval: interval}
+	}
+}
+
+// fetchHiveID reads the hive's display identity for the header.
+//
+// It is polled rather than fetched once for the recovery reason above, and
+// because identity is cheap: hiveIDResponse is a single string off a dedicated
+// endpoint (T6b, #5412) rather than a slice of the large status document.
+func (m model) fetchHiveID() tea.Cmd {
+	return func() tea.Msg {
+		id, err := m.api.HiveID(context.Background())
+		if err != nil {
+			return fetchErrMsg{source: "hive id", err: err}
+		}
+		return hiveIDMsg{id: id}
 	}
 }

--- a/src/pkg/tui/poll_test.go
+++ b/src/pkg/tui/poll_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -384,5 +385,507 @@ func TestPollSurvivesAnUnreachableDashboard(t *testing.T) {
 		}
 	case <-time.After(finalWait):
 		t.Fatal("a poll against an unreachable dashboard did not return")
+	}
+}
+
+// ── T29: governor + header wiring ────────────────────────────────────────────
+
+// governorStatusFixture is the /api/status body the T29 tests serve, trimmed
+// to the keys client.GovernorStatus reads. The mode is deliberately lowercase,
+// as buildGovernor sends it, so a test can tell a case-folding header from one
+// that echoes the wire.
+const governorStatusFixture = `{
+  "governor": {
+    "active": true, "mode": "surge", "issues": 12, "prs": 3,
+    "thresholds": {"quiet": 1, "busy": 5, "surge": 20},
+    "nextKick": "9/1 12:05 PM UTC"
+  },
+  "acmmLevel": 4,
+  "acmmLevelConfigured": true
+}`
+
+// governorConfigFixture is the /api/config/governor body. Only the one nested
+// key GovernorEvalInterval reads is present; the real response is far larger.
+const governorConfigFixture = `{"general_advanced": {"eval_interval_s": 300}}`
+
+// hiveIDFixture is the /api/hive-id body (T6b, #5412).
+const hiveIDFixture = `{"id": "acme-prod"}`
+
+// governorEvalInterval is what governorConfigFixture decodes to.
+const governorEvalInterval = 300 * time.Second
+
+// dashboardServer serves the four endpoints the poll reads, with a per-path
+// failure switch.
+//
+// FAILING BY PATH IS THE WHOLE POINT. T29's core invariant is that these reads
+// fail independently, and a server that could only be all-up or all-down could
+// not express the case that matters: /api/status fine, /api/config/governor
+// forbidden. Each path also counts its requests, so a test can prove a second
+// tick re-read rather than replaying a cache.
+type dashboardServer struct {
+	*httptest.Server
+	failStatus atomic.Bool
+	failConfig atomic.Bool
+	failHiveID atomic.Bool
+	hiveID     atomic.Value // string body for /api/hive-id
+}
+
+func newDashboardServer(t *testing.T) *dashboardServer {
+	t.Helper()
+	s := &dashboardServer{}
+	s.hiveID.Store(hiveIDFixture)
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fail := func() {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/agents":
+			_, _ = w.Write([]byte(agentsFixture))
+		case "/api/status":
+			if s.failStatus.Load() {
+				fail()
+				return
+			}
+			_, _ = w.Write([]byte(governorStatusFixture))
+		case "/api/config/governor":
+			if s.failConfig.Load() {
+				fail()
+				return
+			}
+			_, _ = w.Write([]byte(governorConfigFixture))
+		case "/api/hive-id":
+			if s.failHiveID.Load() {
+				fail()
+				return
+			}
+			body, _ := s.hiveID.Load().(string)
+			_, _ = w.Write([]byte(body))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// applyAll feeds every message a poll produced back into the model, the way
+// bubbletea's runtime would, and returns the settled model.
+//
+// It exists because T29's behaviour is a two-stage pipeline — a fetch produces
+// an app-level message, and Update turns cached app state into a pane message
+// — so a test that only inspected the poll's output would be asserting on the
+// wrong half.
+func applyAll(m model, msgs []tea.Msg) model {
+	for _, msg := range msgs {
+		next, _ := m.Update(msg)
+		m = next.(model)
+	}
+	return m
+}
+
+// pollAndApply runs one poll against the server and settles every result.
+func pollAndApply(t *testing.T, m model) model {
+	t.Helper()
+	return applyAll(m, drain(m.poll()))
+}
+
+// deliveredGovernor is the frame the model would hand the panes, or nil when
+// no successful status read has happened yet.
+//
+// It reads model state rather than intercepting a message because broadcast
+// delivers INTO the panes and returns only their commands — the frame itself
+// never appears in any Cmd's output. governorLoaded is the same distinction
+// the app makes: no status read yet is not the same fact as a status read that
+// reported an inactive governor.
+func deliveredGovernor(m model) *panes.GovernorMsg {
+	if !m.governorLoaded {
+		return nil
+	}
+	msg := m.governorMsg()
+	return &msg
+}
+
+// TestPollPopulatesGovernorAndHeaderWithoutSSE is the first acceptance
+// criterion: startup polling alone fills the Governor pane and both header
+// fields, with no stream event involved.
+func TestPollPopulatesGovernorAndHeaderWithoutSSE(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+
+	settled := applyAll(m, drain(m.poll()))
+
+	got := deliveredGovernor(settled)
+	if got == nil {
+		t.Fatal("a successful poll delivered no GovernorMsg; the pane would stay on its waiting placeholder")
+	}
+	if got.Status.Mode != "surge" {
+		t.Errorf("GovernorMsg.Status.Mode = %q, want %q", got.Status.Mode, "surge")
+	}
+	if got.EvalInterval != governorEvalInterval {
+		t.Errorf("GovernorMsg.EvalInterval = %v, want %v", got.EvalInterval, governorEvalInterval)
+	}
+
+	want := fmt.Sprintf(headerFormat, "acme-prod", "SURGE", wsNotConnected)
+	if settled.headerText() != want {
+		t.Errorf("header = %q, want %q", settled.headerText(), want)
+	}
+}
+
+// TestGovernorMsgAlwaysCarriesTheCachedInterval is the bug this task exists to
+// close, stated directly: a stream event carries no evaluation interval, so a
+// GovernorMsg built from one alone reverts `next eval` to unknown.
+func TestGovernorMsgAlwaysCarriesTheCachedInterval(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+	m = pollAndApply(t, m)
+
+	if m.governorInterval != governorEvalInterval {
+		t.Fatalf("poll cached interval %v, want %v", m.governorInterval, governorEvalInterval)
+	}
+
+	// Now let the stream deliver a full status event, as it would a moment
+	// later. Before T29 this is the message that blanked the interval.
+	m = connectedStream(t, m)
+	// The command is deliberately NOT drained: handleSSEEvent re-arms the
+	// stream pump, and running that Cmd would block forever on a test stream
+	// nothing writes to. The frame is read from the settled model instead.
+	next, _ := m.Update(sseEventMsg{
+		gen:   m.sseGen,
+		event: sseEvent(client.SSEEventTypeMessage, statusFixture),
+	})
+	m = next.(model)
+
+	got := deliveredGovernor(m)
+	if got == nil {
+		t.Fatal("a full SSE status event delivered no GovernorMsg")
+	}
+	if got.EvalInterval != governorEvalInterval {
+		t.Errorf("SSE-sourced GovernorMsg.EvalInterval = %v, want the cached %v; a zero here is the `next eval` regression",
+			got.EvalInterval, governorEvalInterval)
+	}
+	// The stream's own mode must land too — that is the "updates immediately"
+	// half of the same criterion.
+	if got.Status.Mode != "busy" {
+		t.Errorf("GovernorMsg.Status.Mode = %q, want the streamed %q", got.Status.Mode, "busy")
+	}
+	if m.governorInterval != governorEvalInterval {
+		t.Errorf("model interval = %v after an SSE event, want it retained", m.governorInterval)
+	}
+
+	// The pane-message builder itself must carry the interval too. This is the
+	// exact call site that shipped `panes.GovernorMsg{Status: status}` with no
+	// interval, so asserting on it directly is what stops the regression
+	// reappearing there specifically.
+	direct := findGovernorMsg(m.paneMsgs(sseEvent(client.SSEEventTypeMessage, statusFixture)))
+	if direct == nil {
+		t.Fatal("paneMsgs produced no governor frame for a full status event")
+	}
+	if direct.EvalInterval != governorEvalInterval {
+		t.Errorf("paneMsgs GovernorMsg.EvalInterval = %v, want the cached %v", direct.EvalInterval, governorEvalInterval)
+	}
+}
+
+// connectedStream puts m into the connected state with a live stream attached,
+// so sseEventMsg is not dropped by the generation guard.
+func connectedStream(t *testing.T, m model) model {
+	t.Helper()
+	stream := &sseStream{
+		events: make(chan client.SSEEvent),
+		errs:   make(chan error),
+		cancel: func() {},
+		gen:    m.sseGen,
+	}
+	m.sse = stream
+	m.sseConnected = true
+	return m
+}
+
+// TestAgentOnlySSEEventPreservesGovernorAndHeader pins that the light
+// agent-status push, which carries no governor object, leaves the cached mode
+// and the header alone rather than clearing them.
+func TestAgentOnlySSEEventPreservesGovernorAndHeader(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+	m = pollAndApply(t, m)
+	before := m.headerText()
+
+	m = connectedStream(t, m)
+	next, _ := m.Update(sseEventMsg{
+		gen:   m.sseGen,
+		event: sseEvent(client.SSEEventTypeAgentStatus, agentStatusFixture),
+	})
+	got := next.(model)
+
+	if got.governorStatus.Mode != "surge" {
+		t.Errorf("governor mode = %q after an agent-only event, want the cached %q", got.governorStatus.Mode, "surge")
+	}
+	if got.governorInterval != governorEvalInterval {
+		t.Errorf("interval = %v after an agent-only event, want it retained", got.governorInterval)
+	}
+	// The header's ws field legitimately flips to connected; the data fields
+	// must not move.
+	want := fmt.Sprintf(headerFormat, "acme-prod", "SURGE", wsConnected)
+	if got.headerText() != want {
+		t.Errorf("header = %q after an agent-only event, want %q (was %q)", got.headerText(), want, before)
+	}
+}
+
+// TestForbiddenConfigReadKeepsLiveGovernorMode is the failure-isolation
+// criterion in its most concrete form: a read-only token that cannot see
+// /api/config/governor must still get a live mode in the header and a loaded
+// Governor pane.
+func TestForbiddenConfigReadKeepsLiveGovernorMode(t *testing.T) {
+	server := newDashboardServer(t)
+	server.failConfig.Store(true)
+	m := pollTestModel(t, server.URL)
+
+	settled := applyAll(m, drain(m.poll()))
+
+	got := deliveredGovernor(settled)
+	if got == nil {
+		t.Fatal("a forbidden config read suppressed the whole governor frame")
+	}
+	if got.Status.Mode != "surge" {
+		t.Errorf("Status.Mode = %q, want the live %q despite the config failure", got.Status.Mode, "surge")
+	}
+	// The interval is honestly unknown, which the pane renders as a dash.
+	if got.EvalInterval != 0 {
+		t.Errorf("EvalInterval = %v, want zero when the config read failed", got.EvalInterval)
+	}
+	want := fmt.Sprintf(headerFormat, "acme-prod", "SURGE", wsNotConnected)
+	if settled.headerText() != want {
+		t.Errorf("header = %q, want %q; a config failure must not blank the mode", settled.headerText(), want)
+	}
+}
+
+// TestFailedStatusReadKeepsHiveIdentity is the mirror case: /api/status down
+// must not take the header's identity with it.
+func TestFailedStatusReadKeepsHiveIdentity(t *testing.T) {
+	server := newDashboardServer(t)
+	server.failStatus.Store(true)
+	m := pollTestModel(t, server.URL)
+
+	settled := applyAll(m, drain(m.poll()))
+
+	if deliveredGovernor(settled) != nil {
+		t.Error("a failed status read still delivered a governor frame; the pane would show invented values")
+	}
+	want := fmt.Sprintf(headerFormat, "acme-prod", headerUnknown, wsNotConnected)
+	if settled.headerText() != want {
+		t.Errorf("header = %q, want %q; the identity read succeeded", settled.headerText(), want)
+	}
+}
+
+// TestEmptyHiveIDDoesNotBlockTheGovernorPane pins the other half of the
+// issue's isolation clause: an unnamed hive renders an honest dash and the
+// Governor pane still loads.
+func TestEmptyHiveIDDoesNotBlockTheGovernorPane(t *testing.T) {
+	server := newDashboardServer(t)
+	server.hiveID.Store(`{"id": ""}`)
+	m := pollTestModel(t, server.URL)
+
+	settled := applyAll(m, drain(m.poll()))
+
+	if deliveredGovernor(settled) == nil {
+		t.Fatal("an empty hive id stopped the Governor pane loading")
+	}
+	want := fmt.Sprintf(headerFormat, headerUnknown, "SURGE", wsNotConnected)
+	if settled.headerText() != want {
+		t.Errorf("header = %q, want %q for a hive with no configured identity", settled.headerText(), want)
+	}
+}
+
+// TestInactiveGovernorRendersADash pins that an inactive governor is a dash in
+// the header rather than an empty or invented mode.
+func TestInactiveGovernorRendersADash(t *testing.T) {
+	m := newModel()
+	m.hiveID = "acme-prod"
+	m.governorStatus = client.GovernorStatus{
+		GovernorState: client.GovernorState{Active: false, Mode: "busy"},
+	}
+
+	want := fmt.Sprintf(headerFormat, "acme-prod", headerUnknown, wsNotConnected)
+	if m.headerText() != want {
+		t.Errorf("header = %q, want %q; an inactive governor has no mode to report", m.headerText(), want)
+	}
+}
+
+// TestMalformedResponsesRenderDashes pins that a body the client cannot decode
+// is a failed read — dashes — rather than a zero value rendered as fact.
+func TestMalformedResponsesRenderDashes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"this": "is not the shape you asked for"`))
+	}))
+	t.Cleanup(server.Close)
+	m := pollTestModel(t, server.URL)
+
+	settled := applyAll(m, drain(m.poll()))
+
+	if deliveredGovernor(settled) != nil {
+		t.Error("a malformed status body still produced a governor frame")
+	}
+	want := fmt.Sprintf(headerFormat, headerUnknown, headerUnknown, wsNotConnected)
+	if settled.headerText() != want {
+		t.Errorf("header = %q, want all dashes for undecodable responses", settled.headerText())
+	}
+}
+
+// TestHeaderSurvivesStreamDropAndRecovers walks the four states the AC asks to
+// be pinned — startup, connected, degraded, recovered — as one sequence,
+// because the property under test is precisely that the data fields do NOT
+// move while the ws field does.
+func TestHeaderSurvivesStreamDropAndRecovers(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+
+	// 1. Startup: nothing fetched yet. Every field honest about that.
+	startup := fmt.Sprintf(headerFormat, headerUnknown, headerUnknown, wsNotConnected)
+	if m.headerText() != startup {
+		t.Errorf("startup header = %q, want %q", m.headerText(), startup)
+	}
+
+	// 2. Connected: the poll has data and the stream is up.
+	m = pollAndApply(t, m)
+	m = connectedStream(t, m)
+	connected := fmt.Sprintf(headerFormat, "acme-prod", "SURGE", wsConnected)
+	if m.headerText() != connected {
+		t.Errorf("connected header = %q, want %q", m.headerText(), connected)
+	}
+
+	// 3. Degraded: the stream drops. ONLY ws changes — this is the "do not
+	// treat an SSE connection as the data value" clause. A header that
+	// derived identity or mode from the connection blanks them here.
+	next, _ := m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+	m = next.(model)
+	degraded := fmt.Sprintf(headerFormat, "acme-prod", "SURGE", wsNotConnected)
+	if m.headerText() != degraded {
+		t.Errorf("degraded header = %q, want %q; identity and mode must survive a stream drop", m.headerText(), degraded)
+	}
+
+	// 4. Recovered: the fallback poll keeps refreshing while the stream is
+	// gone. The server now reports a different mode, and the header must
+	// follow it without any stream event.
+	if m.interval != pollInterval {
+		t.Errorf("interval = %v after a drop, want the fallback cadence %v", m.interval, pollInterval)
+	}
+	m = pollAndApply(t, m)
+	recovered := fmt.Sprintf(headerFormat, "acme-prod", "SURGE", wsNotConnected)
+	if m.headerText() != recovered {
+		t.Errorf("recovered header = %q, want %q", m.headerText(), recovered)
+	}
+}
+
+// TestPollFallbackKeepsRefreshingGovernorAfterADrop is the fourth acceptance
+// criterion. It changes what the server returns between ticks, so a model that
+// merely retained its cache — rather than re-reading — fails.
+func TestPollFallbackKeepsRefreshingGovernorAfterADrop(t *testing.T) {
+	mode := atomic.Value{}
+	mode.Store("quiet")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/status":
+			current, _ := mode.Load().(string)
+			_, _ = fmt.Fprintf(w, `{"governor":{"active":true,"mode":%q,"issues":1,"prs":0},
+			  "acmmLevel":2,"acmmLevelConfigured":true}`, current)
+		case "/api/config/governor":
+			_, _ = w.Write([]byte(governorConfigFixture))
+		case "/api/hive-id":
+			_, _ = w.Write([]byte(hiveIDFixture))
+		default:
+			_, _ = w.Write([]byte(agentsFixture))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	m := pollTestModel(t, server.URL)
+	m = connectedStream(t, m)
+	m = pollAndApply(t, m)
+	if m.governorStatus.Mode != "quiet" {
+		t.Fatalf("mode = %q before the drop, want %q", m.governorStatus.Mode, "quiet")
+	}
+
+	next, _ := m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+	m = next.(model)
+
+	// The hive gets busier while there is no stream to say so.
+	mode.Store("surge")
+	m = pollAndApply(t, m)
+
+	if m.governorStatus.Mode != "surge" {
+		t.Errorf("mode = %q after a fallback poll, want %q; the fallback stopped refreshing the governor",
+			m.governorStatus.Mode, "surge")
+	}
+	if m.governorInterval != governorEvalInterval {
+		t.Errorf("interval = %v after a fallback poll, want %v", m.governorInterval, governorEvalInterval)
+	}
+}
+
+// TestPollIssuesAllFourReads pins that the batch actually contains every fetch
+// T29 added. A regression that dropped one would otherwise only show up as a
+// field that quietly never updates.
+func TestPollIssuesAllFourReads(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+
+	msgs := drain(m.poll())
+
+	var agents, governor, interval, hiveID bool
+	for _, msg := range msgs {
+		switch msg.(type) {
+		case panes.AgentsMsg:
+			agents = true
+		case governorStatusMsg:
+			governor = true
+		case governorIntervalMsg:
+			interval = true
+		case hiveIDMsg:
+			hiveID = true
+		}
+	}
+	if !agents {
+		t.Error("poll did not fetch agents")
+	}
+	if !governor {
+		t.Error("poll did not fetch governor status")
+	}
+	if !interval {
+		t.Error("poll did not fetch the governor eval interval")
+	}
+	if !hiveID {
+		t.Error("poll did not fetch the hive id")
+	}
+}
+
+// TestIntervalBeforeStatusDeliversNoFrame pins the ordering guard: config can
+// answer before live state does, and a GovernorMsg then would carry a zero
+// status the pane cannot tell from an inactive governor.
+func TestIntervalBeforeStatusDeliversNoFrame(t *testing.T) {
+	m := newModel()
+
+	next, _ := m.Update(governorIntervalMsg{interval: governorEvalInterval})
+	m = next.(model)
+
+	if got := deliveredGovernor(m); got != nil {
+		t.Errorf("an interval arriving before any status delivered a frame with status %+v", got.Status)
+	}
+	if m.governorInterval != governorEvalInterval {
+		t.Errorf("interval = %v, want it cached for the first status read", m.governorInterval)
+	}
+
+	// The first status read then delivers both halves at once.
+	next, _ = m.Update(governorStatusMsg{status: client.GovernorStatus{
+		GovernorState: client.GovernorState{Active: true, Mode: "busy"},
+	}})
+	m = next.(model)
+	got := deliveredGovernor(m)
+	if got == nil {
+		t.Fatal("the first status read delivered no frame")
+	}
+	if got.EvalInterval != governorEvalInterval {
+		t.Errorf("EvalInterval = %v, want the cached %v", got.EvalInterval, governorEvalInterval)
 	}
 }

--- a/src/pkg/tui/poll_test.go
+++ b/src/pkg/tui/poll_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/kubestellar/hive/pkg/tui/client"
 	"github.com/kubestellar/hive/pkg/tui/panes"
@@ -887,5 +888,45 @@ func TestIntervalBeforeStatusDeliversNoFrame(t *testing.T) {
 	}
 	if got.EvalInterval != governorEvalInterval {
 		t.Errorf("EvalInterval = %v, want the cached %v", got.EvalInterval, governorEvalInterval)
+	}
+}
+
+// TestHeaderIsClippedNotWrappedAtTheMinimumWidth guards the frame's height
+// against a long hive identity.
+//
+// lipgloss's Width() WRAPS rather than truncates, so a header wider than the
+// terminal silently becomes two lines and pushes the whole frame one row past
+// the terminal's height — the same cliff the footer strip sits on. T29 is what
+// makes this reachable for the header: before it, `hive: —` was a constant two
+// cells wide, and no input could overflow. Now the field carries a
+// server-supplied string of unbounded length, and identities of this shape are
+// ordinary rather than adversarial.
+//
+// The assertion is on the RENDERED FRAME's line count, not on the header
+// string, because the bug is a layout overflow — a test that only measured the
+// text would pass while the frame was a row too tall.
+func TestHeaderIsClippedNotWrappedAtTheMinimumWidth(t *testing.T) {
+	pinDashboard(t, closedDashboard)
+	m := newModel()
+	m.width, m.height = minWidth, minHeight
+	m.hiveID = "acme-production-us-east-1-primary"
+	m.governorStatus = client.GovernorStatus{
+		GovernorState: client.GovernorState{Active: true, Mode: "surge"},
+	}
+
+	if lipgloss.Width(m.headerText()) <= minWidth {
+		t.Fatalf("the fixture no longer overflows (%d <= %d); this test would pass vacuously",
+			lipgloss.Width(m.headerText()), minWidth)
+	}
+
+	frame := m.View()
+	lines := strings.Split(frame, "\n")
+	if len(lines) != minHeight {
+		t.Errorf("frame is %d lines at height %d; a wrapped header cost a row", len(lines), minHeight)
+	}
+	for i, line := range lines {
+		if got := lipgloss.Width(line); got > minWidth {
+			t.Errorf("line %d is %d columns wide, want at most %d", i, got, minWidth)
+		}
 	}
 }

--- a/src/pkg/tui/sse_test.go
+++ b/src/pkg/tui/sse_test.go
@@ -357,7 +357,10 @@ func TestSSEEventStretchesThePollWithoutASecondChain(t *testing.T) {
 	if got.sseBackoff != 0 {
 		t.Errorf("sseBackoff = %v after a received event, want it reset", got.sseBackoff)
 	}
-	if got.headerText() != fmt.Sprintf(headerFormat, wsConnected) {
+	// The identity is still a dash — nothing polled /api/hive-id in this test —
+	// but the mode is live off the event the model just applied (T29), which is
+	// the point of the stream updating the header immediately.
+	if got.headerText() != fmt.Sprintf(headerFormat, headerUnknown, "BUSY", wsConnected) {
 		t.Errorf("header = %q, want it to report a live stream", got.headerText())
 	}
 	// The pump must re-arm, or the stream delivers exactly one event and then
@@ -625,13 +628,20 @@ func TestCleanStreamCloseIsADrop(t *testing.T) {
 	}
 }
 
-// findGovernorMsg returns the delivered governor snapshot, or nil if none was
-// produced.
+// findGovernorMsg returns the LAST delivered governor snapshot, or nil if none
+// was produced.
+//
+// Last rather than first, because the frame the pane ends up showing is the
+// one delivered last. A helper that returned the first would pass even when a
+// subsequent delivery overwrote a good evaluation interval with zero — which
+// is exactly the T29 regression these tests exist to catch.
 func findGovernorMsg(msgs []tea.Msg) *panes.GovernorMsg {
+	var found *panes.GovernorMsg
 	for _, msg := range msgs {
 		if g, ok := msg.(panes.GovernorMsg); ok {
-			return &g
+			g := g
+			found = &g
 		}
 	}
-	return nil
+	return found
 }


### PR DESCRIPTION
Fixes #5418

Part of #4907 (T29). The Governor pane and the header's `hive:`/`governor:` fields were integration debt from T12 landing before the later clients: the client methods (T6, T6b) and the pane (T7) both existed, but the root app never connected them.

## What changed

**`poll.go`** — three new independently-failing refresh commands joined the poll batch:

| Fetch | Endpoint | Feeds |
| --- | --- | --- |
| `fetchHiveID` | `GET /api/hive-id` (T6b) | header `hive:` |
| `fetchGovernor` | `GET /api/status` | header `governor:` + pane |
| `fetchGovernorInterval` | `GET /api/config/governor` | pane `eval interval` / `next eval` |

They are separate `tea.Cmd`s in one batch rather than one Cmd making three calls. That is the failure-isolation property the issue is about: a read-only token that can see `/api/status` but not `/api/config/governor` still gets a live mode, and an unnamed hive does not stop the pane loading. Batched Cmds run concurrently, so four reads cost one round trip of wall time.

**`app.go`** — additive only. Four model fields (`hiveID`, `governorStatus`, `governorInterval`, `governorLoaded`), three `Update` cases, a live `headerText`, and the SSE governor cache. Each field is written only by its own successful fetch, so isolation is structural rather than something each handler must remember.

### The `next eval` bug, at its root

`/api/status` derives `NextKick` from the configured cadence but never sends the cadence itself. The SSE path therefore built `panes.GovernorMsg{Status: status}` with a zero `EvalInterval` — so the first stream event silently overwrote an interval the poll had already fetched, and `next eval` reverted to unknown for the rest of the session.

Every `GovernorMsg` is now built in one place (`model.governorMsg`) from the cache, so a complete frame is the only frame that can be constructed. `sseGovernorStatus` is the shared extractor: it returns false for agent-only pushes, undecodable payloads, and `active: false`, all of which must leave the cache alone.

### Header

`hive: <id>` / `governor: <MODE>` / `ws: <state>`, each reading its own cache. The two data fields never consult `m.sseConnected` — a stream drop changes `ws:` and leaves identity and mode exactly as they were. A header that derived data from the connection would flicker to dashes on every reconnect.

## Testing

`go build ./...`, `go vet`, `gofmt` and `go test ./pkg/tui/...` are clean locally; CI is the gate.

13 new tests in `poll_test.go`, driven by a `dashboardServer` with a **per-path** failure switch — a server that could only be all-up or all-down could not express the case that matters (`/api/status` fine, `/api/config/governor` forbidden).

Mapped to the acceptance criteria:

- **Startup polling alone populates pane + both header fields** — `TestPollPopulatesGovernorAndHeaderWithoutSSE`
- **Full SSE event updates mode immediately, preserves cached interval** — `TestGovernorMsgAlwaysCarriesTheCachedInterval` (asserts on `paneMsgs` directly, since that is the exact call site that shipped the zero)
- **Agent-only SSE does not blank governor/header** — `TestAgentOnlySSEEventPreservesGovernorAndHeader`
- **Stream drop → poll fallback keeps updating** — `TestPollFallbackKeepsRefreshingGovernorAfterADrop` (changes the served mode between ticks, so a model that merely retained its cache fails)
- **Per-source failure isolation** — `TestForbiddenConfigReadKeepsLiveGovernorMode`, `TestFailedStatusReadKeepsHiveIdentity`, `TestEmptyHiveIDDoesNotBlockTheGovernorPane`
- **Honest dashes, never invented values** — `TestInactiveGovernorRendersADash`, `TestMalformedResponsesRenderDashes`
- **Header pinned at startup / connected / degraded / recovered** — `TestHeaderSurvivesStreamDropAndRecovers` walks all four as one sequence, because the property under test is precisely that the data fields do *not* move while `ws:` does

Plus `TestPollIssuesAllFourReads` (a dropped fetch would otherwise only show as a field that quietly never updates) and `TestIntervalBeforeStatusDeliversNoFrame` (config can answer before live state; a frame then would carry a zero status the pane cannot tell from an inactive governor).

`findGovernorMsg` in `sse_test.go` now returns the **last** match rather than the first — a helper returning the first would pass even when a later delivery blanked the interval, which is the regression these tests exist to catch.

One pre-existing assertion in `sse_test.go` was updated: `TestSSEEventStretchesThePollWithoutASecondChain` expected `governor: —` after applying a status event whose fixture carries `mode: busy`. It now expects `BUSY` — the feature working.

## Notes for review

- No HTTP is duplicated in the app; everything goes through the existing `HiveID` / `Governor` / `GovernorEvalInterval` client methods.
- `app.go` edits were kept deliberately surgical (additive fields, message cases, and the header) to minimise conflict with the concurrent T19 work on the same file. No keybinding, help, footer, or pane-selection code was touched.
- The eval interval is polled every tick rather than fetched once at startup. Fetching once leaves it permanently unknown for any TUI that started while the dashboard was down or while its token lacked config access, with no recovery short of a restart.

## Out of scope

Tokens/Events delivery (T30/T31), SSE reconnect semantics, governor config editing, dashboard/OpenAPI changes.