### PR TITLE
✨ feat(hub): remediation hints + distinct detector states on the health verdict (#5577, 2/3)

### DIFF
--- a/src/pkg/hub/health_verdict.go
+++ b/src/pkg/hub/health_verdict.go
@@ -60,12 +60,39 @@ type HealthVerdict struct {
 	// QueuedWork is the actionable backlog (issues+PRs) that output would drain;
 	// zero means "nothing to do", which makes "no output" healthy.
 	QueuedWork int `json:"queuedWork"`
+	// Remediation is the one-line "do this, there" hint for a non-green
+	// verdict (#5577) — see remediation.go for the signature→action map.
+	// ALWAYS nil on green: a healthy hive gets no instruction.
+	Remediation *Remediation `json:"remediation,omitempty"`
+
+	// cause is the machine-readable signature that produced this verdict
+	// (remediation.go's cause* tokens). Unexported: it exists so the
+	// remediation mapping and the handleMyHives link enrichment switch on a
+	// token instead of string-matching the human reason.
+	cause string
+	// staleOutput marks the two bandFreshness red shapes ("no <verb> in Nh" /
+	// "no <verb> output") — the GENERIC no-output reds that the error-streak
+	// signature is allowed to re-explain. Precondition reds (App, budget,
+	// login) never set it, which is what makes them win by construction.
+	staleOutput bool
 }
 
 // hiveHealthFor computes the verdict for one registry entry. rollup is the
 // already-computed agent fleet rollup (Known/Running/Expected/Problems);
 // queuedWork is ActionableIssues+ActionablePRs; app is the GitHub App health.
+//
+// It layers three passes (#5577): the banded base verdict, then the detector
+// states (error-streak re-explains a generic no-output red; consent-wedge and
+// no-cadence demote green to amber), then the remediation hint mapping — so
+// every non-green verdict that matches a known signature also names its fix.
 func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth, queuedWork int, now time.Time) HealthVerdict {
+	v := hiveHealthBase(e, rollup, app, queuedWork, now)
+	v = applyDetectorStates(v, e)
+	attachRemediation(&v, e)
+	return v
+}
+
+func hiveHealthBase(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth, queuedWork int, now time.Time) HealthVerdict {
 	v := HealthVerdict{QueuedWork: queuedWork}
 
 	// --- Unknown gates first: never claim health for a hive we can't see. ---
@@ -92,6 +119,7 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 	if e.ACMMLevel > acmmInceptionMax {
 		if app.Bucket == ghAppBucketBroken {
 			v.State = HealthStateRed
+			v.cause = causeAppBroken
 			// Name the specific failure when the spoke reported one —
 			// "repo-not-covered" (App installed but this repo not ticked) needs
 			// a completely different remedy than a missing/invalid key.
@@ -113,6 +141,7 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 		// entirely different from debugging a stuck agent.
 		if e.BudgetExhausted != nil && *e.BudgetExhausted {
 			v.State = HealthStateRed
+			v.cause = causeBudgetExhausted
 			// Separate the two ways a budget closes the gate, because the
 			// remedies are unrelated (#5508). A spoke whose LIMIT is too small
 			// to fund one model call never spent anything — waiting for the
@@ -120,8 +149,19 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 			// number. Collapsing that into the generic "exhausted" chip is what
 			// let limits of 5, 50 and 1000 tokens sit unnoticed on the fleet.
 			if e.BudgetLimit != nil && config.BudgetLimitBelowFloor(*e.BudgetLimit) {
+				v.cause = causeBudgetMisconfigured
 				v.Reason = fmt.Sprintf("budget limit misconfigured (%d tokens) — agents halted, window reset will not help",
 					*e.BudgetLimit)
+				return v
+			}
+			// Name the numbers when the beat carried them (#5577): "spend X
+			// of Y" tells the operator at a glance whether this is a rolled
+			// window away from healing or a 3x blowout that needs a bigger
+			// limit — the 2026-09-01 audit's spend-3x-limit case read as
+			// generic quiet without them.
+			if e.BudgetCurrentSpend != nil && e.BudgetLimit != nil && *e.BudgetLimit > 0 {
+				v.Reason = fmt.Sprintf("budget exhausted — spend %d of %d, kicks suppressed",
+					*e.BudgetCurrentSpend, *e.BudgetLimit)
 				return v
 			}
 			v.Reason = "budget exhausted — agents halted"
@@ -136,6 +176,7 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 				// Every blocked agent is wedged at a login prompt: name the one
 				// actionable cause (operator re-login) instead of the generic
 				// count — the EPM/alchemy at-a-glance case.
+				v.cause = causeLoginStuck
 				v.Reason = fmt.Sprintf("%d agent(s) stuck at login — re-login needed", rollup.LoginStuck)
 			case rollup.DeadOrGone == rollup.Problems:
 				// Katamari/ibm-aiops-orchestrator live shapes: failed/dead agents
@@ -277,6 +318,8 @@ func hiveHealthFor(e RegistryEntry, rollup agentFleetRollup, app GitHubAppHealth
 		// green: the hive is healthy but a human action is pending.
 		if verdict.State == HealthStateRed && e.HoldTotal != nil && *e.HoldTotal > 0 {
 			verdict.State = HealthStateAmber
+			verdict.cause = causeHoldStale
+			verdict.staleOutput = false
 			verdict.Reason = fmt.Sprintf("awaiting human review — %d held for approval", *e.HoldTotal)
 		}
 		return verdict
@@ -360,11 +403,13 @@ func bandFreshness(v HealthVerdict, last time.Time, ok bool, queuedWork int, now
 		}
 	case ok:
 		v.State = HealthStateRed
+		v.staleOutput = true
 		// TrimSuffix: humanizeAge says "18h ago" for badge use; "no create in
 		// 18h ago" is not English, so drop the suffix here.
 		v.Reason = fmt.Sprintf("no %s in %s (%d queued)", verb, strings.TrimSuffix(humanizeAge(now.Sub(last)), " ago"), queuedWork)
 	default:
 		v.State = HealthStateRed
+		v.staleOutput = true
 		v.Reason = fmt.Sprintf("no %s output (%d queued)", verb, queuedWork)
 	}
 	return v

--- a/src/pkg/hub/remediation.go
+++ b/src/pkg/hub/remediation.go
@@ -1,0 +1,226 @@
+package hub
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Remediation hints (#5577): every non-green health verdict that matches a
+// known failure signature carries a one-line "do this" + where to do it,
+// rendered under the WHY chip on /fleet. The map below is the RFC's
+// signature→action table; precedence is BY CONSTRUCTION — the base verdict
+// returns on the first matching precondition (App broken, then provider
+// limit, then budget, then blocked agents), so a budget-exhausted red can
+// never be shadowed by the generic no-output red, and App-broken beats
+// everything. A green verdict NEVER carries a hint: a healthy hive gets no
+// instruction, and the detector ambers below only ever demote green, never
+// mask a red.
+
+// Remediation is the operator hint attached to a non-green HealthVerdict.
+type Remediation struct {
+	// Action is the one-line "do this" instruction.
+	Action string `json:"action"`
+	// Surface names WHERE the action happens ("spoke dashboard", "GitHub
+	// App settings", ...) for rows whose Link cannot be resolved.
+	Surface string `json:"surface,omitempty"`
+	// Link is a direct URL to the surface when the hub can build one.
+	Link string `json:"link,omitempty"`
+}
+
+// Verdict cause signatures. Set where the verdict's reason is decided so the
+// remediation map switches on tokens, never on human-facing strings.
+const (
+	causeAppBroken           = "app-broken"
+	causeLoginStuck          = "login-stuck"
+	causeBudgetExhausted     = "budget-exhausted"
+	causeBudgetMisconfigured = "budget-misconfigured"
+	causeErrorStreak         = "error-streak"
+	causeConsentWedge        = "consent-wedge"
+	causeNoCadence           = "no-cadence"
+	causeHoldStale           = "hold-stale"
+	causeChannelLag          = "channel-lag"
+)
+
+// errorStreakRedThreshold is how many consecutive failed model calls turn a
+// generic no-output red into the named "model calls failing" red. Three
+// matches the spoke's own consecutive-failure convention (inference-auth
+// latches at three): one failure is noise, three in a row is a pattern.
+const errorStreakRedThreshold = 3
+
+// applyDetectorStates layers the #5577 detector signals onto the base
+// verdict:
+//
+//   - error-streak RED re-explains a GENERIC stale-output red (and only
+//     that): turns ran, every model call died, and "no write in 4d" pointed
+//     at the wrong thing (#5338). Precondition reds — App, provider, budget,
+//     login — keep their reason; they gate the output stream upstream of the
+//     model calls and already name a more fundamental fix.
+//   - consent-wedge and no-cadence demote GREEN to amber: output may still
+//     look acceptable, but a named agent is looping on a consent screen /
+//     will never be kicked, and only an operator can fix either. They never
+//     touch red or amber verdicts — a harder fault stays the headline.
+//
+// L1 (Inception) and non-reporting hives are exempt: no output is expected,
+// so a config gap is not a health fault there (the base verdict's spine).
+func applyDetectorStates(v HealthVerdict, e RegistryEntry) HealthVerdict {
+	if !e.Online || e.ACMMLevel <= acmmInceptionMax {
+		return v
+	}
+
+	if v.State == HealthStateRed && v.staleOutput {
+		if name, streak := topErrorStreak(e.AgentErrorStreaks); streak >= errorStreakRedThreshold {
+			v.cause = causeErrorStreak
+			v.Reason = fmt.Sprintf("agent %s model calls failing (%d consecutive) — pin a working model", name, streak)
+			return v
+		}
+	}
+
+	if v.State != HealthStateGreen {
+		return v
+	}
+	if len(e.ConsentWedged) > 0 {
+		v.State = HealthStateAmber
+		v.cause = causeConsentWedge
+		v.Reason = fmt.Sprintf("agent(s) %s stuck at Copilot consent — restarting in a loop", nameList(e.ConsentWedged))
+		return v
+	}
+	if len(e.NoCadenceAgents) > 0 {
+		v.State = HealthStateAmber
+		v.cause = causeNoCadence
+		v.Reason = fmt.Sprintf("agent(s) %s enabled but never kicked — set cadences", nameList(e.NoCadenceAgents))
+		return v
+	}
+	return v
+}
+
+// topErrorStreak returns the agent with the longest streak (ties broken by
+// name so the verdict is deterministic across map iterations).
+func topErrorStreak(streaks map[string]int) (string, int) {
+	best, bestName := 0, ""
+	for name, streak := range streaks {
+		if streak > best || (streak == best && best > 0 && name < bestName) {
+			best, bestName = streak, name
+		}
+	}
+	return bestName, best
+}
+
+// channelLagMinCommits is how far behind its tracked channel's head a spoke
+// must be before the digest-lag amber fires. One commit is a rollout in
+// flight; two or more with no upgrade running means the channel moved and the
+// spoke did not follow (the moving-tag/no-repull class).
+const channelLagMinCommits = 2
+
+// applyChannelLag demotes a GREEN verdict to amber when the entry carries the
+// fleet-divergence channel info AND the spoke provably lags its channel:
+// tracking "stable", measurably behind the stable-v4 head, and not currently
+// upgrading. Called from handleMyHives — TrackedChannel and the behind-count
+// live on MyHiveEntry, not the registry entry — and skipped entirely (per the
+// RFC) when either signal is absent. Never touches red/amber: a harder fault
+// stays the headline.
+func applyChannelLag(v *HealthVerdict, trackedChannel string, commitsBehind *int, upgrading bool) {
+	if v == nil || v.State != HealthStateGreen {
+		return
+	}
+	if trackedChannel != "stable" || commitsBehind == nil || upgrading {
+		return
+	}
+	if *commitsBehind < channelLagMinCommits {
+		return
+	}
+	v.State = HealthStateAmber
+	v.cause = causeChannelLag
+	v.Reason = fmt.Sprintf("spoke lags its channel — %d commits behind %s", *commitsBehind, trackedChannel)
+	attachRemediation(v, RegistryEntry{})
+}
+
+// attachRemediation fills v.Remediation from the cause signature — the RFC's
+// signature→action table. Green never gets a hint; an unrecognized cause
+// (provider limit, agents down, advisory stale, ...) gets none either, so a
+// hint is only ever shown when it is specifically true.
+func attachRemediation(v *HealthVerdict, e RegistryEntry) {
+	if v.State == HealthStateGreen || v.State == HealthStateUnknown || v.cause == "" {
+		return
+	}
+	dash := strings.TrimRight(strings.TrimSpace(e.DashboardURL), "/")
+	link := func(path string) string {
+		if dash == "" {
+			return ""
+		}
+		return dash + path
+	}
+	switch v.cause {
+	case causeAppBroken:
+		// The install URL is cluster-scoped (GHE vs github.com), so
+		// handleMyHives enriches Link afterwards via the cluster's GitHub
+		// config; the hint itself never guesses a forge.
+		v.Remediation = &Remediation{
+			Action:  "Install or repair the GitHub App for this repo",
+			Surface: "GitHub App settings",
+		}
+	case causeLoginStuck:
+		v.Remediation = &Remediation{
+			Action:  "Copilot device-flow login on the spoke dashboard",
+			Surface: "spoke dashboard /login",
+			Link:    link("/login"),
+		}
+	case causeBudgetExhausted, causeBudgetMisconfigured:
+		v.Remediation = &Remediation{
+			Action:  "Raise or reset the budget limit (Settings → Budget)",
+			Surface: "spoke dashboard settings",
+			Link:    link(""),
+		}
+	case causeErrorStreak:
+		v.Remediation = &Remediation{
+			Action:  "Pin a working model on the agent card",
+			Surface: "spoke dashboard agent card",
+			Link:    link(""),
+		}
+	case causeConsentWedge:
+		v.Remediation = &Remediation{
+			Action:  "Complete the Copilot consent flow on the live pod dashboard",
+			Surface: "spoke dashboard",
+			Link:    link(""),
+		}
+	case causeNoCadence:
+		v.Remediation = &Remediation{
+			Action:  "Set cadences on the agent card",
+			Surface: "spoke dashboard agent card",
+			Link:    link(""),
+		}
+	case causeHoldStale:
+		v.Remediation = &Remediation{
+			Action:  "Review the needs-human queue",
+			Surface: "repo PR list",
+			Link:    holdQueueLink(e),
+		}
+	case causeChannelLag:
+		v.Remediation = &Remediation{
+			Action:  "Spoke lags its channel — check auto-upgrade / force rollout",
+			Surface: "hub fleet version controls",
+		}
+	}
+}
+
+// holdQueueLink builds the PR-list URL for the hive's first repo — the queue
+// the hold-labeled work is parked in. Empty when the entry has no org/repo
+// (the hint's Surface still tells the operator where to look).
+func holdQueueLink(e RegistryEntry) string {
+	org := strings.TrimSpace(e.Org)
+	if org == "" || len(e.Repos) == 0 {
+		return ""
+	}
+	repo := strings.TrimSpace(e.Repos[0])
+	if repo == "" {
+		return ""
+	}
+	host := strings.TrimSpace(e.GitHubHost)
+	if host == "" {
+		host = "github.com"
+	}
+	path := repo
+	if !strings.Contains(repo, "/") {
+		path = org + "/" + repo
+	}
+	return "https://" + host + "/" + path + "/pulls"
+}

--- a/src/pkg/hub/remediation_test.go
+++ b/src/pkg/hub/remediation_test.go
@@ -1,0 +1,316 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// The #5577 signature→action table, one case per row, plus the precedence
+// rules the RFC fixes: budget-exhausted beats the generic no-output red,
+// App-broken beats everything, and a green verdict never carries a hint.
+
+// remEntry builds an online entry at the given level with one on-duty,
+// fully-granted agent so the freshness bands are exercised.
+func remEntry(level int) RegistryEntry {
+	return RegistryEntry{Online: true, ACMMLevel: level, DashboardURL: "https://spoke.example.com/", Agents: []AgentSummary{
+		{Name: "quality", State: agentStateRunning, Enabled: true, ExpectedActive: true,
+			CanOpenIssue: true, CanOpenPR: true, CanMerge: true},
+	}}
+}
+
+func TestRemediationPerSignature(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	rfc := func(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+	recent := rfc(now.Add(-1 * time.Hour))
+	oldTs := rfc(now.Add(-30 * time.Hour))
+	stale := func(e RegistryEntry) RegistryEntry { return withActivity(e, ractivity("o/r", oldTs, oldTs, "", "")) }
+	fresh := func(e RegistryEntry) RegistryEntry { return withActivity(e, ractivity("o/r", recent, recent, "", "")) }
+
+	tests := []struct {
+		name       string
+		entry      RegistryEntry
+		rollup     agentFleetRollup
+		app        GitHubAppHealth
+		queued     int
+		wantState  string
+		wantReason string // substring, "" = don't check
+		wantAction string // substring of Remediation.Action; "NONE" = no hint
+		wantLink   string // exact, "" = don't check
+	}{
+		{
+			name:       "App broken → install/repair hint",
+			entry:      stale(remEntry(4)),
+			rollup:     okRollup(),
+			app:        GitHubAppHealth{Bucket: ghAppBucketBroken},
+			queued:     5,
+			wantState:  HealthStateRed,
+			wantReason: "GitHub App",
+			wantAction: "Install or repair the GitHub App",
+		},
+		{
+			name:  "agents stuck at login → device-flow login hint with /login link",
+			entry: stale(remEntry(4)),
+			rollup: agentFleetRollup{Expected: 2, Running: 2, Known: 2,
+				Problems: 2, LoginStuck: 2},
+			app:        okApp(),
+			queued:     5,
+			wantState:  HealthStateRed,
+			wantReason: "stuck at login",
+			wantAction: "device-flow login",
+			wantLink:   "https://spoke.example.com/login",
+		},
+		{
+			name: "budget exhausted → own reason with spend X of Y + budget hint",
+			entry: func() RegistryEntry {
+				e := stale(remEntry(4))
+				e.BudgetExhausted = boolptr(true)
+				e.BudgetCurrentSpend = int64ptr(300_000_000)
+				e.BudgetLimit = int64ptr(100_000_000)
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     9,
+			wantState:  HealthStateRed,
+			wantReason: "budget exhausted — spend 300000000 of 100000000, kicks suppressed",
+			wantAction: "Raise or reset the budget limit",
+		},
+		{
+			name: "budget limit below floor → misconfigured reason, same budget hint",
+			entry: func() RegistryEntry {
+				e := stale(remEntry(4))
+				e.BudgetExhausted = boolptr(true)
+				e.BudgetLimit = int64ptr(50)
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     9,
+			wantState:  HealthStateRed,
+			wantReason: "misconfigured",
+			wantAction: "Raise or reset the budget limit",
+		},
+		{
+			name: "error streak → red names the agent and count, pin-a-model hint",
+			entry: func() RegistryEntry {
+				e := stale(remEntry(4))
+				e.AgentErrorStreaks = map[string]int{"quality": 17, "scanner": 1}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     28,
+			wantState:  HealthStateRed,
+			wantReason: "agent quality model calls failing (17 consecutive) — pin a working model",
+			wantAction: "Pin a working model",
+		},
+		{
+			name: "error streak below threshold → generic red, no hint",
+			entry: func() RegistryEntry {
+				e := stale(remEntry(4))
+				e.AgentErrorStreaks = map[string]int{"quality": 2}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     28,
+			wantState:  HealthStateRed,
+			wantReason: "no write",
+			wantAction: "NONE",
+		},
+		{
+			name: "consent wedge → amber demotes green, consent hint",
+			entry: func() RegistryEntry {
+				e := fresh(remEntry(4))
+				e.ConsentWedged = []string{"copilot-fixer"}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     4,
+			wantState:  HealthStateAmber,
+			wantReason: "copilot-fixer stuck at Copilot consent",
+			wantAction: "Complete the Copilot consent flow",
+		},
+		{
+			name: "no cadences → amber names the agents, set-cadences hint",
+			entry: func() RegistryEntry {
+				e := fresh(remEntry(4))
+				e.NoCadenceAgents = []string{"telemetry", "docs"}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     4,
+			wantState:  HealthStateAmber,
+			wantReason: "agent(s) telemetry, docs enabled but never kicked — set cadences",
+			wantAction: "Set cadences on the agent card",
+		},
+		{
+			name: "consent wedge outranks no-cadence when both fire",
+			entry: func() RegistryEntry {
+				e := fresh(remEntry(4))
+				e.ConsentWedged = []string{"copilot-fixer"}
+				e.NoCadenceAgents = []string{"telemetry"}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     4,
+			wantState:  HealthStateAmber,
+			wantReason: "Copilot consent",
+			wantAction: "Complete the Copilot consent flow",
+		},
+		{
+			name: "hold-stale amber keeps #5350's reason and gains the queue link",
+			entry: func() RegistryEntry {
+				e := stale(remEntry(4))
+				e.Org = "flashsystems"
+				e.Repos = []string{"ess"}
+				held := 14
+				e.HoldTotal = &held
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     28,
+			wantState:  HealthStateAmber,
+			wantReason: "awaiting human review — 14 held for approval",
+			wantAction: "Review the needs-human queue",
+			wantLink:   "https://github.com/flashsystems/ess/pulls",
+		},
+		{
+			// PRECEDENCE: budget-exhausted beats the generic no-output red AND
+			// the error-streak re-explanation — agents are halted upstream of
+			// any model call, so the streak is a symptom, not the cause.
+			name: "precedence: budget exhausted beats error streak and no-output",
+			entry: func() RegistryEntry {
+				e := stale(remEntry(4))
+				e.BudgetExhausted = boolptr(true)
+				e.BudgetCurrentSpend = int64ptr(300)
+				e.BudgetLimit = int64ptr(100_000_000)
+				e.AgentErrorStreaks = map[string]int{"quality": 50}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     9,
+			wantState:  HealthStateRed,
+			wantReason: "budget exhausted",
+			wantAction: "Raise or reset the budget limit",
+		},
+		{
+			// PRECEDENCE: App-broken beats everything.
+			name: "precedence: App broken beats budget, streaks and wedges",
+			entry: func() RegistryEntry {
+				e := stale(remEntry(4))
+				e.BudgetExhausted = boolptr(true)
+				e.BudgetLimit = int64ptr(100_000_000)
+				e.AgentErrorStreaks = map[string]int{"quality": 50}
+				e.ConsentWedged = []string{"copilot-fixer"}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        GitHubAppHealth{Bucket: ghAppBucketBroken},
+			queued:     9,
+			wantState:  HealthStateRed,
+			wantReason: "GitHub App",
+			wantAction: "Install or repair the GitHub App",
+		},
+		{
+			name:       "green never carries a hint",
+			entry:      fresh(remEntry(4)),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     4,
+			wantState:  HealthStateGreen,
+			wantAction: "NONE",
+		},
+		{
+			// L1 exemption: the detector ambers must not fault a hive whose
+			// level produces no output at all.
+			name: "L1 inception stays green even with detector signals",
+			entry: func() RegistryEntry {
+				e := remEntry(1)
+				e.NoCadenceAgents = []string{"telemetry"}
+				e.ConsentWedged = []string{"copilot-fixer"}
+				return e
+			}(),
+			rollup:     okRollup(),
+			app:        okApp(),
+			queued:     0,
+			wantState:  HealthStateGreen,
+			wantAction: "NONE",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := hiveHealthFor(tc.entry, tc.rollup, tc.app, tc.queued, now)
+			if v.State != tc.wantState {
+				t.Fatalf("state = %q (reason %q), want %q", v.State, v.Reason, tc.wantState)
+			}
+			if tc.wantReason != "" && !strings.Contains(v.Reason, tc.wantReason) {
+				t.Errorf("reason = %q, want substring %q", v.Reason, tc.wantReason)
+			}
+			if tc.wantAction == "NONE" {
+				if v.Remediation != nil {
+					t.Fatalf("unexpected remediation %+v on %q verdict", v.Remediation, v.State)
+				}
+				return
+			}
+			if v.Remediation == nil {
+				t.Fatalf("no remediation attached (state %q reason %q)", v.State, v.Reason)
+			}
+			if !strings.Contains(v.Remediation.Action, tc.wantAction) {
+				t.Errorf("action = %q, want substring %q", v.Remediation.Action, tc.wantAction)
+			}
+			if tc.wantLink != "" && v.Remediation.Link != tc.wantLink {
+				t.Errorf("link = %q, want %q", v.Remediation.Link, tc.wantLink)
+			}
+		})
+	}
+}
+
+// Digest-lag (#5577's channel row): only a GREEN verdict is demoted, only for
+// a spoke tracking "stable" that is measurably ≥2 commits behind with no
+// upgrade in flight — and it is skipped entirely when the divergence info is
+// absent.
+func TestApplyChannelLag(t *testing.T) {
+	behind := func(n int) *int { return &n }
+	green := func() *HealthVerdict { return &HealthVerdict{State: HealthStateGreen, Reason: "last write 1h ago"} }
+
+	v := green()
+	applyChannelLag(v, "stable", behind(3), false)
+	if v.State != HealthStateAmber || !strings.Contains(v.Reason, "3 commits behind stable") {
+		t.Fatalf("lagging spoke not demoted: %+v", v)
+	}
+	if v.Remediation == nil || !strings.Contains(v.Remediation.Action, "check auto-upgrade") {
+		t.Fatalf("channel-lag hint missing: %+v", v.Remediation)
+	}
+
+	for name, tc := range map[string]struct {
+		channel   string
+		behind    *int
+		upgrading bool
+	}{
+		"one commit is a rollout in flight": {"stable", behind(1), false},
+		"no divergence info reported":       {"stable", nil, false},
+		"not tracking a channel":            {"", behind(5), false},
+		"upgrade already running":           {"stable", behind(5), true},
+	} {
+		v := green()
+		applyChannelLag(v, tc.channel, tc.behind, tc.upgrading)
+		if v.State != HealthStateGreen || v.Remediation != nil {
+			t.Errorf("%s: green verdict touched: %+v", name, v)
+		}
+	}
+
+	// A red verdict is never re-explained by channel lag.
+	red := &HealthVerdict{State: HealthStateRed, Reason: "no write in 30h (7 queued)"}
+	applyChannelLag(red, "stable", behind(9), false)
+	if red.State != HealthStateRed || red.Remediation != nil {
+		t.Errorf("red verdict touched by channel lag: %+v", red)
+	}
+}

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3710,6 +3710,21 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			// just computed. Only for real (non-placeholder) hives with reported
 			// agents — a placeholder has nothing to produce.
 			verdict := hiveHealthFor(result[i].RegistryEntry, rollup, result[i].GitHubAppHealth, queuedWork, journeyNow)
+			// Digest-lag amber (#5577): the channel/behind-count divergence
+			// info lives on MyHiveEntry (TrackedChannel is hub-owned, the
+			// behind-count was computed just above), so this row of the
+			// signature table is applied here rather than in hiveHealthFor.
+			applyChannelLag(&verdict, result[i].TrackedChannel, result[i].CommitsBehindStableV4, result[i].Upgrading)
+			// The App-broken hint's install URL is cluster-scoped (a GHE
+			// cluster must never be handed a github.com link), so resolve it
+			// from this hive's cluster config — the same single URL builder
+			// the create-hive modal uses.
+			if verdict.cause == causeAppBroken && verdict.Remediation != nil {
+				if c, ok := s.clusters[result[i].ClusterID]; ok {
+					gh := clusterGitHubConfig(&c)
+					verdict.Remediation.Link = gh.AppInstallURL()
+				}
+			}
 			result[i].HealthVerdict = &verdict
 		}
 


### PR DESCRIPTION
Second of three PRs for the /fleet remediation-hints RFC. **Depends on #5579** (the detector fields) and is therefore based on its branch — I will retarget to `v4` once #5579 merges. PR3 (UI) follows.

## What this adds

`HealthVerdict` gains `Remediation *Remediation{Action, Surface, Link}`, filled from a cause-token signature→action map (`pkg/hub/remediation.go`) — never by string-matching the human reason:

| Signature | State | Hint |
|---|---|---|
| GitHub App broken | red (existing) | Install or repair the GitHub App → cluster-correct install URL (resolved in `handleMyHives` so a GHE hive never gets a github.com link) |
| Agents stuck at login | red (existing) | Copilot device-flow login → `<dashboard>/login` |
| Budget exhausted | red, **new reason** `budget exhausted — spend X of Y, kicks suppressed` (misconfigured-floor variant from #5508 unchanged) | Raise or reset the budget limit (Settings → Budget) |
| Error streak ≥3 | red, **new reason** `agent <name> model calls failing (N consecutive) — pin a working model` — re-explains only the GENERIC stale-output red | Pin a working model on the agent card |
| Consent wedge | **amber (demotes green)**, names the agents | Complete the Copilot consent flow on the live pod dashboard |
| No cadences | **amber (demotes green)** `agent(s) <names> enabled but never kicked — set cadences` | Set cadences on the agent card |
| Hold-stale | amber — keeps #5350's exact reason | Review the needs-human queue → first repo's `/pulls` |
| Digest ≠ tracked channel | **amber (demotes green)** when the entry carries `TrackedChannel` + `CommitsBehindStableV4` (≥2 behind, no upgrade in flight); **skipped when the divergence info is absent** | check auto-upgrade / force rollout |

## Precedence (tested)

By construction, not by ranking: the base verdict returns on the first matching precondition, so **App-broken beats everything**, **budget-exhausted beats the generic no-output red and the error-streak re-explanation** (agents are halted upstream of any model call), and the detector ambers only ever demote green — they never mask a red. **A green verdict never carries a hint.**

## Tests

Table-driven per signature in `TestRemediationPerSignature` (13 cases: every row above, both precedence cases, below-threshold streak → no hint, green → no hint, L1 exemption) plus `TestApplyChannelLag` (demotes green at ≥2 behind stable; skips 1-behind/absent-info/off-channel/upgrading; never touches red). Existing verdict tests (#5350 hold amber, #5508 misconfigured floor) pass unchanged — the "genuinely spent" wording only changes when the beat carries the spend number.

`gofmt` clean; `go vet ./pkg/hub/` clean.

Refs #5577

🤖 Generated with [Claude Code](https://claude.com/claude-code)