### PR TITLE
📖 docs: document reentrant turn rollout plan

### DIFF
--- a/changelog.d/changed-5799-reentrant-turn-rollout-docs.md
+++ b/changelog.d/changed-5799-reentrant-turn-rollout-docs.md
@@ -1,0 +1,1 @@
+Documented the v5 re-entrant turn opt-in rollout, soak plan, default-flip migration, and rollback guidance.

--- a/docs/rfc-4002-phased-roadmap.md
+++ b/docs/rfc-4002-phased-roadmap.md
@@ -1,13 +1,13 @@
 # RFC #4002 Phased Delivery Roadmap — Re-entrant Conversation-as-State Turn Model
 
-Status: planning; v5 spike complete, production rollout deferred to v6  
-Refs: #4002, #4000
+Status: v5 phase 2/3 opt-in rollout in progress
+Refs: #4002, #4000, #5799
 
 ## Compatibility contract
 
 A re-entrant turn must reconstruct everything it needs from a persisted turn
 envelope, structured input, and the existing session/context model. Until the
-v6 rollout proves safe, the current tmux loop remains the default and the
+phase 3 soak proves safe, the current tmux loop remains the default and the
 re-entrant path is opt-in only. Breaking changes require operator migration
 guidance.
 
@@ -20,18 +20,58 @@ guidance.
 - Handoff evaluation: `src/docs/design/agent-turn-handoff.md`, which defers a
   queue until durable ownership is fixed/reused.
 - Accepted design: `docs/rfc-4002-reentrant-conversation-state.md`.
+- Phase 2 production primitive: `pkg/convergence/mutation.Ledger` is the single
+  durable ownership primitive for re-entrant handoff/adoption. It now refreshes
+  under a cross-process flock and rewrites through unique synced temp files, so
+  independent holders cannot both acquire the same claim or erase each other's
+  disjoint claims.
+- Phase 2 opt-in production path: contributor assignments can persist a
+  `pkg/turn.SessionEnvelope` when `turn.reentrant.enabled` and either the
+  per-agent `reentrant_turn` flag or `turn.reentrant.background_fleet_enabled`
+  are set. The legacy websocket/tmux relay remains the execution default.
+- Tool approvals are first-class envelope operations: every tool approval
+  verdict is recorded in `SessionEnvelope.operations`, and operator decisions
+  settle the same operation before resuming execution.
+- Restart/replay proof: targeted `pkg/turn` tests persist an envelope through
+  `FileStore`, reload it as a fresh process would, and assert the journal
+  suppresses duplicate external effects.
 
-## Phase 2 — v6 opt-in production path
+## Phase 2 — v5 opt-in production path
 
-- Fix/reuse one atomic durable ownership primitive for handoff/adoption.
-- Wire one low-blast-radius production path to the envelope behind an explicit
-  opt-in flag.
-- Persist #4000 tool approvals as first-class ACMM-gated operations.
-- Prove restart and replay behaviour with no duplicated external effects.
+- Keep `turn.reentrant.enabled` false by default in all packaged config.
+- Enable one named low-blast-radius contributor/background agent with:
 
-## Phase 3 — v6+ fleet rollout
+  ```yaml
+  turn:
+    reentrant:
+      enabled: true
+  agents:
+    scanner:
+      reentrant_turn: true
+  ```
 
