### PR TITLE
🐛 fix(dashboard): render config writes from server truth instead of waiting for a rebuild

### DIFF
--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -3723,8 +3723,16 @@ func (s *Server) handleAgentConfigCadences(w http.ResponseWriter, r *http.Reques
 		s.logger.Error("failed to persist config after cadence update", "agent", name, "error", err)
 	}
 	s.auditFromRequest(r, "config_agent_cadences", auditDetail("section", "cadences"), name)
-	s.refreshAndPersist()
-	okResponse(w, map[string]string{"status": "updated", "agent": name})
+	// The rebuild kicked here is asynchronous, so the browser's post-save
+	// GET /api/status can be served the CACHED pre-mutation snapshot and
+	// repaint the OLD cadence — the operator then waits for a later broadcast
+	// to see their own write (#5492). minStatusSeq is the lowest StatusSeq
+	// guaranteed to reflect this mutation; the dashboard raises its
+	// stale-snapshot floor to it and drops anything built earlier (#4348).
+	floor := s.refreshAndPersistSeq()
+	// jsonResponse rather than okResponse: the latter is typed map[string]string
+	// and cannot carry the numeric floor. "ok" is preserved for callers.
+	jsonResponse(w, map[string]any{"ok": true, "status": "updated", "agent": name, "minStatusSeq": floor})
 }
 
 func (s *Server) handleAgentConfigModels(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/dashboard/api_packs.go
+++ b/src/pkg/dashboard/api_packs.go
@@ -476,16 +476,38 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.auditFromRequest(r, "apply_pack", auditDetail("level", levelStr, "name", result.Name), "")
+
+	// This path applied the pack — creating agents, pausing and resuming others
+	// — but never asked for a status rebuild, so the dashboard kept rendering
+	// the pre-apply snapshot until some unrelated broadcast happened to land.
+	// Kick the rebuild and hand back the StatusSeq floor so the browser can
+	// reject any snapshot built before this apply (#5492).
+	floor := s.refreshAndPersistSeq()
+
+	// packAgents mirrors handlePackSetLevel: the dashboard reads it to scope
+	// ACMM section visibility. It was absent here, so the client always fell
+	// back to an empty list after an apply.
+	var packAgentNames []string
+	if pack, err := config.ACMMPackByLevel(level); err == nil {
+		for _, a := range pack.Agents {
+			if !a.Hidden {
+				packAgentNames = append(packAgentNames, a.Name)
+			}
+		}
+	}
+
 	jsonResponse(w, map[string]interface{}{
-		"ok":      true,
-		"status":  "applied",
-		"level":   level,
-		"name":    result.Name,
-		"created": result.Created,
-		"updated": result.Updated,
-		"skipped": result.Skipped,
-		"paused":  result.Paused,
-		"resumed": result.Resumed,
+		"ok":           true,
+		"status":       "applied",
+		"level":        level,
+		"name":         result.Name,
+		"created":      result.Created,
+		"updated":      result.Updated,
+		"skipped":      result.Skipped,
+		"paused":       result.Paused,
+		"resumed":      result.Resumed,
+		"packAgents":   packAgentNames,
+		"minStatusSeq": floor,
 		// Exact before/after values let the dashboard warn before a restart
 		// activates a different evaluation cadence.
 		"governor_changes": result.GovernorChanges,
@@ -561,7 +583,13 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 	s.deps.AgentMgr.SyncModeFiles(level)
 
 	s.persistOnly()
-	s.refreshAsync()
+	// refreshAfterMutationSeq (not the bare refreshAsync) so the mutation epoch
+	// is bumped and the caller gets the StatusSeq floor. Without the floor, the
+	// dashboard's post-write refetch can be served a snapshot built before this
+	// level change and repaint the PREVIOUS level — the operator sees L4 after
+	// moving to L5 and may re-apply, triggering a second fleet-wide reconcile
+	// (#5492).
+	floor := s.refreshAfterMutationSeq()
 
 	pack, packLookupErr := config.ACMMPackByLevel(level)
 	var packAgentNames []string
@@ -624,6 +652,7 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 		"governor_changes": packResult.GovernorChanges,
 		"paused":           paused,
 		"resumed":          resumed,
+		"minStatusSeq":     floor,
 	})
 }
 

