### PR TITLE
🐛 fix: three order-dependent test failures, not timing flakes (#5553)

### DIFF
--- a/src/pkg/dashboard/status_builder_more_coverage_test.go
+++ b/src/pkg/dashboard/status_builder_more_coverage_test.go
@@ -113,6 +113,28 @@ func TestCovH2_BuildHealthAndRateLimits(t *testing.T) {
 	if rl2 == nil {
 		t.Fatalf("buildGHRateLimits(live) returned nil")
 	}
+
+	// The live branch of buildHealth CACHES what it fetched into the package
+	// global cachedHealth. The mock above answers the workflow endpoints with
+	// an empty run list, so the cached map carries ci=0 — and every later
+	// buildHealth(nil, nil) in this package then returns that instead of the
+	// ci=100 default it asserts on. Restore the global so the pollution cannot
+	// outlive this test (#5553: TestBuildHealth_NilClient_Boost failed with
+	// "ci = 0" only on the shuffle orders that put this test first).
+	// The same call can also refresh cachedGreenStreak, so restore that pair
+	// too rather than leaving a second global dirtied for later tests.
+	cachedGreenStreakMu.Lock()
+	prevStreak, prevStreakOK := cachedGreenStreak, cachedGreenStreakOK
+	cachedGreenStreakMu.Unlock()
+	t.Cleanup(func() {
+		cachedHealthMu.Lock()
+		cachedHealth = nil
+		cachedHealthMu.Unlock()
+
+		cachedGreenStreakMu.Lock()
+		cachedGreenStreak, cachedGreenStreakOK = prevStreak, prevStreakOK
+		cachedGreenStreakMu.Unlock()
+	})
 	_ = buildHealth(ghc, ctx)
 
 	// App-auth identity branch: set an AppID so buildGHRateLimits takes the "app" path.

--- a/src/pkg/hub/heartbeat_core_coverage_test.go
+++ b/src/pkg/hub/heartbeat_core_coverage_test.go
@@ -15,11 +15,21 @@ import (
 // ============================================================
 // heartbeat.go — core functions that previously lacked tests
 // ============================================================
+//
+// Heartbeat state lives in package-level atomics, so every test here resets it
+// BEFORE it runs as well as after — the same idiom as the other heartbeat test
+// files. Several of these tests assert the ABSENCE of recorded state ("should
+// not record success on 403"), which an earlier test that recorded a success
+// would satisfy vacuously or fail outright depending on run order. Resetting
+// only on the way out leaves a test at the mercy of whoever ran before it:
+// that is what made TestSendUpgradingHeartbeat_NonSuccess fail under -shuffle
+// and on CI (#5553).
 
 // --- recordHeartbeatSuccess / recordHeartbeatAttempt / Last* / HeartbeatEnabled ---
 
 func TestRecordHeartbeatSuccess(t *testing.T) {
-	defer ResetHeartbeatStateForTest()
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
 
 	// Before any call, LastHeartbeatSuccess returns false.
 	_, ok := LastHeartbeatSuccess()
@@ -42,7 +52,8 @@ func TestRecordHeartbeatSuccess(t *testing.T) {
 }
 
 func TestRecordHeartbeatAttempt(t *testing.T) {
-	defer ResetHeartbeatStateForTest()
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
 
 	_, ok := LastHeartbeatAttempt()
 	if ok {
@@ -63,7 +74,8 @@ func TestRecordHeartbeatAttempt(t *testing.T) {
 }
 
 func TestHeartbeatEnabled(t *testing.T) {
-	defer ResetHeartbeatStateForTest()
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
 
 	if HeartbeatEnabled() {
 		t.Fatal("expected HeartbeatEnabled=false at start")
@@ -137,14 +149,16 @@ func TestNewAgentSummary_ZeroTimes(t *testing.T) {
 // --- SendUpgradingHeartbeat ---
 
 func TestSendUpgradingHeartbeat_NilPayload(t *testing.T) {
-	defer ResetHeartbeatStateForTest()
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
 
 	// nil collector → returns early, no panic
 	SendUpgradingHeartbeat("http://x", func() *HeartbeatPayload { return nil }, "sha1", slog.Default())
 }
 
 func TestSendUpgradingHeartbeat_Success(t *testing.T) {
-	defer ResetHeartbeatStateForTest()
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
 
 	var received HeartbeatPayload
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -183,7 +197,8 @@ func TestSendUpgradingHeartbeat_Success(t *testing.T) {
 }
 
 func TestSendUpgradingHeartbeat_NonSuccess(t *testing.T) {
-	defer ResetHeartbeatStateForTest()
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
@@ -203,7 +218,8 @@ func TestSendUpgradingHeartbeat_NonSuccess(t *testing.T) {
 }
 
 func TestSendUpgradingHeartbeat_BearerToken(t *testing.T) {
-	defer ResetHeartbeatStateForTest()
+	t.Cleanup(ResetHeartbeatStateForTest)
+	ResetHeartbeatStateForTest()
 
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/proxy/github_proxy.go
+++ b/src/pkg/proxy/github_proxy.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -1252,7 +1253,8 @@ func (p *GitHubProxy) tunnelDirect(conn net.Conn, r *http.Request) {
 // total transfer time, so a large-but-flowing response is never cut while an
 // upstream that goes silent mid-body releases the handler — and with it the
 // three sockets of the exchange — within one stall window. A var, not a
-// const, so tests can shorten it (same pattern as tunnelHalfCloseDrain).
+// const, so tests can shorten it (same motivation as tunnelHalfCloseDrain,
+// which is additionally atomic because its reader outlives the writing test).
 // Matches httpReadTimeout: the same patience already extended to the header
 // phase.
 var responseBodyStallTimeout = httpReadTimeout
@@ -1284,16 +1286,37 @@ func (b *stallBoundedBody) Close() error {
 	return err
 }
 
-// tunnelHalfCloseDrain bounds how long one direction of an opaque tunnel may
-// keep waiting for bytes AFTER the other direction has already finished. It is
-// a var, not a const, for the same reason as waitForReadyPollInterval in
-// pkg/hub: tests need a relay that unwedges in milliseconds. Production keeps
-// the default.
+// tunnelHalfCloseDrainDefault bounds how long one direction of an opaque
+// tunnel may keep waiting for bytes AFTER the other direction has already
+// finished.
 //
 // 30s is deliberately generous: the only legitimate traffic still in flight
 // once one side has hung up is a response tail already on the wire, which
 // arrives in RTTs, not tens of seconds.
-var tunnelHalfCloseDrain = 30 * time.Second
+const tunnelHalfCloseDrainDefault = 30 * time.Second
+
+// tunnelHalfCloseDrain is overridable rather than const for the same reason as
+// waitForReadyPollInterval in pkg/hub: tests need a relay that unwedges in
+// milliseconds. Production keeps the default.
+//
+// It is atomic because the write and the read genuinely happen on different
+// goroutines with no happens-before between them. relayTunnel reads the bound
+// from the copy goroutine it spawns, and that goroutine can outlive the test
+// that started it: a handler test only waits for the CONNECT response, not for
+// the relay to drain, so the goroutine is still reading while the NEXT test's
+// shortenTunnelDrain writes. A plain var made that an unsynchronised
+// write-after-read and -race failed whichever test happened to hold the baton
+// (#5553) — the reported test name was incidental, which is why the failure
+// moved between TestRelayTunnelUnwedgesFromSilentUpstream and
+// TestRelayTunnelDataFlowsBothWays across shuffle seeds.
+var tunnelHalfCloseDrain atomic.Int64
+
+func init() { tunnelHalfCloseDrain.Store(int64(tunnelHalfCloseDrainDefault)) }
+
+// tunnelDrain returns the current half-close drain bound.
+func tunnelDrain() time.Duration {
+	return time.Duration(tunnelHalfCloseDrain.Load())
+}
 
 // relayTunnel shuttles bytes both ways between the proxied client conn and the
 // upstream until BOTH directions have finished, bounding each direction once
@@ -1325,14 +1348,14 @@ func relayTunnel(conn, upstream net.Conn) {
 		// Client side is done (EOF or error — a dead client looks the same).
 		// A live upstream answers or closes within RTTs; a blackholed one
 		// never would, so bound the remaining upstream→client read.
-		_ = upstream.SetReadDeadline(time.Now().Add(tunnelHalfCloseDrain))
+		_ = upstream.SetReadDeadline(time.Now().Add(tunnelDrain()))
 		close(done)
 	}()
 	_, _ = io.Copy(conn, upstream)
 	// Mirror image: upstream finished (or errored) but the client may sit
 	// half-open without ever sending EOF; bound the client-side read so
 	// <-done cannot wedge this handler.
-	_ = conn.SetReadDeadline(time.Now().Add(tunnelHalfCloseDrain))
+	_ = conn.SetReadDeadline(time.Now().Add(tunnelDrain()))
 	<-done
 }
 

--- a/src/pkg/proxy/tunnel_drain_test.go
+++ b/src/pkg/proxy/tunnel_drain_test.go
@@ -40,9 +40,8 @@ func tcpPair(t *testing.T) (client, server net.Conn) {
 
 func shortenTunnelDrain(t *testing.T, d time.Duration) {
 	t.Helper()
-	old := tunnelHalfCloseDrain
-	tunnelHalfCloseDrain = d
-	t.Cleanup(func() { tunnelHalfCloseDrain = old })
+	old := tunnelHalfCloseDrain.Swap(int64(d))
+	t.Cleanup(func() { tunnelHalfCloseDrain.Store(old) })
 }
 
 func runRelay(conn, upstream net.Conn) chan struct{} {


### PR DESCRIPTION
## What broke

The scheduled v4 run on `12d140c` failed three tests:

- `TestBuildHealth_NilClient_Boost`
- `TestSendUpgradingHeartbeat_NonSuccess`
- `TestRelayTunnelUnwedgesFromSilentUpstream`

Two of the names look timing-shaped, and the run history pointed at flakiness (five consecutive successes after the failing commit). **None of the three is a timing flake.** All three are order-dependent global state.

This matters for how you reproduce them: `-count=20` on each test *in isolation* passes 20/20 and proves nothing, because the pollution comes from a *different* test in the same package. `-shuffle` reproduces all three, with the byte-for-byte messages from CI.

## Root causes

### `pkg/proxy` — an unsynchronised global (the real bug of the three)

`relayTunnel` reads `tunnelHalfCloseDrain` from the copy goroutine it spawns, and that goroutine outlives the test that started it. `TestHandleConnectDirectNonGitHub` fires `go p.handleConnectDirect(...)`, waits only for the CONNECT response, and returns while the relay is still reading. A later `shortenTunnelDrain` then writes the same var.

`-race` caught the write-after-read and failed whichever test happened to hold the baton — so **the reported test name was incidental**. Across shuffle seeds the failure moved between `...SilentUpstream` and `...DataFlowsBothWays`.

Fixed by making the var an `atomic.Int64` read through `tunnelDrain()`. That fixes the race at the variable, rather than chasing every goroutine-leaking handler test.

### `pkg/dashboard` — a leaked cache

`TestCovH2_BuildHealthAndRateLimits` calls `buildHealth(ghc, ctx)`, whose live branch caches the fetched map into the package global `cachedHealth`. Its mock answers the workflow endpoints with an empty run list, so the cached map carries `ci=0` — and every later `buildHealth(nil, nil)` returned that instead of the `ci=100` default it asserts. That is exactly the `ci = 0` CI reported.

Restored `cachedHealth` (and the `cachedGreenStreak` pair the same call can refresh) on cleanup, matching what the package's other two writers already do.

### `pkg/hub` — reset only on the way out

`heartbeat_core_coverage_test.go` used `defer ResetHeartbeatStateForTest()` at all seven sites, while every other heartbeat test file resets **before and after**. Tests asserting the *absence* of state ("should not record success on 403") are then at the mercy of whoever ran first. Converted all seven to the before-and-after idiom.

## Failure rates by shuffle seed

| package | scope | before | after |
|---|---|---|---|
| dashboard | `TestBuildHealth_NilClient_Boost` + its polluter | **5/10 seeds fail** | **0/10** |
| proxy | full package, `-race` | **3/6 seeds fail** | **0/6** |
| proxy | full package, `-race`, seeds 200-204 | **4/5 seeds race** | **0/6** (200-205) |
| hub | heartbeat tests, seeds 1-25 | **6/25 seeds fail** | **0/25** |

Every "after" run used the same seeds that failed before.

Independent confirmation from a wider full-package sweep over a disjoint seed range (200+), run on both branches:

| package | scope | before | after |
|---|---|---|---|
| proxy | full package, `-race` | **16/21 seeds race** | **0/22** |
| dashboard | `TestBuildHealth_NilClient_Boost` | **4/18 seeds fail** | **0/32** |

The hub sweep also cleared `TestRecordHeartbeatSuccess`, a second victim of the same pollution that CI had not yet surfaced — it fails on baseline seeds 5, 8 and 15.

## Nothing was papered over

No test is skipped, retried, or given a longer sleep — each fix removes the shared state the order-dependence rides on. `testutil.Eventually` (#5537) does **not** apply here: it replaces sleeps that wait on an observable condition, and none of these three was waiting on anything.

## Pre-existing issue found, deliberately not fixed here

`pkg/dashboard` has **83 test failures on unmodified `origin/v4` under `-shuffle=200`** — a broad order-dependence problem in that package, unrelated to and much larger than #5553. At that seed the baseline fails 83 tests *including* `TestBuildHealth_NilClient_Boost`; this branch fails 82 — the same set minus this issue's victim. Worth its own issue; out of scope here.

Fixes #5553
