### PR TITLE
🧪 test: add internal/testutil.Eventually and a time.Sleep ratchet for unit tests

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -83,7 +83,7 @@ jobs:
         id: cover
         continue-on-error: true
         run: |
-          go test ./pkg/... ./cmd/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s \
+          go test ./pkg/... ./cmd/... ./internal/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s \
             2>&1 | tee race-run.log
           exit "${PIPESTATUS[0]}"
 
@@ -181,7 +181,7 @@ jobs:
           # Both were therefore incapable of failing the gate, so adding a
           # package with zero tests was the one guaranteed way to stay green.
           # They are now hard failures in their own right.
-          go test -cover ./pkg/... ./cmd/... -short -count=1 -timeout 600s 2>&1 | tee cover-run.log || true
+          go test -cover ./pkg/... ./cmd/... ./internal/... -short -count=1 -timeout 600s 2>&1 | tee cover-run.log || true
 
           # Floor-map key for a package import path: cmd packages are keyed
           # with a "cmd/" prefix so cmd/hivectl can never resolve to

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -268,7 +268,10 @@ jobs:
           # Anchored: drops exactly pkg/hub and exactly pkg/agent — the sliced
           # jobs run those two bare package paths. A subpackage of either
           # would land here, never nowhere. pkg/hubbackup et al. stay here.
-          go list ./pkg/... ./cmd/... \
+          # ./internal/... carries the shared test helpers (internal/testutil)
+          # and their contract tests, such as the time.Sleep ratchet in
+          # sleep_ratchet_test.go.
+          go list ./pkg/... ./cmd/... ./internal/... \
             | grep -Ev '^github\.com/kubestellar/hive/pkg/hub$' \
             | grep -Ev '^github\.com/kubestellar/hive/pkg/agent$' \
             | LC_ALL=C sort > rest-pkgs.txt

--- a/src/internal/testutil/eventually.go
+++ b/src/internal/testutil/eventually.go
@@ -1,0 +1,77 @@
+// Package testutil holds helpers shared by the unit tests under pkg/ and cmd/.
+// It is test-support code only: nothing under internal/testutil is imported by
+// a production package.
+package testutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// pollInterval is how often Eventually re-evaluates its condition. Short
+// enough that a condition which becomes true quickly is observed within a few
+// milliseconds; long enough not to burn a core while waiting.
+const pollInterval = 10 * time.Millisecond
+
+// Eventually polls cond until it returns true or timeout elapses. On the
+// deadline it fails the test via t.Fatalf with msg (a printf format) and args.
+//
+// Use Eventually instead of a fixed time.Sleep whenever a test is waiting for
+// something OBSERVABLE to happen — a goroutine to bump a counter, a file to
+// appear, a connection to register — and then asserts on it. A fixed sleep is
+// a timing margin: it always waits the full duration on a fast machine and is
+// still too short on a loaded CI runner (that is the flake). Eventually waits
+// exactly as long as needed, up to the timeout, which can therefore be
+// generous without costing wall clock on the happy path.
+//
+// Eventually is NOT the right tool when:
+//
+//   - the test proves that something does NOT happen ("no second reload after
+//     the debounce window"). A negative wait must span the whole window; keep
+//     the sleep and say so in a comment.
+//   - the code under test sleeps or ticks on its own clock and the test cares
+//     about event ORDER, not wall time. Wrap the body in testing/synctest.Test
+//     (Go 1.25): inside the bubble time.Sleep and timers are virtual,
+//     synctest.Wait blocks until every goroutine in the bubble is durably
+//     blocked, and the whole thing completes in microseconds with no polling.
+//     synctest needs the code under test to be bubble-friendly (no real I/O or
+//     exec on goroutines started inside the bubble, no comparisons against a
+//     wall-clock captured outside it), so it is a refactor rather than a
+//     drop-in; reach for it when a test's only dependency on time is the
+//     code's own timers.
+//   - a goroutine you started signals completion. Close a channel or use a
+//     sync.WaitGroup; polling for a signal you can receive directly is
+//     strictly worse.
+func Eventually(t testing.TB, timeout time.Duration, cond func() bool, msg string, args ...any) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s (condition not met within %s)", fmt.Sprintf(msg, args...), timeout)
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+// EventuallyValue polls get until it reports ok and returns the value it
+// produced, failing the test via t.Fatalf on timeout exactly like Eventually.
+// Use it when the test needs the observed value for a subsequent assertion
+// (a snapshot pulled out from under a mutex, the entry that finally appeared)
+// rather than just the fact that it appeared.
+func EventuallyValue[T any](t testing.TB, timeout time.Duration, get func() (T, bool), msg string, args ...any) T {
+	t.Helper()
+	var got T
+	Eventually(t, timeout, func() bool {
+		v, ok := get()
+		if ok {
+			got = v
+		}
+		return ok
+	}, msg, args...)
+	return got
+}

