### PR TITLE
🧪 formal: Spin model of escalation + reviewer-lane lifecycle

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -1,0 +1,35 @@
+name: Formal Verify
+
+# Exhaustively re-verifies the Spin model of the escalation + reviewer-lane
+# lifecycle (src/formal/escalation/) whenever the modeled Go code or the model
+# itself changes. Reporting-only: this check is intentionally NOT required.
+# The run fails when a property that must hold is violated, or when a
+# documented counterexample (known design gap) can no longer be reproduced —
+# both mean the model and the code have drifted apart and a human should look.
+on:
+  pull_request:
+    paths:
+      - 'src/pkg/escalation/**'
+      - 'src/pkg/scheduler/reviewer_lane*'
+      - 'src/formal/**'
+      - '.github/workflows/formal-verify.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  escalation:
+    name: formal-verify (escalation)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Spin
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y spin
+
+      - name: Verify escalation lifecycle model
+        run: bash src/formal/escalation/run.sh

--- a/src/formal/escalation/README.md
+++ b/src/formal/escalation/README.md
@@ -1,0 +1,174 @@
+# Formal model: escalation + reviewer-lane lifecycle
+
+A Spin (Promela) model of the fix-loop escalation machinery and the reviewer
+adjudication lane, at the protocol level: one hive-authored PR's lifecycle as
+nine interacting processes. It verifies the invariants the code comments
+promise — and pins down, with minimized counterexamples, the places where the
+shipped machinery does not deliver them.
+
+The model targets the **post-#5485** machinery (v5 with the reviewer lane,
+#5480, merged; machinery-generation amnesty, #5471).
+
+Run everything:
+
+```console
+$ bash run.sh        # requires spin + a C compiler; ~1 minute
+```
+
+`run.sh` runs every property exhaustively and compares each verdict against
+its expected result. Properties that must hold must pass; properties with a
+**documented counterexample** (the design gaps below) must still *fail* — if
+one stops failing, the code or the model changed and a human must re-check.
+Either divergence exits nonzero. CI runs this via
+`.github/workflows/formal-verify.yml` (reporting-only, not a required check).
+
+## Model ↔ code mapping
+
+| Promela | Go |
+|---|---|
+| `Sweeper` proctype | `runEscalationSweep` (`cmd/hive/main.go`) driving `Store.Sweep` (`pkg/escalation/escalation.go`) once per governor tick |
+| `Reaper` proctype | `reapStuckRedPRs` (`cmd/hive/main.go`) → `Store.TryReEngage` |
+| `Agent` proctype | the FIX-BEFORE-NEW fix lane (`pkg/scheduler/scheduler.go:834-893`): red, non-escalated PRs are routed back to their author agent, which pushes another attempt |
+| `Reviewer` proctype | the reviewer lane (`pkg/scheduler/reviewer_lane.go`): adjudicates escalated rows from `ci-failing.json`, excluding rows labeled `reviewer-passed`; REPAIR and DE-ESCALATE are collapsed into one branch (both = label swap + push); RECOMMEND-CLOSE closes at ACMM ≥ 6 (`-DACMM6`), else comments and stands down |
+| `Human` proctype | the operator watching the `needs-human` label queue; eventually takes ownership or closes. **The queue is the label** — a PR without `needs-human` is invisible to the human |
+| `CI` proctype | per-SHA check verdict: each pushed SHA resolves nondeterministically red or green, once |
+| `Merger` proctype | the auto-merge sweep: a green open PR is eventually merged |
+| `Timer` proctype | wall clock for `Store.StaleRed`: the tracked `CurRedSHA`, unchanged, eventually exceeds `RedPRStaleAfter` |
+| `GenBumper` proctype | `MachineryVersion` bumps (a new fix-dispatch generation ships) |
+| `MergeWatcher` proctype (`-DWATCHER`) | the merge-request watcher's terminal re-engage path (`pkg/github/merge_request_watcher.go:276`) |
+| `entryExists`, `attempts`, `escalated`, `curRedSha`, `reeng`, `entryGen` | `escalation.Entry`: existence in the ledger, `len(RedSHAs)`, `Escalated`, `CurRedSHA`, `ReEngagements`, `Machinery` |
+| `headCounted` | `containsSHA(e.RedSHAs, o.HeadSHA)` for the current head (sound: SHAs are never reused, so only the current head's membership is ever queried) |
+| `stale` | `now − e.FirstRedAt ≥ RedPRStaleAfter` (`Store.StaleRed`) |
+| `escalatedView` | the `escalatedPRs` map returned by `runEscalationSweep` and consumed same-tick by `reapStuckRedPRs` and `writeMergeEligible` (`ci-failing.json` `row.Escalated`); refreshed at the end of each sweep pass |
+| `needsHuman`, `reviewerPassed` | the `needs-human` / `reviewer-passed` labels on the forge |
+| `amnesty_check()` inline | the machinery-amnesty block shared by `Store.Sweep` (escalation.go:181-186) and `Store.TryReEngage` (escalation.go:372-377) |
+| `THRESHOLD=3`, `MAX_REENG=6` | `DefaultThreshold`, `MaxReEngagements` (actual production constants) |
+| `NSHA=4`, `GEN_MAX=3` | finite bounds: distinct head SHAs per PR, machinery generations |
+
+Faithfully carried quirks: `Store.TryReEngage` creates missing entries as
+`&Entry{}` (Machinery **0**, → immediate no-op amnesty), while `Store.Sweep`
+creates them with `Machinery: MachineryVersion`; `Sweep`'s green branch is
+`!o.Red`, which **includes CI-pending observations** (see gap G2); the
+reviewer edits labels only — the ledger's `Escalated` flag is untouched (gap
+G1); `TryReEngage` never consults `Escalated` (gap G3).
+
+## What is abstracted away
+
+- **One PR.** All properties are per-PR; the ledger's cross-PR pruning
+  (`seen` map) reduces to "clear on close/merge". `maxTrackedSHAs=20` is
+  unreachable at `NSHA=4`.
+- **SHAs are ordinals.** Pushes mint strictly increasing SHA ids; a SHA's CI
+  verdict resolves once (a flake re-run would be a new push). Rebases and
+  repairs are pushes.
+- **Time is nondeterminism.** Sweep cadence, `RedPRStaleAfter`, and CI
+  latency are unordered events; every interleaving is explored, which is
+  strictly more behavior than any real timing.
+- **Evidence/comments/ntfy** (excerpts, `CommentBody`, notifications) carry
+  no protocol state and are dropped. `MarkEscalated`'s comment-retry loop is
+  collapsed into the escalation step.
+- **ObserveRed** (`recordRedStaleness`) is folded into `Timer` + the sweep's
+  SHA sync; its entry-creation path is represented by `TryReEngage`'s
+  (both create `&Entry{}` with Machinery 0).
+- **ACMM** is fixed at 5 (lane active) — below 5 the reviewer is a no-op and
+  every property reduces to the pre-#5480 machinery; `-DACMM6` models
+  close authority.
+- Property monitors are compiled in per run (`-DMON_*`) so each exhaustive
+  search carries only the instrumentation it needs; monitor counters saturate
+  at the bounds they are compared against.
+
+## Verification results
+
+Spin 6.5.2, exhaustive (`./pan -m500000`, DFS + COLLAPSE; liveness with weak
+fairness `-a -f`). Every state count is a completed full search.
+
+| # | Property | Run(s) | Result | States |
+|---|---|---|---|---|
+| P1 | Amnesty is one-shot per generation (per entry lifetime) | `p1_p2_amnesty` (assert in `amnesty_check`) | **holds** | 5,598,270 |
+| P2 | No instant re-escalation after amnesty: never in the amnesty pass itself, and only with ≥ `THRESHOLD−1` genuinely new red SHAs or a full fresh re-engage budget | `p1_p2_amnesty` (asserts P2a/P2b) | **holds** | 5,598,270 |
+| P3 | Re-engage budget: `ReEngagements ≤ 6` always; per unchanged red SHA, total ≤ (1 + amnesties) × 6 — i.e. ≤ 12 across one generation bump, ≤ 18 across the 3 modeled generations | `p3_budget_asserts`, `p3_cap_ltl`, `p3_total_ltl` | **holds** | 10,374,648 / 2,100,236 / 10,374,648 |
+| P4a | Once `reviewer-passed`, the reviewer never adjudicates the PR again | `p4a_p6_safety` (assert) | **holds** | 2,100,236 |
+| P4b | …and such a PR, if (still) escalated, eventually reaches the human queue | `p4b_handoff` (LTL, weak fairness) | **VIOLATED — gap G1** | cycle at 7,207 |
+| P5 | Every escalated PR eventually terminal (merged / closed / human-owned) | `p5_termination` (LTL, weak fairness) | **VIOLATED — gap G1** | cycle at 5,169 |
+| P5′ | P5 and P4b under the hypothetical ledger-sync fix | `patch_p5_termination`, `patch_p4b_handoff` (`-DPATCH_REVIEWER`) | **hold** | 2,104,638 / 2,098,622 |
+| P6 | Escalated entries are invisible to the reaper and to FIX-BEFORE-NEW | `p4a_p6_safety`, `p6_watcher_safety` (asserts) | **holds** | 2,100,236 / 20,749,779 |
+| W1 | "One reviewer pass per PR, ever" for RECOMMEND-CLOSE below ACMM 6 | `w_onepass_acmm5` / `w_onepass_acmm6` | **witness found** at ACMM 5 (holds at ACMM 6, 2,140,106 states) — gap G4 | 4,113 |
+| W2 | Ledger history survives until green | `w_pending_wipe` | **witness found** — gap G2 | 4,636 |
+| W3 | The merge watcher never re-engages an escalated PR | `w_watcher_reengage` (`-DWATCHER`) | **witness found** — gap G3 | 207,685 |
+
+## Design gaps found
+
+### G1 — a reviewer pass on a PR that stays red orphans it (REAL, liveness)
+
+`Entry.Escalated` is cleared only by: the PR going green (entry deleted), the
+PR leaving the open set, or machinery amnesty. The reviewer's verdicts edit
+**labels only**. Minimized counterexample (`spin -t -p` on `p5_termination`):
+
+1. Three distinct red SHAs → `Sweep` escalates: `Escalated=true`,
+   `needs-human` added.
+2. The reviewer REPAIRs (or DE-ESCALATEs): removes `needs-human`, adds
+   `reviewer-passed`, pushes a fix SHA.
+3. The fix resolves **red**.
+4. Now: the ledger still says `Escalated` → the row is excluded from
+   FIX-BEFORE-NEW and the reaper; `reviewer-passed` excludes it from the
+   reviewer lane; `NewlyEscala` requires `!e.Escalated`, so the `needs-human`
+   label (and ntfy) can never fire again — the human queue never sees it.
+   The PR sits red and open forever, owned by nobody.
+
+The escalation comment's promise — "Remove the `needs-human` label … to
+return the PR to the automated fix lane" — is broken by the same root cause:
+the lane consults the ledger flag, not the label, so a human removing the
+label (without the PR reaching green) also does not re-enable the fix lane.
+
+Two nondeterministic rescues exist, and neither is a guarantee: a later
+`MachineryVersion` bump (amnesty un-escalates the ledger), or gap G2's
+pending-wipe happening to fire during the fix's CI window. The model shows
+runs where neither occurs.
+
+`-DPATCH_REVIEWER` verifies the obvious fix shape: when the reviewer removes
+`needs-human`, also reset the ledger (`Escalated=false`, `RedSHAs=nil` — the
+same reset amnesty performs). With that, P4b and P5 hold: a still-red repair
+re-enters the fix lane, re-escalates on fresh evidence, `NewlyEscala`
+re-fires, and the `reviewer-passed` exclusion hands it to the human.
+
+### G2 — a CI-pending observation wipes the attempt ledger (REAL, counting)
+
+`Store.Sweep` branches on `!o.Red`, and `runEscalationSweep` computes
+`Red: pr.CIStatus == "failure"` — so a **pending** observation (every fresh
+push has a pending window) takes the "went green" branch and **deletes the
+entry**, discarding the distinct-SHA attempt count. A PR that always happens
+to be enumerated mid-window restarts its count every time and can evade the
+threshold indefinitely (witness `w_pending_wipe`). In practice sweeps usually
+catch settled states, which is why escalation still fires — but the breaker
+is probabilistic where the code intends it to be deterministic. (This wipe is
+also what accidentally rescues some G1 orphans.) A fix would treat pending as
+a no-op observation: only green clears, only red counts.
+
+### G3 — the merge watcher re-engages escalated PRs (minor)
+
+`Store.TryReEngage` never checks `Entry.Escalated`, and the merge-request
+watcher's terminal path (`merge_request_watcher.go:276`) calls it without
+consulting the escalated set (unlike `reapStuckRedPRs`, which does). A merge
+request filed before escalation that exhausts its attempts on a red required
+check therefore burns re-engagement budget on a `needs-human` PR and logs
+"re-engaged fix loop" for a PR the fix loop is standing down from. Benign in
+effect — the dispatch surfaces (FIX-BEFORE-NEW, reaper) still exclude
+escalated rows, and P3/P6 hold in the `-DWATCHER` build — but the counter and
+the log line lie, and a budget burned this way can later trigger an
+exhaustion-based re-escalation path prematurely after amnesty.
+
+### G4 — RECOMMEND-CLOSE below ACMM 6 re-adjudicates every kick (minor)
+
+The work-list builder's "one reviewer pass per PR, ever" holds only for
+REPAIR/DE-ESCALATE, because only those add `reviewer-passed`. Below ACMM 6, a
+RECOMMEND-CLOSE verdict leaves the row fully adjudicable, so the reviewer
+re-adjudicates (and re-comments) it on every kick until a human acts
+(witness `w_onepass_acmm5`; at ACMM 6 the close is immediate and the
+invariant holds). A fix would label or otherwise mark recommend-closed rows.
+
+## Reproducing a counterexample
+
+```console
+$ spin -a escalation.pml && gcc -O2 -DNFAIR=12 -o pan pan.c
+$ ./pan -a -f -i -N p5_term        # -i: iteratively shorten the trail
+$ spin -t -p -g escalation.pml     # replay with state annotations
+```

