### PR TITLE
🧪 test(testutil): make the skip-guard's coverage visible to the gate

### DIFF
--- a/src/internal/testutil/require_behavioural.go
+++ b/src/internal/testutil/require_behavioural.go
@@ -78,7 +78,11 @@ func RequireBehavioural() bool {
 //
 // Like t.Skip and t.Fatal, SkipUnlessRequired does not return: it ends the
 // calling goroutine's test. It must be called from the test goroutine.
-func SkipUnlessRequired(t *testing.T, reason string) {
+//
+// t is a testing.TB — matching Eventually above — so the guard is callable
+// from benchmarks and testable against a double; test callers pass their
+// *testing.T unchanged.
+func SkipUnlessRequired(t testing.TB, reason string) {
 	t.Helper()
 	if RequireBehavioural() {
 		t.Fatalf(failureTemplate, reason, RequireBehaviouralEnv)
@@ -88,7 +92,7 @@ func SkipUnlessRequired(t *testing.T, reason string) {
 
 // SkipfUnlessRequired is SkipUnlessRequired with printf-style formatting, for
 // the common case of embedding the underlying error in the reason.
-func SkipfUnlessRequired(t *testing.T, format string, args ...any) {
+func SkipfUnlessRequired(t testing.TB, format string, args ...any) {
 	t.Helper()
 	if RequireBehavioural() {
 		t.Fatalf(failureTemplate, fmt.Sprintf(format, args...), RequireBehaviouralEnv)

--- a/src/internal/testutil/require_behavioural_test.go
+++ b/src/internal/testutil/require_behavioural_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -15,15 +16,24 @@ import (
 // printed a false PASS in CI), so the observation here has to be the actual
 // outcome of a real *testing.T.
 //
-// Doing that in-process is not possible: a failing subtest marks every ancestor
-// failed, so t.Run's return value cannot be used to "absorb" the failure — the
-// parent goes red too. (That is itself worth stating, because the obvious
-// in-process version of this test LOOKS correct and turns the suite red.)
+// Doing that in-process against a REAL *testing.T is not possible: a failing
+// subtest marks every ancestor failed, so t.Run's return value cannot be used
+// to "absorb" the failure — the parent goes red too. (That is itself worth
+// stating, because the obvious in-process version of this test LOOKS correct
+// and turns the suite red.)
 //
-// So the subject runs in a SUBPROCESS: TestGuardSubject below is a helper that
-// only executes when HIVE_TESTUTIL_SUBPROCESS is set, and the tests re-exec the
-// test binary to run it, then inspect the child's exit status and output. The
-// child's failure is then data, not a verdict on this process.
+// So the real-T half runs in a SUBPROCESS: TestGuardSubject below is a helper
+// that only executes when HIVE_TESTUTIL_SUBPROCESS is set, and the tests
+// re-exec the test binary to run it, then inspect the child's exit status and
+// output. The child's failure is then data, not a verdict on this process.
+//
+// The subprocess proves the guard against the genuine article, but the child's
+// coverage counters die with the child, so the guard measures 0% and trips the
+// coverage gate (#5597). The *_InProcess tests further down therefore exercise
+// the same contract against guardTB — a testing.TB double whose Fatalf/Skip
+// end the goroutine exactly as the real methods do — in this process, where
+// the profile can see it. Both halves stay: the double for the counters and
+// the fine-grained observations, the subprocess for proof against a real T.
 
 const subprocessEnv = "HIVE_TESTUTIL_SUBPROCESS"
 
@@ -165,3 +175,160 @@ func TestFailureMessageNamesFlagAndDiagnosis(t *testing.T) {
 type errStub struct{}
 
 func (errStub) Error() string { return "permission denied" }
+
+// ── In-process tests against a testing.TB double ────────────────────────────
+
+// guardTB is a testing.TB double for the guards. Unlike recordingTB (whose
+// Fatalf must RETURN so Eventually's deadline test can keep asserting),
+// guardTB's Fatalf/Skip/Skipf end the calling goroutine via runtime.Goexit,
+// exactly as the real *testing.T methods do — the guards' documented contract
+// is that they do not return, and a double that returned would let the code
+// after the guard run and hide a missing-termination bug (the "guard returned"
+// defect the subprocess tests also watch for). Embedding testing.TB satisfies
+// the interface's unexported method; any method the guard newly grows a
+// dependency on panics on the nil embed, which is the desired signal.
+type guardTB struct {
+	testing.TB
+	helperCalls int
+	fataled     bool
+	fatal       string
+	skipped     bool
+	skip        string
+}
+
+func (g *guardTB) Helper() { g.helperCalls++ }
+
+func (g *guardTB) Fatalf(format string, args ...any) {
+	g.fataled = true
+	g.fatal = fmt.Sprintf(format, args...)
+	runtime.Goexit()
+}
+
+func (g *guardTB) Skip(args ...any) {
+	g.skipped = true
+	g.skip = fmt.Sprint(args...)
+	runtime.Goexit()
+}
+
+func (g *guardTB) Skipf(format string, args ...any) {
+	g.skipped = true
+	g.skip = fmt.Sprintf(format, args...)
+	runtime.Goexit()
+}
+
+// callGuard invokes fn against a fresh guardTB on a dedicated goroutine —
+// necessary because the guard is expected to END that goroutine — and reports
+// whether fn returned normally instead, which is always a bug in the guard.
+func callGuard(fn func(tb testing.TB)) (tb *guardTB, returned bool) {
+	tb = &guardTB{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn(tb)
+		returned = true
+	}()
+	<-done
+	return tb, returned
+}
+
+func TestSkipUnlessRequired_InProcess_SkipsByDefault(t *testing.T) {
+	t.Setenv(RequireBehaviouralEnv, "")
+
+	tb, returned := callGuard(func(tb testing.TB) {
+		SkipUnlessRequired(tb, "no tmux on this runner")
+	})
+
+	if returned {
+		t.Fatal("guard returned; like t.Skip it must end the calling goroutine")
+	}
+	if tb.fataled {
+		t.Errorf("guard failed the test with the flag unset:\n%s", tb.fatal)
+	}
+	if !tb.skipped {
+		t.Fatal("guard neither skipped nor failed")
+	}
+	if tb.skip != "no tmux on this runner" {
+		t.Errorf("skip reason = %q, want the caller's reason verbatim", tb.skip)
+	}
+	if tb.helperCalls == 0 {
+		t.Error("guard did not call t.Helper(); failures would point at the guard, not the caller")
+	}
+}
+
+func TestSkipUnlessRequired_InProcess_FailsWhenArmed(t *testing.T) {
+	t.Setenv(RequireBehaviouralEnv, "1")
+
+	tb, returned := callGuard(func(tb testing.TB) {
+		SkipUnlessRequired(tb, "planted precondition")
+	})
+
+	if returned {
+		t.Fatal("guard returned; like t.Fatal it must end the calling goroutine")
+	}
+	if tb.skipped {
+		t.Errorf("guard skipped under %s=1: %q", RequireBehaviouralEnv, tb.skip)
+	}
+	if !tb.fataled {
+		t.Fatal("guard did not fail the test under the flag")
+	}
+	if tb.helperCalls == 0 {
+		t.Error("guard did not call t.Helper()")
+	}
+	for _, want := range []string{
+		"planted precondition",       // the caller's reason survives
+		RequireBehaviouralEnv + "=1", // which flag armed this
+		"BROKEN TEST",                // the diagnosis
+	} {
+		if !strings.Contains(tb.fatal, want) {
+			t.Errorf("failure message does not mention %q:\n%s", want, tb.fatal)
+		}
+	}
+}
+
+func TestSkipfUnlessRequired_InProcess_SkipsFormattedByDefault(t *testing.T) {
+	t.Setenv(RequireBehaviouralEnv, "")
+
+	tb, returned := callGuard(func(tb testing.TB) {
+		SkipfUnlessRequired(tb, "cannot write %s: %v", "config.json", errStub{})
+	})
+
+	if returned {
+		t.Fatal("guard returned; like t.Skipf it must end the calling goroutine")
+	}
+	if tb.fataled {
+		t.Errorf("guard failed the test with the flag unset:\n%s", tb.fatal)
+	}
+	if !tb.skipped {
+		t.Fatal("guard neither skipped nor failed")
+	}
+	if want := "cannot write config.json: permission denied"; tb.skip != want {
+		t.Errorf("skip reason = %q, want %q (format must be rendered, not passed raw)", tb.skip, want)
+	}
+}
+
+func TestSkipfUnlessRequired_InProcess_FailsFormattedWhenArmed(t *testing.T) {
+	t.Setenv(RequireBehaviouralEnv, "1")
+
+	tb, returned := callGuard(func(tb testing.TB) {
+		SkipfUnlessRequired(tb, "cannot write %s: %v", "config.json", errStub{})
+	})
+
+	if returned {
+		t.Fatal("guard returned; like t.Fatal it must end the calling goroutine")
+	}
+	if tb.skipped {
+		t.Errorf("guard skipped under %s=1: %q", RequireBehaviouralEnv, tb.skip)
+	}
+	if !tb.fataled {
+		t.Fatal("guard did not fail the test under the flag")
+	}
+	if !strings.Contains(tb.fatal, "cannot write config.json: permission denied") {
+		t.Errorf("formatted reason missing from failure message:\n%s", tb.fatal)
+	}
+	if strings.Contains(tb.fatal, "%s") || strings.Contains(tb.fatal, "%v") {
+		t.Errorf("format verbs leaked unrendered into the failure message:\n%s", tb.fatal)
+	}
+	if !strings.Contains(tb.fatal, "BROKEN TEST") {
+		t.Errorf("failure message lacks the diagnosis:\n%s", tb.fatal)
+	}
+}


### PR DESCRIPTION
Fixes #5597

## What was red

The hourly coverage gate measured `internal/testutil` at **69.2%** against its 90% default floor ([run 33573515741](https://github.com/kubestellar/hive/actions/runs/33573515741), v4 @ 7dcdd0d5). `go tool cover -func` pins it to exactly two functions, both at 0.0%: `SkipUnlessRequired` and `SkipfUnlessRequired`, added in 4a00cbd (the #5388 silent-skip guard).

## Why they measured 0% despite having tests

The guards *do* have behavior tests — but they run the subject in a **subprocess** (`runSubject` re-execs the test binary), because a real `*testing.T` cannot absorb a planted failure in-process. The child's coverage counters die with the child, so the profile the gate reads never sees the guard bodies execute. Verified behavior, invisible coverage.

## Fix — real tests, not a floor adjustment

- Align the guards' signatures with `Eventually` in the same package: `testing.TB` instead of `*testing.T`. Backward compatible — every caller (all in `pkg/agent` coverage suites) passes a `*testing.T`, which satisfies `testing.TB`; no call-site changes.
- Add in-process tests against `guardTB`, a `testing.TB` double whose `Fatalf`/`Skip`/`Skipf` end the calling goroutine via `runtime.Goexit` exactly as the real methods do — so a guard that *returned* instead of terminating is still caught (unlike the package's existing `recordingTB`, whose `Fatalf` must return for `Eventually`'s deadline test). The four new tests assert both arms of the contract: default → skip with the caller's reason verbatim; `HIVE_TEST_REQUIRE_BEHAVIOURAL=1` → `Fatalf` carrying the reason, the flag name, and the `BROKEN TEST` diagnosis; formatted variants render (no leaked verbs); `t.Helper()` is called; and the guard never returns.
- The subprocess tests **stay** as the end-to-end proof against a genuine `*testing.T`; their header comment now explains the split.

No `PKG_THRESHOLD` change; `testutil` stays on the 90% default. Test-only change, so no CHANGELOG entry per its maintenance policy.

## Verification

```
go test -race -count=1 -coverprofile=... ./internal/testutil/
ok  github.com/kubestellar/hive/internal/testutil  coverage: 100.0% of statements
SkipUnlessRequired   100.0%
SkipfUnlessRequired  100.0%
total                100.0%
```

`gofmt -l` clean on both files; `go vet ./internal/testutil/ ./pkg/agent/` clean (agent is the caller package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)