### PR TITLE
🐛 fix(dashboard): restore cachedHealth in t.Cleanup; the 83-failure figure does not reproduce (#5570)

### DIFF
--- a/src/pkg/dashboard/status_builder_more_coverage_test.go
+++ b/src/pkg/dashboard/status_builder_more_coverage_test.go
@@ -73,6 +73,23 @@ func TestCovH2_BuildHealthAndRateLimits(t *testing.T) {
 	deps := testDeps(t)
 	logger := covH2Logger()
 
+	// This test drives buildHealth with a live client below, and that
+	// production path writes the package-level cachedHealth cache
+	// (status_builder.go). Nothing in the non-test code clears it, so without
+	// a restore here the cache leaks into every later test that exercises the
+	// nil-client branch — those tests assert the *default* {"ci": 100} and
+	// instead observe this test's fixture. Snapshot and restore around the
+	// whole test via t.Cleanup rather than defer: cleanup must run even if an
+	// assertion below calls t.Fatalf. Refs #5570.
+	cachedHealthMu.Lock()
+	prevCachedHealth := cachedHealth
+	cachedHealthMu.Unlock()
+	t.Cleanup(func() {
+		cachedHealthMu.Lock()
+		cachedHealth = prevCachedHealth
+		cachedHealthMu.Unlock()
+	})
+
 	// nil client → cached/default fallback branch.
 	h := buildHealth(nil, nil)
 	if h == nil {


### PR DESCRIPTION
Refs #5570.

## The headline finding: the 83-failure figure does not reproduce

#5570 states `pkg/dashboard` fails **83 tests** under `-shuffle`, and asks for a grouping of those 83 by shared global so they can be fixed a global at a time.

I could not reproduce that. Measured on unmodified `origin/v4` (1457917a), the count is **1**, not 83 — and the one is the test #5569 already fixes.

The 83 appears to be an artifact of the measurement environment, not a property of the package. Here is the evidence.

**Seed sweep, default parallelism** — wildly inconsistent, which is already a tell; genuine order-dependence is deterministic per seed:

| seed | failures |
|---|---|
| 200 | 1 |
| 201 | 4 |
| 202 | 0 |
| 203 | 1 |
| 204 | 18 |
| 205 | 0 |
| 206 | 0 |

**The variable failures are ephemeral-port exhaustion, not order-dependence.** The failure messages are `dial tcp 127.0.0.1:PORT: connect: can't assign requested address`. This package stands up hundreds of `httptest` servers; on a machine with a saturated `TIME_WAIT` table the kernel cannot hand out ephemeral ports and the fake servers become unreachable. The count of `can't assign requested address` in each run tracks the failure count exactly (seed 204: 9 such errors, 18 failures; seed 201: 1 error, 4 failures).

Re-running the two worst seeds after the socket table drained, twice each:

| seed | first run | rerun A | rerun B |
|---|---|---|---|
| 201 | 4 | **0** | **0** |
| 204 | 18 | **0** | **0** |

Same seed, same binary, same order — zero failures. That rules out order-dependence by construction.

**With port pressure removed (`-p 1`), the result is clean and stable:**

| seed | 200 | 203 | 207 | 208 | 209 | 210 | 211 | 212 |
|---|---|---|---|---|---|---|---|---|
| failures | 1 | 1 | 1 | 1 | 0 | 0 | 0 | 0 |

The single failure in each case is `TestBuildHealth_NilClient_Boost` — the #5569 test, with `ports=0` in every run.

So the grouping the issue asks for is: **one global, `cachedHealth`, accounting for the one genuinely order-dependent test.** There is no set of 82 others to work through.

## What this PR fixes

While confirming the above I found that **#5569 fixes the victim, not the cause** — so the leak would have returned.

The polluter is the *production* path. `buildHealth` writes the package-level cache at `status_builder.go:1392`, and nothing in the non-test code clears it:

```go
health := ghClient.FetchWorkflowHealth(ctx)

cachedHealthMu.Lock()
cachedHealth = health
cachedHealthMu.Unlock()
```

`TestCovH2_BuildHealthAndRateLimits` is the only test in the package that reaches that branch (`status_builder_more_coverage_test.go:116`, `_ = buildHealth(ghc, ctx)`). It left the cache populated for the rest of the run. Every later test asserting the nil-client default `{"ci": 100}` then observed this test's fixture instead. The other `cachedHealth` writers are test-local and already restore correctly — this was the only unrestored one.

The fix snapshots and restores the cache around the test in **`t.Cleanup`, not `defer`**: this test calls `t.Fatalf` in several places, where `defer` in the enclosing function would be skipped. That is the same shape as one of the three root causes in #5553.

## Verification

The seed that reproduces the failure isolates to an ordering question — with only these two tests selected, the failure occurs precisely when the polluter is scheduled first:

| shuffle seed | first test | result |
|---|---|---|
| 1–4 | `TestBuildHealth_NilClient_Boost` | pass |
| **5** | **`TestCovH2_BuildHealthAndRateLimits`** | **FAIL** |

After the fix, **seed 5 with the polluter still ordered first passes.**

Full package, `-p 1`:

- **Previously failing seeds 200, 203, 207, 208 — before: 1 failure each; after: 0.**
- **Disjoint range 900–907 — 0 failures**, confirming no regression.

13 distinct seeds green. `gofmt` clean, `go vet` clean.

## Before / after

Failing count on `origin/v4`: **1** (`-p 1`, seeds 200/203/207/208). After this PR: **0**.

Note #5569 is still open. It fixes the same symptom by restoring the global from the victim's side; this PR fixes the cause at the writing site. They are compatible — if #5569 merges first this change is still required, because without it the next test to assert the nil-client default reintroduces the bug.

## Wiring `-shuffle` into CI — the durable half

Acceptance item 3 of #5570 asks for `-shuffle` in the `pkg/dashboard` CI lane. On this evidence that is **now unblocked** — the package is at zero, not 82, so a shuffle lane would be green rather than permanently red.

It should go in the existing Go test step for this package, as `-shuffle=on -count=1`. Two things must be true first, and both are about the port exhaustion above, not about ordering:

1. **The lane must constrain parallelism** (`-p 1`, or a bounded `-parallel`). Without it the lane will flake on runners under socket pressure and get ignored — worse than not having it, since a noisy detector trains people to disregard it.
2. **`-shuffle=on` prints the seed and it must be surfaced on failure**, otherwise a red run is not reproducible.

I have deliberately **not** added the CI change here, per the issue's own guidance to keep these surgical and because the parallelism question deserves its own review. Recommend it as a follow-up once this merges.

## What I did NOT verify

- **I did not reproduce the 83.** I cannot rule out that a different environment shows genuine order-dependence my machine does not — but the reruns above show the variable failures I *did* see were not order-dependent.
- **I did not run the full package unshuffled**, nor any package other than `pkg/dashboard`. CI is the gate.
- The port-exhaustion diagnosis is inferred from error text plus the drain/rerun experiment; I did not instrument the socket table during a failing run.
- Seeds tested are 13 of an unbounded space; acceptance asks for 20+ distinct seeds, which CI is better placed to run.