### PR TITLE
fix(agent): pin Claude Remote Control off at every launch

### DIFF
--- a/src/pkg/agent/claude_remote_control.go
+++ b/src/pkg/agent/claude_remote_control.go
@@ -1,0 +1,148 @@
+package agent
+
+// Remote Control startup pin (#5607).
+//
+// Claude Code's Remote Control bridge publishes a local session to
+// claude.ai/code so it can be driven from a browser or the phone app. Since
+// CLI ~2.1.226 the bridge AUTO-STARTS unless an explicit
+// "remoteControlAtStartup" value exists: the resolution order is
+// policySettings > flagSettings > userSettings, and when the key is absent
+// everywhere the CLI falls through to a server-side rollout flag
+// (tengu_cobalt_harbor via GrowthBook) — i.e. the default can flip between two
+// container restarts with no local change at all, and can differ per agent
+// within one fleet (percentage rollout).
+//
+// On a hive that is much worse than on a laptop: the per-agent HOME layout
+// bridges every agent's ~/.claude to the SHARED /data/home/.claude so one
+// login authenticates the fleet, which means every agent registers as a
+// remote-controllable session under the same claude.ai account — and those
+// sessions were launched with --dangerously-skip-permissions. The in-pane
+// /remote-control toggle is session-scoped and writes nothing, so every
+// relaunch (kick, restart, watchdog recovery) re-consults the rollout default
+// and the bridge comes back.
+//
+// The durable OFF is therefore hive's to write, and it is re-asserted on
+// EVERY claude-CLI launch (mirroring ensureBobAuthSettings): seed
+// "remoteControlAtStartup": false into the shared user settings file when the
+// key is absent. The merge is add-if-missing only — an operator who genuinely
+// wants Remote Control sets the key to true in the same file and hive never
+// clobbers it (that explicit value also beats the rollout default in the CLI
+// itself). Inference agents get the identical key via inferenceSettingsSeed,
+// which lands in both their per-agent userSettings and the --settings
+// flagSettings file.
+//
+// There is no environment variable for this in the CLI — the settings key is
+// the only local lever below managed org policy (verified against the shipped
+// bundles of 2.1.226 and 2.1.236 in #5607).
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// remoteControlSettingKey is the Claude Code settings key that controls
+// whether the Remote Control bridge starts with the session. Honored from
+// user settings; an absent key delegates the decision to a server-side
+// rollout, which is exactly what this pin exists to prevent.
+const remoteControlSettingKey = "remoteControlAtStartup"
+
+// remoteControlUsedKey is the ~/.claude.json marker the CLI persists once the
+// bridge has actually run in a session (observed as hasUsedRemoteControl: true
+// on the #5607 fleet). Read-only here: it is the launch-time evidence that the
+// bridge came up despite (or before) the pin.
+const remoteControlUsedKey = "hasUsedRemoteControl"
+
+// claudeRemoteControlSeed returns the key hive pins into the shared Claude
+// user settings for interactive claude-backend agents. Kept minimal on
+// purpose: the shared /data/home/.claude/settings.json also carries
+// fleet-critical keys hive does not own (skipDangerousModePermissionPrompt,
+// enabledPlugins, ...), and the seed must never be a reason to touch them.
+func claudeRemoteControlSeed() map[string]any {
+	return map[string]any{remoteControlSettingKey: false}
+}
+
+// sharedClaudeSettingsFile is the userSettings file every interactive
+// claude-backend agent reads: the per-agent homes symlink ~/.claude to
+// sharedAgentHome/.claude (interactiveHomeBridgeDirs), so one file governs
+// the whole fleet.
+func sharedClaudeSettingsFile() string {
+	return filepath.Join(sharedAgentHome, ".claude", "settings.json")
+}
+
+// ensureClaudeRemoteControlDefault re-asserts, before a claude-backend launch,
+// that Remote Control does not auto-start for the fleet. Called on EVERY
+// launch so a relaunch can never fall back to the server-side rollout default,
+// and so an out-of-band deletion of the key self-heals on the next launch —
+// the same posture as ensureBobAuthSettings for bob's shared settings.
+//
+// Semantics:
+//   - key absent  -> written as false (the pin; this is the whole fix)
+//   - key present -> left untouched, true OR false (operator intent wins);
+//     an explicit true is logged as a receipt so an enabled bridge is always
+//     explainable from the hive log
+//   - unparseable file -> rewritten from the seed alone (seedJSONFile
+//     semantics; the CLI could not read the old keys either)
+//
+// Errors are logged and swallowed: a settings file hive cannot write is not a
+// reason to refuse a launch that may still succeed.
+func (m *Manager) ensureClaudeRemoteControlDefault(agent *AgentProcess) {
+	path := sharedClaudeSettingsFile()
+	// The entrypoint pre-creates /data/home/.claude (it holds the shared OAuth
+	// credential) before the hive starts. If it is missing there is no login
+	// and therefore no bridge entitlement either, so skip rather than invent a
+	// directory whose modes the entrypoint owns.
+	if _, err := os.Lstat(filepath.Dir(path)); err != nil {
+		m.logger.Debug("shared claude settings dir absent; skipping remote-control pin",
+			"agent", agent.Name, "dir", filepath.Dir(path), "error", err)
+		return
+	}
+	m.seedJSONFile(agent.Name, path, claudeRemoteControlSeed())
+	if enabled, explicit := readRemoteControlSetting(path); explicit && enabled {
+		// Receipt, not an error: the operator opted in and hive honored it.
+		m.logger.Info("claude remote control left ON by explicit operator setting",
+			"agent", agent.Name, "path", path, "key", remoteControlSettingKey)
+	}
+	home := AgentHome(agent.Name, agent.UID, "claude")
+	if m.remoteControlBridgeUsed(home) {
+		m.logger.Warn("claude remote control bridge has run for this agent despite the startup pin — history predating the pin, an explicit operator opt-in, or the pin not being honored",
+			"agent", agent.Name, "session_file", claudeSessionFile(home),
+			"marker", remoteControlUsedKey)
+	}
+}
+
+// readRemoteControlSetting reports the value of remoteControlAtStartup in the
+// settings file at path and whether it is explicitly present as a bool.
+func readRemoteControlSetting(path string) (value, explicit bool) {
+	data, err := readInferenceConfigFile(path)
+	if err != nil {
+		return false, false
+	}
+	settings := map[string]any{}
+	if json.Unmarshal(data, &settings) != nil {
+		return false, false
+	}
+	v, ok := settings[remoteControlSettingKey].(bool)
+	return v, ok
+}
+
+// remoteControlBridgeUsed reports whether the agent's Claude session file
+// records the Remote Control bridge having actually run. Best-effort and
+// read-only: on privileged deployments the per-agent 0600 session file is
+// readable by the hive; where it is not, the check silently reports false
+// rather than blocking anything.
+func (m *Manager) remoteControlBridgeUsed(home string) bool {
+	if home == "" {
+		return false
+	}
+	data, err := readInferenceConfigFile(claudeSessionFile(home))
+	if err != nil {
+		return false
+	}
+	session := map[string]any{}
+	if json.Unmarshal(data, &session) != nil {
+		return false
+	}
+	used, _ := session[remoteControlUsedKey].(bool)
+	return used
+}

