### PR TITLE
refactor(hub): extract SHA poller tick body for direct testing

### DIFF
--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -5953,68 +5953,78 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 			return
 		case <-ticker.C:
 		}
-		oldSHAs := getLatestSHAs()
-		oldInfos := snapshotBranchSHAs()
-		// Re-resolve each tick so branches from newly registered hives are
-		// picked up without a hub restart.
-		fetchAllBranchSHAs(s.logger, s.trackedBranchList())
-		newSHAs := getLatestSHAs()
-		if !maps.Equal(snapshotBranchSHAs(), oldInfos) {
-			persistLatestSHAs(s.logger)
+		s.pollLatestSHAsTick(ctx, time.Now())
+	}
+}
+
+// pollLatestSHAsTick is the body of StartLatestSHAPoller's ticker loop,
+// extracted so it can be invoked directly by tests without waiting on the
+// live ticker: re-fetches every tracked branch SHA, persists on change, drives
+// the throttled reconciliation lanes, and runs the hub auto-upgrade check.
+// now is injected so tests control the clock the same way
+// maybeSnapshotImagePulls already does.
+func (s *HubServer) pollLatestSHAsTick(ctx context.Context, now time.Time) {
+	oldSHAs := getLatestSHAs()
+	oldInfos := snapshotBranchSHAs()
+	// Re-resolve each tick so branches from newly registered hives are
+	// picked up without a hub restart.
+	fetchAllBranchSHAs(s.logger, s.trackedBranchList())
+	newSHAs := getLatestSHAs()
+	if !maps.Equal(snapshotBranchSHAs(), oldInfos) {
+		persistLatestSHAs(s.logger)
+	}
+	// Always check for pending auto-upgrades (retries failed/missed hives).
+	s.triggerAutoUpgrades()
+	s.sweepOrphanedUpgradesIfDue()
+	s.sweepStuckAssignmentsIfDue()
+	s.reconcileNetAdminIfDue()
+	s.reconcilePerHiveEnvIfDue()
+	s.reapOrphanedPodsIfDue()
+	s.retireExpiredGenerationsIfDue()
+	s.sweepExpiredAccessIfDue()
+	s.replenishPoolsIfDue()
+	s.maybeSnapshotImagePulls(ctx, now)
+	changed := false
+	for branch, sha := range newSHAs {
+		if sha != "" && sha != oldSHAs[branch] {
+			changed = true
+			break
 		}
-		// Always check for pending auto-upgrades (retries failed/missed hives).
-		s.triggerAutoUpgrades()
-		s.sweepOrphanedUpgradesIfDue()
-		s.sweepStuckAssignmentsIfDue()
-		s.reconcileNetAdminIfDue()
-		s.reconcilePerHiveEnvIfDue()
-		s.reapOrphanedPodsIfDue()
-		s.retireExpiredGenerationsIfDue()
-		s.sweepExpiredAccessIfDue()
-		s.replenishPoolsIfDue()
-		s.maybeSnapshotImagePulls(ctx, time.Now())
-		changed := false
-		for branch, sha := range newSHAs {
-			if sha != "" && sha != oldSHAs[branch] {
-				changed = true
-				break
-			}
+	}
+	_ = changed
+	// Hub auto-upgrade — checked EVERY cycle, not only when the SHA just
+	// changed. Previously this lived inside `if changed {}`, so if the hub
+	// missed the one poll where v2's SHA flipped (busy, mid-restart, or the
+	// SHA moved between polls), it stayed "queued" forever and never retried,
+	// while spokes retry every cycle via triggerAutoUpgrades() above. Mirror
+	// that: whenever auto-upgrade is on and the hub is behind latest v2, trigger
+	// a rollout restart. A debounce prevents re-restarting every 2min while a
+	// restart is already rolling out (the new pod reports the new hash, which
+	// clears the condition, but the poll can fire before the rollout lands).
+	// Use the hub's OWN branch, not a hardcoded "v2": hubUpgradeState() and
+	// handleHubSelfUpgrade() both read s.hubGitBranch, so hardcoding here
+	// made the badge and the poller disagree the moment a hub ran on v3.
+	hubBranchSHA := getLatestHubSHAForBranch(s.hubGitBranch)
+	s.hubUpgradeMu.Lock()
+	debounced := time.Since(s.lastHubUpgradeTrigger) > hubUpgradeDebounce
+	s.hubUpgradeMu.Unlock()
+	// Admin kill switch: while hub upgrades are paused the hub stays on its
+	// current build regardless of new tags — the auto-trigger below never
+	// fires. Checked every cycle (like the trigger itself), so flipping the
+	// switch takes effect on the next poll without a restart.
+	if hubPauseSw, hubPaused := s.hubUpgradesPaused(); hubPaused {
+		if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) {
+			s.logger.Debug("hub auto-upgrade suppressed — hub upgrades are paused",
+				"behind", hubBranchSHA, "paused_by", hubPauseSw.By, "paused_at", hubPauseSw.At)
 		}
-		_ = changed
-		// Hub auto-upgrade — checked EVERY cycle, not only when the SHA just
-		// changed. Previously this lived inside `if changed {}`, so if the hub
-		// missed the one poll where v2's SHA flipped (busy, mid-restart, or the
-		// SHA moved between polls), it stayed "queued" forever and never retried,
-		// while spokes retry every cycle via triggerAutoUpgrades() above. Mirror
-		// that: whenever auto-upgrade is on and the hub is behind latest v2, trigger
-		// a rollout restart. A debounce prevents re-restarting every 2min while a
-		// restart is already rolling out (the new pod reports the new hash, which
-		// clears the condition, but the poll can fire before the rollout lands).
-		// Use the hub's OWN branch, not a hardcoded "v2": hubUpgradeState() and
-		// handleHubSelfUpgrade() both read s.hubGitBranch, so hardcoding here
-		// made the badge and the poller disagree the moment a hub ran on v3.
-		hubBranchSHA := getLatestHubSHAForBranch(s.hubGitBranch)
-		s.hubUpgradeMu.Lock()
-		debounced := time.Since(s.lastHubUpgradeTrigger) > hubUpgradeDebounce
-		s.hubUpgradeMu.Unlock()
-		// Admin kill switch: while hub upgrades are paused the hub stays on its
-		// current build regardless of new tags — the auto-trigger below never
-		// fires. Checked every cycle (like the trigger itself), so flipping the
-		// switch takes effect on the next poll without a restart.
-		if hubPauseSw, hubPaused := s.hubUpgradesPaused(); hubPaused {
-			if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) {
-				s.logger.Debug("hub auto-upgrade suppressed — hub upgrades are paused",
-					"behind", hubBranchSHA, "paused_by", hubPauseSw.By, "paused_at", hubPauseSw.At)
-			}
-		} else if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) && debounced {
-			s.logger.Info("audit: hub auto-upgrade triggered", "from", s.hubGitHash, "to", hubBranchSHA)
-			// rolloutHubToSHA verifies the hub image exists (skips a doomed roll
-			// when the hive-hub build for this SHA failed) and pins the SHA so a
-			// stale cached v2-latest can't come back up. It records the in-flight
-			// state on success so the dashboard shows "Upgrading", not "queued".
-			if err := s.rolloutHubToSHA(hubBranchSHA); err != nil {
-				s.logger.Warn("hub auto-upgrade skipped", "to", hubBranchSHA, "reason", err)
-			}
+	} else if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) && debounced {
+		s.logger.Info("audit: hub auto-upgrade triggered", "from", s.hubGitHash, "to", hubBranchSHA)
+		// rolloutHubToSHA verifies the hub image exists (skips a doomed roll
+		// when the hive-hub build for this SHA failed) and pins the SHA so a
+		// stale cached v2-latest can't come back up. It records the in-flight
+		// state on success so the dashboard shows "Upgrading", not "queued".
+		if err := s.rolloutHubToSHA(hubBranchSHA); err != nil {
+			s.logger.Warn("hub auto-upgrade skipped", "to", hubBranchSHA, "reason", err)
 		}
 	}
 }

