### PR TITLE
🚚 ci: dual-publish images to kubestellar and hivecommons GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       push: ${{ steps.decide.outputs.push }}
+      cross_org: ${{ steps.registries.outputs.cross_org }}
+      cross_secret: ${{ steps.registries.outputs.cross_secret }}
     steps:
       - name: Decide push policy
         id: decide
@@ -132,6 +134,37 @@ jobs:
           esac
           echo "push=$push" >> "$GITHUB_OUTPUT"
           echo "Push to GHCR: $push (branch=$REF_NAME event=$EVENT)"
+
+      # DUAL-PUBLISH (kubestellar -> hivecommons org transfer). During the
+      # transfer window every image publish is mirrored into the OTHER org's
+      # GHCR namespace, so a hive pinned to either registry path keeps
+      # resolving fresh tags no matter which side of the transfer the repo is
+      # on. The NATIVE org is wherever this repo currently lives
+      # (github.repository_owner — the only org this job's GITHUB_TOKEN can
+      # write packages to); the CROSS org and the classic-PAT secret that can
+      # write to it are derived here once, direction-agnostically, so the
+      # workflow needs no edit when the transfer actually happens:
+      #   owner=kubestellar -> cross=hivecommons, secret GHCR_HIVECOMMONS_PAT
+      #   owner=hivecommons -> cross=kubestellar, secret GHCR_KUBESTELLAR_PAT
+      # The merge jobs consume these outputs. Whether a MISSING secret is a
+      # warning or a hard failure is decided there — see the asymmetry
+      # comment on each "Check cross-registry credential" step.
+      - name: Decide cross-registry mirror target
+        id: registries
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ "$OWNER" = "kubestellar" ]; then
+            cross_org=hivecommons
+            cross_secret=GHCR_HIVECOMMONS_PAT
+          else
+            cross_org=kubestellar
+            cross_secret=GHCR_KUBESTELLAR_PAT
+          fi
+          echo "cross_org=${cross_org}" >> "$GITHUB_OUTPUT"
+          echo "cross_secret=${cross_secret}" >> "$GITHUB_OUTPUT"
+          echo "Native org: ${OWNER}; mirroring publishes to ghcr.io/${cross_org} using secret ${cross_secret}."
 
   build:
     needs: gate
@@ -264,7 +297,11 @@ jobs:
           # Push the per-arch digest only for long-lived branches; on a PR
           # branch build without pushing so the image is still validated (CI
           # gate) but nothing lands on GHCR.
-          outputs: type=image,name=ghcr.io/kubestellar/hive,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
+          # The image name is owner-derived (dual-publish, see the gate job):
+          # GITHUB_TOKEN can only push packages in the org that hosts the
+          # repo, so the build always targets the NATIVE org and the merge
+          # job mirrors the finished manifest list into the cross org.
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/hive,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
           # tmux-builder layers come from the local cache warmed above; every
           # other stage is forced to re-execute by no-cache-filters, so there
           # is nothing worth exporting — deliberately NO cache-to here (the
@@ -291,7 +328,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ needs.gate.outputs.push }}" = "true" ]; then
-            IMG="ghcr.io/kubestellar/hive@${{ steps.build.outputs.digest }}"
+            IMG="ghcr.io/${{ github.repository_owner }}/hive@${{ steps.build.outputs.digest }}"
             docker pull "$IMG"
           else
             IMG=hive-freshness-probe:local
@@ -331,7 +368,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ needs.gate.outputs.push }}" = "true" ]; then
-            IMG="ghcr.io/kubestellar/hive@${{ steps.build.outputs.digest }}"
+            IMG="ghcr.io/${{ github.repository_owner }}/hive@${{ steps.build.outputs.digest }}"
           else
             IMG=hive-freshness-probe:local
           fi
@@ -385,9 +422,103 @@ jobs:
       - name: Create manifest list and push
         run: |
           src/scripts/publish-image-tags.sh \
-            ghcr.io/kubestellar/hive /tmp/digests \
+            ghcr.io/${{ github.repository_owner }}/hive /tmp/digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
             v4 false stable,candidate
