### PR TITLE
🌱 refactor(github): drop the pkg/config dependency from the client (phase 1 of #5953)

### DIFF
--- a/src/pkg/github/automerge_sweep.go
+++ b/src/pkg/github/automerge_sweep.go
@@ -12,8 +12,13 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
-	"github.com/hivecommons/hive/pkg/config"
 )
+
+// selfMergeMinACMMLevel mirrors config.SelfMergeMinACMMLevel. It is duplicated
+// rather than imported so this package keeps no dependency on pkg/config
+// (hivecommons/hive#5953 phase 1); config_parity_test.go pins the two equal so
+// they cannot drift silently.
+const selfMergeMinACMMLevel = 6
 
 const DefaultAutoMergeSweepMaxMerges = 3
 
@@ -420,7 +425,7 @@ func (c *Client) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 			level = fmt.Sprintf("%d", *acmmLevel)
 		}
 		c.info("self-authored auto-merge sweep disabled: acmm_level below minimum (or auto_merge.self_authored is off)",
-			"acmm_level", level, "min_acmm_level", config.SelfMergeMinACMMLevel)
+			"acmm_level", level, "min_acmm_level", selfMergeMinACMMLevel)
 		return
 	}
 	interval := selfAuthoredSweepInterval(len(c.getRepos()))

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
-	"github.com/hivecommons/hive/pkg/config"
 	"github.com/hivecommons/hive/pkg/ioscan"
 	"github.com/hivecommons/hive/pkg/logscrub"
 )
