### PR TITLE
✨ feature: adopt dashboard branding override

### DIFF
--- a/changelog.d/added-5690-dashboard-branding.md
+++ b/changelog.d/added-5690-dashboard-branding.md
@@ -1,0 +1,1 @@
+- The dashboard can now carry operator branding through configurable product strings, colors, and an optional custom stylesheet ([#5690](https://github.com/kubestellar/hive/pull/5690)). A deployment can override the visible title/brand without patching the bundled UI, while the default experience remains unchanged when no branding config is supplied.

--- a/src/docs/branding.md
+++ b/src/docs/branding.md
@@ -1,0 +1,114 @@
+# Branding a hive
+
+A deployment can carry its own name, mark and colours without forking the
+dashboard or rebuilding the image. Two files on the data volume:
+
+```
+<data>/branding/
+├── branding.json   # strings: name, tagline, mark, title
+└── custom.css      # colours
+```
+
+Both are optional. A missing file changes nothing; a partial `branding.json`
+leaves every field it omits at the shipped default.
+
+## Strings
+
+```json
+{
+  "product_name": "REEF",
+  "tagline":      "APPLICATIONS",
+  "mark":         "🪸",
+  "title":        "Reef — tuna-os"
+}
+```
+
+| Field | Replaces |
+|---|---|
+| `product_name` | the `HIVE` wordmark in the sidebar |
+| `tagline` | `GATEWAY DASHBOARD` beneath it |
+| `mark` | the 🐝 glyph — both sidebars, the `<h1>`, the Getting Started flyer, **and the favicon** |
+| `title` | the `<title>` |
+
+Substitution is **anchored to the exact markup** that renders each item, never
+a bare string replace: the document is ~1.3 MB of inline HTML/CSS/JS, and
+replacing every `HIVE` or `🐝` would corrupt script and prose. A consequence
+worth knowing: if that markup changes upstream, branding silently stops
+applying rather than breaking the page.
+
+> **Strings are read once at startup.** The index document carries a
+> precomputed gzip body and a strong ETag, so its content cannot vary per
+> request without discarding both. **Editing `branding.json` needs a restart.**
+> `custom.css` is read per request and takes effect on reload.
+
+## Colours
+
+`custom.css` is served at `/branding/custom.css` and linked last in `<head>`,
+so it wins the cascade without `!important`.
+
+Restyle **custom properties**, not layout. The dashboard is one embedded SPA
+whose markup changes between releases; re-pointing tokens survives upgrades,
+restyling structure does not.
+
+```css
+/* Dark — :root carries the DARK palette */
+:root {
+  --bg: #04161f;  --bg-soft: #07202b;  --surface: #0a2430;
+  --panel: #0a2430;  --panel-strong: #0d2c3a;  --card-bg: #0a2430;
+  --line: #12394a;  --line-strong: #1b4d63;  --border: #12394a;
+  --fg: #e8f6f8;  --text: #e8f6f8;  --muted: #8fb3bd;
+  --accent: #2fb6c4;
+}
+
+/* Light — body.light-mode OVERRIDES :root. Style both, or your theme
+   silently does nothing whenever the operator is in light mode. */
+body.light-mode {
+  --bg: #f2f9fa;  --surface: #ffffff;  --panel: #ffffff;
+  --line: #cbdfe5;  --fg: #06232e;  --text: #06232e;  --muted: #4d7683;
+  --accent: #10707c;   /* darker: the dark-mode cyan is ~2.2:1 on white */
+}
+```
+
+Two things that cost us time:
+
+- **Style both themes.** Overriding only `:root` is discarded in light mode.
+- **Re-check contrast per theme.** An accent tuned for a dark surface usually
+  fails as text on a light one.
+
+Available tokens: `--bg` `--bg-soft` `--surface` `--panel` `--panel-strong`
+`--card-bg` `--terminal-bg` `--line` `--line-strong` `--border` `--fg` `--text`
+`--muted` `--accent` `--oc-accent` and a named ramp (`--green` `--red`
+`--orange` `--amber` `--yellow` `--blue` `--cyan` `--indigo` `--purple`, each
+with `-bg`/`-border` variants where used).
+
+Keep **status** colours distinct from your accent — a green that matches the
+brand hue stops reading as "healthy" and starts reading as "branded".
+
+## What is not overridable
+
+- The `KubeStellar Hive Dashboard` text in the `<h1>` (only its emoji is a
+  span).
+- The honeycomb SVG in the Getting Started flyer — it is drawn as paths, not a
+  glyph. Hide it with `.wb-hive { display: none }` if it clashes.
+- Anything rendered by the SPA at runtime rather than present in the shipped
+  document.
+
+## Branding a hub
+
+A hub (`HIVE_MODE=hub`) serves its own UI from the same binary, so the same two
+files apply.
+
+If you want a fully custom landing page, an alternative is to route `/` to your
+own static page at the ingress and keep `/api` on the hub — spoke heartbeats
+and `/api/registry` must keep reaching it, so route by path rather than
+replacing the Service.
+
+## Verifying
+
+Check the **computed** style, not that the file downloaded — a stylesheet that
+loads and applies nothing looks identical to a working one over `curl`:
+
+```js
+getComputedStyle(document.body).backgroundColor
+getComputedStyle(document.documentElement).getPropertyValue('--accent')
+```

--- a/src/pkg/dashboard/branding.go
+++ b/src/pkg/dashboard/branding.go
@@ -1,0 +1,43 @@
+package dashboard
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// brandingCSSPath returns where an operator's override stylesheet lives.
+//
+// Derived from AgentsDir's parent rather than a config field of its own:
+// DataConfig has no single "root", but every deployment already places
+// agents_dir on the persistent data volume, so its parent is that volume.
+// HIVE_BRANDING_CSS overrides it outright for anything unusual. Living on the
+// data volume means the override survives image upgrades and pod restarts.
+func (s *Server) brandingCSSPath() string {
+	if p := os.Getenv("HIVE_BRANDING_CSS"); p != "" {
+		return p
+	}
+	dir := "/data"
+	if s.deps != nil && s.deps.Config != nil && s.deps.Config.Data.AgentsDir != "" {
+		dir = filepath.Dir(s.deps.Config.Data.AgentsDir)
+	}
+	return filepath.Join(dir, "branding", "custom.css")
+}
+
+// handleBrandingCSS serves the operator's override stylesheet, or 404s when
+// there is none. The index document links to this path unconditionally, so a
+// missing file is the normal case and must be cheap and quiet.
+func (s *Server) handleBrandingCSS(w http.ResponseWriter, r *http.Request) {
+	path := s.brandingCSSPath()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	// Never let a stale override outlive an edit: this is an operator-facing
+	// customisation knob, not a hot asset, so correctness beats caching.
+	w.Header().Set("Content-Type", "text/css; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = w.Write(b)
+}

--- a/src/pkg/dashboard/branding.go
+++ b/src/pkg/dashboard/branding.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -40,4 +42,88 @@ func (s *Server) handleBrandingCSS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	_, _ = w.Write(b)
+}
+
+// Branding holds the operator-overridable strings baked into the served index
+// document. Every field is optional; an empty field leaves the shipped default
+// alone, so a partial file is valid and a missing file changes nothing.
+type Branding struct {
+	// ProductName replaces the "HIVE" wordmark in the sidebar.
+	ProductName string `json:"product_name"`
+	// Tagline replaces "GATEWAY DASHBOARD" beneath it.
+	Tagline string `json:"tagline"`
+	// Mark replaces the 🐝 glyph — in both sidebars, the <h1>, and the
+	// favicon, which is an inline SVG data: URI wrapping the same character.
+	Mark string `json:"mark"`
+	// Title replaces the <title> and og:title text.
+	Title string `json:"title"`
+}
+
+// brandingJSONPath is the strings file, beside custom.css on the data volume.
+func (s *Server) brandingJSONPath() string {
+	if p := os.Getenv("HIVE_BRANDING_JSON"); p != "" {
+		return p
+	}
+	return filepath.Join(filepath.Dir(s.brandingCSSPath()), "branding.json")
+}
+
+// loadBranding reads the strings file. A missing or malformed file yields the
+// zero value, which is a no-op — branding must never be able to break startup.
+func (s *Server) loadBranding() Branding {
+	var b Branding
+	raw, err := os.ReadFile(s.brandingJSONPath())
+	if err != nil {
+		return b
+	}
+	if err := json.Unmarshal(raw, &b); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("branding.json is not valid JSON; ignoring", "path", s.brandingJSONPath(), "error", err)
+		}
+		return Branding{}
+	}
+	return b
+}
+
+// applyBranding rewrites the shipped defaults in the index document.
+//
+// Substitution is ANCHORED TO EXACT MARKUP, never a bare string replace: the
+// document is ~1.3 MB of inline HTML/CSS/JS and a loose replace of "HIVE" or
+// "🐝" would corrupt unrelated script and prose. Each anchor below is the
+// literal element that renders the thing being replaced, so a miss is a no-op
+// rather than a mangled page — and if upstream markup changes, branding
+// silently stops applying instead of breaking the dashboard.
+func applyBranding(raw []byte, b Branding) []byte {
+	repl := func(in []byte, old, new string) []byte {
+		if new == "" || old == "" || !bytes.Contains(in, []byte(old)) {
+			return in
+		}
+		return bytes.ReplaceAll(in, []byte(old), []byte(new))
+	}
+
+	if b.Mark != "" {
+		raw = repl(raw, `<span class="oc-logo-icon">🐝</span>`,
+			`<span class="oc-logo-icon">`+b.Mark+`</span>`)
+		raw = repl(raw, `<span class="bee">🐝</span>`,
+			`<span class="bee">`+b.Mark+`</span>`)
+		// The Getting Started flyer writes its bee as an HTML ENTITY, not the
+		// literal glyph — anchoring only on the emoji misses it and leaves a
+		// bee animating on an otherwise rebranded page.
+		raw = repl(raw, `<span class="wb-bee">&#x1F41D;</span>`,
+			`<span class="wb-bee">`+b.Mark+`</span>`)
+		// The favicon is an SVG data: URI with the same glyph inside a <text>.
+		raw = repl(raw, `<text y='.9em' font-size='90'>🐝</text>`,
+			`<text y='.9em' font-size='90'>`+b.Mark+`</text>`)
+	}
+	if b.ProductName != "" {
+		raw = repl(raw, `<div class="oc-logo-title">HIVE</div>`,
+			`<div class="oc-logo-title">`+b.ProductName+`</div>`)
+	}
+	if b.Tagline != "" {
+		raw = repl(raw, `<div class="oc-logo-sub">GATEWAY DASHBOARD</div>`,
+			`<div class="oc-logo-sub">`+b.Tagline+`</div>`)
+	}
+	if b.Title != "" {
+		raw = repl(raw, `<title>Hive Dashboard</title>`, `<title>`+b.Title+`</title>`)
+	}
+	return raw
 }

