### PR TITLE
observability(packs): log which agents a pack apply created

### DIFF
--- a/src/pkg/dashboard/api_packs.go
+++ b/src/pkg/dashboard/api_packs.go
@@ -394,7 +394,14 @@ func (s *Server) applyPack(level int, forceGovernor bool) (*ApplyPackResult, err
 	// field report, so also list WHICH agents were tombstoned (deleted by the operator
 	// and NOT re-created) vs skipped (already present) — a grep by agent name against
 	// this single line answers "did the pack try to re-add the agent I removed?".
-	s.logger.Info("ACMM pack applied", "hive_id", s.deps.Config.HiveID, "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned), "gate_removed", len(removedByGate), "tombstoned_agents", tombstoned, "skipped_agents", skipped)
+	// created_agents is listed by NAME for the same reason #2439 added
+	// tombstoned_agents and skipped_agents: the count alone is not actionable.
+	// `created` is what sets isFirstApplyOrExpansion, which re-asserts the
+	// pack's governor cadences over the operator's — so a steady-state apply
+	// that unexpectedly reports created:1 silently resets every custom cadence,
+	// and the log gives no way to tell WHICH agent authorized that reset. A
+	// grep by agent name against this one line answers it.
+	s.logger.Info("ACMM pack applied", "hive_id", s.deps.Config.HiveID, "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed), "tombstoned", len(tombstoned), "gate_removed", len(removedByGate), "created_agents", created, "tombstoned_agents", tombstoned, "skipped_agents", skipped)
 	if len(tombstoned) > 0 {
 		// Say it plainly in the log too: an operator reading "this level has 6
 		// agents but I see 4" needs the reason, not a silent gap.


### PR DESCRIPTION
### What

Adds `created_agents` to the `ACMM pack applied` log line, alongside the
`tombstoned_agents` / `skipped_agents` name lists that #2439 already added.

Log-only. No behaviour change.

### Why

`created` is the most consequential of the three counts: it is what sets
`isFirstApplyOrExpansion`, which in turn re-asserts `pack.Governor.Cadences`
over whatever the operator configured.

That means a steady-state apply which unexpectedly reports `created: 1`
silently resets every custom cadence in every mode — and the log tells you the
count that authorised the reset, but not *which agent* it was:

```json
{"msg":"ACMM pack applied","created":1,"updated":11,"skipped":0,"tombstoned_agents":null}
{"msg":"ACMM pack changed governor settings","level":6,
 "cadence_changes":[{"mode":"surge","agent":"ci-maintainer","from":"4h","to":"5m"}, ...]}
```

From the operator's side the symptom is that cadence writes persist to
`hive.yaml.dashboard`, show up in `/api/status`, and then revert minutes later
with nothing connecting the two events. Working out which agent was behind it
took a long session of source reading; this one field answers it directly.

Reported in more detail as #5632 — that issue is still open, because we could
not pin the root cause well enough to justify a behavioural patch. This PR is
deliberately scoped to the observability gap that made it hard to find, and
nothing else.

### Verification

- `go build ./...` clean
- `go test ./pkg/dashboard/ -run Pack` passes

Signed-off-by included for DCO.
