### PR TITLE
✨ feat(dashboard): one-click start & resume for paused agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ## Unreleased
 
+### Added
+
+- A paused agent whose session is also down now offers a single **▶ start & resume** button on its dashboard card ([#5594](https://github.com/kubestellar/hive/issues/5594)). This completes the combined-action half of that issue: the card already named every blocker at once, but clearing a pause and a dead session still took two separate clicks (resume, then ↻ restart). The combined button chains the two existing endpoints client-side — resume first, so the fresh session is never born paused, then restart, which for a down session is simply "start" — and its tooltip still names any cadence blockers that one click will not clear. A paused agent with a live session keeps the plain **▶ resume**; a bare Start is never shown on a paused agent.
+
 ### Fixed
 
 - Dashboard model and method changes now update the managed agent's per-agent overlay as well as its runtime override and `hive.yaml` entry ([#5558](https://github.com/kubestellar/hive/issues/5558)). Previously the overlay remained at the pack-provided value and replaced the dashboard's saved choice on every config load; `/data/hive-state.json` replayed the runtime override after restarts, hiding the disagreement until that override was cleared. The dropdowns now persist the selected backend/model together with its operator-ownership marker in the authoritative overlay, and raise a system alert if that write fails.

--- a/src/pkg/dashboard/agent_card_start_resume_ui_test.go
+++ b/src/pkg/dashboard/agent_card_start_resume_ui_test.go
@@ -1,0 +1,96 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// Combined start & resume (#5594 follow-up). Resume-leads (#5599) made the
+// pause impossible to hide and its tooltip names the blockers resuming will
+// not clear — but a paused agent whose session is also down still took two
+// operator actions (resume, then restart) to get moving. These pins hold the
+// final step: one '▶ start & resume' button that clears both flags in a
+// single click, chaining the two EXISTING endpoints client-side.
+
+// TestPausedAgentCombinedStartResumePinned pins the invariants:
+//
+//  1. The paused action is built by the shared pausedAgentActionHtml helper
+//     at every render site (card grid, detail panel, detail fast path, and
+//     toggleAgent's optimistic patch) — the single place that guarantees a
+//     paused agent never shows a bare Start.
+//  2. Session up keeps plain '▶ resume' with agentToggleTitle's
+//     blocker-naming tooltip; session down renders the combined
+//     '▶ start & resume' wired to startResumeAgent.
+//  3. startResumeAgent chains resume BEFORE restart, so the freshly spawned
+//     session is never born paused.
+func TestPausedAgentCombinedStartResumePinned(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		// The shared helper: session-up branch delegates to the resume-leads
+		// tooltip, session-down branch renders the combined action.
+		"function pausedAgentActionHtml(a) {",
+		"agentToggleTitle(a, true, false)",
+		`data-action="startResumeAgent"`,
+		"start &amp; resume</button>",
+		// Dispatcher case for the combined action.
+		"case 'startResumeAgent': startResumeAgent(agent); break;",
+		// Client-side chaining of the two existing endpoints.
+		"function startResumeAgent(agent)",
+		"`/api/resume/${agent}`",
+		"`/api/restart/${agent}`",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("combined start & resume action missing snippet %q", snippet)
+		}
+	}
+
+	// Ordering pin inside startResumeAgent: resume must precede restart.
+	start := strings.Index(html, "function startResumeAgent(agent)")
+	if start < 0 {
+		t.Fatal("startResumeAgent definition missing")
+	}
+	fn := html[start:]
+	if end := strings.Index(fn, "async function restartAgent"); end > 0 {
+		fn = fn[:end]
+	}
+	resumeIdx := strings.Index(fn, "/api/resume/")
+	restartIdx := strings.Index(fn, "/api/restart/")
+	if resumeIdx < 0 || restartIdx < 0 || resumeIdx > restartIdx {
+		t.Fatalf("startResumeAgent must call /api/resume before /api/restart (resume@%d restart@%d)", resumeIdx, restartIdx)
+	}
+
+	// Every paused-action render site delegates to the helper: definition +
+	// card grid + detail full render + detail fast path + toggleAgent's
+	// optimistic just-paused patch.
+	if got := strings.Count(html, "pausedAgentActionHtml(a"); got < 5 {
+		t.Fatalf("pausedAgentActionHtml referenced %d times, want >= 5 (definition + grid + detail + fast path + toggleAgent patch)", got)
+	}
+}
+
+// TestCombinedActionPreservesResumeLeads pins that the follow-up sits ON TOP
+// of resume-leads rather than replacing it: the grid's paused branch still
+// wins the slot before the cadence gear, and the detail panel checks paused
+// before off — so the combined button can never be displaced by, nor
+// degrade into, a bare Start.
+func TestCombinedActionPreservesResumeLeads(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		// Grid: paused leads (same structural pin as TestAgentCardResumeLeads),
+		// now delegating to the shared helper.
+		"const toggleBtn = canToggle ? (isPaused && canPauseToggle\n          ? pausedAgentActionHtml(a)",
+		// Detail panel: paused checked before the off/start branch.
+		": isPaused\n            ? pausedAgentActionHtml(a)",
+		// Detail fast path: paused rebuilds via the helper so data-action
+		// tracks the session state, not just the label.
+		"fastToggle.outerHTML = pausedAgentActionHtml(a);",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("resume-leads integration missing snippet %q", snippet)
+		}
+	}
+	// The combined label must carry the HTML-escaped '&amp;' — a raw '&'
+	// inside button markup is invalid HTML and a regression magnet.
+	if strings.Contains(html, "start & resume</button>") {
+		t.Error("combined label must use the HTML-escaped '&amp;' form, not a raw '&'")
+	}
+}

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -4432,10 +4432,18 @@
         // button would otherwise persist until the user navigates away.
         const fastToggle = detail.querySelector('.oc-detail-actions .btn-toggle');
         if (fastToggle && !isOnDemand) {
-          fastToggle.className = `btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}`;
-          fastToggle.textContent = isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause';
-          fastToggle.dataset.paused = String(isPaused);
-          fastToggle.title = agentToggleTitle(a, isPaused, isOff);
+          if (isPaused) {
+            // Paused gets the full combined-action rebuild — '▶ start &
+            // resume' when the session is also down — so data-action tracks
+            // the session state too, not just the label (#5594 follow-up).
+            fastToggle.outerHTML = pausedAgentActionHtml(a);
+          } else {
+            fastToggle.className = `btn-toggle ${isOff ? 'off' : 'running'}`;
+            fastToggle.textContent = isOff ? '▶ start' : '⏸ pause';
+            fastToggle.dataset.action = 'toggleAgent';
+            fastToggle.dataset.paused = 'false';
+            fastToggle.title = agentToggleTitle(a, false, isOff);
+          }
         }
         // Same for the blockers line, the stat fields and the indicators — they
         // live outside the scroll region, so replacing them wholesale cannot
