### PR TITLE
🧪 test(bin): contract tests for merge-gate.sh and gh-rate-check.sh

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -301,6 +301,35 @@ jobs:
         working-directory: .
         run: bash bin/test_kick_governor.sh
 
+      # bin/merge-gate.sh reads actionable.json (enumerate-actionable.sh's
+      # output) and writes merge-eligible.json — the ONE file agents are told
+      # to trust before running `gh pr merge`. Every CI-check/mergeable/hold-
+      # label/author gate that decides "safe to merge" lives in this one
+      # script, called from conflict-sweeper.sh, gh-wrapper.sh and kick-
+      # agents.sh, and it had NO tests. This EXECUTES the gate against a stub
+      # gh (canned `pr checks` TSV and `pr view --json` fixtures) and asserts
+      # on the written JSON's eligible/not_ready split and block_reasons, with
+      # a positive control beside every exclusion so a gate that admits
+      # everything cannot pass. Runs in ~1s, no network.
+      - name: merge-gate contract tests
+        working-directory: .
+        run: bash bin/test_merge_gate.sh
+
+      # bin/gh-rate-check.sh scans agent tmux panes for GitHub API rate-limit
+      # text and decides which agents to PAUSE and for how long — called from
+      # kick-agents.sh every cycle. A regression here either stops pausing
+      # agents during a real rate limit (burns the fleet's shared quota
+      # faster) or pauses agents on a false positive (the script's own header
+      # warns that Claude/Copilot CLI usage-limit text looks similar but is a
+      # DIFFERENT limit). It had NO tests. This EXECUTES the script against
+      # stub tmux/gh/curl and asserts on the governor pause flags, the
+      # pullback state file and the ntfy calls it makes, with positive and
+      # negative controls on the CLI-usage-limit exclusion pattern. Runs in
+      # ~2s, no network (the ntfy curl call is stubbed).
+      - name: gh-rate-check contract tests
+        working-directory: .
+        run: bash bin/test_gh_rate_check.sh
+
       # #4289: git-credential-hive.sh is the fetch/clone AND push credential
       # source for every agent. Its mode block used to exit 1 in ADVISORY/
       # ISSUES_ONLY/NO_GITHUB modes, cutting off every git READ for advisory

