### PR TITLE
🌱 ci: route trusted CI lanes to self-hosted runners

### DIFF
--- a/.github/workflows/changelog-fragment-guard.yml
+++ b/.github/workflows/changelog-fragment-guard.yml
@@ -63,7 +63,7 @@ concurrency:
 jobs:
   changelog-fragment-guard:
     name: changelog-fragment-guard
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/dashboard-lint.yml
+++ b/.github/workflows/dashboard-lint.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   syntax-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -61,7 +61,7 @@ permissions:
 jobs:
   link-check:
     name: relative links and anchors resolve
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/go-security-analysis.yml
+++ b/.github/workflows/go-security-analysis.yml
@@ -73,7 +73,7 @@ concurrency:
 jobs:
   govulncheck:
     name: govulncheck (known vulnerabilities)
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -149,7 +149,7 @@ jobs:
 
   action-pins:
     name: action pins resolve
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -164,7 +164,7 @@ jobs:
 
   notice-drift:
     name: NOTICE matches the module graph
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     # WHY THIS JOB EXISTS: a CNCF General Technical Review asks how the
     # project ensures third-party attribution stays correct and complete. A
     # generated NOTICE that can silently go stale is worse than no NOTICE at

--- a/.github/workflows/image-attestation-guard.yml
+++ b/.github/workflows/image-attestation-guard.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   no-image-attestations:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/podman-contract.yml
+++ b/.github/workflows/podman-contract.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   contract-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release-line-guard.yml
+++ b/.github/workflows/release-line-guard.yml
@@ -48,7 +48,7 @@ permissions:
 
 jobs:
   release-lines-in-sync:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/suid-contract.yml
+++ b/.github/workflows/suid-contract.yml
@@ -59,7 +59,7 @@ permissions:
 
 jobs:
   contract-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/testutil-guard.yml
+++ b/.github/workflows/testutil-guard.yml
@@ -55,7 +55,7 @@ concurrency:
 jobs:
   testutil-guard:
     name: testutil-guard
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -45,6 +45,7 @@ permissions:
   contents: read
   issues: write
 
+
 # Cancel superseded PR runs only (#4623). A new push to a PR makes the
 # in-flight run's verdict irrelevant, so cancelling it is pure runner-minute
 # savings. Scheduled and workflow_dispatch runs must NEVER be cancelable:

--- a/changelog.d/changed-ci-self-hosted-runners.md
+++ b/changelog.d/changed-ci-self-hosted-runners.md
@@ -1,0 +1,1 @@
+- Trusted CI lanes now target the repository self-hosted runner pool while fork pull requests and privileged release/runtime lanes remain on GitHub-hosted runners.


### PR DESCRIPTION
## Summary
- Routes trusted lightweight/static v4 CI lanes to the repo self-hosted runner pool (`self-hosted`, `hive`).
- Keeps fork PRs, `pull_request_target`, arm64, release-critical Docker publishing, GitHub-CLI-dependent reminders/pruners, race-test Go lanes, and privileged Podman/runtime lanes on GitHub-hosted runners.
- Adds a changelog fragment for the CI routing change.

## Runner routing
| Workflow | Jobs switched | Left hosted / reason |
| --- | --- | --- |
| go-security-analysis.yml | govulncheck, action-pins, notice-drift | gosec/golangci-lint stayed hosted after gosec was too slow on 2 CPU and v5 golangci failed on self-hosted |
| dashboard-lint.yml | syntax-check | none |
| docs-link-check.yml | link-check | none |
| changelog-fragment-guard.yml | changelog-fragment-guard | changelog-reminder uses preinstalled `gh`, so it stays hosted |
| image-attestation-guard.yml | no-image-attestations | none |
| release-line-guard.yml | release-lines-in-sync | none |
| testutil-guard.yml | testutil-guard | none |
| podman-contract.yml | contract-check | live Podman lanes stay hosted |
| suid-contract.yml | contract-check | runtime jobs need container privileges and stay hosted |
| v2-ci.yml / v2-tests.yml / coverage-hourly.yml | none | self-hosted pickup was observed, but Go race lanes lack `gcc` and v2-ci hit hosted-image preinstall assumptions; reverted to hosted instead of blocking CI |
| pr-verifier.yml | none | `pull_request_target` must never use self-hosted |
| docker.yml | none | release-critical multi-arch Docker pipeline; PR #5828 is merged, but this PR avoids conflicting with it |
| backend-smoke/podman-rootless/podman-rootful/podman-arm64/tagged-release/notice-autofix/prune-ghcr*/docs-index-reminder | none | secrets, `gh`, Podman/arm64/runtime/release/workflow_run lanes kept hosted |

## Validation
- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- `git diff --check`
- `actionlint` was also run; it reported the custom `hive` runner label as unknown when arrays were present and pre-existing shellcheck findings in untouched workflows.

## Fork approval
- Current policy was `first_time_contributors`.
- Updated via API to `all_external_contributors`.

## Self-hosted observation
- Jobs were picked up by runners such as `hivecommons-hive-runners-5dvf4-2nx5x` / `hivecommons-hive-runners-5dvf4-2nszr` during validation.
