### PR TITLE
✨ ci(release): enforce the stable soak policy — promote stable by digest only after soak

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -432,7 +432,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/${{ github.repository_owner }}/hive /tmp/digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 true stable,candidate
+            v4 true candidate
 
       # ---- Cross-org mirror (kubestellar <-> hivecommons dual-publish) ----
       # Copy the tags just published above into the other org's GHCR
@@ -496,7 +496,7 @@ jobs:
           # publish step above — keep them in lockstep with that call.
           INCLUDE_LATEST: "true"
           RELEASE_BRANCH: "v4"
-          CHANNELS: "stable,candidate"
+          CHANNELS: "candidate"
         run: |
           set -euo pipefail
           # Same tag set publish-image-tags.sh manages for this image. Each
@@ -634,7 +634,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/${{ github.repository_owner }}/hive-contributor /tmp/contrib-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 true stable,candidate
+            v4 true candidate
 
       # Cross-org mirror — same mechanics, same missing-secret asymmetry, and
       # same "one credential per registry host" ordering constraint as the
@@ -677,7 +677,7 @@ jobs:
           # Lockstep with the publish-image-tags.sh args above.
           INCLUDE_LATEST: "true"
           RELEASE_BRANCH: "v4"
-          CHANNELS: "stable,candidate"
+          CHANNELS: "candidate"
         run: |
           set -euo pipefail
           branch_tag="${BRANCH//\//-}"
@@ -817,7 +817,7 @@ jobs:
           src/scripts/publish-image-tags.sh \
             ghcr.io/${{ github.repository_owner }}/hive-hub /tmp/hub-digests \
             '${{ github.ref_name }}' '${{ github.sha }}' '${{ github.run_number }}' \
-            v4 true stable,candidate
+            v4 true candidate
 
       # Cross-org mirror — same mechanics, same missing-secret asymmetry, and
       # same "one credential per registry host" ordering constraint as the
@@ -860,7 +860,7 @@ jobs:
           # Lockstep with the publish-image-tags.sh args above.
           INCLUDE_LATEST: "true"
           RELEASE_BRANCH: "v4"
