### PR TITLE
🐛 fix: the Submit login code button called an undefined helper

### DIFF
--- a/.github/workflows/dashboard-lint.yml
+++ b/.github/workflows/dashboard-lint.yml
@@ -7,15 +7,25 @@ name: Dashboard Lint
 # would then pass against a checker nobody had exercised. The workflow file is
 # listed for the same reason: an edit to the `find` invocation here changes
 # what gets checked, and that edit must run the job it changes.
+#
+# THE SHIPPED DASHBOARD IS src/pkg/dashboard/static/ (#5516). That is the tree
+# `//go:embed static` compiles into the binary and serves; dashboard/index.html
+# is a different, smaller file. Until this was added, every edit to the
+# dashboard an operator actually loads ran no lint at all — which is how a
+# call to an undefined helper reached a released image and broke the login
+# flow. Both trees are checked now, and both are in the path filter, so a PR
+# touching either runs the job.
 on:
   push:
     paths:
       - 'dashboard/**'
+      - 'src/pkg/dashboard/static/**'
       - '.github/scripts/check-inline-js.js'
       - '.github/workflows/dashboard-lint.yml'
   pull_request:
     paths:
       - 'dashboard/**'
+      - 'src/pkg/dashboard/static/**'
       - '.github/scripts/check-inline-js.js'
       - '.github/workflows/dashboard-lint.yml'
 
@@ -30,5 +40,5 @@ jobs:
 
       - name: Extract and syntax-check inline JavaScript
         run: |
-          find dashboard -name '*.html' -print0 \
+          find dashboard src/pkg/dashboard/static -name '*.html' -print0 \
             | xargs -0 --no-run-if-empty node .github/scripts/check-inline-js.js

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -6228,7 +6228,7 @@
       if (code === null) return;
       if (!code.trim()) { showToast('No code entered', 'error'); return; }
       try {
-        const r = await apiFetch(`/api/agents/${encodeURIComponent(agentName)}/login-code`, {
+        const r = await fetch(`/api/agents/${encodeURIComponent(agentName)}/login-code`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ code: code.trim() }),


### PR DESCRIPTION
## Summary

The **"↩ Submit login code"** button added in #5494 throws `apiFetch is not defined` and sends nothing, so the browser-OAuth sign-in flow that PR set out to unblock is still unfinishable in the released image.

`submitLoginCode()` calls `apiFetch(...)`, which does not exist anywhere in the dashboard — 0 definitions, 1 call site, and that call site is the new one. The control it was modelled on, `copyTerminalUrl()`, uses plain `fetch()`. Reported by an operator on `ghcr.io/kubestellar/hive:stable` @ `5beec6e2`; the gateway log shows **no** request for the endpoint at all, which is the signature of a client-side throw. The server side was never at fault — `POST /api/agents/{name}/login-code` returns `400` (the empty-code refusal), not `404`.

One character of behaviour, plus the CI gap that let it through.

**Blast radius:** restores a control that is currently 100% broken. No server change, no API change.

Fixes #5516

## Why CI did not catch it

`dashboard-lint.yml` filters on `dashboard/**` and runs `find dashboard -name '*.html'`. The dashboard that is **compiled into the binary and served** is `src/pkg/dashboard/static/` (`//go:embed static` in `server.go`). `dashboard/index.html` is a *different* file — 281 KB against 1.5 MB, not a copy.

So the job never ran on #5494, and more generally **every edit to the dashboard an operator actually loads has been running no lint at all.** Both trees are now in the path filter and both are passed to the checker.

## What is deliberately not in this PR

Closing the path gap does not close the bug *class*: `check-inline-js.js` runs `node --check`, and calling a function that does not exist is valid syntax. It fails when someone clicks the button.

I attempted a regex approximation of `no-undef` and removed it. Recording why, so the next person does not repeat it:

- Scanning for `name(` where `name` is never declared reported **seven false positives** on this repo's own dashboard — prose inside comments (`links (see below)`, `Guide (…)`, `brightness (0-1)`) is call-shaped.
- Suppressing those needs comments and string literals blanked first. A single-pass stripper does that, but it cannot tell a regex literal such as `/['"]/` from division without real parsing — the quote inside opens a phantom string and blanks thousands of lines of genuine code, taking real `function` declarations with it. That produced **four more** false positives, on functions that are plainly defined (`acmmShowLevelDialog` at line 15460, and others).
- My own comment on that stripper claimed the weakness "can only ever ADD a candidate identifier". That was wrong: it also *removes declarations*, which is the direction that produces false positives.

A lint that blocks PRs on noise is worse than the gap it closes. The right tool is eslint's `no-undef` over the extracted blocks, which is a dependency and config change that deserves its own PR rather than being half-built inside a one-line fix.

## Testing

- [x] `node .github/scripts/check-inline-js.js` over **both** dashboard trees — passes, and now actually covers the served file
- [x] `cd src && go build ./...`
- [x] `cd src && go test ./pkg/dashboard/`
- [x] `grep -c apiFetch src/pkg/dashboard/static/index.html` → 0
- [ ] Not run: the button itself is not covered by an automated browser test — that absence is the subject of #5516's second half, and is why this shipped.

## Contributor checklist

- [x] PR targets `v4`.
- [x] Title uses the repo emoji convention.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies updated where behavior changes — the workflow comment records which tree is the shipped one and why both are checked.
- [ ] `CHANGELOG.md` — not added; this repairs an unreleased-to-operators regression from #5494 rather than changing intended behaviour. Happy to add one.
- [x] No secrets, credentials, or local runtime state are committed.
