### PR TITLE
🌱 Remove legacy hub cookie machinery from v4 production

### DIFF
--- a/changelog.d/security-5812-dead-hub-cookie.md
+++ b/changelog.d/security-5812-dead-hub-cookie.md
@@ -1,0 +1,1 @@
+security: remove legacy hub session-cookie mint and verification helpers from the production binary while keeping rejection regression tests.

--- a/src/pkg/hub/hub_cookie.go
+++ b/src/pkg/hub/hub_cookie.go
@@ -2,9 +2,7 @@ package hub
 
 import (
 	"crypto/ed25519"
-	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -55,25 +53,6 @@ const hubCookieV2Marker = ".v2."
 // hubCookieB64 encodes the signature URL-safe and unpadded so the cookie value
 // stays within the RFC 6265 cookie-octet set.
 var hubCookieB64 = base64.RawURLEncoding
-
-// mintHubUserCookieValueV2 mints an Ed25519-signed session cookie. seedHex is
-// the hub's PRIVATE session seed; a spoke cannot produce this value.
-//
-// Returns "" on empty inputs or seed material that is not a valid 32-byte
-// Ed25519 seed (e.g. a public key passed by mistake) — fail closed rather than
-// sign with junk, matching MintSSOToken.
-func mintHubUserCookieValueV2(seedHex, username string) string {
-	if seedHex == "" || username == "" {
-		return ""
-	}
-	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
-	if err != nil || len(seed) != ed25519.SeedSize {
-		return ""
-	}
-	priv := ed25519.NewKeyFromSeed(seed)
-	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(username)))
-	return username + hubCookieV2Marker + sig
-}
 
 // verifyHubUserCookieValueV2 verifies an Ed25519-signed cookie against the hub's
 // PUBLIC session key. Returns (username, true) only on a valid signature.