+
+      # ---- Cross-org mirror (kubestellar <-> hivecommons dual-publish) ----
+      # Copy the tags just published above into the other org's GHCR
+      # namespace BY DIGEST (`imagetools create -t <cross>:<tag>
+      # <native>@<digest>`): both registries then serve the byte-identical,
+      # digest-identical manifest list — no second build, no drift. The gate
+      # job computed which org is "cross" and which secret can write to it.
+      #
+      # ASYMMETRY of the missing-secret handling, on purpose:
+      #   - owner=hivecommons (post-transfer): a missing PAT would mean the
+      #     OLD kubestellar registry silently stops receiving images while
+      #     every spoke still pinned there keeps pulling stale tags — the
+      #     dangerous one-sided publish — so it is a hard ::error failure.
+      #   - owner=kubestellar (pre-transfer staging): the PAT may simply not
+      #     exist yet; the mirror is purely additive and nothing that exists
+      #     today degrades, so it is only a ::warning and the run stays green.
+      - name: Check cross-registry credential
+        id: crosspat
+        env:
+          # Env indirection: `if:` cannot read the secrets context, and the
+          # secret NAME itself is computed by the gate job.
+          CROSS_PAT: ${{ secrets[needs.gate.outputs.cross_secret] }}
+          CROSS_ORG: ${{ needs.gate.outputs.cross_org }}
+          CROSS_SECRET_NAME: ${{ needs.gate.outputs.cross_secret }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CROSS_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          if [ "$OWNER" = "hivecommons" ]; then
+            echo "::error::secret ${CROSS_SECRET_NAME} is not set, so this run cannot mirror to ghcr.io/${CROSS_ORG}. Post-transfer that is a silent one-sided publish (spokes pinned to the old org keep pulling stale tags), so this fails hard. Create a classic PAT with write:packages from a ${CROSS_ORG} member and store it as ${CROSS_SECRET_NAME}."
+            exit 1
+          fi
+          echo "::warning::secret ${CROSS_SECRET_NAME} is not set — skipping the ghcr.io/${CROSS_ORG} mirror. Pre-transfer this is expected until that PAT is created; nothing that exists today degrades."
+
+      # ghcr.io is ONE registry host and docker keeps one credential per
+      # host, so this login REPLACES the GITHUB_TOKEN login above. Every
+      # native-org write is already done (the publish step above was the
+      # last one). Reading the native image back for the digest copy still
+      # works: these packages are public, and the PAT is a valid ghcr.io
+      # credential for public reads regardless of org.
+      - name: Log in to GHCR as the cross-org publisher
+        if: steps.crosspat.outputs.available == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets[needs.gate.outputs.cross_secret] }}
+
+      - name: Mirror published tags into the cross-org registry (by digest)
+        if: steps.crosspat.outputs.available == 'true'
+        env:
+          NATIVE_IMAGE: ghcr.io/${{ github.repository_owner }}/hive
+          CROSS_IMAGE: ghcr.io/${{ needs.gate.outputs.cross_org }}/hive
+          BRANCH: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+          # These three mirror publish-image-tags.sh's positional args in the
+          # publish step above — keep them in lockstep with that call.
+          INCLUDE_LATEST: "false"
+          RELEASE_BRANCH: "v4"
+          CHANNELS: "stable,candidate"
+        run: |
+          set -euo pipefail
+          # Same tag set publish-image-tags.sh manages for this image. Each
+          # tag is copied from whatever the NATIVE tag currently points at,
+          # so the monotonic moving-tag guard's decisions carry over: the
+          # cross org can never regress a tag the native org did not.
+          branch_tag="${BRANCH//\//-}"
+          tags=("${GIT_SHA:0:7}" "${branch_tag}-latest")
+          if [ "$INCLUDE_LATEST" = "true" ]; then tags+=("latest"); fi
+          if [ "$BRANCH" = "$RELEASE_BRANCH" ] && [ -n "$CHANNELS" ]; then
+            IFS=, read -ra channel_tags <<<"$CHANNELS"
+            for ch in "${channel_tags[@]}"; do [ -n "$ch" ] && tags+=("$ch"); done
+          fi
+          for tag in "${tags[@]}"; do
+            if ! digest=$(docker buildx imagetools inspect \
+                "${NATIVE_IMAGE}:${tag}" --format '{{.Manifest.Digest}}' 2>&1); then
+              # Distinguish "tag does not exist" (fine: e.g. the monotonic
+              # guard published nothing this run) from a transport/auth
+              # failure (red, same policy as publish-image-tags.sh).
+              if grep -Eqi 'manifest unknown|manifest.*not found|not found.*manifest|no such manifest|(^|[[:space:]:])not found$' <<<"$digest"; then
+                echo "native tag ${NATIVE_IMAGE}:${tag} does not exist — nothing to mirror for it"
+                continue
+              fi
+              echo "::error::could not inspect ${NATIVE_IMAGE}:${tag}; refusing to silently skip a mirror on a transport/auth failure" >&2
+              echo "$digest" >&2
+              exit 1
+            fi
+            echo "Mirroring ${CROSS_IMAGE}:${tag} <- ${NATIVE_IMAGE}@${digest}"
+            docker buildx imagetools create -t "${CROSS_IMAGE}:${tag}" "${NATIVE_IMAGE}@${digest}"
+          done
 
   build-contributor:
     needs: gate
