### PR TITLE
🐛 fix(beads): write beads.json group/world-readable so main process can reload

### DIFF
--- a/src/cmd/hive/beads_reload.go
+++ b/src/cmd/hive/beads_reload.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/kubestellar/hive/pkg/beads"
+)
+
+// beadReloadWarner suppresses repeats of an identical per-agent bead-store
+// reload failure. The eval-cycle reload runs forever, so a store the hub
+// cannot read (e.g. a beads.json owned 0600 by a per-agent uid, #5505)
+// produced the SAME warn line every cycle indefinitely — retry spam that
+// buried the one occurrence carrying the actionable repair hint. The first
+// failure per agent logs at WARN; identical repeats demote to DEBUG; a
+// changed error text warns again (new information); success clears the entry
+// so a future regression warns at WARN again. Mirrors the warnDeduper pattern
+// in pkg/agent/permissions_watcher.go.
+type beadReloadWarner struct {
+	mu   sync.Mutex
+	seen map[string]string // agent -> last error text
+}
+
+// shouldWarn records the failure and reports whether it is new (first failure
+// for this agent, or the error text changed since last time).
+func (w *beadReloadWarner) shouldWarn(agent, errText string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.seen == nil {
+		w.seen = make(map[string]string)
+	}
+	if prev, ok := w.seen[agent]; ok && prev == errText {
+		return false
+	}
+	w.seen[agent] = errText
+	return true
+}
+
+// clear forgets an agent's recorded failure so the next one warns at WARN
+// again. Called on a successful reload — the condition changed, so a future
+// failure is a new finding, not a repeat.
+func (w *beadReloadWarner) clear(agent string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.seen, agent)
+}
+
+// beadReloadWarns is the shared dedupe state for reloadBeadStores. Package
+// level because the eval cycle is re-entered as a plain function call.
+var beadReloadWarns = &beadReloadWarner{}
+
+// reloadBeadStores re-reads every agent's bead store from disk (agents write
+// beads via the bd CLI, so in-memory stores go stale between eval cycles),
+// logging each distinct failure once at WARN and identical repeats at DEBUG.
+func reloadBeadStores(beadStores map[string]*beads.Store, logger *slog.Logger) {
+	for name, store := range beadStores {
+		err := store.Reload()
+		if err == nil {
+			beadReloadWarns.clear(name)
+			continue
+		}
+		if beadReloadWarns.shouldWarn(name, err.Error()) {
+			logger.Warn("failed to reload beads from disk",
+				"agent", name,
+				"error", err,
+				"note", "identical repeats logged at debug until this changes",
+			)
+		} else {
+			logger.Debug("failed to reload beads from disk", "agent", name, "error", err)
+		}
+	}
+}

