### PR TITLE
✨ Wire ADR-0012 BYO agent specs

### DIFF
--- a/changelog.d/added-agentspec-wire.md
+++ b/changelog.d/added-agentspec-wire.md
@@ -1,0 +1,1 @@
+- BYO-agent specs are now wired into v5: agents can set `agent_spec` to load an ADR-0012 spec at launch, and `hivectl agent specs list|search` exposes the skill registry discovery surface ([#5910](https://github.com/hivecommons/hive/issues/5910)).

--- a/src/AGENT-DEFINITION.md
+++ b/src/AGENT-DEFINITION.md
@@ -58,6 +58,7 @@ These defaults match the loader in `src/pkg/config`: an omitted `enabled` defaul
 | `stale_timeout` | int | 28800 | Seconds before an agent is considered stale |
 | `restart_strategy` | string | `"immediate"` | How to restart after crash |
 | `launch_cmd` | string | — | Override the auto-generated launch command |
+| `agent_spec` | string | — | BYO-agent spec file or directory; applies its backend, model, mode, launch command, prompt, tools, and skills at launch |
 | `cli_pinned` | bool | false | Pin the CLI binary version |
 | `caveman_mode` | string | — | Output compression: `lite`, `full`, `ultra`, `wenyan` |
 | `beads_dir` | string | — | Directory for bead storage |

--- a/src/docs/adr/0012-skill-registry.md
+++ b/src/docs/adr/0012-skill-registry.md
@@ -21,8 +21,20 @@ skipped with logs so one bad catalog entry does not prevent Hive from loading.
 
 Requested skills are selected by preferring the curated registry over inline
 `AGENTS.md` snippets, while falling back to repo-local skills the registry does
-not know about. `Get` returns the newest loaded version, and `InjectionText`
-renders a single Markdown block for the kick path.
+not know about. `Get` returns the newest loaded version, `List`/`Search` provide
+catalog UX, and `InjectionText` renders a single Markdown block for the kick
+path.
+
+The same package defines `AgentSpec`, the minimal BYO-agent contract:
+name, backend, model, operating mode, optional launch command, prompt, tools,
+and default skills. Agent configs opt into that contract with `agent_spec`,
+which points at a YAML file or spec directory.
+
+## Status notes
+
+- Implemented in #6004: `agent_spec` is loaded through `skillreg.LoadAgentSpec`
+  on the pkg/agent launch path, and `hivectl agent specs list|search` exposes
+  the registry discovery surface.
 
 ## Consequences
 
@@ -30,5 +42,6 @@ Rationale not recorded beyond the implementation, linked code, and cited design 
 
 Skills become portable without removing simple repo-local snippets. The
 trade-off is that registry skills intentionally override inline snippets, so
-catalog governance matters; and the current registry helper is a loading and
-rendering layer, not a full package manager or deep launcher integration.
+catalog governance matters. BYO-agent specs add launcher integration without
+turning the registry into a package manager: Hive resolves a local declaration
+and applies only the fields in the stable contract.

--- a/src/docs/agent-configuration.md
+++ b/src/docs/agent-configuration.md
@@ -86,9 +86,46 @@ agents:
     launch_cmd: "/usr/bin/copilot --allow-all --model claude-sonnet-4-6"
                                  # explicit launch command (optional — hive builds
                                  #   one from backend + model + mode when omitted)
+    agent_spec: /data/agent-specs/reviewer
+                                 # optional BYO-agent spec file or directory.
+                                 #   When set, Hive loads agent.yaml/spec.yaml
+                                 #   and applies its backend, model, mode,
+                                 #   launch_cmd, prompt, tools, and skills at launch.
 ```
 
 > The dashboard also offers **gemini** as a live method (with live model discovery); as a persisted `backend:` value in `hive.yaml`, stick to the validated list above.
+
+### BYO-agent specs
+
+`agent_spec` wires ADR-0012's bring-your-own-agent contract into the launcher.
+Point it at a YAML file, or at a directory containing `agent.yaml`,
+`agent.yml`, `agent-spec.yaml`, `agent-spec.yml`, `spec.yaml`, or `spec.yml`:
+
+```yaml
+agents:
+  reviewer:
+    agent_spec: /data/agent-specs/reviewer
+```
+
+```yaml
+# /data/agent-specs/reviewer/agent.yaml
+name: reviewer
+backend: claude
+model: claude-sonnet-4-6
+mode: suggest
+launch_cmd: /opt/reviewer/bin/reviewer --stdio
+prompt: "Start with the external reviewer checklist."
+tools:
+  preset: advisory
+skills:
+  - review-checklist
+```
+
+At launch time Hive loads the spec with `skillreg.LoadAgentSpec`; the spec's
+backend, model, mapped mode (`observe` → `ADVISORY`, `suggest` →
+`ISSUES_AND_PRS`, `autonomous` → `ISSUES_PRS_MERGE`), `launch_cmd`, `prompt`,
+`tools`, and `skills` become the agent's effective launch configuration. If the
+spec omits `launch_cmd`, Hive still builds the backend command normally.
 
 ### Behavior — what it may do, and when
 

--- a/src/docs/skills.md
+++ b/src/docs/skills.md
@@ -132,6 +132,38 @@ large file does not silently suppress everything behind it.
 When several files declare the same `name` with different `version` values,
 the **highest version wins** for an agent skill reference.
 
+## Discovering skills
+
+The same registry used at kick time is exposed through hivectl:
+
+```bash
+hivectl agent specs list
+hivectl agent specs search testing --limit 10
+```
+
+Both commands read `/data/skills/` from the local filesystem and return the
+skill name, version, description, source, and tags. Use `--dir` to inspect a
+different local registry, and use `--output json` or `--output yaml` for
+scripts.
+
+## BYO-agent specs
+
+ADR-0012 also defines a small bring-your-own-agent spec that a configured agent
+can reference with `agent_spec`:
+
+```yaml
+agents:
+  reviewer:
+    agent_spec: /data/agent-specs/reviewer
+```
+
+The reference may point to a YAML file or to a directory containing
+`agent.yaml`, `agent.yml`, `agent-spec.yaml`, `agent-spec.yml`, `spec.yaml`, or
+`spec.yml`. Hive loads it with `skillreg.LoadAgentSpec` when the agent launches
+and applies its backend, model, mode, launch command, prompt, tools, and default
+skills. See [Agent configuration](agent-configuration.md#byo-agent-specs) for
+the full example.
+
 ## Package surface
 
 | Function | What it does |
@@ -140,10 +172,12 @@ the **highest version wins** for an agent skill reference.
 | `Registry.Load(dir, logger)` | reads `*.md` from a directory, returns the count loaded |
 | `Registry.Add(skill)` | adds one skill |
 | `Registry.Get(name)` | looks up the newest loaded version for a name |
+| `Registry.Resolve(name, constraint)` | looks up a version by exact, wildcard, caret, or `>=` constraint |
+| `Registry.List()` | lists loaded skills for catalog UX |
+| `Registry.Search(term)` | searches names, descriptions, and tags |
+| `LoadAgentSpec(path)` | loads a BYO-agent YAML file or spec directory |
 | `Registry.ResolveRequested(cfg, names)` | resolves names, preferring registry skills over an `AGENTS.md` inline fallback |
 | `InjectionText(skills)` | renders resolved skills as the Markdown block injected into a kick |
-
-sources.
 
 ## Related
 

--- a/src/pkg/agent/agentspecwire.go
+++ b/src/pkg/agent/agentspecwire.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hivecommons/hive/pkg/config"
+	"github.com/hivecommons/hive/pkg/skillreg"
+)
+
+func (m *Manager) applyAgentSpec(agent *AgentProcess) error {
+	cfg := agent.Config
+	if strings.TrimSpace(agent.baseConfig.AgentSpec) != "" {
+		cfg = agent.baseConfig
+	}
+	cfg, prompt, applied, err := applyAgentSpecConfig(cfg)
+	if err != nil {
+		return err
+	}
+	if !applied {
+		agent.clearAgentSpecPromptIfSpecRemoved(cfg)
+		return nil
+	}
+	agent.Config = cfg
+	prompt = strings.TrimSpace(prompt)
+	if strings.TrimSpace(agent.BootstrapOverride) == "" || strings.TrimSpace(agent.BootstrapOverride) == agent.agentSpecPrompt {
+		agent.BootstrapOverride = prompt
+	}
+	agent.agentSpecPrompt = prompt
+	if m != nil && m.logger != nil {
+		m.logger.Info("loaded agent spec", "agent", agent.Name, "spec", cfg.AgentSpec)
+	}
+	return nil
+}
+
+func (agent *AgentProcess) clearAgentSpecPromptIfSpecRemoved(cfg config.AgentConfig) {
+	if strings.TrimSpace(cfg.AgentSpec) != "" {
+		return
+	}
+	if agent.agentSpecPrompt != "" && strings.TrimSpace(agent.BootstrapOverride) == agent.agentSpecPrompt {
+		agent.BootstrapOverride = ""
+	}
+	agent.agentSpecPrompt = ""
+}
+
+func applyAgentSpecConfig(cfg config.AgentConfig) (config.AgentConfig, string, bool, error) {
+	if strings.TrimSpace(cfg.AgentSpec) == "" {
+		return cfg, "", false, nil
+	}
+	spec, err := skillreg.LoadAgentSpec(cfg.AgentSpec)
+	if err != nil {
+		return cfg, "", false, err
+	}
+	cfg.Backend = spec.Backend()
+	cfg.Model = spec.Model()
+	cfg.Mode = agentSpecMode(spec.Mode())
+	cfg.LaunchCmd = ""
+	cfg.Tools = nil
+	cfg.Skills = nil
+	if spec.LaunchCommand != "" {
+		cfg.LaunchCmd = spec.LaunchCommand
+	}
+	if len(spec.Skills) > 0 {
+		cfg.Skills = append([]string(nil), spec.Skills...)
+	}
+	if spec.Tools != nil {
+		cfg.Tools = &config.ToolsConfig{
+			Preset: spec.Tools.Preset,
+			Rules:  make([]config.ToolRule, 0, len(spec.Tools.Rules)),
+		}
+		for _, rule := range spec.Tools.Rules {
+			cfg.Tools.Rules = append(cfg.Tools.Rules, config.ToolRule{
+				Pattern: rule.Pattern,
+				Action:  rule.Action,
+				Reason:  rule.Reason,
+			})
+		}
+	}
+	return cfg, spec.Prompt, true, nil
+}
+
+func agentSpecMode(mode skillreg.AgentMode) string {
+	switch mode {
+	case skillreg.ModeObserve:
+		return "ADVISORY"
+	case skillreg.ModeAutonomous:
+		return "ISSUES_PRS_MERGE"
+	case skillreg.ModeSuggest:
+		return "ISSUES_AND_PRS"
+	default:
+		return fmt.Sprint(mode)
+	}
+}

--- a/src/pkg/agent/agentspecwire_test.go
+++ b/src/pkg/agent/agentspecwire_test.go
@@ -1,0 +1,304 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hivecommons/hive/pkg/config"
+)
+
+func TestApplyAgentSpecConfigChangesLaunchCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	spec := `name: custom-reviewer
+backend: claude
+model: claude-opus-4-6
+mode: autonomous
+launch_cmd: /opt/agents/reviewer --stdio --model claude-opus-4-6
+prompt: "Use the external review checklist."
+tools:
+  preset: full
+skills:
+  - review-checklist
+`
+	if err := os.WriteFile(path, []byte(spec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, prompt, applied, err := applyAgentSpecConfig(config.AgentConfig{
+		Backend:   "copilot",
+		Model:     "auto",
+		Mode:      "ADVISORY",
+		LaunchCmd: "copilot --model auto",
+		AgentSpec: path,
+	})
+	if err != nil {
+		t.Fatalf("applyAgentSpecConfig: %v", err)
+	}
+	if !applied {
+		t.Fatal("agent spec was not applied")
+	}
+	if cfg.Backend != "claude" {
+		t.Errorf("backend = %q, want claude", cfg.Backend)
+	}
+	if cfg.Model != "claude-opus-4-6" {
+		t.Errorf("model = %q", cfg.Model)
+	}
+	if cfg.Mode != "ISSUES_PRS_MERGE" {
+		t.Errorf("mode = %q, want ISSUES_PRS_MERGE", cfg.Mode)
+	}
+	if cfg.LaunchCmd != "/opt/agents/reviewer --stdio --model claude-opus-4-6" {
+		t.Errorf("launch_cmd = %q", cfg.LaunchCmd)
+	}
+	if prompt != "Use the external review checklist." {
+		t.Errorf("prompt = %q", prompt)
+	}
+	if cfg.Tools == nil || cfg.Tools.Preset != "full" {
+		t.Fatalf("tools = %+v, want full preset", cfg.Tools)
+	}
+	if len(cfg.Skills) != 1 || cfg.Skills[0] != "review-checklist" {
+		t.Errorf("skills = %v", cfg.Skills)
+	}
+}
+
+func TestApplyAgentSpecConfigDirectoryRef(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte("name: a\nbackend: copilot\nmodel: auto\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _, applied, err := applyAgentSpecConfig(config.AgentConfig{AgentSpec: dir, LaunchCmd: "stale custom launcher"})
+	if err != nil {
+		t.Fatalf("applyAgentSpecConfig(dir): %v", err)
+	}
+	if !applied || cfg.Backend != "copilot" || cfg.Model != "auto" {
+		t.Fatalf("cfg = %+v applied=%v", cfg, applied)
+	}
+	if cfg.LaunchCmd != "" {
+		t.Fatalf("launch_cmd = %q, want cleared when spec omits launch_cmd", cfg.LaunchCmd)
+	}
+}
+
+func TestApplyAgentSpecNoRefAndErrors(t *testing.T) {
+	cfg, prompt, applied, err := applyAgentSpecConfig(config.AgentConfig{Backend: "copilot"})
+	if err != nil {
+		t.Fatalf("no-ref error = %v", err)
+	}
+	if applied || prompt != "" || cfg.Backend != "copilot" {
+		t.Fatalf("cfg=%+v prompt=%q applied=%v", cfg, prompt, applied)
+	}
+	if _, _, _, err := applyAgentSpecConfig(config.AgentConfig{AgentSpec: filepath.Join(t.TempDir(), "missing.yaml")}); err == nil {
+		t.Fatal("missing agent_spec should error")
+	}
+}
+
+func TestApplyAgentSpecSetsBootstrapPromptUnlessOverridden(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte("name: a\nbackend: copilot\nmodel: auto\nmode: observe\nprompt: spec prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{}
+	agent := &AgentProcess{Name: "a", Config: config.AgentConfig{AgentSpec: path}}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec: %v", err)
+	}
+	if agent.BootstrapOverride != "spec prompt" {
+		t.Fatalf("BootstrapOverride = %q", agent.BootstrapOverride)
+	}
+	if agent.Config.Mode != "ADVISORY" {
+		t.Fatalf("mode = %q", agent.Config.Mode)
+	}
+
+	agent = &AgentProcess{Name: "a", BootstrapOverride: "operator prompt", Config: config.AgentConfig{AgentSpec: path}}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec with override: %v", err)
+	}
+	if agent.BootstrapOverride != "operator prompt" {
+		t.Fatalf("BootstrapOverride = %q, want operator prompt", agent.BootstrapOverride)
+	}
+}
+
+func TestApplyAgentSpecUpdatesAndClearsSpecOwnedPrompt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte("name: a\nbackend: copilot\nmodel: auto\nmode: observe\nprompt: first prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agent := &AgentProcess{Name: "a", Config: config.AgentConfig{AgentSpec: path}}
+	m := &Manager{}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec first: %v", err)
+	}
+	if agent.BootstrapOverride != "first prompt" {
+		t.Fatalf("BootstrapOverride = %q", agent.BootstrapOverride)
+	}
+
+	if err := os.WriteFile(path, []byte("name: a\nbackend: copilot\nmodel: auto\nmode: observe\nprompt: updated prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec update: %v", err)
+	}
+	if agent.BootstrapOverride != "updated prompt" {
+		t.Fatalf("BootstrapOverride after update = %q", agent.BootstrapOverride)
+	}
+
+	if err := os.WriteFile(path, []byte("name: a\nbackend: copilot\nmodel: auto\nmode: observe\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec removal: %v", err)
+	}
+	if agent.BootstrapOverride != "" {
+		t.Fatalf("BootstrapOverride after prompt removal = %q", agent.BootstrapOverride)
+	}
+}
+
+func TestApplyAgentSpecDoesNotReplaceOperatorPromptOnSpecUpdate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte("name: a\nbackend: copilot\nmodel: auto\nmode: observe\nprompt: spec prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agent := &AgentProcess{Name: "a", Config: config.AgentConfig{AgentSpec: path}}
+	m := &Manager{}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec first: %v", err)
+	}
+	agent.BootstrapOverride = "operator prompt"
+	if err := os.WriteFile(path, []byte("name: a\nbackend: copilot\nmodel: auto\nmode: observe\nprompt: changed spec prompt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec update: %v", err)
+	}
+	if agent.BootstrapOverride != "operator prompt" {
+		t.Fatalf("BootstrapOverride = %q, want operator prompt", agent.BootstrapOverride)
+	}
+}
+
+func TestUpdateConfigRemovingAgentSpecClearsSpecOwnedPrompt(t *testing.T) {
+	agent := &AgentProcess{
+		Name:              "a",
+		Config:            config.AgentConfig{AgentSpec: "agent.yaml"},
+		baseConfig:        config.AgentConfig{AgentSpec: "agent.yaml"},
+		BootstrapOverride: "spec prompt",
+		agentSpecPrompt:   "spec prompt",
+	}
+	m := &Manager{agents: map[string]*AgentProcess{"a": agent}}
+
+	if err := m.UpdateConfig("a", config.AgentConfig{Backend: "copilot"}); err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+	if agent.BootstrapOverride != "" || agent.agentSpecPrompt != "" {
+		t.Fatalf("spec prompt survived removal: bootstrap=%q tracked=%q", agent.BootstrapOverride, agent.agentSpecPrompt)
+	}
+}
+
+func TestUpdateConfigRemovingAgentSpecPreservesOperatorPrompt(t *testing.T) {
+	agent := &AgentProcess{
+		Name:              "a",
+		Config:            config.AgentConfig{AgentSpec: "agent.yaml"},
+		baseConfig:        config.AgentConfig{AgentSpec: "agent.yaml"},
+		BootstrapOverride: "operator prompt",
+		agentSpecPrompt:   "spec prompt",
+	}
+	m := &Manager{agents: map[string]*AgentProcess{"a": agent}}
+
+	if err := m.UpdateConfig("a", config.AgentConfig{Backend: "copilot"}); err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+	if agent.BootstrapOverride != "operator prompt" || agent.agentSpecPrompt != "" {
+		t.Fatalf("operator prompt not preserved: bootstrap=%q tracked=%q", agent.BootstrapOverride, agent.agentSpecPrompt)
+	}
+}
+
+func TestApplyAgentSpecUsesBaseConfigAndRevokesRemovedSpecFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte("name: a\nbackend: claude\nmodel: sonnet\nmode: suggest\nlaunch_cmd: first\ntools:\n  preset: full\nskills:\n  - broad\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := config.AgentConfig{
+		AgentSpec: path,
+		Backend:   "copilot",
+		Model:     "auto",
+		Tools:     &config.ToolsConfig{Preset: "advisory"},
+		Skills:    []string{"base-skill"},
+	}
+	agent := &AgentProcess{Name: "a", Config: base, baseConfig: base}
+	m := &Manager{}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec first: %v", err)
+	}
+	if agent.Config.LaunchCmd != "first" || agent.Config.Tools == nil || agent.Config.Tools.Preset != "full" || len(agent.Config.Skills) != 1 {
+		t.Fatalf("first apply cfg = %+v", agent.Config)
+	}
+
+	if err := os.WriteFile(path, []byte("name: a\nbackend: claude\nmodel: sonnet\nmode: suggest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.applyAgentSpec(agent); err != nil {
+		t.Fatalf("applyAgentSpec second: %v", err)
+	}
+	if agent.Config.LaunchCmd != "" || agent.Config.Tools != nil || agent.Config.Skills != nil {
+		t.Fatalf("removed spec fields persisted: launch=%q tools=%+v skills=%v", agent.Config.LaunchCmd, agent.Config.Tools, agent.Config.Skills)
+	}
+}
+
+func TestRestartValidatesAgentSpecBeforeTeardown(t *testing.T) {
+	cancelled := false
+	agent := &AgentProcess{
+		Name:         "a",
+		State:        StateRunning,
+		Paused:       true,
+		RestartCount: 7,
+		Config: config.AgentConfig{
+			AgentSpec: filepath.Join(t.TempDir(), "missing.yaml"),
+		},
+		cancel: func() { cancelled = true },
+	}
+	m := &Manager{agents: map[string]*AgentProcess{"a": agent}}
+
+	if err := m.Restart(context.Background(), "a"); err == nil {
+		t.Fatal("Restart with missing agent_spec succeeded")
+	}
+	if cancelled {
+		t.Fatal("Restart cancelled running agent before validating agent_spec")
+	}
+	if agent.RestartCount != 7 || agent.forceRelaunch {
+		t.Fatalf("agent teardown fields changed: restart_count=%d force=%v", agent.RestartCount, agent.forceRelaunch)
+	}
+}
+
+func TestRestartWithBootstrapValidatesAgentSpecBeforeMutating(t *testing.T) {
+	agent := &AgentProcess{
+		Name:              "a",
+		State:             StateRunning,
+		Paused:            true,
+		BootstrapOverride: "existing",
+		Config: config.AgentConfig{
+			AgentSpec: filepath.Join(t.TempDir(), "missing.yaml"),
+		},
+		cancel: func() { t.Fatal("cancel called before agent_spec validation") },
+	}
+	m := &Manager{agents: map[string]*AgentProcess{"a": agent}}
+
+	if err := m.RestartWithBootstrap(context.Background(), "a", "replacement"); err == nil {
+		t.Fatal("RestartWithBootstrap with missing agent_spec succeeded")
+	}
+	if agent.BootstrapOverride != "existing" || !agent.Paused {
+		t.Fatalf("agent mutated before validation: bootstrap=%q paused=%v", agent.BootstrapOverride, agent.Paused)
+	}
+}
+
+func TestAgentSpecModeMappings(t *testing.T) {
+	if got := agentSpecMode("unexpected"); got != "unexpected" {
+		t.Fatalf("unexpected mode = %q", got)
+	}
+	if got := agentSpecMode("suggest"); got != "ISSUES_AND_PRS" {
+		t.Fatalf("suggest = %q", got)
+	}
+}

--- a/src/pkg/agent/manager.go
+++ b/src/pkg/agent/manager.go
@@ -230,6 +230,8 @@ type AgentProcess struct {
 	KickRefusalReason string
 	LaunchedMode      AgentMode
 	HasLaunched       bool
+	baseConfig        config.AgentConfig
+	agentSpecPrompt   string
 	tmuxSession       string
 	tmuxSocket        string
 	cancel            context.CancelFunc
@@ -624,11 +626,12 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 			}
 		}
 		m.agents[name] = &AgentProcess{
-			Name:   name,
-			ID:     agentID,
-			Config: cfg,
-			State:  StateStopped,
-			UID:    agentUID,
+			Name:       name,
+			ID:         agentID,
+			Config:     cfg,
+			baseConfig: cfg,
+			State:      StateStopped,
+			UID:        agentUID,
 			// Restore a persisted operator pause so a restart/upgrade
 			// doesn't silently un-pause the agent.
 			Paused:       cfg.Paused,
@@ -658,10 +661,11 @@ func (m *Manager) ResolveAgent(nameOrID string) string {
 }
 
 func (m *Manager) Start(ctx context.Context, name string) error {
-	// PHASE 1 — brief critical section: map lookup, the pure in-memory
-	// decisions (running/sandbox), and claiming the per-agent launch guard.
-	// Nothing here does /data NFS I/O or a subprocess/outbound call, so m.mu is
-	// held only for microseconds.
+	// PHASE 1 — brief critical section: map lookup, BYO-agent spec application,
+	// the pure in-memory decisions (running/sandbox), and claiming the per-agent
+	// launch guard. AgentSpec file I/O stays here so the effective config is
+	// visible before sandbox and tmux preparation, and so Config/BootstrapOverride
+	// writes stay under the same lock as every status reader.
 	m.mu.Lock()
 
 	agent, ok := m.agents[name]
@@ -677,6 +681,22 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	if agent.State == StateRunning {
 		m.mu.Unlock()
 		return fmt.Errorf("agent %s already running", name)
+	}
+	if agent.launching {
+		m.mu.Unlock()
+		return fmt.Errorf("agent %s launch already in progress", name)
+	}
+
+	if err := m.applyAgentSpec(agent); err != nil {
+		m.audit(AuditAgentStartFailed, name, auditFields(
+			"outcome", "failure",
+			"backend", agent.effectiveBackend(),
+			"model", agent.effectiveModel(),
+			"error", err.Error(),
+			"stage", "agent_spec",
+		))
+		m.mu.Unlock()
+		return err
 	}
 
 	if m.agentSandboxEnabledLocked(agent) {
@@ -703,10 +723,6 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	// out-of-lock launch below, this guard is the only thing preventing a
 	// second Start from racing this one's tmux launch and guarded-field writes
 	// (m.mu no longer covers the whole method). Refuse the second caller fast.
-	if agent.launching {
-		m.mu.Unlock()
-		return fmt.Errorf("agent %s launch already in progress", name)
-	}
 	agent.launching = true
 	m.mu.Unlock()
 
@@ -908,6 +924,7 @@ func (m *Manager) AddAgent(name string, cfg config.AgentConfig) {
 		Name:         name,
 		ID:           agentID,
 		Config:       cfg,
+		baseConfig:   cfg,
 		State:        StateStopped,
 		UID:          agentUID,
 		OutputBuffer: NewRingBuffer(outputBufferCapacity),
@@ -951,7 +968,9 @@ func (m *Manager) UpdateConfig(name string, cfg config.AgentConfig) error {
 		return fmt.Errorf("agent %s not found", name)
 	}
 
+	agent.clearAgentSpecPromptIfSpecRemoved(cfg)
 	agent.Config = cfg
+	agent.baseConfig = cfg
 	return nil
 }
 
@@ -971,7 +990,9 @@ func (m *Manager) ReconcileAgents(configs map[string]config.AgentConfig) []strin
 		allowedConfigs[name] = cfg
 		if existing, ok := m.agents[name]; ok {
 			delete(m.idToName, existing.ID)
+			existing.clearAgentSpecPromptIfSpecRemoved(cfg)
 			existing.Config = cfg
+			existing.baseConfig = cfg
 			if cfg.ID != "" {
 				existing.ID = cfg.ID
 			} else {
@@ -1001,6 +1022,7 @@ func (m *Manager) ReconcileAgents(configs map[string]config.AgentConfig) []strin
 			Name:         name,
 			ID:           agentID,
 			Config:       cfg,
+			baseConfig:   cfg,
 			State:        StateStopped,
 			UID:          agentUID,
 			Paused:       cfg.Paused,

--- a/src/pkg/agent/manager_launch.go
+++ b/src/pkg/agent/manager_launch.go
@@ -62,17 +62,21 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		backend = agent.BackendOverride
 	}
 
-	binary, err := m.backendBinary(backend)
-	if err != nil {
-		agent.State = StateFailed
-		agent.LastError = err.Error()
-		m.logger.Warn("backend binary not found", "name", agent.Name, "backend", backend, "error", err)
-		// The tmux session already exists (Start/Restart ran ensureTmuxSession
-		// before this), so without a banner the pane is a silent bare shell —
-		// the operator attaches and sees a prompt, not a failure. Say which
-		// binary was attempted, that it is missing, and what to do.
-		m.announceLaunchFailureInPane(agent, m.backendLaunchFailureMessage(backend, err))
-		return nil
+	binary := ""
+	if strings.TrimSpace(agent.Config.LaunchCmd) == "" {
+		var err error
+		binary, err = m.backendBinary(backend)
+		if err != nil {
+			agent.State = StateFailed
+			agent.LastError = err.Error()
+			m.logger.Warn("backend binary not found", "name", agent.Name, "backend", backend, "error", err)
+			// The tmux session already exists (Start/Restart ran ensureTmuxSession
+			// before this), so without a banner the pane is a silent bare shell —
+			// the operator attaches and sees a prompt, not a failure. Say which
+			// binary was attempted, that it is missing, and what to do.
+			m.announceLaunchFailureInPane(agent, m.backendLaunchFailureMessage(backend, err))
+			return nil
+		}
 	}
 
 	// bob cannot authenticate without an API key in a pod: its default W3ID SSO
@@ -183,7 +187,9 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		m.installCavemanForAgent(agent, backend)
 	}
 
-	if agent.Config.Tools != nil {
+	if strings.TrimSpace(agent.Config.LaunchCmd) != "" {
+		launchCmd = strings.TrimSpace(agent.Config.LaunchCmd)
+	} else if agent.Config.Tools != nil {
 		launchCmd = toolRulesToLaunchCmd(binary, model, backend, agent.Config.Tools, isInference)
 		if agent.Config.Tools != nil && agent.Config.Mode != "" {
 			m.logger.Warn("agent has both tools and mode set; tools takes precedence", "agent", agent.Name)

--- a/src/pkg/agent/manager_restart.go
+++ b/src/pkg/agent/manager_restart.go
@@ -355,6 +355,11 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 		return fmt.Errorf("agent %s not found", name)
 	}
 
+	if err := m.applyAgentSpec(agent); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+
 	agent.BootstrapOverride = prompt
 	agent.Paused = false
 	m.logger.Info("bootstrap override set (atomic)", "agent", name, "len", len(prompt))
@@ -663,6 +668,10 @@ func (m *Manager) Restart(ctx context.Context, name string) error {
 	agent, ok := m.agents[name]
 	if !ok {
 		return fmt.Errorf("agent %s not found", name)
+	}
+
+	if err := m.applyAgentSpec(agent); err != nil {
+		return err
 	}
 
 	if agent.State == StateRunning {

--- a/src/pkg/agent/thrash_coverage_test.go
+++ b/src/pkg/agent/thrash_coverage_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecordBlockedAndCheckWindowAndCooldown(t *testing.T) {
+	now := time.Unix(1000, 0)
+	st := &thrashState{times: []time.Time{now.Add(-2 * time.Minute), now.Add(-30 * time.Second)}}
+	if recordBlockedAndCheck(st, now, time.Minute, 3, time.Minute) {
+		t.Fatal("threshold should not trip after pruning old entries")
+	}
+	if len(st.times) != 2 {
+		t.Fatalf("kept times = %d, want 2", len(st.times))
+	}
+	if !recordBlockedAndCheck(st, now.Add(time.Second), time.Minute, 3, time.Minute) {
+		t.Fatal("threshold should trip outside cooldown")
+	}
+	if recordBlockedAndCheck(st, now.Add(2*time.Second), time.Minute, 3, time.Minute) {
+		t.Fatal("cooldown should suppress repeated trip")
+	}
+	st.times = append(st.times, now.Add(119*time.Second), now.Add(119*time.Second))
+	if !recordBlockedAndCheck(st, now.Add(2*time.Minute), time.Minute, 3, time.Minute) {
+		t.Fatal("trip should reset after cooldown")
+	}
+}
+
+func TestCheckBlockedThrashIgnoresNonMarkersAndRecordsMarkers(t *testing.T) {
+	m := &Manager{}
+	m.checkBlockedThrash("scanner", "ordinary output")
+	if len(m.thrash) != 0 {
+		t.Fatalf("non-marker initialized thrash map: %+v", m.thrash)
+	}
+	m.checkBlockedThrash("scanner", "git push blocked: advisory mode")
+	if len(m.thrash) != 1 {
+		t.Fatalf("marker did not create thrash state: %+v", m.thrash)
+	}
+	if got := len(m.thrash["scanner"].times); got != 1 {
+		t.Fatalf("recorded times = %d, want 1", got)
+	}
+}
+
+func TestBackendLaunchCmdRemainingBranches(t *testing.T) {
+	cases := []struct {
+		name      string
+		binary    string
+		model     string
+		backend   string
+		inference bool
+		want      string
+	}{
+		{"gemini", "gemini", "flash", "gemini", false, "gemini --model flash"},
+		{"pi", "pi", "pi-model", "pi", false, "pi --model pi-model"},
+		{"goose with model", "goose", "gpt", "goose", false, "goose run -s --model gpt"},
+		{"goose no model", "goose", "", "goose", false, "goose run -s"},
+		{"default", "custom", "ignored", "custom", false, "custom"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backendLaunchCmd(tc.binary, tc.model, tc.backend, tc.inference); got != tc.want {
+				t.Fatalf("backendLaunchCmd() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/pkg/config/agent_config.go
+++ b/src/pkg/config/agent_config.go
@@ -137,6 +137,7 @@ type AgentConfig struct {
 	StaleTimeout    int    `yaml:"stale_timeout" json:"stale_timeout,omitempty"`
 	RestartStrategy string `yaml:"restart_strategy" json:"restart_strategy,omitempty"`
 	LaunchCmd       string `yaml:"launch_cmd" json:"launch_cmd,omitempty"`
+	AgentSpec       string `yaml:"agent_spec" json:"agent_spec,omitempty"`
 	DisplayName     string `yaml:"display_name" json:"display_name,omitempty"`
 	Description     string `yaml:"description" json:"description,omitempty"`
 

--- a/src/pkg/config/agent_spec_test.go
+++ b/src/pkg/config/agent_spec_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAgentSpecRef(t *testing.T) {
+	base := func(agentSpec string) *Config {
+		return &Config{
+			Project: ProjectConfig{Org: "my-org"},
+			GitHub:  GitHubConfig{Token: "t"},
+			Agents: map[string]AgentConfig{
+				"supervisor": {Backend: "copilot", AgentSpec: agentSpec},
+			},
+		}
+	}
+	if err := base("agents/reviewer/spec.yaml").validate(); err != nil {
+		t.Fatalf("validate() with agent_spec = %v, want nil", err)
+	}
+	err := base("bad\x00spec").validate()
+	if err == nil {
+		t.Fatal("validate() with NUL agent_spec = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "supervisor") || !strings.Contains(err.Error(), "agent_spec") {
+		t.Errorf("error = %q, want agent name and field", err.Error())
+	}
+}

--- a/src/pkg/config/validate.go
+++ b/src/pkg/config/validate.go
@@ -88,6 +88,16 @@ func (c *Config) validate() error {
 		if err := validateConnections(name, agent.Connections); err != nil {
 			return err
 		}
+		if err := validateAgentSpecRef(name, agent.AgentSpec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAgentSpecRef(agentName, ref string) error {
+	if strings.ContainsRune(ref, '\x00') {
+		return fmt.Errorf("agent %s: agent_spec contains a NUL byte", agentName)
 	}
 	return nil
 }

--- a/src/pkg/hivectl/commands/agent.go
+++ b/src/pkg/hivectl/commands/agent.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hivecommons/hive/pkg/skillreg"
 	"github.com/spf13/cobra"
 )
 
@@ -43,10 +44,92 @@ func newAgentCommand(env *commandEnv) *cobra.Command {
 	agent.AddCommand(agentLogsCommand(env))
 	agent.AddCommand(agentDeleteCommand(env))
 	agent.AddCommand(agentPromptCommand(env))
+	agent.AddCommand(agentSpecsCommand(env))
 	agent.AddCommand(agentModelSetCommand(env))
 	agent.AddCommand(agentBackendSetCommand(env))
 	agent.AddCommand(agentPipelineSetCommand(env))
 	return agent
+}
+
+func agentSpecsCommand(env *commandEnv) *cobra.Command {
+	dir := "/data/skills"
+	specs := &cobra.Command{
+		Use:     "specs",
+		Short:   "List and search reusable agent specs and skills",
+		Example: "  hivectl agent specs list --dir /data/skills\n  hivectl agent specs search go --limit 10",
+	}
+	specs.PersistentFlags().StringVar(&dir, "dir", dir, "skill registry directory")
+	specs.AddCommand(&cobra.Command{
+		Use:     "list",
+		Short:   "List registered reusable skills",
+		Args:    argsNone(),
+		Example: "  hivectl agent specs list --output json",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reg, err := loadLocalSkillRegistry(dir)
+			if err != nil {
+				return err
+			}
+			return env.print(cmd, map[string]any{"items": skillViews(reg.List())})
+		},
+	})
+	var limit int
+	search := &cobra.Command{
+		Use:     "search [query]",
+		Short:   "Search registered reusable skills",
+		Args:    argsMax(1),
+		Example: "  hivectl agent specs search testing --limit 10 --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if limit < 0 {
+				return &usageError{message: "--limit cannot be negative"}
+			}
+			reg, err := loadLocalSkillRegistry(dir)
+			if err != nil {
+				return err
+			}
+			term := ""
+			if len(args) == 1 {
+				term = args[0]
+			}
+			items := skillViews(reg.Search(term))
+			if limit > 0 && len(items) > limit {
+				items = items[:limit]
+			}
+			return env.print(cmd, map[string]any{"items": items})
+		},
+	}
+	search.Flags().IntVar(&limit, "limit", 0, "maximum results; zero returns all matches")
+	specs.AddCommand(search)
+	return specs
+}
+
+type skillView struct {
+	Name        string   `json:"name" yaml:"name"`
+	Version     string   `json:"version" yaml:"version"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Source      string   `json:"source" yaml:"source"`
+	Tags        []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+func loadLocalSkillRegistry(dir string) (*skillreg.Registry, error) {
+	reg := skillreg.NewRegistry()
+	if _, err := reg.Load(dir, nil); err != nil {
+		return nil, err
+	}
+	return reg, nil
+}
+
+func skillViews(skills []skillreg.Skill) []skillView {
+	out := make([]skillView, 0, len(skills))
+	for _, skill := range skills {
+		out = append(out, skillView{
+			Name:        skill.Name,
+			Version:     skill.Version,
+			Description: skill.Description,
+			Source:      string(skill.Source),
+			Tags:        skill.Tags,
+		})
+	}
+	return out
 }
 
 func agentGetCommand(env *commandEnv) *cobra.Command {

--- a/src/pkg/hivectl/commands/agent_more_test.go
+++ b/src/pkg/hivectl/commands/agent_more_test.go
@@ -31,6 +31,40 @@ func TestAgentGetFetchesConfig(t *testing.T) {
 	}
 }
 
+func TestAgentSpecsCommands(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go-testing.md"), []byte(`---
+name: go-testing
+version: 1.0.0
+description: Go testing
+tags: [go]
+---
+Use t.TempDir.`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	stdout, _, err := execute(t, server, "", "--output", "json", "agent", "specs", "--dir", dir, "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "go-testing") {
+		t.Fatalf("list stdout = %q", stdout)
+	}
+	stdout, _, err = execute(t, server, "", "--output", "json", "agent", "specs", "--dir", dir, "search", "go", "--limit", "5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "go-testing") {
+		t.Fatalf("search stdout = %q", stdout)
+	}
+	_, _, err = execute(t, server, "", "agent", "specs", "--dir", dir, "search", "go", "--limit", "-1")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("negative limit err = %v, want usage", err)
+	}
+}
+
 // TestAgentImportFromFile covers the readInput file path used in the
 // import command (not stdin), plus the "url" is empty branch.
 func TestAgentImportFromFile(t *testing.T) {

--- a/src/pkg/scheduler/kick_skills_test.go
+++ b/src/pkg/scheduler/kick_skills_test.go
@@ -91,6 +91,61 @@ func TestPrimeSkills_InjectsDeclaredSkillBody(t *testing.T) {
 	}
 }
 
+func TestPrimeSkills_UsesAgentSpecDefaultSkills(t *testing.T) {
+	dir := useSkillsDir(t)
+	const body = "Apply the BYO checklist."
+	writeSkill(t, dir, "byo.md", "---\nname: byo-checklist\n---\n"+body+"\n")
+	specPath := filepath.Join(t.TempDir(), "agent.yaml")
+	if err := os.WriteFile(specPath, []byte("name: reviewer\nbackend: copilot\nmodel: auto\nskills:\n  - byo-checklist\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := New(&config.Config{
+		Agents: map[string]config.AgentConfig{
+			"reviewer": {AgentSpec: specPath},
+		},
+	}, slog.Default())
+
+	got := s.primeSkills("reviewer", "")
+	if !strings.Contains(got, body) {
+		t.Fatalf("primeSkills from agent_spec = %q, want body %q", got, body)
+	}
+}
+
+func TestPrimeSkills_AgentSpecWithoutSkillsRevokesConfiguredSkills(t *testing.T) {
+	dir := useSkillsDir(t)
+	writeSkill(t, dir, "configured.md", "SHOULD NOT APPEAR")
+	specPath := filepath.Join(t.TempDir(), "agent.yaml")
+	if err := os.WriteFile(specPath, []byte("name: reviewer\nbackend: copilot\nmodel: auto\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := New(&config.Config{
+		Agents: map[string]config.AgentConfig{
+			"reviewer": {AgentSpec: specPath, Skills: []string{"configured"}},
+		},
+	}, slog.Default())
+
+	if got := s.primeSkills("reviewer", ""); got != "" {
+		t.Fatalf("primeSkills with spec omitting skills = %q, want empty", got)
+	}
+}
+
+func TestPrimeSkills_MissingAgentSpecDoesNotFallbackToConfiguredSkills(t *testing.T) {
+	dir := useSkillsDir(t)
+	writeSkill(t, dir, "configured.md", "SHOULD NOT APPEAR")
+	s := New(&config.Config{
+		Agents: map[string]config.AgentConfig{
+			"reviewer": {
+				AgentSpec: filepath.Join(t.TempDir(), "missing.yaml"),
+				Skills:    []string{"configured"},
+			},
+		},
+	}, slog.Default())
+
+	if got := s.primeSkills("reviewer", ""); got != "" {
+		t.Fatalf("primeSkills with missing agent_spec = %q, want empty", got)
+	}
+}
+
 // Skills the agent did NOT declare must stay out of its context.
 func TestPrimeSkills_OnlyDeclaredSkillsAreInjected(t *testing.T) {
 	dir := useSkillsDir(t)

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -1615,7 +1615,21 @@ func (s *Scheduler) primeSkills(agentName, repoRoot string) string {
 		return ""
 	}
 	ac, ok := s.cfg.Agents[agentName]
-	if !ok || len(ac.Skills) == 0 {
+	if !ok {
+		return ""
+	}
+	requested := ac.Skills
+	if ac.AgentSpec != "" {
+		requested = nil
+		spec, err := skillreg.LoadAgentSpec(ac.AgentSpec)
+		if err != nil {
+			s.logger.Warn("skillreg: cannot load agent spec skills",
+				"agent", agentName, "spec", ac.AgentSpec, "error", err)
+		} else {
+			requested = spec.Skills
+		}
+	}
+	if len(requested) == 0 {
 		return ""
 	}
 
@@ -1641,16 +1655,16 @@ func (s *Scheduler) primeSkills(agentName, repoRoot string) string {
 			"dir", skillsRegistryDir, "error", err)
 	}
 
-	resolved := reg.ResolveRequested(repoCfg, ac.Skills)
+	resolved := reg.ResolveRequested(repoCfg, requested)
 	if len(resolved) == 0 {
 		if loaded == 0 && (repoCfg == nil || len(repoCfg.Skills) == 0) {
 			s.logger.Debug("skillreg: no skills available, skipping injection",
 				"dir", skillsRegistryDir, "repo_root", repoRoot,
-				"requested", len(ac.Skills))
+				"requested", len(requested))
 			return ""
 		}
 		s.logger.Warn("skillreg: none of the declared skills resolved",
-			"agent", agentName, "requested", ac.Skills, "registry_size", loaded,
+			"agent", agentName, "requested", requested, "registry_size", loaded,
 			"repo_root", repoRoot)
 		return ""
 	}

--- a/src/pkg/skillreg/agentspec.go
+++ b/src/pkg/skillreg/agentspec.go
@@ -1,0 +1,156 @@
+package skillreg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type AgentMode string
+
+const (
+	ModeObserve    AgentMode = "observe"
+	ModeSuggest    AgentMode = "suggest"
+	ModeAutonomous AgentMode = "autonomous"
+
+	DefaultMode = ModeSuggest
+)
+
+type AgentSpec interface {
+	AgentName() string
+	Backend() string
+	Model() string
+	Mode() AgentMode
+	DefaultSkills() []string
+}
+
+type SpecToolRule struct {
+	Pattern string `yaml:"pattern" json:"pattern"`
+	Action  string `yaml:"action" json:"action"`
+	Reason  string `yaml:"reason,omitempty" json:"reason,omitempty"`
+}
+
+type SpecTools struct {
+	Preset string         `yaml:"preset,omitempty" json:"preset,omitempty"`
+	Rules  []SpecToolRule `yaml:"rules,omitempty" json:"rules,omitempty"`
+}
+
+type SpecData struct {
+	Name          string     `yaml:"name" json:"name"`
+	BackendID     string     `yaml:"backend" json:"backend"`
+	ModelID       string     `yaml:"model" json:"model"`
+	OperatingMode AgentMode  `yaml:"mode" json:"mode"`
+	LaunchCommand string     `yaml:"launch_cmd,omitempty" json:"launch_cmd,omitempty"`
+	Prompt        string     `yaml:"prompt,omitempty" json:"prompt,omitempty"`
+	Tools         *SpecTools `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Skills        []string   `yaml:"skills,omitempty" json:"skills,omitempty"`
+}
+
+var _ AgentSpec = (*SpecData)(nil)
+
+func (s *SpecData) AgentName() string { return s.Name }
+func (s *SpecData) Backend() string   { return s.BackendID }
+func (s *SpecData) Model() string     { return s.ModelID }
+
+func (s *SpecData) Mode() AgentMode {
+	if s.OperatingMode == "" {
+		return DefaultMode
+	}
+	return s.OperatingMode
+}
+
+func (s *SpecData) DefaultSkills() []string { return s.Skills }
+
+var validAgentSpecModes = map[AgentMode]struct{}{
+	ModeObserve:    {},
+	ModeSuggest:    {},
+	ModeAutonomous: {},
+}
+
+func ParseAgentSpec(data []byte) (*SpecData, error) {
+	var spec SpecData
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("skillreg: malformed agent spec: %w", err)
+	}
+	spec.Name = strings.TrimSpace(spec.Name)
+	spec.BackendID = strings.TrimSpace(spec.BackendID)
+	spec.ModelID = strings.TrimSpace(spec.ModelID)
+	spec.LaunchCommand = strings.TrimSpace(spec.LaunchCommand)
+	spec.Prompt = strings.TrimSpace(spec.Prompt)
+
+	if spec.Name == "" {
+		return nil, fmt.Errorf("skillreg: agent spec missing required field: name")
+	}
+	if spec.BackendID == "" {
+		return nil, fmt.Errorf("skillreg: agent spec missing required field: backend")
+	}
+	if spec.ModelID == "" {
+		return nil, fmt.Errorf("skillreg: agent spec missing required field: model")
+	}
+	if spec.OperatingMode == "" {
+		spec.OperatingMode = DefaultMode
+	}
+	if _, ok := validAgentSpecModes[spec.OperatingMode]; !ok {
+		return nil, fmt.Errorf("skillreg: agent spec has unknown mode %q", spec.OperatingMode)
+	}
+	if err := validateSpecTools(spec.Tools); err != nil {
+		return nil, err
+	}
+	return &spec, nil
+}
+
+func validateSpecTools(tools *SpecTools) error {
+	if tools == nil {
+		return nil
+	}
+	validPresets := map[string]bool{"": true, "advisory": true, "issues-only": true, "issues-prs": true, "full": true}
+	if !validPresets[tools.Preset] {
+		return fmt.Errorf("skillreg: agent spec tools.preset %q is invalid", tools.Preset)
+	}
+	validActions := map[string]bool{"allow": true, "deny": true}
+	for i, rule := range tools.Rules {
+		if strings.TrimSpace(rule.Pattern) == "" {
+			return fmt.Errorf("skillreg: agent spec tools.rules[%d]: pattern is required", i)
+		}
+		if !validActions[rule.Action] {
+			return fmt.Errorf("skillreg: agent spec tools.rules[%d]: action must be allow or deny, got %q", i, rule.Action)
+		}
+	}
+	return nil
+}
+
+func LoadAgentSpec(path string) (*SpecData, error) {
+	resolved, err := ResolveAgentSpecPath(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(resolved) // #nosec G304 -- operator-configured local BYO-agent spec path.
+	if err != nil {
+		return nil, fmt.Errorf("skillreg: cannot read agent spec %q: %w", resolved, err)
+	}
+	return ParseAgentSpec(data)
+}
+
+func ResolveAgentSpecPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("skillreg: agent spec path is empty")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("skillreg: cannot stat agent spec %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return path, nil
+	}
+	for _, name := range []string{"agent.yaml", "agent.yml", "agent-spec.yaml", "agent-spec.yml", "spec.yaml", "spec.yml"} {
+		candidate := filepath.Join(path, name)
+		if st, statErr := os.Stat(candidate); statErr == nil && !st.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("skillreg: no agent spec file found in %q", path)
+}

--- a/src/pkg/skillreg/agentspec_test.go
+++ b/src/pkg/skillreg/agentspec_test.go
@@ -1,0 +1,110 @@
+package skillreg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const validSpec = `name: reviewer
+backend: claude
+model: claude-opus
+mode: suggest
+launch_cmd: custom-agent --flag
+prompt: "Start with the ADR checklist."
+tools:
+  preset: advisory
+  rules:
+    - pattern: mcp__github__create_issue
+      action: deny
+      reason: read-only reviewer
+skills:
+  - go-testing
+  - pr-etiquette
+`
+
+func TestParseAgentSpecValid(t *testing.T) {
+	spec, err := ParseAgentSpec([]byte(validSpec))
+	if err != nil {
+		t.Fatalf("ParseAgentSpec: %v", err)
+	}
+	if spec.AgentName() != "reviewer" {
+		t.Errorf("name = %q", spec.AgentName())
+	}
+	if spec.Backend() != "claude" {
+		t.Errorf("backend = %q", spec.Backend())
+	}
+	if spec.Model() != "claude-opus" {
+		t.Errorf("model = %q", spec.Model())
+	}
+	if spec.Mode() != ModeSuggest {
+		t.Errorf("mode = %q", spec.Mode())
+	}
+	if spec.LaunchCommand != "custom-agent --flag" {
+		t.Errorf("launch = %q", spec.LaunchCommand)
+	}
+	if spec.Prompt != "Start with the ADR checklist." {
+		t.Errorf("prompt = %q", spec.Prompt)
+	}
+	if spec.Tools == nil || spec.Tools.Preset != "advisory" || len(spec.Tools.Rules) != 1 {
+		t.Fatalf("tools = %+v", spec.Tools)
+	}
+	if got := spec.DefaultSkills(); len(got) != 2 || got[0] != "go-testing" {
+		t.Errorf("skills = %v", got)
+	}
+}
+
+func TestParseAgentSpecDefaultMode(t *testing.T) {
+	spec, err := ParseAgentSpec([]byte("name: a\nbackend: b\nmodel: m\n"))
+	if err != nil {
+		t.Fatalf("ParseAgentSpec: %v", err)
+	}
+	if spec.Mode() != DefaultMode {
+		t.Errorf("mode = %q, want default %q", spec.Mode(), DefaultMode)
+	}
+}
+
+func TestParseAgentSpecRejections(t *testing.T) {
+	cases := map[string]string{
+		"malformed yaml":    "name: [oops\n\tbad",
+		"missing name":      "backend: b\nmodel: m\n",
+		"missing backend":   "name: a\nmodel: m\n",
+		"missing model":     "name: a\nbackend: b\n",
+		"unknown mode":      "name: a\nbackend: b\nmodel: m\nmode: rogue\n",
+		"bad tools preset":  "name: a\nbackend: b\nmodel: m\ntools:\n  preset: nope\n",
+		"bad tools pattern": "name: a\nbackend: b\nmodel: m\ntools:\n  rules:\n    - action: deny\n",
+		"bad tools action":  "name: a\nbackend: b\nmodel: m\ntools:\n  rules:\n    - pattern: x\n      action: nope\n",
+	}
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseAgentSpec([]byte(doc)); err == nil {
+				t.Errorf("expected rejection for %s", name)
+			}
+		})
+	}
+}
+
+func TestLoadAgentSpecFileAndDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(path, []byte(validSpec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	spec, err := LoadAgentSpec(path)
+	if err != nil {
+		t.Fatalf("LoadAgentSpec(file): %v", err)
+	}
+	if spec.AgentName() != "reviewer" {
+		t.Errorf("file load name = %q", spec.AgentName())
+	}
+	spec, err = LoadAgentSpec(dir)
+	if err != nil {
+		t.Fatalf("LoadAgentSpec(dir): %v", err)
+	}
+	if spec.AgentName() != "reviewer" {
+		t.Errorf("dir load name = %q", spec.AgentName())
+	}
+	if _, err := LoadAgentSpec(filepath.Join(dir, "missing")); err == nil {
+		t.Error("missing path should error")
+	}
+}

--- a/src/pkg/skillreg/skillreg.go
+++ b/src/pkg/skillreg/skillreg.go
@@ -51,6 +51,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -187,7 +188,7 @@ func (r *Registry) Load(dir string, lg *slog.Logger) (int, error) {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
-		raw, rErr := os.ReadFile(path)
+		raw, rErr := os.ReadFile(path) // #nosec G304 -- registry entries are local operator-managed skill files.
 		if rErr != nil {
 			lg.Warn("skillreg: cannot read skill file, skipping", "file", e.Name(), "error", rErr)
 			continue
@@ -274,6 +275,108 @@ func (r *Registry) Get(name string) (Skill, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.highestLocked(name)
+}
+
+// Resolve selects the skill named name whose version satisfies constraint. An
+// empty constraint or "*" selects the highest version. A "^X.Y.Z" constraint
+// selects the highest version sharing X's major component. A ">=X.Y.Z"
+// constraint selects the highest version at or above X.Y.Z. Any other
+// constraint is treated as an exact version match.
+func (r *Registry) Resolve(name, constraint string) (Skill, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" || constraint == "*" {
+		return r.highestLocked(name)
+	}
+
+	versions := r.byName[name]
+	if len(versions) == 0 {
+		return Skill{}, false
+	}
+
+	var best Skill
+	found := false
+	for _, s := range versions {
+		if !satisfies(s.Version, constraint) {
+			continue
+		}
+		if !found || compareVersions(s.Version, best.Version) > 0 {
+			best = s
+			found = true
+		}
+	}
+	return best, found
+}
+
+func satisfies(version, constraint string) bool {
+	switch {
+	case strings.HasPrefix(constraint, "^"):
+		want := strings.TrimSpace(strings.TrimPrefix(constraint, "^"))
+		return sameMajor(version, want) && compareVersions(version, want) >= 0
+	case strings.HasPrefix(constraint, ">="):
+		want := strings.TrimSpace(strings.TrimPrefix(constraint, ">="))
+		return compareVersions(version, want) >= 0
+	default:
+		return compareVersions(version, constraint) == 0
+	}
+}
+
+func sameMajor(a, b string) bool {
+	return versionParts(a)[0] == versionParts(b)[0]
+}
+
+// List returns every skill (all versions) sorted by name then descending
+// version, so the newest version of each name comes first.
+func (r *Registry) List() []Skill {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []Skill
+	for _, versions := range r.byName {
+		out = append(out, versions...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return compareVersions(out[i].Version, out[j].Version) > 0
+	})
+	return out
+}
+
+// Search returns the highest version of every skill whose name, description, or
+// any tag contains term (case-insensitively). An empty term matches everything.
+func (r *Registry) Search(term string) []Skill {
+	term = strings.ToLower(strings.TrimSpace(term))
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var out []Skill
+	for name := range r.byName {
+		best, ok := r.highestLocked(name)
+		if !ok {
+			continue
+		}
+		if term == "" || skillMatches(best, term) {
+			out = append(out, best)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func skillMatches(s Skill, term string) bool {
+	if strings.Contains(strings.ToLower(s.Name), term) ||
+		strings.Contains(strings.ToLower(s.Description), term) {
+		return true
+	}
+	for _, tag := range s.Tags {
+		if strings.Contains(strings.ToLower(tag), term) {
+			return true
+		}
+	}
+	return false
 }
 
 // highestLocked returns the highest-versioned skill for name. Caller holds mu.

--- a/src/pkg/skillreg/skillreg_test.go
+++ b/src/pkg/skillreg/skillreg_test.go
@@ -219,6 +219,9 @@ func TestAdd_SameVersionReplaces(t *testing.T) {
 	if got.Body != "new" {
 		t.Errorf("body = %q, want new (same version replaces)", got.Body)
 	}
+	if len(r.List()) != 1 {
+		t.Errorf("List len = %d, want 1", len(r.List()))
+	}
 }
 
 func TestGet_HighestVersion(t *testing.T) {
@@ -229,6 +232,62 @@ func TestGet_HighestVersion(t *testing.T) {
 	got, ok := r.Get("a")
 	if !ok || got.Version != "2.3.0" {
 		t.Fatalf("Get highest = %q, want 2.3.0", got.Version)
+	}
+}
+
+func TestResolveConstraintHitAndMiss(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "a", Version: "1.0.0"})
+	_ = r.Add(Skill{Name: "a", Version: "1.5.0"})
+	_ = r.Add(Skill{Name: "a", Version: "2.1.0"})
+
+	cases := []struct {
+		name       string
+		constraint string
+		wantVer    string
+		wantOK     bool
+	}{
+		{"empty", "", "2.1.0", true},
+		{"wildcard", "*", "2.1.0", true},
+		{"exact hit", "1.5.0", "1.5.0", true},
+		{"exact miss", "9.9.9", "", false},
+		{"caret", "^1.0.0", "1.5.0", true},
+		{"gte", ">=1.5.0", "2.1.0", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := r.Resolve("a", tc.constraint)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got.Version != tc.wantVer {
+				t.Errorf("version = %q, want %q", got.Version, tc.wantVer)
+			}
+		})
+	}
+}
+
+func TestListAndSearch(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Add(Skill{Name: "go-testing", Version: "1.0.0", Description: "old", Tags: []string{"go"}})
+	_ = r.Add(Skill{Name: "go-testing", Version: "2.0.0", Description: "new", Tags: []string{"quality"}})
+	_ = r.Add(Skill{Name: "pr-etiquette", Version: "1.0.0", Description: "GitHub flow", Tags: []string{"git"}})
+
+	list := r.List()
+	if len(list) != 3 {
+		t.Fatalf("List len = %d, want 3", len(list))
+	}
+	if list[0].Name != "go-testing" || list[0].Version != "2.0.0" || list[1].Version != "1.0.0" {
+		t.Fatalf("List order = %+v", list)
+	}
+
+	search := r.Search("git")
+	if len(search) != 1 || search[0].Name != "pr-etiquette" {
+		t.Fatalf("Search(git) = %+v, want pr-etiquette", search)
+	}
+	search = r.Search("quality")
+	if len(search) != 1 || search[0].Name != "go-testing" || search[0].Version != "2.0.0" {
+		t.Fatalf("Search(quality) = %+v, want newest go-testing", search)
 	}
 }
 


### PR DESCRIPTION
Closes #5910

## Summary
- Wire `agent_spec` into pkg/agent launch/restart paths via `skillreg.LoadAgentSpec`
- Restore skill registry `List`/`Search` discovery and expose it via `hivectl agent specs list|search`
- Document BYO agent specs and add changelog fragment

## Validation
- `go test ./pkg/...`
- `go test -cover ./pkg/skillreg ./pkg/config ./pkg/agent ./pkg/scheduler ./pkg/hivectl/commands`
- `go vet ./...`
- `golangci-lint run ./...`
- `python3 src/scripts/check-docs-links.py`
- `gosec -exclude-generated ./...` still reports pre-existing backlog (502 issues); new skillreg file reads are annotated.