### PR TITLE
🧪 fix(dashboard): centralize cachedHealth test isolation and wire a bounded -shuffle CI lane

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -94,6 +94,12 @@ concurrency:
 #    order moves; shuffling the post-merge net finds them and files an issue
 #    with the seed in the log, while the PR gate stays deterministic so a
 #    contributor is never failed by an ordering their change did not cause.
+#  - pkg/dashboard additionally gets a dedicated shuffled lane on EVERY event,
+#    PRs included (#5570): it is the package with a record of package-level
+#    cache leaks (#5553's cachedHealth), and a leak merged today otherwise
+#    fails weeks later on whichever scheduled run draws a hostile order. The
+#    lane bounds parallelism and surfaces the failing seed — see
+#    test-dashboard-shuffle below for why both bounds are load-bearing.
 #
 # Completeness invariants (nothing can be silently untested):
 #  - rest buckets are computed by EXCLUDING exactly pkg/hub and pkg/agent from
@@ -395,6 +401,67 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
+  # Dedicated shuffled-order lane for pkg/dashboard (#5570). The rest bucket
+  # above shuffles only on NON-pull_request runs, so an order-dependent test
+  # merged today fails weeks later on an unlucky scheduled run — #5553 was
+  # exactly that shape (a cachedHealth cache leak that passed five runs before
+  # and after the one hostile ordering). This lane also runs at PR time, with
+  # the two bounds the #5570 investigation showed the lane needs to stay
+  # signal rather than noise:
+  #  - parallelism is constrained: the package stands up hundreds of httptest
+  #    servers, and unconstrained parallel fan-out exhausts ephemeral ports on
+  #    a loaded machine — that noise (`connect: can't assign requested
+  #    address`) is what inflated #5570's original "83 failures" figure. A
+  #    flaky detector gets ignored, which is worse than no detector.
+  #  - the seed is surfaced in the failure annotation: -shuffle=on draws a
+  #    fresh seed each run, and without the seed a real order-dependence
+  #    finding is unreproducible.
+  # No -coverprofile here: pkg/dashboard's coverage floor is scored from the
+  # rest-bucket profile; this lane exists only to vary the execution order.
+  test-dashboard-shuffle:
+    name: test (dashboard shuffle)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25'
+          cache-dependency-path: src/go.sum
+
+      - name: Test pkg/dashboard in shuffled order
+        run: |
+          set -o pipefail
+          # Bound on concurrent t.Parallel tests inside the package: high
+          # enough to keep the lane fast, low enough that the package's many
+          # httptest servers cannot exhaust ephemeral ports (see job comment).
+          PARALLEL_TESTS=4
+          if go test ./pkg/dashboard -short -race -count=1 -v -shuffle=on -p 1 -parallel "$PARALLEL_TESTS" \
+            2>&1 | grep --line-buffered -vE '^=== (RUN|PAUSE|CONT) ' | tee test-dashboard-shuffle.log; then
+            exit 0
+          fi
+          # The test binary prints "-test.shuffle <seed>" as its first line;
+          # put the seed in the annotation so the failure is reproducible.
+          SEED=$(grep -m1 -E '^-test\.shuffle [0-9]+' test-dashboard-shuffle.log | awk '{print $2}')
+          echo "::error::pkg/dashboard failed under shuffled order. Reproduce from src/ with: go test ./pkg/dashboard -short -race -count=1 -p 1 -parallel $PARALLEL_TESTS -shuffle=${SEED:-<seed line missing from log>}"
+          exit 1
+
+      - name: Slowest tests in this lane
+        if: always()
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/slowest-tests.sh" "dashboard shuffle" test-dashboard-shuffle.log
+
+      - name: Upload shuffle log
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-dashboard-shuffle-log
+          path: src/test-dashboard-shuffle.log
+          if-no-files-found: warn
+          retention-days: 1
+
   # Stable aggregate context named "test", preserved from the pre-shard job so
   # anything keyed on the check name (branch protection, tide, humans' muscle
   # memory) keeps working. Fails closed: every shard AND the partition job
