### PR TITLE
🐛 fix: format release changelog fragment

### DIFF
--- a/changelog.d/security-5812-dead-hub-cookie.md
+++ b/changelog.d/security-5812-dead-hub-cookie.md
@@ -1,1 +1,1 @@
-security: remove legacy hub session-cookie mint and verification helpers from the production binary while keeping rejection regression tests.
+- Removed legacy hub session-cookie mint and verification helpers from the production binary while keeping rejection regression tests.


### PR DESCRIPTION
## Summary
- fix the malformed security changelog fragment blocking tagged-release.yml

## Validation
- src/scripts/compile-changelog.sh