### PR TITLE
🔧 ci: guard that every src/deploy/ test suite is wired into a workflow (#5529); verify repo-root docs/ link check (#5491)

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -632,6 +632,31 @@ jobs:
         env:
           HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: bash src/deploy/test_entrypoint_system_gitconfig.sh
+
+      # #5529: this suite was referenced by NO workflow at all — not v2-ci.yml,
+      # not any specialised lane — so it had never run in CI. It passes 8/0, so
+      # nothing was broken; the point is that the Copilot token-persistence
+      # symlinks it guards were not being checked either. Those symlinks are a
+      # recurring incident surface: a lost ~/.copilot -> /data/home/.copilot
+      # link drops the CLI's stored token on every container restart, which
+      # presents as an agent that silently stops authenticating rather than as
+      # anything that fails loudly.
+      #
+      # It reads entrypoint.sh and bin/agent-launch.sh from the checkout, so it
+      # needs no runtime and belongs in this lane rather than a container one.
+      - name: Entrypoint Copilot token symlink contract (#5529)
+        working-directory: .
+        run: bash src/deploy/test_entrypoint_symlinks.sh
+
+      # The guard that keeps the omission above from recurring: every
+      # src/deploy/test_*.sh must be named by at least one workflow. This is
+      # the src/deploy/ sibling of bin/test_bin_suites_wired.sh (#4363).
+      #
+      # It is registered here, which is also what makes it pass its own check —
+      # exempting itself would be the hole it exists to close.
+      - name: Every src/deploy/ test suite is wired into a workflow (#5529)
+        working-directory: .
+        run: bash src/deploy/test_deploy_suites_wired.sh
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/src/deploy/test_deploy_suites_wired.sh
+++ b/src/deploy/test_deploy_suites_wired.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Every test suite under src/deploy/ must be named by at least one workflow
+# under .github/workflows/ (#5529).
+#
+# This is the src/deploy/ sibling of bin/test_bin_suites_wired.sh (#4363), and
+# it exists because the same hole was measurably open here. src/deploy/ suites
+# are wired INDIVIDUALLY, by name, in a workflow step. A new suite is therefore
+# never picked up automatically, and an omission produces no failure — nothing
+# fails when a test file is simply never named. The suite passes locally, the
+# file looks maintained, and CI is green because it never ran.
+#
+# Three live instances, all found by accident rather than by a gate:
+#
+#   test_entrypoint_symlinks.sh        — referenced by NO workflow at all; the
+#                                        omission this guard was written
+#                                        against (#5529). Passes 8/0, so
+#                                        nothing was broken — but the Copilot
+#                                        token-persistence symlinks it guards
+#                                        were not being checked either.
+#   test_entrypoint_system_gitconfig.sh — same state, found incidentally during
+#                                        #5388 and registered there.
+#   test_hive_snapshot_unit_contract.sh — merged in #5499 with no registration;
+#                                        caught only because a duplicate PR
+#                                        happened to include it (#5504).
+#
+# The bar is "referenced ANYWHERE under .github/workflows/", not "referenced in
+# v2-ci.yml". Several suites live correctly in specialised lanes —
+# test_ambient_cap_runtime.sh and test_manifest_caps_runtime.sh in
+# suid-contract.yml, test_image_suid_inventory.sh in docker.yml and
+# suid-contract.yml, test_quadlet_generator_gate.sh in quadlet-gate.yml —
+# because they need a runtime, an image build, or a generator those workflows
+# already stand up. Demanding v2-ci.yml specifically would fail all four for
+# being in the right place.
+#
+# Run: bash src/deploy/test_deploy_suites_wired.sh
+# Exit codes: 0 every suite is wired, 1 at least one is orphaned.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${ROOT}/.." && pwd)"
+WORKFLOWS="${REPO_ROOT}/.github/workflows"
+
+# Files matching test_*.sh that are NOT suites and must not be required to be
+# wired as one. Format: filename|reason.
+#
+# test_lib.sh is the shared skip-discipline helper (#5388 item 3) that the
+# suites SOURCE; running it standalone asserts nothing. It currently satisfies
+# a naive reference check only because a v2-ci.yml comment happens to mention
+# it by name — delete that comment and the guard would start demanding a
+# library be run as a test. Naming it here makes it a decision rather than an
+# accident of prose.
+NOT_A_SUITE=(
+  "test_lib.sh|shared skip-discipline helper sourced by the suites, not a suite itself"
+)
+
+# Real suites deliberately not in CI. Format: filename|reason. Keep the reason
+# specific enough that a reviewer can judge whether it still holds; an empty
+# list is the healthy state.
+UNWIRED_ON_PURPOSE=(
+)
+
+failures=0
+checked=0
+
+is_exempt() {
+  local name="$1" entry
+  for entry in "${UNWIRED_ON_PURPOSE[@]}"; do
+    [[ "${entry%%|*}" == "$name" ]] && return 0
+  done
+  return 1
+}
+
+is_not_a_suite() {
+  local name="$1" entry
+  for entry in "${NOT_A_SUITE[@]}"; do
+    [[ "${entry%%|*}" == "$name" ]] && return 0
+  done
+  return 1
+}
+
+not_a_suite_reason() {
+  local name="$1" entry
+  for entry in "${NOT_A_SUITE[@]}"; do
+    if [[ "${entry%%|*}" == "$name" ]]; then
+      printf '%s' "${entry#*|}"
+      return 0
+    fi
+  done
+  printf 'no reason recorded'
+}
+
+exempt_reason() {
+  local name="$1" entry
+  for entry in "${UNWIRED_ON_PURPOSE[@]}"; do
+    if [[ "${entry%%|*}" == "$name" ]]; then
+      printf '%s' "${entry#*|}"
+      return 0
+    fi
+  done
+  printf 'no reason recorded'
+}
+
+printf '=== src/deploy/ test suites are wired into a workflow (#5529) ===\n\n'
+
+# A checker aimed at a path matching no files exits 0 and reports success,
+# which is indistinguishable from "everything is wired" (#5388). Both the
+# workflow directory and the suite glob are therefore asserted non-empty
+# BEFORE any per-suite verdict is printed.
+if [[ ! -d "$WORKFLOWS" ]]; then
+  printf 'FATAL: %s does not exist — nothing to check references against.\n' "$WORKFLOWS"
+  exit 1
+fi
+
+workflow_count=$(find "$WORKFLOWS" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | wc -l | tr -d ' ')
+if [[ "$workflow_count" -eq 0 ]]; then
+  printf 'FATAL: no workflow files under %s — every suite would report unwired.\n' "$WORKFLOWS"
+  exit 1
+fi
+
+shopt -s nullglob
+suites=("${ROOT}"/deploy/test_*.sh)
+if [[ "${#suites[@]}" -eq 0 ]]; then
+  printf 'FATAL: no src/deploy/test_*.sh suites matched — the glob is wrong,\n'
+  printf '       not the tree. Passing here would assert nothing.\n'
+  exit 1
+fi
+
+printf 'Scanning %d workflow file(s) for %d suite(s).\n\n' "$workflow_count" "${#suites[@]}"
+
+for path in "${suites[@]}"; do
+  name="$(basename "$path")"
+
+  # Helpers are excluded before counting: they are not suites, so they are
+  # neither "checked" nor eligible to be orphaned.
+  if is_not_a_suite "$name"; then
+    printf '  ----: %s — not a suite: %s\n' "$name" "$(not_a_suite_reason "$name")"
+    continue
+  fi
+
+  # This guard is itself a suite and is checked like any other; skipping it
+  # would be the exact hole it exists to close.
+  checked=$((checked + 1))
+
+  # Fixed-string grep for the basename anywhere under .github/workflows/.
+  # Grep rather than parsing YAML on purpose: a `run:` line, a matrix entry and
+  # a comment all name the file the same way, and a reference that is only a
+  # comment still tells a reader where to look. -F so a name is never read as a
+  # pattern.
+  if grep -rqF -- "$name" "$WORKFLOWS" 2>/dev/null; then
+    printf '  PASS: %s\n' "$name"
+    continue
+  fi
+
+  if is_exempt "$name"; then
+    printf '  SKIP: %s — unwired on purpose: %s\n' "$name" "$(exempt_reason "$name")"
+    continue
+  fi
+
+  printf '  FAIL: %s is not named by any workflow under .github/workflows/\n' "$name"
+  printf '        Add a step next to its siblings in .github/workflows/v2-ci.yml:\n'
+  printf '          - name: <what it guards>\n'
+  printf '            working-directory: .\n'
+  printf '            run: bash src/deploy/%s\n' "$name"
+  printf '        A specialised lane (suid-contract.yml, docker.yml,\n'
+  printf '        quadlet-gate.yml) counts too if the suite needs what it\n'
+  printf '        stands up. If it genuinely should not run in CI, add it to\n'
+  printf '        UNWIRED_ON_PURPOSE in this file with the reason.\n'
+  failures=$((failures + 1))
+done
+
+printf '\nChecked %d suite(s) against %d workflow(s), %d orphaned.\n' \
+  "$checked" "$workflow_count" "$failures"
+[[ "$failures" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Two CI-wiring gaps of the same family. Handled in one PR to avoid two agents colliding in `.github/workflows/`.

**#5491 was already fixed on `v4` and needs no code change here** — see the verification below. **#5529 was genuinely open** and is fixed by this PR.

---

## #5491 — repo-root `docs/` link checking: ALREADY IN PLACE, verified

PR #5501 landed this and the issue was reopened without the fix being reverted. Against a freshly fetched `origin/v4` (`12d140c3`), `docs-link-check.yml` already has all three pieces the issue asked for:

- `docs/**` in the `push` `paths:` filter
- `docs/**` in the `pull_request` `paths:` filter
- a `Check repo-root docs/ relative links and anchors` step running `python3 src/scripts/check-docs-links.py docs`, in plain mode, correctly NOT `--vault-root`

### The checker is not vacuous — file count and a demonstrated failure

Per #5388: a checker aimed at a path matching no files exits 0 and reports success indistinguishably from "all links valid". It is not doing that. **It processes 13 files**, which matches `find docs -name '*.md' | wc -l` exactly:

```
$ python3 src/scripts/check-docs-links.py docs
checked 13 files under docs
all relative links and anchors resolve      # exit 0
```

Broke one relative link in `docs/architecture.md` and watched the step go red for the right reason:

```
$ printf '\n[deliberately broken](./no-such-file-5491.md)\n' >> docs/architecture.md
$ python3 src/scripts/check-docs-links.py docs
checked 13 files under docs

1 broken link(s):

  docs/architecture.md: broken link './no-such-file-5491.md' -> docs/no-such-file-5491.md does not exist
                                                                                        # exit 1
$ git checkout docs/architecture.md && python3 src/scripts/check-docs-links.py docs
checked 13 files under docs
all relative links and anchors resolve      # exit 0
```

And it does not silently pass on a path matching nothing:

```
$ python3 src/scripts/check-docs-links.py docs-nope
no such directory: docs-nope                # exit 1
```

**No files were changed for #5491.** `Fixes #5491` is on this PR to close the reopened issue against the verification above.

---

## #5529 — no guard that every `src/deploy/` test suite is wired into CI

### Demonstrated FAILING against the unfixed tree

The guard was written first and run against `origin/v4` before anything was wired. It caught the known-real gap:

```
=== src/deploy/ test suites are wired into a workflow (#5529) ===

Scanning 32 workflow file(s) for 31 suite(s).

  PASS: test_ambient_cap_runtime.sh
  ...
  FAIL: test_deploy_suites_wired.sh is not named by any workflow under .github/workflows/
  ...
  FAIL: test_entrypoint_symlinks.sh is not named by any workflow under .github/workflows/
  ...

Checked 31 suite(s) against 32 workflow(s), 2 orphaned.
                                            # exit 1
```

`test_entrypoint_symlinks.sh` is the omission the issue measured. The second failure is the guard itself, which is correct — it registers itself rather than self-exempting.

### Passing after the fix

```
Checked 30 suite(s) against 32 workflow(s), 0 orphaned.
                                            # exit 0
```

30 rather than 31 because `test_lib.sh` is now named as a helper, not a suite (see below).

### Acceptance criteria from the issue

| Criterion | Result |
|---|---|
| Fails against current tree because `test_entrypoint_symlinks.sh` is unwired | Shown above, exit 1 |
| Adding a new unwired `src/deploy/test_*.sh` fails CI | Dropped a stub `test_5529_probe.sh` in: `FAIL: test_5529_probe.sh ... 1 orphaned`, **exit 1** |
| A suite referenced only from a non-`v2-ci.yml` workflow passes | All four PASS with 0 occurrences in `v2-ci.yml`: `test_ambient_cap_runtime.sh` and `test_manifest_caps_runtime.sh` (suid-contract.yml), `test_quadlet_generator_gate.sh` (quadlet-gate.yml), `test_image_suid_inventory.sh` (suid-contract.yml + docker.yml) |
| `test_entrypoint_symlinks.sh` wired or deleted, decided by reading it | Read, then **wired** — reasoning below |

### What I did with `test_entrypoint_symlinks.sh`, and why

**Wired it into `v2-ci.yml`, not deleted.** I read it before deciding. It is a 69-line static contract over `src/deploy/entrypoint.sh` and `bin/agent-launch.sh`, asserting eight things about Copilot CLI token persistence: the `~/.copilot -> /data/home/.copilot` symlink, the two `github-copilot` config symlinks, `chmod -R g+rwX /data/home` so every agent UID can read them, `COPILOT_GITHUB_TOKEN` export from both scripts, and that the PAT is read from `/data/copilot-token-pat` rather than hardcoded.

It **passes 8/0 against the current tree**, so it is neither obsolete nor broken — I did not wire a failing suite to satisfy the guard. The invariant is live and load-bearing: a lost symlink drops the CLI's stored token on every container restart and presents as an agent that silently stops authenticating, never as a loud failure. It needs no runtime, so `v2-ci.yml` is the right lane rather than a container one.

### Guard design notes

- **Bar is "referenced anywhere under `.github/workflows/`"**, not "in `v2-ci.yml`". Requiring `v2-ci.yml` would fail the four correctly-placed specialised-lane suites.
- **`test_lib.sh` is declared a helper, not a suite.** It is *sourced* by the suites; running it standalone asserts nothing. It satisfied a naive reference check only because a `v2-ci.yml` **comment** happens to name it — delete that comment and the guard would start demanding a library be run as a test. Naming it in `NOT_A_SUITE` makes it a decision rather than an accident of prose.
- **Refuses to report success on an empty set.** If `.github/workflows/` is missing, contains no workflow files, or the suite glob matches nothing, it exits 1 with `FATAL:` rather than printing a clean 0-orphaned pass — the `find -print -quit`-style vacuity #5388 catalogues.
- `grep -rqF` (fixed-string) so a filename is never reinterpreted as a pattern.

### Local checks

`bash -n` clean, `shellcheck` clean, `yq` parses `v2-ci.yml` and both new steps are present in `jobs.build-and-test.steps`.

---

## What I did NOT verify

- **CI itself has not reported yet at the time of writing.** Everything above is local. The merge gate is CI, not these runs.
- I did not run the other 29 `src/deploy/` suites — only the two this PR touches (`test_entrypoint_symlinks.sh`, the new guard). Whether the newly-wired suite stays green on an ubuntu runner rather than macOS is for CI to say; it is pure `grep` over checked-in files, so I expect no platform sensitivity, but I did not prove it.
- I did not re-audit whether `docs-link-check.yml`'s `paths:` filter fires correctly on a real PR touching only `docs/` — I read the filter, I did not observe a triggered run.
- I did not investigate *why* #5491 was reopened after #5501 merged. If it was reopened for a reason not visible in the workflow file, that reason is unaddressed here.
- No `src/docs/` or wiki-vault behaviour was re-verified; untouched by this PR.

Fixes #5491
Fixes #5529
Refs #4363, #5388, #5504