@@ -4541,7 +4549,9 @@
             ? '<button class="btn-toggle on-demand" title="On-demand agent — kicked manually, not by governor cadence">⚡ on demand</button>'
             : !dashboardRoleAtLeast(window._hiveRole || 'read', 'owner')
             ? ''
-            : `<button class="btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="${isPaused}" title="${esc(agentToggleTitle(a, isPaused, isOff))}">${isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause'}</button>`}
+            : isPaused
+            ? pausedAgentActionHtml(a)
+            : `<button class="btn-toggle ${isOff ? 'off' : 'running'}" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="false" title="${esc(agentToggleTitle(a, false, isOff))}">${isOff ? '▶ start' : '⏸ pause'}</button>`}
           ${sessionChip(a, '▶ terminal', `<a href="${terminalUrl(a.name)}" target="_blank" rel="noopener" class="terminal-link" data-action="openTerminal" data-agent="${esc(a.name)}" title="Open the live tmux terminal session for this agent in a new tab">▶ terminal</a>`)}
           ${sessionChip(a, '📄 full log', `<a href="${fullLogUrl(a.name, false)}" target="_blank" rel="noopener" class="terminal-link" title="Open the full retained log of this agent's latest run as selectable, searchable text in a new tab">📄 full log</a>`)}
           ${sessionChip(a, '⬇ log', `<a href="${fullLogUrl(a.name, true)}" download class="terminal-link" title="Download the full retained log of this agent's latest run as a text file">⬇ log</a>`)}
@@ -6435,6 +6445,29 @@
       if (isOff) return 'Start this agent \u2014 it is currently off in this governor mode';
       return 'Pause this agent \u2014 stops governor from kicking it until resumed';
     }
