### PR TITLE
🐛 forward-port dashboard cross-org repo migration

### DIFF
--- a/changelog.d/fixed-5779-cross-org-repos.md
+++ b/changelog.d/fixed-5779-cross-org-repos.md
@@ -1,0 +1,1 @@
+- The dashboard Repos tab now accepts same-forge `org/repo` entries and GitHub URLs from a new organization as an explicit hosted-hive org migration, while cross-org validation errors explain how to migrate instead of reporting a misleading repo-name shape problem ([#5779](https://github.com/hivecommons/hive/issues/5779)).

--- a/src/pkg/config/repo_target.go
+++ b/src/pkg/config/repo_target.go
@@ -109,18 +109,68 @@ func ValidateProjectRepoTargets(org string, repos []string, primaryRepo, forgeHo
 		return issue("project.repos", "repo is empty — expected org/repo")
 	}
 	for _, repo := range repos {
-		normalized, _ := NormalizeRepoForOrg(org, repo)
-		if repoIssue := validateRepoName("project.repos", normalized); repoIssue != nil {
+		if repoIssue := validateRepoTargetForOrg("project.repos", org, repo, forgeHost); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	if strings.TrimSpace(primaryRepo) != "" {
-		normalizedPrimary, _ := NormalizeRepoForOrg(org, primaryRepo)
-		if repoIssue := validateRepoName("project.primary_repo", normalizedPrimary); repoIssue != nil {
+		if repoIssue := validateRepoTargetForOrg("project.primary_repo", org, primaryRepo, forgeHost); repoIssue != nil {
 			return repoIssue
 		}
 	}
 	return nil
+}
+
+func validateRepoTargetForOrg(field, org, repo, forgeHost string) *RepoTargetIssue {
+	repo = strings.TrimSpace(repo)
+	if parsed, ok := parseExplicitRepoTarget(repo); ok {
+		if parsed.host != "" && !sameRepoTargetForgeHost(parsed.host, forgeHost) {
+			return validateRepoName(field, repo)
+		}
+		if parsed.org != "" && !strings.EqualFold(parsed.org, org) {
+			return issue(field, "repo '"+repo+"' belongs to org '"+parsed.org+"', but this hive is configured for org '"+org+"' — to migrate, save a repo from the new org in Settings → Repos so the dashboard can adopt it")
+		}
+	}
+	normalized, _ := NormalizeRepoForOrg(org, repo)
+	return validateRepoName(field, normalized)
+}
+
+type explicitRepoTarget struct {
+	org  string
+	host string
+}
+
+func parseExplicitRepoTarget(repo string) (explicitRepoTarget, bool) {
+	if repo == "" {
+		return explicitRepoTarget{}, false
+	}
+	if u, err := url.Parse(repo); err == nil && u.Scheme != "" && u.Host != "" {
+		parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)
+		if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+			return explicitRepoTarget{org: parts[0], host: strings.ToLower(u.Host)}, true
+		}
+		return explicitRepoTarget{}, false
+	}
+	stripped := strings.Trim(repo, "/")
+	parts := strings.Split(stripped, "/")
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" && !strings.Contains(parts[0], ".") {
+		return explicitRepoTarget{org: parts[0]}, true
+	}
+	if len(parts) >= 3 && strings.Contains(parts[0], ".") && parts[1] != "" && parts[2] != "" {
+		return explicitRepoTarget{org: parts[1], host: strings.ToLower(parts[0])}, true
+	}
+	return explicitRepoTarget{}, false
+}
+
+func sameRepoTargetForgeHost(a, b string) bool {
+	norm := func(h string) string {
+		h = strings.ToLower(strings.Trim(strings.TrimSpace(h), "/"))
+		if h == "" || h == "github.com" {
+			return "github.com"
+		}
+		return h
+	}
+	return norm(a) == norm(b)
 }
 
 func validateRepoName(field, repo string) *RepoTargetIssue {

--- a/src/pkg/config/repo_target_test.go
+++ b/src/pkg/config/repo_target_test.go
@@ -35,6 +35,13 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 			want:  "Repo target misconfigured: repo 'https://github.com/kubestellar/hive' is a URL — expected repo name only so the target resolves to org/repo. Fix in Settings → Repos.",
 		},
 		{
+			name:  "url pasted for different org explains migration",
+			org:   "kubestellar",
+			repos: []string{"https://github.com/hivecommons/hive"},
+			forge: "github.com",
+			want:  "Repo target misconfigured: repo 'https://github.com/hivecommons/hive' belongs to org 'hivecommons', but this hive is configured for org 'kubestellar' — to migrate, save a repo from the new org in Settings → Repos so the dashboard can adopt it. Fix in Settings → Repos.",
+		},
+		{
 			name:  "host org no repo leaves empty repo",
 			org:   "kubestellar",
 			repos: []string{""},
@@ -67,7 +74,7 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 			org:   "kubestellar",
 			repos: []string{"other/hive"},
 			forge: "github.com",
-			want:  "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Settings → Repos.",
+			want:  "Repo target misconfigured: repo 'other/hive' belongs to org 'other', but this hive is configured for org 'kubestellar' — to migrate, save a repo from the new org in Settings → Repos so the dashboard can adopt it. Fix in Settings → Repos.",
 		},
 		{
 			name:    "primary qualified with a different org",
@@ -75,7 +82,7 @@ func TestValidateProjectRepoTargets(t *testing.T) {
 			repos:   []string{"hive"},
 			primary: "other/hive",
 			forge:   "github.com",
-			want:    "Repo target misconfigured: repo 'other/hive' contains '/' — expected repo name only so the target resolves to org/repo. Fix in Settings → Repos.",
+			want:    "Repo target misconfigured: repo 'other/hive' belongs to org 'other', but this hive is configured for org 'kubestellar' — to migrate, save a repo from the new org in Settings → Repos so the dashboard can adopt it. Fix in Settings → Repos.",
 		},
 		// The live regression: an owner pastes the org/repo form GitHub shows.
 		// Accepted, because it normalizes to the bare repo under the same org.

--- a/src/pkg/dashboard/api.go
+++ b/src/pkg/dashboard/api.go
@@ -6163,8 +6163,11 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	// restore it — the "always exactly one default" guard below runs once the
 	// final repos+primary are known, and a reject must not leave a half-applied
 	// config in memory (which would then be persisted on the next unrelated save).
+	prevOrg := s.deps.Config.Project.Org
 	prevRepos := append([]string(nil), s.deps.Config.Project.Repos...)
 	prevPrimary := s.deps.Config.Project.PrimaryRepo
+	prevBaseURL := s.deps.Config.GitHub.BaseURL
+	prevAPIURL := s.deps.Config.GitHub.APIURL
 
 	spokeHost := s.hiveForgeHost()
 	validateRepos := prevRepos
@@ -6175,18 +6178,26 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	if body.PrimaryRepo != nil {
 		validatePrimary = *body.PrimaryRepo
 	}
-	// Normalize org-qualified entries ("myorg/myrepo" under org "myorg") to the
-	// bare repo name BEFORE validating, so the accepted value and the persisted
-	// value are the same shape. Without this an owner pasting the org/repo form
-	// GitHub shows everywhere is rejected with a 400 here, or — worse, on paths
-	// that skip this handler — persisted org-qualified and then resolved as
-	// "org/org/repo", which fails every agent. An entry qualified with a
-	// different org is left untouched and still 400s below.
-	validateRepos, _ = config.NormalizeProjectRepos(org, validateRepos)
-	validatePrimary, _ = config.NormalizeRepoForOrg(org, validatePrimary)
-	if issue := config.ValidateProjectRepoTargets(org, validateRepos, validatePrimary, spokeHost); issue != nil {
+	adoptOrg := org
+	if nextOrg, errMsg := governorReposAdoptOrg(org, validateRepos, validatePrimary, spokeHost); errMsg != "" {
+		jsonError(w, errMsg, http.StatusBadRequest)
+		return
+	} else if nextOrg != "" {
+		adoptOrg = nextOrg
+	}
+	validateRepos = normalizeGovernorRepoRefs(adoptOrg, validateRepos)
+	validatePrimary = normalizeGovernorRepoRef(adoptOrg, validatePrimary)
+	if issue := config.ValidateProjectRepoTargets(adoptOrg, validateRepos, validatePrimary, spokeHost); issue != nil {
 		jsonError(w, issue.Message, http.StatusBadRequest)
 		return
+	}
+	if adoptOrg != org {
+		s.logger.Info("project org changed from repo paste", "from", org, "to", adoptOrg)
+		org = adoptOrg
+		s.deps.Config.Project.Org = adoptOrg
+		if s.deps.GHClient != nil {
+			s.deps.GHClient.SetOrg(adoptOrg)
+		}
 	}
 	// Feed the normalized values back into the body so the persistence code
 	// below stores bare names even when its own url-parse branch does not fire.
@@ -6195,18 +6206,6 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.PrimaryRepo != nil {
 		body.PrimaryRepo = &validatePrimary
-	}
-	for _, ref := range body.Repos {
-		if h := repoRefHostLabel(ref); h != "" && !sameForgeHost(h, spokeHost) {
-			jsonError(w, fmt.Sprintf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host. Remove the mismatched repo or use a repo on %s.", strings.TrimSpace(ref), h, spokeHost, spokeHost), http.StatusBadRequest)
-			return
-		}
-	}
-	if body.PrimaryRepo != nil {
-		if h := repoRefHostLabel(*body.PrimaryRepo); h != "" && !sameForgeHost(h, spokeHost) {
-			jsonError(w, fmt.Sprintf("default repo %q is on %s but this hive is on %s — the default must live on this hive's forge.", strings.TrimSpace(*body.PrimaryRepo), h, spokeHost), http.StatusBadRequest)
-			return
-		}
 	}
 
 	if len(body.Repos) > 0 {
@@ -6279,9 +6278,13 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if primary == "" || !inList {
+			s.deps.Config.Project.Org = prevOrg
 			s.deps.Config.Project.Repos = prevRepos
 			s.deps.Config.Project.PrimaryRepo = prevPrimary
+			s.deps.Config.GitHub.BaseURL = prevBaseURL
+			s.deps.Config.GitHub.APIURL = prevAPIURL
 			if s.deps.GHClient != nil {
+				s.deps.GHClient.SetOrg(prevOrg)
 				s.deps.GHClient.SetRepos(prevRepos)
 			}
 			jsonError(w, "set a default repo before saving — one of the monitored repos must be marked as the default (the repo where the advisory issue is maintained)", http.StatusBadRequest)
@@ -6306,6 +6309,79 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 // against, and mirrors config.GitHubConfig.HostLabel() (the same value the
 // dashboard reads as github_base_url's host). Falls back to public github.com
 // when no config is loaded (tests/early boot).
+
+type parsedGovernorRepoRef struct {
+	Owner string
+	Name  string
+	Host  string
+	OK    bool
+}
+
+func parseGovernorRepoRef(ref string) parsedGovernorRepoRef {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return parsedGovernorRepoRef{}
+	}
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		parts := strings.SplitN(strings.TrimPrefix(parsed.Path, "/"), "/", 3)
+		if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+			return parsedGovernorRepoRef{Owner: parts[0], Name: parts[1], Host: strings.ToLower(parsed.Host), OK: true}
+		}
+		return parsedGovernorRepoRef{Host: strings.ToLower(parsed.Host)}
+	}
+	stripped := strings.Trim(trimmed, "/")
+	parts := strings.Split(stripped, "/")
+	if len(parts) >= 3 && strings.Contains(parts[0], ".") && parts[1] != "" && parts[2] != "" {
+		return parsedGovernorRepoRef{Owner: parts[1], Name: parts[2], Host: strings.ToLower(parts[0]), OK: true}
+	}
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" && !strings.Contains(parts[0], ".") {
+		return parsedGovernorRepoRef{Owner: parts[0], Name: parts[1], OK: true}
+	}
+	return parsedGovernorRepoRef{}
+}
+
+func governorReposAdoptOrg(currentOrg string, repos []string, primary, spokeHost string) (string, string) {
+	adoptOrg := strings.TrimSpace(currentOrg)
+	refs := append([]string{}, repos...)
+	if strings.TrimSpace(primary) != "" {
+		refs = append(refs, primary)
+	}
+	for _, ref := range refs {
+		parsed := parseGovernorRepoRef(ref)
+		if parsed.Host != "" && !sameForgeHost(parsed.Host, spokeHost) {
+			return "", fmt.Sprintf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host. Remove the mismatched repo or use a repo on %s.", strings.TrimSpace(ref), parsed.Host, spokeHost, spokeHost)
+		}
+		if !parsed.OK || parsed.Owner == "" || strings.EqualFold(parsed.Owner, currentOrg) {
+			continue
+		}
+		if adoptOrg != "" && !strings.EqualFold(adoptOrg, currentOrg) && !strings.EqualFold(adoptOrg, parsed.Owner) {
+			return "", fmt.Sprintf("repos name multiple GitHub orgs (%s and %s). A hive can monitor one org at a time; submit repos from a single destination org to migrate.", adoptOrg, parsed.Owner)
+		}
+		adoptOrg = parsed.Owner
+	}
+	return adoptOrg, ""
+}
+
+func normalizeGovernorRepoRefs(org string, repos []string) []string {
+	if len(repos) == 0 {
+		return repos
+	}
+	out := make([]string, len(repos))
+	for i, repo := range repos {
+		out[i] = normalizeGovernorRepoRef(org, repo)
+	}
+	return out
+}
+
+func normalizeGovernorRepoRef(org, ref string) string {
+	parsed := parseGovernorRepoRef(ref)
+	if parsed.OK && parsed.Name != "" && (parsed.Owner == "" || strings.EqualFold(parsed.Owner, org)) {
+		return parsed.Name
+	}
+	normalized, _ := config.NormalizeRepoForOrg(org, ref)
+	return normalized
+}
+
 func (s *Server) hiveForgeHost() string {
 	if s.deps != nil && s.deps.Config != nil {
 		return s.deps.Config.GitHub.HostLabel()

--- a/src/pkg/dashboard/api_governor_coverage_test.go
+++ b/src/pkg/dashboard/api_governor_coverage_test.go
@@ -138,9 +138,12 @@ func TestCovGov_Repos(t *testing.T) {
 	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.ibm.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusBadRequest {
 		t.Fatalf("cross-forge repo should be rejected: %d", rec.Code)
 	}
-	// A full same-forge (github.com) URL in the repo field is still rejected:
-	// operators must configure org + bare repo, not rely on silent rewriting.
-	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusBadRequest {
-		t.Fatalf("repos url should be rejected: %d", rec.Code)
+	// A full same-forge (github.com) URL in the repo field is accepted as an
+	// explicit org/repo migration and stored in canonical org + bare repo form.
+	if rec := doPut(s, "/api/config/governor/repos", map[string]any{"repos": []string{"https://github.com/myorg/repoC"}, "primaryRepo": "repoC"}); rec.Code != http.StatusOK {
+		t.Fatalf("repos url should be accepted: %d", rec.Code)
+	}
+	if s.deps.Config.Project.Org != "myorg" {
+		t.Fatalf("org = %q, want myorg", s.deps.Config.Project.Org)
 	}
 }

--- a/src/pkg/dashboard/coverage_boost2_test.go
+++ b/src/pkg/dashboard/coverage_boost2_test.go
@@ -91,8 +91,9 @@ func TestHandleGovernorRepos_SimpleRepos(t *testing.T) {
 	}
 }
 
-func TestHandleGovernorRepos_URLParsingRejected(t *testing.T) {
+func TestHandleGovernorRepos_URLParsingMigratesOrg(t *testing.T) {
 	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = "oldorg"
 	body := `{"repos":["https://github.com/myorg/myrepo"],"primaryRepo":"myrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -100,12 +101,14 @@ func TestHandleGovernorRepos_URLParsingRejected(t *testing.T) {
 	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("code = %d, want 400", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200: %s", w.Code, w.Body.String())
 	}
-	want := "Repo target misconfigured: repo 'https://github.com/myorg/myrepo' is a URL — expected repo name only so the target resolves to org/repo. Fix in Settings → Repos."
-	if !strings.Contains(w.Body.String(), want) {
-		t.Fatalf("body = %q, want %q", w.Body.String(), want)
+	if got := srv.deps.Config.Project.Org; got != "myorg" {
+		t.Fatalf("Project.Org = %q, want myorg", got)
+	}
+	if got := srv.deps.Config.Project.Repos; len(got) != 1 || got[0] != "myrepo" {
+		t.Fatalf("Project.Repos = %v, want [myrepo]", got)
 	}
 }
 
@@ -416,10 +419,9 @@ func TestHandleGovernorRepos_BareRepoUnchanged(t *testing.T) {
 	}
 }
 
-// A repo qualified with a DIFFERENT org must still be rejected with the clear
-// repo_target message — normalizing it away would silently retarget the hive at
-// a repository the owner never named.
-func TestHandleGovernorRepos_ForeignOrgPrefixRejected(t *testing.T) {
+// A repo qualified with a DIFFERENT org is an explicit migration request from
+// the Repos tab, so the handler adopts that org and stores the bare repo name.
+func TestHandleGovernorRepos_ForeignOrgPrefixMigrates(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.Project.Org = "testorg"
 	srv.deps.Config.Project.Repos = []string{"repo1"}
@@ -431,15 +433,34 @@ func TestHandleGovernorRepos_ForeignOrgPrefixRejected(t *testing.T) {
 	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := srv.deps.Config.Project.Org; got != "someoneelse" {
+		t.Fatalf("Project.Org = %q, want someoneelse", got)
+	}
+	if got := srv.deps.Config.Project.Repos; len(got) != 1 || got[0] != "repo1" {
+		t.Fatalf("Project.Repos = %v, want [repo1]", got)
+	}
+}
+
+func TestHandleGovernorRepos_RejectsMultipleMigrationOrgs(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Project.Org = "testorg"
+	srv.deps.Config.Project.Repos = []string{"repo1"}
+	srv.deps.Config.Project.PrimaryRepo = "repo1"
+	body := `{"repos":["orgone/repo1","orgtwo/repo2"],"primaryRepo":"repo1"}`
+	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	markOwnerRequest(req)
+	srv.handleGovernorRepos(w, req)
+
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "contains '/'") {
-		t.Fatalf("body = %q, want the repo_target contains-'/' message", w.Body.String())
-	}
-	// The rejected value must not have been persisted.
-	if got := srv.deps.Config.Project.Repos; len(got) != 1 || got[0] != "repo1" {
-		t.Fatalf("Project.Repos = %v, want the pre-request [repo1]", got)
+	if !strings.Contains(w.Body.String(), "multiple GitHub orgs") || !strings.Contains(w.Body.String(), "submit repos from a single destination org") {
+		t.Fatalf("body = %q, want multiple-org migration guidance", w.Body.String())
 	}
 }
 

--- a/src/pkg/dashboard/coverage_boost3_test.go
+++ b/src/pkg/dashboard/coverage_boost3_test.go
@@ -917,7 +917,7 @@ func TestHealthSummary_WithAgents(t *testing.T) {
 
 func TestHandleGovernorRepos_PrimaryRepoURL(t *testing.T) {
 	srv := newFullServer(t)
-	// Full URLs in primary_repo are now rejected instead of silently stripped.
+	srv.deps.Config.Project.Org = "oldorg"
 	body := `{"repos":["otherrepo"],"primaryRepo":"https://github.com/otherorg/otherrepo"}`
 	req := httptest.NewRequest("PUT", "/api/governor/repos", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -925,11 +925,14 @@ func TestHandleGovernorRepos_PrimaryRepoURL(t *testing.T) {
 	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("code = %d, want 400", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200: %s", w.Code, w.Body.String())
 	}
-	if srv.deps.Config.Project.PrimaryRepo == "otherrepo" {
-		t.Errorf("primaryRepo changed to %q despite rejection", srv.deps.Config.Project.PrimaryRepo)
+	if srv.deps.Config.Project.Org != "otherorg" {
+		t.Fatalf("Project.Org = %q, want otherorg", srv.deps.Config.Project.Org)
+	}
+	if srv.deps.Config.Project.PrimaryRepo != "otherrepo" {
+		t.Fatalf("primaryRepo = %q, want otherrepo", srv.deps.Config.Project.PrimaryRepo)
 	}
 }
 

--- a/src/pkg/dashboard/repo_add_form_test.go
+++ b/src/pkg/dashboard/repo_add_form_test.go
@@ -29,8 +29,8 @@ func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("code = %d, want 400 for a cross-forge repo", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "expected repo name only so the target resolves to org/repo") {
-		t.Errorf("expected canonical-shape message, got: %s", w.Body.String())
+	if !strings.Contains(w.Body.String(), "one GitHub host") {
+		t.Errorf("expected single-host message, got: %s", w.Body.String())
 	}
 	// The hive's forge must be left untouched.
 	if srv.deps.Config.GitHub.BaseURL != "" {
@@ -38,26 +38,25 @@ func TestGovernorRepos_RejectsCrossForge(t *testing.T) {
 	}
 }
 
-// A GHE hive still rejects full URLs in repo fields: the forge belongs in the
-// hive GitHub identity, and the repo target must remain org + bare repo.
+// A GHE hive accepts same-forge full URLs for org migration, but still rejects
+// repos pasted from another GitHub host.
 func TestGovernorRepos_GHEHiveHostRules(t *testing.T) {
 	srv := newFullServer(t)
 	srv.deps.Config.GitHub.BaseURL = "https://github.ibm.com"
 	srv.deps.Config.GitHub.APIURL = "https://github.ibm.com/api/v3"
 
-	// Same-forge full URL paste is still ambiguous in a repo field: rejected
-	// rather than silently rewritten.
+	// Same-forge full URL paste is an explicit org/repo target.
 	ok := `{"repos":["https://github.ibm.com/acme/widget"],"primaryRepo":"widget"}`
 	req := httptest.NewRequest("PUT", "/api/config/governor/repos", strings.NewReader(ok))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	markOwnerRequest(req)
 	srv.handleGovernorRepos(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("same-forge URL add: code = %d, want 400 (body: %s)", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("same-forge URL add: code = %d, want 200 (body: %s)", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "is a URL") {
-		t.Fatalf("same-forge URL add body = %s, want URL rejection", w.Body.String())
+	if srv.deps.Config.Project.Org != "acme" {
+		t.Fatalf("same-forge URL add org = %q, want acme", srv.deps.Config.Project.Org)
 	}
 
 	// public github.com paste on a GHE hive: rejected as mixing.

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -20292,7 +20292,7 @@ function burnAreaChart() {
           <div class="config-list-add" style="align-items:stretch">
             <div style="display:flex;flex:1;min-width:0;align-items:stretch;border:1px solid var(--border);border-radius:6px;overflow:hidden">
               <span style="display:inline-flex;align-items:center;padding:0 8px;background:color-mix(in srgb, ${prefixColor} 12%, var(--surface));color:${prefixColor};font-size:0.78rem;font-weight:600;white-space:nowrap;border-right:1px solid var(--border)" title="This hive's forge — every repo must live on ${esc(ghHost)}">${esc(ghHost)}/</span>
-              <input type="text" id="cfg-repo-input" style="flex:1;min-width:0;border:none;border-radius:0" placeholder="org/repo" data-keydown-action="addListItem" data-arg0="repos" data-arg1="list" data-arg2="cfg-repo-input" data-prevent="1" data-keys="Enter" title="GitHub repository in org/repo format (e.g. kubestellar/console). It must live on this hive's forge, ${esc(ghHost)} — the governor rejects repos on other GitHub hosts. It will be monitored for issues, PRs, and CI status.">
+              <input type="text" id="cfg-repo-input" style="flex:1;min-width:0;border:none;border-radius:0" placeholder="org/repo or GitHub URL" data-keydown-action="addListItem" data-arg0="repos" data-arg1="list" data-arg2="cfg-repo-input" data-prevent="1" data-keys="Enter" title="GitHub repository in org/repo format (e.g. kubestellar/console) or a full GitHub URL. It must live on this hive's forge, ${esc(ghHost)} — saving a repo from a different org migrates this hive to that org. It will be monitored for issues, PRs, and CI status.">
             </div>
             <button data-action="addListItem" data-arg0="repos" data-arg1="list" data-arg2="cfg-repo-input" title="Add this repository to the monitored list">+ Add</button>
           </div>
@@ -21839,7 +21839,7 @@ function burnAreaChart() {
     }
 
     function normalizeRepoInput(raw) {
-      return raw.replace(/^https?:\/\/github\.com\//, '').replace(/\/+$/, '');
+      return raw.trim().replace(/\/+$/, '');
     }
 
     // hiveForgeHostLabel returns this hive's bare GitHub host ("github.com" or a

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -504,6 +504,16 @@ func NewClientForTest(serverURL string, org string, repos []string, logger *slog
 	return c
 }
 
+// SetOrg is nil-receiver safe for the same reason as SetRepos: dashboard saves
+// and hub heartbeat delivery can retarget a running hive without rebuilding the
+// GitHub client, so the owner's namespace must stay in sync with config.
+func (c *Client) SetOrg(org string) {
+	if c == nil {
+		return
+	}
+	c.org = org
+}
+
 // SetRepos is nil-receiver safe. A hive that booted without usable GitHub
 // credentials runs with a nil *Client for the life of the process, and the
 // config-reload / project-claim / override-migration paths all re-sync the repo


### PR DESCRIPTION
Fixes #5779\n\nForward-port of #5793 for v5.\n\n## Summary\n- accept same-forge GitHub URLs and cross-org org/repo entries in the dashboard Repos save path as explicit org migration requests\n- keep the Repos tab from stripping pasted URLs before the server can adopt the org\n- improve cross-org validation guidance when migration cannot happen in generic config validation\n\n## Validation\n- cd src && go build ./...\n- cd src && go test ./pkg/dashboard -timeout=120s\n- cd src && go test ./pkg/hub/... -timeout=5m\n- cd src && go test ./pkg/config -run 'TestValidateProjectRepoTargets|TestNormalize'