### PR TITLE
🌱 ci(tests): slice pkg/hub 3-way, rank slowest tests per shard, shuffle the nightly, turn the coverage ratchet

### DIFF
--- a/.github/scripts/slowest-tests.sh
+++ b/.github/scripts/slowest-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Summarize the slowest top-level test functions in a `go test -v` log.
+#
+# Usage: slowest-tests.sh <shard-label> <go-test-log> [count]
+#
+# Every v2-tests.yml shard runs `go test -v` (with the `=== RUN/PAUSE/CONT`
+# noise stripped at tee time) so the log carries one
+#     --- PASS: TestName (1.23s)
+# line per top-level test function. This script ranks those lines and writes
+# the top <count> (default 25) to the job's step summary, so the answer to
+# "what is the PR gate actually waiting on?" is one click away instead of a
+# local reproduction. Subtests are indented and deliberately ignored: their
+# time is already included in the parent's.
+#
+# Never fails the job. A log with no per-test lines (compile failure, empty
+# slice) just reports that and exits 0 — the test step itself is the verdict.
+set -u
+
+label=${1:?shard label}
+log=${2:?go test -v log}
+count=${3:-25}
+
+if [ ! -s "$log" ]; then
+  echo "slowest-tests: $log is missing or empty; nothing to rank"
+  exit 0
+fi
+
+# Column-0 "--- PASS|FAIL|SKIP: Name (secs)" only. `sort -rn` on the seconds
+# column; ties keep input order.
+ranked=$(grep -E '^--- (PASS|FAIL|SKIP): [^ ]+ \([0-9.]+s\)$' "$log" \
+  | sed -E 's/^--- (PASS|FAIL|SKIP): ([^ ]+) \(([0-9.]+)s\)$/\3\t\2\t\1/' \
+  | sort -rn -k1,1 \
+  | head -n "$count")
+
+if [ -z "$ranked" ]; then
+  echo "slowest-tests: no per-test timings in $log (was it run with -v?)"
+  exit 0
+fi
+
+total=$(grep -cE '^--- (PASS|FAIL|SKIP): ' "$log")
+{
+  echo "### Slowest tests — $label ($total top-level functions)"
+  echo
+  echo "| seconds | test | result |"
+  echo "|--------:|------|--------|"
+  printf '%s\n' "$ranked" | awk -F'\t' '{ printf "| %s | `%s` | %s |\n", $1, $2, $3 }'
+  echo
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -36,6 +36,10 @@ on:
       - 'Justfile'
       - 'dashboard/openapi.json'
       - '.github/workflows/v2-tests.yml'
+      # The slowest-tests reporter runs in every shard; an edit to it must run
+      # the job that executes it (same rule dashboard-lint applies to its
+      # checker, #5388).
+      - '.github/scripts/slowest-tests.sh'
 
 permissions:
   contents: read
@@ -59,7 +63,14 @@ concurrency:
 # all run concurrently inside one `go test` invocation. Round-robin over the
 # 840 sorted agent test names measures a worst slice of ~127s at N=5. So:
 #
-#   test (hub)         ./pkg/hub/...          its own job, starts immediately
+#   test (hub i/H)     ./pkg/hub              H jobs, each running a
+#                                             deterministic 1/H slice of the
+#                                             package's test FUNCTIONS via -run
+#                                             (one ~2,700-function package at
+#                                             ~125s serial: it was the PR gate's
+#                                             critical path until sliced the
+#                                             same way as agent) — starts
+#                                             immediately, self-partitions
 #   test (agent i/N)   ./pkg/agent            N jobs, each running a
 #                                             deterministic 1/N slice of the
 #                                             package's test FUNCTIONS via -run
@@ -72,20 +83,44 @@ concurrency:
 #   test (rest i/R)    one bucket each
 #
 # Every shard uses the exact same flags: -short -race -count=1 (untouched),
-# plus -coverprofile for the parse-only coverage gate below.
+# plus -coverprofile for the parse-only coverage gate below, plus:
+#  - -v, with the `=== RUN/PAUSE/CONT` lines stripped before tee, so the log
+#    carries a per-test-function duration and .github/scripts/slowest-tests.sh
+#    can rank the slice's slowest tests into the step summary. That table is
+#    how a slow shard gets diagnosed without a local reproduction.
+#  - -shuffle=on on every NON-pull_request run (the hourly schedule and manual
+#    dispatches). Order-dependent tests (#5102's golden splash race, the
+#    package-var seams in #4795) pass in a fixed order and only fail when the
+#    order moves; shuffling the post-merge net finds them and files an issue
+#    with the seed in the log, while the PR gate stays deterministic so a
+#    contributor is never failed by an ordering their change did not cause.
 #
 # Completeness invariants (nothing can be silently untested):
-#  - rest buckets are computed by EXCLUDING hub/agent from the full `go list`
-#    and PARTITIONING the remainder — a new package always lands in a bucket,
-#    a removed one just disappears from its bucket.
-#  - agent slices partition the sorted `go test -list` output round-robin —
+#  - rest buckets are computed by EXCLUDING exactly pkg/hub and pkg/agent from
+#    the full `go list` and PARTITIONING the remainder — a new package always
+#    lands in a bucket (a future subpackage of either sliced package included,
+#    since the slices run the bare package path), a removed one just
+#    disappears from its bucket.
+#  - hub and agent slices partition the sorted `go test -list` output round-robin —
 #    a new test function always lands in a slice. Anchored full-name regexes
 #    (^(A|B|...)$) make slices pairwise disjoint and jointly exhaustive.
 #  - the aggregate `test` job (the required-check name) fails closed: it
 #    requires list-packages AND every shard to succeed.
 jobs:
+  # pkg/hub is one package of ~2,700 test functions that takes ~125s serially
+  # under -race — after #4118 sliced pkg/agent, this single job was the PR
+  # gate's critical path (~3.3 min wall clock against ~2.4 min for the widest
+  # rest bucket). It is sliced exactly like test-agent below: each job derives
+  # the same sorted `go test -list` output and runs rows where NR mod H ==
+  # idx-1. The coverage job merges the H partial profiles before scoring the
+  # hub floor. Adding a hub test no longer moves the gate's wall clock by its
+  # full duration — only by 1/H of it.
   test-hub:
-    name: test (hub)
+    name: test (hub ${{ matrix.idx }}/3)
+    strategy:
+      fail-fast: false
+      matrix:
+        idx: [1, 2, 3]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -98,11 +133,28 @@ jobs:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
 
-      - name: Test
+      - name: Test slice of pkg/hub
+        env:
+          IDX: ${{ matrix.idx }}
+          TOTAL: ${{ strategy.job-total }}
         run: |
           set -o pipefail
-          go test ./pkg/hub/... -short -race -count=1 -coverprofile=coverage-hub.out \
-            2>&1 | tee test-hub.log
+          go test ./pkg/hub -short -list '.*' | grep -E '^(Test|Example|Fuzz)' | LC_ALL=C sort > all-tests.txt
+          if [ ! -s all-tests.txt ]; then
+            echo "::error::go test -list produced no test functions for pkg/hub — refusing to run an empty slice (fail closed)"
+            exit 1
+          fi
+          awk -v n="$TOTAL" -v i="$IDX" 'NR % n == i - 1' all-tests.txt > slice.txt
+          echo "slice $IDX/$TOTAL: $(wc -l < slice.txt) of $(wc -l < all-tests.txt) test functions"
+          RUN="^($(paste -sd'|' slice.txt))$"
+          SHUFFLE=""
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then SHUFFLE="-shuffle=on"; fi
+          go test ./pkg/hub -short -race -count=1 -v $SHUFFLE -run "$RUN" -coverprofile=coverage-hub-"$IDX".out \
+            2>&1 | grep --line-buffered -vE '^=== (RUN|PAUSE|CONT) ' | tee test-hub-"$IDX".log
+
+      - name: Slowest tests in this slice
+        if: always()
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/slowest-tests.sh" "hub ${{ matrix.idx }}/3" test-hub-${{ matrix.idx }}.log
 
       # Uploaded even on failure so the coverage job (and humans) can inspect
       # the raw `go test` output. `warn` not `error`: on a compile failure the
@@ -112,10 +164,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-shard-hub
+          name: test-shard-hub-${{ matrix.idx }}
           path: |
-            src/coverage-hub.out
-            src/test-hub.log
+            src/coverage-hub-${{ matrix.idx }}.out
+            src/test-hub-${{ matrix.idx }}.log
           if-no-files-found: warn
           retention-days: 1
 
@@ -168,8 +220,14 @@ jobs:
           awk -v n="$TOTAL" -v i="$IDX" 'NR % n == i - 1' all-tests.txt > slice.txt
           echo "slice $IDX/$TOTAL: $(wc -l < slice.txt) of $(wc -l < all-tests.txt) test functions"
           RUN="^($(paste -sd'|' slice.txt))$"
-          go test ./pkg/agent -short -race -count=1 -run "$RUN" -coverprofile=coverage-agent-"$IDX".out \
-            2>&1 | tee test-agent-"$IDX".log
+          SHUFFLE=""
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then SHUFFLE="-shuffle=on"; fi
+          go test ./pkg/agent -short -race -count=1 -v $SHUFFLE -run "$RUN" -coverprofile=coverage-agent-"$IDX".out \
+            2>&1 | grep --line-buffered -vE '^=== (RUN|PAUSE|CONT) ' | tee test-agent-"$IDX".log
+
+      - name: Slowest tests in this slice
+        if: always()
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/slowest-tests.sh" "agent ${{ matrix.idx }}/5" test-agent-${{ matrix.idx }}.log
 
       - name: Upload shard coverage artifacts
         if: always()
@@ -207,11 +265,11 @@ jobs:
         id: partition
         run: |
           R=3
-          # Anchored: drops pkg/hub and its subpackages (the hub job runs
-          # ./pkg/hub/...) and exactly pkg/agent (the agent jobs run it).
-          # pkg/hubbackup et al. stay here.
+          # Anchored: drops exactly pkg/hub and exactly pkg/agent — the sliced
+          # jobs run those two bare package paths. A subpackage of either
+          # would land here, never nowhere. pkg/hubbackup et al. stay here.
           go list ./pkg/... ./cmd/... \
-            | grep -Ev '^github\.com/kubestellar/hive/pkg/hub(/|$)' \
+            | grep -Ev '^github\.com/kubestellar/hive/pkg/hub$' \
             | grep -Ev '^github\.com/kubestellar/hive/pkg/agent$' \
             | LC_ALL=C sort > rest-pkgs.txt
           if [ ! -s rest-pkgs.txt ]; then
@@ -291,8 +349,14 @@ jobs:
             exit 1
           fi
           # shellcheck disable=SC2086 # PKGS is a deliberate word-split list
-          go test $PKGS -short -race -count=1 -coverprofile=coverage-rest-${{ matrix.idx }}.out \
-            2>&1 | tee test-rest-${{ matrix.idx }}.log
+          SHUFFLE=""
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then SHUFFLE="-shuffle=on"; fi
+          go test $PKGS -short -race -count=1 -v $SHUFFLE -coverprofile=coverage-rest-${{ matrix.idx }}.out \
+            2>&1 | grep --line-buffered -vE '^=== (RUN|PAUSE|CONT) ' | tee test-rest-${{ matrix.idx }}.log
+
+      - name: Slowest tests in this bucket
+        if: always()
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/slowest-tests.sh" "rest ${{ matrix.idx }}/${{ matrix.total }}" test-rest-${{ matrix.idx }}.log
 
       - name: Upload shard coverage artifacts
         if: always()
@@ -369,7 +433,7 @@ jobs:
           # KEEP IN SYNC with coverage-hourly.yml, which applies the same floors
           # on its hourly scheduled run.
           declare -A PKG_THRESHOLD=(
-            [dashboard]=82   # ~17% is inception tmux watcher + copilot/claude device-flow + /data file I/O + k8s
+            [dashboard]=84   # 86.2% on 2026-09-01; the residue is the inception tmux watcher + copilot/claude device-flow + /data file I/O + k8s
             [hub]=87         # kubectl-shelling + live-GitHub paths; see #2355. Was 89 against v2's 89.9%; v4 measures 87.6%.
             [agent]=89       # pre-existing shortfall inherited from #2350, NOT a new regression. See #2355.
 
@@ -391,7 +455,7 @@ jobs:
             [tracing]=85
             [review]=80
             [retro]=82
-            [github]=88
+            [github]=89      # 91.8% on 2026-09-01
             [hivectl]=88
             [knowledge]=89
             [proxy]=89
@@ -404,10 +468,17 @@ jobs:
             # ("cmd/<name>") so cmd/hivectl can never collide with
             # pkg/hivectl's floor. Recorded just below what v4 measures after
             # #4700/#4719 so the ratchet can turn as CLI tests land.
-            [cmd/bd]=58       # 60.4% after #4700's kb-CLI tests
-            [cmd/hive]=17     # 18.8% after #4719's merge-authz tests; bulk is main()/run-loop wiring
+            # ── Ratchet turned 2026-09-01 ────────────────────────────────────
+            # cmd/bd, cmd/hive, cmd/hive-backup, dashboard, github: NO code
+            #   change — each had drifted 4–20 points above its recorded floor
+            #   (cmd/hive most of all: 18.8 → 37.5 as eval-cycle helpers grew
+            #   tests) and the gate was no longer catching a drop. Re-measured
+            #   on the 2026-09-01 hourly run and moved to ~2–4 points under
+            #   what they hold. cmd/apiproxy is unchanged at 13.9%.
+            [cmd/bd]=75       # 78.8% on 2026-09-01 (60.4% after #4700's kb-CLI tests)
+            [cmd/hive]=35     # 37.5% on 2026-09-01 (18.8% after #4719); bulk is main()/run-loop wiring
             [cmd/apiproxy]=13 # 14.7%
-            [cmd/hive-backup]=68 # 71.1% after #4736's CLI entry-point tests
+            [cmd/hive-backup]=78 # 81.9% on 2026-09-01 (71.1% after #4736's CLI entry-point tests)
           )
 
           # Thin flag-parsing mains with no test files, wrapping packages the

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,14 +81,19 @@ workflow that publishes the required `test` check — uses the same three flags:
 
 ```bash
 cd src
-go test ./pkg/hub/... -short -race -count=1     # test (hub)
-go test ./pkg/agent   -short -race -count=1 -run '<1/5 slice>'
-go test $PKGS         -short -race -count=1     # test (rest i/3)
+go test ./pkg/hub     -short -race -count=1 -run '<1/3 slice>'   # test (hub i/3)
+go test ./pkg/agent   -short -race -count=1 -run '<1/5 slice>'   # test (agent i/5)
+go test $PKGS         -short -race -count=1                      # test (rest i/3)
 ```
 
-The workflow shards for wall-clock only: `pkg/hub` and `pkg/agent` get dedicated
-jobs, and everything else from `go list ./pkg/... ./cmd/...` is partitioned into
-balanced buckets. The union of the shards is the whole of `./pkg/...` and
+The workflow shards for wall-clock only: `pkg/hub` and `pkg/agent` are each
+sliced across several jobs by test *function* (they are single packages too
+slow to run whole), and everything else from `go list ./pkg/... ./cmd/...` is
+partitioned into balanced buckets. Every shard also runs with `-v` and posts
+its slowest test functions to the job's step summary — look there before
+reaching for a local profile when the gate feels slow. Scheduled runs add
+`-shuffle=on` (the seed is in the log); the PR gate does not, so an
+order-dependent test shows up as a filed issue rather than as a red PR. The union of the shards is the whole of `./pkg/...` and
 `./cmd/...`, so what changes between your loop and the gate is the *flags*, not
 the coverage. To reproduce the gate locally in one unsharded run:
 


### PR DESCRIPTION
## Summary

Four changes to the PR test gate, all aimed at keeping CI fast while tests keep landing.

**1. `pkg/hub` is sliced across three jobs.** After #4118 sliced `pkg/agent`, the single unsliced `test (hub)` job became the gate's critical path: ~3.3 min wall clock (pkg/hub is one package of ~2,700 test functions, ~125 s serial under `-race`) against ~2.4 min for the widest rest bucket and ~2.0 min per agent slice. The hub job now uses the exact scheme the agent job already uses — deterministic round-robin over sorted `go test -list` output, anchored `-run` regex, fail-closed on an empty list. The coverage job already merges partial profiles by summing per-block counts, so the hub floor is scored on the union as before. Expected gate wall clock: ~3.3 min → ~2.4 min, and a new hub test now moves the gate by a third of its duration instead of all of it.

`list-packages` now excludes exactly `pkg/hub` rather than `pkg/hub(/|$)`, so a future subpackage of either sliced package lands in a rest bucket instead of running nowhere.

**2. Per-shard slowest-test table.** Every shard runs `go test -v` with the `=== RUN/PAUSE/CONT` lines stripped before `tee`, and a new `.github/scripts/slowest-tests.sh` ranks the slice's slowest top-level test functions into the step summary. Until now the shard logs carried only the package total, so "what is the gate actually waiting on?" needed a local reproduction. The reporter never fails a job; the script is added to the workflow's `paths:` filter for the same reason dashboard-lint lists its checker (#5388).

**3. `-shuffle=on` on scheduled and manual runs only.** Order-dependent tests (#5102's golden splash race, the package-var seams in #4795) pass in a fixed order and only fail when the order moves. Shuffling the hourly post-merge net finds them and files the issue with the seed in the log, while the PR gate stays deterministic so a contributor is never failed by an ordering their change did not cause.

**4. Coverage ratchet turned.** Five floors had drifted far above their recorded values and were no longer catching a drop — most of all `cmd/hive`, recorded at 17 when it measures 37.5. Re-measured on the 2026-09-01 hourly run and set 2–4 points under: `cmd/hive` 17→35, `cmd/bd` 58→75, `cmd/hive-backup` 68→78, `dashboard` 82→84, `github` 88→89. Applied to both `v2-tests.yml` and `coverage-hourly.yml`, which the files say to keep in sync. No code change.

`docs/development.md` updated to match the new shard shape and to point contributors at the slowest-tests table.

## Verification

- Both workflow files parse as YAML.
- `slowest-tests.sh` exercised against a synthetic `-v` log (ranks top-level PASS/FAIL/SKIP lines, ignores indented subtests) and against an empty log (reports, exits 0).
- The `paths:` contract test (`pkg/github/ci_trigger_contract_test.go`) only checks that listed paths trigger; adding one cannot break it.
- This PR's own run is the live check: three `test (hub i/3)` jobs must each report a non-empty slice and the merged hub coverage must still clear its floor.

Test-only / CI-only change; no CHANGELOG entry per the file's own policy.