### PR TITLE
🌱 refactor(dashboard): slice 2 — collect package (#5565)

### DIFF
--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/kubestellar/hive/pkg/classify"
 	"github.com/kubestellar/hive/pkg/config"
 	"github.com/kubestellar/hive/pkg/dashboard"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	"github.com/kubestellar/hive/pkg/defsrc"
 	"github.com/kubestellar/hive/pkg/discord"
 	"github.com/kubestellar/hive/pkg/escalation"
@@ -1384,7 +1385,7 @@ func main() {
 	// A missing or unparseable file is ordinary on a hive upgrading into this
 	// feature — it simply starts with no history rather than failing to boot.
 	const budgetWindowHistoryPath = "/data/budget-window-history.json"
-	var pendingBudgetWindowSeed []dashboard.BudgetWindowEntry
+	var pendingBudgetWindowSeed []collect.BudgetWindowEntry
 	if budgetData, err := os.ReadFile(budgetWindowHistoryPath); err == nil {
 		if err := json.Unmarshal(budgetData, &pendingBudgetWindowSeed); err == nil && len(pendingBudgetWindowSeed) > 0 {
 			logger.Info("budget window history loaded", "entries", len(pendingBudgetWindowSeed))
@@ -2183,7 +2184,7 @@ func main() {
 			"set project.ai_author in hive.yaml so this hive contributes to the fleet total",
 			"author", fleetStatsAuthor, "org", cfg.Project.Org)
 	}
-	fleetStatsCollector := dashboard.NewFleetStatsCollector(ghClient, fleetStatsAuthor, cfg.Project.Org, logger)
+	fleetStatsCollector := collect.NewFleetStatsCollector(ghClient, fleetStatsAuthor, cfg.Project.Org, logger)
 	// Persist the collected counts on the /data PVC (same store as sessions and
 	// cost/fact history) so a restart resumes from the last-known counts instead
 	// of nil. Without this, a fleet-wide upgrade clears every spoke's in-memory
@@ -2198,7 +2199,7 @@ func main() {
 	// hive is producing output back to its work source. Persisted to the /data
 	// PVC so a restart resumes the last summary; the collector loop reads
 	// /data/audit.jsonl every few minutes.
-	activityCollector := dashboard.NewActivityCollector(dashSrv.GetAudit(), "", logger)
+	activityCollector := collect.NewActivityCollector(dashSrv.GetAudit(), "", logger)
 	activityCollector.EnablePersistence("/data/activity.json")
 	go activityCollector.Start(ctx)
 
@@ -2209,7 +2210,7 @@ func main() {
 	// the same expensive audit read the activity collector does — ran on
 	// every 60s dashboard poll, per open browser tab, instead of once per
 	// collection interval.
-	repoCostCollector := dashboard.NewRepoCostCollector(dashSrv.GetAudit(), tokenCollector, "", logger)
+	repoCostCollector := collect.NewRepoCostCollector(dashSrv.GetAudit(), tokenCollector, "", logger)
 	repoCostCollector.EnablePersistence("/data/repo-cost.json")
 	go repoCostCollector.Start(ctx)
 
@@ -5056,11 +5057,11 @@ const (
 // import pkg/dashboard back — that would be an import cycle, since dashboard
 // already imports hub. A field-by-field copy, mirroring how the fleet-stat
 // scalars are lifted out of their snapshot at the beat's build site.
-func buildRepoActivityWire(repos []dashboard.RepoActivity) []hub.RepoActivityWire {
+func buildRepoActivityWire(repos []collect.RepoActivity) []hub.RepoActivityWire {
 	if len(repos) == 0 {
 		return nil
 	}
-	stat := func(s dashboard.ActivityActionStat) hub.ActivityStatWire {
+	stat := func(s collect.ActivityActionStat) hub.ActivityStatWire {
 		return hub.ActivityStatWire{Count: s.Count, NewestAt: s.NewestAt}
 	}
 	out := make([]hub.RepoActivityWire, 0, len(repos))

--- a/src/cmd/hive/wire_helpers_test.go
+++ b/src/cmd/hive/wire_helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/config"
-	"github.com/kubestellar/hive/pkg/dashboard"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	"github.com/kubestellar/hive/pkg/knowledge"
 )
 
@@ -14,28 +14,28 @@ func TestBuildRepoActivityWireEmpty(t *testing.T) {
 	if got := buildRepoActivityWire(nil); got != nil {
 		t.Errorf("buildRepoActivityWire(nil) = %v, want nil", got)
 	}
-	if got := buildRepoActivityWire([]dashboard.RepoActivity{}); got != nil {
+	if got := buildRepoActivityWire([]collect.RepoActivity{}); got != nil {
 		t.Errorf("buildRepoActivityWire(empty) = %v, want nil", got)
 	}
 }
 
 func TestBuildRepoActivityWireMapsEveryStat(t *testing.T) {
 	at := func(i int) string { return fmt.Sprintf("2026-08-26T04:0%d:00Z", i) }
-	in := []dashboard.RepoActivity{
+	in := []collect.RepoActivity{
 		{
 			Repo:       "kubestellar/hive",
-			Issues:     dashboard.ActivityActionStat{Count: 1, NewestAt: at(0)},
-			PRs:        dashboard.ActivityActionStat{Count: 2, NewestAt: at(1)},
-			Comments:   dashboard.ActivityActionStat{Count: 3, NewestAt: at(2)},
-			Merges:     dashboard.ActivityActionStat{Count: 4, NewestAt: at(3)},
-			Claims:     dashboard.ActivityActionStat{Count: 5, NewestAt: at(4)},
-			Reviews:    dashboard.ActivityActionStat{Count: 6, NewestAt: at(5)},
-			Advisory:   dashboard.ActivityActionStat{Count: 7, NewestAt: at(6)},
-			Reconciled: dashboard.ActivityActionStat{Count: 9, NewestAt: at(8)},
-			Agents: []dashboard.AgentRepoActivity{{
+			Issues:     collect.ActivityActionStat{Count: 1, NewestAt: at(0)},
+			PRs:        collect.ActivityActionStat{Count: 2, NewestAt: at(1)},
+			Comments:   collect.ActivityActionStat{Count: 3, NewestAt: at(2)},
+			Merges:     collect.ActivityActionStat{Count: 4, NewestAt: at(3)},
+			Claims:     collect.ActivityActionStat{Count: 5, NewestAt: at(4)},
+			Reviews:    collect.ActivityActionStat{Count: 6, NewestAt: at(5)},
+			Advisory:   collect.ActivityActionStat{Count: 7, NewestAt: at(6)},
+			Reconciled: collect.ActivityActionStat{Count: 9, NewestAt: at(8)},
+			Agents: []collect.AgentRepoActivity{{
 				Agent:      "quality",
-				Issues:     dashboard.ActivityActionStat{Count: 8, NewestAt: at(7)},
-				Reconciled: dashboard.ActivityActionStat{Count: 10, NewestAt: at(9)},
+				Issues:     collect.ActivityActionStat{Count: 8, NewestAt: at(7)},
+				Reconciled: collect.ActivityActionStat{Count: 10, NewestAt: at(9)},
 			}},
 		},
 		{Repo: "kubestellar/other"},

--- a/src/pkg/dashboard/activity_collector_test.go
+++ b/src/pkg/dashboard/activity_collector_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 )
 
 // writeAuditFixture writes a JSONL audit file with the given entries.
@@ -45,7 +47,7 @@ func TestOutputActionsSince(t *testing.T) {
 		{Timestamp: rfc3339(now.Add(-3 * time.Hour)), Action: "pr_merged", Detail: "repo=o/r, number=3"},
 	})
 	a := &AuditLog{}
-	got := a.OutputActionsSince(now.Add(-24*time.Hour), activityOutputActions, p)
+	got := a.OutputActionsSince(now.Add(-24*time.Hour), collect.ActivityOutputActions, p)
 	if len(got) != 2 {
 		t.Fatalf("want 2 (pr_created + merged within 24h, output actions only), got %d: %+v", len(got), got)
 	}
@@ -77,7 +79,7 @@ func TestOutputActionsSinceReadsRotatedCompressedBackups(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := (&AuditLog{}).OutputActionsSince(now.Add(-24*time.Hour), activityOutputActions, current)
+	got := (&AuditLog{}).OutputActionsSince(now.Add(-24*time.Hour), collect.ActivityOutputActions, current)
 	if len(got) != 2 {
 		t.Fatalf("want current + rotated entries, got %d: %+v", len(got), got)
 	}
@@ -90,123 +92,6 @@ func TestOutputActionsSinceReadsRotatedCompressedBackups(t *testing.T) {
 	}
 }
 
-// collect groups by repo + action with counts and newest timestamps, across
-// multiple repos — the multi-repo case that broke the hand-scraped counts.
-func TestActivityCollector_CountsPerRepo(t *testing.T) {
-	now := time.Now().UTC()
-	dir := t.TempDir()
-	newest := now.Add(-10 * time.Minute)
-	p := writeAuditFixture(t, dir, []AuditEntry{
-		{Timestamp: rfc3339(now.Add(-2 * time.Hour)), Action: "agent_issue_created", Detail: "repo=z/ui, number=1, agent=quality"},
-		{Timestamp: rfc3339(newest), Action: "agent_issue_created", Detail: "repo=z/ui, number=2", Agent: "docs"},
-		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=z/api-server, number=9", Agent: "quality"},
-		{Timestamp: rfc3339(now.Add(-3 * time.Hour)), Action: "pr_merged", Detail: "repo=z/api-server, number=8", Agent: "governor"},
-		{Timestamp: rfc3339(now.Add(-4 * time.Hour)), Action: "agent_pr_reviewed", Detail: "repo=z/ui, number=5, state=approved", Agent: "reviewer"},
-		{Timestamp: rfc3339(now.Add(-5 * time.Hour)), Action: "agent_issue_claimed", Detail: "repo=z/ui-framework, number=3", Agent: "quality"},
-		{Timestamp: rfc3339(now.Add(-6 * time.Hour)), Action: "pr_attribution_reconciled", Detail: "repo=z/ui, number=6", Agent: "governor"},
-	})
-	ac := NewActivityCollector(&AuditLog{}, p, nil)
-	ac.nowFn = func() time.Time { return now }
-	ac.collect()
-	snap, ok := ac.Snapshot()
-	if !ok {
-		t.Fatal("snapshot not ready after collect")
-	}
-	if len(snap.Repos) != 3 {
-		t.Fatalf("want 3 repos, got %d", len(snap.Repos))
-	}
-	byRepo := map[string]RepoActivity{}
-	for _, r := range snap.Repos {
-		byRepo[r.Repo] = r
-	}
-	if byRepo["z/ui"].Issues.Count != 2 {
-		t.Errorf("z/ui issues = %d, want 2", byRepo["z/ui"].Issues.Count)
-	}
-	if byRepo["z/ui"].Issues.NewestAt != rfc3339(newest) {
-		t.Errorf("z/ui newest issue = %q, want %q", byRepo["z/ui"].Issues.NewestAt, rfc3339(newest))
-	}
-	if byRepo["z/ui"].Reviews.Count != 1 {
-		t.Errorf("z/ui reviews = %d, want 1", byRepo["z/ui"].Reviews.Count)
-	}
-	if byRepo["z/ui"].Reconciled.Count != 1 {
-		t.Errorf("z/ui reconciled = %d, want 1", byRepo["z/ui"].Reconciled.Count)
-	}
-	uiAgents := map[string]AgentRepoActivity{}
-	for _, a := range byRepo["z/ui"].Agents {
-		uiAgents[a.Agent] = a
-	}
-	if uiAgents["quality"].Issues.Count != 1 || uiAgents["docs"].Issues.Count != 1 || uiAgents["reviewer"].Reviews.Count != 1 {
-		t.Errorf("z/ui per-agent counts = %+v, want quality/docs issues and reviewer review", uiAgents)
-	}
-	if byRepo["z/api-server"].PRs.Count != 1 || byRepo["z/api-server"].Merges.Count != 1 {
-		t.Errorf("z/api-server prs/merges = %d/%d, want 1/1", byRepo["z/api-server"].PRs.Count, byRepo["z/api-server"].Merges.Count)
-	}
-	if byRepo["z/ui-framework"].Claims.Count != 1 {
-		t.Errorf("z/ui-framework claims = %d, want 1", byRepo["z/ui-framework"].Claims.Count)
-	}
-	if snap.WindowHours != activityHealthWindowHours {
-		t.Errorf("window hours = %d, want %d", snap.WindowHours, activityHealthWindowHours)
-	}
-}
-
-// Entries with no repo= stay out of repo rows and are reported explicitly as
-// unattributed rather than smeared across known repos.
-func TestActivityCollector_SkipsNoRepo(t *testing.T) {
-	now := time.Now().UTC()
-	dir := t.TempDir()
-	p := writeAuditFixture(t, dir, []AuditEntry{
-		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "advisory_commented", Detail: "flow=advisory-digest"}, // no repo=
-	})
-	ac := NewActivityCollector(&AuditLog{}, p, nil)
-	ac.nowFn = func() time.Time { return now }
-	ac.collect()
-	snap, _ := ac.Snapshot()
-	if len(snap.Repos) != 0 {
-		t.Errorf("entry without repo= must be skipped, got %+v", snap.Repos)
-	}
-	if snap.Unattributed.Count != 1 {
-		t.Errorf("unattributed count = %d, want 1", snap.Unattributed.Count)
-	}
-}
-
-// EnablePersistence round-trips a snapshot across a restart.
-func TestActivityCollector_PersistRestore(t *testing.T) {
-	now := time.Now().UTC()
-	dir := t.TempDir()
-	p := writeAuditFixture(t, dir, []AuditEntry{
-		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=o/r, number=1"},
-	})
-	sidecar := filepath.Join(dir, "activity.json")
-
-	ac := NewActivityCollector(&AuditLog{}, p, nil)
-	ac.nowFn = func() time.Time { return now }
-	ac.EnablePersistence(sidecar)
-	ac.collect()
-	if _, err := os.Stat(sidecar); err != nil {
-		t.Fatalf("sidecar not written: %v", err)
-	}
-
-	// Fresh collector with NO audit file readable but the sidecar present →
-	// restores the prior snapshot.
-	ac2 := NewActivityCollector(&AuditLog{}, filepath.Join(dir, "gone.jsonl"), nil)
-	ac2.EnablePersistence(sidecar)
-	snap, ok := ac2.Snapshot()
-	if !ok || len(snap.Repos) != 1 || snap.Repos[0].PRs.Count != 1 {
-		t.Errorf("restore failed: ok=%v snap=%+v", ok, snap)
-	}
-}
-
-// Start is inert with a nil audit reader (no panic, returns).
-func TestActivityCollector_NilAuditInert(t *testing.T) {
-	ac := NewActivityCollector(nil, "", nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	ac.Start(ctx) // must return immediately
-	if _, ok := ac.Snapshot(); ok {
-		t.Error("nil-audit collector must not be ready")
-	}
-}
-
 func TestHandleRepoActivityReportsPhaseOneHonesty(t *testing.T) {
 	now := time.Now().UTC()
 	dir := t.TempDir()
@@ -216,9 +101,13 @@ func TestHandleRepoActivityReportsPhaseOneHonesty(t *testing.T) {
 		Detail:    "repo=o/r, number=1",
 		Agent:     "quality",
 	}})
-	ac := NewActivityCollector(&AuditLog{}, p, nil)
-	ac.nowFn = func() time.Time { return now }
-	ac.collect()
+	ac := collect.NewActivityCollector(&AuditLog{}, p, nil)
+	// One up-front collect, no ticker: Start with an already-cancelled context
+	// performs exactly one collect before observing ctx.Done. The collector's
+	// clock is time.Now; the fixture entry sits 1h back, well inside the window.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ac.Start(ctx)
 
 	// RegisterAPI wires ContributeWSHub, which logs unconditionally; a nil
 	// logger panics in NewContributeWSHub → loadCompletedTasks.
@@ -242,50 +131,5 @@ func TestHandleRepoActivityReportsPhaseOneHonesty(t *testing.T) {
 	}
 	if len(resp.Limitations) == 0 {
 		t.Fatal("limitations must be explicit so activity is not mistaken for cost")
-	}
-}
-
-// TestActivitySnapshotWindowsAreDistinct pins the two windows apart. window_hours
-// is the hub's FRESHNESS window; count_window_hours is the lookback Count was
-// accumulated over. #4860: the snapshot advertised only the 12h freshness value
-// while counting over 14d, so any consumer deriving a rate overstated activity
-// by 28x. Re-coupling them (or dropping count_window_hours) must fail here
-// rather than silently reappear as a wrong number on a cost row later.
-func TestActivitySnapshotWindowsAreDistinct(t *testing.T) {
-	now := time.Now().UTC()
-	dir := t.TempDir()
-	p := writeAuditFixture(t, dir, []AuditEntry{{
-		Timestamp: rfc3339(now.Add(-1 * time.Hour)),
-		Action:    "agent_pr_created",
-		Detail:    "repo=o/r, number=1",
-		Agent:     "quality",
-	}})
-	ac := NewActivityCollector(&AuditLog{}, p, nil)
-	ac.nowFn = func() time.Time { return now }
-	ac.collect()
-
-	snap, ready := ac.Snapshot()
-	if !ready {
-		t.Fatal("snapshot not ready")
-	}
-	if snap.WindowHours != activityHealthWindowHours {
-		t.Errorf("WindowHours = %d, want %d (the freshness window)",
-			snap.WindowHours, activityHealthWindowHours)
-	}
-	wantCount := int(activityWindow / time.Hour)
-	if snap.CountWindowHours != wantCount {
-		t.Errorf("CountWindowHours = %d, want %d (the accumulation window)",
-			snap.CountWindowHours, wantCount)
-	}
-	// The bug was reporting one value for both. If a future edit makes them
-	// equal, the 28x rate error is back and this is the signal.
-	if snap.CountWindowHours == snap.WindowHours {
-		t.Fatalf("count and freshness windows must stay distinct; both = %d", snap.WindowHours)
-	}
-	// The count window must cover the freshness window, or a "fresh" event
-	// could fall outside the counted range.
-	if snap.CountWindowHours < snap.WindowHours {
-		t.Fatalf("CountWindowHours (%d) must be >= WindowHours (%d)",
-			snap.CountWindowHours, snap.WindowHours)
 	}
 }

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubestellar/hive/pkg/beads"
 	"github.com/kubestellar/hive/pkg/classify"
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	"github.com/kubestellar/hive/pkg/dashboard/webstatic"
 	"github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/hub"
@@ -7694,7 +7695,7 @@ func (s *Server) handleTrendHistory(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleBudgetHistory(w http.ResponseWriter, r *http.Request) {
 	windows := s.BudgetWindowHistory()
 	if windows == nil {
-		windows = []BudgetWindowEntry{}
+		windows = []collect.BudgetWindowEntry{}
 	}
 
 	resp := map[string]any{"windows": windows}

--- a/src/pkg/dashboard/api_acmm_recommendation.go
+++ b/src/pkg/dashboard/api_acmm_recommendation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubestellar/hive/pkg/acmmadvisor"
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 )
 
 // qualityAgentName is the config-level name of the quality/coverage agent that
@@ -142,7 +143,7 @@ func hasQualityAgent(cfg *config.Config) bool {
 // archival destroys the post-merge history it needs). The denominator
 // deliberately counts superseded/duplicate PRs as non-successes: stricter,
 // and harder to game by re-proposing the same change.
-func mergeSuccessRateFromFleetStats(fc *FleetStatsCollector) (rate float64, measured bool) {
+func mergeSuccessRateFromFleetStats(fc *collect.FleetStatsCollector) (rate float64, measured bool) {
 	counts, ready := fc.Snapshot()
 	if !ready {
 		return 0, false

--- a/src/pkg/dashboard/api_acmm_recommendation_test.go
+++ b/src/pkg/dashboard/api_acmm_recommendation_test.go
@@ -4,11 +4,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubestellar/hive/pkg/acmmadvisor"
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	ghpkg "github.com/kubestellar/hive/pkg/github"
 )
 
@@ -267,9 +271,26 @@ func TestStatusPayloadCarriesACMMAdvice(t *testing.T) {
 // and when counts are absent or the window is empty the input stays at the
 // honest, conservative zero instead of a fabricated rate.
 func TestBuildACMMStatusInputs_MergeSuccessRate(t *testing.T) {
+	// seededFleetStats builds a ready collector carrying the given counts
+	// through its public persistence API (the tracker's fields moved to
+	// pkg/dashboard/collect with the collector and are no longer pokeable).
+	seededFleetStats := func(counts ghpkg.FleetContribCounts) *collect.FleetStatsCollector {
+		blob, err := json.Marshal(map[string]any{"counts": counts, "collected_at": time.Now().UTC()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "fleet-stats.json")
+		if err := os.WriteFile(path, blob, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		fc := collect.NewFleetStatsCollector(nil, "bot", "org", nil)
+		fc.EnablePersistence(path)
+		return fc
+	}
+
 	cases := []struct {
 		name string
-		fc   *FleetStatsCollector
+		fc   *collect.FleetStatsCollector
 		want float64
 	}{
 		{
@@ -277,7 +298,7 @@ func TestBuildACMMStatusInputs_MergeSuccessRate(t *testing.T) {
 			// 30 merged / 10 rejected over the window → 0.75. Before #3972
 			// this input was hardcoded to 0, so this case fails against the
 			// unfixed behavior.
-			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{PRsMerged: 30, PRsRejected: 10}, ready: true},
+			fc:   seededFleetStats(ghpkg.FleetContribCounts{PRsMerged: 30, PRsRejected: 10}),
 			want: 0.75,
 		},
 		{
@@ -287,24 +308,24 @@ func TestBuildACMMStatusInputs_MergeSuccessRate(t *testing.T) {
 		},
 		{
 			name: "collector never collected stays zero",
-			fc:   &FleetStatsCollector{},
+			fc:   collect.NewFleetStatsCollector(nil, "bot", "org", nil),
 			want: 0,
 		},
 		{
 			name: "empty window stays zero, not a fabricated 1.0",
 			// A successful collect that found no resolved PRs: the rate is
 			// unknown, and the advisor must not see a measured value.
-			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{}, ready: true},
+			fc:   seededFleetStats(ghpkg.FleetContribCounts{}),
 			want: 0,
 		},
 		{
 			name: "all rejected reads as measured zero",
-			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{PRsRejected: 5}, ready: true},
+			fc:   seededFleetStats(ghpkg.FleetContribCounts{PRsRejected: 5}),
 			want: 0,
 		},
 		{
 			name: "all merged reads as measured 1.0",
-			fc:   &FleetStatsCollector{counts: ghpkg.FleetContribCounts{PRsMerged: 4}, ready: true},
+			fc:   seededFleetStats(ghpkg.FleetContribCounts{PRsMerged: 4}),
 			want: 1.0,
 		},
 	}

--- a/src/pkg/dashboard/api_budget_history_activity_test.go
+++ b/src/pkg/dashboard/api_budget_history_activity_test.go
@@ -1,16 +1,13 @@
 package dashboard
 
 import (
-	"context"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"sync/atomic"
 	"testing"
-	"time"
+
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 )
 
 // --- handleBudgetHistory ---
@@ -42,7 +39,7 @@ func TestBudgetHistory_EmptyHistoryNoStatus(t *testing.T) {
 func TestBudgetHistory_CurrentWindowFromStatus(t *testing.T) {
 	s, _ := apiServer(t)
 
-	s.SeedBudgetWindowHistory([]BudgetWindowEntry{
+	s.SeedBudgetWindowHistory([]collect.BudgetWindowEntry{
 		{WindowStart: 1000, WindowEnd: 2000, Limit: 500, Used: 500, PctUsed: 100, Exhausted: true},
 	})
 	s.statusMu.Lock()
@@ -143,165 +140,5 @@ func TestKnowledgeHandlers_NilDepsServiceUnavailable(t *testing.T) {
 		if rec.Code != http.StatusServiceUnavailable {
 			t.Errorf("%s: status = %d, want 503", name, rec.Code)
 		}
-	}
-}
-
-// --- ActivityCollector ---
-
-// stubAuditReader is a canned auditReader so Start/collect run without a real
-// audit log on disk.
-type stubAuditReader struct {
-	entries []AuditEntry
-	calls   atomic.Int32
-}
-
-func (f *stubAuditReader) OutputActionsSince(time.Time, map[string]bool, string) []AuditEntry {
-	f.calls.Add(1)
-	return f.entries
-}
-
-func TestActivityCollector_CollectedAt(t *testing.T) {
-	var nilAC *ActivityCollector
-	if !nilAC.CollectedAt().IsZero() {
-		t.Error("nil collector CollectedAt should be zero")
-	}
-
-	ac := NewActivityCollector(&stubAuditReader{}, "", nil)
-	if !ac.CollectedAt().IsZero() {
-		t.Error("fresh collector CollectedAt should be zero")
-	}
-	ac.collect()
-	if ac.CollectedAt().IsZero() {
-		t.Error("CollectedAt should be set after a collect")
-	}
-}
-
-// Start must be a no-op on a nil collector and on one with no audit reader.
-func TestActivityCollector_StartInert(t *testing.T) {
-	done := make(chan struct{})
-	go func() {
-		var nilAC *ActivityCollector
-		nilAC.Start(context.Background())
-		NewActivityCollector(nil, "", nil).Start(context.Background())
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Start did not return immediately for inert collectors")
-	}
-}
-
-// Start collects once up front, again on each tick, and exits on ctx cancel.
-func TestActivityCollector_StartCollectsAndStops(t *testing.T) {
-	oldInterval := activityCollectInterval
-	activityCollectInterval = 5 * time.Millisecond
-	defer func() { activityCollectInterval = oldInterval }()
-
-	stub := &stubAuditReader{entries: []AuditEntry{
-		{Timestamp: rfc3339(time.Now()), Action: "agent_pr_created", Detail: "repo=o/r, agent=quality"},
-	}}
-	ac := NewActivityCollector(stub, "ignored", nil)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() { ac.Start(ctx); close(done) }()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for stub.calls.Load() < 2 && time.Now().Before(deadline) {
-		time.Sleep(time.Millisecond)
-	}
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Start did not exit after ctx cancel")
-	}
-	if stub.calls.Load() < 2 {
-		t.Errorf("collect calls = %d, want >=2 (upfront + tick)", stub.calls.Load())
-	}
-	snap, ready := ac.Snapshot()
-	if !ready {
-		t.Fatal("snapshot should be ready after collect")
-	}
-	if len(snap.Repos) != 1 || snap.Repos[0].Repo != "o/r" {
-		t.Errorf("snapshot repos = %+v, want one entry for o/r", snap.Repos)
-	}
-}
-
-// persistLocked failure paths: an unwritable temp path and a rename target that
-// is a directory must both be swallowed (logged), never panic or persist junk.
-func TestActivityCollector_PersistLockedFailures(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	// No persist path configured → early return.
-	ac := NewActivityCollector(&stubAuditReader{}, "", logger)
-	ac.persistLocked()
-
-	// Temp-file write fails: parent directory does not exist.
-	ac.persistPath = filepath.Join(t.TempDir(), "missing-subdir", "activity.json")
-	ac.persistLocked()
-
-	// Rename fails: destination is an existing directory.
-	dir := t.TempDir()
-	blocked := filepath.Join(dir, "activity.json")
-	if err := os.Mkdir(blocked, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	ac.persistPath = blocked
-	ac.persistLocked()
-	if _, err := os.Stat(filepath.Join(dir, "activity.json.tmp")); err != nil {
-		t.Fatalf("temp sidecar should exist after failed rename: %v", err)
-	}
-}
-
-// EnablePersistence restore paths: corrupt JSON and a zero collected_at are
-// both "start fresh"; a valid sidecar restores snapshot + timestamp.
-func TestActivityCollector_EnablePersistenceRestore(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	dir := t.TempDir()
-
-	// Corrupt sidecar → logged, ignored, not ready.
-	corrupt := filepath.Join(dir, "corrupt.json")
-	if err := os.WriteFile(corrupt, []byte("{not json"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	ac := NewActivityCollector(&stubAuditReader{}, "", logger)
-	ac.EnablePersistence(corrupt)
-	if _, ready := ac.Snapshot(); ready {
-		t.Error("corrupt sidecar must not mark the collector ready")
-	}
-
-	// Zero collected_at → treated as empty, not ready.
-	zero := filepath.Join(dir, "zero.json")
-	if err := os.WriteFile(zero, []byte(`{"snapshot":{},"collected_at":"0001-01-01T00:00:00Z"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	ac2 := NewActivityCollector(&stubAuditReader{}, "", logger)
-	ac2.EnablePersistence(zero)
-	if _, ready := ac2.Snapshot(); ready {
-		t.Error("zero collected_at must not mark the collector ready")
-	}
-
-	// Round-trip: collect+persist in one collector, restore in a second.
-	stub := &stubAuditReader{entries: []AuditEntry{
-		{Timestamp: rfc3339(time.Now()), Action: "pr_merged", Detail: "repo=o/persisted, agent=quality"},
-	}}
-	sidecar := filepath.Join(dir, "activity.json")
-	writer := NewActivityCollector(stub, "ignored", logger)
-	writer.EnablePersistence(sidecar)
-	writer.collect()
-
-	restored := NewActivityCollector(&stubAuditReader{}, "", logger)
-	restored.EnablePersistence(sidecar)
-	snap, ready := restored.Snapshot()
-	if !ready {
-		t.Fatal("restored collector should be ready")
-	}
-	if len(snap.Repos) != 1 || snap.Repos[0].Repo != "o/persisted" {
-		t.Errorf("restored repos = %+v, want o/persisted", snap.Repos)
-	}
-	if restored.CollectedAt().IsZero() {
-		t.Error("restored CollectedAt should be non-zero")
 	}
 }

--- a/src/pkg/dashboard/api_repo_activity.go
+++ b/src/pkg/dashboard/api_repo_activity.go
@@ -1,0 +1,37 @@
+package dashboard
+
+// The /api/repo-activity handler. The ActivityCollector it serves from moved
+// to pkg/dashboard/collect (kubestellar/hive#5565 slice 2); the HTTP surface
+// stays here with the rest of the dashboard's handlers.
+
+import (
+	"net/http"
+
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
+)
+
+type repoActivityResponse struct {
+	Ready       bool                     `json:"ready"`
+	Phase       string                   `json:"phase"`
+	Snapshot    collect.ActivitySnapshot `json:"snapshot"`
+	Limitations []string                 `json:"limitations"`
+}
+
+func (s *Server) handleRepoActivity(w http.ResponseWriter, r *http.Request) {
+	var snap collect.ActivitySnapshot
+	ready := false
+	if s.deps != nil && s.deps.Activity != nil {
+		snap, ready = s.deps.Activity.Snapshot()
+	}
+	jsonResponse(w, repoActivityResponse{
+		Ready:    ready,
+		Phase:    "phase_1_activity_only",
+		Snapshot: snap,
+		Limitations: []string{
+			"Counts are recorded audit facts only; no token cost is attributed in this phase.",
+			"Entries without repo= are reported as unattributed and are never spread across repos.",
+			"window_hours is the freshness window used by the hub health verdict; per-repo counts are accumulated over count_window_hours. Divide by count_window_hours for a rate — window_hours would overstate it by 28x.",
+			"Counts are bounded by audit-log retention: rotated and compressed backups are read, but only MaxBackups of them are kept, so a busy hive's effective lookback can be shorter than count_window_hours.",
+		},
+	})
+}

--- a/src/pkg/dashboard/api_repo_cost.go
+++ b/src/pkg/dashboard/api_repo_cost.go
@@ -1,0 +1,70 @@
+package dashboard
+
+// The /api/repo-cost handler. The interval join and its caching collector
+// moved to pkg/dashboard/collect (kubestellar/hive#5565 slice 2); the HTTP
+// surface stays here with the rest of the dashboard's handlers.
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
+	"github.com/kubestellar/hive/pkg/tokens"
+)
+
+// handleRepoCost serves GET /api/repo-cost from the cached RepoCostCollector
+// snapshot (see collect/repo_cost_collector.go) rather than recomputing the
+// interval join per request. The join reads every rotated/compressed audit
+// backup (up to 64MB decompressed each) and walks every retained Claude usage
+// event in the window — recomputing that on every 60s dashboard poll, per
+// open tab, was the defect fixed by #4943.
+//
+// When the collector has not produced a snapshot yet (fresh boot, before its
+// first ticker fire), this reports ready=false with an EMPTY by_repo/zero
+// totals and no CollectedAt — never a fabricated $0.00. A cost payload with
+// ready=true and an empty by_repo is indistinguishable from "this hive spent
+// nothing", which is exactly the misreporting the #4836 epic exists to
+// prevent, so the not-ready state must stay visibly different from that.
+func (s *Server) handleRepoCost(w http.ResponseWriter, r *http.Request) {
+	if s.deps != nil && s.deps.RepoCost != nil {
+		snap, ready := s.deps.RepoCost.Snapshot()
+		if !ready {
+			jsonResponse(w, collect.RepoCostResponse{
+				Phase:              "phase_3_interval_join",
+				ByRepo:             []collect.RepoCostEntry{},
+				PriceTableDate:     tokens.PriceTableDate(),
+				Disclaimer:         costEstimateDisclaimer,
+				Limitations:        collect.RepoCostLimitations(),
+				Unattributed:       collect.RepoCostEntry{Repo: collect.RepoCostBucketUnattributed, Source: "estimated"},
+				BackendUnsupported: collect.RepoCostEntry{Repo: collect.RepoCostBucketBackendUnsupported, Source: "estimated"},
+			})
+			return
+		}
+		jsonResponse(w, snap)
+		return
+	}
+
+	// No collector wired (e.g. a minimal test Server): fall back to computing
+	// inline so the endpoint still degrades to a correct answer rather than
+	// 503ing. Production always wires RepoCost (see cmd/hive/main.go).
+	now := time.Now()
+	var summary *tokens.AggregateSummary
+	if s.deps != nil && s.deps.Tokens != nil {
+		summary = s.deps.Tokens.Summary()
+	}
+	var entries []AuditEntry
+	if s.audit != nil {
+		entries = s.audit.OutputActionsSince(now.Add(-collect.RepoCostWindow), collect.ActivityOutputActions, s.auditPathForActivity())
+	}
+	jsonResponse(w, collect.ComputeRepoCost(summary, entries, now))
+}
+
+// auditPathForActivity returns the audit file path the activity collector was
+// configured with, so the cost join reads exactly the same log. "" means the
+// production default (see OutputActionsSince).
+func (s *Server) auditPathForActivity() string {
+	if s.deps != nil && s.deps.Activity != nil {
+		return s.deps.Activity.AuditPath()
+	}
+	return ""
+}

--- a/src/pkg/dashboard/audit.go
+++ b/src/pkg/dashboard/audit.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -43,17 +44,10 @@ var auditPseudoUsers = map[string]bool{
 	"unknown": true,
 }
 
-type AuditEntry struct {
-	Timestamp string `json:"ts"`
-	User      string `json:"user"`
-	Action    string `json:"action"`
-	Detail    string `json:"detail,omitempty"`
-	Agent     string `json:"agent,omitempty"`
-	// UserName is the hub-delivered display name when User is an opaque OIDC
-	// identity key. Stamped at SERVE time only (handleAuditLog) — the ring and
-	// the on-disk log keep the raw key, so history survives name changes.
-	UserName string `json:"user_name,omitempty"`
-}
+// AuditEntry moved to pkg/dashboard/collect with its consumers (the
+// collectors); the alias keeps this package's write side (AuditLog) and every
+// existing call site source-compatible, with an identical JSON contract.
+type AuditEntry = collect.AuditEntry
 
 type AuditLog struct {
 	mu     sync.Mutex

--- a/src/pkg/dashboard/budget_history.go
+++ b/src/pkg/dashboard/budget_history.go
@@ -1,180 +1,22 @@
 package dashboard
 
+// Per-budget-window history (kubestellar/hive#4298) — the Server-side wiring.
+// The tracker itself (collect.BudgetWindowTracker) moved to
+// pkg/dashboard/collect in kubestellar/hive#5565 slice 2; this file keeps the
+// Server accessors that fold status readings into it and serve its history.
+
 import (
-	"sync"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 )
 
-// Per-budget-window history (kubestellar/hive#4298).
-//
-// The dashboard has always shown the CURRENT budget window: how much of the
-// weekly limit this window has consumed, and when it rolls. That answers "am I
-// about to run out", and it is the only question it can answer — the moment the
-// window rolls, the previous window's number is gone.
-//
-// The question an administrator actually asks after two weeks away is the other
-// one: "did the budget stop the hive while I was gone?" Nothing in the tree
-// could answer it. The token sparkline records tokens over time but knows
-// nothing about the limit or where the window boundaries fell, and the governor
-// keeps only the open window's spend.
-//
-// This records one row per CLOSED window — when it ran, what the limit was,
-// what was consumed, and whether it hit the limit — so "for every recent reset,
-// how much of the budget had been used" becomes a lookup.
-//
-// COMPATIBILITY. A hive upgrading into this keeps no history it never
-// collected: the list starts empty, every accessor tolerates that, and the
-// first observation merely starts tracking. Nothing here can fail a status
-// build — an unset limit, a zero window, and a governor that has not opened a
-// window yet are ordinary inputs, not errors.
-
-// budgetWindowMaxEntries caps the ring. With a weekly window, 26 entries is
-// half a year — longer than an operator investigates, and trivially small on
-// disk. A named constant so the retention is a deliberate number rather than an
-// accident of the buffer size.
-const budgetWindowMaxEntries = 26
-
-// BudgetWindowEntry is one CLOSED budget window.
-//
-// Timestamps are epoch milliseconds, matching every other history series the
-// dashboard persists, so the frontend parses them the same way.
-type BudgetWindowEntry struct {
-	// WindowStart and WindowEnd bound the window. WindowEnd is when the reset
-	// happened, which is what an operator correlates against "the fortnight I
-	// was away".
-	WindowStart int64 `json:"windowStart"`
-	WindowEnd   int64 `json:"windowEnd"`
-	// Limit is the weekly token limit that was in force FOR THIS WINDOW.
-	// Recorded per window rather than read live, because an operator who raised
-	// the limit after a bad week must still see what the limit was when it bit.
-	Limit int64 `json:"limit"`
-	// Used is the tokens consumed — the high-water mark observed before the
-	// roll, not a post-roll reading, which would always be ~0.
-	Used int64 `json:"used"`
-	// PctUsed is Used/Limit as a percentage; 0 when no limit was set.
-	PctUsed float64 `json:"pctUsed"`
-	// Exhausted records whether the window actually reached its limit. Stored
-	// rather than recomputed, for the same reason Limit is: a later limit
-	// change must not rewrite history and make a past window look fine.
-	Exhausted bool `json:"exhausted"`
-}
-
-// budgetWindowTracker watches the open window and emits an entry when it rolls.
-// A small leaf-locked struct: nothing here calls back into Server, so the mutex
-// is taken and released inside one method.
-type budgetWindowTracker struct {
-	mu sync.Mutex
-	// start/end bound the window being observed. Zero before the first
-	// observation and whenever the governor reports no open window.
-	start int64
-	end   int64
-	limit int64
-	// peakUsed is the HIGH-WATER spend seen in the open window.
-	//
-	// High-water rather than last-seen because the roll is detected on the
-	// observation AFTER it happened, by which time the live spend has already
-	// reset toward zero. Reading it then would record every window as barely
-	// used — precisely the wrong answer for the question this feature exists to
-	// answer.
-	peakUsed int64
-	// exhausted latches for the same reason: the state is transient and the
-	// roll is observed late.
-	exhausted bool
-	// closed holds completed windows, oldest first.
-	closed []BudgetWindowEntry
-}
-
-// observe folds one status reading into the tracker, returning the entry for a
-// window that just closed (nil when none did).
-//
-// windowStart/windowEnd are the open window's bounds in epoch milliseconds. A
-// zero windowEnd means the governor has no window open (no limit configured),
-// which closes any tracked window without starting a new one.
-func (t *budgetWindowTracker) observe(windowStart, windowEnd, limit, used int64, exhausted bool) *BudgetWindowEntry {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	// Same window still open: accumulate and stop.
-	if windowEnd != 0 && windowEnd == t.end {
-		if used > t.peakUsed {
-			t.peakUsed = used
-		}
-		if exhausted {
-			t.exhausted = true
-		}
-		if limit > 0 {
-			t.limit = limit
-		}
-		return nil
-	}
-
-	// The window changed. Close the tracked one, if there was one.
-	var rolled *BudgetWindowEntry
-	if t.end != 0 {
-		entry := BudgetWindowEntry{
-			WindowStart: t.start,
-			WindowEnd:   t.end,
-			Limit:       t.limit,
-			Used:        t.peakUsed,
-			Exhausted:   t.exhausted,
-		}
-		if t.limit > 0 {
-			const pctMultiplier = 100.0
-			entry.PctUsed = float64(t.peakUsed) / float64(t.limit) * pctMultiplier
-		}
-		t.closed = append(t.closed, entry)
-		if len(t.closed) > budgetWindowMaxEntries {
-			t.closed = t.closed[len(t.closed)-budgetWindowMaxEntries:]
-		}
-		rolled = &entry
-	}
-
-	// Begin tracking the new window. A zero windowEnd leaves the tracker idle
-	// rather than recording an empty row on every status build.
-	if windowEnd == 0 {
-		t.start, t.end, t.limit, t.peakUsed, t.exhausted = 0, 0, 0, 0, false
-		return rolled
-	}
-	t.start, t.end, t.limit = windowStart, windowEnd, limit
-	t.peakUsed, t.exhausted = used, exhausted
-	return rolled
-}
-
-// snapshot returns a copy of the closed windows, newest FIRST — the order an
-// operator reads them in, and the order the API serves.
-func (t *budgetWindowTracker) snapshot() []BudgetWindowEntry {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	out := make([]BudgetWindowEntry, 0, len(t.closed))
-	for i := len(t.closed) - 1; i >= 0; i-- {
-		out = append(out, t.closed[i])
-	}
-	return out
-}
-
-// seed restores persisted history on startup. Entries arrive newest-first (the
-// order snapshot emits and the API serves) and are stored oldest-first
-// internally, so a save/load round trip preserves order. Over-long input is
-// truncated to the newest entries rather than rejected: a file written by a
-// build with a larger cap must not break startup.
-func (t *budgetWindowTracker) seed(entries []BudgetWindowEntry) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.closed = t.closed[:0]
-	for i := len(entries) - 1; i >= 0; i-- {
-		t.closed = append(t.closed, entries[i])
-	}
-	if len(t.closed) > budgetWindowMaxEntries {
-		t.closed = t.closed[len(t.closed)-budgetWindowMaxEntries:]
-	}
-}
-
-// budgetWindowOnceKey guards lazy construction so a zero-value Server — as used
-// in tests that do `&Server{}` — works without a constructor, exactly like
+// budgetWindows guards lazy construction so a zero-value Server — as used in
+// tests that do `&Server{}` — works without a constructor, exactly like
 // initHistories does for the sparkline rings.
-func (s *Server) budgetWindows() *budgetWindowTracker {
+func (s *Server) budgetWindows() *collect.BudgetWindowTracker {
 	s.budgetWindowOnce.Do(func() {
-		s.budgetWindowHist = &budgetWindowTracker{}
+		s.budgetWindowHist = &collect.BudgetWindowTracker{}
 	})
 	return s.budgetWindowHist
 }
@@ -206,7 +48,7 @@ func (s *Server) ObserveBudgetWindow(status *StatusPayload) {
 		}
 	}
 
-	rolled := s.budgetWindows().observe(startMs, endMs, b.WeeklyBudget, b.Used, b.Exhausted)
+	rolled := s.budgetWindows().Observe(startMs, endMs, b.WeeklyBudget, b.Used, b.Exhausted)
 	if rolled != nil && s.logger != nil {
 		s.logger.Info("budget window rolled",
 			"used", rolled.Used, "limit", rolled.Limit,
@@ -216,11 +58,11 @@ func (s *Server) ObserveBudgetWindow(status *StatusPayload) {
 
 // BudgetWindowHistory returns the closed budget windows, newest first. Empty on
 // a hive that has not yet seen a window roll — ordinary, never an error.
-func (s *Server) BudgetWindowHistory() []BudgetWindowEntry {
-	return s.budgetWindows().snapshot()
+func (s *Server) BudgetWindowHistory() []collect.BudgetWindowEntry {
+	return s.budgetWindows().Snapshot()
 }
 
 // SeedBudgetWindowHistory restores persisted per-window history on startup.
-func (s *Server) SeedBudgetWindowHistory(entries []BudgetWindowEntry) {
-	s.budgetWindows().seed(entries)
+func (s *Server) SeedBudgetWindowHistory(entries []collect.BudgetWindowEntry) {
+	s.budgetWindows().Seed(entries)
 }

--- a/src/pkg/dashboard/budget_history_test.go
+++ b/src/pkg/dashboard/budget_history_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 )
 
 // ── Per-budget-window history (#4298) ───────────────────────────────────────
@@ -164,17 +166,17 @@ func TestZeroValueServerAndNilStatusAreSafe(t *testing.T) {
 // TestRetentionKeepsNewest pins the ring bound and that it drops the OLDEST.
 func TestRetentionKeepsNewest(t *testing.T) {
 	s := &Server{}
-	start := time.Now().Add(-time.Duration(budgetWindowMaxEntries+10) * 7 * 24 * time.Hour)
+	start := time.Now().Add(-time.Duration(collect.BudgetWindowMaxEntries+10) * 7 * 24 * time.Hour)
 	week := 7 * 24 * time.Hour
-	total := budgetWindowMaxEntries + 5
+	total := collect.BudgetWindowMaxEntries + 5
 	for i := 0; i < total+1; i++ {
 		ws := start.Add(time.Duration(i) * week)
 		s.ObserveBudgetWindow(windowStatus(ws, ws.Add(week), 1000, int64(i), false))
 	}
 
 	hist := s.BudgetWindowHistory()
-	if len(hist) != budgetWindowMaxEntries {
-		t.Fatalf("history = %d entries, want the cap %d", len(hist), budgetWindowMaxEntries)
+	if len(hist) != collect.BudgetWindowMaxEntries {
+		t.Fatalf("history = %d entries, want the cap %d", len(hist), collect.BudgetWindowMaxEntries)
 	}
 	// Newest first, and the newest closed window is the one before the open one.
 	if hist[0].Used != int64(total-1) {
@@ -201,7 +203,7 @@ func TestSeedRoundTripsThroughJSON(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	var reloaded []BudgetWindowEntry
+	var reloaded []collect.BudgetWindowEntry
 	if err := json.Unmarshal(data, &reloaded); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -237,7 +239,7 @@ func TestBudgetHistoryEndpointAlwaysReturnsAnArray(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 	var body struct {
-		Windows []BudgetWindowEntry `json:"windows"`
+		Windows []collect.BudgetWindowEntry `json:"windows"`
 	}
 	raw := rec.Body.String()
 	if err := json.Unmarshal([]byte(raw), &body); err != nil {

--- a/src/pkg/dashboard/collect/activity_collector.go
+++ b/src/pkg/dashboard/collect/activity_collector.go
@@ -1,10 +1,16 @@
-package dashboard
+// Package collect holds pkg/dashboard's producer-side collectors: the
+// background cache/aggregation types (activity, repo-cost, fleet-stats), the
+// generic timeSeries ring buffer behind every persisted sparkline history, and
+// the budget-window tracker. Slice 2 of the kubestellar/hive#5565
+// decomposition: pure moves out of the dashboard god package, wired back in
+// through Dependencies fields exactly as before. This package deliberately
+// imports only leaf vocabulary (pkg/github, pkg/tokens) — never pkg/dashboard.
+package collect
 
 import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"net/http"
 	"os"
 	"regexp"
 	"sort"
@@ -13,6 +19,22 @@ import (
 
 	ghpkg "github.com/kubestellar/hive/pkg/github"
 )
+
+// AuditEntry is one line of the dashboard's audit log. The type lives here —
+// with its consumers, the collectors — and pkg/dashboard aliases it
+// (type AuditEntry = collect.AuditEntry), so the write side (AuditLog) and the
+// wire/JSON contract are byte-identical to before the split.
+type AuditEntry struct {
+	Timestamp string `json:"ts"`
+	User      string `json:"user"`
+	Action    string `json:"action"`
+	Detail    string `json:"detail,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	// UserName is the hub-delivered display name when User is an opaque OIDC
+	// identity key. Stamped at SERVE time only (handleAuditLog) — the ring and
+	// the on-disk log keep the raw key, so history survives name changes.
+	UserName string `json:"user_name,omitempty"`
+}
 
 // activityCollectInterval is how often the spoke recomputes its per-repo output
 // activity from the audit log. Unlike the fleet-stats collector this makes ZERO
@@ -35,10 +57,11 @@ const activityWindow = 14 * 24 * time.Hour
 // that divides Count by window_hours to get a rate overstates activity by 28x.
 const activityHealthWindowHours = 12
 
-// Audit action names the collector counts as OUTPUT to a work source. Kept in
-// sync with pkg/github/attribution.go. Advisory is counted separately because it
-// is the L2 output signal.
-var activityOutputActions = map[string]bool{
+// ActivityOutputActions is the set of audit action names the collector counts
+// as OUTPUT to a work source. Kept in sync with pkg/github/attribution.go.
+// Advisory is counted separately because it is the L2 output signal. Exported
+// because pkg/dashboard's handleRepoCost fallback path reads the same set.
+var ActivityOutputActions = map[string]bool{
 	ghpkg.AuditActionAgentIssueCreated:       true,
 	ghpkg.AuditActionAgentPRCreated:          true,
 	ghpkg.AuditActionAgentCommentCreated:     true,
@@ -105,9 +128,9 @@ type ActivitySnapshot struct {
 	CollectedAt      time.Time `json:"collected_at"`
 }
 
-// auditReader is the subset of *AuditLog the collector needs, so it can be
-// faked in tests without a full dashboard Server.
-type auditReader interface {
+// AuditReader is the subset of pkg/dashboard's *AuditLog the collectors need,
+// so they can be faked in tests without a full dashboard Server.
+type AuditReader interface {
 	OutputActionsSince(since time.Time, actions map[string]bool, filePath string) []AuditEntry
 }
 
@@ -116,7 +139,7 @@ type auditReader interface {
 // CollectedAt) but reads the local audit file instead of the GitHub API.
 type ActivityCollector struct {
 	mu          sync.Mutex
-	audit       auditReader
+	audit       AuditReader
 	auditPath   string // "" → the default auditLogPath (used by OutputActionsSince)
 	logger      *slog.Logger
 	nowFn       func() time.Time
@@ -136,7 +159,7 @@ type persistedActivity struct {
 // NewActivityCollector builds a collector over the given audit reader. audit nil
 // makes it inert (Snapshot ready=false). auditPath is where OutputActionsSince
 // reads ("" → the production audit log).
-func NewActivityCollector(audit auditReader, auditPath string, logger *slog.Logger) *ActivityCollector {
+func NewActivityCollector(audit AuditReader, auditPath string, logger *slog.Logger) *ActivityCollector {
 	return &ActivityCollector{
 		audit:     audit,
 		auditPath: auditPath,
@@ -226,7 +249,7 @@ var agentRe = regexp.MustCompile(`(?:^|[,\s])agent=([^,\s]+)`)
 func (ac *ActivityCollector) collect() {
 	now := ac.nowFn()
 	since := now.Add(-activityWindow)
-	entries := ac.audit.OutputActionsSince(since, activityOutputActions, ac.auditPath)
+	entries := ac.audit.OutputActionsSince(since, ActivityOutputActions, ac.auditPath)
 
 	byRepo := map[string]*RepoActivity{}
 	byRepoAgent := map[string]map[string]*AgentRepoActivity{}
@@ -337,28 +360,12 @@ func (ac *ActivityCollector) CollectedAt() time.Time {
 	return ac.collectedAt
 }
 
-type repoActivityResponse struct {
-	Ready       bool             `json:"ready"`
-	Phase       string           `json:"phase"`
-	Snapshot    ActivitySnapshot `json:"snapshot"`
-	Limitations []string         `json:"limitations"`
-}
-
-func (s *Server) handleRepoActivity(w http.ResponseWriter, r *http.Request) {
-	var snap ActivitySnapshot
-	ready := false
-	if s.deps != nil && s.deps.Activity != nil {
-		snap, ready = s.deps.Activity.Snapshot()
+// AuditPath returns the audit file path this collector was configured with
+// ("" = the production default). pkg/dashboard's handleRepoCost fallback uses
+// it so the cost join reads exactly the same log file set.
+func (ac *ActivityCollector) AuditPath() string {
+	if ac == nil {
+		return ""
 	}
-	jsonResponse(w, repoActivityResponse{
-		Ready:    ready,
-		Phase:    "phase_1_activity_only",
-		Snapshot: snap,
-		Limitations: []string{
-			"Counts are recorded audit facts only; no token cost is attributed in this phase.",
-			"Entries without repo= are reported as unattributed and are never spread across repos.",
-			"window_hours is the freshness window used by the hub health verdict; per-repo counts are accumulated over count_window_hours. Divide by count_window_hours for a rate — window_hours would overstate it by 28x.",
-			"Counts are bounded by audit-log retention: rotated and compressed backups are read, but only MaxBackups of them are kept, so a busy hive's effective lookback can be shorter than count_window_hours.",
-		},
-	})
+	return ac.auditPath
 }

--- a/src/pkg/dashboard/collect/activity_collector_test.go
+++ b/src/pkg/dashboard/collect/activity_collector_test.go
@@ -1,0 +1,348 @@
+package collect
+
+// Moved from pkg/dashboard with the ActivityCollector (kubestellar/hive#5565
+// slice 2). The collector tests drive the aggregation through a stub
+// AuditReader; the audit-file READING behavior (OutputActionsSince over
+// rotated/compressed backups) stays tested next to AuditLog in pkg/dashboard.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func rfc3339(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+
+// stubAuditReader is a canned AuditReader so Start/collect run without a real
+// audit log on disk.
+type stubAuditReader struct {
+	entries []AuditEntry
+	calls   atomic.Int32
+}
+
+func (f *stubAuditReader) OutputActionsSince(time.Time, map[string]bool, string) []AuditEntry {
+	f.calls.Add(1)
+	return f.entries
+}
+
+// collect groups by repo + action with counts and newest timestamps, across
+// multiple repos — the multi-repo case that broke the hand-scraped counts.
+func TestActivityCollector_CountsPerRepo(t *testing.T) {
+	now := time.Now().UTC()
+	newest := now.Add(-10 * time.Minute)
+	stub := &stubAuditReader{entries: []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-2 * time.Hour)), Action: "agent_issue_created", Detail: "repo=z/ui, number=1, agent=quality"},
+		{Timestamp: rfc3339(newest), Action: "agent_issue_created", Detail: "repo=z/ui, number=2", Agent: "docs"},
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=z/api-server, number=9", Agent: "quality"},
+		{Timestamp: rfc3339(now.Add(-3 * time.Hour)), Action: "pr_merged", Detail: "repo=z/api-server, number=8", Agent: "governor"},
+		{Timestamp: rfc3339(now.Add(-4 * time.Hour)), Action: "agent_pr_reviewed", Detail: "repo=z/ui, number=5, state=approved", Agent: "reviewer"},
+		{Timestamp: rfc3339(now.Add(-5 * time.Hour)), Action: "agent_issue_claimed", Detail: "repo=z/ui-framework, number=3", Agent: "quality"},
+		{Timestamp: rfc3339(now.Add(-6 * time.Hour)), Action: "pr_attribution_reconciled", Detail: "repo=z/ui, number=6", Agent: "governor"},
+	}}
+	ac := NewActivityCollector(stub, "", nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.collect()
+	snap, ok := ac.Snapshot()
+	if !ok {
+		t.Fatal("snapshot not ready after collect")
+	}
+	if len(snap.Repos) != 3 {
+		t.Fatalf("want 3 repos, got %d", len(snap.Repos))
+	}
+	byRepo := map[string]RepoActivity{}
+	for _, r := range snap.Repos {
+		byRepo[r.Repo] = r
+	}
+	if byRepo["z/ui"].Issues.Count != 2 {
+		t.Errorf("z/ui issues = %d, want 2", byRepo["z/ui"].Issues.Count)
+	}
+	if byRepo["z/ui"].Issues.NewestAt != rfc3339(newest) {
+		t.Errorf("z/ui newest issue = %q, want %q", byRepo["z/ui"].Issues.NewestAt, rfc3339(newest))
+	}
+	if byRepo["z/ui"].Reviews.Count != 1 {
+		t.Errorf("z/ui reviews = %d, want 1", byRepo["z/ui"].Reviews.Count)
+	}
+	if byRepo["z/ui"].Reconciled.Count != 1 {
+		t.Errorf("z/ui reconciled = %d, want 1", byRepo["z/ui"].Reconciled.Count)
+	}
+	uiAgents := map[string]AgentRepoActivity{}
+	for _, a := range byRepo["z/ui"].Agents {
+		uiAgents[a.Agent] = a
+	}
+	if uiAgents["quality"].Issues.Count != 1 || uiAgents["docs"].Issues.Count != 1 || uiAgents["reviewer"].Reviews.Count != 1 {
+		t.Errorf("z/ui per-agent counts = %+v, want quality/docs issues and reviewer review", uiAgents)
+	}
+	if byRepo["z/api-server"].PRs.Count != 1 || byRepo["z/api-server"].Merges.Count != 1 {
+		t.Errorf("z/api-server prs/merges = %d/%d, want 1/1", byRepo["z/api-server"].PRs.Count, byRepo["z/api-server"].Merges.Count)
+	}
+	if byRepo["z/ui-framework"].Claims.Count != 1 {
+		t.Errorf("z/ui-framework claims = %d, want 1", byRepo["z/ui-framework"].Claims.Count)
+	}
+	if snap.WindowHours != activityHealthWindowHours {
+		t.Errorf("window hours = %d, want %d", snap.WindowHours, activityHealthWindowHours)
+	}
+}
+
+// Entries with no repo= stay out of repo rows and are reported explicitly as
+// unattributed rather than smeared across known repos.
+func TestActivityCollector_SkipsNoRepo(t *testing.T) {
+	now := time.Now().UTC()
+	stub := &stubAuditReader{entries: []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "advisory_commented", Detail: "flow=advisory-digest"}, // no repo=
+	}}
+	ac := NewActivityCollector(stub, "", nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.collect()
+	snap, _ := ac.Snapshot()
+	if len(snap.Repos) != 0 {
+		t.Errorf("entry without repo= must be skipped, got %+v", snap.Repos)
+	}
+	if snap.Unattributed.Count != 1 {
+		t.Errorf("unattributed count = %d, want 1", snap.Unattributed.Count)
+	}
+}
+
+// EnablePersistence round-trips a snapshot across a restart.
+func TestActivityCollector_PersistRestore(t *testing.T) {
+	now := time.Now().UTC()
+	stub := &stubAuditReader{entries: []AuditEntry{
+		{Timestamp: rfc3339(now.Add(-1 * time.Hour)), Action: "agent_pr_created", Detail: "repo=o/r, number=1"},
+	}}
+	sidecar := filepath.Join(t.TempDir(), "activity.json")
+
+	ac := NewActivityCollector(stub, "", nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.EnablePersistence(sidecar)
+	ac.collect()
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+
+	// Fresh collector with an EMPTY audit reader but the sidecar present →
+	// restores the prior snapshot.
+	ac2 := NewActivityCollector(&stubAuditReader{}, "", nil)
+	ac2.EnablePersistence(sidecar)
+	snap, ok := ac2.Snapshot()
+	if !ok || len(snap.Repos) != 1 || snap.Repos[0].PRs.Count != 1 {
+		t.Errorf("restore failed: ok=%v snap=%+v", ok, snap)
+	}
+}
+
+// Start is inert with a nil audit reader (no panic, returns).
+func TestActivityCollector_NilAuditInert(t *testing.T) {
+	ac := NewActivityCollector(nil, "", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ac.Start(ctx) // must return immediately
+	if _, ok := ac.Snapshot(); ok {
+		t.Error("nil-audit collector must not be ready")
+	}
+}
+
+// TestActivitySnapshotWindowsAreDistinct pins the two windows apart. window_hours
+// is the hub's FRESHNESS window; count_window_hours is the lookback Count was
+// accumulated over. #4860: the snapshot advertised only the 12h freshness value
+// while counting over 14d, so any consumer deriving a rate overstated activity
+// by 28x. Re-coupling them (or dropping count_window_hours) must fail here
+// rather than silently reappear as a wrong number on a cost row later.
+func TestActivitySnapshotWindowsAreDistinct(t *testing.T) {
+	now := time.Now().UTC()
+	stub := &stubAuditReader{entries: []AuditEntry{{
+		Timestamp: rfc3339(now.Add(-1 * time.Hour)),
+		Action:    "agent_pr_created",
+		Detail:    "repo=o/r, number=1",
+		Agent:     "quality",
+	}}}
+	ac := NewActivityCollector(stub, "", nil)
+	ac.nowFn = func() time.Time { return now }
+	ac.collect()
+
+	snap, ready := ac.Snapshot()
+	if !ready {
+		t.Fatal("snapshot not ready")
+	}
+	if snap.WindowHours != activityHealthWindowHours {
+		t.Errorf("WindowHours = %d, want %d (the freshness window)",
+			snap.WindowHours, activityHealthWindowHours)
+	}
+	wantCount := int(activityWindow / time.Hour)
+	if snap.CountWindowHours != wantCount {
+		t.Errorf("CountWindowHours = %d, want %d (the accumulation window)",
+			snap.CountWindowHours, wantCount)
+	}
+	// The bug was reporting one value for both. If a future edit makes them
+	// equal, the 28x rate error is back and this is the signal.
+	if snap.CountWindowHours == snap.WindowHours {
+		t.Fatalf("count and freshness windows must stay distinct; both = %d", snap.WindowHours)
+	}
+	// The count window must cover the freshness window, or a "fresh" event
+	// could fall outside the counted range.
+	if snap.CountWindowHours < snap.WindowHours {
+		t.Fatalf("CountWindowHours (%d) must be >= WindowHours (%d)",
+			snap.CountWindowHours, snap.WindowHours)
+	}
+}
+
+func TestActivityCollector_CollectedAt(t *testing.T) {
+	var nilAC *ActivityCollector
+	if !nilAC.CollectedAt().IsZero() {
+		t.Error("nil collector CollectedAt should be zero")
+	}
+
+	ac := NewActivityCollector(&stubAuditReader{}, "", nil)
+	if !ac.CollectedAt().IsZero() {
+		t.Error("fresh collector CollectedAt should be zero")
+	}
+	ac.collect()
+	if ac.CollectedAt().IsZero() {
+		t.Error("CollectedAt should be set after a collect")
+	}
+}
+
+// AuditPath echoes the configured path (and "" on a nil collector) so the
+// dashboard's repo-cost fallback can read the identical file set.
+func TestActivityCollector_AuditPath(t *testing.T) {
+	var nilAC *ActivityCollector
+	if got := nilAC.AuditPath(); got != "" {
+		t.Errorf("nil collector AuditPath = %q, want empty", got)
+	}
+	ac := NewActivityCollector(&stubAuditReader{}, "/data/custom.jsonl", nil)
+	if got := ac.AuditPath(); got != "/data/custom.jsonl" {
+		t.Errorf("AuditPath = %q, want the configured path", got)
+	}
+}
+
+// Start must be a no-op on a nil collector and on one with no audit reader.
+func TestActivityCollector_StartInert(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		var nilAC *ActivityCollector
+		nilAC.Start(context.Background())
+		NewActivityCollector(nil, "", nil).Start(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return immediately for inert collectors")
+	}
+}
+
+// Start collects once up front, again on each tick, and exits on ctx cancel.
+func TestActivityCollector_StartCollectsAndStops(t *testing.T) {
+	oldInterval := activityCollectInterval
+	activityCollectInterval = 5 * time.Millisecond
+	defer func() { activityCollectInterval = oldInterval }()
+
+	stub := &stubAuditReader{entries: []AuditEntry{
+		{Timestamp: rfc3339(time.Now()), Action: "agent_pr_created", Detail: "repo=o/r, agent=quality"},
+	}}
+	ac := NewActivityCollector(stub, "ignored", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { ac.Start(ctx); close(done) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for stub.calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not exit after ctx cancel")
+	}
+	if stub.calls.Load() < 2 {
+		t.Errorf("collect calls = %d, want >=2 (upfront + tick)", stub.calls.Load())
+	}
+	snap, ready := ac.Snapshot()
+	if !ready {
+		t.Fatal("snapshot should be ready after collect")
+	}
+	if len(snap.Repos) != 1 || snap.Repos[0].Repo != "o/r" {
+		t.Errorf("snapshot repos = %+v, want one entry for o/r", snap.Repos)
+	}
+}
+
+// persistLocked failure paths: an unwritable temp path and a rename target that
+// is a directory must both be swallowed (logged), never panic or persist junk.
+func TestActivityCollector_PersistLockedFailures(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// No persist path configured → early return.
+	ac := NewActivityCollector(&stubAuditReader{}, "", logger)
+	ac.persistLocked()
+
+	// Temp-file write fails: parent directory does not exist.
+	ac.persistPath = filepath.Join(t.TempDir(), "missing-subdir", "activity.json")
+	ac.persistLocked()
+
+	// Rename fails: destination is an existing directory.
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "activity.json")
+	if err := os.Mkdir(blocked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ac.persistPath = blocked
+	ac.persistLocked()
+	if _, err := os.Stat(filepath.Join(dir, "activity.json.tmp")); err != nil {
+		t.Fatalf("temp sidecar should exist after failed rename: %v", err)
+	}
+}
+
+// EnablePersistence restore paths: corrupt JSON and a zero collected_at are
+// both "start fresh"; a valid sidecar restores snapshot + timestamp.
+func TestActivityCollector_EnablePersistenceRestore(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dir := t.TempDir()
+
+	// Corrupt sidecar → logged, ignored, not ready.
+	corrupt := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(corrupt, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ac := NewActivityCollector(&stubAuditReader{}, "", logger)
+	ac.EnablePersistence(corrupt)
+	if _, ready := ac.Snapshot(); ready {
+		t.Error("corrupt sidecar must not mark the collector ready")
+	}
+
+	// Zero collected_at → treated as empty, not ready.
+	zero := filepath.Join(dir, "zero.json")
+	if err := os.WriteFile(zero, []byte(`{"snapshot":{},"collected_at":"0001-01-01T00:00:00Z"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ac2 := NewActivityCollector(&stubAuditReader{}, "", logger)
+	ac2.EnablePersistence(zero)
+	if _, ready := ac2.Snapshot(); ready {
+		t.Error("zero collected_at must not mark the collector ready")
+	}
+
+	// Round-trip: collect+persist in one collector, restore in a second.
+	stub := &stubAuditReader{entries: []AuditEntry{
+		{Timestamp: rfc3339(time.Now()), Action: "pr_merged", Detail: "repo=o/persisted, agent=quality"},
+	}}
+	sidecar := filepath.Join(dir, "activity.json")
+	writer := NewActivityCollector(stub, "ignored", logger)
+	writer.EnablePersistence(sidecar)
+	writer.collect()
+
+	restored := NewActivityCollector(&stubAuditReader{}, "", logger)
+	restored.EnablePersistence(sidecar)
+	snap, ready := restored.Snapshot()
+	if !ready {
+		t.Fatal("restored collector should be ready")
+	}
+	if len(snap.Repos) != 1 || snap.Repos[0].Repo != "o/persisted" {
+		t.Errorf("restored repos = %+v, want o/persisted", snap.Repos)
+	}
+	if restored.CollectedAt().IsZero() {
+		t.Error("restored CollectedAt should be non-zero")
+	}
+}

--- a/src/pkg/dashboard/collect/budget_window.go
+++ b/src/pkg/dashboard/collect/budget_window.go
@@ -1,0 +1,169 @@
+package collect
+
+import (
+	"sync"
+)
+
+// Per-budget-window history (kubestellar/hive#4298).
+//
+// The dashboard has always shown the CURRENT budget window: how much of the
+// weekly limit this window has consumed, and when it rolls. That answers "am I
+// about to run out", and it is the only question it can answer — the moment the
+// window rolls, the previous window's number is gone.
+//
+// The question an administrator actually asks after two weeks away is the other
+// one: "did the budget stop the hive while I was gone?" Nothing in the tree
+// could answer it. The token sparkline records tokens over time but knows
+// nothing about the limit or where the window boundaries fell, and the governor
+// keeps only the open window's spend.
+//
+// This records one row per CLOSED window — when it ran, what the limit was,
+// what was consumed, and whether it hit the limit — so "for every recent reset,
+// how much of the budget had been used" becomes a lookup.
+//
+// COMPATIBILITY. A hive upgrading into this keeps no history it never
+// collected: the list starts empty, every accessor tolerates that, and the
+// first observation merely starts tracking. Nothing here can fail a status
+// build — an unset limit, a zero window, and a governor that has not opened a
+// window yet are ordinary inputs, not errors.
+
+// BudgetWindowMaxEntries caps the ring. With a weekly window, 26 entries is
+// half a year — longer than an operator investigates, and trivially small on
+// disk. A named constant so the retention is a deliberate number rather than an
+// accident of the buffer size.
+const BudgetWindowMaxEntries = 26
+
+// BudgetWindowEntry is one CLOSED budget window.
+//
+// Timestamps are epoch milliseconds, matching every other history series the
+// dashboard persists, so the frontend parses them the same way.
+type BudgetWindowEntry struct {
+	// WindowStart and WindowEnd bound the window. WindowEnd is when the reset
+	// happened, which is what an operator correlates against "the fortnight I
+	// was away".
+	WindowStart int64 `json:"windowStart"`
+	WindowEnd   int64 `json:"windowEnd"`
+	// Limit is the weekly token limit that was in force FOR THIS WINDOW.
+	// Recorded per window rather than read live, because an operator who raised
+	// the limit after a bad week must still see what the limit was when it bit.
+	Limit int64 `json:"limit"`
+	// Used is the tokens consumed — the high-water mark observed before the
+	// roll, not a post-roll reading, which would always be ~0.
+	Used int64 `json:"used"`
+	// PctUsed is Used/Limit as a percentage; 0 when no limit was set.
+	PctUsed float64 `json:"pctUsed"`
+	// Exhausted records whether the window actually reached its limit. Stored
+	// rather than recomputed, for the same reason Limit is: a later limit
+	// change must not rewrite history and make a past window look fine.
+	Exhausted bool `json:"exhausted"`
+}
+
+// BudgetWindowTracker watches the open window and emits an entry when it rolls.
+// A small leaf-locked struct: nothing here calls back into Server, so the mutex
+// is taken and released inside one method.
+type BudgetWindowTracker struct {
+	mu sync.Mutex
+	// start/end bound the window being observed. Zero before the first
+	// observation and whenever the governor reports no open window.
+	start int64
+	end   int64
+	limit int64
+	// peakUsed is the HIGH-WATER spend seen in the open window.
+	//
+	// High-water rather than last-seen because the roll is detected on the
+	// observation AFTER it happened, by which time the live spend has already
+	// reset toward zero. Reading it then would record every window as barely
+	// used — precisely the wrong answer for the question this feature exists to
+	// answer.
+	peakUsed int64
+	// exhausted latches for the same reason: the state is transient and the
+	// roll is observed late.
+	exhausted bool
+	// closed holds completed windows, oldest first.
+	closed []BudgetWindowEntry
+}
+
+// Observe folds one status reading into the tracker, returning the entry for a
+// window that just closed (nil when none did).
+//
+// windowStart/windowEnd are the open window's bounds in epoch milliseconds. A
+// zero windowEnd means the governor has no window open (no limit configured),
+// which closes any tracked window without starting a new one.
+func (t *BudgetWindowTracker) Observe(windowStart, windowEnd, limit, used int64, exhausted bool) *BudgetWindowEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Same window still open: accumulate and stop.
+	if windowEnd != 0 && windowEnd == t.end {
+		if used > t.peakUsed {
+			t.peakUsed = used
+		}
+		if exhausted {
+			t.exhausted = true
+		}
+		if limit > 0 {
+			t.limit = limit
+		}
+		return nil
+	}
+
+	// The window changed. Close the tracked one, if there was one.
+	var rolled *BudgetWindowEntry
+	if t.end != 0 {
+		entry := BudgetWindowEntry{
+			WindowStart: t.start,
+			WindowEnd:   t.end,
+			Limit:       t.limit,
+			Used:        t.peakUsed,
+			Exhausted:   t.exhausted,
+		}
+		if t.limit > 0 {
+			const pctMultiplier = 100.0
+			entry.PctUsed = float64(t.peakUsed) / float64(t.limit) * pctMultiplier
+		}
+		t.closed = append(t.closed, entry)
+		if len(t.closed) > BudgetWindowMaxEntries {
+			t.closed = t.closed[len(t.closed)-BudgetWindowMaxEntries:]
+		}
+		rolled = &entry
+	}
+
+	// Begin tracking the new window. A zero windowEnd leaves the tracker idle
+	// rather than recording an empty row on every status build.
+	if windowEnd == 0 {
+		t.start, t.end, t.limit, t.peakUsed, t.exhausted = 0, 0, 0, 0, false
+		return rolled
+	}
+	t.start, t.end, t.limit = windowStart, windowEnd, limit
+	t.peakUsed, t.exhausted = used, exhausted
+	return rolled
+}
+
+// Snapshot returns a copy of the closed windows, newest FIRST — the order an
+// operator reads them in, and the order the API serves.
+func (t *BudgetWindowTracker) Snapshot() []BudgetWindowEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]BudgetWindowEntry, 0, len(t.closed))
+	for i := len(t.closed) - 1; i >= 0; i-- {
+		out = append(out, t.closed[i])
+	}
+	return out
+}
+
+// Seed restores persisted history on startup. Entries arrive newest-first (the
+// order snapshot emits and the API serves) and are stored oldest-first
+// internally, so a save/load round trip preserves order. Over-long input is
+// truncated to the newest entries rather than rejected: a file written by a
+// build with a larger cap must not break startup.
+func (t *BudgetWindowTracker) Seed(entries []BudgetWindowEntry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = t.closed[:0]
+	for i := len(entries) - 1; i >= 0; i-- {
+		t.closed = append(t.closed, entries[i])
+	}
+	if len(t.closed) > BudgetWindowMaxEntries {
+		t.closed = t.closed[len(t.closed)-BudgetWindowMaxEntries:]
+	}
+}

--- a/src/pkg/dashboard/collect/budget_window_test.go
+++ b/src/pkg/dashboard/collect/budget_window_test.go
@@ -1,0 +1,178 @@
+package collect
+
+// Tracker-level ports of pkg/dashboard's budget-history tests
+// (kubestellar/hive#5565 slice 2): the same scenarios driven directly through
+// BudgetWindowTracker.Observe instead of Server.ObserveBudgetWindow. The
+// Server-mediated versions (status parsing, the /api/budget/history endpoint)
+// stay in pkg/dashboard.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func ms(t time.Time) int64 { return t.UnixMilli() }
+
+// The roll is detected on the observation AFTER it happened, by which time the
+// live spend has already reset toward zero — the recorded row must carry the
+// high-water mark, not the post-reset reading.
+func TestTrackerWindowRollRecordsPeakNotPostResetReading(t *testing.T) {
+	tr := &BudgetWindowTracker{}
+	start := time.Now().Add(-7 * 24 * time.Hour)
+	end := time.Now()
+
+	if rolled := tr.Observe(ms(start), ms(end), 1_000_000, 200_000, false); rolled != nil {
+		t.Fatalf("first observation must not close a window, got %+v", rolled)
+	}
+	tr.Observe(ms(start), ms(end), 1_000_000, 900_000, false) // high water
+	tr.Observe(ms(start), ms(end), 1_000_000, 950_000, true)  // exhausted latches
+
+	// Window rolls: new bounds, spend back near zero.
+	newStart := end
+	newEnd := end.Add(7 * 24 * time.Hour)
+	rolled := tr.Observe(ms(newStart), ms(newEnd), 1_000_000, 10_000, false)
+	if rolled == nil {
+		t.Fatal("window change must emit the closed row")
+	}
+	if rolled.Used != 950_000 {
+		t.Errorf("Used = %d, want the high-water 950000, never the post-reset reading", rolled.Used)
+	}
+	if !rolled.Exhausted {
+		t.Error("Exhausted must latch across later non-exhausted observations")
+	}
+	if rolled.WindowStart != ms(start) || rolled.WindowEnd != ms(end) {
+		t.Errorf("closed row bounds = [%d,%d], want [%d,%d]", rolled.WindowStart, rolled.WindowEnd, ms(start), ms(end))
+	}
+}
+
+// "Did the budget stop the hive while I was away?" — after several rolls the
+// history answers per closed window, newest first.
+func TestTrackerHistoryNewestFirst(t *testing.T) {
+	tr := &BudgetWindowTracker{}
+	base := time.Now().Add(-4 * 7 * 24 * time.Hour)
+	week := 7 * 24 * time.Hour
+	for i := 0; i < 3; i++ {
+		start := base.Add(time.Duration(i) * week)
+		end := start.Add(week)
+		tr.Observe(ms(start), ms(end), 100, int64(10*(i+1)), i == 1)
+	}
+	// Close the third window by reporting no open window.
+	tr.Observe(0, 0, 0, 0, false)
+
+	hist := tr.Snapshot()
+	if len(hist) != 3 {
+		t.Fatalf("history = %d rows, want 3", len(hist))
+	}
+	if hist[0].Used != 30 || hist[2].Used != 10 {
+		t.Errorf("history not newest-first: %+v", hist)
+	}
+	if !hist[1].Exhausted {
+		t.Errorf("middle window must record exhaustion: %+v", hist[1])
+	}
+}
+
+// The limit in force FOR THE WINDOW is recorded, so raising the limit later
+// never rewrites what a past window ran under; PctUsed derives from it.
+func TestTrackerLimitIsRecordedPerWindow(t *testing.T) {
+	tr := &BudgetWindowTracker{}
+	start := time.Now().Add(-7 * 24 * time.Hour)
+	end := time.Now()
+	tr.Observe(ms(start), ms(end), 500, 500, true)
+
+	newEnd := end.Add(7 * 24 * time.Hour)
+	rolled := tr.Observe(ms(end), ms(newEnd), 2_000, 0, false)
+	if rolled == nil {
+		t.Fatal("roll must emit the closed row")
+	}
+	if rolled.Limit != 500 {
+		t.Errorf("Limit = %d, want the 500 in force for the closed window", rolled.Limit)
+	}
+	if rolled.PctUsed != 100 {
+		t.Errorf("PctUsed = %v, want 100", rolled.PctUsed)
+	}
+}
+
+// A zero windowEnd (no limit configured) closes any tracked window without
+// starting a new one, and observing nothing records nothing.
+func TestTrackerNoBudgetConfiguredRecordsNothing(t *testing.T) {
+	tr := &BudgetWindowTracker{}
+	if rolled := tr.Observe(0, 0, 0, 0, false); rolled != nil {
+		t.Fatalf("idle tracker must not emit rows, got %+v", rolled)
+	}
+	if got := tr.Snapshot(); len(got) != 0 {
+		t.Fatalf("history = %+v, want empty", got)
+	}
+}
+
+// Retention: the ring keeps only the newest BudgetWindowMaxEntries rows.
+func TestTrackerRetentionKeepsNewest(t *testing.T) {
+	tr := &BudgetWindowTracker{}
+	week := 7 * 24 * time.Hour
+	start := time.Now().Add(-time.Duration(BudgetWindowMaxEntries+10) * week)
+	total := BudgetWindowMaxEntries + 5
+	for i := 0; i < total; i++ {
+		ws := start.Add(time.Duration(i) * week)
+		we := ws.Add(week)
+		tr.Observe(ms(ws), ms(we), 100, int64(i), false)
+	}
+	tr.Observe(0, 0, 0, 0, false) // close the last one
+
+	hist := tr.Snapshot()
+	if len(hist) != BudgetWindowMaxEntries {
+		t.Fatalf("history = %d entries, want the cap %d", len(hist), BudgetWindowMaxEntries)
+	}
+	if hist[0].Used != int64(total-1) {
+		t.Errorf("newest row Used = %d, want %d (retention must drop the OLDEST)", hist[0].Used, total-1)
+	}
+}
+
+// Seed restores persisted history: a Snapshot → JSON → Seed round trip
+// preserves both content and order, and over-long input truncates to newest.
+func TestTrackerSeedRoundTripsThroughJSON(t *testing.T) {
+	tr := &BudgetWindowTracker{}
+	week := 7 * 24 * time.Hour
+	base := time.Now().Add(-3 * week)
+	for i := 0; i < 2; i++ {
+		ws := base.Add(time.Duration(i) * week)
+		tr.Observe(ms(ws), ms(ws.Add(week)), 100, int64(10*(i+1)), false)
+	}
+	tr.Observe(0, 0, 0, 0, false)
+	saved := tr.Snapshot()
+
+	blob, err := json.Marshal(saved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var loaded []BudgetWindowEntry
+	if err := json.Unmarshal(blob, &loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted := &BudgetWindowTracker{}
+	restarted.Seed(loaded)
+	got := restarted.Snapshot()
+	if len(got) != len(saved) {
+		t.Fatalf("restored %d rows, want %d", len(got), len(saved))
+	}
+	for i := range got {
+		if got[i] != saved[i] {
+			t.Errorf("row %d = %+v, want %+v", i, got[i], saved[i])
+		}
+	}
+
+	// Over-long input keeps the NEWEST cap-many entries rather than rejecting.
+	long := make([]BudgetWindowEntry, BudgetWindowMaxEntries+4)
+	for i := range long {
+		long[i] = BudgetWindowEntry{Used: int64(len(long) - i)} // newest-first
+	}
+	over := &BudgetWindowTracker{}
+	over.Seed(long)
+	trimmed := over.Snapshot()
+	if len(trimmed) != BudgetWindowMaxEntries {
+		t.Fatalf("seeded %d rows, want cap %d", len(trimmed), BudgetWindowMaxEntries)
+	}
+	if trimmed[0].Used != long[0].Used {
+		t.Errorf("truncation must keep the newest entries: got %+v, want %+v", trimmed[0], long[0])
+	}
+}

--- a/src/pkg/dashboard/collect/fleet_stats_collector.go
+++ b/src/pkg/dashboard/collect/fleet_stats_collector.go
@@ -1,4 +1,4 @@
-package dashboard
+package collect
 
 import (
 	"context"

--- a/src/pkg/dashboard/collect/fleet_stats_collector_test.go
+++ b/src/pkg/dashboard/collect/fleet_stats_collector_test.go
@@ -1,4 +1,4 @@
-package dashboard
+package collect
 
 import (
 	"context"

--- a/src/pkg/dashboard/collect/repo_cost.go
+++ b/src/pkg/dashboard/collect/repo_cost.go
@@ -1,4 +1,4 @@
-package dashboard
+package collect
 
 // Per-repo estimated cost attribution — phase 3 of #4836.
 //
@@ -51,7 +51,6 @@ package dashboard
 // respected rather than bypassed.
 
 import (
-	"net/http"
 	"sort"
 	"strconv"
 	"time"
@@ -59,26 +58,33 @@ import (
 	"github.com/kubestellar/hive/pkg/tokens"
 )
 
-// repoCostWindow is the lookback for BOTH sides of the join. It matches the
+// CostEstimateDisclaimer travels with every estimated-cost payload (moved here
+// from pkg/dashboard's cost.go so both the /api/cost handler and the repo-cost
+// join stamp the identical sentence).
+const CostEstimateDisclaimer = "Estimated from token counts × published list prices. " +
+	"Subscription plans (Claude, Copilot), self-hosted inference (vLLM), and negotiated rates differ from list price. " +
+	"Not a bill."
+
+// RepoCostWindow is the lookback for BOTH sides of the join. It matches the
 // activity collector's activityWindow so the audit events and the usage events
 // cover the same span — joining a 14d event stream against a 30d usage stream
 // would silently push 16 days of real spend into `unattributed`.
-const repoCostWindow = activityWindow
+const RepoCostWindow = activityWindow
 
-// repoCostBucketUnattributed and repoCostBucketBackendUnsupported are the two
+// RepoCostBucketUnattributed and RepoCostBucketBackendUnsupported are the two
 // mandatory buckets. They are exported in the payload under fixed keys because
 // a UI must be able to render them without inferring their meaning, and they
 // are always present even when zero.
 const (
-	repoCostBucketUnattributed       = "unattributed"
-	repoCostBucketBackendUnsupported = "backend_unsupported"
+	RepoCostBucketUnattributed       = "unattributed"
+	RepoCostBucketBackendUnsupported = "backend_unsupported"
 )
 
-// repoCostEntry is one repo's attributed estimated cost. USD is a POINTER so a
+// RepoCostEntry is one repo's attributed estimated cost. USD is a POINTER so a
 // repo with no attributable cost renders as "—" and never as "$0.00": those are
 // different facts and conflating them is how an operator concludes a repo was
 // cheap when it was merely unobserved.
-type repoCostEntry struct {
+type RepoCostEntry struct {
 	Repo string   `json:"repo"`
 	USD  *float64 `json:"usd"`
 	// Source is "estimated" when every model contributing to this repo had an
@@ -104,16 +110,16 @@ type repoCostEntry struct {
 	Agents []string `json:"agents,omitempty"`
 }
 
-// repoCostResponse is the GET /api/repo-cost payload.
-type repoCostResponse struct {
+// RepoCostResponse is the GET /api/repo-cost payload.
+type RepoCostResponse struct {
 	Ready bool   `json:"ready"`
 	Phase string `json:"phase"`
 	// ByRepo excludes the two mandatory buckets, which are reported separately
 	// so no consumer can accidentally sum them into a "per-repo" total or
 	// normalize them away as rounding.
-	ByRepo             []repoCostEntry `json:"by_repo"`
-	Unattributed       repoCostEntry   `json:"unattributed"`
-	BackendUnsupported repoCostEntry   `json:"backend_unsupported"`
+	ByRepo             []RepoCostEntry `json:"by_repo"`
+	Unattributed       RepoCostEntry   `json:"unattributed"`
+	BackendUnsupported RepoCostEntry   `json:"backend_unsupported"`
 
 	// TotalUSD is the sum of every bucket below — the hive-wide estimated total
 	// this response partitions. Pricing is linear in token counts, so it tracks
@@ -153,9 +159,9 @@ type repoCostResponse struct {
 	CollectedAt time.Time `json:"collected_at,omitempty"`
 }
 
-// repoCostLimitations is surfaced in the payload so the UI renders the method's
+// RepoCostLimitations is surfaced in the payload so the UI renders the method's
 // caveats alongside the numbers rather than burying them in code comments.
-func repoCostLimitations() []string {
+func RepoCostLimitations() []string {
 	return []string{
 		"Claude sessions only. Copilot records all token usage in a single lump at session shutdown and bob parses no per-message timestamps, so neither can be placed in time. Their spend is real and is reported in full under backend_unsupported — it is not missing, it is not attributable.",
 		"Attribution is inferred from TIMING, not measured. Tokens spent between two audited repo= events are billed to the repo named by the later event.",
@@ -223,8 +229,8 @@ func (a *repoCostAccumulator) add(p repoUsagePoint) {
 	a.touched = true
 }
 
-func (a *repoCostAccumulator) entry(name string) repoCostEntry {
-	e := repoCostEntry{
+func (a *repoCostAccumulator) entry(name string) RepoCostEntry {
+	e := RepoCostEntry{
 		Repo:        name,
 		Input:       a.input,
 		Output:      a.output,
@@ -256,21 +262,21 @@ type repoAuditEvent struct {
 	repo string
 }
 
-// computeRepoCost performs the interval join. It is a pure function of its
+// ComputeRepoCost performs the interval join. It is a pure function of its
 // inputs — no clock, no I/O — so the invariant test can drive it directly.
 //
 // summary is the hive's merged token summary (the same one /api/cost prices).
 // entries are audited output actions carrying repo= over the window.
-func computeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now time.Time) repoCostResponse {
-	resp := repoCostResponse{
+func ComputeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now time.Time) RepoCostResponse {
+	resp := RepoCostResponse{
 		Phase:              "phase_3_interval_join",
-		ByRepo:             []repoCostEntry{},
-		WindowHours:        int(repoCostWindow / time.Hour),
+		ByRepo:             []RepoCostEntry{},
+		WindowHours:        int(RepoCostWindow / time.Hour),
 		PriceTableDate:     tokens.PriceTableDate(),
-		Disclaimer:         costEstimateDisclaimer,
-		Limitations:        repoCostLimitations(),
-		Unattributed:       repoCostEntry{Repo: repoCostBucketUnattributed, Source: "estimated"},
-		BackendUnsupported: repoCostEntry{Repo: repoCostBucketBackendUnsupported, Source: "estimated"},
+		Disclaimer:         CostEstimateDisclaimer,
+		Limitations:        RepoCostLimitations(),
+		Unattributed:       RepoCostEntry{Repo: RepoCostBucketUnattributed, Source: "estimated"},
+		BackendUnsupported: RepoCostEntry{Repo: RepoCostBucketBackendUnsupported, Source: "estimated"},
 		CollectedAt:        now,
 	}
 	if summary == nil {
@@ -304,7 +310,7 @@ func computeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 	resp.OldestEventAt = oldest
 
 	// --- Side B: usage points, split by whether they are placeable in time ---
-	windowStartMs := now.Add(-repoCostWindow).UnixMilli()
+	windowStartMs := now.Add(-RepoCostWindow).UnixMilli()
 	byRepo := map[string]*repoCostAccumulator{}
 	unattributed := &repoCostAccumulator{}
 	backendUnsupported := &repoCostAccumulator{}
@@ -375,8 +381,8 @@ func computeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 		return a.Repo < b.Repo
 	})
 
-	resp.Unattributed = unattributed.entry(repoCostBucketUnattributed)
-	resp.BackendUnsupported = backendUnsupported.entry(repoCostBucketBackendUnsupported)
+	resp.Unattributed = unattributed.entry(RepoCostBucketUnattributed)
+	resp.BackendUnsupported = backendUnsupported.entry(RepoCostBucketBackendUnsupported)
 	resp.TotalUSD += unattributed.usd + backendUnsupported.usd
 	resp.TotalTokens = resp.AttributedTokens + resp.Unattributed.Tokens + resp.BackendUnsupported.Tokens
 
@@ -425,61 +431,4 @@ func attributeRepo(events []repoAuditEvent, tsMs, windowStartMs int64) (repoAudi
 		return repoAuditEvent{}, false
 	}
 	return events[i], true
-}
-
-// handleRepoCost serves GET /api/repo-cost from the cached RepoCostCollector
-// snapshot (see repo_cost_collector.go) rather than recomputing the interval
-// join per request. The join reads every rotated/compressed audit backup
-// (up to 64MB decompressed each) and walks every retained Claude usage
-// event in the window — recomputing that on every 60s dashboard poll, per
-// open tab, was the defect fixed by #4943.
-//
-// When the collector has not produced a snapshot yet (fresh boot, before its
-// first ticker fire), this reports ready=false with an EMPTY by_repo/zero
-// totals and no CollectedAt — never a fabricated $0.00. A cost payload with
-// ready=true and an empty by_repo is indistinguishable from "this hive spent
-// nothing", which is exactly the misreporting the #4836 epic exists to
-// prevent, so the not-ready state must stay visibly different from that.
-func (s *Server) handleRepoCost(w http.ResponseWriter, r *http.Request) {
-	if s.deps != nil && s.deps.RepoCost != nil {
-		snap, ready := s.deps.RepoCost.Snapshot()
-		if !ready {
-			jsonResponse(w, repoCostResponse{
-				Phase:              "phase_3_interval_join",
-				ByRepo:             []repoCostEntry{},
-				PriceTableDate:     tokens.PriceTableDate(),
-				Disclaimer:         costEstimateDisclaimer,
-				Limitations:        repoCostLimitations(),
-				Unattributed:       repoCostEntry{Repo: repoCostBucketUnattributed, Source: "estimated"},
-				BackendUnsupported: repoCostEntry{Repo: repoCostBucketBackendUnsupported, Source: "estimated"},
-			})
-			return
-		}
-		jsonResponse(w, snap)
-		return
-	}
-
-	// No collector wired (e.g. a minimal test Server): fall back to computing
-	// inline so the endpoint still degrades to a correct answer rather than
-	// 503ing. Production always wires RepoCost (see cmd/hive/main.go).
-	now := time.Now()
-	var summary *tokens.AggregateSummary
-	if s.deps != nil && s.deps.Tokens != nil {
-		summary = s.deps.Tokens.Summary()
-	}
-	var entries []AuditEntry
-	if s.audit != nil {
-		entries = s.audit.OutputActionsSince(now.Add(-repoCostWindow), activityOutputActions, s.auditPathForActivity())
-	}
-	jsonResponse(w, computeRepoCost(summary, entries, now))
-}
-
-// auditPathForActivity returns the audit file path the activity collector was
-// configured with, so the cost join reads exactly the same log. "" means the
-// production default (see OutputActionsSince).
-func (s *Server) auditPathForActivity() string {
-	if s.deps != nil && s.deps.Activity != nil {
-		return s.deps.Activity.auditPath
-	}
-	return ""
 }

--- a/src/pkg/dashboard/collect/repo_cost_collector.go
+++ b/src/pkg/dashboard/collect/repo_cost_collector.go
@@ -1,4 +1,4 @@
-package dashboard
+package collect
 
 // RepoCostCollector caches the /api/repo-cost interval join on a ticker,
 // exactly the way ActivityCollector (activity_collector.go) already caches
@@ -21,7 +21,7 @@ import (
 
 // repoCostCollectInterval mirrors activityCollectInterval on purpose: this
 // collector reads the SAME audit window as the activity collector (see
-// repoCostWindow = activityWindow) to feed the interval join, so there is no
+// RepoCostWindow = activityWindow) to feed the interval join, so there is no
 // reason for the two caches to go stale at different rates — a dashboard
 // comparing repo-activity counts against repo-cost dollars would otherwise be
 // looking at two different moments in time. If a reason to diverge ever shows
@@ -40,7 +40,7 @@ type tokensSummaryReader interface {
 // Mirrors ActivityCollector's lifecycle (EnablePersistence/Start/Snapshot).
 type RepoCostCollector struct {
 	mu     sync.Mutex
-	audit  auditReader
+	audit  AuditReader
 	tokens tokensSummaryReader
 	// auditPath is where OutputActionsSince reads ("" -> the production audit
 	// log). Kept in sync with the activity collector's path so both caches
@@ -50,14 +50,14 @@ type RepoCostCollector struct {
 	nowFn       func() time.Time
 	persistPath string
 
-	snap        repoCostResponse
+	snap        RepoCostResponse
 	ready       bool
 	collectedAt time.Time
 }
 
 // persistedRepoCost is the on-disk sidecar shape, mirroring persistedActivity.
 type persistedRepoCost struct {
-	Snapshot    repoCostResponse `json:"snapshot"`
+	Snapshot    RepoCostResponse `json:"snapshot"`
 	CollectedAt time.Time        `json:"collected_at"`
 }
 
@@ -66,7 +66,7 @@ type persistedRepoCost struct {
 // inert (Snapshot ready=false forever). auditPath is where OutputActionsSince
 // reads ("" -> the production audit log; pass the same path the activity
 // collector uses so both read one file set).
-func NewRepoCostCollector(audit auditReader, tok tokensSummaryReader, auditPath string, logger *slog.Logger) *RepoCostCollector {
+func NewRepoCostCollector(audit AuditReader, tok tokensSummaryReader, auditPath string, logger *slog.Logger) *RepoCostCollector {
 	return &RepoCostCollector{
 		audit:     audit,
 		tokens:    tok,
@@ -156,8 +156,8 @@ func (rc *RepoCostCollector) Start(ctx context.Context) {
 func (rc *RepoCostCollector) collect() {
 	now := rc.nowFn()
 	summary := rc.tokens.Summary()
-	entries := rc.audit.OutputActionsSince(now.Add(-repoCostWindow), activityOutputActions, rc.auditPath)
-	resp := computeRepoCost(summary, entries, now)
+	entries := rc.audit.OutputActionsSince(now.Add(-RepoCostWindow), ActivityOutputActions, rc.auditPath)
+	resp := ComputeRepoCost(summary, entries, now)
 
 	rc.mu.Lock()
 	rc.snap = resp
@@ -168,14 +168,14 @@ func (rc *RepoCostCollector) collect() {
 }
 
 // Snapshot returns the last computed response and whether a collect has ever
-// succeeded (i.e. produced a non-nil token summary; see computeRepoCost).
+// succeeded (i.e. produced a non-nil token summary; see ComputeRepoCost).
 // Ready=false must never be papered over with a zero-valued response by the
 // caller — a cost endpoint reporting $0.00 before its first collection is
 // indistinguishable from a hive that genuinely spent nothing, which is
 // exactly the misreporting #4836 exists to prevent.
-func (rc *RepoCostCollector) Snapshot() (repoCostResponse, bool) {
+func (rc *RepoCostCollector) Snapshot() (RepoCostResponse, bool) {
 	if rc == nil {
-		return repoCostResponse{}, false
+		return RepoCostResponse{}, false
 	}
 	rc.mu.Lock()
 	defer rc.mu.Unlock()

--- a/src/pkg/dashboard/collect/repo_cost_collector_test.go
+++ b/src/pkg/dashboard/collect/repo_cost_collector_test.go
@@ -1,0 +1,172 @@
+package collect
+
+// Collector-level RepoCostCollector tests, moved from pkg/dashboard with the
+// collector (kubestellar/hive#5565 slice 2). The /api/repo-cost handler tests
+// that exercise the served path stay in pkg/dashboard.
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/pkg/tokens"
+)
+
+// fakeFixedAudit is an AuditReader that always returns the same entries,
+// regardless of since/actions/filePath — good enough to drive the collector
+// in a test without a real audit file on disk.
+type fakeFixedAudit struct{ entries []AuditEntry }
+
+func (f *fakeFixedAudit) OutputActionsSince(_ time.Time, _ map[string]bool, _ string) []AuditEntry {
+	return f.entries
+}
+
+// fakeTokensSummary returns a fixed *tokens.AggregateSummary, so a test does
+// not need a real *tokens.Collector backed by session files on disk.
+type fakeTokensSummary struct {
+	summary *tokens.AggregateSummary
+}
+
+func (f *fakeTokensSummary) Summary() *tokens.AggregateSummary { return f.summary }
+
+// TestRepoCostCollectorPersistsAcrossRestart mirrors ActivityCollector's
+// EnablePersistence contract: a fresh collector pointed at a prior snapshot
+// file must report ready=true immediately, with the ORIGINAL CollectedAt
+// preserved, before its own first ticker fire — so a restart does not present
+// a stale-but-labeled-fresh figure, and does not regress to not-ready either.
+func TestRepoCostCollectorPersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/repo-cost.json"
+
+	original := NewRepoCostCollector(&fakeFixedAudit{entries: []AuditEntry{
+		rcEvent(time.Now().Add(-time.Hour), "scanner", "org/repo-a"),
+	}}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	fixedNow := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Second)
+	original.nowFn = func() time.Time { return fixedNow }
+	original.EnablePersistence(path)
+	original.collect()
+
+	restarted := NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	restarted.EnablePersistence(path)
+
+	snap, ready := restarted.Snapshot()
+	if !ready {
+		t.Fatal("restored collector must report ready=true without waiting for its own first collect")
+	}
+	if !snap.CollectedAt.Equal(fixedNow) {
+		t.Fatalf("restored CollectedAt = %v, want %v (the ORIGINAL collection time, not now)", snap.CollectedAt, fixedNow)
+	}
+}
+
+// TestRepoCostCollector_StartCollectsAndStops asserts Start performs the
+// up-front collect (Snapshot ready, CollectedAt set), keeps collecting on the
+// ticker, and exits on ctx cancel.
+func TestRepoCostCollector_StartCollectsAndStops(t *testing.T) {
+	origInterval := repoCostCollectInterval
+	repoCostCollectInterval = 5 * time.Millisecond
+	t.Cleanup(func() { repoCostCollectInterval = origInterval })
+
+	audit := &fakeFixedAudit{}
+	rc := NewRepoCostCollector(audit, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+
+	if !rc.CollectedAt().IsZero() {
+		t.Fatalf("CollectedAt = %v before any collect, want zero", rc.CollectedAt())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		rc.Start(ctx)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, ready := rc.Snapshot(); ready {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("Start never produced a ready snapshot")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if rc.CollectedAt().IsZero() {
+		t.Error("CollectedAt still zero after a successful collect")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after ctx cancel — goroutine leak")
+	}
+}
+
+// TestRepoCostCollector_StartInertWithoutInputs asserts the documented inert
+// contract: Start returns immediately (rather than spinning a ticker) when
+// either side of the audit/tokens join is missing, and on a nil receiver.
+func TestRepoCostCollector_StartInertWithoutInputs(t *testing.T) {
+	cases := map[string]*RepoCostCollector{
+		"nil collector": nil,
+		"nil audit":     NewRepoCostCollector(nil, &fakeTokensSummary{}, "", nil),
+		"nil tokens":    NewRepoCostCollector(&fakeFixedAudit{}, nil, "", nil),
+	}
+	for name, rc := range cases {
+		done := make(chan struct{})
+		go func() {
+			rc.Start(context.Background())
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s: Start did not return immediately", name)
+		}
+		if _, ready := rc.Snapshot(); ready {
+			t.Errorf("%s: inert collector must never be ready", name)
+		}
+	}
+}
+
+// EnablePersistence restore paths mirror ActivityCollector's: corrupt JSON and
+// a zero collected_at both "start fresh"; persist failures are swallowed.
+func TestRepoCostCollector_PersistenceEdgeCases(t *testing.T) {
+	dir := t.TempDir()
+
+	// Corrupt sidecar → ignored, not ready.
+	corrupt := dir + "/corrupt.json"
+	if err := os.WriteFile(corrupt, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rc := NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	rc.EnablePersistence(corrupt)
+	if _, ready := rc.Snapshot(); ready {
+		t.Error("corrupt sidecar must not mark the collector ready")
+	}
+
+	// Zero collected_at → treated as empty, not ready.
+	zero := dir + "/zero.json"
+	if err := os.WriteFile(zero, []byte(`{"snapshot":{},"collected_at":"0001-01-01T00:00:00Z"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rc2 := NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	rc2.EnablePersistence(zero)
+	if _, ready := rc2.Snapshot(); ready {
+		t.Error("zero collected_at must not mark the collector ready")
+	}
+
+	// No persist path configured → persistLocked is an early-return no-op.
+	rc2.persistLocked()
+
+	// Nil receiver → EnablePersistence is a no-op, never a panic.
+	var nilRC *RepoCostCollector
+	nilRC.EnablePersistence(dir + "/unused.json")
+	if _, ready := nilRC.Snapshot(); ready {
+		t.Error("nil collector must never be ready")
+	}
+	if !nilRC.CollectedAt().IsZero() {
+		t.Error("nil collector CollectedAt must be zero")
+	}
+}

--- a/src/pkg/dashboard/collect/repo_cost_test.go
+++ b/src/pkg/dashboard/collect/repo_cost_test.go
@@ -1,4 +1,4 @@
-package dashboard
+package collect
 
 import (
 	"testing"
@@ -37,7 +37,7 @@ func rcSession(id, agent string, usage ...tokens.UsageEvent) tokens.SessionSumma
 	return s
 }
 
-func findRepo(t *testing.T, resp repoCostResponse, repo string) repoCostEntry {
+func findRepo(t *testing.T, resp RepoCostResponse, repo string) RepoCostEntry {
 	t.Helper()
 	for _, e := range resp.ByRepo {
 		if e.Repo == repo {
@@ -45,7 +45,7 @@ func findRepo(t *testing.T, resp repoCostResponse, repo string) repoCostEntry {
 		}
 	}
 	t.Fatalf("repo %q not in by_repo: %+v", repo, resp.ByRepo)
-	return repoCostEntry{}
+	return RepoCostEntry{}
 }
 
 // TestRepoCostPartitionInvariant is the epic's hard requirement #1, written as
@@ -86,7 +86,7 @@ func TestRepoCostPartitionInvariant(t *testing.T) {
 		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
 	}
 
-	resp := computeRepoCost(summary, entries, now)
+	resp := ComputeRepoCost(summary, entries, now)
 
 	sum := resp.Unattributed.Tokens + resp.BackendUnsupported.Tokens
 	for _, e := range resp.ByRepo {
@@ -117,7 +117,7 @@ func TestRepoCostAttributesToClosingEvent(t *testing.T) {
 		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
 	}
 
-	resp := computeRepoCost(summary, entries, now)
+	resp := ComputeRepoCost(summary, entries, now)
 	b := findRepo(t, resp, "org/repo-b")
 	if b.Tokens != 1100 {
 		t.Fatalf("closing repo tokens = %d, want 1100", b.Tokens)
@@ -140,7 +140,7 @@ func TestRepoCostNeverAttributesLeadingInterval(t *testing.T) {
 	}}
 	entries := []AuditEntry{rcEvent(rcTime(base, 10), "scanner", "org/repo-a")}
 
-	resp := computeRepoCost(summary, entries, now)
+	resp := ComputeRepoCost(summary, entries, now)
 	if len(resp.ByRepo) != 0 {
 		t.Fatalf("leading interval was attributed: %+v", resp.ByRepo)
 	}
@@ -157,7 +157,7 @@ func TestRepoCostBackendUnsupportedCarriesNonClaude(t *testing.T) {
 		{SessionID: "c1", Agent: "a", Model: "gpt-5", Backend: tokens.BackendCopilot, InputTokens: 100, OutputTokens: 10, TotalTokens: 110},
 		{SessionID: "b1", Agent: "a", Model: "bob", Backend: tokens.BackendBob, InputTokens: 200, OutputTokens: 20, TotalTokens: 220},
 	}}
-	resp := computeRepoCost(summary, nil, now)
+	resp := ComputeRepoCost(summary, nil, now)
 	if resp.BackendUnsupported.Tokens != 330 {
 		t.Fatalf("backend_unsupported tokens = %d, want 330", resp.BackendUnsupported.Tokens)
 	}
@@ -169,7 +169,7 @@ func TestRepoCostBackendUnsupportedCarriesNonClaude(t *testing.T) {
 // TestRepoCostNilNotZero: hard requirement #3. An untouched bucket reports null
 // so the UI renders "—", never "$0.00".
 func TestRepoCostNilNotZero(t *testing.T) {
-	resp := computeRepoCost(&tokens.AggregateSummary{}, nil, time.Now())
+	resp := ComputeRepoCost(&tokens.AggregateSummary{}, nil, time.Now())
 	if resp.Unattributed.USD != nil {
 		t.Fatalf("unattributed USD = %v, want nil (no cost attributed != $0.00)", *resp.Unattributed.USD)
 	}
@@ -177,7 +177,7 @@ func TestRepoCostNilNotZero(t *testing.T) {
 		t.Fatalf("backend_unsupported USD = %v, want nil", *resp.BackendUnsupported.USD)
 	}
 	// The mandatory buckets must still be PRESENT even when empty.
-	if resp.Unattributed.Repo != repoCostBucketUnattributed || resp.BackendUnsupported.Repo != repoCostBucketBackendUnsupported {
+	if resp.Unattributed.Repo != RepoCostBucketUnattributed || resp.BackendUnsupported.Repo != RepoCostBucketBackendUnsupported {
 		t.Fatalf("mandatory buckets missing: %+v %+v", resp.Unattributed, resp.BackendUnsupported)
 	}
 }
@@ -197,7 +197,7 @@ func TestRepoCostUnknownTimestampIsUnattributed(t *testing.T) {
 		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
 		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
 	}
-	resp := computeRepoCost(summary, entries, now)
+	resp := ComputeRepoCost(summary, entries, now)
 	if resp.Unattributed.Tokens != 500 {
 		t.Fatalf("unattributed = %d, want 500 (the zero-timestamp event)", resp.Unattributed.Tokens)
 	}
@@ -218,7 +218,7 @@ func TestRepoCostPerAgentIsolation(t *testing.T) {
 		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
 		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
 	}
-	resp := computeRepoCost(summary, entries, now)
+	resp := ComputeRepoCost(summary, entries, now)
 	if len(resp.ByRepo) != 0 {
 		t.Fatalf("another agent's events attributed these tokens: %+v", resp.ByRepo)
 	}
@@ -236,8 +236,8 @@ func TestRepoCostReportsWindow(t *testing.T) {
 		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
 		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
 	}
-	resp := computeRepoCost(&tokens.AggregateSummary{}, entries, now)
-	if resp.WindowHours != int(repoCostWindow/time.Hour) {
+	resp := ComputeRepoCost(&tokens.AggregateSummary{}, entries, now)
+	if resp.WindowHours != int(RepoCostWindow/time.Hour) {
 		t.Fatalf("WindowHours = %d", resp.WindowHours)
 	}
 	if resp.OldestEventAt != rcTime(base, 10).UTC().Format(time.RFC3339) {
@@ -268,7 +268,7 @@ func TestRepoCostEventsCountOnlyRealClosers(t *testing.T) {
 		rcEvent(rcTime(base, 30), "scanner", "org/repo-a"), // closes an EMPTY interval
 	}
 
-	resp := computeRepoCost(summary, entries, now)
+	resp := ComputeRepoCost(summary, entries, now)
 	a := findRepo(t, resp, "org/repo-a")
 	if a.Events != 1 {
 		t.Fatalf("Events = %d, want 1 (only the event that closed a non-empty interval)", a.Events)
@@ -292,7 +292,7 @@ func TestRepoCostTierPricingIsTagged(t *testing.T) {
 		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
 		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
 	}
-	resp := computeRepoCost(summary, entries, now)
+	resp := ComputeRepoCost(summary, entries, now)
 	if got := findRepo(t, resp, "org/repo-b").Source; got != "estimated_tier" {
 		t.Fatalf("Source = %q, want estimated_tier for an unpriced model", got)
 	}

--- a/src/pkg/dashboard/collect/timeseries.go
+++ b/src/pkg/dashboard/collect/timeseries.go
@@ -1,24 +1,24 @@
-package dashboard
+package collect
 
 import (
 	"sync"
 	"time"
 )
 
-// timeSeries is a generic, concurrency-safe ring buffer of timestamped entries.
+// TimeSeries is a generic, concurrency-safe ring buffer of timestamped entries.
 // It is the single mechanism behind every persisted sparkline history (token,
 // fact, cost, trend): a bounded, most-recent-tail buffer with an optional
 // minimum-interval throttle and copy-on-read semantics.
 //
 // It deliberately owns ONLY the storage mechanics (cap, throttle, mutex, copy).
 // Each concrete history keeps its own typed entry struct and its own JSON
-// contract, so migrating a bespoke buffer onto timeSeries is a behavior- and
+// contract, so migrating a bespoke buffer onto TimeSeries is a behavior- and
 // wire-preserving refactor: the on-disk files and /api/* endpoints are
 // unchanged.
 //
 // T is the entry type. tsOf extracts an entry's timestamp (unix millis) so the
 // buffer can enforce the min-interval throttle without T needing an interface.
-type timeSeries[T any] struct {
+type TimeSeries[T any] struct {
 	mu          sync.RWMutex
 	entries     []T
 	cap         int   // maximum retained entries (most-recent tail kept)
@@ -26,21 +26,21 @@ type timeSeries[T any] struct {
 	tsOf        func(T) int64
 }
 
-// newTimeSeries builds a ring buffer with the given cap and min-interval (ms;
+// NewTimeSeries builds a ring buffer with the given cap and min-interval (ms;
 // 0 disables the throttle). tsOf returns an entry's timestamp in unix millis.
-func newTimeSeries[T any](capacity int, minIntervalMs int64, tsOf func(T) int64) *timeSeries[T] {
-	return &timeSeries[T]{
+func NewTimeSeries[T any](capacity int, minIntervalMs int64, tsOf func(T) int64) *TimeSeries[T] {
+	return &TimeSeries[T]{
 		cap:         capacity,
 		minInterval: minIntervalMs,
 		tsOf:        tsOf,
 	}
 }
 
-// append adds entry unless the throttle suppresses it (the entry's timestamp is
+// Append adds entry unless the throttle suppresses it (the entry's timestamp is
 // less than minInterval after the last retained entry's). It reports whether the
 // entry was stored. Callers that need the current wall clock should stamp the
 // entry before calling; append uses tsOf(entry) for the throttle comparison.
-func (ts *timeSeries[T]) append(entry T) bool {
+func (ts *TimeSeries[T]) Append(entry T) bool {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 
@@ -58,9 +58,9 @@ func (ts *timeSeries[T]) append(entry T) bool {
 	return true
 }
 
-// snapshot returns a copy of the retained entries so callers can't mutate the
+// Snapshot returns a copy of the retained entries so callers can't mutate the
 // buffer's backing array.
-func (ts *timeSeries[T]) snapshot() []T {
+func (ts *TimeSeries[T]) Snapshot() []T {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 	out := make([]T, len(ts.entries))
@@ -68,9 +68,9 @@ func (ts *timeSeries[T]) snapshot() []T {
 	return out
 }
 
-// seed replaces the buffer contents (trimming to the most-recent cap tail),
+// Seed replaces the buffer contents (trimming to the most-recent cap tail),
 // used to restore persisted history on startup.
-func (ts *timeSeries[T]) seed(entries []T) {
+func (ts *TimeSeries[T]) Seed(entries []T) {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 	if ts.cap > 0 && len(entries) > ts.cap {
@@ -79,13 +79,13 @@ func (ts *timeSeries[T]) seed(entries []T) {
 	ts.entries = entries
 }
 
-// len reports the current number of retained entries.
-func (ts *timeSeries[T]) len() int {
+// Len reports the current number of retained entries.
+func (ts *TimeSeries[T]) Len() int {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 	return len(ts.entries)
 }
 
-// nowMillis is the wall clock used when stamping entries; a package var so
+// NowMillis is the wall clock used when stamping entries; a package var so
 // tests could override it if needed.
-func nowMillis() int64 { return time.Now().UnixMilli() }
+func NowMillis() int64 { return time.Now().UnixMilli() }

--- a/src/pkg/dashboard/collect/timeseries_test.go
+++ b/src/pkg/dashboard/collect/timeseries_test.go
@@ -1,6 +1,9 @@
-package dashboard
+package collect
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // tsEntry is a minimal entry type for exercising the generic timeSeries.
 type tsEntry struct {
@@ -12,20 +15,20 @@ func tsTsOf(e tsEntry) int64 { return e.T }
 
 // TestTimeSeriesAppendAndSnapshot verifies appends land and snapshot copies.
 func TestTimeSeriesAppendAndSnapshot(t *testing.T) {
-	ts := newTimeSeries(10, 0, tsTsOf)
-	if ts.len() != 0 {
-		t.Fatalf("fresh len = %d, want 0", ts.len())
+	ts := NewTimeSeries(10, 0, tsTsOf)
+	if ts.Len() != 0 {
+		t.Fatalf("fresh len = %d, want 0", ts.Len())
 	}
-	if !ts.append(tsEntry{T: 1, Val: 100}) {
+	if !ts.Append(tsEntry{T: 1, Val: 100}) {
 		t.Fatal("first append should store")
 	}
-	got := ts.snapshot()
+	got := ts.Snapshot()
 	if len(got) != 1 || got[0].Val != 100 {
 		t.Fatalf("snapshot = %+v, want one entry val=100", got)
 	}
 	// Mutating the returned copy must not leak into the buffer.
 	got[0].Val = 999
-	if again := ts.snapshot(); again[0].Val != 100 {
+	if again := ts.Snapshot(); again[0].Val != 100 {
 		t.Errorf("snapshot is not a copy: got %d", again[0].Val)
 	}
 }
@@ -34,49 +37,49 @@ func TestTimeSeriesAppendAndSnapshot(t *testing.T) {
 // second append and admits one past the interval.
 func TestTimeSeriesThrottle(t *testing.T) {
 	const interval = 300_000
-	ts := newTimeSeries(10, interval, tsTsOf)
+	ts := NewTimeSeries(10, interval, tsTsOf)
 
-	if !ts.append(tsEntry{T: 1000}) {
+	if !ts.Append(tsEntry{T: 1000}) {
 		t.Fatal("first append should store")
 	}
 	// Within the interval → suppressed.
-	if ts.append(tsEntry{T: 1000 + interval - 1}) {
+	if ts.Append(tsEntry{T: 1000 + interval - 1}) {
 		t.Error("append within interval should be suppressed")
 	}
-	if ts.len() != 1 {
-		t.Fatalf("len = %d, want 1 after throttled append", ts.len())
+	if ts.Len() != 1 {
+		t.Fatalf("len = %d, want 1 after throttled append", ts.Len())
 	}
 	// At/after the interval → admitted.
-	if !ts.append(tsEntry{T: 1000 + interval}) {
+	if !ts.Append(tsEntry{T: 1000 + interval}) {
 		t.Error("append at interval boundary should be admitted")
 	}
-	if ts.len() != 2 {
-		t.Fatalf("len = %d, want 2", ts.len())
+	if ts.Len() != 2 {
+		t.Fatalf("len = %d, want 2", ts.Len())
 	}
 }
 
 // TestTimeSeriesNoThrottle verifies a 0 interval admits every append (token
 // history behavior).
 func TestTimeSeriesNoThrottle(t *testing.T) {
-	ts := newTimeSeries(10, 0, tsTsOf)
+	ts := NewTimeSeries(10, 0, tsTsOf)
 	for i := 0; i < 5; i++ {
-		if !ts.append(tsEntry{T: int64(i)}) {
+		if !ts.Append(tsEntry{T: int64(i)}) {
 			t.Fatalf("append %d suppressed with no throttle", i)
 		}
 	}
-	if ts.len() != 5 {
-		t.Fatalf("len = %d, want 5", ts.len())
+	if ts.Len() != 5 {
+		t.Fatalf("len = %d, want 5", ts.Len())
 	}
 }
 
 // TestTimeSeriesCap verifies the ring buffer keeps only the most-recent tail.
 func TestTimeSeriesCap(t *testing.T) {
 	const capacity = 3
-	ts := newTimeSeries(capacity, 0, tsTsOf)
+	ts := NewTimeSeries(capacity, 0, tsTsOf)
 	for i := 0; i < 6; i++ {
-		ts.append(tsEntry{T: int64(i), Val: i})
+		ts.Append(tsEntry{T: int64(i), Val: i})
 	}
-	got := ts.snapshot()
+	got := ts.Snapshot()
 	if len(got) != capacity {
 		t.Fatalf("len = %d, want cap %d", len(got), capacity)
 	}
@@ -90,19 +93,31 @@ func TestTimeSeriesCap(t *testing.T) {
 // most-recent tail and preserves ordering.
 func TestTimeSeriesSeedTrimsToTail(t *testing.T) {
 	const capacity = 4
-	ts := newTimeSeries(capacity, 0, tsTsOf)
+	ts := NewTimeSeries(capacity, 0, tsTsOf)
 
 	over := make([]tsEntry, 10)
 	for i := range over {
 		over[i] = tsEntry{T: int64(i), Val: i}
 	}
-	ts.seed(over)
+	ts.Seed(over)
 
-	got := ts.snapshot()
+	got := ts.Snapshot()
 	if len(got) != capacity {
 		t.Fatalf("seeded len = %d, want cap %d", len(got), capacity)
 	}
 	if got[0].Val != 6 || got[len(got)-1].Val != 9 {
 		t.Errorf("kept tail = %d..%d, want 6..9", got[0].Val, got[len(got)-1].Val)
+	}
+}
+
+// NowMillis is the stamping clock for every history entry; pin it to the
+// wall clock's millisecond epoch so a drifting implementation cannot skew
+// throttle comparisons.
+func TestNowMillis(t *testing.T) {
+	before := time.Now().UnixMilli()
+	got := NowMillis()
+	after := time.Now().UnixMilli()
+	if got < before || got > after {
+		t.Fatalf("NowMillis() = %d, want within [%d, %d]", got, before, after)
 	}
 }

--- a/src/pkg/dashboard/cost.go
+++ b/src/pkg/dashboard/cost.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	"github.com/kubestellar/hive/pkg/tokens"
 )
 
@@ -147,9 +148,9 @@ type costSessionEntry struct {
 // default session ordering.
 const maxCostSessions = 200
 
-const costEstimateDisclaimer = "Estimated from token counts × published list prices. " +
-	"Subscription plans (Claude, Copilot), self-hosted inference (vLLM), and negotiated rates differ from list price. " +
-	"Not a bill."
+// costEstimateDisclaimer moved to pkg/dashboard/collect (the repo-cost join
+// stamps the identical sentence); aliased so every payload keeps one source.
+const costEstimateDisclaimer = collect.CostEstimateDisclaimer
 
 // handleCost serves GET /api/cost — the unified estimated + native cost view.
 func (s *Server) handleCost(w http.ResponseWriter, r *http.Request) {

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/beads"
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	ghpkg "github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/governor"
 	"github.com/kubestellar/hive/pkg/hooks"
@@ -51,13 +52,13 @@ type Dependencies struct {
 	// already uses keeps the advisor read-only and adds zero GitHub traffic.
 	// Nil is safe: Snapshot() on a nil collector reports ready=false and the
 	// advisor leaves the signal at its conservative zero.
-	FleetStats *FleetStatsCollector
-	Activity   *ActivityCollector
+	FleetStats *collect.FleetStatsCollector
+	Activity   *collect.ActivityCollector
 	// RepoCost caches the /api/repo-cost interval join on a ticker (see
 	// repo_cost_collector.go), mirroring Activity's caching of
 	// /api/repo-activity. Nil is safe: handleRepoCost falls back to computing
 	// inline (used by tests that construct a bare Dependencies).
-	RepoCost        *RepoCostCollector
+	RepoCost        *collect.RepoCostCollector
 	BeadSynthesizer *knowledge.BeadSynthesizer
 	BeadStores      map[string]*beads.Store
 	// BeadStoreLoadFailures counts configured bead stores that failed to open at

--- a/src/pkg/dashboard/repo_cost_collector_test.go
+++ b/src/pkg/dashboard/repo_cost_collector_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -10,8 +11,43 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
+	ghpkg "github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/tokens"
 )
+
+// rcTime/rcEvent/rcUsage/rcSession mirror the fixture helpers that moved to
+// pkg/dashboard/collect with the pure join tests; the handler tests here need
+// the same shapes.
+
+func rcTime(base time.Time, min int) time.Time { return base.Add(time.Duration(min) * time.Minute) }
+
+func rcEvent(ts time.Time, agent, repo string) AuditEntry {
+	return AuditEntry{
+		Timestamp: ts.UTC().Format(time.RFC3339),
+		Action:    ghpkg.AuditActionAgentPRCreated,
+		Agent:     agent,
+		Detail:    "agent=" + agent + ", repo=" + repo + ", number=1",
+	}
+}
+
+func rcUsage(ts time.Time, in, out int64) tokens.UsageEvent {
+	return tokens.UsageEvent{TimestampMs: ts.UnixMilli(), Model: "claude-opus-4-1", Coalesced: 1, Input: in, Output: out}
+}
+
+// rcSession builds a Claude session whose summed fields agree with its timeline,
+// exactly as the phase-2 scanner produces.
+func rcSession(id, agent string, usage ...tokens.UsageEvent) tokens.SessionSummary {
+	s := tokens.SessionSummary{SessionID: id, Agent: agent, Model: "claude-opus-4-1", Backend: tokens.BackendClaude, Usage: usage}
+	for _, u := range usage {
+		s.InputTokens += u.Input
+		s.OutputTokens += u.Output
+		s.CacheRead += u.CacheRead
+		s.CacheCreate += u.CacheCreate
+	}
+	s.TotalTokens = s.InputTokens + s.OutputTokens + s.CacheRead + s.CacheCreate
+	return s
+}
 
 // countingAuditReader wraps a real audit fixture and counts how many times
 // OutputActionsSince was called, so a test can assert the served endpoint did
@@ -21,7 +57,7 @@ import (
 // path produces an identical-looking payload; only a call-count assertion
 // proves the cache is doing anything.
 type countingAuditReader struct {
-	inner auditReader
+	inner collect.AuditReader
 	calls int32
 }
 
@@ -60,9 +96,8 @@ func newRepoCostFixtureServer(t *testing.T) (*Server, *countingAuditReader) {
 	inner := &fakeFixedAudit{entries: entries}
 	counting := &countingAuditReader{inner: inner}
 
-	rc := NewRepoCostCollector(counting, &fakeTokensSummary{summary: summary}, "", nil)
-	rc.nowFn = func() time.Time { return now }
-	rc.collect()
+	rc := collect.NewRepoCostCollector(counting, &fakeTokensSummary{summary: summary}, "", nil)
+	runOneCollect(rc)
 
 	s := NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	s.RegisterAPI(&Dependencies{RepoCost: rc})
@@ -76,6 +111,18 @@ type fakeFixedAudit struct{ entries []AuditEntry }
 
 func (f *fakeFixedAudit) OutputActionsSince(_ time.Time, _ map[string]bool, _ string) []AuditEntry {
 	return f.entries
+}
+
+// runOneCollect performs exactly one collect on the collector by starting it
+// with an already-cancelled context: Start's contract is one up-front collect
+// before entering the ticker loop, and the cancelled context makes the loop
+// exit before any tick. The collector's clock is its own (time.Now); the
+// fixtures place events within the join window relative to now, so the served
+// snapshot is identical in shape to the pre-move inline computation.
+func runOneCollect(rc *collect.RepoCostCollector) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rc.Start(ctx)
 }
 
 func getRepoCost(s *Server) *httptest.ResponseRecorder {
@@ -109,7 +156,7 @@ func TestHandleRepoCostServesCachedSnapshotWithoutReReading(t *testing.T) {
 		t.Fatalf("handleRepoCost must serve the cached snapshot, not re-read: calls went from %d to %d across 2 requests", before, after)
 	}
 
-	var body1, body2 repoCostResponse
+	var body1, body2 collect.RepoCostResponse
 	if err := json.Unmarshal(rec1.Body.Bytes(), &body1); err != nil {
 		t.Fatalf("invalid JSON (req 1): %v", err)
 	}
@@ -129,7 +176,7 @@ func TestHandleRepoCostServesCachedSnapshotWithoutReReading(t *testing.T) {
 // with an empty by_repo and no fabricated total — never a $0.00 that reads
 // identically to "this hive spent nothing".
 func TestHandleRepoCostNotReadyBeforeFirstCollect(t *testing.T) {
-	rc := NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
+	rc := collect.NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
 	// Deliberately do NOT call collect(): simulates the window between
 	// process start and the collector's first ticker fire.
 
@@ -140,7 +187,7 @@ func TestHandleRepoCostNotReadyBeforeFirstCollect(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
 	}
-	var body repoCostResponse
+	var body collect.RepoCostResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
@@ -192,9 +239,8 @@ func TestRepoCostPartitionInvariantServedPath(t *testing.T) {
 		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
 	}
 
-	rc := NewRepoCostCollector(&fakeFixedAudit{entries: entries}, &fakeTokensSummary{summary: summary}, "", nil)
-	rc.nowFn = func() time.Time { return now }
-	rc.collect()
+	rc := collect.NewRepoCostCollector(&fakeFixedAudit{entries: entries}, &fakeTokensSummary{summary: summary}, "", nil)
+	runOneCollect(rc)
 
 	s := NewServer(0, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	s.RegisterAPI(&Dependencies{RepoCost: rc})
@@ -203,7 +249,7 @@ func TestRepoCostPartitionInvariantServedPath(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
 	}
-	var body repoCostResponse
+	var body collect.RepoCostResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
@@ -220,34 +266,5 @@ func TestRepoCostPartitionInvariantServedPath(t *testing.T) {
 	}
 	if body.TotalTokens != hiveTotal {
 		t.Fatalf("served TotalTokens = %d, want %d", body.TotalTokens, hiveTotal)
-	}
-}
-
-// TestRepoCostCollectorPersistsAcrossRestart mirrors ActivityCollector's
-// EnablePersistence contract: a fresh collector pointed at a prior snapshot
-// file must report ready=true immediately, with the ORIGINAL CollectedAt
-// preserved, before its own first ticker fire — so a restart does not present
-// a stale-but-labeled-fresh figure, and does not regress to not-ready either.
-func TestRepoCostCollectorPersistsAcrossRestart(t *testing.T) {
-	dir := t.TempDir()
-	path := dir + "/repo-cost.json"
-
-	original := NewRepoCostCollector(&fakeFixedAudit{entries: []AuditEntry{
-		rcEvent(time.Now().Add(-time.Hour), "scanner", "org/repo-a"),
-	}}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
-	fixedNow := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Second)
-	original.nowFn = func() time.Time { return fixedNow }
-	original.EnablePersistence(path)
-	original.collect()
-
-	restarted := NewRepoCostCollector(&fakeFixedAudit{}, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
-	restarted.EnablePersistence(path)
-
-	snap, ready := restarted.Snapshot()
-	if !ready {
-		t.Fatal("restored collector must report ready=true without waiting for its own first collect")
-	}
-	if !snap.CollectedAt.Equal(fixedNow) {
-		t.Fatalf("restored CollectedAt = %v, want %v (the ORIGINAL collection time, not now)", snap.CollectedAt, fixedNow)
 	}
 }

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubestellar/hive/pkg/acmmadvisor"
 	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/dashboard/collect"
 	"github.com/kubestellar/hive/pkg/dashboard/webstatic"
 	"github.com/kubestellar/hive/pkg/github"
 	"github.com/kubestellar/hive/pkg/hub"
@@ -119,13 +120,13 @@ type Server struct {
 	// change. Each keeps its own typed entry struct and JSON contract, so the
 	// unification is internal — on-disk files and /api/* endpoints are unchanged.
 	histOnce  sync.Once
-	tokenHist *timeSeries[TokenSparklineEntry]
-	factHist  *timeSeries[FactHistoryEntry]
-	costHist  *timeSeries[CostHistoryEntry]
+	tokenHist *collect.TimeSeries[TokenSparklineEntry]
+	factHist  *collect.TimeSeries[FactHistoryEntry]
+	costHist  *collect.TimeSeries[CostHistoryEntry]
 	// budgetWindowHist records one row per CLOSED budget window (#4298). Lazily
 	// built like the sparkline rings so a zero-value Server works in tests.
 	budgetWindowOnce sync.Once
-	budgetWindowHist *budgetWindowTracker
+	budgetWindowHist *collect.BudgetWindowTracker
 
 	// convergenceModeTrk captures one (mode, generation) pair per enrolled
 	// eval pass and detects transitions (#4263). convergenceSoakTrk records the
@@ -2564,26 +2565,26 @@ func (s *Server) broadcastFrame(frame string) {
 // on-disk shape are preserved.
 func (s *Server) initHistories() {
 	s.histOnce.Do(func() {
-		s.tokenHist = newTimeSeries(tokenSparklineMaxEntries, 0,
+		s.tokenHist = collect.NewTimeSeries(tokenSparklineMaxEntries, 0,
 			func(e TokenSparklineEntry) int64 { return e.Timestamp })
-		s.factHist = newTimeSeries(factHistoryMaxEntries, factHistoryMinIntervalMs,
+		s.factHist = collect.NewTimeSeries(factHistoryMaxEntries, factHistoryMinIntervalMs,
 			func(e FactHistoryEntry) int64 { return e.Timestamp })
-		s.costHist = newTimeSeries(costHistoryMaxEntries, costHistoryMinIntervalMs,
+		s.costHist = collect.NewTimeSeries(costHistoryMaxEntries, costHistoryMinIntervalMs,
 			func(e CostHistoryEntry) int64 { return e.Timestamp })
 	})
 }
 
-func (s *Server) tokenSeries() *timeSeries[TokenSparklineEntry] {
+func (s *Server) tokenSeries() *collect.TimeSeries[TokenSparklineEntry] {
 	s.initHistories()
 	return s.tokenHist
 }
 
-func (s *Server) factSeries() *timeSeries[FactHistoryEntry] {
+func (s *Server) factSeries() *collect.TimeSeries[FactHistoryEntry] {
 	s.initHistories()
 	return s.factHist
 }
 
-func (s *Server) costSeries() *timeSeries[CostHistoryEntry] {
+func (s *Server) costSeries() *collect.TimeSeries[CostHistoryEntry] {
 	s.initHistories()
 	return s.costHist
 }
@@ -2596,7 +2597,7 @@ func (s *Server) AppendTokenSparkline(status *StatusPayload) {
 	}
 
 	entry := TokenSparklineEntry{
-		Timestamp:   nowMillis(),
+		Timestamp:   collect.NowMillis(),
 		Input:       status.Tokens.Totals.Input,
 		Output:      status.Tokens.Totals.Output,
 		CacheRead:   status.Tokens.Totals.CacheRead,
@@ -2613,35 +2614,35 @@ func (s *Server) AppendTokenSparkline(status *StatusPayload) {
 		entry.ByModel[name] = bucket.Input + bucket.Output + bucket.CacheRead
 	}
 
-	s.tokenSeries().append(entry)
+	s.tokenSeries().Append(entry)
 }
 
 // TokenSparklineHistory returns a copy of the current token sparkline history.
 func (s *Server) TokenSparklineHistory() []TokenSparklineEntry {
-	return s.tokenSeries().snapshot()
+	return s.tokenSeries().Snapshot()
 }
 
 // SeedTokenSparklineHistory restores persisted token history on startup.
 func (s *Server) SeedTokenSparklineHistory(entries []TokenSparklineEntry) {
-	s.tokenSeries().seed(entries)
+	s.tokenSeries().Seed(entries)
 }
 
 // AppendFactHistory records a total-facts count if enough time has passed.
 func (s *Server) AppendFactHistory(count int) {
-	s.factSeries().append(FactHistoryEntry{
-		Timestamp: nowMillis(),
+	s.factSeries().Append(FactHistoryEntry{
+		Timestamp: collect.NowMillis(),
 		Count:     count,
 	})
 }
 
 // FactHistory returns a copy of the fact count history.
 func (s *Server) FactHistory() []FactHistoryEntry {
-	return s.factSeries().snapshot()
+	return s.factSeries().Snapshot()
 }
 
 // SeedFactHistory restores persisted fact history on startup.
 func (s *Server) SeedFactHistory(entries []FactHistoryEntry) {
-	s.factSeries().seed(entries)
+	s.factSeries().Seed(entries)
 }
 
 // AppendCostHistory records an estimated-cost ($) snapshot if enough time has
@@ -2661,7 +2662,7 @@ func (s *Server) AppendCostHistory(usd float64, agents ...map[string]float64) {
 // that feeds the cost table's mini sparklines.
 func (s *Server) AppendCostHistoryFull(usd float64, agents map[string]float64, models map[string]CostModelSnap) {
 	entry := CostHistoryEntry{
-		Timestamp: nowMillis(),
+		Timestamp: collect.NowMillis(),
 		USD:       usd,
 	}
 	if len(agents) > 0 {
@@ -2670,17 +2671,17 @@ func (s *Server) AppendCostHistoryFull(usd float64, agents map[string]float64, m
 	if len(models) > 0 {
 		entry.Models = models
 	}
-	s.costSeries().append(entry)
+	s.costSeries().Append(entry)
 }
 
 // CostHistory returns a copy of the estimated-cost history.
 func (s *Server) CostHistory() []CostHistoryEntry {
-	return s.costSeries().snapshot()
+	return s.costSeries().Snapshot()
 }
 
 // SeedCostHistory restores persisted cost history on startup.
 func (s *Server) SeedCostHistory(entries []CostHistoryEntry) {
-	s.costSeries().seed(entries)
+	s.costSeries().Seed(entries)
 }
 
 // AppendTrendHistory samples the governor / per-repo / beads / system-gauge

--- a/src/pkg/dashboard/zero_cov_lifecycle_test.go
+++ b/src/pkg/dashboard/zero_cov_lifecycle_test.go
@@ -11,13 +11,13 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/pkg/linearagent"
-	"github.com/kubestellar/hive/pkg/tokens"
 )
 
 // Covers previously 0%-covered exported funcs in pkg/dashboard:
 // SetReleaseChannel (api.go), LinearAgentPROpened (api_linear_agent.go),
-// Server.sampleMetricsInputs + StartContributeMetrics (contribute_metrics.go),
-// and RepoCostCollector.Start + CollectedAt (repo_cost_collector.go).
+// Server.sampleMetricsInputs + StartContributeMetrics (contribute_metrics.go).
+// The RepoCostCollector.Start/CollectedAt tests moved to
+// pkg/dashboard/collect with the collector (kubestellar/hive#5565 slice 2).
 
 // ---- SetReleaseChannel ----
 
@@ -191,78 +191,5 @@ func TestStartContributeMetrics_RollsUpAndStopsOnCancel(t *testing.T) {
 	store.mu.Unlock()
 	if final != after {
 		t.Errorf("rollup kept running after ctx cancel: buckets %d -> %d", after, final)
-	}
-}
-
-// ---- RepoCostCollector.Start / CollectedAt ----
-
-// TestRepoCostCollector_StartCollectsAndStops asserts Start performs the
-// up-front collect (Snapshot ready, CollectedAt set), keeps collecting on the
-// ticker, and exits on ctx cancel.
-func TestRepoCostCollector_StartCollectsAndStops(t *testing.T) {
-	origInterval := repoCostCollectInterval
-	repoCostCollectInterval = 5 * time.Millisecond
-	t.Cleanup(func() { repoCostCollectInterval = origInterval })
-
-	audit := &fakeFixedAudit{}
-	rc := NewRepoCostCollector(audit, &fakeTokensSummary{summary: &tokens.AggregateSummary{}}, "", nil)
-
-	if !rc.CollectedAt().IsZero() {
-		t.Fatalf("CollectedAt = %v before any collect, want zero", rc.CollectedAt())
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
-	go func() {
-		rc.Start(ctx)
-		close(done)
-	}()
-
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if _, ready := rc.Snapshot(); ready {
-			break
-		}
-		if time.Now().After(deadline) {
-			cancel()
-			t.Fatal("Start never produced a ready snapshot")
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	if rc.CollectedAt().IsZero() {
-		t.Error("CollectedAt still zero after a successful collect")
-	}
-
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Start did not return after ctx cancel — goroutine leak")
-	}
-}
-
-// TestRepoCostCollector_StartInertWithoutInputs asserts the documented inert
-// contract: Start returns immediately (rather than spinning a ticker) when
-// either side of the audit/tokens join is missing, and on a nil receiver.
-func TestRepoCostCollector_StartInertWithoutInputs(t *testing.T) {
-	cases := map[string]*RepoCostCollector{
-		"nil collector": nil,
-		"nil audit":     NewRepoCostCollector(nil, &fakeTokensSummary{}, "", nil),
-		"nil tokens":    NewRepoCostCollector(&fakeFixedAudit{}, nil, "", nil),
-	}
-	for name, rc := range cases {
-		done := make(chan struct{})
-		go func() {
-			rc.Start(context.Background())
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(2 * time.Second):
-			t.Fatalf("%s: Start must return immediately when inert", name)
-		}
-		if !rc.CollectedAt().IsZero() {
-			t.Errorf("%s: CollectedAt = %v, want zero (no collect must have run)", name, rc.CollectedAt())
-		}
 	}
 }


### PR DESCRIPTION
Slice 2 of the pkg/dashboard decomposition (RFC on the issue; slice 1 = #5595, merged).

## What moves

`pkg/dashboard/collect` now owns the producer-side collectors — the cache/aggregation types referenced from `Dependencies` fields:

| from pkg/dashboard | to pkg/dashboard/collect |
|---|---|
| `activity_collector.go` | `activity_collector.go` — `ActivityCollector`, `ActivitySnapshot`, `AuditEntry`, `AuditReader` |
| `repo_cost.go` | `repo_cost.go` — the interval join (`ComputeRepoCost`, `RepoCostResponse`) |
| `repo_cost_collector.go` | `repo_cost_collector.go` — `RepoCostCollector` |
| `fleet_stats_collector.go` | `fleet_stats_collector.go` — `FleetStatsCollector` |
| `timeseries.go` | `timeseries.go` — the generic `TimeSeries` ring buffer |
| `budget_history.go` | `budget_window.go` — `BudgetWindowTracker`, `BudgetWindowEntry` |

Pure moves (git tracks them as renames) with export renames only; zero behavior change — no endpoint payload, on-disk sidecar, or wire shape changes.

## What stays

The HTTP surface remains in pkg/dashboard: `handleRepoActivity` / `handleRepoCost` (new `api_repo_activity.go` / `api_repo_cost.go`) and the `Server` budget-window accessors (slimmed `budget_history.go`). `AuditLog` (the write side) stays put; `AuditEntry` moves with its consumers and is aliased back (`type AuditEntry = collect.AuditEntry`), so the JSON contract is byte-identical.

`Dependencies.FleetStats/Activity/RepoCost` become `collect.*`, wired in `cmd/hive` exactly as before — same injection style, same construction site.

collect imports only leaf vocabulary (`pkg/github`, `pkg/tokens`), never `pkg/dashboard`: the import arrow points strictly inward. As the RFC notes, leaf extraction does not reduce the 33-import count by itself; the counter starts moving at slice 3.

## Coverage (the #5595 lesson, applied up front)

Tests moved with the code. The new package measures **92.0%** in its own coverprofile: collector lifecycles (Start/tick/cancel, persistence round-trips, corrupt-sidecar restores), the join invariants (partition, leading-interval, per-agent isolation, tier tagging), the ring buffer, and tracker-level ports of the budget-window scenarios. Served-path tests stay in pkg/dashboard and drive the collectors through public API only.

`go build ./pkg/... ./cmd/...`, `go vet` clean; `pkg/dashboard`, `pkg/dashboard/collect`, `cmd/hive` suites all green.

Refs #5565