### PR TITLE
📼 docs(tui): reproducible VHS terminal demo with a loopback fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ _inline.js
 # Test-run scratch: bin/contributor-relay.test.js writes per-task status files
 # into randomly-suffixed workspace dirs under here. Generated per run.
 .relay-test-tmp/
+
+# Rendered output of src/docs/design/tui.tape (VHS). The TAPE is the
+# reproducible source of truth; the GIF is a build product and is not
+# committed — see #5423.
+src/docs/design/_out/

--- a/src/docs/design/tui.tape
+++ b/src/docs/design/tui.tape
@@ -1,0 +1,241 @@
+# VHS tape for `hivectl tui` — the reproducible terminal demo (tui T27, #5423).
+#
+# WHAT THIS RECORDS
+#   The v1 TUI operator loop end to end: launch, the four populated panes and
+#   the live header, focus and row navigation, the help overlay, the four write
+#   actions in their SAFE states, and a clean quit. Every key pressed below and
+#   every result shown is the shipped behaviour documented in
+#   src/docs/hivectl.md ("tui — live terminal dashboard").
+#
+# PREREQUISITES
+#   - VHS >= 0.10 (`brew install vhs`, or see charmbracelet/vhs). VHS needs
+#     ttyd and ffmpeg; the Homebrew formula pulls both in.
+#   - A Go toolchain, to build `hivectl` and run the fixture.
+#   - Nothing else. No Docker, no network, no cluster, no real hive.
+#
+# RENDER IT (from the repository root)
+#
+#     cd src
+#     go build -o bin/hivectl ./cmd/hivectl
+#     go run ./pkg/tui/testdata/demohive &        # fixture; ctrl+c / kill to stop
+#     vhs docs/design/tui.tape
+#     kill %1                                     # stop the fixture
+#
+#   Output lands at src/docs/design/_out/tui.gif, which .gitignore excludes.
+#   The TAPE is the source of truth in this repository; the GIF is a build
+#   product and is NOT committed (see #5423: no generated binary by default).
+#
+# THE FIXTURE, AND WHY THERE IS ONE
+#   `hivectl tui` is a client of the dashboard API. Recording it against a real
+#   hive would burn that hive's identity, agent names, repositories and token
+#   spend into a GIF in a public repository — a terminal recording is a
+#   screenshot of whatever was on screen. So this tape records against
+#   src/pkg/tui/testdata/demohive: a single-file, stdlib-only, loopback-only
+#   HTTP server that serves fixed literals for the ~12 routes the TUI reads.
+#   It refuses to bind anything but 127.0.0.1, holds no state on disk, makes no
+#   outbound connection, and freezes its clock so relative timestamps render
+#   identically on every run. Every name, number and dollar figure it serves is
+#   invented. Read it before trusting it — it is one file.
+#
+#   It listens on 127.0.0.1:3001, which is already the TUI's default
+#   HIVE_DASHBOARD_URL, so nothing below has to point the TUI anywhere.
+#
+# WHAT IS DELIBERATELY NOT RECORDED  (see also the inline notes at each point)
+#   - Local tmux attach (`a`). Demonstrating it needs a live `tmux` session
+#     named hive-<agent> on the recorder's machine, which is exactly the
+#     "depends on a developer's existing sessions" the task rules out. The
+#     tape shows the binding in the help overlay and stops there.
+#   - SSE degradation and recovery. The fixture exposes no control for
+#     dropping its stream on cue, and killing it mid-tape would take the poll
+#     fallback down with it — which is not the state being demonstrated. A
+#     deterministic drop needs a fixture control this tape does not have, so it
+#     is omitted rather than faked.
+#   - Completing any write. Pause is the one action carried through, against a
+#     fixture agent. Model apply and ACMM apply are both driven to their
+#     confirmation state and then CANCELLED, because both mutate a hive and
+#     neither is safe to demonstrate as a completed act.
+
+Output docs/design/_out/tui.gif
+
+# 100x30 — comfortably above the TUI's documented 60x20 minimum, so the frame
+# is the real 2x2 grid rather than the "terminal too small" fallback, and the
+# four panes have room to show their content at a legible font size.
+Set Shell "bash"
+Set FontSize 16
+Set Width 1400
+Set Height 700
+Set Padding 20
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 60ms
+Set WindowBar Colorful
+Set WindowBarSize 40
+
+# A bare, deterministic prompt. The default shell prompt would put the
+# recorder's own username, hostname and working directory into the frame.
+Hide
+Type `export PS1='$ '` Enter
+Type "clear" Enter
+Show
+
+# ---------------------------------------------------------------------------
+# 1. Launch.
+#    No flags: `hivectl tui` is a bare subcommand that reads HIVE_DASHBOARD_URL
+#    (default http://localhost:3001 — what the fixture is serving) and
+#    HIVE_DASHBOARD_TOKEN. The fixture requires no token, so none is set here;
+#    a real hive needs `export HIVE_DASHBOARD_TOKEN=...` first, and no token
+#    value appears anywhere in this tape.
+# ---------------------------------------------------------------------------
+Type "bin/hivectl tui" Sleep 500ms Enter
+
+# ---------------------------------------------------------------------------
+# 2. All four panes and the live header.
+#    Both loops fetch immediately on startup, so AGENTS / GOVERNOR / TOKENS /
+#    EVENTS fill without waiting out an interval. The header reads
+#    `hive: … governor: … ws: …`; `ws:` flips to `connected` only once an event
+#    has actually been received on the stream, which the fixture sends at once.
+# ---------------------------------------------------------------------------
+Sleep 4s
+
+# ---------------------------------------------------------------------------
+# 3. Focus and navigation.
+#    `tab` cycles focus forward, `shift+tab` backward; `j`/`k` move the row
+#    selection in the Agents and Events panes.
+# ---------------------------------------------------------------------------
+Down@400ms 2
+Sleep 1s
+Type@400ms "k"
+Sleep 1s
+
+Tab
+Sleep 1200ms
+Tab
+Sleep 1200ms
+Tab
+Sleep 1200ms
+Down@400ms 3
+Sleep 1500ms
+
+Shift+Tab
+Sleep 1s
+Shift+Tab
+Sleep 1s
+Shift+Tab
+Sleep 1500ms
+
+# ---------------------------------------------------------------------------
+# 4. Help overlay, and dismissal.
+#    `?` toggles it; it lists every binding and dismisses on ANY key. This is
+#    also where `a` (local tmux attach) is visible as a binding — see the
+#    omission note in the header for why it is not exercised.
+# ---------------------------------------------------------------------------
+Type@400ms "?"
+Sleep 3s
+Escape
+Sleep 1500ms
+
+# ---------------------------------------------------------------------------
+# 5a. Pause / resume confirmation.
+#     `p` opens a y/n confirm rather than acting immediately. This is the one
+#     write the tape carries through, and only because the target is a fixture
+#     agent whose paused bit lives in the fixture's memory and is discarded
+#     when it exits.
+# ---------------------------------------------------------------------------
+Type@400ms "p"
+Sleep 2s
+Type@400ms "y"
+Sleep 3s
+
+# Resume it again, so the recording leaves the fixture as it found it.
+Type@400ms "p"
+Sleep 2s
+Type@400ms "y"
+Sleep 3s
+
+# And show the cancel path: `n` (or `esc`) backs out with no request sent.
+Type@400ms "p"
+Sleep 2s
+Type@400ms "n"
+Sleep 1500ms
+
+# ---------------------------------------------------------------------------
+# 5b. Model picker, and its qualifications.
+#     `m` opens the picker for the selected agent and fetches its backend's
+#     catalogue. The fixture returns a list flagged BOTH fallback (discovery
+#     found nothing; these ids are guesses) and partial (some endpoints did not
+#     answer, so an absence proves nothing) so the overlay's notes are visible.
+#     `enter` here would APPLY and restart the agent's session — so this tape
+#     stops at the qualified list and leaves with `esc`.
+# ---------------------------------------------------------------------------
+Type@400ms "m"
+Sleep 3s
+Down@400ms 1
+Sleep 2s
+Escape
+Sleep 1500ms
+
+# ---------------------------------------------------------------------------
+# 5c. Kick, and its footer feedback.
+#     `K` (capital — the shifted twin of `k` navigate, deliberately, so a
+#     missed shift never fires it) queues an immediate run and reports in the
+#     footer: `kick queued for <agent>`. Against the fixture this queues
+#     nothing anywhere; the fixture answers 202 and discards it.
+# ---------------------------------------------------------------------------
+Type@400ms "K"
+Sleep 3s
+
+# ---------------------------------------------------------------------------
+# 5d. ACMM overlay, reaching typed confirmation and CANCELLING.
+#     `A` opens the level overlay from anywhere — the level is a property of
+#     the whole hive, not the focused pane's selection. Selecting a level and
+#     pressing `enter` does not apply it: it opens a typed confirmation that
+#     requires the exact phrase `APPLY L<n>`, and only an exact match arms the
+#     apply on the NEXT enter.
+#
+#     The fixture reports L2 as current, so the tape moves to a DIFFERENT level
+#     to reach confirmation at all — selecting the level already in force
+#     short-circuits to "nothing to apply".
+#
+#     The phrase is typed in full to show the overlay accepting it, and then
+#     the whole thing is abandoned with `esc`. NO APPLY IS COMPLETED. `esc`
+#     during confirmation backs out to the list rather than closing outright,
+#     so a second `esc` closes the overlay.
+# ---------------------------------------------------------------------------
+Type@400ms "A"
+Sleep 3s
+Down@500ms 1
+Sleep 1500ms
+Enter
+Sleep 2s
+Type "APPLY L3"
+Sleep 2500ms
+Escape
+Sleep 1500ms
+Escape
+Sleep 1500ms
+
+# ---------------------------------------------------------------------------
+# 6. Local tmux attach — OMITTED.
+#    `a` attaches to the selected agent's tmux session (hive-<agent>) and is
+#    local-only. It cannot be shown deterministically: a successful attach
+#    needs a live session on the recording machine, and pressing `a` without
+#    one would record the failure message rather than the feature. The binding
+#    is documented in the help overlay shown at step 4 and in
+#    src/docs/hivectl.md; it is not exercised here.
+#
+# 7. SSE degradation and recovery — OMITTED.
+#    The header's `ws:` field would read `not connected` while the stream is
+#    down, and the reconcile cadence would drop from 60s back to 5s. Showing
+#    the transition needs the fixture to drop and restore its stream on cue,
+#    which it has no control for; stopping the fixture outright would take the
+#    poll fallback down with it and record an unreachable hive instead of a
+#    degraded one. Omitted rather than simulated.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# 8. Clean quit.
+#    `q` quits from the top level only — every overlay above was dismissed
+#    first, which is the modal rule: while an overlay is open `q` is swallowed
+#    like every other key.
+# ---------------------------------------------------------------------------
+Type@400ms "q"
+Sleep 2500ms

