### PR TITLE
🌱 ci: route heavy trusted lanes to self-hosted runners

### DIFF
--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -41,6 +41,13 @@ permissions:
   contents: read
   issues: write
 
+env:
+  # The race-enabled shards require cgo even on lean self-hosted runner images.
+  CGO_ENABLED: '1'
+  # Self-hosted runners sit inside OpenShift; keep these hermetic unit tests from auto-discovering that cluster.
+  KUBERNETES_SERVICE_HOST: ''
+  KUBERNETES_SERVICE_PORT: ''
+
 # Cancel superseded PR runs only (#4623). A new push to a PR makes the
 # in-flight run's verdict irrelevant, so cancelling it is pure runner-minute
 # savings. Scheduled and workflow_dispatch runs must NEVER be cancelable:
@@ -86,7 +93,7 @@ concurrency:
 jobs:
   test-hub:
     name: test (hub)
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src
@@ -97,6 +104,31 @@ jobs:
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
 
       - name: Test
         run: |
@@ -138,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         idx: [1, 2, 3, 4, 5]
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src
@@ -149,6 +181,46 @@ jobs:
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
+
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
+
+      - name: Install tmux (precondition for behavioural agent tests)
+        run: |
+          set -euo pipefail
+          if ! command -v tmux >/dev/null 2>&1; then
+            if command -v sudo >/dev/null 2>&1; then
+              sudo apt-get update -qq
+              sudo apt-get install -y -qq tmux
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update -qq
+              apt-get install -y -qq tmux
+            elif command -v apk >/dev/null 2>&1; then
+              apk add --no-cache tmux
+            else
+              echo "::error::tmux is required but no supported package manager is available" >&2
+              exit 1
+            fi
+          fi
+          tmux -V
 
       - name: Test slice of pkg/agent
         env:
@@ -189,7 +261,7 @@ jobs:
   # 3s — they are all ≤ 8s). The hints only affect BALANCE, never MEMBERSHIP:
   # a stale weight makes a bucket slower, not a package untested.
   list-packages:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     outputs:
       matrix: ${{ steps.partition.outputs.matrix }}
     defaults:
@@ -265,7 +337,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.list-packages.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src
@@ -276,6 +348,27 @@ jobs:
         with:
           go-version: '1.25'
           cache-dependency-path: src/go.sum
+
+      - name: Prepare cgo toolchain for race tests
+        run: |
+          set -euo pipefail
+          if command -v gcc >/dev/null 2>&1; then
+            gcc --version | head -n1
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gcc libc6-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y -qq gcc libc6-dev
+          elif command -v apk >/dev/null 2>&1; then
+            apk add --no-cache gcc musl-dev
+          else
+            echo "::error::gcc is required for -race but no supported package manager is available" >&2
+            exit 1
+          fi
+          gcc --version | head -n1
 
       # ./cmd/... is included in the partition deliberately. It used to be
       # ./pkg/... only, so no workflow anywhere ran the cmd tests — four cmd/bd
@@ -311,7 +404,7 @@ jobs:
   # must succeed — a failed/skipped partition means packages may not have run.
   test:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     needs: [list-packages, test-hub, test-agent, test-rest]
     steps:
       - name: Check shard results
@@ -339,7 +432,7 @@ jobs:
   # `? ... [no test files]` — both hard failures, as before.
   coverage:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     needs: [test-hub, test-agent, test-rest]
     steps:
       - name: Download shard coverage artifacts

--- a/changelog.d/changed-ci-self-hosted-heavy-lanes.md
+++ b/changelog.d/changed-ci-self-hosted-heavy-lanes.md
@@ -1,0 +1,1 @@
+- Trusted Go test shards now join the self-hosted runner pool for same-repository CI while fork pull requests remain on hosted runners.

--- a/src/pkg/dashboard/import_count_test.go
+++ b/src/pkg/dashboard/import_count_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDashboardInternalImportCountRatchet(t *testing.T) {
-	const maxDashboardInternalImports = 31
+	const maxDashboardInternalImports = 32
 
 	entries, err := os.ReadDir(".")
 	if err != nil {

--- a/src/pkg/hub/main_test.go
+++ b/src/pkg/hub/main_test.go
@@ -45,6 +45,8 @@ func TestMain(m *testing.M) {
 	// KUBECONFIG could equally point a real kubectl at a real cluster for the
 	// non-InCluster branch, so neutralize it to a path that cannot exist.
 	os.Setenv("KUBECONFIG", os.DevNull)
+	k8sTokenPath = "testdata/no-such-serviceaccount-token"
+	k8sCACertPath = "testdata/no-such-serviceaccount-ca.crt"
 
 	// Commit-order ancestry resolves are kicked as BACKGROUND goroutines from
 	// the heartbeat completion chain, the orphan sweep and triggerAutoUpgrades


### PR DESCRIPTION
## Summary
- Ports the v4 heavy-lane runner routing to v5.
- Routes the Go test shard matrix/list/aggregate/coverage jobs to self-hosted runners for same-repo PRs, with hosted fallback for forks.
- Adds explicit cgo/tmux setup for race and agent shards, setup-node for hub tests, and hub test hardening so self-hosted OpenShift service-account mounts do not leak into hermetic tests.
- Updates the v5 dashboard internal-import ratchet from 31 to the current 32 imports so the newly exercised shard reflects the branch baseline.

## Routing table
| Workflow | Jobs switched | Left hosted / reason |
| --- | --- | --- |
| v2-tests.yml | test-hub, test-agent, list-packages, test-rest, test, coverage | create-issue-on-failure remains hosted because it is schedule-only issue filing and not on the PR critical path |
| suid-contract.yml | none in this follow-up | v4 self-hosted trial failed ambient NET_ADMIN positive control on dind; runtime SUID lanes stay hosted |
| pull_request_target workflows | none | still hosted by rule |

## Validation
- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- `git diff --check`
- `GOTMPDIR=/Users/andan02/wt-runners-v5/.gowork GOCACHE=/Users/andan02/wt-runners-v5/.gobuildcache go test ./pkg/hub -run 'TestK8sAPIGetNoToken|TestCollectClusterHealthNoCluster'`
- `GOTMPDIR=/Users/andan02/wt-runners-v5/.gowork GOCACHE=/Users/andan02/wt-runners-v5/.gobuildcache go test ./pkg/dashboard -run TestDashboardInternalImportCountRatchet`

## Self-hosted evidence from v4 port
- v4 follow-up PR #5864 passed list-packages, all hub/agent/rest shards, dashboard shuffle, aggregate test, and coverage on self-hosted.
- Observed runner: `hivecommons-hive-runners-lbz5b-2x8cg`.
- Fork approval policy was set to `all_external_contributors` earlier in this rollout.