@@ -195,10 +174,10 @@ func newHubCookieSessionID() string {
 // the hub (Go) AND independently by every spoke's Node proxy; minting a shape a
 // not-yet-rolled spoke cannot parse breaks /terminal fleet-wide. That is
 // incident #2773. Minting flips only once the whole fleet verifies v3 — see the
-// rollout note on verifyHubUserCookieEither.
+// rollout note on verifyHubUserCookieEitherAt.
 //
 // Returns "" on empty inputs, a bad seed, a non-positive ttl, or a CSPRNG
-// failure — fail closed rather than sign junk, matching mintHubUserCookieValueV2.
+// failure — fail closed rather than sign junk, matching the older Ed25519 cookie minter.
 func mintHubUserCookieValueV3(seedHex, username string, now time.Time, ttl time.Duration) (value, sid string) {
 	// gen 0 => the G claim is omitted, so this mints exactly the bytes it
 	// minted before generations existed.
@@ -387,79 +366,8 @@ func hubCookieExpiry(value string) int64 {
 	return claims.EXP
 }
 
-// mintHubUserCookieValue returns the signed, tamper-evident cookie value for
-// username. It returns "" when no secret is configured or the username is empty
-// — callers must treat that as "cannot establish a session" rather than emitting
-// an unsigned (trusted-by-default) cookie.
-func mintHubUserCookieValue(secret, username string) string {
-	if secret == "" || username == "" {
-		return ""
-	}
-	return username + "." + hubCookieSign(secret, username)
-}
-
-// verifyHubUserCookieValue parses a cookie value, recomputes its HMAC over the
-// carried username, and constant-time-compares it against the presented
-// signature. It returns (username, true) only when the signature verifies; on a
-// legacy unsigned cookie, a forged value, or a missing secret it returns
-// ("", false) so the caller treats the request as unauthenticated.
-func verifyHubUserCookieValue(secret, value string) (string, bool) {
-	if secret == "" || value == "" {
-		return "", false
-	}
-	// SplitN from the right: usernames are validated to exclude ".", but be
-	// defensive and treat the final segment as the signature regardless.
-	idx := strings.LastIndex(value, ".")
-	if idx <= 0 || idx == len(value)-1 {
-		return "", false
-	}
-	username, sig := value[:idx], value[idx+1:]
-	expected := hubCookieSign(secret, username)
-	if !hmac.Equal([]byte(sig), []byte(expected)) {
-		return "", false
-	}
-	return username, true
-}
-
-// hubCookieSign returns the URL-safe base64 HMAC-SHA256 of username under
-// secret.
-func hubCookieSign(secret, username string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(username))
-	return hubCookieB64.EncodeToString(mac.Sum(nil))
-}
-
-// verifyHubUserCookieEither accepts a v2 (Ed25519) cookie OR a legacy HMAC one,
-// so live sessions survive the N2 cutover.
-//
-// Rollout shape, mirroring the SSO migration: the hub MINTS only v2 while
-// verifying both. Browsers holding a legacy cookie keep working until it is
-// re-minted at their next login; spokes running an older image keep verifying
-// the legacy format until they re-provision.
-//
-// The legacy lane is the vulnerability — anyone holding the symmetric key can
-// forge it — so it is explicitly TEMPORARY. It must be removed once the fleet
-// has rolled and existing cookies have aged out (the cookie's own MaxAge bounds
-// that window). hubCookieIsV2 gives an operator the signal for when that is
-// safe.
-//
-// legacySecret may be "" to disable the legacy lane entirely, which is what the
-// removal PR will pass.
-// F10 adds a THIRD lane, tried first: v3 → v2 → legacy HMAC. Strictly additive.
-// The v2 and legacy lanes are the N2/F1/F2 compatibility paths — removing either
-// one 401s the part of the fleet that has not rolled, so neither goes away here.
-//
-// verifyHubUserCookieEither keeps its original 3-argument shape so no existing
-// call site changes. It cannot consult the revocation store (it has no server
-// handle), so it passes nil: a v3 cookie is still checked for signature and for
-// signed expiry, just not for revocation. Call sites that CAN revoke use
-// verifyHubUserCookieEitherAt via HubServer.verifyHubUserCookie.
-func verifyHubUserCookieEither(pubHex, legacySecret, value string) (string, bool) {
-	return verifyHubUserCookieEitherAt(pubHex, legacySecret, value, time.Now(), nil)
-}
-
-// verifyHubUserCookieEitherAt is verifyHubUserCookieEither with the verifier's
-// clock and revocation lookup made explicit, so expiry and revocation are
+// verifyHubUserCookieEitherAt is the hub session-cookie verifier with
+// explicit clock and revocation lookup, so expiry and revocation are
 // testable without touching global state.
 func verifyHubUserCookieEitherAt(pubHex, legacySecret, value string, now time.Time, revoked hubSessionRevokedFunc) (string, bool) {
 	if u, ok := verifyHubUserCookieValueV3(pubHex, value, now, revoked); ok {
@@ -482,16 +390,4 @@ func verifyHubUserCookieEitherAt(pubHex, legacySecret, value string, now time.Ti
 	// mis-resolve into re-enabling the lane.
 	_ = legacySecret
 	return "", false
-}
-
-// hubCookieIsV3 reports whether a cookie value carries the F10 format. Rollout
-// telemetry only — never an authorization decision on its own.
-func hubCookieIsV3(value string) bool {
-	return strings.Contains(value, hubCookieV3Marker)
-}
-
-// hubCookieIsV2 reports whether a cookie value carries the asymmetric format.
-// Rollout telemetry only — never an authorization decision on its own.
-func hubCookieIsV2(value string) bool {
-	return strings.Contains(value, hubCookieV2Marker)
 }

--- a/src/pkg/hub/hub_cookie_legacy_test.go
+++ b/src/pkg/hub/hub_cookie_legacy_test.go
@@ -1,0 +1,112 @@
+package hub
+
+import (
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+)
+
+// mintHubUserCookieValueV2 mints an Ed25519-signed session cookie. seedHex is
+// the hub's PRIVATE session seed; a spoke cannot produce this value.
+//
+// Returns "" on empty inputs or seed material that is not a valid 32-byte
+// Ed25519 seed (e.g. a public key passed by mistake) — fail closed rather than
+// sign with junk, matching MintSSOToken.
+func mintHubUserCookieValueV2(seedHex, username string) string {
+	if seedHex == "" || username == "" {
+		return ""
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(seedHex))
+	if err != nil || len(seed) != ed25519.SeedSize {
+		return ""
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	sig := hubCookieB64.EncodeToString(ed25519.Sign(priv, []byte(username)))
+	return username + hubCookieV2Marker + sig
+}
+
+// mintHubUserCookieValue returns the signed, tamper-evident cookie value for
+// username. It returns "" when no secret is configured or the username is empty
+// — callers must treat that as "cannot establish a session" rather than emitting
+// an unsigned (trusted-by-default) cookie.
+func mintHubUserCookieValue(secret, username string) string {
+	if secret == "" || username == "" {
+		return ""
+	}
+	return username + "." + hubCookieSign(secret, username)
+}
+
+// verifyHubUserCookieValue parses a cookie value, recomputes its HMAC over the
+// carried username, and constant-time-compares it against the presented
+// signature. It returns (username, true) only when the signature verifies; on a
+// legacy unsigned cookie, a forged value, or a missing secret it returns
+// ("", false) so the caller treats the request as unauthenticated.
+func verifyHubUserCookieValue(secret, value string) (string, bool) {
+	if secret == "" || value == "" {
+		return "", false
+	}
+	// SplitN from the right: usernames are validated to exclude ".", but be
+	// defensive and treat the final segment as the signature regardless.
+	idx := strings.LastIndex(value, ".")
+	if idx <= 0 || idx == len(value)-1 {
+		return "", false
+	}
+	username, sig := value[:idx], value[idx+1:]
+	expected := hubCookieSign(secret, username)
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return "", false
+	}
+	return username, true
+}
+
+// hubCookieSign returns the URL-safe base64 HMAC-SHA256 of username under
+// secret.
+func hubCookieSign(secret, username string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(username))
+	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}
+
+// verifyHubUserCookieEither accepts a v2 (Ed25519) cookie OR a legacy HMAC one,
+// so live sessions survive the N2 cutover.
+//
+// Rollout shape, mirroring the SSO migration: the hub MINTS only v2 while
+// verifying both. Browsers holding a legacy cookie keep working until it is
+// re-minted at their next login; spokes running an older image keep verifying
+// the legacy format until they re-provision.
+//
+// The legacy lane is the vulnerability — anyone holding the symmetric key can
+// forge it — so it is explicitly TEMPORARY. It must be removed once the fleet
+// has rolled and existing cookies have aged out (the cookie's own MaxAge bounds
+// that window). hubCookieIsV2 gives an operator the signal for when that is
+// safe.
+//
+// legacySecret may be "" to disable the legacy lane entirely, which is what the
+// removal PR will pass.
+// F10 adds a THIRD lane, tried first: v3 → v2 → legacy HMAC. Strictly additive.
+// The v2 and legacy lanes are the N2/F1/F2 compatibility paths — removing either
+// one 401s the part of the fleet that has not rolled, so neither goes away here.
+//
+// verifyHubUserCookieEither keeps its original 3-argument shape so no existing
+// call site changes. It cannot consult the revocation store (it has no server
+// handle), so it passes nil: a v3 cookie is still checked for signature and for
+// signed expiry, just not for revocation. Call sites that CAN revoke use
+// verifyHubUserCookieEitherAt via HubServer.verifyHubUserCookie.
+func verifyHubUserCookieEither(pubHex, legacySecret, value string) (string, bool) {
+	return verifyHubUserCookieEitherAt(pubHex, legacySecret, value, time.Now(), nil)
+}
+
+// hubCookieIsV3 reports whether a cookie value carries the F10 format. Rollout
+// telemetry only — never an authorization decision on its own.
+func hubCookieIsV3(value string) bool {
+	return strings.Contains(value, hubCookieV3Marker)
+}
+
+// hubCookieIsV2 reports whether a cookie value carries the asymmetric format.
+// Rollout telemetry only — never an authorization decision on its own.
+func hubCookieIsV2(value string) bool {
+	return strings.Contains(value, hubCookieV2Marker)
+}

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -728,8 +728,8 @@ func (s *HubServer) exchangeGitHubLogin(w http.ResponseWriter, code string) (log
 // saying nothing calls it in production, deliberately, because a spoke that
 // cannot parse the shape breaks /terminal fleet-wide — incident #2773, the
 // v2-hub/v4-spoke split. That condition no longer holds: the fleet is v4, and
-// the spoke-side verifier in src/proxy/server.js tries lanes v3 → v2 → legacy
-// (verifyHubUserCookieEither), so a spoke accepts a V3 cookie today. This is
+// the spoke-side verifier in src/proxy/server.js tries the modern lanes first,
+// so a spoke accepts a V3 cookie today. This is
 // therefore the verify-both/mint-new cutover the N2 change already rehearsed,
 // with the verifier side shipped well ahead of the minter — not a flag day.
 //
@@ -786,10 +786,9 @@ func setSessionCookies(w http.ResponseWriter, r *http.Request, cookieValue strin
 	// The audit asks for a host-only `__Host-` session cookie. That is correct
 	// in the abstract and NOT safely applicable here, because this cookie is
 	// load-bearing across a trust boundary: it is minted by the hub (Go) and
-	// verified INDEPENDENTLY by every spoke's Node proxy
-	// (src/proxy/server.js — verifyHubUserCookieEither, and the WebSocket
-	// terminal path). The proxy can only verify a cookie the browser actually
-	// sends it, and the browser only sends this one to <id>.hive.kubestellar.io
+	// verified INDEPENDENTLY by every spoke's Node proxy on the WebSocket
+	// terminal path (src/proxy/server.js). The proxy can only verify a cookie
+	// the browser actually sends it, and the browser only sends this one to <id>.hive.kubestellar.io
 	// BECAUSE of the Domain attribute below. Dropping Domain (which __Host-
 	// additionally forbids outright) would stop the cookie reaching any spoke
 	// and log every hosted tenant out of their own dashboard and terminal —


### PR DESCRIPTION
## Summary
- backport the issue #5812 hub cookie cleanup to v4
- move legacy/v2 cookie forgery helpers into test-only code
- keep regression tests while removing the dead production HMAC mint/verify lane

Fixes #5812

## Validation
- cd src && go build ./...
- cd src && go vet ./...
- cd src && go test -count=1 ./pkg/hub/...
- cd src && deadcode ./cmd/... | grep hub_cookie.go (no output)
- non-test Go grep for removed identifiers (no output)