### PR TITLE
🔧 ci: point the docs link checker at repo-root docs/ (#5491)

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -40,6 +40,7 @@ on:
     paths:
       - 'src/docs/**'
       - 'src/deploy/data/wiki/**'
+      - 'docs/**'
       - 'src/scripts/check-docs-links.py'
       - 'src/scripts/test-check-docs-links.sh'
       - '.github/workflows/docs-link-check.yml'
@@ -49,6 +50,7 @@ on:
     paths:
       - 'src/docs/**'
       - 'src/deploy/data/wiki/**'
+      - 'docs/**'
       - 'src/scripts/check-docs-links.py'
       - 'src/scripts/test-check-docs-links.sh'
       - '.github/workflows/docs-link-check.yml'
@@ -68,6 +70,20 @@ jobs:
 
       - name: Check src/docs/ relative links and anchors
         run: python3 src/scripts/check-docs-links.py src/docs
+
+      # Repo-root docs/ was covered by nothing until #5491: it was absent from
+      # both paths: filters and had no step, so a PR breaking a relative link
+      # or heading anchor in any of its files ran no link check at all, and no
+      # later PR caught it either. Same shape as #5309 (the wiki vault) and the
+      # exemptions swept in #5388 — the guard was correct and simply never
+      # aimed at this surface.
+      #
+      # Plain mode, NOT --vault-root: root docs/ is served from the repository,
+      # so its many parent-relative links out to src/, bin/, .github/ and the
+      # root README resolve normally for a reader. The vault's flat-layout
+      # containment rule would reject exactly the links that are correct here.
+      - name: Check repo-root docs/ relative links and anchors
+        run: python3 src/scripts/check-docs-links.py docs
 
       # The wiki vault is checked in --vault-root mode, which models the
       # DEPLOYED layout rather than this checkout. See the header comment and


### PR DESCRIPTION
Fixes #5491

## The verified gap

Confirmed against `origin/v4` before changing anything. `.github/workflows/docs-link-check.yml` ran the checker over exactly two trees — `src/docs/` and `src/deploy/data/wiki/` (`--vault-root`) — and both its `push` and `pull_request` `paths:` filters listed only `src/docs/**`, `src/deploy/data/wiki/**`, the two script paths, and the workflow itself.

Repo-root `docs/` was in **neither the filter nor any step**. Its 13 markdown files — `architecture.md`, `troubleshooting.md`, `federation-design.md`, `backend-setup.md`, `HUB_DISASTER_RECOVERY.md`, `advisory-staleness.md`, `outreach-antispam.md`, `LEGACY-v1-architecture.md`, `development.md`, `getting-started-contributing.md`, `inference-backends.md`, `macos.md`, `migration-v1-v2.md` — were covered by nothing. The issue's description is accurate; nothing contradicted it.

Same shape as #5309 (wiki vault checked by nothing) and the exemptions swept in #5388: the guard exists, is correct, and is simply never aimed at the surface.

## The change

1. `docs/**` added to both `paths:` filters.
2. A step running `python3 src/scripts/check-docs-links.py docs`.

Plain mode, **not** `--vault-root`. Root `docs/` is served from the repository, so its many parent-relative links out to `src/`, `bin/`, `.github/` and the root `README.md` resolve normally for a reader; the vault's flat-layout containment rule would reject exactly the links that are correct here.

No change to `check-docs-links.py`, no documentation content edits, no change to the v2 exclusion in `release-lines.yml`.

## Demonstrated failing — the new step is not vacuous

A link checker aimed at a path matching no files exits 0 and reports success, indistinguishable from "all links valid". So this was demonstrated in both directions rather than inferred from a green run.

**File count.** The checker reports what it processed, and it is non-zero:

```
$ python3 src/scripts/check-docs-links.py docs
checked 13 files under docs
all relative links and anchors resolve
```

13 files, matching `find docs -name '*.md' | wc -l` = 13. The tree is genuinely being scanned.

**FAILING state 1 — broken relative link.** Appended `[deliberately broken](./no-such-file-5491.md)` to `docs/troubleshooting.md`:

```
checked 13 files under docs

1 broken link(s):

  docs/troubleshooting.md: broken link './no-such-file-5491.md' -> docs/no-such-file-5491.md does not exist
EXIT=1
```

**FAILING state 2 — broken heading anchor**, the #5206 break shape, and a cross-tree one. Appended `[bad anchor](../src/docs/architecture.md#no-such-heading-5491)`:

```
checked 13 files under docs

1 broken link(s):

  docs/troubleshooting.md: link '../src/docs/architecture.md#no-such-heading-5491' -> src/docs/architecture.md has no heading matching '#no-such-heading-5491'
EXIT=1
```

**PASSING state — deliberate breakage removed:**

```
checked 13 files under docs
all relative links and anchors resolve
EXIT=0
```

Neither deliberate break is in this diff — the diff is 16 added lines in the workflow file and nothing else.

**This PR exercises its own change.** It edits `.github/workflows/docs-link-check.yml`, which is in the `paths:` filter, so the new step runs on this PR rather than being skipped.

All three steps pass locally: self-test OK; `src/docs` 127 files; wiki vault 2 files; `docs` 13 files.

## Broken links found: zero

Contrary to #5398's expectation that widening would be "red on arrival", root `docs/` is clean against the current tree. Nothing needed fixing and nothing was deleted to make CI green. This is the reason to take it now — every unchecked PR is a chance for that to stop being true.

## Explicitly NOT verified

- **Outbound targets outside every `paths:` filter remain unguarded against renames.** Links from `docs/` point at `bin/README.md`, `examples/*`, `Justfile`, `launchd/`, `src/policies/README.md`, `src/pkg/dashboard/contribute_ws.go`, `src/go.mod`, `CONTRIBUTING.md` and `README.md`. A PR that renames one of those and touches nothing in the filter will not trigger this job, so the resulting break in `docs/` still lands silently. The majority of outbound targets *are* under `src/docs/**`, which is filtered, so the common case is covered. Widening the filter to catch the rest would fire the docs job on nearly every PR in the repo; left alone deliberately, and flagged here rather than silently accepted.
- **Not verified on GitHub-hosted runners** beyond what CI reports on this PR — the failing states above were produced locally with the same `python3` invocation the workflow runs.
- **No claim about http(s)/mailto links**, which this checker does not validate by design.
- The wiki and `src/docs` steps were re-run but are unchanged by this PR.