### PR TITLE
✨ tui T30: wire the Tokens pane with estimated cost (#5419)

### DIFF
--- a/src/pkg/tui/app.go
+++ b/src/pkg/tui/app.go
@@ -347,6 +347,25 @@ type model struct {
 	// different facts: the header shows a dash for both, and only the latter
 	// should reach the pane as a frame.
 	governorLoaded bool
+
+	// tokenUsage and costSummary are the last successful /api/tokens and
+	// /api/cost reads, joined into one frame by tokensMsg (T30).
+	//
+	// TOKENS ARE PRIMARY, COST IS OPTIONAL, and the two flags below are what
+	// encode that. tokensLoaded gates delivery entirely: with no successful
+	// count read there is nothing to draw, so a token failure leaves the pane
+	// exactly as it was. costLoaded gates only the dollar columns, so a cost
+	// failure still delivers fresh counts — every row simply renders "—".
+	//
+	// costLoaded is CLEARED, not held, when a cost read fails, and that is the
+	// one place this differs from the governor cache above. A held governor
+	// mode is still true of the hive; a held dollar estimate would be attached
+	// to token counts that have since moved, and a cost-per-agent that no
+	// longer corresponds to the row it sits on is worse than an honest dash.
+	tokenUsage   client.TokenUsage
+	tokensLoaded bool
+	costSummary  client.CostSummary
+	costLoaded   bool
 }
 
 // newModel returns the root model in its initial state. Unexported because the
@@ -416,6 +435,25 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// rather than falling through to the broadcast below is the mechanism:
 		// the panes never see the error, so they never have to decide whether
 		// to clear their data, and the previous frame simply persists.
+		//
+		// The one exception is the cost read, and it is an exception in the
+		// same direction: a failed cost read INVALIDATES the estimate rather
+		// than preserving it, because the counts it was priced against are
+		// about to be replaced by this same poll's token read, and a dollar
+		// figure attached to a row whose counts have moved is worse than a
+		// dash. The re-delivery is what makes that hold REGARDLESS OF ARRIVAL
+		// ORDER: the two Cmds race, so a frame built by the token result that
+		// arrived first would still be carrying the previous poll's costs, and
+		// the pane would show a stale estimate until the next tick. Rebuilding
+		// here clears it in the same frame instead. It is skipped before the
+		// first successful token read, when there is no frame to rebuild.
+		if msg.source == costFetchSource {
+			hadCost := m.costLoaded
+			m.costLoaded = false
+			if hadCost && m.tokensLoaded {
+				return m.broadcastTokens()
+			}
+		}
 		return m, nil
 	case sseOpenMsg:
 		return m.handleSSEOpen(msg)
@@ -453,6 +491,28 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m.broadcastGovernor()
+	case tokenUsageMsg:
+		// Cache first, then deliver — the frame is built from the cache so it
+		// carries whatever cost is currently known, not just what this fetch
+		// knew (which is none). An all-zero usage document is stored as a real
+		// observation: tokensLoaded is what turns the pane's "waiting for data"
+		// into a loaded zero-usage table, and a hive that has burned nothing is
+		// entitled to that frame.
+		m.tokenUsage = msg.usage
+		m.tokensLoaded = true
+		return m.broadcastTokens()
+	case costSummaryMsg:
+		m.costSummary = msg.summary
+		m.costLoaded = true
+		if !m.tokensLoaded {
+			// Cost answered before any count read did. There is no frame to
+			// send: rows come from /api/tokens, so a TokensMsg now would be a
+			// loaded pane with no rows and a fleet total of zero — which the
+			// pane cannot tell from a hive that has genuinely spent nothing.
+			// The estimate is cached and the first token read delivers both.
+			return m, nil
+		}
+		return m.broadcastTokens()
 	case hiveIDMsg:
 		// Header-only, so no pane delivery. An empty id is stored as-is: the
 		// hive genuinely has no configured identity and the header says so.
@@ -629,6 +689,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // that can be built.
 func (m model) broadcastGovernor() (tea.Model, tea.Cmd) {
 	next, cmd := m.broadcast(m.governorMsg())
+	return next, cmd
+}
+
+// broadcastTokens delivers the joined token/cost frame (T30). Like
+// broadcastGovernor it exists so every delivery goes through the single
+// projection in tokensMsg rather than assembling a frame at each call site.
+func (m model) broadcastTokens() (tea.Model, tea.Cmd) {
+	next, cmd := m.broadcast(m.tokensMsg())
 	return next, cmd
 }
 

--- a/src/pkg/tui/poll.go
+++ b/src/pkg/tui/poll.go
@@ -94,12 +94,13 @@ func (m model) scheduleTick() tea.Cmd {
 
 // poll issues every fetch the client can currently make, as one batch.
 //
-// Four reads today: /api/agents (T4, #5067), plus the three T29 wired for the
+// Six reads today: /api/agents (T4, #5067), the three T29 wired for the
 // Governor pane and the header — /api/status for live governor state,
 // /api/config/governor for the evaluation cadence, and /api/hive-id for the
-// hive's identity. The tokens and events fetches (T8/T10) each add one line
-// here and one message type in pkg/tui/panes; the loop, the error policy and
-// the tick scheduling do not change when they land.
+// hive's identity — and the two T30 wires for the Tokens pane: /api/tokens for
+// the counts and /api/cost for the estimated spend joined onto them. The events
+// fetch (T10) adds one line here and one message type in pkg/tui/panes; the
+// loop, the error policy and the tick scheduling do not change when it lands.
 //
 // EACH FETCH FAILS ALONE. They are separate Cmds in one batch rather than one
 // Cmd making four calls, and that is the failure-isolation property T29 is
@@ -121,6 +122,8 @@ func (m model) poll() tea.Cmd {
 		m.fetchGovernor(),
 		m.fetchGovernorInterval(),
 		m.fetchHiveID(),
+		m.fetchTokens(),
+		m.fetchCosts(),
 	)
 }
 
@@ -230,4 +233,178 @@ func (m model) fetchHiveID() tea.Cmd {
 		}
 		return hiveIDMsg{id: id}
 	}