--- a/src/pkg/dashboard/config_write_visibility_test.go
+++ b/src/pkg/dashboard/config_write_visibility_test.go
@@ -1,0 +1,348 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// readSourceFile returns a Go source file from this package by name. The
+// response-shape assertions below are about literal handler source, which the
+// compiler cannot check for us.
+func readSourceFile(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// #5492: an ACMM level change and an agent cadence change both applied
+// server-side but stayed invisible in the dashboard for ~30s.
+//
+// The mechanism is NOT the family of 30s poll constants in index.html — those
+// drive unrelated panels (history, GH auth, nous, KB, audit, leaderboard). Both
+// affected panels render from the SSE status payload, and both write paths
+// already ask for a status rebuild. The lag is a RACE:
+//
+//	handler mutates state
+//	  -> go RefreshFunc()          (asynchronous rebuild, seconds)
+//	  -> returns 200 to the browser
+//	browser refetches GET /api/status
+//	  -> handleStatus serves the CACHED s.status, which the async rebuild has
+//	     not replaced yet -> the PRE-mutation snapshot, i.e. the OLD value
+//
+// The browser then sits on that stale render until some later broadcast
+// happens to carry the new value.
+//
+// #4348 already solved exactly this for the restart counter and the budget
+// window: the handler returns "minStatusSeq" (the lowest StatusSeq guaranteed
+// to reflect the mutation) and the frontend's noteStatusMutation() raises a
+// floor so any snapshot built before the mutation is DISCARDED rather than
+// rendered. These tests pin that same contract onto the two #5492 paths.
+//
+// Critically, this fix never renders an unconfirmed value: the floor only
+// causes stale snapshots to be dropped, so a failed write leaves the old value
+// on screen (and its error toast), it does not paint the requested value.
+
+// serverSeqFixture builds a Server whose RefreshFunc is deliberately slow, so
+// the async-rebuild race the operator hit is reproduced deterministically
+// rather than depending on timing luck.
+func serverSeqFixture(t *testing.T) *Server {
+	t.Helper()
+	s := &Server{}
+	s.sseClients = make(map[chan []byte]struct{})
+	return s
+}
+
+// TestStatusSeqFloorAdvancesPastCachedSnapshot demonstrates the race itself at
+// the seq level: a snapshot published from a build that STARTED before the
+// mutation carries a seq below the floor the mutation handed out, which is
+// precisely the signal the frontend needs to drop it.
+func TestStatusSeqFloorAdvancesPastCachedSnapshot(t *testing.T) {
+	s := serverSeqFixture(t)
+
+	// A snapshot published before any mutation.
+	s.UpdateStatus(&StatusPayload{})
+	s.statusMu.RLock()
+	preSeq := s.status.StatusSeq
+	s.statusMu.RUnlock()
+
+	// The operator's write lands. The handler captures the floor.
+	floor := s.noteStatusMutation()
+
+	if floor <= preSeq {
+		t.Fatalf("mutation floor %d must exceed the pre-mutation snapshot seq %d — "+
+			"otherwise the browser cannot tell a stale snapshot from a fresh one", floor, preSeq)
+	}
+
+	// The stale in-flight rebuild (started before the mutation) would publish
+	// a snapshot whose seq is below the floor. The frontend guard drops it.
+	if preSeq >= floor {
+		t.Fatalf("pre-mutation snapshot seq %d is not below floor %d", preSeq, floor)
+	}
+}
+
+// TestCadenceWriteReturnsStatusSeqFloor asserts the cadence handler hands the
+// browser a minStatusSeq. Without it the browser has no way to reject the
+// pre-mutation /api/status it is about to receive, and renders the OLD cadence.
+func TestCadenceWriteReturnsStatusSeqFloor(t *testing.T) {
+	html := indexHTML(t)
+
+	// The cadence save must raise the floor from the write response.
+	if !strings.Contains(html, "noteStatusMutation(cadenceAck.minStatusSeq);") {
+		t.Error("index.html: the agent cadence save does not raise the stale-snapshot " +
+			"floor from its write response — a pre-mutation /api/status will repaint " +
+			"the old cadence and the operator waits for a later broadcast (#5492)")
+	}
+}
+
+// TestACMMLevelWriteReturnsStatusSeqFloor asserts the same for the ACMM level
+// path, which is the higher-stakes of the two: an operator who still sees L4
+// after moving to L5 may re-apply, triggering a second fleet-wide reconcile.
+//
+// NOTE: the bare string "noteStatusMutation(data.minStatusSeq);" already
+// appears in the UNRELATED resetRestarts() handler (#4348), so a whole-file
+// Contains check here would pass without the fix — vacuous. Both ACMM
+// assertions are therefore scoped to the enclosing function body.
+func TestACMMLevelWriteReturnsStatusSeqFloor(t *testing.T) {
+	for _, fn := range []string{"applyACMMPack", "setACMMLevel"} {
+		body := acmmFuncBody(t, fn)
+		if !strings.Contains(body, "noteStatusMutation(data.minStatusSeq);") {
+			t.Errorf("index.html: %s does not raise the stale-snapshot floor from its "+
+				"write response — the dashboard can repaint the previous level after a "+
+				"successful L4->L5 change (#5492)", fn)
+		}
+	}
+}
+
+// acmmFuncBody returns the source of one of the two ACMM level-change
+// functions, bounded to that function so assertions cannot be satisfied by
+// identical code elsewhere in this 24k-line file.
+func acmmFuncBody(t *testing.T, name string) string {
+	t.Helper()
+	html := indexHTML(t)
+	start := strings.Index(html, "async function "+name+"(level) {")
+	if start < 0 {
+		t.Fatalf("index.html: %s not found", name)
+	}
+	// Both functions end at the next top-level `async function`/`function`
+	// declaration at the same indentation.
+	rest := html[start+10:]
+	end := strings.Index(rest, "\n    async function ")
+	altEnd := strings.Index(rest, "\n    function ")
+	if altEnd >= 0 && (end < 0 || altEnd < end) {
+		end = altEnd
+	}
+	if end < 0 {
+		t.Fatalf("index.html: could not bound %s", name)
+	}
+	return rest[:end]
+}
+
+// TestACMMOverrideRendersServerConfirmedLevel is the anti-lie guard.
+//
+// The pre-fix code set window._lastStatus.acmmLevel from `level` — the value
+// the browser SENT. That is the failure mode the issue explicitly forbids:
+// it renders a value the server did not confirm. The handler already returns
+// the authoritative level in its body, so the render must come from the
+// RESPONSE.
+func TestACMMOverrideRendersServerConfirmedLevel(t *testing.T) {
+	for _, fn := range []string{"applyACMMPack", "setACMMLevel"} {
+		body := acmmFuncBody(t, fn)
+
+		// The confirmed level must be read out of the response body.
+		if !strings.Contains(body, "const confirmedLevel = (data && Number.isFinite(Number(data.level))) ? Number(data.level) : level;") {
+			t.Errorf("index.html: %s does not derive the rendered level from the "+
+				"server's response body — rendering the requested level would show a "+
+				"value the server never confirmed (#5492)", fn)
+		}
+
+		// And the override/state writes must use that confirmed value, not the
+		// requested one. The literal `level` must no longer reach them.
+		for _, snippet := range []string{
+			"window._acmmOverride = { level: confirmedLevel, packAgents: data.packAgents || [] };",
+			"window._lastStatus.acmmLevel = confirmedLevel;",
+		} {
+			if !strings.Contains(body, snippet) {
+				t.Errorf("index.html %s is missing %q — the ACMM panel still renders "+
+					"the requested level rather than the server-confirmed one (#5492)", fn, snippet)
+			}
+		}
+		if strings.Contains(body, "window._acmmOverride = { level: level,") {
+			t.Errorf("index.html %s still pins the override to the REQUESTED level — "+
+				"that renders a value the server never confirmed (#5492)", fn)
+		}
+	}
+}
+
+// TestPackSetLevelResponseCarriesMinStatusSeq asserts the SERVER half of the
+// ACMM contract: the PUT /api/packs/level body must carry minStatusSeq.
+func TestPackSetLevelResponseCarriesMinStatusSeq(t *testing.T) {
+	src := readSourceFile(t, "api_packs.go")
+
+	// BOTH ACMM write paths must carry the floor. handlePackApply previously
+	// triggered no status rebuild at all, so scope each assertion to its own
+	// handler — a whole-file check would let one path satisfy the other.
+	for _, h := range []struct{ fn, next string }{
+		{"handlePackApply", "func (s *Server) handlePackSetLevel("},
+		{"handlePackSetLevel", "func (s *Server) syncAgentVisibility("},
+	} {
+		start := strings.Index(src, "func (s *Server) "+h.fn+"(")
+		if start < 0 {
+			t.Fatalf("api_packs.go: %s not found", h.fn)
+		}
+		end := strings.Index(src[start:], "\n"+h.next)
+		if end < 0 {
+			t.Fatalf("api_packs.go: could not bound %s", h.fn)
+		}
+		body := src[start : start+end]
+
+		// The handler must take a seq-returning refresh, not the bare async one.
+		if !regexp.MustCompile(`floor := s\.refresh(AfterMutationSeq|AndPersistSeq)\(\)`).MatchString(body) {
+			t.Errorf("api_packs.go: %s does not capture the status-seq floor, so its "+
+				"response cannot tell the browser which snapshots predate the level "+
+				"change (#5492)", h.fn)
+		}
+		// gofmt aligns map literal values, so match the key and value
+		// independently of the run of padding spaces between them.
+		if !regexp.MustCompile(`"minStatusSeq":\s+floor,`).MatchString(body) {
+			t.Errorf("api_packs.go: the %s response body does not include "+
+				"minStatusSeq (#5492)", h.fn)
+		}
+	}
+}
+
+// TestCadenceHandlerResponseCarriesMinStatusSeq asserts the server half of the
+// cadence contract.
+func TestCadenceHandlerResponseCarriesMinStatusSeq(t *testing.T) {
+	src := readSourceFile(t, "api.go")
+
+	idx := strings.Index(src, "func (s *Server) handleAgentConfigCadences(")
+	if idx < 0 {
+		t.Fatal("api.go: handleAgentConfigCadences not found")
+	}
+	// Bound the search to the handler body.
+	end := strings.Index(src[idx:], "\nfunc (s *Server) handleAgentConfigModels(")
+	if end < 0 {
+		t.Fatal("api.go: could not bound handleAgentConfigCadences")
+	}
+	body := src[idx : idx+end]
+
+	if !strings.Contains(body, "floor := s.refreshAndPersistSeq()") {
+		t.Error("handleAgentConfigCadences does not capture the status-seq floor, so a " +
+			"pre-mutation /api/status can repaint the old cadence (#5492)")
+	}
+	if !strings.Contains(body, `"minStatusSeq": floor`) {
+		t.Error("handleAgentConfigCadences response does not carry minStatusSeq (#5492)")
+	}
+	// okResponse is map[string]string and silently cannot carry a numeric
+	// floor; the handler must use jsonResponse.
+	if strings.Contains(body, "okResponse(w, map[string]any{") {
+		t.Error("handleAgentConfigCadences uses okResponse for a payload containing a " +
+			"numeric floor — that does not compile; use jsonResponse (#5492)")
+	}
+}
+
+// TestCadenceWriteStillSurfacesFailure is the second anti-lie guard: a failed
+// cadence write must not raise the floor and must not repaint. The floor is
+// only raised inside the success branch.
+func TestCadenceWriteStillSurfacesFailure(t *testing.T) {
+	html := indexHTML(t)
+
+	// The ack parse and floor bump must sit after the !res.ok throw, so a
+	// non-2xx response cannot reach them.
+	ackIdx := strings.Index(html, "noteStatusMutation(cadenceAck.minStatusSeq);")
+	if ackIdx < 0 {
+		t.Fatal("index.html: cadence floor bump not present (#5492)")
+	}
+	// Find the enclosing generic-section save and confirm the error throw
+	// precedes the bump.
+	throwIdx := strings.LastIndex(html[:ackIdx], "if (!res.ok) throw new Error(await saveErrorMessage(res));")
+	if throwIdx < 0 {
+		t.Fatal("index.html: the generic section save no longer throws on a non-OK " +
+			"response — a failed cadence write would be indistinguishable from a slow one")
+	}
+	between := html[throwIdx:ackIdx]
+	if strings.Contains(between, "showToast('Configuration saved'") {
+		t.Error("index.html: the cadence floor bump happens after the success toast — " +
+			"it must be gated on the same non-OK throw so a failed write never advances " +
+			"the floor (#5492)")
+	}
+}
+
+// TestACMMFailedWriteDoesNotRender asserts the ACMM error branch returns before
+// any optimistic render, so a rejected level change leaves the old level on
+// screen with an error message rather than painting the requested level.
+func TestACMMFailedWriteDoesNotRender(t *testing.T) {
+	html := indexHTML(t)
+
+	idx := strings.Index(html, "async function setACMMLevel(level) {")
+	if idx < 0 {
+		t.Fatal("index.html: setACMMLevel not found")
+	}
+	end := strings.Index(html[idx:], "\n    // Packs reconcile scheduling")
+	if end < 0 {
+		t.Fatal("index.html: could not bound setACMMLevel")
+	}
+	body := html[idx : idx+end]
+
+	errIdx := strings.Index(body, "errEl.textContent = data.error || 'Failed to set level';")
+	renderIdx := strings.Index(body, "window._acmmOverride = { level: confirmedLevel")
+	if errIdx < 0 {
+		t.Fatal("setACMMLevel no longer reports a failed level change")
+	}
+	if renderIdx < 0 {
+		t.Fatal("setACMMLevel no longer renders the confirmed level")
+	}
+	if errIdx > renderIdx {
+		t.Error("setACMMLevel renders the level before handling the error response — " +
+			"a failed write would paint the requested level (#5492)")
+	}
+	// The error branch must return, not fall through into the render.
+	tail := body[errIdx:renderIdx]
+	if !strings.Contains(tail, "return;") {
+		t.Error("setACMMLevel's error branch does not return before the render — a " +
+			"failed level change would still repaint the requested level (#5492)")
+	}
+}
+
+// TestStatusHandlerServesCachedSnapshot documents the server behaviour that
+// makes the floor necessary: GET /api/status serves whatever snapshot is
+// cached, with no rebuild. This is why a post-write refetch can legitimately
+// return pre-write data, and therefore why the browser must be told to reject
+// it rather than the endpoint being made synchronous.
+func TestStatusHandlerServesCachedSnapshot(t *testing.T) {
+	s := serverSeqFixture(t)
+	s.UpdateStatus(&StatusPayload{})
+	s.statusMu.RLock()
+	cachedSeq := s.status.StatusSeq
+	s.statusMu.RUnlock()
+
+	// Mutate; the rebuild has NOT run yet (no RefreshFunc wired).
+	floor := s.noteStatusMutation()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	s.handleStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/status = %d, want 200", rec.Code)
+	}
+	var got StatusPayload
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding status: %v", err)
+	}
+	if got.StatusSeq != cachedSeq {
+		t.Fatalf("status seq = %d, want the cached pre-mutation %d", got.StatusSeq, cachedSeq)
+	}
+	if got.StatusSeq >= floor {
+		t.Fatalf("the post-write refetch returned seq %d which is NOT below the floor %d — "+
+			"the stale-snapshot guard would fail to drop it", got.StatusSeq, floor)
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -16344,9 +16344,17 @@ function burnAreaChart() {
         const skipped = (data.skipped || []).length;
         const governorChanges = formatGovernorChanges(data.governor_changes);
         closeACMMDialog();
-        window._acmmOverride = { level: level, packAgents: data.packAgents || [] };
+        // Render the level the SERVER confirmed, never the one we asked for
+        // (#5492). We only reach here on a 2xx, so the write is committed; the
+        // body is authoritative. Falling back to `level` keeps an older spoke
+        // that omits the field working.
+        const confirmedLevel = (data && Number.isFinite(Number(data.level))) ? Number(data.level) : level;
+        // Drop any status snapshot built before this apply, so the async
+        // rebuild's predecessor cannot repaint the previous level (#4348).
+        noteStatusMutation(data.minStatusSeq);
+        window._acmmOverride = { level: confirmedLevel, packAgents: data.packAgents || [] };
         if (window._lastStatus) {
-          window._lastStatus.acmmLevel = level;
+          window._lastStatus.acmmLevel = confirmedLevel;
           window._lastStatus.acmmLevelConfigured = true;
           window._lastStatus.acmmPackAgents = data.packAgents || [];
           render(window._lastStatus);
@@ -16381,14 +16389,17 @@ function burnAreaChart() {
         }
         const governorChanges = formatGovernorChanges(data.governor_changes);
         closeACMMDialog();
-        window._acmmOverride = { level: level, packAgents: data.packAgents || [] };
+        // Server-confirmed level only — see applyACMMPack above (#5492).
+        const confirmedLevel = (data && Number.isFinite(Number(data.level))) ? Number(data.level) : level;
+        noteStatusMutation(data.minStatusSeq);
+        window._acmmOverride = { level: confirmedLevel, packAgents: data.packAgents || [] };
         if (window._lastStatus) {
-          window._lastStatus.acmmLevel = level;
+          window._lastStatus.acmmLevel = confirmedLevel;
           window._lastStatus.acmmLevelConfigured = true;
           window._lastStatus.acmmPackAgents = data.packAgents || [];
           render(window._lastStatus);
         }
-        showToast(`ACMM level set to L${level} (${name})` + (governorChanges ? ' — governor settings changed' : ''), governorChanges ? 'info' : 'success');
+        showToast(`ACMM level set to L${confirmedLevel} (${name})` + (governorChanges ? ' — governor settings changed' : ''), governorChanges ? 'info' : 'success');
         if (governorChanges) await hiveAlert(governorChanges, 'Governor settings changed');
         _acmmPacks = null;
       } catch (err) {
@@ -22128,6 +22139,10 @@ function burnAreaChart() {
           !(await ensureGatewayMethodConfigured(dirty.general.cliPinValue))) return;
       const base = _configState.type === 'governor' ? '/api/config/governor' : `/api/config/agent/${_configState.agent}`;
       let success = true;
+      // Set once a cadences section has been accepted by the server, so the
+      // success path knows to repaint the governor cadence matrix even when
+      // no `general` field changed (#5492).
+      let savedCadences = false;
       for (const [section, values] of Object.entries(dirty)) {
         try {
           if (_configState.type === 'governor' && section === 'general' && values.hiveId !== undefined) {
@@ -22202,6 +22217,19 @@ function burnAreaChart() {
               body: JSON.stringify(values)
             });
             if (!res.ok) throw new Error(await saveErrorMessage(res));
+            if (section === 'cadences') {
+              // A cadence write kicks an ASYNC status rebuild server-side, so
+              // the refetch below can be served the cached pre-write snapshot
+              // and repaint the OLD cadence — the operator waits for a later
+              // broadcast to see their own change (#5492). Raise the
+              // stale-snapshot floor from the write ack so any snapshot built
+              // before this mutation is discarded instead of rendered.
+              // Reached only after the !res.ok throw above, so a failed write
+              // never advances the floor.
+              const cadenceAck = await res.json().catch(() => ({}));
+              noteStatusMutation(cadenceAck.minStatusSeq);
+              savedCadences = true;
+            }
             if (_configState.type === 'governor' && section === 'litellm') {
               // Saving the LiteLLM tab auto-runs the live connection test
               // server-side; surface its result exactly like the Test
@@ -22258,8 +22286,48 @@ function burnAreaChart() {
           renderGovernor(lastData.governor || {}, lastData.cadenceMatrix || [], lastData);
           renderTokens(lastData.tokens || {});
         }
-        fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+        if (savedCadences) {
+          // A cadence-only save has no `general` block, so the optimistic
+          // block above is skipped entirely and nothing repaints the governor
+          // cadence matrix. The matrix is server-derived (cadenceMatrix), so
+          // there is no confirmed value to patch in locally — instead pull the
+          // post-mutation snapshot, which the raised floor guarantees is not a
+          // pre-write one (#5492).
+          refreshStatusUntilFresh();
+        } else {
+          fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+        }
       }
+    }
+
+    // Poll /api/status until a snapshot at or above the stale-snapshot floor
+    // arrives, then render it. The server rebuild kicked by a config write is
+    // asynchronous, so the first refetch usually still returns the cached
+    // pre-write snapshot; render() drops it via the floor guard and this
+    // retries briefly rather than leaving the panel stale until the next
+    // broadcast (#5492).
+    //
+    // This never invents a value: every render is a real server snapshot. If
+    // the rebuild never produces a fresh one, we simply stop retrying and the
+    // regular SSE stream repaints whenever it next delivers — the operator is
+    // never shown an unconfirmed value.
+    var STATUS_FRESH_RETRY_MS = 400;
+    var STATUS_FRESH_MAX_ATTEMPTS = 12;
+    function refreshStatusUntilFresh(attempt) {
+      const n = attempt || 0;
+      fetch('/api/status')
+        .then(r => r.json())
+        .then(data => {
+          // render() itself enforces the floor, but we need to know whether it
+          // took, so test the same condition here before delegating.
+          const seq = (data && data.statusSeq != null) ? Number(data.statusSeq) : null;
+          const stale = seq != null && seq < _statusSeqFloor;
+          if (!stale) { render(data); return; }
+          if (n + 1 < STATUS_FRESH_MAX_ATTEMPTS) {
+            setTimeout(() => refreshStatusUntilFresh(n + 1), STATUS_FRESH_RETRY_MS);
+          }
+        })
+        .catch(() => {});
     }
 
     // --- Chat rich formatting ---


### PR DESCRIPTION
Fixes #5492

## Measured mechanism — it is **neither** the poll intervals **nor** the cache TTLs

The issue's leading hypothesis was the family of 30s poll constants. I measured it, and that is **not** the cause:

- **No `setInterval` anywhere polls `/api/status`.** All 11 `/api/status` call sites are one-shot post-action fetches. The 30s constants (`HISTORY_REFRESH_MS`, `GH_AUTH_POLL_MS`, `NOUS_POLL_MS`, `KB_POLL_MS`, `AUDIT_POLL_MS`, `LEADERBOARD_POLL_MS`) drive unrelated panels and never repaint the ACMM badge or the cadence matrix.
- **The two model-cache TTLs are ruled out definitively.** `INFERENCE_MODEL_CACHE_TTL_MS` and `CLI_MODEL_CACHE_TTL_MS` have exactly one use each, both guarding model-dropdown option lists. Neither is reachable from `updateACMMBadge`, `renderGovernor`, or `renderCadenceMatrix`.
- **SSE already carries both values.** The full-status frame (`source.onmessage` → `render(data)`) carries `acmmLevel` and `cadenceMatrix`. It is the *only* ongoing repaint path for either panel. (The named `agent-status` frame carries neither.)

### The actual cause is a race, not an interval

Both write paths kick an **asynchronous** rebuild and return 200 immediately:

```
handler mutates state
  -> go RefreshFunc()        (asynchronous rebuild)
  -> 200 to the browser
browser refetches GET /api/status
  -> handleStatus serves the CACHED s.status, which the rebuild has
     not replaced yet -> the PRE-mutation snapshot = the OLD value
```

The browser renders that stale snapshot and sits on it until some later broadcast happens to carry the new state. ~30s is simply how long that took to arrive.

`handlePackApply` was worse still: it applied the pack but **never requested a rebuild at all**.

## The fix — reuse the existing #4348 contract, change no interval

#4348 already solved exactly this for the restart counter and the budget window: the handler returns `minStatusSeq` (the lowest `StatusSeq` guaranteed to reflect the mutation) and the frontend's `noteStatusMutation()` raises a floor so pre-mutation snapshots are **discarded rather than rendered**. The frontend guard (`_statusSeqFloor`, index.html:13140) was already written and in place — it simply had no caller on these two paths.

**No poll interval is touched.**

### Server
| Handler | Before | After |
|---|---|---|
| `handleAgentConfigCadences` | `refreshAndPersist()`, returned bare `{"status":"updated"}` | `refreshAndPersistSeq()`, returns `minStatusSeq` |
| `handlePackSetLevel` | `refreshAsync()` — no epoch bump, no floor | `refreshAfterMutationSeq()`, returns `minStatusSeq` |
| `handlePackApply` | **no rebuild at all**, no `packAgents` | `refreshAndPersistSeq()` + `minStatusSeq` + `packAgents` |

### Frontend
- Both ACMM functions set the displayed level from `level` — **the value the browser sent**. They now derive `confirmedLevel` from the response body. The requested value no longer reaches the DOM.
- The cadence save raises the floor from its write ack, **inside the success branch only**.
- A cadence-only save had its entire optimistic re-render skipped (gated on `dirty.general`), so the cadence matrix never repainted. It now pulls the post-mutation snapshot.

## Measured before / after

Harness: `RefreshFunc` given an 800ms rebuild cost, measuring when `/api/status` stops serving the pre-write snapshot.

```
WITHOUT floor: immediately after the 200, /api/status still serves seq 1
               (the PRE-write value). The UI renders the OLD value, and keeps
               rendering it until an unrelated broadcast lands.
WITH floor:    stale snapshots dropped; a snapshot at/above floor 2 appeared
               after 820ms — that is when the UI paints the NEW value.
```

So the stale window closes at **rebuild completion (~820ms here)** instead of persisting until the next incidental broadcast. For the acting browser the ACMM level is confirmed and painted **immediately** on the write response. Other viewers converge on the next full-status SSE frame, which the epoch bump now guarantees is a post-mutation rebuild rather than a possibly-stale one — previously `handlePackSetLevel` bumped no epoch and `handlePackApply` triggered no rebuild at all, so other viewers could be served a stale rebuild indefinitely.

## Not traded a lag for a lie

The floor only causes stale snapshots to be **dropped** — it never fabricates a value. Every render is a real server snapshot or a server-confirmed response field.

- Render is from the **response**, never the request (`confirmedLevel`, not `level`).
- The cadence floor bump sits **after** the `!res.ok` throw, so a failed write never advances it.
- The ACMM error branch `return`s before the render, so a rejected level change leaves the old level on screen with its error message.
- If the rebuild never produces a fresh snapshot, `refreshStatusUntilFresh` simply stops retrying — the panel stays on the last real value rather than showing a hoped-for one.

Two tests cover the failure paths explicitly (`TestCadenceWriteStillSurfacesFailure`, `TestACMMFailedWriteDoesNotRender`).

## Before/after test state

New file: `src/pkg/dashboard/config_write_visibility_test.go` (9 tests).

**Before the fix** — 7 fail, 2 pass:
```
--- PASS: TestStatusSeqFloorAdvancesPastCachedSnapshot
--- FAIL: TestCadenceWriteReturnsStatusSeqFloor
--- FAIL: TestACMMLevelWriteReturnsStatusSeqFloor
--- FAIL: TestACMMOverrideRendersServerConfirmedLevel
--- FAIL: TestPackSetLevelResponseCarriesMinStatusSeq
--- FAIL: TestCadenceHandlerResponseCarriesMinStatusSeq
--- FAIL: TestCadenceWriteStillSurfacesFailure
--- FAIL: TestACMMFailedWriteDoesNotRender
--- PASS: TestStatusHandlerServesCachedSnapshot
```
The 2 that pass before **and** after are deliberate characterization tests: they pin the race itself (a pre-mutation snapshot's seq is below the floor) and the fact that `GET /api/status` serves a cached snapshot with no rebuild. They document *why* the floor is necessary rather than testing the fix.

**After the fix** — all 9 pass, and the full `pkg/dashboard` suite is green.

### Vacuity checks

Given the recent run of vacuous tests in this repo, I verified each assertion can actually fail rather than trusting a green run:

1. **Caught one while writing it.** `TestACMMLevelWriteReturnsStatusSeqFloor` passed *before* the fix — the literal `noteStatusMutation(data.minStatusSeq);` already exists in the unrelated `resetRestarts()` handler, so a whole-file `Contains` matched. Both ACMM tests are now scoped to the enclosing function body via `acmmFuncBody()`.
2. **Per-handler scoping proven.** Reverting **only** `handlePackApply` (leaving `handlePackSetLevel` fixed) fails **only** the `handlePackApply` assertions — a whole-file check would have let one handler satisfy the other.
3. **Per-function scoping proven.** Reverting **only** `setACMMLevel` (leaving `applyACMMPack` fixed) fails only the `setACMMLevel` assertions.
4. **Cadence assertions proven.** Reverting only the cadence floor bump fails both cadence tests.

## Not verified

- **No live-browser run.** There is no JS test harness in this repo (`static/` is a single `index.html`; no jest/playwright), so the frontend assertions are Go source-structure tests in the established `indexHTML(t)` pattern. The JS was not executed — CI is the gate.
- **The 820ms figure is from a synthetic harness** with an injected 800ms rebuild cost, not a production hive. It demonstrates the stale window now closes at rebuild completion; the real-world rebuild cost was not measured.
- **`handlePackSetLevel` refresh became asynchronous.** It previously used `refreshAsync()` (synchronous `RefreshFunc()`); `refreshAfterMutationSeq()` uses `go RefreshFunc()`. The floor makes the client robust to this, and it matches every other mutation handler, but I did not test for a caller depending on the old synchronous timing.
- **`_acmmOverride` remains an unbounded sticky override** that masks server truth until the server agrees. I narrowed what it stores (server-confirmed, not requested) but did not add a timeout or reconciliation warning — that is pre-existing behaviour and out of scope here.