--- a/src/docs/hivectl.md
+++ b/src/docs/hivectl.md
@@ -362,6 +362,33 @@ an operator dismisses the overlay first (see the modal rule above).
 - **Feature parity with the web dashboard's operator loop, not visual
   parity.** The TUI does not attempt to look like the web dashboard.
 
+#### Seeing it run
+
+Everything above is recorded as a VHS tape at
+[`src/docs/design/tui.tape`](design/tui.tape) — launch, the four populated
+panes, focus and navigation, the help overlay, and each write action in its
+safe state. Render it with [VHS](https://github.com/charmbracelet/vhs)
+(`brew install vhs`) and a Go toolchain; it needs no Docker, no network and no
+cluster:
+
+```bash
+cd src
+go build -o bin/hivectl ./cmd/hivectl
+go run ./pkg/tui/testdata/demohive &     # loopback fixture; kill %1 to stop
+vhs docs/design/tui.tape                 # writes docs/design/_out/tui.gif
+```
+
+The tape records against `src/pkg/tui/testdata/demohive`, a single-file,
+stdlib-only, loopback-only fixture that serves fixed literals for the routes
+the TUI reads — so the recording never captures a real hive's identity, agent
+names or spend, and renders identically every time. The GIF is a build product
+and is gitignored; the tape is the committed source of truth.
+
+The tape deliberately does **not** complete a model apply or an ACMM apply (it
+drives each to its confirmation and cancels), and omits local tmux attach and
+SSE degradation, both of which need state the fixture cannot produce
+deterministically. Each omission is explained in a comment in the tape itself.
+
 Track any further work under the `hive tui` epic
 ([#4907](https://github.com/kubestellar/hive/issues/4907)).
 

--- a/src/pkg/tui/testdata/demohive/main.go
+++ b/src/pkg/tui/testdata/demohive/main.go
@@ -1,0 +1,391 @@
+// Command demohive serves a fixed, in-memory imitation of the Hive dashboard
+// API — just the handful of routes pkg/tui/client calls — so that the VHS tape
+// in src/docs/design/tui.tape can record `hivectl tui` deterministically.
+//
+// It exists for one reason: a terminal recording is a screenshot of whatever
+// was on screen, and pointing the recorder at a real hive would publish that
+// hive's agent names, repositories, token spend and identity into a public
+// repo. Every value below is invented.
+//
+// Run it with:
+//
+//	go run ./pkg/tui/testdata/demohive          # listens on 127.0.0.1:3001
+//	go run ./pkg/tui/testdata/demohive -addr 127.0.0.1:3099
+//
+// Stop it with ctrl+c, or `kill` the pid — it holds no state on disk, opens no
+// outbound connection, and writes nothing outside its own process memory.
+//
+// Determinism rules this fixture follows, because the tape depends on them:
+//
+//   - Every payload is a fixed literal. Nothing is sampled from a clock, a
+//     random source, the environment, or the host.
+//   - Timestamps are frozen at a fixed instant (see fixedNow). Relative
+//     "last activity" labels in the Agents pane are therefore stable from run
+//     to run rather than drifting with wall time.
+//   - Writes are accepted and acknowledged but change nothing that a later
+//     read returns, EXCEPT pause/resume, which flips one in-memory bit so the
+//     tape can show the status glyph actually changing. Restarting the process
+//     restores the starting state.
+//   - The SSE stream emits one frame immediately (so the header's `ws:` field
+//     reaches `connected` promptly and at a predictable moment), then repeats
+//     the same frame on a fixed interval. No frame ever carries new numbers.
+//
+// It is not a mock framework and is not imported by any test; it is a fixture
+// binary for the recording, deliberately kept to one file of stdlib Go so a
+// reviewer can read the whole thing before trusting it with a demo.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultAddr matches the TUI's own default HIVE_DASHBOARD_URL
+// (http://localhost:3001), so the tape needs no environment override at all.
+const defaultAddr = "127.0.0.1:3001"
+
+// fixedNow is the single instant every timestamp in this fixture derives from.
+// A frozen clock is what makes the Agents pane's relative activity labels
+// ("2m ago") identical on every render instead of counting up while recording.
+var fixedNow = time.Date(2026, time.January, 15, 9, 30, 0, 0, time.UTC)
+
+// sseFrameInterval is how often the stream repeats its snapshot. It is well
+// under the TUI's 60s settled reconcile cadence so a recording that runs for
+// a minute never watches the stream go quiet, and well over the frame rate so
+// the repeats cost nothing.
+const sseFrameInterval = 10 * time.Second
+
+// paused holds the only mutable bit in the fixture: whether the demo agent the
+// tape pauses is currently paused. Everything else is a constant.
+var paused sync.Map // agent name -> bool
+
+func main() {
+	addr := flag.String("addr", defaultAddr, "address to listen on (loopback only)")
+	flag.Parse()
+
+	if !strings.HasPrefix(*addr, "127.0.0.1:") && !strings.HasPrefix(*addr, "localhost:") {
+		log.Fatalf("demohive refuses to bind %q: loopback only", *addr)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{"status": "ok"})
+	})
+	mux.HandleFunc("/api/hive-id", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{"id": "demo-hive"})
+	})
+	mux.HandleFunc("/api/agents", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, agentRoster())
+	})
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, statusPayload())
+	})
+	mux.HandleFunc("/api/config/governor", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{
+			"general_advanced": map[string]any{"eval_interval_s": 300},
+		})
+	})
+	mux.HandleFunc("/api/tokens", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, tokensPayload())
+	})
+	mux.HandleFunc("/api/cost", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, costPayload())
+	})
+	mux.HandleFunc("/api/audit", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{"entries": auditEntries()})
+	})
+	mux.HandleFunc("/api/packs", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, packs())
+	})
+	mux.HandleFunc("/api/events", serveSSE)
+
+	mux.HandleFunc("/api/inference/models/", func(w http.ResponseWriter, r *http.Request) {
+		backend := strings.TrimPrefix(r.URL.Path, "/api/inference/models/")
+		writeJSON(w, modelCatalogue(backend))
+	})
+	mux.HandleFunc("/api/pause/", func(w http.ResponseWriter, r *http.Request) {
+		setPaused(w, r, "/api/pause/", true)
+	})
+	mux.HandleFunc("/api/resume/", func(w http.ResponseWriter, r *http.Request) {
+		setPaused(w, r, "/api/resume/", false)
+	})
+	mux.HandleFunc("/api/kick/", func(w http.ResponseWriter, r *http.Request) {
+		agent := strings.TrimPrefix(r.URL.Path, "/api/kick/")
+		w.WriteHeader(http.StatusAccepted)
+		writeJSON(w, map[string]any{"status": "queued", "agent": agent})
+	})
+	mux.HandleFunc("/api/model/", func(w http.ResponseWriter, r *http.Request) {
+		// Path is /api/model/{agent}/{model}. The fixture acknowledges the
+		// write with the values it was given and forgets them: the tape never
+		// completes a model apply, and a fixture that remembered one would
+		// make two consecutive runs render differently.
+		rest := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/api/model/"), "/", 2)
+		agent, model := "", ""
+		if len(rest) == 2 {
+			agent, model = rest[0], rest[1]
+		}
+		writeJSON(w, map[string]any{"status": "ok", "agent": agent, "model": model})
+	})
+	mux.HandleFunc("/api/packs/level", func(w http.ResponseWriter, r *http.Request) {
+		// Reachable only if someone completes the ACMM typed confirmation by
+		// hand. The tape cancels out of it with `esc` and never sends this.
+		writeJSON(w, map[string]any{
+			"ok": true, "level": 2,
+			"packAgents": []string{}, "packUpdated": []string{},
+			"paused": []string{}, "resumed": []string{},
+		})
+	})
+
+	log.Printf("demohive listening on http://%s (fixture data only; ctrl+c to stop)", *addr)
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// agentRoster is GET /api/agents — the fleet the Agents pane draws its rows
+// from. Four invented agents with generic role names; none of these exist in
+// any real hive.
+func agentRoster() []map[string]any {
+	return []map[string]any{
+		{"name": "reviewer", "id": "reviewer", "displayName": "Reviewer", "enabled": true, "managed": true, "backend": "claude", "model": "demo-model-large"},
+		{"name": "docs", "id": "docs", "displayName": "Docs", "enabled": true, "managed": true, "backend": "claude", "model": "demo-model-small"},
+		{"name": "triage", "id": "triage", "displayName": "Triage", "enabled": true, "managed": true, "backend": "claude", "model": "demo-model-small"},
+		{"name": "planner", "id": "planner", "displayName": "Planner", "enabled": false, "managed": true, "backend": "claude", "model": "demo-model-large"},
+	}
+}
+
+// statusPayload is GET /api/status and the body of every SSE frame: the live
+// governor slice plus per-agent state the Agents pane joins onto the roster.
+func statusPayload() map[string]any {
+	agents := make([]map[string]any, 0, 4)
+	for _, a := range agentRoster() {
+		name := a["name"].(string)
+		enabled := a["enabled"].(bool)
+		isPaused := !enabled
+		if v, ok := paused.Load(name); ok {
+			isPaused = v.(bool)
+		}
+		state := "running"
+		if isPaused {
+			state = "stopped"
+		}
+		agents = append(agents, map[string]any{
+			"name": name, "enabled": enabled && !isPaused,
+			"paused": isPaused, "state": state,
+		})
+	}
+	return map[string]any{
+		"timestamp": fixedNow.Format(time.RFC3339),
+		"agents":    agents,
+		// acmmLevel / acmmLevelConfigured are TOP-LEVEL on /api/status, not
+		// inside the governor object — see client.GovernorStatus, which embeds
+		// GovernorState under "governor" and keeps the ACMM fields beside it.
+		"acmmLevel":           2,
+		"acmmLevelConfigured": true,
+		"governor": map[string]any{
+			"active": true, "mode": "busy",
+			// The pane's "queue depth" is issues+prs, and both are flat fields
+			// on the governor object. There is no nested "queue" object on the
+			// wire (client/governor.go says so explicitly).
+			"issues": 7, "prs": 3,
+			"thresholds": map[string]any{"quiet": 2, "busy": 6, "surge": 20},
+			// nextKick is a PRE-FORMATTED server-local display string on the
+			// wire ("1/2 3:04 PM MST"), not a duration and not RFC 3339.
+			"nextKick": "1/15 9:35 AM UTC",
+		},
+	}
+}
+
+// tokensPayload is GET /api/tokens. Invented counts, chosen to be large enough
+// that the pane's formatting (thousands separators, per-agent breakdown) is
+// visible in the recording.
+func tokensPayload() map[string]any {
+	return map[string]any{
+		"total_tokens": 4_812_600, "total_input": 3_120_400, "total_output": 412_200,
+		"total_cache_read": 1_180_000, "total_cache_create": 100_000,
+		"total_messages": 942, "session_count": 4,
+		"by_agent": map[string]int64{
+			"reviewer": 2_140_000, "docs": 1_020_600, "triage": 980_000, "planner": 672_000,
+		},
+		// by_agent_detail, NOT by_agent, is what the Tokens pane builds its
+		// rows from (model.tokensMsg walks ByAgentDetail). A payload with only
+		// by_agent renders "no usage recorded".
+		"by_agent_detail": map[string]any{
+			"reviewer": map[string]any{"input": 1_390_000, "output": 186_000, "cache_read": 520_000, "cache_create": 44_000, "messages": 412, "sessions": 2},
+			"docs":     map[string]any{"input": 662_000, "output": 88_600, "cache_read": 248_000, "cache_create": 22_000, "messages": 214, "sessions": 1},
+			"triage":   map[string]any{"input": 636_000, "output": 84_000, "cache_read": 238_000, "cache_create": 22_000, "messages": 196, "sessions": 1},
+			"planner":  map[string]any{"input": 432_400, "output": 53_600, "cache_read": 174_000, "cache_create": 12_000, "messages": 120, "sessions": 0},
+		},
+		"by_model": map[string]int64{
+			"demo-model-large": 2_812_000, "demo-model-small": 2_000_600,
+		},
+		"sessions": []any{},
+	}
+}
+
+// costPayload is GET /api/cost — the optional estimate beside the counts.
+func costPayload() map[string]any {
+	return map[string]any{
+		"estimated": map[string]any{
+			"total_usd": 18.42,
+			// source MUST be "estimated": CostAgentEntry.Known() compares
+			// against exactly that string, and an entry it does not recognise
+			// is treated as unpriced and renders no dollar figure at all.
+			"by_agent": []map[string]any{
+				{"name": "reviewer", "usd": 8.10, "source": "estimated"},
+				{"name": "docs", "usd": 3.95, "source": "estimated"},
+				{"name": "triage", "usd": 3.61, "source": "estimated"},
+				{"name": "planner", "usd": 2.76, "source": "estimated"},
+			},
+			"unpriced_models": []string{},
+		},
+	}
+}
+
+// auditEntries is GET /api/audit, newest first — what the Events pane shows.
+// The user column is a placeholder name, not a GitHub handle.
+func auditEntries() []map[string]any {
+	ts := func(minutesAgo int) string {
+		return fixedNow.Add(-time.Duration(minutesAgo) * time.Minute).Format(time.RFC3339)
+	}
+	return []map[string]any{
+		{"ts": ts(2), "user": "operator", "action": "kick", "agent": "reviewer", "detail": "manual kick queued"},
+		{"ts": ts(9), "user": "governor", "action": "eval", "detail": "mode busy (queue 7/3)"},
+		{"ts": ts(14), "user": "operator", "action": "model-set", "agent": "docs", "detail": "demo-model-small"},
+		{"ts": ts(23), "user": "governor", "action": "kick", "agent": "triage", "detail": "scheduled run"},
+		{"ts": ts(31), "user": "operator", "action": "pause", "agent": "planner", "detail": "paused by operator"},
+		{"ts": ts(46), "user": "governor", "action": "eval", "detail": "mode quiet (queue 1/0)"},
+		{"ts": ts(58), "user": "governor", "action": "kick", "agent": "docs", "detail": "scheduled run"},
+		{"ts": ts(70), "user": "operator", "action": "resume", "agent": "docs", "detail": "resumed by operator"},
+	}
+}
+
+// packs is GET /api/packs — the ACMM level definitions the overlay lists.
+// Level 2 is flagged current, which is why the tape selects a DIFFERENT level
+// to reach the typed-confirmation state: selecting the level already in force
+// short-circuits to "nothing to apply".
+func packs() []map[string]any {
+	def := func(level int, name, desc string, current bool, agents int, modes, merge string) map[string]any {
+		return map[string]any{
+			"level": level, "name": name, "description": desc,
+			"agentCount": agents, "current": current,
+			"governor": map[string]any{
+				"modes": modes, "mergePolicy": merge, "evalIntervalS": 300,
+			},
+			"agents": []any{},
+		}
+	}
+	// Names carry NO "Ln" prefix: the overlay already renders the level, so a
+	// prefixed name reads as "L3 L3 Assist".
+	return []map[string]any{
+		def(1, "Observe", "Read-only observation; no writes.", false, 2, "observe", "none"),
+		def(2, "Advise", "Advisory findings; humans merge.", true, 4, "advisory", "manual"),
+		def(3, "Assist", "Agents open PRs; humans approve.", false, 6, "advisory, active", "approval"),
+		def(4, "Delegate", "Agents merge inside guardrails.", false, 8, "active", "auto-on-green"),
+	}
+}
+
+// modelCatalogue is GET /api/inference/models/{backend}. It returns the list
+// flagged BOTH fallback and partial on purpose: those two qualifications are
+// the notes the tape is meant to show in the picker overlay, and a clean
+// catalogue would render no note at all.
+func modelCatalogue(backend string) map[string]any {
+	return map[string]any{
+		"backend":  backend,
+		"fallback": true,
+		"partial":  true,
+		// A flat []string, NOT objects: client.ModelOption is a string type,
+		// because handleInferenceModels assigns a []string regardless of what
+		// openapi.json declares. Objects here decode as an error and the
+		// picker renders "Catalogue unavailable" instead of a list.
+		"models": []string{
+			"demo-model-large",
+			"demo-model-small",
+			"demo-model-fast",
+		},
+	}
+}
+
+func setPaused(w http.ResponseWriter, r *http.Request, prefix string, want bool) {
+	agent := strings.TrimPrefix(r.URL.Path, prefix)
+	prev := false
+	if v, ok := paused.Load(agent); ok {
+		prev = v.(bool)
+	}
+	paused.Store(agent, want)
+	state := "running"
+	if want {
+		state = "paused"
+	}
+	status := "resumed"
+	if want {
+		status = "paused"
+	}
+	writeJSON(w, map[string]any{
+		"ok": true, "status": status, "agent": agent,
+		"changed": prev != want, "state": state,
+	})
+}
+
+// serveSSE streams the same status snapshot the poll returns. The first frame
+// goes out immediately, which is what makes the header's `ws:` field reach
+// `connected` at a predictable point early in the recording — the TUI only
+// counts the stream as connected once an event has actually been RECEIVED.
+func serveSSE(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	frame, err := json.Marshal(statusPayload())
+	if err != nil {
+		return
+	}
+	emit := func() bool {
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", frame); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+	if !emit() {
+		return
+	}
+	ticker := time.NewTicker(sseFrameInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			// Re-marshal so a pause taken during the recording shows up on the
+			// stream as well as the poll.
+			if f, err := json.Marshal(statusPayload()); err == nil {
+				frame = f
+			}
+			if !emit() {
+				return
+			}
+		}
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}


