### PR TITLE
✨ feature: route contributor work by declared capabilities

### DIFF
--- a/changelog.d/added-2547-capability-routing.md
+++ b/changelog.d/added-2547-capability-routing.md
@@ -1,0 +1,1 @@
+- Added contributor capability-aware routing for explicit task requirement labels, while preserving assignments for undeclared clients and documenting the self-reported nature of the data.

--- a/src/docs/contributor-relay.md
+++ b/src/docs/contributor-relay.md
@@ -46,6 +46,12 @@ just contribute-hive claude local  # host mode — relay + CLI directly on your 
 ```
 
 Containerized mode auto-detects the runtime — docker first, then podman — and can be forced with `export HIVE_CONTAINER_RUNTIME=podman`.
+
+### Capability-aware routing
+
+The relay self-reports runtime capabilities during `auth_response`: container runtime, OS/arch, backend CLI version, credential type, protocol version, and Pi readiness where applicable. These values are self-reported and advisory, never a trust or credential-enforcement signal.
+
+The hub may use them only to avoid explicit task mismatches. Task requirements are derived from issue labels such as `needs-container`, `needs-docker`, `needs-podman`, `os/linux`, `arch/amd64`, `backend/copilot`, and `credential/app`. If a client explicitly declares a contradictory value, the hub skips that task for the client; if every otherwise-admissible task is skipped this way, the relay receives `task_unavailable` with reason `capability_mismatch`. A relay that declares nothing, or leaves a field unknown, continues to receive work as before.
 The resolved runtime is passed into the container, so the "attach to the CLI" hints printed from inside it (the status line, and the banner shown when the CLI needs a login) name the engine that actually launched it ([#5145](https://github.com/kubestellar/hive/issues/5145)). In host mode there is no container, and those hints are a plain `tmux attach -t <session>`.
 
 Use `just contribute-check <backend>` before registering to catch missing CLIs or obvious auth gaps.

--- a/src/pkg/dashboard/contribute_capability_bounds_test.go
+++ b/src/pkg/dashboard/contribute_capability_bounds_test.go
@@ -227,3 +227,30 @@ func waitForClanker(t *testing.T, s *Server, contributorID string) FleetClanker 
 	t.Fatalf("clanker %s never appeared in the fleet snapshot", contributorID)
 	return FleetClanker{}
 }
+
+func TestTaskRequirementsFromLabels(t *testing.T) {
+	req := TaskRequirementsFromLabels([]string{"needs-docker", "os/linux", "arch/amd64", "backend/copilot", "credential/app"})
+	if req.ContainerRuntime != "docker" || req.OS != "linux" || req.Arch != "amd64" || req.CLIBackend != "copilot" || req.CredentialType != "app" {
+		t.Fatalf("requirements = %+v", req)
+	}
+}
+
+func TestContributorCanRunTaskTreatsUnknownAsCompatible(t *testing.T) {
+	req := TaskRequirementsFromLabels([]string{"needs-docker", "os/linux"})
+	if !ContributorCanRunTask(nil, "", req) {
+		t.Fatal("undeclared capabilities must remain compatible")
+	}
+	if !ContributorCanRunTask(&ContributorCapabilities{}, "", req) {
+		t.Fatal("empty declaration must remain compatible")
+	}
+}
+
+func TestContributorCanRunTaskRejectsExplicitContradiction(t *testing.T) {
+	req := TaskRequirementsFromLabels([]string{"needs-docker", "os/linux"})
+	if ContributorCanRunTask(&ContributorCapabilities{ContainerRuntime: "podman", OS: "linux"}, "copilot", req) {
+		t.Fatal("podman declaration must not fit needs-docker")
+	}
+	if ContributorCanRunTask(&ContributorCapabilities{ContainerRuntime: "docker", OS: "darwin"}, "copilot", req) {
+		t.Fatal("darwin declaration must not fit os/linux")
+	}
+}

--- a/src/pkg/dashboard/contribute_protocol.go
+++ b/src/pkg/dashboard/contribute_protocol.go
@@ -22,11 +22,10 @@
 //     supports (e.g. token_refresh, task_unavailable reasons, prompt preview)
 //     instead of probing and reacting to silence.
 //
-//   - This is the DECLARE half of #2547 only. Clients may DECLARE their runtime
-//     posture (container runtime, OS/arch, agent/relay versions, credential
-//     type); the hub PARSES, STORES, and SURFACES it read-only. It does NOT
-//     ROUTE or gate work on any declared capability — that is the deferred Gate
-//     half and is deliberately out of scope here.
+//   - Client capabilities are self-reported. The hub may use an explicit
+//     "cannot fit" declaration to avoid wasting an assignment on a matching
+//     task requirement, but it must never treat the declaration as a trust or
+//     security signal. Unknown/absent still means unknown, not incapable.
 package dashboard
 
 import (
@@ -79,6 +78,11 @@ const (
 	// offer-pool suppression instead of the short idle cooldown loop. Purely
 	// additive: a relay that never sends the field behaves exactly as before.
 	capCompletionVerdict = "completion_verdict"
+	// capCapabilityRouting: the hub can derive task requirements from labels and
+	// avoid assigning a task to a client that explicitly declared it cannot fit.
+	// Self-reported, advisory, and backward-compatible: undeclared clients still
+	// receive work as before.
+	capCapabilityRouting = "capability_routing"
 )
 
 // serverCapabilities returns the capability set this hub advertises on auth_ok.
@@ -93,6 +97,7 @@ func serverCapabilities() []string {
 		capCredentialAfterAccept,
 		capAgentRoleClaim,
 		capCompletionVerdict,
+		capCapabilityRouting,
 	}
 }
 
@@ -109,11 +114,11 @@ const (
 )
 
 // ContributorCapabilities is the OPTIONAL, client-declared runtime posture a
-// contributor relay may report in its auth_response (#2547 declare half). Every
+// contributor relay may report in its auth_response (#2547). Every
 // field is omitempty: a client that declares nothing sends an absent/empty
 // object and is treated exactly as an unversioned client. The hub STORES this on
-// the connection and SURFACES it read-only (FleetClanker) so the Operations tab
-// COULD show it — it is NEVER used to route or gate work.
+// the connection and SURFACES it. Routing may only use it to avoid tasks whose
+// requirements the client explicitly cannot satisfy; it is NEVER a trust signal.
 //
 // Fields are honest self-reports the relay can cheaply determine; none is
 // trusted for a security decision (server-side policy still governs what a
@@ -144,6 +149,99 @@ type ContributorCapabilities struct {
 	PiConfiguration  string `json:"pi_configuration,omitempty"`
 	PiAuthentication string `json:"pi_authentication,omitempty"`
 	PiInvocation     string `json:"pi_invocation,omitempty"`
+}
+
+// ContributorTaskRequirements is the hub-derived task-side vocabulary used for
+// the ROUTE half of #2547. It is intentionally tiny and label-derived: operators
+// can add labels without changing issue bodies, and old relays remain compatible
+// because an undeclared client is treated as unknown rather than incapable.
+type ContributorTaskRequirements struct {
+	ContainerRuntime string `json:"container_runtime,omitempty"`
+	OS               string `json:"os,omitempty"`
+	Arch             string `json:"arch,omitempty"`
+	CLIBackend       string `json:"cli_backend,omitempty"`
+	CredentialType   string `json:"credential_type,omitempty"`
+}
+
+// IsZero reports whether a task has no explicit capability requirements.
+func (r ContributorTaskRequirements) IsZero() bool {
+	return r.ContainerRuntime == "" && r.OS == "" && r.Arch == "" &&
+		r.CLIBackend == "" && r.CredentialType == ""
+}
+
+// TaskRequirementsFromLabels derives hard routing requirements from issue
+// labels. The vocabulary is deliberately explicit: labels outside these forms
+// remain ordinary triage labels and do not affect assignment.
+func TaskRequirementsFromLabels(labels []string) ContributorTaskRequirements {
+	var out ContributorTaskRequirements
+	for _, raw := range labels {
+		l := strings.ToLower(strings.TrimSpace(raw))
+		switch {
+		case l == "needs-container" || l == "requires-container":
+			if out.ContainerRuntime == "" {
+				out.ContainerRuntime = "container"
+			}
+		case l == "needs-docker" || l == "requires-docker" || l == "runtime/docker":
+			out.ContainerRuntime = "docker"
+		case l == "needs-podman" || l == "requires-podman" || l == "runtime/podman":
+			out.ContainerRuntime = "podman"
+		case strings.HasPrefix(l, "os/"):
+			out.OS = strings.TrimSpace(strings.TrimPrefix(l, "os/"))
+		case strings.HasPrefix(l, "arch/"):
+			out.Arch = strings.TrimSpace(strings.TrimPrefix(l, "arch/"))
+		case strings.HasPrefix(l, "backend/"):
+			out.CLIBackend = strings.TrimSpace(strings.TrimPrefix(l, "backend/"))
+		case strings.HasPrefix(l, "credential/"):
+			out.CredentialType = strings.TrimSpace(strings.TrimPrefix(l, "credential/"))
+		}
+	}
+	return out
+}
+
+// ContributorCanRunTask reports whether a self-declared client fits the task's
+// requirements. Unknown always fits for backward compatibility; only an explicit
+// contradictory declaration excludes the client.
+func ContributorCanRunTask(caps *ContributorCapabilities, cliBackend string, req ContributorTaskRequirements) bool {
+	if req.IsZero() || caps == nil || caps.IsZero() {
+		return true
+	}
+	if req.ContainerRuntime != "" {
+		have := strings.ToLower(strings.TrimSpace(caps.ContainerRuntime))
+		want := strings.ToLower(req.ContainerRuntime)
+		if want == "container" {
+			if have == "none" {
+				return false
+			}
+		} else if have != "" && have != want {
+			return false
+		}
+	}
+	if !capabilityFieldFits(caps.OS, req.OS) {
+		return false
+	}
+	if !capabilityFieldFits(caps.Arch, req.Arch) {
+		return false
+	}
+	if !capabilityFieldFits(caps.CredentialType, req.CredentialType) {
+		return false
+	}
+	if req.CLIBackend != "" {
+		have := strings.ToLower(strings.TrimSpace(cliBackend))
+		want := strings.ToLower(req.CLIBackend)
+		if have != "" && have != want {
+			return false
+		}
+	}
+	return true
+}
+
+func capabilityFieldFits(have, want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	if want == "" {
+		return true
+	}
+	have = strings.ToLower(strings.TrimSpace(have))
+	return have == "" || have == want
 }
 
 // IsZero reports whether the client declared no capabilities at all, so the hub

--- a/src/pkg/dashboard/contribute_protocol_test.go
+++ b/src/pkg/dashboard/contribute_protocol_test.go
@@ -435,19 +435,11 @@ func TestContributeStatus_CarriesSurfaceAndVersion(t *testing.T) {
 	}
 }
 
-// ── #2547 DECLARE-half guard: declarations must NEVER influence selection ─────
+// ── #2547 ROUTE: declarations may avoid explicit task mismatches only ─────
 //
-// The accepted design split on kubestellar/hive#2547 is DECLARE only: a client
-// may describe its execution environment, and the hub records and DISPLAYS it —
-// but acting on a declaration when choosing what to assign (the ROUTE half) is
-// explicitly undecided and NOT implemented. The tests below pin that invariant
-// the same way the F14 owner-gate tests do — behaviourally (selection output is
-// identical with and without a declaration) AND at source level (the selection
-// code cannot even see the field) — because the failure mode to defend against
-// is a future change, or a sync merge, quietly wiring the self-reported posture
-// into dispatch. A declaration is unverified self-description; the moment it
-// influences assignment it becomes a value the client controls steering the
-// hub, which #2547 records as an explicit non-goal until ROUTE is decided.
+// ROUTE is now deliberately narrow: a client declaration may only withhold a
+// task whose labels state explicit requirements contradicted by the client.
+// Unlabeled work and undeclared clients preserve the previous assignment path.
 
 // richDeclaration returns a fully-populated, privileged-LOOKING capability
 // declaration. Nothing in it may buy — or cost — an assignment.
@@ -462,12 +454,9 @@ func richDeclaration() *ContributorCapabilities {
 	}
 }
 
-// TestSelectTask_DeclaredCapabilitiesDoNotAffectSelection asserts the ROUTE
-// half is genuinely unimplemented: contributors identical in every input
-// selectTask may legitimately read (tier, role, username, label interests) but
-// differing in what they declared are offered exactly the same work item, and a
-// single contributor's pick does not move when it starts declaring mid-session.
-func TestSelectTask_DeclaredCapabilitiesDoNotAffectSelection(t *testing.T) {
+// TestSelectTask_DeclaredCapabilitiesDoNotAffectUnrequiredWork asserts that
+// plain work is unchanged by a capability declaration.
+func TestSelectTask_DeclaredCapabilitiesDoNotAffectUnrequiredWork(t *testing.T) {
 	hub, s := covK2Hub(t)
 	s.statusMu.Lock()
 	s.status = &StatusPayload{
@@ -548,13 +537,110 @@ func selectionFuncBody(t *testing.T, src, name string) string {
 	return src[i : i+j]
 }
 
-// TestSelectionPathsDoNotReadDeclaredCapabilities is the source-level half of
-// the guard: the assignment/selection code paths must not even MENTION the
-// declared capability map. A behavioural test alone could pass while a routing
-// read hides behind config that is off in tests; a merge that wires the field
-// into selectTask trips this immediately (the exact way the F14 owner-gate
-// regression was caught).
-func TestSelectionPathsDoNotReadDeclaredCapabilities(t *testing.T) {
+func TestSelectTask_SkipsExplicitCapabilityMismatch(t *testing.T) {
+	hub, s := covK2Hub(t)
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{{
+			Name: "repo1",
+			Full: "myorg/repo1",
+			ActionableIssues: []any{
+				map[string]any{
+					"number": float64(10),
+					"title":  "Needs containers",
+					"url":    "https://github.com/myorg/repo1/issues/10",
+					"labels": []string{"needs-container"},
+					"author": "someone",
+				},
+				map[string]any{
+					"number": float64(20),
+					"title":  "Plain work",
+					"url":    "https://github.com/myorg/repo1/issues/20",
+					"author": "someone",
+				},
+			},
+		}},
+	}
+	s.statusMu.Unlock()
+
+	conn := &ContributorConnection{
+		profile:      &ContributorProfile{GitHubUsername: "cap-none", ContributorID: "c-cap-none", TrustTier: "contributor"},
+		lastPong:     time.Now(),
+		cliBackend:   "copilot",
+		capabilities: &ContributorCapabilities{ContainerRuntime: "none", OS: "linux", Arch: "amd64"},
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("expected fallback task_assign, got %+v", msg)
+	}
+	if msg.Number != 20 {
+		t.Fatalf("assigned issue #%d, want #20 after skipping needs-container mismatch", msg.Number)
+	}
+}
+
+func TestSelectTask_AllCapabilityMismatchesReturnsReason(t *testing.T) {
+	hub, s := covK2Hub(t)
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{{
+			Name: "repo1",
+			Full: "myorg/repo1",
+			ActionableIssues: []any{map[string]any{
+				"number": float64(10),
+				"title":  "Needs Docker",
+				"url":    "https://github.com/myorg/repo1/issues/10",
+				"labels": []string{"needs-docker"},
+				"author": "someone",
+			}},
+		}},
+	}
+	s.statusMu.Unlock()
+
+	conn := &ContributorConnection{
+		profile:      &ContributorProfile{GitHubUsername: "podman", ContributorID: "c-podman", TrustTier: "contributor"},
+		lastPong:     time.Now(),
+		cliBackend:   "copilot",
+		capabilities: &ContributorCapabilities{ContainerRuntime: "podman"},
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_unavailable" || msg.Reason != taskUnavailableCapabilityMismatch {
+		t.Fatalf("expected task_unavailable/%s, got %+v", taskUnavailableCapabilityMismatch, msg)
+	}
+}
+
+func TestSelectTask_UndeclaredCapabilitiesStillReceiveRequiredWork(t *testing.T) {
+	hub, s := covK2Hub(t)
+	s.statusMu.Lock()
+	s.status = &StatusPayload{
+		Repos: []FrontendRepo{{
+			Name: "repo1",
+			Full: "myorg/repo1",
+			ActionableIssues: []any{map[string]any{
+				"number": float64(10),
+				"title":  "Needs Docker",
+				"url":    "https://github.com/myorg/repo1/issues/10",
+				"labels": []string{"needs-docker"},
+				"author": "someone",
+			}},
+		}},
+	}
+	s.statusMu.Unlock()
+
+	conn := &ContributorConnection{
+		profile:    &ContributorProfile{GitHubUsername: "old", ContributorID: "c-old", TrustTier: "contributor"},
+		lastPong:   time.Now(),
+		cliBackend: "copilot",
+	}
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" || msg.Number != 10 {
+		t.Fatalf("undeclared client must keep receiving work, got %+v", msg)
+	}
+}
+
+// TestSelectionPathsUseDeclaredCapabilitiesOnlyThroughRouteHelper is the
+// source-level guard: selection may consult declarations only through the
+// explicit #2547 fit helper, not through ad-hoc field reads.
+func TestSelectionPathsUseDeclaredCapabilitiesOnlyThroughRouteHelper(t *testing.T) {
 	raw, err := os.ReadFile("contribute_ws.go")
 	if err != nil {
 		t.Fatalf("read contribute_ws.go: %v", err)
@@ -574,11 +660,9 @@ func TestSelectionPathsDoNotReadDeclaredCapabilities(t *testing.T) {
 		if name == "selectTask" && !strings.Contains(body, "candidates") {
 			t.Fatal("extracted selectTask body has no candidate collection — extraction is wrong; fix the test")
 		}
-		if strings.Contains(strings.ToLower(body), "capabilit") {
-			t.Errorf("%s references the client-declared capability map — ROUTE is intentionally "+
-				"NOT implemented (kubestellar/hive#2547 DECLARE/ROUTE split). If routing has now been "+
-				"decided and recorded by a maintainer, update this test in that same PR; otherwise "+
-				"remove the read.", name)
+		lower := strings.ToLower(body)
+		if strings.Contains(lower, "capabilit") && !strings.Contains(body, "capabilityRoutingInputs") {
+			t.Errorf("%s references client capabilities outside the route helper", name)
 		}
 	}
 }

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -229,6 +229,10 @@ type WSMessage struct {
 	URL     string   `json:"url,omitempty"`
 	Labels  []string `json:"labels,omitempty"`
 	Prompt  string   `json:"prompt,omitempty"`
+	// Requirements carries the hub-derived task-side capability requirements
+	// used by #2547 routing. Additive and advisory: older relays ignore it, and
+	// enforcement already happened server-side before assignment.
+	Requirements *ContributorTaskRequirements `json:"requirements,omitempty"`
 	// TaskKey, SourceType and ExternalID carry the assigned item's canonical,
 	// source-aware identity (kubestellar/hive#4245). All additive and omitempty:
 	// a GitHub task_assign is byte-for-byte unchanged, and Repo/Number keep
@@ -257,10 +261,10 @@ type WSMessage struct {
 	// wire until a concrete client contract exists. (kubestellar/hive#2393 item 8.)
 	Restrictions json.RawMessage `json:"restrictions,omitempty"`
 	// Capabilities is the OPTIONAL client-declared runtime posture a contributor
-	// relay may report in its auth_response (kubestellar/hive#2547, declare half).
+	// relay may report in its auth_response (kubestellar/hive#2547).
 	// It is additive and purely advisory: a client that omits it authenticates
-	// and runs exactly as before, and the hub NEVER routes or gates work on it —
-	// it is only stored and surfaced read-only. Distinct from the RESERVED,
+	// and runs exactly as before. Routing may only use it to avoid explicit
+	// task-requirement mismatches; it is not a trust signal. Distinct from the RESERVED,
 	// server-side-only Restrictions field above: Capabilities flows client→server
 	// as an honest self-report, Restrictions is a reservation that stays empty.
 	Capabilities *ContributorCapabilities `json:"capabilities,omitempty"`
@@ -356,6 +360,9 @@ type WSTaskAssign struct {
 	SourceType string `json:"source_type,omitempty"`
 	ExternalID string `json:"external_id,omitempty"`
 	URL        string `json:"url,omitempty"`
+	// Requirements is the task-side capability requirement set used for
+	// contributor routing. Nil means this task carried no explicit requirements.
+	Requirements *ContributorTaskRequirements `json:"requirements,omitempty"`
 }
 
 // identityKey returns the canonical identity of the assigned item. It prefers
@@ -4749,6 +4756,11 @@ const (
 	// all filters (cooldown, disabled repos, allow/deny, skip-assigned, own-work),
 	// the candidate set is empty. There is simply nothing admissible to do now.
 	taskUnavailableNoMatchingWork = "no_matching_work"
+	// taskUnavailableCapabilityMismatch: work exists, but every otherwise
+	// admissible candidate had explicit task requirements contradicted by this
+	// client's self-declared capabilities. Undeclared/unknown clients do not hit
+	// this path; absence is not incapability.
+	taskUnavailableCapabilityMismatch = "capability_mismatch"
 	// taskUnavailableRoleNotPermitted: the relay requested a spoke agent role, but
 	// the hive config/tier/grant policy does not allow this contributor to claim it.
 	taskUnavailableRoleNotPermitted = "agent_role_not_permitted"
@@ -5018,6 +5030,20 @@ func promptInvocationMeta(c *ContributorConnection) ghpkg.InvocationMeta {
 		Effort:  c.reasoningEffort,
 	}
 	return meta
+}
+
+func capabilityRoutingInputs(c *ContributorConnection) (*ContributorCapabilities, string) {
+	if c == nil {
+		return nil, ""
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var caps *ContributorCapabilities
+	if c.capabilities != nil {
+		cp := *c.capabilities
+		caps = &cp
+	}
+	return caps, c.cliBackend
 }
 
 // canonicalRepoKey maps an arbitrary, possibly client-supplied repo string to the
@@ -5334,6 +5360,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		}
 		return false
 	}
+	declaredCaps, declaredBackend := capabilityRoutingInputs(c)
 
 	type candidate struct {
 		repoFull string
@@ -5353,6 +5380,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		// work is offered first, but a contributor with no match still gets other
 		// work. Off entirely when the contributor set no interests.
 		interestMatch bool
+		requirements  ContributorTaskRequirements
 		// recentFailures is the issue's current consecutive-failure count (#2435).
 		// It is a stable tie-break in the ordering below: among equally-admissible
 		// candidates, fewer-recent-failures first. Issues in an active failure
@@ -5362,6 +5390,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		recentFailures int
 	}
 	var candidates []candidate
+	capabilityMismatchSeen := false
 
 	// One ledger snapshot for this whole selection pass (#3845), shared with the
 	// contributor-neutral admission gate below so ReadyQueue and selectTask judge
@@ -5431,6 +5460,18 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				continue
 			}
 			labels := stringSliceFromAny(issue["labels"])
+			requirements := TaskRequirementsFromLabels(labels)
+			if !ContributorCanRunTask(declaredCaps, declaredBackend, requirements) {
+				capabilityMismatchSeen = true
+				h.logger.Info("[contribute-ws] skip: issue requirements do not fit declared client capabilities",
+					"repo", repo.Full, "number", number,
+					"required_container_runtime", requirements.ContainerRuntime,
+					"required_os", requirements.OS,
+					"required_arch", requirements.Arch,
+					"required_backend", requirements.CLIBackend,
+					"required_credential", requirements.CredentialType)
+				continue
+			}
 			// #3768: skip an issue that an open PR — from ANYONE, hive agent or
 			// human contributor — already claims to fix. The activeIssues guard
 			// above only covers tasks held by LIVE connections, and the
@@ -5561,6 +5602,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				// ordering untouched.
 				isOwn:         ownUsername != "" && strings.EqualFold(author, ownUsername),
 				interestMatch: interestMatchesLabels(labels),
+				requirements:  requirements,
 				// #2435: carry any lingering failure history so the ordering below
 				// can deprioritise a recently-failed issue within its bucket.
 				recentFailures: h.recentFailureCountKey(itemKey),
@@ -5573,6 +5615,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		// now (everything is in cooldown, filtered out, disabled, or already held).
 		// Previously a bare nil — indistinguishable on the wire from "suspended" or
 		// "hub not ready". Send an explicit no_matching_work negative-ack.
+		if capabilityMismatchSeen {
+			return h.taskUnavailable(taskUnavailableCapabilityMismatch)
+		}
 		return h.taskUnavailable(taskUnavailableNoMatchingWork)
 	}
 
@@ -5694,6 +5739,13 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		SourceType: chosen.ref.SourceType,
 		ExternalID: chosen.ref.ExternalID,
 		URL:        chosen.url,
+		Requirements: func() *ContributorTaskRequirements {
+			if chosen.requirements.IsZero() {
+				return nil
+			}
+			req := chosen.requirements
+			return &req
+		}(),
 	}
 	c.currentTaskGen = gen
 	// #2568: start the hub-owned lease clock. task_progress renews it; cleanupLoop
@@ -5753,6 +5805,13 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		TaskKey:    chosen.ref.Key(),
 		SourceType: chosen.ref.SourceType,
 		ExternalID: chosen.ref.ExternalID,
+		Requirements: func() *ContributorTaskRequirements {
+			if chosen.requirements.IsZero() {
+				return nil
+			}
+			req := chosen.requirements
+			return &req
+		}(),
 		// #2537: NO github_token / token_expires_at here. The scoped credential is
 		// split out of task_assign and delivered only after acceptance (see
 		// pendingToken / deliverTaskCredential). task_assign now carries exactly the


### PR DESCRIPTION
Closes #2547.

## Summary
- add label-derived task capability requirements and advertise capability routing
- make contributor assignment skip only explicit mismatches against self-reported client capabilities
- preserve legacy/undeclared relay behavior and return task_unavailable/capability_mismatch when everything otherwise eligible is skipped
- document the label vocabulary and self-reported caveat

## Validation
- cd src && go test ./pkg/dashboard
- cd src && go build ./...