### PR TITLE
🐛 fix(heartbeat): degraded beats no longer blank primaryRepo/repos in the hub registry

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -3665,6 +3665,8 @@ func main() {
 		hub.PublishHeartbeatIdentity(
 			cfg.HiveID,
 			cfg.Project.Org,
+			cfg.Project.PrimaryRepo,
+			cfg.Project.Repos,
 			reporterName,
 			processStartedAt.UTC().Format(time.RFC3339),
 			gitShort,
@@ -4238,8 +4240,20 @@ func main() {
 				}
 				providerLimitReason, providerLimitRebuffs := providerLimitHeartbeatFields(agents)
 				return &hub.HeartbeatPayload{
-					HiveID:                  cfg.HiveID,
-					Org:                     cfg.Project.Org,
+					HiveID: cfg.HiveID,
+					Org:    cfg.Project.Org,
+					// Project identity rides even this minimal beat. The hub
+					// rebuilds the registry entry from each payload VERBATIM
+					// (no carry-forward for these fields), and this beat is
+					// the LAST one the hub holds for the whole restart window
+					// that follows — omitting repos/primary_repo here blanked
+					// the entry (org set, primaryRepo "", repos []) until the
+					// new process's first successful collect, breaking the
+					// public-directory row (no repo link) and rendering the
+					// hive name as "org/". Both values are plain config reads,
+					// exactly as cheap as Org above.
+					Repos:                   cfg.Project.Repos,
+					PrimaryRepo:             cfg.Project.PrimaryRepo,
 					ACMMLevel:               acmmLvl,
 					Agents:                  agents,
 					GitHash:                 gitShort,

--- a/src/pkg/hub/heartbeat.go
+++ b/src/pkg/hub/heartbeat.go
@@ -166,16 +166,28 @@ func publishHeartbeatIdentity(p *HeartbeatPayload) {
 }
 
 // PublishHeartbeatIdentity registers this spoke's collect-independent identity
-// (hive id, org, reporter, started-at, git hash) so the heartbeat loop can send
-// a liveness beat before — or without ever — completing a stats collect.
+// (hive id, org, primary repo, repos, reporter, started-at, git hash) so the
+// heartbeat loop can send a liveness beat before — or without ever — completing
+// a stats collect.
+//
+// PrimaryRepo and Repos are part of this identity for the same reason Org is:
+// they come straight from config, require no network call, and the hub rebuilds
+// its registry entry from each payload verbatim — an identity beat that omitted
+// them blanked the entry's primaryRepo/repos (org set, name "org/"), which broke
+// the public-directory row (no repo link) for the whole window until the first
+// successful collect.
 //
 // Call this as soon as config is loaded, BEFORE StartHeartbeat. It is the piece
 // that makes liveness independent of GitHub: without it, a spoke that restarts
 // while GitHub is slow has nothing it can legitimately address to the hub.
-func PublishHeartbeatIdentity(hiveID, org, reporter, startedAt, gitHash string) {
+func PublishHeartbeatIdentity(hiveID, org, primaryRepo string, repos []string, reporter, startedAt, gitHash string) {
 	publishHeartbeatIdentity(&HeartbeatPayload{
-		HiveID:    hiveID,
-		Org:       org,
+		HiveID:      hiveID,
+		Org:         org,
+		PrimaryRepo: primaryRepo,
+		// Defensive copy: the caller's slice is live config that a hub-delivered
+		// project claim can mutate later; the stored identity must be a snapshot.
+		Repos:     append([]string(nil), repos...),
 		Reporter:  reporter,
 		StartedAt: startedAt,
 		GitHash:   gitHash,

--- a/src/pkg/hub/heartbeat_degraded_beat_carry_test.go
+++ b/src/pkg/hub/heartbeat_degraded_beat_carry_test.go
@@ -1,0 +1,173 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests pin the project-identity carry-forward for DEGRADED beats.
+//
+// Three beat classes legitimately omit the project fields: the pre-restart
+// "upgrading" beat (a minimal payload built outside the normal collect path,
+// and the LAST beat the hub holds for the whole restart window that follows),
+// the identity-only minimal liveness beat (fresh restart, collect timed out
+// with no cache — marked stats_stale), and the upgrade-failure report. The
+// registry entry is otherwise rebuilt from the payload VERBATIM, so those
+// beats blanked org/primaryRepo/repos: the public-directory row lost its repo
+// link (contributors had nothing to contribute to) and the hive rendered as
+// "org/" until the next full collect landed. Observed live on the
+// kubestellar/hive spoke, which auto-upgrades several times a day.
+
+// degradedCarryTestServer isolates the SaaS store and registry on disk and
+// returns a hub server with no bearer requirement, mirroring the other
+// handleHeartbeat tests.
+func degradedCarryTestServer(t *testing.T) *HubServer {
+	t.Helper()
+	dir := t.TempDir()
+	origHives, origRegistry := saasHivesDir, registryPath
+	saasHivesDir = filepath.Join(dir, "hives")
+	registryPath = filepath.Join(dir, "hub-registry.json")
+	t.Cleanup(func() { saasHivesDir, registryPath = origHives, origRegistry })
+
+	srv := NewHubServer(0, slog.Default(), "test", "v4")
+	t.Cleanup(srv.StopSaveLoop)
+	srv.setHubSecret("")
+	return srv
+}
+
+func postBeat(t *testing.T, srv *HubServer, body string) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleHeartbeat(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("heartbeat returned %d (%s), want 200", w.Code, w.Body.String())
+	}
+}
+
+func registryEntryByID(t *testing.T, srv *HubServer, hiveID string) RegistryEntry {
+	t.Helper()
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	for i := range srv.registry.Hives {
+		if srv.registry.Hives[i].ID == hiveID {
+			return srv.registry.Hives[i]
+		}
+	}
+	t.Fatalf("hive %s missing from registry", hiveID)
+	return RegistryEntry{}
+}
+
+// TestHeartbeatUpgradingBeatCarriesProjectIdentityForward is the observed
+// outage: the pre-restart upgrading beat omits primary_repo/repos, and the
+// spoke then EXITS — so the blanked entry is what the hub serves for the whole
+// restart window.
+func TestHeartbeatUpgradingBeatCarriesProjectIdentityForward(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "carry-upgrading-hive"
+
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar","primary_repo":"hive","repos":["hive"]}`)
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar","upgrading":true,"git_hash":"abc1234"}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if entry.PrimaryRepo != "hive" {
+		t.Errorf("PrimaryRepo = %q after upgrading beat, want %q carried forward — a blank primaryRepo breaks the public-directory repo link for the whole restart window", entry.PrimaryRepo, "hive")
+	}
+	if len(entry.Repos) != 1 || entry.Repos[0] != "hive" {
+		t.Errorf("Repos = %v after upgrading beat, want [hive] carried forward", entry.Repos)
+	}
+	if entry.Name != "kubestellar/hive" {
+		t.Errorf("Name = %q after upgrading beat, want %q — the name must be recomputed from the carried fields, not the payload's empty ones", entry.Name, "kubestellar/hive")
+	}
+	if !entry.Upgrading {
+		t.Error("Upgrading = false; the carry-forward must not eat the beat's actual upgrade signal")
+	}
+}
+
+// TestHeartbeatStatsStaleBeatCarriesProjectIdentityForward covers the minimal
+// liveness beat: identity only, org included but repos historically absent
+// (old spokes omit them from the published identity), marked stats_stale.
+func TestHeartbeatStatsStaleBeatCarriesProjectIdentityForward(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "carry-minimal-hive"
+
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar","primary_repo":"hive","repos":["hive"]}`)
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar","stats_stale":true}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if entry.PrimaryRepo != "hive" || len(entry.Repos) != 1 {
+		t.Errorf("after stats_stale beat PrimaryRepo = %q, Repos = %v; want hive/[hive] carried forward", entry.PrimaryRepo, entry.Repos)
+	}
+	if entry.Name != "kubestellar/hive" {
+		t.Errorf("Name = %q, want kubestellar/hive", entry.Name)
+	}
+}
+
+// TestHeartbeatUpgradeFailedBeatCarriesOrgForward covers ReportUpgradeFailure,
+// whose payload is hive_id + SHAs + cause only: even the org is absent, so
+// without carry-forward the entry's name degraded to "/".
+func TestHeartbeatUpgradeFailedBeatCarriesOrgForward(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "carry-upgradefailed-hive"
+
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar","primary_repo":"hive","repos":["hive"]}`)
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","upgrade_failed":true,"upgrade_error":"image pull failed"}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if entry.Org != "kubestellar" {
+		t.Errorf("Org = %q after upgrade-failure beat, want kubestellar carried forward", entry.Org)
+	}
+	if entry.PrimaryRepo != "hive" || len(entry.Repos) != 1 {
+		t.Errorf("PrimaryRepo = %q, Repos = %v after upgrade-failure beat; want hive/[hive] carried forward", entry.PrimaryRepo, entry.Repos)
+	}
+	if entry.Name != "kubestellar/hive" {
+		t.Errorf("Name = %q, want kubestellar/hive", entry.Name)
+	}
+	if !entry.UpgradeFailed {
+		t.Error("UpgradeFailed = false; the carry-forward must not eat the failure signal itself")
+	}
+}
+
+// TestHeartbeatHealthyBeatStillOverwrites is the negative control: a full,
+// non-degraded collect always wins, INCLUDING a genuine clear. Without this
+// gate the carry-forward would pin a removed project forever.
+func TestHeartbeatHealthyBeatStillOverwrites(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "carry-healthy-hive"
+
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar","primary_repo":"hive","repos":["hive"]}`)
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar"}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if entry.PrimaryRepo != "" {
+		t.Errorf("PrimaryRepo = %q after a healthy beat that cleared it, want empty — carry-forward must apply to degraded beats only", entry.PrimaryRepo)
+	}
+	if len(entry.Repos) != 0 {
+		t.Errorf("Repos = %v after a healthy beat that cleared them, want empty", entry.Repos)
+	}
+}
+
+// TestHeartbeatDegradedBeatUnderNewOrgDropsOldRepos: a reset/reassignment
+// changes the org (a reset slot reports its synthetic "available-<id>" org).
+// The previous tenant's repos must never survive into the new org's entry,
+// even on a degraded beat.
+func TestHeartbeatDegradedBeatUnderNewOrgDropsOldRepos(t *testing.T) {
+	srv := degradedCarryTestServer(t)
+	const hiveID = "carry-reset-hive"
+
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"kubestellar","primary_repo":"hive","repos":["hive"]}`)
+	postBeat(t, srv, `{"hive_id":"`+hiveID+`","org":"available-`+hiveID+`","stats_stale":true}`)
+
+	entry := registryEntryByID(t, srv, hiveID)
+	if entry.PrimaryRepo != "" || len(entry.Repos) != 0 {
+		t.Errorf("PrimaryRepo = %q, Repos = %v under a NEW org, want both empty — the old tenant's repos must not survive a reset", entry.PrimaryRepo, entry.Repos)
+	}
+	if entry.Org != "available-"+hiveID {
+		t.Errorf("Org = %q, want the newly reported org", entry.Org)
+	}
+}

--- a/src/pkg/hub/heartbeat_send_on_collect_timeout_test.go
+++ b/src/pkg/hub/heartbeat_send_on_collect_timeout_test.go
@@ -170,7 +170,7 @@ func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness(t *testin
 	ResetHeartbeatStateForTest()
 
 	// Identity is known (published at startup) but NO collect has ever run.
-	PublishHeartbeatIdentity("fresh-hive", "org", "pod-1", "2026-01-01T00:00:00Z", "abc1234")
+	PublishHeartbeatIdentity("fresh-hive", "org", "repo", []string{"repo", "other"}, "pod-1", "2026-01-01T00:00:00Z", "abc1234")
 
 	var posts atomic.Int32
 	got := make(chan HeartbeatPayload, 8)
@@ -209,6 +209,17 @@ func TestSendHeartbeat_FirstBeatTimeoutWithNoCacheStillReportsLiveness(t *testin
 	}
 	if !p.StatsStale {
 		t.Error("minimal beat was not marked StatsStale — the hub would treat absent stats as freshly-observed zeros")
+	}
+	// The hub rebuilds its registry entry from each payload verbatim, so the
+	// minimal beat must carry the config-derived project identity: an
+	// identity beat without primary_repo/repos blanked the registry entry
+	// (org set, primaryRepo "", repos []), which broke the public-directory
+	// row's repo link and rendered the hive name as "org/".
+	if p.PrimaryRepo != "repo" {
+		t.Errorf("minimal beat carried primary_repo %q, want %q — an empty value blanks the hub registry entry for the whole restart window", p.PrimaryRepo, "repo")
+	}
+	if len(p.Repos) != 2 || p.Repos[0] != "repo" || p.Repos[1] != "other" {
+		t.Errorf("minimal beat carried repos %v, want [repo other]", p.Repos)
 	}
 	att, ok := LastHeartbeatAttempt()
 	if !ok || att.Before(before) {
@@ -269,7 +280,7 @@ func TestSendHeartbeat_CachedPayloadPreferredOverMinimal(t *testing.T) {
 	t.Cleanup(ResetHeartbeatStateForTest)
 	ResetHeartbeatStateForTest()
 
-	PublishHeartbeatIdentity("hive", "org", "pod-1", "2026-01-01T00:00:00Z", "abc1234")
+	PublishHeartbeatIdentity("hive", "org", "repo", []string{"repo"}, "pod-1", "2026-01-01T00:00:00Z", "abc1234")
 
 	got := make(chan HeartbeatPayload, 8)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/hub/server.go
+++ b/src/pkg/hub/server.go
@@ -2037,6 +2037,40 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			if entry.SnapshotURL == "" {
 				entry.SnapshotURL = h.SnapshotURL
 			}
+			// Project-identity carry-forward for DEGRADED beats. Three beat
+			// classes legitimately omit project fields: the pre-restart
+			// "upgrading" beat (a minimal payload, and the LAST beat the hub
+			// holds for the whole restart window that follows), the identity-
+			// only minimal liveness beat (fresh restart, collect timed out
+			// with no cache — StatsStale), and the upgrade-failure report
+			// (hive_id + SHAs only). The entry is otherwise rebuilt from the
+			// payload VERBATIM, so those beats blanked org/primaryRepo/repos —
+			// the public-directory row lost its repo link (contributors had
+			// nothing to contribute to) and the hive rendered as "org/" until
+			// the next full collect landed (observed live on the kubestellar/
+			// hive spoke, which auto-upgrades several times a day).
+			//
+			// Gated on the degraded classes so a full, healthy collect always
+			// wins — including a genuine clear. Repo fields carry only under
+			// the SAME org: a reassignment/reset changes the org (a reset slot
+			// reports its synthetic "available-<id>" org), and the old
+			// tenant's repos must never survive it.
+			if payload.Upgrading || payload.StatsStale || payload.UpgradeFailed {
+				if entry.Org == "" && h.Org != "" {
+					entry.Org = h.Org
+				}
+				if strings.EqualFold(entry.Org, h.Org) {
+					if entry.PrimaryRepo == "" && h.PrimaryRepo != "" {
+						entry.PrimaryRepo = h.PrimaryRepo
+					}
+					if len(entry.Repos) == 0 && len(h.Repos) > 0 {
+						entry.Repos = h.Repos
+					}
+				}
+				// Name was computed from the payload's (possibly empty)
+				// fields at build time — recompute it from the carried ones.
+				entry.Name = entry.Org + "/" + entry.PrimaryRepo
+			}
 			// SECURITY (C1/N3, CWE-639): for an EXISTING entry, Owner is never taken
 			// from the heartbeat body. When this hive has an authoritative SaaS
 			// record its Owner was already overlaid above (sh.Owner). Otherwise


### PR DESCRIPTION
## Root cause

The **kubestellar/hive spoke** (`hosted-available-oke-11-placeholder-r05x`, a placeholder converted in place) intermittently showed `org=kubestellar, primaryRepo="", repos=[]` in the hub registry — its public-directory row lost its repo link (contributors could not contribute) and its name rendered as "kubestellar/" — while the spoke's own `/api/config` and both `/data/hive.yaml.runtime` / `.dashboard` correctly carried `project.primary_repo: hive`, `repos: [hive]`.

**Trace:**

1. The pre-restart **upgrading beat** builder (`src/cmd/hive/main.go`, the `SendUpgradingHeartbeat` collect closure) constructs a minimal payload that carries `Org: cfg.Project.Org` but **omits `Repos` and `PrimaryRepo`** — the exact signature observed (org set, repo fields empty).
2. The hub (`src/pkg/hub/server.go`, `handleHeartbeat` entry build around `safePrimary`) rebuilds the registry entry from each payload **verbatim** — `Name: safeOrg+"/"+safePrimary`, `PrimaryRepo: safePrimary`, `Repos:` from payload — with no carry-forward for these fields.
3. The spoke **exits immediately after** sending the upgrading beat, so that blanked entry is what the hub serves for the whole restart window that follows. This spoke tracks `:stable` with `auto_upgrade_mode: instant` and upgraded **three times in one day** (00991a4 → fe96434 → ea0053f → 11e3111 per `/data/logs/hive.log`), so the entry spent long, recurring windows blank. It self-heals on the next successful full collect, which is why the entry reads healthy between upgrade windows.

Two more beat classes blank the same fields the same way:
- the **identity-only minimal liveness beat** (`minimalLivenessPayload`: collect timed out with no last-good cache, i.e. every fresh restart while GitHub enumeration exceeds the 10s collect budget) — carries `Org` but not `PrimaryRepo`/`Repos`;
- the **upgrade-failure report** (`ReportUpgradeFailure`) — carries only `hive_id` + SHAs + cause, blanking even `Org` (name degrades to "/").

Not the cause (verified): spoke config files and live `/api/config` are correct; the regular heartbeat closure reads live `cfg.Project` at beat time; the hub→spoke project echo (`projectConfigForHiveID`) is claim-complete-gated and never pushes an empty project; hub SaaS meta for this hive is complete.

## Fix (three parts)

- **Spoke — upgrading beat** (`src/cmd/hive/main.go`): carry `Repos`/`PrimaryRepo` in the upgrading beat — plain config reads, exactly as cheap as the `Org` it already carried.
- **Spoke — identity** (`src/pkg/hub/heartbeat.go`): `PublishHeartbeatIdentity` now includes `PrimaryRepo`/`Repos` (defensively copied), so the minimal liveness beat carries the full project identity.
- **Hub — carry-forward** (`src/pkg/hub/server.go`): on degraded beats (`upgrading` / `stats_stale` / `upgrade_failed`) the registry rebuild carries `org`/`primaryRepo`/`repos` forward from the previous entry when the payload omits them, and recomputes `Name` from the carried values. This protects the fleet against spokes that have not yet picked up the spoke-side fix (merged ≠ deployed). Gated so a full healthy collect always wins — including a genuine clear — and repo fields carry only under the **same org**, so a reset/reassignment (which switches to the synthetic `available-<id>` org) never inherits the old tenant's repos.

## Tests

- `src/pkg/hub/heartbeat_degraded_beat_carry_test.go` (new): upgrading beat carries identity forward (and keeps the upgrade signal); stats_stale beat carries forward; upgrade-failure beat carries even `Org` forward; **negative control** — a healthy beat that clears the project still overwrites; **reset control** — a degraded beat under a new org drops the old tenant's repos.
- `heartbeat_send_on_collect_timeout_test.go`: minimal liveness beat now asserted to carry `primary_repo`/`repos`.

## Fleet check

Scanned the hub registry (`/data/hub-registry.json` on the hub pod): every other empty-primaryRepo entry is a genuine unclaimed placeholder (`status=available`, synthetic `available-*` org) — no other claimed spoke currently shows the signature. No spoke files were edited and no pods were restarted during diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)