@@ -402,18 +469,20 @@ jobs:
   test:
     if: always()
     runs-on: ubuntu-latest
-    needs: [list-packages, test-hub, test-agent, test-rest]
+    needs: [list-packages, test-hub, test-agent, test-rest, test-dashboard-shuffle]
     steps:
       - name: Check shard results
         run: |
-          echo "list-packages: ${{ needs.list-packages.result }}"
-          echo "test-hub:      ${{ needs.test-hub.result }}"
-          echo "test-agent:    ${{ needs.test-agent.result }}"
-          echo "test-rest:     ${{ needs.test-rest.result }}"
+          echo "list-packages:          ${{ needs.list-packages.result }}"
+          echo "test-hub:               ${{ needs.test-hub.result }}"
+          echo "test-agent:             ${{ needs.test-agent.result }}"
+          echo "test-rest:              ${{ needs.test-rest.result }}"
+          echo "test-dashboard-shuffle: ${{ needs.test-dashboard-shuffle.result }}"
           [ "${{ needs.list-packages.result }}" = "success" ]
           [ "${{ needs.test-hub.result }}" = "success" ]
           [ "${{ needs.test-agent.result }}" = "success" ]
           [ "${{ needs.test-rest.result }}" = "success" ]
+          [ "${{ needs.test-dashboard-shuffle.result }}" = "success" ]
 
   # Per-package coverage-floor gate (#4112): parse-only, consumes the shard
   # artifacts — it runs no tests, so PRs run the suite exactly once. PR-only:
@@ -626,7 +695,7 @@ jobs:
   create-issue-on-failure:
     if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    needs: [list-packages, test-hub, test-agent, test-rest]
+    needs: [list-packages, test-hub, test-agent, test-rest, test-dashboard-shuffle]
     permissions:
       contents: read
       issues: write
@@ -645,6 +714,7 @@ jobs:
               '${{ needs.test-hub.result }}',
               '${{ needs.test-agent.result }}',
               '${{ needs.test-rest.result }}',
+              '${{ needs.test-dashboard-shuffle.result }}',
               '${{ needs.list-packages.result }}',
             ];
             const wasCancelled = results.includes('cancelled');