--- a/src/pkg/dashboard/branding_test.go
+++ b/src/pkg/dashboard/branding_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -60,7 +61,7 @@ func TestBrandingCSSServedWhenPresentAnd404WhenNot(t *testing.T) {
 // Testing injectBranding() alone passes even if newIndexDocument never calls
 // it, so this goes through the real document builder and the real handler.
 func TestServedIndexCarriesBrandingLink(t *testing.T) {
-	doc := newIndexDocument([]byte("<html><head><title>hive</title></head><body></body></html>"))
+	doc := newIndexDocument([]byte("<html><head><title>hive</title></head><body></body></html>"), Branding{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Accept-Encoding", "identity") // want the plain body to assert on
@@ -72,5 +73,67 @@ func TestServedIndexCarriesBrandingLink(t *testing.T) {
 	}
 	if !bytes.Contains(w.Body.Bytes(), []byte(brandingLinkTag)) {
 		t.Errorf("served index is missing the branding link — newIndexDocument is not injecting it:\n%s", w.Body.String())
+	}
+}
+
+// A miniature of the shipped document: every anchor applyBranding targets,
+// plus a bare "HIVE" inside a <script> that must NOT be touched.
+const sampleIndex = `<html><head><title>Hive Dashboard</title>` +
+	`<link rel="icon" href="data:image/svg+xml,<svg><text y='.9em' font-size='90'>🐝</text></svg>">` +
+	`</head><body><span class="oc-logo-icon">🐝</span>` +
+	`<div class="oc-logo-title">HIVE</div>` +
+	`<div class="oc-logo-sub">GATEWAY DASHBOARD</div>` +
+	`<h1><span class="bee">🐝</span> KubeStellar Hive Dashboard</h1>` +
+	`<span class="wb-bee">&#x1F41D;</span>` +
+	`<script>const s="HIVE appears in script too";</script></body></html>`
+
+func TestApplyBrandingReplacesEveryDefault(t *testing.T) {
+	out := string(applyBranding([]byte(sampleIndex), Branding{
+		ProductName: "REEF", Tagline: "APPLICATIONS", Mark: "🪸", Title: "Reef",
+	}))
+	for _, want := range []string{
+		`<span class="oc-logo-icon">🪸</span>`,
+		`<div class="oc-logo-title">REEF</div>`,
+		`<div class="oc-logo-sub">APPLICATIONS</div>`,
+		`<span class="bee">🪸</span>`,
+		`<span class="wb-bee">🪸</span>`,          // entity form, not the glyph
+		`<text y='.9em' font-size='90'>🪸</text>`, // favicon
+		`<title>Reef</title>`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	// Substitution is anchored to markup; a loose replace would corrupt this.
+	if !strings.Contains(out, `"HIVE appears in script too"`) {
+		t.Error("unanchored replacement corrupted script content")
+	}
+}
+
+// An empty field leaves the shipped default alone, so a partial branding.json
+// is valid and a missing file changes nothing at all.
+func TestApplyBrandingPartialAndEmpty(t *testing.T) {
+	if got := string(applyBranding([]byte(sampleIndex), Branding{})); got != sampleIndex {
+		t.Error("empty Branding modified the document")
+	}
+	out := string(applyBranding([]byte(sampleIndex), Branding{ProductName: "SCHOOL"}))
+	if !strings.Contains(out, `<div class="oc-logo-title">SCHOOL</div>`) {
+		t.Error("product name not applied")
+	}
+	if !strings.Contains(out, `<div class="oc-logo-sub">GATEWAY DASHBOARD</div>`) {
+		t.Error("unset tagline should have been left alone")
+	}
+}
+
+// Through the real document builder and handler, so this fails if the wiring
+// is removed even though applyBranding itself still works.
+func TestServedIndexCarriesBrandingStrings(t *testing.T) {
+	doc := newIndexDocument([]byte(sampleIndex), Branding{ProductName: "SCHOOL"})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "identity")
+	w := httptest.NewRecorder()
+	doc.ServeHTTP(w, req)
+	if !strings.Contains(w.Body.String(), `<div class="oc-logo-title">SCHOOL</div>`) {
+		t.Error("served index does not carry the overridden wordmark")
 	}
 }

--- a/src/pkg/dashboard/branding_test.go
+++ b/src/pkg/dashboard/branding_test.go
@@ -1,0 +1,76 @@
+package dashboard
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInjectBrandingPlacesLinkBeforeHeadClose(t *testing.T) {
+	got := injectBranding([]byte("<html><head><title>x</title></head><body>b</body></html>"))
+	if !bytes.Contains(got, []byte(brandingLinkTag)) {
+		t.Fatalf("override link not injected: %s", got)
+	}
+	// It must be LAST in head, or the embedded document's own styles win.
+	if bytes.Index(got, []byte(brandingLinkTag)) > bytes.Index(got, []byte("</head>")) {
+		t.Error("override link injected after </head>; it would not win the cascade")
+	}
+}
+
+// A document with no </head> must be returned untouched rather than corrupted.
+func TestInjectBrandingNoHeadIsInert(t *testing.T) {
+	in := []byte("not really html")
+	if got := injectBranding(in); !bytes.Equal(got, in) {
+		t.Errorf("document without </head> was modified: %s", got)
+	}
+}
+
+func TestBrandingCSSServedWhenPresentAnd404WhenNot(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HIVE_BRANDING_CSS", filepath.Join(dir, "custom.css"))
+	s := &Server{}
+
+	// Absent: the index links to this path unconditionally, so a missing
+	// override is the NORMAL case and must 404 quietly, not error.
+	w := httptest.NewRecorder()
+	s.handleBrandingCSS(w, httptest.NewRequest(http.MethodGet, "/branding/custom.css", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("missing override: got %d, want 404", w.Code)
+	}
+
+	// Present: served as CSS.
+	css := ":root{--accent:#0aa}"
+	if err := os.WriteFile(filepath.Join(dir, "custom.css"), []byte(css), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w = httptest.NewRecorder()
+	s.handleBrandingCSS(w, httptest.NewRequest(http.MethodGet, "/branding/custom.css", nil))
+	if w.Code != http.StatusOK || w.Body.String() != css {
+		t.Errorf("got %d %q, want 200 %q", w.Code, w.Body.String(), css)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/css; charset=utf-8" {
+		t.Errorf("Content-Type = %q", ct)
+	}
+}
+
+// The one that matters: the SERVED document must carry the override link.
+// Testing injectBranding() alone passes even if newIndexDocument never calls
+// it, so this goes through the real document builder and the real handler.
+func TestServedIndexCarriesBrandingLink(t *testing.T) {
+	doc := newIndexDocument([]byte("<html><head><title>hive</title></head><body></body></html>"))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept-Encoding", "identity") // want the plain body to assert on
+	w := httptest.NewRecorder()
+	doc.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(brandingLinkTag)) {
+		t.Errorf("served index is missing the branding link — newIndexDocument is not injecting it:\n%s", w.Body.String())
+	}
+}

--- a/src/pkg/dashboard/csp_script_src.go
+++ b/src/pkg/dashboard/csp_script_src.go
@@ -106,6 +106,9 @@ func scriptSrcElemSources(doc []byte) string {
 var (
 	baseScriptSrcElemOnce    sync.Once
 	baseScriptSrcElemSources string
+
+	brandedIndexMu sync.RWMutex
+	brandedIndex   []byte
 )
 
 // baseScriptSrcElem returns the startup-computed script-src-elem source list
@@ -114,10 +117,37 @@ var (
 // static_index.go and the plain file server) and the device-flow login page
 // (a const, served to any unauthenticated browser path). Computed once, like
 // the #3863 gzip/ETag precomputation it must stay compatible with.
+// setBrandedIndex records the index document AS SERVED, so CSP hashes are
+// computed over the same bytes the browser receives.
+//
+// This matters because branding can rewrite inline SCRIPT content, not just
+// markup: the Getting Started flyer builds its DOM from a JavaScript string
+// literal that contains `<span class="wb-bee">&#x1F41D;</span>`. Replacing the
+// mark there changes a script's bytes, and hashes taken from the embedded
+// document would no longer authorise it — CSP would block the flyer on a
+// branded hive. Must be called before the first request is served.
+func setBrandedIndex(doc []byte) {
+	brandedIndexMu.Lock()
+	brandedIndex = append([]byte(nil), doc...)
+	// Invalidate any previously memoised source list. baseScriptSrcElem uses a
+	// sync.Once, so without this the hashes depend on whether anything happened
+	// to ask for them before the document was built — in production Start()
+	// builds it before serving, but that is an ordering assumption rather than
+	// a guarantee, and it is exactly the kind of thing that works until it
+	// silently does not. Safe because this runs at startup, before any request.
+	baseScriptSrcElemOnce = sync.Once{}
+	brandedIndexMu.Unlock()
+}
+
 func baseScriptSrcElem() string {
 	baseScriptSrcElemOnce.Do(func() {
 		var docs []byte
-		if raw, err := fs.ReadFile(staticFS, "static/index.html"); err == nil {
+		brandedIndexMu.RLock()
+		branded := brandedIndex
+		brandedIndexMu.RUnlock()
+		if len(branded) > 0 {
+			docs = append(docs, branded...)
+		} else if raw, err := fs.ReadFile(staticFS, "static/index.html"); err == nil {
 			docs = append(docs, raw...)
 		}
 		docs = append(docs, []byte(loginPage)...)

--- a/src/pkg/dashboard/csp_script_src_test.go
+++ b/src/pkg/dashboard/csp_script_src_test.go
@@ -154,7 +154,7 @@ func TestEmbeddedIndexScriptsSatisfyCSPHashes(t *testing.T) {
 	}
 
 	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
-	handler := s.securityHeaders(newIndexDocument(raw))
+	handler := s.securityHeaders(newIndexDocument(raw, Branding{}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Accept-Encoding", "gzip")
@@ -184,8 +184,18 @@ func TestEmbeddedIndexScriptsSatisfyCSPHashes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decompressing body: %v", err)
 	}
-	if string(body) != string(raw) {
-		t.Fatal("served SPA bytes differ from the embedded document — startup hashes would not match")
+	// The invariant is that hashes describe the SERVED bytes — not that the
+	// served bytes equal the embed. Branding may legitimately rewrite the
+	// document (including inline script content, e.g. the Getting Started
+	// flyer builds DOM from a string literal containing the bee mark), so the
+	// CSP layer hashes the served document. Assert the real property: every
+	// inline script in the served body is authorised by the header.
+	served := scriptSrcElemSources(body)
+	for _, sc := range extractInlineScripts(body) {
+		if h := cspScriptHash(sc); !strings.Contains(served, h) {
+			t.Fatalf("served inline script is not covered by a CSP hash (%s) — "+
+				"the browser would block it", h)
+		}
 	}
 
 	// POSITIVE CONTROL + COUNT FLOOR: the document still contains its scripts.

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -973,7 +973,17 @@ func (s *Server) Start() error {
 	// on every visit. "/{$}" matches the root path exactly; every other static
 	// path falls through to the plain file server below.
 	if rawIndex, err := fs.ReadFile(staticContent, "index.html"); err == nil {
-		idx := newIndexDocument(rawIndex)
+		// Strings are baked in ONCE here, unlike custom.css which is read per
+		// request: the document carries a precomputed gzip body and a strong
+		// ETag, so its content cannot vary per request without discarding both.
+		// Editing branding.json therefore needs a restart; editing the
+		// stylesheet does not. That asymmetry is documented in branding.md.
+		idx := newIndexDocument(rawIndex, s.loadBranding())
+		// Hand the FINAL served bytes to the CSP layer explicitly, rather than
+		// having newIndexDocument reach out and set global state: constructing a
+		// document should not silently change the process-wide CSP, and a test
+		// building a throwaway document must not shrink the real allowlist.
+		setBrandedIndex(idx.raw)
 		s.mux.Handle("GET /{$}", idx)
 		s.mux.Handle("GET /index.html", idx)
 	} else {

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -979,6 +979,16 @@ func (s *Server) Start() error {
 	} else {
 		s.logger.Warn("embedded index.html unavailable; falling back to plain file serving", "error", err)
 	}
+	// Operator branding override: an optional stylesheet on the data volume,
+	// served at the path the index document links to. Lets a deployment carry
+	// its own colours/logo without forking the embedded SPA or rebuilding the
+	// image — the override is data, not code.
+	//
+	// Read per request (not cached at startup) so dropping a file in takes
+	// effect on reload. It is a single small stylesheet on local disk; the
+	// index document itself remains startup-precompressed.
+	s.mux.HandleFunc("GET /branding/custom.css", s.handleBrandingCSS)
+
 	s.mux.Handle("GET /", http.FileServer(http.FS(staticContent)))
 
 	// authenticate is outermost so the identity headers it injects from a

--- a/src/pkg/dashboard/static_index.go
+++ b/src/pkg/dashboard/static_index.go
@@ -65,7 +65,8 @@ func injectBranding(raw []byte) []byte {
 	return out
 }
 
-func newIndexDocument(raw []byte) *indexDocument {
+func newIndexDocument(raw []byte, b Branding) *indexDocument {
+	raw = applyBranding(raw, b)
 	raw = injectBranding(raw)
 	sum := sha256.Sum256(raw)
 	// 16 hex bytes of the digest is plenty for cache validation and keeps the

--- a/src/pkg/dashboard/static_index.go
+++ b/src/pkg/dashboard/static_index.go
@@ -19,6 +19,7 @@ import (
 //   - no Content-Encoding (Go's file server never compresses),
 //   - no ETag, and
 //   - no Last-Modified (embed.FS files have a zero ModTime),
+//
 // so every dashboard visit re-downloaded the full 1.3 MB uncompressed. None of
 // the fleet's edges compress on our behalf (ingress-nginx ships with gzip off,
 // the OpenShift HAProxy router never compresses), so the spoke process is the
@@ -37,7 +38,35 @@ type indexDocument struct {
 	etag    string
 }
 
+// brandingLinkTag is injected into the served index document so an operator
+// can restyle the dashboard without forking the embedded SPA.
+//
+// It is injected UNCONDITIONALLY, not "only when the file exists": the index
+// document is built once at startup with a precomputed gzip body and a strong
+// ETag, so making its content depend on a file that can appear later would
+// mean either rebuilding it per request or serving a stale page forever. An
+// absent override simply 404s, and a 404'd stylesheet is inert.
+const brandingLinkTag = `<link rel="stylesheet" href="/branding/custom.css">`
+
+// injectBranding places the override link immediately before </head> so it
+// wins the cascade against everything the embedded document defines. Falls
+// back to returning the document untouched if there is no </head> to anchor
+// to, rather than corrupting the markup.
+func injectBranding(raw []byte) []byte {
+	marker := []byte("</head>")
+	i := bytes.Index(raw, marker)
+	if i < 0 {
+		return raw
+	}
+	out := make([]byte, 0, len(raw)+len(brandingLinkTag))
+	out = append(out, raw[:i]...)
+	out = append(out, []byte(brandingLinkTag)...)
+	out = append(out, raw[i:]...)
+	return out
+}
+
 func newIndexDocument(raw []byte) *indexDocument {
+	raw = injectBranding(raw)
 	sum := sha256.Sum256(raw)
 	// 16 hex bytes of the digest is plenty for cache validation and keeps the
 	// header short; the quotes are part of the ETag grammar (RFC 9110 §8.8.3).

--- a/src/pkg/dashboard/static_index_test.go
+++ b/src/pkg/dashboard/static_index_test.go
@@ -17,7 +17,7 @@ var testIndexBody = []byte("<!DOCTYPE html><html>" + strings.Repeat("<div>hive d
 
 func newTestIndex(t *testing.T) *indexDocument {
 	t.Helper()
-	d := newIndexDocument(testIndexBody)
+	d := newIndexDocument(testIndexBody, Branding{})
 	if d.gzipped == nil {
 		t.Fatal("gzip precompression failed for test body")
 	}


### PR DESCRIPTION
Adopts hanthor's #5690 from the fork so the queue can drain after maintainer pushes to the fork were rejected.\n\nThis preserves hanthor's authored commits and adds only the required changelog fragment.\n\nValidation:\n- cd src && go build ./...\n- cd src && go test ./pkg/dashboard -run 'Test(InjectBranding|BrandingCSS|ServedIndexCarriesBranding|CSP)'\n\nCredits: original implementation by @hanthor in #5690.