--- a/src/internal/testutil/eventually_test.go
+++ b/src/internal/testutil/eventually_test.go
@@ -1,0 +1,91 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// recordingTB is a testing.TB double that records Fatalf instead of aborting
+// the goroutine, so the negative case can observe the deadline failure without
+// failing the real test. Embedding the interface satisfies testing.TB's
+// unexported method; only Helper and Fatalf are reached by Eventually, so the
+// nil embedded value is never dereferenced.
+type recordingTB struct {
+	testing.TB
+	helperCalls int
+	failed      bool
+	fatal       string
+}
+
+func (r *recordingTB) Helper() { r.helperCalls++ }
+
+func (r *recordingTB) Fatalf(format string, args ...any) {
+	r.failed = true
+	r.fatal = fmt.Sprintf(format, args...)
+}
+
+func TestEventually_ReturnsOnceConditionHolds(t *testing.T) {
+	const trueOnCall = 3
+	var calls atomic.Int32
+	start := time.Now()
+	Eventually(t, 5*time.Second, func() bool {
+		return calls.Add(1) >= trueOnCall
+	}, "counter never reached %d", trueOnCall)
+	if got := calls.Load(); got != trueOnCall {
+		t.Fatalf("cond called %d times, want exactly %d (must stop polling once true)", got, trueOnCall)
+	}
+	// Two polls' worth of waiting is far below the 5s timeout: Eventually must
+	// not sit out its full budget once the condition is satisfied.
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Eventually took %s after the condition held; expected ~%s", elapsed, 2*pollInterval)
+	}
+}
+
+func TestEventually_FailsWithMessageOnDeadline(t *testing.T) {
+	rec := &recordingTB{}
+	const timeout = 30 * time.Millisecond
+	start := time.Now()
+	Eventually(rec, timeout, func() bool { return false }, "widget %d never became %s", 42, "ready")
+
+	if !rec.failed {
+		t.Fatal("Eventually did not call Fatalf on deadline")
+	}
+	if rec.helperCalls == 0 {
+		t.Error("Eventually did not call t.Helper()")
+	}
+	for _, want := range []string{"widget 42 never became ready", timeout.String()} {
+		if !strings.Contains(rec.fatal, want) {
+			t.Errorf("Fatalf message %q does not contain %q", rec.fatal, want)
+		}
+	}
+	if elapsed := time.Since(start); elapsed < timeout {
+		t.Errorf("Eventually gave up after %s, before the %s timeout", elapsed, timeout)
+	}
+}
+
+func TestEventuallyValue_ReturnsObservedValue(t *testing.T) {
+	var calls atomic.Int32
+	got := EventuallyValue(t, 5*time.Second, func() (string, bool) {
+		if calls.Add(1) < 2 {
+			return "", false
+		}
+		return "arrived", true
+	}, "value never produced")
+	if got != "arrived" {
+		t.Fatalf("EventuallyValue = %q, want %q", got, "arrived")
+	}
+}
+
+func TestEventuallyValue_ZeroValueAndFailureOnDeadline(t *testing.T) {
+	rec := &recordingTB{}
+	got := EventuallyValue(rec, 20*time.Millisecond, func() (int, bool) { return 7, false }, "no value")
+	if !rec.failed {
+		t.Fatal("EventuallyValue did not call Fatalf on deadline")
+	}
+	if got != 0 {
+		t.Fatalf("EventuallyValue returned %d on failure, want the zero value", got)
+	}
+}

