### PR TITLE
✨ tui T32: split SSE reconcile and activity poll cadences

### DIFF
--- a/src/pkg/tui/app.go
+++ b/src/pkg/tui/app.go
@@ -31,6 +31,15 @@
 // fallback and the reconciler: healthy stream, 60s reconcile; dropped stream,
 // back to the 5s poll and a header that says so. See the SSE section at the
 // bottom of this file.
+//
+// T32 (#5421): there are TWO poll loops, because the stretch above is only
+// correct for the data the stream carries. Once T30 and T31 hung /api/tokens,
+// /api/cost and /api/audit off the same timer, a healthy stream stretched them
+// to 60s as well — so the Tokens and Events panes became twelve times staler
+// at exactly the moment the header started saying `ws: connected`. The
+// reconciliation loop keeps the 5s/60s behaviour above; the activity loop runs
+// at 5s unconditionally, with its own message type and generation. See poll.go
+// for the split and which reads belong to which class.
 package tui
 
 import (
@@ -313,20 +322,42 @@ type model struct {
 	// the operator sees. Kick success describes only queueing or deduplication.
 	footerStatus string
 
-	// interval is this model's poll cadence, defaulting to pollInterval.
+	// reconcileInterval is the cadence of the reconciliation loop
+	// (pollReconcile), defaulting to pollInterval.
 	//
 	// It is a field rather than a bare constant read for two reasons. Tests
 	// drive a whole tick — fetch, delivery, and the re-arm — without waiting
 	// five real seconds for it. And T13b needs exactly this knob: once the SSE
-	// stream is connected the poll becomes a fallback and should slow down,
-	// not keep hammering an endpoint the stream has already superseded.
-	interval time.Duration
+	// stream is connected this poll becomes a fallback and should slow down,
+	// not keep hammering endpoints the stream has already superseded.
+	reconcileInterval time.Duration
 
-	// tickGen retires superseded poll chains. Changing interval only affects
-	// the NEXT re-arm, so switching cadence means arming a fresh chain while
-	// the old one is still pending; bumping this makes the pending tick a
-	// no-op instead of a second, permanent loop. See tickMsg in poll.go.
-	tickGen uint64
+	// reconcileGen retires superseded reconciliation chains. Changing the
+	// interval only affects the NEXT re-arm, so switching cadence means arming
+	// a fresh chain while the old one is still pending; bumping this makes the
+	// pending tick a no-op instead of a second, permanent loop. See
+	// reconcileTickMsg in poll.go.
+	reconcileGen uint64
+
+	// activityInterval is the cadence of the activity loop (pollActivity). It
+	// is pollInterval and STAYS pollInterval for the life of the process: no
+	// stream event can refresh a token count or an audit row, so there is
+	// nothing for this cadence to respond to.
+	//
+	// It is a field anyway, for the first of the two reasons above only —
+	// tests must be able to run a whole activity tick without sleeping five
+	// real seconds. Nothing in production writes it.
+	activityInterval time.Duration
+
+	// activityGen is the activity loop's own retirement counter.
+	//
+	// It exists so the two chains have independent lifetimes. Sharing
+	// reconcileGen would make the bump that retires a stretched reconcile
+	// chain on an SSE drop also retire the pending activity tick — and the
+	// drop path re-arms only the reconcile chain, so the Tokens and Events
+	// panes would go permanently dark at the first stream blip. See
+	// activityTickMsg in poll.go.
+	activityGen uint64
 
 	// agents is the last fleet roster a poll returned.
 	//
@@ -419,8 +450,9 @@ func newModel() model {
 			panes.NewTokens(),
 			panes.NewEvents(),
 		},
-		api:      client.New(),
-		interval: pollInterval,
+		api:               client.New(),
+		reconcileInterval: pollInterval,
+		activityInterval:  pollInterval,
 	}
 }
 