@@ -444,7 +575,8 @@ jobs:
           # manifests, not an OCI index. See the note on the main build above.
           provenance: false
           sbom: false
-          outputs: type=image,name=ghcr.io/kubestellar/hive-contributor,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
+          # Owner-derived image name (dual-publish) — see the main build step.
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/hive-contributor,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
           cache-from: type=gha,scope=contributor-${{ steps.slug.outputs.slug }}
           cache-to: type=gha,scope=contributor-${{ steps.slug.outputs.slug }},mode=max
 
@@ -492,9 +624,75 @@ jobs:
       - name: Create contributor manifest list and push
         run: |
           src/scripts/publish-image-tags.sh \
-            ghcr.io/kubestellar/hive-contributor /tmp/contrib-digests \
+            ghcr.io/${{ github.repository_owner }}/hive-contributor /tmp/contrib-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
             v4 true stable,candidate
+
+      # Cross-org mirror — same mechanics, same missing-secret asymmetry, and
+      # same "one credential per registry host" ordering constraint as the
+      # fully commented block in the `merge` job above.
+      - name: Check cross-registry credential
+        id: crosspat
+        env:
+          CROSS_PAT: ${{ secrets[needs.gate.outputs.cross_secret] }}
+          CROSS_ORG: ${{ needs.gate.outputs.cross_org }}
+          CROSS_SECRET_NAME: ${{ needs.gate.outputs.cross_secret }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CROSS_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          if [ "$OWNER" = "hivecommons" ]; then
+            echo "::error::secret ${CROSS_SECRET_NAME} is not set, so this run cannot mirror to ghcr.io/${CROSS_ORG}. Post-transfer that is a silent one-sided publish (spokes pinned to the old org keep pulling stale tags), so this fails hard. Create a classic PAT with write:packages from a ${CROSS_ORG} member and store it as ${CROSS_SECRET_NAME}."
+            exit 1
+          fi
+          echo "::warning::secret ${CROSS_SECRET_NAME} is not set — skipping the ghcr.io/${CROSS_ORG} mirror. Pre-transfer this is expected until that PAT is created; nothing that exists today degrades."
+
+      - name: Log in to GHCR as the cross-org publisher
+        if: steps.crosspat.outputs.available == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets[needs.gate.outputs.cross_secret] }}
+
+      - name: Mirror published tags into the cross-org registry (by digest)
+        if: steps.crosspat.outputs.available == 'true'
+        env:
+          NATIVE_IMAGE: ghcr.io/${{ github.repository_owner }}/hive-contributor
+          CROSS_IMAGE: ghcr.io/${{ needs.gate.outputs.cross_org }}/hive-contributor
+          BRANCH: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+          # Lockstep with the publish-image-tags.sh args above.
+          INCLUDE_LATEST: "true"
+          RELEASE_BRANCH: "v4"
+          CHANNELS: "stable,candidate"
+        run: |
+          set -euo pipefail
+          branch_tag="${BRANCH//\//-}"
+          tags=("${GIT_SHA:0:7}" "${branch_tag}-latest")
+          if [ "$INCLUDE_LATEST" = "true" ]; then tags+=("latest"); fi
+          if [ "$BRANCH" = "$RELEASE_BRANCH" ] && [ -n "$CHANNELS" ]; then
+            IFS=, read -ra channel_tags <<<"$CHANNELS"
+            for ch in "${channel_tags[@]}"; do [ -n "$ch" ] && tags+=("$ch"); done
+          fi
+          for tag in "${tags[@]}"; do
+            if ! digest=$(docker buildx imagetools inspect \
+                "${NATIVE_IMAGE}:${tag}" --format '{{.Manifest.Digest}}' 2>&1); then
+              if grep -Eqi 'manifest unknown|manifest.*not found|not found.*manifest|no such manifest|(^|[[:space:]:])not found$' <<<"$digest"; then
+                echo "native tag ${NATIVE_IMAGE}:${tag} does not exist — nothing to mirror for it"
+                continue
+              fi
+              echo "::error::could not inspect ${NATIVE_IMAGE}:${tag}; refusing to silently skip a mirror on a transport/auth failure" >&2
+              echo "$digest" >&2
+              exit 1
+            fi
+            echo "Mirroring ${CROSS_IMAGE}:${tag} <- ${NATIVE_IMAGE}@${digest}"
+            docker buildx imagetools create -t "${CROSS_IMAGE}:${tag}" "${NATIVE_IMAGE}@${digest}"
+          done
 
   build-hub:
     needs: gate
