### PR TITLE
🐛 fix OIDC display stragglers on hub fleet

### DIFF
--- a/changelog.d/fixed-oidc-display-stragglers.md
+++ b/changelog.d/fixed-oidc-display-stragglers.md
@@ -1,0 +1,1 @@
+- Fix remaining hub OIDC identity display stragglers, including pending access-request rows and provision decision attribution.

--- a/src/pkg/hub/access_request_identity_display_test.go
+++ b/src/pkg/hub/access_request_identity_display_test.go
@@ -1,0 +1,69 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPendingAccessRequestsCarryDisplayLabels(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	const hiveID = "label-hive"
+	const owner = "owner"
+	const requester = "ibmid:6620042TJ8"
+
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: owner}); err != nil {
+		t.Fatalf("save hive: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: owner, Hives: map[string]string{hiveID: "owner"}}); err != nil {
+		t.Fatalf("save owner: %v", err)
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: requester, DisplayName: "Ada Lovelace", Provider: "ibmid"}); err != nil {
+		t.Fatalf("save requester: %v", err)
+	}
+	saveAccessRequests(hiveID, []AccessRequest{{Username: requester, RequestedAt: "2026-09-03T11:00:00Z", Status: "pending", Note: "need access"}})
+
+	s := newHandlerHub()
+	rec := httptest.NewRecorder()
+	s.handleGetRequests(rec, setPathValue(reqWithUser(http.MethodGet, "/api/saas/hives/"+hiveID+"/requests", "", owner), "id", hiveID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Requests []PendingAccessRequest `json:"requests"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(resp.Requests))
+	}
+	got := resp.Requests[0]
+	if got.Username != requester {
+		t.Fatalf("username = %q, want raw key %q", got.Username, requester)
+	}
+	if got.DisplayLabel != "Ada Lovelace" {
+		t.Fatalf("display_label = %q, want Ada Lovelace", got.DisplayLabel)
+	}
+	if got.Provider != "ibmid" {
+		t.Fatalf("provider = %q, want ibmid", got.Provider)
+	}
+}
+
+func TestPendingAccessRequestRowsPreferDisplayLabel(t *testing.T) {
+	checks := []string{
+		"var userLabel = String(pr.display_label || rawUser);",
+		"esc(userLabel || rawUser)",
+		"title=\"Auth key\"",
+		"var userLabel = String(r.display_label || rawUser);",
+	}
+	for _, snippet := range checks {
+		if !strings.Contains(dashboardHTML, snippet) {
+			t.Errorf("dashboardHTML missing pending access label snippet %q", snippet)
+		}
+	}
+}

--- a/src/pkg/hub/clickable_avatars_test.go
+++ b/src/pkg/hub/clickable_avatars_test.go
@@ -27,7 +27,7 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 		// <img> — is unchanged; userAvatar is the other shared helper.
 		{"inline per-hive faces", "? linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, accessAvatarTitle(a), extraStyle)"},
 		{"status-dot hover panel rows", "linkedAvatar(a.username, PANEL_ACCESS_AVATAR_PX,"},
-		{"per-hive pending request rows", "var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');"},
+		{"per-hive pending request rows", "userAvatar({display_name: userLabel, avatar_url: pr.avatar_url, github_username: rawUser}, LIST_AVATAR_PX,"},
 		{"past requests table", "provisionRequesterAvatar(pr, PANEL_ACCESS_AVATAR_PX, 'margin-right:6px')"},
 		{"pending provision cards", "var avatar = provisionRequesterAvatar(pr, TABLE_AVATAR_PX, 'margin-right:8px');"},
 		// The admin users table routes GitHub users through linkedAvatar and OIDC
@@ -35,7 +35,7 @@ func TestAvatarSitesUseSharedHelper(t *testing.T) {
 		// real display name — provider:sub is not a github.com login).
 		{"admin users table (github path)", "? linkedAvatar(u.github_username, TABLE_AVATAR_PX,"},
 		{"admin users table (oidc path)", ": userAvatar(u, TABLE_AVATAR_PX, 'margin-right:6px');"},
-		{"access modal pending requests", "var avatar = linkedAvatar(r.username, LIST_AVATAR_PX, r.username, 'margin-right:6px');"},
+		{"access modal pending requests", "userAvatar({display_name: userLabel, avatar_url: r.avatar_url, github_username: rawUser}, LIST_AVATAR_PX,"},
 		{"access modal access list", "? linkedAvatar(u.github_username, TABLE_AVATAR_PX,"},
 		{"nav bar viewer avatar", "avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,"},
 	}

--- a/src/pkg/hub/provision_context_test.go
+++ b/src/pkg/hub/provision_context_test.go
@@ -141,9 +141,12 @@ func TestEnrichProvisionRequests(t *testing.T) {
 	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "bob", Hives: map[string]string{}}); err != nil {
 		t.Fatalf("saveSaaSUser(bob): %v", err)
 	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "ibmid:ADMIN", DisplayName: "Admin Person", Hives: map[string]string{}}); err != nil {
+		t.Fatalf("saveSaaSUser(admin): %v", err)
+	}
 
 	reqs := []ProvisionRequest{
-		{Username: "alice", Status: provisionStatusApproved, AssignedHive: "hosted-oke-06"},
+		{Username: "alice", Status: provisionStatusApproved, AssignedHive: "hosted-oke-06", DecidedBy: "ibmid:ADMIN"},
 		{Username: "ibmid:650001ABCD", Status: provisionStatusPending, AssignedHive: "hosted-oke-10"},
 		{Username: "bob", Status: provisionStatusDenied, DenyReason: "no capacity"},
 		{Username: "ghost", Status: provisionStatusApproved, AssignedHive: "hosted-oke-99"},
@@ -155,6 +158,9 @@ func TestEnrichProvisionRequests(t *testing.T) {
 	}
 	if got[0].AssignedRole != "owner" {
 		t.Errorf("alice assigned_role = %q, want %q", got[0].AssignedRole, "owner")
+	}
+	if got[0].DecidedBy != "ibmid:ADMIN" || got[0].DecidedByName != "Admin Person" {
+		t.Errorf("decided-by display = raw %q name %q, want raw ibmid:ADMIN name Admin Person", got[0].DecidedBy, got[0].DecidedByName)
 	}
 	wantOther := []UserHiveRole{{HiveID: "hosted-oke-07", Role: "read"}}
 	if !reflect.DeepEqual(got[0].OtherHives, wantOther) {

--- a/src/pkg/hub/saas.go
+++ b/src/pkg/hub/saas.go
@@ -3581,6 +3581,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 					})
 				}
 			}
+			pending = s.decoratePendingAccessRequests(pending)
 			result[i].PendingRequestCount = len(pending)
 			result[i].PendingRequests = pending
 		}
@@ -7430,6 +7431,28 @@ func loadAccessRequests(hiveID string) []AccessRequest {
 	return reqs
 }
 
+func (s *HubServer) decoratePendingAccessRequests(reqs []PendingAccessRequest) []PendingAccessRequest {
+	for i := range reqs {
+		username := strings.TrimSpace(reqs[i].Username)
+		if username == "" {
+			continue
+		}
+		label, avatar := s.displayIdentity(username)
+		reqs[i].DisplayLabel = label
+		reqs[i].AvatarURL = avatar
+		if u := loadSaaSUser(username); u != nil {
+			reqs[i].Provider = grantableUserProvider(u)
+			continue
+		}
+		if provider, _ := splitIdentityKey(username); provider != "" {
+			reqs[i].Provider = normalizeIdentityProvider(provider)
+		} else {
+			reqs[i].Provider = legacyProvider
+		}
+	}
+	return reqs
+}
+
 func saveAccessRequests(hiveID string, reqs []AccessRequest) {
 	if strings.Contains(hiveID, "..") || strings.Contains(hiveID, "/") || strings.Contains(hiveID, "\\") {
 		slog.Warn("saveAccessRequests: invalid hiveID", "hiveID", hiveID)
@@ -7541,12 +7564,17 @@ func (s *HubServer) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reqs := loadAccessRequests(hiveID)
-	pending := make([]AccessRequest, 0)
+	pending := make([]PendingAccessRequest, 0)
 	for _, req := range reqs {
 		if req.Status == "pending" {
-			pending = append(pending, req)
+			pending = append(pending, PendingAccessRequest{
+				Username:    req.Username,
+				RequestedAt: req.RequestedAt,
+				Note:        req.Note,
+			})
 		}
 	}
+	pending = s.decoratePendingAccessRequests(pending)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"requests": pending})
@@ -7806,9 +7834,11 @@ type ProvisionRequest struct {
 	// for an approval — which hive the requester actually got. That made the
 	// history unauditable: an approved request and a denied one looked equally
 	// anonymous. Empty on records decided before these fields existed.
-	DecidedBy    string `json:"decided_by,omitempty"`
-	DecidedAt    string `json:"decided_at,omitempty"`
-	AssignedHive string `json:"assigned_hive,omitempty"`
+	DecidedBy string `json:"decided_by,omitempty"`
+	// DecidedByName is the display-only label for DecidedBy, resolved on read.
+	DecidedByName string `json:"decided_by_name,omitempty"`
+	DecidedAt     string `json:"decided_at,omitempty"`
+	AssignedHive  string `json:"assigned_hive,omitempty"`
 	// DenyReason is the optional free-text explanation shown back to the
 	// requester when a request is turned down.
 	DenyReason string `json:"deny_reason,omitempty"`
@@ -7963,6 +7993,7 @@ func enrichProvisionRequests(requests []ProvisionRequest) []ProvisionRequest {
 		return requests
 	}
 	users := listAllSaaSUsers()
+	label := (&HubServer{}).identityLabeler()
 	for i := range requests {
 		if requests[i].UserID == "" {
 			requests[i].UserID, requests[i].UserIDSource = provisionRequestUserIdentity(requests[i].Username, provisionRequestUserFromRoster(requests[i].Username, users), requests[i].FullName)
@@ -7970,6 +8001,9 @@ func enrichProvisionRequests(requests []ProvisionRequest) []ProvisionRequest {
 			if requests[i].UserID == requests[i].Username {
 				requests[i].UserIDSource = "native"
 			}
+		}
+		if l := label(requests[i].DecidedBy); l != requests[i].DecidedBy {
+			requests[i].DecidedByName = l
 		}
 		requests[i].AssignedRole = roleForUserOnHive(requests[i].Username, requests[i].AssignedHive, users)
 		requests[i].OtherHives = hivesForUser(requests[i].Username, requests[i].AssignedHive, users)
@@ -16789,14 +16823,22 @@ const dashboardHTML = `<!DOCTYPE html>
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (roleAtLeast(h.role, 'read-write')) && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
-            var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');
+            var rawUser = String(pr.username || '');
+            var userLabel = String(pr.display_label || rawUser);
+            var provider = pr.provider || identityProviderFromKey(rawUser);
+            var avatar = (provider === 'github' && rawUser.indexOf(':') === -1)
+              ? linkedAvatar(rawUser, LIST_AVATAR_PX, userLabel, 'margin-right:6px')
+              : userAvatar({display_name: userLabel, avatar_url: pr.avatar_url, github_username: rawUser}, LIST_AVATAR_PX, 'margin-right:6px');
+            var authKey = userLabel && rawUser && userLabel !== rawUser
+              ? '<span style="display:block;font-size:0.68rem;color:var(--muted);word-break:break-word" title="Auth key">' + esc(rawUser) + '</span>'
+              : '';
             var note = (pr.note || '').trim();
             var noteHtml = note
               ? '<div style="margin-top:4px;font-size:0.75rem;color:var(--text);white-space:pre-wrap;word-break:break-word;background:rgba(0,0,0,0.15);border-left:2px solid var(--accent);padding:4px 8px;border-radius:2px">' + esc(note) + '</div>'
               : '<div style="margin-top:4px;font-size:0.72rem;color:var(--muted);font-style:italic">(no note)</div>';
             return '<div style="padding:6px 0;border-bottom:1px solid var(--border)">' +
               '<div style="display:flex;align-items:center;justify-content:space-between">' +
-              '<div>' + avatar + '<span style="font-size:0.85rem">' + esc(pr.username) + '</span></div>' +
+              '<div>' + avatar + '<span style="font-size:0.85rem">' + esc(userLabel || rawUser) + '</span>' + authKey + '</div>' +
               '<div style="display:flex;gap:4px">' +
               '<button onclick="inlineApproveAccess(\'' + esc(h.id) + '\',\'' + esc(pr.username) + '\',this)" style="padding:2px 8px;background:var(--green);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.65rem">Approve</button>' +
               '<button onclick="inlineDenyAccess(\'' + esc(h.id) + '\',\'' + esc(pr.username) + '\',this)" style="padding:2px 8px;background:var(--red);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.65rem">Deny</button>' +
@@ -18142,7 +18184,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td style="white-space:nowrap">' + acmmBadge(pr.acmm_level) + '</td>' +
           '<td style="white-space:nowrap;color:var(--muted);font-size:0.7rem">' + esc((pr.requested_at || '').substring(0, 10)) + '</td>' +
           '<td style="white-space:nowrap"><span style="color:' + color + ';font-weight:600;font-size:0.72rem">' + esc(pr.status) + '</span></td>' +
-          '<td style="white-space:nowrap">' + esc(pr.decided_by || '—') + '</td>' +
+          '<td style="white-space:nowrap">' + esc(pr.decided_by_name || pr.decided_by || '—') + '</td>' +
           '<td style="white-space:nowrap;color:var(--muted);font-size:0.7rem">' + esc((pr.decided_at || '').substring(0, 10) || '—') + '</td>' +
           '<td>' + outcome + '</td>' +
           '<td>' + otherHivesCell(pr.other_hives) + '</td>' +
@@ -18220,6 +18262,11 @@ const dashboardHTML = `<!DOCTYPE html>
 
     var _provisionRequestsByUser = {};
 
+    function provisionRequesterDisplay(username) {
+      var pr = _provisionRequestsByUser[username] || {username: username};
+      return provisionRequesterPrimary(pr) || String(username || '');
+    }
+
     /* openAssignForUser is the entry point from a click on a user in the admin
        users table. It routes to whichever existing flow fits, rather than adding
        a third assign path:
@@ -18254,7 +18301,7 @@ const dashboardHTML = `<!DOCTYPE html>
       var reposText = pr.primary_repo || pr.repos || '';
       var summary =
         '<div style="padding:10px 12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;font-size:0.8rem;margin-bottom:4px">' +
-        '<div><span style="color:var(--muted)">User:</span> <strong>' + esc(username) + '</strong></div>' +
+        '<div><span style="color:var(--muted)">User:</span> <strong>' + esc(provisionRequesterDisplay(username)) + '</strong></div>' +
         '<div><span style="color:var(--muted)">Org:</span> ' + esc(pr.org || '') + '</div>' +
         '<div><span style="color:var(--muted)">Repos:</span> ' + esc(pr.repos || '') + '</div>' +
         '<div><span style="color:var(--muted)">Primary:</span> ' + esc(pr.primary_repo || '') + '</div>' +
@@ -18340,20 +18387,20 @@ const dashboardHTML = `<!DOCTYPE html>
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Assign failed', 'error'); if (submit) { submit.disabled = false; submit.textContent = 'Approve'; } return; }
         closeApproveModal();
-        hiveToast('Approved ' + username + ' → ' + (hiveId || 'auto') + ' (' + (data.hive_id || 'a hive') + ')', 'success');
+        hiveToast('Approved ' + provisionRequesterDisplay(username) + ' → ' + (hiveId || 'auto') + ' (' + (data.hive_id || 'a hive') + ')', 'success');
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); if (submit) { submit.disabled = false; submit.textContent = 'Approve'; } }
     }
 
     async function denyProvision(username, btn) {
-      if (!await hiveConfirm('Deny provision request from ' + username + '?')) return;
+      if (!await hiveConfirm('Deny provision request from ' + provisionRequesterDisplay(username) + '?')) return;
       btn.disabled = true;
       btn.textContent = 'Denying...';
       try {
         var resp = await fetch('/api/saas/deny-provision/' + encodeURIComponent(username), {method: 'DELETE'});
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Deny failed', 'error'); btn.disabled = false; btn.textContent = 'Deny'; return; }
-        hiveToast('Provision request denied for ' + username, 'success');
+        hiveToast('Provision request denied for ' + provisionRequesterDisplay(username), 'success');
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); btn.disabled = false; btn.textContent = 'Deny'; }
     }
@@ -21527,14 +21574,22 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!el) return;
         if (!reqs.length) { el.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">No pending requests</span>'; return; }
         el.innerHTML = reqs.map(function(r) {
-          var avatar = linkedAvatar(r.username, LIST_AVATAR_PX, r.username, 'margin-right:6px');
+          var rawUser = String(r.username || '');
+          var userLabel = String(r.display_label || rawUser);
+          var provider = r.provider || identityProviderFromKey(rawUser);
+          var avatar = (provider === 'github' && rawUser.indexOf(':') === -1)
+            ? linkedAvatar(rawUser, LIST_AVATAR_PX, userLabel, 'margin-right:6px')
+            : userAvatar({display_name: userLabel, avatar_url: r.avatar_url, github_username: rawUser}, LIST_AVATAR_PX, 'margin-right:6px');
+          var authKey = userLabel && rawUser && userLabel !== rawUser
+            ? '<span style="display:block;font-size:0.68rem;color:var(--muted);word-break:break-word" title="Auth key">' + esc(rawUser) + '</span>'
+            : '';
           var note = (r.note || '').trim();
           var noteHtml = note
             ? '<div style="margin-top:4px;font-size:0.75rem;color:var(--text);white-space:pre-wrap;word-break:break-word;background:var(--bg);border-left:2px solid var(--accent);padding:4px 8px;border-radius:2px">' + esc(note) + '</div>'
             : '<div style="margin-top:4px;font-size:0.72rem;color:var(--muted);font-style:italic">(no note)</div>';
           return '<div style="padding:6px 0;border-bottom:1px solid var(--border)">' +
             '<div style="display:flex;align-items:center;justify-content:space-between">' +
-            '<div>' + avatar + '<span style="font-size:0.85rem">' + esc(r.username) + '</span> <span style="font-size:0.7rem;color:var(--muted)">' + esc(r.requested_at.substring(0,10)) + '</span></div>' +
+            '<div>' + avatar + '<span style="font-size:0.85rem">' + esc(userLabel || rawUser) + '</span> <span style="font-size:0.7rem;color:var(--muted)">' + esc(r.requested_at.substring(0,10)) + '</span>' + authKey + '</div>' +
             '<div style="display:flex;gap:4px">' +
             '<select id="req-role-' + esc(r.username) + '" title="Role to grant on approval" style="padding:2px 6px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);font-size:0.7rem"><option value="read" title="' + escAttr(roleDescription('read')) + '">Read</option><option value="read-write" title="' + escAttr(roleDescription('read-write')) + '">Read-Write</option><option value="merger" title="' + escAttr(roleDescription('merger')) + '">Merger</option></select>' +
             '<button onclick="approveRequest(\'' + esc(r.username) + '\')" style="padding:2px 8px;background:var(--green);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.65rem">Approve</button>' +

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -491,6 +491,11 @@ func loadClusters(logger *slog.Logger) map[string]ClusterConfig {
 type PendingAccessRequest struct {
 	Username    string `json:"username"`
 	RequestedAt string `json:"requested_at"`
+	// DisplayLabel is the human-facing name resolved at serve time for opaque
+	// OIDC identities. Username remains the raw auth key used by approve/deny.
+	DisplayLabel string `json:"display_label,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	AvatarURL    string `json:"avatar_url,omitempty"`
 	// Note is the requester's justification for wanting access,
 	// surfaced to owners/approvers. May be empty for legacy records.
 	Note string `json:"note,omitempty"`


### PR DESCRIPTION
## Summary
- add serve-time display_label/provider/avatar fields for pending access requests
- render pending access-request rows in fleet and Manage Access with display labels while keeping raw usernames for approve/deny APIs
- add display-only labels for provision request decision attribution

## Validation
- cd src && go build ./... && go test ./pkg/hub/... ./pkg/dashboard/...
- targeted trigger tests: TestPendingAccessRequestsCarryDisplayLabels, TestPendingAccessRequestRowsPreferDisplayLabel

## Audit
- pending access request rows: fixed now
- Manage Access pending requests: fixed now
- provision request requester cards/history: already display-labeled; modal/toasts fixed now
- provision decision by: fixed now
- owner buckets/grouping/zero chips: already ownerName/display label
- timeline/access audit actors: already actorName
- fleet alerts ack-by: already ackByName
- access faces +N tooltip: already display_label
- spoke header/access/audit: already AuthorizedUserNames/display_name
- contributor queue/leaderboard: intentionally raw GitHub-only usernames
