### PR TITLE
✨ feature: persist contributor turn envelopes

### DIFF
--- a/changelog.d/changed-5799-contribute-turn-envelope.md
+++ b/changelog.d/changed-5799-contribute-turn-envelope.md
@@ -1,0 +1,1 @@
+Added opt-in contributor assignment persistence through the re-entrant pkg/turn envelope.

--- a/src/pkg/dashboard/api_contribute_test.go
+++ b/src/pkg/dashboard/api_contribute_test.go
@@ -32,6 +32,7 @@ func redirectContributeWSDisk(t *testing.T, dir string) {
 	t.Helper()
 	oldActivity, oldCompleted, oldFailed, oldNoPR := activityFilePath, completedTasksFile, failedTasksFile, noPRStreaksFile
 	oldLeases := taskLeasesFile
+	oldTurnEnvelopeDir := turnEnvelopeDirPath
 	oldAsyncActivitySave := asyncActivitySave
 	oldActivityPersistenceEnabled := activityPersistenceEnabled
 	activityFilePath = filepath.Join(dir, "activity.json")
@@ -39,11 +40,13 @@ func redirectContributeWSDisk(t *testing.T, dir string) {
 	failedTasksFile = filepath.Join(dir, "failed-tasks.json")
 	noPRStreaksFile = filepath.Join(dir, "no-pr-streaks.json")
 	taskLeasesFile = filepath.Join(dir, "task-leases.json")
+	turnEnvelopeDirPath = filepath.Join(dir, "turn-envelopes")
 	asyncActivitySave = false
 	activityPersistenceEnabled = false
 	t.Cleanup(func() {
 		activityFilePath, completedTasksFile, failedTasksFile, noPRStreaksFile = oldActivity, oldCompleted, oldFailed, oldNoPR
 		taskLeasesFile = oldLeases
+		turnEnvelopeDirPath = oldTurnEnvelopeDir
 		asyncActivitySave = oldAsyncActivitySave
 		activityPersistenceEnabled = oldActivityPersistenceEnabled
 	})

--- a/src/pkg/dashboard/contribute_turn.go
+++ b/src/pkg/dashboard/contribute_turn.go
@@ -1,0 +1,95 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/toolapprove"
+	"github.com/hivecommons/hive/pkg/turn"
+)
+
+func (h *ContributeWSHub) turnEnvelopeDirOrDefault() string {
+	if h != nil && h.turnEnvelopeDir != "" {
+		return h.turnEnvelopeDir
+	}
+	return turnEnvelopeDirPath
+}
+
+func (h *ContributeWSHub) persistTurnEnvelopeForAssignment(c *ContributorConnection, task *WSTaskAssign, gen uint64, prompt string, labels []string) string {
+	if h == nil || h.server == nil || h.server.deps == nil || h.server.deps.Config == nil || task == nil {
+		return ""
+	}
+	cfg := h.server.deps.Config
+	agentName, agentCfg := turnAgentConfig(cfg, task.Role)
+	if !cfg.ReentrantTurnEnabled(agentCfg) {
+		return ""
+	}
+	acmmLevel := 0
+	if cfg.ACMMLevel != nil {
+		acmmLevel = *cfg.ACMMLevel
+	}
+	now := time.Now().UTC()
+	env := turn.SessionEnvelope{
+		SessionID:        task.TaskID,
+		Agent:            toolapprove.AgentIdentity{Name: agentName, Role: agentCfg.Role, ToolsConfig: agentCfg.Tools},
+		ACMMLevel:        acmmLevel,
+		Status:           turn.StatusActive,
+		WorkingRepo:      task.Repo,
+		BeadID:           task.identityKey(),
+		Owner:            identityOf(c),
+		Epoch:            gen,
+		LeaseExpiry:      now.Add(wsTaskTimeout),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		Variables:        turnEnvelopeVariables(task, labels),
+		PendingApprovals: nil,
+	}
+	env.Messages = append(env.Messages,
+		turn.Message{Role: turn.RoleSystem, Content: "Hive contributor task assignment envelope", Timestamp: now},
+		turn.Message{Role: turn.RoleUser, Content: prompt, Timestamp: now},
+	)
+	if err := (turn.FileStore{Dir: h.turnEnvelopeDirOrDefault()}).Persist(context.Background(), env); err != nil {
+		h.logger.Warn("[contribute-ws] failed to persist re-entrant turn envelope", "task_id", task.TaskID, "error", err)
+		return ""
+	}
+	return task.TaskID
+}
+
+func turnAgentConfig(cfg *config.Config, role string) (string, config.AgentConfig) {
+	agentName := role
+	if agentName == "" {
+		agentName = "contributor"
+	}
+	if cfg != nil {
+		if ac, ok := cfg.Agents[agentName]; ok {
+			return agentName, ac
+		}
+	}
+	return agentName, config.AgentConfig{}
+}
+
+func turnEnvelopeVariables(task *WSTaskAssign, labels []string) map[string]string {
+	vars := map[string]string{
+		"task_id":     task.TaskID,
+		"task_kind":   task.Kind,
+		"task_key":    task.identityKey(),
+		"repo":        task.Repo,
+		"issue":       strconv.Itoa(task.Number),
+		"title":       task.Title,
+		"url":         task.URL,
+		"source_type": task.SourceType,
+		"external_id": task.ExternalID,
+	}
+	for i, label := range labels {
+		vars[fmt.Sprintf("label_%d", i)] = label
+	}
+	return vars
+}
+
+func turnEnvelopePath(dir, id string) string {
+	return filepath.Join(dir, id+".json")
+}

--- a/src/pkg/dashboard/contribute_turn_test.go
+++ b/src/pkg/dashboard/contribute_turn_test.go
@@ -1,0 +1,63 @@
+package dashboard
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/turn"
+)
+
+func TestSelectTaskPersistsTurnEnvelopeWhenOptedIn(t *testing.T) {
+	hub, s := depTestHub(t, nil)
+	dir := t.TempDir()
+	hub.turnEnvelopeDir = dir
+	yes := true
+	level := 4
+	s.deps.Config.ACMMLevel = &level
+	s.deps.Config.Turn = config.TurnConfig{Reentrant: config.ReentrantTurnConfig{Enabled: true}}
+	agent := s.deps.Config.Agents["scanner"]
+	agent.ReentrantTurn = &yes
+	agent.Role = "scanner"
+	s.deps.Config.Agents["scanner"] = agent
+
+	conn := depTestConn()
+	conn.role = "scanner"
+	msg := hub.selectTask(conn)
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("selectTask returned %+v, want task_assign", msg)
+	}
+	if msg.TurnEnvelopeID != msg.TaskID {
+		t.Fatalf("TurnEnvelopeID = %q, want task id %q", msg.TurnEnvelopeID, msg.TaskID)
+	}
+	env, err := (turn.FileStore{Dir: dir}).Load(context.Background(), msg.TurnEnvelopeID)
+	if err != nil {
+		t.Fatalf("loading persisted envelope: %v", err)
+	}
+	if env.SessionID != msg.TaskID || env.WorkingRepo != msg.Repo || env.Epoch != msg.TaskGen {
+		t.Fatalf("envelope mismatch: %+v for message %+v", env, msg)
+	}
+	if env.Owner != identityOf(conn) || env.ACMMLevel != level {
+		t.Fatalf("envelope owner/ACMM mismatch: owner=%q acmm=%d", env.Owner, env.ACMMLevel)
+	}
+	if len(env.Messages) != 2 || env.Messages[1].Content != msg.Prompt {
+		t.Fatalf("envelope messages did not capture prompt: %+v", env.Messages)
+	}
+}
+
+func TestSelectTaskDoesNotPersistTurnEnvelopeByDefault(t *testing.T) {
+	hub, _ := depTestHub(t, nil)
+	dir := t.TempDir()
+	hub.turnEnvelopeDir = dir
+	msg := hub.selectTask(depTestConn())
+	if msg == nil || msg.Type != "task_assign" {
+		t.Fatalf("selectTask returned %+v, want task_assign", msg)
+	}
+	if msg.TurnEnvelopeID != "" {
+		t.Fatalf("TurnEnvelopeID = %q, want empty when not opted in", msg.TurnEnvelopeID)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "*.json")); err != nil || len(matches) != 0 {
+		t.Fatalf("turn envelope files = %v, err=%v; want none", matches, err)
+	}
+}