@@ -560,7 +758,8 @@ jobs:
           # manifests, not an OCI index. See the note on the main build above.
           provenance: false
           sbom: false
-          outputs: type=image,name=ghcr.io/kubestellar/hive-hub,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
+          # Owner-derived image name (dual-publish) — see the main build step.
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/hive-hub,push-by-digest=true,name-canonical=true,push=${{ needs.gate.outputs.push }},oci-mediatypes=false
           cache-from: type=gha,scope=hub-${{ steps.slug.outputs.slug }}
           cache-to: type=gha,scope=hub-${{ steps.slug.outputs.slug }},mode=max
 
@@ -608,6 +807,72 @@ jobs:
       - name: Create hub manifest list and push
         run: |
           src/scripts/publish-image-tags.sh \
-            ghcr.io/kubestellar/hive-hub /tmp/hub-digests \
+            ghcr.io/${{ github.repository_owner }}/hive-hub /tmp/hub-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
             v4 true stable,candidate
+
+      # Cross-org mirror — same mechanics, same missing-secret asymmetry, and
+      # same "one credential per registry host" ordering constraint as the
+      # fully commented block in the `merge` job above.
+      - name: Check cross-registry credential
+        id: crosspat
+        env:
+          CROSS_PAT: ${{ secrets[needs.gate.outputs.cross_secret] }}
+          CROSS_ORG: ${{ needs.gate.outputs.cross_org }}
+          CROSS_SECRET_NAME: ${{ needs.gate.outputs.cross_secret }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CROSS_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          if [ "$OWNER" = "hivecommons" ]; then
+            echo "::error::secret ${CROSS_SECRET_NAME} is not set, so this run cannot mirror to ghcr.io/${CROSS_ORG}. Post-transfer that is a silent one-sided publish (spokes pinned to the old org keep pulling stale tags), so this fails hard. Create a classic PAT with write:packages from a ${CROSS_ORG} member and store it as ${CROSS_SECRET_NAME}."
+            exit 1
+          fi
+          echo "::warning::secret ${CROSS_SECRET_NAME} is not set — skipping the ghcr.io/${CROSS_ORG} mirror. Pre-transfer this is expected until that PAT is created; nothing that exists today degrades."
+
+      - name: Log in to GHCR as the cross-org publisher
+        if: steps.crosspat.outputs.available == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets[needs.gate.outputs.cross_secret] }}
+
+      - name: Mirror published tags into the cross-org registry (by digest)
+        if: steps.crosspat.outputs.available == 'true'
+        env:
+          NATIVE_IMAGE: ghcr.io/${{ github.repository_owner }}/hive-hub
+          CROSS_IMAGE: ghcr.io/${{ needs.gate.outputs.cross_org }}/hive-hub
+          BRANCH: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+          # Lockstep with the publish-image-tags.sh args above.
+          INCLUDE_LATEST: "true"
+          RELEASE_BRANCH: "v4"
+          CHANNELS: "stable,candidate"
+        run: |
+          set -euo pipefail
+          branch_tag="${BRANCH//\//-}"
+          tags=("${GIT_SHA:0:7}" "${branch_tag}-latest")
+          if [ "$INCLUDE_LATEST" = "true" ]; then tags+=("latest"); fi
+          if [ "$BRANCH" = "$RELEASE_BRANCH" ] && [ -n "$CHANNELS" ]; then
+            IFS=, read -ra channel_tags <<<"$CHANNELS"
+            for ch in "${channel_tags[@]}"; do [ -n "$ch" ] && tags+=("$ch"); done
+          fi
+          for tag in "${tags[@]}"; do
+            if ! digest=$(docker buildx imagetools inspect \
+                "${NATIVE_IMAGE}:${tag}" --format '{{.Manifest.Digest}}' 2>&1); then
+              if grep -Eqi 'manifest unknown|manifest.*not found|not found.*manifest|no such manifest|(^|[[:space:]:])not found$' <<<"$digest"; then
+                echo "native tag ${NATIVE_IMAGE}:${tag} does not exist — nothing to mirror for it"
+                continue
+              fi
+              echo "::error::could not inspect ${NATIVE_IMAGE}:${tag}; refusing to silently skip a mirror on a transport/auth failure" >&2
+              echo "$digest" >&2
+              exit 1
+            fi
+            echo "Mirroring ${CROSS_IMAGE}:${tag} <- ${NATIVE_IMAGE}@${digest}"
+            docker buildx imagetools create -t "${CROSS_IMAGE}:${tag}" "${NATIVE_IMAGE}@${digest}"
+          done

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -110,6 +110,15 @@ name: Tagged Release
 # images docker.yml has long since published, so it releases the accumulated
 # Unreleased section without ever tagging content the images do not contain.
 # On a healthy repo it is a no-op (Unreleased is empty => release=false).
