### PR TITLE
contribute: allow multiple concurrent sessions per GitHub account

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -61,6 +61,17 @@ const PI_ENV = BACKEND === 'pi' ? { ...process.env } : {};
 let piInvocationState = 'untested';
 const REASONING_EFFORT = process.env.AGENT_REASONING_EFFORT || '';
 const AGENT_ROLE = (process.env.HIVE_AGENT_ROLE || '').trim();
+// HIVE_SESSION — optional session label (multi-session-per-account). One GitHub
+// account has one contributor identity per hub, and the hub keys task
+// leases/cooldowns/ownership on that identity, so two relays under the same
+// account would collide on a single active-task slot. Declaring a distinct
+// session gives each relay an independent session-scoped identity
+// (ContributorID#session) on the hub while auth/tier stay per-account. Defaults
+// to the backend name so the common case — one relay per CLI backend under one
+// account — works with no extra config. Omitted only if explicitly emptied.
+const AGENT_SESSION = (process.env.HIVE_SESSION !== undefined
+  ? process.env.HIVE_SESSION
+  : BACKEND).trim();
 // Neutral directory both entrypoints launch the CLI from ($HOME). Used to pin
 // the cwd on relaunch; see launchCommandWithCwd for why the relay's own cwd is
 // the wrong answer in local mode.
