### PR TITLE
🐛 bug fix: add dashboard seam tests

### DIFF
--- a/changelog.d/fixed-5708-dashboard-seams.md
+++ b/changelog.d/fixed-5708-dashboard-seams.md
@@ -1,0 +1,1 @@
+- Dashboard low-coverage seams now let tests exercise GHCR tag checks plus sidebar and audit disk persistence against injected clients and file paths, improving confidence in registry and operator-configuration code without live GHCR or `/data` access ([#5708](https://github.com/kubestellar/hive/issues/5708)).

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -826,6 +826,11 @@ var (
 const ghcrCacheTTL = 2 * time.Minute
 const ghcrCheckTimeout = 5 * time.Second
 
+var (
+	ghcrCheckBaseURL = "https://ghcr.io"
+	ghcrCheckClient  = &http.Client{Timeout: ghcrCheckTimeout}
+)
+
 func ghcrTagExistsCached(tag string) bool {
 	ghcrCacheMu.RLock()
 	if exp, ok := ghcrCacheExpiry[tag]; ok && time.Now().Before(exp) {
@@ -844,8 +849,15 @@ func ghcrTagExistsCached(tag string) bool {
 }
 
 func ghcrTagExists(tag string) bool {
-	client := &http.Client{Timeout: ghcrCheckTimeout}
-	tokenResp, err := client.Get("https://ghcr.io/token?scope=repository:kubestellar/hive:pull")
+	return ghcrTagExistsWithClient(ghcrCheckClient, ghcrCheckBaseURL, tag)
+}
+
+func ghcrTagExistsWithClient(client *http.Client, baseURL, tag string) bool {
+	if client == nil {
+		client = &http.Client{Timeout: ghcrCheckTimeout}
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	tokenResp, err := client.Get(baseURL + "/token?scope=repository:kubestellar/hive:pull")
 	if err != nil {
 		return false
 	}
@@ -857,7 +869,7 @@ func ghcrTagExists(tag string) bool {
 		return false
 	}
 
-	manifestURL := fmt.Sprintf("https://ghcr.io/v2/kubestellar/hive/manifests/%s", tag)
+	manifestURL := fmt.Sprintf("%s/v2/kubestellar/hive/manifests/%s", baseURL, tag)
 	req, _ := http.NewRequest("HEAD", manifestURL, nil)
 	req.Header.Set("Authorization", "Bearer "+tok.Token)
 	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json")
@@ -6944,7 +6956,7 @@ func (s *Server) handleSidebarSet(w http.ResponseWriter, r *http.Request) {
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
-const sidebarFile = "/data/sidebar.json"
+var sidebarFile = "/data/sidebar.json"
 
 func (s *Server) loadSidebarFromDisk() {
 	data, err := os.ReadFile(sidebarFile)

--- a/src/pkg/dashboard/api_agents_test.go
+++ b/src/pkg/dashboard/api_agents_test.go
@@ -717,3 +717,51 @@ func TestValueOrDefault(t *testing.T) {
 		t.Errorf("expected %q, got %q", "fallback", got)
 	}
 }
+
+func TestGhcrTagExistsWithClientUsesInjectedBaseURL(t *testing.T) {
+	var gotTokenPath, gotManifestPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			gotTokenPath = r.URL.Path + "?" + r.URL.RawQuery
+			_, _ = w.Write([]byte(`{"token":"test-token"}`))
+		case "/v2/kubestellar/hive/manifests/v4-test":
+			gotManifestPath = r.URL.Path
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	if !ghcrTagExistsWithClient(srv.Client(), srv.URL, "v4-test") {
+		t.Fatal("tag should exist when injected registry returns 200")
+	}
+	if gotTokenPath != "/token?scope=repository:kubestellar/hive:pull" {
+		t.Fatalf("token request = %q", gotTokenPath)
+	}
+	if gotManifestPath != "/v2/kubestellar/hive/manifests/v4-test" || gotAuth != "Bearer test-token" {
+		t.Fatalf("manifest request path/auth = %q/%q", gotManifestPath, gotAuth)
+	}
+}
+
+func TestGhcrTagExistsWithClientHandlesFailures(t *testing.T) {
+	badJSON := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte(`not-json`)) }))
+	t.Cleanup(badJSON.Close)
+	if ghcrTagExistsWithClient(badJSON.Client(), badJSON.URL, "tag") {
+		t.Fatal("bad token JSON should be false")
+	}
+
+	missing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			_, _ = w.Write([]byte(`{"token":"test-token"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(missing.Close)
+	if ghcrTagExistsWithClient(missing.Client(), missing.URL, "tag") {
+		t.Fatal("missing manifest should be false")
+	}
+}

--- a/src/pkg/dashboard/api_coverage_test.go
+++ b/src/pkg/dashboard/api_coverage_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -3981,5 +3982,19 @@ func TestHandleGovernorBudget_EmptyPayloadPreservesAll(t *testing.T) {
 	b := deps.Config.Governor.Budget
 	if b.TotalTokens != 1000 || b.PeriodDays != budgetTestPeriodDays || b.CriticalPct != budgetTestCriticalPct {
 		t.Errorf("empty payload mutated config: %+v", b)
+	}
+}
+
+func TestSidebarDiskUsesInjectablePath(t *testing.T) {
+	old := sidebarFile
+	sidebarFile = filepath.Join(t.TempDir(), "sidebar.json")
+	t.Cleanup(func() { sidebarFile = old })
+	s, _ := apiServer(t)
+	want := map[string]interface{}{"items": []interface{}{"audit", "fleet"}}
+	s.saveSidebarToDisk(want)
+	s.sidebar = nil
+	s.loadSidebarFromDisk()
+	if s.sidebar == nil {
+		t.Fatal("sidebar was not loaded from injected path")
 	}
 }

--- a/src/pkg/dashboard/audit.go
+++ b/src/pkg/dashboard/audit.go
@@ -19,8 +19,9 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
+var auditLogPath = "/data/audit.jsonl"
+
 const (
-	auditLogPath    = "/data/audit.jsonl"
 	auditMaxSizeMB  = 5
 	auditMaxBackups = 3
 	auditMaxAgeDays = 90
@@ -91,7 +92,11 @@ func newAuditLog() *AuditLog {
 }
 
 func (a *AuditLog) loadFromDisk() {
-	data, err := os.ReadFile(auditLogPath)
+	a.loadFromDiskPath(auditLogPath)
+}
+
+func (a *AuditLog) loadFromDiskPath(path string) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}

--- a/src/pkg/dashboard/audit_test.go
+++ b/src/pkg/dashboard/audit_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -254,5 +256,22 @@ func TestAuditDetailFormatsKeyValuePairs(t *testing.T) {
 	}
 	if got := auditDetail("file", "hive.yaml", "dangling"); got != "file=hive.yaml" {
 		t.Fatalf("auditDetail with dangling key = %q, want dangling key ignored", got)
+	}
+}
+
+func TestAuditLogLoadFromDiskPathUsesInjectedPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	data := `{"ts":"2026-09-03T00:00:00Z","user":"alice","action":"saved"}` + "\n" +
+		`{"ts":"2026-09-03T00:01:00Z","user":"system","action":"ignored"}` + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write audit log: %v", err)
+	}
+	audit := &AuditLog{ring: make([]AuditEntry, 0, auditRingCap), lastAction: make(map[string]time.Time)}
+	audit.loadFromDiskPath(path)
+	if len(audit.ring) != 2 {
+		t.Fatalf("loaded entries = %d, want 2", len(audit.ring))
+	}
+	if audit.lastAction["alice"].IsZero() {
+		t.Fatalf("real user last action was not rebuilt from injected path")
 	}
 }


### PR DESCRIPTION
Fixes #5708

## Summary
- Add injectable GHCR client/base URL coverage for tag existence checks.
- Add injectable sidebar and audit disk-path seams with hermetic tests.

## Validation
- cd src && go test ./pkg/dashboard -run 'GhcrTagExistsWithClient|AuditLogLoadFromDiskPath|SidebarDiskUsesInjectablePath'
- cd src && go build ./...