--- a/src/pkg/dashboard/contribute_ws.go
+++ b/src/pkg/dashboard/contribute_ws.go
@@ -337,6 +337,9 @@ type WSMessage struct {
 	// backends are still relying on it. Absent from relays predating #5376 and
 	// from the headless path, which takes the CLI's exit code instead.
 	CompletionSignal string `json:"completion_signal,omitempty"`
+	// TurnEnvelopeID identifies the durable pkg/turn envelope written for this
+	// assignment when the re-entrant-turn rollout gate is enabled.
+	TurnEnvelopeID string `json:"turn_envelope_id,omitempty"`
 	// Permanent marks a task_failed the relay will not retry: it exhausted its
 	// per-task CLI-restart budget and gave up (see MAX_TASK_CLI_RESTARTS in
 	// bin/contributor-relay.sh). Reassigning the same work item to the same
@@ -519,7 +522,8 @@ type ContributeWSHub struct {
 	// taskLeasesFile is where the server-issued lease registry is persisted so it
 	// survives a hub restart (#5681). Overridable per hub for tests, like the
 	// sibling ledgers.
-	taskLeasesFile string
+	taskLeasesFile  string
+	turnEnvelopeDir string
 	// startedAt is when this hub process came up. It bounds the window in which a
 	// lease restored from the previous process is honoured as a hold on its work
 	// item (#5681, leaseHoldGraceAfterStart). Written once at construction and only
@@ -1142,6 +1146,7 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 		failedTasksFile:       failedTasksFile,
 		noPRStreaksFile:       noPRStreaksFile,
 		taskLeasesFile:        taskLeasesFile,
+		turnEnvelopeDir:       turnEnvelopeDirPath,
 		startedAt:             time.Now(),
 		noWorkVerdictsFile:    noWorkVerdictsPath(),
 		asyncActivitySave:     asyncActivitySave,
@@ -1318,6 +1323,7 @@ var noPRStreaksFile = "/data/contributors/no-pr-streaks.json"
 // (#5681). It sits beside the other contributor ledgers, but is written 0600: it is
 // the C4 authorization record a resume is matched against, not a report.
 var taskLeasesFile = "/data/contributors/task-leases.json"
+var turnEnvelopeDirPath = "/data/contributors/turn-envelopes"
 
 // noPRStreakRecord is the in-memory and on-disk shape of one no-PR completion
 // streak (#3980). LastAt is the most recent no-PR completion; the streak is
@@ -5753,8 +5759,7 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	// later stale-worker completion carrying an older generation is fenced out.
 	gen := h.nextTaskGen()
 
-	c.mu.Lock()
-	c.currentTask = &WSTaskAssign{
+	assignment := &WSTaskAssign{
 		TaskID:     taskID,
 		Kind:       "issue",
 		Role:       requestedRole,
@@ -5773,6 +5778,8 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			return &req
 		}(),
 	}
+	c.mu.Lock()
+	c.currentTask = assignment
 	c.currentTaskGen = gen
 	// #2568: start the hub-owned lease clock. task_progress renews it; cleanupLoop
 	// auto-releases the task if it is not renewed within wsTaskTimeout.
@@ -5794,6 +5801,8 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	c.credentialDelivered = false
 	c.tokenMintedAt = time.Now()
 	c.mu.Unlock()
+
+	turnEnvelopeID := h.persistTurnEnvelopeForAssignment(c, assignment, gen, prompt, chosen.labels)
 
 	// C4: record the SERVER-AUTHORITATIVE lease for this assignment so a later
 	// reconnect can be validated against what the hub actually issued — the exact
@@ -5849,8 +5858,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 		// The chosen issue's own labels — the Labels envelope field was declared
 		// but never populated, so a client reading it got nothing (kubestellar/
 		// hive#2393 item 8). Carried on the candidate from the scan above.
-		Labels:        chosen.labels,
-		ContribLabels: []string{"contributor/" + c.profile.GitHubUsername},
+		Labels:         chosen.labels,
+		ContribLabels:  []string{"contributor/" + c.profile.GitHubUsername},
+		TurnEnvelopeID: turnEnvelopeID,
 	}
 }
 