--- a/bin/test_gh_rate_check.sh
+++ b/bin/test_gh_rate_check.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# Contract tests for bin/gh-rate-check.sh.
+# Run: bash bin/test_gh_rate_check.sh
+#
+# gh-rate-check.sh scans agent tmux panes for GitHub API rate-limit messages
+# and decides which agents to PAUSE (by touching a governor flag file) and
+# for how long. A pattern regression here either stops pausing agents during
+# a real rate limit (burns the fleet's quota faster) or pauses agents on a
+# false positive (Claude/Copilot CLI usage-limit text that looks similar but
+# is a DIFFERENT limit — the script's own header calls this out explicitly).
+# It had no tests.
+#
+# Like bin/test_merge_gate.sh and bin/test_enumerate_actionable.sh, this
+# EXECUTES the script rather than grepping it. The script hardcodes
+# /var/run/hive-metrics/{gh_rate_limits.json,rate_pullback/}, /var/run/kick-
+# governor and /var/log/kick-agents.log with no env override, so the harness
+# runs a COPY with those four paths rewritten to a temp dir, and asserts the
+# rewrite landed. GH_BIN, TMUX_BIN, NTFY_SERVER, NTFY_TOPIC and GOVERNOR_ENV
+# ARE overridable via env, so the harness uses the real overrides instead of
+# rewriting those.
+#
+# Doctrine (audit 6/7): every exclusion assertion sits next to a positive
+# control that DOES fire, so a matcher that never fires cannot pass.
+# Hermetic: no network (curl targets 127.0.0.1 and is expected to fail
+# silently, exactly as production does when ntfy is unreachable), no real
+# sleeps, never touches /var/run, /data or /tmp/hive.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/bin/gh-rate-check.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+for dep in python3; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "harness-error: $dep is required"
+    exit 1
+  fi
+done
+
+# Some dev-box python3 shims hang waiting on stdin when invoked non-
+# interactively instead of erroring — invisible in CI (ubuntu-latest's
+# python3 is a real interpreter, first on PATH) but would wedge this harness
+# locally. Pick the first python3 on PATH that answers `-c "pass" </dev/null`
+# inside a hard 3s timeout; put its directory first for every invocation.
+PY_PATH=""
+IFS=':' read -r -a _path_dirs <<<"$PATH"
+for d in "${_path_dirs[@]}"; do
+  [ -x "${d}/python3" ] || continue
+  "${d}/python3" -c "pass" </dev/null >/dev/null 2>&1 &
+  cand_pid=$!
+  waited=0
+  while kill -0 "$cand_pid" 2>/dev/null && [ "$waited" -lt 30 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$cand_pid" 2>/dev/null; then
+    kill -9 "$cand_pid" 2>/dev/null
+    continue
+  fi
+  wait "$cand_pid" 2>/dev/null && { PY_PATH="$d"; break; }
+done
+if [ -z "$PY_PATH" ]; then
+  echo "harness-error: no working non-interactive python3 found on PATH"
+  exit 1
+fi
+export PATH="${PY_PATH}:${PATH}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+RUN_DIR="${WORK}/run"                      # stands in for /var/run/hive-metrics
+GOV_DIR="${WORK}/governor"                 # stands in for /var/run/kick-governor
+LOG_FILE="${WORK}/kick-agents.log"         # stands in for /var/log/kick-agents.log
+SHIM_DIR="${WORK}/shim"
+ETC_HIVE="${WORK}/etc-hive"                # stands in for /etc/hive
+METRICS="${RUN_DIR}/gh_rate_limits.json"
+PULLBACK_DIR="${RUN_DIR}/rate_pullback"
+mkdir -p "$RUN_DIR" "$GOV_DIR" "$SHIM_DIR" "${WORK}/bin" "$ETC_HIVE" "$PULLBACK_DIR"
+
+# ── The path-rewritten copy ──────────────────────────────────────────────────
+SCRIPT_COPY="${WORK}/bin/gh-rate-check.sh"
+sed \
+  -e "s|/var/run/hive-metrics|${RUN_DIR}|g" \
+  -e "s|/var/run/kick-governor|${GOV_DIR}|g" \
+  -e "s|/var/log/kick-agents.log|${LOG_FILE}|g" \
+  -e "s|/etc/hive/|${ETC_HIVE}/|g" \
+  "$SCRIPT" >"$SCRIPT_COPY"
+if grep -qE '/var/run/hive-metrics|/var/run/kick-governor|/var/log/kick-agents\.log|/etc/hive/' "$SCRIPT_COPY" \
+   || ! grep -q "$RUN_DIR" "$SCRIPT_COPY" \
+   || ! grep -q "$GOV_DIR" "$SCRIPT_COPY"; then
+  echo "harness-error: path rewrite did not land — the script's hardcoded paths moved; update the sed above"
+  exit 1
+fi
+
+# Dev-box convenience only: ubuntu-latest ships GNU date; macOS BSD date
+# rejects -Is. Not a contract under test.
+if ! date -Is >/dev/null 2>&1; then
+  REAL_DATE="$(command -v date)"
+  cat >"${SHIM_DIR}/date" <<DATEEOF
+#!/bin/sh
+[ "\${1:-}" = "-Is" ] && exec "${REAL_DATE}" -u +%Y-%m-%dT%H:%M:%S+00:00
+exec "${REAL_DATE}" "\$@"
+DATEEOF
+  chmod +x "${SHIM_DIR}/date"
+fi
+
+# ── Stub gh (rate_limit endpoint only) ───────────────────────────────────────
+# `gh api rate_limit --jq FILTER` is served by evaluating FILTER against
+# $FAKE_RATE_LIMIT_JSON with real jq, so the --jq filters in get_api_reset_
+# epoch and the recovery check are under test, not bypassed.
+GH_STUB="${SHIM_DIR}/gh"
+cat >"$GH_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FAKE_GH_LOG:-/dev/null}"
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "rate_limit" ]; then
+  jqf=""
+  shift 2
+  while [ $# -gt 0 ]; do
+    case "$1" in --jq) jqf="$2"; shift 2 ;; *) shift ;; esac
+  done
+  if [ -n "$jqf" ]; then
+    jq -r "$jqf" "$FAKE_RATE_LIMIT_JSON"
+  else
+    cat "$FAKE_RATE_LIMIT_JSON"
+  fi
+  exit 0
+fi
+exit 0
+STUBEOF
+chmod +x "$GH_STUB"
+
+for dep in jq; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "harness-error: $dep is required (stub gh needs it to honour --jq)"
+    exit 1
+  fi
+done
+
+# ── Stub tmux ─────────────────────────────────────────────────────────────────
+# `has-session -t <name>` succeeds only for sessions listed in
+# $FAKE_TMUX_SESSIONS (space-separated). `capture-pane -t <name> -p ...`
+# prints $FAKE_TMUX_PANES/<name>.txt, or nothing if absent.
+TMUX_STUB="${SHIM_DIR}/tmux"
+cat >"$TMUX_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  has-session)
+    target=""
+    shift
+    while [ $# -gt 0 ]; do case "$1" in -t) target="$2"; shift 2 ;; *) shift ;; esac; done
+    for s in ${FAKE_TMUX_SESSIONS:-}; do
+      [ "$s" = "$target" ] && exit 0
+    done
+    exit 1
+    ;;
+  capture-pane)
+    target=""
+    shift
+    while [ $# -gt 0 ]; do case "$1" in -t) target="$2"; shift 2 ;; *) shift ;; esac; done
+    f="${FAKE_TMUX_PANES}/${target}.txt"
+    [ -f "$f" ] && cat "$f"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+STUBEOF
+chmod +x "$TMUX_STUB"
+
+# ── Stub curl (ntfy) ─────────────────────────────────────────────────────────
+# Records every ntfy POST (title header + body) to $FAKE_NTFY_LOG so
+# assertions can check WHICH notifications fired without any network call.
+CURL_STUB="${SHIM_DIR}/curl"
+cat >"$CURL_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+title=""
+body=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-H" ] && [[ "$a" == Title:* ]]; then title="${a#Title: }"; fi
+  if [ "$prev" = "-d" ]; then body="$a"; fi
+  prev="$a"
+done
+printf 'TITLE=%s BODY=%s\n' "$title" "$body" >> "${FAKE_NTFY_LOG:-/dev/null}"
+exit 0
+STUBEOF
+chmod +x "$CURL_STUB"
+
+# ── Runner ───────────────────────────────────────────────────────────────────
+GH_LOG="${WORK}/gh.log"
+NTFY_LOG="${WORK}/ntfy.log"
+run_check() { # run_check [VAR=value...]
+  : >"$GH_LOG"; : >"$NTFY_LOG"
+  env "$@" \
+    PATH="${SHIM_DIR}:${PATH}" \
+    HOME="${WORK}/home" \
+    GH_BIN="$GH_STUB" \
+    TMUX_BIN="$TMUX_STUB" \
+    FAKE_GH_LOG="$GH_LOG" \
+    FAKE_NTFY_LOG="$NTFY_LOG" \
+    FAKE_RATE_LIMIT_JSON="${RATE_LIMIT_JSON:-${WORK}/rate_default.json}" \
+    FAKE_TMUX_SESSIONS="${TMUX_SESSIONS:-}" \
+    FAKE_TMUX_PANES="${TMUX_PANES:-${WORK}/panes_empty}" \
+    bash "$SCRIPT_COPY" >"${WORK}/stdout" 2>"${WORK}/stderr"
+  echo $?
+}
+jget() { python3 -c "
+import json,sys
+try:
+    d=json.load(open('$METRICS'))
+except Exception as e:
+    print('JSON-ERROR:'+str(e)); sys.exit(0)
+print($1)
+" 2>/dev/null
+}
+assert_eq() { # assert_eq <label> <got> <want>
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "got '$2', want '$3'"; fi
+}
+
+mkdir -p "${WORK}/panes_empty"
+NOW_EPOCH_FILE="${WORK}/now_epoch"
+python3 -c "import time; print(int(time.time()))" > "$NOW_EPOCH_FILE"
+NOW_EPOCH="$(cat "$NOW_EPOCH_FILE")"
+
+# Default: STILL-EXHAUSTED rate limit (remaining=0). Phase 2.5 clears every
+# active alert (and its pullback) the moment the API shows remaining > 0 —
+# that is the recovery contract under test in section 6, and it would also
+# silently erase every alert this harness sets up for detection/dedup/
+# exclusion/operator-paused scenarios if the default fixture looked healthy.
+# Only the recovery tests below swap in a healthy fixture deliberately.
+printf '{"rate":{"remaining":0,"limit":5000},"resources":{"core":{"reset":%d},"graphql":{"reset":%d}}}\n' \
+  "$((NOW_EPOCH + 3600))" "$((NOW_EPOCH + 3600))" > "${WORK}/rate_default.json"
+
+echo "=== gh-rate-check.sh contract tests ==="
+
+# ── 0. No tmux sessions running: exits 0, empty alerts, empty pullbacks ─────
+echo "-- no agent sessions running --"
+rc="$(TMUX_SESSIONS="" run_check)"
+assert_eq "no sessions: exits 0" "$rc" "0"
+if ! python3 -c "import json; json.load(open('$METRICS'))" 2>/dev/null; then
+  echo "harness-error: gh_rate_limits.json is not valid JSON; stderr was:"; cat "${WORK}/stderr"
+  exit 1
+fi
+assert_eq "no sessions: alerts is empty" "$(jget "len(d['alerts'])")" "0"
+assert_eq "no sessions: pullbacks is empty" "$(jget "len(d['pullbacks'])")" "0"
+assert_eq "no sessions: no agent gets paused" "$(ls "$GOV_DIR" 2>/dev/null | wc -l | tr -d ' ')" "0"
+
+# ── 1. Detection: GH rate-limit text triggers an alert + pullback ──────────
+echo "-- detection: GH rate limit text in scanner's pane --"
+PANES1="${WORK}/panes1"; mkdir -p "$PANES1"
+cat >"${PANES1}/scanner.txt" <<'EOF'
+some earlier output
+Error: API rate limit exceeded for installation ID 123.
+more output after
+EOF
+# Give ci-maintainer, architect, outreach real sessions too (same default CLI
+# detection: no /etc/hive/*.env means get_agent_cli returns "unknown" for all
+# four, so a pullback on cli=unknown pauses the other three).
+: >"${PANES1}/ci-maintainer.txt"
+: >"${PANES1}/architect.txt"
+: >"${PANES1}/outreach.txt"
+rc="$(TMUX_SESSIONS="scanner ci-maintainer architect outreach" TMUX_PANES="$PANES1" run_check)"
+assert_eq "detection run exits 0" "$rc" "0"
+assert_eq "one alert recorded for scanner" "$(jget "len(d['alerts'])")" "1"
+assert_eq "alert is attributed to the scanner agent" "$(jget "d['alerts'][0]['agent']")" "scanner"
+assert_eq "alert message captures the matched line (truncated, trimmed)" \
+  "$(jget "d['alerts'][0]['message']")" "Error: API rate limit exceeded for installation ID 123."
+assert_eq "scanner itself is NOT paused (let it finish its cycle)" \
+  "$( [ -f "${GOV_DIR}/paused_scanner" ] && echo paused || echo not-paused )" "not-paused"
+for other in ci-maintainer architect outreach; do
+  assert_eq "same-CLI agent ${other} IS paused by the pullback" \
+    "$( [ -f "${GOV_DIR}/paused_${other}" ] && echo paused || echo not-paused )" "paused"
+done
+assert_eq "exactly one pullback state file is written (cli=unknown)" \
+  "$(ls "$PULLBACK_DIR"/pullback_*.json 2>/dev/null | wc -l | tr -d ' ')" "1"
+PBFILE="$(ls "$PULLBACK_DIR"/pullback_*.json)"
+assert_eq "pullback records the three agents it paused" \
+  "$(python3 -c "import json; print(sorted(json.load(open('$PBFILE'))['paused_agents']))")" \
+  "$(python3 -c "print(sorted(['ci-maintainer','architect','outreach']))")"
+assert_eq "pullback ntfy fires naming the paused agents" \
+  "$(grep -c 'TITLE=Rate Limit Pullback' "$NTFY_LOG")" "1"
+assert_eq "per-hit ntfy also fires for the rate limit itself" \
+  "$(grep -c 'TITLE=GH Rate Limit: scanner' "$NTFY_LOG")" "1"
+
+# ── 2. Dedup: a second run with the SAME pane text does not re-alert ───────
+echo "-- dedup: already-alerted agent is not re-added --"
+rc="$(TMUX_SESSIONS="scanner ci-maintainer architect outreach" TMUX_PANES="$PANES1" run_check)"
+assert_eq "second run exits 0" "$rc" "0"
+assert_eq "still exactly one alert (deduped, not doubled)" "$(jget "len(d['alerts'])")" "1"
+assert_eq "second run: no NEW pullback file created (existing one still active)" \
+  "$(ls "$PULLBACK_DIR"/pullback_*.json 2>/dev/null | wc -l | tr -d ' ')" "1"
+assert_eq "second run: no second pullback ntfy (pullback already exists)" \
+  "$(grep -c 'TITLE=Rate Limit Pullback' "$NTFY_LOG")" "0"
+
+# ── 3. CLI-usage-limit text does NOT trigger a GH rate-limit alert ─────────
+echo "-- POSITIVE/NEGATIVE: CLI usage-limit text is excluded, GH text still matches --"
+rm -rf "$PULLBACK_DIR" "$GOV_DIR"/paused_* "$METRICS"
+mkdir -p "$PULLBACK_DIR"
+PANES2="${WORK}/panes2"; mkdir -p "$PANES2"
+cat >"${PANES2}/scanner.txt" <<'EOF'
+You're out of extra usage credits, resets 3pm
+EOF
+: >"${PANES2}/ci-maintainer.txt"; : >"${PANES2}/architect.txt"; : >"${PANES2}/outreach.txt"
+rc="$(TMUX_SESSIONS="scanner ci-maintainer architect outreach" TMUX_PANES="$PANES2" run_check)"
+assert_eq "CLI-usage-limit-only run exits 0" "$rc" "0"
+assert_eq "NEGATIVE CONTROL: CLI usage-limit text raises NO GH rate-limit alert" "$(jget "len(d['alerts'])")" "0"
+
+cat >"${PANES2}/scanner.txt" <<'EOF'
+You're out of extra usage credits, resets 3pm
+secondary rate limit hit while retrying
+EOF
+rc="$(TMUX_SESSIONS="scanner ci-maintainer architect outreach" TMUX_PANES="$PANES2" run_check)"
+assert_eq "mixed-text run exits 0" "$rc" "0"
+assert_eq "POSITIVE CONTROL: a genuine GH pattern (secondary rate limit) still fires alongside excluded CLI text" \
+  "$(jget "len(d['alerts'])")" "1"
+assert_eq "matched line is the GH one, not the excluded CLI line" \
+  "$(jget "d['alerts'][0]['message']")" "secondary rate limit hit while retrying"
+
+# ── 4. operator-paused agents are never touched by pullback OR its expiry ──
+echo "-- operator-paused agents are protected from pullback pause AND resume --"
+rm -rf "$PULLBACK_DIR" "$GOV_DIR"/paused_* "$GOV_DIR"/operator_paused_* "$METRICS"
+mkdir -p "$PULLBACK_DIR"
+touch "${GOV_DIR}/operator_paused_architect"
+PANES3="${WORK}/panes3"; mkdir -p "$PANES3"
+cat >"${PANES3}/scanner.txt" <<'EOF'
+abuse detection mechanism triggered, please retry later
+EOF
+: >"${PANES3}/ci-maintainer.txt"; : >"${PANES3}/architect.txt"; : >"${PANES3}/outreach.txt"
+rc="$(TMUX_SESSIONS="scanner ci-maintainer architect outreach" TMUX_PANES="$PANES3" run_check)"
+assert_eq "run exits 0" "$rc" "0"
+assert_eq "operator-paused architect is NOT touched (no paused_architect governor flag added)" \
+  "$( [ -f "${GOV_DIR}/paused_architect" ] && echo touched || echo untouched )" "untouched"
+PBFILE3="$(ls "$PULLBACK_DIR"/pullback_*.json)"
+assert_eq "architect recorded as already_paused, not paused_agents" \
+  "$(python3 -c "
+import json
+d=json.load(open('$PBFILE3'))
+print('already' if 'architect' in d['already_paused'] and 'architect' not in d['paused_agents'] else 'wrong')
+")" "already"
+for other in ci-maintainer outreach; do
+  assert_eq "POSITIVE CONTROL: ${other} (not operator-paused) IS paused by the pullback" \
+    "$( [ -f "${GOV_DIR}/paused_${other}" ] && echo paused || echo not-paused )" "paused"
+done
+
+echo "-- expiry: operator-paused agent stays paused after pullback expiry, others resume --"
+# Force the pullback to look expired.
+python3 -c "
+import json
+d = json.load(open('$PBFILE3'))
+d['expiry_epoch'] = 1
+json.dump(d, open('$PBFILE3', 'w'))
+"
+rc="$(TMUX_SESSIONS="" run_check)"
+assert_eq "expiry run exits 0" "$rc" "0"
+assert_eq "operator-paused architect is STILL paused after expiry (never auto-resumed)" \
+  "$( [ -f "${GOV_DIR}/operator_paused_architect" ] && echo still-operator-paused || echo lost )" "still-operator-paused"
+for other in ci-maintainer outreach; do
+  assert_eq "governor-paused ${other} IS resumed when the pullback expires" \
+    "$( [ -f "${GOV_DIR}/paused_${other}" ] && echo still-paused || echo resumed )" "resumed"
+done
+assert_eq "expired pullback file is removed" "$(ls "$PULLBACK_DIR"/pullback_*.json 2>/dev/null | wc -l | tr -d ' ')" "0"
+assert_eq "expiry sends a Pullback Expired ntfy" "$(grep -c 'TITLE=Rate Limit Pullback Expired' "$NTFY_LOG")" "1"
+
+# ── 5. TTL-based alert expiry (no api_reset_epoch on the alert) ────────────
+echo "-- TTL-based alert expiry --"
+rm -rf "$PULLBACK_DIR" "$GOV_DIR"/paused_* "$METRICS"; mkdir -p "$PULLBACK_DIR"
+python3 -c "
+import json
+alert = {'agent':'scanner','cli':'unknown','detected_at':'x','detected_epoch': $NOW_EPOCH - 1000,
+          'message':'old','ttl_seconds':900,'pullback_seconds':900,'api_reset_epoch':0}
+json.dump({'alerts':[alert]}, open('$METRICS','w'))
+"
+rc="$(TMUX_SESSIONS="" run_check)"
+assert_eq "TTL expiry run exits 0" "$rc" "0"
+assert_eq "an alert older than its TTL (no api_reset) is pruned" "$(jget "len(d['alerts'])")" "0"
+
+echo "-- POSITIVE CONTROL: an alert within its TTL survives pruning --"
+python3 -c "
+import json
+alert = {'agent':'scanner','cli':'unknown','detected_at':'x','detected_epoch': $NOW_EPOCH - 10,
+          'message':'fresh','ttl_seconds':900,'pullback_seconds':900,'api_reset_epoch':0}
+json.dump({'alerts':[alert]}, open('$METRICS','w'))
+"
+rc="$(TMUX_SESSIONS="" run_check)"
+assert_eq "fresh-alert run exits 0" "$rc" "0"
+assert_eq "an alert within TTL is kept (not pruned)" "$(jget "len(d['alerts'])")" "1"
+
+echo "-- api_reset_epoch-based expiry takes priority over TTL --"
+python3 -c "
+import json
+# TTL says this should still be fresh (detected 10s ago, ttl 900s), but the
+# API reset time is already in the past — the reset time must win.
+alert = {'agent':'scanner','cli':'unknown','detected_at':'x','detected_epoch': $NOW_EPOCH - 10,
+          'message':'reset-passed','ttl_seconds':900,'pullback_seconds':900,'api_reset_epoch': $NOW_EPOCH - 1}
+json.dump({'alerts':[alert]}, open('$METRICS','w'))
+"
+rc="$(TMUX_SESSIONS="" run_check)"
+assert_eq "reset-based expiry run exits 0" "$rc" "0"
+assert_eq "an alert whose api_reset_epoch has passed is pruned even though its TTL has not elapsed" \
+  "$(jget "len(d['alerts'])")" "0"
+
+# ── 6. Recovery: remaining > 0 clears all alerts AND active pullbacks ──────
+echo "-- recovery clears alerts and unpauses (except operator-paused) --"
+rm -rf "$PULLBACK_DIR" "$GOV_DIR"/paused_* "$GOV_DIR"/operator_paused_* "$METRICS"; mkdir -p "$PULLBACK_DIR"
+python3 -c "
+import json
+alert = {'agent':'scanner','cli':'unknown','detected_at':'x','detected_epoch': $NOW_EPOCH,
+          'message':'still active by ttl','ttl_seconds':900,'pullback_seconds':900,'api_reset_epoch':0}
+json.dump({'alerts':[alert]}, open('$METRICS','w'))
+"
+touch "${GOV_DIR}/paused_ci-maintainer"
+touch "${GOV_DIR}/operator_paused_architect"
+python3 -c "
+import json
+state = {'cli':'unknown','triggered_by':'scanner','triggered_at':'x','expiry_epoch': $NOW_EPOCH + 3600,
+         'paused_agents':['ci-maintainer','architect'],'already_paused':[],'api_reset_epoch': $NOW_EPOCH + 3600}
+json.dump(state, open('$PULLBACK_DIR/pullback_unknown.json','w'))
+"
+RATE_LIMIT_JSON="${WORK}/rate_recovered.json"
+printf '{"rate":{"remaining":100,"limit":5000},"resources":{"core":{"reset":%d},"graphql":{"reset":%d}}}\n' \
+  "$((NOW_EPOCH + 3600))" "$((NOW_EPOCH + 3600))" > "$RATE_LIMIT_JSON"
+rc="$(TMUX_SESSIONS="" RATE_LIMIT_JSON="$RATE_LIMIT_JSON" run_check)"
+assert_eq "recovery run exits 0" "$rc" "0"
+assert_eq "recovery clears the active alert" "$(jget "len(d['alerts'])")" "0"
+assert_eq "recovery resumes the governor-paused agent" \
+  "$( [ -f "${GOV_DIR}/paused_ci-maintainer" ] && echo still-paused || echo resumed )" "resumed"
+assert_eq "recovery does NOT touch the operator-paused agent's own flag" \
+  "$( [ -f "${GOV_DIR}/operator_paused_architect" ] && echo intact || echo removed )" "intact"
+assert_eq "recovery removes the now-stale pullback file" \
+  "$(ls "$PULLBACK_DIR"/pullback_*.json 2>/dev/null | wc -l | tr -d ' ')" "0"
+
+echo "-- POSITIVE CONTROL: remaining <= 0 does NOT trigger recovery --"
+rm -rf "$PULLBACK_DIR" "$METRICS"; mkdir -p "$PULLBACK_DIR"
+python3 -c "
+import json
+alert = {'agent':'scanner','cli':'unknown','detected_at':'x','detected_epoch': $NOW_EPOCH,
+          'message':'still active','ttl_seconds':900,'pullback_seconds':900,'api_reset_epoch':0}
+json.dump({'alerts':[alert]}, open('$METRICS','w'))
+"
+RATE_LIMIT_EXHAUSTED="${WORK}/rate_exhausted.json"
+printf '{"rate":{"remaining":0,"limit":5000},"resources":{"core":{"reset":%d},"graphql":{"reset":%d}}}\n' \
+  "$((NOW_EPOCH + 3600))" "$((NOW_EPOCH + 3600))" > "$RATE_LIMIT_EXHAUSTED"
+rc="$(TMUX_SESSIONS="" RATE_LIMIT_JSON="$RATE_LIMIT_EXHAUSTED" run_check)"
+assert_eq "still-exhausted run exits 0" "$rc" "0"
+assert_eq "alert count stays 1 (no false recovery while remaining=0)" "$(jget "len(d['alerts'])")" "1"
+
+# ── 7. GOVERNOR_ENV pattern overrides are honoured ──────────────────────────
+echo "-- GOVERNOR_ENV pattern override --"
+rm -rf "$PULLBACK_DIR" "$GOV_DIR"/paused_* "$METRICS"; mkdir -p "$PULLBACK_DIR"
+CUSTOM_ENV="${WORK}/governor.env"
+cat >"$CUSTOM_ENV" <<'EOF'
+SENSING_GH_RATE_PATTERNS='TOTALLY-CUSTOM-MARKER'
+EOF
+PANES4="${WORK}/panes4"; mkdir -p "$PANES4"
+cat >"${PANES4}/scanner.txt" <<'EOF'
+API rate limit exceeded (would match the DEFAULT pattern, not the override)
+EOF
+: >"${PANES4}/ci-maintainer.txt"; : >"${PANES4}/architect.txt"; : >"${PANES4}/outreach.txt"
+rc="$(TMUX_SESSIONS="scanner ci-maintainer architect outreach" TMUX_PANES="$PANES4" GOVERNOR_ENV="$CUSTOM_ENV" run_check)"
+assert_eq "custom-pattern run exits 0" "$rc" "0"
+assert_eq "with the pattern overridden to a marker that isn't present, the default-pattern text does NOT alert" \
+  "$(jget "len(d['alerts'])")" "0"
+
+cat >"${PANES4}/scanner.txt" <<'EOF'
+here it is: TOTALLY-CUSTOM-MARKER in the pane
+EOF
+rc="$(TMUX_SESSIONS="scanner ci-maintainer architect outreach" TMUX_PANES="$PANES4" GOVERNOR_ENV="$CUSTOM_ENV" run_check)"
+assert_eq "POSITIVE CONTROL: the overridden pattern DOES alert when its marker is present" \
+  "$(jget "len(d['alerts'])")" "1"
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/bin/test_merge_gate.sh
+++ b/bin/test_merge_gate.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# Contract tests for bin/merge-gate.sh.
+# Run: bash bin/test_merge_gate.sh
+#
+# merge-gate.sh reads /var/run/hive-metrics/actionable.json (written by
+# enumerate-actionable.sh) and writes /var/run/hive-metrics/merge-eligible.json
+# — the ONE file agents are told to trust for "is this PR safe to merge".
+# Every hold/CI/mergeable/author gate that decides whether an agent runs
+# `gh pr merge` lives in this one script, and it had no tests.
+#
+# Like bin/test_enumerate_actionable.sh and bin/test_gh_wrapper_gates.sh, this
+# EXECUTES the script rather than grepping it. The script hardcodes
+# /var/run/hive-metrics/{actionable,merge-eligible}.json and
+# /var/log/kick-agents.log with no env override, so the harness runs a COPY
+# with exactly those three paths rewritten to a temp dir, and asserts the
+# rewrite landed — a refactor that renames them must fail here loudly, not
+# silently run against the real paths. The stub gh serves canned `pr checks`
+# TSV and `pr view --json` fixtures keyed by repo/PR number, so the
+# IGNORED_CHECKS filter and the eligibility arithmetic are under test, not
+# bypassed.
+#
+# Doctrine (audit 6/7): every exclusion assertion sits next to a positive
+# control that IS eligible, so a gate that admits everything cannot pass.
+# Hermetic: no network, no sleeps, never touches /var/run, /data or /tmp/hive.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/bin/merge-gate.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() {
+  echo "  FAIL: $1"
+  [ $# -gt 1 ] && echo "        $2"
+  FAIL=$((FAIL + 1))
+}
+
+# A missing harness dependency must be red, not a silent exit 0 (#5388
+# doctrine). The script under test needs python3; the stub gh needs nothing
+# beyond POSIX sh, but the harness's own fixture builders use python3 too.
+for dep in python3; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "harness-error: $dep is required"
+    exit 1
+  fi
+done
+
+# Some dev-box python3 shims (asdf/pyenv-style, seen with Homebrew's python3
+# symlink under certain toolchain states) hang waiting on stdin when invoked
+# non-interactively instead of erroring — invisible in CI (ubuntu-latest's
+# python3 is a real interpreter, first on PATH) but would wedge this harness
+# locally. Pick the first python3 on PATH that answers `-c "pass" </dev/null`
+# inside a hard 3s timeout; put its directory first for every invocation below.
+PY_PATH=""
+IFS=':' read -r -a _path_dirs <<<"$PATH"
+for d in "${_path_dirs[@]}"; do
+  [ -x "${d}/python3" ] || continue
+  "${d}/python3" -c "pass" </dev/null >/dev/null 2>&1 &
+  cand_pid=$!
+  waited=0
+  while kill -0 "$cand_pid" 2>/dev/null && [ "$waited" -lt 30 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$cand_pid" 2>/dev/null; then
+    kill -9 "$cand_pid" 2>/dev/null
+    continue
+  fi
+  wait "$cand_pid" 2>/dev/null && { PY_PATH="$d"; break; }
+done
+if [ -z "$PY_PATH" ]; then
+  echo "harness-error: no working non-interactive python3 found on PATH"
+  exit 1
+fi
+# Every bare `python3` call below (fixture builders, jget, prfield, and the
+# script copy run via run_gate) must resolve to the same working interpreter,
+# not whatever shim happens to be first on the ambient PATH.
+export PATH="${PY_PATH}:${PATH}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+RUN_DIR="${WORK}/run"                # stands in for /var/run/hive-metrics
+LOG_FILE="${WORK}/kick-agents.log"   # stands in for /var/log/kick-agents.log
+SHIM_DIR="${WORK}/shim"
+FIX_ROOT="${WORK}/fixtures"
+ACTIONABLE="${RUN_DIR}/actionable.json"
+OUT="${RUN_DIR}/merge-eligible.json"
+GH_LOG="${WORK}/gh.log"
+mkdir -p "$RUN_DIR" "$SHIM_DIR" "$FIX_ROOT" "${WORK}/bin"
+
+# ── The path-rewritten copy ──────────────────────────────────────────────────
+SCRIPT_COPY="${WORK}/bin/merge-gate.sh"
+sed \
+  -e "s|/var/run/hive-metrics|${RUN_DIR}|g" \
+  -e "s|/var/log/kick-agents.log|${LOG_FILE}|g" \
+  "$SCRIPT" >"$SCRIPT_COPY"
+if grep -qE '/var/run/hive-metrics|/var/log/kick-agents.log' "$SCRIPT_COPY" \
+   || ! grep -q "$RUN_DIR" "$SCRIPT_COPY"; then
+  echo "harness-error: path rewrite did not land — the script's hardcoded paths moved; update the sed above"
+  exit 1
+fi
+# The script sources $(dirname "$0")/hive-config.sh first (falling back to
+# /usr/local/bin/hive-config.sh, then || true). A no-op stub next to the copy
+# means a real hive-config.sh on a dev box is never consulted and PROJECT_*
+# come only from the env this harness sets.
+: >"${WORK}/bin/hive-config.sh"
+
+# Dev-box convenience only: ubuntu-latest ships GNU date (date -Is works);
+# macOS ships BSD date, which rejects -Is. Not a contract under test — on CI
+# and in the production containers the real GNU date runs.
+if ! date -Is >/dev/null 2>&1; then
+  REAL_DATE="$(command -v date)"
+  cat >"${SHIM_DIR}/date" <<DATEEOF
+#!/bin/sh
+[ "\${1:-}" = "-Is" ] && exec "${REAL_DATE}" -u +%Y-%m-%dT%H:%M:%S+00:00
+exec "${REAL_DATE}" "\$@"
+DATEEOF
+  chmod +x "${SHIM_DIR}/date"
+fi
+
+# ── Stub gh ──────────────────────────────────────────────────────────────────
+# Records every argv to $FAKE_GH_LOG. `pr checks <n> --repo <r>` is served
+# from $FAKE_GH_FIXTURES/checks_<repo-with-underscores>_<n>.tsv as raw TSV
+# text (gh pr checks is NOT JSON). `pr view <n> --repo <r> --json ...` is
+# served from $FAKE_GH_FIXTURES/view_<repo>_<n>.json. Missing fixtures mean
+# "gh call failed" (empty stdout, non-zero exit) so the error-handling paths
+# are reachable without a dedicated flag file.
+cat >"${SHIM_DIR}/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FAKE_GH_LOG}"
+cmd="${1:-}"
+case "$cmd" in
+  pr)
+    sub="${2:-}"
+    case "$sub" in
+      checks)
+        num="${3:-}"
+        repo=""
+        shift 3
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --repo) repo="$2"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        key="checks_$(printf '%s' "$repo" | tr '/' '_')_${num}"
+        f="${FAKE_GH_FIXTURES}/${key}.tsv"
+        [ -f "$f" ] || { echo "stub gh: no checks fixture for ${key}" >&2; exit 1; }
+        cat "$f"
+        # gh pr checks exits non-zero whenever any check is failing/pending —
+        # mirror that so the caller's `|| true` path is exercised too.
+        grep -qiE '\bfail\b|\bpending\b' "$f" && exit 1
+        exit 0
+        ;;
+      view)
+        num="${3:-}"
+        repo=""
+        shift 3
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --repo) repo="$2"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        key="view_$(printf '%s' "$repo" | tr '/' '_')_${num}"
+        f="${FAKE_GH_FIXTURES}/${key}.json"
+        [ -f "$f" ] || { echo '{}'; exit 1; }
+        cat "$f"
+        exit 0
+        ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+STUBEOF
+chmod +x "${SHIM_DIR}/gh"
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+# One repo, several PRs exercising each gate independently plus one PR that
+# combines two block reasons (labels test the reasons array, not just the
+# eligible/not_ready split).
+mkchecks() { # mkchecks <file> "<name>\t<status>" ...
+  local f="$1"; shift
+  : >"$f"
+  for line in "$@"; do printf '%b\n' "$line" >>"$f"; done
+}
+mkview() { # mkview <file> <author> <draft> <mergeable> <reviewDecision> <labels-json>
+  local f="$1"; shift
+  printf '{"title":"t","author":{"login":"%s"},"isDraft":%s,"mergeable":"%s","reviewDecision":"%s","labels":%s}\n' \
+    "$1" "$2" "$3" "$4" "$5" >"$f"
+}
+
+REPO="acme/primary"
+RKEY="acme_primary"
+
+# 401: AI-authored, CI green, mergeable, not held -> ELIGIBLE (positive control)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_401.tsv" "unit-tests\tpass\t1m\turl" "lint\tpass\t10s\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_401.json" "hive-bot" "false" "MERGEABLE" "" "[]"
+
+# 402: community-authored, CI green, mergeable, APPROVED -> ELIGIBLE (positive control)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_402.tsv" "unit-tests\tpass\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_402.json" "somedev" "false" "MERGEABLE" "APPROVED" "[]"
+
+# 403: community-authored, CI green, mergeable, NOT approved -> not_ready (author gate)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_403.tsv" "unit-tests\tpass\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_403.json" "somedev" "false" "MERGEABLE" "" "[]"
+
+# 404: AI-authored but a required check FAILS -> not_ready (ci gate)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_404.tsv" "unit-tests\tfail\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_404.json" "hive-bot" "false" "MERGEABLE" "" "[]"
+
+# 405: AI-authored, only an IGNORED check fails -> ELIGIBLE (IGNORED_CHECKS filter)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_405.tsv" "unit-tests\tpass\t1m\turl" "Playwright e2e\tfail\t2m\turl" "tide\tpending\t0s\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_405.json" "hive-bot" "false" "MERGEABLE" "" "[]"
+
+# 406: AI-authored, a check is "skipping" (conditional job) -> treated as pass -> ELIGIBLE
+mkchecks "${FIX_ROOT}/checks_${RKEY}_406.tsv" "unit-tests\tpass\t1m\turl" "windows-only\tskipping\t0s\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_406.json" "hive-bot" "false" "MERGEABLE" "" "[]"
+
+# 407: AI-authored, CI green, but CONFLICTING -> not_ready (mergeable gate)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_407.tsv" "unit-tests\tpass\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_407.json" "hive-bot" "false" "CONFLICTING" "" "[]"
+
+# 408: AI-authored, CI green, mergeable=UNKNOWN (GitHub still computing) -> ELIGIBLE
+mkchecks "${FIX_ROOT}/checks_${RKEY}_408.tsv" "unit-tests\tpass\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_408.json" "hive-bot" "false" "UNKNOWN" "" "[]"
+
+# 409: AI-authored, CI green, mergeable, but carries a `hold` label -> not_ready (deterministic hold-gate)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_409.tsv" "unit-tests\tpass\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_409.json" "hive-bot" "false" "MERGEABLE" "" '[{"name":"hold"}]'
+
+# 410: community-authored, APPROVED, CI green, mergeable, but `do-not-merge` label -> not_ready
+#      (hold-gate wins over approval — held is checked before is_ai/approved)
+mkchecks "${FIX_ROOT}/checks_${RKEY}_410.tsv" "unit-tests\tpass\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_410.json" "somedev" "false" "MERGEABLE" "APPROVED" '[{"name":"do-not-merge"}]'
+
+# 411: gh pr checks returns nothing at all -> not_ready, status=error (fetch-failure gate)
+# (no checks fixture written for 411 — stub exits 1 with a stderr message and
+#  the script's `checks=$(... 2>/dev/null) || true` makes $checks empty)
+
+# 412: AI-authored via PROJECT_AI_AUTHOR env override, CI green, mergeable -> ELIGIBLE
+mkchecks "${FIX_ROOT}/checks_${RKEY}_412.tsv" "unit-tests\tpass\t1m\turl"
+mkview "${FIX_ROOT}/view_${RKEY}_412.json" "custom-bot" "false" "MERGEABLE" "" "[]"
+
+# ── Runner ───────────────────────────────────────────────────────────────────
+run_gate() { # run_gate [VAR=value...]
+  : >"$GH_LOG"
+  env "$@" \
+    PATH="${SHIM_DIR}:${PATH}" \
+    FAKE_GH_LOG="$GH_LOG" \
+    FAKE_GH_FIXTURES="$FIX_ROOT" \
+    bash "$SCRIPT_COPY" >"${WORK}/stdout" 2>"${WORK}/stderr"
+  echo $?
+}
+jget() { python3 -c "
+import json,sys
+try:
+    d=json.load(open('$OUT'))
+except Exception as e:
+    print('JSON-ERROR:'+str(e)); sys.exit(0)
+print($1)
+" 2>/dev/null; }
+
+prfield() { # prfield <list> <number> <field>
+  python3 -c "
+import json
+d=json.load(open('$OUT'))
+for p in d.get('$1', []):
+    if p.get('number') == $2:
+        v = p.get('$3')
+        print(v if not isinstance(v, list) else ','.join(v))
+        break
+else:
+    print('__NOTFOUND__')
+"
+}
+
+assert_eq() { # assert_eq <label> <got> <want>
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "got '$2', want '$3'"; fi
+}
+
+echo "=== merge-gate.sh contract tests ==="
+
+# ── 0. No actionable.json at all: SKIP, exit 0, no output written ───────────
+echo "-- no actionable.json --"
+rc="$(run_gate PROJECT_AI_AUTHOR=hive-bot)"
+assert_eq "no actionable.json: exits 0" "$rc" "0"
+[ -e "$OUT" ] && fail "no actionable.json: merge-eligible.json NOT written" || pass "no actionable.json: merge-eligible.json NOT written"
+grep -q 'SKIP' "$LOG_FILE" && pass "no actionable.json: SKIP logged" || fail "no actionable.json: SKIP logged"
+
+# ── 1. actionable.json with an empty PR list: exits 0, empty eligible doc ───
+echo "-- empty PR list --"
+printf '{"prs":{"items":[]}}\n' >"$ACTIONABLE"
+rc="$(run_gate PROJECT_AI_AUTHOR=hive-bot)"
+assert_eq "empty PR list: exits 0" "$rc" "0"
+assert_eq "empty PR list: publishes an empty (not missing) document" \
+  "$(jget "'{}/{}/{}'.format(d['count'], len(d['merge_eligible']), len(d['not_ready']))")" "0/0/0"
+assert_eq "empty PR list: count is 0" "$(jget "d['count']")" "0"
+assert_eq "empty PR list: no gh calls made" "$(wc -l <"$GH_LOG" | tr -d ' ')" "0"
+
+# ── 2. Full run against all fixture PRs ──────────────────────────────────────
+echo "-- full gate run --"
+python3 -c "
+import json
+prs = [{'repo':'$REPO','number':n} for n in [401,402,403,404,405,406,407,408,409,410,411,412]]
+print(json.dumps({'prs':{'items':prs}}))
+" >"$ACTIONABLE"
+rc="$(run_gate PROJECT_AI_AUTHOR=hive-bot)"
+assert_eq "full run exits 0" "$rc" "0"
+if ! python3 -c "import json; json.load(open('$OUT'))" 2>/dev/null; then
+  echo "harness-error: merge-eligible.json is not valid JSON; stderr was:"; cat "${WORK}/stderr"
+  exit 1
+fi
+
+ELIGIBLE="$(jget "','.join(str(p['number']) for p in d['merge_eligible'])")"
+NOTREADY="$(jget "','.join(str(p['number']) for p in d['not_ready'])")"
+
+echo "-- eligible / not_ready membership --"
+for n in 401 402 405 406 408; do
+  if [[ ",${ELIGIBLE}," == *",${n},"* ]]; then pass "PR #${n} is merge-eligible"; else fail "PR #${n} is merge-eligible" "eligible list: $ELIGIBLE"; fi
+done
+for excl in "403:community author, not approved" "404:required check failing" "407:not mergeable (CONFLICTING)" "409:hold label" "410:do-not-merge label overrides approval" "411:gh pr checks fetch failed"; do
+  n="${excl%%:*}"; why="${excl#*:}"
+  if [[ ",${NOTREADY}," == *",${n},"* ]]; then pass "PR #${n} is not_ready: ${why}"; else fail "PR #${n} is not_ready: ${why}" "not_ready list: $NOTREADY"; fi
+done
+assert_eq "count == number of eligible PRs" "$(jget "d['count']")" "$(jget "len(d['merge_eligible'])")"
+assert_eq "eligible + not_ready covers every PR in actionable.json" \
+  "$(( $(jget "len(d['merge_eligible'])") + $(jget "len(d['not_ready'])") ))" "12"
+
+echo "-- IGNORED_CHECKS filter (tide, Playwright, attribute, Storybook, Visual , Verify build after merge) --"
+assert_eq "PR #405: Playwright/tide failures are ignored, only unit-tests counts" "$(prfield merge_eligible 405 status)" "pass"
+
+echo "-- 'skipping' status normalized to pass --"
+assert_eq "PR #406: a skipping check does not block eligibility" "$(prfield merge_eligible 406 status)" "pass"
+
+echo "-- block_reasons content on not_ready PRs --"
+assert_eq "PR #403 block_reasons cites author, not held/ci/mergeable" "$(prfield not_ready 403 block_reasons)" "author=somedev (not AI, not approved)"
+assert_eq "PR #404 block_reasons cites ci status" "$(prfield not_ready 404 block_reasons)" "ci=fail"
+assert_eq "PR #407 block_reasons cites mergeable=CONFLICTING" "$(prfield not_ready 407 block_reasons)" "mergeable=CONFLICTING"
+assert_eq "PR #409 block_reasons cites held (hold label present)" "$(prfield not_ready 409 block_reasons)" "held (hold label present)"
+assert_eq "PR #410 block_reasons cites held even though reviewDecision=APPROVED (hold-gate wins)" "$(prfield not_ready 410 block_reasons)" "held (hold label present)"
+assert_eq "PR #411 status is 'error' when gh pr checks fetch fails" "$(prfield not_ready 411 status)" "error"
+
+echo "-- ai_authored / held / ci_pass / approved flags on the record --"
+assert_eq "PR #401 ai_authored=True (default AI_AUTHORS set)" "$(prfield merge_eligible 401 ai_authored)" "True"
+assert_eq "PR #402 approved=True (community + APPROVED review)" "$(prfield merge_eligible 402 approved)" "True"
+assert_eq "PR #409 held=True" "$(prfield not_ready 409 held)" "True"
+
+echo "-- PROJECT_AI_AUTHOR env override extends AI_AUTHORS --"
+python3 -c "
+import json
+print(json.dumps({'prs':{'items':[{'repo':'$REPO','number':412}]}}))
+" >"$ACTIONABLE"
+rc="$(run_gate PROJECT_AI_AUTHOR=custom-bot)"
+assert_eq "custom AI author run exits 0" "$rc" "0"
+assert_eq "PR #412 (author=custom-bot) is eligible only when PROJECT_AI_AUTHOR=custom-bot is set" \
+  "$(jget "','.join(str(p['number']) for p in d['merge_eligible'])")" "412"
+
+echo "-- POSITIVE CONTROL: without PROJECT_AI_AUTHOR override, custom-bot is NOT auto-trusted --"
+rc="$(run_gate)"
+assert_eq "no PROJECT_AI_AUTHOR: run still exits 0" "$rc" "0"
+assert_eq "PR #412 (author=custom-bot) is NOT eligible without the override (not in the built-in AI_AUTHORS set)" \
+  "$(jget "','.join(str(p['number']) for p in d['merge_eligible'])")" ""
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What

Adds `bin/test_merge_gate.sh` and `bin/test_gh_rate_check.sh`, behavioural contract tests for two untested runtime scripts that sit on the merge path:

- **`bin/merge-gate.sh`** (185 lines) — called from `bin/conflict-sweeper.sh`, `bin/gh-wrapper.sh`, `bin/kick-agents.sh`. Reads `actionable.json` (written by `enumerate-actionable.sh`) and writes `merge-eligible.json`, the ONE file agents are told to trust before running `gh pr merge`.
- **`bin/gh-rate-check.sh`** (293 lines) — called from `bin/kick-agents.sh`. Scans agent tmux panes for GitHub API rate-limit text and decides which agents to pause, and for how long.

Neither script had a test. `grep -rl 'merge-gate.sh\|gh-rate-check.sh' --include='*_test*' --include='test_*'` was empty for both before this PR.

## How

Same shape as `bin/test_enumerate_actionable.sh` (#5527) and `bin/test_gh_wrapper_gates.sh`: each harness **EXECUTES** the script rather than grepping it, against stub `gh`/`tmux`/`curl` fakes in a temp `PATH` dir and temp state dirs, with PASS/FAIL per case and non-zero exit on any failure. Every exclusion assertion sits next to a positive control that IS included/eligible/alerted, so a gate or matcher that admits/fires on everything cannot pass.

- Both scripts hardcode their state paths with no env override (`merge-gate.sh`: `/var/run/hive-metrics/{actionable,merge-eligible}.json`, `/var/log/kick-agents.log`; `gh-rate-check.sh`: `/var/run/hive-metrics/{gh_rate_limits.json,rate_pullback/}`, `/var/run/kick-governor`, `/var/log/kick-agents.log`, `/etc/hive/`), so each harness runs a `sed`-rewritten COPY with those paths pointed at a temp dir, and fails as a harness error if the rewrite does not land. `gh-rate-check.sh`'s `GH_BIN`/`TMUX_BIN`/`NTFY_SERVER`/`NTFY_TOPIC`/`GOVERNOR_ENV` ARE overridable via env, so the harness uses those overrides directly instead of rewriting them.
- `test_merge_gate.sh`'s stub `gh` serves canned `pr checks` TSV (gh's real output format, not JSON) and `pr view --json` fixtures keyed by repo/PR number, so the `IGNORED_CHECKS` regex filter and the eligibility arithmetic run through the script's own Python, not a re-implementation.
- `test_gh_rate_check.sh`'s stub `gh` serves `rate_limit` fixtures through real `jq` (so the script's own `--jq` filters are under test), its stub `tmux` serves canned pane text keyed by session name, and its stub `curl` records every ntfy POST's title/body without any network call.
- Hermetic: no network, never touches `/var/run`, `/data` or `/tmp/hive`. Both harnesses shim GNU `date -Is` only when the host `date` doesn't support it (BSD date on macOS dev boxes); CI's `date` is GNU and the shim is a no-op there. Both harnesses also probe for a working non-interactive `python3` on `PATH` before running (a dev-box shim that hangs on stdin is not a script bug); ubuntu-latest's `python3` is a real interpreter and is picked immediately.