--- a/src/formal/escalation/escalation.pml
+++ b/src/formal/escalation/escalation.pml
@@ -1,0 +1,467 @@
+/*
+ * escalation.pml — protocol-level Spin model of the hive fix-loop escalation
+ * lifecycle and the reviewer adjudication lane (post-#5485 machinery).
+ *
+ * Models ONE hive-authored PR interacting with:
+ *   Sweeper   — runEscalationSweep + Store.Sweep     (cmd/hive/main.go, pkg/escalation)
+ *   Reaper    — reapStuckRedPRs + Store.TryReEngage  (cmd/hive/main.go, pkg/escalation)
+ *   Agent     — FIX-BEFORE-NEW fix lane pushes        (pkg/scheduler/scheduler.go)
+ *   Reviewer  — reviewer lane adjudication            (pkg/scheduler/reviewer_lane.go)
+ *   Human     — owner of the needs-human label queue
+ *   CI        — per-SHA red/green verdicts
+ *   Merger    — merges green PRs
+ *   GenBumper — MachineryVersion bumps (amnesty generations)
+ *
+ * See README.md in this directory for the model <-> code mapping, the list of
+ * abstractions, and the verification results.
+ *
+ * Property-specific instrumentation is compiled in per run (see run.sh) so
+ * each exhaustive verification only carries the monitor state it needs:
+ *   -DMON_AMNESTY  — P1 (one-shot amnesty) + P2 (no instant re-escalation)
+ *   -DMON_BUDGET   — P3 (re-engagement budget bounds)
+ *   -DMON_ADJ      — witness w_onepass (repeat adjudication below ACMM 6)
+ *   -DMON_PENDING  — witness w_pending (ledger wipe on a PENDING observation)
+ *   -DWATCHER      — merge-request watcher re-engage path + witness w_watcher
+ *                    (pkg/github/merge_request_watcher.go:276)
+ *   -DACMM6        — reviewer may close after recommend-close (level >= 6)
+ *   -DPATCH_REVIEWER — hypothetical fix: a reviewer pass also resets the
+ *                    LEDGER (Escalated/RedSHAs), not only the labels; shows
+ *                    the P4b/P5 counterexample is closed by that sync.
+ */
+
+#define NSHA        4   /* distinct head SHAs a PR may ever have (bounded pushes) */
+#define THRESHOLD   3   /* escalation.DefaultThreshold */
+#define MAX_REENG   6   /* escalation.MaxReEngagements */
+#define GEN_MAX     3   /* machinery generations modeled (MachineryVersion bumps) */
+
+/* CI verdict of the current head SHA */
+#define CI_PENDING  0
+#define CI_RED      1
+#define CI_GREEN    2
+
+/* PR lifecycle */
+#define PR_OPEN     0
+#define PR_MERGED   1
+#define PR_CLOSED   2
+#define PR_HUMAN    3   /* a human took ownership out-of-band (terminal) */
+
+#define TERMINAL    (prState != PR_OPEN)
+
+/* ---------------- forge / PR state ---------------- */
+byte ci      = CI_PENDING;
+byte prState = PR_OPEN;
+byte minted  = 1;   /* SHAs minted so far; the CURRENT head SHA id is always
+                     * the most recently minted one (SHAs strictly increase) */
+
+bool needsHuman     = false;  /* escalation.NeedsHumanLabel on the PR */
+bool reviewerPassed = false;  /* scheduler.ReviewerPassedLabel on the PR */
+
+/* ---------------- escalation ledger (escalation.Entry) ---------------- */
+bool entryExists = false;
+bool headCounted = false;  /* containsSHA(Entry.RedSHAs, head): whether the
+                            * CURRENT head SHA is already in RedSHAs. Sound
+                            * reduction: head SHAs are never reused, so only
+                            * the current head's membership is ever queried. */
+byte attempts    = 0;      /* len(Entry.RedSHAs) */
+bool escalated   = false;  /* Entry.Escalated */
+byte curRedSha   = 0;      /* Entry.CurRedSHA (0 = unset) */
+bool stale       = false;  /* now - Entry.FirstRedAt >= RedPRStaleAfter */
+byte reeng       = 0;      /* Entry.ReEngagements */
+byte entryGen    = 0;      /* Entry.Machinery (Go zero value 0 on &Entry{}) */
+
+byte gen = 1;              /* escalation.MachineryVersion (current generation) */
+
+/* escalatedPRs map handed by runEscalationSweep to reapStuckRedPRs and to
+ * writeMergeEligible (ci-failing.json row.Escalated). Refreshed by the sweep. */
+bool escalatedView = false;
+
+/* ---------------- property monitors (instrumentation, not machinery) ------ */
+#ifdef MON_AMNESTY
+bool amnestiedAtGen[GEN_MAX + 1];  /* per entry LIFETIME; cleared on delete */
+bool amnestyThisPass   = false;    /* an amnesty fired in the current sweep pass */
+bool amnestyLive       = false;    /* some amnesty happened this entry lifetime */
+byte newShaSinceAmnesty = 0;       /* distinct-SHA appends after the amnesty pass
+                                    * (saturates at THRESHOLD) */
+#endif
+#ifdef MON_BUDGET
+byte totalReengThisSha = 0;  /* successful re-engagements for the current red
+                              * SHA, NOT reset by amnesty (only by SHA change /
+                              * entry delete); saturates just past its bound */
+byte amnestiesThisSha  = 0;  /* amnesties granted while current red SHA unchanged */
+#endif
+#ifdef MON_ADJ
+byte adjudications = 0;      /* reviewer adjudication passes (saturates at 2) */
+#endif
+#ifdef MON_PENDING
+bool wipedPendingWithHistory = false; /* witness: sweep deleted a non-empty entry
+                                       * on a PENDING (not green) observation */
+#endif
+#ifdef WATCHER
+bool mergeReqPending           = false; /* a stale merge request sits in the watcher dir */
+bool watcherReEngagedEscalated = false; /* witness: watcher burned re-engage budget
+                                         * on an escalated (needs-human) PR */
+#endif
+
+/* ---------------- ledger helpers ---------------- */
+
+/* Sweep's delete(s.entries, key): green convergence, or prune on close/merge. */
+inline entry_clear() {
+	entryExists = false;
+	headCounted = false; attempts = 0;
+	escalated = false;
+	curRedSha = 0; stale = false; reeng = 0;
+	entryGen = 0;
+#ifdef MON_AMNESTY
+	amnestiedAtGen[0] = false; amnestiedAtGen[1] = false;
+	amnestiedAtGen[2] = false; amnestiedAtGen[3] = false;
+	amnestyLive = false; amnestyThisPass = false;
+	newShaSinceAmnesty = 0;
+#endif
+#ifdef MON_BUDGET
+	totalReengThisSha = 0; amnestiesThisSha = 0;
+#endif
+}
+
+/* Machinery amnesty — the shared block in Store.Sweep (escalation.go:181-186)
+ * and Store.TryReEngage (escalation.go:372-377):
+ *   if e.Machinery < MachineryVersion {
+ *       e.Machinery = MachineryVersion; e.ReEngagements = 0
+ *       e.Escalated = false;            e.RedSHAs = nil
+ *   }
+ */
+inline amnesty_check() {
+	if
+	:: entryGen < gen ->
+#ifdef MON_AMNESTY
+		/* P1: one-shot per generation, per entry lifetime. Amnesty stamps
+		 * entryGen = gen and gen is monotonic, so a second amnesty at the
+		 * same generation for the same (undeleted) entry is unreachable. */
+		assert(!amnestiedAtGen[gen]);
+		amnestiedAtGen[gen] = true;
+		amnestyThisPass = true;
+		amnestyLive = true;
+		newShaSinceAmnesty = 0;
+#endif
+#ifdef MON_BUDGET
+		if
+		:: amnestiesThisSha < GEN_MAX -> amnestiesThisSha++
+		:: else -> skip
+		fi;
+#endif
+		entryGen = gen;
+		reeng = 0;
+		escalated = false;
+		headCounted = false; attempts = 0  /* RedSHAs = nil */
+	:: else -> skip
+	fi
+}
+
+/* Store.TryReEngage (escalation.go:352-385). obsSha == 0 models the merge
+ * watcher's empty head SHA ("reuse the tracked red SHA"). Sets ok. */
+inline try_reengage(obsSha, ok) {
+	if
+	:: !entryExists -> entryExists = true; entryGen = 0  /* &Entry{}: Machinery=0 */
+	:: else -> skip
+	fi;
+	if
+	:: obsSha != 0 && obsSha != curRedSha ->  /* branch moved: sync + reset */
+		curRedSha = obsSha; stale = false; reeng = 0;
+#ifdef MON_BUDGET
+		totalReengThisSha = 0; amnestiesThisSha = 0;
+#endif
+	:: else -> skip
+	fi;
+	amnesty_check();
+	if
+	:: reeng >= MAX_REENG -> ok = false
+	:: else ->
+		reeng++;
+		/* P3a: the per-SHA budget cap holds at every increment site. */
+		assert(reeng <= MAX_REENG);
+#ifdef MON_BUDGET
+		if
+		:: totalReengThisSha <= GEN_MAX * MAX_REENG -> totalReengThisSha++
+		:: else -> skip
+		fi;
+		/* P3b: total nudges for one unchanged red SHA never exceed one full
+		 * budget per amnesty granted while that SHA was current (+1 initial). */
+		assert(totalReengThisSha <= (amnestiesThisSha + 1) * MAX_REENG);
+#endif
+		ok = true
+	fi
+}
+
+/* ---------------- processes ---------------- */
+
+/* One Store.Sweep pass over this PR's observation, as driven by
+ * runEscalationSweep (main.go:7631). Red := (CIStatus == "failure"), so a
+ * PENDING observation takes the !o.Red branch and DELETES the entry — modeled
+ * faithfully; see witness w_pending. The escalatedPRs view consumed by the
+ * reaper and by ci-failing.json is refreshed at the end of the pass, matching
+ * the same-tick ordering sweep -> writeMergeEligible -> reap in main.go. */
+active proctype Sweeper() {
+	do
+	:: atomic { prState == PR_OPEN ->
+#ifdef MON_AMNESTY
+		amnestyThisPass = false;
+#endif
+		if
+		:: ci != CI_RED ->   /* green OR pending: Go's !o.Red -> delete entry */
+#ifdef MON_PENDING
+			if
+			:: entryExists && ci == CI_PENDING && attempts > 0 ->
+				wipedPendingWithHistory = true
+			:: else -> skip
+			fi;
+#endif
+			entry_clear()
+		:: else ->
+			if
+			:: !entryExists ->  /* &Entry{Machinery: MachineryVersion} */
+				entryExists = true; entryGen = gen
+			:: else -> skip
+			fi;
+			amnesty_check();
+			if
+			:: !headCounted ->  /* unseen red SHA: append to RedSHAs */
+				headCounted = true;
+				attempts++;
+#ifdef MON_AMNESTY
+				if
+				:: amnestyLive && !amnestyThisPass && newShaSinceAmnesty < THRESHOLD ->
+					newShaSinceAmnesty++
+				:: else -> skip
+				fi
+#endif
+			:: else -> skip
+			fi;
+			if
+			:: minted != curRedSha ->  /* branch moved: reset staleness + budget */
+				curRedSha = minted; stale = false; reeng = 0;
+#ifdef MON_BUDGET
+				totalReengThisSha = 0; amnestiesThisSha = 0;
+#endif
+			:: else -> skip
+			fi;
+			if
+			:: !escalated && (attempts >= THRESHOLD || reeng >= MAX_REENG) ->
+				/* NewlyEscala: comment + needs-human label + MarkEscalated */
+#ifdef MON_AMNESTY
+				/* P2a: escalation never fires in the pass that granted amnesty. */
+				assert(!amnestyThisPass);
+				/* P2b: post-amnesty escalation needs THRESHOLD-1 genuinely new
+				 * red SHAs, or a full fresh re-engagement budget (amnesty and
+				 * SHA changes both zero `reeng`, so reeng >= MAX_REENG here
+				 * implies every one of those nudges fired post-amnesty) —
+				 * never zero post-amnesty evidence. */
+				if
+				:: amnestyLive ->
+					assert(newShaSinceAmnesty >= THRESHOLD - 1
+					       || reeng >= MAX_REENG)
+				:: else -> skip
+				fi;
+#endif
+				escalated = true;
+				needsHuman = true
+			:: else -> skip
+			fi
+		fi;
+		escalatedView = escalated }
+	:: atomic { TERMINAL ->  /* PR left the open set: prune (Sweep's seen map) */
+		entry_clear(); escalatedView = false; break }
+	od
+}
+
+/* CI resolves the pending verdict of the current head SHA, nondeterministically
+ * red or green. One resolution per SHA; a flake retry would be a new push. */
+active proctype CI() {
+	do
+	:: atomic { prState == PR_OPEN && ci == CI_PENDING ->
+		if
+		:: ci = CI_RED
+		:: ci = CI_GREEN
+		fi }
+	:: TERMINAL -> break
+	od
+}
+
+/* Wall clock for Store.StaleRed: the current red SHA has gone unchanged for
+ * RedPRStaleAfter. Only the tracked CurRedSHA can turn stale (StaleRed
+ * requires e.CurRedSHA == headSHA). */
+active proctype Timer() {
+	do
+	:: atomic { prState == PR_OPEN && ci == CI_RED && minted == curRedSha && !stale ->
+		stale = true }
+	:: TERMINAL -> break
+	od
+}
+
+/* The fix lane: FIX-BEFORE-NEW (scheduler.go:834-893) routes red PRs back to
+ * their author agent, which pushes another fix attempt (a new head SHA).
+ * Escalated rows are skipped: `if pr.Escalated { continue }` — row.Escalated
+ * is the ledger verdict carried through ci-failing.json. */
+active proctype Agent() {
+	do
+	:: atomic { prState == PR_OPEN && ci == CI_RED && !escalatedView && minted < NSHA ->
+		/* P6b: the fix lane never observes (acts on) an escalated entry. */
+		assert(!escalated);
+		minted++; headCounted = false; ci = CI_PENDING; stale = false }
+	:: TERMINAL -> break
+	od
+}
+
+/* reapStuckRedPRs (main.go:7590): red + stale + not escalated -> TryReEngage.
+ * The escalated check reads the same-tick escalatedPRs map from the sweep. */
+active proctype Reaper() {
+	bool ok;
+	do
+	:: atomic { prState == PR_OPEN && ci == CI_RED && !escalatedView && stale && minted == curRedSha ->
+		/* P6a: the reaper never observes (acts on) an escalated entry. */
+		assert(!escalated);
+		try_reengage(minted, ok) }
+	:: TERMINAL -> break
+	od
+}
+
+/* Reviewer lane (reviewer_lane.go, ACMM >= 5): adjudicates escalated rows from
+ * ci-failing.json, excluding rows already labeled reviewer-passed. REPAIR and
+ * DE-ESCALATE are indistinguishable at this abstraction (label swap + push);
+ * RECOMMEND-CLOSE closes at ACMM >= 6 (-DACMM6), else comments and leaves
+ * needs-human in place. */
+active proctype Reviewer() {
+	do
+	:: atomic { prState == PR_OPEN && ci == CI_RED && escalatedView && !reviewerPassed ->
+		/* P4a: a PR carrying reviewer-passed is never adjudicated again. */
+		assert(!reviewerPassed);
+#ifdef MON_ADJ
+		if
+		:: adjudications < 2 -> adjudications++
+		:: else -> skip
+		fi;
+#endif
+		if
+		:: minted < NSHA ->  /* REPAIR / DE-ESCALATE: fix or rebase, push, relabel */
+			reviewerPassed = true;
+			needsHuman = false;
+#ifdef PATCH_REVIEWER
+			/* Hypothetical fix under test: the label edit also resets the
+			 * LEDGER escalation state, the way TryReEngage's amnesty does,
+			 * so a still-red outcome re-enters the automated lane and can
+			 * re-escalate (NewlyEscala requires !Entry.Escalated). */
+			escalated = false;
+			headCounted = false; attempts = 0;
+			escalatedView = false;
+#endif
+			minted++; headCounted = false; ci = CI_PENDING; stale = false
+		:: true ->           /* RECOMMEND-CLOSE */
+#ifdef ACMM6
+			prState = PR_CLOSED
+#else
+			skip  /* comment posted; needs-human stays; a human closes/owns it */
+#endif
+		fi }
+	:: TERMINAL -> break
+	od
+}
+
+/* The human owner of the needs-human queue: eventually takes over (out-of-band
+ * ownership) or closes. The queue IS the label — a PR without needs-human is
+ * invisible to the human. */
+active proctype Human() {
+	do
+	:: atomic { prState == PR_OPEN && needsHuman ->
+		if
+		:: prState = PR_HUMAN
+		:: prState = PR_CLOSED
+		fi }
+	:: TERMINAL -> break
+	od
+}
+
+/* Merges a green PR (label-queued auto-merge sweep / merge watcher). */
+active proctype Merger() {
+	do
+	:: atomic { prState == PR_OPEN && ci == CI_GREEN -> prState = PR_MERGED }
+	:: TERMINAL -> break
+	od
+}
+
+/* MachineryVersion bumps: a new fix-dispatch generation ships. Bounded. */
+active proctype GenBumper() {
+	do
+	:: atomic { prState == PR_OPEN && gen < GEN_MAX -> gen++ }
+	:: TERMINAL -> break
+	od
+}
+
+#ifdef WATCHER
+/* Merge-request watcher terminal path (merge_request_watcher.go:276): after
+ * mergeRequestMaxAttempts failures on a red required check it calls the
+ * mergeReEngage hook — TryReEngage with an empty head SHA — WITHOUT consulting
+ * the escalated set. A stale merge request can therefore burn re-engagement
+ * budget on a needs-human PR (witness w_watcher). */
+active proctype MergeReqFiler() {
+	if
+	:: atomic { prState == PR_OPEN && !mergeReqPending -> mergeReqPending = true }
+	:: TERMINAL -> skip
+	fi
+}
+active proctype MergeWatcher() {
+	bool ok;
+	do
+	:: atomic { prState == PR_OPEN && ci == CI_RED && mergeReqPending ->
+		if
+		:: escalated -> watcherReEngagedEscalated = true
+		:: else -> skip
+		fi;
+		try_reengage(0, ok);
+		mergeReqPending = false }  /* request quarantined .exhausted */
+	:: TERMINAL -> break
+	od
+}
+#endif
+
+/* ---------------- properties ---------------- */
+
+/* P3 (LTL form): the re-engagement budget cap, as an invariant. */
+ltl p3_cap    { [] (reeng <= MAX_REENG) }
+#ifdef MON_BUDGET
+/* P3 (LTL form): per unchanged red SHA, at most one full budget per modeled
+ * generation — with GEN_MAX = 3 that is 3 * MAX_REENG = 18 total; a single
+ * generation bump admits at most 2 * MAX_REENG = 12. */
+ltl p3_total  { [] (totalReengThisSha <= GEN_MAX * MAX_REENG) }
+#endif
+
+/* P4b: the reviewer->human handoff. Once the reviewer has passed on a PR that
+ * is (still or again) escalated, the PR must eventually reach the human queue
+ * (needs-human) or leave the open set. EXPECTED TO FAIL on the shipped
+ * machinery (see README: reviewer label edits never sync the ledger, and
+ * NewlyEscala requires !Entry.Escalated, so needs-human is never re-applied). */
+ltl p4_handoff { [] ((escalated && reviewerPassed) -> <> (needsHuman || TERMINAL)) }
+
+/* P5: every escalated PR eventually reaches a terminal state (merged, closed,
+ * or human-owned). EXPECTED TO FAIL on the shipped machinery for the same
+ * orphaned-PR reason; passes under -DPATCH_REVIEWER. */
+ltl p5_term   { [] (escalated -> <> TERMINAL) }
+
+#ifdef MON_ADJ
+/* Witness (expected to "fail" = counterexample found below ACMM 6): the code
+ * comment "one reviewer pass per PR, ever" holds only for REPAIR/DE-ESCALATE
+ * verdicts (which add reviewer-passed). A RECOMMEND-CLOSE verdict below ACMM 6
+ * leaves the row adjudicable, so the reviewer re-adjudicates (re-comments)
+ * every kick until a human acts. */
+ltl w_onepass { [] (adjudications <= 1) }
+#endif
+
+#ifdef MON_PENDING
+/* Witness (expected to "fail" = counterexample found): Store.Sweep treats a
+ * PENDING observation as !Red and deletes the entry, wiping accumulated
+ * distinct-SHA attempt history that never converged green. */
+ltl w_pending { [] (!wipedPendingWithHistory) }
+#endif
+
+#ifdef WATCHER
+/* Witness (expected to "fail" = counterexample found): the merge watcher's
+ * re-engage hook fires on an escalated (needs-human) PR. */
+ltl w_watcher { [] (!watcherReEngagedEscalated) }
+#endif

