### PR TITLE
📝 docs: document reviewer selection and retro `analysis_model` prerequisites

### DIFF
--- a/src/docs/retro-lane.md
+++ b/src/docs/retro-lane.md
@@ -27,7 +27,7 @@ Each finding is filed as an `advisory` bead attributed to actor `retro`, using t
 
 ## Optional LLM analysis
 
-Set `retro.analysis_model` to a model served by `governor.litellm` to enable bounded model analysis.
+Set `retro.analysis_model` to a model served by `governor.litellm` to enable bounded model analysis. The lane only calls the model for records that already triggered deterministic findings, keeping cost proportional to actionable anomalies. The prompt contains the compact record and finding types/details with hard truncation bounds.
 
 ### Prerequisites
 
@@ -57,7 +57,7 @@ retro:
   analysis_model: "" # a model ID from your gateway's /v1/models; empty = deterministic findings only
 ```
 
-Leaving `analysis_model` empty is the default and keeps the lane on deterministic findings alone. The lane only calls the model for records that already triggered deterministic findings, keeping cost proportional to actionable anomalies. The prompt contains the compact record and finding types/details with hard truncation bounds.
+Leaving `analysis_model` empty is the default and keeps the lane on deterministic findings alone.
 
 The model must return structured JSON:
 

--- a/src/docs/retro-lane.md
+++ b/src/docs/retro-lane.md
@@ -27,7 +27,37 @@ Each finding is filed as an `advisory` bead attributed to actor `retro`, using t
 
 ## Optional LLM analysis
 
-Set `retro.analysis_model` to a model served by `governor.litellm` to enable bounded model analysis. The lane only calls the model for records that already triggered deterministic findings, keeping cost proportional to actionable anomalies. The prompt contains the compact record and finding types/details with hard truncation bounds.
+Set `retro.analysis_model` to a model served by `governor.litellm` to enable bounded model analysis.
+
+### Prerequisites
+
+Retro LLM analysis has no inference backend of its own. It reuses the governor's LiteLLM gateway: the endpoint and API key are resolved from `governor.litellm` at startup, so that gateway must be configured **before** `retro.analysis_model` does anything. If the model is set but no endpoint resolves, analyzer construction fails with `retro analysis: no model endpoint resolved` and the lane continues filing deterministic advisory beads only.
+
+Configure the gateway by any of these routes:
+
+- **Environment** — `HIVE_LITELLM_ENDPOINT` (base URL) and `HIVE_LITELLM_API_KEY`. See [Inference, CLI backends, and agents](env-vars.md#inference-cli-backends-and-agents) in the environment variable reference.
+- **Dashboard API** — `PUT /api/config/governor/litellm` to save the endpoint and key reference, and `POST /api/config/governor/litellm/test` to verify reachability before enabling retro analysis. See [Configuration](api-reference.md#configuration) in the REST API reference.
+- **Config and concepts** — [Methods: subscription CLIs vs self-hosted inference](agent-configuration.md#methods-subscription-clis-vs-self-hosted-inference) explains the `litellm` method, the endpoint-plus-key-reference model, and why key values live in `/data/secrets/` rather than in YAML.
+
+The endpoint resolves from `HIVE_LITELLM_ENDPOINT` when set, otherwise from the YAML `governor.litellm.endpoint`. The API key is resolved from key files first (`governor.litellm.api_key_file`, then the mounted Secret, then the dashboard-written PVC copy) and only then from the env var.
+
+### Choosing an `analysis_model` value
+
+The value is a **model ID as advertised by your LiteLLM gateway** — it is passed through verbatim as the `model` field of an OpenAI-format `POST {endpoint}/v1/chat/completions` request. Hive applies no allowlist, prefix convention, or validation to it beyond trimming whitespace, so any string your gateway routes is acceptable and a string it does not recognise fails at request time rather than at config load.
+
+Because LiteLLM administrators choose their own `model_name` aliases, there is no single correct example: the right value is whatever your gateway's `GET /v1/models` returns for the key you configured. List them before setting the field rather than copying a name from elsewhere.
+
+```yaml
+governor:
+  litellm:
+    endpoint: https://litellm.example.com
+
+retro:
+  enabled: true
+  analysis_model: "" # a model ID from your gateway's /v1/models; empty = deterministic findings only
+```
+
+Leaving `analysis_model` empty is the default and keeps the lane on deterministic findings alone. The lane only calls the model for records that already triggered deterministic findings, keeping cost proportional to actionable anomalies. The prompt contains the compact record and finding types/details with hard truncation bounds.
 
 The model must return structured JSON:
 

--- a/src/docs/review-swarm.md
+++ b/src/docs/review-swarm.md
@@ -44,6 +44,67 @@ review:
   fixer_agent: scanner                      # optional; defaults to the PR lane, then scanner
 ```
 
