### PR TITLE
🐛 fix(ci): repoint PR verifier image to hivecommons package

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
-      PR_VERIFIER_IMAGE: ghcr.io/kubestellar/pr-verifier@sha256:8c2b63817c4bfa7de510ab699b154637f27a42f87826c98083903daf2a539943
+      PR_VERIFIER_IMAGE: ghcr.io/hivecommons/pr-verifier@sha256:8c2b63817c4bfa7de510ab699b154637f27a42f87826c98083903daf2a539943
     steps:
       - name: Login to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/changelog.d/fixed-5814-pr-verifier-image-org.md
+++ b/changelog.d/fixed-5814-pr-verifier-image-org.md
@@ -1,0 +1,1 @@
+- Repointed the PR verifier image to `ghcr.io/hivecommons/pr-verifier` (same digest) so `verify PR contents` stops failing on every PR after the GHCR org move retired the `kubestellar` package.


### PR DESCRIPTION
## Problem

`.github/workflows/pr-verifier.yml` on v5 pins:

    PR_VERIFIER_IMAGE: ghcr.io/kubestellar/pr-verifier@sha256:8c2b6381...a2539943

That package no longer resolves after the GHCR org move, so `docker pull` fails with `manifest unknown` and the **verify PR contents** check is red on every PR opened against v5.

Because the workflow triggers on `pull_request_target`, the **base branch** copy of the workflow is what executes. A PR therefore cannot repair its own run — this fix only takes effect once it is on the base branch.

## Fix

Repoint to the `hivecommons` package, pinned **by digest** (immutable) rather than by tag:

    PR_VERIFIER_IMAGE: ghcr.io/hivecommons/pr-verifier@sha256:8c2b6381...a2539943

The digest is **unchanged** — `ghcr.io/hivecommons/pr-verifier:v1` resolves to exactly the same `sha256:8c2b63817c4bfa7de510ab699b154637f27a42f87826c98083903daf2a539943` that was previously pinned. Only the org path moves; the image content is bit-identical, so this carries no behavioral risk.

v4 was already corrected by #5818. This brings v5 into line.

## Scope — other `ghcr.io/kubestellar/` references deliberately left alone

I swept `.github/workflows/` and `src/` on both branches and probed every referenced package against the GHCR manifest API:

| Package | Status | Action |
|---|---|---|
| `kubestellar/pr-verifier` | does not resolve | **fixed here** |
| `kubestellar/hive` | resolves (200) | left alone |
| `kubestellar/hive-contributor` | resolves (200) | left alone |
| `kubestellar/hive-hub` | resolves (200) | left alone |

The hive images are still published under `kubestellar` and are healthy, so retargeting them would be an unforced change. `pr-verifier` was the only orphaned reference.

## Validation

- `ghcr.io/hivecommons/pr-verifier:v1` manifest → **HTTP 200**, `docker-content-digest` matches the pinned digest exactly
- `ghcr.io/kubestellar/pr-verifier` → does not resolve
- YAML parses cleanly (`yaml.safe_load`)
- One-line change plus a changelog fragment

## Note for reviewers

The **verify PR contents** check will still be red on this PR, and that is expected and unavoidable — the base branch workflow runs, and the base branch still has the broken image. It self-heals for every subsequent PR the moment this merges. Please assess the other checks.

Refs #5814