--- a/src/internal/testutil/sleep_ratchet_test.go
+++ b/src/internal/testutil/sleep_ratchet_test.go
@@ -1,0 +1,117 @@
+package testutil
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// sleepBaseline is the number of `time.Sleep(` occurrences in *_test.go files
+// under src/pkg and src/cmd at the commit that introduced this ratchet
+// (measured with the same substring count TestSleepRatchet uses, so comments
+// count too — exactly like `grep -o 'time\.Sleep(' | wc -l`).
+//
+// It is a ratchet, not a target: the count may go DOWN freely — lower this
+// constant when you remove sleeps so the ratchet keeps biting — but it must
+// never go UP. A new wait in a test should be testutil.Eventually (or a
+// channel / WaitGroup when a goroutine you own can signal directly); a fixed
+// sleep is only acceptable for a deliberate "nothing happens during this
+// window" negative wait, and that still needs a comment saying so.
+const sleepBaseline = 198
+
+// sleepCall is the literal the ratchet counts. Kept as a constant so the
+// message and the count cannot drift apart.
+const sleepCall = "time.Sleep("
+
+// sleepRatchetRoots are the trees the ratchet walks, relative to this
+// package's directory (src/internal/testutil). src/test is the integration
+// suite, which is not part of the PR gate and is deliberately excluded.
+var sleepRatchetRoots = []string{
+	filepath.Join("..", "..", "pkg"),
+	filepath.Join("..", "..", "cmd"),
+}
+
+// TestSleepRatchet fails when the number of time.Sleep calls in the unit-test
+// trees exceeds sleepBaseline. Fixed sleeps are timing margins: they add wall
+// clock to every PR-gate run and are still the first thing to flake on a
+// loaded runner (9 of 21 flaky-test tickets before this ratchet were exactly
+// that). Runs in well under a second: it is a file walk and a substring count.
+func TestSleepRatchet(t *testing.T) {
+	perFile := map[string]int{}
+	total, files := 0, 0
+	for _, root := range sleepRatchetRoots {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(d.Name(), "_test.go") {
+				return nil
+			}
+			files++
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if n := strings.Count(string(data), sleepCall); n > 0 {
+				perFile[filepath.ToSlash(path)] = n
+				total += n
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+	// Fail closed: a walk that saw no test files at all means the ratchet is
+	// running from the wrong directory and would otherwise pass vacuously.
+	if files == 0 {
+		t.Fatalf("no _test.go files found under %v — is the test running from src/internal/testutil?", sleepRatchetRoots)
+	}
+
+	switch {
+	case total > sleepBaseline:
+		t.Fatalf("%d %q calls in *_test.go under %v, above the baseline of %d.\n"+
+			"Do not add fixed sleeps to tests: wait on the observable condition with "+
+			"testutil.Eventually (or close a channel / sync.WaitGroup when the goroutine is yours). "+
+			"If the sleep is a deliberate negative wait, keep it, comment why, and remove another "+
+			"sleep so the total does not grow.\n%s",
+			total, sleepCall, sleepRatchetRoots, sleepBaseline, topSleepFiles(perFile))
+	case total < sleepBaseline:
+		t.Logf("%d %q calls, below the baseline of %d — lower sleepBaseline in "+
+			"internal/testutil/sleep_ratchet_test.go to %d so the ratchet keeps biting",
+			total, sleepCall, sleepBaseline, total)
+	}
+}
+
+// topSleepFiles renders the files with the most sleeps, most first, so the
+// failure message points at where to look rather than just at a number.
+func topSleepFiles(perFile map[string]int) string {
+	const show = 10
+	type entry struct {
+		path string
+		n    int
+	}
+	entries := make([]entry, 0, len(perFile))
+	for p, n := range perFile {
+		entries = append(entries, entry{p, n})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].n != entries[j].n {
+			return entries[i].n > entries[j].n
+		}
+		return entries[i].path < entries[j].path
+	})
+	if len(entries) > show {
+		entries = entries[:show]
+	}
+	var b strings.Builder
+	b.WriteString("files with the most sleeps:\n")
+	for _, e := range entries {
+		fmt.Fprintf(&b, "  %3d  %s\n", e.n, e.path)
+	}
+	return b.String()
+}

