### PR TITLE
🐛 fix: two mechanisms that ran and silently did nothing — SHA re-check (#5528) and digest pagination (#5522)

### DIFF
--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -328,7 +328,15 @@ done > "$sha_recheck_tmp"
 
 SHA_RECHECK_PARALLELISM=8
 if [ -s "$sha_recheck_tmp" ]; then
-  cat "$sha_recheck_tmp" | xargs -P "$SHA_RECHECK_PARALLELISM" -I {} bash -c '
+  # NOTE (#5528): the fan-out MUST NOT use `xargs -I {}`. -I substitutes every
+  # occurrence of the replacement string in the initial arguments — including
+  # the four python dict literals below (d.get("data",{}), (issue.get("author")
+  # or {}), issue.get("comments",{}), (c.get("author") or {})) which live
+  # inside this quoted script body. That rewrote them to the input line and
+  # made the child python a guaranteed SyntaxError on every entry, silently
+  # downgraded to the string "skip" — so SHA-UNHOLD never fired. `-n 1` passes
+  # the line as $1 and leaves the body untouched.
+  xargs -P "$SHA_RECHECK_PARALLELISM" -n 1 bash -c '
     entry="$1"
     repo="${entry%%:*}"
     rest="${entry#*:}"
@@ -347,6 +355,7 @@ if [ -s "$sha_recheck_tmp" ]; then
           }
         }
       }" 2>/dev/null) || { echo "${repo}:${num}:${marker_file}:skip"; exit 0; }
+    py_err=$(mktemp)
     state=$(echo "$result" | python3 -c "
 import json, sys, re
 d = json.load(sys.stdin)
@@ -364,9 +373,18 @@ reporter_text = body + \" \" + \" \".join(
 )
 SHA_RE = re.compile(r\"[0-9a-f]{7,40}\\b\")
 print(\"has_sha\" if SHA_RE.search(reporter_text) else \"no_sha\")
-" 2>/dev/null || echo "skip")
+" 2>"$py_err") || state="error"
+    # #5528 layer 2: a crashing classifier used to emit the same string as a
+    # legitimate "skip" verdict, so a total failure of this loop was
+    # indistinguishable from a run with nothing to do. Keep them separate and
+    # surface the interpreter error instead of discarding it with 2>/dev/null.
+    if [ "$state" = "error" ] || [ -z "$state" ]; then
+      state="error"
+      echo "SHA-RECHECK-ERROR: ${repo}#${num} classifier failed: $(tr "\n" " " < "$py_err" | tail -c 400)" >&2
+    fi
+    rm -f "$py_err"
     echo "${repo}:${num}:${marker_file}:${state}"
-  ' _ {} >> "$sha_recheck_results"
+  ' _ < "$sha_recheck_tmp" >> "$sha_recheck_results"
 fi
 
 while IFS=: read -r repo num marker_file state; do

--- a/bin/test_enumerate_actionable.sh
+++ b/bin/test_enumerate_actionable.sh
@@ -145,18 +145,36 @@ if ! xargs --version >/dev/null 2>&1; then
   # Sequential subset of GNU `xargs -P N -I REPL cmd args...`.
   cat >"${SHIM_DIR}/xargs" <<'XARGSEOF'
 #!/usr/bin/env bash
+# Sequential subset of GNU `xargs -P N [-I REPL | -n 1] cmd args...`.
+# -I REPL  : substitute REPL everywhere in the initial arguments (the GNU
+#            behaviour that caused #5528 — kept so the ADOPTERS batch at
+#            line ~208, which legitimately uses -I, still runs here).
+# -n 1     : append the line as one extra argument, leaving the initial
+#            arguments byte-for-byte untouched. The SHA re-check uses this
+#            form; a shim that only understood -I would silently fail the
+#            fixed script and make this whole section vacuous.
 repl=""
+nargs=""
 while [ $# -gt 0 ]; do
   case "$1" in
     -P) shift 2 ;;
     -I) repl="$2"; shift 2 ;;
+    -n) nargs="$2"; shift 2 ;;
     *)  break ;;
   esac
 done
+if [ -z "$repl" ] && [ "$nargs" != "1" ]; then
+  echo "xargs shim: unsupported invocation (need -I REPL or -n 1)" >&2
+  exit 2
+fi
 while IFS= read -r line; do
   [ -n "$line" ] || continue
   args=()
-  for a in "$@"; do args+=("${a//"$repl"/$line}"); done
+  if [ -n "$repl" ]; then
+    for a in "$@"; do args+=("${a//"$repl"/$line}"); done
+  else
+    args=("$@" "$line")
+  fi
   "${args[@]}"
 done
 exit 0