+}
+
+// tokenUsageMsg is a successful token-count read from GET /api/tokens.
+//
+// It is app-level rather than panes.TokensMsg for the reason governorStatusMsg
+// is: the pane's frame needs two endpoints, they fail independently, and
+// sending the pane message straight from this fetch would send it with whatever
+// cost this Cmd happened to know — none. The app caches this, joins it with the
+// last cost read, and emits one complete TokensMsg.
+//
+// An empty usage document is a legitimate answer and is kept as one. A hive
+// whose agents have burned no tokens reports zeroes, and the pane must render
+// that as a loaded zero-usage frame rather than sitting on "waiting for data"
+// forever; carrying success in the TYPE (a failure is a fetchErrMsg) is what
+// makes that distinction survive the trip.
+type tokenUsageMsg struct {
+	usage client.TokenUsage
+}
+
+// costSummaryMsg is a successful estimated-cost read from GET /api/cost.
+//
+// Cost is the OPTIONAL half of the Tokens frame. It never gates delivery: a
+// hive whose token endpoint answers and whose cost endpoint does not still gets
+// fresh counts, with every cost column rendered as an em dash. That asymmetry
+// is deliberate and is why this is a separate message from tokenUsageMsg rather
+// than a field on it.
+type costSummaryMsg struct {
+	summary client.CostSummary
+}
+
+// costFetchSource is the fetchErrMsg source naming the /api/cost read.
+//
+// It is a named constant because it is the ONE fetch whose failure the app acts
+// on rather than swallowing (it invalidates the cached estimate), so the
+// producer and that consumer must agree on the spelling. A literal in both
+// places would let a rename silently turn the invalidation off and leave the
+// pane showing a stale dollar figure with no test failing.
+const costFetchSource = "cost"
+
+// fetchTokens reads the fleet's token counts.
+//
+// This is the PRIMARY data for the pane. Its failure is the only failure that
+// holds the pane stale, which is what makes fetchCosts safe to lose.
+func (m model) fetchTokens() tea.Cmd {
+	return func() tea.Msg {
+		usage, err := m.api.Tokens(context.Background())
+		if err != nil {
+			return fetchErrMsg{source: "tokens", err: err}
+		}
+		return tokenUsageMsg{usage: usage}
+	}
+}
+
+// fetchCosts reads the dashboard's estimated spend.
+//
+// Separate from fetchTokens on purpose, and not merely for concurrency: cost is
+// a strictly richer read (it prices every model in the summary) and is the one
+// a restricted token or an older dashboard is likelier to refuse. Folding it
+// into the token fetch would make the counts only as available as the estimate,
+// which is precisely the "hold the whole pane stale behind an optional
+// estimate" failure this task forbids.
+func (m model) fetchCosts() tea.Cmd {
+	return func() tea.Msg {
+		summary, err := m.api.Costs(context.Background())
+		if err != nil {
+			return fetchErrMsg{source: costFetchSource, err: err}
+		}
+		return costSummaryMsg{summary: summary}
+	}
+}
+
+// tokensMsg projects the model's cached token and cost reads into the one frame
+// the Tokens pane consumes.
+//
+// THIS IS THE ONE PLACE A panes.TokensMsg IS BUILT, for the same reason
+// governorMsg is the one place a GovernorMsg is: every rule below has to hold
+// on every path, and a second construction site is a second place to get the
+// priced/unpriced distinction wrong.
+//
+// The projection rules, each of which is a fact about the wire and not a
+// preference:
+//
+//   - ROWS COME FROM ByAgentDetail, and their input/output counts stay the
+//     /api/tokens values. The cost payload carries its own per-agent input and
+//     output, but those are the estimator's view of the same buckets; showing
+//     them would make the counts change depending on whether an unrelated
+//     endpoint answered.
+//
+//   - COST ENRICHES A ROW, it never creates one. An agent priced by /api/cost
+//     but absent from ByAgentDetail has no counts to show, and a row of dashes
+//     with a dollar figure would invite the reading that it spent money without
+//     tokens.
+//
+//   - CostKnown IS THE ENTRY'S SOURCE, never its value. client.CostAgentEntry
+//     documents that an unpriced entry carries USD 0 on the wire as a
+//     placeholder; rendering that as $0.00 would report a free agent, which is
+//     the single most misleading thing this pane could say. Known() is the only
+//     thing consulted.
+//
+//   - FLEET COUNTS COME FROM TotalInput/TotalOutput, not from summing the rows
+//     above. AggregateSummary counts every scanned session including ones it
+//     could not attribute to a configured agent, so the total is legitimately
+//     larger than the visible rows. Re-summing would silently disagree with the
+//     web dashboard for the same hive.
+//
+//   - FLEET COST IS KNOWN ONLY WHEN EVERY MODEL IS PRICED. CostSummary.TotalUSD
+//     is a lower bound whenever UnpricedModels is non-empty, and presenting a
+//     lower bound as the fleet's spend is the same lie as $0.00 on an unpriced
+//     agent, one order of magnitude up.
+//
+// Map iteration order does not leak: the pane sorts what it is handed
+// (panes.sortRows), and this builds rows from a map without imposing any order
+// of its own, so the delivered frame is deterministic no matter which order Go
+// walked ByAgentDetail in.
+func (m model) tokensMsg() panes.TokensMsg {
+	costs := m.agentCosts()
+
+	rows := make([]panes.TokenRow, 0, len(m.tokenUsage.ByAgentDetail))
+	for name, bucket := range m.tokenUsage.ByAgentDetail {
+		if bucket == nil {
+			// A null bucket carries no counts. The dashboard does not emit one
+			// today, but the field is a pointer map and a row of zeroes
+			// attributed to a real agent is worse than no row.
+			continue
+		}
+		row := panes.TokenRow{
+			Agent: name,
+			TokenCounts: panes.TokenCounts{
+				Input:  bucket.Input,
+				Output: bucket.Output,
+			},
+		}
+		if entry, ok := costs[name]; ok && entry.Known() {
+			row.CostUSD = entry.USD
+			row.CostKnown = true
+		}
+		rows = append(rows, row)
+	}
+
+	total := panes.TokenCounts{
+		Input:  m.tokenUsage.TotalInput,
+		Output: m.tokenUsage.TotalOutput,
+	}
+	if m.costLoaded && m.costSummary.AllPriced() {
+		total.CostUSD = m.costSummary.TotalUSD
+		total.CostKnown = true
+	}
+
+	return panes.TokensMsg{Agents: rows, Total: total}
+}
+
+// agentCosts indexes the cost summary by agent name for the join.
+//
+// The join key is the agent name exactly as each endpoint spells it, and that
+// is a canonical key rather than a hopeful one: both payloads are derived from
+// the SAME AggregateSummary.ByAgentDetail map on the server — /api/tokens
+// returns its keys directly and /api/cost prices those same buckets
+// (pkg/tokens/pricing.go EstimateFromSummary, flattened by
+// pkg/dashboard/cost.go). There is no alias layer between them to normalize
+// away, so anything cleverer than an exact match would be inventing a
+// correspondence the server never made.
+//
+// It returns nil when no cost read has succeeded, which is what makes the
+// cost-failure case fall out of the projection rather than needing a branch:
+// every lookup misses and every row is unpriced.
+func (m model) agentCosts() map[string]client.CostAgentEntry {
+	if !m.costLoaded {
+		return nil
+	}
+	byAgent := make(map[string]client.CostAgentEntry, len(m.costSummary.ByAgent))
+	for _, entry := range m.costSummary.ByAgent {
+		byAgent[entry.Name] = entry
+	}
+	return byAgent
 }