--- a/src/pkg/turn/store.go
+++ b/src/pkg/turn/store.go
@@ -1,0 +1,116 @@
+package turn
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const envelopeFileMode = 0o660
+
+// FileStore durably stores one JSON envelope per session ID.
+type FileStore struct {
+	Dir string
+}
+
+// Persist writes env using the same scrub-on-persist serialization as ToJSON.
+func (s FileStore) Persist(ctx context.Context, env SessionEnvelope) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path, err := s.pathFor(env.SessionID)
+	if err != nil {
+		return err
+	}
+	data, err := env.ToPrettyJSON()
+	if err != nil {
+		return fmt.Errorf("marshaling turn envelope: %w", err)
+	}
+	return writeAtomic(path, data)
+}
+
+// Load reads a persisted envelope by session ID.
+func (s FileStore) Load(ctx context.Context, sessionID string) (SessionEnvelope, error) {
+	if err := ctx.Err(); err != nil {
+		return SessionEnvelope{}, err
+	}
+	path, err := s.pathFor(sessionID)
+	if err != nil {
+		return SessionEnvelope{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return SessionEnvelope{}, fmt.Errorf("reading turn envelope %s: %w", path, err)
+	}
+	env, err := ParseEnvelope(data)
+	if err != nil {
+		return SessionEnvelope{}, fmt.Errorf("parsing turn envelope %s: %w", path, err)
+	}
+	return env, nil
+}
+
+func (s FileStore) pathFor(sessionID string) (string, error) {
+	if strings.TrimSpace(s.Dir) == "" {
+		return "", fmt.Errorf("turn: FileStore.Dir is required")
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		return "", fmt.Errorf("turn: session_id is required")
+	}
+	return filepath.Join(s.Dir, safeEnvelopeName(sessionID)+".json"), nil
+}
+
+func safeEnvelopeName(sessionID string) string {
+	var b strings.Builder
+	for _, r := range sessionID {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+func writeAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o770); err != nil {
+		return fmt.Errorf("creating turn envelope directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating tmp turn envelope: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing tmp turn envelope: %w", err)
+	}
+	if err := tmp.Chmod(envelopeFileMode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod tmp turn envelope: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing tmp turn envelope: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing tmp turn envelope: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming tmp turn envelope: %w", err)
+	}
+	cleanup = false
+	if dir, err := os.Open(filepath.Dir(path)); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return nil
+}

--- a/src/pkg/turn/store_test.go
+++ b/src/pkg/turn/store_test.go
@@ -1,0 +1,31 @@
+package turn
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestFileStorePersistLoadScrubsAndSanitizesSessionID(t *testing.T) {
+	store := FileStore{Dir: t.TempDir()}
+	env := SessionEnvelope{
+		SessionID: "repo/issue#7",
+		Messages: []Message{{
+			Role:    RoleUser,
+			Content: "token ghp_1234567890abcdef1234567890abcdef1234",
+		}},
+	}
+	if err := store.Persist(context.Background(), env); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	restored, err := store.Load(context.Background(), env.SessionID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if restored.SessionID != env.SessionID {
+		t.Fatalf("SessionID = %q, want %q", restored.SessionID, env.SessionID)
+	}
+	if strings.Contains(restored.Messages[0].Content, "ghp_") {
+		t.Fatalf("persisted envelope was not scrubbed: %q", restored.Messages[0].Content)
+	}
+}

--- a/src/pkg/turn/types.go
+++ b/src/pkg/turn/types.go
@@ -69,6 +69,9 @@ type SessionEnvelope struct {
 	WorkingRepo      string                    `json:"working_repo,omitempty"`
 	WorkingBranch    string                    `json:"working_branch,omitempty"`
 	BeadID           string                    `json:"bead_id,omitempty"`
+	Owner            string                    `json:"owner,omitempty"`
+	Epoch            uint64                    `json:"epoch,omitempty"`
+	LeaseExpiry      time.Time                 `json:"lease_expiry,omitempty"`
 	Variables        map[string]string         `json:"variables,omitempty"`
 	Subagents        map[string]string         `json:"subagents,omitempty"` // subagent sessionID -> status
 	PendingApprovals []PendingApproval         `json:"pending_approvals,omitempty"`


### PR DESCRIPTION
## Summary
- add an atomic pkg/turn FileStore for durable session envelopes
- persist contributor task assignment envelopes behind the default-off re-entrant turn gate
- return the additive turn_envelope_id only for enrolled assignments

## Validation
- cd src && go test ./pkg/turn ./pkg/dashboard -run 'TestFileStore|TestSelectTask.*TurnEnvelope'\n- cd src && go build ./... && go vet ./...