### PR TITLE
✨ Capture Copilot live cost for repo attribution

### DIFF
--- a/changelog.d/5802-copilot-live-cost-capture.md
+++ b/changelog.d/5802-copilot-live-cost-capture.md
@@ -1,0 +1,1 @@
+✨ Capture MITM Copilot completion usage as timestamped live sessions so `/api/repo-cost` can attribute active Copilot spend without double-counting shutdown totals.

--- a/src/docs/design/copilot-cost-capture.md
+++ b/src/docs/design/copilot-cost-capture.md
@@ -1,10 +1,12 @@
 # Copilot per-repo cost capture at the MITM proxy (#4836 phase 4)
 
-Status: **investigation — no decision taken.** Nothing here is implemented, and
-nothing here is a commitment to implement. This page exists to record what was
-checked, with citations, so the phase-4 decision is made on evidence rather than
-on the epic's one-line sketch of it. Its conclusion is a recommendation against
-building phase 4 as scoped; see [Recommendation](#recommendation).
+Status: **implemented on v5 for #5802.** The implementation follows the
+timestamps-only path recommended below: Copilot completion usage that the MITM
+proxy already observes is persisted as timestamped live-capture sessions, then
+`/api/repo-cost` joins those events to the existing authenticated audit-log
+`repo=` timeline. The proxy does not invent a repo from adjacent request
+traffic; unsupported historical Copilot shutdown totals still remain in
+`backend_unsupported`.
 
 All citations are against `origin/v4` at `8d21a8aa`.
 

--- a/src/pkg/dashboard/collect/repo_cost.go
+++ b/src/pkg/dashboard/collect/repo_cost.go
@@ -34,11 +34,10 @@ package collect
 //     tokens whose timestamp could not be determined. The LEADING interval is
 //     never given to the first repo seen: there is no closing event for it, and
 //     inventing one is how a per-repo cost number becomes plausibly wrong.
-//   - `backend_unsupported` — every non-Claude backend's tokens. Copilot accrues
-//     all usage in one lump at session.shutdown and bob parses no per-message
-//     timestamps, so neither has an intra-session time distribution to join
-//     against. Their spend is REAL and is reported here in full; it is simply
-//     not placeable against a repo.
+//   - `backend_unsupported` — every backend slice without a timestamped usage
+//     timeline. Historical Copilot session.shutdown lumps and bob sessions land
+//     here; Copilot usage captured live by the MITM proxy carries a timeline and
+//     can be joined the same way Claude usage is.
 //
 // The invariant `Σ by_repo + unattributed + backend_unsupported == hive total`
 // holds by construction and is asserted by test. Any token the hive counted
@@ -163,7 +162,7 @@ type RepoCostResponse struct {
 // caveats alongside the numbers rather than burying them in code comments.
 func RepoCostLimitations() []string {
 	return []string{
-		"Claude sessions only. Copilot records all token usage in a single lump at session shutdown and bob parses no per-message timestamps, so neither can be placed in time. Their spend is real and is reported in full under backend_unsupported — it is not missing, it is not attributable.",
+		"Claude sessions and MITM-captured Copilot completions carry timestamped usage timelines. Historical Copilot session.shutdown totals and bob sessions without per-message timestamps are reported in full under backend_unsupported — their spend is real, just not placeable in time.",
 		"Attribution is inferred from TIMING, not measured. Tokens spent between two audited repo= events are billed to the repo named by the later event.",
 		"KNOWN BIAS: an agent that investigates repo A, finds nothing to file, then files on repo B bills ALL of A's investigation to B. This is the method's failure mode, not a rounding error — treat a repo's figure as an upper bound when neighbouring repos show activity but little cost.",
 		"Tokens before an agent's first repo= event, after its last, or from agents with no repo events at all are reported as unattributed and are NEVER spread across repos.",
@@ -318,13 +317,13 @@ func ComputeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 	for i := range summary.Sessions {
 		sess := &summary.Sessions[i]
 
-		// Any backend that cannot produce a per-message timeline contributes
+		// Any backend that cannot produce a per-request/per-message timeline contributes
 		// its FULL session total to backend_unsupported. This is the branch
 		// that keeps the invariant honest: those tokens are counted, just not
 		// placed. A Claude session that somehow carries no timeline (an older
 		// persisted snapshot from before phase 2, say) lands here too — the
 		// tokens are real and must not vanish.
-		if sess.Backend != tokens.BackendClaude || len(sess.Usage) == 0 {
+		if !repoCostBackendSupportsTimeline(sess.Backend) || len(sess.Usage) == 0 {
 			backendUnsupported.add(repoUsagePoint{
 				agent: sess.Agent,
 				model: sess.Model,
@@ -338,10 +337,9 @@ func ComputeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 			continue
 		}
 
-		// A Claude session's retained timeline sums to its session total
-		// exactly (pkg/tokens asserts this), so iterating the timeline
-		// accounts for the whole session and never double-counts it against
-		// the summed fields.
+		// Supported timelines sum to their session total exactly (pkg/tokens
+		// asserts this), so iterating the timeline accounts for the whole
+		// session and never double-counts it against the summed fields.
 		events := byAgentEvents[sess.Agent]
 		for _, u := range sess.Usage {
 			model := u.Model
@@ -387,6 +385,10 @@ func ComputeRepoCost(summary *tokens.AggregateSummary, entries []AuditEntry, now
 	resp.TotalTokens = resp.AttributedTokens + resp.Unattributed.Tokens + resp.BackendUnsupported.Tokens
 
 	return resp
+}
+
+func repoCostBackendSupportsTimeline(backend string) bool {
+	return backend == tokens.BackendClaude || backend == tokens.BackendCopilot
 }
 
 // attributeRepo finds the repo that owns the usage at tsMs: the first audited

--- a/src/pkg/dashboard/collect/repo_cost_test.go
+++ b/src/pkg/dashboard/collect/repo_cost_test.go
@@ -67,7 +67,7 @@ func TestRepoCostPartitionInvariant(t *testing.T) {
 			),
 			// Agent with no repo events at all -> entirely unattributed.
 			rcSession("s2", "lonely", rcUsage(rcTime(base, 15), 400, 40)),
-			// Non-Claude backend -> backend_unsupported, in full.
+			// Non-time-resolved Copilot backend -> backend_unsupported, in full.
 			{SessionID: "s3", Agent: "reviewer", Model: "gpt-5", Backend: tokens.BackendCopilot,
 				InputTokens: 500, OutputTokens: 50, TotalTokens: 550},
 			// Claude session with NO timeline (e.g. a pre-phase-2 persisted
@@ -100,6 +100,59 @@ func TestRepoCostPartitionInvariant(t *testing.T) {
 	}
 	if resp.AttributedTokens+resp.Unattributed.Tokens+resp.BackendUnsupported.Tokens != hiveTotal {
 		t.Fatalf("AttributedTokens does not complete the partition")
+	}
+}
+
+func TestRepoCostPartitionInvariantWithCopilotLiveCapture(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	base := now.Add(-24 * time.Hour)
+
+	liveCopilot := rcSession("copilot-live-scanner", "scanner",
+		tokens.UsageEvent{TimestampMs: rcTime(base, 15).UnixMilli(), Model: "gpt-5", Coalesced: 1, Input: 300, Output: 30},
+		tokens.UsageEvent{TimestampMs: rcTime(base, 25).UnixMilli(), Model: "gpt-5", Coalesced: 1, Input: 200, Output: 20},
+	)
+	liveCopilot.Backend = tokens.BackendCopilot
+	liveCopilot.Model = "gpt-5"
+
+	summary := &tokens.AggregateSummary{
+		Sessions: []tokens.SessionSummary{
+			liveCopilot,
+			// The scanner's session.shutdown copy for the same active Copilot
+			// session is zeroed once live capture starts; if repo-cost summed
+			// scanner and sink totals independently, this test would exceed the
+			// hive total below.
+			{SessionID: "copilot-shutdown-active", Agent: "scanner", Model: "gpt-5", Backend: tokens.BackendCopilot},
+			// Historical Copilot sessions without live per-request capture still
+			// contribute once, under backend_unsupported.
+			{SessionID: "copilot-before-live", Agent: "scanner", Model: "gpt-5", Backend: tokens.BackendCopilot, InputTokens: 50, OutputTokens: 5, TotalTokens: 55},
+		},
+	}
+	var hiveTotal int64
+	for _, s := range summary.Sessions {
+		hiveTotal += s.TotalTokens
+	}
+
+	entries := []AuditEntry{
+		rcEvent(rcTime(base, 10), "scanner", "org/repo-a"),
+		rcEvent(rcTime(base, 20), "scanner", "org/repo-b"),
+	}
+	resp := ComputeRepoCost(summary, entries, now)
+
+	if got := findRepo(t, resp, "org/repo-b").Tokens; got != 330 {
+		t.Fatalf("repo-b Copilot tokens = %d, want 330", got)
+	}
+	if resp.Unattributed.Tokens != 220 {
+		t.Fatalf("unattributed Copilot tokens = %d, want trailing live event 220", resp.Unattributed.Tokens)
+	}
+	if resp.BackendUnsupported.Tokens != 55 {
+		t.Fatalf("backend_unsupported tokens = %d, want historical Copilot 55", resp.BackendUnsupported.Tokens)
+	}
+	sum := resp.Unattributed.Tokens + resp.BackendUnsupported.Tokens
+	for _, e := range resp.ByRepo {
+		sum += e.Tokens
+	}
+	if sum != hiveTotal {
+		t.Fatalf("partition broken with Copilot live capture: got %d, hive total %d", sum, hiveTotal)
 	}
 }
 

--- a/src/pkg/proxy/copilot_sniff_test.go
+++ b/src/pkg/proxy/copilot_sniff_test.go
@@ -41,11 +41,11 @@ func newTestProxyWithCA(t *testing.T) (*GitHubProxy, string) {
 }
 
 // readInferenceUsage reads back the cumulative usage the sink wrote for an
-// agent (inference-<agent>.jsonl) and returns the model plus total in/out
+// agent (copilot-live-<agent>.jsonl) and returns the model plus total in/out
 // tokens.
 func readInferenceUsage(t *testing.T, dir, agent string) (model string, in, out int64) {
 	t.Helper()
-	path := filepath.Join(dir, "inference-"+agent+".jsonl")
+	path := filepath.Join(dir, "copilot-live-"+agent+".jsonl")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("reading usage file %s: %v", path, err)
@@ -343,7 +343,7 @@ func TestProxyCopilotHTTP_NonCompletionPassthrough(t *testing.T) {
 	<-proxyDone
 
 	// No usage file should have been written.
-	if _, err := os.Stat(filepath.Join(dir, "inference-worker3.jsonl")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(dir, "copilot-live-worker3.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("non-completion request should not record usage; file exists: %v", err)
 	}
 }
@@ -613,7 +613,7 @@ func TestProxyCopilotHTTP_NonSuccessCompletion(t *testing.T) {
 	resp.Body.Close()
 	<-done
 
-	if _, err := os.Stat(filepath.Join(dir, "inference-w4.jsonl")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(dir, "copilot-live-w4.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("non-2xx completion must not record usage")
 	}
 }
@@ -754,7 +754,7 @@ func TestProxyCopilotHTTP_ZeroUsageNotRecorded(t *testing.T) {
 		resp.Body.Close()
 	}
 	<-done
-	if _, err := os.Stat(filepath.Join(dir, "inference-w6.jsonl")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(dir, "copilot-live-w6.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("zero-usage completion must not record")
 	}
 }

--- a/src/pkg/proxy/github_proxy.go
+++ b/src/pkg/proxy/github_proxy.go
@@ -2351,7 +2351,7 @@ func (p *GitHubProxy) forwardCopilotResponseWithUsage(client net.Conn, resp *htt
 			}
 		}
 		if resolvedModel != "" && resolvedModel != copilotAutoModelSentinel {
-			p.tokenSink.Record(agentName, resolvedModel, in, out)
+			p.tokenSink.RecordCopilot(agentName, resolvedModel, in, out)
 			p.logger.Info("copilot usage recorded",
 				"agent", agentName,
 				"host", host,

--- a/src/pkg/tokens/collector.go
+++ b/src/pkg/tokens/collector.go
@@ -31,6 +31,12 @@ type SessionEntry struct {
 	// (bare-mode) agents set this so the translator-written usage records
 	// attribute cleanly. Normal Claude/Copilot session files omit it.
 	Agent string `json:"agent,omitempty"`
+	// Backend pins collector-generated session files (for example MITM
+	// Copilot live capture) to their producing backend.
+	Backend string `json:"backend,omitempty"`
+	// Coalesced carries UsageEvent coalescing metadata when the inference sink
+	// rewrites a bounded per-request timeline.
+	Coalesced int `json:"coalesced,omitempty"`
 }
 
 // UsageEvent is one timestamped slice of token usage inside a session — the
@@ -85,9 +91,10 @@ type SessionSummary struct {
 	// provenance and must be treated as NOT time-resolved.
 	Backend string `json:"backend,omitempty"`
 
-	// Usage is the time-ordered per-message usage timeline, populated only by
-	// scanners that can observe the grain (currently Claude — see
-	// BackendClaude). It is ADDITIVE: the summed fields above remain the
+	// Usage is the time-ordered per-message/per-request usage timeline,
+	// populated only by scanners/sinks that can observe the grain (Claude
+	// sessions and MITM-captured Copilot completions). It is ADDITIVE: the
+	// summed fields above remain the
 	// authoritative session totals and are unchanged by its presence. When
 	// non-empty its token sums equal the summed fields exactly, so a consumer
 	// may use either but must never add both.
@@ -122,7 +129,8 @@ type SessionSummary struct {
 // complete as it was before the timeline existed. A restored session therefore
 // has Backend set but Usage empty, which the repo-cost join treats as
 // not-time-resolved and reports under backend_unsupported rather than
-// silently dropping or misattributing its tokens.
+// silently dropping or misattributing its tokens unless its source can
+// rebuild the timeline again (as live Copilot capture does).
 func stripUsageTimelines(agg *AggregateSummary) *AggregateSummary {
 	if agg == nil {
 		return nil
@@ -455,6 +463,8 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 
 	firstUserMsg := ""
 	explicitAgent := ""
+	explicitBackend := ""
+	var timeline usageTimeline
 	// FirstActive/LastActive are the min/max parseable entry timestamps, not
 	// the first/last line seen: flat-format files are append-mostly but not
 	// guaranteed ordered (atomic rewrites and merged records can interleave),
@@ -479,6 +489,9 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 		if entry.Agent != "" && explicitAgent == "" {
 			explicitAgent = entry.Agent
 		}
+		if entry.Backend != "" && explicitBackend == "" {
+			explicitBackend = entry.Backend
+		}
 
 		if entry.Role == "user" && firstUserMsg == "" {
 			firstUserMsg = entry.Message
@@ -492,6 +505,17 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 		summary.OutputTokens += entry.OutputTokens
 		summary.CacheRead += entry.CacheRead
 		summary.CacheCreate += entry.CacheCreation
+		if entry.InputTokens > 0 || entry.OutputTokens > 0 || entry.CacheRead > 0 || entry.CacheCreation > 0 {
+			timeline.add(UsageEvent{
+				TimestampMs: parseTimestampToUnixMilli(entry.Timestamp),
+				Model:       entry.Model,
+				Coalesced:   entry.Coalesced,
+				Input:       entry.InputTokens,
+				Output:      entry.OutputTokens,
+				CacheRead:   entry.CacheRead,
+				CacheCreate: entry.CacheCreation,
+			})
+		}
 
 		if entry.Role == "user" || entry.Role == "assistant" {
 			summary.Messages++
@@ -501,6 +525,18 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 	summary.TotalTokens = summary.InputTokens + summary.OutputTokens + summary.CacheRead + summary.CacheCreate
 	summary.FirstActive = firstTimestamp
 	summary.LastActive = lastTimestamp
+	summary.Usage, summary.UsageCoalesced = timeline.finish()
+	if explicitBackend != "" {
+		summary.Backend = explicitBackend
+	} else {
+		base := filepath.Base(path)
+		switch {
+		case strings.HasPrefix(base, inferenceSessionFilePrefix):
+			summary.Backend = BackendInference
+		case strings.HasPrefix(base, copilotLiveSessionFilePrefix):
+			summary.Backend = BackendCopilot
+		}
+	}
 
 	if explicitAgent != "" {
 		summary.Agent = explicitAgent

--- a/src/pkg/tokens/copilot_scanner.go
+++ b/src/pkg/tokens/copilot_scanner.go
@@ -166,9 +166,9 @@ func parseCopilotSessionFile(path string) (*SessionSummary, error) {
 	summary := &SessionSummary{
 		Agent: "unknown",
 		Model: "unknown",
-		// All token usage lands in one lump at session.shutdown, so there is no
-		// intra-session time distribution to recover. Repo attribution reports
-		// copilot tokens as backend_unsupported.
+		// Native session-file token usage lands in one lump at session.shutdown,
+		// so there is no intra-session time distribution to recover here. Live
+		// MITM capture writes separate BackendCopilot sessions with timelines.
 		Backend: BackendCopilot,
 	}
 

--- a/src/pkg/tokens/inference_sink.go
+++ b/src/pkg/tokens/inference_sink.go
@@ -18,6 +18,11 @@ import (
 // wiring. The prefix keeps them visually distinct from CLI session files.
 const inferenceSessionFilePrefix = "inference-"
 
+// copilotLiveSessionFilePrefix is used for Copilot completions captured by the
+// MITM proxy. Keeping them in their own collectable session file prevents them
+// from being merged with bare-mode inference totals for the same agent.
+const copilotLiveSessionFilePrefix = "copilot-live-"
+
 // inferenceFilePerm is the mode for the per-agent inference usage files.
 const inferenceFilePerm = 0o644
 
@@ -51,6 +56,8 @@ type inferenceAgentTotals struct {
 	// sessions. FirstSeen survives restarts via restoreFromDisk.
 	FirstSeen string
 	LastSeen  string
+	Backend   string
+	Usage     []UsageEvent
 }
 
 // NewInferenceSink returns a sink that writes per-agent usage files into dir.
@@ -82,19 +89,24 @@ func (s *InferenceSink) restoreFromDisk() {
 	if s == nil || s.dir == "" {
 		return
 	}
-	matches, err := filepath.Glob(filepath.Join(s.dir, inferenceSessionFilePrefix+"*.jsonl"))
-	if err != nil {
-		return
-	}
-	for _, path := range matches {
-		base := filepath.Base(path)
-		agent := strings.TrimSuffix(strings.TrimPrefix(base, inferenceSessionFilePrefix), ".jsonl")
-		if agent == "" {
+	for _, prefix := range []string{inferenceSessionFilePrefix, copilotLiveSessionFilePrefix} {
+		matches, err := filepath.Glob(filepath.Join(s.dir, prefix+"*.jsonl"))
+		if err != nil {
 			continue
 		}
-		t := s.parseAgentFile(path)
-		if t != nil {
-			s.totals[agent] = t
+		for _, path := range matches {
+			base := filepath.Base(path)
+			agent := strings.TrimSuffix(strings.TrimPrefix(base, prefix), ".jsonl")
+			if agent == "" {
+				continue
+			}
+			t := s.parseAgentFile(path)
+			if t != nil {
+				if t.Backend == "" {
+					t.Backend = sinkBackendFromPrefix(prefix)
+				}
+				s.totals[sinkTotalsKey(t.Backend, agent)] = t
+			}
 		}
 	}
 }
@@ -121,6 +133,9 @@ func (s *InferenceSink) parseAgentFile(path string) *inferenceAgentTotals {
 		if e.Model != "" {
 			t.Model = e.Model
 		}
+		if e.Backend != "" {
+			t.Backend = e.Backend
+		}
 		if ms := parseTimestampToUnixMilli(e.Timestamp); ms > 0 {
 			if t.FirstSeen == "" || ms < parseTimestampToUnixMilli(t.FirstSeen) {
 				t.FirstSeen = e.Timestamp
@@ -129,9 +144,18 @@ func (s *InferenceSink) parseAgentFile(path string) *inferenceAgentTotals {
 				t.LastSeen = e.Timestamp
 			}
 		}
-		if e.InputTokens > 0 || e.OutputTokens > 0 {
+		if e.InputTokens > 0 || e.OutputTokens > 0 || e.CacheRead > 0 || e.CacheCreation > 0 {
 			t.InputTokens += e.InputTokens
 			t.OutputTokens += e.OutputTokens
+			t.Usage = append(t.Usage, UsageEvent{
+				TimestampMs: parseTimestampToUnixMilli(e.Timestamp),
+				Model:       e.Model,
+				Coalesced:   e.Coalesced,
+				Input:       e.InputTokens,
+				Output:      e.OutputTokens,
+				CacheRead:   e.CacheRead,
+				CacheCreate: e.CacheCreation,
+			})
 			found = true
 		}
 	}
@@ -147,6 +171,18 @@ func (s *InferenceSink) parseAgentFile(path string) *inferenceAgentTotals {
 // no-op when the sink is disabled, the agent name is empty, or the usage is
 // non-positive, so callers can invoke it unconditionally.
 func (s *InferenceSink) Record(agent, model string, inputTokens, outputTokens int64) {
+	s.record(agent, model, BackendInference, inputTokens, outputTokens)
+}
+
+// RecordCopilot adds one Copilot completion captured live by the MITM proxy.
+// Unlike Copilot session.shutdown metrics, each call has a real wall-clock
+// timestamp, so the collector persists a Usage timeline that /api/repo-cost can
+// join against audited repo activity.
+func (s *InferenceSink) RecordCopilot(agent, model string, inputTokens, outputTokens int64) {
+	s.record(agent, model, BackendCopilot, inputTokens, outputTokens)
+}
+
+func (s *InferenceSink) record(agent, model, backend string, inputTokens, outputTokens int64) {
 	if s == nil || s.dir == "" || agent == "" {
 		return
 	}
@@ -155,10 +191,11 @@ func (s *InferenceSink) Record(agent, model string, inputTokens, outputTokens in
 	}
 
 	s.mu.Lock()
-	t, ok := s.totals[agent]
+	key := sinkTotalsKey(backend, agent)
+	t, ok := s.totals[key]
 	if !ok {
-		t = &inferenceAgentTotals{}
-		s.totals[agent] = t
+		t = &inferenceAgentTotals{Backend: backend}
+		s.totals[key] = t
 	}
 	if model != "" {
 		t.Model = model
@@ -178,7 +215,16 @@ func (s *InferenceSink) Record(agent, model string, inputTokens, outputTokens in
 	if outputTokens > 0 {
 		t.OutputTokens += outputTokens
 	}
+	timeline := usageTimeline{events: append([]UsageEvent(nil), t.Usage...)}
+	timeline.add(UsageEvent{
+		TimestampMs: parseTimestampToUnixMilli(stamp),
+		Model:       model,
+		Input:       inputTokens,
+		Output:      outputTokens,
+	})
+	t.Usage, _ = timeline.finish()
 	snapshot := *t
+	snapshot.Usage = append([]UsageEvent(nil), t.Usage...)
 	s.mu.Unlock()
 
 	if err := s.writeAgentFile(agent, &snapshot); err != nil && s.logger != nil {
@@ -197,16 +243,46 @@ func (s *InferenceSink) writeAgentFile(agent string, t *inferenceAgentTotals) er
 		return fmt.Errorf("creating metrics dir: %w", err)
 	}
 
+	backend := t.Backend
+	if backend == "" {
+		backend = BackendInference
+	}
 	entries := []SessionEntry{
-		{Role: "user", Agent: agent, Message: agent, Model: t.Model, Timestamp: t.FirstSeen},
-		{
+		{Role: "user", Agent: agent, Message: agent, Model: t.Model, Timestamp: t.FirstSeen, Backend: backend},
+	}
+	if len(t.Usage) == 0 {
+		entries = append(entries, SessionEntry{
 			Role:         "assistant",
 			Agent:        agent,
 			Model:        t.Model,
 			InputTokens:  t.InputTokens,
 			OutputTokens: t.OutputTokens,
 			Timestamp:    t.LastSeen,
-		},
+			Backend:      backend,
+		})
+	} else {
+		for _, u := range t.Usage {
+			ts := t.LastSeen
+			if u.TimestampMs > 0 {
+				ts = time.UnixMilli(u.TimestampMs).UTC().Format(time.RFC3339)
+			}
+			model := u.Model
+			if model == "" {
+				model = t.Model
+			}
+			entries = append(entries, SessionEntry{
+				Role:          "assistant",
+				Agent:         agent,
+				Model:         model,
+				InputTokens:   u.Input,
+				OutputTokens:  u.Output,
+				CacheRead:     u.CacheRead,
+				CacheCreation: u.CacheCreate,
+				Timestamp:     ts,
+				Backend:       backend,
+				Coalesced:     u.Coalesced,
+			})
+		}
 	}
 
 	var buf []byte
@@ -219,7 +295,7 @@ func (s *InferenceSink) writeAgentFile(agent string, t *inferenceAgentTotals) er
 		buf = append(buf, '\n')
 	}
 
-	path := filepath.Join(s.dir, inferenceSessionFilePrefix+agent+".jsonl")
+	path := filepath.Join(s.dir, sinkFilePrefix(backend)+agent+".jsonl")
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, buf, inferenceFilePerm); err != nil {
 		return fmt.Errorf("writing usage file: %w", err)
@@ -228,4 +304,25 @@ func (s *InferenceSink) writeAgentFile(agent string, t *inferenceAgentTotals) er
 		return fmt.Errorf("renaming usage file: %w", err)
 	}
 	return nil
+}
+
+func sinkTotalsKey(backend, agent string) string {
+	if backend == "" {
+		backend = BackendInference
+	}
+	return backend + "\x00" + agent
+}
+
+func sinkFilePrefix(backend string) string {
+	if backend == BackendCopilot {
+		return copilotLiveSessionFilePrefix
+	}
+	return inferenceSessionFilePrefix
+}
+
+func sinkBackendFromPrefix(prefix string) string {
+	if prefix == copilotLiveSessionFilePrefix {
+		return BackendCopilot
+	}
+	return BackendInference
 }

--- a/src/pkg/tokens/inference_sink_test.go
+++ b/src/pkg/tokens/inference_sink_test.go
@@ -200,3 +200,39 @@ func TestInferenceSinkFirstSeenSurvivesRestart(t *testing.T) {
 		t.Errorf("LastActive = %d, want post-restart Record %d", sess.LastActive, t1.UnixMilli())
 	}
 }
+
+func TestInferenceSinkRecordsCopilotTimeline(t *testing.T) {
+	dir := t.TempDir()
+	sink := NewInferenceSink(dir, nil)
+
+	t0 := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	current := t0
+	sink.now = func() time.Time { return current }
+	sink.RecordCopilot("scanner", "gpt-5", 100, 25)
+	current = t0.Add(5 * time.Minute)
+	sink.RecordCopilot("scanner", "gpt-5", 40, 10)
+
+	agg, err := CollectFromDir(dir, nil)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+	if len(agg.Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(agg.Sessions))
+	}
+	sess := agg.Sessions[0]
+	if sess.Backend != BackendCopilot {
+		t.Fatalf("Backend = %q, want %q", sess.Backend, BackendCopilot)
+	}
+	if sess.TotalTokens != 175 {
+		t.Fatalf("TotalTokens = %d, want 175", sess.TotalTokens)
+	}
+	if got := sess.UsageTotal(); got != sess.TotalTokens {
+		t.Fatalf("UsageTotal = %d, want session total %d", got, sess.TotalTokens)
+	}
+	if len(sess.Usage) != 2 {
+		t.Fatalf("usage events = %d, want 2: %+v", len(sess.Usage), sess.Usage)
+	}
+	if sess.Usage[0].TimestampMs != t0.UnixMilli() || sess.Usage[1].TimestampMs != t0.Add(5*time.Minute).UnixMilli() {
+		t.Fatalf("usage timestamps = %+v, want capture-time stamps", sess.Usage)
+	}
+}

--- a/src/pkg/tokens/usage_timeline.go
+++ b/src/pkg/tokens/usage_timeline.go
@@ -10,10 +10,9 @@ const (
 	// per-assistant-message usage WITH a per-entry timestamp, so it is the only
 	// backend that currently yields a UsageEvent timeline.
 	BackendClaude = "claude"
-	// BackendCopilot is the Copilot CLI. Its events.jsonl accrues all token
-	// usage in a single lump at session.shutdown, so no intra-session time
-	// distribution exists to recover. Interval attribution is structurally
-	// impossible for it without proxy-side capture.
+	// BackendCopilot is the Copilot CLI. Its native events.jsonl accrues all
+	// token usage in a single lump at session.shutdown, while MITM live capture
+	// writes timestamped per-completion usage under the same backend.
 	BackendCopilot = "copilot"
 	// BackendBob is the bobshell backend. Its messages carry per-message usage
 	// but the parser does not currently read per-message timestamps, and


### PR DESCRIPTION
Fixes #5802

## Summary
- persist MITM-captured Copilot completion usage as timestamped copilot-live sessions
- feed live Copilot timelines into /api/repo-cost while leaving historical shutdown lumps in backend_unsupported
- add invariant coverage with live Copilot capture plus zeroed shutdown scanner sessions to guard against double-counting

## Validation
- cd src && go build ./...
- cd src && go vet ./...
- cd src && go test ./pkg/tokens ./pkg/dashboard/collect ./pkg/proxy