--- a/src/formal/escalation/run.sh
+++ b/src/formal/escalation/run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Exhaustive Spin verification of escalation.pml — every property, every run.
+#
+# Each row of the matrix below carries an EXPECTED verdict:
+#   pass — the property must hold (0 errors); a violation fails this script.
+#   fail — a KNOWN counterexample exists (documented design gap or witness,
+#          see README.md). The run must still find it: if a "fail" row stops
+#          failing, either the gap was fixed in the Go code (great — flip the
+#          row to "pass" and update README.md) or the model drifted from the
+#          code (bad — fix the model). Either way, a human must look, so the
+#          script exits nonzero for that too.
+#
+# Requirements: spin (>= 6.x, the Bell Labs model checker) and a C compiler.
+# Runtime: the full matrix is ~1 minute on a laptop.
+set -u
+
+cd "$(dirname "$0")" || exit 2
+
+SPIN=${SPIN:-spin}
+if ! command -v "$SPIN" >/dev/null 2>&1; then
+    echo "error: spin not found (install: apt-get install spin / brew install spin)" >&2
+    exit 2
+fi
+# Guard against Fermyon's unrelated "spin" CLI shadowing the model checker.
+if ! "$SPIN" -V 2>/dev/null | grep -q "Spin Version"; then
+    echo "error: '$SPIN -V' does not look like the Spin model checker" >&2
+    exit 2
+fi
+CC=${CC:-}
+if [ -z "$CC" ]; then
+    CC=$(command -v gcc || command -v cc) || { echo "error: no C compiler" >&2; exit 2; }
+fi
+PAN_DEPTH=${PAN_DEPTH:-500000}
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+failures=0
+printf '%-28s %-10s %-10s %12s\n' "RUN" "EXPECT" "RESULT" "STATES"
+printf '%-28s %-10s %-10s %12s\n' "---" "------" "------" "------"
+
+# run <name> <expect:pass|fail> <spin-defines> <cc-extra> <pan-args>
+run() {
+    local name=$1 expect=$2 defines=$3 ccextra=$4 panargs=$5
+    local dir="$workdir/$name"
+    mkdir -p "$dir"
+    # shellcheck disable=SC2086  # defines/ccextra/panargs are word lists
+    if ! (cd "$dir" && "$SPIN" -a $defines "$OLDPWD/escalation.pml" >/dev/null 2>&1 &&
+          "$CC" -O2 -DCOLLAPSE $ccextra -o pan pan.c >/dev/null 2>&1); then
+        printf '%-28s %-10s %-10s %12s\n' "$name" "$expect" "BUILD-ERR" "-"
+        failures=$((failures + 1))
+        return
+    fi
+    local out
+    # shellcheck disable=SC2086  # panargs is a word list
+    out=$(cd "$dir" && ./pan -m"$PAN_DEPTH" $panargs 2>&1)
+    local states result verdict
+    states=$(printf '%s\n' "$out" | sed -n 's/^ *\([0-9.e+]*\) states, stored.*/\1/p' | head -1)
+    if printf '%s\n' "$out" | grep -q "errors: 0"; then
+        result=pass
+    elif printf '%s\n' "$out" | grep -Eq "errors: [1-9]"; then
+        result=fail
+    else
+        result=inconclusive   # depth/memory limit hit before a verdict
+    fi
+    if [ "$result" = "$expect" ]; then
+        verdict=$result
+    else
+        verdict="UNEXPECTED-$result"
+        failures=$((failures + 1))
+    fi
+    printf '%-28s %-10s %-10s %12s\n' "$name" "$expect" "$verdict" "${states:-?}"
+}
+
+SAFETY="-DSAFETY -DNOCLAIM"
+FAIR="-DNFAIR=12"
+
+# --- properties expected to HOLD -------------------------------------------
+run p1_p2_amnesty        pass "-DMON_AMNESTY"          "$SAFETY" ""
+run p3_budget_asserts    pass "-DMON_BUDGET"           "$SAFETY" ""
+run p3_cap_ltl           pass ""                       ""        "-a -N p3_cap"
+run p3_total_ltl         pass "-DMON_BUDGET"           ""        "-a -N p3_total"
+run p4a_p6_safety        pass ""                       "$SAFETY" ""
+run p6_watcher_safety    pass "-DWATCHER"              "$SAFETY" ""
+run w_onepass_acmm6      pass "-DMON_ADJ -DACMM6"      ""        "-a -N w_onepass"
+
+# --- known counterexamples (documented gaps/witnesses; see README.md) ------
+run p4b_handoff          fail ""                       "$FAIR"   "-a -f -N p4_handoff"
+run p5_termination       fail ""                       "$FAIR"   "-a -f -N p5_term"
+run w_onepass_acmm5      fail "-DMON_ADJ"              ""        "-a -N w_onepass"
+run w_pending_wipe       fail "-DMON_PENDING"          ""        "-a -N w_pending"
+run w_watcher_reengage   fail "-DWATCHER"              ""        "-a -N w_watcher"
+
+# --- hypothetical fix closes the liveness gaps (README: gap G1) ------------
+run patch_safety         pass "-DPATCH_REVIEWER"       "$SAFETY" ""
+run patch_p5_termination pass "-DPATCH_REVIEWER"       "$FAIR"   "-a -f -N p5_term"
+run patch_p4b_handoff    pass "-DPATCH_REVIEWER"       "$FAIR"   "-a -f -N p4_handoff"
+
+echo
+if [ "$failures" -ne 0 ]; then
+    echo "FORMAL VERIFICATION: $failures run(s) diverged from the expected verdicts."
+    exit 1
+fi
+echo "FORMAL VERIFICATION: all runs matched their expected verdicts."


