### PR TITLE
contributor-relay: recognise and dismiss the agy onboarding wizard

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1360,6 +1360,13 @@ function blockingPromptKey(text) {
   // persists, so this prompt stops coming back on every restart the way a
   // plain "Skip" would.
   if (/Update available!/.test(text) && /Skip until next version/.test(text)) return '3';
+  // agy: "Terms of Service & Data Use" ends on a [Previous] [Done] button row
+  // with focus on the CHECKBOX above it, where Enter toggles consent instead of
+  // advancing ("enter Toggle"). A bare Enter therefore never leaves this page.
+  // Down moves to the button row, Right selects [Done]; the caller appends
+  // Enter. The other two steps (theme picker, folder trust) do advance on a
+  // bare Enter and deliberately fall through to null.
+  if (/Terms of Service & Data Use/.test(text) && /\[Done\]/.test(text)) return 'Down Right';
   return null;
 }
 
@@ -1374,6 +1381,16 @@ function getCLIState() {
       if (/copilot login|gh auth login/.test(text)) return 'needs-login';
       if (/Confirm folder trust|trust the files|Do you trust/.test(text)) return 'onboarding';
       if (/\/ commands.*help/.test(text)) return 'ready';
+    } else if (BACKEND === 'agy') {
+      // Antigravity gates first run behind a THREE-step wizard, and every
+      // agent that shares a $HOME re-enters it whenever another agent writes
+      // antigravity-cli/cache/onboarding.json mode 600 (they symlink to one
+      // shared ~/.gemini, so the next agent gets EACCES and starts over).
+      // Without this branch the pane fell through to 'unknown', the relay
+      // waited out CLI_READY_TIMEOUT_MS and handed the task back.
+      if (/not signed in|Select login method/i.test(text)) return 'needs-login';
+      if (/Choose your color scheme|Terms of Service & Data Use|Do you trust the contents|I trust this folder|Welcome to (the )?Antigravity/i.test(text)) return 'onboarding';
+      if (/^>\s*$|❯|Antigravity CLI/m.test(text)) return 'ready';
     } else if (BACKEND === 'gemini') {
       if (/not authenticated|login required/i.test(text)) return 'needs-login';
       if (/>\s*$|❯/.test(text)) return 'ready';


### PR DESCRIPTION
### Problem

`agy` is a first-class backend throughout `contributor-relay.sh` — launch
flags, the `--effort` requirement, capability reporting — but `getCLIState()`
has **no branch for it**. An Antigravity pane always falls through to
`'unknown'`, so the relay waits out `CLI_READY_TIMEOUT_MS` and hands the task
back, with the CLI sitting on a dismissible dialog the entire time.

Antigravity gates first run behind a three-step wizard:

1. `Choose your color scheme:` … `[Next]`
2. `Terms of Service & Data Use` … `[Previous]  [Done]`
3. `Do you trust the contents of this project?` … `Yes, I trust this folder`

This is **not** a once-per-image cost. Agents that share a `$HOME` symlink a
single `~/.gemini`, so the moment one agent writes
`antigravity-cli/cache/onboarding.json` mode `600`, every *other* agent gets
`EACCES` and re-enters the wizard from step 1. On our fleet that recurred
constantly and had to be cleared by hand.

### Changes

**`getCLIState()` gains an `agy` branch** — wizard → `onboarding`,
`not signed in` / `Select login method` → `needs-login`, banner/prompt →
`ready`.

**`blockingPromptKey()` learns the Terms of Service step.** It is the one page
a bare Enter cannot leave: focus sits on the consent **checkbox**, where Enter
*toggles* rather than advances (the footer literally reads `enter Toggle`), so
the existing bare-Enter path dismisses in a loop until timeout. `Down` moves to
the button row and `Right` selects `[Done]`; the caller already appends Enter,
and `tmux send-keys` takes the sequence as-is.

The colour-scheme and folder-trust steps *do* advance on a bare Enter and
deliberately return `null`, matching the function's existing contract.

### Verification

Both functions exercised against pane text captured from a live fleet:

```
blockingPromptKey        getCLIState
  theme  -> null           login  -> needs-login
  tos    -> "Down Right"   theme  -> onboarding
  trust  -> null           tos    -> onboarding
  codex  -> "1"            trust  -> onboarding
                           ready  -> ready
```

codex's existing prompts are unaffected. `node --check` clean.

### Scope

Deliberately narrow. It does not attempt to fix the underlying shared-`$HOME`
permission race — that is an operator-side concern (we normalise the tree to
group-writable on a timer) and arguably wants `umask 007` at launch, which is a
separate conversation.
