### PR TITLE
🐛 Fix latest image multi-arch publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -424,7 +424,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/${{ github.repository_owner }}/hive /tmp/digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 false stable,candidate
+            v4 true stable,candidate
 
       # ---- Cross-org mirror (kubestellar <-> hivecommons dual-publish) ----
       # Copy the tags just published above into the other org's GHCR
@@ -486,7 +486,7 @@ jobs:
           GIT_SHA: ${{ github.sha }}
           # These three mirror publish-image-tags.sh's positional args in the
           # publish step above — keep them in lockstep with that call.
-          INCLUDE_LATEST: "false"
+          INCLUDE_LATEST: "true"
           RELEASE_BRANCH: "v4"
           CHANNELS: "stable,candidate"
         run: |

--- a/changelog.d/fixed-5803-latest-multiarch.md
+++ b/changelog.d/fixed-5803-latest-multiarch.md
@@ -1,0 +1,1 @@
+- Ensure the main Hive `latest` image tag is republished from the v4 multi-arch manifest list, and fail publishing if any managed image tag is missing linux/amd64 or linux/arm64.

--- a/src/scripts/publish-image-tags.sh
+++ b/src/scripts/publish-image-tags.sh
@@ -120,3 +120,23 @@ for file in "${digest_files[@]}"; do
 done
 
 docker buildx imagetools create "${tag_args[@]}" "${source_args[@]}"
+
+assert_linux_platforms() {
+  local ref=$1 platform inspect
+  for platform in linux/amd64 linux/arm64; do
+    if ! inspect=$(docker buildx imagetools inspect \
+        --format "{{json (index .Image \"$platform\")}}" "$ref" 2>&1); then
+      echo "::error::could not inspect $ref after publishing; refusing to leave an unverified moving tag" >&2
+      echo "$inspect" >&2
+      exit 1
+    fi
+    if [[ $inspect == null ]]; then
+      echo "::error::$ref is missing $platform after publishing" >&2
+      exit 1
+    fi
+  done
+}
+
+for ((i = 0; i < ${#tag_args[@]}; i += 2)); do
+  assert_linux_platforms "${tag_args[i+1]}"
+done

--- a/src/scripts/test-publish-image-tags.sh
+++ b/src/scripts/test-publish-image-tags.sh
@@ -15,6 +15,15 @@ cat >"$tmp/bin/docker" <<'MOCK'
 set -euo pipefail
 if [[ $1 == buildx && $2 == imagetools && $3 == inspect ]]; then
   ref=${@: -1}
+  if [[ -e ${MOCK_CAPTURE}.created ]]; then
+    case "${MOCK_INSPECT_MODE:-legacy}" in
+      publish-missing-arm64)
+        if [[ $* == *'linux/arm64'* ]]; then echo 'null'; else echo '{"config":{"Labels":{}}}'; fi
+        ;;
+      *) echo '{"config":{"Labels":{}}}' ;;
+    esac
+    exit 0
+  fi
   case "${MOCK_INSPECT_MODE:-legacy}" in
     missing) echo "ERROR: $ref: not found" >&2; exit 1 ;;
     failure) echo 'dial tcp: registry unavailable' >&2; exit 1 ;;
@@ -27,12 +36,14 @@ if [[ $1 == buildx && $2 == imagetools && $3 == inspect ]]; then
       if [[ $ref == *':latest' ]]; then value=101; else value=99; fi
       printf '{"config":{"Labels":{"io.kubestellar.hive.github-actions-run-number":"%s"}}}\n' "$value"
       ;;
+    publish-missing-arm64) echo '{"config":{"Labels":{}}}' ;;
     *) printf '{"config":{"Labels":{"io.kubestellar.hive.github-actions-run-number":"%s"}}}\n' "$MOCK_INSPECT_MODE" ;;
   esac
   exit 0
 fi
 printf '%q ' "$@" >"$MOCK_CAPTURE"
 printf '\n' >>"$MOCK_CAPTURE"
+touch "${MOCK_CAPTURE}.created"
 MOCK
 chmod +x "$tmp/bin/docker"
 
@@ -82,6 +93,11 @@ if run_case failure 100 "$tmp/create-failure"; then
   exit 1
 fi
 
+if run_case publish-missing-arm64 100 "$tmp/create-missing-arm64"; then
+  echo "post-publish platform assertion did not fail closed" >&2
+  exit 1
+fi
+
 capture="$tmp/create-feature"
 run_custom_case missing 100 "$capture" feat/demo true
 grep -q 'hive-hub:feat-demo-latest' "$capture"
@@ -106,6 +122,8 @@ fi
 workflow="$script_dir/../../.github/workflows/docker.yml"
 [[ $(grep -c 'io.kubestellar.hive.github-actions-run-number=' "$workflow") -eq 3 ]]
 [[ $(grep -c 'src/scripts/publish-image-tags.sh' "$workflow") -eq 3 ]]
+grep -q 'v4 true stable,candidate' "$workflow"
+grep -q 'INCLUDE_LATEST: "true"' "$workflow"
 if grep -q 'head-check\|Verify build commit is still HEAD' "$workflow"; then
   echo "HEAD-only publication guard was reintroduced" >&2
   exit 1


### PR DESCRIPTION
## Summary
- publish the main Hive `latest` tag from the v4 multi-arch digest merge alongside stable/candidate
- mirror that `latest` tag to the cross-org package by digest
- fail tag publishing if any managed tag is missing linux/amd64 or linux/arm64

Fixes #5803

## Validation
- `bash src/scripts/test-publish-image-tags.sh`
- repaired live `ghcr.io/hivecommons/hive:latest` and `ghcr.io/kubestellar/hive:latest` from `stable`; both now list linux/amd64 and linux/arm64