+    /* Combined primary action for a PAUSED agent \u2014 the follow-up to
+       resume-leads (#5594). Resume-leads guarantees the pause is never
+       hidden, and its tooltip names the session as a blocker resuming will
+       not clear; this removes that residual two-step dance: when the session
+       is ALSO down, the one button reads '\u25b6 start & resume' and clears both
+       flags in a single click via startResumeAgent (a client-side chain of
+       the two existing endpoints \u2014 resume, then restart \u2014 no new backend
+       surface). A session-up paused agent keeps the plain '\u25b6 resume' with
+       agentToggleTitle's blocker-naming tooltip. Every render site (card
+       grid, detail panel, detail fast path) builds the paused action here,
+       which is the single place that guarantees a paused agent never shows
+       a bare Start. */
+    function pausedAgentActionHtml(a) {
+      if (a.state === 'running') {
+        return `<button class="btn-toggle paused" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="true" title="${esc(agentToggleTitle(a, true, false))}">\u25b6 resume</button>`;
+      }
+      const rest = [];
+      if (a.offByCadence === true) rest.push('its cadence for the current governor mode is off (\u2699\ufe0f \u2192 Cadences)');
+      if (a.noCadence === true) rest.push('no governor mode gives it a cadence (\u2699\ufe0f \u2192 Cadences)');
+      let title = 'This agent is paused AND its session is down \u2014 one click resumes it and asks the supervisor to start the session. No second Resume step.';
+      if (rest.length > 0) title += ` Still not enough on its own: ${rest.join('; ')}.`;
+      return `<button class="btn-toggle paused" data-action="startResumeAgent" data-agent="${esc(a.name)}" data-paused="true" title="${esc(title)}">\u25b6 start &amp; resume</button>`;
+    }
     function neverScheduledChipHtml(a, configTarget) {
       if (a.noCadence !== true) return '';
       const who = a.displayName || a.name;
@@ -6520,7 +6553,7 @@
            blockers ride in the tooltip and on the blockers line below, so the
            operator learns them before the click, not after. */
         const toggleBtn = canToggle ? (isPaused && canPauseToggle
-          ? `<button class="btn-toggle paused" data-action="toggleAgent" data-agent="${esc(a.name)}" data-paused="true" title="${esc(agentToggleTitle(a, true, false))}">▶ resume</button>`
+          ? pausedAgentActionHtml(a)
           : isOff
           ? `<button class="btn-toggle off" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Agent is off in this governor mode — click to configure per-mode cadences">⚙ off</button>`
           : isOnDemand
@@ -14460,6 +14493,7 @@ function burnAreaChart() {
       const agent = el.dataset.agent || '';
       switch (action) {
         case 'toggleAgent': toggleAgent(agent, el.dataset.paused === 'true'); break;
+        case 'startResumeAgent': startResumeAgent(agent); break;
         case 'restartAgent': restartAgent(agent); break;
         case 'openConfigDialog': { const ct = el.dataset.configType || el.dataset.arg0 || 'agent'; const tab = el.dataset.tab || el.dataset.arg2 || null; if (el.classList.contains('agent-link')) { closeConfigDialog(); setTimeout(() => openConfigDialog(ct, agent, tab), 100); } else { openConfigDialog(ct, agent || null, tab); } } break;
         case 'ocSendKick': ocSendKick(agent); break;
@@ -14838,7 +14872,14 @@ function burnAreaChart() {
         document.querySelectorAll(`.agent-card[data-agent="${CSS.escape(agent)}"] .agent-blockers`)
           .forEach(el => { el.outerHTML = agentBlockerLineHtml(agentObj); });
         document.querySelectorAll(`.agent-card[data-agent="${CSS.escape(agent)}"] .btn-toggle`)
-          .forEach(el => { el.title = agentToggleTitle(agentObj, nowPaused, false); });
+          .forEach(el => {
+            // A just-paused agent gets the full combined-action rebuild —
+            // the combined start-and-resume button when its session is also
+            // down (#5594 follow-up); an unpaused one only needs its tooltip
+            // refreshed.
+            if (nowPaused) el.outerHTML = pausedAgentActionHtml(agentObj);
+            else el.title = agentToggleTitle(agentObj, false, false);
+          });
       }
       // The focused agent-detail panel renders its own toggle button — the
       // .agent-card loop above never reaches it, so re-render it from the
@@ -14859,6 +14900,40 @@ function burnAreaChart() {
       } else {
         dismissToast(toast, `${agent} ${action}d`, 'success');
       }
+    }
+
+    // Combined start & resume for a paused agent whose session is also down
+    // (#5594 follow-up to resume-leads). Client-side chain of the two
+    // existing endpoints — resume FIRST so the pause is cleared before the
+    // supervisor spawns the session (a session started while still paused
+    // would just sit unkickable), then restart, which for a down session is
+    // simply "start". No confirm dialog: unlike restartAgent there is no
+    // live session to kill.
+    async function startResumeAgent(agent) {
+      const toast = showToast(`Starting & resuming ${agent}...`, 'info', true);
+      try {
+        const res = await fetch(`/api/resume/${agent}`, { method: 'POST' });
+        const data = await res.json();
+        if (!data.ok) { dismissToast(toast, `Resume failed: ${data.error || 'unknown'}`, 'error'); return; }
+        const res2 = await fetch(`/api/restart/${agent}`, { method: 'POST' });
+        const data2 = await res2.json();
+        if (!data2.ok) { dismissToast(toast, `Resumed, but session start failed: ${data2.error || 'unknown'}`, 'error'); return; }
+      } catch (e) {
+        dismissToast(toast, `Start & resume failed: ${e}`, 'error');
+        return;
+      }
+      // Same optimistic patch discipline as toggleAgent: the blockers line
+      // and the action button render from the agent object, so update it and
+      // repaint before the next poll confirms.
+      const agentObj = (window._lastAgents || []).find(x => x.name === agent);
+      if (agentObj) {
+        agentObj.paused = false;
+        document.querySelectorAll(`.agent-card[data-agent="${CSS.escape(agent)}"] .agent-blockers`)
+          .forEach(el => { el.outerHTML = agentBlockerLineHtml(agentObj); });
+      }
+      if (typeof ocRenderAgentDetail === 'function') ocRenderAgentDetail();
+      refreshStatus();
+      dismissToast(toast, `${agent} resumed — supervisor is starting the session`, 'success');
     }
 
     async function restartAgent(agent) {


### PR DESCRIPTION
## Summary

Completes the combined-action part of #5594 that PR #5599 deliberately deferred.

#5599 fixed the visibility half: resume leads on a paused card, the tooltip names every blocker resuming will not clear, and the blockers line shows session, scheduling and next kick at once. But a paused agent whose session is also down still takes two operator actions to get moving — resume, then a separate restart. This PR collapses that into one click.

## What changed

**One combined button.** A new shared `pausedAgentActionHtml(a)` helper builds the paused primary action at every render site — card grid, ops-center detail panel, the detail poll fast path, and `toggleAgent`'s optimistic just-paused patch:

- **session up** → the plain `▶ resume` button, unchanged, with `agentToggleTitle`'s blocker-naming tooltip;
- **session down** → one `▶ start & resume` button wired to a new `startResumeAgent` action.

**Client-side chaining, no new backend surface.** `startResumeAgent` chains the two existing endpoints: `POST /api/resume/{agent}` first, so the pause is cleared before the supervisor spawns the session (a session started while still paused would just sit unkickable), then `POST /api/restart/{agent}`, which for a down session is simply "start". No confirm dialog — unlike `↻ restart` there is no live session to kill. Per-step error toasts distinguish "resume failed" from "resumed, but session start failed".

**Rides on top of resume-leads, does not replace it.** The grid's paused branch keeps the slot ahead of the cadence gear (`isPaused && canPauseToggle` still leads), the detail ternary checks paused before off, and the fast path now rebuilds the paused button rather than mutating its label so `data-action` tracks the session state too. The combined button's tooltip still names any cadence blockers the one click will not clear, in the same wording as `agentToggleTitle`. After success the blockers line repaints from the updated agent object, matching `toggleAgent`'s optimistic patch discipline. A bare Start is never shown on a paused agent.

## Tests

Markup pins in `src/pkg/dashboard/agent_card_start_resume_ui_test.go`:

- the helper and its two branches (delegation to `agentToggleTitle` when the session is up; the combined `start &amp; resume` label + `data-action="startResumeAgent"` when down);
- the dispatcher case;
- resume-before-restart ordering inside `startResumeAgent`;
- helper used at all five sites (definition + grid + detail + fast path + toggleAgent patch);
- #5599's resume-leads structural pins still hold (`TestAgentCardResumeLeads`, blockers-line pins) — verified locally alongside the new tests; targeted `go vet ./pkg/dashboard/` clean.

## Related issues

Refs #5594
Refs #5599

## Contributor checklist

- [x] PR targets `v4` (the repo's default branch).
- [x] Title uses the repo emoji convention.
- [x] Commits include DCO sign-off (`git commit -s`).
- [x] `CHANGELOG.md` has an entry under Unreleased → Added.
- [x] No secrets, credentials, or local runtime state are committed.