### PR TITLE
🌱 refactor(github): drop the pkg/config dependency from the client (phase 1 of #5953)

### DIFF
--- a/src/pkg/github/app.go
+++ b/src/pkg/github/app.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	gh "github.com/google/go-github/v72/github"
-
-	"github.com/hivecommons/hive/pkg/config"
 )
 
 const (
@@ -481,7 +479,7 @@ func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, a
 	// registry is never populated and the file receives the real token,
 	// byte-identical to the pre-#1861 behavior.
 	fileToken := token
-	if config.ProxyInjectGHAuth() {
+	if proxyInjectGHAuth() {
 		storeAgentProxyToken(agentName, token)
 		fileToken = AgentDummyToken(agentName)
 	}

--- a/src/pkg/github/automerge_sweep.go
+++ b/src/pkg/github/automerge_sweep.go
@@ -12,8 +12,13 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
-	"github.com/hivecommons/hive/pkg/config"
 )
+
+// selfMergeMinACMMLevel mirrors config.SelfMergeMinACMMLevel. It is duplicated
+// rather than imported so this package keeps no dependency on pkg/config
+// (hivecommons/hive#5953 phase 1); config_parity_test.go pins the two equal so
+// they cannot drift silently.
+const selfMergeMinACMMLevel = 6
 
 const DefaultAutoMergeSweepMaxMerges = 3
 
@@ -420,7 +425,7 @@ func (c *Client) StartSelfAuthoredAutoMergeSweep(ctx context.Context, maxMerges 
 			level = fmt.Sprintf("%d", *acmmLevel)
 		}
 		c.info("self-authored auto-merge sweep disabled: acmm_level below minimum (or auto_merge.self_authored is off)",
-			"acmm_level", level, "min_acmm_level", config.SelfMergeMinACMMLevel)
+			"acmm_level", level, "min_acmm_level", selfMergeMinACMMLevel)
 		return
 	}
 	interval := selfAuthoredSweepInterval(len(c.getRepos()))

--- a/src/pkg/github/client.go
+++ b/src/pkg/github/client.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
-	"github.com/hivecommons/hive/pkg/config"
 	"github.com/hivecommons/hive/pkg/ioscan"
 	"github.com/hivecommons/hive/pkg/logscrub"
 )
