### PR TITLE
🐛 fix(release): log which evidence the promotion gate actually saw

### DIFF
--- a/changelog.d/fixed-promote-gate-log-evidence.md
+++ b/changelog.d/fixed-promote-gate-log-evidence.md
@@ -1,0 +1,1 @@
+- The stable promotion gate now logs the revision it evaluated and each required workflow's verdict. A hold on "missing green release evidence" previously named only the category, never which workflow on which revision concluded what, so the reason had to be reconstructed by hand from outside the run.

--- a/src/scripts/promote-stable.sh
+++ b/src/scripts/promote-stable.sh
@@ -393,6 +393,14 @@ promote() {
   (( age >= 0 )) || age=0
 
   evidence_text=$(collect_required_workflows "$repo" "$first_revision" 2>&1) || green=false
+  # Echo the per-workflow verdicts to the LOG, not only the job summary. A hold
+  # on "missing green release evidence" is otherwise undiagnosable from the run
+  # output: it names the category and never which workflow, on which revision,
+  # concluded what. That cost several blind promotion attempts during the
+  # 2026-09-04 fleet recovery.
+  echo "evidence_revision=${first_revision}"
+  echo "evidence_green=${green}"
+  printf '%s\n' "$evidence_text" | sed 's/^/evidence: /'
   blockers=$(blocker_count "$repo")
   smoke=${SMOKE_EVIDENCE:-}
   if [[ -z $smoke ]]; then


### PR DESCRIPTION
Refs #5994.

## Why

A hold reading `emergency exception cannot bypass missing green release evidence` names a category and nothing else - not the revision evaluated, not which required workflow was missing, not what it concluded. The per-workflow detail exists but goes only to the job summary.

During today's fleet recovery this cost several promotion attempts that could only be diagnosed by re-running the gate's logic locally against the candidate image's revision label. Even then the local run reported `GREEN=true` on the same revision while the workflow held - a discrepancy the run output gives no way to explain.

## What

Echoes to stdout, alongside the existing summary:

- `evidence_revision=<sha>` - the revision actually evaluated, which comes from the candidate image's label and is not necessarily branch HEAD
- `evidence_green=<true|false>`
- each `evidence: - <workflow>: <verdict>` line

No decision logic changes. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmdVsn5zULh5KVpFkYrX59