+#
+# DUAL-PUBLISH (kubestellar -> hivecommons org transfer): during the transfer
+# window every publish targets BOTH ghcr.io/kubestellar and
+# ghcr.io/hivecommons. docker.yml's gate job carries the full
+# direction-agnostic story (native org = github.repository_owner, cross org +
+# PAT secret derived from it). In THIS workflow the native-org registry
+# references are owner-derived, and the immutable v<VERSION> tags are
+# additionally mirrored into the cross org by digest — see the cross-org
+# mirror steps in the release job below.
 on:
   workflow_run:
     workflows: ["Build and Push Docker Image"]
@@ -272,6 +281,12 @@ jobs:
     env:
       VERSION: ${{ needs.decide.outputs.version }}
       SHA: ${{ needs.decide.outputs.sha }}
+      # Dual-publish (see the DUAL-PUBLISH note in this file's header): the
+      # NATIVE org is wherever this repo lives — the only org GITHUB_TOKEN
+      # can write packages to — and the CROSS org is the other side of the
+      # kubestellar <-> hivecommons transfer, written to with a classic PAT.
+      NATIVE_ORG: ${{ github.repository_owner }}
+      CROSS_ORG: ${{ github.repository_owner == 'kubestellar' && 'hivecommons' || 'kubestellar' }}
     steps:
       - name: Checkout the commit docker.yml just built
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -330,8 +345,8 @@ jobs:
           set -euo pipefail
           short="${SHA:0:7}"
           for image in hive hive-contributor hive-hub; do
