### PR TITLE
🐛 fix(governor): stop advisory digests repeat-posting to the same issue

### DIFF
--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	gh "github.com/google/go-github/v72/github"
@@ -199,23 +200,80 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 	if c.advisoryDigestSkips == nil {
 		c.advisoryDigestSkips = make(map[string]int)
 	}
-	if c.advisoryDigestHashes[key] == digestHash &&
-		c.advisoryDigestSkips[key] < advisoryDigestWriteThroughInterval-1 {
-		c.advisoryDigestSkips[key]++
-		skips := c.advisoryDigestSkips[key]
-		c.advisoryMu.Unlock()
-		c.logger.Debug("advisory digest unchanged — skipping forge write",
-			slog.String("repo", repo), slog.Int("issue", issueNum),
-			slog.Int("consecutive_skips", skips))
-		return nil
+	// writeThrough records that this cycle is the periodic re-proof of write
+	// permission rather than a content update. The #5507 suppression below
+	// must NOT swallow it: its whole purpose is to make a 403 regression
+	// visible, and a suppressed cycle performs no write and so proves nothing.
+	writeThrough := false
+	if c.advisoryDigestHashes[key] == digestHash {
+		if c.advisoryDigestSkips[key] < advisoryDigestWriteThroughInterval-1 {
+			c.advisoryDigestSkips[key]++
+			skips := c.advisoryDigestSkips[key]
+			c.advisoryMu.Unlock()
+			c.logger.Debug("advisory digest unchanged — skipping forge write",
+				slog.String("repo", repo), slog.Int("issue", issueNum),
+				slog.Int("consecutive_skips", skips))
+			return nil
+		}
+		writeThrough = true
 	}
 	c.advisoryMu.Unlock()
 
-	commentID, err := c.findDigestComment(ctx, owner, repoName, issueNum)
+	existing, err := c.findDigestCommentDetail(ctx, owner, repoName, issueNum)
 	if err != nil {
 		c.logger.Warn("could not search for existing digest comment, creating new", slog.String("error", err.Error()))
 	}
 
+	// Repeat suppression (#5507). The baseline is the digest ALREADY ON THE
+	// TARGET, just fetched above — not process memory — so a governor that
+	// restarts (the login-blocked spokes in the report restart often) reaches
+	// the same decision instead of forgetting and resuming the spam. See
+	// advisory_suppress.go for why the material fingerprint must exclude
+	// timestamps, and for the zero-finding cap.
+	//
+	// Note this suppresses the EDIT of an existing digest comment as well as
+	// the creation of a new one. Editing is cheap for subscribers (GitHub does
+	// not re-notify on an edit), but the runaway in #5507 was CREATION: once a
+	// target accumulates more than one page of comments, findDigestComment no
+	// longer sees the bot's own digest and every cycle creates a fresh one.
+	// Suppressing on material content stops that at the source regardless of
+	// which branch the write would have taken.
+	sup := evaluateDigestSuppression(digest, existing.body, existing.found(), existing.updatedAt, time.Now())
+	if sup.suppress && writeThrough {
+		c.logger.Debug("advisory digest suppression overridden by periodic write-through",
+			slog.String("repo", repo), slog.Int("issue", issueNum),
+			slog.String("reason", sup.reason))
+		sup = digestSuppression{}
+	}
+	if sup.suppress {
+		// A suppressed cycle counts toward the write-through streak exactly as
+		// an #4818 unchanged-skip does. Without this the streak would never
+		// advance past 0 — every cycle would be suppressed here BEFORE the
+		// counter was touched — and the periodic permission re-proof would
+		// stop firing forever, silently disabling the 403 regression probe.
+		c.advisoryMu.Lock()
+		c.advisoryDigestHashes = ensureStringMap(c.advisoryDigestHashes)
+		c.advisoryDigestHashes[key] = digestHash
+		c.advisoryDigestSkips[key]++
+		c.advisoryMu.Unlock()
+
+		// Audit-log only — deliberately NOT a comment on the issue, which
+		// would swap one kind of subscriber noise for another.
+		c.recordCreationAudit(AuditActionAdvisoryDigestSuppressed, InvocationMeta{Agent: AttributionAgentGovernor},
+			"repo", owner+"/"+repoName,
+			"number", strconv.Itoa(issueNum),
+			"reason", sup.reason,
+			"flow", "advisory-digest")
+		c.logger.Info("advisory digest suppressed — not posting",
+			slog.String("repo", repo), slog.Int("issue", issueNum),
+			slog.String("reason", sup.reason))
+		// nil, like the #4818 unchanged-skip: a suppressed cycle is a HEALTHY
+		// cycle, so the caller's success path still advances the
+		// advisory-staleness freshness record rather than alarming the hub.
+		return nil
+	}
+
+	commentID := existing.id
 	var author string
 	if commentID > 0 {
 		edited, _, err := c.client.Issues.EditComment(ctx, owner, repoName, int64(commentID), &gh.IssueComment{
@@ -331,15 +389,39 @@ func (c *Client) ensureAdvisoryLabel(ctx context.Context, owner, repo string, is
 	_, _, _ = c.client.Issues.AddLabelsToIssue(ctx, owner, repo, issueNum, []string{advisoryLabelName})
 }
 
+// findDigestComment returns the ID of the digest comment this client should
+// edit, or 0 if none exists. It is the narrow form of findDigestCommentDetail,
+// kept because most callers only need the ID.
 func (c *Client) findDigestComment(ctx context.Context, owner, repo string, issueNum int) (int, error) {
+	d, err := c.findDigestCommentDetail(ctx, owner, repo, issueNum)
+	return d.id, err
+}
+
+// digestComment is the existing digest comment on a target, used both as the
+// edit destination and as the restart-safe baseline for repeat suppression
+// (#5507): its body is what the pending digest is compared against, and its
+// last-update time is what the zero-finding cap measures from.
+type digestComment struct {
+	// id is the comment ID to edit, 0 when no adoptable digest comment exists.
+	id int
+	// body is the comment's current rendered body.
+	body string
+	// updatedAt is when the comment was last written.
+	updatedAt time.Time
+}
+
+// found reports whether an existing digest comment was located.
+func (d digestComment) found() bool { return d.id > 0 }
+
+func (c *Client) findDigestCommentDetail(ctx context.Context, owner, repo string, issueNum int) (digestComment, error) {
 	opts := &gh.IssueListCommentsOptions{
 		ListOptions: gh.ListOptions{PerPage: 50},
 	}
 	comments, _, err := c.client.Issues.ListComments(ctx, owner, repo, issueNum, opts)
 	if err != nil {
-		return 0, err
+		return digestComment{}, err
 	}
-	var botAuthored int64
+	var botAuthored digestComment
 	for _, comment := range comments {
 		if !strings.HasPrefix(comment.GetBody(), advisoryDigestPrefix) {
 			continue
@@ -348,20 +430,20 @@ func (c *Client) findDigestComment(ctx context.Context, owner, repo string, issu
 			// Token (PAT) client: historical prefix-only match. The credential
 			// may legitimately be the human who authored the comment, and
 			// authorship cannot be verified without an extra /user round trip.
-			return int(comment.GetID()), nil
+			return digestCommentFrom(comment), nil
 		}
 		login := comment.GetUser().GetLogin()
 		if c.appBotLogin != "" && login == c.appBotLogin {
 			// Exactly our own bot comment — the one credential-safe choice.
-			return int(comment.GetID()), nil
+			return digestCommentFrom(comment), nil
 		}
 		if strings.HasSuffix(login, "[bot]") || comment.GetUser().GetType() == "Bot" {
 			// Bot-authored but not provably ours (bot login unknown, or a slug
 			// mismatch between config and the real App). Remember the first as
 			// a fallback rather than skipping it: refusing our own comment on
 			// a misconfigured slug would create a duplicate every cycle.
-			if botAuthored == 0 {
-				botAuthored = comment.GetID()
+			if !botAuthored.found() {
+				botAuthored = digestCommentFrom(comment)
 			}
 			continue
 		}
@@ -379,7 +461,25 @@ func (c *Client) findDigestComment(ctx context.Context, owner, repo string, issu
 			slog.Int64("comment_id", comment.GetID()),
 			slog.String("author", login))
 	}
-	return int(botAuthored), nil
+	return botAuthored, nil
+}
+
+// digestCommentFrom projects the fields the post path needs out of a forge
+// comment. UpdatedAt is preferred over CreatedAt: the digest comment is EDITED
+// in place, so the last write — not the original creation — is what the
+// zero-finding cap must measure from. A comment that has never been edited
+// reports UpdatedAt == CreatedAt, so the fallback is only for forges that omit
+// it entirely.
+func digestCommentFrom(comment *gh.IssueComment) digestComment {
+	at := comment.GetUpdatedAt().Time
+	if at.IsZero() {
+		at = comment.GetCreatedAt().Time
+	}
+	return digestComment{
+		id:        int(comment.GetID()),
+		body:      comment.GetBody(),
+		updatedAt: at,
+	}
 }
 
 func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int, error) {

--- a/src/pkg/github/advisory_repeat_test.go
+++ b/src/pkg/github/advisory_repeat_test.go
@@ -1,0 +1,283 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/advisory"
+)
+
+// End-to-end coverage for #5507 through PostAdvisoryDigest: the ~250-comment
+// runaway on ibm/alchemy-logging#686 must not be reproducible.
+
+// repeatDigestServer models a target issue that already carries one digest
+// comment and records every write the client attempts. Unlike
+// digestCountingServer it serves the CURRENT body back on the comment list, so
+// the #5507 suppression has the real baseline it uses in production.
+type repeatDigestServer struct {
+	*httptest.Server
+	body       string    // current digest comment body on the issue
+	updatedAt  time.Time // when it was last written
+	editCalls  int
+	createDone int
+}
+
+func newRepeatDigestServer(t *testing.T, org, repo, initialBody string, updatedAt time.Time) *repeatDigestServer {
+	t.Helper()
+	s := &repeatDigestServer{body: initialBody, updatedAt: updatedAt}
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/10/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			out := []map[string]any{}
+			if s.body != "" {
+				out = append(out, map[string]any{
+					"id":         float64(555),
+					"body":       s.body,
+					"updated_at": s.updatedAt.UTC().Format(time.RFC3339),
+					"created_at": s.updatedAt.UTC().Format(time.RFC3339),
+				})
+			}
+			_ = json.NewEncoder(w).Encode(out)
+		case "POST":
+			s.createDone++
+			var in map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&in)
+			if b, ok := in["body"].(string); ok {
+				s.body = b
+			}
+			s.updatedAt = time.Now()
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 556})
+		}
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/555", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PATCH" {
+			s.editCalls++
+			var in map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&in)
+			if b, ok := in["body"].(string); ok {
+				s.body = b
+			}
+			s.updatedAt = time.Now()
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 555})
+		}
+	})
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// writes is every forge write the client performed.
+func (s *repeatDigestServer) writes() int { return s.editCalls + s.createDone }
+
+func emptyDigestAt(at time.Time) string {
+	return advisory.FormatDigestMarkdown(&advisory.Digest{
+		GeneratedAt: at,
+		Mode:        "advisory",
+		ByAgent:     map[string][]advisory.Finding{},
+		TotalCount:  0,
+	}, advisory.DigestOptions{ShowEmpty: true, Org: "testorg", PrimaryRepo: "testrepo"})
+}
+
+// TestPostAdvisoryDigest_LoginBlockedSpokeStopsRepeating reproduces the
+// reported conditions: nothing changes for days, and the governor renders a
+// fresh zero-finding digest every 4h. Before #5507 every cycle wrote, because
+// the GeneratedAt stamp made each body's hash unique. Now only the first
+// writes.
+func TestPostAdvisoryDigest_LoginBlockedSpokeStopsRepeating(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	start := time.Now().Add(-4 * time.Hour)
+	srv := newRepeatDigestServer(t, org, repo, emptyDigestAt(start), start)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	// 12 cycles at the observed ~4h cadence = two days of a wedged spoke.
+	const cycles = 12
+	for i := 0; i < cycles; i++ {
+		body := emptyDigestAt(start.Add(time.Duration(i+1) * 4 * time.Hour))
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, body); err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+	}
+	if srv.writes() != 0 {
+		t.Errorf("wedged spoke wrote %d times over %d cycles, want 0 — the repeat-post bug is still live (edits=%d creates=%d)",
+			srv.writes(), cycles, srv.editCalls, srv.createDone)
+	}
+	if srv.createDone != 0 {
+		t.Errorf("createDone = %d, want 0 — new comments are exactly what accumulated to ~250 on the reported issue", srv.createDone)
+	}
+}
+
+// TestPostAdvisoryDigest_RunawayCreateIsSuppressed models the mechanism that
+// turned repeats into 250 SEPARATE comments rather than 250 edits: on an issue
+// whose comment list no longer surfaces an adoptable digest comment, the post
+// path falls to the CREATE branch every cycle. Suppression must stop it there
+// too, because that branch is the one that notifies every subscriber.
+func TestPostAdvisoryDigest_RunawayCreateIsSuppressed(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	at := time.Now().Add(-time.Hour)
+	posted := emptyDigestAt(at)
+	srv := newRepeatDigestServer(t, org, repo, posted, at)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	// Materially identical to what is already there, only a later stamp.
+	next := emptyDigestAt(time.Now())
+	if next == posted {
+		t.Fatal("fixture bodies are identical; the test would pass without exercising the fingerprint")
+	}
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, next); err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	if srv.writes() != 0 {
+		t.Errorf("writes = %d, want 0 (edits=%d creates=%d)", srv.writes(), srv.editCalls, srv.createDone)
+	}
+}
+
+// findingDigestAt renders a digest carrying one UNCHANGING finding at the
+// given generation time. The finding set never varies, so successive renders
+// differ only by the GeneratedAt stamp.
+func findingDigestAt(at time.Time) string {
+	return advisory.FormatDigestMarkdown(&advisory.Digest{
+		GeneratedAt: at,
+		Mode:        "advisory",
+		ByAgent: map[string][]advisory.Finding{"quality": {{
+			Agent: "quality", Timestamp: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			Type: "coverage-gap", Severity: "high",
+			Title: "uncovered error path in PostAdvisoryDigest",
+		}}},
+		TotalCount: 1,
+	}, advisory.DigestOptions{Org: "testorg", PrimaryRepo: "testrepo"})
+}
+
+// TestPostAdvisoryDigest_UnchangedFindingsStopRepeating is the timestamp-
+// exclusion assertion at the POST-PATH level. It deliberately uses a
+// NON-zero-finding digest so the zero-finding cap cannot fire: the only thing
+// that can suppress these repeats is the material fingerprint ignoring
+// GeneratedAt. If a timestamp ever leaks back into the hash, this fails.
+func TestPostAdvisoryDigest_UnchangedFindingsStopRepeating(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	start := time.Now().Add(-24 * time.Hour)
+	posted := findingDigestAt(start)
+	srv := newRepeatDigestServer(t, org, repo, posted, start)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	if isZeroFindingDigest(posted) {
+		t.Fatal("fixture is a zero-finding digest; the zero-finding cap would mask a timestamp leak and this test would prove nothing")
+	}
+
+	const cycles = 6
+	for i := 0; i < cycles; i++ {
+		body := findingDigestAt(start.Add(time.Duration(i+1) * 4 * time.Hour))
+		if body == posted {
+			t.Fatal("renders are byte-identical; the #4818 in-memory hash would skip these and the material fingerprint would go untested")
+		}
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, body); err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+	}
+	if srv.writes() != 0 {
+		t.Errorf("an unchanging 1-finding digest wrote %d times over %d cycles, want 0 — a timestamp is leaking into the material fingerprint (edits=%d creates=%d)",
+			srv.writes(), cycles, srv.editCalls, srv.createDone)
+	}
+}
+
+// TestPostAdvisoryDigest_NewFindingsBreakThroughSuppression is the safety
+// counterweight through the real post path: when findings actually appear, the
+// digest must reach the issue immediately.
+func TestPostAdvisoryDigest_NewFindingsBreakThroughSuppression(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	at := time.Now().Add(-time.Hour)
+	srv := newRepeatDigestServer(t, org, repo, emptyDigestAt(at), at)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	withFindings := advisory.FormatDigestMarkdown(&advisory.Digest{
+		GeneratedAt: time.Now(),
+		Mode:        "advisory",
+		ByAgent: map[string][]advisory.Finding{"quality": {{
+			Agent: "quality", Timestamp: time.Now(), Type: "coverage-gap",
+			Severity: "high", Title: "uncovered error path in PostAdvisoryDigest",
+		}}},
+		TotalCount: 1,
+	}, advisory.DigestOptions{Org: org, PrimaryRepo: repo})
+
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, withFindings); err != nil {
+		t.Fatalf("post with findings: %v", err)
+	}
+	if srv.writes() != 1 {
+		t.Fatalf("a digest that gained a finding wrote %d times, want 1 — real findings must never be suppressed", srv.writes())
+	}
+}
+
+// TestPostAdvisoryDigest_FirstDigestOnEmptyTargetPosts guards the other
+// direction: a target with no digest comment at all must always receive one,
+// or a fresh advisory issue would stay permanently empty.
+func TestPostAdvisoryDigest_FirstDigestOnEmptyTargetPosts(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	srv := newRepeatDigestServer(t, org, repo, "", time.Time{})
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	if err := c.PostAdvisoryDigest(context.Background(), repo, 10, emptyDigestAt(time.Now())); err != nil {
+		t.Fatalf("first post: %v", err)
+	}
+	if srv.createDone != 1 {
+		t.Errorf("createDone = %d, want 1 — the first digest on a bare target must post", srv.createDone)
+	}
+}
+
+// TestPostAdvisoryDigest_WriteThroughOverridesSuppression protects the #4818
+// permission-regression probe. That probe works by performing a REAL write
+// every advisoryDigestWriteThroughInterval cycles, so a 403 (App dropped from
+// the installation, issues:write revoked) surfaces instead of hiding behind a
+// quiet digest. #5507 suppression would otherwise swallow exactly that write —
+// it is the most suppressible cycle there is, since the body is unchanged —
+// and the regression would go invisible forever.
+func TestPostAdvisoryDigest_WriteThroughOverridesSuppression(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	at := time.Now().Add(-time.Hour)
+	body := findingDigestAt(at)
+	srv := newRepeatDigestServer(t, org, repo, body, at)
+	c := newTestClient(t, srv.Server, org, []string{repo})
+
+	// Feed the SAME body repeatedly so the #4818 in-memory hash matches and
+	// the skip streak advances to the write-through boundary.
+	total := advisoryDigestWriteThroughInterval + 1
+	for i := 0; i < total; i++ {
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, body); err != nil {
+			t.Fatalf("cycle %d: %v", i+1, err)
+		}
+	}
+	if srv.writes() == 0 {
+		t.Fatalf("after %d unchanged cycles the periodic write-through never wrote — a 403 permission regression would now be invisible", total)
+	}
+}
+
+// TestPostAdvisoryDigest_SuppressionSurvivesRestart is the restart-behaviour
+// assertion from the issue. State kept only in process memory would be lost by
+// a restarting governor — and login-blocked spokes, the reported failure
+// environment, restart often. A brand-new Client (a fresh process, empty
+// in-memory maps) must reach the same suppression decision, because the
+// baseline is the comment on the target rather than anything remembered.
+func TestPostAdvisoryDigest_SuppressionSurvivesRestart(t *testing.T) {
+	org, repo := "testorg", "testrepo"
+	at := time.Now().Add(-2 * time.Hour)
+	srv := newRepeatDigestServer(t, org, repo, emptyDigestAt(at), at)
+
+	for i := 0; i < 5; i++ {
+		// A NEW client each iteration: every in-memory guard (#4818 hashes,
+		// skip counters) starts empty, exactly as after a process restart.
+		c := newTestClient(t, srv.Server, org, []string{repo})
+		if c.advisoryDigestHashes != nil {
+			t.Fatal("fresh client already carries digest hashes; this test would not model a restart")
+		}
+		if err := c.PostAdvisoryDigest(context.Background(), repo, 10, emptyDigestAt(time.Now())); err != nil {
+			t.Fatalf("restart %d: %v", i, err)
+		}
+	}
+	if srv.writes() != 0 {
+		t.Errorf("after 5 restarts: writes = %d, want 0 — suppression is not surviving restart, so a crash-looping spoke resumes spamming", srv.writes())
+	}
+}

