### PR TITLE
🌱 refactor: share operation journal identity derivation

### DIFF
--- a/changelog.d/changed-5624-canonical-operation-id.md
+++ b/changelog.d/changed-5624-canonical-operation-id.md
@@ -1,0 +1,1 @@
+- Operation idempotency keys now use `pkg/convergence/mutation` as the canonical derivation point, leaving `pkg/turn`'s duplicate journal as a deprecated compatibility wrapper while the unwired turn prototype migrates.

--- a/src/docs/design/agent-turn-handoff.md
+++ b/src/docs/design/agent-turn-handoff.md
@@ -193,7 +193,10 @@ two unwired journals. The next thing built here should reduce that number.
    journal answer the same question with the same rule. Converging them — most
    plausibly by having `turn` depend on `mutation` rather than the reverse,
    since `mutation` already carries the epoch — is the cheapest possible step
-   and removes a whole class of future divergence.
+   and removes a whole class of future divergence. Phase 1 is done for identity
+   derivation: `turn.DeriveIdempotencyKey` is now a deprecated wrapper around
+   `mutation.DeriveLogicalID`, so new operation-key changes have one canonical
+   helper while the unwired `SessionEnvelope` compatibility shape still exists.
 2. **Give the chosen ledger cross-process serialization**, using the pattern
    beads already proved: `flock` plus re-read-under-lock (`xproc_lock.go:32`),
    plus the unique-temp-name persist beads adopted in #4742.

