### PR TITLE
🌱 ci: route trusted CI lanes to self-hosted runners

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -61,7 +61,7 @@ permissions:
 jobs:
   link-check:
     name: relative links and anchors resolve
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/go-security-analysis.yml
+++ b/.github/workflows/go-security-analysis.yml
@@ -73,7 +73,7 @@ concurrency:
 jobs:
   govulncheck:
     name: govulncheck (known vulnerabilities)
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -149,7 +149,7 @@ jobs:
 
   action-pins:
     name: action pins resolve
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -164,7 +164,7 @@ jobs:
 
   notice-drift:
     name: NOTICE matches the module graph
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     # WHY THIS JOB EXISTS: a CNCF General Technical Review asks how the
     # project ensures third-party attribution stays correct and complete. A
     # generated NOTICE that can silently go stale is worse than no NOTICE at

--- a/.github/workflows/image-attestation-guard.yml
+++ b/.github/workflows/image-attestation-guard.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   no-image-attestations:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/podman-contract.yml
+++ b/.github/workflows/podman-contract.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   contract-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/release-line-guard.yml
+++ b/.github/workflows/release-line-guard.yml
@@ -48,7 +48,7 @@ permissions:
 
 jobs:
   release-lines-in-sync:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/suid-contract.yml
+++ b/.github/workflows/suid-contract.yml
@@ -61,7 +61,7 @@ permissions:
 
 jobs:
   contract-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/changelog.d/changed-ci-self-hosted-runners.md
+++ b/changelog.d/changed-ci-self-hosted-runners.md
@@ -1,0 +1,1 @@
+- Trusted CI lanes now target the repository self-hosted runner pool while fork pull requests and privileged release/runtime lanes remain on GitHub-hosted runners.


### PR DESCRIPTION
## Summary
- Ports the trusted self-hosted runner routing to v5.
- Keeps fork PRs, `pull_request_target`, arm64, release-critical Docker publishing, GitHub-CLI-dependent reminders/pruners, race-test Go lanes, formal apt-install verification, and privileged Podman/runtime lanes on GitHub-hosted runners.
- Adds a changelog fragment for the CI routing change.

## Runner routing
| Workflow | Jobs switched | Left hosted / reason |
| --- | --- | --- |
| go-security-analysis.yml | govulncheck, action-pins, notice-drift | gosec/golangci-lint stayed hosted after gosec was too slow on 2 CPU and v5 golangci failed on self-hosted |
| dashboard-lint.yml | none | v5 workflow relies on preinstalled `node`; self-hosted validation failed with `node: No such file or directory` |
| docs-link-check.yml | link-check | none |
| image-attestation-guard.yml | no-image-attestations | none |
| release-line-guard.yml | release-lines-in-sync | none |
| podman-contract.yml | contract-check | live Podman lanes stay hosted |
| suid-contract.yml | contract-check | runtime jobs need container privileges and stay hosted |
| v2-ci.yml / v2-tests.yml / coverage-hourly.yml | none | v4 self-hosted validation showed Go race lanes lack `gcc` and v2-ci hits hosted-image preinstall assumptions; kept hosted instead of blocking CI |
| pr-verifier.yml | none | `pull_request_target` must never use self-hosted |
| docker.yml | none | release-critical multi-arch Docker pipeline; PR #5828 is merged, but this PR avoids conflicting with it |
| formal-verify/changelog-reminder/docs-index-reminder/backend-smoke/podman-rootless/podman-rootful/podman-arm64/tagged-release/notice-autofix/prune-ghcr* | none | `sudo apt`, secrets, `gh`, Podman/arm64/runtime/release/workflow_run lanes kept hosted |

## Validation
- Rebasing on current `origin/v5` before opening.
- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- `git diff --check`

## Fork approval
- Current policy was `first_time_contributors`.
- Updated via API to `all_external_contributors`.

## Self-hosted observation
- v4 PR validation observed self-hosted pickup on runners such as `hivecommons-hive-runners-5dvf4-2nx5x` / `hivecommons-hive-runners-5dvf4-2nszr`; incompatible Go race lanes were reverted to hosted before this v5 port.
