### PR TITLE
🧪 test(hub): isolate manual upgrade success fixture

### DIFF
--- a/src/pkg/hub/cluster_health_coverage_test.go
+++ b/src/pkg/hub/cluster_health_coverage_test.go
@@ -118,6 +118,10 @@ func TestHandleUpgradeHiveSuccess(t *testing.T) {
 		ID: "h1", GitBranch: "v2",
 		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
 	}}
+	// The handler can only arm an upgrade after the image poller has resolved a
+	// build for the hive's branch. Seed that production precondition explicitly
+	// instead of depending on a preceding test to leak its v2 cache entry.
+	setLatestSHAForBranchForTest(t, "v2", "upgrade-target")
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser("POST", "/up", "", "alice"), "id", "h1")


### PR DESCRIPTION
## What failed

The scheduled `v4` test run linked from #5580 failed under `-shuffle=on`. The first run reported `TestSendUpgradingHeartbeat_NonSuccess` and a proxy race; those were independently fixed by #5569 while this issue was being investigated. The next scheduled run on `4c21d14` exposed the remaining order-dependent failure:

```text
--- FAIL: TestHandleUpgradeHiveSuccess
upgrade success status = 502, want 200
{"error":"upgrade failed — no build target known for this hive's branch"}
```

This leaves the scheduled test lane red even though the production handler is correctly refusing an upgrade for which no image build is known.

## Root cause

`TestHandleUpgradeHiveSuccess` creates a heartbeating `v2` hive and expects the manual-upgrade handler to return 200, but it never establishes the handler's other required production precondition: the image poller must have resolved a build target for `v2` in `latestSHAByBranch`.

The test normally passed because another test happened to seed that package-level cache first. Scheduled runs enable test shuffling, so seed `1788301994415581277` ran this test before a suitable cache writer and exposed the missing fixture. Running the test alone reproduced the same 502 deterministically.

## Fix

`src/pkg/hub/cluster_health_coverage_test.go` now seeds a synthetic `v2` build target with `setLatestSHAForBranchForTest` before invoking the handler. That existing helper restores the prior cache entry through `t.Cleanup`, so the test both owns its prerequisite and does not become a new source of order-dependent state.

No production behavior changes: an upgrade with no known branch build should continue returning 502. The test now models the successful path it claims to cover.

## Regression evidence

- Before the change, the focused test failed in isolation with the same 502 and message seen in CI.
- After the change, the focused test passed 20/20 with the race detector and the failing shuffle seed.
- The exact `hub 3/3` CI partition (931 tests) passed with `-short -race -count=1` and seed `1788301994415581277` on the rebased commit.
- The original heartbeat and proxy victims from the first run were also rechecked under `-race` and shuffle after upstream #5569: 20/20 hub repetitions and 10/10 proxy repetitions passed.

Commands and results:

```console
cd src
env GOCACHE=/tmp/hive-5580-go-cache CCACHE_DIR=/tmp/hive-5580-ccache \
  go test ./pkg/hub -short -race -count=20 \
  -shuffle=1788301994415581277 -run '^TestHandleUpgradeHiveSuccess$'
# ok github.com/kubestellar/hive/pkg/hub 1.118s

# Reconstruct the workflow's hub 3/3 partition, then run it with the CI seed:
RUN="^($(go test ./pkg/hub -short -list '.*' | grep -E '^(Test|Example|Fuzz)' | \
  LC_ALL=C sort | awk 'NR % 3 == 2' | paste -sd'|' -))$"
go test ./pkg/hub -short -race -count=1 \
  -shuffle=1788301994415581277 -run "$RUN"
# ok github.com/kubestellar/hive/pkg/hub 44.706s

git diff --check upstream/v4...HEAD
# clean
```

Full `go test ./...` was not run because this is a one-line hub test-fixture correction; the exact failing race-enabled CI shard provides the broader interaction coverage relevant to the change.

Fixes #5580

— hive: backend=codex