--- a/src/pkg/dashboard/contribute_ws_credential_accept_test.go
+++ b/src/pkg/dashboard/contribute_ws_credential_accept_test.go
@@ -35,6 +35,7 @@ import (
 func wsPipe(t *testing.T) (server *websocket.Conn, client *websocket.Conn) {
 	t.Helper()
 	connReady := make(chan struct{})
+	handlerDone := make(chan struct{})
 	upgrader := websocket.Upgrader{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c, err := upgrader.Upgrade(w, r, nil)
@@ -44,10 +45,12 @@ func wsPipe(t *testing.T) (server *websocket.Conn, client *websocket.Conn) {
 		}
 		server = c
 		close(connReady)
-		// Keep the handler alive so the conn stays open for the reads below.
-		time.Sleep(3 * time.Second)
+		// Keep the handler alive until the test is done with the conn; released
+		// by the cleanup below (LIFO: runs before srv.Close) rather than a timer.
+		<-handlerDone
 	}))
 	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(handlerDone) })
 
 	c, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
 	if err != nil {

--- a/src/pkg/dashboard/contribute_ws_maybe_refresh_test.go
+++ b/src/pkg/dashboard/contribute_ws_maybe_refresh_test.go
@@ -41,6 +41,7 @@ func refreshConn(ws *websocket.Conn, mintedAt time.Time) *ContributorConnection 
 func wsPair(t *testing.T) (serverConn, clientConn *websocket.Conn) {
 	t.Helper()
 	connReady := make(chan struct{})
+	handlerDone := make(chan struct{})
 	upgrader := websocket.Upgrader{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c, err := upgrader.Upgrade(w, r, nil)
@@ -50,10 +51,12 @@ func wsPair(t *testing.T) (serverConn, clientConn *websocket.Conn) {
 		}
 		serverConn = c
 		close(connReady)
-		// Keep the handler alive so the conn stays open for the test body.
-		time.Sleep(2 * time.Second)
+		// Keep the handler alive until the test is done with the conn; released
+		// by the cleanup below (LIFO: runs before srv.Close) rather than a timer.
+		<-handlerDone
 	}))
 	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(handlerDone) })
 
 	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
 	if err != nil {

--- a/src/pkg/dashboard/contribute_ws_token_refresh_test.go
+++ b/src/pkg/dashboard/contribute_ws_token_refresh_test.go
@@ -140,6 +140,7 @@ func TestSendTokenRefreshShape(t *testing.T) {
 	// client can read back and inspect.
 	var serverConn *websocket.Conn
 	connReady := make(chan struct{})
+	handlerDone := make(chan struct{})
 	upgrader := websocket.Upgrader{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c, err := upgrader.Upgrade(w, r, nil)
@@ -149,10 +150,12 @@ func TestSendTokenRefreshShape(t *testing.T) {
 		}
 		serverConn = c
 		close(connReady)
-		// Keep the handler alive so the conn stays open for the read below.
-		time.Sleep(2 * time.Second)
+		// Keep the handler alive until the test body is done with the conn;
+		// released by the deferred close below rather than a fixed timer.
+		<-handlerDone
 	}))
 	defer srv.Close()
+	defer close(handlerDone)
 
 	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
 	if err != nil {
@@ -226,6 +229,7 @@ func TestResumeTaskTokenReArmsRefresh(t *testing.T) {
 	// Real websocket pair so resumeTaskToken -> sendTokenRefresh writes a frame.
 	var serverConn *websocket.Conn
 	connReady := make(chan struct{})
+	handlerDone := make(chan struct{})
 	upgrader := websocket.Upgrader{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c, err := upgrader.Upgrade(w, r, nil)
@@ -235,9 +239,12 @@ func TestResumeTaskTokenReArmsRefresh(t *testing.T) {
 		}
 		serverConn = c
 		close(connReady)
-		time.Sleep(2 * time.Second)
+		// Keep the handler alive until the test body is done with the conn;
+		// released by the deferred close below rather than a fixed timer.
+		<-handlerDone
 	}))
 	defer srv.Close()
