### PR TITLE
🐛 fix(agent): publish UID-isolation markers for runtime-added agents

### DIFF
--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -1749,6 +1749,57 @@ func uidIsolationMarkersReady(markerDir, revision string, uid int) bool {
 	return true
 }
 
+// publishRuntimeUIDIsolationMarker publishes the per-agent completion marker
+// for an agent whose UID was allocated at RUNTIME (AddAgent/ReconcileAgents),
+// after the entrypoint's boot-time migration walk has already finished. The
+// walk only iterates the boot-time roster, so without this an agent added
+// post-boot waits in awaitUIDIsolation for an agent-<uid>.ready marker that
+// nothing will ever write — a permanent launch hold (observed live: an ACMM
+// pack update added `adjudicator` 31 minutes after boot and every governor
+// kick failed with "cannot be kicked: it is stopped" from then on).
+//
+// Semantics mirror the entrypoint's per-agent pass, including its fail-open
+// policy: a runtime-added agent normally has NO tree yet under /data/agents
+// (it is created at launch, owned by the launching UID), so there is nothing
+// to migrate and publishing the marker is the correct, safe resolution. When
+// a tree does exist and is foreign-owned, the entrypoint publishes after a
+// best-effort chown WARN — withholding the marker forever would turn a
+// permissions warning into a permanent agent outage, which is exactly the
+// failure this fixes. The hive process cannot chown (it dropped root), so the
+// ownership repair half is left to the next boot's walk; the marker unblocks
+// launch under the same fail-open contract.
+//
+// Never overwrites a marker that already carries the expected contents, and
+// does nothing on legacy deployments with no marker contract.
+func (m *Manager) publishRuntimeUIDIsolationMarker(name string) {
+	if m.uidMap == nil {
+		return
+	}
+	markerDir, revision, uid := m.uidMap.IsolationContract(name)
+	if markerDir == "" || revision == "" || uid <= 0 {
+		return
+	}
+	marker := filepath.Join(markerDir, fmt.Sprintf("agent-%d.ready", uid))
+	expected := revision + ":" + strconv.Itoa(uid)
+	if data, err := os.ReadFile(marker); err == nil && strings.TrimSpace(string(data)) == expected {
+		return
+	}
+	tmp := marker + ".tmp"
+	if err := os.WriteFile(tmp, []byte(expected+"\n"), 0o644); err != nil {
+		m.logger.Warn("could not publish runtime UID-isolation marker; agent launch will hold until the next boot's migration walk",
+			"agent", name, "uid", uid, "marker", marker, "error", err)
+		return
+	}
+	if err := os.Rename(tmp, marker); err != nil {
+		_ = os.Remove(tmp)
+		m.logger.Warn("could not publish runtime UID-isolation marker; agent launch will hold until the next boot's migration walk",
+			"agent", name, "uid", uid, "marker", marker, "error", err)
+		return
+	}
+	m.logger.Info("published UID-isolation marker for runtime-added agent",
+		"agent", name, "uid", uid, "marker", marker)
+}
+
 // awaitUIDIsolation keeps expensive PVC ownership walks off the pod startup
 // path without weakening per-agent UID isolation. The entrypoint starts the
 // root repair worker asynchronously, allowing the dashboard/startup probe to
@@ -4211,6 +4262,11 @@ func (m *Manager) AddAgent(name string, cfg config.AgentConfig) {
 			tmuxSocket = "hive-" + name
 		}
 		_ = m.uidMap.Save(UIDMapPath)
+		// The boot-time migration walk has already finished; publish this
+		// agent's completion marker now or awaitUIDIsolation holds its launch
+		// forever. One tiny same-PVC write on a rare admin action — not the
+		// hot-path NFS I/O the m.mu discipline guards against.
+		m.publishRuntimeUIDIsolationMarker(name)
 	}
 	m.agents[name] = &AgentProcess{
 		Name:         name,
@@ -4300,6 +4356,10 @@ func (m *Manager) ReconcileAgents(configs map[string]config.AgentConfig) []strin
 				tmuxSocket = "hive-" + name
 			}
 			_ = m.uidMap.Save(UIDMapPath)
