### PR TITLE
🧪 test: SkipUnlessRequired — make silent Go skips fatal in guaranteeing lanes (#5388)

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -202,10 +202,33 @@ jobs:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
 
+      # tmux is what makes HIVE_TEST_REQUIRE_BEHAVIOURAL legitimate below.
+      # ubuntu-latest happens to ship it, but "happens to" is not a guarantee —
+      # a runner image change would silently turn ~50 pkg/agent tests back into
+      # skips, which is the exact failure #5388 exists to prevent. Install it
+      # explicitly and fail the job if it is absent, so the flag below is
+      # asserting something this lane actually enforces.
+      - name: Install tmux (precondition for the behavioural gate)
+        run: |
+          set -euo pipefail
+          if ! command -v tmux >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq tmux
+          fi
+          tmux -V
+
       - name: Test slice of pkg/agent
         env:
           IDX: ${{ matrix.idx }}
           TOTAL: ${{ strategy.job-total }}
+          # This lane GUARANTEES the preconditions the pkg/agent skips gate on:
+          # tmux is installed and verified above, and the rest are t.TempDir()
+          # writes and TestMain-built fixtures. So a skip at a converted site
+          # here means the test broke, not that the environment is unsuitable —
+          # make it fatal (#5388). Only sites judged guaranteed were converted;
+          # genuine capability gates (tmuxAvailable() itself) stay permissive,
+          # matching the shell half's treatment of docker/tmux gates.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: |
           set -o pipefail
           # -list compiles the test binary (cached for the run below) and

--- a/src/internal/testutil/require_behavioural.go
+++ b/src/internal/testutil/require_behavioural.go
@@ -1,0 +1,97 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// RequireBehaviouralEnv is the environment variable that turns a permissive
+// skip into a failure. It is deliberately the SAME variable the shell suites
+// under src/deploy/ honour via hive_test_skip (src/deploy/test_lib.sh), so one
+// flag governs skip discipline across both halves of the test estate (#5388).
+const RequireBehaviouralEnv = "HIVE_TEST_REQUIRE_BEHAVIOURAL"
+
+// ── The defect this exists to close ─────────────────────────────────────────
+//
+// A test that skips on a runner which genuinely cannot run it is CORRECT. The
+// same test skipping on a runner that CAN run it means the test is broken —
+// and it reports green either way. That is #5388: a skip is a result nobody
+// acts on, so a test can quietly stop asserting anything and no lane goes red.
+//
+// ── The contract ────────────────────────────────────────────────────────────
+//
+//	HIVE_TEST_REQUIRE_BEHAVIOURAL unset / not "1" (default)
+//	    SkipUnlessRequired calls t.Skip. The package stays runnable on a
+//	    laptop and on a bare runner that lacks the tooling.
+//
+//	HIVE_TEST_REQUIRE_BEHAVIOURAL=1
+//	    SkipUnlessRequired calls t.Fatal. The CALLER — the lane — is asserting
+//	    the precondition holds, so a skip cannot mean "unsuitable environment";
+//	    it means the precondition moved and the test silently stopped testing.
+//
+// Setting the flag is a judgement call and belongs to the LANE, not the test.
+// Set it only where the runner GUARANTEES the precondition. Setting it where
+// the precondition is merely likely converts a correct skip into a false red,
+// and a noisy detector gets ignored.
+//
+// ── Which skips to convert ──────────────────────────────────────────────────
+//
+// Convert a skip only when the precondition is guaranteed by the test harness
+// itself or by the lane's runner image:
+//
+//   - writes into t.TempDir() or a directory TestMain created and verified;
+//   - fixtures TestMain builds unconditionally and os.Exit(1)s on failure;
+//   - operations that follow an already-passed capability check (a tmux
+//     command failing AFTER tmux was found on PATH is a broken test, not a
+//     missing capability).
+//
+// Do NOT convert a skip that gates on a genuine capability difference between
+// runners — no docker, no tmux binary, tmux older than 3.2, an unprivileged
+// runner, a missing kernel module. Those skips are the system working. The
+// shell half left docker- and tmux-gated skips permissive for exactly this
+// reason; keep the two halves consistent.
+
+// failureTemplate is the printf format used when the flag is armed. Its first
+// verb is the caller's reason; its second is RequireBehaviouralEnv. It names
+// the flag and states the diagnosis (BROKEN TEST, not unsuitable environment)
+// so a CI log reader knows the fix is to repair the test or unset the flag for
+// that lane — never to add another skip. Mirrors hive_test_skip's wording.
+const failureTemplate = "%s\n\t%s=1 — the caller asserts this precondition holds here,\n" +
+	"\tso this is a BROKEN TEST, not an unsuitable environment (#5388)."
+
+// RequireBehavioural reports whether the caller has asserted that the
+// preconditions for behavioural tests hold in this environment. Tests needing
+// finer control than SkipUnlessRequired (for example, choosing between two
+// assertions rather than skipping) can branch on it directly.
+func RequireBehavioural() bool {
+	return os.Getenv(RequireBehaviouralEnv) == "1"
+}
+
+// SkipUnlessRequired skips the test with reason, unless
+// HIVE_TEST_REQUIRE_BEHAVIOURAL=1, in which case it fails the test instead.
+//
+// The failure message names the flag and states that this is a broken test
+// rather than an unsuitable environment, mirroring hive_test_skip's wording,
+// so whoever reads the CI log knows the fix is to repair the test or unset the
+// flag for that lane — not to add another skip.
+//
+// Like t.Skip and t.Fatal, SkipUnlessRequired does not return: it ends the
+// calling goroutine's test. It must be called from the test goroutine.
+func SkipUnlessRequired(t *testing.T, reason string) {
+	t.Helper()
+	if RequireBehavioural() {
+		t.Fatalf(failureTemplate, reason, RequireBehaviouralEnv)
+	}
+	t.Skip(reason)
+}
+
+// SkipfUnlessRequired is SkipUnlessRequired with printf-style formatting, for
+// the common case of embedding the underlying error in the reason.
+func SkipfUnlessRequired(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if RequireBehavioural() {
+		t.Fatalf(failureTemplate, fmt.Sprintf(format, args...), RequireBehaviouralEnv)
+	}
+	t.Skipf(format, args...)
+}

--- a/src/internal/testutil/require_behavioural_test.go
+++ b/src/internal/testutil/require_behavioural_test.go
@@ -1,0 +1,167 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// These tests assert the PROPERTY that matters — that the flag flips a skip
+// into a real test failure — rather than the shape of the code. The #5388
+// family of defects is precisely a guard that reports PASS against the bug it
+// exists to catch (the shell half's first version denied the wrong gate and
+// printed a false PASS in CI), so the observation here has to be the actual
+// outcome of a real *testing.T.
+//
+// Doing that in-process is not possible: a failing subtest marks every ancestor
+// failed, so t.Run's return value cannot be used to "absorb" the failure — the
+// parent goes red too. (That is itself worth stating, because the obvious
+// in-process version of this test LOOKS correct and turns the suite red.)
+//
+// So the subject runs in a SUBPROCESS: TestGuardSubject below is a helper that
+// only executes when HIVE_TESTUTIL_SUBPROCESS is set, and the tests re-exec the
+// test binary to run it, then inspect the child's exit status and output. The
+// child's failure is then data, not a verdict on this process.
+
+const subprocessEnv = "HIVE_TESTUTIL_SUBPROCESS"
+
+// TestGuardSubject is the subject under observation, not a test of its own. It
+// no-ops unless re-exec'd by runSubject, so a normal `go test ./...` neither
+// runs nor reports it.
+func TestGuardSubject(t *testing.T) {
+	mode := os.Getenv(subprocessEnv)
+	if mode == "" {
+		t.Skip("helper process: only runs when re-exec'd by runSubject")
+	}
+	switch mode {
+	case "skip":
+		SkipUnlessRequired(t, "planted precondition")
+	case "skipf":
+		SkipfUnlessRequired(t, "cannot write %s: %v", "config.json", errStub{})
+	default:
+		t.Fatalf("unknown subject mode %q", mode)
+	}
+	// Reached only if the guard RETURNED — which neither branch may do.
+	t.Error("guard returned instead of skipping or failing")
+}
+
+// runSubject re-executes this test binary to run TestGuardSubject with the
+// given guard mode and HIVE_TEST_REQUIRE_BEHAVIOURAL value, returning whether
+// the child passed and everything it printed.
+func runSubject(t *testing.T, mode, flag string) (passed bool, output string) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestGuardSubject$", "-test.v")
+	cmd.Env = append(os.Environ(), subprocessEnv+"="+mode)
+	if flag == "" {
+		// Explicitly clear it: the parent lane may have it set, and "inherited
+		// from the environment" is exactly the ambiguity this test must not have.
+		cmd.Env = append(cmd.Env, RequireBehaviouralEnv+"=")
+	} else {
+		cmd.Env = append(cmd.Env, RequireBehaviouralEnv+"="+flag)
+	}
+
+	out, err := cmd.CombinedOutput()
+	return err == nil, string(out)
+}
+
+func TestSkipUnlessRequired_FailsUnderFlag(t *testing.T) {
+	passed, out := runSubject(t, "skip", "1")
+
+	if passed {
+		t.Fatalf("subject PASSED under %s=1; the guard did not make the skip fatal.\n%s",
+			RequireBehaviouralEnv, out)
+	}
+	// Passing is the only way to be wrong in the "did it fail" sense, but a
+	// failure for the WRONG reason (a panic, a build error, the "guard
+	// returned" line) would also be non-zero. Pin the reason.
+	if !strings.Contains(out, "BROKEN TEST") {
+		t.Errorf("subject failed, but not via the guard's diagnosis:\n%s", out)
+	}
+	if strings.Contains(out, "guard returned instead") {
+		t.Errorf("guard returned normally under the flag:\n%s", out)
+	}
+	if strings.Contains(out, "--- SKIP") {
+		t.Errorf("subject SKIPPED under %s=1:\n%s", RequireBehaviouralEnv, out)
+	}
+}
+
+func TestSkipUnlessRequired_SkipsWithoutFlag(t *testing.T) {
+	passed, out := runSubject(t, "skip", "")
+
+	if !passed {
+		t.Fatalf("subject failed with %s unset; the default must stay permissive.\n%s",
+			RequireBehaviouralEnv, out)
+	}
+	// A passing child is not enough: a guard that simply RETURNED would also
+	// pass. Require that it actually skipped.
+	if !strings.Contains(out, "--- SKIP") {
+		t.Errorf("subject passed but did not skip:\n%s", out)
+	}
+	if strings.Contains(out, "guard returned instead") {
+		t.Errorf("guard returned normally instead of skipping:\n%s", out)
+	}
+}
+
+// Only the exact value "1" may arm the guard, matching hive_test_skip's
+// `[ "$HIVE_TEST_REQUIRE_BEHAVIOURAL" = "1" ]`. A lane exporting "0" or "true"
+// must not silently acquire fatal skips.
+func TestSkipUnlessRequired_OnlyExactlyOneArms(t *testing.T) {
+	for _, v := range []string{"0", "true", "yes", "2", " 1", "01"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(RequireBehaviouralEnv, v)
+			if RequireBehavioural() {
+				t.Fatalf("%s=%q armed the guard; only \"1\" may", RequireBehaviouralEnv, v)
+			}
+
+			passed, out := runSubject(t, "skip", v)
+			if !passed {
+				t.Fatalf("%s=%q made the skip fatal:\n%s", RequireBehaviouralEnv, v, out)
+			}
+			if !strings.Contains(out, "--- SKIP") {
+				t.Errorf("%s=%q: subject did not skip:\n%s", RequireBehaviouralEnv, v, out)
+			}
+		})
+	}
+}
+
+func TestSkipfUnlessRequired_FormatsAndFails(t *testing.T) {
+	passed, out := runSubject(t, "skipf", "1")
+
+	if passed {
+		t.Fatalf("subject PASSED under %s=1:\n%s", RequireBehaviouralEnv, out)
+	}
+	// The formatted reason must survive into the failure message, not be
+	// replaced by the raw format string.
+	if !strings.Contains(out, "cannot write config.json: permission denied") {
+		t.Errorf("formatted reason missing from failure output:\n%s", out)
+	}
+	if strings.Contains(out, "%s") || strings.Contains(out, "%v") {
+		t.Errorf("format verbs leaked unrendered into the failure output:\n%s", out)
+	}
+}
+
+// The rendered message must carry the caller's reason, name the flag, and give
+// the diagnosis, so a CI log reader knows the fix is to repair the test or
+// unset the flag for that lane — never to add another skip.
+func TestFailureMessageNamesFlagAndDiagnosis(t *testing.T) {
+	msg := fmt.Sprintf(failureTemplate, "cannot create tmux session", RequireBehaviouralEnv)
+
+	for _, want := range []string{
+		"cannot create tmux session", // the caller's reason survives
+		RequireBehaviouralEnv + "=1", // which flag armed this
+		"BROKEN TEST",                // the diagnosis
+		"not an unsuitable environment",
+		"#5388",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("failure message does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+type errStub struct{}
+
+func (errStub) Error() string { return "permission denied" }

--- a/src/pkg/agent/coverage_boost_test.go
+++ b/src/pkg/agent/coverage_boost_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubestellar/hive/internal/testutil"
 	"github.com/kubestellar/hive/pkg/config"
 )
 
@@ -384,7 +385,11 @@ func TestSyncModeFiles_WritesCorrectMode(t *testing.T) {
 
 	data, err := os.ReadFile(filepath.Join(agentStateDir, ".hive-mode-scanner"))
 	if err != nil {
-		t.Skipf("could not read mode file: %v", err)
+		// agentStateDir is redirected by TestMain into its temp tree and
+		// MkdirAll-ed there, and SyncModeFiles above just wrote this file.
+		// Unreadable here means SyncModeFiles silently did not write --
+		// exactly the assertion this test exists to make (#5388).
+		testutil.SkipfUnlessRequired(t, "could not read mode file: %v", err)
 	}
 	mode := string(data)
 	if mode != "ISSUES_ONLY" {
@@ -1603,7 +1608,8 @@ func TestReadCoveragePreamble_WithActualFile(t *testing.T) {
 	}
 	data, _ := json.Marshal(metrics)
 	if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
-		t.Skipf("cannot write metrics file: %v", err)
+		// cacheFile lives in t.TempDir() -- guaranteed writable (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write metrics file: %v", err)
 	}
 
 	m := &Manager{logger: discardLogger()}
@@ -1677,7 +1683,8 @@ func TestReadCoveragePreamble_DefaultTarget(t *testing.T) {
 	}
 	data, _ := json.Marshal(metrics)
 	if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
-		t.Skipf("cannot write metrics file: %v", err)
+		// cacheFile lives in t.TempDir() -- guaranteed writable (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write metrics file: %v", err)
 	}
 
 	m := &Manager{logger: discardLogger()}
@@ -1728,7 +1735,10 @@ func TestConfigHasTokens_EmptyTokens_AtPath(t *testing.T) {
 	defer cleanup()
 
 	if err := os.WriteFile(sharedCopilotConfigPath, []byte(`{"copilotTokens": {}}`), 0o660); err != nil {
-		t.Skipf("cannot write: %v", err)
+		// sharedCopilotConfigPath points into t.TempDir(), which the testing
+		// package guarantees is writable. A failure here is a broken test,
+		// not an unsuitable environment (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write: %v", err)
 	}
 	if configHasTokens() {
 		t.Error("configHasTokens should return false for empty tokens")
@@ -1740,7 +1750,10 @@ func TestConfigHasTokens_NoTokensField(t *testing.T) {
 	defer cleanup()
 
 	if err := os.WriteFile(sharedCopilotConfigPath, []byte(`{"someOther": true}`), 0o660); err != nil {
-		t.Skipf("cannot write: %v", err)
+		// sharedCopilotConfigPath points into t.TempDir(), which the testing
+		// package guarantees is writable. A failure here is a broken test,
+		// not an unsuitable environment (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write: %v", err)
 	}
 	if configHasTokens() {
 		t.Error("configHasTokens should return false when field missing")
@@ -1753,7 +1766,10 @@ func TestConfigHasTokens_WithComments_AtPath(t *testing.T) {
 
 	cfg := "// comment line\n{\"copilotTokens\": {\"github.com\": {\"token\": \"gho_test\"}}}"
 	if err := os.WriteFile(sharedCopilotConfigPath, []byte(cfg), 0o660); err != nil {
-		t.Skipf("cannot write: %v", err)
+		// sharedCopilotConfigPath points into t.TempDir(), which the testing
+		// package guarantees is writable. A failure here is a broken test,
+		// not an unsuitable environment (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write: %v", err)
 	}
 	if !configHasTokens() {
 		t.Error("configHasTokens should handle // comments and still find tokens")
@@ -1775,7 +1791,10 @@ func TestClearExpiredTokens_ClearsAndPreservesOther(t *testing.T) {
   "otherSetting": "keep-me"
 }`
 	if err := os.WriteFile(sharedCopilotConfigPath, []byte(cfg), 0o660); err != nil {
-		t.Skipf("cannot write: %v", err)
+		// sharedCopilotConfigPath points into t.TempDir(), which the testing
+		// package guarantees is writable. A failure here is a broken test,
+		// not an unsuitable environment (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write: %v", err)
 	}
 
 	err := clearExpiredTokens()
@@ -1849,7 +1868,10 @@ func TestFixSharedConfigPerms_FixesPerms(t *testing.T) {
 
 	// Write with restrictive perms
 	if err := os.WriteFile(sharedCopilotConfigPath, []byte(`{}`), 0o600); err != nil {
-		t.Skipf("cannot write: %v", err)
+		// sharedCopilotConfigPath points into t.TempDir(), which the testing
+		// package guarantees is writable. A failure here is a broken test,
+		// not an unsuitable environment (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write: %v", err)
 	}
 
 	m := NewManager(map[string]config.AgentConfig{
@@ -1877,7 +1899,10 @@ func TestFixSharedConfigPerms_AlreadyCorrect(t *testing.T) {
 
 	// Write with correct perms
 	if err := os.WriteFile(sharedCopilotConfigPath, []byte(`{}`), sharedConfigDesiredMode); err != nil {
-		t.Skipf("cannot write: %v", err)
+		// sharedCopilotConfigPath points into t.TempDir(), which the testing
+		// package guarantees is writable. A failure here is a broken test,
+		// not an unsuitable environment (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot write: %v", err)
 	}
 
 	m := NewManager(map[string]config.AgentConfig{

--- a/src/pkg/agent/crash_coverage_test.go
+++ b/src/pkg/agent/crash_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubestellar/hive/internal/testutil"
 	"github.com/kubestellar/hive/pkg/config"
 )
 
@@ -26,7 +27,11 @@ func TestCheckAndRestartCrashedAgents_BarePaneRestarts(t *testing.T) {
 
 	// Create a live session with a bare shell (no CLI marker).
 	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
+		// tmuxAvailable() already passed above, so tmux is on PATH and
+		// TMUX_TMPDIR points into TestMain's temp tree. A failure here is a
+		// broken test (stale socket, uncleaned server, name collision), not
+		// a missing capability (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
 	}
 	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 
@@ -54,7 +59,11 @@ func TestCheckAndRestartCrashedAgents_BootGrace(t *testing.T) {
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
 	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
+		// tmuxAvailable() already passed above, so tmux is on PATH and
+		// TMUX_TMPDIR points into TestMain's temp tree. A failure here is a
+		// broken test (stale socket, uncleaned server, name collision), not
+		// a missing capability (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
 	}
 	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 
@@ -81,7 +90,11 @@ func TestCheckAndRestartCrashedAgents_InferenceHealthy(t *testing.T) {
 	agent := m.agents["cxa"]
 	m.mu.RUnlock()
 	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
+		// tmuxAvailable() already passed above, so tmux is on PATH and
+		// TMUX_TMPDIR points into TestMain's temp tree. A failure here is a
+		// broken test (stale socket, uncleaned server, name collision), not
+		// a missing capability (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
 	}
 	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	// Live CLI marker, not a consent screen.

--- a/src/pkg/agent/launch_coverage_test.go
+++ b/src/pkg/agent/launch_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubestellar/hive/internal/testutil"
 	"github.com/kubestellar/hive/pkg/config"
 )
 
@@ -30,7 +31,11 @@ func TestStart_CLIAlreadyRunning(t *testing.T) {
 	// instead, where the manager never looks, so the adopt branch under test
 	// would silently never trigger (#4628).
 	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
+		// tmuxAvailable() already passed above, so tmux is on PATH and
+		// TMUX_TMPDIR points into TestMain's temp tree. A failure here is a
+		// broken test (stale socket, uncleaned server, name collision), not
+		// a missing capability (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
 	}
 	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	// Inject a marker; forceRelaunch defaults to false.
@@ -67,7 +72,11 @@ func TestStart_InferenceCLIAlreadyRunning(t *testing.T) {
 
 	// Same-server requirement as TestStart_CLIAlreadyRunning above.
 	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
+		// tmuxAvailable() already passed above, so tmux is on PATH and
+		// TMUX_TMPDIR points into TestMain's temp tree. A failure here is a
+		// broken test (stale socket, uncleaned server, name collision), not
+		// a missing capability (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
 	}
 	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": esc to interrupt bypass permissions on Claude").Run()
@@ -97,7 +106,11 @@ func TestStart_CopilotAdoptsRunning(t *testing.T) {
 
 	// Same-server requirement as TestStart_CLIAlreadyRunning above.
 	if err := testTmuxCommand("new-session", "-d", "-s", agent.tmuxSession).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
+		// tmuxAvailable() already passed above, so tmux is on PATH and
+		// TMUX_TMPDIR points into TestMain's temp tree. A failure here is a
+		// broken test (stale socket, uncleaned server, name collision), not
+		// a missing capability (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
 	}
 	defer testTmuxCommand("kill-session", "-t", agent.tmuxSession).Run()
 	testTmuxCommand("send-keys", "-t", agent.tmuxSession, "-l", ": Copilot ready").Run()

--- a/src/pkg/agent/tmux_coverage_test.go
+++ b/src/pkg/agent/tmux_coverage_test.go
@@ -9,11 +9,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubestellar/hive/internal/testutil"
 	"github.com/kubestellar/hive/pkg/config"
 )
 
 // tmuxAvailable reports whether a usable tmux binary is on PATH. All tmux-based
 // coverage tests skip when it is absent so the suite still passes in minimal CI.
+//
+// This gate stays PERMISSIVE under HIVE_TEST_REQUIRE_BEHAVIOURAL (#5388): a
+// runner without tmux is a genuine capability difference, not a broken test,
+// and making it fatal would manufacture false reds on any laptop or minimal
+// image. The lane that wants these tests to actually run installs tmux and
+// asserts that via the flag; everything DOWNSTREAM of this check — creating a
+// session, driving a pane — is then a broken test if it fails, and those sites
+// use testutil.SkipUnlessRequired. This mirrors the shell half, which likewise
+// left docker- and tmux-gated skips permissive.
 func tmuxAvailable() bool {
 	_, err := exec.LookPath("tmux")
 	return err == nil
@@ -82,7 +92,12 @@ func overrideStub(t *testing.T, name, firstLine string) {
 	p := filepath.Join(stubBinDir, name)
 	orig, err := os.ReadFile(p)
 	if err != nil {
-		t.Skipf("global stub %q not present: %v", name, err)
+		// TestMain writes every stub in this list unconditionally and
+		// os.Exit(1)s if any write fails, so a missing stub here cannot mean
+		// "unsuitable environment" — it means the harness changed underneath
+		// this helper (a renamed stub, a mutated stubBinDir). Under the flag
+		// that is a broken test, not a reason to stop asserting (#5388).
+		testutil.SkipfUnlessRequired(t, "global stub %q not present: %v", name, err)
 	}
 	// Print the custom line AND the ❯ ready marker so readiness gates resolve
 	// (so no exec-looping goroutine leaks past the test), while the custom line
@@ -110,7 +125,12 @@ func inferenceReadyStub(t *testing.T) {
 func newRawTmuxSession(t *testing.T, session string) {
 	t.Helper()
 	if err := testTmuxCommand("new-session", "-d", "-s", session).Run(); err != nil {
-		t.Skipf("cannot create tmux session: %v", err)
+		// Every caller gates on tmuxAvailable() first, so tmux IS on PATH by
+		// the time we get here and TMUX_TMPDIR points at a directory TestMain
+		// created. A failure now is a broken test — a stale socket, a server
+		// the suite failed to clean up, a session name collision — not a
+		// missing capability (#5388).
+		testutil.SkipfUnlessRequired(t, "cannot create tmux session: %v", err)
 	}
 	t.Cleanup(func() {
 		_ = testTmuxCommand("kill-session", "-t", session).Run()


### PR DESCRIPTION
The Go half of #5388 item 3. The shell half shipped in #5520 (`HIVE_TEST_REQUIRE_BEHAVIOURAL` adoption 2→12 suites, 1→2 workflows); this adds the same contract for Go tests, honouring the **same env var** so one flag governs both halves of the test estate.

`Refs #5388`, not `Fixes` — this delivers the helper plus the `pkg/agent` cluster, deliberately not all 259 sites. See "What remains" for the honest accounting, which materially changes what finishing this issue means.

## 1. `testutil.SkipUnlessRequired`

`src/internal/testutil/require_behavioural.go`. Skips by default; `t.Fatal`s under `HIVE_TEST_REQUIRE_BEHAVIOURAL=1`, with a message that names the flag and gives the diagnosis (`BROKEN TEST, not an unsuitable environment`), mirroring `hive_test_skip`'s wording in `src/deploy/test_lib.sh`. Only the exact value `1` arms it, matching the shell side's `[ "$HIVE_TEST_REQUIRE_BEHAVIOURAL" = "1" ]`.

## 2. Converted vs left permissive — 18 of ~54

Not every skip should become fatal. A skip on a genuine capability difference is the system working; making those fatal manufactures false reds, and a noisy detector gets ignored. The shell half left docker- and tmux-gated skips permissive for exactly this reason and this keeps the two halves consistent.

| file | converted | left | why left |
|---|---|---|---|
| `tmux_coverage_test.go` | 2 | 22 | all 22 are `!tmuxAvailable()` — a runner without tmux is a real capability gap |
| `coverage_boost_test.go` | 9 | 0 | every site was a `t.TempDir()` write or a TestMain-created dir |
| `launch_coverage_test.go` | 3 | 3 | left: the `tmuxAvailable()` gates themselves |
| `crash_coverage_test.go` | 3 | 3 | left: the `tmuxAvailable()` gates themselves |
| `diag_coverage_test.go` | 0 | 9 | all nine are `!tmuxAvailable()`; nothing here is guaranteed |

Converted sites share one property — **the precondition is guaranteed by the harness, not the environment**:

- `overrideStub`'s *"global stub not present"* — `TestMain` writes every stub unconditionally and `os.Exit(1)`s if any write fails, so a miss here means the harness moved underneath the helper.
- `newRawTmuxSession` / the inline `new-session` calls — every caller has **already passed** `tmuxAvailable()`, so tmux is on PATH and `TMUX_TMPDIR` points into a TestMain-created dir. A failure now is a stale socket or a name collision, i.e. a broken test.
- all of `coverage_boost_test.go` — `t.TempDir()` writability is guaranteed by the testing package; the mode-file read is of a file `SyncModeFiles` had just written, so an unreadable file *is* the assertion failing.

## 3. Lane

`HIVE_TEST_REQUIRE_BEHAVIOURAL=1` on the `v2-tests` **agent shard only**. Not global, not on the `rest` buckets.

The lane now installs tmux and prints `tmux -V` first. `ubuntu-latest` happens to ship tmux, but "happens to" is not a guarantee — a runner image change would silently turn ~50 `pkg/agent` tests back into skips, which is precisely the failure this issue exists to prevent. Installing it explicitly is what makes arming the flag legitimate rather than assumed.

## 4. Demonstrated failing

Eleven vacuous checks were found in this repo this week, including one inside the tool built to prevent them. So the guard was assumed defective until watched failing for the right reason. Every mutation below was **verified physically present in the file** before its result was trusted.

**The guard catching a real silent skip.** Planted a bad write path in `TestConfigHasTokens_EmptyTokens_AtPath` — same binary, same test, flag flipped:

```
without the flag:  --- SKIP: TestConfigHasTokens_EmptyTokens_AtPath
                   PASS / ok        <- the #5388 bug itself, green
with the flag:     cannot write: ...PLANTED-not-a-dir: no such file or directory
                     HIVE_TEST_REQUIRE_BEHAVIOURAL=1 — ... BROKEN TEST ...
                   --- FAIL         <- caught
```

**The guard's own tests, against two planted defects.** A first attempt at a compiling-mutation test was rejected because it failed via `"os" imported and not used` — a build error is a vacuous red, not a demonstration. Both real mutations:

- guard never arms (`== "PLANTED-never-matches"`) → `FailsUnderFlag`: *"subject PASSED under HIVE_TEST_REQUIRE_BEHAVIOURAL=1; the guard did not make the skip fatal"*, and `SkipfUnlessRequired_FormatsAndFails` likewise.
- guard always arms (`!= "PLANTED-always-armed"`) → `SkipsWithoutFlag`: *"the default must stay permissive"*, plus all six `OnlyExactlyOneArms` cases (`0`, `true`, `yes`, `2`, `" 1"`, `01`).

Both restored to green; `grep -c PLANTED` = 0 before the commit.

**A defect in the obvious test design, worth recording.** The natural in-process test — run the subject in `t.Run`, assert it returned `false` — **cannot work**. A failing subtest marks *every ancestor* failed, so the guard's own test turns the suite red even when the guard is correct. This was caught by running it, not by reading it. The subject therefore runs in a **subprocess** whose exit status is inspected as data. Assertions pin the *reason*, not just non-zero exit: a build error, a panic, or the guard returning normally each produce a distinguishable message.

**Calibrated against a false positive.** Under the flag, the converted tmux tests fail on a *deep* checkout path: `TMUX_TMPDIR` then exceeds the ~104-char UNIX socket limit (`error connecting to ...: File name too long`). That is an environment artifact, not a test defect — the identical run is green from `/tmp`, and CI paths are short. This is the concrete reason the `tmuxAvailable()` gates stay permissive instead of being converted wholesale.

Helper tests also pass under `-race -shuffle=on`, and with the flag already set in the environment.

## What remains — and what "finishing" #5388 means

**A large fraction of the 259 are legitimate capability gates, and this changes the shape of the remaining work.** Classifying all 259 on current `v4`:

- **~115 (44%)** are genuine capability gates — `not available` (73 mentions), `tmux` (64), root/privilege (41), `permission` (27), podman/docker, `LookPath`/`command -v`. **These should stay permissive.** Converting them is the false-red outcome this issue explicitly warns against.
- **~23 (9%)** are harness/TempDir sites of the kind converted here — the clearly convertible tail.
- The remainder needs case-by-case judgement. A visible convertible family is the ~12 *"X not readable from this package"* sites (`entrypoint.sh` ×5, `backends.conf` ×4, `nginx.conf`, `Dockerfile`, `error-pages.yaml`, `hive-open-pr.sh`, `gh-app-token.sh`) — repo files always present in a checkout. Others are correctly permissive: `POSIX mode bits are not meaningful on Windows`, `reapAgentCLI reads /proc; Linux only`, `root bypasses file permissions`.

So the realistic target is on the order of **40–60 conversions total**, not 259. This PR does 18 of them. A follow-up should cover the repo-file-readable family and the `t.TempDir()` tail in `pkg/config` (`entrypoint_boot_test.go`, 7) and `pkg/policies`, plus the self-disarming skips #5398 catalogued as P1. `pkg/tui` and `pkg/dashboard` are owned by concurrent work and untouched here.

## Not verified

- The full `pkg/agent` suite under the flag **on a CI runner** — verified locally from a short path and per-test, but the authoritative signal is this PR's own agent shard, which is the first run of the newly-armed lane.
- That `apt-get install tmux` is a no-op on `ubuntu-latest` (expected: the `command -v` guard short-circuits) — confirmed only by reading, not by a run.
- No claim that the 22+9 left-permissive `tmuxAvailable()` gates would pass under the flag in CI; that is exactly what was deliberately not asserted.
- The ~115/~23 split is a keyword classification over skip messages, not a site-by-site audit. Treat the percentages as calibration, not a precise count.