### PR DESCRIPTION
Fixes #5423

Adds `src/docs/design/tui.tape` — a VHS script recording the v1 `hivectl tui` operator loop end to end — and the deterministic fixture it records against.

## What is here

| File | Why |
|---|---|
| `src/docs/design/tui.tape` | The tape. 100x30 (well above the documented 60x20 minimum), pinned font/theme, fixed typing and sleep timing. |
| `src/pkg/tui/testdata/demohive/main.go` | One file, stdlib only, loopback only. Serves fixed literals for the ~12 routes the TUI reads. |
| `src/docs/hivectl.md` | Render instructions + the omission notes, under the `tui` section. |
| `.gitignore` | Excludes `src/docs/design/_out/`. |

## Why a fixture

A terminal recording is a screenshot of whatever was on screen. Recording against a real hive would burn that hive's identity, agent names, repositories and token spend into a GIF in a public repo. `demohive` refuses to bind anything but `127.0.0.1`, holds no state on disk, opens no outbound connection, and freezes its clock so relative timestamps render identically run to run. Every name, number and dollar figure it serves is invented. It is one file, deliberately, so a reviewer can read all of it before trusting it.

It listens on `127.0.0.1:3001`, which is already the TUI's default `HIVE_DASHBOARD_URL`, so the tape sets no environment at all — and no token value appears anywhere.