--- a/src/pkg/dashboard/coverage_boost4_test.go
+++ b/src/pkg/dashboard/coverage_boost4_test.go
@@ -376,15 +376,9 @@ func TestHandleKnowledgeCreate_MissingFields_Boost(t *testing.T) {
 // --- buildHealth with cached health ---
 
 func TestBuildHealth_Cached(t *testing.T) {
-	// Set cached health first
-	cachedHealthMu.Lock()
-	cachedHealth = map[string]any{"ci": 95, "nightly": 100}
-	cachedHealthMu.Unlock()
-	defer func() {
-		cachedHealthMu.Lock()
-		cachedHealth = nil
-		cachedHealthMu.Unlock()
-	}()
+	// Seed cached health first; the shared hook restores the pre-test cache
+	// state in t.Cleanup (#5570).
+	setCachedHealth(t, map[string]any{"ci": 95, "nightly": 100})
 
 	// Call with nil client to get cached
 	result := buildHealth(nil, nil)
@@ -705,7 +699,7 @@ func TestHandleContributorTrust_UserNotFound(t *testing.T) {
 	body := `{"username":"nonexistent","tier":"contributor"}`
 	req := httptest.NewRequest("PUT", "/api/contribute/trust", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Hive-Role", "owner") // mutation gate fails closed on a missing role (C5)
+	req.Header.Set("X-Hive-Role", "owner")          // mutation gate fails closed on a missing role (C5)
 	req.Header.Set(ownerRoleVerifiedHeader, "true") // requireOwnerRole needs the verified marker too (F14)
 	w := httptest.NewRecorder()
 	srv.handleContributorTrust(w, req)

--- a/src/pkg/dashboard/health_cache_guard_test.go
+++ b/src/pkg/dashboard/health_cache_guard_test.go
@@ -1,0 +1,51 @@
+package dashboard
+
+import "testing"
+
+// restoreHealthCaches is the isolation hook for the package-level health
+// caches (#5570). buildHealth's live-client path writes cachedHealth and can
+// refresh cachedGreenStreak (status_builder.go), and nothing in non-test code
+// ever clears either — so any test that reaches that path, or seeds the caches
+// directly as a fixture, leaks state into every later test that exercises the
+// nil-client branch and asserts the {"ci": 100} default. Under -shuffle that
+// surfaces as an order-dependent failure (e.g. TestBuildHealth_NilClient_Boost
+// failing with "ci = 0" whenever TestCovH2_BuildHealthAndRateLimits happens to
+// run first; minimal reproduction: -shuffle=11 with just that pair).
+//
+// Call this FIRST in any test that writes the caches — directly or via a
+// non-nil GitHub client — instead of hand-rolling a snapshot/restore at each
+// site. It snapshots both caches and registers a t.Cleanup restoring them, so
+// the restore runs even when the test later calls t.Fatalf, and a future
+// writer test cannot forget half the pair.
+func restoreHealthCaches(tb testing.TB) {
+	tb.Helper()
+
+	cachedHealthMu.Lock()
+	prevHealth := cachedHealth
+	cachedHealthMu.Unlock()
+
+	cachedGreenStreakMu.Lock()
+	prevStreak, prevStreakOK := cachedGreenStreak, cachedGreenStreakOK
+	cachedGreenStreakMu.Unlock()
+
+	tb.Cleanup(func() {
+		cachedHealthMu.Lock()
+		cachedHealth = prevHealth
+		cachedHealthMu.Unlock()
+
+		cachedGreenStreakMu.Lock()
+		cachedGreenStreak, cachedGreenStreakOK = prevStreak, prevStreakOK
+		cachedGreenStreakMu.Unlock()
+	})
+}
+
+// setCachedHealth seeds the cachedHealth fixture for tests that assert the
+// cached-read branch of buildHealth. It routes through restoreHealthCaches so
+// seeding a fixture can never leak past the test that set it.
+func setCachedHealth(tb testing.TB, health map[string]any) {
+	tb.Helper()
+	restoreHealthCaches(tb)
+	cachedHealthMu.Lock()
+	cachedHealth = health
+	cachedHealthMu.Unlock()
+}

--- a/src/pkg/dashboard/status_builder_more_coverage_test.go
+++ b/src/pkg/dashboard/status_builder_more_coverage_test.go
@@ -74,21 +74,14 @@ func TestCovH2_BuildHealthAndRateLimits(t *testing.T) {
 	logger := covH2Logger()
 
 	// This test drives buildHealth with a live client below, and that
-	// production path writes the package-level cachedHealth cache
-	// (status_builder.go). Nothing in the non-test code clears it, so without
-	// a restore here the cache leaks into every later test that exercises the
-	// nil-client branch — those tests assert the *default* {"ci": 100} and
-	// instead observe this test's fixture. Snapshot and restore around the
-	// whole test via t.Cleanup rather than defer: cleanup must run even if an
-	// assertion below calls t.Fatalf. Refs #5570.
-	cachedHealthMu.Lock()
-	prevCachedHealth := cachedHealth
-	cachedHealthMu.Unlock()
-	t.Cleanup(func() {
-		cachedHealthMu.Lock()
-		cachedHealth = prevCachedHealth
-		cachedHealthMu.Unlock()
-	})
+	// production path writes the package-level cachedHealth cache and can
+	// refresh cachedGreenStreak (status_builder.go). Nothing in the non-test
+	// code clears either, so without a restore the caches leak into every
+	// later test that exercises the nil-client branch — those tests assert
+	// the *default* {"ci": 100} and instead observe this test's fixture. The
+	// shared hook snapshots both caches and restores them in t.Cleanup, so
+	// the restore runs even when an assertion below calls t.Fatalf (#5570).
+	restoreHealthCaches(t)
 
 	// nil client → cached/default fallback branch.
 	h := buildHealth(nil, nil)
@@ -132,26 +125,11 @@ func TestCovH2_BuildHealthAndRateLimits(t *testing.T) {
 	}
 
 	// The live branch of buildHealth CACHES what it fetched into the package
-	// global cachedHealth. The mock above answers the workflow endpoints with
-	// an empty run list, so the cached map carries ci=0 — and every later
-	// buildHealth(nil, nil) in this package then returns that instead of the
-	// ci=100 default it asserts on. Restore the global so the pollution cannot
-	// outlive this test (#5553: TestBuildHealth_NilClient_Boost failed with
-	// "ci = 0" only on the shuffle orders that put this test first).
-	// The same call can also refresh cachedGreenStreak, so restore that pair
-	// too rather than leaving a second global dirtied for later tests.
-	cachedGreenStreakMu.Lock()
-	prevStreak, prevStreakOK := cachedGreenStreak, cachedGreenStreakOK
-	cachedGreenStreakMu.Unlock()
-	t.Cleanup(func() {
-		cachedHealthMu.Lock()
-		cachedHealth = nil
-		cachedHealthMu.Unlock()
-
-		cachedGreenStreakMu.Lock()
-		cachedGreenStreak, cachedGreenStreakOK = prevStreak, prevStreakOK
-		cachedGreenStreakMu.Unlock()
-	})
+	// global cachedHealth — the mock above answers the workflow endpoints with
+	// an empty run list, so the cached map carries ci=0 (#5553:
+	// TestBuildHealth_NilClient_Boost failed with "ci = 0" only on the
+	// shuffle orders that put this test first). Both dirtied globals are
+	// restored by the restoreHealthCaches hook registered at the top.
 	_ = buildHealth(ghc, ctx)
 
 	// App-auth identity branch: set an AppID so buildGHRateLimits takes the "app" path.

--- a/src/pkg/dashboard/status_builder_test.go
+++ b/src/pkg/dashboard/status_builder_test.go
@@ -642,16 +642,9 @@ func TestBuildBeads_EmptyStores(t *testing.T) {
 }
 
 func TestBuildHealth_WithCachedHealth(t *testing.T) {
-	// Set cached health and then call with nil client
-	cachedHealthMu.Lock()
-	cachedHealth = map[string]any{"ci": 95, "tests": 100}
-	cachedHealthMu.Unlock()
-
-	defer func() {
-		cachedHealthMu.Lock()
-		cachedHealth = nil
-		cachedHealthMu.Unlock()
-	}()
+	// Seed cached health and then call with nil client; the shared hook
+	// restores the pre-test cache state in t.Cleanup (#5570).
+	setCachedHealth(t, map[string]any{"ci": 95, "tests": 100})
 
 	health := buildHealth(nil, nil)
 	if health["ci"] != 95 {
@@ -1004,10 +997,10 @@ func TestBuildBudget_WithTokenCollectorSummary(t *testing.T) {
 }
 
 func TestBuildHealth_NilClient_NoCached(t *testing.T) {
-	// Clear any cached state
-	cachedHealthMu.Lock()
-	cachedHealth = nil
-	cachedHealthMu.Unlock()
+	// Clear any cached state for the duration of this test only; the shared
+	// hook restores whatever was cached before, so this test cannot erase
+	// another test's fixture under -shuffle (#5570).
+	setCachedHealth(t, nil)
 
 	health := buildHealth(nil, nil)
 	if health["ci"] != 100 {


### PR DESCRIPTION
Dispatched on operator instruction over the hold label.

Fixes #5570

Delivers both halves of the revised scope: the durable isolation fix for the one real `cachedHealth` leak, and the bounded `-shuffle` CI lane the issue names as the point of the exercise.

## Half 1 — centralize health-cache isolation (the leak, fixed structurally)

The leaking state is the package-level pair in `src/pkg/dashboard/status_builder.go`: `cachedHealth`, written unconditionally by `buildHealth`'s live-client path, and `cachedGreenStreak`/`cachedGreenStreakOK`, refreshed on the same pass. Nothing in non-test code ever clears either, so any test reaching that path pollutes every later test that exercises the nil-client branch and asserts the `{"ci": 100}` default.

Minimal reproduction, measured on the pre-#5569 polluter with the current victim — just two tests, hostile order:

    go test ./pkg/dashboard -shuffle=11 -count=1 \
      -run 'TestCovH2_BuildHealthAndRateLimits$|TestBuildHealth_NilClient_Boost$'
    --- FAIL: TestBuildHealth_NilClient_Boost   coverage_boost2_test.go:1271: ci = 0

Seeds 11, 13, 14, 17, 18 all order the polluter first and fail identically; seeds that order the victim first pass — deterministic per seed, i.e. genuine order-dependence, matching the issue's post-correction analysis.

#5569 and #5578 already stopped the bleeding with inline snapshot/restore blocks inside `TestCovH2_BuildHealthAndRateLimits`. What remained was the structural problem: every writer test hand-rolls its own restore, so isolation depends on the next writer remembering the full pair — the exact discipline whose decay produced #5553. This PR adds `restoreHealthCaches(tb)` (snapshots both caches, restores in `t.Cleanup`, so the restore survives `t.Fatalf`) and `setCachedHealth(tb, m)` for fixture seeding, in `health_cache_guard_test.go`, and routes all five touchpoints through them:

- `TestCovH2_BuildHealthAndRateLimits` — both inline blocks collapse into one hook call
- `TestBuildHealth_WithCachedHealth`, `TestBuildHealth_Cached` — `defer`-based fixture teardown → hook
- `TestBuildHealth_NilClient_NoCached` — previously cleared the cache without restoring; now restores the pre-test state

No assertion was weakened; the victims still assert the exact default.

## Half 2 — bounded `-shuffle` lane in CI (the durable detector)

`v2-tests.yml` only applied `-shuffle=on` to non-`pull_request` runs, so this failure class could never block the PR that introduces it — it surfaced weeks later on whichever scheduled run drew a hostile order (#5553's discovery mode). New `test-dashboard-shuffle` job:

- runs `go test ./pkg/dashboard -short -race -count=1 -v -shuffle=on -p 1 -parallel 4` on every event, PRs included
- **bounded parallelism**, per the issue comment's first condition: the package stands up hundreds of `httptest` servers, and unbounded fan-out exhausts ephemeral ports on loaded machines — the noise (`connect: can't assign requested address`) behind the original "83 failures" figure. A flaky detector gets ignored, which is how this issue came to exist.
- **seed surfaced on failure**, per the second condition: the `::error` annotation carries the seed and the exact reproduce command, so a real finding is never unreproducible.
- wired into the aggregate `test` required context (fails closed) and into the scheduled `create-issue-on-failure` filer; no `-coverprofile` (the coverage floor is still scored from the rest-bucket profile, so this lane cannot double-count).

## Before/after counts (per the issue's acceptance bar)

- Before (unmodified `v4` at 7dcdd0d): full-package `-shuffle` failing count is **0** — confirming the issue's correction that #5569/#5578 left no remaining order-dependent failures; the original 83 was port-exhaustion noise.
- Before, with the pre-#5569 polluter restored: **1** deterministic failure on polluter-first seeds (repro above) — the leak this issue is actually about.
- After (this branch): polluter-first seeds 11/13/14/17/18 pass on the minimal pair, and a 20-distinct-seed full-package sweep (`-shuffle=<seed> -count=1 -p 1`; seeds 11, 13, 17, 42, 100, 200, 207, 314, 555, 777, 1000, 1234, 2026, 3000, 4096, 5570, 7777, 9001, 12345, 99999) ended with **every seed green and zero order-dependent failures**. Full disclosure of the measurement, because it re-enacted this issue's own correction: 15 seeds passed on the first back-to-back pass; 5 seeds (1234, 4096, 5570, 9001, 12345) failed 13/4/11/22/30 tests with pairwise-disjoint failure sets that escalated with machine load — and **all 5 passed with zero failures when re-run individually with the same seed** after the socket table drained (under `-p 1 -parallel 4`, the exact bound the new CI lane uses). Same seed, same order, different outcome = not order-dependence; genuine ordering failures are deterministic per seed, as the repro seeds above are. This is the ephemeral-port noise the issue's correction documented, and it is precisely why the CI lane bounds parallelism.

Refs #5553, #5569, #5578
