### PR TITLE
📚 tui T26: document the complete terminal dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,23 @@ flowchart LR
 
 See also the [documentation index](src/docs/README.md), [public roadmap](src/docs/roadmap.md), and [landscape comparison](src/docs/landscape.md) for community-facing documentation and positioning.
 
+## Terminal dashboard
+
+`hivectl tui` is a full-screen, keyboard-driven terminal view of the fleet —
+agents, governor, token spend, and activity in a live 2×2 grid, with
+pause/resume, model apply, kick, and ACMM level actions. It is **not a second
+Hive runtime**: it is another client of the same dashboard API the web
+dashboard at `:3001` uses, over the same auth token and the same SSE stream.
+
+```bash
+export HIVE_DASHBOARD_TOKEN="..."
+hivectl tui
+```
+
+See [`hivectl tui` in the command reference](src/docs/hivectl.md#tui--live-terminal-dashboard)
+for keybindings, pane cadence, and v1 boundaries, and
+[the design record](src/docs/design/tui.md) for the reasoning behind it.
+
 ## Contribute to a Hive
 
 Community members can contribute compute to any hive through **ClankeR**, the

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -36,7 +36,10 @@ Start with [Architecture](architecture.md) for the system overview, then use the
 - [State-triggered hooks](hooks.md) — declarative `transition → action` rules, the transition catalog, the vetted action set, and the security model (RFC #4001).
 - [CEL-based agent triggers](cel-triggers.md) — the `triggers:` config key: declarative CEL rules that kick an agent on a normalized source-control event, additive to built-in label/governor triggering, the `event.*` field reference, and the fail-closed compile/runtime contract.
 - [Public snapshots](https://github.com/kubestellar/hive/blob/v4/src/docs/snapshots.md) — read-only `/snapshot`, custom CSS, and frame-ancestor sharing.
-- [hivectl](hivectl.md) — command-line client for the dashboard API.
+- [hivectl](hivectl.md) — command-line client for the dashboard API, including
+  [`hivectl tui`](hivectl.md#tui--live-terminal-dashboard), the full-screen
+  terminal dashboard: keybindings, pane cadence, and v1 boundaries. See
+  [the design record](design/tui.md) for the reasoning behind it.
 - [`bd` beads CLI](https://github.com/kubestellar/hive/blob/v4/src/docs/beads-cli.md) — work-ledger and knowledge command reference for operators and contributors.
 - [Backup and restore](https://github.com/kubestellar/hive/blob/v4/src/docs/backup-restore.md) — `hive-backup`, Kubernetes CronJob, spoke backup scope, and setting the backup encryption key from Governor Config (hosted flow). Host-level backup, restore, and `docker compose down -v` are given per runtime: Docker Compose, and Podman/Quadlet with the executed backup → wipe → restore cycle in both root modes, the rootless mapped-UID trap that makes a host-shell `tar` skip the GitHub App key, and the Docker→Podman migration (the two volume stores are never shared).
 - [Hub disaster recovery](https://github.com/kubestellar/hive/blob/v4/docs/HUB_DISASTER_RECOVERY.md) — the hub-level runbook that goes beyond per-hive backup: hub backup and key escrow, spoke fleet recovery, Slack blast, and the full rebuild-from-zero procedure after a catastrophic loss.

--- a/src/docs/design/README.md
+++ b/src/docs/design/README.md
@@ -93,15 +93,17 @@ that status is the thing to check before treating a page as current behaviour:
   with its timestamp would move Copilot from "structurally impossible" to
   phase 3's existing join, in `pkg/tokens` only and off the request path.
 
-- [`hive tui` — a terminal dashboard for Hive](tui.md) — **design only.** The
-  accepted plan for the k9s-style terminal client tracked in #4907: scope,
-  the fixed architecture decisions, the default 2x2 pane layout, the keybinding
-  table, and the golden-file testing convention. Read it before picking up any
-  #4907 sub-issue, for two corrections it carries that the sub-issue bodies do
-  not: their `v2/...` paths are pre-#3996 spellings and map to `src/pkg/tui/...`,
-  and `dashboard/openapi.json` — which the epic names as the contract for every
-  client task — publishes 32 of the dashboard's 298 routes and **no write
-  operations at all**, so the four action tasks have no spec to build against.
+- [`hive tui` — a terminal dashboard for Hive](tui.md) — **shipped (v1).** The
+  design record for the k9s-style terminal client tracked in #4907: scope, the
+  fixed architecture decisions, the default 2x2 pane layout, the keybinding
+  table, and the golden-file testing convention. Every v1 sub-issue has landed;
+  [`src/docs/hivectl.md`](../hivectl.md#tui--live-terminal-dashboard) is the
+  operator reference for what actually shipped and the one to read first — this
+  page is read afterward, for the reasoning and the two corrections it carries
+  against the sub-issue bodies: their `v2/...` paths are pre-#3996 spellings
+  that map to `src/pkg/tui/...`, and `dashboard/openapi.json` — which the epic
+  names as the contract for every client task — originally published 32 of the
+  dashboard's 298 routes and no write operations at all, closed by #5023.
 - [Agent host confinement on the default (unconfined) launch path](agent-host-confinement.md)
   — **investigation, no decision taken.** #4918: an agent doing correct,
   benign work on an assigned third-party repo ran that repo's own test suite,

--- a/src/docs/design/tui.md
+++ b/src/docs/design/tui.md
@@ -1,10 +1,16 @@
 # `hive tui` — a terminal dashboard for Hive (#4907)
 
-Status: **design only.** Nothing described here is shipped. The scaffold is
-proposed in [#4916](https://github.com/kubestellar/hive/issues/4916) (PR #4919,
-open); every pane, every client call, and every action below is a separate
-unmerged task in the [#4907](https://github.com/kubestellar/hive/issues/4907)
-task graph. Read this as intent, not as behaviour.
+Status: **shipped (v1).** Every task in the [#4907](https://github.com/kubestellar/hive/issues/4907)
+task graph has landed: the scaffold, all four panes, the SSE stream and its
+polling fallback, and every action (pause/resume, model apply, kick, ACMM
+apply, local tmux attach). Per this record's own convention
+([`design/README.md`](README.md)), this page is **not rewritten** to describe
+that delivery in detail — it stays the plan and the reasoning behind it, with
+only the two corrections below and the
+[Delivery: `hivectl tui`](#delivery-hivectl-tui) note updated against what
+actually shipped. **[`src/docs/hivectl.md`](../hivectl.md#tui--live-terminal-dashboard) is the
+operator reference and the page to read first** — keybindings, pane cadence,
+authorization failures, and v1 boundaries as delivered.
 
 Two things in the epic's drafted text do not match this repository, and both
 are corrected here with the evidence: the `v2/` path prefix
@@ -86,13 +92,22 @@ entrypoints in the module, only one has subcommand structure:
   `http://127.0.0.1:3001` and `--token-env` defaults to `HIVE_DASHBOARD_TOKEN`
   (`src/pkg/hivectl/commands/root.go`).
 
-So the command is **`hivectl tui`**. Note the one deviation this forces from the
-Data source decision as written: the base URL comes from `--server`, whose
-default is `http://127.0.0.1:3001` rather than the epic's
-`HIVE_DASHBOARD_URL` / `http://localhost:3001`. Reusing hivectl's existing flag
-is worth more than a second, differently-spelled way to say the same thing; a
-task that wants `HIVE_DASHBOARD_URL` honoured should add it as the flag's
-default source rather than as a parallel path.
+So the command is **`hivectl tui`**.
+
+**Correction against delivery.** This section originally proposed that the TUI
+reuse hivectl's `--server` / `--token-env` flags for its base URL and token,
+deviating from the Data source decision's `HIVE_DASHBOARD_URL` /
+`http://localhost:3001`. That is not what shipped: `newTUICommand`
+(`src/pkg/hivectl/commands/tui.go`) calls `tui.Run()` with nothing from
+`*commandEnv`, so `hivectl tui` reads `HIVE_DASHBOARD_URL` and
+`HIVE_DASHBOARD_TOKEN` directly — exactly the Data source decision as
+written — and does **not** honour `--server` or `--token-env`. The two base
+URL defaults consequently differ by one detail (`http://localhost:3001` here
+vs. `http://127.0.0.1:3001` for `--server`'s default on every other `hivectl`
+command), which is worth knowing if you pass `--server` for a non-default host
+elsewhere: the TUI will not pick it up. See
+[`src/docs/hivectl.md`](../hivectl.md#launch-and-endpoint-selection) for the
+operator-facing version of this note.
 
 ### Paths: the epic's `v2/` prefix predates #3996
 

--- a/src/docs/hivectl.md
+++ b/src/docs/hivectl.md
@@ -143,31 +143,227 @@ hivectl observe trends --range week        # or --hours 12 (1-720); not both
 hivectl tui
 ```
 
-Opens a full-screen, keyboard-driven view of the fleet over the same dashboard
-API the non-interactive subcommands use, so it honours the same `--hive` /
-endpoint configuration. Requires a real terminal; press `q` or `ctrl+c` to
-exit.
+A full-screen, keyboard-driven view of the fleet — agents, the governor,
+token/cost spend, and recent activity — over the same dashboard API the
+non-interactive subcommands above use. It is not a second Hive runtime, just
+another client of the API: same auth token, same endpoints, same SSE stream
+the web dashboard consumes. Requires a real terminal.
 
-**Under active construction.** Four panes sit in a 2×2 grid, and only half are
-wired to live data today:
+This is the v1 delivery of the `hive tui` epic
+([#4907](https://github.com/kubestellar/hive/issues/4907)); the design
+rationale and the fixed architecture decisions behind it are recorded in
+[`src/docs/design/tui.md`](design/tui.md).
 
-| Pane | State |
-|---|---|
-| Agents | live — polls `GET /api/agents` |
-| Tokens | live — per-agent rows and fleet total |
-| Governor | stub — renders its title, pending T7 |
-| Events | stub — renders its title, pending T11 |
+#### Launch and endpoint selection
 
-`tab` moves focus between panes; `q` or `ctrl+c` exits. Those are the only keys
-bound: no help overlay, no pause/resume, no resize handling yet.
+`hivectl tui` takes no flags — it is a bare subcommand. In particular it does
+**not** honour the root `--server` / `--token-env` flags the other `hivectl`
+commands read: it builds its own client directly from two environment
+variables, checked once at startup:
 
-Note the command's own `--help` text describes an event feed — that is the
-end-state design, not what ships today.
+| Variable | Default | Meaning |
+|---|---|---|
+| `HIVE_DASHBOARD_URL` | `http://localhost:3001` | Dashboard API base URL |
+| `HIVE_DASHBOARD_TOKEN` | *(empty)* | Auth token — the same variable `--token-env` defaults to |
 
-Track progress under the `hive tui` epic
-([#4907](https://github.com/kubestellar/hive/issues/4907)); the open `tui T*`
-issues list what is still missing. Prefer the web dashboard or the
-non-interactive subcommands above for anything you need today.
+If you already have `HIVE_DASHBOARD_TOKEN` exported for the commands above,
+`hivectl tui` picks it up for free — the token variable name is shared on
+purpose. The base URL default differs by one detail from `--server`'s
+(`http://localhost:3001` vs. `http://127.0.0.1:3001`): both resolve to the
+same loopback dashboard, but set `HIVE_DASHBOARD_URL` explicitly if you also
+pass `--server` to other commands against a non-default host, since the TUI
+will not pick that flag up.
+
+#### The four panes
+
+A 2×2 grid — Agents and Governor on top, Tokens and Events on the bottom —
+refreshed from two independent loops with different cadences:
+
+| Pane | Source | Cadence |
+|---|---|---|
+| **Agents** | `GET /api/agents`, joined with live per-agent state pushed over SSE | reconciliation loop |
+| **Governor** | `GET /api/status` (live mode/queue), `GET /api/config/governor` (eval interval) | reconciliation loop |
+| **Tokens** | `GET /api/tokens` (counts, required) + `GET /api/cost` (estimate, optional) | activity loop, fixed |
+| **Events** | `GET /api/audit` (newest-first operator/governor activity) | activity loop, fixed |
+
+The **reconciliation loop** is what the SSE connection status affects: every
+5 seconds while the stream is down or has not proven itself yet, stretching to
+every 60 seconds once an event has actually been received on it (the stream
+is doing the work at that point; the poll is just a reconciler catching a
+roster change the stream does not announce, or a stream that stalled without
+dropping the connection).
+
+The **activity loop** — Tokens and Events — polls every 5 seconds
+**unconditionally**, whether or not the SSE stream is connected. Nothing on
+the stream carries token counts, estimated cost, or audit rows, so there is
+no push event for those panes to wait on; tying them to the reconciliation
+timer would make a *healthy* connection the reason they went stale. (This is
+what `tui T32` / [#5421](https://github.com/kubestellar/hive/issues/5421)
+fixed — earlier builds hung all seven reads off one timer, so a connected
+stream paradoxically made the Tokens and Events panes twelve times staler.)
+
+Both loops fetch once immediately on startup, so the frame fills in before
+either interval elapses. A failed fetch never blanks a pane: the previous
+successful frame stays on screen until the next successful read replaces it.
+One field is the exception — a failed `/api/cost` read *clears* the cached
+estimate rather than holding it, because a dollar figure attached to token
+counts that have since moved by a fresh `/api/tokens` read is worse than an
+honest `—`. Every write action below (pause/resume, model apply, kick,
+ACMM apply, returning from a tmux attach) also triggers an immediate full
+refresh of both loops, so the frame does not wait out an interval to show the
+effect of the operator's own action.
+
+`/api/audit` is the one poll-shaped read that needs owner (read-write) access;
+a read-only token gets a 403 there like any other forbidden read, and it
+travels the same swallowed-error path as a network failure — the Events pane
+simply keeps its last successful snapshot rather than showing an error.
+
+#### Keybindings
+
+| Key | Action | Scope |
+|---|---|---|
+| `tab` / `shift+tab` | Cycle pane focus forward / backward | global |
+| `j` / `k`, `↓` / `↑` | Move the row selection | Agents, Events panes |
+| `p` | Pause or resume the selected agent (opens a y/n confirm) | Agents pane |
+| `m` | Open the model picker for the selected agent | Agents pane |
+| `K` | Kick the selected agent now | Agents pane |
+| `A` | Open the ACMM level overlay | global |
+| `a` | Attach to the selected agent's tmux session (**local only**) | Agents pane |
+| `?` | Toggle the help overlay (lists this table; dismisses on any key) | global |
+| `q` / `ctrl+c` | Quit | global |
+
+Case is meaningful and deliberate: `K` (kick) and `A` (ACMM) are the two
+actions with the widest blast radius bound to a bare key, so each sits on the
+shifted member of a pair whose lowercase twin (`k` navigate, `a` attach) is
+pressed constantly during normal use — a missed shift never fires the bigger
+action by accident. Actions apply to the selection in the **focused** pane
+only; pressing `p`/`m`/`K`/`a` while a pane other than Agents is focused is a
+no-op, never a guess at "the current agent".
+
+**Every overlay below is modal**: while one is open it consumes *every* key,
+including `q`, `tab`, and the other action letters — closing or resolving the
+overlay is the only way those reach the frame underneath again. The ACMM
+overlay is the one exception to "letters are bindings": once its typed
+confirmation is open, ordinary letters (including `p`, `a`, `A`, `K`) are
+literal text being typed into the confirmation phrase, not actions.
+
+#### Pause / resume
+
+`p` on a selected agent opens a confirm dialog (`y` confirm, `n` / `esc`
+cancel) rather than acting immediately. While the request is in flight the
+dialog shows "Working…" and swallows further input; on failure it shows the
+error in place and offers retry (`y`) or cancel. A 403 renders as `Pause
+failed: owner access required` (or `Resume failed: …`) rather than the raw
+HTTP error, since a forbidden pause/resume always means the same thing:
+the token is not the hive owner's.
+
+#### Model apply
+
+`m` opens a picker for the selected agent's backend, fetching its model
+catalogue asynchronously. The catalogue can carry two independent
+qualifications, both shown as a note in the overlay when present:
+
+- **Fallback** — endpoint discovery found nothing and the server substituted
+  its static alias list; these ids are unverified guesses, not a confirmed
+  catalogue.
+- **Partial** — some of the backend's endpoints answered and others did not;
+  a model's *absence* from the list proves nothing, since it may be served
+  only by the endpoint that failed to answer.
+
+`enter` applies the highlighted model. **Applying restarts the agent's
+session** — the overlay states this before every apply — so the picker is not
+a preview; choosing a model takes effect and interrupts in-flight work.
+Applying is refused while a previous apply is still pending, so repeated
+`enter` presses cannot queue a second restart. A 403 here renders as `Model
+change failed: owner access required`.
+
+#### Kick
+
+`K` queues an immediate run for the selected agent and reports the outcome in
+the footer rather than the pane: `kick queued for <agent>` on success, or
+`kick already in flight for <agent> (request deduplicated)` if one was already
+queued. A 403 renders as `Kick failed: owner access required`. Only one local
+kick request is in flight at a time; `K` is a no-op while the previous one is
+still pending.
+
+#### ACMM apply
+
+`A` opens the ACMM level overlay from anywhere — the level is a property of
+the whole hive, not the focused pane's selection. It fetches the pack list
+(the level definitions the server has configured) asynchronously; a 403 here
+renders as `ACMM packs unavailable: owner access required`.
+
+Selecting a level and pressing `enter` does **not** apply it directly — it
+begins a **typed confirmation**: the overlay asks for the exact phrase
+`APPLY L<n>`, and only an exact match arms the apply on the next `enter`.
+Anything else typed is a no-op; `esc` during confirmation backs out to the
+list rather than closing the overlay outright, so a mistyped phrase costs one
+key. Selecting the level already in force skips confirmation entirely and
+shows a "nothing to apply" message instead, since there is no write to
+protect against.
+
+On success the overlay **stays open**, now showing the reconciliation
+receipt, until the operator dismisses it with `enter` or `esc` — it does not
+flash past into a footer line, and a second `enter` cannot re-apply. On a
+partial failure (the level persisted server-side but the fleet has not yet
+reconciled to it — a 500 after the write took effect), the overlay still
+shows an apply error, but the app also triggers an immediate refresh anyway,
+because the panes underneath may already describe a hive that has moved.
+
+#### Local tmux attach
+
+`a` on a selected agent runs a preflight check (`tmux has-session -t
+hive-<agent>`) before suspending the TUI, so a missing `tmux` binary or a
+session that does not exist yet surfaces as a footer message
+(`Attach failed: …`) instead of a redraw flicker. A successful preflight hands
+the terminal to `tmux attach` directly; returning from the session (however it
+ends) restores the TUI and immediately refreshes the fleet, since the agent's
+state may have moved while attached. **This is local-only** — it execs a
+`tmux` binary next to the TUI process and cannot attach to a session running
+on a remote hive.
+
+#### Connection status and the poll fallback
+
+The header's `ws:` field is `connected` only once an event has actually been
+**received** on the SSE stream — not merely dialled, since a successful
+subscribe hands back its channels before the request is even confirmed.
+Everything else — before the first event, during a reconnect's backoff, and
+right after a drop — reads `not connected`, because all three mean the same
+thing to an operator: the numbers on screen are coming from the fallback poll,
+not the stream. `hive:` (identity) and `governor:` (mode) never blank on a
+drop; only `ws:` changes, so a flapping connection does not make the header
+look like the hive itself went away.
+
+On a drop, reconnection backs off starting at 1 second and doubling to a
+30-second cap, and the reconciliation loop's cadence drops back from 60s to 5s
+immediately along with an out-of-cycle fetch, so the fallback's first data
+does not wait out a whole interval. The activity loop (Tokens, Events) is
+unaffected by any of this — see [The four panes](#the-four-panes) above.
+
+#### Terminal size, help, resize, and quit
+
+The grid needs at least **60×20** to stay readable; below that the frame is
+replaced by a single centred `terminal too small (need at least 60x20)`
+message rather than shrinking the panes into unreadable slivers. Resizing is
+automatic — the layout re-derives itself from the terminal size on every
+render, with no keybinding involved. `?` toggles a help overlay listing every
+binding above; it dismisses on any keypress. Colors are chosen for contrast
+against both light and dark terminal backgrounds, so the focused-pane border
+and header stay legible either way. `q` or `ctrl+c` quits **from the top level
+only** — while any overlay is open, `q` is swallowed like every other key, so
+an operator dismisses the overlay first (see the modal rule above).
+
+#### v1 boundaries
+
+- **Self-hosted, token auth only.** `HIVE_DASHBOARD_TOKEN` against a
+  self-hosted hive's dashboard; there is no hub OAuth login flow.
+- **Local tmux attach only.** No remote terminal embedding over the ttyd
+  WebSocket — that is a follow-up epic.
+- **Feature parity with the web dashboard's operator loop, not visual
+  parity.** The TUI does not attempt to look like the web dashboard.
+
+Track any further work under the `hive tui` epic
+([#4907](https://github.com/kubestellar/hive/issues/4907)).
 
 ### enroll — spoke-based lite repo enrollment
 


### PR DESCRIPTION
Fixes #5422

## Summary

- `hivectl tui` is Hive's terminal dashboard — a full-screen, keyboard-driven view of the agent fleet, governor, token spend, and activity feed, built as another client of the same dashboard API the web UI uses (not a second Hive runtime).
- The `#4907` epic that builds it is now complete: T21 (kick), T17 (model picker), T19 (ACMM overlay), and T32 (splitting the poll cadence so a healthy SSE stream doesn't stall the Tokens/Events panes) have all merged. The public guide, however, still described the early scaffold — it said Governor and Events were stubs, only half the panes were live, and help/pause/resize did not exist. An operator reading `src/docs/hivectl.md` or the root README had no way to even discover the TUI existed, let alone find its env vars, keybindings, or limitations.
- This rewrites the documentation against the **shipped code**, not the epic's original plan — including one real behavioral gap I found while writing it (below).
- **Blast radius:** `docs-only`, `no behavior change`. Only `README.md`, `src/docs/README.md`, `src/docs/hivectl.md`, and `src/docs/design/README.md`/`tui.md` changed — no Go, JavaScript, generated OpenAPI, or binary media.

## What changed

**`src/docs/hivectl.md`** — the `tui` section is now a full operator reference, read directly against `src/pkg/tui/*.go`:

- launch and endpoint selection
- the four panes and which of the **two independently-cadenced poll loops** (T32) feeds each — reconciliation (agents/governor, 5s↔60s with SSE) vs. activity (tokens/cost/events, fixed 5s always)
- the complete keybinding table, scope rules, and the modal/overlay-swallows-every-key contract
- pause/resume, model apply (with its restart warning and Fallback/Partial catalogue qualifications), kick's queued/deduplicated footer statuses, ACMM's typed `APPLY L<n>` confirmation and reconciliation receipt, and local-only tmux attach
- SSE connected/degraded semantics and the poll fallback (backoff, immediate re-fetch on drop)
- minimum terminal size, help, resize, light/dark adaptation, and quit
- authorization failures (every mutating action's `owner access required` message), missing-tmux/session behavior, partial model catalogues, and the stale-last-good-data-on-failure contract (with the one exception: a failed cost read *clears* rather than holds, since a dollar figure can't safely outlive the counts it was priced against)
- v1's boundaries: self-hosted token auth, local attach only, no pixel-parity claim

**One real discrepancy found and corrected**, not just prose: I verified `hivectl tui`'s actual flag handling before documenting it, since the issue explicitly asked for "`--hive`/endpoint selection." There is no such flag. `newTUICommand` (`src/pkg/hivectl/commands/tui.go`) calls `tui.Run()` with nothing from `*commandEnv` — `hivectl tui` reads `HIVE_DASHBOARD_URL`/`HIVE_DASHBOARD_TOKEN` directly and does **not** honour the root `--server`/`--token-env` flags every other `hivectl` subcommand reads. The two base-URL defaults even differ by one detail (`http://localhost:3001` vs. `--server`'s `http://127.0.0.1:3001`). I documented what's actually there rather than what the issue assumed, and fixed the same stale claim in the design doc (below) — it had proposed reusing `--server`, which is not what got built.

**`src/docs/design/tui.md`** — status header changed from "design only" to "shipped (v1)". Per this record's own convention (`design/README.md`: design docs are *not* rewritten as later stages ship, only their status and factual corrections), I did not rewrite the body — only the status line and the one `--server` correction above, cited against the actual source (`src/pkg/hivectl/commands/tui.go`).

**`README.md`** and **`src/docs/README.md`** — added a discoverable entry point for both: a short root-README section introducing `hivectl tui` and positioning it as another API client, and a docs-index line under the existing `hivectl` entry.

**`src/docs/design/README.md`** — updated the `tui.md` index entry's status tag and blurb to match.

## Verification

- `python3 src/scripts/check-docs-links.py src/docs` — the repo's own relative-link/anchor checker (added after #5206, a previous silent break from a heading rename in this same file) — **all 127 files pass, every anchor resolves.** I hand-verified every anchor slug I introduced (`#tui--live-terminal-dashboard`, `#launch-and-endpoint-selection`, `#delivery-hivectl-tui`) against GitHub's slugification and against the checker's own output.
- Every relative link this PR touches or adds was manually followed to its target file.
- `cd src && go build ./...` — clean.
- `cd src && go test ./...` — one pre-existing, environment-gated failure in `pkg/config` (`TestGateFailsClosedWithoutIP6Tables`, needs root/`NET_ADMIN` to create an `ip6tables` chain, unavailable in this sandbox) — unrelated to this change, since **no Go file is touched** by this PR. `go test ./pkg/tui/...` (the package this doc describes) is fully green.
- Every documented pane/action/key was checked against the current source rather than assumed from the issue text or the design doc — e.g. the keybinding table, the modal-swallows-every-key rule, the `owner access required` wording, and the Fallback/Partial catalogue flags are all transcribed from `src/pkg/tui/app.go`, `attach.go`, and `pkg/tui/panes/*.go`, not copied from `src/docs/design/tui.md`'s original (aspirational) table.

## Out of scope

No CLI flags added, no behavior changed, no tutorial video/GIF (T27), and no duplication of the full dashboard API reference — all as the issue specifies.

— hive: backend=claude model=claude sonnet high
