### PR TITLE
🐛 bug fix: clarify GitHub App repo-state label

### DIFF
--- a/changelog.d/fixed-5774-ghapp-repo-state-label.md
+++ b/changelog.d/fixed-5774-ghapp-repo-state-label.md
@@ -1,0 +1,1 @@
+- Clarified fleet GitHub App hover labels for repo-scope and repo-transfer failures so they no longer appear as generic permission shortages.

--- a/src/pkg/hub/saas_dashboard_layout_html.go
+++ b/src/pkg/hub/saas_dashboard_layout_html.go
@@ -1455,6 +1455,8 @@ const dashboardHTMLLayout = `<!DOCTYPE html>
        install or reconfigure. */
     var GH_APP_STATE_KEY_MISSING = 'key-missing';
     var GH_APP_STATE_KEY_INVALID = 'key-invalid';
+    var GH_APP_STATE_REPO_NOT_COVERED = 'repo-not-covered';
+    var GH_APP_STATE_REPO_MOVED = 'repo-moved';
     var GH_APP_OPERATOR_STATES = {};
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_MISSING] = true;
     GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_INVALID] = true;
@@ -1472,6 +1474,8 @@ const dashboardHTMLLayout = `<!DOCTYPE html>
       var s = String(state || '').trim();
       if (s === 'wrong-installation') return 'wrong installation (installation_id points at another account)';
       if (s === 'write-forbidden') return 'write forbidden (repo not in the App installation)';
+      if (s === GH_APP_STATE_REPO_NOT_COVERED) return 'repo not covered (repo not ticked in the App installation)';
+      if (s === GH_APP_STATE_REPO_MOVED) return 'repo moved (hive config still points at the old account)';
       if (s === 'no-app-assigned') return 'no App assigned yet';
       return 'permissions insufficient';
     }


### PR DESCRIPTION
## Summary
- label repo-not-covered and repo-moved fleet GitHub App states explicitly
- keep generic permissions-insufficient copy only for true/legacy permission states

## Testing
- cd src && go test ./pkg/hub -run 'TestHealthVerdict|TestGitHubApp'