### PR TITLE
🌱 add dashboard scheduler seam

### DIFF
--- a/changelog.d/changed-5565-dashboard-scheduler-seam.md
+++ b/changelog.d/changed-5565-dashboard-scheduler-seam.md
@@ -1,0 +1,1 @@
+- Reduced `pkg/dashboard` coupling by hiding scheduler access behind a dashboard-owned interface and ratcheting the package's internal import count.

--- a/src/pkg/dashboard/deps.go
+++ b/src/pkg/dashboard/deps.go
@@ -18,10 +18,15 @@ import (
 	"github.com/kubestellar/hive/pkg/hooks"
 	"github.com/kubestellar/hive/pkg/knowledge"
 	"github.com/kubestellar/hive/pkg/rotation"
-	"github.com/kubestellar/hive/pkg/scheduler"
 	"github.com/kubestellar/hive/pkg/tokens"
 	"github.com/kubestellar/hive/pkg/toolapprove"
 )
+
+type SchedulerControl interface {
+	BuildAgentMessage(agentName string, issues []ghpkg.Issue, actionable *ghpkg.ActionableResult) string
+	BuildAgentMessageFromLastActionable(agentName string) string
+	GetLastActionable() *ghpkg.ActionableResult
+}
 
 type Dependencies struct {
 	Config    *config.Config
@@ -40,7 +45,7 @@ type Dependencies struct {
 	Knowledge        *knowledge.KnowledgeAPI
 	Inception        *knowledge.InceptionEngine
 	Nous             *NousState
-	Scheduler        *scheduler.Scheduler
+	Scheduler        SchedulerControl
 	MetricsCollector *MetricsCollector
 	// RotationMgr is the provider-rotation manager (RFC #3958). Nil when
 	// rotation is disabled; the headroom endpoint then reports enabled=false.

--- a/src/pkg/dashboard/import_count_test.go
+++ b/src/pkg/dashboard/import_count_test.go
@@ -1,0 +1,43 @@
+package dashboard
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestDashboardInternalImportCountRatchet(t *testing.T) {
+	const maxDashboardInternalImports = 31
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read dashboard package: %v", err)
+	}
+	importRe := regexp.MustCompile(`"github\.com/kubestellar/hive/pkg/([^"]+)"`)
+	imports := map[string]struct{}{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, match := range importRe.FindAllStringSubmatch(string(data), -1) {
+			pkg := match[1]
+			if strings.HasPrefix(pkg, "dashboard/") {
+				imports[pkg] = struct{}{}
+				continue
+			}
+			if i := strings.IndexByte(pkg, '/'); i >= 0 {
+				pkg = pkg[:i]
+			}
+			imports[pkg] = struct{}{}
+		}
+	}
+	if len(imports) > maxDashboardInternalImports {
+		t.Fatalf("pkg/dashboard imports %d internal packages, want <= %d", len(imports), maxDashboardInternalImports)
+	}
+}

--- a/src/pkg/dashboard/inception_watcher.go
+++ b/src/pkg/dashboard/inception_watcher.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kubestellar/hive/pkg/beads"
 	"github.com/kubestellar/hive/pkg/governor"
 	"github.com/kubestellar/hive/pkg/knowledge"
-	"github.com/kubestellar/hive/pkg/scheduler"
 )
 
 const (
@@ -50,7 +49,7 @@ type inceptionAgentManager interface {
 type InceptionWatcher struct {
 	beadStore *beads.Store
 	inception *knowledge.InceptionEngine
-	scheduler *scheduler.Scheduler
+	scheduler SchedulerControl
 	agentMgr  inceptionAgentManager
 	governor  *governor.Governor
 	logger    *slog.Logger
@@ -80,7 +79,7 @@ type InceptionWatcher struct {
 func NewInceptionWatcher(
 	beadStore *beads.Store,
 	inception *knowledge.InceptionEngine,
-	sched *scheduler.Scheduler,
+	sched SchedulerControl,
 	agentMgr *agent.Manager,
 	gov *governor.Governor,
 	logger *slog.Logger,


### PR DESCRIPTION
## Summary
- introduce a dashboard-owned SchedulerControl interface for scheduler calls
- switch dashboard dependencies and inception watcher construction to the narrow interface
- add an internal import-count ratchet for pkg/dashboard and a changelog fragment

Fixes #5565

## Validation
- cd src && go test ./pkg/dashboard -run 'TestDashboardInternalImportCountRatchet|Test.*Scheduler|Test.*Inception|Test.*Status|Test.*AgentRoles'\n- cd src && go build ./...\n- cd src && go vet ./...\n\nFinal pkg/dashboard internal-import count: 31.