### PR TITLE
ci: take docker and overlayfs-exec-guard off the build-and-test critical path

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -675,9 +675,21 @@ jobs:
               labels: ['ci-failure', 'kind/bug'],
             });
 
+  # Deliberately NO `needs: build-and-test` here or on overlayfs-exec-guard.
+  # Neither job consumes anything build-and-test produces — each compiles the
+  # PR's own tree from scratch inside src/Dockerfile — so chaining them behind
+  # the test gate bought no correctness and put the gate's wall time PLUS a
+  # second trip through the shared runner queue on every PR's time-to-green
+  # (measured 2026-09-01 across three PR runs: ~2.75 min of build-and-test,
+  # then 10-11 min queued before either image job started, then 3.5-4.5 min
+  # of build). Running all three from t=0 makes the guard (~4.5 min) the
+  # ceiling instead of the sum. Cost of the trade: on the ~2% of runs where
+  # build-and-test is red, a compile error also fails the in-Dockerfile
+  # `go build` within ~1 min, and a test-only failure lets these two run to
+  # completion (~8 wasted runner-minutes). nightly-release still requires
+  # BOTH build-and-test and docker, so the v2 nightly gate is unchanged.
   docker:
     runs-on: ubuntu-latest
-    needs: build-and-test
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -717,7 +729,7 @@ jobs:
   # binary EPERMs here and the PR is blocked.
   overlayfs-exec-guard:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    # No `needs: build-and-test` — see the note above the `docker` job.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -728,6 +740,21 @@ jobs:
       # image — buildx (BuildKit), attestations OFF (provenance:false/sbom:false
       # as in the #3760 fix) — and export it as an OCI archive so containerd
       # imports the real BuildKit layer layout (not the docker daemon's).
+      #
+      # cache-from: read docker.yml's `tmux-linux-amd64` gha scope, the same
+      # one its own amd64 build reads. That scope only ever receives
+      # `--target tmux-builder` exports (docker.yml's warm step, run on every
+      # PR and every v4 push), and tmux-builder's inputs are a pinned base
+      # image and a pinned tarball — so no layer carrying /usr/local/bin/hive
+      # can be served from it and the stale-COPY hazard the stale-binary guard
+      # below exists for cannot arise here. Every other stage is still built
+      # from scratch on THIS commit (there is no cache-to and no other scope),
+      # so the assertions below still test the PR's own binary. Read-only: a
+      # miss, a renamed scope, or a cache-service hiccup just recompiles tmux
+      # as before. Measured 2026-09-01: the runtime stage blocks on
+      # tmux-builder (~51s) at its third layer while its own apt layer takes
+      # ~20s, so a hit removes ~30s from a ~3.5 min build; a whole-image
+      # cache-to would instead ADD the 130-225s export docker.yml measured.
       - name: Build image via buildx (OCI archive, no attestations)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -737,6 +764,7 @@ jobs:
           provenance: false
           sbom: false
           outputs: type=oci,oci-mediatypes=true,dest=/tmp/hive-oci.tar,tar=true
+          cache-from: type=gha,scope=tmux-linux-amd64
           build-args: |
             GIT_HASH=${{ github.sha }}
             GIT_BRANCH=${{ github.ref_name }}


### PR DESCRIPTION
## Why

`overlayfs-exec-guard` (the #3760 regression guard) is the longest job on every PR in `v2 CI`, and it is chained behind `build-and-test`. Step timings from three PR runs on 2026-09-01:

| run | build-and-test | queue wait before image jobs | guard: buildx build | guard: containerd probe | guard total | docker total |
|---|---|---|---|---|---|---|
| 33533903671 | 2:46 | 10:53 | 207 s | 47 s | 4:33 | 3:41 |
| 33533861639 | 4:05 | 10:11 | 214 s | 46 s | 4:41 | 3:24 |
| 33533593706 | 2:43 | 12:14 | 199 s | 42 s | 4:15 | 3:29 |

Inside the ~207 s build step (from the BuildKit log): the layer chain is ~150 s (tmux compile 51 s in parallel with Go build 55 s; runtime stage ~115 s sequential, of which litellm pip 29 s, apt 20 s, npm CLIs ~30 s) and `exporting layers` for the 1.3 GiB OCI archive is 50 s. The probe's 43 s is almost entirely `ctr images import` of that archive.

So the dominant step is the image build itself, but the larger time-to-green cost is structural: `docker` and the guard `needs: build-and-test`, so each PR pays the test gate's wall time **plus a second pass through the shared runner queue** (35 runs queued at the time of measurement) before either image job even starts.

## What changes

1. **Drop `needs: build-and-test` from `docker` and `overlayfs-exec-guard`.** Neither consumes anything build-and-test produces — both compile the PR's own tree from scratch inside `src/Dockerfile`. All three jobs now start at t=0, so the guard (~4.5 min) is the ceiling instead of the sum. `nightly-release` still requires both `build-and-test` and `docker`; `create-issue-on-failure` is unchanged. Cost of the trade: on the ~2% of runs where build-and-test is red (1 failure in the last 50 completed runs), a compile error also fails the in-Dockerfile `go build` within about a minute, and a test-only failure lets the two image jobs run to completion (~8 runner-minutes).

2. **Read-only `cache-from` on docker.yml's `tmux-linux-amd64` gha scope** for the guard's buildx step. That scope only ever receives `--target tmux-builder` exports (docker.yml's warm step, which runs on every PR and every v4 push and was a 2 s hit on the same PR), and tmux-builder's inputs are a pinned base image and a pinned tarball — so no layer carrying `/usr/local/bin/hive` can be served from it and the stale-COPY hazard the stale-binary guard exists for cannot arise. Every other stage is still built from scratch on the PR's own commit; there is no `cache-to`. Expected saving ~30 s (the runtime stage blocks on tmux-builder at its third layer). A miss just recompiles tmux as before.

Nothing the guard asserts changes: still buildx, still attestations off, still OCI archive into containerd/overlayfs, still in-place exec with no NET_ADMIN, still the embedded-commit freshness check.

## Considered and rejected

- **Whole-image `cache-to: type=gha`** — docker.yml measured 130-225 s of export per job for ~0 reuse, so it would make the guard slower, and a persistent cache is exactly the #3816 stale-layer path; here it would surface as a false-red PR from the stale-binary guard.
- **Guard consuming the `docker` job's image** — the job's own comment explains plain `docker build` under runc does not reproduce #3760; the guard must build via buildx and export OCI.
- **Path-gating the guard** — a skipped check on a merge-on-green fleet is a silent hole, and the `.github/workflows/v2-ci.yml` `paths:` filter already scopes the whole workflow.

## Validation

- `ruby -ryaml` parses; `needs` is nil on both image jobs and unchanged on `nightly-release`/`create-issue-on-failure`.
- `src/scripts/check-release-lines.sh` (release-line-guard) passes — no `branches:` filter touched.

## Follow-ups worth a separate look (not in this PR)

- Per PR, the same 1.3 GiB `src/Dockerfile` image is built at least four times across workflows (v2-ci `docker`, v2-ci guard, docker.yml amd64 + arm64, plus the podman lanes). Under queue saturation, runner-minutes are the real time-to-green lever; folding the `docker` smoke into the guard (`docker load` of the same OCI archive) would remove one build per PR.
- In the guard, ~93 s of the ~4.5 min is serialising and unpacking the 1.3 GiB archive (gzip export 50 s + `ctr import` 43 s). Layer compression settings could cut that but change the export fidelity the guard depends on, so they need a deliberate decision.