+	defer close(handlerDone)
 
 	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
 	if err != nil {

--- a/src/pkg/discord/bot_test.go
+++ b/src/pkg/discord/bot_test.go
@@ -14,6 +14,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // redirectTransport rewrites every outgoing request so that requests targeting
@@ -803,6 +805,7 @@ func TestPollLoop_TickerBranch(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
@@ -812,8 +815,12 @@ func TestPollLoop_TickerBranch(t *testing.T) {
 	// Start drainLoop so enqueued replies are sent via HTTP.
 	go b.drainLoop(ctx)
 
-	// Wait for two ticks (pollIntervalS=5s each) so the second fetch is routed.
-	time.Sleep(10500 * time.Millisecond)
+	// Wait for two ticks (pollIntervalS=5s each) so the second fetch is routed
+	// and its reply has gone out over HTTP, bounded at three ticks instead of a
+	// fixed margin past the second one.
+	testutil.Eventually(t, 3*pollIntervalS*time.Second, func() bool {
+		return fetchCount.Load() >= 2 && sendCount.Load() > 0
+	}, "expected two ticker fetches and a routed !ping reply")
 	cancel()
 
 	select {
@@ -847,6 +854,7 @@ func TestPollLoop_TickerBranch_FetchError(t *testing.T) {
 
 	b := newTestBot(ts, "ch")
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
@@ -854,7 +862,11 @@ func TestPollLoop_TickerBranch_FetchError(t *testing.T) {
 		b.pollLoop(ctx)
 	}()
 
-	time.Sleep(5500 * time.Millisecond)
+	// One ticker fetch (pollIntervalS=5s) is enough; bounded at two ticks
+	// instead of a fixed margin past the first.
+	testutil.Eventually(t, 2*pollIntervalS*time.Second, func() bool {
+		return fetchCount.Load() > 0
+	}, "expected a ticker fetch attempt")
 	cancel()
 
 	select {
@@ -980,6 +992,7 @@ func TestPollLoop_TickerSuccessPath(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
@@ -989,8 +1002,12 @@ func TestPollLoop_TickerSuccessPath(t *testing.T) {
 	// Start drainLoop so enqueued replies are sent via HTTP.
 	go b.drainLoop(ctx)
 
-	// Wait for two ticks (pollIntervalS=5s each) so the second fetch is routed.
-	time.Sleep(10500 * time.Millisecond)
+	// Wait for two ticks (pollIntervalS=5s each) so the second fetch is routed
+	// and its reply has gone out over HTTP, bounded at three ticks instead of a
+	// fixed margin past the second one.
+	testutil.Eventually(t, 3*pollIntervalS*time.Second, func() bool {
+		return fetchCount.Load() >= 2 && sendCount.Load() > 0
+	}, "expected two ticker fetches and a routed !ping reply")
 	cancel()
 
 	select {
@@ -1023,6 +1040,7 @@ func TestPollLoop_TickerFetchErrorPath(t *testing.T) {
 
 	b := newTestBot(ts, "ch")
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
@@ -1030,7 +1048,11 @@ func TestPollLoop_TickerFetchErrorPath(t *testing.T) {
 		b.pollLoop(ctx)
 	}()
 
-	time.Sleep(5100 * time.Millisecond)
+	// One ticker fetch (pollIntervalS=5s) is enough; bounded at two ticks
+	// instead of a fixed margin past the first.
+	testutil.Eventually(t, 2*pollIntervalS*time.Second, func() bool {
+		return fetchAttempts.Load() > 0
+	}, "expected a ticker fetch attempt")
 	cancel()
 
 	select {

--- a/src/pkg/hub/hub_heartbeat_test.go
+++ b/src/pkg/hub/hub_heartbeat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -146,11 +147,14 @@ func TestStartTaskStatusPushNilPayload(t *testing.T) {
 }
 
 func TestStartHeartbeatWithCancel(t *testing.T) {
+	firstBeat := make(chan struct{})
+	var firstBeatOnce sync.Once
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/health" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+		firstBeatOnce.Do(func() { close(firstBeat) })
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -166,8 +170,13 @@ func TestStartHeartbeatWithCancel(t *testing.T) {
 		close(done)
 	}()
 
-	// Cancel early
-	time.Sleep(500 * time.Millisecond)
+	// Cancel early: as soon as the loop has sent its first heartbeat, or after
+	// the original 500ms margin, whichever comes first. The assertion below is
+	// only that the loop stops on cancel, so this never fails on its own.
+	select {
+	case <-firstBeat:
+	case <-time.After(500 * time.Millisecond):
+	}
 	cancel()
 
 	select {

--- a/src/pkg/proxy/proxy_deep8_test.go
+++ b/src/pkg/proxy/proxy_deep8_test.go
@@ -163,7 +163,9 @@ func TestHandleTransparentTLSNonGitHubWithTCPServer(t *testing.T) {
 	}
 	defer proxyLn.Close()
 
+	handled := make(chan struct{})
 	go func() {
+		defer close(handled)
 		conn, err := proxyLn.Accept()
 		if err != nil {
 			return
@@ -194,8 +196,14 @@ func TestHandleTransparentTLSNonGitHubWithTCPServer(t *testing.T) {
 	rawConn.Write(clientHello)
 
 	// The proxy will extract SNI="example.com", check IsGitHubHost=false,
-	// then try to dial example.com:443 which fails.
-	time.Sleep(3 * time.Second)
+	// then try to dial example.com:443. Wait for the handler goroutine to
+	// finish (immediate when that dial fails, e.g. no egress), keeping the
+	// original 3s upper bound for the case where a tunnel does come up and
+	// only the Close below tears it down.
+	select {
+	case <-handled:
+	case <-time.After(3 * time.Second):
+	}
 	rawConn.Close()
 
 	_ = echoPortStr

--- a/src/pkg/snapshot/builder_test.go
+++ b/src/pkg/snapshot/builder_test.go
@@ -10,6 +10,7 @@ import (
 
 	"log/slog"
 
+	"github.com/kubestellar/hive/internal/testutil"
 	"github.com/kubestellar/hive/pkg/dashboard"
 )
 
@@ -272,13 +273,25 @@ func TestBuild_MultipleCalls_CreateMultipleTimestampedFiles(t *testing.T) {
 		}
 
 		if i < calls-1 {
-			time.Sleep(time.Second)
+			waitForNextSecond(t)
 		}
 	}
 
 	if len(seen) < calls {
 		t.Errorf("expected %d distinct timestamped files, got %d", calls, len(seen))
 	}
+}
+
+// waitForNextSecond blocks until the wall clock has crossed a second boundary,
+// so the next Build gets a distinct second-granular status-<ts>.json name.
+// Polling for the boundary costs on average half the fixed 1s sleep it
+// replaces, and never less than what distinctness actually requires.
+func waitForNextSecond(t *testing.T) {
+	t.Helper()
+	start := time.Now().UTC().Truncate(time.Second)
+	testutil.Eventually(t, 2*time.Second, func() bool {
+		return time.Now().UTC().Truncate(time.Second).After(start)
+	}, "wall clock did not advance past %s", start.Format(time.RFC3339))
 }
 
 func TestBuild_EmptyAgents_Succeeds(t *testing.T) {
@@ -571,7 +584,7 @@ func TestBuild_SecondCall_UpdatesLatestJSON(t *testing.T) {
 		t.Fatalf("first Build() error: %v", err)
 	}
 
-	time.Sleep(time.Second)
+	waitForNextSecond(t)
 
 	s2 := minimalStatus()
 	s2.Governor.Mode = "SURGE"


### PR DESCRIPTION
## Why

9 of the last 21 flaky-test tickets were timing margins, and every fix added another local `waitFor*` helper — there are now 16 of them across `pkg/dashboard`, `pkg/hub`, `pkg/github`, `pkg/watchdog`, `pkg/notify` — sitting next to 210 `time.Sleep` calls in `*_test.go`, several of them fixed multi-second sleeps that add wall clock to every PR-gate run. This PR adds one shared poll helper, migrates the fixed sleeps ≥ 500 ms that were waiting on something observable, and adds a ratchet so the count can only go down.

## What

### `src/internal/testutil` (new)
- `Eventually(t testing.TB, timeout, cond func() bool, msg string, args ...any)` — polls at 10 ms, `t.Helper()`, `t.Fatalf` with the message on deadline.
- `EventuallyValue[T](t, timeout, get func() (T, bool), msg, args...)` — same, returning the observed value.
- The doc comment spells out when a sleep is still correct (negative "nothing happens" waits), when to reach for a Go 1.25 `testing/synctest` bubble instead, and when a channel/WaitGroup beats polling.
- `eventually_test.go` — positive cases plus negative cases through a recording `testing.TB` double (`Fatalf` is captured, not actually raised).
- `sleep_ratchet_test.go` — walks `src/pkg` and `src/cmd` `*_test.go`, counts `time.Sleep(` occurrences (same substring count as `grep -o 'time\.Sleep(' | wc -l`, comments included), and fails when the count **exceeds `sleepBaseline = 198`**. The failure message points at `testutil.Eventually` and lists the files with the most sleeps; when the count drops below the baseline it logs a reminder to lower the constant. Fails closed if the walk finds no test files (wrong cwd). Runs in well under a second.

### CI wiring
`./internal/...` is added to the rest-bucket `go list` in `v2-tests.yml` (default weight 3, lands in a rest bucket) and to both `go test` invocations in `coverage-hourly.yml`. Without this the new package would never run — the partition only listed `./pkg/... ./cmd/...`.

### Migrated sites (assertion semantics unchanged at every one)

| Site | Was | Now | Wall clock removed |
|---|---|---|---|
| `pkg/dashboard/contribute_ws_token_refresh_test.go:153` | `Sleep(2s)` keeping the hijacked-WS handler alive | `<-handlerDone`, closed by a `defer` right after `srv.Close` | 0 s on the gate (ran on the handler goroutine); removes a 2 s margin assumption |
| `pkg/dashboard/contribute_ws_token_refresh_test.go:238` | `Sleep(2s)` same pattern | same | same |
| `pkg/dashboard/contribute_ws_credential_accept_test.go:48` (`wsPipe`) | `Sleep(3s)` same pattern | `<-handlerDone` closed via `t.Cleanup` (LIFO: before `srv.Close`) | same, 3 s margin |
| `pkg/dashboard/contribute_ws_maybe_refresh_test.go:54` (`wsPair`) | `Sleep(2s)` same pattern | same | same, 2 s margin |
| `pkg/proxy/proxy_deep8_test.go:198` | `Sleep(3s)` for the handler goroutine to finish dialing `example.com:443` | `select` on the goroutine's `handled` channel with the original 3 s as the upper bound | up to 3 s (immediate when the dial fails, e.g. no egress); unchanged when a tunnel comes up |
| `pkg/snapshot/builder_test.go:275` (2 iterations) | `Sleep(1s)` for a distinct second-granular `status-<ts>.json` name | `waitForNextSecond` polling for the second boundary via `Eventually` | ~0.5 s avg per iteration (~1 s avg) |
| `pkg/snapshot/builder_test.go:574` | `Sleep(1s)` same reason | same | ~0.5 s avg |
| `pkg/hub/hub_heartbeat_test.go:170` | `Sleep(500ms)` "cancel early" | `select` on first heartbeat POST with the original 500 ms as the upper bound (never fails on its own; assertion is still only that the loop stops on cancel) | ~300–400 ms |
| `pkg/discord/bot_test.go:816` (`TickerBranch`) | `Sleep(10.5s)` for two 5 s ticks | `Eventually(fetch ≥ 2 && send > 0, 15s)` | ~0.5 s; timeout now 3 ticks instead of a fixed margin past the second |
| `pkg/discord/bot_test.go:857` (`TickerBranch_FetchError`, skipped under `-short`) | `Sleep(5.5s)` | `Eventually(fetch > 0, 10s)` | ~0.5 s |
| `pkg/discord/bot_test.go:993` (`TickerSuccessPath`) | `Sleep(10.5s)` | `Eventually(fetch ≥ 2 && send > 0, 15s)` | ~0.5 s |
| `pkg/discord/bot_test.go:1033` (`TickerFetchErrorPath`) | `Sleep(5.1s)` | `Eventually(fetch > 0, 10s)` | ~0.1 s |

The four discord tests also gain `defer cancel()` so an `Eventually` deadline failure still stops `pollLoop`. `pollLoop` fetches only from its ticker (no initial fetch), so waiting on the counters keeps the ticker-branch coverage those tests exist for.

The discord `pollIntervalS` is a package const, so those tests are still bounded below by real 5 s ticks; making the interval injectable (or moving them to a `synctest` bubble) is the follow-up that would actually reclaim ~30 s there.

`time.Sleep(` count in `src/pkg` + `src/cmd` `*_test.go`: **210 → 198** (baseline set to 198).

### Left in place, deliberately
- `pkg/agent/tmux_coverage_test.go:72` — `cleanupAgent`'s 5 s drain of non-ctx-aware launch goroutines (`deliverStartupKick` polls tmux every 2 s and is not cancellable). 37 callers, so this is the single biggest wall-clock item in `pkg/agent`, but there is no observable condition to poll without giving those goroutines a WaitGroup in production code. Follow-up.
- `pkg/agent/kick_restart_recovery_test.go:92` — 4 s wait for `pollTmuxOutputForAgent` to observe its cancel (one 3 s tick + margin); same reason, no signal to wait on.
- `pkg/config/watcher_test.go:131` — 1 s "wait for debounce to settle" before asserting `reloads <= 2`. This is a negative wait: it must span the 500 ms `debounceDelay` window to prove no extra reload fires. `Eventually` would weaken it.
- `pkg/agent/poll_coverage_test.go:89` — 3.5 s in a goroutine that injects pane text between the poller's first and second 3 s ticks. Timing choreography, not a wait.
- Everything < 500 ms and everything under `src/test/` (integration suite, not in the gate) untouched per scope.

## Verification
CI validates (no local build/test). `gofmt -l` is clean on every touched file.
