### PR TITLE
🐛 fix(bin): kick-governor pause checks fail closed, budget loop follows AGENTS_ENABLED, tier downgrade targets a real model

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -173,7 +173,36 @@ RATE_LIMIT_COOLDOWN="${RATE_LIMIT_COOLDOWN:-1800}"  # 30 min
 
 # ── Paths ───────────────────────────────────────────────────────────────────
 STATE_DIR="/var/run/kick-governor"
-_is_agent_paused() { hive_is_paused "$1"; }
+
+# Pause check — FAILS CLOSED.
+#
+# hive_is_paused() is defined in bin/hive-config.sh, which is sourced above
+# only when HIVE_REPOS is unset. When HIVE_REPOS arrives preset (from
+# /etc/hive/governor.env, or the env), hive-config.sh is never sourced and
+# hive_is_paused is undefined. Every _is_agent_paused call site sits inside an
+# `if`/`&&`, which is a `set -e` EXEMPT context — so the resulting exit 127
+# ("hive_is_paused: command not found") was silently read as "NOT paused" and
+# every dashboard pause, operator pause and cadence-zero pause was ignored.
+#
+# hive-config.sh is deliberately NOT sourced unconditionally to repair this:
+# it also assigns AGENTS_ENABLED and PROJECT_REPOS from hive-runtime.yaml and
+# can shell out to mint a GitHub App token, so sourcing it here would silently
+# override the operator's own AGENTS_ENABLED. Instead the pause predicate is
+# self-contained, and if a future refactor removes it the check fails CLOSED:
+# an agent we cannot prove is unpaused is treated as paused. A spuriously
+# paused agent is recoverable by the operator; an agent that ignores a pause
+# is not.
+_is_agent_paused() {
+  local agent="${1:?agent name required}"
+  if declare -F hive_is_paused >/dev/null 2>&1; then
+    hive_is_paused "$agent"
+    return
+  fi
+  # Local equivalent of hive_is_paused (bin/hive-config.sh) against STATE_DIR.
+  [[ -f "$STATE_DIR/paused_${agent}" ]] ||
+    [[ -f "$STATE_DIR/operator_paused_${agent}" ]] ||
+    [[ -f "$STATE_DIR/cadence_paused_${agent}" ]]
+}
 
 # Structured audit log — every governor kick decision records pause state
 KICK_AUDIT_LOG="/var/log/kick-audit.jsonl"
@@ -389,6 +418,58 @@ get_model_selection() {
   echo "$selection"
 }
 