@@ -253,11 +271,13 @@ files src/other.go                >"${BASE}/repos_acme_primary_pulls_305_files.j
 files src/main.go                 >"${BASE}/repos_acme_secondary_pulls_401_files.json"
 files adopters.md                 >"${BASE}/repos_acme_secondary_pulls_402_files.json"
 
-# Re-check fixture for #109: the reporter later commented with a SHA.
+# Re-check fixture for #109, BASE state: the reporter has not answered yet, so
+# the re-check must find no SHA and leave the hold in place. This must agree
+# with the REST fixture that made #109 eligible for the hold — before #5528
+# was fixed the re-check never ran, so the two could disagree unnoticed.
 cat >"${BASE}/graphql_109.json" <<'EOF'
 {"data":{"repository":{"issue":{"state":"OPEN","body":"It crashes on startup","author":{"login":"newcomer"},
- "comments":{"nodes":[{"author":{"login":"hive-bot"},"body":"please add the SHA"},
-                      {"author":{"login":"newcomer"},"body":"sure: 9f8e7d6c5b4a"}]}}}}}
+ "comments":{"nodes":[{"author":{"login":"hive-bot"},"body":"please add the SHA"}]}}}}}
 EOF
 
 # ── Runner ───────────────────────────────────────────────────────────────────
@@ -389,39 +409,87 @@ assert_eq "run 2: hold label is NOT re-added (marker)" "$(gh_calls '--add-label 
 assert_eq "run 2: unresolved marker is re-checked via GraphQL" "$(gh_calls 'api graphql')" "1"
 assert_eq "run 2: POSITIVE CONTROL — the other issues are unchanged" "$(jget '[.issues.items[].number | select(. != 109)] | join(",")')" "201,101,110,111"
 
-# DOCUMENTS THE CURRENT STATE (BUG — see the PR body): the re-check fan-out is
-# `xargs -I {} bash -c '<script>' _ {}`, and -I substitutes EVERY `{}` in the
-# initial arguments — including the python literals d.get("data",{}),
-# (issue.get("author") or {}), issue.get("comments",{}) INSIDE the script
-# string. The child's python is a SyntaxError on every entry, the trailing
-# `|| echo "skip"` hides it, and the has_sha/closed branches below are
-# unreachable. GNU xargs in production behaves exactly like the harness. The
-# graphql_109 fixture says the reporter supplied a SHA in a comment, yet #109
-# is never unheld, never re-admitted, its marker never resolves, and it is
-# re-queried every cycle for as long as the marker exists. Pinned so the fix
-# flips these deliberately (to: unhold call once, marker resolved=, #109 back
-# in items, no GraphQL on run 3).
-if [ "$(gh_calls 'issue edit 109 --repo acme/primary --remove-label hold --add-label kind/bug')" = "0" ]; then
-  pass "run 2: [pinned bug] SHA in the reporter's comment does NOT unhold #109"
-else
-  fail "run 2: [pinned bug] SHA in the reporter's comment does NOT unhold #109" "unhold fired — the xargs {} clobber is fixed; flip these pins to the intended lifecycle"
-fi
+# ── #5528: the SHA re-check actually runs now ───────────────────────────────
+# These assertions were PINNED to the broken behaviour by #5527. The re-check
+# fan-out used to be `xargs -I {} bash -c '<script>' _ {}`; -I substitutes
+# EVERY `{}` in the initial arguments, including the python literals
+# d.get("data",{}), (issue.get("author") or {}), issue.get("comments",{}) and
+# (c.get("author") or {}) INSIDE the quoted script body, so the child python
+# was a SyntaxError on every entry and `2>/dev/null || echo "skip"` laundered
+# it into a plausible verdict. SHA-UNHOLD therefore never fired. The fan-out
+# now uses `-n 1` (the line arrives as $1, the body is untouched) and a
+# classifier crash reports `error` on stderr instead of masquerading as
+# `skip`.
+echo "-- SHA re-check: reporter supplies the SHA (#5528) --"
+SHAADDED="${FIX_ROOT}/shaadded"
+rm -rf "$SHAADDED"; cp -R "$BASE" "$SHAADDED"
+# Same GitHub state EXCEPT the reporter has now answered with a SHA. This is
+# the entry the re-check failed on for its entire existence.
+cat >"${SHAADDED}/graphql_109.json" <<'EOF'
+{"data":{"repository":{"issue":{"state":"OPEN","body":"It crashes on startup","author":{"login":"newcomer"},
+ "comments":{"nodes":[{"author":{"login":"hive-bot"},"body":"please add the SHA"},
+                      {"author":{"login":"newcomer"},"body":"sure: 9f8e7d6c5b4a"}]}}}}}
+EOF
+rc="$(run_enum "$SHAADDED" "${PROJ[@]}")"
+assert_eq "run 3 exits 0" "$rc" "0"
+assert_eq "run 3: SHA in the reporter's comment unholds #109 exactly once" \
+  "$(gh_calls 'issue edit 109 --repo acme/primary --remove-label hold --add-label kind/bug')" "1"
 if grep -q '^resolved=' "$MARKER"; then