+## Reviewer selection
+
+An agent is *review-capable* when `dashboardAgentReviewCapable` (`pkg/dashboard/status_builder.go`) accepts it. The dashboard counts those agents and warns when the count is zero while `require_approval` is true. Selection runs in two stages, and the first stage applies to **both** configuration paths.
+
+### Stage 1 — availability gate (always applied)
+
+An agent is disqualified outright, before any name or keyword is examined, if any of the following is true:
+
+- it is not enabled (`enabled: false`),
+- it is paused (`paused: true`),
+- it is on-demand (`on_demand: true`).
+
+An on-demand agent is excluded even though it can be invoked manually: this count reflects agents available to the governor's automatic fan-out, not agents that exist.
+
+### Stage 2 — which agents qualify
+
+**When `review.reviewer_agents` is non-empty**, only agents whose names appear in that list qualify. Matching is an exact string comparison of the agent name against each list entry after trimming surrounding whitespace — it is *not* case-insensitive and *not* a substring match. A listed agent that fails the stage-1 gate still does not qualify, and no keyword scan is performed as a fallback: if every listed agent is missing, disabled, paused, or on-demand, the effective reviewer set is empty.
+
+**When `review.reviewer_agents` is empty or omitted**, an agent qualifies if the string `review` appears, case-insensitively, in any of these fields:
+
+- the agent's name,
+- `role`,
+- any entry in `aliases`,
+- any entry in `lane_keywords`,
+- any entry in `detect_keywords`.
+
+The match is a substring check, so `reviewer`, `pr-review`, and `code-reviewer` all qualify.
+
+### Making an agent review-capable
+
+The smallest change that works on the keyword path is a `role` containing `review`:
+
+```yaml
+agents:
+  reviewer:
+    enabled: true
+    role: reviewer
+```
+
+Or name the agent explicitly, which bypasses the keyword scan entirely:
+
+```yaml
+review:
+  require_approval: true
+  reviewer_agents: [reviewer]
+
+agents:
+  reviewer:
+    enabled: true
+```
+
+### Troubleshooting "no enabled review-capable agents were detected"
+
+The dashboard emits this warning whenever `require_approval` is true and zero agents pass both stages. Because the availability gate runs first, an operator who has a correctly named reviewer that is merely **paused** sees exactly the same message as one who has no reviewer at all. Check in this order:
+
+1. **Is your intended reviewer enabled, unpaused, and not on-demand?** This is the most common cause and it is invisible in the warning text. Verify all three flags before touching any review configuration — a correct `reviewer_agents` list cannot rescue a paused agent.
+2. **Is `review.reviewer_agents` set?** If it is, the keyword scan never runs. Every name in the list must match an existing agent's name exactly, after whitespace trimming; a typo, a case difference, or an alias instead of the real agent name silently contributes nothing.
+3. **If `reviewer_agents` is unset, does any enabled agent carry `review` somewhere?** Search the five fields listed above. An agent whose only connection to review is an English description elsewhere in its config does not qualify — the scan reads name, `role`, `aliases`, `lane_keywords`, and `detect_keywords` and nothing else.
+
+Until at least one agent passes, `require_approval: true` means no PR ever acquires the aggregate `approve` it needs, so merge-gate output stays empty rather than falling back to unreviewed merges.
+
 When `review.require_approval` is false or omitted, `merge-eligible.json` is produced as before. When true, a PR is included only if `review-verdicts.json` contains an aggregate `approve` for the same repo, PR number, and head SHA.
 
 `review.fan_out` is separately defaulted to false. When both `require_approval` and `fan_out` are true, the governor eval cycle plans review kicks for agent-authored PRs that do not yet have a fresh aggregate verdict for their current head SHA.

--- a/src/docs/review-swarm.md
+++ b/src/docs/review-swarm.md
@@ -103,7 +103,7 @@ The dashboard emits this warning whenever `require_approval` is true and zero ag
 2. **Is `review.reviewer_agents` set?** If it is, the keyword scan never runs. Every name in the list must match an existing agent's name exactly, after whitespace trimming; a typo, a case difference, or an alias instead of the real agent name silently contributes nothing.
 3. **If `reviewer_agents` is unset, does any enabled agent carry `review` somewhere?** Search the five fields listed above. An agent whose only connection to review is an English description elsewhere in its config does not qualify — the scan reads name, `role`, `aliases`, `lane_keywords`, and `detect_keywords` and nothing else.
 
