### PR TITLE
✨ feature: gate legacy operations through approval desk

### DIFF
--- a/changelog.d/changed-4000-tool-approval-gates.md
+++ b/changelog.d/changed-4000-tool-approval-gates.md
@@ -1,0 +1,1 @@
+- Routed the remaining merge-queue and plan-from-label ACMM gates through the tool-approval desk when enabled, preserving legacy decisions while adding the explicit RFC #4000 operation surface.

--- a/src/cmd/hive/approvalwire.go
+++ b/src/cmd/hive/approvalwire.go
@@ -45,6 +45,46 @@ func buildApprovalDesk(cfg *config.Config, logger *slog.Logger) (*toolapprove.De
 	return desk, inbox
 }
 
+// approvalDeskAllowsLegacyOperation wraps an existing legacy gate result in the
+// RFC #4000 decision point. Callers invoke it only after their legacy gate has
+// allowed the operation, so a nil/disabled desk preserves old behavior and an
+// enabled desk may record, audit, or withhold but never widen authority.
+func approvalDeskAllowsLegacyOperation(
+	ctx context.Context,
+	desk *toolapprove.Desk,
+	cfg *config.Config,
+	kind string,
+	tool string,
+	agentName string,
+	logger *slog.Logger,
+) bool {
+	if desk == nil {
+		return true
+	}
+	req := toolapprove.Request{
+		Kind: kind,
+		Tool: toolapprove.ToolRequest{
+			Tool: tool,
+		},
+		Agent: toolapprove.AgentIdentity{
+			Name: agentName,
+		},
+		LegacyAllowed:    true,
+		HasLegacyAllowed: true,
+	}
+	acmmLevel := toolapprove.ACMMLevelOf(cfg)
+	v := desk.Resolve(ctx, req, acmmLevel)
+	if v.Decision == toolapprove.DecisionAutoApprove {
+		return true
+	}
+	if logger != nil {
+		logger.Info("tool-approval: legacy operation withheld",
+			"kind", kind, "tool", tool, "agent", agentName,
+			"decision", string(v.Decision), "rationale", v.Rationale)
+	}
+	return false
+}
+
 // newSelfMergeDeskHook adapts the desk to the GitHub client's narrow
 // ApprovalDeskHook signature, for the self-authored auto-merge sweep — the one
 // real producer wired in this slice.
@@ -79,10 +119,18 @@ func newSelfMergeDeskHook(
 			Title:       in.Title,
 			Labels:      in.Labels,
 			ChecksGreen: in.ChecksGreen,
+			// The GitHub sweep calls this hook only after its legacy
+			// eligibility checks have passed. Preserve that result exactly; the
+			// desk adds policy/audit/queue semantics and may only withhold.
+			LegacyAllowed:    true,
+			HasLegacyAllowed: true,
 			Tool: toolapprove.ToolRequest{
 				Tool:   "hive-merge",
 				Target: in.HeadSHA,
 			},
+		}
+		if in.Kind != "" {
+			req.Kind = in.Kind
 		}
 
 		// A verdict this operator already granted must merge, and must merge

--- a/src/cmd/hive/approvalwire_test.go
+++ b/src/cmd/hive/approvalwire_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubestellar/hive/pkg/config"
+	"github.com/kubestellar/hive/pkg/toolapprove"
+)
+
+func TestApprovalDeskAllowsLegacyOperationNilDesk(t *testing.T) {
+	if !approvalDeskAllowsLegacyOperation(context.Background(), nil, &config.Config{}, toolapprove.KindPlanFromLabel, "plan", "architect", nil) {
+		t.Fatal("nil desk must preserve the legacy allowed operation")
+	}
+}
+
+func TestApprovalDeskAllowsLegacyOperationCanWithhold(t *testing.T) {
+	rules, err := toolapprove.CompileRules([]toolapprove.Rule{{
+		Name:   "human-plan-label",
+		Expr:   `request.kind == "plan-from-label"`,
+		Action: toolapprove.RuleActionOperatorApprove,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("CompileRules: %v", err)
+	}
+	desk := toolapprove.NewDesk(rules, nil)
+	level := 6
+	cfg := &config.Config{ACMMLevel: &level}
+
+	if approvalDeskAllowsLegacyOperation(context.Background(), desk, cfg, toolapprove.KindPlanFromLabel, "plan", "architect", nil) {
+		t.Fatal("operator-approve rule should withhold the legacy operation")
+	}
+}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -2693,7 +2693,7 @@ func main() {
 			initAgentConfigDrivenSystems(cfg)
 		},
 		EnumerateFunc: func() {
-			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
+			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, approvalDesk, logger)
 		},
 		AdvisoryResetFunc: func(newPrimaryRepo string) {
 			logger.Info("advisory reset: primary repo changed, creating new advisory issue", "repo", newPrimaryRepo)
@@ -4934,7 +4934,7 @@ func main() {
 	// interval. A hive with no persisted state (fresh install) has no LastKick
 	// entries, and every cadenced agent is still kicked here, unchanged.
 	logger.Info("startup honors persisted cadence state — first eval kicks only agents whose cadence has elapsed")
-	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, logger)
+	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, nil, approvalDesk, logger)
 	runRotationCheck(ctx, cfg, rotationMgr, gov, agentMgr, logger)
 	if wd != nil {
 		wd.Tick(ctx)
@@ -5013,7 +5013,7 @@ func main() {
 					restarted = append(restarted, name)
 				}
 			}
-			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, restarted, logger)
+			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, restarted, approvalDesk, logger)
 			runRotationCheck(ctx, cfg, rotationMgr, gov, agentMgr, logger)
 			runAutoMergeSweepIfDue(ctx, ghClient, dashSrv, &lastAutoMergeSweep, logger)
 			// Trajectory review runs after the eval cycle (so kicks/intents are
