### PR TITLE
🌱 migrate: port Hive Commons fleet identity to v5

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -239,6 +239,14 @@ jobs:
             GIT_BRANCH=${{ github.ref_name }}
           # Monotonic moving-tag guard metadata (#4804). This config label is
           # inherited by each platform manifest without changing its media type.
+          # ORG-MIGRATION KEEP DECISION (kubestellar -> hivecommons): the
+          # io.kubestellar.hive.* label PREFIX is deliberately NOT renamed. It is
+          # a data-format identifier baked into every already-published manifest
+          # and read back by consumers (the moving-tag guard and
+          # src/deploy/test_standalone_runtime_parity.sh), not an org pointer;
+          # renaming it would make old and new images disagree on the same
+          # field. The identical labels in build-contributor and build-hub
+          # below keep the prefix for the same reason.
           labels: |
             io.kubestellar.hive.github-actions-run-number=${{ github.run_number }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/changelog.d/changed-fleet-hivecommons-identity.md
+++ b/changelog.d/changed-fleet-hivecommons-identity.md
@@ -1,0 +1,1 @@
+- Fleet-facing image, GitHub API, and metrics defaults now use the Hive Commons identity so stable hubs and spokes pull `ghcr.io/hivecommons/hive` while the dual-publish window continues.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -520,7 +520,8 @@ RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null 
     echo "WARN: spec-kit (specify-cli) install failed — inception will generate facts without it"
 # pluk (TypeScript): structured event streaming for AI agent tmux sessions
 ARG PLUK_VERSION=0.8.0
-RUN npm install -g --ignore-scripts --no-fund --no-audit "@hivecommons/pluk@${PLUK_VERSION}" && npm cache clean --force
+RUN (npm install -g --ignore-scripts --no-fund --no-audit "@hivecommons/pluk@${PLUK_VERSION}" || \
+    npm install -g --ignore-scripts --no-fund --no-audit "@kubestellar/pluk@${PLUK_VERSION}") && npm cache clean --force
 RUN mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
     chown dev:node /var/run/pluk/logs /var/run/pluk/commands && \
     chmod 2770 /var/run/pluk/logs /var/run/pluk/commands

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -520,7 +520,7 @@ RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null 
     echo "WARN: spec-kit (specify-cli) install failed — inception will generate facts without it"
 # pluk (TypeScript): structured event streaming for AI agent tmux sessions
 ARG PLUK_VERSION=0.8.0
-RUN npm install -g --ignore-scripts --no-fund --no-audit "@kubestellar/pluk@${PLUK_VERSION}" && npm cache clean --force
+RUN npm install -g --ignore-scripts --no-fund --no-audit "@hivecommons/pluk@${PLUK_VERSION}" && npm cache clean --force
 RUN mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
     chown dev:node /var/run/pluk/logs /var/run/pluk/commands && \
     chmod 2770 /var/run/pluk/logs /var/run/pluk/commands

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -9358,7 +9358,7 @@ func runHub(logger *slog.Logger, configPath string) {
 	// endpoint reports 503 rather than serving fabricated data. The base
 	// branch is the hub's own running branch — the lineage its fleet runs.
 	if ghToken := os.Getenv("HIVE_GITHUB_TOKEN"); ghToken != "" {
-		reachGH := github.NewClient(ghToken, "kubestellar", []string{"hive"}, logger, "")
+		reachGH := github.NewClient(ghToken, "hivecommons", []string{"hive"}, logger, "")
 		hubSrv.SetReachPRSource(hub.NewGitHubPRSource(reachGH, gitBranch))
 	}
 	// Wire 2a's heartbeat-fed registry store into the /api/reach endpoint

--- a/src/pkg/dashboard/metrics_collector.go
+++ b/src/pkg/dashboard/metrics_collector.go
@@ -206,7 +206,11 @@ func (mc *MetricsCollector) collectOutreach(ctx context.Context) map[string]any 
 		result["contributors"] = contribs
 	}
 
-	if mc.org == "kubestellar" {
+	// Adopters/ACMM/outreach are flagship-project counters. The repo moved to
+	// the "hivecommons" org (org transfer), but hives configured before the
+	// transfer still report org "kubestellar" — accept BOTH so the migration
+	// does not silently zero these panels on older configs.
+	if mc.org == "kubestellar" || mc.org == "hivecommons" {
 		adopters := mc.countAdopters(ctx, mc.org, mc.repo)
 		result["adopters"] = adopters
 

--- a/src/pkg/dashboard/metrics_collector.go
+++ b/src/pkg/dashboard/metrics_collector.go
@@ -293,7 +293,11 @@ func (mc *MetricsCollector) countAdopters(ctx context.Context, owner, repo strin
 func (mc *MetricsCollector) countACMM(ctx context.Context, owner, repo string) int {
 	// ACMM leaderboard lives in the docs repo, not the primary repo
 	const acmmLeaderboardPath = "src/app/[locale]/acmm-leaderboard/page.tsx"
-	content, err := mc.ghClient.GetFileContent(ctx, owner, "docs", acmmLeaderboardPath)
+	docsOwner := owner
+	if docsOwner == "hivecommons" {
+		docsOwner = "kubestellar"
+	}
+	content, err := mc.ghClient.GetFileContent(ctx, docsOwner, "docs", acmmLeaderboardPath)
 	if err != nil {
 		mc.logger.Warn("failed to fetch ACMM leaderboard page", "error", err)
 		return 0

--- a/src/pkg/dashboard/metrics_collector_test.go
+++ b/src/pkg/dashboard/metrics_collector_test.go
@@ -170,6 +170,43 @@ func TestMetricsCollector_CountACMM_FetchError(t *testing.T) {
 	}
 }
 
+func TestMetricsCollector_CountACMM_HiveCommonsUsesKubestellarDocs(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	var gotOwner string
+	pageContent := `
+const BADGE_PARTICIPANTS = new Set([
+  "ProjectA",
+]);
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/repos/"), "/")
+		if len(parts) > 0 {
+			gotOwner = parts[0]
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"type":     "file",
+			"encoding": "base64",
+			"content":  encodeBase64ForTest(pageContent),
+		})
+	}))
+	defer srv.Close()
+
+	ghClient := ghpkg.NewClientForTest(srv.URL, "hivecommons", []string{"docs"}, logger)
+	mc := &MetricsCollector{
+		ghClient: ghClient,
+		org:      "hivecommons",
+		repo:     "hive",
+		logger:   logger,
+		metrics:  make(map[string]any),
+	}
+	if count := mc.countACMM(context.Background(), "hivecommons", "hive"); count != 1 {
+		t.Fatalf("countACMM = %d, want 1", count)
+	}
+	if gotOwner != "kubestellar" {
+		t.Fatalf("ACMM docs owner = %q, want kubestellar", gotOwner)
+	}
+}
+
 func TestMetricsCollector_CountAdopters_WithMock(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/src/pkg/dashboard/static/index.html
+++ b/src/pkg/dashboard/static/index.html
@@ -16781,7 +16781,12 @@ function burnAreaChart() {
       // path/ref from whichever URL it receives, so keep the raw form here and
       // let the server round-trip it back in _importBody.
       var keepLinked = !!(document.getElementById('import-keep-linked') || {}).checked;
+      // Org migration: rewrite blob->raw for BOTH the new (hivecommons) org and
+      // the legacy (kubestellar) one, so pre-transfer links pasted from old
+      // docs/bookmarks still import; raw.githubusercontent follows the repo
+      // transfer for the old spelling.
       url = url.replace('github.com/hivecommons/hive/blob/', 'raw.githubusercontent.com/hivecommons/hive/');
+      url = url.replace('github.com/kubestellar/hive/blob/', 'raw.githubusercontent.com/kubestellar/hive/');
       try {
         var resp = await fetch('/api/agents/import', {method:'POST', headers:_inceptionAuthHeaders(), body:JSON.stringify({source:'url',url:url,preview:true,keepLinked:keepLinked})});
         var d = await resp.json();

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -1468,6 +1468,10 @@ func (c *Client) PathExistsAtRef(ctx context.Context, owner, repo, path, ref str
 
 // SearchPRCount searches GitHub for PRs by author within an org.
 // state is "open" or "merged".
+// NOTE (org transfer): the org qualifier uses the CONFIGURED org verbatim.
+// Unlike the REST repo endpoints, GitHub SEARCH does not follow repository
+// transfers or redirects — after a repo moves orgs, a stale configured org
+// here quietly searches the old (now empty) org and returns 0.
 func (c *Client) SearchPRCount(ctx context.Context, author, org, state string) (int, error) {
 	qualifier := fmt.Sprintf("type:pr author:%s org:%s", author, org)
 	if state == "merged" {
@@ -1495,6 +1499,9 @@ func (c *Client) SearchOutreachPRCount(ctx context.Context, author, org, project
 	}
 	// Match the old hive query: author:X type:pr is:STATE "ProjectName" in:title -org:ORG
 	// The -org: prefix excludes PRs within the org, showing only external outreach PRs.
+	// NOTE (org transfer): like SearchPRCount, the -org: qualifier takes the
+	// CONFIGURED org verbatim — GitHub search does not follow repo transfers,
+	// so a stale org keeps counting PRs against the old org name.
 	// Without the projectName filter, this returns ALL external PRs by the author, inflating the count.
 	qualifier := fmt.Sprintf("type:pr author:%s -org:%s \"%s\" in:title", author, org, projectName)
 	if state == "merged" {


### PR DESCRIPTION
## Summary
- port the Hive Commons fleet identity changes to v5
- keep dual-publish support and tolerate the pluk npm mirror lag
- keep ACMM sourced from kubestellar/docs during the org migration

## Validation
- cd src && go build ./... && go vet ./... (passed)
- cd src && go test ./pkg/dashboard -run 'TestMetricsCollector_CountACMM' (passed)
- cd src && go test ./pkg/dashboard ./pkg/github ./pkg/hub ./cmd/hive (baseline v5 ratchet failure: TestDashboardInternalImportCountRatchet imports 32, want <=31; this branch adds no dashboard internal imports)