-            src="ghcr.io/kubestellar/${image}:${short}"
-            dst="ghcr.io/kubestellar/${image}:v${VERSION}"
+            src="ghcr.io/${NATIVE_ORG}/${image}:${short}"
+            dst="ghcr.io/${NATIVE_ORG}/${image}:v${VERSION}"
             echo "Tagging ${dst} from ${src}"
             docker buildx imagetools create -t "$dst" "$src"
           done
@@ -340,7 +355,7 @@ jobs:
       # release" (the operator's framing). Because this workflow retags rather
       # than rebuilds (see above), there is no fresh --version output to check
       # against the tag the way docker.yml's freshness guard checks a commit
-      # hash — the binary inside ghcr.io/kubestellar/hive:v${VERSION} was
+      # hash — the binary inside the native org's hive:v${VERSION} was
       # built by an ordinary docker.yml run that never received a VERSION
       # build-arg, so today it always reports the "0.0.0-dev" fallback (see
       # cmd/hive/main.go and src/docs/releases.md, "What still blocks cutting
@@ -353,7 +368,7 @@ jobs:
       - name: Confirm the newly tagged image runs, and report its embedded version
         run: |
           set -euo pipefail
-          img="ghcr.io/kubestellar/hive:v${VERSION}"
+          img="ghcr.io/${NATIVE_ORG}/hive:v${VERSION}"
           docker pull "$img"
           reported="$(docker run --rm --entrypoint /usr/local/bin/hive "$img" --version)"
           echo "image reports: ${reported}"
@@ -362,6 +377,72 @@ jobs:
           else
             echo "::warning::v${VERSION} is tagged but the image's --version output does not embed that string (reports: ${reported}). This is the known gap in src/docs/releases.md — the image was built by an ordinary docker.yml run with no VERSION build-arg. The GHCR TAG is still correct and immutable; only the binary's self-report is stale."
           fi
