### PR TITLE
🐛 fix: retry NOTICE go-licenses install on v5

### DIFF
--- a/changelog.d/fixed-5716-notice-install-retry.md
+++ b/changelog.d/fixed-5716-notice-install-retry.md
@@ -1,0 +1,1 @@
+- NOTICE regeneration now retries the pinned `go-licenses` install before failing, so transient checksum database stream errors no longer fail the attribution gate without a code or module change ([#5716](https://github.com/kubestellar/hive/issues/5716)).

--- a/src/scripts/generate-notice.sh
+++ b/src/scripts/generate-notice.sh
@@ -78,8 +78,26 @@ if ! command -v go >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "Installing go-licenses@${GO_LICENSES_VERSION} (pinned)..." >&2
-go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
+install_go_licenses() {
+  local attempt max_attempts sleep_seconds
+  max_attempts=3
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    echo "Installing go-licenses@${GO_LICENSES_VERSION} (pinned), attempt ${attempt}/${max_attempts}..." >&2
+    if go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"; then
+      return 0
+    fi
+    if (( attempt == max_attempts )); then
+      break
+    fi
+    sleep_seconds=$((attempt * 5))
+    echo "go-licenses install failed; retrying in ${sleep_seconds}s..." >&2
+    sleep "${sleep_seconds}"
+  done
+  echo "generate-notice.sh: failed to install go-licenses@${GO_LICENSES_VERSION} after ${max_attempts} attempts" >&2
+  return 1
+}
+
+install_go_licenses
 
 GOBIN="$(go env GOPATH)/bin"
 GO_LICENSES_BIN="${GOBIN}/go-licenses"


### PR DESCRIPTION
Fixes #5716