### PR TITLE
🐛 bug fix: add hermetic cmd hive path seams

### DIFF
--- a/changelog.d/fixed-5696-hermetic-cmd-hive-paths.md
+++ b/changelog.d/fixed-5696-hermetic-cmd-hive-paths.md
@@ -1,0 +1,1 @@
+- The `cmd/hive` heartbeat, duplicate-PR claim ledger, and Nous dashboard state loaders now expose narrow path seams with production defaults preserved, allowing hermetic tests for token-cache freshness, corrupt claim ledgers, and governor artifacts without touching host `/var/run` or `/data` paths ([#5696](https://github.com/kubestellar/hive/issues/5696)).

--- a/src/cmd/hive/automerge_sweep_wiring_test.go
+++ b/src/cmd/hive/automerge_sweep_wiring_test.go
@@ -165,6 +165,10 @@ func TestRunAutoMergeSweepIfDue_LogsCompletionWithSeenAndSkipped(t *testing.T) {
 func resetClaimLedgerForTest(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "pr-claims.json")
+	oldPath := claimLedgerPath
+	oldLoader := claimLedgerLoader
+	claimLedgerPath = path
+	claimLedgerLoader = github.LoadClaimLedger
 	claimLedgerOnce = sync.Once{}
 	claimLedgerOnce.Do(func() {
 		claimLedger = github.NewClaimLedger(path, sweepTestLogger(nil))
@@ -172,8 +176,38 @@ func resetClaimLedgerForTest(t *testing.T) string {
 	t.Cleanup(func() {
 		claimLedgerOnce = sync.Once{}
 		claimLedger = nil
+		claimLedgerPath = oldPath
+		claimLedgerLoader = oldLoader
 	})
 	return path
+}
+
+func TestGetClaimLedger_LoadsFromInjectedPathAndSurvivesCorruptFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pr-claims.json")
+	if err := os.WriteFile(path, []byte(`{not json`), 0o600); err != nil {
+		t.Fatalf("write corrupt ledger: %v", err)
+	}
+	oldPath := claimLedgerPath
+	oldLoader := claimLedgerLoader
+	claimLedgerPath = path
+	claimLedgerLoader = github.LoadClaimLedger
+	claimLedgerOnce = sync.Once{}
+	claimLedger = nil
+	t.Cleanup(func() {
+		claimLedgerOnce = sync.Once{}
+		claimLedger = nil
+		claimLedgerPath = oldPath
+		claimLedgerLoader = oldLoader
+	})
+
+	var buf strings.Builder
+	ledger := getClaimLedger(sweepTestLogger(&buf))
+	if ledger == nil {
+		t.Fatal("corrupt ledger should still return a usable empty ledger")
+	}
+	if !strings.Contains(buf.String(), path) {
+		t.Fatalf("warning should include injected path %q, log: %s", path, buf.String())
+	}
 }
 
 func TestGetClaimLedger_ReturnsSamePointerOnEveryCall(t *testing.T) {

--- a/src/cmd/hive/heartbeat_helpers_test.go
+++ b/src/cmd/hive/heartbeat_helpers_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kubestellar/hive/pkg/agent"
 	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/hub"
 )
 
 // quotaExhaustedProcessCount must count ONLY running, unpaused processes whose
@@ -91,5 +95,47 @@ func TestQuotaExhaustedAgentReason(t *testing.T) {
 	}
 	if got := quotaExhaustedAgentReason(3); got != "3 agent(s) out of provider quota" {
 		t.Errorf("quotaExhaustedAgentReason(3) = %q", got)
+	}
+}
+
+func TestGitHubAppTokenHeartbeatFields_UsesInjectableCachePath(t *testing.T) {
+	oldPath := githubAppTokenCachePath
+	t.Cleanup(func() { githubAppTokenCachePath = oldPath })
+	cfg := &config.Config{GitHub: config.GitHubConfig{AppID: 123}}
+	detail := "mint failed"
+
+	githubAppTokenCachePath = filepath.Join(t.TempDir(), "missing.cache")
+	status, minted, lastErr := githubAppTokenHeartbeatFields(cfg, detail)
+	if status != hub.GitHubAppTokenStatusMissing || minted != "" || lastErr != detail {
+		t.Fatalf("missing cache = %q/%q/%q, want missing/empty/detail", status, minted, lastErr)
+	}
+
+	nowPath := filepath.Join(t.TempDir(), "token.cache")
+	if err := os.WriteFile(nowPath, []byte("token"), 0o600); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+	githubAppTokenCachePath = nowPath
+	status, minted, lastErr = githubAppTokenHeartbeatFields(cfg, detail)
+	if status != hub.GitHubAppTokenStatusOK || minted == "" || lastErr != "" {
+		t.Fatalf("fresh cache = %q/%q/%q, want ok/minted/empty", status, minted, lastErr)
+	}
+
+	staleAt := time.Now().Add(-hub.GitHubAppTokenStaleAfter - time.Minute)
+	if err := os.Chtimes(nowPath, staleAt, staleAt); err != nil {
+		t.Fatalf("stale cache: %v", err)
+	}
+	status, minted, lastErr = githubAppTokenHeartbeatFields(cfg, detail)
+	if status != hub.GitHubAppTokenStatusStale || minted == "" || lastErr != detail {
+		t.Fatalf("stale cache = %q/%q/%q, want stale/minted/detail", status, minted, lastErr)
+	}
+
+	parentFile := filepath.Join(t.TempDir(), "not-dir")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write parent file: %v", err)
+	}
+	githubAppTokenCachePath = filepath.Join(parentFile, "token.cache")
+	status, minted, lastErr = githubAppTokenHeartbeatFields(cfg, detail)
+	if status != hub.GitHubAppTokenStatusError || minted != "" || lastErr == "" {
+		t.Fatalf("stat error = %q/%q/%q, want error/empty/error", status, minted, lastErr)
 	}
 }

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -677,11 +677,13 @@ func describeKeySource(v string) string {
 	return v
 }
 
+var githubAppTokenCachePath = github.TokenCachePath
+
 func githubAppTokenHeartbeatFields(cfg *config.Config, detail string) (status, lastMintAt, lastErr string) {
 	if cfg == nil || !cfg.GitHub.HasApp() {
 		return "", "", ""
 	}
-	info, err := os.Stat(github.TokenCachePath)
+	info, err := os.Stat(githubAppTokenCachePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return hub.GitHubAppTokenStatusMissing, "", detail
@@ -8034,8 +8036,10 @@ func mergeableJSON(m github.Mergeable) string {
 // failure) rather than at startup, so a missing or corrupt /data ledger can
 // never block the hive from booting.
 var (
-	claimLedgerOnce sync.Once
-	claimLedger     *github.ClaimLedger
+	claimLedgerOnce   sync.Once
+	claimLedger       *github.ClaimLedger
+	claimLedgerPath   = github.ClaimLedgerPath
+	claimLedgerLoader = github.LoadClaimLedger
 )
 
 // hiveIdentity determines which PR authors count as "this hive", so only our
@@ -8076,12 +8080,12 @@ func applyDuplicatePRGuard(
 // and the ledger itself is internally locked.
 func getClaimLedger(logger *slog.Logger) *github.ClaimLedger {
 	claimLedgerOnce.Do(func() {
-		ledger, err := github.LoadClaimLedger(github.ClaimLedgerPath, logger)
+		ledger, err := claimLedgerLoader(claimLedgerPath, logger)
 		if err != nil {
 			// LoadClaimLedger always returns a usable (possibly empty) ledger
 			// alongside the error, so we keep it and just report the problem.
 			logger.Warn("duplicate-PR guard: could not load persisted claim ledger, starting empty",
-				"path", github.ClaimLedgerPath, "error", err)
+				"path", claimLedgerPath, "error", err)
 		}
 		claimLedger = ledger
 	})
@@ -8883,6 +8887,10 @@ const (
 )
 
 func loadNousState(logger *slog.Logger) *dashboard.NousState {
+	return loadNousStateFromPaths(logger, nousGovernorDir, nousSnapshotDir)
+}
+
+func loadNousStateFromPaths(logger *slog.Logger, governorDir, snapshotDir string) *dashboard.NousState {
 	state := &dashboard.NousState{
 		Mode:   "observe",
 		Scope:  "governor",
@@ -8891,7 +8899,7 @@ func loadNousState(logger *slog.Logger) *dashboard.NousState {
 		Config: make(map[string]interface{}),
 	}
 
-	if ledgerData, err := os.ReadFile(nousGovernorDir + "/ledger.json"); err == nil {
+	if ledgerData, err := os.ReadFile(filepath.Join(governorDir, "ledger.json")); err == nil {
 		var ledger struct {
 			Iterations []map[string]interface{} `json:"iterations"`
 		}
@@ -8901,7 +8909,7 @@ func loadNousState(logger *slog.Logger) *dashboard.NousState {
 		}
 	}
 
-	if principlesData, err := os.ReadFile(nousGovernorDir + "/principles.json"); err == nil {
+	if principlesData, err := os.ReadFile(filepath.Join(governorDir, "principles.json")); err == nil {
 		var pFile struct {
 			Principles []json.RawMessage `json:"principles"`
 		}
@@ -8922,7 +8930,7 @@ func loadNousState(logger *slog.Logger) *dashboard.NousState {
 	}
 
 	snapshotCount := 0
-	if entries, err := os.ReadDir(nousSnapshotDir); err == nil {
+	if entries, err := os.ReadDir(snapshotDir); err == nil {
 		snapshotCount = len(entries)
 	}
 

--- a/src/cmd/hive/nous_state_defaults_test.go
+++ b/src/cmd/hive/nous_state_defaults_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubestellar/hive/pkg/dashboard"
@@ -52,5 +54,30 @@ func TestLoadNousStateStatusConsistency(t *testing.T) {
 	// The baseline target rides from the dashboard package's single constant.
 	if state.Status["baseline_target"] != dashboard.NousBaselineTarget {
 		t.Errorf("baseline_target = %v, want %d", state.Status["baseline_target"], dashboard.NousBaselineTarget)
+	}
+}
+
+func TestLoadNousStateFromPathsLoadsHermeticArtifacts(t *testing.T) {
+	governorDir := t.TempDir()
+	snapshotDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(governorDir, "ledger.json"), []byte(`{"iterations":[{"id":"one"},{"id":"two"}]}`), 0o600); err != nil {
+		t.Fatalf("write ledger: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(governorDir, "principles.json"), []byte(`{"principles":[{"id":"p1","statement":"Prefer seams","confidence":"high","category":"testing"}]}`), 0o600); err != nil {
+		t.Fatalf("write principles: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snapshotDir, "snapshot.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	state := loadNousStateFromPaths(restoreTestLogger(), governorDir, snapshotDir)
+	if state.Phase != "observing" || len(state.Ledger) != 2 {
+		t.Fatalf("phase/ledger = %q/%d, want observing/2", state.Phase, len(state.Ledger))
+	}
+	if len(state.Principles) != 1 || state.Principles[0].ID != "p1" || state.Principles[0].Confidence != 0.9 {
+		t.Fatalf("principles = %+v, want parsed p1 with confidence", state.Principles)
+	}
+	if state.Status["snapshotCount"] != 1 || state.Status["iterations"] != 2 || state.Status["principles"] != 1 {
+		t.Fatalf("status counts = %+v, want one snapshot, two iterations, one principle", state.Status)
 	}
 }


### PR DESCRIPTION
Fixes #5696

## Summary
- Add narrow injectable path seams for the GitHub App token cache, claim ledger loader/path, and Nous governor artifacts.
- Cover missing/stale/fresh/stat-error token cache states, corrupt claim ledger fallback, and hermetic Nous ledger/principle/snapshot loading.

## Validation
- cd src && go test ./cmd/hive -run 'GitHubAppTokenHeartbeatFields|GetClaimLedger|LoadNousState'
- cd src && go build ./...