--- a/src/pkg/agent/claude_remote_control_test.go
+++ b/src/pkg/agent/claude_remote_control_test.go
@@ -1,0 +1,168 @@
+package agent
+
+// Remote Control startup pin (#5607) — property tests.
+//
+// The invariant under test: every Claude-CLI launch surface hive provisions
+// carries an EXPLICIT "remoteControlAtStartup": false, because an absent key
+// delegates the decision to a server-side rollout that flipped to auto-ON.
+// Presence of the key is the security property; merge-only semantics (an
+// operator's explicit true survives) is the escape hatch.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+)
+
+func readSettingsMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	parsed := map[string]any{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON in %s: %v", path, err)
+	}
+	return parsed
+}
+
+func assertRemoteControlOff(t *testing.T, path string) {
+	t.Helper()
+	parsed := readSettingsMap(t, path)
+	v, ok := parsed[remoteControlSettingKey]
+	if !ok {
+		t.Fatalf("%s: %s key ABSENT — an absent key delegates to the server-side rollout default, which is the #5607 exposure", path, remoteControlSettingKey)
+	}
+	if v != false {
+		t.Fatalf("%s: %s = %v, want false", path, remoteControlSettingKey, v)
+	}
+}
+
+// --- inference seed ----------------------------------------------------------
+
+func TestInferenceSettingsSeed_PinsRemoteControlOff(t *testing.T) {
+	seed := inferenceSettingsSeed()
+	v, ok := seed[remoteControlSettingKey]
+	if !ok {
+		t.Fatalf("inferenceSettingsSeed missing %s — inference launches would fall back to the server-side rollout default", remoteControlSettingKey)
+	}
+	if v != false {
+		t.Fatalf("inferenceSettingsSeed[%s] = %v, want false", remoteControlSettingKey, v)
+	}
+}
+
+func TestEnsureClaudeSettings_PinsRemoteControlOff(t *testing.T) {
+	orig := inferenceHomePrefixOverride
+	inferenceHomePrefixOverride = filepath.Join(t.TempDir(), "inference-home") + "-"
+	t.Cleanup(func() { inferenceHomePrefixOverride = orig })
+	os.Remove(claudeInferenceSettingsPath)
+
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	m.ensureClaudeSettings("rc-pin", 0)
+
+	// Both settings surfaces the CLI reads for an inference agent:
+	// userSettings in the per-agent HOME and the --settings flagSettings file.
+	assertRemoteControlOff(t, filepath.Join(inferenceHomePath("rc-pin"), ".claude", "settings.json"))
+	assertRemoteControlOff(t, claudeInferenceSettingsPath)
+}
+
+// --- shared interactive settings --------------------------------------------
+
+// withSharedClaudeDir provisions the shared home and its .claude dir (the
+// entrypoint's job in production) and returns the settings path.
+func withSharedClaudeDir(t *testing.T) string {
+	t.Helper()
+	shared := withSharedAgentHome(t)
+	if err := os.MkdirAll(filepath.Join(shared, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return sharedClaudeSettingsFile()
+}
+
+func rcTestAgent() *AgentProcess {
+	return &AgentProcess{Name: "scanner", UID: 1001}
+}
+
+func TestEnsureClaudeRemoteControlDefault_SeedsFalse(t *testing.T) {
+	path := withSharedClaudeDir(t)
+	m := quietManager()
+
+	m.ensureClaudeRemoteControlDefault(rcTestAgent())
+	assertRemoteControlOff(t, path)
+
+	// Idempotent: a second launch leaves the pin in place unchanged.
+	m.ensureClaudeRemoteControlDefault(rcTestAgent())
+	assertRemoteControlOff(t, path)
+}
+
+func TestEnsureClaudeRemoteControlDefault_PreservesOperatorTrue(t *testing.T) {
+	path := withSharedClaudeDir(t)
+	if err := os.WriteFile(path, []byte(`{"remoteControlAtStartup":true,"theme":"dark"}`), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	quietManager().ensureClaudeRemoteControlDefault(rcTestAgent())
+
+	parsed := readSettingsMap(t, path)
+	if parsed[remoteControlSettingKey] != true {
+		t.Fatalf("explicit operator opt-in was clobbered: %s = %v, want true", remoteControlSettingKey, parsed[remoteControlSettingKey])
+	}
+	if parsed["theme"] != "dark" {
+		t.Fatalf("sibling key clobbered: theme = %v", parsed["theme"])
+	}
+}
+
+func TestEnsureClaudeRemoteControlDefault_PreservesFleetKeys(t *testing.T) {
+	// The shared file carries keys hive does not own and the fleet cannot run
+	// without (the bypass-permissions consent suppressor above all). The pin
+	// must be add-only.
+	path := withSharedClaudeDir(t)
+	existing := `{"skipDangerousModePermissionPrompt":true,"bypassPermissions":true,"hasCompletedOnboarding":true}`
+	if err := os.WriteFile(path, []byte(existing), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	quietManager().ensureClaudeRemoteControlDefault(rcTestAgent())
+
+	parsed := readSettingsMap(t, path)
+	assertRemoteControlOff(t, path)
+	for _, key := range []string{"skipDangerousModePermissionPrompt", "bypassPermissions", "hasCompletedOnboarding"} {
+		if parsed[key] != true {
+			t.Fatalf("fleet key %s = %v after pin, want true", key, parsed[key])
+		}
+	}
+}
+
+func TestEnsureClaudeRemoteControlDefault_SkipsWhenClaudeDirAbsent(t *testing.T) {
+	shared := withSharedAgentHome(t) // no .claude dir: entrypoint owns creating it
+	quietManager().ensureClaudeRemoteControlDefault(rcTestAgent())
+	if _, err := os.Lstat(filepath.Join(shared, ".claude")); !os.IsNotExist(err) {
+		t.Fatalf(".claude dir should not be invented by the pin (err=%v)", err)
+	}
+}
+
+// --- runtime evidence check --------------------------------------------------
+
+func TestRemoteControlBridgeUsed(t *testing.T) {
+	withSharedAgentHome(t)
+	m := quietManager()
+
+	home := interactiveHomePath("scanner")
+	if m.remoteControlBridgeUsed(home) {
+		t.Fatal("missing session file should report bridge unused")
+	}
+
+	writeSession(t, home, `{"hasCompletedOnboarding":true}`)
+	if m.remoteControlBridgeUsed(home) {
+		t.Fatal("session without the marker should report bridge unused")
+	}
+
+	writeSession(t, home, `{"hasCompletedOnboarding":true,"hasUsedRemoteControl":true}`)
+	if !m.remoteControlBridgeUsed(home) {
+		t.Fatal("session with hasUsedRemoteControl:true should report bridge used — this is the launch-time evidence log for #5607")
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -2568,6 +2568,17 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		m.clearInferenceRouteCallback(agent.Name)
 	}
 
+	// #5607: every claude-CLI launch re-asserts that the Remote Control bridge
+	// (session publishing to claude.ai/code) does not auto-start. Inference
+	// agents already got the pin via inferenceSettingsSeed in
+	// ensureClaudeSettings above; this covers the plain claude backend, whose
+	// userSettings is the SHARED /data/home/.claude/settings.json that hive
+	// never otherwise writes — the exact gap that let a CLI-side rollout
+	// default expose the whole fleet under one claude.ai account.
+	if backend == "claude" && !isInference {
+		m.ensureClaudeRemoteControlDefault(agent)
+	}
+
 	if agent.Config.CavemanMode != "" {
 		m.installCavemanForAgent(agent, backend)
 	}
@@ -7708,6 +7719,12 @@ func inferenceUserConfigSeed(agentName string) map[string]any {
 // this key every --dangerously-skip-permissions launch shows a consent menu
 // whose default selection is "No, exit" — if dismissal loses the race, the
 // CLI exits and the pane degrades to bare bash.
+// "remoteControlAtStartup" is pinned false because an ABSENT key delegates
+// the decision to a server-side rollout that flipped to auto-ON (#5607, CLI
+// 2.1.226+). Seeding it into both the userSettings and the --settings
+// flagSettings file keeps the Remote Control bridge off at every relaunch;
+// the merge-only repair in seedJSONFile preserves an operator's explicit
+// true. See claude_remote_control.go for the full mechanism.
 func inferenceSettingsSeed() map[string]any {
 	return map[string]any{
 		"permissions":                       map[string]any{"allow": []any{}, "deny": []any{}},
@@ -7715,6 +7732,7 @@ func inferenceSettingsSeed() map[string]any {
 		"bypassPermissions":                 true,
 		"hasAcknowledgedDisclaimer":         true,
 		"skipDangerousModePermissionPrompt": true,
+		remoteControlSettingKey:             false,
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #5607.

Since Claude Code ~2.1.226 the Remote Control bridge (session publishing to `claude.ai/code`) auto-starts whenever no explicit `remoteControlAtStartup` value exists anywhere: with the key absent, the CLI falls through to a server-side rollout flag (`tengu_cobalt_harbor`), which is why the image upgrade flipped it on fleet-wide with no config change, why it can differ per agent on the same hive (percentage rollout), and why the in-pane `/remote-control` toggle — session-scoped, writes nothing — never sticks across a relaunch.

Hive never wrote that key for plain `claude`-backend agents: their per-agent homes bridge `~/.claude` to the shared `/data/home/.claude`, whose `settings.json` hive did not own. That was the gap.

## Mechanism

`remoteControlAtStartup` in user settings is the documented local lever (source precedence `policySettings > flagSettings > userSettings`; there is **no** env var for this — verified against the shipped 2.1.226/2.1.236 bundles in the issue). Hive now writes it, re-asserted on **every** claude-CLI launch, mirroring the `ensureBobAuthSettings` shared-settings precedent:

- **plain `claude` backend** — new `ensureClaudeRemoteControlDefault` (called from `launchInTmux`) merges `"remoteControlAtStartup": false` into the shared `/data/home/.claude/settings.json` whenever the key is absent
- **inference/gateway agents** — the same key added to `inferenceSettingsSeed`, landing in both the per-agent userSettings and the `--settings` flagSettings file via the existing `ensureClaudeSettings` repair-on-every-launch path

## Operator opt-in stays possible (default OFF)

The merge is add-if-missing only: an operator who genuinely wants Remote Control sets the key to `true` in the same file and hive never clobbers it — that explicit value also beats the rollout default in the CLI itself. An explicit `true` is logged as an Info receipt on every launch, so an enabled bridge is always explainable from the hive log.

## Runtime evidence check

At launch, if the agent's session file records `hasUsedRemoteControl: true` despite the pin, hive logs a Warn naming the session file — the bridge having come up anyway (pre-pin history, opt-in, or a pin not being honored) is now visible in `kubectl logs` instead of only inside an unattended pane.

## Tests

Property-asserting per repo discipline (`pkg/agent/claude_remote_control_test.go`):
- the inference seed and both written inference settings surfaces contain an **explicit** `false` (absence = delegation to the server rollout is the failure mode, so presence is the asserted invariant)
- shared-file pin: seeds `false` when absent, idempotent, preserves an operator's explicit `true`, preserves fleet-critical sibling keys (`skipDangerousModePermissionPrompt` et al.), refuses to invent `/data/home/.claude` when the entrypoint hasn't created it
- `remoteControlBridgeUsed` marker detection

`gofmt` clean on touched files; `go vet ./pkg/agent` clean; targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)