### PR TITLE
🧪 test(testutil): cover EventuallyEveryFunc — restore the 90% floor

### DIFF
--- a/src/internal/testutil/eventually_test.go
+++ b/src/internal/testutil/eventually_test.go
@@ -89,3 +89,76 @@ func TestEventuallyValue_ZeroValueAndFailureOnDeadline(t *testing.T) {
 		t.Fatalf("EventuallyValue returned %d on failure, want the zero value", got)
 	}
 }
+
+func TestEventuallyEveryFunc_ReturnsOnceConditionHolds(t *testing.T) {
+	const trueOnCall = 3
+	var calls atomic.Int32
+	var describeCalls atomic.Int32
+	start := time.Now()
+	EventuallyEveryFunc(t, 5*time.Second, time.Millisecond, func() bool {
+		return calls.Add(1) >= trueOnCall
+	}, func() string {
+		describeCalls.Add(1)
+		return "must never be rendered"
+	})
+	if got := calls.Load(); got != trueOnCall {
+		t.Fatalf("cond called %d times, want exactly %d (must stop polling once true)", got, trueOnCall)
+	}
+	// describe's contract is "at most once, only on the failure path": a
+	// describe that renders frames or dumps queues must cost nothing when the
+	// wait succeeds.
+	if got := describeCalls.Load(); got != 0 {
+		t.Fatalf("describe called %d times on the success path, want 0", got)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("EventuallyEveryFunc took %s after the condition held; expected a few polls' worth", elapsed)
+	}
+}
+
+// The function's entire reason to exist: the failure message must describe the
+// system AT THE DEADLINE, not at t=0. cond counts its own polls and describe
+// reports the count; an implementation that captured the description eagerly
+// (at entry, before the first poll — exactly what the printf-argument form it
+// replaces did) would report 0.
+func TestEventuallyEveryFunc_DescribeIsLazyAndAtMostOnce(t *testing.T) {
+	rec := &recordingTB{}
+	var polls atomic.Int32
+	var describeCalls atomic.Int32
+	const timeout = 30 * time.Millisecond
+	start := time.Now()
+	EventuallyEveryFunc(rec, timeout, 5*time.Millisecond, func() bool {
+		polls.Add(1)
+		return false
+	}, func() string {
+		describeCalls.Add(1)
+		return fmt.Sprintf("state after %d polls", polls.Load())
+	})
+
+	if !rec.failed {
+		t.Fatal("EventuallyEveryFunc did not call Fatalf on deadline")
+	}
+	if rec.helperCalls == 0 {
+		t.Error("EventuallyEveryFunc did not call t.Helper()")
+	}
+	if elapsed := time.Since(start); elapsed < timeout {
+		t.Errorf("EventuallyEveryFunc gave up after %s, before the %s timeout", elapsed, timeout)
+	}
+	if got := describeCalls.Load(); got != 1 {
+		t.Errorf("describe called %d times, want exactly once (it may do real work: render a frame, dump a queue)", got)
+	}
+	finalPolls := polls.Load()
+	if finalPolls < 2 {
+		t.Fatalf("cond polled only %d times in %s at a 5ms interval; the wait did not sample", finalPolls, timeout)
+	}
+	if strings.Contains(rec.fatal, "state after 0 polls") {
+		t.Errorf("failure message describes t=0 — the description was captured eagerly:\n%s", rec.fatal)
+	}
+	for _, want := range []string{
+		fmt.Sprintf("state after %d polls", finalPolls), // the deadline-time state
+		timeout.String(), // how long it waited
+	} {
+		if !strings.Contains(rec.fatal, want) {
+			t.Errorf("Fatalf message %q does not contain %q", rec.fatal, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Restores the `internal/testutil` coverage gate (red at v4 @ 6845aaf4: `testutil: 75.7% (floor 90%)`, run 33578483134) by adding behavioural tests for `EventuallyEveryFunc`, the only uncovered function (0%). Package is back to **100.0% of statements**.

## Which merge introduced the gap

Commit `22b8eff8` — "fix(tui): fix six hanging/flaky acceptance tests in the T33 harness", merged via **#5573** (merge commit `6845aaf4`) — added `EventuallyEveryFunc` to `src/internal/testutil/eventually.go` as a supporting helper for the TUI harness fix, with no accompanying test. That merge landed after #5598 had brought the package to 100%, so the new 33-line helper alone pulled it to 75.7%.

This is the second occurrence of the same pattern (#5597 was the first): a PR whose primary subject lives elsewhere adds a helper to `internal/testutil` and ships it untested, and the gap only surfaces when the gate runs on the merge commit. A contributing guard ("any diff touching `src/internal/testutil/*.go` must touch a `*_test.go` in the same package, or the coverage job runs on the PR itself") may be worth a follow-up.

## Tests (in-process, per the #5598 convention, so the profile sees them)

- **`TestEventuallyEveryFunc_ReturnsOnceConditionHolds`** — returns as soon as cond holds, stops polling exactly then, and `describe` is never invoked on the success path (its contract: "at most once, only on the failure path"), so an expensive describe is free when the wait succeeds.
- **`TestEventuallyEveryFunc_DescribeIsLazyAndAtMostOnce`** — pins the function's raison d'être. `cond` counts its own polls; `describe` reports the count. An implementation that captured the description eagerly (the printf-argument form this helper replaces) would report the t=0 state ("0 polls"); the test requires the deadline-time state, `describe` called exactly once, `t.Helper()` called, the timeout string in the message, and the full timeout honoured before giving up.

`EventuallyEveryFunc` returns after `Fatalf`, so the package's existing `recordingTB` double suffices (no `runtime.Goexit` double needed — that pattern is only required for the non-returning guards).

## Verification

- `go test ./internal/testutil/ -count=1` → `coverage: 100.0% of statements`
- `go test ./internal/testutil/ -count=5 -shuffle=on` → ok
- `go vet ./internal/testutil/` clean; `gofmt -l` clean on the changed file

Fixes #5600