@@ -52,7 +51,7 @@ type Client struct {
 	// re-applies it while the enumeration goroutine reads it. Zero value =
 	// admit everything (pre-existing behavior).
 	issueFilterMu sync.RWMutex
-	issueFilter   config.IssueFilterConfig
+	issueFilter   IssueAdmitter
 	// autoMergeLabel is the configured merger-queue label. Guarded because
 	// config reload re-applies it while request handlers read it.
 	autoMergeLabelMu sync.RWMutex
@@ -432,7 +431,7 @@ var PermanentExemptLabels = []string{"do-not-merge"}
 // applies when a hive has not configured `governor.labels.automerge`. Prefer
 // Client.AutoMergeLabel(), which honours that configuration; this constant
 // exists so a nil or unconfigured client still has a sane value.
-const AutoMergeQueuedLabel = config.DefaultAutoMergeLabel
+const AutoMergeQueuedLabel = "lgtm"
 
 const slaThresholdMinutes = 30
 
@@ -1153,7 +1152,7 @@ func (c *Client) SetExemptLabels(labels []string) {
 // safe for the same reason as SetRepos: the config-reload / heartbeat-delivery
 // paths re-apply it unconditionally, and a hive that booted without GitHub
 // credentials runs with a nil *Client.
-func (c *Client) SetIssueFilter(f config.IssueFilterConfig) {
+func (c *Client) SetIssueFilter(f IssueAdmitter) {
 	if c == nil {
 		return
 	}
@@ -1162,9 +1161,16 @@ func (c *Client) SetIssueFilter(f config.IssueFilterConfig) {
 	c.issueFilter = f
 }
 
-func (c *Client) getIssueFilter() config.IssueFilterConfig {
+// getIssueFilter never returns nil: an unset filter admits everything, which
+// is the zero-value contract the config struct had before this became an
+// interface. Returning nil here would turn "no filter configured" into a
+// panic at the one call site that consults it.
+func (c *Client) getIssueFilter() IssueAdmitter {
 	c.issueFilterMu.RLock()
 	defer c.issueFilterMu.RUnlock()
+	if c.issueFilter == nil {
+		return admitAllIssues{}
+	}
 	return c.issueFilter
 }
 

--- a/src/pkg/github/config_parity_test.go
+++ b/src/pkg/github/config_parity_test.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+// Phase 1 of kubestellar/hive#5953 removed this package's production
+// dependency on pkg/config. Two values had to be duplicated to do that. This
+// file is the only place pkg/config is still referenced here, and it exists to
+// make the duplication safe: if either definition moves, the build of this
+// test fails and the drift is caught at CI time rather than in behaviour.
+//
+// A test-only import does not reintroduce the coupling the issue is about —
+// production code in this package no longer pulls in the application config
+// surface, so importers of the client no longer do either.
+
+func TestAutoMergeQueuedLabelMatchesConfigDefault(t *testing.T) {
+	if AutoMergeQueuedLabel != config.DefaultAutoMergeLabel {
+		t.Fatalf("AutoMergeQueuedLabel = %q, config.DefaultAutoMergeLabel = %q — "+
+			"these name the same merger-queue label and must not drift",
+			AutoMergeQueuedLabel, config.DefaultAutoMergeLabel)
+	}
+}
+
+func TestSelfMergeMinACMMLevelMatchesConfig(t *testing.T) {
+	if selfMergeMinACMMLevel != config.SelfMergeMinACMMLevel {
+		t.Fatalf("selfMergeMinACMMLevel = %d, config.SelfMergeMinACMMLevel = %d — "+
+			"the sweep logs this as the authority for self-authored auto-merge; "+
+			"a mismatch would misreport the gate an operator is being held to",
+			selfMergeMinACMMLevel, config.SelfMergeMinACMMLevel)
+	}
+}
+
+// config.IssueFilterConfig must keep satisfying IssueAdmitter, because every
+// construction site passes it directly. If it stops, those sites break at the
+// call rather than here, which is a much less obvious failure.
+func TestIssueFilterConfigSatisfiesIssueAdmitter(t *testing.T) {
+	var _ IssueAdmitter = config.IssueFilterConfig{}
+}
+
+// An unset filter must admit everything: that was the zero-value behaviour of
+// the struct this interface replaced, and enumeration relies on it.
+func TestUnsetIssueFilterAdmitsEverything(t *testing.T) {
+	c := &Client{}
+	if got := c.getIssueFilter(); got == nil {
+		t.Fatal("getIssueFilter() returned nil; the enumeration path would panic")
+	}
+	if !c.getIssueFilter().Admits([]string{"anything"}) {
+		t.Fatal("an unset filter rejected a label; unset must admit everything")
+	}
+	if !c.getIssueFilter().Admits(nil) {
+		t.Fatal("an unset filter rejected an unlabelled issue")
+	}
+}

--- a/src/pkg/github/issue_admitter.go
+++ b/src/pkg/github/issue_admitter.go
@@ -1,0 +1,27 @@
+package github
+
+// IssueAdmitter decides whether an issue carrying the given labels is eligible
+// for agent work.
+//
+// This exists so the client can honour the operator's project.issue_filter
+// without importing pkg/config. The filter's semantics — exact,
+// case-insensitive matching, empty means admit everything, and "exclude wins"
+// being the caller's job — belong to the configuration layer that owns the
+// policy; the client only needs the verdict. config.IssueFilterConfig
+// satisfies this interface as-is, so construction sites keep passing it
+// unchanged (kubestellar/hive#5953, phase 1).
+//
+// Keeping the decision behind an interface rather than copying the matching
+// logic here is deliberate: this is an approval gate, and a second
+// implementation of it that drifted from the first would fail open.
+type IssueAdmitter interface {
+	// Admits reports whether an issue with these labels may be worked.
+	Admits(labels []string) bool
+}
+
+// admitAllIssues is the filter used when none has been installed. It preserves
+// the pre-existing zero-value behaviour of config.IssueFilterConfig, where an
+// unset filter admits every issue.
+type admitAllIssues struct{}
+
+func (admitAllIssues) Admits([]string) bool { return true }


### PR DESCRIPTION
## Summary

`pkg/github` is the package everything in hive uses to talk to GitHub — ten
packages import it. It also imported `pkg/config`, the application's 6,000-line
configuration file, which meant anything wanting an HTTP client dragged the
entire operator-configuration surface along with it, and inverted the natural
layering (configuration should depend on the client, not the other way round).

This removes that dependency. It is phase 1 of the four-phase split the issue
proposes, and the only phase that changes package boundaries; the policy
engines and watcher daemons stay where they are for now.

**No behaviour change**, and no call site changes: the seven places that
install an issue filter pass exactly what they passed before.

## Detail

The dependency was four references, not a deep entanglement:

| Reference | Use |
| --- | --- |
| `config.IssueFilterConfig` | type of `Client.issueFilter`; one method called, `Admits(labels)` |
| `config.DefaultAutoMergeLabel` | aliased by the `AutoMergeQueuedLabel` constant |
| `config.SelfMergeMinACMMLevel` | logged by the self-authored auto-merge sweep |

Everything else the issue counts is prose in comments naming `config.RoleMerger`
and `config.AutoMergeConfig`; those are references to concepts, not imports.

### The filter becomes a one-method interface

`IssueAdmitter` is declared here and asks the only question the client actually
has: may an issue carrying these labels be worked?

```go
type IssueAdmitter interface {
	Admits(labels []string) bool
}
```

`config.IssueFilterConfig` already satisfies it, so `SetIssueFilter` keeps
taking the same values and **all seven construction sites are untouched**
(`cmd/hive/main.go` ×6, `pkg/dashboard/api.go` ×1).

The matching logic is deliberately *not* copied into this package. It is an
approval gate with exact, case-insensitive semantics, and a second
implementation of it that drifted from the first would fail **open** — the
unsafe direction. The policy stays with the configuration layer that owns it;
the client only consumes the verdict.

`getIssueFilter()` now never returns nil. The zero value of the old struct
admitted everything, and an interface's zero value is nil, so without that
guard "no filter configured" would become a panic on the enumeration path
rather than the documented admit-all.

### The two constants are pinned, not trusted

They are duplicated rather than imported, and `config_parity_test.go` asserts
each equals its `pkg/config` counterpart, so a change on either side breaks the
build instead of quietly changing behaviour. That file is the only remaining
reference to `pkg/config` in this package. A test-only import does not put
config back into the dependency tree of the ten importers, which is what the
issue is about.

### Verification

```
go list -deps ./pkg/github | grep -c hive/pkg/config
  before: 1
  after:  0
```

## Testing

- [x] `cd src && go build ./...`
- [x] `cd src && go test ./pkg/github/...` — pass
- [x] `cd src && go test ./pkg/dashboard/... ./cmd/hive/...` — pass
- [x] `cd src && go vet ./pkg/github/...` — clean
- [x] Other / not run (explain): `go test ./pkg/config/...` has one failure,
      `TestGateFailsClosedWithoutIP6Tables`, which reproduces identically on
      unmodified `upstream/v4` in this environment (no `ip6tables`). Confirmed
      by stashing the change and re-running. Not touched by this PR.

New coverage in `src/pkg/github/config_parity_test.go`: both constants pinned
to their config counterparts; `config.IssueFilterConfig` pinned as satisfying
`IssueAdmitter` (so the seven call sites break here, loudly, rather than at the
call); and the unset filter pinned as admitting everything, including the nil
label slice.

## Scope

Phase 1 only. Phases 2–4 from the issue — extracting the automerge policy
engine, the request watchers, and the advisory digest rendering — are untouched
and the issue should stay open for them, hence `Part of` rather than `Fixes`.

## Note for reviewers

No changelog fragment: `changelog.d/README.md` says routine refactors need
none, and this has no operator-visible effect. Happy to add one, or the
`no-changelog` label, if the guard asks.

Part of #5953

— hive: backend=claude model=claude opus 5 high
