### PR TITLE
✨ feat(spoke+hub): remediation-hint detectors on the heartbeat (#5577, 1/3)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3806,6 +3806,16 @@ func main() {
 
 			providerLimitReason, providerLimitRebuffs := providerLimitHeartbeatFields(agents)
 
+			// Remediation-hint detectors (#5577). All three read state the
+			// spoke already maintains — no new GitHub calls, no new file
+			// scans on the beat path. AgentErrorStreaks is nil until the
+			// token collector's first bob-recording scan completes ("not
+			// measured", hub carries forward); the other two are always live
+			// measurements and send [] to clear a stale carry-forward.
+			agentErrorStreaks := tokenCollector.AgentErrorStreaks()
+			consentWedged := agentMgr.ConsentWedgedAgents()
+			noCadenceAgents := gov.NoCadenceAgents()
+
 			return &hub.HeartbeatPayload{
 				AgentsWithModel:      &agentsWithModel,
 				BudgetCurrentSpend:   budgetSpend,
@@ -3818,6 +3828,9 @@ func main() {
 				AwaitingReview:       awaitingReview,
 				SLAViolations:        slaViolations,
 				TasksCompleted7d:     tasksCompleted7d,
+				AgentErrorStreaks:    agentErrorStreaks,
+				ConsentWedged:        consentWedged,
+				NoCadenceAgents:      noCadenceAgents,
 				// Read-back for hub-funded gateways: the hub clears its pending
 				// record only when it sees the gateway named here, so a lost
 				// delivery is re-offered rather than dropped. Names only — the
@@ -4238,6 +4251,14 @@ func main() {
 					RepoTargetIssue:         repoTargetIssueMessage(),
 					ProviderLimitReason:     providerLimitReason,
 					ProviderLimitRebuffs:    providerLimitRebuffs,
+					// Remediation-hint detectors (#5577): all three are
+					// cheap in-memory reads, so even this minimal upgrading
+					// beat carries them — the pod is about to restart, and
+					// carrying the last real measurement across the roll keeps
+					// a live wedge visible instead of blanking it.
+					AgentErrorStreaks: tokenCollector.AgentErrorStreaks(),
+					ConsentWedged:     agentMgr.ConsentWedgedAgents(),
+					NoCadenceAgents:   gov.NoCadenceAgents(),
 				}
 			}, targetSHA, logger)
 

--- a/src/pkg/agent/consent_wedge.go
+++ b/src/pkg/agent/consent_wedge.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Consent-wedge tracking (#5577). A Copilot CLI parked on an interactive
+// consent screen passes the "❯" marker check, so the kick path detects it
+// via paneShowsConsentScreen and restarts the agent before sending — which
+// lands right back on the same consent screen. The result is a restart loop
+// (observed live at ~1/min) that the logs record ("consent_screen=true") but
+// nothing surfaces: the agent reads green while doing no work. This tracker
+// remembers those restarts so the heartbeat can name the wedged agents.
+
+// consentWedgeWindow is how recent a consent-screen restart must be for the
+// agent to count as wedged. One restart an hour ago that never recurred means
+// the operator completed the consent flow; a live loop refreshes the stamp
+// every kick attempt.
+const consentWedgeWindow = time.Hour
+
+// consentWedgeTracker records the most recent consent-screen restart per
+// agent. It has its OWN mutex — the recording sites run while m.mu is held
+// (SendKick / deliverKickAsync), and re-acquiring m.mu there would deadlock
+// (see the manager's mutex-reentrancy history).
+type consentWedgeTracker struct {
+	mu          sync.Mutex
+	lastByAgent map[string]time.Time
+}
+
+func (t *consentWedgeTracker) note(name string, now time.Time) {
+	if name == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.lastByAgent == nil {
+		t.lastByAgent = make(map[string]time.Time)
+	}
+	t.lastByAgent[name] = now
+}
+
+func (t *consentWedgeTracker) wedged(now time.Time) []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	// Non-nil even when empty: the tracker is always live in-process, so its
+	// answer is always a MEASUREMENT — the heartbeat must send [] (clear the
+	// hub's carry-forward), never null ("not measured").
+	out := []string{}
+	for name, at := range t.lastByAgent {
+		if now.Sub(at) <= consentWedgeWindow {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// noteConsentWedge records that a kick found this agent's CLI sitting on a
+// consent screen and restarted it. Called from the two kick recovery sites
+// with m.mu held; safe there because the tracker locks only its own mutex.
+func (m *Manager) noteConsentWedge(name string) {
+	m.consentWedges.note(name, time.Now())
+}
+
+// ConsentWedgedAgents returns the agents whose kick path hit a consent-screen
+// restart within the last consentWedgeWindow, sorted. Empty (non-nil callers
+// need not distinguish) when none are wedged.
+func (m *Manager) ConsentWedgedAgents() []string {
+	return m.consentWedges.wedged(time.Now())
+}

--- a/src/pkg/agent/consent_wedge_test.go
+++ b/src/pkg/agent/consent_wedge_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// The consent-wedge tracker (#5577) answers one question for the heartbeat:
+// which agents hit a consent-screen restart within the last hour? A wedge
+// loop refreshes its stamp on every kick attempt, so "recent restart" IS the
+// live-loop signal; an old stamp means the operator completed the flow.
+func TestConsentWedgeTracker_WindowAndOrdering(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	var tr consentWedgeTracker
+
+	tr.note("quality", now.Add(-5*time.Minute))  // live wedge
+	tr.note("scanner", now.Add(-59*time.Minute)) // still inside the window
+	tr.note("outreach", now.Add(-2*time.Hour))   // resolved long ago
+	tr.note("", now)                             // never recorded
+
+	got := tr.wedged(now)
+	if want := []string{"quality", "scanner"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("wedged = %v, want %v", got, want)
+	}
+}
+
+// Empty must be a non-nil measurement: the heartbeat serializes [] so the hub
+// clears a carried-forward wedge once it resolves, instead of reading null as
+// "not measured" and keeping the stale alarm alive.
+func TestConsentWedgeTracker_EmptyIsNonNil(t *testing.T) {
+	var tr consentWedgeTracker
+	got := tr.wedged(time.Now())
+	if got == nil {
+		t.Fatal("wedged returned nil; must be a non-nil measurement")
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty tracker reported %v", got)
+	}
+}
+
+// A repeat sighting refreshes the stamp — the loop shape — and the Manager
+// facade records through the tracker without touching m.mu (the recording
+// sites hold it).
+func TestManagerConsentWedge_RecordAndExpire(t *testing.T) {
+	m := &Manager{}
+	m.noteConsentWedge("quality")
+	got := m.ConsentWedgedAgents()
+	if want := []string{"quality"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ConsentWedgedAgents = %v, want %v", got, want)
+	}
+
+	// Age the stamp past the window: the wedge report must clear itself.
+	m.consentWedges.mu.Lock()
+	m.consentWedges.lastByAgent["quality"] = time.Now().Add(-consentWedgeWindow - time.Minute)
+	m.consentWedges.mu.Unlock()
+	if got := m.ConsentWedgedAgents(); len(got) != 0 {
+		t.Fatalf("expired wedge still reported: %v", got)
+	}
+}

--- a/src/pkg/agent/kick_async.go
+++ b/src/pkg/agent/kick_async.go
@@ -231,8 +231,13 @@ func (m *Manager) deliverKickAsync(name, message string) error {
 	// consumed by the menu, or by bash once "No, exit" exits the CLI.
 	pane := m.captureVisiblePaneForAgent(agent)
 	if !paneHasCLIMarker(pane) || paneShowsConsentScreen(pane) {
+		consentScreen := paneShowsConsentScreen(pane)
+		if consentScreen {
+			// Same wedge bookkeeping as SendKick — see noteConsentWedge.
+			m.noteConsentWedge(name)
+		}
 		m.logger.Warn("agent CLI crashed or stuck on consent screen, restarting before kick",
-			"name", name, "consent_screen", paneShowsConsentScreen(pane))
+			"name", name, "consent_screen", consentScreen)
 		m.mu.Unlock()
 		if err := m.Restart(context.Background(), name); err != nil {
 			return fmt.Errorf("failed to restart crashed agent %s: %w", name, err)

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -427,8 +427,12 @@ type Manager struct {
 	// thrashMu guards thrash — its own mutex, NEVER m.mu: the breaker runs on
 	// the output-capture goroutines, and taking m.mu there risks the startup
 	// re-entrancy deadlock class (see the 2026-07 provisionWG incident).
-	thrashMu         sync.Mutex
-	thrash           map[string]*thrashState
+	thrashMu sync.Mutex
+	thrash   map[string]*thrashState
+	// consentWedges records consent-screen restarts for the heartbeat's
+	// ConsentWedged signal (#5577). Own mutex, NEVER m.mu — the recording
+	// sites run with m.mu held. Zero value ready.
+	consentWedges    consentWedgeTracker
 	logger           *slog.Logger
 	workDir          string
 	project          ProjectContext
@@ -4674,8 +4678,15 @@ func (m *Manager) SendKick(name string, message string) error {
 	// (observed live: "-bash: NEVER: command not found").
 	pane := m.captureVisiblePaneForAgent(agent)
 	if !paneHasCLIMarker(pane) || paneShowsConsentScreen(pane) {
+		consentScreen := paneShowsConsentScreen(pane)
+		if consentScreen {
+			// Remember the wedge for the heartbeat's ConsentWedged signal
+			// (#5577): a restart here lands back on the same consent screen,
+			// so repeats of this path ARE the wedge loop.
+			m.noteConsentWedge(name)
+		}
 		m.logger.Warn("agent CLI crashed or stuck on consent screen, restarting before kick",
-			"name", name, "consent_screen", paneShowsConsentScreen(pane))
+			"name", name, "consent_screen", consentScreen)
 		m.mu.Unlock()
 		if err := m.Restart(context.Background(), name); err != nil {
 			m.mu.Lock()

--- a/src/pkg/governor/no_cadence.go
+++ b/src/pkg/governor/no_cadence.go
@@ -1,0 +1,60 @@
+package governor
+
+import "sort"
+
+// No-cadence detection (#5577). An agent that is enabled and governor-kickable
+// but appears in NO mode's cadence map is never timer-kicked; if it has also
+// never been kicked by any other path (LastKick empty forever), it will sit
+// green and idle indefinitely while the dashboard's "not producing output"
+// warnings name the symptom without the cause. This names the cause: the
+// operator never configured a cadence.
+
+// NoCadenceAgents returns the enabled, governor-kickable agents that have no
+// cadence entry in ANY configured mode (an explicit "off"/"pause" entry counts
+// as configured — that is operator choice, not omission) and have never been
+// kicked at all. Sorted; empty when every agent is either scheduled, kicked,
+// on-demand, event-driven, or disabled.
+func (g *Governor) NoCadenceAgents() []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	// Non-nil even when empty: the governor's config is always loaded, so
+	// this is always a measurement — the heartbeat must send [] (clearing the
+	// hub's carried-forward value), never null ("not measured").
+	out := []string{}
+	for name, ac := range g.agents {
+		if !ac.Enabled || ac.OnDemand || !ac.UsesGovernorKick() {
+			continue
+		}
+		if g.agentHasAnyCadenceLocked(name) {
+			continue
+		}
+		if lk, ok := g.state.LastKick[name]; ok && !lk.IsZero() {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// agentHasAnyCadenceLocked reports whether ANY mode's cadence map names this
+// agent (directly or via its replica base, mirroring resolveCadence's
+// fallback). Caller must hold g.mu.
+func (g *Governor) agentHasAnyCadenceLocked(agentName string) bool {
+	baseName := agentName
+	if ac, ok := g.agents[agentName]; ok && ac.ReplicaOf != "" {
+		baseName = ac.ReplicaOf
+	}
+	for _, mode := range g.cfg.Modes {
+		if _, ok := mode.Cadences[agentName]; ok {
+			return true
+		}
+		if baseName != agentName {
+			if _, ok := mode.Cadences[baseName]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/src/pkg/governor/no_cadence_test.go
+++ b/src/pkg/governor/no_cadence_test.go
@@ -1,0 +1,78 @@
+package governor
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+// NoCadenceAgents (#5577) names the silent-idle class: enabled, kickable
+// agents with no cadence in ANY mode and no kick ever. Everything an operator
+// deliberately configured — a cadence anywhere (including "off"), on-demand,
+// event-only channels, disabled — must NOT be flagged.
+func TestNoCadenceAgents(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	// telemetry: enabled, kickable, in NO mode's cadence map, never kicked —
+	// the flagged shape (the live case behind the RFC).
+	agents["telemetry"] = config.AgentConfig{Enabled: true}
+	// disabled agent with no cadences: operator switched it off, not flagged.
+	agents["mothballed"] = config.AgentConfig{Enabled: false}
+	// on-demand agent: kicked manually by design, not flagged.
+	agents["helper"] = config.AgentConfig{Enabled: true, OnDemand: true}
+	// event-driven agent (non-kick channels): governor timer is not its
+	// trigger, not flagged.
+	agents["watcher"] = config.AgentConfig{Enabled: true, Channels: []config.ChannelConfig{{Type: "advisory"}}}
+	// explicit "off" cadence: configured choice, not omission — not flagged.
+	agents["parked"] = config.AgentConfig{Enabled: true}
+	cfg.Modes["idle"].Cadences["parked"] = "off"
+
+	g := New(cfg, agents, testLogger())
+
+	got := g.NoCadenceAgents()
+	if want := []string{"telemetry"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("NoCadenceAgents = %v, want %v", got, want)
+	}
+}
+
+// A kick from ANY path (manual, CEL, resume) clears the agent: "never kicked
+// ever" is half the definition, so RecordKick must remove it.
+func TestNoCadenceAgents_ClearedByAnyKick(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	agents["telemetry"] = config.AgentConfig{Enabled: true}
+	g := New(cfg, agents, testLogger())
+
+	g.RecordKick("telemetry")
+
+	if got := g.NoCadenceAgents(); len(got) != 0 {
+		t.Fatalf("kicked agent still flagged: %v", got)
+	}
+}
+
+// The result is always a measurement: non-nil even when empty, so the
+// heartbeat serializes [] (clearing the hub's carry-forward) rather than null
+// ("not measured").
+func TestNoCadenceAgents_EmptyIsNonNil(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	got := g.NoCadenceAgents()
+	if got == nil {
+		t.Fatal("NoCadenceAgents returned nil; must be a non-nil measurement")
+	}
+	if len(got) != 0 {
+		t.Fatalf("scheduled agent flagged: %v", got)
+	}
+}
+
+// A replica inherits its base agent's cadence (resolveCadence's fallback), so
+// a replica whose BASE is scheduled must not be flagged.
+func TestNoCadenceAgents_ReplicaUsesBaseCadence(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	agents["scanner-2"] = config.AgentConfig{Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2}
+	g := New(cfg, agents, testLogger())
+
+	if got := g.NoCadenceAgents(); len(got) != 0 {
+		t.Fatalf("replica of a scheduled base flagged: %v", got)
+	}
+}

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -787,6 +787,30 @@ type HeartbeatPayload struct {
 	HoldTotal      *int `json:"hold_total,omitempty"`
 	AwaitingReview *int `json:"awaiting_review,omitempty"`
 
+	// --- Remediation-hint detectors (#5577) -------------------------------
+	// Three silent-failure classes a 2026-09-01 fleet audit could only find by
+	// exec'ing into pods. All follow the PRsMerged90d convention: absent means
+	// "not measured" (old spoke, collector not warm) and is carried forward
+	// hub-side — BUT, unlike the count pointers, a MEASURED empty result must
+	// also be distinguishable from absent so a recovered hive clears its own
+	// signal. These therefore omit `omitempty`: nil encodes as null ("not
+	// measured", hub carries forward) while a measured all-clear encodes as
+	// {} / [] and overwrites.
+	//
+	// AgentErrorStreaks maps agent name → consecutive failed model calls
+	// (zero-usage turns from the token scanner's chat recordings — the #5338
+	// bobshell crash-loop signal, where turns run, every call dies, and the
+	// agent stays green).
+	AgentErrorStreaks map[string]int `json:"agent_error_streaks"`
+	// ConsentWedged lists agents whose kick path hit a consent-screen restart
+	// in the last hour — the Copilot consent wedge that restarts an agent
+	// ~1/min while it reads green.
+	ConsentWedged []string `json:"consent_wedged"`
+	// NoCadenceAgents lists enabled, governor-kickable agents with no cadence
+	// configured in any mode AND no kick ever — agents that will idle forever
+	// until the operator sets a cadence.
+	NoCadenceAgents []string `json:"no_cadence_agents"`
+
 	// SLAViolations is work aging past its service threshold, taken from the
 	// governor's eval snapshot.
 	SLAViolations *int `json:"sla_violations,omitempty"`

--- a/src/pkg/hub/remediation_signals_test.go
+++ b/src/pkg/hub/remediation_signals_test.go
@@ -1,0 +1,173 @@
+package hub
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// Remediation-hint detector fields (#5577): AgentErrorStreaks, ConsentWedged,
+// NoCadenceAgents must round-trip handleHeartbeat sanitized, carry forward
+// across minimal beats that omit them, and CLEAR when a beat carries a
+// measured empty value — the nil-vs-empty distinction the whole design rests
+// on (a recovered hive must be able to clear its own alarm).
+
+// storedEntry fetches a registry entry by hive id.
+func storedEntry(t *testing.T, s *HubServer, id string) RegistryEntry {
+	t.Helper()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, h := range s.registry.Hives {
+		if h.ID == id {
+			return h
+		}
+	}
+	t.Fatalf("hive %q not in registry", id)
+	return RegistryEntry{}
+}
+
+func TestHeartbeatRemediationSignals_RoundTrip(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	body := `{
+		"hive_id":"h1",
+		"agent_error_streaks":{"quality":17},
+		"consent_wedged":["copilot-fixer"],
+		"no_cadence_agents":["telemetry","docs"]
+	}`
+	if rec := postHeartbeat(t, s, body); rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	e := storedEntry(t, s, "h1")
+	if e.AgentErrorStreaks == nil || e.AgentErrorStreaks["quality"] != 17 {
+		t.Errorf("AgentErrorStreaks = %v, want quality:17", e.AgentErrorStreaks)
+	}
+	if len(e.ConsentWedged) != 1 || e.ConsentWedged[0] != "copilot-fixer" {
+		t.Errorf("ConsentWedged = %v, want [copilot-fixer]", e.ConsentWedged)
+	}
+	if len(e.NoCadenceAgents) != 2 || e.NoCadenceAgents[0] != "telemetry" || e.NoCadenceAgents[1] != "docs" {
+		t.Errorf("NoCadenceAgents = %v, want [telemetry docs]", e.NoCadenceAgents)
+	}
+}
+
+// A minimal beat (spoke restarting, collectors not warm) omits the fields —
+// nil on decode — and must NOT blank the last real measurement; a later beat
+// carrying a measured EMPTY value must clear it.
+func TestHeartbeatRemediationSignals_CarryForwardAndClear(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	full := `{
+		"hive_id":"h1",
+		"agent_error_streaks":{"quality":5},
+		"consent_wedged":["copilot-fixer"],
+		"no_cadence_agents":["telemetry"]
+	}`
+	if rec := postHeartbeat(t, s, full); rec.Code != http.StatusOK {
+		t.Fatalf("full beat status = %d", rec.Code)
+	}
+
+	// Minimal beat: none of the three keys present.
+	if rec := postHeartbeat(t, s, `{"hive_id":"h1"}`); rec.Code != http.StatusOK {
+		t.Fatalf("minimal beat status = %d", rec.Code)
+	}
+	e := storedEntry(t, s, "h1")
+	if e.AgentErrorStreaks == nil || e.AgentErrorStreaks["quality"] != 5 {
+		t.Errorf("carry-forward dropped AgentErrorStreaks: %v", e.AgentErrorStreaks)
+	}
+	if len(e.ConsentWedged) != 1 {
+		t.Errorf("carry-forward dropped ConsentWedged: %v", e.ConsentWedged)
+	}
+	if len(e.NoCadenceAgents) != 1 {
+		t.Errorf("carry-forward dropped NoCadenceAgents: %v", e.NoCadenceAgents)
+	}
+
+	// Measured all-clear: explicit empty values must OVERWRITE — this is how
+	// a fixed hive clears its own alarm.
+	clearBody := `{
+		"hive_id":"h1",
+		"agent_error_streaks":{},
+		"consent_wedged":[],
+		"no_cadence_agents":[]
+	}`
+	if rec := postHeartbeat(t, s, clearBody); rec.Code != http.StatusOK {
+		t.Fatalf("clear beat status = %d", rec.Code)
+	}
+	e = storedEntry(t, s, "h1")
+	if len(e.AgentErrorStreaks) != 0 || e.AgentErrorStreaks == nil {
+		t.Errorf("measured empty AgentErrorStreaks did not clear/stay measured: %v", e.AgentErrorStreaks)
+	}
+	if len(e.ConsentWedged) != 0 || e.ConsentWedged == nil {
+		t.Errorf("measured empty ConsentWedged did not clear/stay measured: %v", e.ConsentWedged)
+	}
+	if len(e.NoCadenceAgents) != 0 || e.NoCadenceAgents == nil {
+		t.Errorf("measured empty NoCadenceAgents did not clear/stay measured: %v", e.NoCadenceAgents)
+	}
+}
+
+// Hostile/broken payloads: names are identifier-sanitized, non-positive
+// streaks dropped, values clamped, and collection sizes capped at the same
+// bound as the agent list itself.
+func TestHeartbeatRemediationSignals_SanitizeAndClamp(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHeartbeatHub()
+
+	body := `{
+		"hive_id":"h1",
+		"agent_error_streaks":{"qua<script>lity":9,"neg":-4,"huge":999999},
+		"consent_wedged":["<b>x</b>",""],
+		"no_cadence_agents":["ok-agent","<>&"]
+	}`
+	if rec := postHeartbeat(t, s, body); rec.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d", rec.Code)
+	}
+
+	e := storedEntry(t, s, "h1")
+	if v := e.AgentErrorStreaks["quascriptlity"]; v != 9 {
+		t.Errorf("sanitized streak key missing/wrong: %v", e.AgentErrorStreaks)
+	}
+	if _, ok := e.AgentErrorStreaks["neg"]; ok {
+		t.Errorf("negative streak kept: %v", e.AgentErrorStreaks)
+	}
+	if v := e.AgentErrorStreaks["huge"]; v != maxAgentErrorStreak {
+		t.Errorf("streak not clamped: got %d want %d", v, maxAgentErrorStreak)
+	}
+	// "<b>x</b>" sanitizes to "bx/b" (angle brackets stripped) and "" drops.
+	if len(e.ConsentWedged) != 1 || e.ConsentWedged[0] != "bx/b" {
+		t.Errorf("ConsentWedged sanitize wrong: %v", e.ConsentWedged)
+	}
+	// "<>&" sanitizes to empty and drops; the list stays measured (non-nil).
+	if len(e.NoCadenceAgents) != 1 || e.NoCadenceAgents[0] != "ok-agent" {
+		t.Errorf("NoCadenceAgents sanitize wrong: %v", e.NoCadenceAgents)
+	}
+}
+
+func TestSanitizeRemediationSignals_Bounds(t *testing.T) {
+	// nil stays nil (not measured), never an empty measurement.
+	if sanitizeAgentErrorStreaks(nil) != nil {
+		t.Error("nil streak map must stay nil")
+	}
+	if sanitizeAgentNameList(nil) != nil {
+		t.Error("nil name list must stay nil")
+	}
+
+	// Oversized collections are capped at maxRemediationAgents.
+	bigMap := make(map[string]int, maxRemediationAgents+10)
+	var bigList []string
+	for i := 0; i < maxRemediationAgents+10; i++ {
+		name := fmt.Sprintf("agent-%03d", i)
+		bigMap[name] = 1
+		bigList = append(bigList, name)
+	}
+	if got := sanitizeAgentErrorStreaks(bigMap); len(got) != maxRemediationAgents {
+		t.Errorf("streak map not capped: %d", len(got))
+	}
+	if got := sanitizeAgentNameList(bigList); len(got) != maxRemediationAgents {
+		t.Errorf("name list not capped: %d", len(got))
+	}
+}

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -364,6 +364,17 @@ type RegistryEntry struct {
 	SLAViolations    *int `json:"slaViolations,omitempty"`
 	TasksCompleted7d *int `json:"tasksCompleted7d,omitempty"`
 
+	// Remediation-hint detectors (#5577), always the sanitized product of
+	// sanitizeAgentErrorStreaks / sanitizeAgentNameList, never the raw
+	// payload. nil = not measured (old spoke / collector not warm), carried
+	// forward across beats that omit them like the quadrant signals above; a
+	// MEASURED all-clear arrives as an empty (non-nil) value and overwrites,
+	// so a recovered hive clears its own signal. See the matching
+	// HeartbeatPayload fields for the semantics of each.
+	AgentErrorStreaks map[string]int `json:"agentErrorStreaks,omitempty"`
+	ConsentWedged     []string       `json:"consentWedged,omitempty"`
+	NoCadenceAgents   []string       `json:"noCadenceAgents,omitempty"`
+
 	// ComponentReach is the LATEST component-reach report from this hive's
 	// spoke (#3993, phase 2a of #3973): per (component, running commit) span
 	// counters aggregated in-process on the spoke and carried on the
@@ -1872,6 +1883,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		AwaitingReview:       clampFleetCount(payload.AwaitingReview),
 		SLAViolations:        clampFleetCount(payload.SLAViolations),
 		TasksCompleted7d:     clampFleetCount(payload.TasksCompleted7d),
+		// Remediation-hint detectors (#5577): sanitized + clamped, never the
+		// raw payload. nil stays nil ("not measured") and is carried forward
+		// below; a measured empty value stays empty and overwrites.
+		AgentErrorStreaks: sanitizeAgentErrorStreaks(payload.AgentErrorStreaks),
+		ConsentWedged:     sanitizeAgentNameList(payload.ConsentWedged),
+		NoCadenceAgents:   sanitizeAgentNameList(payload.NoCadenceAgents),
 		FleetStatsCollectedAt: func() time.Time {
 			if payload.FleetStatsCollectedAt == "" {
 				return time.Time{}
@@ -2096,6 +2113,21 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			if entry.TasksCompleted7d == nil && h.TasksCompleted7d != nil {
 				entry.TasksCompleted7d = h.TasksCompleted7d
+			}
+			// Carry the remediation-hint detectors (#5577) forward the same
+			// way: a restarting spoke reports nil ("not measured") until its
+			// collectors warm up, and blanking the last real measurement
+			// would hide a live wedge for exactly the window an operator is
+			// most likely to be looking. A MEASURED all-clear arrives as an
+			// empty non-nil value, is not nil here, and correctly overwrites.
+			if entry.AgentErrorStreaks == nil && h.AgentErrorStreaks != nil {
+				entry.AgentErrorStreaks = h.AgentErrorStreaks
+			}
+			if entry.ConsentWedged == nil && h.ConsentWedged != nil {
+				entry.ConsentWedged = h.ConsentWedged
+			}
+			if entry.NoCadenceAgents == nil && h.NoCadenceAgents != nil {
+				entry.NoCadenceAgents = h.NoCadenceAgents
 			}
 			// Carry the last real component-reach report forward when this
 			// beat omits one (#3993) — a restarting spoke reports nil until
@@ -4108,6 +4140,63 @@ func clampQuadrantSpend(v *int64) *int64 {
 	}
 	c := clampInt64(*v, 0, maxQuadrantSpend)
 	return &c
+}
+
+// maxRemediationAgents bounds the remediation-hint detector collections
+// (#5577) per hive, mirroring the maxAgents cap on the agent list itself: no
+// hive has more agents than that, so anything larger is a broken or hostile
+// payload.
+const maxRemediationAgents = 50
+
+// maxAgentErrorStreak bounds a single agent's reported consecutive-failure
+// count. The verdict only needs "≥ threshold"; the spoke already caps at
+// 10 000, so anything past this is garbage, not a bigger emergency.
+const maxAgentErrorStreak = 10_000
+
+// sanitizeAgentErrorStreaks validates a spoke-reported error-streak map. nil
+// stays nil ("not measured" — carried forward, never treated as all-clear); a
+// non-nil map stays non-nil even when everything inside is dropped, so a
+// measured all-clear still overwrites a stale streak. Agent names pass the
+// identifier sanitizer, non-positive streaks are dropped (a zero streak is
+// simply absence), and both entry count and per-agent value are clamped.
+func sanitizeAgentErrorStreaks(in map[string]int) map[string]int {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for name, streak := range in {
+		if len(out) >= maxRemediationAgents {
+			break
+		}
+		name = sanitizeHeartbeatField(name)
+		if name == "" || streak <= 0 {
+			continue
+		}
+		out[name] = clampInt(streak, 1, maxAgentErrorStreak)
+	}
+	return out
+}
+
+// sanitizeAgentNameList validates a spoke-reported agent-name list with the
+// same nil-vs-empty discipline as sanitizeAgentErrorStreaks: nil stays nil,
+// a measured empty list stays non-nil. Names pass the identifier sanitizer,
+// empties are dropped, and the list is capped.
+func sanitizeAgentNameList(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, name := range in {
+		if len(out) >= maxRemediationAgents {
+			break
+		}
+		name = sanitizeHeartbeatField(name)
+		if name == "" {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out
 }
 
 // parseHeartbeatTime converts an RFC3339 timestamp from a heartbeat into a

--- a/src/pkg/tokens/bob_scanner.go
+++ b/src/pkg/tokens/bob_scanner.go
@@ -40,6 +40,10 @@ type bobChatMessage struct {
 	// Type is the role discriminator: "user", "bob-shell", etc.
 	Type    string `json:"type"`
 	Content string `json:"content"`
+	// Timestamp is the per-message RFC3339 stamp bobshell records. Used by
+	// the error-streak scan (error_streak.go) to age turns; the token
+	// aggregation itself only needs the session-level times.
+	Timestamp string `json:"timestamp,omitempty"`
 	// Model is per-message (e.g. "premium", "standard").
 	Model string `json:"model,omitempty"`
 	// Tokens carries usage for assistant ("bob-shell") messages.

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -193,6 +193,7 @@ type Collector struct {
 	logger                    *slog.Logger
 	mu                        sync.RWMutex
 	latest                    *AggregateSummary
+	errorStreaks              map[string]int
 	scanInterval              time.Duration
 	prevSessionCount          int
 	prevTotalTokens           int64
@@ -322,6 +323,14 @@ func (c *Collector) scan() {
 		} else if bobAgg != nil && bobAgg.SessionCount > 0 {
 			MergeAggregates(agg, bobAgg)
 		}
+		// Per-agent consecutive model-call failure streaks (#5577/#5338),
+		// derived from the same recordings this scan just walked. Always
+		// stored non-nil after a scan, so AgentErrorStreaks can distinguish
+		// "measured, none failing" (empty) from "never scanned" (nil).
+		streaks := BobAgentErrorStreaks(c.bobSessionsDir, time.Now())
+		c.mu.Lock()
+		c.errorStreaks = streaks
+		c.mu.Unlock()
 	}
 
 	sessionDelta := agg.SessionCount - c.prevSessionCount
@@ -370,6 +379,24 @@ func (c *Collector) Summary() *AggregateSummary {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.latest
+}
+
+// AgentErrorStreaks returns the per-agent consecutive model-call failure
+// streaks computed on the last scan (see BobAgentErrorStreaks). nil until a
+// scan of a configured bob sessions dir has completed — callers (the
+// heartbeat) forward that nil as "not measured", never as "no failures".
+// The returned map is a copy.
+func (c *Collector) AgentErrorStreaks() map[string]int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.errorStreaks == nil {
+		return nil
+	}
+	out := make(map[string]int, len(c.errorStreaks))
+	for k, v := range c.errorStreaks {
+		out[k] = v
+	}
+	return out
 }
 
 func CollectFromDir(sessionsDir string, agentDetector func(firstMsg string) string) (*AggregateSummary, error) {

--- a/src/pkg/tokens/error_streak.go
+++ b/src/pkg/tokens/error_streak.go
@@ -1,0 +1,210 @@
+package tokens
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Per-agent model-call error streaks (#5577; the demotion-signal half of
+// #5338).
+//
+// The signal: an agent whose CLI keeps RUNNING turns while EVERY model call
+// dies produces no usage and no output, yet reports green — the bobshell
+// opus-4-6 crash loop shape, where the hive's only write-capable agent was
+// dead for 4+ days behind a generic "no write" chip. The strongest artifact
+// the spoke already records for this is the bobshell chat recording itself:
+// every kick appends a user turn, and a SUCCESSFUL call appends an assistant
+// reply carrying a usage block (tokens.input/output) — so a run of trailing
+// user turns with no usage-bearing reply IS the consecutive-failure streak,
+// with per-turn granularity and per-agent attribution via the same
+// trustedFolders projectHash mapping the token scanner uses.
+//
+// Why not the alternatives:
+//   - .bob-errors/ logs are direct evidence but free-form text the spoke has
+//     never parsed; counting lines conflates one multi-line stack trace with
+//     N failures, and the format is version-dependent.
+//   - CLI exit tracking misses this class entirely — the CLI stays up and the
+//     agent stays green while every call inside it dies (#5338's exact shape).
+
+const (
+	// errorStreakGrace ignores the newest UNANSWERED turn(s) younger than
+	// this: a kick delivered moments ago legitimately has no reply yet, and
+	// counting it would flag every agent mid-turn. An assistant reply that
+	// explicitly recorded zero usage is a completed failure and is counted
+	// regardless of age.
+	errorStreakGrace = 10 * time.Minute
+
+	// errorStreakMaxAge bounds how stale a streak may be and still be
+	// reported: if the newest failed turn is older than this, the agent is
+	// simply idle (or was fixed) and the streak is history, not a live fault.
+	errorStreakMaxAge = 24 * time.Hour
+
+	// maxErrorStreakPerAgent caps the reported count. The hub only needs
+	// "N consecutive ≥ threshold"; an unbounded number from a week-long crash
+	// loop adds nothing but payload risk.
+	maxErrorStreakPerAgent = 10_000
+)
+
+// bobTurn is one user-initiated model turn reconstructed from a chat
+// recording: when it happened and whether a usage-bearing assistant reply
+// ever answered it.
+type bobTurn struct {
+	at time.Time
+	// answered is true once ANY assistant reply followed the user turn
+	// (successful or not); success is true only when that reply carried
+	// real token usage — the proof the model call actually completed.
+	answered bool
+	success  bool
+}
+
+// BobAgentErrorStreaks scans bobshell chat recordings under bobHomeDir
+// (the same tmp/*/chats/*.json files the token scanner reads) and returns,
+// per agent, the count of CONSECUTIVE most-recent turns whose model call
+// produced no usage — either an assistant reply that recorded zero tokens,
+// or a user turn (older than errorStreakGrace) that never received a reply
+// at all, which is what a call that crashes before responding leaves behind.
+//
+// Agents whose recordings never carry an explicit usage block anywhere in the
+// window are skipped: an estimation-era format that records no usage for
+// SUCCESSFUL calls either would make every turn look failed. Streaks whose
+// newest failure is older than errorStreakMaxAge are dropped as stale. The
+// result is always non-nil (an empty map means "measured, no streaks") so
+// callers can tell a clean fleet from a scan that never ran.
+func BobAgentErrorStreaks(bobHomeDir string, now time.Time) map[string]int {
+	out := make(map[string]int)
+	if bobHomeDir == "" {
+		return out
+	}
+
+	matches, err := filepath.Glob(filepath.Join(bobHomeDir, "tmp", "*", "chats", "*.json"))
+	if err != nil {
+		return out
+	}
+	agentsByHash := bobTrustedAgentsByProjectHash(bobHomeDir)
+	cutoff := now.Add(-maxBobSessionAge)
+
+	type agentTrace struct {
+		turns []bobTurn
+		// usageCapable is true once any message in any of this agent's
+		// sessions carried an explicit usage structure (even all-zero):
+		// the format proves usage WOULD be recorded on success.
+		usageCapable bool
+	}
+	traces := make(map[string]*agentTrace)
+
+	// Sessions sort by first-activity so cross-session turn order is
+	// chronological per agent (one agent's sessions are sequential in
+	// practice; recordings within a file are already ordered).
+	type sessRec struct {
+		agent    string
+		start    int64
+		turns    []bobTurn
+		hasUsage bool
+	}
+	var sessions []sessRec
+
+	for _, path := range matches {
+		sess, err := parseBobChatFile(path)
+		if err != nil || sess == nil || len(sess.Messages) == 0 {
+			continue
+		}
+		last := bobSessionLastActive(sess)
+		if last > 0 && time.UnixMilli(last).Before(cutoff) {
+			continue
+		}
+		fallbackTS := time.UnixMilli(last)
+
+		projectHash := strings.TrimSpace(sess.ProjectHash)
+		if projectHash == "" {
+			projectHash = extractBobProjectHash(path)
+		}
+		agentName := bobAgentName(projectHash, agentsByHash)
+
+		rec := sessRec{agent: agentName, start: bobSessionFirstActive(sess)}
+		for i := range sess.Messages {
+			msg := &sess.Messages[i]
+			ts := fallbackTS
+			if t, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(msg.Timestamp)); err == nil {
+				ts = t
+			}
+			switch msg.effectiveType() {
+			case "user":
+				rec.turns = append(rec.turns, bobTurn{at: ts})
+			case "bob-shell", "assistant":
+				if msg.Tokens != nil || msg.Usage != nil {
+					rec.hasUsage = true
+				}
+				in, out2, _ := msg.effectiveTokensReal()
+				if len(rec.turns) > 0 {
+					t := &rec.turns[len(rec.turns)-1]
+					t.answered = true
+					if in > 0 || out2 > 0 {
+						t.success = true
+					}
+					// A reply's own timestamp is the better "when did this
+					// turn conclude" marker than the kick's.
+					if !ts.IsZero() {
+						t.at = ts
+					}
+				}
+			}
+		}
+		if len(rec.turns) > 0 {
+			sessions = append(sessions, rec)
+		}
+	}
+
+	sort.SliceStable(sessions, func(i, j int) bool { return sessions[i].start < sessions[j].start })
+	for _, rec := range sessions {
+		tr := traces[rec.agent]
+		if tr == nil {
+			tr = &agentTrace{}
+			traces[rec.agent] = tr
+		}
+		tr.turns = append(tr.turns, rec.turns...)
+		tr.usageCapable = tr.usageCapable || rec.hasUsage
+	}
+
+	for agentName, tr := range traces {
+		if !tr.usageCapable {
+			continue
+		}
+		streak, newest := trailingFailureStreak(tr.turns, now)
+		if streak == 0 {
+			continue
+		}
+		if now.Sub(newest) > errorStreakMaxAge {
+			continue
+		}
+		if streak > maxErrorStreakPerAgent {
+			streak = maxErrorStreakPerAgent
+		}
+		out[agentName] = streak
+	}
+	return out
+}
+
+// trailingFailureStreak counts consecutive FAILED turns from the tail of the
+// timeline, stopping at the first success. Unanswered turns younger than
+// errorStreakGrace are skipped (still in flight, not evidence either way).
+// Returns the streak and the timestamp of its newest counted failure.
+func trailingFailureStreak(turns []bobTurn, now time.Time) (int, time.Time) {
+	streak := 0
+	var newest time.Time
+	for i := len(turns) - 1; i >= 0; i-- {
+		t := turns[i]
+		if t.success {
+			break
+		}
+		if !t.answered && now.Sub(t.at) < errorStreakGrace {
+			continue // in-flight turn: not a failure yet
+		}
+		streak++
+		if t.at.After(newest) {
+			newest = t.at
+		}
+	}
+	return streak, newest
+}

--- a/src/pkg/tokens/error_streak_test.go
+++ b/src/pkg/tokens/error_streak_test.go
@@ -1,0 +1,185 @@
+package tokens
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Helpers building a synthetic bob home: trustedFolders.json maps a folder to
+// its basename (the agent), and chat recordings live under
+// tmp/<sha256(folder)>/chats/.
+
+func writeBobHome(t *testing.T, agents map[string]string) string {
+	t.Helper()
+	home := t.TempDir()
+	folders := map[string]string{}
+	for folder := range agents {
+		folders[folder] = "trusted"
+	}
+	b, err := json.Marshal(folders)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "trustedFolders.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func writeBobChat(t *testing.T, home, folder, sessionID string, sess map[string]any) {
+	t.Helper()
+	sum := sha256.Sum256([]byte(folder))
+	hash := hexLower(sum[:])
+	dir := filepath.Join(home, "tmp", hash, "chats")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sess["projectHash"] = hash
+	b, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sessionID+".json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ts(base time.Time, minutes int) string {
+	return base.Add(time.Duration(minutes) * time.Minute).Format(time.RFC3339Nano)
+}
+
+// The #5338 shape: an agent whose earlier turns carried real usage, then every
+// later call died — some recorded as zero-token replies, some as kicks that
+// never got a reply at all. The streak counts the consecutive tail failures
+// and stops at the last success.
+func TestBobAgentErrorStreaks_CrashLoopCounted(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	base := now.Add(-3 * time.Hour)
+	folder := "/data/agents/quality"
+	home := writeBobHome(t, map[string]string{folder: "quality"})
+
+	writeBobChat(t, home, folder, "s1", map[string]any{
+		"sessionId":   "s1",
+		"startTime":   ts(base, 0),
+		"lastUpdated": ts(base, 120),
+		"messages": []map[string]any{
+			// A successful turn: usage recorded.
+			{"type": "user", "timestamp": ts(base, 0), "content": "kick 1"},
+			{"type": "bob-shell", "timestamp": ts(base, 1), "model": "premium",
+				"tokens": map[string]int64{"input": 100, "output": 20}},
+			// Failure recorded as an explicit zero-usage reply.
+			{"type": "user", "timestamp": ts(base, 30), "content": "kick 2"},
+			{"type": "bob-shell", "timestamp": ts(base, 31), "model": "premium",
+				"tokens": map[string]int64{"input": 0, "output": 0}},
+			// Failures recorded as kicks with no reply at all (the call
+			// crashed before responding).
+			{"type": "user", "timestamp": ts(base, 60), "content": "kick 3"},
+			{"type": "user", "timestamp": ts(base, 90), "content": "kick 4"},
+		},
+	})
+
+	got := BobAgentErrorStreaks(home, now)
+	if got["quality"] != 3 {
+		t.Fatalf("streak = %v, want quality:3", got)
+	}
+}
+
+// A trailing unanswered turn younger than the grace window is an in-flight
+// kick, not a failure — but an explicit zero-usage reply counts regardless.
+func TestBobAgentErrorStreaks_InFlightTurnNotCounted(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	base := now.Add(-time.Hour)
+	folder := "/data/agents/scanner"
+	home := writeBobHome(t, map[string]string{folder: "scanner"})
+
+	writeBobChat(t, home, folder, "s1", map[string]any{
+		"sessionId":   "s1",
+		"startTime":   ts(base, 0),
+		"lastUpdated": now.Format(time.RFC3339Nano),
+		"messages": []map[string]any{
+			{"type": "user", "timestamp": ts(base, 0), "content": "kick"},
+			{"type": "bob-shell", "timestamp": ts(base, 1),
+				"tokens": map[string]int64{"input": 50, "output": 10}},
+			// Fresh kick, no reply yet: must not be flagged.
+			{"type": "user", "timestamp": now.Add(-2 * time.Minute).Format(time.RFC3339Nano), "content": "kick"},
+		},
+	})
+
+	if got := BobAgentErrorStreaks(home, now); got["scanner"] != 0 {
+		t.Fatalf("in-flight turn counted as failure: %v", got)
+	}
+}
+
+// A streak whose newest failure is older than a day is history (the agent is
+// idle or was fixed), and an agent whose recordings never carry an explicit
+// usage structure (estimation-era format) must be skipped entirely — in that
+// format a SUCCESSFUL call records no usage either, so every turn would look
+// failed.
+func TestBobAgentErrorStreaks_StaleAndIncapableSkipped(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour)
+	stale := "/data/agents/stale"
+	legacy := "/data/agents/legacy"
+	home := writeBobHome(t, map[string]string{stale: "stale", legacy: "legacy"})
+
+	writeBobChat(t, home, stale, "s1", map[string]any{
+		"sessionId":   "s1",
+		"startTime":   ts(old, 0),
+		"lastUpdated": ts(old, 30),
+		"messages": []map[string]any{
+			{"type": "user", "timestamp": ts(old, 0), "content": "kick"},
+			{"type": "bob-shell", "timestamp": ts(old, 1),
+				"tokens": map[string]int64{"input": 10, "output": 5}},
+			{"type": "user", "timestamp": ts(old, 20), "content": "kick"},
+			{"type": "bob-shell", "timestamp": ts(old, 21),
+				"tokens": map[string]int64{"input": 0, "output": 0}},
+		},
+	})
+	// Legacy format: turns with content but no tokens/usage structures at all.
+	writeBobChat(t, home, legacy, "s2", map[string]any{
+		"sessionId":   "s2",
+		"startTime":   ts(now.Add(-time.Hour), 0),
+		"lastUpdated": ts(now.Add(-time.Hour), 30),
+		"messages": []map[string]any{
+			{"type": "user", "timestamp": ts(now.Add(-time.Hour), 0), "content": "kick"},
+			{"type": "bob-shell", "timestamp": ts(now.Add(-time.Hour), 1), "content": "reply"},
+		},
+	})
+
+	got := BobAgentErrorStreaks(home, now)
+	if len(got) != 0 {
+		t.Fatalf("stale/legacy streaks reported: %v", got)
+	}
+}
+
+// The result is always a measurement (non-nil), and a healthy agent reports
+// no entry at all rather than a zero.
+func TestBobAgentErrorStreaks_HealthyIsAbsent(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	base := now.Add(-time.Hour)
+	folder := "/data/agents/healthy"
+	home := writeBobHome(t, map[string]string{folder: "healthy"})
+
+	writeBobChat(t, home, folder, "s1", map[string]any{
+		"sessionId":   "s1",
+		"startTime":   ts(base, 0),
+		"lastUpdated": ts(base, 10),
+		"messages": []map[string]any{
+			{"type": "user", "timestamp": ts(base, 0), "content": "kick"},
+			{"type": "bob-shell", "timestamp": ts(base, 1),
+				"tokens": map[string]int64{"input": 100, "output": 40}},
+		},
+	})
+
+	got := BobAgentErrorStreaks(home, now)
+	if got == nil {
+		t.Fatal("result must be a non-nil measurement")
+	}
+	if _, ok := got["healthy"]; ok {
+		t.Fatalf("healthy agent flagged: %v", got)
+	}
+}


### PR DESCRIPTION
First of three PRs implementing the /fleet remediation-hints RFC. This one adds the **spoke detectors and heartbeat plumbing**; PR2 maps them into the health verdict's `Remediation` hint, PR3 renders them on /fleet and the spoke dashboard.

## New heartbeat signals (spoke → hub)

Three silent-failure classes the 2026-09-01 fleet audit could only find by exec'ing into pods:

| Field | Detector |
|---|---|
| `agent_error_streaks` (map agent→int) | consecutive failed model calls per agent (the #5338 bobshell crash-loop class) |
| `consent_wedged` (list) | agents whose kick path hit a consent-screen restart in the last hour (recorded at the two restart-before-kick sites that already log `consent_screen=true`) |
| `no_cadence_agents` (list) | enabled, governor-kickable agents with **no cadence in any mode** and **no kick ever** |

Budget exhaustion (`budget_exhausted` / `budget_current_spend` / `budget_limit`) already rides the beat from the quadrant work and is reused as-is — the RFC's `BudgetSpend` is the existing `BudgetCurrentSpend`, sourced from the same governor state behind the "budget exhausted — suppressing kicks" log line. No duplicate field added.

## Error-streak signal: which artifact, and why

Chosen: **the bobshell chat recordings the token scanner already parses** (`pkg/tokens`). A successful call appends an assistant reply carrying a usage block; a failed call leaves either an explicit zero-usage reply or a kick with no reply at all. So the count of consecutive trailing turns with no usage-bearing reply IS the per-agent failure streak, with per-turn granularity and the scanner's existing trustedFolders attribution. Guards: in-flight grace (10 min) for the newest unanswered turn, 24 h staleness bound, and estimation-era recordings (no usage structure anywhere) are skipped so old formats can't fake a streak.

Rejected alternatives: `.bob-errors/` logs are direct evidence but free-form, version-dependent text the spoke has never parsed — counting lines conflates one multi-line stack trace with N failures; CLI exit tracking misses the class entirely (the CLI stays up and the agent stays green while every call inside it dies — #5338's exact shape).

## Conventions

- Mirrors the `PRsMerged90d` discipline in `handleHeartbeat`: sanitize (identifier sanitizer on names), clamp (counts to `maxAgentErrorStreak`, collections to `maxRemediationAgents` = the agent-list cap), carry forward on minimal beats.
- One refinement over the count pointers: these fields omit `omitempty`, so **nil = not measured** (carried forward) while a **measured all-clear = empty non-nil** value that overwrites — a recovered hive clears its own alarm instead of a stale wedge living forever on the carry-forward.
- Wired into **both** heartbeat build sites (regular beat + the minimal upgrading beat; all three reads are cheap in-memory).

## Tests

- `TestHeartbeatRemediationSignals_RoundTrip`, `_CarryForwardAndClear`, `_SanitizeAndClamp`, `TestSanitizeRemediationSignals_Bounds` (pkg/hub)
- `TestBobAgentErrorStreaks_CrashLoopCounted`, `_InFlightTurnNotCounted`, `_StaleAndIncapableSkipped`, `_HealthyIsAbsent` (pkg/tokens)
- `TestConsentWedgeTracker_WindowAndOrdering`, `_EmptyIsNonNil`, `TestManagerConsentWedge_RecordAndExpire` (pkg/agent)
- `TestNoCadenceAgents`, `_ClearedByAnyKick`, `_EmptyIsNonNil`, `_ReplicaUsesBaseCadence` (pkg/governor)

`gofmt` clean; `go vet` clean on all four touched packages.

Refs #5577

🤖 Generated with [Claude Code](https://claude.com/claude-code)