## Contracts pinned

### `bin/merge-gate.sh` (36 assertions)

1. **No `actionable.json`** — exits 0, `merge-eligible.json` is NOT written, SKIP is logged (the "run enumerate-actionable.sh first" contract).
2. **Empty PR list** — exits 0, publishes an empty (not missing) document, no `gh` calls.
3. **Eligibility gate** (POSITIVE CONTROL: AI-authored + CI-green + mergeable + unheld PR is eligible) against every individual block reason:
   - community author without an APPROVED review
   - a required CI check failing
   - `mergeable != MERGEABLE/UNKNOWN` (`CONFLICTING`)
   - a `hold`-family label present (the deterministic hold-gate wins even over `reviewDecision=APPROVED`)
   - `gh pr checks` fetch failure (`status: "error"`)
4. **`IGNORED_CHECKS` filter** — `tide`/`Playwright`/etc. failures do not block eligibility when the only non-ignored check passes.
5. **`skipping` status normalization** — a `skipping` check (conditional job) is treated as `pass`, not as blocking.
6. **`mergeable=UNKNOWN`** (GitHub still computing) is treated as eligible, not blocked.
7. **`block_reasons` content** — each not-ready PR's reasons array names the actual gate(s) that fired.
8. **`PROJECT_AI_AUTHOR` env override** — extends the built-in `AI_AUTHORS` set; a custom bot author is eligible only when the env var names it, and a POSITIVE/NEGATIVE control pair proves the override is doing the work (not some other gate).
9. **Output arithmetic** — `count == len(merge_eligible)`, `eligible + not_ready` covers every PR in `actionable.json`.

