### PR TITLE
🐛 fix(hub): skip login picker for signed-in users with a redirect target

### DIFF
--- a/changelog.d/fixed-login-session-shortcircuit.md
+++ b/changelog.d/fixed-login-session-shortcircuit.md
@@ -1,0 +1,1 @@
+- A user already signed in to the hub who is bounced to `/login?redirect=…` (for example by a spoke's auth gate) is now returned straight to the validated target instead of being shown the login provider picker and forced through OAuth again.

--- a/src/pkg/hub/oauth.go
+++ b/src/pkg/hub/oauth.go
@@ -201,6 +201,22 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	redirect := s.loginRedirectTarget(r)
+	// A signed-in user bounced here with a redirect target (a spoke's nginx
+	// auth-signin, or any trusted ?redirect=) needs no provider round-trip —
+	// the session cookie already proves who they are. Send them straight back
+	// to the validated target instead of rendering the picker or re-entering
+	// OAuth. Plain /login with no redirect still shows the picker so switching
+	// accounts stays possible. The target is already validated by
+	// loginRedirectTarget (isTrustedRedirectTarget), so this introduces no new
+	// open-redirect surface.
+	if redirect != "" {
+		for _, value := range hubSessionCookieValues(r) {
+			if u, ok := s.verifyHubUserCookie(value); ok && loadSaaSUser(u) != nil {
+				http.Redirect(w, r, redirect, http.StatusSeeOther)
+				return
+			}
+		}
+	}
 	providers := s.authProviders.Providers()
 	if len(providers) == 0 {
 		// Registry not built (a HubServer constructed without registerOAuth — the

--- a/src/pkg/hub/oauth_login_shortcircuit_test.go
+++ b/src/pkg/hub/oauth_login_shortcircuit_test.go
@@ -1,0 +1,75 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ============================================================
+// /login session short-circuit — a user who already carries a valid hub
+// session and arrives at /login WITH a redirect target (the spoke auth-signin
+// bounce) must be returned straight to that target. No provider picker, no
+// second OAuth round-trip.
+// ============================================================
+
+// TestHandleLoginSignedInWithRedirectShortCircuits pins the fix: valid
+// session + ?redirect= → 303 straight to the validated target.
+func TestHandleLoginSignedInWithRedirectShortCircuits(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "octocat")
+
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login?redirect=%2Fdashboard", nil)
+	req.AddCookie(testAuthCookie("octocat"))
+	rec := httptest.NewRecorder()
+	s.handleLogin(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("signed-in /login?redirect= = %d, want %d (body=%q)", rec.Code, http.StatusSeeOther, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != "/dashboard" {
+		t.Fatalf("Location = %q, want /dashboard", loc)
+	}
+}
+
+// TestHandleLoginSignedInWithoutRedirectKeepsLoginFlow pins that a bare
+// /login visit (no redirect target) does NOT short-circuit even when signed
+// in, so deliberately re-visiting login (e.g. to switch accounts) still works.
+func TestHandleLoginSignedInWithoutRedirectKeepsLoginFlow(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+	mkUser(t, "octocat")
+
+	req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login", nil)
+	req.AddCookie(testAuthCookie("octocat"))
+	rec := httptest.NewRecorder()
+	s.handleLogin(rec, req)
+
+	if rec.Code == http.StatusSeeOther {
+		t.Fatalf("bare /login short-circuited to %q — must keep the normal login flow", rec.Header().Get("Location"))
+	}
+}
+
+// TestHandleLoginAnonymousWithRedirectKeepsLoginFlow pins that the
+// short-circuit requires a VERIFIED session: an anonymous (or forged-cookie)
+// request with a redirect target still goes through the login flow.
+func TestHandleLoginAnonymousWithRedirectKeepsLoginFlow(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	s := newHandlerHub()
+
+	for _, c := range []*http.Cookie{nil, {Name: "hive_hub_user", Value: "forged"}} {
+		req := httptest.NewRequest(http.MethodGet, "https://hive.kubestellar.io/login?redirect=%2Fdashboard", nil)
+		if c != nil {
+			req.AddCookie(c)
+		}
+		rec := httptest.NewRecorder()
+		s.handleLogin(rec, req)
+		if rec.Code == http.StatusSeeOther && rec.Header().Get("Location") == "/dashboard" {
+			t.Fatalf("unauthenticated /login?redirect= short-circuited to the target — session verification is not being enforced")
+		}
+	}
+}


### PR DESCRIPTION
A signed-in hub user bounced to `/login?redirect=…` (spoke auth-signin, hosted spoke sign-in button) was shown the provider picker and forced through OAuth again — observed live after the canonical-host cutover when clicking spokes from the hub.

**Fix:** `handleLogin` now tries every presented `hive_hub_user` cookie via `verifyHubUserCookie` first; with a valid session **and** a redirect target it 303s straight to the target (already validated by `loginRedirectTarget`/`isTrustedRedirectTarget` — no new open-redirect surface). Bare `/login` keeps the existing flow so account switching is unaffected.

**Tests:** new `oauth_login_shortcircuit_test.go` pins: signed-in+redirect → 303; signed-in bare /login → no short-circuit; anonymous/forged cookie → no short-circuit. Full `pkg/hub` suite green.