## What the recording shows

Launch → all four populated panes and the live header (`hive:` / `governor:` / `ws: connected`) → `tab`/`shift+tab` focus and `j`/`k` navigation in Agents and Events → `?` help and dismissal → pause/resume (confirm, the cancel path, and back to the starting state) → the model picker with **both** its fallback and partial qualifications visible → `K` kick and its `kick queued for docs` footer line → the ACMM overlay driven to its typed `APPLY L3` confirmation and then **cancelled** → clean `q` quit.

**No apply is completed.** Model apply and ACMM apply are both driven to their confirmation state and abandoned with `esc`; the only write carried through is pause/resume, against a fixture agent whose paused bit lives in the fixture's memory and dies with the process.

Every key and every rendered result was checked against `src/docs/hivectl.md` as rewritten by #5557.

## Omitted, with a comment in the tape saying why

- **Local tmux attach (`a`)** — needs a live `hive-<agent>` session on the recording machine, i.e. exactly the dependency on a developer's existing sessions the task rules out. The binding is visible in the help overlay; it is not exercised.
- **SSE degradation and recovery** — the fixture has no control for dropping its stream on cue, and killing it outright would take the poll fallback down with it and record an *unreachable* hive rather than a *degraded* one. Omitted rather than simulated.

## No binary committed

