### PR TITLE
🌱 ci: path-filter podman/quadlet lanes to deploy-affecting changes (v5)

### DIFF
--- a/.github/workflows/podman-arm64-lane.yml
+++ b/.github/workflows/podman-arm64-lane.yml
@@ -85,11 +85,19 @@ name: Podman arm64 Lane
 
 on:
   push:
+    paths:
+      - '.github/workflows/podman-arm64-lane.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4
       - v5
   pull_request:
+    paths:
+      - '.github/workflows/podman-arm64-lane.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4

--- a/.github/workflows/podman-rootful-lane.yml
+++ b/.github/workflows/podman-rootful-lane.yml
@@ -63,11 +63,19 @@ name: Podman Rootful Lane
 
 on:
   push:
+    paths:
+      - '.github/workflows/podman-rootful-lane.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4
       - v5
   pull_request:
+    paths:
+      - '.github/workflows/podman-rootful-lane.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4

--- a/.github/workflows/podman-rootless-lane.yml
+++ b/.github/workflows/podman-rootless-lane.yml
@@ -44,11 +44,19 @@ name: Podman Rootless Lane
 
 on:
   push:
+    paths:
+      - '.github/workflows/podman-rootless-lane.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4
       - v5
   pull_request:
+    paths:
+      - '.github/workflows/podman-rootless-lane.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4

--- a/.github/workflows/quadlet-gate.yml
+++ b/.github/workflows/quadlet-gate.yml
@@ -55,11 +55,19 @@ name: Quadlet Generator Gate
 
 on:
   push:
+    paths:
+      - '.github/workflows/quadlet-gate.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4
       - v5
   pull_request:
+    paths:
+      - '.github/workflows/quadlet-gate.yml'
+      - 'src/deploy/**'
+      - 'justfile'
     branches:
       - v2
       - v4

--- a/changelog.d/5901.changed.md
+++ b/changelog.d/5901.changed.md
@@ -1,0 +1,1 @@
+Podman lane and Quadlet gate workflows now run only when their workflow file, `src/deploy/**`, or the justfile changes, instead of on every PR.


### PR DESCRIPTION
v5 counterpart of #5866: trigger-level `paths:` filters on the 4 podman/quadlet lanes (workflow file, `src/deploy/**`, justfile). None are required checks. Saves ~4 hosted runs per PR.