### PR TITLE
🐛 test: make a silent skip fatal where the lane guarantees the precondition (#5388)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -88,6 +88,12 @@ jobs:
       # github_auth: fail. EXECUTES the real merge block extracted from the
       # shipped entrypoint, so a regression fails the PR rather than a hive.
       - name: Entrypoint dangling key_file tests (#4368)
+        env:
+          # #5388: ubuntu-latest GUARANTEES python3 with PyYAML (actions/runner-images
+          # ships both preinstalled), so this suite's "python3/PyYAML unavailable"
+          # skip cannot be true here. If it fires, the precondition moved and the
+          # suite stopped asserting — that must be red, not a silent exit 0.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash deploy/test_entrypoint_dangling_keyfile.sh
 
       # #5369: the `chown -R dev:node /data` in the entrypoint's root phase is
@@ -163,6 +169,12 @@ jobs:
       # other tool, the proxy attached to the network the hive runs on) and none
       # of those break anything at runtime — so they need a gate, not a review.
       - name: Docker-socket containment guard (#3865)
+        env:
+          # #5388: ubuntu-latest GUARANTEES python3 with PyYAML (actions/runner-images
+          # ships both preinstalled), so this suite's "python3/PyYAML unavailable"
+          # skip cannot be true here. If it fires, the precondition moved and the
+          # suite stopped asserting — that must be red, not a silent exit 0.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash deploy/test_watchtower_socket_contract.sh
 
       # #4204: the socket guard above covers the auto-update profile, and the
@@ -174,6 +186,12 @@ jobs:
       # and just loses agent state on the next recreate. This is also the
       # snapshot the Podman runtime work (#4188) has to keep passing.
       - name: Standalone service deployment contract (#4204)
+        env:
+          # #5388: ubuntu-latest GUARANTEES python3 with PyYAML (actions/runner-images
+          # ships both preinstalled), so this suite's "python3/PyYAML unavailable"
+          # skip cannot be true here. If it fires, the precondition moved and the
+          # suite stopped asserting — that must be red, not a silent exit 0.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash deploy/test_standalone_service_contract.sh
 
       # #4375: the guard above parses docker-compose.yaml and therefore cannot
@@ -215,6 +233,12 @@ jobs:
       # rather than listing them, so a fourth copy of the quick start is gated
       # the day it is written.
       - name: Documented Compose quick start contract (#4477)
+        env:
+          # #5388: actions/checkout GUARANTEES a real git checkout, so this
+          # suite's "not a git checkout" skip — which would silently retire the
+          # assertion that src/.env is gitignored, on a path the quick start
+          # tells operators to put a PAT in — cannot legitimately fire here.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash deploy/test_compose_quickstart_contract.sh
 
       # #4404: every guard above looks at ONE runtime. test_standalone_service_
@@ -230,6 +254,12 @@ jobs:
       # reason. Entries are swept in reverse too: an exception that no longer
       # matches a real divergence is itself a failure, so the table cannot rot.
       - name: Docker/Podman contract parity (#4404)
+        env:
+          # #5388: ubuntu-latest GUARANTEES python3 with PyYAML (actions/runner-images
+          # ships both preinstalled), so this suite's "python3/PyYAML unavailable"
+          # skip cannot be true here. If it fires, the precondition moved and the
+          # suite stopped asserting — that must be red, not a silent exit 0.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash deploy/test_standalone_runtime_parity.sh
 
       # bin/gh-wrapper.sh is the merge gate standing behind the proxy hard-deny:
@@ -468,6 +498,12 @@ jobs:
           just --version
       - name: Contributor K8s Workload Generation
         working-directory: .
+        env:
+          # #5388: the "Install just" step above GUARANTEES the binary, and
+          # ubuntu-latest guarantees python3+PyYAML, so neither of this suite's
+          # skips can legitimately fire here. Before this, a failed install
+          # silently turned the whole suite into an exit-0 no-op.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash src/deploy/test_contribute_k8s_workload.sh
 
       # #4399: the browser terminal must say when it is NOT showing live output.
@@ -516,6 +552,12 @@ jobs:
       # that still dies on the first non-zero command.
       - name: Changelog reminder never blocks a merge (#4440)
         working-directory: .
+        env:
+          # #5388: ubuntu-latest GUARANTEES python3 with PyYAML (actions/runner-images
+          # ships both preinstalled), so this suite's "python3/PyYAML unavailable"
+          # skip cannot be true here. If it fires, the precondition moved and the
+          # suite stopped asserting — that must be red, not a silent exit 0.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash src/deploy/test_changelog_reminder.sh
 
       # #4408: `just contribute-move` relocates an already-registered
@@ -544,6 +586,32 @@ jobs:
       - name: In-container attach hints name the real runtime (#5145)
         working-directory: .
         run: bash src/deploy/test_attach_hint_runtime.sh
+
+      # #5388 item 3: the guard on the skip discipline itself.
+      #
+      # test_lib.sh only helps if the suites that source it ACTUALLY go fatal
+      # under HIVE_TEST_REQUIRE_BEHAVIOURAL=1. This does not grep for adoption —
+      # a grep passes on a suite that sources the lib and never reaches the
+      # call. It RUNS each registered suite in a sandbox PATH with the tool its
+      # behavioural block needs genuinely absent, and requires exit 0 without
+      # the flag and exit 1 with it. The suite's own exit status is the
+      # assertion, so this cannot green while proving nothing.
+      #
+      # Deliberately NOT given HIVE_TEST_REQUIRE_BEHAVIOURAL itself: its method
+      # is running children with the flag off and on, so it unsets it.
+      - name: A skip is fatal where the caller guarantees the precondition (#5388)
+        working-directory: .
+        run: bash src/deploy/test_skip_discipline.sh
+
+      # #5388: this suite existed but was wired into NO workflow, so it had
+      # never run in CI — the same silent-non-execution failure the issue is
+      # about, one level out. Registering it here; git is guaranteed by
+      # actions/checkout, so its "git not available" skip is fatal.
+      - name: Entrypoint system gitconfig contract
+        working-directory: .
+        env:
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
+        run: bash src/deploy/test_entrypoint_system_gitconfig.sh
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/src/deploy/test_changelog_reminder.sh
+++ b/src/deploy/test_changelog_reminder.sh
@@ -17,6 +17,12 @@ set -uo pipefail
 
 PASS=0
 FAIL=0
+
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; [ $# -gt 1 ] && echo "        $2"; FAIL=$((FAIL + 1)); }
 
@@ -30,8 +36,8 @@ if [ ! -f "$WF" ]; then
   echo ""; echo "=== Results: $PASS passed, $FAIL failed ==="; exit 1
 fi
 if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import yaml' >/dev/null 2>&1; then
-  echo "  SKIP: python3 + PyYAML unavailable — cannot extract the step script"
-  exit 0
+  hive_test_skip "python3 + PyYAML unavailable — cannot extract the step script"
+  hive_test_report; exit $?
 fi
 
 WORK="$(mktemp -d)"

--- a/src/deploy/test_compose_quickstart_contract.sh
+++ b/src/deploy/test_compose_quickstart_contract.sh
@@ -50,6 +50,12 @@ COMPOSE_REL="src/docker-compose.yaml"
 
 PASS=0
 FAIL=0
+
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; [ $# -gt 1 ] && echo "        $2"; FAIL=$((FAIL + 1)); }
 
@@ -245,7 +251,7 @@ if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
          "the quick start tells the operator to put a PAT there and git would take it"
   fi
 else
-  echo "  SKIP: not a git checkout, cannot ask git whether src/.env is ignored"
+  hive_test_skip "not a git checkout, cannot ask git whether src/.env is ignored"
 fi
 
 echo

--- a/src/deploy/test_contribute_k8s_workload.sh
+++ b/src/deploy/test_contribute_k8s_workload.sh
@@ -14,6 +14,12 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+
 check() {
   local label="$1" want="$2" got="$3"
   if [ "$want" = "$got" ]; then
@@ -41,8 +47,8 @@ contains() {
 # Locate the repo root (this script lives in src/deploy/) and require `just`.
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 if ! command -v just >/dev/null 2>&1; then
-  echo "  SKIP: 'just' not installed; cannot exercise the recipe"
-  exit 0
+  hive_test_skip "'just' not installed; cannot exercise the recipe"
+  hive_test_report; exit $?
 fi
 
 echo "=== contribute-k8s workload generation tests ==="
@@ -100,7 +106,7 @@ if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&
   KINDS="$(printf '%s' "$OUT" | python3 -c 'import sys,yaml; print(",".join(d["kind"] for d in yaml.safe_load_all(sys.stdin) if d))')"
   check "YAML parses to the four expected kinds" "Namespace,ConfigMap,Secret,Deployment" "$KINDS"
 else
-  echo "  SKIP: PyYAML unavailable; skipping structural parse"
+  hive_test_skip "PyYAML unavailable; skipping structural parse"
 fi
 
 # ── Backend credential delivery (#5103) ──

--- a/src/deploy/test_entrypoint_dangling_keyfile.sh
+++ b/src/deploy/test_entrypoint_dangling_keyfile.sh
@@ -19,6 +19,12 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+
 DEPLOY_DIR="$(cd "$(dirname "$0")" && pwd)"
 ENTRYPOINT="$DEPLOY_DIR/entrypoint.sh"
 
@@ -36,12 +42,12 @@ fail() {
 echo "=== entrypoint dangling key_file tests (#4368) ==="
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "  SKIP: python3 not available"
-  exit 0
+  hive_test_skip "python3 not available"
+  hive_test_report; exit $?
 fi
 if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-  echo "  SKIP: python3 yaml module not available"
-  exit 0
+  hive_test_skip "python3 yaml module not available"
+  hive_test_report; exit $?
 fi
 
 # Extract the merge block verbatim from the entrypoint: everything between the

--- a/src/deploy/test_entrypoint_data_ownership.sh
+++ b/src/deploy/test_entrypoint_data_ownership.sh
@@ -19,8 +19,11 @@
 # Run: bash src/deploy/test_entrypoint_data_ownership.sh
 set -uo pipefail
 
-PASS=0
-FAIL=0
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1. Extracted from this file and its
+# sibling by #5388 so every deploy suite can use the same contract.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
 
 ENTRYPOINT="$(cd "$(dirname "$0")" && pwd)/entrypoint.sh"
 RUNTIME_UID=1001
@@ -40,31 +43,6 @@ check() {
 
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 bad()  { echo "  FAIL: $1"; [ -n "${2:-}" ] && echo "        $2"; FAIL=$((FAIL + 1)); }
-
-# ── Skipping is a result, and where it is wrong it must be fatal (#5380) ──
-#
-# The behavioural block below needs root and a `dev` account. On a bare
-# ubuntu-latest runner or a laptop it has neither, so it skips LOUDLY rather
-# than faking a pass — that stays, and this suite remains runnable anywhere.
-#
-# But a loud skip that nothing acts on is still a guard that cannot fail, and
-# that is #5380: the assertions which would catch a regression never executed
-# on any PR. So when the caller KNOWS the preconditions are met — the podman
-# arm64 lane runs this inside the image, as root, where `dev` exists — it sets
-# HIVE_TEST_REQUIRE_BEHAVIOURAL=1 and a skip becomes a FAILURE. There, a skip
-# does not mean "unsuitable environment", it means the test is broken.
-REQUIRE_BEHAVIOURAL="${HIVE_TEST_REQUIRE_BEHAVIOURAL:-0}"
-
-skip() {
-  if [ "$REQUIRE_BEHAVIOURAL" = "1" ]; then
-    bad "$1" \
-        "HIVE_TEST_REQUIRE_BEHAVIOURAL=1 — the caller asserts root and a 'dev' account are present, so this is a BROKEN TEST, not an unsuitable environment (#5380)"
-  else
-    echo "  SKIP: $1"
-    [ -n "${2:-}" ] && echo "        $2"
-  fi
-  return 0
-}
 
 echo "=== #5369: /data ownership invariant ==="
 
@@ -231,12 +209,12 @@ echo
 echo "=== behavioural: swept paths are readable by the runtime user ==="
 
 if [ "$(id -u)" != "0" ]; then
-  skip "not root — cannot create root-owned files or drop to another uid" \
+  hive_test_skip "not root — cannot create root-owned files or drop to another uid" \
        "(this is the case a container lane must run; see #5360/#5369)"
 elif ! id -u dev >/dev/null 2>&1; then
-  skip "no 'dev' account on this host — cannot exercise the drop"
+  hive_test_skip "no 'dev' account on this host — cannot exercise the drop"
 elif ! stat -c '%u' / >/dev/null 2>&1; then
-  skip "no GNU stat -c on this host — the helpers require it"
+  hive_test_skip "no GNU stat -c on this host — the helpers require it"
 else
   SWEEP_FN="$SWEEP"
   ASSERT_FN="$(sed -n '/^hive_assert_runtime_readable() {/,/^}/p' "$ENTRYPOINT")"
@@ -346,6 +324,4 @@ $tmpd/home"
   trap - EXIT
 fi
 
-echo
-echo "=== $PASS passed, $FAIL failed ==="
-[ "$FAIL" -eq 0 ]
+hive_test_report

--- a/src/deploy/test_entrypoint_runtime_config.sh
+++ b/src/deploy/test_entrypoint_runtime_config.sh
@@ -13,8 +13,11 @@
 # Run: bash src/deploy/test_entrypoint_runtime_config.sh
 set -euo pipefail
 
-PASS=0
-FAIL=0
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1. Extracted from this file and its
+# sibling by #5388 so every deploy suite can use the same contract.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
 
 ENTRYPOINT="$(cd "$(dirname "$0")" && pwd)/entrypoint.sh"
 
@@ -29,34 +32,6 @@ check() {
     echo "        got:  '$got'"
     FAIL=$((FAIL + 1))
   fi
-}
-
-# ── Skipping is a result, and where it is wrong it must be fatal (#5380) ──
-#
-# The behavioural block below needs root and a `dev` account. On a bare
-# ubuntu-latest runner or a laptop it has neither, so it skips LOUDLY rather
-# than faking a pass — that stays, and this suite remains runnable anywhere.
-#
-# But a loud skip that nothing acts on is still a guard that cannot fail, and
-# that is #5380: the assertions which would catch a regression never executed
-# on any PR. So when the caller KNOWS the preconditions are met — the podman
-# arm64 lane runs this inside the image, as root, where `dev` exists — it sets
-# HIVE_TEST_REQUIRE_BEHAVIOURAL=1 and a skip becomes a FAILURE. There, a skip
-# does not mean "unsuitable environment", it means the test is broken.
-REQUIRE_BEHAVIOURAL="${HIVE_TEST_REQUIRE_BEHAVIOURAL:-0}"
-
-skip() {
-  if [ "$REQUIRE_BEHAVIOURAL" = "1" ]; then
-    echo "  FAIL: $1"
-    echo "        HIVE_TEST_REQUIRE_BEHAVIOURAL=1 — the caller asserts root and a"
-    echo "        'dev' account are present, so this is a BROKEN TEST, not an"
-    echo "        unsuitable environment (#5380)."
-    FAIL=$((FAIL + 1))
-  else
-    echo "  SKIP: $1"
-    [ -n "${2:-}" ] && echo "        $2"
-  fi
-  return 0
 }
 
 echo "=== entrypoint runtime-config migration tests ==="
@@ -183,10 +158,10 @@ fi
 # pass — a silent skip here is how the original gap shipped.
 RUNTIME_UID=1001
 if [ "$(id -u)" != "0" ]; then
-  skip "not root — cannot exercise the root-creates/dev-reads path" \
+  hive_test_skip "not root — cannot exercise the root-creates/dev-reads path" \
        "(this is the case CI must run; see #5360)"
 elif ! id -u dev >/dev/null 2>&1; then
-  skip "no 'dev' account on this host — cannot exercise the drop"
+  hive_test_skip "no 'dev' account on this host — cannot exercise the drop"
 else
   tmpd="$(mktemp -d)"
   trap 'rm -rf "$tmpd"' EXIT
@@ -256,6 +231,4 @@ else
   trap - EXIT
 fi
 
-echo
-echo "=== $PASS passed, $FAIL failed ==="
-[ "$FAIL" -eq 0 ]
+hive_test_report

--- a/src/deploy/test_entrypoint_system_gitconfig.sh
+++ b/src/deploy/test_entrypoint_system_gitconfig.sh
@@ -23,6 +23,12 @@ set -uo pipefail
 PASS=0
 FAIL=0
 
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; [ -n "${2:-}" ] && echo "        $2"; FAIL=$((FAIL + 1)); }
 
@@ -32,8 +38,8 @@ HELPER_PATH="/usr/local/bin/git-credential-hive.sh"
 echo "=== Entrypoint system gitconfig (#5343) ==="
 
 if ! command -v git >/dev/null 2>&1; then
-  echo "  SKIP: git not available"
-  exit 0
+  hive_test_skip "git not available"
+  hive_test_report; exit $?
 fi
 
 TMP="$(mktemp -d)"

--- a/src/deploy/test_lib.sh
+++ b/src/deploy/test_lib.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Shared skip discipline for the src/deploy/test_*.sh suites (#5388 item 3).
+#
+# ── The defect this exists to close ──────────────────────────────────────────
+#
+# A test block that skips on a runner that genuinely cannot run it is CORRECT.
+# The same block skipping on a runner that CAN run it means the test is broken
+# — and it reports green either way. That is the whole of #5388 item 3: a skip
+# is a result nobody acts on, so a suite can quietly stop asserting anything
+# and no lane ever goes red.
+#
+# #5383 solved this for exactly one case: HIVE_TEST_REQUIRE_BEHAVIOURAL=1 makes
+# a skip fatal in the podman arm64 lane, where the container guarantees root and
+# a `dev` account. It was never generalised — the helper was copy-pasted into
+# two suites and nothing else. This file is that helper, extracted, so any suite
+# can opt in and any lane whose runner GUARANTEES the precondition can demand it.
+#
+# ── The contract ─────────────────────────────────────────────────────────────
+#
+#   HIVE_TEST_REQUIRE_BEHAVIOURAL unset / 0 (default)
+#       hive_test_skip prints "SKIP: <reason>" and the suite continues. Suites
+#       stay runnable on a laptop and on a bare runner that lacks the tooling.
+#
+#   HIVE_TEST_REQUIRE_BEHAVIOURAL=1
+#       hive_test_skip prints "FAIL: <reason>" and increments FAIL. The CALLER
+#       is asserting the precondition holds, so a skip cannot mean "unsuitable
+#       environment" — it means the precondition moved and the test silently
+#       stopped testing.
+#
+# Setting the flag is a judgement call and belongs to the LANE, not the suite.
+# Set it only where the runner guarantees the precondition. Setting it where the
+# precondition is merely likely converts a correct skip into a false red.
+#
+# ── Usage ────────────────────────────────────────────────────────────────────
+#
+#   # shellcheck source=src/deploy/test_lib.sh
+#   . "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+#   ...
+#   if ! command -v python3 >/dev/null 2>&1; then
+#     hive_test_skip "python3 unavailable — cannot make structural assertions"
+#     hive_test_report; exit $?          # honours the skip-as-failure result
+#   fi
+#
+# Suites must define PASS and FAIL as integers before sourcing, or let this file
+# initialise them (it does, if unset). hive_test_report prints the tally and
+# RETURNS non-zero when FAIL > 0, so the suite's EXIT STATUS is the assertion —
+# not a string a grep could match while nothing ran.
+
+# Deliberately no `set -e` here: sourcing must not change the caller's shell
+# options. Each suite keeps whatever discipline it already chose.
+
+: "${PASS:=0}"
+: "${FAIL:=0}"
+
+# 1 when the caller asserts the preconditions for behavioural blocks are met.
+HIVE_TEST_REQUIRE_BEHAVIOURAL="${HIVE_TEST_REQUIRE_BEHAVIOURAL:-0}"
+
+# hive_test_require_behavioural — true when skips are fatal in this environment.
+hive_test_require_behavioural() {
+  [ "$HIVE_TEST_REQUIRE_BEHAVIOURAL" = "1" ]
+}
+
+# hive_test_pass <label>
+hive_test_pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+# hive_test_fail <label> [detail]
+hive_test_fail() {
+  echo "  FAIL: $1"
+  [ -n "${2:-}" ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+  return 0
+}
+
+# hive_test_skip <reason> [detail]
+#
+# Permissive by default; FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1. Always
+# returns 0 so `set -e` suites are not aborted mid-tally — the verdict is
+# carried in FAIL and surfaced by hive_test_report's exit status.
+hive_test_skip() {
+  if hive_test_require_behavioural; then
+    echo "  FAIL: $1"
+    [ -n "${2:-}" ] && echo "        $2"
+    echo "        HIVE_TEST_REQUIRE_BEHAVIOURAL=1 — the caller asserts this"
+    echo "        precondition holds here, so this is a BROKEN TEST, not an"
+    echo "        unsuitable environment (#5388)."
+    FAIL=$((FAIL + 1))
+  else
+    echo "  SKIP: $1"
+    [ -n "${2:-}" ] && echo "        $2"
+  fi
+  return 0
+}
+
+# hive_test_report — print the tally; return 0 only when nothing failed.
+hive_test_report() {
+  echo
+  echo "=== $PASS passed, $FAIL failed ==="
+  [ "$FAIL" -eq 0 ]
+}

--- a/src/deploy/test_skip_discipline.sh
+++ b/src/deploy/test_skip_discipline.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# #5388 item 3: the guard on the guard.
+#
+# test_lib.sh only helps if the suites that claim to use it ACTUALLY become
+# fatal under HIVE_TEST_REQUIRE_BEHAVIOURAL=1. A suite could source the lib and
+# still `exit 0` on a skip — and it would look adopted while asserting nothing.
+# That is the exact defect class #5388 is about, reproduced one level up.
+#
+# So this does not grep for adoption. It EXECUTES each registered suite in a
+# deliberately unsuitable environment and requires:
+#
+#   flag unset → exit 0   (a correct skip must stay permissive)
+#   flag=1     → exit 1   (the same skip must be fatal)
+#
+# The second half is the load-bearing one: a suite that exits 0 under the flag
+# has a skip nobody acts on, which is what the whole issue is about. Note the
+# trap this deliberately avoids — an inline `grep -l hive_test_skip src/deploy/*`
+# would pass on a suite that sources the lib and never reaches the call, and a
+# `find ... -print -quit` style probe exits 0 on NO match, greening while
+# asserting nothing (#5435). Here the suite's own exit status is the assertion.
+#
+# Run: bash src/deploy/test_skip_discipline.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=src/deploy/test_lib.sh
+. "${HERE}/test_lib.sh"
+
+# This suite tests the discipline itself, so it must never inherit the flag from
+# an outer lane — its whole method is running children with the flag OFF and ON.
+unset HIVE_TEST_REQUIRE_BEHAVIOURAL
+
+echo "=== #5388: a skip is fatal where the caller guarantees the precondition ==="
+
+# ── 1. test_lib.sh's own contract ────────────────────────────────────────────
+#
+# Exercised directly, because everything below inherits it. A subshell per case
+# so the PASS/FAIL counters of this suite are not disturbed.
+
+lib_case() {
+  # lib_case <flag> <expected-exit> <expected-substring> <label>
+  local flag="$1" want_rc="$2" want_str="$3" label="$4" out rc
+  out="$(
+    HIVE_TEST_REQUIRE_BEHAVIOURAL="$flag" bash -c '
+      . "$1/test_lib.sh"
+      hive_test_pass "a real assertion ran"
+      hive_test_skip "synthetic precondition missing"
+      hive_test_report
+    ' _ "$HERE" 2>&1
+  )"
+  rc=$?
+  if [ "$rc" = "$want_rc" ] && printf '%s' "$out" | grep -q "$want_str"; then
+    hive_test_pass "$label"
+  else
+    hive_test_fail "$label" "want rc=$want_rc containing '$want_str'; got rc=$rc: $(printf '%s' "$out" | tr '\n' '|')"
+  fi
+}
+
+lib_case "0" 0 "SKIP: synthetic precondition missing" \
+  "flag unset: hive_test_skip is permissive and the suite exits 0"
+lib_case "1" 1 "FAIL: synthetic precondition missing" \
+  "flag=1: the same skip is fatal and the suite exits 1"
+
+# Anti-vacuity: a suite that skips NOTHING must stay green under the flag, or
+# every lane we set the flag in would go red for the wrong reason.
+out="$(
+  HIVE_TEST_REQUIRE_BEHAVIOURAL=1 bash -c '
+    . "$1/test_lib.sh"; hive_test_pass "ran"; hive_test_report' _ "$HERE" 2>&1
+)"
+if [ $? -eq 0 ]; then
+  hive_test_pass "flag=1 with no skip stays green (the flag is not a blanket failure)"
+else
+  hive_test_fail "flag=1 with no skip stays green" "got: $out"
+fi
+
+# ── 2. Every registered suite honours the flag, proven by running it ─────────
+#
+# Each entry names a suite and an environment that FORCES its behavioural block
+# to skip. Suites are run with PATH stripped of the tool they need, which is the
+# honest way to reach the skip path on a machine that has the tool.
+#
+# ADDING A SUITE: source test_lib.sh, route its skip through hive_test_skip,
+# and add a line here. An unregistered suite is not covered — same failure mode
+# as an unregistered test in v2-ci.yml.
+
+# ── Denying a tool honestly ──────────────────────────────────────────────────
+#
+# Deleting PATH entries would take the whole of /usr/bin with it — dirname and
+# mktemp included — and a suite would die at line 1 for an unrelated reason,
+# which is a false red. A stub that resolves but exits non-zero is also wrong:
+# suites that probe with `command -v` sail past their guard and fail later, and
+# that misreports as "this suite does not honour the flag".
+#
+# So: build ONE sandbox bin of symlinks to everything on PATH, then per case
+# copy the symlink farm minus the denied tools. `command -v <tool>` then
+# genuinely fails, which is exactly what the suites' guards test, while every
+# unrelated utility still works. The farm is built once — rebuilding it per
+# suite is O(PATH) forks and takes minutes.
+SANDBOX_ROOT="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX_ROOT"' EXIT
+FULL_BIN="${SANDBOX_ROOT}/full"
+mkdir -p "$FULL_BIN"
+while IFS= read -r _d; do
+  [ -d "$_d" ] || continue
+  for _entry in "$_d"/*; do
+    [ -x "$_entry" ] || continue
+    _name="${_entry##*/}"
+    [ -e "${FULL_BIN}/${_name}" ] && continue
+    ln -s "$_entry" "${FULL_BIN}/${_name}" 2>/dev/null || true
+  done
+done <<<"$(printf '%s' "$PATH" | tr ':' '\n')"
+
+if [ ! -x "${FULL_BIN}/bash" ]; then
+  hive_test_fail "could not build a PATH sandbox" "no bash under ${FULL_BIN}"
+  hive_test_report; exit $?
+fi
+
+_case_n=0
+
+# check_suite <suite> <how-the-precondition-is-denied> [tool ...]
+check_suite() {
+  local suite="$1" how="$2"; shift 2
+  local bindir out rc_off rc_on tool
+
+  _case_n=$((_case_n + 1))
+  bindir="${SANDBOX_ROOT}/case${_case_n}"
+  cp -a "$FULL_BIN" "$bindir"
+  for tool in "$@"; do
+    [ -n "$tool" ] && rm -f "${bindir}/${tool}"
+  done
+
+  if [ ! -f "${HERE}/${suite}" ]; then
+    hive_test_fail "${suite} is registered but does not exist" \
+      "a renamed or deleted suite silently stops being covered"
+    return 0
+  fi
+
+  # Anti-vacuity: if a denial did not take, this case would assert nothing.
+  for tool in "$@"; do
+    [ -z "$tool" ] && continue
+    if PATH="$bindir" command -v "$tool" >/dev/null 2>&1; then
+      hive_test_fail "${suite}: '${tool}' is still reachable in the sandbox" \
+        "the denial did not take, so this case proves nothing"
+      return 0
+    fi
+  done
+
+  out="$(PATH="$bindir" HIVE_TEST_REQUIRE_BEHAVIOURAL=0 \
+         bash "${HERE}/${suite}" 2>&1)"; rc_off=$?
+  out="$(PATH="$bindir" HIVE_TEST_REQUIRE_BEHAVIOURAL=1 \
+         bash "${HERE}/${suite}" 2>&1)"; rc_on=$?
+
+  if [ "$rc_off" -ne 0 ]; then
+    hive_test_fail "${suite}: permissive run stays green when ${how}" \
+      "exit ${rc_off} — a genuinely unsuitable environment must not fail by default"
+    return 0
+  fi
+  hive_test_pass "${suite}: skips permissively (exit 0) when ${how}"
+
+  if [ "$rc_on" -eq 0 ]; then
+    hive_test_fail "${suite}: HIVE_TEST_REQUIRE_BEHAVIOURAL=1 makes the skip fatal" \
+      "exit 0 under the flag — this suite's skip is still silent, so it is NOT adopted (#5388). Route it through hive_test_skip."
+    return 0
+  fi
+  hive_test_pass "${suite}: the same skip is FATAL (exit ${rc_on}) under the flag"
+}
+
+echo
+echo "--- registered suites ---"
+
+# Deny python3 outright: the structural-assertion suites all gate on it.
+check_suite test_entrypoint_dangling_keyfile.sh   "python3 is absent"  python3
+check_suite test_standalone_service_contract.sh   "python3 is absent"  python3
+check_suite test_watchtower_socket_contract.sh    "python3 is absent"  python3
+check_suite test_standalone_runtime_parity.sh     "python3 is absent"  python3
+check_suite test_changelog_reminder.sh            "python3 is absent"  python3
+check_suite test_contribute_k8s_workload.sh       "'just' is absent"   just
+check_suite test_entrypoint_system_gitconfig.sh   "git is absent"      git
+
+# The two #5383 suites gate on being root, which cannot be denied by PATH — but
+# this test process is not root anywhere it matters, so they reach the skip on
+# their own. Running them unmodified is the migration's regression check.
+check_suite test_entrypoint_runtime_config.sh   "the runner is not root"
+check_suite test_entrypoint_data_ownership.sh   "the runner is not root"
+
+hive_test_report

--- a/src/deploy/test_standalone_runtime_parity.sh
+++ b/src/deploy/test_standalone_runtime_parity.sh
@@ -60,6 +60,12 @@ PASS=0
 FAIL=0
 EXCEPTED=0
 
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+
 pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
 fail() {
   printf '  FAIL: %s\n' "$1"
@@ -79,12 +85,12 @@ for required in "$COMPOSE" "$UNIT_DIR" "$ENV_EXAMPLE" "$IMAGES_SH"; do
 done
 
 if ! command -v python3 >/dev/null 2>&1; then
-  printf '  SKIP: python3 unavailable — cannot compare the two descriptions structurally\n'
-  exit 0
+  hive_test_skip "python3 unavailable — cannot compare the two descriptions structurally"
+  hive_test_report; exit $?
 fi
 if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-  printf '  SKIP: PyYAML unavailable — cannot parse docker-compose.yaml\n'
-  exit 0
+  hive_test_skip "PyYAML unavailable — cannot parse docker-compose.yaml"
+  hive_test_report; exit $?
 fi
 
 # Image references are normalised by the SOURCE OF TRUTH's own function rather

--- a/src/deploy/test_standalone_service_contract.sh
+++ b/src/deploy/test_standalone_service_contract.sh
@@ -32,6 +32,12 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+
 SRC_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 COMPOSE="$SRC_DIR/docker-compose.yaml"
 
@@ -66,12 +72,12 @@ else
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "  SKIP: python3 unavailable — cannot make structural assertions"
-  exit 0
+  hive_test_skip "python3 unavailable — cannot make structural assertions"
+  hive_test_report; exit $?
 fi
 if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-  echo "  SKIP: PyYAML unavailable — cannot make structural assertions"
-  exit 0
+  hive_test_skip "PyYAML unavailable — cannot make structural assertions"
+  hive_test_report; exit $?
 fi
 
 RESULTS="$(RENDER="$RENDER" COMPOSE="$COMPOSE" python3 <<'PY'

--- a/src/deploy/test_watchtower_socket_contract.sh
+++ b/src/deploy/test_watchtower_socket_contract.sh
@@ -72,8 +72,8 @@ if ! command -v python3 >/dev/null 2>&1; then
   hive_test_report; exit $?
 fi
 if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-  hive_test_skip "PyYAML unavailable — cannot make structural assertions"
-  hive_test_report; exit $?
+  echo "  SKIP: PyYAML unavailable — cannot make structural assertions"
+  exit 0
 fi
 
 RESULTS="$(RENDER="$RENDER" COMPOSE="$COMPOSE" python3 <<'PY'

--- a/src/deploy/test_watchtower_socket_contract.sh
+++ b/src/deploy/test_watchtower_socket_contract.sh
@@ -25,6 +25,12 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
+# Shared skip discipline (#5388): hive_test_skip is permissive by default and
+# FATAL under HIVE_TEST_REQUIRE_BEHAVIOURAL=1, so a lane whose runner GUARANTEES
+# the precondition below turns a silent skip into a red build.
+# shellcheck source=src/deploy/test_lib.sh
+. "$(cd "$(dirname "$0")" && pwd)/test_lib.sh"
+
 V2_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 COMPOSE="$V2_DIR/docker-compose.yaml"
 DOC="$V2_DIR/docs/auto-update-profile.md"
@@ -62,12 +68,12 @@ fi
 # python3 with PyYAML does the structural assertions; a raw grep would pass on a
 # commented-out line and fail on a reordered key.
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "  SKIP: python3 unavailable — cannot make structural assertions"
-  exit 0
+  hive_test_skip "python3 unavailable — cannot make structural assertions"
+  hive_test_report; exit $?
 fi
 if ! python3 -c 'import yaml' >/dev/null 2>&1; then
-  echo "  SKIP: PyYAML unavailable — cannot make structural assertions"
-  exit 0
+  hive_test_skip "PyYAML unavailable — cannot make structural assertions"
+  hive_test_report; exit $?
 fi
 
 RESULTS="$(RENDER="$RENDER" COMPOSE="$COMPOSE" python3 <<'PY'


### PR DESCRIPTION
Fixes #5388

Item 3 of #5388 — the one the issue calls highest leverage, because it converts a whole class from silent to loud. Items 1 and 2 were closed by #5398 and #5467.

A test block that skips on a runner that genuinely cannot run it is **correct**. The same block skipping on a runner that **can** run it means the test is broken — and it reports green either way. #5383 solved this for exactly one case with `HIVE_TEST_REQUIRE_BEHAVIOURAL=1` and it was never generalised.

## Re-verified adoption before this PR

Scanner's counts were close but not exact; measured at `c54e9ca`:

| | scanner said | actual |
|---|---|---|
| `src/deploy/test_*.sh` suites | ~40 | **27** |
| honouring the flag | 2 | **2** — confirmed (`test_entrypoint_runtime_config.sh`, `test_entrypoint_data_ownership.sh`) |
| workflows setting it | 1 | **1** — confirmed (`podman-arm64-lane.yml`) |
| non-`testing.Short()` `t.Skip` in `src/pkg` | 251 | **256** |
| of those in `tmux_coverage_test.go` | 24 | **24** — confirmed |

Deploy suites containing a `SKIP`: **16 of 27**.

## 1. The shared lib

`src/deploy/test_lib.sh` — `hive_test_skip` prints `SKIP` and continues by default; under `HIVE_TEST_REQUIRE_BEHAVIOURAL=1` it prints `FAIL` and increments `FAIL`. `hive_test_report` prints the tally and **returns non-zero when `FAIL > 0`, so the suite's exit status is the assertion**.

Both #5383 suites migrated with **no behaviour change** — identical output and identical exit status in both modes, before and after:

```
flag=0  test_entrypoint_runtime_config   11 passed, 0 failed   exit 0
flag=0  test_entrypoint_data_ownership   11 passed, 0 failed   exit 0
flag=1  test_entrypoint_runtime_config   11 passed, 1 failed   exit 1
flag=1  test_entrypoint_data_ownership   11 passed, 1 failed   exit 1
```

Then 8 more suites migrated. Adoption goes **2 → 12** suites and **1 → 2** workflows.

## 2. Which lanes were flipped, and why each precondition is guaranteed

The judgement call. The flag is set **per step**, never job-wide, and only where the runner guarantees the precondition. Each of these skips is currently unreachable on that lane — which is exactly why it going silent would be invisible.

| Step (`v2-ci.yml`, `ubuntu-latest`) | Skip made fatal | Why guaranteed |
|---|---|---|
| Entrypoint dangling key_file (#4368) | python3 / PyYAML absent | `actions/runner-images` ships python3 **with PyYAML preinstalled** on ubuntu-latest |
| Docker-socket containment (#3865) | python3 / PyYAML absent | same |
| Standalone service contract (#4204) | python3 / PyYAML absent | same |
| Docker/Podman contract parity (#4404) — `test_standalone_runtime_parity.sh` | python3 / PyYAML absent | same |
| Changelog reminder (#4440) | python3 / PyYAML absent | same |
| Documented Compose quick start (#4477) | "not a git checkout" | `actions/checkout` guarantees a real checkout. This skip silently retired the assertion that `src/.env` is gitignored — the path the quick start tells operators to put a PAT in |
| Contributor K8s workload | `just` absent, PyYAML absent | the **`Install just` step immediately above** guarantees the binary; a failed install previously turned the whole suite into an exit-0 no-op |
| Entrypoint system gitconfig (newly registered, §4) | `git` absent | `actions/checkout` cannot function without git |

**Deliberately left permissive** — the precondition is *not* guaranteed, so making a skip fatal would convert a correct skip into a false red:

- `test_ambient_cap_runtime.sh`, `test_manifest_caps_runtime.sh` — skip on **docker unavailable**. Real on some lanes; that is a genuinely unsuitable environment.
- `test_terminal_scrollback_status.sh`, `test_ttyd_url_arg.sh` — skip on **tmux absent** and on **tmux older than 3.2**. The version skip is a real capability difference, not a broken test.
- `test_contribute_move.sh` — skips per missing tool across a tool list.
- `test_quadlet_config_contract.sh` — "not a git checkout"; wired into lanes where that is not established the way `actions/checkout` establishes it.
- The two #5383 suites keep their existing root/`dev` skips permissive on bare runners and fatal only in the podman arm64 lane, exactly as #5383 set them. **Unchanged.**

No lane is made a required status check. No existing assertion is weakened — every change strictly adds a failure mode.

## 3. Demonstrated failing — including a real hole it found in my own guard

Per the bar this issue set: *demonstrated, not asserted.* Full output is in the first PR comment; the short version:

`src/deploy/test_skip_discipline.sh` is the guard on the discipline. It does **not** grep for adoption — a grep passes on a suite that sources the lib and never reaches the call, and the `find … -print -quit` shape that trapped #5435 exits 0 on no match, greening while asserting nothing. It **runs every registered suite** with the needed tool genuinely absent and requires `exit 0` without the flag and `exit 1` with it. The child's exit status is the assertion.

**Round 1 — the guard failed against the planted bug, in CI.** I restored the silent `echo SKIP; exit 0` in `test_watchtower_socket_contract.sh`'s **PyYAML** branch. `build-and-test` came back **green** and the guard printed `PASS: … the same skip is FATAL`. Cause: these suites gate twice (python3, then `import yaml`), and the guard denied `python3` outright, so every suite stopped at the **first** gate and the PyYAML branch was never reached — the guard asserting shape rather than property, which is the very defect #5388 names.

Fixing it surfaced a second finding worth recording: **three plausible denial mechanisms silently do not deny.** An executable stub that exits non-zero still *resolves*, so `command -v` succeeds and the suite sails past its own guard; a non-executable placeholder and a dangling symlink are both *skipped* by the PATH search, which then finds the real binary further along. All three verified directly rather than assumed. Only a PATH that genuinely lacks the tool works, so each case now runs against a per-case copy of a symlink farm with the denied names deleted.

**The `NO_PYYAML` axis** keeps python3 on PATH and working and masks only `import yaml`, so the second gate is reached. Both halves are asserted before a case counts — the interpreter must work **and** the import must fail — so a denial that stops taking fails loudly rather than quietly proving nothing.

**Round 2 — red, then green.** Run links are posted in the comments. The tip commit deliberately still carries the regression until that red run is recorded, so **this is not ready to merge yet.**

## 4. A suite that had never run in CI

`src/deploy/test_entrypoint_system_gitconfig.sh` (#5343, 10 assertions) is referenced by **no workflow, Justfile, or script**. It has never executed in CI since it was written — the same silent-non-execution failure, one level out. Registered here; it passes 10/0.

The existing `bin/test_bin_suites_wired.sh` (#4363) guard covers **only `bin/`**, which is why this slipped through. An equivalent guard for `src/deploy/` is the obvious follow-up and is noted below rather than bundled here.

## Scope — what this PR does NOT cover

- **The Go side is untouched.** No `SkipUnlessRequired`, no migration of the **256** `t.Skip` sites. A 256-site migration in one PR is unreviewable. Follow-up sketch: add `internal/testutil.SkipUnlessRequired(t, reason)` honouring the same env var, migrate `pkg/agent` first (24 sites in `tmux_coverage_test.go` alone), and take the self-disarming skips #5398 catalogued as P1 — `error_pages_backend_test.go:187`, `entrypoint_boot_test.go:370`, `backend_picker_parity_test.go:194`, `worksource/github_issues_test.go:79` — since #5467 already did `f16_owner_gate_test.go`.
- **The 11 deploy suites with no `SKIP`** need nothing.
- **The docker/tmux/version-gated skips** are left permissive on purpose, as above.
- **No `src/pkg/tui/` files touched** (#5416/#5418 are concurrent).
- **A wiring guard for `src/deploy/`** — worth its own issue, not bundled.

## Separately filed

#5491 — repo-root `docs/` is never link-checked; `docs-link-check.yml` covers only `src/docs/` and the wiki. Deferred by #5398 as "worth its own issue" and verified still untracked. Worth noting it can land **green**: `check-docs-links.py docs` reports *checked 13 files, all relative links and anchors resolve* today, contrary to #5398's expectation that it would be red on arrival.

## Notes

- `shellcheck -S error` clean on `test_lib.sh`, `test_skip_discipline.sh`, and all `src/deploy/test_*.sh`.
- `v2-ci.yml` parses (`yaml.safe_load`); `check-release-lines.sh` → `RESULT: PASS`.
- No action pins added or changed. No production code changed — the diff is test scripts plus workflow steps.
- No local run is offered as a merge gate; CI is the gate.
