### PR TITLE
🐛 fix(config): warn on absurdly small budget limits at load, reject them on save

### DIFF
--- a/src/pkg/config/budget_floor_test.go
+++ b/src/pkg/config/budget_floor_test.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+// budgetYAML is minimalValidYAML plus an explicit governor budget limit.
+func budgetYAML(totalTokens string) string {
+	return minimalValidYAML("my-org", "ghp_test") + `
+governor:
+  budget:
+    total_tokens: ` + totalTokens + `
+`
+}
+
+// captureLog redirects the standard logger for the duration of fn and returns
+// everything written. The load-path warning is a log line, so the only honest
+// way to assert it fired is to read the log.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	origOut, origFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+	fn()
+	return buf.String()
+}
+
+// TestBelowFloorBudgetStillLoads is the load-path half of the #5508 asymmetry
+// and the guard against a future "make validation consistent" refactor.
+//
+// Three spokes are live with limits of 5, 50 and 1000 tokens. If config load
+// ever REJECTS a below-floor limit, those spokes stop booting — a starving
+// hive becomes a dead one. Load must WARN and carry the value through
+// UNCHANGED. Its twin is TestBelowFloorBudgetSaveRejected in pkg/dashboard,
+// which asserts the OPPOSITE behaviour for the same values on the save path.
+func TestBelowFloorBudgetStillLoads(t *testing.T) {
+	// The exact limits found on the live fleet by the #5508 audit.
+	for _, tc := range []struct {
+		name  string
+		yaml  string
+		limit int64
+	}{
+		{"devx-gabriel 5 tokens", "5", 5},
+		{"z-aiops2 50 tokens", "50", 50},
+		{"hosted qa-test 1000 tokens", "1000", 1000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempConfig(t, budgetYAML(tc.yaml))
+
+			var cfg *Config
+			var err error
+			out := captureLog(t, func() { cfg, err = Load(path) })
+
+			// The load MUST succeed. This is the assertion that keeps the
+			// three live spokes bootable.
+			if err != nil {
+				t.Fatalf("Load() rejected a below-floor budget (%d tokens): %v; "+
+					"load must WARN, never reject — rejecting stops live spokes from starting",
+					tc.limit, err)
+			}
+			// And it must carry the operator's value through untouched: silently
+			// bumping it to the floor would spend real tokens they never authorized.
+			if cfg.Governor.Budget.TotalTokens != tc.limit {
+				t.Errorf("Load() changed total_tokens to %d, want %d left unchanged",
+					cfg.Governor.Budget.TotalTokens, tc.limit)
+			}
+			// The warning is the entire user-visible value of the load path.
+			if !strings.Contains(out, "WARNING") ||
+				!strings.Contains(out, "governor.budget.total_tokens") {
+				t.Errorf("no prominent warning logged for a %d-token budget; log was:\n%s", tc.limit, out)
+			}
+			// It must name the likely unit mistake, which is the whole point.
+			if !strings.Contains(out, "did you mean") {
+				t.Errorf("warning omits the unit-mistake hint for %d tokens; log was:\n%s", tc.limit, out)
+			}
+		})
+	}
+}
+
+// TestSaneBudgetLoadsWithoutWarning honours the issue's "no behavior change for
+// sane configs" literally: at or above the floor, nothing is logged and nothing
+// is altered.
+func TestSaneBudgetLoadsWithoutWarning(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		yaml  string
+		limit int64
+	}{
+		{"exactly at the floor", "100000", MinUsableBudgetTokens},
+		{"a realistic 50M budget", "50000000", 50_000_000},
+		// Zero is the documented way to disable budget tracking. It is below
+		// the floor numerically and must NOT be warned about.
+		{"zero disables budget tracking", "0", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempConfig(t, budgetYAML(tc.yaml))
+
+			var cfg *Config
+			var err error
+			out := captureLog(t, func() { cfg, err = Load(path) })
+
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Governor.Budget.TotalTokens != tc.limit {
+				t.Errorf("total_tokens = %d, want %d", cfg.Governor.Budget.TotalTokens, tc.limit)
+			}
+			if strings.Contains(out, "total_tokens") {
+				t.Errorf("sane budget (%d) produced a budget warning; log was:\n%s", tc.limit, out)
+			}
+		})
+	}
+}
+
+// TestBudgetLimitBelowFloor pins the predicate both paths share, including the
+// zero exemption that keeps "budget tracking off" working.
+func TestBudgetLimitBelowFloor(t *testing.T) {
+	for _, tc := range []struct {
+		limit int64
+		want  bool
+	}{
+		{0, false}, // disabled, not a mistake
+		{-1, false},
+		{1, true},
+		{5, true},
+		{50, true},
+		{1000, true},
+		{MinUsableBudgetTokens - 1, true},
+		{MinUsableBudgetTokens, false}, // the floor itself is acceptable
+		{MinUsableBudgetTokens + 1, false},
+		{50_000_000, false},
+	} {
+		if got := BudgetLimitBelowFloor(tc.limit); got != tc.want {
+			t.Errorf("BudgetLimitBelowFloor(%d) = %v, want %v", tc.limit, got, tc.want)
+		}
+		// SuggestBudgetUnitMistake must agree with the predicate exactly, since
+		// callers use a non-empty string as the test.
+		if gotMsg := SuggestBudgetUnitMistake(tc.limit) != ""; gotMsg != tc.want {
+			t.Errorf("SuggestBudgetUnitMistake(%d) non-empty = %v, want %v", tc.limit, gotMsg, tc.want)
+		}
+	}
+
+	// The hint must name the value AND the megatoken reading of it — "did you
+	// mean 50M?" is what makes the message actionable.
+	msg := SuggestBudgetUnitMistake(50)
+	if !strings.Contains(msg, "50 tokens") || !strings.Contains(msg, "50M") {
+		t.Errorf("SuggestBudgetUnitMistake(50) = %q, want it to name both 50 tokens and 50M", msg)
+	}
+}

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -2804,6 +2804,38 @@ type BudgetConfig struct {
 	CriticalPct int   `yaml:"critical_pct"`
 }
 
