### PR TITLE
📝 docs: cross-link fleet health verdict from health-checks.md

### DIFF
--- a/src/docs/health-checks.md
+++ b/src/docs/health-checks.md
@@ -2,6 +2,8 @@
 
 Hive reports dashboard health from both the spoke and hub vantage points. The newer checks replace the old assumption that the public hub can always probe every spoke URL directly.
 
+This page covers *reachability* — HTTP probes of the dashboard URL and route. For the per-hive green/amber/red/unknown *output* verdict on `/fleet` (the WHY chip and remediation hints), see [fleet health](fleet-health.md): a hive can pass every probe here and still be red there.
+
 ## Kubernetes RBAC
 
 Apply the dashboard route RBAC manifest with the other Kubernetes resources:


### PR DESCRIPTION
## Summary

Follow-up to #5612 (merged): ports the one piece of the duplicate PR #5609 that #5612 did not carry — a cross-link at the top of `src/docs/health-checks.md` pointing readers at the new `fleet-health.md` page, so the reachability-vs-output split is discoverable from both directions.

Two lines, docs only.

Relates to #5606

🤖 Generated with [Claude Code](https://claude.com/claude-code)