### PR TITLE
🐛 preserve local relay sandbox on relaunch

### DIFF
--- a/.github/workflows/podman-arm64-lane.yml
+++ b/.github/workflows/podman-arm64-lane.yml
@@ -151,7 +151,8 @@ jobs:
           cgroups="$(podman info --format '{{.Host.CgroupsVersion}}')"
           runtime="$(podman info --format '{{.Host.OCIRuntime.Name}}')"
           backend="$(podman info --format '{{.Host.NetworkBackend}}')"
-          rootlessnet="$(podman info --format '{{.Host.RootlessNetworkCmd}}')"
+          rootlessnet="$(podman info --format '{{.Host.RootlessNetworkCmd}}' 2>/dev/null || true)"
+          rootlessnet="${rootlessnet:-unreported}"
 
           printf 'podman       %s (%s)\n' "$version" "$(command -v podman)"
           printf 'arch         %s (uname %s)\n' "$arch" "$(uname -m)"

--- a/.github/workflows/podman-rootless-lane.yml
+++ b/.github/workflows/podman-rootless-lane.yml
@@ -101,7 +101,8 @@ jobs:
           rootless="$(podman info --format '{{.Host.Security.Rootless}}')"
           cgroups="$(podman info --format '{{.Host.CgroupsVersion}}')"
           backend="$(podman info --format '{{.Host.NetworkBackend}}')"
-          rootlessnet="$(podman info --format '{{.Host.RootlessNetworkCmd}}')"
+          rootlessnet="$(podman info --format '{{.Host.RootlessNetworkCmd}}' 2>/dev/null || true)"
+          rootlessnet="${rootlessnet:-unreported}"
           runtime="$(podman info --format '{{.Host.OCIRuntime.Name}}')"
 
           printf 'podman      %s (%s)\n' "$version" "$(command -v podman)"

--- a/Justfile
+++ b/Justfile
@@ -1131,9 +1131,10 @@ contribute-hive backend="" mode="docker": check-version
       # costs nothing and keeps the default blast radius off the user's home.
       export HIVE_AGENT_CWD="${XDG_STATE_HOME:-${HOME}/.local/state}/hive/agent-cwd"
       mkdir -p "$HIVE_AGENT_CWD"
+      export AGENT_LAUNCH_CMD="${LITELLM_ENV:+$LITELLM_ENV }$CMD${PERM_FLAG:+ $PERM_FLAG}"
       tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
       tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50 -c "$HIVE_WORKSPACE_DIR"
