### PR TITLE
🧪 test: finish the #5388 Go-side skip conversion — repo-file gates and self-disarming guards

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -143,6 +143,13 @@ jobs:
         env:
           IDX: ${{ matrix.idx }}
           TOTAL: ${{ strategy.job-total }}
+          # The converted skips in pkg/hub gate on repo files being present in
+          # the checkout (deploy/k8s/error-pages.yaml) — a precondition
+          # actions/checkout above GUARANTEES here, so a skip at a converted
+          # site means the test broke, not that the environment is unsuitable
+          # (#5388). Only testutil.SkipUnlessRequired sites become fatal;
+          # plain t.Skip capability gates are unaffected.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: |
           set -o pipefail
           go test ./pkg/hub -short -list '.*' | grep -E '^(Test|Example|Fuzz)' | LC_ALL=C sort > all-tests.txt
@@ -374,6 +381,16 @@ jobs:
       - name: Test
         env:
           PKGS: ${{ matrix.pkgs }}
+          # The converted skips in the rest packages gate on repo files being
+          # present in the checkout (deploy/entrypoint.sh, Dockerfile,
+          # deploy/nginx.conf, config/backends.conf, bin/gh-app-token.sh,
+          # bin/hive-open-pr.sh) — a precondition actions/checkout above
+          # GUARANTEES here, so a skip at a converted site means the test
+          # broke, not that the environment is unsuitable (#5388). Only
+          # testutil.SkipUnlessRequired sites become fatal; plain t.Skip
+          # capability gates (root, symlinks, git, /data writability, tool
+          # availability) are unaffected and stay permissive.
+          HIVE_TEST_REQUIRE_BEHAVIOURAL: '1'
         run: |
           set -o pipefail
           if [ -z "$PKGS" ]; then