--- a/src/pkg/convergence/mutation/journal.go
+++ b/src/pkg/convergence/mutation/journal.go
@@ -62,6 +62,31 @@ var (
 const journalFileMode = 0o660
 const journalFormatVersion = 1
 
+// DeriveLogicalID is the canonical operation-id derivation for Hive effects.
+// The caller supplies the already-ordered, load-bearing identity fields and any
+// additional named inputs; owner, holder, epoch, attempt id, and model tool-call
+// ids must stay out of both arguments so a retry or reassignment adopts the same
+// durable operation instead of minting a duplicate.
+func DeriveLogicalID(parts []string, inputs map[string]string) string {
+	h := sha256.New()
+	write := func(parts ...string) {
+		for _, p := range parts {
+			h.Write([]byte(p))
+			h.Write([]byte{0})
+		}
+	}
+	write(parts...)
+	names := make([]string, 0, len(inputs))
+	for k := range inputs {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	for _, k := range names {
+		write(k, inputs[k])
+	}
+	return "op:" + hex.EncodeToString(h.Sum(nil))
+}
+
 // Effect is the complete description of one desired external effect. Its
 // LogicalID deliberately EXCLUDES the owner and epoch: retry or reassignment
 // of the same desired effect must find the same journal entry, and a
@@ -111,23 +136,7 @@ func (e Effect) LogicalID() string {
 	if err := e.Validate(); err != nil {
 		return ""
 	}
-	h := sha256.New()
-	write := func(parts ...string) {
-		for _, p := range parts {
-			h.Write([]byte(p))
-			h.Write([]byte{0})
-		}
-	}
-	write(e.OutcomeKey, fmt.Sprintf("%d", e.DesiredGeneration), e.Transition, e.Subject, e.ClaimKey, e.Kind)
-	names := make([]string, 0, len(e.Inputs))
-	for k := range e.Inputs {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-	for _, k := range names {
-		write(k, e.Inputs[k])
-	}
-	return "op:" + hex.EncodeToString(h.Sum(nil))
+	return DeriveLogicalID([]string{e.OutcomeKey, fmt.Sprintf("%d", e.DesiredGeneration), e.Transition, e.Subject, e.ClaimKey, e.Kind}, e.Inputs)
 }
 
 // Attempt is one authorized attempt at the effect, recorded INSIDE the

--- a/src/pkg/convergence/mutation/journal_test.go
+++ b/src/pkg/convergence/mutation/journal_test.go
@@ -32,6 +32,18 @@ func openJournal(t *testing.T) *Journal {
 	return j
 }
 
+func TestDeriveLogicalIDExcludesAttemptMetadata(t *testing.T) {
+	parts := []string{"v1", "session", "comment", "kubestellar/hive", "5624", "same body"}
+	first := DeriveLogicalID(parts, nil)
+	second := DeriveLogicalID(append([]string(nil), parts...), nil)
+	if first == "" || first != second {
+		t.Fatalf("DeriveLogicalID must be stable: first=%q second=%q", first, second)
+	}
+	if changed := DeriveLogicalID([]string{"v1", "session", "comment", "kubestellar/hive", "5624", "different body"}, nil); changed == first {
+		t.Fatal("changing a load-bearing field must change the logical operation id")
+	}
+}
+
 // Row: crash after intent, before the effect — replay finds the same logical
 // operation; reconciliation to NotApplied authorizes at most one retry.
 func TestJournal_CrashBeforeEffect_ReconcilesThenRetries(t *testing.T) {

--- a/src/pkg/turn/journal.go
+++ b/src/pkg/turn/journal.go
@@ -1,12 +1,12 @@
 package turn
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/hive/pkg/convergence/mutation"
 )
 
 // OpKind classifies a journaled operation by the kind of side effect it has on
@@ -123,6 +123,12 @@ const idempotencyKeyVersion = "v1"
 
 // DeriveIdempotencyKey computes the stable identity of a logical side effect.
 //
+// Deprecated: turn operation identities are now derived by
+// mutation.DeriveLogicalID, the canonical operation-id helper shared with the
+// durable convergence journal. This wrapper remains only for the unwired
+// SessionEnvelope prototype until callers migrate to the mutation journal
+// directly.
+//
 // Design (RFC #4002 stage 2). The key must satisfy two opposing constraints:
 //
 //  1. STABLE ACROSS RE-ENTRY — recomputing it in a fresh process, from the
@@ -134,8 +140,9 @@ const idempotencyKeyVersion = "v1"
 //     turn would silently under-perform (a failure mode strictly worse than a
 //     duplicate, because it is invisible).
 //
-// The derivation is therefore a hash over the semantic content of the effect
-// and nothing else:
+// The derivation delegates to mutation.DeriveLogicalID, the same helper used
+// by pkg/convergence/mutation's durable journal, over the semantic content of
+// the effect and nothing else:
 //
 //	sha256(version | session | kind | repo | target | body)
 //
@@ -165,8 +172,8 @@ const idempotencyKeyVersion = "v1"
 // useful and this design uses them, but as RECONCILIATION for the ambiguous
 // OpIntended window (see Reconciler), not as the key itself: they cost a round
 // trip, they are eventually consistent, and they cannot be computed offline.
-// The content hash is the primary key; the remote query is the tie-breaker for
-// the one state where the local journal cannot know the answer.
+// The shared content hash is the primary key; the remote query is the
+// tie-breaker for the one state where the local journal cannot know the answer.
 //
 // Lineage: at-least-once delivery over non-idempotent GitHub writes is exactly
 // the duplicate-work class the fleet eradicated one incident at a time in
@@ -175,25 +182,22 @@ const idempotencyKeyVersion = "v1"
 // durably recorded — patched at a different layer. This journal is the
 // generalization: record the effect, not the attempt.
 func DeriveIdempotencyKey(sessionID string, in OpIntent) string {
-	h := sha256.New()
-	// Length-prefix every field so that concatenation is unambiguous and
-	// ("ab","c") cannot hash the same as ("a","bc").
-	for _, part := range []string{
+	return mutation.DeriveLogicalID([]string{
 		idempotencyKeyVersion,
 		sessionID,
 		string(in.Kind),
 		in.Repo,
 		in.Target,
 		in.Body,
-	} {
-		fmt.Fprintf(h, "%d:%s|", len(part), part)
-	}
-	return idempotencyKeyVersion + "-" + hex.EncodeToString(h.Sum(nil))[:32]
+	}, nil)
 }
 
 // Journal is the ordered list of operation records carried inside the
 // envelope. Order is the operation-boundary sequence of the turn; the map-free
 // slice representation keeps the JSON stable and diffable.
+//
+// Deprecated: use pkg/convergence/mutation.Journal for durable operation
+// journaling. pkg/turn must not grow a second idempotency implementation.
 type Journal struct {
 	Entries []JournalEntry `json:"entries,omitempty"`
 }


### PR DESCRIPTION
## Summary
- add pkg/convergence/mutation.DeriveLogicalID as the canonical operation identity helper
- route pkg/turn idempotency keys through that helper and mark the turn journal compatibility-only
- document the phase-1 journal convergence step

Fixes #5624

## Validation
- cd src && go build ./...
- cd src && go test ./pkg/convergence/mutation ./pkg/turn