### PR TITLE
🐛 bug fix: require session for GitHub logout

### DIFF
--- a/changelog.d/security-5743-auth-gh-user-logout.md
+++ b/changelog.d/security-5743-auth-gh-user-logout.md
@@ -1,0 +1,1 @@
+- The GitHub user-auth logout endpoint now requires a live user session before deleting persisted owner credentials, preventing anonymous POSTs from logging the hive owner out on non-allowlist spokes ([#5743](https://github.com/kubestellar/hive/issues/5743)).

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -2688,22 +2688,31 @@ func (s *Server) handleGHUserAuthLogout(w http.ResponseWriter, r *http.Request) 
 	// Clear only THIS request's session so logging out affects one user, not
 	// everyone. Removing the disk token only makes sense when the logging-out
 	// user is the one whose token is persisted (the owner/last-authenticated
-	// user); on a direct-route spoke a read-only viewer logging out must not
-	// wipe the owner's persisted token.
+	// user); an anonymous POST must never wipe the owner's persisted token.
 	var loggedOut, loggedOutRole string
-	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
-		if sess := s.lookupSession(c.Value); sess != nil {
-			loggedOut = sess.Username
-			loggedOutRole = sess.Role
-		}
-		s.deleteSession(c.Value)
+	c, err := r.Cookie(sessionCookieName)
+	if err != nil || c.Value == "" {
+		clearSessionCookie(w)
+		jsonError(w, "GitHub user session required", http.StatusUnauthorized)
+		return
 	}
+	sess := s.lookupSession(c.Value)
+	if sess == nil {
+		s.deleteSession(c.Value)
+		clearSessionCookie(w)
+		jsonError(w, "GitHub user session required", http.StatusUnauthorized)
+		return
+	}
+	loggedOut = sess.Username
+	loggedOutRole = sess.Role
+	s.deleteSession(c.Value)
+
 	// Only clear the persisted GitHub token when the logging-out user is the
 	// owner (read-write). Use the role bound to the session at login time — not
 	// a fresh config lookup — so a later allowlist change can't leave a
 	// logging-out owner's own token stranded on disk. Viewer logouts leave the
 	// hive's user client intact.
-	if !s.directRouteAuthzEnabled() || loggedOutRole == config.RoleOwner {
+	if loggedOutRole == config.RoleOwner {
 		if err := os.Remove(userTokenPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			s.deps.Logger.Error("GitHub user token removal failed", "error", err)
 			jsonError(w, "failed to remove persisted GitHub credentials", http.StatusInternalServerError)

--- a/src/pkg/dashboard/api_misc_coverage_test.go
+++ b/src/pkg/dashboard/api_misc_coverage_test.go
@@ -115,11 +115,11 @@ func TestCovG_HandleGHUserAuthSession(t *testing.T) {
 func TestCovG_HandleGHUserAuthLogout(t *testing.T) {
 	s := covMiscServer(t)
 
-	// Logout with no session cookie: still clears cookie + audits + 200.
+	// Logout with no session cookie is rejected before it can delete credentials.
 	rec := httptest.NewRecorder()
 	s.handleGHUserAuthLogout(rec, httptest.NewRequest(http.MethodPost, "/api/gh-user-auth/logout", nil))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("logout no-session: expected 200, got %d", rec.Code)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("logout no-session: expected 401, got %d", rec.Code)
 	}
 
 	// Logout WITH a live session cookie exercises the lookup + delete branch.

--- a/src/pkg/dashboard/api_routes_coverage_test.go
+++ b/src/pkg/dashboard/api_routes_coverage_test.go
@@ -223,9 +223,9 @@ func TestCovG2_GHUserAuthPollAndLogout(t *testing.T) {
 		t.Errorf("poll no-flow = %d, want 400", rec.Code)
 	}
 
-	// Logout (no session) still succeeds and clears cookie.
-	if rec := doPost(s, "/api/gh-user-auth/logout", nil); rec.Code != http.StatusOK {
-		t.Errorf("logout = %d", rec.Code)
+	// Logout requires a live GitHub user session.
+	if rec := doPost(s, "/api/gh-user-auth/logout", nil); rec.Code != http.StatusUnauthorized {
+		t.Errorf("logout = %d, want 401", rec.Code)
 	}
 }
 

--- a/src/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/src/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -418,6 +419,23 @@ func TestCovDF_GHUserAuthStatus_NoTokenFile(t *testing.T) {
 	json.Unmarshal(rec.Body.Bytes(), &body)
 	if body["logged_in"] != false {
 		t.Fatalf("no token file should be logged_in=false, got %v", body)
+	}
+}
+
+func TestGHUserAuthLogout_AnonymousDoesNotDeletePersistedToken(t *testing.T) {
+	s, _, _ := dfServer(t, "complete", "octocat")
+	if err := os.WriteFile(userTokenPath, []byte("gho_owner_token"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/gh-user-auth/logout", nil)
+	s.mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous logout code = %d, want 401", rec.Code)
+	}
+	if _, err := os.Stat(userTokenPath); err != nil {
+		t.Fatalf("anonymous logout removed persisted token: %v", err)
 	}
 }
 

--- a/src/pkg/dashboard/coverage_boost3_test.go
+++ b/src/pkg/dashboard/coverage_boost3_test.go
@@ -937,7 +937,9 @@ func TestHandleGovernorRepos_PrimaryRepoURL(t *testing.T) {
 
 func TestHandleGHUserAuthLogout_Boost(t *testing.T) {
 	srv := newFullServer(t)
+	sid := srv.createUserSession("owner", config.RoleOwner)
 	req := httptest.NewRequest("POST", "/api/gh-user-auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
 	w := httptest.NewRecorder()
 	srv.handleGHUserAuthLogout(w, req)
 

--- a/src/pkg/dashboard/dashboard_inception_handlers_test.go
+++ b/src/pkg/dashboard/dashboard_inception_handlers_test.go
@@ -233,7 +233,9 @@ func TestHandleGHUserAuthPollNoState(t *testing.T) {
 
 func TestHandleGHUserAuthLogout(t *testing.T) {
 	srv := newMinimalServer(t)
+	sid := srv.createUserSession("owner", config.RoleOwner)
 	req := httptest.NewRequest("POST", "/api/gh-user-auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
 	w := httptest.NewRecorder()
 	srv.handleGHUserAuthLogout(w, req)
 	if w.Code != http.StatusOK {

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -1430,7 +1430,7 @@ func isPublicPath(path string) bool {
 	case strings.HasPrefix(path, "/api/leaderboard"):
 		return true
 	case strings.HasPrefix(path, "/api/gh-user-auth/"):
-		return true
+		return path != "/api/gh-user-auth/logout"
 	case path == openRouterCallbackPath:
 		// OpenRouter OAuth PKCE return: the sponsor's browser comes back with no
 		// session, so the path must be public. The single-use state token in the

--- a/src/pkg/dashboard/server_more_coverage_test.go
+++ b/src/pkg/dashboard/server_more_coverage_test.go
@@ -32,7 +32,7 @@ func TestCovH2_IsPublicPath(t *testing.T) {
 			t.Errorf("expected %q to be public", p)
 		}
 	}
-	privates := []string{"/api/status", "/api/agents", "/", "/dashboard", "/api/config/github"}
+	privates := []string{"/api/status", "/api/agents", "/", "/dashboard", "/api/config/github", "/api/gh-user-auth/logout"}
 	for _, p := range privates {
 		if isPublicPath(p) {
 			t.Errorf("expected %q to NOT be public", p)


### PR DESCRIPTION
Fixes #5743

## Summary
- Require a live GitHub user session before the logout endpoint deletes persisted credentials.
- Keep the endpoint out of the public-path allowlist and add regression coverage for anonymous POSTs.

## Validation
- cd src && go test ./pkg/dashboard -run 'GHUserAuthLogout|PublicPaths|PollAndLogout|HandleGHUserAuthLogout'
- cd src && go build ./...