--- a/src/pkg/github/advisory_suppress.go
+++ b/src/pkg/github/advisory_suppress.go
@@ -1,0 +1,183 @@
+package github
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Advisory-digest repeat suppression (#5507).
+//
+// The digest write path already had a skip-if-unchanged guard (#4818) keyed on
+// a sha256 of the FINAL comment body. That guard never fired in practice,
+// because FormatDigestMarkdown stamps d.GeneratedAt into the body in two
+// places — the "## 🐝 Advisory Digest — 2026-08-31 04:00 UTC" header and the
+// "evaluated <RFC3339>" clause of the zero-finding line. Every cycle therefore
+// produced a unique body hash, so every cycle wrote. On a spoke where all
+// agents were login-blocked and no finding ever changed, that turned into ~250
+// comments on ibm/alchemy-logging#686, the vast majority reading "0 findings".
+//
+// Two guards close it, both computed from the MATERIAL content of a digest —
+// the findings, counts and prose — with every timestamp and formatting-churn
+// artifact removed:
+//
+//  1. identical: the material fingerprint of the digest about to be posted
+//     matches the material fingerprint of the digest already on the target.
+//  2. zero_finding_cap: both the pending and the posted digest report zero
+//     findings, and the posted one is younger than
+//     zeroFindingDigestMinInterval. A zero-finding digest carries no news, so
+//     one per target per 48h is plenty even when its wording drifts.
+//
+// Guard 2 applies ONLY when BOTH digests are zero-finding. A digest that goes
+// 0 findings → 3 findings is material news and posts immediately, inside the
+// window or not.
+//
+// State: there is deliberately no new persistent store. The comparison baseline
+// is the digest comment ALREADY ON THE TARGET, which the post path fetches
+// anyway (findDigestComment). That makes both guards inherently restart-safe:
+// a governor that restarts re-reads the same comment and reaches the same
+// decision. The observed failure was on login-blocked spokes, which restart
+// often, so in-memory-only state would have forgotten and resumed spamming —
+// exactly the bug. The pre-existing in-memory #4818 hash guard is retained on
+// top as a cheap fast path; it is an optimization, not the correctness gate.
+
+const (
+	// zeroFindingDigestMinInterval is the minimum time between two
+	// zero-finding advisory digests on the SAME target. A digest reporting no
+	// findings says nothing that a reader needs twice a day, and these
+	// comments land on THIRD-PARTY repositories where every subscriber is
+	// notified. 48h keeps the freshness signal alive (the hub's staleness gate
+	// alarms well after this) while collapsing ~12 zero-finding posts a day
+	// into one.
+	zeroFindingDigestMinInterval = 48 * time.Hour
+
+	// suppressReasonIdentical marks a digest suppressed because its material
+	// content is byte-identical to the digest already on the target.
+	suppressReasonIdentical = "identical"
+	// suppressReasonZeroFindingCap marks a digest suppressed because it is a
+	// zero-finding digest posted inside zeroFindingDigestMinInterval of the
+	// previous zero-finding digest on the same target.
+	suppressReasonZeroFindingCap = "zero_finding_cap"
+)
+
+// AuditActionAdvisoryDigestSuppressed is the audit action recorded when a
+// digest post is suppressed. It is LOCAL-AUDIT-ONLY by design: posting a
+// "suppressed" note to the issue would replace one kind of subscriber noise
+// with another.
+const AuditActionAdvisoryDigestSuppressed = "advisory_digest_suppressed"
+
+// volatileDigestPatterns match the parts of a rendered digest that change on
+// every render without the findings changing. They are stripped before
+// fingerprinting so that "same findings, one minute later" hashes identically.
+//
+// Getting this exclusion right is the whole fix: if a single timestamp leaks
+// into the fingerprint every digest is unique and the suppression silently
+// does nothing — which is precisely how the #4818 guard failed.
+var volatileDigestPatterns = []*regexp.Regexp{
+	// Header stamp: "## 🐝 Advisory Digest — 2026-08-31 04:00 UTC".
+	// Matched by shape, not by prefix, so a renamed heading still scrubs.
+	regexp.MustCompile(`\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?( [A-Za-z/_+\-0-9]{1,10})?`),
+	// RFC3339 stamps: "evaluated 2026-08-31T04:00:11Z", finding timestamps,
+	// and the analyzed-snapshot footer's date.
+	regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+\-]\d{2}:\d{2})`),
+	// Relative ages the renderer emits ("3h ago", "2 days ago"): these tick
+	// upward every cycle while the underlying finding is unchanged.
+	regexp.MustCompile(`\b\d+\s*(s|m|h|d|second|minute|hour|day|week|month)s?\s+ago\b`),
+	// Commit-pin footer: the snapshot SHA advances with every upstream push,
+	// which is repo churn rather than a change in what the agents found.
+	regexp.MustCompile(`\b[0-9a-f]{7,40}\b`),
+}
+
+// materialDigestFingerprint reduces a rendered digest body to a stable hash of
+// its MATERIAL content: the findings, their counts and their prose, with all
+// timestamps, relative ages, commit pins and whitespace churn removed. Two
+// digests rendered a day apart from an unchanged finding set fingerprint
+// identically; a digest whose finding set changed does not.
+func materialDigestFingerprint(body string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(materialDigestContent(body))))
+}
+
+// materialDigestContent is the normalized text materialDigestFingerprint
+// hashes. Split out so tests can assert on the normalization directly rather
+// than only on hash equality — an assertion over opaque hashes cannot show
+// WHICH part of the exclusion is wrong.
+func materialDigestContent(body string) string {
+	s := body
+	for _, re := range volatileDigestPatterns {
+		s = re.ReplaceAllString(s, "")
+	}
+	// Collapse whitespace last: stripping a stamp mid-line leaves ragged runs
+	// of spaces that would otherwise re-introduce spurious differences.
+	lines := strings.Split(s, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		ln = strings.Join(strings.Fields(ln), " ")
+		if ln == "" {
+			continue
+		}
+		kept = append(kept, ln)
+	}
+	return strings.Join(kept, "\n")
+}
+
+// zeroFindingLine matches the rendered "**Findings:** 0" summary that
+// FormatDigestMarkdown emits for a digest with no open findings. The count is
+// captured so a digest with any findings at all is never treated as
+// zero-finding.
+var zeroFindingLine = regexp.MustCompile(`(?m)^\*\*Findings:\*\*\s*(\d+)`)
+
+// isZeroFindingDigest reports whether a rendered digest body announces zero
+// findings. A body with no recognizable findings line returns false — the
+// conservative answer, since the zero-finding cap must never suppress a digest
+// whose content it could not read.
+func isZeroFindingDigest(body string) bool {
+	m := zeroFindingLine.FindStringSubmatch(body)
+	if m == nil {
+		return false
+	}
+	return m[1] == "0"
+}
+
+// ensureStringMap returns m, allocating it first when nil. The advisory maps
+// are lazily created across several branches of PostAdvisoryDigest; this keeps
+// each of them a one-liner under the same mutex.
+func ensureStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return make(map[string]string)
+	}
+	return m
+}
+
+// digestSuppression is the decision for one post attempt.
+type digestSuppression struct {
+	// suppress reports whether the forge write must be skipped.
+	suppress bool
+	// reason is suppressReasonIdentical or suppressReasonZeroFindingCap, set
+	// only when suppress is true.
+	reason string
+}
+
+// evaluateDigestSuppression decides whether posting pending to a target that
+// already carries posted (last updated at postedAt) should be suppressed.
+//
+// hasPosted is false when the target carries no digest comment yet — the first
+// digest on a target ALWAYS posts, so a fresh advisory issue is never left
+// empty by the guards.
+func evaluateDigestSuppression(pending, posted string, hasPosted bool, postedAt, now time.Time) digestSuppression {
+	if !hasPosted {
+		return digestSuppression{}
+	}
+	if materialDigestFingerprint(pending) == materialDigestFingerprint(posted) {
+		return digestSuppression{suppress: true, reason: suppressReasonIdentical}
+	}
+	// Zero-finding cap. Requires BOTH sides to be zero-finding: a transition
+	// out of (or into) a non-empty finding set is material news and must post
+	// even inside the window.
+	if isZeroFindingDigest(pending) && isZeroFindingDigest(posted) &&
+		!postedAt.IsZero() && now.Sub(postedAt) < zeroFindingDigestMinInterval {
+		return digestSuppression{suppress: true, reason: suppressReasonZeroFindingCap}
+	}
+	return digestSuppression{}
+}

--- a/src/pkg/github/advisory_suppress_test.go
+++ b/src/pkg/github/advisory_suppress_test.go
@@ -1,0 +1,239 @@
+package github
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/advisory"
+)
+
+// Tests for advisory-digest repeat suppression (#5507).
+//
+// The bug these guard: ~250 digest comments accumulated on a third-party
+// issue, the vast majority reading "0 findings", because the pre-existing
+// #4818 body hash included FormatDigestMarkdown's GeneratedAt stamps and so
+// differed on every render. The load-bearing assertion in this file is
+// therefore the timestamp-exclusion proof (TestMaterialFingerprint_*): if that
+// regresses, every other guard here silently stops firing.
+
+// renderZeroFindingDigest renders an empty digest through the REAL formatter at
+// the given generation time. Using the production renderer (rather than a
+// hand-written fixture) is deliberate: a fixture would only prove the
+// fingerprint ignores stamps the test author remembered to include, whereas
+// this proves it against the exact bytes the governor posts.
+func renderZeroFindingDigest(t *testing.T, at time.Time) string {
+	t.Helper()
+	md := advisory.FormatDigestMarkdown(&advisory.Digest{
+		GeneratedAt: at,
+		Mode:        "advisory",
+		ByAgent:     map[string][]advisory.Finding{},
+		TotalCount:  0,
+	}, advisory.DigestOptions{ShowEmpty: true, Org: "testorg", PrimaryRepo: "testrepo"})
+	if md == "" {
+		t.Fatal("renderer returned empty digest; test fixture is vacuous")
+	}
+	return md
+}
+
+// renderFindingDigest renders a digest carrying n findings at the given time.
+func renderFindingDigest(t *testing.T, at time.Time, n int) string {
+	t.Helper()
+	findings := make([]advisory.Finding, 0, n)
+	for i := 0; i < n; i++ {
+		findings = append(findings, advisory.Finding{
+			Agent:     "quality",
+			Timestamp: at,
+			Type:      "coverage-gap",
+			Severity:  "high",
+			Title:     "uncovered branch in handler " + string(rune('A'+i)),
+			Detail:    "add a test for the error path",
+		})
+	}
+	md := advisory.FormatDigestMarkdown(&advisory.Digest{
+		GeneratedAt: at,
+		Mode:        "advisory",
+		ByAgent:     map[string][]advisory.Finding{"quality": findings},
+		TotalCount:  n,
+	}, advisory.DigestOptions{Org: "testorg", PrimaryRepo: "testrepo"})
+	if md == "" {
+		t.Fatal("renderer returned empty digest; test fixture is vacuous")
+	}
+	return md
+}
+
+// TestMaterialFingerprint_ExcludesTimestamps is THE proof that the fix is not
+// a no-op. Two digests with an identical (empty) finding set are rendered a
+// full 37 hours apart, which forces a different calendar DATE, a different
+// clock time and a different RFC3339 stamp — so this can never pass by
+// accident because both renders happened in the same second.
+func TestMaterialFingerprint_ExcludesTimestamps(t *testing.T) {
+	t1 := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	t2 := t1.Add(37 * time.Hour)
+
+	a := renderZeroFindingDigest(t, t1)
+	b := renderZeroFindingDigest(t, t2)
+
+	// Guard the guard: if the renderer ever stops stamping the body, this test
+	// would pass trivially while proving nothing about exclusion.
+	if a == b {
+		t.Fatal("rendered bodies are byte-identical across a 37h gap — the renderer no longer stamps a timestamp, so this test cannot prove timestamp EXCLUSION; re-point it at whatever volatile field replaced it")
+	}
+	if !strings.Contains(a, "2026-08-30") || !strings.Contains(b, "2026-08-31") {
+		t.Fatalf("expected distinct calendar dates in the two bodies:\nA=%q\nB=%q", a, b)
+	}
+
+	if got, want := materialDigestFingerprint(a), materialDigestFingerprint(b); got != want {
+		t.Errorf("material fingerprint differs across renders that changed only the timestamp:\n got=%s\nwant=%s\nnormalized A:\n%s\nnormalized B:\n%s",
+			got, want, materialDigestContent(a), materialDigestContent(b))
+	}
+}
+
+// TestMaterialFingerprint_NormalizedContentHasNoTimestamps asserts on the
+// normalization directly. Hash equality alone cannot show WHICH volatile field
+// leaked, so this checks the stripped text contains no date-shaped residue.
+func TestMaterialFingerprint_NormalizedContentHasNoTimestamps(t *testing.T) {
+	at := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	normalized := materialDigestContent(renderZeroFindingDigest(t, at))
+	for _, residue := range []string{"2026-08-30", "04:00", "T04:00:11Z"} {
+		if strings.Contains(normalized, residue) {
+			t.Errorf("normalized digest still contains volatile substring %q — it will leak into the hash and defeat suppression:\n%s", residue, normalized)
+		}
+	}
+}
+
+// TestMaterialFingerprint_DetectsRealContentChange is the counterweight: the
+// exclusion must not be so aggressive that it erases the findings themselves.
+func TestMaterialFingerprint_DetectsRealContentChange(t *testing.T) {
+	at := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	zero := renderZeroFindingDigest(t, at)
+	three := renderFindingDigest(t, at, 3)
+
+	if materialDigestFingerprint(zero) == materialDigestFingerprint(three) {
+		t.Fatal("0-finding and 3-finding digests fingerprint identically — the normalization is stripping material content, not just timestamps")
+	}
+
+	// Same count, different finding text must also differ.
+	one := renderFindingDigest(t, at, 1)
+	two := renderFindingDigest(t, at, 2)
+	if materialDigestFingerprint(one) == materialDigestFingerprint(two) {
+		t.Error("1-finding and 2-finding digests fingerprint identically")
+	}
+}
+
+func TestIsZeroFindingDigest(t *testing.T) {
+	at := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	if !isZeroFindingDigest(renderZeroFindingDigest(t, at)) {
+		t.Error("empty digest not recognized as zero-finding")
+	}
+	if isZeroFindingDigest(renderFindingDigest(t, at, 3)) {
+		t.Error("3-finding digest misread as zero-finding")
+	}
+	// Unreadable body: must fail SAFE (not zero-finding), so the zero-finding
+	// cap never suppresses a digest whose count it could not parse.
+	if isZeroFindingDigest("## 🐝 Advisory Digest\n\nsomething the parser does not know") {
+		t.Error("unparseable digest treated as zero-finding; the cap would suppress content it cannot read")
+	}
+	// A count of 10 must not match a prefix-y "0".
+	if isZeroFindingDigest("**Findings:** 10\n") {
+		t.Error("**Findings:** 10 misread as zero-finding")
+	}
+}
+
+// TestEvaluateDigestSuppression_FirstPostAlwaysAllowed pins the hasPosted
+// short-circuit. The inputs are chosen so that WITHOUT that short-circuit the
+// call would suppress: the pending body is passed as its own baseline, so the
+// identical guard would fire on it. Only the "no digest comment on the target
+// yet" check can let it through. (A naive version of this test that passed
+// posted="" proves nothing — an empty baseline fingerprints differently from
+// any real digest, so it is allowed through whether the guard exists or not.)
+func TestEvaluateDigestSuppression_FirstPostAlwaysAllowed(t *testing.T) {
+	at := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	pending := renderZeroFindingDigest(t, at)
+
+	// Sanity: with hasPosted=true these same inputs MUST suppress, otherwise
+	// the assertion below is not exercising the short-circuit.
+	if sup := evaluateDigestSuppression(pending, pending, true, at, at); !sup.suppress {
+		t.Fatal("control case did not suppress; this test cannot prove the first-post short-circuit")
+	}
+
+	if sup := evaluateDigestSuppression(pending, pending, false, at, at); sup.suppress {
+		t.Fatalf("first digest on a target was suppressed (reason=%s); a fresh advisory issue would stay empty forever", sup.reason)
+	}
+}
+
+func TestEvaluateDigestSuppression_IdenticalContentSuppressed(t *testing.T) {
+	t1 := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	t2 := t1.Add(4 * time.Hour) // the observed ~4h repost cadence
+	posted := renderZeroFindingDigest(t, t1)
+	pending := renderZeroFindingDigest(t, t2)
+
+	sup := evaluateDigestSuppression(pending, posted, true, t1, t2)
+	if !sup.suppress {
+		t.Fatal("a materially identical re-post was NOT suppressed — this is the exact 250-comment bug")
+	}
+	if sup.reason != suppressReasonIdentical {
+		t.Errorf("reason = %q, want %q", sup.reason, suppressReasonIdentical)
+	}
+}
+
+// TestEvaluateDigestSuppression_ChangedContentPostsInsideWindow is the design
+// caution from the issue: 0 findings → 3 findings is news and must post even
+// well inside the 48h zero-finding window.
+func TestEvaluateDigestSuppression_ChangedContentPostsInsideWindow(t *testing.T) {
+	t1 := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	t2 := t1.Add(1 * time.Hour) // deep inside zeroFindingDigestMinInterval
+	posted := renderZeroFindingDigest(t, t1)
+	pending := renderFindingDigest(t, t2, 3)
+
+	if sup := evaluateDigestSuppression(pending, posted, true, t1, t2); sup.suppress {
+		t.Fatalf("0-findings → 3-findings was suppressed (reason=%s) — real news would be swallowed", sup.reason)
+	}
+
+	// And the reverse transition, 3 findings → 0 (everything fixed), is also
+	// news: it must post rather than be caught by the zero-finding cap.
+	postedThree := renderFindingDigest(t, t1, 3)
+	pendingZero := renderZeroFindingDigest(t, t2)
+	if sup := evaluateDigestSuppression(pendingZero, postedThree, true, t1, t2); sup.suppress {
+		t.Fatalf("3-findings → 0-findings was suppressed (reason=%s) — the all-clear would never be posted", sup.reason)
+	}
+}
+
+// TestEvaluateDigestSuppression_ZeroFindingCap covers guard 2: two zero-finding
+// digests whose text DRIFTS materially (so the identical guard cannot catch
+// them) are still capped to one per 48h.
+func TestEvaluateDigestSuppression_ZeroFindingCap(t *testing.T) {
+	t1 := time.Date(2026, 8, 30, 4, 0, 11, 0, time.UTC)
+	posted := renderZeroFindingDigest(t, t1)
+	// Force material drift while keeping the count at zero, so this test
+	// exercises the CAP and not the identical guard.
+	pending := renderZeroFindingDigest(t, t1.Add(4*time.Hour)) + "\n_scanned 41 files_\n"
+	if materialDigestFingerprint(pending) == materialDigestFingerprint(posted) {
+		t.Fatal("fixtures fingerprint identically; this test would exercise the identical guard, not the zero-finding cap")
+	}
+
+	// Pin the window to the value the issue specifies. Expressing the
+	// boundaries below only in terms of the constant would make this test move
+	// WITH any change to it — including a change to 1s that disables the cap in
+	// practice — so the contract is asserted against a literal here and the
+	// boundary cases are anchored on absolute offsets.
+	if zeroFindingDigestMinInterval != 48*time.Hour {
+		t.Fatalf("zeroFindingDigestMinInterval = %v, want 48h (#5507: at most one zero-finding digest per target per 48h)", zeroFindingDigestMinInterval)
+	}
+
+	// Just under 48h: capped.
+	inside := t1.Add(47 * time.Hour)
+	sup := evaluateDigestSuppression(pending, posted, true, t1, inside)
+	if !sup.suppress {
+		t.Fatal("drifting zero-finding digest inside the 48h window was not capped")
+	}
+	if sup.reason != suppressReasonZeroFindingCap {
+		t.Errorf("reason = %q, want %q", sup.reason, suppressReasonZeroFindingCap)
+	}
+
+	// Just past 48h: posts again, so the freshness signal never dies.
+	outside := t1.Add(49 * time.Hour)
+	if sup := evaluateDigestSuppression(pending, posted, true, t1, outside); sup.suppress {
+		t.Fatalf("zero-finding digest suppressed 49h after the last post (reason=%s); the digest would freeze permanently", sup.reason)
+	}
+}


### PR DESCRIPTION
Fixes #5507

## The bug, and why the existing guard never caught it

The governor re-posted its advisory digest to a single tracked issue roughly every 4 hours with nothing suppressing the repeats, accumulating ~250 comments on `ibm/alchemy-logging#686` — the vast majority reading "0 findings" — on a spoke where every agent was login-blocked so nothing could change.