@@ -434,18 +466,22 @@ func New() tea.Model {
 
 // Init implements tea.Model.
 //
-// It gathers the panes' initial commands and starts the poll loop: one fetch
-// immediately, and the first tick armed for pollInterval later. The immediate
-// fetch is what keeps startup honest — without it every pane would show
-// "waiting for data" for a full interval while a perfectly reachable dashboard
-// sat there answering, and an operator would read that as the TUI being broken.
+// It gathers the panes' initial commands and starts BOTH poll loops: one full
+// fetch immediately, and each loop's first tick armed for its own interval
+// later. The immediate fetch is what keeps startup honest — without it every
+// pane would show "waiting for data" for a full interval while a perfectly
+// reachable dashboard sat there answering, and an operator would read that as
+// the TUI being broken. Both classes are covered by that one m.poll(), so
+// neither loop waits out an interval before its panes have anything, and the
+// two chains are armed separately because they are two chains.
 //
-// The SSE subscription starts here too, and starts ALONGSIDE the poll rather
-// than instead of it: the stream's first event may be seconds away (or never
+// The SSE subscription starts here too, and starts ALONGSIDE the polls rather
+// than instead of them: the stream's first event may be seconds away (or never
 // arrive, on a dashboard that is down), and the first frame must not wait on
-// it. The poll stretches only once the stream has proved itself.
+// it. Only the reconciliation loop stretches, and only once the stream has
+// proved itself.
 func (m model) Init() tea.Cmd {
-	cmds := []tea.Cmd{m.poll(), m.scheduleTick(), m.connectSSE()}
+	cmds := []tea.Cmd{m.poll(), m.scheduleReconcileTick(), m.scheduleActivityTick(), m.connectSSE()}
 	for _, p := range m.panes {
 		if c := p.Init(); c != nil {
 			cmds = append(cmds, c)
@@ -460,16 +496,25 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
-	case tickMsg:
-		if msg.gen != m.tickGen {
+	case reconcileTickMsg:
+		if msg.gen != m.reconcileGen {
 			// A tick from a chain the cadence change retired. Dropping it
-			// without re-arming is what ends that chain; see tickMsg.
+			// without re-arming is what ends that chain; see reconcileTickMsg.
 			return m, nil
 		}
 		// Re-arm BEFORE the fetches are issued, not after they resolve: the
 		// loop's cadence must not depend on how long a fetch takes, and a
 		// dashboard that never answers must not be able to stop the clock.
-		return m, tea.Batch(m.scheduleTick(), m.poll())
+		return m, tea.Batch(m.scheduleReconcileTick(), m.pollReconcile())
+	case activityTickMsg:
+		if msg.gen != m.activityGen {
+			return m, nil
+		}
+		// Same re-arm-first rule, and it matters more here: this loop is the
+		// only source the Tokens and Events panes have, so a /api/audit read
+		// that hangs until its 5s client timeout must not also be the thing
+		// deciding when the next one is attempted.
+		return m, tea.Batch(m.scheduleActivityTick(), m.pollActivity())
 	case fetchErrMsg:
 		// Swallowed on purpose — see fetchErrMsg's doc comment. Returning here
 		// rather than falling through to the broadcast below is the mechanism:
@@ -1560,13 +1605,20 @@ func (m model) handleSSEEvent(msg sseEventMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	// A received event is the only proof the stream is up (see wsConnected),
-	// so it is what resets the backoff and stretches the poll. No new tick
-	// chain is armed for the stretch: the pending tick re-arms itself from
-	// m.interval, so the new cadence takes effect within one pollInterval
-	// without a second chain ever existing.
+	// so it is what resets the backoff and stretches the reconciliation poll.
+	// No new tick chain is armed for the stretch: the pending tick re-arms
+	// itself from m.reconcileInterval, so the new cadence takes effect within
+	// one pollInterval without a second chain ever existing.
+	//
+	// ONLY RECONCILIATION STRETCHES. The activity loop is not touched here —
+	// not its interval, not its generation, not with an extra tick — because
+	// this event carried no token counts and no audit rows, so there is
+	// nothing it could have superseded. Stretching it too is the bug T32
+	// closes: a healthy stream would make the Tokens and Events panes twelve
+	// times staler than a broken one.
 	m.sseConnected = true
 	m.sseBackoff = 0
-	m.interval = sseReconcileInterval
+	m.reconcileInterval = sseReconcileInterval
 
 	cmds := []tea.Cmd{waitSSE(m.sse)}
 
@@ -1630,19 +1682,28 @@ func (m model) handleSSEDropped(msg sseDroppedMsg) (tea.Model, tea.Cmd) {
 		return sseReconnectMsg{gen: gen}
 	})}
 
-	// Only the first drop after a healthy stream restores the poll, because it
-	// is the only one with a stretched cadence to undo. Retiring the 60s chain
-	// and arming a 5s one on EVERY failed reconnect as well would issue a
-	// fetch per backoff step — which is how a dashboard that is down ends up
+	// Only the first drop after a healthy stream restores the cadence, because
+	// it is the only one with a stretched cadence to undo. Retiring the 60s
+	// chain and arming a 5s one on EVERY failed reconnect as well would issue
+	// a fetch per backoff step — which is how a dashboard that is down ends up
 	// receiving more requests than one that is up.
-	if m.interval != pollInterval {
-		m.interval = pollInterval
-		m.tickGen++
+	//
+	// THE FALLBACK FETCH IS pollReconcile, NOT poll. The activity loop never
+	// stretched, so it has been reading /api/tokens, /api/cost and /api/audit
+	// every 5s throughout the healthy stream and is still doing so right now.
+	// A full poll here would issue a second copy of those three reads on top
+	// of a chain that is already mid-interval — duplicate requests that buy no
+	// freshness, on the exact code path a flapping dashboard walks repeatedly.
+	// Nothing here touches activityGen either: this bump retires the stretched
+	// reconcile chain, and the activity chain must survive it untouched.
+	if m.reconcileInterval != pollInterval {
+		m.reconcileInterval = pollInterval
+		m.reconcileGen++
 		// Fetch now as well as re-arming: the pending tick belonged to the 60s
-		// chain this retires, so without an immediate poll the fallback's
+		// chain this retires, so without an immediate fetch the fallback's
 		// first data would be a whole pollInterval away — spent showing a
 		// frame the stream has already stopped updating.
-		cmds = append(cmds, m.scheduleTick(), m.poll())
+		cmds = append(cmds, m.scheduleReconcileTick(), m.pollReconcile())
 	}
 	return m, tea.Batch(cmds...)
 }

--- a/src/pkg/tui/grid_test.go
+++ b/src/pkg/tui/grid_test.go
@@ -34,14 +34,15 @@ func (f *fakePane) Update(tea.Msg) (panes.Pane, tea.Cmd) {
 func (f *fakePane) View(width, height int) string { return f.title }
 func (f *fakePane) Title() string                 { return f.title }
 
-// modelWithFakes swaps every pane for a fake and shortens the poll cadence so
-// a test can run a whole tick — fetch, delivery and re-arm — without waiting
-// out a real interval. The dashboard URL is pinned for the whole package in
-// TestMain, so the fakes' model polls a closed port rather than whatever the
-// developer has running on localhost:3001.
+// modelWithFakes swaps every pane for a fake and shortens both poll cadences
+// so a test can run a whole tick — fetch, delivery and re-arm — without
+// waiting out a real interval. The dashboard URL is pinned for the whole
+// package in TestMain, so the fakes' model polls a closed port rather than
+// whatever the developer has running on localhost:3001.
 func modelWithFakes() (model, []*fakePane) {
 	m := newModel()
-	m.interval = time.Millisecond
+	m.reconcileInterval = time.Millisecond
+	m.activityInterval = time.Millisecond
 	fakes := make([]*fakePane, paneCount)
 	for i := range fakes {
 		fakes[i] = &fakePane{title: m.panes[i].Title()}
@@ -74,7 +75,7 @@ func TestInitBatchesPaneCommands(t *testing.T) {
 		switch msg := msg.(type) {
 		case fakeInitMsg:
 			seen[msg.title] = true
-		case tickMsg:
+		case reconcileTickMsg:
 			sawTick = true
 		}
 	}

--- a/src/pkg/tui/poll.go
+++ b/src/pkg/tui/poll.go
@@ -27,27 +27,62 @@ import (
 // data comes from without changing how often the frame moves. It is also the
 // cadence the fallback returns to: while the stream is up the loop stretches to
 // sseReconcileInterval (app.go), and a dropped stream puts it back here.
+//
+// T32 splits the loop in two, and this is the cadence of both — for opposite
+// reasons. The ACTIVITY loop runs at it unconditionally, because no stream
+// event can refresh what it reads and 5s is the freshest the server rebuilds
+// at. The RECONCILIATION loop runs at it only while the stream is down, and
+// stretches to sseReconcileInterval once the stream proves itself.
 const pollInterval = 5 * time.Second
 
-// tickMsg is the poll heartbeat. It carries no time: the tick is a "go fetch
-// now" signal, not a clock, and nothing reads when it fired. tea.Tick supplies
-// the instant to the callback, which discards it — T13b made this a struct for
-// the generation below, and a field kept only because the callback is handed
-// one would be a value no reader could rely on.
+// The two poll heartbeats. Neither carries a time: a tick is a "go fetch now"
+// signal, not a clock, and nothing reads when it fired. tea.Tick supplies the
+// instant to the callback, which discards it — T13b made this a struct for the
+// generation below, and a field kept only because the callback is handed one
+// would be a value no reader could rely on.
 //
-// GEN IS WHAT KEEPS THE LOOP SINGLE. tea.Tick fires once and the loop stays
-// alive by re-arming from the handler, so "arm the new cadence" and "the old
-// cadence is still armed" are the same instant: T13b changes the cadence when
-// the SSE stream connects or drops, and arming a replacement chain without
-// retiring the old one would leave two live chains ticking forever — one
-// cadence change doubling the fetch rate for the rest of the process's life.
-// Each chain therefore carries the model's tick generation, and a tick whose
+// THERE ARE TWO CHAINS BECAUSE THERE ARE TWO KINDS OF DATA, not because there
+// are two intervals. The stream carries live agent and governor state, so the
+// reconciliation loop can afford to slow to a minute once it is healthy — it
+// is only there to catch a roster change or a silently stalled stream. Nothing
+// on the stream carries token counts, estimated cost, or audit rows, so the
+// activity loop's endpoints are the ONLY source those three panes have. Attach
+// them to the stretching timer, as they were before T32, and a healthy `ws:`
+// indicator would paradoxically make half the screen twelve times staler —
+// the frame looking its most alive at the moment it stopped being.
+//
+// GEN IS WHAT KEEPS EACH LOOP SINGLE. tea.Tick fires once and a loop stays
+// alive by re-arming from its handler, so "arm the new cadence" and "the old
+// cadence is still armed" are the same instant: T13b changes the reconcile
+// cadence when the stream connects or drops, and arming a replacement chain
+// without retiring the old one would leave two live chains ticking forever —
+// one cadence change doubling the fetch rate for the rest of the process's
+// life. Each chain therefore carries its own generation, and a tick whose
 // generation no longer matches is dropped instead of re-armed. That is what
 // ends the superseded chain at its next fire rather than running it alongside
 // the new one.
-type tickMsg struct {
-	gen uint64
-}
+//
+// THE GENERATIONS ARE SEPARATE COUNTERS, and that separation is load-bearing
+// rather than symmetry for its own sake. A shared counter would mean the bump
+// that retires the stretched reconcile chain on an SSE drop also retires the
+// pending activity tick — which nothing re-arms, because the drop path arms a
+// reconcile chain and only a reconcile chain. The Tokens and Events panes
+// would freeze permanently at the first stream drop, which is the exact
+// failure this task exists to prevent, arrived at from the other direction.
+type (
+	// reconcileTickMsg drives the loop whose cadence the stream changes.
+	reconcileTickMsg struct {
+		gen uint64
+	}
+
+	// activityTickMsg drives the fixed loop. Its generation is never bumped
+	// today — the cadence has nothing to respond to — and the guard is kept
+	// anyway because it is what makes that true STRUCTURALLY: the chain cannot
+	// be retired by a reconcile-side bump, only by a deliberate one here.
+	activityTickMsg struct {
+		gen uint64
+	}
+)
 
 // fetchErrMsg reports that one poll failed.
 //
@@ -77,30 +112,50 @@ func (e fetchErrMsg) Error() string {
 	return fmt.Sprintf("%s poll failed: %v", e.source, e.err)
 }
 
-// scheduleTick arms the next heartbeat.
+// scheduleReconcileTick arms the next reconciliation heartbeat.
 //
-// tea.Tick fires ONCE, so the loop is kept alive by re-arming from the tickMsg
+// tea.Tick fires ONCE, so a loop is kept alive by re-arming from its own tick
 // handler rather than by a repeating timer. That is not merely how bubbletea
 // spells it — it is what stops ticks stacking: the next one is scheduled
 // relative to the moment this one was handled, so a slow dashboard cannot
 // queue up a backlog of pending fetches that all land at once when it
 // recovers.
-func (m model) scheduleTick() tea.Cmd {
-	gen := m.tickGen
-	return tea.Tick(m.interval, func(time.Time) tea.Msg {
-		return tickMsg{gen: gen}
+func (m model) scheduleReconcileTick() tea.Cmd {
+	gen := m.reconcileGen
+	return tea.Tick(m.reconcileInterval, func(time.Time) tea.Msg {
+		return reconcileTickMsg{gen: gen}
+	})
+}
+
+// scheduleActivityTick arms the next activity heartbeat.
+//
+// Same shape, deliberately separate function rather than one parameterised by
+// which class it is arming. The pair a caller must get right is (interval,
+// generation), and every caller here picks it by naming the loop instead of by
+// passing two arguments that could be mismatched — arming the activity chain
+// with the reconcile generation would stamp it for retirement by the next
+// cadence change, and nothing about the call site would look wrong.
+func (m model) scheduleActivityTick() tea.Cmd {
+	gen := m.activityGen
+	return tea.Tick(m.activityInterval, func(time.Time) tea.Msg {
+		return activityTickMsg{gen: gen}
 	})
 }
 
 // poll issues every fetch the client can currently make, as one batch.
 //
-// Seven reads today: /api/agents (T4, #5067), the three T29 wired for the
-// Governor pane and the header — /api/status for live governor state,
-// /api/config/governor for the evaluation cadence, and /api/hive-id for the
-// hive's identity — and the two T30 wires for the Tokens pane: /api/tokens for
-// the counts and /api/cost for the estimated spend joined onto them, plus
-// /api/audit for the Events pane (T31). /api/events is deliberately absent: it
-// is the long-lived SSE status stream, not the poll-shaped activity feed.
+// It is the ONE-SHOT full refresh, not a loop: nothing here arms a tick. It is
+// what Init uses to fill the whole frame before either chain's first interval
+// elapses, and what an action handler uses after a write — a pause, a model
+// apply, an ACMM apply, or returning from an attached tmux session — where
+// every class of data is stale at once. A write moves the roster AND appends
+// the operator's own action to the audit log, so refreshing one class and
+// waiting out the other's cadence would show the effect of an action before
+// the record of it.
+//
+// Seven reads today, split between the two loops below: see pollReconcile for
+// the four the stream reconciles against and pollActivity for the three it
+// cannot carry.
 //
 // EACH FETCH FAILS ALONE. They are separate Cmds in one batch rather than one
 // Cmd making seven calls, and that is the failure-isolation property T29 is
@@ -110,18 +165,61 @@ func (m model) scheduleTick() tea.Cmd {
 // Folding them together would make every value only as available as the least
 // available endpoint, because one error return would discard three good
 // results. Batched Cmds also run concurrently, so seven reads cost one round
-// trip of wall time, not seven.
+// trip of wall time, not seven — and that is why splitting the batch in two
+// costs nothing: two concurrent batches are still one round trip.
 //
 // Deliberately NOT polled: /api/health. It exists and would succeed, but
 // nothing in the frame renders it — the header's `ws:` field is SSE connection
 // state, which is T13b's, not API reachability. Polling an endpoint whose
 // result cannot be displayed would spend a request every 5s to learn nothing.
 func (m model) poll() tea.Cmd {
+	return tea.Batch(m.pollReconcile(), m.pollActivity())
+}
+
+// pollReconcile reads the state the SSE stream also carries.
+//
+// Four reads: /api/agents (T4, #5067) and the three T29 wired for the Governor
+// pane and the header — /api/status for live governor state,
+// /api/config/governor for the evaluation cadence, and /api/hive-id for the
+// hive's identity.
+//
+// This is the batch whose cadence the stream changes, and it is the batch that
+// can afford to: every value here either arrives on the stream (agent states,
+// governor status) or changes on human timescales (identity, the configured
+// eval interval). At 60s it is doing the job sseReconcileInterval describes —
+// noticing a roster change the stream does not announce, and bounding how long
+// a silently stalled stream can show a stale frame.
+//
+// /api/config/governor and /api/hive-id are in the reconcile class rather than
+// the activity one even though no stream event carries them, because the class
+// is about how fast the DATA moves, not about which endpoint feeds it. A hive
+// whose name or evaluation cadence changed a minute ago is not a stale frame;
+// a token count that is a minute old, on a fleet burning tokens continuously,
+// is.
+func (m model) pollReconcile() tea.Cmd {
 	return tea.Batch(
 		m.fetchAgents(),
 		m.fetchGovernor(),
 		m.fetchGovernorInterval(),
 		m.fetchHiveID(),
+	)
+}
+
+// pollActivity reads what the SSE stream cannot carry.
+//
+// Three reads: /api/tokens for the counts and /api/cost for the estimated
+// spend joined onto them (T30), and /api/audit for the Events pane (T31).
+// /api/events is deliberately absent: it is the long-lived SSE status stream,
+// not the poll-shaped activity feed, and its payload contains none of these.
+//
+// This batch's cadence NEVER changes. There is no stream event that refreshes
+// a token count or appends an audit row, so slowing it while the stream is
+// healthy would not be trading polling for pushing — it would just be polling
+// less. Before T32 these three shared the reconciliation timer, which meant a
+// connected stream stretched them to 60s: the Tokens and Events panes were at
+// their stalest precisely when the header said the frame was live.
+func (m model) pollActivity() tea.Cmd {
+	return tea.Batch(
 		m.fetchTokens(),
 		m.fetchCosts(),
 		m.fetchEvents(),

--- a/src/pkg/tui/poll_test.go
+++ b/src/pkg/tui/poll_test.go
@@ -75,20 +75,25 @@ func pinDashboard(t *testing.T, url string) {
 	t.Setenv(client.TokenEnv, "test-token")
 }
 
-// pollTestModel is a model pointed at url with a poll interval short enough
-// that a tick can be run to completion inside a test.
+// pollTestModel is a model pointed at url with BOTH poll intervals short
+// enough that a tick can be run to completion inside a test.
 //
-// The interval is what makes these tests fast without sleeping a real one: the
-// AC asks for tick scheduling covered without waiting out the cadence, and the
-// interval being a model field rather than a bare constant read is what allows
-// it. It is deliberately not zero — a zero-duration tea.Tick is a hot loop, and
-// a test that passed with one would hide exactly the bug
+// The intervals are what make these tests fast without sleeping a real one:
+// the AC asks for tick scheduling covered without waiting out the cadence, and
+// each interval being a model field rather than a bare constant read is what
+// allows it. Neither is zero — a zero-duration tea.Tick is a hot loop, and a
+// test that passed with one would hide exactly the bug
 // TestNewModelPollsOnAnInterval guards.
+//
+// Both are shortened, not just the reconcile one: since T32 the two loops have
+// separate timers, and leaving the activity chain at its production 5s would
+// let a test that means to exercise it silently exercise nothing.
 func pollTestModel(t *testing.T, url string) model {
 	t.Helper()
 	pinDashboard(t, url)
 	m := newModel()
-	m.interval = time.Millisecond
+	m.reconcileInterval = time.Millisecond
+	m.activityInterval = time.Millisecond
 	return m
 }
 
@@ -114,12 +119,21 @@ func drain(cmd tea.Cmd) []tea.Msg {
 	return out
 }
 
-// runTick injects a tick into m and returns every message the resulting
-// command produced. The tick is INJECTED, never waited for — that is the AC's
-// "does not sleep real intervals", and it is also what makes these assertions
-// deterministic rather than timing-dependent.
+// runTick injects a RECONCILIATION tick into m and returns every message the
+// resulting command produced. The tick is INJECTED, never waited for — that is
+// the AC's "does not sleep real intervals", and it is also what makes these
+// assertions deterministic rather than timing-dependent.
 func runTick(m model) []tea.Msg {
-	_, cmd := m.Update(tickMsg{})
+	_, cmd := m.Update(reconcileTickMsg{})
+	return drain(cmd)
+}
+
+// runActivityTick is the same for the activity chain. It is a separate helper
+// rather than a parameter because since T32 the two ticks fetch DIFFERENT
+// endpoints, so a test that used the wrong one would not fail loudly — it
+// would assert against a batch that never contained what it was looking for.
+func runActivityTick(m model) []tea.Msg {
+	_, cmd := m.Update(activityTickMsg{})
 	return drain(cmd)
 }
 
@@ -136,11 +150,34 @@ func findAgentsMsg(msgs []tea.Msg) *panes.AgentsMsg {
 
 func hasTick(msgs []tea.Msg) bool {
 	for _, m := range msgs {
-		if _, ok := m.(tickMsg); ok {
+		if _, ok := m.(reconcileTickMsg); ok {
 			return true
 		}
 	}
 	return false
+}
+
+func hasActivityTick(msgs []tea.Msg) bool {
+	for _, m := range msgs {
+		if _, ok := m.(activityTickMsg); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// countMsg counts messages of one type in a drained batch. "Exactly one chain
+// of each class" is a COUNTING claim, so the tests that make it need a counter
+// rather than the boolean has* helpers above: two armed ticks and one armed
+// tick both look like `true`, and two is the failure.
+func countMsg[T tea.Msg](msgs []tea.Msg) int {
+	n := 0
+	for _, m := range msgs {
+		if _, ok := m.(T); ok {
+			n++
+		}
+	}
+	return n
 }
 
 func findFetchErr(msgs []tea.Msg) *fetchErrMsg {
@@ -194,16 +231,28 @@ func newAgentsServer(t *testing.T) *agentsServer {
 // tea.Tick(0, …) fires immediately and forever, so a model that forgot to set
 // the field would spin the CPU and hammer the dashboard as fast as the network
 // allows — while every other test in this package still passed, because they
-// all override the interval themselves.
+// all override the intervals themselves.
+//
+// BOTH are checked. T32 added the second field, and a constructor that set
+// only the one it inherited would leave the activity chain hot-looping on
+// /api/tokens, /api/cost and /api/audit from the moment the TUI started.
 func TestNewModelPollsOnAnInterval(t *testing.T) {
 	pinDashboard(t, closedDashboard)
 	m := newModel()
 
-	if m.interval <= 0 {
-		t.Fatalf("newModel().interval = %v, want a positive cadence (a zero tick is a hot loop)", m.interval)
-	}
-	if m.interval != pollInterval {
-		t.Errorf("newModel().interval = %v, want pollInterval (%v)", m.interval, pollInterval)
+	for _, c := range []struct {
+		name string
+		got  time.Duration
+	}{
+		{"reconcileInterval", m.reconcileInterval},
+		{"activityInterval", m.activityInterval},
+	} {
+		if c.got <= 0 {
+			t.Fatalf("newModel().%s = %v, want a positive cadence (a zero tick is a hot loop)", c.name, c.got)
+		}
+		if c.got != pollInterval {
+			t.Errorf("newModel().%s = %v, want pollInterval (%v)", c.name, c.got, pollInterval)
+		}
 	}
 	if m.api == nil {
 		t.Fatal("newModel() built no client; poll would nil-panic on the first tick")
@@ -227,11 +276,41 @@ func TestInitPollsImmediatelyAndArmsTick(t *testing.T) {
 	if len(got.Agents) != 3 {
 		t.Errorf("Init() delivered %d agents, want 3", len(got.Agents))
 	}
-	if !hasTick(msgs) {
-		t.Error("Init() armed no tick; the poll loop would never run a second time")
+	// BOTH chains must be armed, and exactly once each. Init is the only place
+	// either is started, so a missing arm here is a loop that never runs at
+	// all — and since T32 there are two loops to forget.
+	if n := countMsg[reconcileTickMsg](msgs); n != 1 {
+		t.Errorf("Init() armed %d reconciliation ticks, want exactly 1", n)
+	}
+	if n := countMsg[activityTickMsg](msgs); n != 1 {
+		t.Errorf("Init() armed %d activity ticks, want exactly 1; the Tokens and Events panes would never refresh", n)
 	}
 	if n := server.requests.Load(); n != 1 {
 		t.Errorf("Init() made %d requests, want exactly 1", n)
+	}
+}
+
+// TestInitFetchesBothClassesImmediately is the AC's "neither loop waits one
+// interval before its first data" clause.
+//
+// It is a separate test from the arming one above because they fail
+// differently: an Init that armed both chains but fetched only the reconcile
+// class would still fill the Tokens and Events panes — five seconds late,
+// which is invisible to a test that only checks the chains exist.
+func TestInitFetchesBothClassesImmediately(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+
+	msgs := drain(m.Init())
+
+	if findAgentsMsg(msgs) == nil {
+		t.Error("Init() delivered no agents; the reconciliation class did not fetch at startup")
+	}
+	if countMsg[tokenUsageMsg](msgs) == 0 {
+		t.Error("Init() delivered no token counts; the Tokens pane would say `waiting for data` for a whole interval")
+	}
+	if countMsg[panes.EventsMsg](msgs) == 0 {
+		t.Error("Init() delivered no audit rows; the Events pane would say `waiting for data` for a whole interval")
 	}
 }
 
@@ -245,7 +324,7 @@ func TestTickFetchesAndRearms(t *testing.T) {
 	server := newAgentsServer(t)
 	m := pollTestModel(t, server.URL)
 
-	next, cmd := m.Update(tickMsg{})
+	next, cmd := m.Update(reconcileTickMsg{})
 	if cmd == nil {
 		t.Fatal("a tick produced no command at all")
 	}
@@ -822,8 +901,8 @@ func TestHeaderSurvivesStreamDropAndRecovers(t *testing.T) {
 	// 4. Recovered: the fallback poll keeps refreshing while the stream is
 	// gone. The server now reports a different mode, and the header must
 	// follow it without any stream event.
-	if m.interval != pollInterval {
-		t.Errorf("interval = %v after a drop, want the fallback cadence %v", m.interval, pollInterval)
+	if m.reconcileInterval != pollInterval {
+		t.Errorf("interval = %v after a drop, want the fallback cadence %v", m.reconcileInterval, pollInterval)
 	}
 	m = pollAndApply(t, m)
 	recovered := fmt.Sprintf(headerFormat, "acme-prod", "SURGE", wsNotConnected)
@@ -1800,5 +1879,364 @@ func TestTokenFrameDoesNotOverflowTheMinimumTerminal(t *testing.T) {
 		if got := lipgloss.Width(line); got > minWidth {
 			t.Errorf("line %d is %d columns wide, want at most %d", i, got, minWidth)
 		}
+	}
+}
+
+// ── T32: split reconcile and activity cadences ───────────────────────────────
+
+// streamHealthyModel is a model in the state a healthy stream leaves behind,
+// built so the ACTIVITY chain can still be drained.
+//
+// pollTestModel shortens both intervals; this puts the reconcile one back to
+// the stretched production value, because these tests are about what that
+// stretch does and does not reach. The consequence is that a reconcile tick
+// armed by this model carries a real 60s timer — drainUntil it, never drain().
+func streamHealthyModel(t *testing.T, url string) model {
+	t.Helper()
+	m := pollTestModel(t, url)
+	m = connectedStream(t, m)
+	m.reconcileInterval = sseReconcileInterval
+	return m
+}
+
+// activityMsgCount is how many of the three activity reads a drained batch
+// delivered. It counts rather than reporting presence because the failures it
+// guards are "one of them went missing" and "all three were issued twice".
+func activityMsgCount(msgs []tea.Msg) int {
+	return countMsg[tokenUsageMsg](msgs) +
+		countMsg[costSummaryMsg](msgs) +
+		countMsg[panes.EventsMsg](msgs)
+}
+
+// findEventsMsg returns the delivered audit snapshot, or nil if no EventsMsg
+// was produced.
+func findEventsMsg(msgs []tea.Msg) *panes.EventsMsg {
+	for _, m := range msgs {
+		if e, ok := m.(panes.EventsMsg); ok {
+			return &e
+		}
+	}
+	return nil
+}
+
+// reconcileMsgCount is the same for the four reconciliation reads.
+func reconcileMsgCount(msgs []tea.Msg) int {
+	return countMsg[panes.AgentsMsg](msgs) +
+		countMsg[governorStatusMsg](msgs) +
+		countMsg[governorIntervalMsg](msgs) +
+		countMsg[hiveIDMsg](msgs)
+}
+
+// TestEachTickFetchesOnlyItsOwnClass is the split itself, asserted from both
+// sides.
+//
+// Testing only that each batch contains what it should would pass on a model
+// that never split them at all — one loop fetching everything satisfies every
+// "contains" clause. What distinguishes the split is the ABSENCE: a
+// reconciliation tick must not read /api/audit, and an activity tick must not
+// read /api/agents. Without that, the two loops are one loop running twice.
+func TestEachTickFetchesOnlyItsOwnClass(t *testing.T) {
+	t.Run("reconcile", func(t *testing.T) {
+		server := newDashboardServer(t)
+		m := pollTestModel(t, server.URL)
+
+		msgs := runTick(m)
+
+		if got := reconcileMsgCount(msgs); got != 4 {
+			t.Errorf("a reconciliation tick delivered %d of its 4 reads; a wired endpoint went missing", got)
+		}
+		if got := activityMsgCount(msgs); got != 0 {
+			t.Errorf("a reconciliation tick delivered %d activity reads, want 0 — those belong to the fixed loop", got)
+		}
+		if n := server.auditRequests.Load(); n != 0 {
+			t.Errorf("a reconciliation tick read /api/audit %d times, want 0", n)
+		}
+		if !hasTick(msgs) {
+			t.Error("a reconciliation tick did not arm the next one")
+		}
+		if hasActivityTick(msgs) {
+			t.Error("a reconciliation tick armed an activity chain; the two would multiply on every tick")
+		}
+	})
+
+	t.Run("activity", func(t *testing.T) {
+		server := newDashboardServer(t)
+		m := pollTestModel(t, server.URL)
+
+		msgs := runActivityTick(m)
+
+		if got := activityMsgCount(msgs); got != 3 {
+			t.Errorf("an activity tick delivered %d of its 3 reads; a wired endpoint went missing", got)
+		}
+		if got := reconcileMsgCount(msgs); got != 0 {
+			t.Errorf("an activity tick delivered %d reconciliation reads, want 0 — those belong to the stretching loop", got)
+		}
+		if n := server.auditRequests.Load(); n != 1 {
+			t.Errorf("an activity tick read /api/audit %d times, want exactly 1", n)
+		}
+		if !hasActivityTick(msgs) {
+			t.Error("an activity tick did not arm the next one; the Tokens and Events panes would freeze")
+		}
+		if hasTick(msgs) {
+			t.Error("an activity tick armed a reconciliation chain; the two would multiply on every tick")
+		}
+	})
+}
+
+// TestPollStillIssuesBothClasses pins that splitting the batch did not split
+// the one-shot refresh.
+//
+// poll() is what Init and every action handler use — a pause, a model apply,
+// an ACMM apply, returning from tmux. Those writes move the roster AND append
+// the operator's own action to the audit log, so a poll() that had quietly
+// become reconcile-only would show the effect of an action while the Events
+// pane sat there not recording it.
+func TestPollStillIssuesBothClasses(t *testing.T) {
+	server := newDashboardServer(t)
+	m := pollTestModel(t, server.URL)
+
+	msgs := drain(m.poll())
+
+	if got := reconcileMsgCount(msgs); got != 4 {
+		t.Errorf("poll() delivered %d reconciliation reads, want 4", got)
+	}
+	if got := activityMsgCount(msgs); got != 3 {
+		t.Errorf("poll() delivered %d activity reads, want 3", got)
+	}
+	if hasTick(msgs) || hasActivityTick(msgs) {
+		t.Error("poll() armed a tick chain; it is the one-shot refresh, and arming from an action handler would fork a second loop per keypress")
+	}
+}
+
+// TestHealthyStreamStretchesOnlyTheReconcileLoop is the bug T32 exists to fix,
+// stated as directly as the model allows.
+//
+// Before this change all seven reads hung off one timer, so the SSE event that
+// proved the stream healthy also stretched /api/tokens, /api/cost and
+// /api/audit to 60s. The Tokens and Events panes were therefore at their
+// stalest precisely when the header said `ws: connected` — the frame looking
+// its most alive at the moment half of it stopped moving.
+func TestHealthyStreamStretchesOnlyTheReconcileLoop(t *testing.T) {
+	m := pollTestModel(t, closedDashboard)
+	m = connectedStream(t, m)
+	m.reconcileInterval = pollInterval
+	m.activityInterval = pollInterval
+	beforeGen := m.activityGen
+
+	// The returned command is the stream reader re-arming on channels nothing
+	// ever writes to, so it is deliberately not drained.
+	next, _ := m.Update(sseEventMsg{
+		gen:   m.sseGen,
+		event: sseEvent(client.SSEEventTypeMessage, statusFixture),
+	})
+	got := next.(model)
+
+	if got.reconcileInterval != sseReconcileInterval {
+		t.Errorf("reconcileInterval = %v after a healthy stream event, want %v",
+			got.reconcileInterval, sseReconcileInterval)
+	}
+	if got.activityInterval != pollInterval {
+		t.Errorf("activityInterval = %v after a healthy stream event, want it untouched at %v; "+
+			"no stream event carries token counts or audit rows, so stretching this loop only makes the panes staler",
+			got.activityInterval, pollInterval)
+	}
+	if got.activityGen != beforeGen {
+		t.Error("a stream event retired the activity chain; nothing re-arms it, so the Tokens and Events panes would go dark")
+	}
+}
+
+// TestActivityLoopKeepsRefreshingWhileTheStreamIsHealthy is the same claim
+// made behaviourally rather than by reading a field.
+//
+// The audit body changes between the two ticks, so a model that had attached
+// the activity reads to the stretched timer — or that simply stopped issuing
+// them once connected — delivers the first snapshot twice and fails.
+func TestActivityLoopKeepsRefreshingWhileTheStreamIsHealthy(t *testing.T) {
+	server := newDashboardServer(t)
+	m := streamHealthyModel(t, server.URL)
+
+	first := runActivityTick(m)
+	if activityMsgCount(first) != 3 {
+		t.Fatalf("the first activity tick under a healthy stream delivered %d of 3 reads", activityMsgCount(first))
+	}
+
+	// The hive does something while the stream is up and says nothing about it.
+	server.audit.Store(`{"entries":[{"ts":"2026-09-01T13:00:00Z","user":"operator","action":"while-connected","agent":"scanner"}]}`)
+
+	second := runActivityTick(m)
+	events := findEventsMsg(second)
+	if events == nil {
+		t.Fatal("the second activity tick delivered no audit rows; the loop stopped under a healthy stream")
+	}
+	if len(events.Events) != 1 || events.Events[0].Action != "while-connected" {
+		t.Errorf("the second activity tick replayed the first snapshot: %+v", events.Events)
+	}
+	if n := server.auditRequests.Load(); n != 2 {
+		t.Errorf("/api/audit was read %d times across two activity ticks, want 2", n)
+	}
+	if !hasActivityTick(second) {
+		t.Error("the activity chain did not re-arm while the stream was healthy")
+	}
+}
+
+// TestStreamDropDoesNotRetireTheActivityChain is the failure a shared
+// generation counter would produce, and the reason activityGen exists.
+//
+// The drop path bumps the reconcile generation to retire the stretched 60s
+// chain, and re-arms a reconcile chain only. Had both classes stamped their
+// ticks with that one counter, the same bump would retire the activity tick
+// already in flight — and nothing would ever arm another. The Tokens and
+// Events panes would go dark for the rest of the session at the first stream
+// blip, which is the very failure this task is about, reached from the other
+// side.
+func TestStreamDropDoesNotRetireTheActivityChain(t *testing.T) {
+	server := newDashboardServer(t)
+	m := streamHealthyModel(t, server.URL)
+	inFlightGen, beforeInterval := m.activityGen, m.activityInterval
+
+	next, _ := m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+	got := next.(model)
+
+	if got.activityGen != inFlightGen {
+		t.Errorf("activityGen moved from %d to %d on a stream drop; the in-flight activity tick is now stale",
+			inFlightGen, got.activityGen)
+	}
+	if got.activityInterval != beforeInterval {
+		t.Errorf("activityInterval = %v after a drop, want it untouched at %v", got.activityInterval, beforeInterval)
+	}
+
+	// The proof, rather than the bookkeeping: the tick that was ALREADY ARMED
+	// when the stream dropped — carrying the pre-drop generation — must still
+	// fetch and still re-arm on the post-drop model.
+	_, cmd := got.Update(activityTickMsg{gen: inFlightGen})
+	if cmd == nil {
+		t.Fatal("the activity chain died with the stream; nothing would ever refresh Tokens or Events again")
+	}
+	msgs := drain(cmd)
+	if activityMsgCount(msgs) != 3 {
+		t.Errorf("the activity tick armed before the drop delivered %d of 3 reads afterwards", activityMsgCount(msgs))
+	}
+	if !hasActivityTick(msgs) {
+		t.Error("the surviving activity tick did not arm its successor")
+	}
+}
+
+// TestStreamDropDoesNotDuplicateActivityRequests is the AC's "does not
+// duplicate activity requests" clause.
+//
+// The fallback must fetch immediately — the reconcile data really is stale the
+// moment the stream stops — but the activity loop never stretched, so it has
+// been reading these three endpoints every 5s throughout and is mid-interval
+// right now. A full poll() here would issue a second copy of each, on the
+// exact code path a flapping dashboard walks over and over.
+func TestStreamDropDoesNotDuplicateActivityRequests(t *testing.T) {
+	server := newDashboardServer(t)
+	m := streamHealthyModel(t, server.URL)
+
+	_, cmd := m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+
+	// Waiting for the reconnect message is what makes the counter assertion
+	// trustworthy: it is a real sseBackoffMin timer, so by the time it lands a
+	// duplicate audit fetch against a local test server has had a full second
+	// to complete and be counted.
+	msgs := drainUntil(cmd, finalWait, func(msgs []tea.Msg) bool {
+		return findAgentsMsg(msgs) != nil && hasMsg[sseReconnectMsg](msgs)
+	})
+
+	if findAgentsMsg(msgs) == nil {
+		t.Fatal("the drop issued no immediate reconciliation fetch; the frame would sit stale for a whole interval")
+	}
+	if got := activityMsgCount(msgs); got != 0 {
+		t.Errorf("the drop issued %d activity reads, want 0 — the 5s loop is already doing that", got)
+	}
+	if n := server.auditRequests.Load(); n != 0 {
+		t.Errorf("the drop read /api/audit %d times, want 0", n)
+	}
+	if hasActivityTick(msgs) {
+		t.Error("the drop armed a second activity chain; every reconnect would double the activity fetch rate")
+	}
+}
+
+// TestConnectDropCyclesLeaveOneChainOfEachClass is the AC's repeated-cycle
+// clause, and it is the one a per-cycle leak actually shows up in.
+//
+// Every individual handler can look correct while the pair leaks: an extra
+// chain armed once per cycle is invisible in a single connect/drop test and
+// doubles the request rate every time a flaky dashboard blips. After three
+// full cycles there must still be exactly one live chain of each class — and
+// every retired reconcile generation must be dead, not merely outnumbered.
+func TestConnectDropCyclesLeaveOneChainOfEachClass(t *testing.T) {
+	m := pollTestModel(t, closedDashboard)
+
+	const cycles = 3
+	for range cycles {
+		m = connectedStream(t, m)
+		next, _ := m.Update(sseEventMsg{
+			gen:   m.sseGen,
+			event: sseEvent(client.SSEEventTypeMessage, statusFixture),
+		})
+		m = next.(model)
+		if m.reconcileInterval != sseReconcileInterval {
+			t.Fatalf("cycle setup: reconcileInterval = %v, want the stream to have stretched it", m.reconcileInterval)
+		}
+
+		next, _ = m.Update(sseDroppedMsg{gen: m.sseGen, err: errSSEClosed})
+		m = next.(model)
+	}
+
+	if m.activityGen != 0 {
+		t.Errorf("activityGen = %d after %d connect/drop cycles, want 0; the fixed loop has no cadence to change",
+			m.activityGen, cycles)
+	}
+	if m.reconcileGen != cycles {
+		t.Errorf("reconcileGen = %d after %d cycles, want one retirement per stretch undone", m.reconcileGen, cycles)
+	}
+
+	// Every retired reconcile chain is dead.
+	for gen := uint64(0); gen < m.reconcileGen; gen++ {
+		if _, cmd := m.Update(reconcileTickMsg{gen: gen}); cmd != nil {
+			t.Errorf("a tick from retired reconcile generation %d re-armed itself", gen)
+		}
+	}
+
+	// Exactly one live chain of each class. The reconcile interval is back at
+	// its production 5s after the last drop; shortening it here is what lets
+	// the re-arm be drained without the test sleeping it.
+	m.reconcileInterval = time.Millisecond
+	_, reconcileCmd := m.Update(reconcileTickMsg{gen: m.reconcileGen})
+	if n := countMsg[reconcileTickMsg](drain(reconcileCmd)); n != 1 {
+		t.Errorf("the live reconcile tick armed %d successors, want exactly 1", n)
+	}
+
+	_, activityCmd := m.Update(activityTickMsg{gen: m.activityGen})
+	if n := countMsg[activityTickMsg](drain(activityCmd)); n != 1 {
+		t.Errorf("the live activity tick armed %d successors, want exactly 1", n)
+	}
+}
+
+// TestActivityTickRearmsWhenTheFetchFails is the activity half of the error
+// policy that keeps a loop alive, and it matters more here than for
+// reconciliation: this loop is the ONLY source the Tokens and Events panes
+// have, so an unreachable dashboard that stopped the clock would leave them
+// frozen even after it came back.
+func TestActivityTickRearmsWhenTheFetchFails(t *testing.T) {
+	m := pollTestModel(t, closedDashboard)
+
+	done := make(chan []tea.Msg, 1)
+	go func() { done <- runActivityTick(m) }()
+
+	select {
+	case msgs := <-done:
+		if findFetchErr(msgs) == nil {
+			t.Error("an unreachable dashboard produced no fetchErrMsg on the activity loop")
+		}
+		if activityMsgCount(msgs) != 0 {
+			t.Error("a failed activity fetch produced pane data; panes must never see a zero-valued result")
+		}
+		if !hasActivityTick(msgs) {
+			t.Error("a failed activity fetch stopped the activity loop")
+		}
+	case <-time.After(finalWait):
+		t.Fatal("an activity tick against an unreachable dashboard did not return")
 	}
 }

--- a/src/pkg/tui/sse_test.go
+++ b/src/pkg/tui/sse_test.go
@@ -184,8 +184,13 @@ func hasMsg[T tea.Msg](msgs []tea.Msg) bool {
 }
 
 // connectedModel is a model in the state a healthy stream leaves behind: an
-// open subscription, the header reporting connected, and the poll stretched to
-// the reconcile cadence.
+// open subscription, the header reporting connected, and the RECONCILIATION
+// poll stretched to the reconcile cadence.
+//
+// activityInterval is deliberately left at its constructed pollInterval, which
+// is the whole point of T32: a healthy stream is not a reason for the activity
+// loop to slow down, so the state a healthy stream leaves behind has it still
+// at 5s.
 func connectedModel(t *testing.T, url string) model {
 	t.Helper()
 	pinDashboard(t, url)
@@ -197,24 +202,30 @@ func connectedModel(t *testing.T, url string) model {
 		gen:    m.sseGen,
 	}
 	m.sseConnected = true
-	m.interval = sseReconcileInterval
+	m.reconcileInterval = sseReconcileInterval
 	return m
 }
 
 // TestSSEEventUpdatesAPaneWithoutATick is the AC's first case, driven through
 // the real program.
 //
-// The model's poll interval is set to an hour, so no tick can fire inside the
-// test: everything on screen beyond the single startup fetch arrived because
-// the stream pushed it. Each assertion is something polling cannot produce —
-// /api/agents carries no live state at all, and nothing polled feeds the
-// governor pane today.
+// BOTH poll intervals are set to an hour, so no tick of either class can fire
+// inside the test: everything on screen beyond the single startup fetch
+// arrived because the stream pushed it. Each assertion is something polling
+// cannot produce — /api/agents carries no live state at all, and nothing
+// polled feeds the governor pane today.
+//
+// The activity interval has to be stretched explicitly since T32. It no longer
+// follows the reconcile one, and at its production 5s it would fire twice
+// inside this test's window — not changing the outcome, but making "nothing
+// polled" a claim the test no longer actually establishes.
 func TestSSEEventUpdatesAPaneWithoutATick(t *testing.T) {
 	server := newStreamServer(t, statusFixture)
 	pinDashboard(t, server.URL)
 
 	m := newModel()
-	m.interval = time.Hour
+	m.reconcileInterval = time.Hour
+	m.activityInterval = time.Hour
 
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(100, 30))
 	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
@@ -234,9 +245,9 @@ func TestSSEEventUpdatesAPaneWithoutATick(t *testing.T) {
 	if !final.sseConnected {
 		t.Error("a stream that delivered events left the header disconnected")
 	}
-	if final.interval != sseReconcileInterval {
+	if final.reconcileInterval != sseReconcileInterval {
 		t.Errorf("interval = %v after a healthy stream, want the reconcile cadence %v",
-			final.interval, sseReconcileInterval)
+			final.reconcileInterval, sseReconcileInterval)
 	}
 }
 
@@ -258,8 +269,8 @@ func TestSSEDropFallsBackToPolling(t *testing.T) {
 		t.Fatalf("a dropped stream returned %T, want the root model", next)
 	}
 
-	if got.interval != pollInterval {
-		t.Errorf("interval = %v after a drop, want the fallback cadence %v", got.interval, pollInterval)
+	if got.reconcileInterval != pollInterval {
+		t.Errorf("interval = %v after a drop, want the fallback cadence %v", got.reconcileInterval, pollInterval)
 	}
 	if got.sseConnected {
 		t.Error("a dropped stream still reports connected")
@@ -267,7 +278,7 @@ func TestSSEDropFallsBackToPolling(t *testing.T) {
 	if got.sse != nil {
 		t.Error("a dropped stream was not released")
 	}
-	if got.tickGen == m.tickGen {
+	if got.reconcileGen == m.reconcileGen {
 		t.Error("the stretched tick chain was not retired; the 60s chain would keep ticking alongside the 5s one")
 	}
 	if got.sseGen == m.sseGen {
@@ -314,11 +325,11 @@ func TestRepeatedDropsDoNotRestartTheFallback(t *testing.T) {
 	second, cmd := degraded.Update(sseDroppedMsg{gen: degraded.sseGen, err: errSSEClosed})
 	again := second.(model)
 
-	if again.tickGen != degraded.tickGen {
+	if again.reconcileGen != degraded.reconcileGen {
 		t.Error("a repeated drop armed a second tick chain")
 	}
-	if again.interval != pollInterval {
-		t.Errorf("interval = %v after a repeated drop, want %v", again.interval, pollInterval)
+	if again.reconcileInterval != pollInterval {
+		t.Errorf("interval = %v after a repeated drop, want %v", again.reconcileInterval, pollInterval)
 	}
 	msgs := drainUntil(cmd, finalWait, func(msgs []tea.Msg) bool { return hasMsg[sseReconnectMsg](msgs) })
 	if findAgentsMsg(msgs) != nil {
@@ -336,7 +347,7 @@ func TestRepeatedDropsDoNotRestartTheFallback(t *testing.T) {
 func TestSSEEventStretchesThePollWithoutASecondChain(t *testing.T) {
 	m := connectedModel(t, closedDashboard)
 	m.sseConnected = false
-	m.interval = pollInterval
+	m.reconcileInterval = pollInterval
 	m.sseBackoff = sseBackoffMax
 
 	next, cmd := m.Update(sseEventMsg{
@@ -345,10 +356,10 @@ func TestSSEEventStretchesThePollWithoutASecondChain(t *testing.T) {
 	})
 	got := next.(model)
 
-	if got.interval != sseReconcileInterval {
-		t.Errorf("interval = %v while the stream is healthy, want %v", got.interval, sseReconcileInterval)
+	if got.reconcileInterval != sseReconcileInterval {
+		t.Errorf("interval = %v while the stream is healthy, want %v", got.reconcileInterval, sseReconcileInterval)
 	}
-	if got.tickGen != m.tickGen {
+	if got.reconcileGen != m.reconcileGen {
 		t.Error("stretching the poll armed a second tick chain")
 	}
 	if !got.sseConnected {
@@ -410,8 +421,8 @@ func TestStaleSSEMessagesAreIgnored(t *testing.T) {
 		if got.sseConnected {
 			t.Error("a stale event reported the replacement stream healthy")
 		}
-		if got.interval != pollInterval {
-			t.Errorf("interval = %v, want the fallback cadence untouched by a stale event", got.interval)
+		if got.reconcileInterval != pollInterval {
+			t.Errorf("interval = %v, want the fallback cadence untouched by a stale event", got.reconcileInterval)
 		}
 	})
 
@@ -424,7 +435,7 @@ func TestStaleSSEMessagesAreIgnored(t *testing.T) {
 		if cmd != nil {
 			t.Error("a stale drop produced a command")
 		}
-		if !got.sseConnected || got.interval != sseReconcileInterval {
+		if !got.sseConnected || got.reconcileInterval != sseReconcileInterval {
 			t.Error("a stale drop degraded a healthy stream")
 		}
 	})
@@ -460,39 +471,80 @@ func TestStaleSSEMessagesAreIgnored(t *testing.T) {
 
 // TestStaleTickDoesNotRearm pins the mechanism the fallback relies on: the
 // retired chain ends at its next fire instead of running forever beside the
-// new one.
+// new one. Both classes carry the guard, so both are checked.
 func TestStaleTickDoesNotRearm(t *testing.T) {
-	m := pollTestModel(t, closedDashboard)
-	m.tickGen = 1
+	t.Run("reconcile", func(t *testing.T) {
+		m := pollTestModel(t, closedDashboard)
+		m.reconcileGen = 1
 
-	next, cmd := m.Update(tickMsg{})
-	if cmd != nil {
-		t.Error("a tick from a retired chain re-armed itself")
-	}
-	if next.(model).tickGen != 1 {
-		t.Error("a stale tick changed the tick generation")
-	}
+		next, cmd := m.Update(reconcileTickMsg{})
+		if cmd != nil {
+			t.Error("a tick from a retired chain re-armed itself")
+		}
+		if next.(model).reconcileGen != 1 {
+			t.Error("a stale tick changed the tick generation")
+		}
+	})
+
+	t.Run("activity", func(t *testing.T) {
+		m := pollTestModel(t, closedDashboard)
+		m.activityGen = 1
+
+		next, cmd := m.Update(activityTickMsg{})
+		if cmd != nil {
+			t.Error("a tick from a retired activity chain re-armed itself")
+		}
+		if next.(model).activityGen != 1 {
+			t.Error("a stale activity tick changed the activity generation")
+		}
+	})
 }
 
 // TestScheduleTickStampsTheCurrentGeneration is the other half of that
 // mechanism: a chain armed after a cadence change must carry the new
 // generation, or the guard above would drop the live chain instead of the dead
 // one and the poll would stop entirely.
+//
+// The two cases also pin that each scheduler reads its OWN generation. Arming
+// the activity chain with reconcileGen would compile, run, and look correct
+// until the first stream drop bumped that counter and silently retired a chain
+// nothing re-arms.
 func TestScheduleTickStampsTheCurrentGeneration(t *testing.T) {
-	m := pollTestModel(t, closedDashboard)
-	m.tickGen = 7
+	t.Run("reconcile", func(t *testing.T) {
+		m := pollTestModel(t, closedDashboard)
+		m.reconcileGen = 7
+		m.activityGen = 99
 
-	msgs := drain(m.scheduleTick())
-	if len(msgs) != 1 {
-		t.Fatalf("scheduleTick produced %d messages, want 1", len(msgs))
-	}
-	tick, ok := msgs[0].(tickMsg)
-	if !ok {
-		t.Fatalf("scheduleTick produced %T, want a tickMsg", msgs[0])
-	}
-	if tick.gen != 7 {
-		t.Errorf("tick carries generation %d, want the model's 7", tick.gen)
-	}
+		msgs := drain(m.scheduleReconcileTick())
+		if len(msgs) != 1 {
+			t.Fatalf("scheduleReconcileTick produced %d messages, want 1", len(msgs))
+		}
+		tick, ok := msgs[0].(reconcileTickMsg)
+		if !ok {
+			t.Fatalf("scheduleReconcileTick produced %T, want a reconcileTickMsg", msgs[0])
+		}
+		if tick.gen != 7 {
+			t.Errorf("tick carries generation %d, want the model's reconcileGen 7", tick.gen)
+		}
+	})
+
+	t.Run("activity", func(t *testing.T) {
+		m := pollTestModel(t, closedDashboard)
+		m.reconcileGen = 99
+		m.activityGen = 7
+
+		msgs := drain(m.scheduleActivityTick())
+		if len(msgs) != 1 {
+			t.Fatalf("scheduleActivityTick produced %d messages, want 1", len(msgs))
+		}
+		tick, ok := msgs[0].(activityTickMsg)
+		if !ok {
+			t.Fatalf("scheduleActivityTick produced %T, want an activityTickMsg", msgs[0])
+		}
+		if tick.gen != 7 {
+			t.Errorf("tick carries generation %d, want the model's activityGen 7", tick.gen)
+		}
+	})
 }
 
 // TestPaneMsgsTranslateStatusEvents pins the translation itself: which pane


### PR DESCRIPTION
Fixes #5421

## Summary

- Hive's terminal dashboard (`hivectl tui`) draws four panes and refreshes them on a timer. It also subscribes to the dashboard's live event stream, and **slows that timer down while the stream is healthy** — the stream is already pushing updates, so polling hard would just spend requests to re-learn what it just told us.
- That was correct while the timer only fetched things the stream carries. #5419 (T30) and #5420 (T31) then attached **token counts, estimated cost, and the audit activity feed** to the same timer — and the stream carries none of those. So a connected stream stretched those three reads from 5s to 60s: **the Tokens and Events panes became twelve times staler at exactly the moment the header started reporting `ws: connected`.** The frame looked its most alive as half of it stopped moving.
- This splits the single timer into two independent loops, one per refresh class, so the stream's health only affects the data the stream can actually replace.
- **Blast radius:** `pkg/tui` only. No cadence *values* changed (still 5s and 60s), no client or pane code touched, no visual change, no new flags or endpoints.

## The two classes

| loop | reads | cadence |
|---|---|---|
| **reconciliation** | `/api/agents`, `/api/status`, `/api/config/governor`, `/api/hive-id` | 5s while the stream is down, 60s while it is healthy — unchanged from T13b |
| **activity** | `/api/tokens`, `/api/cost`, `/api/audit` | 5s, **always** |

Each has its own tick message, interval field, and generation counter.

The class boundary is about **how fast the data moves**, not which transport feeds it. `/api/config/governor` and `/api/hive-id` are in the reconcile class even though no stream event carries them either: a hive whose name or evaluation cadence changed a minute ago is not a stale frame, whereas a minute-old token count on a fleet burning tokens continuously is.

## The separate generation counter is load-bearing

This is the part worth reviewing closely. The drop path bumps the reconcile generation to retire the stretched 60s chain, then re-arms **a reconcile chain only**. Had both classes stamped their ticks with one shared counter, that same bump would retire the activity tick already in flight — and nothing would ever arm another.

The Tokens and Events panes would go permanently dark at the first stream blip: the exact failure this task exists to prevent, arrived at from the other direction. `TestStreamDropDoesNotRetireTheActivityChain` pins it by feeding the *pre-drop* generation to the *post-drop* model and asserting it still fetches and still re-arms.

Relatedly, the drop's immediate fallback fetch is now `pollReconcile()` rather than the full `poll()`. The activity loop never stretched, so it has been reading those three endpoints every 5s throughout the healthy stream and is mid-interval at the moment of the drop; a full poll would issue a duplicate copy of each, on the exact code path a flapping dashboard walks repeatedly.

`poll()` itself still issues all seven reads and remains the **one-shot** full refresh — nothing in it arms a tick. That is what `Init` uses so neither loop waits out an interval before its first data, and what every action handler uses after a write. A pause, model apply, or ACMM apply moves the roster *and* appends the operator's own action to the audit log, so a `poll()` that had quietly become reconcile-only would show the effect of an action while the Events pane failed to record it.

## Naming

`tickMsg`/`interval`/`tickGen` are now `reconcileTickMsg`/`reconcileInterval`/`reconcileGen`, with `activityTickMsg`/`activityInterval`/`activityGen` alongside. With two of each, a bare `m.interval` no longer says which loop it belongs to. The rename is mechanical and no existing assertion was weakened — every SSE fallback/backoff test kept its substance.

## Mutation evidence

Every new invariant was proven capable of failing. Each defect was introduced by a patcher that aborts unless its pattern matches exactly once (the repo has been bitten before by a heredoc silently no-op'ing a mutation and reporting a false PASS), the suite run, then reverted.

| # | Defect introduced | Result |
|---|---|---|
| M1 | SSE event stretches `activityInterval` too | **CAUGHT** — `TestHealthyStreamStretchesOnlyTheReconcileLoop` |
| M2 | Drop bumps a shared generation (`activityGen++` as well) | **CAUGHT** — `TestStreamDropDoesNotRetireTheActivityChain`, `TestConnectDropCyclesLeaveOneChainOfEachClass` |
| M3 | Drop's fallback fetch is the full `poll()` | **CAUGHT** — `TestStreamDropDoesNotDuplicateActivityRequests` |
| M4 | `pollReconcile` also reads `/api/audit` | **CAUGHT** — `TestEachTickFetchesOnlyItsOwnClass/reconcile`, `TestPollStillIssuesBothClasses`, `TestPollIssuesEveryRead` |
| M5 | Activity tick fetches without re-arming | **CAUGHT** — `TestActivityTickRearmsWhenTheFetchFails`, `TestActivityLoopKeepsRefreshingWhileTheStreamIsHealthy`, `TestEachTickFetchesOnlyItsOwnClass/activity` |
| M6 | `Init` forgets to arm the activity chain | **CAUGHT** — `TestInitPollsImmediatelyAndArmsTick` |
| M7 | `scheduleActivityTick` stamps `reconcileGen` | **CAUGHT** — `TestScheduleTickStampsTheCurrentGeneration/activity` |
| M8 | `poll()` quietly becomes reconcile-only | **CAUGHT** — `TestInitFetchesBothClassesImmediately` + 9 existing T30/T31 tests |

The narrowness matters as much as the catches: M1 fails **only** the stretch test and M6 **only** the Init-arming test, so those are independently sensitive rather than one assertion double-counted. M8's blast radius is the reassuring direction — the existing T30/T31 suite already refuses to let the one-shot refresh lose its activity half.

Two notes on the tests themselves:

- `TestEachTickFetchesOnlyItsOwnClass` asserts **absence** in both directions. A "contains what it should" test alone passes on a model that never split anything — one loop fetching everything satisfies every such clause. What distinguishes a real split is that the reconcile tick does not read `/api/audit` and the activity tick does not read `/api/agents`.
- `TestStreamDropDoesNotDuplicateActivityRequests` waits for the `sseReconnectMsg` before reading the audit request counter. That message is a real `sseBackoffMin` timer, so by the time it lands a duplicate fetch against a local test server has had a full second to complete and be counted — the counter assertion is not racing the thing it is trying to observe.

No test sleeps a production interval: both intervals are model fields, every tick is injected, and the one place a 60s chain is unavoidable (`streamHealthyModel`) is drained through the existing concurrent `drainUntil` helper.

## Verified

```
cd src
go build ./...          # clean across the module
go test ./pkg/tui/...   # all four packages green
gofmt -l pkg/tui        # clean
go vet ./pkg/tui/...    # clean
```

CI is the gate; the above is local iteration only.

## Out of scope

The 5s and 60s policy values, a second SSE endpoint or server-side streaming of audit/token data, and any client, pane, or visual change. Documentation of the resulting cadence contract belongs to T26 (#5422), which is held on this PR.

— hive: backend=claude model=claude opus 5 high
