### PR TITLE
🐛 fix(hub): close the ambient-kubeconfig escape that leaked 76 namespaces onto a live cluster

### DIFF
--- a/changelog.d/fixed-5768-ambient-kubectl-escape.md
+++ b/changelog.d/fixed-5768-ambient-kubectl-escape.md
@@ -1,0 +1,1 @@
+- Stopped hub provisioning from falling back to a machine's ambient kubeconfig. A cluster config claiming `in_cluster` outside a real pod now aims kubectl at the unreachable sentinel and fails loudly, instead of applying namespaces and Deployments to whatever cluster the current context named.

--- a/src/pkg/hub/hub_coverage_boost_test.go
+++ b/src/pkg/hub/hub_coverage_boost_test.go
@@ -1834,7 +1834,13 @@ func TestLoadClustersDefault(t *testing.T) {
 // ============================================================
 
 func TestKubectlForCluster(t *testing.T) {
-	// In-cluster
+	// In-cluster. The ServiceAccount environment must be SET for this case:
+	// "in-cluster does not use --kubeconfig" is only true of a real hub pod,
+	// where the kubelet injects both vars. Asserting it with them unset is what
+	// encoded the #5768 ambient-config escape as expected behaviour — see
+	// kubectl_ambient_escape_test.go for the guarded no-env case.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
 	inCluster := &ClusterConfig{InCluster: true}
 	cmd := kubectlForCluster(inCluster, "get", "pods")
 	args := cmd.Args

--- a/src/pkg/hub/kubectl_ambient_escape_test.go
+++ b/src/pkg/hub/kubectl_ambient_escape_test.go
@@ -1,0 +1,144 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// The tests below pin the fix for issue #5768.
+//
+// A hosted-spoke provisioning call builds its kubectl argv through the single
+// chokepoint kubectlArgsForCluster. For a cluster whose config CLAIMS
+// InCluster, that function used to append the in-cluster connection flags only
+// when KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT were both set, and
+// nothing at all otherwise. "Nothing at all" is not a safe default: kubectl
+// with no --server and no --kubeconfig resolves against its ambient
+// configuration, so the command executes against whatever cluster the machine's
+// current context names.
+//
+// That is how 76 hive-hosted-hosted-<fixture-org>-* namespaces reached a live
+// CI cluster with no corresponding hub bookkeeping — the applies were real
+// while the store writes went to a per-test t.TempDir().
+
+// hasFlag reports whether argv contains flag.
+func hasFlag(argv []string, flag string) bool {
+	for _, a := range argv {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// flagValue returns the value following flag, or "" when absent.
+func flagValue(argv []string, flag string) string {
+	for i, a := range argv {
+		if a == flag && i+1 < len(argv) {
+			return argv[i+1]
+		}
+	}
+	return ""
+}
+
+// TestInClusterClaimWithoutServiceAccountEnvCannotUseAmbientConfig is the
+// regression test for #5768. It is the test that would have caught the leak:
+// with the ServiceAccount environment absent, an InCluster claim must NOT
+// produce an argv that lets kubectl choose a cluster for itself.
+//
+// This test FAILS without the fix in kubectlArgsForCluster — the pre-fix argv
+// for these inputs is exactly ["apply","-f","-"], which carries no connection
+// flag and therefore inherits $KUBECONFIG / ~/.kube/config.
+func TestInClusterClaimWithoutServiceAccountEnvCannotUseAmbientConfig(t *testing.T) {
+	// TestMain already clears these; set them empty explicitly so this test
+	// states its own precondition rather than depending on suite-wide setup.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	cluster := &ClusterConfig{ID: "hive-oke", InCluster: true}
+	argv := kubectlArgsForCluster(cluster, "apply", "-f", "-")
+
+	// The core invariant: SOME explicit target must be named. An argv with
+	// neither --server nor --kubeconfig is the ambient-config escape.
+	if !hasFlag(argv, "--server") && !hasFlag(argv, "--kubeconfig") {
+		t.Fatalf("ambient-config escape: InCluster claim with no ServiceAccount env produced "+
+			"no --server and no --kubeconfig, so kubectl would target the machine's "+
+			"current context. argv=%q", argv)
+	}
+
+	// And specifically it must be aimed at the unreachable sentinel, so the
+	// command fails loudly instead of mutating some other cluster.
+	if got := flagValue(argv, "--kubeconfig"); got != unreachableKubeconfigSentinel {
+		t.Errorf("--kubeconfig = %q, want the unreachable sentinel %q (argv=%q)",
+			got, unreachableKubeconfigSentinel, argv)
+	}
+}
+
+// TestDefaultClusterRegistryEntryCannotEscapeToAmbientConfig covers the exact
+// path the leak took. A test that points clustersConfigPath at an empty
+// t.TempDir() gets clustersAbsent, so loadClustersChecked synthesises
+// defaultClusterRegistry() — whose single entry claims InCluster: true. That
+// synthesised entry is what provisioning then used, so it must be safe too.
+func TestDefaultClusterRegistryEntryCannotEscapeToAmbientConfig(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	reg := defaultClusterRegistry()
+	cluster, ok := reg[defaultClusterID]
+	if !ok {
+		t.Fatalf("defaultClusterRegistry() has no %q entry", defaultClusterID)
+	}
+	if !cluster.InCluster {
+		t.Skip("default registry entry no longer claims InCluster; this escape is moot")
+	}
+
+	argv := kubectlArgsForCluster(&cluster, "create", "namespace", "hive-hosted-hosted-acme-repo-abcd")
+	if !hasFlag(argv, "--server") && !hasFlag(argv, "--kubeconfig") {
+		t.Fatalf("synthesised default cluster would provision against the ambient cluster: argv=%q", argv)
+	}
+	if got := flagValue(argv, "--kubeconfig"); got != unreachableKubeconfigSentinel {
+		t.Errorf("--kubeconfig = %q, want %q (argv=%q)", got, unreachableKubeconfigSentinel, argv)
+	}
+}
+
+// TestRealInClusterStillUsesServiceAccount pins the behaviour the guard must
+// NOT change: inside a genuine hub pod both env vars are present, and kubectl
+// must still be handed the ServiceAccount credentials rather than the sentinel.
+// Without this, a fix could "close" the escape by breaking real provisioning.
+func TestRealInClusterStillUsesServiceAccount(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	cluster := &ClusterConfig{ID: "hive-oke", InCluster: true}
+	argv := kubectlArgsForCluster(cluster, "get", "pods")
+
+	if got := flagValue(argv, "--server"); got != "https://10.96.0.1:443" {
+		t.Errorf("--server = %q, want https://10.96.0.1:443 (argv=%q)", got, argv)
+	}
+	if hasFlag(argv, "--kubeconfig") {
+		t.Errorf("a real in-cluster hub must use its ServiceAccount, not --kubeconfig: argv=%q", argv)
+	}
+	if !hasFlag(argv, "--certificate-authority") || !hasFlag(argv, "--token") {
+		t.Errorf("real in-cluster argv missing ServiceAccount credentials: argv=%q", argv)
+	}
+	// The caller's own args must survive at the tail.
+	if !strings.HasSuffix(strings.Join(argv, " "), "get pods") {
+		t.Errorf("caller args were not preserved: argv=%q", argv)
+	}
+}
+
+// TestUnreachableRemoteClusterUnchanged pins the pre-existing pull-only
+// behaviour so this change is provably additive: a non-InCluster cluster the
+// hub cannot reach already aimed at the sentinel, and still must.
+func TestUnreachableRemoteClusterUnchanged(t *testing.T) {
+	pullOnly := &ClusterConfig{ID: "vllm-d", PullOnly: true, KubeconfigPath: "/etc/hive/kubeconfigs/vllm-d"}
+	argv := kubectlArgsForCluster(pullOnly, "get", "ns")
+	if got := flagValue(argv, "--kubeconfig"); got != unreachableKubeconfigSentinel {
+		t.Errorf("pull-only cluster --kubeconfig = %q, want sentinel %q", got, unreachableKubeconfigSentinel)
+	}
+
+	reachable := &ClusterConfig{ID: "a-ks-wec2", KubeconfigPath: "/etc/hive/kubeconfigs/a-ks-wec2", Context: "wec2"}
+	argv2 := kubectlArgsForCluster(reachable, "get", "ns")
+	if got := flagValue(argv2, "--kubeconfig"); got != "/etc/hive/kubeconfigs/a-ks-wec2" {
+		t.Errorf("reachable remote cluster --kubeconfig = %q, want its real path", got)
+	}
+}

--- a/src/pkg/hub/saas_provision.go
+++ b/src/pkg/hub/saas_provision.go
@@ -433,6 +433,27 @@ func kubectlArgsForCluster(cluster *ClusterConfig, args ...string) []string {
 				"--certificate-authority", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 				"--token", readSAToken(),
 			)
+		} else {
+			// InCluster is a CLAIM, not a fact, and this is the branch where the
+			// claim is demonstrably false: a real hub pod ALWAYS has both
+			// KUBERNETES_SERVICE_HOST and _PORT injected by the kubelet, so
+			// their absence is positive evidence this process is not in a pod.
+			//
+			// Without this arm we appended NO connection flag at all, and
+			// kubectl then resolves against its AMBIENT configuration —
+			// $KUBECONFIG or ~/.kube/config — i.e. whatever cluster the machine
+			// happens to be pointed at. That is issue #5768: hub tests that
+			// reach a provisioning entry point ran a REAL `kubectl apply` of a
+			// Namespace + Deployment named from the test's own fixture org
+			// against a developer/agent machine's current-context cluster,
+			// leaking 76 hive-hosted-hosted-{apporg,myorg,acme}-* namespaces
+			// onto a live CI cluster. The hub kept no record of them because
+			// saveSaaSHive had been redirected to the test's t.TempDir().
+			//
+			// Aim at the sentinel instead, exactly as the unreachable branch
+			// above does, so a false InCluster claim fails loudly rather than
+			// mutating an unrelated cluster.
+			fullArgs = append(fullArgs, "--kubeconfig", unreachableKubeconfigSentinel)
 		}
 	}
 	fullArgs = append(fullArgs, args...)


### PR DESCRIPTION
## What

`kubectlArgsForCluster` (`src/pkg/hub/saas_provision.go:414`) treated `ClusterConfig.InCluster` as a fact. For an `InCluster` cluster it appended `--server` / `--certificate-authority` / `--token` **only** when `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` were both set, and appended **nothing at all** otherwise.

"Nothing at all" is not a safe default. `kubectl` with no `--server` and no `--kubeconfig` resolves against its **ambient** configuration — `$KUBECONFIG` or `~/.kube/config` — so the command targets whatever cluster the machine's current context happens to name.

This is the mechanism behind #5768: 76 `hive-hosted-hosted-<fixture-org>-*` namespaces on the live `ks-console-ci-3` cluster, each with one never-ready `hive` Deployment, and **no hub bookkeeping for any of them**.

## Why bookkeeping was absent

The two halves of provisioning have different destinations under test:

- `saveSaaSHive` (`saas_provision.go:1757`) writes under the package var `saasHivesDir`, which essentially every hub test reassigns to a `t.TempDir()`. The record **was** written — then deleted with the temp dir.
- the `kubectl apply` went out through the argv chokepoint above, with no connection flag, to the **real** ambient cluster.

So "namespace exists, no record" is the expected signature of this escape, not evidence of an exotic code path. It also explains why `grep ks-console-ci` over `hub-registry.json` returns nothing and why all 95 `/data/saas/hives/` entries reconcile to the four legitimate clusters.

## Why the fake didn't catch it

`installScriptedKubectl` is a `PATH` prepend. It constrains *which binary* runs, never *which cluster it talks to* — and **6 of the 7** test files that drive `handleCreateHive` never install it at all (only `saas_handlers2_coverage_test.go` does). Their fixture orgs are exactly the leaked names: `apporg`, `myorg` (`hub_filesystem_extra_test.go`, `hub_coverage_deep_test.go`) and `acme` (`final5_coverage_test.go`).

The path into a real cluster is short: test helpers point `clustersConfigPath` at an empty `t.TempDir()` → `loadClustersChecked` reports `clustersAbsent` → `defaultClusterRegistry()` (`clusters_registry.go:199`) synthesises one entry with **`InCluster: true`** → the chokepoint adds no flag → ambient cluster.

`TestKubectlForCluster` (`hub_coverage_boost_test.go:1836`) asserted *"in-cluster should not use `--kubeconfig`"* **with those env vars unset** — it encoded the bug as expected behaviour.

## The fix

The guard goes at the single argv chokepoint both `kubectlForCluster` and `kubectlForClusterContext` funnel through, not in individual tests — a per-test fix would have to be repeated forever and re-missed once. An `InCluster` claim with **no ServiceAccount environment** now aims at the existing `unreachableKubeconfigSentinel`, the same mechanism the pull-only branch already uses.

Absence of both env vars is positive, reliable evidence the process is not in a pod: the kubelet always injects them into a real hub pod. Genuine in-cluster provisioning is therefore untouched.

## Tests, and proof they can fail

`src/pkg/hub/kubectl_ambient_escape_test.go`:

- `TestInClusterClaimWithoutServiceAccountEnvCannotUseAmbientConfig` — the core invariant
- `TestDefaultClusterRegistryEntryCannotEscapeToAmbientConfig` — the exact synthesised-registry path the leak took
- `TestRealInClusterStillUsesServiceAccount` — pins that a real pod still gets its ServiceAccount, so the escape can't be "closed" by breaking production
- `TestUnreachableRemoteClusterUnchanged` — pins pull-only/reachable behaviour as unchanged

Verified failing without the fix (else-arm neutralised, everything else identical):

```
--- FAIL: TestInClusterClaimWithoutServiceAccountEnvCannotUseAmbientConfig
    ambient-config escape: InCluster claim with no ServiceAccount env produced
    no --server and no --kubeconfig, so kubectl would target the machine's
    current context. argv=["apply" "-f" "-"]
--- FAIL: TestDefaultClusterRegistryEntryCannotEscapeToAmbientConfig
    synthesised default cluster would provision against the ambient cluster:
    argv=["create" "namespace" "hive-hosted-hosted-acme-repo-abcd"]
```

and passing with it.

## Relationship to the existing TestMain guard

`src/pkg/hub/main_test.go` clears these same env vars — and it was **created 2026-07-31** (`377fefd8`, #2287) in response to the 2026-07-27 incident its own comment documents. Both leak events predate it: the `apporg`/`myorg` bulk at 52-55 days (~2026-07-10..13) and the `acme` pair at 36 days (~2026-07-29). At `1b4b6a01` (2026-07-25) the hub package had **no `TestMain` at all**, which is why the leak was possible then and has not recurred since.

That guard is test-side and covers only this package's `go test` runs. This change puts the same invariant in production code at the chokepoint, so it holds for any caller in any process — which is what makes it durable rather than another thing to remember.

No cluster objects are touched by this PR; the one-time cleanup of the 76 existing namespaces remains an operator action tracked in #5768.

Refs #5768