@@ -5878,6 +5878,7 @@ func runEvalCycle(
 	advisoryStore *advisory.Store,
 	advisoryIssues map[string]int,
 	restartedAgents []string,
+	approvalDesk *toolapprove.Desk,
 	logger *slog.Logger,
 ) {
 	// Governor eval-cycle span. When tracing is disabled (the default) this is
@@ -6421,7 +6422,8 @@ func runEvalCycle(
 	// no duplicate epic if one already exists). Cheap, synchronous, adds NO
 	// goroutine, and drives the architect only via SendKick (never the launch
 	// path). Gated by config/ACMM so low-maturity hives stay advisory-only.
-	if acmmLvl := inferACMMLevel(cfg); cfg.Planning.PlanFromLabelEnabled(acmmLvl) {
+	if acmmLvl := inferACMMLevel(cfg); cfg.Planning.PlanFromLabelEnabled(acmmLvl) &&
+		approvalDeskAllowsLegacyOperation(ctx, approvalDesk, cfg, toolapprove.KindPlanFromLabel, "plan-from-label", planning.ArchitectAgentName, logger) {
 		planFromLabeledIssues(actionable, beadStores, agentMgr, gov, dashSrv, logger, acmmLvl)
 	}
 

--- a/src/docs/design/tool-approval-desk.md
+++ b/src/docs/design/tool-approval-desk.md
@@ -273,13 +273,18 @@ enabled — a hive that has not opted in sees no new chrome.
 
 ## 8. What is wired today
 
-One real producer, **behind a default-OFF flag**: the self-authored auto-merge
-sweep (`pkg/github/automerge_desk.go`).
+Three real producers, **behind a default-OFF flag**:
 
-It is the cheapest honest producer — already exactly the shape the desk
-generalizes, it is the gate whose incident history the RFC cites, and it needs
-no new call site because the sweep already computes repo, number, author, and a
-real `ChecksGreen` from `commitGreen`.
+- The self-authored auto-merge sweep (`pkg/github/automerge_desk.go`).
+- The trusted human merge queue (`trySweepQueuedPR`).
+- The plan-from-label trigger in the governor evaluation cycle.
+
+The merge producers were the cheapest honest starting point: they already have
+the shape the desk generalizes and compute repo, number, author, reviewed SHA,
+and a real `ChecksGreen` from `commitGreen`. The plan-from-label producer wraps
+the existing `PlanningConfig.PlanFromLabelEnabled` result so the desk can
+withhold or audit the operation without making the label trigger more
+permissive.
 
 The consultation happens **after** the sweep's own eligibility checks, so the
 desk can only ever *withhold* a merge the legacy gate already permitted — it can
@@ -327,9 +332,9 @@ Two deliberate choices:
 
 ### Remaining
 
-- Migrate the other three gates (plan approval, plan-from-label, queued merge)
-  onto the desk at their call sites. Parity functions and tests already exist
-  for all three; only the call-site swap remains.
+- Wire any future production caller of the decomposition `plan_auto_approve`
+  gate through the desk. The parity function exists, but the current v5 tree has
+  no long-running hive call site beyond direct `bd decompose --auto-approve`.
 - Route `security-scan` through the sec-check agent surface
   (`buildSecCheckMessage`) rather than the in-process `DefaultSecurityScanner`,
   with the async/post-hoc path for pattern-matched-known-safe requests that

--- a/src/pkg/github/automerge_desk.go
+++ b/src/pkg/github/automerge_desk.go
@@ -86,6 +86,10 @@ type ApprovalDeskRequest struct {
 // toolapprove.KindSelfMerge without importing it.
 const ApprovalDeskKindSelfMerge = "self-merge"
 
+// ApprovalDeskKindQueuedMerge names the trusted-human merge-queue lane. It
+// mirrors toolapprove.KindQueuedMerge without importing it.
+const ApprovalDeskKindQueuedMerge = "queued-merge"
+
 // SetApprovalDesk installs the approval-desk hook. Passing nil removes it,
 // restoring pre-desk behavior. A nil client is a no-op.
 //

--- a/src/pkg/github/automerge_sweep.go
+++ b/src/pkg/github/automerge_sweep.go
@@ -732,6 +732,23 @@ func (c *Client) trySweepQueuedPR(ctx context.Context, displayRepo, owner, repo 
 		return AutoMergeSweepEvent{}, reason, nil
 	}
 
+	// Approval desk (RFC #4000) for the trusted human merge-queue lane.
+	// Consulted only after the legacy queue approval, trusted-merger,
+	// mergeability, and green-check gates pass, so enabling the desk can record
+	// or withhold this operation but cannot widen merge authority.
+	if allow, deskReason := c.consultApprovalDesk(ctx, ApprovalDeskRequest{
+		Kind:        ApprovalDeskKindQueuedMerge,
+		Repo:        displayRepo,
+		Number:      number,
+		Author:      author,
+		Title:       pr.GetTitle(),
+		Labels:      labels,
+		ChecksGreen: true,
+		HeadSHA:     headSHA,
+	}); !allow {
+		return AutoMergeSweepEvent{}, deskReason, nil
+	}
+
 	mergeResult, _, err := c.client.PullRequests.Merge(ctx, owner, repo, number, "", &gh.PullRequestOptions{
 		SHA:         headSHA,
 		MergeMethod: "squash",

--- a/src/pkg/toolapprove/desk.go
+++ b/src/pkg/toolapprove/desk.go
@@ -203,6 +203,13 @@ type Request struct {
 	// IdempotencyKey de-duplicates a re-delivered request. Empty means the
 	// caller accepts a derived key (see DeriveIdempotencyKey).
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
+	// LegacyAllowed carries the call site's existing gate result when migrating
+	// a non-tool lane. It lets the desk preserve day-one behavior exactly while
+	// adding rules, ceiling, inbox, and audit semantics around that result.
+	LegacyAllowed bool `json:"legacy_allowed,omitempty"`
+	// HasLegacyAllowed distinguishes an explicit false legacy gate result from
+	// a request that did not provide one.
+	HasLegacyAllowed bool `json:"has_legacy_allowed,omitempty"`
 }
 
 // Request kinds. Each corresponds to one of the gates RFC #4000 inventoried,

--- a/src/pkg/toolapprove/parity.go
+++ b/src/pkg/toolapprove/parity.go
@@ -79,6 +79,17 @@ func LegacyBaseDecision(req Request, acmmLevel int) Verdict {
 		Agent:     req.Agent.Name,
 	}
 
+	if req.HasLegacyAllowed {
+		if req.LegacyAllowed {
+			v.Decision = DecisionAutoApprove
+			v.Rationale = fmt.Sprintf("legacy %s gate allowed request; approval desk records and audits the explicit operation", req.Kind)
+		} else {
+			v.Decision = DecisionOperatorApprove
+			v.Rationale = fmt.Sprintf("legacy %s gate did not allow request: routed to operator approval", req.Kind)
+		}
+		return v
+	}
+
 	switch req.Kind {
 	case KindSelfMerge:
 		// Parity note: the legacy gate ALSO requires AutoMergeConfig.Enabled and


### PR DESCRIPTION
Closes #4000.

## Summary
- preserve migrated legacy gate results explicitly in tool-approval desk requests
- route queued merges and plan-from-label through the approval desk when enabled
- document the wired producers and add coverage for desk withholding of legacy operations

## Validation
- cd src && go test ./pkg/toolapprove ./pkg/github ./cmd/hive
- cd src && go build ./...