+			// Same contract as AddAgent: a reconcile-added agent gets its
+			// marker now, or its launch holds forever (the live adjudicator
+			// wedge came through exactly this path).
+			m.publishRuntimeUIDIsolationMarker(name)
 		}
 		m.agents[name] = &AgentProcess{
 			Name:         name,

--- a/src/pkg/agent/runtime_uid_isolation_marker_test.go
+++ b/src/pkg/agent/runtime_uid_isolation_marker_test.go
@@ -1,0 +1,146 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// These tests pin the fix for the runtime-added-agent launch wedge: the
+// entrypoint's UID-isolation migration walk only covers the boot-time roster,
+// so an agent added afterwards (AddAgent via the dashboard, or
+// ReconcileAgents after an ACMM pack update) allocated a fresh UID whose
+// agent-<uid>.ready marker nothing would ever write. awaitUIDIsolation then
+// held the launch forever and every governor kick failed with "cannot be
+// kicked: it is stopped". Observed live on hosted-kubestellar-console-4vkt:
+// the L6 pack's adjudicator was reconciled in 31 minutes after boot and
+// stayed down until the marker was written by hand.
+
+// isolationTestUIDMap builds a UIDMap carrying a marker contract rooted in a
+// test temp dir, with boot-time markers already published the way the
+// entrypoint's walk leaves them.
+func isolationTestUIDMap(t *testing.T, revision string) (*UIDMap, string) {
+	t.Helper()
+	markerDir := t.TempDir()
+	u := NewUIDMap()
+	u.IsolationMarkerDir = markerDir
+	u.IsolationRevision = revision
+	if err := os.WriteFile(filepath.Join(markerDir, "home.ready"), []byte(revision+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return u, markerDir
+}
+
+func markerContent(t *testing.T, markerDir string, uid int) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(markerDir, "agent-"+strconv.Itoa(uid)+".ready"))
+	if err != nil {
+		t.Fatalf("marker for uid %d not published: %v", uid, err)
+	}
+	return string(data)
+}
+
+func TestAddAgentPublishesUIDIsolationMarker(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, slog.Default(), ProjectContext{ACMMLevel: 6})
+	uidMapPath := filepath.Join(t.TempDir(), "uid-map.json")
+	oldPath := UIDMapPath
+	UIDMapPath = uidMapPath
+	defer func() { UIDMapPath = oldPath }()
+
+	u, markerDir := isolationTestUIDMap(t, "1")
+	m.uidMap = u
+
+	m.AddAgent("adjudicator", config.AgentConfig{})
+
+	uid := u.Agents["adjudicator"]
+	if uid <= 0 {
+		t.Fatalf("expected a runtime UID allocation, got %d", uid)
+	}
+	got := markerContent(t, markerDir, uid)
+	want := "1:" + strconv.Itoa(uid) + "\n"
+	if got != want {
+		t.Fatalf("marker content = %q, want %q", got, want)
+	}
+
+	// The whole point: the launch hold must now clear. awaitUIDIsolation
+	// checks the markers before ever sleeping, so a ready contract returns
+	// immediately.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	agent := m.agents["adjudicator"]
+	if err := m.awaitUIDIsolation(ctx, agent); err != nil {
+		t.Fatalf("launch still held after AddAgent published the marker: %v", err)
+	}
+}
+
+func TestReconcileAgentsPublishesUIDIsolationMarker(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, slog.Default(), ProjectContext{ACMMLevel: 6})
+	uidMapPath := filepath.Join(t.TempDir(), "uid-map.json")
+	oldPath := UIDMapPath
+	UIDMapPath = uidMapPath
+	defer func() { UIDMapPath = oldPath }()
+
+	u, markerDir := isolationTestUIDMap(t, "1")
+	m.uidMap = u
+
+	added := m.ReconcileAgents(map[string]config.AgentConfig{
+		"adjudicator": {},
+	})
+	if len(added) != 1 || added[0] != "adjudicator" {
+		t.Fatalf("expected adjudicator to be added, got %v", added)
+	}
+
+	uid := u.Agents["adjudicator"]
+	if uid <= 0 {
+		t.Fatalf("expected a runtime UID allocation, got %d", uid)
+	}
+	got := markerContent(t, markerDir, uid)
+	want := "1:" + strconv.Itoa(uid) + "\n"
+	if got != want {
+		t.Fatalf("marker content = %q, want %q", got, want)
+	}
+}
+
+func TestPublishRuntimeUIDIsolationMarkerIsIdempotent(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, slog.Default(), ProjectContext{ACMMLevel: 6})
+	u, markerDir := isolationTestUIDMap(t, "1")
+	m.uidMap = u
+	uid := u.AllocateUID("adjudicator")
+
+	m.publishRuntimeUIDIsolationMarker("adjudicator")
+	marker := filepath.Join(markerDir, "agent-"+strconv.Itoa(uid)+".ready")
+	first, err := os.Stat(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A second publish with matching contents must not rewrite the file.
+	time.Sleep(10 * time.Millisecond)
+	m.publishRuntimeUIDIsolationMarker("adjudicator")
+	second, err := os.Stat(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.ModTime().Equal(second.ModTime()) {
+		t.Error("matching marker was rewritten; publish must be idempotent")
+	}
+}
+
+func TestPublishRuntimeUIDIsolationMarkerLegacyNoContract(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, slog.Default(), ProjectContext{ACMMLevel: 6})
+	u := NewUIDMap() // no marker dir / revision: legacy shared-UID deployment
+	m.uidMap = u
+	u.AllocateUID("adjudicator")
+
+	// Must be a no-op, not a panic or a stray file in the working directory.
+	m.publishRuntimeUIDIsolationMarker("adjudicator")
+	if _, err := os.Stat("agent-2001.ready"); !os.IsNotExist(err) {
+		t.Error("legacy deployment must not write markers")
+	}
+}


### PR DESCRIPTION
The entrypoint's UID-isolation migration walk only iterates the boot-time roster. An agent added AFTER boot — `AddAgent` from the dashboard, or `ReconcileAgents` after an ACMM pack update — allocates a fresh UID whose `agent-<uid>.ready` marker nothing ever writes, so `awaitUIDIsolation` holds its launch forever and every governor kick fails with `cannot be kicked: it is stopped`.

**Observed live** on `hosted-kubestellar-console-4vkt` (v5 edge, 25a6683): the L6 pack's `adjudicator` was added by reconcile 31 minutes after boot (uid 2014); markers existed for boot uids 2001–2013 only. The hive reported degraded (`2 down: adjudicator, reviewer`) until the marker was written by hand.

**Fix**: `publishRuntimeUIDIsolationMarker` mirrors the entrypoint's per-agent pass under its existing fail-open contract (runtime-added agents normally have no tree yet — nothing to migrate; a foreign-owned tree gets repaired by the next boot's walk, exactly as the entrypoint's WARN-and-publish path already behaves). Wired at both runtime allocation sites; idempotent; no-op on legacy deployments without a marker contract.

Tests: marker published via AddAgent + ReconcileAgents, launch hold clears (`awaitUIDIsolation` returns), idempotency (no rewrite), legacy no-op. Full `./pkg/agent` suite green (290s).