### PR TITLE
🌱 ci: keep backend-smoke running after the hivecommons transfer

### DIFF
--- a/.github/workflows/backend-smoke.yml
+++ b/.github/workflows/backend-smoke.yml
@@ -70,7 +70,12 @@ jobs:
   smoke:
     # Forks have no model credentials; a scheduled run there would only
     # produce a permanently red workflow.
-    if: github.repository == 'kubestellar/hive'
+    # Match BOTH homes: the repo is moving kubestellar/hive → hivecommons/hive
+    # (split-consensus + CNCF Sandbox prep). An equality guard on the old name
+    # would make this job skip SILENTLY on transfer day — smoke coverage gone
+    # with no red anywhere. Both names listed explicitly (rather than
+    # github.repository_owner) so forks still skip as before.
+    if: github.repository == 'kubestellar/hive' || github.repository == 'hivecommons/hive'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:


### PR DESCRIPTION
Part of the hivecommons migration (P1.3 of the approved plan; pluk and hotshot already transferred as the system test).

`backend-smoke.yml:73` gated its job on `github.repository == 'kubestellar/hive'`. After the transfer that job would skip **silently** — no red check, just vanished smoke coverage. This widens the guard to match both homes explicitly (forks still skip, and the explicit list is auditable, unlike a repository_owner check).

Sweep result: this is the **only** repo-equality guard in the workflow tree; all other `github.repository` uses are dynamic interpolations (nightly image path, tagged-release API calls, notice-autofix fork guard) that self-correct on transfer. `gate` is docker.yml's own job and unaffected either way.

Safe to merge now — behavior under kubestellar/hive is unchanged.