### PR TITLE
🧪 test(governor): extract six testable seams from runEvalCycle

### DIFF
--- a/src/cmd/hive/eval_cycle_seams.go
+++ b/src/cmd/hive/eval_cycle_seams.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/scheduler"
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+// Decision points of runEvalCycle, extracted verbatim so they are testable.
+// runEvalCycle calls each in the same place and order as before; side effects
+// that are not part of the decision (SendKick, dashboard state, the probe
+// stamp) stay at the call site in main.go.
+
+// workSourceIssuesForCycle is the non-GitHub work-source overlay (#4187,
+// #4731, #4975). Only the Issues half is replaced; PRs always come from
+// GitHub. Both error paths FAIL CLOSED (empty issues, PR maintenance intact)
+// so the hive never dispatches against a stale list or the GitHub issues it
+// was configured to ignore. The success path applies the same exempt-label
+// and issue-filter gates as GitHub enumeration (#4731). wsErr is the
+// worksource.FromConfig error; when non-nil, ws is not consulted.
+func workSourceIssuesForCycle(
+	ctx context.Context,
+	ws worksource.WorkSource,
+	wsErr error,
+	exempt []string,
+	filter config.IssueFilterConfig,
+	logger *slog.Logger,
+) github.IssueResult {
+	if wsErr != nil {
+		logger.Error("work_source config error; failing closed for issues while preserving GitHub PR maintenance", "error", wsErr)
+		return github.IssueResultFromItems([]github.Issue{})
+	}
+	wsIssues, listErr := ws.ListIssues(ctx)
+	if listErr != nil {
+		logger.Error("work_source enumeration failed; failing closed for issues while preserving GitHub PR maintenance", "source", ws.SourceType(), "error", listErr)
+		return github.IssueResultFromItems([]github.Issue{})
+	}
+	items := github.FilterExemptIssues(worksource.ToGitHubIssues(wsIssues), exempt)
+	filtered := items[:0]
+	for _, issue := range items {
+		if filter.Admits(issue.Labels) {
+			filtered = append(filtered, issue)
+		}
+	}
+	return github.IssueResultFromItems(filtered)
+}
+
+// mergeResumeKicks appends crash-restarted agents to the due list ONLY through
+// the governor's gate (#2573, #2627): unconditional resume kicks let a
+// crash-looping CLI burn tokens on every eval cycle, past any cadence or
+// budget. allow is Governor.AllowResumeKick. An agent already due keeps its
+// single slot; order is governor-due first, then admitted restarts.
+func mergeResumeKicks(agentsDue, restartedAgents []string, allow func(string) bool, logger *slog.Logger) []string {
+	if len(restartedAgents) == 0 {
+		return agentsDue
+	}
+	dueSet := make(map[string]bool, len(agentsDue))
+	for _, a := range agentsDue {
+		dueSet[a] = true
+	}
+	for _, a := range restartedAgents {
+		if dueSet[a] {
+			continue
+		}
+		if !allow(a) {
+			logger.Info("restarted agent NOT resume-kicked (cadence/budget gate); it will be kicked at its next scheduled slot", "agent", a)
+			continue
+		}
+		agentsDue = append(agentsDue, a)
+		logger.Info("adding restarted agent to kick list", "agent", a)
+	}
+	return agentsDue
+}
+
+// filterKickableAgents drops agents the governor must never kick on cadence:
+// on-demand agents flagged in config OR in any ACMM pack level (#808, #815 —
+// the pack scan is level-independent because the level may not be settled
+// when the loop first runs), and operator-paused agents, which must consume
+// nothing (#2573) — filtering here keeps them out of BuildKickMessages and the
+// audit log instead of producing a spurious SendKick error every cycle.
+// A nil result for "nothing due" is the historical contract.
+func filterKickableAgents(
+	agentsDue []string,
+	agents map[string]config.AgentConfig,
+	onDemandSet map[string]bool,
+	isPaused func(string) bool,
+) []string {
+	var filteredDue []string
+	for _, name := range agentsDue {
+		if ac, ok := agents[name]; ok && ac.OnDemand {
+			continue
+		}
+		if onDemandSet[name] {
+			continue
+		}
+		if isPaused(name) {
+			continue
+		}
+		filteredDue = append(filteredDue, name)
+	}
+	return filteredDue
+}
+
+// providerBudgetKickGate is the outcome of gateKickMessagesForProviderBudget.
+type providerBudgetKickGate struct {
+	Kept     []scheduler.KickMessage // kicks that go out this cycle
+	Withheld []string                // agents whose kicks were dropped, in message order
+	// ReleaseProbe: exactly one kick was let through to probe the provider
+	// window; the caller must re-arm suppression (providerBudgetProbe.markReleased).
+	ReleaseProbe bool
+}
+
+// gateKickMessagesForProviderBudget applies the PROVIDER SPEND REBUFF (#4294)
+// to the fully assembled kick list (governor-due + CEL union + review swarm).
+// Fresh latch (suppress): drop EVERY kick — the limit is on the key, no agent
+// can succeed. Stale latch (latched, !suppress): release exactly ONE probe;
+// its inference call is the only thing that can clear or re-freshen the
+// latch. Not latched: pass through. An empty list never releases a probe, so
+// the probe stamp cannot advance without a real kick going out.
+func gateKickMessagesForProviderBudget(messages []scheduler.KickMessage, suppress, latched bool) providerBudgetKickGate {
+	if suppress && len(messages) > 0 {
+		withheld := make([]string, 0, len(messages))
+		for _, msg := range messages {
+			withheld = append(withheld, msg.Agent)
+		}
+		return providerBudgetKickGate{Kept: nil, Withheld: withheld}
+	}
+	if latched && len(messages) > 0 {
+		gate := providerBudgetKickGate{Kept: messages, ReleaseProbe: true}
+		if len(messages) > 1 {
+			dropped := make([]string, 0, len(messages)-1)
+			for _, msg := range messages[1:] {
+				dropped = append(dropped, msg.Agent)
+			}
+			gate.Withheld = dropped
+			gate.Kept = messages[:1]
+		}
+		return gate
+	}
+	return providerBudgetKickGate{Kept: messages}
+}
+
+// doubleSLAMinutes is the age past which an issue is a "2x SLA breach".
+const doubleSLAMinutes = 60
+
+// maxSLANotificationsPerCycle caps pages per eval cycle (915bb96a: ten overdue
+// issues on a 5-minute eval was 120 pages an hour). Per CYCLE, not deduped —
+// the same issues page again next cycle until someone acts.
+const maxSLANotificationsPerCycle = 3
+
+// selectSLABreachNotifications returns the first maxSLANotificationsPerCycle
+// issues older than doubleSLAMinutes, in enumeration order; capped reports
+// that a further qualifying issue was skipped.
+func selectSLABreachNotifications(items []github.Issue) (selected []github.Issue, capped bool) {
+	for _, issue := range items {
+		if issue.AgeMinutes > doubleSLAMinutes {
+			if len(selected) >= maxSLANotificationsPerCycle {
+				return selected, true
+			}
+			selected = append(selected, issue)
+		}
+	}
+	return selected, false
+}
+
+// advisoryPostFailure classifies a failed App-authenticated digest post. The
+// ORDER is the invariant: (1) a 403 "Resource not accessible by integration"
+// is write-forbidden — App installed, write refused, attribute honestly via
+// classifyGitHubAppWriteForbidden (#2353); (2) any rate-limit text is skipped
+// and never touches the banner — a rate-limited 403 is not "App not
+// installed" (#1699); (3) everything else (401, 404, 5xx, network) goes to
+// classifyGitHubAppFailure, the same verdict as boot and Re-check (106a95fc,
+// #2301).
+type advisoryPostFailure int
+
+const (
+	advisoryPostWriteForbidden advisoryPostFailure = iota
+	advisoryPostRateLimited
+	advisoryPostAuthProbe
+)
+
+// githubWriteForbiddenText is GitHub's body when an installation token holds
+// the permission but the repo is not in the installation's selected repos.
+const githubWriteForbiddenText = "Resource not accessible by integration"
+
+func classifyAdvisoryPostError(err error) advisoryPostFailure {
+	if err == nil {
+		return advisoryPostAuthProbe
+	}
+	text := err.Error()
+	if strings.Contains(text, "403") && strings.Contains(text, githubWriteForbiddenText) {
+		return advisoryPostWriteForbidden
+	}
+	if isGitHubRateLimitText(err) {
+		return advisoryPostRateLimited
+	}
+	return advisoryPostAuthProbe
+}

