### PR TITLE
🐛 fix: let an operator complete a CLI login from the dashboard

### DIFF
--- a/dashboard/openapi.json
+++ b/dashboard/openapi.json
@@ -2838,6 +2838,75 @@
         }
       }
     },
+    "/api/agents/{name}/login-code": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Submit an authorization code to the agent's terminal",
+        "description": "Owner only. Types an operator-supplied OAuth/device authorization code into the agent's tmux pane and submits it with a single Enter. The write-side twin of `GET /api/agents/{name}/terminal-urls`: that endpoint exists because the embedded ttyd terminal cannot deliver a copy (#5188), and this one because it cannot reliably accept a paste either, which leaves an operator unable to finish a sign-in hand-off from the dashboard at all. It grants no capability the writable ttyd terminal does not already give the same operator; it is strictly narrower, and takes the strictest gate rather than inheriting the read endpoint's any-authenticated-role rule. The code is validated as printable and whitespace-free before it is typed, so it cannot carry a newline and become a second command in the agent's shell, and it is never logged or echoed back.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Agent name"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "maxLength": 512,
+                    "description": "The authorization code from the sign-in page. Must be printable and contain no whitespace or control characters; a value carrying a newline is refused rather than sanitised, because typing it would submit at that point and run everything after it as a fresh line."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Code typed into the agent's pane",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "agent": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Code was empty, too long, or carried whitespace or control characters; nothing was typed"
+          },
+          "403": {
+            "description": "Owner access required"
+          },
+          "503": {
+            "description": "Agent manager unavailable"
+          }
+        }
+      }
+    },
     "/api/agents/{name}/terminal-urls": {
       "get": {
         "tags": [

--- a/src/pkg/agent/login_code.go
+++ b/src/pkg/agent/login_code.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// maxLoginCodeLen bounds an operator-supplied authorization code. Real ones are
+// well under this (a Google OAuth code is ~75 characters, a GitHub device code
+// 8); the cap exists so this can never become a channel for pasting a script.
+const maxLoginCodeLen = 512
+
+// ErrLoginCodeUnprintable is returned for a code carrying anything that is not
+// a printable, non-space character.
+var ErrLoginCodeUnprintable = errors.New("authorization code contains control characters or whitespace")
+
+// validateLoginCode checks an operator-supplied code before it is typed into an
+// agent's pane.
+//
+// SECURITY: this is the whole reason SubmitLoginCode is a narrow endpoint
+// rather than a general "send text to a pane" one. The pane is an interactive
+// shell hosting a CLI; a value containing a newline or carriage return would be
+// SUBMITTED at that point and everything after it typed as a fresh line, which
+// turns "paste my login code" into "run this". Rejecting every non-printable
+// and every space leaves a code — which is what an OAuth or device code is —
+// and nothing that can carry a second command.
+//
+// It rejects rather than sanitises deliberately: silently stripping a character
+// would submit a code the operator did not supply, and a login that fails for
+// an unexplained reason is worse than one that refuses with a reason.
+func validateLoginCode(code string) error {
+	if code == "" {
+		return errors.New("authorization code is empty")
+	}
+	if len(code) > maxLoginCodeLen {
+		return fmt.Errorf("authorization code too long (%d bytes, max %d)", len(code), maxLoginCodeLen)
+	}
+	for _, r := range code {
+		if !unicode.IsPrint(r) || unicode.IsSpace(r) {
+			return ErrLoginCodeUnprintable
+		}
+	}
+	return nil
+}
+
+// SubmitLoginCode types an operator-supplied authorization code into the
+// agent's pane and submits it with a single Enter.
+//
+// WHY THIS EXISTS. The dashboard terminal is ttyd/xterm.js over tmux, and it is
+// as hostile to pasting IN as it is to copying OUT — the defect
+// handleAgentTerminalURLs already works around in the other direction (#5188).
+// An operator completing an OAuth hand-off has to paste a code back into the
+// pane, and the browser terminal mangles it. Without this the only routes left
+// are a host shell and `tmux send-keys`, which is not an answer for an operator
+// whose interface is a web dashboard.
+//
+// It grants no new capability: the dashboard already publishes a WRITABLE ttyd
+// terminal for these panes (`ttyd -W`), so anyone who can reach this can
+// already type anything into the agent. This is strictly narrower — one
+// validated, printable, whitespace-free token followed by exactly one Enter.
+//
+// ONE Enter, not tmuxSendEntersForAgent's three. That helper repeats
+// deliberately, as insurance that a launch line actually ran; here the pane is
+// known to be sitting at a prompt, and extra Enters stop being insurance and
+// become answers to whatever the CLI asks next — the codex "1. Update now"
+// failure documented on that helper.
+//
+// The code is never logged, and never returned in an error.
+func (m *Manager) SubmitLoginCode(name, code string) error {
+	if err := validateLoginCode(strings.TrimSpace(code)); err != nil {
+		return err
+	}
+	code = strings.TrimSpace(code)
+
+	m.mu.RLock()
+	agent := m.agents[name]
+	m.mu.RUnlock()
+	if agent == nil {
+		return fmt.Errorf("agent %s not found", name)
+	}
+	if !m.tmuxSessionExistsForAgent(agent) {
+		return fmt.Errorf("agent %s has no terminal session to submit a code to", name)
+	}
+
+	m.tmuxSendLiteralForAgent(agent, code)
+	// One Enter, sent directly rather than through tmuxSendEntersForAgent.
+	_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+	return nil
+}

--- a/src/pkg/agent/login_code_test.go
+++ b/src/pkg/agent/login_code_test.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestValidateLoginCodeRejectsCommandInjection is the security property of the
+// whole endpoint. The pane is an interactive shell hosting a CLI: a code
+// carrying a newline is SUBMITTED at that point and everything after it is
+// typed as a fresh line, turning "paste my login code" into "run this".
+func TestValidateLoginCodeRejectsCommandInjection(t *testing.T) {
+	for _, tc := range []struct{ name, code string }{
+		{"newline", "4/0Abc\nrm -rf /"},
+		{"carriage return", "4/0Abc\rrm -rf /"},
+		{"space then command", "4/0Abc; whoami"},
+		{"tab", "4/0Abc\twhoami"},
+		{"escape sequence", "4/0Abc\x1b[A"},
+		{"nul", "4/0Abc\x00"},
+		{"empty", ""},
+		{"over length", strings.Repeat("a", maxLoginCodeLen+1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateLoginCode(tc.code); err == nil {
+				t.Fatalf("accepted %q — this value can carry a second command into the agent's shell", tc.code)
+			}
+		})
+	}
+}
+
+// Real codes must still go through: a Google OAuth code and a GitHub device
+// code are both printable and whitespace-free.
+func TestValidateLoginCodeAcceptsRealCodes(t *testing.T) {
+	for _, code := range []string{
+		"4/0AVMBsJhV-9wKq2QpX8n_example-code",
+		"ABCD-1234",
+		"cuog9M96pk-QlnAiRsq_jA",
+	} {
+		if err := validateLoginCode(code); err != nil {
+			t.Fatalf("rejected a legitimate authorization code %q: %v", code, err)
+		}
+	}
+}
+
+// SubmitLoginCode must type the code and submit it with EXACTLY one Enter —
+// extra Enters answer whatever the CLI asks next (the codex "1. Update now"
+// failure documented on tmuxSendEntersForAgent).
+func TestSubmitLoginCodeTypesCodeAndSubmitsOnce(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"scanner": {Backend: "agy"},
+	}, discardLogger(), ProjectContext{ACMMLevel: 5})
+
+	origExists := tmuxSessionExists
+	tmuxSessionExists = func(_ *Manager, _ *AgentProcess) bool { return true }
+	t.Cleanup(func() { tmuxSessionExists = origExists })
+
+	var typed []string
+	m.sendLiteralForAgent = func(_ *AgentProcess, text string) { typed = append(typed, text) }
+
+	if err := m.SubmitLoginCode("scanner", "  4/0AVMBsJh-code  "); err != nil {
+		t.Fatalf("SubmitLoginCode: %v", err)
+	}
+	if len(typed) != 1 || typed[0] != "4/0AVMBsJh-code" {
+		t.Fatalf("typed = %q, want exactly the trimmed code once", typed)
+	}
+}
+
+// A refused code must never be typed at all — no partial submission.
+func TestSubmitLoginCodeRefusesWithoutTyping(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"scanner": {Backend: "agy"},
+	}, discardLogger(), ProjectContext{ACMMLevel: 5})
+
+	var typed []string
+	m.sendLiteralForAgent = func(_ *AgentProcess, text string) { typed = append(typed, text) }
+
+	if err := m.SubmitLoginCode("scanner", "code\nrm -rf /"); err == nil {
+		t.Fatal("accepted a newline-bearing code")
+	}
+	if len(typed) != 0 {
+		t.Fatalf("typed %q despite refusing the code", typed)
+	}
+}
+
+// TestAgyLoginPromptIsDetected: an agy agent parked at its OAuth hand-off
+// reported state=running / needsLogin=false and raised no alert, because agy
+// never prints the word "login" and no pattern matched its chrome.
+func TestAgyLoginPromptIsDetected(t *testing.T) {
+	pane := []string{
+		" Your browser should open automatically. If not:",
+		" https://accounts.google.com/o/oauth2/auth?access_type=offline&client_id=x",
+		" If you aren't automatically redirected, paste the authorization code below:",
+		" authorization code...",
+	}
+	if !paneShowsLoginPrompt(pane) {
+		t.Fatal("agy's OAuth hand-off is not recognised as a login prompt — the agent reports healthy while doing no work")
+	}
+}
+
+// The fragment "authorization code" alone must NOT trip the detector: an agent
+// reading or writing about OAuth prints it in ordinary output (the #3959
+// lesson that cost two earlier false-positive incidents).
+func TestAgyPatternsDoNotMatchOrdinaryProse(t *testing.T) {
+	for _, line := range []string{
+		"  the handler exchanges the authorization code for a token",
+		"  // authorization code grant, see RFC 6749",
+		"  browser automation is out of scope for this task",
+	} {
+		if paneShowsLoginPrompt([]string{line}) {
+			t.Fatalf("ordinary agent output read as a login prompt: %q", line)
+		}
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -6392,6 +6392,18 @@ var loginPromptPatterns = []string{
 	// GitHub device-flow screen (Copilot CLI)
 	"Enter one-time code",
 	"github.com/login/device",
+	// Google / antigravity (`agy`). Verified verbatim on a live agy pane
+	// (2026-09-01). This CLI never prints the word "login" — it hands off to a
+	// browser and then asks for a pasted code — so neither
+	// lineHasLoginDirective nor any pattern above could see it, and an agy
+	// agent parked at its OAuth prompt reported state=running, needsLogin=
+	// false, and raised no alert while doing no work at all.
+	//
+	// Both are full imperative sentences from the CLI's own chrome rather than
+	// fragments like "authorization code", which an agent READING about OAuth
+	// would print in ordinary output — the #3959 lesson.
+	"Your browser should open automatically",
+	"paste the authorization code below",
 }
 
 // fatalNetworkErrorPatterns are substrings that indicate a transient TLS or

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -97,6 +97,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/breaker/release", s.handleBreakerRelease)
 	s.mux.HandleFunc("POST /api/pin/{agent}/{dimension}", s.handlePin)
 	s.mux.HandleFunc("POST /api/unpin/{agent}/{dimension}", s.handleUnpin)
+	// Write-side twin of the terminal-urls copy control: the dashboard terminal
+	// can neither hand an operator a wrapped login URL nor accept the code back.
+	s.mux.HandleFunc("POST /api/agents/{name}/login-code", s.handleAgentLoginCode)
 	s.mux.HandleFunc("POST /api/restart/{agent}", s.handleRestart)
 	s.mux.HandleFunc("POST /api/reset-restarts/{agent}", s.handleResetRestarts)
 

--- a/src/pkg/dashboard/login_code.go
+++ b/src/pkg/dashboard/login_code.go
@@ -1,0 +1,61 @@
+package dashboard
+
+import (
+	"net/http"
+)
+
+// handleAgentLoginCode types an operator-supplied authorization code into an
+// agent's pane, completing an OAuth hand-off the dashboard terminal cannot.
+//
+// It is the write-side twin of handleAgentTerminalURLs. That endpoint exists
+// because the terminal cannot deliver a COPY (#5188); this one exists because
+// it cannot reliably accept a PASTE either. An operator who has opened the
+// sign-in URL is then asked to paste a code back into a ttyd/xterm.js pane over
+// tmux, where it arrives mangled — leaving a host shell and `tmux send-keys` as
+// the only route, which is no answer for an operator whose interface is a web
+// dashboard.
+//
+// OWNER-ONLY, unlike its read-side twin. handleAgentTerminalURLs is a GET that
+// any authenticated role may call because it exposes strictly less than the
+// terminal proxy already does. This one WRITES to an interactive pane, so it
+// takes the strictest gate the dashboard has rather than inheriting the read
+// endpoint's reasoning. It grants no capability the writable ttyd terminal does
+// not already give the same operator; the point of the gate is that a narrower
+// door should not be easier to open than the wide one beside it.
+//
+// The code is validated in agent.SubmitLoginCode (printable, whitespace-free,
+// length-bounded) so it cannot carry a newline and become a second command. It
+// is never logged, and never echoed back in a response — the audit entry
+// records that a code was submitted for an agent, not what it was.
+func (s *Server) handleAgentLoginCode(w http.ResponseWriter, r *http.Request) {
+	if !requireOwnerRole(w, r) {
+		return
+	}
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		jsonError(w, "agent manager unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	name := s.resolveAgentParam(r.PathValue("name"))
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.deps.AgentMgr.SubmitLoginCode(name, body.Code); err != nil {
+		// SubmitLoginCode's errors describe the SHAPE of the problem and never
+		// quote the value, so they are safe to return to the operator who typed
+		// it — and they are the only way that operator learns why a paste was
+		// refused.
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if s.deps.Logger != nil {
+		s.deps.Logger.Info("audit: login code submitted to agent", "agent", name, "trigger", "dashboard-api")
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "agent": name})
+}

--- a/src/pkg/dashboard/owner_only_handlers_deny_test.go
+++ b/src/pkg/dashboard/owner_only_handlers_deny_test.go
@@ -52,6 +52,7 @@ func TestV4OwnerOnlyHandlerGapsRejectUnverifiedOwners(t *testing.T) {
 		{"agent config stats", http.MethodPut, "/api/config/agent/scanner/stats", srv.handleAgentConfigStats},
 		{"agent config tools", http.MethodPut, "/api/config/agent/scanner/tools", srv.handleAgentConfigTools},
 		{"agent delete", http.MethodDelete, "/api/agents/scanner", srv.handleAgentDelete},
+		{"agent login code", http.MethodPost, "/api/agents/scanner/login-code", srv.handleAgentLoginCode},
 		{"agent prompt save", http.MethodPut, "/api/config/agent/scanner/prompt", srv.handleAgentPromptSave},
 		{"backup download", http.MethodPost, "/api/backup", srv.handleBackupDownload},
 		{"backup status", http.MethodGet, "/api/backup/status", srv.handleBackupStatus},

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -6175,7 +6175,8 @@
        hover a tooltip to find out what it is for. */
     function terminalCopyUrlButtonHtml(agentName, needsLogin) {
       if (!agentName || !needsLogin) return '';
-      return `<button type="button" class="terminal-copy-url-btn" data-action="copyTerminalUrl" data-agent="${esc(agentName)}" title="Show this agent\u2019s sign-in URL, captured whole from its terminal — wrapped lines are rejoined so the OAuth link is not broken by the wrap">🔑 Copy login URL</button>`;
+      return `<button type="button" class="terminal-copy-url-btn" data-action="copyTerminalUrl" data-agent="${esc(agentName)}" title="Show this agent\u2019s sign-in URL, captured whole from its terminal — wrapped lines are rejoined so the OAuth link is not broken by the wrap">🔑 Copy login URL</button>`
+        + `<button type="button" class="terminal-copy-url-btn" data-action="submitLoginCode" data-agent="${esc(agentName)}" title="Paste the authorization code the sign-in page gave you. It is typed into the agent\u2019s terminal by the server, so the browser terminal cannot mangle it.">↩ Submit login code</button>`;
     }
 
     /* Writes text to the clipboard, reporting honestly when it cannot.
@@ -6205,6 +6206,39 @@
       } catch { ok = false; }
       ta.remove();
       return ok;
+    }
+
+    /* The write-side twin of copyTerminalUrl.
+
+       Copying OUT of the dashboard terminal is broken (#5188) and this is the
+       same defect in the other direction: an operator who has opened the
+       sign-in URL must paste a code BACK, and ttyd/xterm.js over tmux mangles
+       it. Without this the only route left is a host shell and `tmux
+       send-keys`, which is not an answer for an operator whose interface is a
+       web dashboard.
+
+       The code goes to the server, which types it into the pane — the browser
+       terminal is never involved. It is refused rather than sanitised if it
+       carries whitespace or control characters, so a value that could submit a
+       second command into the agent's shell cannot be typed at all; the reason
+       is surfaced verbatim rather than as a generic failure. */
+    async function submitLoginCode(agentName) {
+      if (!agentName) return;
+      const code = prompt(`Paste the authorization code for "${agentName}".\n\nIt is sent to the server and typed into the agent's terminal, so the browser terminal cannot corrupt it.`);
+      if (code === null) return;
+      if (!code.trim()) { showToast('No code entered', 'error'); return; }
+      try {
+        const r = await apiFetch(`/api/agents/${encodeURIComponent(agentName)}/login-code`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: code.trim() }),
+        });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) { showToast(d.error || `Could not submit the code (HTTP ${r.status})`, 'error'); return; }
+        showToast(`Code submitted to ${agentName}`, 'success');
+      } catch (err) {
+        showToast(`Could not submit the code: ${err && err.message ? err.message : err}`, 'error');
+      }
     }
 
     async function copyTerminalUrl(agentName) {
@@ -14332,6 +14366,7 @@ function burnAreaChart() {
         case 'kickEmpty': { const inp = document.getElementById('kick-prompt-' + agent); if (inp) inp.value = ''; kick(agent); } break;
         case 'openTerminal': e.preventDefault(); openTerminal(agent, el.href); break;
         case 'copyTerminalUrl': e.stopPropagation(); copyTerminalUrl(agent); break;
+        case 'submitLoginCode': e.stopPropagation(); submitLoginCode(agent); break;
         case 'showTerminalKeyboardHint': e.stopPropagation(); showTerminalKeyboardHint(); break;
         case 'togglePin': togglePin(agent, el.dataset.pinType, el.dataset.unpin === 'true'); break;
         case 'resetRestarts': resetRestarts(agent); break;

--- a/src/pkg/dashboard/terminal_urls.go
+++ b/src/pkg/dashboard/terminal_urls.go
@@ -37,6 +37,89 @@ const maxTerminalURLs = 20
 // swallow the words after it.
 var terminalURLPattern = regexp.MustCompile(`https?://[^\s"'` + "`" + `<>]+`)
 
+// urlContinuationLine matches a pane line that is nothing but RFC 3986 URL
+// characters — no whitespace, no prose, no scheme of its own.
+//
+// It is the signature of a CLI that hard-wrapped a long URL itself.
+//
+// It does NOT exclude a redaction marker on its own: `*` is an RFC 3986
+// sub-delimiter and is legitimately in this class, so "***REDACTED***" matches
+// it. The redaction guard is therefore an explicit test in the join loop, not
+// an accident of the character class — an earlier revision of this code relied
+// on the class and bridged a redacted line, which is what
+// TestRejoinNeverBridgesRedaction pins.
+var urlContinuationLine = regexp.MustCompile(`^[A-Za-z0-9%._~:/?#\[\]@!$&'()*+,;=-]+$`)
+
+const (
+	// maxURLContinuationLines bounds how far a single URL may be reassembled.
+	// A 700-character OAuth URL at an 80-column pane is ~9 lines; 12 leaves
+	// headroom without letting a runaway match swallow a screen.
+	maxURLContinuationLines = 12
+	maxRejoinedURLLen       = 4096
+)
+
+// rejoinHardWrappedURLs puts a URL back together that the CLI — not tmux —
+// broke across lines.
+//
+// THE DEFECT THIS FIXES. handleAgentTerminalURLs was built on `capture-pane
+// -J`, whose join only covers lines TMUX wrapped: tmux flags those, and -J
+// honours the flag. A CLI that wraps a URL to the terminal width *itself*
+// emits real newlines, tmux has nothing to flag, and -J is a no-op. The
+// endpoint then hands the operator the first line of the URL and calls it a
+// login link. Measured live against antigravity (`agy`) on a six-agent hive
+// (2026-09-01): the URL is 704 characters, and the endpoint returned 209 of
+// them at a 211-column pane and 498 at a 500-column one — always exactly one
+// line, always "malformed URL" on paste, and worse at the narrow widths a
+// browser terminal actually runs at.
+//
+// The heuristic is deliberately narrow: a line is only extended when its LAST
+// URL match runs to the end of the line (a wrap point, not a URL that merely
+// sits mid-sentence) and the following line is nothing but URL characters. A
+// prose line has spaces; a fresh URL has "://"; a redacted line has "*". All
+// three stop the join, as does a redaction marker.
+//
+// Residual false positive: a line ending in a URL followed by a lone
+// space-free token — a bare path, a hash — would be appended. That yields a
+// URL that fails visibly at the identity provider, which is no worse than the
+// truncated URL it replaces, and it costs nothing on the flow this exists for.
+// Joining is preferred over offering both because a control labelled "Copy
+// login URL" that presents two candidates is a worse answer than one.
+func rejoinHardWrappedURLs(capture string) string {
+	lines := strings.Split(capture, "\n")
+	out := make([]string, 0, len(lines))
+
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimRight(lines[i], " \t")
+		matches := terminalURLPattern.FindAllStringIndex(line, -1)
+		if len(matches) == 0 || matches[len(matches)-1][1] != len(line) {
+			out = append(out, lines[i])
+			continue
+		}
+
+		joined := line
+		for n := 0; n < maxURLContinuationLines && i+1 < len(lines); n++ {
+			next := strings.TrimSpace(lines[i+1])
+			// Never bridge a redacted segment: redactTokens is entitled to cut
+			// a credential out of a line, and reassembling across that cut
+			// would hand back bytes it removed. Checked against the same
+			// vocabulary the caller's drop-filter uses.
+			if strings.Contains(next, "REDACTED") || strings.Contains(next, "***") {
+				break
+			}
+			if next == "" || strings.Contains(next, "://") || !urlContinuationLine.MatchString(next) {
+				break
+			}
+			if len(joined)+len(next) > maxRejoinedURLLen {
+				break
+			}
+			joined += next
+			i++
+		}
+		out = append(out, joined)
+	}
+	return strings.Join(out, "\n")
+}
+
 // terminalURLTrailing is punctuation a terminal line commonly puts AFTER a URL
 // — a sentence period, a closing paren, a trailing comma — which is not part
 // of the URL. Stripped from the right only.
@@ -99,8 +182,12 @@ func (s *Server) handleAgentTerminalURLs(w http.ResponseWriter, r *http.Request)
 // exists for, a Claude Code `/login` OAuth URL, is not device-flow shaped and
 // comes through whole.
 func prepareTerminalURLs(log string) []string {
+	// Redact FIRST (see above), then rejoin. The order is a security property,
+	// not a style choice: rejoining first would splice a URL back together
+	// across a boundary redactTokens is entitled to cut, handing the operator
+	// bytes the redactor had already decided must not leave the server.
 	redacted := redactTokens(log)
-	matches := terminalURLPattern.FindAllString(redacted, -1)
+	matches := terminalURLPattern.FindAllString(rejoinHardWrappedURLs(redacted), -1)
 
 	seen := make(map[string]bool, len(matches))
 	// Collected newest-first: the pane is chronological, so the URL an

--- a/src/pkg/dashboard/terminal_urls_wrap_test.go
+++ b/src/pkg/dashboard/terminal_urls_wrap_test.go
@@ -1,0 +1,80 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// agyLoginPane is a real antigravity (`agy`) login screen, captured verbatim
+// from a hive agent's pane on 2026-09-01 at a 211-column terminal — the width a
+// browser terminal actually runs at. The URL is 704 characters and agy wrapped
+// it ITSELF, so tmux never flagged the breaks and `capture-pane -J` leaves them
+// exactly as they are here.
+const agyLoginPane = ` Your browser should open automatically. If not:
+ https://accounts.google.com/o/oauth2/auth?access_type=offline&client_id=1071006060591-x.apps.googleusercontent.com&code_challenge=VCsnbBttr5DazUcZIn2Yo7kcvuNDV-ZfJJrlOvvXiK0&code
+ _challenge_method=S256&prompt=consent&redirect_uri=https%3A%2F%2Fantigravity.google%2Foauth-callback&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform+https%3A%2F%2Fwww.googleap
+ is.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fexperimentsandconfigs+https%3
+ A%2F%2Fwww.googleapis.com%2Fauth%2Faicode+openid&state=cuog9M96pk-QlnAiRsq_jA
+ If you aren't automatically redirected, paste the authorization code below:
+ authorization code...
+`
+
+// TestTerminalURLsRejoinsCLIHardWrappedURL is the defect in one assertion: the
+// endpoint promised a whole login URL and delivered the first line of one.
+func TestTerminalURLsRejoinsCLIHardWrappedURL(t *testing.T) {
+	urls := prepareTerminalURLs(agyLoginPane)
+	if len(urls) == 0 {
+		t.Fatal("no URL extracted from a pane that plainly contains one")
+	}
+
+	got := urls[0]
+	for _, want := range []string{"state=cuog9M96pk-QlnAiRsq_jA", "code_challenge_method=S256", "redirect_uri="} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rejoined URL is missing %q — it was truncated at a wrap point.\ngot (%d chars): %s", want, len(got), got)
+		}
+	}
+	if strings.ContainsAny(got, " \n") {
+		t.Fatalf("rejoined URL contains whitespace, which invalidates the OAuth exchange: %q", got)
+	}
+	if !isAuthURL(got) {
+		t.Fatalf("rejoined URL no longer classifies as a sign-in link: %s", got)
+	}
+}
+
+// A URL that was never wrapped must come through untouched.
+func TestRejoinLeavesUnwrappedURLsAlone(t *testing.T) {
+	pane := "see https://example.com/a?b=c for details\nnext line\n"
+	if got := rejoinHardWrappedURLs(pane); got != pane {
+		t.Fatalf("rewrote a pane with no wrapped URL:\n got: %q\nwant: %q", got, pane)
+	}
+}
+
+// Prose after a URL must never be swallowed: a line with spaces is not a
+// continuation, and joining it would corrupt the link.
+func TestRejoinStopsAtProse(t *testing.T) {
+	pane := "https://example.com/auth?a=1\nthis line has spaces\n"
+	got := rejoinHardWrappedURLs(pane)
+	if strings.Contains(got, "auth?a=1this") {
+		t.Fatalf("joined a prose line onto a URL: %q", got)
+	}
+}
+
+// The join must never bridge a redacted segment. redactTokens is entitled to
+// cut a credential out of the middle of a line; reassembling across that cut
+// would hand the operator bytes the redactor removed.
+func TestRejoinNeverBridgesRedaction(t *testing.T) {
+	pane := "https://example.com/authorize?token=\n***REDACTED***\nmore\n"
+	got := rejoinHardWrappedURLs(pane)
+	if strings.Contains(got, "token=***REDACTED***") {
+		t.Fatalf("join bridged a redacted line: %q", got)
+	}
+}
+
+// A second URL on the following line is a new URL, not a continuation.
+func TestRejoinStopsAtANewURL(t *testing.T) {
+	pane := "https://example.com/authorize?a=1\nhttps://example.com/other\n"
+	got := rejoinHardWrappedURLs(pane)
+	if strings.Contains(got, "a=1https://") {
+		t.Fatalf("joined two distinct URLs: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

An agent whose CLI signs in through a browser could not be logged in from the dashboard at all. Three separate defects, each blocking a different step of the same flow, so fixing any one alone leaves the operator stuck:

- **The fleet doesn't report it.** An antigravity (`agy`) agent parked at its OAuth prompt showed `state=running, needsLogin=false`, no 🔑 badge and no alert, while doing no work.
- **"Copy login URL" hands back a truncated URL.** The endpoint assumes `capture-pane -J` rejoins wrapped URLs — true only when *tmux* did the wrapping. A CLI that wraps to the terminal width itself emits real newlines, and `-J` is a no-op. Measured: 209 of 704 characters at a browser-width pane. Pasting it gives "malformed URL".
- **There is no way to paste the code back.** #5188 fixed copying *out* of the ttyd terminal server-side; pasting *in* is the same defect in the other direction, and it is the one that makes the flow unfinishable.

The only working route was a host shell and `tmux send-keys`, which is not an answer for an operator whose interface is a web dashboard.

**Blast radius:** two of the three fixes are backend-independent (any CLI that hard-wraps a login URL benefits). The new endpoint is owner-gated and additive. No existing behaviour changes for agents that were already detectable.

Fixes #5493

## The measurements

The URL agy prints is **704 characters**. What the endpoint returned, by pane width:

| pane width | bytes returned |
|---|---|
| 211 (a browser terminal) | 209 |
| 500 (hive's `new-session -x 500`) | 498 |
| 900 (wider than the whole URL) | 704 ✅ |

Always exactly one line, and worst at the widths a browser terminal actually runs at. `capture-pane` with and without `-J` return the identical 209 characters, which is what identifies the wrap as the CLI's rather than tmux's.

## Change

**1. `loginPromptPatterns` learns agy's chrome.** Two full imperative sentences — `Your browser should open automatically` and `paste the authorization code below` — rather than the fragment "authorization code", which an agent *reading* about OAuth prints in ordinary output. That is the #3959 lesson, and `TestAgyPatternsDoNotMatchOrdinaryProse` pins it against three realistic false-positive lines.

**2. `rejoinHardWrappedURLs`** reassembles a URL the CLI broke. A line is extended only when its **last** URL match runs to the end of the line (a wrap point, not a URL sitting mid-sentence) and the following line is nothing but RFC 3986 characters. Prose has spaces; a fresh URL has `://`; a redacted line carries `***`. All four stop the join.

Order is a security property, not style: redaction runs **first**, then the join. Rejoining first would splice a URL back together across a boundary `redactTokens` is entitled to cut, handing back bytes the redactor had already removed.

> An earlier revision of this patch claimed the character class excluded redaction markers "because `*` is absent from it". It is not — `*` is an RFC 3986 sub-delimiter — so `***REDACTED***` matched as a continuation and the join bridged it. `TestRejoinNeverBridgesRedaction` caught that before it left my machine; the guard is now an explicit test in the loop, and the comment says so.

Residual false positive, stated in the code: a line ending in a URL followed by a lone space-free token would be appended, yielding a URL that fails visibly at the identity provider — no worse than the truncated one it replaces. Joining is preferred over offering both because a control labelled "Copy login URL" that presents two candidates is a worse answer than one.

**3. `POST /api/agents/{name}/login-code`** types a validated code into the pane server-side, so the browser terminal is never involved, with a matching "↩ Submit login code" control beside the existing copy button (rendered on the same `needsLogin` condition, so it appears exactly when there is a login in flight).

## On the new endpoint's authority

It is **owner-gated**, unlike its read-side twin. `handleAgentTerminalURLs` is a GET that any authenticated role may call because it exposes strictly less than the terminal proxy already does. This one **writes to an interactive pane**, so it takes the strictest gate the dashboard has rather than inheriting that reasoning.

It grants no capability the operator does not already have: the dashboard publishes a *writable* ttyd terminal for these panes (`ttyd -W`), so anyone who can reach this can already type anything into the agent. This is strictly narrower — one validated token and exactly one Enter. The point of the gate is that a narrower door should not be easier to open than the wide one beside it.

The code is **refused, not sanitised**, if it carries whitespace or control characters. A newline would be *submitted* at that point and everything after it typed as a fresh line, turning "paste my login code" into "run this". Silently stripping it would submit a code the operator did not supply, and a login that fails for an unexplained reason is worse than one that refuses with a reason. It is never logged and never echoed back; the audit line records that a code was submitted, not what it was.

**One Enter, not `tmuxSendEntersForAgent`'s three.** That helper repeats deliberately, as insurance that a launch line ran. Here the pane is known to be at a prompt, where extra Enters stop being insurance and become answers to whatever the CLI asks next — the codex "1. Update now" failure documented on that helper.

## Also observed, deliberately not fixed here

agy writes stderr into the same pane and interleaves *mid-line*: `…&state=Rqw-vAfo2SOXfU8T3NY1Aw` runs straight into `before google.Init:`. One extraction during diagnosis came back with `www.googleapeis.com` — a character mangled inside the host name. That argues any pane scraper should validate its output rather than trust the capture, but it is a separate concern from the wrap and is recorded in #5493 rather than patched blind.

## Verification

| Property | Test |
|---|---|
| the 704-char agy URL comes back whole (real captured pane as fixture) | `TestTerminalURLsRejoinsCLIHardWrappedURL` |
| an unwrapped pane is returned byte-identical | `TestRejoinLeavesUnwrappedURLsAlone` |
| prose after a URL is never swallowed | `TestRejoinStopsAtProse` |
| a join never bridges a redacted segment | `TestRejoinNeverBridgesRedaction` |
| two adjacent URLs are not fused | `TestRejoinStopsAtANewURL` |
| newline / CR / tab / space / ESC / NUL / empty / over-length codes refused | `TestValidateLoginCodeRejectsCommandInjection` |
| real Google and GitHub device codes still accepted | `TestValidateLoginCodeAcceptsRealCodes` |
| exactly one Enter, code trimmed | `TestSubmitLoginCodeTypesCodeAndSubmitsOnce` |
| a refused code is never partially typed | `TestSubmitLoginCodeRefusesWithoutTyping` |
| agy's hand-off is detected | `TestAgyLoginPromptIsDetected` |
| ordinary OAuth prose is not | `TestAgyPatternsDoNotMatchOrdinaryProse` |
| the endpoint is owner-only | added to `TestOwnerOnlyHandlersDeny` |

## Testing

- [x] `cd src && go build ./...`
- [x] `cd src && go test ./pkg/dashboard/ ./pkg/agent/ ./cmd/hive/`
- [x] `go vet ./pkg/dashboard/... ./pkg/agent/...`, `git diff --check`
- [x] OpenAPI route parity (`TestOpenAPISpecCoversEveryRegisteredRoute`) — the new path is inserted surgically, 69 added lines, no reformatting of the other 34k
- [ ] Other / not run: `TestAgentLaunchScriptScrubsDirectExecStderr` and `…BackendStderr` failed once in a full-package run and passed in the two subsequent full runs and in isolation; they also pass on an unmodified base checkout. Treated as flaky, same class as `TestSendKick_RestartsCrashedCLIThenDelivers`.
- [ ] The UI control is not exercised by an automated browser test; the endpoint it calls is covered above.

## Contributor checklist

- [x] PR targets `v4`.
- [x] Title uses the repo emoji convention.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs updated — the OpenAPI spec documents the new endpoint and its refusal semantics.
- [ ] `CHANGELOG.md` — not added; happy to add an entry if you want this in the operator-facing log.
- [x] No secrets, credentials, or local runtime state are committed.
