### PR TITLE
✨ feat(quality): add formal verification capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ## Unreleased
 
+### Added
+
+- The quality lane can now opt into agent-authored formal verification with `quality.formal: true` at ACMM L5/L6. Every quality kick receives the same model-worthiness, `formal/<subsystem>/` artifact, expected-verdict drift, reporting-only CI, counterexample narrative/deduplication, and modeled-subsystem maintenance contract even when its ordinary policy prompt is customized. The zero value is off, and the setting becomes inert on an ACMM downgrade below L5 without being discarded ([#5512](https://github.com/kubestellar/hive/issues/5512)).
+
 ## 2026-09-01 (v4.0.1)
 
 ### Added

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -58,6 +58,7 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 ## Configuration and agents
 
 - [Agent configuration](agent-configuration.md) — agent fields, methods, models, pins, cadences, caveman mode, ACMM packs, and live-linked `definition_source` (with its seed-only trust model).
+- [Formal verification](formal-verification.md) — the optional L5/L6 `quality.formal` capability for agent-authored Spin/Promela models, reporting-only CI, and deduplicated counterexample issues.
 - [Advisory digest](advisory.md) — what the digest shows (`max_findings`, `show_all`) and how findings are retired (staleness auto-close, PR-linked auto-close).
 - [Advisory digest staleness](advisory-staleness.md) — when the hub raises the stale-advisory pill and alert, the gates that deliberately suppress it (undelivered App, App cannot write, all agents quiet), and the admin diagnostics that measure hidden staleness.
 - [Governor mode thresholds](https://github.com/kubestellar/hive/blob/v4/src/docs/governor-thresholds.md) — how idle/quiet/busy/surge thresholds scale with repo count, the `threshold_scaling` curves, and when explicit thresholds win.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -426,6 +426,14 @@ The L5 roster is the canonical worked example — eleven agents, eight on the go
 
 At L5, every agent PR gets a `hold` label automatically. The system proposes; it does not merge autonomously.
 
+The quality lane has an additional opt-in formal-verification capability at
+L5/L6. Set top-level `quality.formal: true` to let quality identify
+protocol-shaped subsystems and author Spin/Promela models, their executable
+property contract, and reporting-only CI. The setting is inert below L5 and
+does not turn modeling into a default for every repository. See
+[Formal verification](formal-verification.md) for the admission, artifact,
+reporting, and maintenance rules.
+
 Telemetry and operations are L5/L6-only agents. They stay absent below L5 and remain paused at L5/L6 until an operator deliberately opts in. Their lane keywords are disjoint: telemetry owns instrumentation and observability terms, while operations owns health, SLO, runbook, incident, rollback, and alerting terms.
 
 Configure that opt-in under **Settings → Project Observability**. This tab is

--- a/src/docs/formal-verification.md
+++ b/src/docs/formal-verification.md
@@ -1,0 +1,102 @@
+# Formal verification in the quality lane
+
+Hive can let the quality agent author and maintain Spin/Promela models for
+protocol-shaped code. This is an optional capability, not another default lane
+and not a claim that Hive proves functional correctness.
+
+## Enablement and maturity gate
+
+Enable it in the trusted hive configuration:
+
+```yaml
+acmm_level: 5
+quality:
+  formal: true
+```
+
+Both conditions are required. `quality.formal` defaults to false, and an
+explicit true is inert below ACMM L5. Downgrading a hive therefore disables
+formal-model authoring immediately without deleting the operator's preference;
+raising it back to L5/L6 restores the capability.
+
+The contract is injected after ordinary policy-template resolution. It reaches
+scheduled and manual kicks, quality replicas, and locally customized or remote
+quality prompts. Operators can customize the rest of the quality policy without
+silently weakening what `quality.formal` promises.
+
+## What is worth modeling
+
+The agent must justify model-worthiness in every PR that introduces a model. A
+candidate should have one or more concrete signals such as:
+
+- a state-machine lifecycle;
+- concurrent actors;
+- retry, escalation, or durable ledger state;
+- ordering or lock invariants;
+- lease, claim, or ownership transfer; or
+- prior incidents caused by a protocol interleaving.
+
+If no subsystem qualifies, the quality agent continues its normal test and
+coverage work. It must not add a placeholder model. Formal scope is protocol,
+safety, and liveness behavior; modeling every component or proving general
+functional correctness is out of scope.
+
+## Repository artifact contract
+
+Each modeled subsystem owns:
+
+```text
+formal/<subsystem>/
+├── model.pml
+├── run.sh
+└── README.md
+```
+
+A repository organized below a component root may put `formal/` at that root.
+The README maps every modeled state and transition to its production code,
+documents abstractions and fairness assumptions, lists each property, and gives
+counterexample replay commands. The model PR explains why ordinary tests cannot
+reliably explore the interleavings being modeled.
+
+`run.sh` is the executable source of truth. It performs exhaustive Spin checks
+and returns nonzero whenever an observed verdict differs from the pinned
+expectation. That includes both must-pass properties and intentional
+expected-fail witnesses. A new violation and an undocumented fix that makes a
+known witness disappear are both model drift and both make the script red.
+
+## CI and failure reporting
+
+The model PR adds a path-gated CI job covering the model, the corresponding
+production subsystem, and the workflow itself. The job is reporting-only and
+must not be configured as a required merge check. It preserves the logs or
+trails needed for local replay, but a raw Spin trail is not an actionable issue.
+
+The quality agent minimizes and replays each unexpected counterexample, then
+files one issue per violated property using this stable title:
+
+```text
+[formal:<subsystem>:<property-id>] <property summary>
+```
+
+Before creating, it performs only a narrow exact-title lookup. If that property
+already has an open issue, the agent updates it with the new model revision,
+run, and narrative instead of creating a duplicate. Different properties never
+share one issue. The narrative records user impact, an actor-by-actor
+interleaving, the reproducible model revision/run, matching production code,
+and what a modeled candidate fix proves when one exists.
+
+Issue narration stays agent-owned. A pull-request workflow should not receive
+broad issue-write permission solely to turn an untrusted raw trail into prose.
+When the repository supplies an issue relay such as `hive-open-issue`, the agent
+uses that relay and its exact-title deduplication contract.
+
+## Modeled-code maintenance
+
+A PR that touches a modeled subsystem and turns its formal job red must either
+fix the code or update the model in the same PR with the new invariant story.
+Rerunning past the evidence, weakening a property, deleting an expected witness,
+or narrowing the path gate merely to make CI green is not maintenance.
+
+Existing red quality PRs still take precedence under FIX-BEFORE-NEW. Enabling
+formal verification does not authorize the quality agent to abandon repair work
+and start a fresh model.

--- a/src/docs/operator-reference.md
+++ b/src/docs/operator-reference.md
@@ -58,6 +58,7 @@ Top-level YAML keys accepted by `config.Config`:
 | `hub` | Hub/spoke hosted-hive metadata. | Usually provisioner-owned. |
 | `hive_id` | Stable spoke identifier. | Usually provisioner-owned. |
 | `acmm_level` | Current ACMM pack level. | May be set by hub/dashboard. |
+| `quality` | Optional quality-lane capabilities. | `formal: true` enables agent-authored Spin models only at ACMM L5/L6; see [Formal verification](formal-verification.md). |
 | `variables` | Trusted variable resolver definitions. | Env-only substitution works without this block. |
 | `removed_agents` | Persistent tombstones for deleted agents. | Dashboard/overlay-owned; do not seed casually. |
 

--- a/src/hive.yaml.example
+++ b/src/hive.yaml.example
@@ -408,6 +408,14 @@ governor:
 # planning:
 #   plan_from_label: false
 
+# Optional formal-verification capability for the quality lane. OFF by default
+# and effective only at ACMM L5/L6. When enabled, quality may author
+# Spin/Promela models for protocol-shaped code under formal/<subsystem>/, add a
+# path-gated reporting-only CI job, and maintain one deduplicated issue per
+# violated property. See docs/formal-verification.md for the artifact contract.
+# quality:
+#   formal: false
+
 # CEL-based agent triggers — declarative rules that kick an agent directly off
 # a normalized source-control event (issue opened, PR opened, a label applied,
 # a comment posted), evaluated with CEL against the `event` variable. This is

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	Ioscan       IoscanConfig       `yaml:"ioscan,omitempty" json:"ioscan,omitempty"`
 	Classifier   ClassifierConfig   `yaml:"classifier,omitempty" json:"classifier,omitempty"`
 	Planning     PlanningConfig     `yaml:"planning,omitempty" json:"planning,omitempty"`
+	Quality      QualityConfig      `yaml:"quality,omitempty" json:"quality,omitempty"`
 	Intent       IntentConfig       `yaml:"intent,omitempty" json:"intent,omitempty"`
 	Escalation   EscalationConfig   `yaml:"escalation,omitempty" json:"escalation,omitempty"`
 	Retro        RetroConfig        `yaml:"retro,omitempty" json:"retro,omitempty"`
@@ -366,6 +367,29 @@ type PlanningConfig struct {
 	// true is a no-op below L5, because the architect that decomposes the minted
 	// epics is not scheduled there.
 	PlanFromLabel *bool `yaml:"plan_from_label,omitempty" json:"plan_from_label,omitempty"`
+}
+
+// FormalQualityMinACMMLevel is the first maturity level at which the quality
+// lane may author and maintain formal models. Below L5, quality is either
+// advisory or restricted to narrower testing work, so enabling the capability
+// there would grant behavior the active ACMM pack does not permit.
+const FormalQualityMinACMMLevel = 5
+
+// QualityConfig controls opt-in capabilities of the quality lane. The zero
+// value preserves the existing test/coverage-only behavior.
+type QualityConfig struct {
+	// Formal lets the quality agent identify protocol-shaped code and add a
+	// Spin/Promela model, its executable verification contract, and reporting-
+	// only CI. It is deliberately opt-in and is effective only at ACMM L5+.
+	Formal bool `yaml:"formal,omitempty" json:"formal,omitempty"`
+}
+
+// FormalEnabled reports whether the operator opt-in and ACMM floor both allow
+// formal-model work. Keeping the floor in this effective-value method means a
+// level downgrade safely disables the capability without making the persisted
+// config invalid or forgetting the operator's preference.
+func (q QualityConfig) FormalEnabled(acmmLevel int) bool {
+	return q.Formal && acmmLevel >= FormalQualityMinACMMLevel
 }
 
 // RetroConfig gates the post-completion retro lane. It is off by

--- a/src/pkg/config/formal_quality_test.go
+++ b/src/pkg/config/formal_quality_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestFormalQualityCapabilityRequiresOptInAndL5(t *testing.T) {
+	tests := []struct {
+		name   string
+		formal bool
+		level  int
+		want   bool
+	}{
+		{name: "absent at L6", level: 6},
+		{name: "opted in below floor", formal: true, level: 4},
+		{name: "opted in at floor", formal: true, level: 5, want: true},
+		{name: "opted in above floor", formal: true, level: 6, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := (QualityConfig{Formal: tt.formal}).FormalEnabled(tt.level)
+			if got != tt.want {
+				t.Fatalf("FormalEnabled(%d) = %v, want %v", tt.level, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormalQualityConfigSerialization(t *testing.T) {
+	var cfg Config
+	if err := yaml.Unmarshal([]byte("quality:\n  formal: true\n"), &cfg); err != nil {
+		t.Fatalf("unmarshal YAML: %v", err)
+	}
+	if !cfg.Quality.Formal {
+		t.Fatal("quality.formal did not parse from YAML")
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	var roundTrip struct {
+		Quality QualityConfig `json:"quality"`
+	}
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+	if !roundTrip.Quality.Formal {
+		t.Fatalf("quality.formal lost in JSON round trip: %s", data)
+	}
+}

--- a/src/pkg/policies/defaults/formal-quality-capability.md
+++ b/src/pkg/policies/defaults/formal-quality-capability.md
@@ -1,0 +1,59 @@
+## Formal verification capability — operator enabled
+
+`quality.formal` is enabled and this hive is at ACMM L5 or above. Formal work
+is optional per repository and is limited to protocol and liveness properties;
+do not try to prove general functional correctness or model every subsystem.
+
+### Admission: justify model-worthiness first
+
+Author a model only when the target has protocol-shaped behavior with one or
+more concrete signals such as a state-machine lifecycle, concurrent actors,
+retry/escalation/ledger state, ordering or lock invariants, lease/claim
+ownership, or a prior protocol incident. In the model PR, name the signals and
+explain why ordinary unit tests cannot reliably cover the relevant
+interleavings. If no subsystem qualifies, continue ordinary quality work and do
+not add placeholder formal artifacts.
+
+### Artifact and verification contract
+
+- Put each model at `formal/<subsystem>/{model.pml,run.sh,README.md}`. A repo
+  whose source lives below a component root may keep `formal/` at that root.
+- `README.md` must map every modeled state and transition to its concrete code
+  construct, state all abstractions and fairness assumptions, identify every
+  invariant/property, and give local counterexample replay commands.
+- `run.sh` must run exhaustive Spin verification and exit nonzero on property
+  drift. Pin both expected-pass properties and intentional expected-fail
+  witnesses: a regression and a silent fix that leaves stale expectations must
+  both turn the script red.
+- Add a path-gated, reporting-only CI job for `formal/**`, the modeled source,
+  and the workflow itself. It must never become a required merge check. Preserve
+  enough logs/trails to replay a failure; do not publish a raw trail as the
+  issue explanation.
+
+### One actionable issue per violated property
+
+For each unexpected violation, minimize/replay the counterexample and translate
+it into a plain-language actor-by-actor interleaving. Use the stable title
+`[formal:<subsystem>:<property-id>] <property summary>`. A narrow exact-title
+lookup for that title is allowed solely for deduplication. Create the issue if
+none is open; otherwise update the existing issue with the new model revision,
+failing run, and narrative. Never create one issue per run, and never combine
+distinct properties into one issue. Include:
+
+- the violated property and user impact;
+- the minimized interleaving, naming each actor and state transition;
+- the model revision plus the failing CI run or reproducible local command;
+- the corresponding production code paths; and
+- whether a candidate fix was modeled and what the patched model proved.
+
+Use the repository's issue-write helper when one is provided. Do not grant a
+pull-request workflow broad issue-write permission merely to automate filing;
+the quality agent owns narrative construction and exact-title deduplication.
+
+### Maintenance rule
+
+When a PR touches a modeled subsystem and formal verification turns red, fix
+the code or update the model in that same PR with the changed invariant story.
+Do not rerun past the evidence, weaken an invariant, delete an expected witness,
+or narrow the path gate just to make CI green. Existing red PR repair remains
+FIX-BEFORE-NEW and takes precedence over authoring another model.

--- a/src/pkg/scheduler/formal_quality.go
+++ b/src/pkg/scheduler/formal_quality.go
@@ -1,0 +1,45 @@
+package scheduler
+
+import (
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/policies"
+)
+
+const formalQualityPolicyPath = "defaults/formal-quality-capability.md"
+
+// addFormalQualityCapability prepends the formal-model authoring contract to
+// every quality-role kick when the operator opt-in and ACMM floor both allow
+// it. This is deliberately outside template resolution: an operator-authored
+// or remotely sourced quality prompt may customize the lane, but cannot make
+// quality.formal silently mean something weaker than the artifact/reporting
+// contract documented by Hive.
+func (s *Scheduler) addFormalQualityCapability(agentName, message string) string {
+	if message == "" || s.cfg == nil || s.agentRole(agentName) != "quality" {
+		return message
+	}
+	level := 0
+	if s.cfg.ACMMLevel != nil {
+		level = *s.cfg.ACMMLevel
+	}
+	if !s.cfg.Quality.FormalEnabled(level) {
+		return message
+	}
+
+	data, err := policies.DefaultPolicies.ReadFile(formalQualityPolicyPath)
+	if err != nil {
+		// The file is embedded at build time, so this can only indicate a broken
+		// binary. Fail closed: do not launch a formal-enabled quality kick with
+		// an incomplete safety/maintenance contract.
+		if s.logger != nil {
+			s.logger.Error("formal quality capability contract unavailable", "path", formalQualityPolicyPath, "error", err)
+		}
+		return ""
+	}
+
+	section := strings.TrimSpace(string(data)) + "\n\n"
+	if newline := strings.IndexByte(message, '\n'); newline >= 0 {
+		return message[:newline+1] + "\n" + section + message[newline+1:]
+	}
+	return section + message
+}

--- a/src/pkg/scheduler/formal_quality_test.go
+++ b/src/pkg/scheduler/formal_quality_test.go
@@ -1,0 +1,100 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+func formalQualityScheduler(t *testing.T, level int, enabled bool, role string) *Scheduler {
+	t.Helper()
+	redirectPolicySeams(t)
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentsDir, "custom-quality.md"), []byte("CUSTOM QUALITY POLICY\n${ISSUE_LIST}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		ACMMLevel: &level,
+		Quality:   config.QualityConfig{Formal: enabled},
+		Project: config.ProjectConfig{
+			Org: "acme", Name: "Acme", PrimaryRepo: "widget", Repos: []string{"widget"},
+		},
+		Agents: map[string]config.AgentConfig{
+			"quality": {Role: role, KickTemplate: "custom-quality.md"},
+		},
+		Policies: config.PoliciesConfig{LocalDir: dir},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return New(cfg, logger)
+}
+
+func TestFormalQualityCapabilityReachesCustomizedKicks(t *testing.T) {
+	s := formalQualityScheduler(t, config.FormalQualityMinACMMLevel, true, "quality")
+	msg := s.BuildAgentMessage("quality", nil, nil)
+	for _, want := range []string{
+		"[agent:quality]",
+		"Formal verification capability — operator enabled",
+		"formal/<subsystem>/{model.pml,run.sh,README.md}",
+		"expected-pass properties and intentional expected-fail",
+		"reporting-only CI job",
+		"[formal:<subsystem>:<property-id>]",
+		"plain-language actor-by-actor interleaving",
+		"FIX-BEFORE-NEW",
+		"CUSTOM QUALITY POLICY",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("formal quality kick missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Index(msg, "Formal verification capability") > strings.Index(msg, "CUSTOM QUALITY POLICY") {
+		t.Fatalf("formal contract must precede customizable work selection:\n%s", msg)
+	}
+}
+
+func TestFormalQualityCapabilityIsHardGated(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		level   int
+		enabled bool
+		role    string
+	}{
+		{name: "disabled at L5", level: 5, role: "quality"},
+		{name: "enabled below L5", level: 4, enabled: true, role: "quality"},
+		{name: "enabled for non-quality role", level: 6, enabled: true, role: "scanner"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := formalQualityScheduler(t, tt.level, tt.enabled, tt.role)
+			msg := s.BuildAgentMessage("quality", nil, nil)
+			if strings.Contains(msg, "Formal verification capability") {
+				t.Fatalf("formal contract rendered outside its capability gate:\n%s", msg)
+			}
+			if !strings.Contains(msg, "CUSTOM QUALITY POLICY") {
+				t.Fatalf("ordinary quality policy was suppressed:\n%s", msg)
+			}
+		})
+	}
+}
+
+func TestFormalQualityCapabilityAppliesAtL6(t *testing.T) {
+	s := formalQualityScheduler(t, 6, true, "quality")
+	if msg := s.BuildAgentMessage("quality", nil, nil); !strings.Contains(msg, "Formal verification capability") {
+		t.Fatalf("L6 opt-in did not enable formal capability:\n%s", msg)
+	}
+}
+
+func TestFormalQualityCapabilityAppliesToReplicas(t *testing.T) {
+	s := formalQualityScheduler(t, 5, true, "quality")
+	s.cfg.Agents["quality-2"] = config.AgentConfig{Role: "quality", ReplicaOf: "quality"}
+	msg := s.BuildAgentMessage("quality-2", nil, nil)
+	if !strings.Contains(msg, "[agent:quality-2]") || !strings.Contains(msg, "Formal verification capability") {
+		t.Fatalf("quality replica did not inherit formal capability:\n%s", msg)
+	}
+}

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -616,6 +616,11 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 	// operator overrides vulnerable indefinitely (kubestellar/hive#4744).
 	defer func() {
 		message = s.addHeldPRCoordination(agentName, actionable, message)
+		// Formal verification is an operator-enabled quality capability, not a
+		// property of one particular prompt file. Inject its contract after
+		// template resolution so local edits, remote prompts, replicas, scheduled
+		// kicks, and manual kicks cannot accidentally omit it.
+		message = s.addFormalQualityCapability(agentName, message)
 		// Fix-before-new: an agent with red PRs of its own must see them —
 		// with the CI evidence — ahead of any new work. Injected at the same
 		// post-resolution seam as the held-PR preflight so no template path


### PR DESCRIPTION
## Problem

Hive's quality lane can author tests and CI improvements, but it has no operator-facing switch or durable policy contract for formal verification. An operator cannot opt a mature hive into model authoring, and simply editing the built-in quality templates would not be sufficient: local policy overrides, remote prompts, replicas, and manual kicks could all omit the model/artifact/reporting rules.

That leaves the workflow demonstrated by #5511 as a hand-scoped pilot rather than a reusable quality-lane capability. In particular, Hive did not encode when a subsystem is model-worthy, how model verdicts become executable drift checks, or how repeated counterexamples map to one actionable issue per property.

## Root cause

Formal verification was not represented in `config.Config`, and the scheduler had no post-template capability seam for it. Quality behavior was entirely selected through ordinary kick templates. Those templates are intentionally customizable, so using them as the only enforcement point would make `quality.formal` mean different things on different hives and would allow stale overrides to silently omit key invariants.

## Implementation

- Adds top-level `quality.formal` through `config.QualityConfig`. The zero value is off. `FormalEnabled` combines the explicit opt-in with a hard ACMM L5 floor.
- Injects the formal capability contract after all normal prompt resolution in `Scheduler.BuildAgentMessage`. This covers embedded, local, and remote templates plus scheduled/manual kicks and quality replicas.
- Fails closed if a formal-enabled binary cannot load its embedded contract: Hive suppresses that kick rather than launching a quality agent with incomplete safety and maintenance instructions.
- Defines the agent contract in `pkg/policies/defaults/formal-quality-capability.md`:
  - justify model-worthiness for protocol-shaped code before authoring;
  - use `formal/<subsystem>/{model.pml,run.sh,README.md}` and map model state back to production code;
  - pin expected-pass and intentional expected-fail outcomes so fixes and regressions both expose drift;
  - add only path-gated, reporting-only CI;
  - minimize/replay failures and use stable `[formal:<subsystem>:<property-id>]` titles so repeat runs update instead of duplicate;
  - keep issue narration agent-owned rather than granting a PR workflow broad issue-write permission; and
  - require modeled-code changes to fix the code or update the invariant story in the same PR, while preserving FIX-BEFORE-NEW priority.
- Documents enablement, admission criteria, artifacts, counterexample reporting, and maintenance in `src/docs/formal-verification.md`, with links from the agent and operator references and a commented example in `src/hive.yaml.example`.
- Adds the user-visible capability to `CHANGELOG.md`.

## Design decisions and invariants

The ACMM boundary is evaluated as an effective value instead of rejecting config at load time. If an operator downgrades from L5 to L4, formal work becomes inert immediately but the explicit preference is retained; raising the hive back to L5/L6 restores it. This avoids turning a safe downgrade into a startup failure or silently deleting operator intent.

The contract is injected outside customizable quality templates. Editing every shipped quality template was rejected because it would not reach existing local overrides or remote prompt sources. Conversely, the rest of the quality policy remains customizable; only the capability's admission, artifact, reporting, and maintenance invariants are fixed when the operator turns it on.

This does not add a central Spin daemon, vendor Spin, or make formal checks required. Models remain repository-owned and agent-authored, and their exhaustive runner remains ordinary reporting-only CI. Issue creation/update also stays with the quality agent so a raw counterexample is minimized and translated before publication; PR workflows do not gain issue-write permission merely because formal verification is enabled.

## Regression coverage

- `TestFormalQualityCapabilityRequiresOptInAndL5` proves the zero value and L4 boundary are inert while L5/L6 opt-ins activate.
- `TestFormalQualityConfigSerialization` proves the literal YAML surface parses and survives JSON serialization.
- `TestFormalQualityCapabilityReachesCustomizedKicks` proves the complete contract is prepended ahead of a customized quality policy.
- `TestFormalQualityCapabilityIsHardGated` covers opt-out, below-L5, and non-quality-role cases without suppressing ordinary quality work.
- `TestFormalQualityCapabilityAppliesAtL6` and `TestFormalQualityCapabilityAppliesToReplicas` cover the upper maturity level and derived-agent path.
- The full policy tests validate the new embedded Markdown against repository policy invariants.

## Verification

Passed:

```text
go test ./pkg/config -run 'TestFormalQuality' -count=1
go test ./pkg/scheduler -run 'TestFormalQuality' -count=1
go test ./pkg/policies -count=1
go test ./pkg/config -skip '^TestGateFailsClosedWithoutIP6Tables$'
go test ./pkg/scheduler ./pkg/policies
python3 src/scripts/check-docs-links.py
git diff --check
```

The documentation checker inspected 130 files and reported that all relative links and anchors resolve. The broader config run excludes only `TestGateFailsClosedWithoutIP6Tables`: on this host `ip6tables` exists but the test process lacks `NET_ADMIN`, so the command reports an authorization failure where that test fixture expects a missing-binary diagnostic. The formal config tests pass, and this change does not touch the egress-gate code or test.

## Scope boundaries

- The concrete escalation/reviewer model and workflow remain in prerequisite PR #5511; this PR supplies the reusable capability contract and does not duplicate that pilot.
- The capability is limited to protocol safety/liveness modeling; it does not claim functional correctness or ask quality to model every repository.
- Formal CI is explicitly reporting-only and does not alter branch protection.
- This PR does not implement a dashboard toggle; operators enable the trusted YAML setting directly.

Fixes #5512

— hive: backend=codex