--- a/src/pkg/hub/sha_poller_tick_test.go
+++ b/src/pkg/hub/sha_poller_tick_test.go
@@ -1,0 +1,219 @@
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ============================================================
+// saas.go — pollLatestSHAsTick (the StartLatestSHAPoller ticker-loop body)
+//
+// StartLatestSHAPoller's loop blocks on a 2-minute ticker, so
+// TestStartLatestSHAPollerPreLoop (sha_poller_coverage_test.go) never runs the
+// tick body. pollLatestSHAsTick is the extracted body, callable directly here
+// against the same fake GitHub/GHCR fixture, with no ticker and no sleeps.
+// ============================================================
+
+// newTickTestServer builds a minimal HubServer suitable for pollLatestSHAsTick:
+// a registered hive (so trackedBranchList() has something to fetch) and a hub
+// git identity distinct from the fake's advertised SHA (so the hub
+// auto-upgrade block below has a real behind/ahead decision to make).
+func newTickTestServer() *HubServer {
+	s := &HubServer{
+		logger:     slog.Default(),
+		saveCh:     make(chan struct{}, 1),
+		hubGitHash: "oldhubsha",
+	}
+	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
+	return s
+}
+
+// (a) a changed SHA is persisted; an unchanged SHA is not re-persisted.
+func TestPollLatestSHAsTick_PersistsOnlyOnChange(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetSHACaches(t)
+
+	dir := t.TempDir()
+	oldPath := latestSHAsPath
+	latestSHAsPath = dir + "/latest-shas.json"
+	defer func() { latestSHAsPath = oldPath }()
+
+	sha := "abcdef1234567890"
+	fakeGitHubGHCR(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusOK) // image on GHCR
+		case strings.Contains(r.URL.Path, "/token"):
+			w.Write([]byte(`{"token":"anon"}`))
+		case strings.Contains(r.URL.Path, "/branches/"):
+			w.Write([]byte(`{"commit":{"sha":"` + sha + `","commit":{"message":"m"}}}`))
+		default:
+			w.Write([]byte(`{}`))
+		}
+	})
+
+	s := newTickTestServer()
+	ctx := context.Background()
+
+	// First tick: v2 has no cached SHA yet, so this fetch is a change and must
+	// persist.
+	s.pollLatestSHAsTick(ctx, time.Now())
+	data, err := os.ReadFile(latestSHAsPath)
+	if err != nil {
+		t.Fatalf("expected persisted file after first tick (changed SHA), got error: %v", err)
+	}
+	firstWrite := string(data)
+	if !strings.Contains(firstWrite, shortSHA(sha)) {
+		t.Fatalf("persisted file missing new SHA: %s", firstWrite)
+	}
+
+	// Remove the file and tick again with the SAME fake (unchanged upstream
+	// SHA). Positive control: persistLatestSHAs must NOT run this time, so the
+	// file must NOT reappear.
+	if err := os.Remove(latestSHAsPath); err != nil {
+		t.Fatalf("remove persisted file: %v", err)
+	}
+	s.pollLatestSHAsTick(ctx, time.Now())
+	if _, err := os.Stat(latestSHAsPath); err == nil {
+		t.Fatalf("persisted file reappeared after an unchanged-SHA tick — should not have been re-persisted")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error checking persisted file: %v", err)
+	}
+}
+
+// (b) the throttled reconciliation lanes are invoked each tick. Every *IfDue
+// lane records its own s.last<Lane> timestamp (guarded by
+// s.clusterUnreachableMu) before doing its throttled work, and each starts at
+// its zero value on a fresh HubServer — so a single tick against a due (zero)
+// timestamp is the lane's own observable proof it ran. No new test-only hook
+// is needed for these.
+func TestPollLatestSHAsTick_InvokesThrottledLanes(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetSHACaches(t)
+
+	dir := t.TempDir()
+	oldPath := latestSHAsPath
+	latestSHAsPath = dir + "/latest-shas.json"
+	defer func() { latestSHAsPath = oldPath }()
+
+	fakeGitHubGHCR(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/token"):
+			w.Write([]byte(`{"token":"anon"}`))
+		case strings.Contains(r.URL.Path, "/branches/"):
+			w.Write([]byte(`{"commit":{"sha":"abcdef1234567890","commit":{"message":"m"}}}`))
+		default:
+			w.Write([]byte(`{}`))
+		}
+	})
+
+	s := newTickTestServer()
+
+	before := time.Now()
+	s.pollLatestSHAsTick(context.Background(), before)
+
+	s.clusterUnreachableMu.Lock()
+	lastTimestamps := map[string]time.Time{
+		"sweepOrphanedUpgradesIfDue (lastOrphanedUpgradeSweep)": s.lastOrphanedUpgradeSweep,
+		"sweepStuckAssignmentsIfDue (lastStuckAssignmentSweep)": s.lastStuckAssignmentSweep,
+		"reconcileNetAdminIfDue (lastNetAdminReconcile)":        s.lastNetAdminReconcile,
+		"reconcilePerHiveEnvIfDue (lastPerHiveEnvReconcile)":    s.lastPerHiveEnvReconcile,
+		"reapOrphanedPodsIfDue (lastOrphanedPodReap)":           s.lastOrphanedPodReap,
+		"retireExpiredGenerationsIfDue (lastGenerationRetire)":  s.lastGenerationRetire,
+		"sweepExpiredAccessIfDue (lastAccessExpirySweep)":       s.lastAccessExpirySweep,
+		"replenishPoolsIfDue (lastPoolReplenish)":               s.lastPoolReplenish,
+	}
+	s.clusterUnreachableMu.Unlock()
+
+	for lane, ts := range lastTimestamps {
+		if ts.IsZero() {
+			t.Errorf("%s: throttle timestamp still zero after a tick — lane was not invoked", lane)
+			continue
+		}
+		if ts.Before(before) {
+			t.Errorf("%s: throttle timestamp %v predates the tick (%v) — stale value, lane was not invoked this tick", lane, ts, before)
+		}
+	}
+}
+
+// (c) the hub auto-upgrade check runs every tick, not only when the SHA just
+// changed — the regression the code comment documents. We drive this with
+// TWO ticks against an UNCHANGED upstream SHA (so `changed` is false on both,
+// proving the check is not gated on it) and assert the auto-upgrade decision
+// is (re)made on the second tick too, not just the first.
+//
+// hubImageExists is stubbed (existing package-level test seam, also used by
+// saas_edge_coverage_test.go and hub_upgrade_state_test.go) so the assertion
+// exercises the decision logic without shelling out to kubectl. Counting its
+// calls is the observable: rolloutHubToSHA only calls it once the hub
+// auto-upgrade branch has decided hubBranchSHA is set, not the current hash,
+// and not debounced — i.e. once the every-tick check actually ran and found
+// work to do.
+func TestPollLatestSHAsTick_HubAutoUpgradeCheckedEveryTick(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	resetSHACaches(t)
+
+	dir := t.TempDir()
+	oldPath := latestSHAsPath
+	latestSHAsPath = dir + "/latest-shas.json"
+	defer func() { latestSHAsPath = oldPath }()
+
+	// Upstream v2 never moves across the two ticks below — this is the
+	// "SHA did not just change" condition the regression comment describes.
+	fakeGitHubGHCR(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/token"):
+			w.Write([]byte(`{"token":"anon"}`))
+		case strings.Contains(r.URL.Path, "/branches/"):
+			w.Write([]byte(`{"commit":{"sha":"newhubsha00000","commit":{"message":"m"}}}`))
+		default:
+			w.Write([]byte(`{}`))
+		}
+	})
+
+	setAutoUpgrade(t, true)
+
+	imageCheckCalls := 0
+	oldImgCheck := hubImageExists
+	hubImageExists = func(sha string, _ *slog.Logger) bool {
+		imageCheckCalls++
+		return false // decline the rollout itself; only the DECISION is under test
+	}
+	t.Cleanup(func() { hubImageExists = oldImgCheck })
+
+	s := newTickTestServer()
+	s.hubGitBranch = "v2"
+	s.hubGitHash = "oldhubsha" // behind the fake's advertised hub SHA the whole time
+
+	// First tick: resolves and caches the hub SHA, and the hub is behind it —
+	// the auto-upgrade branch reaches rolloutHubToSHA, which calls
+	// hubImageExists as its first real step.
+	s.pollLatestSHAsTick(context.Background(), time.Now())
+	if imageCheckCalls == 0 {
+		t.Fatalf("hub auto-upgrade check did not run on tick 1 (hub behind, auto-upgrade on)")
+	}
+	firstTickCalls := imageCheckCalls
+
+	// Second tick: the upstream SHA is UNCHANGED from tick 1 (branch API keeps
+	// returning the same commit, so fetchAllBranchSHAs finds nothing new and
+	// `changed` is false). Before the fix this block lived inside `if changed`,
+	// so it would be skipped here. It must still run.
+	s.pollLatestSHAsTick(context.Background(), time.Now())
+	if imageCheckCalls <= firstTickCalls {
+		t.Fatalf("hub auto-upgrade check did not run on tick 2 (SHA unchanged from tick 1) — "+
+			"regression: the check must run every tick, not only when the SHA just changed; "+
+			"calls after tick1=%d, after tick2=%d", firstTickCalls, imageCheckCalls)
+	}
+}

