### PR TITLE
🐛 fix(harness): classify provider API errors and back off instead of re-prompting

### DIFF
--- a/changelog.d/fixed-5915-provider-error-backoff.md
+++ b/changelog.d/fixed-5915-provider-error-backoff.md
@@ -1,0 +1,1 @@
+- Inference-backed agents now classify provider API failures before the anti-narration watchdog fires, back off retries, and show the blocked inference error in the dashboard instead of looping on “execute it yourself” nudges ([#5915](https://github.com/hivecommons/hive/issues/5915)).

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -6277,6 +6277,22 @@ func runEvalCycle(
 	// only `agentsDue` earlier would still let a CEL match or a review kick fire
 	// into the same clipped key.
 	//
+	if len(messages) > 0 {
+		filtered := messages[:0]
+		for _, msg := range messages {
+			if remaining, class, line, ok := agentMgr.ProviderErrorBackoffRemaining(msg.Agent); ok {
+				logger.Warn("provider inference error: withholding agent kick during backoff",
+					"agent", msg.Agent,
+					"class", class,
+					"retry_in", remaining.Round(time.Second),
+					"error", line)
+				continue
+			}
+			filtered = append(filtered, msg)
+		}
+		messages = filtered
+	}
+
 	// Suppression is total rather than per-agent because the limit is on the
 	// KEY: no agent can succeed while it is clipped. It self-heals — the first
 	// inference call that succeeds after the provider's window resets clears the
@@ -6296,16 +6312,16 @@ func runEvalCycle(
 	// re-arms suppression immediately, so the cycles while the probe's run
 	// is still in flight withhold again rather than leaking more kicks.
 	kickGate := gateKickMessagesForProviderBudget(messages, suppressKicks, providerBudgetLatched)
+	releaseProviderBudgetProbe := kickGate.ReleaseProbe
 	if suppressKicks && len(messages) > 0 {
 		logger.Warn("provider spending limit: withholding agent kicks",
 			"withheld", kickGate.Withheld, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince,
 			"next_probe_in", (providerBudgetProbeInterval - time.Since(providerBudgetProbe.freshest(providerBudgetLastRebuff))).Truncate(time.Second))
-	} else if kickGate.ReleaseProbe {
+	} else if releaseProviderBudgetProbe {
 		if len(kickGate.Withheld) > 0 {
 			logger.Warn("provider spending limit: withholding all but the probe kick",
 				"withheld", kickGate.Withheld, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince)
 		}
-		providerBudgetProbe.markReleased(time.Now())
 		logger.Info("provider spending limit: releasing a single probe kick",
 			"probe_agent", kickGate.Kept[0].Agent, "rebuffs", providerBudgetRebuffs, "since", providerBudgetSince,
 			"last_rebuff", providerBudgetLastRebuff, "probe_interval", providerBudgetProbeInterval)
@@ -6318,6 +6334,14 @@ func runEvalCycle(
 	var deliveredReviewKicks []review.DispatchKick
 	if len(messages) > 0 {
 		for _, msg := range messages {
+			if remaining, class, line, ok := agentMgr.ProviderErrorBackoffRemaining(msg.Agent); ok {
+				logger.Warn("provider inference error: withholding agent kick during backoff",
+					"agent", msg.Agent,
+					"class", class,
+					"retry_in", remaining.Round(time.Second),
+					"error", line)
+				continue
+			}
 			agentCfg := cfg.Agents[msg.Agent]
 			_, kickSpan := tracing.StartSpan(ctx, "agent.kick", tracing.AgentKickAttributes(
 				msg.Agent,
@@ -6339,6 +6363,10 @@ func runEvalCycle(
 				persistReviewDispatchState(reviewPlan, deliveredReviewKicks, logger)
 			}
 			kickSpan.End()
+			if releaseProviderBudgetProbe {
+				providerBudgetProbe.markReleased(time.Now())
+				releaseProviderBudgetProbe = false
+			}
 			gov.RecordKick(msg.Agent)
 			dashSrv.AuditLog("governor", "kick", "trigger=governor-eval", msg.Agent)
 

--- a/src/docs/env-vars.md
+++ b/src/docs/env-vars.md
@@ -163,6 +163,8 @@ new value at the same time.
 | `CODEX_API_KEY` | No | none | API key consulted for the Codex CLI backend. |
 | `HIVE_AGENT_TOKEN_REFRESH_INTERVAL` | No | `40m` | Go duration overriding the per-agent token refresh interval. Invalid or non-positive values fall back to the default. |
 | `HIVE_CREDENTIAL_WATCHDOG_INTERVAL` | No | `5m` | Go duration overriding how often the credential watchdog verifies each in-use backend credential file. `0` does NOT disable the watchdog — disabling is intentionally not offered. |
+| `HIVE_PROVIDER_ERROR_BACKOFF_BASE` | No | `2m` | Go duration for the first inference-provider error backoff before another kick is allowed. Invalid or non-positive values fall back to the default. |
+| `HIVE_PROVIDER_ERROR_BACKOFF_MAX` | No | `30m` | Go duration cap for exponential inference-provider error backoff. Invalid or non-positive values fall back to the default. |
 | `HIVE_COPILOT_SESSION_REFRESH_INTERVAL` | No | `10m` | Go duration overriding the Copilot session refresh interval. |
 | `HIVE_COPILOT_SESSION_REFRESH_START_DELAY` | No | `30s` | Go duration overriding the delay before the first Copilot session refresh. |
 | `HIVE_CLAUDE_DANGEROUSLY_ALLOW_HOST_STATE` | No | unset | Bypasses the Claude host-state isolation guard. As the name says, unsafe outside local development. |

--- a/src/pkg/agent/kick_async.go
+++ b/src/pkg/agent/kick_async.go
@@ -176,6 +176,12 @@ func (m *Manager) SendKickAsync(name string, message string) (started bool, err 
 		m.mu.Unlock()
 		return false, fmt.Errorf("agent %s cannot be kicked: %s", name, notRunningReason(agent))
 	}
+	if remaining := m.providerErrorBackoffRemainingLocked(agent, time.Now()); remaining > 0 {
+		class, line := agent.ProviderErrorClass, agent.ProviderErrorLine
+		m.mu.Unlock()
+		return false, fmt.Errorf("agent %s blocked: inference (%s): %s; next provider probe in %v",
+			name, class, line, remaining.Round(time.Second))
+	}
 
 	if !m.tmuxSessionExistsForAgent(agent) {
 		session := agent.tmuxSession
@@ -224,6 +230,12 @@ func (m *Manager) deliverKickAsync(name, message string) error {
 		m.mu.Unlock()
 		return fmt.Errorf("agent %s cannot be kicked: %s", name, reason)
 	}
+	if remaining := m.providerErrorBackoffRemainingLocked(agent, time.Now()); remaining > 0 {
+		class, line := agent.ProviderErrorClass, agent.ProviderErrorLine
+		m.mu.Unlock()
+		return fmt.Errorf("agent %s blocked: inference (%s): %s; next provider probe in %v",
+			name, class, line, remaining.Round(time.Second))
+	}
 
 	// Detect a crashed CLI (bare shell) or a CLI stuck on a consent screen and
 	// restart before sending — identical to SendKick's recovery. A consent pane
@@ -268,6 +280,10 @@ func (m *Manager) deliverKickAsync(name, message string) error {
 	agent, ok = m.agents[name]
 	if !ok {
 		return fmt.Errorf("agent %s disappeared while waiting for input prompt", name)
+	}
+	if remaining := m.providerErrorBackoffRemainingLocked(agent, time.Now()); remaining > 0 {
+		return fmt.Errorf("agent %s blocked: inference (%s): %s; next provider probe in %v",
+			name, agent.ProviderErrorClass, agent.ProviderErrorLine, remaining.Round(time.Second))
 	}
 	m.deliverKickLocked(agent, message, "send-kick")
 	return nil

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -303,23 +303,28 @@ type AgentProcess struct {
 	// authenticated CLI sits there producing nothing. Written under paneMu by
 	// pollTmuxOutputForAgent alongside lastPaneCapture; zero until the poller
 	// has seen two differing captures, which reads as "unknown", never "idle".
-	LastPaneChange     time.Time
-	consentSeenAt      time.Time // watcher: when a consent screen was first seen in the pane
-	lastConsentDismiss time.Time // watcher: cooldown for re-running dismissInferencePrompts
-	lastInferKickAt    time.Time // stall watchdog: when the last kick was delivered to an inference agent
-	lastInferKickPane  string    // stall watchdog: hash of the visible pane just after kick delivery
-	stallNudgeSent     bool      // stall watchdog: at most one nudge per kick
-	StallNudges        int       // total post-kick stall nudges sent (surfaced to the dashboard)
+	LastPaneChange       time.Time
+	consentSeenAt        time.Time // watcher: when a consent screen was first seen in the pane
+	lastConsentDismiss   time.Time // watcher: cooldown for re-running dismissInferencePrompts
+	lastInferKickAt      time.Time // stall watchdog: when the last kick was delivered to an inference agent
+	lastInferKickPane    string    // stall watchdog: hash of the visible pane just after kick delivery
+	lastInferKickVisible string    // stall watchdog: visible pane text just after kick delivery
+	stallNudgeSent       bool      // stall watchdog: at most one nudge per kick
+	StallNudges          int       // total post-kick stall nudges sent (surfaced to the dashboard)
 	// Transient API-error recovery (#4697), for CLI backends. lastTransientNudge
 	// is the cooldown anchor — the poller runs every 3s and the error text stays
 	// on screen after the nudge is typed, so without it one incident would fire
 	// a nudge per tick. transientNudgesThisKick is the per-kick cap; both it and
 	// the cooldown reset on the next kick.
-	lastTransientNudge      time.Time
-	transientNudgesThisKick int
-	TransientNudges         int // total transient-API-error nudges sent (surfaced to the dashboard)
-	launchGen               int // increments per launch; stale deliverStartupKick goroutines check it and drop
-	lastInferKickMarks      int // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
+	lastTransientNudge          time.Time
+	transientNudgesThisKick     int
+	TransientNudges             int // total transient-API-error nudges sent (surfaced to the dashboard)
+	launchGen                   int // increments per launch; stale deliverStartupKick goroutines check it and drop
+	lastInferKickMarks          int // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
+	ProviderErrorClass          string
+	ProviderErrorLine           string
+	ProviderErrorBackoffUntil   time.Time
+	providerErrorBackoffAttempt int
 	// kickLogPending is true while the current tmux session holds kick output
 	// that has not yet been archived to a per-kick log file (see
 	// kick_logs.go). Set after every kick delivery; cleared when the
@@ -845,6 +850,7 @@ func (m *Manager) linearEnvPairs(agent *AgentProcess) []agentEnvPair {
 	if !m.agentMode(agent).CanCreateIssues() {
 		return nil
 	}
+
 	cred := m.linearCredential()
 	switch {
 	case cred.AccessToken != "":
@@ -4730,6 +4736,10 @@ func (m *Manager) SendKick(name string, message string) error {
 	if agent.State != StateRunning {
 		return fmt.Errorf("agent %s cannot be kicked: %s", name, notRunningReason(agent))
 	}
+	if remaining := m.providerErrorBackoffRemainingLocked(agent, time.Now()); remaining > 0 {
+		return fmt.Errorf("agent %s blocked: inference (%s): %s; next provider probe in %v",
+			name, agent.ProviderErrorClass, agent.ProviderErrorLine, remaining.Round(time.Second))
+	}
 
 	if !m.tmuxSessionExistsForAgent(agent) {
 		return fmt.Errorf("tmux session %s not found", agent.tmuxSession)
@@ -4779,6 +4789,10 @@ func (m *Manager) SendKick(name string, message string) error {
 	agent, ok = m.agents[name]
 	if !ok {
 		return fmt.Errorf("agent %s disappeared while waiting for input prompt", name)
+	}
+	if remaining := m.providerErrorBackoffRemainingLocked(agent, time.Now()); remaining > 0 {
+		return fmt.Errorf("agent %s blocked: inference (%s): %s; next provider probe in %v",
+			name, agent.ProviderErrorClass, agent.ProviderErrorLine, remaining.Round(time.Second))
 	}
 
 	m.deliverKickLocked(agent, message, "send-kick")
@@ -5567,6 +5581,18 @@ const (
 	// working agent. Sized to cover the error block plus the idle prompt under
 	// it without reaching back into the previous response.
 	transientAPIErrorTailLines = 12
+	// providerErrorBackoffBaseDefault is the first delay after an inference
+	// provider failure. A repeat of the same request cannot fix bad DNS, auth,
+	// quota, rate-limit, or overloaded-backend errors, so the hive backs off
+	// instead of typing anti-narration nudges into the failure.
+	providerErrorBackoffBaseDefault = 2 * time.Minute
+	// providerErrorBackoffMaxDefault caps the exponential provider-error
+	// backoff so one broken backend still gets periodic probe kicks.
+	providerErrorBackoffMaxDefault = 30 * time.Minute
+	// ProviderErrorBackoffBaseEnv overrides providerErrorBackoffBaseDefault.
+	ProviderErrorBackoffBaseEnv = "HIVE_PROVIDER_ERROR_BACKOFF_BASE"
+	// ProviderErrorBackoffMaxEnv overrides providerErrorBackoffMaxDefault.
+	ProviderErrorBackoffMaxEnv = "HIVE_PROVIDER_ERROR_BACKOFF_MAX"
 	// cliInputPromptMarker is the CLI's idle input prompt indicator.
 	cliInputPromptMarker = "❯"
 	// inferenceActionNudgeGrace is the minimum time after a kick before the
@@ -5705,17 +5731,90 @@ func paneContentHash(pane string) string {
 	return fmt.Sprintf("%016x", h.Sum64())
 }
 
+func paneAfterKickBaseline(pane, baseline string) string {
+	if baseline == "" {
+		return pane
+	}
+	if idx := strings.LastIndex(pane, baseline); idx >= 0 {
+		return pane[idx+len(baseline):]
+	}
+	paneLines := strings.Split(pane, "\n")
+	baseLines := strings.Split(baseline, "\n")
+	common := 0
+	for common < len(paneLines) && common < len(baseLines) && paneLines[common] == baseLines[common] {
+		common++
+	}
+	if common > 0 {
+		return strings.Join(paneLines[common:], "\n")
+	}
+	return pane
+}
+
 // recordInferenceKick arms the post-kick stall watchdog for an inference
 // agent: remembers when the kick was delivered and what the pane looked like
 // right after delivery. Caller must hold m.mu.
 func (m *Manager) recordInferenceKick(agent *AgentProcess, at time.Time) {
+	visible := m.captureVisiblePaneForAgent(agent)
 	agent.lastInferKickAt = at
-	agent.lastInferKickPane = paneContentHash(m.captureVisiblePaneForAgent(agent))
+	agent.lastInferKickPane = paneContentHash(visible)
+	agent.lastInferKickVisible = visible
 	agent.stallNudgeSent = false
 	// Baseline for the no-action check: markers already in scrollback from
 	// work done before this kick must not count as post-kick tool activity.
 	agent.lastInferKickMarks = countToolMarkers(m.captureTmuxPaneForAgent(agent))
 	agent.actionNudgeSent = false
+}
+
+func (m *Manager) markProviderErrorLocked(agent *AgentProcess, match providerErrorMatch, now time.Time) time.Duration {
+	if !agent.ProviderErrorBackoffUntil.IsZero() && now.Before(agent.ProviderErrorBackoffUntil) &&
+		agent.ProviderErrorClass == match.Class && agent.ProviderErrorLine == match.Line {
+		return agent.ProviderErrorBackoffUntil.Sub(now)
+	}
+	agent.providerErrorBackoffAttempt++
+	delay := providerErrorBackoffDelay(agent.providerErrorBackoffAttempt)
+	agent.ProviderErrorBackoffUntil = now.Add(delay)
+	agent.ProviderErrorClass = match.Class
+	agent.ProviderErrorLine = match.Line
+	agent.LastError = match.Line
+	agent.lastInferKickPane = ""
+	agent.actionNudgeSent = false
+	return delay
+}
+
+func (m *Manager) clearProviderErrorLocked(agent *AgentProcess) {
+	if agent.ProviderErrorClass == "" && agent.ProviderErrorLine == "" && agent.ProviderErrorBackoffUntil.IsZero() {
+		return
+	}
+	if agent.LastError == agent.ProviderErrorLine {
+		agent.LastError = ""
+	}
+	agent.ProviderErrorClass = ""
+	agent.ProviderErrorLine = ""
+	agent.ProviderErrorBackoffUntil = time.Time{}
+	agent.providerErrorBackoffAttempt = 0
+}
+
+func (m *Manager) providerErrorBackoffRemainingLocked(agent *AgentProcess, now time.Time) time.Duration {
+	if agent == nil || agent.ProviderErrorBackoffUntil.IsZero() || !now.Before(agent.ProviderErrorBackoffUntil) {
+		return 0
+	}
+	return agent.ProviderErrorBackoffUntil.Sub(now)
+}
+
+// ProviderErrorBackoffRemaining reports the active inference-provider backoff
+// for a dashboard/governor caller that wants to avoid even attempting a kick.
+func (m *Manager) ProviderErrorBackoffRemaining(name string) (time.Duration, string, string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	agent, ok := m.agents[name]
+	if !ok {
+		return 0, "", "", false
+	}
+	remaining := m.providerErrorBackoffRemainingLocked(agent, time.Now())
+	if remaining <= 0 {
+		return 0, agent.ProviderErrorClass, agent.ProviderErrorLine, false
+	}
+	return remaining, agent.ProviderErrorClass, agent.ProviderErrorLine, true
 }
 
 // nudgeIfKickStalled watches an inference agent after a kick and corrects
@@ -5746,6 +5845,20 @@ func (m *Manager) nudgeIfKickStalled(name, pane string) {
 		return
 	}
 	sinceKick := now.Sub(agent.lastInferKickAt)
+	if match, ok := classifyProviderError(paneAfterKickBaseline(pane, agent.lastInferKickVisible)); ok {
+		backoff := m.markProviderErrorLocked(agent, match, now)
+		attempt := agent.providerErrorBackoffAttempt
+		m.mu.Unlock()
+
+		m.logger.Warn("inference provider error detected, backing off kicks instead of sending action nudge",
+			"name", name,
+			"class", match.Class,
+			"attempt", attempt,
+			"backoff", backoff.Round(time.Second),
+			"error", match.Line)
+		return
+	}
+	m.clearProviderErrorLocked(agent)
 
 	if paneContentHash(pane) == agent.lastInferKickPane {
 		// Frozen pane: the CLI never consumed the kick.
@@ -6064,40 +6177,43 @@ func (a *AgentProcess) snapshot() AgentProcess {
 	copy(conds, a.WatchdogConditions)
 	a.paneMu.RUnlock()
 	return AgentProcess{
-		Name:               a.Name,
-		ID:                 a.ID,
-		Config:             a.Config,
-		State:              a.State,
-		PID:                a.PID,
-		UID:                a.UID,
-		StartedAt:          a.StartedAt,
-		LastKick:           a.LastKick,
-		Paused:             a.Paused,
-		PausedAt:           a.PausedAt,
-		PausedReason:       a.PausedReason,
-		PausedTrigger:      a.PausedTrigger,
-		PausedBy:           a.PausedBy,
-		PinnedCLI:          a.PinnedCLI,
-		PinnedModel:        a.PinnedModel,
-		ModelOverride:      a.ModelOverride,
-		BackendOverride:    a.BackendOverride,
-		RestartCount:       a.RestartCount,
-		TurnLoss:           cloneTurnLoss(a.TurnLoss),
-		KickHistory:        history,
-		LastKickMessage:    a.LastKickMessage,
-		NeedsLogin:         needsLogin,
-		QuotaExhausted:     quotaExhausted,
-		LastPaneChange:     lastPaneChange,
-		WatchdogConditions: conds,
-		StallNudges:        a.StallNudges,
-		ActionNudges:       a.ActionNudges,
-		TransientNudges:    a.TransientNudges,
-		HasLaunched:        a.HasLaunched,
-		LaunchedMode:       a.LaunchedMode,
-		tmuxSession:        a.tmuxSession,
-		tmuxSocket:         a.tmuxSocket,
-		OutputBuffer:       a.OutputBuffer,
-		lastPaneCapture:    pane,
+		Name:                      a.Name,
+		ID:                        a.ID,
+		Config:                    a.Config,
+		State:                     a.State,
+		PID:                       a.PID,
+		UID:                       a.UID,
+		StartedAt:                 a.StartedAt,
+		LastKick:                  a.LastKick,
+		Paused:                    a.Paused,
+		PausedAt:                  a.PausedAt,
+		PausedReason:              a.PausedReason,
+		PausedTrigger:             a.PausedTrigger,
+		PausedBy:                  a.PausedBy,
+		PinnedCLI:                 a.PinnedCLI,
+		PinnedModel:               a.PinnedModel,
+		ModelOverride:             a.ModelOverride,
+		BackendOverride:           a.BackendOverride,
+		RestartCount:              a.RestartCount,
+		TurnLoss:                  cloneTurnLoss(a.TurnLoss),
+		KickHistory:               history,
+		LastKickMessage:           a.LastKickMessage,
+		NeedsLogin:                needsLogin,
+		QuotaExhausted:            quotaExhausted,
+		LastPaneChange:            lastPaneChange,
+		WatchdogConditions:        conds,
+		StallNudges:               a.StallNudges,
+		ActionNudges:              a.ActionNudges,
+		TransientNudges:           a.TransientNudges,
+		ProviderErrorClass:        a.ProviderErrorClass,
+		ProviderErrorLine:         a.ProviderErrorLine,
+		ProviderErrorBackoffUntil: a.ProviderErrorBackoffUntil,
+		HasLaunched:               a.HasLaunched,
+		LaunchedMode:              a.LaunchedMode,
+		tmuxSession:               a.tmuxSession,
+		tmuxSocket:                a.tmuxSocket,
+		OutputBuffer:              a.OutputBuffer,
+		lastPaneCapture:           pane,
 	}
 }
 
@@ -6558,6 +6674,111 @@ func paneShowsTransientAPIError(lines []string) bool {
 		}
 	}
 	return false
+}
+
+type providerErrorMatch struct {
+	Class string
+	Line  string
+}
+
+var (
+	providerAPIErrorStatusRe = regexp.MustCompile(`(?i)\bAPI Error:\s*(\d{3})\b`)
+	providerRetryingRe       = regexp.MustCompile(`(?i)\bRetrying in \d+s\s+·\s+attempt \d+/\d+\b`)
+	providerHTTPStatusRe     = regexp.MustCompile(`\b(401|403|429|500|502|503|529)\b`)
+)
+
+func providerErrorBackoffBase() time.Duration {
+	if v := os.Getenv(ProviderErrorBackoffBaseEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return providerErrorBackoffBaseDefault
+}
+
+func providerErrorBackoffMax() time.Duration {
+	if v := os.Getenv(ProviderErrorBackoffMaxEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return providerErrorBackoffMaxDefault
+}
+
+func providerErrorBackoffDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	base := providerErrorBackoffBase()
+	maxDelay := providerErrorBackoffMax()
+	delay := base
+	for i := 1; i < attempt && delay < maxDelay; i++ {
+		delay *= 2
+		if delay > maxDelay {
+			return maxDelay
+		}
+	}
+	return delay
+}
+
+// classifyProviderError recognizes provider/API failures rendered by agent
+// CLIs. These are infrastructure failures, not model narration, so callers use
+// the verdict to block and back off instead of sending action nudges.
+func classifyProviderError(pane string) (providerErrorMatch, bool) {
+	for _, line := range strings.Split(stripExplainLines(pane), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		switch {
+		case strings.Contains(lower, "insufficient_quota"):
+			return providerErrorMatch{Class: "quota", Line: trimmed}, true
+		case strings.Contains(lower, "rate_limit") ||
+			((strings.Contains(lower, "rate limit") || strings.Contains(lower, "too many requests")) && providerLineHasAPIContext(lower)):
+			return providerErrorMatch{Class: "rate_limit", Line: trimmed}, true
+		case strings.Contains(lower, "overloaded_error") ||
+			(strings.Contains(lower, "overloaded") && providerLineHasAPIContext(lower)):
+			return providerErrorMatch{Class: "overloaded", Line: trimmed}, true
+		case strings.Contains(lower, `"type":"api_error"`) || strings.Contains(lower, `"type": "api_error"`) ||
+			strings.Contains(lower, "inference backend unreachable"):
+			return providerErrorMatch{Class: "api_error", Line: trimmed}, true
+		case providerRetryingRe.MatchString(trimmed):
+			return providerErrorMatch{Class: "retrying", Line: trimmed}, true
+		}
+		if m := providerAPIErrorStatusRe.FindStringSubmatch(trimmed); len(m) == 2 {
+			return providerErrorMatch{Class: providerErrorStatusClass(m[1]), Line: trimmed}, true
+		}
+		if providerLineHasAPIContext(lower) {
+			if m := providerHTTPStatusRe.FindStringSubmatch(trimmed); len(m) == 2 {
+				return providerErrorMatch{Class: providerErrorStatusClass(m[1]), Line: trimmed}, true
+			}
+		}
+	}
+	return providerErrorMatch{}, false
+}
+
+func providerLineHasAPIContext(lower string) bool {
+	return strings.Contains(lower, "api error") ||
+		strings.Contains(lower, "api_error") ||
+		strings.Contains(lower, "inference") ||
+		strings.Contains(lower, "backend") ||
+		strings.Contains(lower, "quota") ||
+		strings.Contains(lower, "unauthorized") ||
+		strings.Contains(lower, "forbidden")
+}
+
+func providerErrorStatusClass(status string) string {
+	switch status {
+	case "401", "403":
+		return "auth"
+	case "429":
+		return "rate_limit"
+	case "529":
+		return "overloaded"
+	default:
+		return "api_error"
+	}
 }
 
 // claudeCredentialReachable reports whether a usable Claude credential exists

--- a/src/pkg/agent/provider_error_test.go
+++ b/src/pkg/agent/provider_error_test.go
@@ -1,0 +1,162 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+func TestClassifyProviderError(t *testing.T) {
+	cases := []struct {
+		name      string
+		pane      string
+		wantClass string
+		want      bool
+	}{
+		{
+			name:      "issue 502 unreachable",
+			pane:      `API Error: 502 {"type":"error","error":{"type":"api_error","message":"inference backend unreachable: Post \"https://example.invalid/v1/chat/completions\": dial tcp: lookup example.invalid: no such host"}}`,
+			wantClass: "api_error",
+			want:      true,
+		},
+		{
+			name:      "claude retry countdown",
+			pane:      `502 {"type":"error"} · Retrying in 14s · attempt 6/10`,
+			wantClass: "retrying",
+			want:      true,
+		},
+		{
+			name:      "rate limit json",
+			pane:      `API Error: 429 {"error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
+			wantClass: "rate_limit",
+			want:      true,
+		},
+		{
+			name:      "auth 401",
+			pane:      `API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`,
+			wantClass: "auth",
+			want:      true,
+		},
+		{
+			name:      "auth 403",
+			pane:      `API Error: 403 {"type":"error","error":{"message":"team not allowed to access model"}}`,
+			wantClass: "auth",
+			want:      true,
+		},
+		{
+			name:      "quota",
+			pane:      `Provider returned {"error":{"type":"insufficient_quota","message":"quota exhausted"}}`,
+			wantClass: "quota",
+			want:      true,
+		},
+		{
+			name: "normal prose",
+			pane: "I inspected the repository and will run the tests next.",
+			want: false,
+		},
+		{
+			name: "plan without tool calls",
+			pane: "Plan:\n1. Inspect the code.\n2. Add tests.\n3. Open a PR.",
+			want: false,
+		},
+		{
+			name: "tool result mentioning error identifier in code",
+			pane: "⎿  const err = errors.New(\"provider returned error\")\n❯ ",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := classifyProviderError(tc.pane)
+			if ok != tc.want {
+				t.Fatalf("classifyProviderError ok=%v, want %v (match=%+v)", ok, tc.want, got)
+			}
+			if tc.want && got.Class != tc.wantClass {
+				t.Fatalf("classifyProviderError class=%q, want %q", got.Class, tc.wantClass)
+			}
+			if tc.want && !strings.Contains(tc.pane, got.Line) {
+				t.Fatalf("error line %q was not captured from pane %q", got.Line, tc.pane)
+			}
+		})
+	}
+}
+
+func TestNudgeIfKickStalled_ProviderErrorBacksOffInsteadOfActionNudge(t *testing.T) {
+	t.Setenv(ProviderErrorBackoffBaseEnv, "1s")
+	t.Setenv(ProviderErrorBackoffMaxEnv, "4s")
+	m := NewManager(map[string]config.AgentConfig{
+		"vinf": {Backend: "vllm"},
+	}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["vinf"]
+	m.mu.RUnlock()
+
+	pane := "❯ [agent:quality] work\n" +
+		`API Error: 502 {"type":"error","error":{"type":"api_error","message":"inference backend unreachable"}}` + "\n" +
+		"✻ Worked for 3m 2s\n" +
+		"❯ "
+	agent.State = StateRunning
+	agent.lastInferKickAt = time.Now().Add(-inferenceActionNudgeGrace - time.Minute)
+	agent.lastInferKickPane = paneContentHash("pane at kick")
+	agent.lastInferKickMarks = 0
+
+	m.nudgeIfKickStalled("vinf", pane)
+	if agent.ActionNudges != 0 {
+		t.Fatalf("provider error must not count as action nudge, got %d", agent.ActionNudges)
+	}
+	if agent.ProviderErrorClass != "api_error" {
+		t.Fatalf("ProviderErrorClass = %q, want api_error", agent.ProviderErrorClass)
+	}
+	if agent.LastError == "" || !strings.Contains(agent.LastError, "API Error: 502") {
+		t.Fatalf("LastError = %q, want surfaced provider error line", agent.LastError)
+	}
+	if remaining, class, _, ok := m.ProviderErrorBackoffRemaining("vinf"); !ok || class != "api_error" || remaining <= 0 {
+		t.Fatalf("ProviderErrorBackoffRemaining = (%v, %q, ok=%v), want active api_error", remaining, class, ok)
+	}
+	if err := m.SendKick("vinf", "retry now"); err == nil || !strings.Contains(err.Error(), "blocked: inference (api_error)") {
+		t.Fatalf("SendKick during backoff error = %v, want blocked inference", err)
+	}
+}
+
+func TestNudgeIfKickStalled_IgnoresProviderErrorBeforeKickBaseline(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"vinf": {Backend: "vllm"},
+	}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["vinf"]
+	m.mu.RUnlock()
+
+	stale := `API Error: 502 {"type":"error","error":{"type":"api_error","message":"old outage"}}`
+	baseline := stale + "\n❯ [agent:quality] retry after backoff"
+	pane := baseline + "\n⏺ I will inspect the repository and then run tests.\n✻ Worked for 26s\n❯ "
+	agent.State = StateRunning
+	agent.lastInferKickAt = time.Now().Add(-inferenceActionNudgeGrace - time.Minute)
+	agent.lastInferKickPane = paneContentHash(baseline)
+	agent.lastInferKickVisible = baseline
+	agent.lastInferKickMarks = 0
+
+	m.nudgeIfKickStalled("vinf", pane)
+	if agent.ProviderErrorClass != "" {
+		t.Fatalf("stale provider error re-armed backoff: class=%q line=%q", agent.ProviderErrorClass, agent.ProviderErrorLine)
+	}
+	if agent.ActionNudges != 1 {
+		t.Fatalf("current prose-only response should still get action nudge, got %d", agent.ActionNudges)
+	}
+}
+
+func TestProviderErrorBackoffDelayUsesEnvAndCaps(t *testing.T) {
+	t.Setenv(ProviderErrorBackoffBaseEnv, "2s")
+	t.Setenv(ProviderErrorBackoffMaxEnv, "5s")
+	if got := providerErrorBackoffDelay(1); got != 2*time.Second {
+		t.Fatalf("attempt 1 delay = %v, want 2s", got)
+	}
+	if got := providerErrorBackoffDelay(2); got != 4*time.Second {
+		t.Fatalf("attempt 2 delay = %v, want 4s", got)
+	}
+	if got := providerErrorBackoffDelay(3); got != 5*time.Second {
+		t.Fatalf("attempt 3 delay = %v, want capped 5s", got)
+	}
+}

--- a/src/pkg/agent/watchdog_fleet.go
+++ b/src/pkg/agent/watchdog_fleet.go
@@ -121,23 +121,31 @@ func (f WatchdogFleet) Observe(name string) (watchdog.Observation, error) {
 	// verdicts during boot. Copied by value: the field is a pointer the
 	// manager mutates on relaunch.
 	var startedAt time.Time
+	providerClass := ""
+	providerLine := ""
 	f.M.mu.RLock()
 	if agent.StartedAt != nil {
 		startedAt = *agent.StartedAt
 	}
+	if f.M.providerErrorBackoffRemainingLocked(agent, time.Now()) > 0 {
+		providerClass = agent.ProviderErrorClass
+		providerLine = agent.ProviderErrorLine
+	}
 	f.M.mu.RUnlock()
 
 	return watchdog.Observation{
-		Backend:          backend,
-		SessionExists:    sessionExists,
-		Pane:             pane,
-		HasCLIMarker:     paneHasCLIMarker(pane),
-		ShowsLoginPrompt: needsLogin || paneShowsLoginPrompt(strings.Split(pane, "\n")),
-		LastChange:       lastChange,
-		StartedAt:        startedAt,
-		AuthAvailable:    authAvailable,
-		AuthKnown:        authKnown,
-		CredentialProven: credentialProven,
+		Backend:            backend,
+		SessionExists:      sessionExists,
+		Pane:               pane,
+		HasCLIMarker:       paneHasCLIMarker(pane),
+		ShowsLoginPrompt:   needsLogin || paneShowsLoginPrompt(strings.Split(pane, "\n")),
+		LastChange:         lastChange,
+		StartedAt:          startedAt,
+		AuthAvailable:      authAvailable,
+		AuthKnown:          authKnown,
+		CredentialProven:   credentialProven,
+		ProviderErrorClass: providerClass,
+		ProviderErrorLine:  providerLine,
 	}, nil
 }
 

--- a/src/pkg/dashboard/status_builder.go
+++ b/src/pkg/dashboard/status_builder.go
@@ -675,6 +675,13 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			Conditions:      proc.WatchdogConditions,
 			WatchdogMode:    watchdogMode,
 		}
+		if proc.ProviderErrorClass != "" && time.Now().Before(proc.ProviderErrorBackoffUntil) {
+			a.StructuredStatus = "BLOCKED"
+			a.StatusEvidence = "blocked: inference (" + proc.ProviderErrorClass + ")"
+			if line := strings.TrimSpace(proc.ProviderErrorLine); line != "" {
+				a.StatusEvidence += ": " + line
+			}
+		}
 
 		acmmLevel := 0
 		if cfg.ACMMLevel != nil {

--- a/src/pkg/watchdog/classify.go
+++ b/src/pkg/watchdog/classify.go
@@ -85,6 +85,10 @@ type Observation struct {
 	// credential file there. That is the exact evidence this reconciler must
 	// not trust on its own when deciding whether to page a human.
 	CredentialProven bool
+	// ProviderErrorClass/Line carry an active inference-provider block from the
+	// agent manager. It is a producing/readiness fault, not a dead pane.
+	ProviderErrorClass string
+	ProviderErrorLine  string
 }
 
 // authScreenPatterns match credential screens the marker tables miss: the

--- a/src/pkg/watchdog/reconciler.go
+++ b/src/pkg/watchdog/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 )
@@ -472,7 +473,7 @@ func (r *Reconciler) reconcileAgent(ctx context.Context, name string, now time.T
 	r.mu.Unlock()
 
 	r.reconcileAuth(ctx, name, obs, cls, now, authCache)
-	r.reconcileReadiness(name, now)
+	r.reconcileReadiness(name, obs, now)
 
 	if act != nil {
 		act()
@@ -755,13 +756,20 @@ func (r *Reconciler) reconcileAuth(ctx context.Context, name string, obs Observa
 // evidence. A readiness failure alone NEVER pauses or restarts (design
 // decision on RFC open question 3): it publishes Producing=False and a
 // warning alert, degrading the agent's standing rather than its life.
-func (r *Reconciler) reconcileReadiness(name string, now time.Time) {
+func (r *Reconciler) reconcileReadiness(name string, obs Observation, now time.Time) {
 	settings := r.snapshotSettings()
 	last, ok := r.fleet.LastProduction(name)
 	status := ConditionUnknown
 	reason := "NoEvidence"
 	message := "no production evidence source is readable for this agent"
-	if ok {
+	if obs.ProviderErrorClass != "" {
+		status = ConditionFalse
+		reason = "ProviderInferenceError"
+		message = fmt.Sprintf("blocked: inference (%s)", obs.ProviderErrorClass)
+		if line := strings.TrimSpace(obs.ProviderErrorLine); line != "" {
+			message += ": " + line
+		}
+	} else if ok {
 		age := now.Sub(last)
 		switch {
 		case age < settings.NoProductionFor:

--- a/src/pkg/watchdog/reconciler_test.go
+++ b/src/pkg/watchdog/reconciler_test.go
@@ -797,6 +797,45 @@ func TestProducingRequiresQueuedWork(t *testing.T) {
 	})
 }
 
+func TestReadinessProviderErrorSurfacesBlockedInferenceLine(t *testing.T) {
+	clock := newFakeClock()
+	fleet := newFakeFleet("a1")
+	fleet.setQueued(3)
+	errLine := `API Error: 502 {"type":"error","error":{"type":"api_error","message":"inference backend unreachable"}}`
+	fleet.setObs("a1", Observation{
+		Backend:            "vllm",
+		SessionExists:      true,
+		Pane:               "❯",
+		HasCLIMarker:       true,
+		ProviderErrorClass: "api_error",
+		ProviderErrorLine:  errLine,
+	})
+	fleet.mu.Lock()
+	fleet.production["a1"] = clock.Now().Add(-time.Hour)
+	fleet.mu.Unlock()
+	alerter := newFakeAlerter()
+	r := newTestReconciler(t, Settings{Mode: ModeObserve, ProbeInterval: time.Millisecond, NoProductionFor: time.Minute}, fleet, alerter, clock)
+
+	r.Tick(context.Background())
+
+	cond, ok := FindCondition(fleet.conds["a1"], ConditionProducing)
+	if !ok {
+		t.Fatal("Producing condition missing")
+	}
+	if cond.Status != ConditionFalse || cond.Reason != "ProviderInferenceError" {
+		t.Fatalf("Producing condition = %+v, want ProviderInferenceError false", cond)
+	}
+	if !strings.Contains(cond.Message, "blocked: inference (api_error)") || !strings.Contains(cond.Message, errLine) {
+		t.Fatalf("condition message %q does not surface provider error", cond.Message)
+	}
+	alerter.mu.Lock()
+	alert := alerter.alerts[producingAlertID("a1")]
+	alerter.mu.Unlock()
+	if !strings.Contains(alert, "alive but not producing") || !strings.Contains(alert, errLine) {
+		t.Fatalf("alert %q does not surface provider error", alert)
+	}
+}
+
 // TestReconcileDoesNotSelfDeadlock is the regression guard for the observe-mode
 // self-deadlock: planRestartLocked runs with r.mu held, and a helper inside it
 // reached back for a locked settings snapshot, so the goroutine blocked forever


### PR DESCRIPTION
## Summary
- classify provider API failures before inference anti-narration nudges run
- block further kicks behind env-configurable exponential backoff and expose the last provider line to dashboard/watchdog status
- add classifier/backoff/watchdog tests plus changelog fragment

## Validation
- go test ./pkg/agent -run 'TestClassifyProviderError|TestNudgeIfKickStalled_ProviderError|TestNudgeIfKickStalled_IgnoresProviderError|TestProviderErrorBackoffDelay' -count=1\n- go test ./pkg/watchdog -run TestReadinessProviderErrorSurfacesBlockedInferenceLine -count=1\n- go test ./pkg/dashboard -run TestAgentPayloadCarriesWatchdogConditions -count=1\n- go test ./pkg/agent ./pkg/watchdog ./pkg/dashboard (fails on this macOS path because tmux socket path is too long in existing agent tests; focused tests above pass)\n- go test ./pkg/... (fails in existing pkg/config entrypoint chmod expectations on macOS; unrelated to this change)\n\nCloses #5915