### PR TITLE
🐛 fix(escalation): sync reviewer verdicts into the ledger — close orphan path proven by Spin model

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -7520,6 +7520,7 @@ func hivePRObservations(cfg *config.Config, actionable *github.ActionableResult)
 			HeadSHA: pr.HeadSHA,
 			Red:     pr.HasFailingRequiredCheck(),
 			Excerpt: pr.CIFailureExcerpt,
+			Labels:  pr.Labels,
 		})
 	}
 	return obs
@@ -7666,6 +7667,11 @@ func runEscalationSweep(
 			HeadSHA: pr.HeadSHA,
 			Red:     pr.CIStatus == "failure",
 			Excerpt: pr.CIFailureExcerpt,
+			// Labels let Sweep reconcile reviewer-lane verdicts (label-only
+			// edits: needs-human removed, reviewer-passed added) back into the
+			// ledger so a reviewer-repaired PR that goes red again re-enters
+			// the fix lifecycle instead of being orphaned (#5511, gap G1).
+			Labels: pr.Labels,
 		})
 		meta[escalation.Key(repo, pr.Number)] = prMeta{checks: pr.FailingChecks}
 	}

--- a/src/formal/escalation/README.md
+++ b/src/formal/escalation/README.md
@@ -7,7 +7,13 @@ promise — and pins down, with minimized counterexamples, the places where the
 shipped machinery does not deliver them.
 
 The model targets the **post-#5485** machinery (v5 with the reviewer lane,
-#5480, merged; machinery-generation amnesty, #5471).
+#5480, merged; machinery-generation amnesty, #5471) **with the #5511 G1/G3/G4
+fixes applied**: the reviewer-verdict ledger sync in `Store.Sweep`, the
+escalated guard in `Store.TryReEngage`, and the recommend-close work-list
+marker. Model and code moved together — the formerly-hypothetical
+`-DPATCH_REVIEWER` behavior is now the shipped (and modeled) default, and the
+properties it was shown to close (P4b, P5) now hold on the default build.
+Gap G2 remains open and its witness is still pinned as an expected failure.
 
 Run everything:
 
@@ -29,7 +35,7 @@ Either divergence exits nonzero. CI runs this via
 | `Sweeper` proctype | `runEscalationSweep` (`cmd/hive/main.go`) driving `Store.Sweep` (`pkg/escalation/escalation.go`) once per governor tick |
 | `Reaper` proctype | `reapStuckRedPRs` (`cmd/hive/main.go`) → `Store.TryReEngage` |
 | `Agent` proctype | the FIX-BEFORE-NEW fix lane (`pkg/scheduler/scheduler.go:834-893`): red, non-escalated PRs are routed back to their author agent, which pushes another attempt |
-| `Reviewer` proctype | the reviewer lane (`pkg/scheduler/reviewer_lane.go`): adjudicates escalated rows from `ci-failing.json`, excluding rows labeled `reviewer-passed`; REPAIR and DE-ESCALATE are collapsed into one branch (both = label swap + push); RECOMMEND-CLOSE closes at ACMM ≥ 6 (`-DACMM6`), else comments and stands down |
+| `Reviewer` proctype | the reviewer lane (`pkg/scheduler/reviewer_lane.go`): adjudicates escalated rows from `ci-failing.json`, excluding rows labeled `reviewer-passed` or `reviewer-recommend-close`; REPAIR and DE-ESCALATE are collapsed into one branch (both = label swap + push); RECOMMEND-CLOSE closes at ACMM ≥ 6 (`-DACMM6`), else comments, adds `reviewer-recommend-close`, and stands down |
 | `Human` proctype | the operator watching the `needs-human` label queue; eventually takes ownership or closes. **The queue is the label** — a PR without `needs-human` is invisible to the human |
 | `CI` proctype | per-SHA check verdict: each pushed SHA resolves nondeterministically red or green, once |
 | `Merger` proctype | the auto-merge sweep: a green open PR is eventually merged |
@@ -40,7 +46,7 @@ Either divergence exits nonzero. CI runs this via
 | `headCounted` | `containsSHA(e.RedSHAs, o.HeadSHA)` for the current head (sound: SHAs are never reused, so only the current head's membership is ever queried) |
 | `stale` | `now − e.FirstRedAt ≥ RedPRStaleAfter` (`Store.StaleRed`) |
 | `escalatedView` | the `escalatedPRs` map returned by `runEscalationSweep` and consumed same-tick by `reapStuckRedPRs` and `writeMergeEligible` (`ci-failing.json` `row.Escalated`); refreshed at the end of each sweep pass |
-| `needsHuman`, `reviewerPassed` | the `needs-human` / `reviewer-passed` labels on the forge |
+| `needsHuman`, `reviewerPassed`, `recommendedClose` | the `needs-human` / `reviewer-passed` / `reviewer-recommend-close` labels on the forge |
 | `amnesty_check()` inline | the machinery-amnesty block shared by `Store.Sweep` (escalation.go:181-186) and `Store.TryReEngage` (escalation.go:372-377) |
 | `THRESHOLD=3`, `MAX_REENG=6` | `DefaultThreshold`, `MaxReEngagements` (actual production constants) |
 | `NSHA=4`, `GEN_MAX=3` | finite bounds: distinct head SHAs per PR, machinery generations |
@@ -48,9 +54,15 @@ Either divergence exits nonzero. CI runs this via
 Faithfully carried quirks: `Store.TryReEngage` creates missing entries as
 `&Entry{}` (Machinery **0**, → immediate no-op amnesty), while `Store.Sweep`
 creates them with `Machinery: MachineryVersion`; `Sweep`'s green branch is
-`!o.Red`, which **includes CI-pending observations** (see gap G2); the
-reviewer edits labels only — the ledger's `Escalated` flag is untouched (gap
-G1); `TryReEngage` never consults `Escalated` (gap G3).
+`!o.Red`, which **includes CI-pending observations** (see gap G2).
+
+Faithfully carried **fixes** (#5511): the reviewer still edits labels only —
+the ledger sync happens SWEEP-side, exactly as shipped: `Store.Sweep` resets
+an `Escalated` entry whose observation labels carry `reviewer-passed` without
+`needs-human` (gap G1); `TryReEngage` refuses escalated entries after the
+amnesty check (gap G3); a below-ACMM-6 RECOMMEND-CLOSE marks the row with
+`reviewer-recommend-close`, which the work list excludes like
+`reviewer-passed` (gap G4).
 
 ## What is abstracted away
 
@@ -79,25 +91,37 @@ G1); `TryReEngage` never consults `Escalated` (gap G3).
 ## Verification results
 
 Spin 6.5.2, exhaustive (`./pan -m500000`, DFS + COLLAPSE; liveness with weak
-fairness `-a -f`). Every state count is a completed full search.
+fairness `-a -f`). Every state count is a completed full search, on the
+post-#5511 model (the G1/G3/G4 fixes are the modeled default, so the counts
+differ from the pre-fix runs recorded in the #5511 discussion).
 
 | # | Property | Run(s) | Result | States |
 |---|---|---|---|---|