-- Extend opt-in to the background fleet.
-- Run at least two release cycles with multiple agent classes enabled.
-- Publish migration and rollback guidance before changing defaults.
-- Flip the default only after the legacy loop has a deprecation window.
+- Confirm envelopes appear under `/data/contributors/turn-envelopes` and that
+  dashboard assignment, task completion, failure cooldowns, and approval-desk
+  behaviour remain unchanged.
+- If symptoms appear, roll back by setting `turn.reentrant.enabled: false` or
+  `HIVE_REENTRANT_TURN_ENABLED=false`; existing envelopes are inert and can be
+  kept for audit or deleted after capture.
+
+## Phase 3 — v5+ opt-in fleet rollout and default flip
+
+- Extend opt-in to the background fleet with
+  `turn.reentrant.background_fleet_enabled: true` or
+  `HIVE_REENTRANT_TURN_BACKGROUND_FLEET=true` only after the single-agent path
+  has clean restart/replay evidence.
+- Soak for at least two release cycles with contributor, scheduler/background,
+  and approval-producing agents represented. Track restart-cost/turn-loss
+  counters, envelope write errors, duplicate-effect reconciliations, pending
+  approval settlements, and stale-epoch refusals.
+- Default-flip migration:
+  1. Announce the target release and keep the legacy loop available for one
+     deprecation window.
+  2. Flip packaged defaults only after soak shows no duplicate external effects
+     and no unresolved approval operations.
+  3. Preserve `HIVE_REENTRANT_TURN_ENABLED=false` as the one-step rollback.
+  4. During rollback, leave mutation ledgers and turn envelopes in place; they
+     are replay/audit state and do not force the re-entrant path on.

--- a/docs/rfc-4002-reentrant-conversation-state.md
+++ b/docs/rfc-4002-reentrant-conversation-state.md
@@ -1,7 +1,7 @@
 # RFC #4002: Re-entrant conversation-as-state turn model
 
-Status: accepted design; v5 spike complete, production rollout deferred  
-Refs: #4002, #4000, #4001, #4036, #4053, #4879, #5272, #5635
+Status: accepted design; v5 opt-in production rollout started
+Refs: #4002, #4000, #4001, #4036, #4053, #4879, #5272, #5635, #5799
 
 ## Summary
 
@@ -22,9 +22,9 @@ Step(ctx, envelope, input) (nextEnvelope, output, error)
 The envelope is the durable state. It records messages, operation intents,
 settlements, pending approvals, subagent synchronization, task/claim identity,
 and enough metadata to resume without depending on a suspended goroutine or a
-live tmux pane. v5 has delivered the investigation, prototype, and handoff
-evaluation needed to accept the design. Wiring it into production agents is a
-future opt-in rollout, not part of this closing RFC.
+live tmux pane. v5 delivered the investigation, prototype, and handoff evaluation needed to
+accept the design. Issue #5799 starts the production rollout on v5, still
+default-off and explicitly opt-in.
 
 ## Goals
 
@@ -84,6 +84,25 @@ of adding a parallel queue and recreating duplicate-work bugs.
 #4000 is one operation within this model. A paused tool approval is not an
 out-of-band flag; it is an operation whose request, ACMM decision, settlement,
 and resume input are serialized in the turn envelope.
+
+## v5 phase 2/3 rollout status
+
+- Durable ownership uses one primitive: `pkg/convergence/mutation.Ledger`. Its
+  claim acquisition and state transitions are cross-process serialized and
+  epoch-fenced; replacements adopt expired/waiting claims at a higher epoch.
+- The first production path is contributor assignment. When explicitly opted
+  in, the hub persists a `pkg/turn.SessionEnvelope` for the assignment while
+  preserving the existing websocket relay execution path.
+- The opt-in surface is:
+  - global: `turn.reentrant.enabled` or `HIVE_REENTRANT_TURN_ENABLED`;
+  - named agent: `agents.<name>.reentrant_turn`;
+  - fleet: `turn.reentrant.background_fleet_enabled` or
+    `HIVE_REENTRANT_TURN_BACKGROUND_FLEET`.
+- Tool approvals now appear in `SessionEnvelope.operations` as
+  `tool_approval` operations with the ACMM verdict, tool call, pending/settled
+  status, and operator decision.
+- Rollback remains one flag flip: disable the global gate. Persisted envelopes
+  are passive audit/replay state and are not consumed when the gate is off.
 
 ## State envelope
 


### PR DESCRIPTION
## Summary
- document the v5 re-entrant turn phase 2/3 rollout status
- describe the single-agent and background-fleet opt-in flags
- add soak, default-flip migration, and rollback guidance

Fixes #5799

## Validation
- git diff --check