### PR TITLE
🐛 bug fix: add contributor WebSocket close correlation

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -321,6 +321,8 @@ const hubs = rawHubList.map((url, i) => ({
   reconnectDelay: BASE_RECONNECT_DELAY_MS,
   heartbeatInterval: null,
   lastPong: Date.now(),
+  lastPingSentAt: 0,
+  connectionId: '',
   connectGeneration: 0,
   reconnectTimer: null,
   authenticated: false,
@@ -3513,6 +3515,7 @@ function handleMessage(data, hub) {
       break;
 
     case 'auth_ok':
+      hub.connectionId = msg.connection_id || '';
       console.log(`Authenticated with ${hub.url} as ${msg.contributor_id} (tier: ${msg.trust_tier})`);
       // #2567: the hub advertises its protocol version + capability set here. We
       // log them (forward-compatible: unknown/absent fields are simply skipped)
@@ -3804,6 +3807,15 @@ function describeWsClose(code, reason) {
   return text ? `${label}: ${text}` : label;
 }
 
+function wsCloseCorrelation(hub, now = Date.now()) {
+  const lastPongAge = hub.lastPong ? Math.max(0, now - hub.lastPong) : -1;
+  const lastPingAge = hub.lastPingSentAt ? Math.max(0, now - hub.lastPingSentAt) : -1;
+  return `conn=${hub.connectionId || 'unknown'} ` +
+    `last_pong_age_ms=${lastPongAge} last_ping_age_ms=${lastPingAge} ` +
+    `reconnect_delay_ms=${hub.reconnectDelay} ` +
+    `heartbeat_interval_ms=${HEARTBEAT_INTERVAL_MS} heartbeat_timeout_ms=${HEARTBEAT_TIMEOUT_MS}`;
+}
+
 function connectHub(hub) {
   if (hub.reconnectTimer) { clearTimeout(hub.reconnectTimer); hub.reconnectTimer = null; }
   if (hub.heartbeatInterval) { clearInterval(hub.heartbeatInterval); hub.heartbeatInterval = null; }
@@ -3817,14 +3829,17 @@ function connectHub(hub) {
     console.log(`Connected to ${hub.url}`);
     hub.reconnectDelay = BASE_RECONNECT_DELAY_MS;
     hub.lastPong = Date.now();
+    hub.lastPingSentAt = 0;
+    hub.connectionId = '';
 
     hub.heartbeatInterval = setInterval(() => {
       if (gen !== hub.connectGeneration) { clearInterval(hub.heartbeatInterval); return; }
       if (Date.now() - hub.lastPong > HEARTBEAT_TIMEOUT_MS) {
-        console.error(`Heartbeat timeout on ${hub.url} — reconnecting`);
+        console.error(`Heartbeat timeout on ${hub.url} (${wsCloseCorrelation(hub)}) — reconnecting`);
         hub.ws.terminate();
         return;
       }
+      hub.lastPingSentAt = Date.now();
       sendTo(hub, { type: 'ping', seq: nextSeq() });
       // Also emit a PROTOCOL-level Ping control frame (kubestellar/hive#5090).
       // The JSON ping above is an ordinary text frame; an L7 proxy that scores
@@ -3860,7 +3875,7 @@ function connectHub(hub) {
   hub.ws.on('close', (code, reason) => {
     if (gen !== hub.connectGeneration) return;
     console.log(`Connection to ${hub.url} closed (${describeWsClose(code, reason)}). ` +
-      `Reconnecting in ${hub.reconnectDelay}ms...`);
+      `${wsCloseCorrelation(hub)}. Reconnecting in ${hub.reconnectDelay}ms...`);
     if (hub.heartbeatInterval) { clearInterval(hub.heartbeatInterval); hub.heartbeatInterval = null; }
     hub.reconnectTimer = setTimeout(() => connectHub(hub), hub.reconnectDelay);
     hub.reconnectDelay = Math.min(hub.reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
@@ -4020,6 +4035,7 @@ if (process.env.HIVE_RELAY_TEST_MODE === '1') {
     classifyPeerProtocol,
     warnOnProtocolDrift,
     describeWsClose,
+    wsCloseCorrelation,
     // Headless (non-interactive) mode surface (kubestellar/hive#2538).
     CONTRIBUTOR_MODE,
     MODE_INTERACTIVE,

--- a/bin/contributor-relay.test.js
+++ b/bin/contributor-relay.test.js
@@ -1016,6 +1016,25 @@ test('#5090 a normal closure with no text still identifies itself', () => {
   } finally { teardown(relay); }
 });
 
+test('#5090 close diagnostics include hub connection id and keepalive timing', () => {
+  const relay = loadRelay({ backend: 'claude' });
+  try {
+    const hub = relay.getHubs()[0];
+    hub.connectionId = 'abc123';
+    hub.lastPong = 1_000;
+    hub.lastPingSentAt = 3_000;
+    hub.reconnectDelay = 4_000;
+
+    const out = relay.wsCloseCorrelation(hub, 5_500);
+    assert.ok(out.includes('conn=abc123'), 'hub connection id must be present for log correlation');
+    assert.ok(out.includes('last_pong_age_ms=4500'), 'last pong age connects the flap to keepalive state');
+    assert.ok(out.includes('last_ping_age_ms=2500'), 'last ping age connects the flap to ping cadence');
+    assert.ok(out.includes('reconnect_delay_ms=4000'), 'backoff state must be visible in the close log');
+    assert.ok(out.includes('heartbeat_interval_ms=30000'));
+    assert.ok(out.includes('heartbeat_timeout_ms=90000'));
+  } finally { teardown(relay); }
+});
+
 test('task prompt is queued, not typed, while cliReady is false', () => {
   const relay = loadRelay({ backend: 'copilot' });
   try {

--- a/changelog.d/fixed-5090-ws-close-correlation.md
+++ b/changelog.d/fixed-5090-ws-close-correlation.md
@@ -1,0 +1,1 @@
+- Added contributor WebSocket close-correlation telemetry so relay logs carry hub connection ids, close codes/reasons, keepalive ages, and reconnect backoff state for production flap diagnosis.

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -11,6 +11,7 @@ package dashboard
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -76,6 +77,7 @@ var wsUpgrader = websocket.Upgrader{
 
 type ContributorConnection struct {
 	ws              *websocket.Conn
+	connID          string
 	profile         *ContributorProfile
 	cliBackend      string
 	model           string
@@ -275,13 +277,16 @@ type WSMessage struct {
 	// probing (e.g. token_refresh, task_unavailable_reasons). Additive; old
 	// clients ignore the unknown field.
 	ServerCapabilities []string `json:"server_capabilities,omitempty"`
-	Role               string   `json:"role,omitempty"`
-	ContribLabels      []string `json:"contributor_labels,omitempty"`
-	Status             string   `json:"status,omitempty"`
-	Result             string   `json:"result,omitempty"`
-	Summary            string   `json:"summary,omitempty"`
-	TmuxOutput         []string `json:"tmux_output,omitempty"`
-	AcceptedModels     []string `json:"accepted_models,omitempty"`
+	// ConnectionID is the hub's per-socket id, advertised on auth_ok so relay
+	// close logs can be correlated with hub disconnect/cleanup logs for #5090.
+	ConnectionID   string   `json:"connection_id,omitempty"`
+	Role           string   `json:"role,omitempty"`
+	ContribLabels  []string `json:"contributor_labels,omitempty"`
+	Status         string   `json:"status,omitempty"`
+	Result         string   `json:"result,omitempty"`
+	Summary        string   `json:"summary,omitempty"`
+	TmuxOutput     []string `json:"tmux_output,omitempty"`
+	AcceptedModels []string `json:"accepted_models,omitempty"`
 	// PRURL is the pull request the agent opened for this task, reported on
 	// task_complete. It is best-effort: the relay fills it when it can spot a
 	// PR link in the agent's output, and it is empty when the agent went idle
@@ -3272,6 +3277,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			// deliberately leaving kubestellar/hive#5151's accounting untouched).
 			if abandonedTask != nil && h.taskReadoptedByLiveConnection(contributor, abandonedTask) {
 				h.logger.Info("[contribute-ws] disconnect release skipped: task already re-adopted on a live connection",
+					"id", connID,
 					"username", contributor.profile.GitHubUsername,
 					"task", abandonedTask.TaskID,
 					"repo", abandonedTask.Repo,
@@ -3282,6 +3288,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 
 			if abandonedTask != nil {
 				h.logger.Warn("[contribute-ws] task released on disconnect",
+					"id", connID,
 					"username", contributor.profile.GitHubUsername,
 					"task", abandonedTask.TaskID,
 				)
@@ -3325,7 +3332,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 					contributor.role, contributor.cliBackend, contributor.model,
 					contributor.reasoningEffort, taskDescOf(abandonedTask))
 			}
-			h.logger.Info("[contribute-ws] disconnected", "username", contributor.profile.GitHubUsername)
+			h.logger.Info("[contribute-ws] disconnected", "id", connID, "username", contributor.profile.GitHubUsername)
 			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend, contributor.model, contributor.reasoningEffort, "")
 		}
 		_ = conn.Close()
@@ -3335,7 +3342,14 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		_, raw, err := conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
-				h.logger.Warn("[contribute-ws] read error", "id", connID, "error", err)
+				code, reason, source := websocketCloseErrorDetails(err)
+				h.logger.Warn("[contribute-ws] read error",
+					"id", connID,
+					"username", contributorUsername(contributor),
+					"close_source", source,
+					"close_code", code,
+					"close_reason", reason,
+					"error", err)
 			}
 			return
 		}
@@ -3470,6 +3484,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 
 			contributor = &ContributorConnection{
 				ws:              conn,
+				connID:          connID,
 				profile:         profile,
 				cliBackend:      msg.CLIBackend,
 				model:           msg.Model,
@@ -3523,12 +3538,14 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				// probing. Additive — an existing client ignores these unknown fields.
 				ProtocolVersion:    contributorProtocolVersion,
 				ServerCapabilities: serverCapabilities(),
+				ConnectionID:       connID,
 			}); err != nil {
 				h.logger.Warn("[contribute-ws] failed to send auth_ok", "username", profile.GitHubUsername, "error", err)
 				return
 			}
 
 			h.logger.Info("[contribute-ws] authenticated",
+				"id", connID,
 				"username", profile.GitHubUsername,
 				"tier", profile.TrustTier,
 				"cli", msg.CLIBackend,
@@ -4184,7 +4201,12 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 		c.mu.Unlock()
 
 		if time.Since(lastPong) > wsHeartbeatTimeout {
-			h.logger.Info("[contribute-ws] heartbeat timeout", "username", c.profile.GitHubUsername)
+			h.logger.Info("[contribute-ws] heartbeat timeout",
+				"id", c.connID,
+				"username", c.profile.GitHubUsername,
+				"last_pong_age_ms", time.Since(lastPong).Milliseconds(),
+				"heartbeat_timeout_ms", wsHeartbeatTimeout.Milliseconds(),
+			)
 			closeWithReason(c.ws, websocket.CloseGoingAway, "heartbeat timeout: no pong within the heartbeat window")
 			return
 		}
@@ -4192,7 +4214,11 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 		h.maybeRefreshToken(c)
 
 		if err := c.send(WSMessage{Type: "ping", Seq: h.nextSeq()}); err != nil {
-			h.logger.Info("[contribute-ws] heartbeat ping failed, closing", "username", c.profile.GitHubUsername)
+			h.logger.Info("[contribute-ws] heartbeat ping failed, closing",
+				"id", c.connID,
+				"username", c.profile.GitHubUsername,
+				"error", err,
+			)
 			closeWithReason(c.ws, websocket.CloseGoingAway, "heartbeat ping write failed")
 			return
 		}
@@ -4205,7 +4231,7 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 		// heartbeat-timeout check remains the authority on when to hang up.
 		if err := writeProtocolPing(c.ws); err != nil {
 			h.logger.Debug("[contribute-ws] protocol ping failed",
-				"username", c.profile.GitHubUsername, "error", err)
+				"id", c.connID, "username", c.profile.GitHubUsername, "error", err)
 		}
 	}
 }
@@ -5866,6 +5892,25 @@ func writeProtocolPing(conn *websocket.Conn) error {
 		nil,
 		time.Now().Add(wsProtocolPingDeadline),
 	)
+}
+
+func websocketCloseErrorDetails(err error) (code int, reason, source string) {
+	var closeErr *websocket.CloseError
+	if errors.As(err, &closeErr) {
+		source = "close-frame"
+		if closeErr.Code == websocket.CloseAbnormalClosure {
+			source = "abnormal-no-close-frame"
+		}
+		return closeErr.Code, closeErr.Text, source
+	}
+	return 0, "", "read-error"
+}
+
+func contributorUsername(c *ContributorConnection) string {
+	if c == nil || c.profile == nil {
+		return ""
+	}
+	return c.profile.GitHubUsername
 }
 
 // closeWithReason closes a contributor socket after telling the client WHY.

--- a/src/pkg/dashboard/contribute_ws_test.go
+++ b/src/pkg/dashboard/contribute_ws_test.go
@@ -110,6 +110,9 @@ func TestWSAuthValid(t *testing.T) {
 	if authOk.ContributorID == "" {
 		t.Fatal("missing contributor_id")
 	}
+	if authOk.ConnectionID == "" {
+		t.Fatal("missing connection_id for relay/hub close-log correlation")
+	}
 	if authOk.TrustTier != "newcomer" {
 		t.Fatalf("expected newcomer, got %s", authOk.TrustTier)
 	}


### PR DESCRIPTION
Fixes #5090

## Summary
- sends hub connection_id in auth_ok so relay and hub logs can be joined
- logs hub close source/code/reason and heartbeat timeout context
- adds relay close diagnostics with keepalive ages and reconnect backoff state
- adds changelog fragment

## Validation
- node --test bin/contributor-relay.test.js --test-name-pattern '#5090'\n- cd src && go test ./pkg/dashboard -run 'TestWSAuthValid|TestWS_AuthFailureClosesWithAStatedReason|TestWS_MissingTokenClosesWithAStatedReason'\n- cd src && go build ./...