### PR TITLE
🌱 ci: repoint reusable workflows to hivecommons/infra (P4)

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   label:
-    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-add-help-wanted.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -35,7 +35,7 @@ jobs:
     # kubestellar/infra's main could alter what runs here with our credentials.
     # Bump this SHA deliberately when adopting a reviewed change to the reusable
     # workflow.
-    uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-ai-fix.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   assignment-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-assignment-helper.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-copilot-automation.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
     secrets:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   copilot-dco:
-    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-copilot-dco.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   feedback:
-    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-feedback.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   greet:
-    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-greetings.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   label-helper:
-    uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-label-helper.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   analysis:
-    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@dd836e89cb97c6e433067497ebcb355a01741aad # kubestellar/infra main as of 2026-09-01
+    uses: hivecommons/infra/.github/workflows/reusable-scorecard.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   stale:
-    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@1a04a3fd17771e78e5cf6d42a3fda84e3ba478f3 # kubestellar/infra main as of 2026-08-11
+    uses: hivecommons/infra/.github/workflows/reusable-stale.yml@f1c0b61675386f54e63c04cf07b3aa933cc963eb # hivecommons/infra main as of 2026-09-02

--- a/changelog.d/changed-p4-infra-mirrors.md
+++ b/changelog.d/changed-p4-infra-mirrors.md
@@ -1,0 +1,1 @@
+- Reusable CI workflows now come from `hivecommons/infra` instead of `kubestellar/infra`, completing the org transfer for the last 10 callers. The mirrored copies carry Apache-2.0 attribution to the KubeStellar Authors and swap KubeStellar-specific links for Hive Commons ones; behavior is otherwise unchanged.


### PR DESCRIPTION
## Summary

Completes the P4 half of the org transfer: the last 10 workflow callers still resolved their reusable workflows through `kubestellar/infra`. They now point at the `hivecommons/infra` mirror, pinned to `f1c0b616`.

## Verification done before repointing

- **All 10 files exist at the pinned SHA.** Checked individually via the contents API at `?ref=f1c0b616`, because a pin to a commit missing the file fails at run time rather than at lint.
- **Content differences reviewed.** The mirrored copies are not byte-identical to the kubestellar originals. The diffs are the intended de-branding and nothing else: Apache-2.0 attribution headers crediting the KubeStellar Authors, and KubeStellar Console / Marketplace / Knowledge Base links replaced with the Hive Commons discussions page (`reusable-feedback.yml` also renames its `survey_url` description accordingly). No logic changes.

## Deliberately NOT changed

**Historical issue citations.** 385 references of the form `kubestellar/hive#2393` remain in comments across the Justfile, `bin/`, and elsewhere. Those name where an issue was actually filed; rewriting them would falsify the record. GitHub redirects resolve them correctly.

**Dual-publish references.** The 4 remaining `ghcr.io/kubestellar` mentions are the intentional dual-publish window in `tagged-release.yml` and the migration doc describing it.

## P3 status, for context

The `migrate/standalone-assets-hivecommons` branch turned out to be already upstream - a rebase onto v4 dropped its only commit as "patch contents already upstream", and the tree now has zero `ghcr.io/kubestellar` references under `bin/`, `src/deploy/`, or `docker-compose.yaml`. On the cluster, 30 hive workloads run `ghcr.io/hivecommons` images and none run the old org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmdVsn5zULh5KVpFkYrX59