### `bin/gh-rate-check.sh` (52 assertions)

1. **No agent tmux sessions** — exits 0, empty alerts/pullbacks, no agent paused.
2. **Detection** — GH rate-limit text in one agent's pane produces exactly one alert attributed to that agent, with the matched line captured verbatim; the triggering agent itself is NOT paused ("let it finish its cycle"); every other same-CLI agent IS paused; exactly one pullback state file records who it paused; both the pullback ntfy and the per-hit ntfy fire.
3. **Dedup** — a second run against the same pane text does not duplicate the alert, does not create a second pullback file, and does not re-fire the pullback ntfy.
4. **`CLI_EXCLUDE_PATTERNS` vs `GH_RATE_PATTERNS`** — NEGATIVE CONTROL: Claude/Copilot CLI usage-limit text ("You're out of extra usage... resets 3pm") alone raises no GH alert; POSITIVE CONTROL: a genuine GH pattern (`secondary rate limit`) still fires when CLI-usage text is also present in the same pane, and the alert message is the GH line, not the excluded one.
5. **Operator-paused exemption** — an agent already `operator_paused_*` is never touched by a pullback (recorded in `already_paused`, not `paused_agents`, and its governor flag is never added), and — after the pullback naturally expires — the operator-paused agent stays paused while the governor-paused agents are resumed.
6. **TTL-based alert expiry** vs **`api_reset_epoch`-based expiry** — an alert with no reset time expires on `TTL_SECONDS`; an alert within its TTL survives; an alert whose `api_reset_epoch` has already passed is pruned even though its TTL has not elapsed (reset time takes priority).
7. **Recovery** — `gh api rate_limit --jq .rate.remaining > 0` while alerts are active clears every alert AND every active pullback (resuming governor-paused agents, leaving operator-paused agents' own flag untouched); POSITIVE CONTROL: `remaining <= 0` does NOT trigger recovery, the alert survives.
8. **`GOVERNOR_ENV` pattern override** — `SENSING_GH_RATE_PATTERNS` from the governor env file replaces the built-in pattern outright: default-pattern text does NOT alert once overridden, and NEGATIVE/POSITIVE controls prove the overridden marker text does.

## CI wiring

Two steps added to `.github/workflows/v2-ci.yml`'s `build-and-test` job, directly after `gh-wrapper gate tests` (before `git-credential-hive helper tests`), each with a why-comment in the sibling style explaining the blast radius and what the harness executes. `bin/test_bin_suites_wired.sh` (the guard that fails CI when a `bin/test_*.sh` file isn't named by any workflow) passes with both new suites listed. YAML validated with `ruby -ryaml -e 'YAML.load_file(".github/workflows/v2-ci.yml")'`.

## Suspected bugs found

**None.** Both scripts behaved exactly as their comments and structure indicate through every case calibrated locally — no pin-current-behaviour comments were needed in either test file. (Calibration did surface one local-environment-only artifact, not a script bug: a broken dev-box `python3` shim on `PATH` that hangs on stdin instead of erroring; the harnesses probe for a working interpreter before running and are otherwise unaffected on CI, where ubuntu-latest's `python3` is picked immediately.)

## CI cost

`test_merge_gate.sh`: 36 assertions, ~1s locally (few `gh`/python3 spawns, 12 parallel PR checks). `test_gh_rate_check.sh`: 52 assertions, ~2s locally. Both run in `build-and-test` alongside the other `bin/test_*.sh` suites, not on the test-gate critical path. No network in either.

No CHANGELOG edit; neither script under test is touched.
