### PR TITLE
🐛 fix: agy sign-in cannot persist; a claude login must not restart an agy agent

### DIFF
--- a/src/deploy/entrypoint.sh
+++ b/src/deploy/entrypoint.sh
@@ -814,7 +814,7 @@ if [ "$(id -u)" = "0" ]; then
   # Shared CLI auth/cache lives in /data/home (persistent volume).
   # Make it group-writable so all agent UIDs (node group) can use it.
   # The manager sets HOME=/data/home for agent tmux sessions.
-  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/home/.codex /data/home/.bob/settings /data/config/github-copilot /home/dev/.config
+  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/home/.codex /data/home/.gemini /data/home/.bob/settings /data/config/github-copilot /home/dev/.config
   # $HOME itself must be group-writable, not just its children. bob calls
   # mkdirSync('$HOME/.bob') on first run, which needs write on /data/home — a
   # 0755 root-owned $HOME makes that EACCES even though every child dir below
@@ -838,6 +838,22 @@ if [ "$(id -u)" = "0" ]; then
   # codex backend fails with "Permission denied" initializing state_N.sqlite.
   chmod 2775 /data/home/.codex 2>/dev/null || true
   chown -R dev:node /data/home/.codex 2>/dev/null || true
+  # Antigravity (`agy`) persists its OAuth session to
+  # $HOME/.gemini/antigravity-cli/antigravity-oauth-token. Pre-create the tree
+  # group-writable + setgid for the same reason as .codex above.
+  #
+  # This was measured, not assumed. On a live hive .gemini existed at 2750 —
+  # group READ-only, because nothing here had ever created or repaired it and
+  # agy made it itself. The agent UID could not write the directory, so every
+  # sign-in succeeded in-process and then evaporated: `agy models` in any new
+  # process reported "Please sign in", and each hive restart lost the session
+  # again. The operator saw four consecutive logins "fail" with no error that
+  # named a permission. One chmod produced the token file immediately.
+  #
+  # 2770 rather than .codex's 2775: this directory holds an OAuth token, so it
+  # follows .copilot/.bob in keeping world off it.
+  chmod 2770 /data/home/.gemini 2>/dev/null || true
+  chown -R dev:node /data/home/.gemini 2>/dev/null || true
   # bob writes installation_id, settings.json, trustedFolders.json and tmp/ under
   # $HOME/.bob, plus custom modes under $HOME/.bob/settings. Pre-create both
   # group-writable + setgid so the FIRST agent to launch (a 2001+ UID in group
@@ -859,7 +875,7 @@ if [ "$(id -u)" = "0" ]; then
   # too so that gap cannot reopen.
   NEED_PERM_FIX=false
   if [ -d "/data/home/.copilot" ] && [ -d "/data/home/.claude" ]; then
-    for perm_dir in /data/home /data/home/.copilot /data/home/.claude /data/home/.bob; do
+    for perm_dir in /data/home /data/home/.copilot /data/home/.claude /data/home/.gemini /data/home/.bob; do
       # Missing dir → repair. Default 755 → repair (no group-write/setgid).
       DIR_PERMS=$(stat -c '%a' "$perm_dir" 2>/dev/null || echo "755")
       case "$DIR_PERMS" in
@@ -920,7 +936,19 @@ if [ "$(id -u)" = "0" ]; then
         chown -R dev:node /data/home/.codex 2>/dev/null
       done
     ) &