-  fail "run 2: [pinned bug] marker is never stamped resolved=" "marker resolved — flip these pins to the intended lifecycle"
+  pass "run 3: marker is stamped resolved="
 else
-  pass "run 2: [pinned bug] marker is never stamped resolved="
+  fail "run 3: marker is stamped resolved=" "marker still unresolved: '$(cat "$MARKER" 2>/dev/null)'"
 fi
-ISSUE_NUMS2="$(jget '[.issues.items[].number] | join(",")')"
-if [[ ",${ISSUE_NUMS2}," == *",109,"* ]]; then
-  fail "run 2: [pinned bug] #109 is never re-admitted to actionable" "got $ISSUE_NUMS2 — flip these pins to the intended lifecycle"
+assert_eq "run 3: #109 is re-admitted to actionable" \
+  "$(jget '[.issues.items[].number] | sort | join(",")')" "101,109,110,111,201"
+
+# Run 4: the marker is resolved, so it costs NOTHING — no GraphQL call at all.
+# The unresolved marker used to be re-queried every cycle forever.
+rc="$(run_enum "$SHAADDED" "${PROJ[@]}")"
+assert_eq "run 4: a resolved marker is not re-queried (per-cycle cost is gone)" "${rc}:$(gh_calls 'api graphql')" "0:0"
+assert_eq "run 4: no further label churn on #109" "$(gh_calls 'issue edit 109')" "0"
+
+# Closed-issue branch: the other outcome the clobbered classifier could never
+# reach. A closed held issue must resolve its marker and stop being queried.
+echo "-- SHA re-check: closed issue resolves its marker (#5528) --"
+CLOSEDQL="${FIX_ROOT}/closedql"
+rm -rf "$CLOSEDQL"; cp -R "$BASE" "$CLOSEDQL"
+printf '%s\n' '{"data":{"repository":{"issue":{"state":"CLOSED","body":"nvm","author":{"login":"newcomer"},"comments":{"nodes":[]}}}}}' \
+  >"${CLOSEDQL}/graphql_109.json"
+rm -f "$RUN_DIR"/sha_hold_posted_*
+rc="$(run_enum "$CLOSEDQL" "${PROJ[@]}")"
+assert_eq "closed re-check exits 0" "$rc" "0"
+if grep -q '^resolved=.* closed' "$MARKER" 2>/dev/null; then
+  pass "closed issue stamps the marker resolved=... closed"
 else
-  pass "run 2: [pinned bug] #109 is never re-admitted to actionable"
+  fail "closed issue stamps the marker resolved=... closed" "marker: '$(cat "$MARKER" 2>/dev/null)'"
+fi
+assert_eq "closed issue is NOT unheld (no label writes beyond the initial hold)" \
+  "$(gh_calls 'issue edit 109 --repo acme/primary --remove-label hold')" "0"
+
+# NEGATIVE CONTROL for the second masking layer. A payload that is valid JSON
+# but has no data.repository.issue must NOT be laundered into a confident
+# verdict: no unhold, no resolved= stamp. Before the fix every entry produced
+# the string "skip" whether the classifier worked or crashed, so this case and
+# a total failure of the loop were indistinguishable.
+echo "-- SHA re-check: an unclassifiable payload does not act (#5528 layer 2) --"
+BADQL="${FIX_ROOT}/badql"
+rm -rf "$BADQL"; cp -R "$BASE" "$BADQL"
+printf '%s\n' '{"data":{"repository":{"issue":null}}}' >"${BADQL}/graphql_109.json"
+rm -f "$RUN_DIR"/sha_hold_posted_*
+rc="$(run_enum "$BADQL" "${PROJ[@]}")"
+assert_eq "unclassifiable re-check payload does not fail the run" "$rc" "0"
+assert_eq "unclassifiable re-check payload does not unhold #109" \
+  "$(gh_calls 'issue edit 109 --repo acme/primary --remove-label hold')" "0"
+if grep -q '^resolved=' "$MARKER" 2>/dev/null; then
+  fail "unclassifiable re-check payload leaves the marker unresolved" "marker was resolved on a null issue"
+else
+  pass "unclassifiable re-check payload leaves the marker unresolved"
 fi
 
-# Run 3: an unresolved marker keeps costing one GraphQL call per cycle.
+# Restore the plain held state for the sections below.
+rm -rf "$SHAADDED" "$CLOSEDQL" "$BADQL"
+rm -f "$RUN_DIR"/sha_hold_posted_*
 rc="$(run_enum "$BASE" "${PROJ[@]}")"
