### PR TITLE
🐛 Security hardening: port public identity header proofing to v4

### DIFF
--- a/changelog.d/security-5771-public-identity-proof.md
+++ b/changelog.d/security-5771-public-identity-proof.md
@@ -1,0 +1,1 @@
+- Public dashboard endpoints now strip forged `X-Hive-User`/`X-Hive-Role` identity headers unless the hub's `X-Hive-Proxy-Auth` proof is valid, closing an anonymous contributor-control and impersonation bypass ([#5771](https://github.com/hivecommons/hive/issues/5771)).

--- a/src/pkg/dashboard/auth_public_headers_test.go
+++ b/src/pkg/dashboard/auth_public_headers_test.go
@@ -1,0 +1,203 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func publicIdentityTestServer(t *testing.T) (*Server, http.Handler) {
+	t.Helper()
+	setupContributeEnv(t)
+	oldUserTokenPath := userTokenPath
+	userTokenPath = t.TempDir() + "/missing-gh-user-token"
+	t.Cleanup(func() { userTokenPath = oldUserTokenPath })
+	s, _ := apiServer(t)
+	s.authToken = "shared-secret-token"
+	return s, s.authenticate(s.roleEnforcement(s.mux))
+}
+
+func seedPublicIdentityProfile(t *testing.T, username string) {
+	t.Helper()
+	if err := saveContributorProfile(&ContributorProfile{
+		GitHubUsername: username,
+		ContributorID:  "c-" + username,
+		TrustTier:      "trusted",
+		RegisteredAt:   time.Now().UTC().Format(time.RFC3339),
+		LabelInterests: []string{"old"},
+		Archetype:      "old archetype",
+	}); err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+}
+
+func servePublicIdentityRequest(handler http.Handler, method, path, body string, proof bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-User", "trusted")
+	req.Header.Set("X-Hive-Role", "owner")
+	if proof {
+		req.Header.Set(proxyAuthHeader, "shared-secret-token")
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func TestPublicContributeQueueControlsIgnoreForgedIdentityHeadersWithoutProxyProof(t *testing.T) {
+	_, handler := publicIdentityTestServer(t)
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"queue_order", http.MethodPut, "/api/contribute/queue/order", `{"order":[]}`},
+		{"queue_hold", http.MethodPost, "/api/contribute/queue/hold", `{"key":"myorg/repo1#1","held":true}`},
+		{"queue_hold_clear", http.MethodPost, "/api/contribute/queue/hold/clear", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := servePublicIdentityRequest(handler, tc.method, tc.path, tc.body, false)
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("forged identity without proxy proof got %d, want 403: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestPublicContributeQueueControlsAcceptProxiedIdentityWithValidProof(t *testing.T) {
+	_, handler := publicIdentityTestServer(t)
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"queue_order", http.MethodPut, "/api/contribute/queue/order", `{"order":[]}`},
+		{"queue_hold", http.MethodPost, "/api/contribute/queue/hold", `{"key":"myorg/repo1#1","held":true}`},
+		{"queue_hold_clear", http.MethodPost, "/api/contribute/queue/hold/clear", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := servePublicIdentityRequest(handler, tc.method, tc.path, tc.body, true)
+			if w.Code != http.StatusOK {
+				t.Fatalf("proxied identity with valid proof got %d, want 200: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestPublicContributorSelfServiceIgnoresForgedIdentityHeadersWithoutProxyProof(t *testing.T) {
+	_, handler := publicIdentityTestServer(t)
+	seedPublicIdentityProfile(t, "trusted")
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		want   int
+	}{
+		{"invite", http.MethodPost, "/api/contribute/invite", `{}`, http.StatusUnauthorized},
+		{"interests", http.MethodPut, "/api/contribute/interests", `{"interests":["pwned"]}`, http.StatusUnauthorized},
+		{"dossier", http.MethodPost, "/api/contribute/dossier", `{"archetype":"pwned"}`, http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := servePublicIdentityRequest(handler, tc.method, tc.path, tc.body, false)
+			if w.Code != tc.want {
+				t.Fatalf("forged identity without proxy proof got %d, want %d: %s", w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+
+	prof := findContributor("trusted")
+	if prof == nil {
+		t.Fatal("seeded profile missing")
+	}
+	if len(prof.LabelInterests) != 1 || prof.LabelInterests[0] != "old" {
+		t.Fatalf("forged interests request mutated profile: %+v", prof.LabelInterests)
+	}
+	if prof.Archetype != "old archetype" {
+		t.Fatalf("forged dossier request mutated archetype to %q", prof.Archetype)
+	}
+
+	limits := servePublicIdentityRequest(handler, http.MethodGet, "/api/contribute/limits", ``, false)
+	if limits.Code != http.StatusOK {
+		t.Fatalf("anonymous limits got %d, want 200: %s", limits.Code, limits.Body.String())
+	}
+	var limitsResp map[string]any
+	if err := json.Unmarshal(limits.Body.Bytes(), &limitsResp); err != nil {
+		t.Fatalf("decode limits: %v", err)
+	}
+	if _, ok := limitsResp["you"]; ok {
+		t.Fatalf("forged limits request exposed viewer-specific usage: %s", limits.Body.String())
+	}
+
+	status := servePublicIdentityRequest(handler, http.MethodGet, "/api/gh-user-auth/status", ``, false)
+	if status.Code != http.StatusOK {
+		t.Fatalf("auth status got %d, want 200: %s", status.Code, status.Body.String())
+	}
+	var statusResp map[string]any
+	if err := json.Unmarshal(status.Body.Bytes(), &statusResp); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if loggedIn, _ := statusResp["logged_in"].(bool); loggedIn {
+		t.Fatalf("forged auth status reported logged in: %s", status.Body.String())
+	}
+}
+
+func TestPublicContributorSelfServiceAcceptsProxiedIdentityWithValidProof(t *testing.T) {
+	_, handler := publicIdentityTestServer(t)
+	seedPublicIdentityProfile(t, "trusted")
+
+	invite := servePublicIdentityRequest(handler, http.MethodPost, "/api/contribute/invite", `{}`, true)
+	if invite.Code != http.StatusOK {
+		t.Fatalf("proxied invite got %d, want 200: %s", invite.Code, invite.Body.String())
+	}
+	var inviteResp map[string]any
+	if err := json.Unmarshal(invite.Body.Bytes(), &inviteResp); err != nil {
+		t.Fatalf("decode invite: %v", err)
+	}
+	if inviteResp["inviter"] != "trusted" {
+		t.Fatalf("proxied invite inviter = %v, want trusted", inviteResp["inviter"])
+	}
+
+	interests := servePublicIdentityRequest(handler, http.MethodPut, "/api/contribute/interests", `{"interests":["gpu"]}`, true)
+	if interests.Code != http.StatusOK {
+		t.Fatalf("proxied interests got %d, want 200: %s", interests.Code, interests.Body.String())
+	}
+	dossier := servePublicIdentityRequest(handler, http.MethodPost, "/api/contribute/dossier", `{"archetype":"verified"}`, true)
+	if dossier.Code != http.StatusOK {
+		t.Fatalf("proxied dossier got %d, want 200: %s", dossier.Code, dossier.Body.String())
+	}
+
+	limits := servePublicIdentityRequest(handler, http.MethodGet, "/api/contribute/limits", ``, true)
+	if limits.Code != http.StatusOK {
+		t.Fatalf("proxied limits got %d, want 200: %s", limits.Code, limits.Body.String())
+	}
+	var limitsResp map[string]any
+	if err := json.Unmarshal(limits.Body.Bytes(), &limitsResp); err != nil {
+		t.Fatalf("decode limits: %v", err)
+	}
+	you, ok := limitsResp["you"].(map[string]any)
+	if !ok || you["username"] != "trusted" {
+		t.Fatalf("proxied limits did not include trusted viewer: %s", limits.Body.String())
+	}
+
+	status := servePublicIdentityRequest(handler, http.MethodGet, "/api/gh-user-auth/status", ``, true)
+	if status.Code != http.StatusOK {
+		t.Fatalf("proxied auth status got %d, want 200: %s", status.Code, status.Body.String())
+	}
+	var statusResp map[string]any
+	if err := json.Unmarshal(status.Body.Bytes(), &statusResp); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if loggedIn, _ := statusResp["logged_in"].(bool); !loggedIn || statusResp["username"] != "trusted" || statusResp["role"] != "owner" {
+		t.Fatalf("proxied auth status did not report trusted owner: %s", status.Body.String())
+	}
+}

--- a/src/pkg/dashboard/server.go
+++ b/src/pkg/dashboard/server.go
@@ -1129,7 +1129,45 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		//
 		// The authToken=="" bypass remains for spokes that are genuinely open by
 		// design (no allowlist AND no token) — e.g. a local/dev dashboard.
+		inboundUser := r.Header.Get("X-Hive-User")
+		inboundRole := r.Header.Get("X-Hive-Role")
+
+		// Treat identity headers as an internal request attribute. Preserve inbound
+		// values only after the request has proved it transited the trusted hub
+		// proxy; this must happen before public-path dispatch because several public
+		// contribute handlers consult X-Hive-User/X-Hive-Role for optional identity.
+		r.Header.Del("X-Hive-User")
+		r.Header.Del("X-Hive-Role")
+		r.Header.Del(ownerRoleVerifiedHeader)
+
+		trustProxyIdentity := func(markOwner bool) (bool, string) {
+			if directRouteAuthz || inboundUser == "" || inboundRole == "" {
+				return false, ""
+			}
+			proof := r.Header.Get(proxyAuthHeader)
+			switch {
+			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
+				r.Header.Set("X-Hive-User", inboundUser)
+				r.Header.Set("X-Hive-Role", inboundRole)
+				if markOwner && isOwnerRole(inboundRole) {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+				return true, ""
+			case proof == "" && !proxyProofRequired:
+				r.Header.Set("X-Hive-User", inboundUser)
+				r.Header.Set("X-Hive-Role", inboundRole)
+				return true, ""
+			case proof == "":
+				return false, "missing proxy proof header"
+			default:
+				return false, "invalid proxy proof header"
+			}
+		}
+
 		if isPublicPath(r.URL.Path) {
+			// Public endpoints remain reachable anonymously, but identity headers are
+			// visible to handlers only when backed by the hub's proxy proof.
+			trustProxyIdentity(true)
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -1150,26 +1188,24 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 						r.Header.Set(ownerRoleVerifiedHeader, "true")
 					}
 				}
-			} else if r.Header.Get("X-Hive-Role") == "" {
+			} else if inboundRole != "" {
+				// Open/dev spokes have no auth boundary; preserve an explicit role so
+				// local role-gate tests and read-only demos can still exercise least
+				// privilege. Public paths returned above with unproved identity stripped.
+				if inboundUser != "" {
+					r.Header.Set("X-Hive-User", inboundUser)
+				}
+				r.Header.Set("X-Hive-Role", inboundRole)
+				if isOwnerRole(inboundRole) {
+					r.Header.Set(ownerRoleVerifiedHeader, "true")
+				}
+			} else {
 				r.Header.Set("X-Hive-Role", config.RoleOwner)
-				r.Header.Set(ownerRoleVerifiedHeader, "true")
-			} else if isOwnerRole(r.Header.Get("X-Hive-Role")) {
 				r.Header.Set(ownerRoleVerifiedHeader, "true")
 			}
 			next.ServeHTTP(w, r)
 			return
 		}
-		inboundUser := r.Header.Get("X-Hive-User")
-		inboundRole := r.Header.Get("X-Hive-Role")
-
-		// Treat identity headers as an internal request attribute. Preserve the
-		// inbound values only in the hub-proxy branch below, after that path has
-		// been authenticated as trusted; all other auth paths must set any role
-		// explicitly so clients cannot spoof owner access with X-Hive-Role.
-		r.Header.Del("X-Hive-User")
-		r.Header.Del("X-Hive-Role")
-		r.Header.Del(ownerRoleVerifiedHeader)
-
 		// Internal automation authenticates with the shared token via the
 		// X-Hive-Internal header; this is a trusted server-to-server path
 		// (the local proxy injects it) and carries no browser user identity.
@@ -1227,35 +1263,11 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// inject X-Hive-Proxy-Auth must be upgraded before their identity headers
 		// are accepted.
 		proxyProofRejectReason := ""
-		if !trusted && !directRouteAuthz &&
-			inboundUser != "" && inboundRole != "" {
-			proof := r.Header.Get(proxyAuthHeader)
-			switch {
-			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
-				// Proof present and valid — definitely came through the hub.
+		if !trusted {
+			if ok, reason := trustProxyIdentity(true); ok {
 				trusted = true
-				if isOwnerRole(inboundRole) {
-					r.Header.Set(ownerRoleVerifiedHeader, "true")
-				}
-			case proof == "" && !proxyProofRequired:
-				// No proof header yet (hub not upgraded) and we're not enforcing
-				// strictly — trust the identity headers as before (rollout window).
-				// Do not mark owner as verified in this legacy path: missing proof
-				// keeps reads/general writes compatible but owner-only mutations
-				// must fail closed.
-				trusted = true
-			default:
-				// Proof header present but WRONG, or strict mode with no proof:
-				// this did not come through the trusted hub proxy — reject.
-				if proof == "" {
-					proxyProofRejectReason = "missing proxy proof header"
-				} else {
-					proxyProofRejectReason = "invalid proxy proof header"
-				}
-			}
-			if trusted {
-				r.Header.Set("X-Hive-User", inboundUser)
-				r.Header.Set("X-Hive-Role", inboundRole)
+			} else {
+				proxyProofRejectReason = reason
 			}
 		}
 


### PR DESCRIPTION
## Summary
- port the v5 public-path identity-header hardening to v4
- strip forged X-Hive-User/X-Hive-Role before public route handlers
- keep valid hub-proxied identity working via X-Hive-Proxy-Auth

## Tests
- cd src && go build ./... && go test ./pkg/dashboard/...

Refs #5771 (v4 port)