### PR TITLE
✨ feature: add reentrant turn ownership gate

### DIFF
--- a/changelog.d/changed-5799-reentrant-turn-primitive.md
+++ b/changelog.d/changed-5799-reentrant-turn-primitive.md
@@ -1,0 +1,1 @@
+Fixed the re-entrant turn rollout's durable ownership primitive and added the explicit default-off turn envelope opt-in gate.

--- a/src/pkg/config/agent_config.go
+++ b/src/pkg/config/agent_config.go
@@ -181,6 +181,9 @@ type AgentConfig struct {
 	// Sandbox opts this agent into phase-1 sandbox execution when the global
 	// agent_sandbox.enabled gate is also true.
 	Sandbox *AgentSandboxOverride `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
+	// ReentrantTurn opts this agent into the RFC #4002 envelope runner when the
+	// global turn.reentrant.enabled rollout gate is also true.
+	ReentrantTurn *bool `yaml:"reentrant_turn,omitempty" json:"reentrant_turn,omitempty"`
 
 	// Channels declares how this agent gets triggered (kick, webhook, discord, schedule, bead).
 	// When nil/empty, the agent uses governor timer kicks by default (implicit kick channel).

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -66,6 +66,9 @@ type Config struct {
 	// Convergence toggles the convergence-driven admission surfaces
 	// (kubestellar/hive#3845 follow-ons). Default off → zero behaviour change.
 	Convergence ConvergenceConfig `yaml:"convergence,omitempty" json:"convergence,omitempty"`
+	// Turn gates the re-entrant conversation-as-state rollout (#5799). Default
+	// off leaves every agent on the legacy tmux loop until an operator opts in.
+	Turn TurnConfig `yaml:"turn,omitempty" json:"turn,omitempty"`
 
 	// RemovedAgents are agent names an operator deliberately deleted. It is a
 	// TOMBSTONE list, and it exists because deletion had no durable record

--- a/src/pkg/config/turn_config.go
+++ b/src/pkg/config/turn_config.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// TurnConfig groups opt-in gates for the RFC #4002 re-entrant turn rollout.
+type TurnConfig struct {
+	Reentrant ReentrantTurnConfig `yaml:"reentrant,omitempty" json:"reentrant,omitempty"`
+}
+
+// ReentrantTurnConfig is the explicit opt-in surface for the pkg/turn envelope.
+type ReentrantTurnConfig struct {
+	// Enabled is the global safety catch. Default false means no agent can enter
+	// the envelope runner, even if its per-agent reentrant_turn field is true.
+	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	// BackgroundFleetEnabled extends opt-in to every enabled background agent
+	// once a soak is underway. Default false keeps the rollout to named agents.
+	BackgroundFleetEnabled bool `yaml:"background_fleet_enabled,omitempty" json:"background_fleet_enabled,omitempty"`
+}
+
+const (
+	// ReentrantTurnEnvVar overrides the configured rollout gate for one process.
+	ReentrantTurnEnvVar = "HIVE_REENTRANT_TURN_ENABLED"
+	// ReentrantTurnBackgroundFleetEnvVar extends the opt-in to the background
+	// fleet for one process.
+	ReentrantTurnBackgroundFleetEnvVar = "HIVE_REENTRANT_TURN_BACKGROUND_FLEET"
+)
+
+// ReentrantTurnEnabled reports whether agent is enrolled in the pkg/turn
+// envelope. It is fail-safe: the global gate must be on, and an individual
+// agent must explicitly opt in unless the background-fleet gate is on.
+func (c *Config) ReentrantTurnEnabled(agent AgentConfig) bool {
+	if !c.reentrantTurnGlobalEnabled() {
+		return false
+	}
+	if agent.ReentrantTurn != nil {
+		return *agent.ReentrantTurn
+	}
+	return c.reentrantTurnBackgroundFleetEnabled()
+}
+
+func (c *Config) reentrantTurnGlobalEnabled() bool {
+	if v, ok := parseBoolEnv(ReentrantTurnEnvVar); ok {
+		return v
+	}
+	if c == nil {
+		return false
+	}
+	return c.Turn.Reentrant.Enabled
+}
+
+func (c *Config) reentrantTurnBackgroundFleetEnabled() bool {
+	if v, ok := parseBoolEnv(ReentrantTurnBackgroundFleetEnvVar); ok {
+		return v
+	}
+	if c == nil {
+		return false
+	}
+	return c.Turn.Reentrant.BackgroundFleetEnabled
+}
+
+func parseBoolEnv(name string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}

--- a/src/pkg/config/turn_config_test.go
+++ b/src/pkg/config/turn_config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import "testing"
+
+func TestReentrantTurnEnabledDefaultOff(t *testing.T) {
+	t.Setenv(ReentrantTurnEnvVar, "")
+	t.Setenv(ReentrantTurnBackgroundFleetEnvVar, "")
+	yes := true
+	var nilCfg *Config
+	if nilCfg.ReentrantTurnEnabled(AgentConfig{ReentrantTurn: &yes}) {
+		t.Fatal("nil config must not enable re-entrant turns")
+	}
+	if (&Config{}).ReentrantTurnEnabled(AgentConfig{ReentrantTurn: &yes}) {
+		t.Fatal("zero config must not enable re-entrant turns")
+	}
+}
+
+func TestReentrantTurnEnabledRequiresGlobalAndAgentOptIn(t *testing.T) {
+	t.Setenv(ReentrantTurnEnvVar, "")
+	t.Setenv(ReentrantTurnBackgroundFleetEnvVar, "")
+	yes := true
+	no := false
+	cfg := &Config{Turn: TurnConfig{Reentrant: ReentrantTurnConfig{Enabled: true}}}
+	if !cfg.ReentrantTurnEnabled(AgentConfig{ReentrantTurn: &yes}) {
+		t.Fatal("global gate plus per-agent opt-in should enable")
+	}
+	if cfg.ReentrantTurnEnabled(AgentConfig{ReentrantTurn: &no}) {
+		t.Fatal("per-agent opt-out should win")
+	}
+	if cfg.ReentrantTurnEnabled(AgentConfig{}) {
+		t.Fatal("global gate alone should not enroll an agent")
+	}
+}
+
+func TestReentrantTurnBackgroundFleetGate(t *testing.T) {
+	t.Setenv(ReentrantTurnEnvVar, "")
+	t.Setenv(ReentrantTurnBackgroundFleetEnvVar, "")
+	cfg := &Config{Turn: TurnConfig{Reentrant: ReentrantTurnConfig{
+		Enabled:                true,
+		BackgroundFleetEnabled: true,
+	}}}
+	if !cfg.ReentrantTurnEnabled(AgentConfig{}) {
+		t.Fatal("background fleet gate should enroll unspecified agents")
+	}
+}
+
+func TestReentrantTurnEnvOverrides(t *testing.T) {
+	cfg := &Config{Turn: TurnConfig{Reentrant: ReentrantTurnConfig{
+		Enabled:                false,
+		BackgroundFleetEnabled: false,
+	}}}
+	t.Setenv(ReentrantTurnEnvVar, "true")
+	t.Setenv(ReentrantTurnBackgroundFleetEnvVar, "true")
+	if !cfg.ReentrantTurnEnabled(AgentConfig{}) {
+		t.Fatal("env gates should enable background fleet")
+	}
+	t.Setenv(ReentrantTurnEnvVar, "false")
+	if cfg.ReentrantTurnEnabled(AgentConfig{}) {
+		t.Fatal("global env false should disable rollout")
+	}
+}

--- a/src/pkg/convergence/mutation/ledger.go
+++ b/src/pkg/convergence/mutation/ledger.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -43,6 +45,7 @@ var (
 
 // ledgerFileMode matches the outcome/proof/beads persistence idiom.
 const ledgerFileMode = 0o660
+const ledgerLockFileSuffix = ".lock"
 
 // ledgerFormatVersion is the persisted schema version.
 const ledgerFormatVersion = 1
@@ -101,42 +104,79 @@ func OpenLedger(path string, maxWritersPerRepo int) (*Ledger, error) {
 		maxWritersPerRepo = DefaultMaxWritersPerRepo
 	}
 	l := &Ledger{path: path, maxWriters: maxWritersPerRepo, entries: make(map[string]*Entry)}
-	data, err := os.ReadFile(path)
+	if err := l.reloadLocked(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (l *Ledger) reloadLocked() error {
+	data, err := os.ReadFile(l.path)
 	if errors.Is(err, os.ErrNotExist) {
-		return l, nil
+		l.entries = make(map[string]*Entry)
+		return nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("reading mutation claim ledger %s: %w", path, err)
+		return fmt.Errorf("reading mutation claim ledger %s: %w", l.path, err)
 	}
 	var persisted persistedLedger
 	if err := json.Unmarshal(data, &persisted); err != nil {
-		return nil, fmt.Errorf("mutation claim ledger %s is unparseable and is left untouched for inspection: %w", path, err)
+		return fmt.Errorf("mutation claim ledger %s is unparseable and is left untouched for inspection: %w", l.path, err)
 	}
+	entries := make(map[string]*Entry, len(persisted.Entries))
 	for i := range persisted.Entries {
 		e := persisted.Entries[i]
 		if err := e.Claim.Validate(); err != nil {
-			return nil, fmt.Errorf("mutation claim ledger %s holds an invalid claim: %w", path, err)
+			return fmt.Errorf("mutation claim ledger %s holds an invalid claim: %w", l.path, err)
 		}
 		key := e.Claim.Key()
-		if _, dup := l.entries[key]; dup {
-			return nil, fmt.Errorf("mutation claim ledger %s holds conflicting entries for %s", path, key)
+		if _, dup := entries[key]; dup {
+			return fmt.Errorf("mutation claim ledger %s holds conflicting entries for %s", l.path, key)
 		}
 		cp := e
-		l.entries[key] = &cp
+		entries[key] = &cp
 	}
-	return l, nil
+	l.entries = entries
+	return nil
+}
+
+func (l *Ledger) lockAndRefreshLocked() (func(), error) {
+	lockPath := l.path + ledgerLockFileSuffix
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o770); err != nil {
+		return nil, fmt.Errorf("creating mutation claim ledger lock directory: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, ledgerFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("opening mutation claim ledger lock %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("locking mutation claim ledger %s: %w", lockPath, err)
+	}
+	if err := l.reloadLocked(); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
 }
 
 // reconcileExpiredLocked fences an ActiveMutation entry whose window has
 // passed: it moves to Waiting at its OWN epoch (retained for history), so the
 // old owner is fenced and the slot is freed, but ownership is never silently
 // released. Callers hold l.mu.
-func (l *Ledger) reconcileExpiredLocked(now time.Time) {
+func (l *Ledger) reconcileExpiredLocked(now time.Time) bool {
+	changed := false
 	for _, e := range l.entries {
 		if e.State == StateActiveMutation && now.After(e.ExpiresAt) {
 			e.State = StateWaiting
+			changed = true
 		}
 	}
+	return changed
 }
 
 // activeWritersLocked counts consumed mutation-writer slots in a repo:
@@ -173,7 +213,16 @@ func (l *Ledger) Acquire(c Claim, holder string, ttl time.Duration, now time.Tim
 	key := c.Key()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.reconcileExpiredLocked(now)
+	unlock, err := l.lockAndRefreshLocked()
+	if err != nil {
+		return Entry{}, err
+	}
+	defer unlock()
+	if l.reconcileExpiredLocked(now) {
+		if err := l.persistLocked(); err != nil {
+			return Entry{}, err
+		}
+	}
 
 	for otherKey, e := range l.entries {
 		if e.State != StateActiveMutation {
@@ -220,7 +269,16 @@ func (l *Ledger) Acquire(c Claim, holder string, ttl time.Duration, now time.Tim
 func (l *Ledger) transition(key string, expectedEpoch uint64, from map[string]bool, to string, now time.Time) (Entry, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.reconcileExpiredLocked(now)
+	unlock, err := l.lockAndRefreshLocked()
+	if err != nil {
+		return Entry{}, err
+	}
+	defer unlock()
+	if l.reconcileExpiredLocked(now) {
+		if err := l.persistLocked(); err != nil {
+			return Entry{}, err
+		}
+	}
 	e, ok := l.entries[key]
 	if !ok || e.Epoch != expectedEpoch || !from[e.State] {
 		return Entry{}, fmt.Errorf("%s: expected epoch %d in %v: %w", key, expectedEpoch, keysOf(from), ErrStaleEpoch)
@@ -257,7 +315,16 @@ func (l *Ledger) Release(key string, expectedEpoch uint64, now time.Time) (Entry
 func (l *Ledger) ValidateEpoch(key string, epoch uint64, now time.Time) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.reconcileExpiredLocked(now)
+	unlock, err := l.lockAndRefreshLocked()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if l.reconcileExpiredLocked(now) {
+		if err := l.persistLocked(); err != nil {
+			return err
+		}
+	}
 	e, ok := l.entries[key]
 	if !ok {
 		return fmt.Errorf("%s has no claim entry: %w", key, ErrStaleEpoch)
@@ -275,6 +342,10 @@ func (l *Ledger) ValidateEpoch(key string, epoch uint64, now time.Time) error {
 func (l *Ledger) Get(key string) (Entry, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	unlock, err := l.lockAndRefreshLocked()
+	if err == nil {
+		defer unlock()
+	}
 	e, ok := l.entries[key]
 	if !ok {
 		return Entry{}, false
@@ -292,11 +363,44 @@ func (l *Ledger) persistLocked() error {
 	if err != nil {
 		return fmt.Errorf("marshaling mutation claim ledger: %w", err)
 	}
-	tmpPath := l.path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, ledgerFileMode); err != nil {
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o770); err != nil {
+		return fmt.Errorf("creating mutation claim ledger directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(l.path), filepath.Base(l.path)+".*.tmp")
+	if err != nil {
 		return fmt.Errorf("writing tmp mutation claim ledger: %w", err)
 	}
-	return os.Rename(tmpPath, l.path)
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing tmp mutation claim ledger: %w", err)
+	}
+	if err := tmp.Chmod(ledgerFileMode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod tmp mutation claim ledger: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing tmp mutation claim ledger: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing tmp mutation claim ledger: %w", err)
+	}
+	if err := os.Rename(tmpPath, l.path); err != nil {
+		return fmt.Errorf("renaming tmp mutation claim ledger: %w", err)
+	}
+	cleanup = false
+	if dir, err := os.Open(filepath.Dir(l.path)); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return nil
 }
 
 func keysOf(m map[string]bool) []string {

--- a/src/pkg/convergence/mutation/ledger_crossprocess_test.go
+++ b/src/pkg/convergence/mutation/ledger_crossprocess_test.go
@@ -7,22 +7,14 @@ import (
 	"time"
 )
 
-// These are CHARACTERIZATION tests for the step-3 handoff evaluation of RFC
-// #4002 (src/docs/design/agent-turn-handoff.md). The Ledger's CAS is documented
-// as serialized by "the ledger mutex" (ledger.go:81) — a sync.Mutex, which is
-// per-process. The package is inert today (nothing outside it calls OpenLedger),
-// so this is not a live defect; it is the property a cross-process handoff would
-// have to close before reusing this ledger as its lease.
-//
-// Nothing here asserts the current behaviour is desirable. If a later change
-// adds cross-process serialization these tests skip with a rewrite instruction
-// rather than failing opaquely.
+// These tests cover the cross-process serialization property required by the
+// step-3 handoff evaluation of RFC #4002
+// (src/docs/design/agent-turn-handoff.md). Two handles opened before either
+// writes must still observe a single durable owner and must merge independent
+// claims instead of overwriting a peer's file snapshot.
 
-// TestTwoOpenLedgersBothAcquireTheSameClaim pins the gap. Each handle keeps its
-// own in-memory index and its own mutex, so the overlap scan in Acquire consults
-// only what THAT handle has seen. Two processes holding the ledger open across
-// an acquisition therefore both win — at the same epoch, which is what makes it
-// a fencing failure rather than merely a duplicate grant.
+// TestTwoOpenLedgersBothAcquireTheSameClaim verifies the ledger's durable CAS
+// holds across independent handles, not just goroutines sharing one mutex.
 func TestTwoOpenLedgersBothAcquireTheSameClaim(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "claims.json")
 	claim := TaskClaim("hivecommons/hive", "hivecommons/hive#4002")
@@ -43,34 +35,19 @@ func TestTwoOpenLedgersBothAcquireTheSameClaim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first acquire: %v", err)
 	}
-	b, err := second.Acquire(claim, "spoke-b", time.Hour, now)
+	_, err = second.Acquire(claim, "spoke-b", time.Hour, now)
 	if err != nil {
-		if errors.Is(err, ErrClaimHeld) {
-			t.Skipf("second acquire was refused (%v) — the ledger has gained "+
-				"cross-process serialization; rewrite this test as that guarantee", err)
+		if !errors.Is(err, ErrClaimHeld) {
+			t.Fatalf("second acquire: %v", err)
 		}
-		t.Fatalf("second acquire: %v", err)
+		return
 	}
-
-	if a.Epoch != b.Epoch {
-		t.Fatalf("epochs %d and %d differ — the second handle saw the first's "+
-			"entry, so the step-3 evaluation's premise needs revisiting", a.Epoch, b.Epoch)
-	}
-	// Two holders at one epoch: ValidateEpoch cannot tell them apart, so the
-	// fence authorizes both.
-	if err := first.ValidateEpoch(claim.Key(), a.Epoch, now); err != nil {
-		t.Fatalf("first holder fenced out at its own epoch: %v", err)
-	}
-	if err := second.ValidateEpoch(claim.Key(), b.Epoch, now); err != nil {
-		t.Fatalf("second holder fenced out at its own epoch: %v", err)
-	}
+	t.Fatalf("second acquire unexpectedly succeeded after first holder %s epoch %d", a.Holder, a.Epoch)
 }
 
-// TestReopeningAfterAConcurrentAcquireSeesOnlyTheLastWriter pins the durable
-// consequence: persistLocked rewrites the whole file from one handle's index,
-// so the loser's record is not merged, it is erased. A third process booting
-// afterwards — the actual restart-recovery path — reads a ledger that never
-// mentions the first holder.
+// TestReopeningAfterAConcurrentAcquireSeesOnlyTheLastWriter verifies two
+// handles that acquire disjoint claims under available capacity preserve both
+// records in the durable ledger.
 func TestReopeningAfterAConcurrentAcquireSeesOnlyTheLastWriter(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "claims.json")
 	other := TaskClaim("hivecommons/hive", "hivecommons/hive#4000")
@@ -86,8 +63,8 @@ func TestReopeningAfterAConcurrentAcquireSeesOnlyTheLastWriter(t *testing.T) {
 		t.Fatalf("opening second ledger: %v", err)
 	}
 
-	// Distinct, non-overlapping claims: even with no contention at all, the
-	// two handles cannot both survive a rewrite.
+	// Distinct, non-overlapping claims must both survive the second handle's
+	// refresh-and-rewrite cycle.
 	if _, err := first.Acquire(other, "spoke-a", time.Hour, now); err != nil {
 		t.Fatalf("first acquire: %v", err)
 	}
@@ -102,8 +79,7 @@ func TestReopeningAfterAConcurrentAcquireSeesOnlyTheLastWriter(t *testing.T) {
 	if _, ok := recovered.Get(claim.Key()); !ok {
 		t.Fatalf("last writer's claim %s is missing from the reloaded ledger", claim.Key())
 	}
-	if _, ok := recovered.Get(other.Key()); ok {
-		t.Skipf("both claims survived — the ledger now merges concurrent writers; " +
-			"rewrite this test as that guarantee")
+	if _, ok := recovered.Get(other.Key()); !ok {
+		t.Fatalf("first writer's claim %s was lost during the second handle's rewrite", other.Key())
 	}
 }


### PR DESCRIPTION
## Summary
- make the mutation claim ledger safe for cross-process handoff/adoption with flock-protected refresh and atomic durable rewrites
- add default-off re-entrant turn rollout gates (global, per-agent, and background-fleet opt-in)
- replace handoff characterization tests with positive durable-CAS coverage

## Validation
- cd src && go test ./pkg/convergence/mutation
- cd src && go test ./pkg/config -run TestReentrantTurn
- cd src && go build ./... && go vet ./...