-assert_eq "run 3: [pinned bug] the same marker is re-queried again (unbounded per-cycle cost)" "${rc}:$(gh_calls 'api graphql')" "0:1"
-assert_eq "run 3: no label churn on #109" "$(gh_calls 'issue edit 109')" "0"
 
 # ── 7. Partial API failure: retry, degrade per repo, still publish ──────────
 echo "-- partial API failure --"

--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -151,6 +151,33 @@ const (
 	// this forces roughly one real write per hour — enough to keep the
 	// App-banner logic honest while still eliminating ~98% of the no-op edits.
 	advisoryDigestWriteThroughInterval = 60
+	// advisoryDigestCommentsPerPage is the page size used when scanning a
+	// target's comments for the bot's own digest. 100 is GitHub's maximum for
+	// this endpoint; using anything smaller only multiplies the number of
+	// round trips needed to cover the same history.
+	advisoryDigestCommentsPerPage = 100
+	// advisoryDigestScanMaxPages bounds that scan (#5522). findDigestComment
+	// used to read ONE page of 50 and stop, so on any target carrying more
+	// than ~50 comments the bot could not see its own digest and CREATEd a
+	// fresh one every cycle instead of EDITing — each new comment pushing the
+	// digest one position further out of reach. That is the mechanism that
+	// turned a repeat-post bug into 250 separate comments on
+	// ibm/alchemy-logging#686.
+	//
+	// The scan now walks pages NEWEST-FIRST (direction=desc), because the
+	// bot's own digest is overwhelmingly likely to be recent: the common case
+	// resolves on page 1 at the same one-call cost as before, and a target
+	// with thousands of ancient comments is still covered near its head.
+	//
+	// 10 pages x 100 = the most recent 1,000 comments per cycle. WHEN THE CAP
+	// IS HIT the scan stops and reports "not found" — the same answer it gives
+	// for a genuinely absent digest, so the post path CREATEs a new digest
+	// comment. That is a deliberate trade: a digest older than the 1,000 most
+	// recent comments on a target is effectively unreachable, and one new
+	// comment (which every later cycle then finds on page 1 and edits) is
+	// preferable to walking unbounded history on every ~60s cycle. The cap
+	// being hit is logged at Warn so the case is visible rather than silent.
+	advisoryDigestScanMaxPages = 10
 )
 
 // PostAdvisoryDigest updates the existing digest comment on the advisory issue,
