### PR TITLE
🧪 test(agent): make watchdog fleet tests hermetic against leaked uid-maps

### DIFF
--- a/src/pkg/agent/watchdog_fleet_test.go
+++ b/src/pkg/agent/watchdog_fleet_test.go
@@ -15,6 +15,15 @@ import (
 // running, with the tmux seams faked so no subprocess ever runs.
 func newWatchdogTestManager(t *testing.T, backends map[string]string) (*Manager, *map[string]string) {
 	t.Helper()
+	// NewManager silently loads whatever uid-map sits at UIDMapPath, and the
+	// TestMain path is shared by the whole binary. A map leaked there by an
+	// earlier test (any writer that skips stubUIDMapPath — the #5580 chain,
+	// re-observed as #5631) hands these agents real UIDs, so AgentHome
+	// resolves to a per-UID home instead of $HOME and LastProduction scans
+	// the wrong directory, silently falling back to pane evidence. Watchdog
+	// tests never exercise UID plumbing; isolate the path so no leak — past
+	// or future — can reach them.
+	stubUIDMapPath(t)
 	cfgs := make(map[string]config.AgentConfig, len(backends))
 	for name, backend := range backends {
 		cfgs[name] = config.AgentConfig{Backend: backend}
@@ -368,6 +377,18 @@ func TestWatchdogLastProduction(t *testing.T) {
 	m, _ := newWatchdogTestManager(t, map[string]string{"a1": "claude", "b1": "bob"})
 	fleet := WatchdogFleet{M: m}
 
+	// Pin the invariant every assertion below rests on: with UID 0, AgentHome
+	// is $HOME, so the evidence written under this test's HOME is the evidence
+	// LastProduction scans. A nonzero UID means a uid-map leaked into
+	// NewManager and re-routed the scan to a per-UID home — which used to
+	// surface as a baffling "LastProduction is the pane time, two hours off"
+	// failure (#5631) instead of naming the cause.
+	for _, name := range []string{"a1", "b1"} {
+		if uid := m.agents[name].UID; uid != 0 {
+			t.Fatalf("agent %s inherited UID %d from a leaked uid-map; AgentHome would skip $HOME and miss the state-file evidence", name, uid)
+		}
+	}
+
 	// No evidence anywhere: pane never changed, no state dirs.
 	if _, ok := fleet.LastProduction("a1"); ok {
 		t.Fatal("no evidence must report ok=false")
@@ -376,8 +397,14 @@ func TestWatchdogLastProduction(t *testing.T) {
 		t.Fatal("unknown agent has no evidence")
 	}
 
+	// Both fixtures derive from ONE clock read so their 1h59m spread is fixed
+	// by construction: pane evidence sits 2h back (coincidentally the
+	// watchdog's NoProductionFor default — no production threshold is in play
+	// here) and the state-file mtime 1m back, so the mtime must win.
+	now := time.Now()
+
 	// Pane activity alone is evidence.
-	paneTime := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	paneTime := now.Add(-2 * time.Hour).Truncate(time.Second)
 	m.agents["a1"].LastPaneChange = paneTime
 	got, ok := fleet.LastProduction("a1")
 	if !ok || !got.Equal(paneTime) {
@@ -393,7 +420,7 @@ func TestWatchdogLastProduction(t *testing.T) {
 	if err := os.WriteFile(convo, []byte("{}"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	newer := time.Now().Add(-time.Minute).Truncate(time.Second)
+	newer := now.Add(-time.Minute).Truncate(time.Second)
 	if err := os.Chtimes(convo, newer, newer); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What

Fixes #5631 — the `TestWatchdogLastProduction` flake where LastProduction came back "exactly ~2h" behind the state-file mtime.

## Root cause (not a timezone/boundary bug)

The 1h59m offset is the test's own fixtures: pane evidence at now−2h vs state-file mtime at now−1m. The failure means the mtime evidence was never seen at all, and got == the pane fixture exactly.

Run 33571438566 (shard agent 5/5, `-shuffle` seed 1788305582043268182) shows the chain:

1. `TestAddAgent_WithUIDMap` (unstubbed at that SHA — the run predates #5596's merge by 48 minutes) saved a uid-map to the binary-wide TestMain `UIDMapPath`.
2. A later shuffled test's `NewManager` loaded it; `audit_test.go`'s `AddAgent("a1", ...)` allocated a real UID for "a1" and re-saved the amplified map.
3. `TestWatchdogLastProduction`'s `NewManager` loaded that map, `LookupByName("a1")` returned a real UID, `AgentHome` resolved to the per-UID home instead of $HOME, the evidence scan walked the wrong directory, and LastProduction silently fell back to pane evidence (now−2h = the reported 21:33:24 vs wanted 23:32:24).

Same family as #5580. The "clean 2h" reading in the issue is a coincidence with the test's −2h pane fixture (and with the watchdog's unrelated `NoProductionFor` default).

## Why #5596 alone is not enough

Writer-side stubs only hold while every future writer test remembers `stubUIDMapPath`. `NewManager` still silently loads whatever sits at the shared path, so one forgotten stub re-poisons this test. Reproduced on current v4 HEAD by seeding a uid-map containing "a1" at `UIDMapPath`: `TestWatchdogLastProduction` fails with the exact CI signature.

## Fix (reader-side hermeticity)

- `newWatchdogTestManager` stubs `UIDMapPath` before `NewManager` — watchdog tests never exercise UID plumbing, so no leaked map (past or future) can reach them.
- `TestWatchdogLastProduction` pins the invariant directly: a nonzero UID now fails with `agent a1 inherited UID 2001 from a leaked uid-map; AgentHome would skip $HOME and miss the state-file evidence` instead of a baffling two-hours-off timestamp mismatch.
- Both time fixtures derive from a single `time.Now()` read, making the 1h59m spread fixed by construction.

## Verification

- Poison repro (uid-map with "a1" seeded at `UIDMapPath`): fails with the CI signature before, passes after.
- Guard check: with the stub disabled and the map poisoned, the new assertion fires with the diagnostic message.
- `go vet ./pkg/agent` and `gofmt` clean; watchdog test suite green. Full-package run under the CI's failing seed shows only the known pre-existing local (no-tmux) failures, identical on clean HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
