### PR TITLE
🐛 fix(github): paginate findDigestComment newest-first so the bot can see its own digest

### DIFF
--- a/src/pkg/github/advisory.go
+++ b/src/pkg/github/advisory.go
@@ -151,6 +151,33 @@ const (
 	// this forces roughly one real write per hour — enough to keep the
 	// App-banner logic honest while still eliminating ~98% of the no-op edits.
 	advisoryDigestWriteThroughInterval = 60
+	// advisoryDigestCommentsPerPage is the page size used when scanning a
+	// target's comments for the bot's own digest. 100 is GitHub's maximum for
+	// this endpoint; using anything smaller only multiplies the number of
+	// round trips needed to cover the same history.
+	advisoryDigestCommentsPerPage = 100
+	// advisoryDigestScanMaxPages bounds that scan (#5522). findDigestComment
+	// used to read ONE page of 50 and stop, so on any target carrying more
+	// than ~50 comments the bot could not see its own digest and CREATEd a
+	// fresh one every cycle instead of EDITing — each new comment pushing the
+	// digest one position further out of reach. That is the mechanism that
+	// turned a repeat-post bug into 250 separate comments on
+	// ibm/alchemy-logging#686.
+	//
+	// The scan now walks pages NEWEST-FIRST (direction=desc), because the
+	// bot's own digest is overwhelmingly likely to be recent: the common case
+	// resolves on page 1 at the same one-call cost as before, and a target
+	// with thousands of ancient comments is still covered near its head.
+	//
+	// 10 pages x 100 = the most recent 1,000 comments per cycle. WHEN THE CAP
+	// IS HIT the scan stops and reports "not found" — the same answer it gives
+	// for a genuinely absent digest, so the post path CREATEs a new digest
+	// comment. That is a deliberate trade: a digest older than the 1,000 most
+	// recent comments on a target is effectively unreachable, and one new
+	// comment (which every later cycle then finds on page 1 and edits) is
+	// preferable to walking unbounded history on every ~60s cycle. The cap
+	// being hit is logged at Warn so the case is visible rather than silent.
+	advisoryDigestScanMaxPages = 10
 )
 
 // PostAdvisoryDigest updates the existing digest comment on the advisory issue,