--- a/src/cmd/hive/eval_cycle_seams_test.go
+++ b/src/cmd/hive/eval_cycle_seams_test.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/github"
+	"github.com/kubestellar/hive/pkg/scheduler"
+	"github.com/kubestellar/hive/pkg/worksource"
+)
+
+type fakeWorkSource struct {
+	issues []worksource.Issue
+	err    error
+	calls  int
+}
+
+func (f *fakeWorkSource) SourceType() string { return "fake" }
+func (f *fakeWorkSource) ListIssues(context.Context) ([]worksource.Issue, error) {
+	f.calls++
+	return f.issues, f.err
+}
+
+// TestWorkSourceIssuesForCycle guards the non-GitHub overlay (#4187, #4731,
+// #4975): both failure modes fail CLOSED for issues, and the success path
+// applies the GitHub exempt/require-label gates and SLA summary.
+func TestWorkSourceIssuesForCycle(t *testing.T) {
+	old := time.Now().Add(-3 * time.Hour) // past the SLA threshold
+	cases := []struct {
+		name       string
+		ws         *fakeWorkSource
+		wsErr      error
+		exempt     []string
+		filter     config.IssueFilterConfig
+		wantTitles []string
+		wantSLA    int
+		wantCalls  int
+	}{
+		{ // positive control
+			name:       "success projects every item",
+			ws:         &fakeWorkSource{issues: []worksource.Issue{{Title: "a", CreatedAt: old}, {Title: "b"}}},
+			wantTitles: []string{"a", "b"}, wantSLA: 1, wantCalls: 1,
+		},
+		{ // #4731: Linear items held to the same exempt policy as GitHub
+			name:       "exempt labels drop items",
+			ws:         &fakeWorkSource{issues: []worksource.Issue{{Title: "keep"}, {Title: "hold", Labels: []string{"hold"}}}},
+			exempt:     []string{"hold"},
+			wantTitles: []string{"keep"}, wantCalls: 1,
+		},
+		{ // #4731: require_labels applies to the overlay too
+			name:       "issue filter admits only required labels",
+			ws:         &fakeWorkSource{issues: []worksource.Issue{{Title: "yes", Labels: []string{"hive"}}, {Title: "no"}}},
+			filter:     config.IssueFilterConfig{RequireLabels: []string{"hive"}},
+			wantTitles: []string{"yes"}, wantCalls: 1,
+		},
+		{ // constructor failure: fail closed, never consult the source
+			name:       "config error fails closed and skips ListIssues",
+			ws:         &fakeWorkSource{issues: []worksource.Issue{{Title: "stale"}}},
+			wsErr:      errors.New("bad work_source"),
+			wantTitles: []string{}, wantCalls: 0,
+		},
+		{ // #4975: enumeration failure empties issues, never a stale list
+			name:       "list error fails closed",
+			ws:         &fakeWorkSource{err: errors.New("linear 502")},
+			wantTitles: []string{}, wantCalls: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workSourceIssuesForCycle(context.Background(), tc.ws, tc.wsErr, tc.exempt, tc.filter, testLogger())
+			titles := make([]string, 0, len(got.Items))
+			for _, it := range got.Items {
+				titles = append(titles, it.Title)
+			}
+			if !reflect.DeepEqual(titles, tc.wantTitles) || got.Count != len(tc.wantTitles) {
+				t.Fatalf("items = %v (count %d), want %v", titles, got.Count, tc.wantTitles)
+			}
+			if got.SLAViolations != tc.wantSLA {
+				t.Fatalf("SLAViolations = %d, want %d", got.SLAViolations, tc.wantSLA)
+			}
+			if got.Items == nil {
+				t.Fatalf("Items must never be nil (fail-closed result is an empty list)")
+			}
+			if tc.ws.calls != tc.wantCalls {
+				t.Fatalf("ListIssues calls = %d, want %d", tc.ws.calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+// TestMergeResumeKicks guards #2573/#2627 (e4589b66): a crash-restarted agent
+// is resume-kicked only through the governor gate, never duplicated, never
+// reordered ahead of the governor's own due list.
+func TestMergeResumeKicks(t *testing.T) {
+	cases := []struct {
+		name            string
+		due, restarted  []string
+		allow           map[string]bool
+		want, wantAsked []string
+	}{
+		{name: "no restarts is a no-op", due: []string{"scanner"}, want: []string{"scanner"}},
+		{ // positive control
+			name: "allowed restarts appended in order",
+			due:  []string{"scanner"}, restarted: []string{"reviewer", "fixer"},
+			allow: map[string]bool{"reviewer": true, "fixer": true},
+			want:  []string{"scanner", "reviewer", "fixer"}, wantAsked: []string{"reviewer", "fixer"},
+		},
+		{ // #2627: the crash-looping CLI — gate closed, due list untouched
+			name: "gated restart is not kicked",
+			due:  []string{"scanner"}, restarted: []string{"looping"},
+			allow: map[string]bool{},
+			want:  []string{"scanner"}, wantAsked: []string{"looping"},
+		},
+		{ // already due keeps ONE slot and does not spend a resume allowance
+			name: "already-due restart is not duplicated or re-gated",
+			due:  []string{"scanner"}, restarted: []string{"scanner"},
+			allow: map[string]bool{"scanner": true},
+			want:  []string{"scanner"}, wantAsked: nil,
+		},
+		{
+			name:      "empty due list still admits allowed restarts",
+			restarted: []string{"reviewer"}, allow: map[string]bool{"reviewer": true},
+			want: []string{"reviewer"}, wantAsked: []string{"reviewer"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var asked []string
+			allow := func(a string) bool { asked = append(asked, a); return tc.allow[a] }
+			got := mergeResumeKicks(append([]string(nil), tc.due...), tc.restarted, allow, testLogger())
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("due = %v, want %v", got, tc.want)
+			}
+			if !reflect.DeepEqual(asked, tc.wantAsked) {
+				t.Fatalf("gate consulted for %v, want %v", asked, tc.wantAsked)
+			}
+		})
+	}
+}
+
+// TestFilterKickableAgents guards #808/#815 (d225de17) and #2573: on-demand
+// agents from config OR any ACMM pack are never kicked on cadence, and
+// operator-paused agents consume nothing.
+func TestFilterKickableAgents(t *testing.T) {
+	agents := map[string]config.AgentConfig{"scanner": {}, "brainstorm": {OnDemand: true}}
+	cases := []struct {
+		name             string
+		due              []string
+		onDemand, paused map[string]bool
+		want, wantPaused []string
+		wantNil          bool
+	}{
+		{name: "positive control passes everything", due: []string{"scanner", "reviewer"},
+			want: []string{"scanner", "reviewer"}, wantPaused: []string{"scanner", "reviewer"}},
+		{name: "config on_demand dropped before the pause check", due: []string{"brainstorm", "scanner"},
+			want: []string{"scanner"}, wantPaused: []string{"scanner"}},
+		{ // #815: pack-declared on-demand agent absent from cfg.Agents is still dropped
+			name: "pack on_demand dropped even when not in config", due: []string{"planner", "scanner"},
+			onDemand: map[string]bool{"planner": true},
+			want:     []string{"scanner"}, wantPaused: []string{"scanner"}},
+		{ // #2573: filtered here, not left for SendKick to reject every cycle
+			name: "paused dropped", due: []string{"scanner", "reviewer"},
+			paused: map[string]bool{"reviewer": true},
+			want:   []string{"scanner"}, wantPaused: []string{"scanner", "reviewer"}},
+		{name: "everything filtered yields nil", due: []string{"brainstorm"}, wantNil: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var pausedAsked []string
+			isPaused := func(a string) bool { pausedAsked = append(pausedAsked, a); return tc.paused[a] }
+			got := filterKickableAgents(tc.due, agents, tc.onDemand, isPaused)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("got %v, want nil", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			if !reflect.DeepEqual(pausedAsked, tc.wantPaused) {
+				t.Fatalf("IsPaused consulted for %v, want %v", pausedAsked, tc.wantPaused)
+			}
+		})
+	}
+}
+
+func kickMsgs(agents ...string) []scheduler.KickMessage {
+	out := make([]scheduler.KickMessage, 0, len(agents))
+	for _, a := range agents {
+		out = append(out, scheduler.KickMessage{Agent: a, Message: "kick " + a})
+	}
+	return out
+}
+
+// TestGateKickMessagesForProviderBudget guards #4294 (and #4583): a fresh
+// spend rebuff withholds EVERY assembled kick, a stale one releases exactly
+// one probe, and a healthy provider is inert.
+func TestGateKickMessagesForProviderBudget(t *testing.T) {
+	cases := []struct {
+		name               string
+		msgs               []scheduler.KickMessage
+		suppress, latched  bool
+		wantKept, wantHeld []string
+		wantProbe          bool
+	}{
+		{name: "not latched passes through", msgs: kickMsgs("a", "b"), wantKept: []string{"a", "b"}},
+		{ // #4294: total — a CEL or review kick is withheld like any other
+			name: "fresh latch withholds all", msgs: kickMsgs("governor", "cel", "review"),
+			suppress: true, latched: true, wantHeld: []string{"governor", "cel", "review"}},
+		{name: "stale latch releases exactly one probe", msgs: kickMsgs("first", "second", "third"),
+			latched: true, wantKept: []string{"first"}, wantHeld: []string{"second", "third"}, wantProbe: true},
+		{name: "stale latch with a single kick releases it as the probe", msgs: kickMsgs("only"),
+			latched: true, wantKept: []string{"only"}, wantProbe: true},
+		{ // the probe stamp must not advance without a real kick going out
+			name: "stale latch with no kicks releases nothing", latched: true},
+		{name: "fresh latch with no kicks is inert", suppress: true, latched: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gateKickMessagesForProviderBudget(tc.msgs, tc.suppress, tc.latched)
+			kept := make([]string, 0, len(got.Kept))
+			for _, m := range got.Kept {
+				kept = append(kept, m.Agent)
+			}
+			if !reflect.DeepEqual(kept, orEmpty(tc.wantKept)) {
+				t.Fatalf("kept = %v, want %v", kept, tc.wantKept)
+			}
+			if !reflect.DeepEqual(orEmpty(got.Withheld), orEmpty(tc.wantHeld)) {
+				t.Fatalf("withheld = %v, want %v", got.Withheld, tc.wantHeld)
+			}
+			if got.ReleaseProbe != tc.wantProbe || (got.ReleaseProbe && len(got.Kept) != 1) {
+				t.Fatalf("ReleaseProbe = %v (kept %d), want %v with exactly one kick", got.ReleaseProbe, len(got.Kept), tc.wantProbe)
+			}
+		})
+	}
+}
+
+func orEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+// TestSelectSLABreachNotifications guards 915bb96a: at most three 2x-SLA
+// pages per cycle, in enumeration order, with the cap reported.
+func TestSelectSLABreachNotifications(t *testing.T) {
+	aged := func(mins ...int) []github.Issue {
+		out := make([]github.Issue, 0, len(mins))
+		for i, m := range mins {
+			out = append(out, github.Issue{Number: i + 1, AgeMinutes: m})
+		}
+		return out
+	}
+	cases := []struct {
+		name       string
+		items      []github.Issue
+		want       []int
+		wantCapped bool
+	}{
+		{name: "nothing breached", items: aged(5, 60), want: []int{}},
+		{name: "boundary: exactly 60 is not a 2x breach", items: aged(60), want: []int{}},
+		{name: "positive control: two breaches, both paged", items: aged(61, 10, 120), want: []int{1, 3}},
+		{name: "exactly three is not capped", items: aged(90, 90, 90), want: []int{1, 2, 3}},
+		{ // 915bb96a: only the first three go out; the fourth trips the cap
+			name: "fourth breach trips the cap", items: aged(90, 90, 90, 90, 90), want: []int{1, 2, 3}, wantCapped: true},
+		{name: "interleaved healthy issues neither count nor cap early",
+			items: aged(90, 1, 90, 1, 90, 1, 90), want: []int{1, 3, 5}, wantCapped: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, capped := selectSLABreachNotifications(tc.items)
+			nums := make([]int, 0, len(got))
+			for _, it := range got {
+				nums = append(nums, it.Number)
+			}
+			if !reflect.DeepEqual(nums, tc.want) || capped != tc.wantCapped {
+				t.Fatalf("selected = %v capped = %v, want %v capped = %v", nums, capped, tc.want, tc.wantCapped)
+			}
+		})
+	}
+}
+
+// TestClassifyAdvisoryPostError guards the App-banner verdict ordering on a
+// failed digest post: #1699 (e22e3530) a rate-limited 403 is NOT "App not
+// installed"; #2353 (c60969f2) a write-forbidden 403 is attributed honestly;
+// 106a95fc/#2301 everything else goes to the shared auth probe.
+func TestClassifyAdvisoryPostError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  string
+		want advisoryPostFailure
+	}{
+		{"403 resource not accessible is write-forbidden",
+			"POST https://api.github.com/repos/o/r/issues/1/comments: 403 Resource not accessible by integration []", advisoryPostWriteForbidden},
+		// #1699: the exact regression — a rate-limited 403 must not reach the banner path.
+		{"403 rate limit is rate-limited, not write-forbidden", "403 API rate limit exceeded for installation ID 1", advisoryPostRateLimited},
+		{"secondary rate limit without a status code is rate-limited", "You have exceeded a secondary Rate Limit", advisoryPostRateLimited},
+		// 106a95fc: a 401 must reach the auth probe, not be swallowed.
+		{"401 bad credentials goes to the auth probe", "401 Bad credentials", advisoryPostAuthProbe},
+		{"resource not accessible without 403 goes to the auth probe", "Resource not accessible by integration", advisoryPostAuthProbe},
+		{"5xx goes to the auth probe", "502 Bad Gateway", advisoryPostAuthProbe},
+		// Historical check order: write-forbidden wins when both texts appear.
+		{"write-forbidden is checked before rate limit", "403 Resource not accessible by integration (rate limit headers present)", advisoryPostWriteForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyAdvisoryPostError(errors.New(tc.err)); got != tc.want {
+				t.Fatalf("classifyAdvisoryPostError(%q) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -5921,25 +5921,7 @@ func runEvalCycle(
 			ghToken = os.Getenv("HIVE_GITHUB_TOKEN")
 		}
 		ws, wsErr := worksource.FromConfig(cfg.Governor.WorkSource, ghClient, ghToken, cfg.Project.Org, logger)
-		if wsErr != nil {
-			logger.Error("work_source config error; failing closed for issues while preserving GitHub PR maintenance", "error", wsErr)
-			actionable.Issues = github.IssueResultFromItems([]github.Issue{})
-		} else if wsIssues, listErr := ws.ListIssues(ctx); listErr != nil {
-			logger.Error("work_source enumeration failed; failing closed for issues while preserving GitHub PR maintenance", "source", ws.SourceType(), "error", listErr)
-			actionable.Issues = github.IssueResultFromItems([]github.Issue{})
-		} else {
-			// Replace the Issues portion of actionable with worksource results,
-			// applying the same label gates and SLA summary rules as GitHub.
-			items := github.FilterExemptIssues(worksource.ToGitHubIssues(wsIssues), cfg.Governor.Labels.Exempt)
-			filtered := items[:0]
-			for _, issue := range items {
-				if cfg.Project.IssueFilter.Admits(issue.Labels) {
-					filtered = append(filtered, issue)
-				}
-			}
-			items = filtered
-			actionable.Issues = github.IssueResultFromItems(items)
-		}
+		actionable.Issues = workSourceIssuesForCycle(ctx, ws, wsErr, cfg.Governor.Labels.Exempt, cfg.Project.IssueFilter, logger)
 	}
 
 	ghClient.EnrichCIStatus(ctx, actionable.PRs.Items)
@@ -6028,23 +6010,7 @@ func runEvalCycle(
 	// burning backend tokens far faster than any configured cadence and
 	// bypassing the budget gate; AllowResumeKick bounds resume kicks to one
 	// per cadence interval and respects mode pauses and the budget.
-	if len(restartedAgents) > 0 {
-		dueSet := make(map[string]bool, len(agentsDue))
-		for _, a := range agentsDue {
-			dueSet[a] = true
-		}
-		for _, a := range restartedAgents {
-			if dueSet[a] {
-				continue
-			}
-			if !gov.AllowResumeKick(a) {
-				logger.Info("restarted agent NOT resume-kicked (cadence/budget gate); it will be kicked at its next scheduled slot", "agent", a)
-				continue
-			}
-			agentsDue = append(agentsDue, a)
-			logger.Info("adding restarted agent to kick list", "agent", a)
-		}
-	}
+	agentsDue = mergeResumeKicks(agentsDue, restartedAgents, gov.AllowResumeKick, logger)
 
 	govState := gov.GetState()
 	span.SetAttributes(
@@ -6065,26 +6031,9 @@ func runEvalCycle(
 	// via the dashboard is always respected; the governor only controls kicks.
 
 	// Filter out on-demand agents — they are only triggered explicitly
-	onDemandSet := config.OnDemandAgentsFromPacks()
-	var filteredDue []string
-	for _, name := range agentsDue {
-		if ac, ok := cfg.Agents[name]; ok && ac.OnDemand {
-			continue
-		}
-		if onDemandSet[name] {
-			continue
-		}
-		// Operator-paused agents must consume NOTHING (#2573). SendKick
-		// would reject the kick anyway (paused ⇒ not running), but skipping
-		// here keeps paused agents out of BuildKickMessages and the audit
-		// log, and avoids a spurious "failed to send kick" error every eval
-		// cycle for a deliberate pause.
-		if agentMgr.IsPaused(name) {
-			continue
-		}
-		filteredDue = append(filteredDue, name)
-	}
-	agentsDue = filteredDue
+	// Operator-paused agents must consume NOTHING (#2573); see
+	// filterKickableAgents for the full gate.
+	agentsDue = filterKickableAgents(agentsDue, cfg.Agents, config.OnDemandAgentsFromPacks(), agentMgr.IsPaused)
 
 	// PROVIDER SPEND REBUFF (#4294). When the inference gateway is refusing on a
 	// money limit, every kick launched this cycle is a run that cannot buy a
@@ -6208,38 +6157,31 @@ func runEvalCycle(
 	// decision (#2573) and must not be forged by an automatic signal that will
 	// clear itself; withholding kicks achieves the saving without leaving paused
 	// agents behind for a human to un-pause by hand.
+	//
+	// Probe cycle: when the last rebuff has gone stale, ONE kick is
+	// deliberately allowed through to find out whether the provider is
+	// serving again. Its inference calls are what clear the latch (on a
+	// 2xx) or re-freshen it (on another rebuff) — nothing else can. Only
+	// one: the question is "is the window still clipped", and every kick
+	// beyond the first spends a run to learn the same answer. Releasing it
+	// re-arms suppression immediately, so the cycles while the probe's run
+	// is still in flight withhold again rather than leaking more kicks.
+	kickGate := gateKickMessagesForProviderBudget(messages, suppressKicks, providerBudgetLatched)
 	if suppressKicks && len(messages) > 0 {
-		withheld := make([]string, 0, len(messages))
-		for _, msg := range messages {
-			withheld = append(withheld, msg.Agent)
-		}
 		logger.Warn("provider spending limit: withholding agent kicks",
-			"withheld", withheld, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince,
+			"withheld", kickGate.Withheld, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince,
 			"next_probe_in", (providerBudgetProbeInterval - time.Since(providerBudgetProbe.freshest(providerBudgetLastRebuff))).Truncate(time.Second))
-		messages = nil
-	} else if providerBudgetLatched && len(messages) > 0 {
-		// Probe cycle: the last rebuff has gone stale, so ONE kick is
-		// deliberately allowed through to find out whether the provider is
-		// serving again. Its inference calls are what clear the latch (on a
-		// 2xx) or re-freshen it (on another rebuff) — nothing else can. Only
-		// one: the question is "is the window still clipped", and every kick
-		// beyond the first spends a run to learn the same answer. Releasing it
-		// re-arms suppression immediately, so the cycles while the probe's run
-		// is still in flight withhold again rather than leaking more kicks.
-		if len(messages) > 1 {
-			dropped := make([]string, 0, len(messages)-1)
-			for _, msg := range messages[1:] {
-				dropped = append(dropped, msg.Agent)
-			}
+	} else if kickGate.ReleaseProbe {
+		if len(kickGate.Withheld) > 0 {
 			logger.Warn("provider spending limit: withholding all but the probe kick",
-				"withheld", dropped, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince)
-			messages = messages[:1]
+				"withheld", kickGate.Withheld, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince)
 		}
 		providerBudgetProbe.markReleased(time.Now())
 		logger.Info("provider spending limit: releasing a single probe kick",
-			"probe_agent", messages[0].Agent, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince,
+			"probe_agent", kickGate.Kept[0].Agent, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince,
 			"last_rebuff", providerBudgetLastRebuff, "probe_interval", providerBudgetProbeInterval)
 	}
+	messages = kickGate.Kept
 	if notifyProviderBudget {
 		notifier.Send("Provider spending limit reached", providerBudgetCause, notify.PriorityHigh)
 	}
@@ -6292,22 +6234,16 @@ func runEvalCycle(
 	persistReviewDispatchState(reviewPlan, deliveredReviewKicks, logger)
 
 	if actionable.Issues.SLAViolations > 0 {
-		const doubleSLAMinutes = 60
-		const maxSLANotificationsPerCycle = 3
-		sent := 0
-		for _, issue := range actionable.Issues.Items {
-			if issue.AgeMinutes > doubleSLAMinutes {
-				if sent >= maxSLANotificationsPerCycle {
-					logger.Info("SLA notification cap reached, skipping remaining", "remaining", actionable.Issues.SLAViolations-sent)
-					break
-				}
-				notifier.Send(
-					"SLA 2x breach",
-					fmt.Sprintf("%s age %dm: %s\n%s", actionableIssueRef(issue), issue.AgeMinutes, issue.Title, issue.URL),
-					notify.PriorityHigh,
-				)
-				sent++
-			}
+		toNotify, capped := selectSLABreachNotifications(actionable.Issues.Items)
+		for _, issue := range toNotify {
+			notifier.Send(
+				"SLA 2x breach",
+				fmt.Sprintf("%s age %dm: %s\n%s", actionableIssueRef(issue), issue.AgeMinutes, issue.Title, issue.URL),
+				notify.PriorityHigh,
+			)
+		}
+		if capped {
+			logger.Info("SLA notification cap reached, skipping remaining", "remaining", actionable.Issues.SLAViolations-len(toNotify))
 		}
 	}
 
@@ -6577,7 +6513,8 @@ func runEvalCycle(
 						// string logged just below — log-safe, never key material.
 						dashSrv.RecordAdvisoryError(err.Error())
 						logger.Warn("failed to post advisory digest via app", "repo", primaryRepo, "issue", issueNum, "error", err)
-						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
+						switch classifyAdvisoryPostError(err) {
+						case advisoryPostWriteForbidden:
 							// App is installed (we found the issue) but a real
 							// WRITE was forbidden. #2353: attribute this honestly.
 							// diagnoseGitHubApp only inspects installation-level
@@ -6598,9 +6535,9 @@ func runEvalCycle(
 							logger.Warn("GitHub App write failed — cannot write issue comments",
 								"repo", primaryRepo, "state", state.String(),
 								"operator_actionable", state.OperatorActionable(), "detail", msg)
-						} else if isGitHubRateLimitText(err) {
+						case advisoryPostRateLimited:
 							logger.Warn("GitHub API rate limit hit, skipping advisory digest post", "repo", primaryRepo)
-						} else {
+						default:
 							// Same verdict function as boot and Re-check, so a
 							// healthy or unclassifiable probe cannot raise the
 							// banner here either.


### PR DESCRIPTION
## Summary

`runEvalCycle` (`src/cmd/hive/main.go`, ~900 lines) has been touched by 37 fix-titled commits and none of its decisions were callable from a test because every collaborator is constructed inline. This PR extracts six of those decisions into `src/cmd/hive/eval_cycle_seams.go` as pure functions (or functions taking an interface/func value already present at the call site) and adds table tests for each in `eval_cycle_seams_test.go`. Behaviour-preserving refactor: no CHANGELOG entry, `main()` untouched.

## Seams extracted (and the incident each guards)

| Seam | Replaces | Past fixes cited |
|---|---|---|
| `workSourceIssuesForCycle(ctx, ws, wsErr, exempt, filter, logger) IssueResult` | the non-GitHub work-source overlay: config error / list error fail CLOSED for issues, success path applies exempt + require-label gates | #4187, #4731 (e9c07779), #4975 (a9cff5b7) |
| `mergeResumeKicks(due, restarted, allow, logger) []string` | crash-restart resume kicks gated by `Governor.AllowResumeKick`, no duplicate slot | #2573, #2627 (e4589b66) |
| `filterKickableAgents(due, cfg.Agents, onDemandSet, isPaused) []string` | drop config-on-demand, pack-on-demand (level-independent scan), and operator-paused agents | #808 (f422d872), #815 (d225de17), #2573 |
| `gateKickMessagesForProviderBudget(messages, suppress, latched) providerBudgetKickGate` | provider spend rebuff: withhold all vs release exactly one probe vs pass through | #4294, #4583 (f8156ead) |
| `selectSLABreachNotifications(items) (selected, capped)` | 2x-SLA page selection capped at 3 per cycle (constants hoisted, no magic numbers) | 915bb96a, 9a4ecd0b |
| `classifyAdvisoryPostError(err) advisoryPostFailure` | ordering of the App-banner verdict on a failed digest post: write-forbidden 403 -> rate-limit text -> shared auth probe | #1699 (e22e3530), #2353 (c60969f2), 106a95fc, #2301 |

## Proof of no behaviour change

- Call sites in `runEvalCycle` are unchanged in position and order; each extracted body is the previous inline code moved verbatim, with the same log messages and fields.
- Error semantics preserved: work-source overlay still fails closed on both paths (empty `IssueResult`, never nil `Items`); provider-budget gate still only re-arms the probe stamp (`markReleased`) when a real kick is released; SLA cap log still fires after the third send and reports `SLAViolations - sent`.
- `classifyAdvisoryPostError` keeps the historical check order (403+"Resource not accessible by integration" before rate-limit text before the auth probe); the `if/else if/else` became a `switch` over the classification with the same three bodies.
- Side effects that are not part of a decision (SendKick, dashboard state, `providerBudgetProbe.markReleased`, `notifier.Send`) stay in `main.go` at their original positions.
- No new dependencies; `gofmt -l` clean. Diff is 556+/98-.

## Tests (`src/cmd/hive/eval_cycle_seams_test.go`)

- `TestWorkSourceIssuesForCycle` — success projects items (positive control, SLA count); exempt labels drop items (#4731); require_labels admits only matches (#4731); config error fails closed and never calls `ListIssues`; list error fails closed (#4975).
- `TestMergeResumeKicks` — no-op without restarts; allowed restarts appended in order (positive control); gated restart not kicked (#2627 crash loop); already-due restart neither duplicated nor re-gated; empty due list still admits allowed restarts.
- `TestFilterKickableAgents` — positive control; config `on_demand` dropped before the pause check; pack-declared on-demand dropped even when absent from config (#815); paused dropped (#2573); all-filtered yields nil.
- `TestGateKickMessagesForProviderBudget` — not latched passes through; fresh latch withholds all incl. CEL/review kicks (#4294); stale latch releases exactly one probe; single-kick probe; no kicks releases nothing (probe stamp must not advance); fresh latch with no kicks inert.
- `TestSelectSLABreachNotifications` — nothing breached; 60-minute boundary; two breaches both paged (positive control); exactly three not capped; fourth trips the cap (915bb96a); interleaved healthy issues neither count nor cap early.
- `TestClassifyAdvisoryPostError` — write-forbidden 403; rate-limited 403 is NOT write-forbidden (#1699); secondary rate limit; 401 to auth probe (106a95fc); write-forbidden text without 403 to auth probe; 5xx to auth probe; write-forbidden wins when both texts appear.

## Judged too entangled to extract in this PR

- Advisory snapshot pinning + `VerifyPath` fail-open (#3704, #4694): needs an interface over three `*github.Client` methods (`GetRepo`, `LatestCommitHash`, `PathExistsAtRef`) returning go-github types.
- The digest-post SUCCESS branch (#1884, #2575, #4291): mutates five dashboard fields, closes healed beads, and builds a memoized `canRead` closure over `AppAuth().VerifyRepoRead` — a struct-level refactor, not a seam.
- ioscan canary blocking of advisory findings: creates beads and audit-log entries inline while deciding.
- `hasExistingPinnedIssueForEmptyDigest` / `hasDigestHome`: already covered through `shouldBuildAdvisoryDigest` / `shouldPostAdvisoryDigest` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FL9uphzhyBKfEXvNCmPV1D
