### PR TITLE
🌱 ci: route phase 2 lanes to self-hosted runners

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: [self-hosted, hive]
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","hive"]') || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: src

--- a/changelog.d/changed-ci-self-hosted-phase2-lanes.md
+++ b/changelog.d/changed-ci-self-hosted-phase2-lanes.md
@@ -1,0 +1,1 @@
+- Trusted v4 build-and-test jobs now use the self-hosted runner pool for same-repository events while fork pull requests remain on hosted runners; Docker, overlayfs, Podman, and Quadlet lanes remain hosted after self-hosted environment probes exposed runner blockers.


### PR DESCRIPTION
## Summary
- Routes v4 `v2-ci.yml` `build-and-test` to repo self-hosted runners for same-repo PRs and trusted non-PR events.
- Keeps fork PRs on `ubuntu-latest` via the per-job same-repo guard.
- Attempted phase-2 Docker, overlayfs, Podman, and Quadlet lanes on self-hosted; reverted them to hosted after concrete runner environment blockers.

## Routing table
| Workflow | Jobs switched | Left hosted / reason |
| --- | --- | --- |
| v2-ci.yml | build-and-test | docker and overlayfs-exec-guard stay hosted: self-hosted Docker daemon failed overlay snapshot mounts in dind (`failed to mount ... fstype: overlay ... invalid argument`) |
| podman-rootless-lane.yml | none after trial | hosted: self-hosted runner lacks podman (`podman is not installed`) |
| podman-rootful-lane.yml | none after trial | hosted: self-hosted runner lacks podman/passwordless rootful Podman facility |
| quadlet-gate.yml | none after trial | hosted: self-hosted podman/generator image pull failed, so gate could not run reliably |
| backend-smoke.yml | already self-hosted on current v4 | no change needed |
| podman-arm64-lane.yml | none | requires ubuntu-24.04-arm; self-hosted fleet is X64 |
| scorecard.yml / pull_request_target | none | hosted for OIDC/trust and public-repo safety |

## Validation
- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- `git diff --check`