@@ -52,7 +51,7 @@ type Client struct {
 	// re-applies it while the enumeration goroutine reads it. Zero value =
 	// admit everything (pre-existing behavior).
 	issueFilterMu sync.RWMutex
-	issueFilter   config.IssueFilterConfig
+	issueFilter   IssueAdmitter
 	// autoMergeLabel is the configured merger-queue label. Guarded because
 	// config reload re-applies it while request handlers read it.
 	autoMergeLabelMu sync.RWMutex
@@ -456,7 +455,7 @@ var PermanentExemptLabels = []string{"do-not-merge"}
 // applies when a hive has not configured `governor.labels.automerge`. Prefer
 // Client.AutoMergeLabel(), which honours that configuration; this constant
 // exists so a nil or unconfigured client still has a sane value.
-const AutoMergeQueuedLabel = config.DefaultAutoMergeLabel
+const AutoMergeQueuedLabel = "lgtm"
 
 const slaThresholdMinutes = 30
 
@@ -1188,7 +1187,7 @@ func (c *Client) SetExemptLabels(labels []string) {
 // safe for the same reason as SetRepos: the config-reload / heartbeat-delivery
 // paths re-apply it unconditionally, and a hive that booted without GitHub
 // credentials runs with a nil *Client.
-func (c *Client) SetIssueFilter(f config.IssueFilterConfig) {
+func (c *Client) SetIssueFilter(f IssueAdmitter) {
 	if c == nil {
 		return
 	}
@@ -1197,9 +1196,16 @@ func (c *Client) SetIssueFilter(f config.IssueFilterConfig) {
 	c.issueFilter = f
 }
 
-func (c *Client) getIssueFilter() config.IssueFilterConfig {
+// getIssueFilter never returns nil: an unset filter admits everything, which
+// is the zero-value contract the config struct had before this became an
+// interface. Returning nil here would turn "no filter configured" into a
+// panic at the one call site that consults it.
+func (c *Client) getIssueFilter() IssueAdmitter {
 	c.issueFilterMu.RLock()
 	defer c.issueFilterMu.RUnlock()
+	if c.issueFilter == nil {
+		return admitAllIssues{}
+	}
 	return c.issueFilter
 }
 

--- a/src/pkg/github/config_parity_test.go
+++ b/src/pkg/github/config_parity_test.go
@@ -1,0 +1,90 @@
+package github
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+// Phase 1 of kubestellar/hive#5953 removed this package's production
+// dependency on pkg/config. Two values had to be duplicated to do that. This
+// file is the only place pkg/config is still referenced here, and it exists to
+// make the duplication safe: if either definition moves, the build of this
+// test fails and the drift is caught at CI time rather than in behaviour.
+//
+// A test-only import does not reintroduce the coupling the issue is about —
+// production code in this package no longer pulls in the application config
+// surface, so importers of the client no longer do either.
+
+func TestAutoMergeQueuedLabelMatchesConfigDefault(t *testing.T) {
+	if AutoMergeQueuedLabel != config.DefaultAutoMergeLabel {
+		t.Fatalf("AutoMergeQueuedLabel = %q, config.DefaultAutoMergeLabel = %q — "+
+			"these name the same merger-queue label and must not drift",
+			AutoMergeQueuedLabel, config.DefaultAutoMergeLabel)
+	}
+}
+
+func TestSelfMergeMinACMMLevelMatchesConfig(t *testing.T) {
+	if selfMergeMinACMMLevel != config.SelfMergeMinACMMLevel {
+		t.Fatalf("selfMergeMinACMMLevel = %d, config.SelfMergeMinACMMLevel = %d — "+
+			"the sweep logs this as the authority for self-authored auto-merge; "+
+			"a mismatch would misreport the gate an operator is being held to",
+			selfMergeMinACMMLevel, config.SelfMergeMinACMMLevel)
+	}
+}
+
+// config.IssueFilterConfig must keep satisfying IssueAdmitter, because every
+// construction site passes it directly. If it stops, those sites break at the
+// call rather than here, which is a much less obvious failure.
+func TestIssueFilterConfigSatisfiesIssueAdmitter(t *testing.T) {
+	var _ IssueAdmitter = config.IssueFilterConfig{}
+}
+
+// An unset filter must admit everything: that was the zero-value behaviour of
+// the struct this interface replaced, and enumeration relies on it.
+func TestUnsetIssueFilterAdmitsEverything(t *testing.T) {
+	c := &Client{}
+	if got := c.getIssueFilter(); got == nil {
+		t.Fatal("getIssueFilter() returned nil; the enumeration path would panic")
+	}
+	if !c.getIssueFilter().Admits([]string{"anything"}) {
+		t.Fatal("an unset filter rejected a label; unset must admit everything")
+	}
+	if !c.getIssueFilter().Admits(nil) {
+		t.Fatal("an unset filter rejected an unlabelled issue")
+	}
+}
+
+// The #1861 credential-divert switch is read independently by this package now.
+// Compare the two readers BEHAVIOURALLY over the values an operator might
+// plausibly set, including the near-misses: a duplicate that treated "TRUE" or
+// "1" as enabled — or, worse, failed to treat "true" as enabled — would diverge
+// from the configuration layer while looking correct.
+func TestProxyInjectGHAuthMatchesConfig(t *testing.T) {
+	for _, v := range []string{"", "true", " true ", "TRUE", "True", "1", "yes", "false", "  "} {
+		t.Run("value="+v, func(t *testing.T) {
+			t.Setenv(config.ProxyInjectGHAuthEnv, v)
+			if got, want := proxyInjectGHAuth(), config.ProxyInjectGHAuth(); got != want {
+				t.Fatalf("proxyInjectGHAuth()=%v but config.ProxyInjectGHAuth()=%v for %q — "+
+					"the credential-divert switch must not diverge", got, want, v)
+			}
+		})
+	}
+	// And unset, which is the default posture.
+	os.Unsetenv(config.ProxyInjectGHAuthEnv)
+	if proxyInjectGHAuth() != config.ProxyInjectGHAuth() {
+		t.Fatal("readers diverge when the env var is unset")
+	}
+	if proxyInjectGHAuth() {
+		t.Fatal("divert must default to OFF when unset")
+	}
+}
+
+// The env var name itself must match, or the local reader silently watches a
+// variable nobody sets.
+func TestProxyInjectGHAuthEnvNameMatchesConfig(t *testing.T) {
+	if proxyInjectGHAuthEnv != config.ProxyInjectGHAuthEnv {
+		t.Fatalf("env name %q != config %q", proxyInjectGHAuthEnv, config.ProxyInjectGHAuthEnv)
+	}
+}

--- a/src/pkg/github/issue_admitter.go
+++ b/src/pkg/github/issue_admitter.go
@@ -1,0 +1,27 @@
+package github
+
+// IssueAdmitter decides whether an issue carrying the given labels is eligible
+// for agent work.
+//
+// This exists so the client can honour the operator's project.issue_filter
+// without importing pkg/config. The filter's semantics — exact,
+// case-insensitive matching, empty means admit everything, and "exclude wins"
+// being the caller's job — belong to the configuration layer that owns the
+// policy; the client only needs the verdict. config.IssueFilterConfig
+// satisfies this interface as-is, so construction sites keep passing it
+// unchanged (kubestellar/hive#5953, phase 1).
+//
+// Keeping the decision behind an interface rather than copying the matching
+// logic here is deliberate: this is an approval gate, and a second
+// implementation of it that drifted from the first would fail open.
+type IssueAdmitter interface {
+	// Admits reports whether an issue with these labels may be worked.
+	Admits(labels []string) bool
+}
+
+// admitAllIssues is the filter used when none has been installed. It preserves
+// the pre-existing zero-value behaviour of config.IssueFilterConfig, where an
+// unset filter admits every issue.
+type admitAllIssues struct{}
+
+func (admitAllIssues) Admits([]string) bool { return true }

--- a/src/pkg/github/proxy_inject_flag.go
+++ b/src/pkg/github/proxy_inject_flag.go
@@ -1,0 +1,30 @@
+package github
+
+import (
+	"os"
+	"strings"
+)
+
+// proxyInjectGHAuthEnv and proxyInjectGHAuthEnabledValue mirror the constants
+// of the same meaning in pkg/config. They are duplicated rather than imported
+// so this package keeps no dependency on the application configuration surface
+// (hivecommons/hive#5953 phase 1).
+//
+// This is the #1861 credential-divert switch, so the duplication is pinned by a
+// BEHAVIOURAL test (config_parity_test.go) that runs both readers over the same
+// env values rather than merely comparing two constants. The risk being guarded
+// is failing open: a divergent reader returning false where config returns true
+// would hand agents the real token while the operator believed the divert was
+// on.
+const (
+	proxyInjectGHAuthEnv          = "HIVE_PROXY_INJECT_GH_AUTH"
+	proxyInjectGHAuthEnabledValue = "true"
+)
+
+// proxyInjectGHAuth reports whether agent-facing credential files should
+// receive a placeholder instead of the real token. Exact match after trimming,
+// matching config.ProxyInjectGHAuth: "TRUE" and "1" are NOT enabled, which is
+// the conservative reading for a security switch.
+func proxyInjectGHAuth() bool {
+	return strings.TrimSpace(os.Getenv(proxyInjectGHAuthEnv)) == proxyInjectGHAuthEnabledValue
+}


### PR DESCRIPTION
## Summary

`pkg/github` is the package everything in hive uses to talk to GitHub — ten
packages import it. It also imported `pkg/config`, the application's
configuration surface, so anything wanting an HTTP client dragged the entire
operator-configuration surface along with it, and the layering ran backwards
(configuration should depend on the client, not the reverse).

This removes that dependency. It is phase 1 of the four-phase split the issue
proposes, and the only phase that changes package boundaries; the policy
engines and watcher daemons stay where they are for now.

**No behaviour change**, and no call site changes: the seven places that
install an issue filter pass exactly what they passed before.

## Detail

Four references, not a deep entanglement:

| Reference | Use |
| --- | --- |
| `config.IssueFilterConfig` | type of `Client.issueFilter`; one method called, `Admits(labels)` |
| `config.DefaultAutoMergeLabel` | aliased by the `AutoMergeQueuedLabel` constant |
| `config.SelfMergeMinACMMLevel` | logged by the self-authored auto-merge sweep |
| `config.ProxyInjectGHAuth()` | read by `app.go` — the #1861 credential-divert switch |

Everything else the issue counts is prose in comments naming `config.RoleMerger`
and `config.AutoMergeConfig` — references to concepts, not imports. The issue
also names `tokenscopes.go` as an importer; it does not import `pkg/config`.

### The filter becomes a one-method interface

`IssueAdmitter` asks the only question the client actually has:

```go
type IssueAdmitter interface {
	Admits(labels []string) bool
}
```

`config.IssueFilterConfig` already satisfies it, so `SetIssueFilter` keeps
taking the same values and **all seven construction sites are untouched**
(`cmd/hive/main.go` ×6, `pkg/dashboard/api.go` ×1).

The matching logic is deliberately *not* copied here. It is an approval gate
with exact, case-insensitive semantics, and a second implementation that
drifted would fail **open** — the unsafe direction. The policy stays with the
layer that owns it; the client consumes the verdict.

`getIssueFilter()` now never returns nil. The old struct's zero value admitted
everything and an interface's zero value is nil, so without that guard "no
filter configured" would become a panic on the enumeration path rather than the
documented admit-all.

### The duplicated values are pinned, not trusted

Two constants and the divert switch are duplicated rather than imported.
`config_parity_test.go` pins each to its `pkg/config` counterpart so a change on
either side breaks the build rather than quietly changing behaviour.

The switch is pinned **behaviourally** — both readers run over the same env
values, including the near-misses `TRUE`, `True` and `1`, plus unset — rather
than by comparing constants. The risk being guarded is failing open: a reader
that returned false where config returns true would hand agents the real token
while the operator believed the divert was on.

`config_parity_test.go` is the only remaining reference to `pkg/config` in this
package. A test-only import does not put config back into the dependency tree
of the ten importers, which is what the issue is about.

### Verification

```
go list -deps ./pkg/github | grep -c hive/pkg/config
  before: 1
  after:  0
```

## Testing

- [x] `cd src && go build ./...`
- [x] `cd src && go test ./pkg/github/...` — pass
- [x] `cd src && go test ./pkg/dashboard/... ./cmd/hive/...` — pass
- [x] `cd src && go vet ./pkg/github/...` — clean
- [x] Other / not run (explain): full `go test ./...` not run locally; the
      change is confined to `src/pkg/github`. CI covers the rest.

New coverage in `src/pkg/github/config_parity_test.go`: both constants pinned to
their config counterparts; the divert switch pinned behaviourally across nine
env values plus unset, including an explicit assertion that it defaults **off**;
the env var *name* pinned, so the local reader cannot end up watching a variable
nobody sets; `config.IssueFilterConfig` pinned as satisfying `IssueAdmitter` (so
the seven call sites break here, loudly, rather than at the call); and the unset
filter pinned as admitting everything, including a nil label slice.

## Scope

Phase 1 only. Phases 2–4 from the issue — extracting the automerge policy
engine, the request watchers, and the advisory digest rendering — are untouched
and the issue should stay open for them, hence `Part of` rather than `Fixes`.

## Note for reviewers

No changelog fragment: `changelog.d/README.md` says routine refactors need none
and this has no operator-visible effect. Happy to add one, or take the
`no-changelog` label, if the guard asks.

Part of #5953

— hive: backend=claude model=claude opus 5 high

Refs #5953
