### PR TITLE
🔒 fix: bring relay redaction to parity with pkg/logscrub (JWT, PEM, Bearer, AWS)

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1609,20 +1609,114 @@ function shellQuote(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
+// ── Redaction categories (kubestellar/hive#5478) ────────────────────────────
+//
+// HIVE_REDACTION_CATEGORIES is the relay's half of a cross-language contract
+// with src/pkg/logscrub. Each `category` name here must have a matching entry
+// in logscrub's secretPatterns, and vice versa; the parity guard in
+// src/pkg/logscrub/redaction_parity_test.go reads THIS array (by parsing the
+// `category:` fields out of this file) and fails when either side gains a
+// category the other lacks.
+//
+// It exists because the two redaction lists were previously hand-maintained
+// with no shared source of truth and nothing failing when they diverged. The
+// relay had fallen four categories behind the Go path: an agent terminal that
+// printed a JWT, an AWS access key, a `Bearer` value or a PEM private-key
+// block had it forwarded to the hub unredacted.
+//
+// Why the relay declares its own regexes rather than importing Go's: Go's RE2
+// and JavaScript's RegExp are different dialects. Go writes inline flags
+// (`(?s)`, `(?i)`) that JS expresses only as trailing flags, and Go's `\b` in
+// `\b(AKIA|ASIA)` sits next to character classes JS treats differently. A
+// generator would therefore have to translate dialects, and a translation bug
+// would fail OPEN — producing a JS regex that compiles and matches nothing,
+// which is exactly the silent-miss shape this guard exists to catch. Naming
+// the categories and asserting BEHAVIOUR on both sides (each side must
+// actually redact a synthetic sample of its own category — see the parity
+// test's anti-vacuity check) is the safer contract: it cannot pass on a
+// pattern that compiles but does not fire.
+//
+// Redaction is fail-safe: over-redacting a token-shaped string is far cheaper
+// than forwarding a real credential, so these lean deliberately broad.
+const HIVE_REDACTION_CATEGORIES = [
+  // Canary markers planted to detect exfiltration; their whole purpose is to
+  // be noticed, so they must never travel in cleartext.
+  { category: 'hive_canary', re: /HIVE-CANARY-[A-Fa-f0-9]{48}/g, to: '***REDACTED***' },
+
+  // GitHub tokens. Two deliberate alignments with logscrub (#5478):
+  //
+  //   1. Character class is [A-Za-z0-9_], not [A-Za-z0-9]. Go accepted the
+  //      underscore for every prefix; the relay accepted it only for
+  //      github_pat_, so a gho_ token CONTAINING an underscore was redacted by
+  //      Go and passed through here.
+  //
+  //   2. Floor is {10,}, not {36,}, matching Go. A short or truncated
+  //      token-shaped run — a token clipped by a terminal-width wrap, say —
+  //      cleared the old 36-character floor and survived.
+  //
+  // The bound stays OPEN-ENDED ({10,} not {10}) for the #4267 reason: an exact
+  // bound redacts only the first N characters and leaks a longer token's tail.
+  // The floor moved; the open-endedness is load-bearing and must stay.
+  //
+  // The replacement keeps the matched prefix ("gho_***REDACTED***") so hub-side
+  // log readers can still tell WHICH credential class appeared without seeing
+  // the secret — the #4267 contract, preserved.
+  {
+    category: 'github_token',
+    re: /(ghs_|ghp_|gho_|ghu_|ghr_|github_pat_)[A-Za-z0-9_]{10,}/g,
+    to: (_m, prefix) => `${prefix}***REDACTED***`,
+  },
+
+  // JWTs. header.payload.signature; the payload routinely carries an
+  // installation identity and the signature makes the whole thing bearer-usable.
+  {
+    category: 'jwt',
+    re: /eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/g,
+    to: '***REDACTED***',
+  },
+
+  // AWS access key IDs (long-lived AKIA, temporary ASIA).
+  { category: 'aws_access_key', re: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, to: '***REDACTED***' },
+
+  // `Bearer <value>` in any casing — the shape an agent prints when it echoes a
+  // curl invocation or an HTTP debug trace.
+  {
+    category: 'bearer',
+    re: /\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi,
+    to: '***REDACTED***',
+  },
+
+  // PEM private-key blocks. Matched across newlines (the `s` flag) and lazily
+  // (`*?`) so two adjacent blocks are redacted separately rather than as one
+  // span that swallows the text between them.
+  {
+    category: 'pem_private_key',
+    re: /-----BEGIN\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----.*?-----END\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----/gs,
+    to: '***REDACTED***',
+  },
+  {
+    category: 'pem_encrypted_private_key',
+    re: /-----BEGIN\s+ENCRYPTED\s+PRIVATE\s+KEY-----.*?-----END\s+ENCRYPTED\s+PRIVATE\s+KEY-----/gs,
+    to: '***REDACTED***',
+  },
+  {
+    category: 'pgp_private_key',
+    re: /-----BEGIN\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----.*?-----END\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----/gs,
+    to: '***REDACTED***',
+  },
+];
+
 function redactTokens(text) {
-  // {36,} not {36}: GitHub documents that token length may grow, and an exact
-  // bound would redact only the first 36 characters of a longer token, leaking
-  // its tail into the hub log line (kubestellar/hive#4267).
-  const githubRedacted = text.replace(/gho_[A-Za-z0-9]{36,}/g, 'gho_***REDACTED***')
-    .replace(/ghp_[A-Za-z0-9]{36,}/g, 'ghp_***REDACTED***')
-    .replace(/ghs_[A-Za-z0-9]{36,}/g, 'ghs_***REDACTED***')
-    .replace(/ghu_[A-Za-z0-9]{36,}/g, 'ghu_***REDACTED***')
-    .replace(/ghr_[A-Za-z0-9]{36,}/g, 'ghr_***REDACTED***')
-    // Fine-grained PATs: github_pat_ + 82 chars of [A-Za-z0-9_]. The Go-side
-    // redactors (dashboard, status_builder, prompt_history) already scrub this
-    // prefix; the relay must match or PAT material leaks into hub log lines.
-    .replace(/github_pat_[A-Za-z0-9_]{36,}/g, 'github_pat_***REDACTED***');
-  return BACKEND === 'pi' ? redactPiCredentials(githubRedacted, PI_SELECTION, PI_ENV) : githubRedacted;
+  let out = String(text == null ? '' : text);
+  for (const { re, to } of HIVE_REDACTION_CATEGORIES) {
+    // The regexes are /g and therefore stateful via lastIndex. String.replace
+    // resets lastIndex itself, but these literals are module-level and shared
+    // across calls, so reset defensively — a stale lastIndex would silently
+    // skip the start of the next line, i.e. fail open.
+    re.lastIndex = 0;
+    out = out.replace(re, to);
+  }
+  return BACKEND === 'pi' ? redactPiCredentials(out, PI_SELECTION, PI_ENV) : out;
 }
 
 function captureTmuxLines(n) {
@@ -3835,6 +3929,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     CONTAINER_RUNTIME,
     // Coverage for previously untested pure/isolated functions (#4267).
     redactTokens,
+    HIVE_REDACTION_CATEGORIES,
     detectNoWorkVerdict,
     detectPRURL,
     resolveBackend,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -3509,6 +3509,194 @@ test('#4267 redactTokens redacts a token even when glued to a preceding word', (
   } finally { teardown(relay); }
 });
 
+// ---------------------------------------------------------------------------
+// kubestellar/hive#5478 — redaction parity with src/pkg/logscrub.
+//
+// The relay used to redact GitHub token prefixes and nothing else, while the
+// Go path also scrubbed JWTs, AWS keys, `Bearer` values, PEM private-key
+// blocks and canary markers. Agent terminal output carrying any of those was
+// forwarded to the hub unredacted. The Go-side companion guard lives in
+// src/pkg/logscrub/redaction_parity_test.go and fails if either side gains a
+// category the other lacks.
+//
+// Every value below is obviously synthetic and shape-accurate; none of it is
+// copied from a real credential or log. Assertions are on the redacted OUTPUT
+// only — the pre-redaction input is never printed.
+// ---------------------------------------------------------------------------
+
+test('#5478 redactTokens scrubs a JWT', () => {
+  const relay = loadRelay({});
+  try {
+    const payload = 'b'.repeat(25);
+    const jwt = `eyJ${'a'.repeat(25)}.${payload}.${'c'.repeat(25)}`;
+    const out = relay.redactTokens(`authorization: ${jwt}`);
+    assert.ok(!out.includes(payload), 'JWT payload survived redaction');
+    assert.ok(out.includes('***REDACTED***'), `expected a redaction marker, got: ${out}`);
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens scrubs AWS access key IDs (AKIA and ASIA)', () => {
+  const relay = loadRelay({});
+  try {
+    for (const prefix of ['AKIA', 'ASIA']) {
+      const key = `${prefix}${'A'.repeat(16)}`;
+      const out = relay.redactTokens(`aws_access_key_id = ${key}`);
+      assert.ok(!out.includes(key), `${prefix} key survived redaction: ${out}`);
+    }
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens scrubs a Bearer value in any casing', () => {
+  const relay = loadRelay({});
+  try {
+    const secret = 'a'.repeat(32);
+    for (const word of ['Bearer', 'bearer', 'BEARER']) {
+      const out = relay.redactTokens(`curl -H 'Authorization: ${word} ${secret}'`);
+      assert.ok(!out.includes(secret), `${word} value survived redaction: ${out}`);
+    }
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens scrubs PEM private-key blocks', () => {
+  const relay = loadRelay({});
+  try {
+    const blocks = [
+      ['-----BEGIN PRIVATE KEY-----', '-----END PRIVATE KEY-----'],
+      ['-----BEGIN RSA PRIVATE KEY-----', '-----END RSA PRIVATE KEY-----'],
+      ['-----BEGIN OPENSSH PRIVATE KEY-----', '-----END OPENSSH PRIVATE KEY-----'],
+      ['-----BEGIN ENCRYPTED PRIVATE KEY-----', '-----END ENCRYPTED PRIVATE KEY-----'],
+      ['-----BEGIN PGP PRIVATE KEY BLOCK-----', '-----END PGP PRIVATE KEY BLOCK-----'],
+    ];
+    for (const [begin, end] of blocks) {
+      const body = 'SYNTHETICKEYMATERIAL';
+      const out = relay.redactTokens(`cat id_key\n${begin}\n${body}\n${end}\ndone`);
+      assert.ok(!out.includes(body), `key body survived for ${begin}: ${out}`);
+      assert.ok(out.includes('***REDACTED***'), `expected a redaction marker for ${begin}`);
+    }
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens scrubs a HIVE-CANARY marker', () => {
+  const relay = loadRelay({});
+  try {
+    const canary = `HIVE-CANARY-${'ab'.repeat(24)}`;
+    const out = relay.redactTokens(`leaked ${canary} here`);
+    assert.ok(!out.includes(canary), `canary marker survived redaction: ${out}`);
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens redacts a gho_ token containing an underscore', () => {
+  // The relay's character class was [A-Za-z0-9] for gh*_ while Go's was
+  // [A-Za-z0-9_], so a token body containing an underscore was redacted by Go
+  // and passed through here.
+  const relay = loadRelay({});
+  try {
+    const body = `${'a'.repeat(16)}_${'b'.repeat(19)}`;
+    const out = relay.redactTokens(`token=gho_${body} end`);
+    assert.strictEqual(out, 'token=gho_***REDACTED*** end',
+      `underscore-bearing token leaked: ${out}`);
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens redacts a short (20-char) token body', () => {
+  // The relay's floor was 36 trailing characters and Go's was 10, so a
+  // truncated token-shaped run cleared the relay and was forwarded.
+  const relay = loadRelay({});
+  try {
+    const body = 'a'.repeat(20);
+    const out = relay.redactTokens(`token=ghp_${body} end`);
+    assert.strictEqual(out, 'token=ghp_***REDACTED*** end',
+      `short token body leaked: ${out}`);
+  } finally { teardown(relay); }
+});
+
+test('#5478 the lowered floor still does not redact ordinary prose', () => {
+  // Moving the floor from 36 to 10 widens what matches, so pin that plainly
+  // non-credential text is still passed through untouched. Redaction is
+  // fail-safe, but a floor low enough to eat normal output would make the
+  // forwarded pane text useless.
+  const relay = loadRelay({});
+  try {
+    for (const s of [
+      'plain output',
+      'ghost_stories are fine',
+      'ghp_short',
+      'git push origin main',
+      'see https://github.com/kubestellar/hive/pull/5478',
+      'Bearer with no value follows',
+      '',
+    ]) {
+      assert.strictEqual(relay.redactTokens(s), s, `must pass through unchanged: ${s}`);
+    }
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens redacts two adjacent PEM blocks separately', () => {
+  // The block pattern is lazy (.*?), so two blocks must not be swallowed as
+  // one span that also eats the text between them.
+  const relay = loadRelay({});
+  try {
+    const text = [
+      '-----BEGIN PRIVATE KEY-----', 'FIRSTKEYMATERIAL', '-----END PRIVATE KEY-----',
+      'KEEP-THIS-LINE',
+      '-----BEGIN PRIVATE KEY-----', 'SECONDKEYMATERIAL', '-----END PRIVATE KEY-----',
+    ].join('\n');
+    const out = relay.redactTokens(text);
+    assert.ok(!out.includes('FIRSTKEYMATERIAL'), 'first key body survived');
+    assert.ok(!out.includes('SECONDKEYMATERIAL'), 'second key body survived');
+    assert.ok(out.includes('KEEP-THIS-LINE'),
+      `the text between two key blocks was swallowed: ${out}`);
+  } finally { teardown(relay); }
+});
+
+test('#5478 redactTokens is stable across repeated calls (no lastIndex carry-over)', () => {
+  // The category regexes are module-level and /g, so they carry lastIndex.
+  // A stale lastIndex would make the SECOND call skip the start of its input
+  // and fail open — the exact silent-miss shape this issue is about.
+  const relay = loadRelay({});
+  try {
+    const input = `token=gho_${TOKEN_BODY} end`;
+    const first = relay.redactTokens(input);
+    for (let i = 0; i < 5; i++) {
+      assert.strictEqual(relay.redactTokens(input), first,
+        `redaction was not idempotent on call ${i + 2} — regex lastIndex carried over`);
+    }
+    assert.ok(!first.includes(TOKEN_BODY));
+  } finally { teardown(relay); }
+});
+
+test('#5478 every declared redaction category actually fires', () => {
+  // Anti-vacuity: a category could be declared with a regex that compiles and
+  // never matches, satisfying the Go-side NAME parity check while the material
+  // still leaked. Assert each declared category redacts a sample of its own
+  // shape, and that the declared set is non-empty to begin with.
+  const relay = loadRelay({});
+  try {
+    const samples = {
+      hive_canary: `HIVE-CANARY-${'ab'.repeat(24)}`,
+      github_token: `gho_${TOKEN_BODY}`,
+      jwt: `eyJ${'a'.repeat(25)}.${'b'.repeat(25)}.${'c'.repeat(25)}`,
+      aws_access_key: `AKIA${'A'.repeat(16)}`,
+      bearer: `Bearer ${'a'.repeat(32)}`,
+      pem_private_key: '-----BEGIN PRIVATE KEY-----\nSYNTHETIC\n-----END PRIVATE KEY-----',
+      pem_encrypted_private_key:
+        '-----BEGIN ENCRYPTED PRIVATE KEY-----\nSYNTHETIC\n-----END ENCRYPTED PRIVATE KEY-----',
+      pgp_private_key:
+        '-----BEGIN PGP PRIVATE KEY BLOCK-----\nSYNTHETIC\n-----END PGP PRIVATE KEY BLOCK-----',
+    };
+    const declared = relay.HIVE_REDACTION_CATEGORIES.map(c => c.category);
+    assert.ok(declared.length > 0,
+      'HIVE_REDACTION_CATEGORIES is empty — every assertion here would pass vacuously');
+    for (const name of declared) {
+      const sample = samples[name];
+      assert.ok(sample, `category ${name} has no sample here; add one so it is actually exercised`);
+      const out = relay.redactTokens(sample);
+      assert.ok(out.includes('***REDACTED***') && out !== sample,
+        `declared category ${name} did not redact its own sample — the pattern compiles but never fires`);
+    }
+  } finally { teardown(relay); }
+});
+
 // --- paneLooksBlockedOnHuman -------------------------------------------------
 
 test('#4267 blocked-on-human: trailing question mark on the last content line', () => {

--- a/src/pkg/logscrub/handler.go
+++ b/src/pkg/logscrub/handler.go
@@ -15,14 +15,66 @@ var TokenPattern = regexp.MustCompile(
 		`|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}`,
 )
 
-var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`HIVE-CANARY-[A-Fa-f0-9]{48}`),
-	TokenPattern,
-	regexp.MustCompile(`\b(AKIA|ASIA)[0-9A-Z]{16}\b`),
-	regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b`),
-	regexp.MustCompile(`(?s)-----BEGIN\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----.*?-----END\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----`),
-	regexp.MustCompile(`(?s)-----BEGIN\s+ENCRYPTED\s+PRIVATE\s+KEY-----.*?-----END\s+ENCRYPTED\s+PRIVATE\s+KEY-----`),
-	regexp.MustCompile(`(?s)-----BEGIN\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----.*?-----END\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----`),
+// secretPattern is one named redaction category. The Category name is not
+// cosmetic: it is the join key for the cross-language parity guard in
+// redaction_parity_test.go, which asserts that every category Go redacts is
+// also redacted by redactTokens() in bin/contributor-relay.sh. Before #5478
+// the two implementations were hand-maintained lists in different languages
+// with nothing failing when they drifted, and the relay had silently fallen
+// four categories behind — JWTs, PEM private-key blocks, Bearer values and
+// AWS access keys all reached the hub unredacted.
+//
+// Adding a pattern here without a matching HIVE_REDACTION_CATEGORY entry in
+// the relay (or a declared exception in the parity test) fails that test.
+type secretPattern struct {
+	// Category is the stable identifier shared with the relay. Renaming it is
+	// a breaking change to the parity guard on both sides.
+	Category string
+	Re       *regexp.Regexp
+}
+
+// Category identifiers. Declared as constants so a typo is a compile error on
+// the Go side rather than a silently-unmatched string in the parity test.
+const (
+	CategoryHiveCanary   = "hive_canary"
+	CategoryGitHubToken  = "github_token"
+	CategoryJWT          = "jwt"
+	CategoryAWSAccessKey = "aws_access_key"
+	CategoryBearer       = "bearer"
+	CategoryPEMPrivate   = "pem_private_key"
+	CategoryPEMEncrypted = "pem_encrypted_private_key"
+	CategoryPGPPrivate   = "pgp_private_key"
+)
+
+// jwtPattern is the JWT third of TokenPattern, broken out so the parity test
+// can name it as its own category. TokenPattern keeps both alternatives fused
+// because pkg/ioscan and pkg/pushbroker consume it as a single "is this string
+// credential-shaped?" probe.
+var jwtPattern = regexp.MustCompile(`eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}`)
+
+// githubTokenPattern is the GitHub-prefix half of TokenPattern, likewise broken
+// out for category naming.
+var githubTokenPattern = regexp.MustCompile(`(ghs_|ghp_|gho_|ghu_|ghr_|github_pat_)[A-Za-z0-9_]{10,}`)
+
+var secretPatterns = []secretPattern{
+	{CategoryHiveCanary, regexp.MustCompile(`HIVE-CANARY-[A-Fa-f0-9]{48}`)},
+	{CategoryGitHubToken, githubTokenPattern},
+	{CategoryJWT, jwtPattern},
+	{CategoryAWSAccessKey, regexp.MustCompile(`\b(AKIA|ASIA)[0-9A-Z]{16}\b`)},
+	{CategoryBearer, regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b`)},
+	{CategoryPEMPrivate, regexp.MustCompile(`(?s)-----BEGIN\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----.*?-----END\s+(?:(?:RSA|EC|OPENSSH|DSA)\s+)?PRIVATE\s+KEY-----`)},
+	{CategoryPEMEncrypted, regexp.MustCompile(`(?s)-----BEGIN\s+ENCRYPTED\s+PRIVATE\s+KEY-----.*?-----END\s+ENCRYPTED\s+PRIVATE\s+KEY-----`)},
+	{CategoryPGPPrivate, regexp.MustCompile(`(?s)-----BEGIN\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----.*?-----END\s+PGP\s+PRIVATE\s+KEY\s+BLOCK-----`)},
+}
+
+// Categories returns the redaction category names Go covers, in declaration
+// order. The parity test compares this against the relay's declared set.
+func Categories() []string {
+	out := make([]string, 0, len(secretPatterns))
+	for _, p := range secretPatterns {
+		out = append(out, p.Category)
+	}
+	return out
 }
 
 const redacted = "[REDACTED]"
@@ -71,7 +123,7 @@ func scrub(s string) string {
 // GitHub tokens, AWS access keys, bearer tokens, JWTs, and private-key blocks.
 func ScrubString(s string) string {
 	for _, p := range secretPatterns {
-		s = p.ReplaceAllString(s, redacted)
+		s = p.Re.ReplaceAllString(s, redacted)
 	}
 	return s
 }

--- a/src/pkg/logscrub/redaction_parity_test.go
+++ b/src/pkg/logscrub/redaction_parity_test.go
@@ -1,0 +1,404 @@
+package logscrub
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Cross-language parity guard for the two redaction implementations
+// (kubestellar/hive#5478).
+//
+// Hive redacts credential-shaped text in two places:
+//
+//   - this package (Go), used by the hub logger, pkg/ioscan, pkg/turn and the
+//     sandbox executor; and
+//   - redactTokens() in bin/contributor-relay.sh (JavaScript), which scrubs
+//     agent tmux output before it is forwarded to the hub.
+//
+// They were hand-maintained lists in different languages with no shared source
+// of truth and nothing failing when they drifted. The relay had fallen four
+// categories behind: JWTs, PEM private-key blocks, `Bearer` values and AWS
+// access keys were redacted by Go and forwarded unredacted by the relay.
+//
+// This is the same shape as TestShellAndGoCLIBackendListsAgree
+// (src/pkg/config/backend_list_parity_test.go): a closed exception set that
+// itself fails when an entry goes stale. It differs in one way that matters —
+// the backend guard compares NAMES only, because a backend name is the whole
+// contract. A redaction category name proves nothing on its own: a relay entry
+// could declare `category: 'jwt'` next to a regex that never fires and the
+// name check would pass while JWTs still leaked. So this file checks names AND
+// behaviour, by running a synthetic sample of every category through both
+// implementations.
+
+const relayPath = "../../../bin/contributor-relay.sh"
+
+// relayCategoryRe pulls the `category: 'name'` fields out of the
+// HIVE_REDACTION_CATEGORIES array in the relay. Parsing the source rather than
+// executing it keeps this test free of a Node dependency for the NAME half;
+// the BEHAVIOUR half below shells out to node and skips if it is absent.
+var relayCategoryRe = regexp.MustCompile(`category:\s*'([a-z0-9_]+)'`)
+
+// redactionParityException documents one category that legitimately lives in
+// only one implementation, and why. This is NOT a place to silence real drift.
+// An entry whose stated asymmetry no longer holds fails the test below rather
+// than rotting quietly.
+type redactionParityException struct {
+	name   string
+	reason string
+}
+
+// redactionExceptions is the complete, closed set of permitted asymmetries.
+// Anything not listed here must appear on both sides or the test fails.
+//
+// It is deliberately EMPTY: as of #5478 both implementations cover exactly the
+// same eight categories. The type and the staleness check are kept so that a
+// future genuinely one-sided category has a documented home, rather than being
+// bolted on under time pressure by deleting the guard.
+var redactionExceptions = []redactionParityException{}
+
+func exceptedCategories() map[string]bool {
+	out := make(map[string]bool, len(redactionExceptions))
+	for _, e := range redactionExceptions {
+		out[e.name] = true
+	}
+	return out
+}
+
+// relayCategories returns the category names declared in the relay source.
+func relayCategories(t *testing.T) []string {
+	t.Helper()
+	src, err := os.ReadFile(relayPath)
+	if err != nil {
+		t.Skipf("contributor-relay.sh not reachable from the test working directory: %v", err)
+	}
+	// Scope the scan to the HIVE_REDACTION_CATEGORIES array so an unrelated
+	// `category:` key elsewhere in the relay cannot inflate the set.
+	start := strings.Index(string(src), "const HIVE_REDACTION_CATEGORIES = [")
+	if start < 0 {
+		t.Fatalf("HIVE_REDACTION_CATEGORIES not found in %s — the relay's redaction "+
+			"category table was renamed or removed, which silently disables this parity guard", relayPath)
+	}
+	rest := string(src)[start:]
+	end := strings.Index(rest, "\n];")
+	if end < 0 {
+		t.Fatalf("HIVE_REDACTION_CATEGORIES in %s is not terminated by a line starting `];` — "+
+			"cannot delimit the array, so this guard would scan the rest of the file", relayPath)
+	}
+	var out []string
+	for _, m := range relayCategoryRe.FindAllStringSubmatch(rest[:end], -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// TestGoAndRelayRedactionCategoriesAgree is the guard #5478 asks for: every
+// category redacted by Go is declared by the relay and vice versa.
+//
+// This DOES go red if a category is added to Go only. Adding an entry to
+// secretPatterns with no HIVE_REDACTION_CATEGORIES counterpart fails the
+// "Go has X, relay does not" direction on the first `go test` run touching
+// this package.
+func TestGoAndRelayRedactionCategoriesAgree(t *testing.T) {
+	goSet := make(map[string]bool)
+	for _, c := range Categories() {
+		goSet[c] = true
+	}
+	relaySet := make(map[string]bool)
+	for _, c := range relayCategories(t) {
+		relaySet[c] = true
+	}
+
+	// Anti-vacuity (the #5409 lesson): a parse that yielded nothing on either
+	// side would make every comparison below trivially true, so the test would
+	// pass loudest exactly when it had stopped reading anything. Both sides
+	// must be non-empty before any comparison is trusted.
+	if len(goSet) == 0 {
+		t.Fatalf("logscrub.Categories() returned no categories — the Go redaction list is " +
+			"empty or unreadable, and every parity assertion below would pass vacuously")
+	}
+	if len(relaySet) == 0 {
+		t.Fatalf("parsed no categories out of HIVE_REDACTION_CATEGORIES in %s — the array was "+
+			"reshaped past what relayCategoryRe understands, and every parity assertion "+
+			"below would pass vacuously", relayPath)
+	}
+
+	excepted := exceptedCategories()
+
+	var problems []string
+	for name := range goSet {
+		if !relaySet[name] && !excepted[name] {
+			problems = append(problems, "logscrub secretPatterns has "+name+
+				" but HIVE_REDACTION_CATEGORIES in bin/contributor-relay.sh does not, "+
+				"and it is not a declared exception — agent output carrying this "+
+				"category reaches the hub unredacted")
+		}
+	}
+	for name := range relaySet {
+		if !goSet[name] && !excepted[name] {
+			problems = append(problems, "HIVE_REDACTION_CATEGORIES in bin/contributor-relay.sh has "+
+				name+" but logscrub secretPatterns does not, and it is not a declared exception")
+		}
+	}
+
+	// A declared exception that no longer describes a real asymmetry (the
+	// category is now in BOTH lists, or in NEITHER) is stale bookkeeping that
+	// would mask a future real removal on one side.
+	for name := range excepted {
+		inGo, inRelay := goSet[name], relaySet[name]
+		if inGo && inRelay {
+			problems = append(problems, "declared exception "+name+
+				" is now present in BOTH implementations; remove it from redactionExceptions")
+		}
+		if !inGo && !inRelay {
+			problems = append(problems, "declared exception "+name+
+				" is present in NEITHER implementation; remove it from redactionExceptions")
+		}
+	}
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("Go and relay redaction categories have drifted:\n  %s", strings.Join(problems, "\n  "))
+	}
+}
+
+// parityCase is a synthetic sample for one category. Values are obviously fake
+// but shape-accurate; nothing here is copied from a real credential or log.
+type parityCase struct {
+	category string
+	input    string
+	// secret is the substring that must NOT survive redaction on either side.
+	secret string
+}
+
+// A 36-character token body, the canonical length GitHub mints today.
+const synthTokenBody = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+// parityCases carries one sample per category. Every category declared by Go
+// must appear here — TestRedactionParityCasesCoverEveryCategory enforces that,
+// so a new category cannot be added with a behavioural sample quietly omitted.
+var parityCases = []parityCase{
+	{
+		category: CategoryHiveCanary,
+		input:    "canary HIVE-CANARY-" + strings.Repeat("ab", 24) + " tail",
+		secret:   "HIVE-CANARY-" + strings.Repeat("ab", 24),
+	},
+	{
+		category: CategoryGitHubToken,
+		input:    "token=gho_" + synthTokenBody + " end",
+		secret:   synthTokenBody,
+	},
+	{
+		category: CategoryJWT,
+		// Three dot-separated base64url runs of 20+ chars — JWT shape, not a
+		// real token; the payload segment decodes to nothing meaningful.
+		input:  "auth eyJ" + strings.Repeat("a", 25) + "." + strings.Repeat("b", 25) + "." + strings.Repeat("c", 25) + " end",
+		secret: strings.Repeat("b", 25),
+	},
+	{
+		category: CategoryAWSAccessKey,
+		input:    "aws AKIAAAAAAAAAAAAAAAAA end",
+		secret:   "AKIAAAAAAAAAAAAAAAAA",
+	},
+	{
+		category: CategoryBearer,
+		input:    "curl -H 'Authorization: Bearer " + strings.Repeat("a", 32) + "' https://example.test",
+		secret:   strings.Repeat("a", 32),
+	},
+	{
+		category: CategoryPEMPrivate,
+		input:    "key -----BEGIN RSA PRIVATE KEY-----\nSYNTHETICKEYMATERIAL\n-----END RSA PRIVATE KEY----- done",
+		secret:   "SYNTHETICKEYMATERIAL",
+	},
+	{
+		category: CategoryPEMEncrypted,
+		input:    "key -----BEGIN ENCRYPTED PRIVATE KEY-----\nSYNTHETICENCMATERIAL\n-----END ENCRYPTED PRIVATE KEY----- done",
+		secret:   "SYNTHETICENCMATERIAL",
+	},
+	{
+		category: CategoryPGPPrivate,
+		input:    "key -----BEGIN PGP PRIVATE KEY BLOCK-----\nSYNTHETICPGPMATERIAL\n-----END PGP PRIVATE KEY BLOCK----- done",
+		secret:   "SYNTHETICPGPMATERIAL",
+	},
+}
+
+// TestRedactionParityCasesCoverEveryCategory keeps the behavioural half of
+// this guard from going hollow. Without it, someone could add a category to
+// both implementations, satisfy the name check, and never assert that either
+// regex actually fires.
+func TestRedactionParityCasesCoverEveryCategory(t *testing.T) {
+	covered := make(map[string]bool, len(parityCases))
+	for _, c := range parityCases {
+		covered[c.category] = true
+	}
+	for _, name := range Categories() {
+		if !covered[name] {
+			t.Errorf("category %q is declared in secretPatterns but has no entry in parityCases, "+
+				"so nothing asserts that either implementation actually redacts it", name)
+		}
+	}
+	if len(parityCases) == 0 {
+		t.Fatal("parityCases is empty — the behavioural half of this parity guard asserts nothing")
+	}
+}
+
+// TestGoRedactsEveryParityCase pins the Go half: each synthetic sample is
+// redacted and its secret substring does not survive.
+func TestGoRedactsEveryParityCase(t *testing.T) {
+	for _, c := range parityCases {
+		out := ScrubString(c.input)
+		// Assert only on post-redaction output; the input is never logged.
+		if strings.Contains(out, c.secret) {
+			t.Errorf("category %s: Go did not redact the sample (secret substring survived)", c.category)
+		}
+		if !strings.Contains(out, redacted) {
+			t.Errorf("category %s: Go produced no %s marker", c.category, redacted)
+		}
+	}
+}
+
+// TestRelayRedactsEveryParityCase is the assertion the issue's verification
+// list asks for: a JWT, a PEM block, a `Bearer` value and an AWS key are
+// redacted in relay output. It runs the REAL redactTokens() from the relay,
+// not a Go reimplementation of it — a reimplementation would pass while the
+// shipped relay leaked.
+func TestRelayRedactsEveryParityCase(t *testing.T) {
+	for _, c := range parityCases {
+		out := runRelayRedact(t, c.input)
+		if strings.Contains(out, c.secret) {
+			t.Errorf("category %s: the relay did not redact the sample (secret substring survived)", c.category)
+		}
+		if !strings.Contains(out, "***REDACTED***") {
+			t.Errorf("category %s: the relay produced no ***REDACTED*** marker", c.category)
+		}
+	}
+}
+
+// TestUnderscoreGitHubTokenRedactedByBothPaths pins the specific divergence
+// #5478 names: Go accepted [A-Za-z0-9_] after every GitHub prefix while the
+// relay accepted only [A-Za-z0-9] for gh*_, so a gho_ token CONTAINING an
+// underscore was redacted by Go and passed through by the relay.
+func TestUnderscoreGitHubTokenRedactedByBothPaths(t *testing.T) {
+	// Synthetic: a gho_ token whose body contains an underscore.
+	body := "aaaaaaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbb"
+	input := "token=gho_" + body + " end"
+
+	if out := ScrubString(input); strings.Contains(out, body) {
+		t.Error("Go did not redact a gho_ token containing an underscore")
+	}
+	if out := runRelayRedact(t, input); strings.Contains(out, body) {
+		t.Error("the relay did not redact a gho_ token containing an underscore " +
+			"(the [A-Za-z0-9] vs [A-Za-z0-9_] divergence from #5478 has regressed)")
+	}
+}
+
+// TestShortGitHubTokenRedactedByBothPaths pins the other divergence: Go's
+// floor was 10 trailing characters and the relay's was 36, so a truncated
+// token-shaped run cleared the relay and was forwarded.
+func TestShortGitHubTokenRedactedByBothPaths(t *testing.T) {
+	// 20 characters: over Go's floor of 10, under the relay's OLD floor of 36.
+	body := strings.Repeat("a", 20)
+	input := "token=ghp_" + body + " end"
+
+	if out := ScrubString(input); strings.Contains(out, body) {
+		t.Error("Go did not redact a 20-character ghp_ token body")
+	}
+	if out := runRelayRedact(t, input); strings.Contains(out, body) {
+		t.Error("the relay did not redact a 20-character ghp_ token body " +
+			"(the 36-vs-10 length-floor divergence from #5478 has regressed)")
+	}
+}
+
+// TestRelayKeepsOpenEndedTokenBound pins the #4267 invariant the fix had to
+// preserve while moving the floor: the bound stays open-ended, so the WHOLE
+// body of a longer-than-floor token is scrubbed rather than its first N
+// characters with the tail leaking after the marker.
+func TestRelayKeepsOpenEndedTokenBound(t *testing.T) {
+	body := synthTokenBody + "TAILTAILTAIL"
+	out := runRelayRedact(t, "log: gho_"+body+".")
+	if strings.Contains(out, "TAILTAILTAIL") {
+		t.Errorf("the tail of a long token leaked past the redaction marker — the {n,} "+
+			"bound became exact, regressing #4267; got %q", out)
+	}
+}
+
+// runRelayRedact loads bin/contributor-relay.sh in node and returns
+// redactTokens(input). Only the redacted OUTPUT crosses back, and the input is
+// passed on stdin rather than argv so it never lands in a process listing.
+func runRelayRedact(t *testing.T, input string) string {
+	t.Helper()
+	if _, err := os.Stat(relayPath); err != nil {
+		t.Skipf("contributor-relay.sh not reachable from the test working directory: %v", err)
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not available; skipping relay-side behavioural parity")
+	}
+
+	// HIVE_RELAY_TEST_MODE is what bin/contributor-relay.test.js sets to keep
+	// the relay from touching tmux, bash or a WebSocket on load.
+	// Loads the relay IN PLACE (so its own relative require of ./pi-backend.js
+	// resolves) with 'ws' and child_process stubbed, mirroring the harness in
+	// bin/contributor-relay.test.js. Nothing here reaches tmux, bash or a
+	// socket.
+	const driver = `
+const Module = require('module');
+const stubs = {
+  ws: class { on() {} send() {} close() {} ping() {} },
+  child_process: {
+    execSync: () => '',
+    execFile: () => {},
+    execFileSync: () => '',
+  },
+};
+const origLoad = Module._load;
+Module._load = function (request) {
+  if (Object.prototype.hasOwnProperty.call(stubs, request)) return stubs[request];
+  return origLoad.apply(this, arguments);
+};
+// node refuses to require a .sh file with the default extension handlers.
+Module._extensions['.sh'] = Module._extensions['.js'];
+const relay = require(require('path').resolve(process.argv[1]));
+Module._load = origLoad;
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { input += d; });
+process.stdin.on('end', () => {
+  // process.exit after an explicit flush: loading the relay arms heartbeat and
+  // progress timers that would otherwise hold the event loop open forever and
+  // hang the Go test rather than failing it.
+  process.stdout.write(relay.redactTokens(input), () => process.exit(0));
+});
+`
+	// Bounded: if the relay ever stops exiting (a new non-unref'd timer, say),
+	// this must fail the test rather than hang the CI job indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "node", "-e", driver, relayPath)
+	cmd.Stdin = strings.NewReader(input)
+	// The relay refuses to load without a registration token and a backend, and
+	// HIVE_RELAY_TEST_MODE keeps it from opening a hub connection. These mirror
+	// what bin/contributor-relay.test.js sets. AGENT_BACKEND is deliberately
+	// NOT 'pi': the pi path appends redactPiCredentials, whose behaviour is
+	// covered by its own tests, and this guard is about the shared categories.
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(),
+		"HIVE_RELAY_TEST_MODE=1",
+		"HIVE_REGISTRATION_TOKEN=parity-test-token",
+		"AGENT_BACKEND=claude",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		// Surface the relay's own stderr: without it a load failure reports
+		// only "exit status 1" and looks like a redaction bug.
+		t.Fatalf("running the relay's redactTokens under node failed: %v\nstderr: %s", err, stderr.String())
+	}
+	return string(out)
+}


### PR DESCRIPTION
Fixes #5478

## Problem

Hive redacts credential-shaped text in two places with no shared source of truth, and the relay half was materially narrower. An agent terminal printing a JWT, an AWS key or a private-key block had it forwarded to the hub **unredacted**.

## 1. Categories added to the relay

`redactTokens()` (`bin/contributor-relay.sh`) previously covered GitHub token prefixes and nothing else. It now covers everything `pkg/logscrub` does:

| Category | Before | After |
|---|---|---|
| GitHub prefixes | yes | yes |
| `HIVE-CANARY-` | no | **yes** |
| JWT (`eyJ…`) | no | **yes** |
| AWS `AKIA`/`ASIA` | no | **yes** |
| `Bearer` values | no | **yes** |
| PEM private key (incl. RSA/EC/OPENSSH/DSA) | no | **yes** |
| PEM encrypted private key | no | **yes** |
| PGP private key block | no | **yes** |

## 2. Shared-pattern alignment

Two independent ways token-shaped material survived the relay:

- **Character class** — the relay accepted only `[A-Za-z0-9]` after `gh*_` (underscore allowed for `github_pat_` alone) while Go accepted `[A-Za-z0-9_]` everywhere. A `gho_` token *containing an underscore* was redacted by Go and passed through by the relay. Now `[A-Za-z0-9_]` on both sides.
- **Length floor** — Go required 10+ trailing characters, the relay 36+. A short or truncated token-shaped run cleared the relay. Floor is now 10 on both sides.

### Preserved deliberately

- The bound stays **open-ended** (`{10,}`, not `{10}`). Per #4267 an exact bound redacts only the first N characters and leaks a longer token's tail. Only the floor value moved. `TestRelayKeepsOpenEndedTokenBound` pins this.
- The prefix-preserving replacement (`gho_***REDACTED***`) is unchanged, so hub-side readers can still tell *which* credential class appeared. The existing #4267 tests continue to pass unmodified.
- The Go side was **not** weakened to meet the relay. Parity was reached by widening the relay only; `ScrubString` behaviour is unchanged for every pre-existing category.

## 3. Removing the hand-maintenance

Both sides now declare **named categories** — `secretPatterns` gains a `Category` field, the relay gains `HIVE_REDACTION_CATEGORIES` — and `src/pkg/logscrub/redaction_parity_test.go` asserts they agree. It follows `TestShellAndGoCLIBackendListsAgree`: a closed exception set that fails when an entry goes stale (currently empty by design; the machinery is kept so a future one-sided category has a documented home rather than being bolted on by deleting the guard).

### Generation was evaluated and rejected — with the reason

Generating the relay's regexes from the Go source is the stronger option in principle, and it is not what this PR does. Go's RE2 and JavaScript's `RegExp` are different dialects: Go writes inline flags (`(?s)`, `(?i)`) that JS expresses only as trailing flags, and Go's `\b` sits next to character classes JS treats differently. A generator would have to translate dialects, and **a translation bug would fail open** — emitting a JS regex that compiles fine and matches nothing, which is precisely the silent-miss shape this issue is about.

Naming the categories and asserting **behaviour on both sides** is the safer contract, because it cannot pass on a pattern that compiles but never fires. That is enforced by `TestRedactionParityCasesCoverEveryCategory` (every Go category must have a behavioural sample) and by the relay-side `#5478 every declared redaction category actually fires`.

## Testing

Per #5388 — guards that cannot fail — the parity guard was verified to actually go red, not merely observed green.

**Demonstration: category added to Go but not the relay.** Added a `drift_probe` category to `secretPatterns` only:

```
=== RUN   TestGoAndRelayRedactionCategoriesAgree
    redaction_parity_test.go:166: Go and relay redaction categories have drifted:
          logscrub secretPatterns has drift_probe but HIVE_REDACTION_CATEGORIES in
          bin/contributor-relay.sh does not, and it is not a declared exception —
          agent output carrying this category reaches the hub unredacted
--- FAIL: TestGoAndRelayRedactionCategoriesAgree (0.00s)
=== RUN   TestRedactionParityCasesCoverEveryCategory
    redaction_parity_test.go:241: category "drift_probe" is declared in secretPatterns
          but has no entry in parityCases, so nothing asserts that either
          implementation actually redacts it
--- FAIL: TestRedactionParityCasesCoverEveryCategory (0.00s)
FAIL
```

Reverting the probe returns the package to green:

```
--- PASS: TestGoAndRelayRedactionCategoriesAgree (0.00s)
--- PASS: TestRedactionParityCasesCoverEveryCategory (0.00s)
--- PASS: TestGoRedactsEveryParityCase (0.00s)
--- PASS: TestRelayRedactsEveryParityCase (0.31s)
--- PASS: TestUnderscoreGitHubTokenRedactedByBothPaths (0.04s)
--- PASS: TestShortGitHubTokenRedactedByBothPaths (0.04s)
--- PASS: TestRelayKeepsOpenEndedTokenBound (0.04s)
ok  	github.com/kubestellar/hive/pkg/logscrub	0.669s
```

**Anti-vacuity check (the #5409 lesson), also demonstrated red.** A parity test that parses zero categories would pass trivially. Breaking `relayCategoryRe` so it matches nothing:

```
=== RUN   TestGoAndRelayRedactionCategoriesAgree
    redaction_parity_test.go:126: parsed no categories out of HIVE_REDACTION_CATEGORIES
          in ../../../bin/contributor-relay.sh — the array was reshaped past what
          relayCategoryRe understands, and every parity assertion below would pass vacuously
--- FAIL: TestGoAndRelayRedactionCategoriesAgree (0.00s)
```

**Relay-side suite:** `node bin/contributor-relay.test.js` → **267/267 passed** (256 pre-existing, all unmodified, + 11 new). New coverage asserts JWT, AWS (`AKIA` and `ASIA`), `Bearer` in three casings, five PEM block variants and canary markers are redacted; that an underscore-bearing and a 20-char token are redacted; that two adjacent PEM blocks are redacted separately without swallowing the text between them; and that repeated calls are idempotent (the category regexes are module-level and `/g`, so a carried-over `lastIndex` would skip the start of the next line and fail open).

The relay-side behavioural test drives the **real** `redactTokens()` loaded from `bin/contributor-relay.sh`, not a Go reimplementation — a reimplementation would pass while the shipped relay leaked.

**Also green:** `go build ./...`, and `pkg/logscrub`, `pkg/ioscan`, `pkg/pushbroker`, `pkg/turn` (the `TokenPattern` consumers), plus `bash bin/contributor-agent.test.sh` and `node --check`.

### Note on a flaky neighbour

A full-package run of `pkg/agent` failed once on `TestSendKick_RestartsCrashedCLIThenDelivers`. It passes in isolation on **both** this branch and clean `v4`, and passes on a full-package re-run here; clean `v4` also passes the full package. It drives real tmux CLI restarts with wall-clock waits — a pre-existing timing flake, not a regression. This change touches that package only through `logscrub.ScrubString`, whose behaviour is unchanged for all pre-existing categories.

## Security notes

- No real token material anywhere. All fixtures are obviously-synthetic and shape-accurate (`gho_` + 36 `a`s, `AKIA` + 16 `A`s, a JWT of `a`/`b`/`c` runs, `SYNTHETICKEYMATERIAL` PEM bodies).
- Assertions are on **post-redaction output only**; no pre-redaction value is logged.
- Widening is fail-safe by design. `#5478 the lowered floor still does not redact ordinary prose` pins that the lower floor does not start eating normal pane text.

## Scope left open, deliberately

The issue's third divergence — placeholder text (`[REDACTED]` vs `***REDACTED***`) — is **not** changed here. Unifying it would break the #4267 prefix-preserving contract that existing relay tests pin, and it is cosmetic next to the leak. Worth its own issue if alerting depends on a single marker string.

## Overlap with concurrent work

`bin/contributor-relay.sh` is shared with in-flight relay work. Checked explicitly:

- **#5447** and **#5151** are **closed**; **#5090** (WebSocket flap) has no open PR touching the relay.
- **PR #5408** is the only open PR touching this file. **No overlap** — it edits relay lines ~998–1200 (`HEADLESS_BACKENDS`, `runHeadlessTask`) and test lines ~2262–2351. This PR edits relay ~1612 (`redactTokens`) and appends tests after ~3510. Textually disjoint; either order merges cleanly.
- **#5435** (`systemd/hive-discord.service`, deploy scripts) touches no file in this PR.