--- a/src/pkg/agent/host_state_deny_test.go
+++ b/src/pkg/agent/host_state_deny_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // backendsConfPath is the shell half of this policy. Both launch paths must
@@ -88,7 +90,7 @@ func TestGitHubWriteDenialsSurvive(t *testing.T) {
 // same way whichever launched it.
 func TestShellAndGoDenyListsAgree(t *testing.T) {
 	if _, err := os.Stat(backendsConfPath); err != nil {
-		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+		testutil.SkipfUnlessRequired(t, "backends.conf not reachable from the test working directory: %v", err)
 	}
 	out, err := exec.Command("bash", "-c",
 		"source "+backendsConfPath+" && printf '%s' \"$CLAUDE_HOST_DENY_TOOLS\"").Output()

--- a/src/pkg/config/backend_list_parity_test.go
+++ b/src/pkg/config/backend_list_parity_test.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // backendListsConfPath is the shell half of the CLI-backend list. config.go's
@@ -70,7 +72,7 @@ func exceptedCLINames() map[string]bool {
 func shellKnownBackends(t *testing.T) []string {
 	t.Helper()
 	if _, err := os.Stat(backendListsConfPath); err != nil {
-		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+		testutil.SkipfUnlessRequired(t, "backends.conf not reachable from the test working directory: %v", err)
 	}
 	out, err := exec.Command("bash", "-c",
 		"source "+backendListsConfPath+" && printf '%s' \"$KNOWN_BACKENDS\"").Output()
@@ -163,7 +165,7 @@ func TestLiteLLMExceptionIsAnInferenceBackend(t *testing.T) {
 // name the shell has no path to at all.
 func TestGeminiExceptionRoutesByModelPrefix(t *testing.T) {
 	if _, err := os.Stat(backendListsConfPath); err != nil {
-		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+		testutil.SkipfUnlessRequired(t, "backends.conf not reachable from the test working directory: %v", err)
 	}
 	out, err := exec.Command("bash", "-c",
 		"source "+backendListsConfPath+" && detect_backend_from_model gemini-2.5-pro").Output()
@@ -186,7 +188,7 @@ func TestGeminiExceptionRoutesByModelPrefix(t *testing.T) {
 // fallback.
 func TestBackendBinaryAndPermFlagCoverKnownBackends(t *testing.T) {
 	if _, err := os.Stat(backendListsConfPath); err != nil {
-		t.Skipf("backends.conf not reachable from the test working directory: %v", err)
+		testutil.SkipfUnlessRequired(t, "backends.conf not reachable from the test working directory: %v", err)
 	}
 	for _, name := range shellKnownBackends(t) {
 		script := "source " + backendListsConfPath + " && " +

--- a/src/pkg/config/egress_gate_ipv6_test.go
+++ b/src/pkg/config/egress_gate_ipv6_test.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // These tests pin the IPv6 half of the forced-proxy egress gate (#4319).
@@ -35,7 +37,7 @@ func runEgressGate(t *testing.T, env map[string]string, shims []string, ipv6Stac
 	t.Helper()
 	src, err := os.ReadFile(entrypointPath)
 	if err != nil {
-		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "entrypoint.sh not readable from this package: %v", err)
 	}
 	text := string(src)
 	start := strings.Index(text, "PROXY_PORT=18443")

--- a/src/pkg/config/entrypoint_boot_test.go
+++ b/src/pkg/config/entrypoint_boot_test.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // entrypointPath is the script under test, relative to this package.
@@ -41,7 +43,7 @@ func runBootPreludeRoot(t *testing.T, env map[string]string, files map[string]st
 	t.Helper()
 	src, err := os.ReadFile(entrypointPath)
 	if err != nil {
-		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "entrypoint.sh not readable from this package: %v", err)
 	}
 	text := string(src)
 	// Cut at the cleanup marker that follows the config branch.
@@ -290,7 +292,7 @@ func launchArgvAfterReconciliation(t *testing.T, hiveConfigEnv string) []string 
 	t.Helper()
 	src, err := os.ReadFile(entrypointPath)
 	if err != nil {
-		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "entrypoint.sh not readable from this package: %v", err)
 	}
 	text := string(src)
 
@@ -369,7 +371,7 @@ func TestUnsetHiveConfigLeavesArgvAlone(t *testing.T) {
 func TestLaunchUsesTheReconciledArgv(t *testing.T) {
 	src, err := os.ReadFile(entrypointPath)
 	if err != nil {
-		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "entrypoint.sh not readable from this package: %v", err)
 	}
 	if !strings.Contains(string(src), `hive "$@" &`) {
 		t.Error(`entrypoint.sh no longer launches the binary as 'hive "$@" &'; the argv reconciliation above it can no longer reach the process`)
@@ -386,14 +388,21 @@ func TestLaunchUsesTheReconciledArgv(t *testing.T) {
 func TestDockerfileCMDAndEntrypointAgreeOnConfigPath(t *testing.T) {
 	dockerfile, err := os.ReadFile("../../Dockerfile")
 	if err != nil {
-		t.Skipf("Dockerfile not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "Dockerfile not readable from this package: %v", err)
 	}
 	if !strings.Contains(string(dockerfile), `CMD ["--config"`) {
-		t.Skip("the image CMD no longer passes -config explicitly; the coupling this guards is gone")
+		// Fail rather than skip (#5388): this condition depends only on repo
+		// content, so it is identical on every machine — a skip here is never
+		// "unsuitable environment", it means the coupling this test pins moved.
+		// If the CMD change is deliberate, retire or re-point this test in the
+		// same PR instead of letting it silently stop asserting anything.
+		t.Fatal("the image CMD no longer passes -config explicitly; the coupling this " +
+			"test guards is gone — update or retire TestDockerfileCMDAndEntrypointAgreeOnConfigPath " +
+			"in the PR that changed the Dockerfile CMD")
 	}
 	entry, err := os.ReadFile(entrypointPath)
 	if err != nil {
-		t.Skipf("entrypoint.sh not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "entrypoint.sh not readable from this package: %v", err)
 	}
 	if !strings.Contains(string(entry), `set -- "$@" --config "$HIVE_CONFIG"`) {
 		t.Error("the image CMD passes -config explicitly but entrypoint.sh no longer appends its own; HIVE_CONFIG is inert again (#4973)")

--- a/src/pkg/config/gateway_nginx_dualstack_test.go
+++ b/src/pkg/config/gateway_nginx_dualstack_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // nginxConfPath is the gateway config under test, relative to this package.
@@ -25,7 +27,7 @@ func readNginxConf(t *testing.T) string {
 	t.Helper()
 	src, err := os.ReadFile(nginxConfPath)
 	if err != nil {
-		t.Skipf("nginx.conf not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "nginx.conf not readable from this package: %v", err)
 	}
 	return string(src)
 }
@@ -68,8 +70,14 @@ func TestGatewayConfDoesNotRelyOnConfD(t *testing.T) {
 	conf := readNginxConf(t)
 	includeConfD := regexp.MustCompile(`(?m)^\s*include\s+/etc/nginx/conf\.d/`)
 	if includeConfD.MatchString(conf) {
-		t.Skip("nginx.conf now includes conf.d; the upstream IPv6 fixup may apply " +
-			"and the dual-stack rationale in TestGatewayListensDualStack needs review")
+		// Fail rather than skip (#5388): nginx.conf is repo content, identical
+		// everywhere, so a skip here could never mean "unsuitable environment"
+		// — it means the premise TestGatewayListensDualStack rests on moved.
+		// If including conf.d is deliberate, revisit that test's rationale in
+		// the same PR rather than letting this guard disarm itself silently.
+		t.Fatal("nginx.conf now includes /etc/nginx/conf.d; the upstream IPv6 fixup may " +
+			"apply and the dual-stack rationale in TestGatewayListensDualStack needs review " +
+			"in the PR that added the include")
 	}
 }
 

--- a/src/pkg/config/gh_app_token_script_test.go
+++ b/src/pkg/config/gh_app_token_script_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // bin/gh-app-token.sh mints two very different things from the same GitHub App
@@ -51,7 +53,7 @@ func runGHAppTokenScript(t *testing.T, warmCache bool, args ...string) scriptRun
 
 	src, err := os.ReadFile(ghAppTokenScriptPath)
 	if err != nil {
-		t.Skipf("gh-app-token.sh not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "gh-app-token.sh not readable from this package: %v", err)
 	}
 	for _, tool := range []string{"bash", "openssl", "jq", "python3"} {
 		if _, err := exec.LookPath(tool); err != nil {

--- a/src/pkg/dashboard/backend_picker_parity_test.go
+++ b/src/pkg/dashboard/backend_picker_parity_test.go
@@ -191,7 +191,14 @@ func TestCLIPinTooltipNamesNoUndispatchableBackend(t *testing.T) {
 	const marker = "Which CLI backend to pin this agent to when CLI Pinned is on. Options:"
 	i := strings.Index(src, marker)
 	if i < 0 {
-		t.Skip("CLI Pin Value tooltip not found; it was reworded and this guard needs re-pointing")
+		// Fail rather than skip (#5388): the tooltip text is repo content, so
+		// this condition is identical on every machine and a skip could never
+		// mean "unsuitable environment" — it means the marker moved and the
+		// prose guard #4988 asked for silently stopped covering anything.
+		// Rewording the tooltip is fine; re-point the marker in the same PR.
+		t.Fatal("CLI Pin Value tooltip marker not found; the tooltip was reworded — " +
+			"re-point the marker in TestCLIPinTooltipNamesNoUndispatchableBackend " +
+			"in the PR that reworded it")
 	}
 	rest := src[i+len(marker):]
 	if end := strings.Index(rest, "."); end >= 0 {

--- a/src/pkg/github/hive_open_pr_script_test.go
+++ b/src/pkg/github/hive_open_pr_script_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kubestellar/hive/internal/testutil"
 )
 
 // bin/hive-open-pr.sh is what agents run INSTEAD of `gh pr create`; it writes
@@ -27,7 +29,7 @@ func runHiveOpenPR(t *testing.T, args ...string) PRRequest {
 	t.Helper()
 	src, err := os.ReadFile(hiveOpenPRScriptPath)
 	if err != nil {
-		t.Skipf("hive-open-pr.sh not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "hive-open-pr.sh not readable from this package: %v", err)
 	}
 	for _, tool := range []string{"bash", "python3"} {
 		if _, err := exec.LookPath(tool); err != nil {

--- a/src/pkg/hub/error_pages_backend_test.go
+++ b/src/pkg/hub/error_pages_backend_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubestellar/hive/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,7 +22,7 @@ func errorPagesConfigMaps(t *testing.T) (docs, conf map[string]string) {
 	t.Helper()
 	raw, err := os.ReadFile(errorPagesManifestPath)
 	if err != nil {
-		t.Skipf("error-pages.yaml not readable from this package: %v", err)
+		testutil.SkipfUnlessRequired(t, "error-pages.yaml not readable from this package: %v", err)
 	}
 	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
 	for {
@@ -186,7 +187,14 @@ func TestErrorBackendKeepsHealthProbe(t *testing.T) {
 // anything and should be revisited rather than silently kept green.
 func TestHiveIngressStillRoutesErrorsToThisBackend(t *testing.T) {
 	if !strings.Contains(k8sManifestTemplate, `nginx.ingress.kubernetes.io/custom-http-errors: "502,503"`) {
-		t.Skip("the hive Ingress no longer intercepts 502/503; the error backend contract needs re-review")
+		// Fail rather than skip (#5388): k8sManifestTemplate is repo content,
+		// identical everywhere, so a skip here could never mean "unsuitable
+		// environment" — it means the premise of this whole suite moved and
+		// every error-pages assertion above silently stopped guarding anything.
+		// If dropping the interception is deliberate, re-review this file's
+		// contract in the same PR rather than letting it stay green vacuously.
+		t.Fatal("the hive Ingress no longer intercepts 502/503; the error backend contract " +
+			"this suite pins needs re-review in the PR that removed the custom-http-errors annotation")
 	}
 	if !strings.Contains(k8sManifestTemplate, "nginx.ingress.kubernetes.io/default-backend: hive-error-pages") {
 		t.Error("custom-http-errors is set without pointing at hive-error-pages, so intercepted " +

--- a/src/pkg/worksource/github_issues_test.go
+++ b/src/pkg/worksource/github_issues_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/github"
@@ -76,15 +77,28 @@ func TestGitHubIssuesSource_ListIssues_Error(t *testing.T) {
 	defer srv.Close()
 
 	client := github.NewClientForTest(srv.URL, "org", []string{"repo"}, testLogger())
+
+	// This used to skip when EnumerateActionable returned nil — which is
+	// exactly when it should fail (#5388): with a single repo whose every
+	// request 500s, a nil error means the all-repos-failed guard in
+	// EnumerateActionable regressed, and a zero-count result would tell the
+	// governor the queue is empty and idle the agents. The guard's absence is
+	// the bug this test exists to catch, not a reason to stand aside.
 	if _, err := client.EnumerateActionable(context.Background()); err == nil {
-		// Some client paths tolerate per-repo failures; only assert the
-		// worksource error wrapping when enumeration itself fails.
-		t.Skip("EnumerateActionable tolerates repo errors; skipping error-path assertion")
+		t.Fatal("EnumerateActionable returned nil error although every request to its " +
+			"only repo failed; the all-repos-failed guard has regressed and a zero-count " +
+			"result would silently idle the agents")
 	}
 
 	src := worksource.NewGitHubIssuesSource(client)
-	if _, err := src.ListIssues(context.Background()); err == nil {
+	_, err := src.ListIssues(context.Background())
+	if err == nil {
 		t.Fatal("expected error from ListIssues, got nil")
+	}
+	// The worksource must wrap, not swallow or rephrase, the enumeration
+	// error, so callers can trace a failure back through the source boundary.
+	if !strings.Contains(err.Error(), "worksource/github: enumerate:") {
+		t.Errorf("ListIssues error %q does not carry the worksource/github: enumerate: wrap", err)
 	}
 }
 


### PR DESCRIPTION
## Audit: the four guards #5388 named are already property-asserting on v4

| # | guard | state on v4 today |
|---|---|---|
| #5360 | `test_entrypoint_runtime_config.sh` | asserts the property: really `open()`s the hardened config as uid 1001 via `su`, with a `nobody` negative control, and its skips are fatal under `HIVE_TEST_REQUIRE_BEHAVIOURAL=1` (#5383, #5520) |
| #5370 | Podman arm64 lane | builds the PR's own image on `pull_request`, probes it with `--local`, missing-image fails rather than skips; pinned by `test_arm64_lane_probes_pr_code.sh` |
| #5380 | entrypoint suites skipping silently | `src/deploy/test_lib.sh` `hive_test_skip` is fatal under the flag; armed in `v2-ci.yml`, `podman-arm64-lane.yml` (#5490/#5520) |
| #5077 | openapi route parity documented-not-true | `openapi_schema_parity_test.go` pins documented schemas to the Go types the handlers marshal; `openapi_route_parity_test.go` fails on unresolvable routes and stale exceptions; `dashboard/openapi.json` is inside `v2-tests.yml`'s path filter |

So this PR closes what the issue thread identified as the outstanding remainder: the last convertible Go-side `t.Skip` sites (the "one more PR, not a migration programme" from the scope-correction comment).

## What this PR does

### 1. Repo-file skip family → `testutil.SkipUnlessRequired` (13 sites)

Skips gating on `entrypoint.sh`, `Dockerfile`, `nginx.conf`, `backends.conf`, `error-pages.yaml`, `gh-app-token.sh`, or `hive-open-pr.sh` being readable. These files are guaranteed present by **any checkout** — the discriminator this issue settled on ("convert where our own code guarantees the precondition, leave permissive where the machine does") puts them squarely in the convertible set.

- `pkg/config/entrypoint_boot_test.go` (5 sites), `egress_gate_ipv6_test.go`, `gateway_nginx_dualstack_test.go`, `gh_app_token_script_test.go`, `backend_list_parity_test.go` (3 sites)
- `pkg/github/hive_open_pr_script_test.go`
- `pkg/hub/error_pages_backend_test.go`
- `pkg/agent/host_state_deny_test.go` (live immediately — the agent lane already arms the flag)

`HIVE_TEST_REQUIRE_BEHAVIOURAL=1` is now armed on the **test-hub** and **test-rest** shards of `v2-tests.yml`, whose `actions/checkout` enforces exactly this precondition. Only `SkipUnlessRequired` sites become fatal; plain `t.Skip` capability gates (root, symlinks, git, `/data` writability, tool availability, Windows semantics) are untouched and stay permissive.

### 2. Self-disarming skips → fail instead of skip (5 sites, f16 precedent)

These skips' conditions are **repo content**, identical on every machine — a skip could never mean "unsuitable environment"; it fires exactly when the guarded property moves, converting the guard into a silent green (the #5398 P1 family; `f16_owner_gate_test.go` set the precedent):

- `pkg/config/entrypoint_boot_test.go` — Dockerfile CMD drops `--config` → was skip, now fail ("retire or re-point in the PR that changed the CMD")
- `pkg/hub/error_pages_backend_test.go` — Ingress drops 502/503 interception → was skip, now fail
- `pkg/dashboard/backend_picker_parity_test.go` — CLI Pin tooltip marker gone → was skip, now fail
- `pkg/config/gateway_nginx_dualstack_test.go` — `conf.d` include appears → was skip, now fail
- `pkg/worksource/github_issues_test.go` — rewritten to assert the actual invariant: with every request to the only repo failing, a nil error from `EnumerateActionable` **is** the regression (the all-repos-failed guard protecting the governor from a false-empty queue), not a reason to stand aside. Also asserts the `worksource/github: enumerate:` error wrap.

### 3. What deliberately stays permissive

Per the calibration finding recorded on the issue: genuine capability gates (tmux, root/privilege, podman/docker, git, symlinks, `/data` writability, Windows mode-bit semantics) are **not** converted — making those fatal manufactures false reds and gets the detector ignored.

## Can-fail demonstrations (per the #5383/#5384 standard)

All produced locally by breaking the **subject** (never the test), observed, then restored before committing — no demo commit is carried on the branch, per the pattern #5587 established. Every mutation compiled (no vacuous reds).

### Repo-file family — file physically removed, same test, only the flag flipped

| demo | flag unset | flag=1 |
|---|---|---|
| `deploy/entrypoint.sh` removed / `config.TestLaunchUsesTheReconciledArgv` | `--- SKIP … ok` (the #5388 bug, green) | `--- FAIL … BROKEN TEST` |
| `Dockerfile` removed / `config.TestDockerfileCMDAndEntrypointAgreeOnConfigPath` | `--- SKIP … ok` | `--- FAIL … BROKEN TEST` |
| `deploy/nginx.conf` removed / `config.TestGatewayListensDualStack` | `--- SKIP … ok` | `--- FAIL … BROKEN TEST` |
| `config/backends.conf` removed / `config.TestShellAndGoCLIBackendListsAgree` | `--- SKIP … ok` | `--- FAIL … BROKEN TEST` |
| `config/backends.conf` removed / `agent.TestShellAndGoDenyListsAgree` | `--- SKIP … ok` | `--- FAIL … BROKEN TEST` |
| `bin/gh-app-token.sh` removed / `config.TestBareInvocationNeverPrintsTheToken` | subtests SKIP, parent green | `--- FAIL … BROKEN TEST` |
| `deploy/k8s/error-pages.yaml` removed / `hub.TestErrorBackendKeepsHealthProbe` | `--- SKIP … ok` | `--- FAIL … BROKEN TEST` |
| `bin/hive-open-pr.sh` removed / `github.TestHiveOpenPRScript_OmittedBaseLeavesBaseUnset` | `--- SKIP … ok` | `--- FAIL … BROKEN TEST` |

### Self-disarming sites — planted mutation, old guard vs new guard

| demo (mutation planted in the subject) | old guard | new guard |
|---|---|---|
| Dockerfile `CMD ["--config"` → `["--konfig"` | `--- SKIP … ok` (silent green) | `--- FAIL` |
| `saas_provision.go` `custom-http-errors: "502,503"` → `"502,504"` | `--- SKIP … ok` | `--- FAIL` |
| `static/index.html` CLI Pin tooltip reworded | `--- SKIP … ok` | `--- FAIL` |
| `deploy/nginx.conf` gains `include /etc/nginx/conf.d/*.conf;` | `--- SKIP … ok` | `--- FAIL` |
| `client.go` all-repos-failed guard `>=` → `>` (compiles; guard never fires) | `--- SKIP … ok` | `--- FAIL` |

Every "old guard" column is the pre-change test run against the identical mutation — ten silent greens that are now ten reds.

## Verification

- `gofmt -l` clean on all ten touched Go files
- `go vet ./pkg/config ./pkg/github ./pkg/hub ./pkg/agent ./pkg/dashboard ./pkg/worksource` clean
- Every test function in the touched files run in **both** flag states: green (one pre-existing macOS-only failure in `TestEntrypointHardensRuntimeConfigItRecreates` — `chown dev:node` host artifact, fails identically on clean v4, green on Linux CI)

Fixes #5388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
