### PR TITLE
test(hub): per-test HubServer construction with isolated /data footprint

### DIFF
--- a/src/pkg/hub/assign_forge_identity_test.go
+++ b/src/pkg/hub/assign_forge_identity_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"log/slog"
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/config"
@@ -17,7 +16,7 @@ import (
 // the GHE App is a build constant, so assign must still answer with the full
 // identity set.
 func TestAssignTimeAppIdentityUnregisteredGHECluster(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.clusters = map[string]ClusterConfig{
 		"hive-oke": {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
 	}
@@ -65,7 +64,7 @@ func TestAssignTimeAppIdentityUnregisteredGHECluster(t *testing.T) {
 // asserts the public case does NOT pin forge URLs — the spoke already defaults
 // to public github.com, so writing them would state a value as an override.
 func TestAssignTimeAppIdentityPublicForge(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.clusters = map[string]ClusterConfig{}
 
 	h := &SaaSHive{
@@ -93,7 +92,7 @@ func TestAssignTimeAppIdentityPublicForge(t *testing.T) {
 // a forge this build cannot name must yield nil so assign leaves the spoke
 // alone rather than guessing an App ID that would 404 against that host.
 func TestAssignTimeAppIdentityUnknownForgeSaysNothing(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.clusters = map[string]ClusterConfig{}
 
 	h := &SaaSHive{
@@ -115,7 +114,7 @@ func TestAssignTimeAppIdentityUnknownForgeSaysNothing(t *testing.T) {
 // unregistered cluster, never an override of a configured App.
 func TestAssignTimeAppIdentityRegisteredClusterWins(t *testing.T) {
 	const customAppID int64 = 4242
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.clusters = map[string]ClusterConfig{
 		"custom": {
 			ID:            "custom",
@@ -152,7 +151,7 @@ func TestAssignTimeAppIdentityRegisteredClusterWins(t *testing.T) {
 // returned nil for an unknown cluster and produced the misleading
 // "cluster names no github app — cannot repair" warning forever.
 func TestAppIdentityForHiveUnregisteredClusterRepairs(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.clusters = map[string]ClusterConfig{
 		"hive-oke": {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
 	}
@@ -184,7 +183,7 @@ func TestAppIdentityForHiveUnregisteredClusterRepairs(t *testing.T) {
 // placeholder has elected nothing, so inferring a forge for it would be exactly
 // the 2026-08-05 mistake (public hives flipped onto the GHE App).
 func TestAppIdentityForHiveUnregisteredClusterUnclaimedSaysNothing(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.clusters = map[string]ClusterConfig{}
 
 	h := &SaaSHive{

--- a/src/pkg/hub/fleet_route_test.go
+++ b/src/pkg/hub/fleet_route_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,7 +14,7 @@ import (
 // /api/saas/my-hives is intentionally unchanged.
 func TestFleetRouteServesPageAndMyHivesRedirects(t *testing.T) {
 	t.Setenv("HUB_DATA_DIR", t.TempDir())
-	srv := NewHubServer(0, slog.Default(), "test", "v4")
+	srv := newHubServerForTest(t, withHubIdentity("test", "v4"))
 
 	req := httptest.NewRequest("GET", "/fleet", nil)
 	w := httptest.NewRecorder()

--- a/src/pkg/hub/hive_namespace_overlay_test.go
+++ b/src/pkg/hub/hive_namespace_overlay_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
@@ -35,7 +34,7 @@ func TestHeartbeatOverlaysHostedNamespace(t *testing.T) {
 	useTempHiveDir(t) // restored via t.Cleanup — no leaked global for -race to catch
 
 	t.Run("hosted hive with a SaaSHive record gets hive-hosted-<id>", func(t *testing.T) {
-		srv := NewHubServer(0, slog.Default(), "test", "v2")
+		srv := newHubServerForTest(t)
 		srv.setHubSecret("")
 
 		const hiveID = "hosted-available-oke-07-placeholder-a1b2"
@@ -62,7 +61,7 @@ func TestHeartbeatOverlaysHostedNamespace(t *testing.T) {
 	})
 
 	t.Run("hive with no SaaSHive record keeps Namespace empty", func(t *testing.T) {
-		srv := NewHubServer(0, slog.Default(), "test", "v2")
+		srv := newHubServerForTest(t)
 		srv.setHubSecret("")
 
 		// No saveSaaSHive: this is a self-hosted/BYO spoke the hub did not

--- a/src/pkg/hub/hover_timeline_relay_test.go
+++ b/src/pkg/hub/hover_timeline_relay_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -186,7 +185,7 @@ func TestMyHivesEmbedsRecentEvents(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, token, owner)
 	defer cleanup()
 
-	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s := newHubServerForTest(t)
 	s.mu.Lock()
 	s.registry.Hives = []RegistryEntry{{
 		ID:            hiveID,

--- a/src/pkg/hub/hub_coverage_boost_test.go
+++ b/src/pkg/hub/hub_coverage_boost_test.go
@@ -315,7 +315,7 @@ func TestClusterIDForSaaSHive(t *testing.T) {
 // ============================================================
 
 func TestClusterNameForID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// The default cluster should exist
 	name := srv.clusterNameForID(defaultClusterID)
 	// It may be empty or "OKE (default)" depending on config
@@ -328,7 +328,7 @@ func TestClusterNameForID(t *testing.T) {
 }
 
 func TestClusterForHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Default cluster
 	h := &SaaSHive{ID: "test-hive"}
@@ -353,7 +353,7 @@ func TestClusterForHive(t *testing.T) {
 }
 
 func TestHubCluster(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	c := srv.hubCluster()
 	if c == nil {
 		t.Fatal("hubCluster should never return nil")
@@ -433,7 +433,7 @@ func TestValidateGitHubTokenWithMockServer(t *testing.T) {
 	}
 	ghTokenCacheMu.Unlock()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	result := srv.validateGitHubToken("mock-valid")
 	if result != "mockuser" {
 		t.Errorf("expected mockuser, got %q", result)
@@ -499,7 +499,7 @@ func TestGhcrTagExistsWithMock(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatValidPayload(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := HeartbeatPayload{
@@ -535,7 +535,7 @@ func TestHandleHeartbeatValidPayload(t *testing.T) {
 }
 
 func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"","org":"test"}`
@@ -551,7 +551,7 @@ func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidHiveID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	// sanitizeHeartbeatField strips most chars; use a string that becomes >100 chars of valid chars
@@ -569,7 +569,7 @@ func TestHandleHeartbeatInvalidHiveID(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidOrg(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","org":"bad org name!"}`
@@ -585,7 +585,7 @@ func TestHandleHeartbeatInvalidOrg(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidRepo(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	// Use a repo name that's >100 chars (too long for isValidName)
@@ -603,7 +603,7 @@ func TestHandleHeartbeatInvalidRepo(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidRepoInList(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","repos":["good-repo","bad repo!"]}`
@@ -619,7 +619,7 @@ func TestHandleHeartbeatInvalidRepoInList(t *testing.T) {
 }
 
 func TestHandleHeartbeatBadDashboardURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","dashboard_url":"ftp://bad-scheme.com"}`
@@ -635,7 +635,7 @@ func TestHandleHeartbeatBadDashboardURL(t *testing.T) {
 }
 
 func TestHandleHeartbeatBadSnapshotURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","snapshot_url":"ftp://bad.com"}`
@@ -651,7 +651,7 @@ func TestHandleHeartbeatBadSnapshotURL(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","agents":[{"name":"bad agent!","state":"running"}]}`
@@ -667,7 +667,7 @@ func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("test-secret")
 
 	payload := `{"hive_id":"valid-id","leaderboard":[{"github_username":"bad user!"}]}`
@@ -683,7 +683,7 @@ func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
 }
 
 func TestHandleHeartbeatNoSecretRequired(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	payload := `{"hive_id":"valid-id"}`
@@ -698,7 +698,7 @@ func TestHandleHeartbeatNoSecretRequired(t *testing.T) {
 }
 
 func TestHandleHeartbeatWrongSecret(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("correct-secret")
 
 	payload := `{"hive_id":"valid-id"}`
@@ -714,7 +714,7 @@ func TestHandleHeartbeatWrongSecret(t *testing.T) {
 }
 
 func TestHandleHeartbeatExistingHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Pre-populate a hive
@@ -741,7 +741,7 @@ func TestHandleHeartbeatExistingHive(t *testing.T) {
 }
 
 func TestHandleHeartbeatLocalHiveType(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	secret := srv.hubSecret
 
 	payload := `{"hive_id":"my-local-hive","hive_type":"local"}`
@@ -773,7 +773,7 @@ func TestHandleHeartbeatLocalHiveType(t *testing.T) {
 }
 
 func TestHandleHeartbeatHostedHiveRejectedWithoutSaaS(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	secret := srv.hubSecret
 
 	// hosted- prefix without SaaS entry should be rejected
@@ -794,7 +794,7 @@ func TestHandleHeartbeatHostedHiveRejectedWithoutSaaS(t *testing.T) {
 // ============================================================
 
 func TestHandleTaskStatusNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("secret")
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("{}"))
@@ -808,7 +808,7 @@ func TestHandleTaskStatusNoAuth(t *testing.T) {
 }
 
 func TestHandleTaskStatusValid(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("secret")
 
 	// Pre-populate a hive in registry
@@ -831,7 +831,7 @@ func TestHandleTaskStatusValid(t *testing.T) {
 }
 
 func TestHandleTaskStatusBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("secret")
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("not json"))
@@ -846,7 +846,7 @@ func TestHandleTaskStatusBadJSON(t *testing.T) {
 }
 
 func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("secret")
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(`{"hive_id":""}`))
@@ -861,7 +861,7 @@ func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
 }
 
 func TestHandleTaskStatusOfflineHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("secret")
 
 	srv.mu.Lock()
@@ -886,7 +886,7 @@ func TestHandleTaskStatusOfflineHive(t *testing.T) {
 // ============================================================
 
 func TestHandleRegistryDeleteNoAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
@@ -907,7 +907,7 @@ func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
 	// user record and a signed session cookie.
 	ensureSaaSUser(hubAdminUsername)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "delete-me", Online: true},
@@ -938,7 +938,7 @@ func TestHandleRegistryDeleteNotFound(t *testing.T) {
 	defer cleanup()
 	ensureSaaSUser(hubAdminUsername)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
@@ -958,7 +958,7 @@ func TestHandleRegistryDeleteNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleHubVersionAsAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "admin-hash", "v2")
+	srv := newHubServerForTest(t, withHubIdentity("admin-hash", "v2"))
 
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
 	req.AddCookie(testAuthCookie(hubAdminUsername))
@@ -979,7 +979,7 @@ func TestHandleHubVersionAsAdmin(t *testing.T) {
 }
 
 func TestHandleHubVersionNonAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "user-hash", "v2")
+	srv := newHubServerForTest(t, withHubIdentity("user-hash", "v2"))
 
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
 	w := httptest.NewRecorder()
@@ -999,7 +999,7 @@ func TestHandleHubVersionNonAdmin(t *testing.T) {
 // ============================================================
 
 func TestMergeLeaderboards(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{
@@ -1067,7 +1067,7 @@ func TestMergeLeaderboards(t *testing.T) {
 // ============================================================
 
 func TestHandleRegistryFiltersPrivateHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "public-1", IsPublic: true, Online: true, LastHeartbeat: time.Now().Format(time.RFC3339)},
@@ -1094,7 +1094,7 @@ func TestHandleRegistryFiltersPrivateHives(t *testing.T) {
 }
 
 func TestHandleRegistryDedupLocalVsHosted(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	// Use a stale heartbeat (>5min ago) so markStaleHives marks it offline
 	stale := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
@@ -1125,7 +1125,7 @@ func TestHandleRegistryDedupLocalVsHosted(t *testing.T) {
 // ============================================================
 
 func TestHandleContributeStatusNoHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/contribute/status", nil)
 	w := httptest.NewRecorder()
@@ -1145,7 +1145,7 @@ func TestHandleContributeStatusWithPublicHive(t *testing.T) {
 	// L3: keep this hermetic — the hive's DashboardURL below must classify as
 	// public without an external DNS lookup.
 	stubPrivateURLResolver(t, "example.com")
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -1172,7 +1172,7 @@ func TestHandleContributeStatusWithPublicHive(t *testing.T) {
 // ============================================================
 
 func TestHandleLatestSHA(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/latest-sha", nil)
 	w := httptest.NewRecorder()
@@ -1193,7 +1193,7 @@ func TestHandleLatestSHA(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessDenied(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/access-denied?hive=test-hive", nil)
 	w := httptest.NewRecorder()
@@ -1208,7 +1208,7 @@ func TestHandleAccessDenied(t *testing.T) {
 }
 
 func TestHandleAccessDeniedWithOwner(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "owned-hive", Owner: "owneruser"},
@@ -1233,7 +1233,7 @@ func TestHandleAccessDeniedWithOwner(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessStatusNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/access-status", nil)
 	w := httptest.NewRecorder()
@@ -1254,7 +1254,7 @@ func TestHandleAccessStatusNoAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleListClusters(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Call handler directly to skip requireAuth
 	req := httptest.NewRequest("GET", "/api/hub/clusters", nil)
@@ -1279,7 +1279,7 @@ func TestHandleListClusters(t *testing.T) {
 // ============================================================
 
 func TestServeStatic(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Test the learn page
 	req := httptest.NewRequest("GET", "/learn", nil)
@@ -1292,7 +1292,7 @@ func TestServeStatic(t *testing.T) {
 }
 
 func TestServeStaticMissing(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	handler := srv.serveStatic("static/nonexistent.html")
 	req := httptest.NewRequest("GET", "/missing", nil)
@@ -1309,7 +1309,7 @@ func TestServeStaticMissing(t *testing.T) {
 // ============================================================
 
 func TestShutdownNoServer(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// httpServer is nil when Start hasn't been called
 	err := srv.Shutdown(time.Second)
 	if err != nil {
@@ -1322,7 +1322,7 @@ func TestShutdownNoServer(t *testing.T) {
 // ============================================================
 
 func TestMarkStaleHivesEmptyHeartbeat(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "no-heartbeat", Online: true, LastHeartbeat: ""},
@@ -1338,7 +1338,7 @@ func TestMarkStaleHivesEmptyHeartbeat(t *testing.T) {
 }
 
 func TestMarkStaleHivesRemoveOld(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	old := time.Now().Add(-48 * time.Hour).Format(time.RFC3339) // older than staleRemoveAge (24h)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -1466,7 +1466,7 @@ func TestIsHubAutoUpgrade(t *testing.T) {
 // ============================================================
 
 func TestRequireAuthCSRFFails(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1486,7 +1486,7 @@ func TestRequireAuthCSRFFails(t *testing.T) {
 }
 
 func TestRequireAuthNoUser(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1502,7 +1502,7 @@ func TestRequireAuthNoUser(t *testing.T) {
 }
 
 func TestRequireAdminNonAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := srv.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1519,7 +1519,7 @@ func TestRequireAdminNonAdmin(t *testing.T) {
 }
 
 func TestRequireAdminNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := srv.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1538,7 +1538,7 @@ func TestRequireAdminNoAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleSaaSAuthCheckPublicPath(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Public paths should pass without auth
 	publicPaths := []string{"/snapshot", "/leaderboard", "/contribute", "/api/leaderboard", "/api/contribute"}
@@ -1555,7 +1555,7 @@ func TestHandleSaaSAuthCheckPublicPath(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckUnfurlBot(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 	req.Header.Set("User-Agent", "Slackbot-LinkExpanding 1.0")
@@ -1568,7 +1568,7 @@ func TestHandleSaaSAuthCheckUnfurlBot(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckXOriginalURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 	req.Header.Set("X-Original-URL", "https://example.com/snapshot/test")
@@ -1581,7 +1581,7 @@ func TestHandleSaaSAuthCheckXOriginalURL(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckURIParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive&uri=/leaderboard/page", nil)
 	w := httptest.NewRecorder()
@@ -1629,7 +1629,7 @@ func TestHandleOAuthCallbackFullFlowMockGitHub(t *testing.T) {
 // ============================================================
 
 func TestHandleAuthUserWithBearerToken(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Pre-populate the token cache
 	ghTokenCacheMu.Lock()
@@ -1663,7 +1663,7 @@ func TestHandleAuthUserWithBearerToken(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleVisibilityNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", srv.handleToggleVisibility)
@@ -1679,7 +1679,7 @@ func TestHandleToggleVisibilityNotFound(t *testing.T) {
 }
 
 func TestHandleToggleVisibilityCORSPreflight(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("OPTIONS /visibility-test/{id}", srv.handleToggleVisibility)
@@ -1699,7 +1699,7 @@ func TestHandleToggleVisibilityCORSPreflight(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleAutoUpgradeNotFoundNoRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", srv.handleToggleAutoUpgrade)
@@ -1715,7 +1715,7 @@ func TestHandleToggleAutoUpgradeNotFoundNoRegistry(t *testing.T) {
 }
 
 func TestHandleToggleAutoUpgradeCORSPreflight(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("OPTIONS /auto-upgrade-test/{id}", srv.handleToggleAutoUpgrade)
@@ -1731,7 +1731,7 @@ func TestHandleToggleAutoUpgradeCORSPreflight(t *testing.T) {
 }
 
 func TestHandleToggleAutoUpgradeFromRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Hive exists in registry but not in SaaS store
 	srv.mu.Lock()
@@ -1755,7 +1755,7 @@ func TestHandleToggleAutoUpgradeFromRegistry(t *testing.T) {
 }
 
 func TestHandleToggleAutoUpgradeBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -1781,7 +1781,7 @@ func TestHandleToggleAutoUpgradeBadJSON(t *testing.T) {
 // ============================================================
 
 func TestHandleHubAutoUpgradeBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("PUT", "/hub-auto-upgrade", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
@@ -1906,7 +1906,7 @@ func TestSendUpgradingHeartbeatBadURL(t *testing.T) {
 // ============================================================
 
 func TestFindContributeHivePrivateURLSkipped(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "private-url", Online: true, IsPublic: true, DashboardURL: "http://10.0.0.1:3001", Owner: "user"},
@@ -1920,7 +1920,7 @@ func TestFindContributeHivePrivateURLSkipped(t *testing.T) {
 }
 
 func TestFindContributeHiveNoOwnerSkipped(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "no-owner", Online: true, IsPublic: true, DashboardURL: "https://example.com", Owner: ""},
@@ -1934,7 +1934,7 @@ func TestFindContributeHiveNoOwnerSkipped(t *testing.T) {
 }
 
 func TestFindContributeHiveOfflineSkipped(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "offline", Online: false, IsPublic: true, DashboardURL: "https://example.com", Owner: "user"},
@@ -1952,7 +1952,7 @@ func TestFindContributeHiveOfflineSkipped(t *testing.T) {
 // ============================================================
 
 func TestHandleMyHivesWithBearerAndCache(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_myhives_test"] = ghTokenCacheEntry{
@@ -1981,7 +1981,7 @@ func TestHandleMyHivesWithBearerAndCache(t *testing.T) {
 // ============================================================
 
 func TestHandleRequestProvisionNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("POST", "/api/saas/request-provision", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -1994,7 +1994,7 @@ func TestHandleRequestProvisionNoAuth(t *testing.T) {
 }
 
 func TestHandleRequestProvisionBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_test"] = ghTokenCacheEntry{
@@ -2020,7 +2020,7 @@ func TestHandleRequestProvisionBadJSON(t *testing.T) {
 }
 
 func TestHandleRequestProvisionMissingFields(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_miss"] = ghTokenCacheEntry{
@@ -2046,7 +2046,7 @@ func TestHandleRequestProvisionMissingFields(t *testing.T) {
 }
 
 func TestHandleRequestProvisionInvalidOrg(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_org"] = ghTokenCacheEntry{
@@ -2072,7 +2072,7 @@ func TestHandleRequestProvisionInvalidOrg(t *testing.T) {
 }
 
 func TestHandleRequestProvisionInvalidRepo(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_repo"] = ghTokenCacheEntry{
@@ -2102,7 +2102,7 @@ func TestHandleRequestProvisionInvalidRepo(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveProvisionNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
@@ -2117,7 +2117,7 @@ func TestHandleApproveProvisionNotFound(t *testing.T) {
 }
 
 func TestHandleDenyProvisionNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", srv.handleDenyProvision)
@@ -2136,7 +2136,7 @@ func TestHandleDenyProvisionNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveAccessNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
@@ -2151,7 +2151,7 @@ func TestHandleApproveAccessNotFound(t *testing.T) {
 }
 
 func TestHandleDenyAccessNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
@@ -2174,7 +2174,7 @@ func TestHandleDenyAccessNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatWithClusterHealth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	payload := HeartbeatPayload{
@@ -2211,7 +2211,7 @@ func TestHandleHeartbeatWithClusterHealth(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatResponseContainsFields(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Set up a latestSHA
@@ -2246,7 +2246,7 @@ func TestHandleHeartbeatResponseContainsFields(t *testing.T) {
 // ============================================================
 
 func TestHandleStatsWithHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{

--- a/src/pkg/hub/hub_coverage_deep_test.go
+++ b/src/pkg/hub/hub_coverage_deep_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,7 +33,7 @@ func TestHandleToggleAutoUpgradeRegistryHiveOwnerMatch(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_toggle_owner", "toggle-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "toggle-reg-hive", Owner: "toggle-owner", Online: true, GitHash: "abc123", GitBranch: "v2"},
@@ -61,7 +60,7 @@ func TestHandleToggleAutoUpgradeRegistryHiveForbidden(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_toggle_nonowner", "not-the-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "forbidden-hive", Owner: "actual-owner", Online: true},
@@ -87,7 +86,7 @@ func TestHandleToggleAutoUpgradeRegistryHiveBadBody(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_toggle_bad", "toggle-owner-bad")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "badbody-hive", Owner: "toggle-owner-bad", Online: true},
@@ -117,7 +116,7 @@ func TestHandleUpgradeHiveForbidden(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_upgrade_notown", "not-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// We can't create a SaaS hive file, so loadSaaSHive returns nil → 404
 	mux := http.NewServeMux()
@@ -142,7 +141,7 @@ func TestHandleToggleVisibilityForbidden(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_vis_notown", "not-vis-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", srv.handleToggleVisibility)
@@ -168,7 +167,7 @@ func TestHandleDeleteHiveWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_del_user", "del-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
@@ -205,7 +204,7 @@ func TestHandleAccessListWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_acl_user", "acl-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/access", srv.handleAccessList)
@@ -224,7 +223,7 @@ func TestHandleAccessAddWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_add_user", "add-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
@@ -245,7 +244,7 @@ func TestHandleAccessRemoveWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_rm_user", "rm-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", srv.handleAccessRemove)
@@ -265,7 +264,7 @@ func TestHandleAccessRemoveWithAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessAddBadBody(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
@@ -290,7 +289,7 @@ func TestHandleRequestAccessWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_reqacc", "req-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
 
@@ -308,7 +307,7 @@ func TestHandleGetRequestsWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_getreq", "getreq-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/requests", srv.handleGetRequests)
 
@@ -326,7 +325,7 @@ func TestHandleApproveRequestWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_approve", "approver")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", srv.handleApproveRequest)
 
@@ -346,7 +345,7 @@ func TestHandleDenyRequestWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_deny", "denier")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", srv.handleDenyRequest)
 
@@ -368,7 +367,7 @@ func TestHandleApproveAccessWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_appracc", "approver-acc")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
 
@@ -386,7 +385,7 @@ func TestHandleDenyAccessWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_denyacc", "denier-acc")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
 
@@ -408,7 +407,7 @@ func TestHandleCreateHiveWithAuthNoUser(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_create_nouser", "create-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("POST", "/create-hive",
 		strings.NewReader(`{"org":"myorg","repos":"repo1","github_token":"ghp_fake123"}`))
@@ -431,7 +430,7 @@ func TestHandleHiveStatusWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_status_user", "status-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -453,7 +452,7 @@ func TestHandleAccessStatusWithUserAndHives(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_accstat_user", "accstat-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -489,7 +488,7 @@ func TestHandleSaaSAuthCheckUserNoAccessFile(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_authcheck_user", "authcheck-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=some-hive", nil)
 	req.Header.Set("Authorization", "Bearer ghp_authcheck_user")
@@ -510,7 +509,7 @@ func TestHandleMyHivesAdminWithBearer(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_admin_my", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -537,7 +536,7 @@ func TestHandleUserTokenSelfRequest(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_usertoken", "token-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"hive_id":"h1","username":"token-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -556,7 +555,7 @@ func TestHandleUserTokenAdminRequestOther(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_admin_token", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"hive_id":"h1","username":"other-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -579,7 +578,7 @@ func TestHandleRequestProvisionValidBody(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_prov_valid", "prov-valid-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// github_host is required: a request must name the GitHub forge its org
 	// lives on, so a "valid body" fixture has to carry one.
@@ -601,7 +600,7 @@ func TestHandleRequestProvisionACMMLevelDefault(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_prov_acmm", "prov-acmm-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Carries github_host AND full_name on purpose: both are required, and
 	// omitting either makes the handler 400 long before the ACMM clamp this
@@ -629,7 +628,7 @@ func TestHandleRequestProvisionACMMLevelHigh(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_prov_high", "prov-high-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// See TestHandleRequestProvisionACMMLevelDefault: github_host and full_name
 	// are required, so a fixture missing them never reaches the clamp.
@@ -655,7 +654,7 @@ func TestHandleApproveProvisionWithAdminAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_approv_admin", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
@@ -674,7 +673,7 @@ func TestHandleDenyProvisionWithAdminAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_deny_admin", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", srv.handleDenyProvision)
@@ -694,7 +693,7 @@ func TestHandleDenyProvisionWithAdminAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleAdminUpdateUserWithAdminAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/admin/users/{username}", srv.handleAdminUpdateUser)
@@ -720,7 +719,7 @@ func TestRequireAuthUserNilAfterEnsure(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_blocked_test", "blocked-test-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -745,7 +744,7 @@ func TestHandleAuthUserKnownButNotInFile(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_authuser_known", "known-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Authorization", "Bearer ghp_authuser_known")
@@ -767,7 +766,7 @@ func TestHandleAuthUserKnownButNotInFile(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Set latest SHA
@@ -798,7 +797,7 @@ func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 }
 
 func TestHandleHeartbeatAutoUpgradeNoUpgradeNeeded(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	latestSHAMu.Lock()
@@ -824,7 +823,7 @@ func TestHandleHeartbeatAutoUpgradeNoUpgradeNeeded(t *testing.T) {
 }
 
 func TestHandleHeartbeatAutoUpgradeEmptyGitHash(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	latestSHAMu.Lock()
@@ -851,7 +850,7 @@ func TestHandleHeartbeatAutoUpgradeEmptyGitHash(t *testing.T) {
 }
 
 func TestHandleHeartbeatDefaultBranch(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// No git_branch → defaults to "v2"

--- a/src/pkg/hub/hub_coverage_extra_test.go
+++ b/src/pkg/hub/hub_coverage_extra_test.go
@@ -148,7 +148,7 @@ func TestConvertHeartbeatToPerClusterHealthNoGPU(t *testing.T) {
 // ============================================================
 
 func TestGetHeartbeatHealthForCluster(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// No data
 	if got := srv.getHeartbeatHealthForCluster("nonexistent"); got != nil {
@@ -191,7 +191,7 @@ func TestGetHeartbeatHealthForCluster(t *testing.T) {
 // ============================================================
 
 func TestHandleClusterHealthNotAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/cluster-health", nil)
 	w := httptest.NewRecorder()
@@ -207,7 +207,7 @@ func TestHandleClusterHealthNotAdmin(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessStatusWithBearerAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Pre-populate cache for bearer auth
 	ghTokenCacheMu.Lock()
@@ -250,7 +250,7 @@ func TestHandleAccessStatusWithBearerAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleCreateHiveNotAuthenticatedDirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("POST", "/test", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -271,7 +271,7 @@ func TestHandleCreateHiveNotAuthenticatedDirect(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleVisibilityCORSHeaders(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /visibility/{id}", srv.handleToggleVisibility)
@@ -288,7 +288,7 @@ func TestHandleToggleVisibilityCORSHeaders(t *testing.T) {
 }
 
 func TestHandleToggleVisibilityUntrustedOrigin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /visibility/{id}", srv.handleToggleVisibility)
@@ -309,7 +309,7 @@ func TestHandleToggleVisibilityUntrustedOrigin(t *testing.T) {
 // ============================================================
 
 func TestHandleUpgradeHiveCORSHeaders(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /upgrade/{id}", srv.handleUpgradeHive)
@@ -329,7 +329,7 @@ func TestHandleUpgradeHiveCORSHeaders(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleAutoUpgradeCORSHeaders(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /auto-upgrade/{id}", srv.handleToggleAutoUpgrade)
@@ -351,7 +351,7 @@ func TestHandleToggleAutoUpgradeCORSHeaders(t *testing.T) {
 
 func TestHandleHubAutoUpgradeValid(t *testing.T) {
 	defer helperSetupTempDirs(t)()
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("PUT", "/hub-auto-upgrade", strings.NewReader(`{"auto_upgrade":false}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -368,7 +368,7 @@ func TestHandleHubAutoUpgradeValid(t *testing.T) {
 
 func TestHandleHubAutoUpgradeEnable(t *testing.T) {
 	defer helperSetupTempDirs(t)()
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("PUT", "/hub-auto-upgrade", strings.NewReader(`{"auto_upgrade":true}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -417,7 +417,7 @@ func TestHandleHubSelfUpgrade(t *testing.T) {
 		latestSHAMu.Unlock()
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("POST", "/hub-self-upgrade", nil)
 	w := httptest.NewRecorder()
@@ -437,7 +437,7 @@ func TestHandleHubSelfUpgrade(t *testing.T) {
 // ============================================================
 
 func TestHandleHiveStatusPathTraversal(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
@@ -456,7 +456,7 @@ func TestHandleHiveStatusPathTraversal(t *testing.T) {
 // ============================================================
 
 func TestHandleDeleteHiveNotOwner(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
@@ -500,7 +500,7 @@ func TestLoadClustersWithTempFile(t *testing.T) {
 // ============================================================
 
 func TestHandleSaaSAuthCheckPublicPathSnapshot(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test", nil)
 	req.Header.Set("X-Original-URI", "/snapshot/something")
@@ -513,7 +513,7 @@ func TestHandleSaaSAuthCheckPublicPathSnapshot(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckPublicPathContribute(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test", nil)
 	req.Header.Set("X-Original-URI", "/contribute/something")
@@ -530,7 +530,7 @@ func TestHandleSaaSAuthCheckPublicPathContribute(t *testing.T) {
 // ============================================================
 
 func TestHandleMyHivesAdminSeesAllHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Pre-populate cache for admin user
 	ghTokenCacheMu.Lock()
@@ -566,7 +566,7 @@ func TestHandleMyHivesAdminSeesAllHives(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveAccessNotAuthorized(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
@@ -582,7 +582,7 @@ func TestHandleApproveAccessNotAuthorized(t *testing.T) {
 }
 
 func TestHandleDenyAccessNotAuthorized(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
@@ -601,7 +601,7 @@ func TestHandleDenyAccessNotAuthorized(t *testing.T) {
 // ============================================================
 
 func TestHandleRequestAccessHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
@@ -620,7 +620,7 @@ func TestHandleRequestAccessHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleGetRequestsHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/requests", srv.handleGetRequests)
@@ -639,7 +639,7 @@ func TestHandleGetRequestsHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveRequestHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", srv.handleApproveRequest)
@@ -659,7 +659,7 @@ func TestHandleApproveRequestHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleDenyRequestHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", srv.handleDenyRequest)
@@ -678,7 +678,7 @@ func TestHandleDenyRequestHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatUpdateExistingWithSparkline(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Pre-populate a hive with sparkline data from 20 minutes ago
@@ -724,7 +724,7 @@ func TestHandleHeartbeatUpdateExistingWithSparkline(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatUpgradeCompleted(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	srv.mu.Lock()
@@ -763,7 +763,7 @@ func TestHandleHeartbeatUpgradeCompleted(t *testing.T) {
 }
 
 func TestHandleHeartbeatUpgradeInProgress(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	srv.mu.Lock()
@@ -806,7 +806,7 @@ func TestHandleHeartbeatUpgradeInProgress(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatResponseAutoUpgrade(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Set up a latestSHA for v2
@@ -849,7 +849,7 @@ func TestHandleHeartbeatResponseAutoUpgrade(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatStoresClusterHealth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	payload := HeartbeatPayload{
@@ -887,7 +887,7 @@ func TestHandleHeartbeatStoresClusterHealth(t *testing.T) {
 // ============================================================
 
 func TestRequestSave(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// Should not panic when called multiple times
 	srv.requestSave()
 	srv.requestSave()
@@ -905,7 +905,7 @@ func TestHandleContributeProxyRejectsPrivateURL(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "contribute-hive", Online: true, IsPublic: true, DashboardURL: upstream.URL, Owner: "user1"},
@@ -928,7 +928,7 @@ func TestHandleContributeProxyRejectsPrivateURL(t *testing.T) {
 // ============================================================
 
 func TestHandleContributeWSProxyNoHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/contribute/ws", nil)
 	w := httptest.NewRecorder()
@@ -944,7 +944,7 @@ func TestHandleContributeWSProxyNoHive(t *testing.T) {
 // ============================================================
 
 func TestHandleUserTokenEmptyBody(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("POST", "/test", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -957,7 +957,7 @@ func TestHandleUserTokenEmptyBody(t *testing.T) {
 }
 
 func TestHandleUserTokenInvalidJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("POST", "/test", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
@@ -974,7 +974,7 @@ func TestHandleUserTokenInvalidJSON(t *testing.T) {
 // ============================================================
 
 func TestHandleRequestProvisionDefaultPrimaryRepo(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_prov_default"] = ghTokenCacheEntry{
@@ -1008,7 +1008,7 @@ func TestHandleRequestProvisionDefaultPrimaryRepo(t *testing.T) {
 // ============================================================
 
 func TestHandleAdminUsersResponse(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/admin-users", nil)
 	w := httptest.NewRecorder()
@@ -1049,7 +1049,7 @@ func TestDecryptTokenWithBadCiphertext(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatTriggersRegistrySave(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	payload := `{"hive_id":"save-trigger-hive"}`
@@ -1069,7 +1069,7 @@ func TestHandleHeartbeatTriggersRegistrySave(t *testing.T) {
 // ============================================================
 
 func TestHandleDashboardRegularBrowserWithCookie(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "user123"})
@@ -1090,7 +1090,7 @@ func TestHandleDashboardRegularBrowserWithCookie(t *testing.T) {
 // ============================================================
 
 func TestHandleOAuthCallbackMissingCodeParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/callback", nil)
 	w := httptest.NewRecorder()
@@ -1106,7 +1106,7 @@ func TestHandleOAuthCallbackMissingCodeParam(t *testing.T) {
 // ============================================================
 
 func TestHandleContributeProxyBadURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Set a hive with an unparseable URL
 	srv.mu.Lock()
@@ -1136,7 +1136,7 @@ func TestHandleProxyHiveConfigUpstreamError(t *testing.T) {
 	hiveConfigSSRFGuard = func(context.Context, string) bool { return false }
 	defer func() { hiveConfigSSRFGuard = orig }()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Ownerless entry: after the F9 fix the unauthenticated test caller cannot
 	// reach the upstream, so the ownership check (403) preempts any proxy fetch.
@@ -1174,7 +1174,7 @@ func TestHandleProxyHiveConfigUpstreamError(t *testing.T) {
 // ============================================================
 
 func TestStartAndShutdown(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// Start in background
 	errCh := make(chan error, 1)
@@ -1196,7 +1196,7 @@ func TestStartAndShutdown(t *testing.T) {
 // ============================================================
 
 func TestTriggerAutoUpgradesNoHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// Should not panic with no hives
 	srv.triggerAutoUpgrades()
 }
@@ -1206,7 +1206,7 @@ func TestTriggerAutoUpgradesNoHives(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatSaaSHivePrefix(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	secret := srv.hubSecret
 
 	// saas- prefix without SaaS entry should be rejected
@@ -1223,7 +1223,7 @@ func TestHandleHeartbeatSaaSHivePrefix(t *testing.T) {
 }
 
 func TestHandleHeartbeatUpgradingFlag(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	payload := `{"hive_id":"upgrading-flag-test","upgrading":true,"upgrade_target_sha":"7a41e01"}`
@@ -1246,7 +1246,7 @@ func TestHandleHeartbeatUpgradingFlag(t *testing.T) {
 }
 
 func TestHandleLeaderboardWithData(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{
@@ -1286,7 +1286,7 @@ func TestGetLatestSHAForBranchNotFound(t *testing.T) {
 }
 
 func TestHandleHeartbeatHiveTypeExplicit(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	payload := `{"hive_id":"explicit-type","hive_type":"custom-type"}`
@@ -1311,7 +1311,7 @@ func TestHandleHeartbeatHiveTypeExplicit(t *testing.T) {
 }
 
 func TestHandleHeartbeatMaxAgents(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Create 60 agents to test the max agents cap (50)
@@ -1346,7 +1346,7 @@ func TestHandleHeartbeatMaxAgents(t *testing.T) {
 }
 
 func TestHandleHeartbeatSnapshotURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// First heartbeat with snapshot

--- a/src/pkg/hub/hub_filesystem_extra_test.go
+++ b/src/pkg/hub/hub_filesystem_extra_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -27,7 +26,7 @@ func TestHandleAccessStatusFullWithFilesystem(t *testing.T) {
 		{Username: "accstatus-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -84,7 +83,7 @@ func TestHandleRequestAccessNoteRequired(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "note-hive", Owner: "someone-else"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
 
@@ -142,7 +141,7 @@ func TestHandleToggleAutoUpgradeWithFilesystem(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "toggle-fs-hive", Owner: "toggle-fs-owner", AutoUpgrade: false})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", srv.handleToggleAutoUpgrade)
 
@@ -186,7 +185,7 @@ func TestHandleMyHivesWithSaaSHivesOnly(t *testing.T) {
 		VanityURL:   vanityURL,
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_saas")
@@ -239,7 +238,7 @@ func TestHandleMyHivesWithErrorHive(t *testing.T) {
 		Error:  "provisioning failed",
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/fleet", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_err")
@@ -278,7 +277,7 @@ func TestHandleMyHivesAdminSeesAll(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "hosted-admin-hive", Owner: "other-owner", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -325,7 +324,7 @@ func TestTriggerAutoUpgradesWithFilesystem(t *testing.T) {
 		latestSHAMu.Unlock()
 	}()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "auto-up-fs", Online: true, GitHash: "old111", GitBranch: "v2"},
@@ -357,7 +356,7 @@ func TestTriggerAutoUpgradesSkipsProvisioning(t *testing.T) {
 		Status:      "provisioning",
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.triggerAutoUpgrades()
 	// Should skip provisioning hives — no crash
 }
@@ -382,7 +381,7 @@ func TestTriggerAutoUpgradesSkipsAlreadyUpgrading(t *testing.T) {
 		latestSHAMu.Unlock()
 	}()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "already-up", Online: true, GitHash: "old1", GitBranch: "v2", Upgrading: true, UpgradeTarget: "target2"},
@@ -413,7 +412,7 @@ func TestTriggerAutoUpgradesSkipsCurrentSHA(t *testing.T) {
 		latestSHAMu.Unlock()
 	}()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "current-sha", Online: true, GitHash: "current", GitBranch: "v2"},
@@ -435,7 +434,7 @@ func TestHandleCreateHiveAppAuth(t *testing.T) {
 	u.SaaSQuota = 5
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"org":"apporg","repos":"repo1","auth_method":"app","app_id":"123","installation_id":"456","app_private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -460,7 +459,7 @@ func TestHandleCreateHiveUnknownCluster(t *testing.T) {
 	u.SaaSQuota = 5
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_fake12345678","cluster_id":"unknown-cluster-xyz"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -485,7 +484,7 @@ func TestHandleCreateHiveNoQuota(t *testing.T) {
 	u.SaaSQuota = 0
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_fake12345678"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -510,7 +509,7 @@ func TestHandleCreateHiveBlockedUser(t *testing.T) {
 	u.Blocked = true
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_fake12345678"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -537,7 +536,7 @@ func TestHandleDeleteHiveWithFilesystemFull(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "del-full-hive", Owner: "del-full-owner", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// Add to registry
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -568,7 +567,7 @@ func TestHandleHiveStatusAccessDenied(t *testing.T) {
 	ensureSaaSUser("noowner")
 	saveSaaSHive(&SaaSHive{ID: "secret-hive", Owner: "real-owner"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -597,7 +596,7 @@ func TestHandleHiveStatusWithAccess(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "acc-hive", Owner: "other-owner", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -617,7 +616,7 @@ func TestHandleAuthUserWithFileUser(t *testing.T) {
 
 	ensureSaaSUser("file-auth-user")
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
 	req.AddCookie(testAuthCookie("file-auth-user"))
@@ -640,7 +639,7 @@ func TestHandleAuthUserAdmin(t *testing.T) {
 
 	ensureSaaSUser(hubAdminUsername)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
 	req.AddCookie(testAuthCookie(hubAdminUsername))
@@ -660,7 +659,7 @@ func TestGetAuthUserWithCookieAndFile(t *testing.T) {
 
 	ensureSaaSUser("cookie-user")
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.AddCookie(testAuthCookie("cookie-user"))

--- a/src/pkg/hub/hub_filesystem_test.go
+++ b/src/pkg/hub/hub_filesystem_test.go
@@ -401,7 +401,7 @@ func TestHandleAdminUpdateUserWithFilesystem(t *testing.T) {
 
 	ensureSaaSUser("target-user")
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/admin/users/{username}", srv.handleAdminUpdateUser)
@@ -433,7 +433,7 @@ func TestHandleAdminUsersWithFilesystem(t *testing.T) {
 	ensureSaaSUser("user-a")
 	ensureSaaSUser("user-b")
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/admin-users", nil)
 	w := httptest.NewRecorder()
@@ -457,7 +457,7 @@ func TestRequireAuthWithFilesystem(t *testing.T) {
 	authCleanup := helperSetupAuthUser(t, "ghp_auth_fs", "fs-auth-user")
 	defer authCleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	var calledWith string
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		calledWith = srv.getAuthUser(r)
@@ -489,7 +489,7 @@ func TestRequireAuthBlockedUserFS(t *testing.T) {
 	authCleanup := helperSetupAuthUser(t, "ghp_blocked_fs", "blocked-user")
 	defer authCleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -529,7 +529,7 @@ func TestHandleMyHivesWithFilesystem(t *testing.T) {
 		AutoUpgrade: true,
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -569,7 +569,7 @@ func TestHandleHiveStatusWithFilesystem(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "status-hive", Owner: "status-user", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -593,7 +593,7 @@ func TestHandleDeleteHiveWithFilesystem(t *testing.T) {
 	ensureSaaSUser("delete-user")
 	saveSaaSHive(&SaaSHive{ID: "del-hive", Owner: "delete-user", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
 
@@ -624,7 +624,7 @@ func TestHandleAccessListWithFilesystem(t *testing.T) {
 	u.Hives["acl-hive"] = "read"
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/access", srv.handleAccessList)
 
@@ -654,7 +654,7 @@ func TestHandleAccessAddWithFilesystem(t *testing.T) {
 	ensureSaaSUser("add-owner")
 	saveSaaSHive(&SaaSHive{ID: "add-hive", Owner: "add-owner"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
 
@@ -686,7 +686,7 @@ func TestHandleAccessAddBadRole(t *testing.T) {
 	ensureSaaSUser("role-owner")
 	saveSaaSHive(&SaaSHive{ID: "role-hive", Owner: "role-owner"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
 
@@ -716,7 +716,7 @@ func TestHandleAccessRemoveWithFilesystem(t *testing.T) {
 	target.Hives["rm-hive"] = "read"
 	saveSaaSUser(target)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", srv.handleAccessRemove)
 
@@ -744,7 +744,7 @@ func TestHandleAccessRemoveLastOwner(t *testing.T) {
 	target.Hives["lastowner-hive"] = "owner"
 	saveSaaSUser(target)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", srv.handleAccessRemove)
 
@@ -768,7 +768,7 @@ func TestHandleRequestAccessWithFilesystem(t *testing.T) {
 	ensureSaaSUser("requesting-user")
 	saveSaaSHive(&SaaSHive{ID: "req-hive-fs", Owner: "someone-else"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
 
@@ -806,7 +806,7 @@ func TestHandleRequestAccessAlreadyHasAccess(t *testing.T) {
 	saveSaaSUser(u)
 	saveSaaSHive(&SaaSHive{ID: "has-hive", Owner: "other"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
 
@@ -841,7 +841,7 @@ func TestHandleGetRequestsWithFilesystem(t *testing.T) {
 		{Username: "req2", RequestedAt: "2024-01-02T00:00:00Z", Status: "approved"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/requests", srv.handleGetRequests)
 
@@ -877,7 +877,7 @@ func TestHandleApproveRequestWithFilesystem(t *testing.T) {
 		{Username: "pending-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", srv.handleApproveRequest)
 
@@ -909,7 +909,7 @@ func TestHandleDenyRequestWithFilesystem(t *testing.T) {
 		{Username: "denied-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", srv.handleDenyRequest)
 
@@ -939,7 +939,7 @@ func TestHandleApproveAccessWithFilesystem(t *testing.T) {
 		{Username: "approved-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
 
@@ -969,7 +969,7 @@ func TestHandleDenyAccessWithFilesystem(t *testing.T) {
 		{Username: "denied-acc-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
 
@@ -990,7 +990,7 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 	authCleanup := helperSetupAuthUser(t, "ghp_reqprov_fs", "reqprov-user")
 	defer authCleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// github_host is required — the forge the org lives on must be captured at
 	// request time, so this end-to-end save fixture carries one.
@@ -1034,7 +1034,7 @@ func TestHandleRequestProvisionClampsAboveOnboardingCeiling(t *testing.T) {
 			authCleanup := helperSetupAuthUser(t, token, username)
 			defer authCleanup()
 
-			srv := NewHubServer(0, slog.Default(), "test", "v2")
+			srv := newHubServerForTest(t)
 
 			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d,"full_name":"Ada Lovelace"}`, requested)
 			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
@@ -1070,7 +1070,7 @@ func TestHandleRequestProvisionAcceptsOnboardingLevels(t *testing.T) {
 			authCleanup := helperSetupAuthUser(t, token, username)
 			defer authCleanup()
 
-			srv := NewHubServer(0, slog.Default(), "test", "v2")
+			srv := newHubServerForTest(t)
 
 			body := fmt.Sprintf(`{"org":"validorg","github_host":"github.com","repos":"repo1","primary_repo":"repo1","acmm_level":%d,"full_name":"Ada Lovelace"}`, requested)
 			req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
@@ -1120,7 +1120,7 @@ func TestHandleApproveProvisionWithFilesystem(t *testing.T) {
 		t.Fatalf("seed placeholder: %v", err)
 	}
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
 
@@ -1176,7 +1176,7 @@ func TestHandleApproveProvisionNoPlaceholderWithFilesystem(t *testing.T) {
 	})
 
 	// No available placeholder seeded -> the admin must be told to provision more.
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
 
@@ -1207,7 +1207,7 @@ func TestHandleAssignHiveWithFilesystem(t *testing.T) {
 		t.Fatalf("seed placeholder: %v", err)
 	}
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// Assign only adopts a vanity URL once the host is actually SERVABLE, and
 	// kubectl does not exist under test, so stub the seam to report success.
 	// Without this the assign correctly declines to adopt an unservable host —
@@ -1284,7 +1284,7 @@ func TestHandleDenyProvisionWithFilesystem(t *testing.T) {
 		Status:   provisionStatusPending,
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", srv.handleDenyProvision)
 
@@ -1327,7 +1327,7 @@ func TestHandleUserTokenWithFilesystem(t *testing.T) {
 	u.EncryptedToken = enc
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"hive_id":"token-hive","username":"token-fs-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -1358,7 +1358,7 @@ func TestHandleUserTokenNoToken(t *testing.T) {
 	u.Hives["token-hive"] = "owner"
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"hive_id":"token-hive","username":"notoken-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -1381,7 +1381,7 @@ func TestHandleUserTokenNoHiveAccess(t *testing.T) {
 
 	ensureSaaSUser("noacc-user")
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"hive_id":"no-access-hive","username":"noacc-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -1406,7 +1406,7 @@ func TestHandleSaaSAuthCheckWithFilesystem(t *testing.T) {
 	u.Hives["check-hive"] = "read"
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=check-hive", nil)
 	req.Header.Set("Authorization", "Bearer ghp_authcheck_fs")
@@ -1443,7 +1443,7 @@ func TestHandleSaaSAuthCheckProxyAuthHeader(t *testing.T) {
 	u.Hives["proxy-hive"] = "admin"
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// The hive must be in the registry with a known cluster so the hub can
 	// resolve its dashboard token in the auth-check handler.
 	srv.registry.Hives = []RegistryEntry{{ID: "proxy-hive", ClusterID: "hive-oke"}}
@@ -1484,7 +1484,7 @@ func TestHandleSaaSAuthCheckNoAccess(t *testing.T) {
 
 	ensureSaaSUser("noauth-user")
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=no-access-hive", nil)
 	req.Header.Set("Authorization", "Bearer ghp_noauth_fs")
@@ -1507,7 +1507,7 @@ func TestHandleCreateHiveWithFilesystem(t *testing.T) {
 	u.SaaSQuota = 5
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_faketoken12345678","project_name":"My Project","acmm_level":2}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -1541,7 +1541,7 @@ func TestHandleCreateHiveQuotaReached(t *testing.T) {
 	// Pre-create a hive owned by this user
 	saveSaaSHive(&SaaSHive{ID: "existing-hive", Owner: "quota-user"})
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_faketoken12345678"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))

--- a/src/pkg/hub/hub_heartbeat_test.go
+++ b/src/pkg/hub/hub_heartbeat_test.go
@@ -325,7 +325,7 @@ func TestSendHeartbeatAutoUpgradeInPayload(t *testing.T) {
 }
 
 func TestHeartbeatNoUpgradeToForHubManagedHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Simulate a heartbeat from a spoke with auto_upgrade=true
@@ -360,7 +360,7 @@ func TestHeartbeatNoUpgradeToForHubManagedHives(t *testing.T) {
 }
 
 func TestHeartbeatUpgradeToForSpokeManaged(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Spoke declares auto_upgrade but no SaaS hive exists on hub

--- a/src/pkg/hub/hub_heartbeat_tokens_test.go
+++ b/src/pkg/hub/hub_heartbeat_tokens_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,7 +12,7 @@ import (
 // (reached via heartbeat, not hub-kubectl) show real token consumption on the
 // My Hives token column.
 func TestHeartbeatStoresTokenTotal(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	const wantTokens = int64(1234567)
@@ -49,7 +48,7 @@ func TestHeartbeatStoresTokenTotal(t *testing.T) {
 // TestHeartbeatTokenTotalClamped verifies the token total is clamped to a sane
 // maximum so a corrupt/hostile spoke cannot inject an absurd value.
 func TestHeartbeatTokenTotalClamped(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	payload := `{

--- a/src/pkg/hub/hub_keys.go
+++ b/src/pkg/hub/hub_keys.go
@@ -603,13 +603,14 @@ func SSOSigningSeedFromMaster(master string) string {
 
 // provisionMasterSecret resolves the hub's MASTER secret at provision time, the
 // same way NewHubServer does: prefer HIVE_HUB_SECRET, else the persisted
-// /data/saas/hub-secret.key. Used ONLY to derive the per-domain sub-keys that get
-// injected into a spoke — the master itself is never placed in the Deployment.
+// hubSecretPath (/data/saas/hub-secret.key in production). Used ONLY to derive
+// the per-domain sub-keys that get injected into a spoke — the master itself is
+// never placed in the Deployment.
 func provisionMasterSecret() string {
 	if s := strings.TrimSpace(os.Getenv("HIVE_HUB_SECRET")); s != "" {
 		return s
 	}
-	if data, err := os.ReadFile("/data/saas/hub-secret.key"); err == nil {
+	if data, err := os.ReadFile(hubSecretPath); err == nil {
 		return strings.TrimSpace(string(data))
 	}
 	return ""

--- a/src/pkg/hub/hub_saas_handlers_test.go
+++ b/src/pkg/hub/hub_saas_handlers_test.go
@@ -3,7 +3,6 @@ package hub
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestHandleLoginRedirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Register OAuth routes manually (won't register without env var)
@@ -32,7 +31,7 @@ func TestHandleLoginRedirect(t *testing.T) {
 }
 
 func TestHandleLoginWithRedirectParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /login-test", srv.handleLogin)
 
@@ -50,7 +49,7 @@ func TestHandleLoginWithRedirectParam(t *testing.T) {
 }
 
 func TestHandleLoginRejectsOpenRedirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /login-redir", srv.handleLogin)
 
@@ -65,7 +64,7 @@ func TestHandleLoginRejectsOpenRedirect(t *testing.T) {
 }
 
 func TestHandleLoginRdParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /login-rd", srv.handleLogin)
 
@@ -79,7 +78,7 @@ func TestHandleLoginRdParam(t *testing.T) {
 }
 
 func TestHandleLogout(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("POST /logout-test", srv.handleLogout)
 
@@ -103,7 +102,7 @@ func TestHandleLogout(t *testing.T) {
 }
 
 func TestHandleAuthUserNoCookie(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /auth-user-test", srv.handleAuthUser)
 
@@ -119,7 +118,7 @@ func TestHandleAuthUserNoCookie(t *testing.T) {
 }
 
 func TestHandleAuthUserEmptyCookie(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /auth-user-empty", srv.handleAuthUser)
 
@@ -136,7 +135,7 @@ func TestHandleAuthUserEmptyCookie(t *testing.T) {
 }
 
 func TestHandleAuthUserUnknownUser(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /auth-user-unknown", srv.handleAuthUser)
 
@@ -153,7 +152,7 @@ func TestHandleAuthUserUnknownUser(t *testing.T) {
 }
 
 func TestHandleAdminUsersAsAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Call handler directly to skip requireAdmin middleware (no /data on macOS)
@@ -173,7 +172,7 @@ func TestHandleAdminUsersAsAdmin(t *testing.T) {
 }
 
 func TestHandleAdminUpdateUserNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Call directly to skip requireAdmin
@@ -190,7 +189,7 @@ func TestHandleAdminUpdateUserNotFound(t *testing.T) {
 }
 
 func TestHandleAdminUpdateUserBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -206,7 +205,7 @@ func TestHandleAdminUpdateUserBadJSON(t *testing.T) {
 }
 
 func TestHandleHiveStatusNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -221,7 +220,7 @@ func TestHandleHiveStatusNotFound(t *testing.T) {
 }
 
 func TestHandleDeleteHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -237,7 +236,7 @@ func TestHandleDeleteHiveNotFound(t *testing.T) {
 }
 
 func TestHandleDeleteHivePathTraversal(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -252,7 +251,7 @@ func TestHandleDeleteHivePathTraversal(t *testing.T) {
 }
 
 func TestHandleUpgradeHiveCORSPreflight(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Register directly to avoid requireAuth for OPTIONS
@@ -272,7 +271,7 @@ func TestHandleUpgradeHiveCORSPreflight(t *testing.T) {
 }
 
 func TestHandleUpgradeHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -288,7 +287,7 @@ func TestHandleUpgradeHiveNotFound(t *testing.T) {
 }
 
 func TestHandleAccessListNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -303,7 +302,7 @@ func TestHandleAccessListNotFound(t *testing.T) {
 }
 
 func TestHandleAccessAddNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -320,7 +319,7 @@ func TestHandleAccessAddNotFound(t *testing.T) {
 }
 
 func TestHandleAccessRemoveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -335,7 +334,7 @@ func TestHandleAccessRemoveNotFound(t *testing.T) {
 }
 
 func TestHandleRequestAccessNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -350,7 +349,7 @@ func TestHandleRequestAccessNotFound(t *testing.T) {
 }
 
 func TestHandleGetRequestsNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -365,7 +364,7 @@ func TestHandleGetRequestsNotFound(t *testing.T) {
 }
 
 func TestHandleApproveRequestNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -381,7 +380,7 @@ func TestHandleApproveRequestNotFound(t *testing.T) {
 }
 
 func TestHandleDenyRequestNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	mux := http.NewServeMux()
@@ -396,7 +395,7 @@ func TestHandleDenyRequestNotFound(t *testing.T) {
 }
 
 func TestHandleCreateHiveNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
@@ -411,7 +410,7 @@ func TestHandleCreateHiveNoAuth(t *testing.T) {
 }
 
 func TestHandleCreateHiveBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Call handler directly to skip requireAuth
@@ -427,7 +426,7 @@ func TestHandleCreateHiveBadJSON(t *testing.T) {
 }
 
 func TestHandleCreateHiveValidation(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	tests := []struct {
@@ -459,7 +458,7 @@ func TestHandleCreateHiveValidation(t *testing.T) {
 }
 
 func TestHandleUserTokenBadBody(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("POST", "/user-token-test", strings.NewReader(`{}`))
@@ -473,7 +472,7 @@ func TestHandleUserTokenBadBody(t *testing.T) {
 }
 
 func TestHandleUserTokenMissingFields(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("POST", "/user-token-test", strings.NewReader(`{"hive_id":"h1"}`))
@@ -487,7 +486,7 @@ func TestHandleUserTokenMissingFields(t *testing.T) {
 }
 
 func TestHandleUserTokenOtherUserForbidden(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	body := `{"hive_id":"h1","username":"otheruser"}`
@@ -503,7 +502,7 @@ func TestHandleUserTokenOtherUserForbidden(t *testing.T) {
 }
 
 func TestHandleUserTokenUserNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// getAuthUser returns "" on macOS, so requester="" != username → 403
@@ -522,7 +521,7 @@ func TestHandleUserTokenUserNotFound(t *testing.T) {
 }
 
 func TestHandleProxyHiveConfigNotInRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/proxy-config-test", nil)
@@ -542,7 +541,7 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 	hiveConfigSSRFGuard = func(context.Context, string) bool { return false }
 	defer func() { hiveConfigSSRFGuard = orig }()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// The upstream must NOT be reached: this registry entry is ownerless, and
@@ -579,7 +578,7 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 }
 
 func TestHandleMyHivesNoAuthDirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/my-hives-test", nil)
@@ -592,7 +591,7 @@ func TestHandleMyHivesNoAuthDirect(t *testing.T) {
 }
 
 func TestHandleMyHivesWithRegistryHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	srv.mu.Lock()
@@ -613,7 +612,7 @@ func TestHandleMyHivesWithRegistryHives(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckNoHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check", nil)
@@ -626,7 +625,7 @@ func TestHandleSaaSAuthCheckNoHive(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckNoAuthWithHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
@@ -639,7 +638,7 @@ func TestHandleSaaSAuthCheckNoAuthWithHive(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckWithUserNoAccess(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
@@ -683,7 +682,7 @@ func TestDecryptTokenTooShort(t *testing.T) {
 }
 
 func TestHandleDashboardUnfurlBotReturnsOG(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
@@ -700,7 +699,7 @@ func TestHandleDashboardUnfurlBotReturnsOG(t *testing.T) {
 }
 
 func TestHandleDashboardNoCookieRedirects(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
@@ -716,7 +715,7 @@ func TestHandleDashboardNoCookieRedirects(t *testing.T) {
 }
 
 func TestHandleDashboardWithCookieReturnsDashboard(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
@@ -733,7 +732,7 @@ func TestHandleDashboardWithCookieReturnsDashboard(t *testing.T) {
 }
 
 func TestRequireAuthBlockedUser(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// On macOS, loadSaaSUser returns nil (no /data/saas/users)
@@ -754,7 +753,7 @@ func TestRequireAuthBlockedUser(t *testing.T) {
 }
 
 func TestHandleOAuthCallbackMissingCode(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 	srv.mux.HandleFunc("GET /callback-test", srv.handleOAuthCallback)
 
@@ -768,7 +767,7 @@ func TestHandleOAuthCallbackMissingCode(t *testing.T) {
 }
 
 func TestHandleOAuthCallbackWithCode(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// With a code present, it tries to exchange with GitHub (ghTokenURL const)
@@ -830,7 +829,7 @@ func TestIsUnfurlBotVariants(t *testing.T) {
 }
 
 func TestValidateGitHubTokenInvalid(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Will try to call GitHub API and fail (no real token)
@@ -849,7 +848,7 @@ func TestSaveAccessRequestsNonexistentDir(t *testing.T) {
 }
 
 func TestValidateGitHubTokenCacheHit(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Pre-populate the cache
@@ -872,7 +871,7 @@ func TestValidateGitHubTokenCacheHit(t *testing.T) {
 }
 
 func TestValidateGitHubTokenCacheExpired(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Pre-populate with expired entry
@@ -896,7 +895,7 @@ func TestValidateGitHubTokenCacheExpired(t *testing.T) {
 }
 
 func TestValidateGitHubTokenEmpty(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	result := srv.validateGitHubToken("")
@@ -906,7 +905,7 @@ func TestValidateGitHubTokenEmpty(t *testing.T) {
 }
 
 func TestGetAuthUserBearer(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Pre-populate cache so Bearer auth works
@@ -967,7 +966,7 @@ func TestOriginTrustBadParse(t *testing.T) {
 func TestRegisterOAuthEnabled(t *testing.T) {
 	t.Setenv("HIVE_HUB_OAUTH_CLIENT_ID", "test-client-id")
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// OAuth routes should be registered, test /login exists
@@ -986,7 +985,7 @@ func TestRegisterOAuthEnabled(t *testing.T) {
 }
 
 func TestHandleOAuthCallbackNoAccessToken(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Code is present but GitHub returns error (invalid code)
@@ -1001,7 +1000,7 @@ func TestHandleOAuthCallbackNoAccessToken(t *testing.T) {
 }
 
 func TestHandleContributeProxyWithLocalHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	// Hive with localhost URL → private URL → rejected by findContributeHive
@@ -1023,7 +1022,7 @@ func TestHandleContributeProxyWithLocalHive(t *testing.T) {
 }
 
 func TestHandleContributeWSProxyWithLocalHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	srv.mu.Lock()
@@ -1058,7 +1057,7 @@ func TestLoadSaaSUserValid(t *testing.T) {
 }
 
 func TestMarkStaleHivesWithOldHeartbeat(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("")
 
 	old := "2020-01-01T00:00:00Z"
@@ -1128,7 +1127,7 @@ func TestIsCSRFSafeGetAlwaysPasses(t *testing.T) {
 // caller is refused even for a public URL.
 func TestHandleProxyHiveConfigSSRFAndOwnership(t *testing.T) {
 	// 1) SSRF guard active (default) → a loopback DashboardURL is rejected 403.
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{{ID: "ssrf-hive", DashboardURL: "http://127.0.0.1:1/x"}}
 	srv.mu.Unlock()
@@ -1165,7 +1164,7 @@ func TestHandleProxyHiveConfigOwnerlessDenied(t *testing.T) {
 	hiveConfigSSRFGuard = func(context.Context, string) bool { return false }
 	defer func() { hiveConfigSSRFGuard = orig }()
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.mu.Lock()
 	// Owner intentionally empty (ownerless), public URL, SSRF disabled.
 	srv.registry.Hives = []RegistryEntry{{ID: "ownerless-hive", DashboardURL: "https://example.com", Owner: ""}}

--- a/src/pkg/hub/hub_test.go
+++ b/src/pkg/hub/hub_test.go
@@ -204,7 +204,7 @@ func TestIsUnfurlBot(t *testing.T) {
 
 func TestNewHubServer(t *testing.T) {
 	logger := slog.Default()
-	srv := NewHubServer(8080, logger, "abc123", "v2")
+	srv := newHubServerForTest(t, withHubPort(8080), withHubLogger(logger), withHubIdentity("abc123", "v2"))
 	if srv == nil {
 		t.Fatal("NewHubServer returned nil")
 	}
@@ -214,7 +214,7 @@ func TestNewHubServer(t *testing.T) {
 }
 
 func TestHandleRegistryEmpty(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/registry", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -224,7 +224,7 @@ func TestHandleRegistryEmpty(t *testing.T) {
 }
 
 func TestHandleHealthCheck(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// The hub doesn't have a /api/health endpoint registered in the mux,
 	// but the registry endpoint should work
 	req := httptest.NewRequest("GET", "/api/registry", nil)
@@ -236,7 +236,7 @@ func TestHandleHealthCheck(t *testing.T) {
 }
 
 func TestHandleHeartbeatNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.setHubSecret("secret123")
 	req := httptest.NewRequest("POST", "/api/heartbeat", nil)
 	w := httptest.NewRecorder()
@@ -254,7 +254,7 @@ func TestDecryptTokenInvalid(t *testing.T) {
 }
 
 func TestHandleRegistryJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/registry", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -268,7 +268,7 @@ func TestHandleRegistryJSON(t *testing.T) {
 }
 
 func TestHandleHeartbeatBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -279,7 +279,7 @@ func TestHandleHeartbeatBadJSON(t *testing.T) {
 }
 
 func TestHandleHubVersion(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "abc123", "v2")
+	srv := newHubServerForTest(t, withHubIdentity("abc123", "v2"))
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -292,7 +292,7 @@ func TestHandleHubVersion(t *testing.T) {
 }
 
 func TestHandleLeaderboard(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/hub/leaderboard", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -302,7 +302,7 @@ func TestHandleLeaderboard(t *testing.T) {
 }
 
 func TestHandleStats(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/hub/stats", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)

--- a/src/pkg/hub/hub_testing_helpers_invariant_test.go
+++ b/src/pkg/hub/hub_testing_helpers_invariant_test.go
@@ -1,0 +1,129 @@
+package hub
+
+// hub_testing_helpers_invariant_test.go pins what newHubServerForTest promises,
+// so a refactor of the helper cannot quietly hand the suite back the shared
+// /data footprint it was written to remove.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hubTestRun records what one helper-built server saw, for inspection AFTER
+// that subtest's cleanups have run.
+type hubTestRun struct {
+	dir      string
+	registry string
+	secret   string
+	srv      *HubServer
+}
+
+// TestNewHubServerForTest_IsolatesEachTest proves the three invariants:
+//
+//  1. consecutive tests get DIFFERENT registry and secret paths, each under
+//     its own TempDir, and the package vars are restored between them;
+//  2. the generated master secret lands at hubSecretPath under that TempDir —
+//     never under /data — and is the secret the server actually holds;
+//  3. once the test's cleanup has run, its save loop has exited (saveLoopDone
+//     is closed) and its TempDir is gone, i.e. the loop was joined BEFORE the
+//     directory was removed rather than left to race it (#4774).
+func TestNewHubServerForTest_IsolatesEachTest(t *testing.T) {
+	prodRegistry, prodSecret := registryPath, hubSecretPath
+	// Snapshot every managed var rather than assuming the production default:
+	// an earlier test in the process may legitimately have left a read-only
+	// var moved, and the helper's contract is "restore what it found", not
+	// "restore production".
+	before := make([]string, len(hubTestPathVars))
+	for i, v := range hubTestPathVars {
+		before[i] = *v.ptr
+	}
+
+	var runs []hubTestRun
+	for _, name := range []string{"first", "second"} {
+		t.Run(name, func(t *testing.T) {
+			// Force the file path: with the env var set NewHubServer would
+			// never touch hubSecretPath and the secret assertions below would
+			// pass vacuously.
+			t.Setenv("HIVE_HUB_SECRET", "")
+
+			srv := newHubServerForTest(t)
+			run := hubTestRun{
+				dir:      filepath.Dir(registryPath),
+				registry: registryPath,
+				secret:   hubSecretPath,
+				srv:      srv,
+			}
+			runs = append(runs, run)
+
+			if srv.registryPath != registryPath {
+				t.Fatalf("server captured registryPath %q but the helper set %q", srv.registryPath, registryPath)
+			}
+			if strings.HasPrefix(registryPath, "/data") || strings.HasPrefix(hubSecretPath, "/data") {
+				t.Fatalf("helper left a production path in place: registry=%q secret=%q", registryPath, hubSecretPath)
+			}
+			if !strings.HasPrefix(hubSecretPath, run.dir+string(os.PathSeparator)) {
+				t.Fatalf("secret %q is not under the per-test dir %q", hubSecretPath, run.dir)
+			}
+			data, err := os.ReadFile(hubSecretPath)
+			if err != nil {
+				t.Fatalf("generated secret was not written under the TempDir: %v", err)
+			}
+			if got := strings.TrimSpace(string(data)); got != srv.hubSecret {
+				t.Fatalf("secret on disk %q != secret the server holds %q", got, srv.hubSecret)
+			}
+		})
+	}
+
+	if registryPath != prodRegistry || hubSecretPath != prodSecret {
+		t.Fatalf("package path vars not restored after cleanup: registry=%q secret=%q", registryPath, hubSecretPath)
+	}
+	for i, v := range hubTestPathVars {
+		if *v.ptr != before[i] {
+			t.Errorf("path var for %q not restored: %q != %q", v.rel, *v.ptr, before[i])
+		}
+	}
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(runs))
+	}
+	if runs[0].registry == runs[1].registry || runs[0].secret == runs[1].secret || runs[0].dir == runs[1].dir {
+		t.Fatalf("consecutive tests shared a path: %+v vs %+v", runs[0], runs[1])
+	}
+	for _, run := range runs {
+		select {
+		case <-run.srv.saveLoopDone:
+		default:
+			t.Errorf("save loop for %q is still running after the test's cleanup — it was not joined", run.dir)
+		}
+		if _, err := os.Stat(run.dir); !os.IsNotExist(err) {
+			t.Errorf("per-test dir %q still exists after cleanup (stat err=%v)", run.dir, err)
+		}
+	}
+}
+
+// TestNewHubServerForTest_RespectsCallerPaths pins the two ways a test keeps
+// control of a path: withRegistryPath for the registry, and moving a read-only
+// var off its production default BEFORE calling the helper for the rest.
+func TestNewHubServerForTest_RespectsCallerPaths(t *testing.T) {
+	own := t.TempDir()
+	pinnedRegistry := filepath.Join(own, "pinned-registry.json")
+	seededClusters := filepath.Join(own, "clusters.json")
+
+	oldClusters := clustersConfigPath
+	clustersConfigPath = seededClusters
+	t.Cleanup(func() { clustersConfigPath = oldClusters })
+
+	srv := newHubServerForTest(t, withRegistryPath(pinnedRegistry))
+	if srv.registryPath != pinnedRegistry || registryPath != pinnedRegistry {
+		t.Fatalf("withRegistryPath not honoured: server=%q var=%q", srv.registryPath, registryPath)
+	}
+	if clustersConfigPath != seededClusters {
+		t.Fatalf("helper overrode a var the test had already moved: %q", clustersConfigPath)
+	}
+	// The secret is a WRITE target, so it must still be per-test even though
+	// the registry was pinned elsewhere.
+	if filepath.Dir(filepath.Dir(hubSecretPath)) == own {
+		t.Fatalf("secret %q landed in the caller's dir instead of the helper's", hubSecretPath)
+	}
+}

--- a/src/pkg/hub/hub_testing_helpers_test.go
+++ b/src/pkg/hub/hub_testing_helpers_test.go
@@ -1,0 +1,198 @@
+package hub
+
+// hub_testing_helpers_test.go — build a REAL HubServer for a test without
+// touching the host's /data and without leaking its save loop.
+//
+// WHY THIS EXISTS. NewHubServer is not a pure constructor. On every call it:
+//
+//   - reads hubSecretPath and, when the file is absent and HIVE_HUB_SECRET is
+//     unset, GENERATES a master secret and WRITES it there (creating the
+//     parent directory);
+//   - reads registryPath, hubBannersPath, hubGenerationsPath,
+//     clustersConfigPath, reachHistoryPath, timelineDir, journeyStatePath,
+//     alertAcksPath and revokedSessionsPath;
+//   - starts the debounced saveLoop goroutine, which writes registryPath.
+//
+// On CI /data does not exist, so every one of those writes fails silently —
+// and that silent failure is the only thing that has kept ~30 test files'
+// servers from sharing one registry file and one secret. On a hive host (the
+// agents run this suite inside the pod) the writes SUCCEED against the real
+// /data, and a save loop nobody stopped wakes up registrySaveDelay after its
+// test returned and recreates files inside a t.TempDir the framework is
+// already removing — the intermittent "TempDir RemoveAll cleanup: directory
+// not empty" failure fixed for one file by #4774 and reintroduced by every
+// file that never adopted StopSaveLoop.
+//
+// WHY PER-TEST, NOT ONE SHARED TempDir IN TestMain. Pointing the package path
+// vars at a single suite-wide directory would make the writes succeed
+// everywhere, which is strictly WORSE than today: test A's server would
+// persist its registry, test B's NewHubServer would load it, and B would
+// inherit A's hives, banners and (via hubSecretPath) A's master secret. The
+// failing /data writes are currently doing the isolation work by accident; a
+// shared directory removes the accident without replacing the isolation. The
+// unit of isolation has to be the test, so this helper gives each caller its
+// own t.TempDir, redirects the path vars only for that test's lifetime, and
+// joins the save loop before the directory is removed.
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+)
+
+// hubTestIsolationEnv is a marker variable set through t.Setenv purely so the
+// testing package refuses t.Parallel for us: t.Setenv panics if the test is
+// already parallel, and t.Parallel panics if t.Setenv was called first. Nothing
+// reads the variable. The package path vars are process-global, so two tests
+// swapping them concurrently would each construct against the other's
+// directory — there is no correct parallel behaviour, only a loud refusal.
+const hubTestIsolationEnv = "HIVE_HUB_TEST_ISOLATED"
+
+// Defaults NewHubServer callers in this package have used since the first
+// handler test; kept as the helper's defaults so a mechanical migration from
+// `NewHubServer(0, slog.Default(), "test", "v2")` changes no assertion.
+const (
+	hubTestDefaultGitHash   = "test"
+	hubTestDefaultGitBranch = "v2"
+)
+
+// hubTestPathVar describes one package-level path var that NewHubServer reads
+// on construction, and where under the per-test directory it should point.
+type hubTestPathVar struct {
+	ptr *string
+	// prod is the production default, captured at package init before any
+	// test can have moved the var.
+	prod string
+	// rel is the location under the per-test directory, mirroring the /data
+	// layout so a test that inspects the directory sees familiar names.
+	rel string
+	// always redirects the var even when a test has already moved it off its
+	// production default. True only for the two paths NewHubServer WRITES on
+	// construction (the secret) or from its save loop (the registry): those
+	// must be per-test no matter what, and a test that wants a specific
+	// registry file says so through withRegistryPath. The read-only ones stay
+	// wherever the test put them, because seeding a file at a redirected path
+	// BEFORE constructing the server is exactly how tests exercise the load
+	// paths (see pull_only_cluster_test.go's clustersConfigPath).
+	always bool
+}
+
+// hubTestPathVars is every package path var a plain NewHubServer touches.
+// Order is irrelevant; the save/restore below is keyed by index.
+var hubTestPathVars = []hubTestPathVar{
+	{ptr: &registryPath, prod: registryPath, rel: "hub-registry.json", always: true},
+	{ptr: &hubSecretPath, prod: hubSecretPath, rel: filepath.Join("saas", "hub-secret.key"), always: true},
+	{ptr: &hubBannersPath, prod: hubBannersPath, rel: filepath.Join("saas", "hub-banners.json")},
+	{ptr: &hubGenerationsPath, prod: hubGenerationsPath, rel: filepath.Join("saas", "hub-generations.json")},
+	{ptr: &clustersConfigPath, prod: clustersConfigPath, rel: filepath.Join("saas", "clusters.json")},
+	{ptr: &reachHistoryPath, prod: reachHistoryPath, rel: "reach-history.json"},
+	{ptr: &timelineDir, prod: timelineDir, rel: filepath.Join("saas", "timeline")},
+	{ptr: &journeyStatePath, prod: journeyStatePath, rel: filepath.Join("saas", "journey-state.json")},
+	{ptr: &alertAcksPath, prod: alertAcksPath, rel: filepath.Join("saas", "hub-alert-acks.json")},
+	{ptr: &revokedSessionsPath, prod: revokedSessionsPath, rel: filepath.Join("saas", "hub-revoked-sessions.json")},
+}
+
+// hubTestConfig is the resolved set of NewHubServer arguments plus the one
+// path a test may legitimately want to pin.
+type hubTestConfig struct {
+	port         int
+	logger       *slog.Logger
+	gitHash      string
+	gitBranch    string
+	registryPath string
+}
+
+// hubTestOption customises newHubServerForTest. Every option corresponds to
+// something a pre-existing NewHubServer call site varied, so no migration had
+// to change what a test asserts.
+type hubTestOption func(*hubTestConfig)
+
+// withHubIdentity sets the gitHash / gitBranch passed to NewHubServer. Note
+// NewHubServer itself rewrites an empty or "unknown" branch to "v2".
+func withHubIdentity(gitHash, gitBranch string) hubTestOption {
+	return func(c *hubTestConfig) {
+		c.gitHash = gitHash
+		c.gitBranch = gitBranch
+	}
+}
+
+// withHubLogger replaces the default slog.Default() logger.
+func withHubLogger(logger *slog.Logger) hubTestOption {
+	return func(c *hubTestConfig) { c.logger = logger }
+}
+
+// withHubPort sets the port passed to NewHubServer (the helper never listens).
+func withHubPort(port int) hubTestOption {
+	return func(c *hubTestConfig) { c.port = port }
+}
+
+// withRegistryPath pins registryPath for the duration of the test instead of
+// the helper's per-test file. For tests that seed or inspect the registry
+// file at a path they chose.
+func withRegistryPath(path string) hubTestOption {
+	return func(c *hubTestConfig) { c.registryPath = path }
+}
+
+// newHubServerForTest constructs a HubServer whose on-disk footprint lives
+// entirely under a fresh t.TempDir and whose save loop is joined before that
+// directory is removed.
+//
+// It must not be used from a parallel test (see hubTestIsolationEnv). It may
+// be called more than once per test — each call gets its own directory — and
+// from a subtest, because the restore is last-in-first-out and the subtest's
+// cleanup runs before its parent's.
+//
+// Cleanup ORDER is the whole point and testing.T runs cleanups in reverse
+// registration order, so read the body bottom-up:
+//
+//  1. t.TempDir registers RemoveAll first, so it runs LAST;
+//  2. the path-var restore is registered second;
+//  3. s.StopSaveLoop is registered last, so it runs FIRST — the loop has
+//     flushed and exited before the vars go back and before the directory
+//     disappears (#4774).
+func newHubServerForTest(t *testing.T, opts ...hubTestOption) *HubServer {
+	t.Helper()
+	t.Setenv(hubTestIsolationEnv, "1")
+
+	dir := t.TempDir()
+
+	cfg := hubTestConfig{
+		logger:    slog.Default(),
+		gitHash:   hubTestDefaultGitHash,
+		gitBranch: hubTestDefaultGitBranch,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Restore ONLY what this call changed. A var the test moved itself is the
+	// test's to restore, and it may do so with a plain defer — which runs
+	// BEFORE t.Cleanup — so re-writing the value we found here would leak the
+	// test's redirect into every test that follows.
+	saved := make([]string, len(hubTestPathVars))
+	changed := make([]bool, len(hubTestPathVars))
+	for i, v := range hubTestPathVars {
+		if !v.always && *v.ptr != v.prod {
+			// The test moved this one deliberately; leave its seeded file
+			// reachable.
+			continue
+		}
+		saved[i] = *v.ptr
+		changed[i] = true
+		*v.ptr = filepath.Join(dir, v.rel)
+	}
+	if cfg.registryPath != "" {
+		registryPath = cfg.registryPath
+	}
+	t.Cleanup(func() {
+		for i, v := range hubTestPathVars {
+			if changed[i] {
+				*v.ptr = saved[i]
+			}
+		}
+	})
+
+	s := NewHubServer(cfg.port, cfg.logger, cfg.gitHash, cfg.gitBranch)
+	t.Cleanup(s.StopSaveLoop)
+	return s
+}

--- a/src/pkg/hub/hub_version_diagnostics_test.go
+++ b/src/pkg/hub/hub_version_diagnostics_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -98,7 +97,7 @@ func TestHubVersionDistinguishesBuildingFromWedgedPoller(t *testing.T) {
 			defer resetSHACaches(t)
 			seedSHACaches(tc.spoke, tc.hub, tc.head, tc.status)
 
-			srv := NewHubServer(0, slog.Default(), tc.hub, "v2")
+			srv := newHubServerForTest(t, withHubIdentity(tc.hub, "v2"))
 			got := getHubVersion(t, srv)
 
 			if got.ImageStatuses["v2"] != tc.wantStatus {
@@ -132,7 +131,7 @@ func TestHubVersionUpgradeStateUsesHubCacheNotSpokeCache(t *testing.T) {
 	// Hub image is at c6ec89d (what the hub runs); spoke image lags at f2b4719.
 	seedSHACaches("f2b4719", "c6ec89d", "c6ec89d", imageStatusBuilding)
 
-	srv := NewHubServer(0, slog.Default(), "c6ec89d", "v2")
+	srv := newHubServerForTest(t, withHubIdentity("c6ec89d", "v2"))
 	got := getHubVersion(t, srv)
 
 	if got.UpgradeState != "current" {
@@ -153,7 +152,7 @@ func TestHubVersionEmptyHeadSHAsSignalsPollerNotRunning(t *testing.T) {
 	// Only the persisted spoke cache is warm (as after loadPersistedSHAs).
 	seedSHACaches("f2b4719", "", "", "")
 
-	srv := NewHubServer(0, slog.Default(), "f2b4719", "v2")
+	srv := newHubServerForTest(t, withHubIdentity("f2b4719", "v2"))
 	got := getHubVersion(t, srv)
 
 	if _, ok := got.HeadSHAs["v2"]; ok {

--- a/src/pkg/hub/main_test.go
+++ b/src/pkg/hub/main_test.go
@@ -46,6 +46,27 @@ func TestMain(m *testing.M) {
 	// non-InCluster branch, so neutralize it to a path that cannot exist.
 	os.Setenv("KUBECONFIG", os.DevNull)
 
+	// Provider and forge credentials. The suite is run inside hive pods and on
+	// developer machines whose environment carries REAL keys, and handlers
+	// under test (GitHub token validation, model probes, the gh wrapper paths)
+	// read these straight from os.Getenv. A test that forgets to stub one
+	// would silently exercise a live provider on the operator's credit — the
+	// #4889-class leak — instead of failing offline. Tests that need a value
+	// set it explicitly with t.Setenv. HIVE_HUB_SECRET is scrubbed for the
+	// same reason: with it unset, NewHubServer resolves the master through
+	// hubSecretPath, which newHubServerForTest points into a per-test TempDir,
+	// rather than inheriting whatever master the host process was given.
+	for _, key := range []string{
+		"OPENAI_API_KEY",
+		"CODEX_API_KEY",
+		"ANTHROPIC_API_KEY",
+		"GITHUB_TOKEN",
+		"GH_TOKEN",
+		"HIVE_HUB_SECRET",
+	} {
+		os.Unsetenv(key)
+	}
+
 	// Commit-order ancestry resolves are kicked as BACKGROUND goroutines from
 	// the heartbeat completion chain, the orphan sweep and triggerAutoUpgrades
 	// (commitAtOrAheadOfTarget). Any test that crosses those paths with an

--- a/src/pkg/hub/migrate_removed_test.go
+++ b/src/pkg/hub/migrate_removed_test.go
@@ -16,7 +16,7 @@ import (
 // ran (2xx, or the 400/403/409 the old handler used to return).
 func TestMigrateRouteIsGone(t *testing.T) {
 	t.Cleanup(helperSetupTempDirs(t))
-	srv := NewHubServer(0, discardLogger(), "test", "v2")
+	srv := newHubServerForTest(t, withHubLogger(discardLogger()))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/saas/hives/hosted-x/migrate",
 		strings.NewReader(`{"target_cluster_id":"c2"}`))

--- a/src/pkg/hub/perhive_env_unreachable_test.go
+++ b/src/pkg/hub/perhive_env_unreachable_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"log/slog"
 	"testing"
 	"time"
 )
@@ -154,7 +153,7 @@ func TestSafeToRetirePreviousBlocksOnUnreachableSpokes(t *testing.T) {
 // This is the test that fails if someone reverts the noteUnreachable calls and
 // restores the bare `continue`.
 func TestPullOnlyClusterHivesCountAsUnreachable(t *testing.T) {
-	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s := newHubServerForTest(t)
 	s.clusters = map[string]ClusterConfig{
 		"vllm-d": {ID: "vllm-d", PullOnly: true, KubeconfigPath: "/etc/hive/kubeconfigs/vllm-d.yaml", Domain: "d"},
 	}

--- a/src/pkg/hub/placeholder_health_test.go
+++ b/src/pkg/hub/placeholder_health_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -401,7 +400,7 @@ func TestMyHivesPlaceholderRowShipsGreenHealth(t *testing.T) {
 	defer cleanup()
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s := newHubServerForTest(t)
 	s.mu.Lock()
 	s.registry.Hives = []RegistryEntry{
 		{

--- a/src/pkg/hub/provision_context_test.go
+++ b/src/pkg/hub/provision_context_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -259,7 +258,7 @@ func TestProvisionRequestUserIDRenderingPinned(t *testing.T) {
 // only ever reach the hub admin. A non-admin (or anonymous) caller hitting an
 // admin route gets a 4xx and no body at all.
 func TestPastRequestsContextStaysAdminOnly(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// Stand-in for any handler that would serve enriched provision requests.
 	handler := srv.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/src/pkg/hub/pull_only_cluster_test.go
+++ b/src/pkg/hub/pull_only_cluster_test.go
@@ -129,7 +129,7 @@ func TestKubectlNeverFallsBackToAmbientClusterForPullOnly(t *testing.T) {
 // the hub never pays the dial timeout that made a pool of hives serialise into
 // tens of minutes of blocking.
 func TestPullOnlyClusterCountsAsUnreachableWithoutDialing(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.clusters = map[string]ClusterConfig{
 		"a-ks-wec2": {ID: "a-ks-wec2", PullOnly: true, Domain: "wec2.example.cloud"},
 		"hive-oke":  {ID: "hive-oke", InCluster: true, Domain: "hive.kubestellar.io"},
@@ -162,7 +162,7 @@ func TestPullOnlyClusterHealthUsesHeartbeat(t *testing.T) {
 // live: vanity repair for an a-ks-wec2 hive ran kubectl against hive-oke and
 // reported "no ingress found" for a namespace on another cluster.
 func TestPullOnlyVanityHostIsNotSilentlyAttempted(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	called := false
 	srv.vanityHostServable = func(hiveID, vanityHost string, cluster *ClusterConfig) error {
 		called = true

--- a/src/pkg/hub/reach_api_test.go
+++ b/src/pkg/hub/reach_api_test.go
@@ -65,7 +65,7 @@ func (f *fakeReachAncestry) IsAncestor(ancestor, descendant string) (bool, error
 // would reach handleReach and answer 200 with reach data, so every assertion
 // below fails (verified by mutating the registration during development).
 func TestReachEndpointRequiresAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	// Data IS available — the gate, not a missing dependency, must refuse.
 	mergedAt := time.Now().Add(-48 * time.Hour)
 	srv.reachPRSource = &fakeReachPRSource{prs: map[int]reach.PRInfo{
@@ -106,7 +106,7 @@ func TestReachEndpointRequiresAdmin(t *testing.T) {
 // TestHandleReachNoSource: with no GitHub PR source wired (hub without
 // credentials), the handler reports 503 — never fabricated data.
 func TestHandleReachNoSource(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/reach", nil)
 	w := httptest.NewRecorder()
 	srv.handleReach(w, req)
@@ -117,7 +117,7 @@ func TestHandleReachNoSource(t *testing.T) {
 
 // TestHandleReachBadParams: malformed queries are 400s, not upstream calls.
 func TestHandleReachBadParams(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.reachPRSource = &fakeReachPRSource{err: errors.New("must not be called")}
 	for _, q := range []string{"?pr=abc", "?pr=-1", "?recent=0", "?recent=99999", "?recent=x"} {
 		req := httptest.NewRequest("GET", "/api/reach"+q, nil)
@@ -136,7 +136,7 @@ func TestHandleReachSinglePR(t *testing.T) {
 	mergedAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
 	firstRun := mergedAt.Add(90 * time.Minute)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.reachPRSource = &fakeReachPRSource{prs: map[int]reach.PRInfo{
 		3994: {
 			Number:      3994,
@@ -276,7 +276,7 @@ func TestHandleReachErrorDeltas(t *testing.T) {
 	mergedAt := time.Now().UTC().Add(-4 * time.Hour)
 	firstRun := mergedAt.Add(30 * time.Minute)
 
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.reachPRSource = &fakeReachPRSource{prs: map[int]reach.PRInfo{
 		3995: {
 			Number:      3995,

--- a/src/pkg/hub/reach_diag_wiring_test.go
+++ b/src/pkg/hub/reach_diag_wiring_test.go
@@ -18,7 +18,7 @@ import (
 // prevalence question; the snapshot, log line, and HTTP surface must all
 // agree with buildAdvisoryDiagnostics over the live registry.
 func TestAdvisoryDiagnosticsEndpoint(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "h-fresh", Online: true, AdvisoryLastPostedAt: now.Add(-10 * time.Minute).UTC().Format(time.RFC3339)},
@@ -59,7 +59,7 @@ func TestAdvisoryDiagnosticsEndpoint(t *testing.T) {
 // Under `go test` the diagnostics ticker must refuse to start (it would leak
 // a goroutine logging every 30 minutes into unrelated tests).
 func TestStartAdvisoryDiagnosticsNoopInTests(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	done := make(chan struct{})
 	go func() {
 		srv.StartAdvisoryDiagnostics(t.Context())
@@ -75,7 +75,7 @@ func TestStartAdvisoryDiagnosticsNoopInTests(t *testing.T) {
 // RegistryReachReporter is the producer→consumer wiring of the reach epic:
 // it must snapshot only well-formed entries and skip hives without reports.
 func TestRegistryReachReporterLatestReach(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "h-good", ComponentReach: &tracing.ReachReport{Entries: []tracing.ReachEntry{
 			{Component: "hub", Commit: "abc1234", SpansTotal: 10, SpansError: 1,
@@ -100,7 +100,7 @@ func TestRegistryReachReporterLatestReach(t *testing.T) {
 }
 
 func TestSetReachWiring(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// nil reporter must keep the stub (fail-safe default), non-nil replaces it.
 	before := srv.reachReporter

--- a/src/pkg/hub/request_contact_fields_test.go
+++ b/src/pkg/hub/request_contact_fields_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
@@ -43,7 +42,7 @@ func helperContactRequestBody(t *testing.T, fullName, slackID string) string {
 func TestRequestProvisionRequiresName(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	authAsForgeTester(t, "ghp_contact_noname", "contact-noname-user")
 
 	for _, name := range []string{"", "   ", "\t\n"} {
@@ -63,7 +62,7 @@ func TestRequestProvisionRequiresName(t *testing.T) {
 func TestRequestProvisionSlackIDIsOptional(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	const user = "contact-noslack-user"
 	authAsForgeTester(t, "ghp_contact_noslack", user)
 
@@ -89,7 +88,7 @@ func TestRequestProvisionSlackIDIsOptional(t *testing.T) {
 func TestRequestProvisionPersistsContactFields(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	const user = "contact-persist-user"
 	authAsForgeTester(t, "ghp_contact_persist", user)
 
@@ -113,7 +112,7 @@ func TestRequestProvisionPersistsContactFields(t *testing.T) {
 func TestRequestProvisionPersistsFriendlyUserID(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	const user = "ibmid:650001ABCD"
 	if err := saveSaaSUser(&SaaSUser{
 		GitHubUsername:    user,
@@ -151,7 +150,7 @@ func TestRequestProvisionPersistsFriendlyUserID(t *testing.T) {
 func TestRequestProvisionCapsContactFields(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	const user = "contact-cap-user"
 	authAsForgeTester(t, "ghp_contact_cap", user)
 
@@ -194,7 +193,7 @@ func TestRequestProvisionStoresHostileNameVerbatim(t *testing.T) {
 		t.Run(tc.user, func(t *testing.T) {
 			cleanup := helperSetupTempDirs(t)
 			defer cleanup()
-			srv := NewHubServer(0, slog.Default(), "test", "v2")
+			srv := newHubServerForTest(t)
 			authAsForgeTester(t, tc.token, tc.user)
 
 			w := postProvisionRequest(t, srv, tc.token, helperContactRequestBody(t, tc.name, ""))

--- a/src/pkg/hub/request_forge_required_test.go
+++ b/src/pkg/hub/request_forge_required_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -115,7 +114,7 @@ func postProvisionRequest(t *testing.T, srv *HubServer, token, body string) *htt
 // Client-side validation is not enforcement — a curl or a stale page bypasses
 // it entirely.
 func TestRequestProvisionRejectsMissingForge(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	authAsForgeTester(t, "ghp_forge_missing", "forge-missing-user")
 
 	w := postProvisionRequest(t, srv, "ghp_forge_missing", `{"org":"z-innersource","repos":"repo1,repo2"}`)
@@ -130,7 +129,7 @@ func TestRequestProvisionRejectsMissingForge(t *testing.T) {
 // TestRequestProvisionRejectsGarbageForge — a non-empty but nonsensical forge
 // is no better than a missing one.
 func TestRequestProvisionRejectsGarbageForge(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	authAsForgeTester(t, "ghp_forge_garbage", "forge-garbage-user")
 
 	w := postProvisionRequest(t, srv, "ghp_forge_garbage",
@@ -161,7 +160,7 @@ func TestRequestProvisionAcceptsAllForgeForms(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		srv := NewHubServer(0, slog.Default(), "test", "v2")
+		srv := newHubServerForTest(t)
 		// A fresh username per case: the handler refuses a second pending
 		// request from the same user.
 		user := "forge-form-user-" + string(rune('a'+i))

--- a/src/pkg/hub/saas_bulk_test.go
+++ b/src/pkg/hub/saas_bulk_test.go
@@ -18,7 +18,7 @@ func bulkTestHub(t *testing.T) *HubServer {
 	cleanup := helperSetupTempDirs(t)
 	t.Cleanup(cleanup)
 	// NewHubServer -> registerSaaSRoutes already wires the bulk route.
-	return NewHubServer(0, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), "test", "v2")
+	return newHubServerForTest(t, withHubLogger(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))))
 }
 
 // bulkSeedHive writes a hosted hive owned by owner into the temp SaaS store,

--- a/src/pkg/hub/saas_user_contact_test.go
+++ b/src/pkg/hub/saas_user_contact_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -44,7 +43,7 @@ func TestAdminUpdateUserContactAuthorization(t *testing.T) {
 	// requireAdmin resolves the cookie through loadSaaSUser, so the admin needs a
 	// real record on disk for an authenticated admin request to be possible.
 	ensureSaaSUser(hubAdminUsername)
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := contactUpdateHandler(srv)
 
 	tests := []struct {
@@ -97,7 +96,7 @@ func TestAdminUpdateUserContactFieldCaps(t *testing.T) {
 	// requireAdmin resolves the cookie through loadSaaSUser, so the admin needs a
 	// real record on disk for an authenticated admin request to be possible.
 	ensureSaaSUser(hubAdminUsername)
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := contactUpdateHandler(srv)
 
 	tests := []struct {
@@ -168,7 +167,7 @@ func TestAdminUpdateUserContactPreservesOtherFields(t *testing.T) {
 	// requireAdmin resolves the cookie through loadSaaSUser, so the admin needs a
 	// real record on disk for an authenticated admin request to be possible.
 	ensureSaaSUser(hubAdminUsername)
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	handler := contactUpdateHandler(srv)
 
 	seed := func(t *testing.T) {

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -47,6 +47,16 @@ var registryPath = "/data/hub-registry.json"
 // banner). A var (not a const) so tests can redirect it at a temp file.
 var hubBannersPath = "/data/saas/hub-banners.json"
 
+// hubSecretPath is the on-disk file holding the hub's MASTER secret when
+// HIVE_HUB_SECRET is unset: NewHubServer reads it, and generates + writes it
+// when absent; provisionMasterSecret (hub_keys.go) reads it at provision time.
+// A var (not a const) for the same reason as registryPath: NewHubServer
+// touches this path UNCONDITIONALLY on construction, so every test that builds
+// a real server would otherwise read — or worse, create — /data/saas on the
+// host running the suite. newHubServerForTest points it into a per-test
+// t.TempDir. Production never reassigns it.
+var hubSecretPath = "/data/saas/hub-secret.key"
+
 // hubBannerMaxAge bounds how long a persisted banner is honored after it was
 // sent. On load, entries older than this are dropped so a long-forgotten banner
 // does not resurrect across an upgrade months later. Admins still clear banners
@@ -1308,7 +1318,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	}
 	secret := os.Getenv("HIVE_HUB_SECRET")
 	if secret == "" {
-		if data, err := os.ReadFile("/data/saas/hub-secret.key"); err == nil {
+		if data, err := os.ReadFile(hubSecretPath); err == nil {
 			secret = strings.TrimSpace(string(data))
 		}
 	}
@@ -1318,11 +1328,11 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		cryptoRand.Read(b)
 		secret = fmt.Sprintf("%x", b)
 		// Best-effort: a failed mkdir surfaces via the WriteFile error below.
-		_ = os.MkdirAll("/data/saas", 0o755)
-		if err := os.WriteFile("/data/saas/hub-secret.key", []byte(secret), 0o600); err != nil {
+		_ = os.MkdirAll(filepath.Dir(hubSecretPath), 0o755)
+		if err := os.WriteFile(hubSecretPath, []byte(secret), 0o600); err != nil {
 			logger.Error("failed to write hub secret", "error", err)
 		}
-		logger.Info("generated hub secret", "path", "/data/saas/hub-secret.key")
+		logger.Info("generated hub secret", "path", hubSecretPath)
 	}
 	s := &HubServer{
 		mux:          http.NewServeMux(),

--- a/src/pkg/hub/server_handlers_coverage_test.go
+++ b/src/pkg/hub/server_handlers_coverage_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -30,7 +29,7 @@ const f24TestHiveID = "hive-f24"
 // TestHeartbeatBearerOK_LegacyRawSecret and _DerivedKey. Both tokens the deleted
 // acceptor honoured must now be refused.
 func TestF24_FleetWideHeartbeatBearerIsRejected(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	// POSITIVE CONTROL FIRST: prove the per-hive bearer DOES verify, so that a
 	// verifier which rejected everything could not pass this test. Without this
@@ -61,7 +60,7 @@ func TestF24_FleetWideHeartbeatBearerIsRejected(t *testing.T) {
 // bearer must not authenticate hive B. A fleet-wide lane of any shape breaks
 // this, so it guards the invariant rather than one deleted function.
 func TestF24_PerHiveBearerDoesNotCrossHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	keyA := srv.heartbeatKeyFor("hive-a")
 	keyB := srv.heartbeatKeyFor("hive-b")
@@ -94,7 +93,7 @@ func TestF24_PerHiveBearerDoesNotCrossHives(t *testing.T) {
 // over every live generation; a fleet-wide lane re-added to ANY generation would
 // be invisible to a single-generation test.
 func TestF24_CrossHiveRejectedUnderEveryLiveGeneration(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	if srv.keyGenerations == nil {
 		t.Fatal("precondition: no generation set on a default hub server")
 	}
@@ -134,7 +133,7 @@ func TestF24_CrossHiveRejectedUnderEveryLiveGeneration(t *testing.T) {
 // verifyHeartbeatBearer takes the token itself, so the header-parsing cases
 // become token-shaped and the empty-hiveID fail-closed case is added.
 func TestF24_MalformedAndEmptyBearersRejected(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	valid := srv.heartbeatKeyFor(f24TestHiveID)
 	if valid == "" {
 		t.Fatal("precondition: heartbeatKeyFor returned empty")
@@ -190,7 +189,7 @@ func TestF24_NoFleetWideHeartbeatLaneInSource(t *testing.T) {
 // --- storePendingGitHubAppConfig / consumePendingGitHubAppConfig tests ---
 
 func TestPendingGitHubAppConfig_StoreAndConsume(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	cfg := &HeartbeatGitHubAppConfig{AppID: 42, InstallationID: 99}
 
 	srv.storePendingGitHubAppConfig("hive-1", cfg)
@@ -210,14 +209,14 @@ func TestPendingGitHubAppConfig_StoreAndConsume(t *testing.T) {
 }
 
 func TestPendingGitHubAppConfig_ConsumeNonExistent(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	if got := srv.consumePendingGitHubAppConfig("no-such-hive"); got != nil {
 		t.Errorf("consume on empty map returned %v, want nil", got)
 	}
 }
 
 func TestPendingGitHubAppConfig_OverwritesPrevious(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.storePendingGitHubAppConfig("hive-1", &HeartbeatGitHubAppConfig{AppID: 1})
 	srv.storePendingGitHubAppConfig("hive-1", &HeartbeatGitHubAppConfig{AppID: 2})
 
@@ -230,7 +229,7 @@ func TestPendingGitHubAppConfig_OverwritesPrevious(t *testing.T) {
 // --- handleLeaderboard tests ---
 
 func TestHandleLeaderboard_EmptyRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/leaderboard", nil)
 	w := httptest.NewRecorder()
 
@@ -254,7 +253,7 @@ func TestHandleLeaderboard_EmptyRegistry(t *testing.T) {
 }
 
 func TestHandleLeaderboard_WithEntries(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.registry.Hives = []RegistryEntry{
 		{
 			ID:       "hive-1",
@@ -296,7 +295,7 @@ func TestHandleLeaderboard_WithEntries(t *testing.T) {
 }
 
 func TestHandleLeaderboard_PrivateHivesExcluded(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.registry.Hives = []RegistryEntry{
 		{
 			ID:       "priv",
@@ -325,7 +324,7 @@ func TestHandleLeaderboard_PrivateHivesExcluded(t *testing.T) {
 // --- handleStats tests ---
 
 func TestHandleStats_EmptyRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/stats", nil)
 	w := httptest.NewRecorder()
 	srv.handleStats(w, req)
@@ -359,7 +358,7 @@ func TestHandleStats_EmptyRegistry(t *testing.T) {
 }
 
 func TestHandleStats_OnlyCountsPublicHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "pub1", IsPublic: true, Online: true, AgentCount: 3, ActiveContributors: 2, ActionableIssues: 5, ActionablePRs: 4},
 		{ID: "priv1", IsPublic: false, Online: true, AgentCount: 10, ActiveContributors: 10, ActionableIssues: 10, ActionablePRs: 10},
@@ -398,7 +397,7 @@ func TestHandleStats_OnlyCountsPublicHives(t *testing.T) {
 // --- handleTaskStatus tests ---
 
 func TestHandleTaskStatus_Unauthorized(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"hive_id":"hive-1","leaderboard":[],"contributors":{"registered":0,"active":0}}`
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(body))
@@ -412,7 +411,7 @@ func TestHandleTaskStatus_Unauthorized(t *testing.T) {
 }
 
 func TestHandleTaskStatus_ValidPayload(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "hive-1", Name: "TestHive", Online: true},
 	}
@@ -443,7 +442,7 @@ func TestHandleTaskStatus_ValidPayload(t *testing.T) {
 }
 
 func TestHandleTaskStatus_OfflineHiveRejected(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "hive-1", Name: "TestHive", Online: false},
 	}
@@ -463,7 +462,7 @@ func TestHandleTaskStatus_OfflineHiveRejected(t *testing.T) {
 }
 
 func TestHandleTaskStatus_InvalidJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("not json"))
 	// Post-F2 task-status auth is fail-closed AND identity-bound: it accepts ONLY
@@ -479,7 +478,7 @@ func TestHandleTaskStatus_InvalidJSON(t *testing.T) {
 }
 
 func TestHandleTaskStatus_EmptyHiveID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 
 	body := `{"hive_id":"","leaderboard":[],"contributors":{}}`
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(body))
@@ -503,7 +502,7 @@ func TestHandleTaskStatus_EmptyHiveID(t *testing.T) {
 // with a positive control so a handler that rejected everything cannot pass.
 func TestHandleTaskStatus_AcceptsPerHiveKeyOnly(t *testing.T) {
 	newSrv := func() *HubServer {
-		s := NewHubServer(0, slog.Default(), "test", "v2")
+		s := newHubServerForTest(t)
 		s.registry.Hives = []RegistryEntry{{ID: "hive-1", Name: "TestHive", Online: true}}
 		return s
 	}
@@ -538,7 +537,7 @@ func TestHandleTaskStatus_AcceptsPerHiveKeyOnly(t *testing.T) {
 // --- regPath tests ---
 
 func TestRegPath_ReturnsNonEmpty(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	p := srv.regPath()
 	if p == "" {
 		t.Error("regPath() returned empty string")

--- a/src/pkg/hub/sso_authcheck_test.go
+++ b/src/pkg/hub/sso_authcheck_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +51,7 @@ func TestAuthCheck_SSOHandoffBypassesGate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			srv := NewHubServer(0, slog.Default(), "test", "v2")
+			srv := newHubServerForTest(t)
 			req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 			req.Header.Set("X-Original-URI", tc.originalURI)
 			w := httptest.NewRecorder()
@@ -70,7 +69,7 @@ func TestAuthCheck_SSOHandoffBypassesGate(t *testing.T) {
 // a public-path bypass. If the /sso bypass leaked the hive's dashboard token,
 // anyone could fetch it by hitting the auth-check with X-Original-URI=/sso.
 func TestAuthCheck_SSOBypassSetsNoProxyProof(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv := newHubServerForTest(t)
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 	req.Header.Set("X-Original-URI", ssoHandoffPath)
 	w := httptest.NewRecorder()

--- a/src/pkg/hub/user_country_admin_assign_test.go
+++ b/src/pkg/hub/user_country_admin_assign_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,7 +34,7 @@ func adminAssignHub(t *testing.T) *HubServer {
 	cleanup := helperSetupTempDirs(t)
 	t.Cleanup(cleanup)
 	ensureSaaSUser(hubAdminUsername)
-	return NewHubServer(0, slog.Default(), "test", "v2")
+	return newHubServerForTest(t)
 }
 
 // adminPut issues the admin edit through the REAL requireAdmin wrapper and the

--- a/src/pkg/hub/whoami_sso_test.go
+++ b/src/pkg/hub/whoami_sso_test.go
@@ -2,7 +2,6 @@ package hub
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -139,7 +138,7 @@ func TestWhoamiUnauthenticated(t *testing.T) {
 func TestWhoamiIsGETOnly(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := NewHubServer(0, slog.Default(), "", "")
+	s := newHubServerForTest(t, withHubIdentity("", ""))
 	req := httptest.NewRequest(http.MethodPost, "https://hive.kubestellar.io/api/saas/whoami", nil)
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)


### PR DESCRIPTION
## Summary

`NewHubServer` is not a pure constructor. On every call it reads `/data/saas/hub-secret.key` and, when absent, generates and writes a master secret there; reads nine other `/data` paths (`registryPath`, `hubBannersPath`, `hubGenerationsPath`, `clustersConfigPath`, `reachHistoryPath`, `timelineDir`, `journeyStatePath`, `alertAcksPath`, `revokedSessionsPath`); and starts the debounced registry save loop. Only ~6 of ~33 test files that construct a server ever called `StopSaveLoop` (#4774). On CI the `/data` writes fail silently; on a hive host, where agents run this suite inside the pod, they hit the real `/data` and the unjoined save loop races `t.TempDir` cleanup.

This PR is test infrastructure only. No CHANGELOG entry.

## The seam

`hubSecretPath` is a new package var (default unchanged: `/data/saas/hub-secret.key`) used by `NewHubServer` (server.go) and `provisionMasterSecret` (hub_keys.go), with `os.MkdirAll(filepath.Dir(hubSecretPath))` instead of a hardcoded `/data/saas`. Production never reassigns it. This is the same convention as `registryPath`, `alertAcksPath`, `journeyStatePath`, etc.

## Why per-test isolation, not one shared TempDir in TestMain

Pointing the path vars at a single suite-wide directory would make every `/data` write succeed, which is strictly worse than today: test A's server would persist its registry, test B's `NewHubServer` would load it, and B would inherit A's hives, banners and, via `hubSecretPath`, A's master secret. The failing `/data` writes are currently doing the isolation work by accident. So the unit of isolation is the test:

`newHubServerForTest(t *testing.T, opts ...hubTestOption) *HubServer` (new `hub_testing_helpers_test.go`):

- takes a fresh `t.TempDir()` per call (a test may call it more than once, and from subtests: restore is LIFO);
- redirects `registryPath` and `hubSecretPath` unconditionally (the two paths `NewHubServer` or its save loop WRITE), and the eight read-only construction-time vars only when they still sit at their production default, so a test that seeds a file at its own redirected path before constructing keeps working (e.g. `pull_only_cluster_test.go` and `clustersConfigPath`, `helperSetupTempDirs` and `reachHistoryPath`);
- restores only the vars it changed, in `t.Cleanup`, so a test that restored its own var via a plain `defer` (which runs before Cleanup) is not re-leaked;
- registers `t.Cleanup(s.StopSaveLoop)` last, so it runs first: the loop is flushed and joined before the vars go back and before the directory is removed;
- refuses `t.Parallel` by calling `t.Setenv` on a marker variable: the testing package panics if a test is already parallel, or if it later calls `t.Parallel`. The path vars are process-global, so there is no correct concurrent behaviour, only a loud refusal.

Options mirror what existing call sites varied: `withHubIdentity(hash, branch)`, `withHubLogger`, `withHubPort`, `withRegistryPath`. Defaults are `0, slog.Default(), "test", "v2"`, so the migration is mechanical and no assertion changed.

`TestMain` now also scrubs `OPENAI_API_KEY`, `CODEX_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `GH_TOKEN` and `HIVE_HUB_SECRET` (the #4889 class of leak came from real env). Tests that need a value already set it with `t.Setenv`; with `HIVE_HUB_SECRET` unset the secret is resolved through `hubSecretPath`, i.e. the per-test file.

## Invariant tests (`hub_testing_helpers_invariant_test.go`)

- `TestNewHubServerForTest_IsolatesEachTest`: two consecutive subtests get different registry, secret and directory paths; the generated secret is written under the TempDir (never `/data`) and equals `srv.hubSecret`; after each subtest's cleanup, `saveLoopDone` is closed and the directory is gone; all managed vars are restored to what the helper found.
- `TestNewHubServerForTest_RespectsCallerPaths`: `withRegistryPath` is honoured, a pre-moved read-only var is left alone, and the secret still lands in the helper's own dir.

## Migrated (29 files, 344 call sites)

assign_forge_identity_test.go, fleet_route_test.go, hive_namespace_overlay_test.go, hover_timeline_relay_test.go, hub_coverage_boost_test.go, hub_coverage_deep_test.go, hub_coverage_extra_test.go, hub_filesystem_extra_test.go, hub_filesystem_test.go, hub_heartbeat_test.go, hub_heartbeat_tokens_test.go, hub_saas_handlers_test.go, hub_test.go, hub_version_diagnostics_test.go, migrate_removed_test.go, perhive_env_unreachable_test.go, placeholder_health_test.go, provision_context_test.go, pull_only_cluster_test.go, reach_api_test.go, reach_diag_wiring_test.go, request_contact_fields_test.go, request_forge_required_test.go, saas_bulk_test.go, saas_user_contact_test.go, server_handlers_coverage_test.go, sso_authcheck_test.go, user_country_admin_assign_test.go, whoami_sso_test.go.

Unused `log/slog` imports were dropped from 19 of them. Existing `srv.Shutdown(...)` calls in two files remain; `StopSaveLoop` is idempotent.

## Left as-is (deliberately)

- `delete_hive_registry_test.go`, `heartbeat_visibility_preserve_test.go`, `save_loop_join_test.go`, `upgrade_recovery_test.go`: each already sets its own `registryPath` and calls `StopSaveLoop`/`Shutdown`; `save_loop_join_test.go` is the #4774 regression pin and must keep constructing directly.
- `newTestHubServer` (task_status_stats_test.go) and `testHubServer` (slack_send_coverage_test.go) build bare `&HubServer{}` literals, never call `NewHubServer`, and start no loop; out of scope.

## Validation

No local build/test (CI is the gate). `gofmt -l` clean on every touched file; every migrated call site sits in a function or closure with `t *testing.T` in scope; no migrated file calls `t.Parallel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FL9uphzhyBKfEXvNCmPV1D
