### PR TITLE
fix(entrypoint): keep UID isolation PVC walks off startup path

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -106,6 +106,14 @@ jobs:
       - name: Entrypoint /data ownership invariant (#5369)
         run: bash deploy/test_entrypoint_data_ownership.sh
 
+      # #5525: v4 -> v5 flips on long-lived NFS PVCs spent longer than the
+      # startup-probe budget in recursive per-agent chown/chmod, so kubelet
+      # killed the pod before :3002 listened and every restart began again.
+      # Pin both halves of the replacement: recursive walks live only in a
+      # background root worker, and UID/revision-bound markers gate agent launch.
+      - name: Entrypoint UID-isolation migration (#5525)
+        run: bash deploy/test_entrypoint_uid_isolation.sh
+
       # #5370: the arm64 lane probed the PUBLISHED image, so on a PR it
       # validated code already on v4 rather than the change proposed — a PR
       # fixing a startup bug stayed red, one introducing a startup bug went

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 - The quality lane can now opt into agent-authored formal verification with `quality.formal: true` at ACMM L5/L6. Every quality kick receives the same model-worthiness, `formal/<subsystem>/` artifact, expected-verdict drift, reporting-only CI, counterexample narrative/deduplication, and modeled-subsystem maintenance contract even when its ordinary policy prompt is customized. The zero value is off, and the setting becomes inert on an ACMM downgrade below L5 without being discarded ([#5512](https://github.com/kubestellar/hive/issues/5512)).
 
+### Fixed
+
+- Version flips no longer trap hosted spokes with large, long-lived `/data` PVCs in a startup-probe death loop ([#5525](https://github.com/kubestellar/hive/issues/5525)). The v5 entrypoint synchronously ran recursive per-agent `chown` and shared-home `chmod` passes before the Go server could bind `:3002`; on an NFS/RWX volume with months of worktrees the walk exceeded the probe budget, kubelet killed the container with exit 137, and the next boot restarted the same walk from the beginning. Size-dependent permission repair now runs in a root background worker, so the dashboard and health endpoint start independently of PVC size. Protected completion markers bind each finished pass to the ownership-schema revision and target UID, and the agent manager waits for both the shared-home and per-agent markers before touching that agent's tree, preserving UID isolation without putting the server behind the migration. Completed steady-state boots skip the recursive pass, while a changed UID invalidates its marker and repairs only the affected agent before launch.
+
 ## 2026-09-01 (v4.0.1)
 
 ### Added

--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -68,6 +68,92 @@ HIVE_CONFIG_RUNTIME_LEGACY="/data/hive.yaml.bak"
 HIVE_RUNTIME_USER="dev"
 HIVE_RUNTIME_GROUP="node"
 
+# UID-isolation ownership migrations are deliberately versioned separately
+# from the image. Keying the marker to every image SHA would turn every edge
+# rollout back into an O(size of PVC) walk; bump this only when the ownership
+# contract itself changes and an existing tree needs another full pass.
+HIVE_UID_ISOLATION_REVISION="1"
+HIVE_UID_ISOLATION_MARKER_DIR="${HIVE_UID_ISOLATION_MARKER_DIR:-/data/.hive/uid-isolation}"
+export HIVE_UID_ISOLATION_REVISION HIVE_UID_ISOLATION_MARKER_DIR
+
+hive_uid_isolation_marker_path() {
+  echo "${HIVE_UID_ISOLATION_MARKER_DIR}/agent-$1.ready"
+}
+
+hive_uid_isolation_marker_matches() {
+  [ -f "$1" ] && [ "$(cat "$1" 2>/dev/null || true)" = "$2" ]
+}
+
+hive_publish_uid_isolation_marker() {
+  _marker_path="$1"
+  _marker_value="$2"
+  _marker_tmp="${_marker_path}.tmp.$$"
+  if printf '%s\n' "$_marker_value" > "$_marker_tmp" 2>/dev/null \
+     && chmod 0644 "$_marker_tmp" 2>/dev/null \
+     && mv -f "$_marker_tmp" "$_marker_path" 2>/dev/null; then
+    return 0
+  fi
+  rm -f "$_marker_tmp" 2>/dev/null || true
+  echo "[entrypoint] WARN: could not publish UID-isolation marker $_marker_path; the affected agent will remain held rather than enter a partially migrated tree"
+  return 1
+}
+
+# Run every operation whose cost scales with persistent-volume size outside
+# PID 1's startup path. The Go server can therefore bind :3002 and satisfy the
+# startup probe while a version flip repairs a months-old NFS tree. The UID map
+# tells the Go manager which protected markers to await before launching each
+# agent, so making the walk asynchronous does not create a partially-isolated
+# execution window.
+hive_run_uid_isolation_migration() {
+  _home_marker="${HIVE_UID_ISOLATION_MARKER_DIR}/home.ready"
+
+  if [ "${HIVE_HOME_MIGRATION_NEEDED:-false}" = "true" ]; then
+    echo "[entrypoint] UID isolation: repairing shared home in background"
+    chown -R dev:node /data/home/.claude /data/home/.codex /data/home/.bob 2>/dev/null \
+      || echo "[entrypoint] WARN: shared-home chown was incomplete; continuing with the existing fail-open permission policy"
+    if [ "${HIVE_HOME_MODE_REPAIR_NEEDED:-false}" = "true" ]; then
+      chmod -R g+rwX /data/home 2>/dev/null \
+        || echo "[entrypoint] WARN: chmod -R g+rwX /data/home failed — is CAP_FOWNER in the pod's capabilities.add? Continuing; agents may hit EACCES under /data/home"
+      find /data/home -type d -exec chmod g+s {} + 2>/dev/null \
+        || echo "[entrypoint] WARN: chmod g+s on /data/home dirs failed — is CAP_FOWNER/CAP_FSETID in the pod's capabilities.add? Continuing"
+    fi
+    # A marker records that the best-effort pass COMPLETED, matching the old
+    # fail-open behaviour when chown/chmod encounter an NFS race. A command
+    # failure is still logged above; withholding the marker forever would turn
+    # a recoverable permissions warning into a fleet-wide agent outage.
+    hive_publish_uid_isolation_marker "$_home_marker" "$HIVE_UID_ISOLATION_REVISION" || true
+    echo "[entrypoint] UID isolation: shared-home pass complete"
+  fi
+
+  _uid_offset=0
+  echo "$AGENT_NAMES" | while read -r _agent_name; do
+    [ -n "$_agent_name" ] || continue
+    _agent_uid=$((HIVE_UID_BASE + _uid_offset))
+    _agent_dir="/data/agents/${_agent_name}"
+    _agent_marker="$(hive_uid_isolation_marker_path "$_agent_uid")"
+    _agent_expected="${HIVE_UID_ISOLATION_REVISION}:${_agent_uid}"
+    _agent_owner="$(stat -c '%u' "$_agent_dir" 2>/dev/null || echo 0)"
+
+    if hive_uid_isolation_marker_matches "$_agent_marker" "$_agent_expected" \
+       && [ "$_agent_owner" = "$_agent_uid" ]; then
+      echo "[entrypoint] UID isolation: ${_agent_name} already current — skipping"
+    else
+      echo "[entrypoint] UID isolation: repairing ${_agent_name} (uid ${_agent_uid}) in background"
+      chown -R "hive-${_agent_name}:node" "$_agent_dir" 2>/dev/null \
+        || echo "[entrypoint] WARN: UID-isolation chown for ${_agent_name} was incomplete; continuing with the existing fail-open permission policy"
+      chmod g+rwX "$_agent_dir" 2>/dev/null || true
+      hive_publish_uid_isolation_marker "$_agent_marker" "$_agent_expected" || true
+      echo "[entrypoint] UID isolation: ${_agent_name} pass complete"
+    fi
+    _uid_offset=$((_uid_offset + 1))
+  done
+}
+
+hive_start_uid_isolation_migration() {
+  hive_run_uid_isolation_migration &
+  echo "[entrypoint] UID-isolation migration running in background (PID $!)"
+}
+
 # hive_harden_runtime_config makes $1 readable by the user that reads it, and
 # by nobody else: chown to dev:node, then chmod 0600.
 #
@@ -147,6 +233,7 @@ hive_harden_runtime_config() {
 #   /data/.hive/proxy-ca-key.pem   — owner-only by design, chowned at its site.
 HIVE_DATA_ROOT_PHASE_PATHS="
 /data/.hive
+/data/.hive/uid-isolation
 /data/secrets
 /data/config
 /data/config/github-copilot
@@ -656,6 +743,9 @@ if [ "$(id -u)" = "0" ]; then
   # cannot be redirected to an attacker-controlled path.
   mkdir -p /data/.hive && chown dev:node /data/.hive 2>/dev/null || true
   chmod 700 /data/.hive 2>/dev/null || true
+  mkdir -p "$HIVE_UID_ISOLATION_MARKER_DIR"
+  chown dev:node "$HIVE_UID_ISOLATION_MARKER_DIR" 2>/dev/null || true
+  chmod 0700 "$HIVE_UID_ISOLATION_MARKER_DIR" 2>/dev/null || true
   if [ -L /data/.hive/proxy-ca-key.pem ]; then
     rm -f -- /data/.hive/proxy-ca-key.pem 2>/dev/null || true
   fi
@@ -831,13 +921,13 @@ if [ "$(id -u)" = "0" ]; then
   chmod 2770 /data/home/.copilot 2>/dev/null || true
   chown dev:node /data/home/.copilot 2>/dev/null || true
   chmod 2775 /data/home/.claude /data/home/.claude/session-env 2>/dev/null || true
-  chown -R dev:node /data/home/.claude 2>/dev/null || true
+  chown dev:node /data/home/.claude /data/home/.claude/session-env 2>/dev/null || true
   # Codex (newer method) writes a local sqlite state db under $HOME/.codex —
   # pre-create it group-writable + setgid so every agent UID (node group) can
   # init it, matching .claude/.copilot. Without this, switching an agent to the
   # codex backend fails with "Permission denied" initializing state_N.sqlite.
   chmod 2775 /data/home/.codex 2>/dev/null || true
-  chown -R dev:node /data/home/.codex 2>/dev/null || true
+  chown dev:node /data/home/.codex 2>/dev/null || true
   # bob writes installation_id, settings.json, trustedFolders.json and tmp/ under
   # $HOME/.bob, plus custom modes under $HOME/.bob/settings. Pre-create both
   # group-writable + setgid so the FIRST agent to launch (a 2001+ UID in group
@@ -845,7 +935,7 @@ if [ "$(id -u)" = "0" ]; then
   # in #2284/#2253. Pre-creating also removes the ordering dependency on which
   # process touches .bob first. 2770: no world access, these hold auth settings.
   chmod 2770 /data/home/.bob /data/home/.bob/settings 2>/dev/null || true
-  chown -R dev:node /data/home/.bob 2>/dev/null || true
+  chown dev:node /data/home/.bob /data/home/.bob/settings 2>/dev/null || true
   ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
   ln -sfn /data/config/github-copilot /data/home/.config/github-copilot
   ln -sfn /data/home/.copilot /home/dev/.copilot
@@ -870,29 +960,18 @@ if [ "$(id -u)" = "0" ]; then
   else
     NEED_PERM_FIX=true
   fi
-  if [ "$NEED_PERM_FIX" = "true" ]; then
-    # Run synchronously — on fresh provisions /data/home is nearly empty so
-    # this completes in <1s. Running in background caused a race where agents
-    # started before perms were fixed, hitting EACCES on config.json.
-    echo "[entrypoint] Fixing /data/home perms..."
-    # This file runs under `set -e`. chmod on an inode root does not OWN (the
-    # tree is dev-owned) needs CAP_FOWNER, and keeping the setgid bit needs
-    # CAP_FSETID — both are in deployment.yaml's capabilities.add. Before they
-    # were, a failed chmod here exited the container with status 1 right after
-    # the line above and NO error text, crash-looping every fresh PVC. Log and
-    # continue instead: agents may hit EACCES later, but the operator gets a
-    # WARN naming the cause rather than a silent exit.
-    chmod -R g+rwX /data/home 2>/dev/null \
-      || echo "[entrypoint] WARN: chmod -R g+rwX /data/home failed — is CAP_FOWNER in the pod's capabilities.add? Continuing; agents may hit EACCES under /data/home"
-    find /data/home -type d -exec chmod g+s {} + 2>/dev/null \
-      || echo "[entrypoint] WARN: chmod g+s on /data/home dirs failed — is CAP_FOWNER/CAP_FSETID in the pod's capabilities.add? Continuing"
-    if [ "$DATA_OWNER" != "1001" ]; then
-      chown -R dev:node /data/config /data/home 2>/dev/null \
-        || echo "[entrypoint] WARN: chown -R dev:node /data/config /data/home failed — is CAP_CHOWN in the pod's capabilities.add? Continuing"
-    fi
-    echo "[entrypoint] perm fix complete"
+  _home_marker="${HIVE_UID_ISOLATION_MARKER_DIR}/home.ready"
+  HIVE_HOME_MODE_REPAIR_NEEDED="$NEED_PERM_FIX"
+  HIVE_HOME_MIGRATION_NEEDED=false
+  if [ "$NEED_PERM_FIX" = "true" ] \
+     || ! hive_uid_isolation_marker_matches "$_home_marker" "$HIVE_UID_ISOLATION_REVISION"; then
+    # Invalidate synchronously, before the Go process can read the UID map.
+    # The expensive repair itself runs in hive_run_uid_isolation_migration.
+    rm -f "$_home_marker" 2>/dev/null || true
+    HIVE_HOME_MIGRATION_NEEDED=true
+    echo "[entrypoint] /data/home permission migration scheduled in background"
   else
-    echo "[entrypoint] /data/home perms OK — skipping"
+    echo "[entrypoint] /data/home ownership marker and perms OK — skipping"
   fi
   chown dev:node /home/dev/.config 2>/dev/null || true
   # Copilot CLI rewrites config.json with 0600 on every token refresh,
@@ -1084,11 +1163,15 @@ print('\n'.join(sorted(names)))
         useradd --system -u "$AGENT_UID" -g node -d /data/home -M -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
       fi
       mkdir -p "/data/agents/${agent_name}"
-      # Skip recursive chown if already owned by this agent — avoids NFS
-      # contention during rolling updates when the old pod is still writing.
+      # Invalidate a stale/incomplete marker synchronously, then leave the
+      # recursive work to the background migration. Manager.Start waits for
+      # this protected marker before the agent can enter its tree.
       AGENT_DIR_OWNER=$(stat -c '%u' "/data/agents/${agent_name}" 2>/dev/null || echo "0")
-      if [ "$AGENT_DIR_OWNER" != "$AGENT_UID" ]; then
-        chown -R "hive-${agent_name}:node" "/data/agents/${agent_name}" 2>/dev/null || true
+      AGENT_ISOLATION_MARKER=$(hive_uid_isolation_marker_path "$AGENT_UID")
+      AGENT_ISOLATION_EXPECTED="${HIVE_UID_ISOLATION_REVISION}:${AGENT_UID}"
+      if [ "$AGENT_DIR_OWNER" != "$AGENT_UID" ] \
+         || ! hive_uid_isolation_marker_matches "$AGENT_ISOLATION_MARKER" "$AGENT_ISOLATION_EXPECTED"; then
+        rm -f "$AGENT_ISOLATION_MARKER" 2>/dev/null || true
       fi
       # Ensure agent dirs are group-writable so the dev user (same node group)
       # can clean up stale workspaces at runtime without root privileges.
@@ -1158,13 +1241,20 @@ uid_map = {
     'agents': agents,
     'proxy_uid': $PROXY_UID,
     'base_uid': $HIVE_UID_BASE,
-    'iptables_active': False
+    'iptables_active': False,
+    'isolation_marker_dir': os.environ['HIVE_UID_ISOLATION_MARKER_DIR'],
+    'isolation_revision': os.environ['HIVE_UID_ISOLATION_REVISION']
 }
 os.makedirs('/var/run/hive', exist_ok=True)
 with open('/var/run/hive/uid-map.json', 'w') as f:
     json.dump(uid_map, f, indent=2)
 print('[entrypoint] UID map written to /var/run/hive/uid-map.json')
 " 2>/dev/null || echo "[entrypoint] WARN: Failed to write UID map"
+
+    # This returns immediately. The root child keeps the capabilities needed
+    # for chown/chmod while the re-exec below drops PID 1 to dev and starts the
+    # HTTP server. Per-agent launches are held on the markers written here.
+    hive_start_uid_isolation_migration
 
     # Set up iptables: redirect all outbound :443 to the MITM proxy port,
     # except traffic from the proxy itself (UID 1001 / dev user).

--- a/src/deploy/test_entrypoint_uid_isolation.sh
+++ b/src/deploy/test_entrypoint_uid_isolation.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# #5525: a version flip must not park PID 1 on an O(size of PVC) ownership walk.
+# The root repair runs in a background worker, while protected markers keep the
+# Go manager from launching an agent into a partially migrated tree.
+# Run: bash src/deploy/test_entrypoint_uid_isolation.sh
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ENTRYPOINT="$(cd "$(dirname "$0")" && pwd)/entrypoint.sh"
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "  FAIL: $1"; [ -n "${2:-}" ] && echo "        $2"; FAIL=$((FAIL + 1)); }
+
+echo "=== #5525: non-blocking UID-isolation migration ==="
+
+# The provisioning loop is on PID 1's root startup path. It may invalidate a
+# marker and touch the agent root, but it must never recurse into the PVC.
+provisioning="$(sed -n '/Creating per-agent users for UID isolation/,/Write uid-map.json/p' "$ENTRYPOINT")"
+if grep -qE '^[[:space:]]*(chown|chmod)[[:space:]]+-[^[:space:]]*R.*[" ]/data/agents|^[[:space:]]*find[[:space:]]+/data/agents' <<<"$provisioning"; then
+  bad "the synchronous per-agent provisioning loop contains a recursive walk" \
+      "all size-dependent ownership work must stay in hive_run_uid_isolation_migration"
+else
+  ok "the synchronous per-agent provisioning loop is O(number of agents)"
+fi
+
+worker="$(sed -n '/^hive_run_uid_isolation_migration() {/,/^}/p' "$ENTRYPOINT")"
+starter="$(sed -n '/^hive_start_uid_isolation_migration() {/,/^}/p' "$ENTRYPOINT")"
+if grep -q 'chown -R' <<<"$worker" && grep -q 'hive_run_uid_isolation_migration &' <<<"$starter"; then
+  ok "recursive ownership repair is confined to the background worker"
+else
+  bad "background migration wiring is missing" \
+      "expected recursive repair in the worker and an '&' at its call site"
+fi
+
+if grep -q "'isolation_marker_dir':" "$ENTRYPOINT" \
+   && grep -q "'isolation_revision':" "$ENTRYPOINT"; then
+  ok "uid-map.json carries the marker contract to the Go manager"
+else
+  bad "uid-map.json does not carry both isolation marker fields"
+fi
+
+# Execute the real marker helpers in a temporary directory. The marker must be
+# exact (revision + target UID), and publishing must leave no temporary file.
+helpers="$(sed -n '/^hive_uid_isolation_marker_path() {/,/^hive_run_uid_isolation_migration() {/p' "$ENTRYPOINT" | sed '$d')"
+if [ -z "$helpers" ]; then
+  bad "could not extract the marker helpers from entrypoint.sh"
+else
+  marker_tmp="$(mktemp -d)"
+  # shellcheck disable=SC1090,SC2086 -- intentionally execute extracted shipped helpers.
+  eval "$helpers"
+  HIVE_UID_ISOLATION_MARKER_DIR="$marker_tmp"
+  marker="$(hive_uid_isolation_marker_path 2001)"
+  if hive_publish_uid_isolation_marker "$marker" "1:2001" \
+     && hive_uid_isolation_marker_matches "$marker" "1:2001" \
+     && ! hive_uid_isolation_marker_matches "$marker" "1:2002" \
+     && ! compgen -G "${marker}.tmp.*" >/dev/null; then
+    ok "completion markers are atomically published and UID-bound"
+  else
+    bad "marker helper behaviour is not atomic and UID-bound"
+  fi
+  rm -rf "$marker_tmp"
+fi
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -62,6 +62,11 @@ const (
 	proxyListenPort      = 18443
 	proxyCACertPath      = "/data/proxy-ca.pem"
 
+	// Completion markers live on the same potentially slow NFS PVC as the
+	// migrated trees. One read per second per waiting agent is responsive
+	// without amplifying load during a rolling update.
+	uidIsolationPollInterval = time.Second
+
 	// fullLogCaptureLines bounds the "download/view full log" capture (see
 	// CaptureFullLog). tmux's -S - captures the entire scrollback, but a wedged
 	// agent that has spammed for hours can hold a very large buffer; this caps the
@@ -1723,6 +1728,66 @@ func (m *Manager) mintAgentTokenUnlocked(ctx context.Context, agent *AgentProces
 	m.issueAgentMintToken(agent.Name, tier, agent.UID)
 }
 
+// uidIsolationMarkersReady reports whether both ownership passes an agent
+// depends on have completed: the shared HOME repair and that agent's own tree.
+// Marker contents bind readiness to both the ownership-schema revision and the
+// assigned UID, so a roster change that shifts UIDs cannot reuse a stale pass.
+func uidIsolationMarkersReady(markerDir, revision string, uid int) bool {
+	if markerDir == "" || revision == "" || uid <= 0 {
+		return true // legacy/shared-UID deployment: no marker contract to await
+	}
+	checks := map[string]string{
+		filepath.Join(markerDir, "home.ready"):                       revision,
+		filepath.Join(markerDir, fmt.Sprintf("agent-%d.ready", uid)): revision + ":" + strconv.Itoa(uid),
+	}
+	for path, expected := range checks {
+		data, err := os.ReadFile(path)
+		if err != nil || strings.TrimSpace(string(data)) != expected {
+			return false
+		}
+	}
+	return true
+}
+
+// awaitUIDIsolation keeps expensive PVC ownership walks off the pod startup
+// path without weakening per-agent UID isolation. The entrypoint starts the
+// root repair worker asynchronously, allowing the dashboard/startup probe to
+// become healthy; each agent waits here before sanitizeGitRemotes, tmux setup,
+// or any backend process can touch its persistent tree.
+func (m *Manager) awaitUIDIsolation(ctx context.Context, agent *AgentProcess) error {
+	if m.uidMap == nil || agent.UID <= 0 {
+		return nil
+	}
+	markerDir, revision, uid := m.uidMap.IsolationContract(agent.Name)
+	if uidIsolationMarkersReady(markerDir, revision, uid) {
+		return nil
+	}
+
+	m.logger.Info("agent launch held for UID-isolation migration",
+		"agent", agent.Name,
+		"uid", uid,
+		"marker_dir", markerDir,
+		"revision", revision,
+	)
+	ticker := time.NewTicker(uidIsolationPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for agent %s UID-isolation migration: %w", agent.Name, ctx.Err())
+		case <-ticker.C:
+			if uidIsolationMarkersReady(markerDir, revision, uid) {
+				m.logger.Info("UID-isolation migration complete; releasing agent launch",
+					"agent", agent.Name,
+					"uid", uid,
+					"revision", revision,
+				)
+				return nil
+			}
+		}
+	}
+}
+
 func (m *Manager) Start(ctx context.Context, name string) error {
 	// PHASE 1 — brief critical section: map lookup, the pure in-memory
 	// decisions (running/sandbox), and claiming the per-agent launch guard.
@@ -1794,6 +1859,10 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	// advancing, and /api/livez stays 200. Neither call mutates m.mu-guarded
 	// AgentProcess fields (they read only immutable Name/UID/tmuxSession/
 	// tmuxSocket and Config), so running them lock-free is race-free.
+	if err := m.awaitUIDIsolation(ctx, agent); err != nil {
+		return err
+	}
+
 	m.sanitizeGitRemotes(agent)
 
 	if err := m.ensureTmuxSession(agent); err != nil {

--- a/src/pkg/agent/uid_isolation_migration_test.go
+++ b/src/pkg/agent/uid_isolation_migration_test.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeIsolationMarker(t *testing.T, dir, name, value string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(value+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUIDIsolationMarkersReady(t *testing.T) {
+	const (
+		revision = "1"
+		uid      = 2007
+	)
+	dir := t.TempDir()
+
+	if !uidIsolationMarkersReady("", "", uid) {
+		t.Fatal("a legacy UID map with no marker contract must preserve legacy launch behaviour")
+	}
+	writeIsolationMarker(t, dir, "home.ready", revision)
+	if uidIsolationMarkersReady(dir, revision, uid) {
+		t.Fatal("home completion alone released the agent before its own tree completed")
+	}
+	writeIsolationMarker(t, dir, "agent-2007.ready", "1:2006")
+	if uidIsolationMarkersReady(dir, revision, uid) {
+		t.Fatal("a marker for the wrong target UID released the agent")
+	}
+	writeIsolationMarker(t, dir, "agent-2007.ready", "1:2007")
+	if !uidIsolationMarkersReady(dir, revision, uid) {
+		t.Fatal("matching home and agent completion markers did not release the agent")
+	}
+}
+
+func TestAwaitUIDIsolationHonoursCancellation(t *testing.T) {
+	dir := t.TempDir()
+	uids := NewUIDMap()
+	uids.Agents["quality"] = 2001
+	uids.IsolationMarkerDir = dir
+	uids.IsolationRevision = "1"
+	m := &Manager{
+		uidMap: uids,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	agent := &AgentProcess{Name: "quality", UID: 2001}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := m.awaitUIDIsolation(ctx, agent)
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("awaitUIDIsolation() error = %v, want context cancellation while markers are absent", err)
+	}
+}
+
+func TestAwaitUIDIsolationReturnsForCompletedPass(t *testing.T) {
+	dir := t.TempDir()
+	writeIsolationMarker(t, dir, "home.ready", "2")
+	writeIsolationMarker(t, dir, "agent-2010.ready", "2:2010")
+	uids := NewUIDMap()
+	uids.Agents["scanner"] = 2010
+	uids.IsolationMarkerDir = dir
+	uids.IsolationRevision = "2"
+	m := &Manager{
+		uidMap: uids,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := m.awaitUIDIsolation(context.Background(), &AgentProcess{Name: "scanner", UID: 2010}); err != nil {
+		t.Fatalf("awaitUIDIsolation() returned error for a completed pass: %v", err)
+	}
+}

--- a/src/pkg/agent/uidmap.go
+++ b/src/pkg/agent/uidmap.go
@@ -22,12 +22,23 @@ const (
 )
 
 type UIDMap struct {
-	Agents         map[string]int `json:"agents"`
-	ProxyUID       int            `json:"proxy_uid"`
-	BaseUID        int            `json:"base_uid"`
-	IptablesActive bool           `json:"iptables_active"`
+	Agents             map[string]int `json:"agents"`
+	ProxyUID           int            `json:"proxy_uid"`
+	BaseUID            int            `json:"base_uid"`
+	IptablesActive     bool           `json:"iptables_active"`
+	IsolationMarkerDir string         `json:"isolation_marker_dir,omitempty"`
+	IsolationRevision  string         `json:"isolation_revision,omitempty"`
 
 	mu sync.RWMutex
+}
+
+// IsolationContract returns the entrypoint's protected completion-marker
+// contract for an agent. Empty values mean the UID map predates asynchronous
+// migration, so callers preserve the legacy launch behaviour.
+func (u *UIDMap) IsolationContract(name string) (markerDir, revision string, uid int) {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return u.IsolationMarkerDir, u.IsolationRevision, u.Agents[name]
 }
 
 func NewUIDMap() *UIDMap {


### PR DESCRIPTION
## Problem

Moving a hosted spoke from the v4 stable image to v5 edge can make a large, long-lived `/data` PVC permanently unbootable. The root phase of `src/deploy/entrypoint.sh` recursively changes ownership on every per-agent workspace whose top-level UID does not match the new v5 allocation, and may recursively repair shared-home ownership/modes as well. Those NFS/RWX walks run before the Go server binds `:3002`.

On the reported spoke, the work exceeded the startup probe's ten-minute budget. Kubelet killed the container with exit 137 while the entrypoint was still in `chown -R`/`chmod -R`; because no completion state existed, the replacement container began the same traversal again. The hive never became ready, and a rolling update also left the old pod writing the same RWX tree while the new pod attempted its migration.

## Root cause

The existing top-directory-owner shortcut is not a reliable completion record. A mismatched root correctly requests migration, but there is no durable distinction between “not started” and “partially traversed before SIGKILL.” Keeping the recursive command in PID 1's synchronous root setup therefore couples the startup probe budget to total PVC size.

Shared-home setup had the same scaling problem: `.claude`, `.codex`, and `.bob` were recursively chowned before the existing permission fast-path was evaluated, and a required mode repair recursively chmodded `/data/home` before the listener could start.

## Implementation

- `src/deploy/entrypoint.sh` now performs only bounded top-level checks and marker invalidation on the synchronous root path. Every ownership/mode operation whose cost scales with stored PVC contents runs in `hive_run_uid_isolation_migration`, launched as a background root child before PID 1 drops to `dev`.
- Completion state lives under `/data/.hive/uid-isolation`, which is `0700` and owned by `dev:node`; per-agent UIDs cannot forge it. Marker writes use a temporary file plus rename, so a killed pass cannot expose partial completion.
- The shared-home marker is bound to an ownership-schema revision. Each agent marker is additionally bound to its assigned UID (`revision:uid`), and the entrypoint also checks the agent directory's current owner. A UID allocation change therefore invalidates only the affected agent instead of trusting stale state.
- `uid-map.json` carries the marker directory and schema revision into `pkg/agent`. `Manager.Start` waits for both shared-home and per-agent completion before `sanitizeGitRemotes`, tmux setup, token minting, or backend launch can touch that agent's tree. The dashboard and `/api/health` can become ready while migration proceeds, but agents cannot enter partially migrated state.
- Legacy UID maps omit the new fields and retain their previous behavior. Runtime allocations not provisioned by this entrypoint likewise do not invent a marker contract.
- The existing best-effort permission policy remains intact: an NFS race or missing capability is logged and the completed pass is marked rather than converting a formerly recoverable warning into a permanent fleet-wide hold. Failure to publish a marker is different: the agent remains held and the log names the marker that could not be written.

The marker revision is intentionally independent of the image SHA. Binding it to every edge build would force the full recursive pass on every ordinary rollout and recreate the original scaling failure; maintainers bump the schema revision only when the ownership contract itself changes.

## Regression coverage

`src/deploy/test_entrypoint_uid_isolation.sh` executes the shipped marker helpers and proves that:

- the synchronous per-agent provisioning loop contains no recursive `/data/agents` walk;
- recursive repair is confined to the background worker;
- the UID map exposes the marker contract;
- markers are atomically published and reject the wrong target UID.

`src/pkg/agent/uid_isolation_migration_test.go` proves that shared-home completion alone cannot release an agent, a wrong-UID marker cannot release it, matching markers do release it, legacy maps remain compatible, and cancellation interrupts an agent waiting for migration.

The new shell regression is wired into `v2-ci.yml`. Existing `/data` ownership and shared-home/symlink regression suites also remain green.

## Verification

- `bash -n deploy/entrypoint.sh deploy/test_entrypoint_uid_isolation.sh` — passed.
- `bash deploy/test_entrypoint_uid_isolation.sh` — 4 passed, 0 failed.
- `bash deploy/test_entrypoint_data_ownership.sh` — 11 passed, 0 failed; the root-only behavioral portion skipped as designed on the unprivileged host.
- `bash deploy/test_entrypoint_symlinks.sh` — 8 passed, 0 failed.
- `go vet ./pkg/agent` — passed.
- `go test ./pkg/agent -run 'TestUIDMapSaveLoadRoundTrip|TestLoadUIDMap|TestUIDIsolation|TestAwaitUIDIsolation' -count=1` — passed.
- `go test ./pkg/agent -count=1` — passed in 252.126s from a short detached worktree with tmux socket access.
- `git diff upstream/v5...HEAD --check` — passed.

## Scope

This does not raise probe thresholds or attempt to predict PVC size. It does not remove the existing guarded whole-`/data` migration used when the mount root itself has the wrong owner, and it leaves the deliberately small beads-store repair and runtime permission watchers unchanged. The change is limited to preventing the v5 per-agent/shared-home UID-isolation pass from blocking server startup while preserving the launch-time isolation boundary.

Fixes #5525

— hive: backend=codex
