### PR TITLE
🌱 feat(hub): make canonical public host configurable (host-swap phase 0)

### DIFF
--- a/changelog.d/added-5830-host-swap-config.md
+++ b/changelog.d/added-5830-host-swap-config.md
@@ -1,0 +1,1 @@
+- Made the hub public URL, provisioned spoke domain, and optional legacy SSO cookie domain configurable while preserving the existing hive.kubestellar.io defaults.

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -20,6 +20,9 @@ This reference is compiled by hand from the Go source under `src/`, the deployme
 | `HIVE_ID` | No | config or generated id | Stable hive/spoke identifier override; passed through to launched agents. |
 | `HIVE_CLUSTER_ID` | No | config or hub-provisioned value | Hosted cluster identifier override. |
 | `HIVE_HUB_URL` | No | `hub.url` from config | Hub URL override for spoke heartbeats/registration. |
+| `HIVE_HUB_PUBLIC_URL` | No | `https://hive.kubestellar.io` | Hub canonical public origin used to derive OAuth/OIDC callback URLs, hub Open Graph/notification links, same-origin checks, and the registrable-domain scope for hub SSO cookies. Set this to the externally reachable hub URL when moving the public host; leave unset to preserve the current canonical host. |
+| `HIVE_HUB_SPOKE_DOMAIN` | No | `hive.kubestellar.io` | Parent domain used for hub-provisioned spoke ingress hostnames (for example `<hive-id>.<domain>`). Kept separate from `HIVE_HUB_PUBLIC_URL` because the wildcard spoke domain may differ from the hub's own hostname. |
+| `HIVE_HUB_LEGACY_COOKIE_DOMAIN` | No | none | Optional transition-only hub SSO cookie domain to expire alongside the active cookie domain while accepting any carried `hive_hub_user` cookie value during a host migration. Writes still target the domain derived from `HIVE_HUB_PUBLIC_URL`; unset disables the extra legacy-domain cleanup. |
 | `HIVE_HUB_SECRET` | Required for spokes registered to a protected hub; optional for a standalone hub with `/data/saas/hub-secret.key` | `/data/saas/hub-secret.key` on the hub when present; no fallback for spoke heartbeat auth | Bearer secret for spoke heartbeats and hub/spoke SaaS APIs. |
 | `HIVE_COVERAGE_BADGE_URL` | No | none | Optional coverage badge URL exposed in dashboard status. |
 | `HIVE_WORK_DIR` | No | `/data/agents` | Agent manager working directory. |

--- a/src/pkg/hub/access_notify.go
+++ b/src/pkg/hub/access_notify.go
@@ -31,7 +31,7 @@ func hubDashboardBaseURL() string {
 			return strings.TrimRight(v, "/")
 		}
 	}
-	return hubPublicURL
+	return hubPublicURL()
 }
 
 // accessRequestReviewLink builds the one-click deep link that opens the

