### PR TITLE
🔒 test(contribute): pin the #5652 local-relaunch posture invariant from both sides

### DIFF
--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -435,6 +435,81 @@ test('relaunchCLI sends the cd-prefixed command to tmux', () => {
   } finally { teardown(relay); }
 });
 
+// ---------------------------------------------------------------------------
+// kubestellar/hive#5652, remaining edges — a relaunch must reuse the
+// LAUNCHER's resolved launch line, never re-derive one that drops local
+// mode's sandbox.
+//
+// The positive half (an exported AGENT_LAUNCH_CMD wins over the container
+// posture for claude/copilot/opencode, byte-identical) is pinned by
+// "#5652 relaunch reuses the entrypoint launch command" above. These are the
+// negative controls: the fix pins launch == relaunch, so it must neither
+// invent a sandbox the operator explicitly opted out of, nor append flags the
+// launcher deliberately omitted, nor break the container/older-launcher path
+// where nothing is exported and the derived posture IS the launched posture.
+// backendPerm is the container bypass string on purpose: the assertion is
+// precisely about when it may and may not win.
+// ---------------------------------------------------------------------------
+
+// A faithful reduction of what claude_family_local_perm_flag_shell emits.
+const LOCAL_SANDBOXED_CLAUDE_CMD = 'claude --permission-mode dontAsk ' +
+  '--settings \\{\\"permissions\\":\\{\\"allow\\":\\[\\"Write\\(/home/dev/workspace/\\*\\*\\)\\"\\]\\},' +
+  '\\"sandbox\\":\\{\\"enabled\\":true,\\"failIfUnavailable\\":true,\\"allowUnsandboxedCommands\\":false\\}\\} ' +
+  '--add-dir /home/dev/workspace --disallowed-tools Bash\\(sudo:\\*\\),Bash\\(rpm-ostree:\\*\\)';
+const CONTAINER_BYPASS_PERM = '--dangerously-skip-permissions --permission-mode bypassPermissions';
+
+test('#5652 negative control: a sandbox-off launch relaunches unchanged, no sandbox is invented', () => {
+  // HIVE_CLAUDE_DANGEROUSLY_BYPASS_APPROVALS_AND_SANDBOX makes the launcher
+  // resolve — and export — the bypass posture itself. Reusing the line verbatim
+  // must preserve THAT choice too: the fix pins launch == relaunch, it does not
+  // force a sandbox into either.
+  const optedOut = `claude ${CONTAINER_BYPASS_PERM} --disallowed-tools Bash\\(sudo:\\*\\)`;
+  const relay = loadRelay({
+    backend: 'claude',
+    backendPerm: CONTAINER_BYPASS_PERM,
+    env: { AGENT_LAUNCH_CMD: optedOut },
+  });
+  try {
+    assert.strictEqual(relay.buildLaunchCommand(), optedOut);
+    const before = relay.__tmuxSends().length;
+    relay.relaunchCLI();
+    const launch = relay.__tmuxSends().slice(before).find(c => /claude/.test(c));
+    assert.ok(launch, 'no relaunch command was sent to tmux');
+    assert.match(launch, /--dangerously-skip-permissions/,
+      `an explicitly opted-out launch must relaunch as launched: ${launch}`);
+    assert.ok(!/--settings/.test(launch),
+      `the relaunch must not add sandbox flags the launcher omitted: ${launch}`);
+  } finally { teardown(relay); }
+});
+
+test('#5652 negative control: without a launcher-resolved line the backends.conf derivation still applies', () => {
+  // Container mode (and any older launcher) exports nothing; there the
+  // derived posture IS the launched posture, and it must keep working.
+  const relay = loadRelay({ backend: 'claude', backendPerm: CONTAINER_BYPASS_PERM });
+  try {
+    const cmd = relay.buildLaunchCommand();
+    assert.match(cmd, /claude/);
+    assert.match(cmd, /--dangerously-skip-permissions/,
+      `fallback derivation no longer reflects backends.conf: ${cmd}`);
+  } finally { teardown(relay); }
+});
+
+test('#5652 the launcher-resolved line is the WHOLE command — no flags are appended to it', () => {
+  // The local launcher includes any model flag it wants in the line itself
+  // (litellm/pi append to PERM_FLAG); re-adding one here would be the same
+  // two-derivations drift in the other direction.
+  const relay = loadRelay({
+    backend: 'claude',
+    model: 'claude-opus-4-6',
+    backendPerm: CONTAINER_BYPASS_PERM,
+    env: { AGENT_LAUNCH_CMD: LOCAL_SANDBOXED_CLAUDE_CMD },
+  });
+  try {
+    assert.strictEqual(relay.buildLaunchCommand(), LOCAL_SANDBOXED_CLAUDE_CMD,
+      'AGENT_MODEL must not be appended onto the launcher-resolved line');
+  } finally { teardown(relay); }
+});
+
 test('a shell in the pane is only a death after consecutive confirmations', () => {
   const relay = loadRelay({ backend: 'agy', procAlive: false });
   try {

--- a/src/pkg/dashboard/contribute_local_relaunch_posture_test.go
+++ b/src/pkg/dashboard/contribute_local_relaunch_posture_test.go
@@ -1,0 +1,99 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// kubestellar/hive#5652: the relay's post-task relaunch dropped local mode's
+// sandbox. `just contribute-hive <backend> local` resolves a NARROWED launch
+// line (claude: --permission-mode dontAsk + native sandbox settings + workspace
+// write-allowlist; copilot: --sandbox; opencode: the host-state deny-list) —
+// but that resolution lived only in the Justfile, at first launch. The relay
+// re-derived its relaunch line from backends.conf's backend_perm_flag, which
+// answers with the CONTAINER posture, so the first task exit relaunched a
+// sandboxed local agent as `claude --dangerously-skip-permissions
+// --permission-mode bypassPermissions` for the rest of the session.
+//
+// The fix is single-sourcing: the Justfile resolves the launch line once,
+// types it into the pane, and exports the SAME value to the relay as
+// AGENT_LAUNCH_CMD; buildLaunchCommand() in bin/contributor-relay.sh prefers
+// that over its own derivation. The launcher half of that contract is pinned by
+// TestContributeHiveExportsLaunchCommandForRelayRelaunch in
+// contribute_pane_cwd_test.go; this file pins the CONSUMER half and the
+// cross-file agreement. The relay's behaviour itself — a relaunch byte-
+// identical to the exported line, sandbox kept when the launch had one, none
+// invented when the operator opted out, container fallback intact — is pinned
+// behaviorally in bin/contributor-relay.test.js ("#5652 ...").
+
+// localModeLaunchBlock returns the local-mode text from the branch head through
+// the relay start, covering both the pane launch and the relay's environment.
+func localModeLaunchBlock(t *testing.T) string {
+	t.Helper()
+	src := justfileSource(t)
+	start := strings.Index(src, `if [[ "$_MODE" == "local" ]]; then`)
+	if start < 0 {
+		t.Fatal("contribute-hive local-mode branch not found in the Justfile")
+	}
+	end := strings.Index(src[start:], "cleanup() {")
+	if end < 0 {
+		t.Fatal("end of the local-mode relay start block not found in the Justfile")
+	}
+	return src[start : start+end]
+}
+
+// TestRelayReadsTheExactVariableTheLauncherExports pins the env-var contract
+// across the two files. A rename on either side would fail silently at
+// runtime — the variable would simply be absent in the relay's environment,
+// and the permissive backends.conf fallback would win again, which is exactly
+// the #5652 escape. Neither file's own tests can catch that: each side would
+// still be self-consistent.
+func TestRelayReadsTheExactVariableTheLauncherExports(t *testing.T) {
+	const launchCmdVar = "AGENT_LAUNCH_CMD"
+
+	block := localModeLaunchBlock(t)
+	if !strings.Contains(block, "export "+launchCmdVar+"=") {
+		t.Fatalf("the Justfile local branch no longer exports %s; "+
+			"relaunches would re-derive the CONTAINER posture and drop the sandbox (#5652)", launchCmdVar)
+	}
+
+	relay := fileSource(t, "bin/contributor-relay.sh")
+	if !strings.Contains(relay, "process.env."+launchCmdVar) {
+		t.Fatalf("bin/contributor-relay.sh no longer reads %s; "+
+			"local-mode relaunches would fall back to the container posture (#5652)", launchCmdVar)
+	}
+}
+
+// TestRelayBuildLaunchCommandPrefersTheEntrypointLine pins that the exported
+// line is consulted in buildLaunchCommand() itself — the single source every
+// relaunch path (task exit, crash restart, stall backstop, revoke) goes
+// through — not merely read somewhere in the file.
+func TestRelayBuildLaunchCommandPrefersTheEntrypointLine(t *testing.T) {
+	relay := fileSource(t, "bin/contributor-relay.sh")
+	fnStart := strings.Index(relay, "function buildLaunchCommand()")
+	if fnStart < 0 {
+		t.Fatal("buildLaunchCommand() not found in bin/contributor-relay.sh")
+	}
+	buildFn := relay[fnStart:]
+	if end := strings.Index(buildFn, "\n}"); end > 0 {
+		buildFn = buildFn[:end]
+	}
+	if !strings.Contains(buildFn, "ENTRYPOINT_LAUNCH_CMD") {
+		t.Error("buildLaunchCommand() no longer prefers the entrypoint-resolved launch line (#5652)")
+	}
+}
+
+// TestLocalModePaneLaunchNeverBypassesTheExportedLine pins the vulnerable
+// shape out of existence: a send-keys line interpolating $CMD $PERM_FLAG
+// directly again would relaunch from a DIFFERENT construction than the one
+// exported to the relay — two derivations of one launch line, which is how
+// #5652 (and #2203 bug 1 before it) happened.
+func TestLocalModePaneLaunchNeverBypassesTheExportedLine(t *testing.T) {
+	block := localModeLaunchBlock(t)
+	for _, line := range strings.Split(block, "\n") {
+		if strings.Contains(line, "send-keys") && strings.Contains(line, "$PERM_FLAG") {
+			t.Errorf("a local-mode pane launch interpolates $PERM_FLAG directly, bypassing AGENT_LAUNCH_CMD: %s",
+				strings.TrimSpace(line))
+		}
+	}
+}


### PR DESCRIPTION
Follow-up coverage for #5652 (fixed by #5702).

This PR originally carried an independent fix for the relay's post-task relaunch dropping local mode's sandbox; #5702 merged the same single-source-of-truth fix first (the launcher exports the resolved line as `AGENT_LAUNCH_CMD`, `buildLaunchCommand()` prefers it). Rebased onto v4, this PR now adds only the regression coverage the issue asked for beyond #5702's positive-path test:

**Relay negative controls** (`bin/contributor-relay.test.js`):
- A sandbox-off (explicitly opted-out) launch relaunches unchanged — the fix pins launch == relaunch, it must not invent a sandbox the operator declined.
- Without an exported line, the `backends.conf` derivation still applies (container mode and older launchers, where derived posture == launched posture).
- The exported line is the WHOLE command: `AGENT_MODEL` is never appended onto it — the same two-derivations drift in the other direction.

**Cross-file contract** (`src/pkg/dashboard/contribute_local_relaunch_posture_test.go`, new):
- The relay reads the exact variable the Justfile exports. A rename on either side would fail silently at runtime — the env var would simply be absent and the permissive fallback would win again — and neither file's own tests can catch it, since each side stays self-consistent.
- `buildLaunchCommand()` itself consults the entrypoint line (the single choke point every relaunch path goes through), not merely somewhere in the file.
- No local-mode `send-keys` line interpolates `$PERM_FLAG` directly again, bypassing the exported single source.

Relay suite 289/289 green; `node --check` clean on relay + tests; `gofmt`/`go vet` clean; targeted dashboard tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)