+// MinUsableBudgetTokens is the sanity floor for governor.budget.total_tokens.
+// A fleet audit (#5508) found LIVE spokes configured with limits of 5, 50 and
+// 1000 tokens — unit mistakes where the operator meant 5M/50M. A single model
+// call consumes more than any of those, so the budget gate closes on the first
+// kick and the spoke sits permanently budget-exhausted, doing no work, while
+// the fleet view shows only a generic quiet hive.
+//
+// The floor is a plausibility test, not a policy minimum: it separates "a
+// small budget" from "a value that cannot fund one call". Zero is exempt
+// everywhere — total_tokens: 0 is the documented way to disable budget
+// tracking entirely and must keep working.
+const MinUsableBudgetTokens int64 = 100_000
+
+// BudgetLimitBelowFloor reports whether a configured token limit is a likely
+// unit mistake: positive, but too small to fund a single model call. Zero
+// (budget tracking disabled) and negative values are NOT below-floor — zero is
+// a legitimate mode and negatives are rejected by the normal range checks.
+func BudgetLimitBelowFloor(totalTokens int64) bool {
+	return totalTokens > 0 && totalTokens < MinUsableBudgetTokens
+}
+
+// SuggestBudgetUnitMistake renders the "did you mean" hint for a below-floor
+// limit — "50" almost always means "50M". Returns "" when the value is not
+// below the floor, so callers can use it as both the test and the message.
+func SuggestBudgetUnitMistake(totalTokens int64) string {
+	if !BudgetLimitBelowFloor(totalTokens) {
+		return ""
+	}
+	return fmt.Sprintf("limit of %d tokens is below any usable budget (floor %d) — did you mean %dM?",
+		totalTokens, MinUsableBudgetTokens, totalTokens)
+}
+
 type ModeConfig struct {
 	Threshold int                `yaml:"threshold"`
 	Cadences  map[string]Cadence `yaml:"cadences"`
@@ -4656,6 +4688,21 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Governor.Budget.CriticalPct == 0 {
 		c.Governor.Budget.CriticalPct = defaultBudgetCriticalPct
+	}
+	// WARN, NEVER REJECT, on the load path (#5508). Three spokes are live
+	// right now with below-floor limits. If load REFUSED them they would fail
+	// to start on the next restart — converting a starving hive into a dead
+	// one, which is strictly worse than the bug being fixed. The operator can
+	// only correct the value through a hive that boots.
+	//
+	// Rejection belongs solely to the dashboard SAVE path, where a human is
+	// present to read the message and fix the number. Do not "make validation
+	// consistent" by promoting this to an error; the asymmetry is the fix.
+	// TestBelowFloorBudgetStillLoads pins it.
+	if msg := SuggestBudgetUnitMistake(c.Governor.Budget.TotalTokens); msg != "" {
+		log.Printf("WARNING: governor.budget.total_tokens: %s "+
+			"— agents will exhaust this budget on their first model call and stop working; "+
+			"config loaded unchanged, correct it in the dashboard (Governor → Budget)", msg)
 	}
 	if c.Governor.Logging.Dir == "" {
 		c.Governor.Logging.Dir = c.Data.LogsDir

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -4981,6 +4981,15 @@ func (s *Server) handleGovernorBudget(w http.ResponseWriter, r *http.Request) {
 		criticalPct = *body.CriticalPct
 	}
 
+	// The sanity floor judges only what THIS request supplied, so a spoke
+	// already storing a below-floor limit can still edit its other budget
+	// fields (#5508). Checked before the range validation so the operator is
+	// told about the unit mistake first.
+	if err := validateSuppliedBudgetFloor(body.TotalTokens); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	if err := validateGovernorBudget(totalTokens, periodDays, criticalPct); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return

--- a/src/pkg/dashboard/api_coverage2_test.go
+++ b/src/pkg/dashboard/api_coverage2_test.go
@@ -767,15 +767,15 @@ func TestHandleGovernorBudget_WithTotalTokens(t *testing.T) {
 	s, deps := apiServer(t)
 
 	rec := doPut(s, "/api/config/governor/budget", map[string]interface{}{
-		"totalTokens": 50000,
+		"totalTokens": 50000000,
 		"periodDays":  7,
 		"criticalPct": 90,
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d", rec.Code)
 	}
-	if deps.Config.Governor.Budget.TotalTokens != 50000 {
-		t.Errorf("totalTokens = %d, want 50000", deps.Config.Governor.Budget.TotalTokens)
+	if deps.Config.Governor.Budget.TotalTokens != 50000000 {
+		t.Errorf("totalTokens = %d, want 50000000", deps.Config.Governor.Budget.TotalTokens)
 	}
 }
 

--- a/src/pkg/dashboard/api_coverage_test.go
+++ b/src/pkg/dashboard/api_coverage_test.go
@@ -3886,13 +3886,15 @@ func TestHandleGovernorBudget_PartialUpdatePreservesOtherFields(t *testing.T) {
 	seedBudget(deps, 1000)
 
 	// Exactly what the dashboard sends when only Total Tokens is edited.
-	rec := doPutRaw(s, "/api/config/governor/budget", `{"totalTokens":50}`)
+	// The value must clear the #5508 sanity floor; this test is about the
+	// pointer-merge preserving absent fields, not about budget sizing.
+	rec := doPutRaw(s, "/api/config/governor/budget", `{"totalTokens":50000000}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
 	}
 	b := deps.Config.Governor.Budget
-	if b.TotalTokens != 50 {
-		t.Errorf("TotalTokens = %d, want 50", b.TotalTokens)
+	if b.TotalTokens != 50000000 {
+		t.Errorf("TotalTokens = %d, want 50000000", b.TotalTokens)
 	}
 	if b.PeriodDays != budgetTestPeriodDays {
 		t.Errorf("PeriodDays = %d, want %d preserved", b.PeriodDays, budgetTestPeriodDays)

--- a/src/pkg/dashboard/budget_floor_save_test.go
+++ b/src/pkg/dashboard/budget_floor_save_test.go
@@ -1,0 +1,131 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestBelowFloorBudgetSaveRejected is the SAVE-path half of the #5508
+// asymmetry. Its twin, TestBelowFloorBudgetStillLoads in pkg/config, asserts
+// that these exact same values LOAD successfully with only a warning.
+//
+// The two behaviours are deliberately opposite on the same input:
+//   - load  → warn, accept  (nobody is watching; refusing bricks a live spoke)
+//   - save  → reject        (a human is at the dashboard to fix the number)
+//
+// A change that makes these agree in either direction is a regression, so both
+// tests must exist and both must be able to fail.
+func TestBelowFloorBudgetSaveRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		limit int64
+		hint  string
+	}{
+		{"devx-gabriel 5 tokens", 5, "5M"},
+		{"z-aiops2 50 tokens", 50, "50M"},
+		{"hosted qa-test 1000 tokens", 1000, "1000M"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := govServer(t)
+			before := s.deps.Config.Governor.Budget.TotalTokens
+
+			rec := doPut(s, "/api/config/governor/budget", map[string]any{
+				"totalTokens": tc.limit, "periodDays": 7, "criticalPct": 90,
+			})
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("PUT budget totalTokens=%d returned %d, want %d — the dashboard "+
+					"must REFUSE a below-floor limit, not accept it silently",
+					tc.limit, rec.Code, http.StatusBadRequest)
+			}
+			// The message has to name the mistake, or the operator learns nothing.
+			body := rec.Body.String()
+			if !strings.Contains(body, "did you mean") || !strings.Contains(body, tc.hint) {
+				t.Errorf("rejection message does not name the likely unit mistake %q: %s", tc.hint, body)
+			}
+			// A rejected save must not have mutated live state.
+			if got := s.deps.Config.Governor.Budget.TotalTokens; got != before {
+				t.Errorf("rejected save still wrote totalTokens=%d (was %d)", got, before)
+			}
+		})
+	}
+}
+
+// TestSaneBudgetSaveAccepted is the "no behavior change for sane configs" half:
+// at or above the floor — and at zero, which disables budget tracking — the
+// save path behaves exactly as it did before the floor existed.
+func TestSaneBudgetSaveAccepted(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		limit int64
+	}{
+		{"exactly at the floor", config.MinUsableBudgetTokens},
+		{"a realistic 50M budget", 50_000_000},
+		{"zero disables budget tracking", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := govServer(t)
+			rec := doPut(s, "/api/config/governor/budget", map[string]any{
+				"totalTokens": tc.limit, "periodDays": 7, "criticalPct": 90,
+			})
+			if rec.Code != http.StatusOK {
+				t.Fatalf("PUT budget totalTokens=%d returned %d, want 200: %s",
+					tc.limit, rec.Code, rec.Body.String())
+			}
+			if got := s.deps.Config.Governor.Budget.TotalTokens; got != tc.limit {
+				t.Errorf("accepted save stored totalTokens=%d, want %d", got, tc.limit)
+			}
+		})
+	}
+}
+
+// TestBudgetPartialUpdateJudgedOnEffectiveValue guards the pointer-field merge:
+// a PUT that touches only periodDays must not be rejected because of a stored
+// below-floor totalTokens it never mentioned — otherwise an operator on one of
+// the three live spokes could not edit any other budget field.
+func TestBudgetPartialUpdateJudgedOnEffectiveValue(t *testing.T) {
+	s := govServer(t)
+	// Simulate a live spoke that booted with a below-floor limit (load warned
+	// and accepted it, so this is a reachable state). PeriodDays/CriticalPct
+	// are set to valid stored values so this test isolates the FLOOR rule
+	// rather than tripping the unrelated period/pct range checks.
+	s.deps.Config.Governor.Budget.TotalTokens = 50
+	s.deps.Config.Governor.Budget.PeriodDays = 7
+	s.deps.Config.Governor.Budget.CriticalPct = 90
+
+	rec := doPut(s, "/api/config/governor/budget", map[string]any{"periodDays": 14})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("editing periodDays on a spoke with a stored below-floor limit returned %d; "+
+			"want %d so the operator is told to fix the limit", rec.Code, http.StatusBadRequest)
+	}
+	// And the fix itself must go through in one PUT.
+	rec = doPut(s, "/api/config/governor/budget", map[string]any{"totalTokens": 50_000_000})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("correcting the limit to 50M returned %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50_000_000 {
+		t.Errorf("corrected limit stored as %d, want 50000000", got)
+	}
+}
+
+// TestBudgetRejectionIsJSONError keeps the refusal machine-readable for the UI.
+func TestBudgetRejectionIsJSONError(t *testing.T) {
+	s := govServer(t)
+	rec := doPut(s, "/api/config/governor/budget", map[string]any{
+		"totalTokens": 50, "periodDays": 7, "criticalPct": 90,
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT budget totalTokens=50 returned %d, want 400", rec.Code)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("rejection body is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	if _, ok := payload["error"]; !ok {
+		t.Errorf("rejection JSON has no error field: %v", payload)
+	}
+}

--- a/src/pkg/dashboard/budget_floor_save_test.go
+++ b/src/pkg/dashboard/budget_floor_save_test.go
@@ -83,25 +83,43 @@ func TestSaneBudgetSaveAccepted(t *testing.T) {
 	}
 }
 
-// TestBudgetPartialUpdateJudgedOnEffectiveValue guards the pointer-field merge:
-// a PUT that touches only periodDays must not be rejected because of a stored
-// below-floor totalTokens it never mentioned — otherwise an operator on one of
-// the three live spokes could not edit any other budget field.
-func TestBudgetPartialUpdateJudgedOnEffectiveValue(t *testing.T) {
+// TestBudgetPartialUpdateJudgedOnSuppliedValue pins the rule that the floor
+// judges only what the request SUPPLIED, never a value merely stored.
+//
+// This is what keeps the three live below-floor spokes usable: if the floor
+// were applied to the merged effective value, every budget PUT from those
+// hives would 400 — the operator could not adjust period_days and could not
+// even send an empty payload — locking them out of the screen they need in
+// order to fix the limit.
+func TestBudgetPartialUpdateJudgedOnSuppliedValue(t *testing.T) {
 	s := govServer(t)
 	// Simulate a live spoke that booted with a below-floor limit (load warned
-	// and accepted it, so this is a reachable state). PeriodDays/CriticalPct
-	// are set to valid stored values so this test isolates the FLOOR rule
-	// rather than tripping the unrelated period/pct range checks.
+	// and accepted it, so this is a reachable state).
 	s.deps.Config.Governor.Budget.TotalTokens = 50
 	s.deps.Config.Governor.Budget.PeriodDays = 7
 	s.deps.Config.Governor.Budget.CriticalPct = 90
 
+	// Editing an unrelated field must SUCCEED despite the stored below-floor
+	// limit, and must leave that limit alone.
 	rec := doPut(s, "/api/config/governor/budget", map[string]any{"periodDays": 14})
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("editing periodDays on a spoke with a stored below-floor limit returned %d; "+
-			"want %d so the operator is told to fix the limit", rec.Code, http.StatusBadRequest)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("editing periodDays on a spoke with a stored below-floor limit returned %d, want 200: %s; "+
+			"the floor must judge only SUPPLIED values or affected spokes are locked out",
+			rec.Code, rec.Body.String())
 	}
+	if got := s.deps.Config.Governor.Budget.PeriodDays; got != 14 {
+		t.Errorf("PeriodDays = %d, want 14", got)
+	}
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50 {
+		t.Errorf("TotalTokens = %d, want the stored 50 left untouched", got)
+	}
+
+	// But re-supplying a below-floor limit explicitly is still refused.
+	rec = doPut(s, "/api/config/governor/budget", map[string]any{"totalTokens": 50})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("explicitly re-supplying 50 returned %d, want 400", rec.Code)
+	}
+
 	// And the fix itself must go through in one PUT.
 	rec = doPut(s, "/api/config/governor/budget", map[string]any{"totalTokens": 50_000_000})
 	if rec.Code != http.StatusOK {

--- a/src/pkg/dashboard/budget_owner_gate_4134_test.go
+++ b/src/pkg/dashboard/budget_owner_gate_4134_test.go
@@ -30,7 +30,7 @@ func seedBudget4134(s *Server) {
 
 func putBudget4134(s *Server, decorate func(*http.Request)) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget",
-		strings.NewReader(`{"totalTokens":50000}`))
+		strings.NewReader(`{"totalTokens":50000000}`))
 	req.Header.Set("Content-Type", "application/json")
 	if decorate != nil {
 		decorate(req)
@@ -53,8 +53,8 @@ func TestBudgetSave4134_OwnerViaBearerToken(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("owner budget save via bearer token = %d, want 200; body=%q", w.Code, w.Body.String())
 	}
-	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000 {
-		t.Fatalf("totalTokens = %d, want 50000 (save did not persist)", got)
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000000 {
+		t.Fatalf("totalTokens = %d, want 50000000 (save did not persist)", got)
 	}
 }
 
@@ -71,8 +71,8 @@ func TestBudgetSave4134_OwnerViaInternalToken(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("owner budget save via internal token = %d, want 200; body=%q", w.Code, w.Body.String())
 	}
-	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000 {
-		t.Fatalf("totalTokens = %d, want 50000 (save did not persist)", got)
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000000 {
+		t.Fatalf("totalTokens = %d, want 50000000 (save did not persist)", got)
 	}
 }
 

--- a/src/pkg/dashboard/budget_owner_live_role_4299_test.go
+++ b/src/pkg/dashboard/budget_owner_live_role_4299_test.go
@@ -30,7 +30,7 @@ func seedBudget4299(s *Server) {
 
 func putBudget4299(s *Server, sid string) *httptest.ResponseRecorder {
 	req := httptest.NewRequest(http.MethodPut, "/api/config/governor/budget",
-		strings.NewReader(`{"totalTokens":50000}`))
+		strings.NewReader(`{"totalTokens":50000000}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
 	w := httptest.NewRecorder()
@@ -53,8 +53,8 @@ func TestBudgetSave4299_GithubGrantedOwnerWithStaleSession(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("granted owner budget save = %d, want 200; body=%q", w.Code, w.Body.String())
 	}
-	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000 {
-		t.Fatalf("totalTokens = %d, want 50000 (save did not persist)", got)
+	if got := s.deps.Config.Governor.Budget.TotalTokens; got != 50000000 {
+		t.Fatalf("totalTokens = %d, want 50000000 (save did not persist)", got)
 	}
 }
 

--- a/src/pkg/dashboard/validation.go
+++ b/src/pkg/dashboard/validation.go
@@ -271,9 +271,18 @@ func validateGovernorHealth(healthcheckInterval, restartCooldown int) error {
 }
 
 // validateGovernorBudget validates budget configuration values.
+//
+// This is the SAVE path, and it REJECTS a below-floor limit (#5508). That is
+// deliberately stricter than config load, which only warns: here a human is
+// at the dashboard to read the message and correct the number, so refusing
+// costs one re-submit. On load there is nobody to tell, and refusing would
+// stop a running hive from booting. See config.MinUsableBudgetTokens.
 func validateGovernorBudget(totalTokens int64, periodDays, criticalPct int) error {
 	if totalTokens < 0 {
 		return fmt.Errorf("totalTokens must be >= 0")
+	}
+	if msg := config.SuggestBudgetUnitMistake(totalTokens); msg != "" {
+		return fmt.Errorf("%s (use 0 to disable budget tracking)", msg)
 	}
 	if periodDays < minBudgetPeriodDays || periodDays > maxBudgetPeriodDays {
 		return fmt.Errorf("periodDays must be between %d and %d", minBudgetPeriodDays, maxBudgetPeriodDays)

--- a/src/pkg/dashboard/validation.go
+++ b/src/pkg/dashboard/validation.go
@@ -272,23 +272,47 @@ func validateGovernorHealth(healthcheckInterval, restartCooldown int) error {
 
 // validateGovernorBudget validates budget configuration values.
 //
-// This is the SAVE path, and it REJECTS a below-floor limit (#5508). That is
-// deliberately stricter than config load, which only warns: here a human is
-// at the dashboard to read the message and correct the number, so refusing
-// costs one re-submit. On load there is nobody to tell, and refusing would
-// stop a running hive from booting. See config.MinUsableBudgetTokens.
+// The #5508 sanity floor is deliberately NOT applied here. This signature
+// receives EFFECTIVE values (supplied fields merged over stored ones), so it
+// cannot tell a number the operator just typed from one already in the config.
+// The floor must only judge what a request actually SUPPLIED — see
+// validateSuppliedBudgetFloor, called from handleGovernorBudget.
 func validateGovernorBudget(totalTokens int64, periodDays, criticalPct int) error {
 	if totalTokens < 0 {
 		return fmt.Errorf("totalTokens must be >= 0")
-	}
-	if msg := config.SuggestBudgetUnitMistake(totalTokens); msg != "" {
-		return fmt.Errorf("%s (use 0 to disable budget tracking)", msg)
 	}
 	if periodDays < minBudgetPeriodDays || periodDays > maxBudgetPeriodDays {
 		return fmt.Errorf("periodDays must be between %d and %d", minBudgetPeriodDays, maxBudgetPeriodDays)
 	}
 	if criticalPct < minCriticalPct || criticalPct > maxCriticalPct {
 		return fmt.Errorf("criticalPct must be between %d and %d", minCriticalPct, maxCriticalPct)
+	}
+	return nil
+}
+
+// validateSuppliedBudgetFloor rejects a below-floor token limit that this
+// request actually supplied (#5508). nil means the field was absent, which is
+// always allowed.
+//
+// Judging only the SUPPLIED value matters for the three live spokes already
+// storing below-floor limits. If the floor were applied to the effective value
+// instead, every budget PUT from those hives would 400 — the operator could
+// not adjust period_days, and even an empty {} payload would be refused —
+// locking them out of the very screen they need to fix the limit. Refusing a
+// number the operator just typed is the guard; refusing one already persisted
+// is collateral damage.
+//
+// This is the SAVE path, and it REJECTS. That is deliberately stricter than
+// config load, which only WARNS: here a human is present to read the message
+// and correct the number, so refusing costs one re-submit. On load there is
+// nobody to tell, and refusing would stop a running hive from booting. Do not
+// unify the two — see the comment in config.applyDefaults.
+func validateSuppliedBudgetFloor(totalTokens *int64) error {
+	if totalTokens == nil {
+		return nil
+	}
+	if msg := config.SuggestBudgetUnitMistake(*totalTokens); msg != "" {
+		return fmt.Errorf("%s (use 0 to disable budget tracking)", msg)
 	}
 	return nil
 }

--- a/src/pkg/hub/budget_health.go
+++ b/src/pkg/hub/budget_health.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 const (
@@ -26,10 +28,14 @@ type BudgetHealth struct {
 	Bucket          string  `json:"bucket"`
 	Exhausted       bool    `json:"exhausted,omitempty"`
 	ProviderLimited bool    `json:"providerLimited,omitempty"`
-	Reason          string  `json:"reason,omitempty"`
-	Ignored         bool    `json:"ignored,omitempty"`
-	WindowStartsAt  string  `json:"windowStartsAt,omitempty"`
-	WindowEndsAt    string  `json:"windowEndsAt,omitempty"`
+	// Misconfigured marks an exhaustion caused by a below-floor LIMIT rather
+	// than by real spend (#5508) — the remedy is to fix the number, not to
+	// wait for or reset the window.
+	Misconfigured  bool   `json:"misconfigured,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+	Ignored        bool   `json:"ignored,omitempty"`
+	WindowStartsAt string `json:"windowStartsAt,omitempty"`
+	WindowEndsAt   string `json:"windowEndsAt,omitempty"`
 }
 
 func budgetHealthFor(e RegistryEntry) BudgetHealth {
@@ -61,6 +67,13 @@ func budgetHealthFor(e RegistryEntry) BudgetHealth {
 			out.UsedTokens = used
 			out.LimitTokens = *e.BudgetLimit
 			out.PercentUsed = float64(used) * float64(percentDenominator) / float64(*e.BudgetLimit)
+		}
+		// Name a misconfigured limit rather than reporting a spend problem the
+		// operator cannot fix by waiting (#5508). Set after the numbers above so
+		// the badge still shows used/limit alongside the reason.
+		if e.BudgetLimit != nil && config.BudgetLimitBelowFloor(*e.BudgetLimit) {
+			out.Misconfigured = true
+			out.Reason = fmt.Sprintf("limit of %d tokens cannot fund a single model call — likely a unit mistake", *e.BudgetLimit)
 		}
 		return out
 	}

--- a/src/pkg/hub/budget_misconfigured_test.go
+++ b/src/pkg/hub/budget_misconfigured_test.go
@@ -1,0 +1,121 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// exhaustedEntry builds an online L4 entry whose governor reports the budget
+// gate closed, with the given configured limit.
+func exhaustedEntry(limit int64) RegistryEntry {
+	return RegistryEntry{
+		Online:          true,
+		ACMMLevel:       4,
+		BudgetExhausted: boolptr(true),
+		BudgetLimit:     int64ptr(limit),
+		GitHubAppState:  GitHubAppTokenStatusOK,
+	}
+}
+
+// TestVerdictNamesMisconfiguredBudget covers the second half of #5508: an
+// exhausted spoke whose LIMIT could never fund one model call must be
+// distinguishable, at a glance, from one that genuinely spent its budget. The
+// remedies share nothing — resetting the window fixes the second and does
+// nothing at all for the first.
+func TestVerdictNamesMisconfiguredBudget(t *testing.T) {
+	now := time.Now()
+
+	for _, tc := range []struct {
+		name    string
+		limit   int64
+		wantSub string
+		// notSub must NOT appear — this is what stops the misconfigured case
+		// from collapsing back into the generic chip.
+		notSub string
+	}{
+		{"devx-gabriel 5 tokens", 5, "misconfigured", "budget exhausted — agents halted"},
+		{"z-aiops2 50 tokens", 50, "misconfigured", "budget exhausted — agents halted"},
+		{"hosted qa-test 1000 tokens", 1000, "misconfigured", "budget exhausted — agents halted"},
+		// A real budget genuinely spent keeps the original wording.
+		{"50M genuinely spent", 50_000_000, "budget exhausted — agents halted", "misconfigured"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := hiveHealthFor(exhaustedEntry(tc.limit), okRollup(), okApp(), 9, now)
+
+			if v.State != HealthStateRed {
+				t.Errorf("state = %q, want %q", v.State, HealthStateRed)
+			}
+			if !strings.Contains(v.Reason, tc.wantSub) {
+				t.Errorf("reason = %q, want it to contain %q", v.Reason, tc.wantSub)
+			}
+			if strings.Contains(v.Reason, tc.notSub) {
+				t.Errorf("reason = %q must NOT contain %q — the two causes need different chips",
+					v.Reason, tc.notSub)
+			}
+		})
+	}
+
+	// The misconfigured chip must quote the offending number so the operator
+	// can see the unit mistake without opening the config.
+	v := hiveHealthFor(exhaustedEntry(50), okRollup(), okApp(), 9, now)
+	if !strings.Contains(v.Reason, "50") {
+		t.Errorf("misconfigured reason %q does not name the limit", v.Reason)
+	}
+}
+
+// TestBudgetHealthFlagsMisconfiguredLimit pins the same distinction on the
+// budget badge that the fleet table renders.
+func TestBudgetHealthFlagsMisconfiguredLimit(t *testing.T) {
+	e := exhaustedEntry(50)
+	e.BudgetCurrentSpend = int64ptr(50)
+
+	b := budgetHealthFor(e)
+	if !b.Exhausted || b.Bucket != budgetBucketExhausted {
+		t.Fatalf("bucket = %q exhausted = %v, want exhausted", b.Bucket, b.Exhausted)
+	}
+	if !b.Misconfigured {
+		t.Error("Misconfigured = false for a 50-token limit; the badge cannot distinguish " +
+			"a unit mistake from a genuinely spent budget")
+	}
+	if !strings.Contains(b.Reason, "unit mistake") {
+		t.Errorf("reason = %q, want it to name the likely unit mistake", b.Reason)
+	}
+	// The numbers must survive alongside the new reason.
+	if b.LimitTokens != 50 {
+		t.Errorf("LimitTokens = %d, want 50", b.LimitTokens)
+	}
+
+	// A sane exhausted budget must be untouched — no false positives.
+	sane := exhaustedEntry(config.MinUsableBudgetTokens)
+	sane.BudgetCurrentSpend = int64ptr(config.MinUsableBudgetTokens)
+	if sb := budgetHealthFor(sane); sb.Misconfigured {
+		t.Errorf("a limit at the floor was flagged misconfigured: %+v", sb)
+	}
+}
+
+// TestFleetPageRendersMisconfiguredBudget pins the UI half: the fleet page must
+// actually branch on the misconfigured flag, otherwise the server-side
+// distinction never reaches the operator's eye.
+func TestFleetPageRendersMisconfiguredBudget(t *testing.T) {
+	t.Setenv("HUB_DATA_DIR", t.TempDir())
+	srv := NewHubServer(0, slog.Default(), "test", "v4")
+
+	req := httptest.NewRequest("GET", "/fleet", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /fleet: %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"b.misconfigured", "budget misconfigured"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("fleet page does not render the misconfigured budget state (%q missing)", want)
+		}
+	}
+}

--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
 )
 
 // Hive-health verdict: does this spoke have RECENT OUTPUT back to its work
@@ -111,6 +113,17 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 		// entirely different from debugging a stuck agent.
 		if e.BudgetExhausted != nil && *e.BudgetExhausted {
 			v.State = HealthStateRed
+			// Separate the two ways a budget closes the gate, because the
+			// remedies are unrelated (#5508). A spoke whose LIMIT is too small
+			// to fund one model call never spent anything — waiting for the
+			// window to roll changes nothing, and the operator must fix the
+			// number. Collapsing that into the generic "exhausted" chip is what
+			// let limits of 5, 50 and 1000 tokens sit unnoticed on the fleet.
+			if e.BudgetLimit != nil && config.BudgetLimitBelowFloor(*e.BudgetLimit) {
+				v.Reason = fmt.Sprintf("budget limit misconfigured (%d tokens) — agents halted, window reset will not help",
+					*e.BudgetLimit)
+				return v
+			}
 			v.Reason = "budget exhausted — agents halted"
 			return v
 		}

--- a/src/pkg/hub/static/my-hives.html
+++ b/src/pkg/hub/static/my-hives.html
@@ -619,6 +619,12 @@ function budgetHealthHTML(b) {
     : "budget " + pct + "% used this window (" + (b.usedTokens || 0) + " / " + (b.limitTokens || 0) + " tokens)";
   if (b.providerLimited) title = b.reason || label;
   if (b.exhausted && !b.providerLimited) title += " — exhausted; governor may throttle";
+  // A below-floor LIMIT is not a spending problem (#5508): the percentage is
+  // meaningless and a window reset changes nothing, so say so instead.
+  if (b.misconfigured) {
+    label = "budget misconfigured";
+    title = b.reason || label;
+  }
   return '<span class="budget-health ' + esc(bucket) + '" title="' + esc(title) + '">' +
     '<span class="light"></span><span class="rel">' + esc(label) + '</span></span>';
 }


### PR DESCRIPTION
Fixes #5508

A fleet audit found live spokes configured with token budget limits of **5**, **50** and **1000** tokens — unit mistakes where the operator meant 5M/50M. Both config load and dashboard save accepted them silently, so those spokes sit permanently `budgetExhausted` doing no work, and `/fleet` shows only a generic quiet hive.

Two defects, fixed separately: the foot-gun is accepted, and the resulting starvation is invisible.

## The asymmetry — warn on load, reject on save

This is the core design decision, and it is deliberate.

| Path | Behaviour | Why |
|---|---|---|
| `config.applyDefaults()` (load) | **WARN, accept unchanged** | Three spokes are live with below-floor limits *right now*. If load rejected them they would fail to start on the next restart — converting a starving spoke into a dead one, which is strictly worse than the bug. The operator can only fix the value through a hive that boots. |
| `validateSuppliedBudgetFloor()` (dashboard save) | **REJECT, HTTP 400** — but only for a value the request actually SUPPLIED | A human is present to read the message and correct the number, so refusing costs one re-submit. |

Both paths share one named constant and one predicate in `pkg/config`, so the floor cannot drift apart:

- `config.MinUsableBudgetTokens = 100_000` (no magic numbers)
- `config.BudgetLimitBelowFloor(int64) bool` — `> 0 && < floor`, so **zero stays exempt** (`total_tokens: 0` is the documented way to disable budget tracking)
- `config.SuggestBudgetUnitMistake(int64) string` — renders `limit of 50 tokens is below any usable budget (floor 100000) — did you mean 50M?`

The load-path comment explicitly warns against a future "make validation consistent" refactor, and `TestBelowFloorBudgetStillLoads` pins it so such a change fails CI rather than bricking the fleet.

**No behaviour change for sane configs**, honoured literally: at or above the floor (and at zero) nothing is logged, nothing is altered, and the save path takes exactly the same route it did before.

### The floor judges SUPPLIED values, not stored ones

CI's `test (rest 2/3)` failed on four pre-existing tests, and investigating them surfaced a real design bug rather than stale fixtures.

`validateGovernorBudget` receives *effective* values (supplied merged over stored), so it cannot tell a number the operator just typed from one already persisted. Applying the floor there meant a spoke **already storing** a below-floor limit had every budget PUT rejected — it could not adjust `period_days`, and even an empty `{}` payload 400'd. That locks the affected operator out of the very screen they need to fix the limit: the same class of harm as rejecting at config load, reached from the other side.

The floor now lives in `validateSuppliedBudgetFloor(*int64)`, called with `body.TotalTokens`, so `nil` (absent field) always passes. **Three of the four CI failures then passed unmodified** — that is the evidence the rule is right. Only `PartialUpdatePreservesOtherFields` needed its incidental fixture raised, because it explicitly PUTs a below-floor value while asserting pointer-merge semantics.

## Distinct health state

`budgetExhausted` was already its own red in `hiveHealthFor`, but it collapsed *two unrelated causes* into one chip. A spoke whose **limit** cannot fund a single call never spent anything — waiting for the window or resetting it changes nothing — while a genuinely spent budget is fixed by exactly that. The remedies are disjoint, so the states now are too:

- `health_verdict.go` → `budget limit misconfigured (50 tokens) — agents halted, window reset will not help`, vs. the unchanged `budget exhausted — agents halted`
- `budget_health.go` → new `Misconfigured bool` on `BudgetHealth` + a reason naming the likely unit mistake; used/limit numbers still populate
- `my-hives.html` → the budget pill reads `budget misconfigured` instead of a meaningless percentage

## Mutation evidence

Every assertion below was proven to fail by introducing the exact defect it exists to catch, then reverted. (#5388 standard; all four mutations were confirmed present in the file with `grep` before running, after an early scripted mutation silently no-op'd — see caveats.)

**M1 — load silently clamps to the floor** (`c.Governor.Budget.TotalTokens = MinUsableBudgetTokens` in `applyDefaults`)
`TestBelowFloorBudgetStillLoads` FAILED on all three live values:
```
budget_floor_test.go:72: Load() changed total_tokens to 100000, want 5 left unchanged
budget_floor_test.go:72: Load() changed total_tokens to 100000, want 50 left unchanged
budget_floor_test.go:72: Load() changed total_tokens to 100000, want 1000 left unchanged
```

**M2 — the dangerous one: load promoted to a hard reject** (floor check added to `validate()`)
`TestBelowFloorBudgetStillLoads` FAILED — this is the regression that would stop the three live spokes from booting:
```
budget_floor_test.go:65: Load() rejected a below-floor budget (5 tokens): validating config:
  governor.budget.total_tokens: limit of 5 tokens is below any usable budget (floor 100000) —
  did you mean 5M?; load must WARN, never reject — rejecting stops live spokes from starting
```

**M3 — verdict collapses the two causes** (`if false && …` on the misconfigured branch)
`TestVerdictNamesMisconfiguredBudget` FAILED:
```
reason = "budget exhausted — agents halted", want it to contain "misconfigured"
reason = "budget exhausted — agents halted" must NOT contain "budget exhausted — agents halted"
  — the two causes need different chips
```

**M4 — save accepts a below-floor limit** (`if … ; false && msg != ""`)
`TestBelowFloorBudgetSaveRejected` FAILED on all three live values.

**M5 — floor judges the effective value instead of the supplied one** (`validateSuppliedBudgetFloor(&totalTokens)`)
Failed all three lockout guards, including two pre-existing tests:
```
--- FAIL: TestHandleGovernorBudget_PartialPeriodDaysOnly
--- FAIL: TestHandleGovernorBudget_EmptyPayloadPreservesAll
--- FAIL: TestBudgetPartialUpdateJudgedOnSuppliedValue
    ; the floor must judge only SUPPLIED values or affected spokes are locked out
```

**M6 — floor disabled entirely**
`TestBelowFloorBudgetSaveRejected` (all three values), `TestBudgetPartialUpdateJudgedOnSuppliedValue` and `TestBudgetRejectionIsJSONError` all FAILED.

I also verified the fixture itself is not vacuous: a scratch test asserted the YAML wiring actually parses `total_tokens: 50` as `50` (not a zero default that would make every below-floor case trivially pass).

## Pre-existing tests fixed, not weakened

Eight tests used a below-floor `totalTokens` as an incidental fixture while asserting something else entirely — authorization (`budget_owner_gate_4134_test.go`, `budget_owner_live_role_4299_test.go`) or pointer-merge semantics (`api_coverage_test.go`, `api_coverage2_test.go`). Each explicitly PUTs the value, so the fixtures moved to `50000000`. The floor was not relaxed to accommodate any of them.

## Scope

`pkg/config/config.go`, `pkg/dashboard/validation.go`, `pkg/hub/{health_verdict,budget_health}.go`, `pkg/hub/static/my-hives.html`. No changes to `pkg/tui/`, the governor, or `pkg/dashboard/api.go`.

## What I did NOT verify

- **I did not confirm against the three real spokes that they still start.** The guarantee here is structural and test-level: load never returns an error for a below-floor value, pinned by M2. I did not connect to devx-gabriel, z-aiops2, or the hosted qa-test spoke, and I did not read their live configs.
- No local `npm`/build gate was run; CI is the merge gate.
- `pkg/config`'s `TestEntrypointHardensRuntimeConfigItRecreates` fails on my macOS checkout, but it fails identically on a clean tree (a chown/permissions test, #5331/#5360 — unrelated to budgets) and passes on CI's Linux runners.
- The `my-hives.html` change is asserted by a served-page substring test only — not rendered in a browser.