--- a/src/pkg/hub/access_notify_test.go
+++ b/src/pkg/hub/access_notify_test.go
@@ -166,7 +166,7 @@ func TestHubDashboardBaseURLFallsBackToPublicURL(t *testing.T) {
 	for _, key := range []string{"HIVE_HUB_PUBLIC_URL", "HIVE_PUBLIC_URL", "HIVE_HUB_BASE_URL", "HIVE_DASHBOARD_URL", "HIVE_HUB_URL"} {
 		t.Setenv(key, "")
 	}
-	if got := hubDashboardBaseURL(); got != hubPublicURL {
-		t.Errorf("base URL = %q, want fallback %q", got, hubPublicURL)
+	if got := hubDashboardBaseURL(); got != hubPublicURL() {
+		t.Errorf("base URL = %q, want fallback %q", got, hubPublicURL())
 	}
 }

--- a/src/pkg/hub/clusters_registry.go
+++ b/src/pkg/hub/clusters_registry.go
@@ -206,7 +206,7 @@ func defaultClusterRegistry() map[string]ClusterConfig {
 			IngressType:  "nginx",
 			IngressClass: "nginx",
 			CertIssuer:   "letsencrypt-prod",
-			Domain:       "hive.kubestellar.io",
+			Domain:       hubSpokeDomain(),
 			Arch:         "arm64",
 			// v4 is the ONLY image a hosted spoke can run: audit F2 deleted the
 			// fleet-wide heartbeat lane, and a v2 spoke has no SpokeHeartbeatKey

--- a/src/pkg/hub/host_config_test.go
+++ b/src/pkg/hub/host_config_test.go
@@ -1,0 +1,95 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHubPublicHostDefaultsPreserveCanonicalValues(t *testing.T) {
+	t.Setenv("HIVE_HUB_PUBLIC_URL", "")
+	t.Setenv("HIVE_HUB_SPOKE_DOMAIN", "")
+	t.Setenv("HIVE_HUB_LEGACY_COOKIE_DOMAIN", "")
+
+	if got := hubPublicURL(); got != "https://hive.kubestellar.io" {
+		t.Fatalf("hubPublicURL() = %q, want historical default", got)
+	}
+	if got := oauthRedirectURI(); got != "https://hive.kubestellar.io/api/auth/callback" {
+		t.Fatalf("oauthRedirectURI() = %q, want historical default", got)
+	}
+	if got := hubCanonicalHost(); got != "hive.kubestellar.io" {
+		t.Fatalf("hubCanonicalHost() = %q, want historical default", got)
+	}
+	if got := sessionCookieDomain("hive.kubestellar.io"); got != ".kubestellar.io" {
+		t.Fatalf("sessionCookieDomain(default hub) = %q, want .kubestellar.io", got)
+	}
+	if got := defaultClusterRegistry()[defaultClusterID].Domain; got != "hive.kubestellar.io" {
+		t.Fatalf("default cluster domain = %q, want historical default", got)
+	}
+}
+
+func TestHubPublicURLConfiguresCallbackCookieDomainAndOrigin(t *testing.T) {
+	t.Setenv("HIVE_HUB_PUBLIC_URL", "https://hive.hivecommons.dev/")
+	t.Setenv("HIVE_HUB_SPOKE_DOMAIN", "")
+
+	if got := hubPublicURL(); got != "https://hive.hivecommons.dev" {
+		t.Fatalf("hubPublicURL() = %q, want trimmed configured URL", got)
+	}
+	if got := oauthRedirectURI(); got != "https://hive.hivecommons.dev/api/auth/callback" {
+		t.Fatalf("oauthRedirectURI() = %q, want configured callback", got)
+	}
+	if got := sessionCookieDomain("hive.hivecommons.dev"); got != ".hivecommons.dev" {
+		t.Fatalf("sessionCookieDomain(configured hub) = %q, want .hivecommons.dev", got)
+	}
+	if !isSameOriginAsHub("https://hive.hivecommons.dev/dashboard") {
+		t.Fatal("configured hub origin was not trusted")
+	}
+	if isSameOriginAsHub("https://hive.kubestellar.io/dashboard") {
+		t.Fatal("old hub origin stayed trusted after HIVE_HUB_PUBLIC_URL override")
+	}
+}
+
+func TestHubSpokeDomainConfiguresDefaultClusterRegistry(t *testing.T) {
+	t.Setenv("HIVE_HUB_SPOKE_DOMAIN", "spokes.hivecommons.dev")
+
+	if got := defaultClusterRegistry()[defaultClusterID].Domain; got != "spokes.hivecommons.dev" {
+		t.Fatalf("default cluster domain = %q, want configured spoke domain", got)
+	}
+}
+
+func TestLegacyCookieDomainReadRemintsNewDomainAndClearsLegacy(t *testing.T) {
+	t.Setenv("HIVE_HUB_PUBLIC_URL", "https://hive.hivecommons.dev")
+	t.Setenv("HIVE_HUB_LEGACY_COOKIE_DOMAIN", "kubestellar.io")
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "octocat")
+
+	req := httptest.NewRequest(http.MethodGet, "https://hive.hivecommons.dev/api/auth/user", nil)
+	presented := testAuthCookie("octocat")
+	req.AddCookie(presented)
+	rec := httptest.NewRecorder()
+	s.handleAuthUser(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authenticated /api/auth/user = %d, want 200", rec.Code)
+	}
+	var live, legacyClear *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != "hive_hub_user" {
+			continue
+		}
+		switch {
+		case c.Value == presented.Value:
+			live = c
+		case c.Value == "" && c.Domain == "kubestellar.io":
+			legacyClear = c
+		}
+	}
+	if live == nil || live.Domain != "hivecommons.dev" {
+		t.Fatalf("live cookie = %#v, want session on hivecommons.dev", live)
+	}
+	if legacyClear == nil || legacyClear.MaxAge >= 0 {
+		t.Fatalf("legacy clear cookie = %#v, want expired kubestellar.io cookie", legacyClear)
+	}
+}