### PR DESCRIPTION
Adds `src/formal/escalation/` — a Spin (Promela) model of the fix-loop escalation lifecycle composed with the reviewer adjudication lane, verified exhaustively, plus a reporting-only CI lane that keeps the model and the code honest against each other.

The model targets the **post-#5485 machinery**: `pkg/escalation` (`Sweep`, `TryReEngage`, `MachineryVersion=2` amnesty), `pkg/scheduler/reviewer_lane.go` (#5480), and the governor wiring in `cmd/hive/main.go` (`runEscalationSweep` → `writeMergeEligible` → `reapStuckRedPRs`). One PR's lifecycle is modeled as nine interacting processes (Sweeper, Reaper, fix-lane Agent, Reviewer, Human, CI, Merger, staleness Timer, generation bumper) at the protocol level, with the actual production constants (`DefaultThreshold=3`, `MaxReEngagements=6`), SHAs bounded to 4 and machinery generations to 3. The README documents the full model↔code mapping and every abstraction.

## What is proved (exhaustive searches, Spin 6.5.2)

| # | Property | Result | States |
|---|---|---|---|
| P1 | Amnesty is one-shot per generation (per entry lifetime) | holds | 5,598,270 |
| P2 | No instant re-escalation post-amnesty: never in the amnesty pass; needs ≥2 genuinely new red SHAs or a full fresh re-engage budget | holds | 5,598,270 |
| P3 | `ReEngagements ≤ 6` always; per unchanged red SHA ≤ (1+amnesties)×6 — ≤ 12 across one generation bump, ≤ 18 across the 3 modeled generations | holds | 10,374,648 |
| P4a | A `reviewer-passed` PR is never adjudicated by the reviewer again | holds | 2,100,236 |
| P4b | …and, if still escalated, eventually reaches the human queue | **violated — gap G1** | cycle @ 7,207 |
| P5 | Every escalated PR eventually terminal (merged/closed/human-owned), weak fairness | **violated — gap G1** | cycle @ 5,169 |
| P6 | Escalated entries are invisible to the reaper and FIX-BEFORE-NEW | holds | 20,749,779 |