@@ -414,14 +441,52 @@ type digestComment struct {
 func (d digestComment) found() bool { return d.id > 0 }
 
 func (c *Client) findDigestCommentDetail(ctx context.Context, owner, repo string, issueNum int) (digestComment, error) {
+	// #5522: scan newest-first and paginate. See advisoryDigestScanMaxPages
+	// for the bound and for what happens when it is reached.
 	opts := &gh.IssueListCommentsOptions{
-		ListOptions: gh.ListOptions{PerPage: 50},
-	}
-	comments, _, err := c.client.Issues.ListComments(ctx, owner, repo, issueNum, opts)
-	if err != nil {
-		return digestComment{}, err
+		Sort:      gh.Ptr("created"),
+		Direction: gh.Ptr("desc"),
+		ListOptions: gh.ListOptions{
+			PerPage: advisoryDigestCommentsPerPage,
+		},
 	}
 	var botAuthored digestComment
+	pages := 0
+	for {
+		comments, resp, err := c.client.Issues.ListComments(ctx, owner, repo, issueNum, opts)
+		if err != nil {
+			// A partial scan that already found a usable fallback still
+			// beats creating a duplicate, so surface the error but keep
+			// whatever the earlier pages turned up.
+			return botAuthored, err
+		}
+		pages++
+		found, done := c.scanDigestPage(owner, repo, issueNum, comments, &botAuthored)
+		if done {
+			return found, nil
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return botAuthored, nil
+		}
+		if pages >= advisoryDigestScanMaxPages {
+			c.logger.Warn("advisory digest comment scan hit its page cap — treating the digest as absent, which will CREATE a new one",
+				slog.String("repo", owner+"/"+repo),
+				slog.Int("issue", issueNum),
+				slog.Int("pages_scanned", pages),
+				slog.Int("comments_scanned", pages*advisoryDigestCommentsPerPage))
+			return botAuthored, nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+// scanDigestPage applies the authorship rules to one page of comments. It
+// returns (comment, true) when it has found the definitive digest to edit and
+// the scan can stop, or (_, false) to continue to the next page. A
+// bot-authored-but-not-provably-ours comment is remembered in botAuthored as a
+// fallback rather than ending the scan, so a later page can still yield an
+// exact match.
+func (c *Client) scanDigestPage(owner, repo string, issueNum int, comments []*gh.IssueComment, botAuthored *digestComment) (digestComment, bool) {
 	for _, comment := range comments {
 		if !strings.HasPrefix(comment.GetBody(), advisoryDigestPrefix) {
 			continue
@@ -430,20 +495,22 @@ func (c *Client) findDigestCommentDetail(ctx context.Context, owner, repo string
 			// Token (PAT) client: historical prefix-only match. The credential
 			// may legitimately be the human who authored the comment, and
 			// authorship cannot be verified without an extra /user round trip.
-			return digestCommentFrom(comment), nil
+			return digestCommentFrom(comment), true
 		}
 		login := comment.GetUser().GetLogin()
 		if c.appBotLogin != "" && login == c.appBotLogin {
 			// Exactly our own bot comment — the one credential-safe choice.
-			return digestCommentFrom(comment), nil
+			return digestCommentFrom(comment), true
 		}
 		if strings.HasSuffix(login, "[bot]") || comment.GetUser().GetType() == "Bot" {
 			// Bot-authored but not provably ours (bot login unknown, or a slug
 			// mismatch between config and the real App). Remember the first as
 			// a fallback rather than skipping it: refusing our own comment on
 			// a misconfigured slug would create a duplicate every cycle.
+			// "First" is now the NEWEST such comment, since the scan runs
+			// newest-first.
 			if !botAuthored.found() {
-				botAuthored = digestCommentFrom(comment)
+				*botAuthored = digestCommentFrom(comment)
 			}
 			continue
 		}
@@ -461,7 +528,7 @@ func (c *Client) findDigestCommentDetail(ctx context.Context, owner, repo string
 			slog.Int64("comment_id", comment.GetID()),
 			slog.String("author", login))
 	}
-	return botAuthored, nil
+	return digestComment{}, false
 }
 
 // digestCommentFrom projects the fields the post path needs out of a forge

--- a/src/pkg/github/advisory_pagination_test.go
+++ b/src/pkg/github/advisory_pagination_test.go
@@ -1,0 +1,328 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// --------------------------------------------------------------------------
+// #5522 — findDigestComment must paginate.
+//
+// The bug: findDigestCommentDetail read ONE page (PerPage: 50) and stopped.
+// On any target carrying more than ~50 comments the bot could not see its own
+// digest, so the post path fell through to CREATE instead of EDIT, and every
+// comment it created pushed the digest one position further out of reach.
+//
+// The fixtures below deliberately place the digest BEYOND the first page. A
+// fixture with the marker at position 3 would pass against the unpaginated
+// code and prove nothing.
+// --------------------------------------------------------------------------
+
+// commentPager serves a synthetic comment list with GitHub's Link header
+// pagination, honouring page/per_page and direction=desc.
+type commentPager struct {
+	// bodies is the comment list in CHRONOLOGICAL order (oldest first), the
+	// order GitHub returns for direction=asc.
+	bodies []string
+	// authors parallels bodies; empty means a plain human login.
+	authors []string
+	// pageRequests records the ?page= value of each request, so a test can
+	// assert how many pages were actually walked.
+	pageRequests []int
+	// lastDirection records the direction parameter of the final request.
+	lastDirection string
+}
+
+func (p *commentPager) handler(t *testing.T, basePath string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		perPage, _ := strconv.Atoi(q.Get("per_page"))
+		if perPage <= 0 {
+			perPage = 30
+		}
+		page, _ := strconv.Atoi(q.Get("page"))
+		if page <= 0 {
+			page = 1
+		}
+		p.pageRequests = append(p.pageRequests, page)
+		p.lastDirection = q.Get("direction")
+
+		// Build the ordered view the caller asked for.
+		type item struct {
+			id     int
+			body   string
+			author string
+		}
+		ordered := make([]item, 0, len(p.bodies))
+		for i, b := range p.bodies {
+			a := ""
+			if i < len(p.authors) {
+				a = p.authors[i]
+			}
+			ordered = append(ordered, item{id: 1000 + i, body: b, author: a})
+		}
+		if q.Get("direction") == "desc" {
+			for i, j := 0, len(ordered)-1; i < j; i, j = i+1, j-1 {
+				ordered[i], ordered[j] = ordered[j], ordered[i]
+			}
+		}
+
+		start := (page - 1) * perPage
+		if start > len(ordered) {
+			start = len(ordered)
+		}
+		end := start + perPage
+		if end > len(ordered) {
+			end = len(ordered)
+		}
+		slice := ordered[start:end]
+
+		out := make([]map[string]any, 0, len(slice))
+		for _, it := range slice {
+			user := map[string]any{"login": "humanreviewer", "type": "User"}
+			if it.author != "" {
+				user = map[string]any{"login": it.author, "type": "Bot"}
+			}
+			out = append(out, map[string]any{
+				"id":   it.id,
+				"body": it.body,
+				"user": user,
+			})
+		}
+		if end < len(ordered) {
+			next := fmt.Sprintf("<%s%s?per_page=%d&page=%d>; rel=\"next\"",
+				"http://"+r.Host, basePath, perPage, page+1)
+			w.Header().Set("Link", next)
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+// digestAt builds n comments with the digest marker at index markerIdx
+// (0-based, chronological). markerIdx < 0 means no digest at all.
+func digestAt(n, markerIdx int) ([]string, []string) {
+	bodies := make([]string, n)
+	authors := make([]string, n)
+	for i := range bodies {
+		bodies[i] = fmt.Sprintf("ordinary human discussion comment #%d", i)
+	}
+	if markerIdx >= 0 && markerIdx < n {
+		bodies[markerIdx] = advisoryDigestPrefix + " — findings for this cycle"
+		authors[markerIdx] = "hive-app[bot]"
+	}
+	return bodies, authors
+}
+
+func newPagerServer(t *testing.T, org, repo string, issue int, p *commentPager) *httptest.Server {
+	t.Helper()
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", org, repo, issue)
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, p.handler(t, path))
+	return httptest.NewServer(mux)
+}
+
+// TestFindDigestComment_MarkerBeyondFirstPage is the direct regression test
+// for #5522. 260 comments with the digest at chronological index 130 — the
+// exact middle, so it is beyond the first page in BOTH orderings: page 1
+// oldest-first (the old PerPage:50 ascending read) covers 0..49, and page 1
+// newest-first covers 259..160. Only a scan that actually turns the page can
+// reach it. A fixture with the marker near either end would be found by the
+// unpaginated code and would prove nothing.
+func TestFindDigestComment_MarkerBeyondFirstPage(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	const markerIdx = 130
+	bodies, authors := digestAt(260, markerIdx)
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	want := 1000 + markerIdx
+	if id != want {
+		t.Fatalf("comment id = %d, want %d — the digest sits at chronological index 130 of 260, "+
+			"so a single-page scan cannot see it and the caller would CREATE a duplicate", id, want)
+	}
+	if len(p.pageRequests) < 2 {
+		t.Errorf("pages requested = %v, want more than one — a marker this deep is unreachable in one page", p.pageRequests)
+	}
+}
+
+// TestFindDigestComment_NewestFirstFindsRecentInOnePage pins the ordering
+// choice: the bot's own digest is overwhelmingly likely to be the most recent
+// comment, so the common case must still cost exactly one API call even on a
+// target with hundreds of comments.
+func TestFindDigestComment_NewestFirstFindsRecentInOnePage(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(400, 399) // newest comment is the digest
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 1000+399 {
+		t.Fatalf("comment id = %d, want %d", id, 1000+399)
+	}
+	if len(p.pageRequests) != 1 {
+		t.Errorf("pages requested = %v, want exactly 1 — a recent digest must not cost a full walk", p.pageRequests)
+	}
+	if p.lastDirection != "desc" {
+		t.Errorf("direction = %q, want %q — the scan must run newest-first", p.lastDirection, "desc")
+	}
+}
+
+// TestFindDigestComment_ScanIsBounded pins the cap stated in
+// advisoryDigestScanMaxPages. A target with far more comments than the cap
+// allows must stop at the cap rather than walking unbounded history every
+// ~60s cycle, and must report "not found" (id 0) so the caller CREATEs a new
+// digest that every later cycle then finds on page 1.
+func TestFindDigestComment_ScanIsBounded(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	total := advisoryDigestScanMaxPages*advisoryDigestCommentsPerPage + 500
+	bodies, authors := digestAt(total, 0) // digest is the OLDEST comment
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 0 {
+		t.Errorf("comment id = %d, want 0 — a digest beyond the cap is reported absent", id)
+	}
+	if len(p.pageRequests) != advisoryDigestScanMaxPages {
+		t.Errorf("pages requested = %d, want exactly %d (the cap)", len(p.pageRequests), advisoryDigestScanMaxPages)
+	}
+}
+
+// TestFindDigestComment_ExhaustsWithoutMarker is the negative control: a
+// paginated scan that finds nothing must return 0 and must not report an
+// error, and must stop when the list is exhausted rather than at the cap.
+func TestFindDigestComment_ExhaustsWithoutMarker(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(250, -1)
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 0 {
+		t.Errorf("comment id = %d, want 0", id)
+	}
+	// 250 comments at 100/page = 3 pages, well under the cap.
+	if len(p.pageRequests) != 3 {
+		t.Errorf("pages requested = %d, want 3 (list exhausted, not capped)", len(p.pageRequests))
+	}
+}
+
+// TestFindDigestComment_BotFallbackSurvivesPagination pins that the
+// not-provably-ours bot fallback (a slug mismatch between config and the real
+// App) still works across pages: a fallback seen on page 1 must not be
+// discarded when later pages yield nothing, or the bot would create a
+// duplicate every cycle on a misconfigured slug.
+func TestFindDigestComment_BotFallbackSurvivesPagination(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(250, 249) // newest, but authored by ANOTHER bot
+	authors[249] = "some-other-app[bot]"
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]" // does NOT match the comment author
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 1000+249 {
+		t.Errorf("comment id = %d, want %d — the bot-authored fallback found on page 1 "+
+			"must survive the rest of the scan", id, 1000+249)
+	}
+}
+
+// TestFindDigestComment_HumanAuthoredIsSkippedAcrossPages pins that the
+// App-can-never-edit rule (#1927 / kalantar-msb/soft-reflective#1) still
+// applies once the scan is paginated: a human-authored digest comment beyond
+// the first page must be skipped, not adopted.
+func TestFindDigestComment_HumanAuthoredIsSkippedAcrossPages(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(250, 5) // deep in history
+	authors[5] = ""                     // human author
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 0 {
+		t.Errorf("comment id = %d, want 0 — an App can never edit a human-authored comment", id)
+	}
+}
+
+// TestFindDigestComment_PerPageIsMaximised guards against a silent regression
+// to a small page size, which would multiply the round trips needed to cover
+// the same history.
+func TestFindDigestComment_PerPageIsMaximised(t *testing.T) {
+	if advisoryDigestCommentsPerPage != 100 {
+		t.Errorf("advisoryDigestCommentsPerPage = %d, want 100 (GitHub's maximum)", advisoryDigestCommentsPerPage)
+	}
+	org, repo, issue := "testorg", "testrepo", 686
+	var gotPerPage string
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/comments", org, repo, issue),
+		func(w http.ResponseWriter, r *http.Request) {
+			gotPerPage = r.URL.Query().Get("per_page")
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	if _, err := c.findDigestComment(context.Background(), org, repo, issue); err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if gotPerPage != strconv.Itoa(advisoryDigestCommentsPerPage) {
+		t.Errorf("per_page = %q, want %q", gotPerPage, strconv.Itoa(advisoryDigestCommentsPerPage))
+	}
+	_ = strings.TrimSpace("")
+}


### PR DESCRIPTION
Two independent bugs of the same shape: a mechanism runs every cycle, produces
output that reads as a verdict, and has never actually done its job.

Fixes #5528
Fixes #5522

---

## #5528 — the SHA re-check has never run

`bin/enumerate-actionable.sh` fanned the external-issue SHA re-check out as:

```
cat "$tmp" | xargs -P N -I {} bash -c '<script>' _ {}
```

`-I` substitutes **every** occurrence of the replacement string in the initial
arguments — including the four python dict literals that live inside the
quoted child body: `d.get("data",{})`, `(issue.get("author") or {})`,
`issue.get("comments",{})` and `(c.get("author") or {})`. Each was rewritten to
the input line, so the child python raised `SyntaxError` on every entry, on
every run, on GNU and BSD xargs alike:

```
$ printf 'REPO:1:file\n' | xargs -I {} bash -c 'echo "d.get(\"data\",{})"' _ {}
d.get("data",REPO:1:file)
```

**Both masking layers are fixed; either alone leaves the failure invisible.**

**Layer 1 — the clobber.** `xargs -P N -n 1 bash -c '<body>' _` appends the
line as `$1` and leaves the body byte-for-byte untouched.

**Layer 2 — the masking.** The classifier ran as
`python3 -c "..." 2>/dev/null || echo "skip"`, so a crash and a legitimate
`skip` verdict produced the **same string** — a total failure of the loop was
indistinguishable from a cycle with nothing to do. stderr is now captured
rather than discarded, a crash yields the distinct state `error`, and the
interpreter message is logged. `error` matches no branch in the dispatch, so
an unclassifiable entry still declines to act — it just says so.

What was broken, now fixed: an external issue auto-held for a missing commit
SHA was never un-held after the reporter supplied one; closed issues never had
their markers resolved; every unresolved marker cost one GraphQL call per kick
cycle forever.

### What was done with #5527's pinned assertions

PR #5527 added `bin/test_enumerate_actionable.sh`, which **pins the current bug
as expected behaviour** with instructions to flip the pins when it is fixed.
That PR is still open, so its commit is cherry-picked here and the pins are
flipped as part of this fix — otherwise this change would turn its CI red and
look broken. If #5527 merges first, this branch rebases onto it.

Flipped:

- the base `graphql_109` fixture is now the honest pre-answer state (no SHA
  yet). The re-check agreeing with the REST fixture that made #109 eligible for
  hold is now itself asserted — previously the two could disagree unnoticed,
  because the re-check never ran.
- **new run 3** against a fixture where the reporter HAS answered: unhold fires
  exactly once, the marker is stamped `resolved=`, #109 returns to actionable.
- **new run 4**: a resolved marker makes NO GraphQL call — the per-cycle cost
  is gone.
- **new closed-issue case**, the other branch the clobbered classifier could
  never reach: marker stamped `resolved=... closed`, no unhold issued.
- **new negative control for layer 2**: a payload that is valid JSON but
  carries no `data.repository.issue` must not be laundered into a confident
  verdict — no unhold, no `resolved=` stamp.

One more trap worth naming: the harness ships its own `xargs` **shim** (macOS
has no GNU xargs) that only understood `-I`. Left as-is it would have failed
the FIXED script and made this entire section vacuous. It now supports `-n 1`
too, and rejects any other invocation loudly instead of silently doing nothing.

---

## #5522 — findDigestComment read only the first page

`findDigestCommentDetail` read ONE page (`PerPage: 50`, no pagination). Past
~50 comments the bot could no longer see its own digest, so the post path fell
through to CREATE instead of EDIT — and every comment it created pushed the
digest one position further out of reach. That self-reinforcing loop is what
turned a repeat-post bug into 250 separate comments on `ibm/alchemy-logging#686`
rather than 250 edits to one.

#5507 removed the pressure driving the count up. It does not restore
edit-in-place: any target already carrying >50 comments — from ordinary human
discussion, not just bot noise — is past the horizon **today**.

The scan now paginates **newest-first** (`sort=created&direction=desc`) at
GitHub's maximum page size of 100. Newest-first matters: the bot's own digest
is overwhelmingly likely to be recent, so the common case still resolves in
exactly one API call — the same cost as before — with full pagination as the
fallback for anything older.

### The cap

`advisoryDigestScanMaxPages = 10` → the **1,000 most recent comments** per
cycle.

**When the cap is hit** the scan stops and reports *not found* — the same
answer it gives for a genuinely absent digest — so the caller CREATEs a new
digest comment, which every later cycle then finds on page 1 and edits.
Deliberate: a digest buried under the 1,000 most recent comments is effectively
unreachable, and one new comment beats walking unbounded history on every ~60s
cycle. Hitting the cap is logged at `Warn` so the case is visible rather than
silent.

The per-page authorship rules are unchanged, factored into `scanDigestPage`.
Two behaviours preserved across the new page boundary and pinned by tests: the
not-provably-ours bot-authored fallback now carries across pages (a slug
mismatch must not create a duplicate every cycle), and a human-authored digest
comment is still skipped rather than adopted, since an App can never edit one
(#1927, `kalantar-msb/soft-reflective#1`).

---

## Demonstrated-failing evidence

A green run proves nothing here — both mechanisms were green the whole time.
Each fix was watched failing for the right reason first.

**#5528** — flipped assertions run against the **unfixed** script:

```
FAIL: run 3: SHA in the reporter's comment unholds #109 exactly once   got '0', want '1'
FAIL: run 3: marker is stamped resolved=                               marker still unresolved: ''
FAIL: run 3: #109 is re-admitted to actionable                         got '101,110,111,201', want '101,109,110,111,201'
FAIL: run 4: a resolved marker is not re-queried                       got '0:1', want '0:0'
FAIL: closed issue stamps the marker resolved=... closed               marker: ''
=== 78 passed, 5 failed ===
```

With the fix: **83 passed, 0 failed**. (Baseline check first: the ORIGINAL
pinned test passes 76/76 against the unfixed script, confirming the pins were
genuinely pinning the bug.)

**#5522** — new tests run against the **single-page** implementation:

```
TestFindDigestComment_MarkerBeyondFirstPage   id = 0, want 1130
TestFindDigestComment_NewestFirstFindsRecent  id = 0, want 1399
TestFindDigestComment_ScanIsBounded           pages = 1, want 10
TestFindDigestComment_ExhaustsWithoutMarker   pages = 1, want 3
TestFindDigestComment_BotFallbackSurvives     id = 0, want 1249
TestFindDigestComment_PerPageIsMaximised      per_page = 50, want 100
```

The main fixture places the digest at chronological **index 130 of 260** — the
exact middle, so it is outside page 1 in **both** orderings and cannot be
reached without turning a page. A marker near either end would have been found
by the unpaginated code and proved nothing: an earlier draft of this test put
the marker at index 12, which the buggy code found on page 1, and only the
page-count assertion caught it. That draft was a vacuous check and was
replaced.

Full suite: `go test ./pkg/github/` → `ok 47.164s` (skipping the two
pre-existing sandbox-hanging tests, `TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset`
and `TestCommitGreenNoConfigRequiredChecksFallsBackToAPIThenAllowlist`).