-          CHANNELS: "stable,candidate"
+          CHANNELS: "candidate"
         run: |
           set -euo pipefail
           branch_tag="${BRANCH//\//-}"

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -1,0 +1,148 @@
+name: Promote Stable Channel
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Evaluate only; do not move stable tags'
+        type: boolean
+        default: true
+      soak-hours:
+        description: 'Minimum candidate soak window in hours'
+        type: string
+        default: '24'
+      smoke-evidence:
+        description: 'Maintained-hive heartbeat/dashboard evidence, or why smoke is not applicable'
+        type: string
+        required: false
+        default: ''
+      emergency-exception-reason:
+        description: 'Emergency promotion note; must name risk of waiting, checks that passed, and rollback digest'
+        type: string
+        required: false
+        default: ''
+      emergency-followup-issue:
+        description: 'Follow-up issue for skipped soak/smoke evidence when using an emergency exception'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  issues: write
+  packages: write
+
+concurrency:
+  group: stable-promotion-v4
+  cancel-in-progress: false
+
+env:
+  RELEASE_BRANCH: v4
+  SOAK_HOURS: ${{ inputs.soak-hours || '24' }}
+  DRY_RUN: ${{ inputs.dry-run || 'false' }}
+  IMAGE_NAMES: hive hive-contributor hive-hub
+  BLOCKER_LABEL: release-blocker
+  SMOKE_EVIDENCE: ${{ inputs.smoke-evidence || vars.STABLE_SMOKE_EVIDENCE || '' }}
+  EMERGENCY_EXCEPTION_REASON: ${{ inputs.emergency-exception-reason || '' }}
+  EMERGENCY_FOLLOWUP_ISSUE: ${{ inputs.emergency-followup-issue || '' }}
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout promotion scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to native GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Select cross-registry mirror target
+        id: registries
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ "$OWNER" = "kubestellar" ]; then
+            cross_org=hivecommons
+            cross_secret=GHCR_HIVECOMMONS_PAT
+          else
+            cross_org=kubestellar
+            cross_secret=GHCR_KUBESTELLAR_PAT
+          fi
+          echo "cross_org=${cross_org}" >> "$GITHUB_OUTPUT"
+          echo "cross_secret=${cross_secret}" >> "$GITHUB_OUTPUT"
+
+      - name: Check cross-registry credential before publishing
+        id: crosspat
+        if: env.DRY_RUN != 'true'
+        env:
+          CROSS_PAT: ${{ secrets[steps.registries.outputs.cross_secret] }}
+          CROSS_ORG: ${{ steps.registries.outputs.cross_org }}
+          CROSS_SECRET_NAME: ${{ steps.registries.outputs.cross_secret }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CROSS_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          if [ "$OWNER" = "hivecommons" ]; then
+            echo "::error::secret ${CROSS_SECRET_NAME} is not set, so this run cannot mirror stable to ghcr.io/${CROSS_ORG}; refusing a one-sided native promotion."
+            exit 1
+          fi
+          echo "::warning::secret ${CROSS_SECRET_NAME} is not set — a native stable promotion will skip the ghcr.io/${CROSS_ORG} mirror."
+
+      - name: Evaluate and promote native stable tags
+        id: native
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+        run: src/scripts/promote-stable.sh promote
+
+      - name: Log in to GHCR as the cross-org publisher
+        if: steps.crosspat.outputs.available == 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets[steps.registries.outputs.cross_secret] }}
+
+      - name: Mirror promoted stable tags into the cross-org registry
+        if: steps.crosspat.outputs.available == 'true'
+        env:
+          NATIVE_PREFIX: ghcr.io/${{ github.repository_owner }}
+          CROSS_PREFIX: ghcr.io/${{ steps.registries.outputs.cross_org }}
+        run: |
+          set -euo pipefail
+          for image in $IMAGE_NAMES; do
+            digest=$(docker buildx imagetools inspect "${NATIVE_PREFIX}/${image}:stable" --format '{{.Manifest.Digest}}')
+            src/scripts/promote-stable.sh mirror-stable "${CROSS_PREFIX}/${image}" "${NATIVE_PREFIX}/${image}@${digest}" "$DRY_RUN"
+          done
+
+      - name: Record emergency exception on follow-up issue
+        if: steps.native.outputs.promoted == 'true' && env.EMERGENCY_EXCEPTION_REASON != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FOLLOWUP: ${{ env.EMERGENCY_FOLLOWUP_ISSUE }}
+          REASON: ${{ env.EMERGENCY_EXCEPTION_REASON }}
+          DIGEST: ${{ steps.native.outputs.candidate_digest }}
+          SHA: ${{ steps.native.outputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          unset GITHUB_TOKEN && gh issue comment "$FOLLOWUP" --body "Emergency stable promotion exception used for ${SHA} (${DIGEST}): ${REASON}"

--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Docker release-tag publication policy (#4804)
         run: bash scripts/test-publish-image-tags.sh
 
+      - name: Stable soak promotion policy (#5974)
+        run: bash scripts/test-promote-stable.sh
+
       # #5142: v4.0.1 failed to publish twice in a row inside tagged-release.yml's
       # final push — once on GH006 propagation lag (branch protection had not
       # yet ingested the just-earned gate check), once on a non-fast-forward

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,11 +62,11 @@ issues. Accepted workstreams:
   the same PR.
 - **Channel-based release trains.** The three channels — `edge` (newest
   good build), `candidate` (awaiting soak), `stable` (promoted after
-  soak) — exist today as moving GHCR tags, and divergence has begun: `v4`
-  builds publish `stable` and `candidate` while `v5` builds publish
-  `edge`. Remaining work is the soak/promotion policy in CI and
-  digest-verifiable deployment, so what a spoke runs is provable rather
-  than inferred from a tag. See
+  soak) — exist as moving GHCR tags with enforced divergence: `v4` builds
+  publish `candidate`, the stable-promotion workflow advances `stable` by
+  digest after the soak/evidence/blocker/smoke gate, and `v5` builds
+  publish `edge`. Remaining work is digest-verifiable deployment, so what
+  a spoke runs is provable rather than inferred from a tag. See
   [release channels](src/docs/release-channels.md).
 - **Multi-spoke constellations.** A production external deployment
   (tunaos.org: a self-hosted hub coordinating two spokes at ACMM L5/L6

--- a/changelog.d/added-5974-stable-soak-promotion.md
+++ b/changelog.d/added-5974-stable-soak-promotion.md
@@ -1,0 +1,1 @@
+- Enforce the v4 stable soak policy in CI: `candidate` continues to advance on every green v4 image build, while `stable` is promoted later by digest only after the soak, evidence, blocker, smoke, and monotonic safety gates pass.

--- a/src/docs/release-channels.md
+++ b/src/docs/release-channels.md
@@ -8,19 +8,19 @@ Hive publishes three **release channels** — moving GHCR image tags an operator
 | `candidate` | A build believed good, awaiting soak before promotion to stable. |
 | `edge` | The newest good build, with no soak period. |
 
-> **Note — current promotion policy:** the channels have begun to diverge by release line. Every merge to **`v4`** retags **`stable` and `candidate`** (so those two still point at the same digest as `v4-latest`), while every merge to **`v5`** retags **`edge`** — meaning `edge` is now an **active-development v5 build**, not a synonym for `stable`. What has *not* landed yet is the soak/promotion step between `candidate` and `stable` (see [#3702](https://github.com/hivecommons/hive/pull/3702) for the channel plumbing): within the `v4` line, treat those two names as forward-looking track selection, not as a guarantee of differing maturity yet. The proposed v4 gate is documented in [v4 stable soak and promotion policy](stable-soak-policy.md).
+> **Promotion policy:** the channels diverge by release line and maturity. Every green merge to **`v4`** retags **`candidate`**; **`stable`** advances later by digest through the scheduled/manual stable-promotion workflow after the [v4 stable soak and promotion policy](stable-soak-policy.md) passes. Merges to **`v5`** retag **`edge`**, so `edge` is an active-development v5 build, not a synonym for `stable`.
 
 ## How channels are published
 
-Channels are **retags, not rebuilds**. Each release line's `docker.yml` workflow adds its channels as extra tags in the same `docker buildx imagetools create` call that publishes the branch's `-latest` and immutable short-SHA tags, so a channel always points at an already-built, multi-arch digest. Builds of branch `v4` publish `stable` and `candidate`; builds of branch `v5` publish `edge`. All three images get their line's channels in both published orgs:
+Channels are **retags, not rebuilds**. Each release line's `docker.yml` workflow adds fast-moving channels as extra tags in the same `docker buildx imagetools create` call that publishes the branch's `-latest` and immutable short-SHA tags, so a channel always points at an already-built, multi-arch digest. Builds of branch `v4` publish `candidate`; the separate stable-promotion workflow later retags `stable` by candidate digest after the soak gate passes. Builds of branch `v5` publish `edge`. All three images get their line's channels in both published orgs:
 
-- `ghcr.io/hivecommons/hive` and `ghcr.io/hivecommons/hive`
-- `ghcr.io/hivecommons/hive-contributor` and `ghcr.io/hivecommons/hive-contributor`
-- `ghcr.io/hivecommons/hive-hub` and `ghcr.io/hivecommons/hive-hub`
+- `ghcr.io/hivecommons/hive` and `ghcr.io/kubestellar/hive`
+- `ghcr.io/hivecommons/hive-contributor` and `ghcr.io/kubestellar/hive-contributor`
+- `ghcr.io/hivecommons/hive-hub` and `ghcr.io/kubestellar/hive-hub`
 
 The `hivecommons` packages are mirror tags of the same manifest digest as the native `kubestellar` packages during the org transfer, so operators can verify or pin the digest against either registry. Only builds of the release branches (`v4`, `v5`) publish channels — a feature-branch build can never move a production channel.
 
-Publishing is monotonic by workflow run number. Every successful multi-arch build receives its immutable short-SHA tag even if a newer merge has already reached the branch. If that exact short-SHA tag already exists, a re-run leaves it untouched. Moving tags (the branch's `-latest` tag and its channels) advance only when that build is newer than the generation currently published; an older workflow that runs out of queue order publishes only any missing immutable tag. This avoids both failure modes of a HEAD-only guard: a merge burst cannot starve all tags, and an old queued build cannot move a channel backwards. Registry inspection failures fail the publish job instead of producing a silent green skip.
+Publishing is monotonic by workflow run number. Every successful multi-arch build receives its immutable short-SHA tag even if a newer merge has already reached the branch. If that exact short-SHA tag already exists, a re-run leaves it untouched. Moving tags (the branch's `-latest` tag and fast channels such as `candidate`/`edge`) advance only when that build is newer than the generation currently published; an older workflow that runs out of queue order publishes only any missing immutable tag. `stable` uses the same generation guard during digest promotion, so a delayed promotion cannot move it backwards over a newer stable. Registry inspection failures fail the publish or promotion job instead of producing a silent green skip.
 
 Short-SHA tags are retained as a bounded rollback/debug window, not forever. The scheduled GHCR pruning workflow deletes only old package versions whose complete tag set is one or more 7-hex short-SHA tags, after 90 days. Versions still carrying any moving tag (`v4-latest`, `latest`, `stable`, `candidate`, `edge`, or future channel names) are never deleted by that cleanup.
 

--- a/src/docs/roadmap.md
+++ b/src/docs/roadmap.md
@@ -29,7 +29,7 @@ order, not priority rank.
 | Retrospective learning lane | Build from deterministic post-completion advisory beads toward LLM-assisted retro summaries and knowledge extraction. | [#2809](https://github.com/hivecommons/hive/issues/2809), [retro lane](retro-lane.md) |
 | ADR back-fill for remaining subsystems | **Done.** Back-filled accepted ADRs capture the knowledge system, skill registry, CEL/channel triggers, and hub/spoke mechanics, so architecture decisions stay auditable. | [ADR-0011](adr/0011-knowledge-system.md), [ADR-0012](adr/0012-skill-registry.md), [ADR-0013](adr/0013-cel-triggers.md), [ADR-0014](adr/0014-hub-spoke.md) |
 | HiveCommons org migration | Make the kubestellar-to-hivecommons migration auditable before package or repository defaults change, including image mirror phases, docs sweeps, v5 edge coverage, and operator communications. | [migration tracker](hivecommons-migration.md), [#5686](https://github.com/hivecommons/hive/issues/5686) |
-| v4 stable soak gate | Define the candidate-to-stable soak window, emergency exception path, and CI promotion shape so bursty v4 merge days do not immediately advance the operator-facing stable tag. | [stable soak policy](stable-soak-policy.md), [#5744](https://github.com/hivecommons/hive/issues/5744) |
+| v4 stable soak gate | **Done.** CI now keeps `candidate` moving on every green v4 image build and promotes `stable` later by digest only after the soak, evidence, blocker, smoke, and monotonic guards pass. | [stable soak policy](stable-soak-policy.md), [#5974](https://github.com/hivecommons/hive/issues/5974) |
 
 ## Next
 

--- a/src/docs/stable-soak-policy.md
+++ b/src/docs/stable-soak-policy.md
@@ -1,9 +1,8 @@
 # v4 stable soak and promotion policy
 
-This proposal closes the policy gap where every successful `v4` merge retags both
-`candidate` and `stable`. Until the CI promotion step is implemented, operators
-should treat `stable` as a compatibility tag, not as evidence that the build has
-soaked longer than `candidate`.
+This policy is enforced by CI: every successful `v4` image build retags
+`candidate`, while a separate scheduled or manually dispatched promotion
+workflow advances `stable` by digest only after the gate below passes.
 
 ## Goals
 
@@ -34,38 +33,40 @@ conditions hold:
 The release captain records the promoted digest, candidate tag, stable tag, soak
 start/end time, and smoke evidence in the promotion PR or workflow summary.
 
-## Emergency promotion exception
-
-Security and data-loss fixes may promote faster than 24 hours when the maintainer
-who owns the release writes an explicit exception note naming:
-
-- the risk of waiting;
-- the checks that did pass;
-- the rollback digest; and
-- the follow-up issue for any skipped soak evidence.
-
-Emergency promotion should still publish `candidate` first. The exception only
-shortens the candidate-to-stable delay; it does not bypass builds or tests.
-
-## CI shape
+## CI enforcement
 
 The existing release build continues to publish immutable short-SHA tags and move
-`candidate`. A separate scheduled or manually dispatched promotion workflow should
-then:
+`candidate`; it no longer moves `stable` on every `v4` merge. The
+`Promote Stable Channel` workflow runs hourly and can also be manually dispatched.
+It:
 
-1. resolve the current `candidate` digest;
-2. compare it with the current `stable` digest;
-3. read the candidate's first-seen time from workflow artifacts, tag metadata, or
-   a checked-in promotion ledger;
-4. evaluate the gate above; and
-5. retag `stable` to the candidate digest only when the gate passes.
+1. resolves the current `candidate` digest for `hive`, `hive-contributor`, and
+   `hive-hub`;
+2. compares the candidate digest with the current `stable` digest;
+3. reads the candidate's first-seen time from the successful `docker.yml` run
+   number recorded in the image metadata;
+4. requires successful `v2 CI` and `v2 Tests` workflow evidence for the
+   candidate SHA;
+5. requires no open issue or PR labelled `release-blocker`;
+6. requires maintained-hive smoke evidence from the dispatch input or the
+   `STABLE_SMOKE_EVIDENCE` repository variable; and
+7. retags `stable` to the candidate digest only when the gate passes and the
+   moving-tag generation is newer than the currently published `stable` tag.
 
-If the gate fails, the workflow exits neutral with a human-readable reason such as
-`candidate age 7h14m < 24h` or `newer candidate superseded digest`.
+The workflow writes the candidate digest, SHA, generation, first-seen time, age,
+checks consulted, blocker count, smoke evidence, decision, and any exception note
+to the GitHub Actions step summary. If the gate fails, the workflow leaves
+`stable` unchanged with a human-readable reason such as `candidate age 3600s <
+required 86400s (24h)` or `newer candidate superseded this digest before the soak
+window completed`.
 
-## Operator guidance while CI catches up
+## Emergency promotion exception
 
-Until the promotion workflow exists, operators that need soak protection should
-pin an immutable short-SHA tag, or track `candidate`/`stable` only on hives where
-a same-day auto-upgrade is acceptable. Release notes and changelog entries should
-call out any burst release days so fleets can decide whether to defer upgrades.
+Manual dispatch may set `emergency-exception-reason` to shorten the 24-hour soak.
+The reason must name the risk of waiting, the checks that passed, and the
+rollback digest, and `emergency-followup-issue` must name the follow-up issue for
+skipped soak or smoke evidence. The exception still requires the candidate to be
+current, required workflows to be green, no open `release-blocker`, and the
+monotonic generation guard to pass. When an emergency promotion succeeds, the
+workflow records the exception in the step summary and comments on the follow-up
+issue.

--- a/src/scripts/promote-stable.sh
+++ b/src/scripts/promote-stable.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# Evaluate and publish v4 candidate -> stable promotions by manifest digest.
+set -euo pipefail
+
+SOAK_HOURS_DEFAULT=24
+RELEASE_BRANCH_DEFAULT=v4
+CANDIDATE_CHANNEL_DEFAULT=candidate
+STABLE_CHANNEL_DEFAULT=stable
+IMAGE_NAMES_DEFAULT="hive hive-contributor hive-hub"
+BLOCKER_LABEL_DEFAULT=release-blocker
+SMOKE_VAR_DEFAULT=STABLE_SMOKE_EVIDENCE
+RUN_LABEL=io.kubestellar.hive.github-actions-run-number
+REVISION_LABEL=org.opencontainers.image.revision
+DOCKER_WORKFLOW_DEFAULT=docker.yml
+REQUIRED_WORKFLOWS_DEFAULT="v2-ci.yml v2-tests.yml"
+
+usage() {
+  cat >&2 <<USAGE
+usage: $0 decide|promote|publish-stable
+
+Subcommands:
+  decide          Evaluate env-provided gate facts and print decision=<promote|hold>.
+  promote         Resolve GHCR/GitHub evidence, evaluate, and optionally move stable.
+  publish-stable  Move one IMAGE:stable to DIGEST after the monotonic guard passes.
+  mirror-stable   Move TARGET_IMAGE:stable from SOURCE_REF after the same guard passes.
+USAGE
+}
+
+bool() { [[ ${1:-} == true || ${1:-} == 1 || ${1:-} == yes ]]; }
+
+hours_to_seconds() {
+  local hours=${1:-$SOAK_HOURS_DEFAULT}
+  python3 - "$hours" <<'PY'
+import decimal, sys
+h = decimal.Decimal(sys.argv[1])
+if h < 0:
+    raise SystemExit("negative soak hours")
+print(int(h * decimal.Decimal(3600)))
+PY
+}
+
+iso_to_epoch() {
+  python3 - "$1" <<'PY'
+from datetime import datetime, timezone
+import sys
+s = sys.argv[1].replace('Z', '+00:00')
+print(int(datetime.fromisoformat(s).astimezone(timezone.utc).timestamp()))
+PY
+}
+
+now_epoch() {
+  if [[ -n ${NOW_EPOCH:-} ]]; then
+    echo "$NOW_EPOCH"
+  else
+    date -u +%s
+  fi
+}
+
+write_output() {
+  local key=$1 value=$2
+  if [[ -n ${GITHUB_OUTPUT:-} ]]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+append_summary() {
+  if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+    cat >> "$GITHUB_STEP_SUMMARY"
+  else
+    cat
+  fi
+}
+
+normalized_decision() {
+  local candidate_digest=${CANDIDATE_DIGEST:-}
+  local stable_digest=${STABLE_DIGEST:-}
+  local candidate_age_seconds=${CANDIDATE_AGE_SECONDS:-0}
+  local soak_hours=${SOAK_HOURS:-$SOAK_HOURS_DEFAULT}
+  local current_candidate=${CURRENT_CANDIDATE:-false}
+  local green_evidence=${GREEN_EVIDENCE:-false}
+  local blocker_count=${BLOCKER_COUNT:-0}
+  local smoke_evidence=${SMOKE_EVIDENCE:-}
+  local emergency_reason=${EMERGENCY_EXCEPTION_REASON:-}
+  local emergency_followup=${EMERGENCY_FOLLOWUP_ISSUE:-}
+  local candidate_generation=${CANDIDATE_GENERATION:-0}
+  local stable_generation=${STABLE_GENERATION:-0}
+  local soak_seconds reason decision
+
+  soak_seconds=$(hours_to_seconds "$soak_hours")
+  decision=hold
+
+  if [[ -z $candidate_digest ]]; then
+    reason="candidate digest is unavailable"
+  elif [[ $candidate_digest == "$stable_digest" ]]; then
+    reason="stable already points at candidate digest $candidate_digest"
+  elif ! [[ $candidate_age_seconds =~ ^[0-9]+$ ]]; then
+    reason="candidate age is invalid: $candidate_age_seconds"
+  elif ! [[ $candidate_generation =~ ^[0-9]+$ && $stable_generation =~ ^[0-9]+$ ]]; then
+    reason="generation metadata is invalid"
+  elif (( candidate_generation <= stable_generation )); then
+    reason="monotonic guard held: candidate generation $candidate_generation <= stable generation $stable_generation"
+  elif [[ -n $emergency_reason ]]; then
+    if [[ -z $emergency_followup ]]; then
+      reason="emergency exception requires a follow-up issue"
+    elif [[ $green_evidence != true ]]; then
+      reason="emergency exception cannot bypass missing green release evidence"
+    elif (( blocker_count != 0 )); then
+      reason="emergency exception cannot bypass $blocker_count open release blocker(s)"
+    elif [[ $current_candidate != true ]]; then
+      reason="emergency exception candidate was superseded before publication"
+    else
+      decision=promote
+      reason="emergency exception recorded: $emergency_reason"
+    fi
+  elif (( candidate_age_seconds < soak_seconds )); then
+    reason="candidate age ${candidate_age_seconds}s < required ${soak_seconds}s (${soak_hours}h)"
+  elif [[ $current_candidate != true ]]; then
+    reason="newer candidate superseded this digest before the soak window completed"
+  elif [[ $green_evidence != true ]]; then
+    reason="required v2 CI / v2 Tests evidence is not green"
+  elif (( blocker_count != 0 )); then
+    reason="$blocker_count open release blocker(s) labelled release-blocker"
+  elif [[ -z $smoke_evidence ]]; then
+    reason="operator smoke signal is missing"
+  else
+    decision=promote
+    reason="all stable soak promotion conditions passed"
+  fi
+
+  printf 'decision=%s\nreason=%s\n' "$decision" "$reason"
+  write_output decision "$decision"
+  write_output reason "$reason"
+}
+
+inspect_raw() {
+  docker buildx imagetools inspect "$@"
+}
+
+manifest_digest() {
+  local ref=$1 digest
+  if ! digest=$(inspect_raw "$ref" --format '{{.Manifest.Digest}}' 2>&1); then
+    echo "$digest" >&2
+    return 1
+  fi
+  echo "$digest"
+}
+
+platform_json() {
+  local ref=$1 out
+  if ! out=$(inspect_raw --format '{{json (index .Image "linux/amd64")}}' "$ref" 2>&1); then
+    echo "$out" >&2
+    return 1
+  fi
+  if [[ $out == null || -z $out ]]; then
+    echo "linux/amd64 manifest is missing for $ref" >&2
+    return 1
+  fi
+  echo "$out"
+}
+
+label_value() {
+  local ref=$1 label=$2 value
+  value=$(platform_json "$ref" | jq -r --arg label "$label" '.config.Labels[$label] // empty')
+  [[ -n $value ]] || return 1
+  echo "$value"
+}
+
+is_missing_manifest_error() {
+  grep -Eqi 'manifest unknown|manifest.*not found|not found.*manifest|no such manifest|(^|[[:space:]:])not found$'
+}
+
+generation_for_ref() {
+  local ref=$1 inspect value
+  if ! inspect=$(platform_json "$ref" 2>&1); then
+    if is_missing_manifest_error <<<"$inspect"; then
+      echo 0
+      return 0
+    fi
+    echo "$inspect" >&2
+    return 1
+  fi
+  value=$(jq -r --arg label "$RUN_LABEL" '.config.Labels[$label] // "0"' <<<"$inspect")
+  if [[ $value =~ ^[0-9]+$ ]]; then
+    echo "$value"
+  else
+    echo "invalid $RUN_LABEL label on $ref: $value" >&2
+    return 1
+  fi
+}
+
+revision_for_ref() {
+  label_value "$1" "$REVISION_LABEL"
+}
+
+workflow_success() {
+  local repo=$1 workflow=$2 sha=$3 result
+  result=$(unset GITHUB_TOKEN && gh api -H "Accept: application/vnd.github+json" \
+    "/repos/${repo}/actions/workflows/${workflow}/runs?branch=${RELEASE_BRANCH:-$RELEASE_BRANCH_DEFAULT}&head_sha=${sha}&per_page=20" \
+    --jq '[.workflow_runs[] | select(.conclusion == "success")] | length' 2>/dev/null || echo 0)
+  [[ $result =~ ^[0-9]+$ && $result -gt 0 ]]
+}
+
+workflow_run_created_at() {
+  local repo=$1 run_number=$2 result
+  result=$(unset GITHUB_TOKEN && gh run list -R "$repo" --workflow "${DOCKER_WORKFLOW:-$DOCKER_WORKFLOW_DEFAULT}" \
+    --branch "${RELEASE_BRANCH:-$RELEASE_BRANCH_DEFAULT}" --json number,createdAt,status,conclusion --limit 100 \
+    --jq ".[] | select(.number == ${run_number}) | select(.status == \"completed\") | .createdAt" | head -n 1)
+  [[ -n $result ]] || return 1
+  echo "$result"
+}
+
+blocker_count() {
+  unset GITHUB_TOKEN && gh issue list -R "$1" --state open --label "${BLOCKER_LABEL:-$BLOCKER_LABEL_DEFAULT}" --json number --limit 100 --jq 'length'
+}
+
+collect_required_workflows() {
+  local repo=$1 sha=$2 workflow ok=true lines=()
+  for workflow in ${REQUIRED_WORKFLOWS:-$REQUIRED_WORKFLOWS_DEFAULT}; do
+    if workflow_success "$repo" "$workflow" "$sha"; then
+      lines+=("- ${workflow}: success")
+    else
+      lines+=("- ${workflow}: missing success for ${sha}")
+      ok=false
+    fi
+  done
+  printf '%s\n' "${lines[@]}"
+  [[ $ok == true ]]
+}
+
+publish_stable_from_source() {
+  local image=$1 source_ref=$2 dry_run=${3:-true}
+  local stable_channel=${STABLE_CHANNEL:-$STABLE_CHANNEL_DEFAULT}
+  local stable_ref="${image}:${stable_channel}"
+  local candidate_generation stable_generation
+  candidate_generation=$(generation_for_ref "$source_ref")
+  if (( candidate_generation == 0 )); then
+    echo "::error::source ${source_ref} has no ${RUN_LABEL} metadata; refusing to move ${stable_ref}" >&2
+    return 1
+  fi
+  stable_generation=$(generation_for_ref "$stable_ref")
+  if (( candidate_generation <= stable_generation )); then
+    echo "::warning::not moving ${stable_ref}: candidate generation ${candidate_generation} <= stable generation ${stable_generation}"
+    return 0
+  fi
+  if bool "$dry_run"; then
+    echo "DRY-RUN: would promote ${stable_ref} to ${source_ref} (generation ${candidate_generation} > ${stable_generation})"
+  else
+    echo "Promoting ${stable_ref} to ${source_ref} (generation ${candidate_generation} > ${stable_generation})"
+    docker buildx imagetools create -t "$stable_ref" "$source_ref"
+  fi
+}
+
+publish_stable() {
+  local image=$1 digest=$2 dry_run=${3:-true}
+  publish_stable_from_source "$image" "${image}@${digest}" "$dry_run"
+}
+
+promote() {
+  local repo=${GITHUB_REPOSITORY:-${REPO:-hivecommons/hive}}
+  local owner=${GITHUB_REPOSITORY_OWNER:-${OWNER:-hivecommons}}
+  local image_prefix=${IMAGE_PREFIX:-ghcr.io/${owner}}
+  local dry_run=${DRY_RUN:-true}
+  local candidate_channel=${CANDIDATE_CHANNEL:-$CANDIDATE_CHANNEL_DEFAULT}
+  local stable_channel=${STABLE_CHANNEL:-$STABLE_CHANNEL_DEFAULT}
+  local images=( ${IMAGE_NAMES:-$IMAGE_NAMES_DEFAULT} )
+  local candidate_digest stable_digest candidate_generation stable_generation revision run_created run_epoch age now
+  local first_digest= first_revision= first_generation= evidence_text green=true blockers smoke decision reason image image_stable_digest
+  local max_stable_generation=0 min_stable_generation= stable_all_candidate=true newer_stable=false
+  declare -A candidate_digests
+
+  for image in "${images[@]}"; do
+    local ref="${image_prefix}/${image}:${candidate_channel}"
+    candidate_digest=$(manifest_digest "$ref")
+    revision=$(revision_for_ref "${image_prefix}/${image}@${candidate_digest}")
+    candidate_generation=$(generation_for_ref "${image_prefix}/${image}@${candidate_digest}")
+    candidate_digests[$image]=$candidate_digest
+    image_stable_digest=$(manifest_digest "${image_prefix}/${image}:${stable_channel}" 2>/dev/null || true)
+    if [[ $image_stable_digest != "$candidate_digest" ]]; then
+      stable_all_candidate=false
+    fi
+    stable_generation=$(generation_for_ref "${image_prefix}/${image}:${stable_channel}")
+    if (( stable_generation > candidate_generation )); then
+      newer_stable=true
+    fi
+    if (( stable_generation > max_stable_generation )); then
+      max_stable_generation=$stable_generation
+    fi
+    if [[ -z $min_stable_generation || stable_generation -lt min_stable_generation ]]; then
+      min_stable_generation=$stable_generation
+    fi
+    if [[ -z $first_digest ]]; then
+      first_digest=$candidate_digest; first_revision=$revision; first_generation=$candidate_generation
+    elif [[ $revision != "$first_revision" || $candidate_generation != "$first_generation" ]]; then
+      CANDIDATE_DIGEST=$candidate_digest STABLE_DIGEST= CANDIDATE_AGE_SECONDS=0 CURRENT_CANDIDATE=false \
+        GREEN_EVIDENCE=false BLOCKER_COUNT=0 SMOKE_EVIDENCE= CANDIDATE_GENERATION=$candidate_generation STABLE_GENERATION=0 normalized_decision
+      return 0
+    fi
+  done
+
+  if [[ $stable_all_candidate == true ]]; then
+    stable_digest=$first_digest
+  else
+    stable_digest="mixed-or-not-promoted"
+  fi
+  if [[ $newer_stable == true ]]; then
+    stable_generation=$max_stable_generation
+  else
+    stable_generation=${min_stable_generation:-0}
+  fi
+  run_created=$(workflow_run_created_at "$repo" "$first_generation")
+  run_epoch=$(iso_to_epoch "$run_created")
+  now=$(now_epoch)
+  age=$((now - run_epoch))
+  (( age >= 0 )) || age=0
+
+  evidence_text=$(collect_required_workflows "$repo" "$first_revision" 2>&1) || green=false
+  blockers=$(blocker_count "$repo")
+  smoke=${SMOKE_EVIDENCE:-}
+  if [[ -z $smoke ]]; then
+    smoke=${!SMOKE_VAR_DEFAULT:-}
+  fi
+
+  local out
+  out=$(CANDIDATE_DIGEST="$first_digest" STABLE_DIGEST="$stable_digest" CANDIDATE_AGE_SECONDS="$age" \
+    CURRENT_CANDIDATE=true GREEN_EVIDENCE="$green" BLOCKER_COUNT="$blockers" SMOKE_EVIDENCE="$smoke" \
+    CANDIDATE_GENERATION="$first_generation" STABLE_GENERATION="$stable_generation" \
+    EMERGENCY_EXCEPTION_REASON="${EMERGENCY_EXCEPTION_REASON:-}" EMERGENCY_FOLLOWUP_ISSUE="${EMERGENCY_FOLLOWUP_ISSUE:-}" normalized_decision)
+  decision=$(awk -F= '/^decision=/{print $2}' <<<"$out")
+  reason=$(awk -F= '/^reason=/{sub(/^reason=/,""); print}' <<<"$out")
+  echo "$out"
+  local promoted=false
+  if [[ $decision == promote ]] && ! bool "$dry_run"; then
+    promoted=true
+  fi
+  write_output promoted "$promoted"
+  write_output candidate_digest "$first_digest"
+  write_output candidate_sha "$first_revision"
+
+  {
+    echo "## Stable promotion decision"
+    echo
+    echo "- Decision: ${decision}"
+    echo "- Reason: ${reason}"
+    echo "- Candidate digest: ${first_digest}"
+    echo "- Candidate SHA: ${first_revision}"
+    echo "- Candidate generation: ${first_generation}"
+    echo "- Candidate first seen: ${run_created}"
+    echo "- Candidate age: ${age}s"
+    echo "- Required soak: ${SOAK_HOURS:-$SOAK_HOURS_DEFAULT}h"
+    echo "- Stable digest: ${stable_digest:-missing}"
+    echo "- Stable generation: ${stable_generation}"
+    echo "- Open ${BLOCKER_LABEL:-$BLOCKER_LABEL_DEFAULT} blockers: ${blockers}"
+    echo "- Smoke evidence: ${smoke:-missing}"
+    if [[ -n ${EMERGENCY_EXCEPTION_REASON:-} ]]; then
+      echo "- Emergency exception reason: ${EMERGENCY_EXCEPTION_REASON}"
+      echo "- Emergency follow-up issue: ${EMERGENCY_FOLLOWUP_ISSUE:-missing}"
+    fi
+    echo
+    echo "### Checks consulted"
+    echo "$evidence_text"
+  } | append_summary
+
+  if [[ $decision == promote ]]; then
+    for image in "${images[@]}"; do
+      candidate_digest=$(manifest_digest "${image_prefix}/${image}:${candidate_channel}")
+      if [[ $candidate_digest != "${candidate_digests[$image]}" ]]; then
+        echo "::error::${image_prefix}/${image}:${candidate_channel} changed during evaluation; refusing to promote a superseded candidate" >&2
+        exit 1
+      fi
+      publish_stable "${image_prefix}/${image}" "$candidate_digest" "$dry_run"
+    done
+  fi
+}
+
+case ${1:-} in
+  decide) normalized_decision ;;
+  promote) promote ;;
+  publish-stable) shift; [[ $# -eq 3 ]] || { usage; exit 2; }; publish_stable "$@" ;;
+  mirror-stable) shift; [[ $# -eq 3 ]] || { usage; exit 2; }; publish_stable_from_source "$@" ;;
+  *) usage; exit 2 ;;
+esac

--- a/src/scripts/publish-image-tags.sh
+++ b/src/scripts/publish-image-tags.sh
@@ -20,11 +20,11 @@ run_number=$5
 release_branch=$6
 include_latest=$7
 # CHANNELS: comma-separated release-channel tags this branch's builds own
-# (default preserves the historical behavior). Channel ownership is
-# per-branch: v4 owns stable+candidate, the v5 line owns edge — without the
+# (default is fail-closed and never moves stable). Channel ownership is
+# per-branch: v4 merge builds own candidate, the v5 line owns edge — without the
 # split, every v4 merge silently re-pointed edge back onto v4 minutes after
 # any deliberate promotion of edge to v5.
-channels=${8:-stable,candidate,edge}
+channels=${8:-candidate}
 run_label=io.kubestellar.hive.github-actions-run-number
 
 if [[ ! $run_number =~ ^[0-9]+$ ]]; then

--- a/src/scripts/test-promote-stable.sh
+++ b/src/scripts/test-promote-stable.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Unit tests for the stable soak promotion decision gate (#5974).
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+promoter="$script_dir/promote-stable.sh"
+fail=0
+pass() { echo "  ok: $*"; }
+bad() { echo "  FAIL: $*"; fail=1; }
+
+run_decide() {
+  env -i PATH="$PATH" \
+    CANDIDATE_DIGEST="${CANDIDATE_DIGEST-sha256:candidate}" \
+    STABLE_DIGEST="${STABLE_DIGEST-sha256:stable}" \
+    CANDIDATE_AGE_SECONDS="${CANDIDATE_AGE_SECONDS-90000}" \
+    SOAK_HOURS="${SOAK_HOURS-24}" \
+    CURRENT_CANDIDATE="${CURRENT_CANDIDATE-true}" \
+    GREEN_EVIDENCE="${GREEN_EVIDENCE-true}" \
+    BLOCKER_COUNT="${BLOCKER_COUNT-0}" \
+    SMOKE_EVIDENCE="${SMOKE_EVIDENCE-maintained hive heartbeat healthy}" \
+    CANDIDATE_GENERATION="${CANDIDATE_GENERATION-200}" \
+    STABLE_GENERATION="${STABLE_GENERATION-100}" \
+    EMERGENCY_EXCEPTION_REASON="${EMERGENCY_EXCEPTION_REASON-}" \
+    EMERGENCY_FOLLOWUP_ISSUE="${EMERGENCY_FOLLOWUP_ISSUE-}" \
+    "$promoter" decide
+}
+
+expect_decision() {
+  local want=$1 desc=$2 needle=${3:-}
+  local out got
+  out=$(run_decide)
+  got=$(awk -F= '/^decision=/{print $2}' <<<"$out")
+  if [[ $got == "$want" ]] && { [[ -z $needle ]] || grep -qF "$needle" <<<"$out"; }; then
+    pass "$desc"
+  else
+    bad "$desc (got ${got}; output: ${out})"
+  fi
+}
+
+expect_decision promote "all five policy conditions promote"
+CANDIDATE_AGE_SECONDS=3600 expect_decision hold "minimum soak failure holds" "candidate age"
+CURRENT_CANDIDATE=false expect_decision hold "superseded candidate failure holds" "superseded"
+GREEN_EVIDENCE=false expect_decision hold "green evidence failure holds" "evidence"
+BLOCKER_COUNT=1 expect_decision hold "open release blocker failure holds" "release blocker"
+SMOKE_EVIDENCE= expect_decision hold "missing operator smoke signal holds" "smoke signal"
+CANDIDATE_GENERATION=100 STABLE_GENERATION=200 expect_decision hold "monotonic guard prevents backwards stable moves" "monotonic guard"
+CANDIDATE_DIGEST=sha256:candidate STABLE_DIGEST=mixed-or-not-promoted CANDIDATE_GENERATION=200 STABLE_GENERATION=100 expect_decision promote "partial image promotions remain retryable"
+CANDIDATE_AGE_SECONDS=3600 EMERGENCY_EXCEPTION_REASON="security fix risk exceeds waiting; v2 CI and v2 Tests passed; rollback digest sha256:old" EMERGENCY_FOLLOWUP_ISSUE=5975 expect_decision promote "emergency exception bypasses soak with required evidence" "emergency exception recorded"
+CANDIDATE_AGE_SECONDS=3600 EMERGENCY_EXCEPTION_REASON="security fix" EMERGENCY_FOLLOWUP_ISSUE= expect_decision hold "emergency exception requires follow-up issue" "follow-up issue"
+GREEN_EVIDENCE=false EMERGENCY_EXCEPTION_REASON="security fix" EMERGENCY_FOLLOWUP_ISSUE=5975 expect_decision hold "emergency exception cannot bypass checks" "green release evidence"
+
+
+
+tmp_root="$script_dir/../.test-tmp"
+mkdir -p "$tmp_root"
+tmp="$tmp_root/promote-stable.$$"
+mkdir -p "$tmp/bin"
+trap 'rm -rf "$tmp"; rmdir "$tmp_root" 2>/dev/null || true' EXIT
+cat > "$tmp/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $1 == buildx && $2 == imagetools && $3 == inspect ]]; then
+  ref=${@: -1}
+  if [[ $ref == *':stable' && ${MOCK_STABLE_FAILURE:-0} == 1 ]]; then
+    echo 'dial tcp: registry unavailable' >&2
+    exit 1
+  fi
+  if [[ $ref == *':stable' ]]; then gen=${MOCK_STABLE_GENERATION:-100}; else gen=${MOCK_CANDIDATE_GENERATION:-200}; fi
+  printf '{"config":{"Labels":{"io.kubestellar.hive.github-actions-run-number":"%s","org.opencontainers.image.revision":"abcdef"}}}\n' "$gen"
+  exit 0
+fi
+printf '%q ' "$@" > "$MOCK_CAPTURE"
+printf '\n' >> "$MOCK_CAPTURE"
+MOCK
+chmod +x "$tmp/bin/docker"
+
+capture="$tmp/create-stable"
+PATH="$tmp/bin:$PATH" MOCK_CAPTURE="$capture" MOCK_CANDIDATE_GENERATION=100 MOCK_STABLE_GENERATION=200 \
+  "$promoter" publish-stable ghcr.io/hivecommons/hive sha256:candidate false >/dev/null
+if [[ -e $capture ]]; then
+  bad "publish-stable moved stable backwards despite the monotonic guard"
+else
+  pass "publish-stable monotonic guard leaves newer stable untouched"
+fi
+PATH="$tmp/bin:$PATH" MOCK_CAPTURE="$capture" MOCK_CANDIDATE_GENERATION=300 MOCK_STABLE_GENERATION=200 \
+  "$promoter" publish-stable ghcr.io/hivecommons/hive sha256:candidate false >/dev/null
+grep -q -- '-t ghcr.io/hivecommons/hive:stable ghcr.io/hivecommons/hive@sha256:candidate' "$capture" \
+  && pass "publish-stable retags stable by digest when generation advances" \
+  || bad "publish-stable did not retag stable by digest on a forward generation"
+rm -f "$capture"
+if PATH="$tmp/bin:$PATH" MOCK_CAPTURE="$capture" MOCK_STABLE_FAILURE=1 \
+    "$promoter" publish-stable ghcr.io/hivecommons/hive sha256:candidate false >/dev/null 2>&1; then
+  bad "publish-stable treated a stable inspection failure as generation zero"
+elif [[ -e $capture ]]; then
+  bad "publish-stable created a tag after a stable inspection failure"
+else
+  pass "publish-stable fails closed on stable inspection errors"
+fi
+if PATH="$tmp/bin:$PATH" MOCK_CAPTURE="$capture" MOCK_CANDIDATE_GENERATION=0 MOCK_STABLE_GENERATION=0 \
+    "$promoter" mirror-stable ghcr.io/kubestellar/hive ghcr.io/hivecommons/hive@sha256:candidate false >/dev/null 2>&1; then
+  bad "mirror-stable accepted a source digest without generation metadata"
+elif [[ -e $capture ]]; then
+  bad "mirror-stable created a tag from an unverified source digest"
+else
+  pass "mirror-stable fails closed when source digest metadata is missing"
+fi
+
+workflow="$script_dir/../../.github/workflows/docker.yml"
+if grep -q 'stable,candidate\|CHANNELS: "stable,candidate"' "$workflow"; then
+  bad "docker workflow still publishes stable together with candidate"
+else
+  pass "docker workflow leaves stable to the promotion workflow"
+fi
+
+echo
+if [[ $fail -ne 0 ]]; then
+  echo "RESULT: FAIL — stable promotion gate regressed."
+  exit 1
+fi
+echo "RESULT: PASS — stable promotion gate enforces the policy."

--- a/src/scripts/test-publish-image-tags.sh
+++ b/src/scripts/test-publish-image-tags.sh
@@ -63,7 +63,10 @@ capture="$tmp/create-new"
 run_case missing 100 "$capture"
 grep -q 'hive:abcdef1' "$capture"
 grep -q 'hive:v4-latest' "$capture"
-grep -q 'hive:stable' "$capture"
+if grep -q 'hive:stable' "$capture"; then
+  echo "v4 merge publish moved stable instead of candidate only" >&2
+  exit 1
+fi
 
 capture="$tmp/create-forward"
 run_case 99 100 "$capture"
@@ -122,7 +125,11 @@ fi
 workflow="$script_dir/../../.github/workflows/docker.yml"
 [[ $(grep -c 'io.kubestellar.hive.github-actions-run-number=' "$workflow") -eq 3 ]]
 [[ $(grep -c 'src/scripts/publish-image-tags.sh' "$workflow") -eq 3 ]]
-grep -q 'v4 true stable,candidate' "$workflow"
+grep -q 'v4 true candidate' "$workflow"
+if grep -q 'v4 true stable,candidate\|CHANNELS: "stable,candidate"' "$workflow"; then
+  echo "docker workflow still publishes stable on every v4 merge" >&2
+  exit 1
+fi
 grep -q 'INCLUDE_LATEST: "true"' "$workflow"
 if grep -q 'head-check\|Verify build commit is still HEAD' "$workflow"; then
   echo "HEAD-only publication guard was reintroduced" >&2


### PR DESCRIPTION
## Summary
- stop per-merge v4 Docker publishes from moving stable; candidate keeps advancing for hive, hive-contributor, and hive-hub across native and mirror tags
- add an hourly/manual stable promotion workflow that promotes by digest after soak, CI evidence, blocker, smoke, emergency, and monotonic guards
- document the enforced policy and add shell coverage for the decision logic and monotonic guard

## Validation
- actionlint .github/workflows/docker.yml .github/workflows/promote-stable.yml
- actionlint -ignore 'label "hive" is unknown|SC2024|SC2034' .github/workflows/v2-ci.yml\n- src/scripts/test-promote-stable.sh\n- src/scripts/test-publish-image-tags.sh\n- (cd src && bash scripts/test-compile-changelog.sh)\n\nCloses #5974