-Until at least one agent passes, `require_approval: true` means no PR ever acquires the aggregate `approve` it needs, so merge-gate output stays empty rather than falling back to unreviewed merges.
+Until at least one agent passes, no reviewer receives a perspective prompt, so no PR acquires the aggregate `approve` that `require_approval: true` requires (see [Configuration](#configuration) above).
 
 When `review.require_approval` is false or omitted, `merge-eligible.json` is produced as before. When true, a PR is included only if `review-verdicts.json` contains an aggregate `approve` for the same repo, PR number, and head SHA.
 


### PR DESCRIPTION
Fixes #5542
Fixes #5543

Docs only. No Go code changed.

## #5542 — reviewer selection was undocumented

`src/docs/review-swarm.md` mentioned `reviewer_agents` in exactly one place: an inline YAML comment on line 43 reading `# optional; otherwise agents with review role/keywords are selected`. Nothing explained what "review role/keywords" means, so an operator seeing the dashboard warning *"Review approval is required, but no enabled review-capable agents were detected"* had no way to diagnose it from the docs.

Adds a **Reviewer selection** section written from `dashboardAgentReviewCapable` in `src/pkg/dashboard/status_builder.go`, plus a troubleshooting subsection ordered by how likely each cause is in practice.

### Where the code differs from the issue description

The issue listed the availability gate as part of the *keyword* path — "otherwise, an agent qualifies if it is enabled, non-paused, non-on-demand **and** the string `review` appears...". The code does not do that. The gate is the first statement in the function and applies to **both** paths:

```go
func dashboardAgentReviewCapable(name string, a config.AgentConfig, allowed []string) bool {
	if !a.Enabled || a.Paused || a.OnDemand {
		return false
	}
	if len(allowed) > 0 { ... exact match ... }
	...
}
```

An agent named in `reviewer_agents` that is disabled, paused, or on-demand does **not** qualify. The docs follow the code, and the distinction matters operationally: it is why a paused reviewer produces the exact same warning as no reviewer at all, which is the point the troubleshooting section leads with.

Two other details taken from the code rather than the issue text: the `reviewer_agents` match is an exact string comparison after `strings.TrimSpace` (not case-insensitive, not substring), and when the list is non-empty there is no keyword fallback — the function returns `false` outright.

## #5543 — `analysis_model` had no configuration path

`src/docs/retro-lane.md` line 30 said "Set `retro.analysis_model` to a model served by `governor.litellm` to enable bounded model analysis" and stopped there.

Adds a **Prerequisites** section and a **Choosing an `analysis_model` value** section covering the env, dashboard-API, and conceptual routes to configuring the gateway, plus the endpoint and key resolution order.

### What a valid `analysis_model` value looks like, and how that was established

Traced through the code rather than guessed:

- `src/cmd/hive/main.go:4860` wires `AnalysisEndpoint: cfg.Governor.LiteLLM.ResolveEndpoint()` and `AnalysisAPIKey: cfg.Governor.LiteLLM.ResolveAPIKey()` — confirming retro has no inference backend of its own and reuses the governor gateway.
- `src/pkg/retro/analysis.go:47` `NewAnalyzer` trims the model, returns `nil, nil` when empty (deterministic-only), and errors with `retro analysis: no model endpoint resolved` when a model is set but no endpoint resolves.
- `src/pkg/retro/analysis.go:159,165` marshals `chatRequest{Model: c.model, ...}` and POSTs to `c.endpoint + "/v1/chat/completions"`.

So the value is passed **verbatim** as the OpenAI `model` field. `grep` over `src/pkg/config/` finds no validation, allowlist, or format constraint on `Retro.AnalysisModel` beyond the trim.

Consequently there is no single correct example to give: LiteLLM administrators define their own `model_name` aliases, and the correct value is whatever the operator's own gateway advertises at `GET /v1/models` for the configured key. The docs say exactly that and direct operators to list their gateway's models rather than copy a name. The YAML example deliberately shows an empty value with an explanatory comment instead of inventing a plausible-looking model ID that would be wrong on most deployments. The issue suggested `gpt-4o-mini` as an illustration; that would be correct only on a gateway that happens to alias it, so it is not presented as a value to copy.

## Link verification

All three cross-reference targets are siblings in `src/docs/`, and each anchor was checked against the target file's actual headings using GitHub slug rules:

| Link | Target heading | Status |
|---|---|---|
| `env-vars.md#inference-cli-backends-and-agents` | `## Inference, CLI backends, and agents` | resolves |
| `api-reference.md#configuration` | `## Configuration` | resolves |
| `agent-configuration.md#methods-subscription-clis-vs-self-hosted-inference` | `## Methods: subscription CLIs vs self-hosted inference` | resolves |

Each target was also confirmed to actually contain LiteLLM material, not merely to exist: `env-vars.md` documents `HIVE_LITELLM_ENDPOINT`/`_API_KEY`/`_MODELS` in that section, `api-reference.md` lists both `PUT /api/config/governor/litellm` and `POST /api/config/governor/litellm/test` under Configuration, and `agent-configuration.md` describes the `litellm` method with `/v1/models` entitlement-filtered discovery.

All YAML field names in the new examples were verified against the structs: `enabled`, `paused`, `on_demand`, `role`, `aliases`, `lane_keywords`, `detect_keywords` on `AgentConfig`, and `require_approval`, `reviewer_agents` on the review config.

## Not verified

- **Merge-gate runtime behaviour.** `review.require_approval` is read by config and dashboard plumbing in `src/pkg/`, but the code that actually filters `merge-eligible.json` lives in `bin/`, which is owned by another agent and was not read here. The troubleshooting section therefore states only the consequence this file already documents (no aggregate `approve` is produced) and does not assert what the merge gate emits.
- **Rendered-page anchors.** Verified by computing GitHub slugs from the target files' heading text, not by loading the published docs site.
- **Dashboard warning wording** was read from `src/pkg/dashboard/static/index.html:20724`; the trigger condition there is `reviewRequireApproval && reviewCapableAgents === 0`. I did not exercise the dashboard to observe it render.
