### PR TITLE
fix(relay): treat Claude Code's silent API retry as busy, not idle-complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Hive did not historically maintain a complete changelog. This file starts a prag
 
 ## Unreleased
 
+### Fixed
+
+- The contributor relay no longer books a task complete while Claude Code is silently retrying a dropped API connection ([#5654](https://github.com/kubestellar/hive/issues/5654)). When the connection drops mid-turn, Claude Code does not print its `● API Error:` chrome — it retries internally and renders a spinner countdown (`✻ Waiting for API response · will retry in 1m 57s · check your network`). That pane carried no busy marker, matched no error detector, and still showed the persistent `⏵⏵` footer plus the *previous* turn's `✻ Worked for …` summary, so `classifyTmuxPane` returned `IDLE_COMPLETE` for an agent mid-turn; after the chrome-idle grace window the relay reported the task complete, and the hub revoked the lease, booked the cooldown, and offered the issue to someone else while the turn kept running. The retry countdown now counts as a busy marker: the pane classifies `WORKING`, nothing is typed over a retry the CLI is recovering from on its own, and a retry loop that never resolves is still bounded by the existing stall backstop and task duration ceiling. Genuine idle completion — the same chrome with no retry line — is unchanged.
+
 ## 2026-09-02 (v4.1.0)
 
 ### Added

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -2213,7 +2213,30 @@ function classifyTmuxPane(text) {
     // unknown Claude UI still errs toward busy.
     hasIdlePrompt = /⏵⏵|← for agents|bypass permissions|shift\+tab to cycle/.test(claudeTail);
     hasCompletionMarker = /[✻✶✽] \S+ed for \d+[ms]|Honking|tokens\)/.test(text);
-    const claudeBusyMarker = /esc to interrupt/i.test(claudeTail);
+    // #5654: Claude Code retries a dropped API connection SILENTLY — no
+    // "● API Error:" chrome, just a spinner-glyph countdown line:
+    //
+    //   ✻ Waiting for API response · will retry in 1m 57s · check your network
+    //
+    // That pane is mid-turn, but every gate below said otherwise: no busy
+    // marker, no recognised error line, and the persistent ⏵⏵ footer plus a
+    // PREVIOUS turn's "✻ Worked for …" summary satisfied the completion test —
+    // the ✻ glyph is Claude's spinner, not a completion signal — so a stalled
+    // agent could be booked IDLE_COMPLETE mid-turn. A retry countdown is the
+    // CLI saying it is still working, so it counts as a BUSY marker: the task
+    // stays WORKING, nothing is typed into the pane (interrupting a self-
+    // recovering retry would cause the stall it prevents — see the ordering
+    // note above paneShowsUnretryableAPIError below), and a retry loop that
+    // never resolves is bounded by the existing stall backstop and
+    // MAX_TASK_DURATION rather than mis-booked here.
+    //
+    // The two halves of the line are matched independently because a narrow
+    // pane wraps it; the digit anchor on "will retry in" keeps completed-turn
+    // prose ("the job will retry indefinitely") from pinning an idle pane, and
+    // the tail scope — same window as every other marker in this branch —
+    // keeps a scrolled-past mention from doing so either.
+    const claudeRetryMarker = /Waiting for API response|will retry in \d/i.test(claudeTail);
+    const claudeBusyMarker = /esc to interrupt/i.test(claudeTail) || claudeRetryMarker;
     isWorking = claudeBusyMarker ||
       (!hasIdlePrompt && (/─.*Bash\(|Reading|Editing|Writing|Searching/.test(claudeTail) || /ing…/.test(claudeTail)));
   } else if (BACKEND === 'copilot') {

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -4316,6 +4316,123 @@ test('#5094 with a human attached the relay asks for attention instead of typing
 
 
 // ---------------------------------------------------------------------------
+// kubestellar/hive#5654 — Claude Code's SILENT API retry must not read as
+// IDLE_COMPLETE.
+//
+// When the connection drops mid-turn, Claude Code does not print its
+// "● API Error:" chrome — it retries internally and renders a countdown under
+// its spinner glyph. That pane answered "no" to busy (no "esc to interrupt"),
+// "no" to every error detector, and "yes" to the completion test: the ⏵⏵
+// footer is still drawn, and the PREVIOUS turn's "✻ Worked for …" summary
+// satisfies hasCompletionMarker — the same ✻ glyph the retry line itself uses.
+// So a stalled agent was bookable as complete mid-turn, the hub revoked the
+// lease and offered the issue to someone else while the turn kept running.
+// The retry countdown is the CLI saying it is still working: it is a BUSY
+// marker now.
+// ---------------------------------------------------------------------------
+
+// The pane the issue was filed from: a prior turn's duration summary still on
+// screen, the silent-retry countdown, and Claude's persistent idle footer.
+const CLAUDE_SILENT_RETRY_PANE = [
+  '● Pushed the branch; opening the PR next.',
+  '',
+  '✻ Worked for 15m 39s',
+  '',
+  '✻ Waiting for API response · will retry in 1m 57s · check your network',
+  '',
+  '❯ ',
+  '  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents',
+].join('\n');
+
+// The same pane once the retry resolved and the turn actually finished.
+const CLAUDE_RETRY_RECOVERED_PANE = [
+  '● Pushed the branch; opening the PR next.',
+  '',
+  '● Done — opened https://github.com/kubestellar/hive/pull/5655',
+  '',
+  '✻ Worked for 15m 39s',
+  '',
+  '❯ ',
+  '  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents',
+].join('\n');
+
+test('#5654 a claude pane waiting on a silent API retry classifies as WORKING, not complete', () => {
+  const relay = loadRelay({ backend: 'claude', paneText: CLAUDE_SILENT_RETRY_PANE });
+  try {
+    assert.strictEqual(relay.classifyTmuxPane(CLAUDE_SILENT_RETRY_PANE),
+      relay.PANE_STATE_WORKING,
+      'a retry countdown is the CLI still working — the previous turn\'s ✻ summary must not certify it complete');
+  } finally { teardown(relay); }
+});
+
+test('#5654 a wrapped retry line still reads as WORKING on either fragment', () => {
+  // Narrow panes wrap the countdown line, so either half alone must hold.
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    for (const fragment of [
+      '✻ Waiting for API response',
+      'will retry in 3s · check your network',
+    ]) {
+      const pane = CLAUDE_SILENT_RETRY_PANE.replace(
+        '✻ Waiting for API response · will retry in 1m 57s · check your network',
+        fragment);
+      assert.strictEqual(relay.classifyTmuxPane(pane), relay.PANE_STATE_WORKING,
+        `retry fragment must classify WORKING: ${fragment}`);
+    }
+  } finally { teardown(relay); }
+});
+
+test('#5654 a turn that really finished after a retry still classifies as complete', () => {
+  // The guard that matters as much as the fix: genuine idle detection must not
+  // be weakened. Same chrome, same prior-turn summary, no retry line.
+  const relay = loadRelay({ backend: 'claude', paneText: CLAUDE_RETRY_RECOVERED_PANE });
+  try {
+    assert.strictEqual(relay.classifyTmuxPane(CLAUDE_RETRY_RECOVERED_PANE),
+      relay.PANE_STATE_IDLE_COMPLETE);
+  } finally { teardown(relay); }
+});
+
+test('#5654 completed-turn prose about retrying does not pin an idle pane to WORKING', () => {
+  // The digit anchor on "will retry in": an agent whose finished summary
+  // DESCRIBES retry behaviour must still be credited with its completion.
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    const pane = [
+      '● Done — the workflow will retry indefinitely on transient failures.',
+      '',
+      '✻ Worked for 4m 2s',
+      '',
+      '❯ ',
+      '  ⏵⏵ auto mode on (shift+tab to cycle)',
+    ].join('\n');
+    assert.strictEqual(relay.classifyTmuxPane(pane), relay.PANE_STATE_IDLE_COMPLETE,
+      'prose about retries carries no countdown digit and must not read as busy');
+  } finally { teardown(relay); }
+});
+
+test('#5654 the relay never books a task complete off a pane waiting on a retry', () => {
+  // End to end: even across the full chrome-idle grace window, a retrying pane
+  // must keep reporting working — not complete, and not typed into either
+  // (interrupting a self-recovering retry would cause the stall it prevents).
+  const relay = loadRelay({ backend: 'claude', paneText: CLAUDE_SILENT_RETRY_PANE });
+  try {
+    relay.setCliReady(true);
+    assignTask(relay, 't-silent-retry');
+    const before = relay.__tmuxSends().length;
+    graceTicks(relay, () => relay.__crashTick());
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_complete').length, 0,
+      'a mid-retry turn must not be booked complete, even after the grace window');
+    assert.strictEqual(relay.__sent.filter(m => m.type === 'task_failed').length, 0,
+      'waiting on a retry is not a failure either');
+    assert.ok(relay.getCurrentTask(), 'the task must still be held');
+    const sends = relay.__tmuxSends().slice(before);
+    assert.ok(!sends.some(c => /send-keys.*-l/.test(c)),
+      `nothing may be typed into a pane the CLI is about to recover itself: ${JSON.stringify(sends)}`);
+  } finally { teardown(relay); }
+});
+
+
+// ---------------------------------------------------------------------------
 // kubestellar/hive#5277 — "a client is attached" is not "a human is here".
 //
 // The #5094 guard above is right to refuse to type over someone, but it tested


### PR DESCRIPTION
## Summary

When Claude Code loses its API connection mid-turn it retries internally without printing its `● API Error:` chrome — it renders a spinner countdown instead:

```
✻ Waiting for API response · will retry in 1m 57s · check your network
```

In `classifyTmuxPane`'s claude branch (`bin/contributor-relay.sh`) that pane answered **no** to busy (no `esc to interrupt`), **no** to every API-error detector (no error chrome, no status code), and **yes** to the completion test: the persistent `⏵⏵` footer satisfies `hasIdlePrompt`, and the *previous* turn's `✻ Worked for 15m 39s` summary satisfies `hasCompletionMarker` — the `✻` glyph is Claude's spinner, not a completion signal. A stalled agent could therefore be classified `IDLE_COMPLETE` mid-turn and, after `CHROME_IDLE_GRACE_TICKS`, be booked complete as `chrome_idle` — making the hub revoke the lease, book the cooldown, and offer the issue to someone else while the turn kept running.

## Fix

The retry countdown is the CLI saying it is still working, so it now counts as a **busy marker** in the claude branch:

- pane classifies `WORKING`; the completion path is never reached
- nothing is typed into a pane the CLI is recovering on its own (interrupting a self-recovering retry would cause the stall it prevents)
- a retry loop that never resolves is still bounded by the existing stall backstop and `MAX_TASK_DURATION`

The two halves of the line are matched independently because narrow panes wrap it, and the digit anchor on `will retry in \d` keeps completed-turn prose about retries from pinning an idle pane. The match is scoped to the same 15-line tail as every other marker in the branch, so a scrolled-past mention cannot pin busy either.

## Tests (both directions)

- a pane holding the retry countdown + a prior turn's `✻ Worked for …` summary + the `⏵⏵` footer classifies `WORKING` (fails pre-fix: was `IDLE_COMPLETE`)
- each wrapped fragment of the retry line alone classifies `WORKING` (fails pre-fix)
- end to end: across the full chrome-idle grace window the relay sends no `task_complete`, no `task_failed`, keeps the task, and types nothing into the pane (fails pre-fix)
- genuine idle is not weakened: the same chrome with the retry resolved still classifies `IDLE_COMPLETE`, and a finished summary whose prose merely says "will retry indefinitely" still completes (both pass pre- and post-fix)

`node bin/contributor-relay.test.js`: 272/272 pass with the fix; the three retry-direction tests fail without it.

TurnLoss accounting (`src/pkg/agent/turn_loss.go`) is unaffected — it is spoke-side teardown accounting keyed on `kickLogPending` and pane-change clocks, not on the relay's pane classification. No Go files are touched. The stale-`hasCompletionMarker`/stale-`HIVE_VERDICT` shape the issue notes in passing is #5650's territory and deliberately not touched here.

Fixes #5654

Related: #5650, #5094, #5121, #5162

🤖 Generated with [Claude Code](https://claude.com/claude-code)