### PR TITLE
🐛 get-started: replace nonexistent npx package with the real contributor-relay setup

### DIFF
--- a/src/pkg/hub/static/get-started.html
+++ b/src/pkg/hub/static/get-started.html
@@ -499,9 +499,9 @@ open http://localhost:3001</code></pre>
 cd hive
 
 export HIVE_HUB=wss://HIVE_HOST/contribute
-just contribute-setup claude   # one-time: register + verify your CLI
-just contribute-hive           # start taking tasks</code></pre>
-      <p>Every hive also serves a landing page at <code>https://&lt;hive-dashboard&gt;/contribute</code> with live queue stats and copy-paste setup commands tailored to the CLI you pick.</p>
+just contribute-setup &lt;backend&gt;   # one-time: register + verify your CLI
+just contribute-hive              # start taking tasks</code></pre>
+      <p>Pick the CLI you already have: <code>claude</code>, <code>copilot</code>, <code>goose</code>, <code>bob</code>, <code>codex</code>, <code>pi</code>, <code>aider</code>, <code>litellm</code>, <code>agy</code>, <code>opencode</code>, or <code>kilo</code>. Every hive also serves a landing page at <code>https://&lt;hive-dashboard&gt;/contribute</code> with live queue stats and copy-paste setup commands tailored to the CLI you pick.</p>
       <p style="margin-bottom:0">Your CLI runs agents locally. Tasks are assigned by the hive governor. You start as a <strong>newcomer</strong> and progress through contributor → trusted → advisor as you complete work.</p>
     </div>
   </section>

--- a/src/pkg/hub/static/get-started.html
+++ b/src/pkg/hub/static/get-started.html
@@ -495,9 +495,13 @@ open http://localhost:3001</code></pre>
       <p>Lend your AI CLI to run agents for any public hive. Earn trust tiers and climb the <a href="/#leaderboard" style="color:var(--blue)">leaderboard</a>.</p>
     </div>
     <div class="alt-card">
-      <pre><code>npx @kubestellar/hive-contribute
+      <pre><code>git clone https://github.com/kubestellar/hive.git
+cd hive
 
-hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
+export HIVE_HUB=wss://HIVE_HOST/contribute
+just contribute-setup claude   # one-time: register + verify your CLI
+just contribute-hive           # start taking tasks</code></pre>
+      <p>Every hive also serves a landing page at <code>https://&lt;hive-dashboard&gt;/contribute</code> with live queue stats and copy-paste setup commands tailored to the CLI you pick.</p>
       <p style="margin-bottom:0">Your CLI runs agents locally. Tasks are assigned by the hive governor. You start as a <strong>newcomer</strong> and progress through contributor → trusted → advisor as you complete work.</p>
     </div>
   </section>


### PR DESCRIPTION
A user hit this today:

```
npx @kubestellar/hive-contribute
npm error 404 Not Found - GET https://registry.npmjs.org/@kubestellar%2Fhive-contribute
```

The hub's /get-started Contribute card advertises `npx @kubestellar/hive-contribute`, but that package was never published — the command fails with E404 for every visitor who tries it.

Replace it with the real ClankeR contributor-relay flow (docs/contributor-relay.md): clone the repo, `just contribute-setup <backend>`, `just contribute-hive`, and mention the per-hive `/contribute` landing page that serves live queue stats and copy-paste commands tailored to the chosen CLI.

Validation: `go build ./pkg/hub/` + related hub tests pass; no test pins the old snippet.