--- a/src/pkg/hub/sha_poller_tick_test.go
+++ b/src/pkg/hub/sha_poller_tick_test.go
@@ -177,7 +177,7 @@ func TestPollLatestSHAsTick_HubAutoUpgradeCheckedEveryTick(t *testing.T) {
 		case strings.Contains(r.URL.Path, "/token"):
 			w.Write([]byte(`{"token":"anon"}`))
 		case strings.Contains(r.URL.Path, "/branches/"):
-			w.Write([]byte(`{"commit":{"sha":"newhubsha00000","commit":{"message":"m"}}}`))
+			w.Write([]byte(`{"commit":{"sha":"0123456789abcdef0123456789abcdef01234567","commit":{"message":"m"}}}`))
 		default:
 			w.Write([]byte(`{}`))
 		}


### PR DESCRIPTION
## What

`StartLatestSHAPoller`'s ticker-loop body was only reachable by waiting on a live 2-minute ticker, so the existing coverage test (`TestStartLatestSHAPollerPreLoop`) exercises only the synchronous pre-loop pass and never the tick itself — the ten `*IfDue` reconciliation lanes and the hub auto-upgrade check inside the loop have had zero test coverage across 15 fix commits.

Extracts the loop body into:

```go
func (s *HubServer) pollLatestSHAsTick(ctx context.Context, now time.Time)
```