-| P1 | Amnesty is one-shot per generation (per entry lifetime) | `p1_p2_amnesty` (assert in `amnesty_check`) | **holds** | 5,598,270 |
-| P2 | No instant re-escalation after amnesty: never in the amnesty pass itself, and only with ≥ `THRESHOLD−1` genuinely new red SHAs or a full fresh re-engage budget | `p1_p2_amnesty` (asserts P2a/P2b) | **holds** | 5,598,270 |
-| P3 | Re-engage budget: `ReEngagements ≤ 6` always; per unchanged red SHA, total ≤ (1 + amnesties) × 6 — i.e. ≤ 12 across one generation bump, ≤ 18 across the 3 modeled generations | `p3_budget_asserts`, `p3_cap_ltl`, `p3_total_ltl` | **holds** | 10,374,648 / 2,100,236 / 10,374,648 |
-| P4a | Once `reviewer-passed`, the reviewer never adjudicates the PR again | `p4a_p6_safety` (assert) | **holds** | 2,100,236 |
-| P4b | …and such a PR, if (still) escalated, eventually reaches the human queue | `p4b_handoff` (LTL, weak fairness) | **VIOLATED — gap G1** | cycle at 7,207 |
-| P5 | Every escalated PR eventually terminal (merged / closed / human-owned) | `p5_termination` (LTL, weak fairness) | **VIOLATED — gap G1** | cycle at 5,169 |
-| P5′ | P5 and P4b under the hypothetical ledger-sync fix | `patch_p5_termination`, `patch_p4b_handoff` (`-DPATCH_REVIEWER`) | **hold** | 2,104,638 / 2,098,622 |
-| P6 | Escalated entries are invisible to the reaper and to FIX-BEFORE-NEW | `p4a_p6_safety`, `p6_watcher_safety` (asserts) | **holds** | 2,100,236 / 20,749,779 |
-| W1 | "One reviewer pass per PR, ever" for RECOMMEND-CLOSE below ACMM 6 | `w_onepass_acmm5` / `w_onepass_acmm6` | **witness found** at ACMM 5 (holds at ACMM 6, 2,140,106 states) — gap G4 | 4,113 |
-| W2 | Ledger history survives until green | `w_pending_wipe` | **witness found** — gap G2 | 4,636 |
-| W3 | The merge watcher never re-engages an escalated PR | `w_watcher_reengage` (`-DWATCHER`) | **witness found** — gap G3 | 207,685 |
+| P1 | Amnesty is one-shot per generation (per entry lifetime) | `p1_p2_amnesty` (assert in `amnesty_check`) | **holds** | 8,822,910 |
+| P2 | No instant re-escalation after amnesty: never in the amnesty pass itself, and only with ≥ `THRESHOLD−1` genuinely new red SHAs or a full fresh re-engage budget | `p1_p2_amnesty` (asserts P2a/P2b) | **holds** | 8,822,910 |
+| P3 | Re-engage budget: `ReEngagements ≤ 6` always; per unchanged red SHA, total ≤ (1 + amnesties) × 6 — i.e. ≤ 12 across one generation bump, ≤ 18 across the 3 modeled generations | `p3_budget_asserts`, `p3_cap_ltl`, `p3_total_ltl` | **holds** | 15,779,561 / 3,215,657 / 15,779,561 |
+| P4a | Once `reviewer-passed`, the reviewer never adjudicates the PR again | `p4a_p6_safety` (assert) | **holds** | 3,215,657 |
+| P4b | …and such a PR, if (still) escalated, eventually reaches the human queue | `p4b_handoff` (LTL, weak fairness) | **holds** — gap G1 FIXED (#5511: sweep-side reviewer-verdict ledger sync) | 3,217,019 |
+| P5 | Every escalated PR eventually terminal (merged / closed / human-owned) | `p5_termination` (LTL, weak fairness) | **holds** — gap G1 FIXED | 3,224,760 |
+| P6 | Escalated entries are invisible to the reaper and to FIX-BEFORE-NEW | `p4a_p6_safety`, `p6_watcher_safety` (asserts) | **holds** | 3,215,657 / 27,818,920 |
+| W1 | "One reviewer pass per PR, ever" — every verdict class, every level | `w_onepass_acmm5` / `w_onepass_acmm6` | **holds** at both levels — gap G4 FIXED (#5511: `reviewer-recommend-close` marker) | 3,215,657 / 2,140,034 |
+| W2 | Ledger history survives until green | `w_pending_wipe` | **witness found** — gap G2 (still open) | 7,706 |
+| W3 | The merge watcher never burns re-engage budget on an escalated PR | `w_watcher_reengage` (`-DWATCHER`) | **holds** — gap G3 FIXED (#5511: `TryReEngage` escalated guard) | 27,818,920 |
+
+Pre-fix baseline (the counterexamples that motivated #5511): P4b acceptance
+cycle at 7,207 states, P5 at 5,169; W1 witness at 4,113 states (ACMM 5); W3
+witness at 207,685. The former `-DPATCH_REVIEWER` runs — which proved the G1
+fix shape closes P4b/P5 before it was implemented — are retired: the patch is
+now the default build.
 
 ## Design gaps found
 
-### G1 — a reviewer pass on a PR that stays red orphans it (REAL, liveness)
+Gaps G1, G3, and G4 were **fixed in #5511** (the same PR that promoted this
+model's `-DPATCH_REVIEWER` hypothetical to shipped behavior); their sections
+below keep the original counterexample narratives, followed by the shipped
+fix. G2 remains open.
+
+### G1 — a reviewer pass on a PR that stays red orphans it (FIXED in #5511)
 
 `Entry.Escalated` is cleared only by: the PR going green (entry deleted), the
 PR leaving the open set, or machinery amnesty. The reviewer's verdicts edit
@@ -124,13 +148,29 @@ Two nondeterministic rescues exist, and neither is a guarantee: a later
 pending-wipe happening to fire during the fix's CI window. The model shows
 runs where neither occurs.
 
-`-DPATCH_REVIEWER` verifies the obvious fix shape: when the reviewer removes
-`needs-human`, also reset the ledger (`Escalated=false`, `RedSHAs=nil` — the
-same reset amnesty performs). With that, P4b and P5 hold: a still-red repair
-re-enters the fix lane, re-escalates on fresh evidence, `NewlyEscala`
-re-fires, and the `reviewer-passed` exclusion hands it to the human.
+The model's `-DPATCH_REVIEWER` variant proved the fix shape before it was
+written: when the reviewer removes `needs-human`, also reset the ledger
+(`Escalated=false`, `RedSHAs=nil` — the same reset amnesty performs). With
+that, P4b and P5 hold: a still-red repair re-enters the fix lane, re-escalates
+on fresh evidence, `NewlyEscala` re-fires, and the `reviewer-passed` exclusion
+hands it to the human.
 
-### G2 — a CI-pending observation wipes the attempt ledger (REAL, counting)
+**Shipped fix (#5511)**: implemented SWEEP-side, because the reviewer's label
+edits happen through a direct `gh pr edit` the hub may never observe.
+`escalation.Observation` now carries the PR's labels (threaded from the
+enumeration in `runEscalationSweep`), and `Store.Sweep` reconciles the
+verdict: an `Escalated` entry whose observation labels contain
+`reviewer-passed` and not `needs-human` is reset (un-escalated, `RedSHAs`
+cleared, fresh re-engagement budget, `Machinery` untouched). The reset fires
+once — clearing `Escalated` disarms it — so fresh reds re-accumulate to a
+normal re-escalation. The reset keys on the label PAIR (`reviewer-passed`
+present, `needs-human` absent), so a human removing `needs-human` on a PR
+without a reviewer pass still does not re-enter the lane — the escalation
+comment's "remove the label" promise remains label-pair-scoped, not fully
+honored (deliberate: an unlabeled un-escalation has no marker distinguishing
+it from a label sync race). P4b and P5 now hold on the default build.
+
+### G2 — a CI-pending observation wipes the attempt ledger (REAL, still open)
 
 `Store.Sweep` branches on `!o.Red`, and `runEscalationSweep` computes
 `Red: pr.CIStatus == "failure"` — so a **pending** observation (every fresh
@@ -143,32 +183,50 @@ is probabilistic where the code intends it to be deterministic. (This wipe is
 also what accidentally rescues some G1 orphans.) A fix would treat pending as
 a no-op observation: only green clears, only red counts.
 
-### G3 — the merge watcher re-engages escalated PRs (minor)
+### G3 — the merge watcher re-engages escalated PRs (FIXED in #5511)
 
-`Store.TryReEngage` never checks `Entry.Escalated`, and the merge-request
-watcher's terminal path (`merge_request_watcher.go:276`) calls it without
+`Store.TryReEngage` never checked `Entry.Escalated`, and the merge-request
+watcher's terminal path (`merge_request_watcher.go`) calls it without
 consulting the escalated set (unlike `reapStuckRedPRs`, which does). A merge
 request filed before escalation that exhausts its attempts on a red required
-check therefore burns re-engagement budget on a `needs-human` PR and logs
+check therefore burned re-engagement budget on a `needs-human` PR and logged
 "re-engaged fix loop" for a PR the fix loop is standing down from. Benign in
 effect — the dispatch surfaces (FIX-BEFORE-NEW, reaper) still exclude
-escalated rows, and P3/P6 hold in the `-DWATCHER` build — but the counter and
-the log line lie, and a budget burned this way can later trigger an
-exhaustion-based re-escalation path prematurely after amnesty.
+escalated rows, and P3/P6 held even then — but the counter and the log line
+lied, and a budget burned this way could later trigger an exhaustion-based
+re-escalation prematurely after amnesty.
 
-### G4 — RECOMMEND-CLOSE below ACMM 6 re-adjudicates every kick (minor)
+**Shipped fix (#5511)**: `TryReEngage` returns false for escalated entries,
+guarded AFTER the machinery-amnesty block so an older-generation escalated
+entry is still amnestied (un-escalated) and then re-engaged on its fresh
+budget, exactly as amnesty intends. No budget increment, no false log line.
+Invariant `w_watcher` (budget never granted while the entry is escalated)
+now holds in the `-DWATCHER` build.
 
-The work-list builder's "one reviewer pass per PR, ever" holds only for
+### G4 — RECOMMEND-CLOSE below ACMM 6 re-adjudicates every kick (FIXED in #5511)
+
+The work-list builder's "one reviewer pass per PR, ever" held only for
 REPAIR/DE-ESCALATE, because only those add `reviewer-passed`. Below ACMM 6, a
-RECOMMEND-CLOSE verdict leaves the row fully adjudicable, so the reviewer
-re-adjudicates (and re-comments) it on every kick until a human acts
+RECOMMEND-CLOSE verdict left the row fully adjudicable, so the reviewer
+re-adjudicated (and re-commented) it on every kick until a human acted
 (witness `w_onepass_acmm5`; at ACMM 6 the close is immediate and the
-invariant holds). A fix would label or otherwise mark recommend-closed rows.
+invariant held).
+
+**Shipped fix (#5511)**: the kick contract instructs the reviewer to add the
+`reviewer-recommend-close` label alongside the recommend-close comment, and
+the work-list builder excludes labeled rows exactly like `reviewer-passed`.
+`w_onepass` now holds at every ACMM level.
 
 ## Reproducing a counterexample
 
+The only remaining expected counterexample is gap G2's witness:
+
 ```console
-$ spin -a escalation.pml && gcc -O2 -DNFAIR=12 -o pan pan.c
-$ ./pan -a -f -i -N p5_term        # -i: iteratively shorten the trail
-$ spin -t -p -g escalation.pml     # replay with state annotations
+$ spin -a -DMON_PENDING escalation.pml && gcc -O2 -o pan pan.c
+$ ./pan -a -i -N w_pending         # -i: iteratively shorten the trail
+$ spin -t -p -g -DMON_PENDING escalation.pml   # replay with state annotations
 ```
+
+To replay the RETIRED G1 counterexamples (pre-fix machinery), check out the
+model as introduced by #5511's model commit and run `p5_term`/`p4_handoff`
+with `-DNFAIR=12` and `-a -f`.

--- a/src/formal/escalation/escalation.pml
+++ b/src/formal/escalation/escalation.pml
@@ -19,14 +19,20 @@
  * each exhaustive verification only carries the monitor state it needs:
  *   -DMON_AMNESTY  — P1 (one-shot amnesty) + P2 (no instant re-escalation)
  *   -DMON_BUDGET   — P3 (re-engagement budget bounds)
- *   -DMON_ADJ      — witness w_onepass (repeat adjudication below ACMM 6)
+ *   -DMON_ADJ      — invariant w_onepass (one adjudication per PR, ever)
  *   -DMON_PENDING  — witness w_pending (ledger wipe on a PENDING observation)
- *   -DWATCHER      — merge-request watcher re-engage path + witness w_watcher
- *                    (pkg/github/merge_request_watcher.go:276)
+ *   -DWATCHER      — merge-request watcher re-engage path + invariant
+ *                    w_watcher (pkg/github/merge_request_watcher.go)
  *   -DACMM6        — reviewer may close after recommend-close (level >= 6)
- *   -DPATCH_REVIEWER — hypothetical fix: a reviewer pass also resets the
- *                    LEDGER (Escalated/RedSHAs), not only the labels; shows
- *                    the P4b/P5 counterexample is closed by that sync.
+ *
+ * The G1/G3/G4 fixes (#5511) are the modeled DEFAULT, matching the shipped Go:
+ *   G1 — Store.Sweep reconciles the reviewer's label-only verdict into the
+ *        ledger (Escalated/RedSHAs reset when reviewer-passed is present and
+ *        needs-human absent) — see the Sweeper's reconciliation step. This is
+ *        what the former -DPATCH_REVIEWER run verified; it is now shipped.
+ *   G3 — Store.TryReEngage refuses escalated entries (post-amnesty guard).
+ *   G4 — a RECOMMEND-CLOSE verdict below ACMM 6 marks the PR
+ *        (reviewer-recommend-close label) and the work list excludes it.
  */
 
 #define NSHA        4   /* distinct head SHAs a PR may ever have (bounded pushes) */
@@ -53,8 +59,11 @@ byte prState = PR_OPEN;
 byte minted  = 1;   /* SHAs minted so far; the CURRENT head SHA id is always
                      * the most recently minted one (SHAs strictly increase) */
 
-bool needsHuman     = false;  /* escalation.NeedsHumanLabel on the PR */
-bool reviewerPassed = false;  /* scheduler.ReviewerPassedLabel on the PR */
+bool needsHuman       = false;  /* escalation.NeedsHumanLabel on the PR */
+bool reviewerPassed   = false;  /* escalation.ReviewerPassedLabel on the PR */
+bool recommendedClose = false;  /* scheduler.ReviewerRecommendCloseLabel: the
+                                 * recommend-close verdict was delivered (#5511
+                                 * G4); the work list excludes marked rows */
 
 /* ---------------- escalation ledger (escalation.Entry) ---------------- */
 bool entryExists = false;
@@ -98,8 +107,9 @@ bool wipedPendingWithHistory = false; /* witness: sweep deleted a non-empty entr
 #endif
 #ifdef WATCHER
 bool mergeReqPending           = false; /* a stale merge request sits in the watcher dir */
-bool watcherReEngagedEscalated = false; /* witness: watcher burned re-engage budget
-                                         * on an escalated (needs-human) PR */
+bool watcherReEngagedEscalated = false; /* violation flag: re-engage budget was
+                                         * granted while the entry was escalated
+                                         * (must stay false post-G3 fix) */
 #endif
 
 /* ---------------- ledger helpers ---------------- */
@@ -173,7 +183,11 @@ inline try_reengage(obsSha, ok) {
 	fi;
 	amnesty_check();
 	if
-	:: reeng >= MAX_REENG -> ok = false
+	/* #5511 G3 fix (shipped): an escalated (needs-human) entry is out of the
+	 * automated lane — refuse without burning budget. The amnesty above may
+	 * have just un-escalated an older-generation entry, which then proceeds. */
+	:: escalated -> ok = false
+	:: !escalated && reeng >= MAX_REENG -> ok = false
 	:: else ->
 		reeng++;
 		/* P3a: the per-SHA budget cap holds at every increment site. */
@@ -222,6 +236,23 @@ active proctype Sweeper() {
 			:: else -> skip
 			fi;
 			amnesty_check();
+			/* #5511 G1 fix (shipped): reviewer-verdict reconciliation. The
+			 * reviewer's REPAIR/DE-ESCALATE verdict is label edits only; if
+			 * the ledger still says Escalated but the PR no longer carries
+			 * needs-human and does carry reviewer-passed, sync the verdict:
+			 * reset the entry the way amnesty does (un-escalate, restart the
+			 * distinct-SHA ledger, fresh budget, Machinery untouched) so the
+			 * PR re-enters the normal lifecycle. Escalated is cleared, so the
+			 * reset cannot repeat — fresh reds re-accumulate and a later
+			 * re-escalation fires normally; reviewer-passed then routes it to
+			 * the human, not back to the reviewer. */
+			if
+			:: escalated && reviewerPassed && !needsHuman ->
+				escalated = false;
+				headCounted = false; attempts = 0;  /* RedSHAs = nil */
+				reeng = 0
+			:: else -> skip
+			fi;
 			if
 			:: !headCounted ->  /* unseen red SHA: append to RedSHAs */
 				headCounted = true;
@@ -324,13 +355,17 @@ active proctype Reaper() {
 }
 
 /* Reviewer lane (reviewer_lane.go, ACMM >= 5): adjudicates escalated rows from
- * ci-failing.json, excluding rows already labeled reviewer-passed. REPAIR and
+ * ci-failing.json, excluding rows already labeled reviewer-passed or
+ * reviewer-recommend-close (#5511 G4 fix: every verdict class marks the row,
+ * so "one reviewer pass per PR, ever" holds unconditionally). REPAIR and
  * DE-ESCALATE are indistinguishable at this abstraction (label swap + push);
- * RECOMMEND-CLOSE closes at ACMM >= 6 (-DACMM6), else comments and leaves
- * needs-human in place. */
+ * the ledger sync for those verdicts happens SWEEP-side (G1 fix), not here —
+ * the reviewer edits labels only, exactly like the real agent. RECOMMEND-CLOSE
+ * closes at ACMM >= 6 (-DACMM6), else comments, adds the recommend-close
+ * label, and leaves needs-human in place. */
 active proctype Reviewer() {
 	do
-	:: atomic { prState == PR_OPEN && ci == CI_RED && escalatedView && !reviewerPassed ->
+	:: atomic { prState == PR_OPEN && ci == CI_RED && escalatedView && !reviewerPassed && !recommendedClose ->
 		/* P4a: a PR carrying reviewer-passed is never adjudicated again. */
 		assert(!reviewerPassed);
 #ifdef MON_ADJ
@@ -343,21 +378,15 @@ active proctype Reviewer() {
 		:: minted < NSHA ->  /* REPAIR / DE-ESCALATE: fix or rebase, push, relabel */
 			reviewerPassed = true;
 			needsHuman = false;
-#ifdef PATCH_REVIEWER
-			/* Hypothetical fix under test: the label edit also resets the
-			 * LEDGER escalation state, the way TryReEngage's amnesty does,
-			 * so a still-red outcome re-enters the automated lane and can
-			 * re-escalate (NewlyEscala requires !Entry.Escalated). */
-			escalated = false;
-			headCounted = false; attempts = 0;
-			escalatedView = false;
-#endif
 			minted++; headCounted = false; ci = CI_PENDING; stale = false
 		:: true ->           /* RECOMMEND-CLOSE */
 #ifdef ACMM6
 			prState = PR_CLOSED
 #else
-			skip  /* comment posted; needs-human stays; a human closes/owns it */
+			/* Comment posted; needs-human stays; a human closes/owns it.
+			 * The verdict is marked (reviewer-recommend-close label) so the
+			 * work list never re-serves the row (#5511 G4). */
+			recommendedClose = true
 #endif
 		fi }
 	:: TERMINAL -> break
@@ -395,11 +424,14 @@ active proctype GenBumper() {
 }
 
 #ifdef WATCHER
-/* Merge-request watcher terminal path (merge_request_watcher.go:276): after
+/* Merge-request watcher terminal path (merge_request_watcher.go): after
  * mergeRequestMaxAttempts failures on a red required check it calls the
- * mergeReEngage hook — TryReEngage with an empty head SHA — WITHOUT consulting
- * the escalated set. A stale merge request can therefore burn re-engagement
- * budget on a needs-human PR (witness w_watcher). */
+ * mergeReEngage hook — TryReEngage with an empty head SHA — without consulting
+ * the escalated set. The #5511 G3 fix guards STORE-side: TryReEngage refuses
+ * escalated entries, so the watcher's call can no longer burn budget on a
+ * needs-human PR (invariant w_watcher: budget is never granted while the
+ * entry is escalated; a grant after machinery amnesty un-escalates first,
+ * which is amnesty's intended semantics). */
 active proctype MergeReqFiler() {
 	if
 	:: atomic { prState == PR_OPEN && !mergeReqPending -> mergeReqPending = true }
@@ -410,11 +442,11 @@ active proctype MergeWatcher() {
 	bool ok;
 	do
 	:: atomic { prState == PR_OPEN && ci == CI_RED && mergeReqPending ->
+		try_reengage(0, ok);
 		if
-		:: escalated -> watcherReEngagedEscalated = true
+		:: ok && escalated -> watcherReEngagedEscalated = true
 		:: else -> skip
 		fi;
-		try_reengage(0, ok);
 		mergeReqPending = false }  /* request quarantined .exhausted */
 	:: TERMINAL -> break
 	od
@@ -434,22 +466,23 @@ ltl p3_total  { [] (totalReengThisSha <= GEN_MAX * MAX_REENG) }
 
 /* P4b: the reviewer->human handoff. Once the reviewer has passed on a PR that
  * is (still or again) escalated, the PR must eventually reach the human queue
- * (needs-human) or leave the open set. EXPECTED TO FAIL on the shipped
- * machinery (see README: reviewer label edits never sync the ledger, and
- * NewlyEscala requires !Entry.Escalated, so needs-human is never re-applied). */
+ * (needs-human) or leave the open set. HOLDS since the #5511 G1 fix: the
+ * sweep syncs the reviewer's label verdict into the ledger, the PR re-enters
+ * the automated lane, re-escalates on fresh evidence, and NewlyEscala
+ * re-applies needs-human (the reviewer-passed exclusion then makes the queue
+ * a human's). Failed on the pre-fix machinery — see README, gap G1. */
 ltl p4_handoff { [] ((escalated && reviewerPassed) -> <> (needsHuman || TERMINAL)) }
 
 /* P5: every escalated PR eventually reaches a terminal state (merged, closed,
- * or human-owned). EXPECTED TO FAIL on the shipped machinery for the same
- * orphaned-PR reason; passes under -DPATCH_REVIEWER. */
+ * or human-owned). HOLDS since the #5511 G1 fix (failed before it for the
+ * same orphaned-PR reason — see README, gap G1). */
 ltl p5_term   { [] (escalated -> <> TERMINAL) }
 
 #ifdef MON_ADJ
-/* Witness (expected to "fail" = counterexample found below ACMM 6): the code
- * comment "one reviewer pass per PR, ever" holds only for REPAIR/DE-ESCALATE
- * verdicts (which add reviewer-passed). A RECOMMEND-CLOSE verdict below ACMM 6
- * leaves the row adjudicable, so the reviewer re-adjudicates (re-comments)
- * every kick until a human acts. */
+/* "One reviewer pass per PR, ever" — for EVERY verdict class. HOLDS since the
+ * #5511 G4 fix: a RECOMMEND-CLOSE verdict below ACMM 6 marks the row
+ * (reviewer-recommend-close) and the work list excludes it, exactly like
+ * reviewer-passed. Failed at ACMM 5 on the pre-fix machinery — gap G4. */
 ltl w_onepass { [] (adjudications <= 1) }
 #endif
 
@@ -461,7 +494,9 @@ ltl w_pending { [] (!wipedPendingWithHistory) }
 #endif
 
 #ifdef WATCHER
-/* Witness (expected to "fail" = counterexample found): the merge watcher's
- * re-engage hook fires on an escalated (needs-human) PR. */
+/* The merge watcher never burns re-engagement budget on an escalated
+ * (needs-human) PR. HOLDS since the #5511 G3 fix (TryReEngage's escalated
+ * guard); the pre-fix machinery granted budget through the watcher's
+ * unguarded call — gap G3. */
 ltl w_watcher { [] (!watcherReEngagedEscalated) }
 #endif

--- a/src/formal/escalation/run.sh
+++ b/src/formal/escalation/run.sh
@@ -84,17 +84,19 @@ run p4a_p6_safety        pass ""                       "$SAFETY" ""
 run p6_watcher_safety    pass "-DWATCHER"              "$SAFETY" ""
 run w_onepass_acmm6      pass "-DMON_ADJ -DACMM6"      ""        "-a -N w_onepass"
 
-# --- known counterexamples (documented gaps/witnesses; see README.md) ------
-run p4b_handoff          fail ""                       "$FAIR"   "-a -f -N p4_handoff"
-run p5_termination       fail ""                       "$FAIR"   "-a -f -N p5_term"
-run w_onepass_acmm5      fail "-DMON_ADJ"              ""        "-a -N w_onepass"
-run w_pending_wipe       fail "-DMON_PENDING"          ""        "-a -N w_pending"
-run w_watcher_reengage   fail "-DWATCHER"              ""        "-a -N w_watcher"
+# --- properties closed by the #5511 G1/G3/G4 fixes (previously pinned fails) -
+# G1: Sweep's reviewer-verdict reconciliation (the former -DPATCH_REVIEWER
+# hypothetical, now the shipped default) closes the P4b/P5 orphan path.
+run p4b_handoff          pass ""                       "$FAIR"   "-a -f -N p4_handoff"
+run p5_termination       pass ""                       "$FAIR"   "-a -f -N p5_term"
+# G4: recommend-close marks the row; one adjudication ever, at every level.
+run w_onepass_acmm5      pass "-DMON_ADJ"              ""        "-a -N w_onepass"
+# G3: TryReEngage's escalated guard — no budget burned on needs-human PRs.
+run w_watcher_reengage   pass "-DWATCHER"              ""        "-a -N w_watcher"
 
-# --- hypothetical fix closes the liveness gaps (README: gap G1) ------------
-run patch_safety         pass "-DPATCH_REVIEWER"       "$SAFETY" ""
-run patch_p5_termination pass "-DPATCH_REVIEWER"       "$FAIR"   "-a -f -N p5_term"
-run patch_p4b_handoff    pass "-DPATCH_REVIEWER"       "$FAIR"   "-a -f -N p4_handoff"
+# --- known counterexamples (documented gaps/witnesses; see README.md) ------
+# G2 (pending observation wipes the attempt ledger) is still open.
+run w_pending_wipe       fail "-DMON_PENDING"          ""        "-a -N w_pending"
 
 echo
 if [ "$failures" -ne 0 ]; then

--- a/src/pkg/escalation/escalation.go
+++ b/src/pkg/escalation/escalation.go
@@ -136,6 +136,11 @@ type Observation struct {
 	HeadSHA string
 	Red     bool // CI status is failure
 	Excerpt string
+	// Labels are the PR's current forge labels. Sweep reads them to reconcile
+	// reviewer-lane verdicts (which are expressed as label edits, possibly made
+	// entirely outside the hub's view) back into the ledger — see the
+	// reviewer-pass reset in Sweep.
+	Labels []string
 }
 
 // Result reports the ledger's verdict for one observed PR.
@@ -183,6 +188,26 @@ func (s *Store) Sweep(obs []Observation, threshold int) map[string]Result {
 			e.ReEngagements = 0
 			e.Escalated = false
 			e.RedSHAs = nil
+		}
+		// Reviewer-verdict reconciliation (#5511, gap G1): the reviewer lane's
+		// REPAIR/DE-ESCALATE verdict is expressed as label edits only —
+		// needs-human removed, reviewer-passed added — usually via a direct
+		// `gh pr edit` the hub never observes. Without syncing that verdict
+		// into the ledger the entry stays Escalated forever, and if the
+		// reviewer's pushed fix goes red again the PR is orphaned: the fix
+		// lane and the reaper skip escalated rows, reviewer-passed excludes it
+		// from the reviewer lane, and NewlyEscala requires !Escalated so
+		// needs-human can never re-fire (proven by the Spin model in
+		// src/formal/escalation, property P5). Reset the entry the way
+		// machinery amnesty does — un-escalate, restart the distinct-SHA
+		// ledger, fresh re-engagement budget, Machinery untouched — so the PR
+		// re-enters the normal lifecycle. A later re-escalation then fires
+		// normally, and the reviewer-passed label routes it to a human rather
+		// than back to the reviewer.
+		if e.Escalated && containsLabel(o.Labels, ReviewerPassedLabel) && !containsLabel(o.Labels, NeedsHumanLabel) {
+			e.Escalated = false
+			e.RedSHAs = nil
+			e.ReEngagements = 0
 		}
 		if o.HeadSHA != "" && !containsSHA(e.RedSHAs, o.HeadSHA) {
 			e.RedSHAs = append(e.RedSHAs, o.HeadSHA)
@@ -375,6 +400,16 @@ func (s *Store) TryReEngage(repo string, number int, headSHA string) bool {
 		e.Escalated = false
 		e.RedSHAs = nil
 	}
+	// An escalated (needs-human) entry is out of the automated lane entirely:
+	// re-engaging it would burn budget on a PR the fix loop is standing down
+	// from and let a caller log "re-engaged fix loop" for a human-parked PR
+	// (#5511, gap G3 — the merge-request watcher's terminal path reaches here
+	// without consulting the escalated set, unlike the governor reaper). The
+	// amnesty above may have just un-escalated an older-generation entry, in
+	// which case re-engagement proceeds on its fresh budget as intended.
+	if e.Escalated {
+		return false
+	}
 	if e.ReEngagements >= MaxReEngagements {
 		return false
 	}
@@ -419,6 +454,15 @@ func containsSHA(shas []string, sha string) bool {
 	return false
 }
 
+func containsLabel(labels []string, label string) bool {
+	for _, l := range labels {
+		if l == label {
+			return true
+		}
+	}
+	return false
+}
+
 // CommentBody renders the escalation comment posted on the PR. It leads with
 // the raw CI evidence — the whole point is that a human (or the next agent
 // pass) sees the actual error, not just "CI failed".
@@ -444,3 +488,9 @@ func CommentBody(attempts int, failingChecks []string, excerpt string) string {
 // NeedsHumanLabel is the label applied to escalated PRs. Kick builders exclude
 // items carrying it from fix dispatch.
 const NeedsHumanLabel = "needs-human"
+
+// ReviewerPassedLabel marks a PR the reviewer lane (#5480) has repaired or
+// de-escalated once. Canonical here because Sweep's reviewer-verdict
+// reconciliation reads it against the ledger; the scheduler's reviewer lane
+// (pkg/scheduler) re-exports it for the work-list builder and kick contract.
+const ReviewerPassedLabel = "reviewer-passed"

--- a/src/pkg/escalation/escalation_test.go
+++ b/src/pkg/escalation/escalation_test.go
@@ -11,6 +11,14 @@ func obs(repo string, num int, sha string, red bool) Observation {
 	return Observation{Repo: repo, Number: num, HeadSHA: sha, Red: red, Excerpt: "ReferenceError: seedMission is not defined"}
 }
 
+// obsLabeled is obs with the PR's current forge labels attached, as the
+// enumeration pass supplies them for reviewer-verdict reconciliation.
+func obsLabeled(repo string, num int, sha string, red bool, labels ...string) Observation {
+	o := obs(repo, num, sha, red)
+	o.Labels = labels
+	return o
+}
+
 func TestSweep_EscalatesAtThresholdOfDistinctRedSHAs(t *testing.T) {
 	s := Load(filepath.Join(t.TempDir(), "streaks.json"))
 
@@ -278,5 +286,105 @@ func TestSweep_MachineryAmnestyReleasesOldGenerationEscalations(t *testing.T) {
 	}
 	if s.TryReEngage("org/repo", 9, "c") {
 		t.Fatal("cap must hold at the current generation — amnesty is one-shot")
+	}
+}
+
+// escalate drives a fresh entry for repo#num across three distinct red SHAs
+// and marks the escalation side effects fired, leaving it Escalated under the
+// CURRENT machinery generation.
+func escalate(t *testing.T, s *Store, repo string, num int) {
+	t.Helper()
+	for _, sha := range []string{"e1", "e2", "e3"} {
+		s.Sweep([]Observation{obs(repo, num, sha, true)}, 3)
+	}
+	s.MarkEscalated(repo, num)
+}
+
+// Reviewer-verdict reconciliation (#5511, gap G1): the reviewer lane's
+// REPAIR/DE-ESCALATE verdict is label edits only (needs-human removed,
+// reviewer-passed added), usually via direct gh the hub never sees. Sweep must
+// sync that verdict into the ledger — reset the entry like amnesty does — or
+// a reviewer fix that goes red again is orphaned: excluded from the fix lane,
+// the reaper, the reviewer lane, AND the needs-human queue, forever.
+func TestSweep_ReviewerPassResetsEscalatedEntry(t *testing.T) {
+	s := Load(filepath.Join(t.TempDir(), "streaks.json"))
+	escalate(t, s, "org/repo", 7)
+
+	// The reviewer repaired and relabeled; the pushed fix is red again. The
+	// entry must be reset: un-escalated, distinct-SHA ledger restarted at the
+	// new red SHA, back in the automated lane.
+	r := s.Sweep([]Observation{obsLabeled("org/repo", 7, "fix1", true, ReviewerPassedLabel)}, 3)
+	got := r[Key("org/repo", 7)]
+	if got.Escalated || got.NewlyEscala {
+		t.Fatalf("reviewer pass must un-escalate the ledger entry: got %+v", got)
+	}
+	if got.Attempts != 1 {
+		t.Fatalf("reviewer pass must restart the distinct-SHA ledger: got %+v", got)
+	}
+	// The reset entry has a fresh re-engagement budget (it is a normal
+	// automated-lane entry again).
+	if !s.TryReEngage("org/repo", 7, "fix1") {
+		t.Fatal("reset entry must be re-engageable")
+	}
+
+	// Re-escalation happens only on fresh red evidence: two more distinct red
+	// SHAs (labels unchanged — the reset must NOT repeat while un-escalated,
+	// or the count could never reach the threshold).
+	s.Sweep([]Observation{obsLabeled("org/repo", 7, "fix2", true, ReviewerPassedLabel)}, 3)
+	r = s.Sweep([]Observation{obsLabeled("org/repo", 7, "fix3", true, ReviewerPassedLabel)}, 3)
+	got = r[Key("org/repo", 7)]
+	if got.Attempts != 3 || !got.NewlyEscala {
+		t.Fatalf("three fresh red SHAs after the reset must re-escalate: got %+v", got)
+	}
+}
+
+// The reset must NOT fire while needs-human is still present (the reviewer has
+// not delivered a verdict — e.g. a partially-applied label edit) or when the
+// labels carry no reviewer verdict at all.
+func TestSweep_ReviewerResetRequiresVerdictLabels(t *testing.T) {
+	s := Load(filepath.Join(t.TempDir(), "streaks.json"))
+
+	// needs-human still present alongside reviewer-passed: no reset.
+	escalate(t, s, "org/repo", 8)
+	r := s.Sweep([]Observation{obsLabeled("org/repo", 8, "x1", true, NeedsHumanLabel, ReviewerPassedLabel)}, 3)
+	if got := r[Key("org/repo", 8)]; !got.Escalated {
+		t.Fatalf("needs-human still present must keep the entry escalated: got %+v", got)
+	}
+
+	// No reviewer verdict labels at all: no reset.
+	escalate(t, s, "org/repo", 9)
+	r = s.Sweep([]Observation{obsLabeled("org/repo", 9, "y1", true, NeedsHumanLabel)}, 3)
+	if got := r[Key("org/repo", 9)]; !got.Escalated {
+		t.Fatalf("an escalated entry without a reviewer verdict must stay escalated: got %+v", got)
+	}
+}
+
+// TryReEngage must refuse escalated entries (#5511, gap G3): the merge-request
+// watcher's terminal path calls it without consulting the escalated set, and
+// without this guard it burns re-engagement budget — and logs "re-engaged fix
+// loop" — for a PR the fix loop is standing down from.
+func TestTryReEngage_RefusesEscalatedEntry(t *testing.T) {
+	s := Load(filepath.Join(t.TempDir(), "streaks.json"))
+	escalate(t, s, "org/repo", 5)
+
+	if s.TryReEngage("org/repo", 5, "e3") {
+		t.Fatal("an escalated entry must not be re-engaged")
+	}
+	if got := s.ReEngagements("org/repo", 5); got != 0 {
+		t.Fatalf("refused re-engage must not burn budget: count = %d, want 0", got)
+	}
+	// Empty-SHA path (the merge watcher's actual call shape) too.
+	if s.TryReEngage("org/repo", 5, "") {
+		t.Fatal("an escalated entry must not be re-engaged via the empty-SHA path")
+	}
+
+	// Machinery amnesty still wins: an OLD-generation escalated entry is
+	// un-escalated by the amnesty block and gets its fresh budget.
+	key := Key("org/repo", 6)
+	s.mu.Lock()
+	s.entries[key] = &Entry{RedSHAs: []string{"a", "b", "c"}, Escalated: true, CurRedSHA: "c", Machinery: 1}
+	s.mu.Unlock()
+	if !s.TryReEngage("org/repo", 6, "c") {
+		t.Fatal("amnesty must still release an older-generation escalated entry")
 	}
 }

--- a/src/pkg/scheduler/reviewer_lane.go
+++ b/src/pkg/scheduler/reviewer_lane.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kubestellar/hive/pkg/escalation"
 	"github.com/kubestellar/hive/pkg/github"
 )
 
@@ -57,7 +58,19 @@ const (
 	// belongs to a true human: the work-list builder excludes labeled rows, so
 	// there is no reviewer<->escalation ping-pong. The machinery-generation
 	// amnesty (#5471) plus one reviewer pass then human is the full ladder.
-	ReviewerPassedLabel = "reviewer-passed"
+	// Canonical in pkg/escalation, where Sweep's reviewer-verdict
+	// reconciliation resets the ledger for PRs carrying it (#5511, gap G1).
+	ReviewerPassedLabel = escalation.ReviewerPassedLabel
+
+	// ReviewerRecommendCloseLabel marks a PR on which the reviewer has already
+	// delivered a RECOMMEND-CLOSE verdict. Below reviewerCloseACMMLevel the PR
+	// stays open (closing is operator-only), so without this marker the row
+	// remains fully adjudicable and the reviewer re-comments the same verdict
+	// on every kick until a human acts (#5511, gap G4 — Spin model witness
+	// w_onepass_acmm5). The work-list builder excludes labeled rows exactly
+	// like ReviewerPassedLabel; the kick contract instructs the reviewer to
+	// add the label alongside the recommend-close comment.
+	ReviewerRecommendCloseLabel = "reviewer-recommend-close"
 )
 
 // agentRole resolves the effective role for an agent name: the configured
@@ -127,6 +140,8 @@ func (s *Scheduler) buildReviewerMessage(agentName string, actionable *github.Ac
 	b.WriteString("  3. RECOMMEND-CLOSE — duplicate, superseded, or irreparably lossy: post exactly\n")
 	b.WriteString("     ONE comment:\n")
 	b.WriteString("        gh pr comment <number> --body \"[reviewer] recommend close: <rationale>\"\n")
+	b.WriteString(fmt.Sprintf("     then mark the verdict delivered so it is never repeated:\n"+
+		"        gh pr edit <number> --add-label %s\n", ReviewerRecommendCloseLabel))
 	if level >= reviewerCloseACMMLevel {
 		b.WriteString(fmt.Sprintf("     At this hive's ACMM level (%d) you MAY then close the PR yourself\n", level))
 		b.WriteString("     (gh pr close <number>) after posting the comment.\n")
@@ -164,8 +179,9 @@ func (s *Scheduler) buildReviewerWorkList() string {
 // ci-failing.json bytes. Rows are ESCALATED hive-authored PRs only —
 // writeMergeEligible builds the file exclusively from the hive's own PR
 // enumeration with per-agent attribution, so every row is hive work; rows
-// whose Labels carry ReviewerPassedLabel are excluded (one reviewer pass per
-// PR, ever). Output is capped at reviewerMaxPRsPerKick rows, oldest first
+// whose Labels carry ReviewerPassedLabel or ReviewerRecommendCloseLabel are
+// excluded (one reviewer pass per PR, ever — whatever the verdict was).
+// Output is capped at reviewerMaxPRsPerKick rows, oldest first
 // (ascending PR number per repo — the enumeration carries no creation time,
 // and numbers are monotonic per repo).
 func formatReviewerWorkList(data []byte) string {
@@ -190,15 +206,19 @@ func formatReviewerWorkList(data []byte) string {
 		if !pr.Escalated {
 			continue // still in the automated fix lane — not the reviewer's
 		}
-		passed := false
+		adjudicated := false
 		for _, l := range pr.Labels {
-			if l == ReviewerPassedLabel {
-				passed = true
+			// One reviewer pass per PR, ever — for EVERY verdict class:
+			// reviewer-passed covers REPAIR/DE-ESCALATE; recommend-close
+			// covers the below-close-authority verdict whose PR stays open
+			// awaiting an operator (#5511, gap G4).
+			if l == ReviewerPassedLabel || l == ReviewerRecommendCloseLabel {
+				adjudicated = true
 				break
 			}
 		}
-		if passed {
-			continue // one reviewer pass per PR: a re-escalation is a human's
+		if adjudicated {
+			continue // one reviewer pass per PR: the rest is a human's
 		}
 		rows = append(rows, pr)
 	}

--- a/src/pkg/scheduler/reviewer_lane_test.go
+++ b/src/pkg/scheduler/reviewer_lane_test.go
@@ -29,6 +29,8 @@ const reviewerFixture = `{"generated_at":"2026-09-01T00:00:00Z","ci_failing":[
    "excerpt":"ReferenceError: seedMission is not defined"},
   {"number":41,"repo":"test-org/console","title":"escalated, already adjudicated","agent":"quality","escalated":true,
    "labels":["needs-human","reviewer-passed"],"failing_checks":["go test"]},
+  {"number":44,"repo":"test-org/console","title":"escalated, close already recommended","agent":"quality","escalated":true,
+   "labels":["needs-human","reviewer-recommend-close"],"failing_checks":["go test"]},
   {"number":3,"repo":"test-org/console","title":"oldest escalated","escalated":true,
    "labels":["needs-human"],"failing_checks":["lint"]}
 ]}`
@@ -54,6 +56,12 @@ func TestFormatReviewerWorkList_EscalatedOnlyAndReviewerPassedExcluded(t *testin
 	}
 	if strings.Contains(out, "#41") {
 		t.Error("reviewer-passed PR must be excluded: one reviewer pass per PR, ever")
+	}
+	// #5511 gap G4: below the close-authority level a RECOMMEND-CLOSE verdict
+	// leaves the PR open, so without this exclusion the reviewer would
+	// re-adjudicate (re-comment) it on every kick until an operator acts.
+	if strings.Contains(out, "#44") {
+		t.Error("reviewer-recommend-close PR must be excluded: the verdict was already delivered")
 	}
 	// Unattributed rows surface as scanner, the fleet's primary PR creator.
 	if !strings.Contains(out, "original author agent: scanner") {
@@ -169,6 +177,7 @@ func TestBuildReviewerMessage_ContractAtL5(t *testing.T) {
 		"--remove-label needs-human",
 		"--add-label " + ReviewerPassedLabel,
 		"[reviewer] recommend close:",
+		"--add-label " + ReviewerRecommendCloseLabel,
 		"NEVER close the PR yourself",
 		fmt.Sprintf("AT MOST %d PRs this kick", reviewerMaxPRsPerKick),
 		"NEVER touch a human-authored PR",


### PR DESCRIPTION
Fixes the gaps documented in #5511 (G1, G3, G4). Refs #5480.

## G1 — the reviewer-pass orphan (the real bug)

The reviewer lane's REPAIR/DE-ESCALATE verdict is expressed as **label edits only**: `needs-human` removed, `reviewer-passed` added, fix pushed. The escalation ledger was never told — `Entry.Escalated` stayed `true`. So if the reviewer's pushed fix resolved **red** again, the PR was excluded from *every* lane, forever:

- FIX-BEFORE-NEW and the reaper skip escalated rows (`row.Escalated` from the ledger);
- `reviewer-passed` excludes it from the reviewer lane;
- `NewlyEscala` requires `!Entry.Escalated`, so the `needs-human` label (and ntfy) could never re-fire — the human queue is the label, and the label never came back.

Red, open, owned by nobody. The Spin model in `src/formal/escalation` (#5511) proved this is a genuine liveness violation (P5: acceptance cycle at 5,169 states) with only nondeterministic rescues (a `MachineryVersion` bump, or gap G2's pending-wipe happening to fire in the CI window), and proved via its `-DPATCH_REVIEWER` variant that a ledger reset at the reviewer pass closes it.

**Fix (sweep-side, per the proven patch shape)**: `escalation.Observation` now carries the PR's labels (threaded from the enumeration in `runEscalationSweep`), and `Store.Sweep` reconciles the verdict: an `Escalated` entry observed with `reviewer-passed` and **without** `needs-human` is reset the way machinery amnesty resets — un-escalated, `RedSHAs` cleared, fresh re-engagement budget, `Machinery` untouched. Sweep-side because the reviewer's `gh pr edit` happens outside the hub's view; the sweep sees the labels every pass regardless of who edited them. The reset disarms itself (it requires `Escalated`), so fresh reds re-accumulate normally; a later re-escalation fires `NewlyEscala` again, and the `reviewer-passed` exclusion routes it to a human, not back to the reviewer.

## G3 — `TryReEngage` lacked an `Escalated` guard

The merge-request watcher's terminal path calls `TryReEngage` without consulting the escalated set (unlike the reaper), burning re-engagement budget and logging "re-engaged fix loop" for `needs-human` PRs — and a budget burned this way could trigger a premature exhaustion re-escalation after amnesty. Escalated entries now return `false`, guarded after the amnesty block so older-generation entries still get their amnesty release.

## G4 — RECOMMEND-CLOSE repeated every kick below ACMM 6

Below the close-authority level the PR stays open and the row stayed fully adjudicable, so the reviewer re-commented the same verdict on every kick. The kick contract now instructs adding the `reviewer-recommend-close` label alongside the comment, and the work-list builder excludes it exactly like `reviewer-passed`.

## Model re-verification (same PR: the fixes are the modeled default)

The former `-DPATCH_REVIEWER` hypothetical is retired — the model now carries the shipped behavior (sweep-side reconciliation, store-side re-engage guard, recommend-close marker). Full matrix, Spin 6.5.2, exhaustive (`-m500000`, DFS + COLLAPSE, liveness with weak fairness; deepest search depth 384, all searches completed, 0 unexpected verdicts):

| Property | Before (#5511 model) | After (this PR) | States |
|---|---|---|---|
| P4b reviewer→human handoff | **VIOLATED** (cycle at 7,207) | **holds** | 3,217,019 |
| P5 escalated ⇒ eventually terminal | **VIOLATED** (cycle at 5,169) | **holds** | 3,224,760 |
| W1 one adjudication ever, ACMM 5 | witness at 4,113 | **holds** | 3,215,657 |
| W3 no re-engage budget on escalated PR | witness at 207,685 | **holds** | 27,818,920 |
| P1/P2 amnesty invariants | holds | holds | 8,822,910 |
| P3 budget caps | holds | holds | 15,779,561 / 3,215,657 / 15,779,561 |
| P4a / P6 exclusion safety | holds | holds | 3,215,657 / 27,818,920 |
| W1 at ACMM 6 | holds | holds | 2,140,034 |
| W2 pending-wipe (gap G2, still open) | witness | witness (pinned expected-fail) | 7,706 |

`run.sh` expectations flipped for the four closed rows; G2's witness remains the only pinned expected failure. README results table, gap narratives, and the model↔code mapping updated to match.

## Tests

- `TestSweep_ReviewerPassResetsEscalatedEntry` — reset on the label pair, ledger restarts at the new red SHA, re-escalates only on three fresh reds.
- `TestSweep_ReviewerResetRequiresVerdictLabels` — no reset while `needs-human` persists or without a verdict label.
- `TestTryReEngage_RefusesEscalatedEntry` — no budget burned on escalated entries (head-SHA and empty-SHA paths); amnesty still releases old generations.
- `TestFormatReviewerWorkList_EscalatedOnlyAndReviewerPassedExcluded` — extended for the `reviewer-recommend-close` exclusion; contract test asserts the new label instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)