--- a/src/pkg/hub/link_preview_test.go
+++ b/src/pkg/hub/link_preview_test.go
@@ -77,7 +77,7 @@ func TestWriteLinkPreviewServesHiveTags(t *testing.T) {
 		`property="og:description"`,
 		`property="og:image"`,
 		`name="twitter:card" content="summary_large_image"`,
-		hubPublicURL + "/og-card.png",
+		hubPublicURL() + "/og-card.png",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("preview HTML missing %q", want)

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -31,11 +31,6 @@ const (
 	// is inside the signature and checked by every verifier.
 	cookieSessionTTL = time.Duration(cookieMaxAgeDays) * 24 * time.Hour
 
-	// oauthRedirectURI is the single OAuth/OIDC callback registered on every
-	// provider's side. All providers share one callback path; the state parameter
-	// carries which provider to complete against.
-	oauthRedirectURI = "https://hive.kubestellar.io/api/auth/callback"
-
 	// oidcNonceCookieName holds the per-login OIDC replay nonce. Host-scoped like
 	// the CSRF state cookie; the id_token must echo it back or the callback fails.
 	oidcNonceCookieName = "hive_oidc_nonce"
@@ -126,12 +121,6 @@ func isLinkPreviewCrawler(r *http.Request) bool {
 	return false
 }
 
-// hubPublicURL is the canonical public origin used to build absolute Open Graph
-// URLs. Unfurlers require absolute image URLs — a relative path is ignored — and
-// they fetch the image without a session, so this must be the externally
-// reachable host.
-const hubPublicURL = "https://hive.kubestellar.io"
-
 // linkPreviewMaxAge is how long an unfurler may cache the preview HTML. Short,
 // because the copy may be reworded on any deploy; the image is cached far longer.
 const linkPreviewMaxAge = 5 * time.Minute
@@ -142,7 +131,8 @@ const linkPreviewMaxAge = 5 * time.Minute
 // The meta tags are kept at the very top of <head>: Slackbot reads only the
 // first 32KB of a response, so anything below that is invisible to it.
 func writeLinkPreview(w http.ResponseWriter) {
-	const previewHTML = `<!DOCTYPE html>
+	publicURL := hubPublicURL()
+	previewHTML := `<!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8">
 <title>Hive — AI agents that maintain your repo</title>
 <meta name="description" content="Hive — the AI maintainer you own outright. AI agents triage issues, write fixes, patch CVEs, and merge on green behind six autonomy levels.">
@@ -150,8 +140,8 @@ func writeLinkPreview(w http.ResponseWriter) {
 <meta property="og:title" content="Hive — AI agents that maintain your repo">
 <meta property="og:description" content="Put your repo on autopilot. Hive runs a fleet of AI agents on your backlog behind six autonomy levels — test coverage earns the confidence to raise a level, and you (the admin) choose when to raise it.">
 <meta property="og:type" content="website">
-<meta property="og:url" content="` + hubPublicURL + `">
-<meta property="og:image" content="` + hubPublicURL + `/og-card.png">
+<meta property="og:url" content="` + publicURL + `">
+<meta property="og:image" content="` + publicURL + `/og-card.png">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -159,10 +149,10 @@ func writeLinkPreview(w http.ResponseWriter) {
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Hive — AI agents that maintain your repo">
 <meta name="twitter:description" content="Put your repo on autopilot. AI agents on your backlog behind six autonomy levels.">
-<meta name="twitter:image" content="` + hubPublicURL + `/og-card.png">
+<meta name="twitter:image" content="` + publicURL + `/og-card.png">
 </head><body>
 <h1>Hive</h1>
-<p>AI agents that maintain your repo. <a href="` + hubPublicURL + `">Sign in to continue.</a></p>
+<p>AI agents that maintain your repo. <a href="` + publicURL + `">Sign in to continue.</a></p>
 </body></html>`
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	// Preview cards are identical for every link and change only on deploy.
@@ -310,7 +300,7 @@ func (s *HubServer) startProviderLogin(w http.ResponseWriter, r *http.Request, p
 		// serves /user's public profile (including "login") unscoped. Do NOT add a
 		// scope without a feature that needs it.
 		authURL := fmt.Sprintf("%s?client_id=%s&scope=&redirect_uri=%s&state=%s",
-			p.AuthorizeURL, p.ClientID, oauthRedirectURI, state)
+			p.AuthorizeURL, p.ClientID, oauthRedirectURI(), state)
 		http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
 		return
 	}
@@ -332,7 +322,7 @@ func (s *HubServer) startProviderLogin(w http.ResponseWriter, r *http.Request, p
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
-	authURL, err := p.AuthCodeURL(oauthRedirectURI, state, oidcNonce)
+	authURL, err := p.AuthCodeURL(oauthRedirectURI(), state, oidcNonce)
 	if err != nil {
 		s.logger.Warn("OIDC: cannot build authorize URL", "provider", p.Name, "error", err)
 		http.Error(w, "login unavailable — provider not reachable", http.StatusBadGateway)
@@ -471,7 +461,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		ghToken     string // GitHub user access token, if any (stored encrypted)
 	)
 	if p.IsOIDC {
-		claims, err := p.Exchange(r.Context(), code, oauthRedirectURI, s.oidcNonceFromCookie(r))
+		claims, err := p.Exchange(r.Context(), code, oauthRedirectURI(), s.oidcNonceFromCookie(r))
 		s.clearOIDCNonceCookie(w)
 		if err != nil {
 			// Server-side diagnostics only: log which step failed (discovery /
@@ -835,12 +825,12 @@ func setSessionCookies(w http.ResponseWriter, r *http.Request, cookieValue strin
 	// interim are handled by hubSessionCookieValues, which tries every copy.)
 	// Emitted BEFORE the real cookie so anything scanning Set-Cookie in order
 	// finds the live session last.
-	if domain != "" && domain != hubDomainSuffix {
+	for _, clearDomain := range legacySessionCookieDomains(domain) {
 		http.SetCookie(w, &http.Cookie{
 			Name:     "hive_hub_user",
 			Value:    "",
 			Path:     "/",
-			Domain:   hubDomainSuffix,
+			Domain:   clearDomain,
 			MaxAge:   -1,
 			HttpOnly: true,
 			Secure:   true,
@@ -1072,10 +1062,8 @@ func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	// only removes the jar entry whose domain matches. Also clear the legacy
 	// .hive.kubestellar.io-scoped entry (#4171 rollout: a pre-widening session
 	// is a separate jar entry that a parent-scoped deletion cannot remove).
-	clearDomains := []string{sessionCookieDomain(r.Host)}
-	if clearDomains[0] != "" && clearDomains[0] != hubDomainSuffix {
-		clearDomains = append(clearDomains, hubDomainSuffix)
-	}
+	liveDomain := sessionCookieDomain(r.Host)
+	clearDomains := append([]string{liveDomain}, legacySessionCookieDomains(liveDomain)...)
 	for _, domain := range clearDomains {
 		http.SetCookie(w, &http.Cookie{
 			Name:     "hive_hub_user",

--- a/src/pkg/hub/oauth_provider_login_test.go
+++ b/src/pkg/hub/oauth_provider_login_test.go
@@ -58,8 +58,8 @@ func TestHandleProviderLoginStartsProviderFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse location: %v", err)
 	}
-	if got := parsed.Query().Get("redirect_uri"); got != oauthRedirectURI {
-		t.Fatalf("redirect_uri = %q, want %q", got, oauthRedirectURI)
+	if got := parsed.Query().Get("redirect_uri"); got != oauthRedirectURI() {
+		t.Fatalf("redirect_uri = %q, want %q", got, oauthRedirectURI())
 	}
 	var stateCookie *http.Cookie
 	for _, c := range rec.Result().Cookies() {

--- a/src/pkg/hub/openrouter.go
+++ b/src/pkg/hub/openrouter.go
@@ -28,10 +28,6 @@ import (
 )
 
 const (
-	// hubBaseURL is the hub's own public origin, used to build the OAuth
-	// callback_url server-side (never accepted from the client). Matches the
-	// hardcoded origin used elsewhere in the hub (cookies, redirect_uri).
-	hubBaseURL = "https://hive.kubestellar.io"
 	// hubOpenRouterCallbackPath is the hub's PUBLIC OAuth return path.
 	hubOpenRouterCallbackPath = "/openrouter/callback"
 	// hubOpenRouterGatewayName is the gateway name a funded key is delivered as.
@@ -106,7 +102,7 @@ func (s *HubServer) handleHubOpenRouterStart(w http.ResponseWriter, r *http.Requ
 		http.Error(w, `{"error":"failed to start flow"}`, http.StatusInternalServerError)
 		return
 	}
-	authURL, err := openrouter.BuildAuthorizeURL(hubBaseURL+hubOpenRouterCallbackPath, challenge, state)
+	authURL, err := openrouter.BuildAuthorizeURL(hubPublicURL()+hubOpenRouterCallbackPath, challenge, state)
 	if err != nil {
 		http.Error(w, `{"error":"failed to build authorize URL"}`, http.StatusInternalServerError)
 		return

--- a/src/pkg/hub/saas_auth.go
+++ b/src/pkg/hub/saas_auth.go
@@ -11,9 +11,12 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
@@ -343,16 +346,72 @@ func isNonBrowserAPIRequest(r *http.Request) bool {
 	return true
 }
 
+const (
+	defaultHubPublicURL          = "https://hive.kubestellar.io"
+	defaultHubCanonicalHost      = "hive.kubestellar.io"
+	defaultHubSpokeDomain        = "hive.kubestellar.io"
+	defaultLegacyHubCookieDomain = ".hive.kubestellar.io"
+)
+
+// hubPublicURL is the canonical public origin used to build absolute URLs.
+func hubPublicURL() string {
+	if v := strings.TrimSpace(os.Getenv("HIVE_HUB_PUBLIC_URL")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return defaultHubPublicURL
+}
+
+// oauthRedirectURI is the single OAuth/OIDC callback registered on every
+// provider's side. All providers share one callback path; the state parameter
+// carries which provider to complete against.
+func oauthRedirectURI() string {
+	return hubPublicURL() + "/api/auth/callback"
+}
+
 // hubCanonicalHost is the ONE host that serves the hub's own dashboard and API.
 // Every legitimate browser mutation against the hub is issued by a document
 // loaded from this host — tenant spokes are separate origins that talk to the
 // hub through their own proxy, never by scripting a cross-origin POST at it.
-const hubCanonicalHost = "hive.kubestellar.io"
+func hubCanonicalHost() string {
+	u, err := url.Parse(hubPublicURL())
+	if err != nil || u.Hostname() == "" {
+		return defaultHubCanonicalHost
+	}
+	return strings.ToLower(u.Hostname())
+}
 
-// hubDomainSuffix is the shared parent domain the hosted tenants live under
-// (<id>.hive.kubestellar.io). It is a REDIRECT-trust boundary only — see
-// isTrustedRedirectTarget — and deliberately NOT a CSRF or CORS boundary.
-const hubDomainSuffix = ".hive.kubestellar.io"
+// hubSpokeDomain is the shared parent domain the hosted tenants live under
+// (<id>.hive.kubestellar.io by default). It is a REDIRECT-trust boundary only
+// — see isTrustedRedirectTarget — and deliberately NOT a CSRF or CORS boundary.
+func hubSpokeDomain() string {
+	if v := strings.TrimSpace(os.Getenv("HIVE_HUB_SPOKE_DOMAIN")); v != "" {
+		return strings.TrimPrefix(strings.TrimSuffix(strings.ToLower(v), "."), ".")
+	}
+	return defaultHubSpokeDomain
+}
+
+func hubDomainSuffix() string {
+	return "." + hubSpokeDomain()
+}
+
+func legacyHubCookieDomain() string {
+	v := strings.TrimSpace(os.Getenv("HIVE_HUB_LEGACY_COOKIE_DOMAIN"))
+	if v == "" {
+		return ""
+	}
+	return "." + strings.TrimPrefix(strings.TrimSuffix(strings.ToLower(v), "."), ".")
+}
+
+func legacySessionCookieDomains(liveDomain string) []string {
+	var domains []string
+	if liveDomain != "" && liveDomain != defaultLegacyHubCookieDomain {
+		domains = append(domains, defaultLegacyHubCookieDomain)
+	}
+	if legacy := legacyHubCookieDomain(); legacy != "" && legacy != liveDomain && legacy != defaultLegacyHubCookieDomain {
+		domains = append(domains, legacy)
+	}
+	return domains
+}
 
 // sessionCookieParentDomain is the registrable parent domain the hub session
 // cookie is scoped to, so first-party sibling products on other kubestellar.io
@@ -360,10 +419,13 @@ const hubDomainSuffix = ".hive.kubestellar.io"
 // GET /api/saas/whoami. Derived from hubCanonicalHost (its parent domain)
 // rather than spelled out so the two can never disagree.
 func sessionCookieParentDomain() string {
-	if _, parent, ok := strings.Cut(hubCanonicalHost, "."); ok {
+	if parent, err := publicsuffix.EffectiveTLDPlusOne(hubCanonicalHost()); err == nil {
 		return parent
 	}
-	return hubCanonicalHost
+	if _, parent, ok := strings.Cut(hubCanonicalHost(), "."); ok {
+		return parent
+	}
+	return hubCanonicalHost()
 }
 
 // sessionCookieDomain returns the Domain attribute the hub session cookie
@@ -431,7 +493,7 @@ func isSameOriginAsHub(raw string) bool {
 	if !ok {
 		return false
 	}
-	return host == hubCanonicalHost || host == "localhost" || host == "127.0.0.1"
+	return host == hubCanonicalHost() || host == "localhost" || host == "127.0.0.1"
 }
 
 // isTrustedRedirectTarget reports whether raw is a URL the hub may bounce a
@@ -456,8 +518,8 @@ func isTrustedRedirectTarget(raw string) bool {
 	if !ok {
 		return false
 	}
-	return host == hubCanonicalHost ||
-		strings.HasSuffix(host, hubDomainSuffix) ||
+	return host == hubCanonicalHost() ||
+		strings.HasSuffix(host, hubDomainSuffix()) ||
 		host == "localhost" ||
 		host == "127.0.0.1"
 }

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -2282,6 +2282,7 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		// symmetric; per-hive so an invite link cannot travel between tenants.
 		"InviteKey": provisionInviteKey(h.ID),
 		// Cluster-aware fields.
+		"HubPublicURL":       hubPublicURL(),
 		"DashboardHost":      dashboardHost,
 		"DashboardURL":       dashboardURL,
 		"DashboardPort":      dashboardPort,
@@ -2832,7 +2833,7 @@ data:
       hub_proxied: {{.IsNginxIngress}}
     hub:
       enabled: true
-      url: https://hive.kubestellar.io
+      url: {{.HubPublicURL}}
       dashboard_url: {{.DashboardURL}}
       hive_type: {{.HiveType}}
       is_public: {{.IsPublic}}
@@ -3086,7 +3087,7 @@ spec:
         - name: HIVE_LEVEL
           value: "{{.ACMMLevel}}"
         - name: HIVE_HUB_URL
-          value: https://hive.kubestellar.io
+          value: {{.HubPublicURL}}
         # C2 domain separation: derived per-domain sub-keys ONLY — never the
         # master HIVE_HUB_SECRET. HEARTBEAT authenticates beats to the hub;
         # SESSION verifies hub-minted cookies. SSO is ASYMMETRIC (C2 follow-up):
@@ -3231,10 +3232,10 @@ metadata:
   namespace: {{.Namespace}}
   annotations:
     cert-manager.io/cluster-issuer: {{.CertIssuer}}
-    nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}&uri=$request_uri"
+    nginx.ingress.kubernetes.io/auth-url: "{{.HubPublicURL}}/api/saas/auth-check?hive={{.ID}}&uri=$request_uri"
     nginx.ingress.kubernetes.io/custom-http-errors: "502,503"
     nginx.ingress.kubernetes.io/default-backend: hive-error-pages
-    nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "{{.HubPublicURL}}/login?redirect=$scheme://$http_host$request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role,X-Hive-Proxy-Auth"
 spec:
   ingressClassName: {{.IngressClass}}
@@ -3322,8 +3323,8 @@ metadata:
     # shared .hive.kubestellar.io cookie) reaches ANY tenant's /terminal. The
     # auth-check endpoint verifies the caller against THIS hive's authorized
     # users (user.Hives[{{.ID}}]) and 403s a user with no access to this hive.
-    nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}&uri=$request_uri"
-    nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
+    nginx.ingress.kubernetes.io/auth-url: "{{.HubPublicURL}}/api/saas/auth-check?hive={{.ID}}&uri=$request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "{{.HubPublicURL}}/login?redirect=$scheme://$http_host$request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role,X-Hive-Proxy-Auth"
 spec:
   ingressClassName: {{.IngressClass}}

--- a/src/pkg/hub/saas_provision_key_file_test.go
+++ b/src/pkg/hub/saas_provision_key_file_test.go
@@ -64,7 +64,7 @@ func renderProvisionManifestWithAuth(t *testing.T, useApp, useAppFull bool, toke
 		"Org":               "kubestellar",
 		"Repos":             "[]",
 		"PrimaryRepo":       "hivecommons/hive",
-		"HubURL":            "https://hive.kubestellar.io",
+		"HubPublicURL":      "https://hive.kubestellar.io",
 		"DashboardURL":      "https://test-hive.hive.kubestellar.io",
 		"HiveType":          "hosted",
 		"IsPublic":          false,

--- a/src/pkg/hub/saas_provision_secretmode_test.go
+++ b/src/pkg/hub/saas_provision_secretmode_test.go
@@ -58,7 +58,7 @@ func renderManifest(t *testing.T, requiresSCC bool) string {
 		"StorageClass":      "standard",
 		"Host":              "test-hive.hive.kubestellar.io",
 		"Owner":             "alice",
-		"HubURL":            "https://hive.kubestellar.io",
+		"HubPublicURL":      "https://hive.kubestellar.io",
 		"ProjectName":       "test",
 		"PrimaryRepo":       "org/repo",
 		"AppKeys":           []provisionAppKey{},

--- a/src/pkg/hub/saas_provision_terminal_authz_test.go
+++ b/src/pkg/hub/saas_provision_terminal_authz_test.go
@@ -19,6 +19,7 @@ func renderManifestForTest(t *testing.T, nginx bool) string {
 	}
 	data := map[string]interface{}{
 		"ID":               "hosted-hive-x",
+		"HubPublicURL":     "https://hive.kubestellar.io",
 		"Namespace":        "hive-hosted-hosted-hive-x",
 		"DashboardHost":    "hosted-hive-x.hive.kubestellar.io",
 		"DashboardPort":    8080,

--- a/src/pkg/hub/upgrade_pause_test.go
+++ b/src/pkg/hub/upgrade_pause_test.go
@@ -557,7 +557,7 @@ func TestUpgradePauseEndpointsAdminOnly(t *testing.T) {
 	}
 	rec = httptest.NewRecorder()
 	req := reqWithUser(http.MethodPost, "/api/saas/upgrade-pause", `{"target":"spokes","paused":true}`, "alice")
-	req.Header.Set("Origin", "https://"+hubCanonicalHost)
+	req.Header.Set("Origin", "https://"+hubCanonicalHost())
 	postH(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("non-admin POST status = %d, want 403", rec.Code)
@@ -571,7 +571,7 @@ func TestUpgradePauseEndpointsAdminOnly(t *testing.T) {
 	// and GET reflects the persisted state with who/when.
 	rec = httptest.NewRecorder()
 	req = reqWithUser(http.MethodPost, "/api/saas/upgrade-pause", `{"target":"spokes","paused":true}`, hubAdminUsername)
-	req.Header.Set("Origin", "https://"+hubCanonicalHost)
+	req.Header.Set("Origin", "https://"+hubCanonicalHost())
 	postH(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("admin POST status = %d, want 200; body=%s", rec.Code, rec.Body.String())
@@ -589,7 +589,7 @@ func TestUpgradePauseEndpointsAdminOnly(t *testing.T) {
 	// Unknown target is rejected.
 	rec = httptest.NewRecorder()
 	req = reqWithUser(http.MethodPost, "/api/saas/upgrade-pause", `{"target":"everything","paused":true}`, hubAdminUsername)
-	req.Header.Set("Origin", "https://"+hubCanonicalHost)
+	req.Header.Set("Origin", "https://"+hubCanonicalHost())
 	postH(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("bad target status = %d, want 400", rec.Code)


### PR DESCRIPTION
## Summary
- port v4 host-swap phase 0 to v5 SaaS auth split
- make HIVE_HUB_PUBLIC_URL derive callbacks, link previews, origin checks, OpenRouter callback, and SSO cookie scope
- add HIVE_HUB_SPOKE_DOMAIN for spoke ingress hostnames and HIVE_HUB_LEGACY_COOKIE_DOMAIN for transition cookie cleanup

## Tests
- cd src && go build ./...
- cd src && go test ./pkg/hub -run "TestHubPublic|TestLegacyCookieDomain|TestHubSpoke|TestTerminalIngress|TestMainAndTerminalIngress|TestHandleProviderLoginStartsProviderFlow" -count=1
- cd src && go test ./pkg/hub/... ./pkg/config/... (pkg/config currently fails TestEntrypointHardensRuntimeConfigItRecreates: runtime config mode 0644 vs 0600 in this local macOS environment)