+
+      # ---- Cross-org mirror of the immutable version tags (kubestellar <->
+      # hivecommons dual-publish; docker.yml's gate job has the full
+      # direction-agnostic story). The v${VERSION} tag just created above is
+      # copied into the other org's registry BY DIGEST, so both registries'
+      # version tags are digest-identical — REUSE, NOT REBUILD, one level
+      # further out.
+      #
+      # Missing-secret asymmetry, same as docker.yml's merge jobs and on
+      # purpose: post-transfer (owner=hivecommons) a missing PAT is a hard
+      # ::error failure — a release tagged in only one registry is the
+      # dangerous one-sided publish; pre-transfer (owner=kubestellar) the PAT
+      # may simply not exist yet, the mirror is purely additive, so it is
+      # only a ::warning and the release proceeds.
+      #
+      # ORDERING: ghcr.io is ONE registry host and docker keeps one
+      # credential per host, so the cross login below REPLACES the
+      # GITHUB_TOKEN login above. Every native-registry WRITE is already done
+      # at this point; the later steps (verify pull happened above, SBOMs
+      # below) only READ the native image, which remains possible because
+      # these packages are public.
+      - name: Check cross-registry credential
+        id: crosspat
+        env:
+          # Env indirection: `if:` cannot read the secrets context. The
+          # secret NAME follows the direction of the transfer:
+          #   owner=kubestellar -> GHCR_HIVECOMMONS_PAT (writes hivecommons)
+          #   owner=hivecommons -> GHCR_KUBESTELLAR_PAT (writes kubestellar)
+          CROSS_PAT: ${{ secrets[github.repository_owner == 'kubestellar' && 'GHCR_HIVECOMMONS_PAT' || 'GHCR_KUBESTELLAR_PAT'] }}
+          CROSS_SECRET_NAME: ${{ github.repository_owner == 'kubestellar' && 'GHCR_HIVECOMMONS_PAT' || 'GHCR_KUBESTELLAR_PAT' }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CROSS_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          if [ "$OWNER" = "hivecommons" ]; then
+            echo "::error::secret ${CROSS_SECRET_NAME} is not set, so this release cannot mirror v${VERSION} to ghcr.io/${CROSS_ORG}. Post-transfer that is a silent one-sided publish, so this fails hard (the release is retried by the hourly backstop once the secret exists). Create a classic PAT with write:packages from a ${CROSS_ORG} member and store it as ${CROSS_SECRET_NAME}."
+            exit 1
+          fi
+          echo "::warning::secret ${CROSS_SECRET_NAME} is not set — v${VERSION} will exist only in ghcr.io/${NATIVE_ORG}. Pre-transfer this is expected until that PAT is created."
+
+      - name: Log in to GHCR as the cross-org publisher
+        if: steps.crosspat.outputs.available == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets[github.repository_owner == 'kubestellar' && 'GHCR_HIVECOMMONS_PAT' || 'GHCR_KUBESTELLAR_PAT'] }}
+
+      - name: Mirror immutable version tags into the cross-org registry (by digest)
+        if: steps.crosspat.outputs.available == 'true'
+        run: |
+          set -euo pipefail
+          for image in hive hive-contributor hive-hub; do
+            native="ghcr.io/${NATIVE_ORG}/${image}"
+            # The native v tag was created a few steps up in this same job,
+            # so ANY inspect failure here (including manifest unknown) is a
+            # hard error, not a skippable absence.
+            digest="$(docker buildx imagetools inspect "${native}:v${VERSION}" --format '{{.Manifest.Digest}}')"
+            dst="ghcr.io/${CROSS_ORG}/${image}:v${VERSION}"
+            echo "Mirroring ${dst} <- ${native}@${digest}"
+            docker buildx imagetools create -t "$dst" "${native}@${digest}"
+          done
 
       # NOT stable/candidate/edge. Channel promotion is deliberate, separate
       # policy (src/docs/release-channels.md) and this workflow must never
@@ -406,10 +487,16 @@ jobs:
       # package manifest is representative of both. This is recorded here
       # AND in the generated release notes rather than silently shipping one
       # file and implying full multi-arch coverage.
+      #
+      # REGISTRIES: the scans below reference the NATIVE org's v tag. That
+      # one SBOM per image covers BOTH registries: the cross-org v tag
+      # mirrored above is a by-digest copy of the very same manifest, so the
+      # two references resolve to byte-identical content and a second scan
+      # could only ever produce the same document twice.
       - name: Generate per-image SBOMs (SPDX JSON, Syft, linux/amd64)
         uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
-          image: ghcr.io/kubestellar/hive:v${{ env.VERSION }}
+          image: ghcr.io/${{ github.repository_owner }}/hive:v${{ env.VERSION }}
           output-file: hive-v${{ env.VERSION }}-sbom.spdx.json
           format: spdx-json
           artifact-name: "" # do not also attach to a GH Actions run artifact; the release upload below is the distribution point
@@ -417,7 +504,7 @@ jobs:
       - name: Generate contributor image SBOM
         uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
-          image: ghcr.io/kubestellar/hive-contributor:v${{ env.VERSION }}
+          image: ghcr.io/${{ github.repository_owner }}/hive-contributor:v${{ env.VERSION }}
           output-file: hive-contributor-v${{ env.VERSION }}-sbom.spdx.json
           format: spdx-json
           artifact-name: ""
@@ -425,7 +512,7 @@ jobs:
       - name: Generate hub image SBOM
         uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
-          image: ghcr.io/kubestellar/hive-hub:v${{ env.VERSION }}
+          image: ghcr.io/${{ github.repository_owner }}/hive-hub:v${{ env.VERSION }}
           output-file: hive-hub-v${{ env.VERSION }}-sbom.spdx.json
           format: spdx-json
           artifact-name: ""


### PR DESCRIPTION
## Migration context (P1.2)

