### PR TITLE
🧪 test(hub+agent): two more shuffle-order dependencies — uid-map file leak and an unseeded upgrade target

### DIFF
--- a/src/pkg/agent/coverage_boost_test.go
+++ b/src/pkg/agent/coverage_boost_test.go
@@ -1117,12 +1117,11 @@ func TestAddAgent_WithUIDMap(t *testing.T) {
 	m.uidMap = NewUIDMap()
 	m.uidMap.AllocateUIDs([]string{"existing"})
 
-	// Save to temp dir
-	dir := t.TempDir()
-	uidMapFile := filepath.Join(dir, "uid-map.json")
+	// AddAgent allocates a UID and persists the map to UIDMapPath. Redirect
+	// the path into this test's own temp dir: saving to the binary-wide
+	// TestMain path leaks the map into every later NewManager (#5580).
+	uidMapFile := stubUIDMapPath(t)
 
-	// AddAgent should allocate UID and try to save
-	// The save will fail since UIDMapPath is a const, but that's OK
 	m.AddAgent("new-agent", config.AgentConfig{Backend: "claude"})
 
 	m.mu.RLock()
@@ -1135,7 +1134,9 @@ func TestAddAgent_WithUIDMap(t *testing.T) {
 	if agent.tmuxSocket == "" {
 		t.Error("agent with UID should have tmux socket set")
 	}
-	_ = uidMapFile
+	if _, err := os.Stat(uidMapFile); err != nil {
+		t.Errorf("AddAgent should persist the uid-map at UIDMapPath: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pkg/agent/manager_replicas_test.go
+++ b/src/pkg/agent/manager_replicas_test.go
@@ -10,6 +10,9 @@ import (
 func TestReconcileAgentsAddsReplicaWithUIDAndRemovesExtra(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{"scanner": {ID: "scanner", Enabled: true}}, slog.Default(), ProjectContext{})
 	m.uidMap = NewUIDMap()
+	// ReconcileAgents persists the UID map to UIDMapPath when one is live;
+	// keep the save out of the binary-wide TestMain path (#5580).
+	stubUIDMapPath(t)
 	m.ReconcileAgents(map[string]config.AgentConfig{
 		"scanner":   {ID: "scanner", Enabled: true, ReplicaIndex: 1, ReplicaCount: 2},
 		"scanner-2": {ID: "scanner-2", Enabled: true, ReplicaOf: "scanner", ReplicaIndex: 2, ReplicaCount: 2},

--- a/src/pkg/agent/manager_test.go
+++ b/src/pkg/agent/manager_test.go
@@ -200,6 +200,24 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// stubUIDMapPath points UIDMapPath at a file inside this test's own temp dir
+// and restores it on cleanup. Every test that can WRITE the uid-map must use
+// it: AddAgent and ReconcileAgents both call uidMap.Save(UIDMapPath) whenever
+// a UID map is live, and TestMain's shared uid-map.json path persists for the
+// whole binary run. A map saved there is silently loaded by every later
+// NewManager, whose AddAgent then allocates and RE-SAVES unrelated agent
+// names — handing later tests' agents real UIDs, per-UID tmux sockets and
+// per-UID homes. Under -shuffle=on that chain made TestWatchdogLastProduction
+// inherit a UID for "a1" and scan the wrong HOME for production evidence
+// (#5580).
+func stubUIDMapPath(t *testing.T) string {
+	t.Helper()
+	old := UIDMapPath
+	UIDMapPath = filepath.Join(t.TempDir(), "uid-map.json")
+	t.Cleanup(func() { UIDMapPath = old })
+	return UIDMapPath
+}
+
 func makeAgentConfig(backend, model string) config.AgentConfig {
 	return config.AgentConfig{
 		Backend: backend,

--- a/src/pkg/hub/cluster_health_coverage_test.go
+++ b/src/pkg/hub/cluster_health_coverage_test.go
@@ -106,6 +106,17 @@ func TestHandleUpgradeHiveSuccess(t *testing.T) {
 
 	mkUser(t, "alice")
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
+	// The success path requires a known build target for the hive's branch:
+	// handleUpgradeHive hard-fails with 502 when getLatestSHAForBranch("v2")
+	// is empty. Seed it here rather than inherit whatever an earlier test left
+	// in the process-global SHA cache — under -shuffle=on this test ran before
+	// any seeder and got "" (#5580). Reset before AND after so this seed never
+	// leaks into another test the same way.
+	resetSHACaches(t)
+	latestSHAMu.Lock()
+	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "abc1234"}
+	latestSHAMu.Unlock()
+	t.Cleanup(func() { resetSHACaches(t) })
 	s := &HubServer{
 		hubSecret: testHubSecret,
 		logger:    slog.Default(),


### PR DESCRIPTION
## Summary

The scheduled v4 runs behind #5580 shuffle (`-shuffle=on` on every non-PR run), and each new seed has been surfacing another order-dependent test. The two failures still live on current v4 — reported in the issue's follow-up comments on `4c21d14` ([run 33566746778](https://github.com/kubestellar/hive/actions/runs/33566746778)) and `7dcdd0d` ([run 33571438566](https://github.com/kubestellar/hive/actions/runs/33571438566)) — are both order-dependent global state, the same family as #5553. (The two failures in the originally cited [run 33556009812](https://github.com/kubestellar/hive/actions/runs/33556009812) on `0bdce4b` — `TestSendUpgradingHeartbeat_NonSuccess` and the `tunnelHalfCloseDrain` race — were already fixed by #5569, which merged after that run's commit.)

Both were reproduced locally by replaying the exact CI slice with the exact CI shuffle seed, and both are green after the fix under the same seed.

## pkg/agent — TestWatchdogLastProduction (agent 5/5, seed 1788305582043268182)

TestMain points `UIDMapPath` into a binary-wide temp path "where it never exists unless a test creates it" — and two tests create it: `TestAddAgent_WithUIDMap` and `TestReconcileAgentsAddsReplicaWithUIDAndRemovesExtra` set `m.uidMap` and hit `AddAgent`/`ReconcileAgents`, which `Save(UIDMapPath)`. From then on every `NewManager` loads the file, so any later `AddAgent` (the audit tests add `a1` repeatedly) allocates and re-saves unrelated names into it. `TestWatchdogLastProduction` then constructs a manager whose `a1` carries a poisoned UID > 0, `AgentHome()` resolves the per-UID home instead of the test's `$HOME`, the conversation-file scan finds nothing, and pane evidence wins — the exact `want state-file mtime` failure in CI.

Fix: a `stubUIDMapPath(t)` seam (per-test path, restored on cleanup) applied to both writer tests. `TestAddAgent_WithUIDMap` now also asserts the save actually landed, replacing a comment that wrongly claimed the save fails because `UIDMapPath` is a const.

## pkg/hub — TestHandleUpgradeHiveSuccess (hub 3/3, seed 1788301994415581277)

The success path requires `getLatestSHAForBranch("v2")` to be non-empty (`handleUpgradeHive` hard-fails 502 "no build target known" otherwise), but the test never seeded it — it passed only when an earlier test left a SHA in the process-global cache. Under shuffle it ran first and got "". Fix: seed the target in the test itself, `resetSHACaches` before AND after (the #5553 idiom), so the test owns its precondition and leaks nothing.

## Verification

- `go test ./pkg/hub -short -race -count=1 -shuffle=1788301994415581277 -run '<CI slice 3/3>'` — failed before, `ok` after
- `go test ./pkg/agent -short -race -count=1 -shuffle=1788305582043268182 -run '<CI slice 5/5>'` — `TestWatchdogLastProduction` failed before, passes after
- No assertion was weakened; the failing tests themselves were correct.

Fixes #5580

🤖 Generated with [Claude Code](https://claude.com/claude-code)