@@ -414,14 +441,52 @@ type digestComment struct {
 func (d digestComment) found() bool { return d.id > 0 }
 
 func (c *Client) findDigestCommentDetail(ctx context.Context, owner, repo string, issueNum int) (digestComment, error) {
+	// #5522: scan newest-first and paginate. See advisoryDigestScanMaxPages
+	// for the bound and for what happens when it is reached.
 	opts := &gh.IssueListCommentsOptions{
-		ListOptions: gh.ListOptions{PerPage: 50},
-	}
-	comments, _, err := c.client.Issues.ListComments(ctx, owner, repo, issueNum, opts)
-	if err != nil {
-		return digestComment{}, err
+		Sort:      gh.Ptr("created"),
+		Direction: gh.Ptr("desc"),
+		ListOptions: gh.ListOptions{
+			PerPage: advisoryDigestCommentsPerPage,
+		},
 	}
 	var botAuthored digestComment
+	pages := 0
+	for {
+		comments, resp, err := c.client.Issues.ListComments(ctx, owner, repo, issueNum, opts)
+		if err != nil {
+			// A partial scan that already found a usable fallback still
+			// beats creating a duplicate, so surface the error but keep
+			// whatever the earlier pages turned up.
+			return botAuthored, err
+		}
+		pages++
+		found, done := c.scanDigestPage(owner, repo, issueNum, comments, &botAuthored)
+		if done {
+			return found, nil
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return botAuthored, nil
+		}
+		if pages >= advisoryDigestScanMaxPages {
+			c.logger.Warn("advisory digest comment scan hit its page cap — treating the digest as absent, which will CREATE a new one",
+				slog.String("repo", owner+"/"+repo),
+				slog.Int("issue", issueNum),
+				slog.Int("pages_scanned", pages),
+				slog.Int("comments_scanned", pages*advisoryDigestCommentsPerPage))
+			return botAuthored, nil
+		}
+		opts.Page = resp.NextPage
+	}
+}
+
+// scanDigestPage applies the authorship rules to one page of comments. It
+// returns (comment, true) when it has found the definitive digest to edit and
+// the scan can stop, or (_, false) to continue to the next page. A
+// bot-authored-but-not-provably-ours comment is remembered in botAuthored as a
+// fallback rather than ending the scan, so a later page can still yield an
+// exact match.
+func (c *Client) scanDigestPage(owner, repo string, issueNum int, comments []*gh.IssueComment, botAuthored *digestComment) (digestComment, bool) {
 	for _, comment := range comments {
 		if !strings.HasPrefix(comment.GetBody(), advisoryDigestPrefix) {
 			continue
@@ -430,20 +495,22 @@ func (c *Client) findDigestCommentDetail(ctx context.Context, owner, repo string
 			// Token (PAT) client: historical prefix-only match. The credential
 			// may legitimately be the human who authored the comment, and
 			// authorship cannot be verified without an extra /user round trip.
-			return digestCommentFrom(comment), nil
+			return digestCommentFrom(comment), true
 		}
 		login := comment.GetUser().GetLogin()
 		if c.appBotLogin != "" && login == c.appBotLogin {
 			// Exactly our own bot comment — the one credential-safe choice.
-			return digestCommentFrom(comment), nil
+			return digestCommentFrom(comment), true
 		}
 		if strings.HasSuffix(login, "[bot]") || comment.GetUser().GetType() == "Bot" {
 			// Bot-authored but not provably ours (bot login unknown, or a slug
 			// mismatch between config and the real App). Remember the first as
 			// a fallback rather than skipping it: refusing our own comment on
 			// a misconfigured slug would create a duplicate every cycle.
+			// "First" is now the NEWEST such comment, since the scan runs
+			// newest-first.
 			if !botAuthored.found() {
-				botAuthored = digestCommentFrom(comment)
+				*botAuthored = digestCommentFrom(comment)
 			}
 			continue
 		}
@@ -461,7 +528,7 @@ func (c *Client) findDigestCommentDetail(ctx context.Context, owner, repo string
 			slog.Int64("comment_id", comment.GetID()),
 			slog.String("author", login))
 	}
-	return botAuthored, nil
+	return digestComment{}, false
 }
 
 // digestCommentFrom projects the fields the post path needs out of a forge

--- a/src/pkg/github/advisory_pagination_test.go
+++ b/src/pkg/github/advisory_pagination_test.go
@@ -1,0 +1,328 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// --------------------------------------------------------------------------
+// #5522 — findDigestComment must paginate.
+//
+// The bug: findDigestCommentDetail read ONE page (PerPage: 50) and stopped.
+// On any target carrying more than ~50 comments the bot could not see its own
+// digest, so the post path fell through to CREATE instead of EDIT, and every
+// comment it created pushed the digest one position further out of reach.
+//
+// The fixtures below deliberately place the digest BEYOND the first page. A
+// fixture with the marker at position 3 would pass against the unpaginated
+// code and prove nothing.
+// --------------------------------------------------------------------------
+
+// commentPager serves a synthetic comment list with GitHub's Link header
+// pagination, honouring page/per_page and direction=desc.
+type commentPager struct {
+	// bodies is the comment list in CHRONOLOGICAL order (oldest first), the
+	// order GitHub returns for direction=asc.
+	bodies []string
+	// authors parallels bodies; empty means a plain human login.
+	authors []string
+	// pageRequests records the ?page= value of each request, so a test can
+	// assert how many pages were actually walked.
+	pageRequests []int
+	// lastDirection records the direction parameter of the final request.
+	lastDirection string
+}
+
+func (p *commentPager) handler(t *testing.T, basePath string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		perPage, _ := strconv.Atoi(q.Get("per_page"))
+		if perPage <= 0 {
+			perPage = 30
+		}
+		page, _ := strconv.Atoi(q.Get("page"))
+		if page <= 0 {
+			page = 1
+		}
+		p.pageRequests = append(p.pageRequests, page)
+		p.lastDirection = q.Get("direction")
+
+		// Build the ordered view the caller asked for.
+		type item struct {
+			id     int
+			body   string
+			author string
+		}
+		ordered := make([]item, 0, len(p.bodies))
+		for i, b := range p.bodies {
+			a := ""
+			if i < len(p.authors) {
+				a = p.authors[i]
+			}
+			ordered = append(ordered, item{id: 1000 + i, body: b, author: a})
+		}
+		if q.Get("direction") == "desc" {
+			for i, j := 0, len(ordered)-1; i < j; i, j = i+1, j-1 {
+				ordered[i], ordered[j] = ordered[j], ordered[i]
+			}
+		}
+
+		start := (page - 1) * perPage
+		if start > len(ordered) {
+			start = len(ordered)
+		}
+		end := start + perPage
+		if end > len(ordered) {
+			end = len(ordered)
+		}
+		slice := ordered[start:end]
+
+		out := make([]map[string]any, 0, len(slice))
+		for _, it := range slice {
+			user := map[string]any{"login": "humanreviewer", "type": "User"}
+			if it.author != "" {
+				user = map[string]any{"login": it.author, "type": "Bot"}
+			}
+			out = append(out, map[string]any{
+				"id":   it.id,
+				"body": it.body,
+				"user": user,
+			})
+		}
+		if end < len(ordered) {
+			next := fmt.Sprintf("<%s%s?per_page=%d&page=%d>; rel=\"next\"",
+				"http://"+r.Host, basePath, perPage, page+1)
+			w.Header().Set("Link", next)
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+// digestAt builds n comments with the digest marker at index markerIdx
+// (0-based, chronological). markerIdx < 0 means no digest at all.
+func digestAt(n, markerIdx int) ([]string, []string) {
+	bodies := make([]string, n)
+	authors := make([]string, n)
+	for i := range bodies {
+		bodies[i] = fmt.Sprintf("ordinary human discussion comment #%d", i)
+	}
+	if markerIdx >= 0 && markerIdx < n {
+		bodies[markerIdx] = advisoryDigestPrefix + " — findings for this cycle"
+		authors[markerIdx] = "hive-app[bot]"
+	}
+	return bodies, authors
+}
+
+func newPagerServer(t *testing.T, org, repo string, issue int, p *commentPager) *httptest.Server {
+	t.Helper()
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", org, repo, issue)
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, p.handler(t, path))
+	return httptest.NewServer(mux)
+}
+
+// TestFindDigestComment_MarkerBeyondFirstPage is the direct regression test
+// for #5522. 260 comments with the digest at chronological index 130 — the
+// exact middle, so it is beyond the first page in BOTH orderings: page 1
+// oldest-first (the old PerPage:50 ascending read) covers 0..49, and page 1
+// newest-first covers 259..160. Only a scan that actually turns the page can
+// reach it. A fixture with the marker near either end would be found by the
+// unpaginated code and would prove nothing.
+func TestFindDigestComment_MarkerBeyondFirstPage(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	const markerIdx = 130
+	bodies, authors := digestAt(260, markerIdx)
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	want := 1000 + markerIdx
+	if id != want {
+		t.Fatalf("comment id = %d, want %d — the digest sits at chronological index 130 of 260, "+
+			"so a single-page scan cannot see it and the caller would CREATE a duplicate", id, want)
+	}
+	if len(p.pageRequests) < 2 {
+		t.Errorf("pages requested = %v, want more than one — a marker this deep is unreachable in one page", p.pageRequests)
+	}
+}
+
+// TestFindDigestComment_NewestFirstFindsRecentInOnePage pins the ordering
+// choice: the bot's own digest is overwhelmingly likely to be the most recent
+// comment, so the common case must still cost exactly one API call even on a
+// target with hundreds of comments.
+func TestFindDigestComment_NewestFirstFindsRecentInOnePage(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(400, 399) // newest comment is the digest
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 1000+399 {
+		t.Fatalf("comment id = %d, want %d", id, 1000+399)
+	}
+	if len(p.pageRequests) != 1 {
+		t.Errorf("pages requested = %v, want exactly 1 — a recent digest must not cost a full walk", p.pageRequests)
+	}
+	if p.lastDirection != "desc" {
+		t.Errorf("direction = %q, want %q — the scan must run newest-first", p.lastDirection, "desc")
+	}
+}
+
+// TestFindDigestComment_ScanIsBounded pins the cap stated in
+// advisoryDigestScanMaxPages. A target with far more comments than the cap
+// allows must stop at the cap rather than walking unbounded history every
+// ~60s cycle, and must report "not found" (id 0) so the caller CREATEs a new
+// digest that every later cycle then finds on page 1.
+func TestFindDigestComment_ScanIsBounded(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	total := advisoryDigestScanMaxPages*advisoryDigestCommentsPerPage + 500
+	bodies, authors := digestAt(total, 0) // digest is the OLDEST comment
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 0 {
+		t.Errorf("comment id = %d, want 0 — a digest beyond the cap is reported absent", id)
+	}
+	if len(p.pageRequests) != advisoryDigestScanMaxPages {
+		t.Errorf("pages requested = %d, want exactly %d (the cap)", len(p.pageRequests), advisoryDigestScanMaxPages)
+	}
+}
+
+// TestFindDigestComment_ExhaustsWithoutMarker is the negative control: a
+// paginated scan that finds nothing must return 0 and must not report an
+// error, and must stop when the list is exhausted rather than at the cap.
+func TestFindDigestComment_ExhaustsWithoutMarker(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(250, -1)
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 0 {
+		t.Errorf("comment id = %d, want 0", id)
+	}
+	// 250 comments at 100/page = 3 pages, well under the cap.
+	if len(p.pageRequests) != 3 {
+		t.Errorf("pages requested = %d, want 3 (list exhausted, not capped)", len(p.pageRequests))
+	}
+}
+
+// TestFindDigestComment_BotFallbackSurvivesPagination pins that the
+// not-provably-ours bot fallback (a slug mismatch between config and the real
+// App) still works across pages: a fallback seen on page 1 must not be
+// discarded when later pages yield nothing, or the bot would create a
+// duplicate every cycle on a misconfigured slug.
+func TestFindDigestComment_BotFallbackSurvivesPagination(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(250, 249) // newest, but authored by ANOTHER bot
+	authors[249] = "some-other-app[bot]"
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]" // does NOT match the comment author
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 1000+249 {
+		t.Errorf("comment id = %d, want %d — the bot-authored fallback found on page 1 "+
+			"must survive the rest of the scan", id, 1000+249)
+	}
+}
+
+// TestFindDigestComment_HumanAuthoredIsSkippedAcrossPages pins that the
+// App-can-never-edit rule (#1927 / kalantar-msb/soft-reflective#1) still
+// applies once the scan is paginated: a human-authored digest comment beyond
+// the first page must be skipped, not adopted.
+func TestFindDigestComment_HumanAuthoredIsSkippedAcrossPages(t *testing.T) {
+	org, repo, issue := "testorg", "testrepo", 686
+	bodies, authors := digestAt(250, 5) // deep in history
+	authors[5] = ""                     // human author
+	p := &commentPager{bodies: bodies, authors: authors}
+	server := newPagerServer(t, org, repo, issue, p)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	c.appAuth = &AppAuth{}
+	c.appBotLogin = "hive-app[bot]"
+
+	id, err := c.findDigestComment(context.Background(), org, repo, issue)
+	if err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if id != 0 {
+		t.Errorf("comment id = %d, want 0 — an App can never edit a human-authored comment", id)
+	}
+}
+
+// TestFindDigestComment_PerPageIsMaximised guards against a silent regression
+// to a small page size, which would multiply the round trips needed to cover
+// the same history.
+func TestFindDigestComment_PerPageIsMaximised(t *testing.T) {
+	if advisoryDigestCommentsPerPage != 100 {
+		t.Errorf("advisoryDigestCommentsPerPage = %d, want 100 (GitHub's maximum)", advisoryDigestCommentsPerPage)
+	}
+	org, repo, issue := "testorg", "testrepo", 686
+	var gotPerPage string
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/comments", org, repo, issue),
+		func(w http.ResponseWriter, r *http.Request) {
+			gotPerPage = r.URL.Query().Get("per_page")
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	if _, err := c.findDigestComment(context.Background(), org, repo, issue); err != nil {
+		t.Fatalf("findDigestComment: %v", err)
+	}
+	if gotPerPage != strconv.Itoa(advisoryDigestCommentsPerPage) {
+		t.Errorf("per_page = %q, want %q", gotPerPage, strconv.Itoa(advisoryDigestCommentsPerPage))
+	}
+	_ = strings.TrimSpace("")
+}


### PR DESCRIPTION
`findDigestComment` read only the first page — `PerPage: 50`, no pagination. Past ~50 comments on a target issue the bot could no longer see its own digest, fell through to CREATE instead of EDIT, and each new comment pushed the next one further out of reach. Self-reinforcing: that is the mechanism that turned a repeat-post bug into ~250 **separate comments** on one issue rather than 250 edits to one.

## Why this is still needed after #5521

#5521 added content-hash suppression, which removes the pressure that drove the count up. It does **not** restore edit-in-place on any target already past the horizon — and that includes issues carrying >50 comments of ordinary human discussion, which are past it *today*, not eventually.

## The fix

The scan walks **newest-first** (`sort=created`, `direction=desc`) at GitHub's max page size, so the common case — a digest posted recently — still costs exactly **one API call**. Full pagination is the fallback, not the default path.

**Bounded** at `advisoryDigestScanMaxPages × advisoryDigestCommentsPerPage` = the 1,000 most recent comments per cycle, both named constants rather than literals.

**When the cap is hit**, the scan returns not-found — identical to a genuinely absent digest — so the caller CREATEs a comment that every later cycle then finds on page one and edits. It self-heals rather than looping, and it is logged at `Warn` rather than passing silently.

Per-page authorship rules are factored into `scanDigestPage`, so the bot-authored fallback survives across pages and human-authored comments are still skipped.

## Provenance

This is the pagination half of #5541, retargeted. #5539 shipped the `enumerate-actionable` xargs fix and closed #5528, making that PR's `bin/` half redundant and leaving it conflicting. Only the unshipped half is carried here — `bin/` is untouched and identical to merged `v4`.

## Testing

The tests came from #5541 and one of them was **caught being vacuous before it was trusted**: the marker was initially placed at chronological index 12 of 260, which the *buggy* single-page read still found, so only the page-count assertion tripped. Moved to index **130 of 260** — the exact middle, outside page one in both orderings — it now fails on the id itself, which is the real symptom (`id 0` means CREATE a duplicate).

Against the single-page implementation, 6 of 7 tests fail: `id = 0, want 1130`; `id = 0, want 1399`; `pages = 1, want 10`; `pages = 1, want 3`; `id = 0, want 1249`; `per_page = 50, want 100`.

## Not verified

- **No live GitHub run.** All pagination evidence is against an `httptest` server implementing Link-header paging. The bot was not pointed at a real >50-comment target, and `ibm/alchemy-logging#686` was not touched or recovered.
- `pkg/github` has two pre-existing hanging tests (`TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset`, `TestCommitGreenNoConfigRequiredChecksFallsBackToAPIThenAllowlist`) that `exec.Command` out to a shell script and block in sandboxes; skipping exactly those two gives `ok ... 47s`. They fail identically on unmodified `v4`.

Fixes #5522