This repo is about to be transferred from `kubestellar` to the `hivecommons` org (pluk and hotshot already moved as a system test). During the transfer window, spokes and hubs will be pinned to registry paths in **both** orgs, so every image publish must land in both `ghcr.io/kubestellar/{hive,hive-contributor,hive-hub}` and `ghcr.io/hivecommons/{same}` — regardless of which org hosts the repo at that moment.

## Design

**Direction-agnostic.** The *native* org is `github.repository_owner` — the only org the workflow's `GITHUB_TOKEN` can write packages to. Every previously hardcoded `ghcr.io/kubestellar/...` image reference in `docker.yml` and `tagged-release.yml` is now owner-derived, and `docker.yml`'s `gate` job computes the *cross* org plus the secret that can write to it, once:

| repo owner | native push (auth) | cross mirror (auth) |
|---|---|---|
| `kubestellar` (now) | `ghcr.io/kubestellar` (`GITHUB_TOKEN`) | `ghcr.io/hivecommons` (`GHCR_HIVECOMMONS_PAT`) |
| `hivecommons` (post-transfer) | `ghcr.io/hivecommons` (`GITHUB_TOKEN`) | `ghcr.io/kubestellar` (`GHCR_KUBESTELLAR_PAT`) |

So the workflows need **no edit on transfer day** — the direction flips itself.

**Digest identity, no second build.** The buildx pipeline is extended, not duplicated: the per-arch `type=image,name=...,push-by-digest=true` builds and the digest-merge jobs are untouched except for the owner-derived name. After each merge job's native `publish-image-tags.sh` call (and after `tagged-release.yml`'s native `v<VERSION>` retag), a mirror step copies each tag with `docker buildx imagetools create -t ghcr.io/<cross>/<image>:<tag> ghcr.io/<native>/<image>@<digest>` — both registries serve the byte-identical, digest-identical manifest list. The mirror copies whatever the native tag *currently* points at, so the monotonic moving-tag guard's decisions carry over: the cross org can never regress a tag the native org did not. The tag set mirrored per image is kept in lockstep with the `publish-image-tags.sh` positional args (`<sha7>`, `<branch>-latest`, `latest` where applicable, `stable`/`candidate` on v4).

**One registry host, one credential.** `ghcr.io` is a single host and docker keeps one credential per host, so the cross-org `docker/login-action` *replaces* the `GITHUB_TOKEN` login. The mirror steps are therefore ordered strictly after the last native write in each job (commented in-line).

**SBOMs.** `tagged-release.yml`'s Syft scans reference the native org's `v` tag; since the cross-org `v` tag is a by-digest copy of the same manifest, the one SBOM per image describes both registries' tags (recorded in the workflow comments).

## Secret matrix — who must create what

| Secret | What | Created by | When |
|---|---|---|---|
| `GHCR_HIVECOMMONS_PAT` | classic PAT, `write:packages` scope | a **hivecommons** owner/member with package write | set on this repo **now**, while it lives in kubestellar |
| `GHCR_KUBESTELLAR_PAT` | classic PAT, `write:packages` scope | a **kubestellar** member with package write on the three images | set **now** as well — repo secrets travel with the transfer, so it is already in place the moment the repo becomes `hivecommons/hive` |

## Loud vs. quiet skip — the asymmetry, on purpose

- **Owner = kubestellar (pre-transfer), secret absent:** `::warning` and the run stays green. The mirror is purely additive at this stage; the PAT may simply not exist yet, and nothing that exists today degrades.
- **Owner = hivecommons (post-transfer), secret absent:** `::error` and the job **fails**. A skipped mirror there is the dangerous *silent one-sided publish*: the old kubestellar registry quietly stops receiving images while every spoke still pinned to it keeps pulling stale tags forever.

**Merging this before either PAT exists is safe** — pre-transfer, missing secrets produce warnings only; native publishing is unchanged.

## Guards

`check-no-image-attestations.sh` and `check-release-lines.sh` both pass against the edited workflows (no new `build-push-action` steps; `LONG_LIVED` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FL9uphzhyBKfEXvNCmPV1D