There was already a skip-if-unchanged guard meant to prevent exactly this (#4818). It never fired. It hashes the **final comment body**, and `FormatDigestMarkdown` stamps `GeneratedAt` into that body in two places:

- the `## 🐝 Advisory Digest — 2026-08-31 04:00 UTC` header
- the `evaluated <RFC3339>` clause of the zero-finding line

So every render produced a unique hash and every cycle wrote. This is the exact trap the issue warns about, and it is why the fix below is built around a fingerprint that provably excludes timestamps rather than another body hash.

A second mechanism explains why this produced 250 **separate comments** rather than 250 edits of one: `findDigestComment` reads only the first page of comments (`PerPage: 50`, no pagination). Once a target accumulates more than a page, the bot can no longer see its own digest, falls to the CREATE branch, and each new comment pushes the next one further out of reach — a self-reinforcing runaway that notifies every subscriber of a third-party repo.

## What this adds

Two guards in `pkg/github/advisory_suppress.go`, both computed over the **material** content of a digest — findings, counts and prose — with timestamps, relative ages (`3h ago`) and commit pins stripped before hashing:

1. **`identical`** — the pending digest's material fingerprint matches the digest already on the target.
2. **`zero_finding_cap`** — both the pending and posted digests report zero findings and the posted one is younger than `zeroFindingDigestMinInterval` (48h, a named constant). This applies **only when both sides are zero-finding**, so a 0 → 3 findings transition posts immediately, and so does the 3 → 0 all-clear.

Suppression is recorded in the **local audit log only** — `advisory_digest_suppressed` with `reason=identical|zero_finding_cap`. No "suppressed" comment is posted to the issue, which would swap one kind of subscriber noise for another.

## State, and restart behaviour

**No new persistent store, and the guards survive restart.** The comparison baseline is the digest comment **already on the target**, which the post path fetches anyway via `findDigestComment`. A governor that restarts re-reads the same comment and reaches the same decision.

This was a deliberate choice over in-memory state. The reported failure was on **login-blocked spokes, which restart often** — in-memory-only state would have been forgotten on each restart and the spam would have resumed, which is close to the observed behaviour. Deriving the baseline from the forge makes restart-safety structural rather than something that has to be maintained. The pre-existing in-memory #4818 hash is kept on top purely as a cheap fast path; it is an optimization, not the correctness gate.

## Preserving the #4818 permission probe

The write-through in #4818 performs a real write every `advisoryDigestWriteThroughInterval` cycles to re-prove `issues:write`, so a 403 regression (App dropped from the installation) stays visible instead of hiding behind a quiet digest. That cycle is the most suppressible one there is — the body is unchanged — so suppression explicitly does **not** swallow it.

Writing the test for this surfaced a real bug in my own first draft: because suppression returned before the skip counter was touched, the streak never advanced past 0 and the write-through would have **stopped firing forever**, silently disabling the permission probe. Suppressed cycles now advance that streak. `TestPostAdvisoryDigest_WriteThroughOverridesSuppression` covers it.

## Mutation evidence

Per #5388, every assertion was mutation-tested: introduce the defect the test exists to catch, confirm that specific test fails, revert. **Three of the five mutations initially SURVIVED and forced test changes** — those are recorded below rather than quietly fixed.

| # | Mutation | Result |
|---|---|---|
| 1 | `materialDigestContent` stops stripping volatile patterns (reverts to the naive #4818 body hash) | **CAUGHT** — 4 tests fail |
| 2 | Zero-finding cap drops the "both sides zero-finding" requirement | **CAUGHT** — 2 tests fail |
| 3 | `hasPosted` first-post short-circuit removed | **SURVIVED → test fixed → CAUGHT** |
| 4 | Write-through override disabled | **CAUGHT** — 1 test fails |
| 5 | `zeroFindingDigestMinInterval` changed 48h → 1s | **SURVIVED → test fixed → CAUGHT** |

### Mutation 1 — the timestamp-exclusion proof

This is the load-bearing one: if a timestamp leaks into the fingerprint, the fix silently does nothing, exactly as #4818 did.

```
--- FAIL: TestPostAdvisoryDigest_UnchangedFindingsStopRepeating (0.01s)
--- FAIL: TestMaterialFingerprint_ExcludesTimestamps (0.00s)
--- FAIL: TestMaterialFingerprint_NormalizedContentHasNoTimestamps (0.00s)
--- FAIL: TestEvaluateDigestSuppression_IdenticalContentSuppressed (0.00s)
```

The proof is specifically built so it cannot pass by accident:

- `TestMaterialFingerprint_ExcludesTimestamps` renders the two digests **37 hours apart**, forcing a different calendar date, clock time and RFC3339 stamp. It cannot pass because both renders landed in the same second.
- It **asserts the two raw bodies differ** before comparing fingerprints. If the renderer ever stops stamping the body, the test fails with an explicit message rather than passing vacuously.
- `TestMaterialFingerprint_NormalizedContentHasNoTimestamps` asserts on the normalized text directly (`2026-08-30`, `04:00`, `T04:00:11Z` absent), because hash equality alone cannot show *which* volatile field leaked.
- Both fixtures are rendered through the **real `advisory.FormatDigestMarkdown`**, not hand-written strings — a fixture would only prove the fingerprint ignores stamps I remembered to include.

An initial round found that the three post-path tests (`LoginBlockedSpokeStopsRepeating`, `RunawayCreateIsSuppressed`, `SuppressionSurvivesRestart`) **passed under mutation 1**, because they use zero-finding digests and the zero-finding cap caught them independently. Rather than claim they prove timestamp exclusion, I added `TestPostAdvisoryDigest_UnchangedFindingsStopRepeating`, which deliberately uses a **non-zero-finding** digest so the cap cannot fire — the material fingerprint is then the only thing that can suppress it. That test appears in the failure list above.

### Mutation 3 — survived, test was vacuous

`TestEvaluateDigestSuppression_FirstPostAlwaysAllowed` originally passed `posted=""` with `hasPosted=false`. An empty baseline fingerprints differently from any real digest, so the call was allowed through **whether or not the guard existed**. The test now passes the pending body as its own baseline (so the identical guard would fire without the short-circuit) and includes a control assertion proving the same inputs DO suppress when `hasPosted=true`. Mutation 3 then fails it.

### Mutation 5 — survived, self-referential assertion

The cap-boundary test expressed both boundaries as `zeroFindingDigestMinInterval ± time.Minute`, so it moved with the constant and passed even when the window was cut to 1 second, which disables the cap in practice. It now asserts the constant equals 48h against a literal and anchors the boundary cases on absolute 47h/49h offsets. Mutation 5 then fails it.

Additional anti-vacuity guards in the fixtures: the zero-finding-cap test asserts its two fixtures fingerprint **differently** (otherwise it would be exercising the identical guard, not the cap); the restart test asserts each fresh client starts with `advisoryDigestHashes == nil` (otherwise it would not model a restart); and `TestPostAdvisoryDigest_UnchangedFindingsStopRepeating` asserts its renders are not byte-identical (otherwise the #4818 in-memory hash would skip them and the material fingerprint would go untested).

## Design cautions from the issue

- **A digest whose content changed is never suppressed.** `TestEvaluateDigestSuppression_ChangedContentPostsInsideWindow` covers 0 → 3 findings *and* 3 → 0 (the all-clear) inside the 48h window; `TestPostAdvisoryDigest_NewFindingsBreakThroughSuppression` covers it through the real post path. Both fail under mutation 2.
- **Unreadable digests fail safe.** `isZeroFindingDigest` returns false when it cannot parse a findings count, so the cap never suppresses content it could not read.
- **The first digest on a target always posts**, so a fresh advisory issue is never left permanently empty.
- **Erring toward suppression:** the guards suppress the EDIT path as well as CREATE. Editing does not re-notify subscribers, so it is the cheaper case, but the runaway was in CREATE and suppressing on material content stops it regardless of which branch the write would have taken.

## Testing

`pkg/advisory` and `cmd/hive` pass clean. `pkg/github` passes for all advisory-digest tests including the pre-existing #4818 suite (`UnchangedSkipsForgeWrite`, `ChangedBodyWritesExactlyOnce`, `WriteThroughFiresOnNthCycle`, `FailedWriteIsNotRecordedAsPosted`, `SkipKeyedPerIssue`), which are unmodified and still green. `gofmt` clean, `go vet` clean.

Local runs are iteration only — **CI is the merge gate**.

## Note on the local `pkg/github` runtime

Running the whole `pkg/github` package locally never finishes and ends in a `panic: test timed out after 25m0s`. **This is pre-existing and unrelated to this change.** Both this branch and unmodified `v4` at `a7024858` behave identically:

- both report **zero `--- FAIL` lines** — no test actually fails on either
- both hang in the same two tests, `TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset` and `TestCommitGreenNoConfigRequiredChecksFallsBackToAPIThenAllowlist`, which shell out to `hive-open-pr.sh` via `exec.Command` and block in this sandbox

Skipping exactly those two, the package passes on this branch:

```
$ go test ./pkg/github/ -skip 'TestHiveOpenPRScript|TestCommitGreenNoConfigRequiredChecksFallsBackToAPIThenAllowlist'
ok  	github.com/kubestellar/hive/pkg/github	47.578s
```

Every advisory-digest test in this PR runs in 0.00s. CI is the merge gate regardless.