-      tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$HIVE_AGENT_CWD") && ${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
+      tmux send-keys -t "$TMUX_SESSION" "cd $(printf %q "$HIVE_AGENT_CWD") && $AGENT_LAUNCH_CMD" Enter
 
       # Surface a poisoned tmux server rather than letting the backend die a
       # silent, unexplained death 30 seconds into its first task.

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -76,6 +76,10 @@ const AGENT_SESSION = (process.env.HIVE_SESSION !== undefined
 // the cwd on relaunch; see launchCommandWithCwd for why the relay's own cwd is
 // the wrong answer in local mode.
 const AGENT_CWD = (process.env.HIVE_AGENT_CWD || '').trim();
+// AGENT_LAUNCH_CMD is the launch line resolved by the entrypoint that started
+// the pane. Local mode uses stricter sandbox flags than container mode; a relay
+// restart must reuse that exact posture instead of deriving container defaults.
+const ENTRYPOINT_LAUNCH_CMD = (process.env.AGENT_LAUNCH_CMD || '').trim();
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
 // Where the hub-delivered, task-scoped token is written (injectGhToken). This
 // deliberately does NOT default to /var/run/hive-metrics/gh-app-token.cache:
@@ -692,10 +696,10 @@ const AGY_EFFORTS = ['low', 'medium', 'high'];
 const agyEffort = AGY_EFFORTS.includes(REASONING_EFFORT) ? REASONING_EFFORT : AGY_DEFAULT_EFFORT;
 
 // Single source of truth for the CLI launch command (issue #2203, bug 1).
-// contributor-agent.sh builds "$CMD $PERM_FLAG $MODEL_FLAG" for the FIRST
-// launch; every restart path in this file previously rebuilt only "$CMD $PERM"
-// inline, silently dropping the resolved model for the rest of the container's
-// life. Build it once here and reuse it everywhere so the paths cannot drift.
+// The entrypoint may export AGENT_LAUNCH_CMD with the exact command used for
+// the FIRST launch. Prefer it so local mode keeps its sandbox/allowlist posture
+// across restarts instead of rebuilding the more-permissive container default
+// (#5652). Older entrypoints fall back to resolving backend flags here.
 let cachedLaunchCommand = null;
 let cachedBackendResolution = null;
 
@@ -969,6 +973,10 @@ function progressModelFields() {
 
 function buildLaunchCommand() {
   if (cachedLaunchCommand) return cachedLaunchCommand;
+  if (ENTRYPOINT_LAUNCH_CMD) {
+    cachedLaunchCommand = ENTRYPOINT_LAUNCH_CMD;
+    return cachedLaunchCommand;
+  }
   const { cmd, perm } = resolveBackend();
   const modelFlag = modelFlagFor();
   const reasoningFlag = BACKEND === 'codex' && REASONING_EFFORT

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -270,6 +270,29 @@ test('bob never receives --model even when AGENT_MODEL is set', () => {
   } finally { teardown(relay); }
 });
 
+test('#5652 relaunch reuses the entrypoint launch command instead of container defaults', () => {
+  for (const [backend, launch] of [
+    ['claude', 'claude --permission-mode dontAsk --settings {sandbox:true} --add-dir /home/me/workspace'],
+    ['copilot', 'copilot --sandbox --add-dir /home/me/workspace'],
+    ['opencode', 'opencode run --permission.bash=deny-host-state'],
+  ]) {
+    const relay = loadRelay({
+      backend,
+      backendPerm: '--dangerously-skip-permissions --permission-mode bypassPermissions',
+      env: { AGENT_LAUNCH_CMD: launch },
+    });
+    try {
+      assert.strictEqual(relay.buildLaunchCommand(), launch,
+        `${backend} relaunch must preserve the original local-mode posture`);
+      relay.relaunchCLI();
+      const sent = relay.__tmuxSends().find(c => c.includes(launch));
+      assert.ok(sent, `${backend} relaunch did not send the entrypoint command to tmux`);
+      assert.ok(!sent.includes('bypassPermissions'),
+        `${backend} relaunch fell back to the container posture: ${sent}`);
+    } finally { teardown(relay); }
+  }
+});
+
 // --- agy pane classification: stale narration must not pin WORKING ---------
 //
 // Verbatim shape of a real wedged pane (kubestellar/hive): agy had finished the

--- a/changelog.d/fixed-5652-local-relaunch-sandbox.md
+++ b/changelog.d/fixed-5652-local-relaunch-sandbox.md
@@ -1,0 +1,1 @@
+- Contributor local-mode relay relaunches now preserve the original sandboxed launch command instead of rebuilding permissive container flags.

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -136,6 +136,9 @@ file edits may write only to `HIVE_AGENT_CWD` and `HIVE_WORKSPACE_DIR`.
 Network domains are unrestricted because assigned third-party repositories
 must be able to fetch arbitrary test/build dependencies; this is write
 confinement, not a claim that the process can read or exfiltrate nothing.
+The local launcher exports the resolved `AGENT_LAUNCH_CMD`, and the relay reuses
+that exact command for post-task, revoke, and recovery relaunches so the
+stricter host-mode sandbox flags cannot drift back to container defaults.
 
 On Linux/WSL2 the native sandbox requires `bubblewrap` and `socat`; macOS uses
 Seatbelt. Missing dependencies are a hard launch failure, never a silent

--- a/src/pkg/dashboard/contribute_pane_cwd_test.go
+++ b/src/pkg/dashboard/contribute_pane_cwd_test.go
@@ -83,13 +83,13 @@ func requireCdBeforeCmd(t *testing.T, block, label string) {
 	t.Helper()
 	sendKeys := ""
 	for _, line := range strings.Split(block, "\n") {
-		if strings.Contains(line, "send-keys") && strings.Contains(line, "$CMD") {
+		if strings.Contains(line, "send-keys") && (strings.Contains(line, "$CMD") || strings.Contains(line, "$AGENT_LAUNCH_CMD")) {
 			sendKeys = line
 			break
 		}
 	}
 	if sendKeys == "" {
-		t.Fatalf("%s: no send-keys line launching $CMD found in the block", label)
+		t.Fatalf("%s: no send-keys line launching the CLI found in the block", label)
 	}
 	if !strings.Contains(sendKeys, "cd ") {
 		t.Errorf("%s: the CLI launch must cd into a durable directory first — a tmux server can hand the pane a "+
@@ -146,5 +146,18 @@ func TestContributorAgentPinsPaneWorkingDirectory(t *testing.T) {
 	// Defense in depth, correct on a healthy server (but not sufficient alone).
 	if !strings.Contains(block, "new-session") || !strings.Contains(block, "-c ") {
 		t.Error("new-session should also pass -c so a healthy server starts the pane in the right directory")
+	}
+}
+
+func TestContributeHiveExportsLaunchCommandForRelayRelaunch(t *testing.T) {
+	block := contributeHiveLaunchBlock(t)
+	if !strings.Contains(block, "export AGENT_LAUNCH_CMD=") {
+		t.Fatal("local contribute-hive must export the exact launch command for contributor-relay.sh relaunches")
+	}
+	if !strings.Contains(block, "$AGENT_LAUNCH_CMD") {
+		t.Fatal("the first local launch must use the same AGENT_LAUNCH_CMD value the relay will reuse")
+	}
+	if !strings.Contains(block, "PERM_FLAG") || !strings.Contains(block, "LITELLM_ENV") {
+		t.Fatal("AGENT_LAUNCH_CMD must include the resolved permission flags and backend environment prefix")
 	}
 }


### PR DESCRIPTION
Fixes #5652

Validation:
- node --test bin/contributor-relay.test.js
- cd src && go test ./pkg/dashboard -run 'TestContributeHiveExportsLaunchCommandForRelayRelaunch|TestContributeHivePinsPaneWorkingDirectory|TestContributorAgentPinsPaneWorkingDirectory'\n- cd src && go build ./...