+# ── Budget-pressure tier downgrade ───────────────────────────────────────────
+# The >95% ladder used to downgrade by literal string substitution
+# (${model/sonnet/haiku}), which swapped the tier word but kept the ORIGINAL
+# tier's version suffix: "claude-sonnet-4-6" became "claude-haiku-4-6", a model
+# that does not exist (every haiku default in this file, and config/backends.conf's
+# own model_tier(), use claude-haiku-4-5). The budget-critical path handed the
+# CLI an unavailable model at exactly the moment it existed to protect spend.
+#
+# Map tier AND version together, to this file's own constants. Anything whose
+# tier we do not recognise is returned unchanged — an unknown model is left for
+# the operator rather than being rewritten into a guess.
+GOVERNOR_MODEL_SONNET="${GOVERNOR_MODEL_SONNET:-claude-sonnet-4-6}"
+GOVERNOR_MODEL_HAIKU="${GOVERNOR_MODEL_HAIKU:-claude-haiku-4-5}"
+
+downgrade_model_one_tier() {
+  local model="$1"
+  local tier="unknown"
+  if declare -F model_tier >/dev/null 2>&1; then
+    tier=$(model_tier "$model")
+  fi
+  # model_tier() only knows the claude-* families; fall back to a tier-word
+  # match so a copilot-notation or newer model still ladders down correctly.
+  if [[ "$tier" != "opus" && "$tier" != "sonnet" && "$tier" != "haiku" ]]; then
+    case "$model" in
+      *opus*)   tier="opus" ;;
+      *sonnet*) tier="sonnet" ;;
+      *haiku*)  tier="haiku" ;;
+    esac
+  fi
+  case "$tier" in
+    opus)   echo "$GOVERNOR_MODEL_SONNET" ;;
+    sonnet) echo "$GOVERNOR_MODEL_HAIKU" ;;
+    *)      echo "$model" ;;   # haiku is the floor; unknown is left alone
+  esac
+}
+
+# Priority agents — always kicked, and laddered opus->sonnet->haiku under
+# budget pressure rather than being pushed straight to copilot. Global (not a
+# local inside optimize_model_assignment) so _is_priority_agent below does not
+# depend on dynamic scoping from its caller.
+priority_agents=(scanner ci-maintainer)
+
+# Is this agent on the priority ladder (scanner/ci-maintainer)? Used to keep
+# the budget loops from downgrading a priority agent twice.
+_is_priority_agent() {
+  local agent="$1" p
+  for p in "${priority_agents[@]}"; do
+    [[ "$p" == "$agent" ]] && return 0
+  done
+  return 1
+}
+
 get_cost_weight() {
   local backend="$1" model="$2"
   case "$backend" in
@@ -494,7 +575,6 @@ BUDGETEOF
 optimize_model_assignment() {
   local mode="$1"
   local agents=($AGENTS_ENABLED)
-  local priority_agents=(scanner ci-maintainer)
 
   local projected_pct
   projected_pct=$(compute_budget_state)
@@ -511,7 +591,16 @@ optimize_model_assignment() {
   elif (( projected_pct > TOKEN_BUDGET_SAFETY_PCT )); then
     log "BUDGET PRESSURE: projected ${projected_pct}% > safety ${TOKEN_BUDGET_SAFETY_PCT}%"
 
-    for agent in outreach architect supervisor; do
+    # Only agents this fleet actually runs. This list used to be the hardcoded
+    # `outreach architect supervisor`, but `assignments` is populated from
+    # AGENTS_ENABLED — so an operator whose AGENTS_ENABLED omitted any one of
+    # those names hit `${assignments[$agent]}: unbound variable` under set -u,
+    # aborting optimize_model_assignment (a bare statement, so set -e DOES
+    # fire) before maybe_kick ever ran. One missing name meant NO agent was
+    # kicked that cycle — precisely when the budget was under pressure.
+    for agent in "${agents[@]}"; do
+      # Priority agents ride the opus->sonnet->haiku ladder below instead.
+      _is_priority_agent "$agent" && continue
       local current="${assignments[$agent]}"
       local backend="${current%%:*}"
       if [[ "$backend" != "copilot" && "$backend" != "goose" ]]; then
@@ -526,23 +615,19 @@ optimize_model_assignment() {
 
     if (( projected_pct > 95 )); then
       for agent in "${priority_agents[@]}"; do
+        # A priority agent this fleet does not run has no assignment; skip it
+        # rather than reading an unset key under set -u.
+        [[ -n "${assignments[$agent]+set}" ]] || continue
         local current="${assignments[$agent]}"
         local backend="${current%%:*}"
         local model="${current#*:}"
-        case "$model" in
-          *opus*)
-            local new_model="${model/opus/sonnet}"
-            assignments[$agent]="${backend}:${new_model}"
-            override_reasons[$agent]="budget_downgrade"
-            log "  budget override: $agent opus->sonnet"
-            ;;
-          *sonnet*)
-            local new_model="${model/sonnet/haiku}"
-            assignments[$agent]="${backend}:${new_model}"
-            override_reasons[$agent]="budget_downgrade"
-            log "  budget override: $agent sonnet->haiku"
-            ;;
-        esac
+        local new_model
+        new_model=$(downgrade_model_one_tier "$model")
+        if [[ "$new_model" != "$model" ]]; then
+          assignments[$agent]="${backend}:${new_model}"
+          override_reasons[$agent]="budget_downgrade"
+          log "  budget override: $agent ${model} -> ${new_model}"
+        fi
       done
     fi
 

--- a/bin/test_kick_governor.sh
+++ b/bin/test_kick_governor.sh
@@ -259,41 +259,50 @@ rc="$(run_gov "${BASE_ENV[@]}")"
 assert_eq "sanity: shimmed copy runs to completion (rewrite + hive_is_paused shim both hold)" "$rc" "0"
 grep -q "GOVERNOR DONE" "$LOG_FILE_T" && pass "sanity: GOVERNOR DONE reached" || fail "sanity: GOVERNOR DONE reached" "log: $(cat "$LOG_FILE_T")"
 
-# ── 1. hive_is_paused is never sourced — PINNED BUG (fails OPEN, not closed) ─
-# kick-governor.sh calls _is_agent_paused() -> hive_is_paused() at 6 call
-# sites (maybe_kick, optimize_model_assignment, the model-cadence writer, the
-# buffer-clear loop, the stale-status loop) but only ever sources
-# backends.conf and /etc/hive/governor*.env — never hive-config.sh, the file
-# that DEFINES hive_is_paused. No systemd unit for kick-governor.timer exists
-# in-repo either, so nothing is shown to source hive-config.sh into the
-# governor's shell before it runs.
+# ── 1. Pause checks FAIL CLOSED with hive_is_paused undefined (#5549 fix 1) ──
+# kick-governor.sh calls _is_agent_paused() at 6 call sites (maybe_kick,
+# optimize_model_assignment, the model-cadence writer, the buffer-clear loop,
+# the stale-status loop). hive_is_paused() itself lives in bin/hive-config.sh,
+# which the script sources ONLY when HIVE_REPOS is unset — so whenever
+# HIVE_REPOS arrives preset (from /etc/hive/governor.env or the env, the
+# normal production configuration) hive_is_paused was never defined.
 #
-# This does NOT crash the script: every one of the 6 call sites is inside an
-# `if _is_agent_paused ...; then` or `_is_agent_paused ... && continue` — both
-# are set -e EXEMPT contexts (a command's failure inside an if/&&/|| condition
-# never triggers set -e). So "hive_is_paused: command not found" (exit 127)
-# is silently treated as "agent is NOT paused" at every call site. The
-# governor runs to GOVERNOR DONE and kicks normally — it just never honours
-# ANY pause file (dashboard pause, operator pause, cadence-zero pause) for as
-# long as hive_is_paused stays undefined. That is fail-OPEN on a safety
-# control, the opposite of what an operator hitting "pause" would expect.
-# Pinned so a fix (sourcing hive-config.sh, or inlining the check) flips this
-# deliberately; see the PR body for the finding.
-echo "-- pinned bug: hive_is_paused undefined makes every pause check fail OPEN --"
+# That did NOT crash the script: every call site is inside an
+# `if _is_agent_paused ...; then` or `_is_agent_paused ... && continue`, both
+# set -e EXEMPT contexts. So "hive_is_paused: command not found" (exit 127)
+# was silently read as "agent is NOT paused" at every call site, and the
+# governor kicked paused agents anyway — fail-OPEN on a safety control.
+#
+# #5549 makes _is_agent_paused self-contained and fail CLOSED: it delegates to
+# hive_is_paused when that IS defined, and otherwise checks the same three
+# markers directly against STATE_DIR. These assertions run against SCRIPT_RAW
+# (no shim injected — hive_is_paused genuinely undefined), which is exactly the
+# preset-HIVE_REPOS production shape.
+echo "-- pause checks fail CLOSED when hive_is_paused is undefined (#5549) --"
 reset_state
 write_actionable 0 0
-touch "${STATE_DIR_T}/paused_scanner"   # an operator pause the unmodified script should honour
+touch "${STATE_DIR_T}/paused_scanner"            # dashboard pause
+touch "${STATE_DIR_T}/operator_paused_outreach"  # operator pause
 rc="$(run_gov_raw AGENTS_ENABLED="scanner ci-maintainer architect outreach" HIVE_REPOS="acme/primary")"
-assert_eq "[pinned bug] unmodified script still exits 0 (set -e does NOT fire — the call sits inside an if/&&)" "$rc" "0"
+assert_eq "no hive_is_paused: script still exits 0 (pause handling is not an error path)" "$rc" "0"
 grep -q 'hive_is_paused.*not found\|command not found' "${WORK}/stderr-raw" \
-  && pass "[pinned bug] stderr carries 'hive_is_paused: command not found' on every call site, unhandled" \
-  || fail "[pinned bug] stderr carries 'hive_is_paused: command not found' on every call site, unhandled" "stderr: $(cat "${WORK}/stderr-raw")"
+  && fail "no hive_is_paused: stderr must NOT carry 'command not found' — the check is self-contained now" "stderr: $(cat "${WORK}/stderr-raw")" \
+  || pass "no hive_is_paused: stderr carries no 'command not found' — the check is self-contained now"
 grep -q "GOVERNOR DONE" "${WORK}/stderr-raw" \
-  && pass "[pinned bug] the script still reaches GOVERNOR DONE (does not abort)" \
-  || fail "[pinned bug] the script still reaches GOVERNOR DONE (does not abort)" "stderr: $(cat "${WORK}/stderr-raw")"
+  && pass "no hive_is_paused: the script still reaches GOVERNOR DONE (does not abort)" \
+  || fail "no hive_is_paused: the script still reaches GOVERNOR DONE (does not abort)" "stderr: $(cat "${WORK}/stderr-raw")"
 grep -q '^kicked:scanner$' "$KICK_LOG" \
-  && pass "[pinned bug] the paused_scanner marker is IGNORED — scanner is kicked anyway" \
-  || fail "[pinned bug] the paused_scanner marker is IGNORED — scanner is kicked anyway" "kicks: $(cat "$KICK_LOG" 2>/dev/null)"
+  && fail "no hive_is_paused: dashboard-paused scanner must NOT be kicked (fail closed)" "kicks: $(cat "$KICK_LOG" 2>/dev/null)" \
+  || pass "no hive_is_paused: dashboard-paused scanner is NOT kicked (fail closed)"
+grep -q '^kicked:outreach$' "$KICK_LOG" \
+  && fail "no hive_is_paused: operator-paused outreach must NOT be kicked (fail closed)" "kicks: $(cat "$KICK_LOG" 2>/dev/null)" \
+  || pass "no hive_is_paused: operator-paused outreach is NOT kicked (fail closed)"
+# POSITIVE CONTROL: the fix must not simply refuse to kick anything. architect
+# carries no pause marker and has cadence>0 in idle, so it MUST still be kicked
+# on the very same run that skipped the two paused agents.
+grep -q '^kicked:architect$' "$KICK_LOG" \
+  && pass "no hive_is_paused: POSITIVE CONTROL — the UNpaused architect IS still kicked on the same run" \
+  || fail "no hive_is_paused: POSITIVE CONTROL — the UNpaused architect IS still kicked on the same run" "kicks: $(cat "$KICK_LOG" 2>/dev/null)"
 
 # ── 2. AGENTS_ENABLED unset fails closed and loud, not silent ───────────────
 echo "-- AGENTS_ENABLED unset: fail-closed under set -u --"
@@ -447,19 +456,24 @@ mkdir -p "$METRICS_DIR_T"
 printf '{"weekly":{"billableTokens":96},"hourlyBurnRate":{"billable":0}}\n' \
   >"${METRICS_DIR_T}/tokens.json"
 run_gov "${BASE_ENV[@]}" TOKEN_BUDGET_WEEKLY=100 TOKEN_BUDGET_SAFETY_PCT=85 >/dev/null
-# DOCUMENTS THE CURRENT STATE (BUG — see the PR body): the sonnet->haiku
-# downgrade is a literal string substitution, `${model/sonnet/haiku}`, applied
-# to "claude-sonnet-4-6" — it swaps the tier word but leaves the version
-# suffix untouched, producing "claude-haiku-4-6". Every OTHER haiku default in
-# this file (MODEL_*_SUPERVISOR, MODEL_QUIET_SCANNER) and config/backends.conf's
-# own model_tier() both use "claude-haiku-4-5" — 4-6 is not a haiku version
-# that exists. A budget-critical downgrade (the exact moment this code path
-# exists to protect against runaway spend) hands the CLI a model name that
-# does not exist. Pinned so a fix (mapping tier AND version together, e.g.
-# via model_tier()/a lookup table) flips this deliberately.
-assert_eq "[pinned bug] budget >95%: sonnet->haiku downgrade keeps the SONNET version suffix (4-6), not haiku's real 4-5" \
+# #5549 fix 3: the sonnet->haiku downgrade used to be a literal string
+# substitution, `${model/sonnet/haiku}`, applied to "claude-sonnet-4-6" — it
+# swapped the tier word but left the version suffix untouched, producing
+# "claude-haiku-4-6". Every OTHER haiku default in this file
+# (MODEL_*_SUPERVISOR, MODEL_QUIET_SCANNER) and config/backends.conf's own
+# model_tier() use "claude-haiku-4-5"; 4-6 is not a haiku version that exists,
+# so the budget-critical path handed the CLI an unavailable model at exactly
+# the moment it existed to protect against runaway spend. downgrade_model_one_tier()
+# now maps tier AND version together onto GOVERNOR_MODEL_HAIKU.
+assert_eq "budget >95%: sonnet downgrades to the real haiku constant (claude-haiku-4-5), not a version-mangled claude-haiku-4-6" \
   "$(grep '^BACKEND=' "${STATE_DIR_T}/model_scanner" | cut -d= -f2):$(grep '^MODEL=' "${STATE_DIR_T}/model_scanner" | cut -d= -f2)" \
-  "claude:claude-haiku-4-6"
+  "claude:claude-haiku-4-5"
+# The downgrade target must be a model config/backends.conf actually recognises
+# — an assertion on the literal string alone would still pass if a future edit
+# swapped in another nonexistent name.
+assert_eq "budget >95%: the downgraded model is a tier backends.conf recognises (not 'unknown')" \
+  "$(cd "$WORK" && . ./config/backends.conf && model_tier "$(grep '^MODEL=' "${STATE_DIR_T}/model_scanner" | cut -d= -f2)")" \
+  "haiku"
 
 reset_state
 write_actionable 25 0
@@ -471,39 +485,46 @@ run_gov "${BASE_ENV[@]}" TOKEN_BUDGET_WEEKLY=100 TOKEN_BUDGET_SAFETY_PCT=85 >/de
 assert_eq "BUDGET_IGNORE_FLAG bypasses every downgrade even above 99%" \
   "$(grep '^BACKEND=' "${STATE_DIR_T}/model_scanner" | cut -d= -f2)" "claude"
 
-# DOCUMENTS THE CURRENT STATE (BUG — see the PR body): the budget-downgrade
-# loop at line ~514 is `for agent in outreach architect supervisor` —
-# hardcoded, not derived from AGENTS_ENABLED/agents[@]. The `assignments`
-# associative array (declare -A) is populated ONLY for agents actually in
-# AGENTS_ENABLED (line ~504). bin/hive.sh's own default AGENTS_ENABLED
-# includes supervisor, but it is an operator-configurable env var — nothing
-# stops an operator from running without it. If they do, and the token budget
-# then crosses TOKEN_BUDGET_SAFETY_PCT, `${assignments[supervisor]}` reads an
-# unset associative-array key under `set -u` and the WHOLE
-# optimize_model_assignment() call aborts (bare statement, not inside an
-# if/&&, so set -e DOES fire here — unlike the hive_is_paused case above).
-# That happens before maybe_kick ever runs (line 776 vs 919), so ONE missing
-# agent name in this hardcoded list means NO agent gets kicked that cycle,
-# the moment the budget crosses the safety threshold. Pinned so a fix
-# (deriving the loop from agents[@], or guarding the lookup) flips this
-# deliberately.
-echo "-- pinned bug: budget pressure crashes if AGENTS_ENABLED omits 'supervisor' --"
+# #5549 fix 2: the budget-downgrade loop used to be
+# `for agent in outreach architect supervisor` — hardcoded, not derived from
+# AGENTS_ENABLED/agents[@]. The `assignments` associative array is populated
+# ONLY for agents actually in AGENTS_ENABLED. bin/hive.sh's default
+# AGENTS_ENABLED includes supervisor, but it is an operator-configurable env
+# var. An operator running without it, whose budget then crossed
+# TOKEN_BUDGET_SAFETY_PCT, hit `${assignments[supervisor]}` — an unset
+# associative-array key under `set -u` — and the WHOLE
+# optimize_model_assignment() call aborted (bare statement, so set -e DOES
+# fire here, unlike the hive_is_paused case above). That happens before
+# maybe_kick ever runs, so ONE missing name in the hardcoded list meant NO
+# agent got kicked that cycle, the moment the budget crossed the threshold.
+# The loop now iterates agents[@], and the >95% priority ladder guards its
+# lookup with ${assignments[$agent]+set}.
+echo "-- budget pressure survives an AGENTS_ENABLED without 'supervisor' (#5549) --"
+# surge, so architect's default (claude:claude-opus-4-6) is a NON-copilot
+# backend and the >85% loop has something real to downgrade — in idle its
+# default is already copilot and the loop correctly skips it, which would make
+# the positive control below vacuous.
 reset_state
-write_actionable 0 0
+write_actionable 25 0
 mkdir -p "$METRICS_DIR_T"
 printf '{"weekly":{"billableTokens":90},"hourlyBurnRate":{"billable":0}}\n' \
   >"${METRICS_DIR_T}/tokens.json"
 rc="$(run_gov AGENTS_ENABLED="scanner ci-maintainer architect outreach" HIVE_REPOS="acme/primary" \
   TOKEN_BUDGET_WEEKLY=100 TOKEN_BUDGET_SAFETY_PCT=85)"
-assert_eq "[pinned bug] governor exits non-zero when budget pressure hits and supervisor is absent" \
-  "$( [ "$rc" != "0" ] && echo nonzero || echo 0 )" "nonzero"
+assert_eq "budget pressure without supervisor: governor exits 0, does not abort" "$rc" "0"
 grep -q "assignments\[.*\]: unbound variable" "${WORK}/stderr" \
-  && pass "[pinned bug] the documented crash signature: assignments[\$agent]: unbound variable" \
-  || fail "[pinned bug] the documented crash signature: assignments[\$agent]: unbound variable" "stderr: $(cat "${WORK}/stderr")"
+  && fail "budget pressure without supervisor: must NOT hit assignments[\$agent]: unbound variable" "stderr: $(cat "${WORK}/stderr")" \
+  || pass "budget pressure without supervisor: no assignments[\$agent] unbound-variable crash"
 grep -q "GOVERNOR DONE" "${WORK}/stderr" \
-  && fail "[pinned bug] GOVERNOR DONE is never reached — no agent is kicked this cycle" \
-  || pass "[pinned bug] GOVERNOR DONE is never reached — no agent is kicked this cycle"
-assert_eq "[pinned bug] POSITIVE CONTROL: the same scenario WITH supervisor present does not crash" \
+  && pass "budget pressure without supervisor: GOVERNOR DONE is reached" \
+  || fail "budget pressure without supervisor: GOVERNOR DONE is reached" "stderr: $(cat "${WORK}/stderr")"
+# POSITIVE CONTROL: reaching GOVERNOR DONE is not enough — the downgrade the
+# loop exists to perform must still actually happen for the agents that ARE
+# configured. architect's idle default is copilot already, so assert on the
+# recorded reason rather than the backend.
+assert_eq "budget pressure without supervisor: the downgrade STILL fires for a configured agent (architect)" \
+  "$(grep '^REASON=' "${STATE_DIR_T}/model_architect" 2>/dev/null | cut -d= -f2)" "budget_downgrade"
+assert_eq "budget pressure without supervisor: POSITIVE CONTROL — the same scenario WITH supervisor present also exits 0" \
   "$(run_gov "${BASE_ENV[@]}" TOKEN_BUDGET_WEEKLY=100 TOKEN_BUDGET_SAFETY_PCT=85)" "0"
 
 # ── 8. What is written where — the file contract other tooling reads ────────


### PR DESCRIPTION
Fixes #5549

Three defects in `bin/kick-governor.sh`, plus the six assertions #5548 pinned on them.

## 1. Pause markers ignored when `HIVE_REPOS` is preset — failed OPEN

`hive_is_paused()` is defined in `bin/hive-config.sh`, which `kick-governor.sh` sources **only** under `if [[ -z "${HIVE_REPOS:-}" ]]`. In the normal production shape — `HIVE_REPOS` arriving from `/etc/hive/governor.env` — it was never defined. All six `_is_agent_paused` call sites sit inside an `if` or `&&`, which are `set -e` **exempt**, so the exit-127 "command not found" was silently read as **"not paused"**. Dashboard pauses, operator pauses and cadence-zero pauses were all ignored.

**Fix shape chosen: guard + fail CLOSED**, not unconditional sourcing.

Sourcing `hive-config.sh` unconditionally would have been a wider behaviour change than the bug: it also assigns `AGENTS_ENABLED` (line 168) and `PROJECT_REPOS` (line 163) from `hive-runtime.yaml`, and can shell out to `gh-app-token.sh` to mint a GitHub App token (lines 196-205). Sourcing it here would silently override the operator's own `AGENTS_ENABLED` — the very variable defect 2 is about. So `_is_agent_paused` is now self-contained: it delegates to `hive_is_paused` when that *is* defined, and otherwise checks the same three markers directly against `STATE_DIR`. If a future refactor removes both, it fails **closed** — an agent we cannot prove is unpaused is treated as paused. A spuriously paused agent is recoverable by the operator; an agent that ignores a pause is not.

### Before / after — reproduced against the real script, not the harness

`HIVE_REPOS` set (so `hive-config.sh` is never sourced), `paused_scanner` and `operator_paused_outreach` markers present:

**Before**
```
exit code: 0
stderr 'command not found' lines: 20
kicks recorded:
kicked:scanner
kicked:architect
kicked:outreach
FAIL-OPEN: scanner was PAUSED (paused_scanner marker present) but was KICKED ANYWAY
FAIL-OPEN: outreach was OPERATOR-PAUSED but was KICKED ANYWAY
```

**After**
```
exit code: 0
stderr 'command not found' lines: 0
kicks recorded:
kicked:architect
pause honoured: scanner was NOT kicked
pause honoured: outreach was NOT kicked
```

`architect` — unpaused, cadence>0 — is still kicked on the same run, so this is not a governor that merely refuses to kick anything.

## 2. Budget pressure crashed on a fleet missing a hardcoded agent

The >85% loop iterated a hardcoded `outreach architect supervisor` while `assignments` is populated from `AGENTS_ENABLED`. A fleet omitting any of those names hit `${assignments[supervisor]}` — an unset associative-array key under `set -u`. That is a bare statement, so unlike defect 1 `set -e` **did** fire, aborting `optimize_model_assignment()` before `maybe_kick` ever ran: **no agent kicked at all**, precisely when the budget was under pressure.

The loop now iterates `agents[@]` (skipping priority agents, which have their own ladder). The >95% priority ladder had the **same latent hazard** — `priority_agents=(scanner ci-maintainer)` is equally hardcoded — so its lookup is now guarded with `${assignments[$agent]+set}`.

**Before** (`AGENTS_ENABLED="scanner ci-maintainer architect outreach"`, budget over threshold)
```
governor exits non-zero
stderr: kick-governor.sh: line 521: assignments[$agent]: unbound variable
GOVERNOR DONE never reached — no agent kicked this cycle
```

**After**
```
governor exits 0
no assignments[$agent] unbound-variable crash
GOVERNOR DONE reached
REASON=budget_downgrade still recorded for architect (the downgrade still fires)
```

### Set-equivalence, and a second bug the same hardcoding hid

For the **default** fleet the change is behaviour-identical — the old hardcoded list and the new `agents[@]`-minus-priority set are the same three names:

```
default fleet — old set: ['architect', 'outreach', 'supervisor']
default fleet — new set: ['architect', 'outreach', 'supervisor']
IDENTICAL: True
```

But the hardcoding was also silently *under*-covering. This same file defines `CADENCE_STRATEGIST_*`, `CADENCE_ANALYST_*` and `CADENCE_GUARDIAN_*` for the nous fleet. On a fleet running them:

```
nous fleet — old set (hardcoded): ['architect', 'outreach', 'supervisor']
nous fleet — new set: ['analyst', 'architect', 'guardian', 'outreach', 'strategist', 'supervisor']
newly covered (were silently NEVER downgraded): ['analyst', 'guardian', 'strategist']
```

So the hardcoded list did not only crash on a *missing* name — it also silently exempted every agent added to the fleet after it was written, letting them keep a metered backend through budget pressure. Deriving from `agents[@]` fixes both directions at once.

## 3. The >95% downgrade produced a nonexistent model

`${model/sonnet/haiku}` swapped the tier word but kept the *original* tier's version suffix: `claude-sonnet-4-6` became `claude-haiku-4-6`. Every haiku default in the same file, and `config/backends.conf`'s own `model_tier()`, use `claude-haiku-4-5`. The budget-critical path handed the CLI an unavailable model at exactly the moment it exists to protect spend.

`downgrade_model_one_tier()` now maps tier **and** version together onto the file's own constants (`GOVERNOR_MODEL_SONNET` / `GOVERNOR_MODEL_HAIKU`), classifying via `model_tier()` where it applies and falling back to a tier-word match otherwise. An unrecognised model is returned unchanged rather than rewritten into a guess. This also fixes the same latent bug on the opus rung — `claude-opus-4-7` (a tier `model_tier()` knows) would have become `claude-sonnet-4-7`, equally nonexistent.

**Before**: `model_scanner` → `claude:claude-haiku-4-6` (`model_tier` → `unknown`)
**After**: `model_scanner` → `claude:claude-haiku-4-5` (`model_tier` → `haiku`)

## How #5548's pinned assertions were handled

#5548 pinned the current buggy behaviour with comments saying each fix flips one assertion. Against the fixed script the suite went **44 passed / 6 failed** — exactly the six pins, in three clusters, one per defect, with nothing else disturbed. Each was rewritten to assert the fixed behaviour and its comment rewritten from "DOCUMENTS THE CURRENT STATE (BUG)" to a description of the fix. Suite is now **54 passed / 0 failed** (50 → 54; four added, all positive controls).

### The flipped assertions are not vacuous

Restoring all three buggy code shapes under the **new** tests (verified the restore landed by grepping for each original construct) produces **45 passed / 9 failed**, red in all three clusters for the right reasons.

Separately, mutating the fail-closed marker check to `return 1` ("always not paused") — with the mutation asserted present before running — kills exactly the two fail-closed assertions. They are load-bearing, not decorative.

## Also noted in #5549 — investigated, both are real, neither fixed here

Both were flagged in the issue as "not a defect on its own". Both **are** defects. Neither is fixed here to avoid silently widening scope; they want their own issue.

**`ci-maintainer` keyed to `reviewer` — real, and more serious than "dead config".** `get_cadence()` uppercases the agent name (`ci-maintainer` → `CI_MAINTAINER`) but every default is written `CADENCE_REVIEWER_*`. The lookup falls through to `:-0`, and cadence 0 means PAUSED — so `ci-maintainer` is **permanently paused in every mode**, not merely running on a wrong cadence, unless the operator sets `CADENCE_CI_MAINTAINER_*_SEC` explicitly. `get_model_selection()` falls through the same way to the hardcoded `copilot:claude-sonnet-4-6`. The entire ci-maintainer ladder documented in the file's header comment is unreachable. Fixing it changes which agents actually run, which is an operational change that deserves to be visible on its own PR rather than buried in a bug fix.

**`busyness_pct` / `queue_depth` disagreement — real.** `measure_queue()` writes `queue_depth` as issues+PRs (line 327) but *returns* `total_i`, issues only (line 331). Mode and `busyness_pct` therefore use issues-only. But `get_queue_depth()`'s fallback path, when the collector is down, reads the `queue_depth` **file** — the issues+PRs number. So the same value means two different things depending on collector health, and the fallback is systematically **higher**, biasing the governor toward surge exactly when its data is least reliable. #5548 pinned the issues-only behaviour as the contract; changing it would move mode thresholds fleet-wide.

## What I did NOT verify

- **No run against a real deployed spoke.** Everything here is the hermetic harness plus a standalone reproduction, both against path-rewritten copies. The production path — `/etc/hive/governor.env` actually setting `HIVE_REPOS`, `hive-config.sh` actually at `/usr/local/bin` — is inferred from the source, not observed on a live pod.
- **`GOVERNOR_MODEL_SONNET`/`GOVERNOR_MODEL_HAIKU` are not validated against what the backends will accept.** They match every other default in the file and `backends.conf`'s `model_tier()`, but nothing here confirms the CLIs currently serve `claude-haiku-4-5`.
- **The `>99%` all-agents-to-copilot rung is unchanged and only covered by the pre-existing `BUDGET_IGNORE_FLAG` assertion.** It already iterated `agents[@]`, so defect 2 never applied to it.
- **The tmux/stuck-buffer and stale-status call sites of `_is_agent_paused`** (lines ~833, ~876) are exercised only indirectly; the harness stubs tmux to "no session", as #5548 established.
- **No shellcheck regression**, but that is a comparison: baseline and fixed both emit the same four pre-existing warnings, none from the new code.