## Design gaps found (no Go changed in this PR; documented in the README)

- **G1 (real, liveness): a reviewer pass on a PR that stays red orphans it.** The reviewer's REPAIR/DE-ESCALATE edits labels only; `Entry.Escalated` is cleared solely by green/prune/amnesty. If the reviewer's push resolves red: the ledger still says escalated (fix lane + reaper excluded), `reviewer-passed` excludes the reviewer, and `NewlyEscala` requires `!e.Escalated` so `needs-human` (and ntfy) can never re-fire — the human queue never sees it again. Red, open, owned by nobody, forever. The same root cause breaks the escalation comment's promise that removing `needs-human` returns a PR to the automated lane. A hypothetical fix (reviewer label edit also resets the ledger, `-DPATCH_REVIEWER`) is verified to restore P4b and P5.
- **G2 (real, counting): a CI-pending observation wipes the ledger.** `Sweep` branches on `!o.Red` with `Red := CIStatus == "failure"`, so pending takes the "went green" path and deletes the entry — the distinct-SHA breaker is probabilistic wherever sweeps catch a push's pending window (witness `w_pending_wipe`).
- **G3 (minor): the merge watcher re-engages escalated PRs.** `TryReEngage` has no `Escalated` guard and `merge_request_watcher.go:276` calls it without the escalated-set check the reaper performs. Benign in effect (dispatch surfaces still exclude escalated rows; P3/P6 hold in the `-DWATCHER` build) but the counter and the "re-engaged fix loop" log lie.
- **G4 (minor): RECOMMEND-CLOSE below ACMM 6 re-adjudicates every kick** — "one reviewer pass per PR, ever" only holds for verdicts that add `reviewer-passed`; at ACMM 6 the invariant holds (verified).

## Mechanics

- `run.sh` runs the full matrix (15 exhaustive verifications, ~90 s) and checks each verdict against its **expected** result: must-hold properties must pass, and the documented counterexamples must keep reproducing — either direction of drift exits nonzero. Portable bash, `spin` + `gcc`/`cc` from PATH.
- `.github/workflows/formal-verify.yml` (job `formal-verify (escalation)`) runs it on PRs touching `src/pkg/escalation/**`, `src/pkg/scheduler/reviewer_lane*`, `src/formal/**`, or the workflow itself, plus `workflow_dispatch`; `sudo apt-get install -y spin` on ubuntu-latest. **Reporting-only — intentionally not a required check.**
- Counterexamples were minimized with `./pan -i` and replayed with `spin -t -p -g`; reproduction steps are in the README.

Refs #5480
