### PR TITLE
🌱 refactor(cmd/hive): extract GitHub App key file handling to pkg/appkey (phase 1 of #5898)

### DIFF
--- a/src/cmd/hive/app_key_derivation_test.go
+++ b/src/cmd/hive/app_key_derivation_test.go
@@ -61,17 +61,17 @@ func writeKey(t *testing.T, path string) {
 // claim has a per-app-id key of its own.
 func TestResolveAppKeyFileIgnoresStaleGenericPin(t *testing.T) {
 	dir := t.TempDir()
-	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
-	spokeAppKeyDir = dir
-	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
-	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+	origDir, origGeneric := appKeys.DataDir, appKeys.DataKeyPath
+	appKeys.DataDir = dir
+	appKeys.DataKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { appKeys.DataDir, appKeys.DataKeyPath = origDir, origGeneric })
 
 	const publicAppID = 3568013
-	writeKey(t, spokeAppKeyPath)              // the stale GHE key
-	writeKey(t, perAppIDKeyPath(publicAppID)) // the correct public key
+	writeKey(t, appKeys.DataKeyPath)                  // the stale GHE key
+	writeKey(t, appKeys.PerAppIDKeyPath(publicAppID)) // the correct public key
 
-	got := resolveAppKeyFile(spokeAppKeyPath, "", publicAppID)
-	if want := perAppIDKeyPath(publicAppID); got != want {
+	got := appKeys.Resolve(appKeys.DataKeyPath, "", publicAppID)
+	if want := appKeys.PerAppIDKeyPath(publicAppID); got != want {
 		t.Fatalf("resolved %q, want %q — a stale generic pin must not shadow the key for the App we claim", got, want)
 	}
 }
@@ -82,17 +82,17 @@ func TestResolveAppKeyFileIgnoresStaleGenericPin(t *testing.T) {
 // at a bespoke location, and that must still win.
 func TestResolveAppKeyFileKeepsOperatorOverride(t *testing.T) {
 	dir := t.TempDir()
-	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
-	spokeAppKeyDir = dir
-	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
-	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+	origDir, origGeneric := appKeys.DataDir, appKeys.DataKeyPath
+	appKeys.DataDir = dir
+	appKeys.DataKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { appKeys.DataDir, appKeys.DataKeyPath = origDir, origGeneric })
 
 	const oddAppID = 4240368
 	bespoke := filepath.Join(dir, "custom", "my-app.pem")
 	writeKey(t, bespoke)
-	writeKey(t, perAppIDKeyPath(oddAppID)) // present, and must NOT be preferred
+	writeKey(t, appKeys.PerAppIDKeyPath(oddAppID)) // present, and must NOT be preferred
 
-	if got := resolveAppKeyFile(bespoke, "", oddAppID); got != bespoke {
+	if got := appKeys.Resolve(bespoke, "", oddAppID); got != bespoke {
 		t.Fatalf("resolved %q, want the operator's %q", got, bespoke)
 	}
 }
@@ -102,30 +102,30 @@ func TestResolveAppKeyFileKeepsOperatorOverride(t *testing.T) {
 // must be returned rather than dropping the hive to no key at all.
 func TestResolveAppKeyFileGenericPinSurvivesWithoutPerAppKey(t *testing.T) {
 	dir := t.TempDir()
-	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
-	spokeAppKeyDir = dir
-	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
-	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+	origDir, origGeneric := appKeys.DataDir, appKeys.DataKeyPath
+	appKeys.DataDir = dir
+	appKeys.DataKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { appKeys.DataDir, appKeys.DataKeyPath = origDir, origGeneric })
 
-	writeKey(t, spokeAppKeyPath)
-	if got := resolveAppKeyFile(spokeAppKeyPath, "", 3568013); got != spokeAppKeyPath {
-		t.Fatalf("resolved %q, want %q — with no per-app key the generic one is still the only key", got, spokeAppKeyPath)
+	writeKey(t, appKeys.DataKeyPath)
+	if got := appKeys.Resolve(appKeys.DataKeyPath, "", 3568013); got != appKeys.DataKeyPath {
+		t.Fatalf("resolved %q, want %q — with no per-app key the generic one is still the only key", got, appKeys.DataKeyPath)
 	}
 }
 
 // TestEnvOverrideStillWins: GH_APP_KEY_FILE outranks everything, unchanged.
 func TestEnvOverrideStillWins(t *testing.T) {
 	dir := t.TempDir()
-	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
-	spokeAppKeyDir = dir
-	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
-	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+	origDir, origGeneric := appKeys.DataDir, appKeys.DataKeyPath
+	appKeys.DataDir = dir
+	appKeys.DataKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { appKeys.DataDir, appKeys.DataKeyPath = origDir, origGeneric })
 
-	writeKey(t, spokeAppKeyPath)
-	writeKey(t, perAppIDKeyPath(3568013))
+	writeKey(t, appKeys.DataKeyPath)
+	writeKey(t, appKeys.PerAppIDKeyPath(3568013))
 	env := filepath.Join(dir, "env.pem")
 	writeKey(t, env)
-	if got := resolveAppKeyFile(spokeAppKeyPath, env, 3568013); got != env {
+	if got := appKeys.Resolve(appKeys.DataKeyPath, env, 3568013); got != env {
 		t.Fatalf("resolved %q, want env override %q", got, env)
 	}
 }
@@ -138,28 +138,28 @@ func TestEnvOverrideStillWins(t *testing.T) {
 // on disk said so, and correcting app_id to the public App kept signing with it.
 func TestDeliveredKeyPathNamesTheApp(t *testing.T) {
 	dir := t.TempDir()
-	origDir, origGeneric := spokeAppKeyDir, spokeAppKeyPath
-	spokeAppKeyDir = dir
-	spokeAppKeyPath = filepath.Join(dir, "gh-app-key.pem")
-	t.Cleanup(func() { spokeAppKeyDir, spokeAppKeyPath = origDir, origGeneric })
+	origDir, origGeneric := appKeys.DataDir, appKeys.DataKeyPath
+	appKeys.DataDir = dir
+	appKeys.DataKeyPath = filepath.Join(dir, "gh-app-key.pem")
+	t.Cleanup(func() { appKeys.DataDir, appKeys.DataKeyPath = origDir, origGeneric })
 
 	const publicAppID, gheAppID = 3568013, 5686
 
 	pub := deliveredKeyPath(publicAppID)
 	ghe := deliveredKeyPath(gheAppID)
 
-	if pub == spokeAppKeyPath {
+	if pub == appKeys.DataKeyPath {
 		t.Fatalf("delivered key for app %d landed on the generic path %q — the filename must name the App", publicAppID, pub)
 	}
 	if pub == ghe {
 		t.Fatalf("two different Apps share one key path %q; a key for one App would overwrite the other's", pub)
 	}
-	if want := perAppIDKeyPath(publicAppID); pub != want {
+	if want := appKeys.PerAppIDKeyPath(publicAppID); pub != want {
 		t.Fatalf("delivered path = %q, want %q", pub, want)
 	}
 
 	// A delivery naming no App must still land somewhere rather than be lost.
-	if got := deliveredKeyPath(0); got != spokeAppKeyPath {
-		t.Fatalf("App-less delivery = %q, want the generic %q", got, spokeAppKeyPath)
+	if got := deliveredKeyPath(0); got != appKeys.DataKeyPath {
+		t.Fatalf("App-less delivery = %q, want the generic %q", got, appKeys.DataKeyPath)
 	}
 }

--- a/src/cmd/hive/appkey_testhelper_test.go
+++ b/src/cmd/hive/appkey_testhelper_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+// testRSAKeyBits is deliberately small: these tests only need a parseable RSA
+// key, never a secure one, and 1024 keeps the suite fast.
+const testRSAKeyBits = 1024
+
+// writeTestKey writes a throwaway RSA private key at path and returns its
+// fingerprint. A copy of the helper that moved to pkg/appkey with the App-key
+// file logic (hivecommons/hive#5898 phase 1) — cmd/hive still has tests that
+// need to plant a key on disk, and duplicating ten lines of test scaffolding
+// beats exporting a testing helper from a production package.
+func writeTestKey(t *testing.T, path string) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, testRSAKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	})
+	if err := os.WriteFile(path, pemData, appKeys.FileMode); err != nil {
+		t.Fatalf("write key %s: %v", path, err)
+	}
+	fp, err := config.AppKeyFingerprint(string(pemData))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	return fp
+}

--- a/src/cmd/hive/ghapp_banner_verdict_test.go
+++ b/src/cmd/hive/ghapp_banner_verdict_test.go
@@ -54,10 +54,10 @@ func verdictTestAuth(t *testing.T, apiURL string) *github.AppAuth {
 	// key-missing without any API call when none holds content. Point one of
 	// them at the real key so these tests exercise the API classification the
 	// verdict actually depends on. Restored via t.Cleanup.
-	origProvisioned, origPVC := spokeProvisionedAppKeyPath, spokeAppKeyPath
-	spokeProvisionedAppKeyPath, spokeAppKeyPath = keyPath, keyPath
+	origProvisioned, origPVC := appKeys.ProvisionedKeyPath, appKeys.DataKeyPath
+	appKeys.ProvisionedKeyPath, appKeys.DataKeyPath = keyPath, keyPath
 	t.Cleanup(func() {
-		spokeProvisionedAppKeyPath, spokeAppKeyPath = origProvisioned, origPVC
+		appKeys.ProvisionedKeyPath, appKeys.DataKeyPath = origProvisioned, origPVC
 	})
 	auth, err := github.NewAppAuth(verdictTestAppID, verdictTestInstallationID, keyPath, verdictTestLogger(), apiURL)
 	if err != nil {

--- a/src/cmd/hive/githubauth_test.go
+++ b/src/cmd/hive/githubauth_test.go
@@ -36,12 +36,12 @@ const realInstallationID int64 = 149757667
 func isolateAppKeyLookup(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	origData, origSecrets := spokeAppKeyPath, spokeProvisionedAppKeyPath
-	spokeAppKeyPath = filepath.Join(dir, "absent-data-key.pem")
-	spokeProvisionedAppKeyPath = filepath.Join(dir, "absent-secrets-key.pem")
+	origData, origSecrets := appKeys.DataKeyPath, appKeys.ProvisionedKeyPath
+	appKeys.DataKeyPath = filepath.Join(dir, "absent-data-key.pem")
+	appKeys.ProvisionedKeyPath = filepath.Join(dir, "absent-secrets-key.pem")
 	t.Setenv("GH_APP_KEY_FILE", "")
 	t.Cleanup(func() {
-		spokeAppKeyPath, spokeProvisionedAppKeyPath = origData, origSecrets
+		appKeys.DataKeyPath, appKeys.ProvisionedKeyPath = origData, origSecrets
 	})
 	return dir
 }
@@ -171,7 +171,7 @@ func TestInitGitHubAuthRealAppMissingKeyDegrades(t *testing.T) {
 		t.Errorf("failure reason omits the path actually tried (%q): %q", missing, got.Failure)
 	}
 	// The resolution order, named explicitly.
-	for _, want := range []string{"GH_APP_KEY_FILE", "github.key_file", spokeAppKeyPath, spokeProvisionedAppKeyPath} {
+	for _, want := range []string{"GH_APP_KEY_FILE", "github.key_file", appKeys.DataKeyPath, appKeys.ProvisionedKeyPath} {
 		if !strings.Contains(got.Failure, want) {
 			t.Errorf("failure reason omits %q from the resolution order: %q", want, got.Failure)
 		}
@@ -337,7 +337,7 @@ func TestDescribeAppKeyFailureNamesEnvOverride(t *testing.T) {
 	// With neither set, the message must say so rather than printing a bare
 	// "=" and leaving the operator to guess whether the value was empty or the
 	// message was truncated.
-	bare := describeAppKeyFailure("", "", spokeProvisionedAppKeyPath, os.ErrNotExist)
+	bare := describeAppKeyFailure("", "", appKeys.ProvisionedKeyPath, os.ErrNotExist)
 	if strings.Count(bare, "(unset)") != 2 {
 		t.Errorf("both unset sources should render as (unset): %q", bare)
 	}

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/hivecommons/hive/pkg/advisory"
 	"github.com/hivecommons/hive/pkg/agent"
+	"github.com/hivecommons/hive/pkg/appkey"
 	"github.com/hivecommons/hive/pkg/beads"
 	"github.com/hivecommons/hive/pkg/classify"
 	"github.com/hivecommons/hive/pkg/config"
@@ -114,38 +115,14 @@ var (
 	gitBranch = "unknown"
 )
 
-// GitHub App private-key locations on a spoke, and how the two differ.
+// GitHub App private-key locations on a spoke live in pkg/appkey, which owns
+// where they are, which one is correct for the App this hive claims, and how a
+// hub-delivered key is written down (hivecommons/hive#5898 phase 1).
 //
-//   - spokeProvisionedAppKeyPath is a read-only Kubernetes Secret mount, written
-//     at PROVISIONING time from a key an operator supplied for THIS hive
-//     specifically. Its presence is the marker of a deliberate per-hive
-//     credential, which the hub's cluster-wide reconcile must never overwrite.
-//   - spokeAppKeyPath is on the PVC and is where a hub-delivered (cluster
-//     default) key lands. It is also what cfg.GitHub.KeyFile is repointed at
-//     once the hub delivers one, so it takes effect over the provisioned mount.
-//
-// Vars rather than consts so tests can point them at a temp dir and exercise
-// the real resolution order; production never reassigns them.
-var (
-	spokeProvisionedAppKeyPath = "/secrets/gh-app-key.pem"
-	spokeAppKeyPath            = "/data/gh-app-key.pem"
-	// spokeAppKeyDir is where per-app-id keys the hub delivers land, one file per
-	// App the fleet knows: gh-app-key-<appid>.pem. It is the PVC directory that
-	// already holds spokeAppKeyPath, so both survive restarts. A var so tests can
-	// redirect it; production never reassigns it.
-	spokeAppKeyDir = "/data"
-	// spokeProvisionedAppKeyDir is the read-only projected-Secret mount where
-	// PROVISIONING places per-app-id keys (gh-app-key-<appid>.pem), mirroring
-	// spokeAppKeyDir on the PVC. A hive provisioned with the fleet's full key set
-	// holds them here from its very first boot — before any heartbeat has run — so
-	// a forge switch never has to wait a beat for the target forge's key. The
-	// mount is readOnly, so nothing ever writes here; it is a lookup source only.
-	spokeProvisionedAppKeyDir = "/secrets"
-)
-
-// spokeAppKeyFileMode is rw------- : signing material must never be readable by
-// anything else sharing the PVC or the pod.
-const spokeAppKeyFileMode = 0o600
+// A var, not a const, for the same reason the paths themselves used to be: a
+// test points it at a temp dir and exercises the real resolution order.
+// Production never reassigns it.
+var appKeys = appkey.Default()
 
 // traceShutdownTimeout bounds how long we wait for the OTel exporter to flush
 // pending spans during shutdown, so a slow/unreachable collector can't hang
@@ -367,13 +344,6 @@ func nextInstallationID(current int64, ghCfg *hub.HeartbeatGitHubAppConfig) (nex
 	return current, false
 }
 
-func perAppIDKeyPath(appID int64) string {
-	if appID <= 0 {
-		return ""
-	}
-	return filepath.Join(spokeAppKeyDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
-}
-
 // deliveredKeyPath is where a hub-delivered private key for appID is stored.
 //
 // The filename NAMES the App, so a key can only ever be found under the App it
@@ -386,263 +356,10 @@ func perAppIDKeyPath(appID int64) string {
 // Falls back to the generic path only when the delivery names no App, so a key
 // is never dropped on the floor.
 func deliveredKeyPath(appID int64) string {
-	if p := perAppIDKeyPath(appID); p != "" {
+	if p := appKeys.PerAppIDKeyPath(appID); p != "" {
 		return p
 	}
-	return spokeAppKeyPath
-}
-
-// perAppIDProvisionedKeyPath is perAppIDKeyPath's read-only twin: the same
-// per-app-id filename under the provisioning Secret mount. It is consulted only
-// when the PVC has no usable key for the app_id, so a heartbeat-delivered key
-// (which can be rotated) always wins over the one baked in at provision time.
-func perAppIDProvisionedKeyPath(appID int64) string {
-	if appID <= 0 {
-		return ""
-	}
-	return filepath.Join(spokeProvisionedAppKeyDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
-}
-
-// perAppIDKeyFilePrefix / Suffix bracket the per-app-id key filename so a scan
-// can recover the app_id from the name. Named so the format lives in exactly one
-// place alongside perAppIDKeyPath.
-const (
-	perAppIDKeyFilePrefix = "gh-app-key-"
-	perAppIDKeyFileSuffix = ".pem"
-)
-
-// heldPerAppIDKeyFingerprints scans the PVC for per-app-id key files
-// (gh-app-key-<appid>.pem) and returns app_id (decimal string) → fingerprint for
-// every one that holds a usable key. It is what the spoke reports so the hub
-// delivers the fleet's additional keys idempotently: a key already present with
-// the right fingerprint is not re-sent.
-//
-// It never returns key material — only fingerprints. A missing directory,
-// unreadable file, or unparseable key is silently skipped: the worst case is the
-// hub re-delivers a key the spoke already writes idempotently, never a crash.
-func heldPerAppIDKeyFingerprints() map[string]string {
-	entries, err := os.ReadDir(spokeAppKeyDir)
-	if err != nil {
-		return nil
-	}
-	var held map[string]string
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasPrefix(name, perAppIDKeyFilePrefix) || !strings.HasSuffix(name, perAppIDKeyFileSuffix) {
-			continue
-		}
-		idStr := strings.TrimSuffix(strings.TrimPrefix(name, perAppIDKeyFilePrefix), perAppIDKeyFileSuffix)
-		id, convErr := strconv.ParseInt(idStr, 10, 64)
-		if convErr != nil || id <= 0 {
-			continue
-		}
-		fp, fpErr := config.AppKeyFingerprintFromFile(filepath.Join(spokeAppKeyDir, name))
-		if fpErr != nil || fp == "" {
-			continue
-		}
-		if held == nil {
-			held = make(map[string]string)
-		}
-		held[idStr] = fp
-	}
-	return held
-}
-
-// writePerAppIDKey persists a hub-delivered per-app-id key to its PVC file
-// atomically (temp file in the same dir, then rename) with a restrictive 0600
-// mode from creation, so a spoke can never sign with a half-written key. Returns
-// the resulting fingerprint (never the key) for auditable logging, or an error.
-func writePerAppIDKey(appID int64, pemData string) (string, error) {
-	path := perAppIDKeyPath(appID)
-	if path == "" {
-		return "", fmt.Errorf("refusing to write key for non-positive app_id %d", appID)
-	}
-	trimmed := strings.TrimSpace(pemData)
-	if !strings.HasPrefix(trimmed, "-----BEGIN") {
-		return "", fmt.Errorf("app key for app_id %d is not PEM", appID)
-	}
-	fp, err := config.AppKeyFingerprint(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("app key for app_id %d is unusable: %w", appID, err)
-	}
-	if err := os.MkdirAll(spokeAppKeyDir, 0o700); err != nil {
-		return "", fmt.Errorf("create app key dir: %w", err)
-	}
-	tmp, err := os.CreateTemp(spokeAppKeyDir, "."+filepath.Base(path)+".tmp*")
-	if err != nil {
-		return "", fmt.Errorf("create temp app key file: %w", err)
-	}
-	tmpName := tmp.Name()
-	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename below succeeds
-	if err := tmp.Chmod(spokeAppKeyFileMode); err != nil {
-		_ = tmp.Close() // best-effort cleanup; the chmod error is what's returned
-		return "", fmt.Errorf("chmod temp app key file: %w", err)
-	}
-	if _, err := tmp.WriteString(trimmed + "\n"); err != nil {
-		_ = tmp.Close() // best-effort cleanup; the write error is what's returned
-		return "", fmt.Errorf("write temp app key file: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close() // best-effort cleanup; the sync error is what's returned
-		return "", fmt.Errorf("sync temp app key file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return "", fmt.Errorf("close temp app key file: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return "", fmt.Errorf("rename app key into place: %w", err)
-	}
-	return fp, nil
-}
-
-// reportedAppKeyFingerprint returns the non-secret fingerprint of the App key
-// this spoke is ACTUALLY using, for the heartbeat payload. It fingerprints the
-// resolved key file rather than a hard-coded path so the hub compares against
-// the key that would really sign a JWT.
-//
-// Returns "" whenever there is no usable key — no file, empty file, or
-// unparseable contents. All three mean the same thing to the hub ("this spoke
-// cannot authenticate") and are repaired identically. The private key itself is
-// never returned, and never enters the payload.
-func reportedAppKeyFingerprint(keyFile string, appID int64) string {
-	// Lead with the same path resolveAppKeyFile would sign with, so the hub is
-	// told about the key actually in effect and never about a shadowed one.
-	candidates := []string{
-		resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE"), appID),
-		perAppIDKeyPath(appID),
-		keyFile, spokeAppKeyPath, spokeProvisionedAppKeyPath,
-	}
-	for _, p := range candidates {
-		if strings.TrimSpace(p) == "" {
-			continue
-		}
-		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
-			return fp
-		}
-	}
-	return ""
-}
-
-// hasPerHiveAppKey reports whether this spoke's key came from a per-hive
-// provisioning secret rather than the cluster default. The provisioned mount is
-// read-only, so its mere existence with real PEM content is the signal — a
-// hub-delivered key can never create or alter it.
-//
-// When BOTH exist the hub-delivered PVC key is the one in effect (the callback
-// repoints cfg.GitHub.KeyFile at it), so this only claims an override while the
-// provisioned key is genuinely the one being used.
-func hasPerHiveAppKey(keyFile string, appID int64) bool {
-	fp, err := config.AppKeyFingerprintFromFile(spokeProvisionedAppKeyPath)
-	if err != nil || fp == "" {
-		return false
-	}
-	// The provisioned key exists. It is the effective credential only if the
-	// resolved key file still points at it — resolveAppKeyFile is the single
-	// authority on that, so an unconfigured hive that has already taken delivery
-	// of a /data key (or a per-app-id key) correctly stops claiming a per-hive
-	// override.
-	return resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE"), appID) == spokeProvisionedAppKeyPath
-}
-
-// resolveAppKeyFile picks which App private key this process will actually sign
-// with, given the configured key_file and the GH_APP_KEY_FILE env override.
-//
-// WHY THE /data PREFERENCE MATTERS
-//
-// A hub-delivered key lands at spokeAppKeyPath (/data, on the PVC) and the
-// heartbeat callback repoints cfg.GitHub.KeyFile at it — but only in memory, for
-// the life of that process. A hive whose config carries NO key_file (which is
-// the state of the three live GHE hives this repairs) used to fall straight
-// through to the read-only /secrets provisioning mount. That mount holds the
-// stale, wrong key, and the spoke cannot write to it. So on every restart the
-// hive would silently go back to signing with the key that cannot work, and the
-// hub — seeing the wrong fingerprint reported again — would redeliver forever.
-// The key would be delivered and never used: a fault that reads as fixed.
-//
-// So when nothing is explicitly configured, a key already present on the PVC is
-// preferred over the provisioning mount. An EXPLICIT key_file or env override
-// still wins outright: those are deliberate, and this must not silently redirect
-// an operator who named a path.
-//
-// PER-APP-ID SELECTION (the both-keys fix)
-//
-// appID is the App this process is configured to authenticate AS
-// (cfg.GitHub.AppID). When the hub has delivered a per-app-id key for exactly
-// that App — /data/gh-app-key-<appID>.pem — it is preferred over the generic
-// single-file paths, because it is provably the RIGHT key for the app_id we
-// claim. This is what lets a github.com hive on a GitHub-Enterprise cluster sign
-// with the github.com key even though its cluster default (and its single
-// /data/gh-app-key.pem) is the GHE key. It sits just below an explicit
-// key_file/env override — an operator who named a path still wins — and above
-// the generic fallbacks. appID <= 0 disables it entirely, so nothing changes for
-// a hive that reports no app_id.
-func resolveAppKeyFile(configured, envOverride string, appID int64) string {
-	if v := strings.TrimSpace(envOverride); v != "" {
-		return v
-	}
-	if v := strings.TrimSpace(configured); v != "" {
-		// MIGRATION. A configured key_file that is the GENERIC path is not an
-		// operator's choice — it is a value older builds wrote automatically on
-		// every key delivery, and it does not name the App it holds. When we can
-		// see a per-app-id key for the app_id we actually claim, that key is
-		// correct by construction and the generic pin is stale, so ignore it.
-		//
-		// Without this, the ~33 spokes already carrying
-		// key_file: /data/gh-app-key.pem keep signing with whichever App's key
-		// happens to sit there — the live 404 Integration not found — because an
-		// explicit value short-circuits the per-app-id lookup below.
-		//
-		// Deliberately narrow: only the exact generic path is overridden, and
-		// only when a usable per-app-id key exists. Any other path is a genuine
-		// operator override (a hive on a third App with a bespoke key location)
-		// and still wins outright.
-		//
-		// BOTH generic paths qualify. /data/gh-app-key.pem is what older builds
-		// wrote on every key delivery; /secrets/gh-app-key.pem is what the
-		// PROVISIONING TEMPLATE hardcodes for every App-using hive
-		// (saas_provision.go). Neither names the App it holds, and neither was
-		// typed by an operator. Until /secrets was included here, a provisioned
-		// hive could never change forges: the hub could correct app_id all it
-		// liked and the spoke kept signing with the provisioned key, which on
-		// the spoke-cluster pool was a placeholder matching NEITHER real App.
-		if v == spokeAppKeyPath || v == spokeProvisionedAppKeyPath {
-			if p := perAppIDKeyPath(appID); p != "" {
-				if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
-					return p
-				}
-			}
-		}
-		return v
-	}
-	// Nothing explicitly configured. Prefer a per-app-id key matching the App we
-	// claim — the only key that is CORRECT-by-construction for this app_id — over
-	// the generic cluster/provisioned files. The fingerprint check (not mere
-	// existence) keeps an empty or truncated per-app file from shadowing a good
-	// generic key.
-	if p := perAppIDKeyPath(appID); p != "" {
-		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
-			return p
-		}
-	}
-	// Same idea, but from the read-only provisioning mount: a hive provisioned
-	// with the fleet's full key set can sign as its configured App on its very
-	// first boot, before any heartbeat has delivered anything to the PVC. Ranked
-	// BELOW the PVC copy so a rotated key delivered by heartbeat always wins over
-	// the one frozen into the Secret at provision time.
-	if p := perAppIDProvisionedKeyPath(appID); p != "" {
-		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
-			return p
-		}
-	}
-	// Prefer a usable hub-delivered key on the PVC; fall back to the provisioning
-	// mount only when /data has no parseable key.
-	if fp, err := config.AppKeyFingerprintFromFile(spokeAppKeyPath); err == nil && fp != "" {
-		return spokeAppKeyPath
-	}
-	return spokeProvisionedAppKeyPath
+	return appKeys.DataKeyPath
 }
 
 // describeAppKeyFailure turns a bare wrapped os error from github.NewAppAuth
@@ -658,10 +375,10 @@ func describeAppKeyFailure(configured, envOverride, resolved string, err error) 
 	order := []string{
 		fmt.Sprintf("$GH_APP_KEY_FILE=%s", describeKeySource(envOverride)),
 		fmt.Sprintf("github.key_file=%s", describeKeySource(configured)),
-		fmt.Sprintf("per-app-id PVC key %s/gh-app-key-<app_id>.pem", spokeAppKeyDir),
-		fmt.Sprintf("per-app-id provisioning key %s/gh-app-key-<app_id>.pem", spokeProvisionedAppKeyDir),
-		fmt.Sprintf("PVC fallback %s", spokeAppKeyPath),
-		fmt.Sprintf("provisioning mount %s", spokeProvisionedAppKeyPath),
+		fmt.Sprintf("per-app-id PVC key %s/gh-app-key-<app_id>.pem", appKeys.DataDir),
+		fmt.Sprintf("per-app-id provisioning key %s/gh-app-key-<app_id>.pem", appKeys.ProvisionedDir),
+		fmt.Sprintf("PVC fallback %s", appKeys.DataKeyPath),
+		fmt.Sprintf("provisioning mount %s", appKeys.ProvisionedKeyPath),
 	}
 	return fmt.Sprintf(
 		"GitHub App private key could not be loaded from %q: %v. "+
@@ -740,7 +457,7 @@ type githubAuth struct {
 // config.PlaceholderAppID.
 func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger) githubAuth {
 	var out githubAuth
-	appKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
+	appKeyFile := appKeys.Resolve(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
 
 	// HasApp() rejects config.PlaceholderAppID. Build AppAuth as soon as a real
 	// app_id and key are present, even when installation_id is still empty: the
@@ -2824,7 +2541,7 @@ func main() {
 		// raw key_file, which is deliberately empty on hub-delivered per-app-id
 		// keys (#2459).
 		ResolveAppKeyFileFunc: func(configured string, appID int64) string {
-			return resolveAppKeyFile(configured, os.Getenv("GH_APP_KEY_FILE"), appID)
+			return appKeys.Resolve(configured, os.Getenv("GH_APP_KEY_FILE"), appID)
 		},
 	})
 
@@ -2833,17 +2550,17 @@ func main() {
 	// SetGitHubAppRecheckFn pattern). Fingerprints and paths only — the
 	// provider never touches key material.
 	dashSrv.SetForgeAppInventoryFn(func() dashboard.ForgeAppInventory {
-		held := heldPerAppIDKeyFingerprints()
+		held := appKeys.HeldFingerprints()
 		keys := make([]dashboard.ForgeAppKey, 0, len(held))
 		for idStr, fp := range held {
 			keys = append(keys, dashboard.ForgeAppKey{
 				AppID:       idStr,
-				Path:        filepath.Join(spokeAppKeyDir, perAppIDKeyFilePrefix+idStr+perAppIDKeyFileSuffix),
+				Path:        appKeys.PerAppIDKeyPathFor(idStr),
 				Fingerprint: fp,
 			})
 		}
 		return dashboard.ForgeAppInventory{
-			ActiveKeyFile: resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID),
+			ActiveKeyFile: appKeys.Resolve(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID),
 			HeldKeys:      keys,
 		}
 	})
@@ -3247,8 +2964,8 @@ func main() {
 		// Comparing RESOLVED paths also catches a change the raw comparison
 		// cannot see: a per-app-id key arriving on the PVC changes which key
 		// this process should sign with while cfg.GitHub.KeyFile stays "".
-		prevKeyFile := resolveAppKeyFile(prevGitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), prevGitHub.AppID)
-		nextKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
+		prevKeyFile := appKeys.Resolve(prevGitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), prevGitHub.AppID)
+		nextKeyFile := appKeys.Resolve(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
 		if prevGitHub.AppID != cfg.GitHub.AppID ||
 			prevGitHub.InstallationID != cfg.GitHub.InstallationID ||
 			prevKeyFile != nextKeyFile ||
@@ -4142,8 +3859,8 @@ func main() {
 				// this against its per-cluster key and pushes a correction only
 				// on a mismatch, so a spoke already holding the right key costs
 				// nothing and a spoke holding the wrong one self-heals.
-				GitHubAppKeyFingerprint: reportedAppKeyFingerprint(cfg.GitHub.KeyFile, cfg.GitHub.AppID),
-				GitHubAppKeyPerHive:     hasPerHiveAppKey(cfg.GitHub.KeyFile, cfg.GitHub.AppID),
+				GitHubAppKeyFingerprint: appKeys.ReportedFingerprint(cfg.GitHub.KeyFile, cfg.GitHub.AppID),
+				GitHubAppKeyPerHive:     appKeys.HasPerHiveKey(cfg.GitHub.KeyFile, cfg.GitHub.AppID),
 				// Report the App this hive believes it authenticates as. The hub
 				// pairs it with the fingerprint above to tell a per-hive key that
 				// is WRONG for this App from one that is deliberately for another.
@@ -4159,7 +3876,7 @@ func main() {
 				// Report the fingerprint of every ADDITIONAL per-app-id key already
 				// on the PVC, so the hub delivers the fleet's other App keys once
 				// and then stops re-sending them.
-				GitHubAppKeysHeld: heldPerAppIDKeyFingerprints(),
+				GitHubAppKeysHeld: appKeys.HeldFingerprints(),
 				// Component reach counters (#3993, phase 2a of #3973): per
 				// (component, running commit) span counts aggregated in-process,
 				// exporter or not (D2) — the heartbeat is the only channel that
@@ -4460,7 +4177,7 @@ func main() {
 				// from the spoke's own logs. Fingerprints only — the key itself
 				// is never logged.
 				beforeFP, _ := config.AppKeyFingerprintFromFile(keyPath)
-				if err := os.WriteFile(keyPath, []byte(ghCfg.PrivateKey), spokeAppKeyFileMode); err != nil {
+				if err := os.WriteFile(keyPath, []byte(ghCfg.PrivateKey), appKeys.FileMode); err != nil {
 					logger.Error("failed to write github app key from heartbeat", "error", err)
 					return
 				}
@@ -4468,7 +4185,7 @@ func main() {
 				// exists, so a key written by an older build (or restored from a
 				// looser-moded source) would keep its old permissions forever.
 				// Chmod unconditionally so every path converges on 0600.
-				if err := os.Chmod(keyPath, spokeAppKeyFileMode); err != nil {
+				if err := os.Chmod(keyPath, appKeys.FileMode); err != nil {
 					logger.Warn("could not tighten github app key permissions", "path", keyPath, "error", err)
 				}
 				afterFP, _ := config.AppKeyFingerprintFromFile(keyPath)
@@ -4508,9 +4225,9 @@ func main() {
 				if privateKey == "" || appID <= 0 {
 					return
 				}
-				perAppPath := perAppIDKeyPath(appID)
+				perAppPath := appKeys.PerAppIDKeyPath(appID)
 				beforeFP, _ := config.AppKeyFingerprintFromFile(perAppPath)
-				fp, err := writePerAppIDKey(appID, privateKey)
+				fp, err := appKeys.WritePerAppIDKey(appID, privateKey)
 				if err != nil {
 					logger.Error("failed to write "+kind+" github app key from heartbeat",
 						"app_id", appID, "error", err)
@@ -4637,7 +4354,7 @@ func main() {
 			// primary key_file configured — the exact heartbeat-only-cluster state) still finds
 			// it: resolveAppKeyFile prefers /data/gh-app-key-<appid>.pem for the
 			// app_id we now claim. An explicit key_file still wins outright.
-			rebuildKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
+			rebuildKeyFile := appKeys.Resolve(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), cfg.GitHub.AppID)
 			if cfg.GitHub.HasUsableApp() && rebuildKeyFile != "" {
 				newAppAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, rebuildKeyFile, logger, cfg.GitHub.ResolvedAPIURL())
 				if err != nil {
@@ -5522,7 +5239,7 @@ func diagnoseGitHubAppFull(ctx context.Context, appAuth *github.AppAuth, expecte
 	if appAuth == nil {
 		return github.AppAuthDiagnosis{State: github.AppStateOK, ExpectedAccount: expectedOwner}
 	}
-	return appAuth.DiagnoseAppAuth(ctx, expectedOwner, spokeAppKeyPath, spokeProvisionedAppKeyPath)
+	return appAuth.DiagnoseAppAuth(ctx, expectedOwner, appKeys.DataKeyPath, appKeys.ProvisionedKeyPath)
 }
 
 // maxTimelineEnumeratePerCycle bounds how many enumerated-issue events a single

--- a/src/cmd/hive/main.go
+++ b/src/cmd/hive/main.go
@@ -137,14 +137,6 @@ const traceShutdownTimeout = 5 * time.Second
 // (persistState), loaded once at boot.
 const reachStatePath = "/data/reach-state.json"
 
-// perAppIDKeyPath returns the on-disk path of the key file a spoke uses for a
-// specific app_id — /data/gh-app-key-<appid>.pem. This is what lets one spoke
-// hold BOTH the github.com App key AND its cluster's GitHub Enterprise App key
-// at once and sign with whichever matches its configured app_id.
-//
-// Returns "" for a non-positive app_id (0 = unknown/unset, the placeholder
-// sentinel, or a hand-corrupted value): there is no meaningful per-app file for
-// those, and the caller falls back to the existing single-file behaviour.
 // agentActivityFor gathers the per-agent liveness evidence the hub needs to
 // tell a deliberately-paused agent from one that is running but unable to
 // work. Shared by both heartbeat build sites so the ordinary beat and the

--- a/src/docs/design/master-delivery-wrapped.md
+++ b/src/docs/design/master-delivery-wrapped.md
@@ -145,10 +145,10 @@ ambiguous (`master-key-rotation.md:461-463`).
 
 This mirrors an established pattern rather than inventing one. The spoke
 already persists private key material on the same PVC at the same mode:
-`spokeAppKeyPath = "/data/gh-app-key.pem"` (`src/cmd/hive/main.go:99`) and
-`spokeAppKeyDir = "/data"` (`:104`), with `spokeAppKeyFileMode = 0o600`
-(`:116`) and the comment "signing material must never be readable by anything
-else sharing the PVC or the pod" (`:114-115`). `/data` is the PVC mount in the spoke template
+`appkey.DefaultDataKeyPath = "/data/gh-app-key.pem"` and
+`appkey.DefaultDataDir = "/data"`, with `appkey.DefaultFileMode = 0o600`
+and the comment "signing material must never be readable by anything
+else sharing the PVC or the pod" (`src/pkg/appkey/appkey.go`). `/data` is the PVC mount in the spoke template
 (`src/pkg/hub/saas_provision.go:2585`), and `/data/hive-id` (`src/cmd/hive/main.go:5297`)
 already establishes that identity-critical state persists there across
 restarts.
@@ -363,9 +363,9 @@ context, not by the hub. The template already injects per-hive secret material
 (`src/pkg/hub/saas_provision.go:1966-1986`: `HeartbeatKey`, `SessionKey`, `SSOPublicKey`,
 `TerminalKey`, `InviteKey`), and the `/secrets` read-only projected mount
 (`src/pkg/hub/saas_provision.go:2763`) already carries private key material at provision
-time — `spokeProvisionedAppKeyPath = "/secrets/gh-app-key.pem"`
-(`src/cmd/hive/main.go:98`), which the spoke holds "from its very first boot —
-before any heartbeat has run" (`:108`).
+time — `appkey.DefaultProvisionedKeyPath = "/secrets/gh-app-key.pem"`
+(`src/pkg/appkey/appkey.go`), and per-app-id keys in that mount are available
+"from [a hive's] very first boot — before any heartbeat has run."
 
 So there is an existing, precedented channel for giving a spoke a secret at
 birth that the hub does not have to reach in to deliver.

--- a/src/pkg/appkey/appkey.go
+++ b/src/pkg/appkey/appkey.go
@@ -1,0 +1,345 @@
+// Package appkey owns the GitHub App signing-key files a spoke keeps on disk:
+// where they live, which one is correct for the App the hive claims, and how a
+// hub-delivered key is written down atomically.
+//
+// It was extracted from package main (hivecommons/hive#5898 phase 1), where it
+// sat as ~200 lines of domain logic in a 9,600-line file that CI never ran:
+// the test workflows run `go test ./pkg/...` only, so cmd/hive's tests — 475
+// lines of them for this logic alone — were never executed. Moving the code
+// here is what puts them under CI, with no workflow change.
+//
+// Deliberately NOT placed in pkg/github: this needs config.AppKeyFingerprint*,
+// and pkg/github#5953 phase 1 just removed that package's dependency on
+// pkg/config. Putting App-key file handling there would reintroduce exactly
+// the upward dependency that change deleted.
+package appkey
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+// Default paths on a running spoke.
+const (
+	DefaultDataDir            = "/data"
+	DefaultDataKeyPath        = "/data/gh-app-key.pem"
+	DefaultProvisionedDir     = "/secrets"
+	DefaultProvisionedKeyPath = "/secrets/gh-app-key.pem"
+	// DefaultFileMode is rw------- : signing material must never be readable by
+	// anything else sharing the PVC or the pod.
+	DefaultFileMode os.FileMode = 0o600
+)
+
+// perAppIDKeyFilePrefix / Suffix bracket the per-app-id key filename so a scan
+// of the directory can recover the app_id from the name.
+const (
+	perAppIDKeyFilePrefix = "gh-app-key-"
+	perAppIDKeyFileSuffix = ".pem"
+)
+
+// Resolver locates and writes App signing keys against a set of directories.
+//
+// The paths are fields rather than package-level vars — which is what they were
+// in package main — so a test can point one Resolver at a temp dir without
+// mutating state shared with every other test. Production uses Default().
+type Resolver struct {
+	// DataDir is the PVC directory where hub-delivered per-app-id keys land,
+	// one file per App the fleet knows: gh-app-key-<appid>.pem.
+	DataDir string
+	// DataKeyPath is the generic PVC key path older builds wrote on every key
+	// delivery. It does not name the App it holds; see Resolve.
+	DataKeyPath string
+	// ProvisionedDir is the read-only projected-Secret mount where provisioning
+	// places per-app-id keys. Nothing ever writes here; it is a lookup source.
+	ProvisionedDir string
+	// ProvisionedKeyPath is the generic path the provisioning template hardcodes
+	// for every App-using hive.
+	ProvisionedKeyPath string
+	// FileMode is applied to keys this Resolver writes.
+	FileMode os.FileMode
+}
+
+// Default returns a Resolver using the production spoke layout.
+func Default() *Resolver {
+	return &Resolver{
+		DataDir:            DefaultDataDir,
+		DataKeyPath:        DefaultDataKeyPath,
+		ProvisionedDir:     DefaultProvisionedDir,
+		ProvisionedKeyPath: DefaultProvisionedKeyPath,
+		FileMode:           DefaultFileMode,
+	}
+}
+
+func (r *Resolver) PerAppIDKeyPath(appID int64) string {
+	if appID <= 0 {
+		return ""
+	}
+	return filepath.Join(r.DataDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
+}
+
+// perAppIDProvisionedKeyPath is perAppIDKeyPath's read-only twin: the same
+// per-app-id filename under the provisioning Secret mount. It is consulted only
+// when the PVC has no usable key for the app_id, so a heartbeat-delivered key
+// (which can be rotated) always wins over the one baked in at provision time.
+func (r *Resolver) provisionedPerAppIDKeyPath(appID int64) string {
+	if appID <= 0 {
+		return ""
+	}
+	return filepath.Join(r.ProvisionedDir, fmt.Sprintf("gh-app-key-%d.pem", appID))
+}
+
+// heldPerAppIDKeyFingerprints scans the PVC for per-app-id key files
+// (gh-app-key-<appid>.pem) and returns app_id (decimal string) → fingerprint for
+// every one that holds a usable key. It is what the spoke reports so the hub
+// delivers the fleet's additional keys idempotently: a key already present with
+// the right fingerprint is not re-sent.
+//
+// It never returns key material — only fingerprints. A missing directory,
+// unreadable file, or unparseable key is silently skipped: the worst case is the
+// hub re-delivers a key the spoke already writes idempotently, never a crash.
+func (r *Resolver) HeldFingerprints() map[string]string {
+	entries, err := os.ReadDir(r.DataDir)
+	if err != nil {
+		return nil
+	}
+	var held map[string]string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, perAppIDKeyFilePrefix) || !strings.HasSuffix(name, perAppIDKeyFileSuffix) {
+			continue
+		}
+		idStr := strings.TrimSuffix(strings.TrimPrefix(name, perAppIDKeyFilePrefix), perAppIDKeyFileSuffix)
+		id, convErr := strconv.ParseInt(idStr, 10, 64)
+		if convErr != nil || id <= 0 {
+			continue
+		}
+		fp, fpErr := config.AppKeyFingerprintFromFile(filepath.Join(r.DataDir, name))
+		if fpErr != nil || fp == "" {
+			continue
+		}
+		if held == nil {
+			held = make(map[string]string)
+		}
+		held[idStr] = fp
+	}
+	return held
+}
+
+// writePerAppIDKey persists a hub-delivered per-app-id key to its PVC file
+// atomically (temp file in the same dir, then rename) with a restrictive 0600
+// mode from creation, so a spoke can never sign with a half-written key. Returns
+// the resulting fingerprint (never the key) for auditable logging, or an error.
+func (r *Resolver) WritePerAppIDKey(appID int64, pemData string) (string, error) {
+	path := r.PerAppIDKeyPath(appID)
+	if path == "" {
+		return "", fmt.Errorf("refusing to write key for non-positive app_id %d", appID)
+	}
+	trimmed := strings.TrimSpace(pemData)
+	if !strings.HasPrefix(trimmed, "-----BEGIN") {
+		return "", fmt.Errorf("app key for app_id %d is not PEM", appID)
+	}
+	fp, err := config.AppKeyFingerprint(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("app key for app_id %d is unusable: %w", appID, err)
+	}
+	if err := os.MkdirAll(r.DataDir, 0o700); err != nil {
+		return "", fmt.Errorf("create app key dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(r.DataDir, "."+filepath.Base(path)+".tmp*")
+	if err != nil {
+		return "", fmt.Errorf("create temp app key file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename below succeeds
+	if err := tmp.Chmod(r.FileMode); err != nil {
+		_ = tmp.Close() // best-effort cleanup; the chmod error is what's returned
+		return "", fmt.Errorf("chmod temp app key file: %w", err)
+	}
+	if _, err := tmp.WriteString(trimmed + "\n"); err != nil {
+		_ = tmp.Close() // best-effort cleanup; the write error is what's returned
+		return "", fmt.Errorf("write temp app key file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close() // best-effort cleanup; the sync error is what's returned
+		return "", fmt.Errorf("sync temp app key file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close temp app key file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return "", fmt.Errorf("rename app key into place: %w", err)
+	}
+	return fp, nil
+}
+
+// resolveAppKeyFile picks which App private key this process will actually sign
+// with, given the configured key_file and the GH_APP_KEY_FILE env override.
+//
+// WHY THE /data PREFERENCE MATTERS
+//
+// A hub-delivered key lands at r.DataKeyPath (/data, on the PVC) and the
+// heartbeat callback repoints cfg.GitHub.KeyFile at it — but only in memory, for
+// the life of that process. A hive whose config carries NO key_file (which is
+// the state of the three live GHE hives this repairs) used to fall straight
+// through to the read-only /secrets provisioning mount. That mount holds the
+// stale, wrong key, and the spoke cannot write to it. So on every restart the
+// hive would silently go back to signing with the key that cannot work, and the
+// hub — seeing the wrong fingerprint reported again — would redeliver forever.
+// The key would be delivered and never used: a fault that reads as fixed.
+//
+// So when nothing is explicitly configured, a key already present on the PVC is
+// preferred over the provisioning mount. An EXPLICIT key_file or env override
+// still wins outright: those are deliberate, and this must not silently redirect
+// an operator who named a path.
+//
+// PER-APP-ID SELECTION (the both-keys fix)
+//
+// appID is the App this process is configured to authenticate AS
+// (cfg.GitHub.AppID). When the hub has delivered a per-app-id key for exactly
+// that App — /data/gh-app-key-<appID>.pem — it is preferred over the generic
+// single-file paths, because it is provably the RIGHT key for the app_id we
+// claim. This is what lets a github.com hive on a GitHub-Enterprise cluster sign
+// with the github.com key even though its cluster default (and its single
+// /data/gh-app-key.pem) is the GHE key. It sits just below an explicit
+// key_file/env override — an operator who named a path still wins — and above
+// the generic fallbacks. appID <= 0 disables it entirely, so nothing changes for
+// a hive that reports no app_id.
+func (r *Resolver) Resolve(configured, envOverride string, appID int64) string {
+	if v := strings.TrimSpace(envOverride); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(configured); v != "" {
+		// MIGRATION. A configured key_file that is the GENERIC path is not an
+		// operator's choice — it is a value older builds wrote automatically on
+		// every key delivery, and it does not name the App it holds. When we can
+		// see a per-app-id key for the app_id we actually claim, that key is
+		// correct by construction and the generic pin is stale, so ignore it.
+		//
+		// Without this, the ~33 spokes already carrying
+		// key_file: /data/gh-app-key.pem keep signing with whichever App's key
+		// happens to sit there — the live 404 Integration not found — because an
+		// explicit value short-circuits the per-app-id lookup below.
+		//
+		// Deliberately narrow: only the exact generic path is overridden, and
+		// only when a usable per-app-id key exists. Any other path is a genuine
+		// operator override (a hive on a third App with a bespoke key location)
+		// and still wins outright.
+		//
+		// BOTH generic paths qualify. /data/gh-app-key.pem is what older builds
+		// wrote on every key delivery; /secrets/gh-app-key.pem is what the
+		// PROVISIONING TEMPLATE hardcodes for every App-using hive
+		// (saas_provision.go). Neither names the App it holds, and neither was
+		// typed by an operator. Until /secrets was included here, a provisioned
+		// hive could never change forges: the hub could correct app_id all it
+		// liked and the spoke kept signing with the provisioned key, which on
+		// the spoke-cluster pool was a placeholder matching NEITHER real App.
+		if v == r.DataKeyPath || v == r.ProvisionedKeyPath {
+			if p := r.PerAppIDKeyPath(appID); p != "" {
+				if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+					return p
+				}
+			}
+		}
+		return v
+	}
+	// Nothing explicitly configured. Prefer a per-app-id key matching the App we
+	// claim — the only key that is CORRECT-by-construction for this app_id — over
+	// the generic cluster/provisioned files. The fingerprint check (not mere
+	// existence) keeps an empty or truncated per-app file from shadowing a good
+	// generic key.
+	if p := r.PerAppIDKeyPath(appID); p != "" {
+		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+			return p
+		}
+	}
+	// Same idea, but from the read-only provisioning mount: a hive provisioned
+	// with the fleet's full key set can sign as its configured App on its very
+	// first boot, before any heartbeat has delivered anything to the PVC. Ranked
+	// BELOW the PVC copy so a rotated key delivered by heartbeat always wins over
+	// the one frozen into the Secret at provision time.
+	if p := r.provisionedPerAppIDKeyPath(appID); p != "" {
+		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+			return p
+		}
+	}
+	// Prefer a usable hub-delivered key on the PVC; fall back to the provisioning
+	// mount only when /data has no parseable key.
+	if fp, err := config.AppKeyFingerprintFromFile(r.DataKeyPath); err == nil && fp != "" {
+		return r.DataKeyPath
+	}
+	return r.ProvisionedKeyPath
+}
+
+// PerAppIDKeyPathFor is PerAppIDKeyPath for callers that already hold the
+// app_id in string form — notably the dashboard's forge-app inventory, which
+// builds its rows from the keys of HeldFingerprints. It exists so the
+// filename scheme stays inside this package instead of being reassembled by
+// every caller from exported prefix/suffix constants.
+func (r *Resolver) PerAppIDKeyPathFor(appIDStr string) string {
+	if appIDStr == "" {
+		return ""
+	}
+	return filepath.Join(r.DataDir, perAppIDKeyFilePrefix+appIDStr+perAppIDKeyFileSuffix)
+}
+
+// ReportedFingerprint is the fingerprint of the key this Resolver would
+// actually sign with, for reporting upward (the hub heartbeat). Moved here
+// from package main with the rest of the App-key file logic
+// (hivecommons/hive#5898 phase 1); it is a pure read over the same candidate
+// ladder Resolve walks, so it belongs beside it rather than in a binary.
+// reportedAppKeyFingerprint returns the non-secret fingerprint of the App key
+// this spoke is ACTUALLY using, for the heartbeat payload. It fingerprints the
+// resolved key file rather than a hard-coded path so the hub compares against
+// the key that would really sign a JWT.
+//
+// Returns "" whenever there is no usable key — no file, empty file, or
+// unparseable contents. All three mean the same thing to the hub ("this spoke
+// cannot authenticate") and are repaired identically. The private key itself is
+// never returned, and never enters the payload.
+func (r *Resolver) ReportedFingerprint(keyFile string, appID int64) string {
+	// Lead with the same path resolveAppKeyFile would sign with, so the hub is
+	// told about the key actually in effect and never about a shadowed one.
+	candidates := []string{
+		r.Resolve(keyFile, os.Getenv("GH_APP_KEY_FILE"), appID),
+		r.PerAppIDKeyPath(appID),
+		keyFile, r.DataKeyPath, r.ProvisionedKeyPath,
+	}
+	for _, p := range candidates {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+			return fp
+		}
+	}
+	return ""
+}
+
+// hasPerHiveAppKey reports whether this spoke's key came from a per-hive
+// provisioning secret rather than the cluster default. The provisioned mount is
+// read-only, so its mere existence with real PEM content is the signal — a
+// hub-delivered key can never create or alter it.
+//
+// When BOTH exist the hub-delivered PVC key is the one in effect (the callback
+// repoints cfg.GitHub.KeyFile at it), so this only claims an override while the
+// provisioned key is genuinely the one being used.
+func (r *Resolver) HasPerHiveKey(keyFile string, appID int64) bool {
+	fp, err := config.AppKeyFingerprintFromFile(r.ProvisionedKeyPath)
+	if err != nil || fp == "" {
+		return false
+	}
+	// The provisioned key exists. It is the effective credential only if the
+	// resolved key file still points at it — resolveAppKeyFile is the single
+	// authority on that, so an unconfigured hive that has already taken delivery
+	// of a /data key (or a per-app-id key) correctly stops claiming a per-hive
+	// override.
+	return r.Resolve(keyFile, os.Getenv("GH_APP_KEY_FILE"), appID) == r.ProvisionedKeyPath
+}

--- a/src/pkg/appkey/appkeyfile_test.go
+++ b/src/pkg/appkey/appkeyfile_test.go
@@ -1,4 +1,4 @@
-package main
+package appkey
 
 import (
 	"crypto/rand"
@@ -26,7 +26,7 @@ func writeTestKey(t *testing.T, path string) string {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(k),
 	})
-	if err := os.WriteFile(path, pemData, spokeAppKeyFileMode); err != nil {
+	if err := os.WriteFile(path, pemData, testKeys.FileMode); err != nil {
 		t.Fatalf("write key %s: %v", path, err)
 	}
 	fp, err := config.AppKeyFingerprint(string(pemData))
@@ -42,32 +42,32 @@ func writeTestKey(t *testing.T, path string) string {
 func redirectSpokeKeyPaths(t *testing.T) (dataPath, secretsPath string) {
 	t.Helper()
 	dir := t.TempDir()
-	origData, origSecrets, origDir := spokeAppKeyPath, spokeProvisionedAppKeyPath, spokeAppKeyDir
-	origProvDir := spokeProvisionedAppKeyDir
-	spokeAppKeyPath = filepath.Join(dir, "data-gh-app-key.pem")
-	spokeProvisionedAppKeyPath = filepath.Join(dir, "secrets-gh-app-key.pem")
+	origData, origSecrets, origDir := testKeys.DataKeyPath, testKeys.ProvisionedKeyPath, testKeys.DataDir
+	origProvDir := testKeys.ProvisionedDir
+	testKeys.DataKeyPath = filepath.Join(dir, "data-gh-app-key.pem")
+	testKeys.ProvisionedKeyPath = filepath.Join(dir, "secrets-gh-app-key.pem")
 	// Per-app-id keys land in this same temp dir, so perAppIDKeyPath and
 	// heldPerAppIDKeyFingerprints never touch the real /data.
-	spokeAppKeyDir = dir
+	testKeys.DataDir = dir
 	// The provisioning mount gets a SEPARATE dir: the PVC and the read-only
 	// Secret hold per-app-id files under identical names, so pointing both at one
 	// dir would make it impossible to tell which source a resolution came from.
-	spokeProvisionedAppKeyDir = filepath.Join(dir, "secrets")
-	if err := os.MkdirAll(spokeProvisionedAppKeyDir, 0o700); err != nil {
+	testKeys.ProvisionedDir = filepath.Join(dir, "secrets")
+	if err := os.MkdirAll(testKeys.ProvisionedDir, 0o700); err != nil {
 		t.Fatalf("mkdir provisioned key dir: %v", err)
 	}
 	t.Cleanup(func() {
-		spokeAppKeyPath, spokeProvisionedAppKeyPath, spokeAppKeyDir = origData, origSecrets, origDir
-		spokeProvisionedAppKeyDir = origProvDir
+		testKeys.DataKeyPath, testKeys.ProvisionedKeyPath, testKeys.DataDir = origData, origSecrets, origDir
+		testKeys.ProvisionedDir = origProvDir
 	})
-	return spokeAppKeyPath, spokeProvisionedAppKeyPath
+	return testKeys.DataKeyPath, testKeys.ProvisionedKeyPath
 }
 
 // TestResolveAppKeyFilePrefersDeliveredKey is the test that keeps the fix from
 // being cosmetic.
 //
 // The hub can deliver a correct key and the hive can still authenticate with the
-// wrong one: the delivered key lands on the PVC at spokeAppKeyPath, but the
+// wrong one: the delivered key lands on the PVC at testKeys.DataKeyPath, but the
 // stale operator-provisioned key sits at the read-only /secrets mount that the
 // spoke cannot overwrite. If resolution fell through to /secrets whenever
 // key_file was unset — which is exactly the state of the three broken GHE hives
@@ -84,7 +84,7 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 		}
 
 		// key_file unset — the vllmd-01..03 state.
-		got := resolveAppKeyFile("", "", 0)
+		got := testKeys.Resolve("", "", 0)
 		if got != dataPath {
 			t.Fatalf("resolveAppKeyFile = %q, want the delivered key at %q", got, dataPath)
 		}
@@ -100,13 +100,13 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 
 		// The heartbeat must report that same key, or the hub compares against a
 		// key that is not signing anything.
-		if reported := reportedAppKeyFingerprint("", 0); reported != goodFP {
+		if reported := testKeys.ReportedFingerprint("", 0); reported != goodFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, goodFP)
 		}
 
 		// And it must stop claiming a per-hive override, so the hub's idempotence
 		// check sees a plain match and stops pushing.
-		if hasPerHiveAppKey("", 0) {
+		if testKeys.HasPerHiveKey("", 0) {
 			t.Error("hasPerHiveAppKey = true after taking delivery; the /secrets key is no longer in effect")
 		}
 	})
@@ -116,16 +116,16 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 		provisionedFP := writeTestKey(t, secretsPath)
 		_ = dataPath // deliberately absent
 
-		got := resolveAppKeyFile("", "", 0)
+		got := testKeys.Resolve("", "", 0)
 		if got != secretsPath {
 			t.Fatalf("resolveAppKeyFile = %q, want the provisioned key at %q", got, secretsPath)
 		}
-		if reported := reportedAppKeyFingerprint("", 0); reported != provisionedFP {
+		if reported := testKeys.ReportedFingerprint("", 0); reported != provisionedFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
 		}
 		// A genuine per-hive credential must still be reported as such, so the
 		// hub's protective precedence keeps working.
-		if !hasPerHiveAppKey("", 0) {
+		if !testKeys.HasPerHiveKey("", 0) {
 			t.Error("hasPerHiveAppKey = false; a provisioned key in effect is a per-hive override")
 		}
 	})
@@ -135,14 +135,14 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 		provisionedFP := writeTestKey(t, secretsPath)
 		// An empty /data file is exactly what vllmd-06..09 had. Mere existence
 		// must not win — only a parseable key may.
-		if err := os.WriteFile(dataPath, nil, spokeAppKeyFileMode); err != nil {
+		if err := os.WriteFile(dataPath, nil, testKeys.FileMode); err != nil {
 			t.Fatal(err)
 		}
 
-		if got := resolveAppKeyFile("", "", 0); got != secretsPath {
+		if got := testKeys.Resolve("", "", 0); got != secretsPath {
 			t.Fatalf("resolveAppKeyFile = %q, want %q; an empty file is not a key", got, secretsPath)
 		}
-		if reported := reportedAppKeyFingerprint("", 0); reported != provisionedFP {
+		if reported := testKeys.ReportedFingerprint("", 0); reported != provisionedFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
 		}
 	})
@@ -152,19 +152,19 @@ func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
 		writeTestKey(t, dataPath)
 		explicit := filepath.Join(t.TempDir(), "operator-chosen.pem")
 
-		if got := resolveAppKeyFile(explicit, "", 0); got != explicit {
+		if got := testKeys.Resolve(explicit, "", 0); got != explicit {
 			t.Errorf("configured key_file = %q, want %q; an explicit path must not be redirected", got, explicit)
 		}
-		if got := resolveAppKeyFile("", explicit, 0); got != explicit {
+		if got := testKeys.Resolve("", explicit, 0); got != explicit {
 			t.Errorf("env override = %q, want %q", got, explicit)
 		}
 		// Env beats config, matching the original precedence.
 		other := filepath.Join(t.TempDir(), "from-config.pem")
-		if got := resolveAppKeyFile(other, explicit, 0); got != explicit {
+		if got := testKeys.Resolve(other, explicit, 0); got != explicit {
 			t.Errorf("env override = %q, want it to beat key_file %q", got, explicit)
 		}
 		// Whitespace is not a path.
-		if got := resolveAppKeyFile("  ", "  ", 0); got != dataPath {
+		if got := testKeys.Resolve("  ", "  ", 0); got != dataPath {
 			t.Errorf("blank inputs = %q, want the delivered key at %q", got, dataPath)
 		}
 	})
@@ -184,60 +184,60 @@ func TestResolveAppKeyFilePrefersPerAppIDKey(t *testing.T) {
 
 	t.Run("per-app-id key wins over the generic data key", func(t *testing.T) {
 		redirectSpokeKeyPaths(t)
-		clusterKeyFP := writeTestKey(t, spokeAppKeyPath) // GHE cluster default at /data
-		perAppPath := perAppIDKeyPath(githubAppID)
+		clusterKeyFP := writeTestKey(t, testKeys.DataKeyPath) // GHE cluster default at /data
+		perAppPath := testKeys.PerAppIDKeyPath(githubAppID)
 		githubKeyFP := writeTestKey(t, perAppPath) // github.com key, per-app-id file
 		if clusterKeyFP == githubKeyFP {
 			t.Fatal("test keys collided; the two paths must hold different keys")
 		}
 
-		got := resolveAppKeyFile("", "", githubAppID)
+		got := testKeys.Resolve("", "", githubAppID)
 		if got != perAppPath {
 			t.Fatalf("resolveAppKeyFile = %q, want the per-app-id key at %q", got, perAppPath)
 		}
 		// The key actually in effect — and the fingerprint the heartbeat reports —
 		// must be the github.com one, not the cluster default.
-		if reported := reportedAppKeyFingerprint("", githubAppID); reported != githubKeyFP {
+		if reported := testKeys.ReportedFingerprint("", githubAppID); reported != githubKeyFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want the github.com key %q", reported, githubKeyFP)
 		}
 	})
 
 	t.Run("a different app_id still gets the generic data key", func(t *testing.T) {
 		redirectSpokeKeyPaths(t)
-		clusterKeyFP := writeTestKey(t, spokeAppKeyPath)
+		clusterKeyFP := writeTestKey(t, testKeys.DataKeyPath)
 		// A per-app-id key exists for github.com, but this hive claims the GHE app.
-		writeTestKey(t, perAppIDKeyPath(githubAppID))
+		writeTestKey(t, testKeys.PerAppIDKeyPath(githubAppID))
 
 		const gheAppID int64 = 5686
-		got := resolveAppKeyFile("", "", gheAppID)
-		if got != spokeAppKeyPath {
-			t.Fatalf("resolveAppKeyFile = %q, want the generic data key at %q (no per-app file for this app_id)", got, spokeAppKeyPath)
+		got := testKeys.Resolve("", "", gheAppID)
+		if got != testKeys.DataKeyPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the generic data key at %q (no per-app file for this app_id)", got, testKeys.DataKeyPath)
 		}
-		if reported := reportedAppKeyFingerprint("", gheAppID); reported != clusterKeyFP {
+		if reported := testKeys.ReportedFingerprint("", gheAppID); reported != clusterKeyFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want the cluster key %q", reported, clusterKeyFP)
 		}
 	})
 
 	t.Run("empty per-app-id file does not shadow the generic key", func(t *testing.T) {
 		redirectSpokeKeyPaths(t)
-		clusterKeyFP := writeTestKey(t, spokeAppKeyPath)
+		clusterKeyFP := writeTestKey(t, testKeys.DataKeyPath)
 		// A truncated per-app file must never win — only a parseable key may.
-		if err := os.WriteFile(perAppIDKeyPath(githubAppID), nil, spokeAppKeyFileMode); err != nil {
+		if err := os.WriteFile(testKeys.PerAppIDKeyPath(githubAppID), nil, testKeys.FileMode); err != nil {
 			t.Fatal(err)
 		}
-		if got := resolveAppKeyFile("", "", githubAppID); got != spokeAppKeyPath {
-			t.Fatalf("resolveAppKeyFile = %q, want the generic key at %q; an empty per-app file is not a key", got, spokeAppKeyPath)
+		if got := testKeys.Resolve("", "", githubAppID); got != testKeys.DataKeyPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the generic key at %q; an empty per-app file is not a key", got, testKeys.DataKeyPath)
 		}
-		if reported := reportedAppKeyFingerprint("", githubAppID); reported != clusterKeyFP {
+		if reported := testKeys.ReportedFingerprint("", githubAppID); reported != clusterKeyFP {
 			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, clusterKeyFP)
 		}
 	})
 
 	t.Run("explicit key_file still beats a per-app-id key", func(t *testing.T) {
 		redirectSpokeKeyPaths(t)
-		writeTestKey(t, perAppIDKeyPath(githubAppID))
+		writeTestKey(t, testKeys.PerAppIDKeyPath(githubAppID))
 		explicit := filepath.Join(t.TempDir(), "operator-chosen.pem")
-		if got := resolveAppKeyFile(explicit, "", githubAppID); got != explicit {
+		if got := testKeys.Resolve(explicit, "", githubAppID); got != explicit {
 			t.Errorf("configured key_file = %q, want %q; an explicit path must not be redirected", got, explicit)
 		}
 	})
@@ -263,7 +263,7 @@ func TestWritePerAppIDKeyAndReport(t *testing.T) {
 		t.Fatalf("fingerprint: %v", err)
 	}
 
-	fp, err := writePerAppIDKey(appID, pemData)
+	fp, err := testKeys.WritePerAppIDKey(appID, pemData)
 	if err != nil {
 		t.Fatalf("writePerAppIDKey: %v", err)
 	}
@@ -272,24 +272,24 @@ func TestWritePerAppIDKeyAndReport(t *testing.T) {
 	}
 
 	// The file must be 0600 — signing material is never group/other readable.
-	info, err := os.Stat(perAppIDKeyPath(appID))
+	info, err := os.Stat(testKeys.PerAppIDKeyPath(appID))
 	if err != nil {
 		t.Fatalf("stat per-app key: %v", err)
 	}
-	if info.Mode().Perm() != spokeAppKeyFileMode {
-		t.Fatalf("per-app key mode = %o, want %o", info.Mode().Perm(), spokeAppKeyFileMode)
+	if info.Mode().Perm() != testKeys.FileMode {
+		t.Fatalf("per-app key mode = %o, want %o", info.Mode().Perm(), testKeys.FileMode)
 	}
 
 	// heldPerAppIDKeyFingerprints must surface exactly this app_id → fingerprint,
 	// which is what the hub diffs against to stop re-delivering.
-	held := heldPerAppIDKeyFingerprints()
+	held := testKeys.HeldFingerprints()
 	if got := held["3568013"]; got != wantFP {
 		t.Fatalf("heldPerAppIDKeyFingerprints[3568013] = %q, want %q (full map: %v)", got, wantFP, held)
 	}
 
 	// A non-positive app_id is refused rather than writing an ambiguous file.
-	if _, err := writePerAppIDKey(0, pemData); err == nil {
-		t.Error("writePerAppIDKey(0, ...) succeeded; a non-positive app_id must be refused")
+	if _, err := testKeys.WritePerAppIDKey(0, pemData); err == nil {
+		t.Error("testKeys.WritePerAppIDKey(0, ...) succeeded; a non-positive app_id must be refused")
 	}
 }
 
@@ -303,10 +303,10 @@ func TestResolveAppKeyFileUsesProvisionedPerAppIDKey(t *testing.T) {
 	redirectSpokeKeyPaths(t)
 	const publicAppID = 3568013
 
-	provisioned := perAppIDProvisionedKeyPath(publicAppID)
+	provisioned := testKeys.provisionedPerAppIDKeyPath(publicAppID)
 	writeTestKey(t, provisioned)
 
-	if got := resolveAppKeyFile("", "", publicAppID); got != provisioned {
+	if got := testKeys.Resolve("", "", publicAppID); got != provisioned {
 		t.Fatalf("want provisioned per-app-id key %s, got %s", provisioned, got)
 	}
 }
@@ -318,11 +318,11 @@ func TestResolveAppKeyFilePrefersPVCOverProvisionedPerAppID(t *testing.T) {
 	redirectSpokeKeyPaths(t)
 	const publicAppID = 3568013
 
-	writeTestKey(t, perAppIDProvisionedKeyPath(publicAppID))
-	pvc := perAppIDKeyPath(publicAppID)
+	writeTestKey(t, testKeys.provisionedPerAppIDKeyPath(publicAppID))
+	pvc := testKeys.PerAppIDKeyPath(publicAppID)
 	writeTestKey(t, pvc)
 
-	if got := resolveAppKeyFile("", "", publicAppID); got != pvc {
+	if got := testKeys.Resolve("", "", publicAppID); got != pvc {
 		t.Fatalf("rotated PVC key must win, want %s, got %s", pvc, got)
 	}
 }
@@ -332,11 +332,11 @@ func TestResolveAppKeyFileExplicitOverrideBeatsProvisionedPerAppID(t *testing.T)
 	redirectSpokeKeyPaths(t)
 	const publicAppID = 3568013
 
-	writeTestKey(t, perAppIDProvisionedKeyPath(publicAppID))
+	writeTestKey(t, testKeys.provisionedPerAppIDKeyPath(publicAppID))
 	named := filepath.Join(t.TempDir(), "operator-named.pem")
 	writeTestKey(t, named)
 
-	if got := resolveAppKeyFile(named, "", publicAppID); got != named {
+	if got := testKeys.Resolve(named, "", publicAppID); got != named {
 		t.Fatalf("explicit key_file must win, want %s, got %s", named, got)
 	}
 }
@@ -347,13 +347,13 @@ func TestResolveAppKeyFileIgnoresUnusableProvisionedPerAppIDKey(t *testing.T) {
 	dataPath, _ := redirectSpokeKeyPaths(t)
 	const publicAppID = 3568013
 
-	if err := os.WriteFile(perAppIDProvisionedKeyPath(publicAppID),
+	if err := os.WriteFile(testKeys.provisionedPerAppIDKeyPath(publicAppID),
 		[]byte("PLACEHOLDER-awaiting-github-app-key"), 0o600); err != nil {
 		t.Fatalf("write placeholder: %v", err)
 	}
 	writeTestKey(t, dataPath)
 
-	if got := resolveAppKeyFile("", "", publicAppID); got != dataPath {
+	if got := testKeys.Resolve("", "", publicAppID); got != dataPath {
 		t.Fatalf("unusable per-app-id key must be skipped, want %s, got %s", dataPath, got)
 	}
 }

--- a/src/pkg/appkey/provisioned_key_pin_test.go
+++ b/src/pkg/appkey/provisioned_key_pin_test.go
@@ -1,4 +1,4 @@
-package main
+package appkey
 
 import (
 	"os"
@@ -61,20 +61,20 @@ func writeTestAppKey(t *testing.T, path string) {
 func TestResolveAppKeyFileProvisionedGenericPinYieldsToPerAppID(t *testing.T) {
 	dir := isolateAppKeyLookup(t)
 
-	origDir := spokeAppKeyDir
-	spokeAppKeyDir = dir
-	t.Cleanup(func() { spokeAppKeyDir = origDir })
+	origDir := testKeys.DataDir
+	testKeys.DataDir = dir
+	t.Cleanup(func() { testKeys.DataDir = origDir })
 
 	const appID int64 = 5686
 	perApp := filepath.Join(dir, "gh-app-key-5686.pem")
 	writeTestAppKey(t, perApp)
 
 	// Exactly what provisioning writes into hive.yaml.
-	got := resolveAppKeyFile(spokeProvisionedAppKeyPath, "", appID)
+	got := testKeys.Resolve(testKeys.ProvisionedKeyPath, "", appID)
 	if got != perApp {
-		t.Errorf("resolveAppKeyFile(%q) = %q, want the per-app-id key %q — "+
+		t.Errorf("testKeys.Resolve(%q) = %q, want the per-app-id key %q — "+
 			"the provisioned generic pin must not block per-app-id selection",
-			spokeProvisionedAppKeyPath, got, perApp)
+			testKeys.ProvisionedKeyPath, got, perApp)
 	}
 }
 
@@ -84,9 +84,9 @@ func TestResolveAppKeyFileProvisionedGenericPinYieldsToPerAppID(t *testing.T) {
 func TestResolveAppKeyFileRealOperatorOverrideStillWins(t *testing.T) {
 	dir := isolateAppKeyLookup(t)
 
-	origDir := spokeAppKeyDir
-	spokeAppKeyDir = dir
-	t.Cleanup(func() { spokeAppKeyDir = origDir })
+	origDir := testKeys.DataDir
+	testKeys.DataDir = dir
+	t.Cleanup(func() { testKeys.DataDir = origDir })
 
 	const appID int64 = 5686
 	writeTestAppKey(t, filepath.Join(dir, "gh-app-key-5686.pem"))
@@ -94,8 +94,8 @@ func TestResolveAppKeyFileRealOperatorOverrideStillWins(t *testing.T) {
 	bespoke := filepath.Join(dir, "operator-chosen.pem")
 	writeTestAppKey(t, bespoke)
 
-	if got := resolveAppKeyFile(bespoke, "", appID); got != bespoke {
-		t.Errorf("resolveAppKeyFile(%q) = %q, want the operator's own path", bespoke, got)
+	if got := testKeys.Resolve(bespoke, "", appID); got != bespoke {
+		t.Errorf("testKeys.Resolve(%q) = %q, want the operator's own path", bespoke, got)
 	}
 }
 
@@ -105,12 +105,12 @@ func TestResolveAppKeyFileRealOperatorOverrideStillWins(t *testing.T) {
 func TestResolveAppKeyFileProvisionedPinKeptWithoutPerAppKey(t *testing.T) {
 	dir := isolateAppKeyLookup(t)
 
-	origDir := spokeAppKeyDir
-	spokeAppKeyDir = dir
-	t.Cleanup(func() { spokeAppKeyDir = origDir })
+	origDir := testKeys.DataDir
+	testKeys.DataDir = dir
+	t.Cleanup(func() { testKeys.DataDir = origDir })
 
-	if got := resolveAppKeyFile(spokeProvisionedAppKeyPath, "", 5686); got != spokeProvisionedAppKeyPath {
+	if got := testKeys.Resolve(testKeys.ProvisionedKeyPath, "", 5686); got != testKeys.ProvisionedKeyPath {
 		t.Errorf("resolveAppKeyFile = %q, want %q kept when no per-app-id key exists",
-			got, spokeProvisionedAppKeyPath)
+			got, testKeys.ProvisionedKeyPath)
 	}
 }

--- a/src/pkg/appkey/testkeys_test.go
+++ b/src/pkg/appkey/testkeys_test.go
@@ -1,0 +1,31 @@
+package appkey
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// testKeys mirrors the package-level path vars these tests mutated when this
+// code lived in package main: the tests were moved here unchanged apart from a
+// mechanical rename onto this Resolver, so their save/restore patterns and
+// assertions are byte-for-byte the same logic they were before the move
+// (hivecommons/hive#5898 phase 1).
+var testKeys = Default()
+
+// isolateAppKeyLookup points the shared test Resolver at an empty temp dir so a
+// test starts from "no key anywhere". Duplicated from cmd/hive's copy when this
+// logic moved here (hivecommons/hive#5898 phase 1): both packages now have
+// tests that need the isolation, and a ten-line test helper is not worth an
+// exported testing surface.
+func isolateAppKeyLookup(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	origData, origSecrets := testKeys.DataKeyPath, testKeys.ProvisionedKeyPath
+	testKeys.DataKeyPath = filepath.Join(dir, "absent-data-key.pem")
+	testKeys.ProvisionedKeyPath = filepath.Join(dir, "absent-secrets-key.pem")
+	t.Setenv("GH_APP_KEY_FILE", "")
+	t.Cleanup(func() {
+		testKeys.DataKeyPath, testKeys.ProvisionedKeyPath = origData, origSecrets
+	})
+	return dir
+}


### PR DESCRIPTION
## Summary

`cmd/hive/main.go` is 9,669 lines. That matters for more than readability: the
test workflows run `go test ./pkg/...`, so **nothing in `cmd/` is executed by
CI at all** — and the GitHub App signing-key logic living in `main.go` had 475
lines of tests that had therefore never run there.

This moves that logic into a new `pkg/appkey`, tests included. They now run
under `./pkg/...` with no workflow change, which is the concrete payoff the
issue identifies.

```
main.go: 9,669 → 9,386 lines,  136 → 129 top-level functions
```

**No behaviour change.** Phase 1 of the extraction the issue proposes.

## What moved

The App-key file lifecycle: where a spoke's keys live, which one is correct for
the App this hive claims, how a hub-delivered key is written down atomically,
and the two read-only reports over that same resolution ladder.

| moved | now |
| --- | --- |
| `perAppIDKeyPath` | `(*Resolver).PerAppIDKeyPath` |
| `perAppIDProvisionedKeyPath` | `(*Resolver).provisionedPerAppIDKeyPath` |
| `resolveAppKeyFile` | `(*Resolver).Resolve` |
| `writePerAppIDKey` | `(*Resolver).WritePerAppIDKey` |
| `heldPerAppIDKeyFingerprints` | `(*Resolver).HeldFingerprints` |
| `reportedAppKeyFingerprint` | `(*Resolver).ReportedFingerprint` |
| `hasPerHiveAppKey` | `(*Resolver).HasPerHiveKey` |

The last two were not on the issue's list; they came along because the moved
tests exercise them and they are pure reads over the same ladder `Resolve`
walks. Leaving them behind would have split one piece of logic across two
packages.

## Three decisions worth review

**Not `pkg/github`, which is where the issue suggests.** This code needs
`config.AppKeyFingerprint*`, and #5953 phase 1 has just removed `pkg/github`'s
dependency on `pkg/config`. Putting App-key handling there would reintroduce
exactly the upward dependency that change deleted. `pkg/appkey` depends on
`pkg/config` and is depended on by `cmd/hive` — the natural direction, and it
keeps both issues' goals intact.

**The path vars became `Resolver` fields.** This was forced rather than chosen:
they were unexported package vars that tests reassigned *and* that non-moving
`main` code still reads, so a literal move would have had to export mutable
globals. A struct avoids that. The side effect is a better seam — each test
gets its own `Resolver` instead of mutating state shared with every other test
in the package.

**`healGitHubAppInstallation` deliberately stays in `main`.** It mutates `cfg`
and calls `cfg.Save()`. That is application wiring, not the "pure/leaf helpers
with existing seams" phase 1 targets, and moving it would drag config mutation
into the new package.

## Reviewing the test move

The two test files are detected as renames, and moved **unchanged apart from a
mechanical rename onto the `Resolver`** — no assertion, table entry or case was
rewritten. The diff is reviewable as a move rather than a rewrite, which is the
point.

Two ten-line helpers (`writeTestKey`, `isolateAppKeyLookup`) are now duplicated
across the split. Both packages have tests that need them, and duplicating test
scaffolding beats exporting a testing surface from a production package.

## Testing

- [x] `cd src && go build ./...`
- [x] `cd src && go test ./pkg/appkey/...` — 10 tests, all pass; these are the
      ones CI could not previously reach
- [x] `cd src && go test ./cmd/hive/...` — pass
- [x] `cd src && go vet ./pkg/appkey/ ./cmd/hive/` — clean
- [x] `gofmt -l` clean on both packages
- [x] Other / not run (explain): full `go test ./...` not run locally; the
      change is confined to `cmd/hive` and the new package. CI covers the rest.

`go list -deps ./pkg/appkey` pulls only `pkg/config` and `pkg/resolve` — the new
package is not a second grab-bag.

## Scope

Phase 1 only, and only the first of its three suggested groups. The
budget-suppression state machines, the heartbeat/quota computation, and the
`main()` split into `run(cfg, deps) error` are untouched, so the issue should
stay open — hence `Part of` rather than `Fixes`.

## Note for reviewers

No changelog fragment: `changelog.d/README.md` says routine refactors need none
and this has no operator-visible effect. Happy to add one, or take the
`no-changelog` label, if the guard asks.

Part of #5898

— hive: backend=claude model=claude opus 5 high

Refs #5898