@@ -3444,6 +3455,9 @@ function handleMessage(data, hub) {
         model: refreshDetectedModel(),
         reasoning_effort: effectiveReasoningEffort() || undefined,
         role: AGENT_ROLE,
+        // Multi-session-per-account: additive, optional. An older hub ignores
+        // this unknown field and treats the relay as a single session.
+        session: AGENT_SESSION || undefined,
         // #2547 declare half + #2567: additive, optional self-report of runtime
         // posture and protocol version. An older hub ignores these unknown fields.
         protocol_version: RELAY_PROTOCOL_VERSION,

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -78,6 +78,12 @@ type ContributorConnection struct {
 	ws              *websocket.Conn
 	profile         *ContributorProfile
 	cliBackend      string
+	// session is the OPTIONAL client-declared session label from auth_response
+	// (multi-session-per-account). Empty for a single-session contributor, which
+	// keeps identityOf() at the bare ContributorID. When set, identityOf()
+	// returns ContributorID#session so concurrent relays under one account get
+	// independent lease/assignment/failure slots. Sanitized at auth time.
+	session         string
 	model           string
 	reasoningEffort string
 	role            string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
@@ -236,6 +242,19 @@ type WSMessage struct {
 	// routing authority; Model remains the canonical selection transport.
 	Provider        string `json:"provider,omitempty"`
 	Model           string `json:"model,omitempty"`
+	// Session is an OPTIONAL client-declared session label (kubestellar/hive:
+	// multi-session-per-account). One GitHub account has ONE contributor profile
+	// (one ContributorID, one auth token, one trust tier), but a contributor may
+	// want to run several relays at once under that account — e.g. one per CLI
+	// backend (claude, agy, pi, kiro). All identity-keyed hub state (task leases,
+	// assignment cooldowns, failure streaks, ownership fences) keys on
+	// identityOf(); without a distinguisher those sessions would collide on a
+	// single active-task slot. A distinct Session yields a distinct
+	// session-scoped identity (ContributorID#session) for that state, while auth,
+	// tier, model admission and rate-limit accounting stay per-account. Additive
+	// and backward-compatible: omitted → identity is the bare ContributorID,
+	// exactly the previous single-session behavior. Sanitized/bounded before use.
+	Session         string `json:"session,omitempty"`
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	TaskID          string `json:"task_id,omitempty"`
 	// TaskGen is the assignment GENERATION / lease token for this task (kubestellar/
@@ -3329,6 +3348,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				ws:              conn,
 				profile:         profile,
 				cliBackend:      msg.CLIBackend,
+				session:         sanitizeSessionLabel(msg.Session),
 				model:           msg.Model,
 				reasoningEffort: msg.ReasoningEffort,
 				role:            requestedRole,
@@ -4773,14 +4793,47 @@ const (
 // registered ContributorID is preferred; GitHubUsername is the fallback for
 // connections whose profile predates or lacks an ID. Two WebSocket connections
 // opened by the same registered contributor therefore share one identity.
+// sanitizeSessionLabel bounds and cleans a client-declared session label before
+// it becomes part of a map key, log field, and UI string. Multi-session-per-
+// account: the label distinguishes concurrent relays under one GitHub account.
+// Only [A-Za-z0-9._-] survive (so the ContributorID#session key stays a single
+// clean token and cannot smuggle path/format characters); the result is capped
+// at 32 bytes. An empty or all-stripped label returns "", which identityOf
+// treats as the historical single-session case.
+func sanitizeSessionLabel(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		}
+		if b.Len() >= 32 {
+			break
+		}
+	}
+	return b.String()
+}
+
 func identityOf(c *ContributorConnection) string {
 	if c == nil || c.profile == nil {
 		return ""
 	}
-	if c.profile.ContributorID != "" {
-		return c.profile.ContributorID
+	base := c.profile.ContributorID
+	if base == "" {
+		base = c.profile.GitHubUsername
 	}
-	return c.profile.GitHubUsername
+	// Session-scoped identity (multi-session-per-account): a distinct session
+	// label lets concurrent relays under one account hold independent task
+	// leases/cooldowns/ownership. Empty session preserves the historical bare
+	// ContributorID key, so existing single-session contributors are unchanged.
+	if base != "" && c.session != "" {
+		return base + "#" + c.session
+	}
+	return base
 }
 
 // rateWindowCounts returns how many task assignments the given identity has been

--- a/src/pkg/dashboard/contribute_ws_session_identity_test.go
+++ b/src/pkg/dashboard/contribute_ws_session_identity_test.go
@@ -1,0 +1,69 @@
+package dashboard
+
+import "testing"
+
+// Multi-session-per-account (one GitHub account, several concurrent relays —
+// e.g. one per CLI backend). identityOf() is the key for task leases,
+// assignment cooldowns, failure streaks and ownership fences, so two sessions
+// under one account MUST resolve to distinct identities or they collide on a
+// single active-task slot. A contributor that declares no session keeps the
+// historical bare-ContributorID identity (backward compatibility).
+
+func TestIdentityOfSessionScoping(t *testing.T) {
+	profile := &ContributorProfile{GitHubUsername: "hanthor", ContributorID: "c-abc123", TrustTier: "contributor"}
+
+	bare := &ContributorConnection{profile: profile}
+	if got := identityOf(bare); got != "c-abc123" {
+		t.Fatalf("no session: identityOf = %q, want the bare ContributorID %q", got, "c-abc123")
+	}
+
+	claude := &ContributorConnection{profile: profile, session: "claude"}
+	agy := &ContributorConnection{profile: profile, session: "agy"}
+	if identityOf(claude) == identityOf(agy) {
+		t.Fatalf("two sessions under one account share an identity (%q) — they will collide on one task slot", identityOf(claude))
+	}
+	if got, want := identityOf(claude), "c-abc123#claude"; got != want {
+		t.Fatalf("session identity = %q, want %q", got, want)
+	}
+	if identityOf(bare) == identityOf(claude) {
+		t.Fatalf("a sessioned relay collides with the bare identity; existing single-session contributors would be displaced")
+	}
+}
+
+func TestIdentityOfFallsBackToUsername(t *testing.T) {
+	// No ContributorID (a profile created before IDs, or username-only): the
+	// session still scopes off the username so the fallback path is not a
+	// single-slot regression.
+	profile := &ContributorProfile{GitHubUsername: "hanthor"}
+	sessioned := &ContributorConnection{profile: profile, session: "pi"}
+	if got, want := identityOf(sessioned), "hanthor#pi"; got != want {
+		t.Fatalf("username fallback with session = %q, want %q", got, want)
+	}
+	bare := &ContributorConnection{profile: profile}
+	if got, want := identityOf(bare), "hanthor"; got != want {
+		t.Fatalf("username fallback no session = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeSessionLabel(t *testing.T) {
+	cases := map[string]string{
+		"":                              "",
+		"claude":                        "claude",
+		"pi-codex":                      "pi-codex",
+		"Agy_1.2":                       "Agy_1.2",
+		"bad/label":                     "badlabel",       // path chars stripped
+		"a b\tc":                        "abc",            // whitespace stripped
+		"../../etc":                     "....etc",        // no traversal survives as separators
+		"drop#tables":                   "droptables",     // '#' (our separator) stripped
+		"0123456789012345678901234567890123456789": "01234567890123456789012345678901", // capped at 32
+	}
+	for in, want := range cases {
+		if got := sanitizeSessionLabel(in); got != want {
+			t.Errorf("sanitizeSessionLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// The cap must never emit more than 32 bytes.
+	if got := sanitizeSessionLabel("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); len(got) > 32 {
+		t.Errorf("sanitizeSessionLabel over-long output len=%d, want <=32", len(got))
+	}
+}


### PR DESCRIPTION
## Problem

One GitHub account maps to one contributor profile per hub (one `ContributorID`, one registration token, one trust tier). Every identity-keyed piece of hub state — task leases, assignment cooldowns, failure streaks, ownership generation fences — keys on `identityOf()`, which returns that single `ContributorID`. So two relays under the same account collide on **one active-task slot**: a contributor with a single GitHub account can only run **one backend at a time**.

This is a real limitation for anyone who wants to run several CLI backends (claude, agy, pi, kiro, …) concurrently but has only one GitHub identity.

## Change

Add an **optional** client-declared session label:

- Relay: `HIVE_SESSION` (defaults to the backend name), sent as `session` in `auth_response`.
- Hub: `identityOf()` returns `ContributorID#session` when a session is declared.

Identity-keyed state (leases, cooldowns, failure streaks, ownership fences) becomes per-session, so concurrent relays under one account get independent task slots. **Auth, trust tier, model admission and rate-limit accounting stay per-account** — a session is not a way to escape your account's limits, only to run more than one backend at once.

## Backward compatibility

Fully additive. A relay that declares no session (or an older relay that doesn't know the field) resolves to the bare `ContributorID`, exactly as today. An older hub ignores the unknown `session` field. No migration, no protocol break.

The label is sanitized (`[A-Za-z0-9._-]`, capped at 32 bytes) before it becomes a map key, log field, or UI string.

## Tests

`src/pkg/dashboard/contribute_ws_session_identity_test.go`:
- session scoping produces distinct identities per session
- no-session and username-fallback paths preserve the historical identity
- label sanitization (path chars, whitespace, the `#` separator, length cap)

Full `pkg/dashboard` suite passes.