--- a/src/cmd/hive/beads_reload_test.go
+++ b/src/cmd/hive/beads_reload_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/beads"
+)
+
+// TestBeadReloadWarner_DedupesIdenticalFailures pins the dedupe contract: the
+// first failure per agent warns, an identical repeat does not, a changed error
+// text warns again, and clear() (a successful reload) re-arms the WARN.
+func TestBeadReloadWarner_DedupesIdenticalFailures(t *testing.T) {
+	w := &beadReloadWarner{}
+
+	if !w.shouldWarn("supervisor", "permission denied") {
+		t.Error("first failure should warn")
+	}
+	if w.shouldWarn("supervisor", "permission denied") {
+		t.Error("identical repeat should not warn")
+	}
+	if !w.shouldWarn("supervisor", "no such file") {
+		t.Error("changed error text should warn again")
+	}
+	if !w.shouldWarn("scanner", "permission denied") {
+		t.Error("a different agent is an independent key")
+	}
+
+	w.clear("supervisor")
+	if !w.shouldWarn("supervisor", "no such file") {
+		t.Error("after clear, the next failure should warn again")
+	}
+}
+
+// TestReloadBeadStores_WarnsOncePerDistinctError drives the real reload loop
+// against a store whose beads.json read fails persistently (it is a
+// directory), and asserts the retry-spam fix: cycle one logs WARN, cycle two
+// logs the identical failure at DEBUG only. This is the hub-side half of
+// #5505 — one actionable line, not one per eval cycle.
+func TestReloadBeadStores_WarnsOncePerDistinctError(t *testing.T) {
+	beadReloadWarns = &beadReloadWarner{} // isolate from other tests in this package
+	dir := filepath.Join(t.TempDir(), "supervisor")
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	// Make every subsequent load fail the same way: beads.json as a directory.
+	if err := os.Mkdir(filepath.Join(dir, "beads.json"), 0o755); err != nil {
+		t.Fatalf("mkdir beads.json: %v", err)
+	}
+	stores := map[string]*beads.Store{"supervisor": store}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	reloadBeadStores(stores, logger)
+	first := buf.String()
+	if !strings.Contains(first, "failed to reload beads from disk") {
+		t.Fatalf("first cycle should WARN, got log: %q", first)
+	}
+
+	buf.Reset()
+	reloadBeadStores(stores, logger)
+	if repeat := buf.String(); strings.Contains(repeat, "failed to reload beads from disk") {
+		t.Errorf("identical repeat should be demoted below WARN, got log: %q", repeat)
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6378,12 +6378,9 @@ func runEvalCycle(
 
 	// Reload bead stores from disk before building the digest. Agents write
 	// beads via the bd CLI which persists directly to disk, so the in-memory
-	// stores can become stale between eval cycles.
-	for name, store := range beadStores {
-		if err := store.Reload(); err != nil {
-			logger.Warn("failed to reload beads from disk", "agent", name, "error", err)
-		}
-	}
+	// stores can become stale between eval cycles. Reload failures are deduped
+	// (WARN once per distinct error, then DEBUG) — see beads_reload.go (#5505).
+	reloadBeadStores(beadStores, logger)
 
 	// Phase 4 Part B: `plan`/`epic` label trigger. An actionable issue carrying a
 	// plan label auto-mints an epic and requests decomposition — the same flow as

--- a/src/pkg/beads/beads.go
+++ b/src/pkg/beads/beads.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -675,6 +677,36 @@ func (s *Store) UnsetMetadata(id, key string) error {
 
 const beadsFileName = "beads.json"
 
+// beadsFilePerms is the on-disk mode for beads.json: owner+group read/write
+// (0660), matching the shared-node-group FilePerms model used across /data
+// (pkg/agent/permissions_watcher FilePerms=0o660, DirPerms=0o770). Group read
+// is what lets the main hive process reload a store persisted by a per-agent
+// uid (hive-<agent>): a 0600 beads.json makes every hub reload fail with
+// EACCES ("failed to reload beads from disk: open
+// /data/beads/supervisor/beads.json: permission denied" — kubestellar/hive#5505),
+// permanently staling that agent's in-memory store.
+const beadsFilePerms os.FileMode = 0o660
+
+// widenBeadsFileMode ORs the group read/write bits (beadsFilePerms) into an
+// existing beads.json that lacks them — never narrowing owner or other bits,
+// so an already-correct file is left byte-identical. Only the file's owner (or
+// a privileged uid) can chmod, which is exactly the point: an agent's own
+// bd/store processes own the file and repair it here, healing a legacy 0600
+// file for the hub reader without any cross-uid privilege (#5505). Returns the
+// chmod error for the caller that needs to know the repair failed; a nil
+// return with nothing to do is success.
+func widenBeadsFileMode(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	perm := fi.Mode().Perm()
+	if perm&beadsFilePerms == beadsFilePerms {
+		return nil
+	}
+	return os.Chmod(path, perm|beadsFilePerms)
+}
+
 // Reload re-reads beads from disk. Agents write directly to the JSON file
 // via the bd CLI, so the in-memory store can become stale.
 func (s *Store) Reload() error {
@@ -701,9 +733,32 @@ func (s *Store) load() error {
 	if os.IsNotExist(err) {
 		return nil
 	}
+	if errors.Is(err, fs.ErrPermission) {
+		// A beads.json persisted 0600 by an older writer (or narrowed
+		// externally) is unreadable by every other node-group uid, and nothing
+		// else ever repairs it: persist() only runs on mutation (an idle agent
+		// never rewrites), and the permissions watcher deliberately skips files
+		// owned by other non-root uids. Attempt the repair — it succeeds when
+		// this process owns the file — and retry the read once (#5505).
+		if chmodErr := widenBeadsFileMode(path); chmodErr == nil {
+			data, err = os.ReadFile(path)
+		} else {
+			// Unrepairable from this uid. Return ONE actionable error naming
+			// the fix so the caller's log line tells the operator what to do,
+			// instead of a bare "permission denied" every reload cycle.
+			return fmt.Errorf("%s is not readable by uid %d and could not be repaired (%v); run `chmod g+rw %s` as the file's owner: %w",
+				path, os.Getuid(), chmodErr, path, err)
+		}
+	}
 	if err != nil {
 		return err
 	}
+
+	// Self-heal a readable-but-narrow file (e.g. this process owns a legacy
+	// 0600 beads.json): widen it so OTHER node-group uids — the main hive
+	// process reloading this store — can read it too. Best-effort: a chmod this
+	// uid is not permitted to make is not a load failure; the data was read.
+	_ = widenBeadsFileMode(path)
 
 	var beads []*Bead
 	if err := json.Unmarshal(data, &beads); err != nil {
@@ -797,11 +852,12 @@ func (s *Store) persist(_ *Bead) error {
 		return fmt.Errorf("creating tmp beads file: %w", err)
 	}
 	tmpPath := tmp.Name()
-	// 0660 (group-writable) so a bead file created by one node-group member can be
-	// rewritten by another (e.g. the architect agent and the dashboard both write
-	// the architect store). Matches the /data/home/* FilePerms model. CreateTemp
-	// makes 0600, so widen explicitly.
-	_ = tmp.Chmod(0660)
+	// beadsFilePerms (0660, group-writable) so a bead file created by one
+	// node-group member can be rewritten by another (e.g. the architect agent
+	// and the dashboard both write the architect store) and READ by the main
+	// hive process reloading the store as a different uid (#5505). Matches the
+	// /data/home/* FilePerms model. CreateTemp makes 0600, so widen explicitly.
+	_ = tmp.Chmod(beadsFilePerms)
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()        // best-effort cleanup; the write error is what's returned
 		_ = os.Remove(tmpPath) // best-effort cleanup; the write error is what's returned

--- a/src/pkg/beads/beads_perms_test.go
+++ b/src/pkg/beads/beads_perms_test.go
@@ -96,6 +96,52 @@ func TestNewStore_PinsDirGroupToCreatorEgid(t *testing.T) {
 	}
 }
 
+// TestReload_WidensNarrowedBeadsFile verifies the #5505 self-heal: a beads.json
+// narrowed to 0600 (legacy writer, external chmod) is widened back to include
+// the group read/write bits on the next load, by the uid that owns it. This is
+// what un-wedges the live failure — a per-agent-owned 0600 file that the main
+// hive process could never read ("failed to reload beads from disk: ...
+// permission denied") and that nothing else repairs, because persist() only
+// runs on mutation and the permissions watcher skips foreign-uid files.
+func TestReload_WidensNarrowedBeadsFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "beads", "supervisor")
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if _, err := s.Create("finding", TypeAdvisory, PriorityLow, "supervisor", ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	fpath := filepath.Join(dir, beadsFileName)
+	// Reproduce the broken fleet state: owner-only file, no group access.
+	if err := os.Chmod(fpath, 0o600); err != nil {
+		t.Fatalf("chmod 0600: %v", err)
+	}
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	fi, err := os.Stat(fpath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm&beadsFilePerms != beadsFilePerms {
+		t.Errorf("beads file mode = %o after Reload, want group rw restored (>= %o)", perm, beadsFilePerms)
+	}
+	// The widen must never narrow what the owner already had.
+	if perm := fi.Mode().Perm(); perm&0o600 != 0o600 {
+		t.Errorf("beads file mode = %o after Reload, owner rw bits were narrowed", perm)
+	}
+	if got := s.Count(); got != 1 {
+		t.Errorf("Reload lost data: count = %d, want 1", got)
+	}
+}
+
 // umaskAllowsGroupWrite reports whether the process umask leaves the group-write
 // bit (0020) unmasked, so a group-writable create can actually land it. It reads
 // and restores the umask non-destructively.


### PR DESCRIPTION
## Problem

From a fleet audit — the main hive process on spoke bluefin logs, on every governor eval cycle:

```
failed to reload beads from disk: open /data/beads/supervisor/beads.json: permission denied
```

The file is mode `0600` owned by the per-agent user `hive-supervisor`; the reader runs as a different uid in the shared `node` group. The supervisor's in-memory store is permanently stale on the hub, and the identical WARN repeats forever.

`persist()` already chmods new writes to `0660`, but nothing ever repairs an existing narrow file: persist only runs on mutation (an idle/blocked agent never rewrites), and the permissions watcher deliberately skips files owned by other non-root uids (`pkg/agent/permissions_watcher.go` fixEntry guard), so a `hive-<agent>`-owned `0600` beads.json stays broken indefinitely.

## Fix

- **Named mode constant** `beadsFilePerms = 0o660` in `src/pkg/beads/beads.go`, matching the established shared-node-group `FilePerms` convention (`pkg/agent` `FilePerms=0o660` / `DirPerms=0o770`, the `/data/home/*` model) — group read is what the hub reader needs; `persist()` now uses the constant.
- **Self-heal on load/Reload** (`Store.load`): after a successful read, widen a file lacking the group r/w bits (OR-only, never narrows owner/other bits) — the owning agent's own `bd`/store processes repair the file for the hub. On EACCES: attempt the chmod, retry the read once, otherwise return a single actionable error naming the repair (`chmod g+rw <path>` as the owner) instead of a bare `permission denied`.
- **Retry-spam fix** (`src/cmd/hive/beads_reload.go`): the eval-cycle reload loop now dedupes failures — WARN once per distinct (agent, error), DEBUG on identical repeats, re-armed when the reload succeeds or the error changes. Mirrors the `warnDeduper` pattern already in `pkg/agent/permissions_watcher.go`.

## Tests

- `TestReload_WidensNarrowedBeadsFile` (pkg/beads): a store whose beads.json was narrowed to `0600` gets group r/w restored on `Reload()`, owner bits untouched, no data loss.
- `TestBeadReloadWarner_DedupesIdenticalFailures` / `TestReloadBeadStores_WarnsOncePerDistinctError` (cmd/hive): the reload loop warns once for a persistent failure, not once per cycle.

Fixes #5505