`src/docs/design/_out/` is gitignored. The tape is the source of truth; the GIF is a build product. `git status --short` after a render shows nothing.

## Rendering — actually performed

Rendered with **VHS 0.11.0** (macOS/arm64) during development, frames extracted with ffmpeg and inspected. That is what caught four fixture-shape bugs a tape written from the wire structs alone would have shipped with:

- `models` is a flat `[]string` (`client.ModelOption` is a string type) — objects rendered *"Catalogue unavailable: json: cannot unmarshal object…"* instead of a picker.
- cost `source` must be exactly `"estimated"`; `Known()` compares against that literal, and anything else renders no dollar figure.
- Tokens rows come from `by_agent_detail`, not `by_agent` — a payload with only the latter rendered *"no usage recorded"*.
- `acmmLevel`/`acmmLevelConfigured` are top-level on `/api/status`, and `issues`/`prs` are flat inside `governor` (there is no nested `queue` object) — with these misplaced the pane showed `queue depth 0` and `acmm level —`.

## Not verified

- Not rendered on Linux or in CI — only macOS/arm64 with VHS 0.11.0.
- The fixture is not exercised by any test and is not imported by one; it is a fixture binary for the recording. It does pass `gofmt`, `go vet` and `go build`.
- `src/pkg/tui/` itself is untouched — #5424 owns that tree.