-    echo "[entrypoint] inotify perm guard active (copilot + claude + codex)"
+    (
+      # agy writes antigravity-oauth-token 0600 owned by the agent that signed
+      # in, which locks every other agent UID out of a credential the shared
+      # CLI home exists to share — the same shape as copilot's config.json
+      # above. Re-opening it to the node group is what makes ONE agy login
+      # serve the fleet instead of one login per agent.
+      while inotifywait -qq -e close_write,moved_to,create /data/home/.gemini/ 2>/dev/null; do
+        chmod -R g+rwX /data/home/.gemini 2>/dev/null
+        find /data/home/.gemini -type d -exec chmod g+s {} + 2>/dev/null
+        chown -R dev:node /data/home/.gemini 2>/dev/null
+      done
+    ) &
+    echo "[entrypoint] inotify perm guard active (copilot + claude + codex + gemini)"
   fi
   (
     CYCLE=0
@@ -931,8 +959,8 @@ if [ "$(id -u)" = "0" ]; then
       # Slow cycle: fix entire /data/home tree every 5 min (new dirs from agents)
       CYCLE=$((CYCLE + 1))
       if [ "$CYCLE" -ge 60 ]; then
-        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude /data/home/.codex /data/home/.bob 2>/dev/null
-        find /data/home/.cache /data/home/.claude /data/home/.codex /data/home/.bob -type d -exec chmod g+s {} + 2>/dev/null
+        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude /data/home/.codex /data/home/.gemini /data/home/.bob 2>/dev/null
+        find /data/home/.cache /data/home/.claude /data/home/.codex /data/home/.gemini /data/home/.bob -type d -exec chmod g+s {} + 2>/dev/null
         CYCLE=0
       fi
       sleep 5

--- a/src/deploy/test_entrypoint_data_ownership.sh
+++ b/src/deploy/test_entrypoint_data_ownership.sh
@@ -324,4 +324,41 @@ $tmpd/home"
   trap - EXIT
 fi
 
+# ---------------------------------------------------------------------------
+# Every interactive-auth CLI credential dir must be group-writable AND repaired
+# by the ongoing perm guard.
+#
+# This is the drift that broke agy sign-in. .gemini was in no list at all, so
+# agy created it itself at 2750 — group READ-only. Every sign-in then succeeded
+# in-process and evaporated, because the agent UID could not write the token
+# file. Nothing reported a permission problem; the operator saw four logins in
+# a row appear to fail.
+#
+# A dir being mkdir'd and chowned is NOT enough, which is why this is separate
+# from the sweep check above: the credential file itself is rewritten 0600 by
+# the CLI on every refresh (copilot's config.json, agy's oauth token), so a dir
+# that is not in the ONGOING guard silently re-locks after the first refresh.
+echo
+echo "Interactive-auth credential dirs are group-writable and guarded:"
+for cred_dir in .claude .copilot .codex .gemini .bob; do
+  path="/data/home/$cred_dir"
+
+  if grep -qE "chmod (2770|2775) [^&|;]*${path}( |$|/)" "$ENTRYPOINT"; then
+    ok "$cred_dir is created group-writable + setgid"
+  else
+    bad "$cred_dir has no 'chmod 277x' at its creation site" \
+        "an agent UID cannot write it; a CLI sign-in there succeeds in memory and is lost on exit"
+  fi
+
+  # The ongoing repair: either an inotify watcher on the dir, or the polling
+  # slow-cycle chmod -R. One is enough; neither is the bug.
+  if grep -qE "inotifywait [^|]*${path}/" "$ENTRYPOINT" || \
+     grep -qE "chmod -R g\+rwX [^&|;]*${path}( |$)" "$ENTRYPOINT"; then
+    ok "$cred_dir is repaired by the ongoing perm guard"
+  else
+    bad "$cred_dir is never re-opened after the CLI rewrites its credential 0600" \
+        "add it to the inotify guard or the polling slow-cycle chmod, beside .claude/.codex"
+  fi
+done
+
 hive_test_report

--- a/src/pkg/agent/agy_restart_gate_test.go
+++ b/src/pkg/agent/agy_restart_gate_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// TestTokenRestartHealIsBackendScoped pins the gate that stopped an agy agent
+// being restart-looped out of a sign-in.
+//
+// configHasTokens() is backend-blind: it answers true when EITHER the shared
+// claude or copilot credential is usable, regardless of which backend the agent
+// in front of it runs. Gating the token-restart heal on it meant an agy agent
+// sitting at its Google OAuth prompt was restarted because an unrelated CLAUDE
+// login was valid. A restart cannot mint a Google session, so it looped — and
+// every relaunch minted a fresh PKCE challenge, invalidating the code the
+// operator was mid-way through pasting. Measured live: 15 restarts in an hour,
+// 8 distinct challenges.
+func TestTokenRestartHealIsBackendScoped(t *testing.T) {
+	// A live, usable shared claude credential — the thing that used to make the
+	// backend-blind gate answer true for every agent on the hive.
+	stageSharedClaudeCredential(t, map[string]any{
+		"accessToken": "sk-ant-oat-live",
+		"expiresAt":   time.Now().Add(6 * time.Hour).UnixMilli(),
+	})
+
+	m := NewManager(map[string]config.AgentConfig{
+		"scanner": {Backend: "agy"},
+		"quality": {Backend: "claude"},
+	}, discardLogger(), ProjectContext{ACMMLevel: 5})
+
+	if configHasTokens() != true {
+		t.Fatal("precondition: the backend-blind check must be true here — otherwise this test proves nothing")
+	}
+
+	if m.AgentHasValidCredential("scanner") {
+		t.Fatal("an agy agent must NOT read as credentialed off a claude login: restarting it cannot mint a Google session, and each relaunch rotates the PKCE challenge the operator is using")
+	}
+	if !m.AgentHasValidCredential("quality") {
+		t.Fatal("a claude agent with a usable shared credential must still qualify — the heal's real use case (#4596) must keep working")
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -3008,7 +3008,22 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			//      login agent that was kicked long ago restarts after the
 			//      grace expires; delivered work is never killed mid-scan.
 			//   3. The existing cooldown.
-			if showsLogin && loginStreak >= loginStreakRestartMin && configHasTokens() {
+			//   4. THE CREDENTIAL MUST BE THIS AGENT'S. configHasTokens() is
+			//      backend-blind: it answers true when EITHER the shared claude
+			//      or copilot credential is usable, whatever backend the agent
+			//      in front of it runs. So an agy agent parked at its Google
+			//      OAuth prompt was restarted on the strength of an unrelated
+			//      claude login. A restart cannot mint a Google session, so it
+			//      looped — and each relaunch minted a fresh PKCE challenge,
+			//      invalidating the code the operator was in the middle of
+			//      pasting. Observed live 2026-09-01: 15 restarts in an hour
+			//      and 8 distinct challenges, which made signing in impossible
+			//      rather than merely slow. AgentHasValidCredential resolves
+			//      the agent's OWN backend and is positive-evidence-only, so a
+			//      backend whose credential this process cannot verify (agy,
+			//      gemini) answers false and is left alone — which is correct:
+			//      do not restart when you cannot show a restart would help.
+			if showsLogin && loginStreak >= loginStreakRestartMin && m.AgentHasValidCredential(agent.Name) {
 				m.mu.RLock()
 				lastKick := agent.LastKick
 				m.mu.RUnlock()


### PR DESCRIPTION
## Summary

An `agy` (antigravity) agent could never stay signed in, and while an operator tried, hive restart-looped it out of the flow. Two defects that compounded into "the login just fails", with nothing anywhere naming a cause.

- **The credential could not be written.** `/data/home/.gemini` is group **read-only** and appears in none of the five places `entrypoint.sh` manages CLI credential dirs. agy persists its session there, so every sign-in succeeded in-process and evaporated on exit.
- **A claude login restarted an agy agent.** `configHasTokens()` is backend-blind, so an agy agent stuck at its Google OAuth prompt was restarted on the strength of an unrelated credential — rotating the PKCE challenge the operator was mid-way through using.

**Blast radius:** the entrypoint change adds `.gemini` beside `.claude`/`.codex`/`.copilot`; no existing dir's handling changes. The heal gate becomes *narrower* — it now requires evidence for the agent's own backend, and the case it was built for is unchanged and pinned.

Fixes #5551

## 1. `.gemini` is group read-only and in no perm guard

Measured on a live hive:

```
2775 dev:node  /data/home/.claude    ← group write
2770 dev:node  /data/home/.copilot   ← group write
2750 dev:node  /data/home/.gemini    ← group READ-ONLY
```

```
$ touch /data/home/.gemini/.writetest        # as the agent uid
touch: cannot touch '.writetest': Permission denied
```

agy writes `$HOME/.gemini/antigravity-cli/antigravity-oauth-token`. It could not, so `agy models` in any new process reported "Please sign in" while the running agent looked authenticated, and every restart demanded a fresh login. **One `chmod g+w` produced the token file on the next sign-in, and it survived a restart.**

`.gemini` is added to all five sites — `mkdir`, `chmod`/`chown`, the `NEED_PERM_FIX` sample, the inotify guard, and the polling slow-cycle. `2770` rather than `.codex`'s `2775`: it holds an OAuth token, so it follows `.copilot`/`.bob` in keeping world off it.

**The ongoing guard matters as much as the create-time mode.** agy writes the token `0600` owned by whichever agent signed in:

```
600 hive-scanner:node  …/antigravity-oauth-token
```

The shared CLI home exists so one login serves the fleet — that is why the guard already re-opens copilot's `config.json` (rewritten `0600` on every refresh) and the whole `.claude` tree. Without `.gemini` in it, every agy agent needs a separate login and each re-auth locks the others out.

## 2. The token-restart heal was backend-blind

`configHasTokens()` answers true when **either** the shared claude or copilot credential is usable, whatever backend the agent actually runs. So an agy agent parked at its Google OAuth prompt was restarted because an unrelated *claude* login was valid. A restart cannot mint a Google session, so it looped — and each relaunch minted a fresh PKCE `code_challenge`, invalidating the code the operator was pasting.

Measured on the same hive: **15 restarts in one hour, 8 distinct challenges.** The operator saw

```
oauth2: "invalid_grant" "Malformed auth code."
```

and reasonably concluded the code had been mangled in transit. It had not — the challenge no longer existed. That misdirection cost more diagnosis time than either bug.

The gate is now `AgentHasValidCredential`, which resolves the agent's **own** backend and is positive-evidence-only, so a backend this process cannot verify (agy, gemini) answers false and is left alone. That is the correct answer: *do not restart when you cannot show a restart would help.* The heal's documented case — a claude agent with a usable shared credential, #4596 — is unchanged.

This only became reachable when #5494 taught the detector to see agy's login prompt. Before that agy was invisible and idle, so the heal never fired on it — the fix that made the outage visible is what exposed this.

## Verification

| Property | Test |
|---|---|
| every interactive-auth credential dir is created group-writable + setgid | `test_entrypoint_data_ownership.sh` (new section) |
| …and is repaired by the ongoing guard after the CLI rewrites it `0600` | same |
| an agy agent does not read as credentialed off a claude login | `TestTokenRestartHealIsBackendScoped` |
| a claude agent with a usable shared credential still does | same |

The entrypoint guard is mutation-checked both ways — removing the `chmod 2770` fails the create-time half, removing the inotify watcher **and** the polling entry fails the ongoing half. It is deliberately two assertions rather than one: a dir that is `mkdir`'d and chowned but absent from the ongoing guard silently re-locks after the CLI's first credential refresh, which is exactly the shape of this bug.

The new test asserts `configHasTokens() == true` as an explicit **precondition** before checking the scoped answer — without it the test would pass for the wrong reason if the shared credential fixture ever stopped being usable.

## Testing

- [x] `cd src && go build ./...`
- [x] `cd src && go test ./pkg/agent/ ./pkg/dashboard/`
- [x] `go vet ./pkg/agent/...`, `bash -n src/deploy/entrypoint.sh`, `git diff --check`
- [x] `bash src/deploy/test_entrypoint_data_ownership.sh` → 21 passed, 0 failed
- [x] Verified live: after the permission fix a sign-in wrote `antigravity-oauth-token`, survived a hive-driven restart, and the agent came back `state=running needsLogin=False` with zero restarts.
- [ ] Not run: no automated coverage that an agy sign-in *persists* end to end — that needs a real Google OAuth flow. The permission precondition it depends on is now pinned instead.

## Contributor checklist

- [x] PR targets `v4`.
- [x] Title uses the repo emoji convention.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] Docs, examples, and policies updated where behavior changes — the entrypoint comments record the measurement and why `.gemini` is `2770`.
- [ ] `CHANGELOG.md` — not added; happy to add one if you want this in the operator-facing log.
- [x] No secrets, credentials, or local runtime state are committed.
