### PR TITLE
🐛 fix(ci): backend-smoke.yml rejected by workflow parser — matrix context in job-level if

### DIFF
--- a/.github/workflows/backend-smoke.yml
+++ b/.github/workflows/backend-smoke.yml
@@ -70,17 +70,22 @@ jobs:
   smoke:
     # Forks have no model credentials; a scheduled run there would only
     # produce a permanently red workflow.
-    if: >-
-      github.repository == 'kubestellar/hive' &&
-      (github.event_name != 'workflow_dispatch' ||
-       inputs.lane == 'both' || inputs.lane == matrix.lane)
+    if: github.repository == 'kubestellar/hive'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         backend: [claude, codex]
-        lane: [latest, pinned]
+        # The dispatch lane filter lives HERE, not in the job-level `if`: that
+        # `if` is evaluated before the matrix expands, so `matrix` is not in
+        # scope there and GitHub rejects the whole file (#5550). Selecting the
+        # lane list up front also means an unwanted lane never schedules a
+        # runner at all, rather than starting one that immediately no-ops.
+        lane: >-
+          ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != 'both')
+              && fromJSON(format('["{0}"]', inputs.lane))
+              || fromJSON('["latest","pinned"]') }}
     env:
       # Per-arm credential scoping: each backend arm gets only its own
       # vendor's credential, in whichever form the repo provisioned (see the


### PR DESCRIPTION
## Problem

`.github/workflows/backend-smoke.yml` gated its `smoke` job with a job-level `if` that referenced `matrix.lane`:

```yaml
if: >-
  github.repository == 'kubestellar/hive' &&
  (github.event_name != 'workflow_dispatch' ||
   inputs.lane == 'both' || inputs.lane == matrix.lane)
```

`jobs.<id>.if` is evaluated **before** the matrix expands, so the `matrix` context does not exist at that point. GitHub rejects the entire workflow file. Consequences since it merged (~2026-09-01 14:03 UTC, 3890c4d/ae92788):

- every push to every branch produces a 0-second failed run named `.github/workflows/backend-smoke.yml`
- the scheduled smoke lanes (`cron: 45 2,8,14,20`) have **never run**

## Fix chosen, and why

Two options were on the table. I took the **matrix-computation** one.

The lane filter now lives in `strategy.matrix.lane`, which selects the lane list up front via `fromJSON`. The `inputs` context **is** in scope inside `strategy`, so a dispatch naming a single lane expands the matrix to just that lane:

```yaml
lane: >-
  ${{ (github.event_name == 'workflow_dispatch' && inputs.lane != 'both')
      && fromJSON(format('["{0}"]', inputs.lane))
      || fromJSON('["latest","pinned"]') }}
```

The alternative — moving the `inputs.lane` term to a step-level `if` — also parses, since `matrix` is available at step level. I rejected it because the whole point of the condition is to *avoid running* a lane the operator did not ask for. A step-level guard still spins up a runner for every unwanted arm and then no-ops, reporting green-but-empty jobs. Computing the matrix means the unwanted lane never schedules at all, which is what the original author was reaching for.

The `github.repository == 'kubestellar/hive'` fork guard **stays** on the job-level `if`, where it is perfectly valid — forks have no model credentials and would go permanently red without it.

Injection note: `inputs.lane` is a `choice` constrained to `both|latest|pinned`, so the `format()` interpolation cannot introduce arbitrary JSON.

## Verification — actionlint

**Before** (on `origin/v4`):

```
$ actionlint .github/workflows/backend-smoke.yml
.github/workflows/backend-smoke.yml:74:50: context "matrix" is not allowed here. available contexts are "github", "inputs", "needs", "vars". see https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability for more details [expression]
EXIT=1
```

**After** (this branch):

```
$ actionlint .github/workflows/backend-smoke.yml
EXIT=0
```

A full-repo `actionlint` run also exits 0; the only remaining output is pre-existing shellcheck `SC2016` *info* in the unrelated `podman-arm64-lane.yml`.

Since a file can parse locally and still be rejected by GitHub, registration on the pushed branch was checked separately — see the comment below.

## Not verified

- **The scheduled cron lanes actually work.** Cron cannot be triggered on demand, and this workflow is `schedule` + `workflow_dispatch` only, so pushing does not exercise the smoke itself. This PR proves the file is *accepted*; the first real evidence the lanes run will be the next scheduled tick.
- **The smoke suite passing.** No credentials are exercised here and no lane was dispatched; this change is confined to workflow scheduling semantics.
- `bin/test_backend_smoke.sh` is untouched.

Fixes #5550