### PR TITLE
🌱 ci: route heavy trusted lanes to self-hosted runners

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -45,6 +45,13 @@ permissions:
   contents: read
   issues: write
 
+env:
+  # The race-enabled shards require cgo even on lean self-hosted runner images.
+  CGO_ENABLED: '1'
+  # Self-hosted runners sit inside OpenShift; keep these hermetic unit tests from auto-discovering that cluster.
+  KUBERNETES_SERVICE_HOST: ''
+  KUBERNETES_SERVICE_PORT: ''
+
 
 # Cancel superseded PR runs only (#4623). A new push to a PR makes the
 # in-flight run's verdict irrelevant, so cancelling it is pure runner-minute
@@ -128,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         idx: [1, 2, 3]
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src
@@ -139,6 +146,31 @@ jobs:
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
 
       - name: Test slice of pkg/hub
         env:
@@ -204,7 +236,7 @@ jobs:
       fail-fast: false
       matrix:
         idx: [1, 2, 3, 4, 5]
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src
@@ -216,6 +248,27 @@ jobs:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
 
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
+
       # tmux is what makes HIVE_TEST_REQUIRE_BEHAVIOURAL legitimate below.
       # ubuntu-latest happens to ship it, but "happens to" is not a guarantee —
       # a runner image change would silently turn ~50 pkg/agent tests back into
@@ -226,8 +279,18 @@ jobs:
         run: |
           set -euo pipefail
           if ! command -v tmux >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq tmux
+            if command -v sudo >/dev/null 2>&1; then
+              sudo apt-get update -qq
+              sudo apt-get install -y -qq tmux
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update -qq
+              apt-get install -y -qq tmux
+            elif command -v apk >/dev/null 2>&1; then
+              apk add --no-cache tmux
+            else
+              echo "::error::tmux is required but no supported package manager is available" >&2
+              exit 1
+            fi
           fi
           tmux -V
 
@@ -284,7 +347,7 @@ jobs:
   # 3s — they are all ≤ 8s). The hints only affect BALANCE, never MEMBERSHIP:
   # a stale weight makes a bucket slower, not a package untested.
   list-packages:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.partition.outputs.matrix }}
     defaults:
@@ -297,6 +360,27 @@ jobs:
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
+
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
 
       - name: Partition packages into balanced buckets
         id: partition
@@ -363,7 +447,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.list-packages.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src
@@ -374,6 +458,27 @@ jobs:
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
+
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
 
       # ./cmd/... is included in the partition deliberately. It used to be
       # ./pkg/... only, so no workflow anywhere ran the cmd tests — four cmd/bd
@@ -438,7 +543,7 @@ jobs:
   # rest-bucket profile; this lane exists only to vary the execution order.
   test-dashboard-shuffle:
     name: test (dashboard shuffle)
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src
@@ -449,6 +554,27 @@ jobs:
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
+
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
 
       - name: Test pkg/dashboard in shuffled order
         run: |
@@ -486,7 +612,7 @@ jobs:
   # must succeed — a failed/skipped partition means packages may not have run.
   test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     needs: [list-packages, test-hub, test-agent, test-rest, test-dashboard-shuffle]
     steps:
       - name: Check shard results
@@ -516,7 +642,7 @@ jobs:
   # `? ... [no test files]` — both hard failures, as before.
   coverage:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     needs: [test-hub, test-agent, test-rest]
     steps:
       - name: Download shard coverage artifacts

--- a/changelog.d/changed-ci-self-hosted-heavy-lanes.md
+++ b/changelog.d/changed-ci-self-hosted-heavy-lanes.md
@@ -1,0 +1,1 @@
+- Trusted Go test shards now join the self-hosted runner pool for same-repository CI while fork pull requests remain on hosted runners.

--- a/src/pkg/hub/main_test.go
+++ b/src/pkg/hub/main_test.go
@@ -45,6 +45,8 @@ func TestMain(m *testing.M) {
 	// KUBECONFIG could equally point a real kubectl at a real cluster for the
 	// non-InCluster branch, so neutralize it to a path that cannot exist.
 	os.Setenv("KUBECONFIG", os.DevNull)
+	k8sTokenPath = "testdata/no-such-serviceaccount-token"
+	k8sCACertPath = "testdata/no-such-serviceaccount-ca.crt"
 
 	// Provider and forge credentials. The suite is run inside hive pods and on
 	// developer machines whose environment carries REAL keys, and handlers


### PR DESCRIPTION
## Summary
- Routes the v4 Go test shard matrix/list/aggregate/coverage jobs to self-hosted runners for same-repo PRs, with hosted fallback for forks.
- Adds explicit cgo toolchain preparation before race-enabled shards so lean self-hosted images can satisfy `go test -race`.
- Keeps the hub tests hermetic inside OpenShift by blanking Kubernetes in-cluster env vars, masking service-account file paths in `TestMain`, and adding setup-node for Node-backed hub tests.

## Routing table
| Workflow | Jobs switched | Left hosted / reason |
| --- | --- | --- |
| v2-tests.yml | test-hub, test-agent, list-packages, test-rest, test-dashboard-shuffle, test, coverage | create-issue-on-failure remains hosted because it is schedule-only issue filing and not on the PR critical path |
| suid-contract.yml | none in this follow-up | ambient-cap-runtime failed the NET_ADMIN positive control on self-hosted dind; manifest-cap-runtime and image-suid-inventory stay hosted with it |
| pull_request_target workflows | none | still hosted by rule |

## Validation
- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- `git diff --check`

## Self-hosted findings
- Job-container approach was rejected because Docker Hub returned 429 on `golang:1.25-bookworm` pulls.
- First bare-runner attempt showed real env blockers: missing Node in hub tests and live in-cluster Kubernetes service-account discovery; this revision fixes both.
- SUID runtime self-hosted attempt used runner `hivecommons-hive-runners-lbz5b-*` and failed the ambient NET_ADMIN positive control, so those jobs are left hosted.