The loop now just calls it each tick. Behavior-preserving — the tick body itself is unchanged, only lifted into its own method, with `now` injected the same way `maybeSnapshotImagePulls` already takes it.

## Tests

Added `sha_poller_tick_test.go`, calling `pollLatestSHAsTick` directly (no ticker, no sleeps) against the same fake GitHub/GHCR fixture and helpers the existing pre-loop test uses (`fakeGitHubGHCR`, `helperSetupTempDirs`, `resetSHACaches`):

- **`TestPollLatestSHAsTick_PersistsOnlyOnChange`** — positive control both ways: a first tick with no cached SHA persists `persistLatestSHAs`'s output to disk; a second tick against the same (unchanged) upstream SHA does not re-persist it (file removed between ticks, asserted absent after).
- **`TestPollLatestSHAsTick_InvokesThrottledLanes`** — asserts all eight throttle-timestamp fields (`lastOrphanedUpgradeSweep`, `lastStuckAssignmentSweep`, `lastNetAdminReconcile`, `lastPerHiveEnvReconcile`, `lastOrphanedPodReap`, `lastGenerationRetire`, `lastAccessExpirySweep`, `lastPoolReplenish`) move from zero to a post-tick timestamp on a single call. Each `*IfDue` lane already records its own throttle timestamp before doing its throttled work, and each starts zero-valued (due) on a fresh `HubServer`, so this is an existing observable — no new test hook needed for these.
- **`TestPollLatestSHAsTick_HubAutoUpgradeCheckedEveryTick`** — targets the regression the inline code comment documents: the hub auto-upgrade check used to live inside `if changed {}` and could stay "queued" forever if the hub missed the one poll where the SHA flipped. Drives two ticks against an *unchanged* upstream SHA (so `changed` is false both times) and asserts the auto-upgrade decision path is reached on tick 2 as well as tick 1. Observed by stubbing the existing `hubImageExists` package-level test seam (already used by `saas_edge_coverage_test.go` and `hub_upgrade_state_test.go`) and counting calls — `rolloutHubToSHA` only reaches it once the every-tick check has decided the hub is behind, undebounced, and auto-upgrade is on, so a call on both ticks is direct proof the check isn't gated on `changed`.

`triggerAutoUpgrades()` itself has no standalone throttle timestamp (it does real per-hive work directly, gated only by the spoke-pause switch), so its per-tick invocation isn't separately asserted beyond running without error each tick; everything else asked for is directly observable via existing fields, so no new hook var was needed anywhere in this PR.

The pre-loop test (`TestStartLatestSHAPollerPreLoop`) is untouched. All three new tests run in well under a second (no sleeps, no ticker — `pollLatestSHAsTick` is called directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)