--- a/src/pkg/tui/poll_test.go
+++ b/src/pkg/tui/poll_test.go
@@ -423,18 +423,29 @@ const governorEvalInterval = 300 * time.Second
 // not express the case that matters: /api/status fine, /api/config/governor
 // forbidden. Each path also counts its requests, so a test can prove a second
 // tick re-read rather than replaying a cache.
+//
+// T30 adds /api/tokens and /api/cost on the same terms, and the same reasoning
+// applies twice over: the Tokens pane's whole failure contract is that the two
+// halves are independently losable, and only a per-path switch can serve the
+// "counts fine, estimate forbidden" shape that contract is about.
 type dashboardServer struct {
 	*httptest.Server
 	failStatus atomic.Bool
 	failConfig atomic.Bool
 	failHiveID atomic.Bool
+	failTokens atomic.Bool
+	failCost   atomic.Bool
 	hiveID     atomic.Value // string body for /api/hive-id
+	tokens     atomic.Value // string body for /api/tokens
+	cost       atomic.Value // string body for /api/cost
 }
 
 func newDashboardServer(t *testing.T) *dashboardServer {
 	t.Helper()
 	s := &dashboardServer{}
 	s.hiveID.Store(hiveIDFixture)
+	s.tokens.Store(tokensFixture)
+	s.cost.Store(costFixture)
 	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fail := func() {
 			w.WriteHeader(http.StatusForbidden)
@@ -462,6 +473,20 @@ func newDashboardServer(t *testing.T) *dashboardServer {
 				return
 			}
 			body, _ := s.hiveID.Load().(string)
+			_, _ = w.Write([]byte(body))
+		case "/api/tokens":
+			if s.failTokens.Load() {
+				fail()
+				return
+			}
+			body, _ := s.tokens.Load().(string)
+			_, _ = w.Write([]byte(body))
+		case "/api/cost":
+			if s.failCost.Load() {
+				fail()
+				return
+			}
+			body, _ := s.cost.Load().(string)
 			_, _ = w.Write([]byte(body))
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -825,16 +850,16 @@ func TestPollFallbackKeepsRefreshingGovernorAfterADrop(t *testing.T) {
 	}
 }
 
-// TestPollIssuesAllFourReads pins that the batch actually contains every fetch
-// T29 added. A regression that dropped one would otherwise only show up as a
-// field that quietly never updates.
-func TestPollIssuesAllFourReads(t *testing.T) {
+// TestPollIssuesEveryRead pins that the batch actually contains every fetch the
+// app has wired. A regression that dropped one would otherwise only show up as
+// a field (or, since T30, a whole pane) that quietly never updates.
+func TestPollIssuesEveryRead(t *testing.T) {
 	server := newDashboardServer(t)
 	m := pollTestModel(t, server.URL)
 
 	msgs := drain(m.poll())
 
-	var agents, governor, interval, hiveID bool
+	var agents, governor, interval, hiveID, tokens, cost bool
 	for _, msg := range msgs {
 		switch msg.(type) {
 		case panes.AgentsMsg:
@@ -845,6 +870,10 @@ func TestPollIssuesAllFourReads(t *testing.T) {
 			interval = true
 		case hiveIDMsg:
 			hiveID = true
+		case tokenUsageMsg:
+			tokens = true
+		case costSummaryMsg:
+			cost = true
 		}
 	}
 	if !agents {
@@ -858,6 +887,12 @@ func TestPollIssuesAllFourReads(t *testing.T) {
 	}
 	if !hiveID {
 		t.Error("poll did not fetch the hive id")
+	}
+	if !tokens {
+		t.Error("poll did not fetch token usage; the Tokens pane would stay on its placeholder")
+	}
+	if !cost {
+		t.Error("poll did not fetch the cost estimate; every cost column would render a dash")
 	}
 }
 
@@ -923,6 +958,680 @@ func TestHeaderIsClippedNotWrappedAtTheMinimumWidth(t *testing.T) {
 	lines := strings.Split(frame, "\n")
 	if len(lines) != minHeight {
 		t.Errorf("frame is %d lines at height %d; a wrapped header cost a row", len(lines), minHeight)
+	}
+	for i, line := range lines {
+		if got := lipgloss.Width(line); got > minWidth {
+			t.Errorf("line %d is %d columns wide, want at most %d", i, got, minWidth)
+		}
+	}
+}
+
+// --- T30: Tokens pane wiring (#5419) ---------------------------------------
+
+// paneTokensIndex is the Tokens pane's slot in the model's pane array, fixed by
+// newModel's construction order and by the design doc's §3 grid.
+//
+// It is a test-local constant rather than something the app exports: the app
+// broadcasts to every pane and never addresses one, so an index is a fact these
+// tests need and production code deliberately does not.
+const paneTokensIndex = 2
+
+// tokensPlaceholder is the pre-data text every pane shows (panes.placeholder,
+// which is unexported). Asserting on the literal is what makes "the pane is
+// still waiting" a statement about what an OPERATOR sees rather than about an
+// internal flag.
+const tokensPlaceholder = "waiting for data"
+
+// tokensFixture is the /api/tokens body the T30 tests serve.
+//
+// IT IS DELIBERATELY NOT SELF-CONSISTENT. total_input/total_output exceed the
+// sum of by_agent_detail by exactly one unattributed session's worth
+// (1000 in / 100 out), because AggregateSummary counts every scanned session
+// including ones it could not attribute to a configured agent. That gap is the
+// whole point of the fixture: an implementation that re-sums the visible rows
+// instead of reading the server's totals produces 33000/3300 here and fails,
+// where a fixture whose numbers added up would let it pass.
+//
+// Three agents, so an ordering bug is visible, and by_agent_detail is a JSON
+// object — a Go map after decoding — so every test built on this fixture is
+// also exercising the map-iteration determinism requirement.
+const tokensFixture = `{
+  "total_tokens": 37400,
+  "total_input": 34000,
+  "total_output": 3400,
+  "by_agent": {"scanner": 22000, "quality": 8800, "reviewer": 2200},
+  "by_agent_detail": {
+    "scanner":  {"input": 20000, "output": 2000, "messages": 40, "sessions": 4},
+    "quality":  {"input":  8000, "output":  800, "messages": 16, "sessions": 2},
+    "reviewer": {"input":  2000, "output":  200, "messages":  4, "sessions": 1}
+  },
+  "session_count": 8
+}`
+
+// unattributedInput and unattributedOutput are the fleet-total surplus above.
+const (
+	fixtureTotalInput  = 34000
+	fixtureTotalOutput = 3400
+	// The sum of the three by_agent_detail rows, which is what a re-summing
+	// implementation would report instead.
+	fixtureAgentSumInput  = 30000
+	fixtureAgentSumOutput = 3000
+)
+
+// costFixture is the /api/cost body: every agent priced, no unpriced models.
+// This is the fully-known case, where both the per-agent and the fleet cost
+// are real figures.
+const costFixture = `{
+  "estimated": {
+    "total_usd": 12.5,
+    "unpriced_models": [],
+    "by_agent": [
+      {"name": "scanner",  "usd": 8.25, "source": "estimated", "input": 20000, "output": 2000},
+      {"name": "quality",  "usd": 3.00, "source": "estimated", "input":  8000, "output":  800},
+      {"name": "reviewer", "usd": 1.25, "source": "estimated", "input":  2000, "output":  200}
+    ]
+  }
+}`
+
+// mixedCostFixture prices one agent and leaves two unpriced, with a non-empty
+// unpriced_models list.
+//
+// The unpriced entries carry a NON-ZERO usd on the wire on purpose. The
+// dashboard emits a tier estimate for models it cannot price exactly
+// (pkg/tokens/pricing.go), so "unpriced" does not mean "zero" — an
+// implementation that decided knownness by testing usd != 0 would show these as
+// real spend, and one that tested usd == 0 would still show them. Only Source
+// separates them, which is what these rows force a reader to consult.
+const mixedCostFixture = `{
+  "estimated": {
+    "total_usd": 9.75,
+    "unpriced_models": ["glm-4.6", "qwen3-coder"],
+    "by_agent": [
+      {"name": "scanner",  "usd": 8.25, "source": "estimated", "input": 20000, "output": 2000},
+      {"name": "quality",  "usd": 1.10, "source": "unpriced",  "input":  8000, "output":  800},
+      {"name": "reviewer", "usd": 0.40, "source": "unpriced",  "input":  2000, "output":  200}
+    ]
+  }
+}`
+
+// emptyTokensFixture is a hive that has burned nothing: a successful read whose
+// every count is zero. It is NOT the same as a failed read, and the pane must
+// render it as a loaded zero-usage table.
+const emptyTokensFixture = `{
+  "total_tokens": 0, "total_input": 0, "total_output": 0,
+  "by_agent": {}, "by_agent_detail": {}, "session_count": 0
+}`
+
+// deliveredTokens is the frame the model would hand the panes, or nil when no
+// successful token read has happened yet.
+//
+// It reads model state for the same reason deliveredGovernor does: broadcast
+// delivers INTO the panes and returns only their commands, so the frame itself
+// never appears in any Cmd's output. tokensLoaded is the same distinction the
+// app makes — no count read yet is not the same fact as a hive that has spent
+// nothing.
+func deliveredTokens(m model) *panes.TokensMsg {
+	if !m.tokensLoaded {
+		return nil
+	}
+	msg := m.tokensMsg()
+	return &msg
+}
+
+// tokenRowsByAgent indexes a delivered frame by agent name so a test can assert
+// on one row without depending on the order rows were built in.
+func tokenRowsByAgent(msg panes.TokensMsg) map[string]panes.TokenRow {
+	out := make(map[string]panes.TokenRow, len(msg.Agents))
+	for _, row := range msg.Agents {
+		out[row.Agent] = row
+	}
+	return out
+}
+
+// TestStartupPollFillsTheTokensPane is the first acceptance criterion: a
+// startup poll alone replaces the pane's placeholder with real rows and totals.
+//
+// It asserts on the RENDERED PANE, not just the message, because the message
+// being correct while the pane never receives it is exactly the bug this task
+// exists to fix — the clients and the pane were both already tested in
+// isolation and the operator still saw "waiting for data" forever.
+func TestStartupPollFillsTheTokensPane(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+
+	before := m.panes[paneTokensIndex].View(60, 12)
+	if !strings.Contains(before, tokensPlaceholder) {
+		t.Fatalf("the Tokens pane did not start on its placeholder; this test would pass vacuously.\n%s", before)
+	}
+
+	settled := pollAndApply(t, m)
+
+	view := settled.panes[paneTokensIndex].View(60, 12)
+	if strings.Contains(view, tokensPlaceholder) {
+		t.Fatalf("the Tokens pane still shows %q after a successful poll:\n%s", tokensPlaceholder, view)
+	}
+	for _, agent := range []string{"scanner", "quality", "reviewer"} {
+		if !strings.Contains(view, agent) {
+			t.Errorf("rendered Tokens pane is missing agent %q:\n%s", agent, view)
+		}
+	}
+	if !strings.Contains(view, "total") {
+		t.Errorf("rendered Tokens pane is missing its totals row:\n%s", view)
+	}
+}
+
+// TestTokenRowsCarryTheTokenEndpointCounts pins that input/output come from
+// /api/tokens and not from the cost payload's own per-agent counts.
+func TestTokenRowsCarryTheTokenEndpointCounts(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	frame := deliveredTokens(m)
+	if frame == nil {
+		t.Fatal("a successful poll delivered no TokensMsg")
+	}
+	if len(frame.Agents) != 3 {
+		t.Fatalf("delivered %d rows, want 3 (one per by_agent_detail key)", len(frame.Agents))
+	}
+
+	rows := tokenRowsByAgent(*frame)
+	for _, want := range []panes.TokenRow{
+		{Agent: "scanner", TokenCounts: panes.TokenCounts{Input: 20000, Output: 2000, CostUSD: 8.25, CostKnown: true}},
+		{Agent: "quality", TokenCounts: panes.TokenCounts{Input: 8000, Output: 800, CostUSD: 3.00, CostKnown: true}},
+		{Agent: "reviewer", TokenCounts: panes.TokenCounts{Input: 2000, Output: 200, CostUSD: 1.25, CostKnown: true}},
+	} {
+		if got := rows[want.Agent]; got != want {
+			t.Errorf("row %q = %+v, want %+v", want.Agent, got, want)
+		}
+	}
+}
+
+// TestFleetTotalsComeFromTheServerNotTheRows is the unattributed-usage
+// criterion. tokensFixture's totals exceed the sum of its agent rows, so a
+// re-summing implementation reports the smaller number and fails here.
+func TestFleetTotalsComeFromTheServerNotTheRows(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	frame := deliveredTokens(m)
+	if frame == nil {
+		t.Fatal("a successful poll delivered no TokensMsg")
+	}
+
+	// Guard the fixture itself: if the numbers ever balance, this test proves
+	// nothing and should say so rather than passing quietly.
+	var sumIn, sumOut int64
+	for _, row := range frame.Agents {
+		sumIn += row.Input
+		sumOut += row.Output
+	}
+	if sumIn != fixtureAgentSumInput || sumOut != fixtureAgentSumOutput {
+		t.Fatalf("fixture rows sum to %d/%d, want %d/%d", sumIn, sumOut, fixtureAgentSumInput, fixtureAgentSumOutput)
+	}
+	if sumIn == fixtureTotalInput {
+		t.Fatal("the fixture has no unattributed usage; a re-summing implementation would pass vacuously")
+	}
+
+	if frame.Total.Input != fixtureTotalInput {
+		t.Errorf("Total.Input = %d, want the server's %d (a re-sum of rows gives %d)",
+			frame.Total.Input, fixtureTotalInput, sumIn)
+	}
+	if frame.Total.Output != fixtureTotalOutput {
+		t.Errorf("Total.Output = %d, want the server's %d (a re-sum of rows gives %d)",
+			frame.Total.Output, fixtureTotalOutput, sumOut)
+	}
+}
+
+// TestFullyPricedSummaryKnowsTheFleetCost: no unpriced models, so total_usd is
+// the complete spend and is presented as such.
+func TestFullyPricedSummaryKnowsTheFleetCost(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	frame := deliveredTokens(m)
+	if frame == nil {
+		t.Fatal("a successful poll delivered no TokensMsg")
+	}
+	if !frame.Total.CostKnown {
+		t.Fatal("Total.CostKnown = false for a summary with no unpriced models; the fleet cost renders a dash for no reason")
+	}
+	if frame.Total.CostUSD != 12.5 {
+		t.Errorf("Total.CostUSD = %v, want the summary's total_usd 12.5", frame.Total.CostUSD)
+	}
+}
+
+// TestMixedSummaryPricesOnlyTheEstimatedRows is the load-bearing case: unpriced
+// entries carry a non-zero usd on the wire, and only Source distinguishes them.
+func TestMixedSummaryPricesOnlyTheEstimatedRows(t *testing.T) {
+	server := newDashboardServer(t)
+	server.cost.Store(mixedCostFixture)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	frame := deliveredTokens(m)
+	if frame == nil {
+		t.Fatal("a successful poll delivered no TokensMsg")
+	}
+	rows := tokenRowsByAgent(*frame)
+
+	scanner := rows["scanner"]
+	if !scanner.CostKnown || scanner.CostUSD != 8.25 {
+		t.Errorf("scanner cost = {%v %v}, want {8.25 true}: source is \"estimated\"", scanner.CostUSD, scanner.CostKnown)
+	}
+	for _, agent := range []string{"quality", "reviewer"} {
+		row := rows[agent]
+		if row.CostKnown {
+			t.Errorf("%s CostKnown = true for an entry whose source is \"unpriced\"; the pane would render $%.2f as real spend",
+				agent, row.CostUSD)
+		}
+		if row.CostUSD != 0 {
+			t.Errorf("%s CostUSD = %v on an unknown row; an unknown cost must not carry a figure a later change could render",
+				agent, row.CostUSD)
+		}
+		// The counts are unaffected by the missing price.
+		if row.Input == 0 || row.Output == 0 {
+			t.Errorf("%s lost its token counts to an unpriced model: %+v", agent, row)
+		}
+	}
+
+	if frame.Total.CostKnown {
+		t.Errorf("Total.CostKnown = true with unpriced_models present; a lower bound (%v) was presented as the fleet's complete spend",
+			frame.Total.CostUSD)
+	}
+}
+
+// TestUnpricedZeroIsNotRenderedAsFree drives the mixed case all the way to the
+// rendered pane, where the distinction is visible to an operator.
+//
+// The wire fixture is a $0.00 unpriced entry — the exact shape
+// client.CostAgentEntry warns about — so an implementation that trusted the
+// float would render "$0.00" and claim the agent is free.
+func TestUnpricedZeroIsNotRenderedAsFree(t *testing.T) {
+	server := newDashboardServer(t)
+	server.cost.Store(`{"estimated": {
+	  "total_usd": 8.25,
+	  "unpriced_models": ["glm-4.6"],
+	  "by_agent": [
+	    {"name": "scanner",  "usd": 8.25, "source": "estimated"},
+	    {"name": "quality",  "usd": 0,    "source": "unpriced"},
+	    {"name": "reviewer", "usd": 0,    "source": "unpriced"}
+	  ]
+	}}`)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	rows := tokenRowsByAgent(*deliveredTokens(m))
+	if rows["quality"].CostKnown {
+		t.Error("a $0 unpriced entry was taken as a known cost; the pane renders $0.00 for an agent whose price is simply unknown")
+	}
+
+	view := m.panes[paneTokensIndex].View(60, 12)
+	if strings.Contains(view, "$0.00") {
+		t.Errorf("the rendered pane shows $0.00 for an unpriced agent:\n%s", view)
+	}
+	if !strings.Contains(view, "—") {
+		t.Errorf("the rendered pane shows no em dash for the unknown costs:\n%s", view)
+	}
+	if !strings.Contains(view, "$8.25") {
+		t.Errorf("the rendered pane lost the one cost that IS known:\n%s", view)
+	}
+}
+
+// TestCostFailureStillRefreshesCounts is the failure-isolation criterion: the
+// optional half is gone, the primary half is not held behind it.
+func TestCostFailureStillRefreshesCounts(t *testing.T) {
+	server := newDashboardServer(t)
+	server.failCost.Store(true)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	frame := deliveredTokens(m)
+	if frame == nil {
+		t.Fatal("a cost failure suppressed the whole frame; the pane stays on its placeholder despite a healthy /api/tokens")
+	}
+	if len(frame.Agents) != 3 {
+		t.Errorf("delivered %d rows with cost down, want the 3 the token read returned", len(frame.Agents))
+	}
+	if frame.Total.Input != fixtureTotalInput {
+		t.Errorf("Total.Input = %d with cost down, want the fresh %d", frame.Total.Input, fixtureTotalInput)
+	}
+	for _, row := range frame.Agents {
+		if row.CostKnown {
+			t.Errorf("row %q reports a known cost of %v after /api/cost failed", row.Agent, row.CostUSD)
+		}
+	}
+	if frame.Total.CostKnown {
+		t.Errorf("Total.CostKnown = true after /api/cost failed (%v)", frame.Total.CostUSD)
+	}
+
+	view := m.panes[paneTokensIndex].View(60, 12)
+	if !strings.Contains(view, "scanner") {
+		t.Errorf("the pane did not render fresh counts with cost down:\n%s", view)
+	}
+}
+
+// TestTokenFailurePreservesThePriorPane is the other half of that contract: the
+// primary read is the one whose failure holds the pane.
+func TestTokenFailurePreservesThePriorPane(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	good := m.panes[paneTokensIndex].View(60, 12)
+	if strings.Contains(good, tokensPlaceholder) {
+		t.Fatalf("no data to preserve; this test would pass vacuously:\n%s", good)
+	}
+
+	// The dashboard's token endpoint goes away. Everything else still answers.
+	server.failTokens.Store(true)
+	m = pollAndApply(t, m)
+
+	after := m.panes[paneTokensIndex].View(60, 12)
+	if after != good {
+		t.Errorf("a failed /api/tokens changed the pane.\nbefore:\n%s\nafter:\n%s", good, after)
+	}
+}
+
+// TestStaleCostIsClearedWhenTheEstimateGoesAway pins the arrival-order property
+// the fetchErrMsg handler exists for.
+//
+// A cost failure invalidates the cached estimate AND rebuilds the frame. Without
+// the rebuild, a token result that happened to be applied before the error would
+// leave the previous poll's dollar figures sitting on this poll's counts — a
+// stale price on fresh usage, which is the one thing worse than a dash.
+func TestStaleCostIsClearedWhenTheEstimateGoesAway(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	if !deliveredTokens(m).Total.CostKnown {
+		t.Fatal("the first poll produced no known cost; this test would pass vacuously")
+	}
+
+	// Apply the messages in the order that hides the bug: the fresh counts
+	// first, then the cost failure.
+	server.failCost.Store(true)
+	server.tokens.Store(`{
+	  "total_input": 99000, "total_output": 9900,
+	  "by_agent_detail": {"scanner": {"input": 99000, "output": 9900}}
+	}`)
+	msgs := drain(m.poll())
+	var errs []tea.Msg
+	for _, msg := range msgs {
+		if _, isErr := msg.(fetchErrMsg); isErr {
+			errs = append(errs, msg)
+			continue
+		}
+		next, _ := m.Update(msg)
+		m = next.(model)
+	}
+	m = applyAll(m, errs)
+
+	frame := deliveredTokens(m)
+	if frame.Total.Input != 99000 {
+		t.Errorf("Total.Input = %d, want the refreshed 99000", frame.Total.Input)
+	}
+	if frame.Total.CostKnown {
+		t.Errorf("Total.CostKnown = true (%v) after /api/cost failed; a stale estimate is sitting on fresh counts", frame.Total.CostUSD)
+	}
+	for _, row := range frame.Agents {
+		if row.CostKnown {
+			t.Errorf("row %q kept a stale cost of %v after /api/cost failed", row.Agent, row.CostUSD)
+		}
+	}
+
+	view := m.panes[paneTokensIndex].View(60, 12)
+	if strings.Contains(view, "$") {
+		t.Errorf("the rendered pane still shows a dollar figure after the estimate went away:\n%s", view)
+	}
+}
+
+// TestEmptyUsageIsALoadedZeroFrame: a successful read of an idle hive is data,
+// not an absence of data.
+func TestEmptyUsageIsALoadedZeroFrame(t *testing.T) {
+	server := newDashboardServer(t)
+	server.tokens.Store(emptyTokensFixture)
+	server.cost.Store(`{"estimated": {"total_usd": 0, "unpriced_models": [], "by_agent": []}}`)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	frame := deliveredTokens(m)
+	if frame == nil {
+		t.Fatal("an empty-but-successful token read delivered no frame; the pane would wait forever on a healthy idle hive")
+	}
+	if len(frame.Agents) != 0 {
+		t.Errorf("delivered %d rows for an empty summary, want 0", len(frame.Agents))
+	}
+	if frame.Total.Input != 0 || frame.Total.Output != 0 {
+		t.Errorf("Total = %+v, want zeroes", frame.Total)
+	}
+
+	view := m.panes[paneTokensIndex].View(60, 12)
+	if strings.Contains(view, tokensPlaceholder) {
+		t.Errorf("an idle hive still renders %q rather than a loaded zero table:\n%s", tokensPlaceholder, view)
+	}
+	if !strings.Contains(view, "no usage recorded") {
+		t.Errorf("the loaded zero state did not render the pane's empty row:\n%s", view)
+	}
+	// A zero-usage hive with a fully priced (empty) summary genuinely spent
+	// $0.00, and that is a fact rather than an unknown.
+	if !frame.Total.CostKnown {
+		t.Error("Total.CostKnown = false for an empty fully-priced summary; a real $0.00 was reported as unknown")
+	}
+}
+
+// TestCostBeforeTokensDeliversNoFrame is the ordering guard, the mirror of
+// TestIntervalBeforeStatusDeliversNoFrame: the two fetches race, and a cost
+// result arriving first must not produce a loaded pane with no rows — which the
+// pane cannot tell from a hive that has genuinely spent nothing.
+func TestCostBeforeTokensDeliversNoFrame(t *testing.T) {
+	m := newModel()
+
+	next, _ := m.Update(costSummaryMsg{summary: client.CostSummary{
+		TotalUSD: 12.5,
+		ByAgent:  []client.CostAgentEntry{{Name: "scanner", USD: 8.25, Source: "estimated"}},
+	}})
+	m = next.(model)
+
+	if got := deliveredTokens(m); got != nil {
+		t.Errorf("a cost read arriving before any token read delivered a frame: %+v", *got)
+	}
+	// The pane is the real assertion: deliveredTokens reads the same
+	// tokensLoaded flag the guard does, so it cannot observe a frame that WAS
+	// broadcast. Only the pane can, and a loaded pane here is a hive reported
+	// as having spent nothing when nothing has been read.
+	if view := m.panes[paneTokensIndex].View(60, 12); !strings.Contains(view, tokensPlaceholder) {
+		t.Errorf("a cost read alone loaded the pane; an idle-looking zero table is showing before any count was read:\n%s", view)
+	}
+	if !m.costLoaded {
+		t.Error("the estimate was not cached for the first token read")
+	}
+
+	// The first token read then delivers both halves at once.
+	next, _ = m.Update(tokenUsageMsg{usage: client.TokenUsage{
+		TotalInput:    20000,
+		TotalOutput:   2000,
+		ByAgentDetail: map[string]*client.TokenBucket{"scanner": {Input: 20000, Output: 2000}},
+	}})
+	m = next.(model)
+
+	frame := deliveredTokens(m)
+	if frame == nil {
+		t.Fatal("the first token read delivered no frame")
+	}
+	if len(frame.Agents) != 1 || !frame.Agents[0].CostKnown || frame.Agents[0].CostUSD != 8.25 {
+		t.Errorf("the frame did not join the cached estimate: %+v", frame.Agents)
+	}
+}
+
+// TestRepeatedPollsRenderDeterministically is the map-nondeterminism criterion.
+//
+// by_agent_detail and the cost by_agent list are decoded into a Go map, whose
+// iteration order is randomized per range. Polling repeatedly and comparing the
+// RENDERED pane is what catches a projection that let that order through: the
+// pane sorts what it is handed, so this also pins that the wiring did not
+// bypass that sort by delivering pre-ordered rows the pane would keep.
+//
+// The rows are given EQUAL totals so the sort's tie-break is the thing under
+// test. With distinct magnitudes the descending sort alone would mask a lost
+// tie-break, and equal-spend agents swapping places every 5 seconds is exactly
+// the flicker the contract forbids.
+func TestRepeatedPollsRenderDeterministically(t *testing.T) {
+	server := newDashboardServer(t)
+	server.tokens.Store(`{
+	  "total_input": 3000, "total_output": 300,
+	  "by_agent_detail": {
+	    "alpha":   {"input": 1000, "output": 100},
+	    "bravo":   {"input": 1000, "output": 100},
+	    "charlie": {"input": 1000, "output": 100},
+	    "delta":   {"input": 1000, "output": 100},
+	    "echo":    {"input": 1000, "output": 100}
+	  }
+	}`)
+	server.cost.Store(`{"estimated": {
+	  "total_usd": 5, "unpriced_models": [],
+	  "by_agent": [
+	    {"name": "alpha", "usd": 1, "source": "estimated"},
+	    {"name": "bravo", "usd": 1, "source": "estimated"},
+	    {"name": "charlie", "usd": 1, "source": "estimated"},
+	    {"name": "delta", "usd": 1, "source": "estimated"},
+	    {"name": "echo", "usd": 1, "source": "estimated"}
+	  ]
+	}}`)
+
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+	want := m.panes[paneTokensIndex].View(60, 14)
+
+	// One poll can only observe one iteration order. Repeating is what makes a
+	// leak show up rather than passing on a lucky shuffle.
+	const repeats = 30
+	for i := 0; i < repeats; i++ {
+		m = pollAndApply(t, m)
+		if got := m.panes[paneTokensIndex].View(60, 14); got != want {
+			t.Fatalf("poll %d rendered a different pane; map iteration order leaked into the frame.\nfirst:\n%s\nnow:\n%s", i+1, want, got)
+		}
+	}
+}
+
+// TestTokenPollSurvivesAnUnreachableDashboard: neither fetch may panic or hang
+// when nothing is listening, and both must report as failures rather than as
+// empty successes.
+func TestTokenPollSurvivesAnUnreachableDashboard(t *testing.T) {
+	m := pollTestModel(t, closedDashboard)
+
+	msgs := drain(m.poll())
+
+	var sources []string
+	for _, msg := range msgs {
+		if err, ok := msg.(fetchErrMsg); ok {
+			sources = append(sources, err.source)
+		}
+		if _, ok := msg.(tokenUsageMsg); ok {
+			t.Error("an unreachable dashboard produced a tokenUsageMsg; an empty success would render as a zero-usage hive")
+		}
+		if _, ok := msg.(costSummaryMsg); ok {
+			t.Error("an unreachable dashboard produced a costSummaryMsg")
+		}
+	}
+	for _, want := range []string{"tokens", costFetchSource} {
+		found := false
+		for _, got := range sources {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no fetchErrMsg with source %q; sources were %v", want, sources)
+		}
+	}
+
+	settled := applyAll(m, msgs)
+	if deliveredTokens(settled) != nil {
+		t.Error("a fully failed poll delivered a frame")
+	}
+	view := settled.panes[paneTokensIndex].View(60, 12)
+	if !strings.Contains(view, tokensPlaceholder) {
+		t.Errorf("the pane left its placeholder without ever receiving data:\n%s", view)
+	}
+}
+
+// TestCostForAnUnknownAgentCreatesNoRow: cost enriches rows, it never invents
+// them. An agent priced by /api/cost but absent from by_agent_detail has no
+// counts to show, and a row of dashes carrying a dollar figure would read as
+// spend without tokens.
+func TestCostForAnUnknownAgentCreatesNoRow(t *testing.T) {
+	server := newDashboardServer(t)
+	server.tokens.Store(`{
+	  "total_input": 1000, "total_output": 100,
+	  "by_agent_detail": {"scanner": {"input": 1000, "output": 100}}
+	}`)
+	server.cost.Store(`{"estimated": {
+	  "total_usd": 9, "unpriced_models": [],
+	  "by_agent": [
+	    {"name": "scanner", "usd": 4, "source": "estimated"},
+	    {"name": "ghost",   "usd": 5, "source": "estimated"}
+	  ]
+	}}`)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	frame := deliveredTokens(m)
+	if len(frame.Agents) != 1 {
+		t.Fatalf("delivered %d rows, want only the 1 with token counts: %+v", len(frame.Agents), frame.Agents)
+	}
+	if frame.Agents[0].Agent != "scanner" {
+		t.Errorf("row is %q, want scanner", frame.Agents[0].Agent)
+	}
+}
+
+// TestNullAgentBucketIsSkipped: by_agent_detail is a map of POINTERS, so a null
+// value decodes to a nil bucket. A row of zeroes attributed to a real agent
+// would read as an idle agent rather than as missing data.
+func TestNullAgentBucketIsSkipped(t *testing.T) {
+	server := newDashboardServer(t)
+	server.tokens.Store(`{
+	  "total_input": 1000, "total_output": 100,
+	  "by_agent_detail": {"scanner": {"input": 1000, "output": 100}, "broken": null}
+	}`)
+	m := pollAndApply(t, pollTestModel(t, server.URL))
+
+	for _, row := range deliveredTokens(m).Agents {
+		if row.Agent == "broken" {
+			t.Errorf("a null bucket produced a row: %+v", row)
+		}
+	}
+}
+
+// TestTokenFrameDoesNotOverflowTheMinimumTerminal guards the frame's geometry
+// against the values THIS TASK newly lets reach it.
+//
+// It is the same cliff #5486 and #5487 hit: lipgloss's Width() WRAPS rather
+// than truncates, so an over-wide row silently becomes two lines and pushes the
+// frame a row past the terminal's height. Before T30 the Tokens pane was
+// unreachable from real data — nothing sent it a TokensMsg — so no
+// server-supplied string could overflow it. Now agent names and dollar amounts
+// both arrive from the wire with no length bound.
+//
+// The assertion is that the EXISTING pane already clips (panes.truncate for the
+// name column, the grid's MaxWidth/MaxHeight for the rest), so this task needs
+// no clipping of its own. It is a regression guard, not a fix: if a later change
+// to the pane's layout removes that clipping, this fails at the wiring that
+// made the values reachable.
+func TestTokenFrameDoesNotOverflowTheMinimumTerminal(t *testing.T) {
+	pinDashboard(t, closedDashboard)
+	m := newModel()
+	m.width, m.height = minWidth, minHeight
+
+	longName := strings.Repeat("agent-with-an-absurdly-long-name-", 8)
+	m.costLoaded = true
+	m.costSummary = client.CostSummary{
+		TotalUSD: 987654321098765,
+		ByAgent:  []client.CostAgentEntry{{Name: longName, USD: 123456789012345, Source: "estimated"}},
+	}
+	next, _ := m.Update(tokenUsageMsg{usage: client.TokenUsage{
+		TotalInput:    9876543210,
+		TotalOutput:   1234567890,
+		ByAgentDetail: map[string]*client.TokenBucket{longName: {Input: 9876543210, Output: 1234567890}},
+	}})
+	m = next.(model)
+
+	frame := m.View()
+	lines := strings.Split(frame, "\n")
+	if len(lines) != minHeight {
+		t.Errorf("frame is %d lines at height %d; a wrapped token row cost a row", len(lines), minHeight)
 	}
 	for i, line := range lines {
 		if got := lipgloss.Width(line); got > minWidth {


### PR DESCRIPTION
Fixes #5419

## The failure

The Tokens pane (T9, #5058) and both clients (T8 #5057, T28 #5415) were each tested in isolation, and the app never called any of them. Nothing sent a `panes.TokensMsg`, so a real `hivectl tui` session showed `waiting for data` in that quadrant forever — while three of the four panes were live.

## What this does

Adds `/api/tokens` and `/api/cost` to the existing poll batch as two independent fetches (`tokenUsageMsg`, `costSummaryMsg`), caches each successful read on the model, and projects them into one `TokensMsg` from a single place — `model.tokensMsg()`, the same one-construction-site shape T29 used for `governorMsg()`.

No new timer. This is the existing poll batch; T32 (#5421) separates the refresh classes.

## The projection rules

- **Rows come from `TokenUsage.ByAgentDetail`**, and their input/output stay the `/api/tokens` values. The cost payload carries its own per-agent counts, but showing those would make the counts change depending on whether an unrelated endpoint answered.
- **Cost enriches a row, never creates one.** An agent priced by `/api/cost` but absent from `ByAgentDetail` has no counts to show, and a row of dashes carrying a dollar figure reads as spend without tokens.
- **The join key is the agent name exactly as each endpoint spells it.** This is canonical rather than hopeful: both payloads derive from the *same* server-side `AggregateSummary.ByAgentDetail` map — `/api/tokens` returns its keys directly, and `/api/cost` prices those same buckets (`pkg/tokens/pricing.go` `EstimateFromSummary`, flattened by `pkg/dashboard/cost.go`). There is no alias layer between them, so anything cleverer than an exact match would invent a correspondence the server never made.
- **`CostKnown` is the entry's `Source`, never its `USD`.** An unpriced entry carries a placeholder on the wire — sometimes `0`, sometimes a non-zero tier estimate — so *neither* `usd == 0` nor `usd != 0` distinguishes it. Only `CostAgentEntry.Known()` does. An unpriced entry renders `—`, never `$0.00`.
- **Fleet input/output are `TotalInput`/`TotalOutput`**, not a re-sum of the displayed rows. `AggregateSummary` counts every scanned session including ones it could not attribute, so the server total is legitimately larger; a re-sum would silently disagree with the web dashboard for the same hive.
- **Fleet cost is `estimated.total_usd`, known only when `unpriced_models` is empty.** A lower bound presented as complete spend is the same lie as `$0.00` on an unpriced agent, one order of magnitude up.
- **Map order does not leak.** Rows are built from a map with no order imposed here; the pane sorts what it is handed.

## Failure isolation

Follows the invariant #5487 established, with one deliberate asymmetry:

| | behaviour |
|---|---|
| `/api/tokens` fails | pane unchanged — it is the primary data |
| `/api/cost` fails | **fresh counts delivered**, every cost column `—` |
| cost read succeeds first | no frame yet; cached until the first token read |
| empty successful usage | loaded zero-usage table, not `waiting for data` |

A failed cost read **clears** the cached estimate rather than holding it (unlike the governor cache, where a held mode is still true of the hive). A held dollar figure would be attached to counts that have since moved. It also **re-delivers** the frame, because the two Cmds race: without that, a frame built by the token result that landed first would still carry the previous poll's costs, and the pane would show a stale estimate for a full tick.

## Testing notes

Fifteen tests in `poll_test.go`, one per contract clause. Notable fixture choices:

- `tokensFixture` is **deliberately not self-consistent** — its totals exceed the sum of its agent rows by one unattributed session. A re-summing implementation reports the smaller number and fails, where a fixture whose numbers balanced would let it pass.
- `mixedCostFixture`'s unpriced entries carry **non-zero** `usd`, and a second fixture carries **zero** `usd` on unpriced entries. Together they mean neither float test can pass; only `Source` works.
- The determinism test gives all five agents **equal totals**, so the sort's name tie-break is what is under test. Distinct magnitudes would let a lost tie-break hide behind the descending sort. It polls 30 times and compares the rendered pane, since one poll observes only one map order.
- The unpriced and empty cases assert on the **rendered pane**, not just the message — `$0.00` absent, `—` present, `no usage recorded` present.
- `TestStaleCostIsClearedWhenTheEstimateGoesAway` applies the messages in the order that *hides* the bug (counts first, error last).

Every invariant was mutation-checked: re-summing the fleet total, dropping `Known()`, dropping `AllPriced()`, removing the cost invalidation, removing the re-delivery, removing the cost-before-tokens guard, blanking the token cache on failure, and removing the pane's sort each make a specific test fail.

`TestPollIssuesAllFourReads` is renamed `TestPollIssuesEveryRead` and extended to six.

### On the `lipgloss.Width()` wrapping cliff (#5486/#5487)

T30 is what first lets server-supplied strings of unbounded length reach this pane. I probed it at the 60x20 minimum with a 264-character agent name and 15-digit dollar amounts: **the pane already clips correctly** via its own `truncate` on the name column plus the grid's `MaxWidth`/`MaxHeight`, so no `Inline(true)` clipping is needed here and adding one would mean changing pane layout, which is out of scope. `TestTokenFrameDoesNotOverflowTheMinimumTerminal` pins that as a regression guard at the wiring that made those values reachable.

## Scope

`poll.go` and `poll_test.go`, plus a minimal additive `app.go` touch (four model fields, two `Update` cases, one clause on the existing `fetchErrMsg` case, one `broadcastTokens` helper). No Tokens pane layout change; no client wire-type change. Nothing touched in `panes/acmm.go`, `app.go`'s ACMM path, `panes/help.go`, or `help.golden` (#5417's files).

## Verify with

```bash
cd src
go build ./...
go test ./pkg/tui/...
```

CI is the gate.