### PR TITLE
🐛 bug fix: parse prefixed PR refs

### DIFF
--- a/changelog.d/fixed-5741-prefixed-pr-refs.md
+++ b/changelog.d/fixed-5741-prefixed-pr-refs.md
@@ -1,0 +1,1 @@
+- Knowledge PR enrichment now strips the `gh-` namespace from repo-qualified external references before fetching metadata, so multi-repo beads such as `gh-owner/repo#123` enrich from the intended repository instead of caching a silent miss ([#5741](https://github.com/kubestellar/hive/issues/5741)).

--- a/src/pkg/knowledge/api_coverage2_test.go
+++ b/src/pkg/knowledge/api_coverage2_test.go
@@ -215,7 +215,9 @@ func mockGHClient(t *testing.T, handler http.HandlerFunc) (*gh.Client, func()) {
 }
 
 func TestPREnricher_EnrichBody(t *testing.T) {
+	var paths []string
 	client, closeSrv := mockGHClient(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
 		pr := map[string]any{
 			"number":        7,
 			"title":         "Fix the thing",
@@ -252,6 +254,15 @@ func TestPREnricher_EnrichBody(t *testing.T) {
 	b2 := &beads.Bead{ID: "b2", ExternalRef: "gh-7", Metadata: map[string]any{}}
 	if got := e.EnrichBody(context.Background(), b2, "scanner"); got == "" {
 		t.Error("expected non-empty body for gh-<n> ref")
+	}
+
+	// Prefixed qualified refs strip the gh- namespace before fetching.
+	bPrefixed := &beads.Bead{ID: "b-prefixed", ExternalRef: "gh-myorg/repo1#7", Metadata: map[string]any{}}
+	if got := e.EnrichBody(context.Background(), bPrefixed, "scanner"); got == "" {
+		t.Error("expected non-empty body for gh-owner/repo#n ref")
+	}
+	if paths[len(paths)-1] != "/api/v3/repos/myorg/repo1/pulls/7" {
+		t.Fatalf("prefixed qualified ref fetched %q; want /api/v3/repos/myorg/repo1/pulls/7", paths[len(paths)-1])
 	}
 
 	// Unparseable ref -> empty.

--- a/src/pkg/knowledge/bead_synthesizer.go
+++ b/src/pkg/knowledge/bead_synthesizer.go
@@ -832,6 +832,8 @@ func (e *PREnricher) parseRef(ref string) (string, string, int) {
 		return e.org, "", n
 	}
 
+	ref = strings.TrimPrefix(ref, "gh-")
+
 	if m := repoRefPattern.FindStringSubmatch(ref); m != nil {
 		owner := m[1]
 		if owner == "" {

--- a/src/pkg/knowledge/bead_synthesizer_test.go
+++ b/src/pkg/knowledge/bead_synthesizer_test.go
@@ -765,6 +765,24 @@ func TestPREnricher_ParseRef_OrgRepoHash(t *testing.T) {
 	}
 }
 
+func TestPREnricher_ParseRef_PrefixedRepoHash(t *testing.T) {
+	e := NewPREnricher(nil, "kubestellar", []string{"console"}, synthTestLogger())
+
+	owner, repo, num := e.parseRef("gh-docs#123")
+	if owner != "kubestellar" || repo != "docs" || num != 123 {
+		t.Errorf("parseRef(gh-docs#123) = %q, %q, %d; want kubestellar, docs, 123", owner, repo, num)
+	}
+}
+
+func TestPREnricher_ParseRef_PrefixedOrgRepoHash(t *testing.T) {
+	e := NewPREnricher(nil, "kubestellar", nil, synthTestLogger())
+
+	owner, repo, num := e.parseRef("gh-other-org/my-repo#99")
+	if owner != "other-org" || repo != "my-repo" || num != 99 {
+		t.Errorf("parseRef(gh-other-org/my-repo#99) = %q, %q, %d; want other-org, my-repo, 99", owner, repo, num)
+	}
+}
+
 func TestPREnricher_ParseRef_Invalid(t *testing.T) {
 	e := NewPREnricher(nil, "kubestellar", nil, synthTestLogger())
 


### PR DESCRIPTION
Fixes #5741

## Summary
- Strip the gh- namespace before parsing repo-qualified PR refs for enrichment.
- Add parseRef and enrichment-path regressions for prefixed repo refs.

## Validation
- cd src && go test ./pkg/knowledge
- cd src && go build ./...