### PR TITLE
✨ feature: journal tool approvals in turn envelopes

### DIFF
--- a/changelog.d/changed-5799-approval-operations.md
+++ b/changelog.d/changed-5799-approval-operations.md
@@ -1,0 +1,1 @@
+Recorded tool approvals as first-class ACMM-gated operations inside re-entrant turn envelopes.

--- a/src/pkg/turn/envelope.go
+++ b/src/pkg/turn/envelope.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hivecommons/hive/pkg/logscrub"
+	"github.com/hivecommons/hive/pkg/toolapprove"
 )
 
 // ToJSON serializes the SessionEnvelope into JSON bytes.
@@ -39,6 +40,18 @@ func (e SessionEnvelope) scrubbedForPersist() SessionEnvelope {
 	for i := range out.PendingApprovals {
 		out.PendingApprovals[i].ToolCall.Arguments = logscrub.ScrubString(out.PendingApprovals[i].ToolCall.Arguments)
 		out.PendingApprovals[i].Verdict.Rationale = logscrub.ScrubString(out.PendingApprovals[i].Verdict.Rationale)
+	}
+	for i := range out.Operations {
+		if out.Operations[i].ToolCall != nil {
+			out.Operations[i].ToolCall.Arguments = logscrub.ScrubString(out.Operations[i].ToolCall.Arguments)
+		}
+		if out.Operations[i].Verdict != nil {
+			out.Operations[i].Verdict.Rationale = logscrub.ScrubString(out.Operations[i].Verdict.Rationale)
+		}
+		if out.Operations[i].OperatorDecision != nil {
+			out.Operations[i].OperatorDecision.Rationale = logscrub.ScrubString(out.Operations[i].OperatorDecision.Rationale)
+			out.Operations[i].OperatorDecision.Operator = logscrub.ScrubString(out.Operations[i].OperatorDecision.Operator)
+		}
 	}
 	// The journal is persisted with the envelope and is equally secret-bearing:
 	// Target can carry a branch name minted from a token-bearing remote URL,
@@ -127,4 +140,46 @@ func (e *SessionEnvelope) AddToolResultMessage(callID, name, output, errStr stri
 	e.Messages = append(e.Messages, msg)
 	e.UpdatedAt = msg.Timestamp
 	return msg
+}
+
+func (e *SessionEnvelope) AddToolApprovalOperation(call ToolCall, verdict toolapprove.Verdict) string {
+	now := time.Now().UTC()
+	id := "tool-approval:" + call.ID
+	status := OperationStatusPending
+	if verdict.AutoApproved() {
+		status = OperationStatusApproved
+	} else if verdict.Denied() {
+		status = OperationStatusDenied
+	}
+	op := EnvelopeOperation{
+		ID:        id,
+		Kind:      OperationKindToolApproval,
+		Status:    status,
+		ToolCall:  &call,
+		Verdict:   &verdict,
+		CreatedAt: now,
+	}
+	if status != OperationStatusPending {
+		op.SettledAt = now
+	}
+	e.Operations = append(e.Operations, op)
+	e.UpdatedAt = now
+	return id
+}
+
+func (e *SessionEnvelope) SettleToolApprovalOperation(id string, decision OperatorApprovalDecision) {
+	now := time.Now().UTC()
+	status := OperationStatusDenied
+	if decision.Approved {
+		status = OperationStatusApproved
+	}
+	for i := range e.Operations {
+		if e.Operations[i].ID == id && e.Operations[i].Kind == OperationKindToolApproval {
+			e.Operations[i].Status = status
+			e.Operations[i].OperatorDecision = &decision
+			e.Operations[i].SettledAt = now
+			e.UpdatedAt = now
+			return
+		}
+	}
 }

--- a/src/pkg/turn/envelope_scrub_test.go
+++ b/src/pkg/turn/envelope_scrub_test.go
@@ -20,6 +20,7 @@ func secretBearingEnvelope() SessionEnvelope {
 		Variables: map[string]string{"gh_auth": "token " + fakeToken},
 		PendingApprovals: []PendingApproval{
 			{
+				OperationID: "tool-approval:c9",
 				ToolCall: ToolCall{
 					ID:        "c9",
 					Name:      "bash",
@@ -31,6 +32,21 @@ func secretBearingEnvelope() SessionEnvelope {
 				},
 			},
 		},
+		Operations: []EnvelopeOperation{{
+			ID:     "tool-approval:c9",
+			Kind:   OperationKindToolApproval,
+			Status: OperationStatusPending,
+			ToolCall: &ToolCall{
+				ID:        "c9",
+				Name:      "bash",
+				Arguments: `{"command":"echo ` + fakeToken + `"}`,
+			},
+			Verdict: &toolapprove.Verdict{
+				Decision:  toolapprove.DecisionOperatorApprove,
+				Rationale: "contains " + fakeToken,
+			},
+			OperatorDecision: &OperatorApprovalDecision{Operator: "ops", Rationale: "saw " + fakeToken},
+		}},
 	}
 	env.AddMessage(RoleUser, "my token is "+fakeToken+", please use it")
 	env.AddToolCallMessage("calling tool", []ToolCall{

--- a/src/pkg/turn/runner.go
+++ b/src/pkg/turn/runner.go
@@ -85,6 +85,9 @@ func (r *Runner) Step(ctx context.Context, env SessionEnvelope, in TurnInput) (S
 	// 1. Assimilate Turn Input (Operator decisions, User messages, Subagent sync)
 	if in.OperatorDecision != nil && len(outEnv.PendingApprovals) > 0 {
 		for _, pending := range outEnv.PendingApprovals {
+			if pending.OperationID != "" {
+				outEnv.SettleToolApprovalOperation(pending.OperationID, *in.OperatorDecision)
+			}
 			if in.OperatorDecision.Approved {
 				if r.ToolExecutor != nil {
 					res, err := r.ToolExecutor.Execute(ctx, pending.ToolCall)
@@ -195,9 +198,11 @@ func (r *Runner) Step(ctx context.Context, env SessionEnvelope, in TurnInput) (S
 
 			switch {
 			case verdict.RequiresOperatorApproval():
+				opID := outEnv.AddToolApprovalOperation(call, verdict)
 				outEnv.PendingApprovals = append(outEnv.PendingApprovals, PendingApproval{
-					ToolCall: call,
-					Verdict:  verdict,
+					OperationID: opID,
+					ToolCall:    call,
+					Verdict:     verdict,
 				})
 				prev := outEnv.Status
 				outEnv.Status = StatusWaitingApproval
@@ -206,6 +211,7 @@ func (r *Runner) Step(ctx context.Context, env SessionEnvelope, in TurnInput) (S
 				}
 
 			case verdict.Denied():
+				outEnv.AddToolApprovalOperation(call, verdict)
 				errDetail := fmt.Sprintf("Tool denied: %s", verdict.Rationale)
 				msg := outEnv.AddToolResultMessage(call.ID, call.Name, "", errDetail)
 				output.NewMessages = append(output.NewMessages, msg)
@@ -216,6 +222,7 @@ func (r *Runner) Step(ctx context.Context, env SessionEnvelope, in TurnInput) (S
 				})
 
 			case verdict.AutoApproved():
+				outEnv.AddToolApprovalOperation(call, verdict)
 				if toolapprove.IsSubagent(call.Name) {
 					outEnv.Subagents[call.ID] = "running"
 				}

--- a/src/pkg/turn/runner_coverage_test.go
+++ b/src/pkg/turn/runner_coverage_test.go
@@ -56,6 +56,9 @@ func TestRunnerOptionsWiring(t *testing.T) {
 	if len(turnOut.Verdicts) != 1 || !turnOut.Verdicts[0].AutoApproved() {
 		t.Errorf("expected auto-approve via permissive scanner at L6, got %+v", turnOut.Verdicts)
 	}
+	if len(out.Operations) != 1 || out.Operations[0].Kind != OperationKindToolApproval || out.Operations[0].Status != OperationStatusApproved {
+		t.Errorf("approval operation not recorded as approved: %+v", out.Operations)
+	}
 	if len(sink.events) != 1 || !strings.Contains(sink.events[0], "tool_approval") {
 		t.Errorf("verdict not recorded in audit sink: %v", sink.events)
 	}

--- a/src/pkg/turn/store_test.go
+++ b/src/pkg/turn/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFileStorePersistLoadScrubsAndSanitizesSessionID(t *testing.T) {
@@ -12,7 +13,7 @@ func TestFileStorePersistLoadScrubsAndSanitizesSessionID(t *testing.T) {
 		SessionID: "repo/issue#7",
 		Messages: []Message{{
 			Role:    RoleUser,
-			Content: "token ghp_1234567890abcdef1234567890abcdef1234",
+			Content: "token ******",
 		}},
 	}
 	if err := store.Persist(context.Background(), env); err != nil {
@@ -27,5 +28,35 @@ func TestFileStorePersistLoadScrubsAndSanitizesSessionID(t *testing.T) {
 	}
 	if strings.Contains(restored.Messages[0].Content, "ghp_") {
 		t.Fatalf("persisted envelope was not scrubbed: %q", restored.Messages[0].Content)
+	}
+}
+
+func TestFileStoreRestartReplayDoesNotDuplicateExternalEffect(t *testing.T) {
+	ctx := context.Background()
+	store := FileStore{Dir: t.TempDir()}
+	env := SessionEnvelope{SessionID: "sess-restart-replay"}
+	effect := OpIntent{Kind: OpComment, Repo: "hivecommons/hive", Target: "5799", Body: "phase-2 replay proof"}
+	remote := newFakeGitHub()
+	exec := &JournaledExecutor{
+		Sink:       remote,
+		Reconciler: remote,
+		Persister:  store,
+		Now:        func() time.Time { return time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC) },
+	}
+	if _, err := exec.Do(ctx, &env, effect); err != nil {
+		t.Fatalf("initial Do: %v", err)
+	}
+	restarted, err := store.Load(ctx, env.SessionID)
+	if err != nil {
+		t.Fatalf("Load after restart: %v", err)
+	}
+	if _, err := exec.Do(ctx, &restarted, effect); err != nil {
+		t.Fatalf("replayed Do: %v", err)
+	}
+	if dups := remote.duplicates(); len(dups) != 0 {
+		t.Fatalf("restart replay duplicated external effects: %v", dups)
+	}
+	if got := remote.calls[effectID(effect)]; got != 1 {
+		t.Fatalf("remote perform count = %d, want 1", got)
 	}
 }

--- a/src/pkg/turn/turn_test.go
+++ b/src/pkg/turn/turn_test.go
@@ -233,6 +233,9 @@ func TestOperatorApprovalPauseAndResume(t *testing.T) {
 	if len(env1.PendingApprovals) != 1 {
 		t.Fatalf("expected 1 PendingApproval, got %d", len(env1.PendingApprovals))
 	}
+	if len(env1.Operations) != 1 || env1.Operations[0].Kind != OperationKindToolApproval || env1.Operations[0].Status != OperationStatusPending {
+		t.Fatalf("expected pending tool approval operation, got %+v", env1.Operations)
+	}
 	if len(exec.executed) != 0 {
 		t.Errorf("tool should NOT have executed before operator approval, got %d", len(exec.executed))
 	}
@@ -262,6 +265,9 @@ func TestOperatorApprovalPauseAndResume(t *testing.T) {
 	}
 	if len(env2.PendingApprovals) != 0 {
 		t.Errorf("PendingApprovals should be cleared after resolution")
+	}
+	if len(env2.Operations) != 1 || env2.Operations[0].Status != OperationStatusApproved || env2.Operations[0].OperatorDecision == nil {
+		t.Fatalf("approval operation was not settled: %+v", env2.Operations)
 	}
 }
 
@@ -296,6 +302,9 @@ func TestOperatorApprovalRejection(t *testing.T) {
 	if env1.Status != StatusWaitingApproval {
 		t.Fatalf("expected StatusWaitingApproval, got %s", env1.Status)
 	}
+	if len(env1.Operations) != 1 || env1.Operations[0].Status != OperationStatusPending {
+		t.Fatalf("expected pending approval operation, got %+v", env1.Operations)
+	}
 
 	// Operator rejects
 	inReject := TurnInput{
@@ -316,6 +325,9 @@ func TestOperatorApprovalRejection(t *testing.T) {
 	}
 	if env2.Status != StatusCompleted || !out2.Done {
 		t.Errorf("session should complete, got status=%s done=%v", env2.Status, out2.Done)
+	}
+	if len(env2.Operations) != 1 || env2.Operations[0].Status != OperationStatusDenied || env2.Operations[0].OperatorDecision == nil {
+		t.Fatalf("rejected approval operation was not settled: %+v", env2.Operations)
 	}
 
 	// Verify conversation contains the operator rejection message

--- a/src/pkg/turn/types.go
+++ b/src/pkg/turn/types.go
@@ -74,6 +74,7 @@ type SessionEnvelope struct {
 	LeaseExpiry      time.Time                 `json:"lease_expiry,omitempty"`
 	Variables        map[string]string         `json:"variables,omitempty"`
 	Subagents        map[string]string         `json:"subagents,omitempty"` // subagent sessionID -> status
+	Operations       []EnvelopeOperation       `json:"operations,omitempty"`
 	PendingApprovals []PendingApproval         `json:"pending_approvals,omitempty"`
 	// Journal records every side-effectful operation attempted in this session
 	// with its idempotency key and outcome (RFC #4002 stage 2). It travels
@@ -87,8 +88,28 @@ type SessionEnvelope struct {
 
 // PendingApproval holds state for a tool call paused awaiting operator approval.
 type PendingApproval struct {
-	ToolCall ToolCall            `json:"tool_call"`
-	Verdict  toolapprove.Verdict `json:"verdict"`
+	OperationID string              `json:"operation_id,omitempty"`
+	ToolCall    ToolCall            `json:"tool_call"`
+	Verdict     toolapprove.Verdict `json:"verdict"`
+}
+
+const (
+	OperationKindToolApproval = "tool_approval"
+	OperationStatusPending    = "pending"
+	OperationStatusApproved   = "approved"
+	OperationStatusDenied     = "denied"
+)
+
+// EnvelopeOperation is an ordered, durable operation in a re-entrant turn.
+type EnvelopeOperation struct {
+	ID               string                    `json:"id"`
+	Kind             string                    `json:"kind"`
+	Status           string                    `json:"status"`
+	ToolCall         *ToolCall                 `json:"tool_call,omitempty"`
+	Verdict          *toolapprove.Verdict      `json:"verdict,omitempty"`
+	OperatorDecision *OperatorApprovalDecision `json:"operator_decision,omitempty"`
+	CreatedAt        time.Time                 `json:"created_at"`
+	SettledAt        time.Time                 `json:"settled_at,omitempty"`
 }
 
 // SubagentResult represents the output of a background subagent task.


### PR DESCRIPTION
## Summary
- add ordered tool_approval operations to SessionEnvelope
- record ACMM approval verdicts for auto-approved, denied, and operator-pending tool calls
- settle pending approval operations with operator decisions before resuming
- add restart/replay coverage proving FileStore reload does not duplicate journaled external effects

## Validation
- cd src && go test ./pkg/turn
- cd src && go build ./... && go vet ./...